### PR TITLE
feature: Complete german meta text

### DIFF
--- a/meta/translations/de.json
+++ b/meta/translations/de.json
@@ -1,11 +1,11 @@
 {
 	"$schema": "./schema.json",
-	"__comment__": "Missing abilityTypes and some Trainer Types",
+	"__comment__": "Should be complete",
 	"abilityType": {
-		"Ability": "Ability",
-		"Ancient Trait": "Ancient Trait",
-		"Poke-BODY": "Poke-BODY",
-		"Poke-POWER": "Poke-POWER",
+		"Ability": "Fähigkeit",
+		"Ancient Trait": "Uralte Eigenschaft",
+		"Poke-BODY": "Poké-BODY",
+		"Poke-POWER": "Poké-POWER",
 		"Pokemon Power": "Pokemon Power"
 
 	},
@@ -21,11 +21,11 @@
 	"rarity": {
 		"Amazing": "Atemberaubend",
 		"Common": "Häufig",
-		"None": "Ninguno",
-		"Rare": "Keine",
-		"Secret Rare": "Heimliche Seltenheit",
-		"Ultra Rare": "ultraselten",
-		"Uncommon": "Nicht so häufig"
+		"None": "Keine",
+		"Rare": "Selten",
+		"Secret Rare": "Versteckt Selten",
+		"Ultra Rare": "Ultra Selten",
+		"Uncommon": "Ungewöhnlich"
 	},
 	"stage": {
 		"BREAK": "TURBO",
@@ -48,8 +48,8 @@
 		"V": "V"
 	},
 	"trainerType": {
-		"Ace Spec": "Ace Spec",
-		"Goldenrod Game Corner": "Goldenrod Game Corner",
+		"Ace Spec": "ASS-KLASSE",
+		"Goldenrod Game Corner": "Dukatias Spielhalle",
 		"Item": "Itemkarte",
 		"Rocket's Secret Machine": "Rockets Geheime Maschine",
 		"Stadium": "Stadionkarte",
@@ -59,7 +59,7 @@
 	},
 	"types": {
 		"Colorless": "Farblos",
-		"Darkness": "Finsternis",
+		"Darkness": "Unlicht",
 		"Dragon": "Drache",
 		"Fairy": "Fee",
 		"Fighting": "Kampf",


### PR DESCRIPTION
Ace Spec, Poke Body, Poke Power and Goldrenrod Game Corner were changed to the text on the german version of the relevant cards. 'Ancient Trait' doesn't have a translation on the card, so I picked the closest thing that makes sense. Some others were also mixed up/wrong and should be fixed now.