### PR TITLE
fix: Update Dependabot to use conventional commits

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,13 +10,21 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    versioning-strategy: lockfile-only
+    commit-message:
+      prefix: build
 
   - package-ecosystem: "npm"
     directory: "/server"
     schedule:
       interval: "daily"
+    versioning-strategy: lockfile-only
+    commit-message:
+      prefix: build
 
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "daily"
+    commit-message:
+      prefix: build


### PR DESCRIPTION
<!--
Thanks for your Pull Request, Please provide the related Issue using "Fix #0" or describe the change(s) you made.
The issue title must follow Conventional Commit (verified by Github Actions) conventionalcommits.org.
More informations at https://github.com/tcgdex/cards-database/blob/master/CONTRIBUTING.md
-->
This PR fixes dependabot making PR with an incorrect name