### PR TITLE
fix: Fix Resistance and Weaknesses GQL being incorrect type

### DIFF
--- a/meta/definitions/graphql.gql
+++ b/meta/definitions/graphql.gql
@@ -77,7 +77,7 @@ type Card {
 	name: String!
 	rarity: String!
 	regulationMark: String
-	resistances: [[WeakResListItem]]
+	resistances: [WeakResListItem]
 	retreat: Float
 	set: Set!
 	stage: String
@@ -85,7 +85,7 @@ type Card {
 	trainerType: String
 	types: [String]
 	variants: Variants
-	weaknesses: [[WeakResListItem]]
+	weaknesses: [WeakResListItem]
 }
 
 type AbilitiesListItem {


### PR DESCRIPTION
<!--
Thanks for your Pull Request, Please provide the related Issue using "Fix #0" or describe the change(s) you made.
The issue title must follow Conventional Commit (verified by Github Actions) conventionalcommits.org.
More informations at https://github.com/tcgdex/cards-database/blob/master/CONTRIBUTING.md
-->
Resistances and weaknesses fields werent the good type in GraphQL