### PR TITLE
feat: Add W Promotional variant

### DIFF
--- a/data/Base/Base Set 2/63.ts
+++ b/data/Base/Base Set 2/63.ts
@@ -58,10 +58,9 @@ const card: Card = {
 		},
 	],
 
-
-
-
-
+	variants: {
+		wPromo: true
+	}
 }
 
 export default card

--- a/data/Base/Fossil/50.ts
+++ b/data/Base/Fossil/50.ts
@@ -62,6 +62,10 @@ const card: Card = {
 
 	description: {
 		fr: "Disparu depuis longtemps, il peut être réanimé génétiquement à partir d'anciens fossiles."
+	},
+
+	variants: {
+		wPromo: true
 	}
 }
 

--- a/data/Base/Jungle/60.ts
+++ b/data/Base/Jungle/60.ts
@@ -56,6 +56,10 @@ const card: Card = {
 
 	description: {
 		fr: "Quand plusieurs de ces Pokémon se réunissent, ils provoquent de gigantesques orages."
+	},
+
+	variants: {
+		wPromo: true
 	}
 }
 

--- a/data/Base/Team Rocket/19.ts
+++ b/data/Base/Team Rocket/19.ts
@@ -72,6 +72,10 @@ const card: Card = {
 
 	description: {
 		fr: "Il paralyse ses proies d'un regard. Si vous en rencontrez un, gardez-vous de le regarder dans les yeux ."
+	},
+
+	variants: {
+		wPromo: true
 	}
 }
 

--- a/data/Base/Team Rocket/32.ts
+++ b/data/Base/Team Rocket/32.ts
@@ -72,6 +72,10 @@ const card: Card = {
 
 	description: {
 		fr: "Sa queue incroyablement puissante est capable de soulever 5 hommes."
+	},
+
+	variants: {
+		wPromo: true
 	}
 }
 

--- a/data/Base/W Promotional.ts
+++ b/data/Base/W Promotional.ts
@@ -1,6 +1,10 @@
 import { Set } from '../../interfaces'
 import serie from '../Base'
 
+/**
+ * @deprecated
+ * Will be removed in V3
+ */
 const wp: Set = {
 	id: "wp",
 
@@ -13,7 +17,7 @@ const wp: Set = {
 	serie: serie,
 
 	cardCount: {
-		official: 53
+		official: 7
 	},
 
 	releaseDate: "1999-09-01"

--- a/data/Gym/Gym Challenge/37.ts
+++ b/data/Gym/Gym Challenge/37.ts
@@ -56,7 +56,9 @@ const card: Card = {
 		},
 	],
 
-
+	variants: {
+		wPromo: true
+	}
 
 
 

--- a/data/Gym/Gym Heroes/54.ts
+++ b/data/Gym/Gym Heroes/54.ts
@@ -53,7 +53,9 @@ const card: Card = {
 		},
 	],
 
-
+	variants: {
+		wPromo: true
+	}
 
 
 

--- a/interfaces.d.ts
+++ b/interfaces.d.ts
@@ -13,12 +13,40 @@ export interface Serie {
 }
 
 interface variants {
+	/**
+	 * Card base version
+	 */
 	normal?: boolean
+	/**
+	 * Holo Reverse
+	 * (colored Background holographic)
+	 */
 	reverse?: boolean
+	/**
+	 * Holo Card
+	 * (illustration holographic)
+	 */
 	holo?: boolean
+
+	/**
+	 * can have a first Edition stamp
+	 */
 	firstEdition?: boolean
+
+	/**
+	 * Can be found in Jumob Format
+	 */
 	jumbo?: boolean
+
+	/**
+	 * Card has a pre-release stamp
+	 */
 	preRelease?: boolean
+
+	/**
+	 * Card has a W stamp
+	 */
+	wPromo?: true
 }
 
 export type Types = 'Colorless' | 'Darkness' | 'Dragon' |


### PR DESCRIPTION
W Promotional Cards do not have any other changes on them than the `W` stamp so they should ba a variant

<!--
Thanks for your Pull Request, Please provide the related Issue using "Fix #0" or describe the change(s) you made.
The issue title must follow Conventional Commit (verified by Github Actions) conventionalcommits.org.
More informations at https://github.com/tcgdex/cards-database/blob/master/CONTRIBUTING.md
-->
