### PR TITLE
fix: mistype in evolveFrom name in french

### DIFF
--- a/data/XY/XY Black Star Promos/XY35.ts
+++ b/data/XY/XY Black Star Promos/XY35.ts
@@ -20,7 +20,7 @@ const card: Card = {
 	],
 	evolveFrom: {
 		en: "Metagross-EX",
-		fr: "Métalosse-EEX",
+		fr: "Métalosse-EX",
 	},
 	stage: "MEGA",
 


### PR DESCRIPTION
"Métalosse-EEX" to "Métalosse-EX"

<!--
Thanks for your Pull Request, Please provide the related Issue using "Fix #0" or describe the change(s) you made.
The issue title must follow Conventional Commit (verified by Github Actions) conventionalcommits.org.
More informations at https://github.com/tcgdex/cards-database/blob/master/CONTRIBUTING.md
-->
