### PR TITLE
feat: Add `updated` field

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,10 @@ FROM node:alpine as BUILD_IMAGE
 
 WORKDIR /app
 
+# Add git as it is used to fetch updated times
+RUN apk add git
+
+# prepare dependencies
 ADD package.json package-lock.json ./
 ADD server/package.json server/package-lock.json ./server/
 

--- a/meta/codeshift.ts
+++ b/meta/codeshift.ts
@@ -56,6 +56,20 @@ function simplify(base: ObjectExpression): ObjectField {
 	}
 }
 
+function exists(path: ObjectExpression | ArrayExpression, key: string | number) {
+	if (path.type === 'ObjectExpression') {
+		path.properties.forEach((p) => {
+			const prop = p as Property
+			if ((prop.key as Identifier).name === (key + '')) {
+				return true
+			}
+		})
+		return false
+	} else {
+
+	}
+}
+
 function set(j: JSCodeshift, path: ObjectExpression | ArrayExpression, value: Possible, key: string | number, options?: {override?: boolean}) {
 
 	let exists = false

--- a/meta/definitions/api.d.ts
+++ b/meta/definitions/api.d.ts
@@ -261,7 +261,9 @@ export interface Card extends CardResume {
 		 * Ability to play in expanded tournaments
 		 */
 		expanded: boolean;
-	};
+	}
+
+	updated: string
 }
 
 /**

--- a/server/compiler/utils/cardUtil.ts
+++ b/server/compiler/utils/cardUtil.ts
@@ -161,7 +161,7 @@ export async function getCards(lang: SupportedLanguages, set?: Set): Promise<Arr
 }
 
 async function getCardLastEdit(localId: string, card: Card): Promise<string> {
-	const path = `../data/${card.set.serie.name.en}/${card.set.name.en}/${localId}.ts`
+	const path = `../data/${card.set.serie.name.en}/${card.set.name.en ?? card.set.name.fr}/${localId}.ts`
 	const command = `git log -1 --pretty="format:%ci" "${path}"`
 	// console.log(command)
 	return new Promise((res, rej) => {

--- a/server/package.json
+++ b/server/package.json
@@ -5,7 +5,7 @@
 	"description": "",
 	"main": "index.js",
 	"scripts": {
-		"compile": "ts-node --project ../tsconfig.json compiler/index.ts",
+		"compile": "ts-node --prefer-ts-exts --project ../tsconfig.json compiler/index.ts",
 		"dev": "ts-node-dev -T src/index.ts",
 		"build": "tsc --project tsconfig.json",
 		"start": "node dist/index.js"


### PR DESCRIPTION
this PR add a new field for endpoints being the `updated` field

It will inform the user of the last time the field was updated (Through Git history only currently)

<!--
Thanks for your Pull Request, Please provide the related Issue using "Fix #0" or describe the change(s) you made.
The issue title must follow Conventional Commit (verified by Github Actions) conventionalcommits.org.
More informations at https://github.com/tcgdex/cards-database/blob/master/CONTRIBUTING.md
-->
