### PR TITLE
fix: Ordering failing when one value is null

### DIFF
--- a/.bruno/fixes/489-crash-when-sorting-with-null-values.bru
+++ b/.bruno/fixes/489-crash-when-sorting-with-null-values.bru
@@ -1,0 +1,17 @@
+meta {
+  name: 489 - Crash When sorting with Null values
+  type: http
+  seq: 6
+}
+
+get {
+  url: {{BASE_URL}}/v2/en/cards?name=pikachu&sort:field=hp&sort:order=DESC
+  body: none
+  auth: none
+}
+
+query {
+  name: pikachu
+  sort:field: hp
+  sort:order: DESC
+}

--- a/server/src/util.ts
+++ b/server/src/util.ts
@@ -150,9 +150,21 @@ export function handleSort(data: Array<any>, query: Query<any>) {
  * @param order the base ordering
  * @returns a function that is feed in the `sort` function
  */
-const advSort = (a: string | number, b: string | number, order: 'ASC' | 'DESC' = 'ASC') => {
-	a = tryParse(a) ?? a
-	b = tryParse(b) ?? b
+const advSort = (a?: string | number, b?: string | number, order: 'ASC' | 'DESC' = 'ASC') => {
+	const isANull = isNull(a)
+	const isBNull = isNull(b)
+	if (isANull && isBNull) {
+		return 0
+	}
+	if (isANull) {
+		return order === 'ASC' ? -1 : 1
+	}
+	if (isBNull) {
+		return order === 'ASC' ? 1 : -1
+	}
+
+	a = tryParse(a!) ?? a
+	b = tryParse(b!) ?? b
 
 	if (order === 'DESC') {
 		const tmp = a

--- a/server/src/util.ts
+++ b/server/src/util.ts
@@ -176,7 +176,7 @@ const advSort = (a?: string | number, b?: string | number, order: 'ASC' | 'DESC'
 		return a - b
 	}
 
-	return a.toString().localeCompare(b.toString())
+	return a!.toString().localeCompare(b!.toString())
 }
 
 function tryParse(value: string | number): number | null {


### PR DESCRIPTION
<!--
Thanks for your Pull Request, Please provide the related Issue using "Fix #0" or describe the change(s) you made.
The issue title must follow Conventional Commit (verified by Github Actions) conventionalcommits.org.
More informations at https://github.com/tcgdex/cards-database/blob/master/CONTRIBUTING.md
-->
