### PR TITLE
fix: Reversal Energy type should be "Special"

### DIFF
--- a/data/Scarlet & Violet/Paradox Rift/266.ts
+++ b/data/Scarlet & Violet/Paradox Rift/266.ts
@@ -25,7 +25,7 @@ const card: Card = {
 		de: "Solange diese Karte an ein Pokémon angelegt ist, liefert sie Colorless-Energie.\nWenn du mehr verbleibende Preiskarten hast als dein Gegner und diese Karte an ein Entwicklungs-Pokémon angelegt ist, das kein Regelfeld hat\n(Pokémon-ex, Pokémon-V usw. haben Regelfelder), liefert diese Karte jeden Energietyp, aber immer nur 3 Energien."
 	},
 
-	energyType: "Normal",
+	energyType: "Special",
 	regulationMark: "G",
 
 	variants: {


### PR DESCRIPTION
Reversal Energy is a special energy. I think the allowed values are "Special" and "Basic" in any case, but that string may come from a translation (Spanish, probably).