### PR TITLE
fix: Remove reference to Set Variants from api.d.ts

### DIFF
--- a/meta/definitions/api.d.ts
+++ b/meta/definitions/api.d.ts
@@ -49,7 +49,6 @@ export interface SetResume {
 export interface Set extends SetResume {
 	serie: SerieResume;
 	tcgOnline?: string;
-	variants?: variants;
 	releaseDate: string;
 	/**
 	 * Designate if the set is usable in tournaments
@@ -134,7 +133,7 @@ export interface Card extends CardResume {
 	 */
 	category: string;
 	/**
-	 * Card Variants (Override Set Variants)
+	 * Card Variants
 	 */
 	variants?: variants;
 	/**


### PR DESCRIPTION
<!--
Thanks for your Pull Request, Please provide the related Issue using "Fix #0" or describe the change(s) you made.
The issue title must follow Conventional Commit conventionalcommits.org.
More informations at https://github.com/tcgdex/cards-database/blob/master/CONTRIBUTING.md
-->
fix: Remove reference to Set Variants from api.d.ts

Change to api.d.ts to remove set interface's variants and also remove card interface comment's reference to it overriding the set's.

I'm interested in this project and was referencing this to understand the format and discovered that this set variant field had been removed a while ago and so got a bit confused. If this is still in there for a reason, I apologize.