### PR TITLE
fix: Temporal Forces holo rare cards are missing reverse variants

### DIFF
--- a/data/Scarlet & Violet/Temporal Forces/015.ts
+++ b/data/Scarlet & Violet/Temporal Forces/015.ts
@@ -61,7 +61,6 @@ const card: Card = {
 	regulationMark: "H",
 
 	variants: {
-		reverse: false,
 		normal: false
 	}
 }

--- a/data/Scarlet & Violet/Temporal Forces/021.ts
+++ b/data/Scarlet & Violet/Temporal Forces/021.ts
@@ -69,7 +69,6 @@ const card: Card = {
 	regulationMark: "H",
 
 	variants: {
-		reverse: false,
 		normal: false
 	}
 }

--- a/data/Scarlet & Violet/Temporal Forces/029.ts
+++ b/data/Scarlet & Violet/Temporal Forces/029.ts
@@ -61,7 +61,6 @@ const card: Card = {
 	regulationMark: "H",
 
 	variants: {
-		reverse: false,
 		normal: false
 	}
 }

--- a/data/Scarlet & Violet/Temporal Forces/041.ts
+++ b/data/Scarlet & Violet/Temporal Forces/041.ts
@@ -70,7 +70,6 @@ const card: Card = {
 	regulationMark: "H",
 
 	variants: {
-		reverse: false,
 		normal: false
 	}
 }

--- a/data/Scarlet & Violet/Temporal Forces/062.ts
+++ b/data/Scarlet & Violet/Temporal Forces/062.ts
@@ -60,7 +60,6 @@ const card: Card = {
 	regulationMark: "H",
 
 	variants: {
-		reverse: false,
 		normal: false
 	}
 }

--- a/data/Scarlet & Violet/Temporal Forces/078.ts
+++ b/data/Scarlet & Violet/Temporal Forces/078.ts
@@ -69,7 +69,6 @@ const card: Card = {
 	regulationMark: "H",
 
 	variants: {
-		reverse: false,
 		normal: false
 	}
 }

--- a/data/Scarlet & Violet/Temporal Forces/080.ts
+++ b/data/Scarlet & Violet/Temporal Forces/080.ts
@@ -67,7 +67,6 @@ const card: Card = {
 	regulationMark: "H",
 
 	variants: {
-		reverse: false,
 		normal: false
 	}
 }

--- a/data/Scarlet & Violet/Temporal Forces/084.ts
+++ b/data/Scarlet & Violet/Temporal Forces/084.ts
@@ -61,7 +61,6 @@ const card: Card = {
 	regulationMark: "H",
 
 	variants: {
-		reverse: false,
 		normal: false
 	}
 }

--- a/data/Scarlet & Violet/Temporal Forces/109.ts
+++ b/data/Scarlet & Violet/Temporal Forces/109.ts
@@ -60,8 +60,7 @@ const card: Card = {
 	regulationMark: "H",
 
 	variants: {
-		normal: false,
-		reverse: false
+		normal: false
 	}
 }
 

--- a/data/Scarlet & Violet/Temporal Forces/117.ts
+++ b/data/Scarlet & Violet/Temporal Forces/117.ts
@@ -51,7 +51,6 @@ const card: Card = {
 	regulationMark: "H",
 
 	variants: {
-		reverse: false,
 		normal: false
 	}
 }

--- a/data/Scarlet & Violet/Temporal Forces/119.ts
+++ b/data/Scarlet & Violet/Temporal Forces/119.ts
@@ -69,7 +69,6 @@ const card: Card = {
 	regulationMark: "H",
 
 	variants: {
-		reverse: false,
 		normal: false
 	}
 }

--- a/data/Scarlet & Violet/Temporal Forces/121.ts
+++ b/data/Scarlet & Violet/Temporal Forces/121.ts
@@ -60,7 +60,6 @@ const card: Card = {
 	regulationMark: "H",
 
 	variants: {
-		reverse: false,
 		normal: false
 	}
 }

--- a/data/Scarlet & Violet/Temporal Forces/129.ts
+++ b/data/Scarlet & Violet/Temporal Forces/129.ts
@@ -60,7 +60,6 @@ const card: Card = {
 	regulationMark: "H",
 
 	variants: {
-		reverse: false,
 		normal: false
 	}
 }

--- a/data/Scarlet & Violet/Temporal Forces/138.ts
+++ b/data/Scarlet & Violet/Temporal Forces/138.ts
@@ -61,7 +61,6 @@ const card: Card = {
 	regulationMark: "H",
 
 	variants: {
-		reverse: false,
 		normal: false
 	}
 }


### PR DESCRIPTION
This PR adds the reverse variant for holo rare cards in SV05: Temporal Forces

closes #595