### PR TITLE
fix: Twilight Masquerade holo rare cards are missing reverse variants

### DIFF
--- a/data/Scarlet & Violet/Twilight Masquerade/019.ts
+++ b/data/Scarlet & Violet/Twilight Masquerade/019.ts
@@ -67,7 +67,6 @@ const card: Card = {
 	regulationMark: "H",
 
 	variants: {
-		reverse: false,
 		normal: false
 	}
 }

--- a/data/Scarlet & Violet/Twilight Masquerade/022.ts
+++ b/data/Scarlet & Violet/Twilight Masquerade/022.ts
@@ -67,8 +67,7 @@ const card: Card = {
 	regulationMark: "H",
 
 	variants: {
-		normal: false,
-		reverse: false
+		normal: false
 	}
 }
 

--- a/data/Scarlet & Violet/Twilight Masquerade/024.ts
+++ b/data/Scarlet & Violet/Twilight Masquerade/024.ts
@@ -67,7 +67,6 @@ const card: Card = {
 	regulationMark: "H",
 
 	variants: {
-		reverse: false,
 		normal: false
 	}
 }

--- a/data/Scarlet & Violet/Twilight Masquerade/033.ts
+++ b/data/Scarlet & Violet/Twilight Masquerade/033.ts
@@ -70,7 +70,6 @@ const card: Card = {
 	regulationMark: "H",
 
 	variants: {
-		reverse: false,
 		normal: false
 	}
 }

--- a/data/Scarlet & Violet/Twilight Masquerade/038.ts
+++ b/data/Scarlet & Violet/Twilight Masquerade/038.ts
@@ -70,7 +70,6 @@ const card: Card = {
 	regulationMark: "H",
 
 	variants: {
-		reverse: false,
 		normal: false
 	}
 }

--- a/data/Scarlet & Violet/Twilight Masquerade/053.ts
+++ b/data/Scarlet & Violet/Twilight Masquerade/053.ts
@@ -61,7 +61,6 @@ const card: Card = {
 	regulationMark: "H",
 
 	variants: {
-		reverse: false,
 		normal: false
 	}
 }

--- a/data/Scarlet & Violet/Twilight Masquerade/063.ts
+++ b/data/Scarlet & Violet/Twilight Masquerade/063.ts
@@ -69,8 +69,7 @@ const card: Card = {
 	regulationMark: "H",
 
 	variants: {
-		normal: false,
-		reverse: false
+		normal: false
 	}
 }
 

--- a/data/Scarlet & Violet/Twilight Masquerade/065.ts
+++ b/data/Scarlet & Violet/Twilight Masquerade/065.ts
@@ -68,7 +68,6 @@ const card: Card = {
 	regulationMark: "H",
 
 	variants: {
-		reverse: false,
 		normal: false
 	}
 }

--- a/data/Scarlet & Violet/Twilight Masquerade/082.ts
+++ b/data/Scarlet & Violet/Twilight Masquerade/082.ts
@@ -68,7 +68,6 @@ const card: Card = {
 	regulationMark: "H",
 
 	variants: {
-		reverse: false,
 		normal: false
 	}
 }

--- a/data/Scarlet & Violet/Twilight Masquerade/093.ts
+++ b/data/Scarlet & Violet/Twilight Masquerade/093.ts
@@ -60,8 +60,7 @@ const card: Card = {
 	regulationMark: "H",
 
 	variants: {
-		normal: false,
-		reverse: false
+		normal: false
 	}
 }
 

--- a/data/Scarlet & Violet/Twilight Masquerade/095.ts
+++ b/data/Scarlet & Violet/Twilight Masquerade/095.ts
@@ -69,8 +69,7 @@ const card: Card = {
 	regulationMark: "H",
 
 	variants: {
-		normal: false,
-		reverse: false
+		normal: false
 	}
 }
 

--- a/data/Scarlet & Violet/Twilight Masquerade/096.ts
+++ b/data/Scarlet & Violet/Twilight Masquerade/096.ts
@@ -69,7 +69,6 @@ const card: Card = {
 	regulationMark: "H",
 
 	variants: {
-		reverse: false,
 		normal: false
 	}
 }

--- a/data/Scarlet & Violet/Twilight Masquerade/100.ts
+++ b/data/Scarlet & Violet/Twilight Masquerade/100.ts
@@ -67,7 +67,6 @@ const card: Card = {
 	regulationMark: "H",
 
 	variants: {
-		reverse: false,
 		normal: false
 	}
 }

--- a/data/Scarlet & Violet/Twilight Masquerade/110.ts
+++ b/data/Scarlet & Violet/Twilight Masquerade/110.ts
@@ -60,7 +60,6 @@ const card: Card = {
 	regulationMark: "H",
 
 	variants: {
-		reverse: false,
 		normal: false
 	}
 }

--- a/data/Scarlet & Violet/Twilight Masquerade/111.ts
+++ b/data/Scarlet & Violet/Twilight Masquerade/111.ts
@@ -60,7 +60,6 @@ const card: Card = {
 	regulationMark: "H",
 
 	variants: {
-		reverse: false,
 		normal: false
 	}
 }

--- a/data/Scarlet & Violet/Twilight Masquerade/123.ts
+++ b/data/Scarlet & Violet/Twilight Masquerade/123.ts
@@ -70,7 +70,6 @@ const card: Card = {
 	regulationMark: "H",
 
 	variants: {
-		reverse: false,
 		normal: false
 	}
 }


### PR DESCRIPTION
This PR adds the reverse variant for holo rare cards in SV06 Twilight Masquerade

closes https://github.com/tcgdex/cards-database/issues/599