### PR TITLE
fix: Paldean Fates holo rare cards are missing reverse variants

### DIFF
--- a/data/Scarlet & Violet/Paldean Fates/010.ts
+++ b/data/Scarlet & Violet/Paldean Fates/010.ts
@@ -61,8 +61,7 @@ const card: Card = {
 	regulationMark: "G",
 
 	variants: {
-		normal: false,
-		reverse: false
+		normal: false
 	}
 }
 

--- a/data/Scarlet & Violet/Paldean Fates/013.ts
+++ b/data/Scarlet & Violet/Paldean Fates/013.ts
@@ -48,8 +48,7 @@ const card: Card = {
 	regulationMark: "G",
 
 	variants: {
-		normal: false,
-		reverse: false
+		normal: false
 	}
 }
 

--- a/data/Scarlet & Violet/Paldean Fates/015.ts
+++ b/data/Scarlet & Violet/Paldean Fates/015.ts
@@ -69,8 +69,7 @@ const card: Card = {
 	regulationMark: "G",
 
 	variants: {
-		normal: false,
-		reverse: false
+		normal: false
 	}
 }
 

--- a/data/Scarlet & Violet/Paldean Fates/019.ts
+++ b/data/Scarlet & Violet/Paldean Fates/019.ts
@@ -70,8 +70,7 @@ const card: Card = {
 	regulationMark: "G",
 
 	variants: {
-		normal: false,
-		reverse: false
+		normal: false
 	}
 }
 

--- a/data/Scarlet & Violet/Paldean Fates/024.ts
+++ b/data/Scarlet & Violet/Paldean Fates/024.ts
@@ -70,8 +70,7 @@ const card: Card = {
 	regulationMark: "G",
 
 	variants: {
-		normal: false,
-		reverse: false
+		normal: false
 	}
 }
 

--- a/data/Scarlet & Violet/Paldean Fates/026.ts
+++ b/data/Scarlet & Violet/Paldean Fates/026.ts
@@ -61,8 +61,7 @@ const card: Card = {
 	regulationMark: "G",
 
 	variants: {
-		normal: false,
-		reverse: false
+		normal: false
 	}
 }
 

--- a/data/Scarlet & Violet/Paldean Fates/037.ts
+++ b/data/Scarlet & Violet/Paldean Fates/037.ts
@@ -68,8 +68,7 @@ const card: Card = {
 	regulationMark: "G",
 
 	variants: {
-		normal: false,
-		reverse: false
+		normal: false
 	}
 }
 

--- a/data/Scarlet & Violet/Paldean Fates/040.ts
+++ b/data/Scarlet & Violet/Paldean Fates/040.ts
@@ -69,8 +69,7 @@ const card: Card = {
 	regulationMark: "G",
 
 	variants: {
-		normal: false,
-		reverse: false
+		normal: false
 	}
 }
 

--- a/data/Scarlet & Violet/Paldean Fates/043.ts
+++ b/data/Scarlet & Violet/Paldean Fates/043.ts
@@ -47,8 +47,7 @@ const card: Card = {
 	regulationMark: "G",
 
 	variants: {
-		normal: false,
-		reverse: false
+		normal: false
 	}
 }
 

--- a/data/Scarlet & Violet/Paldean Fates/047.ts
+++ b/data/Scarlet & Violet/Paldean Fates/047.ts
@@ -69,8 +69,7 @@ const card: Card = {
 	regulationMark: "G",
 
 	variants: {
-		normal: false,
-		reverse: false
+		normal: false
 	}
 }
 

--- a/data/Scarlet & Violet/Paldean Fates/063.ts
+++ b/data/Scarlet & Violet/Paldean Fates/063.ts
@@ -69,8 +69,7 @@ const card: Card = {
 	regulationMark: "G",
 
 	variants: {
-		normal: false,
-		reverse: false
+		normal: false
 	}
 }
 

--- a/data/Scarlet & Violet/Paldean Fates/065.ts
+++ b/data/Scarlet & Violet/Paldean Fates/065.ts
@@ -69,8 +69,7 @@ const card: Card = {
 	regulationMark: "G",
 
 	variants: {
-		normal: false,
-		reverse: false
+		normal: false
 	}
 }
 

--- a/data/Scarlet & Violet/Paldean Fates/067.ts
+++ b/data/Scarlet & Violet/Paldean Fates/067.ts
@@ -67,8 +67,7 @@ const card: Card = {
 	regulationMark: "G",
 
 	variants: {
-		normal: false,
-		reverse: false
+		normal: false
 	}
 }
 

--- a/data/Scarlet & Violet/Paldean Fates/070.ts
+++ b/data/Scarlet & Violet/Paldean Fates/070.ts
@@ -47,8 +47,7 @@ const card: Card = {
 	regulationMark: "G",
 
 	variants: {
-		normal: false,
-		reverse: false
+		normal: false
 	}
 }
 

--- a/data/Scarlet & Violet/Paldean Fates/087.ts
+++ b/data/Scarlet & Violet/Paldean Fates/087.ts
@@ -29,8 +29,7 @@ const card: Card = {
 	regulationMark: "G",
 
 	variants: {
-		normal: false,
-		reverse: false
+		normal: false
 	}
 }
 

--- a/data/Scarlet & Violet/Paldean Fates/088.ts
+++ b/data/Scarlet & Violet/Paldean Fates/088.ts
@@ -29,8 +29,7 @@ const card: Card = {
 	regulationMark: "G",
 
 	variants: {
-		normal: false,
-		reverse: false
+		normal: false
 	}
 }
 


### PR DESCRIPTION
This PR adds the reverse variant for holo rare cards in SV4.5: Paldean Fates

closes #601 