### PR TITLE
fix: add missing S&V 151 reverse holo variants

### DIFF
--- a/data/Scarlet & Violet/151/015.ts
+++ b/data/Scarlet & Violet/151/015.ts
@@ -61,8 +61,7 @@ const card: Card = {
 	regulationMark: "G",
 
 	variants: {
-		normal: false,
-		reverse: false
+		normal: false
 	}
 }
 

--- a/data/Scarlet & Violet/151/026.ts
+++ b/data/Scarlet & Violet/151/026.ts
@@ -70,7 +70,6 @@ const card: Card = {
 	regulationMark: "G",
 
 	variants: {
-		reverse: false,
 		normal: false
 	}
 }

--- a/data/Scarlet & Violet/151/034.ts
+++ b/data/Scarlet & Violet/151/034.ts
@@ -70,7 +70,6 @@ const card: Card = {
 	regulationMark: "G",
 
 	variants: {
-		reverse: false,
 		normal: false
 	}
 }

--- a/data/Scarlet & Violet/151/045.ts
+++ b/data/Scarlet & Violet/151/045.ts
@@ -61,8 +61,7 @@ const card: Card = {
 	regulationMark: "G",
 
 	variants: {
-		normal: false,
-		reverse: false
+		normal: false
 	}
 }
 

--- a/data/Scarlet & Violet/151/068.ts
+++ b/data/Scarlet & Violet/151/068.ts
@@ -70,7 +70,6 @@ const card: Card = {
 	regulationMark: "G",
 
 	variants: {
-		reverse: false,
 		normal: false
 	}
 }

--- a/data/Scarlet & Violet/151/085.ts
+++ b/data/Scarlet & Violet/151/085.ts
@@ -70,7 +70,6 @@ const card: Card = {
 	regulationMark: "G",
 
 	variants: {
-		reverse: false,
 		normal: false
 	}
 }

--- a/data/Scarlet & Violet/151/094.ts
+++ b/data/Scarlet & Violet/151/094.ts
@@ -70,8 +70,7 @@ const card: Card = {
 	regulationMark: "G",
 
 	variants: {
-		normal: false,
-		reverse: false
+		normal: false
 	}
 }
 

--- a/data/Scarlet & Violet/151/101.ts
+++ b/data/Scarlet & Violet/151/101.ts
@@ -61,7 +61,6 @@ const card: Card = {
 	regulationMark: "G",
 
 	variants: {
-		reverse: false,
 		normal: false
 	}
 }

--- a/data/Scarlet & Violet/151/105.ts
+++ b/data/Scarlet & Violet/151/105.ts
@@ -70,8 +70,7 @@ const card: Card = {
 	regulationMark: "G",
 
 	variants: {
-		normal: false,
-		reverse: false
+		normal: false
 	}
 }
 

--- a/data/Scarlet & Violet/151/110.ts
+++ b/data/Scarlet & Violet/151/110.ts
@@ -70,7 +70,6 @@ const card: Card = {
 	regulationMark: "G",
 
 	variants: {
-		reverse: false,
 		normal: false
 	}
 }

--- a/data/Scarlet & Violet/151/113.ts
+++ b/data/Scarlet & Violet/151/113.ts
@@ -61,8 +61,7 @@ const card: Card = {
 	regulationMark: "G",
 
 	variants: {
-		normal: false,
-		reverse: false
+		normal: false
 	}
 }
 

--- a/data/Scarlet & Violet/151/121.ts
+++ b/data/Scarlet & Violet/151/121.ts
@@ -61,8 +61,7 @@ const card: Card = {
 	regulationMark: "G",
 
 	variants: {
-		normal: false,
-		reverse: false
+		normal: false
 	}
 }
 

--- a/data/Scarlet & Violet/151/122.ts
+++ b/data/Scarlet & Violet/151/122.ts
@@ -68,8 +68,7 @@ const card: Card = {
 	regulationMark: "G",
 
 	variants: {
-		normal: false,
-		reverse: false
+		normal: false
 	}
 }
 

--- a/data/Scarlet & Violet/151/130.ts
+++ b/data/Scarlet & Violet/151/130.ts
@@ -70,8 +70,7 @@ const card: Card = {
 	regulationMark: "G",
 
 	variants: {
-		normal: false,
-		reverse: false
+		normal: false
 	}
 }
 

--- a/data/Scarlet & Violet/151/132.ts
+++ b/data/Scarlet & Violet/151/132.ts
@@ -61,7 +61,6 @@ const card: Card = {
 	regulationMark: "G",
 
 	variants: {
-		reverse: false,
 		normal: false
 	}
 }

--- a/data/Scarlet & Violet/151/134.ts
+++ b/data/Scarlet & Violet/151/134.ts
@@ -70,7 +70,6 @@ const card: Card = {
 	regulationMark: "G",
 
 	variants: {
-		reverse: false,
 		normal: false
 	}
 }

--- a/data/Scarlet & Violet/151/135.ts
+++ b/data/Scarlet & Violet/151/135.ts
@@ -68,7 +68,6 @@ const card: Card = {
 	regulationMark: "G",
 
 	variants: {
-		reverse: false,
 		normal: false
 	}
 }

--- a/data/Scarlet & Violet/151/136.ts
+++ b/data/Scarlet & Violet/151/136.ts
@@ -70,7 +70,6 @@ const card: Card = {
 	regulationMark: "G",
 
 	variants: {
-		reverse: false,
 		normal: false
 	}
 }

--- a/data/Scarlet & Violet/151/139.ts
+++ b/data/Scarlet & Violet/151/139.ts
@@ -70,7 +70,6 @@ const card: Card = {
 	regulationMark: "G",
 
 	variants: {
-		reverse: false,
 		normal: false
 	}
 }

--- a/data/Scarlet & Violet/151/141.ts
+++ b/data/Scarlet & Violet/151/141.ts
@@ -70,7 +70,6 @@ const card: Card = {
 	regulationMark: "G",
 
 	variants: {
-		reverse: false,
 		normal: false
 	}
 }

--- a/data/Scarlet & Violet/151/142.ts
+++ b/data/Scarlet & Violet/151/142.ts
@@ -61,7 +61,6 @@ const card: Card = {
 	regulationMark: "G",
 
 	variants: {
-		reverse: false,
 		normal: false
 	}
 }

--- a/data/Scarlet & Violet/151/144.ts
+++ b/data/Scarlet & Violet/151/144.ts
@@ -70,7 +70,6 @@ const card: Card = {
 	regulationMark: "G",
 
 	variants: {
-		reverse: false,
 		normal: false
 	}
 }

--- a/data/Scarlet & Violet/151/145.ts
+++ b/data/Scarlet & Violet/151/145.ts
@@ -70,7 +70,6 @@ const card: Card = {
 	regulationMark: "G",
 
 	variants: {
-		reverse: false,
 		normal: false
 	}
 }

--- a/data/Scarlet & Violet/151/149.ts
+++ b/data/Scarlet & Violet/151/149.ts
@@ -70,8 +70,7 @@ const card: Card = {
 	regulationMark: "G",
 
 	variants: {
-		normal: false,
-		reverse: false
+		normal: false
 	}
 }
 

--- a/data/Scarlet & Violet/151/150.ts
+++ b/data/Scarlet & Violet/151/150.ts
@@ -70,8 +70,7 @@ const card: Card = {
 	regulationMark: "G",
 
 	variants: {
-		normal: false,
-		reverse: false
+		normal: false
 	}
 }
 


### PR DESCRIPTION
This PR adds the reverse variant for holo rare cards in the S&V 151 set

closes #608 