### PR TITLE
fix: add missing SV03 Obsidian Flames reverse holo variants

### DIFF
--- a/data/Scarlet & Violet/Obsidian Flames/025.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/025.ts
@@ -69,7 +69,6 @@ const card: Card = {
 	regulationMark: "G",
 
 	variants: {
-		reverse: false,
 		normal: false
 	}
 }

--- a/data/Scarlet & Violet/Obsidian Flames/030.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/030.ts
@@ -70,7 +70,6 @@ const card: Card = {
 	regulationMark: "G",
 
 	variants: {
-		reverse: false,
 		normal: false
 	}
 }

--- a/data/Scarlet & Violet/Obsidian Flames/062.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/062.ts
@@ -69,7 +69,6 @@ const card: Card = {
 	regulationMark: "G",
 
 	variants: {
-		reverse: false,
 		normal: false
 	}
 }

--- a/data/Scarlet & Violet/Obsidian Flames/070.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/070.ts
@@ -70,7 +70,6 @@ const card: Card = {
 	regulationMark: "G",
 
 	variants: {
-		reverse: false,
 		normal: false
 	}
 }

--- a/data/Scarlet & Violet/Obsidian Flames/072.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/072.ts
@@ -67,7 +67,6 @@ const card: Card = {
 	regulationMark: "G",
 
 	variants: {
-		reverse: false,
 		normal: false
 	}
 }

--- a/data/Scarlet & Violet/Obsidian Flames/085.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/085.ts
@@ -70,7 +70,6 @@ const card: Card = {
 	regulationMark: "G",
 
 	variants: {
-		reverse: false,
 		normal: false
 	}
 }

--- a/data/Scarlet & Violet/Obsidian Flames/095.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/095.ts
@@ -68,7 +68,6 @@ const card: Card = {
 	regulationMark: "G",
 
 	variants: {
-		reverse: false,
 		normal: false
 	}
 }

--- a/data/Scarlet & Violet/Obsidian Flames/136.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/136.ts
@@ -70,7 +70,6 @@ const card: Card = {
 	regulationMark: "G",
 
 	variants: {
-		reverse: false,
 		normal: false
 	}
 }

--- a/data/Scarlet & Violet/Obsidian Flames/141.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/141.ts
@@ -61,7 +61,6 @@ const card: Card = {
 	regulationMark: "G",
 
 	variants: {
-		reverse: false,
 		normal: false
 	}
 }

--- a/data/Scarlet & Violet/Obsidian Flames/188.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/188.ts
@@ -29,7 +29,6 @@ const card: Card = {
 	regulationMark: "G",
 
 	variants: {
-		reverse: false,
 		normal: false
 	}
 }


### PR DESCRIPTION
This PR adds the reverse variant for holo rare cards in the SV03: Obsidian Flames set

closes #610 