### PR TITLE
fix: Paldea Evolved variants are incorrect

### DIFF
--- a/data/Scarlet & Violet/Paldea Evolved/003.ts
+++ b/data/Scarlet & Violet/Paldea Evolved/003.ts
@@ -70,8 +70,7 @@ const card: Card = {
 	regulationMark: "G",
 
 	variants: {
-		normal: false,
-		reverse: false
+		normal: false
 	}
 }
 

--- a/data/Scarlet & Violet/Paldea Evolved/011.ts
+++ b/data/Scarlet & Violet/Paldea Evolved/011.ts
@@ -61,7 +61,6 @@ const card: Card = {
 	regulationMark: "G",
 
 	variants: {
-		reverse: false,
 		normal: false
 	}
 }

--- a/data/Scarlet & Violet/Paldea Evolved/021.ts
+++ b/data/Scarlet & Violet/Paldea Evolved/021.ts
@@ -60,7 +60,6 @@ const card: Card = {
 	regulationMark: "G",
 
 	variants: {
-		reverse: false,
 		normal: false
 	}
 }

--- a/data/Scarlet & Violet/Paldea Evolved/033.ts
+++ b/data/Scarlet & Violet/Paldea Evolved/033.ts
@@ -61,7 +61,6 @@ const card: Card = {
 	regulationMark: "G",
 
 	variants: {
-		reverse: false,
 		normal: false
 	}
 }

--- a/data/Scarlet & Violet/Paldea Evolved/043.ts
+++ b/data/Scarlet & Violet/Paldea Evolved/043.ts
@@ -70,7 +70,6 @@ const card: Card = {
 	regulationMark: "G",
 
 	variants: {
-		reverse: false,
 		normal: false
 	}
 }

--- a/data/Scarlet & Violet/Paldea Evolved/056.ts
+++ b/data/Scarlet & Violet/Paldea Evolved/056.ts
@@ -60,7 +60,6 @@ const card: Card = {
 	regulationMark: "G",
 
 	variants: {
-		reverse: false,
 		normal: false
 	}
 }

--- a/data/Scarlet & Violet/Paldea Evolved/060.ts
+++ b/data/Scarlet & Violet/Paldea Evolved/060.ts
@@ -60,7 +60,6 @@ const card: Card = {
 	regulationMark: "G",
 
 	variants: {
-		reverse: false,
 		normal: false
 	}
 }

--- a/data/Scarlet & Violet/Paldea Evolved/071.ts
+++ b/data/Scarlet & Violet/Paldea Evolved/071.ts
@@ -70,7 +70,6 @@ const card: Card = {
 	regulationMark: "G",
 
 	variants: {
-		reverse: false,
 		normal: false
 	}
 }

--- a/data/Scarlet & Violet/Paldea Evolved/076.ts
+++ b/data/Scarlet & Violet/Paldea Evolved/076.ts
@@ -60,7 +60,6 @@ const card: Card = {
 	regulationMark: "G",
 
 	variants: {
-		reverse: false,
 		normal: false
 	}
 }

--- a/data/Scarlet & Violet/Paldea Evolved/079.ts
+++ b/data/Scarlet & Violet/Paldea Evolved/079.ts
@@ -67,7 +67,6 @@ const card: Card = {
 	regulationMark: "G",
 
 	variants: {
-		reverse: false,
 		normal: false
 	}
 }

--- a/data/Scarlet & Violet/Paldea Evolved/084.ts
+++ b/data/Scarlet & Violet/Paldea Evolved/084.ts
@@ -61,7 +61,7 @@ const card: Card = {
 	regulationMark: "G",
 
 	variants: {
-		reverse: false
+		normal: false
 	}
 }
 

--- a/data/Scarlet & Violet/Paldea Evolved/089.ts
+++ b/data/Scarlet & Violet/Paldea Evolved/089.ts
@@ -70,7 +70,6 @@ const card: Card = {
 	regulationMark: "G",
 
 	variants: {
-		reverse: false,
 		normal: false
 	}
 }

--- a/data/Scarlet & Violet/Paldea Evolved/097.ts
+++ b/data/Scarlet & Violet/Paldea Evolved/097.ts
@@ -68,8 +68,7 @@ const card: Card = {
 	regulationMark: "G",
 
 	variants: {
-		normal: false,
-		reverse: false
+		normal: false
 	}
 }
 

--- a/data/Scarlet & Violet/Paldea Evolved/098.ts
+++ b/data/Scarlet & Violet/Paldea Evolved/098.ts
@@ -69,7 +69,6 @@ const card: Card = {
 	regulationMark: "G",
 
 	variants: {
-		reverse: false,
 		normal: false
 	}
 }

--- a/data/Scarlet & Violet/Paldea Evolved/099.ts
+++ b/data/Scarlet & Violet/Paldea Evolved/099.ts
@@ -67,8 +67,7 @@ const card: Card = {
 	regulationMark: "G",
 
 	variants: {
-		normal: false,
-		reverse: false
+		normal: false
 	}
 }
 

--- a/data/Scarlet & Violet/Paldea Evolved/105.ts
+++ b/data/Scarlet & Violet/Paldea Evolved/105.ts
@@ -69,7 +69,6 @@ const card: Card = {
 	regulationMark: "G",
 
 	variants: {
-		reverse: false,
 		normal: false
 	}
 }

--- a/data/Scarlet & Violet/Paldea Evolved/113.ts
+++ b/data/Scarlet & Violet/Paldea Evolved/113.ts
@@ -61,7 +61,6 @@ const card: Card = {
 	regulationMark: "G",
 
 	variants: {
-		reverse: false,
 		normal: false
 	}
 }

--- a/data/Scarlet & Violet/Paldea Evolved/123.ts
+++ b/data/Scarlet & Violet/Paldea Evolved/123.ts
@@ -69,7 +69,6 @@ const card: Card = {
 	regulationMark: "G",
 
 	variants: {
-		reverse: false,
 		normal: false
 	}
 }

--- a/data/Scarlet & Violet/Paldea Evolved/126.ts
+++ b/data/Scarlet & Violet/Paldea Evolved/126.ts
@@ -67,7 +67,6 @@ const card: Card = {
 	regulationMark: "G",
 
 	variants: {
-		reverse: false,
 		normal: false
 	}
 }

--- a/data/Scarlet & Violet/Paldea Evolved/134.ts
+++ b/data/Scarlet & Violet/Paldea Evolved/134.ts
@@ -61,7 +61,7 @@ const card: Card = {
 	regulationMark: "G",
 
 	variants: {
-		reverse: false
+		normal: false
 	}
 }
 

--- a/data/Scarlet & Violet/Paldea Evolved/135.ts
+++ b/data/Scarlet & Violet/Paldea Evolved/135.ts
@@ -70,8 +70,7 @@ const card: Card = {
 	regulationMark: "G",
 
 	variants: {
-		normal: false,
-		reverse: false
+		normal: false
 	}
 }
 

--- a/data/Scarlet & Violet/Paldea Evolved/136.ts
+++ b/data/Scarlet & Violet/Paldea Evolved/136.ts
@@ -68,7 +68,6 @@ const card: Card = {
 	regulationMark: "G",
 
 	variants: {
-		reverse: false,
 		normal: false
 	}
 }

--- a/data/Scarlet & Violet/Paldea Evolved/140.ts
+++ b/data/Scarlet & Violet/Paldea Evolved/140.ts
@@ -61,7 +61,6 @@ const card: Card = {
 	regulationMark: "G",
 
 	variants: {
-		reverse: false,
 		normal: false
 	}
 }

--- a/data/Scarlet & Violet/Paldea Evolved/151.ts
+++ b/data/Scarlet & Violet/Paldea Evolved/151.ts
@@ -69,7 +69,6 @@ const card: Card = {
 	regulationMark: "G",
 
 	variants: {
-		reverse: false,
 		normal: false
 	}
 }

--- a/data/Scarlet & Violet/Paldea Evolved/162.ts
+++ b/data/Scarlet & Violet/Paldea Evolved/162.ts
@@ -70,7 +70,6 @@ const card: Card = {
 	regulationMark: "G",
 
 	variants: {
-		reverse: false,
 		normal: false
 	}
 }

--- a/data/Scarlet & Violet/Paldea Evolved/172.ts
+++ b/data/Scarlet & Violet/Paldea Evolved/172.ts
@@ -29,7 +29,6 @@ const card: Card = {
 	regulationMark: "G",
 
 	variants: {
-		reverse: false,
 		normal: false
 	}
 }

--- a/data/Scarlet & Violet/Paldea Evolved/185.ts
+++ b/data/Scarlet & Violet/Paldea Evolved/185.ts
@@ -26,11 +26,7 @@ const card: Card = {
 	},
 
 	trainerType: "Supporter",
-	regulationMark: "G",
-
-	variants: {
-		holo: false
-	}
+	regulationMark: "G"
 }
 
 export default card


### PR DESCRIPTION
Fixes Paldea Evolved's variants (mainly the missing rare rev holos, but a couple other corrections too).