### PR TITLE
Added evolveFrom tag to all Genetic Apex cards to Fix #619

### DIFF
--- a/data/Pokémon TCG Pocket/Genetic Apex/002.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/002.ts
@@ -13,6 +13,9 @@ const card: Card = {
 	hp: 90,
 	types: ["Grass"],
 	stage: "Stage1",
+	evolveFrom: {
+		en: "Bulbasaur"
+	}, 
 
 	attacks: [{
 		cost: ["Grass", "Colorless", "Colorless"],

--- a/data/Pokémon TCG Pocket/Genetic Apex/003.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/003.ts
@@ -13,6 +13,9 @@ const card: Card = {
 	hp: 160,
 	types: ["Grass"],
 	stage: "Stage2",
+	evolveFrom: {
+		en: "Ivysaur"
+	},
 
 	attacks: [{
 		cost: ["Grass", "Grass", "Colorless", "Colorless"],

--- a/data/Pokémon TCG Pocket/Genetic Apex/004.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/004.ts
@@ -13,6 +13,9 @@ const card: Card = {
 	hp: 190,
 	types: ["Grass"],
 	stage: "Stage2",
+	evolveFrom: {
+		en: "Ivysaur"
+	},
 	suffix: "EX",
 
 	attacks: [{

--- a/data/Pokémon TCG Pocket/Genetic Apex/006.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/006.ts
@@ -13,6 +13,9 @@ const card: Card = {
 	hp: 80,
 	types: ["Grass"],
 	stage: "Stage1",
+	evolveFrom: {
+		en: "Caterpie"
+	},
 
 	attacks: [{
 		cost: ["Colorless", "Colorless"],

--- a/data/Pokémon TCG Pocket/Genetic Apex/007.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/007.ts
@@ -13,6 +13,9 @@ const card: Card = {
 	hp: 120,
 	types: ["Grass"],
 	stage: "Stage2",
+	evolveFrom: {
+		en: "Metapod"
+	},
 
 	abilities: [{
 		type: "Ability",

--- a/data/Pokémon TCG Pocket/Genetic Apex/009.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/009.ts
@@ -13,6 +13,9 @@ const card: Card = {
 	hp: 80,
 	types: ["Grass"],
 	stage: "Stage1",
+	evolveFrom: {
+		en: "Weedle"
+	},
 
 	attacks: [{
 		cost: ["Grass"],

--- a/data/Pokémon TCG Pocket/Genetic Apex/010.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/010.ts
@@ -13,6 +13,9 @@ const card: Card = {
 	hp: 120,
 	types: ["Grass"],
 	stage: "Stage2",
+	evolveFrom: {
+		en: "Kakuna"
+	},
 
 	attacks: [{
 		cost: ["Grass"],

--- a/data/Pokémon TCG Pocket/Genetic Apex/012.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/012.ts
@@ -13,6 +13,9 @@ const card: Card = {
 	hp: 80,
 	types: ["Grass"],
 	stage: "Stage1",
+	evolveFrom: {
+		en: "Oddish"
+	},
 
 	attacks: [{
 		cost: ["Grass", "Colorless"],

--- a/data/Pokémon TCG Pocket/Genetic Apex/013.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/013.ts
@@ -13,6 +13,9 @@ const card: Card = {
 	hp: 140,
 	types: ["Grass"],
 	stage: "Stage2",
+	evolveFrom: {
+		en: "Gloom"
+	},
 
 	attacks: [{
 		cost: ["Grass", "Grass", "Colorless"],

--- a/data/Pokémon TCG Pocket/Genetic Apex/015.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/015.ts
@@ -13,6 +13,9 @@ const card: Card = {
 	hp: 120,
 	types: ["Grass"],
 	stage: "Stage1",
+	evolveFrom: {
+		en: "Paras"
+	},
 
 	attacks: [{
 		cost: ["Grass", "Grass", "Colorless"],

--- a/data/Pokémon TCG Pocket/Genetic Apex/017.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/017.ts
@@ -13,6 +13,9 @@ const card: Card = {
 	hp: 80,
 	types: ["Grass"],
 	stage: "Stage1",
+	evolveFrom: {
+		en: "Venonat"
+	},
 
 	attacks: [{
 		cost: ["Grass"],

--- a/data/Pokémon TCG Pocket/Genetic Apex/019.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/019.ts
@@ -13,6 +13,9 @@ const card: Card = {
 	hp: 90,
 	types: ["Grass"],
 	stage: "Stage1",
+	evolveFrom: {
+		en: "Bellsprout"
+	},
 
 	attacks: [{
 		cost: ["Grass", "Colorless"],

--- a/data/Pokémon TCG Pocket/Genetic Apex/020.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/020.ts
@@ -13,6 +13,9 @@ const card: Card = {
 	hp: 140,
 	types: ["Grass"],
 	stage: "Stage2",
+	evolveFrom: {
+		en: "Weepinbell"
+	},
 
 	abilities: [{
 		type: "Ability",

--- a/data/Pokémon TCG Pocket/Genetic Apex/022.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/022.ts
@@ -13,6 +13,9 @@ const card: Card = {
 	hp: 160,
 	types: ["Grass"],
 	stage: "Stage1",
+	evolveFrom: {
+		en: "Exeggcute"
+	},
 
 	attacks: [{
 		cost: ["Grass"],

--- a/data/Pokémon TCG Pocket/Genetic Apex/023.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/023.ts
@@ -13,6 +13,9 @@ const card: Card = {
 	hp: 160,
 	types: ["Grass"],
 	stage: "Stage1",
+	evolveFrom: {
+		en: "Exeggcute"
+	},
 	attacks: [{
 		cost: ["Grass"],
 

--- a/data/Pokémon TCG Pocket/Genetic Apex/028.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/028.ts
@@ -13,6 +13,9 @@ const card: Card = {
 	hp: 80,
 	types: ["Grass"],
 	stage: "Stage1",
+	evolveFrom: {
+		en: "Cottonee"
+	},
 
 	attacks: [{
 		cost: ["Colorless"],

--- a/data/Pokémon TCG Pocket/Genetic Apex/030.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/030.ts
@@ -13,6 +13,10 @@ const card: Card = {
 	hp: 100,
 	types: ["Grass"],
 	stage: "Stage1",
+	evolveFrom: {
+		en: "Petilil"
+	},
+
 
 	attacks: [{
 		cost: ["Grass", "Grass"],

--- a/data/Pokémon TCG Pocket/Genetic Apex/032.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/032.ts
@@ -12,6 +12,10 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 120,
 	stage: "Stage1",
+	evolveFrom: {
+		en: "Skiddo"
+	},
+
 
 	attacks: [{
 		cost: ["Grass", "Colorless", "Colorless"],

--- a/data/Pokémon TCG Pocket/Genetic Apex/034.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/034.ts
@@ -13,6 +13,10 @@ const card: Card = {
 	hp: 90,
 	types: ["Fire"],
 	stage: "Stage1",
+	evolveFrom: {
+		en: "Charmander"
+	},
+
 
 	attacks: [{
 		cost: ["Fire", "Colorless", "Colorless"],

--- a/data/Pokémon TCG Pocket/Genetic Apex/035.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/035.ts
@@ -13,6 +13,10 @@ const card: Card = {
 	hp: 150,
 	types: ["Fire"],
 	stage: "Stage2",
+	evolveFrom: {
+		en: "Charmeleon"
+	},
+
 
 	attacks: [{
 		cost: ["Fire", "Fire", "Colorless", "Colorless"],

--- a/data/Pokémon TCG Pocket/Genetic Apex/036.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/036.ts
@@ -13,6 +13,10 @@ const card: Card = {
 	hp: 180,
 	types: ["Fire"],
 	stage: "Stage2",
+	evolveFrom: {
+		en: "Charmeleon"
+	},
+
 	suffix: "EX",
 
 	attacks: [{

--- a/data/Pokémon TCG Pocket/Genetic Apex/038.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/038.ts
@@ -13,6 +13,10 @@ const card: Card = {
 	hp: 90,
 	types: ["Fire"],
 	stage: "Stage1",
+	evolveFrom: {
+		en: "Vulpix"
+	},
+
 
 	attacks: [{
 		cost: ["Fire", "Fire"],

--- a/data/Pokémon TCG Pocket/Genetic Apex/040.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/040.ts
@@ -13,6 +13,10 @@ const card: Card = {
 	hp: 150,
 	types: ["Fire"],
 	stage: "Stage1",
+	evolveFrom: {
+		en: "Growlithe"
+	},
+
 
 	attacks: [{
 		cost: ["Fire", "Fire", "Colorless"],

--- a/data/Pokémon TCG Pocket/Genetic Apex/041.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/041.ts
@@ -13,6 +13,10 @@ const card: Card = {
 	hp: 150,
 	types: ["Fire"],
 	stage: "Stage1",
+	evolveFrom: {
+		en: "Growlithe"
+	},
+
 	suffix: "EX",
 
 	attacks: [{

--- a/data/Pokémon TCG Pocket/Genetic Apex/043.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/043.ts
@@ -13,6 +13,10 @@ const card: Card = {
 	hp: 100,
 	types: ["Fire"],
 	stage: "Stage1",
+	evolveFrom: {
+		en: "Ponyta"
+	},
+
 
 	attacks: [{
 		cost: ["Fire"],

--- a/data/Pokémon TCG Pocket/Genetic Apex/045.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/045.ts
@@ -13,6 +13,10 @@ const card: Card = {
 	hp: 120,
 	types: ["Fire"],
 	stage: "Stage1",
+	evolveFrom: {
+		en: "Eevee"
+	},
+
 
 	attacks: [{
 		cost: ["Fire", "Colorless", "Colorless"],

--- a/data/Pokémon TCG Pocket/Genetic Apex/052.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/052.ts
@@ -13,6 +13,10 @@ const card: Card = {
 	hp: 130,
 	types: ["Fire"],
 	stage: "Stage1",
+	evolveFrom: {
+		en: "Sizzlipede"
+	},
+
 
 	attacks: [{
 		cost: ["Fire", "Colorless", "Colorless", "Colorless"],

--- a/data/Pokémon TCG Pocket/Genetic Apex/054.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/054.ts
@@ -13,6 +13,10 @@ const card: Card = {
 	hp: 80,
 	types: ["Water"],
 	stage: "Stage1",
+	evolveFrom: {
+		en: "Squirtle"
+	},
+
 
 	attacks: [{
 		cost: ["Water", "Colorless"],

--- a/data/Pokémon TCG Pocket/Genetic Apex/055.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/055.ts
@@ -13,6 +13,10 @@ const card: Card = {
 	hp: 150,
 	types: ["Water"],
 	stage: "Stage2",
+	evolveFrom: {
+		en: "Wartortle"
+	},
+
 
 	attacks: [{
 		cost: ["Water", "Colorless"],

--- a/data/Pokémon TCG Pocket/Genetic Apex/056.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/056.ts
@@ -13,6 +13,10 @@ const card: Card = {
 	hp: 180,
 	types: ["Water"],
 	stage: "Stage2",
+	evolveFrom: {
+		en: "Wartortle"
+	},
+
 	suffix: "EX",
 
 	attacks: [{

--- a/data/Pokémon TCG Pocket/Genetic Apex/058.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/058.ts
@@ -13,6 +13,10 @@ const card: Card = {
 	hp: 90,
 	types: ["Water"],
 	stage: "Stage1",
+	evolveFrom: {
+		en: "Psyduck"
+	},
+
 
 	attacks: [{
 		cost: ["Water", "Water"],

--- a/data/Pokémon TCG Pocket/Genetic Apex/060.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/060.ts
@@ -13,6 +13,10 @@ const card: Card = {
 	hp: 90,
 	types: ["Water"],
 	stage: "Stage1",
+	evolveFrom: {
+		en: "Poliwag"
+	},
+
 
 	attacks: [{
 		cost: ["Colorless", "Colorless"],

--- a/data/Pokémon TCG Pocket/Genetic Apex/061.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/061.ts
@@ -13,6 +13,10 @@ const card: Card = {
 	hp: 150,
 	types: ["Water"],
 	stage: "Stage2",
+	evolveFrom: {
+		en: "Poliwhirl"
+	},
+
 
 	abilities: [{
 		type: "Ability",

--- a/data/Pokémon TCG Pocket/Genetic Apex/063.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/063.ts
@@ -13,6 +13,10 @@ const card: Card = {
 	hp: 110,
 	types: ["Water"],
 	stage: "Stage1",
+	evolveFrom: {
+		en: "Tentacool"
+	},
+
 
 	attacks: [{
 		cost: ["Water", "Colorless"],

--- a/data/Pokémon TCG Pocket/Genetic Apex/065.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/065.ts
@@ -13,6 +13,10 @@ const card: Card = {
 	hp: 120,
 	types: ["Water"],
 	stage: "Stage1",
+	evolveFrom: {
+		en: "Seel"
+	},
+
 
 	attacks: [{
 		cost: ["Water", "Water", "Water"],

--- a/data/Pokémon TCG Pocket/Genetic Apex/067.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/067.ts
@@ -13,6 +13,10 @@ const card: Card = {
 	hp: 120,
 	types: ["Water"],
 	stage: "Stage1",
+	evolveFrom: {
+		en: "Shellder"
+	},
+
 
 	abilities: [{
 		type: "Ability",

--- a/data/Pokémon TCG Pocket/Genetic Apex/069.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/069.ts
@@ -13,6 +13,10 @@ const card: Card = {
 	hp: 120,
 	types: ["Water"],
 	stage: "Stage1",
+	evolveFrom: {
+		en: "Krabby"
+	},
+
 
 	attacks: [{
 		cost: ["Water", "Water", "Colorless"],

--- a/data/Pokémon TCG Pocket/Genetic Apex/071.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/071.ts
@@ -13,6 +13,10 @@ const card: Card = {
 	hp: 70,
 	types: ["Water"],
 	stage: "Stage1",
+	evolveFrom: {
+		en: "Horsea"
+	},
+
 
 	attacks: [{
 		cost: ["Water", "Water", "Colorless"],

--- a/data/Pokémon TCG Pocket/Genetic Apex/073.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/073.ts
@@ -13,6 +13,10 @@ const card: Card = {
 	hp: 100,
 	types: ["Water"],
 	stage: "Stage1",
+	evolveFrom: {
+		en: "Goldeen"
+	},
+
 
 	attacks: [{
 		cost: ["Water"],

--- a/data/Pokémon TCG Pocket/Genetic Apex/075.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/075.ts
@@ -13,6 +13,10 @@ const card: Card = {
 	hp: 90,
 	types: ["Water"],
 	stage: "Stage1",
+	evolveFrom: {
+		en: "Staryu"
+	},
+
 
 	attacks: [{
 		cost: ["Water"],

--- a/data/Pokémon TCG Pocket/Genetic Apex/076.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/076.ts
@@ -13,6 +13,10 @@ const card: Card = {
 	hp: 130,
 	types: ["Water"],
 	stage: "Stage1",
+	evolveFrom: {
+		en: "Staryu"
+	},
+
 	suffix: "EX",
 
 	attacks: [{

--- a/data/Pokémon TCG Pocket/Genetic Apex/078.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/078.ts
@@ -13,6 +13,10 @@ const card: Card = {
 	hp: 150,
 	types: ["Water"],
 	stage: "Stage1",
+	evolveFrom: {
+		en: "Magikarp"
+	},
+
 
 	attacks: [{
 		cost: ["Water", "Water", "Water", "Water"],

--- a/data/Pokémon TCG Pocket/Genetic Apex/080.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/080.ts
@@ -13,6 +13,10 @@ const card: Card = {
 	hp: 130,
 	types: ["Water"],
 	stage: "Stage1",
+	evolveFrom: {
+		en: "Eevee"
+	},
+
 
 	attacks: [{
 		cost: ["Water", "Colorless", "Colorless"],

--- a/data/Pokémon TCG Pocket/Genetic Apex/081.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/081.ts
@@ -13,6 +13,10 @@ const card: Card = {
 	hp: 90,
 	types: ["Water"],
 	stage: "Stage1",
+	evolveFrom: {
+		en: "Helix Fossil"
+	},
+
 
 	attacks: [{
 		cost: ["Water"],

--- a/data/Pokémon TCG Pocket/Genetic Apex/082.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/082.ts
@@ -13,6 +13,10 @@ const card: Card = {
 	hp: 140,
 	types: ["Water"],
 	stage: "Stage2",
+	evolveFrom: {
+		en: "Omanyte"
+	},
+
 
 	attacks: [{
 		cost: ["Water", "Colorless", "Colorless"],

--- a/data/Pokémon TCG Pocket/Genetic Apex/086.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/086.ts
@@ -13,6 +13,10 @@ const card: Card = {
 	hp: 90,
 	types: ["Water"],
 	stage: "Stage1",
+	evolveFrom: {
+		en: "Ducklett"
+	},
+
 
 	attacks: [{
 		cost: ["Colorless", "Colorless", "Colorless"],

--- a/data/Pokémon TCG Pocket/Genetic Apex/088.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/088.ts
@@ -13,6 +13,10 @@ const card: Card = {
 	hp: 80,
 	types: ["Water"],
 	stage: "Stage1",
+	evolveFrom: {
+		en: "Froakie"
+	},
+
 
 	attacks: [{
 		cost: ["Colorless"],

--- a/data/Pokémon TCG Pocket/Genetic Apex/089.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/089.ts
@@ -13,6 +13,10 @@ const card: Card = {
 	hp: 120,
 	types: ["Water"],
 	stage: "Stage2",
+	evolveFrom: {
+		en: "Frogadier"
+	},
+
 
 	abilities: [{
 		type: "Ability",

--- a/data/Pokémon TCG Pocket/Genetic Apex/093.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/093.ts
@@ -13,6 +13,10 @@ const card: Card = {
 	hp: 90,
 	types: ["Water"],
 	stage: "Stage1",
+	evolveFrom: {
+		en: "Snom"
+	},
+
 
 	attacks: [{
 		cost: ["Water", "Colorless"],

--- a/data/Pokémon TCG Pocket/Genetic Apex/095.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/095.ts
@@ -13,6 +13,10 @@ const card: Card = {
 	hp: 100,
 	types: ["Lightning"],
 	stage: "Stage1",
+	evolveFrom: {
+		en: "Pikachu"
+	},
+
 
 	attacks: [{
 		cost: ["Lightning", "Lightning", "Lightning"],

--- a/data/Pokémon TCG Pocket/Genetic Apex/098.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/098.ts
@@ -13,6 +13,10 @@ const card: Card = {
 	hp: 80,
 	types: ["Lightning"],
 	stage: "Stage1",
+	evolveFrom: {
+		en: "Magnemite"
+	},
+
 
 	abilities: [{
 		type: "Ability",

--- a/data/Pokémon TCG Pocket/Genetic Apex/100.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/100.ts
@@ -13,6 +13,10 @@ const card: Card = {
 	hp: 80,
 	types: ["Lightning"],
 	stage: "Stage1",
+	evolveFrom: {
+		en: "Voltorb"
+	},
+
 
 	attacks: [{
 		cost: ["Lightning", "Lightning"],

--- a/data/Pokémon TCG Pocket/Genetic Apex/102.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/102.ts
@@ -13,6 +13,10 @@ const card: Card = {
 	hp: 90,
 	types: ["Lightning"],
 	stage: "Stage1",
+	evolveFrom: {
+		en: "Eevee"
+	},
+
 
 	attacks: [{
 		cost: ["Lightning", "Colorless"],

--- a/data/Pokémon TCG Pocket/Genetic Apex/106.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/106.ts
@@ -13,6 +13,10 @@ const card: Card = {
 	hp: 90,
 	types: ["Lightning"],
 	stage: "Stage1",
+	evolveFrom: {
+		en: "Blitzle"
+	},
+
 
 	attacks: [{
 		cost: ["Lightning"],

--- a/data/Pokémon TCG Pocket/Genetic Apex/108.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/108.ts
@@ -13,6 +13,10 @@ const card: Card = {
 	hp: 80,
 	types: ["Lightning"],
 	stage: "Stage1",
+	evolveFrom: {
+		en: "Tynamo"
+	},
+
 
 	attacks: [{
 		cost: ["Lightning"],

--- a/data/Pokémon TCG Pocket/Genetic Apex/109.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/109.ts
@@ -13,6 +13,10 @@ const card: Card = {
 	hp: 140,
 	types: ["Lightning"],
 	stage: "Stage2",
+	evolveFrom: {
+		en: "Eelektrik"
+	},
+
 
 	attacks: [{
 		cost: ["Lightning", "Lightning", "Colorless"],

--- a/data/Pokémon TCG Pocket/Genetic Apex/111.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/111.ts
@@ -13,6 +13,10 @@ const card: Card = {
 	hp: 90,
 	types: ["Lightning"],
 	stage: "Stage1",
+	evolveFrom: {
+		en: "Helioptile"
+	},
+
 
 	attacks: [{
 		cost: ["Colorless", "Colorless"],

--- a/data/Pokémon TCG Pocket/Genetic Apex/114.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/114.ts
@@ -13,6 +13,10 @@ const card: Card = {
 	hp: 100,
 	types: ["Psychic"],
 	stage: "Stage1",
+	evolveFrom: {
+		en: "Clefairy"
+	},
+
 
 	attacks: [{
 		cost: ["Psychic"],

--- a/data/Pokémon TCG Pocket/Genetic Apex/116.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/116.ts
@@ -13,6 +13,10 @@ const card: Card = {
 	hp: 80,
 	types: ["Psychic"],
 	stage: "Stage1",
+	evolveFrom: {
+		en: "Abra"
+	},
+
 
 	attacks: [{
 		cost: ["Psychic", "Colorless", "Colorless"],

--- a/data/Pokémon TCG Pocket/Genetic Apex/117.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/117.ts
@@ -13,6 +13,10 @@ const card: Card = {
 	hp: 130,
 	types: ["Psychic"],
 	stage: "Stage2",
+	evolveFrom: {
+		en: "Kadabra"
+	},
+
 
 	attacks: [{
 		cost: ["Psychic", "Colorless", "Colorless"],

--- a/data/Pokémon TCG Pocket/Genetic Apex/119.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/119.ts
@@ -13,6 +13,10 @@ const card: Card = {
 	hp: 130,
 	types: ["Psychic"],
 	stage: "Stage1",
+	evolveFrom: {
+		en: "Slowpoke"
+	},
+
 
 	attacks: [{
 		cost: ["Psychic", "Psychic", "Colorless"],

--- a/data/Pokémon TCG Pocket/Genetic Apex/121.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/121.ts
@@ -13,6 +13,10 @@ const card: Card = {
 	hp: 80,
 	types: ["Psychic"],
 	stage: "Stage1",
+	evolveFrom: {
+		en: "Gastly"
+	},
+
 
 	attacks: [{
 		cost: ["Psychic"],

--- a/data/Pokémon TCG Pocket/Genetic Apex/122.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/122.ts
@@ -13,6 +13,10 @@ const card: Card = {
 	hp: 130,
 	types: ["Psychic"],
 	stage: "Stage2",
+	evolveFrom: {
+		en: "Haunter"
+	},
+
 
 	attacks: [{
 		cost: ["Psychic"],

--- a/data/Pokémon TCG Pocket/Genetic Apex/123.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/123.ts
@@ -13,6 +13,10 @@ const card: Card = {
 	hp: 170,
 	types: ["Psychic"],
 	stage: "Stage2",
+	evolveFrom: {
+		en: "Haunter"
+	},
+
 	suffix: "EX",
 
 	abilities: [{

--- a/data/Pokémon TCG Pocket/Genetic Apex/125.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/125.ts
@@ -13,6 +13,10 @@ const card: Card = {
 	hp: 100,
 	types: ["Psychic"],
 	stage: "Stage1",
+	evolveFrom: {
+		en: "Drowzee"
+	},
+
 
 	abilities: [{
 		type: "Ability",

--- a/data/Pokémon TCG Pocket/Genetic Apex/131.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/131.ts
@@ -13,6 +13,10 @@ const card: Card = {
 	hp: 80,
 	types: ["Psychic"],
 	stage: "Stage1",
+	evolveFrom: {
+		en: "Ralts"
+	},
+
 
 	attacks: [{
 		cost: ["Psychic", "Colorless"],

--- a/data/Pokémon TCG Pocket/Genetic Apex/132.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/132.ts
@@ -13,6 +13,10 @@ const card: Card = {
 	hp: 110,
 	types: ["Psychic"],
 	stage: "Stage2",
+	evolveFrom: {
+		en: "Kirlia"
+	},
+
 
 	abilities: [{
 		type: "Ability",

--- a/data/Pokémon TCG Pocket/Genetic Apex/134.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/134.ts
@@ -13,6 +13,10 @@ const card: Card = {
 	hp: 90,
 	types: ["Psychic"],
 	stage: "Stage1",
+	evolveFrom: {
+		en: "Woobat"
+	},
+
 
 	attacks: [{
 		cost: ["Psychic", "Colorless"],

--- a/data/Pokémon TCG Pocket/Genetic Apex/136.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/136.ts
@@ -13,6 +13,10 @@ const card: Card = {
 	hp: 140,
 	types: ["Psychic"],
 	stage: "Stage1",
+	evolveFrom: {
+		en: "Golett"
+	},
+
 
 	attacks: [{
 		cost: ["Psychic", "Psychic", "Colorless", "Colorless"],

--- a/data/Pokémon TCG Pocket/Genetic Apex/138.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/138.ts
@@ -13,6 +13,10 @@ const card: Card = {
 	hp: 100,
 	types: ["Fighting"],
 	stage: "Stage1",
+	evolveFrom: {
+		en: "Sandshrew"
+	},
+
 
 	attacks: [{
 		cost: ["Fighting", "Fighting"],

--- a/data/Pokémon TCG Pocket/Genetic Apex/140.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/140.ts
@@ -13,6 +13,10 @@ const card: Card = {
 	hp: 70,
 	types: ["Fighting"],
 	stage: "Stage1",
+	evolveFrom: {
+		en: "Diglett"
+	},
+
 
 	attacks: [{
 		cost: ["Fighting"],

--- a/data/Pokémon TCG Pocket/Genetic Apex/142.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/142.ts
@@ -13,6 +13,10 @@ const card: Card = {
 	hp: 90,
 	types: ["Fighting"],
 	stage: "Stage1",
+	evolveFrom: {
+		en: "Mankey"
+	},
+
 
 	attacks: [{
 		cost: ["Fighting", "Fighting"],

--- a/data/Pokémon TCG Pocket/Genetic Apex/144.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/144.ts
@@ -13,6 +13,10 @@ const card: Card = {
 	hp: 100,
 	types: ["Fighting"],
 	stage: "Stage1",
+	evolveFrom: {
+		en: "Machop"
+	},
+
 
 	attacks: [{
 		cost: ["Fighting", "Fighting"],

--- a/data/Pokémon TCG Pocket/Genetic Apex/145.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/145.ts
@@ -13,6 +13,10 @@ const card: Card = {
 	hp: 150,
 	types: ["Fighting"],
 	stage: "Stage2",
+	evolveFrom: {
+		en: "Machoke"
+	},
+
 
 	attacks: [{
 		cost: ["Fighting", "Fighting", "Fighting"],

--- a/data/Pokémon TCG Pocket/Genetic Apex/146.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/146.ts
@@ -13,6 +13,10 @@ const card: Card = {
 	hp: 180,
 	types: ["Fighting"],
 	stage: "Stage2",
+	evolveFrom: {
+		en: "Machoke"
+	},
+
 	suffix: "EX",
 
 	attacks: [{

--- a/data/Pokémon TCG Pocket/Genetic Apex/148.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/148.ts
@@ -13,6 +13,10 @@ const card: Card = {
 	hp: 100,
 	types: ["Fighting"],
 	stage: "Stage1",
+	evolveFrom: {
+		en: "Geodude"
+	},
+
 
 	attacks: [{
 		cost: ["Fighting", "Colorless", "Colorless"],

--- a/data/Pokémon TCG Pocket/Genetic Apex/149.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/149.ts
@@ -13,6 +13,10 @@ const card: Card = {
 	hp: 160,
 	types: ["Fighting"],
 	stage: "Stage2",
+	evolveFrom: {
+		en: "Graveler"
+	},
+
 
 	attacks: [{
 		cost: ["Fighting", "Colorless", "Colorless", "Colorless"],

--- a/data/Pokémon TCG Pocket/Genetic Apex/152.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/152.ts
@@ -13,6 +13,10 @@ const card: Card = {
 	hp: 140,
 	types: ["Fighting"],
 	stage: "Stage1",
+	evolveFrom: {
+		en: "Cubone"
+	},
+
 
 	attacks: [{
 		cost: ["Fighting"],

--- a/data/Pokémon TCG Pocket/Genetic Apex/153.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/153.ts
@@ -13,6 +13,10 @@ const card: Card = {
 	hp: 140,
 	types: ["Fighting"],
 	stage: "Stage1",
+	evolveFrom: {
+		en: "Cubone"
+	},
+
 	suffix: "EX",
 
 	attacks: [{

--- a/data/Pokémon TCG Pocket/Genetic Apex/157.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/157.ts
@@ -13,6 +13,10 @@ const card: Card = {
 	hp: 120,
 	types: ["Fighting"],
 	stage: "Stage1",
+	evolveFrom: {
+		en: "Rhyhorn"
+	},
+
 
 	attacks: [{
 		cost: ["Fighting", "Fighting", "Fighting", "Colorless"],

--- a/data/Pokémon TCG Pocket/Genetic Apex/158.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/158.ts
@@ -13,6 +13,10 @@ const card: Card = {
 	hp: 90,
 	types: ["Fighting"],
 	stage: "Stage1",
+	evolveFrom: {
+		en: "Dome Fossil"
+	},
+
 
 	attacks: [{
 		cost: ["Fighting"],

--- a/data/Pokémon TCG Pocket/Genetic Apex/159.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/159.ts
@@ -13,6 +13,10 @@ const card: Card = {
 	hp: 140,
 	types: ["Fighting"],
 	stage: "Stage2",
+	evolveFrom: {
+		en: "Kabuto"
+	},
+
 
 	attacks: [{
 		cost: ["Fighting"],

--- a/data/Pokémon TCG Pocket/Genetic Apex/161.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/161.ts
@@ -13,6 +13,10 @@ const card: Card = {
 	hp: 80,
 	types: ["Fighting"],
 	stage: "Stage1",
+	evolveFrom: {
+		en: "Mienfoo"
+	},
+
 
 	attacks: [{
 		cost: ["Colorless"],

--- a/data/Pokémon TCG Pocket/Genetic Apex/163.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/163.ts
@@ -13,6 +13,10 @@ const card: Card = {
 	hp: 130,
 	types: ["Fighting"],
 	stage: "Stage1",
+	evolveFrom: {
+		en: "Clobbopus"
+	},
+
 
 	attacks: [{
 		cost: ["Fighting", "Fighting", "Colorless"],

--- a/data/Pokémon TCG Pocket/Genetic Apex/165.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/165.ts
@@ -13,6 +13,10 @@ const card: Card = {
 	hp: 100,
 	types: ["Darkness"],
 	stage: "Stage1",
+	evolveFrom: {
+		en: "Ekans"
+	},
+
 
 	attacks: [{
 		cost: ["Darkness", "Colorless"],

--- a/data/Pokémon TCG Pocket/Genetic Apex/167.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/167.ts
@@ -13,6 +13,10 @@ const card: Card = {
 	hp: 80,
 	types: ["Darkness"],
 	stage: "Stage1",
+	evolveFrom: {
+		en: "Nidoran♀"
+	},
+
 
 	attacks: [{
 		cost: ["Darkness"],

--- a/data/Pokémon TCG Pocket/Genetic Apex/168.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/168.ts
@@ -13,6 +13,9 @@ const card: Card = {
 	hp: 140,
 	types: ["Darkness"],
 	stage: "Stage2",
+	evolveFrom: {
+		en: "Nidorina"
+	},
 
 	attacks: [{
 		cost: ["Darkness", "Darkness", "Colorless"],

--- a/data/Pokémon TCG Pocket/Genetic Apex/170.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/170.ts
@@ -13,6 +13,9 @@ const card: Card = {
 	hp: 90,
 	types: ["Darkness"],
 	stage: "Stage1",
+	evolveFrom: {
+		en: "Nidoran♂"
+	},
 
 	attacks: [{
 		cost: ["Darkness", "Colorless"],

--- a/data/Pokémon TCG Pocket/Genetic Apex/171.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/171.ts
@@ -13,6 +13,9 @@ const card: Card = {
 	hp: 150,
 	types: ["Darkness"],
 	stage: "Stage2",
+	evolveFrom: {
+		en: "Nidorino"
+	},
 
 	attacks: [{
 		cost: ["Darkness", "Darkness", "Colorless"],

--- a/data/Pokémon TCG Pocket/Genetic Apex/173.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/173.ts
@@ -13,6 +13,9 @@ const card: Card = {
 	hp: 70,
 	types: ["Darkness"],
 	stage: "Stage1",
+	evolveFrom: {
+		en: "Zubat"
+	},
 
 	attacks: [{
 		cost: ["Colorless"],

--- a/data/Pokémon TCG Pocket/Genetic Apex/175.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/175.ts
@@ -13,6 +13,9 @@ const card: Card = {
 	hp: 130,
 	types: ["Darkness"],
 	stage: "Stage1",
+	evolveFrom: {
+		en: "Grimer"
+	},
 
 	attacks: [{
 		cost: ["Darkness", "Darkness", "Colorless"],

--- a/data/Pokémon TCG Pocket/Genetic Apex/177.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/177.ts
@@ -13,6 +13,9 @@ const card: Card = {
 	hp: 110,
 	types: ["Darkness"],
 	stage: "Stage1",
+	evolveFrom: {
+		en: "Koffing"
+	},
 
 	abilities: [{
 		type: "Ability",

--- a/data/Pokémon TCG Pocket/Genetic Apex/180.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/180.ts
@@ -13,6 +13,9 @@ const card: Card = {
 	hp: 90,
 	types: ["Metal"],
 	stage: "Stage1",
+	evolveFrom: {
+		en: "Pawniard"
+	},
 
 	attacks: [{
 		cost: ["Metal", "Metal"],

--- a/data/Pokémon TCG Pocket/Genetic Apex/182.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/182.ts
@@ -13,6 +13,9 @@ const card: Card = {
 	hp: 130,
 	types: ["Metal"],
 	stage: "Stage1",
+	evolveFrom: {
+		en: "Meltan"
+	},
 
 	abilities: [{
 		type: "Ability",

--- a/data/Pokémon TCG Pocket/Genetic Apex/184.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/184.ts
@@ -13,6 +13,9 @@ const card: Card = {
 	hp: 100,
 	types: ["Dragon"],
 	stage: "Stage1",
+	evolveFrom: {
+		en: "Dratini"
+	},
 
 	attacks: [{
 		cost: ["Water", "Lightning", "Colorless"],

--- a/data/Pokémon TCG Pocket/Genetic Apex/185.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/185.ts
@@ -13,6 +13,9 @@ const card: Card = {
 	hp: 160,
 	types: ["Dragon"],
 	stage: "Stage2",
+	evolveFrom: {
+		en: "Dragonair"
+	},
 
 	attacks: [{
 		cost: ["Water", "Lightning", "Colorless", "Colorless"],

--- a/data/Pokémon TCG Pocket/Genetic Apex/187.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/187.ts
@@ -13,6 +13,9 @@ const card: Card = {
 	hp: 80,
 	types: ["Colorless"],
 	stage: "Stage1",
+	evolveFrom: {
+		en: "Pidgey"
+	},
 
 	attacks: [{
 		cost: ["Colorless"],

--- a/data/Pokémon TCG Pocket/Genetic Apex/188.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/188.ts
@@ -13,6 +13,9 @@ const card: Card = {
 	hp: 130,
 	types: ["Colorless"],
 	stage: "Stage2",
+	evolveFrom: {
+		en: "Pidgeotto"
+	},
 
 	abilities: [{
 		type: "Ability",

--- a/data/Pokémon TCG Pocket/Genetic Apex/190.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/190.ts
@@ -13,6 +13,9 @@ const card: Card = {
 	hp: 80,
 	types: ["Colorless"],
 	stage: "Stage1",
+	evolveFrom: {
+		en: "Rattata"
+	},
 
 	attacks: [{
 		cost: ["Colorless"],

--- a/data/Pokémon TCG Pocket/Genetic Apex/192.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/192.ts
@@ -13,6 +13,9 @@ const card: Card = {
 	hp: 100,
 	types: ["Colorless"],
 	stage: "Stage1",
+	evolveFrom: {
+		en: "Spearow"
+	},
 
 	attacks: [{
 		cost: ["Colorless", "Colorless"],

--- a/data/Pokémon TCG Pocket/Genetic Apex/194.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/194.ts
@@ -13,6 +13,9 @@ const card: Card = {
 	hp: 100,
 	types: ["Colorless"],
 	stage: "Stage1",
+	evolveFrom: {
+		en: "Jigglypuff"
+	},
 
 	attacks: [{
 		cost: ["Colorless", "Colorless"],

--- a/data/Pokémon TCG Pocket/Genetic Apex/195.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/195.ts
@@ -13,6 +13,9 @@ const card: Card = {
 	hp: 140,
 	types: ["Colorless"],
 	stage: "Stage1",
+	evolveFrom: {
+		en: "Jigglypuff"
+	},
 	suffix: "EX",
 
 	attacks: [{

--- a/data/Pokémon TCG Pocket/Genetic Apex/197.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/197.ts
@@ -13,6 +13,9 @@ const card: Card = {
 	hp: 90,
 	types: ["Colorless"],
 	stage: "Stage1",
+	evolveFrom: {
+		en: "Meowth"
+	},
 
 	attacks: [{
 		cost: ["Colorless", "Colorless"],

--- a/data/Pokémon TCG Pocket/Genetic Apex/200.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/200.ts
@@ -13,6 +13,9 @@ const card: Card = {
 	hp: 80,
 	types: ["Colorless"],
 	stage: "Stage1",
+	evolveFrom: {
+		en: "Doduo"
+	},
 
 	attacks: [{
 		cost: ["Colorless"],

--- a/data/Pokémon TCG Pocket/Genetic Apex/210.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/210.ts
@@ -13,6 +13,9 @@ const card: Card = {
 	hp: 100,
 	types: ["Colorless"],
 	stage: "Stage1",
+	evolveFrom: {
+		en: "Old Amber"
+	},
 
 	attacks: [{
 		cost: ["Colorless", "Colorless"],

--- a/data/Pokémon TCG Pocket/Genetic Apex/213.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/213.ts
@@ -13,6 +13,9 @@ const card: Card = {
 	hp: 90,
 	types: ["Colorless"],
 	stage: "Stage1",
+	evolveFrom: {
+		en: "Minccino"
+	},
 
 	attacks: [{
 		cost: ["Colorless", "Colorless", "Colorless"],

--- a/data/Pokémon TCG Pocket/Genetic Apex/215.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/215.ts
@@ -13,6 +13,9 @@ const card: Card = {
 	hp: 120,
 	types: ["Colorless"],
 	stage: "Stage1",
+	evolveFrom: {
+		en: "Wooloo"
+	},
 
 	attacks: [{
 		cost: ["Colorless", "Colorless", "Colorless"],

--- a/data/Pokémon TCG Pocket/Genetic Apex/228.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/228.ts
@@ -13,6 +13,9 @@ const card: Card = {
 	hp: 80,
 	types: ["Grass"],
 	stage: "Stage1",
+	evolveFrom: {
+		en: "Oddish"
+	},
 
 	attacks: [{
 		cost: ["Grass", "Colorless"],

--- a/data/Pokémon TCG Pocket/Genetic Apex/231.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/231.ts
@@ -13,6 +13,9 @@ const card: Card = {
 	hp: 100,
 	types: ["Fire"],
 	stage: "Stage1",
+	evolveFrom: {
+		en: "Ponyta"
+	},
 
 	attacks: [{
 		cost: ["Fire"],

--- a/data/Pokémon TCG Pocket/Genetic Apex/233.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/233.ts
@@ -13,6 +13,9 @@ const card: Card = {
 	hp: 150,
 	types: ["Water"],
 	stage: "Stage1",
+	evolveFrom: {
+		en: "Magikarp"
+	},
 
 	attacks: [{
 		cost: ["Water", "Water", "Water", "Water"],

--- a/data/Pokémon TCG Pocket/Genetic Apex/235.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/235.ts
@@ -13,6 +13,9 @@ const card: Card = {
 	hp: 80,
 	types: ["Lightning"],
 	stage: "Stage1",
+	evolveFrom: {
+		en: "Voltorb"
+	},
 
 	attacks: [{
 		cost: ["Lightning", "Lightning"],

--- a/data/Pokémon TCG Pocket/Genetic Apex/236.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/236.ts
@@ -13,6 +13,9 @@ const card: Card = {
 	hp: 130,
 	types: ["Psychic"],
 	stage: "Stage2",
+	evolveFrom: {
+		en: "Kadabra"
+	},
 
 	attacks: [{
 		cost: ["Psychic", "Colorless", "Colorless"],

--- a/data/Pokémon TCG Pocket/Genetic Apex/240.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/240.ts
@@ -13,6 +13,9 @@ const card: Card = {
 	hp: 140,
 	types: ["Darkness"],
 	stage: "Stage2",
+	evolveFrom: {
+		en: "Nidorina"
+	},
 
 	attacks: [{
 		cost: ["Darkness", "Darkness", "Colorless"],

--- a/data/Pokémon TCG Pocket/Genetic Apex/241.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/241.ts
@@ -13,6 +13,9 @@ const card: Card = {
 	hp: 150,
 	types: ["Darkness"],
 	stage: "Stage2",
+	evolveFrom: {
+		en: "Nidorino"
+	},
 
 	attacks: [{
 		cost: ["Darkness", "Darkness", "Colorless"],

--- a/data/Pokémon TCG Pocket/Genetic Apex/242.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/242.ts
@@ -13,6 +13,9 @@ const card: Card = {
 	hp: 70,
 	types: ["Darkness"],
 	stage: "Stage1",
+	evolveFrom: {
+		en: "Zubat"
+	},
 
 	attacks: [{
 		cost: ["Colorless"],

--- a/data/Pokémon TCG Pocket/Genetic Apex/243.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/243.ts
@@ -13,6 +13,9 @@ const card: Card = {
 	hp: 110,
 	types: ["Darkness"],
 	stage: "Stage1",
+	evolveFrom: {
+		en: "Koffing"
+	},
 
 	abilities: [{
 		type: "Ability",

--- a/data/Pokémon TCG Pocket/Genetic Apex/244.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/244.ts
@@ -13,6 +13,9 @@ const card: Card = {
 	hp: 160,
 	types: ["Dragon"],
 	stage: "Stage2",
+	evolveFrom: {
+		en: "Dragonair"
+	},
 
 	attacks: [{
 		cost: ["Water", "Lightning", "Colorless", "Colorless"],

--- a/data/Pokémon TCG Pocket/Genetic Apex/245.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/245.ts
@@ -13,6 +13,9 @@ const card: Card = {
 	hp: 130,
 	types: ["Colorless"],
 	stage: "Stage2",
+	evolveFrom: {
+		en: "Pidgeotto"
+	},
 
 	abilities: [{
 		type: "Ability",

--- a/data/Pokémon TCG Pocket/Genetic Apex/251.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/251.ts
@@ -13,6 +13,9 @@ const card: Card = {
 	hp: 190,
 	types: ["Grass"],
 	stage: "Stage2",
+	evolveFrom: {
+		en: "Ivysaur"
+	},
 	suffix: "EX",
 
 	attacks: [{

--- a/data/Pokémon TCG Pocket/Genetic Apex/252.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/252.ts
@@ -13,6 +13,9 @@ const card: Card = {
 	hp: 160,
 	types: ["Grass"],
 	stage: "Stage1",
+	evolveFrom: {
+		en: "Exeggcute"
+	},
 	suffix: "EX",
 	attacks: [{
 		cost: ["Grass"],

--- a/data/Pokémon TCG Pocket/Genetic Apex/253.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/253.ts
@@ -13,6 +13,9 @@ const card: Card = {
 	hp: 180,
 	types: ["Fire"],
 	stage: "Stage2",
+	evolveFrom: {
+		en: "Charmeleon"
+	},
 	suffix: "EX",
 
 	attacks: [{

--- a/data/Pokémon TCG Pocket/Genetic Apex/254.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/254.ts
@@ -13,6 +13,9 @@ const card: Card = {
 	hp: 150,
 	types: ["Fire"],
 	stage: "Stage1",
+	evolveFrom: {
+		en: "Growlithe"
+	},
 	suffix: "EX",
 
 	attacks: [{

--- a/data/Pokémon TCG Pocket/Genetic Apex/256.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/256.ts
@@ -13,6 +13,9 @@ const card: Card = {
 	hp: 180,
 	types: ["Water"],
 	stage: "Stage2",
+	evolveFrom: {
+		en: "Wartortle"
+	},
 	suffix: "EX",
 
 	attacks: [{

--- a/data/Pokémon TCG Pocket/Genetic Apex/257.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/257.ts
@@ -13,6 +13,9 @@ const card: Card = {
 	hp: 130,
 	types: ["Water"],
 	stage: "Stage1",
+	evolveFrom: {
+		en: "Staryu"
+	},
 	suffix: "EX",
 
 	attacks: [{

--- a/data/Pokémon TCG Pocket/Genetic Apex/261.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/261.ts
@@ -13,6 +13,9 @@ const card: Card = {
 	hp: 170,
 	types: ["Psychic"],
 	stage: "Stage2",
+	evolveFrom: {
+		en: "Haunter"
+	},
 	suffix: "EX",
 
 	abilities: [{

--- a/data/Pokémon TCG Pocket/Genetic Apex/263.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/263.ts
@@ -13,6 +13,9 @@ const card: Card = {
 	hp: 180,
 	types: ["Fighting"],
 	stage: "Stage2",
+	evolveFrom: {
+		en: "Machoke"
+	},
 	suffix: "EX",
 
 	attacks: [{

--- a/data/Pokémon TCG Pocket/Genetic Apex/264.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/264.ts
@@ -13,6 +13,9 @@ const card: Card = {
 	hp: 140,
 	types: ["Fighting"],
 	stage: "Stage1",
+	evolveFrom: {
+		en: "Cubone"
+	},
 	suffix: "EX",
 
 	attacks: [{

--- a/data/Pokémon TCG Pocket/Genetic Apex/265.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/265.ts
@@ -13,6 +13,9 @@ const card: Card = {
 	hp: 140,
 	types: ["Colorless"],
 	stage: "Stage1",
+	evolveFrom: {
+		en: "Jigglypuff"
+	},
 	suffix: "EX",
 	attacks: [{
 		cost: ["Colorless", "Colorless", "Colorless"],

--- a/data/Pokémon TCG Pocket/Genetic Apex/277.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/277.ts
@@ -13,6 +13,9 @@ const card: Card = {
 	hp: 170,
 	types: ["Psychic"],
 	stage: "Stage2",
+	evolveFrom: {
+		en: "Haunter"
+	},
 	suffix: "EX",
 
 	abilities: [{

--- a/data/Pokémon TCG Pocket/Genetic Apex/278.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/278.ts
@@ -13,6 +13,9 @@ const card: Card = {
 	hp: 180,
 	types: ["Fighting"],
 	stage: "Stage2",
+	evolveFrom: {
+		en: "Machoke"
+	},
 	suffix: "EX",
 
 	attacks: [{

--- a/data/Pokémon TCG Pocket/Genetic Apex/279.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/279.ts
@@ -13,6 +13,9 @@ const card: Card = {
 	hp: 140,
 	types: ["Colorless"],
 	stage: "Stage1",
+	evolveFrom: {
+		en: "Jigglypuff"
+	},
 	suffix: "EX",
 	attacks: [{
 		cost: ["Colorless", "Colorless", "Colorless"],

--- a/data/Pokémon TCG Pocket/Genetic Apex/280.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/280.ts
@@ -13,6 +13,9 @@ const card: Card = {
 	hp: 180,
 	types: ["Fire"],
 	stage: "Stage2",
+	evolveFrom: {
+		en: "Charmeleon"
+	},
 	suffix: "EX",
 
 	attacks: [{

--- a/data/Pokémon TCG Pocket/Genetic Apex/284.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/284.ts
@@ -13,6 +13,9 @@ const card: Card = {
 	hp: 180,
 	types: ["Fire"],
 	stage: "Stage2",
+	evolveFrom: {
+		en: "Charmeleon"
+	},
 	suffix: "EX",
 
 	attacks: [{


### PR DESCRIPTION
Used existing data type to add on all Stage 1 and 2 Pokemon with the correct "evolves from" basic card using syntax; 

evolveFrom: {
		en: "[Basic_Name]"
	},

<!--
Thanks for your Pull Request, Please provide the related Issue using "Fix #0" or describe the change(s) you made.
The issue title must follow Conventional Commit conventionalcommits.org.
More informations at https://github.com/tcgdex/cards-database/blob/master/CONTRIBUTING.md
-->
