### PR TITLE
fix: update graphql AttacksListItem definition

### DIFF
--- a/meta/definitions/graphql.gql
+++ b/meta/definitions/graphql.gql
@@ -254,7 +254,7 @@ type AttacksListItem {
 	effect: String
 
 	"""The attack name"""
-	name: String!
+	name: String
 }
 
 """


### PR DESCRIPTION
### Changed
- Updated `AttacksListItem` with nullable `name`.

### Context
- Fixes #645.
