### PR TITLE
fix: Add normal variant for swsh9-008

### DIFF
--- a/data/Sword & Shield/Brilliant Stars/008.ts
+++ b/data/Sword & Shield/Brilliant Stars/008.ts
@@ -70,7 +70,7 @@ const card: Card = {
 	retreat: 4,
 	regulationMark: "F",
 	variants: {
-		normal: false,
+		normal: true,
 		reverse: true,
 		holo: true,
 		firstEdition: false


### PR DESCRIPTION
Changed the `normal` variant for card `008` in the `swsh9` set (Brilliant Stars) to `true` as this card also has a normal variant which can be obtained from the Build & Battle boxes.

PR made after a small discussion and confirming message on Discord: https://discord.com/channels/857231041261076491/857231041956413451/1337221782389657663

Hoping this will be a useful first contribution 🌟 