### PR TITLE
fix: Add holo variants for sv03-148 and sv03-149

### DIFF
--- a/data/Scarlet & Violet/Obsidian Flames/148.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/148.ts
@@ -48,7 +48,9 @@ const card: Card = {
 	regulationMark: "G",
 
 	variants: {
-		holo: false
+		normal: true,
+		reverse: true,
+		holo: true,
 	}
 }
 

--- a/data/Scarlet & Violet/Obsidian Flames/149.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/149.ts
@@ -61,7 +61,9 @@ const card: Card = {
 	regulationMark: "G",
 
 	variants: {
-		holo: false
+		normal: true,
+		reverse: true,
+		holo: true,
 	}
 }
 


### PR DESCRIPTION
Added a `holo` variant for cards 148 and 149 in the sv03 (Obsidian Flames) set.

The holo variants are obtained from the Kingambit Illustration Collection from Shrouded Fable. 

Decided to also add the `normal` and `reverse` variants explicitly so card data doesn't break if the defaults ever change. Saw there are other cards that also redefine the defaults.



