### PR TITLE
fix: Remove incorrect weaknesses from Pocket A1a and A2 dragons

### DIFF
--- a/data/Pokémon TCG Pocket/Mythical Island/056.ts
+++ b/data/Pokémon TCG Pocket/Mythical Island/056.ts
@@ -40,11 +40,6 @@ const card: Card = {
 		cost: ["Fire", "Water", "Colorless"]
 	}],
 
-	weaknesses: [{
-		type: "Colorless",
-		value: "+20"
-	}],
-
 	retreat: 2,
 	rarity: "Two Diamond"
 }

--- a/data/Pokémon TCG Pocket/Space-Time Smackdown/121.ts
+++ b/data/Pokémon TCG Pocket/Space-Time Smackdown/121.ts
@@ -29,11 +29,6 @@ const card: Card = {
 		cost: ["Colorless"]
 	}],
 
-	weaknesses: [{
-		type: "Colorless",
-		value: "+20"
-	}],
-
 	retreat: 1
 }
 

--- a/data/Pokémon TCG Pocket/Space-Time Smackdown/122.ts
+++ b/data/Pokémon TCG Pocket/Space-Time Smackdown/122.ts
@@ -33,11 +33,6 @@ const card: Card = {
 		cost: ["Water", "Fighting"]
 	}],
 
-	weaknesses: [{
-		type: "Colorless",
-		value: "+20"
-	}],
-
 	retreat: 1
 }
 

--- a/data/Pokémon TCG Pocket/Space-Time Smackdown/123.ts
+++ b/data/Pokémon TCG Pocket/Space-Time Smackdown/123.ts
@@ -45,11 +45,6 @@ const card: Card = {
 		cost: ["Water", "Fighting"]
 	}],
 
-	weaknesses: [{
-		type: "Colorless",
-		value: "+20"
-	}],
-
 	retreat: 1
 }
 

--- a/data/Pokémon TCG Pocket/Space-Time Smackdown/175.ts
+++ b/data/Pokémon TCG Pocket/Space-Time Smackdown/175.ts
@@ -45,11 +45,6 @@ const card: Card = {
 		cost: ["Water", "Fighting"]
 	}],
 
-	weaknesses: [{
-		type: "Colorless",
-		value: "+20"
-	}],
-
 	retreat: 1
 }
 


### PR DESCRIPTION
Remove weaknesses from Dragon cards in Pocket Mythical Island and Space-Time Smackdown sets, as they were incorrectly reporting a Colorless weakness.

- [x] A1a 056
- [x] A2 121
- [x] A2 122
- [x] A2 123
- [x] A2 175
