### PR TITLE
fix: Add holo variants for sv03-023 and sv03-027

### DIFF
--- a/data/Scarlet & Violet/Obsidian Flames/026.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/026.ts
@@ -48,7 +48,9 @@ const card: Card = {
 	regulationMark: "G",
 
 	variants: {
-		holo: false
+		normal: true,
+		reverse: true,
+		holo: true,
 	}
 }
 

--- a/data/Scarlet & Violet/Obsidian Flames/027.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/027.ts
@@ -48,7 +48,9 @@ const card: Card = {
 	regulationMark: "G",
 
 	variants: {
-		holo: false
+		normal: true,
+		reverse: true,
+		holo: true,
 	}
 }
 


### PR DESCRIPTION
Added a holo variant for cards 026 and 027 in the sv03 (Obsidian Flames) set.

The holo variants are obtained from the Charizard EX Premium Collection 

Decided to also add the normal and reverse variants explicitly so card data doesn't break if the defaults ever change. Saw there are other cards that also redefine the defaults.