### PR TITLE
fix: Add reverse holo variant for sv01-134

### DIFF
--- a/data/Scarlet & Violet/Scarlet & Violet/134.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/134.ts
@@ -66,7 +66,6 @@ const card: Card = {
 	illustrator: "Anesaki Dynamic",
 
 	variants: {
-		reverse: false,
 		normal: false
 	}
 }


### PR DESCRIPTION
Added a reverse holo variant for card 134 (Kingambit) in the sv01 (Scarlet & Violet base) set.

Reverse holo variant can be obtained through checklane bundle.