### PR TITLE
fix: Add normal variant for sv03-062

### DIFF
--- a/data/Scarlet & Violet/Obsidian Flames/062.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/062.ts
@@ -69,7 +69,9 @@ const card: Card = {
 	regulationMark: "G",
 
 	variants: {
-		normal: false
+		normal: true,
+		holo: true,
+		reverse: true,
 	}
 }
 


### PR DESCRIPTION
Added normal variant for card 062 (Palafin) in the sv03 (Obsidian Flame) set.

Normal variant can be obtained through Obsidian Flame Build & Battle box.

Added known variants in a verbose matter to prevent issues when default change