### PR TITLE
fix: Add normal variant for sv01-190

### DIFF
--- a/data/Scarlet & Violet/Scarlet & Violet/190.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/190.ts
@@ -30,7 +30,6 @@ const card: Card = {
 
 	variants: {
 		reverse: false,
-		normal: false
 	}
 }
 


### PR DESCRIPTION
Added normal variant for card 190 (Professor's Research) in the sv01 (Scarlet & Violet base) set.

Normal variant can be obtained through Obsidian Flame Build & Battle box.