### PR TITLE
fix: Add holo variants for sv03-013 and sv03-014

### DIFF
--- a/data/Scarlet & Violet/Obsidian Flames/013.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/013.ts
@@ -39,7 +39,6 @@ const card: Card = {
 	regulationMark: "G",
 
 	variants: {
-		holo: false
 	}
 }
 

--- a/data/Scarlet & Violet/Obsidian Flames/014.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/014.ts
@@ -48,7 +48,6 @@ const card: Card = {
 	regulationMark: "G",
 
 	variants: {
-		holo: false
 	}
 }
 


### PR DESCRIPTION
Added holo variant for card 013 (Rowlet) and 014 (Dartrix) in the sv03 (Obsidian Flame) set.

Normal variant can be obtained through Decidueye EX box