### PR TITLE
feat: add genetic apex cards (french)

### DIFF
--- a/data/Pokémon TCG Pocket/Genetic Apex/001.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/001.ts
@@ -5,7 +5,8 @@ const card: Card = {
 	set: Set,
 
 	name: {
-		en: "Bulbasaur"
+		en: "Bulbasaur",
+		fr: "Bulbizarre"
 	},
 
 	illustrator: "Narumi Sato",
@@ -18,7 +19,8 @@ const card: Card = {
 		cost: ["Grass", "Colorless"],
 
 		name: {
-			en: "Vine Whip"
+			en: "Vine Whip",
+			fr: "Fouet Lianes"
 		},
 
 		damage: "40"
@@ -34,6 +36,7 @@ const card: Card = {
 
 	description: {
 		en: "There is a plant seed on its back right from the day this Pokémon is born. The seed slowly grows larger.",
+		fr: "Il a une graine sur son dos depuis sa naissance. Elle grossit un peu chaque jour."
 	}
 }
 

--- a/data/Pokémon TCG Pocket/Genetic Apex/002.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/002.ts
@@ -5,7 +5,8 @@ const card: Card = {
 	set: Set,
 
 	name: {
-		en: "Ivysaur"
+		en: "Ivysaur",
+		fr: "Herbizarre"
 	},
 
 	illustrator: "Kurata So",
@@ -14,14 +15,16 @@ const card: Card = {
 	types: ["Grass"],
 	stage: "Stage1",
 	evolveFrom: {
-		en: "Bulbasaur"
-	}, 
+		en: "Bulbasaur",
+		fr: "Bulbizarre"
+	},
 
 	attacks: [{
 		cost: ["Grass", "Colorless", "Colorless"],
 
 		name: {
-			en: "Razor Leaf"
+			en: "Razor Leaf",
+			fr: "Tranch'Herbe"
 		},
 
 		damage: "60"
@@ -37,6 +40,7 @@ const card: Card = {
 
 	description: {
 		en: "When the bulb on its back grows large, it appears to lose the ability to stand on its hind legs.",
+		fr: "Son bulbe dorsal est devenu si gros qu'il ne peut plus se tenir sur ses pattes postérieures."
 	}
 }
 

--- a/data/Pokémon TCG Pocket/Genetic Apex/003.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/003.ts
@@ -5,7 +5,8 @@ const card: Card = {
 	set: Set,
 
 	name: {
-		en: "Venusaur"
+		en: "Venusaur",
+		fr: "Florizarre"
 	},
 
 	illustrator: "Ryota Murayama",
@@ -14,18 +15,21 @@ const card: Card = {
 	types: ["Grass"],
 	stage: "Stage2",
 	evolveFrom: {
-		en: "Ivysaur"
+		en: "Ivysaur",
+		fr: "Herbizarre"
 	},
 
 	attacks: [{
 		cost: ["Grass", "Grass", "Colorless", "Colorless"],
 
 		name: {
-			en: "Mega Drain"
+			en: "Mega Drain",
+			fr: "Méga-Sangsue"
 		},
 
 		effect: {
-			en: "Heal 30 damage from this Pokémon."
+			en: "Heal 30 damage from this Pokémon.",
+			fr: "Soignez 30 dégâts de ce Pokémon."
 		},
 
 		damage: "80"
@@ -41,6 +45,7 @@ const card: Card = {
 
 	description: {
 		en: "Its plant blooms when it is absorbing solar energy. It stays on the move to seek sunlight.",
+		fr: "Sa plante donne une grosse fleur quand elle absorbe les rayons du soleil. Il est toujours à la recherche des endroits les plus ensoleillés."
 	}
 }
 

--- a/data/Pokémon TCG Pocket/Genetic Apex/004.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/004.ts
@@ -5,7 +5,8 @@ const card: Card = {
 	set: Set,
 
 	name: {
-		en: "Venusaur ex"
+		en: "Venusaur ex",
+		fr: "Florizarre ex"
 	},
 
 	illustrator: "PLANETA CG Works",
@@ -14,7 +15,8 @@ const card: Card = {
 	types: ["Grass"],
 	stage: "Stage2",
 	evolveFrom: {
-		en: "Ivysaur"
+		en: "Ivysaur",
+		fr: "Herbizarre"
 	},
 	suffix: "EX",
 
@@ -22,7 +24,8 @@ const card: Card = {
 		cost: ["Grass", "Colorless", "Colorless"],
 
 		name: {
-			en: "Razor Leaf"
+			en: "Razor Leaf",
+			fr: "Tranch'Herbe"
 		},
 
 		damage: "60"
@@ -30,11 +33,13 @@ const card: Card = {
 		cost: ["Grass", "Grass", "Colorless", "Colorless"],
 
 		name: {
-			en: "Giant Bloom"
+			en: "Giant Bloom",
+			fr: "Pousse Géante"
 		},
 
 		effect: {
-			en: "Heal 30 damage from this Pokémon."
+			en: "Heal 30 damage from this Pokémon.",
+			fr: "Soignez 30 dégâts de ce Pokémon."
 		},
 
 		damage: "100"

--- a/data/Pokémon TCG Pocket/Genetic Apex/005.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/005.ts
@@ -5,7 +5,8 @@ const card: Card = {
 	set: Set,
 
 	name: {
-		en: "Caterpie"
+		en: "Caterpie",
+		fr: "Chenipan"
 	},
 
 	illustrator: "Miki Tanaka",
@@ -18,11 +19,13 @@ const card: Card = {
 		cost: ["Colorless"],
 
 		name: {
-			en: "Find a Friend"
+			en: "Find a Friend",
+			fr: "Trouver un Ami"
 		},
 
 		effect: {
-			en: "Put 1 random G Pokémon from your deck into your hand."
+			en: "Put 1 random G Pokémon from your deck into your hand.",
+			fr: "Ajoutez au hasard un Pokémon G de votre deck à votre main."
 		}
 	}],
 
@@ -36,6 +39,7 @@ const card: Card = {
 
 	description: {
 		en: "For protection, it releases a horrible stench from the antenna on its head to drive away enemies.",
+		fr: "Pour se protéger, il émet par ses antennes une odeur nauséabonde qui fait fuir ses ennemis."
 	}
 }
 

--- a/data/Pokémon TCG Pocket/Genetic Apex/006.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/006.ts
@@ -5,7 +5,8 @@ const card: Card = {
 	set: Set,
 
 	name: {
-		en: "Metapod"
+		en: "Metapod",
+		fr: "Chrysacier"
 	},
 
 	illustrator: "Yuka Morii",
@@ -14,14 +15,16 @@ const card: Card = {
 	types: ["Grass"],
 	stage: "Stage1",
 	evolveFrom: {
-		en: "Caterpie"
+		en: "Caterpie",
+		fr: "Chenipan"
 	},
 
 	attacks: [{
 		cost: ["Colorless", "Colorless"],
 
 		name: {
-			en: "Bug Bite"
+			en: "Bug Bite",
+			fr: "Piqûre"
 		},
 
 		damage: "30"
@@ -37,6 +40,7 @@ const card: Card = {
 
 	description: {
 		en: "It is waiting for the moment to evolve. At this stage, it can only harden, so it remains motionless to avoid attack.",
+		fr: "En attendant sa prochaine évolution, il ne peut que durcir sa carapace et rester immobile pour éviter de se faire attaquer."
 	}
 }
 

--- a/data/Pokémon TCG Pocket/Genetic Apex/007.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/007.ts
@@ -5,7 +5,8 @@ const card: Card = {
 	set: Set,
 
 	name: {
-		en: "Butterfree"
+		en: "Butterfree",
+		fr: "Papilusion"
 	},
 
 	illustrator: "Shin Nagasawa",
@@ -14,18 +15,21 @@ const card: Card = {
 	types: ["Grass"],
 	stage: "Stage2",
 	evolveFrom: {
-		en: "Metapod"
+		en: "Metapod",
+		fr: "Chrysacier"
 	},
 
 	abilities: [{
 		type: "Ability",
 
 		name: {
-			en: "Powder Heal"
+			en: "Powder Heal",
+			fr: "Soin Poudre"
 		},
 
 		effect: {
-			en: "Once during your turn, you may heal 20 damage from each of your Pokémon."
+			en: "Once during your turn, you may heal 20 damage from each of your Pokémon.",
+			fr: "Une fois pendant votre tour, vous pouvez soigner 20 dégâts de chacun de vos Pokémon."
 		}
 	}],
 
@@ -49,6 +53,7 @@ const card: Card = {
 
 	description: {
 		en: "In battle, it flaps its wings at great speed to release highly toxic dust into the air.",
+		fr: "En combat, il bat des ailes très rapidement pour projeter de la poudre toxique sur ses ennemis."
 	}
 }
 

--- a/data/Pokémon TCG Pocket/Genetic Apex/008.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/008.ts
@@ -5,7 +5,8 @@ const card: Card = {
 	set: Set,
 
 	name: {
-		en: "Weedle"
+		en: "Weedle",
+		fr: "Aspicot"
 	},
 
 	illustrator: "Hajime Kusajima",
@@ -18,7 +19,8 @@ const card: Card = {
 		cost: ["Grass"],
 
 		name: {
-			en: "Sting"
+			en: "Sting",
+			fr: "Dard"
 		},
 
 		damage: "20"
@@ -34,6 +36,7 @@ const card: Card = {
 
 	description: {
 		en: "Often found in forests and grasslands. It has a sharp, toxic barb of around two inches on top of its head.",
+		fr: "On trouve souvent ce Pokémon dans les forêts et les hautes herbes. L'aiguillon de 5 cm sur sa tête contient un venin très toxique."
 	}
 }
 

--- a/data/Pokémon TCG Pocket/Genetic Apex/009.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/009.ts
@@ -5,7 +5,8 @@ const card: Card = {
 	set: Set,
 
 	name: {
-		en: "Kakuna"
+		en: "Kakuna",
+		fr: "Coconfort"
 	},
 
 	illustrator: "miki kudo",
@@ -21,7 +22,8 @@ const card: Card = {
 		cost: ["Grass"],
 
 		name: {
-			en: "Bug Bite"
+			en: "Bug Bite",
+			fr: "Piqûre"
 		},
 
 		damage: "30"
@@ -37,6 +39,7 @@ const card: Card = {
 
 	description: {
 		en: "Almost incapable of moving, this Pokémon can only harden its shell to protect itself when it is in danger.",
+		fr: "Incapable de se déplacer de lui-même, il se défend en durcissant sa carapace."
 	}
 }
 

--- a/data/Pokémon TCG Pocket/Genetic Apex/010.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/010.ts
@@ -5,7 +5,8 @@ const card: Card = {
 	set: Set,
 
 	name: {
-		en: "Beedrill"
+		en: "Beedrill",
+		fr: "Dardargnan"
 	},
 
 	illustrator: "You Iribi",
@@ -21,7 +22,8 @@ const card: Card = {
 		cost: ["Grass"],
 
 		name: {
-			en: "Sharp Sting"
+			en: "Sharp Sting",
+			fr: "Piqûre Pointue"
 		},
 
 		damage: "70"
@@ -37,6 +39,7 @@ const card: Card = {
 
 	description: {
 		en: "It has three poisonous stingers on its forelegs and its tail. They are used to jab its enemy repeatedly.",
+		fr: "Il se sert de ses trois aiguillons empoisonnés pour attaquer sans relâche ses adversaires."
 	}
 }
 

--- a/data/Pokémon TCG Pocket/Genetic Apex/011.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/011.ts
@@ -5,7 +5,8 @@ const card: Card = {
 	set: Set,
 
 	name: {
-		en: "Oddish"
+		en: "Oddish",
+		fr: "Mystherbe"
 	},
 
 	illustrator: "HYOGONOSUKE",
@@ -18,7 +19,8 @@ const card: Card = {
 		cost: ["Grass"],
 
 		name: {
-			en: "Ram"
+			en: "Ram",
+			fr: "Collision"
 		},
 
 		damage: "20"
@@ -34,6 +36,7 @@ const card: Card = {
 
 	description: {
 		en: "If exposed to moonlight, it starts to move. It roams far and wide at night to scatter its seeds.",
+		fr: "Il ne bouge que lorsqu'il est exposé aux rayons de la lune. Il se déplace alors pour disséminer ses graines."
 	}
 }
 

--- a/data/Pokémon TCG Pocket/Genetic Apex/012.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/012.ts
@@ -5,7 +5,8 @@ const card: Card = {
 	set: Set,
 
 	name: {
-		en: "Gloom"
+		en: "Gloom",
+		fr: "Ortide"
 	},
 
 	illustrator: "Anesaki Dynamic",
@@ -14,7 +15,8 @@ const card: Card = {
 	types: ["Grass"],
 	stage: "Stage1",
 	evolveFrom: {
-		en: "Oddish"
+		en: "Oddish",
+		fr: "Mystherbe"
 	},
 
 	attacks: [{
@@ -37,6 +39,7 @@ const card: Card = {
 
 	description: {
 		en: "Its pistils exude an incredibly foul odor. The horrid stench can cause fainting at a distance of 1.25 miles.",
+		fr: "Ses pistils sécrètent une odeur incroyablement fétide qui fait perdre connaissance à ses adversaires jusqu'à 2 km à la ronde."
 	}
 }
 

--- a/data/Pokémon TCG Pocket/Genetic Apex/013.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/013.ts
@@ -5,7 +5,8 @@ const card: Card = {
 	set: Set,
 
 	name: {
-		en: "Vileplume"
+		en: "Vileplume",
+		fr: "Rafflesia"
 	},
 
 	illustrator: "Kyoko Umemoto",
@@ -14,18 +15,21 @@ const card: Card = {
 	types: ["Grass"],
 	stage: "Stage2",
 	evolveFrom: {
-		en: "Gloom"
+		en: "Gloom",
+		fr: "Ortide"
 	},
 
 	attacks: [{
 		cost: ["Grass", "Grass", "Colorless"],
 
 		name: {
-			en: "Soothing Scent"
+			en: "Soothing Scent",
+			fr: "Senteur Apaisante"
 		},
 
 		effect: {
-			en: "Your opponent's Active Pokémon is now Asleep"
+			en: "Your opponent's Active Pokémon is now Asleep",
+			fr: "Le Pokémon Actif de votre adversaire est maintenant Endormi"
 		},
 
 		damage: "80"
@@ -41,6 +45,7 @@ const card: Card = {
 
 	description: {
 		en: "It has the world's largest petals. With every step, the petals shake out heavy clouds of toxic pollen.",
+		fr: "Il possède les plus gros pétales du monde qui sèment d'épais nuages de pollen toxique à chacun de ses pas."
 	}
 }
 

--- a/data/Pokémon TCG Pocket/Genetic Apex/014.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/014.ts
@@ -5,7 +5,8 @@ const card: Card = {
 	set: Set,
 
 	name: {
-		en: "Paras"
+		en: "Paras",
+		fr: "Paras"
 	},
 
 	illustrator: "Naoyo Kimura",
@@ -18,7 +19,8 @@ const card: Card = {
 		cost: ["Grass", "Colorless"],
 
 		name: {
-			en: "Scratch"
+			en: "Scratch",
+			fr: "Griffe"
 		},
 
 		damage: "30"
@@ -34,6 +36,7 @@ const card: Card = {
 
 	description: {
 		en: "The mushrooms, known as tochukaso, are controlling the bug. Even if the bug bugs the mushrooms, they tell it to bug off.",
+		fr: "Les champignons, appelés tochukaso, contrôlent l'insecte contre sa volonté."
 	}
 }
 

--- a/data/Pokémon TCG Pocket/Genetic Apex/015.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/015.ts
@@ -5,7 +5,8 @@ const card: Card = {
 	set: Set,
 
 	name: {
-		en: "Parasect"
+		en: "Parasect",
+		fr: "Parasect"
 	},
 
 	illustrator: "Eri Yamaki",
@@ -14,14 +15,16 @@ const card: Card = {
 	types: ["Grass"],
 	stage: "Stage1",
 	evolveFrom: {
-		en: "Paras"
+		en: "Paras",
+		fr: "Paras"
 	},
 
 	attacks: [{
 		cost: ["Grass", "Grass", "Colorless"],
 
 		name: {
-			en: "Slash"
+			en: "Slash",
+			fr: "Tranche"
 		},
 
 		damage: "80"
@@ -37,6 +40,7 @@ const card: Card = {
 
 	description: {
 		en: "The bug is mostly dead, with the mushroom on its back having become the main body. If the mushroom comes off, the bug stops moving.",
+		fr: "L'insecte est quasiment mort, à ce stade, et le champignon est devenu le véritable cerveau. Si on l'ôte de seon dos, il ne peut plus bouger."
 	}
 }
 

--- a/data/Pokémon TCG Pocket/Genetic Apex/016.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/016.ts
@@ -5,7 +5,8 @@ const card: Card = {
 	set: Set,
 
 	name: {
-		en: "Venonat"
+		en: "Venonat",
+		fr: "Mimitoss"
 	},
 
 	illustrator: "HYOGONOSUKE",
@@ -18,7 +19,8 @@ const card: Card = {
 		cost: ["Grass"],
 
 		name: {
-			en: "Tackle"
+			en: "Tackle",
+			fr: "Charge"
 		},
 
 		damage: "20"
@@ -34,6 +36,7 @@ const card: Card = {
 
 	description: {
 		en: "Poison oozes from all over its body. It catches small bug Pokémon at night that are attracted by light.",
+		fr: "Son corps sécrète un poison redoutable. La nuit il capture de petits Pokémon insectes attirés par la lumière."
 	}
 }
 

--- a/data/Pokémon TCG Pocket/Genetic Apex/017.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/017.ts
@@ -5,7 +5,8 @@ const card: Card = {
 	set: Set,
 
 	name: {
-		en: "Venomoth"
+		en: "Venomoth",
+		fr: "Aéromite"
 	},
 
 	illustrator: "Mina Nakai",
@@ -14,18 +15,21 @@ const card: Card = {
 	types: ["Grass"],
 	stage: "Stage1",
 	evolveFrom: {
-		en: "Venonat"
+		en: "Venonat",
+		fr: "Mimitoss"
 	},
 
 	attacks: [{
 		cost: ["Grass"],
 
 		name: {
-			en: "Poison Powder"
+			en: "Poison Powder",
+			fr: "Poudre Toxik"
 		},
 
 		effect: {
-			en: "Your opponent's Active Pokémon is now Poisoned."
+			en: "Your opponent's Active Pokémon is now Poisoned.",
+			fr: "Le Pokémon Actif de votre adversaire est maintenant Empoisonné."
 		},
 
 		damage: "30"
@@ -41,6 +45,7 @@ const card: Card = {
 
 	description: {
 		en: "The wings are covered with dustlike scales. Every time it flaps its wings, it looses highly toxic dust.",
+		fr: "Ses ailes sont couvertes d'écailles poudreuses. À chaque battement d'ailes, il laisse tomber de la poudre hautement toxique."
 	}
 }
 

--- a/data/Pokémon TCG Pocket/Genetic Apex/018.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/018.ts
@@ -5,7 +5,8 @@ const card: Card = {
 	set: Set,
 
 	name: {
-		en: "Bellsprout"
+		en: "Bellsprout",
+		fr: "Chétiflor"
 	},
 
 	illustrator: "HYOGONOSUKE",
@@ -18,7 +19,8 @@ const card: Card = {
 		cost: ["Grass"],
 
 		name: {
-			en: "Vine Whip"
+			en: "Vine Whip",
+			fr: "Fouet Lianes"
 		},
 
 		damage: "20"
@@ -34,6 +36,7 @@ const card: Card = {
 
 	description: {
 		en: "Even though its body is extremely skinny, it is blindingly fast when catching its prey.",
+		fr: "Même si son coprs est très frêle, ce Pokémon est extrêmement rapide quand il attaque ses adversaires."
 	}
 }
 

--- a/data/Pokémon TCG Pocket/Genetic Apex/019.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/019.ts
@@ -5,7 +5,8 @@ const card: Card = {
 	set: Set,
 
 	name: {
-		en: "Weepinbell"
+		en: "Weepinbell",
+		fr: "Boustiflor"
 	},
 
 	illustrator: "Miki Tanaka",
@@ -14,14 +15,16 @@ const card: Card = {
 	types: ["Grass"],
 	stage: "Stage1",
 	evolveFrom: {
-		en: "Bellsprout"
+		en: "Bellsprout",
+		fr: "Chétiflor"
 	},
 
 	attacks: [{
 		cost: ["Grass", "Colorless"],
 
 		name: {
-			en: "Razor Leaf"
+			en: "Razor Leaf",
+			fr: "Tranch'Herbe"
 		},
 
 		damage: "40"
@@ -37,6 +40,7 @@ const card: Card = {
 
 	description: {
 		en: "The leafy parts act as cutters for slashing foes. It spits a fluid that dissolves everything.",
+		fr: "Ses membres en forme de feuilles permettent à Boustiflor de trancher ses adversaires. Il crache un fluide capable de tout dissoudre."
 	}
 }
 

--- a/data/Pokémon TCG Pocket/Genetic Apex/020.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/020.ts
@@ -5,7 +5,8 @@ const card: Card = {
 	set: Set,
 
 	name: {
-		en: "Victreebel"
+		en: "Victreebel",
+		fr: "Empiflor"
 	},
 
 	illustrator: "Sumiyoshi Kizuki",
@@ -14,18 +15,21 @@ const card: Card = {
 	types: ["Grass"],
 	stage: "Stage2",
 	evolveFrom: {
-		en: "Weepinbell"
+		en: "Weepinbell",
+		fr: "Boustiflor"
 	},
 
 	abilities: [{
 		type: "Ability",
 
 		name: {
-			en: "Fragrance Trap"
+			en: "Fragrance Trap",
+			fr: "Piège Parfumé"
 		},
 
 		effect: {
-			en: "If this Pokémon is in the Active Spot, once during your turn, you may switch in 1 of your opponent's Benched Basic Pokémon to the Active Spot."
+			en: "If this Pokémon is in the Active Spot, once during your turn, you may switch in 1 of your opponent's Benched Basic Pokémon to the Active Spot.",
+			fr: "Si ce Pokémon est sur le Poste Actif, une fois pendant votre tour, vous pouvez échanger l'un des Pokémon de base sur le Banc de votre adversaire contre son Pokémon Actif."
 		}
 	}],
 
@@ -33,7 +37,8 @@ const card: Card = {
 		cost: ["Grass", "Colorless"],
 
 		name: {
-			en: "Vine Whip"
+			en: "Vine Whip",
+			fr: "Fouet Lianes"
 		},
 
 		damage: "60"
@@ -49,6 +54,7 @@ const card: Card = {
 
 	description: {
 		en: "Said to live in huge colonies deep in jungles, although no one has ever returned from there.",
+		fr: "On dit qu'il vit en colonie dans la jungle, mais personne n'en est jamais revenu vivant pour le confirmer."
 	}
 }
 

--- a/data/Pokémon TCG Pocket/Genetic Apex/021.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/021.ts
@@ -5,7 +5,8 @@ const card: Card = {
 	set: Set,
 
 	name: {
-		en: "Exeggcute"
+		en: "Exeggcute",
+		fr: "Noeunoeuf"
 	},
 
 	illustrator: "kawayoo",
@@ -18,7 +19,8 @@ const card: Card = {
 		cost: ["Grass"],
 
 		name: {
-			en: "Seed Bomb"
+			en: "Seed Bomb",
+			fr: "Canon Graine"
 		},
 
 		damage: "20"
@@ -34,6 +36,7 @@ const card: Card = {
 
 	description: {
 		en: "Though it may look like it's just a bunch of eggs, it's a proper Pokémon. Exeggcute communicates with others of its kind via telepathy, apparently.",
+		fr: "Même s'il ressemble à un tas d'oeufs, il s'agit bien d'un Pokémon. Il parait qu'ils communiquent entre eux par télépathie."
 	}
 }
 

--- a/data/Pokémon TCG Pocket/Genetic Apex/022.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/022.ts
@@ -5,7 +5,8 @@ const card: Card = {
 	set: Set,
 
 	name: {
-		en: "Exeggutor"
+		en: "Exeggutor",
+		fr: "Noadkoko"
 	},
 
 	illustrator: "Yukiko Baba",
@@ -14,18 +15,21 @@ const card: Card = {
 	types: ["Grass"],
 	stage: "Stage1",
 	evolveFrom: {
-		en: "Exeggcute"
+		en: "Exeggcute",
+		fr: "Noeunoeuf"
 	},
 
 	attacks: [{
 		cost: ["Grass"],
 
 		name: {
-			en: "Stomp"
+			en: "Stomp",
+			fr: "Écrasement"
 		},
 
 		effect: {
-			en: "Flip a coin. If heads, this attack does 30 more damage."
+			en: "Flip a coin. If heads, this attack does 30 more damage.",
+			fr: "Lancez une pièce. Si c'est face, cette attaque inflige 30 dégâts de plus."
 		},
 
 		damage: "30+"
@@ -41,6 +45,7 @@ const card: Card = {
 
 	description: {
 		en: "Each of Exeggutor's three heads is thinking different thoughts. The three don't seem to be very interested in one another.",
+		fr: "Chacune de ses trois têtes pense de manière autonome. Elles ne semblent s'intéresser qu'à elles-mêmes."
 	}
 }
 

--- a/data/Pokémon TCG Pocket/Genetic Apex/023.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/023.ts
@@ -5,7 +5,8 @@ const card: Card = {
 	set: Set,
 
 	name: {
-		en: "Exeggutor ex"
+		en: "Exeggutor ex",
+		fr: "Noadkoko ex"
 	},
 
 	illustrator: "PLANETA CG Works",
@@ -20,11 +21,13 @@ const card: Card = {
 		cost: ["Grass"],
 
 		name: {
-			en: "Tropical Swing"
+			en: "Tropical Swing",
+			fr: "Coup Tropical"
 		},
 
 		effect: {
-			en: "Flip a coin. If heads, this attack does 40 more damage."
+			en: "Flip a coin. If heads, this attack does 40 more damage.",
+			fr: "Lancez une pièce. Si c'est face, cette attaque inflige 40 dégâts de plus."
 		},
 
 		damage: "40+"

--- a/data/Pokémon TCG Pocket/Genetic Apex/024.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/024.ts
@@ -5,7 +5,8 @@ const card: Card = {
 	set: Set,
 
 	name: {
-		en: "Tangela"
+		en: "Tangela",
+		fr: "Saquedeneu"
 	},
 
 	illustrator: "Midori Harada",
@@ -18,11 +19,13 @@ const card: Card = {
 		cost: ["Grass", "Colorless"],
 
 		name: {
-			en: "Absorb"
+			en: "Absorb",
+			fr: "Vole-Vie"
 		},
 
 		effect: {
-			en: "Heal 10 damage from this Pokémon."
+			en: "Heal 10 damage from this Pokémon.",
+			fr: "Soignez 10 dégâts de ce Pokémon."
 		},
 
 		damage: "40"
@@ -38,6 +41,7 @@ const card: Card = {
 
 	description: {
 		en: "Hidden beneath a tangle of vines that grows nonstop even if the vines are torn off, this Pokémon's true appearance remains a mystery.",
+		fr: "On ne sait toujours pas ce qui se cache sous ses lianes. Même si on les coupe, elles repoussent à l'infini."
 	}
 }
 

--- a/data/Pokémon TCG Pocket/Genetic Apex/025.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/025.ts
@@ -5,7 +5,8 @@ const card: Card = {
 	set: Set,
 
 	name: {
-		en: "Scyther"
+		en: "Scyther",
+		fr: "Insécateur"
 	},
 
 	illustrator: "Hasuno",
@@ -18,7 +19,8 @@ const card: Card = {
 		cost: ["Grass"],
 
 		name: {
-			en: "Sharp Scythe"
+			en: "Sharp Scythe",
+			fr: "Faucille Acérée"
 		},
 
 		damage: "30"
@@ -34,6 +36,7 @@ const card: Card = {
 
 	description: {
 		en: "It slashes through grass with its sharp scythes, moving too fast for the human eye to track.",
+		fr: "Il fauche les herbes avec ses lames acérées. Ses mouvements sont si rapides qu'ils sont imperceptibles à l'oeil nu."
 	}
 }
 

--- a/data/Pokémon TCG Pocket/Genetic Apex/026.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/026.ts
@@ -5,7 +5,8 @@ const card: Card = {
 	set: Set,
 
 	name: {
-		en: "Pinsir"
+		en: "Pinsir",
+		fr: "Scarabrute"
 	},
 
 	illustrator: "Eri Yamaki",
@@ -18,11 +19,13 @@ const card: Card = {
 		cost: ["Grass", "Grass"],
 
 		name: {
-			en: "Double Horn"
+			en: "Double Horn",
+			fr: "Double Corne"
 		},
 
 		effect: {
-			en: "Flip 2 coins. This attack does 50 damage for each heads."
+			en: "Flip 2 coins. This attack does 50 damage for each heads.",
+			fr: "Lancez 2 pièces. Cette attaque inflige 50 dégâts pour chaque côté face."
 		},
 
 		damage: "50×"
@@ -38,6 +41,7 @@ const card: Card = {
 
 	description: {
 		en: "These Pokémon judge one another based on pincers. Thicker, more impressive pincers make for more popularity with the opposite gender.",
+		fr: "Ses cornes déterminent son rang au sein du groupe. Plus elles sont imposantes, plus les membres du sexe opposé l'apprécient."
 	}
 }
 

--- a/data/Pokémon TCG Pocket/Genetic Apex/027.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/027.ts
@@ -5,7 +5,8 @@ const card: Card = {
 	set: Set,
 
 	name: {
-		en: "Cottonee"
+		en: "Cottonee",
+		fr: "Doudouvet"
 	},
 
 	illustrator: "Kanako Eo",
@@ -18,7 +19,8 @@ const card: Card = {
 		cost: ["Colorless"],
 
 		name: {
-			en: "Attach"
+			en: "Attach",
+			fr: "Accrochage"
 		},
 
 		damage: "10"
@@ -34,6 +36,7 @@ const card: Card = {
 
 	description: {
 		en: "It shoots cotton from its body to protect itself. If it gets caught up in hurricane-strength winds, it can get sent to the other side of the Earth.",
+		fr: "Il sème du coton pour se protéger. Il lui arrive d'être emporté par une tempête à l'autre bout du monde."
 	}
 }
 

--- a/data/Pokémon TCG Pocket/Genetic Apex/028.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/028.ts
@@ -5,7 +5,8 @@ const card: Card = {
 	set: Set,
 
 	name: {
-		en: "Whimsicott"
+		en: "Whimsicott",
+		fr: "Farfaduvet"
 	},
 
 	illustrator: "Atsuko Nishida",
@@ -14,14 +15,16 @@ const card: Card = {
 	types: ["Grass"],
 	stage: "Stage1",
 	evolveFrom: {
-		en: "Cottonee"
+		en: "Cottonee",
+		fr: "Doudouvet"
 	},
 
 	attacks: [{
 		cost: ["Colorless"],
 
 		name: {
-			en: "Rolling Tackle"
+			en: "Rolling Tackle",
+			fr: "Roulé-Boulé"
 		},
 
 		damage: "40"
@@ -37,6 +40,7 @@ const card: Card = {
 
 	description: {
 		en: "It scatters cotton all over the place as a prank. If it gets wet, it'll become too heavy to move and have no choice but to answer for its mischief.",
+		fr: "Il joue de mauvais tours en répendant son coton. Si on le mouille. Il s'alourdit et ne peut plus bouger, ce qui l'oblige à s'avouer vaincu."
 	}
 }
 

--- a/data/Pokémon TCG Pocket/Genetic Apex/029.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/029.ts
@@ -5,7 +5,8 @@ const card: Card = {
 	set: Set,
 
 	name: {
-		en: "Petilil"
+		en: "Petilil",
+		fr: "Chlorobule"
 	},
 
 	illustrator: "Naoyo Kimura",
@@ -18,11 +19,13 @@ const card: Card = {
 		cost: ["Grass"],
 
 		name: {
-			en: "Blot"
+			en: "Blot",
+			fr: "Pâté"
 		},
 
 		effect: {
-			en: "Heal 10 damage from this Pokémon."
+			en: "Heal 10 damage from this Pokémon.",
+			fr: "Soignez 10 dégâts de ce Pokémon."
 		},
 
 		damage: "10"
@@ -38,6 +41,7 @@ const card: Card = {
 
 	description: {
 		en: "The leaves on its head grow right back even if they fall out. These bitter leaves refresh those who eat them.",
+		fr: "Les feuilles sur sa tête repoussent très vite. Elles sont fort amères, mais elles revigorent les corps les plus éreintés."
 	}
 }
 

--- a/data/Pokémon TCG Pocket/Genetic Apex/030.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/030.ts
@@ -5,7 +5,8 @@ const card: Card = {
 	set: Set,
 
 	name: {
-		en: "Lilligant"
+		en: "Lilligant",
+		fr: "Fragilady"
 	},
 
 	illustrator: "You Iribi",
@@ -14,7 +15,8 @@ const card: Card = {
 	types: ["Grass"],
 	stage: "Stage1",
 	evolveFrom: {
-		en: "Petilil"
+		en: "Petilil",
+		fr: "Chlorobule"
 	},
 
 
@@ -22,11 +24,13 @@ const card: Card = {
 		cost: ["Grass", "Grass"],
 
 		name: {
-			en: "Leaf Supply"
+			en: "Leaf Supply",
+			fr: "Provision de Feuillage"
 		},
 
 		effect: {
-			en: "Take a G Energy from your Energy Zone and attach it to 1 of your Benched G Pokémon."
+			en: "Take a G Energy from your Energy Zone and attach it to 1 of your Benched G Pokémon.",
+			fr: "Prenez une Énergie G de votre zone Énergie et attachez-la à l'un de vos Pokémon G de Banc."
 		},
 
 		damage: "50"
@@ -43,6 +47,7 @@ const card: Card = {
 
 	description: {
 		en: "The fragrance of the garland on its head has a relaxing effect, but taking care of it is very difficult.",
+		fr: "La fleur sur sa tête émet un parfum qui apaise instantanément, mais elle est très difficile à entretenir."
 	}
 }
 

--- a/data/Pokémon TCG Pocket/Genetic Apex/031.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/031.ts
@@ -5,7 +5,8 @@ const card: Card = {
 	set: Set,
 
 	name: {
-		en: "Skiddo"
+		en: "Skiddo",
+		fr: "Cabriolaine"
 	},
 
 	illustrator: "Naoki Saito",
@@ -18,11 +19,13 @@ const card: Card = {
 		cost: ["Colorless"],
 
 		name: {
-			en: "Surprise Attack"
+			en: "Surprise Attack",
+			fr: "Attaque Surprise"
 		},
 
 		effect: {
-			en: "Flip a coin. If tails, this attack does nothing."
+			en: "Flip a coin. If tails, this attack does nothing.",
+			fr: "Lancez une pièce. Si c'est pile, cette attaque ne fait rien."
 		},
 
 		damage: "40"
@@ -38,6 +41,7 @@ const card: Card = {
 
 	description: {
 		en: "Until recently, people living in the mountains would ride on the backs of these Pokémon to traverse the mountain paths.",
+		fr: "Il y a encore peu, les personnes vivant dans les zones montagneuses se déplaçaient à dos de Cabriolaine."
 	}
 }
 

--- a/data/Pokémon TCG Pocket/Genetic Apex/032.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/032.ts
@@ -5,7 +5,8 @@ const card: Card = {
 	set: Set,
 
 	name: {
-		en: "Gogoat"
+		en: "Gogoat",
+		fr: "Chevroum"
 	},
 
 	illustrator: "You Iribi",
@@ -14,15 +15,16 @@ const card: Card = {
 	types: ["Grass"],
 	stage: "Stage1",
 	evolveFrom: {
-		en: "Skiddo"
+		en: "Skiddo",
+		fr: "Cabriolaine"
 	},
-
 
 	attacks: [{
 		cost: ["Grass", "Colorless", "Colorless"],
 
 		name: {
-			en: "Razor Leaf"
+			en: "Razor Leaf",
+			fr: "Tranch'Herbe"
 		},
 
 		damage: "70"
@@ -38,6 +40,7 @@ const card: Card = {
 
 	description: {
 		en: "It can sense the feelings of others by touching them with its horns. This species has assisted people with their work since 5,000 years ago.",
+		fr: "Il peut ressentir les émotions de ses adversaires en les touchant avec ses cornes. Il aide les êtres humains dans leurs travaux depuis 5 000 ans."
 	}
 }
 


### PR DESCRIPTION
This update adds translations for the cards in the Genetic Apex expansion, including their title, attacks, effects, and descriptions in French.

Genetic Apex :

- [x] Grass
- [ ] Fire
- [ ] Water
- [ ] Electric
- [ ] Psy
- [ ] Fight
- [ ] Dark
- [ ] Steel
- [ ] Dragon
- [ ] Colorless