### PR TITLE
Fix: A2b Shining Revelry attack amendments

### DIFF
--- a/data/Pokémon TCG Pocket/Shining Revelry.ts
+++ b/data/Pokémon TCG Pocket/Shining Revelry.ts
@@ -5,18 +5,18 @@ const set: Set = {
 	id: "A2b",
 
 	name: {
-		// de: "Unschlagbare Gene",
+		de: "Glänzendes Festival",
 		en: "Shining Revelry",
-		// es: "Genes Formidables",
-		// fr: "Puissance Génétique",
-		// it: "Geni Supremi",
-		// pt: "Dominação Genética"
+		es: "Festival Brillante",
+		fr: "Réjouissances Rayonnantes",
+		it: "Tripudio Splendente",
+		pt: "Festival Brilhante"
 	},
 
 	serie: serie,
 
 	cardCount: {
-		official: 78
+		official: 72
 	},
 
 	releaseDate: "2025-03-27"

--- a/data/Pokémon TCG Pocket/Shining Revelry/004.ts
+++ b/data/Pokémon TCG Pocket/Shining Revelry/004.ts
@@ -25,7 +25,7 @@ const card: Card = {
 			en: "Guillotine Rush"
 		},
 
-		damage: 50,
+		damage: "50+",
 		cost: ["Grass", "Colorless", "Colorless"],
 
 		effect: {

--- a/data/Pokémon TCG Pocket/Shining Revelry/005.ts
+++ b/data/Pokémon TCG Pocket/Shining Revelry/005.ts
@@ -28,7 +28,7 @@ const card: Card = {
 		cost: ["Grass"],
 
 		effect: {
-			en: "Put 1 random  Pokémon from your deck into your hand."
+			en: "Put 1 random [Grass] Pokémon from your deck into your hand."
 		}
 	}],
 

--- a/data/Pokémon TCG Pocket/Shining Revelry/007.ts
+++ b/data/Pokémon TCG Pocket/Shining Revelry/007.ts
@@ -29,7 +29,7 @@ const card: Card = {
 			en: "Fighting Claws"
 		},
 
-		damage: 60,
+		damage: "60+",
 		cost: ["Grass", "Grass"],
 
 		effect: {

--- a/data/Pokémon TCG Pocket/Shining Revelry/010.ts
+++ b/data/Pokémon TCG Pocket/Shining Revelry/010.ts
@@ -29,7 +29,7 @@ const card: Card = {
 		cost: ["Fire"],
 
 		effect: {
-			en: "Take 3  Energy from your Energy Zone and attach it to this Pokémon."
+			en: "Take 3 [Fire] Energy from your Energy Zone and attach it to this Pokémon."
 		}
 	}, {
 		name: {

--- a/data/Pokémon TCG Pocket/Shining Revelry/024.ts
+++ b/data/Pokémon TCG Pocket/Shining Revelry/024.ts
@@ -29,7 +29,7 @@ const card: Card = {
 			en: "Tumbling Attack"
 		},
 
-		damage: 50,
+		damage: "50+",
 		cost: ["Lightning", "Lightning"],
 
 		effect: {

--- a/data/Pokémon TCG Pocket/Shining Revelry/025.ts
+++ b/data/Pokémon TCG Pocket/Shining Revelry/025.ts
@@ -29,7 +29,7 @@ const card: Card = {
 		cost: ["Lightning"],
 
 		effect: {
-			en: "Take a  Energy from your Energy Zone and attach it to 1 of your Benched  Pokémon."
+			en: "Take a [Lightning] Energy from your Energy Zone and attach it to 1 of your Benched  Pokémon."
 		}
 	}],
 

--- a/data/Pokémon TCG Pocket/Shining Revelry/032.ts
+++ b/data/Pokémon TCG Pocket/Shining Revelry/032.ts
@@ -25,7 +25,7 @@ const card: Card = {
 			en: "Juggling"
 		},
 
-		damage: 20,
+		damage: "20x",
 		cost: ["Psychic", "Colorless"],
 
 		effect: {

--- a/data/Pokémon TCG Pocket/Shining Revelry/038.ts
+++ b/data/Pokémon TCG Pocket/Shining Revelry/038.ts
@@ -29,7 +29,7 @@ const card: Card = {
 			en: "Pummel"
 		},
 
-		damage: 30,
+		damage: "30+",
 		cost: ["Fighting", "Fighting"],
 
 		effect: {

--- a/data/Pokémon TCG Pocket/Shining Revelry/039.ts
+++ b/data/Pokémon TCG Pocket/Shining Revelry/039.ts
@@ -33,7 +33,7 @@ const card: Card = {
 		cost: ["Fighting", "Fighting"],
 
 		effect: {
-			en: "If this Pokémon has at least 2 extra  Energy attached, this attack does 50 more damage."
+			en: "If this Pokémon has at least 2 extra [Fighting] Energy attached, this attack does 50 more damage."
 		}
 	}],
 

--- a/data/Pokémon TCG Pocket/Shining Revelry/039.ts
+++ b/data/Pokémon TCG Pocket/Shining Revelry/039.ts
@@ -29,7 +29,7 @@ const card: Card = {
 			en: "Power Press"
 		},
 
-		damage: 70,
+		damage: "70+",
 		cost: ["Fighting", "Fighting"],
 
 		effect: {

--- a/data/Pokémon TCG Pocket/Shining Revelry/044.ts
+++ b/data/Pokémon TCG Pocket/Shining Revelry/044.ts
@@ -25,7 +25,7 @@ const card: Card = {
 			en: "Double Kick"
 		},
 
-		damage: 50,
+		damage: "50x",
 		cost: ["Fighting", "Fighting"],
 
 		effect: {

--- a/data/Pokémon TCG Pocket/Shining Revelry/048.ts
+++ b/data/Pokémon TCG Pocket/Shining Revelry/048.ts
@@ -26,7 +26,7 @@ const card: Card = {
 			en: "Venoshock"
 		},
 
-		damage: 60,
+		damage: "60+",
 		cost: ["Darkness", "Darkness"],
 
 		effect: {

--- a/data/Pokémon TCG Pocket/Shining Revelry/053.ts
+++ b/data/Pokémon TCG Pocket/Shining Revelry/053.ts
@@ -29,7 +29,7 @@ const card: Card = {
 			en: "Tenacious Hammer"
 		},
 
-		damage: 30,
+		damage: "30+",
 		cost: ["Metal", "Metal"],
 
 		effect: {

--- a/data/Pokémon TCG Pocket/Shining Revelry/054.ts
+++ b/data/Pokémon TCG Pocket/Shining Revelry/054.ts
@@ -26,7 +26,7 @@ const card: Card = {
 			en: "Terrific Thumping"
 		},
 
-		damage: 80,
+		damage: "80+",
 		cost: ["Metal", "Metal", "Colorless"],
 
 		effect: {

--- a/data/Pokémon TCG Pocket/Shining Revelry/057.ts
+++ b/data/Pokémon TCG Pocket/Shining Revelry/057.ts
@@ -29,7 +29,7 @@ const card: Card = {
 			en: "Scintillating Surfing"
 		},
 
-		damage: 50,
+		damage: "50x",
 		cost: ["Metal", "Colorless", "Colorless"],
 
 		effect: {

--- a/data/Pokémon TCG Pocket/Shining Revelry/057.ts
+++ b/data/Pokémon TCG Pocket/Shining Revelry/057.ts
@@ -33,7 +33,7 @@ const card: Card = {
 		cost: ["Metal", "Colorless", "Colorless"],
 
 		effect: {
-			en: "Flip a coin for each  Energy attached to this Pokémon. This attack does 50 damage for each heads."
+			en: "Flip a coin for each [Metal] Energy attached to this Pokémon. This attack does 50 damage for each heads."
 		}
 	}],
 

--- a/data/Pokémon TCG Pocket/Shining Revelry/073.ts
+++ b/data/Pokémon TCG Pocket/Shining Revelry/073.ts
@@ -29,7 +29,7 @@ const card: Card = {
 			en: "Fighting Claws"
 		},
 
-		damage: 60,
+		damage: "60+",
 		cost: ["Grass", "Grass"],
 
 		effect: {

--- a/data/Pokémon TCG Pocket/Shining Revelry/077.ts
+++ b/data/Pokémon TCG Pocket/Shining Revelry/077.ts
@@ -29,7 +29,7 @@ const card: Card = {
 			en: "Scintillating Surfing"
 		},
 
-		damage: 50,
+		damage: "50x",
 		cost: ["Metal", "Colorless", "Colorless"],
 
 		effect: {

--- a/data/Pokémon TCG Pocket/Shining Revelry/077.ts
+++ b/data/Pokémon TCG Pocket/Shining Revelry/077.ts
@@ -33,7 +33,7 @@ const card: Card = {
 		cost: ["Metal", "Colorless", "Colorless"],
 
 		effect: {
-			en: "Flip a coin for each  Energy attached to this Pokémon. This attack does 50 damage for each heads."
+			en: "Flip a coin for each [Metal] Energy attached to this Pokémon. This attack does 50 damage for each heads."
 		}
 	}],
 

--- a/data/Pokémon TCG Pocket/Shining Revelry/080.ts
+++ b/data/Pokémon TCG Pocket/Shining Revelry/080.ts
@@ -29,7 +29,7 @@ const card: Card = {
 		cost: ["Fire"],
 
 		effect: {
-			en: "Take 3  Energy from your Energy Zone and attach it to this Pokémon."
+			en: "Take 3 [Fire] Energy from your Energy Zone and attach it to this Pokémon."
 		}
 	}, {
 		name: {

--- a/data/Pokémon TCG Pocket/Shining Revelry/086.ts
+++ b/data/Pokémon TCG Pocket/Shining Revelry/086.ts
@@ -26,7 +26,7 @@ const card: Card = {
 			en: "Terrific Thumping"
 		},
 
-		damage: 80,
+		damage: "80+",
 		cost: ["Metal", "Metal", "Colorless"],
 
 		effect: {

--- a/data/Pokémon TCG Pocket/Shining Revelry/094.ts
+++ b/data/Pokémon TCG Pocket/Shining Revelry/094.ts
@@ -26,7 +26,7 @@ const card: Card = {
 			en: "Terrific Thumping"
 		},
 
-		damage: 80,
+		damage: "80+",
 		cost: ["Metal", "Metal", "Colorless"],
 
 		effect: {

--- a/data/Pokémon TCG Pocket/Shining Revelry/103.ts
+++ b/data/Pokémon TCG Pocket/Shining Revelry/103.ts
@@ -28,7 +28,7 @@ const card: Card = {
 		cost: ["Lightning"],
 
 		effect: {
-			en: "Take a  Energy from your Energy Zone and attach it to 1 of your Benched  Pokémon."
+			en: "Take a [Lightning] Energy from your Energy Zone and attach it to 1 of your Benched  Pokémon."
 		}
 	}],
 

--- a/data/Pokémon TCG Pocket/Shining Revelry/108.ts
+++ b/data/Pokémon TCG Pocket/Shining Revelry/108.ts
@@ -28,7 +28,7 @@ const card: Card = {
 		cost: ["Fire"],
 
 		effect: {
-			en: "Take 3  Energy from your Energy Zone and attach it to this Pokémon."
+			en: "Take 3 [Fire] Energy from your Energy Zone and attach it to this Pokémon."
 		}
 	}, {
 		name: {


### PR DESCRIPTION
Make amendments to correct card data for A2b:

* Attacks with additional or multiplied damage were missing + and x symbols respectively
* Energy symbols were stripped from card text. 
  - I've added these back in square brackets (eg `[Fire]`, `[Grass]` etc), as we don't currently have a consistent way to represent them`*`. 
  
  
`*` For Pocket, we currently use span tags for most sets (eg `<span class=\"energy-text energy-text--type-fire\"></span>` and symbol font characters for Genetic Apex (eg `R` for Fire, `G` for Grass etc), likely due to the initial source of data. It would be helpful for API consumers if we could standardise to one format, I've raised issue #697 to discuss this further.