### PR TITLE
fix: Add holo variant for sv03-100

### DIFF
--- a/data/Scarlet & Violet/Obsidian Flames/100.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/100.ts
@@ -48,7 +48,11 @@ const card: Card = {
 	retreat: 3,
 	regulationMark: "G",
 
-	variants: {},
+	variants: {
+		normal: true,
+		holo: true,
+		reverse: true,
+	},
 };
 
 export default card;

--- a/data/Scarlet & Violet/Obsidian Flames/100.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/100.ts
@@ -1,5 +1,5 @@
-import { Card } from "../../../interfaces"
-import Set from "../Obsidian Flames"
+import { Card } from "../../../interfaces";
+import Set from "../Obsidian Flames";
 
 const card: Card = {
 	set: Set,
@@ -10,7 +10,7 @@ const card: Card = {
 		es: "Greavard",
 		it: "Greavard",
 		pt: "Greavard",
-		de: "Gruff"
+		de: "Gruff",
 	},
 
 	rarity: "Common",
@@ -19,36 +19,36 @@ const card: Card = {
 	types: ["Psychic"],
 	stage: "Basic",
 
-	attacks: [{
-		cost: ["Colorless", "Colorless", "Colorless"],
+	attacks: [
+		{
+			cost: ["Colorless", "Colorless", "Colorless"],
 
-		name: {
-			fr: "Câlinerie",
-			en: "Play Rough",
-			es: "Carantoña",
-			it: "Carineria",
-			pt: "Jogo Duro",
-			de: "Knuddler"
+			name: {
+				fr: "Câlinerie",
+				en: "Play Rough",
+				es: "Carantoña",
+				it: "Carineria",
+				pt: "Jogo Duro",
+				de: "Knuddler",
+			},
+
+			effect: {
+				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 30 dégâts supplémentaires.",
+				en: "Flip a coin. If heads, this attack does 30 more damage.",
+				es: "Lanza 1 moneda. Si sale cara, este ataque hace 30 puntos de daño más.",
+				it: "Lancia una moneta. Se esce testa, questo attacco infligge 30 danni in più.",
+				pt: "Jogue uma moeda. Se sair cara, este ataque causará 30 pontos de dano a mais.",
+				de: "Wirf 1 Münze. Bei Kopf fügt diese Attacke 30 Schadenspunkte mehr zu.",
+			},
+
+			damage: "30+",
 		},
-
-		effect: {
-			fr: "Lancez une pièce. Si c'est face, cette attaque inflige 30 dégâts supplémentaires.",
-			en: "Flip a coin. If heads, this attack does 30 more damage.",
-			es: "Lanza 1 moneda. Si sale cara, este ataque hace 30 puntos de daño más.",
-			it: "Lancia una moneta. Se esce testa, questo attacco infligge 30 danni in più.",
-			pt: "Jogue uma moeda. Se sair cara, este ataque causará 30 pontos de dano a mais.",
-			de: "Wirf 1 Münze. Bei Kopf fügt diese Attacke 30 Schadenspunkte mehr zu."
-		},
-
-		damage: "30+"
-	}],
+	],
 
 	retreat: 3,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	}
-}
+	variants: {},
+};
 
-export default card
+export default card;


### PR DESCRIPTION
Added holo variant for card 100 (Greavard) in the sv03 (Obsidian Flame) set.

Holo variant can be obtained through Houndstone EX box.

Added known variants in a verbose matter to prevent issues when defaults change