### PR TITLE
feat: Add 1 Missing card in tk-dp-l

### DIFF
--- a/data/Trainer kits/DP trainer Kit (Lucario)/1.ts
+++ b/data/Trainer kits/DP trainer Kit (Lucario)/1.ts
@@ -1,0 +1,52 @@
+import { Card } from '../../../interfaces'
+import Set from '../DP trainer Kit (Lucario)'
+
+const card: Card = {
+	dexId: [74],
+	set: Set,
+
+	name: {
+		en: "Geodude"
+	},
+
+	illustrator: "Ken Sudimori",
+	rarity: "None",
+	category: "Pokemon",
+
+	hp: 60,
+
+	types: [
+		"Fighting",
+	],
+
+	attacks: [{
+
+		cost: [
+			"Fighting",
+		],
+
+		name: {
+			en: "Stone Throw"
+		},
+
+		effect: {
+			en: "Choose 2 of your opponent's Benched Pokémon. This attack does 10 damage to each of them. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+		}
+	}],
+
+	weaknesses: [
+		{
+			type: "Grass",
+			value: "×2"
+		},
+	],
+
+	description: {
+		en: "Many live on mountain trails and remain half buried while keeping an eye on climbers"
+	},
+
+	retreat: 2,
+
+}
+
+export default card


### PR DESCRIPTION
<!--
Thanks for your Pull Request, Please provide the related Issue using "Fix #0" or describe the change(s) you made.
The issue title must follow Conventional Commit conventionalcommits.org.
More informations at https://github.com/tcgdex/cards-database/blob/master/CONTRIBUTING.md
-->

Hi, i added a card which is included in the set: trainer Kit (Lucario) with the set_id: tk-dp-l

there are still more cards missing to the trainer Kits and I experienced many more missing cards. I would gladly help out to add those, since I'm using the API for my own purpose.