### PR TITLE
Fix: Celestial Guardians corrections

### DIFF
--- a/data/Pokémon TCG Pocket/Celestial Guardians.ts
+++ b/data/Pokémon TCG Pocket/Celestial Guardians.ts
@@ -5,12 +5,12 @@ const set: Set = {
 	id: "A3",
 
 	name: {
-		// de: "Unschlagbare Gene",
+		de: "Hüter des Firmaments",
 		en: "Celestial Guardians",
-		// es: "Genes Formidables",
-		// fr: "Puissance Génétique",
-		// it: "Geni Supremi",
-		// pt: "Dominação Genética"
+		es: "Guardianes Celestiales",
+		fr: "Gardiens Astraux",
+		it: "Guardiani Astrali",
+		pt: "Guardiões Celestiais"
 	},
 
 	serie: serie,

--- a/data/Pokémon TCG Pocket/Celestial Guardians/003.ts
+++ b/data/Pokémon TCG Pocket/Celestial Guardians/003.ts
@@ -25,7 +25,7 @@ const card: Card = {
 			en: "Quick Attack"
 		},
 
-		damage: 10,
+		damage: "10+",
 		cost: ["Colorless"],
 
 		effect: {

--- a/data/Pokémon TCG Pocket/Celestial Guardians/019.ts
+++ b/data/Pokémon TCG Pocket/Celestial Guardians/019.ts
@@ -29,7 +29,7 @@ const card: Card = {
 			en: "Double Spin"
 		},
 
-		damage: 30,
+		damage: "30x",
 		cost: ["Grass"],
 
 		effect: {

--- a/data/Pokémon TCG Pocket/Celestial Guardians/020.ts
+++ b/data/Pokémon TCG Pocket/Celestial Guardians/020.ts
@@ -29,7 +29,7 @@ const card: Card = {
 			en: "Three Kick Combo"
 		},
 
-		damage: 50,
+		damage: "50x",
 		cost: ["Grass"],
 
 		effect: {

--- a/data/Pokémon TCG Pocket/Celestial Guardians/022.ts
+++ b/data/Pokémon TCG Pocket/Celestial Guardians/022.ts
@@ -29,7 +29,7 @@ const card: Card = {
 			en: "First Impression"
 		},
 
-		damage: 60,
+		damage: "60+",
 		cost: ["Grass", "Grass", "Grass"],
 
 		effect: {

--- a/data/Pokémon TCG Pocket/Celestial Guardians/027.ts
+++ b/data/Pokémon TCG Pocket/Celestial Guardians/027.ts
@@ -29,7 +29,7 @@ const card: Card = {
 			en: "Burning Bonemerang"
 		},
 
-		damage: 70,
+		damage: "70x",
 		cost: ["Fire", "Fire", "Colorless"],
 
 		effect: {

--- a/data/Pokémon TCG Pocket/Celestial Guardians/033.ts
+++ b/data/Pokémon TCG Pocket/Celestial Guardians/033.ts
@@ -37,7 +37,7 @@ const card: Card = {
 			en: "Scar-Charged Smash"
 		},
 
-		damage: 80,
+		damage: "80+",
 		cost: ["Fire", "Fire", "Colorless"],
 
 		effect: {

--- a/data/Pokémon TCG Pocket/Celestial Guardians/037.ts
+++ b/data/Pokémon TCG Pocket/Celestial Guardians/037.ts
@@ -29,7 +29,7 @@ const card: Card = {
 		cost: ["Fire", "Fire", "Colorless"],
 
 		effect: {
-			en: "Discard a  Energy from this Pokémon."
+			en: "Discard a Fire Energy from this Pokémon."
 		}
 	}],
 

--- a/data/Pokémon TCG Pocket/Celestial Guardians/040.ts
+++ b/data/Pokémon TCG Pocket/Celestial Guardians/040.ts
@@ -28,7 +28,7 @@ const card: Card = {
 		cost: ["Water"],
 
 		effect: {
-			en: "Take a  Energy from your Energy Zone and attach it to this Pokémon."
+			en: "Take a Water Energy from your Energy Zone and attach it to this Pokémon."
 		}
 	}],
 

--- a/data/Pokémon TCG Pocket/Celestial Guardians/048.ts
+++ b/data/Pokémon TCG Pocket/Celestial Guardians/048.ts
@@ -32,7 +32,7 @@ const card: Card = {
 		},
 
 		effect: {
-			en: "Once during your turn, you may heal 30 damage from each of your  Pokémon."
+			en: "Once during your turn, you may heal 30 damage from each of your Water Pokémon."
 		}
 	}],
 

--- a/data/Pokémon TCG Pocket/Celestial Guardians/051.ts
+++ b/data/Pokémon TCG Pocket/Celestial Guardians/051.ts
@@ -21,7 +21,7 @@ const card: Card = {
 			en: "School Storm"
 		},
 
-		damage: 30,
+		damage: "30+",
 		cost: ["Water", "Water", "Water"],
 
 		effect: {

--- a/data/Pokémon TCG Pocket/Celestial Guardians/053.ts
+++ b/data/Pokémon TCG Pocket/Celestial Guardians/053.ts
@@ -29,7 +29,7 @@ const card: Card = {
 			en: "Dangerous Claws"
 		},
 
-		damage: 60,
+		damage: "60+",
 		cost: ["Water", "Water", "Colorless"],
 
 		effect: {

--- a/data/Pokémon TCG Pocket/Celestial Guardians/058.ts
+++ b/data/Pokémon TCG Pocket/Celestial Guardians/058.ts
@@ -26,7 +26,7 @@ const card: Card = {
 			en: "Psychic"
 		},
 
-		damage: 60,
+		damage: "60+",
 		cost: ["Colorless", "Colorless", "Colorless"],
 
 		effect: {

--- a/data/Pokémon TCG Pocket/Celestial Guardians/061.ts
+++ b/data/Pokémon TCG Pocket/Celestial Guardians/061.ts
@@ -33,7 +33,7 @@ const card: Card = {
 		cost: ["Lightning", "Lightning", "Colorless", "Colorless"],
 
 		effect: {
-			en: "Discard 2  Energy from this Pokémon."
+			en: "Discard 2 Lightning Energy from this Pokémon."
 		}
 	}],
 

--- a/data/Pokémon TCG Pocket/Celestial Guardians/067.ts
+++ b/data/Pokémon TCG Pocket/Celestial Guardians/067.ts
@@ -25,7 +25,7 @@ const card: Card = {
 			en: "Electrosmash"
 		},
 
-		damage: 20,
+		damage: "20+",
 		cost: ["Lightning"],
 
 		effect: {

--- a/data/Pokémon TCG Pocket/Celestial Guardians/068.ts
+++ b/data/Pokémon TCG Pocket/Celestial Guardians/068.ts
@@ -29,7 +29,7 @@ const card: Card = {
 		cost: ["Lightning", "Lightning", "Lightning"],
 
 		effect: {
-			en: "Switch this Pokémon with 1 of your Benched  Pokémon."
+			en: "Switch this Pokémon with 1 of your Benched Lightning Pokémon."
 		}
 	}],
 

--- a/data/Pokémon TCG Pocket/Celestial Guardians/071.ts
+++ b/data/Pokémon TCG Pocket/Celestial Guardians/071.ts
@@ -28,7 +28,7 @@ const card: Card = {
 		cost: ["Psychic"],
 
 		effect: {
-			en: "Take a  Energy from your Energy Zone and attach it to this Pokémon."
+			en: "Take a Psychic Energy from your Energy Zone and attach it to this Pokémon."
 		}
 	}],
 

--- a/data/Pokémon TCG Pocket/Celestial Guardians/077.ts
+++ b/data/Pokémon TCG Pocket/Celestial Guardians/077.ts
@@ -25,7 +25,7 @@ const card: Card = {
 			en: "Spiteful Dance"
 		},
 
-		damage: 20,
+		damage: "20+",
 		cost: ["Psychic"],
 
 		effect: {

--- a/data/Pokémon TCG Pocket/Celestial Guardians/080.ts
+++ b/data/Pokémon TCG Pocket/Celestial Guardians/080.ts
@@ -28,7 +28,7 @@ const card: Card = {
 		},
 
 		effect: {
-			en: "Each of your Pokémon that has any  Energy attached recovers from all Special Conditions and can't be affected by any Special Conditions."
+			en: "Each of your Pokémon that has any Psychic Energy attached recovers from all Special Conditions and can't be affected by any Special Conditions."
 		}
 	}],
 

--- a/data/Pokémon TCG Pocket/Celestial Guardians/087.ts
+++ b/data/Pokémon TCG Pocket/Celestial Guardians/087.ts
@@ -29,7 +29,7 @@ const card: Card = {
 		},
 
 		effect: {
-			en: "Once during your turn, you may move all  Energy from 1 of your Benched  Pokémon to your Active Pokémon."
+			en: "Once during your turn, you may move all Psychic Energy from 1 of your Benched Psychic Pokémon to your Active Pokémon."
 		}
 	}],
 

--- a/data/Pokémon TCG Pocket/Celestial Guardians/101.ts
+++ b/data/Pokémon TCG Pocket/Celestial Guardians/101.ts
@@ -29,7 +29,7 @@ const card: Card = {
 			en: "Blood Fang"
 		},
 
-		damage: 50,
+		damage: "50+",
 		cost: ["Fighting", "Fighting"],
 
 		effect: {

--- a/data/Pokémon TCG Pocket/Celestial Guardians/104.ts
+++ b/data/Pokémon TCG Pocket/Celestial Guardians/104.ts
@@ -24,7 +24,7 @@ const card: Card = {
 		},
 
 		effect: {
-			en: "If this Pokémon is in the Active Spot and is Knocked Out by damage from an attack from your opponent's Pokémon, move all  Energy from this Pokémon to 1 of your Benched Pokémon."
+			en: "If this Pokémon is in the Active Spot and is Knocked Out by damage from an attack from your opponent's Pokémon, move all Fighting Energy from this Pokémon to 1 of your Benched Pokémon."
 		}
 	}],
 

--- a/data/Pokémon TCG Pocket/Celestial Guardians/112.ts
+++ b/data/Pokémon TCG Pocket/Celestial Guardians/112.ts
@@ -25,7 +25,7 @@ const card: Card = {
 			en: "Unseen Claw"
 		},
 
-		damage: 20,
+		damage: "20+",
 		cost: ["Darkness", "Colorless"],
 
 		effect: {

--- a/data/Pokémon TCG Pocket/Celestial Guardians/116.ts
+++ b/data/Pokémon TCG Pocket/Celestial Guardians/116.ts
@@ -29,7 +29,7 @@ const card: Card = {
 			en: "Spike Cannon"
 		},
 
-		damage: 20,
+		damage: "20x",
 		cost: ["Darkness"],
 
 		effect: {

--- a/data/Pokémon TCG Pocket/Celestial Guardians/118.ts
+++ b/data/Pokémon TCG Pocket/Celestial Guardians/118.ts
@@ -29,7 +29,7 @@ const card: Card = {
 			en: "Iron Head"
 		},
 
-		damage: 70,
+		damage: "70x",
 		cost: ["Metal", "Metal"],
 
 		effect: {

--- a/data/Pokémon TCG Pocket/Celestial Guardians/123.ts
+++ b/data/Pokémon TCG Pocket/Celestial Guardians/123.ts
@@ -25,7 +25,7 @@ const card: Card = {
 			en: "Silver Cannon"
 		},
 
-		damage: 40,
+		damage: "40+",
 		cost: ["Metal", "Metal"],
 
 		effect: {

--- a/data/Pokémon TCG Pocket/Celestial Guardians/124.ts
+++ b/data/Pokémon TCG Pocket/Celestial Guardians/124.ts
@@ -33,11 +33,6 @@ const card: Card = {
 		}
 	}],
 
-	weaknesses: [{
-		type: "Colorless",
-		value: "+20"
-	}],
-
 	retreat: 2
 }
 

--- a/data/Pokémon TCG Pocket/Celestial Guardians/124.ts
+++ b/data/Pokémon TCG Pocket/Celestial Guardians/124.ts
@@ -25,7 +25,7 @@ const card: Card = {
 			en: "Berserk"
 		},
 
-		damage: 20,
+		damage: "20+",
 		cost: ["Colorless", "Colorless"],
 
 		effect: {

--- a/data/Pokémon TCG Pocket/Celestial Guardians/125.ts
+++ b/data/Pokémon TCG Pocket/Celestial Guardians/125.ts
@@ -29,11 +29,6 @@ const card: Card = {
 		cost: ["Colorless"]
 	}],
 
-	weaknesses: [{
-		type: "Colorless",
-		value: "+20"
-	}],
-
 	retreat: 1
 }
 

--- a/data/Pokémon TCG Pocket/Celestial Guardians/126.ts
+++ b/data/Pokémon TCG Pocket/Celestial Guardians/126.ts
@@ -33,11 +33,6 @@ const card: Card = {
 		cost: ["Lightning", "Fighting"]
 	}],
 
-	weaknesses: [{
-		type: "Colorless",
-		value: "+20"
-	}],
-
 	retreat: 2
 }
 

--- a/data/Pokémon TCG Pocket/Celestial Guardians/127.ts
+++ b/data/Pokémon TCG Pocket/Celestial Guardians/127.ts
@@ -37,11 +37,6 @@ const card: Card = {
 		}
 	}],
 
-	weaknesses: [{
-		type: "Colorless",
-		value: "+20"
-	}],
-
 	retreat: 2
 }
 

--- a/data/Pokémon TCG Pocket/Celestial Guardians/128.ts
+++ b/data/Pokémon TCG Pocket/Celestial Guardians/128.ts
@@ -25,7 +25,7 @@ const card: Card = {
 			en: "Rising Lunge"
 		},
 
-		damage: 50,
+		damage: "50+",
 		cost: ["Colorless", "Colorless", "Colorless"],
 
 		effect: {

--- a/data/Pokémon TCG Pocket/Celestial Guardians/130.ts
+++ b/data/Pokémon TCG Pocket/Celestial Guardians/130.ts
@@ -33,7 +33,7 @@ const card: Card = {
 		cost: ["Colorless"],
 
 		effect: {
-			en: "Take a  Energy from your Energy Zone and attach it to 1 of your Benched Pokémon."
+			en: "Take a Colorless Energy from your Energy Zone and attach it to 1 of your Benched Pokémon."
 		}
 	}],
 

--- a/data/Pokémon TCG Pocket/Celestial Guardians/132.ts
+++ b/data/Pokémon TCG Pocket/Celestial Guardians/132.ts
@@ -29,7 +29,7 @@ const card: Card = {
 		cost: ["Colorless"],
 
 		effect: {
-			en: "If your opponent's Active Pokémon is a  Pokémon, this attack does 30 more damage."
+			en: "If your opponent's Active Pokémon is a Darkness Pokémon, this attack does 30 more damage."
 		}
 	}],
 

--- a/data/Pokémon TCG Pocket/Celestial Guardians/132.ts
+++ b/data/Pokémon TCG Pocket/Celestial Guardians/132.ts
@@ -25,7 +25,7 @@ const card: Card = {
 			en: "Justified Press"
 		},
 
-		damage: 20,
+		damage: "20+",
 		cost: ["Colorless"],
 
 		effect: {

--- a/data/Pokémon TCG Pocket/Celestial Guardians/140.ts
+++ b/data/Pokémon TCG Pocket/Celestial Guardians/140.ts
@@ -29,7 +29,7 @@ const card: Card = {
 		cost: ["Colorless", "Colorless"],
 
 		effect: {
-			en: "During your opponent's next turn, attacks used by the Defending Pokémon cost 1  more, and its Retreat Cost is 1  more."
+			en: "During your opponent's next turn, attacks used by the Defending Pokémon cost 1 Colorless more, and its Retreat Cost is 1 Colorless more."
 		}
 	}],
 

--- a/data/Pokémon TCG Pocket/Celestial Guardians/143.ts
+++ b/data/Pokémon TCG Pocket/Celestial Guardians/143.ts
@@ -13,7 +13,7 @@ const card: Card = {
 	category: "Trainer",
 
 	effect: {
-		en: "Put a random Basic  Pokémon from your discard pile into your hand."
+		en: "Put a random Basic Water Pokémon from your discard pile into your hand."
 	},
 
 	trainerType: "Item"

--- a/data/Pokémon TCG Pocket/Celestial Guardians/147.ts
+++ b/data/Pokémon TCG Pocket/Celestial Guardians/147.ts
@@ -13,7 +13,7 @@ const card: Card = {
 	category: "Trainer",
 
 	effect: {
-		en: "The  Pokémon this card is attached to gets +30 HP."
+		en: "The Grass Pokémon this card is attached to gets +30 HP."
 	},
 
 	trainerType: "Tool"

--- a/data/Pokémon TCG Pocket/Celestial Guardians/149.ts
+++ b/data/Pokémon TCG Pocket/Celestial Guardians/149.ts
@@ -13,7 +13,7 @@ const card: Card = {
 	category: "Trainer",
 
 	effect: {
-		en: "Put 1 of your  Pokémon that has damage on it into your hand."
+		en: "Put 1 of your Colorless Pokémon that has damage on it into your hand."
 	},
 
 	trainerType: "Supporter"

--- a/data/Pokémon TCG Pocket/Celestial Guardians/150.ts
+++ b/data/Pokémon TCG Pocket/Celestial Guardians/150.ts
@@ -13,7 +13,7 @@ const card: Card = {
 	category: "Trainer",
 
 	effect: {
-		en: "Choose 1 of your Alolan Marowak or Turtonator. Take 2  Energy from your Energy Zone and attach it to that Pokémon. Your turn ends."
+		en: "Choose 1 of your Alolan Marowak or Turtonator. Take 2 Fire Energy from your Energy Zone and attach it to that Pokémon. Your turn ends."
 	},
 
 	trainerType: "Supporter"

--- a/data/Pokémon TCG Pocket/Celestial Guardians/155.ts
+++ b/data/Pokémon TCG Pocket/Celestial Guardians/155.ts
@@ -13,7 +13,7 @@ const card: Card = {
 	category: "Trainer",
 
 	effect: {
-		en: "Heal 60 damage from 1 of your Two Pokémon."
+		en: "Heal 60 damage from 1 of your Stage 2 Pokémon."
 	},
 
 	trainerType: "Supporter"

--- a/data/Pokémon TCG Pocket/Celestial Guardians/158.ts
+++ b/data/Pokémon TCG Pocket/Celestial Guardians/158.ts
@@ -29,7 +29,7 @@ const card: Card = {
 			en: "Three Kick Combo"
 		},
 
-		damage: 50,
+		damage: "50x",
 		cost: ["Grass"],
 
 		effect: {

--- a/data/Pokémon TCG Pocket/Celestial Guardians/160.ts
+++ b/data/Pokémon TCG Pocket/Celestial Guardians/160.ts
@@ -29,7 +29,7 @@ const card: Card = {
 			en: "Burning Bonemerang"
 		},
 
-		damage: 70,
+		damage: "70x",
 		cost: ["Fire", "Fire", "Colorless"],
 
 		effect: {

--- a/data/Pokémon TCG Pocket/Celestial Guardians/161.ts
+++ b/data/Pokémon TCG Pocket/Celestial Guardians/161.ts
@@ -29,7 +29,7 @@ const card: Card = {
 		cost: ["Fire", "Fire", "Colorless"],
 
 		effect: {
-			en: "Discard a  Energy from this Pokémon."
+			en: "Discard a Fire Energy from this Pokémon."
 		}
 	}],
 

--- a/data/Pokémon TCG Pocket/Celestial Guardians/162.ts
+++ b/data/Pokémon TCG Pocket/Celestial Guardians/162.ts
@@ -28,7 +28,7 @@ const card: Card = {
 		cost: ["Water"],
 
 		effect: {
-			en: "Take a  Energy from your Energy Zone and attach it to this Pokémon."
+			en: "Take a Water Energy from your Energy Zone and attach it to this Pokémon."
 		}
 	}],
 

--- a/data/Pokémon TCG Pocket/Celestial Guardians/166.ts
+++ b/data/Pokémon TCG Pocket/Celestial Guardians/166.ts
@@ -29,7 +29,7 @@ const card: Card = {
 		cost: ["Lightning", "Lightning", "Lightning"],
 
 		effect: {
-			en: "Switch this Pokémon with 1 of your Benched  Pokémon."
+			en: "Switch this Pokémon with 1 of your Benched Lightning Pokémon."
 		}
 	}],
 

--- a/data/Pokémon TCG Pocket/Celestial Guardians/168.ts
+++ b/data/Pokémon TCG Pocket/Celestial Guardians/168.ts
@@ -28,7 +28,7 @@ const card: Card = {
 		},
 
 		effect: {
-			en: "Each of your Pokémon that has any  Energy attached recovers from all Special Conditions and can't be affected by any Special Conditions."
+			en: "Each of your Pokémon that has any Psychic Energy attached recovers from all Special Conditions and can't be affected by any Special Conditions."
 		}
 	}],
 

--- a/data/Pokémon TCG Pocket/Celestial Guardians/175.ts
+++ b/data/Pokémon TCG Pocket/Celestial Guardians/175.ts
@@ -25,7 +25,7 @@ const card: Card = {
 			en: "Silver Cannon"
 		},
 
-		damage: 40,
+		damage: "40+",
 		cost: ["Metal", "Metal"],
 
 		effect: {

--- a/data/Pokémon TCG Pocket/Celestial Guardians/176.ts
+++ b/data/Pokémon TCG Pocket/Celestial Guardians/176.ts
@@ -33,11 +33,6 @@ const card: Card = {
 		}
 	}],
 
-	weaknesses: [{
-		type: "Colorless",
-		value: "+20"
-	}],
-
 	retreat: 2
 }
 

--- a/data/Pokémon TCG Pocket/Celestial Guardians/176.ts
+++ b/data/Pokémon TCG Pocket/Celestial Guardians/176.ts
@@ -25,7 +25,7 @@ const card: Card = {
 			en: "Berserk"
 		},
 
-		damage: 20,
+		damage: "20+",
 		cost: ["Colorless", "Colorless"],
 
 		effect: {

--- a/data/Pokémon TCG Pocket/Celestial Guardians/184.ts
+++ b/data/Pokémon TCG Pocket/Celestial Guardians/184.ts
@@ -21,7 +21,7 @@ const card: Card = {
 			en: "School Storm"
 		},
 
-		damage: 30,
+		damage: "30+",
 		cost: ["Water", "Water", "Water"],
 
 		effect: {

--- a/data/Pokémon TCG Pocket/Celestial Guardians/185.ts
+++ b/data/Pokémon TCG Pocket/Celestial Guardians/185.ts
@@ -26,7 +26,7 @@ const card: Card = {
 			en: "Psychic"
 		},
 
-		damage: 60,
+		damage: "60+",
 		cost: ["Colorless", "Colorless", "Colorless"],
 
 		effect: {

--- a/data/Pokémon TCG Pocket/Celestial Guardians/186.ts
+++ b/data/Pokémon TCG Pocket/Celestial Guardians/186.ts
@@ -29,7 +29,7 @@ const card: Card = {
 		},
 
 		effect: {
-			en: "Once during your turn, you may move all  Energy from 1 of your Benched  Pokémon to your Active Pokémon."
+			en: "Once during your turn, you may move all Psychic Energy from 1 of your Benched Psychic Pokémon to your Active Pokémon."
 		}
 	}],
 

--- a/data/Pokémon TCG Pocket/Celestial Guardians/187.ts
+++ b/data/Pokémon TCG Pocket/Celestial Guardians/187.ts
@@ -24,7 +24,7 @@ const card: Card = {
 		},
 
 		effect: {
-			en: "If this Pokémon is in the Active Spot and is Knocked Out by damage from an attack from your opponent's Pokémon, move all  Energy from this Pokémon to 1 of your Benched Pokémon."
+			en: "If this Pokémon is in the Active Spot and is Knocked Out by damage from an attack from your opponent's Pokémon, move all Fighting Energy from this Pokémon to 1 of your Benched Pokémon."
 		}
 	}],
 

--- a/data/Pokémon TCG Pocket/Celestial Guardians/191.ts
+++ b/data/Pokémon TCG Pocket/Celestial Guardians/191.ts
@@ -13,7 +13,7 @@ const card: Card = {
 	category: "Trainer",
 
 	effect: {
-		en: "Put 1 of your  Pokémon that has damage on it into your hand."
+		en: "Put 1 of your Colorless Pokémon that has damage on it into your hand."
 	},
 
 	trainerType: "Supporter"

--- a/data/Pokémon TCG Pocket/Celestial Guardians/192.ts
+++ b/data/Pokémon TCG Pocket/Celestial Guardians/192.ts
@@ -13,7 +13,7 @@ const card: Card = {
 	category: "Trainer",
 
 	effect: {
-		en: "Choose 1 of your Alolan Marowak or Turtonator. Take 2  Energy from your Energy Zone and attach it to that Pokémon. Your turn ends."
+		en: "Choose 1 of your Alolan Marowak or Turtonator. Take 2 Fire Energy from your Energy Zone and attach it to that Pokémon. Your turn ends."
 	},
 
 	trainerType: "Supporter"

--- a/data/Pokémon TCG Pocket/Celestial Guardians/197.ts
+++ b/data/Pokémon TCG Pocket/Celestial Guardians/197.ts
@@ -13,7 +13,7 @@ const card: Card = {
 	category: "Trainer",
 
 	effect: {
-		en: "Heal 60 damage from 1 of your Two Pokémon."
+		en: "Heal 60 damage from 1 of your Stage 2 Pokémon."
 	},
 
 	trainerType: "Supporter"

--- a/data/Pokémon TCG Pocket/Celestial Guardians/202.ts
+++ b/data/Pokémon TCG Pocket/Celestial Guardians/202.ts
@@ -21,7 +21,7 @@ const card: Card = {
 			en: "School Storm"
 		},
 
-		damage: 30,
+		damage: "30+",
 		cost: ["Water", "Water", "Water"],
 
 		effect: {

--- a/data/Pokémon TCG Pocket/Celestial Guardians/203.ts
+++ b/data/Pokémon TCG Pocket/Celestial Guardians/203.ts
@@ -26,7 +26,7 @@ const card: Card = {
 			en: "Psychic"
 		},
 
-		damage: 60,
+		damage: "60+",
 		cost: ["Colorless", "Colorless", "Colorless"],
 
 		effect: {

--- a/data/Pokémon TCG Pocket/Celestial Guardians/204.ts
+++ b/data/Pokémon TCG Pocket/Celestial Guardians/204.ts
@@ -29,7 +29,7 @@ const card: Card = {
 		},
 
 		effect: {
-			en: "Once during your turn, you may move all  Energy from 1 of your Benched  Pokémon to your Active Pokémon."
+			en: "Once during your turn, you may move all Psychic Energy from 1 of your Benched Psychic Pokémon to your Active Pokémon."
 		}
 	}],
 

--- a/data/Pokémon TCG Pocket/Celestial Guardians/205.ts
+++ b/data/Pokémon TCG Pocket/Celestial Guardians/205.ts
@@ -24,7 +24,7 @@ const card: Card = {
 		},
 
 		effect: {
-			en: "If this Pokémon is in the Active Spot and is Knocked Out by damage from an attack from your opponent's Pokémon, move all  Energy from this Pokémon to 1 of your Benched Pokémon."
+			en: "If this Pokémon is in the Active Spot and is Knocked Out by damage from an attack from your opponent's Pokémon, move all Fighting Energy from this Pokémon to 1 of your Benched Pokémon."
 		}
 	}],
 

--- a/data/Pokémon TCG Pocket/Celestial Guardians/209.ts
+++ b/data/Pokémon TCG Pocket/Celestial Guardians/209.ts
@@ -13,7 +13,7 @@ const card: Card = {
 	category: "Trainer",
 
 	effect: {
-		en: "Heal 60 damage from 1 of your Two Pokémon."
+		en: "Heal 60 damage from 1 of your Stage 2 Pokémon."
 	},
 
 	trainerType: "Supporter"

--- a/data/Pokémon TCG Pocket/Celestial Guardians/214.ts
+++ b/data/Pokémon TCG Pocket/Celestial Guardians/214.ts
@@ -29,7 +29,7 @@ const card: Card = {
 			en: "Psychic"
 		},
 
-		damage: 80,
+		damage: "80+",
 		cost: ["Grass", "Colorless", "Colorless", "Colorless"],
 
 		effect: {

--- a/data/Pokémon TCG Pocket/Celestial Guardians/225.ts
+++ b/data/Pokémon TCG Pocket/Celestial Guardians/225.ts
@@ -33,7 +33,7 @@ const card: Card = {
 		cost: ["Fighting", "Fighting"],
 
 		effect: {
-			en: "If this Pokémon has at least 2 extra  Energy attached, this attack does 50 more damage."
+			en: "If this Pokémon has at least 2 extra Fighting Energy attached, this attack does 50 more damage."
 		}
 	}],
 

--- a/data/Pokémon TCG Pocket/Celestial Guardians/225.ts
+++ b/data/Pokémon TCG Pocket/Celestial Guardians/225.ts
@@ -29,7 +29,7 @@ const card: Card = {
 			en: "Power Press"
 		},
 
-		damage: 70,
+		damage: "70+",
 		cost: ["Fighting", "Fighting"],
 
 		effect: {

--- a/data/Pokémon TCG Pocket/Celestial Guardians/231.ts
+++ b/data/Pokémon TCG Pocket/Celestial Guardians/231.ts
@@ -26,7 +26,7 @@ const card: Card = {
 			en: "Tropical Swing"
 		},
 
-		damage: 40,
+		damage: "40+",
 		cost: ["Grass"],
 
 		effect: {

--- a/data/Pokémon TCG Pocket/Celestial Guardians/232.ts
+++ b/data/Pokémon TCG Pocket/Celestial Guardians/232.ts
@@ -33,7 +33,7 @@ const card: Card = {
 			en: "Hydro Bazooka"
 		},
 
-		damage: 100,
+		damage: "100+",
 		cost: ["Water", "Water", "Colorless"],
 
 		effect: {

--- a/data/Pokémon TCG Pocket/Celestial Guardians/232.ts
+++ b/data/Pokémon TCG Pocket/Celestial Guardians/232.ts
@@ -37,7 +37,7 @@ const card: Card = {
 		cost: ["Water", "Water", "Colorless"],
 
 		effect: {
-			en: "If this Pokémon has at least 2 extra  Energy attached, this attack does 60 more damage."
+			en: "If this Pokémon has at least 2 extra Water Energy attached, this attack does 60 more damage."
 		}
 	}],
 

--- a/data/Pokémon TCG Pocket/Celestial Guardians/236.ts
+++ b/data/Pokémon TCG Pocket/Celestial Guardians/236.ts
@@ -26,7 +26,7 @@ const card: Card = {
 			en: "Bonemerang"
 		},
 
-		damage: 80,
+		damage: "80x",
 		cost: ["Fighting", "Fighting"],
 
 		effect: {

--- a/data/Pokémon TCG Pocket/Celestial Guardians/238.ts
+++ b/data/Pokémon TCG Pocket/Celestial Guardians/238.ts
@@ -29,7 +29,7 @@ const card: Card = {
 		},
 
 		effect: {
-			en: "Once during your turn, you may move all  Energy from 1 of your Benched  Pokémon to your Active Pokémon."
+			en: "Once during your turn, you may move all Psychic Energy from 1 of your Benched Psychic Pokémon to your Active Pokémon."
 		}
 	}],
 


### PR DESCRIPTION
Make the following data fixes for new Celestial Guardians set:
* Add missing + and x symbols for attacks with additional or multiplied damage
* Add missing energy symbols which were stripped from effect text
* Correct Lillie to mention "Stage 2 Pokémon" instead of "Two Pokémon"
* Remove incorrect Colorless weakness from Dragons