### PR TITLE
Updating rarity values for PTCGP

### DIFF
--- a/data/Pokémon TCG Pocket/Genetic Apex/265.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/265.ts
@@ -59,7 +59,7 @@ const card: Card = {
 	}],
 
 	retreat: 2,
-	rarity: "None",
+	rarity: "Two Star",
 	boosters: ["pikachu"]
 }
 

--- a/data/Pokémon TCG Pocket/Genetic Apex/279.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/279.ts
@@ -59,7 +59,7 @@ const card: Card = {
 	}],
 
 	retreat: 2,
-	rarity: "None",
+	rarity: "Two Star",
 	boosters: ["pikachu"]
 }
 

--- a/data/Pokémon TCG Pocket/Promos-A/001.ts
+++ b/data/Pokémon TCG Pocket/Promos-A/001.ts
@@ -15,7 +15,7 @@ const card: Card = {
 	},
 
 	illustrator: "5ban Graphics",
-	rarity: "None",
+	rarity: "One Diamond",
 	category: "Trainer",
 
 	effect: {

--- a/data/Pokémon TCG Pocket/Promos-A/002.ts
+++ b/data/Pokémon TCG Pocket/Promos-A/002.ts
@@ -15,7 +15,7 @@ const card: Card = {
 	},
 
 	illustrator: "Toyste Beach",
-	rarity: "None",
+	rarity: "One Diamond",
 	category: "Trainer",
 
 	effect: {

--- a/data/Pokémon TCG Pocket/Promos-A/003.ts
+++ b/data/Pokémon TCG Pocket/Promos-A/003.ts
@@ -15,7 +15,7 @@ const card: Card = {
 	},
 
 	illustrator: "Toyste Beach",
-	rarity: "None",
+	rarity: "One Diamond",
 	category: "Trainer",
 
 	effect: {

--- a/data/Pokémon TCG Pocket/Promos-A/004.ts
+++ b/data/Pokémon TCG Pocket/Promos-A/004.ts
@@ -15,7 +15,7 @@ const card: Card = {
 	},
 
 	illustrator: "Ryo Ueda",
-	rarity: "None",
+	rarity: "One Diamond",
 	category: "Trainer",
 
 	effect: {

--- a/data/Pokémon TCG Pocket/Promos-A/005.ts
+++ b/data/Pokémon TCG Pocket/Promos-A/005.ts
@@ -15,7 +15,7 @@ const card: Card = {
 	},
 
 	illustrator: "Ryo Ueda",
-	rarity: "None",
+	rarity: "One Diamond",
 	category: "Trainer",
 
 	effect: {

--- a/data/Pokémon TCG Pocket/Promos-A/006.ts
+++ b/data/Pokémon TCG Pocket/Promos-A/006.ts
@@ -15,7 +15,7 @@ const card: Card = {
 	},
 
 	illustrator: "5ban Graphics",
-	rarity: "None",
+	rarity: "One Diamond",
 	category: "Trainer",
 
 	effect: {

--- a/data/Pokémon TCG Pocket/Promos-A/007.ts
+++ b/data/Pokémon TCG Pocket/Promos-A/007.ts
@@ -15,7 +15,7 @@ const card: Card = {
 	},
 
 	illustrator: "Naoki Saito",
-	rarity: "None",
+	rarity: "One Diamond",
 	category: "Trainer",
 
 	effect: {

--- a/data/Pokémon TCG Pocket/Promos-A/008.ts
+++ b/data/Pokémon TCG Pocket/Promos-A/008.ts
@@ -15,7 +15,7 @@ const card: Card = {
 	},
 
 	illustrator: "Yuu Nishida",
-	rarity: "None",
+	rarity: "One Diamond",
 	category: "Trainer",
 
 	effect: {

--- a/data/Pokémon TCG Pocket/Promos-A/009.ts
+++ b/data/Pokémon TCG Pocket/Promos-A/009.ts
@@ -15,7 +15,7 @@ const card: Card = {
 	},
 
 	illustrator: "Atsushi Furusawa",
-	rarity: "None",
+	rarity: "One Star",
 	category: "Pokemon",
 	types: ["Lightning"],
 	stage: "Basic",

--- a/data/Pokémon TCG Pocket/Promos-A/010.ts
+++ b/data/Pokémon TCG Pocket/Promos-A/010.ts
@@ -15,7 +15,7 @@ const card: Card = {
 	},
 
 	illustrator: "Krgc",
-	rarity: "None",
+	rarity: "One Star",
 	category: "Pokemon",
 	types: ["Psychic"],
 	stage: "Basic",

--- a/data/Pokémon TCG Pocket/Promos-A/011.ts
+++ b/data/Pokémon TCG Pocket/Promos-A/011.ts
@@ -15,7 +15,7 @@ const card: Card = {
 	},
 
 	illustrator: "sowsow",
-	rarity: "None",
+	rarity: "Three Diamond",
 	category: "Pokemon",
 	types: ["Colorless"],
 	stage: "Basic",

--- a/data/Pokémon TCG Pocket/Promos-A/012.ts
+++ b/data/Pokémon TCG Pocket/Promos-A/012.ts
@@ -15,7 +15,7 @@ const card: Card = {
 	},
 
 	illustrator: "Shigenori Negishi",
-	rarity: "None",
+	rarity: "Three Diamond",
 	category: "Pokemon",
 	types: ["Colorless"],
 	stage: "Basic",

--- a/data/Pokémon TCG Pocket/Promos-A/013.ts
+++ b/data/Pokémon TCG Pocket/Promos-A/013.ts
@@ -15,7 +15,7 @@ const card: Card = {
 	},
 
 	illustrator: "miki kudo",
-	rarity: "None",
+	rarity: "Three Diamond",
 	category: "Pokemon",
 	types: ["Grass"],
 	stage: "Stage2",

--- a/data/Pokémon TCG Pocket/Promos-A/014.ts
+++ b/data/Pokémon TCG Pocket/Promos-A/014.ts
@@ -15,7 +15,7 @@ const card: Card = {
 	},
 
 	illustrator: "PLANETA CG Works",
-	rarity: "None",
+	rarity: "Four Diamond",
 	category: "Pokemon",
 	types: ["Water"],
 	stage: "Basic",

--- a/data/Pokémon TCG Pocket/Promos-A/015.ts
+++ b/data/Pokémon TCG Pocket/Promos-A/015.ts
@@ -15,7 +15,7 @@ const card: Card = {
 	},
 
 	illustrator: "Kouki Saitou",
-	rarity: "None",
+	rarity: "One Diamond",
 	category: "Pokemon",
 	types: ["Lightning"],
 	stage: "Basic",

--- a/data/Pokémon TCG Pocket/Promos-A/016.ts
+++ b/data/Pokémon TCG Pocket/Promos-A/016.ts
@@ -15,7 +15,7 @@ const card: Card = {
 	},
 
 	illustrator: "Shibuzoh.",
-	rarity: "None",
+	rarity: "One Diamond",
 	category: "Pokemon",
 	types: ["Psychic"],
 	stage: "Basic",

--- a/data/Pokémon TCG Pocket/Promos-A/017.ts
+++ b/data/Pokémon TCG Pocket/Promos-A/017.ts
@@ -15,7 +15,7 @@ const card: Card = {
 	},
 
 	illustrator: "Souichirou Gunjima",
-	rarity: "None",
+	rarity: "One Diamond",
 	category: "Pokemon",
 	types: ["Fighting"],
 	stage: "Basic",

--- a/data/Pokémon TCG Pocket/Promos-A/018.ts
+++ b/data/Pokémon TCG Pocket/Promos-A/018.ts
@@ -15,7 +15,7 @@ const card: Card = {
 	},
 
 	illustrator: "Kuroimori",
-	rarity: "None",
+	rarity: "One Star",
 	category: "Pokemon",
 	types: ["Grass"],
 	stage: "Stage2",

--- a/data/Pokémon TCG Pocket/Promos-A/019.ts
+++ b/data/Pokémon TCG Pocket/Promos-A/019.ts
@@ -15,7 +15,7 @@ const card: Card = {
 	},
 
 	illustrator: "Sanosuke Sakuma",
-	rarity: "None",
+	rarity: "Three Diamond",
 	category: "Pokemon",
 	types: ["Water"],
 	stage: "Stage2",

--- a/data/Pokémon TCG Pocket/Promos-A/020.ts
+++ b/data/Pokémon TCG Pocket/Promos-A/020.ts
@@ -15,7 +15,7 @@ const card: Card = {
 	},
 
 	illustrator: "Mékayu",
-	rarity: "None",
+	rarity: "One Diamond",
 	category: "Pokemon",
 	types: ["Psychic"],
 	stage: "Stage1",

--- a/data/Pokémon TCG Pocket/Promos-A/021.ts
+++ b/data/Pokémon TCG Pocket/Promos-A/021.ts
@@ -15,7 +15,7 @@ const card: Card = {
 	},
 
 	illustrator: "Tomokazu Komiya",
-	rarity: "None",
+	rarity: "One Diamond",
 	category: "Pokemon",
 	types: ["Fighting"],
 	stage: "Basic",

--- a/data/Pokémon TCG Pocket/Promos-A/022.ts
+++ b/data/Pokémon TCG Pocket/Promos-A/022.ts
@@ -15,7 +15,7 @@ const card: Card = {
 	},
 
 	illustrator: "Kurata So",
-	rarity: "None",
+	rarity: "One Diamond",
 	category: "Pokemon",
 	types: ["Colorless"],
 	stage: "Basic",

--- a/data/Pokémon TCG Pocket/Promos-A/023.ts
+++ b/data/Pokémon TCG Pocket/Promos-A/023.ts
@@ -15,7 +15,7 @@ const card: Card = {
 	},
 
 	illustrator: "Kouki Saitou",
-	rarity: "None",
+	rarity: "Three Diamond",
 	category: "Pokemon",
 	types: ["Grass"],
 	stage: "Basic",

--- a/data/Pokémon TCG Pocket/Promos-A/024.ts
+++ b/data/Pokémon TCG Pocket/Promos-A/024.ts
@@ -15,7 +15,7 @@ const card: Card = {
 	},
 
 	illustrator: "Miki Tanaka",
-	rarity: "None",
+	rarity: "Three Diamond",
 	category: "Pokemon",
 	types: ["Lightning"],
 	stage: "Basic",

--- a/data/Pokémon TCG Pocket/Promos-A/025.ts
+++ b/data/Pokémon TCG Pocket/Promos-A/025.ts
@@ -15,7 +15,7 @@ const card: Card = {
 	},
 
 	illustrator: "PLANETA Igarashi",
-	rarity: "None",
+	rarity: "Four Diamond",
 	category: "Pokemon",
 	hp: 140,
 	types: ["Fire"],

--- a/data/Pokémon TCG Pocket/Promos-A/026.ts
+++ b/data/Pokémon TCG Pocket/Promos-A/026.ts
@@ -15,7 +15,7 @@ const card: Card = {
 	},
 
 	illustrator: "Kouki Saitou",
-	rarity: "None",
+	rarity: "One Star",
 	category: "Pokemon",
 	hp: 60,
 	types: ["Lightning"],

--- a/data/Pokémon TCG Pocket/Promos-A/027.ts
+++ b/data/Pokémon TCG Pocket/Promos-A/027.ts
@@ -15,7 +15,7 @@ const card: Card = {
 	},
 
 	illustrator: "Yoriyuki Ikegami",
-	rarity: "None",
+	rarity: "One Diamond",
 	category: "Pokemon",
 	hp: 60,
 	types: ["Grass"],

--- a/data/Pokémon TCG Pocket/Promos-A/028.ts
+++ b/data/Pokémon TCG Pocket/Promos-A/028.ts
@@ -15,7 +15,7 @@ const card: Card = {
 	},
 
 	illustrator: "Shin Nagasawa",
-	rarity: "None",
+	rarity: "Three Diamond",
 	category: "Pokemon",
 	hp: 120,
 	types: ["Fire"],

--- a/data/Pokémon TCG Pocket/Promos-A/029.ts
+++ b/data/Pokémon TCG Pocket/Promos-A/029.ts
@@ -14,7 +14,7 @@ const card: Card = {
 	},
 
 	illustrator: "danciao",
-	rarity: "None",
+	rarity: "One Star",
 	category: "Pokemon",
 	hp: 150,
 	types: ["Water"],

--- a/data/Pokémon TCG Pocket/Promos-A/030.ts
+++ b/data/Pokémon TCG Pocket/Promos-A/030.ts
@@ -15,7 +15,7 @@ const card: Card = {
 	},
 
 	illustrator: "En Morikura",
-	rarity: "None",
+	rarity: "One Diamond",
 	category: "Pokemon",
 	hp: 60,
 	types: ["Colorless"],

--- a/data/Pokémon TCG Pocket/Promos-A/031.ts
+++ b/data/Pokémon TCG Pocket/Promos-A/031.ts
@@ -15,7 +15,7 @@ const card: Card = {
 	},
 
 	illustrator: "MAHOU",
-	rarity: "None",
+	rarity: "One Diamond",
 	category: "Pokemon",
 	hp: 90,
 	types: ["Colorless"],

--- a/data/Pokémon TCG Pocket/Promos-A/032.ts
+++ b/data/Pokémon TCG Pocket/Promos-A/032.ts
@@ -14,7 +14,7 @@ const card: Card = {
 	},
 
 	illustrator: "Naoyo Kimura",
-	rarity: "None",
+	rarity: "Three Diamond",
 	category: "Pokemon",
 	hp: 60,
 	types: ["Fire"],

--- a/data/Pokémon TCG Pocket/Promos-A/033.ts
+++ b/data/Pokémon TCG Pocket/Promos-A/033.ts
@@ -15,7 +15,7 @@ const card: Card = {
 	},
 
 	illustrator: "Kanako Eo",
-	rarity: "None",
+	rarity: "Three Diamond",
 	category: "Pokemon",
 	hp: 60,
 	types: ["Water"],

--- a/data/Pokémon TCG Pocket/Promos-A/034.ts
+++ b/data/Pokémon TCG Pocket/Promos-A/034.ts
@@ -15,7 +15,7 @@ const card: Card = {
 	},
 
 	illustrator: "Kariya",
-	rarity: "None",
+	rarity: "One Star",
 	category: "Pokemon",
 	hp: 60,
 	types: ["Water"],

--- a/data/Pokémon TCG Pocket/Promos-A/035.ts
+++ b/data/Pokémon TCG Pocket/Promos-A/035.ts
@@ -15,7 +15,7 @@ const card: Card = {
 	},
 
 	illustrator: "Atsuko Nishida",
-	rarity: "None",
+	rarity: "One Diamond",
 	category: "Pokemon",
 	hp: 80,
 	types: ["Grass"],

--- a/data/Pokémon TCG Pocket/Promos-A/036.ts
+++ b/data/Pokémon TCG Pocket/Promos-A/036.ts
@@ -14,7 +14,7 @@ const card: Card = {
 	},
 
 	illustrator: "Sumiyoshi Kizuki",
-	rarity: "None",
+	rarity: "Three Diamond",
 	category: "Pokemon",
 	hp: 120,
 	types: ["Lightning"],

--- a/data/Pokémon TCG Pocket/Promos-A/037.ts
+++ b/data/Pokémon TCG Pocket/Promos-A/037.ts
@@ -15,7 +15,7 @@ const card: Card = {
 	},
 
 	illustrator: "PLANETA Mochizuki",
-	rarity: "None",
+	rarity: "Four Diamond",
 	category: "Pokemon",
 	hp: 140,
 	types: ["Psychic"],

--- a/data/Pokémon TCG Pocket/Promos-A/038.ts
+++ b/data/Pokémon TCG Pocket/Promos-A/038.ts
@@ -15,7 +15,7 @@ const card: Card = {
 	},
 
 	illustrator: "Miki Tanaka",
-	rarity: "None",
+	rarity: "One Diamond",
 	category: "Pokemon",
 	hp: 60,
 	types: ["Psychic"],

--- a/data/Pokémon TCG Pocket/Promos-A/039.ts
+++ b/data/Pokémon TCG Pocket/Promos-A/039.ts
@@ -15,7 +15,7 @@ const card: Card = {
 	},
 
 	illustrator: "Anesaki Dynamic",
-	rarity: "None",
+	rarity: "One Diamond",
 	category: "Pokemon",
 	hp: 80,
 	types: ["Metal"],

--- a/data/Pokémon TCG Pocket/Promos-A/040.ts
+++ b/data/Pokémon TCG Pocket/Promos-A/040.ts
@@ -15,7 +15,7 @@ const card: Card = {
 	},
 
 	illustrator: "sui",
-	rarity: "None",
+	rarity: "Three Diamond",
 	category: "Pokemon",
 	hp: 60,
 	types: ["Fire"],

--- a/data/Pokémon TCG Pocket/Promos-A/041.ts
+++ b/data/Pokémon TCG Pocket/Promos-A/041.ts
@@ -15,7 +15,7 @@ const card: Card = {
 	},
 
 	illustrator: "Naoyo Kimura",
-	rarity: "None",
+	rarity: "Three Diamond",
 	category: "Pokemon",
 	hp: 50,
 	types: ["Psychic"],

--- a/data/Pokémon TCG Pocket/Promos-A/042.ts
+++ b/data/Pokémon TCG Pocket/Promos-A/042.ts
@@ -15,7 +15,7 @@ const card: Card = {
 	},
 
 	illustrator: "PLANETA Mochizuki",
-	rarity: "None",
+	rarity: "Four Diamond",
 	category: "Pokemon",
 	hp: 140,
 	types: ["Darkness"],

--- a/data/Pokémon TCG Pocket/Promos-A/043.ts
+++ b/data/Pokémon TCG Pocket/Promos-A/043.ts
@@ -15,7 +15,7 @@ const card: Card = {
 	},
 
 	illustrator: "MAHOU",
-	rarity: "None",
+	rarity: "One Diamond",
 	category: "Pokemon",
 	hp: 80,
 	types: ["Grass"],

--- a/data/Pokémon TCG Pocket/Promos-A/044.ts
+++ b/data/Pokémon TCG Pocket/Promos-A/044.ts
@@ -15,7 +15,7 @@ const card: Card = {
 	},
 
 	illustrator: "Kazumasa Yasukuni",
-	rarity: "None",
+	rarity: "Three Diamond",
 	category: "Pokemon",
 	hp: 90,
 	types: ["Lightning"],

--- a/data/Pokémon TCG Pocket/Promos-A/045.ts
+++ b/data/Pokémon TCG Pocket/Promos-A/045.ts
@@ -15,7 +15,7 @@ const card: Card = {
 	},
 
 	illustrator: "Tomokazu Komiya",
-	rarity: "None",
+	rarity: "One Diamond",
 	category: "Pokemon",
 	hp: 60,
 	types: ["Fighting"],

--- a/data/Pokémon TCG Pocket/Promos-A/046.ts
+++ b/data/Pokémon TCG Pocket/Promos-A/046.ts
@@ -15,7 +15,7 @@ const card: Card = {
 	},
 
 	illustrator: "Uninori",
-	rarity: "None",
+	rarity: "One Star",
 	category: "Pokemon",
 	hp: 60,
 	types: ["Fighting"],

--- a/data/Pokémon TCG Pocket/Promos-A/047.ts
+++ b/data/Pokémon TCG Pocket/Promos-A/047.ts
@@ -14,7 +14,7 @@ const card: Card = {
 	},
 
 	illustrator: "Hasuno",
-	rarity: "None",
+	rarity: "One Diamond",
 	category: "Pokemon",
 	hp: 140,
 	types: ["Colorless"],

--- a/data/Pokémon TCG Pocket/Promos-A/048.ts
+++ b/data/Pokémon TCG Pocket/Promos-A/048.ts
@@ -15,7 +15,7 @@ const card: Card = {
 	},
 
 	illustrator: "sui",
-	rarity: "None",
+	rarity: "Three Diamond",
 	category: "Pokemon",
 	hp: 50,
 	types: ["Water"],

--- a/data/Pokémon TCG Pocket/Promos-A/049.ts
+++ b/data/Pokémon TCG Pocket/Promos-A/049.ts
@@ -15,7 +15,7 @@ const card: Card = {
 	},
 
 	illustrator: "okayamatakatoshi",
-	rarity: "None",
+	rarity: "Three Diamond",
 	category: "Pokemon",
 	hp: 140,
 	types: ["Colorless"],

--- a/data/Pokémon TCG Pocket/Promos-A/050.ts
+++ b/data/Pokémon TCG Pocket/Promos-A/050.ts
@@ -15,7 +15,7 @@ const card: Card = {
 	},
 
 	illustrator: "PLANETA Mochizuki",
-	rarity: "None",
+	rarity: "Two Shiny",
 	category: "Pokemon",
 	hp: 150,
 	types: ["Psychic"],

--- a/data/Pokémon TCG Pocket/Promos-A/051.ts
+++ b/data/Pokémon TCG Pocket/Promos-A/051.ts
@@ -15,7 +15,7 @@ const card: Card = {
 	},
 
 	illustrator: "Shigenori Negishi",
-	rarity: "None",
+	rarity: "One Shiny",
 	category: "Pokemon",
 	hp: 80,
 	types: ["Colorless"],

--- a/data/Pokémon TCG Pocket/Promos-A/052.ts
+++ b/data/Pokémon TCG Pocket/Promos-A/052.ts
@@ -15,7 +15,7 @@ const card: Card = {
 	},
 
 	illustrator: "MINAMINAMI Take",
-	rarity: "None",
+	rarity: "One Star",
 	category: "Pokemon",
 	hp: 60,
 	types: ["Grass"],

--- a/data/Pokémon TCG Pocket/Promos-A/053.ts
+++ b/data/Pokémon TCG Pocket/Promos-A/053.ts
@@ -15,7 +15,7 @@ const card: Card = {
 	},
 
 	illustrator: "Shin Nagasawa",
-	rarity: "None",
+	rarity: "One Diamond",
 	category: "Pokemon",
 	hp: 100,
 	types: ["Water"],

--- a/data/Pokémon TCG Pocket/Promos-A/054.ts
+++ b/data/Pokémon TCG Pocket/Promos-A/054.ts
@@ -15,7 +15,7 @@ const card: Card = {
 	},
 
 	illustrator: "REND",
-	rarity: "None",
+	rarity: "One Star",
 	category: "Pokemon",
 	hp: 140,
 	types: ["Lightning"],

--- a/data/Pokémon TCG Pocket/Promos-A/055.ts
+++ b/data/Pokémon TCG Pocket/Promos-A/055.ts
@@ -15,7 +15,7 @@ const card: Card = {
 	},
 
 	illustrator: "Masakazu Fukuda",
-	rarity: "None",
+	rarity: "Three Diamond",
 	category: "Pokemon",
 	hp: 150,
 	types: ["Fighting"],

--- a/data/Pokémon TCG Pocket/Promos-A/056.ts
+++ b/data/Pokémon TCG Pocket/Promos-A/056.ts
@@ -15,7 +15,7 @@ const card: Card = {
 	},
 
 	illustrator: "Krgc",
-	rarity: "None",
+	rarity: "One Diamond",
 	category: "Pokemon",
 	hp: 60,
 	types: ["Darkness"],

--- a/data/Pokémon TCG Pocket/Promos-A/057.ts
+++ b/data/Pokémon TCG Pocket/Promos-A/057.ts
@@ -15,7 +15,7 @@ const card: Card = {
 	},
 
 	illustrator: "Kouki Saitou",
-	rarity: "None",
+	rarity: "One Diamond",
 	category: "Pokemon",
 	hp: 70,
 	types: ["Colorless"],

--- a/data/Pokémon TCG Pocket/Promos-A/058.ts
+++ b/data/Pokémon TCG Pocket/Promos-A/058.ts
@@ -15,7 +15,7 @@ const card: Card = {
 	},
 
 	illustrator: "OOYAMA",
-	rarity: "None",
+	rarity: "Three Diamond",
 	category: "Pokemon",
 	hp: 70,
 	types: ["Lightning"],

--- a/data/Pokémon TCG Pocket/Promos-A/059.ts
+++ b/data/Pokémon TCG Pocket/Promos-A/059.ts
@@ -15,7 +15,7 @@ const card: Card = {
 	},
 
 	illustrator: "Akira Komayama",
-	rarity: "None",
+	rarity: "Three Diamond",
 	category: "Pokemon",
 	hp: 70,
 	types: ["Fighting"],


### PR DESCRIPTION
Most of these updates are to promo cards. You can derive the rarity of a promo card by looking at the Shinedust cost to get its first flair.