### PR TITLE
WIP:FIX: Compiler returning incorrect sets for series without a "EN" version

### DIFF
--- a/.bruno/bruno.json
+++ b/.bruno/bruno.json
@@ -3,11 +3,6 @@
   "name": "TCGdex",
   "type": "collection",
   "presets": {
-    "requestType": "http",
-    "requestUrl": "127.0.0.1:3000"
-  },
-  "ignore": [
-    "node_modules",
-    ".git"
-  ]
+    "requestType": "http"
+  }
 }

--- a/.bruno/bruno.json
+++ b/.bruno/bruno.json
@@ -3,6 +3,11 @@
   "name": "TCGdex",
   "type": "collection",
   "presets": {
-    "requestType": "http"
-  }
+    "requestType": "http",
+    "requestUrl": "127.0.0.1:3000"
+  },
+  "ignore": [
+    "node_modules",
+    ".git"
+  ]
 }

--- a/.editorconfig
+++ b/.editorconfig
@@ -6,6 +6,8 @@ indent_size = 4
 charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
+ij_typescript_spaces_within_imports = true
+ij_typescript_spaces_within_object_literal_braces = true
 
 [*.{yaml|yml}]
 indent_style = space

--- a/data-asia/DP/DP1a.ts
+++ b/data-asia/DP/DP1a.ts
@@ -1,5 +1,5 @@
 import { Set } from '../../interfaces'
-import serie from '../DPt'
+import serie from '../DP'
 
 const set: Set = {
 	id: 'DP1a',

--- a/data-asia/DP/DP1b.ts
+++ b/data-asia/DP/DP1b.ts
@@ -1,5 +1,5 @@
 import { Set } from '../../interfaces'
-import serie from '../DPt'
+import serie from '../DP'
 
 const set: Set = {
 	id: 'DP1b',

--- a/data-asia/DP/DP2.ts
+++ b/data-asia/DP/DP2.ts
@@ -1,5 +1,5 @@
 import { Set } from '../../interfaces'
-import serie from '../DPt'
+import serie from '../DP'
 
 const set: Set = {
 	id: 'DP2',

--- a/data-asia/DP/DP3.ts
+++ b/data-asia/DP/DP3.ts
@@ -1,5 +1,5 @@
 import { Set } from '../../interfaces'
-import serie from '../DPt'
+import serie from '../DP'
 
 const set: Set = {
 	id: 'DP3',

--- a/data-asia/DP/DP4a.ts
+++ b/data-asia/DP/DP4a.ts
@@ -1,5 +1,5 @@
 import { Set } from '../../interfaces'
-import serie from '../DPt'
+import serie from '../DP'
 
 const set: Set = {
 	id: 'DP4a',

--- a/data-asia/DP/DP4b.ts
+++ b/data-asia/DP/DP4b.ts
@@ -1,5 +1,5 @@
 import { Set } from '../../interfaces'
-import serie from '../DPt'
+import serie from '../DP'
 
 const set: Set = {
 	id: 'DP4b',

--- a/data-asia/DP/DP5a.ts
+++ b/data-asia/DP/DP5a.ts
@@ -1,5 +1,5 @@
 import { Set } from '../../interfaces'
-import serie from '../DPt'
+import serie from '../DP'
 
 const set: Set = {
 	id: 'DP5a',

--- a/data-asia/DP/DP5b.ts
+++ b/data-asia/DP/DP5b.ts
@@ -1,5 +1,5 @@
 import { Set } from '../../interfaces'
-import serie from '../DPt'
+import serie from '../DP'
 
 const set: Set = {
 	id: 'DP5b',

--- a/data-asia/DP/DP6.ts
+++ b/data-asia/DP/DP6.ts
@@ -1,5 +1,5 @@
 import { Set } from '../../interfaces'
-import serie from '../DPt'
+import serie from '../DP'
 
 const set: Set = {
 	id: 'DP6',

--- a/data/Scarlet & Violet/Destined Rivals/001.ts
+++ b/data/Scarlet & Violet/Destined Rivals/001.ts
@@ -64,8 +64,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		normal: true,
-		reverse: true
+		holo: false,
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/001.ts
+++ b/data/Scarlet & Violet/Destined Rivals/001.ts
@@ -63,10 +63,6 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "I",
 
-	variants: {
-		holo: false,
-	},
-
 	variants_detailed: [
 		{
 			type: 'normal'

--- a/data/Scarlet & Violet/Destined Rivals/001.ts
+++ b/data/Scarlet & Violet/Destined Rivals/001.ts
@@ -63,7 +63,7 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'normal'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/001.ts
+++ b/data/Scarlet & Violet/Destined Rivals/001.ts
@@ -1,4 +1,4 @@
-import { Card } from "../../../interfaces"
+import {Card} from "../../../interfaces"
 import Set from "../Destined Rivals"
 
 const card: Card = {
@@ -64,8 +64,19 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		holo: false
-	}
+		normal: true,
+		reverse: true
+	},
+
+	variants_detailed: [
+		{
+			type: 'normal'
+		},
+		{
+			type: 'reverse'
+		},
+	]
+
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/002.ts
+++ b/data/Scarlet & Violet/Destined Rivals/002.ts
@@ -62,8 +62,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		normal: true,
-		reverse: true,
+		holo: false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/002.ts
+++ b/data/Scarlet & Violet/Destined Rivals/002.ts
@@ -61,10 +61,6 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "I",
 
-	variants: {
-		holo: false
-	},
-
 	variants_detailed: [
 		{
 			type: 'normal'

--- a/data/Scarlet & Violet/Destined Rivals/002.ts
+++ b/data/Scarlet & Violet/Destined Rivals/002.ts
@@ -62,8 +62,18 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		holo: false
-	}
+		normal: true,
+		reverse: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'normal'
+		},
+		{
+			type: 'reverse'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/002.ts
+++ b/data/Scarlet & Violet/Destined Rivals/002.ts
@@ -61,7 +61,7 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'normal'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/003.ts
+++ b/data/Scarlet & Violet/Destined Rivals/003.ts
@@ -73,11 +73,6 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "I",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
-
 	variants_detailed: [
 		{
 			type: 'holo'

--- a/data/Scarlet & Violet/Destined Rivals/003.ts
+++ b/data/Scarlet & Violet/Destined Rivals/003.ts
@@ -74,7 +74,8 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		holo: true,
+		normal: false,
+		reverse: false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/003.ts
+++ b/data/Scarlet & Violet/Destined Rivals/003.ts
@@ -73,7 +73,7 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'holo'
 		}

--- a/data/Scarlet & Violet/Destined Rivals/003.ts
+++ b/data/Scarlet & Violet/Destined Rivals/003.ts
@@ -74,9 +74,14 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		reverse: false,
-		normal: false
-	}
+		holo: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'holo'
+		}
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/004.ts
+++ b/data/Scarlet & Violet/Destined Rivals/004.ts
@@ -39,7 +39,7 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'normal'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/004.ts
+++ b/data/Scarlet & Violet/Destined Rivals/004.ts
@@ -40,8 +40,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		normal: true,
-		reverse: true,
+		holo: false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/004.ts
+++ b/data/Scarlet & Violet/Destined Rivals/004.ts
@@ -39,10 +39,6 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "I",
 
-	variants: {
-		holo: false
-	},
-
 	variants_detailed: [
 		{
 			type: 'normal'

--- a/data/Scarlet & Violet/Destined Rivals/004.ts
+++ b/data/Scarlet & Violet/Destined Rivals/004.ts
@@ -40,8 +40,18 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		holo: false
-	}
+		normal: true,
+		reverse: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'normal'
+		},
+		{
+			type: 'reverse'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/005.ts
+++ b/data/Scarlet & Violet/Destined Rivals/005.ts
@@ -39,10 +39,6 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "I",
 
-	variants: {
-		holo: false
-	},
-
 	variants_detailed: [
 		{
 			type: 'normal'

--- a/data/Scarlet & Violet/Destined Rivals/005.ts
+++ b/data/Scarlet & Violet/Destined Rivals/005.ts
@@ -40,8 +40,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		normal: true,
-		reverse: true,
+		holo: false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/005.ts
+++ b/data/Scarlet & Violet/Destined Rivals/005.ts
@@ -39,7 +39,7 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'normal'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/005.ts
+++ b/data/Scarlet & Violet/Destined Rivals/005.ts
@@ -40,8 +40,18 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		holo: false
-	}
+		normal: true,
+		reverse: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'normal'
+		},
+		{
+			type: 'reverse'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/006.ts
+++ b/data/Scarlet & Violet/Destined Rivals/006.ts
@@ -74,8 +74,18 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		holo: false
-	}
+		normal: true,
+		reverse: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'normal'
+		},
+		{
+			type: 'reverse'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/006.ts
+++ b/data/Scarlet & Violet/Destined Rivals/006.ts
@@ -73,7 +73,7 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'normal'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/006.ts
+++ b/data/Scarlet & Violet/Destined Rivals/006.ts
@@ -73,10 +73,6 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "I",
 
-	variants: {
-		holo: false
-	},
-
 	variants_detailed: [
 		{
 			type: 'normal'

--- a/data/Scarlet & Violet/Destined Rivals/006.ts
+++ b/data/Scarlet & Violet/Destined Rivals/006.ts
@@ -74,8 +74,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		normal: true,
-		reverse: true,
+		holo: false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/007.ts
+++ b/data/Scarlet & Violet/Destined Rivals/007.ts
@@ -39,10 +39,6 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "I",
 
-	variants: {
-		holo: false
-	},
-
 	variants_detailed: [
 		{
 			type: 'normal'

--- a/data/Scarlet & Violet/Destined Rivals/007.ts
+++ b/data/Scarlet & Violet/Destined Rivals/007.ts
@@ -40,8 +40,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		normal: true,
-		reverse: true,
+		holo: false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/007.ts
+++ b/data/Scarlet & Violet/Destined Rivals/007.ts
@@ -39,7 +39,7 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'normal'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/007.ts
+++ b/data/Scarlet & Violet/Destined Rivals/007.ts
@@ -40,8 +40,18 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		holo: false
-	}
+		normal: true,
+		reverse: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'normal'
+		},
+		{
+			type: 'reverse'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/008.ts
+++ b/data/Scarlet & Violet/Destined Rivals/008.ts
@@ -64,9 +64,18 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		normal: false,
-		reverse: false
-	}
+		reverse: true,
+		holo: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'reverse'
+		},
+		{
+			type: 'holo'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/008.ts
+++ b/data/Scarlet & Violet/Destined Rivals/008.ts
@@ -64,8 +64,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		reverse: true,
-		holo: true,
+		normal:false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/008.ts
+++ b/data/Scarlet & Violet/Destined Rivals/008.ts
@@ -63,7 +63,7 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'reverse'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/008.ts
+++ b/data/Scarlet & Violet/Destined Rivals/008.ts
@@ -63,10 +63,6 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "I",
 
-	variants: {
-		normal:false
-	},
-
 	variants_detailed: [
 		{
 			type: 'reverse'

--- a/data/Scarlet & Violet/Destined Rivals/009.ts
+++ b/data/Scarlet & Violet/Destined Rivals/009.ts
@@ -73,10 +73,6 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "I",
 
-	variants: {
-		holo: false
-	},
-
 	variants_detailed: [
 		{
 			type: 'normal'

--- a/data/Scarlet & Violet/Destined Rivals/009.ts
+++ b/data/Scarlet & Violet/Destined Rivals/009.ts
@@ -74,8 +74,18 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		holo: false
-	}
+		normal: true,
+		reverse: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'normal'
+		},
+		{
+			type: 'reverse'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/009.ts
+++ b/data/Scarlet & Violet/Destined Rivals/009.ts
@@ -73,7 +73,7 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'normal'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/009.ts
+++ b/data/Scarlet & Violet/Destined Rivals/009.ts
@@ -74,8 +74,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		normal: true,
-		reverse: true,
+		holo: false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/010.ts
+++ b/data/Scarlet & Violet/Destined Rivals/010.ts
@@ -64,8 +64,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		normal: true,
-		reverse: true,
+		holo: false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/010.ts
+++ b/data/Scarlet & Violet/Destined Rivals/010.ts
@@ -63,7 +63,7 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'normal'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/010.ts
+++ b/data/Scarlet & Violet/Destined Rivals/010.ts
@@ -63,10 +63,6 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "I",
 
-	variants: {
-		holo: false
-	},
-
 	variants_detailed: [
 		{
 			type: 'normal'

--- a/data/Scarlet & Violet/Destined Rivals/010.ts
+++ b/data/Scarlet & Violet/Destined Rivals/010.ts
@@ -64,8 +64,18 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		holo: false
-	}
+		normal: true,
+		reverse: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'normal'
+		},
+		{
+			type: 'reverse'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/011.ts
+++ b/data/Scarlet & Violet/Destined Rivals/011.ts
@@ -48,8 +48,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		normal: true,
-		reverse: true,
+		holo: false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/011.ts
+++ b/data/Scarlet & Violet/Destined Rivals/011.ts
@@ -47,10 +47,6 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "I",
 
-	variants: {
-		holo: false
-	},
-
 	variants_detailed: [
 		{
 			type: 'normal'

--- a/data/Scarlet & Violet/Destined Rivals/011.ts
+++ b/data/Scarlet & Violet/Destined Rivals/011.ts
@@ -48,8 +48,18 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		holo: false
-	}
+		normal: true,
+		reverse: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'normal'
+		},
+		{
+			type: 'reverse'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/011.ts
+++ b/data/Scarlet & Violet/Destined Rivals/011.ts
@@ -47,7 +47,7 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'normal'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/012.ts
+++ b/data/Scarlet & Violet/Destined Rivals/012.ts
@@ -74,8 +74,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		reverse: true,
-		holo: true,
+		normal:false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/012.ts
+++ b/data/Scarlet & Violet/Destined Rivals/012.ts
@@ -73,7 +73,7 @@ const card: Card = {
 	retreat: 3,
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'reverse'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/012.ts
+++ b/data/Scarlet & Violet/Destined Rivals/012.ts
@@ -73,10 +73,6 @@ const card: Card = {
 	retreat: 3,
 	regulationMark: "I",
 
-	variants: {
-		normal:false
-	},
-
 	variants_detailed: [
 		{
 			type: 'reverse'

--- a/data/Scarlet & Violet/Destined Rivals/012.ts
+++ b/data/Scarlet & Violet/Destined Rivals/012.ts
@@ -74,9 +74,18 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		reverse: false,
-		normal: false
-	}
+		reverse: true,
+		holo: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'reverse'
+		},
+		{
+			type: 'holo'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/013.ts
+++ b/data/Scarlet & Violet/Destined Rivals/013.ts
@@ -39,10 +39,6 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "I",
 
-	variants: {
-		holo: false
-	},
-
 	variants_detailed: [
 		{
 			type: 'normal'

--- a/data/Scarlet & Violet/Destined Rivals/013.ts
+++ b/data/Scarlet & Violet/Destined Rivals/013.ts
@@ -40,8 +40,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		normal: true,
-		reverse: true,
+		holo: false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/013.ts
+++ b/data/Scarlet & Violet/Destined Rivals/013.ts
@@ -39,7 +39,7 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'normal'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/013.ts
+++ b/data/Scarlet & Violet/Destined Rivals/013.ts
@@ -40,8 +40,18 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		holo: false
-	}
+		normal: true,
+		reverse: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'normal'
+		},
+		{
+			type: 'reverse'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/014.ts
+++ b/data/Scarlet & Violet/Destined Rivals/014.ts
@@ -64,8 +64,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		normal: true,
-		reverse: true,
+		holo: false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/014.ts
+++ b/data/Scarlet & Violet/Destined Rivals/014.ts
@@ -63,7 +63,7 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'normal'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/014.ts
+++ b/data/Scarlet & Violet/Destined Rivals/014.ts
@@ -63,10 +63,6 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "I",
 
-	variants: {
-		holo: false
-	},
-
 	variants_detailed: [
 		{
 			type: 'normal'

--- a/data/Scarlet & Violet/Destined Rivals/014.ts
+++ b/data/Scarlet & Violet/Destined Rivals/014.ts
@@ -64,8 +64,18 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		holo: false
-	}
+		normal: true,
+		reverse: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'normal'
+		},
+		{
+			type: 'reverse'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/015.ts
+++ b/data/Scarlet & Violet/Destined Rivals/015.ts
@@ -48,8 +48,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		normal: true,
-		reverse: true,
+		holo: false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/015.ts
+++ b/data/Scarlet & Violet/Destined Rivals/015.ts
@@ -47,10 +47,6 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "I",
 
-	variants: {
-		holo: false
-	},
-
 	variants_detailed: [
 		{
 			type: 'normal'

--- a/data/Scarlet & Violet/Destined Rivals/015.ts
+++ b/data/Scarlet & Violet/Destined Rivals/015.ts
@@ -48,8 +48,18 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		holo: false
-	}
+		normal: true,
+		reverse: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'normal'
+		},
+		{
+			type: 'reverse'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/015.ts
+++ b/data/Scarlet & Violet/Destined Rivals/015.ts
@@ -47,7 +47,7 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'normal'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/016.ts
+++ b/data/Scarlet & Violet/Destined Rivals/016.ts
@@ -49,7 +49,7 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'normal'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/016.ts
+++ b/data/Scarlet & Violet/Destined Rivals/016.ts
@@ -49,10 +49,6 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "I",
 
-	variants: {
-		holo: false
-	},
-
 	variants_detailed: [
 		{
 			type: 'normal'

--- a/data/Scarlet & Violet/Destined Rivals/016.ts
+++ b/data/Scarlet & Violet/Destined Rivals/016.ts
@@ -50,8 +50,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		normal: true,
-		reverse: true,
+		holo: false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/016.ts
+++ b/data/Scarlet & Violet/Destined Rivals/016.ts
@@ -50,8 +50,18 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		holo: false
-	}
+		normal: true,
+		reverse: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'normal'
+		},
+		{
+			type: 'reverse'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/017.ts
+++ b/data/Scarlet & Violet/Destined Rivals/017.ts
@@ -49,7 +49,7 @@ const card: Card = {
 	retreat: 3,
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'normal'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/017.ts
+++ b/data/Scarlet & Violet/Destined Rivals/017.ts
@@ -49,10 +49,6 @@ const card: Card = {
 	retreat: 3,
 	regulationMark: "I",
 
-	variants: {
-		holo: false
-	},
-
 	variants_detailed: [
 		{
 			type: 'normal'

--- a/data/Scarlet & Violet/Destined Rivals/017.ts
+++ b/data/Scarlet & Violet/Destined Rivals/017.ts
@@ -50,8 +50,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		normal: true,
-		reverse: true,
+		holo: false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/017.ts
+++ b/data/Scarlet & Violet/Destined Rivals/017.ts
@@ -50,8 +50,18 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		holo: false
-	}
+		normal: true,
+		reverse: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'normal'
+		},
+		{
+			type: 'reverse'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/018.ts
+++ b/data/Scarlet & Violet/Destined Rivals/018.ts
@@ -62,8 +62,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		reverse: true,
-		holo: true,
+		normal:false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/018.ts
+++ b/data/Scarlet & Violet/Destined Rivals/018.ts
@@ -61,7 +61,7 @@ const card: Card = {
 	retreat: 3,
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'reverse'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/018.ts
+++ b/data/Scarlet & Violet/Destined Rivals/018.ts
@@ -61,10 +61,6 @@ const card: Card = {
 	retreat: 3,
 	regulationMark: "I",
 
-	variants: {
-		normal:false
-	},
-
 	variants_detailed: [
 		{
 			type: 'reverse'

--- a/data/Scarlet & Violet/Destined Rivals/018.ts
+++ b/data/Scarlet & Violet/Destined Rivals/018.ts
@@ -62,9 +62,18 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		normal: false,
-		reverse: false
-	}
+		reverse: true,
+		holo: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'reverse'
+		},
+		{
+			type: 'holo'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/019.ts
+++ b/data/Scarlet & Violet/Destined Rivals/019.ts
@@ -49,7 +49,7 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'normal'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/019.ts
+++ b/data/Scarlet & Violet/Destined Rivals/019.ts
@@ -49,10 +49,6 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "I",
 
-	variants: {
-		holo: false
-	},
-
 	variants_detailed: [
 		{
 			type: 'normal'

--- a/data/Scarlet & Violet/Destined Rivals/019.ts
+++ b/data/Scarlet & Violet/Destined Rivals/019.ts
@@ -50,8 +50,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		normal: true,
-		reverse: true,
+		holo: false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/019.ts
+++ b/data/Scarlet & Violet/Destined Rivals/019.ts
@@ -50,8 +50,18 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		holo: false
-	}
+		normal: true,
+		reverse: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'normal'
+		},
+		{
+			type: 'reverse'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/020.ts
+++ b/data/Scarlet & Violet/Destined Rivals/020.ts
@@ -74,8 +74,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		reverse: true,
-		holo: true,
+		normal:false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/020.ts
+++ b/data/Scarlet & Violet/Destined Rivals/020.ts
@@ -73,10 +73,6 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "I",
 
-	variants: {
-		normal:false
-	},
-
 	variants_detailed: [
 		{
 			type: 'reverse'

--- a/data/Scarlet & Violet/Destined Rivals/020.ts
+++ b/data/Scarlet & Violet/Destined Rivals/020.ts
@@ -73,7 +73,7 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'reverse'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/020.ts
+++ b/data/Scarlet & Violet/Destined Rivals/020.ts
@@ -74,9 +74,18 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		reverse: false,
-		normal: false
-	}
+		reverse: true,
+		holo: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'reverse'
+		},
+		{
+			type: 'holo'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/021.ts
+++ b/data/Scarlet & Violet/Destined Rivals/021.ts
@@ -39,10 +39,6 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "I",
 
-	variants: {
-		holo: false
-	},
-
 	variants_detailed: [
 		{
 			type: 'normal'

--- a/data/Scarlet & Violet/Destined Rivals/021.ts
+++ b/data/Scarlet & Violet/Destined Rivals/021.ts
@@ -40,8 +40,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		normal: true,
-		reverse: true,
+		holo: false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/021.ts
+++ b/data/Scarlet & Violet/Destined Rivals/021.ts
@@ -39,7 +39,7 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'normal'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/021.ts
+++ b/data/Scarlet & Violet/Destined Rivals/021.ts
@@ -40,8 +40,18 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		holo: false
-	}
+		normal: true,
+		reverse: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'normal'
+		},
+		{
+			type: 'reverse'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/022.ts
+++ b/data/Scarlet & Violet/Destined Rivals/022.ts
@@ -62,8 +62,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		normal: true,
-		reverse: true,
+		holo: false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/022.ts
+++ b/data/Scarlet & Violet/Destined Rivals/022.ts
@@ -61,10 +61,6 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "I",
 
-	variants: {
-		holo: false
-	},
-
 	variants_detailed: [
 		{
 			type: 'normal'

--- a/data/Scarlet & Violet/Destined Rivals/022.ts
+++ b/data/Scarlet & Violet/Destined Rivals/022.ts
@@ -62,8 +62,18 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		holo: false
-	}
+		normal: true,
+		reverse: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'normal'
+		},
+		{
+			type: 'reverse'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/022.ts
+++ b/data/Scarlet & Violet/Destined Rivals/022.ts
@@ -61,7 +61,7 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'normal'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/023.ts
+++ b/data/Scarlet & Violet/Destined Rivals/023.ts
@@ -74,7 +74,6 @@ const card: Card = {
 	variants: {
 		normal: false,
 	},
-
 	variants_detailed: [
 		{
 			type: 'holo'

--- a/data/Scarlet & Violet/Destined Rivals/023.ts
+++ b/data/Scarlet & Violet/Destined Rivals/023.ts
@@ -71,9 +71,6 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "I",
 
-	variants: {
-		normal: false,
-	},
 	variants: [
 		{
 			type: 'holo'

--- a/data/Scarlet & Violet/Destined Rivals/023.ts
+++ b/data/Scarlet & Violet/Destined Rivals/023.ts
@@ -72,9 +72,14 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		normal: false,
-		reverse: false
-	}
+		holo: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'holo'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/023.ts
+++ b/data/Scarlet & Violet/Destined Rivals/023.ts
@@ -74,7 +74,7 @@ const card: Card = {
 	variants: {
 		normal: false,
 	},
-	variants_detailed: [
+	variants: [
 		{
 			type: 'holo'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/023.ts
+++ b/data/Scarlet & Violet/Destined Rivals/023.ts
@@ -72,7 +72,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		holo: true,
+		normal: false,
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/024.ts
+++ b/data/Scarlet & Violet/Destined Rivals/024.ts
@@ -62,8 +62,7 @@ const card: Card = {
 	regulationMark: "H",
 
 	variants: {
-		normal: true,
-		reverse: true,
+		holo: false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/024.ts
+++ b/data/Scarlet & Violet/Destined Rivals/024.ts
@@ -60,11 +60,6 @@ const card: Card = {
 
 	retreat: 1,
 	regulationMark: "H",
-
-	variants: {
-		holo: false
-	},
-
 	variants_detailed: [
 		{
 			type: 'normal'

--- a/data/Scarlet & Violet/Destined Rivals/024.ts
+++ b/data/Scarlet & Violet/Destined Rivals/024.ts
@@ -62,8 +62,18 @@ const card: Card = {
 	regulationMark: "H",
 
 	variants: {
-		holo: false
-	}
+		normal: true,
+		reverse: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'normal'
+		},
+		{
+			type: 'reverse'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/024.ts
+++ b/data/Scarlet & Violet/Destined Rivals/024.ts
@@ -60,7 +60,7 @@ const card: Card = {
 
 	retreat: 1,
 	regulationMark: "H",
-	variants_detailed: [
+	variants: [
 		{
 			type: 'normal'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/025.ts
+++ b/data/Scarlet & Violet/Destined Rivals/025.ts
@@ -70,7 +70,7 @@ const card: Card = {
 
 	retreat: 1,
 	regulationMark: "H",
-	variants_detailed: [
+	variants: [
 		{
 			type: 'holo'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/025.ts
+++ b/data/Scarlet & Violet/Destined Rivals/025.ts
@@ -72,9 +72,14 @@ const card: Card = {
 	regulationMark: "H",
 
 	variants: {
-		reverse: false,
-		normal: false
-	}
+		holo: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'holo'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/025.ts
+++ b/data/Scarlet & Violet/Destined Rivals/025.ts
@@ -70,12 +70,6 @@ const card: Card = {
 
 	retreat: 1,
 	regulationMark: "H",
-
-	variants: {
-		normal: false,
-		reverse: false
-	},
-
 	variants_detailed: [
 		{
 			type: 'holo'

--- a/data/Scarlet & Violet/Destined Rivals/025.ts
+++ b/data/Scarlet & Violet/Destined Rivals/025.ts
@@ -72,7 +72,8 @@ const card: Card = {
 	regulationMark: "H",
 
 	variants: {
-		holo: true,
+		normal: false,
+		reverse: false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/026.ts
+++ b/data/Scarlet & Violet/Destined Rivals/026.ts
@@ -72,8 +72,18 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		holo: false
-	}
+		normal: true,
+		reverse: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'normal'
+		},
+		{
+			type: 'reverse'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/026.ts
+++ b/data/Scarlet & Violet/Destined Rivals/026.ts
@@ -72,8 +72,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		normal: true,
-		reverse: true,
+		holo: false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/026.ts
+++ b/data/Scarlet & Violet/Destined Rivals/026.ts
@@ -71,10 +71,6 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "I",
 
-	variants: {
-		holo: false
-	},
-
 	variants_detailed: [
 		{
 			type: 'normal'

--- a/data/Scarlet & Violet/Destined Rivals/026.ts
+++ b/data/Scarlet & Violet/Destined Rivals/026.ts
@@ -71,7 +71,7 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'normal'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/027.ts
+++ b/data/Scarlet & Violet/Destined Rivals/027.ts
@@ -53,7 +53,7 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'normal'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/027.ts
+++ b/data/Scarlet & Violet/Destined Rivals/027.ts
@@ -53,10 +53,6 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "I",
 
-	variants: {
-		holo: false
-	},
-
 	variants_detailed: [
 		{
 			type: 'normal'

--- a/data/Scarlet & Violet/Destined Rivals/027.ts
+++ b/data/Scarlet & Violet/Destined Rivals/027.ts
@@ -54,8 +54,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		normal: true,
-		reverse: true,
+		holo: false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/027.ts
+++ b/data/Scarlet & Violet/Destined Rivals/027.ts
@@ -54,8 +54,18 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		holo: false
-	}
+		normal: true,
+		reverse: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'normal'
+		},
+		{
+			type: 'reverse'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/028.ts
+++ b/data/Scarlet & Violet/Destined Rivals/028.ts
@@ -63,7 +63,7 @@ const card: Card = {
 	retreat: 3,
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'normal'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/028.ts
+++ b/data/Scarlet & Violet/Destined Rivals/028.ts
@@ -64,8 +64,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		normal: true,
-		reverse: true,
+		holo: false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/028.ts
+++ b/data/Scarlet & Violet/Destined Rivals/028.ts
@@ -63,10 +63,6 @@ const card: Card = {
 	retreat: 3,
 	regulationMark: "I",
 
-	variants: {
-		holo: false
-	},
-
 	variants_detailed: [
 		{
 			type: 'normal'

--- a/data/Scarlet & Violet/Destined Rivals/028.ts
+++ b/data/Scarlet & Violet/Destined Rivals/028.ts
@@ -64,8 +64,18 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		holo: false
-	}
+		normal: true,
+		reverse: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'normal'
+		},
+		{
+			type: 'reverse'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/029.ts
+++ b/data/Scarlet & Violet/Destined Rivals/029.ts
@@ -49,7 +49,7 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'normal'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/029.ts
+++ b/data/Scarlet & Violet/Destined Rivals/029.ts
@@ -49,10 +49,6 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "I",
 
-	variants: {
-		holo: false
-	},
-
 	variants_detailed: [
 		{
 			type: 'normal'

--- a/data/Scarlet & Violet/Destined Rivals/029.ts
+++ b/data/Scarlet & Violet/Destined Rivals/029.ts
@@ -50,8 +50,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		normal: true,
-		reverse: true,
+		holo: false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/029.ts
+++ b/data/Scarlet & Violet/Destined Rivals/029.ts
@@ -50,8 +50,18 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		holo: false
-	}
+		normal: true,
+		reverse: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'normal'
+		},
+		{
+			type: 'reverse'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/030.ts
+++ b/data/Scarlet & Violet/Destined Rivals/030.ts
@@ -64,8 +64,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		normal: true,
-		reverse: true,
+		holo: false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/030.ts
+++ b/data/Scarlet & Violet/Destined Rivals/030.ts
@@ -63,7 +63,7 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'normal'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/030.ts
+++ b/data/Scarlet & Violet/Destined Rivals/030.ts
@@ -63,10 +63,6 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "I",
 
-	variants: {
-		holo: false
-	},
-
 	variants_detailed: [
 		{
 			type: 'normal'

--- a/data/Scarlet & Violet/Destined Rivals/030.ts
+++ b/data/Scarlet & Violet/Destined Rivals/030.ts
@@ -64,8 +64,18 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		holo: false
-	}
+		normal: true,
+		reverse: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'normal'
+		},
+		{
+			type: 'reverse'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/031.ts
+++ b/data/Scarlet & Violet/Destined Rivals/031.ts
@@ -72,9 +72,14 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		reverse: false,
-		normal: false
-	}
+		holo: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'holo'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/031.ts
+++ b/data/Scarlet & Violet/Destined Rivals/031.ts
@@ -71,7 +71,7 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'holo'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/031.ts
+++ b/data/Scarlet & Violet/Destined Rivals/031.ts
@@ -72,7 +72,8 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		holo: true,
+		normal: false,
+		reverse: false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/031.ts
+++ b/data/Scarlet & Violet/Destined Rivals/031.ts
@@ -71,11 +71,6 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "I",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
-
 	variants_detailed: [
 		{
 			type: 'holo'

--- a/data/Scarlet & Violet/Destined Rivals/032.ts
+++ b/data/Scarlet & Violet/Destined Rivals/032.ts
@@ -49,7 +49,7 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'normal'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/032.ts
+++ b/data/Scarlet & Violet/Destined Rivals/032.ts
@@ -49,10 +49,6 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "I",
 
-	variants: {
-		holo: false
-	},
-
 	variants_detailed: [
 		{
 			type: 'normal'

--- a/data/Scarlet & Violet/Destined Rivals/032.ts
+++ b/data/Scarlet & Violet/Destined Rivals/032.ts
@@ -50,8 +50,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		normal: true,
-		reverse: true,
+		holo: false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/032.ts
+++ b/data/Scarlet & Violet/Destined Rivals/032.ts
@@ -50,8 +50,18 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		holo: false
-	}
+		normal: true,
+		reverse: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'normal'
+		},
+		{
+			type: 'reverse'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/033.ts
+++ b/data/Scarlet & Violet/Destined Rivals/033.ts
@@ -64,8 +64,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		normal: true,
-		reverse: true,
+		holo: false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/033.ts
+++ b/data/Scarlet & Violet/Destined Rivals/033.ts
@@ -63,7 +63,7 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'normal'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/033.ts
+++ b/data/Scarlet & Violet/Destined Rivals/033.ts
@@ -63,10 +63,6 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "I",
 
-	variants: {
-		holo: false
-	},
-
 	variants_detailed: [
 		{
 			type: 'normal'

--- a/data/Scarlet & Violet/Destined Rivals/033.ts
+++ b/data/Scarlet & Violet/Destined Rivals/033.ts
@@ -64,8 +64,18 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		holo: false
-	}
+		normal: true,
+		reverse: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'normal'
+		},
+		{
+			type: 'reverse'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/034.ts
+++ b/data/Scarlet & Violet/Destined Rivals/034.ts
@@ -63,7 +63,7 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'reverse'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/034.ts
+++ b/data/Scarlet & Violet/Destined Rivals/034.ts
@@ -64,8 +64,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		reverse: true,
-		holo: true,
+		normal:false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/034.ts
+++ b/data/Scarlet & Violet/Destined Rivals/034.ts
@@ -63,10 +63,6 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "I",
 
-	variants: {
-		normal:false
-	},
-
 	variants_detailed: [
 		{
 			type: 'reverse'

--- a/data/Scarlet & Violet/Destined Rivals/034.ts
+++ b/data/Scarlet & Violet/Destined Rivals/034.ts
@@ -64,9 +64,31 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		reverse: false,
-		normal: false
-	}
+		reverse: true,
+		holo: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'reverse'
+		},
+		{
+			type: 'holo'
+		},
+		{
+			type: 'holo',
+			stamp: [
+				"set-logo"
+			]
+		},
+		{
+			type: 'holo',
+			stamp: [
+				"set-logo",
+				"staff"
+			]
+		}
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/035.ts
+++ b/data/Scarlet & Violet/Destined Rivals/035.ts
@@ -39,7 +39,7 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'normal'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/035.ts
+++ b/data/Scarlet & Violet/Destined Rivals/035.ts
@@ -40,8 +40,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		normal: true,
-		reverse: true,
+		holo: false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/035.ts
+++ b/data/Scarlet & Violet/Destined Rivals/035.ts
@@ -39,10 +39,6 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "I",
 
-	variants: {
-		holo: false
-	},
-
 	variants_detailed: [
 		{
 			type: 'normal'

--- a/data/Scarlet & Violet/Destined Rivals/035.ts
+++ b/data/Scarlet & Violet/Destined Rivals/035.ts
@@ -40,8 +40,18 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		holo: false
-	}
+		normal: true,
+		reverse: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'normal'
+		},
+		{
+			type: 'reverse'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/036.ts
+++ b/data/Scarlet & Violet/Destined Rivals/036.ts
@@ -74,8 +74,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		reverse: true,
-		holo: true,
+		normal:false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/036.ts
+++ b/data/Scarlet & Violet/Destined Rivals/036.ts
@@ -73,7 +73,7 @@ const card: Card = {
 	retreat: 3,
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'reverse'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/036.ts
+++ b/data/Scarlet & Violet/Destined Rivals/036.ts
@@ -73,10 +73,6 @@ const card: Card = {
 	retreat: 3,
 	regulationMark: "I",
 
-	variants: {
-		normal:false
-	},
-
 	variants_detailed: [
 		{
 			type: 'reverse'

--- a/data/Scarlet & Violet/Destined Rivals/036.ts
+++ b/data/Scarlet & Violet/Destined Rivals/036.ts
@@ -74,9 +74,18 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		reverse: false,
-		normal: false
-	}
+		reverse: true,
+		holo: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'reverse'
+		},
+		{
+			type: 'holo'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/037.ts
+++ b/data/Scarlet & Violet/Destined Rivals/037.ts
@@ -39,10 +39,6 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "I",
 
-	variants: {
-		holo: false
-	},
-
 	variants_detailed: [
 		{
 			type: 'normal'

--- a/data/Scarlet & Violet/Destined Rivals/037.ts
+++ b/data/Scarlet & Violet/Destined Rivals/037.ts
@@ -40,8 +40,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		normal: true,
-		reverse: true,
+		holo: false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/037.ts
+++ b/data/Scarlet & Violet/Destined Rivals/037.ts
@@ -39,7 +39,7 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'normal'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/037.ts
+++ b/data/Scarlet & Violet/Destined Rivals/037.ts
@@ -40,8 +40,18 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		holo: false
-	}
+		normal: true,
+		reverse: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'normal'
+		},
+		{
+			type: 'reverse'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/038.ts
+++ b/data/Scarlet & Violet/Destined Rivals/038.ts
@@ -72,8 +72,18 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		holo: false
-	}
+		normal: true,
+		reverse: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'normal'
+		},
+		{
+			type: 'reverse'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/038.ts
+++ b/data/Scarlet & Violet/Destined Rivals/038.ts
@@ -71,10 +71,6 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "I",
 
-	variants: {
-		holo: false
-	},
-
 	variants_detailed: [
 		{
 			type: 'normal'

--- a/data/Scarlet & Violet/Destined Rivals/038.ts
+++ b/data/Scarlet & Violet/Destined Rivals/038.ts
@@ -72,8 +72,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		normal: true,
-		reverse: true,
+		holo: false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/038.ts
+++ b/data/Scarlet & Violet/Destined Rivals/038.ts
@@ -71,7 +71,7 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'normal'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/039.ts
+++ b/data/Scarlet & Violet/Destined Rivals/039.ts
@@ -73,7 +73,7 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'holo'
 		}

--- a/data/Scarlet & Violet/Destined Rivals/039.ts
+++ b/data/Scarlet & Violet/Destined Rivals/039.ts
@@ -73,11 +73,6 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "I",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
-
 	variants_detailed: [
 		{
 			type: 'holo'

--- a/data/Scarlet & Violet/Destined Rivals/039.ts
+++ b/data/Scarlet & Violet/Destined Rivals/039.ts
@@ -74,7 +74,8 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		holo: true
+		normal: false,
+		reverse: false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/039.ts
+++ b/data/Scarlet & Violet/Destined Rivals/039.ts
@@ -74,9 +74,14 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		reverse: false,
-		normal: false
-	}
+		holo: true
+	},
+
+	variants_detailed: [
+		{
+			type: 'holo'
+		}
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/040.ts
+++ b/data/Scarlet & Violet/Destined Rivals/040.ts
@@ -62,8 +62,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		normal: true,
-		reverse: true,
+		holo: false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/040.ts
+++ b/data/Scarlet & Violet/Destined Rivals/040.ts
@@ -61,10 +61,6 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "I",
 
-	variants: {
-		holo: false
-	},
-
 	variants_detailed: [
 		{
 			type: 'normal'

--- a/data/Scarlet & Violet/Destined Rivals/040.ts
+++ b/data/Scarlet & Violet/Destined Rivals/040.ts
@@ -62,8 +62,18 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		holo: false
-	}
+		normal: true,
+		reverse: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'normal'
+		},
+		{
+			type: 'reverse'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/040.ts
+++ b/data/Scarlet & Violet/Destined Rivals/040.ts
@@ -61,7 +61,7 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'normal'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/041.ts
+++ b/data/Scarlet & Violet/Destined Rivals/041.ts
@@ -64,8 +64,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		normal: true,
-		reverse: true,
+		holo: false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/041.ts
+++ b/data/Scarlet & Violet/Destined Rivals/041.ts
@@ -63,7 +63,7 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'normal'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/041.ts
+++ b/data/Scarlet & Violet/Destined Rivals/041.ts
@@ -63,10 +63,6 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "I",
 
-	variants: {
-		holo: false
-	},
-
 	variants_detailed: [
 		{
 			type: 'normal'

--- a/data/Scarlet & Violet/Destined Rivals/041.ts
+++ b/data/Scarlet & Violet/Destined Rivals/041.ts
@@ -64,8 +64,18 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		holo: false
-	}
+		normal: true,
+		reverse: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'normal'
+		},
+		{
+			type: 'reverse'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/042.ts
+++ b/data/Scarlet & Violet/Destined Rivals/042.ts
@@ -63,7 +63,7 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'reverse'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/042.ts
+++ b/data/Scarlet & Violet/Destined Rivals/042.ts
@@ -64,9 +64,18 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		reverse: false,
-		normal: false
-	}
+		reverse: true,
+		holo: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'reverse'
+		},
+		{
+			type: 'holo'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/042.ts
+++ b/data/Scarlet & Violet/Destined Rivals/042.ts
@@ -64,8 +64,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		reverse: true,
-		holo: true,
+		normal:false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/042.ts
+++ b/data/Scarlet & Violet/Destined Rivals/042.ts
@@ -63,10 +63,6 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "I",
 
-	variants: {
-		normal:false
-	},
-
 	variants_detailed: [
 		{
 			type: 'reverse'

--- a/data/Scarlet & Violet/Destined Rivals/043.ts
+++ b/data/Scarlet & Violet/Destined Rivals/043.ts
@@ -72,8 +72,18 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		holo: false
-	}
+		normal: true,
+		reverse: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'normal'
+		},
+		{
+			type: 'reverse'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/043.ts
+++ b/data/Scarlet & Violet/Destined Rivals/043.ts
@@ -71,10 +71,6 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "I",
 
-	variants: {
-		holo: false
-	},
-
 	variants_detailed: [
 		{
 			type: 'normal'

--- a/data/Scarlet & Violet/Destined Rivals/043.ts
+++ b/data/Scarlet & Violet/Destined Rivals/043.ts
@@ -72,8 +72,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		normal: true,
-		reverse: true,
+		holo: false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/043.ts
+++ b/data/Scarlet & Violet/Destined Rivals/043.ts
@@ -71,7 +71,7 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'normal'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/044.ts
+++ b/data/Scarlet & Violet/Destined Rivals/044.ts
@@ -72,8 +72,18 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		holo: false
-	}
+		normal: true,
+		reverse: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'normal'
+		},
+		{
+			type: 'reverse'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/044.ts
+++ b/data/Scarlet & Violet/Destined Rivals/044.ts
@@ -72,8 +72,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		normal: true,
-		reverse: true,
+		holo: false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/044.ts
+++ b/data/Scarlet & Violet/Destined Rivals/044.ts
@@ -71,10 +71,6 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "I",
 
-	variants: {
-		holo: false
-	},
-
 	variants_detailed: [
 		{
 			type: 'normal'

--- a/data/Scarlet & Violet/Destined Rivals/044.ts
+++ b/data/Scarlet & Violet/Destined Rivals/044.ts
@@ -71,7 +71,7 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'normal'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/045.ts
+++ b/data/Scarlet & Violet/Destined Rivals/045.ts
@@ -64,8 +64,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		normal: true,
-		reverse: true,
+		holo: false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/045.ts
+++ b/data/Scarlet & Violet/Destined Rivals/045.ts
@@ -63,7 +63,7 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'normal'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/045.ts
+++ b/data/Scarlet & Violet/Destined Rivals/045.ts
@@ -63,10 +63,6 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "I",
 
-	variants: {
-		holo: false
-	},
-
 	variants_detailed: [
 		{
 			type: 'normal'

--- a/data/Scarlet & Violet/Destined Rivals/045.ts
+++ b/data/Scarlet & Violet/Destined Rivals/045.ts
@@ -64,8 +64,18 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		holo: false
-	}
+		normal: true,
+		reverse: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'normal'
+		},
+		{
+			type: 'reverse'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/046.ts
+++ b/data/Scarlet & Violet/Destined Rivals/046.ts
@@ -49,7 +49,7 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'normal'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/046.ts
+++ b/data/Scarlet & Violet/Destined Rivals/046.ts
@@ -49,10 +49,6 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "I",
 
-	variants: {
-		holo: false
-	},
-
 	variants_detailed: [
 		{
 			type: 'normal'

--- a/data/Scarlet & Violet/Destined Rivals/046.ts
+++ b/data/Scarlet & Violet/Destined Rivals/046.ts
@@ -50,8 +50,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		normal: true,
-		reverse: true,
+		holo: false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/046.ts
+++ b/data/Scarlet & Violet/Destined Rivals/046.ts
@@ -50,8 +50,18 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		holo: false
-	}
+		normal: true,
+		reverse: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'normal'
+		},
+		{
+			type: 'reverse'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/047.ts
+++ b/data/Scarlet & Violet/Destined Rivals/047.ts
@@ -49,7 +49,7 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'normal'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/047.ts
+++ b/data/Scarlet & Violet/Destined Rivals/047.ts
@@ -49,10 +49,6 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "I",
 
-	variants: {
-		holo: false
-	},
-
 	variants_detailed: [
 		{
 			type: 'normal'

--- a/data/Scarlet & Violet/Destined Rivals/047.ts
+++ b/data/Scarlet & Violet/Destined Rivals/047.ts
@@ -50,8 +50,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		normal: true,
-		reverse: true,
+		holo: false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/047.ts
+++ b/data/Scarlet & Violet/Destined Rivals/047.ts
@@ -50,8 +50,18 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		holo: false
-	}
+		normal: true,
+		reverse: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'normal'
+		},
+		{
+			type: 'reverse'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/048.ts
+++ b/data/Scarlet & Violet/Destined Rivals/048.ts
@@ -64,8 +64,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		normal: true,
-		reverse: true,
+		holo: false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/048.ts
+++ b/data/Scarlet & Violet/Destined Rivals/048.ts
@@ -63,7 +63,7 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'normal'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/048.ts
+++ b/data/Scarlet & Violet/Destined Rivals/048.ts
@@ -63,10 +63,6 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "I",
 
-	variants: {
-		holo: false
-	},
-
 	variants_detailed: [
 		{
 			type: 'normal'

--- a/data/Scarlet & Violet/Destined Rivals/048.ts
+++ b/data/Scarlet & Violet/Destined Rivals/048.ts
@@ -64,8 +64,18 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		holo: false
-	}
+		normal: true,
+		reverse: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'normal'
+		},
+		{
+			type: 'reverse'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/049.ts
+++ b/data/Scarlet & Violet/Destined Rivals/049.ts
@@ -63,7 +63,7 @@ const card: Card = {
 	retreat: 4,
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'reverse'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/049.ts
+++ b/data/Scarlet & Violet/Destined Rivals/049.ts
@@ -64,8 +64,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		reverse: true,
-		holo: true,
+		normal:false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/049.ts
+++ b/data/Scarlet & Violet/Destined Rivals/049.ts
@@ -63,10 +63,6 @@ const card: Card = {
 	retreat: 4,
 	regulationMark: "I",
 
-	variants: {
-		normal:false
-	},
-
 	variants_detailed: [
 		{
 			type: 'reverse'

--- a/data/Scarlet & Violet/Destined Rivals/049.ts
+++ b/data/Scarlet & Violet/Destined Rivals/049.ts
@@ -64,9 +64,31 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		reverse: false,
-		normal: false
-	}
+		reverse: true,
+		holo: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'reverse'
+		},
+		{
+			type: 'holo'
+		},
+		{
+			type: 'holo',
+			stamp: [
+				"set-logo"
+			]
+		},
+		{
+			type: 'holo',
+			stamp: [
+				"set-logo",
+				"staff"
+			]
+		}
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/050.ts
+++ b/data/Scarlet & Violet/Destined Rivals/050.ts
@@ -62,8 +62,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		normal: true,
-		reverse: true,
+		holo: false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/050.ts
+++ b/data/Scarlet & Violet/Destined Rivals/050.ts
@@ -61,10 +61,6 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "I",
 
-	variants: {
-		holo: false
-	},
-
 	variants_detailed: [
 		{
 			type: 'normal'

--- a/data/Scarlet & Violet/Destined Rivals/050.ts
+++ b/data/Scarlet & Violet/Destined Rivals/050.ts
@@ -62,8 +62,18 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		holo: false
-	}
+		normal: true,
+		reverse: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'normal'
+		},
+		{
+			type: 'reverse'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/050.ts
+++ b/data/Scarlet & Violet/Destined Rivals/050.ts
@@ -61,7 +61,7 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'normal'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/051.ts
+++ b/data/Scarlet & Violet/Destined Rivals/051.ts
@@ -74,8 +74,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		reverse: true,
-		holo: true,
+		normal:false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/051.ts
+++ b/data/Scarlet & Violet/Destined Rivals/051.ts
@@ -74,9 +74,18 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		reverse: false,
-		normal: false
-	}
+		reverse: true,
+		holo: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'reverse'
+		},
+		{
+			type: 'holo'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/051.ts
+++ b/data/Scarlet & Violet/Destined Rivals/051.ts
@@ -73,7 +73,7 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'reverse'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/051.ts
+++ b/data/Scarlet & Violet/Destined Rivals/051.ts
@@ -73,10 +73,6 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "I",
 
-	variants: {
-		normal:false
-	},
-
 	variants_detailed: [
 		{
 			type: 'reverse'

--- a/data/Scarlet & Violet/Destined Rivals/052.ts
+++ b/data/Scarlet & Violet/Destined Rivals/052.ts
@@ -49,7 +49,7 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'normal'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/052.ts
+++ b/data/Scarlet & Violet/Destined Rivals/052.ts
@@ -49,10 +49,6 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "I",
 
-	variants: {
-		holo: false
-	},
-
 	variants_detailed: [
 		{
 			type: 'normal'

--- a/data/Scarlet & Violet/Destined Rivals/052.ts
+++ b/data/Scarlet & Violet/Destined Rivals/052.ts
@@ -50,8 +50,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		normal: true,
-		reverse: true,
+		holo: false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/052.ts
+++ b/data/Scarlet & Violet/Destined Rivals/052.ts
@@ -50,8 +50,18 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		holo: false
-	}
+		normal: true,
+		reverse: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'normal'
+		},
+		{
+			type: 'reverse'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/053.ts
+++ b/data/Scarlet & Violet/Destined Rivals/053.ts
@@ -49,7 +49,7 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'normal'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/053.ts
+++ b/data/Scarlet & Violet/Destined Rivals/053.ts
@@ -50,8 +50,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		normal: true,
-		reverse: true,
+		holo: false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/053.ts
+++ b/data/Scarlet & Violet/Destined Rivals/053.ts
@@ -49,10 +49,6 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "I",
 
-	variants: {
-		holo: false
-	},
-
 	variants_detailed: [
 		{
 			type: 'normal'

--- a/data/Scarlet & Violet/Destined Rivals/053.ts
+++ b/data/Scarlet & Violet/Destined Rivals/053.ts
@@ -50,8 +50,18 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		holo: false
-	}
+		normal: true,
+		reverse: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'normal'
+		},
+		{
+			type: 'reverse'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/054.ts
+++ b/data/Scarlet & Violet/Destined Rivals/054.ts
@@ -49,7 +49,7 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'normal'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/054.ts
+++ b/data/Scarlet & Violet/Destined Rivals/054.ts
@@ -50,8 +50,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		normal: true,
-		reverse: true,
+		holo: false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/054.ts
+++ b/data/Scarlet & Violet/Destined Rivals/054.ts
@@ -49,10 +49,6 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "I",
 
-	variants: {
-		holo: false
-	},
-
 	variants_detailed: [
 		{
 			type: 'normal'

--- a/data/Scarlet & Violet/Destined Rivals/054.ts
+++ b/data/Scarlet & Violet/Destined Rivals/054.ts
@@ -50,8 +50,18 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		holo: false
-	}
+		normal: true,
+		reverse: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'normal'
+		},
+		{
+			type: 'reverse'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/055.ts
+++ b/data/Scarlet & Violet/Destined Rivals/055.ts
@@ -64,8 +64,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		normal: true,
-		reverse: true,
+		holo: false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/055.ts
+++ b/data/Scarlet & Violet/Destined Rivals/055.ts
@@ -63,7 +63,7 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'normal'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/055.ts
+++ b/data/Scarlet & Violet/Destined Rivals/055.ts
@@ -63,10 +63,6 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "I",
 
-	variants: {
-		holo: false
-	},
-
 	variants_detailed: [
 		{
 			type: 'normal'

--- a/data/Scarlet & Violet/Destined Rivals/055.ts
+++ b/data/Scarlet & Violet/Destined Rivals/055.ts
@@ -64,8 +64,18 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		holo: false
-	}
+		normal: true,
+		reverse: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'normal'
+		},
+		{
+			type: 'reverse'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/056.ts
+++ b/data/Scarlet & Violet/Destined Rivals/056.ts
@@ -49,10 +49,6 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "I",
 
-	variants: {
-		normal:false
-	},
-
 	variants_detailed: [
 		{
 			type: 'reverse'

--- a/data/Scarlet & Violet/Destined Rivals/056.ts
+++ b/data/Scarlet & Violet/Destined Rivals/056.ts
@@ -49,7 +49,7 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'reverse'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/056.ts
+++ b/data/Scarlet & Violet/Destined Rivals/056.ts
@@ -50,9 +50,18 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		reverse: false,
-		normal: false
-	}
+		reverse: true,
+		holo: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'reverse'
+		},
+		{
+			type: 'holo'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/056.ts
+++ b/data/Scarlet & Violet/Destined Rivals/056.ts
@@ -50,8 +50,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		reverse: true,
-		holo: true,
+		normal:false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/057.ts
+++ b/data/Scarlet & Violet/Destined Rivals/057.ts
@@ -53,10 +53,6 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "I",
 
-	variants: {
-		holo: false
-	},
-
 	variants_detailed: [
 		{
 			type: 'normal'

--- a/data/Scarlet & Violet/Destined Rivals/057.ts
+++ b/data/Scarlet & Violet/Destined Rivals/057.ts
@@ -54,8 +54,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		normal: true,
-		reverse: true,
+		holo: false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/057.ts
+++ b/data/Scarlet & Violet/Destined Rivals/057.ts
@@ -53,7 +53,7 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'normal'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/057.ts
+++ b/data/Scarlet & Violet/Destined Rivals/057.ts
@@ -54,8 +54,18 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		holo: false
-	}
+		normal: true,
+		reverse: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'normal'
+		},
+		{
+			type: 'reverse'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/058.ts
+++ b/data/Scarlet & Violet/Destined Rivals/058.ts
@@ -73,10 +73,6 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "I",
 
-	variants: {
-		holo: false
-	},
-
 	variants_detailed: [
 		{
 			type: 'normal'

--- a/data/Scarlet & Violet/Destined Rivals/058.ts
+++ b/data/Scarlet & Violet/Destined Rivals/058.ts
@@ -74,8 +74,18 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		holo: false
-	}
+		normal: true,
+		reverse: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'normal'
+		},
+		{
+			type: 'reverse'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/058.ts
+++ b/data/Scarlet & Violet/Destined Rivals/058.ts
@@ -73,7 +73,7 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'normal'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/058.ts
+++ b/data/Scarlet & Violet/Destined Rivals/058.ts
@@ -74,8 +74,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		normal: true,
-		reverse: true,
+		holo: false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/059.ts
+++ b/data/Scarlet & Violet/Destined Rivals/059.ts
@@ -53,7 +53,7 @@ const card: Card = {
 	retreat: 3,
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'normal'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/059.ts
+++ b/data/Scarlet & Violet/Destined Rivals/059.ts
@@ -53,10 +53,6 @@ const card: Card = {
 	retreat: 3,
 	regulationMark: "I",
 
-	variants: {
-		holo: false
-	},
-
 	variants_detailed: [
 		{
 			type: 'normal'

--- a/data/Scarlet & Violet/Destined Rivals/059.ts
+++ b/data/Scarlet & Violet/Destined Rivals/059.ts
@@ -54,8 +54,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		normal: true,
-		reverse: true,
+		holo: false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/059.ts
+++ b/data/Scarlet & Violet/Destined Rivals/059.ts
@@ -54,8 +54,18 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		holo: false
-	}
+		normal: true,
+		reverse: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'normal'
+		},
+		{
+			type: 'reverse'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/060.ts
+++ b/data/Scarlet & Violet/Destined Rivals/060.ts
@@ -64,8 +64,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		normal: true,
-		reverse: true,
+		holo: false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/060.ts
+++ b/data/Scarlet & Violet/Destined Rivals/060.ts
@@ -63,10 +63,6 @@ const card: Card = {
 	retreat: 4,
 	regulationMark: "I",
 
-	variants: {
-		holo: false
-	},
-
 	variants_detailed: [
 		{
 			type: 'normal'

--- a/data/Scarlet & Violet/Destined Rivals/060.ts
+++ b/data/Scarlet & Violet/Destined Rivals/060.ts
@@ -63,7 +63,7 @@ const card: Card = {
 	retreat: 4,
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'normal'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/060.ts
+++ b/data/Scarlet & Violet/Destined Rivals/060.ts
@@ -64,8 +64,18 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		holo: false
-	}
+		normal: true,
+		reverse: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'normal'
+		},
+		{
+			type: 'reverse'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/061.ts
+++ b/data/Scarlet & Violet/Destined Rivals/061.ts
@@ -74,8 +74,18 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		holo: false
-	}
+		normal: true,
+		reverse: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'normal'
+		},
+		{
+			type: 'reverse'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/061.ts
+++ b/data/Scarlet & Violet/Destined Rivals/061.ts
@@ -73,7 +73,7 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'normal'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/061.ts
+++ b/data/Scarlet & Violet/Destined Rivals/061.ts
@@ -73,10 +73,6 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "I",
 
-	variants: {
-		holo: false
-	},
-
 	variants_detailed: [
 		{
 			type: 'normal'

--- a/data/Scarlet & Violet/Destined Rivals/061.ts
+++ b/data/Scarlet & Violet/Destined Rivals/061.ts
@@ -74,8 +74,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		normal: true,
-		reverse: true,
+		holo: false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/062.ts
+++ b/data/Scarlet & Violet/Destined Rivals/062.ts
@@ -49,7 +49,7 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'normal'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/062.ts
+++ b/data/Scarlet & Violet/Destined Rivals/062.ts
@@ -49,10 +49,6 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "I",
 
-	variants: {
-		holo: false
-	},
-
 	variants_detailed: [
 		{
 			type: 'normal'

--- a/data/Scarlet & Violet/Destined Rivals/062.ts
+++ b/data/Scarlet & Violet/Destined Rivals/062.ts
@@ -50,8 +50,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		normal: true,
-		reverse: true,
+		holo: false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/062.ts
+++ b/data/Scarlet & Violet/Destined Rivals/062.ts
@@ -50,8 +50,18 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		holo: false
-	}
+		normal: true,
+		reverse: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'normal'
+		},
+		{
+			type: 'reverse'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/063.ts
+++ b/data/Scarlet & Violet/Destined Rivals/063.ts
@@ -64,8 +64,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		normal: true,
-		reverse: true,
+		holo: false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/063.ts
+++ b/data/Scarlet & Violet/Destined Rivals/063.ts
@@ -63,7 +63,7 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'normal'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/063.ts
+++ b/data/Scarlet & Violet/Destined Rivals/063.ts
@@ -63,10 +63,6 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "I",
 
-	variants: {
-		holo: false
-	},
-
 	variants_detailed: [
 		{
 			type: 'normal'

--- a/data/Scarlet & Violet/Destined Rivals/063.ts
+++ b/data/Scarlet & Violet/Destined Rivals/063.ts
@@ -64,8 +64,18 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		holo: false
-	}
+		normal: true,
+		reverse: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'normal'
+		},
+		{
+			type: 'reverse'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/064.ts
+++ b/data/Scarlet & Violet/Destined Rivals/064.ts
@@ -53,7 +53,7 @@ const card: Card = {
 	retreat: 3,
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'normal'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/064.ts
+++ b/data/Scarlet & Violet/Destined Rivals/064.ts
@@ -53,10 +53,6 @@ const card: Card = {
 	retreat: 3,
 	regulationMark: "I",
 
-	variants: {
-		holo: false
-	},
-
 	variants_detailed: [
 		{
 			type: 'normal'

--- a/data/Scarlet & Violet/Destined Rivals/064.ts
+++ b/data/Scarlet & Violet/Destined Rivals/064.ts
@@ -54,8 +54,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		normal: true,
-		reverse: true,
+		holo: false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/064.ts
+++ b/data/Scarlet & Violet/Destined Rivals/064.ts
@@ -54,8 +54,18 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		holo: false
-	}
+		normal: true,
+		reverse: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'normal'
+		},
+		{
+			type: 'reverse'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/065.ts
+++ b/data/Scarlet & Violet/Destined Rivals/065.ts
@@ -74,8 +74,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		reverse: true,
-		holo: true,
+		normal:false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/065.ts
+++ b/data/Scarlet & Violet/Destined Rivals/065.ts
@@ -74,9 +74,18 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		reverse: false,
-		normal: false
-	}
+		reverse: true,
+		holo: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'reverse'
+		},
+		{
+			type: 'holo'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/065.ts
+++ b/data/Scarlet & Violet/Destined Rivals/065.ts
@@ -73,10 +73,6 @@ const card: Card = {
 	retreat: 4,
 	regulationMark: "I",
 
-	variants: {
-		normal:false
-	},
-
 	variants_detailed: [
 		{
 			type: 'reverse'

--- a/data/Scarlet & Violet/Destined Rivals/065.ts
+++ b/data/Scarlet & Violet/Destined Rivals/065.ts
@@ -73,7 +73,7 @@ const card: Card = {
 	retreat: 4,
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'reverse'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/066.ts
+++ b/data/Scarlet & Violet/Destined Rivals/066.ts
@@ -74,8 +74,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		reverse: true,
-		holo: true,
+		normal:false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/066.ts
+++ b/data/Scarlet & Violet/Destined Rivals/066.ts
@@ -74,9 +74,18 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		normal: false,
-		reverse: false
-	}
+		reverse: true,
+		holo: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'reverse'
+		},
+		{
+			type: 'holo'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/066.ts
+++ b/data/Scarlet & Violet/Destined Rivals/066.ts
@@ -73,10 +73,6 @@ const card: Card = {
 	retreat: 4,
 	regulationMark: "I",
 
-	variants: {
-		normal:false
-	},
-
 	variants_detailed: [
 		{
 			type: 'reverse'

--- a/data/Scarlet & Violet/Destined Rivals/066.ts
+++ b/data/Scarlet & Violet/Destined Rivals/066.ts
@@ -73,7 +73,7 @@ const card: Card = {
 	retreat: 4,
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'reverse'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/067.ts
+++ b/data/Scarlet & Violet/Destined Rivals/067.ts
@@ -72,8 +72,18 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		holo: false
-	}
+		normal: true,
+		reverse: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'normal'
+		},
+		{
+			type: 'reverse'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/067.ts
+++ b/data/Scarlet & Violet/Destined Rivals/067.ts
@@ -72,8 +72,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		normal: true,
-		reverse: true,
+		holo: false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/067.ts
+++ b/data/Scarlet & Violet/Destined Rivals/067.ts
@@ -71,10 +71,6 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "I",
 
-	variants: {
-		holo: false
-	},
-
 	variants_detailed: [
 		{
 			type: 'normal'

--- a/data/Scarlet & Violet/Destined Rivals/067.ts
+++ b/data/Scarlet & Violet/Destined Rivals/067.ts
@@ -71,7 +71,7 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'normal'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/068.ts
+++ b/data/Scarlet & Violet/Destined Rivals/068.ts
@@ -39,7 +39,7 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'normal'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/068.ts
+++ b/data/Scarlet & Violet/Destined Rivals/068.ts
@@ -40,8 +40,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		normal: true,
-		reverse: true,
+		holo: false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/068.ts
+++ b/data/Scarlet & Violet/Destined Rivals/068.ts
@@ -39,10 +39,6 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "I",
 
-	variants: {
-		holo: false
-	},
-
 	variants_detailed: [
 		{
 			type: 'normal'

--- a/data/Scarlet & Violet/Destined Rivals/068.ts
+++ b/data/Scarlet & Violet/Destined Rivals/068.ts
@@ -40,8 +40,18 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		holo: false
-	}
+		normal: true,
+		reverse: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'normal'
+		},
+		{
+			type: 'reverse'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/069.ts
+++ b/data/Scarlet & Violet/Destined Rivals/069.ts
@@ -71,7 +71,7 @@ const card: Card = {
 	retreat: 4,
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'reverse'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/069.ts
+++ b/data/Scarlet & Violet/Destined Rivals/069.ts
@@ -71,10 +71,6 @@ const card: Card = {
 	retreat: 4,
 	regulationMark: "I",
 
-	variants: {
-		normal:false
-	},
-
 	variants_detailed: [
 		{
 			type: 'reverse'

--- a/data/Scarlet & Violet/Destined Rivals/069.ts
+++ b/data/Scarlet & Violet/Destined Rivals/069.ts
@@ -72,8 +72,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		reverse: true,
-		holo: true,
+		normal:false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/069.ts
+++ b/data/Scarlet & Violet/Destined Rivals/069.ts
@@ -72,9 +72,18 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		reverse: false,
-		normal: false
-	}
+		reverse: true,
+		holo: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'reverse'
+		},
+		{
+			type: 'holo'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/070.ts
+++ b/data/Scarlet & Violet/Destined Rivals/070.ts
@@ -74,8 +74,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		reverse: true,
-		holo: true,
+		normal:false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/070.ts
+++ b/data/Scarlet & Violet/Destined Rivals/070.ts
@@ -74,9 +74,18 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		normal: false,
-		reverse: false
-	}
+		reverse: true,
+		holo: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'reverse'
+		},
+		{
+			type: 'holo'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/070.ts
+++ b/data/Scarlet & Violet/Destined Rivals/070.ts
@@ -73,7 +73,7 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'reverse'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/070.ts
+++ b/data/Scarlet & Violet/Destined Rivals/070.ts
@@ -73,10 +73,6 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "I",
 
-	variants: {
-		normal:false
-	},
-
 	variants_detailed: [
 		{
 			type: 'reverse'

--- a/data/Scarlet & Violet/Destined Rivals/071.ts
+++ b/data/Scarlet & Violet/Destined Rivals/071.ts
@@ -48,8 +48,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		normal: true,
-		reverse: true,
+		holo: false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/071.ts
+++ b/data/Scarlet & Violet/Destined Rivals/071.ts
@@ -47,7 +47,7 @@ const card: Card = {
 	retreat: 0,
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'normal'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/071.ts
+++ b/data/Scarlet & Violet/Destined Rivals/071.ts
@@ -48,8 +48,18 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		holo: false
-	}
+		normal: true,
+		reverse: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'normal'
+		},
+		{
+			type: 'reverse'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/071.ts
+++ b/data/Scarlet & Violet/Destined Rivals/071.ts
@@ -47,10 +47,6 @@ const card: Card = {
 	retreat: 0,
 	regulationMark: "I",
 
-	variants: {
-		holo: false
-	},
-
 	variants_detailed: [
 		{
 			type: 'normal'

--- a/data/Scarlet & Violet/Destined Rivals/072.ts
+++ b/data/Scarlet & Violet/Destined Rivals/072.ts
@@ -62,8 +62,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		normal: true,
-		reverse: true,
+		holo: false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/072.ts
+++ b/data/Scarlet & Violet/Destined Rivals/072.ts
@@ -61,10 +61,6 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "I",
 
-	variants: {
-		holo: false
-	},
-
 	variants_detailed: [
 		{
 			type: 'normal'

--- a/data/Scarlet & Violet/Destined Rivals/072.ts
+++ b/data/Scarlet & Violet/Destined Rivals/072.ts
@@ -62,8 +62,18 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		holo: false
-	}
+		normal: true,
+		reverse: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'normal'
+		},
+		{
+			type: 'reverse'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/072.ts
+++ b/data/Scarlet & Violet/Destined Rivals/072.ts
@@ -61,7 +61,7 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'normal'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/073.ts
+++ b/data/Scarlet & Violet/Destined Rivals/073.ts
@@ -49,7 +49,7 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'normal'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/073.ts
+++ b/data/Scarlet & Violet/Destined Rivals/073.ts
@@ -50,8 +50,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		normal: true,
-		reverse: true,
+		holo: false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/073.ts
+++ b/data/Scarlet & Violet/Destined Rivals/073.ts
@@ -49,10 +49,6 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "I",
 
-	variants: {
-		holo: false
-	},
-
 	variants_detailed: [
 		{
 			type: 'normal'

--- a/data/Scarlet & Violet/Destined Rivals/073.ts
+++ b/data/Scarlet & Violet/Destined Rivals/073.ts
@@ -50,8 +50,18 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		holo: false
-	}
+		normal: true,
+		reverse: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'normal'
+		},
+		{
+			type: 'reverse'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/074.ts
+++ b/data/Scarlet & Violet/Destined Rivals/074.ts
@@ -64,8 +64,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		normal: true,
-		reverse: true,
+		holo: false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/074.ts
+++ b/data/Scarlet & Violet/Destined Rivals/074.ts
@@ -63,7 +63,7 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'normal'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/074.ts
+++ b/data/Scarlet & Violet/Destined Rivals/074.ts
@@ -63,10 +63,6 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "I",
 
-	variants: {
-		holo: false
-	},
-
 	variants_detailed: [
 		{
 			type: 'normal'

--- a/data/Scarlet & Violet/Destined Rivals/074.ts
+++ b/data/Scarlet & Violet/Destined Rivals/074.ts
@@ -64,8 +64,18 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		holo: false
-	}
+		normal: true,
+		reverse: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'normal'
+		},
+		{
+			type: 'reverse'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/075.ts
+++ b/data/Scarlet & Violet/Destined Rivals/075.ts
@@ -53,10 +53,6 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "I",
 
-	variants: {
-		holo: false
-	},
-
 	variants_detailed: [
 		{
 			type: 'normal'

--- a/data/Scarlet & Violet/Destined Rivals/075.ts
+++ b/data/Scarlet & Violet/Destined Rivals/075.ts
@@ -54,8 +54,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		normal: true,
-		reverse: true,
+		holo: false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/075.ts
+++ b/data/Scarlet & Violet/Destined Rivals/075.ts
@@ -53,7 +53,7 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'normal'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/075.ts
+++ b/data/Scarlet & Violet/Destined Rivals/075.ts
@@ -54,8 +54,18 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		holo: false
-	}
+		normal: true,
+		reverse: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'normal'
+		},
+		{
+			type: 'reverse'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/076.ts
+++ b/data/Scarlet & Violet/Destined Rivals/076.ts
@@ -64,8 +64,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		normal: true,
-		reverse: true,
+		holo: false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/076.ts
+++ b/data/Scarlet & Violet/Destined Rivals/076.ts
@@ -63,7 +63,7 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'normal'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/076.ts
+++ b/data/Scarlet & Violet/Destined Rivals/076.ts
@@ -63,10 +63,6 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "I",
 
-	variants: {
-		holo: false
-	},
-
 	variants_detailed: [
 		{
 			type: 'normal'

--- a/data/Scarlet & Violet/Destined Rivals/076.ts
+++ b/data/Scarlet & Violet/Destined Rivals/076.ts
@@ -64,8 +64,18 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		holo: false
-	}
+		normal: true,
+		reverse: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'normal'
+		},
+		{
+			type: 'reverse'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/077.ts
+++ b/data/Scarlet & Violet/Destined Rivals/077.ts
@@ -73,10 +73,6 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "I",
 
-	variants: {
-		holo: false
-	},
-
 	variants_detailed: [
 		{
 			type: 'normal'

--- a/data/Scarlet & Violet/Destined Rivals/077.ts
+++ b/data/Scarlet & Violet/Destined Rivals/077.ts
@@ -74,8 +74,18 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		holo: false
-	}
+		normal: true,
+		reverse: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'normal'
+		},
+		{
+			type: 'reverse'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/077.ts
+++ b/data/Scarlet & Violet/Destined Rivals/077.ts
@@ -73,7 +73,7 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'normal'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/077.ts
+++ b/data/Scarlet & Violet/Destined Rivals/077.ts
@@ -74,8 +74,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		normal: true,
-		reverse: true,
+		holo: false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/078.ts
+++ b/data/Scarlet & Violet/Destined Rivals/078.ts
@@ -62,8 +62,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		reverse: true,
-		holo: true,
+		normal:false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/078.ts
+++ b/data/Scarlet & Violet/Destined Rivals/078.ts
@@ -62,9 +62,18 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		reverse: false,
-		normal: false
-	}
+		reverse: true,
+		holo: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'reverse'
+		},
+		{
+			type: 'holo'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/078.ts
+++ b/data/Scarlet & Violet/Destined Rivals/078.ts
@@ -61,7 +61,7 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'reverse'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/078.ts
+++ b/data/Scarlet & Violet/Destined Rivals/078.ts
@@ -61,10 +61,6 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "I",
 
-	variants: {
-		normal:false
-	},
-
 	variants_detailed: [
 		{
 			type: 'reverse'

--- a/data/Scarlet & Violet/Destined Rivals/079.ts
+++ b/data/Scarlet & Violet/Destined Rivals/079.ts
@@ -49,7 +49,7 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'normal'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/079.ts
+++ b/data/Scarlet & Violet/Destined Rivals/079.ts
@@ -50,8 +50,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		normal: true,
-		reverse: true,
+		holo: false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/079.ts
+++ b/data/Scarlet & Violet/Destined Rivals/079.ts
@@ -49,10 +49,6 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "I",
 
-	variants: {
-		holo: false
-	},
-
 	variants_detailed: [
 		{
 			type: 'normal'

--- a/data/Scarlet & Violet/Destined Rivals/079.ts
+++ b/data/Scarlet & Violet/Destined Rivals/079.ts
@@ -50,8 +50,18 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		holo: false
-	}
+		normal: true,
+		reverse: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'normal'
+		},
+		{
+			type: 'reverse'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/080.ts
+++ b/data/Scarlet & Violet/Destined Rivals/080.ts
@@ -64,8 +64,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		normal: true,
-		reverse: true,
+		holo: false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/080.ts
+++ b/data/Scarlet & Violet/Destined Rivals/080.ts
@@ -63,7 +63,7 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'normal'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/080.ts
+++ b/data/Scarlet & Violet/Destined Rivals/080.ts
@@ -63,10 +63,6 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "I",
 
-	variants: {
-		holo: false
-	},
-
 	variants_detailed: [
 		{
 			type: 'normal'

--- a/data/Scarlet & Violet/Destined Rivals/080.ts
+++ b/data/Scarlet & Violet/Destined Rivals/080.ts
@@ -64,8 +64,18 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		holo: false
-	}
+		normal: true,
+		reverse: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'normal'
+		},
+		{
+			type: 'reverse'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/081.ts
+++ b/data/Scarlet & Violet/Destined Rivals/081.ts
@@ -74,8 +74,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		reverse: true,
-		holo: true,
+		normal:false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/081.ts
+++ b/data/Scarlet & Violet/Destined Rivals/081.ts
@@ -73,7 +73,7 @@ const card: Card = {
 	retreat: 3,
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'reverse'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/081.ts
+++ b/data/Scarlet & Violet/Destined Rivals/081.ts
@@ -73,10 +73,6 @@ const card: Card = {
 	retreat: 3,
 	regulationMark: "I",
 
-	variants: {
-		normal:false
-	},
-
 	variants_detailed: [
 		{
 			type: 'reverse'

--- a/data/Scarlet & Violet/Destined Rivals/081.ts
+++ b/data/Scarlet & Violet/Destined Rivals/081.ts
@@ -74,9 +74,18 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		reverse: false,
-		normal: false
-	}
+		reverse: true,
+		holo: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'reverse'
+		},
+		{
+			type: 'holo'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/082.ts
+++ b/data/Scarlet & Violet/Destined Rivals/082.ts
@@ -62,8 +62,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		reverse: true,
-		holo: true,
+		normal:false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/082.ts
+++ b/data/Scarlet & Violet/Destined Rivals/082.ts
@@ -62,9 +62,18 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		reverse: false,
-		normal: false
-	}
+		reverse: true,
+		holo: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'reverse'
+		},
+		{
+			type: 'holo'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/082.ts
+++ b/data/Scarlet & Violet/Destined Rivals/082.ts
@@ -61,7 +61,7 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'reverse'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/082.ts
+++ b/data/Scarlet & Violet/Destined Rivals/082.ts
@@ -61,10 +61,6 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "I",
 
-	variants: {
-		normal:false
-	},
-
 	variants_detailed: [
 		{
 			type: 'reverse'

--- a/data/Scarlet & Violet/Destined Rivals/083.ts
+++ b/data/Scarlet & Violet/Destined Rivals/083.ts
@@ -62,8 +62,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		normal: true,
-		reverse: true,
+		holo: false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/083.ts
+++ b/data/Scarlet & Violet/Destined Rivals/083.ts
@@ -61,10 +61,6 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "I",
 
-	variants: {
-		holo: false
-	},
-
 	variants_detailed: [
 		{
 			type: 'normal'

--- a/data/Scarlet & Violet/Destined Rivals/083.ts
+++ b/data/Scarlet & Violet/Destined Rivals/083.ts
@@ -62,8 +62,18 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		holo: false
-	}
+		normal: true,
+		reverse: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'normal'
+		},
+		{
+			type: 'reverse'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/083.ts
+++ b/data/Scarlet & Violet/Destined Rivals/083.ts
@@ -61,7 +61,7 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'normal'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/084.ts
+++ b/data/Scarlet & Violet/Destined Rivals/084.ts
@@ -74,8 +74,18 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		holo: false
-	}
+		normal: true,
+		reverse: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'normal'
+		},
+		{
+			type: 'reverse'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/084.ts
+++ b/data/Scarlet & Violet/Destined Rivals/084.ts
@@ -73,7 +73,7 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'normal'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/084.ts
+++ b/data/Scarlet & Violet/Destined Rivals/084.ts
@@ -73,10 +73,6 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "I",
 
-	variants: {
-		holo: false
-	},
-
 	variants_detailed: [
 		{
 			type: 'normal'

--- a/data/Scarlet & Violet/Destined Rivals/084.ts
+++ b/data/Scarlet & Violet/Destined Rivals/084.ts
@@ -74,8 +74,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		normal: true,
-		reverse: true,
+		holo: false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/085.ts
+++ b/data/Scarlet & Violet/Destined Rivals/085.ts
@@ -46,8 +46,18 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		holo: false
-	}
+		normal: true,
+		reverse: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'normal'
+		},
+		{
+			type: 'reverse'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/085.ts
+++ b/data/Scarlet & Violet/Destined Rivals/085.ts
@@ -46,8 +46,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		normal: true,
-		reverse: true,
+		holo: false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/085.ts
+++ b/data/Scarlet & Violet/Destined Rivals/085.ts
@@ -45,10 +45,6 @@ const card: Card = {
 	retreat: 0,
 	regulationMark: "I",
 
-	variants: {
-		holo: false
-	},
-
 	variants_detailed: [
 		{
 			type: 'normal'

--- a/data/Scarlet & Violet/Destined Rivals/085.ts
+++ b/data/Scarlet & Violet/Destined Rivals/085.ts
@@ -45,7 +45,7 @@ const card: Card = {
 	retreat: 0,
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'normal'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/086.ts
+++ b/data/Scarlet & Violet/Destined Rivals/086.ts
@@ -64,8 +64,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		normal: true,
-		reverse: true,
+		holo: false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/086.ts
+++ b/data/Scarlet & Violet/Destined Rivals/086.ts
@@ -63,7 +63,7 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'normal'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/086.ts
+++ b/data/Scarlet & Violet/Destined Rivals/086.ts
@@ -63,10 +63,6 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "I",
 
-	variants: {
-		holo: false
-	},
-
 	variants_detailed: [
 		{
 			type: 'normal'

--- a/data/Scarlet & Violet/Destined Rivals/086.ts
+++ b/data/Scarlet & Violet/Destined Rivals/086.ts
@@ -64,8 +64,18 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		holo: false
-	}
+		normal: true,
+		reverse: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'normal'
+		},
+		{
+			type: 'reverse'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/087.ts
+++ b/data/Scarlet & Violet/Destined Rivals/087.ts
@@ -47,8 +47,6 @@ const card: Card = {
 	retreat: 0,
 	regulationMark: "I",
 
-	variants: {
-	},
 	variants: [
 		{
 			type: 'normal'

--- a/data/Scarlet & Violet/Destined Rivals/087.ts
+++ b/data/Scarlet & Violet/Destined Rivals/087.ts
@@ -49,7 +49,7 @@ const card: Card = {
 
 	variants: {
 	},
-	variants_detailed: [
+	variants: [
 		{
 			type: 'normal'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/087.ts
+++ b/data/Scarlet & Violet/Destined Rivals/087.ts
@@ -49,7 +49,6 @@ const card: Card = {
 
 	variants: {
 	},
-
 	variants_detailed: [
 		{
 			type: 'normal'

--- a/data/Scarlet & Violet/Destined Rivals/087.ts
+++ b/data/Scarlet & Violet/Destined Rivals/087.ts
@@ -48,9 +48,6 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		normal: true,
-		reverse: true,
-		holo: true,
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/087.ts
+++ b/data/Scarlet & Violet/Destined Rivals/087.ts
@@ -1,4 +1,4 @@
-import { Card } from "../../../interfaces"
+import {Card} from "../../../interfaces"
 import Set from "../Destined Rivals"
 
 const card: Card = {
@@ -48,8 +48,30 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		holo: false
-	}
+		normal: true,
+		reverse: true,
+		holo: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'normal'
+		},
+		{
+			type: 'reverse'
+		},
+		{
+			type: 'holo',
+		},
+		{
+			type: 'holo',
+			stamp: ["set-logo"]
+		},
+		{
+			type: 'holo',
+			stamp: ["set-logo", "staff"]
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/088.ts
+++ b/data/Scarlet & Violet/Destined Rivals/088.ts
@@ -61,7 +61,7 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'normal'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/088.ts
+++ b/data/Scarlet & Violet/Destined Rivals/088.ts
@@ -62,8 +62,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		normal: true,
-		reverse: true,
+		holo: false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/088.ts
+++ b/data/Scarlet & Violet/Destined Rivals/088.ts
@@ -61,10 +61,6 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "I",
 
-	variants: {
-		holo: false
-	},
-
 	variants_detailed: [
 		{
 			type: 'normal'

--- a/data/Scarlet & Violet/Destined Rivals/088.ts
+++ b/data/Scarlet & Violet/Destined Rivals/088.ts
@@ -62,8 +62,18 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		holo: false
-	}
+		normal: true,
+		reverse: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'normal'
+		},
+		{
+			type: 'reverse'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/089.ts
+++ b/data/Scarlet & Violet/Destined Rivals/089.ts
@@ -74,8 +74,18 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		holo: false
-	}
+		normal: true,
+		reverse: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'normal'
+		},
+		{
+			type: 'reverse'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/089.ts
+++ b/data/Scarlet & Violet/Destined Rivals/089.ts
@@ -73,7 +73,7 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'normal'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/089.ts
+++ b/data/Scarlet & Violet/Destined Rivals/089.ts
@@ -73,10 +73,6 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "I",
 
-	variants: {
-		holo: false
-	},
-
 	variants_detailed: [
 		{
 			type: 'normal'

--- a/data/Scarlet & Violet/Destined Rivals/089.ts
+++ b/data/Scarlet & Violet/Destined Rivals/089.ts
@@ -74,8 +74,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		normal: true,
-		reverse: true,
+		holo: false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/090.ts
+++ b/data/Scarlet & Violet/Destined Rivals/090.ts
@@ -49,7 +49,7 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'normal'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/090.ts
+++ b/data/Scarlet & Violet/Destined Rivals/090.ts
@@ -49,10 +49,6 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "I",
 
-	variants: {
-		holo: false
-	},
-
 	variants_detailed: [
 		{
 			type: 'normal'

--- a/data/Scarlet & Violet/Destined Rivals/090.ts
+++ b/data/Scarlet & Violet/Destined Rivals/090.ts
@@ -50,8 +50,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		normal: true,
-		reverse: true,
+		holo: false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/090.ts
+++ b/data/Scarlet & Violet/Destined Rivals/090.ts
@@ -50,8 +50,18 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		holo: false
-	}
+		normal: true,
+		reverse: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'normal'
+		},
+		{
+			type: 'reverse'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/091.ts
+++ b/data/Scarlet & Violet/Destined Rivals/091.ts
@@ -48,8 +48,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		normal: true,
-		reverse: true,
+		holo: false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/091.ts
+++ b/data/Scarlet & Violet/Destined Rivals/091.ts
@@ -47,10 +47,6 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "I",
 
-	variants: {
-		holo: false
-	},
-
 	variants_detailed: [
 		{
 			type: 'normal'

--- a/data/Scarlet & Violet/Destined Rivals/091.ts
+++ b/data/Scarlet & Violet/Destined Rivals/091.ts
@@ -48,8 +48,18 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		holo: false
-	}
+		normal: true,
+		reverse: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'normal'
+		},
+		{
+			type: 'reverse'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/091.ts
+++ b/data/Scarlet & Violet/Destined Rivals/091.ts
@@ -47,7 +47,7 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'normal'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/092.ts
+++ b/data/Scarlet & Violet/Destined Rivals/092.ts
@@ -74,8 +74,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		reverse: true,
-		holo: true,
+		normal:false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/092.ts
+++ b/data/Scarlet & Violet/Destined Rivals/092.ts
@@ -73,10 +73,6 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "I",
 
-	variants: {
-		normal:false
-	},
-
 	variants_detailed: [
 		{
 			type: 'reverse'

--- a/data/Scarlet & Violet/Destined Rivals/092.ts
+++ b/data/Scarlet & Violet/Destined Rivals/092.ts
@@ -74,9 +74,18 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		normal: false,
-		reverse: false
-	}
+		reverse: true,
+		holo: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'reverse'
+		},
+		{
+			type: 'holo'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/092.ts
+++ b/data/Scarlet & Violet/Destined Rivals/092.ts
@@ -73,7 +73,7 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'reverse'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/093.ts
+++ b/data/Scarlet & Violet/Destined Rivals/093.ts
@@ -72,8 +72,18 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		holo: false
-	}
+		normal: true,
+		reverse: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'normal'
+		},
+		{
+			type: 'reverse'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/093.ts
+++ b/data/Scarlet & Violet/Destined Rivals/093.ts
@@ -72,8 +72,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		normal: true,
-		reverse: true,
+		holo: false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/093.ts
+++ b/data/Scarlet & Violet/Destined Rivals/093.ts
@@ -71,10 +71,6 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "I",
 
-	variants: {
-		holo: false
-	},
-
 	variants_detailed: [
 		{
 			type: 'normal'

--- a/data/Scarlet & Violet/Destined Rivals/093.ts
+++ b/data/Scarlet & Violet/Destined Rivals/093.ts
@@ -71,7 +71,7 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'normal'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/094.ts
+++ b/data/Scarlet & Violet/Destined Rivals/094.ts
@@ -49,7 +49,7 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'normal'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/094.ts
+++ b/data/Scarlet & Violet/Destined Rivals/094.ts
@@ -49,10 +49,6 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "I",
 
-	variants: {
-		holo: false
-	},
-
 	variants_detailed: [
 		{
 			type: 'normal'

--- a/data/Scarlet & Violet/Destined Rivals/094.ts
+++ b/data/Scarlet & Violet/Destined Rivals/094.ts
@@ -50,8 +50,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		normal: true,
-		reverse: true,
+		holo: false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/094.ts
+++ b/data/Scarlet & Violet/Destined Rivals/094.ts
@@ -50,8 +50,18 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		holo: false
-	}
+		normal: true,
+		reverse: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'normal'
+		},
+		{
+			type: 'reverse'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/095.ts
+++ b/data/Scarlet & Violet/Destined Rivals/095.ts
@@ -49,7 +49,7 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'normal'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/095.ts
+++ b/data/Scarlet & Violet/Destined Rivals/095.ts
@@ -50,8 +50,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		normal: true,
-		reverse: true,
+		holo: false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/095.ts
+++ b/data/Scarlet & Violet/Destined Rivals/095.ts
@@ -49,10 +49,6 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "I",
 
-	variants: {
-		holo: false
-	},
-
 	variants_detailed: [
 		{
 			type: 'normal'

--- a/data/Scarlet & Violet/Destined Rivals/095.ts
+++ b/data/Scarlet & Violet/Destined Rivals/095.ts
@@ -50,8 +50,18 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		holo: false
-	}
+		normal: true,
+		reverse: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'normal'
+		},
+		{
+			type: 'reverse'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/096.ts
+++ b/data/Scarlet & Violet/Destined Rivals/096.ts
@@ -74,9 +74,6 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		normal: true,
-		reverse: true,
-		holo: true,
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/096.ts
+++ b/data/Scarlet & Violet/Destined Rivals/096.ts
@@ -73,8 +73,6 @@ const card: Card = {
 	retreat: 3,
 	regulationMark: "I",
 
-	variants: {
-	},
 	variants: [
 		{
 			type: 'normal'

--- a/data/Scarlet & Violet/Destined Rivals/096.ts
+++ b/data/Scarlet & Violet/Destined Rivals/096.ts
@@ -75,7 +75,6 @@ const card: Card = {
 
 	variants: {
 	},
-
 	variants_detailed: [
 		{
 			type: 'normal'

--- a/data/Scarlet & Violet/Destined Rivals/096.ts
+++ b/data/Scarlet & Violet/Destined Rivals/096.ts
@@ -75,7 +75,7 @@ const card: Card = {
 
 	variants: {
 	},
-	variants_detailed: [
+	variants: [
 		{
 			type: 'normal'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/096.ts
+++ b/data/Scarlet & Violet/Destined Rivals/096.ts
@@ -74,9 +74,27 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		reverse: false,
-		normal: false
-	}
+		normal: true,
+		reverse: true,
+		holo: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'normal'
+		},
+		{
+			type: 'reverse'
+		},
+		{
+			type: 'holo',
+			stamp: ["set-logo"]
+		},
+		{
+			type: 'holo',
+			stamp: ["set-logo", "staff"]
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/097.ts
+++ b/data/Scarlet & Violet/Destined Rivals/097.ts
@@ -53,7 +53,7 @@ const card: Card = {
 	retreat: 3,
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'normal'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/097.ts
+++ b/data/Scarlet & Violet/Destined Rivals/097.ts
@@ -53,10 +53,6 @@ const card: Card = {
 	retreat: 3,
 	regulationMark: "I",
 
-	variants: {
-		holo: false
-	},
-
 	variants_detailed: [
 		{
 			type: 'normal'

--- a/data/Scarlet & Violet/Destined Rivals/097.ts
+++ b/data/Scarlet & Violet/Destined Rivals/097.ts
@@ -54,8 +54,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		normal: true,
-		reverse: true,
+		holo: false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/097.ts
+++ b/data/Scarlet & Violet/Destined Rivals/097.ts
@@ -54,8 +54,18 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		holo: false
-	}
+		normal: true,
+		reverse: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'normal'
+		},
+		{
+			type: 'reverse'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/098.ts
+++ b/data/Scarlet & Violet/Destined Rivals/098.ts
@@ -63,7 +63,7 @@ const card: Card = {
 	retreat: 3,
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'normal'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/098.ts
+++ b/data/Scarlet & Violet/Destined Rivals/098.ts
@@ -64,8 +64,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		normal: true,
-		reverse: true,
+		holo: false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/098.ts
+++ b/data/Scarlet & Violet/Destined Rivals/098.ts
@@ -63,10 +63,6 @@ const card: Card = {
 	retreat: 3,
 	regulationMark: "I",
 
-	variants: {
-		holo: false
-	},
-
 	variants_detailed: [
 		{
 			type: 'normal'

--- a/data/Scarlet & Violet/Destined Rivals/098.ts
+++ b/data/Scarlet & Violet/Destined Rivals/098.ts
@@ -64,8 +64,18 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		holo: false
-	}
+		normal: true,
+		reverse: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'normal'
+		},
+		{
+			type: 'reverse'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/099.ts
+++ b/data/Scarlet & Violet/Destined Rivals/099.ts
@@ -49,7 +49,7 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'normal'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/099.ts
+++ b/data/Scarlet & Violet/Destined Rivals/099.ts
@@ -49,10 +49,6 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "I",
 
-	variants: {
-		holo: false
-	},
-
 	variants_detailed: [
 		{
 			type: 'normal'

--- a/data/Scarlet & Violet/Destined Rivals/099.ts
+++ b/data/Scarlet & Violet/Destined Rivals/099.ts
@@ -50,8 +50,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		normal: true,
-		reverse: true,
+		holo: false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/099.ts
+++ b/data/Scarlet & Violet/Destined Rivals/099.ts
@@ -50,8 +50,18 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		holo: false
-	}
+		normal: true,
+		reverse: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'normal'
+		},
+		{
+			type: 'reverse'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/100.ts
+++ b/data/Scarlet & Violet/Destined Rivals/100.ts
@@ -49,7 +49,7 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'normal'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/100.ts
+++ b/data/Scarlet & Violet/Destined Rivals/100.ts
@@ -49,10 +49,6 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "I",
 
-	variants: {
-		holo: false
-	},
-
 	variants_detailed: [
 		{
 			type: 'normal'

--- a/data/Scarlet & Violet/Destined Rivals/100.ts
+++ b/data/Scarlet & Violet/Destined Rivals/100.ts
@@ -50,8 +50,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		normal: true,
-		reverse: true,
+		holo: false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/100.ts
+++ b/data/Scarlet & Violet/Destined Rivals/100.ts
@@ -50,8 +50,18 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		holo: false
-	}
+		normal: true,
+		reverse: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'normal'
+		},
+		{
+			type: 'reverse'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/101.ts
+++ b/data/Scarlet & Violet/Destined Rivals/101.ts
@@ -71,11 +71,6 @@ const card: Card = {
 	retreat: 3,
 	regulationMark: "I",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
-
 	variants_detailed: [
 		{
 			type: 'holo'

--- a/data/Scarlet & Violet/Destined Rivals/101.ts
+++ b/data/Scarlet & Violet/Destined Rivals/101.ts
@@ -72,9 +72,14 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		normal: false,
-		reverse: false
-	}
+		holo: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'holo'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/101.ts
+++ b/data/Scarlet & Violet/Destined Rivals/101.ts
@@ -72,7 +72,8 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		holo: true,
+		normal: false,
+		reverse: false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/101.ts
+++ b/data/Scarlet & Violet/Destined Rivals/101.ts
@@ -71,7 +71,7 @@ const card: Card = {
 	retreat: 3,
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'holo'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/102.ts
+++ b/data/Scarlet & Violet/Destined Rivals/102.ts
@@ -49,7 +49,7 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'normal'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/102.ts
+++ b/data/Scarlet & Violet/Destined Rivals/102.ts
@@ -49,10 +49,6 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "I",
 
-	variants: {
-		holo: false
-	},
-
 	variants_detailed: [
 		{
 			type: 'normal'

--- a/data/Scarlet & Violet/Destined Rivals/102.ts
+++ b/data/Scarlet & Violet/Destined Rivals/102.ts
@@ -50,8 +50,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		normal: true,
-		reverse: true,
+		holo: false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/102.ts
+++ b/data/Scarlet & Violet/Destined Rivals/102.ts
@@ -50,8 +50,18 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		holo: false
-	}
+		normal: true,
+		reverse: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'normal'
+		},
+		{
+			type: 'reverse'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/103.ts
+++ b/data/Scarlet & Violet/Destined Rivals/103.ts
@@ -64,8 +64,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		normal: true,
-		reverse: true,
+		holo: false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/103.ts
+++ b/data/Scarlet & Violet/Destined Rivals/103.ts
@@ -63,7 +63,7 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'normal'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/103.ts
+++ b/data/Scarlet & Violet/Destined Rivals/103.ts
@@ -63,10 +63,6 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "I",
 
-	variants: {
-		holo: false
-	},
-
 	variants_detailed: [
 		{
 			type: 'normal'

--- a/data/Scarlet & Violet/Destined Rivals/103.ts
+++ b/data/Scarlet & Violet/Destined Rivals/103.ts
@@ -64,8 +64,18 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		holo: false
-	}
+		normal: true,
+		reverse: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'normal'
+		},
+		{
+			type: 'reverse'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/104.ts
+++ b/data/Scarlet & Violet/Destined Rivals/104.ts
@@ -74,7 +74,8 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		holo: true,
+		normal: false,
+		reverse: false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/104.ts
+++ b/data/Scarlet & Violet/Destined Rivals/104.ts
@@ -74,9 +74,14 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		reverse: false,
-		normal: false
-	}
+		holo: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'holo'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/104.ts
+++ b/data/Scarlet & Violet/Destined Rivals/104.ts
@@ -73,11 +73,6 @@ const card: Card = {
 	retreat: 0,
 	regulationMark: "I",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
-
 	variants_detailed: [
 		{
 			type: 'holo'

--- a/data/Scarlet & Violet/Destined Rivals/104.ts
+++ b/data/Scarlet & Violet/Destined Rivals/104.ts
@@ -73,7 +73,7 @@ const card: Card = {
 	retreat: 0,
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'holo'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/105.ts
+++ b/data/Scarlet & Violet/Destined Rivals/105.ts
@@ -50,8 +50,18 @@ const card: Card = {
 	regulationMark: "H",
 
 	variants: {
-		holo: false
-	}
+		normal: true,
+		reverse: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'normal'
+		},
+		{
+			type: 'reverse'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/105.ts
+++ b/data/Scarlet & Violet/Destined Rivals/105.ts
@@ -50,8 +50,7 @@ const card: Card = {
 	regulationMark: "H",
 
 	variants: {
-		normal: true,
-		reverse: true,
+		holo: false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/105.ts
+++ b/data/Scarlet & Violet/Destined Rivals/105.ts
@@ -48,11 +48,6 @@ const card: Card = {
 
 	retreat: 3,
 	regulationMark: "H",
-
-	variants: {
-		holo: false
-	},
-
 	variants_detailed: [
 		{
 			type: 'normal'

--- a/data/Scarlet & Violet/Destined Rivals/105.ts
+++ b/data/Scarlet & Violet/Destined Rivals/105.ts
@@ -48,7 +48,7 @@ const card: Card = {
 
 	retreat: 3,
 	regulationMark: "H",
-	variants_detailed: [
+	variants: [
 		{
 			type: 'normal'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/106.ts
+++ b/data/Scarlet & Violet/Destined Rivals/106.ts
@@ -62,7 +62,7 @@ const card: Card = {
 
 	retreat: 4,
 	regulationMark: "H",
-	variants_detailed: [
+	variants: [
 		{
 			type: 'normal'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/106.ts
+++ b/data/Scarlet & Violet/Destined Rivals/106.ts
@@ -64,8 +64,7 @@ const card: Card = {
 	regulationMark: "H",
 
 	variants: {
-		normal: true,
-		reverse: true,
+		holo: false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/106.ts
+++ b/data/Scarlet & Violet/Destined Rivals/106.ts
@@ -64,8 +64,18 @@ const card: Card = {
 	regulationMark: "H",
 
 	variants: {
-		holo: false
-	}
+		normal: true,
+		reverse: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'normal'
+		},
+		{
+			type: 'reverse'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/106.ts
+++ b/data/Scarlet & Violet/Destined Rivals/106.ts
@@ -62,11 +62,6 @@ const card: Card = {
 
 	retreat: 4,
 	regulationMark: "H",
-
-	variants: {
-		holo: false
-	},
-
 	variants_detailed: [
 		{
 			type: 'normal'

--- a/data/Scarlet & Violet/Destined Rivals/107.ts
+++ b/data/Scarlet & Violet/Destined Rivals/107.ts
@@ -49,7 +49,7 @@ const card: Card = {
 	retreat: 3,
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'normal'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/107.ts
+++ b/data/Scarlet & Violet/Destined Rivals/107.ts
@@ -49,10 +49,6 @@ const card: Card = {
 	retreat: 3,
 	regulationMark: "I",
 
-	variants: {
-		holo: false
-	},
-
 	variants_detailed: [
 		{
 			type: 'normal'

--- a/data/Scarlet & Violet/Destined Rivals/107.ts
+++ b/data/Scarlet & Violet/Destined Rivals/107.ts
@@ -50,8 +50,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		normal: true,
-		reverse: true,
+		holo: false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/107.ts
+++ b/data/Scarlet & Violet/Destined Rivals/107.ts
@@ -50,8 +50,18 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		holo: false
-	}
+		normal: true,
+		reverse: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'normal'
+		},
+		{
+			type: 'reverse'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/108.ts
+++ b/data/Scarlet & Violet/Destined Rivals/108.ts
@@ -63,7 +63,7 @@ const card: Card = {
 	retreat: 3,
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'normal'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/108.ts
+++ b/data/Scarlet & Violet/Destined Rivals/108.ts
@@ -64,8 +64,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		normal: true,
-		reverse: true,
+		holo: false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/108.ts
+++ b/data/Scarlet & Violet/Destined Rivals/108.ts
@@ -63,10 +63,6 @@ const card: Card = {
 	retreat: 3,
 	regulationMark: "I",
 
-	variants: {
-		holo: false
-	},
-
 	variants_detailed: [
 		{
 			type: 'normal'

--- a/data/Scarlet & Violet/Destined Rivals/108.ts
+++ b/data/Scarlet & Violet/Destined Rivals/108.ts
@@ -64,8 +64,18 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		holo: false
-	}
+		normal: true,
+		reverse: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'normal'
+		},
+		{
+			type: 'reverse'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/109.ts
+++ b/data/Scarlet & Violet/Destined Rivals/109.ts
@@ -49,7 +49,7 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'normal'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/109.ts
+++ b/data/Scarlet & Violet/Destined Rivals/109.ts
@@ -49,10 +49,6 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "I",
 
-	variants: {
-		holo: false
-	},
-
 	variants_detailed: [
 		{
 			type: 'normal'

--- a/data/Scarlet & Violet/Destined Rivals/109.ts
+++ b/data/Scarlet & Violet/Destined Rivals/109.ts
@@ -50,8 +50,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		normal: true,
-		reverse: true,
+		holo: false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/109.ts
+++ b/data/Scarlet & Violet/Destined Rivals/109.ts
@@ -50,8 +50,18 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		holo: false
-	}
+		normal: true,
+		reverse: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'normal'
+		},
+		{
+			type: 'reverse'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/110.ts
+++ b/data/Scarlet & Violet/Destined Rivals/110.ts
@@ -72,8 +72,18 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		holo: false
-	}
+		normal: true,
+		reverse: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'normal'
+		},
+		{
+			type: 'reverse'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/110.ts
+++ b/data/Scarlet & Violet/Destined Rivals/110.ts
@@ -71,10 +71,6 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "I",
 
-	variants: {
-		holo: false
-	},
-
 	variants_detailed: [
 		{
 			type: 'normal'

--- a/data/Scarlet & Violet/Destined Rivals/110.ts
+++ b/data/Scarlet & Violet/Destined Rivals/110.ts
@@ -72,8 +72,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		normal: true,
-		reverse: true,
+		holo: false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/110.ts
+++ b/data/Scarlet & Violet/Destined Rivals/110.ts
@@ -71,7 +71,7 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'normal'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/111.ts
+++ b/data/Scarlet & Violet/Destined Rivals/111.ts
@@ -72,8 +72,18 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		holo: false
-	}
+		normal: true,
+		reverse: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'normal'
+		},
+		{
+			type: 'reverse'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/111.ts
+++ b/data/Scarlet & Violet/Destined Rivals/111.ts
@@ -72,8 +72,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		normal: true,
-		reverse: true,
+		holo: false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/111.ts
+++ b/data/Scarlet & Violet/Destined Rivals/111.ts
@@ -71,10 +71,6 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "I",
 
-	variants: {
-		holo: false
-	},
-
 	variants_detailed: [
 		{
 			type: 'normal'

--- a/data/Scarlet & Violet/Destined Rivals/111.ts
+++ b/data/Scarlet & Violet/Destined Rivals/111.ts
@@ -71,7 +71,7 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'normal'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/112.ts
+++ b/data/Scarlet & Violet/Destined Rivals/112.ts
@@ -62,8 +62,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		normal: true,
-		reverse: true,
+		holo: false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/112.ts
+++ b/data/Scarlet & Violet/Destined Rivals/112.ts
@@ -61,10 +61,6 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "I",
 
-	variants: {
-		holo: false
-	},
-
 	variants_detailed: [
 		{
 			type: 'normal'

--- a/data/Scarlet & Violet/Destined Rivals/112.ts
+++ b/data/Scarlet & Violet/Destined Rivals/112.ts
@@ -62,8 +62,18 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		holo: false
-	}
+		normal: true,
+		reverse: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'normal'
+		},
+		{
+			type: 'reverse'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/112.ts
+++ b/data/Scarlet & Violet/Destined Rivals/112.ts
@@ -61,7 +61,7 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'normal'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/113.ts
+++ b/data/Scarlet & Violet/Destined Rivals/113.ts
@@ -72,8 +72,18 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		holo: false
-	}
+		normal: true,
+		reverse: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'normal'
+		},
+		{
+			type: 'reverse'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/113.ts
+++ b/data/Scarlet & Violet/Destined Rivals/113.ts
@@ -71,10 +71,6 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "I",
 
-	variants: {
-		holo: false
-	},
-
 	variants_detailed: [
 		{
 			type: 'normal'

--- a/data/Scarlet & Violet/Destined Rivals/113.ts
+++ b/data/Scarlet & Violet/Destined Rivals/113.ts
@@ -72,8 +72,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		normal: true,
-		reverse: true,
+		holo: false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/113.ts
+++ b/data/Scarlet & Violet/Destined Rivals/113.ts
@@ -71,7 +71,7 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'normal'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/114.ts
+++ b/data/Scarlet & Violet/Destined Rivals/114.ts
@@ -49,7 +49,7 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'normal'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/114.ts
+++ b/data/Scarlet & Violet/Destined Rivals/114.ts
@@ -49,10 +49,6 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "I",
 
-	variants: {
-		holo: false
-	},
-
 	variants_detailed: [
 		{
 			type: 'normal'

--- a/data/Scarlet & Violet/Destined Rivals/114.ts
+++ b/data/Scarlet & Violet/Destined Rivals/114.ts
@@ -50,8 +50,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		normal: true,
-		reverse: true,
+		holo: false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/114.ts
+++ b/data/Scarlet & Violet/Destined Rivals/114.ts
@@ -50,8 +50,18 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		holo: false
-	}
+		normal: true,
+		reverse: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'normal'
+		},
+		{
+			type: 'reverse'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/115.ts
+++ b/data/Scarlet & Violet/Destined Rivals/115.ts
@@ -61,7 +61,7 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'normal'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/115.ts
+++ b/data/Scarlet & Violet/Destined Rivals/115.ts
@@ -62,8 +62,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		normal: true,
-		reverse: true,
+		holo: false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/115.ts
+++ b/data/Scarlet & Violet/Destined Rivals/115.ts
@@ -61,10 +61,6 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "I",
 
-	variants: {
-		holo: false
-	},
-
 	variants_detailed: [
 		{
 			type: 'normal'

--- a/data/Scarlet & Violet/Destined Rivals/115.ts
+++ b/data/Scarlet & Violet/Destined Rivals/115.ts
@@ -62,8 +62,18 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		holo: false
-	}
+		normal: true,
+		reverse: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'normal'
+		},
+		{
+			type: 'reverse'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/116.ts
+++ b/data/Scarlet & Violet/Destined Rivals/116.ts
@@ -63,7 +63,7 @@ const card: Card = {
 	retreat: 3,
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'normal'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/116.ts
+++ b/data/Scarlet & Violet/Destined Rivals/116.ts
@@ -64,8 +64,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		normal: true,
-		reverse: true,
+		holo: false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/116.ts
+++ b/data/Scarlet & Violet/Destined Rivals/116.ts
@@ -63,10 +63,6 @@ const card: Card = {
 	retreat: 3,
 	regulationMark: "I",
 
-	variants: {
-		holo: false
-	},
-
 	variants_detailed: [
 		{
 			type: 'normal'

--- a/data/Scarlet & Violet/Destined Rivals/116.ts
+++ b/data/Scarlet & Violet/Destined Rivals/116.ts
@@ -64,8 +64,18 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		holo: false
-	}
+		normal: true,
+		reverse: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'normal'
+		},
+		{
+			type: 'reverse'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/117.ts
+++ b/data/Scarlet & Violet/Destined Rivals/117.ts
@@ -53,10 +53,6 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "I",
 
-	variants: {
-		holo: false
-	},
-
 	variants_detailed: [
 		{
 			type: 'normal'

--- a/data/Scarlet & Violet/Destined Rivals/117.ts
+++ b/data/Scarlet & Violet/Destined Rivals/117.ts
@@ -54,8 +54,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		normal: true,
-		reverse: true,
+		holo: false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/117.ts
+++ b/data/Scarlet & Violet/Destined Rivals/117.ts
@@ -53,7 +53,7 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'normal'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/117.ts
+++ b/data/Scarlet & Violet/Destined Rivals/117.ts
@@ -54,8 +54,18 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		holo: false
-	}
+		normal: true,
+		reverse: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'normal'
+		},
+		{
+			type: 'reverse'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/118.ts
+++ b/data/Scarlet & Violet/Destined Rivals/118.ts
@@ -64,8 +64,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		normal: true,
-		reverse: true,
+		holo: false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/118.ts
+++ b/data/Scarlet & Violet/Destined Rivals/118.ts
@@ -63,7 +63,7 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'normal'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/118.ts
+++ b/data/Scarlet & Violet/Destined Rivals/118.ts
@@ -63,10 +63,6 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "I",
 
-	variants: {
-		holo: false
-	},
-
 	variants_detailed: [
 		{
 			type: 'normal'

--- a/data/Scarlet & Violet/Destined Rivals/118.ts
+++ b/data/Scarlet & Violet/Destined Rivals/118.ts
@@ -64,8 +64,18 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		holo: false
-	}
+		normal: true,
+		reverse: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'normal'
+		},
+		{
+			type: 'reverse'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/119.ts
+++ b/data/Scarlet & Violet/Destined Rivals/119.ts
@@ -63,7 +63,7 @@ const card: Card = {
 	retreat: 3,
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'holo'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/119.ts
+++ b/data/Scarlet & Violet/Destined Rivals/119.ts
@@ -64,9 +64,14 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		reverse: false,
-		normal: false
-	}
+		holo: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'holo'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/119.ts
+++ b/data/Scarlet & Violet/Destined Rivals/119.ts
@@ -64,7 +64,8 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		holo: true,
+		normal: false,
+		reverse: false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/119.ts
+++ b/data/Scarlet & Violet/Destined Rivals/119.ts
@@ -63,11 +63,6 @@ const card: Card = {
 	retreat: 3,
 	regulationMark: "I",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
-
 	variants_detailed: [
 		{
 			type: 'holo'

--- a/data/Scarlet & Violet/Destined Rivals/120.ts
+++ b/data/Scarlet & Violet/Destined Rivals/120.ts
@@ -48,8 +48,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		normal: true,
-		reverse: true,
+		holo: false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/120.ts
+++ b/data/Scarlet & Violet/Destined Rivals/120.ts
@@ -47,10 +47,6 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "I",
 
-	variants: {
-		holo: false
-	},
-
 	variants_detailed: [
 		{
 			type: 'normal'

--- a/data/Scarlet & Violet/Destined Rivals/120.ts
+++ b/data/Scarlet & Violet/Destined Rivals/120.ts
@@ -48,8 +48,18 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		holo: false
-	}
+		normal: true,
+		reverse: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'normal'
+		},
+		{
+			type: 'reverse'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/120.ts
+++ b/data/Scarlet & Violet/Destined Rivals/120.ts
@@ -47,7 +47,7 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'normal'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/121.ts
+++ b/data/Scarlet & Violet/Destined Rivals/121.ts
@@ -73,10 +73,6 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "I",
 
-	variants: {
-		holo: false
-	},
-
 	variants_detailed: [
 		{
 			type: 'normal'

--- a/data/Scarlet & Violet/Destined Rivals/121.ts
+++ b/data/Scarlet & Violet/Destined Rivals/121.ts
@@ -74,8 +74,18 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		holo: false
-	}
+		normal: true,
+		reverse: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'normal'
+		},
+		{
+			type: 'reverse'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/121.ts
+++ b/data/Scarlet & Violet/Destined Rivals/121.ts
@@ -73,7 +73,7 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'normal'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/121.ts
+++ b/data/Scarlet & Violet/Destined Rivals/121.ts
@@ -74,8 +74,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		normal: true,
-		reverse: true,
+		holo: false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/122.ts
+++ b/data/Scarlet & Violet/Destined Rivals/122.ts
@@ -73,11 +73,6 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "I",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
-
 	variants_detailed: [
 		{
 			type: 'holo'

--- a/data/Scarlet & Violet/Destined Rivals/122.ts
+++ b/data/Scarlet & Violet/Destined Rivals/122.ts
@@ -74,7 +74,8 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		holo: true,
+		normal: false,
+		reverse: false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/122.ts
+++ b/data/Scarlet & Violet/Destined Rivals/122.ts
@@ -74,9 +74,14 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		reverse: false,
-		normal: false
-	}
+		holo: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'holo'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/122.ts
+++ b/data/Scarlet & Violet/Destined Rivals/122.ts
@@ -73,7 +73,7 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'holo'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/123.ts
+++ b/data/Scarlet & Violet/Destined Rivals/123.ts
@@ -48,8 +48,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		normal: true,
-		reverse: true,
+		holo: false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/123.ts
+++ b/data/Scarlet & Violet/Destined Rivals/123.ts
@@ -48,8 +48,18 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		holo: false
-	}
+		normal: true,
+		reverse: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'normal'
+		},
+		{
+			type: 'reverse'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/123.ts
+++ b/data/Scarlet & Violet/Destined Rivals/123.ts
@@ -47,7 +47,7 @@ const card: Card = {
 	retreat: 3,
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'normal'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/123.ts
+++ b/data/Scarlet & Violet/Destined Rivals/123.ts
@@ -47,10 +47,6 @@ const card: Card = {
 	retreat: 3,
 	regulationMark: "I",
 
-	variants: {
-		holo: false
-	},
-
 	variants_detailed: [
 		{
 			type: 'normal'

--- a/data/Scarlet & Violet/Destined Rivals/124.ts
+++ b/data/Scarlet & Violet/Destined Rivals/124.ts
@@ -74,8 +74,18 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		holo: false
-	}
+		normal: true,
+		reverse: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'normal'
+		},
+		{
+			type: 'reverse'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/124.ts
+++ b/data/Scarlet & Violet/Destined Rivals/124.ts
@@ -73,10 +73,6 @@ const card: Card = {
 	retreat: 4,
 	regulationMark: "I",
 
-	variants: {
-		holo: false
-	},
-
 	variants_detailed: [
 		{
 			type: 'normal'

--- a/data/Scarlet & Violet/Destined Rivals/124.ts
+++ b/data/Scarlet & Violet/Destined Rivals/124.ts
@@ -73,7 +73,7 @@ const card: Card = {
 	retreat: 4,
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'normal'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/124.ts
+++ b/data/Scarlet & Violet/Destined Rivals/124.ts
@@ -74,8 +74,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		normal: true,
-		reverse: true,
+		holo: false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/125.ts
+++ b/data/Scarlet & Violet/Destined Rivals/125.ts
@@ -64,8 +64,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		normal: true,
-		reverse: true,
+		holo: false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/125.ts
+++ b/data/Scarlet & Violet/Destined Rivals/125.ts
@@ -63,7 +63,7 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'normal'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/125.ts
+++ b/data/Scarlet & Violet/Destined Rivals/125.ts
@@ -63,10 +63,6 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "I",
 
-	variants: {
-		holo: false
-	},
-
 	variants_detailed: [
 		{
 			type: 'normal'

--- a/data/Scarlet & Violet/Destined Rivals/125.ts
+++ b/data/Scarlet & Violet/Destined Rivals/125.ts
@@ -64,8 +64,18 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		holo: false
-	}
+		normal: true,
+		reverse: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'normal'
+		},
+		{
+			type: 'reverse'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/126.ts
+++ b/data/Scarlet & Violet/Destined Rivals/126.ts
@@ -49,7 +49,7 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'normal'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/126.ts
+++ b/data/Scarlet & Violet/Destined Rivals/126.ts
@@ -50,8 +50,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		normal: true,
-		reverse: true,
+		holo: false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/126.ts
+++ b/data/Scarlet & Violet/Destined Rivals/126.ts
@@ -49,10 +49,6 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "I",
 
-	variants: {
-		holo: false
-	},
-
 	variants_detailed: [
 		{
 			type: 'normal'

--- a/data/Scarlet & Violet/Destined Rivals/126.ts
+++ b/data/Scarlet & Violet/Destined Rivals/126.ts
@@ -50,8 +50,18 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		holo: false
-	}
+		normal: true,
+		reverse: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'normal'
+		},
+		{
+			type: 'reverse'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/127.ts
+++ b/data/Scarlet & Violet/Destined Rivals/127.ts
@@ -72,8 +72,18 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		holo: false
-	}
+		normal: true,
+		reverse: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'normal'
+		},
+		{
+			type: 'reverse'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/127.ts
+++ b/data/Scarlet & Violet/Destined Rivals/127.ts
@@ -72,8 +72,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		normal: true,
-		reverse: true,
+		holo: false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/127.ts
+++ b/data/Scarlet & Violet/Destined Rivals/127.ts
@@ -71,10 +71,6 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "I",
 
-	variants: {
-		holo: false
-	},
-
 	variants_detailed: [
 		{
 			type: 'normal'

--- a/data/Scarlet & Violet/Destined Rivals/127.ts
+++ b/data/Scarlet & Violet/Destined Rivals/127.ts
@@ -71,7 +71,7 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'normal'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/128.ts
+++ b/data/Scarlet & Violet/Destined Rivals/128.ts
@@ -62,8 +62,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		reverse: true,
-		holo: true,
+		normal:false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/128.ts
+++ b/data/Scarlet & Violet/Destined Rivals/128.ts
@@ -61,7 +61,7 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'reverse'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/128.ts
+++ b/data/Scarlet & Violet/Destined Rivals/128.ts
@@ -61,10 +61,6 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "I",
 
-	variants: {
-		normal:false
-	},
-
 	variants_detailed: [
 		{
 			type: 'reverse'

--- a/data/Scarlet & Violet/Destined Rivals/128.ts
+++ b/data/Scarlet & Violet/Destined Rivals/128.ts
@@ -62,9 +62,18 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		normal: false,
-		reverse: false
-	}
+		reverse: true,
+		holo: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'reverse'
+		},
+		{
+			type: 'holo'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/129.ts
+++ b/data/Scarlet & Violet/Destined Rivals/129.ts
@@ -49,7 +49,7 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'normal'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/129.ts
+++ b/data/Scarlet & Violet/Destined Rivals/129.ts
@@ -49,10 +49,6 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "I",
 
-	variants: {
-		holo: false
-	},
-
 	variants_detailed: [
 		{
 			type: 'normal'

--- a/data/Scarlet & Violet/Destined Rivals/129.ts
+++ b/data/Scarlet & Violet/Destined Rivals/129.ts
@@ -50,8 +50,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		normal: true,
-		reverse: true,
+		holo: false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/129.ts
+++ b/data/Scarlet & Violet/Destined Rivals/129.ts
@@ -50,8 +50,18 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		holo: false
-	}
+		normal: true,
+		reverse: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'normal'
+		},
+		{
+			type: 'reverse'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/130.ts
+++ b/data/Scarlet & Violet/Destined Rivals/130.ts
@@ -49,7 +49,7 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'normal'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/130.ts
+++ b/data/Scarlet & Violet/Destined Rivals/130.ts
@@ -49,10 +49,6 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "I",
 
-	variants: {
-		holo: false
-	},
-
 	variants_detailed: [
 		{
 			type: 'normal'

--- a/data/Scarlet & Violet/Destined Rivals/130.ts
+++ b/data/Scarlet & Violet/Destined Rivals/130.ts
@@ -50,8 +50,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		normal: true,
-		reverse: true,
+		holo: false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/130.ts
+++ b/data/Scarlet & Violet/Destined Rivals/130.ts
@@ -50,8 +50,18 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		holo: false
-	}
+		normal: true,
+		reverse: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'normal'
+		},
+		{
+			type: 'reverse'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/131.ts
+++ b/data/Scarlet & Violet/Destined Rivals/131.ts
@@ -49,7 +49,7 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'normal'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/131.ts
+++ b/data/Scarlet & Violet/Destined Rivals/131.ts
@@ -49,10 +49,6 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "I",
 
-	variants: {
-		holo: false
-	},
-
 	variants_detailed: [
 		{
 			type: 'normal'

--- a/data/Scarlet & Violet/Destined Rivals/131.ts
+++ b/data/Scarlet & Violet/Destined Rivals/131.ts
@@ -50,8 +50,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		normal: true,
-		reverse: true,
+		holo: false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/131.ts
+++ b/data/Scarlet & Violet/Destined Rivals/131.ts
@@ -50,8 +50,18 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		holo: false
-	}
+		normal: true,
+		reverse: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'normal'
+		},
+		{
+			type: 'reverse'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/132.ts
+++ b/data/Scarlet & Violet/Destined Rivals/132.ts
@@ -49,7 +49,7 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'normal'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/132.ts
+++ b/data/Scarlet & Violet/Destined Rivals/132.ts
@@ -49,10 +49,6 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "I",
 
-	variants: {
-		holo: false
-	},
-
 	variants_detailed: [
 		{
 			type: 'normal'

--- a/data/Scarlet & Violet/Destined Rivals/132.ts
+++ b/data/Scarlet & Violet/Destined Rivals/132.ts
@@ -50,8 +50,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		normal: true,
-		reverse: true,
+		holo: false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/132.ts
+++ b/data/Scarlet & Violet/Destined Rivals/132.ts
@@ -50,8 +50,18 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		holo: false
-	}
+		normal: true,
+		reverse: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'normal'
+		},
+		{
+			type: 'reverse'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/133.ts
+++ b/data/Scarlet & Violet/Destined Rivals/133.ts
@@ -64,8 +64,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		normal: true,
-		reverse: true,
+		holo: false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/133.ts
+++ b/data/Scarlet & Violet/Destined Rivals/133.ts
@@ -63,7 +63,7 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'normal'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/133.ts
+++ b/data/Scarlet & Violet/Destined Rivals/133.ts
@@ -63,10 +63,6 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "I",
 
-	variants: {
-		holo: false
-	},
-
 	variants_detailed: [
 		{
 			type: 'normal'

--- a/data/Scarlet & Violet/Destined Rivals/133.ts
+++ b/data/Scarlet & Violet/Destined Rivals/133.ts
@@ -64,8 +64,18 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		holo: false
-	}
+		normal: true,
+		reverse: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'normal'
+		},
+		{
+			type: 'reverse'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/134.ts
+++ b/data/Scarlet & Violet/Destined Rivals/134.ts
@@ -62,8 +62,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		normal: true,
-		reverse: true,
+		holo: false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/134.ts
+++ b/data/Scarlet & Violet/Destined Rivals/134.ts
@@ -61,10 +61,6 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "I",
 
-	variants: {
-		holo: false
-	},
-
 	variants_detailed: [
 		{
 			type: 'normal'

--- a/data/Scarlet & Violet/Destined Rivals/134.ts
+++ b/data/Scarlet & Violet/Destined Rivals/134.ts
@@ -62,8 +62,18 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		holo: false
-	}
+		normal: true,
+		reverse: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'normal'
+		},
+		{
+			type: 'reverse'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/134.ts
+++ b/data/Scarlet & Violet/Destined Rivals/134.ts
@@ -61,7 +61,7 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'normal'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/135.ts
+++ b/data/Scarlet & Violet/Destined Rivals/135.ts
@@ -39,10 +39,6 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "I",
 
-	variants: {
-		holo: false
-	},
-
 	variants_detailed: [
 		{
 			type: 'normal'

--- a/data/Scarlet & Violet/Destined Rivals/135.ts
+++ b/data/Scarlet & Violet/Destined Rivals/135.ts
@@ -40,8 +40,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		normal: true,
-		reverse: true,
+		holo: false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/135.ts
+++ b/data/Scarlet & Violet/Destined Rivals/135.ts
@@ -39,7 +39,7 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'normal'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/135.ts
+++ b/data/Scarlet & Violet/Destined Rivals/135.ts
@@ -40,8 +40,18 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		holo: false
-	}
+		normal: true,
+		reverse: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'normal'
+		},
+		{
+			type: 'reverse'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/136.ts
+++ b/data/Scarlet & Violet/Destined Rivals/136.ts
@@ -74,9 +74,14 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		normal: false,
-		reverse: false
-	}
+		holo: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'holo'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/136.ts
+++ b/data/Scarlet & Violet/Destined Rivals/136.ts
@@ -74,7 +74,8 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		holo: true,
+		normal: false,
+		reverse: false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/136.ts
+++ b/data/Scarlet & Violet/Destined Rivals/136.ts
@@ -73,11 +73,6 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "I",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
-
 	variants_detailed: [
 		{
 			type: 'holo'

--- a/data/Scarlet & Violet/Destined Rivals/136.ts
+++ b/data/Scarlet & Violet/Destined Rivals/136.ts
@@ -73,7 +73,7 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'holo'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/137.ts
+++ b/data/Scarlet & Violet/Destined Rivals/137.ts
@@ -49,10 +49,6 @@ const card: Card = {
 	retreat: 0,
 	regulationMark: "I",
 
-	variants: {
-		holo: false
-	},
-
 	variants_detailed: [
 		{
 			type: 'normal'

--- a/data/Scarlet & Violet/Destined Rivals/137.ts
+++ b/data/Scarlet & Violet/Destined Rivals/137.ts
@@ -49,7 +49,7 @@ const card: Card = {
 	retreat: 0,
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'normal'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/137.ts
+++ b/data/Scarlet & Violet/Destined Rivals/137.ts
@@ -50,8 +50,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		normal: true,
-		reverse: true,
+		holo: false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/137.ts
+++ b/data/Scarlet & Violet/Destined Rivals/137.ts
@@ -50,8 +50,18 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		holo: false
-	}
+		normal: true,
+		reverse: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'normal'
+		},
+		{
+			type: 'reverse'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/138.ts
+++ b/data/Scarlet & Violet/Destined Rivals/138.ts
@@ -53,7 +53,7 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'normal'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/138.ts
+++ b/data/Scarlet & Violet/Destined Rivals/138.ts
@@ -53,10 +53,6 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "I",
 
-	variants: {
-		holo: false
-	},
-
 	variants_detailed: [
 		{
 			type: 'normal'

--- a/data/Scarlet & Violet/Destined Rivals/138.ts
+++ b/data/Scarlet & Violet/Destined Rivals/138.ts
@@ -54,8 +54,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		normal: true,
-		reverse: true,
+		holo: false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/138.ts
+++ b/data/Scarlet & Violet/Destined Rivals/138.ts
@@ -54,8 +54,18 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		holo: false
-	}
+		normal: true,
+		reverse: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'normal'
+		},
+		{
+			type: 'reverse'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/139.ts
+++ b/data/Scarlet & Violet/Destined Rivals/139.ts
@@ -74,9 +74,14 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		normal: false,
-		reverse: false
-	}
+		holo: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'holo'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/139.ts
+++ b/data/Scarlet & Violet/Destined Rivals/139.ts
@@ -74,7 +74,8 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		holo: true,
+		normal: false,
+		reverse: false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/139.ts
+++ b/data/Scarlet & Violet/Destined Rivals/139.ts
@@ -73,7 +73,7 @@ const card: Card = {
 	retreat: 3,
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'holo'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/139.ts
+++ b/data/Scarlet & Violet/Destined Rivals/139.ts
@@ -73,11 +73,6 @@ const card: Card = {
 	retreat: 3,
 	regulationMark: "I",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
-
 	variants_detailed: [
 		{
 			type: 'holo'

--- a/data/Scarlet & Violet/Destined Rivals/140.ts
+++ b/data/Scarlet & Violet/Destined Rivals/140.ts
@@ -74,8 +74,18 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		holo: false
-	}
+		normal: true,
+		reverse: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'normal'
+		},
+		{
+			type: 'reverse'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/140.ts
+++ b/data/Scarlet & Violet/Destined Rivals/140.ts
@@ -73,7 +73,7 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'normal'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/140.ts
+++ b/data/Scarlet & Violet/Destined Rivals/140.ts
@@ -73,10 +73,6 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "I",
 
-	variants: {
-		holo: false
-	},
-
 	variants_detailed: [
 		{
 			type: 'normal'

--- a/data/Scarlet & Violet/Destined Rivals/140.ts
+++ b/data/Scarlet & Violet/Destined Rivals/140.ts
@@ -74,8 +74,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		normal: true,
-		reverse: true,
+		holo: false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/141.ts
+++ b/data/Scarlet & Violet/Destined Rivals/141.ts
@@ -62,8 +62,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		normal: true,
-		reverse: true,
+		holo: false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/141.ts
+++ b/data/Scarlet & Violet/Destined Rivals/141.ts
@@ -61,10 +61,6 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "I",
 
-	variants: {
-		holo: false
-	},
-
 	variants_detailed: [
 		{
 			type: 'normal'

--- a/data/Scarlet & Violet/Destined Rivals/141.ts
+++ b/data/Scarlet & Violet/Destined Rivals/141.ts
@@ -62,8 +62,18 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		holo: false
-	}
+		normal: true,
+		reverse: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'normal'
+		},
+		{
+			type: 'reverse'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/141.ts
+++ b/data/Scarlet & Violet/Destined Rivals/141.ts
@@ -61,7 +61,7 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'normal'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/142.ts
+++ b/data/Scarlet & Violet/Destined Rivals/142.ts
@@ -62,8 +62,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		normal: true,
-		reverse: true,
+		holo: false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/142.ts
+++ b/data/Scarlet & Violet/Destined Rivals/142.ts
@@ -61,10 +61,6 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "I",
 
-	variants: {
-		holo: false
-	},
-
 	variants_detailed: [
 		{
 			type: 'normal'

--- a/data/Scarlet & Violet/Destined Rivals/142.ts
+++ b/data/Scarlet & Violet/Destined Rivals/142.ts
@@ -62,8 +62,18 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		holo: false
-	}
+		normal: true,
+		reverse: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'normal'
+		},
+		{
+			type: 'reverse'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/142.ts
+++ b/data/Scarlet & Violet/Destined Rivals/142.ts
@@ -61,7 +61,7 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'normal'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/143.ts
+++ b/data/Scarlet & Violet/Destined Rivals/143.ts
@@ -39,10 +39,6 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "I",
 
-	variants: {
-		holo: false
-	},
-
 	variants_detailed: [
 		{
 			type: 'normal'

--- a/data/Scarlet & Violet/Destined Rivals/143.ts
+++ b/data/Scarlet & Violet/Destined Rivals/143.ts
@@ -40,8 +40,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		normal: true,
-		reverse: true,
+		holo: false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/143.ts
+++ b/data/Scarlet & Violet/Destined Rivals/143.ts
@@ -39,7 +39,7 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'normal'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/143.ts
+++ b/data/Scarlet & Violet/Destined Rivals/143.ts
@@ -40,8 +40,18 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		holo: false
-	}
+		normal: true,
+		reverse: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'normal'
+		},
+		{
+			type: 'reverse'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/144.ts
+++ b/data/Scarlet & Violet/Destined Rivals/144.ts
@@ -49,7 +49,7 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'reverse'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/144.ts
+++ b/data/Scarlet & Violet/Destined Rivals/144.ts
@@ -49,10 +49,6 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "I",
 
-	variants: {
-		normal:false
-	},
-
 	variants_detailed: [
 		{
 			type: 'reverse'

--- a/data/Scarlet & Violet/Destined Rivals/144.ts
+++ b/data/Scarlet & Violet/Destined Rivals/144.ts
@@ -50,9 +50,18 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		normal: false,
-		reverse: false
-	}
+		reverse: true,
+		holo: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'reverse'
+		},
+		{
+			type: 'holo'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/144.ts
+++ b/data/Scarlet & Violet/Destined Rivals/144.ts
@@ -50,8 +50,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		reverse: true,
-		holo: true,
+		normal:false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/145.ts
+++ b/data/Scarlet & Violet/Destined Rivals/145.ts
@@ -63,7 +63,7 @@ const card: Card = {
 	retreat: 3,
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'holo'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/145.ts
+++ b/data/Scarlet & Violet/Destined Rivals/145.ts
@@ -64,7 +64,8 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		holo: true,
+		normal: false,
+		reverse: false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/145.ts
+++ b/data/Scarlet & Violet/Destined Rivals/145.ts
@@ -63,11 +63,6 @@ const card: Card = {
 	retreat: 3,
 	regulationMark: "I",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
-
 	variants_detailed: [
 		{
 			type: 'holo'

--- a/data/Scarlet & Violet/Destined Rivals/145.ts
+++ b/data/Scarlet & Violet/Destined Rivals/145.ts
@@ -64,9 +64,14 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		normal: false,
-		reverse: false
-	}
+		holo: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'holo'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/146.ts
+++ b/data/Scarlet & Violet/Destined Rivals/146.ts
@@ -49,7 +49,7 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'normal'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/146.ts
+++ b/data/Scarlet & Violet/Destined Rivals/146.ts
@@ -50,8 +50,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		normal: true,
-		reverse: true,
+		holo: false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/146.ts
+++ b/data/Scarlet & Violet/Destined Rivals/146.ts
@@ -49,10 +49,6 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "I",
 
-	variants: {
-		holo: false
-	},
-
 	variants_detailed: [
 		{
 			type: 'normal'

--- a/data/Scarlet & Violet/Destined Rivals/146.ts
+++ b/data/Scarlet & Violet/Destined Rivals/146.ts
@@ -50,8 +50,18 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		holo: false
-	}
+		normal: true,
+		reverse: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'normal'
+		},
+		{
+			type: 'reverse'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/147.ts
+++ b/data/Scarlet & Violet/Destined Rivals/147.ts
@@ -49,7 +49,7 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'normal'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/147.ts
+++ b/data/Scarlet & Violet/Destined Rivals/147.ts
@@ -49,10 +49,6 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "I",
 
-	variants: {
-		holo: false
-	},
-
 	variants_detailed: [
 		{
 			type: 'normal'

--- a/data/Scarlet & Violet/Destined Rivals/147.ts
+++ b/data/Scarlet & Violet/Destined Rivals/147.ts
@@ -50,8 +50,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		normal: true,
-		reverse: true,
+		holo: false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/147.ts
+++ b/data/Scarlet & Violet/Destined Rivals/147.ts
@@ -50,8 +50,18 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		holo: false
-	}
+		normal: true,
+		reverse: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'normal'
+		},
+		{
+			type: 'reverse'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/148.ts
+++ b/data/Scarlet & Violet/Destined Rivals/148.ts
@@ -49,7 +49,7 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'normal'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/148.ts
+++ b/data/Scarlet & Violet/Destined Rivals/148.ts
@@ -49,10 +49,6 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "I",
 
-	variants: {
-		holo: false
-	},
-
 	variants_detailed: [
 		{
 			type: 'normal'

--- a/data/Scarlet & Violet/Destined Rivals/148.ts
+++ b/data/Scarlet & Violet/Destined Rivals/148.ts
@@ -50,8 +50,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		normal: true,
-		reverse: true,
+		holo: false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/148.ts
+++ b/data/Scarlet & Violet/Destined Rivals/148.ts
@@ -50,8 +50,18 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		holo: false
-	}
+		normal: true,
+		reverse: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'normal'
+		},
+		{
+			type: 'reverse'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/149.ts
+++ b/data/Scarlet & Violet/Destined Rivals/149.ts
@@ -72,8 +72,18 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		holo: false
-	}
+		normal: true,
+		reverse: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'normal'
+		},
+		{
+			type: 'reverse'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/149.ts
+++ b/data/Scarlet & Violet/Destined Rivals/149.ts
@@ -72,8 +72,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		normal: true,
-		reverse: true,
+		holo: false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/149.ts
+++ b/data/Scarlet & Violet/Destined Rivals/149.ts
@@ -71,10 +71,6 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "I",
 
-	variants: {
-		holo: false
-	},
-
 	variants_detailed: [
 		{
 			type: 'normal'

--- a/data/Scarlet & Violet/Destined Rivals/149.ts
+++ b/data/Scarlet & Violet/Destined Rivals/149.ts
@@ -71,7 +71,7 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'normal'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/150.ts
+++ b/data/Scarlet & Violet/Destined Rivals/150.ts
@@ -71,7 +71,7 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'holo'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/150.ts
+++ b/data/Scarlet & Violet/Destined Rivals/150.ts
@@ -72,9 +72,14 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		normal: false,
-		reverse: false
-	}
+		holo: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'holo'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/150.ts
+++ b/data/Scarlet & Violet/Destined Rivals/150.ts
@@ -72,7 +72,8 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		holo: true,
+		normal: false,
+		reverse: false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/150.ts
+++ b/data/Scarlet & Violet/Destined Rivals/150.ts
@@ -71,11 +71,6 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "I",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
-
 	variants_detailed: [
 		{
 			type: 'holo'

--- a/data/Scarlet & Violet/Destined Rivals/151.ts
+++ b/data/Scarlet & Violet/Destined Rivals/151.ts
@@ -64,8 +64,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		normal: true,
-		reverse: true,
+		holo: false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/151.ts
+++ b/data/Scarlet & Violet/Destined Rivals/151.ts
@@ -63,7 +63,7 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'normal'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/151.ts
+++ b/data/Scarlet & Violet/Destined Rivals/151.ts
@@ -63,10 +63,6 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "I",
 
-	variants: {
-		holo: false
-	},
-
 	variants_detailed: [
 		{
 			type: 'normal'

--- a/data/Scarlet & Violet/Destined Rivals/151.ts
+++ b/data/Scarlet & Violet/Destined Rivals/151.ts
@@ -64,8 +64,18 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		holo: false
-	}
+		normal: true,
+		reverse: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'normal'
+		},
+		{
+			type: 'reverse'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/152.ts
+++ b/data/Scarlet & Violet/Destined Rivals/152.ts
@@ -64,8 +64,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		normal: true,
-		reverse: true,
+		holo: false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/152.ts
+++ b/data/Scarlet & Violet/Destined Rivals/152.ts
@@ -63,7 +63,7 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'normal'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/152.ts
+++ b/data/Scarlet & Violet/Destined Rivals/152.ts
@@ -63,10 +63,6 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "I",
 
-	variants: {
-		holo: false
-	},
-
 	variants_detailed: [
 		{
 			type: 'normal'

--- a/data/Scarlet & Violet/Destined Rivals/152.ts
+++ b/data/Scarlet & Violet/Destined Rivals/152.ts
@@ -64,8 +64,18 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		holo: false
-	}
+		normal: true,
+		reverse: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'normal'
+		},
+		{
+			type: 'reverse'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/153.ts
+++ b/data/Scarlet & Violet/Destined Rivals/153.ts
@@ -48,8 +48,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		normal: true,
-		reverse: true,
+		holo: false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/153.ts
+++ b/data/Scarlet & Violet/Destined Rivals/153.ts
@@ -47,10 +47,6 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "I",
 
-	variants: {
-		holo: false
-	},
-
 	variants_detailed: [
 		{
 			type: 'normal'

--- a/data/Scarlet & Violet/Destined Rivals/153.ts
+++ b/data/Scarlet & Violet/Destined Rivals/153.ts
@@ -48,8 +48,18 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		holo: false
-	}
+		normal: true,
+		reverse: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'normal'
+		},
+		{
+			type: 'reverse'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/153.ts
+++ b/data/Scarlet & Violet/Destined Rivals/153.ts
@@ -47,7 +47,7 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'normal'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/154.ts
+++ b/data/Scarlet & Violet/Destined Rivals/154.ts
@@ -49,7 +49,7 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'normal'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/154.ts
+++ b/data/Scarlet & Violet/Destined Rivals/154.ts
@@ -49,10 +49,6 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "I",
 
-	variants: {
-		holo: false
-	},
-
 	variants_detailed: [
 		{
 			type: 'normal'

--- a/data/Scarlet & Violet/Destined Rivals/154.ts
+++ b/data/Scarlet & Violet/Destined Rivals/154.ts
@@ -50,8 +50,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		normal: true,
-		reverse: true,
+		holo: false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/154.ts
+++ b/data/Scarlet & Violet/Destined Rivals/154.ts
@@ -50,8 +50,18 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		holo: false
-	}
+		normal: true,
+		reverse: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'normal'
+		},
+		{
+			type: 'reverse'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/155.ts
+++ b/data/Scarlet & Violet/Destined Rivals/155.ts
@@ -73,10 +73,6 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "I",
 
-	variants: {
-		holo: false
-	},
-
 	variants_detailed: [
 		{
 			type: 'normal'

--- a/data/Scarlet & Violet/Destined Rivals/155.ts
+++ b/data/Scarlet & Violet/Destined Rivals/155.ts
@@ -74,8 +74,18 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		holo: false
-	}
+		normal: true,
+		reverse: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'normal'
+		},
+		{
+			type: 'reverse'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/155.ts
+++ b/data/Scarlet & Violet/Destined Rivals/155.ts
@@ -73,7 +73,7 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'normal'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/155.ts
+++ b/data/Scarlet & Violet/Destined Rivals/155.ts
@@ -74,8 +74,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		normal: true,
-		reverse: true,
+		holo: false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/156.ts
+++ b/data/Scarlet & Violet/Destined Rivals/156.ts
@@ -39,10 +39,6 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "I",
 
-	variants: {
-		holo: false
-	},
-
 	variants_detailed: [
 		{
 			type: 'normal'

--- a/data/Scarlet & Violet/Destined Rivals/156.ts
+++ b/data/Scarlet & Violet/Destined Rivals/156.ts
@@ -40,8 +40,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		normal: true,
-		reverse: true,
+		holo: false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/156.ts
+++ b/data/Scarlet & Violet/Destined Rivals/156.ts
@@ -39,7 +39,7 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'normal'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/156.ts
+++ b/data/Scarlet & Violet/Destined Rivals/156.ts
@@ -40,8 +40,18 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		holo: false
-	}
+		normal: true,
+		reverse: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'normal'
+		},
+		{
+			type: 'reverse'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/157.ts
+++ b/data/Scarlet & Violet/Destined Rivals/157.ts
@@ -61,7 +61,7 @@ const card: Card = {
 	retreat: 0,
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'normal'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/157.ts
+++ b/data/Scarlet & Violet/Destined Rivals/157.ts
@@ -62,8 +62,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		normal: true,
-		reverse: true,
+		holo: false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/157.ts
+++ b/data/Scarlet & Violet/Destined Rivals/157.ts
@@ -61,10 +61,6 @@ const card: Card = {
 	retreat: 0,
 	regulationMark: "I",
 
-	variants: {
-		holo: false
-	},
-
 	variants_detailed: [
 		{
 			type: 'normal'

--- a/data/Scarlet & Violet/Destined Rivals/157.ts
+++ b/data/Scarlet & Violet/Destined Rivals/157.ts
@@ -62,8 +62,18 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		holo: false
-	}
+		normal: true,
+		reverse: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'normal'
+		},
+		{
+			type: 'reverse'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/158.ts
+++ b/data/Scarlet & Violet/Destined Rivals/158.ts
@@ -49,7 +49,7 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'normal'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/158.ts
+++ b/data/Scarlet & Violet/Destined Rivals/158.ts
@@ -49,10 +49,6 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "I",
 
-	variants: {
-		holo: false
-	},
-
 	variants_detailed: [
 		{
 			type: 'normal'

--- a/data/Scarlet & Violet/Destined Rivals/158.ts
+++ b/data/Scarlet & Violet/Destined Rivals/158.ts
@@ -50,8 +50,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		normal: true,
-		reverse: true,
+		holo: false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/158.ts
+++ b/data/Scarlet & Violet/Destined Rivals/158.ts
@@ -50,8 +50,18 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		holo: false
-	}
+		normal: true,
+		reverse: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'normal'
+		},
+		{
+			type: 'reverse'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/159.ts
+++ b/data/Scarlet & Violet/Destined Rivals/159.ts
@@ -63,7 +63,7 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'reverse'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/159.ts
+++ b/data/Scarlet & Violet/Destined Rivals/159.ts
@@ -64,9 +64,18 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		normal: false,
-		reverse: false
-	}
+		reverse: true,
+		holo: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'reverse'
+		},
+		{
+			type: 'holo'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/159.ts
+++ b/data/Scarlet & Violet/Destined Rivals/159.ts
@@ -64,8 +64,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		reverse: true,
-		holo: true,
+		normal:false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/159.ts
+++ b/data/Scarlet & Violet/Destined Rivals/159.ts
@@ -63,10 +63,6 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "I",
 
-	variants: {
-		normal:false
-	},
-
 	variants_detailed: [
 		{
 			type: 'reverse'

--- a/data/Scarlet & Violet/Destined Rivals/160.ts
+++ b/data/Scarlet & Violet/Destined Rivals/160.ts
@@ -49,7 +49,7 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'normal'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/160.ts
+++ b/data/Scarlet & Violet/Destined Rivals/160.ts
@@ -49,10 +49,6 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "I",
 
-	variants: {
-		holo: false
-	},
-
 	variants_detailed: [
 		{
 			type: 'normal'

--- a/data/Scarlet & Violet/Destined Rivals/160.ts
+++ b/data/Scarlet & Violet/Destined Rivals/160.ts
@@ -50,8 +50,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		normal: true,
-		reverse: true,
+		holo: false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/160.ts
+++ b/data/Scarlet & Violet/Destined Rivals/160.ts
@@ -50,8 +50,18 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		holo: false
-	}
+		normal: true,
+		reverse: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'normal'
+		},
+		{
+			type: 'reverse'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/161.ts
+++ b/data/Scarlet & Violet/Destined Rivals/161.ts
@@ -30,10 +30,6 @@ const card: Card = {
 	trainerType: "Item",
 	regulationMark: "I",
 
-	variants: {
-		holo: false
-	},
-
 	variants_detailed: [
 		{
 			type: 'normal'

--- a/data/Scarlet & Violet/Destined Rivals/161.ts
+++ b/data/Scarlet & Violet/Destined Rivals/161.ts
@@ -31,8 +31,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		normal: true,
-		reverse: true,
+		holo: false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/161.ts
+++ b/data/Scarlet & Violet/Destined Rivals/161.ts
@@ -31,8 +31,18 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		holo: false
-	}
+		normal: true,
+		reverse: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'normal'
+		},
+		{
+			type: 'reverse'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/161.ts
+++ b/data/Scarlet & Violet/Destined Rivals/161.ts
@@ -30,7 +30,7 @@ const card: Card = {
 	trainerType: "Item",
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'normal'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/162.ts
+++ b/data/Scarlet & Violet/Destined Rivals/162.ts
@@ -30,10 +30,6 @@ const card: Card = {
 	trainerType: "Tool",
 	regulationMark: "I",
 
-	variants: {
-		holo: false
-	},
-
 	variants_detailed: [
 		{
 			type: 'normal'

--- a/data/Scarlet & Violet/Destined Rivals/162.ts
+++ b/data/Scarlet & Violet/Destined Rivals/162.ts
@@ -31,8 +31,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		normal: true,
-		reverse: true,
+		holo: false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/162.ts
+++ b/data/Scarlet & Violet/Destined Rivals/162.ts
@@ -30,7 +30,7 @@ const card: Card = {
 	trainerType: "Tool",
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'normal'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/162.ts
+++ b/data/Scarlet & Violet/Destined Rivals/162.ts
@@ -31,8 +31,18 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		holo: false
-	}
+		normal: true,
+		reverse: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'normal'
+		},
+		{
+			type: 'reverse'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/163.ts
+++ b/data/Scarlet & Violet/Destined Rivals/163.ts
@@ -30,7 +30,7 @@ const card: Card = {
 	trainerType: "Supporter",
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'normal'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/163.ts
+++ b/data/Scarlet & Violet/Destined Rivals/163.ts
@@ -31,8 +31,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		normal: true,
-		reverse: true,
+		holo: false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/163.ts
+++ b/data/Scarlet & Violet/Destined Rivals/163.ts
@@ -31,8 +31,18 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		holo: false
-	}
+		normal: true,
+		reverse: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'normal'
+		},
+		{
+			type: 'reverse'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/163.ts
+++ b/data/Scarlet & Violet/Destined Rivals/163.ts
@@ -30,10 +30,6 @@ const card: Card = {
 	trainerType: "Supporter",
 	regulationMark: "I",
 
-	variants: {
-		holo: false
-	},
-
 	variants_detailed: [
 		{
 			type: 'normal'

--- a/data/Scarlet & Violet/Destined Rivals/164.ts
+++ b/data/Scarlet & Violet/Destined Rivals/164.ts
@@ -30,10 +30,6 @@ const card: Card = {
 	trainerType: "Item",
 	regulationMark: "I",
 
-	variants: {
-		holo: false
-	},
-
 	variants_detailed: [
 		{
 			type: 'normal'

--- a/data/Scarlet & Violet/Destined Rivals/164.ts
+++ b/data/Scarlet & Violet/Destined Rivals/164.ts
@@ -31,8 +31,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		normal: true,
-		reverse: true,
+		holo: false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/164.ts
+++ b/data/Scarlet & Violet/Destined Rivals/164.ts
@@ -31,8 +31,18 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		holo: false
-	}
+		normal: true,
+		reverse: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'normal'
+		},
+		{
+			type: 'reverse'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/164.ts
+++ b/data/Scarlet & Violet/Destined Rivals/164.ts
@@ -30,7 +30,7 @@ const card: Card = {
 	trainerType: "Item",
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'normal'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/165.ts
+++ b/data/Scarlet & Violet/Destined Rivals/165.ts
@@ -30,7 +30,7 @@ const card: Card = {
 	trainerType: "Supporter",
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'normal'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/165.ts
+++ b/data/Scarlet & Violet/Destined Rivals/165.ts
@@ -31,8 +31,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		normal: true,
-		reverse: true,
+		holo: false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/165.ts
+++ b/data/Scarlet & Violet/Destined Rivals/165.ts
@@ -31,8 +31,18 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		holo: false
-	}
+		normal: true,
+		reverse: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'normal'
+		},
+		{
+			type: 'reverse'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/165.ts
+++ b/data/Scarlet & Violet/Destined Rivals/165.ts
@@ -30,10 +30,6 @@ const card: Card = {
 	trainerType: "Supporter",
 	regulationMark: "I",
 
-	variants: {
-		holo: false
-	},
-
 	variants_detailed: [
 		{
 			type: 'normal'

--- a/data/Scarlet & Violet/Destined Rivals/166.ts
+++ b/data/Scarlet & Violet/Destined Rivals/166.ts
@@ -31,8 +31,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		normal: true,
-		reverse: true,
+		holo: false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/166.ts
+++ b/data/Scarlet & Violet/Destined Rivals/166.ts
@@ -30,10 +30,6 @@ const card: Card = {
 	trainerType: "Stadium",
 	regulationMark: "I",
 
-	variants: {
-		holo: false
-	},
-
 	variants_detailed: [
 		{
 			type: 'normal'

--- a/data/Scarlet & Violet/Destined Rivals/166.ts
+++ b/data/Scarlet & Violet/Destined Rivals/166.ts
@@ -30,7 +30,7 @@ const card: Card = {
 	trainerType: "Stadium",
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'normal'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/166.ts
+++ b/data/Scarlet & Violet/Destined Rivals/166.ts
@@ -31,8 +31,18 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		holo: false
-	}
+		normal: true,
+		reverse: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'normal'
+		},
+		{
+			type: 'reverse'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/167.ts
+++ b/data/Scarlet & Violet/Destined Rivals/167.ts
@@ -29,7 +29,7 @@ const card: Card = {
 
 	trainerType: "Supporter",
 	regulationMark: "G",
-	variants_detailed: [
+	variants: [
 		{
 			type: 'normal'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/167.ts
+++ b/data/Scarlet & Violet/Destined Rivals/167.ts
@@ -29,11 +29,6 @@ const card: Card = {
 
 	trainerType: "Supporter",
 	regulationMark: "G",
-
-	variants: {
-		holo: false
-	},
-
 	variants_detailed: [
 		{
 			type: 'normal'

--- a/data/Scarlet & Violet/Destined Rivals/167.ts
+++ b/data/Scarlet & Violet/Destined Rivals/167.ts
@@ -31,8 +31,7 @@ const card: Card = {
 	regulationMark: "G",
 
 	variants: {
-		normal: true,
-		reverse: true,
+		holo: false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/167.ts
+++ b/data/Scarlet & Violet/Destined Rivals/167.ts
@@ -31,8 +31,18 @@ const card: Card = {
 	regulationMark: "G",
 
 	variants: {
-		holo: false
-	}
+		normal: true,
+		reverse: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'normal'
+		},
+		{
+			type: 'reverse'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/168.ts
+++ b/data/Scarlet & Violet/Destined Rivals/168.ts
@@ -30,10 +30,6 @@ const card: Card = {
 	trainerType: "Item",
 	regulationMark: "I",
 
-	variants: {
-		holo: false
-	},
-
 	variants_detailed: [
 		{
 			type: 'normal'

--- a/data/Scarlet & Violet/Destined Rivals/168.ts
+++ b/data/Scarlet & Violet/Destined Rivals/168.ts
@@ -31,8 +31,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		normal: true,
-		reverse: true,
+		holo: false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/168.ts
+++ b/data/Scarlet & Violet/Destined Rivals/168.ts
@@ -31,8 +31,18 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		holo: false
-	}
+		normal: true,
+		reverse: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'normal'
+		},
+		{
+			type: 'reverse'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/168.ts
+++ b/data/Scarlet & Violet/Destined Rivals/168.ts
@@ -30,7 +30,7 @@ const card: Card = {
 	trainerType: "Item",
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'normal'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/169.ts
+++ b/data/Scarlet & Violet/Destined Rivals/169.ts
@@ -31,8 +31,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		normal: true,
-		reverse: true,
+		holo: false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/169.ts
+++ b/data/Scarlet & Violet/Destined Rivals/169.ts
@@ -30,10 +30,6 @@ const card: Card = {
 	trainerType: "Stadium",
 	regulationMark: "I",
 
-	variants: {
-		holo: false
-	},
-
 	variants_detailed: [
 		{
 			type: 'normal'

--- a/data/Scarlet & Violet/Destined Rivals/169.ts
+++ b/data/Scarlet & Violet/Destined Rivals/169.ts
@@ -30,7 +30,7 @@ const card: Card = {
 	trainerType: "Stadium",
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'normal'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/169.ts
+++ b/data/Scarlet & Violet/Destined Rivals/169.ts
@@ -31,8 +31,18 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		holo: false
-	}
+		normal: true,
+		reverse: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'normal'
+		},
+		{
+			type: 'reverse'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/170.ts
+++ b/data/Scarlet & Violet/Destined Rivals/170.ts
@@ -30,7 +30,7 @@ const card: Card = {
 	trainerType: "Supporter",
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'normal'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/170.ts
+++ b/data/Scarlet & Violet/Destined Rivals/170.ts
@@ -31,8 +31,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		normal: true,
-		reverse: true,
+		holo: false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/170.ts
+++ b/data/Scarlet & Violet/Destined Rivals/170.ts
@@ -31,8 +31,18 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		holo: false
-	}
+		normal: true,
+		reverse: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'normal'
+		},
+		{
+			type: 'reverse'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/170.ts
+++ b/data/Scarlet & Violet/Destined Rivals/170.ts
@@ -30,10 +30,6 @@ const card: Card = {
 	trainerType: "Supporter",
 	regulationMark: "I",
 
-	variants: {
-		holo: false
-	},
-
 	variants_detailed: [
 		{
 			type: 'normal'

--- a/data/Scarlet & Violet/Destined Rivals/171.ts
+++ b/data/Scarlet & Violet/Destined Rivals/171.ts
@@ -30,7 +30,7 @@ const card: Card = {
 	trainerType: "Supporter",
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'normal'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/171.ts
+++ b/data/Scarlet & Violet/Destined Rivals/171.ts
@@ -31,8 +31,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		normal: true,
-		reverse: true,
+		holo: false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/171.ts
+++ b/data/Scarlet & Violet/Destined Rivals/171.ts
@@ -31,8 +31,18 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		holo: false
-	}
+		normal: true,
+		reverse: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'normal'
+		},
+		{
+			type: 'reverse'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/171.ts
+++ b/data/Scarlet & Violet/Destined Rivals/171.ts
@@ -30,10 +30,6 @@ const card: Card = {
 	trainerType: "Supporter",
 	regulationMark: "I",
 
-	variants: {
-		holo: false
-	},
-
 	variants_detailed: [
 		{
 			type: 'normal'

--- a/data/Scarlet & Violet/Destined Rivals/172.ts
+++ b/data/Scarlet & Violet/Destined Rivals/172.ts
@@ -30,10 +30,6 @@ const card: Card = {
 	trainerType: "Item",
 	regulationMark: "I",
 
-	variants: {
-		holo: false
-	},
-
 	variants_detailed: [
 		{
 			type: 'normal'

--- a/data/Scarlet & Violet/Destined Rivals/172.ts
+++ b/data/Scarlet & Violet/Destined Rivals/172.ts
@@ -31,8 +31,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		normal: true,
-		reverse: true,
+		holo: false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/172.ts
+++ b/data/Scarlet & Violet/Destined Rivals/172.ts
@@ -31,8 +31,18 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		holo: false
-	}
+		normal: true,
+		reverse: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'normal'
+		},
+		{
+			type: 'reverse'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/172.ts
+++ b/data/Scarlet & Violet/Destined Rivals/172.ts
@@ -30,7 +30,7 @@ const card: Card = {
 	trainerType: "Item",
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'normal'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/173.ts
+++ b/data/Scarlet & Violet/Destined Rivals/173.ts
@@ -31,8 +31,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		normal: true,
-		reverse: true,
+		holo: false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/173.ts
+++ b/data/Scarlet & Violet/Destined Rivals/173.ts
@@ -30,10 +30,6 @@ const card: Card = {
 	trainerType: "Stadium",
 	regulationMark: "I",
 
-	variants: {
-		holo: false
-	},
-
 	variants_detailed: [
 		{
 			type: 'normal'

--- a/data/Scarlet & Violet/Destined Rivals/173.ts
+++ b/data/Scarlet & Violet/Destined Rivals/173.ts
@@ -30,7 +30,7 @@ const card: Card = {
 	trainerType: "Stadium",
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'normal'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/173.ts
+++ b/data/Scarlet & Violet/Destined Rivals/173.ts
@@ -31,8 +31,18 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		holo: false
-	}
+		normal: true,
+		reverse: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'normal'
+		},
+		{
+			type: 'reverse'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/174.ts
+++ b/data/Scarlet & Violet/Destined Rivals/174.ts
@@ -30,7 +30,7 @@ const card: Card = {
 	trainerType: "Supporter",
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'normal'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/174.ts
+++ b/data/Scarlet & Violet/Destined Rivals/174.ts
@@ -31,8 +31,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		normal: true,
-		reverse: true,
+		holo: false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/174.ts
+++ b/data/Scarlet & Violet/Destined Rivals/174.ts
@@ -31,8 +31,18 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		holo: false
-	}
+		normal: true,
+		reverse: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'normal'
+		},
+		{
+			type: 'reverse'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/174.ts
+++ b/data/Scarlet & Violet/Destined Rivals/174.ts
@@ -30,10 +30,6 @@ const card: Card = {
 	trainerType: "Supporter",
 	regulationMark: "I",
 
-	variants: {
-		holo: false
-	},
-
 	variants_detailed: [
 		{
 			type: 'normal'

--- a/data/Scarlet & Violet/Destined Rivals/175.ts
+++ b/data/Scarlet & Violet/Destined Rivals/175.ts
@@ -30,10 +30,6 @@ const card: Card = {
 	trainerType: "Item",
 	regulationMark: "I",
 
-	variants: {
-		holo: false
-	},
-
 	variants_detailed: [
 		{
 			type: 'normal'

--- a/data/Scarlet & Violet/Destined Rivals/175.ts
+++ b/data/Scarlet & Violet/Destined Rivals/175.ts
@@ -31,8 +31,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		normal: true,
-		reverse: true,
+		holo: false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/175.ts
+++ b/data/Scarlet & Violet/Destined Rivals/175.ts
@@ -31,8 +31,18 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		holo: false
-	}
+		normal: true,
+		reverse: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'normal'
+		},
+		{
+			type: 'reverse'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/175.ts
+++ b/data/Scarlet & Violet/Destined Rivals/175.ts
@@ -30,7 +30,7 @@ const card: Card = {
 	trainerType: "Item",
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'normal'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/176.ts
+++ b/data/Scarlet & Violet/Destined Rivals/176.ts
@@ -30,7 +30,7 @@ const card: Card = {
 	trainerType: "Supporter",
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'normal'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/176.ts
+++ b/data/Scarlet & Violet/Destined Rivals/176.ts
@@ -31,8 +31,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		normal: true,
-		reverse: true,
+		holo: false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/176.ts
+++ b/data/Scarlet & Violet/Destined Rivals/176.ts
@@ -31,8 +31,18 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		holo: false
-	}
+		normal: true,
+		reverse: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'normal'
+		},
+		{
+			type: 'reverse'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/176.ts
+++ b/data/Scarlet & Violet/Destined Rivals/176.ts
@@ -30,10 +30,6 @@ const card: Card = {
 	trainerType: "Supporter",
 	regulationMark: "I",
 
-	variants: {
-		holo: false
-	},
-
 	variants_detailed: [
 		{
 			type: 'normal'

--- a/data/Scarlet & Violet/Destined Rivals/177.ts
+++ b/data/Scarlet & Violet/Destined Rivals/177.ts
@@ -30,7 +30,7 @@ const card: Card = {
 	trainerType: "Supporter",
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'normal'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/177.ts
+++ b/data/Scarlet & Violet/Destined Rivals/177.ts
@@ -31,8 +31,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		normal: true,
-		reverse: true,
+		holo: false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/177.ts
+++ b/data/Scarlet & Violet/Destined Rivals/177.ts
@@ -31,8 +31,18 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		holo: false
-	}
+		normal: true,
+		reverse: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'normal'
+		},
+		{
+			type: 'reverse'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/177.ts
+++ b/data/Scarlet & Violet/Destined Rivals/177.ts
@@ -30,10 +30,6 @@ const card: Card = {
 	trainerType: "Supporter",
 	regulationMark: "I",
 
-	variants: {
-		holo: false
-	},
-
 	variants_detailed: [
 		{
 			type: 'normal'

--- a/data/Scarlet & Violet/Destined Rivals/178.ts
+++ b/data/Scarlet & Violet/Destined Rivals/178.ts
@@ -30,10 +30,6 @@ const card: Card = {
 	trainerType: "Item",
 	regulationMark: "I",
 
-	variants: {
-		holo: false
-	},
-
 	variants_detailed: [
 		{
 			type: 'normal'

--- a/data/Scarlet & Violet/Destined Rivals/178.ts
+++ b/data/Scarlet & Violet/Destined Rivals/178.ts
@@ -31,8 +31,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		normal: true,
-		reverse: true,
+		holo: false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/178.ts
+++ b/data/Scarlet & Violet/Destined Rivals/178.ts
@@ -31,8 +31,18 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		holo: false
-	}
+		normal: true,
+		reverse: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'normal'
+		},
+		{
+			type: 'reverse'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/178.ts
+++ b/data/Scarlet & Violet/Destined Rivals/178.ts
@@ -30,7 +30,7 @@ const card: Card = {
 	trainerType: "Item",
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'normal'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/179.ts
+++ b/data/Scarlet & Violet/Destined Rivals/179.ts
@@ -30,10 +30,6 @@ const card: Card = {
 	trainerType: "Item",
 	regulationMark: "I",
 
-	variants: {
-		holo: false
-	},
-
 	variants_detailed: [
 		{
 			type: 'normal'

--- a/data/Scarlet & Violet/Destined Rivals/179.ts
+++ b/data/Scarlet & Violet/Destined Rivals/179.ts
@@ -31,8 +31,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		normal: true,
-		reverse: true,
+		holo: false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/179.ts
+++ b/data/Scarlet & Violet/Destined Rivals/179.ts
@@ -31,8 +31,18 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		holo: false
-	}
+		normal: true,
+		reverse: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'normal'
+		},
+		{
+			type: 'reverse'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/179.ts
+++ b/data/Scarlet & Violet/Destined Rivals/179.ts
@@ -30,7 +30,7 @@ const card: Card = {
 	trainerType: "Item",
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'normal'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/180.ts
+++ b/data/Scarlet & Violet/Destined Rivals/180.ts
@@ -31,8 +31,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		normal: true,
-		reverse: true,
+		holo: false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/180.ts
+++ b/data/Scarlet & Violet/Destined Rivals/180.ts
@@ -30,10 +30,6 @@ const card: Card = {
 	trainerType: "Stadium",
 	regulationMark: "I",
 
-	variants: {
-		holo: false
-	},
-
 	variants_detailed: [
 		{
 			type: 'normal'

--- a/data/Scarlet & Violet/Destined Rivals/180.ts
+++ b/data/Scarlet & Violet/Destined Rivals/180.ts
@@ -30,7 +30,7 @@ const card: Card = {
 	trainerType: "Stadium",
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'normal'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/180.ts
+++ b/data/Scarlet & Violet/Destined Rivals/180.ts
@@ -31,8 +31,18 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		holo: false
-	}
+		normal: true,
+		reverse: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'normal'
+		},
+		{
+			type: 'reverse'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/181.ts
+++ b/data/Scarlet & Violet/Destined Rivals/181.ts
@@ -29,11 +29,6 @@ const card: Card = {
 
 	trainerType: "Item",
 	regulationMark: "H",
-
-	variants: {
-		holo: false
-	},
-
 	variants_detailed: [
 		{
 			type: 'normal'

--- a/data/Scarlet & Violet/Destined Rivals/181.ts
+++ b/data/Scarlet & Violet/Destined Rivals/181.ts
@@ -29,7 +29,7 @@ const card: Card = {
 
 	trainerType: "Item",
 	regulationMark: "H",
-	variants_detailed: [
+	variants: [
 		{
 			type: 'normal'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/181.ts
+++ b/data/Scarlet & Violet/Destined Rivals/181.ts
@@ -31,8 +31,7 @@ const card: Card = {
 	regulationMark: "H",
 
 	variants: {
-		normal: true,
-		reverse: true,
+		holo: false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/181.ts
+++ b/data/Scarlet & Violet/Destined Rivals/181.ts
@@ -31,8 +31,18 @@ const card: Card = {
 	regulationMark: "H",
 
 	variants: {
-		holo: false
-	}
+		normal: true,
+		reverse: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'normal'
+		},
+		{
+			type: 'reverse'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/182.ts
+++ b/data/Scarlet & Violet/Destined Rivals/182.ts
@@ -30,10 +30,6 @@ const card: Card = {
 	energyType: "Special",
 	regulationMark: "I",
 
-	variants: {
-		holo: false
-	},
-
 	variants_detailed: [
 		{
 			type: 'normal'

--- a/data/Scarlet & Violet/Destined Rivals/182.ts
+++ b/data/Scarlet & Violet/Destined Rivals/182.ts
@@ -31,8 +31,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		normal: true,
-		reverse: true,
+		holo: false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/182.ts
+++ b/data/Scarlet & Violet/Destined Rivals/182.ts
@@ -30,7 +30,7 @@ const card: Card = {
 	energyType: "Special",
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'normal'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/182.ts
+++ b/data/Scarlet & Violet/Destined Rivals/182.ts
@@ -31,8 +31,18 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		holo: false
-	}
+		normal: true,
+		reverse: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'normal'
+		},
+		{
+			type: 'reverse'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/183.ts
+++ b/data/Scarlet & Violet/Destined Rivals/183.ts
@@ -61,7 +61,7 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'holo'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/183.ts
+++ b/data/Scarlet & Violet/Destined Rivals/183.ts
@@ -62,7 +62,8 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		holo: true,
+		normal: false,
+		reverse: false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/183.ts
+++ b/data/Scarlet & Violet/Destined Rivals/183.ts
@@ -61,11 +61,6 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "I",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
-
 	variants_detailed: [
 		{
 			type: 'holo'

--- a/data/Scarlet & Violet/Destined Rivals/183.ts
+++ b/data/Scarlet & Violet/Destined Rivals/183.ts
@@ -62,9 +62,14 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		reverse: false,
-		normal: false
-	}
+		holo: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'holo'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/184.ts
+++ b/data/Scarlet & Violet/Destined Rivals/184.ts
@@ -64,7 +64,8 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		holo: true,
+		normal: false,
+		reverse: false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/184.ts
+++ b/data/Scarlet & Violet/Destined Rivals/184.ts
@@ -63,7 +63,7 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'holo'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/184.ts
+++ b/data/Scarlet & Violet/Destined Rivals/184.ts
@@ -63,11 +63,6 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "I",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
-
 	variants_detailed: [
 		{
 			type: 'holo'

--- a/data/Scarlet & Violet/Destined Rivals/184.ts
+++ b/data/Scarlet & Violet/Destined Rivals/184.ts
@@ -64,9 +64,14 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		normal: false,
-		reverse: false
-	}
+		holo: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'holo'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/185.ts
+++ b/data/Scarlet & Violet/Destined Rivals/185.ts
@@ -64,7 +64,8 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		holo: true,
+		normal: false,
+		reverse: false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/185.ts
+++ b/data/Scarlet & Violet/Destined Rivals/185.ts
@@ -63,7 +63,7 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'holo'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/185.ts
+++ b/data/Scarlet & Violet/Destined Rivals/185.ts
@@ -63,11 +63,6 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "I",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
-
 	variants_detailed: [
 		{
 			type: 'holo'

--- a/data/Scarlet & Violet/Destined Rivals/185.ts
+++ b/data/Scarlet & Violet/Destined Rivals/185.ts
@@ -64,9 +64,14 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		normal: false,
-		reverse: false
-	}
+		holo: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'holo'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/186.ts
+++ b/data/Scarlet & Violet/Destined Rivals/186.ts
@@ -74,9 +74,14 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		normal: false,
-		reverse: false
-	}
+		holo: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'holo'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/186.ts
+++ b/data/Scarlet & Violet/Destined Rivals/186.ts
@@ -74,7 +74,8 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		holo: true,
+		normal: false,
+		reverse: false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/186.ts
+++ b/data/Scarlet & Violet/Destined Rivals/186.ts
@@ -73,7 +73,7 @@ const card: Card = {
 	retreat: 3,
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'holo'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/186.ts
+++ b/data/Scarlet & Violet/Destined Rivals/186.ts
@@ -73,11 +73,6 @@ const card: Card = {
 	retreat: 3,
 	regulationMark: "I",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
-
 	variants_detailed: [
 		{
 			type: 'holo'

--- a/data/Scarlet & Violet/Destined Rivals/187.ts
+++ b/data/Scarlet & Violet/Destined Rivals/187.ts
@@ -74,9 +74,14 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		normal: false,
-		reverse: false
-	}
+		holo: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'holo'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/187.ts
+++ b/data/Scarlet & Violet/Destined Rivals/187.ts
@@ -74,7 +74,8 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		holo: true,
+		normal: false,
+		reverse: false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/187.ts
+++ b/data/Scarlet & Violet/Destined Rivals/187.ts
@@ -73,11 +73,6 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "I",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
-
 	variants_detailed: [
 		{
 			type: 'holo'

--- a/data/Scarlet & Violet/Destined Rivals/187.ts
+++ b/data/Scarlet & Violet/Destined Rivals/187.ts
@@ -73,7 +73,7 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'holo'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/188.ts
+++ b/data/Scarlet & Violet/Destined Rivals/188.ts
@@ -61,11 +61,6 @@ const card: Card = {
 	retreat: 3,
 	regulationMark: "I",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
-
 	variants_detailed: [
 		{
 			type: 'holo'

--- a/data/Scarlet & Violet/Destined Rivals/188.ts
+++ b/data/Scarlet & Violet/Destined Rivals/188.ts
@@ -62,7 +62,8 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		holo: true,
+		normal: false,
+		reverse: false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/188.ts
+++ b/data/Scarlet & Violet/Destined Rivals/188.ts
@@ -62,9 +62,14 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		normal: false,
-		reverse: false
-	}
+		holo: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'holo'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/188.ts
+++ b/data/Scarlet & Violet/Destined Rivals/188.ts
@@ -61,7 +61,7 @@ const card: Card = {
 	retreat: 3,
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'holo'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/189.ts
+++ b/data/Scarlet & Violet/Destined Rivals/189.ts
@@ -64,7 +64,8 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		holo: true,
+		normal: false,
+		reverse: false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/189.ts
+++ b/data/Scarlet & Violet/Destined Rivals/189.ts
@@ -63,7 +63,7 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'holo'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/189.ts
+++ b/data/Scarlet & Violet/Destined Rivals/189.ts
@@ -63,11 +63,6 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "I",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
-
 	variants_detailed: [
 		{
 			type: 'holo'

--- a/data/Scarlet & Violet/Destined Rivals/189.ts
+++ b/data/Scarlet & Violet/Destined Rivals/189.ts
@@ -64,9 +64,14 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		normal: false,
-		reverse: false
-	}
+		holo: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'holo'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/190.ts
+++ b/data/Scarlet & Violet/Destined Rivals/190.ts
@@ -63,7 +63,7 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'holo'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/190.ts
+++ b/data/Scarlet & Violet/Destined Rivals/190.ts
@@ -63,11 +63,6 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "I",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
-
 	variants_detailed: [
 		{
 			type: 'holo'

--- a/data/Scarlet & Violet/Destined Rivals/190.ts
+++ b/data/Scarlet & Violet/Destined Rivals/190.ts
@@ -64,7 +64,8 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		holo: true,
+		normal: false,
+		reverse: false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/190.ts
+++ b/data/Scarlet & Violet/Destined Rivals/190.ts
@@ -64,9 +64,14 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		normal: false,
-		reverse: false
-	}
+		holo: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'holo'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/191.ts
+++ b/data/Scarlet & Violet/Destined Rivals/191.ts
@@ -71,7 +71,7 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'holo'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/191.ts
+++ b/data/Scarlet & Violet/Destined Rivals/191.ts
@@ -72,9 +72,14 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		normal: false,
-		reverse: false
-	}
+		holo: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'holo'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/191.ts
+++ b/data/Scarlet & Violet/Destined Rivals/191.ts
@@ -72,7 +72,8 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		holo: true,
+		normal: false,
+		reverse: false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/191.ts
+++ b/data/Scarlet & Violet/Destined Rivals/191.ts
@@ -71,11 +71,6 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "I",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
-
 	variants_detailed: [
 		{
 			type: 'holo'

--- a/data/Scarlet & Violet/Destined Rivals/192.ts
+++ b/data/Scarlet & Violet/Destined Rivals/192.ts
@@ -63,7 +63,7 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'holo'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/192.ts
+++ b/data/Scarlet & Violet/Destined Rivals/192.ts
@@ -63,11 +63,6 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "I",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
-
 	variants_detailed: [
 		{
 			type: 'holo'

--- a/data/Scarlet & Violet/Destined Rivals/192.ts
+++ b/data/Scarlet & Violet/Destined Rivals/192.ts
@@ -64,7 +64,8 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		holo: true,
+		normal: false,
+		reverse: false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/192.ts
+++ b/data/Scarlet & Violet/Destined Rivals/192.ts
@@ -64,9 +64,14 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		normal: false,
-		reverse: false
-	}
+		holo: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'holo'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/193.ts
+++ b/data/Scarlet & Violet/Destined Rivals/193.ts
@@ -64,7 +64,8 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		holo: true,
+		normal: false,
+		reverse: false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/193.ts
+++ b/data/Scarlet & Violet/Destined Rivals/193.ts
@@ -63,7 +63,7 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'holo'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/193.ts
+++ b/data/Scarlet & Violet/Destined Rivals/193.ts
@@ -63,11 +63,6 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "I",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
-
 	variants_detailed: [
 		{
 			type: 'holo'

--- a/data/Scarlet & Violet/Destined Rivals/193.ts
+++ b/data/Scarlet & Violet/Destined Rivals/193.ts
@@ -64,9 +64,14 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		normal: false,
-		reverse: false
-	}
+		holo: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'holo'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/194.ts
+++ b/data/Scarlet & Violet/Destined Rivals/194.ts
@@ -61,7 +61,7 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'holo'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/194.ts
+++ b/data/Scarlet & Violet/Destined Rivals/194.ts
@@ -62,7 +62,8 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		holo: true,
+		normal: false,
+		reverse: false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/194.ts
+++ b/data/Scarlet & Violet/Destined Rivals/194.ts
@@ -62,9 +62,14 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		normal: false,
-		reverse: false
-	}
+		holo: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'holo'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/194.ts
+++ b/data/Scarlet & Violet/Destined Rivals/194.ts
@@ -61,11 +61,6 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "I",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
-
 	variants_detailed: [
 		{
 			type: 'holo'

--- a/data/Scarlet & Violet/Destined Rivals/195.ts
+++ b/data/Scarlet & Violet/Destined Rivals/195.ts
@@ -50,7 +50,8 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		holo: true,
+		normal: false,
+		reverse: false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/195.ts
+++ b/data/Scarlet & Violet/Destined Rivals/195.ts
@@ -50,9 +50,14 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		normal: false,
-		reverse: false
-	}
+		holo: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'holo'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/195.ts
+++ b/data/Scarlet & Violet/Destined Rivals/195.ts
@@ -49,7 +49,7 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'holo'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/195.ts
+++ b/data/Scarlet & Violet/Destined Rivals/195.ts
@@ -49,11 +49,6 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "I",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
-
 	variants_detailed: [
 		{
 			type: 'holo'

--- a/data/Scarlet & Violet/Destined Rivals/196.ts
+++ b/data/Scarlet & Violet/Destined Rivals/196.ts
@@ -54,9 +54,14 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		normal: false,
-		reverse: false
-	}
+		holo: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'holo'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/196.ts
+++ b/data/Scarlet & Violet/Destined Rivals/196.ts
@@ -54,7 +54,8 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		holo: true,
+		normal: false,
+		reverse: false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/196.ts
+++ b/data/Scarlet & Violet/Destined Rivals/196.ts
@@ -53,11 +53,6 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "I",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
-
 	variants_detailed: [
 		{
 			type: 'holo'

--- a/data/Scarlet & Violet/Destined Rivals/196.ts
+++ b/data/Scarlet & Violet/Destined Rivals/196.ts
@@ -53,7 +53,7 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'holo'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/197.ts
+++ b/data/Scarlet & Violet/Destined Rivals/197.ts
@@ -73,11 +73,6 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "I",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
-
 	variants_detailed: [
 		{
 			type: 'holo'

--- a/data/Scarlet & Violet/Destined Rivals/197.ts
+++ b/data/Scarlet & Violet/Destined Rivals/197.ts
@@ -74,7 +74,8 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		holo: true,
+		normal: false,
+		reverse: false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/197.ts
+++ b/data/Scarlet & Violet/Destined Rivals/197.ts
@@ -74,9 +74,14 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		reverse: false,
-		normal: false
-	}
+		holo: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'holo'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/197.ts
+++ b/data/Scarlet & Violet/Destined Rivals/197.ts
@@ -73,7 +73,7 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'holo'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/198.ts
+++ b/data/Scarlet & Violet/Destined Rivals/198.ts
@@ -74,7 +74,8 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		holo: true,
+		normal: false,
+		reverse: false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/198.ts
+++ b/data/Scarlet & Violet/Destined Rivals/198.ts
@@ -73,11 +73,6 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "I",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
-
 	variants_detailed: [
 		{
 			type: 'holo'

--- a/data/Scarlet & Violet/Destined Rivals/198.ts
+++ b/data/Scarlet & Violet/Destined Rivals/198.ts
@@ -74,9 +74,14 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		reverse: false,
-		normal: false
-	}
+		holo: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'holo'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/198.ts
+++ b/data/Scarlet & Violet/Destined Rivals/198.ts
@@ -73,7 +73,7 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'holo'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/199.ts
+++ b/data/Scarlet & Violet/Destined Rivals/199.ts
@@ -50,7 +50,8 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		holo: true,
+		normal: false,
+		reverse: false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/199.ts
+++ b/data/Scarlet & Violet/Destined Rivals/199.ts
@@ -50,9 +50,14 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		normal: false,
-		reverse: false
-	}
+		holo: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'holo'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/199.ts
+++ b/data/Scarlet & Violet/Destined Rivals/199.ts
@@ -49,7 +49,7 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'holo'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/199.ts
+++ b/data/Scarlet & Violet/Destined Rivals/199.ts
@@ -49,11 +49,6 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "I",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
-
 	variants_detailed: [
 		{
 			type: 'holo'

--- a/data/Scarlet & Violet/Destined Rivals/200.ts
+++ b/data/Scarlet & Violet/Destined Rivals/200.ts
@@ -72,9 +72,14 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		reverse: false,
-		normal: false
-	}
+		holo: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'holo'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/200.ts
+++ b/data/Scarlet & Violet/Destined Rivals/200.ts
@@ -71,11 +71,6 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "I",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
-
 	variants_detailed: [
 		{
 			type: 'holo'

--- a/data/Scarlet & Violet/Destined Rivals/200.ts
+++ b/data/Scarlet & Violet/Destined Rivals/200.ts
@@ -72,7 +72,8 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		holo: true,
+		normal: false,
+		reverse: false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/200.ts
+++ b/data/Scarlet & Violet/Destined Rivals/200.ts
@@ -71,7 +71,7 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'holo'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/201.ts
+++ b/data/Scarlet & Violet/Destined Rivals/201.ts
@@ -50,7 +50,8 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		holo: true,
+		normal: false,
+		reverse: false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/201.ts
+++ b/data/Scarlet & Violet/Destined Rivals/201.ts
@@ -50,9 +50,14 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		normal: false,
-		reverse: false
-	}
+		holo: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'holo'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/201.ts
+++ b/data/Scarlet & Violet/Destined Rivals/201.ts
@@ -49,7 +49,7 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'holo'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/201.ts
+++ b/data/Scarlet & Violet/Destined Rivals/201.ts
@@ -49,11 +49,6 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "I",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
-
 	variants_detailed: [
 		{
 			type: 'holo'

--- a/data/Scarlet & Violet/Destined Rivals/202.ts
+++ b/data/Scarlet & Violet/Destined Rivals/202.ts
@@ -49,7 +49,7 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'holo'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/202.ts
+++ b/data/Scarlet & Violet/Destined Rivals/202.ts
@@ -50,7 +50,8 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		holo: true,
+		normal: false,
+		reverse: false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/202.ts
+++ b/data/Scarlet & Violet/Destined Rivals/202.ts
@@ -50,9 +50,14 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		reverse: false,
-		normal: false
-	}
+		holo: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'holo'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/202.ts
+++ b/data/Scarlet & Violet/Destined Rivals/202.ts
@@ -49,11 +49,6 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "I",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
-
 	variants_detailed: [
 		{
 			type: 'holo'

--- a/data/Scarlet & Violet/Destined Rivals/203.ts
+++ b/data/Scarlet & Violet/Destined Rivals/203.ts
@@ -72,9 +72,14 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		normal: false,
-		reverse: false
-	}
+		holo: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'holo'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/203.ts
+++ b/data/Scarlet & Violet/Destined Rivals/203.ts
@@ -71,11 +71,6 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "I",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
-
 	variants_detailed: [
 		{
 			type: 'holo'

--- a/data/Scarlet & Violet/Destined Rivals/203.ts
+++ b/data/Scarlet & Violet/Destined Rivals/203.ts
@@ -72,7 +72,8 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		holo: true,
+		normal: false,
+		reverse: false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/203.ts
+++ b/data/Scarlet & Violet/Destined Rivals/203.ts
@@ -71,7 +71,7 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'holo'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/204.ts
+++ b/data/Scarlet & Violet/Destined Rivals/204.ts
@@ -63,7 +63,7 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'holo'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/204.ts
+++ b/data/Scarlet & Violet/Destined Rivals/204.ts
@@ -64,9 +64,14 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		reverse: false,
-		normal: false
-	}
+		holo: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'holo'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/204.ts
+++ b/data/Scarlet & Violet/Destined Rivals/204.ts
@@ -63,11 +63,6 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "I",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
-
 	variants_detailed: [
 		{
 			type: 'holo'

--- a/data/Scarlet & Violet/Destined Rivals/204.ts
+++ b/data/Scarlet & Violet/Destined Rivals/204.ts
@@ -64,7 +64,8 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		holo: true,
+		normal: false,
+		reverse: false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/205.ts
+++ b/data/Scarlet & Violet/Destined Rivals/205.ts
@@ -63,7 +63,7 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'holo'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/205.ts
+++ b/data/Scarlet & Violet/Destined Rivals/205.ts
@@ -63,11 +63,6 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "I",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
-
 	variants_detailed: [
 		{
 			type: 'holo'

--- a/data/Scarlet & Violet/Destined Rivals/205.ts
+++ b/data/Scarlet & Violet/Destined Rivals/205.ts
@@ -64,7 +64,8 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		holo: true,
+		normal: false,
+		reverse: false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/205.ts
+++ b/data/Scarlet & Violet/Destined Rivals/205.ts
@@ -64,9 +64,14 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		normal: false,
-		reverse: false
-	}
+		holo: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'holo'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/206.ts
+++ b/data/Scarlet & Violet/Destined Rivals/206.ts
@@ -73,11 +73,6 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "I",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
-
 	variants_detailed: [
 		{
 			type: 'holo'

--- a/data/Scarlet & Violet/Destined Rivals/206.ts
+++ b/data/Scarlet & Violet/Destined Rivals/206.ts
@@ -74,7 +74,8 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		holo: true,
+		normal: false,
+		reverse: false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/206.ts
+++ b/data/Scarlet & Violet/Destined Rivals/206.ts
@@ -74,9 +74,14 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		reverse: false,
-		normal: false
-	}
+		holo: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'holo'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/206.ts
+++ b/data/Scarlet & Violet/Destined Rivals/206.ts
@@ -73,7 +73,7 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'holo'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/207.ts
+++ b/data/Scarlet & Violet/Destined Rivals/207.ts
@@ -71,7 +71,7 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'holo'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/207.ts
+++ b/data/Scarlet & Violet/Destined Rivals/207.ts
@@ -72,9 +72,14 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		normal: false,
-		reverse: false
-	}
+		holo: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'holo'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/207.ts
+++ b/data/Scarlet & Violet/Destined Rivals/207.ts
@@ -72,7 +72,8 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		holo: true,
+		normal: false,
+		reverse: false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/207.ts
+++ b/data/Scarlet & Violet/Destined Rivals/207.ts
@@ -71,11 +71,6 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "I",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
-
 	variants_detailed: [
 		{
 			type: 'holo'

--- a/data/Scarlet & Violet/Destined Rivals/208.ts
+++ b/data/Scarlet & Violet/Destined Rivals/208.ts
@@ -71,7 +71,7 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'holo'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/208.ts
+++ b/data/Scarlet & Violet/Destined Rivals/208.ts
@@ -72,9 +72,14 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		normal: false,
-		reverse: false
-	}
+		holo: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'holo'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/208.ts
+++ b/data/Scarlet & Violet/Destined Rivals/208.ts
@@ -72,7 +72,8 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		holo: true,
+		normal: false,
+		reverse: false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/208.ts
+++ b/data/Scarlet & Violet/Destined Rivals/208.ts
@@ -71,11 +71,6 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "I",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
-
 	variants_detailed: [
 		{
 			type: 'holo'

--- a/data/Scarlet & Violet/Destined Rivals/209.ts
+++ b/data/Scarlet & Violet/Destined Rivals/209.ts
@@ -74,9 +74,14 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		normal: false,
-		reverse: false
-	}
+		holo: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'holo'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/209.ts
+++ b/data/Scarlet & Violet/Destined Rivals/209.ts
@@ -74,7 +74,8 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		holo: true,
+		normal: false,
+		reverse: false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/209.ts
+++ b/data/Scarlet & Violet/Destined Rivals/209.ts
@@ -73,11 +73,6 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "I",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
-
 	variants_detailed: [
 		{
 			type: 'holo'

--- a/data/Scarlet & Violet/Destined Rivals/209.ts
+++ b/data/Scarlet & Violet/Destined Rivals/209.ts
@@ -73,7 +73,7 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'holo'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/210.ts
+++ b/data/Scarlet & Violet/Destined Rivals/210.ts
@@ -74,9 +74,14 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		normal: false,
-		reverse: false
-	}
+		holo: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'holo'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/210.ts
+++ b/data/Scarlet & Violet/Destined Rivals/210.ts
@@ -74,7 +74,8 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		holo: true,
+		normal: false,
+		reverse: false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/210.ts
+++ b/data/Scarlet & Violet/Destined Rivals/210.ts
@@ -73,7 +73,7 @@ const card: Card = {
 	retreat: 4,
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'holo'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/210.ts
+++ b/data/Scarlet & Violet/Destined Rivals/210.ts
@@ -73,11 +73,6 @@ const card: Card = {
 	retreat: 4,
 	regulationMark: "I",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
-
 	variants_detailed: [
 		{
 			type: 'holo'

--- a/data/Scarlet & Violet/Destined Rivals/211.ts
+++ b/data/Scarlet & Violet/Destined Rivals/211.ts
@@ -74,9 +74,14 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		normal: false,
-		reverse: false
-	}
+		holo: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'holo'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/211.ts
+++ b/data/Scarlet & Violet/Destined Rivals/211.ts
@@ -74,7 +74,8 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		holo: true,
+		normal: false,
+		reverse: false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/211.ts
+++ b/data/Scarlet & Violet/Destined Rivals/211.ts
@@ -73,7 +73,7 @@ const card: Card = {
 	retreat: 4,
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'holo'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/211.ts
+++ b/data/Scarlet & Violet/Destined Rivals/211.ts
@@ -73,11 +73,6 @@ const card: Card = {
 	retreat: 4,
 	regulationMark: "I",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
-
 	variants_detailed: [
 		{
 			type: 'holo'

--- a/data/Scarlet & Violet/Destined Rivals/212.ts
+++ b/data/Scarlet & Violet/Destined Rivals/212.ts
@@ -71,7 +71,7 @@ const card: Card = {
 	retreat: 4,
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'holo'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/212.ts
+++ b/data/Scarlet & Violet/Destined Rivals/212.ts
@@ -72,9 +72,14 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		normal: false,
-		reverse: false
-	}
+		holo: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'holo'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/212.ts
+++ b/data/Scarlet & Violet/Destined Rivals/212.ts
@@ -71,11 +71,6 @@ const card: Card = {
 	retreat: 4,
 	regulationMark: "I",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
-
 	variants_detailed: [
 		{
 			type: 'holo'

--- a/data/Scarlet & Violet/Destined Rivals/212.ts
+++ b/data/Scarlet & Violet/Destined Rivals/212.ts
@@ -72,7 +72,8 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		holo: true,
+		normal: false,
+		reverse: false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/213.ts
+++ b/data/Scarlet & Violet/Destined Rivals/213.ts
@@ -74,9 +74,14 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		normal: false,
-		reverse: false
-	}
+		holo: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'holo'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/213.ts
+++ b/data/Scarlet & Violet/Destined Rivals/213.ts
@@ -74,7 +74,8 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		holo: true,
+		normal: false,
+		reverse: false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/213.ts
+++ b/data/Scarlet & Violet/Destined Rivals/213.ts
@@ -73,7 +73,7 @@ const card: Card = {
 	retreat: 3,
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'holo'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/213.ts
+++ b/data/Scarlet & Violet/Destined Rivals/213.ts
@@ -73,11 +73,6 @@ const card: Card = {
 	retreat: 3,
 	regulationMark: "I",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
-
 	variants_detailed: [
 		{
 			type: 'holo'

--- a/data/Scarlet & Violet/Destined Rivals/214.ts
+++ b/data/Scarlet & Violet/Destined Rivals/214.ts
@@ -71,11 +71,6 @@ const card: Card = {
 	retreat: 3,
 	regulationMark: "I",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
-
 	variants_detailed: [
 		{
 			type: 'holo'

--- a/data/Scarlet & Violet/Destined Rivals/214.ts
+++ b/data/Scarlet & Violet/Destined Rivals/214.ts
@@ -72,9 +72,14 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		normal: false,
-		reverse: false
-	}
+		holo: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'holo'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/214.ts
+++ b/data/Scarlet & Violet/Destined Rivals/214.ts
@@ -72,7 +72,8 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		holo: true,
+		normal: false,
+		reverse: false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/214.ts
+++ b/data/Scarlet & Violet/Destined Rivals/214.ts
@@ -71,7 +71,7 @@ const card: Card = {
 	retreat: 3,
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'holo'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/215.ts
+++ b/data/Scarlet & Violet/Destined Rivals/215.ts
@@ -74,9 +74,14 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		normal: false,
-		reverse: false
-	}
+		holo: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'holo'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/215.ts
+++ b/data/Scarlet & Violet/Destined Rivals/215.ts
@@ -74,7 +74,8 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		holo: true,
+		normal: false,
+		reverse: false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/215.ts
+++ b/data/Scarlet & Violet/Destined Rivals/215.ts
@@ -73,11 +73,6 @@ const card: Card = {
 	retreat: 0,
 	regulationMark: "I",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
-
 	variants_detailed: [
 		{
 			type: 'holo'

--- a/data/Scarlet & Violet/Destined Rivals/215.ts
+++ b/data/Scarlet & Violet/Destined Rivals/215.ts
@@ -73,7 +73,7 @@ const card: Card = {
 	retreat: 0,
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'holo'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/216.ts
+++ b/data/Scarlet & Violet/Destined Rivals/216.ts
@@ -63,7 +63,7 @@ const card: Card = {
 	retreat: 3,
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'holo'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/216.ts
+++ b/data/Scarlet & Violet/Destined Rivals/216.ts
@@ -64,7 +64,8 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		holo: true,
+		normal: false,
+		reverse: false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/216.ts
+++ b/data/Scarlet & Violet/Destined Rivals/216.ts
@@ -63,11 +63,6 @@ const card: Card = {
 	retreat: 3,
 	regulationMark: "I",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
-
 	variants_detailed: [
 		{
 			type: 'holo'

--- a/data/Scarlet & Violet/Destined Rivals/216.ts
+++ b/data/Scarlet & Violet/Destined Rivals/216.ts
@@ -64,9 +64,14 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		normal: false,
-		reverse: false
-	}
+		holo: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'holo'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/217.ts
+++ b/data/Scarlet & Violet/Destined Rivals/217.ts
@@ -73,11 +73,6 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "I",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
-
 	variants_detailed: [
 		{
 			type: 'holo'

--- a/data/Scarlet & Violet/Destined Rivals/217.ts
+++ b/data/Scarlet & Violet/Destined Rivals/217.ts
@@ -74,9 +74,14 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		normal: false,
-		reverse: false
-	}
+		holo: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'holo'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/217.ts
+++ b/data/Scarlet & Violet/Destined Rivals/217.ts
@@ -74,7 +74,8 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		holo: true,
+		normal: false,
+		reverse: false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/217.ts
+++ b/data/Scarlet & Violet/Destined Rivals/217.ts
@@ -73,7 +73,7 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'holo'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/218.ts
+++ b/data/Scarlet & Violet/Destined Rivals/218.ts
@@ -74,9 +74,14 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		normal: false,
-		reverse: false
-	}
+		holo: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'holo'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/218.ts
+++ b/data/Scarlet & Violet/Destined Rivals/218.ts
@@ -74,7 +74,8 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		holo: true,
+		normal: false,
+		reverse: false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/218.ts
+++ b/data/Scarlet & Violet/Destined Rivals/218.ts
@@ -73,7 +73,7 @@ const card: Card = {
 	retreat: 3,
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'holo'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/218.ts
+++ b/data/Scarlet & Violet/Destined Rivals/218.ts
@@ -73,11 +73,6 @@ const card: Card = {
 	retreat: 3,
 	regulationMark: "I",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
-
 	variants_detailed: [
 		{
 			type: 'holo'

--- a/data/Scarlet & Violet/Destined Rivals/219.ts
+++ b/data/Scarlet & Violet/Destined Rivals/219.ts
@@ -71,7 +71,7 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'holo'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/219.ts
+++ b/data/Scarlet & Violet/Destined Rivals/219.ts
@@ -72,9 +72,14 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		normal: false,
-		reverse: false
-	}
+		holo: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'holo'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/219.ts
+++ b/data/Scarlet & Violet/Destined Rivals/219.ts
@@ -72,7 +72,8 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		holo: true,
+		normal: false,
+		reverse: false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/219.ts
+++ b/data/Scarlet & Violet/Destined Rivals/219.ts
@@ -71,11 +71,6 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "I",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
-
 	variants_detailed: [
 		{
 			type: 'holo'

--- a/data/Scarlet & Violet/Destined Rivals/220.ts
+++ b/data/Scarlet & Violet/Destined Rivals/220.ts
@@ -31,9 +31,14 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		normal: false,
-		reverse: false
-	}
+		holo: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'holo'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/220.ts
+++ b/data/Scarlet & Violet/Destined Rivals/220.ts
@@ -31,7 +31,8 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		holo: true,
+		normal: false,
+		reverse: false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/220.ts
+++ b/data/Scarlet & Violet/Destined Rivals/220.ts
@@ -30,11 +30,6 @@ const card: Card = {
 	trainerType: "Supporter",
 	regulationMark: "I",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
-
 	variants_detailed: [
 		{
 			type: 'holo'

--- a/data/Scarlet & Violet/Destined Rivals/220.ts
+++ b/data/Scarlet & Violet/Destined Rivals/220.ts
@@ -30,7 +30,7 @@ const card: Card = {
 	trainerType: "Supporter",
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'holo'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/221.ts
+++ b/data/Scarlet & Violet/Destined Rivals/221.ts
@@ -31,9 +31,14 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		normal: false,
-		reverse: false
-	}
+		holo: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'holo'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/221.ts
+++ b/data/Scarlet & Violet/Destined Rivals/221.ts
@@ -31,7 +31,8 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		holo: true,
+		normal: false,
+		reverse: false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/221.ts
+++ b/data/Scarlet & Violet/Destined Rivals/221.ts
@@ -30,11 +30,6 @@ const card: Card = {
 	trainerType: "Supporter",
 	regulationMark: "I",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
-
 	variants_detailed: [
 		{
 			type: 'holo'

--- a/data/Scarlet & Violet/Destined Rivals/221.ts
+++ b/data/Scarlet & Violet/Destined Rivals/221.ts
@@ -30,7 +30,7 @@ const card: Card = {
 	trainerType: "Supporter",
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'holo'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/222.ts
+++ b/data/Scarlet & Violet/Destined Rivals/222.ts
@@ -31,9 +31,14 @@ const card: Card = {
 	regulationMark: "G",
 
 	variants: {
-		normal: false,
-		reverse: false
-	}
+		holo: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'holo'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/222.ts
+++ b/data/Scarlet & Violet/Destined Rivals/222.ts
@@ -29,7 +29,7 @@ const card: Card = {
 
 	trainerType: "Supporter",
 	regulationMark: "G",
-	variants_detailed: [
+	variants: [
 		{
 			type: 'holo'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/222.ts
+++ b/data/Scarlet & Violet/Destined Rivals/222.ts
@@ -31,7 +31,8 @@ const card: Card = {
 	regulationMark: "G",
 
 	variants: {
-		holo: true,
+		normal: false,
+		reverse: false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/222.ts
+++ b/data/Scarlet & Violet/Destined Rivals/222.ts
@@ -29,12 +29,6 @@ const card: Card = {
 
 	trainerType: "Supporter",
 	regulationMark: "G",
-
-	variants: {
-		normal: false,
-		reverse: false
-	},
-
 	variants_detailed: [
 		{
 			type: 'holo'

--- a/data/Scarlet & Violet/Destined Rivals/223.ts
+++ b/data/Scarlet & Violet/Destined Rivals/223.ts
@@ -31,9 +31,14 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		normal: false,
-		reverse: false
-	}
+		holo: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'holo'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/223.ts
+++ b/data/Scarlet & Violet/Destined Rivals/223.ts
@@ -31,7 +31,8 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		holo: true,
+		normal: false,
+		reverse: false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/223.ts
+++ b/data/Scarlet & Violet/Destined Rivals/223.ts
@@ -30,11 +30,6 @@ const card: Card = {
 	trainerType: "Supporter",
 	regulationMark: "I",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
-
 	variants_detailed: [
 		{
 			type: 'holo'

--- a/data/Scarlet & Violet/Destined Rivals/223.ts
+++ b/data/Scarlet & Violet/Destined Rivals/223.ts
@@ -30,7 +30,7 @@ const card: Card = {
 	trainerType: "Supporter",
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'holo'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/224.ts
+++ b/data/Scarlet & Violet/Destined Rivals/224.ts
@@ -31,9 +31,14 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		normal: false,
-		reverse: false
-	}
+		holo: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'holo'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/224.ts
+++ b/data/Scarlet & Violet/Destined Rivals/224.ts
@@ -31,7 +31,8 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		holo: true,
+		normal: false,
+		reverse: false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/224.ts
+++ b/data/Scarlet & Violet/Destined Rivals/224.ts
@@ -30,11 +30,6 @@ const card: Card = {
 	trainerType: "Supporter",
 	regulationMark: "I",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
-
 	variants_detailed: [
 		{
 			type: 'holo'

--- a/data/Scarlet & Violet/Destined Rivals/224.ts
+++ b/data/Scarlet & Violet/Destined Rivals/224.ts
@@ -30,7 +30,7 @@ const card: Card = {
 	trainerType: "Supporter",
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'holo'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/225.ts
+++ b/data/Scarlet & Violet/Destined Rivals/225.ts
@@ -31,9 +31,14 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		normal: false,
-		reverse: false
-	}
+		holo: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'holo'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/225.ts
+++ b/data/Scarlet & Violet/Destined Rivals/225.ts
@@ -31,7 +31,8 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		holo: true,
+		normal: false,
+		reverse: false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/225.ts
+++ b/data/Scarlet & Violet/Destined Rivals/225.ts
@@ -30,11 +30,6 @@ const card: Card = {
 	trainerType: "Supporter",
 	regulationMark: "I",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
-
 	variants_detailed: [
 		{
 			type: 'holo'

--- a/data/Scarlet & Violet/Destined Rivals/225.ts
+++ b/data/Scarlet & Violet/Destined Rivals/225.ts
@@ -30,7 +30,7 @@ const card: Card = {
 	trainerType: "Supporter",
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'holo'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/226.ts
+++ b/data/Scarlet & Violet/Destined Rivals/226.ts
@@ -31,9 +31,14 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		normal: false,
-		reverse: false
-	}
+		holo: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'holo'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/226.ts
+++ b/data/Scarlet & Violet/Destined Rivals/226.ts
@@ -31,7 +31,8 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		holo: true,
+		normal: false,
+		reverse: false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/226.ts
+++ b/data/Scarlet & Violet/Destined Rivals/226.ts
@@ -30,11 +30,6 @@ const card: Card = {
 	trainerType: "Supporter",
 	regulationMark: "I",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
-
 	variants_detailed: [
 		{
 			type: 'holo'

--- a/data/Scarlet & Violet/Destined Rivals/226.ts
+++ b/data/Scarlet & Violet/Destined Rivals/226.ts
@@ -30,7 +30,7 @@ const card: Card = {
 	trainerType: "Supporter",
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'holo'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/227.ts
+++ b/data/Scarlet & Violet/Destined Rivals/227.ts
@@ -31,9 +31,14 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		normal: false,
-		reverse: false
-	}
+		holo: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'holo'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/227.ts
+++ b/data/Scarlet & Violet/Destined Rivals/227.ts
@@ -31,7 +31,8 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		holo: true,
+		normal: false,
+		reverse: false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/227.ts
+++ b/data/Scarlet & Violet/Destined Rivals/227.ts
@@ -30,11 +30,6 @@ const card: Card = {
 	trainerType: "Supporter",
 	regulationMark: "I",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
-
 	variants_detailed: [
 		{
 			type: 'holo'

--- a/data/Scarlet & Violet/Destined Rivals/227.ts
+++ b/data/Scarlet & Violet/Destined Rivals/227.ts
@@ -30,7 +30,7 @@ const card: Card = {
 	trainerType: "Supporter",
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'holo'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/228.ts
+++ b/data/Scarlet & Violet/Destined Rivals/228.ts
@@ -73,11 +73,6 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "I",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
-
 	variants_detailed: [
 		{
 			type: 'holo'

--- a/data/Scarlet & Violet/Destined Rivals/228.ts
+++ b/data/Scarlet & Violet/Destined Rivals/228.ts
@@ -74,9 +74,14 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		normal: false,
-		reverse: false
-	}
+		holo: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'holo'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/228.ts
+++ b/data/Scarlet & Violet/Destined Rivals/228.ts
@@ -74,7 +74,8 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		holo: true,
+		normal: false,
+		reverse: false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/228.ts
+++ b/data/Scarlet & Violet/Destined Rivals/228.ts
@@ -73,7 +73,7 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'holo'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/229.ts
+++ b/data/Scarlet & Violet/Destined Rivals/229.ts
@@ -71,7 +71,7 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'holo'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/229.ts
+++ b/data/Scarlet & Violet/Destined Rivals/229.ts
@@ -72,9 +72,14 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		normal: false,
-		reverse: false
-	}
+		holo: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'holo'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/229.ts
+++ b/data/Scarlet & Violet/Destined Rivals/229.ts
@@ -72,7 +72,8 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		holo: true,
+		normal: false,
+		reverse: false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/229.ts
+++ b/data/Scarlet & Violet/Destined Rivals/229.ts
@@ -71,11 +71,6 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "I",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
-
 	variants_detailed: [
 		{
 			type: 'holo'

--- a/data/Scarlet & Violet/Destined Rivals/230.ts
+++ b/data/Scarlet & Violet/Destined Rivals/230.ts
@@ -74,9 +74,14 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		normal: false,
-		reverse: false
-	}
+		holo: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'holo'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/230.ts
+++ b/data/Scarlet & Violet/Destined Rivals/230.ts
@@ -74,7 +74,8 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		holo: true,
+		normal: false,
+		reverse: false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/230.ts
+++ b/data/Scarlet & Violet/Destined Rivals/230.ts
@@ -73,11 +73,6 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "I",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
-
 	variants_detailed: [
 		{
 			type: 'holo'

--- a/data/Scarlet & Violet/Destined Rivals/230.ts
+++ b/data/Scarlet & Violet/Destined Rivals/230.ts
@@ -73,7 +73,7 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'holo'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/231.ts
+++ b/data/Scarlet & Violet/Destined Rivals/231.ts
@@ -74,9 +74,14 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		normal: false,
-		reverse: false
-	}
+		holo: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'holo'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/231.ts
+++ b/data/Scarlet & Violet/Destined Rivals/231.ts
@@ -74,7 +74,8 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		holo: true,
+		normal: false,
+		reverse: false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/231.ts
+++ b/data/Scarlet & Violet/Destined Rivals/231.ts
@@ -73,7 +73,7 @@ const card: Card = {
 	retreat: 3,
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'holo'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/231.ts
+++ b/data/Scarlet & Violet/Destined Rivals/231.ts
@@ -73,11 +73,6 @@ const card: Card = {
 	retreat: 3,
 	regulationMark: "I",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
-
 	variants_detailed: [
 		{
 			type: 'holo'

--- a/data/Scarlet & Violet/Destined Rivals/232.ts
+++ b/data/Scarlet & Violet/Destined Rivals/232.ts
@@ -74,9 +74,14 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		normal: false,
-		reverse: false
-	}
+		holo: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'holo'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/232.ts
+++ b/data/Scarlet & Violet/Destined Rivals/232.ts
@@ -74,7 +74,8 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		holo: true,
+		normal: false,
+		reverse: false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/232.ts
+++ b/data/Scarlet & Violet/Destined Rivals/232.ts
@@ -73,11 +73,6 @@ const card: Card = {
 	retreat: 0,
 	regulationMark: "I",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
-
 	variants_detailed: [
 		{
 			type: 'holo'

--- a/data/Scarlet & Violet/Destined Rivals/232.ts
+++ b/data/Scarlet & Violet/Destined Rivals/232.ts
@@ -73,7 +73,7 @@ const card: Card = {
 	retreat: 0,
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'holo'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/233.ts
+++ b/data/Scarlet & Violet/Destined Rivals/233.ts
@@ -63,7 +63,7 @@ const card: Card = {
 	retreat: 3,
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'holo'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/233.ts
+++ b/data/Scarlet & Violet/Destined Rivals/233.ts
@@ -64,7 +64,8 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		holo: true,
+		normal: false,
+		reverse: false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/233.ts
+++ b/data/Scarlet & Violet/Destined Rivals/233.ts
@@ -63,11 +63,6 @@ const card: Card = {
 	retreat: 3,
 	regulationMark: "I",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
-
 	variants_detailed: [
 		{
 			type: 'holo'

--- a/data/Scarlet & Violet/Destined Rivals/233.ts
+++ b/data/Scarlet & Violet/Destined Rivals/233.ts
@@ -64,9 +64,14 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		normal: false,
-		reverse: false
-	}
+		holo: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'holo'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/234.ts
+++ b/data/Scarlet & Violet/Destined Rivals/234.ts
@@ -73,11 +73,6 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "I",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
-
 	variants_detailed: [
 		{
 			type: 'holo'

--- a/data/Scarlet & Violet/Destined Rivals/234.ts
+++ b/data/Scarlet & Violet/Destined Rivals/234.ts
@@ -74,9 +74,14 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		normal: false,
-		reverse: false
-	}
+		holo: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'holo'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/234.ts
+++ b/data/Scarlet & Violet/Destined Rivals/234.ts
@@ -74,7 +74,8 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		holo: true,
+		normal: false,
+		reverse: false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/234.ts
+++ b/data/Scarlet & Violet/Destined Rivals/234.ts
@@ -73,7 +73,7 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'holo'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/235.ts
+++ b/data/Scarlet & Violet/Destined Rivals/235.ts
@@ -74,9 +74,14 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		normal: false,
-		reverse: false
-	}
+		holo: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'holo'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/235.ts
+++ b/data/Scarlet & Violet/Destined Rivals/235.ts
@@ -74,7 +74,8 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		holo: true,
+		normal: false,
+		reverse: false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/235.ts
+++ b/data/Scarlet & Violet/Destined Rivals/235.ts
@@ -73,7 +73,7 @@ const card: Card = {
 	retreat: 3,
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'holo'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/235.ts
+++ b/data/Scarlet & Violet/Destined Rivals/235.ts
@@ -73,11 +73,6 @@ const card: Card = {
 	retreat: 3,
 	regulationMark: "I",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
-
 	variants_detailed: [
 		{
 			type: 'holo'

--- a/data/Scarlet & Violet/Destined Rivals/236.ts
+++ b/data/Scarlet & Violet/Destined Rivals/236.ts
@@ -31,9 +31,14 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		normal: false,
-		reverse: false
-	}
+		holo: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'holo'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/236.ts
+++ b/data/Scarlet & Violet/Destined Rivals/236.ts
@@ -31,7 +31,8 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		holo: true,
+		normal: false,
+		reverse: false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/236.ts
+++ b/data/Scarlet & Violet/Destined Rivals/236.ts
@@ -30,11 +30,6 @@ const card: Card = {
 	trainerType: "Supporter",
 	regulationMark: "I",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
-
 	variants_detailed: [
 		{
 			type: 'holo'

--- a/data/Scarlet & Violet/Destined Rivals/236.ts
+++ b/data/Scarlet & Violet/Destined Rivals/236.ts
@@ -30,7 +30,7 @@ const card: Card = {
 	trainerType: "Supporter",
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'holo'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/237.ts
+++ b/data/Scarlet & Violet/Destined Rivals/237.ts
@@ -31,9 +31,14 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		normal: false,
-		reverse: false
-	}
+		holo: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'holo'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/237.ts
+++ b/data/Scarlet & Violet/Destined Rivals/237.ts
@@ -31,7 +31,8 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		holo: true,
+		normal: false,
+		reverse: false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/237.ts
+++ b/data/Scarlet & Violet/Destined Rivals/237.ts
@@ -30,11 +30,6 @@ const card: Card = {
 	trainerType: "Supporter",
 	regulationMark: "I",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
-
 	variants_detailed: [
 		{
 			type: 'holo'

--- a/data/Scarlet & Violet/Destined Rivals/237.ts
+++ b/data/Scarlet & Violet/Destined Rivals/237.ts
@@ -30,7 +30,7 @@ const card: Card = {
 	trainerType: "Supporter",
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'holo'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/238.ts
+++ b/data/Scarlet & Violet/Destined Rivals/238.ts
@@ -33,7 +33,6 @@ const card: Card = {
 	variants: {
 		normal: false,
 	},
-
 	variants_detailed: [
 		{
 			type: 'holo'

--- a/data/Scarlet & Violet/Destined Rivals/238.ts
+++ b/data/Scarlet & Violet/Destined Rivals/238.ts
@@ -31,9 +31,14 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		normal: false,
-		reverse: false
-	}
+		holo: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'holo'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/238.ts
+++ b/data/Scarlet & Violet/Destined Rivals/238.ts
@@ -31,7 +31,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		holo: true,
+		normal: false,
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/238.ts
+++ b/data/Scarlet & Violet/Destined Rivals/238.ts
@@ -30,9 +30,6 @@ const card: Card = {
 	trainerType: "Supporter",
 	regulationMark: "I",
 
-	variants: {
-		normal: false,
-	},
 	variants: [
 		{
 			type: 'holo'

--- a/data/Scarlet & Violet/Destined Rivals/238.ts
+++ b/data/Scarlet & Violet/Destined Rivals/238.ts
@@ -33,7 +33,7 @@ const card: Card = {
 	variants: {
 		normal: false,
 	},
-	variants_detailed: [
+	variants: [
 		{
 			type: 'holo'
 		},

--- a/data/Scarlet & Violet/Destined Rivals/239.ts
+++ b/data/Scarlet & Violet/Destined Rivals/239.ts
@@ -74,9 +74,15 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		normal: false,
-		reverse: false
-	}
+		holo: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'holo',
+			foil: 'gold'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/239.ts
+++ b/data/Scarlet & Violet/Destined Rivals/239.ts
@@ -73,11 +73,6 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "I",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
-
 	variants_detailed: [
 		{
 			type: 'holo',

--- a/data/Scarlet & Violet/Destined Rivals/239.ts
+++ b/data/Scarlet & Violet/Destined Rivals/239.ts
@@ -74,7 +74,8 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		holo: true,
+		normal: false,
+		reverse: false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/239.ts
+++ b/data/Scarlet & Violet/Destined Rivals/239.ts
@@ -73,7 +73,7 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'holo',
 			foil: 'gold'

--- a/data/Scarlet & Violet/Destined Rivals/240.ts
+++ b/data/Scarlet & Violet/Destined Rivals/240.ts
@@ -74,9 +74,15 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		normal: false,
-		reverse: false
-	}
+		holo: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'holo',
+			foil: 'gold'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/240.ts
+++ b/data/Scarlet & Violet/Destined Rivals/240.ts
@@ -73,7 +73,7 @@ const card: Card = {
 	retreat: 3,
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'holo',
 			foil: 'gold'

--- a/data/Scarlet & Violet/Destined Rivals/240.ts
+++ b/data/Scarlet & Violet/Destined Rivals/240.ts
@@ -74,7 +74,8 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		holo: true,
+		normal: false,
+		reverse: false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/240.ts
+++ b/data/Scarlet & Violet/Destined Rivals/240.ts
@@ -73,11 +73,6 @@ const card: Card = {
 	retreat: 3,
 	regulationMark: "I",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
-
 	variants_detailed: [
 		{
 			type: 'holo',

--- a/data/Scarlet & Violet/Destined Rivals/241.ts
+++ b/data/Scarlet & Violet/Destined Rivals/241.ts
@@ -74,9 +74,15 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		normal: false,
-		reverse: false
-	}
+		holo: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'holo',
+			foil: 'gold'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/241.ts
+++ b/data/Scarlet & Violet/Destined Rivals/241.ts
@@ -74,7 +74,8 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		holo: true,
+		normal: false,
+		reverse: false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/241.ts
+++ b/data/Scarlet & Violet/Destined Rivals/241.ts
@@ -73,11 +73,6 @@ const card: Card = {
 	retreat: 0,
 	regulationMark: "I",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
-
 	variants_detailed: [
 		{
 			type: 'holo',

--- a/data/Scarlet & Violet/Destined Rivals/241.ts
+++ b/data/Scarlet & Violet/Destined Rivals/241.ts
@@ -73,7 +73,7 @@ const card: Card = {
 	retreat: 0,
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'holo',
 			foil: 'gold'

--- a/data/Scarlet & Violet/Destined Rivals/242.ts
+++ b/data/Scarlet & Violet/Destined Rivals/242.ts
@@ -74,9 +74,15 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		normal: false,
-		reverse: false
-	}
+		holo: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'holo',
+			foil: 'gold'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/242.ts
+++ b/data/Scarlet & Violet/Destined Rivals/242.ts
@@ -73,7 +73,7 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'holo',
 			foil: 'gold'

--- a/data/Scarlet & Violet/Destined Rivals/242.ts
+++ b/data/Scarlet & Violet/Destined Rivals/242.ts
@@ -74,7 +74,8 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		holo: true,
+		normal: false,
+		reverse: false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/242.ts
+++ b/data/Scarlet & Violet/Destined Rivals/242.ts
@@ -73,11 +73,6 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "I",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
-
 	variants_detailed: [
 		{
 			type: 'holo',

--- a/data/Scarlet & Violet/Destined Rivals/243.ts
+++ b/data/Scarlet & Violet/Destined Rivals/243.ts
@@ -29,12 +29,6 @@ const card: Card = {
 
 	trainerType: "Stadium",
 	regulationMark: "H",
-
-	variants: {
-		normal: false,
-		reverse: false
-	},
-
 	variants_detailed: [
 		{
 			type: 'holo',

--- a/data/Scarlet & Violet/Destined Rivals/243.ts
+++ b/data/Scarlet & Violet/Destined Rivals/243.ts
@@ -31,9 +31,15 @@ const card: Card = {
 	regulationMark: "H",
 
 	variants: {
-		normal: false,
-		reverse: false
-	}
+		holo: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'holo',
+			foil: 'gold'
+		},
+	]
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/243.ts
+++ b/data/Scarlet & Violet/Destined Rivals/243.ts
@@ -29,7 +29,7 @@ const card: Card = {
 
 	trainerType: "Stadium",
 	regulationMark: "H",
-	variants_detailed: [
+	variants: [
 		{
 			type: 'holo',
 			foil: 'gold'

--- a/data/Scarlet & Violet/Destined Rivals/243.ts
+++ b/data/Scarlet & Violet/Destined Rivals/243.ts
@@ -31,7 +31,8 @@ const card: Card = {
 	regulationMark: "H",
 
 	variants: {
-		holo: true,
+		normal: false,
+		reverse: false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/244.ts
+++ b/data/Scarlet & Violet/Destined Rivals/244.ts
@@ -30,11 +30,6 @@ const card: Card = {
 	trainerType: "Stadium",
 	regulationMark: "I",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
-
 	variants_detailed: [
 		{
 			type: 'holo',

--- a/data/Scarlet & Violet/Destined Rivals/244.ts
+++ b/data/Scarlet & Violet/Destined Rivals/244.ts
@@ -30,7 +30,7 @@ const card: Card = {
 	trainerType: "Stadium",
 	regulationMark: "I",
 
-	variants_detailed: [
+	variants: [
 		{
 			type: 'holo',
 			foil: 'gold'

--- a/data/Scarlet & Violet/Destined Rivals/244.ts
+++ b/data/Scarlet & Violet/Destined Rivals/244.ts
@@ -31,7 +31,8 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		holo: true,
+		normal: false,
+		reverse: false
 	},
 
 	variants_detailed: [

--- a/data/Scarlet & Violet/Destined Rivals/244.ts
+++ b/data/Scarlet & Violet/Destined Rivals/244.ts
@@ -31,9 +31,15 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		normal: false,
-		reverse: false
-	}
+		holo: true,
+	},
+
+	variants_detailed: [
+		{
+			type: 'holo',
+			foil: 'gold'
+		},
+	]
 }
 
 export default card

--- a/interfaces.d.ts
+++ b/interfaces.d.ts
@@ -187,13 +187,7 @@ export interface Card {
 	/**
 	 * Card Variants (Override Set Variants)
 	 */
-	variants?: variants
-
-	/**
-	 * Card Variants Detailed.
-	 * detailed information about card variants, to replace the variants field in V3
-	 */
-	variants_detailed?: Array<variant_detailed>
+	variants?: variants | Array<variant_detailed>
 
 	/**
 	 * Card Set

--- a/interfaces.d.ts
+++ b/interfaces.d.ts
@@ -1,5 +1,5 @@
 export type SupportedLanguages =
-	// inter languages
+// inter languages
 	'en' | 'fr' | 'es' | 'es-mx' | 'it' | 'pt' | 'pt-br' | 'pt-pt' | 'de' | 'nl' | 'pl' | 'ru' |
 	// Asian languages
 	'ja' | 'ko' | 'zh-tw' | 'id' | 'th' | 'zh-cn'
@@ -14,6 +14,38 @@ export interface Serie {
 	 * Serie Energy cards
 	 */
 	energies?: Array<Types>
+}
+
+interface variant_detailed {
+	/**
+	 * define the variant type
+	 * - normal: no holographic elements
+	 * - holo: the illustration has a foil
+	 * - reverse: everything but the illustration is foiled
+	 */
+	type: 'normal' | 'holo' | 'reverse' | 'metal'
+	/**
+	 * define the size of the card
+	 * - standard: the classic size of a card
+	 * - jumbo: also said oversized, big card.
+	 */
+	size?: 'standard' | 'jumbo'
+	/**
+	 * indicate that this variant has a stamp
+	 * a card may have multiple stamps, example "Ethan's Typhlosion pre-release staff"
+	 * this was a pre-release card only given to staff and has both the set-logo and the staff stamp.
+	 * - 1st edition: a 1st edition card (mostly for the first series of the game)
+	 * - w-promo:
+	 * - pre-release:
+	 * - pokemon-center: a card that is stamped with the Pokémon Center logo
+	 * - set-promo: a card that is stamped with the set logo
+	 * - staff: a card that is stamped with the staff text
+	 */
+	stamp?: Array<'1st edition' | 'w-promo' | 'pre-release' | 'pokemon-center' | 'set-logo' | 'staff'>
+	/**
+	 * for the holo & reverse, **optional** indicate which foil is used on the card
+	 */
+	foil?: 'pokeball' | 'ultraball' | 'masterball' | 'gold'
 }
 
 interface variants {
@@ -54,9 +86,9 @@ interface variants {
 }
 
 export type Types = 'Colorless' | 'Darkness' | 'Dragon' |
-'Fairy' | 'Fighting' | 'Fire' |
-'Grass' | 'Lightning' | 'Metal' |
-'Psychic' | 'Water'
+	'Fairy' | 'Fighting' | 'Fire' |
+	'Grass' | 'Lightning' | 'Metal' |
+	'Psychic' | 'Water'
 
 type ISODate = `${number}-${number}-${number}`
 
@@ -135,13 +167,13 @@ export interface Card {
 	 * - Uncommon: https://www.tcgdex.net/database/Sword-&-Shield/Darkness-Ablaze/136-Furret
 	 */
 	rarity: 'ACE SPEC Rare' | 'Amazing Rare' | 'Classic Collection' | 'Common' |
-			'Double rare' | 'Full Art Trainer' | 'Holo Rare' | 'Holo Rare V' |
-			'Holo Rare VMAX' | 'Holo Rare VSTAR' | 'Hyper rare' | 'Illustration rare' |
-			'LEGEND' | 'None' | 'Radiant Rare' | 'Rare' | 'Rare Holo' | 'Rare Holo LV.X' |
-			'Rare PRIME' | 'Secret Rare' | 'Shiny Ultra Rare' | 'Shiny rare' | 'Shiny rare V' |
-			'Shiny rare VMAX' | 'Special illustration rare' | 'Ultra Rare' | 'Uncommon' |
-			// Pokémon TCG Pocket Rarities
-			'One Diamond' | 'Two Diamond' | 'Three Diamond' | 'Four Diamond' | 'One Star' | 'Two Star' | 'Three Star' | 'Crown' | 'One Shiny' | 'Two Shiny'
+		'Double rare' | 'Full Art Trainer' | 'Holo Rare' | 'Holo Rare V' |
+		'Holo Rare VMAX' | 'Holo Rare VSTAR' | 'Hyper rare' | 'Illustration rare' |
+		'LEGEND' | 'None' | 'Radiant Rare' | 'Rare' | 'Rare Holo' | 'Rare Holo LV.X' |
+		'Rare PRIME' | 'Secret Rare' | 'Shiny Ultra Rare' | 'Shiny rare' | 'Shiny rare V' |
+		'Shiny rare VMAX' | 'Special illustration rare' | 'Ultra Rare' | 'Uncommon' |
+		// Pokémon TCG Pocket Rarities
+		'One Diamond' | 'Two Diamond' | 'Three Diamond' | 'Four Diamond' | 'One Star' | 'Two Star' | 'Three Star' | 'Crown' | 'One Shiny' | 'Two Shiny'
 
 	/**
 	 * Card Category
@@ -156,6 +188,12 @@ export interface Card {
 	 * Card Variants (Override Set Variants)
 	 */
 	variants?: variants
+
+	/**
+	 * Card Variants Detailed.
+	 * detailed information about card variants, to replace the variants field in V3
+	 */
+	variants_detailed?: Array<variant_detailed>
 
 	/**
 	 * Card Set
@@ -290,17 +328,17 @@ export interface Card {
 
 	// Trainer Only
 	trainerType?: 'Supporter' | // https://www.tcgdex.net/database/ex/ex7/83
-	'Item' | // https://www.tcgdex.net/database/ex/ex7/89
-	'Stadium' | // https://www.tcgdex.net/database/ex/ex7/87
-	'Tool' | // https://www.tcgdex.net/database/neo/neo1/93
-	'Ace Spec' | // https://www.tcgdex.net/database/bw/bw7/139
-	'Technical Machine' | // https://www.tcgdex.net/database/ecard/ecard1/144
-	'Goldenrod Game Corner' | // https://www.tcgdex.net/database/neo/neo1/83
-	'Rocket\'s Secret Machine' // https://www.tcgdex.net/database/ex/ex7/84
+		'Item' | // https://www.tcgdex.net/database/ex/ex7/89
+		'Stadium' | // https://www.tcgdex.net/database/ex/ex7/87
+		'Tool' | // https://www.tcgdex.net/database/neo/neo1/93
+		'Ace Spec' | // https://www.tcgdex.net/database/bw/bw7/139
+		'Technical Machine' | // https://www.tcgdex.net/database/ecard/ecard1/144
+		'Goldenrod Game Corner' | // https://www.tcgdex.net/database/neo/neo1/83
+		'Rocket\'s Secret Machine' // https://www.tcgdex.net/database/ex/ex7/84
 
 	// Energy Only
 	energyType?: 'Normal' | // https://www.tcgdex.net/database/ecard/ecard1/160
-	'Special' // https://www.tcgdex.net/database/ecard/ecard1/158
+		'Special' // https://www.tcgdex.net/database/ecard/ecard1/158
 }
 
 /**

--- a/interfaces.d.ts
+++ b/interfaces.d.ts
@@ -24,6 +24,13 @@ interface variant_detailed {
 	 * - reverse: everything but the illustration is foiled
 	 */
 	type: 'normal' | 'holo' | 'reverse' | 'metal'
+
+	/**
+	 * Some older sets had specific subtypes for the cards
+	 * i.e Base Set had shadowless with and without a 1st edition stamp.
+	 * and the Unlimited version of the set had no shadow.
+	 */
+	subtype?: 'shadowless' | 'unlimited'
 	/**
 	 * define the size of the card
 	 * - standard: the classic size of a card

--- a/meta/definitions/api.d.ts
+++ b/meta/definitions/api.d.ts
@@ -57,6 +57,13 @@ interface variants {
 	wPromo?: boolean
 }
 
+interface variant_detailed {
+	type: string
+	size?: string
+	stamp?: Array<string>
+	foil?: string
+}
+
 export interface SetResume {
 	id: string;
 	name: string;
@@ -174,6 +181,17 @@ export interface Card extends CardResume {
 	 * Card Variants (Override Set Variants)
 	 */
 	variants?: variants;
+
+	/**
+	 * Card Variants Detailed
+	 *
+	 * - type: the type of variant (normal, reverse, holo, etc)
+	 * - size: the size of the variant (normal, jumbo, etc)
+	 * - stamp: the stamps of the variant (ex: 'Staff', 'Pre-release', etc)
+	 * - foil: the foil of the variant (ex: 'Holo', 'Reverse Holo', etc)
+	 */
+	variants_detailed?: Array<variant_detailed>
+
 	/**
 	 * Card Set
 	 */

--- a/meta/definitions/api.d.ts
+++ b/meta/definitions/api.d.ts
@@ -179,6 +179,7 @@ export interface Card extends CardResume {
 	category: string;
 	/**
 	 * Card Variants (Override Set Variants)
+	 * To be deprecated in V3
 	 */
 	variants?: variants;
 
@@ -189,8 +190,9 @@ export interface Card extends CardResume {
 	 * - size: the size of the variant (normal, jumbo, etc)
 	 * - stamp: the stamps of the variant (ex: 'Staff', 'Pre-release', etc)
 	 * - foil: the foil of the variant (ex: 'Holo', 'Reverse Holo', etc)
+
 	 */
-	variants_detailed?: Array<variant_detailed>
+	variants_detailed?: Array<variant_detailed>;
 
 	/**
 	 * Card Set

--- a/meta/definitions/graphql.gql
+++ b/meta/definitions/graphql.gql
@@ -219,6 +219,9 @@ type Card {
 	"""The card variants"""
 	variants: Variants
 
+	"""Detailed card variants, including type, size, and stamps"""
+	variants_detailed: [DetailedVariants]
+
 	"""The boosters in which the card is available"""
 	boosters: [Booster]
 

--- a/meta/definitions/graphql.gql
+++ b/meta/definitions/graphql.gql
@@ -314,6 +314,19 @@ type Variants {
 }
 
 """
+Detailed card variants
+"""
+type DetailedVariants {
+	"""The type of card, e.g., 'normal', 'reverse', 'holo', etc."""
+	type: String!
+	"""The size of the card, e.g., 'standard', 'jumbo', etc."""
+	size: String!
+	"""Any stamps the variant may have, e.g., '1st Edition', 'Staff', etc."""
+	stamps: [String]
+	"""The type of foil"""
+	foil: String
+}
+"""
 A booster pack for Pokémon TCG cards
 
 Boosters represent the different pack designs that cards can be obtained from within a set.

--- a/meta/definitions/openapi.yaml
+++ b/meta/definitions/openapi.yaml
@@ -1511,6 +1511,31 @@ components:
             wPromo:
               type: boolean
               description: Indicates whether a promotional variant exists
+        variant_detailed:
+            type: [array,"null"]
+            description: Detailed information about a card variant
+            items:
+                type: object
+                required:
+                    - type
+                properties:
+                    type:
+                        type: string
+                        description: The type of variant (e.g., normal, reverse, holo, etc.)
+                    size:
+                        type: string
+                        description: The size of the variant (e.g., standard, jumbo, etc.)
+                        nullable: true
+                    stamp:
+                        type: array
+                        description: The stamps of the variant (e.g., 'Staff', 'Pokemon-Centre', etc.)
+                        items:
+                            type: string
+                        nullable: true
+                    foil:
+                        type: string
+                        description: The foil of the variant (e.g., 'Pokeball', 'MasterBall', etc.)
+                        nullable: true
         hp:
           type: [number, "null"]
           description: Hit Points (HP) of the Pokemon

--- a/meta/translations/de.json
+++ b/meta/translations/de.json
@@ -125,5 +125,9 @@
 		"set-logo": "Set-Logo",
 		"pokemon-center": "Pokémon-Center",
 		"staff": "Mitarbeiter"
+	},
+	"variantSubtype": {
+		"shadowless": "schattenlos",
+		"unlimited": "unbegrenzt"
 	}
 }

--- a/meta/translations/de.json
+++ b/meta/translations/de.json
@@ -101,5 +101,29 @@
 		"Metal": "Metall",
 		"Psychic": "Psycho",
 		"Water": "Wasser"
+	},
+	"variantType": {
+		"normal": "Normal",
+		"holo": "Holo",
+		"reverse": "Reverse",
+		"metal": "Metall"
+	},
+	"variantSize": {
+		"standard": "Standard",
+		"jumbo": "Jumbo"
+	},
+	"variantFoil": {
+		"pokeball": "Pokéball",
+		"ultraball": "Ultraball",
+		"masterball": "Meisterball",
+		"gold": "Gold"
+	},
+	"variantStamp": {
+		"1st Edition": "1. Auflage",
+		"w-promo": "w-promo",
+		"pre-release": "Vorveröffentlichung",
+		"set-logo": "Set-Logo",
+		"pokemon-center": "Pokémon-Center",
+		"staff": "Mitarbeiter"
 	}
 }

--- a/meta/translations/es.json
+++ b/meta/translations/es.json
@@ -101,5 +101,29 @@
 		"Metal": "Metálica",
 		"Psychic": "Psíquico",
 		"Water": "Agua"
+	},
+	"variantType": {
+		"normal": "básico",
+		"holo": "holo",
+		"reverse": "reversa",
+		"metal": "metal"
+	},
+	"variantSize": {
+		"standard": "estándar",
+		"jumbo": "jumbo"
+	},
+	"variantFoil": {
+		"pokeball": "Pokébola",
+		"ultraball": "UltraBall",
+		"masterball": "MasterBall",
+		"gold": "Oro"
+	},
+	"variantStamp": {
+		"1st Edition": "1ra Edición",
+		"w-promo": "w-promo",
+		"pre-release": "pre-lanzamiento",
+		"set-logo": "logo del set",
+		"pokemon-center": "pokemon-center",
+		"staff": "staff"
 	}
 }

--- a/meta/translations/es.json
+++ b/meta/translations/es.json
@@ -125,5 +125,9 @@
 		"set-logo": "logo del set",
 		"pokemon-center": "pokemon-center",
 		"staff": "staff"
+	},
+	"variantSubtype": {
+		"shadowless": "sin sombra",
+		"unlimited": "ilimitado"
 	}
 }

--- a/meta/translations/fr.json
+++ b/meta/translations/fr.json
@@ -100,5 +100,29 @@
 		"Metal": "Métal",
 		"Psychic": "Psy",
 		"Water": "Eau"
+	},
+	"variantType": {
+		"normal": "De base",
+		"holo": "Holo",
+		"reverse": "Reverse",
+		"metal": "Métal"
+	},
+	"variantSize": {
+		"standard": "Standard",
+		"jumbo": "Jumbo"
+	},
+	"variantFoil": {
+		"pokeball": "Pokéball",
+		"ultraball": "Ultraball",
+		"masterball": "Masterball",
+		"gold": "Or"
+	},
+	"variantStamp": {
+		"1st Edition": "1re Édition",
+		"w-promo": "w-promo",
+		"pre-release": "Pré-release",
+		"set-logo": "Logo de la série",
+		"pokemon-center": "Pokémon Center",
+		"staff": "Staff"
 	}
 }

--- a/meta/translations/fr.json
+++ b/meta/translations/fr.json
@@ -124,5 +124,9 @@
 		"set-logo": "Logo de la série",
 		"pokemon-center": "Pokémon Center",
 		"staff": "Staff"
+	},
+	"variantSubtype": {
+		"shadowless": "sans ombre",
+		"unlimited": "illimité"
 	}
 }

--- a/meta/translations/it.json
+++ b/meta/translations/it.json
@@ -101,5 +101,29 @@
 		"Metal": "Metallo",
 		"Psychic": "Psico",
 		"Water": "Acqua"
+	},
+	"variantType": {
+		"normal": "Normale",
+		"holo": "Olografica",
+		"reverse": "Reverse",
+		"metal": "Metallo"
+	},
+	"variantSize": {
+		"standard": "Standard",
+		"jumbo": "Jumbo"
+	},
+	"variantFoil": {
+		"pokeball": "Poké Ball",
+		"ultraball": "Ultra Ball",
+		"masterball": "Master Ball",
+		"gold": "Oro"
+	},
+	"variantStamp": {
+		"1st Edition": "1a Edizione",
+		"w-promo": "w-promo",
+		"pre-release": "Pre-release",
+		"set-logo": "Logo set",
+		"pokemon-center": "Pokémon Center",
+		"staff": "Staff"
 	}
 }

--- a/meta/translations/it.json
+++ b/meta/translations/it.json
@@ -125,5 +125,9 @@
 		"set-logo": "Logo set",
 		"pokemon-center": "Pokémon Center",
 		"staff": "Staff"
+	},
+	"variantSubtype": {
+		"shadowless": "senza ombra",
+		"unlimited": "illimitato"
 	}
 }

--- a/meta/translations/pt.json
+++ b/meta/translations/pt.json
@@ -100,5 +100,29 @@
 		"Metal": "Metal",
 		"Psychic": "Psíquico",
 		"Water": "Água"
+	},
+	"variantType": {
+		"normal": "Normal",
+		"holo": "Holo",
+		"reverse": "Reverse",
+		"metal": "Metal"
+	},
+	"variantSize": {
+		"standard": "Padrão",
+		"jumbo": "Jumbo"
+	},
+	"variantFoil": {
+		"pokeball": "Poké Bola",
+		"ultraball": "Ultra Bola",
+		"masterball": "Master Bola",
+		"gold": "Ouro"
+	},
+	"variantStamp": {
+		"1st Edition": "1ª Edição",
+		"w-promo": "w-promo",
+		"pre-release": "Pré-lançamento",
+		"set-logo": "Logo da coleção",
+		"pokemon-center": "Pokémon Center",
+		"staff": "Staff"
 	}
 }

--- a/meta/translations/pt.json
+++ b/meta/translations/pt.json
@@ -124,5 +124,9 @@
 		"set-logo": "Logo da coleção",
 		"pokemon-center": "Pokémon Center",
 		"staff": "Staff"
+	},
+	"variantSubtype": {
+		"shadowless": "sem sombra",
+		"unlimited": "ilimitado"
 	}
 }

--- a/server/compiler/utils/cardUtil.ts
+++ b/server/compiler/utils/cardUtil.ts
@@ -60,6 +60,16 @@ export async function cardToCardSingle(localId: string, card: Card, lang: Suppor
 			wPromo: typeof card.variants?.wPromo === 'boolean' ? card.variants.wPromo : false
 		},
 
+		variants_detailed: card.variants_detailed?.map((variant)=> {
+			return {
+				type: translate('variantType', variant.type, lang) as any,
+				size: variant.size ? translate('variantSize', variant.size, lang) as any : translate('variantSize','standard', lang) as any,
+				stamp: variant.stamp ? variant.stamp.map((stamp) => {
+					return translate('variantStamp', stamp, lang)
+				}) : undefined,
+				foil: variant.foil ? translate('variantFoil', variant.foil, lang) : undefined
+			}
+		}),
 
 		dexId: card.dexId,
 		hp: card.hp,

--- a/server/compiler/utils/cardUtil.ts
+++ b/server/compiler/utils/cardUtil.ts
@@ -64,15 +64,16 @@ export async function cardToCardSingle(localId: string, card: Card, lang: Suppor
 		rarity: translate('rarity', card.rarity, lang) as any,
 		set: await setToSetSimple(card.set, lang),
 
-		variants: card.variants ? {
+		variants : Array.isArray(card.variants) ?
+			variantsDetailedToVariants(card.variants) : {
 			firstEdition: typeof card.variants?.firstEdition === 'boolean' ? card.variants.firstEdition : false,
 			holo: typeof card.variants?.holo === 'boolean' ? card.variants.holo : true,
 			normal: typeof card.variants?.normal === 'boolean' ? card.variants.normal : true,
 			reverse: typeof card.variants?.reverse === 'boolean' ? card.variants.reverse : true,
 			wPromo: typeof card.variants?.wPromo === 'boolean' ? card.variants.wPromo : false
-		} : variantsDetailedToVariants(card.variants_detailed),
+		},
 
-		variants_detailed: card.variants_detailed?.map((variant) => {
+		variants_detailed: Array.isArray(card.variants) ? card.variants?.map((variant) => {
 			return {
 				type: translate('variantType', variant.type, lang) as any,
 				size: variant.size ? translate('variantSize', variant.size, lang) as any : translate('variantSize', 'standard', lang) as any,
@@ -81,7 +82,7 @@ export async function cardToCardSingle(localId: string, card: Card, lang: Suppor
 				}) : undefined,
 				foil: variant.foil ? translate('variantFoil', variant.foil, lang) : undefined
 			}
-		}),
+		}) : undefined,
 
 		dexId: card.dexId,
 		hp: card.hp,

--- a/server/compiler/utils/cardUtil.ts
+++ b/server/compiler/utils/cardUtil.ts
@@ -1,8 +1,8 @@
 /* eslint-disable sort-keys */
-import {exec} from 'child_process'
-import {Card, Set, SupportedLanguages, Types} from '../../../interfaces'
-import {CardResume, Card as CardSingle} from '../../../meta/definitions/api'
-import {getSet, setToSetSimple} from './setUtil'
+import { exec } from 'child_process'
+import { Card, Set, SupportedLanguages, Types } from '../../../interfaces'
+import { CardResume, Card as CardSingle } from '../../../meta/definitions/api'
+import { getSet, setToSetSimple } from './setUtil'
 import translate from './translationUtil'
 import { DB_PATH, cardIsLegal, fetchRemoteFile, getDataFolder, getLastEdit, resolveText, smartGlob } from './util'
 import { objectMap, objectPick } from '@dzeio/object-util'

--- a/server/compiler/utils/cardUtil.ts
+++ b/server/compiler/utils/cardUtil.ts
@@ -6,6 +6,7 @@ import { getSet, setToSetSimple } from './setUtil'
 import translate from './translationUtil'
 import { DB_PATH, cardIsLegal, fetchRemoteFile, getDataFolder, getLastEdit, resolveText, smartGlob } from './util'
 import { objectMap, objectPick } from '@dzeio/object-util'
+import {variant_detailed} from "../../public/v2/api";
 
 export async function getCardPictures(cardId: string, card: Card, lang: SupportedLanguages): Promise<string | undefined> {
 	try {

--- a/server/compiler/utils/cardUtil.ts
+++ b/server/compiler/utils/cardUtil.ts
@@ -103,6 +103,7 @@ export async function cardToCardSingle(localId: string, card: Card, lang: Suppor
 		variants_detailed: Array.isArray(card.variants) ? card.variants?.map((variant) => {
 			return {
 				type: translate('variantType', variant.type, lang) as any,
+				subtype: translate('variantSubtype', variant.subtype, lang) as any,
 				size: variant.size ? translate('variantSize', variant.size, lang) as any : translate('variantSize', 'standard', lang) as any,
 				stamp: variant.stamp ? variant.stamp.map((stamp) => {
 					return translate('variantStamp', stamp, lang)

--- a/server/compiler/utils/serieUtil.ts
+++ b/server/compiler/utils/serieUtil.ts
@@ -11,7 +11,7 @@ export async function isSerieAvailable(serie: Serie, lang: SupportedLanguages): 
 	if (!resolveText(serie.name, lang)) {
 		return false
 	}
-	const sets = await getSets(serie.name.en, lang)
+	const sets = await getSets(serie.name[lang], lang)
 	return sets.length > 0
 }
 
@@ -31,7 +31,7 @@ export async function getSeries(lang: SupportedLanguages): Promise<Array<Serie>>
 	// Sort series by the first set release date
 	const tmp: Array<[Serie, Set | undefined]> = await Promise.all(series.map(async (it) => [
 		it,
-		(await getSets(it.name.en, lang))
+		(await getSets(it.name[lang], lang))
 			.reduce<Set | undefined>((p, c) => p ? p.releaseDate < c.releaseDate ? p : c : c, undefined) as Set
 	] as [Serie, Set]))
 
@@ -39,7 +39,7 @@ export async function getSeries(lang: SupportedLanguages): Promise<Array<Serie>>
 }
 
 export async function serieToSerieSimple(serie: Serie, lang: SupportedLanguages): Promise<SerieResume> {
-	const setsTmp = await getSets(serie.name.en, lang)
+	const setsTmp = await getSets(serie.name[lang], lang)
 	const sets = await Promise.all(setsTmp
 		.sort((a, b) => a.releaseDate > b.releaseDate ? 1 : -1)
 		.map((el) => setToSetSimple(el, lang)))
@@ -52,7 +52,7 @@ export async function serieToSerieSimple(serie: Serie, lang: SupportedLanguages)
 }
 
 export async function serieToSerieSingle(serie: Serie, lang: SupportedLanguages): Promise<SerieSingle> {
-	const setsTmp = await getSets(serie.name.en, lang)
+	const setsTmp = await getSets(serie.name[lang], lang)
 	const sortedSetsTmp = setsTmp.sort((a, b) => a.releaseDate > b.releaseDate ? 1 : -1)
 	const sets = await Promise.all(sortedSetsTmp.map((el) => setToSetSimple(el, lang)))
 	const logo = (

--- a/server/compiler/utils/setUtil.ts
+++ b/server/compiler/utils/setUtil.ts
@@ -1,5 +1,5 @@
 import { objectKeys, objectMap } from '@dzeio/object-util'
-import {Card, Set, SupportedLanguages} from '../../../interfaces'
+import { Card, Set, SupportedLanguages } from '../../../interfaces'
 import { SetResume, Set as SetSingle } from '../../../meta/definitions/api'
 import { cardToCardSimple, getCards } from './cardUtil'
 import { DB_PATH, fetchRemoteFile, getDataFolder, resolveText, setIsLegal, smartGlob } from './util'

--- a/server/compiler/utils/translationUtil.ts
+++ b/server/compiler/utils/translationUtil.ts
@@ -5,7 +5,7 @@ import pt from '../../../meta/translations/pt.json'
 import de from '../../../meta/translations/de.json'
 import fr from '../../../meta/translations/fr.json'
 
-type translatable = 'types' | 'rarity' | 'stage' | 'category' | 'suffix' | 'abilityType' | 'trainerType' | 'energyType'
+type translatable = 'types' | 'rarity' | 'stage' | 'category' | 'suffix' | 'abilityType' | 'trainerType' | 'energyType' | 'variantType' | 'variantSize' | 'variantFoil' | 'variantStamp'
 
 const translations: Record<string, Record<translatable, Record<string, string>>> = {
 	es,

--- a/server/compiler/utils/translationUtil.ts
+++ b/server/compiler/utils/translationUtil.ts
@@ -5,7 +5,7 @@ import pt from '../../../meta/translations/pt.json'
 import de from '../../../meta/translations/de.json'
 import fr from '../../../meta/translations/fr.json'
 
-type translatable = 'types' | 'rarity' | 'stage' | 'category' | 'suffix' | 'abilityType' | 'trainerType' | 'energyType' | 'variantType' | 'variantSize' | 'variantFoil' | 'variantStamp'
+type translatable = 'types' | 'rarity' | 'stage' | 'category' | 'suffix' | 'abilityType' | 'trainerType' | 'energyType' | 'variantType' | 'variantSize' | 'variantFoil' | 'variantStamp' | 'variantSubtype'
 
 const translations: Record<string, Record<translatable, Record<string, string>>> = {
 	es,

--- a/server/src/V2/Components/Card.ts
+++ b/server/src/V2/Components/Card.ts
@@ -1,6 +1,6 @@
-import {objectLoop} from '@dzeio/object-util'
-import type {CardResume, Card as SDKCard, SupportedLanguages} from '@tcgdex/sdk'
-import {executeQuery, type Query} from '../../libs/QueryEngine/filter'
+import { objectLoop } from '@dzeio/object-util'
+import type { CardResume, Card as SDKCard, SupportedLanguages } from '@tcgdex/sdk'
+import { executeQuery, type Query } from '../../libs/QueryEngine/filter'
 import TCGSet from './Set'
 
 import de from '../../../generated/de/cards.json'

--- a/server/src/V2/Components/Card.ts
+++ b/server/src/V2/Components/Card.ts
@@ -1,6 +1,6 @@
-import { objectLoop } from '@dzeio/object-util'
-import type { CardResume, Card as SDKCard, SupportedLanguages } from '@tcgdex/sdk'
-import { executeQuery, type Query } from '../../libs/QueryEngine/filter'
+import {objectLoop} from '@dzeio/object-util'
+import type {CardResume, Card as SDKCard, SupportedLanguages} from '@tcgdex/sdk'
+import {executeQuery, type Query} from '../../libs/QueryEngine/filter'
 import TCGSet from './Set'
 
 import de from '../../../generated/de/cards.json'
@@ -43,7 +43,7 @@ const cards = {
 	'zh-cn': zhcn,
 } as const
 
-type LocalCard = Omit<SDKCard, 'set'> & {set: () => TCGSet}
+type LocalCard = Omit<SDKCard, 'set'> & { set: () => TCGSet }
 
 interface variants {
 	normal?: boolean;
@@ -52,11 +52,18 @@ interface variants {
 	firstEdition?: boolean;
 }
 
+interface variant_detailed {
+	type: string;
+	size: string;
+	stamp?: string[] | undefined
+}
+
 export default class Card implements LocalCard {
 	illustrator?: string | undefined
 	rarity!: string
 	category!: string
 	variants?: variants | undefined
+	variants_detailed?: variant_detailed[] | undefined
 	dexId?: number[] | undefined
 	hp?: number | undefined
 	types?: string[] | undefined
@@ -68,7 +75,12 @@ export default class Card implements LocalCard {
 	suffix?: string | undefined
 	item?: { name: string; effect: string } | undefined
 	abilities?: { type: string; name: string; effect: string }[] | undefined
-	attacks?: { cost?: string[] | undefined; name: string; effect?: string | undefined; damage?: string | number | undefined }[] | undefined
+	attacks?: {
+		cost?: string[] | undefined;
+		name: string;
+		effect?: string | undefined;
+		damage?: string | number | undefined
+	}[] | undefined
 	weaknesses?: { type: string; value?: string | undefined }[] | undefined
 	resistances?: { type: string; value?: string | undefined }[] | undefined
 	retreat?: number | undefined
@@ -95,7 +107,7 @@ export default class Card implements LocalCard {
 	}
 
 	public set(): TCGSet {
-		return TCGSet.findOne(this.lang, { id: this.card.set.id }) as TCGSet
+		return TCGSet.findOne(this.lang, {id: this.card.set.id}) as TCGSet
 	}
 
 	public static getAll(lang: SupportedLanguages): Array<SDKCard> {

--- a/server/src/V2/Components/Card.ts
+++ b/server/src/V2/Components/Card.ts
@@ -54,6 +54,7 @@ interface variants {
 
 interface variant_detailed {
 	type: string;
+	subtype?: string | undefined;
 	size: string;
 	stamp?: string[] | undefined
 }


### PR DESCRIPTION
This is waiting for Variant_details to be merged.

Issue was in the compiler/utils/serieUtil

it was only looking for set names specifically with name.en this causes all sets to be returned for ones that didn't have a en translation. Refactored to take into account the lang that is being compiled 