### PR TITLE
fix: invalid card count in Kalos starter set

### DIFF
--- a/data/XY/Kalos Starter Set.ts
+++ b/data/XY/Kalos Starter Set.ts
@@ -17,7 +17,7 @@ const xy0: Set = {
 	tcgOnline: "KSS",
 
 	cardCount: {
-		official: 45
+		official: 39
 	},
 
 	releaseDate: "2013-11-08",


### PR DESCRIPTION
<!--
Thanks for your Pull Request, Please provide the related Issue using "Fix #0" or describe the change(s) you made.
The issue title must follow Conventional Commit conventionalcommits.org.
More informations at https://github.com/tcgdex/cards-database/blob/master/CONTRIBUTING.md
-->
