### PR TITLE
feature/add_missing_dex_id_for_astral_radiance

### DIFF
--- a/data/Sword & Shield/Astral Radiance/001.ts
+++ b/data/Sword & Shield/Astral Radiance/001.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Astral Radiance"
 
 const card: Card = {
+	dexId: [15],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Astral Radiance/002.ts
+++ b/data/Sword & Shield/Astral Radiance/002.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Astral Radiance"
 
 const card: Card = {
+	dexId: [100],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Astral Radiance/003.ts
+++ b/data/Sword & Shield/Astral Radiance/003.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Astral Radiance"
 
 const card: Card = {
+	dexId: [101],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Astral Radiance/016.ts
+++ b/data/Sword & Shield/Astral Radiance/016.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Astral Radiance"
 
 const card: Card = {
+	dexId: [549],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Astral Radiance/017.ts
+++ b/data/Sword & Shield/Astral Radiance/017.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Astral Radiance"
 
 const card: Card = {
+	dexId: [549],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Astral Radiance/018.ts
+++ b/data/Sword & Shield/Astral Radiance/018.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Astral Radiance"
 
 const card: Card = {
+	dexId: [549],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Astral Radiance/025.ts
+++ b/data/Sword & Shield/Astral Radiance/025.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Astral Radiance"
 
 const card: Card = {
+	dexId: [485],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Astral Radiance/026.ts
+++ b/data/Sword & Shield/Astral Radiance/026.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Astral Radiance"
 
 const card: Card = {
+	dexId: [485],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Astral Radiance/027.ts
+++ b/data/Sword & Shield/Astral Radiance/027.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Astral Radiance"
 
 const card: Card = {
+	dexId: [485],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Astral Radiance/030.ts
+++ b/data/Sword & Shield/Astral Radiance/030.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Astral Radiance"
 
 const card: Card = {
+	dexId: [121],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Astral Radiance/039.ts
+++ b/data/Sword & Shield/Astral Radiance/039.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Astral Radiance"
 
 const card: Card = {
+	dexId: [484],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Astral Radiance/040.ts
+++ b/data/Sword & Shield/Astral Radiance/040.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Astral Radiance"
 
 const card: Card = {
+	dexId: [484],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Astral Radiance/043.ts
+++ b/data/Sword & Shield/Astral Radiance/043.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Astral Radiance"
 
 const card: Card = {
+	dexId: [550],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Astral Radiance/044.ts
+++ b/data/Sword & Shield/Astral Radiance/044.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Astral Radiance"
 
 const card: Card = {
+	dexId: [902],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Astral Radiance/046.ts
+++ b/data/Sword & Shield/Astral Radiance/046.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Astral Radiance"
 
 const card: Card = {
+	dexId: [658],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Astral Radiance/048.ts
+++ b/data/Sword & Shield/Astral Radiance/048.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Astral Radiance"
 
 const card: Card = {
+	dexId: [713],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Astral Radiance/049.ts
+++ b/data/Sword & Shield/Astral Radiance/049.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Astral Radiance"
 
 const card: Card = {
+	dexId: [866],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Astral Radiance/050.ts
+++ b/data/Sword & Shield/Astral Radiance/050.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Astral Radiance"
 
 const card: Card = {
+	dexId: [405],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Astral Radiance/051.ts
+++ b/data/Sword & Shield/Astral Radiance/051.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Astral Radiance"
 
 const card: Card = {
+	dexId: [894],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Astral Radiance/052.ts
+++ b/data/Sword & Shield/Astral Radiance/052.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Astral Radiance"
 
 const card: Card = {
+	dexId: [157],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Astral Radiance/053.ts
+++ b/data/Sword & Shield/Astral Radiance/053.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Astral Radiance"
 
 const card: Card = {
+	dexId: [157],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Astral Radiance/054.ts
+++ b/data/Sword & Shield/Astral Radiance/054.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Astral Radiance"
 
 const card: Card = {
+	dexId: [157],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Astral Radiance/069.ts
+++ b/data/Sword & Shield/Astral Radiance/069.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Astral Radiance"
 
 const card: Card = {
+	dexId: [899],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Astral Radiance/070.ts
+++ b/data/Sword & Shield/Astral Radiance/070.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Astral Radiance"
 
 const card: Card = {
+	dexId: [58],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Astral Radiance/071.ts
+++ b/data/Sword & Shield/Astral Radiance/071.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Astral Radiance"
 
 const card: Card = {
+	dexId: [59],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Astral Radiance/072.ts
+++ b/data/Sword & Shield/Astral Radiance/072.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Astral Radiance"
 
 const card: Card = {
+	dexId: [68],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Astral Radiance/073.ts
+++ b/data/Sword & Shield/Astral Radiance/073.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Astral Radiance"
 
 const card: Card = {
+	dexId: [68],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Astral Radiance/078.ts
+++ b/data/Sword & Shield/Astral Radiance/078.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Astral Radiance"
 
 const card: Card = {
+	dexId: [448],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Astral Radiance/081.ts
+++ b/data/Sword & Shield/Astral Radiance/081.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Astral Radiance"
 
 const card: Card = {
+	dexId: [701],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Astral Radiance/082.ts
+++ b/data/Sword & Shield/Astral Radiance/082.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Astral Radiance"
 
 const card: Card = {
+	dexId: [724],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Astral Radiance/083.ts
+++ b/data/Sword & Shield/Astral Radiance/083.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Astral Radiance"
 
 const card: Card = {
+	dexId: [724],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Astral Radiance/084.ts
+++ b/data/Sword & Shield/Astral Radiance/084.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Astral Radiance"
 
 const card: Card = {
+	dexId: [724],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Astral Radiance/085.ts
+++ b/data/Sword & Shield/Astral Radiance/085.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Astral Radiance"
 
 const card: Card = {
+	dexId: [900],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Astral Radiance/086.ts
+++ b/data/Sword & Shield/Astral Radiance/086.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Astral Radiance"
 
 const card: Card = {
+	dexId: [900],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Astral Radiance/087.ts
+++ b/data/Sword & Shield/Astral Radiance/087.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Astral Radiance"
 
 const card: Card = {
+	dexId: [900],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Astral Radiance/088.ts
+++ b/data/Sword & Shield/Astral Radiance/088.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Astral Radiance"
 
 const card: Card = {
+	dexId: [211],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Astral Radiance/089.ts
+++ b/data/Sword & Shield/Astral Radiance/089.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Astral Radiance"
 
 const card: Card = {
+	dexId: [211],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Astral Radiance/090.ts
+++ b/data/Sword & Shield/Astral Radiance/090.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Astral Radiance"
 
 const card: Card = {
+	dexId: [904],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Astral Radiance/091.ts
+++ b/data/Sword & Shield/Astral Radiance/091.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Astral Radiance"
 
 const card: Card = {
+	dexId: [904],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Astral Radiance/092.ts
+++ b/data/Sword & Shield/Astral Radiance/092.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Astral Radiance"
 
 const card: Card = {
+	dexId: [215],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Astral Radiance/093.ts
+++ b/data/Sword & Shield/Astral Radiance/093.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Astral Radiance"
 
 const card: Card = {
+	dexId: [903],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Astral Radiance/094.ts
+++ b/data/Sword & Shield/Astral Radiance/094.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Astral Radiance"
 
 const card: Card = {
+	dexId: [903],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Astral Radiance/098.ts
+++ b/data/Sword & Shield/Astral Radiance/098.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Astral Radiance"
 
 const card: Card = {
+	dexId: [491],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Astral Radiance/099.ts
+++ b/data/Sword & Shield/Astral Radiance/099.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Astral Radiance"
 
 const card: Card = {
+	dexId: [491],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Astral Radiance/100.ts
+++ b/data/Sword & Shield/Astral Radiance/100.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Astral Radiance"
 
 const card: Card = {
+	dexId: [503],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Astral Radiance/101.ts
+++ b/data/Sword & Shield/Astral Radiance/101.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Astral Radiance"
 
 const card: Card = {
+	dexId: [503],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Astral Radiance/102.ts
+++ b/data/Sword & Shield/Astral Radiance/102.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Astral Radiance"
 
 const card: Card = {
+	dexId: [503],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Astral Radiance/113.ts
+++ b/data/Sword & Shield/Astral Radiance/113.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Astral Radiance"
 
 const card: Card = {
+	dexId: [483],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Astral Radiance/114.ts
+++ b/data/Sword & Shield/Astral Radiance/114.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Astral Radiance"
 
 const card: Card = {
+	dexId: [483],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Astral Radiance/117.ts
+++ b/data/Sword & Shield/Astral Radiance/117.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Astral Radiance"
 
 const card: Card = {
+	dexId: [445],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Astral Radiance/118.ts
+++ b/data/Sword & Shield/Astral Radiance/118.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Astral Radiance"
 
 const card: Card = {
+	dexId: [895],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Astral Radiance/124.ts
+++ b/data/Sword & Shield/Astral Radiance/124.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Astral Radiance"
 
 const card: Card = {
+	dexId: [901],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Astral Radiance/132.ts
+++ b/data/Sword & Shield/Astral Radiance/132.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Astral Radiance"
 
 const card: Card = {
+	dexId: [628],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Astral Radiance/133.ts
+++ b/data/Sword & Shield/Astral Radiance/133.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Astral Radiance"
 
 const card: Card = {
+	dexId: [765],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Astral Radiance/134.ts
+++ b/data/Sword & Shield/Astral Radiance/134.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Astral Radiance"
 
 const card: Card = {
+	dexId: [899],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Astral Radiance/160.ts
+++ b/data/Sword & Shield/Astral Radiance/160.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Astral Radiance"
 
 const card: Card = {
+	dexId: [15],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Astral Radiance/161.ts
+++ b/data/Sword & Shield/Astral Radiance/161.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Astral Radiance"
 
 const card: Card = {
+	dexId: [15],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Astral Radiance/162.ts
+++ b/data/Sword & Shield/Astral Radiance/162.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Astral Radiance"
 
 const card: Card = {
+	dexId: [549],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Astral Radiance/163.ts
+++ b/data/Sword & Shield/Astral Radiance/163.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Astral Radiance"
 
 const card: Card = {
+	dexId: [549],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Astral Radiance/164.ts
+++ b/data/Sword & Shield/Astral Radiance/164.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Astral Radiance"
 
 const card: Card = {
+	dexId: [640],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Astral Radiance/165.ts
+++ b/data/Sword & Shield/Astral Radiance/165.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Astral Radiance"
 
 const card: Card = {
+	dexId: [485],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Astral Radiance/166.ts
+++ b/data/Sword & Shield/Astral Radiance/166.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Astral Radiance"
 
 const card: Card = {
+	dexId: [121],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Astral Radiance/167.ts
+++ b/data/Sword & Shield/Astral Radiance/167.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Astral Radiance"
 
 const card: Card = {
+	dexId: [484],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Astral Radiance/168.ts
+++ b/data/Sword & Shield/Astral Radiance/168.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Astral Radiance"
 
 const card: Card = {
+	dexId: [405],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Astral Radiance/169.ts
+++ b/data/Sword & Shield/Astral Radiance/169.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Astral Radiance"
 
 const card: Card = {
+	dexId: [157],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Astral Radiance/170.ts
+++ b/data/Sword & Shield/Astral Radiance/170.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Astral Radiance"
 
 const card: Card = {
+	dexId: [385],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Astral Radiance/171.ts
+++ b/data/Sword & Shield/Astral Radiance/171.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Astral Radiance"
 
 const card: Card = {
+	dexId: [68],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Astral Radiance/172.ts
+++ b/data/Sword & Shield/Astral Radiance/172.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Astral Radiance"
 
 const card: Card = {
+	dexId: [68],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Astral Radiance/173.ts
+++ b/data/Sword & Shield/Astral Radiance/173.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Astral Radiance"
 
 const card: Card = {
+	dexId: [724],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Astral Radiance/174.ts
+++ b/data/Sword & Shield/Astral Radiance/174.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Astral Radiance"
 
 const card: Card = {
+	dexId: [903],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Astral Radiance/175.ts
+++ b/data/Sword & Shield/Astral Radiance/175.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Astral Radiance"
 
 const card: Card = {
+	dexId: [903],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Astral Radiance/176.ts
+++ b/data/Sword & Shield/Astral Radiance/176.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Astral Radiance"
 
 const card: Card = {
+	dexId: [503],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Astral Radiance/177.ts
+++ b/data/Sword & Shield/Astral Radiance/177.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Astral Radiance"
 
 const card: Card = {
+	dexId: [483],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Astral Radiance/178.ts
+++ b/data/Sword & Shield/Astral Radiance/178.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Astral Radiance"
 
 const card: Card = {
+	dexId: [445],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Astral Radiance/179.ts
+++ b/data/Sword & Shield/Astral Radiance/179.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Astral Radiance"
 
 const card: Card = {
+	dexId: [765],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Astral Radiance/180.ts
+++ b/data/Sword & Shield/Astral Radiance/180.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Astral Radiance"
 
 const card: Card = {
+	dexId: [899],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Astral Radiance/190.ts
+++ b/data/Sword & Shield/Astral Radiance/190.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Astral Radiance"
 
 const card: Card = {
+	dexId: [549],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Astral Radiance/191.ts
+++ b/data/Sword & Shield/Astral Radiance/191.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Astral Radiance"
 
 const card: Card = {
+	dexId: [485],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Astral Radiance/192.ts
+++ b/data/Sword & Shield/Astral Radiance/192.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Astral Radiance"
 
 const card: Card = {
+	dexId: [484],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Astral Radiance/193.ts
+++ b/data/Sword & Shield/Astral Radiance/193.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Astral Radiance"
 
 const card: Card = {
+	dexId: [157],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Astral Radiance/194.ts
+++ b/data/Sword & Shield/Astral Radiance/194.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Astral Radiance"
 
 const card: Card = {
+	dexId: [68],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Astral Radiance/195.ts
+++ b/data/Sword & Shield/Astral Radiance/195.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Astral Radiance"
 
 const card: Card = {
+	dexId: [724],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Astral Radiance/196.ts
+++ b/data/Sword & Shield/Astral Radiance/196.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Astral Radiance"
 
 const card: Card = {
+	dexId: [900],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Astral Radiance/197.ts
+++ b/data/Sword & Shield/Astral Radiance/197.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Astral Radiance"
 
 const card: Card = {
+	dexId: [503],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Astral Radiance/198.ts
+++ b/data/Sword & Shield/Astral Radiance/198.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Astral Radiance"
 
 const card: Card = {
+	dexId: [483],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Astral Radiance/208.ts
+++ b/data/Sword & Shield/Astral Radiance/208.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Astral Radiance"
 
 const card: Card = {
+	dexId: [484],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Astral Radiance/209.ts
+++ b/data/Sword & Shield/Astral Radiance/209.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Astral Radiance"
 
 const card: Card = {
+	dexId: [503],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Astral Radiance/210.ts
+++ b/data/Sword & Shield/Astral Radiance/210.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Astral Radiance"
 
 const card: Card = {
+	dexId: [483],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Astral Radiance/TG06.ts
+++ b/data/Sword & Shield/Astral Radiance/TG06.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Astral Radiance"
 
 const card: Card = {
+	dexId: [899],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Astral Radiance/TG07.ts
+++ b/data/Sword & Shield/Astral Radiance/TG07.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Astral Radiance"
 
 const card: Card = {
+	dexId: [870],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Astral Radiance/TG08.ts
+++ b/data/Sword & Shield/Astral Radiance/TG08.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Astral Radiance"
 
 const card: Card = {
+	dexId: [900],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Astral Radiance/TG13.ts
+++ b/data/Sword & Shield/Astral Radiance/TG13.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Astral Radiance"
 
 const card: Card = {
+	dexId: [121],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Astral Radiance/TG14.ts
+++ b/data/Sword & Shield/Astral Radiance/TG14.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Astral Radiance"
 
 const card: Card = {
+	dexId: [898],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Astral Radiance/TG17.ts
+++ b/data/Sword & Shield/Astral Radiance/TG17.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Astral Radiance"
 
 const card: Card = {
+	dexId: [898],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Astral Radiance/TG23.ts
+++ b/data/Sword & Shield/Astral Radiance/TG23.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Astral Radiance"
 
 const card: Card = {
+	dexId: [445],
 	set: Set,
 
 	name: {


### PR DESCRIPTION
This PR manually adds the missing dexId fields to cards from the Astral Radiance set.

**Details:**
- Each affected card was updated with its correct Pokédex ID (dexId)