### PR TITLE
feature/add_missing_dex_id_for_chilling_reign

### DIFF
--- a/data/Sword & Shield/Chilling Reign/100.ts
+++ b/data/Sword & Shield/Chilling Reign/100.ts
@@ -2,6 +2,7 @@ import { Card } from '../../../interfaces'
 import Set from '../Chilling Reign'
 
 const card: Card = {
+	dexId: [199],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Chilling Reign/104.ts
+++ b/data/Sword & Shield/Chilling Reign/104.ts
@@ -2,6 +2,7 @@ import { Card } from '../../../interfaces'
 import Set from '../Chilling Reign'
 
 const card: Card = {
+	dexId: [510],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Chilling Reign/108.ts
+++ b/data/Sword & Shield/Chilling Reign/108.ts
@@ -2,6 +2,7 @@ import { Card } from '../../../interfaces'
 import Set from '../Chilling Reign'
 
 const card: Card = {
+	dexId: [892],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Chilling Reign/112.ts
+++ b/data/Sword & Shield/Chilling Reign/112.ts
@@ -2,6 +2,7 @@ import { Card } from '../../../interfaces'
 import Set from '../Chilling Reign'
 
 const card: Card = {
+	dexId: [376],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Chilling Reign/113.ts
+++ b/data/Sword & Shield/Chilling Reign/113.ts
@@ -2,6 +2,7 @@ import { Card } from '../../../interfaces'
 import Set from '../Chilling Reign'
 
 const card: Card = {
+	dexId: [376],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Chilling Reign/119.ts
+++ b/data/Sword & Shield/Chilling Reign/119.ts
@@ -2,6 +2,7 @@ import { Card } from '../../../interfaces'
 import Set from '../Chilling Reign'
 
 const card: Card = {
+	dexId: [242],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Chilling Reign/124.ts
+++ b/data/Sword & Shield/Chilling Reign/124.ts
@@ -2,6 +2,7 @@ import { Card } from '../../../interfaces'
 import Set from '../Chilling Reign'
 
 const card: Card = {
+	dexId: [641],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Chilling Reign/125.ts
+++ b/data/Sword & Shield/Chilling Reign/125.ts
@@ -2,6 +2,7 @@ import { Card } from '../../../interfaces'
 import Set from '../Chilling Reign'
 
 const card: Card = {
+	dexId: [641],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Chilling Reign/127.ts
+++ b/data/Sword & Shield/Chilling Reign/127.ts
@@ -2,6 +2,7 @@ import { Card } from '../../../interfaces'
 import Set from '../Chilling Reign'
 
 const card: Card = {
+	dexId: [819],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Chilling Reign/128.ts
+++ b/data/Sword & Shield/Chilling Reign/128.ts
@@ -2,6 +2,7 @@ import { Card } from '../../../interfaces'
 import Set from '../Chilling Reign'
 
 const card: Card = {
+	dexId: [820],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Chilling Reign/161.ts
+++ b/data/Sword & Shield/Chilling Reign/161.ts
@@ -2,6 +2,7 @@ import { Card } from '../../../interfaces'
 import Set from '../Chilling Reign'
 
 const card: Card = {
+	dexId: [257],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Chilling Reign/162.ts
+++ b/data/Sword & Shield/Chilling Reign/162.ts
@@ -2,6 +2,7 @@ import { Card } from '../../../interfaces'
 import Set from '../Chilling Reign'
 
 const card: Card = {
+	dexId: [721],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Chilling Reign/163.ts
+++ b/data/Sword & Shield/Chilling Reign/163.ts
@@ -2,6 +2,7 @@ import { Card } from '../../../interfaces'
 import Set from '../Chilling Reign'
 
 const card: Card = {
+	dexId: [898],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Chilling Reign/164.ts
+++ b/data/Sword & Shield/Chilling Reign/164.ts
@@ -2,6 +2,7 @@ import { Card } from '../../../interfaces'
 import Set from '../Chilling Reign'
 
 const card: Card = {
+	dexId: [898],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Chilling Reign/171.ts
+++ b/data/Sword & Shield/Chilling Reign/171.ts
@@ -2,6 +2,7 @@ import { Card } from '../../../interfaces'
 import Set from '../Chilling Reign'
 
 const card: Card = {
+	dexId: [898],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Chilling Reign/172.ts
+++ b/data/Sword & Shield/Chilling Reign/172.ts
@@ -2,6 +2,7 @@ import { Card } from '../../../interfaces'
 import Set from '../Chilling Reign'
 
 const card: Card = {
+	dexId: [898],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Chilling Reign/175.ts
+++ b/data/Sword & Shield/Chilling Reign/175.ts
@@ -2,6 +2,7 @@ import { Card } from '../../../interfaces'
 import Set from '../Chilling Reign'
 
 const card: Card = {
+	dexId: [844],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Chilling Reign/178.ts
+++ b/data/Sword & Shield/Chilling Reign/178.ts
@@ -2,6 +2,7 @@ import { Card } from '../../../interfaces'
 import Set from '../Chilling Reign'
 
 const card: Card = {
+	dexId: [199],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Chilling Reign/179.ts
+++ b/data/Sword & Shield/Chilling Reign/179.ts
@@ -2,6 +2,7 @@ import { Card } from '../../../interfaces'
 import Set from '../Chilling Reign'
 
 const card: Card = {
+	dexId: [199],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Chilling Reign/180.ts
+++ b/data/Sword & Shield/Chilling Reign/180.ts
@@ -2,6 +2,7 @@ import { Card } from '../../../interfaces'
 import Set from '../Chilling Reign'
 
 const card: Card = {
+	dexId: [510],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Chilling Reign/181.ts
+++ b/data/Sword & Shield/Chilling Reign/181.ts
@@ -2,6 +2,7 @@ import { Card } from '../../../interfaces'
 import Set from '../Chilling Reign'
 
 const card: Card = {
+	dexId: [376],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Chilling Reign/182.ts
+++ b/data/Sword & Shield/Chilling Reign/182.ts
@@ -2,6 +2,7 @@ import { Card } from '../../../interfaces'
 import Set from '../Chilling Reign'
 
 const card: Card = {
+	dexId: [242],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Chilling Reign/183.ts
+++ b/data/Sword & Shield/Chilling Reign/183.ts
@@ -2,6 +2,7 @@ import { Card } from '../../../interfaces'
 import Set from '../Chilling Reign'
 
 const card: Card = {
+	dexId: [242],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Chilling Reign/184.ts
+++ b/data/Sword & Shield/Chilling Reign/184.ts
@@ -2,6 +2,7 @@ import { Card } from '../../../interfaces'
 import Set from '../Chilling Reign'
 
 const card: Card = {
+	dexId: [641],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Chilling Reign/185.ts
+++ b/data/Sword & Shield/Chilling Reign/185.ts
@@ -2,6 +2,7 @@ import { Card } from '../../../interfaces'
 import Set from '../Chilling Reign'
 
 const card: Card = {
+	dexId: [641],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Chilling Reign/19.ts
+++ b/data/Sword & Shield/Chilling Reign/19.ts
@@ -2,6 +2,7 @@ import { Card } from '../../../interfaces'
 import Set from '../Chilling Reign'
 
 const card: Card = {
+	dexId: [893],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Chilling Reign/199.ts
+++ b/data/Sword & Shield/Chilling Reign/199.ts
@@ -2,6 +2,7 @@ import { Card } from '../../../interfaces'
 import Set from '../Chilling Reign'
 
 const card: Card = {
+	dexId: [251],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Chilling Reign/20.ts
+++ b/data/Sword & Shield/Chilling Reign/20.ts
@@ -2,6 +2,7 @@ import { Card } from '../../../interfaces'
 import Set from '../Chilling Reign'
 
 const card: Card = {
+	dexId: [257],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Chilling Reign/200.ts
+++ b/data/Sword & Shield/Chilling Reign/200.ts
@@ -2,6 +2,7 @@ import { Card } from '../../../interfaces'
 import Set from '../Chilling Reign'
 
 const card: Card = {
+	dexId: [257],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Chilling Reign/201.ts
+++ b/data/Sword & Shield/Chilling Reign/201.ts
@@ -2,6 +2,7 @@ import { Card } from '../../../interfaces'
 import Set from '../Chilling Reign'
 
 const card: Card = {
+	dexId: [257],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Chilling Reign/206.ts
+++ b/data/Sword & Shield/Chilling Reign/206.ts
@@ -2,6 +2,7 @@ import { Card } from '../../../interfaces'
 import Set from '../Chilling Reign'
 
 const card: Card = {
+	dexId: [844],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Chilling Reign/207.ts
+++ b/data/Sword & Shield/Chilling Reign/207.ts
@@ -2,6 +2,7 @@ import { Card } from '../../../interfaces'
 import Set from '../Chilling Reign'
 
 const card: Card = {
+	dexId: [199],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Chilling Reign/208.ts
+++ b/data/Sword & Shield/Chilling Reign/208.ts
@@ -2,6 +2,7 @@ import { Card } from '../../../interfaces'
 import Set from '../Chilling Reign'
 
 const card: Card = {
+	dexId: [376],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Chilling Reign/209.ts
+++ b/data/Sword & Shield/Chilling Reign/209.ts
@@ -2,6 +2,7 @@ import { Card } from '../../../interfaces'
 import Set from '../Chilling Reign'
 
 const card: Card = {
+	dexId: [641],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Chilling Reign/21.ts
+++ b/data/Sword & Shield/Chilling Reign/21.ts
@@ -2,6 +2,7 @@ import { Card } from '../../../interfaces'
 import Set from '../Chilling Reign'
 
 const card: Card = {
+	dexId: [257],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Chilling Reign/25.ts
+++ b/data/Sword & Shield/Chilling Reign/25.ts
@@ -2,6 +2,7 @@ import { Card } from '../../../interfaces'
 import Set from '../Chilling Reign'
 
 const card: Card = {
+	dexId: [721],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Chilling Reign/44.ts
+++ b/data/Sword & Shield/Chilling Reign/44.ts
@@ -2,6 +2,7 @@ import { Card } from '../../../interfaces'
 import Set from '../Chilling Reign'
 
 const card: Card = {
+	dexId: [892],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Chilling Reign/45.ts
+++ b/data/Sword & Shield/Chilling Reign/45.ts
@@ -2,6 +2,7 @@ import { Card } from '../../../interfaces'
 import Set from '../Chilling Reign'
 
 const card: Card = {
+	dexId: [898],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Chilling Reign/72.ts
+++ b/data/Sword & Shield/Chilling Reign/72.ts
@@ -2,6 +2,7 @@ import { Card } from '../../../interfaces'
 import Set from '../Chilling Reign'
 
 const card: Card = {
+	dexId: [857],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Chilling Reign/73.ts
+++ b/data/Sword & Shield/Chilling Reign/73.ts
@@ -2,6 +2,7 @@ import { Card } from '../../../interfaces'
 import Set from '../Chilling Reign'
 
 const card: Card = {
+	dexId: [858],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Chilling Reign/74.ts
+++ b/data/Sword & Shield/Chilling Reign/74.ts
@@ -2,6 +2,7 @@ import { Card } from '../../../interfaces'
 import Set from '../Chilling Reign'
 
 const card: Card = {
+	dexId: [898],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Chilling Reign/78.ts
+++ b/data/Sword & Shield/Chilling Reign/78.ts
@@ -2,6 +2,7 @@ import { Card } from '../../../interfaces'
 import Set from '../Chilling Reign'
 
 const card: Card = {
+	dexId: [83],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Chilling Reign/79.ts
+++ b/data/Sword & Shield/Chilling Reign/79.ts
@@ -2,6 +2,7 @@ import { Card } from '../../../interfaces'
 import Set from '../Chilling Reign'
 
 const card: Card = {
+	dexId: [599],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Chilling Reign/8.ts
+++ b/data/Sword & Shield/Chilling Reign/8.ts
@@ -2,6 +2,7 @@ import { Card } from '../../../interfaces'
 import Set from '../Chilling Reign'
 
 const card: Card = {
+	dexId: [251],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Chilling Reign/82.ts
+++ b/data/Sword & Shield/Chilling Reign/82.ts
@@ -2,6 +2,7 @@ import { Card } from '../../../interfaces'
 import Set from '../Chilling Reign'
 
 const card: Card = {
+	dexId: [562],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Chilling Reign/83.ts
+++ b/data/Sword & Shield/Chilling Reign/83.ts
@@ -2,6 +2,7 @@ import { Card } from '../../../interfaces'
 import Set from '../Chilling Reign'
 
 const card: Card = {
+	dexId: [867],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Chilling Reign/89.ts
+++ b/data/Sword & Shield/Chilling Reign/89.ts
@@ -2,6 +2,7 @@ import { Card } from '../../../interfaces'
 import Set from '../Chilling Reign'
 
 const card: Card = {
+	dexId: [844],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Chilling Reign/90.ts
+++ b/data/Sword & Shield/Chilling Reign/90.ts
@@ -2,6 +2,7 @@ import { Card } from '../../../interfaces'
 import Set from '../Chilling Reign'
 
 const card: Card = {
+	dexId: [844],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Chilling Reign/93.ts
+++ b/data/Sword & Shield/Chilling Reign/93.ts
@@ -2,6 +2,7 @@ import { Card } from '../../../interfaces'
 import Set from '../Chilling Reign'
 
 const card: Card = {
+	dexId: [891],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Chilling Reign/96.ts
+++ b/data/Sword & Shield/Chilling Reign/96.ts
@@ -2,6 +2,7 @@ import { Card } from '../../../interfaces'
 import Set from '../Chilling Reign'
 
 const card: Card = {
+	dexId: [109],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Chilling Reign/98.ts
+++ b/data/Sword & Shield/Chilling Reign/98.ts
@@ -2,6 +2,7 @@ import { Card } from '../../../interfaces'
 import Set from '../Chilling Reign'
 
 const card: Card = {
+	dexId: [199],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Chilling Reign/99.ts
+++ b/data/Sword & Shield/Chilling Reign/99.ts
@@ -2,6 +2,7 @@ import { Card } from '../../../interfaces'
 import Set from '../Chilling Reign'
 
 const card: Card = {
+	dexId: [199],
 	set: Set,
 
 	name: {


### PR DESCRIPTION
This PR manually adds the missing dexId fields to cards from the Chilling Reign set.

Details:

Each affected card was updated with its correct Pokédex ID (dexId)