### PR TITLE
feature/add_missing_dex_id_for_darkness_ablaze

### DIFF
--- a/data/Sword & Shield/Darkness Ablaze/1.ts
+++ b/data/Sword & Shield/Darkness Ablaze/1.ts
@@ -14,6 +14,7 @@ const card: Card = {
 	illustrator: "Saki Hayashiro",
 	rarity: "Holo Rare V",
 	category: "Pokemon",
+	dexId: [12],
 	set: Set,
 	hp: 190,
 

--- a/data/Sword & Shield/Darkness Ablaze/115.ts
+++ b/data/Sword & Shield/Darkness Ablaze/115.ts
@@ -14,6 +14,7 @@ const card: Card = {
 	illustrator: "5ban Graphics",
 	rarity: "Holo Rare VMAX",
 	category: "Pokemon",
+	dexId: [861],
 	set: Set,
 	hp: 330,
 

--- a/data/Sword & Shield/Darkness Ablaze/118.ts
+++ b/data/Sword & Shield/Darkness Ablaze/118.ts
@@ -14,6 +14,7 @@ const card: Card = {
 	illustrator: "Shin Nagasawa",
 	rarity: "Holo Rare V",
 	category: "Pokemon",
+	dexId: [212],
 	set: Set,
 	hp: 210,
 

--- a/data/Sword & Shield/Darkness Ablaze/119.ts
+++ b/data/Sword & Shield/Darkness Ablaze/119.ts
@@ -14,6 +14,7 @@ const card: Card = {
 	illustrator: "5ban Graphics",
 	rarity: "Holo Rare VMAX",
 	category: "Pokemon",
+	dexId: [212],
 	set: Set,
 	hp: 320,
 

--- a/data/Sword & Shield/Darkness Ablaze/128.ts
+++ b/data/Sword & Shield/Darkness Ablaze/128.ts
@@ -14,6 +14,7 @@ const card: Card = {
 	illustrator: "PLANETA Tsuji",
 	rarity: "Holo Rare V",
 	category: "Pokemon",
+	dexId: [618],
 	set: Set,
 	hp: 200,
 

--- a/data/Sword & Shield/Darkness Ablaze/130.ts
+++ b/data/Sword & Shield/Darkness Ablaze/130.ts
@@ -14,6 +14,7 @@ const card: Card = {
 	illustrator: "NC Empire",
 	rarity: "Rare",
 	category: "Pokemon",
+	dexId: [809],
 	set: Set,
 	hp: 150,
 

--- a/data/Sword & Shield/Darkness Ablaze/143.ts
+++ b/data/Sword & Shield/Darkness Ablaze/143.ts
@@ -14,6 +14,7 @@ const card: Card = {
 	illustrator: "Saki Hayashiro",
 	rarity: "Holo Rare V",
 	category: "Pokemon",
+	dexId: [373],
 	set: Set,
 	hp: 220,
 

--- a/data/Sword & Shield/Darkness Ablaze/144.ts
+++ b/data/Sword & Shield/Darkness Ablaze/144.ts
@@ -14,6 +14,7 @@ const card: Card = {
 	illustrator: "5ban Graphics",
 	rarity: "Holo Rare VMAX",
 	category: "Pokemon",
+	dexId: [373],
 	set: Set,
 	hp: 320,
 

--- a/data/Sword & Shield/Darkness Ablaze/152.ts
+++ b/data/Sword & Shield/Darkness Ablaze/152.ts
@@ -14,6 +14,7 @@ const card: Card = {
 	illustrator: "Akira Komayama",
 	rarity: "Common",
 	category: "Pokemon",
+	dexId: [819],
 	set: Set,
 	hp: 70,
 

--- a/data/Sword & Shield/Darkness Ablaze/153.ts
+++ b/data/Sword & Shield/Darkness Ablaze/153.ts
@@ -14,6 +14,7 @@ const card: Card = {
 	illustrator: "Kouki Saitou",
 	rarity: "Rare",
 	category: "Pokemon",
+	dexId: [820],
 	set: Set,
 	hp: 120,
 

--- a/data/Sword & Shield/Darkness Ablaze/177.ts
+++ b/data/Sword & Shield/Darkness Ablaze/177.ts
@@ -14,6 +14,7 @@ const card: Card = {
 	illustrator: "Saki Hayashiro",
 	rarity: "Ultra Rare",
 	category: "Pokemon",
+	dexId: [12],
 	set: Set,
 	hp: 190,
 

--- a/data/Sword & Shield/Darkness Ablaze/178.ts
+++ b/data/Sword & Shield/Darkness Ablaze/178.ts
@@ -14,6 +14,7 @@ const card: Card = {
 	illustrator: "Ayaka Yoshida",
 	rarity: "Ultra Rare",
 	category: "Pokemon",
+	dexId: [229],
 	set: Set,
 	hp: 210,
 

--- a/data/Sword & Shield/Darkness Ablaze/179.ts
+++ b/data/Sword & Shield/Darkness Ablaze/179.ts
@@ -14,6 +14,7 @@ const card: Card = {
 	illustrator: "5ban Graphics",
 	rarity: "Ultra Rare",
 	category: "Pokemon",
+	dexId: [851],
 	set: Set,
 	hp: 210,
 

--- a/data/Sword & Shield/Darkness Ablaze/180.ts
+++ b/data/Sword & Shield/Darkness Ablaze/180.ts
@@ -14,6 +14,7 @@ const card: Card = {
 	illustrator: "Ayaka Yoshida",
 	rarity: "Ultra Rare",
 	category: "Pokemon",
+	dexId: [738],
 	set: Set,
 	hp: 210,
 

--- a/data/Sword & Shield/Darkness Ablaze/181.ts
+++ b/data/Sword & Shield/Darkness Ablaze/181.ts
@@ -14,6 +14,7 @@ const card: Card = {
 	illustrator: "Eske Yoshinob",
 	rarity: "Ultra Rare",
 	category: "Pokemon",
+	dexId: [464],
 	set: Set,
 	hp: 230,
 

--- a/data/Sword & Shield/Darkness Ablaze/183.ts
+++ b/data/Sword & Shield/Darkness Ablaze/183.ts
@@ -14,6 +14,7 @@ const card: Card = {
 	illustrator: "Satoshi Shirai",
 	rarity: "Ultra Rare",
 	category: "Pokemon",
+	dexId: [212],
 	set: Set,
 	hp: 210,
 

--- a/data/Sword & Shield/Darkness Ablaze/184.ts
+++ b/data/Sword & Shield/Darkness Ablaze/184.ts
@@ -14,6 +14,7 @@ const card: Card = {
 	illustrator: "PLANETA Tsuji",
 	rarity: "Ultra Rare",
 	category: "Pokemon",
+	dexId: [618],
 	set: Set,
 	hp: 200,
 

--- a/data/Sword & Shield/Darkness Ablaze/185.ts
+++ b/data/Sword & Shield/Darkness Ablaze/185.ts
@@ -14,6 +14,7 @@ const card: Card = {
 	illustrator: "Saki Hayashiro",
 	rarity: "Ultra Rare",
 	category: "Pokemon",
+	dexId: [373],
 	set: Set,
 	hp: 220,
 

--- a/data/Sword & Shield/Darkness Ablaze/190.ts
+++ b/data/Sword & Shield/Darkness Ablaze/190.ts
@@ -14,6 +14,7 @@ const card: Card = {
 	illustrator: "aky CG Works",
 	rarity: "Secret Rare",
 	category: "Pokemon",
+	dexId: [12],
 	set: Set,
 	hp: 300,
 

--- a/data/Sword & Shield/Darkness Ablaze/191.ts
+++ b/data/Sword & Shield/Darkness Ablaze/191.ts
@@ -14,6 +14,7 @@ const card: Card = {
 	illustrator: "5ban Graphics",
 	rarity: "Secret Rare",
 	category: "Pokemon",
+	dexId: [851],
 	set: Set,
 	hp: 320,
 

--- a/data/Sword & Shield/Darkness Ablaze/193.ts
+++ b/data/Sword & Shield/Darkness Ablaze/193.ts
@@ -14,6 +14,7 @@ const card: Card = {
 	illustrator: "5ban Graphics",
 	rarity: "Secret Rare",
 	category: "Pokemon",
+	dexId: [212],
 	set: Set,
 	hp: 320,
 

--- a/data/Sword & Shield/Darkness Ablaze/194.ts
+++ b/data/Sword & Shield/Darkness Ablaze/194.ts
@@ -14,6 +14,7 @@ const card: Card = {
 	illustrator: "5ban Graphics",
 	rarity: "Secret Rare",
 	category: "Pokemon",
+	dexId: [373],
 	set: Set,
 	hp: 320,
 

--- a/data/Sword & Shield/Darkness Ablaze/2.ts
+++ b/data/Sword & Shield/Darkness Ablaze/2.ts
@@ -14,6 +14,7 @@ const card: Card = {
 	illustrator: "aky CG Works",
 	rarity: "Holo Rare VMAX",
 	category: "Pokemon",
+	dexId: [12],
 	set: Set,
 	hp: 300,
 

--- a/data/Sword & Shield/Darkness Ablaze/20.ts
+++ b/data/Sword & Shield/Darkness Ablaze/20.ts
@@ -14,6 +14,7 @@ const card: Card = {
 	illustrator: "aky CG Works",
 	rarity: "Holo Rare VMAX",
 	category: "Pokemon",
+	dexId: [6],
 	set: Set,
 	hp: 330,
 

--- a/data/Sword & Shield/Darkness Ablaze/21.ts
+++ b/data/Sword & Shield/Darkness Ablaze/21.ts
@@ -14,6 +14,7 @@ const card: Card = {
 	illustrator: "Ayaka Yoshida",
 	rarity: "Holo Rare V",
 	category: "Pokemon",
+	dexId: [229],
 	set: Set,
 	hp: 210,
 

--- a/data/Sword & Shield/Darkness Ablaze/28.ts
+++ b/data/Sword & Shield/Darkness Ablaze/28.ts
@@ -14,6 +14,7 @@ const card: Card = {
 	illustrator: "Misa Tsutsui",
 	rarity: "Rare",
 	category: "Pokemon",
+	dexId: [555],
 	set: Set,
 	hp: 140,
 

--- a/data/Sword & Shield/Darkness Ablaze/33.ts
+++ b/data/Sword & Shield/Darkness Ablaze/33.ts
@@ -14,6 +14,7 @@ const card: Card = {
 	illustrator: "5ban Graphics",
 	rarity: "Holo Rare V",
 	category: "Pokemon",
+	dexId: [851],
 	set: Set,
 	hp: 210,
 

--- a/data/Sword & Shield/Darkness Ablaze/34.ts
+++ b/data/Sword & Shield/Darkness Ablaze/34.ts
@@ -14,6 +14,7 @@ const card: Card = {
 	illustrator: "5ban Graphics",
 	rarity: "Holo Rare VMAX",
 	category: "Pokemon",
+	dexId: [851],
 	set: Set,
 	hp: 320,
 

--- a/data/Sword & Shield/Darkness Ablaze/35.ts
+++ b/data/Sword & Shield/Darkness Ablaze/35.ts
@@ -14,6 +14,7 @@ const card: Card = {
 	illustrator: "Misa Tsutsui",
 	rarity: "Common",
 	category: "Pokemon",
+	dexId: [122],
 	set: Set,
 	hp: 80,
 

--- a/data/Sword & Shield/Darkness Ablaze/36.ts
+++ b/data/Sword & Shield/Darkness Ablaze/36.ts
@@ -14,6 +14,7 @@ const card: Card = {
 	illustrator: "Naoki Saito",
 	rarity: "Rare",
 	category: "Pokemon",
+	dexId: [866],
 	set: Set,
 	hp: 120,
 

--- a/data/Sword & Shield/Darkness Ablaze/43.ts
+++ b/data/Sword & Shield/Darkness Ablaze/43.ts
@@ -14,6 +14,7 @@ const card: Card = {
 	illustrator: "Shin Nagasawa",
 	rarity: "Common",
 	category: "Pokemon",
+	dexId: [554],
 	set: Set,
 	hp: 70,
 

--- a/data/Sword & Shield/Darkness Ablaze/44.ts
+++ b/data/Sword & Shield/Darkness Ablaze/44.ts
@@ -14,6 +14,7 @@ const card: Card = {
 	illustrator: "Masakazu Fukuda",
 	rarity: "Rare",
 	category: "Pokemon",
+	dexId: [555],
 	set: Set,
 	hp: 140,
 

--- a/data/Sword & Shield/Darkness Ablaze/53.ts
+++ b/data/Sword & Shield/Darkness Ablaze/53.ts
@@ -14,6 +14,7 @@ const card: Card = {
 	illustrator: "Hitoshi Ariga",
 	rarity: "Holo Rare",
 	category: "Pokemon",
+	dexId: [882],
 	set: Set,
 	hp: 150,
 

--- a/data/Sword & Shield/Darkness Ablaze/54.ts
+++ b/data/Sword & Shield/Darkness Ablaze/54.ts
@@ -14,6 +14,7 @@ const card: Card = {
 	illustrator: "Shin Nagasawa",
 	rarity: "Rare",
 	category: "Pokemon",
+	dexId: [883],
 	set: Set,
 	hp: 150,
 

--- a/data/Sword & Shield/Darkness Ablaze/60.ts
+++ b/data/Sword & Shield/Darkness Ablaze/60.ts
@@ -14,6 +14,7 @@ const card: Card = {
 	illustrator: "Ayaka Yoshida",
 	rarity: "Holo Rare V",
 	category: "Pokemon",
+	dexId: [738],
 	set: Set,
 	hp: 210,
 

--- a/data/Sword & Shield/Darkness Ablaze/62.ts
+++ b/data/Sword & Shield/Darkness Ablaze/62.ts
@@ -14,6 +14,7 @@ const card: Card = {
 	illustrator: "Akira Komayama",
 	rarity: "Common",
 	category: "Pokemon",
+	dexId: [848],
 	set: Set,
 	hp: 70,
 

--- a/data/Sword & Shield/Darkness Ablaze/63.ts
+++ b/data/Sword & Shield/Darkness Ablaze/63.ts
@@ -14,6 +14,7 @@ const card: Card = {
 	illustrator: "Shin Nagasawa",
 	rarity: "Holo Rare",
 	category: "Pokemon",
+	dexId: [849],
 	set: Set,
 	hp: 120,
 

--- a/data/Sword & Shield/Darkness Ablaze/65.ts
+++ b/data/Sword & Shield/Darkness Ablaze/65.ts
@@ -14,6 +14,7 @@ const card: Card = {
 	illustrator: "Misa Tsutsui",
 	rarity: "Rare",
 	category: "Pokemon",
+	dexId: [880],
 	set: Set,
 	hp: 160,
 

--- a/data/Sword & Shield/Darkness Ablaze/69.ts
+++ b/data/Sword & Shield/Darkness Ablaze/69.ts
@@ -14,6 +14,7 @@ const card: Card = {
 	illustrator: "PLANETA Mochizuki",
 	rarity: "Holo Rare V",
 	category: "Pokemon",
+	dexId: [151],
 	set: Set,
 	hp: 180,
 

--- a/data/Sword & Shield/Darkness Ablaze/95.ts
+++ b/data/Sword & Shield/Darkness Ablaze/95.ts
@@ -14,6 +14,7 @@ const card: Card = {
 	illustrator: "Eske Yoshinob",
 	rarity: "Holo Rare V",
 	category: "Pokemon",
+	dexId: [464],
 	set: Set,
 	hp: 230,
 

--- a/data/Sword & Shield/Darkness Ablaze/98.ts
+++ b/data/Sword & Shield/Darkness Ablaze/98.ts
@@ -14,6 +14,7 @@ const card: Card = {
 	illustrator: "Ryota Murayama",
 	rarity: "Rare",
 	category: "Pokemon",
+	dexId: [599],
 	set: Set,
 	hp: 130,
 

--- a/data/Sword & Shield/Darkness Ablaze/99.ts
+++ b/data/Sword & Shield/Darkness Ablaze/99.ts
@@ -14,6 +14,7 @@ const card: Card = {
 	illustrator: "5ban Graphics",
 	rarity: "Holo Rare V",
 	category: "Pokemon",
+	dexId: [80],
 	set: Set,
 	hp: 210,
 


### PR DESCRIPTION
This PR manually adds the missing dexId fields to cards from the Darkness ablaze set.

Details:

Each affected card was updated with its correct Pokédex ID (dexId)