### PR TITLE
feature/add_missing_dex_id_for_pokemon_go

### DIFF
--- a/data/Sword & Shield/Pokémon GO/004.ts
+++ b/data/Sword & Shield/Pokémon GO/004.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Pokémon GO"
 
 const card: Card = {
+	dexId: [3],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Pokémon GO/005.ts
+++ b/data/Sword & Shield/Pokémon GO/005.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Pokémon GO"
 
 const card: Card = {
+	dexId: [103],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Pokémon GO/011.ts
+++ b/data/Sword & Shield/Pokémon GO/011.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Pokémon GO"
 
 const card: Card = {
+	dexId: [6],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Pokémon GO/018.ts
+++ b/data/Sword & Shield/Pokémon GO/018.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Pokémon GO"
 
 const card: Card = {
+	dexId: [9],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Pokémon GO/030.ts
+++ b/data/Sword & Shield/Pokémon GO/030.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Pokémon GO"
 
 const card: Card = {
+	dexId: [150],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Pokémon GO/031.ts
+++ b/data/Sword & Shield/Pokémon GO/031.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Pokémon GO"
 
 const card: Card = {
+	dexId: [150],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Pokémon GO/040.ts
+++ b/data/Sword & Shield/Pokémon GO/040.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Pokémon GO"
 
 const card: Card = {
+	dexId: [534],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Pokémon GO/046.ts
+++ b/data/Sword & Shield/Pokémon GO/046.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Pokémon GO"
 
 const card: Card = {
+	dexId: [809],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Pokémon GO/047.ts
+++ b/data/Sword & Shield/Pokémon GO/047.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Pokémon GO"
 
 const card: Card = {
+	dexId: [809],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Pokémon GO/048.ts
+++ b/data/Sword & Shield/Pokémon GO/048.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Pokémon GO"
 
 const card: Card = {
+	dexId: [809],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Pokémon GO/050.ts
+++ b/data/Sword & Shield/Pokémon GO/050.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Pokémon GO"
 
 const card: Card = {
+	dexId: [148],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Pokémon GO/058.ts
+++ b/data/Sword & Shield/Pokémon GO/058.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Pokémon GO"
 
 const card: Card = {
+	dexId: [289],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Pokémon GO/071.ts
+++ b/data/Sword & Shield/Pokémon GO/071.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Pokémon GO"
 
 const card: Card = {
+	dexId: [103],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Pokémon GO/072.ts
+++ b/data/Sword & Shield/Pokémon GO/072.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Pokémon GO"
 
 const card: Card = {
+	dexId: [150],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Pokémon GO/073.ts
+++ b/data/Sword & Shield/Pokémon GO/073.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Pokémon GO"
 
 const card: Card = {
+	dexId: [534],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Pokémon GO/074.ts
+++ b/data/Sword & Shield/Pokémon GO/074.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Pokémon GO"
 
 const card: Card = {
+	dexId: [534],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Pokémon GO/075.ts
+++ b/data/Sword & Shield/Pokémon GO/075.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Pokémon GO"
 
 const card: Card = {
+	dexId: [809],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Pokémon GO/077.ts
+++ b/data/Sword & Shield/Pokémon GO/077.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Pokémon GO"
 
 const card: Card = {
+	dexId: [289],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Pokémon GO/079.ts
+++ b/data/Sword & Shield/Pokémon GO/079.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Pokémon GO"
 
 const card: Card = {
+	dexId: [150],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Pokémon GO/080.ts
+++ b/data/Sword & Shield/Pokémon GO/080.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Pokémon GO"
 
 const card: Card = {
+	dexId: [809],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Pokémon GO/081.ts
+++ b/data/Sword & Shield/Pokémon GO/081.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Pokémon GO"
 
 const card: Card = {
+	dexId: [148],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Pokémon GO/086.ts
+++ b/data/Sword & Shield/Pokémon GO/086.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Pokémon GO"
 
 const card: Card = {
+	dexId: [150],
 	set: Set,
 
 	name: {


### PR DESCRIPTION
This PR manually adds the missing dexId fields to cards from the Pokemon Go set.

Details:

Each affected card was updated with its correct Pokédex ID (dexId)