### PR TITLE
feature/add_missing_dex_id_for_rebel_clash

### DIFF
--- a/data/Sword & Shield/Rebel Clash/101.ts
+++ b/data/Sword & Shield/Rebel Clash/101.ts
@@ -14,6 +14,7 @@ const card: Card = {
 	illustrator: "Akira Komayama",
 	rarity: "Common",
 	category: "Pokemon",
+	dexId: [562],
 	set: Set,
 
 	attacks: [

--- a/data/Sword & Shield/Rebel Clash/102.ts
+++ b/data/Sword & Shield/Rebel Clash/102.ts
@@ -14,6 +14,7 @@ const card: Card = {
 	illustrator: "TOKIYA",
 	rarity: "Rare",
 	category: "Pokemon",
+	dexId: [867],
 	set: Set,
 
 	evolveFrom: {

--- a/data/Sword & Shield/Rebel Clash/105.ts
+++ b/data/Sword & Shield/Rebel Clash/105.ts
@@ -14,6 +14,7 @@ const card: Card = {
 	illustrator: "Misa Tsutsui",
 	rarity: "Common",
 	category: "Pokemon",
+	dexId: [837],
 	set: Set,
 
 	attacks: [

--- a/data/Sword & Shield/Rebel Clash/106.ts
+++ b/data/Sword & Shield/Rebel Clash/106.ts
@@ -14,6 +14,7 @@ const card: Card = {
 	illustrator: "Mitsuhiro Arita",
 	rarity: "Uncommon",
 	category: "Pokemon",
+	dexId: [838],
 	set: Set,
 
 	evolveFrom: {

--- a/data/Sword & Shield/Rebel Clash/108.ts
+++ b/data/Sword & Shield/Rebel Clash/108.ts
@@ -14,6 +14,7 @@ const card: Card = {
 	illustrator: "aky CG Works",
 	rarity: "Holo Rare V",
 	category: "Pokemon",
+	dexId: [844],
 	set: Set,
 
 	attacks: [

--- a/data/Sword & Shield/Rebel Clash/109.ts
+++ b/data/Sword & Shield/Rebel Clash/109.ts
@@ -14,6 +14,7 @@ const card: Card = {
 	illustrator: "Misa Tsutsui",
 	rarity: "Uncommon",
 	category: "Pokemon",
+	dexId: [870],
 	set: Set,
 
 	attacks: [

--- a/data/Sword & Shield/Rebel Clash/110.ts
+++ b/data/Sword & Shield/Rebel Clash/110.ts
@@ -14,6 +14,7 @@ const card: Card = {
 	illustrator: "aky CG Works",
 	rarity: "Holo Rare V",
 	category: "Pokemon",
+	dexId: [870],
 	set: Set,
 
 	abilities: [

--- a/data/Sword & Shield/Rebel Clash/113.ts
+++ b/data/Sword & Shield/Rebel Clash/113.ts
@@ -14,6 +14,7 @@ const card: Card = {
 	illustrator: "Mitsuhiro Arita",
 	rarity: "Holo Rare",
 	category: "Pokemon",
+	dexId: [109],
 	set: Set,
 
 	evolveFrom: {

--- a/data/Sword & Shield/Rebel Clash/121.ts
+++ b/data/Sword & Shield/Rebel Clash/121.ts
@@ -14,6 +14,7 @@ const card: Card = {
 	illustrator: "Eske Yoshinob",
 	rarity: "Holo Rare V",
 	category: "Pokemon",
+	dexId: [687],
 	set: Set,
 
 	attacks: [

--- a/data/Sword & Shield/Rebel Clash/122.ts
+++ b/data/Sword & Shield/Rebel Clash/122.ts
@@ -14,6 +14,7 @@ const card: Card = {
 	illustrator: "5ban Graphics",
 	rarity: "Holo Rare VMAX",
 	category: "Pokemon",
+	dexId: [687],
 	set: Set,
 
 	evolveFrom: {

--- a/data/Sword & Shield/Rebel Clash/123.ts
+++ b/data/Sword & Shield/Rebel Clash/123.ts
@@ -14,6 +14,7 @@ const card: Card = {
 	illustrator: "Kouki Saitou",
 	rarity: "Common",
 	category: "Pokemon",
+	dexId: [859],
 	set: Set,
 
 	attacks: [

--- a/data/Sword & Shield/Rebel Clash/124.ts
+++ b/data/Sword & Shield/Rebel Clash/124.ts
@@ -14,6 +14,7 @@ const card: Card = {
 	illustrator: "Hitoshi Ariga",
 	rarity: "Uncommon",
 	category: "Pokemon",
+	dexId: [860],
 	set: Set,
 
 	evolveFrom: {

--- a/data/Sword & Shield/Rebel Clash/125.ts
+++ b/data/Sword & Shield/Rebel Clash/125.ts
@@ -14,6 +14,7 @@ const card: Card = {
 	illustrator: "nagimiso",
 	rarity: "Holo Rare",
 	category: "Pokemon",
+	dexId: [861],
 	set: Set,
 
 	evolveFrom: {

--- a/data/Sword & Shield/Rebel Clash/137.ts
+++ b/data/Sword & Shield/Rebel Clash/137.ts
@@ -14,6 +14,7 @@ const card: Card = {
 	illustrator: "5ban Graphics",
 	rarity: "Holo Rare VMAX",
 	category: "Pokemon",
+	dexId: [879],
 	set: Set,
 
 	evolveFrom: {

--- a/data/Sword & Shield/Rebel Clash/151.ts
+++ b/data/Sword & Shield/Rebel Clash/151.ts
@@ -14,6 +14,7 @@ const card: Card = {
 	illustrator: "Mina Nakai",
 	rarity: "Common",
 	category: "Pokemon",
+	dexId: [819],
 	set: Set,
 
 	attacks: [

--- a/data/Sword & Shield/Rebel Clash/152.ts
+++ b/data/Sword & Shield/Rebel Clash/152.ts
@@ -14,6 +14,7 @@ const card: Card = {
 	illustrator: "kirisAki",
 	rarity: "Rare",
 	category: "Pokemon",
+	dexId: [820],
 	set: Set,
 
 	evolveFrom: {

--- a/data/Sword & Shield/Rebel Clash/177.ts
+++ b/data/Sword & Shield/Rebel Clash/177.ts
@@ -14,6 +14,7 @@ const card: Card = {
 	illustrator: "Saki Hayashiro",
 	rarity: "Ultra Rare",
 	category: "Pokemon",
+	dexId: [38],
 	set: Set,
 
 	attacks: [

--- a/data/Sword & Shield/Rebel Clash/179.ts
+++ b/data/Sword & Shield/Rebel Clash/179.ts
@@ -14,6 +14,7 @@ const card: Card = {
 	illustrator: "Ayaka Yoshida",
 	rarity: "Ultra Rare",
 	category: "Pokemon",
+	dexId: [350],
 	set: Set,
 
 	attacks: [

--- a/data/Sword & Shield/Rebel Clash/18.ts
+++ b/data/Sword & Shield/Rebel Clash/18.ts
@@ -14,6 +14,7 @@ const card: Card = {
 	illustrator: "5ban Graphics",
 	rarity: "Holo Rare VMAX",
 	category: "Pokemon",
+	dexId: [812],
 	set: Set,
 	hp: 330,
 

--- a/data/Sword & Shield/Rebel Clash/184.ts
+++ b/data/Sword & Shield/Rebel Clash/184.ts
@@ -14,6 +14,7 @@ const card: Card = {
 	illustrator: "aky CG Works",
 	rarity: "Ultra Rare",
 	category: "Pokemon",
+	dexId: [844],
 	set: Set,
 
 	attacks: [

--- a/data/Sword & Shield/Rebel Clash/185.ts
+++ b/data/Sword & Shield/Rebel Clash/185.ts
@@ -14,6 +14,7 @@ const card: Card = {
 	illustrator: "aky CG Works",
 	rarity: "Ultra Rare",
 	category: "Pokemon",
+	dexId: [870],
 	set: Set,
 
 	abilities: [

--- a/data/Sword & Shield/Rebel Clash/186.ts
+++ b/data/Sword & Shield/Rebel Clash/186.ts
@@ -14,6 +14,7 @@ const card: Card = {
 	illustrator: "Eske Yoshinob",
 	rarity: "Ultra Rare",
 	category: "Pokemon",
+	dexId: [687],
 	set: Set,
 
 	attacks: [

--- a/data/Sword & Shield/Rebel Clash/193.ts
+++ b/data/Sword & Shield/Rebel Clash/193.ts
@@ -2,6 +2,7 @@ import { Card } from '../../../interfaces'
 import Set from '../Rebel Clash'
 
 const card: Card = {
+	dexId: [812],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Rebel Clash/194.ts
+++ b/data/Sword & Shield/Rebel Clash/194.ts
@@ -2,6 +2,7 @@ import { Card } from '../../../interfaces'
 import Set from '../Rebel Clash'
 
 const card: Card = {
+	dexId: [815],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Rebel Clash/196.ts
+++ b/data/Sword & Shield/Rebel Clash/196.ts
@@ -2,6 +2,7 @@ import { Card } from '../../../interfaces'
 import Set from '../Rebel Clash'
 
 const card: Card = {
+	dexId: [849],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Rebel Clash/198.ts
+++ b/data/Sword & Shield/Rebel Clash/198.ts
@@ -2,6 +2,7 @@ import { Card } from '../../../interfaces'
 import Set from '../Rebel Clash'
 
 const card: Card = {
+	dexId: [687],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Rebel Clash/199.ts
+++ b/data/Sword & Shield/Rebel Clash/199.ts
@@ -2,6 +2,7 @@ import { Card } from '../../../interfaces'
 import Set from '../Rebel Clash'
 
 const card: Card = {
+	dexId: [879],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Rebel Clash/26.ts
+++ b/data/Sword & Shield/Rebel Clash/26.ts
@@ -14,6 +14,7 @@ const card: Card = {
 	illustrator: "Saki Hayashiro",
 	rarity: "Holo Rare V",
 	category: "Pokemon",
+	dexId: [38],
 	set: Set,
 
 	attacks: [

--- a/data/Sword & Shield/Rebel Clash/36.ts
+++ b/data/Sword & Shield/Rebel Clash/36.ts
@@ -14,6 +14,7 @@ const card: Card = {
 	illustrator: "5ban Graphics",
 	rarity: "Holo Rare VMAX",
 	category: "Pokemon",
+	dexId: [815],
 	set: Set,
 	hp: 320,
 

--- a/data/Sword & Shield/Rebel Clash/37.ts
+++ b/data/Sword & Shield/Rebel Clash/37.ts
@@ -14,6 +14,7 @@ const card: Card = {
 	illustrator: "kirisAki",
 	rarity: "Common",
 	category: "Pokemon",
+	dexId: [122],
 	set: Set,
 
 	attacks: [

--- a/data/Sword & Shield/Rebel Clash/38.ts
+++ b/data/Sword & Shield/Rebel Clash/38.ts
@@ -14,6 +14,7 @@ const card: Card = {
 	illustrator: "Mitsuhiro Arita",
 	rarity: "Rare",
 	category: "Pokemon",
+	dexId: [866],
 	set: Set,
 
 	evolveFrom: {

--- a/data/Sword & Shield/Rebel Clash/43.ts
+++ b/data/Sword & Shield/Rebel Clash/43.ts
@@ -14,6 +14,7 @@ const card: Card = {
 	illustrator: "Ayaka Yoshida",
 	rarity: "Holo Rare V",
 	category: "Pokemon",
+	dexId: [350],
 	set: Set,
 
 	attacks: [

--- a/data/Sword & Shield/Rebel Clash/47.ts
+++ b/data/Sword & Shield/Rebel Clash/47.ts
@@ -14,6 +14,7 @@ const card: Card = {
 	illustrator: "Akira Komayama",
 	rarity: "Common",
 	category: "Pokemon",
+	dexId: [554],
 	set: Set,
 
 	attacks: [

--- a/data/Sword & Shield/Rebel Clash/48.ts
+++ b/data/Sword & Shield/Rebel Clash/48.ts
@@ -14,6 +14,7 @@ const card: Card = {
 	illustrator: "Kouki Saitou",
 	rarity: "Rare",
 	category: "Pokemon",
+	dexId: [555],
 	set: Set,
 
 	evolveFrom: {

--- a/data/Sword & Shield/Rebel Clash/53.ts
+++ b/data/Sword & Shield/Rebel Clash/53.ts
@@ -14,6 +14,7 @@ const card: Card = {
 	illustrator: "Kouki Saitou",
 	rarity: "Rare",
 	category: "Pokemon",
+	dexId: [847],
 	set: Set,
 
 	evolveFrom: {

--- a/data/Sword & Shield/Rebel Clash/55.ts
+++ b/data/Sword & Shield/Rebel Clash/55.ts
@@ -14,6 +14,7 @@ const card: Card = {
 	illustrator: "PLANETA Tsuji",
 	rarity: "Holo Rare V",
 	category: "Pokemon",
+	dexId: [875],
 	set: Set,
 
 	abilities: [

--- a/data/Sword & Shield/Rebel Clash/68.ts
+++ b/data/Sword & Shield/Rebel Clash/68.ts
@@ -14,6 +14,7 @@ const card: Card = {
 	illustrator: "nagimiso",
 	rarity: "Common",
 	category: "Pokemon",
+	dexId: [848],
 	set: Set,
 
 	attacks: [

--- a/data/Sword & Shield/Rebel Clash/69.ts
+++ b/data/Sword & Shield/Rebel Clash/69.ts
@@ -14,6 +14,7 @@ const card: Card = {
 	illustrator: "TOKIYA",
 	rarity: "Rare",
 	category: "Pokemon",
+	dexId: [849],
 	set: Set,
 
 	evolveFrom: {

--- a/data/Sword & Shield/Rebel Clash/71.ts
+++ b/data/Sword & Shield/Rebel Clash/71.ts
@@ -14,6 +14,7 @@ const card: Card = {
 	illustrator: "5ban Graphics",
 	rarity: "Holo Rare VMAX",
 	category: "Pokemon",
+	dexId: [849],
 	set: Set,
 	hp: 320,
 

--- a/data/Sword & Shield/Rebel Clash/72.ts
+++ b/data/Sword & Shield/Rebel Clash/72.ts
@@ -14,6 +14,7 @@ const card: Card = {
 	illustrator: "PLANETA Igarashi",
 	rarity: "Holo Rare V",
 	category: "Pokemon",
+	dexId: [871],
 	set: Set,
 
 	abilities: [

--- a/data/Sword & Shield/Rebel Clash/78.ts
+++ b/data/Sword & Shield/Rebel Clash/78.ts
@@ -14,6 +14,7 @@ const card: Card = {
 	illustrator: "Mitsuhiro Arita",
 	rarity: "Common",
 	category: "Pokemon",
+	dexId: [222],
 	set: Set,
 
 	attacks: [

--- a/data/Sword & Shield/Rebel Clash/79.ts
+++ b/data/Sword & Shield/Rebel Clash/79.ts
@@ -14,6 +14,7 @@ const card: Card = {
 	illustrator: "Kagemaru Himeno",
 	rarity: "Holo Rare",
 	category: "Pokemon",
+	dexId: [864],
 	set: Set,
 
 	evolveFrom: {

--- a/data/Sword & Shield/Rebel Clash/84.ts
+++ b/data/Sword & Shield/Rebel Clash/84.ts
@@ -14,6 +14,7 @@ const card: Card = {
 	illustrator: "kirisAki",
 	rarity: "Uncommon",
 	category: "Pokemon",
+	dexId: [857],
 	set: Set,
 
 	evolveFrom: {

--- a/data/Sword & Shield/Rebel Clash/85.ts
+++ b/data/Sword & Shield/Rebel Clash/85.ts
@@ -14,6 +14,7 @@ const card: Card = {
 	illustrator: "Kagemaru Himeno",
 	rarity: "Holo Rare",
 	category: "Pokemon",
+	dexId: [858],
 	set: Set,
 
 	evolveFrom: {

--- a/data/Sword & Shield/Rebel Clash/86.ts
+++ b/data/Sword & Shield/Rebel Clash/86.ts
@@ -14,6 +14,7 @@ const card: Card = {
 	illustrator: "Mina Nakai",
 	rarity: "Common",
 	category: "Pokemon",
+	dexId: [868],
 	set: Set,
 
 	attacks: [

--- a/data/Sword & Shield/Rebel Clash/88.ts
+++ b/data/Sword & Shield/Rebel Clash/88.ts
@@ -14,6 +14,7 @@ const card: Card = {
 	illustrator: "Mizue",
 	rarity: "Uncommon",
 	category: "Pokemon",
+	dexId: [876],
 	set: Set,
 
 	attacks: [

--- a/data/Sword & Shield/Rebel Clash/89.ts
+++ b/data/Sword & Shield/Rebel Clash/89.ts
@@ -14,6 +14,7 @@ const card: Card = {
 	illustrator: "Akira Komayama",
 	rarity: "Common",
 	category: "Pokemon",
+	dexId: [885],
 	set: Set,
 
 	attacks: [

--- a/data/Sword & Shield/Rebel Clash/90.ts
+++ b/data/Sword & Shield/Rebel Clash/90.ts
@@ -14,6 +14,7 @@ const card: Card = {
 	illustrator: "Kouki Saitou",
 	rarity: "Uncommon",
 	category: "Pokemon",
+	dexId: [886],
 	set: Set,
 
 	evolveFrom: {

--- a/data/Sword & Shield/Rebel Clash/91.ts
+++ b/data/Sword & Shield/Rebel Clash/91.ts
@@ -14,6 +14,7 @@ const card: Card = {
 	illustrator: "Shin Nagasawa",
 	rarity: "Holo Rare",
 	category: "Pokemon",
+	dexId: [887],
 	set: Set,
 
 	evolveFrom: {

--- a/data/Sword & Shield/Rebel Clash/94.ts
+++ b/data/Sword & Shield/Rebel Clash/94.ts
@@ -14,6 +14,7 @@ const card: Card = {
 	illustrator: "Akira Komayama",
 	rarity: "Common",
 	category: "Pokemon",
+	dexId: [83],
 	set: Set,
 
 	attacks: [

--- a/data/Sword & Shield/Rebel Clash/95.ts
+++ b/data/Sword & Shield/Rebel Clash/95.ts
@@ -14,6 +14,7 @@ const card: Card = {
 	illustrator: "You Iribi",
 	rarity: "Holo Rare",
 	category: "Pokemon",
+	dexId: [599],
 	set: Set,
 
 	evolveFrom: {


### PR DESCRIPTION
This PR manually adds the missing dexId fields to cards from the Rebel Clash set.

Details:

Each affected card was updated with its correct Pokédex ID (dexId)