### PR TITLE
feature/add_missing_dex_id_for_shining_fates

### DIFF
--- a/data/Sword & Shield/Shining Fates/10.ts
+++ b/data/Sword & Shield/Shining Fates/10.ts
@@ -2,6 +2,7 @@ import { Card } from '../../../interfaces'
 import Set from '../Shining Fates'
 
 const card: Card = {
+	dexId: [781],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Shining Fates/16.ts
+++ b/data/Sword & Shield/Shining Fates/16.ts
@@ -2,6 +2,7 @@ import { Card } from '../../../interfaces'
 import Set from '../Shining Fates'
 
 const card: Card = {
+	dexId: [893],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Shining Fates/19.ts
+++ b/data/Sword & Shield/Shining Fates/19.ts
@@ -2,6 +2,7 @@ import { Card } from '../../../interfaces'
 import Set from '../Shining Fates'
 
 const card: Card = {
+	dexId: [815],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Shining Fates/42.ts
+++ b/data/Sword & Shield/Shining Fates/42.ts
@@ -2,6 +2,7 @@ import { Card } from '../../../interfaces'
 import Set from '../Shining Fates'
 
 const card: Card = {
+	dexId: [109],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Shining Fates/50.ts
+++ b/data/Sword & Shield/Shining Fates/50.ts
@@ -2,6 +2,7 @@ import { Card } from '../../../interfaces'
 import Set from '../Shining Fates'
 
 const card: Card = {
+	dexId: [132],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Shining Fates/51.ts
+++ b/data/Sword & Shield/Shining Fates/51.ts
@@ -2,6 +2,7 @@ import { Card } from '../../../interfaces'
 import Set from '../Shining Fates'
 
 const card: Card = {
+	dexId: [132],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Shining Fates/53.ts
+++ b/data/Sword & Shield/Shining Fates/53.ts
@@ -2,6 +2,7 @@ import { Card } from '../../../interfaces'
 import Set from '../Shining Fates'
 
 const card: Card = {
+	dexId: [820],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Shining Fates/55.ts
+++ b/data/Sword & Shield/Shining Fates/55.ts
@@ -2,6 +2,7 @@ import { Card } from '../../../interfaces'
 import Set from '../Shining Fates'
 
 const card: Card = {
+	dexId: [845],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Shining Fates/56.ts
+++ b/data/Sword & Shield/Shining Fates/56.ts
@@ -2,6 +2,7 @@ import { Card } from '../../../interfaces'
 import Set from '../Shining Fates'
 
 const card: Card = {
+	dexId: [876],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Shining Fates/64.ts
+++ b/data/Sword & Shield/Shining Fates/64.ts
@@ -2,6 +2,7 @@ import { Card } from '../../../interfaces'
 import Set from '../Shining Fates'
 
 const card: Card = {
+	dexId: [869],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Shining Fates/73.ts
+++ b/data/Sword & Shield/Shining Fates/73.ts
@@ -2,6 +2,7 @@ import { Card } from '../../../interfaces'
 import Set from '../Shining Fates'
 
 const card: Card = {
+	dexId: [869],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Shining Fates/SV020.ts
+++ b/data/Sword & Shield/Shining Fates/SV020.ts
@@ -2,6 +2,7 @@ import { Card } from '../../../interfaces'
 import Set from '../Shining Fates'
 
 const card: Card = {
+	dexId: [122],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Shining Fates/SV021.ts
+++ b/data/Sword & Shield/Shining Fates/SV021.ts
@@ -2,6 +2,7 @@ import { Card } from '../../../interfaces'
 import Set from '../Shining Fates'
 
 const card: Card = {
+	dexId: [866],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Shining Fates/SV023.ts
+++ b/data/Sword & Shield/Shining Fates/SV023.ts
@@ -2,6 +2,7 @@ import { Card } from '../../../interfaces'
 import Set from '../Shining Fates'
 
 const card: Card = {
+	dexId: [554],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Shining Fates/SV024.ts
+++ b/data/Sword & Shield/Shining Fates/SV024.ts
@@ -2,6 +2,7 @@ import { Card } from '../../../interfaces'
 import Set from '../Shining Fates'
 
 const card: Card = {
+	dexId: [555],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Shining Fates/SV032.ts
+++ b/data/Sword & Shield/Shining Fates/SV032.ts
@@ -2,6 +2,7 @@ import { Card } from '../../../interfaces'
 import Set from '../Shining Fates'
 
 const card: Card = {
+	dexId: [847],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Shining Fates/SV036.ts
+++ b/data/Sword & Shield/Shining Fates/SV036.ts
@@ -2,6 +2,7 @@ import { Card } from '../../../interfaces'
 import Set from '../Shining Fates'
 
 const card: Card = {
+	dexId: [882],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Shining Fates/SV037.ts
+++ b/data/Sword & Shield/Shining Fates/SV037.ts
@@ -2,6 +2,7 @@ import { Card } from '../../../interfaces'
 import Set from '../Shining Fates'
 
 const card: Card = {
+	dexId: [883],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Shining Fates/SV041.ts
+++ b/data/Sword & Shield/Shining Fates/SV041.ts
@@ -2,6 +2,7 @@ import { Card } from '../../../interfaces'
 import Set from '../Shining Fates'
 
 const card: Card = {
+	dexId: [848],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Shining Fates/SV042.ts
+++ b/data/Sword & Shield/Shining Fates/SV042.ts
@@ -2,6 +2,7 @@ import { Card } from '../../../interfaces'
 import Set from '../Shining Fates'
 
 const card: Card = {
+	dexId: [849],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Shining Fates/SV045.ts
+++ b/data/Sword & Shield/Shining Fates/SV045.ts
@@ -2,6 +2,7 @@ import { Card } from '../../../interfaces'
 import Set from '../Shining Fates'
 
 const card: Card = {
+	dexId: [880],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Shining Fates/SV049.ts
+++ b/data/Sword & Shield/Shining Fates/SV049.ts
@@ -2,6 +2,7 @@ import { Card } from '../../../interfaces'
 import Set from '../Shining Fates'
 
 const card: Card = {
+	dexId: [222],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Shining Fates/SV050.ts
+++ b/data/Sword & Shield/Shining Fates/SV050.ts
@@ -2,6 +2,7 @@ import { Card } from '../../../interfaces'
 import Set from '../Shining Fates'
 
 const card: Card = {
+	dexId: [864],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Shining Fates/SV055.ts
+++ b/data/Sword & Shield/Shining Fates/SV055.ts
@@ -2,6 +2,7 @@ import { Card } from '../../../interfaces'
 import Set from '../Shining Fates'
 
 const card: Card = {
+	dexId: [857],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Shining Fates/SV056.ts
+++ b/data/Sword & Shield/Shining Fates/SV056.ts
@@ -2,6 +2,7 @@ import { Card } from '../../../interfaces'
 import Set from '../Shining Fates'
 
 const card: Card = {
+	dexId: [858],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Shining Fates/SV057.ts
+++ b/data/Sword & Shield/Shining Fates/SV057.ts
@@ -2,6 +2,7 @@ import { Card } from '../../../interfaces'
 import Set from '../Shining Fates'
 
 const card: Card = {
+	dexId: [868],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Shining Fates/SV059.ts
+++ b/data/Sword & Shield/Shining Fates/SV059.ts
@@ -2,6 +2,7 @@ import { Card } from '../../../interfaces'
 import Set from '../Shining Fates'
 
 const card: Card = {
+	dexId: [876],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Shining Fates/SV060.ts
+++ b/data/Sword & Shield/Shining Fates/SV060.ts
@@ -2,6 +2,7 @@ import { Card } from '../../../interfaces'
 import Set from '../Shining Fates'
 
 const card: Card = {
+	dexId: [885],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Shining Fates/SV061.ts
+++ b/data/Sword & Shield/Shining Fates/SV061.ts
@@ -2,6 +2,7 @@ import { Card } from '../../../interfaces'
 import Set from '../Shining Fates'
 
 const card: Card = {
+	dexId: [886],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Shining Fates/SV062.ts
+++ b/data/Sword & Shield/Shining Fates/SV062.ts
@@ -2,6 +2,7 @@ import { Card } from '../../../interfaces'
 import Set from '../Shining Fates'
 
 const card: Card = {
+	dexId: [887],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Shining Fates/SV063.ts
+++ b/data/Sword & Shield/Shining Fates/SV063.ts
@@ -2,6 +2,7 @@ import { Card } from '../../../interfaces'
 import Set from '../Shining Fates'
 
 const card: Card = {
+	dexId: [83],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Shining Fates/SV064.ts
+++ b/data/Sword & Shield/Shining Fates/SV064.ts
@@ -2,6 +2,7 @@ import { Card } from '../../../interfaces'
 import Set from '../Shining Fates'
 
 const card: Card = {
+	dexId: [599],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Shining Fates/SV065.ts
+++ b/data/Sword & Shield/Shining Fates/SV065.ts
@@ -2,6 +2,7 @@ import { Card } from '../../../interfaces'
 import Set from '../Shining Fates'
 
 const card: Card = {
+	dexId: [562],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Shining Fates/SV066.ts
+++ b/data/Sword & Shield/Shining Fates/SV066.ts
@@ -2,6 +2,7 @@ import { Card } from '../../../interfaces'
 import Set from '../Shining Fates'
 
 const card: Card = {
+	dexId: [867],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Shining Fates/SV067.ts
+++ b/data/Sword & Shield/Shining Fates/SV067.ts
@@ -2,6 +2,7 @@ import { Card } from '../../../interfaces'
 import Set from '../Shining Fates'
 
 const card: Card = {
+	dexId: [837],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Shining Fates/SV068.ts
+++ b/data/Sword & Shield/Shining Fates/SV068.ts
@@ -2,6 +2,7 @@ import { Card } from '../../../interfaces'
 import Set from '../Shining Fates'
 
 const card: Card = {
+	dexId: [838],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Shining Fates/SV074.ts
+++ b/data/Sword & Shield/Shining Fates/SV074.ts
@@ -2,6 +2,7 @@ import { Card } from '../../../interfaces'
 import Set from '../Shining Fates'
 
 const card: Card = {
+	dexId: [870],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Shining Fates/SV077.ts
+++ b/data/Sword & Shield/Shining Fates/SV077.ts
@@ -2,6 +2,7 @@ import { Card } from '../../../interfaces'
 import Set from '../Shining Fates'
 
 const card: Card = {
+	dexId: [109],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Shining Fates/SV083.ts
+++ b/data/Sword & Shield/Shining Fates/SV083.ts
@@ -2,6 +2,7 @@ import { Card } from '../../../interfaces'
 import Set from '../Shining Fates'
 
 const card: Card = {
+	dexId: [859],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Shining Fates/SV084.ts
+++ b/data/Sword & Shield/Shining Fates/SV084.ts
@@ -2,6 +2,7 @@ import { Card } from '../../../interfaces'
 import Set from '../Shining Fates'
 
 const card: Card = {
+	dexId: [860],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Shining Fates/SV085.ts
+++ b/data/Sword & Shield/Shining Fates/SV085.ts
@@ -2,6 +2,7 @@ import { Card } from '../../../interfaces'
 import Set from '../Shining Fates'
 
 const card: Card = {
+	dexId: [861],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Shining Fates/SV099.ts
+++ b/data/Sword & Shield/Shining Fates/SV099.ts
@@ -2,6 +2,7 @@ import { Card } from '../../../interfaces'
 import Set from '../Shining Fates'
 
 const card: Card = {
+	dexId: [819],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Shining Fates/SV100.ts
+++ b/data/Sword & Shield/Shining Fates/SV100.ts
@@ -2,6 +2,7 @@ import { Card } from '../../../interfaces'
 import Set from '../Shining Fates'
 
 const card: Card = {
+	dexId: [820],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Shining Fates/SV106.ts
+++ b/data/Sword & Shield/Shining Fates/SV106.ts
@@ -2,6 +2,7 @@ import { Card } from '../../../interfaces'
 import Set from '../Shining Fates'
 
 const card: Card = {
+	dexId: [812],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Shining Fates/SV107.ts
+++ b/data/Sword & Shield/Shining Fates/SV107.ts
@@ -2,6 +2,7 @@ import { Card } from '../../../interfaces'
 import Set from '../Shining Fates'
 
 const card: Card = {
+	dexId: [6],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Shining Fates/SV108.ts
+++ b/data/Sword & Shield/Shining Fates/SV108.ts
@@ -2,6 +2,7 @@ import { Card } from '../../../interfaces'
 import Set from '../Shining Fates'
 
 const card: Card = {
+	dexId: [851],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Shining Fates/SV109.ts
+++ b/data/Sword & Shield/Shining Fates/SV109.ts
@@ -2,6 +2,7 @@ import { Card } from '../../../interfaces'
 import Set from '../Shining Fates'
 
 const card: Card = {
+	dexId: [851],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Shining Fates/SV113.ts
+++ b/data/Sword & Shield/Shining Fates/SV113.ts
@@ -2,6 +2,7 @@ import { Card } from '../../../interfaces'
 import Set from '../Shining Fates'
 
 const card: Card = {
+	dexId: [849],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Shining Fates/SV115.ts
+++ b/data/Sword & Shield/Shining Fates/SV115.ts
@@ -2,6 +2,7 @@ import { Card } from '../../../interfaces'
 import Set from '../Shining Fates'
 
 const card: Card = {
+	dexId: [870],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Shining Fates/SV117.ts
+++ b/data/Sword & Shield/Shining Fates/SV117.ts
@@ -2,6 +2,7 @@ import { Card } from '../../../interfaces'
 import Set from '../Shining Fates'
 
 const card: Card = {
+	dexId: [861],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Shining Fates/SV118.ts
+++ b/data/Sword & Shield/Shining Fates/SV118.ts
@@ -2,6 +2,7 @@ import { Card } from '../../../interfaces'
 import Set from '../Shining Fates'
 
 const card: Card = {
+	dexId: [132],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Shining Fates/SV119.ts
+++ b/data/Sword & Shield/Shining Fates/SV119.ts
@@ -2,6 +2,7 @@ import { Card } from '../../../interfaces'
 import Set from '../Shining Fates'
 
 const card: Card = {
+	dexId: [132],
 	set: Set,
 
 	name: {


### PR DESCRIPTION
This PR manually adds the missing dexId fields to cards from the Shining Fates set.

Details:

Each affected card was updated with its correct Pokédex ID (dexId)