### PR TITLE
feature/add_missing_dex_id_for_silver_tempest

### DIFF
--- a/data/Sword & Shield/Silver Tempest/007.ts
+++ b/data/Sword & Shield/Silver Tempest/007.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Silver Tempest"
 
 const card: Card = {
+	dexId: [497],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Silver Tempest/008.ts
+++ b/data/Sword & Shield/Silver Tempest/008.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Silver Tempest"
 
 const card: Card = {
+	dexId: [497],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Silver Tempest/010.ts
+++ b/data/Sword & Shield/Silver Tempest/010.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Silver Tempest"
 
 const card: Card = {
+	dexId: [549],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Silver Tempest/015.ts
+++ b/data/Sword & Shield/Silver Tempest/015.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Silver Tempest"
 
 const card: Card = {
+	dexId: [652],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Silver Tempest/016.ts
+++ b/data/Sword & Shield/Silver Tempest/016.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Silver Tempest"
 
 const card: Card = {
+	dexId: [763],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Silver Tempest/024.ts
+++ b/data/Sword & Shield/Silver Tempest/024.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Silver Tempest"
 
 const card: Card = {
+	dexId: [643],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Silver Tempest/033.ts
+++ b/data/Sword & Shield/Silver Tempest/033.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Silver Tempest"
 
 const card: Card = {
+	dexId: [37],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Silver Tempest/034.ts
+++ b/data/Sword & Shield/Silver Tempest/034.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Silver Tempest"
 
 const card: Card = {
+	dexId: [37],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Silver Tempest/035.ts
+++ b/data/Sword & Shield/Silver Tempest/035.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Silver Tempest"
 
 const card: Card = {
+	dexId: [139],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Silver Tempest/057.ts
+++ b/data/Sword & Shield/Silver Tempest/057.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Silver Tempest"
 
 const card: Card = {
+	dexId: [894],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Silver Tempest/058.ts
+++ b/data/Sword & Shield/Silver Tempest/058.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Silver Tempest"
 
 const card: Card = {
+	dexId: [894],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Silver Tempest/059.ts
+++ b/data/Sword & Shield/Silver Tempest/059.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Silver Tempest"
 
 const card: Card = {
+	dexId: [65],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Silver Tempest/066.ts
+++ b/data/Sword & Shield/Silver Tempest/066.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Silver Tempest"
 
 const card: Card = {
+	dexId: [201],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Silver Tempest/070.ts
+++ b/data/Sword & Shield/Silver Tempest/070.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Silver Tempest"
 
 const card: Card = {
+	dexId: [303],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Silver Tempest/071.ts
+++ b/data/Sword & Shield/Silver Tempest/071.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Silver Tempest"
 
 const card: Card = {
+	dexId: [303],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Silver Tempest/086.ts
+++ b/data/Sword & Shield/Silver Tempest/086.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Silver Tempest"
 
 const card: Card = {
+	dexId: [876],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Silver Tempest/087.ts
+++ b/data/Sword & Shield/Silver Tempest/087.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Silver Tempest"
 
 const card: Card = {
+	dexId: [885],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Silver Tempest/088.ts
+++ b/data/Sword & Shield/Silver Tempest/088.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Silver Tempest"
 
 const card: Card = {
+	dexId: [886],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Silver Tempest/089.ts
+++ b/data/Sword & Shield/Silver Tempest/089.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Silver Tempest"
 
 const card: Card = {
+	dexId: [887],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Silver Tempest/090.ts
+++ b/data/Sword & Shield/Silver Tempest/090.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Silver Tempest"
 
 const card: Card = {
+	dexId: [59],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Silver Tempest/102.ts
+++ b/data/Sword & Shield/Silver Tempest/102.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Silver Tempest"
 
 const card: Card = {
+	dexId: [901],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Silver Tempest/108.ts
+++ b/data/Sword & Shield/Silver Tempest/108.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Silver Tempest"
 
 const card: Card = {
+	dexId: [435],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Silver Tempest/120.ts
+++ b/data/Sword & Shield/Silver Tempest/120.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Silver Tempest"
 
 const card: Card = {
+	dexId: [385],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Silver Tempest/128.ts
+++ b/data/Sword & Shield/Silver Tempest/128.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Silver Tempest"
 
 const card: Card = {
+	dexId: [801],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Silver Tempest/135.ts
+++ b/data/Sword & Shield/Silver Tempest/135.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Silver Tempest"
 
 const card: Card = {
+	dexId: [895],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Silver Tempest/136.ts
+++ b/data/Sword & Shield/Silver Tempest/136.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Silver Tempest"
 
 const card: Card = {
+	dexId: [895],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Silver Tempest/138.ts
+++ b/data/Sword & Shield/Silver Tempest/138.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Silver Tempest"
 
 const card: Card = {
+	dexId: [249],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Silver Tempest/139.ts
+++ b/data/Sword & Shield/Silver Tempest/139.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Silver Tempest"
 
 const card: Card = {
+	dexId: [249],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Silver Tempest/140.ts
+++ b/data/Sword & Shield/Silver Tempest/140.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Silver Tempest"
 
 const card: Card = {
+	dexId: [250],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Silver Tempest/149.ts
+++ b/data/Sword & Shield/Silver Tempest/149.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Silver Tempest"
 
 const card: Card = {
+	dexId: [628],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Silver Tempest/170.ts
+++ b/data/Sword & Shield/Silver Tempest/170.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Silver Tempest"
 
 const card: Card = {
+	dexId: [497],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Silver Tempest/171.ts
+++ b/data/Sword & Shield/Silver Tempest/171.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Silver Tempest"
 
 const card: Card = {
+	dexId: [652],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Silver Tempest/172.ts
+++ b/data/Sword & Shield/Silver Tempest/172.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Silver Tempest"
 
 const card: Card = {
+	dexId: [643],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Silver Tempest/173.ts
+++ b/data/Sword & Shield/Silver Tempest/173.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Silver Tempest"
 
 const card: Card = {
+	dexId: [37],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Silver Tempest/174.ts
+++ b/data/Sword & Shield/Silver Tempest/174.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Silver Tempest"
 
 const card: Card = {
+	dexId: [139],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Silver Tempest/175.ts
+++ b/data/Sword & Shield/Silver Tempest/175.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Silver Tempest"
 
 const card: Card = {
+	dexId: [894],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Silver Tempest/178.ts
+++ b/data/Sword & Shield/Silver Tempest/178.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Silver Tempest"
 
 const card: Card = {
+	dexId: [303],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Silver Tempest/179.ts
+++ b/data/Sword & Shield/Silver Tempest/179.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Silver Tempest"
 
 const card: Card = {
+	dexId: [59],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Silver Tempest/180.ts
+++ b/data/Sword & Shield/Silver Tempest/180.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Silver Tempest"
 
 const card: Card = {
+	dexId: [435],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Silver Tempest/181.ts
+++ b/data/Sword & Shield/Silver Tempest/181.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Silver Tempest"
 
 const card: Card = {
+	dexId: [435],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Silver Tempest/182.ts
+++ b/data/Sword & Shield/Silver Tempest/182.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Silver Tempest"
 
 const card: Card = {
+	dexId: [801],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Silver Tempest/183.ts
+++ b/data/Sword & Shield/Silver Tempest/183.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Silver Tempest"
 
 const card: Card = {
+	dexId: [895],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Silver Tempest/184.ts
+++ b/data/Sword & Shield/Silver Tempest/184.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Silver Tempest"
 
 const card: Card = {
+	dexId: [895],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Silver Tempest/185.ts
+++ b/data/Sword & Shield/Silver Tempest/185.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Silver Tempest"
 
 const card: Card = {
+	dexId: [249],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Silver Tempest/186.ts
+++ b/data/Sword & Shield/Silver Tempest/186.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Silver Tempest"
 
 const card: Card = {
+	dexId: [249],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Silver Tempest/187.ts
+++ b/data/Sword & Shield/Silver Tempest/187.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Silver Tempest"
 
 const card: Card = {
+	dexId: [250],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Silver Tempest/196.ts
+++ b/data/Sword & Shield/Silver Tempest/196.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Silver Tempest"
 
 const card: Card = {
+	dexId: [497],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Silver Tempest/197.ts
+++ b/data/Sword & Shield/Silver Tempest/197.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Silver Tempest"
 
 const card: Card = {
+	dexId: [37],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Silver Tempest/198.ts
+++ b/data/Sword & Shield/Silver Tempest/198.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Silver Tempest"
 
 const card: Card = {
+	dexId: [894],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Silver Tempest/199.ts
+++ b/data/Sword & Shield/Silver Tempest/199.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Silver Tempest"
 
 const card: Card = {
+	dexId: [201],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Silver Tempest/200.ts
+++ b/data/Sword & Shield/Silver Tempest/200.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Silver Tempest"
 
 const card: Card = {
+	dexId: [303],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Silver Tempest/201.ts
+++ b/data/Sword & Shield/Silver Tempest/201.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Silver Tempest"
 
 const card: Card = {
+	dexId: [895],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Silver Tempest/202.ts
+++ b/data/Sword & Shield/Silver Tempest/202.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Silver Tempest"
 
 const card: Card = {
+	dexId: [249],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Silver Tempest/210.ts
+++ b/data/Sword & Shield/Silver Tempest/210.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Silver Tempest"
 
 const card: Card = {
+	dexId: [497],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Silver Tempest/211.ts
+++ b/data/Sword & Shield/Silver Tempest/211.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Silver Tempest"
 
 const card: Card = {
+	dexId: [249],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Silver Tempest/TG12.ts
+++ b/data/Sword & Shield/Silver Tempest/TG12.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Silver Tempest"
 
 const card: Card = {
+	dexId: [173],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Silver Tempest/TG13.ts
+++ b/data/Sword & Shield/Silver Tempest/TG13.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Silver Tempest"
 
 const card: Card = {
+	dexId: [497],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Silver Tempest/TG14.ts
+++ b/data/Sword & Shield/Silver Tempest/TG14.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Silver Tempest"
 
 const card: Card = {
+	dexId: [257],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Silver Tempest/TG15.ts
+++ b/data/Sword & Shield/Silver Tempest/TG15.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Silver Tempest"
 
 const card: Card = {
+	dexId: [257],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Silver Tempest/TG17.ts
+++ b/data/Sword & Shield/Silver Tempest/TG17.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Silver Tempest"
 
 const card: Card = {
+	dexId: [303],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Silver Tempest/TG18.ts
+++ b/data/Sword & Shield/Silver Tempest/TG18.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Silver Tempest"
 
 const card: Card = {
+	dexId: [823],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Silver Tempest/TG19.ts
+++ b/data/Sword & Shield/Silver Tempest/TG19.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Silver Tempest"
 
 const card: Card = {
+	dexId: [823],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Silver Tempest/TG22.ts
+++ b/data/Sword & Shield/Silver Tempest/TG22.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Silver Tempest"
 
 const card: Card = {
+	dexId: [242],
 	set: Set,
 
 	name: {


### PR DESCRIPTION
This PR manually adds the missing dexId fields to cards from the Silver tempest set.

Details:

Each affected card was updated with its correct Pokédex ID (dexId)