### PR TITLE
feature/add_missing_dex_id_for_swsh_black_star_promo

### DIFF
--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH062.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH062.ts
@@ -2,6 +2,7 @@ import { Card } from '../../../interfaces'
 import Set from '../SWSH Black Star Promos'
 
 const card: Card = {
+	dexId: [25],
 	set: Set,
 
 	variants: {

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH079.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH079.ts
@@ -2,6 +2,7 @@ import { Card } from '../../../interfaces'
 import Set from '../SWSH Black Star Promos'
 
 const card: Card = {
+	dexId: [866],
 	set: Set,
 	illustrator: "KEIICHIRO ITO",
 	category: "Pokemon",

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH130.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH130.ts
@@ -2,6 +2,7 @@ import { Card } from '../../../interfaces'
 import Set from '../SWSH Black Star Promos'
 
 const card: Card = {
+	dexId: [898],
 	set: Set,
 	illustrator: "5ban Graphics",
 	category: "Pokemon",

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH131.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH131.ts
@@ -2,6 +2,7 @@ import { Card } from '../../../interfaces'
 import Set from '../SWSH Black Star Promos'
 
 const card: Card = {
+	dexId: [898],
 	set: Set,
 	illustrator: "5ban Graphics",
 	category: "Pokemon",

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH132.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH132.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces";
 import Set from "../SWSH Black Star Promos";
 
 const card: Card = {
+	dexId: [887],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH133.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH133.ts
@@ -2,6 +2,7 @@ import { Card } from '../../../interfaces'
 import Set from '../SWSH Black Star Promos'
 
 const card: Card = {
+	dexId: [6],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH134.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH134.ts
@@ -2,6 +2,7 @@ import { Card } from '../../../interfaces'
 import Set from '../SWSH Black Star Promos'
 
 const card: Card = {
+	dexId: [700],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH135.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH135.ts
@@ -2,6 +2,7 @@ import { Card } from '../../../interfaces'
 import Set from '../SWSH Black Star Promos'
 
 const card: Card = {
+	dexId: [888],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH137.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH137.ts
@@ -2,6 +2,7 @@ import { Card } from '../../../interfaces'
 import Set from '../SWSH Black Star Promos'
 
 const card: Card = {
+	dexId: [849],
 	set: Set,
 
 	variants: {

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH138.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH138.ts
@@ -2,6 +2,7 @@ import { Card } from '../../../interfaces'
 import Set from '../SWSH Black Star Promos'
 
 const card: Card = {
+	dexId: [635],
 	set: Set,
 
 	variants: {

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH139.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH139.ts
@@ -2,6 +2,7 @@ import { Card } from '../../../interfaces'
 import Set from '../SWSH Black Star Promos'
 
 const card: Card = {
+	dexId: [25],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH140.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH140.ts
@@ -2,6 +2,7 @@ import { Card } from '../../../interfaces'
 import Set from '../SWSH Black Star Promos'
 
 const card: Card = {
+	dexId: [25],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH141.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH141.ts
@@ -2,6 +2,7 @@ import { Card } from '../../../interfaces'
 import Set from '../SWSH Black Star Promos'
 
 const card: Card = {
+	dexId: [25],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH142.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH142.ts
@@ -2,6 +2,7 @@ import { Card } from '../../../interfaces'
 import Set from '../SWSH Black Star Promos'
 
 const card: Card = {
+	dexId: [25],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH144.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH144.ts
@@ -2,6 +2,7 @@ import { Card } from '../../../interfaces'
 import Set from '../SWSH Black Star Promos'
 
 const card: Card = {
+	dexId: [658],
 	set: Set,
 
 	variants: {

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH153.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH153.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../SWSH Black Star Promos"
 
 const card: Card = {
+	dexId: [25],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH155.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH155.ts
@@ -2,6 +2,7 @@ import { Card } from '../../../interfaces'
 import Set from '../SWSH Black Star Promos'
 
 const card: Card = {
+	dexId: [658],
 	set: Set,
 	illustrator: "Shin Nagasawa",
 	category: "Pokemon",

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH156.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH156.ts
@@ -2,6 +2,7 @@ import { Card } from '../../../interfaces'
 import Set from '../SWSH Black Star Promos'
 
 const card: Card = {
+	dexId: [658],
 	set: Set,
 	illustrator: "Shin Nagasawa",
 	category: "Pokemon",

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH157.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH157.ts
@@ -2,6 +2,7 @@ import { Card } from '../../../interfaces'
 import Set from '../SWSH Black Star Promos'
 
 const card: Card = {
+	dexId: [658],
 	set: Set,
 	illustrator: "Shin Nagasawa",
 	category: "Pokemon",

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH158.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH158.ts
@@ -2,6 +2,7 @@ import { Card } from '../../../interfaces'
 import Set from '../SWSH Black Star Promos'
 
 const card: Card = {
+	dexId: [658],
 	set: Set,
 	illustrator: "Shin Nagasawa",
 	category: "Pokemon",

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH159.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH159.ts
@@ -2,6 +2,7 @@ import { Card } from '../../../interfaces'
 import Set from '../SWSH Black Star Promos'
 
 const card: Card = {
+	dexId: [150],
 	set: Set,
 	illustrator: "AKIRA EGAWA",
 	category: "Pokemon",

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH160.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH160.ts
@@ -2,6 +2,7 @@ import { Card } from '../../../interfaces'
 import Set from '../SWSH Black Star Promos'
 
 const card: Card = {
+	dexId: [150],
 	set: Set,
 	illustrator: "AKIRA EGAWA",
 	category: "Pokemon",

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH161.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH161.ts
@@ -2,6 +2,7 @@ import { Card } from '../../../interfaces'
 import Set from '../SWSH Black Star Promos'
 
 const card: Card = {
+	dexId: [150],
 	set: Set,
 	illustrator: "AKIRA EGAWA",
 	category: "Pokemon",

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH162.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH162.ts
@@ -2,6 +2,7 @@ import { Card } from '../../../interfaces'
 import Set from '../SWSH Black Star Promos'
 
 const card: Card = {
+	dexId: [150],
 	set: Set,
 	illustrator: "AKIRA EGAWA",
 	category: "Pokemon",

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH163.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH163.ts
@@ -2,6 +2,7 @@ import { Card } from '../../../interfaces'
 import Set from '../SWSH Black Star Promos'
 
 const card: Card = {
+	dexId: [888],
 	set: Set,
 	illustrator: "PLANETA Tsuji",
 	category: "Pokemon",

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH164.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH164.ts
@@ -2,6 +2,7 @@ import { Card } from '../../../interfaces'
 import Set from '../SWSH Black Star Promos'
 
 const card: Card = {
+	dexId: [888],
 	set: Set,
 	illustrator: "PLANETA Tsuji",
 	category: "Pokemon",

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH165.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH165.ts
@@ -2,6 +2,7 @@ import { Card } from '../../../interfaces'
 import Set from '../SWSH Black Star Promos'
 
 const card: Card = {
+	dexId: [888],
 	set: Set,
 	illustrator: "PLANETA Tsuji",
 	category: "Pokemon",

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH166.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH166.ts
@@ -2,6 +2,7 @@ import { Card } from '../../../interfaces'
 import Set from '../SWSH Black Star Promos'
 
 const card: Card = {
+	dexId: [888],
 	set: Set,
 	illustrator: "PLANETA Tsuji",
 	category: "Pokemon",

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH168.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH168.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../SWSH Black Star Promos"
 
 const card: Card = {
+	dexId: [741],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH169.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH169.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../SWSH Black Star Promos"
 
 const card: Card = {
+	dexId: [771],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH170.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH170.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../SWSH Black Star Promos"
 
 const card: Card = {
+	dexId: [386],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH171.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH171.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../SWSH Black Star Promos"
 
 const card: Card = {
+	dexId: [380],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH172.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH172.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../SWSH Black Star Promos"
 
 const card: Card = {
+	dexId: [498],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH173.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH173.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../SWSH Black Star Promos"
 
 const card: Card = {
+	dexId: [522],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH174.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH174.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../SWSH Black Star Promos"
 
 const card: Card = {
+	dexId: [196],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH175.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH175.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../SWSH Black Star Promos"
 
 const card: Card = {
+	dexId: [133],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH176.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH176.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../SWSH Black Star Promos"
 
 const card: Card = {
+	dexId: [720],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH177.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH177.ts
@@ -2,6 +2,7 @@ import { Card } from '../../../interfaces'
 import Set from '../SWSH Black Star Promos'
 
 const card: Card = {
+	dexId: [399],
 	set: Set,
 	illustrator: "The Pokémon Company Art Team",
 	category: "Pokemon",

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH179.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH179.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../SWSH Black Star Promos"
 
 const card: Card = {
+	dexId: [136],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH180.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH180.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../SWSH Black Star Promos"
 
 const card: Card = {
+	dexId: [136],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH181.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH181.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../SWSH Black Star Promos"
 
 const card: Card = {
+	dexId: [134],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH182.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH182.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../SWSH Black Star Promos"
 
 const card: Card = {
+	dexId: [134],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH183.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH183.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../SWSH Black Star Promos"
 
 const card: Card = {
+	dexId: [135],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH184.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH184.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../SWSH Black Star Promos"
 
 const card: Card = {
+	dexId: [135],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH185.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH185.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../SWSH Black Star Promos"
 
 const card: Card = {
+	dexId: [146],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH186.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH186.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../SWSH Black Star Promos"
 
 const card: Card = {
+	dexId: [448],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH187.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH187.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../SWSH Black Star Promos"
 
 const card: Card = {
+	dexId: [510],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH188.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH188.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../SWSH Black Star Promos"
 
 const card: Card = {
+	dexId: [400],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH189.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH189.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../SWSH Black Star Promos"
 
 const card: Card = {
+	dexId: [841],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH190.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH190.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../SWSH Black Star Promos"
 
 const card: Card = {
+	dexId: [133],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH191.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH191.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../SWSH Black Star Promos"
 
 const card: Card = {
+	dexId: [470],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH192.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH192.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../SWSH Black Star Promos"
 
 const card: Card = {
+	dexId: [471],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH193.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH193.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../SWSH Black Star Promos"
 
 const card: Card = {
+	dexId: [862],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH194.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH194.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../SWSH Black Star Promos"
 
 const card: Card = {
+	dexId: [470],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH195.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH195.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../SWSH Black Star Promos"
 
 const card: Card = {
+	dexId: [470],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH196.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH196.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../SWSH Black Star Promos"
 
 const card: Card = {
+	dexId: [471],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH197.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH197.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../SWSH Black Star Promos"
 
 const card: Card = {
+	dexId: [471],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH198.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH198.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../SWSH Black Star Promos"
 
 const card: Card = {
+	dexId: [25],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH199.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH199.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../SWSH Black Star Promos"
 
 const card: Card = {
+	dexId: [745],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH200.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH200.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../SWSH Black Star Promos"
 
 const card: Card = {
+	dexId: [823],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH201.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH201.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../SWSH Black Star Promos"
 
 const card: Card = {
+	dexId: [196],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH202.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH202.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../SWSH Black Star Promos"
 
 const card: Card = {
+	dexId: [700],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH203.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH203.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../SWSH Black Star Promos"
 
 const card: Card = {
+	dexId: [197],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH204.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH204.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../SWSH Black Star Promos"
 
 const card: Card = {
+	dexId: [493],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH205.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH205.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../SWSH Black Star Promos"
 
 const card: Card = {
+	dexId: [902],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH206.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH206.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../SWSH Black Star Promos"
 
 const card: Card = {
+	dexId: [899],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH207.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH207.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../SWSH Black Star Promos"
 
 const card: Card = {
+	dexId: [503],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH208.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH208.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../SWSH Black Star Promos"
 
 const card: Card = {
+	dexId: [462],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH209.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH209.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../SWSH Black Star Promos"
 
 const card: Card = {
+	dexId: [848],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH210.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH210.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../SWSH Black Star Promos"
 
 const card: Card = {
+	dexId: [741],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH211.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH211.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../SWSH Black Star Promos"
 
 const card: Card = {
+	dexId: [700],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH212.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH212.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../SWSH Black Star Promos"
 
 const card: Card = {
+	dexId: [133],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH213.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH213.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../SWSH Black Star Promos"
 
 const card: Card = {
+	dexId: [448],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH214.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH214.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../SWSH Black Star Promos"
 
 const card: Card = {
+	dexId: [448],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH215.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH215.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../SWSH Black Star Promos"
 
 const card: Card = {
+	dexId: [877],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH216.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH216.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../SWSH Black Star Promos"
 
 const card: Card = {
+	dexId: [877],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH217.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH217.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../SWSH Black Star Promos"
 
 const card: Card = {
+	dexId: [877],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH218.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH218.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../SWSH Black Star Promos"
 
 const card: Card = {
+	dexId: [877],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH219.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH219.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../SWSH Black Star Promos"
 
 const card: Card = {
+	dexId: [836],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH220.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH220.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../SWSH Black Star Promos"
 
 const card: Card = {
+	dexId: [722],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH221.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH221.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../SWSH Black Star Promos"
 
 const card: Card = {
+	dexId: [155],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH222.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH222.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../SWSH Black Star Promos"
 
 const card: Card = {
+	dexId: [501],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH223.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH223.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../SWSH Black Star Promos"
 
 const card: Card = {
+	dexId: [150],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH224.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH224.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../SWSH Black Star Promos"
 
 const card: Card = {
+	dexId: [809],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH225.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH225.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../SWSH Black Star Promos"
 
 const card: Card = {
+	dexId: [103],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH229.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH229.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../SWSH Black Star Promos"
 
 const card: Card = {
+	dexId: [150],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH230.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH230.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../SWSH Black Star Promos"
 
 const card: Card = {
+	dexId: [133],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH231.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH231.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../SWSH Black Star Promos"
 
 const card: Card = {
+	dexId: [1],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH232.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH232.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../SWSH Black Star Promos"
 
 const card: Card = {
+	dexId: [4],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH233.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH233.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../SWSH Black Star Promos"
 
 const card: Card = {
+	dexId: [7],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH234.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH234.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../SWSH Black Star Promos"
 
 const card: Card = {
+	dexId: [25],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH235.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH235.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../SWSH Black Star Promos"
 
 const card: Card = {
+	dexId: [148],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH236.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH236.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../SWSH Black Star Promos"
 
 const card: Card = {
+	dexId: [148],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH237.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH237.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../SWSH Black Star Promos"
 
 const card: Card = {
+	dexId: [157],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH238.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH238.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../SWSH Black Star Promos"
 
 const card: Card = {
+	dexId: [724],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH239.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH239.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../SWSH Black Star Promos"
 
 const card: Card = {
+	dexId: [503],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH240.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH240.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../SWSH Black Star Promos"
 
 const card: Card = {
+	dexId: [456],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH241.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH241.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../SWSH Black Star Promos"
 
 const card: Card = {
+	dexId: [94],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH242.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH242.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../SWSH Black Star Promos"
 
 const card: Card = {
+	dexId: [764],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH243.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH243.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../SWSH Black Star Promos"
 
 const card: Card = {
+	dexId: [68],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH244.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH244.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../SWSH Black Star Promos"
 
 const card: Card = {
+	dexId: [813],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH245.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH245.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../SWSH Black Star Promos"
 
 const card: Card = {
+	dexId: [453],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH246.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH246.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../SWSH Black Star Promos"
 
 const card: Card = {
+	dexId: [461],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH247.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH247.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../SWSH Black Star Promos"
 
 const card: Card = {
+	dexId: [486],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH248.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH248.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../SWSH Black Star Promos"
 
 const card: Card = {
+	dexId: [900],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH249.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH249.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../SWSH Black Star Promos"
 
 const card: Card = {
+	dexId: [900],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH250.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH250.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../SWSH Black Star Promos"
 
 const card: Card = {
+	dexId: [457],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH252.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH252.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../SWSH Black Star Promos"
 
 const card: Card = {
+	dexId: [63],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH253.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH253.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../SWSH Black Star Promos"
 
 const card: Card = {
+	dexId: [484],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH254.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH254.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../SWSH Black Star Promos"
 
 const card: Card = {
+	dexId: [484],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH255.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH255.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../SWSH Black Star Promos"
 
 const card: Card = {
+	dexId: [483],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH256.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH256.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../SWSH Black Star Promos"
 
 const card: Card = {
+	dexId: [483],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH257.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH257.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../SWSH Black Star Promos"
 
 const card: Card = {
+	dexId: [479],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH258.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH258.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../SWSH Black Star Promos"
 
 const card: Card = {
+	dexId: [475],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH259.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH259.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../SWSH Black Star Promos"
 
 const card: Card = {
+	dexId: [487],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH260.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH260.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../SWSH Black Star Promos"
 
 const card: Card = {
+	dexId: [6],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH261.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH261.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../SWSH Black Star Promos"
 
 const card: Card = {
+	dexId: [6],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH262.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH262.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../SWSH Black Star Promos"
 
 const card: Card = {
+	dexId: [6],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH263.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH263.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../SWSH Black Star Promos"
 
 const card: Card = {
+	dexId: [807],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH264.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH264.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../SWSH Black Star Promos"
 
 const card: Card = {
+	dexId: [807],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH265.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH265.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../SWSH Black Star Promos"
 
 const card: Card = {
+	dexId: [807],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH266.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH266.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../SWSH Black Star Promos"
 
 const card: Card = {
+	dexId: [386],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH267.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH267.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../SWSH Black Star Promos"
 
 const card: Card = {
+	dexId: [386],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH268.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH268.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../SWSH Black Star Promos"
 
 const card: Card = {
+	dexId: [386],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH269.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH269.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../SWSH Black Star Promos"
 
 const card: Card = {
+	dexId: [192],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH270.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH270.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../SWSH Black Star Promos"
 
 const card: Card = {
+	dexId: [78],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH271.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH271.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../SWSH Black Star Promos"
 
 const card: Card = {
+	dexId: [281],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH272.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH272.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../SWSH Black Star Promos"
 
 const card: Card = {
+	dexId: [567],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH273.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH273.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../SWSH Black Star Promos"
 
 const card: Card = {
+	dexId: [550],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH274.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH274.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../SWSH Black Star Promos"
 
 const card: Card = {
+	dexId: [408],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH275.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH275.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../SWSH Black Star Promos"
 
 const card: Card = {
+	dexId: [490],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH276.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH276.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../SWSH Black Star Promos"
 
 const card: Card = {
+	dexId: [176],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH277.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH277.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../SWSH Black Star Promos"
 
 const card: Card = {
+	dexId: [812],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH278.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH278.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../SWSH Black Star Promos"
 
 const card: Card = {
+	dexId: [815],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH279.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH279.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../SWSH Black Star Promos"
 
 const card: Card = {
+	dexId: [818],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH280.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH280.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../SWSH Black Star Promos"
 
 const card: Card = {
+	dexId: [894],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH281.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH281.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../SWSH Black Star Promos"
 
 const card: Card = {
+	dexId: [895],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH285.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH285.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../SWSH Black Star Promos"
 
 const card: Card = {
+	dexId: [25],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH286.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH286.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../SWSH Black Star Promos"
 
 const card: Card = {
+	dexId: [25],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH291.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH291.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../SWSH Black Star Promos"
 
 const card: Card = {
+	dexId: [448],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH294.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH294.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../SWSH Black Star Promos"
 
 const card: Card = {
+	dexId: [101],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH295.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH295.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../SWSH Black Star Promos"
 
 const card: Card = {
+	dexId: [640],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH297.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH297.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../SWSH Black Star Promos"
 
 const card: Card = {
+	dexId: [571],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH298.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH298.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../SWSH Black Star Promos"
 
 const card: Card = {
+	dexId: [571],
 	set: Set,
 
 	name: {


### PR DESCRIPTION
This PR manually adds the missing dexId fields to cards from the SWSH Black Star Promo set.

Details:

Each affected card was updated with its correct Pokédex ID (dexId)