### PR TITLE
feature/add_missing_dex_id_for_sm_black_star_promos

### DIFF
--- a/data/Sun & Moon/SM Black Star Promos/SM181.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM181.ts
@@ -2,6 +2,7 @@ import { Card } from '../../../interfaces'
 import Set from '../SM Black Star Promos'
 
 const card: Card = {
+	dexId: [809],
 	set: Set,
 
 	name: {

--- a/data/Sun & Moon/SM Black Star Promos/SM188.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM188.ts
@@ -14,6 +14,8 @@ const card: Card = {
 	rarity: "Rare",
 	category: "Pokemon",
 
+	dexId: [115],
+
 	set: Set,
 
 	hp: 180,

--- a/data/Sun & Moon/SM Black Star Promos/SM228.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM228.ts
@@ -2,6 +2,7 @@ import { Card } from '../../../interfaces'
 import Set from '../SM Black Star Promos'
 
 const card: Card = {
+	dexId: [150],
 	set: Set,
 
 	name: {

--- a/data/Sun & Moon/SM Black Star Promos/SM232.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM232.ts
@@ -2,6 +2,7 @@ import { Card } from '../../../interfaces'
 import Set from '../SM Black Star Promos'
 
 const card: Card = {
+	dexId: [25],
 	set: Set,
 
 	name: {

--- a/data/Sun & Moon/SM Black Star Promos/SM236.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM236.ts
@@ -2,6 +2,7 @@ import { Card } from '../../../interfaces'
 import Set from '../SM Black Star Promos'
 
 const card: Card = {
+	dexId: [28],
 	set: Set,
 
 	name: {

--- a/data/Sun & Moon/SM Black Star Promos/SM239.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM239.ts
@@ -2,6 +2,7 @@ import { Card } from '../../../interfaces'
 import Set from '../SM Black Star Promos'
 
 const card: Card = {
+	dexId: [565],
 	set: Set,
 
 	name: {


### PR DESCRIPTION
This PR manually adds the missing dexId fields to cards from the SM Black Stars Promo set.

Details:

Each affected card was updated with its correct Pokédex ID (dexId)