### PR TITLE
feature/add_missing_dex_id_for_black_bolt

### DIFF
--- a/data/Scarlet & Violet/Black Bolt/001.ts
+++ b/data/Scarlet & Violet/Black Bolt/001.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Black Bolt"
 
 const card: Card = {
+	dexId: [495],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Black Bolt/002.ts
+++ b/data/Scarlet & Violet/Black Bolt/002.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Black Bolt"
 
 const card: Card = {
+	dexId: [496],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Black Bolt/003.ts
+++ b/data/Scarlet & Violet/Black Bolt/003.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Black Bolt"
 
 const card: Card = {
+	dexId: [497],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Black Bolt/004.ts
+++ b/data/Scarlet & Violet/Black Bolt/004.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Black Bolt"
 
 const card: Card = {
+	dexId: [511],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Black Bolt/005.ts
+++ b/data/Scarlet & Violet/Black Bolt/005.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Black Bolt"
 
 const card: Card = {
+	dexId: [512],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Black Bolt/006.ts
+++ b/data/Scarlet & Violet/Black Bolt/006.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Black Bolt"
 
 const card: Card = {
+	dexId: [548],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Black Bolt/007.ts
+++ b/data/Scarlet & Violet/Black Bolt/007.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Black Bolt"
 
 const card: Card = {
+	dexId: [549],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Black Bolt/008.ts
+++ b/data/Scarlet & Violet/Black Bolt/008.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Black Bolt"
 
 const card: Card = {
+	dexId: [556],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Black Bolt/009.ts
+++ b/data/Scarlet & Violet/Black Bolt/009.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Black Bolt"
 
 const card: Card = {
+	dexId: [588],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Black Bolt/010.ts
+++ b/data/Scarlet & Violet/Black Bolt/010.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Black Bolt"
 
 const card: Card = {
+	dexId: [590],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Black Bolt/011.ts
+++ b/data/Scarlet & Violet/Black Bolt/011.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Black Bolt"
 
 const card: Card = {
+	dexId: [591],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Black Bolt/012.ts
+++ b/data/Scarlet & Violet/Black Bolt/012.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Black Bolt"
 
 const card: Card = {
+	dexId: [494],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Black Bolt/013.ts
+++ b/data/Scarlet & Violet/Black Bolt/013.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Black Bolt"
 
 const card: Card = {
+	dexId: [554],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Black Bolt/014.ts
+++ b/data/Scarlet & Violet/Black Bolt/014.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Black Bolt"
 
 const card: Card = {
+	dexId: [555],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Black Bolt/015.ts
+++ b/data/Scarlet & Violet/Black Bolt/015.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Black Bolt"
 
 const card: Card = {
+	dexId: [636],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Black Bolt/016.ts
+++ b/data/Scarlet & Violet/Black Bolt/016.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Black Bolt"
 
 const card: Card = {
+	dexId: [637],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Black Bolt/017.ts
+++ b/data/Scarlet & Violet/Black Bolt/017.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Black Bolt"
 
 const card: Card = {
+	dexId: [515],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Black Bolt/018.ts
+++ b/data/Scarlet & Violet/Black Bolt/018.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Black Bolt"
 
 const card: Card = {
+	dexId: [516],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Black Bolt/019.ts
+++ b/data/Scarlet & Violet/Black Bolt/019.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Black Bolt"
 
 const card: Card = {
+	dexId: [535],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Black Bolt/020.ts
+++ b/data/Scarlet & Violet/Black Bolt/020.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Black Bolt"
 
 const card: Card = {
+	dexId: [536],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Black Bolt/021.ts
+++ b/data/Scarlet & Violet/Black Bolt/021.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Black Bolt"
 
 const card: Card = {
+	dexId: [537],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Black Bolt/022.ts
+++ b/data/Scarlet & Violet/Black Bolt/022.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Black Bolt"
 
 const card: Card = {
+	dexId: [564],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Black Bolt/023.ts
+++ b/data/Scarlet & Violet/Black Bolt/023.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Black Bolt"
 
 const card: Card = {
+	dexId: [565],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Black Bolt/024.ts
+++ b/data/Scarlet & Violet/Black Bolt/024.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Black Bolt"
 
 const card: Card = {
+	dexId: [594],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Black Bolt/025.ts
+++ b/data/Scarlet & Violet/Black Bolt/025.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Black Bolt"
 
 const card: Card = {
+	dexId: [613],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Black Bolt/026.ts
+++ b/data/Scarlet & Violet/Black Bolt/026.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Black Bolt"
 
 const card: Card = {
+	dexId: [614],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Black Bolt/027.ts
+++ b/data/Scarlet & Violet/Black Bolt/027.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Black Bolt"
 
 const card: Card = {
+	dexId: [615],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Black Bolt/028.ts
+++ b/data/Scarlet & Violet/Black Bolt/028.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Black Bolt"
 
 const card: Card = {
+	dexId: [646],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Black Bolt/029.ts
+++ b/data/Scarlet & Violet/Black Bolt/029.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Black Bolt"
 
 const card: Card = {
+	dexId: [587],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Black Bolt/030.ts
+++ b/data/Scarlet & Violet/Black Bolt/030.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Black Bolt"
 
 const card: Card = {
+	dexId: [602],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Black Bolt/031.ts
+++ b/data/Scarlet & Violet/Black Bolt/031.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Black Bolt"
 
 const card: Card = {
+	dexId: [603],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Black Bolt/032.ts
+++ b/data/Scarlet & Violet/Black Bolt/032.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Black Bolt"
 
 const card: Card = {
+	dexId: [604],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Black Bolt/033.ts
+++ b/data/Scarlet & Violet/Black Bolt/033.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Black Bolt"
 
 const card: Card = {
+	dexId: [642],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Black Bolt/034.ts
+++ b/data/Scarlet & Violet/Black Bolt/034.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Black Bolt"
 
 const card: Card = {
+	dexId: [644],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Black Bolt/035.ts
+++ b/data/Scarlet & Violet/Black Bolt/035.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Black Bolt"
 
 const card: Card = {
+	dexId: [517],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Black Bolt/036.ts
+++ b/data/Scarlet & Violet/Black Bolt/036.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Black Bolt"
 
 const card: Card = {
+	dexId: [518],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Black Bolt/037.ts
+++ b/data/Scarlet & Violet/Black Bolt/037.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Black Bolt"
 
 const card: Card = {
+	dexId: [577],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Black Bolt/038.ts
+++ b/data/Scarlet & Violet/Black Bolt/038.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Black Bolt"
 
 const card: Card = {
+	dexId: [578],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Black Bolt/039.ts
+++ b/data/Scarlet & Violet/Black Bolt/039.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Black Bolt"
 
 const card: Card = {
+	dexId: [579],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Black Bolt/040.ts
+++ b/data/Scarlet & Violet/Black Bolt/040.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Black Bolt"
 
 const card: Card = {
+	dexId: [605],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Black Bolt/041.ts
+++ b/data/Scarlet & Violet/Black Bolt/041.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Black Bolt"
 
 const card: Card = {
+	dexId: [606],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Black Bolt/042.ts
+++ b/data/Scarlet & Violet/Black Bolt/042.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Black Bolt"
 
 const card: Card = {
+	dexId: [622],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Black Bolt/043.ts
+++ b/data/Scarlet & Violet/Black Bolt/043.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Black Bolt"
 
 const card: Card = {
+	dexId: [623],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Black Bolt/044.ts
+++ b/data/Scarlet & Violet/Black Bolt/044.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Black Bolt"
 
 const card: Card = {
+	dexId: [648],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Black Bolt/045.ts
+++ b/data/Scarlet & Violet/Black Bolt/045.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Black Bolt"
 
 const card: Card = {
+	dexId: [529],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Black Bolt/046.ts
+++ b/data/Scarlet & Violet/Black Bolt/046.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Black Bolt"
 
 const card: Card = {
+	dexId: [530],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Black Bolt/047.ts
+++ b/data/Scarlet & Violet/Black Bolt/047.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Black Bolt"
 
 const card: Card = {
+	dexId: [532],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Black Bolt/048.ts
+++ b/data/Scarlet & Violet/Black Bolt/048.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Black Bolt"
 
 const card: Card = {
+	dexId: [533],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Black Bolt/049.ts
+++ b/data/Scarlet & Violet/Black Bolt/049.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Black Bolt"
 
 const card: Card = {
+	dexId: [534],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Black Bolt/050.ts
+++ b/data/Scarlet & Violet/Black Bolt/050.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Black Bolt"
 
 const card: Card = {
+	dexId: [538],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Black Bolt/051.ts
+++ b/data/Scarlet & Violet/Black Bolt/051.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Black Bolt"
 
 const card: Card = {
+	dexId: [557],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Black Bolt/052.ts
+++ b/data/Scarlet & Violet/Black Bolt/052.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Black Bolt"
 
 const card: Card = {
+	dexId: [558],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Black Bolt/053.ts
+++ b/data/Scarlet & Violet/Black Bolt/053.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Black Bolt"
 
 const card: Card = {
+	dexId: [645],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Black Bolt/054.ts
+++ b/data/Scarlet & Violet/Black Bolt/054.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Black Bolt"
 
 const card: Card = {
+	dexId: [543],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Black Bolt/055.ts
+++ b/data/Scarlet & Violet/Black Bolt/055.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Black Bolt"
 
 const card: Card = {
+	dexId: [544],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Black Bolt/056.ts
+++ b/data/Scarlet & Violet/Black Bolt/056.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Black Bolt"
 
 const card: Card = {
+	dexId: [545],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Black Bolt/057.ts
+++ b/data/Scarlet & Violet/Black Bolt/057.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Black Bolt"
 
 const card: Card = {
+	dexId: [551],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Black Bolt/058.ts
+++ b/data/Scarlet & Violet/Black Bolt/058.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Black Bolt"
 
 const card: Card = {
+	dexId: [552],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Black Bolt/059.ts
+++ b/data/Scarlet & Violet/Black Bolt/059.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Black Bolt"
 
 const card: Card = {
+	dexId: [553],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Black Bolt/060.ts
+++ b/data/Scarlet & Violet/Black Bolt/060.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Black Bolt"
 
 const card: Card = {
+	dexId: [589],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Black Bolt/061.ts
+++ b/data/Scarlet & Violet/Black Bolt/061.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Black Bolt"
 
 const card: Card = {
+	dexId: [599],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Black Bolt/062.ts
+++ b/data/Scarlet & Violet/Black Bolt/062.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Black Bolt"
 
 const card: Card = {
+	dexId: [600],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Black Bolt/063.ts
+++ b/data/Scarlet & Violet/Black Bolt/063.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Black Bolt"
 
 const card: Card = {
+	dexId: [599],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Black Bolt/064.ts
+++ b/data/Scarlet & Violet/Black Bolt/064.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Black Bolt"
 
 const card: Card = {
+	dexId: [624],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Black Bolt/065.ts
+++ b/data/Scarlet & Violet/Black Bolt/065.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Black Bolt"
 
 const card: Card = {
+	dexId: [625],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Black Bolt/066.ts
+++ b/data/Scarlet & Violet/Black Bolt/066.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Black Bolt"
 
 const card: Card = {
+	dexId: [638],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Black Bolt/067.ts
+++ b/data/Scarlet & Violet/Black Bolt/067.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Black Bolt"
 
 const card: Card = {
+	dexId: [649],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Black Bolt/068.ts
+++ b/data/Scarlet & Violet/Black Bolt/068.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Black Bolt"
 
 const card: Card = {
+	dexId: [610],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Black Bolt/069.ts
+++ b/data/Scarlet & Violet/Black Bolt/069.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Black Bolt"
 
 const card: Card = {
+	dexId: [611],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Black Bolt/070.ts
+++ b/data/Scarlet & Violet/Black Bolt/070.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Black Bolt"
 
 const card: Card = {
+	dexId: [612],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Black Bolt/071.ts
+++ b/data/Scarlet & Violet/Black Bolt/071.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Black Bolt"
 
 const card: Card = {
+	dexId: [519],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Black Bolt/072.ts
+++ b/data/Scarlet & Violet/Black Bolt/072.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Black Bolt"
 
 const card: Card = {
+	dexId: [520],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Black Bolt/073.ts
+++ b/data/Scarlet & Violet/Black Bolt/073.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Black Bolt"
 
 const card: Card = {
+	dexId: [521],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Black Bolt/074.ts
+++ b/data/Scarlet & Violet/Black Bolt/074.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Black Bolt"
 
 const card: Card = {
+	dexId: [531],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Black Bolt/075.ts
+++ b/data/Scarlet & Violet/Black Bolt/075.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Black Bolt"
 
 const card: Card = {
+	dexId: [572],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Black Bolt/076.ts
+++ b/data/Scarlet & Violet/Black Bolt/076.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Black Bolt"
 
 const card: Card = {
+	dexId: [573],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Black Bolt/077.ts
+++ b/data/Scarlet & Violet/Black Bolt/077.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Black Bolt"
 
 const card: Card = {
+	dexId: [627],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Black Bolt/078.ts
+++ b/data/Scarlet & Violet/Black Bolt/078.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Black Bolt"
 
 const card: Card = {
+	dexId: [628],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Black Bolt/087.ts
+++ b/data/Scarlet & Violet/Black Bolt/087.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Black Bolt"
 
 const card: Card = {
+	dexId: [495],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Black Bolt/088.ts
+++ b/data/Scarlet & Violet/Black Bolt/088.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Black Bolt"
 
 const card: Card = {
+	dexId: [496],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Black Bolt/089.ts
+++ b/data/Scarlet & Violet/Black Bolt/089.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Black Bolt"
 
 const card: Card = {
+	dexId: [511],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Black Bolt/090.ts
+++ b/data/Scarlet & Violet/Black Bolt/090.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Black Bolt"
 
 const card: Card = {
+	dexId: [512],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Black Bolt/091.ts
+++ b/data/Scarlet & Violet/Black Bolt/091.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Black Bolt"
 
 const card: Card = {
+	dexId: [548],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Black Bolt/092.ts
+++ b/data/Scarlet & Violet/Black Bolt/092.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Black Bolt"
 
 const card: Card = {
+	dexId: [549],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Black Bolt/093.ts
+++ b/data/Scarlet & Violet/Black Bolt/093.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Black Bolt"
 
 const card: Card = {
+	dexId: [556],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Black Bolt/094.ts
+++ b/data/Scarlet & Violet/Black Bolt/094.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Black Bolt"
 
 const card: Card = {
+	dexId: [588],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Black Bolt/095.ts
+++ b/data/Scarlet & Violet/Black Bolt/095.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Black Bolt"
 
 const card: Card = {
+	dexId: [590],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Black Bolt/096.ts
+++ b/data/Scarlet & Violet/Black Bolt/096.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Black Bolt"
 
 const card: Card = {
+	dexId: [591],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Black Bolt/097.ts
+++ b/data/Scarlet & Violet/Black Bolt/097.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Black Bolt"
 
 const card: Card = {
+	dexId: [554],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Black Bolt/098.ts
+++ b/data/Scarlet & Violet/Black Bolt/098.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Black Bolt"
 
 const card: Card = {
+	dexId: [555],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Black Bolt/099.ts
+++ b/data/Scarlet & Violet/Black Bolt/099.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Black Bolt"
 
 const card: Card = {
+	dexId: [636],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Black Bolt/100.ts
+++ b/data/Scarlet & Violet/Black Bolt/100.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Black Bolt"
 
 const card: Card = {
+	dexId: [637],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Black Bolt/101.ts
+++ b/data/Scarlet & Violet/Black Bolt/101.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Black Bolt"
 
 const card: Card = {
+	dexId: [515],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Black Bolt/102.ts
+++ b/data/Scarlet & Violet/Black Bolt/102.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Black Bolt"
 
 const card: Card = {
+	dexId: [516],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Black Bolt/103.ts
+++ b/data/Scarlet & Violet/Black Bolt/103.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Black Bolt"
 
 const card: Card = {
+	dexId: [535],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Black Bolt/104.ts
+++ b/data/Scarlet & Violet/Black Bolt/104.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Black Bolt"
 
 const card: Card = {
+	dexId: [536],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Black Bolt/105.ts
+++ b/data/Scarlet & Violet/Black Bolt/105.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Black Bolt"
 
 const card: Card = {
+	dexId: [537],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Black Bolt/106.ts
+++ b/data/Scarlet & Violet/Black Bolt/106.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Black Bolt"
 
 const card: Card = {
+	dexId: [564],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Black Bolt/107.ts
+++ b/data/Scarlet & Violet/Black Bolt/107.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Black Bolt"
 
 const card: Card = {
+	dexId: [565],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Black Bolt/108.ts
+++ b/data/Scarlet & Violet/Black Bolt/108.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Black Bolt"
 
 const card: Card = {
+	dexId: [594],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Black Bolt/109.ts
+++ b/data/Scarlet & Violet/Black Bolt/109.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Black Bolt"
 
 const card: Card = {
+	dexId: [613],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Black Bolt/110.ts
+++ b/data/Scarlet & Violet/Black Bolt/110.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Black Bolt"
 
 const card: Card = {
+	dexId: [614],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Black Bolt/111.ts
+++ b/data/Scarlet & Violet/Black Bolt/111.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Black Bolt"
 
 const card: Card = {
+	dexId: [615],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Black Bolt/112.ts
+++ b/data/Scarlet & Violet/Black Bolt/112.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Black Bolt"
 
 const card: Card = {
+	dexId: [587],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Black Bolt/113.ts
+++ b/data/Scarlet & Violet/Black Bolt/113.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Black Bolt"
 
 const card: Card = {
+	dexId: [602],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Black Bolt/114.ts
+++ b/data/Scarlet & Violet/Black Bolt/114.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Black Bolt"
 
 const card: Card = {
+	dexId: [603],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Black Bolt/115.ts
+++ b/data/Scarlet & Violet/Black Bolt/115.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Black Bolt"
 
 const card: Card = {
+	dexId: [604],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Black Bolt/116.ts
+++ b/data/Scarlet & Violet/Black Bolt/116.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Black Bolt"
 
 const card: Card = {
+	dexId: [517],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Black Bolt/117.ts
+++ b/data/Scarlet & Violet/Black Bolt/117.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Black Bolt"
 
 const card: Card = {
+	dexId: [518],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Black Bolt/118.ts
+++ b/data/Scarlet & Violet/Black Bolt/118.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Black Bolt"
 
 const card: Card = {
+	dexId: [577],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Black Bolt/119.ts
+++ b/data/Scarlet & Violet/Black Bolt/119.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Black Bolt"
 
 const card: Card = {
+	dexId: [578],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Black Bolt/120.ts
+++ b/data/Scarlet & Violet/Black Bolt/120.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Black Bolt"
 
 const card: Card = {
+	dexId: [605],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Black Bolt/121.ts
+++ b/data/Scarlet & Violet/Black Bolt/121.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Black Bolt"
 
 const card: Card = {
+	dexId: [606],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Black Bolt/122.ts
+++ b/data/Scarlet & Violet/Black Bolt/122.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Black Bolt"
 
 const card: Card = {
+	dexId: [622],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Black Bolt/123.ts
+++ b/data/Scarlet & Violet/Black Bolt/123.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Black Bolt"
 
 const card: Card = {
+	dexId: [623],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Black Bolt/124.ts
+++ b/data/Scarlet & Violet/Black Bolt/124.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Black Bolt"
 
 const card: Card = {
+	dexId: [529],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Black Bolt/125.ts
+++ b/data/Scarlet & Violet/Black Bolt/125.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Black Bolt"
 
 const card: Card = {
+	dexId: [532],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Black Bolt/126.ts
+++ b/data/Scarlet & Violet/Black Bolt/126.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Black Bolt"
 
 const card: Card = {
+	dexId: [533],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Black Bolt/127.ts
+++ b/data/Scarlet & Violet/Black Bolt/127.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Black Bolt"
 
 const card: Card = {
+	dexId: [534],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Black Bolt/128.ts
+++ b/data/Scarlet & Violet/Black Bolt/128.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Black Bolt"
 
 const card: Card = {
+	dexId: [538],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Black Bolt/129.ts
+++ b/data/Scarlet & Violet/Black Bolt/129.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Black Bolt"
 
 const card: Card = {
+	dexId: [557],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Black Bolt/130.ts
+++ b/data/Scarlet & Violet/Black Bolt/130.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Black Bolt"
 
 const card: Card = {
+	dexId: [558],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Black Bolt/131.ts
+++ b/data/Scarlet & Violet/Black Bolt/131.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Black Bolt"
 
 const card: Card = {
+	dexId: [645],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Black Bolt/132.ts
+++ b/data/Scarlet & Violet/Black Bolt/132.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Black Bolt"
 
 const card: Card = {
+	dexId: [543],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Black Bolt/133.ts
+++ b/data/Scarlet & Violet/Black Bolt/133.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Black Bolt"
 
 const card: Card = {
+	dexId: [544],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Black Bolt/134.ts
+++ b/data/Scarlet & Violet/Black Bolt/134.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Black Bolt"
 
 const card: Card = {
+	dexId: [545],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Black Bolt/135.ts
+++ b/data/Scarlet & Violet/Black Bolt/135.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Black Bolt"
 
 const card: Card = {
+	dexId: [551],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Black Bolt/136.ts
+++ b/data/Scarlet & Violet/Black Bolt/136.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Black Bolt"
 
 const card: Card = {
+	dexId: [552],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Black Bolt/137.ts
+++ b/data/Scarlet & Violet/Black Bolt/137.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Black Bolt"
 
 const card: Card = {
+	dexId: [553],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Black Bolt/138.ts
+++ b/data/Scarlet & Violet/Black Bolt/138.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Black Bolt"
 
 const card: Card = {
+	dexId: [589],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Black Bolt/139.ts
+++ b/data/Scarlet & Violet/Black Bolt/139.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Black Bolt"
 
 const card: Card = {
+	dexId: [599],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Black Bolt/140.ts
+++ b/data/Scarlet & Violet/Black Bolt/140.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Black Bolt"
 
 const card: Card = {
+	dexId: [600],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Black Bolt/141.ts
+++ b/data/Scarlet & Violet/Black Bolt/141.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Black Bolt"
 
 const card: Card = {
+	dexId: [599],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Black Bolt/142.ts
+++ b/data/Scarlet & Violet/Black Bolt/142.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Black Bolt"
 
 const card: Card = {
+	dexId: [624],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Black Bolt/143.ts
+++ b/data/Scarlet & Violet/Black Bolt/143.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Black Bolt"
 
 const card: Card = {
+	dexId: [625],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Black Bolt/144.ts
+++ b/data/Scarlet & Violet/Black Bolt/144.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Black Bolt"
 
 const card: Card = {
+	dexId: [638],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Black Bolt/145.ts
+++ b/data/Scarlet & Violet/Black Bolt/145.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Black Bolt"
 
 const card: Card = {
+	dexId: [610],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Black Bolt/146.ts
+++ b/data/Scarlet & Violet/Black Bolt/146.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Black Bolt"
 
 const card: Card = {
+	dexId: [611],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Black Bolt/147.ts
+++ b/data/Scarlet & Violet/Black Bolt/147.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Black Bolt"
 
 const card: Card = {
+	dexId: [612],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Black Bolt/148.ts
+++ b/data/Scarlet & Violet/Black Bolt/148.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Black Bolt"
 
 const card: Card = {
+	dexId: [519],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Black Bolt/149.ts
+++ b/data/Scarlet & Violet/Black Bolt/149.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Black Bolt"
 
 const card: Card = {
+	dexId: [520],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Black Bolt/150.ts
+++ b/data/Scarlet & Violet/Black Bolt/150.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Black Bolt"
 
 const card: Card = {
+	dexId: [521],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Black Bolt/151.ts
+++ b/data/Scarlet & Violet/Black Bolt/151.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Black Bolt"
 
 const card: Card = {
+	dexId: [531],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Black Bolt/152.ts
+++ b/data/Scarlet & Violet/Black Bolt/152.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Black Bolt"
 
 const card: Card = {
+	dexId: [572],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Black Bolt/153.ts
+++ b/data/Scarlet & Violet/Black Bolt/153.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Black Bolt"
 
 const card: Card = {
+	dexId: [573],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Black Bolt/154.ts
+++ b/data/Scarlet & Violet/Black Bolt/154.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Black Bolt"
 
 const card: Card = {
+	dexId: [627],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Black Bolt/155.ts
+++ b/data/Scarlet & Violet/Black Bolt/155.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Black Bolt"
 
 const card: Card = {
+	dexId: [628],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Black Bolt/156.ts
+++ b/data/Scarlet & Violet/Black Bolt/156.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Black Bolt"
 
 const card: Card = {
+	dexId: [497],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Black Bolt/157.ts
+++ b/data/Scarlet & Violet/Black Bolt/157.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Black Bolt"
 
 const card: Card = {
+	dexId: [646],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Black Bolt/158.ts
+++ b/data/Scarlet & Violet/Black Bolt/158.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Black Bolt"
 
 const card: Card = {
+	dexId: [644],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Black Bolt/159.ts
+++ b/data/Scarlet & Violet/Black Bolt/159.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Black Bolt"
 
 const card: Card = {
+	dexId: [648],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Black Bolt/160.ts
+++ b/data/Scarlet & Violet/Black Bolt/160.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Black Bolt"
 
 const card: Card = {
+	dexId: [530],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Black Bolt/161.ts
+++ b/data/Scarlet & Violet/Black Bolt/161.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Black Bolt"
 
 const card: Card = {
+	dexId: [649],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Black Bolt/164.ts
+++ b/data/Scarlet & Violet/Black Bolt/164.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Black Bolt"
 
 const card: Card = {
+	dexId: [497],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Black Bolt/165.ts
+++ b/data/Scarlet & Violet/Black Bolt/165.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Black Bolt"
 
 const card: Card = {
+	dexId: [646],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Black Bolt/166.ts
+++ b/data/Scarlet & Violet/Black Bolt/166.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Black Bolt"
 
 const card: Card = {
+	dexId: [644],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Black Bolt/167.ts
+++ b/data/Scarlet & Violet/Black Bolt/167.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Black Bolt"
 
 const card: Card = {
+	dexId: [648],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Black Bolt/168.ts
+++ b/data/Scarlet & Violet/Black Bolt/168.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Black Bolt"
 
 const card: Card = {
+	dexId: [530],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Black Bolt/169.ts
+++ b/data/Scarlet & Violet/Black Bolt/169.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Black Bolt"
 
 const card: Card = {
+	dexId: [649],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Black Bolt/171.ts
+++ b/data/Scarlet & Violet/Black Bolt/171.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Black Bolt"
 
 const card: Card = {
+	dexId: [494],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Black Bolt/172.ts
+++ b/data/Scarlet & Violet/Black Bolt/172.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Black Bolt"
 
 const card: Card = {
+	dexId: [644],
 	set: Set,
 
 	name: {


### PR DESCRIPTION
This PR manually adds the missing dexId fields to cards from the Black bolt set.

Details:

Each affected card was updated with its correct Pokédex ID (dexId)