### PR TITLE
feature/add_missing_dex_id_for_destined_rivals

### DIFF
--- a/data/Scarlet & Violet/Destined Rivals/001.ts
+++ b/data/Scarlet & Violet/Destined Rivals/001.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Destined Rivals"
 
 const card: Card = {
+	dexId: [127],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Destined Rivals/002.ts
+++ b/data/Scarlet & Violet/Destined Rivals/002.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Destined Rivals"
 
 const card: Card = {
+	dexId: [193],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Destined Rivals/003.ts
+++ b/data/Scarlet & Violet/Destined Rivals/003.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Destined Rivals"
 
 const card: Card = {
+	dexId: [469],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Destined Rivals/004.ts
+++ b/data/Scarlet & Violet/Destined Rivals/004.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Destined Rivals"
 
 const card: Card = {
+	dexId: [204],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Destined Rivals/005.ts
+++ b/data/Scarlet & Violet/Destined Rivals/005.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Destined Rivals"
 
 const card: Card = {
+	dexId: [285],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Destined Rivals/006.ts
+++ b/data/Scarlet & Violet/Destined Rivals/006.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Destined Rivals"
 
 const card: Card = {
+	dexId: [286],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Destined Rivals/007.ts
+++ b/data/Scarlet & Violet/Destined Rivals/007.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Destined Rivals"
 
 const card: Card = {
+	dexId: [315],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Destined Rivals/008.ts
+++ b/data/Scarlet & Violet/Destined Rivals/008.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Destined Rivals"
 
 const card: Card = {
+	dexId: [407],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Destined Rivals/009.ts
+++ b/data/Scarlet & Violet/Destined Rivals/009.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Destined Rivals"
 
 const card: Card = {
+	dexId: [479],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Destined Rivals/010.ts
+++ b/data/Scarlet & Violet/Destined Rivals/010.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Destined Rivals"
 
 const card: Card = {
+	dexId: [492],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Destined Rivals/011.ts
+++ b/data/Scarlet & Violet/Destined Rivals/011.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Destined Rivals"
 
 const card: Card = {
+	dexId: [557],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Destined Rivals/012.ts
+++ b/data/Scarlet & Violet/Destined Rivals/012.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Destined Rivals"
 
 const card: Card = {
+	dexId: [558],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Destined Rivals/013.ts
+++ b/data/Scarlet & Violet/Destined Rivals/013.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Destined Rivals"
 
 const card: Card = {
+	dexId: [753],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Destined Rivals/014.ts
+++ b/data/Scarlet & Violet/Destined Rivals/014.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Destined Rivals"
 
 const card: Card = {
+	dexId: [754],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Destined Rivals/015.ts
+++ b/data/Scarlet & Violet/Destined Rivals/015.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Destined Rivals"
 
 const card: Card = {
+	dexId: [824],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Destined Rivals/016.ts
+++ b/data/Scarlet & Violet/Destined Rivals/016.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Destined Rivals"
 
 const card: Card = {
+	dexId: [840],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Destined Rivals/017.ts
+++ b/data/Scarlet & Violet/Destined Rivals/017.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Destined Rivals"
 
 const card: Card = {
+	dexId: [1011],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Destined Rivals/018.ts
+++ b/data/Scarlet & Violet/Destined Rivals/018.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Destined Rivals"
 
 const card: Card = {
+	dexId: [1019],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Destined Rivals/019.ts
+++ b/data/Scarlet & Violet/Destined Rivals/019.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Destined Rivals"
 
 const card: Card = {
+	dexId: [917],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Destined Rivals/020.ts
+++ b/data/Scarlet & Violet/Destined Rivals/020.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Destined Rivals"
 
 const card: Card = {
+	dexId: [918],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Destined Rivals/021.ts
+++ b/data/Scarlet & Violet/Destined Rivals/021.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Destined Rivals"
 
 const card: Card = {
+	dexId: [928],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Destined Rivals/022.ts
+++ b/data/Scarlet & Violet/Destined Rivals/022.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Destined Rivals"
 
 const card: Card = {
+	dexId: [929],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Destined Rivals/023.ts
+++ b/data/Scarlet & Violet/Destined Rivals/023.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Destined Rivals"
 
 const card: Card = {
+	dexId: [930],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Destined Rivals/024.ts
+++ b/data/Scarlet & Violet/Destined Rivals/024.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Destined Rivals"
 
 const card: Card = {
+	dexId: [953],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Destined Rivals/025.ts
+++ b/data/Scarlet & Violet/Destined Rivals/025.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Destined Rivals"
 
 const card: Card = {
+	dexId: [954],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Destined Rivals/026.ts
+++ b/data/Scarlet & Violet/Destined Rivals/026.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Destined Rivals"
 
 const card: Card = {
+	dexId: [1017],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Destined Rivals/027.ts
+++ b/data/Scarlet & Violet/Destined Rivals/027.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Destined Rivals"
 
 const card: Card = {
+	dexId: [58],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Destined Rivals/028.ts
+++ b/data/Scarlet & Violet/Destined Rivals/028.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Destined Rivals"
 
 const card: Card = {
+	dexId: [59],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Destined Rivals/029.ts
+++ b/data/Scarlet & Violet/Destined Rivals/029.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Destined Rivals"
 
 const card: Card = {
+	dexId: [77],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Destined Rivals/030.ts
+++ b/data/Scarlet & Violet/Destined Rivals/030.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Destined Rivals"
 
 const card: Card = {
+	dexId: [78],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Destined Rivals/031.ts
+++ b/data/Scarlet & Violet/Destined Rivals/031.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Destined Rivals"
 
 const card: Card = {
+	dexId: [146],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Destined Rivals/032.ts
+++ b/data/Scarlet & Violet/Destined Rivals/032.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Destined Rivals"
 
 const card: Card = {
+	dexId: [155],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Destined Rivals/033.ts
+++ b/data/Scarlet & Violet/Destined Rivals/033.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Destined Rivals"
 
 const card: Card = {
+	dexId: [156],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Destined Rivals/034.ts
+++ b/data/Scarlet & Violet/Destined Rivals/034.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Destined Rivals"
 
 const card: Card = {
+	dexId: [157],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Destined Rivals/035.ts
+++ b/data/Scarlet & Violet/Destined Rivals/035.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Destined Rivals"
 
 const card: Card = {
+	dexId: [218],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Destined Rivals/036.ts
+++ b/data/Scarlet & Violet/Destined Rivals/036.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Destined Rivals"
 
 const card: Card = {
+	dexId: [219],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Destined Rivals/037.ts
+++ b/data/Scarlet & Violet/Destined Rivals/037.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Destined Rivals"
 
 const card: Card = {
+	dexId: [228],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Destined Rivals/038.ts
+++ b/data/Scarlet & Violet/Destined Rivals/038.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Destined Rivals"
 
 const card: Card = {
+	dexId: [229],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Destined Rivals/039.ts
+++ b/data/Scarlet & Violet/Destined Rivals/039.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Destined Rivals"
 
 const card: Card = {
+	dexId: [250],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Destined Rivals/040.ts
+++ b/data/Scarlet & Violet/Destined Rivals/040.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Destined Rivals"
 
 const card: Card = {
+	dexId: [255],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Destined Rivals/041.ts
+++ b/data/Scarlet & Violet/Destined Rivals/041.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Destined Rivals"
 
 const card: Card = {
+	dexId: [256],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Destined Rivals/042.ts
+++ b/data/Scarlet & Violet/Destined Rivals/042.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Destined Rivals"
 
 const card: Card = {
+	dexId: [257],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Destined Rivals/043.ts
+++ b/data/Scarlet & Violet/Destined Rivals/043.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Destined Rivals"
 
 const card: Card = {
+	dexId: [479],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Destined Rivals/044.ts
+++ b/data/Scarlet & Violet/Destined Rivals/044.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Destined Rivals"
 
 const card: Card = {
+	dexId: [1017],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Destined Rivals/045.ts
+++ b/data/Scarlet & Violet/Destined Rivals/045.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Destined Rivals"
 
 const card: Card = {
+	dexId: [54],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Destined Rivals/046.ts
+++ b/data/Scarlet & Violet/Destined Rivals/046.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Destined Rivals"
 
 const card: Card = {
+	dexId: [120],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Destined Rivals/047.ts
+++ b/data/Scarlet & Violet/Destined Rivals/047.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Destined Rivals"
 
 const card: Card = {
+	dexId: [121],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Destined Rivals/048.ts
+++ b/data/Scarlet & Violet/Destined Rivals/048.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Destined Rivals"
 
 const card: Card = {
+	dexId: [129],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Destined Rivals/049.ts
+++ b/data/Scarlet & Violet/Destined Rivals/049.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Destined Rivals"
 
 const card: Card = {
+	dexId: [130],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Destined Rivals/050.ts
+++ b/data/Scarlet & Violet/Destined Rivals/050.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Destined Rivals"
 
 const card: Card = {
+	dexId: [131],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Destined Rivals/051.ts
+++ b/data/Scarlet & Violet/Destined Rivals/051.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Destined Rivals"
 
 const card: Card = {
+	dexId: [144],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Destined Rivals/052.ts
+++ b/data/Scarlet & Violet/Destined Rivals/052.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Destined Rivals"
 
 const card: Card = {
+	dexId: [349],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Destined Rivals/053.ts
+++ b/data/Scarlet & Violet/Destined Rivals/053.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Destined Rivals"
 
 const card: Card = {
+	dexId: [350],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Destined Rivals/054.ts
+++ b/data/Scarlet & Violet/Destined Rivals/054.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Destined Rivals"
 
 const card: Card = {
+	dexId: [366],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Destined Rivals/055.ts
+++ b/data/Scarlet & Violet/Destined Rivals/055.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Destined Rivals"
 
 const card: Card = {
+	dexId: [367],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Destined Rivals/056.ts
+++ b/data/Scarlet & Violet/Destined Rivals/056.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Destined Rivals"
 
 const card: Card = {
+	dexId: [368],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Destined Rivals/057.ts
+++ b/data/Scarlet & Violet/Destined Rivals/057.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Destined Rivals"
 
 const card: Card = {
+	dexId: [418],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Destined Rivals/058.ts
+++ b/data/Scarlet & Violet/Destined Rivals/058.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Destined Rivals"
 
 const card: Card = {
+	dexId: [419],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Destined Rivals/059.ts
+++ b/data/Scarlet & Violet/Destined Rivals/059.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Destined Rivals"
 
 const card: Card = {
+	dexId: [459],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Destined Rivals/060.ts
+++ b/data/Scarlet & Violet/Destined Rivals/060.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Destined Rivals"
 
 const card: Card = {
+	dexId: [460],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Destined Rivals/061.ts
+++ b/data/Scarlet & Violet/Destined Rivals/061.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Destined Rivals"
 
 const card: Card = {
+	dexId: [479],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Destined Rivals/062.ts
+++ b/data/Scarlet & Violet/Destined Rivals/062.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Destined Rivals"
 
 const card: Card = {
+	dexId: [846],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Destined Rivals/063.ts
+++ b/data/Scarlet & Violet/Destined Rivals/063.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Destined Rivals"
 
 const card: Card = {
+	dexId: [847],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Destined Rivals/064.ts
+++ b/data/Scarlet & Violet/Destined Rivals/064.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Destined Rivals"
 
 const card: Card = {
+	dexId: [974],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Destined Rivals/065.ts
+++ b/data/Scarlet & Violet/Destined Rivals/065.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Destined Rivals"
 
 const card: Card = {
+	dexId: [975],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Destined Rivals/066.ts
+++ b/data/Scarlet & Violet/Destined Rivals/066.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Destined Rivals"
 
 const card: Card = {
+	dexId: [977],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Destined Rivals/067.ts
+++ b/data/Scarlet & Violet/Destined Rivals/067.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Destined Rivals"
 
 const card: Card = {
+	dexId: [1017],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Destined Rivals/068.ts
+++ b/data/Scarlet & Violet/Destined Rivals/068.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Destined Rivals"
 
 const card: Card = {
+	dexId: [125],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Destined Rivals/069.ts
+++ b/data/Scarlet & Violet/Destined Rivals/069.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Destined Rivals"
 
 const card: Card = {
+	dexId: [466],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Destined Rivals/070.ts
+++ b/data/Scarlet & Violet/Destined Rivals/070.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Destined Rivals"
 
 const card: Card = {
+	dexId: [145],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Destined Rivals/071.ts
+++ b/data/Scarlet & Violet/Destined Rivals/071.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Destined Rivals"
 
 const card: Card = {
+	dexId: [172],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Destined Rivals/072.ts
+++ b/data/Scarlet & Violet/Destined Rivals/072.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Destined Rivals"
 
 const card: Card = {
+	dexId: [179],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Destined Rivals/073.ts
+++ b/data/Scarlet & Violet/Destined Rivals/073.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Destined Rivals"
 
 const card: Card = {
+	dexId: [180],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Destined Rivals/074.ts
+++ b/data/Scarlet & Violet/Destined Rivals/074.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Destined Rivals"
 
 const card: Card = {
+	dexId: [181],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Destined Rivals/075.ts
+++ b/data/Scarlet & Violet/Destined Rivals/075.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Destined Rivals"
 
 const card: Card = {
+	dexId: [309],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Destined Rivals/076.ts
+++ b/data/Scarlet & Violet/Destined Rivals/076.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Destined Rivals"
 
 const card: Card = {
+	dexId: [310],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Destined Rivals/077.ts
+++ b/data/Scarlet & Violet/Destined Rivals/077.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Destined Rivals"
 
 const card: Card = {
+	dexId: [479],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Destined Rivals/078.ts
+++ b/data/Scarlet & Violet/Destined Rivals/078.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Destined Rivals"
 
 const card: Card = {
+	dexId: [807],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Destined Rivals/079.ts
+++ b/data/Scarlet & Violet/Destined Rivals/079.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Destined Rivals"
 
 const card: Card = {
+	dexId: [96],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Destined Rivals/080.ts
+++ b/data/Scarlet & Violet/Destined Rivals/080.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Destined Rivals"
 
 const card: Card = {
+	dexId: [97],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Destined Rivals/081.ts
+++ b/data/Scarlet & Violet/Destined Rivals/081.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Destined Rivals"
 
 const card: Card = {
+	dexId: [150],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Destined Rivals/082.ts
+++ b/data/Scarlet & Violet/Destined Rivals/082.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Destined Rivals"
 
 const card: Card = {
+	dexId: [202],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Destined Rivals/083.ts
+++ b/data/Scarlet & Violet/Destined Rivals/083.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Destined Rivals"
 
 const card: Card = {
+	dexId: [343],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Destined Rivals/084.ts
+++ b/data/Scarlet & Violet/Destined Rivals/084.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Destined Rivals"
 
 const card: Card = {
+	dexId: [344],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Destined Rivals/085.ts
+++ b/data/Scarlet & Violet/Destined Rivals/085.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Destined Rivals"
 
 const card: Card = {
+	dexId: [433],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Destined Rivals/086.ts
+++ b/data/Scarlet & Violet/Destined Rivals/086.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Destined Rivals"
 
 const card: Card = {
+	dexId: [703],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Destined Rivals/087.ts
+++ b/data/Scarlet & Violet/Destined Rivals/087.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Destined Rivals"
 
 const card: Card = {
+	dexId: [778],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Destined Rivals/088.ts
+++ b/data/Scarlet & Violet/Destined Rivals/088.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Destined Rivals"
 
 const card: Card = {
+	dexId: [825],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Destined Rivals/089.ts
+++ b/data/Scarlet & Violet/Destined Rivals/089.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Destined Rivals"
 
 const card: Card = {
+	dexId: [826],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Destined Rivals/090.ts
+++ b/data/Scarlet & Violet/Destined Rivals/090.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Destined Rivals"
 
 const card: Card = {
+	dexId: [56],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Destined Rivals/091.ts
+++ b/data/Scarlet & Violet/Destined Rivals/091.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Destined Rivals"
 
 const card: Card = {
+	dexId: [57],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Destined Rivals/092.ts
+++ b/data/Scarlet & Violet/Destined Rivals/092.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Destined Rivals"
 
 const card: Card = {
+	dexId: [979],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Destined Rivals/093.ts
+++ b/data/Scarlet & Violet/Destined Rivals/093.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Destined Rivals"
 
 const card: Card = {
+	dexId: [185],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Destined Rivals/094.ts
+++ b/data/Scarlet & Violet/Destined Rivals/094.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Destined Rivals"
 
 const card: Card = {
+	dexId: [246],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Destined Rivals/095.ts
+++ b/data/Scarlet & Violet/Destined Rivals/095.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Destined Rivals"
 
 const card: Card = {
+	dexId: [247],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Destined Rivals/096.ts
+++ b/data/Scarlet & Violet/Destined Rivals/096.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Destined Rivals"
 
 const card: Card = {
+	dexId: [248],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Destined Rivals/097.ts
+++ b/data/Scarlet & Violet/Destined Rivals/097.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Destined Rivals"
 
 const card: Card = {
+	dexId: [299],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Destined Rivals/098.ts
+++ b/data/Scarlet & Violet/Destined Rivals/098.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Destined Rivals"
 
 const card: Card = {
+	dexId: [299],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Destined Rivals/099.ts
+++ b/data/Scarlet & Violet/Destined Rivals/099.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Destined Rivals"
 
 const card: Card = {
+	dexId: [307],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Destined Rivals/100.ts
+++ b/data/Scarlet & Violet/Destined Rivals/100.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Destined Rivals"
 
 const card: Card = {
+	dexId: [308],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Destined Rivals/101.ts
+++ b/data/Scarlet & Violet/Destined Rivals/101.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Destined Rivals"
 
 const card: Card = {
+	dexId: [377],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Destined Rivals/102.ts
+++ b/data/Scarlet & Violet/Destined Rivals/102.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Destined Rivals"
 
 const card: Card = {
+	dexId: [443],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Destined Rivals/103.ts
+++ b/data/Scarlet & Violet/Destined Rivals/103.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Destined Rivals"
 
 const card: Card = {
+	dexId: [444],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Destined Rivals/104.ts
+++ b/data/Scarlet & Violet/Destined Rivals/104.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Destined Rivals"
 
 const card: Card = {
+	dexId: [445],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Destined Rivals/105.ts
+++ b/data/Scarlet & Violet/Destined Rivals/105.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Destined Rivals"
 
 const card: Card = {
+	dexId: [449],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Destined Rivals/106.ts
+++ b/data/Scarlet & Violet/Destined Rivals/106.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Destined Rivals"
 
 const card: Card = {
+	dexId: [450],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Destined Rivals/107.ts
+++ b/data/Scarlet & Violet/Destined Rivals/107.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Destined Rivals"
 
 const card: Card = {
+	dexId: [749],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Destined Rivals/108.ts
+++ b/data/Scarlet & Violet/Destined Rivals/108.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Destined Rivals"
 
 const card: Card = {
+	dexId: [750],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Destined Rivals/109.ts
+++ b/data/Scarlet & Violet/Destined Rivals/109.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Destined Rivals"
 
 const card: Card = {
+	dexId: [948],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Destined Rivals/110.ts
+++ b/data/Scarlet & Violet/Destined Rivals/110.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Destined Rivals"
 
 const card: Card = {
+	dexId: [949],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Destined Rivals/111.ts
+++ b/data/Scarlet & Violet/Destined Rivals/111.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Destined Rivals"
 
 const card: Card = {
+	dexId: [1017],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Destined Rivals/112.ts
+++ b/data/Scarlet & Violet/Destined Rivals/112.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Destined Rivals"
 
 const card: Card = {
+	dexId: [23],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Destined Rivals/113.ts
+++ b/data/Scarlet & Violet/Destined Rivals/113.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Destined Rivals"
 
 const card: Card = {
+	dexId: [24],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Destined Rivals/114.ts
+++ b/data/Scarlet & Violet/Destined Rivals/114.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Destined Rivals"
 
 const card: Card = {
+	dexId: [29],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Destined Rivals/115.ts
+++ b/data/Scarlet & Violet/Destined Rivals/115.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Destined Rivals"
 
 const card: Card = {
+	dexId: [30],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Destined Rivals/116.ts
+++ b/data/Scarlet & Violet/Destined Rivals/116.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Destined Rivals"
 
 const card: Card = {
+	dexId: [31],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Destined Rivals/117.ts
+++ b/data/Scarlet & Violet/Destined Rivals/117.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Destined Rivals"
 
 const card: Card = {
+	dexId: [32],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Destined Rivals/118.ts
+++ b/data/Scarlet & Violet/Destined Rivals/118.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Destined Rivals"
 
 const card: Card = {
+	dexId: [33],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Destined Rivals/119.ts
+++ b/data/Scarlet & Violet/Destined Rivals/119.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Destined Rivals"
 
 const card: Card = {
+	dexId: [34],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Destined Rivals/120.ts
+++ b/data/Scarlet & Violet/Destined Rivals/120.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Destined Rivals"
 
 const card: Card = {
+	dexId: [41],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Destined Rivals/121.ts
+++ b/data/Scarlet & Violet/Destined Rivals/121.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Destined Rivals"
 
 const card: Card = {
+	dexId: [42],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Destined Rivals/122.ts
+++ b/data/Scarlet & Violet/Destined Rivals/122.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Destined Rivals"
 
 const card: Card = {
+	dexId: [169],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Destined Rivals/123.ts
+++ b/data/Scarlet & Violet/Destined Rivals/123.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Destined Rivals"
 
 const card: Card = {
+	dexId: [88],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Destined Rivals/124.ts
+++ b/data/Scarlet & Violet/Destined Rivals/124.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Destined Rivals"
 
 const card: Card = {
+	dexId: [88],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Destined Rivals/125.ts
+++ b/data/Scarlet & Violet/Destined Rivals/125.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Destined Rivals"
 
 const card: Card = {
+	dexId: [109],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Destined Rivals/126.ts
+++ b/data/Scarlet & Violet/Destined Rivals/126.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Destined Rivals"
 
 const card: Card = {
+	dexId: [109],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Destined Rivals/127.ts
+++ b/data/Scarlet & Violet/Destined Rivals/127.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Destined Rivals"
 
 const card: Card = {
+	dexId: [198],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Destined Rivals/128.ts
+++ b/data/Scarlet & Violet/Destined Rivals/128.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Destined Rivals"
 
 const card: Card = {
+	dexId: [215],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Destined Rivals/129.ts
+++ b/data/Scarlet & Violet/Destined Rivals/129.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Destined Rivals"
 
 const card: Card = {
+	dexId: [442],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Destined Rivals/130.ts
+++ b/data/Scarlet & Violet/Destined Rivals/130.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Destined Rivals"
 
 const card: Card = {
+	dexId: [509],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Destined Rivals/131.ts
+++ b/data/Scarlet & Violet/Destined Rivals/131.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Destined Rivals"
 
 const card: Card = {
+	dexId: [510],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Destined Rivals/132.ts
+++ b/data/Scarlet & Violet/Destined Rivals/132.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Destined Rivals"
 
 const card: Card = {
+	dexId: [559],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Destined Rivals/133.ts
+++ b/data/Scarlet & Violet/Destined Rivals/133.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Destined Rivals"
 
 const card: Card = {
+	dexId: [560],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Destined Rivals/134.ts
+++ b/data/Scarlet & Violet/Destined Rivals/134.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Destined Rivals"
 
 const card: Card = {
+	dexId: [859],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Destined Rivals/135.ts
+++ b/data/Scarlet & Violet/Destined Rivals/135.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Destined Rivals"
 
 const card: Card = {
+	dexId: [860],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Destined Rivals/136.ts
+++ b/data/Scarlet & Violet/Destined Rivals/136.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Destined Rivals"
 
 const card: Card = {
+	dexId: [861],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Destined Rivals/137.ts
+++ b/data/Scarlet & Violet/Destined Rivals/137.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Destined Rivals"
 
 const card: Card = {
+	dexId: [877],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Destined Rivals/138.ts
+++ b/data/Scarlet & Violet/Destined Rivals/138.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Destined Rivals"
 
 const card: Card = {
+	dexId: [942],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Destined Rivals/139.ts
+++ b/data/Scarlet & Violet/Destined Rivals/139.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Destined Rivals"
 
 const card: Card = {
+	dexId: [943],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Destined Rivals/140.ts
+++ b/data/Scarlet & Violet/Destined Rivals/140.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Destined Rivals"
 
 const card: Card = {
+	dexId: [205],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Destined Rivals/141.ts
+++ b/data/Scarlet & Violet/Destined Rivals/141.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Destined Rivals"
 
 const card: Card = {
+	dexId: [227],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Destined Rivals/142.ts
+++ b/data/Scarlet & Violet/Destined Rivals/142.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Destined Rivals"
 
 const card: Card = {
+	dexId: [227],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Destined Rivals/143.ts
+++ b/data/Scarlet & Violet/Destined Rivals/143.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Destined Rivals"
 
 const card: Card = {
+	dexId: [374],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Destined Rivals/144.ts
+++ b/data/Scarlet & Violet/Destined Rivals/144.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Destined Rivals"
 
 const card: Card = {
+	dexId: [375],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Destined Rivals/145.ts
+++ b/data/Scarlet & Violet/Destined Rivals/145.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Destined Rivals"
 
 const card: Card = {
+	dexId: [376],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Destined Rivals/146.ts
+++ b/data/Scarlet & Violet/Destined Rivals/146.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Destined Rivals"
 
 const card: Card = {
+	dexId: [889],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Destined Rivals/147.ts
+++ b/data/Scarlet & Violet/Destined Rivals/147.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Destined Rivals"
 
 const card: Card = {
+	dexId: [19],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Destined Rivals/148.ts
+++ b/data/Scarlet & Violet/Destined Rivals/148.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Destined Rivals"
 
 const card: Card = {
+	dexId: [20],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Destined Rivals/149.ts
+++ b/data/Scarlet & Violet/Destined Rivals/149.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Destined Rivals"
 
 const card: Card = {
+	dexId: [52],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Destined Rivals/150.ts
+++ b/data/Scarlet & Violet/Destined Rivals/150.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Destined Rivals"
 
 const card: Card = {
+	dexId: [53],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Destined Rivals/151.ts
+++ b/data/Scarlet & Violet/Destined Rivals/151.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Destined Rivals"
 
 const card: Card = {
+	dexId: [115],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Destined Rivals/152.ts
+++ b/data/Scarlet & Violet/Destined Rivals/152.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Destined Rivals"
 
 const card: Card = {
+	dexId: [128],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Destined Rivals/153.ts
+++ b/data/Scarlet & Violet/Destined Rivals/153.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Destined Rivals"
 
 const card: Card = {
+	dexId: [137],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Destined Rivals/154.ts
+++ b/data/Scarlet & Violet/Destined Rivals/154.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Destined Rivals"
 
 const card: Card = {
+	dexId: [137],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Destined Rivals/155.ts
+++ b/data/Scarlet & Violet/Destined Rivals/155.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Destined Rivals"
 
 const card: Card = {
+	dexId: [137],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Destined Rivals/156.ts
+++ b/data/Scarlet & Violet/Destined Rivals/156.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Destined Rivals"
 
 const card: Card = {
+	dexId: [276],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Destined Rivals/157.ts
+++ b/data/Scarlet & Violet/Destined Rivals/157.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Destined Rivals"
 
 const card: Card = {
+	dexId: [277],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Destined Rivals/158.ts
+++ b/data/Scarlet & Violet/Destined Rivals/158.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Destined Rivals"
 
 const card: Card = {
+	dexId: [819],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Destined Rivals/159.ts
+++ b/data/Scarlet & Violet/Destined Rivals/159.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Destined Rivals"
 
 const card: Card = {
+	dexId: [820],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Destined Rivals/160.ts
+++ b/data/Scarlet & Violet/Destined Rivals/160.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Destined Rivals"
 
 const card: Card = {
+	dexId: [931],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Destined Rivals/183.ts
+++ b/data/Scarlet & Violet/Destined Rivals/183.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Destined Rivals"
 
 const card: Card = {
+	dexId: [193],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Destined Rivals/184.ts
+++ b/data/Scarlet & Violet/Destined Rivals/184.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Destined Rivals"
 
 const card: Card = {
+	dexId: [407],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Destined Rivals/185.ts
+++ b/data/Scarlet & Violet/Destined Rivals/185.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Destined Rivals"
 
 const card: Card = {
+	dexId: [492],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Destined Rivals/186.ts
+++ b/data/Scarlet & Violet/Destined Rivals/186.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Destined Rivals"
 
 const card: Card = {
+	dexId: [558],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Destined Rivals/187.ts
+++ b/data/Scarlet & Violet/Destined Rivals/187.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Destined Rivals"
 
 const card: Card = {
+	dexId: [918],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Destined Rivals/188.ts
+++ b/data/Scarlet & Violet/Destined Rivals/188.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Destined Rivals"
 
 const card: Card = {
+	dexId: [1019],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Destined Rivals/189.ts
+++ b/data/Scarlet & Violet/Destined Rivals/189.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Destined Rivals"
 
 const card: Card = {
+	dexId: [78],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Destined Rivals/190.ts
+++ b/data/Scarlet & Violet/Destined Rivals/190.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Destined Rivals"
 
 const card: Card = {
+	dexId: [157],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Destined Rivals/191.ts
+++ b/data/Scarlet & Violet/Destined Rivals/191.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Destined Rivals"
 
 const card: Card = {
+	dexId: [229],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Destined Rivals/192.ts
+++ b/data/Scarlet & Violet/Destined Rivals/192.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Destined Rivals"
 
 const card: Card = {
+	dexId: [257],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Destined Rivals/193.ts
+++ b/data/Scarlet & Violet/Destined Rivals/193.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Destined Rivals"
 
 const card: Card = {
+	dexId: [54],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Destined Rivals/194.ts
+++ b/data/Scarlet & Violet/Destined Rivals/194.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Destined Rivals"
 
 const card: Card = {
+	dexId: [131],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Destined Rivals/195.ts
+++ b/data/Scarlet & Violet/Destined Rivals/195.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Destined Rivals"
 
 const card: Card = {
+	dexId: [366],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Destined Rivals/196.ts
+++ b/data/Scarlet & Violet/Destined Rivals/196.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Destined Rivals"
 
 const card: Card = {
+	dexId: [309],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Destined Rivals/197.ts
+++ b/data/Scarlet & Violet/Destined Rivals/197.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Destined Rivals"
 
 const card: Card = {
+	dexId: [479],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Destined Rivals/198.ts
+++ b/data/Scarlet & Violet/Destined Rivals/198.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Destined Rivals"
 
 const card: Card = {
+	dexId: [826],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Destined Rivals/199.ts
+++ b/data/Scarlet & Violet/Destined Rivals/199.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Destined Rivals"
 
 const card: Card = {
+	dexId: [109],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Destined Rivals/200.ts
+++ b/data/Scarlet & Violet/Destined Rivals/200.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Destined Rivals"
 
 const card: Card = {
+	dexId: [198],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Destined Rivals/201.ts
+++ b/data/Scarlet & Violet/Destined Rivals/201.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Destined Rivals"
 
 const card: Card = {
+	dexId: [889],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Destined Rivals/202.ts
+++ b/data/Scarlet & Violet/Destined Rivals/202.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Destined Rivals"
 
 const card: Card = {
+	dexId: [20],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Destined Rivals/203.ts
+++ b/data/Scarlet & Violet/Destined Rivals/203.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Destined Rivals"
 
 const card: Card = {
+	dexId: [52],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Destined Rivals/204.ts
+++ b/data/Scarlet & Violet/Destined Rivals/204.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Destined Rivals"
 
 const card: Card = {
+	dexId: [115],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Destined Rivals/205.ts
+++ b/data/Scarlet & Violet/Destined Rivals/205.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Destined Rivals"
 
 const card: Card = {
+	dexId: [820],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Destined Rivals/206.ts
+++ b/data/Scarlet & Violet/Destined Rivals/206.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Destined Rivals"
 
 const card: Card = {
+	dexId: [469],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Destined Rivals/207.ts
+++ b/data/Scarlet & Violet/Destined Rivals/207.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Destined Rivals"
 
 const card: Card = {
+	dexId: [930],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Destined Rivals/208.ts
+++ b/data/Scarlet & Violet/Destined Rivals/208.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Destined Rivals"
 
 const card: Card = {
+	dexId: [146],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Destined Rivals/209.ts
+++ b/data/Scarlet & Violet/Destined Rivals/209.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Destined Rivals"
 
 const card: Card = {
+	dexId: [250],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Destined Rivals/210.ts
+++ b/data/Scarlet & Violet/Destined Rivals/210.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Destined Rivals"
 
 const card: Card = {
+	dexId: [975],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Destined Rivals/211.ts
+++ b/data/Scarlet & Violet/Destined Rivals/211.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Destined Rivals"
 
 const card: Card = {
+	dexId: [977],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Destined Rivals/212.ts
+++ b/data/Scarlet & Violet/Destined Rivals/212.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Destined Rivals"
 
 const card: Card = {
+	dexId: [466],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Destined Rivals/213.ts
+++ b/data/Scarlet & Violet/Destined Rivals/213.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Destined Rivals"
 
 const card: Card = {
+	dexId: [150],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Destined Rivals/214.ts
+++ b/data/Scarlet & Violet/Destined Rivals/214.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Destined Rivals"
 
 const card: Card = {
+	dexId: [377],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Destined Rivals/215.ts
+++ b/data/Scarlet & Violet/Destined Rivals/215.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Destined Rivals"
 
 const card: Card = {
+	dexId: [445],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Destined Rivals/216.ts
+++ b/data/Scarlet & Violet/Destined Rivals/216.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Destined Rivals"
 
 const card: Card = {
+	dexId: [34],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Destined Rivals/217.ts
+++ b/data/Scarlet & Violet/Destined Rivals/217.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Destined Rivals"
 
 const card: Card = {
+	dexId: [169],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Destined Rivals/218.ts
+++ b/data/Scarlet & Violet/Destined Rivals/218.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Destined Rivals"
 
 const card: Card = {
+	dexId: [943],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Destined Rivals/219.ts
+++ b/data/Scarlet & Violet/Destined Rivals/219.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Destined Rivals"
 
 const card: Card = {
+	dexId: [53],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Destined Rivals/228.ts
+++ b/data/Scarlet & Violet/Destined Rivals/228.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Destined Rivals"
 
 const card: Card = {
+	dexId: [469],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Destined Rivals/229.ts
+++ b/data/Scarlet & Violet/Destined Rivals/229.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Destined Rivals"
 
 const card: Card = {
+	dexId: [146],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Destined Rivals/230.ts
+++ b/data/Scarlet & Violet/Destined Rivals/230.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Destined Rivals"
 
 const card: Card = {
+	dexId: [250],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Destined Rivals/231.ts
+++ b/data/Scarlet & Violet/Destined Rivals/231.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Destined Rivals"
 
 const card: Card = {
+	dexId: [150],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Destined Rivals/232.ts
+++ b/data/Scarlet & Violet/Destined Rivals/232.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Destined Rivals"
 
 const card: Card = {
+	dexId: [445],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Destined Rivals/233.ts
+++ b/data/Scarlet & Violet/Destined Rivals/233.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Destined Rivals"
 
 const card: Card = {
+	dexId: [34],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Destined Rivals/234.ts
+++ b/data/Scarlet & Violet/Destined Rivals/234.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Destined Rivals"
 
 const card: Card = {
+	dexId: [169],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Destined Rivals/235.ts
+++ b/data/Scarlet & Violet/Destined Rivals/235.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Destined Rivals"
 
 const card: Card = {
+	dexId: [943],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Destined Rivals/239.ts
+++ b/data/Scarlet & Violet/Destined Rivals/239.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Destined Rivals"
 
 const card: Card = {
+	dexId: [250],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Destined Rivals/240.ts
+++ b/data/Scarlet & Violet/Destined Rivals/240.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Destined Rivals"
 
 const card: Card = {
+	dexId: [150],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Destined Rivals/241.ts
+++ b/data/Scarlet & Violet/Destined Rivals/241.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Destined Rivals"
 
 const card: Card = {
+	dexId: [445],
 	set: Set,
 
 	name: {

--- a/data/Scarlet & Violet/Destined Rivals/242.ts
+++ b/data/Scarlet & Violet/Destined Rivals/242.ts
@@ -2,6 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Destined Rivals"
 
 const card: Card = {
+	dexId: [169],
 	set: Set,
 
 	name: {


### PR DESCRIPTION
This PR manually adds the missing dexId fields to cards from the Destined Rivals set.

Details:

Each affected card was updated with its correct Pokédex ID (dexId)