### PR TITLE
fix: Replace '=' with '-' in 'Ho-Oh' in Wisdom of Sea 

### DIFF
--- a/data/Pokémon TCG Pocket/Wisdom of Sea and Sky.ts
+++ b/data/Pokémon TCG Pocket/Wisdom of Sea and Sky.ts
@@ -30,7 +30,7 @@ const set: Set = {
 		},
 		'ho-oh': {
 			name: {
-				en: 'Ho=Oh'
+				en: 'Ho-Oh'
 			}
 		}
 	}


### PR DESCRIPTION
Fix a typo in the name 'Ho-Oh' of the Booster pPack in Wisdom of Sea and Sky in Pocket
