### PR TITLE
fix: Update SV/DRI/144 variants

### DIFF
--- a/data/Scarlet & Violet/Destined Rivals/144.ts
+++ b/data/Scarlet & Violet/Destined Rivals/144.ts
@@ -50,8 +50,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: {
-		normal: false,
-		reverse: false
+		holo: false
 	}
 }
 


### PR DESCRIPTION
Card is not available in Holo, only normal/reverse

<!--
Thanks for your Pull Request, Please provide the related Issue using "Fix #0" or describe the change(s) you made.
The issue title must follow Conventional Commit conventionalcommits.org.
More informations at https://github.com/tcgdex/cards-database/blob/master/CONTRIBUTING.md
-->
