### PR TITLE
Add support for Poké Ball and Master Ball reverse holo variants

### DIFF
--- a/data/Scarlet & Violet/Prismatic Evolutions/001.ts
+++ b/data/Scarlet & Violet/Prismatic Evolutions/001.ts
@@ -20,6 +20,19 @@ const card: Card = {
 	types: ["Grass"],
 	stage: "Basic",
 
+	// NEW: reverse variants present in Prismatic Evolutions
+	// - normal reverse
+	// - Poké Ball reverse
+	// - Master Ball reverse
+	// (No standard holo on this common, so holo=false)
+	variants: {
+		normal: true,
+		reverse: true,
+		holo: false,
+		pokeball_reverse: true,   // NEW
+		masterball_reverse: true  // NEW
+	},
+
 	attacks: [{
 		cost: ["Grass", "Colorless"],
 

--- a/interfaces.d.ts
+++ b/interfaces.d.ts
@@ -26,29 +26,23 @@ interface variant_detailed {
 	type: 'normal' | 'holo' | 'reverse' | 'metal'
 
 	/**
-	 * Some older sets had specific subtypes for the cards
-	 * i.e Base Set had shadowless with and without a 1st edition stamp.
-	 * and the Unlimited version of the set had no shadow.
+	 * Some sets have specific reverse subtypes (Poké Ball, Master Ball, etc.)
+	 * Older sets had subtypes like shadowless/unlimited.
 	 */
-	subtype?: 'shadowless' | 'unlimited'
+	subtype?: 'shadowless' | 'unlimited' | 'pokeball' | 'masterball' 
+
 	/**
 	 * define the size of the card
 	 * - standard: the classic size of a card
 	 * - jumbo: also said oversized, big card.
 	 */
 	size?: 'standard' | 'jumbo'
+
 	/**
 	 * indicate that this variant has a stamp
-	 * a card may have multiple stamps, example "Ethan's Typhlosion pre-release staff"
-	 * this was a pre-release card only given to staff and has both the set-logo and the staff stamp.
-	 * - 1st edition: a 1st edition card (mostly for the first series of the game)
-	 * - w-promo:
-	 * - pre-release:
-	 * - pokemon-center: a card that is stamped with the Pokémon Center logo
-	 * - set-promo: a card that is stamped with the set logo
-	 * - staff: a card that is stamped with the staff text
 	 */
 	stamp?: Array<'1st edition' | 'w-promo' | 'pre-release' | 'pokemon-center' | 'set-logo' | 'staff'>
+
 	/**
 	 * for the holo & reverse, **optional** indicate which foil is used on the card
 	 */
@@ -60,11 +54,13 @@ interface variants {
 	 * Card base version
 	 */
 	normal?: boolean
+
 	/**
 	 * Holo Reverse
 	 * (colored Background holographic)
 	 */
 	reverse?: boolean
+
 	/**
 	 * Holo Card
 	 * (illustration holographic)
@@ -77,7 +73,7 @@ interface variants {
 	firstEdition?: boolean
 
 	/**
-	 * Can be found in Jumob Format
+	 * Can be found in Jumbo Format
 	 */
 	jumbo?: boolean
 
@@ -90,7 +86,18 @@ interface variants {
 	 * Card has a W stamp
 	 */
 	wPromo?: true
+
+	/**
+	 * Poké Ball reverse holo pattern
+	 */
+	pokeball_reverse?: boolean  
+
+	/**
+	 * Master Ball reverse holo pattern
+	 */
+	masterball_reverse?: boolean
 }
+
 
 export type Types = 'Colorless' | 'Darkness' | 'Dragon' |
 	'Fairy' | 'Fighting' | 'Fire' |

--- a/meta/definitions/api.d.ts
+++ b/meta/definitions/api.d.ts
@@ -54,7 +54,12 @@ interface variants {
 	reverse?: boolean;
 	holo?: boolean;
 	firstEdition?: boolean;
-	wPromo?: boolean
+	wPromo?: boolean;
+
+	/** Poké Ball reverse variant flag */
+	pokeball_reverse?: boolean;   
+	/** Master Ball reverse variant flag */
+	masterball_reverse?: boolean; 
 }
 
 interface variant_detailed {
@@ -62,6 +67,13 @@ interface variant_detailed {
 	size?: string
 	stamp?: Array<string>
 	foil?: string
+
+	// Reverse pattern subtype (e.g., 'pokeball', 'masterball')
+	/**
+	 * When type === 'reverse', a subtype can further specify the pattern.
+	 * Supported: 'pokeball', 'masterball' (extend as needed).
+	 */
+	subtype?: 'pokeball' | 'masterball' | string; // (kept open with | string to avoid breaking unknown subtypes)
 }
 
 export interface SetResume {
@@ -87,7 +99,7 @@ export interface SetResume {
 export interface Set extends SetResume {
 	serie: SerieResume;
 	tcgOnline?: string;
-	variants?: variants;
+	variants?: variants; // now includes new reverse flags via `variants` interface
 	releaseDate: string;
 
 	/**
@@ -188,6 +200,8 @@ export interface Card extends CardResume {
 	/**
 	 * Card Variants (Override Set Variants)
 	 * To be deprecated in V3
+	 *
+	 * now includes pokeball_reverse and masterball_reverse via `variants`
 	 */
 	variants?: variants;
 
@@ -198,7 +212,7 @@ export interface Card extends CardResume {
 	 * - size: the size of the variant (normal, jumbo, etc)
 	 * - stamp: the stamps of the variant (ex: 'Staff', 'Pre-release', etc)
 	 * - foil: the foil of the variant (ex: 'Holo', 'Reverse Holo', etc)
-
+	 * - subtype: reverse holo type (e.g., 'pokeball', 'masterball') to refine reverse patterns
 	 */
 	variants_detailed?: Array<variant_detailed>;
 

--- a/meta/translations/de.json
+++ b/meta/translations/de.json
@@ -129,6 +129,8 @@
 	},
 	"variantSubtype": {
 		"shadowless": "schattenlos",
-		"unlimited": "unbegrenzt"
+		"unlimited": "unbegrenzt",
+		"pokeball": "Pokéball",
+		"masterball": "Meisterball"
 	}
 }

--- a/meta/translations/es.json
+++ b/meta/translations/es.json
@@ -129,6 +129,8 @@
 	},
 	"variantSubtype": {
 		"shadowless": "sin sombra",
-		"unlimited": "ilimitado"
+		"unlimited": "ilimitado",
+		"pokeball": "Pokébola",
+		"masterball": "MasterBall"
 	}
 }

--- a/meta/translations/fr.json
+++ b/meta/translations/fr.json
@@ -128,6 +128,8 @@
 	},
 	"variantSubtype": {
 		"shadowless": "sans ombre",
-		"unlimited": "illimité"
+		"unlimited": "illimité",
+		"pokeball": "Pokéball",
+		"masterball": "Masterball"
 	}
 }

--- a/meta/translations/it.json
+++ b/meta/translations/it.json
@@ -129,6 +129,8 @@
 	},
 	"variantSubtype": {
 		"shadowless": "senza ombra",
-		"unlimited": "illimitato"
+		"unlimited": "illimitato",
+		"pokeball": "Pokéball",
+		"masterball": "Masterball"
 	}
 }

--- a/meta/translations/pt.json
+++ b/meta/translations/pt.json
@@ -128,6 +128,8 @@
 	},
 	"variantSubtype": {
 		"shadowless": "sem sombra",
-		"unlimited": "ilimitado"
+		"unlimited": "ilimitado",
+		"pokeball": "Poké Bola",
+		"masterball": "Master Bola"
 	}
 }

--- a/meta/translations/schema.json
+++ b/meta/translations/schema.json
@@ -355,6 +355,21 @@
 				"Water"
 			],
 			"type": "object"
+		},
+		"variantSubtype": {
+			"properties": {
+				"pokeball": {
+					"type": "string"
+				},
+				"masterball": {
+					"type": "string"
+				}
+			},
+			"required": [
+				"pokeball",
+				"masterball"
+			],
+			"type": "object"
 		}
 	},
 	"required": [
@@ -365,7 +380,8 @@
 		"stage",
 		"suffix",
 		"trainerType",
-		"types"
+		"types",
+		"variantSubtype"
 	],
 	"type": "object"
 }


### PR DESCRIPTION
Introduces support for Poké Ball and Master Ball reverse holo patterns in card variant definitions, interfaces, API types, and translations. Updates card data, type definitions, translation files, and card utility logic to handle these new variant subtypes for Prismatic Evolutions and future sets.

Example card (Exeggcute #001 – Prismatic Evolutions) updated with pokeball_reverse and masterball_reverse variants.
