### PR TITLE
Fix: Release date null

### DIFF
--- a/meta/definitions/graphql.gql
+++ b/meta/definitions/graphql.gql
@@ -386,7 +386,7 @@ type Set {
 	serie: Serie!
 
 	"""The set official release date"""
-	releaseDate: String!
+	releaseDate: String
 
 	"""The set tcgOnline code if available in the APP"""
 	tcgOnline: String
@@ -462,6 +462,15 @@ type Serie {
 	name: String!
 	"""the list of sets that are part of the serie"""
 	sets: [Set]!
+
+	"""the release data of the first set"""
+	releaseDate: String
+
+	"""the first set released in the serie"""
+	firstSet: Set
+
+	"""the last set released in the serie"""
+	lastSet: Set
 }
 
 """


### PR DESCRIPTION
Changed Set.releaseDate to be nullable and added releaseDate, firstSet, and lastSet fields to the Serie type for improved data representation of set release information.

<!--
Thanks for your Pull Request, Please provide the related Issue using "Fix #0" or describe the change(s) you made.
The issue title must follow Conventional Commit conventionalcommits.org.
More informations at https://github.com/tcgdex/cards-database/blob/master/CONTRIBUTING.md
-->
