### PR TITLE
fix: PAR-109 variants, add reverse

### DIFF
--- a/data/Scarlet & Violet/Paradox Rift/109.ts
+++ b/data/Scarlet & Violet/Paradox Rift/109.ts
@@ -68,7 +68,6 @@ const card: Card = {
 	regulationMark: "G",
 
 	variants: {
-		reverse: false,
 		normal: false
 	},
 


### PR DESCRIPTION
Available in Holo & Reverse

<!--
Thanks for your Pull Request, Please provide the related Issue using "Fix #0" or describe the change(s) you made.
The issue title must follow Conventional Commit conventionalcommits.org.
More informations at https://github.com/tcgdex/cards-database/blob/master/CONTRIBUTING.md
-->
