### PR TITLE
feat: Expand variant_detailed + sv10.5b variants

### DIFF
--- a/data/Scarlet & Violet/Black Bolt/001.ts
+++ b/data/Scarlet & Violet/Black Bolt/001.ts
@@ -56,7 +56,36 @@ const card: Card = {
 
 	thirdParty: {
 		cardmarket: 835903
-	}
+	},
+
+	variants: [{
+		type: "normal",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "standard"
+	}, {
+		type: "reverse",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}, {
+		type: "reverse",
+		size: "standard",
+		foil: "pokeball",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}, {
+		type: "reverse",
+		size: "standard",
+		foil: "masterball",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}, {
+		type: "holo",
+		size: "standard",
+		description: "Tinsel Holo found in Unova Poster Collection",
+		set: "other"
+	}]
 }
 
 export default card

--- a/data/Scarlet & Violet/Black Bolt/002.ts
+++ b/data/Scarlet & Violet/Black Bolt/002.ts
@@ -66,7 +66,31 @@ const card: Card = {
 
 	thirdParty: {
 		cardmarket: 835905
-	}
+	},
+
+	variants: [{
+		type: "normal",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "standard"
+	}, {
+		type: "reverse",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}, {
+		type: "reverse",
+		size: "standard",
+		foil: "pokeball",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}, {
+		type: "reverse",
+		size: "standard",
+		foil: "masterball",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}]
 }
 
 export default card

--- a/data/Scarlet & Violet/Black Bolt/003.ts
+++ b/data/Scarlet & Violet/Black Bolt/003.ts
@@ -76,7 +76,14 @@ const card: Card = {
 
 	thirdParty: {
 		cardmarket: 835908
-	}
+	},
+
+	variants: [{
+		type: "holo",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "standard"
+	}]
 }
 
 export default card

--- a/data/Scarlet & Violet/Black Bolt/004.ts
+++ b/data/Scarlet & Violet/Black Bolt/004.ts
@@ -64,7 +64,31 @@ const card: Card = {
 
 	thirdParty: {
 		cardmarket: 835910
-	}
+	},
+
+	variants: [{
+		type: "normal",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "standard"
+	}, {
+		type: "reverse",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}, {
+		type: "reverse",
+		size: "standard",
+		foil: "pokeball",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}, {
+		type: "reverse",
+		size: "standard",
+		foil: "masterball",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}]
 }
 
 export default card

--- a/data/Scarlet & Violet/Black Bolt/005.ts
+++ b/data/Scarlet & Violet/Black Bolt/005.ts
@@ -42,7 +42,31 @@ const card: Card = {
 
 	thirdParty: {
 		cardmarket: 835912
-	}
+	},
+
+	variants: [{
+		type: "normal",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "standard"
+	}, {
+		type: "reverse",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}, {
+		type: "reverse",
+		size: "standard",
+		foil: "pokeball",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}, {
+		type: "reverse",
+		size: "standard",
+		foil: "masterball",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}]
 }
 
 export default card

--- a/data/Scarlet & Violet/Black Bolt/006.ts
+++ b/data/Scarlet & Violet/Black Bolt/006.ts
@@ -64,7 +64,31 @@ const card: Card = {
 
 	thirdParty: {
 		cardmarket: 835914
-	}
+	},
+
+	variants: [{
+		type: "normal",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "standard"
+	}, {
+		type: "reverse",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}, {
+		type: "reverse",
+		size: "standard",
+		foil: "pokeball",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}, {
+		type: "reverse",
+		size: "standard",
+		foil: "masterball",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}]
 }
 
 export default card

--- a/data/Scarlet & Violet/Black Bolt/007.ts
+++ b/data/Scarlet & Violet/Black Bolt/007.ts
@@ -66,7 +66,31 @@ const card: Card = {
 
 	thirdParty: {
 		cardmarket: 835916
-	}
+	},
+
+	variants: [{
+		type: "normal",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "standard"
+	}, {
+		type: "reverse",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}, {
+		type: "reverse",
+		size: "standard",
+		foil: "pokeball",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}, {
+		type: "reverse",
+		size: "standard",
+		foil: "masterball",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}]
 }
 
 export default card

--- a/data/Scarlet & Violet/Black Bolt/008.ts
+++ b/data/Scarlet & Violet/Black Bolt/008.ts
@@ -66,7 +66,31 @@ const card: Card = {
 
 	thirdParty: {
 		cardmarket: 835918
-	}
+	},
+
+	variants: [{
+		type: "normal",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "standard"
+	}, {
+		type: "reverse",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}, {
+		type: "reverse",
+		size: "standard",
+		foil: "pokeball",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}, {
+		type: "reverse",
+		size: "standard",
+		foil: "masterball",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}]
 }
 
 export default card

--- a/data/Scarlet & Violet/Black Bolt/009.ts
+++ b/data/Scarlet & Violet/Black Bolt/009.ts
@@ -66,7 +66,31 @@ const card: Card = {
 
 	thirdParty: {
 		cardmarket: 835919
-	}
+	},
+
+	variants: [{
+		type: "normal",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "standard"
+	}, {
+		type: "reverse",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}, {
+		type: "reverse",
+		size: "standard",
+		foil: "pokeball",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}, {
+		type: "reverse",
+		size: "standard",
+		foil: "masterball",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}]
 }
 
 export default card

--- a/data/Scarlet & Violet/Black Bolt/010.ts
+++ b/data/Scarlet & Violet/Black Bolt/010.ts
@@ -50,7 +50,31 @@ const card: Card = {
 
 	thirdParty: {
 		cardmarket: 835921
-	}
+	},
+
+	variants: [{
+		type: "normal",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "standard"
+	}, {
+		type: "reverse",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}, {
+		type: "reverse",
+		size: "standard",
+		foil: "pokeball",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}, {
+		type: "reverse",
+		size: "standard",
+		foil: "masterball",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}]
 }
 
 export default card

--- a/data/Scarlet & Violet/Black Bolt/011.ts
+++ b/data/Scarlet & Violet/Black Bolt/011.ts
@@ -66,7 +66,31 @@ const card: Card = {
 
 	thirdParty: {
 		cardmarket: 835922
-	}
+	},
+
+	variants: [{
+		type: "normal",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "standard"
+	}, {
+		type: "reverse",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}, {
+		type: "reverse",
+		size: "standard",
+		foil: "pokeball",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}, {
+		type: "reverse",
+		size: "standard",
+		foil: "masterball",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}]
 }
 
 export default card

--- a/data/Scarlet & Violet/Black Bolt/012.ts
+++ b/data/Scarlet & Violet/Black Bolt/012.ts
@@ -52,7 +52,31 @@ const card: Card = {
 
 	thirdParty: {
 		cardmarket: 835926
-	}
+	},
+
+	variants: [{
+		type: "holo",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "standard"
+	}, {
+		type: "reverse",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}, {
+		type: "reverse",
+		size: "standard",
+		foil: "masterball",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}, {
+		type: "reverse",
+		size: "standard",
+		foil: "pokeball",
+		description: "Found in Victini Illustration Collection",
+		set: "other"
+	}]
 }
 
 export default card

--- a/data/Scarlet & Violet/Black Bolt/013.ts
+++ b/data/Scarlet & Violet/Black Bolt/013.ts
@@ -42,7 +42,31 @@ const card: Card = {
 
 	thirdParty: {
 		cardmarket: 835928
-	}
+	},
+
+	variants: [{
+		type: "normal",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "standard"
+	}, {
+		type: "reverse",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}, {
+		type: "reverse",
+		size: "standard",
+		foil: "pokeball",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}, {
+		type: "reverse",
+		size: "standard",
+		foil: "masterball",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}]
 }
 
 export default card

--- a/data/Scarlet & Violet/Black Bolt/014.ts
+++ b/data/Scarlet & Violet/Black Bolt/014.ts
@@ -76,7 +76,31 @@ const card: Card = {
 
 	thirdParty: {
 		cardmarket: 835929
-	}
+	},
+
+	variants: [{
+		type: "normal",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "standard"
+	}, {
+		type: "reverse",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}, {
+		type: "reverse",
+		size: "standard",
+		foil: "pokeball",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}, {
+		type: "reverse",
+		size: "standard",
+		foil: "masterball",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}]
 }
 
 export default card

--- a/data/Scarlet & Violet/Black Bolt/015.ts
+++ b/data/Scarlet & Violet/Black Bolt/015.ts
@@ -52,7 +52,31 @@ const card: Card = {
 
 	thirdParty: {
 		cardmarket: 835932
-	}
+	},
+
+	variants: [{
+		type: "normal",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "standard"
+	}, {
+		type: "reverse",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}, {
+		type: "reverse",
+		size: "standard",
+		foil: "pokeball",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}, {
+		type: "reverse",
+		size: "standard",
+		foil: "masterball",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}]
 }
 
 export default card

--- a/data/Scarlet & Violet/Black Bolt/016.ts
+++ b/data/Scarlet & Violet/Black Bolt/016.ts
@@ -66,7 +66,31 @@ const card: Card = {
 
 	thirdParty: {
 		cardmarket: 835934
-	}
+	},
+
+	variants: [{
+		type: "holo",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "standard"
+	}, {
+		type: "reverse",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}, {
+		type: "reverse",
+		size: "standard",
+		foil: "pokeball",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}, {
+		type: "reverse",
+		size: "standard",
+		foil: "masterball",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}]
 }
 
 export default card

--- a/data/Scarlet & Violet/Black Bolt/017.ts
+++ b/data/Scarlet & Violet/Black Bolt/017.ts
@@ -64,7 +64,31 @@ const card: Card = {
 
 	thirdParty: {
 		cardmarket: 835936
-	}
+	},
+
+	variants: [{
+		type: "normal",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "standard"
+	}, {
+		type: "reverse",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}, {
+		type: "reverse",
+		size: "standard",
+		foil: "pokeball",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}, {
+		type: "reverse",
+		size: "standard",
+		foil: "masterball",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}]
 }
 
 export default card

--- a/data/Scarlet & Violet/Black Bolt/018.ts
+++ b/data/Scarlet & Violet/Black Bolt/018.ts
@@ -42,7 +42,31 @@ const card: Card = {
 
 	thirdParty: {
 		cardmarket: 835939
-	}
+	},
+
+	variants: [{
+		type: "normal",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "standard"
+	}, {
+		type: "reverse",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}, {
+		type: "reverse",
+		size: "standard",
+		foil: "pokeball",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}, {
+		type: "reverse",
+		size: "standard",
+		foil: "masterball",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}]
 }
 
 export default card

--- a/data/Scarlet & Violet/Black Bolt/019.ts
+++ b/data/Scarlet & Violet/Black Bolt/019.ts
@@ -52,7 +52,31 @@ const card: Card = {
 
 	thirdParty: {
 		cardmarket: 835940
-	}
+	},
+
+	variants: [{
+		type: "normal",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "standard"
+	}, {
+		type: "reverse",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}, {
+		type: "reverse",
+		size: "standard",
+		foil: "pokeball",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}, {
+		type: "reverse",
+		size: "standard",
+		foil: "masterball",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}]
 }
 
 export default card

--- a/data/Scarlet & Violet/Black Bolt/020.ts
+++ b/data/Scarlet & Violet/Black Bolt/020.ts
@@ -66,7 +66,31 @@ const card: Card = {
 
 	thirdParty: {
 		cardmarket: 835942
-	}
+	},
+
+	variants: [{
+		type: "normal",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "standard"
+	}, {
+		type: "reverse",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}, {
+		type: "reverse",
+		size: "standard",
+		foil: "pokeball",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}, {
+		type: "reverse",
+		size: "standard",
+		foil: "masterball",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}]
 }
 
 export default card

--- a/data/Scarlet & Violet/Black Bolt/021.ts
+++ b/data/Scarlet & Violet/Black Bolt/021.ts
@@ -66,7 +66,31 @@ const card: Card = {
 
 	thirdParty: {
 		cardmarket: 835943
-	}
+	},
+
+	variants: [{
+		type: "normal",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "standard"
+	}, {
+		type: "reverse",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}, {
+		type: "reverse",
+		size: "standard",
+		foil: "pokeball",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}, {
+		type: "reverse",
+		size: "standard",
+		foil: "masterball",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}]
 }
 
 export default card

--- a/data/Scarlet & Violet/Black Bolt/022.ts
+++ b/data/Scarlet & Violet/Black Bolt/022.ts
@@ -66,7 +66,31 @@ const card: Card = {
 
 	thirdParty: {
 		cardmarket: 835945
-	}
+	},
+
+	variants: [{
+		type: "normal",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "standard"
+	}, {
+		type: "reverse",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}, {
+		type: "reverse",
+		size: "standard",
+		foil: "pokeball",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}, {
+		type: "reverse",
+		size: "standard",
+		foil: "masterball",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}]
 }
 
 export default card

--- a/data/Scarlet & Violet/Black Bolt/023.ts
+++ b/data/Scarlet & Violet/Black Bolt/023.ts
@@ -76,7 +76,31 @@ const card: Card = {
 
 	thirdParty: {
 		cardmarket: 835947
-	}
+	},
+
+	variants: [{
+		type: "holo",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "standard"
+	}, {
+		type: "reverse",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}, {
+		type: "reverse",
+		size: "standard",
+		foil: "pokeball",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}, {
+		type: "reverse",
+		size: "standard",
+		foil: "masterball",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}]
 }
 
 export default card

--- a/data/Scarlet & Violet/Black Bolt/024.ts
+++ b/data/Scarlet & Violet/Black Bolt/024.ts
@@ -66,7 +66,31 @@ const card: Card = {
 
 	thirdParty: {
 		cardmarket: 835948
-	}
+	},
+
+	variants: [{
+		type: "normal",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "standard"
+	}, {
+		type: "reverse",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}, {
+		type: "reverse",
+		size: "standard",
+		foil: "pokeball",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}, {
+		type: "reverse",
+		size: "standard",
+		foil: "masterball",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}]
 }
 
 export default card

--- a/data/Scarlet & Violet/Black Bolt/025.ts
+++ b/data/Scarlet & Violet/Black Bolt/025.ts
@@ -52,7 +52,31 @@ const card: Card = {
 
 	thirdParty: {
 		cardmarket: 835949
-	}
+	},
+
+	variants: [{
+		type: "normal",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "standard"
+	}, {
+		type: "reverse",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}, {
+		type: "reverse",
+		size: "standard",
+		foil: "pokeball",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}, {
+		type: "reverse",
+		size: "standard",
+		foil: "masterball",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}]
 }
 
 export default card

--- a/data/Scarlet & Violet/Black Bolt/026.ts
+++ b/data/Scarlet & Violet/Black Bolt/026.ts
@@ -76,7 +76,31 @@ const card: Card = {
 
 	thirdParty: {
 		cardmarket: 835950
-	}
+	},
+
+	variants: [{
+		type: "holo",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "standard"
+	}, {
+		type: "reverse",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}, {
+		type: "reverse",
+		size: "standard",
+		foil: "pokeball",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}, {
+		type: "reverse",
+		size: "standard",
+		foil: "masterball",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}]
 }
 
 export default card

--- a/data/Scarlet & Violet/Black Bolt/027.ts
+++ b/data/Scarlet & Violet/Black Bolt/027.ts
@@ -64,7 +64,31 @@ const card: Card = {
 
 	thirdParty: {
 		cardmarket: 835953
-	}
+	},
+
+	variants: [{
+		type: "normal",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "standard"
+	}, {
+		type: "reverse",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}, {
+		type: "reverse",
+		size: "standard",
+		foil: "pokeball",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}, {
+		type: "reverse",
+		size: "standard",
+		foil: "masterball",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}]
 }
 
 export default card

--- a/data/Scarlet & Violet/Black Bolt/028.ts
+++ b/data/Scarlet & Violet/Black Bolt/028.ts
@@ -66,7 +66,14 @@ const card: Card = {
 
 	thirdParty: {
 		cardmarket: 835955
-	}
+	},
+
+	variants: [{
+		type: "holo",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "standard"
+	}]
 }
 
 export default card

--- a/data/Scarlet & Violet/Black Bolt/029.ts
+++ b/data/Scarlet & Violet/Black Bolt/029.ts
@@ -64,7 +64,31 @@ const card: Card = {
 
 	thirdParty: {
 		cardmarket: 835957
-	}
+	},
+
+	variants: [{
+		type: "normal",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "standard"
+	}, {
+		type: "reverse",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}, {
+		type: "reverse",
+		size: "standard",
+		foil: "pokeball",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}, {
+		type: "reverse",
+		size: "standard",
+		foil: "masterball",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}]
 }
 
 export default card

--- a/data/Scarlet & Violet/Black Bolt/030.ts
+++ b/data/Scarlet & Violet/Black Bolt/030.ts
@@ -50,7 +50,31 @@ const card: Card = {
 
 	thirdParty: {
 		cardmarket: 835959
-	}
+	},
+
+	variants: [{
+		type: "normal",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "standard"
+	}, {
+		type: "reverse",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}, {
+		type: "reverse",
+		size: "standard",
+		foil: "pokeball",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}, {
+		type: "reverse",
+		size: "standard",
+		foil: "masterball",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}]
 }
 
 export default card

--- a/data/Scarlet & Violet/Black Bolt/031.ts
+++ b/data/Scarlet & Violet/Black Bolt/031.ts
@@ -66,7 +66,31 @@ const card: Card = {
 
 	thirdParty: {
 		cardmarket: 835961
-	}
+	},
+
+	variants: [{
+		type: "normal",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "standard"
+	}, {
+		type: "reverse",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}, {
+		type: "reverse",
+		size: "standard",
+		foil: "pokeball",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}, {
+		type: "reverse",
+		size: "standard",
+		foil: "masterball",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}]
 }
 
 export default card

--- a/data/Scarlet & Violet/Black Bolt/032.ts
+++ b/data/Scarlet & Violet/Black Bolt/032.ts
@@ -76,7 +76,31 @@ const card: Card = {
 
 	thirdParty: {
 		cardmarket: 835964
-	}
+	},
+
+	variants: [{
+		type: "normal",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "standard"
+	}, {
+		type: "reverse",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}, {
+		type: "reverse",
+		size: "standard",
+		foil: "pokeball",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}, {
+		type: "reverse",
+		size: "standard",
+		foil: "masterball",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}]
 }
 
 export default card

--- a/data/Scarlet & Violet/Black Bolt/033.ts
+++ b/data/Scarlet & Violet/Black Bolt/033.ts
@@ -74,7 +74,31 @@ const card: Card = {
 
 	thirdParty: {
 		cardmarket: 835970
-	}
+	},
+
+	variants: [{
+		type: "holo",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "standard"
+	}, {
+		type: "reverse",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}, {
+		type: "reverse",
+		size: "standard",
+		foil: "pokeball",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}, {
+		type: "reverse",
+		size: "standard",
+		foil: "masterball",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}]
 }
 
 export default card

--- a/data/Scarlet & Violet/Black Bolt/034.ts
+++ b/data/Scarlet & Violet/Black Bolt/034.ts
@@ -66,7 +66,14 @@ const card: Card = {
 
 	thirdParty: {
 		cardmarket: 835966
-	}
+	},
+
+	variants: [{
+		type: "holo",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "standard"
+	}]
 }
 
 export default card

--- a/data/Scarlet & Violet/Black Bolt/035.ts
+++ b/data/Scarlet & Violet/Black Bolt/035.ts
@@ -64,7 +64,31 @@ const card: Card = {
 
 	thirdParty: {
 		cardmarket: 835978
-	}
+	},
+
+	variants: [{
+		type: "normal",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "standard"
+	}, {
+		type: "reverse",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}, {
+		type: "reverse",
+		size: "standard",
+		foil: "pokeball",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}, {
+		type: "reverse",
+		size: "standard",
+		foil: "masterball",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}]
 }
 
 export default card

--- a/data/Scarlet & Violet/Black Bolt/036.ts
+++ b/data/Scarlet & Violet/Black Bolt/036.ts
@@ -74,7 +74,31 @@ const card: Card = {
 
 	thirdParty: {
 		cardmarket: 835980
-	}
+	},
+
+	variants: [{
+		type: "normal",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "standard"
+	}, {
+		type: "reverse",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}, {
+		type: "reverse",
+		size: "standard",
+		foil: "pokeball",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}, {
+		type: "reverse",
+		size: "standard",
+		foil: "masterball",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}]
 }
 
 export default card

--- a/data/Scarlet & Violet/Black Bolt/037.ts
+++ b/data/Scarlet & Violet/Black Bolt/037.ts
@@ -42,7 +42,31 @@ const card: Card = {
 
 	thirdParty: {
 		cardmarket: 835981
-	}
+	},
+
+	variants: [{
+		type: "normal",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "standard"
+	}, {
+		type: "reverse",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}, {
+		type: "reverse",
+		size: "standard",
+		foil: "pokeball",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}, {
+		type: "reverse",
+		size: "standard",
+		foil: "masterball",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}]
 }
 
 export default card

--- a/data/Scarlet & Violet/Black Bolt/038.ts
+++ b/data/Scarlet & Violet/Black Bolt/038.ts
@@ -64,7 +64,31 @@ const card: Card = {
 
 	thirdParty: {
 		cardmarket: 835983
-	}
+	},
+
+	variants: [{
+		type: "normal",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "standard"
+	}, {
+		type: "reverse",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}, {
+		type: "reverse",
+		size: "standard",
+		foil: "pokeball",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}, {
+		type: "reverse",
+		size: "standard",
+		foil: "masterball",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}]
 }
 
 export default card

--- a/data/Scarlet & Violet/Black Bolt/039.ts
+++ b/data/Scarlet & Violet/Black Bolt/039.ts
@@ -74,7 +74,31 @@ const card: Card = {
 
 	thirdParty: {
 		cardmarket: 835985
-	}
+	},
+
+	variants: [{
+		type: "normal",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "standard"
+	}, {
+		type: "reverse",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}, {
+		type: "reverse",
+		size: "standard",
+		foil: "pokeball",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}, {
+		type: "reverse",
+		size: "standard",
+		foil: "masterball",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}]
 }
 
 export default card

--- a/data/Scarlet & Violet/Black Bolt/040.ts
+++ b/data/Scarlet & Violet/Black Bolt/040.ts
@@ -64,7 +64,31 @@ const card: Card = {
 
 	thirdParty: {
 		cardmarket: 835988
-	}
+	},
+
+	variants: [{
+		type: "normal",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "standard"
+	}, {
+		type: "reverse",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}, {
+		type: "reverse",
+		size: "standard",
+		foil: "pokeball",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}, {
+		type: "reverse",
+		size: "standard",
+		foil: "masterball",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}]
 }
 
 export default card

--- a/data/Scarlet & Violet/Black Bolt/041.ts
+++ b/data/Scarlet & Violet/Black Bolt/041.ts
@@ -74,7 +74,31 @@ const card: Card = {
 
 	thirdParty: {
 		cardmarket: 835989
-	}
+	},
+
+	variants: [{
+		type: "normal",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "standard"
+	}, {
+		type: "reverse",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}, {
+		type: "reverse",
+		size: "standard",
+		foil: "pokeball",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}, {
+		type: "reverse",
+		size: "standard",
+		foil: "masterball",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}]
 }
 
 export default card

--- a/data/Scarlet & Violet/Black Bolt/042.ts
+++ b/data/Scarlet & Violet/Black Bolt/042.ts
@@ -52,7 +52,31 @@ const card: Card = {
 
 	thirdParty: {
 		cardmarket: 835992
-	}
+	},
+
+	variants: [{
+		type: "normal",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "standard"
+	}, {
+		type: "reverse",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}, {
+		type: "reverse",
+		size: "standard",
+		foil: "pokeball",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}, {
+		type: "reverse",
+		size: "standard",
+		foil: "masterball",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}]
 }
 
 export default card

--- a/data/Scarlet & Violet/Black Bolt/043.ts
+++ b/data/Scarlet & Violet/Black Bolt/043.ts
@@ -66,7 +66,31 @@ const card: Card = {
 
 	thirdParty: {
 		cardmarket: 835994
-	}
+	},
+
+	variants: [{
+		type: "normal",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "standard"
+	}, {
+		type: "reverse",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}, {
+		type: "reverse",
+		size: "standard",
+		foil: "pokeball",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}, {
+		type: "reverse",
+		size: "standard",
+		foil: "masterball",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}]
 }
 
 export default card

--- a/data/Scarlet & Violet/Black Bolt/044.ts
+++ b/data/Scarlet & Violet/Black Bolt/044.ts
@@ -76,7 +76,14 @@ const card: Card = {
 
 	thirdParty: {
 		cardmarket: 835996
-	}
+	},
+
+	variants: [{
+		type: "holo",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "standard"
+	}]
 }
 
 export default card

--- a/data/Scarlet & Violet/Black Bolt/045.ts
+++ b/data/Scarlet & Violet/Black Bolt/045.ts
@@ -56,7 +56,31 @@ const card: Card = {
 
 	thirdParty: {
 		cardmarket: 835998
-	}
+	},
+
+	variants: [{
+		type: "normal",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "standard"
+	}, {
+		type: "reverse",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}, {
+		type: "reverse",
+		size: "standard",
+		foil: "pokeball",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}, {
+		type: "reverse",
+		size: "standard",
+		foil: "masterball",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}]
 }
 
 export default card

--- a/data/Scarlet & Violet/Black Bolt/046.ts
+++ b/data/Scarlet & Violet/Black Bolt/046.ts
@@ -76,7 +76,14 @@ const card: Card = {
 
 	thirdParty: {
 		cardmarket: 835999
-	}
+	},
+
+	variants: [{
+		type: "holo",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "standard"
+	}]
 }
 
 export default card

--- a/data/Scarlet & Violet/Black Bolt/047.ts
+++ b/data/Scarlet & Violet/Black Bolt/047.ts
@@ -56,7 +56,31 @@ const card: Card = {
 
 	thirdParty: {
 		cardmarket: 836003
-	}
+	},
+
+	variants: [{
+		type: "normal",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "standard"
+	}, {
+		type: "reverse",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}, {
+		type: "reverse",
+		size: "standard",
+		foil: "pokeball",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}, {
+		type: "reverse",
+		size: "standard",
+		foil: "masterball",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}]
 }
 
 export default card

--- a/data/Scarlet & Violet/Black Bolt/048.ts
+++ b/data/Scarlet & Violet/Black Bolt/048.ts
@@ -66,7 +66,31 @@ const card: Card = {
 
 	thirdParty: {
 		cardmarket: 836005
-	}
+	},
+
+	variants: [{
+		type: "normal",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "standard"
+	}, {
+		type: "reverse",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}, {
+		type: "reverse",
+		size: "standard",
+		foil: "pokeball",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}, {
+		type: "reverse",
+		size: "standard",
+		foil: "masterball",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}]
 }
 
 export default card

--- a/data/Scarlet & Violet/Black Bolt/049.ts
+++ b/data/Scarlet & Violet/Black Bolt/049.ts
@@ -76,7 +76,31 @@ const card: Card = {
 
 	thirdParty: {
 		cardmarket: 836007
-	}
+	},
+
+	variants: [{
+		type: "holo",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "standard"
+	}, {
+		type: "reverse",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}, {
+		type: "reverse",
+		size: "standard",
+		foil: "pokeball",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}, {
+		type: "reverse",
+		size: "standard",
+		foil: "masterball",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}]
 }
 
 export default card

--- a/data/Scarlet & Violet/Black Bolt/050.ts
+++ b/data/Scarlet & Violet/Black Bolt/050.ts
@@ -52,7 +52,31 @@ const card: Card = {
 
 	thirdParty: {
 		cardmarket: 836009
-	}
+	},
+
+	variants: [{
+		type: "normal",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "standard"
+	}, {
+		type: "reverse",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}, {
+		type: "reverse",
+		size: "standard",
+		foil: "pokeball",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}, {
+		type: "reverse",
+		size: "standard",
+		foil: "masterball",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}]
 }
 
 export default card

--- a/data/Scarlet & Violet/Black Bolt/051.ts
+++ b/data/Scarlet & Violet/Black Bolt/051.ts
@@ -66,7 +66,31 @@ const card: Card = {
 
 	thirdParty: {
 		cardmarket: 836011
-	}
+	},
+
+	variants: [{
+		type: "normal",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "standard"
+	}, {
+		type: "reverse",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}, {
+		type: "reverse",
+		size: "standard",
+		foil: "pokeball",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}, {
+		type: "reverse",
+		size: "standard",
+		foil: "masterball",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}]
 }
 
 export default card

--- a/data/Scarlet & Violet/Black Bolt/052.ts
+++ b/data/Scarlet & Violet/Black Bolt/052.ts
@@ -76,7 +76,31 @@ const card: Card = {
 
 	thirdParty: {
 		cardmarket: 836013
-	}
+	},
+
+	variants: [{
+		type: "normal",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "standard"
+	}, {
+		type: "reverse",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}, {
+		type: "reverse",
+		size: "standard",
+		foil: "pokeball",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}, {
+		type: "reverse",
+		size: "standard",
+		foil: "masterball",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}]
 }
 
 export default card

--- a/data/Scarlet & Violet/Black Bolt/053.ts
+++ b/data/Scarlet & Violet/Black Bolt/053.ts
@@ -74,7 +74,31 @@ const card: Card = {
 
 	thirdParty: {
 		cardmarket: 836015
-	}
+	},
+
+	variants: [{
+		type: "holo",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "standard"
+	}, {
+		type: "reverse",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}, {
+		type: "reverse",
+		size: "standard",
+		foil: "pokeball",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}, {
+		type: "reverse",
+		size: "standard",
+		foil: "masterball",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}]
 }
 
 export default card

--- a/data/Scarlet & Violet/Black Bolt/054.ts
+++ b/data/Scarlet & Violet/Black Bolt/054.ts
@@ -50,7 +50,31 @@ const card: Card = {
 
 	thirdParty: {
 		cardmarket: 836017
-	}
+	},
+
+	variants: [{
+		type: "normal",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "standard"
+	}, {
+		type: "reverse",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}, {
+		type: "reverse",
+		size: "standard",
+		foil: "pokeball",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}, {
+		type: "reverse",
+		size: "standard",
+		foil: "masterball",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}]
 }
 
 export default card

--- a/data/Scarlet & Violet/Black Bolt/055.ts
+++ b/data/Scarlet & Violet/Black Bolt/055.ts
@@ -52,7 +52,31 @@ const card: Card = {
 
 	thirdParty: {
 		cardmarket: 836018
-	}
+	},
+
+	variants: [{
+		type: "normal",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "standard"
+	}, {
+		type: "reverse",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}, {
+		type: "reverse",
+		size: "standard",
+		foil: "pokeball",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}, {
+		type: "reverse",
+		size: "standard",
+		foil: "masterball",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}]
 }
 
 export default card

--- a/data/Scarlet & Violet/Black Bolt/056.ts
+++ b/data/Scarlet & Violet/Black Bolt/056.ts
@@ -76,7 +76,31 @@ const card: Card = {
 
 	thirdParty: {
 		cardmarket: 836021
-	}
+	},
+
+	variants: [{
+		type: "normal",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "standard"
+	}, {
+		type: "reverse",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}, {
+		type: "reverse",
+		size: "standard",
+		foil: "pokeball",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}, {
+		type: "reverse",
+		size: "standard",
+		foil: "masterball",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}]
 }
 
 export default card

--- a/data/Scarlet & Violet/Black Bolt/057.ts
+++ b/data/Scarlet & Violet/Black Bolt/057.ts
@@ -52,7 +52,31 @@ const card: Card = {
 
 	thirdParty: {
 		cardmarket: 836023
-	}
+	},
+
+	variants: [{
+		type: "normal",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "standard"
+	}, {
+		type: "reverse",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}, {
+		type: "reverse",
+		size: "standard",
+		foil: "pokeball",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}, {
+		type: "reverse",
+		size: "standard",
+		foil: "masterball",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}]
 }
 
 export default card

--- a/data/Scarlet & Violet/Black Bolt/058.ts
+++ b/data/Scarlet & Violet/Black Bolt/058.ts
@@ -52,7 +52,31 @@ const card: Card = {
 
 	thirdParty: {
 		cardmarket: 836024
-	}
+	},
+
+	variants: [{
+		type: "normal",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "standard"
+	}, {
+		type: "reverse",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}, {
+		type: "reverse",
+		size: "standard",
+		foil: "pokeball",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}, {
+		type: "reverse",
+		size: "standard",
+		foil: "masterball",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}]
 }
 
 export default card

--- a/data/Scarlet & Violet/Black Bolt/059.ts
+++ b/data/Scarlet & Violet/Black Bolt/059.ts
@@ -76,7 +76,31 @@ const card: Card = {
 
 	thirdParty: {
 		cardmarket: 836026
-	}
+	},
+
+	variants: [{
+		type: "normal",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "standard"
+	}, {
+		type: "reverse",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}, {
+		type: "reverse",
+		size: "standard",
+		foil: "pokeball",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}, {
+		type: "reverse",
+		size: "standard",
+		foil: "masterball",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}]
 }
 
 export default card

--- a/data/Scarlet & Violet/Black Bolt/060.ts
+++ b/data/Scarlet & Violet/Black Bolt/060.ts
@@ -52,7 +52,31 @@ const card: Card = {
 
 	thirdParty: {
 		cardmarket: 836033
-	}
+	},
+
+	variants: [{
+		type: "normal",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "standard"
+	}, {
+		type: "reverse",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}, {
+		type: "reverse",
+		size: "standard",
+		foil: "pokeball",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}, {
+		type: "reverse",
+		size: "standard",
+		foil: "masterball",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}]
 }
 
 export default card

--- a/data/Scarlet & Violet/Black Bolt/061.ts
+++ b/data/Scarlet & Violet/Black Bolt/061.ts
@@ -52,7 +52,31 @@ const card: Card = {
 
 	thirdParty: {
 		cardmarket: 836035
-	}
+	},
+
+	variants: [{
+		type: "normal",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "standard"
+	}, {
+		type: "reverse",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}, {
+		type: "reverse",
+		size: "standard",
+		foil: "pokeball",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}, {
+		type: "reverse",
+		size: "standard",
+		foil: "masterball",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}]
 }
 
 export default card

--- a/data/Scarlet & Violet/Black Bolt/062.ts
+++ b/data/Scarlet & Violet/Black Bolt/062.ts
@@ -52,7 +52,31 @@ const card: Card = {
 
 	thirdParty: {
 		cardmarket: 836037
-	}
+	},
+
+	variants: [{
+		type: "normal",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "standard"
+	}, {
+		type: "reverse",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}, {
+		type: "reverse",
+		size: "standard",
+		foil: "pokeball",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}, {
+		type: "reverse",
+		size: "standard",
+		foil: "masterball",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}]
 }
 
 export default card

--- a/data/Scarlet & Violet/Black Bolt/063.ts
+++ b/data/Scarlet & Violet/Black Bolt/063.ts
@@ -66,7 +66,31 @@ const card: Card = {
 
 	thirdParty: {
 		cardmarket: 836039
-	}
+	},
+
+	variants: [{
+		type: "holo",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "standard"
+	}, {
+		type: "reverse",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}, {
+		type: "reverse",
+		size: "standard",
+		foil: "pokeball",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}, {
+		type: "reverse",
+		size: "standard",
+		foil: "masterball",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}]
 }
 
 export default card

--- a/data/Scarlet & Violet/Black Bolt/064.ts
+++ b/data/Scarlet & Violet/Black Bolt/064.ts
@@ -52,7 +52,31 @@ const card: Card = {
 
 	thirdParty: {
 		cardmarket: 836041
-	}
+	},
+
+	variants: [{
+		type: "normal",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "standard"
+	}, {
+		type: "reverse",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}, {
+		type: "reverse",
+		size: "standard",
+		foil: "pokeball",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}, {
+		type: "reverse",
+		size: "standard",
+		foil: "masterball",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}]
 }
 
 export default card

--- a/data/Scarlet & Violet/Black Bolt/065.ts
+++ b/data/Scarlet & Violet/Black Bolt/065.ts
@@ -66,7 +66,31 @@ const card: Card = {
 
 	thirdParty: {
 		cardmarket: 836043
-	}
+	},
+
+	variants: [{
+		type: "normal",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "standard"
+	}, {
+		type: "reverse",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}, {
+		type: "reverse",
+		size: "standard",
+		foil: "pokeball",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}, {
+		type: "reverse",
+		size: "standard",
+		foil: "masterball",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}]
 }
 
 export default card

--- a/data/Scarlet & Violet/Black Bolt/066.ts
+++ b/data/Scarlet & Violet/Black Bolt/066.ts
@@ -76,7 +76,31 @@ const card: Card = {
 
 	thirdParty: {
 		cardmarket: 836045
-	}
+	},
+
+	variants: [{
+		type: "holo",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "standard"
+	}, {
+		type: "reverse",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}, {
+		type: "reverse",
+		size: "standard",
+		foil: "pokeball",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}, {
+		type: "reverse",
+		size: "standard",
+		foil: "masterball",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}]
 }
 
 export default card

--- a/data/Scarlet & Violet/Black Bolt/067.ts
+++ b/data/Scarlet & Violet/Black Bolt/067.ts
@@ -76,7 +76,14 @@ const card: Card = {
 
 	thirdParty: {
 		cardmarket: 836046
-	}
+	},
+
+	variants: [{
+		type: "holo",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "standard"
+	}]
 }
 
 export default card

--- a/data/Scarlet & Violet/Black Bolt/068.ts
+++ b/data/Scarlet & Violet/Black Bolt/068.ts
@@ -50,7 +50,31 @@ const card: Card = {
 
 	thirdParty: {
 		cardmarket: 836047
-	}
+	},
+
+	variants: [{
+		type: "normal",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "standard"
+	}, {
+		type: "reverse",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}, {
+		type: "reverse",
+		size: "standard",
+		foil: "pokeball",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}, {
+		type: "reverse",
+		size: "standard",
+		foil: "masterball",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}]
 }
 
 export default card

--- a/data/Scarlet & Violet/Black Bolt/069.ts
+++ b/data/Scarlet & Violet/Black Bolt/069.ts
@@ -66,7 +66,31 @@ const card: Card = {
 
 	thirdParty: {
 		cardmarket: 836048
-	}
+	},
+
+	variants: [{
+		type: "normal",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "standard"
+	}, {
+		type: "reverse",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}, {
+		type: "reverse",
+		size: "standard",
+		foil: "pokeball",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}, {
+		type: "reverse",
+		size: "standard",
+		foil: "masterball",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}]
 }
 
 export default card

--- a/data/Scarlet & Violet/Black Bolt/070.ts
+++ b/data/Scarlet & Violet/Black Bolt/070.ts
@@ -74,7 +74,31 @@ const card: Card = {
 
 	thirdParty: {
 		cardmarket: 836050
-	}
+	},
+
+	variants: [{
+		type: "holo",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "standard"
+	}, {
+		type: "reverse",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}, {
+		type: "reverse",
+		size: "standard",
+		foil: "pokeball",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}, {
+		type: "reverse",
+		size: "standard",
+		foil: "masterball",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}]
 }
 
 export default card

--- a/data/Scarlet & Violet/Black Bolt/071.ts
+++ b/data/Scarlet & Violet/Black Bolt/071.ts
@@ -64,7 +64,31 @@ const card: Card = {
 
 	thirdParty: {
 		cardmarket: 836052
-	}
+	},
+
+	variants: [{
+		type: "normal",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "standard"
+	}, {
+		type: "reverse",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}, {
+		type: "reverse",
+		size: "standard",
+		foil: "pokeball",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}, {
+		type: "reverse",
+		size: "standard",
+		foil: "masterball",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}]
 }
 
 export default card

--- a/data/Scarlet & Violet/Black Bolt/072.ts
+++ b/data/Scarlet & Violet/Black Bolt/072.ts
@@ -52,7 +52,31 @@ const card: Card = {
 
 	thirdParty: {
 		cardmarket: 836055
-	}
+	},
+
+	variants: [{
+		type: "normal",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "standard"
+	}, {
+		type: "reverse",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}, {
+		type: "reverse",
+		size: "standard",
+		foil: "pokeball",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}, {
+		type: "reverse",
+		size: "standard",
+		foil: "masterball",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}]
 }
 
 export default card

--- a/data/Scarlet & Violet/Black Bolt/073.ts
+++ b/data/Scarlet & Violet/Black Bolt/073.ts
@@ -74,7 +74,31 @@ const card: Card = {
 
 	thirdParty: {
 		cardmarket: 836056
-	}
+	},
+
+	variants: [{
+		type: "normal",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "standard"
+	}, {
+		type: "reverse",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}, {
+		type: "reverse",
+		size: "standard",
+		foil: "pokeball",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}, {
+		type: "reverse",
+		size: "standard",
+		foil: "masterball",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}]
 }
 
 export default card

--- a/data/Scarlet & Violet/Black Bolt/074.ts
+++ b/data/Scarlet & Violet/Black Bolt/074.ts
@@ -52,7 +52,31 @@ const card: Card = {
 
 	thirdParty: {
 		cardmarket: 836058
-	}
+	},
+
+	variants: [{
+		type: "normal",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "standard"
+	}, {
+		type: "reverse",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}, {
+		type: "reverse",
+		size: "standard",
+		foil: "pokeball",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}, {
+		type: "reverse",
+		size: "standard",
+		foil: "masterball",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}]
 }
 
 export default card

--- a/data/Scarlet & Violet/Black Bolt/075.ts
+++ b/data/Scarlet & Violet/Black Bolt/075.ts
@@ -52,7 +52,31 @@ const card: Card = {
 
 	thirdParty: {
 		cardmarket: 836060
-	}
+	},
+
+	variants: [{
+		type: "normal",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "standard"
+	}, {
+		type: "reverse",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}, {
+		type: "reverse",
+		size: "standard",
+		foil: "pokeball",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}, {
+		type: "reverse",
+		size: "standard",
+		foil: "masterball",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}]
 }
 
 export default card

--- a/data/Scarlet & Violet/Black Bolt/076.ts
+++ b/data/Scarlet & Violet/Black Bolt/076.ts
@@ -52,7 +52,31 @@ const card: Card = {
 
 	thirdParty: {
 		cardmarket: 836063
-	}
+	},
+
+	variants: [{
+		type: "normal",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "standard"
+	}, {
+		type: "reverse",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}, {
+		type: "reverse",
+		size: "standard",
+		foil: "pokeball",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}, {
+		type: "reverse",
+		size: "standard",
+		foil: "masterball",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}]
 }
 
 export default card

--- a/data/Scarlet & Violet/Black Bolt/077.ts
+++ b/data/Scarlet & Violet/Black Bolt/077.ts
@@ -56,7 +56,31 @@ const card: Card = {
 
 	thirdParty: {
 		cardmarket: 836064
-	}
+	},
+
+	variants: [{
+		type: "normal",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "standard"
+	}, {
+		type: "reverse",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}, {
+		type: "reverse",
+		size: "standard",
+		foil: "pokeball",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}, {
+		type: "reverse",
+		size: "standard",
+		foil: "masterball",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}]
 }
 
 export default card

--- a/data/Scarlet & Violet/Black Bolt/078.ts
+++ b/data/Scarlet & Violet/Black Bolt/078.ts
@@ -66,7 +66,31 @@ const card: Card = {
 
 	thirdParty: {
 		cardmarket: 836065
-	}
+	},
+
+	variants: [{
+		type: "normal",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "standard"
+	}, {
+		type: "reverse",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}, {
+		type: "reverse",
+		size: "standard",
+		foil: "pokeball",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}, {
+		type: "reverse",
+		size: "standard",
+		foil: "masterball",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}]
 }
 
 export default card

--- a/data/Scarlet & Violet/Black Bolt/079.ts
+++ b/data/Scarlet & Violet/Black Bolt/079.ts
@@ -32,7 +32,25 @@ const card: Card = {
 
 	thirdParty: {
 		cardmarket: 836066
-	}
+	},
+
+	variants: [{
+		type: "normal",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "standard"
+	}, {
+		type: "reverse",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}, {
+		type: "reverse",
+		size: "standard",
+		foil: "pokeball",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}]
 }
 
 export default card

--- a/data/Scarlet & Violet/Black Bolt/080.ts
+++ b/data/Scarlet & Violet/Black Bolt/080.ts
@@ -56,7 +56,25 @@ const card: Card = {
 
 	thirdParty: {
 		cardmarket: 836067
-	}
+	},
+
+	variants: [{
+		type: "normal",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "standard"
+	}, {
+		type: "reverse",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}, {
+		type: "reverse",
+		size: "standard",
+		foil: "pokeball",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}]
 }
 
 export default card

--- a/data/Scarlet & Violet/Black Bolt/081.ts
+++ b/data/Scarlet & Violet/Black Bolt/081.ts
@@ -32,7 +32,25 @@ const card: Card = {
 
 	thirdParty: {
 		cardmarket: 836068
-	}
+	},
+
+	variants: [{
+		type: "normal",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "standard"
+	}, {
+		type: "reverse",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}, {
+		type: "reverse",
+		size: "standard",
+		foil: "pokeball",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}]
 }
 
 export default card

--- a/data/Scarlet & Violet/Black Bolt/082.ts
+++ b/data/Scarlet & Violet/Black Bolt/082.ts
@@ -32,7 +32,25 @@ const card: Card = {
 
 	thirdParty: {
 		cardmarket: 836069
-	}
+	},
+
+	variants: [{
+		type: "normal",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "standard"
+	}, {
+		type: "reverse",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}, {
+		type: "reverse",
+		size: "standard",
+		foil: "pokeball",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}]
 }
 
 export default card

--- a/data/Scarlet & Violet/Black Bolt/083.ts
+++ b/data/Scarlet & Violet/Black Bolt/083.ts
@@ -32,7 +32,25 @@ const card: Card = {
 
 	thirdParty: {
 		cardmarket: 836070
-	}
+	},
+
+	variants: [{
+		type: "normal",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "standard"
+	}, {
+		type: "reverse",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}, {
+		type: "reverse",
+		size: "standard",
+		foil: "pokeball",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}]
 }
 
 export default card

--- a/data/Scarlet & Violet/Black Bolt/084.ts
+++ b/data/Scarlet & Violet/Black Bolt/084.ts
@@ -32,7 +32,25 @@ const card: Card = {
 
 	thirdParty: {
 		cardmarket: 836073
-	}
+	},
+
+	variants: [{
+		type: "normal",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "standard"
+	}, {
+		type: "reverse",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}, {
+		type: "reverse",
+		size: "standard",
+		foil: "pokeball",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}]
 }
 
 export default card

--- a/data/Scarlet & Violet/Black Bolt/085.ts
+++ b/data/Scarlet & Violet/Black Bolt/085.ts
@@ -32,7 +32,25 @@ const card: Card = {
 
 	thirdParty: {
 		cardmarket: 836076
-	}
+	},
+
+	variants: [{
+		type: "normal",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "standard"
+	}, {
+		type: "reverse",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}, {
+		type: "reverse",
+		size: "standard",
+		foil: "pokeball",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}]
 }
 
 export default card

--- a/data/Scarlet & Violet/Black Bolt/086.ts
+++ b/data/Scarlet & Violet/Black Bolt/086.ts
@@ -32,7 +32,25 @@ const card: Card = {
 
 	thirdParty: {
 		cardmarket: 836078
-	}
+	},
+
+	variants: [{
+		type: "normal",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "standard"
+	}, {
+		type: "reverse",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}, {
+		type: "reverse",
+		size: "standard",
+		foil: "pokeball",
+		description: "Found in Booster Packs",
+		set: "parallel"
+	}]
 }
 
 export default card

--- a/data/Scarlet & Violet/Black Bolt/087.ts
+++ b/data/Scarlet & Violet/Black Bolt/087.ts
@@ -56,7 +56,14 @@ const card: Card = {
 
 	thirdParty: {
 		cardmarket: 835903
-	}
+	},
+
+	variants: [{
+		type: "holo",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "standard"
+	}]
 }
 
 export default card

--- a/data/Scarlet & Violet/Black Bolt/088.ts
+++ b/data/Scarlet & Violet/Black Bolt/088.ts
@@ -66,7 +66,14 @@ const card: Card = {
 
 	thirdParty: {
 		cardmarket: 835905
-	}
+	},
+
+	variants: [{
+		type: "holo",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "standard"
+	}]
 }
 
 export default card

--- a/data/Scarlet & Violet/Black Bolt/089.ts
+++ b/data/Scarlet & Violet/Black Bolt/089.ts
@@ -64,7 +64,14 @@ const card: Card = {
 
 	thirdParty: {
 		cardmarket: 835910
-	}
+	},
+
+	variants: [{
+		type: "holo",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "standard"
+	}]
 }
 
 export default card

--- a/data/Scarlet & Violet/Black Bolt/090.ts
+++ b/data/Scarlet & Violet/Black Bolt/090.ts
@@ -42,7 +42,14 @@ const card: Card = {
 
 	thirdParty: {
 		cardmarket: 835912
-	}
+	},
+
+	variants: [{
+		type: "holo",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "standard"
+	}]
 }
 
 export default card

--- a/data/Scarlet & Violet/Black Bolt/091.ts
+++ b/data/Scarlet & Violet/Black Bolt/091.ts
@@ -64,7 +64,14 @@ const card: Card = {
 
 	thirdParty: {
 		cardmarket: 835914
-	}
+	},
+
+	variants: [{
+		type: "holo",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "standard"
+	}]
 }
 
 export default card

--- a/data/Scarlet & Violet/Black Bolt/092.ts
+++ b/data/Scarlet & Violet/Black Bolt/092.ts
@@ -66,7 +66,14 @@ const card: Card = {
 
 	thirdParty: {
 		cardmarket: 835916
-	}
+	},
+
+	variants: [{
+		type: "holo",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "standard"
+	}]
 }
 
 export default card

--- a/data/Scarlet & Violet/Black Bolt/093.ts
+++ b/data/Scarlet & Violet/Black Bolt/093.ts
@@ -66,7 +66,14 @@ const card: Card = {
 
 	thirdParty: {
 		cardmarket: 835918
-	}
+	},
+
+	variants: [{
+		type: "holo",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "standard"
+	}]
 }
 
 export default card

--- a/data/Scarlet & Violet/Black Bolt/094.ts
+++ b/data/Scarlet & Violet/Black Bolt/094.ts
@@ -66,7 +66,14 @@ const card: Card = {
 
 	thirdParty: {
 		cardmarket: 835919
-	}
+	},
+
+	variants: [{
+		type: "holo",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "standard"
+	}]
 }
 
 export default card

--- a/data/Scarlet & Violet/Black Bolt/095.ts
+++ b/data/Scarlet & Violet/Black Bolt/095.ts
@@ -50,7 +50,14 @@ const card: Card = {
 
 	thirdParty: {
 		cardmarket: 835921
-	}
+	},
+
+	variants: [{
+		type: "holo",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "standard"
+	}]
 }
 
 export default card

--- a/data/Scarlet & Violet/Black Bolt/096.ts
+++ b/data/Scarlet & Violet/Black Bolt/096.ts
@@ -66,7 +66,14 @@ const card: Card = {
 
 	thirdParty: {
 		cardmarket: 835922
-	}
+	},
+
+	variants: [{
+		type: "holo",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "standard"
+	}]
 }
 
 export default card

--- a/data/Scarlet & Violet/Black Bolt/097.ts
+++ b/data/Scarlet & Violet/Black Bolt/097.ts
@@ -42,7 +42,14 @@ const card: Card = {
 
 	thirdParty: {
 		cardmarket: 835928
-	}
+	},
+
+	variants: [{
+		type: "holo",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "standard"
+	}]
 }
 
 export default card

--- a/data/Scarlet & Violet/Black Bolt/098.ts
+++ b/data/Scarlet & Violet/Black Bolt/098.ts
@@ -76,7 +76,14 @@ const card: Card = {
 
 	thirdParty: {
 		cardmarket: 835929
-	}
+	},
+
+	variants: [{
+		type: "holo",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "standard"
+	}]
 }
 
 export default card

--- a/data/Scarlet & Violet/Black Bolt/099.ts
+++ b/data/Scarlet & Violet/Black Bolt/099.ts
@@ -52,7 +52,14 @@ const card: Card = {
 
 	thirdParty: {
 		cardmarket: 835932
-	}
+	},
+
+	variants: [{
+		type: "holo",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "standard"
+	}]
 }
 
 export default card

--- a/data/Scarlet & Violet/Black Bolt/100.ts
+++ b/data/Scarlet & Violet/Black Bolt/100.ts
@@ -66,7 +66,14 @@ const card: Card = {
 
 	thirdParty: {
 		cardmarket: 835934
-	}
+	},
+
+	variants: [{
+		type: "holo",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "standard"
+	}]
 }
 
 export default card

--- a/data/Scarlet & Violet/Black Bolt/101.ts
+++ b/data/Scarlet & Violet/Black Bolt/101.ts
@@ -64,7 +64,14 @@ const card: Card = {
 
 	thirdParty: {
 		cardmarket: 835936
-	}
+	},
+
+	variants: [{
+		type: "holo",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "standard"
+	}]
 }
 
 export default card

--- a/data/Scarlet & Violet/Black Bolt/102.ts
+++ b/data/Scarlet & Violet/Black Bolt/102.ts
@@ -42,7 +42,14 @@ const card: Card = {
 
 	thirdParty: {
 		cardmarket: 835939
-	}
+	},
+
+	variants: [{
+		type: "holo",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "standard"
+	}]
 }
 
 export default card

--- a/data/Scarlet & Violet/Black Bolt/103.ts
+++ b/data/Scarlet & Violet/Black Bolt/103.ts
@@ -52,7 +52,14 @@ const card: Card = {
 
 	thirdParty: {
 		cardmarket: 835940
-	}
+	},
+
+	variants: [{
+		type: "holo",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "standard"
+	}]
 }
 
 export default card

--- a/data/Scarlet & Violet/Black Bolt/104.ts
+++ b/data/Scarlet & Violet/Black Bolt/104.ts
@@ -66,7 +66,14 @@ const card: Card = {
 
 	thirdParty: {
 		cardmarket: 835942
-	}
+	},
+
+	variants: [{
+		type: "holo",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "standard"
+	}]
 }
 
 export default card

--- a/data/Scarlet & Violet/Black Bolt/105.ts
+++ b/data/Scarlet & Violet/Black Bolt/105.ts
@@ -66,7 +66,14 @@ const card: Card = {
 
 	thirdParty: {
 		cardmarket: 835943
-	}
+	},
+
+	variants: [{
+		type: "holo",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "standard"
+	}]
 }
 
 export default card

--- a/data/Scarlet & Violet/Black Bolt/106.ts
+++ b/data/Scarlet & Violet/Black Bolt/106.ts
@@ -66,7 +66,14 @@ const card: Card = {
 
 	thirdParty: {
 		cardmarket: 835945
-	}
+	},
+
+	variants: [{
+		type: "holo",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "standard"
+	}]
 }
 
 export default card

--- a/data/Scarlet & Violet/Black Bolt/107.ts
+++ b/data/Scarlet & Violet/Black Bolt/107.ts
@@ -76,7 +76,14 @@ const card: Card = {
 
 	thirdParty: {
 		cardmarket: 835947
-	}
+	},
+
+	variants: [{
+		type: "holo",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "standard"
+	}]
 }
 
 export default card

--- a/data/Scarlet & Violet/Black Bolt/108.ts
+++ b/data/Scarlet & Violet/Black Bolt/108.ts
@@ -66,7 +66,14 @@ const card: Card = {
 
 	thirdParty: {
 		cardmarket: 835948
-	}
+	},
+
+	variants: [{
+		type: "holo",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "standard"
+	}]
 }
 
 export default card

--- a/data/Scarlet & Violet/Black Bolt/109.ts
+++ b/data/Scarlet & Violet/Black Bolt/109.ts
@@ -52,7 +52,14 @@ const card: Card = {
 
 	thirdParty: {
 		cardmarket: 835949
-	}
+	},
+
+	variants: [{
+		type: "holo",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "standard"
+	}]
 }
 
 export default card

--- a/data/Scarlet & Violet/Black Bolt/110.ts
+++ b/data/Scarlet & Violet/Black Bolt/110.ts
@@ -76,7 +76,14 @@ const card: Card = {
 
 	thirdParty: {
 		cardmarket: 835950
-	}
+	},
+
+	variants: [{
+		type: "holo",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "standard"
+	}]
 }
 
 export default card

--- a/data/Scarlet & Violet/Black Bolt/111.ts
+++ b/data/Scarlet & Violet/Black Bolt/111.ts
@@ -64,7 +64,14 @@ const card: Card = {
 
 	thirdParty: {
 		cardmarket: 835953
-	}
+	},
+
+	variants: [{
+		type: "holo",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "standard"
+	}]
 }
 
 export default card

--- a/data/Scarlet & Violet/Black Bolt/112.ts
+++ b/data/Scarlet & Violet/Black Bolt/112.ts
@@ -64,7 +64,14 @@ const card: Card = {
 
 	thirdParty: {
 		cardmarket: 835957
-	}
+	},
+
+	variants: [{
+		type: "holo",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "standard"
+	}]
 }
 
 export default card

--- a/data/Scarlet & Violet/Black Bolt/113.ts
+++ b/data/Scarlet & Violet/Black Bolt/113.ts
@@ -50,7 +50,14 @@ const card: Card = {
 
 	thirdParty: {
 		cardmarket: 835959
-	}
+	},
+
+	variants: [{
+		type: "holo",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "standard"
+	}]
 }
 
 export default card

--- a/data/Scarlet & Violet/Black Bolt/114.ts
+++ b/data/Scarlet & Violet/Black Bolt/114.ts
@@ -66,7 +66,14 @@ const card: Card = {
 
 	thirdParty: {
 		cardmarket: 835961
-	}
+	},
+
+	variants: [{
+		type: "holo",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "standard"
+	}]
 }
 
 export default card

--- a/data/Scarlet & Violet/Black Bolt/115.ts
+++ b/data/Scarlet & Violet/Black Bolt/115.ts
@@ -76,7 +76,14 @@ const card: Card = {
 
 	thirdParty: {
 		cardmarket: 835964
-	}
+	},
+
+	variants: [{
+		type: "holo",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "standard"
+	}]
 }
 
 export default card

--- a/data/Scarlet & Violet/Black Bolt/116.ts
+++ b/data/Scarlet & Violet/Black Bolt/116.ts
@@ -64,7 +64,14 @@ const card: Card = {
 
 	thirdParty: {
 		cardmarket: 835978
-	}
+	},
+
+	variants: [{
+		type: "holo",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "standard"
+	}]
 }
 
 export default card

--- a/data/Scarlet & Violet/Black Bolt/117.ts
+++ b/data/Scarlet & Violet/Black Bolt/117.ts
@@ -74,7 +74,14 @@ const card: Card = {
 
 	thirdParty: {
 		cardmarket: 835980
-	}
+	},
+
+	variants: [{
+		type: "holo",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "standard"
+	}]
 }
 
 export default card

--- a/data/Scarlet & Violet/Black Bolt/118.ts
+++ b/data/Scarlet & Violet/Black Bolt/118.ts
@@ -42,7 +42,14 @@ const card: Card = {
 
 	thirdParty: {
 		cardmarket: 835981
-	}
+	},
+
+	variants: [{
+		type: "holo",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "standard"
+	}]
 }
 
 export default card

--- a/data/Scarlet & Violet/Black Bolt/119.ts
+++ b/data/Scarlet & Violet/Black Bolt/119.ts
@@ -64,7 +64,14 @@ const card: Card = {
 
 	thirdParty: {
 		cardmarket: 835983
-	}
+	},
+
+	variants: [{
+		type: "holo",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "standard"
+	}]
 }
 
 export default card

--- a/data/Scarlet & Violet/Black Bolt/120.ts
+++ b/data/Scarlet & Violet/Black Bolt/120.ts
@@ -64,7 +64,14 @@ const card: Card = {
 
 	thirdParty: {
 		cardmarket: 835988
-	}
+	},
+
+	variants: [{
+		type: "holo",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "standard"
+	}]
 }
 
 export default card

--- a/data/Scarlet & Violet/Black Bolt/121.ts
+++ b/data/Scarlet & Violet/Black Bolt/121.ts
@@ -74,7 +74,14 @@ const card: Card = {
 
 	thirdParty: {
 		cardmarket: 835989
-	}
+	},
+
+	variants: [{
+		type: "holo",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "standard"
+	}]
 }
 
 export default card

--- a/data/Scarlet & Violet/Black Bolt/122.ts
+++ b/data/Scarlet & Violet/Black Bolt/122.ts
@@ -52,7 +52,14 @@ const card: Card = {
 
 	thirdParty: {
 		cardmarket: 835992
-	}
+	},
+
+	variants: [{
+		type: "holo",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "standard"
+	}]
 }
 
 export default card

--- a/data/Scarlet & Violet/Black Bolt/123.ts
+++ b/data/Scarlet & Violet/Black Bolt/123.ts
@@ -66,7 +66,14 @@ const card: Card = {
 
 	thirdParty: {
 		cardmarket: 835994
-	}
+	},
+
+	variants: [{
+		type: "holo",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "standard"
+	}]
 }
 
 export default card

--- a/data/Scarlet & Violet/Black Bolt/124.ts
+++ b/data/Scarlet & Violet/Black Bolt/124.ts
@@ -56,7 +56,14 @@ const card: Card = {
 
 	thirdParty: {
 		cardmarket: 835998
-	}
+	},
+
+	variants: [{
+		type: "holo",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "standard"
+	}]
 }
 
 export default card

--- a/data/Scarlet & Violet/Black Bolt/125.ts
+++ b/data/Scarlet & Violet/Black Bolt/125.ts
@@ -56,7 +56,14 @@ const card: Card = {
 
 	thirdParty: {
 		cardmarket: 836003
-	}
+	},
+
+	variants: [{
+		type: "holo",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "standard"
+	}]
 }
 
 export default card

--- a/data/Scarlet & Violet/Black Bolt/126.ts
+++ b/data/Scarlet & Violet/Black Bolt/126.ts
@@ -66,7 +66,14 @@ const card: Card = {
 
 	thirdParty: {
 		cardmarket: 836005
-	}
+	},
+
+	variants: [{
+		type: "holo",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "standard"
+	}]
 }
 
 export default card

--- a/data/Scarlet & Violet/Black Bolt/127.ts
+++ b/data/Scarlet & Violet/Black Bolt/127.ts
@@ -76,7 +76,14 @@ const card: Card = {
 
 	thirdParty: {
 		cardmarket: 836007
-	}
+	},
+
+	variants: [{
+		type: "holo",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "standard"
+	}]
 }
 
 export default card

--- a/data/Scarlet & Violet/Black Bolt/128.ts
+++ b/data/Scarlet & Violet/Black Bolt/128.ts
@@ -52,7 +52,14 @@ const card: Card = {
 
 	thirdParty: {
 		cardmarket: 836009
-	}
+	},
+
+	variants: [{
+		type: "holo",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "standard"
+	}]
 }
 
 export default card

--- a/data/Scarlet & Violet/Black Bolt/129.ts
+++ b/data/Scarlet & Violet/Black Bolt/129.ts
@@ -66,7 +66,14 @@ const card: Card = {
 
 	thirdParty: {
 		cardmarket: 836011
-	}
+	},
+
+	variants: [{
+		type: "holo",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "standard"
+	}]
 }
 
 export default card

--- a/data/Scarlet & Violet/Black Bolt/130.ts
+++ b/data/Scarlet & Violet/Black Bolt/130.ts
@@ -76,7 +76,14 @@ const card: Card = {
 
 	thirdParty: {
 		cardmarket: 836013
-	}
+	},
+
+	variants: [{
+		type: "holo",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "standard"
+	}]
 }
 
 export default card

--- a/data/Scarlet & Violet/Black Bolt/131.ts
+++ b/data/Scarlet & Violet/Black Bolt/131.ts
@@ -74,7 +74,14 @@ const card: Card = {
 
 	thirdParty: {
 		cardmarket: 836015
-	}
+	},
+
+	variants: [{
+		type: "holo",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "standard"
+	}]
 }
 
 export default card

--- a/data/Scarlet & Violet/Black Bolt/132.ts
+++ b/data/Scarlet & Violet/Black Bolt/132.ts
@@ -50,7 +50,14 @@ const card: Card = {
 
 	thirdParty: {
 		cardmarket: 836017
-	}
+	},
+
+	variants: [{
+		type: "holo",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "standard"
+	}]
 }
 
 export default card

--- a/data/Scarlet & Violet/Black Bolt/133.ts
+++ b/data/Scarlet & Violet/Black Bolt/133.ts
@@ -52,7 +52,14 @@ const card: Card = {
 
 	thirdParty: {
 		cardmarket: 836018
-	}
+	},
+
+	variants: [{
+		type: "holo",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "standard"
+	}]
 }
 
 export default card

--- a/data/Scarlet & Violet/Black Bolt/134.ts
+++ b/data/Scarlet & Violet/Black Bolt/134.ts
@@ -76,7 +76,14 @@ const card: Card = {
 
 	thirdParty: {
 		cardmarket: 836021
-	}
+	},
+
+	variants: [{
+		type: "holo",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "standard"
+	}]
 }
 
 export default card

--- a/data/Scarlet & Violet/Black Bolt/135.ts
+++ b/data/Scarlet & Violet/Black Bolt/135.ts
@@ -52,7 +52,14 @@ const card: Card = {
 
 	thirdParty: {
 		cardmarket: 836023
-	}
+	},
+
+	variants: [{
+		type: "holo",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "standard"
+	}]
 }
 
 export default card

--- a/data/Scarlet & Violet/Black Bolt/136.ts
+++ b/data/Scarlet & Violet/Black Bolt/136.ts
@@ -52,7 +52,14 @@ const card: Card = {
 
 	thirdParty: {
 		cardmarket: 836024
-	}
+	},
+
+	variants: [{
+		type: "holo",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "standard"
+	}]
 }
 
 export default card

--- a/data/Scarlet & Violet/Black Bolt/137.ts
+++ b/data/Scarlet & Violet/Black Bolt/137.ts
@@ -76,7 +76,14 @@ const card: Card = {
 
 	thirdParty: {
 		cardmarket: 836026
-	}
+	},
+
+	variants: [{
+		type: "holo",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "standard"
+	}]
 }
 
 export default card

--- a/data/Scarlet & Violet/Black Bolt/138.ts
+++ b/data/Scarlet & Violet/Black Bolt/138.ts
@@ -52,7 +52,14 @@ const card: Card = {
 
 	thirdParty: {
 		cardmarket: 836033
-	}
+	},
+
+	variants: [{
+		type: "holo",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "standard"
+	}]
 }
 
 export default card

--- a/data/Scarlet & Violet/Black Bolt/139.ts
+++ b/data/Scarlet & Violet/Black Bolt/139.ts
@@ -52,7 +52,14 @@ const card: Card = {
 
 	thirdParty: {
 		cardmarket: 836035
-	}
+	},
+
+	variants: [{
+		type: "holo",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "standard"
+	}]
 }
 
 export default card

--- a/data/Scarlet & Violet/Black Bolt/140.ts
+++ b/data/Scarlet & Violet/Black Bolt/140.ts
@@ -52,7 +52,14 @@ const card: Card = {
 
 	thirdParty: {
 		cardmarket: 836037
-	}
+	},
+
+	variants: [{
+		type: "holo",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "standard"
+	}]
 }
 
 export default card

--- a/data/Scarlet & Violet/Black Bolt/141.ts
+++ b/data/Scarlet & Violet/Black Bolt/141.ts
@@ -66,7 +66,14 @@ const card: Card = {
 
 	thirdParty: {
 		cardmarket: 836039
-	}
+	},
+
+	variants: [{
+		type: "holo",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "standard"
+	}]
 }
 
 export default card

--- a/data/Scarlet & Violet/Black Bolt/142.ts
+++ b/data/Scarlet & Violet/Black Bolt/142.ts
@@ -52,7 +52,14 @@ const card: Card = {
 
 	thirdParty: {
 		cardmarket: 836041
-	}
+	},
+
+	variants: [{
+		type: "holo",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "standard"
+	}]
 }
 
 export default card

--- a/data/Scarlet & Violet/Black Bolt/143.ts
+++ b/data/Scarlet & Violet/Black Bolt/143.ts
@@ -66,7 +66,14 @@ const card: Card = {
 
 	thirdParty: {
 		cardmarket: 836043
-	}
+	},
+
+	variants: [{
+		type: "holo",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "standard"
+	}]
 }
 
 export default card

--- a/data/Scarlet & Violet/Black Bolt/144.ts
+++ b/data/Scarlet & Violet/Black Bolt/144.ts
@@ -76,7 +76,14 @@ const card: Card = {
 
 	thirdParty: {
 		cardmarket: 836045
-	}
+	},
+
+	variants: [{
+		type: "holo",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "standard"
+	}]
 }
 
 export default card

--- a/data/Scarlet & Violet/Black Bolt/145.ts
+++ b/data/Scarlet & Violet/Black Bolt/145.ts
@@ -50,7 +50,14 @@ const card: Card = {
 
 	thirdParty: {
 		cardmarket: 836047
-	}
+	},
+
+	variants: [{
+		type: "holo",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "standard"
+	}]
 }
 
 export default card

--- a/data/Scarlet & Violet/Black Bolt/146.ts
+++ b/data/Scarlet & Violet/Black Bolt/146.ts
@@ -66,7 +66,14 @@ const card: Card = {
 
 	thirdParty: {
 		cardmarket: 836048
-	}
+	},
+
+	variants: [{
+		type: "holo",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "standard"
+	}]
 }
 
 export default card

--- a/data/Scarlet & Violet/Black Bolt/147.ts
+++ b/data/Scarlet & Violet/Black Bolt/147.ts
@@ -74,7 +74,14 @@ const card: Card = {
 
 	thirdParty: {
 		cardmarket: 836050
-	}
+	},
+
+	variants: [{
+		type: "holo",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "standard"
+	}]
 }
 
 export default card

--- a/data/Scarlet & Violet/Black Bolt/148.ts
+++ b/data/Scarlet & Violet/Black Bolt/148.ts
@@ -64,7 +64,14 @@ const card: Card = {
 
 	thirdParty: {
 		cardmarket: 836052
-	}
+	},
+
+	variants: [{
+		type: "holo",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "standard"
+	}]
 }
 
 export default card

--- a/data/Scarlet & Violet/Black Bolt/149.ts
+++ b/data/Scarlet & Violet/Black Bolt/149.ts
@@ -52,7 +52,14 @@ const card: Card = {
 
 	thirdParty: {
 		cardmarket: 836055
-	}
+	},
+
+	variants: [{
+		type: "holo",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "standard"
+	}]
 }
 
 export default card

--- a/data/Scarlet & Violet/Black Bolt/150.ts
+++ b/data/Scarlet & Violet/Black Bolt/150.ts
@@ -74,7 +74,14 @@ const card: Card = {
 
 	thirdParty: {
 		cardmarket: 836056
-	}
+	},
+
+	variants: [{
+		type: "holo",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "standard"
+	}]
 }
 
 export default card

--- a/data/Scarlet & Violet/Black Bolt/151.ts
+++ b/data/Scarlet & Violet/Black Bolt/151.ts
@@ -52,7 +52,14 @@ const card: Card = {
 
 	thirdParty: {
 		cardmarket: 836058
-	}
+	},
+
+	variants: [{
+		type: "holo",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "standard"
+	}]
 }
 
 export default card

--- a/data/Scarlet & Violet/Black Bolt/152.ts
+++ b/data/Scarlet & Violet/Black Bolt/152.ts
@@ -52,7 +52,14 @@ const card: Card = {
 
 	thirdParty: {
 		cardmarket: 836060
-	}
+	},
+
+	variants: [{
+		type: "holo",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "standard"
+	}]
 }
 
 export default card

--- a/data/Scarlet & Violet/Black Bolt/153.ts
+++ b/data/Scarlet & Violet/Black Bolt/153.ts
@@ -52,7 +52,14 @@ const card: Card = {
 
 	thirdParty: {
 		cardmarket: 836063
-	}
+	},
+
+	variants: [{
+		type: "holo",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "standard"
+	}]
 }
 
 export default card

--- a/data/Scarlet & Violet/Black Bolt/154.ts
+++ b/data/Scarlet & Violet/Black Bolt/154.ts
@@ -56,7 +56,14 @@ const card: Card = {
 
 	thirdParty: {
 		cardmarket: 836064
-	}
+	},
+
+	variants: [{
+		type: "holo",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "standard"
+	}]
 }
 
 export default card

--- a/data/Scarlet & Violet/Black Bolt/155.ts
+++ b/data/Scarlet & Violet/Black Bolt/155.ts
@@ -66,7 +66,14 @@ const card: Card = {
 
 	thirdParty: {
 		cardmarket: 836065
-	}
+	},
+
+	variants: [{
+		type: "holo",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "standard"
+	}]
 }
 
 export default card

--- a/data/Scarlet & Violet/Black Bolt/156.ts
+++ b/data/Scarlet & Violet/Black Bolt/156.ts
@@ -76,7 +76,14 @@ const card: Card = {
 
 	thirdParty: {
 		cardmarket: 835908
-	}
+	},
+
+	variants: [{
+		type: "holo",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "standard"
+	}]
 }
 
 export default card

--- a/data/Scarlet & Violet/Black Bolt/157.ts
+++ b/data/Scarlet & Violet/Black Bolt/157.ts
@@ -66,7 +66,14 @@ const card: Card = {
 
 	thirdParty: {
 		cardmarket: 835955
-	}
+	},
+
+	variants: [{
+		type: "holo",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "standard"
+	}]
 }
 
 export default card

--- a/data/Scarlet & Violet/Black Bolt/158.ts
+++ b/data/Scarlet & Violet/Black Bolt/158.ts
@@ -66,7 +66,14 @@ const card: Card = {
 
 	thirdParty: {
 		cardmarket: 835966
-	}
+	},
+
+	variants: [{
+		type: "holo",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "standard"
+	}]
 }
 
 export default card

--- a/data/Scarlet & Violet/Black Bolt/159.ts
+++ b/data/Scarlet & Violet/Black Bolt/159.ts
@@ -76,7 +76,14 @@ const card: Card = {
 
 	thirdParty: {
 		cardmarket: 835996
-	}
+	},
+
+	variants: [{
+		type: "holo",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "standard"
+	}]
 }
 
 export default card

--- a/data/Scarlet & Violet/Black Bolt/160.ts
+++ b/data/Scarlet & Violet/Black Bolt/160.ts
@@ -76,7 +76,14 @@ const card: Card = {
 
 	thirdParty: {
 		cardmarket: 835999
-	}
+	},
+
+	variants: [{
+		type: "holo",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "standard"
+	}]
 }
 
 export default card

--- a/data/Scarlet & Violet/Black Bolt/161.ts
+++ b/data/Scarlet & Violet/Black Bolt/161.ts
@@ -76,7 +76,14 @@ const card: Card = {
 
 	thirdParty: {
 		cardmarket: 836046
-	}
+	},
+
+	variants: [{
+		type: "holo",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "standard"
+	}]
 }
 
 export default card

--- a/data/Scarlet & Violet/Black Bolt/162.ts
+++ b/data/Scarlet & Violet/Black Bolt/162.ts
@@ -32,7 +32,14 @@ const card: Card = {
 
 	thirdParty: {
 		cardmarket: 836069
-	}
+	},
+
+	variants: [{
+		type: "holo",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "standard"
+	}]
 }
 
 export default card

--- a/data/Scarlet & Violet/Black Bolt/163.ts
+++ b/data/Scarlet & Violet/Black Bolt/163.ts
@@ -32,7 +32,14 @@ const card: Card = {
 
 	thirdParty: {
 		cardmarket: 836070
-	}
+	},
+
+	variants: [{
+		type: "holo",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "standard"
+	}]
 }
 
 export default card

--- a/data/Scarlet & Violet/Black Bolt/164.ts
+++ b/data/Scarlet & Violet/Black Bolt/164.ts
@@ -76,7 +76,14 @@ const card: Card = {
 
 	thirdParty: {
 		cardmarket: 835908
-	}
+	},
+
+	variants: [{
+		type: "holo",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "standard"
+	}]
 }
 
 export default card

--- a/data/Scarlet & Violet/Black Bolt/165.ts
+++ b/data/Scarlet & Violet/Black Bolt/165.ts
@@ -66,7 +66,14 @@ const card: Card = {
 
 	thirdParty: {
 		cardmarket: 835955
-	}
+	},
+
+	variants: [{
+		type: "holo",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "standard"
+	}]
 }
 
 export default card

--- a/data/Scarlet & Violet/Black Bolt/166.ts
+++ b/data/Scarlet & Violet/Black Bolt/166.ts
@@ -66,7 +66,14 @@ const card: Card = {
 
 	thirdParty: {
 		cardmarket: 835966
-	}
+	},
+
+	variants: [{
+		type: "holo",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "standard"
+	}]
 }
 
 export default card

--- a/data/Scarlet & Violet/Black Bolt/167.ts
+++ b/data/Scarlet & Violet/Black Bolt/167.ts
@@ -76,7 +76,14 @@ const card: Card = {
 
 	thirdParty: {
 		cardmarket: 835996
-	}
+	},
+
+	variants: [{
+		type: "holo",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "standard"
+	}]
 }
 
 export default card

--- a/data/Scarlet & Violet/Black Bolt/168.ts
+++ b/data/Scarlet & Violet/Black Bolt/168.ts
@@ -76,7 +76,14 @@ const card: Card = {
 
 	thirdParty: {
 		cardmarket: 835999
-	}
+	},
+
+	variants: [{
+		type: "holo",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "standard"
+	}]
 }
 
 export default card

--- a/data/Scarlet & Violet/Black Bolt/169.ts
+++ b/data/Scarlet & Violet/Black Bolt/169.ts
@@ -76,7 +76,14 @@ const card: Card = {
 
 	thirdParty: {
 		cardmarket: 836046
-	}
+	},
+
+	variants: [{
+		type: "holo",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "standard"
+	}]
 }
 
 export default card

--- a/data/Scarlet & Violet/Black Bolt/170.ts
+++ b/data/Scarlet & Violet/Black Bolt/170.ts
@@ -32,7 +32,14 @@ const card: Card = {
 
 	thirdParty: {
 		cardmarket: 836070
-	}
+	},
+
+	variants: [{
+		type: "holo",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "standard"
+	}]
 }
 
 export default card

--- a/data/Scarlet & Violet/Black Bolt/171.ts
+++ b/data/Scarlet & Violet/Black Bolt/171.ts
@@ -52,7 +52,14 @@ const card: Card = {
 
 	thirdParty: {
 		cardmarket: 835926
-	}
+	},
+
+	variants: [{
+		type: "holo",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "standard"
+	}]
 }
 
 export default card

--- a/data/Scarlet & Violet/Black Bolt/172.ts
+++ b/data/Scarlet & Violet/Black Bolt/172.ts
@@ -66,7 +66,14 @@ const card: Card = {
 
 	thirdParty: {
 		cardmarket: 835966
-	}
+	},
+
+	variants: [{
+		type: "holo",
+		size: "standard",
+		description: "Found in Booster Packs",
+		set: "standard"
+	}]
 }
 
 export default card

--- a/interfaces.d.ts
+++ b/interfaces.d.ts
@@ -53,6 +53,18 @@ interface variant_detailed {
 	 * for the holo & reverse, **optional** indicate which foil is used on the card
 	 */
 	foil?: 'pokeball' | 'ultraball' | 'masterball' | 'gold'
+  /**
+	 * Where it can be found or exclusivity details
+	 */
+	description?: string
+	/**
+	 * As per the set's ETB booklet
+	 * standard + parallel constitutes a "master set"
+	 * - standard: found as normal and holo in booster packs
+	 * - parallel: found as reverse holo in booster packs
+	 * - other: found in other products (battle decks, trick or trade, etc.)
+	 */
+	set?: 'standard' | 'parallel' | 'other'
 }
 
 interface variants {

--- a/meta/definitions/api.d.ts
+++ b/meta/definitions/api.d.ts
@@ -62,6 +62,8 @@ interface variant_detailed {
 	size?: string
 	stamp?: Array<string>
 	foil?: string
+  description?: string
+  set?: string
 }
 
 export interface SetResume {
@@ -198,6 +200,8 @@ export interface Card extends CardResume {
 	 * - size: the size of the variant (normal, jumbo, etc)
 	 * - stamp: the stamps of the variant (ex: 'Staff', 'Pre-release', etc)
 	 * - foil: the foil of the variant (ex: 'Holo', 'Reverse Holo', etc)
+   * - description: Where it can be found or exclusivity details
+   * - set: As per the set's ETB booklet (standard, parallel, other)
 
 	 */
 	variants_detailed?: Array<variant_detailed>;

--- a/meta/definitions/graphql.gql
+++ b/meta/definitions/graphql.gql
@@ -328,6 +328,10 @@ type DetailedVariants {
 	stamps: [String]
 	"""The type of foil"""
 	foil: String
+  """Where it can be found or exclusivity details"""
+  description: String
+  """As per the set's ETB booklet (standard, parallel, other)"""
+  set: String
 }
 """
 A booster pack for Pokémon TCG cards

--- a/meta/definitions/openapi.yaml
+++ b/meta/definitions/openapi.yaml
@@ -1536,6 +1536,14 @@ components:
                         type: string
                         description: The foil of the variant (e.g., 'Pokeball', 'MasterBall', etc.)
                         nullable: true
+                    description:
+                        type: string
+                        description: Where it can be found or exclusivity details
+                        nullable: true
+                    set:
+                        type: string
+                        description: What set this variant belongs to (e.g., 'standard', 'parallel', 'other')
+                        nullable: true
         hp:
           type: [number, "null"]
           description: Hit Points (HP) of the Pokemon


### PR DESCRIPTION
I'm planning on adding all variants found on `pkmn.gg`. The data includes
- The "main" variant of a card, that is the first one found in the set. Depicted as a variant of the "standard set"
- All of a card's variants,  including promotional/product exclusive ones.
- A description of the variant (e.g.: "Pikachu Deck stamp Battle Academy exclusive",  "(Cracked Ice) Found in Sword & Shield Rillaboom Theme Deck", etc.)
- The TCGPlayer Store ID of the variant. _Omitted as of now but could be useful?_

## Changes
- Added two fields to `variant_detailed`
  - description, used to denote where a certain variant was found
  - set, used to denote whether the variant is part of the standard set, parallel set, or neither _(could be renamed to something else?)_
- Added variants to all SV10.5b cards