### PR TITLE
Feat: Add SVP Black Star Promos cards 208-212

### DIFF
--- a/data/Scarlet & Violet/SVP Black Star Promos/208.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/208.ts
@@ -1,0 +1,59 @@
+import { Card } from "../../../interfaces"
+import Set from "../SVP Black Star Promos"
+
+const card: Card = {
+	dexId: [494],
+	set: Set,
+
+	name: {
+		en: "Victini",
+	},
+
+	rarity: "None",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Fire"],
+	stage: "Basic",
+	illustrator: "Amelicart",
+
+	attacks: [{
+		cost: ["Fire", "Fire"],
+
+		name: {
+			en: "V-Force",
+		},
+
+		effect:{
+			en: "If you have 4 or fewer Benched Pokémon, this attack does nothing.",
+		},
+
+		damage: 120
+	}],
+
+	retreat: 1,
+	regulationMark: "I",
+
+	weaknesses: [
+		{
+			type: "Water",
+			value: "×2"
+		}
+	],
+
+	variants: [
+		{
+			type: "holo"
+		},
+		{
+			type: "holo",
+			size: "jumbo"
+		}
+	],
+
+	thirdParty: {
+		cardmarket: 836653,
+		tcgplayer: 646169,
+	}
+}
+
+export default card

--- a/data/Scarlet & Violet/SVP Black Star Promos/209.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/209.ts
@@ -1,0 +1,72 @@
+import { Card } from "../../../interfaces"
+import Set from "../SVP Black Star Promos"
+
+const card: Card = {
+	dexId: [642],
+	set: Set,
+
+	name: {
+		en: "Thundurus",
+	},
+
+	rarity: "None",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Lightning"],
+	stage: "Basic",
+	illustrator: "Anesaki Dynamic",
+
+	attacks: [
+		{
+			cost: ["Colorless"],
+
+			name: {
+				en: "Charge",
+			},
+
+			effect: {
+				en: "Search your deck for a Basic Lightning Energy card and attach it to this Pokémon. Then, shuffle your deck.",
+			},
+		},
+		{
+			cost: ["Lightning", "Colorless", "Colorless"],
+
+			name: {
+				en: "Disaster Volt",
+			},
+
+			effect: {
+				en: "Discard an Energy from this Pokémon.",
+			},
+
+			damage: 110
+		}
+	],
+
+	retreat: 1,
+	regulationMark: "I",
+
+	weaknesses: [
+		{
+			type: "Fighting",
+			value: "×2"
+		}
+	],
+
+	variants: [
+		{
+			type: "holo"
+		},
+		{
+			type: "holo",
+			stamp: ["pokemon-center"]
+		}
+	],
+
+	thirdParty: {
+		cardmarket: 836655,
+		tcgplayer: 644833,
+	}
+}
+
+export default card

--- a/data/Scarlet & Violet/SVP Black Star Promos/210.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/210.ts
@@ -1,0 +1,79 @@
+import { Card } from "../../../interfaces"
+import Set from "../SVP Black Star Promos"
+
+const card: Card = {
+	dexId: [641],
+	set: Set,
+
+	name: {
+		en: "Tornadus",
+	},
+
+	rarity: "None",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Colorless"],
+	stage: "Basic",
+	illustrator: "Kouki Saitou",
+
+	attacks: [
+		{
+			cost: ["Colorless"],
+
+			name: {
+				en: "Wrapped in Wind",
+			},
+
+			effect: {
+				en: "Attach a Basic Energy card from your hand to this Pokémon.",
+			},
+		},
+		{
+			cost: ["Colorless", "Colorless", "Colorless"],
+
+			name: {
+				en: "Hurricane",
+			},
+
+			effect: {
+				en: "Move a Basic Energy from this Pokémon to 1 of your Benched Pokémon.",
+			},
+
+			damage: 100
+		}
+	],
+
+	retreat: 1,
+	regulationMark: "I",
+
+	weaknesses: [
+		{
+			type: "Lightning",
+			value: "×2"
+		}
+	],
+
+	resistances: [
+		{
+			type: "Fighting",
+			value: "-30"
+		}
+	],
+
+	variants: [
+		{
+			type: "holo"
+		},
+		{
+			type: "holo",
+			stamp: ["pokemon-center"]
+		}
+	],
+
+	thirdParty: {
+		cardmarket: 836656,
+		tcgplayer: 644835,
+	}
+}
+
+export default card

--- a/data/Scarlet & Violet/SVP Black Star Promos/211.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/211.ts
@@ -1,0 +1,63 @@
+import { Card } from "../../../interfaces"
+import Set from "../SVP Black Star Promos"
+
+const card: Card = {
+	dexId: [576],
+	set: Set,
+
+	name: {
+		en: "Gothitelle",
+	},
+
+	rarity: "None",
+	category: "Pokemon",
+	hp: 150,
+	types: ["Colorless"],
+	stage: "Stage2",
+	illustrator: "IKEDA Saki",
+
+	attacks: [
+		{
+			cost: ["Psychic","Colorless"],
+
+			name: {
+				en: "Synchro Shot",
+			},
+
+			effect: {
+				en: "If you have the same number of cards in your hand as your opponent, this attack does 90 more damage.",
+			},
+			damage: "90+"
+		}
+	],
+
+	weaknesses: [
+		{
+			type: "Darkness",
+			value: "×2"
+		}
+	],
+
+	resistances: [
+		{
+			type: "Fighting",
+			value: "-30"
+		}
+	],
+
+	retreat: 2,
+	regulationMark: "I",
+
+	variants: [
+		{
+			type: "holo"
+		},
+	],
+
+	thirdParty: {
+		cardmarket: 836659,
+		tcgplayer: 647306,
+	}
+}
+
+export default card

--- a/data/Scarlet & Violet/SVP Black Star Promos/212.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/212.ts
@@ -1,0 +1,75 @@
+import { Card } from "../../../interfaces"
+import Set from "../SVP Black Star Promos"
+
+const card: Card = {
+	dexId: [579],
+	set: Set,
+
+	name: {
+		en: "Reuniclus",
+	},
+
+	rarity: "None",
+	category: "Pokemon",
+	hp: 140,
+	types: ["Psychic"],
+	stage: "Stage2",
+	illustrator: "satoma",
+
+	attacks: [
+		{
+			cost: ["Colorless"],
+
+			name: {
+				en: "Cellular Ascension",
+			},
+
+			effect: {
+				en: "For each of your Benched Pokémon, search your deck for a card that evolves from that Pokémon and put it onto that Pokémon to evolve it. Then, shuffle your deck.",
+			},
+		},
+		{
+			cost: ["Colorless"],
+
+			name: {
+				en: "Evo-Lariat",
+			},
+
+			effect: {
+				en: "This attack foes 40 more damage for each of your Evolution Pokémon in play.",
+			},
+
+			damage: "40+"
+		}
+	],
+
+	retreat: 1,
+	regulationMark: "I",
+
+	weaknesses: [
+		{
+			type: "Darkness",
+			value: "×2"
+		}
+	],
+
+	resistances: [
+		{
+			type: "Fighting",
+			value: "-30"
+		}
+	],
+
+	variants: [
+		{
+			type: "holo"
+		}
+	],
+
+	thirdParty: {
+		cardmarket: 836658,
+		tcgplayer: 647309,
+	}
+}
+
+export default card


### PR DESCRIPTION
Added new card data files for Victini (208), Thundurus (209), Tornadus (210), Gothitelle (211), and Reuniclus (212) to the Scarlet & Violet SVP Black Star Promos set.
