### PR TITLE
Feat: Add abbreviation to SetResume

### DIFF
--- a/meta/definitions/api.d.ts
+++ b/meta/definitions/api.d.ts
@@ -79,6 +79,7 @@ export interface SetResume {
 		 */
 		official: number;
 	};
+	abbreviation: { official: string, localized: string };
 }
 
 /**
@@ -137,7 +138,6 @@ export interface Set extends SetResume {
 		firstEd?: number;
 	};
 	cards: Array<CardResume>;
-	abbreviation: { official: string, localized: string };
 	thirdParty?: {
 		cardmarket?: number
 		tcgplayer?: number

--- a/server/compiler/utils/setUtil.ts
+++ b/server/compiler/utils/setUtil.ts
@@ -76,7 +76,11 @@ export async function setToSetSimple(set: Set, lang: SupportedLanguages): Promis
 		id: set.id,
 		logo: pics[0],
 		name: resolveText(set.name, lang),
-		symbol: pics[1]
+		symbol: pics[1],
+		abbreviation: (set.abbreviations?.official || resolveText(set.abbreviations, lang)) ? {
+			official: set.abbreviations?.official,
+			localized: resolveText(set.abbreviations, lang)
+		} : undefined,
 	}
 }
 

--- a/server/src/V2/Components/Set.ts
+++ b/server/src/V2/Components/Set.ts
@@ -76,6 +76,7 @@ export function setToBrief(set: SDKSet): SetResume {
 		name: set.name,
 		logo: set.logo,
 		symbol: set.symbol,
+		abbreviation: set.abbreviation,
 		cardCount: {
 			total: set.cardCount.total,
 			official: set.cardCount.official


### PR DESCRIPTION
Update to SDK for this change [here](https://github.com/tcgdex/javascript-sdk/pull/306)

Example output
`"set": {
    "cardCount": {
      "official": 130,
      "total": 130
    },
    "id": "base4",
    "logo": "https://assets.tcgdex.net/en/base/base4/logo",
    "name": "Base Set 2",
    "symbol": "https://assets.tcgdex.net/univ/base/base4/symbol",
    "abbreviation": {
      "official": "B2"
    }
  },`