### PR TITLE
feat: Add SV11W (Japanese) cards

### DIFF
--- a/data-asia/SV/SV11W.ts
+++ b/data-asia/SV/SV11W.ts
@@ -1,0 +1,20 @@
+import { Set } from '../../interfaces'
+import serie from '../SV'
+
+const set: Set = {
+	id: 'SV11W',
+	name: {
+		ja: 'ホワイトフレア'
+	},
+
+	serie: serie,
+
+	cardCount: {
+		official: 86
+	},
+	releaseDate: {
+		ja: '2025-06-06'
+	}
+}
+
+export default set

--- a/data-asia/SV/SV11W/001.ts
+++ b/data-asia/SV/SV11W/001.ts
@@ -1,0 +1,52 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV11W";
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		ja: "クルミル",
+	},
+
+	illustrator: "Oswaldo KATO",
+	category: "Pokemon",
+	hp: 50,
+	types: ["Grass"],
+
+	description: {
+		ja: "タマゴから かえると ハハコモリに 服を 作ってもらい 着せられる。 フードで 頭を 隠して 寝る。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: {
+				ja: "むしくい",
+			},
+			damage: 20,
+			cost: ["Grass"],
+		},
+	],
+
+	weaknesses: [
+		{
+			type: "Fire",
+			value: "×2",
+		},
+	],
+
+	variants: {
+		normal: true,
+		reverse: true,
+		holo: false,
+		firstEdition: false,
+	},
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "Common",
+	dexId: [540],
+};
+
+export default card;

--- a/data-asia/SV/SV11W/002.ts
+++ b/data-asia/SV/SV11W/002.ts
@@ -1,0 +1,59 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV11W";
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		ja: "クルマユ",
+	},
+
+	illustrator: "Oswaldo KATO",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Grass"],
+
+	description: {
+		ja: "クルマユの 住む 森は 草木が よく 育つ。 クルマユが 落ち葉を 栄養分に 変えているのだ。",
+	},
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "はっぱヒール" },
+			effect: {
+				ja: "自分の番に1回使える。自分のバトルポケモンのHPを「20」回復する。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "むしのさざめき" },
+			damage: 40,
+			cost: ["Grass", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "×2" }],
+
+	variants: {
+		normal: true,
+		reverse: true,
+		holo: false,
+		firstEdition: false,
+	},
+
+	evolveFrom: {
+		ja: "クルミル",
+	},
+
+	retreat: 2,
+	regulationMark: "I",
+	rarity: "Common",
+	dexId: [541],
+};
+
+export default card;

--- a/data-asia/SV/SV11W/003.ts
+++ b/data-asia/SV/SV11W/003.ts
@@ -1,0 +1,57 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV11W";
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		ja: "ハハコモリ",
+	},
+
+	illustrator: "Oswaldo KATO",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Grass"],
+
+	description: {
+		ja: "小さい ポケモンを 見つけると 腕の カッターと 粘着糸で 葉っぱの 服を 縫う 習性。",
+	},
+
+	stage: "Stage2",
+
+	attacks: [
+		{
+			name: { ja: "いやしのおくるみ" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分のたねポケモン全員のHPを、それぞれ「100」回復する。",
+			},
+		},
+		{
+			name: { ja: "シザークロス" },
+			damage: "90＋",
+			cost: ["Grass", "Colorless"],
+			effect: { ja: "コインを1回投げオモテなら、40ダメージ追加。" },
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "×2" }],
+
+	variants: {
+		normal: true,
+		reverse: true,
+		holo: false,
+		firstEdition: false,
+	},
+
+	evolveFrom: {
+		ja: "クルマユ",
+	},
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "Uncommon",
+	dexId: [542],
+};
+
+export default card;

--- a/data-asia/SV/SV11W/004.ts
+++ b/data-asia/SV/SV11W/004.ts
@@ -1,0 +1,46 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV11W";
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		ja: "モンメン",
+	},
+
+	illustrator: "sui",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Grass"],
+
+	description: {
+		ja: "襲われると 体から 綿を 飛ばす。 敵が 綿を モンメンと 間違えている すきに 逃げるのだ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "すいとる" },
+			damage: 10,
+			cost: ["Grass"],
+			effect: { ja: "このポケモンのHPを「10」回復する。" },
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "×2" }],
+
+	variants: {
+		normal: true,
+		reverse: true,
+		holo: false,
+		firstEdition: false,
+	},
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "Common",
+	dexId: [546],
+};
+
+export default card;

--- a/data-asia/SV/SV11W/005.ts
+++ b/data-asia/SV/SV11W/005.ts
@@ -1,0 +1,44 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV11W";
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		ja: "エルフーンex",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 230,
+	types: ["Grass"],
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "エナジーギフト" },
+			cost: ["Grass"],
+			effect: {
+				ja: "自分の山札から基本エネルギーを3枚まで選び、自分のポケモンに好きなようにつける。そして山札を切る。",
+			},
+		},
+		{
+			name: { ja: "ワンダーコットン" },
+			damage: "50×",
+			cost: ["Grass"],
+			effect: {
+				ja: "相手の手札を見て、その中にあるトレーナーズの枚数×50ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "×2" }],
+
+	retreat: 0,
+	regulationMark: "I",
+	rarity: "Double rare",
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/SV/SV11W/006.ts
+++ b/data-asia/SV/SV11W/006.ts
@@ -1,0 +1,45 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV11W";
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		ja: "シキジカ",
+	},
+
+	illustrator: "Narano",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Grass"],
+
+	description: {
+		ja: "体毛が 野山の 草と 同じ 色と 香りに 変わる。 敵意を 感じると 草むらに 隠れる。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "うしろげり" },
+			damage: 30,
+			cost: ["Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "×2" }],
+
+	variants: {
+		normal: true,
+		reverse: true,
+		holo: false,
+		firstEdition: false,
+	},
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "Common",
+	dexId: [585],
+};
+
+export default card;

--- a/data-asia/SV/SV11W/007.ts
+++ b/data-asia/SV/SV11W/007.ts
@@ -1,0 +1,57 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV11W";
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		ja: "メブキジカ",
+	},
+
+	illustrator: "Narano",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Grass"],
+
+	description: {
+		ja: "季節によって 住処を 変える。 人々は メブキジカの ツノで 季節の 移り変わりを 感じる。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "つきとばす" },
+			damage: 50,
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをベンチポケモンと入れ替える。［バトル場に出すポケモンは相手が選ぶ。］",
+			},
+		},
+		{
+			name: { ja: "ソーラービーム" },
+			damage: 100,
+			cost: ["Grass", "Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "×2" }],
+
+	variants: {
+		normal: true,
+		reverse: true,
+		holo: false,
+		firstEdition: false,
+	},
+
+	evolveFrom: {
+		ja: "シキジカ",
+	},
+
+	retreat: 2,
+	regulationMark: "I",
+	rarity: "Uncommon",
+	dexId: [586],
+};
+
+export default card;

--- a/data-asia/SV/SV11W/008.ts
+++ b/data-asia/SV/SV11W/008.ts
@@ -1,0 +1,51 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV11W";
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		ja: "チョボマキ",
+	},
+
+	illustrator: "Saboteri",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Grass"],
+
+	description: {
+		ja: "敵に 襲われると 殻の ふたを 閉じて 防御。 ふたの すきまから ベトベトした 毒液を 飛ばす。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "しげきしんか" },
+			effect: {
+				ja: "自分の場に「カブルモ」がいるなら、このポケモンは、最初の自分の番や、出したばかりの番でも進化できる。",
+			},
+		},
+	],
+
+	attacks: [
+		{ name: { ja: "とびだしヘッド" }, damage: 10, cost: ["Colorless"] },
+	],
+
+	weaknesses: [{ type: "Fire", value: "×2" }],
+
+	variants: {
+		normal: true,
+		reverse: true,
+		holo: false,
+		firstEdition: false,
+	},
+
+	retreat: 3,
+	regulationMark: "I",
+	rarity: "Common",
+	dexId: [616],
+};
+
+export default card;

--- a/data-asia/SV/SV11W/009.ts
+++ b/data-asia/SV/SV11W/009.ts
@@ -1,0 +1,52 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV11W";
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		ja: "アギルダー",
+	},
+
+	illustrator: "Saboteri",
+	category: "Pokemon",
+	hp: 100,
+	types: ["Grass"],
+
+	description: {
+		ja: "体が 乾くと 弱ってしまう。 薄い 膜を 何重も 巻いて 乾燥を 防いでいるのだ。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "アシッドボム" },
+			damage: 50,
+			cost: ["Grass"],
+			effect: {
+				ja: "コインを1回投げオモテなら、相手のバトルポケモンについているエネルギーを1個選び、トラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "×2" }],
+
+	variants: {
+		normal: true,
+		reverse: true,
+		holo: false,
+		firstEdition: false,
+	},
+
+	evolveFrom: {
+		ja: "チョボマキ",
+	},
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "Uncommon",
+	dexId: [617],
+};
+
+export default card;

--- a/data-asia/SV/SV11W/010.ts
+++ b/data-asia/SV/SV11W/010.ts
@@ -1,0 +1,54 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV11W";
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		ja: "ビリジオン",
+	},
+
+	illustrator: "Felicia Chen",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Grass"],
+
+	description: {
+		ja: "仲間を 守るため 人間に 戦いを 挑んだ ポケモン。 伝説で 語り継がれている。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ギガドレイン" },
+			damage: 30,
+			cost: ["Grass"],
+			effect: {
+				ja: "相手のバトルポケモンに与えたダメージぶん、このポケモンのHPを回復する。",
+			},
+		},
+		{
+			name: { ja: "エメラルドブレード" },
+			damage: 130,
+			cost: ["Grass", "Grass", "Colorless"],
+			effect: { ja: "次の自分の番、このポケモンはワザが使えない。" },
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "×2" }],
+
+	variants: {
+		normal: false,
+		reverse: true,
+		holo: true,
+		firstEdition: false,
+	},
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "Rare",
+	dexId: [640],
+};
+
+export default card;

--- a/data-asia/SV/SV11W/011.ts
+++ b/data-asia/SV/SV11W/011.ts
@@ -1,0 +1,42 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV11W";
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		ja: "ポカブ",
+	},
+
+	illustrator: "Teeziro",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Fire"],
+
+	description: {
+		ja: "敵の 攻撃を 身軽に 避けて 鼻から 火の玉を 撃ち出す。 炎で 木の実を 焼いて 食べる。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{ name: { ja: "たいあたり" }, damage: 10, cost: ["Fire"] },
+		{ name: { ja: "ころがる" }, damage: 30, cost: ["Fire", "Fire"] },
+	],
+
+	weaknesses: [{ type: "Water", value: "×2" }],
+
+	variants: {
+		normal: true,
+		reverse: true,
+		holo: false,
+		firstEdition: false,
+	},
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "Common",
+	dexId: [498],
+};
+
+export default card;

--- a/data-asia/SV/SV11W/012.ts
+++ b/data-asia/SV/SV11W/012.ts
@@ -1,0 +1,50 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV11W";
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		ja: "チャオブー",
+	},
+
+	illustrator: "Teeziro",
+	category: "Pokemon",
+	hp: 110,
+	types: ["Fire"],
+
+	description: {
+		ja: "体内の 炎が 燃え上がると 動きの キレと スピードが 増す。 ピンチになると 煙を 吹き出す。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{ name: { ja: "かえん" }, damage: 30, cost: ["Fire"] },
+		{
+			name: { ja: "ヒートスタンプ" },
+			damage: 80,
+			cost: ["Fire", "Fire", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "×2" }],
+
+	variants: {
+		normal: true,
+		reverse: true,
+		holo: false,
+		firstEdition: false,
+	},
+
+	evolveFrom: {
+		ja: "ポカブ",
+	},
+
+	retreat: 3,
+	regulationMark: "I",
+	rarity: "Common",
+	dexId: [499],
+};
+
+export default card;

--- a/data-asia/SV/SV11W/013.ts
+++ b/data-asia/SV/SV11W/013.ts
@@ -1,0 +1,59 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV11W";
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		ja: "エンブオー",
+	},
+
+	illustrator: "Teeziro",
+	category: "Pokemon",
+	hp: 180,
+	types: ["Fire"],
+
+	description: {
+		ja: "アゴの 炎で こぶしを 燃やして 炎の パンチを 繰り出す。 とても 仲間思いの ポケモン。",
+	},
+
+	stage: "Stage2",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "れっからんぶ" },
+			effect: {
+				ja: "自分の番に何回でも使える。自分の手札から「基本エネルギー」を1枚選び、自分のポケモンにつける。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ヒートスタンプ" },
+			damage: 120,
+			cost: ["Fire", "Fire", "Fire", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "×2" }],
+
+	variants: {
+		normal: false,
+		reverse: true,
+		holo: true,
+		firstEdition: false,
+	},
+
+	evolveFrom: {
+		ja: "チャオブー",
+	},
+
+	retreat: 4,
+	regulationMark: "I",
+	rarity: "Rare",
+	dexId: [500],
+};
+
+export default card;

--- a/data-asia/SV/SV11W/014.ts
+++ b/data-asia/SV/SV11W/014.ts
@@ -1,0 +1,50 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV11W";
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		ja: "バオップ",
+	},
+
+	illustrator: "Julie Hang",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Fire"],
+
+	description: {
+		ja: "頭の ふさは 怒ると 温度が 上がり ３００度 以上になる。 木の実を ふさで 焼いて 食べる。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "もってくる" },
+			cost: ["Colorless"],
+			effect: { ja: "自分の山札を1枚引く。" },
+		},
+		{
+			name: { ja: "ひっかく" },
+			damage: 30,
+			cost: ["Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "×2" }],
+
+	variants: {
+		normal: true,
+		reverse: true,
+		holo: false,
+		firstEdition: false,
+	},
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "Common",
+	dexId: [513],
+};
+
+export default card;

--- a/data-asia/SV/SV11W/015.ts
+++ b/data-asia/SV/SV11W/015.ts
@@ -1,0 +1,49 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV11W";
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		ja: "バオッキー",
+	},
+
+	illustrator: "Julie Hang",
+	category: "Pokemon",
+	hp: 100,
+	types: ["Fire"],
+
+	description: {
+		ja: "甘いものが 大好物。 体内の 炎を 燃やす エネルギーに なるのだ。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "ひっぱたく" },
+			damage: 70,
+			cost: ["Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "×2" }],
+
+	variants: {
+		normal: true,
+		reverse: true,
+		holo: false,
+		firstEdition: false,
+	},
+
+	evolveFrom: {
+		ja: "バオップ",
+	},
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "Uncommon",
+	dexId: [514],
+};
+
+export default card;

--- a/data-asia/SV/SV11W/016.ts
+++ b/data-asia/SV/SV11W/016.ts
@@ -1,0 +1,48 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV11W";
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		ja: "クイタラン",
+	},
+
+	illustrator: "Minahamu",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Fire"],
+
+	description: {
+		ja: "尻尾の 穴から 空気を 吸って 体内で 炎を 燃やす。 アイアントの 天敵。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ベロベロキャッチ" },
+			cost: ["Fire"],
+			effect: {
+				ja: "自分の山札からポケモンと「基本エネルギー」を合計3枚まで選び、相手に見せて、手札に加える。そして山札を切る。",
+			},
+		},
+		{ name: { ja: "ほのおのツメ" }, damage: 60, cost: ["Fire", "Fire"] },
+	],
+
+	weaknesses: [{ type: "Water", value: "×2" }],
+
+	variants: {
+		normal: true,
+		reverse: true,
+		holo: false,
+		firstEdition: false,
+	},
+
+	retreat: 2,
+	regulationMark: "I",
+	rarity: "Uncommon",
+	dexId: [631],
+};
+
+export default card;

--- a/data-asia/SV/SV11W/017.ts
+++ b/data-asia/SV/SV11W/017.ts
@@ -1,0 +1,42 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV11W";
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		ja: "レシラムex",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 230,
+	types: ["Fire"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "きりさく" },
+			damage: 50,
+			cost: ["Colorless", "Colorless"],
+		},
+		{
+			name: { ja: "ブレイズバースト" },
+			damage: "130+",
+			cost: ["Fire", "Fire", "Colorless"],
+			effect: {
+				ja: "相手がすでにとったサイドの枚数×50ダメージ追加。このポケモンについているエネルギーを1個選び、トラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "×2" }],
+
+	retreat: 2,
+	regulationMark: "I",
+	rarity: "Double rare",
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/SV/SV11W/018.ts
+++ b/data-asia/SV/SV11W/018.ts
@@ -1,0 +1,42 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV11W";
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		ja: "ミジュマル",
+	},
+
+	illustrator: "rika",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Water"],
+
+	description: {
+		ja: "お腹の ホタチで 戦う。 攻撃を 受け止めてから すかさず 切りつけて 反撃するのだ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{ name: { ja: "たいあたり" }, damage: 10, cost: ["Water"] },
+		{ name: { ja: "みずでっぽう" }, damage: 30, cost: ["Water", "Water"] },
+	],
+
+	weaknesses: [{ type: "Lightning", value: "×2" }],
+
+	variants: {
+		normal: true,
+		reverse: true,
+		holo: false,
+		firstEdition: false,
+	},
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "Common",
+	dexId: [501],
+};
+
+export default card;

--- a/data-asia/SV/SV11W/019.ts
+++ b/data-asia/SV/SV11W/019.ts
@@ -1,0 +1,52 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV11W";
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		ja: "フタチマル",
+	},
+
+	illustrator: "rika",
+	category: "Pokemon",
+	hp: 100,
+	types: ["Water"],
+
+	description: {
+		ja: "流れるような 太刀さばきで ２枚の ホタチを あつかう 技は 厳しい 修業によって 身につける。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "エナジーシェル" },
+			damage: "30x",
+			cost: ["Water"],
+			effect: {
+				ja: "このポケモンについているエネルギーの数×30ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "×2" }],
+
+	variants: {
+		normal: true,
+		reverse: true,
+		holo: false,
+		firstEdition: false,
+	},
+
+	evolveFrom: {
+		ja: "ミジュマル",
+	},
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "Common",
+	dexId: [502],
+};
+
+export default card;

--- a/data-asia/SV/SV11W/020.ts
+++ b/data-asia/SV/SV11W/020.ts
@@ -1,0 +1,62 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV11W";
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		ja: "ダイケンキ",
+	},
+
+	illustrator: "rika",
+	category: "Pokemon",
+	hp: 160,
+	types: ["Water"],
+
+	description: {
+		ja: "よろいに 仕込まれた 剣の 一振りで 相手を 倒す。 ひとにらみで 敵を 黙らせる。",
+	},
+
+	stage: "Stage2",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "げきりゅうのうず" },
+			effect: {
+				ja: "自分の番に1回使える。自分のバトルポケモンをベンチポケモンと入れ替える。その後、相手は相手自身のバトルポケモンをベンチポケモンと入れ替える。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "エナジースラッシュ" },
+			damage: "30+",
+			cost: ["Water"],
+			effect: {
+				ja: "このポケモンについているエネルギーの数×50ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "×2" }],
+
+	variants: {
+		normal: false,
+		reverse: true,
+		holo: true,
+		firstEdition: false,
+	},
+
+	evolveFrom: {
+		ja: "フタチマル",
+	},
+
+	retreat: 2,
+	regulationMark: "I",
+	rarity: "Rare",
+	dexId: [503],
+};
+
+export default card;


### PR DESCRIPTION
Add 174/86 cards from the Japanese S&V White Flare Set (SV11W).

This also includes adding the set itself, which was proposed in #750 but has yet to be merged.
