### PR TITLE
Feat: Add new SVP Black Star Promos cards

### DIFF
--- a/data/Scarlet & Violet/SVP Black Star Promos/191.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/191.ts
@@ -1,0 +1,55 @@
+import { Card } from "../../../interfaces"
+import Set from "../SVP Black Star Promos"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Sprigatito",
+	},
+
+	rarity: "None",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Grass"],
+	stage: "Basic",
+	dexId: [906],
+	weaknesses: [{
+		type: "Fire",
+		value: "×2"
+	}],
+
+	illustrator: "Yamazaki Rei",
+
+	attacks: [
+		{
+			cost: ["Colorless"],
+
+			name: {
+				en: "Scratch",
+			},
+
+			damage: "10"
+		},
+		{
+			cost: ["Grass", "Colorless"],
+
+			name: {
+				en: "Leafage",
+			},
+			damage: "20",
+		}
+	],
+
+	retreat: 1,
+	regulationMark: "G",
+
+	variants:[
+		{
+			type: "holo",
+			stamp: ["horizons"]
+		}
+	]
+}
+
+export default card

--- a/data/Scarlet & Violet/SVP Black Star Promos/192.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/192.ts
@@ -1,0 +1,47 @@
+import { Card } from "../../../interfaces"
+import Set from "../SVP Black Star Promos"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Fuecoco",
+	},
+
+	rarity: "None",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Fire"],
+	stage: "Basic",
+	dexId: [909],
+	weaknesses: [{
+		type: "Water",
+		value: "×2"
+	}],
+
+	illustrator: "Ito Kyoko",
+
+	attacks: [
+		{
+			cost: ["Fire"],
+
+			name: {
+				en: "Tackle",
+			},
+
+			damage: "20"
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "G",
+
+	variants:[
+		{
+			type: "holo",
+			stamp: ["horizons"]
+		}
+	]
+}
+
+export default card

--- a/data/Scarlet & Violet/SVP Black Star Promos/196.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/196.ts
@@ -1,0 +1,69 @@
+import { Card } from "../../../interfaces"
+import Set from "../SVP Black Star Promos"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Charizard EX",
+	},
+
+	suffix: "EX",
+	rarity: "None",
+	category: "Pokemon",
+	hp: 330,
+	types: ["Darkness"],
+	stage: "Stage2",
+	dexId: [6],
+	weaknesses: [{
+		type: "Grass",
+		value: "×2"
+	}],
+
+	illustrator: "5ban Graphics",
+
+	abilities: [
+		{
+			type: "Ability",
+
+			name: {
+				en: "Infernal Reign",
+			},
+			effect: {
+				en: "When you play this Pokémon from your hand to evolve 1 of your Pokémon during your turn, you may " +
+					"search your deck for up to 3 Basic Fire Energy cards and attach them to your Pokémon in any way " +
+					"you like. Then, shuffle your deck.",
+			},
+		}
+	],
+
+	attacks: [
+		{
+			cost: ["Fire"],
+
+			name: {
+				en: "Burning Darkness",
+			},
+
+			damage: "180+",
+			effect: {
+				en: "This attack does 30 more damage for each Prize card your opponent has taken.",
+			}
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "G",
+
+	variants:[
+		{
+			type: "holo",
+		},
+		{
+			type: "lenticular",
+			size: "jumbo"
+		}
+	]
+}
+
+export default card

--- a/data/Scarlet & Violet/SVP Black Star Promos/199.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/199.ts
@@ -1,0 +1,59 @@
+import { Card } from "../../../interfaces"
+import Set from "../SVP Black Star Promos"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Zarude",
+	},
+
+	rarity: "None",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Grass"],
+	stage: "Basic",
+	illustrator: "Uninori",
+	dexId: [893],
+	attacks: [
+		{
+			cost: ["Grass"],
+			name: {
+				en: "Pluck off",
+			},
+			effect: {
+				en: "Search your deck for up to 3 Basic Grass Energy cards, reveal them, and put them into your hand. " +
+					"Then, shuffle your deck."
+			}
+		},
+		{
+			cost: ["Grass", "Grass", "Grass"],
+			name: {
+				en: "Hammer Whip",
+			},
+			effect:{
+				en: "During your next turn, this Pokémon can't attack."
+			},
+			damage: 130,
+		}
+	],
+
+	weaknesses: [
+		{
+			type: "Fire",
+			value: "×2"
+		}
+	],
+
+	retreat: 2,
+	regulationMark: "G",
+
+	variants: [
+		{
+			type: "holo",
+			subtype: "cosmos"
+		}
+	]
+}
+
+export default card

--- a/data/Scarlet & Violet/SVP Black Star Promos/200.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/200.ts
@@ -1,0 +1,55 @@
+import { Card } from "../../../interfaces"
+import Set from "../SVP Black Star Promos"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Eevee",
+	},
+
+	rarity: "None",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Colorless"],
+	stage: "Basic",
+	illustrator: "Kariya",
+	dexId: [133],
+	attacks: [
+		{
+			cost: ["Colorless"],
+			name: {
+				en: "Call for Family",
+			},
+			effect: {
+				en: "Search your deck for a Basic Pokémon and put it onto your Bench. Then, shuffle your deck."
+			}
+		},
+		{
+			cost: ["Colorless", "Colorless"],
+			name: {
+				en: "Gnaw",
+			},
+			damage: 20,
+		}
+	],
+
+	weaknesses: [
+		{
+			type: "Fighting",
+			value: "×2"
+		}
+	],
+
+	retreat: 1,
+	regulationMark: "G",
+
+	variants: [
+		{
+			type: "holo",
+			subtype: "cosmos"
+		}
+	]
+}
+
+export default card

--- a/data/Scarlet & Violet/SVP Black Star Promos/201.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/201.ts
@@ -1,0 +1,55 @@
+import { Card } from "../../../interfaces"
+import Set from "../SVP Black Star Promos"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Zebstrika",
+	},
+
+	rarity: "None",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Lightning"],
+	stage: "Stage1",
+	illustrator: "Krgc",
+	dexId: [523],
+	attacks: [
+		{
+			cost: ["Colorless"],
+			name: {
+				en: "Full Speed",
+			},
+			effect: {
+				en: "Discard your hand and draw 6 cards."
+			}
+		},
+		{
+			cost: ["Lightning", "Colorless"],
+			name: {
+				en: "Head Bolt",
+			},
+			damage: 70,
+		}
+	],
+
+	weaknesses: [
+		{
+			type: "Fighting",
+			value: "×2"
+		}
+	],
+
+	retreat: 1,
+	regulationMark: "H",
+
+	variants: [
+		{
+			type: "holo",
+			subtype: "cosmos"
+		}
+	]
+}
+
+export default card

--- a/data/Scarlet & Violet/SVP Black Star Promos/202.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/202.ts
@@ -1,0 +1,55 @@
+import { Card } from "../../../interfaces"
+import Set from "../SVP Black Star Promos"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Kangaskhan",
+	},
+
+	rarity: "None",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Colorless"],
+	stage: "Basic",
+	illustrator: "Uta",
+	dexId: [115],
+	attacks: [
+		{
+			cost: ["Colorless"],
+			name: {
+				en: "Call for Family",
+			},
+			effect: {
+				en: "Search your deck for a Basic Pokémon and put it onto your Bench. Then, shuffle your deck."
+			}
+		},
+		{
+			cost: ["Colorless", "Colorless","Colorless"],
+			name: {
+				en: "Mega Punch",
+			},
+			damage: 100,
+		}
+	],
+
+	weaknesses: [
+		{
+			type: "Fighting",
+			value: "×2"
+		}
+	],
+
+	retreat: 2,
+	regulationMark: "H",
+
+	variants: [
+		{
+			type: "holo",
+			subtype: "cosmos"
+		}
+	]
+}
+
+export default card

--- a/data/Scarlet & Violet/SVP Black Star Promos/203.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/203.ts
@@ -1,0 +1,66 @@
+import { Card } from "../../../interfaces"
+import Set from "../SVP Black Star Promos"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Team Rocket's Wobbuffet",
+	},
+
+	rarity: "None",
+	category: "Pokemon",
+	hp: 110,
+	types: ["Psychic"],
+	stage: "Basic",
+	illustrator: "Saboteri",
+	dexId: [202],
+	attacks: [
+		{
+			cost: ["Psychic","Colorless"],
+			name: {
+				en: "Rocket Mirror",
+			},
+			effect: {
+				en: "Move all damage counters from 1 of your Benched Team Rocket's Pokémon to your opponent's Active Pokémon."
+			}
+		},
+		{
+			cost: ["Psychic", "Colorless","Colorless"],
+			name: {
+				en: "Headbutt Bounce",
+			},
+			damage: 70,
+		}
+	],
+
+	weaknesses: [
+		{
+			type: "Darkness",
+			value: "×2"
+		}
+	],
+
+	resistances: [
+		{
+			type: "Fighting",
+			value: "-30"
+		}
+	],
+
+	retreat: 2,
+	regulationMark: "H",
+
+	variants: [
+		{
+			type: "holo",
+			subtype: "cosmos"
+		},
+		{
+			type: "holo",
+			stamp: ["pokemon-center"]
+		}
+	]
+}
+
+export default card

--- a/data/Scarlet & Violet/SVP Black Star Promos/204.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/204.ts
@@ -1,0 +1,57 @@
+import { Card } from "../../../interfaces"
+import Set from "../SVP Black Star Promos"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Cynthia's Garchomp ex",
+	},
+	suffix: "EX",
+	rarity: "None",
+	category: "Pokemon",
+	hp: 330,
+	types: ["Fighting"],
+	stage: "Stage2",
+	illustrator: "PLANETA Igarashi",
+	dexId: [445],
+	attacks: [
+		{
+			cost: ["Fighting"],
+			name: {
+				en: "Corkscrew Dive",
+			},
+			effect: {
+				en: "You may draw cards until you have 6 cards in your hand."
+			},
+			damage: 100,
+		},
+		{
+			cost: ["Fighting", "Fighting"],
+			name: {
+				en: "Draconic Buster",
+			},
+			effect: {
+				en: "Discard all Energy from this Pokémon."
+			},
+			damage: 260,
+		}
+	],
+
+	weaknesses: [
+		{
+			type: "Grass",
+			value: "×2"
+		}
+	],
+
+	regulationMark: "I",
+
+	variants: [
+		{
+			type: "holo",
+		}
+	]
+}
+
+export default card

--- a/data/Scarlet & Violet/SVP Black Star Promos/205.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/205.ts
@@ -1,0 +1,73 @@
+import { Card } from "../../../interfaces"
+import Set from "../SVP Black Star Promos"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Team Rocket's Mewtwo ex",
+	},
+	suffix: "EX",
+	rarity: "None",
+	category: "Pokemon",
+	hp: 280,
+	types: ["Psychic"],
+	stage: "Basic",
+	illustrator: "aky CG Works",
+	dexId: [150],
+
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				en: "Power Saver",
+			},
+			effect:{
+				en: "This Pokémon can't attack unless you have 4 or more Team Rocket's Pokémon in play."
+			}
+		}
+	],
+
+	attacks: [
+		{
+			cost: ["Psychic","Psychic","Colorless"],
+			name: {
+				en: "Erasure Ball",
+			},
+			effect: {
+				en: "You may discard up to 2 Energy from your Benched Pokémon. This attack does 60 more damage for each" +
+					" card you discarded in this way."
+			},
+			damage: "160+",
+		},
+	],
+
+	weaknesses: [
+		{
+			type: "Darkness",
+			value: "×2"
+		}
+	],
+
+	resistances: [
+		{
+			type: "Fighting",
+			value: "-30"
+		}
+	],
+
+	retreat: 3,
+	regulationMark: "I",
+
+	variants: [
+		{
+			type: "holo",
+		},
+		{
+			type: "holo",
+			size: "jumbo"
+		}
+	]
+}
+
+export default card

--- a/data/Scarlet & Violet/SVP Black Star Promos/213.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/213.ts
@@ -1,0 +1,50 @@
+import { Card } from "../../../interfaces"
+import Set from "../SVP Black Star Promos"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Feraligatr",
+	},
+	rarity: "None",
+	category: "Pokemon",
+	hp: 180,
+	types: ["Water"],
+	stage: "Stage2",
+	illustrator: "Acorviart",
+	dexId: [160],
+
+	attacks: [
+		{
+			cost: ["Water","Water","Water","Colorless"],
+			name: {
+				en: "Deep Submergence",
+			},
+			effect: {
+				en: "Flip a coin. If heads, during your opponent's next turn, prevent all damage from and effects of " +
+					"attacks done to this Pokémon."
+			},
+			damage: "140",
+		},
+	],
+
+	weaknesses: [
+		{
+			type: "Lightning",
+			value: "×2"
+		}
+	],
+
+	retreat: 3,
+	regulationMark: "I",
+
+	variants: [
+		{
+			type: "normal",
+			stamp: ["illustration-contest-2024"]
+		},
+	]
+}
+
+export default card

--- a/data/Scarlet & Violet/SVP Black Star Promos/214.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/214.ts
@@ -1,0 +1,48 @@
+import { Card } from "../../../interfaces"
+import Set from "../SVP Black Star Promos"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Pikachu",
+	},
+	rarity: "None",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Lightning"],
+	stage: "Basic",
+	illustrator: "Kazuki Minami",
+	dexId: [25],
+
+	attacks: [
+		{
+			cost: ["Colorless"],
+			name: {
+				en: "Unwind",
+			},
+			effect: {
+				en:	"Heal 20 damage from this Pokémon."
+			},
+		},
+	],
+
+	weaknesses: [
+		{
+			type: "Fighting",
+			value: "×2"
+		}
+	],
+
+	retreat: 1,
+	regulationMark: "I",
+
+	variants: [
+		{
+			type: "normal",
+			stamp: ["illustration-contest-2024"]
+		},
+	]
+}
+
+export default card

--- a/data/Scarlet & Violet/SVP Black Star Promos/215.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/215.ts
@@ -1,0 +1,51 @@
+import { Card } from "../../../interfaces"
+import Set from "../SVP Black Star Promos"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Toxtricity ex",
+	},
+
+	suffix: "EX",
+	rarity: "None",
+	category: "Pokemon",
+	hp: 260,
+	types: ["Lightning"],
+	stage: "Stage1",
+	illustrator: "Anderson",
+	dexId: [849],
+
+	attacks: [
+		{
+			cost: ["Lightning","Lightning","Colorless"],
+			name: {
+				en: "Stumming Thunder",
+			},
+			effect: {
+				en:	"Discard 2 Energy from this Pokémon."
+			},
+			damage: "240",
+		},
+	],
+
+	weaknesses: [
+		{
+			type: "Fighting",
+			value: "×2"
+		}
+	],
+
+	retreat: 2,
+	regulationMark: "I",
+
+	variants: [
+		{
+			type: "normal",
+			stamp: ["illustration-contest-2024"]
+		},
+	]
+}
+
+export default card

--- a/data/Scarlet & Violet/SVP Black Star Promos/216.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/216.ts
@@ -1,0 +1,73 @@
+import { Card } from "../../../interfaces"
+import Set from "../SVP Black Star Promos"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Team Rocket's Mewtwo ex",
+	},
+	suffix: "EX",
+	rarity: "None",
+	category: "Pokemon",
+	hp: 280,
+	types: ["Psychic"],
+	stage: "Basic",
+	illustrator: "aky CG Works",
+	dexId: [150],
+
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				en: "Power Saver",
+			},
+			effect:{
+				en: "This Pokémon can't attack unless you have 4 or more Team Rocket's Pokémon in play."
+			}
+		}
+	],
+
+	attacks: [
+		{
+			cost: ["Psychic","Psychic","Colorless"],
+			name: {
+				en: "Erasure Ball",
+			},
+			effect: {
+				en: "You may discard up to 2 Energy from your Benched Pokémon. This attack does 60 more damage for each" +
+					" card you discarded in this way."
+			},
+			damage: "160+",
+		},
+	],
+
+	weaknesses: [
+		{
+			type: "Darkness",
+			value: "×2"
+		}
+	],
+
+	resistances: [
+		{
+			type: "Fighting",
+			value: "-30"
+		}
+	],
+
+	retreat: 3,
+	regulationMark: "I",
+
+	variants: [
+		{
+			type: "holo",
+		},
+		{
+			type: "holo",
+			size: "jumbo"
+		}
+	]
+}
+
+export default card

--- a/data/Scarlet & Violet/SVP Black Star Promos/217.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/217.ts
@@ -1,0 +1,57 @@
+import { Card } from "../../../interfaces"
+import Set from "../SVP Black Star Promos"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Team Rocket's Nidoking ex",
+	},
+	suffix: "EX",
+	rarity: "None",
+	category: "Pokemon",
+	hp: 330,
+	types: ["Darkness"],
+	stage: "Stage2",
+	illustrator: "5ban Graphics",
+	dexId: [34],
+
+	attacks: [
+		{
+			cost: ["Darkness","Darkness","Colorless"],
+			name: {
+				en: "Tainted Horn",
+			},
+			effect: {
+				en: "Your opponent's Active Pokémon is now Poisoned. During Pokémon Checkup, put 8 damage counters on " +
+					"that Pokémon instead of 1."
+			},
+			damage: "100",
+		},
+		{
+			cost: ["Darkness","Darkness","Darkness","Colorless"],
+			name: {
+				en: "Kingly Impact",
+			},
+			damage: "240",
+		},
+	],
+
+	weaknesses: [
+		{
+			type: "Fighting",
+			value: "×2"
+		}
+	],
+
+	retreat: 3,
+	regulationMark: "I",
+
+	variants: [
+		{
+			type: "holo",
+		}
+	]
+}
+
+export default card

--- a/data/Scarlet & Violet/SVP Black Star Promos/218.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/218.ts
@@ -1,0 +1,59 @@
+import { Card } from "../../../interfaces"
+import Set from "../SVP Black Star Promos"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Team Rocket's Persian ex",
+	},
+	suffix: "EX",
+	rarity: "None",
+	category: "Pokemon",
+	hp: 260,
+	types: ["Colorless"],
+	stage: "Stage1",
+	illustrator: "5ban Graphics",
+	dexId: [53],
+
+	attacks: [
+		{
+			cost: ["Colorless","Colorless"],
+			name: {
+				en: "Haughty Order",
+			},
+			effect: {
+				en: "Reveal the top 10 cards of your opponent's deck. You may choose an attack from a Pokémon you find" +
+					" there and use it as this attack. Shuffle the revealed cards into your opponent's deck."
+			},
+		},
+		{
+			cost: ["Colorless","Colorless","Colorless"],
+			name: {
+				en: "Cruel Slash",
+			},
+			effect: {
+				en: "Your opponent's Active Pokémon is now Confused."
+			},
+			damage: "140",
+		},
+	],
+
+	weaknesses: [
+		{
+			type: "Fighting",
+			value: "×2"
+		}
+	],
+
+	retreat: 2,
+	regulationMark: "I",
+
+	variants: [
+		{
+			type: "holo",
+		}
+	]
+}
+
+export default card

--- a/data/Scarlet & Violet/SVP Black Star Promos/224.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/224.ts
@@ -1,0 +1,52 @@
+import { Card } from "../../../interfaces"
+import Set from "../SVP Black Star Promos"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Paradise Resort",
+	},
+	rarity: "None",
+	category: "Trainer",
+	illustrator: "Naoki Saito",
+
+	effect: {
+		en: "The Retreat Cost of each Psyduck in play (both yours and your opponent's) is Colorless less."
+	},
+
+	regulationMark: "I",
+
+	variants: [
+		{
+			type: "normal",
+			stamp: ["worlds-2025"]
+		},
+		{
+			type: "normal",
+			stamp: ["worlds-2025","staff"]
+		},
+		{
+			type: "normal",
+			stamp: ["worlds-2025","top-thirty-two"]
+		},
+		{
+			type: "normal",
+			stamp: ["worlds-2025","top-sixteen"]
+		},
+		{
+			type: "normal",
+			stamp: ["worlds-2025","top-eight"]
+		},
+		{
+			type: "normal",
+			stamp: ["worlds-2025","semi-finalist"]
+		},
+		{
+			type: "normal",
+			stamp: ["worlds-2025","finalist"]
+		},
+	]
+}
+
+export default card

--- a/data/Scarlet & Violet/SVP Black Star Promos/225.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/225.ts
@@ -1,0 +1,54 @@
+import { Card } from "../../../interfaces"
+import Set from "../SVP Black Star Promos"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Pikachu",
+	},
+	rarity: "None",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Lightning"],
+	stage: "Basic",
+	illustrator: "DOM",
+	dexId: [25],
+
+	attacks: [
+		{
+			cost: ["Lightning","Lightning","Colorless"],
+			name: {
+				en: "Scrappy Spark",
+			},
+			effect: {
+				en:	"Flip a coin until you get tails. This attack does 30 more damage for each heads."
+			},
+			damage: "30+"
+		},
+	],
+
+	weaknesses: [
+		{
+			type: "Fighting",
+			value: "×2"
+		}
+	],
+
+	retreat: 1,
+	regulationMark: "I",
+
+	variants: [
+		{
+			type: "normal",
+			stamp: ["worlds-2025"]
+		},
+		{
+			type: "reverse",
+			foil: "league",
+			stamp: ["winner"]
+		},
+	]
+}
+
+export default card

--- a/data/Scarlet & Violet/SVP Black Star Promos/500.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/500.ts
@@ -1,0 +1,47 @@
+import { Card } from "../../../interfaces"
+import Set from "../SVP Black Star Promos"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Terapagos & Friends",
+	},
+	rarity: "None",
+	category: "Pokemon",
+	types: ["Colorless"],
+	hp: 90,
+	stage: "Basic",
+	dexId: [1024, 25,906,909,9012],
+	illustrator: "Yamazaki Rei",
+
+	attacks:[
+		{
+			cost: ["Colorless","Colorless","Colorless","Colorless"],
+			name: {
+				en: "A Grand Adventure with Friends",
+			},
+			effect:{
+				en: "This attack does 100 damage for each of your Pokémon in play."
+			},
+			damage: "100×",
+		}
+	],
+	weaknesses: [
+		{
+			type: "Fighting",
+			value: "×2"
+		}
+	],
+	retreat: 2,
+
+	variants: [
+		{
+			type: "normal",
+			size: "jumbo",
+			stamp: ["horizons"]
+		},
+	]
+}
+
+export default card

--- a/interfaces.d.ts
+++ b/interfaces.d.ts
@@ -23,14 +23,14 @@ interface variant_detailed {
 	 * - holo: the illustration has a foil
 	 * - reverse: everything but the illustration is foiled
 	 */
-	type: 'normal' | 'holo' | 'reverse' | 'metal'
+	type: 'normal' | 'holo' | 'reverse' | 'metal' | 'lenticular'
 
 	/**
 	 * Some older sets had specific subtypes for the cards
 	 * i.e Base Set had shadowless with and without a 1st edition stamp.
 	 * and the Unlimited version of the set had no shadow.
 	 */
-	subtype?: 'shadowless' | 'unlimited'
+	subtype?: 'shadowless' | 'unlimited' | 'cosmos'
 	/**
 	 * define the size of the card
 	 * - standard: the classic size of a card
@@ -50,11 +50,14 @@ interface variant_detailed {
 	 * - snowflake: a card that is stamped with a snowflake, available in the yearly advent calendar
 	 * - trick-or-trade: a card that is stamped with a pikachu-pumpkin, available in the yearly halloween/trick-or-trade boosters
 	 */
-	stamp?: Array<'1st edition' | 'w-promo' | 'pre-release' | 'pokemon-center' | 'set-logo' | 'staff' | 'snowflake' | 'trick-or-trade'>
+	stamp?: Array<'1st edition' | 'w-promo' | 'pre-release' | 'pokemon-center' | 'set-logo' | 'staff' | 'snowflake' |
+		'trick-or-trade' | 'horizons' | 'illustration-contest-2024' | 'worlds-2025' | 'top-thirty-two' | 'top-sixteen'
+		| 'top-eight' | 'semi-finalist' | 'finalist' | 'winner'
+	>
 	/**
 	 * for the holo & reverse, **optional** indicate which foil is used on the card
 	 */
-	foil?: 'pokeball' | 'ultraball' | 'masterball' | 'gold'
+	foil?: 'pokeball' | 'ultraball' | 'masterball' | 'gold' | 'league'
 }
 
 interface variants {

--- a/meta/translations/de.json
+++ b/meta/translations/de.json
@@ -108,7 +108,8 @@
 		"normal": "Normal",
 		"holo": "Holo",
 		"reverse": "Reverse",
-		"metal": "Metall"
+		"metal": "Metall",
+		"lenticular": "lenticular"
 	},
 	"variantSize": {
 		"standard": "Standard",
@@ -118,7 +119,8 @@
 		"pokeball": "Pokéball",
 		"ultraball": "Ultraball",
 		"masterball": "Meisterball",
-		"gold": "Gold"
+		"gold": "Gold",
+		"league": "league"
 	},
 	"variantStamp": {
 		"1st Edition": "1. Auflage",
@@ -126,10 +128,20 @@
 		"pre-release": "Vorveröffentlichung",
 		"set-logo": "Set-Logo",
 		"pokemon-center": "Pokémon-Center",
-		"staff": "Mitarbeiter"
+		"staff": "Mitarbeiter",
+		"horizons": "horizons",
+		"illustration-contest-2024": "illustration-contest-2024",
+		"worlds-2025": "worlds-2025",
+		"top-thirty-two": "top-thirty-two",
+		"top-sixteen": "top-sixteen",
+		"top-eight": "top-eight",
+		"semi-finalist": "semi-finalist",
+		"finalist": "finalist",
+		"winner": "winner"
 	},
 	"variantSubtype": {
 		"shadowless": "schattenlos",
-		"unlimited": "unbegrenzt"
+		"unlimited": "unbegrenzt",
+		"cosmos": "cosmos"
 	}
 }

--- a/meta/translations/es.json
+++ b/meta/translations/es.json
@@ -108,7 +108,8 @@
 		"normal": "básico",
 		"holo": "holo",
 		"reverse": "reversa",
-		"metal": "metal"
+		"metal": "metal",
+		"lenticular": "lenticular"
 	},
 	"variantSize": {
 		"standard": "estándar",
@@ -118,7 +119,8 @@
 		"pokeball": "Pokébola",
 		"ultraball": "UltraBall",
 		"masterball": "MasterBall",
-		"gold": "Oro"
+		"gold": "Oro",
+		"league": "league"
 	},
 	"variantStamp": {
 		"1st Edition": "1ra Edición",
@@ -126,10 +128,20 @@
 		"pre-release": "pre-lanzamiento",
 		"set-logo": "logo del set",
 		"pokemon-center": "pokemon-center",
-		"staff": "staff"
+		"staff": "staff",
+		"horizons": "horizons",
+		"illustration-contest-2024": "illustration-contest-2024",
+		"worlds-2025": "worlds-2025",
+		"top-thirty-two": "top-thirty-two",
+		"top-sixteen": "top-sixteen",
+		"top-eight": "top-eight",
+		"semi-finalist": "semi-finalist",
+		"finalist": "finalist",
+		"winner": "winner"
 	},
 	"variantSubtype": {
 		"shadowless": "sin sombra",
-		"unlimited": "ilimitado"
+		"unlimited": "ilimitado",
+		"cosmos": "cosmos"
 	}
 }

--- a/meta/translations/fr.json
+++ b/meta/translations/fr.json
@@ -107,7 +107,8 @@
 		"normal": "De base",
 		"holo": "Holo",
 		"reverse": "Reverse",
-		"metal": "Métal"
+		"metal": "Métal",
+		"lenticular": "lenticular"
 	},
 	"variantSize": {
 		"standard": "Standard",
@@ -117,7 +118,8 @@
 		"pokeball": "Pokéball",
 		"ultraball": "Ultraball",
 		"masterball": "Masterball",
-		"gold": "Or"
+		"gold": "Or",
+		"league": "league"
 	},
 	"variantStamp": {
 		"1st Edition": "1re Édition",
@@ -125,10 +127,20 @@
 		"pre-release": "Pré-release",
 		"set-logo": "Logo de la série",
 		"pokemon-center": "Pokémon Center",
-		"staff": "Staff"
+		"staff": "Staff",
+		"horizons": "horizons",
+		"illustration-contest-2024": "illustration-contest-2024",
+		"worlds-2025": "worlds-2025",
+		"top-thirty-two": "top-thirty-two",
+		"top-sixteen": "top-sixteen",
+		"top-eight": "top-eight",
+		"semi-finalist": "semi-finalist",
+		"finalist": "finalist",
+		"winner": "winner"
 	},
 	"variantSubtype": {
 		"shadowless": "sans ombre",
-		"unlimited": "illimité"
+		"unlimited": "illimité",
+		"cosmos": "cosmos"
 	}
 }

--- a/meta/translations/it.json
+++ b/meta/translations/it.json
@@ -108,7 +108,8 @@
 		"normal": "Normale",
 		"holo": "Olografica",
 		"reverse": "Reverse",
-		"metal": "Metallo"
+		"metal": "Metallo",
+		"lenticular": "lenticular"
 	},
 	"variantSize": {
 		"standard": "Standard",
@@ -118,7 +119,8 @@
 		"pokeball": "Poké Ball",
 		"ultraball": "Ultra Ball",
 		"masterball": "Master Ball",
-		"gold": "Oro"
+		"gold": "Oro",
+		"league": "league"
 	},
 	"variantStamp": {
 		"1st Edition": "1a Edizione",
@@ -126,10 +128,20 @@
 		"pre-release": "Pre-release",
 		"set-logo": "Logo set",
 		"pokemon-center": "Pokémon Center",
-		"staff": "Staff"
+		"staff": "Staff",
+		"horizons": "horizons",
+		"illustration-contest-2024": "illustration-contest-2024",
+		"worlds-2025": "worlds-2025",
+		"top-thirty-two": "top-thirty-two",
+		"top-sixteen": "top-sixteen",
+		"top-eight": "top-eight",
+		"semi-finalist": "semi-finalist",
+		"finalist": "finalist",
+		"winner": "winner"
 	},
 	"variantSubtype": {
 		"shadowless": "senza ombra",
-		"unlimited": "illimitato"
+		"unlimited": "illimitato",
+		"cosmos": "cosmos"
 	}
 }

--- a/meta/translations/pt.json
+++ b/meta/translations/pt.json
@@ -107,7 +107,8 @@
 		"normal": "Normal",
 		"holo": "Holo",
 		"reverse": "Reverse",
-		"metal": "Metal"
+		"metal": "Metal",
+		"lenticular": "lenticular"
 	},
 	"variantSize": {
 		"standard": "Padrão",
@@ -117,7 +118,8 @@
 		"pokeball": "Poké Bola",
 		"ultraball": "Ultra Bola",
 		"masterball": "Master Bola",
-		"gold": "Ouro"
+		"gold": "Ouro",
+		"league": "league"
 	},
 	"variantStamp": {
 		"1st Edition": "1ª Edição",
@@ -125,10 +127,20 @@
 		"pre-release": "Pré-lançamento",
 		"set-logo": "Logo da coleção",
 		"pokemon-center": "Pokémon Center",
-		"staff": "Staff"
+		"staff": "Staff",
+		"horizons": "horizons",
+		"illustration-contest-2024": "illustration-contest-2024",
+		"worlds-2025": "worlds-2025",
+		"top-thirty-two": "top-thirty-two",
+		"top-sixteen": "top-sixteen",
+		"top-eight": "top-eight",
+		"semi-finalist": "semi-finalist",
+		"finalist": "finalist",
+		"winner": "winner"
 	},
 	"variantSubtype": {
 		"shadowless": "sem sombra",
-		"unlimited": "ilimitado"
+		"unlimited": "ilimitado",
+		"cosmos": "cosmos"
 	}
 }


### PR DESCRIPTION
Added multiple new card files for the Scarlet & Violet SVP Black Star Promos set. Updated interfaces.d.ts to support new variant types, subtypes, stamps, and foils. Extended translation files (de, es, fr, it, pt) to include new variant and stamp terms for recent promos and events.
