### PR TITLE
Add missing dexId for ME01 (Mega Evolution) set

### DIFF
--- a/data/Mega Evolution/Mega Evolution/001.ts
+++ b/data/Mega Evolution/Mega Evolution/001.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 80,
 	types: ["Grass"],
 	stage: "Basic",
+	dexId: [1],
 
 	attacks: [{
 		cost: ["Grass"],

--- a/data/Mega Evolution/Mega Evolution/002.ts
+++ b/data/Mega Evolution/Mega Evolution/002.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 110,
 	types: ["Grass"],
 	stage: "Stage1",
+	dexId: [2],
 
 	attacks: [{
 		cost: ["Grass", "Grass"],

--- a/data/Mega Evolution/Mega Evolution/003.ts
+++ b/data/Mega Evolution/Mega Evolution/003.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 380,
 	types: ["Grass"],
 	stage: "Stage2",
+	dexId: [3],
 
 	abilities: [{
 		type: "Ability",

--- a/data/Mega Evolution/Mega Evolution/004.ts
+++ b/data/Mega Evolution/Mega Evolution/004.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 60,
 	types: ["Grass"],
 	stage: "Basic",
+	dexId: [102],
 
 	attacks: [{
 		cost: ["Colorless"],

--- a/data/Mega Evolution/Mega Evolution/005.ts
+++ b/data/Mega Evolution/Mega Evolution/005.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 140,
 	types: ["Grass"],
 	stage: "Stage1",
+	dexId: [103],
 
 	attacks: [{
 		cost: ["Grass"],

--- a/data/Mega Evolution/Mega Evolution/006.ts
+++ b/data/Mega Evolution/Mega Evolution/006.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 80,
 	types: ["Grass"],
 	stage: "Basic",
+	dexId: [114],
 
 	attacks: [{
 		cost: ["Grass"],

--- a/data/Mega Evolution/Mega Evolution/007.ts
+++ b/data/Mega Evolution/Mega Evolution/007.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 150,
 	types: ["Grass"],
 	stage: "Stage1",
+	dexId: [465],
 
 	attacks: [{
 		cost: ["Grass", "Colorless"],

--- a/data/Mega Evolution/Mega Evolution/008.ts
+++ b/data/Mega Evolution/Mega Evolution/008.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 70,
 	types: ["Grass"],
 	stage: "Basic",
+	dexId: [152],
 
 	attacks: [{
 		cost: ["Grass"],

--- a/data/Mega Evolution/Mega Evolution/009.ts
+++ b/data/Mega Evolution/Mega Evolution/009.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 110,
 	types: ["Grass"],
 	stage: "Stage1",
+	dexId: [153],
 
 	attacks: [{
 		cost: ["Grass", "Colorless"],

--- a/data/Mega Evolution/Mega Evolution/010.ts
+++ b/data/Mega Evolution/Mega Evolution/010.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 160,
 	types: ["Grass"],
 	stage: "Stage2",
+	dexId: [154],
 
 	abilities: [{
 		type: "Ability",

--- a/data/Mega Evolution/Mega Evolution/011.ts
+++ b/data/Mega Evolution/Mega Evolution/011.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 80,
 	types: ["Grass"],
 	stage: "Basic",
+	dexId: [213],
 
 	abilities: [{
 		type: "Ability",

--- a/data/Mega Evolution/Mega Evolution/012.ts
+++ b/data/Mega Evolution/Mega Evolution/012.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 80,
 	types: ["Grass"],
 	stage: "Basic",
+	dexId: [251],
 
 	attacks: [{
 		cost: ["Grass"],

--- a/data/Mega Evolution/Mega Evolution/013.ts
+++ b/data/Mega Evolution/Mega Evolution/013.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 60,
 	types: ["Grass"],
 	stage: "Basic",
+	dexId: [273],
 
 	attacks: [{
 		cost: ["Colorless"],

--- a/data/Mega Evolution/Mega Evolution/014.ts
+++ b/data/Mega Evolution/Mega Evolution/014.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 100,
 	types: ["Grass"],
 	stage: "Stage1",
+	dexId: [274],
 
 	attacks: [{
 		cost: ["Grass"],

--- a/data/Mega Evolution/Mega Evolution/015.ts
+++ b/data/Mega Evolution/Mega Evolution/015.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 160,
 	types: ["Grass"],
 	stage: "Stage2",
+	dexId: [275],
 
 	attacks: [{
 		cost: ["Grass"],

--- a/data/Mega Evolution/Mega Evolution/016.ts
+++ b/data/Mega Evolution/Mega Evolution/016.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 50,
 	types: ["Grass"],
 	stage: "Basic",
+	dexId: [290],
 
 	attacks: [{
 		cost: ["Colorless"],

--- a/data/Mega Evolution/Mega Evolution/017.ts
+++ b/data/Mega Evolution/Mega Evolution/017.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 80,
 	types: ["Grass"],
 	stage: "Stage1",
+	dexId: [291],
 
 	abilities: [{
 		type: "Ability",

--- a/data/Mega Evolution/Mega Evolution/018.ts
+++ b/data/Mega Evolution/Mega Evolution/018.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 120,
 	types: ["Grass"],
 	stage: "Basic",
+	dexId: [781],
 
 	attacks: [{
 		cost: ["Grass", "Colorless"],

--- a/data/Mega Evolution/Mega Evolution/019.ts
+++ b/data/Mega Evolution/Mega Evolution/019.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 70,
 	types: ["Fire"],
 	stage: "Basic",
+	dexId: [37],
 
 	attacks: [{
 		cost: ["Colorless"],

--- a/data/Mega Evolution/Mega Evolution/020.ts
+++ b/data/Mega Evolution/Mega Evolution/020.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 120,
 	types: ["Fire"],
 	stage: "Stage1",
+	dexId: [38],
 
 	attacks: [{
 		cost: ["Colorless"],

--- a/data/Mega Evolution/Mega Evolution/021.ts
+++ b/data/Mega Evolution/Mega Evolution/021.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 80,
 	types: ["Fire"],
 	stage: "Basic",
+	dexId: [322],
 
 	attacks: [{
 		cost: ["Fire"],

--- a/data/Mega Evolution/Mega Evolution/022.ts
+++ b/data/Mega Evolution/Mega Evolution/022.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 340,
 	types: ["Fire"],
 	stage: "Stage1",
+	dexId: [322],
 
 	attacks: [{
 		cost: ["Fire"],

--- a/data/Mega Evolution/Mega Evolution/023.ts
+++ b/data/Mega Evolution/Mega Evolution/023.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 70,
 	types: ["Fire"],
 	stage: "Basic",
+	dexId: [667],
 
 	attacks: [{
 		cost: ["Fire", "Colorless"],

--- a/data/Mega Evolution/Mega Evolution/024.ts
+++ b/data/Mega Evolution/Mega Evolution/024.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 130,
 	types: ["Fire"],
 	stage: "Stage1",
+	dexId: [668],
 
 	abilities: [{
 		type: "Ability",

--- a/data/Mega Evolution/Mega Evolution/025.ts
+++ b/data/Mega Evolution/Mega Evolution/025.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 130,
 	types: ["Fire"],
 	stage: "Basic",
+	dexId: [721],
 
 	attacks: [{
 		cost: ["Fire"],

--- a/data/Mega Evolution/Mega Evolution/026.ts
+++ b/data/Mega Evolution/Mega Evolution/026.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 70,
 	types: ["Fire"],
 	stage: "Basic",
+	dexId: [813],
 
 	attacks: [{
 		cost: ["Colorless"],

--- a/data/Mega Evolution/Mega Evolution/027.ts
+++ b/data/Mega Evolution/Mega Evolution/027.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 100,
 	types: ["Fire"],
 	stage: "Stage1",
+	dexId: [814],
 
 	attacks: [{
 		cost: ["Colorless"],

--- a/data/Mega Evolution/Mega Evolution/028.ts
+++ b/data/Mega Evolution/Mega Evolution/028.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 160,
 	types: ["Fire"],
 	stage: "Stage2",
+	dexId: [815],
 
 	abilities: [{
 		type: "Ability",

--- a/data/Mega Evolution/Mega Evolution/029.ts
+++ b/data/Mega Evolution/Mega Evolution/029.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 80,
 	types: ["Fire"],
 	stage: "Basic",
+	dexId: [850],
 
 	attacks: [{
 		cost: ["Fire"],

--- a/data/Mega Evolution/Mega Evolution/030.ts
+++ b/data/Mega Evolution/Mega Evolution/030.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 140,
 	types: ["Fire"],
 	stage: "Stage1",
+	dexId: [851],
 
 	attacks: [{
 		cost: ["Colorless", "Colorless"],

--- a/data/Mega Evolution/Mega Evolution/031.ts
+++ b/data/Mega Evolution/Mega Evolution/031.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 110,
 	types: ["Fire"],
 	stage: "Basic",
+	dexId: [1004],
 
 	attacks: [{
 		cost: ["Fire"],

--- a/data/Mega Evolution/Mega Evolution/032.ts
+++ b/data/Mega Evolution/Mega Evolution/032.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 110,
 	types: ["Water"],
 	stage: "Basic",
+	dexId: [226],
 
 	attacks: [{
 		cost: ["Colorless"],

--- a/data/Mega Evolution/Mega Evolution/033.ts
+++ b/data/Mega Evolution/Mega Evolution/033.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 80,
 	types: ["Water"],
 	stage: "Basic",
+	dexId: [341],
 
 	attacks: [{
 		cost: ["Colorless"],

--- a/data/Mega Evolution/Mega Evolution/034.ts
+++ b/data/Mega Evolution/Mega Evolution/034.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 150,
 	types: ["Water"],
 	stage: "Basic",
+	dexId: [382],
 
 	attacks: [{
 		cost: ["Water"],

--- a/data/Mega Evolution/Mega Evolution/035.ts
+++ b/data/Mega Evolution/Mega Evolution/035.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 90,
 	types: ["Water"],
 	stage: "Basic",
+	dexId: [459],
 
 	attacks: [{
 		cost: ["Water"],

--- a/data/Mega Evolution/Mega Evolution/036.ts
+++ b/data/Mega Evolution/Mega Evolution/036.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 350,
 	types: ["Water"],
 	stage: "Stage1",
+	dexId: [460],
 
 	attacks: [{
 		cost: ["Water", "Water"],

--- a/data/Mega Evolution/Mega Evolution/037.ts
+++ b/data/Mega Evolution/Mega Evolution/037.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 80,
 	types: ["Water"],
 	stage: "Basic",
+	dexId: [692],
 
 	attacks: [{
 		cost: ["Water", "Water"],

--- a/data/Mega Evolution/Mega Evolution/038.ts
+++ b/data/Mega Evolution/Mega Evolution/038.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 130,
 	types: ["Water"],
 	stage: "Stage1",
+	dexId: [693],
 
 	abilities: [{
 		type: "Ability",

--- a/data/Mega Evolution/Mega Evolution/039.ts
+++ b/data/Mega Evolution/Mega Evolution/039.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 70,
 	types: ["Water"],
 	stage: "Basic",
+	dexId: [816],
 
 	attacks: [{
 		cost: ["Water"],

--- a/data/Mega Evolution/Mega Evolution/040.ts
+++ b/data/Mega Evolution/Mega Evolution/040.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 100,
 	types: ["Water"],
 	stage: "Stage1",
+	dexId: [817],
 
 	attacks: [{
 		cost: ["Water"],

--- a/data/Mega Evolution/Mega Evolution/041.ts
+++ b/data/Mega Evolution/Mega Evolution/041.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 150,
 	types: ["Water"],
 	stage: "Stage2",
+	dexId: [818],
 
 	attacks: [{
 		cost: ["Water"],

--- a/data/Mega Evolution/Mega Evolution/042.ts
+++ b/data/Mega Evolution/Mega Evolution/042.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 50,
 	types: ["Water"],
 	stage: "Basic",
+	dexId: [872],
 
 	attacks: [{
 		cost: ["Water"],

--- a/data/Mega Evolution/Mega Evolution/043.ts
+++ b/data/Mega Evolution/Mega Evolution/043.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 110,
 	types: ["Water"],
 	stage: "Stage1",
+	dexId: [873],
 
 	attacks: [{
 		cost: ["Water"],

--- a/data/Mega Evolution/Mega Evolution/044.ts
+++ b/data/Mega Evolution/Mega Evolution/044.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 110,
 	types: ["Water"],
 	stage: "Basic",
+	dexId: [875],
 
 	attacks: [{
 		cost: ["Colorless"],

--- a/data/Mega Evolution/Mega Evolution/045.ts
+++ b/data/Mega Evolution/Mega Evolution/045.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 70,
 	types: ["Lightning"],
 	stage: "Basic",
+	dexId: [81],
 
 	attacks: [{
 		cost: ["Lightning"],

--- a/data/Mega Evolution/Mega Evolution/046.ts
+++ b/data/Mega Evolution/Mega Evolution/046.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 90,
 	types: ["Lightning"],
 	stage: "Stage1",
+	dexId: [82],
 
 	attacks: [{
 		cost: ["Lightning"],

--- a/data/Mega Evolution/Mega Evolution/047.ts
+++ b/data/Mega Evolution/Mega Evolution/047.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 160,
 	types: ["Lightning"],
 	stage: "Stage2",
+	dexId: [462],
 
 	attacks: [{
 		cost: ["Lightning"],

--- a/data/Mega Evolution/Mega Evolution/048.ts
+++ b/data/Mega Evolution/Mega Evolution/048.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 120,
 	types: ["Lightning"],
 	stage: "Basic",
+	dexId: [243],
 
 	attacks: [{
 		cost: ["Lightning", "Lightning"],

--- a/data/Mega Evolution/Mega Evolution/049.ts
+++ b/data/Mega Evolution/Mega Evolution/049.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 70,
 	types: ["Lightning"],
 	stage: "Basic",
+	dexId: [309],
 
 	attacks: [{
 		cost: ["Lightning"],

--- a/data/Mega Evolution/Mega Evolution/050.ts
+++ b/data/Mega Evolution/Mega Evolution/050.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 330,
 	types: ["Lightning"],
 	stage: "Stage1",
+	dexId: [310],
 
 	attacks: [{
 		cost: ["Lightning", "Lightning"],

--- a/data/Mega Evolution/Mega Evolution/051.ts
+++ b/data/Mega Evolution/Mega Evolution/051.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 70,
 	types: ["Lightning"],
 	stage: "Basic",
+	dexId: [417],
 
 	attacks: [{
 		cost: ["Lightning"],

--- a/data/Mega Evolution/Mega Evolution/052.ts
+++ b/data/Mega Evolution/Mega Evolution/052.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 70,
 	types: ["Lightning"],
 	stage: "Basic",
+	dexId: [694],
 
 	attacks: [{
 		cost: ["Colorless"],

--- a/data/Mega Evolution/Mega Evolution/053.ts
+++ b/data/Mega Evolution/Mega Evolution/053.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 120,
 	types: ["Lightning"],
 	stage: "Stage1",
+	dexId: [695],
 
 	attacks: [{
 		cost: ["Colorless"],

--- a/data/Mega Evolution/Mega Evolution/054.ts
+++ b/data/Mega Evolution/Mega Evolution/054.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 50,
 	types: ["Psychic"],
 	stage: "Basic",
+	dexId: [63],
 
 	attacks: [{
 		cost: ["Psychic"],

--- a/data/Mega Evolution/Mega Evolution/055.ts
+++ b/data/Mega Evolution/Mega Evolution/055.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 80,
 	types: ["Psychic"],
 	stage: "Stage1",
+	dexId: [64],
 
 	abilities: [{
 		type: "Ability",

--- a/data/Mega Evolution/Mega Evolution/056.ts
+++ b/data/Mega Evolution/Mega Evolution/056.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 140,
 	types: ["Psychic"],
 	stage: "Stage2",
+	dexId: [65],
 
 	abilities: [{
 		type: "Ability",

--- a/data/Mega Evolution/Mega Evolution/057.ts
+++ b/data/Mega Evolution/Mega Evolution/057.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 110,
 	types: ["Psychic"],
 	stage: "Basic",
+	dexId: [124],
 
 	attacks: [{
 		cost: ["Psychic", "Psychic"],

--- a/data/Mega Evolution/Mega Evolution/058.ts
+++ b/data/Mega Evolution/Mega Evolution/058.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 70,
 	types: ["Psychic"],
 	stage: "Basic",
+	dexId: [280],
 
 	attacks: [{
 		cost: ["Colorless"],

--- a/data/Mega Evolution/Mega Evolution/059.ts
+++ b/data/Mega Evolution/Mega Evolution/059.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 100,
 	types: ["Psychic"],
 	stage: "Stage1",
+	dexId: [281],
 
 	attacks: [{
 		cost: ["Psychic"],

--- a/data/Mega Evolution/Mega Evolution/060.ts
+++ b/data/Mega Evolution/Mega Evolution/060.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 360,
 	types: ["Psychic"],
 	stage: "Stage2",
+	dexId: [282],
 
 	attacks: [{
 		cost: ["Psychic"],

--- a/data/Mega Evolution/Mega Evolution/061.ts
+++ b/data/Mega Evolution/Mega Evolution/061.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 60,
 	types: ["Psychic"],
 	stage: "Stage1",
+	dexId: [292],
 
 	abilities: [{
 		type: "Ability",

--- a/data/Mega Evolution/Mega Evolution/062.ts
+++ b/data/Mega Evolution/Mega Evolution/062.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 70,
 	types: ["Psychic"],
 	stage: "Basic",
+	dexId: [325],
 
 	attacks: [{
 		cost: ["Psychic"],

--- a/data/Mega Evolution/Mega Evolution/063.ts
+++ b/data/Mega Evolution/Mega Evolution/063.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 120,
 	types: ["Psychic"],
 	stage: "Stage1",
+	dexId: [326],
 
 	abilities: [{
 		type: "Ability",

--- a/data/Mega Evolution/Mega Evolution/064.ts
+++ b/data/Mega Evolution/Mega Evolution/064.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 120,
 	types: ["Psychic"],
 	stage: "Basic",
+	dexId: [716],
 
 	attacks: [{
 		cost: ["Psychic"],

--- a/data/Mega Evolution/Mega Evolution/065.ts
+++ b/data/Mega Evolution/Mega Evolution/065.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 80,
 	types: ["Psychic"],
 	stage: "Basic",
+	dexId: [971],
 
 	attacks: [{
 		cost: ["Psychic"],

--- a/data/Mega Evolution/Mega Evolution/066.ts
+++ b/data/Mega Evolution/Mega Evolution/066.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 140,
 	types: ["Psychic"],
 	stage: "Stage1",
+	dexId: [972],
 
 	attacks: [{
 		cost: ["Psychic"],

--- a/data/Mega Evolution/Mega Evolution/067.ts
+++ b/data/Mega Evolution/Mega Evolution/067.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 70,
 	types: ["Psychic"],
 	stage: "Basic",
+	dexId: [999],
 
 	attacks: [{
 		cost: ["Colorless"],

--- a/data/Mega Evolution/Mega Evolution/068.ts
+++ b/data/Mega Evolution/Mega Evolution/068.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 70,
 	types: ["Fighting"],
 	stage: "Basic",
+	dexId: [27],
 
 	attacks: [{
 		cost: ["Colorless"],

--- a/data/Mega Evolution/Mega Evolution/069.ts
+++ b/data/Mega Evolution/Mega Evolution/069.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 120,
 	types: ["Fighting"],
 	stage: "Stage1",
+	dexId: [28],
 
 	attacks: [{
 		cost: ["Colorless", "Colorless"],

--- a/data/Mega Evolution/Mega Evolution/070.ts
+++ b/data/Mega Evolution/Mega Evolution/070.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 120,
 	types: ["Fighting"],
 	stage: "Basic",
+	dexId: [95],
 
 	attacks: [{
 		cost: ["Colorless", "Colorless"],

--- a/data/Mega Evolution/Mega Evolution/071.ts
+++ b/data/Mega Evolution/Mega Evolution/071.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 30,
 	types: ["Fighting"],
 	stage: "Basic",
+	dexId: [236],
 
 	attacks: [{
 		name: {

--- a/data/Mega Evolution/Mega Evolution/072.ts
+++ b/data/Mega Evolution/Mega Evolution/072.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 80,
 	types: ["Fighting"],
 	stage: "Basic",
+	dexId: [296],
 
 	attacks: [{
 		cost: ["Fighting"],

--- a/data/Mega Evolution/Mega Evolution/073.ts
+++ b/data/Mega Evolution/Mega Evolution/073.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 150,
 	types: ["Fighting"],
 	stage: "Stage1",
+	dexId: [297],
 
 	abilities: [{
 		type: "Ability",

--- a/data/Mega Evolution/Mega Evolution/074.ts
+++ b/data/Mega Evolution/Mega Evolution/074.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 110,
 	types: ["Fighting"],
 	stage: "Basic",
+	dexId: [337],
 
 	abilities: [{
 		type: "Ability",

--- a/data/Mega Evolution/Mega Evolution/075.ts
+++ b/data/Mega Evolution/Mega Evolution/075.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 110,
 	types: ["Fighting"],
 	stage: "Basic",
+	dexId: [338],
 
 	attacks: [{
 		cost: ["Fighting"],

--- a/data/Mega Evolution/Mega Evolution/076.ts
+++ b/data/Mega Evolution/Mega Evolution/076.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 80,
 	types: ["Fighting"],
 	stage: "Basic",
+	dexId: [447],
 
 	attacks: [{
 		cost: ["Fighting"],

--- a/data/Mega Evolution/Mega Evolution/077.ts
+++ b/data/Mega Evolution/Mega Evolution/077.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 340,
 	types: ["Fighting"],
 	stage: "Stage1",
+	dexId: [448],
 
 	attacks: [{
 		cost: ["Fighting"],

--- a/data/Mega Evolution/Mega Evolution/078.ts
+++ b/data/Mega Evolution/Mega Evolution/078.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 70,
 	types: ["Fighting"],
 	stage: "Basic",
+	dexId: [453],
 
 	attacks: [{
 		cost: ["Fighting"],

--- a/data/Mega Evolution/Mega Evolution/079.ts
+++ b/data/Mega Evolution/Mega Evolution/079.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 130,
 	types: ["Fighting"],
 	stage: "Stage1",
+	dexId: [454],
 
 	attacks: [{
 		cost: ["Fighting"],

--- a/data/Mega Evolution/Mega Evolution/080.ts
+++ b/data/Mega Evolution/Mega Evolution/080.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 90,
 	types: ["Fighting"],
 	stage: "Basic",
+	dexId: [802],
 
 	attacks: [{
 		cost: ["Fighting", "Fighting"],

--- a/data/Mega Evolution/Mega Evolution/081.ts
+++ b/data/Mega Evolution/Mega Evolution/081.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 130,
 	types: ["Fighting"],
 	stage: "Basic",
+	dexId: [874],
 
 	attacks: [{
 		cost: ["Fighting"],

--- a/data/Mega Evolution/Mega Evolution/082.ts
+++ b/data/Mega Evolution/Mega Evolution/082.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 70,
 	types: ["Fighting"],
 	stage: "Basic",
+	dexId: [932],
 
 	attacks: [{
 		cost: ["Colorless"],

--- a/data/Mega Evolution/Mega Evolution/083.ts
+++ b/data/Mega Evolution/Mega Evolution/083.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 110,
 	types: ["Fighting"],
 	stage: "Stage1",
+	dexId: [933],
 
 	attacks: [{
 		cost: ["Fighting", "Colorless"],

--- a/data/Mega Evolution/Mega Evolution/084.ts
+++ b/data/Mega Evolution/Mega Evolution/084.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 180,
 	types: ["Fighting"],
 	stage: "Stage2",
+	dexId: [934],
 
 	abilities: [{
 		type: "Ability",

--- a/data/Mega Evolution/Mega Evolution/085.ts
+++ b/data/Mega Evolution/Mega Evolution/085.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 130,
 	types: ["Darkness"],
 	stage: "Stage1",
+	dexId: [342],
 
 	attacks: [{
 		cost: ["Colorless"],

--- a/data/Mega Evolution/Mega Evolution/086.ts
+++ b/data/Mega Evolution/Mega Evolution/086.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 280,
 	types: ["Darkness"],
 	stage: "Basic",
+	dexId: [351],
 
 	attacks: [{
 		cost: ["Darkness", "Colorless"],

--- a/data/Mega Evolution/Mega Evolution/087.ts
+++ b/data/Mega Evolution/Mega Evolution/087.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 80,
 	types: ["Darkness"],
 	stage: "Basic",
+	dexId: [442],
 
 	abilities: [{
 		type: "Ability",

--- a/data/Mega Evolution/Mega Evolution/088.ts
+++ b/data/Mega Evolution/Mega Evolution/088.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 110,
 	types: ["Darkness"],
 	stage: "Basic",
+	dexId: [717],
 
 	attacks: [{
 		cost: ["Darkness"],

--- a/data/Mega Evolution/Mega Evolution/089.ts
+++ b/data/Mega Evolution/Mega Evolution/089.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 70,
 	types: ["Darkness"],
 	stage: "Basic",
+	dexId: [827],
 
 	attacks: [{
 		cost: ["Darkness"],

--- a/data/Mega Evolution/Mega Evolution/090.ts
+++ b/data/Mega Evolution/Mega Evolution/090.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 120,
 	types: ["Darkness"],
 	stage: "Stage1",
+	dexId: [828],
 
 	attacks: [{
 		cost: ["Colorless"],

--- a/data/Mega Evolution/Mega Evolution/091.ts
+++ b/data/Mega Evolution/Mega Evolution/091.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 60,
 	types: ["Darkness"],
 	stage: "Basic",
+	dexId: [944],
 
 	attacks: [{
 		cost: ["Darkness", "Colorless"],

--- a/data/Mega Evolution/Mega Evolution/092.ts
+++ b/data/Mega Evolution/Mega Evolution/092.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 100,
 	types: ["Darkness"],
 	stage: "Stage1",
+	dexId: [945],
 
 	attacks: [{
 		cost: ["Darkness", "Colorless"],

--- a/data/Mega Evolution/Mega Evolution/093.ts
+++ b/data/Mega Evolution/Mega Evolution/093.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 200,
 	types: ["Metal"],
 	stage: "Stage1",
+	dexId: [208],
 
 	attacks: [{
 		cost: ["Colorless", "Colorless"],

--- a/data/Mega Evolution/Mega Evolution/094.ts
+++ b/data/Mega Evolution/Mega Evolution/094.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 270,
 	types: ["Metal"],
 	stage: "Basic",
+	dexId: [303],
 
 	attacks: [{
 		cost: ["Metal", "Metal"],

--- a/data/Mega Evolution/Mega Evolution/095.ts
+++ b/data/Mega Evolution/Mega Evolution/095.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 140,
 	types: ["Metal"],
 	stage: "Basic",
+	dexId: [483],
 
 	attacks: [{
 		cost: ["Metal"],

--- a/data/Mega Evolution/Mega Evolution/096.ts
+++ b/data/Mega Evolution/Mega Evolution/096.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 70,
 	types: ["Metal"],
 	stage: "Basic",
+	dexId: [957],
 
 	attacks: [{
 		cost: ["Metal"],

--- a/data/Mega Evolution/Mega Evolution/097.ts
+++ b/data/Mega Evolution/Mega Evolution/097.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 90,
 	types: ["Metal"],
 	stage: "Stage1",
+	dexId: [958],
 
 	abilities: [{
 		type: "Ability",

--- a/data/Mega Evolution/Mega Evolution/098.ts
+++ b/data/Mega Evolution/Mega Evolution/098.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 160,
 	types: ["Metal"],
 	stage: "Stage2",
+	dexId: [959],
 
 	attacks: [{
 		cost: ["Metal"],

--- a/data/Mega Evolution/Mega Evolution/099.ts
+++ b/data/Mega Evolution/Mega Evolution/099.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 130,
 	types: ["Metal"],
 	stage: "Stage1",
+	dexId: [1000],
 
 	attacks: [{
 		cost: ["Colorless"],

--- a/data/Mega Evolution/Mega Evolution/100.ts
+++ b/data/Mega Evolution/Mega Evolution/100.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 280,
 	types: ["Dragon"],
 	stage: "Basic",
+	dexId: [380],
 
 	attacks: [{
 		cost: ["Colorless"],

--- a/data/Mega Evolution/Mega Evolution/101.ts
+++ b/data/Mega Evolution/Mega Evolution/101.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 130,
 	types: ["Dragon"],
 	stage: "Basic",
+	dexId: [381],
 
 	abilities: [{
 		type: "Ability",

--- a/data/Mega Evolution/Mega Evolution/102.ts
+++ b/data/Mega Evolution/Mega Evolution/102.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 60,
 	types: ["Colorless"],
 	stage: "Basic",
+	dexId: [21],
 
 	attacks: [{
 		cost: ["Colorless"],

--- a/data/Mega Evolution/Mega Evolution/103.ts
+++ b/data/Mega Evolution/Mega Evolution/103.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 100,
 	types: ["Colorless"],
 	stage: "Stage1",
+	dexId: [22],
 
 	attacks: [{
 		cost: ["Colorless"],

--- a/data/Mega Evolution/Mega Evolution/104.ts
+++ b/data/Mega Evolution/Mega Evolution/104.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 300,
 	types: ["Colorless"],
 	stage: "Basic",
+	dexId: [115],
 
 	abilities: [{
 		type: "Ability",

--- a/data/Mega Evolution/Mega Evolution/105.ts
+++ b/data/Mega Evolution/Mega Evolution/105.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 90,
 	types: ["Colorless"],
 	stage: "Basic",
+	dexId: [225],
 
 	attacks: [{
 		cost: ["Colorless"],

--- a/data/Mega Evolution/Mega Evolution/106.ts
+++ b/data/Mega Evolution/Mega Evolution/106.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 120,
 	types: ["Colorless"],
 	stage: "Basic",
+	dexId: [241],
 
 	attacks: [{
 		cost: ["Colorless", "Colorless"],

--- a/data/Mega Evolution/Mega Evolution/107.ts
+++ b/data/Mega Evolution/Mega Evolution/107.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 70,
 	types: ["Colorless"],
 	stage: "Basic",
+	dexId: [427],
 
 	attacks: [{
 		cost: ["Colorless"],

--- a/data/Mega Evolution/Mega Evolution/108.ts
+++ b/data/Mega Evolution/Mega Evolution/108.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 110,
 	types: ["Colorless"],
 	stage: "Stage1",
+	dexId: [428],
 
 	attacks: [{
 		cost: ["Colorless"],

--- a/data/Mega Evolution/Mega Evolution/109.ts
+++ b/data/Mega Evolution/Mega Evolution/109.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 70,
 	types: ["Colorless"],
 	stage: "Basic",
+	dexId: [734],
 
 	attacks: [{
 		cost: ["Colorless"],

--- a/data/Mega Evolution/Mega Evolution/110.ts
+++ b/data/Mega Evolution/Mega Evolution/110.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 100,
 	types: ["Colorless"],
 	stage: "Stage1",
+	dexId: [735],
 
 	abilities: [{
 		type: "Ability",

--- a/data/Mega Evolution/Mega Evolution/111.ts
+++ b/data/Mega Evolution/Mega Evolution/111.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 70,
 	types: ["Colorless"],
 	stage: "Basic",
+	dexId: [759],
 
 	attacks: [{
 		cost: ["Colorless"],

--- a/data/Mega Evolution/Mega Evolution/112.ts
+++ b/data/Mega Evolution/Mega Evolution/112.ts
@@ -20,6 +20,8 @@ const card: Card = {
 	hp: 130,
 	types: ["Colorless"],
 	stage: "Stage1",
+	dexId: [760],
+
 
 	attacks: [{
 		cost: ["Colorless", "Colorless"],

--- a/data/Mega Evolution/Mega Evolution/133.ts
+++ b/data/Mega Evolution/Mega Evolution/133.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 80,
 	types: ["Grass"],
 	stage: "Basic",
+	dexId: [1],
 
 	attacks: [{
 		cost: ["Grass"],

--- a/data/Mega Evolution/Mega Evolution/134.ts
+++ b/data/Mega Evolution/Mega Evolution/134.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 110,
 	types: ["Grass"],
 	stage: "Stage1",
+	dexId: [2],
 
 	attacks: [{
 		cost: ["Grass", "Grass"],

--- a/data/Mega Evolution/Mega Evolution/135.ts
+++ b/data/Mega Evolution/Mega Evolution/135.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 140,
 	types: ["Grass"],
 	stage: "Stage1",
+	dexId: [103],
 
 	attacks: [{
 		cost: ["Grass"],

--- a/data/Mega Evolution/Mega Evolution/136.ts
+++ b/data/Mega Evolution/Mega Evolution/136.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 80,
 	types: ["Grass"],
 	stage: "Basic",
+	dexId: [213],
 
 	abilities: [{
 		type: "Ability",

--- a/data/Mega Evolution/Mega Evolution/137.ts
+++ b/data/Mega Evolution/Mega Evolution/137.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 80,
 	types: ["Grass"],
 	stage: "Stage1",
+	dexId: [291],
 
 	abilities: [{
 		type: "Ability",

--- a/data/Mega Evolution/Mega Evolution/138.ts
+++ b/data/Mega Evolution/Mega Evolution/138.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 70,
 	types: ["Fire"],
 	stage: "Basic",
+	dexId: [37],
 
 	attacks: [{
 		cost: ["Colorless"],

--- a/data/Mega Evolution/Mega Evolution/139.ts
+++ b/data/Mega Evolution/Mega Evolution/139.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 70,
 	types: ["Fire"],
 	stage: "Basic",
+	dexId: [667],
 
 	attacks: [{
 		cost: ["Fire", "Colorless"],

--- a/data/Mega Evolution/Mega Evolution/140.ts
+++ b/data/Mega Evolution/Mega Evolution/140.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 90,
 	types: ["Water"],
 	stage: "Basic",
+	dexId: [459],
 
 	attacks: [{
 		cost: ["Water"],

--- a/data/Mega Evolution/Mega Evolution/141.ts
+++ b/data/Mega Evolution/Mega Evolution/141.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 130,
 	types: ["Water"],
 	stage: "Stage1",
+	dexId: [693],
 
 	abilities: [{
 		type: "Ability",

--- a/data/Mega Evolution/Mega Evolution/142.ts
+++ b/data/Mega Evolution/Mega Evolution/142.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 150,
 	types: ["Water"],
 	stage: "Stage2",
+	dexId: [818],
 
 	attacks: [{
 		cost: ["Water"],

--- a/data/Mega Evolution/Mega Evolution/143.ts
+++ b/data/Mega Evolution/Mega Evolution/143.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 70,
 	types: ["Lightning"],
 	stage: "Basic",
+	dexId: [694],
 
 	attacks: [{
 		cost: ["Colorless"],

--- a/data/Mega Evolution/Mega Evolution/144.ts
+++ b/data/Mega Evolution/Mega Evolution/144.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 60,
 	types: ["Psychic"],
 	stage: "Stage1",
+	dexId: [292],
 
 	abilities: [{
 		type: "Ability",

--- a/data/Mega Evolution/Mega Evolution/145.ts
+++ b/data/Mega Evolution/Mega Evolution/145.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 140,
 	types: ["Psychic"],
 	stage: "Stage1",
+	dexId: [972],
 
 	attacks: [{
 		cost: ["Psychic"],

--- a/data/Mega Evolution/Mega Evolution/146.ts
+++ b/data/Mega Evolution/Mega Evolution/146.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 90,
 	types: ["Fighting"],
 	stage: "Basic",
+	dexId: [802],
 
 	attacks: [{
 		cost: ["Fighting", "Fighting"],

--- a/data/Mega Evolution/Mega Evolution/147.ts
+++ b/data/Mega Evolution/Mega Evolution/147.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 180,
 	types: ["Fighting"],
 	stage: "Stage2",
+	dexId: [934],
 
 	abilities: [{
 		type: "Ability",

--- a/data/Mega Evolution/Mega Evolution/148.ts
+++ b/data/Mega Evolution/Mega Evolution/148.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 80,
 	types: ["Darkness"],
 	stage: "Basic",
+	dexId: [442],
 
 	abilities: [{
 		type: "Ability",

--- a/data/Mega Evolution/Mega Evolution/149.ts
+++ b/data/Mega Evolution/Mega Evolution/149.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 60,
 	types: ["Darkness"],
 	stage: "Basic",
+	dexId: [944],
 
 	attacks: [{
 		cost: ["Darkness", "Colorless"],

--- a/data/Mega Evolution/Mega Evolution/150.ts
+++ b/data/Mega Evolution/Mega Evolution/150.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 200,
 	types: ["Metal"],
 	stage: "Stage1",
+	dexId: [208],
 
 	attacks: [{
 		cost: ["Colorless", "Colorless"],

--- a/data/Mega Evolution/Mega Evolution/151.ts
+++ b/data/Mega Evolution/Mega Evolution/151.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 60,
 	types: ["Colorless"],
 	stage: "Basic",
+	dexId: [21],
 
 	attacks: [{
 		cost: ["Colorless"],

--- a/data/Mega Evolution/Mega Evolution/152.ts
+++ b/data/Mega Evolution/Mega Evolution/152.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 90,
 	types: ["Colorless"],
 	stage: "Basic",
+	dexId: [225],
 
 	attacks: [{
 		cost: ["Colorless"],

--- a/data/Mega Evolution/Mega Evolution/153.ts
+++ b/data/Mega Evolution/Mega Evolution/153.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 100,
 	types: ["Colorless"],
 	stage: "Stage1",
+	dexId: [735],
 
 	abilities: [{
 		type: "Ability",

--- a/data/Mega Evolution/Mega Evolution/154.ts
+++ b/data/Mega Evolution/Mega Evolution/154.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 70,
 	types: ["Colorless"],
 	stage: "Basic",
+	dexId: [759],
 
 	attacks: [{
 		cost: ["Colorless"],

--- a/data/Mega Evolution/Mega Evolution/155.ts
+++ b/data/Mega Evolution/Mega Evolution/155.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 380,
 	types: ["Grass"],
 	stage: "Stage2",
+	dexId: [3],
 
 	abilities: [{
 		type: "Ability",

--- a/data/Mega Evolution/Mega Evolution/156.ts
+++ b/data/Mega Evolution/Mega Evolution/156.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 340,
 	types: ["Fire"],
 	stage: "Stage1",
+	dexId: [323],
 
 	attacks: [{
 		cost: ["Fire"],

--- a/data/Mega Evolution/Mega Evolution/157.ts
+++ b/data/Mega Evolution/Mega Evolution/157.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 350,
 	types: ["Water"],
 	stage: "Stage1",
+	dexId: [460],
 
 	attacks: [{
 		cost: ["Water", "Water"],

--- a/data/Mega Evolution/Mega Evolution/158.ts
+++ b/data/Mega Evolution/Mega Evolution/158.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 330,
 	types: ["Lightning"],
 	stage: "Stage1",
+	dexId: [310],
 
 	attacks: [{
 		cost: ["Lightning", "Lightning"],

--- a/data/Mega Evolution/Mega Evolution/159.ts
+++ b/data/Mega Evolution/Mega Evolution/159.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 360,
 	types: ["Psychic"],
 	stage: "Stage2",
+	dexId: [282],
 
 	attacks: [{
 		cost: ["Psychic"],

--- a/data/Mega Evolution/Mega Evolution/160.ts
+++ b/data/Mega Evolution/Mega Evolution/160.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 340,
 	types: ["Fighting"],
 	stage: "Stage1",
+	dexId: [448],
 
 	attacks: [{
 		cost: ["Fighting"],

--- a/data/Mega Evolution/Mega Evolution/161.ts
+++ b/data/Mega Evolution/Mega Evolution/161.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 280,
 	types: ["Darkness"],
 	stage: "Basic",
+	dexId: [359],
 
 	attacks: [{
 		cost: ["Darkness", "Colorless"],

--- a/data/Mega Evolution/Mega Evolution/162.ts
+++ b/data/Mega Evolution/Mega Evolution/162.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 270,
 	types: ["Metal"],
 	stage: "Basic",
+	dexId: [303],
 
 	attacks: [{
 		cost: ["Metal", "Metal"],

--- a/data/Mega Evolution/Mega Evolution/163.ts
+++ b/data/Mega Evolution/Mega Evolution/163.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 280,
 	types: ["Dragon"],
 	stage: "Basic",
+	dexId: [380],
 
 	attacks: [{
 		cost: ["Colorless"],

--- a/data/Mega Evolution/Mega Evolution/164.ts
+++ b/data/Mega Evolution/Mega Evolution/164.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 300,
 	types: ["Colorless"],
 	stage: "Basic",
+	dexId: [115],
 
 	abilities: [{
 		type: "Ability",

--- a/data/Mega Evolution/Mega Evolution/177.ts
+++ b/data/Mega Evolution/Mega Evolution/177.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 380,
 	types: ["Grass"],
 	stage: "Stage2",
+	dexId: [3],
 
 	abilities: [{
 		type: "Ability",

--- a/data/Mega Evolution/Mega Evolution/178.ts
+++ b/data/Mega Evolution/Mega Evolution/178.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 360,
 	types: ["Psychic"],
 	stage: "Stage2",
+	dexId: [282],
 
 	attacks: [{
 		cost: ["Psychic"],

--- a/data/Mega Evolution/Mega Evolution/179.ts
+++ b/data/Mega Evolution/Mega Evolution/179.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 340,
 	types: ["Fighting"],
 	stage: "Stage1",
+	dexId: [448],
 
 	attacks: [{
 		cost: ["Fighting"],

--- a/data/Mega Evolution/Mega Evolution/180.ts
+++ b/data/Mega Evolution/Mega Evolution/180.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 280,
 	types: ["Darkness"],
 	stage: "Basic",
+	dexId: [359],
 
 	attacks: [{
 		cost: ["Darkness", "Colorless"],

--- a/data/Mega Evolution/Mega Evolution/181.ts
+++ b/data/Mega Evolution/Mega Evolution/181.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 280,
 	types: ["Dragon"],
 	stage: "Basic",
+	dexId: [380],
 
 	attacks: [{
 		cost: ["Colorless"],

--- a/data/Mega Evolution/Mega Evolution/182.ts
+++ b/data/Mega Evolution/Mega Evolution/182.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 300,
 	types: ["Colorless"],
 	stage: "Basic",
+	dexId: [115],
 
 	abilities: [{
 		type: "Ability",

--- a/data/Mega Evolution/Mega Evolution/187.ts
+++ b/data/Mega Evolution/Mega Evolution/187.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 360,
 	types: ["Psychic"],
 	stage: "Stage2",
+	dexId: [282],
 
 	attacks: [{
 		cost: ["Psychic"],

--- a/data/Mega Evolution/Mega Evolution/188.ts
+++ b/data/Mega Evolution/Mega Evolution/188.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 340,
 	types: ["Fighting"],
 	stage: "Stage1",
+	dexId: [448],
 
 	attacks: [{
 		cost: ["Fighting"],


### PR DESCRIPTION
This PR adds the correct dexId values for all cards in the ME01 (Mega Evolution) set.
Previously, these cards were missing dexId, which caused issues when filtering or adding them to collections.