### PR TITLE
Fix: Yaml error when composing Docker

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,8 +3,9 @@ services:
     image: tcgdex/server:edge # You can choose between using the hub.docker.com one or the github one
     # image: ghcr.io/tcgdex/server:edge
     restart: unless-stopped
+    environment:
       # by default the server will start a worker for each threads available
-      # You downgrade the max number of workers by changing this value
+      # You can downgrade the max number of workers by changing this value
       - MAX_WORKERS=2
     ports:
       - 3000:3000 # You can choose any port you want


### PR DESCRIPTION
<!--
Thanks for your Pull Request, Please provide the related Issue using "Fix #0" or describe the change(s) you made.
The issue title must follow Conventional Commit conventionalcommits.org.
More informations at https://github.com/tcgdex/cards-database/blob/master/CONTRIBUTING.md
-->

### Bug 
When trying to compose docker by running `docker-compose up -d`, I am seeing the following error 
```
yaml: line 2: did not find expected key
```

### Fix
It looks like the docker-compose.yml file has a syntax issue, adding the `environment` tag looks to fix the issue. I was able to compose docker afterwards
