### PR TITLE
Update Cardmarket IDs for White Flare cards

### DIFF
--- a/data/Scarlet & Violet/White Flare/033.ts
+++ b/data/Scarlet & Violet/White Flare/033.ts
@@ -51,7 +51,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	thirdParty: {
-		cardmarket: 835967
+		cardmarket: 836053
 	}
 }
 

--- a/data/Scarlet & Violet/White Flare/050.ts
+++ b/data/Scarlet & Violet/White Flare/050.ts
@@ -51,7 +51,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	thirdParty: {
-		cardmarket: 835993
+		cardmarket: 835991
 	}
 }
 

--- a/data/Scarlet & Violet/White Flare/087.ts
+++ b/data/Scarlet & Violet/White Flare/087.ts
@@ -41,7 +41,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	thirdParty: {
-		cardmarket: 835898
+		cardmarket: 836071
 	}
 }
 

--- a/data/Scarlet & Violet/White Flare/088.ts
+++ b/data/Scarlet & Violet/White Flare/088.ts
@@ -65,7 +65,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	thirdParty: {
-		cardmarket: 835899
+		cardmarket: 836072
 	}
 }
 

--- a/data/Scarlet & Violet/White Flare/089.ts
+++ b/data/Scarlet & Violet/White Flare/089.ts
@@ -73,7 +73,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	thirdParty: {
-		cardmarket: 835901
+		cardmarket: 836074
 	}
 }
 

--- a/data/Scarlet & Violet/White Flare/090.ts
+++ b/data/Scarlet & Violet/White Flare/090.ts
@@ -51,7 +51,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	thirdParty: {
-		cardmarket: 835907
+		cardmarket: 836075
 	}
 }
 

--- a/data/Scarlet & Violet/White Flare/091.ts
+++ b/data/Scarlet & Violet/White Flare/091.ts
@@ -41,7 +41,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	thirdParty: {
-		cardmarket: 835911
+		cardmarket: 836077
 	}
 }
 

--- a/data/Scarlet & Violet/White Flare/092.ts
+++ b/data/Scarlet & Violet/White Flare/092.ts
@@ -65,7 +65,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	thirdParty: {
-		cardmarket: 835913
+		cardmarket: 836079
 	}
 }
 

--- a/data/Scarlet & Violet/White Flare/093.ts
+++ b/data/Scarlet & Violet/White Flare/093.ts
@@ -65,7 +65,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	thirdParty: {
-		cardmarket: 835915
+		cardmarket: 836080
 	}
 }
 

--- a/data/Scarlet & Violet/White Flare/094.ts
+++ b/data/Scarlet & Violet/White Flare/094.ts
@@ -51,7 +51,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	thirdParty: {
-		cardmarket: 835917
+		cardmarket: 836081
 	}
 }
 

--- a/data/Scarlet & Violet/White Flare/095.ts
+++ b/data/Scarlet & Violet/White Flare/095.ts
@@ -75,7 +75,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	thirdParty: {
-		cardmarket: 835920
+		cardmarket: 836083
 	}
 }
 

--- a/data/Scarlet & Violet/White Flare/096.ts
+++ b/data/Scarlet & Violet/White Flare/096.ts
@@ -55,7 +55,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	thirdParty: {
-		cardmarket: 835923
+		cardmarket: 836084
 	}
 }
 

--- a/data/Scarlet & Violet/White Flare/097.ts
+++ b/data/Scarlet & Violet/White Flare/097.ts
@@ -55,7 +55,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	thirdParty: {
-		cardmarket: 835924
+		cardmarket: 836086
 	}
 }
 

--- a/data/Scarlet & Violet/White Flare/098.ts
+++ b/data/Scarlet & Violet/White Flare/098.ts
@@ -65,7 +65,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	thirdParty: {
-		cardmarket: 835925
+		cardmarket: 836088
 	}
 }
 

--- a/data/Scarlet & Violet/White Flare/099.ts
+++ b/data/Scarlet & Violet/White Flare/099.ts
@@ -63,7 +63,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	thirdParty: {
-		cardmarket: 835927
+		cardmarket: 836090
 	}
 }
 

--- a/data/Scarlet & Violet/White Flare/100.ts
+++ b/data/Scarlet & Violet/White Flare/100.ts
@@ -41,7 +41,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	thirdParty: {
-		cardmarket: 835930
+		cardmarket: 836092
 	}
 }
 

--- a/data/Scarlet & Violet/White Flare/101.ts
+++ b/data/Scarlet & Violet/White Flare/101.ts
@@ -49,7 +49,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	thirdParty: {
-		cardmarket: 835931
+		cardmarket: 836095
 	}
 }
 

--- a/data/Scarlet & Violet/White Flare/102.ts
+++ b/data/Scarlet & Violet/White Flare/102.ts
@@ -51,7 +51,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	thirdParty: {
-		cardmarket: 835933
+		cardmarket: 836097
 	}
 }
 

--- a/data/Scarlet & Violet/White Flare/103.ts
+++ b/data/Scarlet & Violet/White Flare/103.ts
@@ -75,7 +75,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	thirdParty: {
-		cardmarket: 835935
+		cardmarket: 836099
 	}
 }
 

--- a/data/Scarlet & Violet/White Flare/104.ts
+++ b/data/Scarlet & Violet/White Flare/104.ts
@@ -63,7 +63,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	thirdParty: {
-		cardmarket: 835937
+		cardmarket: 836103
 	}
 }
 

--- a/data/Scarlet & Violet/White Flare/105.ts
+++ b/data/Scarlet & Violet/White Flare/105.ts
@@ -55,7 +55,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	thirdParty: {
-		cardmarket: 835941
+		cardmarket: 836104
 	}
 }
 

--- a/data/Scarlet & Violet/White Flare/106.ts
+++ b/data/Scarlet & Violet/White Flare/106.ts
@@ -51,7 +51,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	thirdParty: {
-		cardmarket: 835944
+		cardmarket: 836106
 	}
 }
 

--- a/data/Scarlet & Violet/White Flare/107.ts
+++ b/data/Scarlet & Violet/White Flare/107.ts
@@ -75,7 +75,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	thirdParty: {
-		cardmarket: 835946
+		cardmarket: 836108
 	}
 }
 

--- a/data/Scarlet & Violet/White Flare/108.ts
+++ b/data/Scarlet & Violet/White Flare/108.ts
@@ -65,7 +65,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	thirdParty: {
-		cardmarket: 835951
+		cardmarket: 836110
 	}
 }
 

--- a/data/Scarlet & Violet/White Flare/109.ts
+++ b/data/Scarlet & Violet/White Flare/109.ts
@@ -63,7 +63,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	thirdParty: {
-		cardmarket: 835952
+		cardmarket: 836112
 	}
 }
 

--- a/data/Scarlet & Violet/White Flare/110.ts
+++ b/data/Scarlet & Violet/White Flare/110.ts
@@ -65,7 +65,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	thirdParty: {
-		cardmarket: 835954
+		cardmarket: 836114
 	}
 }
 

--- a/data/Scarlet & Violet/White Flare/111.ts
+++ b/data/Scarlet & Violet/White Flare/111.ts
@@ -65,7 +65,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	thirdParty: {
-		cardmarket: 835956
+		cardmarket: 836116
 	}
 }
 

--- a/data/Scarlet & Violet/White Flare/112.ts
+++ b/data/Scarlet & Violet/White Flare/112.ts
@@ -65,7 +65,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	thirdParty: {
-		cardmarket: 835958
+		cardmarket: 836118
 	}
 }
 

--- a/data/Scarlet & Violet/White Flare/113.ts
+++ b/data/Scarlet & Violet/White Flare/113.ts
@@ -65,7 +65,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	thirdParty: {
-		cardmarket: 835960
+		cardmarket: 836120
 	}
 }
 

--- a/data/Scarlet & Violet/White Flare/114.ts
+++ b/data/Scarlet & Violet/White Flare/114.ts
@@ -55,7 +55,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	thirdParty: {
-		cardmarket: 835963
+		cardmarket: 836122
 	}
 }
 

--- a/data/Scarlet & Violet/White Flare/115.ts
+++ b/data/Scarlet & Violet/White Flare/115.ts
@@ -65,7 +65,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	thirdParty: {
-		cardmarket: 835965
+		cardmarket: 836124
 	}
 }
 

--- a/data/Scarlet & Violet/White Flare/116.ts
+++ b/data/Scarlet & Violet/White Flare/116.ts
@@ -51,7 +51,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	thirdParty: {
-		cardmarket: 835967
+		cardmarket: 836126
 	}
 }
 

--- a/data/Scarlet & Violet/White Flare/117.ts
+++ b/data/Scarlet & Violet/White Flare/117.ts
@@ -51,7 +51,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	thirdParty: {
-		cardmarket: 835968
+		cardmarket: 836128
 	}
 }
 

--- a/data/Scarlet & Violet/White Flare/118.ts
+++ b/data/Scarlet & Violet/White Flare/118.ts
@@ -65,7 +65,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	thirdParty: {
-		cardmarket: 835969
+		cardmarket: 836130
 	}
 }
 

--- a/data/Scarlet & Violet/White Flare/119.ts
+++ b/data/Scarlet & Violet/White Flare/119.ts
@@ -41,7 +41,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	thirdParty: {
-		cardmarket: 835971
+		cardmarket: 836131
 	}
 }
 

--- a/data/Scarlet & Violet/White Flare/120.ts
+++ b/data/Scarlet & Violet/White Flare/120.ts
@@ -63,7 +63,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	thirdParty: {
-		cardmarket: 835972
+		cardmarket: 836133
 	}
 }
 

--- a/data/Scarlet & Violet/White Flare/121.ts
+++ b/data/Scarlet & Violet/White Flare/121.ts
@@ -71,7 +71,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	thirdParty: {
-		cardmarket: 835973
+		cardmarket: 836134
 	}
 }
 

--- a/data/Scarlet & Violet/White Flare/122.ts
+++ b/data/Scarlet & Violet/White Flare/122.ts
@@ -51,7 +51,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	thirdParty: {
-		cardmarket: 835974
+		cardmarket: 836136
 	}
 }
 

--- a/data/Scarlet & Violet/White Flare/123.ts
+++ b/data/Scarlet & Violet/White Flare/123.ts
@@ -73,7 +73,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	thirdParty: {
-		cardmarket: 835975
+		cardmarket: 836138
 	}
 }
 

--- a/data/Scarlet & Violet/White Flare/124.ts
+++ b/data/Scarlet & Violet/White Flare/124.ts
@@ -41,7 +41,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	thirdParty: {
-		cardmarket: 835976
+		cardmarket: 836140
 	}
 }
 

--- a/data/Scarlet & Violet/White Flare/125.ts
+++ b/data/Scarlet & Violet/White Flare/125.ts
@@ -63,7 +63,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	thirdParty: {
-		cardmarket: 835977
+		cardmarket: 836141
 	}
 }
 

--- a/data/Scarlet & Violet/White Flare/126.ts
+++ b/data/Scarlet & Violet/White Flare/126.ts
@@ -51,7 +51,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	thirdParty: {
-		cardmarket: 835982
+		cardmarket: 836142
 	}
 }
 

--- a/data/Scarlet & Violet/White Flare/127.ts
+++ b/data/Scarlet & Violet/White Flare/127.ts
@@ -63,7 +63,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	thirdParty: {
-		cardmarket: 835986
+		cardmarket: 836143
 	}
 }
 

--- a/data/Scarlet & Violet/White Flare/128.ts
+++ b/data/Scarlet & Violet/White Flare/128.ts
@@ -65,7 +65,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	thirdParty: {
-		cardmarket: 835987
+		cardmarket: 836145
 	}
 }
 

--- a/data/Scarlet & Violet/White Flare/129.ts
+++ b/data/Scarlet & Violet/White Flare/129.ts
@@ -65,7 +65,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	thirdParty: {
-		cardmarket: 835990
+		cardmarket: 836147
 	}
 }
 

--- a/data/Scarlet & Violet/White Flare/130.ts
+++ b/data/Scarlet & Violet/White Flare/130.ts
@@ -65,7 +65,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	thirdParty: {
-		cardmarket: 835991
+		cardmarket: 836149
 	}
 }
 

--- a/data/Scarlet & Violet/White Flare/131.ts
+++ b/data/Scarlet & Violet/White Flare/131.ts
@@ -51,7 +51,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	thirdParty: {
-		cardmarket: 835993
+		cardmarket: 836150
 	}
 }
 

--- a/data/Scarlet & Violet/White Flare/132.ts
+++ b/data/Scarlet & Violet/White Flare/132.ts
@@ -65,7 +65,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	thirdParty: {
-		cardmarket: 835995
+		cardmarket: 836152
 	}
 }
 

--- a/data/Scarlet & Violet/White Flare/133.ts
+++ b/data/Scarlet & Violet/White Flare/133.ts
@@ -41,7 +41,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	thirdParty: {
-		cardmarket: 835997
+		cardmarket: 836153
 	}
 }
 

--- a/data/Scarlet & Violet/White Flare/134.ts
+++ b/data/Scarlet & Violet/White Flare/134.ts
@@ -65,7 +65,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	thirdParty: {
-		cardmarket: 836000
+		cardmarket: 836155
 	}
 }
 

--- a/data/Scarlet & Violet/White Flare/135.ts
+++ b/data/Scarlet & Violet/White Flare/135.ts
@@ -65,7 +65,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	thirdParty: {
-		cardmarket: 836001
+		cardmarket: 836157
 	}
 }
 

--- a/data/Scarlet & Violet/White Flare/136.ts
+++ b/data/Scarlet & Violet/White Flare/136.ts
@@ -49,7 +49,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	thirdParty: {
-		cardmarket: 836002
+		cardmarket: 836158
 	}
 }
 

--- a/data/Scarlet & Violet/White Flare/137.ts
+++ b/data/Scarlet & Violet/White Flare/137.ts
@@ -51,7 +51,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	thirdParty: {
-		cardmarket: 836004
+		cardmarket: 836159
 	}
 }
 

--- a/data/Scarlet & Violet/White Flare/138.ts
+++ b/data/Scarlet & Violet/White Flare/138.ts
@@ -55,7 +55,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	thirdParty: {
-		cardmarket: 836006
+		cardmarket: 836161
 	}
 }
 

--- a/data/Scarlet & Violet/White Flare/139.ts
+++ b/data/Scarlet & Violet/White Flare/139.ts
@@ -51,7 +51,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	thirdParty: {
-		cardmarket: 836008
+		cardmarket: 836163
 	}
 }
 

--- a/data/Scarlet & Violet/White Flare/140.ts
+++ b/data/Scarlet & Violet/White Flare/140.ts
@@ -55,7 +55,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	thirdParty: {
-		cardmarket: 836010
+		cardmarket: 836164
 	}
 }
 

--- a/data/Scarlet & Violet/White Flare/141.ts
+++ b/data/Scarlet & Violet/White Flare/141.ts
@@ -65,7 +65,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	thirdParty: {
-		cardmarket: 836012
+		cardmarket: 836166
 	}
 }
 

--- a/data/Scarlet & Violet/White Flare/142.ts
+++ b/data/Scarlet & Violet/White Flare/142.ts
@@ -51,7 +51,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	thirdParty: {
-		cardmarket: 836014
+		cardmarket: 836168
 	}
 }
 

--- a/data/Scarlet & Violet/White Flare/143.ts
+++ b/data/Scarlet & Violet/White Flare/143.ts
@@ -73,7 +73,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	thirdParty: {
-		cardmarket: 836016
+		cardmarket: 836171
 	}
 }
 

--- a/data/Scarlet & Violet/White Flare/144.ts
+++ b/data/Scarlet & Violet/White Flare/144.ts
@@ -41,7 +41,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	thirdParty: {
-		cardmarket: 836019
+		cardmarket: 836173
 	}
 }
 

--- a/data/Scarlet & Violet/White Flare/145.ts
+++ b/data/Scarlet & Violet/White Flare/145.ts
@@ -65,7 +65,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	thirdParty: {
-		cardmarket: 836020
+		cardmarket: 836175
 	}
 }
 

--- a/data/Scarlet & Violet/White Flare/146.ts
+++ b/data/Scarlet & Violet/White Flare/146.ts
@@ -65,7 +65,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	thirdParty: {
-		cardmarket: 836022
+		cardmarket: 836178
 	}
 }
 

--- a/data/Scarlet & Violet/White Flare/147.ts
+++ b/data/Scarlet & Violet/White Flare/147.ts
@@ -65,7 +65,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	thirdParty: {
-		cardmarket: 836025
+		cardmarket: 836179
 	}
 }
 

--- a/data/Scarlet & Violet/White Flare/148.ts
+++ b/data/Scarlet & Violet/White Flare/148.ts
@@ -55,7 +55,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	thirdParty: {
-		cardmarket: 836028
+		cardmarket: 836180
 	}
 }
 

--- a/data/Scarlet & Violet/White Flare/149.ts
+++ b/data/Scarlet & Violet/White Flare/149.ts
@@ -63,7 +63,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	thirdParty: {
-		cardmarket: 836029
+		cardmarket: 836182
 	}
 }
 

--- a/data/Scarlet & Violet/White Flare/150.ts
+++ b/data/Scarlet & Violet/White Flare/150.ts
@@ -65,7 +65,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	thirdParty: {
-		cardmarket: 836030
+		cardmarket: 836184
 	}
 }
 

--- a/data/Scarlet & Violet/White Flare/151.ts
+++ b/data/Scarlet & Violet/White Flare/151.ts
@@ -75,7 +75,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	thirdParty: {
-		cardmarket: 836031
+		cardmarket: 836185
 	}
 }
 

--- a/data/Scarlet & Violet/White Flare/152.ts
+++ b/data/Scarlet & Violet/White Flare/152.ts
@@ -63,7 +63,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	thirdParty: {
-		cardmarket: 836032
+		cardmarket: 836186
 	}
 }
 

--- a/data/Scarlet & Violet/White Flare/153.ts
+++ b/data/Scarlet & Violet/White Flare/153.ts
@@ -73,7 +73,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	thirdParty: {
-		cardmarket: 836034
+		cardmarket: 836188
 	}
 }
 

--- a/data/Scarlet & Violet/White Flare/154.ts
+++ b/data/Scarlet & Violet/White Flare/154.ts
@@ -51,7 +51,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	thirdParty: {
-		cardmarket: 836036
+		cardmarket: 836189
 	}
 }
 

--- a/data/Scarlet & Violet/White Flare/155.ts
+++ b/data/Scarlet & Violet/White Flare/155.ts
@@ -63,7 +63,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	thirdParty: {
-		cardmarket: 836038
+		cardmarket: 836191
 	}
 }
 

--- a/data/Scarlet & Violet/White Flare/156.ts
+++ b/data/Scarlet & Violet/White Flare/156.ts
@@ -73,7 +73,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	thirdParty: {
-		cardmarket: 836040
+		cardmarket: 836194
 	}
 }
 

--- a/data/Scarlet & Violet/White Flare/157.ts
+++ b/data/Scarlet & Violet/White Flare/157.ts
@@ -73,7 +73,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	thirdParty: {
-		cardmarket: 835909
+		cardmarket: 836195
 	}
 }
 

--- a/data/Scarlet & Violet/White Flare/158.ts
+++ b/data/Scarlet & Violet/White Flare/158.ts
@@ -65,7 +65,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	thirdParty: {
-		cardmarket: 835938
+		cardmarket: 836196
 	}
 }
 

--- a/data/Scarlet & Violet/White Flare/159.ts
+++ b/data/Scarlet & Violet/White Flare/159.ts
@@ -75,7 +75,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	thirdParty: {
-		cardmarket: 835962
+		cardmarket: 836198
 	}
 }
 

--- a/data/Scarlet & Violet/White Flare/160.ts
+++ b/data/Scarlet & Violet/White Flare/160.ts
@@ -75,7 +75,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	thirdParty: {
-		cardmarket: 835984
+		cardmarket: 836200
 	}
 }
 

--- a/data/Scarlet & Violet/White Flare/161.ts
+++ b/data/Scarlet & Violet/White Flare/161.ts
@@ -75,7 +75,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	thirdParty: {
-		cardmarket: 836027
+		cardmarket: 836201
 	}
 }
 

--- a/data/Scarlet & Violet/White Flare/162.ts
+++ b/data/Scarlet & Violet/White Flare/162.ts
@@ -75,7 +75,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	thirdParty: {
-		cardmarket: 836042
+		cardmarket: 836202
 	}
 }
 

--- a/data/Scarlet & Violet/White Flare/163.ts
+++ b/data/Scarlet & Violet/White Flare/163.ts
@@ -31,7 +31,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	thirdParty: {
-		cardmarket: 836057
+		cardmarket: 836203
 	}
 }
 

--- a/data/Scarlet & Violet/White Flare/164.ts
+++ b/data/Scarlet & Violet/White Flare/164.ts
@@ -31,7 +31,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	thirdParty: {
-		cardmarket: 836059
+		cardmarket: 836204
 	}
 }
 

--- a/data/Scarlet & Violet/White Flare/165.ts
+++ b/data/Scarlet & Violet/White Flare/165.ts
@@ -73,7 +73,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	thirdParty: {
-		cardmarket: 835909
+		cardmarket: 836207
 	}
 }
 

--- a/data/Scarlet & Violet/White Flare/166.ts
+++ b/data/Scarlet & Violet/White Flare/166.ts
@@ -65,7 +65,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	thirdParty: {
-		cardmarket: 835938
+		cardmarket: 836209
 	}
 }
 

--- a/data/Scarlet & Violet/White Flare/167.ts
+++ b/data/Scarlet & Violet/White Flare/167.ts
@@ -75,7 +75,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	thirdParty: {
-		cardmarket: 835962
+		cardmarket: 836211
 	}
 }
 

--- a/data/Scarlet & Violet/White Flare/168.ts
+++ b/data/Scarlet & Violet/White Flare/168.ts
@@ -75,7 +75,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	thirdParty: {
-		cardmarket: 835984
+		cardmarket: 836214
 	}
 }
 

--- a/data/Scarlet & Violet/White Flare/169.ts
+++ b/data/Scarlet & Violet/White Flare/169.ts
@@ -75,7 +75,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	thirdParty: {
-		cardmarket: 836027
+		cardmarket: 836216
 	}
 }
 

--- a/data/Scarlet & Violet/White Flare/170.ts
+++ b/data/Scarlet & Violet/White Flare/170.ts
@@ -75,7 +75,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	thirdParty: {
-		cardmarket: 836042
+		cardmarket: 836218
 	}
 }
 

--- a/data/Scarlet & Violet/White Flare/171.ts
+++ b/data/Scarlet & Violet/White Flare/171.ts
@@ -31,7 +31,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	thirdParty: {
-		cardmarket: 836059
+		cardmarket: 836220
 	}
 }
 

--- a/data/Scarlet & Violet/White Flare/173.ts
+++ b/data/Scarlet & Violet/White Flare/173.ts
@@ -65,7 +65,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	thirdParty: {
-		cardmarket: 835938
+		cardmarket: 836227
 	}
 }
 


### PR DESCRIPTION
Updated the 'cardmarket' thirdParty IDs for cards 033–171 in the Scarlet & Violet/White Flare

<!--
Thanks for your Pull Request, Please provide the related Issue using "Fix #0" or describe the change(s) you made.
The issue title must follow Conventional Commit conventionalcommits.org.
More informations at https://github.com/tcgdex/cards-database/blob/master/CONTRIBUTING.md
-->
