### PR TITLE
Fix:Update Cardmarket IDs for Temporal Forces 

### DIFF
--- a/data/Scarlet & Violet/Temporal Forces/080.ts
+++ b/data/Scarlet & Violet/Temporal Forces/080.ts
@@ -74,7 +74,7 @@ const card: Card = {
 	illustrator: "chibi",
 
 	thirdParty: {
-		cardmarket: 760709
+		cardmarket: 760710
 	}
 }
 

--- a/data/Scarlet & Violet/Temporal Forces/097.ts
+++ b/data/Scarlet & Violet/Temporal Forces/097.ts
@@ -65,7 +65,7 @@ const card: Card = {
 	illustrator: "GIDORA",
 
 	thirdParty: {
-		cardmarket: 760726
+		cardmarket: 760727
 	}
 }
 

--- a/data/Scarlet & Violet/Temporal Forces/163.ts
+++ b/data/Scarlet & Violet/Temporal Forces/163.ts
@@ -75,7 +75,7 @@ const card: Card = {
 	illustrator: "SIE NANAHARA",
 
 	thirdParty: {
-		cardmarket: 760635
+		cardmarket: 760793
 	}
 }
 

--- a/data/Scarlet & Violet/Temporal Forces/164.ts
+++ b/data/Scarlet & Violet/Temporal Forces/164.ts
@@ -68,7 +68,7 @@ const card: Card = {
 	illustrator: "Oswaldo KATO",
 
 	thirdParty: {
-		cardmarket: 760641
+		cardmarket: 760794
 	}
 }
 

--- a/data/Scarlet & Violet/Temporal Forces/165.ts
+++ b/data/Scarlet & Violet/Temporal Forces/165.ts
@@ -68,7 +68,7 @@ const card: Card = {
 	illustrator: "Susumu Maeya",
 
 	thirdParty: {
-		cardmarket: 760646
+		cardmarket: 760795
 	}
 }
 

--- a/data/Scarlet & Violet/Temporal Forces/166.ts
+++ b/data/Scarlet & Violet/Temporal Forces/166.ts
@@ -68,7 +68,7 @@ const card: Card = {
 	illustrator: "Susumu Maeya",
 
 	thirdParty: {
-		cardmarket: 760647
+		cardmarket: 760796
 	}
 }
 

--- a/data/Scarlet & Violet/Temporal Forces/167.ts
+++ b/data/Scarlet & Violet/Temporal Forces/167.ts
@@ -55,7 +55,7 @@ const card: Card = {
 	illustrator: "Makura Tami",
 
 	thirdParty: {
-		cardmarket: 760662
+		cardmarket: 760797
 	}
 }
 

--- a/data/Scarlet & Violet/Temporal Forces/168.ts
+++ b/data/Scarlet & Violet/Temporal Forces/168.ts
@@ -55,7 +55,7 @@ const card: Card = {
 	illustrator: "N-DESIGN Inc.",
 
 	thirdParty: {
-		cardmarket: 760675
+		cardmarket: 760798
 	}
 }
 

--- a/data/Scarlet & Violet/Temporal Forces/169.ts
+++ b/data/Scarlet & Violet/Temporal Forces/169.ts
@@ -46,7 +46,7 @@ const card: Card = {
 	illustrator: "Mina Nakai",
 
 	thirdParty: {
-		cardmarket: 760685
+		cardmarket: 760799
 	}
 }
 

--- a/data/Scarlet & Violet/Temporal Forces/170.ts
+++ b/data/Scarlet & Violet/Temporal Forces/170.ts
@@ -55,7 +55,7 @@ const card: Card = {
 	illustrator: "sowsow",
 
 	thirdParty: {
-		cardmarket: 760698
+		cardmarket: 760800
 	}
 }
 

--- a/data/Scarlet & Violet/Temporal Forces/171.ts
+++ b/data/Scarlet & Violet/Temporal Forces/171.ts
@@ -75,7 +75,7 @@ const card: Card = {
 	illustrator: "Atsushi Furusawa",
 
 	thirdParty: {
-		cardmarket: 760702
+		cardmarket: 760801
 	}
 }
 

--- a/data/Scarlet & Violet/Temporal Forces/172.ts
+++ b/data/Scarlet & Violet/Temporal Forces/172.ts
@@ -55,7 +55,7 @@ const card: Card = {
 	illustrator: "REND",
 
 	thirdParty: {
-		cardmarket: 760705
+		cardmarket: 760802
 	}
 }
 

--- a/data/Scarlet & Violet/Temporal Forces/173.ts
+++ b/data/Scarlet & Violet/Temporal Forces/173.ts
@@ -68,7 +68,7 @@ const card: Card = {
 	illustrator: "Mitsuhiro Arita",
 
 	thirdParty: {
-		cardmarket: 760714
+		cardmarket: 760803
 	}
 }
 

--- a/data/Scarlet & Violet/Temporal Forces/174.ts
+++ b/data/Scarlet & Violet/Temporal Forces/174.ts
@@ -68,7 +68,7 @@ const card: Card = {
 	illustrator: "Saboteri",
 
 	thirdParty: {
-		cardmarket: 760716
+		cardmarket: 760804
 	}
 }
 

--- a/data/Scarlet & Violet/Temporal Forces/175.ts
+++ b/data/Scarlet & Violet/Temporal Forces/175.ts
@@ -75,7 +75,7 @@ const card: Card = {
 	illustrator: "MINAMINAMI Take",
 
 	thirdParty: {
-		cardmarket: 760722
+		cardmarket: 760805
 	}
 }
 

--- a/data/Scarlet & Violet/Temporal Forces/176.ts
+++ b/data/Scarlet & Violet/Temporal Forces/176.ts
@@ -66,7 +66,7 @@ const card: Card = {
 	illustrator: "OKUBO",
 
 	thirdParty: {
-		cardmarket: 760731
+		cardmarket: 760806
 	}
 }
 

--- a/data/Scarlet & Violet/Temporal Forces/177.ts
+++ b/data/Scarlet & Violet/Temporal Forces/177.ts
@@ -66,7 +66,7 @@ const card: Card = {
 	illustrator: "Mousho",
 
 	thirdParty: {
-		cardmarket: 760732
+		cardmarket: 760807
 	}
 }
 

--- a/data/Scarlet & Violet/Temporal Forces/178.ts
+++ b/data/Scarlet & Violet/Temporal Forces/178.ts
@@ -77,7 +77,7 @@ const card: Card = {
 	illustrator: "Katsunori Sato",
 
 	thirdParty: {
-		cardmarket: 760745
+		cardmarket: 760808
 	}
 }
 

--- a/data/Scarlet & Violet/Temporal Forces/179.ts
+++ b/data/Scarlet & Violet/Temporal Forces/179.ts
@@ -46,7 +46,7 @@ const card: Card = {
 	illustrator: "Masa",
 
 	thirdParty: {
-		cardmarket: 760746
+		cardmarket: 760809
 	}
 }
 

--- a/data/Scarlet & Violet/Temporal Forces/180.ts
+++ b/data/Scarlet & Violet/Temporal Forces/180.ts
@@ -66,7 +66,7 @@ const card: Card = {
 	illustrator: "Orca",
 
 	thirdParty: {
-		cardmarket: 760754
+		cardmarket: 760810
 	}
 }
 

--- a/data/Scarlet & Violet/Temporal Forces/181.ts
+++ b/data/Scarlet & Violet/Temporal Forces/181.ts
@@ -66,7 +66,7 @@ const card: Card = {
 	illustrator: "Scav",
 
 	thirdParty: {
-		cardmarket: 760762
+		cardmarket: 760811
 	}
 }
 

--- a/data/Scarlet & Violet/Temporal Forces/182.ts
+++ b/data/Scarlet & Violet/Temporal Forces/182.ts
@@ -66,7 +66,7 @@ const card: Card = {
 	illustrator: "Shibuzoh.",
 
 	thirdParty: {
-		cardmarket: 760766
+		cardmarket: 760812
 	}
 }
 

--- a/data/Scarlet & Violet/Temporal Forces/183.ts
+++ b/data/Scarlet & Violet/Temporal Forces/183.ts
@@ -68,7 +68,7 @@ const card: Card = {
 	illustrator: "Shibuzoh.",
 
 	thirdParty: {
-		cardmarket: 760767
+		cardmarket: 760813
 	}
 }
 

--- a/data/Scarlet & Violet/Temporal Forces/184.ts
+++ b/data/Scarlet & Violet/Temporal Forces/184.ts
@@ -68,7 +68,7 @@ const card: Card = {
 	illustrator: "Mékayu",
 
 	thirdParty: {
-		cardmarket: 760768
+		cardmarket: 760814
 	}
 }
 

--- a/data/Scarlet & Violet/Temporal Forces/185.ts
+++ b/data/Scarlet & Violet/Temporal Forces/185.ts
@@ -77,7 +77,7 @@ const card: Card = {
 	illustrator: "PLANETA Tsuji",
 
 	thirdParty: {
-		cardmarket: 760642
+		cardmarket: 760815
 	}
 }
 

--- a/data/Scarlet & Violet/Temporal Forces/186.ts
+++ b/data/Scarlet & Violet/Temporal Forces/186.ts
@@ -77,7 +77,7 @@ const card: Card = {
 	illustrator: "5ban Graphics",
 
 	thirdParty: {
-		cardmarket: 760655
+		cardmarket: 760816
 	}
 }
 

--- a/data/Scarlet & Violet/Temporal Forces/187.ts
+++ b/data/Scarlet & Violet/Temporal Forces/187.ts
@@ -77,7 +77,7 @@ const card: Card = {
 	illustrator: "N-DESIGN Inc.",
 
 	thirdParty: {
-		cardmarket: 760664
+		cardmarket: 760817
 	}
 }
 

--- a/data/Scarlet & Violet/Temporal Forces/188.ts
+++ b/data/Scarlet & Violet/Temporal Forces/188.ts
@@ -68,7 +68,7 @@ const card: Card = {
 	illustrator: "5ban Graphics",
 
 	thirdParty: {
-		cardmarket: 760668
+		cardmarket: 760818
 	}
 }
 

--- a/data/Scarlet & Violet/Temporal Forces/189.ts
+++ b/data/Scarlet & Violet/Temporal Forces/189.ts
@@ -77,7 +77,7 @@ const card: Card = {
 	illustrator: "takuyoa",
 
 	thirdParty: {
-		cardmarket: 760680
+		cardmarket: 760819
 	}
 }
 

--- a/data/Scarlet & Violet/Temporal Forces/190.ts
+++ b/data/Scarlet & Violet/Temporal Forces/190.ts
@@ -75,7 +75,7 @@ const card: Card = {
 	illustrator: "5ban Graphics",
 
 	thirdParty: {
-		cardmarket: 760690
+		cardmarket: 760820
 	}
 }
 

--- a/data/Scarlet & Violet/Temporal Forces/191.ts
+++ b/data/Scarlet & Violet/Temporal Forces/191.ts
@@ -75,7 +75,7 @@ const card: Card = {
 	illustrator: "5ban Graphics",
 
 	thirdParty: {
-		cardmarket: 760711
+		cardmarket: 760821
 	}
 }
 

--- a/data/Scarlet & Violet/Temporal Forces/192.ts
+++ b/data/Scarlet & Violet/Temporal Forces/192.ts
@@ -77,7 +77,7 @@ const card: Card = {
 	illustrator: "5ban Graphics",
 
 	thirdParty: {
-		cardmarket: 760729
+		cardmarket: 760822
 	}
 }
 

--- a/data/Scarlet & Violet/Temporal Forces/193.ts
+++ b/data/Scarlet & Violet/Temporal Forces/193.ts
@@ -77,7 +77,7 @@ const card: Card = {
 	illustrator: "Satoshi Shirai",
 
 	thirdParty: {
-		cardmarket: 760734
+		cardmarket: 760823
 	}
 }
 

--- a/data/Scarlet & Violet/Temporal Forces/194.ts
+++ b/data/Scarlet & Violet/Temporal Forces/194.ts
@@ -77,7 +77,7 @@ const card: Card = {
 	illustrator: "5ban Graphics",
 
 	thirdParty: {
-		cardmarket: 760738
+		cardmarket: 760824
 	}
 }
 

--- a/data/Scarlet & Violet/Temporal Forces/195.ts
+++ b/data/Scarlet & Violet/Temporal Forces/195.ts
@@ -77,7 +77,7 @@ const card: Card = {
 	illustrator: "Eske Yoshinob",
 
 	thirdParty: {
-		cardmarket: 760741
+		cardmarket: 760825
 	}
 }
 

--- a/data/Scarlet & Violet/Temporal Forces/196.ts
+++ b/data/Scarlet & Violet/Temporal Forces/196.ts
@@ -75,7 +75,7 @@ const card: Card = {
 	illustrator: "aky CG Works",
 
 	thirdParty: {
-		cardmarket: 760753
+		cardmarket: 760826
 	}
 }
 

--- a/data/Scarlet & Violet/Temporal Forces/197.ts
+++ b/data/Scarlet & Violet/Temporal Forces/197.ts
@@ -36,7 +36,7 @@ const card: Card = {
 	illustrator: "En Morikura",
 
 	thirdParty: {
-		cardmarket: 760772
+		cardmarket: 760827
 	}
 }
 

--- a/data/Scarlet & Violet/Temporal Forces/198.ts
+++ b/data/Scarlet & Violet/Temporal Forces/198.ts
@@ -36,7 +36,7 @@ const card: Card = {
 	illustrator: "Taira Akitsu",
 
 	thirdParty: {
-		cardmarket: 760775
+		cardmarket: 760828
 	}
 }
 

--- a/data/Scarlet & Violet/Temporal Forces/199.ts
+++ b/data/Scarlet & Violet/Temporal Forces/199.ts
@@ -36,7 +36,7 @@ const card: Card = {
 	illustrator: "GOSSAN",
 
 	thirdParty: {
-		cardmarket: 760776
+		cardmarket: 760829
 	}
 }
 

--- a/data/Scarlet & Violet/Temporal Forces/200.ts
+++ b/data/Scarlet & Violet/Temporal Forces/200.ts
@@ -36,7 +36,7 @@ const card: Card = {
 	illustrator: "Hideki Ishikawa",
 
 	thirdParty: {
-		cardmarket: 760777
+		cardmarket: 760830
 	}
 }
 

--- a/data/Scarlet & Violet/Temporal Forces/201.ts
+++ b/data/Scarlet & Violet/Temporal Forces/201.ts
@@ -36,7 +36,7 @@ const card: Card = {
 	illustrator: "GIDORA",
 
 	thirdParty: {
-		cardmarket: 760785
+		cardmarket: 760831
 	}
 }
 

--- a/data/Scarlet & Violet/Temporal Forces/202.ts
+++ b/data/Scarlet & Violet/Temporal Forces/202.ts
@@ -36,7 +36,7 @@ const card: Card = {
 	illustrator: "Ryuta Fuse",
 
 	thirdParty: {
-		cardmarket: 760790
+		cardmarket: 760832
 	}
 }
 

--- a/data/Scarlet & Violet/Temporal Forces/203.ts
+++ b/data/Scarlet & Violet/Temporal Forces/203.ts
@@ -77,7 +77,7 @@ const card: Card = {
 	illustrator: "nagimiso",
 
 	thirdParty: {
-		cardmarket: 760655
+		cardmarket: 760833
 	}
 }
 

--- a/data/Scarlet & Violet/Temporal Forces/204.ts
+++ b/data/Scarlet & Violet/Temporal Forces/204.ts
@@ -68,7 +68,7 @@ const card: Card = {
 	illustrator: "Teeziro",
 
 	thirdParty: {
-		cardmarket: 760668
+		cardmarket: 760834
 	}
 }
 

--- a/data/Scarlet & Violet/Temporal Forces/205.ts
+++ b/data/Scarlet & Violet/Temporal Forces/205.ts
@@ -77,7 +77,7 @@ const card: Card = {
 	illustrator: "Teeziro",
 
 	thirdParty: {
-		cardmarket: 760680
+		cardmarket: 760835
 	}
 }
 

--- a/data/Scarlet & Violet/Temporal Forces/206.ts
+++ b/data/Scarlet & Violet/Temporal Forces/206.ts
@@ -75,7 +75,7 @@ const card: Card = {
 	illustrator: "nagimiso",
 
 	thirdParty: {
-		cardmarket: 760711
+		cardmarket: 760836
 	}
 }
 

--- a/data/Scarlet & Violet/Temporal Forces/207.ts
+++ b/data/Scarlet & Violet/Temporal Forces/207.ts
@@ -77,7 +77,7 @@ const card: Card = {
 	illustrator: "nagimiso",
 
 	thirdParty: {
-		cardmarket: 760729
+		cardmarket: 760837
 	}
 }
 

--- a/data/Scarlet & Violet/Temporal Forces/208.ts
+++ b/data/Scarlet & Violet/Temporal Forces/208.ts
@@ -75,7 +75,7 @@ const card: Card = {
 	illustrator: "Teeziro",
 
 	thirdParty: {
-		cardmarket: 760753
+		cardmarket: 760838
 	}
 }
 

--- a/data/Scarlet & Violet/Temporal Forces/209.ts
+++ b/data/Scarlet & Violet/Temporal Forces/209.ts
@@ -36,7 +36,7 @@ const card: Card = {
 	illustrator: "Cona Nitanda",
 
 	thirdParty: {
-		cardmarket: 760772
+		cardmarket: 760839
 	}
 }
 

--- a/data/Scarlet & Violet/Temporal Forces/210.ts
+++ b/data/Scarlet & Violet/Temporal Forces/210.ts
@@ -36,7 +36,7 @@ const card: Card = {
 	illustrator: "DOM",
 
 	thirdParty: {
-		cardmarket: 760776
+		cardmarket: 760840
 	}
 }
 

--- a/data/Scarlet & Violet/Temporal Forces/211.ts
+++ b/data/Scarlet & Violet/Temporal Forces/211.ts
@@ -36,7 +36,7 @@ const card: Card = {
 	illustrator: "Megumi Mizutani",
 
 	thirdParty: {
-		cardmarket: 760785
+		cardmarket: 760841
 	}
 }
 

--- a/data/Scarlet & Violet/Temporal Forces/212.ts
+++ b/data/Scarlet & Violet/Temporal Forces/212.ts
@@ -36,7 +36,7 @@ const card: Card = {
 	illustrator: "Tetsu Kayama",
 
 	thirdParty: {
-		cardmarket: 760790
+		cardmarket: 760842
 	}
 }
 

--- a/data/Scarlet & Violet/Temporal Forces/213.ts
+++ b/data/Scarlet & Violet/Temporal Forces/213.ts
@@ -77,7 +77,7 @@ const card: Card = {
 	illustrator: "5ban Graphics",
 
 	thirdParty: {
-		cardmarket: 760655
+		cardmarket: 760843
 	}
 }
 

--- a/data/Scarlet & Violet/Temporal Forces/214.ts
+++ b/data/Scarlet & Violet/Temporal Forces/214.ts
@@ -68,7 +68,7 @@ const card: Card = {
 	illustrator: "5ban Graphics",
 
 	thirdParty: {
-		cardmarket: 760668
+		cardmarket: 760844
 	}
 }
 

--- a/data/Scarlet & Violet/Temporal Forces/215.ts
+++ b/data/Scarlet & Violet/Temporal Forces/215.ts
@@ -77,7 +77,7 @@ const card: Card = {
 	illustrator: "takuyoa",
 
 	thirdParty: {
-		cardmarket: 760680
+		cardmarket: 760845
 	}
 }
 

--- a/data/Scarlet & Violet/Temporal Forces/216.ts
+++ b/data/Scarlet & Violet/Temporal Forces/216.ts
@@ -75,7 +75,7 @@ const card: Card = {
 	illustrator: "5ban Graphics",
 
 	thirdParty: {
-		cardmarket: 760711
+		cardmarket: 760846
 	}
 }
 

--- a/data/Scarlet & Violet/Temporal Forces/217.ts
+++ b/data/Scarlet & Violet/Temporal Forces/217.ts
@@ -77,7 +77,7 @@ const card: Card = {
 	illustrator: "5ban Graphics",
 
 	thirdParty: {
-		cardmarket: 760729
+		cardmarket: 760847
 	}
 }
 

--- a/data/Scarlet & Violet/Temporal Forces/218.ts
+++ b/data/Scarlet & Violet/Temporal Forces/218.ts
@@ -75,7 +75,7 @@ const card: Card = {
 	illustrator: "aky CG Works",
 
 	thirdParty: {
-		cardmarket: 760753
+		cardmarket: 760848
 	}
 }
 


### PR DESCRIPTION
Corrected the 'cardmarket' thirdParty IDs for cards 080 and 097 through 218 in the Scarlet & Violet/Temporal Forces set to reflect updated values.


