### PR TITLE
Fix:Update Cardmarket IDs for Obsidian Flames cards

### DIFF
--- a/data/Scarlet & Violet/Obsidian Flames/024.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/024.ts
@@ -54,7 +54,7 @@ const card: Card = {
 	illustrator: "Pani Kobayashi",
 
 	thirdParty: {
-		cardmarket: 725103
+		cardmarket: 725104
 	}
 }
 

--- a/data/Scarlet & Violet/Obsidian Flames/061.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/061.ts
@@ -45,7 +45,7 @@ const card: Card = {
 	illustrator: "Kouki Saitou",
 
 	thirdParty: {
-		cardmarket: 725140
+		cardmarket: 725141
 	}
 }
 

--- a/data/Scarlet & Violet/Obsidian Flames/075.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/075.ts
@@ -54,7 +54,7 @@ const card: Card = {
 	illustrator: "Saya Tsuruta",
 
 	thirdParty: {
-		cardmarket: 725154
+		cardmarket: 725155
 	}
 }
 

--- a/data/Scarlet & Violet/Obsidian Flames/076.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/076.ts
@@ -54,7 +54,7 @@ const card: Card = {
 	illustrator: "Shin Nagasawa",
 
 	thirdParty: {
-		cardmarket: 725154
+		cardmarket: 725156
 	}
 }
 

--- a/data/Scarlet & Violet/Obsidian Flames/078.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/078.ts
@@ -76,7 +76,7 @@ const card: Card = {
 	illustrator: "Toshinao Aoki",
 
 	thirdParty: {
-		cardmarket: 725157
+		cardmarket: 725158
 	}
 }
 

--- a/data/Scarlet & Violet/Obsidian Flames/100.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/100.ts
@@ -56,7 +56,7 @@ const card: Card = {
 	illustrator: "Pani Kobayashi",
 
 	thirdParty: {
-		cardmarket: 725179
+		cardmarket: 791826
 	}
 };
 

--- a/data/Scarlet & Violet/Obsidian Flames/119.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/119.ts
@@ -67,7 +67,7 @@ const card: Card = {
 	illustrator: "Kouki Saitou",
 
 	thirdParty: {
-		cardmarket: 725102
+		cardmarket: 725199
 	}
 }
 

--- a/data/Scarlet & Violet/Obsidian Flames/122.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/122.ts
@@ -54,7 +54,7 @@ const card: Card = {
 	illustrator: "GIDORA",
 
 	thirdParty: {
-		cardmarket: 725201
+		cardmarket: 725202
 	}
 }
 

--- a/data/Scarlet & Violet/Obsidian Flames/127.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/127.ts
@@ -45,7 +45,7 @@ const card: Card = {
 	illustrator: "Pani Kobayashi",
 
 	thirdParty: {
-		cardmarket: 725206
+		cardmarket: 725207
 	}
 }
 

--- a/data/Scarlet & Violet/Obsidian Flames/129.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/129.ts
@@ -74,7 +74,7 @@ const card: Card = {
 	illustrator: "Shin Nagasawa",
 
 	thirdParty: {
-		cardmarket: 725208
+		cardmarket: 725209
 	}
 }
 

--- a/data/Scarlet & Violet/Obsidian Flames/132.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/132.ts
@@ -58,7 +58,7 @@ const card: Card = {
 	illustrator: "Kurata So",
 
 	thirdParty: {
-		cardmarket: 725211
+		cardmarket: 725212
 	}
 }
 

--- a/data/Scarlet & Violet/Obsidian Flames/143.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/143.ts
@@ -67,7 +67,7 @@ const card: Card = {
 	illustrator: "sowsow",
 
 	thirdParty: {
-		cardmarket: 725169
+		cardmarket: 725223
 	}
 }
 

--- a/data/Scarlet & Violet/Obsidian Flames/148.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/148.ts
@@ -56,7 +56,7 @@ const card: Card = {
 	illustrator: "Hitoshi Ariga",
 
 	thirdParty: {
-		cardmarket: 725228
+		cardmarket: 781859
 	}
 }
 

--- a/data/Scarlet & Violet/Obsidian Flames/149.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/149.ts
@@ -69,7 +69,7 @@ const card: Card = {
 	illustrator: "GIDORA",
 
 	thirdParty: {
-		cardmarket: 725229
+		cardmarket: 781860
 	}
 }
 

--- a/data/Scarlet & Violet/Obsidian Flames/155.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/155.ts
@@ -45,7 +45,7 @@ const card: Card = {
 	illustrator: "Saya Tsuruta",
 
 	thirdParty: {
-		cardmarket: 725234
+		cardmarket: 725235
 	}
 }
 

--- a/data/Scarlet & Violet/Obsidian Flames/181.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/181.ts
@@ -54,7 +54,7 @@ const card: Card = {
 	illustrator: "Tomokazu Komiya",
 
 	thirdParty: {
-		cardmarket: 725260
+		cardmarket: 725261
 	}
 }
 

--- a/data/Scarlet & Violet/Obsidian Flames/182.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/182.ts
@@ -58,7 +58,7 @@ const card: Card = {
 	illustrator: "Atsuko Nishida",
 
 	thirdParty: {
-		cardmarket: 725260
+		cardmarket: 725262
 	}
 }
 

--- a/data/Scarlet & Violet/Obsidian Flames/184.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/184.ts
@@ -74,7 +74,7 @@ const card: Card = {
 	illustrator: "Akira Komayama",
 
 	thirdParty: {
-		cardmarket: 725263
+		cardmarket: 725264
 	}
 }
 

--- a/data/Scarlet & Violet/Obsidian Flames/198.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/198.ts
@@ -66,7 +66,7 @@ const card: Card = {
 	illustrator: "Masako Tomii",
 
 	thirdParty: {
-		cardmarket: 725082
+		cardmarket: 725278
 	}
 }
 

--- a/data/Scarlet & Violet/Obsidian Flames/199.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/199.ts
@@ -66,7 +66,7 @@ const card: Card = {
 	illustrator: "SIE NANAHARA",
 
 	thirdParty: {
-		cardmarket: 725109
+		cardmarket: 725279
 	}
 }
 

--- a/data/Scarlet & Violet/Obsidian Flames/200.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/200.ts
@@ -77,7 +77,7 @@ const card: Card = {
 	illustrator: "Akira Komayama",
 
 	thirdParty: {
-		cardmarket: 725142
+		cardmarket: 725280
 	}
 }
 

--- a/data/Scarlet & Violet/Obsidian Flames/201.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/201.ts
@@ -77,7 +77,7 @@ const card: Card = {
 	illustrator: "KEIICHIRO ITO",
 
 	thirdParty: {
-		cardmarket: 725157
+		cardmarket: 725281
 	}
 }
 

--- a/data/Scarlet & Violet/Obsidian Flames/202.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/202.ts
@@ -51,7 +51,7 @@ const card: Card = {
 	illustrator: "HYOGONOSUKE",
 
 	thirdParty: {
-		cardmarket: 725160
+		cardmarket: 725282
 	}
 }
 

--- a/data/Scarlet & Violet/Obsidian Flames/203.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/203.ts
@@ -59,7 +59,7 @@ const card: Card = {
 	illustrator: "Miki Tanaka",
 
 	thirdParty: {
-		cardmarket: 725185
+		cardmarket: 725283
 	}
 }
 

--- a/data/Scarlet & Violet/Obsidian Flames/204.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/204.ts
@@ -75,7 +75,7 @@ const card: Card = {
 	illustrator: "KYUPIYAMA",
 
 	thirdParty: {
-		cardmarket: 725211
+		cardmarket: 725284
 	}
 }
 

--- a/data/Scarlet & Violet/Obsidian Flames/205.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/205.ts
@@ -68,7 +68,7 @@ const card: Card = {
 	illustrator: "Oku",
 
 	thirdParty: {
-		cardmarket: 725221
+		cardmarket: 725285
 	}
 }
 

--- a/data/Scarlet & Violet/Obsidian Flames/206.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/206.ts
@@ -55,7 +55,7 @@ const card: Card = {
 	illustrator: "Souichirou Gunjima",
 
 	thirdParty: {
-		cardmarket: 725234
+		cardmarket: 725286
 	}
 }
 

--- a/data/Scarlet & Violet/Obsidian Flames/207.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/207.ts
@@ -46,7 +46,7 @@ const card: Card = {
 	illustrator: "Jerky",
 
 	thirdParty: {
-		cardmarket: 725242
+		cardmarket: 725287
 	}
 }
 

--- a/data/Scarlet & Violet/Obsidian Flames/208.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/208.ts
@@ -46,7 +46,7 @@ const card: Card = {
 	illustrator: "Jerky",
 
 	thirdParty: {
-		cardmarket: 725243
+		cardmarket: 725288
 	}
 }
 

--- a/data/Scarlet & Violet/Obsidian Flames/209.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/209.ts
@@ -46,7 +46,7 @@ const card: Card = {
 	illustrator: "Narumi Sato",
 
 	thirdParty: {
-		cardmarket: 725260
+		cardmarket: 725289
 	}
 }
 

--- a/data/Scarlet & Violet/Obsidian Flames/210.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/210.ts
@@ -55,7 +55,7 @@ const card: Card = {
 	illustrator: "5ban Graphics",
 
 	thirdParty: {
-		cardmarket: 725122
+		cardmarket: 725290
 	}
 }
 

--- a/data/Scarlet & Violet/Obsidian Flames/211.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/211.ts
@@ -77,7 +77,7 @@ const card: Card = {
 	illustrator: "5ban Graphics",
 
 	thirdParty: {
-		cardmarket: 725146
+		cardmarket: 725291
 	}
 }
 

--- a/data/Scarlet & Violet/Obsidian Flames/212.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/212.ts
@@ -75,7 +75,7 @@ const card: Card = {
 	illustrator: "5ban Graphics",
 
 	thirdParty: {
-		cardmarket: 725176
+		cardmarket: 725292
 	}
 }
 

--- a/data/Scarlet & Violet/Obsidian Flames/213.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/213.ts
@@ -77,7 +77,7 @@ const card: Card = {
 	illustrator: "5ban Graphics",
 
 	thirdParty: {
-		cardmarket: 725203
+		cardmarket: 725293
 	}
 }
 

--- a/data/Scarlet & Violet/Obsidian Flames/214.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/214.ts
@@ -75,7 +75,7 @@ const card: Card = {
 	illustrator: "PLANETA Mochizuki",
 
 	thirdParty: {
-		cardmarket: 725215
+		cardmarket: 725294
 	}
 }
 

--- a/data/Scarlet & Violet/Obsidian Flames/215.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/215.ts
@@ -77,7 +77,7 @@ const card: Card = {
 	illustrator: "5ban Graphics",
 
 	thirdParty: {
-		cardmarket: 725205
+		cardmarket: 725295
 	}
 }
 

--- a/data/Scarlet & Violet/Obsidian Flames/216.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/216.ts
@@ -77,7 +77,7 @@ const card: Card = {
 	illustrator: "takuyoa",
 
 	thirdParty: {
-		cardmarket: 725236
+		cardmarket: 725296
 	}
 }
 

--- a/data/Scarlet & Violet/Obsidian Flames/217.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/217.ts
@@ -77,7 +77,7 @@ const card: Card = {
 	illustrator: "takuyoa",
 
 	thirdParty: {
-		cardmarket: 725244
+		cardmarket: 725297
 	}
 }
 

--- a/data/Scarlet & Violet/Obsidian Flames/218.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/218.ts
@@ -36,7 +36,7 @@ const card: Card = {
 	illustrator: "kirisAki",
 
 	thirdParty: {
-		cardmarket: 725268
+		cardmarket: 725298
 	}
 }
 

--- a/data/Scarlet & Violet/Obsidian Flames/219.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/219.ts
@@ -36,7 +36,7 @@ const card: Card = {
 	illustrator: "Naoki Saito",
 
 	thirdParty: {
-		cardmarket: 725270
+		cardmarket: 725299
 	}
 }
 

--- a/data/Scarlet & Violet/Obsidian Flames/220.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/220.ts
@@ -36,7 +36,7 @@ const card: Card = {
 	illustrator: "yuu",
 
 	thirdParty: {
-		cardmarket: 725273
+		cardmarket: 725300
 	}
 }
 

--- a/data/Scarlet & Violet/Obsidian Flames/221.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/221.ts
@@ -36,7 +36,7 @@ const card: Card = {
 	illustrator: "nagimiso",
 
 	thirdParty: {
-		cardmarket: 725274
+		cardmarket: 725301
 	}
 }
 

--- a/data/Scarlet & Violet/Obsidian Flames/222.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/222.ts
@@ -55,7 +55,7 @@ const card: Card = {
 	illustrator: "Toshinao Aoki",
 
 	thirdParty: {
-		cardmarket: 725122
+		cardmarket: 725302
 	}
 }
 

--- a/data/Scarlet & Violet/Obsidian Flames/223.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/223.ts
@@ -77,7 +77,7 @@ const card: Card = {
 	illustrator: "AKIRA EGAWA",
 
 	thirdParty: {
-		cardmarket: 725205
+		cardmarket: 725303
 	}
 }
 

--- a/data/Scarlet & Violet/Obsidian Flames/224.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/224.ts
@@ -77,7 +77,7 @@ const card: Card = {
 	illustrator: "Souichirou Gunjima",
 
 	thirdParty: {
-		cardmarket: 725236
+		cardmarket: 725304
 	}
 }
 

--- a/data/Scarlet & Violet/Obsidian Flames/225.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/225.ts
@@ -77,7 +77,7 @@ const card: Card = {
 	illustrator: "Jerky",
 
 	thirdParty: {
-		cardmarket: 725244
+		cardmarket: 725305
 	}
 }
 

--- a/data/Scarlet & Violet/Obsidian Flames/226.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/226.ts
@@ -36,7 +36,7 @@ const card: Card = {
 	illustrator: "DOM",
 
 	thirdParty: {
-		cardmarket: 725268
+		cardmarket: 725306
 	}
 }
 

--- a/data/Scarlet & Violet/Obsidian Flames/227.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/227.ts
@@ -36,7 +36,7 @@ const card: Card = {
 	illustrator: "Ryota Murayama",
 
 	thirdParty: {
-		cardmarket: 725273
+		cardmarket: 725307
 	}
 }
 

--- a/data/Scarlet & Violet/Obsidian Flames/228.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/228.ts
@@ -77,7 +77,7 @@ const card: Card = {
 	illustrator: "5ban Graphics",
 
 	thirdParty: {
-		cardmarket: 725205
+		cardmarket: 725308
 	}
 }
 


### PR DESCRIPTION
Corrected the 'cardmarket' thirdParty IDs for multiple cards in Scarlet & Violet: Obsidian Flames

<!--
Contribution guide: https://github.com/tcgdex/cards-database/blob/master/CONTRIBUTING.md
please submit changes up to 1 set at most.
-->

## Changes

<!-- Quickly explain your changes -->

024, 061, 075, 076, 078, 100, 119, 122, 127, 129, 132, 143, 148, 149, 155, 181, 182, 184 
198-228

<!-- You can also give more details about your changes -->

