### PR TITLE
fix: Add Cardmarket IDs to Destined Rivals cards

### DIFF
--- a/data/Scarlet & Violet/Destined Rivals/001.ts
+++ b/data/Scarlet & Violet/Destined Rivals/001.ts
@@ -71,7 +71,11 @@ const card: Card = {
 		{
 			type: 'reverse'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 825875,
+	}
 
 }
 

--- a/data/Scarlet & Violet/Destined Rivals/002.ts
+++ b/data/Scarlet & Violet/Destined Rivals/002.ts
@@ -69,7 +69,11 @@ const card: Card = {
 		{
 			type: 'reverse'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 825876
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/003.ts
+++ b/data/Scarlet & Violet/Destined Rivals/003.ts
@@ -78,7 +78,11 @@ const card: Card = {
 		{
 			type: 'holo'
 		}
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 825877
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/004.ts
+++ b/data/Scarlet & Violet/Destined Rivals/004.ts
@@ -47,7 +47,11 @@ const card: Card = {
 		{
 			type: 'reverse'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 825878,
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/005.ts
+++ b/data/Scarlet & Violet/Destined Rivals/005.ts
@@ -47,7 +47,11 @@ const card: Card = {
 		{
 			type: 'reverse'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 825879
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/006.ts
+++ b/data/Scarlet & Violet/Destined Rivals/006.ts
@@ -81,7 +81,11 @@ const card: Card = {
 		{
 			type: 'reverse'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 825880
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/007.ts
+++ b/data/Scarlet & Violet/Destined Rivals/007.ts
@@ -47,7 +47,11 @@ const card: Card = {
 		{
 			type: 'reverse'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 825881
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/008.ts
+++ b/data/Scarlet & Violet/Destined Rivals/008.ts
@@ -71,7 +71,11 @@ const card: Card = {
 		{
 			type: 'holo'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 825882
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/009.ts
+++ b/data/Scarlet & Violet/Destined Rivals/009.ts
@@ -81,7 +81,11 @@ const card: Card = {
 		{
 			type: 'reverse'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 825883
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/010.ts
+++ b/data/Scarlet & Violet/Destined Rivals/010.ts
@@ -71,7 +71,11 @@ const card: Card = {
 		{
 			type: 'reverse'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 825884
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/011.ts
+++ b/data/Scarlet & Violet/Destined Rivals/011.ts
@@ -55,7 +55,11 @@ const card: Card = {
 		{
 			type: 'reverse'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 825885
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/012.ts
+++ b/data/Scarlet & Violet/Destined Rivals/012.ts
@@ -81,7 +81,11 @@ const card: Card = {
 		{
 			type: 'holo'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 825886
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/013.ts
+++ b/data/Scarlet & Violet/Destined Rivals/013.ts
@@ -47,7 +47,11 @@ const card: Card = {
 		{
 			type: 'reverse'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 825887
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/014.ts
+++ b/data/Scarlet & Violet/Destined Rivals/014.ts
@@ -71,7 +71,11 @@ const card: Card = {
 		{
 			type: 'reverse'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 825888
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/015.ts
+++ b/data/Scarlet & Violet/Destined Rivals/015.ts
@@ -55,7 +55,11 @@ const card: Card = {
 		{
 			type: 'reverse'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 825889
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/016.ts
+++ b/data/Scarlet & Violet/Destined Rivals/016.ts
@@ -57,7 +57,11 @@ const card: Card = {
 		{
 			type: 'reverse'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 825890
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/017.ts
+++ b/data/Scarlet & Violet/Destined Rivals/017.ts
@@ -57,7 +57,11 @@ const card: Card = {
 		{
 			type: 'reverse'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 825891
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/018.ts
+++ b/data/Scarlet & Violet/Destined Rivals/018.ts
@@ -69,7 +69,11 @@ const card: Card = {
 		{
 			type: 'holo'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 825892
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/019.ts
+++ b/data/Scarlet & Violet/Destined Rivals/019.ts
@@ -57,7 +57,11 @@ const card: Card = {
 		{
 			type: 'reverse'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 825893
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/020.ts
+++ b/data/Scarlet & Violet/Destined Rivals/020.ts
@@ -81,7 +81,11 @@ const card: Card = {
 		{
 			type: 'holo'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 825894
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/021.ts
+++ b/data/Scarlet & Violet/Destined Rivals/021.ts
@@ -47,7 +47,11 @@ const card: Card = {
 		{
 			type: 'reverse'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 825895
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/022.ts
+++ b/data/Scarlet & Violet/Destined Rivals/022.ts
@@ -69,7 +69,11 @@ const card: Card = {
 		{
 			type: 'reverse'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 825896
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/023.ts
+++ b/data/Scarlet & Violet/Destined Rivals/023.ts
@@ -76,7 +76,11 @@ const card: Card = {
 		{
 			type: 'holo'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 825897
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/024.ts
+++ b/data/Scarlet & Violet/Destined Rivals/024.ts
@@ -68,7 +68,11 @@ const card: Card = {
 		{
 			type: 'reverse'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 825898
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/025.ts
+++ b/data/Scarlet & Violet/Destined Rivals/025.ts
@@ -75,7 +75,11 @@ const card: Card = {
 		{
 			type: 'holo'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 825899
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/026.ts
+++ b/data/Scarlet & Violet/Destined Rivals/026.ts
@@ -79,7 +79,11 @@ const card: Card = {
 		{
 			type: 'reverse'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 825900
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/027.ts
+++ b/data/Scarlet & Violet/Destined Rivals/027.ts
@@ -61,7 +61,11 @@ const card: Card = {
 		{
 			type: 'reverse'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 825901
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/028.ts
+++ b/data/Scarlet & Violet/Destined Rivals/028.ts
@@ -71,7 +71,11 @@ const card: Card = {
 		{
 			type: 'reverse'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 825902
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/029.ts
+++ b/data/Scarlet & Violet/Destined Rivals/029.ts
@@ -57,7 +57,11 @@ const card: Card = {
 		{
 			type: 'reverse'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 825903
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/030.ts
+++ b/data/Scarlet & Violet/Destined Rivals/030.ts
@@ -71,7 +71,11 @@ const card: Card = {
 		{
 			type: 'reverse'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 825904
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/031.ts
+++ b/data/Scarlet & Violet/Destined Rivals/031.ts
@@ -76,7 +76,11 @@ const card: Card = {
 		{
 			type: 'holo'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 825905
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/032.ts
+++ b/data/Scarlet & Violet/Destined Rivals/032.ts
@@ -57,7 +57,11 @@ const card: Card = {
 		{
 			type: 'reverse'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 825906
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/033.ts
+++ b/data/Scarlet & Violet/Destined Rivals/033.ts
@@ -71,7 +71,11 @@ const card: Card = {
 		{
 			type: 'reverse'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 825907
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/034.ts
+++ b/data/Scarlet & Violet/Destined Rivals/034.ts
@@ -84,7 +84,11 @@ const card: Card = {
 				"staff"
 			]
 		}
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 825908
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/035.ts
+++ b/data/Scarlet & Violet/Destined Rivals/035.ts
@@ -47,7 +47,11 @@ const card: Card = {
 		{
 			type: 'reverse'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 825909
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/036.ts
+++ b/data/Scarlet & Violet/Destined Rivals/036.ts
@@ -81,7 +81,11 @@ const card: Card = {
 		{
 			type: 'holo'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 825910
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/037.ts
+++ b/data/Scarlet & Violet/Destined Rivals/037.ts
@@ -47,7 +47,11 @@ const card: Card = {
 		{
 			type: 'reverse'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 825911
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/038.ts
+++ b/data/Scarlet & Violet/Destined Rivals/038.ts
@@ -79,7 +79,11 @@ const card: Card = {
 		{
 			type: 'reverse'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 825912
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/039.ts
+++ b/data/Scarlet & Violet/Destined Rivals/039.ts
@@ -78,7 +78,11 @@ const card: Card = {
 		{
 			type: 'holo'
 		}
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 825913
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/040.ts
+++ b/data/Scarlet & Violet/Destined Rivals/040.ts
@@ -69,7 +69,11 @@ const card: Card = {
 		{
 			type: 'reverse'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 825914
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/041.ts
+++ b/data/Scarlet & Violet/Destined Rivals/041.ts
@@ -71,7 +71,11 @@ const card: Card = {
 		{
 			type: 'reverse'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 825915
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/042.ts
+++ b/data/Scarlet & Violet/Destined Rivals/042.ts
@@ -71,7 +71,11 @@ const card: Card = {
 		{
 			type: 'holo'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 825916
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/043.ts
+++ b/data/Scarlet & Violet/Destined Rivals/043.ts
@@ -79,7 +79,11 @@ const card: Card = {
 		{
 			type: 'reverse'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 825917
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/044.ts
+++ b/data/Scarlet & Violet/Destined Rivals/044.ts
@@ -79,7 +79,11 @@ const card: Card = {
 		{
 			type: 'reverse'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 825918
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/045.ts
+++ b/data/Scarlet & Violet/Destined Rivals/045.ts
@@ -71,7 +71,11 @@ const card: Card = {
 		{
 			type: 'reverse'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 825919
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/046.ts
+++ b/data/Scarlet & Violet/Destined Rivals/046.ts
@@ -57,7 +57,11 @@ const card: Card = {
 		{
 			type: 'reverse'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 825920
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/047.ts
+++ b/data/Scarlet & Violet/Destined Rivals/047.ts
@@ -57,7 +57,11 @@ const card: Card = {
 		{
 			type: 'reverse'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 825921
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/048.ts
+++ b/data/Scarlet & Violet/Destined Rivals/048.ts
@@ -71,7 +71,11 @@ const card: Card = {
 		{
 			type: 'reverse'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 825922
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/049.ts
+++ b/data/Scarlet & Violet/Destined Rivals/049.ts
@@ -84,7 +84,11 @@ const card: Card = {
 				"staff"
 			]
 		}
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 825923
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/050.ts
+++ b/data/Scarlet & Violet/Destined Rivals/050.ts
@@ -69,7 +69,11 @@ const card: Card = {
 		{
 			type: 'reverse'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 825924
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/051.ts
+++ b/data/Scarlet & Violet/Destined Rivals/051.ts
@@ -81,7 +81,11 @@ const card: Card = {
 		{
 			type: 'holo'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 825925
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/052.ts
+++ b/data/Scarlet & Violet/Destined Rivals/052.ts
@@ -57,7 +57,11 @@ const card: Card = {
 		{
 			type: 'reverse'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 825926
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/053.ts
+++ b/data/Scarlet & Violet/Destined Rivals/053.ts
@@ -57,7 +57,11 @@ const card: Card = {
 		{
 			type: 'reverse'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 825927
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/054.ts
+++ b/data/Scarlet & Violet/Destined Rivals/054.ts
@@ -57,7 +57,11 @@ const card: Card = {
 		{
 			type: 'reverse'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 825928
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/055.ts
+++ b/data/Scarlet & Violet/Destined Rivals/055.ts
@@ -71,7 +71,11 @@ const card: Card = {
 		{
 			type: 'reverse'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 825929
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/056.ts
+++ b/data/Scarlet & Violet/Destined Rivals/056.ts
@@ -57,7 +57,11 @@ const card: Card = {
 		{
 			type: 'holo'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 825930
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/057.ts
+++ b/data/Scarlet & Violet/Destined Rivals/057.ts
@@ -61,7 +61,11 @@ const card: Card = {
 		{
 			type: 'reverse'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 825931
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/058.ts
+++ b/data/Scarlet & Violet/Destined Rivals/058.ts
@@ -81,7 +81,11 @@ const card: Card = {
 		{
 			type: 'reverse'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 825932
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/059.ts
+++ b/data/Scarlet & Violet/Destined Rivals/059.ts
@@ -61,7 +61,11 @@ const card: Card = {
 		{
 			type: 'reverse'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 825933
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/060.ts
+++ b/data/Scarlet & Violet/Destined Rivals/060.ts
@@ -71,7 +71,11 @@ const card: Card = {
 		{
 			type: 'reverse'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 825934
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/061.ts
+++ b/data/Scarlet & Violet/Destined Rivals/061.ts
@@ -81,7 +81,11 @@ const card: Card = {
 		{
 			type: 'reverse'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 825935
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/062.ts
+++ b/data/Scarlet & Violet/Destined Rivals/062.ts
@@ -57,7 +57,11 @@ const card: Card = {
 		{
 			type: 'reverse'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 825936
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/063.ts
+++ b/data/Scarlet & Violet/Destined Rivals/063.ts
@@ -71,7 +71,11 @@ const card: Card = {
 		{
 			type: 'reverse'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 825937
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/064.ts
+++ b/data/Scarlet & Violet/Destined Rivals/064.ts
@@ -61,7 +61,11 @@ const card: Card = {
 		{
 			type: 'reverse'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 825938
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/065.ts
+++ b/data/Scarlet & Violet/Destined Rivals/065.ts
@@ -81,7 +81,11 @@ const card: Card = {
 		{
 			type: 'holo'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 825939
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/066.ts
+++ b/data/Scarlet & Violet/Destined Rivals/066.ts
@@ -81,7 +81,11 @@ const card: Card = {
 		{
 			type: 'holo'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 825940
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/067.ts
+++ b/data/Scarlet & Violet/Destined Rivals/067.ts
@@ -79,7 +79,11 @@ const card: Card = {
 		{
 			type: 'reverse'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 825941
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/068.ts
+++ b/data/Scarlet & Violet/Destined Rivals/068.ts
@@ -47,7 +47,11 @@ const card: Card = {
 		{
 			type: 'reverse'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 825942
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/069.ts
+++ b/data/Scarlet & Violet/Destined Rivals/069.ts
@@ -79,7 +79,11 @@ const card: Card = {
 		{
 			type: 'holo'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 825943
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/070.ts
+++ b/data/Scarlet & Violet/Destined Rivals/070.ts
@@ -81,7 +81,11 @@ const card: Card = {
 		{
 			type: 'holo'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 825944
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/071.ts
+++ b/data/Scarlet & Violet/Destined Rivals/071.ts
@@ -55,7 +55,11 @@ const card: Card = {
 		{
 			type: 'reverse'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 825945
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/072.ts
+++ b/data/Scarlet & Violet/Destined Rivals/072.ts
@@ -69,7 +69,11 @@ const card: Card = {
 		{
 			type: 'reverse'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 825946
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/073.ts
+++ b/data/Scarlet & Violet/Destined Rivals/073.ts
@@ -57,7 +57,11 @@ const card: Card = {
 		{
 			type: 'reverse'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 825947
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/074.ts
+++ b/data/Scarlet & Violet/Destined Rivals/074.ts
@@ -71,7 +71,11 @@ const card: Card = {
 		{
 			type: 'reverse'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 825948
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/075.ts
+++ b/data/Scarlet & Violet/Destined Rivals/075.ts
@@ -61,7 +61,11 @@ const card: Card = {
 		{
 			type: 'reverse'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 825949
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/076.ts
+++ b/data/Scarlet & Violet/Destined Rivals/076.ts
@@ -71,7 +71,11 @@ const card: Card = {
 		{
 			type: 'reverse'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 825950
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/077.ts
+++ b/data/Scarlet & Violet/Destined Rivals/077.ts
@@ -81,7 +81,11 @@ const card: Card = {
 		{
 			type: 'reverse'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 825951
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/078.ts
+++ b/data/Scarlet & Violet/Destined Rivals/078.ts
@@ -69,7 +69,11 @@ const card: Card = {
 		{
 			type: 'holo'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 825952
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/079.ts
+++ b/data/Scarlet & Violet/Destined Rivals/079.ts
@@ -57,7 +57,11 @@ const card: Card = {
 		{
 			type: 'reverse'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 825953
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/080.ts
+++ b/data/Scarlet & Violet/Destined Rivals/080.ts
@@ -71,7 +71,11 @@ const card: Card = {
 		{
 			type: 'reverse'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 825954
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/081.ts
+++ b/data/Scarlet & Violet/Destined Rivals/081.ts
@@ -81,7 +81,11 @@ const card: Card = {
 		{
 			type: 'holo'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 825955
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/082.ts
+++ b/data/Scarlet & Violet/Destined Rivals/082.ts
@@ -69,7 +69,11 @@ const card: Card = {
 		{
 			type: 'holo'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 825956
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/083.ts
+++ b/data/Scarlet & Violet/Destined Rivals/083.ts
@@ -69,7 +69,11 @@ const card: Card = {
 		{
 			type: 'reverse'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 825957
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/084.ts
+++ b/data/Scarlet & Violet/Destined Rivals/084.ts
@@ -81,7 +81,11 @@ const card: Card = {
 		{
 			type: 'reverse'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 825958
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/085.ts
+++ b/data/Scarlet & Violet/Destined Rivals/085.ts
@@ -53,7 +53,11 @@ const card: Card = {
 		{
 			type: 'reverse'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 825959
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/086.ts
+++ b/data/Scarlet & Violet/Destined Rivals/086.ts
@@ -71,7 +71,11 @@ const card: Card = {
 		{
 			type: 'reverse'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 825960
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/087.ts
+++ b/data/Scarlet & Violet/Destined Rivals/087.ts
@@ -66,7 +66,11 @@ const card: Card = {
 			type: 'holo',
 			stamp: ["set-logo", "staff"]
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 825961
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/088.ts
+++ b/data/Scarlet & Violet/Destined Rivals/088.ts
@@ -69,7 +69,11 @@ const card: Card = {
 		{
 			type: 'reverse'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 825962
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/089.ts
+++ b/data/Scarlet & Violet/Destined Rivals/089.ts
@@ -81,7 +81,11 @@ const card: Card = {
 		{
 			type: 'reverse'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 825963
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/090.ts
+++ b/data/Scarlet & Violet/Destined Rivals/090.ts
@@ -57,7 +57,11 @@ const card: Card = {
 		{
 			type: 'reverse'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 825964
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/091.ts
+++ b/data/Scarlet & Violet/Destined Rivals/091.ts
@@ -55,7 +55,11 @@ const card: Card = {
 		{
 			type: 'reverse'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 825965
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/092.ts
+++ b/data/Scarlet & Violet/Destined Rivals/092.ts
@@ -81,7 +81,11 @@ const card: Card = {
 		{
 			type: 'holo'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 825966
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/093.ts
+++ b/data/Scarlet & Violet/Destined Rivals/093.ts
@@ -79,7 +79,11 @@ const card: Card = {
 		{
 			type: 'reverse'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 825967
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/094.ts
+++ b/data/Scarlet & Violet/Destined Rivals/094.ts
@@ -57,7 +57,11 @@ const card: Card = {
 		{
 			type: 'reverse'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 825968
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/095.ts
+++ b/data/Scarlet & Violet/Destined Rivals/095.ts
@@ -57,7 +57,11 @@ const card: Card = {
 		{
 			type: 'reverse'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 825969
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/096.ts
+++ b/data/Scarlet & Violet/Destined Rivals/096.ts
@@ -89,7 +89,11 @@ const card: Card = {
 			type: 'holo',
 			stamp: ["set-logo", "staff"]
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 825970
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/097.ts
+++ b/data/Scarlet & Violet/Destined Rivals/097.ts
@@ -61,7 +61,11 @@ const card: Card = {
 		{
 			type: 'reverse'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 825971
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/098.ts
+++ b/data/Scarlet & Violet/Destined Rivals/098.ts
@@ -71,7 +71,11 @@ const card: Card = {
 		{
 			type: 'reverse'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 825972
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/099.ts
+++ b/data/Scarlet & Violet/Destined Rivals/099.ts
@@ -57,7 +57,11 @@ const card: Card = {
 		{
 			type: 'reverse'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 825973
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/100.ts
+++ b/data/Scarlet & Violet/Destined Rivals/100.ts
@@ -57,7 +57,11 @@ const card: Card = {
 		{
 			type: 'reverse'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 825974
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/101.ts
+++ b/data/Scarlet & Violet/Destined Rivals/101.ts
@@ -76,7 +76,11 @@ const card: Card = {
 		{
 			type: 'holo'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 825975
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/102.ts
+++ b/data/Scarlet & Violet/Destined Rivals/102.ts
@@ -57,7 +57,11 @@ const card: Card = {
 		{
 			type: 'reverse'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 825976
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/103.ts
+++ b/data/Scarlet & Violet/Destined Rivals/103.ts
@@ -71,7 +71,11 @@ const card: Card = {
 		{
 			type: 'reverse'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 825977
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/104.ts
+++ b/data/Scarlet & Violet/Destined Rivals/104.ts
@@ -78,7 +78,11 @@ const card: Card = {
 		{
 			type: 'holo'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 825978
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/105.ts
+++ b/data/Scarlet & Violet/Destined Rivals/105.ts
@@ -56,7 +56,11 @@ const card: Card = {
 		{
 			type: 'reverse'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 825979
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/106.ts
+++ b/data/Scarlet & Violet/Destined Rivals/106.ts
@@ -70,7 +70,11 @@ const card: Card = {
 		{
 			type: 'reverse'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 825980
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/107.ts
+++ b/data/Scarlet & Violet/Destined Rivals/107.ts
@@ -57,7 +57,11 @@ const card: Card = {
 		{
 			type: 'reverse'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 825981
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/108.ts
+++ b/data/Scarlet & Violet/Destined Rivals/108.ts
@@ -71,7 +71,11 @@ const card: Card = {
 		{
 			type: 'reverse'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 825982
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/109.ts
+++ b/data/Scarlet & Violet/Destined Rivals/109.ts
@@ -57,7 +57,11 @@ const card: Card = {
 		{
 			type: 'reverse'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 825983
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/110.ts
+++ b/data/Scarlet & Violet/Destined Rivals/110.ts
@@ -79,7 +79,11 @@ const card: Card = {
 		{
 			type: 'reverse'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 825984
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/111.ts
+++ b/data/Scarlet & Violet/Destined Rivals/111.ts
@@ -79,7 +79,11 @@ const card: Card = {
 		{
 			type: 'reverse'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 825985
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/112.ts
+++ b/data/Scarlet & Violet/Destined Rivals/112.ts
@@ -69,7 +69,11 @@ const card: Card = {
 		{
 			type: 'reverse'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 825986
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/113.ts
+++ b/data/Scarlet & Violet/Destined Rivals/113.ts
@@ -79,7 +79,11 @@ const card: Card = {
 		{
 			type: 'reverse'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 825987
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/114.ts
+++ b/data/Scarlet & Violet/Destined Rivals/114.ts
@@ -57,7 +57,11 @@ const card: Card = {
 		{
 			type: 'reverse'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 825988
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/115.ts
+++ b/data/Scarlet & Violet/Destined Rivals/115.ts
@@ -69,7 +69,11 @@ const card: Card = {
 		{
 			type: 'reverse'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 825989
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/116.ts
+++ b/data/Scarlet & Violet/Destined Rivals/116.ts
@@ -71,7 +71,11 @@ const card: Card = {
 		{
 			type: 'reverse'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 825990
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/117.ts
+++ b/data/Scarlet & Violet/Destined Rivals/117.ts
@@ -61,7 +61,11 @@ const card: Card = {
 		{
 			type: 'reverse'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 825991
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/118.ts
+++ b/data/Scarlet & Violet/Destined Rivals/118.ts
@@ -71,7 +71,11 @@ const card: Card = {
 		{
 			type: 'reverse'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 825992
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/119.ts
+++ b/data/Scarlet & Violet/Destined Rivals/119.ts
@@ -68,7 +68,11 @@ const card: Card = {
 		{
 			type: 'holo'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 825993
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/120.ts
+++ b/data/Scarlet & Violet/Destined Rivals/120.ts
@@ -55,7 +55,11 @@ const card: Card = {
 		{
 			type: 'reverse'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 825994
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/121.ts
+++ b/data/Scarlet & Violet/Destined Rivals/121.ts
@@ -81,7 +81,11 @@ const card: Card = {
 		{
 			type: 'reverse'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 825995
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/122.ts
+++ b/data/Scarlet & Violet/Destined Rivals/122.ts
@@ -78,7 +78,11 @@ const card: Card = {
 		{
 			type: 'holo'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 825996
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/123.ts
+++ b/data/Scarlet & Violet/Destined Rivals/123.ts
@@ -55,7 +55,11 @@ const card: Card = {
 		{
 			type: 'reverse'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 825997
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/124.ts
+++ b/data/Scarlet & Violet/Destined Rivals/124.ts
@@ -81,7 +81,11 @@ const card: Card = {
 		{
 			type: 'reverse'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 825998
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/125.ts
+++ b/data/Scarlet & Violet/Destined Rivals/125.ts
@@ -71,7 +71,11 @@ const card: Card = {
 		{
 			type: 'reverse'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 825999
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/126.ts
+++ b/data/Scarlet & Violet/Destined Rivals/126.ts
@@ -57,7 +57,11 @@ const card: Card = {
 		{
 			type: 'reverse'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 826000
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/127.ts
+++ b/data/Scarlet & Violet/Destined Rivals/127.ts
@@ -79,7 +79,11 @@ const card: Card = {
 		{
 			type: 'reverse'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 826001
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/128.ts
+++ b/data/Scarlet & Violet/Destined Rivals/128.ts
@@ -69,7 +69,11 @@ const card: Card = {
 		{
 			type: 'holo'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 826002
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/129.ts
+++ b/data/Scarlet & Violet/Destined Rivals/129.ts
@@ -57,7 +57,11 @@ const card: Card = {
 		{
 			type: 'reverse'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 826003
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/130.ts
+++ b/data/Scarlet & Violet/Destined Rivals/130.ts
@@ -57,7 +57,11 @@ const card: Card = {
 		{
 			type: 'reverse'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 826004
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/131.ts
+++ b/data/Scarlet & Violet/Destined Rivals/131.ts
@@ -57,7 +57,11 @@ const card: Card = {
 		{
 			type: 'reverse'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 826005
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/132.ts
+++ b/data/Scarlet & Violet/Destined Rivals/132.ts
@@ -57,7 +57,11 @@ const card: Card = {
 		{
 			type: 'reverse'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 826006
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/133.ts
+++ b/data/Scarlet & Violet/Destined Rivals/133.ts
@@ -71,7 +71,11 @@ const card: Card = {
 		{
 			type: 'reverse'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 826007
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/134.ts
+++ b/data/Scarlet & Violet/Destined Rivals/134.ts
@@ -69,7 +69,11 @@ const card: Card = {
 		{
 			type: 'reverse'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 826008
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/135.ts
+++ b/data/Scarlet & Violet/Destined Rivals/135.ts
@@ -47,7 +47,11 @@ const card: Card = {
 		{
 			type: 'reverse'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 826009
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/136.ts
+++ b/data/Scarlet & Violet/Destined Rivals/136.ts
@@ -78,7 +78,11 @@ const card: Card = {
 		{
 			type: 'holo'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 826010
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/137.ts
+++ b/data/Scarlet & Violet/Destined Rivals/137.ts
@@ -57,7 +57,11 @@ const card: Card = {
 		{
 			type: 'reverse'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 826011
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/138.ts
+++ b/data/Scarlet & Violet/Destined Rivals/138.ts
@@ -61,7 +61,11 @@ const card: Card = {
 		{
 			type: 'reverse'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 826012
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/139.ts
+++ b/data/Scarlet & Violet/Destined Rivals/139.ts
@@ -78,7 +78,11 @@ const card: Card = {
 		{
 			type: 'holo'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 826013
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/140.ts
+++ b/data/Scarlet & Violet/Destined Rivals/140.ts
@@ -81,7 +81,11 @@ const card: Card = {
 		{
 			type: 'reverse'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 826014
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/141.ts
+++ b/data/Scarlet & Violet/Destined Rivals/141.ts
@@ -69,7 +69,11 @@ const card: Card = {
 		{
 			type: 'reverse'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 826015
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/142.ts
+++ b/data/Scarlet & Violet/Destined Rivals/142.ts
@@ -69,7 +69,11 @@ const card: Card = {
 		{
 			type: 'reverse'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 826016
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/143.ts
+++ b/data/Scarlet & Violet/Destined Rivals/143.ts
@@ -47,7 +47,11 @@ const card: Card = {
 		{
 			type: 'reverse'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 826017
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/144.ts
+++ b/data/Scarlet & Violet/Destined Rivals/144.ts
@@ -57,7 +57,11 @@ const card: Card = {
 		{
 			type: 'reverse'
 		}
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 826018
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/145.ts
+++ b/data/Scarlet & Violet/Destined Rivals/145.ts
@@ -68,7 +68,11 @@ const card: Card = {
 		{
 			type: 'holo'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 826019
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/146.ts
+++ b/data/Scarlet & Violet/Destined Rivals/146.ts
@@ -57,7 +57,11 @@ const card: Card = {
 		{
 			type: 'reverse'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 826020
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/147.ts
+++ b/data/Scarlet & Violet/Destined Rivals/147.ts
@@ -57,7 +57,11 @@ const card: Card = {
 		{
 			type: 'reverse'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 826021
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/148.ts
+++ b/data/Scarlet & Violet/Destined Rivals/148.ts
@@ -57,7 +57,11 @@ const card: Card = {
 		{
 			type: 'reverse'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 826022
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/149.ts
+++ b/data/Scarlet & Violet/Destined Rivals/149.ts
@@ -79,7 +79,11 @@ const card: Card = {
 		{
 			type: 'reverse'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 826023
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/150.ts
+++ b/data/Scarlet & Violet/Destined Rivals/150.ts
@@ -76,7 +76,11 @@ const card: Card = {
 		{
 			type: 'holo'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 826024
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/151.ts
+++ b/data/Scarlet & Violet/Destined Rivals/151.ts
@@ -71,7 +71,11 @@ const card: Card = {
 		{
 			type: 'reverse'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 826025
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/152.ts
+++ b/data/Scarlet & Violet/Destined Rivals/152.ts
@@ -71,7 +71,11 @@ const card: Card = {
 		{
 			type: 'reverse'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 826026
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/153.ts
+++ b/data/Scarlet & Violet/Destined Rivals/153.ts
@@ -55,7 +55,11 @@ const card: Card = {
 		{
 			type: 'reverse'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 826027
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/154.ts
+++ b/data/Scarlet & Violet/Destined Rivals/154.ts
@@ -57,7 +57,11 @@ const card: Card = {
 		{
 			type: 'reverse'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 826028
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/155.ts
+++ b/data/Scarlet & Violet/Destined Rivals/155.ts
@@ -81,7 +81,11 @@ const card: Card = {
 		{
 			type: 'reverse'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 826029
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/156.ts
+++ b/data/Scarlet & Violet/Destined Rivals/156.ts
@@ -47,7 +47,11 @@ const card: Card = {
 		{
 			type: 'reverse'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 826030
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/157.ts
+++ b/data/Scarlet & Violet/Destined Rivals/157.ts
@@ -69,7 +69,11 @@ const card: Card = {
 		{
 			type: 'reverse'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 826031
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/158.ts
+++ b/data/Scarlet & Violet/Destined Rivals/158.ts
@@ -57,7 +57,11 @@ const card: Card = {
 		{
 			type: 'reverse'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 826032
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/159.ts
+++ b/data/Scarlet & Violet/Destined Rivals/159.ts
@@ -71,7 +71,11 @@ const card: Card = {
 		{
 			type: 'holo'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 826033
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/160.ts
+++ b/data/Scarlet & Violet/Destined Rivals/160.ts
@@ -57,7 +57,11 @@ const card: Card = {
 		{
 			type: 'reverse'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 826034
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/161.ts
+++ b/data/Scarlet & Violet/Destined Rivals/161.ts
@@ -37,7 +37,11 @@ const card: Card = {
 		{
 			type: 'reverse'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 826035
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/162.ts
+++ b/data/Scarlet & Violet/Destined Rivals/162.ts
@@ -37,7 +37,11 @@ const card: Card = {
 		{
 			type: 'reverse'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 826036
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/163.ts
+++ b/data/Scarlet & Violet/Destined Rivals/163.ts
@@ -37,7 +37,11 @@ const card: Card = {
 		{
 			type: 'reverse'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 826037
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/164.ts
+++ b/data/Scarlet & Violet/Destined Rivals/164.ts
@@ -37,7 +37,11 @@ const card: Card = {
 		{
 			type: 'reverse'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 826038
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/165.ts
+++ b/data/Scarlet & Violet/Destined Rivals/165.ts
@@ -37,7 +37,11 @@ const card: Card = {
 		{
 			type: 'reverse'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 826039
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/166.ts
+++ b/data/Scarlet & Violet/Destined Rivals/166.ts
@@ -37,7 +37,11 @@ const card: Card = {
 		{
 			type: 'reverse'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 826040
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/167.ts
+++ b/data/Scarlet & Violet/Destined Rivals/167.ts
@@ -36,7 +36,11 @@ const card: Card = {
 		{
 			type: 'reverse'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 826041
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/168.ts
+++ b/data/Scarlet & Violet/Destined Rivals/168.ts
@@ -37,7 +37,11 @@ const card: Card = {
 		{
 			type: 'reverse'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 826042
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/169.ts
+++ b/data/Scarlet & Violet/Destined Rivals/169.ts
@@ -37,7 +37,11 @@ const card: Card = {
 		{
 			type: 'reverse'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 826043
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/170.ts
+++ b/data/Scarlet & Violet/Destined Rivals/170.ts
@@ -37,7 +37,11 @@ const card: Card = {
 		{
 			type: 'reverse'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 826044
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/171.ts
+++ b/data/Scarlet & Violet/Destined Rivals/171.ts
@@ -37,7 +37,11 @@ const card: Card = {
 		{
 			type: 'reverse'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 826045
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/172.ts
+++ b/data/Scarlet & Violet/Destined Rivals/172.ts
@@ -37,7 +37,11 @@ const card: Card = {
 		{
 			type: 'reverse'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 826046
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/173.ts
+++ b/data/Scarlet & Violet/Destined Rivals/173.ts
@@ -37,7 +37,11 @@ const card: Card = {
 		{
 			type: 'reverse'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 826047
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/174.ts
+++ b/data/Scarlet & Violet/Destined Rivals/174.ts
@@ -37,7 +37,11 @@ const card: Card = {
 		{
 			type: 'reverse'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 826048
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/175.ts
+++ b/data/Scarlet & Violet/Destined Rivals/175.ts
@@ -37,7 +37,11 @@ const card: Card = {
 		{
 			type: 'reverse'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 826049
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/176.ts
+++ b/data/Scarlet & Violet/Destined Rivals/176.ts
@@ -37,7 +37,11 @@ const card: Card = {
 		{
 			type: 'reverse'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 826050
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/177.ts
+++ b/data/Scarlet & Violet/Destined Rivals/177.ts
@@ -37,7 +37,11 @@ const card: Card = {
 		{
 			type: 'reverse'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 826051
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/178.ts
+++ b/data/Scarlet & Violet/Destined Rivals/178.ts
@@ -37,7 +37,11 @@ const card: Card = {
 		{
 			type: 'reverse'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 826052
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/179.ts
+++ b/data/Scarlet & Violet/Destined Rivals/179.ts
@@ -37,7 +37,11 @@ const card: Card = {
 		{
 			type: 'reverse'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 826053
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/180.ts
+++ b/data/Scarlet & Violet/Destined Rivals/180.ts
@@ -37,7 +37,11 @@ const card: Card = {
 		{
 			type: 'reverse'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 826054
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/181.ts
+++ b/data/Scarlet & Violet/Destined Rivals/181.ts
@@ -36,7 +36,11 @@ const card: Card = {
 		{
 			type: 'reverse'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 826055
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/182.ts
+++ b/data/Scarlet & Violet/Destined Rivals/182.ts
@@ -37,7 +37,11 @@ const card: Card = {
 		{
 			type: 'reverse'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 826056
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/183.ts
+++ b/data/Scarlet & Violet/Destined Rivals/183.ts
@@ -66,7 +66,11 @@ const card: Card = {
 		{
 			type: 'holo'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 826057
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/184.ts
+++ b/data/Scarlet & Violet/Destined Rivals/184.ts
@@ -68,7 +68,11 @@ const card: Card = {
 		{
 			type: 'holo'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 826058
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/185.ts
+++ b/data/Scarlet & Violet/Destined Rivals/185.ts
@@ -68,7 +68,11 @@ const card: Card = {
 		{
 			type: 'holo'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 826059
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/186.ts
+++ b/data/Scarlet & Violet/Destined Rivals/186.ts
@@ -78,7 +78,11 @@ const card: Card = {
 		{
 			type: 'holo'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 826060
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/187.ts
+++ b/data/Scarlet & Violet/Destined Rivals/187.ts
@@ -78,7 +78,11 @@ const card: Card = {
 		{
 			type: 'holo'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 826061
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/188.ts
+++ b/data/Scarlet & Violet/Destined Rivals/188.ts
@@ -66,7 +66,11 @@ const card: Card = {
 		{
 			type: 'holo'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 826062
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/189.ts
+++ b/data/Scarlet & Violet/Destined Rivals/189.ts
@@ -68,7 +68,11 @@ const card: Card = {
 		{
 			type: 'holo'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 826063
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/190.ts
+++ b/data/Scarlet & Violet/Destined Rivals/190.ts
@@ -68,7 +68,11 @@ const card: Card = {
 		{
 			type: 'holo'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 826064
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/191.ts
+++ b/data/Scarlet & Violet/Destined Rivals/191.ts
@@ -76,7 +76,11 @@ const card: Card = {
 		{
 			type: 'holo'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 826065
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/192.ts
+++ b/data/Scarlet & Violet/Destined Rivals/192.ts
@@ -68,7 +68,11 @@ const card: Card = {
 		{
 			type: 'holo'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 826066
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/193.ts
+++ b/data/Scarlet & Violet/Destined Rivals/193.ts
@@ -68,7 +68,11 @@ const card: Card = {
 		{
 			type: 'holo'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 826067
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/194.ts
+++ b/data/Scarlet & Violet/Destined Rivals/194.ts
@@ -66,7 +66,11 @@ const card: Card = {
 		{
 			type: 'holo'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 826068
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/195.ts
+++ b/data/Scarlet & Violet/Destined Rivals/195.ts
@@ -54,7 +54,11 @@ const card: Card = {
 		{
 			type: 'holo'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 826069
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/196.ts
+++ b/data/Scarlet & Violet/Destined Rivals/196.ts
@@ -58,7 +58,11 @@ const card: Card = {
 		{
 			type: 'holo'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 826070
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/197.ts
+++ b/data/Scarlet & Violet/Destined Rivals/197.ts
@@ -78,7 +78,11 @@ const card: Card = {
 		{
 			type: 'holo'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 826071
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/198.ts
+++ b/data/Scarlet & Violet/Destined Rivals/198.ts
@@ -78,7 +78,11 @@ const card: Card = {
 		{
 			type: 'holo'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 826072
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/199.ts
+++ b/data/Scarlet & Violet/Destined Rivals/199.ts
@@ -54,7 +54,11 @@ const card: Card = {
 		{
 			type: 'holo'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 826073
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/200.ts
+++ b/data/Scarlet & Violet/Destined Rivals/200.ts
@@ -76,7 +76,11 @@ const card: Card = {
 		{
 			type: 'holo'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 826074
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/201.ts
+++ b/data/Scarlet & Violet/Destined Rivals/201.ts
@@ -54,7 +54,11 @@ const card: Card = {
 		{
 			type: 'holo'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 826075
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/202.ts
+++ b/data/Scarlet & Violet/Destined Rivals/202.ts
@@ -54,7 +54,11 @@ const card: Card = {
 		{
 			type: 'holo'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 826076
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/203.ts
+++ b/data/Scarlet & Violet/Destined Rivals/203.ts
@@ -76,7 +76,11 @@ const card: Card = {
 		{
 			type: 'holo'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 826077
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/204.ts
+++ b/data/Scarlet & Violet/Destined Rivals/204.ts
@@ -68,7 +68,11 @@ const card: Card = {
 		{
 			type: 'holo'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 826078
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/205.ts
+++ b/data/Scarlet & Violet/Destined Rivals/205.ts
@@ -68,7 +68,11 @@ const card: Card = {
 		{
 			type: 'holo'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 826079
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/206.ts
+++ b/data/Scarlet & Violet/Destined Rivals/206.ts
@@ -78,7 +78,11 @@ const card: Card = {
 		{
 			type: 'holo'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 826080
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/207.ts
+++ b/data/Scarlet & Violet/Destined Rivals/207.ts
@@ -76,7 +76,11 @@ const card: Card = {
 		{
 			type: 'holo'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 826081
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/208.ts
+++ b/data/Scarlet & Violet/Destined Rivals/208.ts
@@ -76,7 +76,11 @@ const card: Card = {
 		{
 			type: 'holo'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 826082
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/209.ts
+++ b/data/Scarlet & Violet/Destined Rivals/209.ts
@@ -78,7 +78,11 @@ const card: Card = {
 		{
 			type: 'holo'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 826083
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/210.ts
+++ b/data/Scarlet & Violet/Destined Rivals/210.ts
@@ -78,7 +78,11 @@ const card: Card = {
 		{
 			type: 'holo'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 826084
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/211.ts
+++ b/data/Scarlet & Violet/Destined Rivals/211.ts
@@ -78,7 +78,11 @@ const card: Card = {
 		{
 			type: 'holo'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 826085
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/212.ts
+++ b/data/Scarlet & Violet/Destined Rivals/212.ts
@@ -76,7 +76,11 @@ const card: Card = {
 		{
 			type: 'holo'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 826086
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/213.ts
+++ b/data/Scarlet & Violet/Destined Rivals/213.ts
@@ -78,7 +78,11 @@ const card: Card = {
 		{
 			type: 'holo'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 826087
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/214.ts
+++ b/data/Scarlet & Violet/Destined Rivals/214.ts
@@ -76,7 +76,11 @@ const card: Card = {
 		{
 			type: 'holo'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 826088
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/215.ts
+++ b/data/Scarlet & Violet/Destined Rivals/215.ts
@@ -78,7 +78,11 @@ const card: Card = {
 		{
 			type: 'holo'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 826089
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/216.ts
+++ b/data/Scarlet & Violet/Destined Rivals/216.ts
@@ -68,7 +68,11 @@ const card: Card = {
 		{
 			type: 'holo'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 826090
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/217.ts
+++ b/data/Scarlet & Violet/Destined Rivals/217.ts
@@ -78,7 +78,11 @@ const card: Card = {
 		{
 			type: 'holo'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 826091
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/218.ts
+++ b/data/Scarlet & Violet/Destined Rivals/218.ts
@@ -78,7 +78,11 @@ const card: Card = {
 		{
 			type: 'holo'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 826092
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/219.ts
+++ b/data/Scarlet & Violet/Destined Rivals/219.ts
@@ -76,7 +76,11 @@ const card: Card = {
 		{
 			type: 'holo'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 826093
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/220.ts
+++ b/data/Scarlet & Violet/Destined Rivals/220.ts
@@ -34,7 +34,11 @@ const card: Card = {
 		{
 			type: 'holo'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 826094
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/221.ts
+++ b/data/Scarlet & Violet/Destined Rivals/221.ts
@@ -34,7 +34,11 @@ const card: Card = {
 		{
 			type: 'holo'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 826095
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/222.ts
+++ b/data/Scarlet & Violet/Destined Rivals/222.ts
@@ -33,7 +33,11 @@ const card: Card = {
 		{
 			type: 'holo'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 826096
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/223.ts
+++ b/data/Scarlet & Violet/Destined Rivals/223.ts
@@ -34,7 +34,11 @@ const card: Card = {
 		{
 			type: 'holo'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 826097
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/224.ts
+++ b/data/Scarlet & Violet/Destined Rivals/224.ts
@@ -34,7 +34,11 @@ const card: Card = {
 		{
 			type: 'holo'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 826098
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/225.ts
+++ b/data/Scarlet & Violet/Destined Rivals/225.ts
@@ -34,7 +34,11 @@ const card: Card = {
 		{
 			type: 'holo'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 826099
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/226.ts
+++ b/data/Scarlet & Violet/Destined Rivals/226.ts
@@ -34,7 +34,11 @@ const card: Card = {
 		{
 			type: 'holo'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 826100
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/227.ts
+++ b/data/Scarlet & Violet/Destined Rivals/227.ts
@@ -34,7 +34,11 @@ const card: Card = {
 		{
 			type: 'holo'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 826101
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/228.ts
+++ b/data/Scarlet & Violet/Destined Rivals/228.ts
@@ -78,7 +78,11 @@ const card: Card = {
 		{
 			type: 'holo'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 826102
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/229.ts
+++ b/data/Scarlet & Violet/Destined Rivals/229.ts
@@ -76,7 +76,11 @@ const card: Card = {
 		{
 			type: 'holo'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 826103
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/230.ts
+++ b/data/Scarlet & Violet/Destined Rivals/230.ts
@@ -78,7 +78,11 @@ const card: Card = {
 		{
 			type: 'holo'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 826104
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/231.ts
+++ b/data/Scarlet & Violet/Destined Rivals/231.ts
@@ -78,7 +78,11 @@ const card: Card = {
 		{
 			type: 'holo'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 826105
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/232.ts
+++ b/data/Scarlet & Violet/Destined Rivals/232.ts
@@ -78,7 +78,11 @@ const card: Card = {
 		{
 			type: 'holo'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 826106
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/233.ts
+++ b/data/Scarlet & Violet/Destined Rivals/233.ts
@@ -68,7 +68,11 @@ const card: Card = {
 		{
 			type: 'holo'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 826107
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/234.ts
+++ b/data/Scarlet & Violet/Destined Rivals/234.ts
@@ -78,7 +78,11 @@ const card: Card = {
 		{
 			type: 'holo'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 826108
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/235.ts
+++ b/data/Scarlet & Violet/Destined Rivals/235.ts
@@ -78,7 +78,11 @@ const card: Card = {
 		{
 			type: 'holo'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 826109
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/236.ts
+++ b/data/Scarlet & Violet/Destined Rivals/236.ts
@@ -34,7 +34,11 @@ const card: Card = {
 		{
 			type: 'holo'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 826110
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/237.ts
+++ b/data/Scarlet & Violet/Destined Rivals/237.ts
@@ -34,7 +34,11 @@ const card: Card = {
 		{
 			type: 'holo'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 826111
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/238.ts
+++ b/data/Scarlet & Violet/Destined Rivals/238.ts
@@ -34,7 +34,11 @@ const card: Card = {
 		{
 			type: 'holo'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 826112
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/239.ts
+++ b/data/Scarlet & Violet/Destined Rivals/239.ts
@@ -79,7 +79,11 @@ const card: Card = {
 			type: 'holo',
 			foil: 'gold'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 826113
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/240.ts
+++ b/data/Scarlet & Violet/Destined Rivals/240.ts
@@ -79,7 +79,11 @@ const card: Card = {
 			type: 'holo',
 			foil: 'gold'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 826114
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/241.ts
+++ b/data/Scarlet & Violet/Destined Rivals/241.ts
@@ -79,7 +79,11 @@ const card: Card = {
 			type: 'holo',
 			foil: 'gold'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 826115
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/242.ts
+++ b/data/Scarlet & Violet/Destined Rivals/242.ts
@@ -79,7 +79,11 @@ const card: Card = {
 			type: 'holo',
 			foil: 'gold'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 826116
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/243.ts
+++ b/data/Scarlet & Violet/Destined Rivals/243.ts
@@ -34,7 +34,11 @@ const card: Card = {
 			type: 'holo',
 			foil: 'gold'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 826117
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/244.ts
+++ b/data/Scarlet & Violet/Destined Rivals/244.ts
@@ -35,7 +35,11 @@ const card: Card = {
 			type: 'holo',
 			foil: 'gold'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 826118
+	}
 }
 
 export default card


### PR DESCRIPTION
Added the 'thirdParty.cardmarket' field with appropriate Cardmarket IDs to all DRI cards 



