### PR TITLE
fix: Update Cardmarket IDs for Stellar Crown cards

### DIFF
--- a/data/Scarlet & Violet/Stellar Crown/030.ts
+++ b/data/Scarlet & Violet/Stellar Crown/030.ts
@@ -77,7 +77,7 @@ const card: Card = {
 	illustrator: "PLANETA Igarashi",
 
 	thirdParty: {
-		cardmarket: 785883
+		cardmarket: 841264
 	}
 }
 

--- a/data/Scarlet & Violet/Stellar Crown/078.ts
+++ b/data/Scarlet & Violet/Stellar Crown/078.ts
@@ -65,7 +65,7 @@ const card: Card = {
 	illustrator: "Yuu Nishida",
 
 	thirdParty: {
-		cardmarket: 785931
+		cardmarket: 785932
 	}
 }
 

--- a/data/Scarlet & Violet/Stellar Crown/103.ts
+++ b/data/Scarlet & Violet/Stellar Crown/103.ts
@@ -65,7 +65,7 @@ const card: Card = {
 	illustrator: "Apios",
 
 	thirdParty: {
-		cardmarket: 785956
+		cardmarket: 785957
 	}
 }
 

--- a/data/Scarlet & Violet/Stellar Crown/105.ts
+++ b/data/Scarlet & Violet/Stellar Crown/105.ts
@@ -55,7 +55,7 @@ const card: Card = {
 	illustrator: "takuyoa",
 
 	thirdParty: {
-		cardmarket: 785959
+		cardmarket: 841266
 	}
 }
 

--- a/data/Scarlet & Violet/Stellar Crown/107.ts
+++ b/data/Scarlet & Violet/Stellar Crown/107.ts
@@ -76,7 +76,7 @@ const card: Card = {
 	illustrator: "Oswaldo KATO",
 
 	thirdParty: {
-		cardmarket: 785961
+		cardmarket: 789015
 	}
 }
 

--- a/data/Scarlet & Violet/Stellar Crown/111.ts
+++ b/data/Scarlet & Violet/Stellar Crown/111.ts
@@ -65,7 +65,7 @@ const card: Card = {
 	illustrator: "kodama",
 
 	thirdParty: {
-		cardmarket: 785965
+		cardmarket: 786551
 	}
 }
 

--- a/data/Scarlet & Violet/Stellar Crown/119.ts
+++ b/data/Scarlet & Violet/Stellar Crown/119.ts
@@ -76,7 +76,7 @@ const card: Card = {
 	illustrator: "GOSSAN",
 
 	thirdParty: {
-		cardmarket: 785973
+		cardmarket: 789025
 	}
 }
 

--- a/data/Scarlet & Violet/Stellar Crown/128.ts
+++ b/data/Scarlet & Violet/Stellar Crown/128.ts
@@ -77,7 +77,7 @@ const card: Card = {
 	illustrator: "5ban Graphics",
 
 	thirdParty: {
-		cardmarket: 785982
+		cardmarket: 790524
 	}
 }
 

--- a/data/Scarlet & Violet/Stellar Crown/144.ts
+++ b/data/Scarlet & Violet/Stellar Crown/144.ts
@@ -77,7 +77,7 @@ const card: Card = {
 	illustrator: "HYOGONOSUKE",
 
 	thirdParty: {
-		cardmarket: 785856
+		cardmarket: 785998
 	}
 }
 

--- a/data/Scarlet & Violet/Stellar Crown/145.ts
+++ b/data/Scarlet & Violet/Stellar Crown/145.ts
@@ -55,7 +55,7 @@ const card: Card = {
 	illustrator: "Mori Yuu",
 
 	thirdParty: {
-		cardmarket: 785858
+		cardmarket: 785999
 	}
 }
 

--- a/data/Scarlet & Violet/Stellar Crown/146.ts
+++ b/data/Scarlet & Violet/Stellar Crown/146.ts
@@ -77,7 +77,7 @@ const card: Card = {
 	illustrator: "Yukihiro Tada",
 
 	thirdParty: {
-		cardmarket: 785878
+		cardmarket: 786000
 	}
 }
 

--- a/data/Scarlet & Violet/Stellar Crown/147.ts
+++ b/data/Scarlet & Violet/Stellar Crown/147.ts
@@ -59,7 +59,7 @@ const card: Card = {
 	illustrator: "rika",
 
 	thirdParty: {
-		cardmarket: 785880
+		cardmarket: 786001
 	}
 }
 

--- a/data/Scarlet & Violet/Stellar Crown/149.ts
+++ b/data/Scarlet & Violet/Stellar Crown/149.ts
@@ -77,7 +77,7 @@ const card: Card = {
 	illustrator: "Mitsuhiro Arita",
 
 	thirdParty: {
-		cardmarket: 785896
+		cardmarket: 786003
 	}
 }
 

--- a/data/Scarlet & Violet/Stellar Crown/150.ts
+++ b/data/Scarlet & Violet/Stellar Crown/150.ts
@@ -53,7 +53,7 @@ const card: Card = {
 	illustrator: "MARINA Chikazawa",
 
 	thirdParty: {
-		cardmarket: 785904
+		cardmarket: 786004
 	}
 }
 

--- a/data/Scarlet & Violet/Stellar Crown/151.ts
+++ b/data/Scarlet & Violet/Stellar Crown/151.ts
@@ -55,7 +55,7 @@ const card: Card = {
 	illustrator: "Kazumasa Yasukuni",
 
 	thirdParty: {
-		cardmarket: 785909
+		cardmarket: 786005
 	}
 }
 

--- a/data/Scarlet & Violet/Stellar Crown/152.ts
+++ b/data/Scarlet & Violet/Stellar Crown/152.ts
@@ -46,7 +46,7 @@ const card: Card = {
 	illustrator: "Dsuke",
 
 	thirdParty: {
-		cardmarket: 785918
+		cardmarket: 786006
 	}
 }
 

--- a/data/Scarlet & Violet/Stellar Crown/153.ts
+++ b/data/Scarlet & Violet/Stellar Crown/153.ts
@@ -66,7 +66,7 @@ const card: Card = {
 	illustrator: "Yuriko Akase",
 
 	thirdParty: {
-		cardmarket: 785931
+		cardmarket: 786007
 	}
 }
 

--- a/data/Scarlet & Violet/Stellar Crown/154.ts
+++ b/data/Scarlet & Violet/Stellar Crown/154.ts
@@ -68,7 +68,7 @@ const card: Card = {
 	illustrator: "Jerky",
 
 	thirdParty: {
-		cardmarket: 785945
+		cardmarket: 786008
 	}
 }
 

--- a/data/Scarlet & Violet/Stellar Crown/155.ts
+++ b/data/Scarlet & Violet/Stellar Crown/155.ts
@@ -77,7 +77,7 @@ const card: Card = {
 	illustrator: "Toshinao Aoki",
 
 	thirdParty: {
-		cardmarket: 785961
+		cardmarket: 786009
 	}
 }
 

--- a/data/Scarlet & Violet/Stellar Crown/156.ts
+++ b/data/Scarlet & Violet/Stellar Crown/156.ts
@@ -77,7 +77,7 @@ const card: Card = {
 	illustrator: "5ban Graphics",
 
 	thirdParty: {
-		cardmarket: 785867
+		cardmarket: 786010
 	}
 }
 

--- a/data/Scarlet & Violet/Stellar Crown/157.ts
+++ b/data/Scarlet & Violet/Stellar Crown/157.ts
@@ -75,7 +75,7 @@ const card: Card = {
 	illustrator: "5ban Graphics",
 
 	thirdParty: {
-		cardmarket: 785881
+		cardmarket: 786011
 	}
 }
 

--- a/data/Scarlet & Violet/Stellar Crown/158.ts
+++ b/data/Scarlet & Violet/Stellar Crown/158.ts
@@ -75,7 +75,7 @@ const card: Card = {
 	illustrator: "5ban Graphics",
 
 	thirdParty: {
-		cardmarket: 785886
+		cardmarket: 786012
 	}
 }
 

--- a/data/Scarlet & Violet/Stellar Crown/159.ts
+++ b/data/Scarlet & Violet/Stellar Crown/159.ts
@@ -77,7 +77,7 @@ const card: Card = {
 	illustrator: "5ban Graphics",
 
 	thirdParty: {
-		cardmarket: 785905
+		cardmarket: 786013
 	}
 }
 

--- a/data/Scarlet & Violet/Stellar Crown/160.ts
+++ b/data/Scarlet & Violet/Stellar Crown/160.ts
@@ -77,7 +77,7 @@ const card: Card = {
 	illustrator: "PLANETA Mochizuki",
 
 	thirdParty: {
-		cardmarket: 785921
+		cardmarket: 786014
 	}
 }
 

--- a/data/Scarlet & Violet/Stellar Crown/161.ts
+++ b/data/Scarlet & Violet/Stellar Crown/161.ts
@@ -75,7 +75,7 @@ const card: Card = {
 	illustrator: "PLANETA Yamashita",
 
 	thirdParty: {
-		cardmarket: 785934
+		cardmarket: 786015
 	}
 }
 

--- a/data/Scarlet & Violet/Stellar Crown/162.ts
+++ b/data/Scarlet & Violet/Stellar Crown/162.ts
@@ -77,7 +77,7 @@ const card: Card = {
 	illustrator: "PLANETA Mochizuki",
 
 	thirdParty: {
-		cardmarket: 785964
+		cardmarket: 786016
 	}
 }
 

--- a/data/Scarlet & Violet/Stellar Crown/163.ts
+++ b/data/Scarlet & Violet/Stellar Crown/163.ts
@@ -36,7 +36,7 @@ const card: Card = {
 	illustrator: "Naoki Saito",
 
 	thirdParty: {
-		cardmarket: 785986
+		cardmarket: 786017
 	}
 }
 

--- a/data/Scarlet & Violet/Stellar Crown/164.ts
+++ b/data/Scarlet & Violet/Stellar Crown/164.ts
@@ -36,7 +36,7 @@ const card: Card = {
 	illustrator: "GIDORA",
 
 	thirdParty: {
-		cardmarket: 785987
+		cardmarket: 786018
 	}
 }
 

--- a/data/Scarlet & Violet/Stellar Crown/165.ts
+++ b/data/Scarlet & Violet/Stellar Crown/165.ts
@@ -36,7 +36,7 @@ const card: Card = {
 	illustrator: "Hideki Ishikawa",
 
 	thirdParty: {
-		cardmarket: 785992
+		cardmarket: 786019
 	}
 }
 

--- a/data/Scarlet & Violet/Stellar Crown/166.ts
+++ b/data/Scarlet & Violet/Stellar Crown/166.ts
@@ -36,7 +36,7 @@ const card: Card = {
 	illustrator: "Sanosuke Sakuma",
 
 	thirdParty: {
-		cardmarket: 785993
+		cardmarket: 786020
 	}
 }
 

--- a/data/Scarlet & Violet/Stellar Crown/167.ts
+++ b/data/Scarlet & Violet/Stellar Crown/167.ts
@@ -77,7 +77,7 @@ const card: Card = {
 	illustrator: "Teeziro",
 
 	thirdParty: {
-		cardmarket: 785867
+		cardmarket: 786021
 	}
 }
 

--- a/data/Scarlet & Violet/Stellar Crown/168.ts
+++ b/data/Scarlet & Violet/Stellar Crown/168.ts
@@ -77,7 +77,7 @@ const card: Card = {
 	illustrator: "MARINA Chikazawa",
 
 	thirdParty: {
-		cardmarket: 785905
+		cardmarket: 786022
 	}
 }
 

--- a/data/Scarlet & Violet/Stellar Crown/169.ts
+++ b/data/Scarlet & Violet/Stellar Crown/169.ts
@@ -77,7 +77,7 @@ const card: Card = {
 	illustrator: "Yuu Nishida",
 
 	thirdParty: {
-		cardmarket: 785921
+		cardmarket: 786023
 	}
 }
 

--- a/data/Scarlet & Violet/Stellar Crown/170.ts
+++ b/data/Scarlet & Violet/Stellar Crown/170.ts
@@ -77,7 +77,7 @@ const card: Card = {
 	illustrator: "Saboteri",
 
 	thirdParty: {
-		cardmarket: 785982
+		cardmarket: 786024
 	}
 }
 

--- a/data/Scarlet & Violet/Stellar Crown/171.ts
+++ b/data/Scarlet & Violet/Stellar Crown/171.ts
@@ -36,7 +36,7 @@ const card: Card = {
 	illustrator: "DOM",
 
 	thirdParty: {
-		cardmarket: 785986
+		cardmarket: 786025
 	}
 }
 

--- a/data/Scarlet & Violet/Stellar Crown/172.ts
+++ b/data/Scarlet & Violet/Stellar Crown/172.ts
@@ -36,7 +36,7 @@ const card: Card = {
 	illustrator: "Souichirou Gunjima",
 
 	thirdParty: {
-		cardmarket: 785993
+		cardmarket: 786026
 	}
 }
 

--- a/data/Scarlet & Violet/Stellar Crown/173.ts
+++ b/data/Scarlet & Violet/Stellar Crown/173.ts
@@ -77,7 +77,7 @@ const card: Card = {
 	illustrator: "5ban Graphics",
 
 	thirdParty: {
-		cardmarket: 785982
+		cardmarket: 786027
 	}
 }
 

--- a/data/Scarlet & Violet/Stellar Crown/174.ts
+++ b/data/Scarlet & Violet/Stellar Crown/174.ts
@@ -36,7 +36,7 @@ const card: Card = {
 	illustrator: "MARINA Chikazawa",
 
 	thirdParty: {
-		cardmarket: 785985
+		cardmarket: 786028
 	}
 }
 


### PR DESCRIPTION
Updated the 'cardmarket' thirdParty IDs for multiple cards in the Scarlet & Violet/Stellar Crown

