### PR TITLE
fix: Update Cardmarket IDs for Journey Together cards

### DIFF
--- a/data/Scarlet & Violet/Journey Together/142.ts
+++ b/data/Scarlet & Violet/Journey Together/142.ts
@@ -38,7 +38,11 @@ const card: Card = {
 		{
 			type: 'reverse'
 		},
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 817294
+	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Journey Together/144.ts
+++ b/data/Scarlet & Violet/Journey Together/144.ts
@@ -32,7 +32,7 @@ const card: Card = {
 	illustrator: "GOSSAN",
 
 	thirdParty: {
-		cardmarket: 817295
+		cardmarket: 817294
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/Journey Together/145.ts
+++ b/data/Scarlet & Violet/Journey Together/145.ts
@@ -32,7 +32,7 @@ const card: Card = {
 	illustrator: "GOSSAN",
 
 	thirdParty: {
-		cardmarket: 817295
+		cardmarket: 817297
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/Journey Together/160.ts
+++ b/data/Scarlet & Violet/Journey Together/160.ts
@@ -76,7 +76,7 @@ const card: Card = {
 	illustrator: "Ounishi",
 
 	thirdParty: {
-		cardmarket: 817160
+		cardmarket: 817312
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/Journey Together/161.ts
+++ b/data/Scarlet & Violet/Journey Together/161.ts
@@ -64,7 +64,7 @@ const card: Card = {
 	illustrator: "Kuroimori",
 
 	thirdParty: {
-		cardmarket: 817184
+		cardmarket: 817313
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/Journey Together/162.ts
+++ b/data/Scarlet & Violet/Journey Together/162.ts
@@ -52,7 +52,7 @@ const card: Card = {
 	illustrator: "Katsunori Sato",
 
 	thirdParty: {
-		cardmarket: 817193
+		cardmarket: 817314
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/Journey Together/163.ts
+++ b/data/Scarlet & Violet/Journey Together/163.ts
@@ -66,7 +66,7 @@ const card: Card = {
 	illustrator: "Terada Tera",
 
 	thirdParty: {
-		cardmarket: 817207
+		cardmarket: 817315
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/Journey Together/164.ts
+++ b/data/Scarlet & Violet/Journey Together/164.ts
@@ -66,7 +66,7 @@ const card: Card = {
 	illustrator: "saino misaki",
 
 	thirdParty: {
-		cardmarket: 817219
+		cardmarket: 817316
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/Journey Together/165.ts
+++ b/data/Scarlet & Violet/Journey Together/165.ts
@@ -64,7 +64,7 @@ const card: Card = {
 	illustrator: "Nakamura Ippan",
 
 	thirdParty: {
-		cardmarket: 817229
+		cardmarket: 817317
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/Journey Together/166.ts
+++ b/data/Scarlet & Violet/Journey Together/166.ts
@@ -76,7 +76,7 @@ const card: Card = {
 	illustrator: "GIDORA",
 
 	thirdParty: {
-		cardmarket: 817237
+		cardmarket: 817318
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/Journey Together/167.ts
+++ b/data/Scarlet & Violet/Journey Together/167.ts
@@ -66,7 +66,7 @@ const card: Card = {
 	illustrator: "Bun Toujo",
 
 	thirdParty: {
-		cardmarket: 817268
+		cardmarket: 817320
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/Journey Together/168.ts
+++ b/data/Scarlet & Violet/Journey Together/168.ts
@@ -56,7 +56,7 @@ const card: Card = {
 	illustrator: "REND",
 
 	thirdParty: {
-		cardmarket: 817271
+		cardmarket: 817321
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/Journey Together/169.ts
+++ b/data/Scarlet & Violet/Journey Together/169.ts
@@ -52,7 +52,7 @@ const card: Card = {
 	illustrator: "sowsow",
 
 	thirdParty: {
-		cardmarket: 817279
+		cardmarket: 817322
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/Journey Together/170.ts
+++ b/data/Scarlet & Violet/Journey Together/170.ts
@@ -42,7 +42,7 @@ const card: Card = {
 	illustrator: "MINAMINAMI Take",
 
 	thirdParty: {
-		cardmarket: 817287
+		cardmarket: 817323
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/Journey Together/171.ts
+++ b/data/Scarlet & Violet/Journey Together/171.ts
@@ -76,7 +76,7 @@ const card: Card = {
 	illustrator: "5ban Graphics",
 
 	thirdParty: {
-		cardmarket: 817183
+		cardmarket: 817324
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/Journey Together/172.ts
+++ b/data/Scarlet & Violet/Journey Together/172.ts
@@ -76,7 +76,7 @@ const card: Card = {
 	illustrator: "5ban Graphics",
 
 	thirdParty: {
-		cardmarket: 817205
+		cardmarket: 817325
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/Journey Together/173.ts
+++ b/data/Scarlet & Violet/Journey Together/173.ts
@@ -74,7 +74,7 @@ const card: Card = {
 	illustrator: "5ban Graphics",
 
 	thirdParty: {
-		cardmarket: 817208
+		cardmarket: 817326
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/Journey Together/174.ts
+++ b/data/Scarlet & Violet/Journey Together/174.ts
@@ -76,7 +76,7 @@ const card: Card = {
 	illustrator: "N-DESIGN Inc.",
 
 	thirdParty: {
-		cardmarket: 817231
+		cardmarket: 817327
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/Journey Together/175.ts
+++ b/data/Scarlet & Violet/Journey Together/175.ts
@@ -74,7 +74,7 @@ const card: Card = {
 	illustrator: "takuyoa",
 
 	thirdParty: {
-		cardmarket: 817250
+		cardmarket: 817328
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/Journey Together/176.ts
+++ b/data/Scarlet & Violet/Journey Together/176.ts
@@ -76,7 +76,7 @@ const card: Card = {
 	illustrator: "aky CG Works",
 
 	thirdParty: {
-		cardmarket: 817263
+		cardmarket: 817329
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/Journey Together/177.ts
+++ b/data/Scarlet & Violet/Journey Together/177.ts
@@ -74,7 +74,7 @@ const card: Card = {
 	illustrator: "5ban Graphics",
 
 	thirdParty: {
-		cardmarket: 817266
+		cardmarket: 817330
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/Journey Together/178.ts
+++ b/data/Scarlet & Violet/Journey Together/178.ts
@@ -76,7 +76,7 @@ const card: Card = {
 	illustrator: "5ban Graphics",
 
 	thirdParty: {
-		cardmarket: 817273
+		cardmarket: 817331
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/Journey Together/179.ts
+++ b/data/Scarlet & Violet/Journey Together/179.ts
@@ -32,7 +32,7 @@ const card: Card = {
 	illustrator: "Teeziro",
 
 	thirdParty: {
-		cardmarket: 817298
+		cardmarket: 817332
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/Journey Together/180.ts
+++ b/data/Scarlet & Violet/Journey Together/180.ts
@@ -32,7 +32,7 @@ const card: Card = {
 	illustrator: "yuu",
 
 	thirdParty: {
-		cardmarket: 817301
+		cardmarket: 817333
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/Journey Together/181.ts
+++ b/data/Scarlet & Violet/Journey Together/181.ts
@@ -32,7 +32,7 @@ const card: Card = {
 	illustrator: "Hideki Ishikawa",
 
 	thirdParty: {
-		cardmarket: 817309
+		cardmarket: 817334
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/Journey Together/182.ts
+++ b/data/Scarlet & Violet/Journey Together/182.ts
@@ -76,7 +76,7 @@ const card: Card = {
 	illustrator: "akagi",
 
 	thirdParty: {
-		cardmarket: 817183
+		cardmarket: 817335
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/Journey Together/183.ts
+++ b/data/Scarlet & Violet/Journey Together/183.ts
@@ -76,7 +76,7 @@ const card: Card = {
 	illustrator: "Yuu Nishida",
 
 	thirdParty: {
-		cardmarket: 817205
+		cardmarket: 817336
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/Journey Together/184.ts
+++ b/data/Scarlet & Violet/Journey Together/184.ts
@@ -72,7 +72,7 @@ const card: Card = {
 	illustrator: "Susumu Maeya",
 
 	thirdParty: {
-		cardmarket: 817208
+		cardmarket: 817337
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/Journey Together/185.ts
+++ b/data/Scarlet & Violet/Journey Together/185.ts
@@ -74,7 +74,7 @@ const card: Card = {
 	illustrator: "Megumi Mizutani",
 
 	thirdParty: {
-		cardmarket: 817250
+		cardmarket: 817338
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/Journey Together/186.ts
+++ b/data/Scarlet & Violet/Journey Together/186.ts
@@ -76,7 +76,7 @@ const card: Card = {
 	illustrator: "DOM",
 
 	thirdParty: {
-		cardmarket: 817263
+		cardmarket: 817339
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/Journey Together/187.ts
+++ b/data/Scarlet & Violet/Journey Together/187.ts
@@ -74,7 +74,7 @@ const card: Card = {
 	illustrator: "Tsuyoshi Nagano",
 
 	thirdParty: {
-		cardmarket: 817266
+		cardmarket: 817340
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/Journey Together/188.ts
+++ b/data/Scarlet & Violet/Journey Together/188.ts
@@ -76,7 +76,7 @@ const card: Card = {
 	illustrator: "5ban Graphics",
 
 	thirdParty: {
-		cardmarket: 817205
+		cardmarket: 817341
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/Journey Together/189.ts
+++ b/data/Scarlet & Violet/Journey Together/189.ts
@@ -74,7 +74,7 @@ const card: Card = {
 	illustrator: "takuyoa",
 
 	thirdParty: {
-		cardmarket: 817250
+		cardmarket: 817342
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/Journey Together/190.ts
+++ b/data/Scarlet & Violet/Journey Together/190.ts
@@ -31,7 +31,7 @@ const card: Card = {
 	regulationMark: "I",
 
 	thirdParty: {
-		cardmarket: 817311
+		cardmarket: 817343
 	},
 
 	variants: [


### PR DESCRIPTION
Corrected and updated the 'cardmarket' thirdParty IDs for cards 142 and 144-190 in the Scarlet & Violet/Journey Together



