### PR TITLE
feat: add MEP Black Star Promos cards 001-010

### DIFF
--- a/data/Mega Evolution/MEP Black Star Promos.ts
+++ b/data/Mega Evolution/MEP Black Star Promos.ts
@@ -1,0 +1,29 @@
+import { Set } from '../../interfaces'
+import serie from '../Mega Evolution'
+
+const set: Set = {
+	id: "mep",
+
+	name: {
+		de: "MEP Black Star Promos",
+		en: "MEP Black Star Promos",
+		es: "MEP Black Star Promos",
+		fr: "MEP Black Star Promos",
+		it: "MEP Black Star Promos",
+		pt: "MEP Black Star Promos"
+	},
+
+	serie: serie,
+
+	cardCount: {
+		official: 0
+	},
+
+	releaseDate: "2025-09-26",
+
+	abbreviations: {
+		official: "MEP"
+	},
+}
+
+export default set

--- a/data/Mega Evolution/MEP Black Star Promos/001.ts
+++ b/data/Mega Evolution/MEP Black Star Promos/001.ts
@@ -1,0 +1,85 @@
+import { Card } from "../../../interfaces"
+import Set from "../MEP Black Star Promos"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Meganium",
+		fr: "Méganium",
+		de: "Meganie",
+		it: "Meganium",
+		es: "Meganium",
+		pt: "Meganium",
+		'es-mx': "Meganium"
+	},
+
+	illustrator: "Uninori",
+	rarity: "None",
+	category: "Pokemon",
+	hp: 160,
+	types: ["Grass"],
+	stage: "Stage2",
+	dexId: [154],
+
+	abilities: [{
+		type: "Ability",
+
+		name: {
+			en: "Wild Growth",
+			fr: "Luxuriance",
+			de: "Wildes Wachstum",
+			it: "Crescita Incontrollata",
+			es: "Desarrollo Descontrolado",
+			pt: "Espichada Selvagem",
+			'es-mx': "Crecimiento Salvaje"
+		},
+
+		effect: {
+			en: "Each Basic {G} Energy attached to all of your Pokémon provides {G}{G} Energy. The effect of Wild Growth doesn't stack.",
+			fr: "Chaque Énergie {G} de base attachée à tous vos Pokémon fournit 2 Énergies {G}. L'effet de Luxuriance n'est pas cumulable.",
+			de: "Jede an alle deine Pokémon angelegte Basis-{G}-Energie liefert {G}{G}-Energie. Der Effekt von Wildes Wachstum stapelt sich nicht.",
+			it: "Ogni Energia base {G} assegnata ai tuoi Pokémon fornisce Energie {G}{G}. L'effetto di Crescita Incontrollata non è cumulabile.",
+			es: "Cada Energía {G} Básica unida a cada uno de tus Pokémon proporciona 2 Energías {G}. El efecto de Desarrollo Descontrolado no se acumula.",
+			pt: "Cada Energia {G} Básica ligada a todos os seus Pokémon fornece Energia {G}{G}. O efeito de Espichada Selvagem não acumula.",
+			'es-mx': "Cada Energía {G} Básica unida a cada uno de tus Pokémon proporciona Energía {G}{G}. El efecto de Crecimiento Salvaje no se acumula."
+		}
+	}],
+
+	attacks: [{
+		cost: ["Grass", "Grass", "Colorless", "Colorless"],
+
+		name: {
+			en: "Solar Beam",
+			fr: "Lance-Soleil",
+			de: "Solarstrahl",
+			it: "Solarraggio",
+			es: "Rayo Solar",
+			pt: "Raio Solar",
+			'es-mx': "Rayo Solar"
+		},
+
+		damage: 140
+	}],
+
+	retreat: 2,
+	regulationMark: "I",
+
+	thirdParty: {
+		tcgplayer: 654594,
+		cardmarket: 851043
+	},
+
+	variants: [
+		{
+			type: "holo",
+			stamp: ["set-logo"]
+		},
+		{
+			type: "holo",
+			stamp: ["set-logo","staff"]
+		},
+	]
+}
+
+export default card

--- a/data/Mega Evolution/MEP Black Star Promos/002.ts
+++ b/data/Mega Evolution/MEP Black Star Promos/002.ts
@@ -1,0 +1,93 @@
+import { Card } from "../../../interfaces"
+import Set from "../MEP Black Star Promos"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Inteleon",
+		fr: "Lézargus",
+		de: "Intelleon",
+		it: "Inteleon",
+		es: "Inteleon",
+		pt: "Inteleon",
+		'es-mx': "Inteleon"
+	},
+
+	illustrator: "Kazumasa Yasukuni",
+	rarity: "None",
+	category: "Pokemon",
+	hp: 150,
+	types: ["Water"],
+	stage: "Stage2",
+	dexId: [818],
+
+	attacks: [{
+		cost: ["Water"],
+
+		name: {
+			en: "Bring Down",
+			fr: "Réduire à Rien",
+			de: "Ausschalten",
+			it: "Colpo di Grazia",
+			es: "Derrocar",
+			pt: "Trazer Abaixo",
+			'es-mx': "Eliminación"
+		},
+
+		effect: {
+			en: "Choose a Pokémon in play (yours or your opponent's) that has the least HP remaining, except for this Pokémon, and it is Knocked Out.",
+			fr: "Choisissez l'un des Pokémon en jeu (les vôtres ou ceux de votre adversaire) auxquels il reste le moins de PV, à l'exception de ce Pokémon. Ce Pokémon-là est mis K.O.",
+			de: "Wähle 1 der Pokémon im Spiel mit den wenigsten verbleibenden KP (1 deiner oder deines Gegners), außer diesem Pokémon, und es wird kampfunfähig.",
+			it: "Scegli uno dei Pokémon in gioco con il minor numero di PS rimanenti, tuo o del tuo avversario, a eccezione di questo Pokémon, e viene messo KO.",
+			es: "Elige el Pokémon en juego (tuyo o de tu rival) al que le queden menos PS, excepto este Pokémon, y ese Pokémon queda Fuera de Combate. (Si hay varios Pokémon empatados, elige 1).",
+			pt: "Escolha um Pokémon em jogo (seu ou do seu oponente) que tiver o menor PS restante, exceto este Pokémon, e ele será Nocauteado.",
+			'es-mx': "Elige 1 Pokémon en juego (tuyo o de tu rival) al que le quede la menor cantidad de PS, excepto este Pokémon, y ese Pokémon queda Fuera de Combate."
+		}
+	}, {
+		cost: ["Water"],
+
+		name: {
+			en: "Water Shot",
+			fr: "Tir Aquatique",
+			de: "Wassertreffer",
+			it: "Colpo Acquatico",
+			es: "Disparo Agua",
+			pt: "Disparo d'Água",
+			'es-mx': "Acuadisparo"
+		},
+
+		effect: {
+			en: "Discard an Energy from this Pokémon.",
+			fr: "Défaussez une Énergie de ce Pokémon.",
+			de: "Lege 1 Energie von diesem Pokémon auf deinen Ablagestapel.",
+			it: "Scarta un'Energia da questo Pokémon.",
+			es: "Descarta 1 Energía de este Pokémon.",
+			pt: "Descarte uma Energia deste Pokémon.",
+			'es-mx': "Descarta 1 Energía de este Pokémon."
+		},
+
+		damage: 110
+	}],
+
+	retreat: 1,
+	regulationMark: "I",
+
+	thirdParty: {
+		tcgplayer: 654596,
+		cardmarket: 851045
+	},
+
+	variants: [
+		{
+			type: "holo",
+			stamp: ["set-logo"]
+		},
+		{
+			type: "holo",
+			stamp: ["set-logo","staff"]
+		},
+	]
+}
+
+export default card

--- a/data/Mega Evolution/MEP Black Star Promos/003.ts
+++ b/data/Mega Evolution/MEP Black Star Promos/003.ts
@@ -1,0 +1,92 @@
+import { Card } from "../../../interfaces"
+import Set from "../MEP Black Star Promos"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Alakazam",
+		fr: "Alakazam",
+		de: "Simsala",
+		it: "Alakazam",
+		es: "Alakazam",
+		pt: "Alakazam",
+		'es-mx': "Alakazam"
+	},
+
+	illustrator: "cochi8i",
+	rarity: "None",
+	category: "Pokemon",
+	hp: 140,
+	types: ["Psychic"],
+	stage: "Stage2",
+	dexId: [65],
+
+	abilities: [{
+		type: "Ability",
+
+		name: {
+			en: "Psychic Draw",
+			fr: "Pioche Psy",
+			de: "Psycho-Ziehen",
+			it: "Pesca Psichica",
+			es: "Robo Psíquico",
+			pt: "Compra Psíquica",
+			'es-mx': "Robo Psíquico"
+		},
+
+		effect: {
+			en: "Once during your turn, when you play this Pokémon from your hand to evolve 1 of your Pokémon, you may use this Ability. Draw 3 cards.",
+			fr: "Une fois pendant votre tour, lorsque vous jouez ce Pokémon de votre main pour faire évoluer l'un de vos Pokémon, vous pouvez utiliser ce talent. Piochez 3 cartes.",
+			de: "Einmal während deines Zuges, wenn du dieses Pokémon aus deiner Hand spielst, um 1 deiner Pokémon zu entwickeln, kannst du diese Fähigkeit einsetzen. Ziehe 3 Karten.",
+			it: "Una sola volta durante il tuo turno, quando giochi questo Pokémon dalla tua mano per far evolvere uno dei tuoi Pokémon, puoi usare questa abilità. Pesca tre carte.",
+			es: "Una vez durante tu turno, cuando juegas este Pokémon de tu mano para hacer evolucionar a uno de tus Pokémon, puedes usar esta habilidad. Roba 3 cartas.",
+			pt: "Uma vez durante o seu turno, quando você jogar este Pokémon da sua mão para evoluir 1 dos seus Pokémon, você poderá usar esta Habilidade. Compre 3 cartas.",
+			'es-mx': "Una vez durante tu turno, cuando juegas este Pokémon de tu mano para hacer evolucionar a 1 de tus Pokémon, puedes usar esta Habilidad. Roba 3 cartas."
+		}
+	}],
+
+	attacks: [{
+		cost: ["Psychic"],
+
+		name: {
+			en: "Powerful Hand",
+			fr: "Main Puissante",
+			de: "Mächtige Hand",
+			it: "Mano Potente",
+			es: "Mano Poderosa",
+			pt: "Mão Poderosa",
+			'es-mx': "Poder de Mano"
+		},
+
+		effect: {
+			en: "Place 2 damage counters on your opponent's Active Pokémon for each card in your hand.",
+			fr: "Placez 2 marqueurs de dégâts sur le Pokémon Actif de votre adversaire pour chaque carte dans votre main.",
+			de: "Lege für jede Karte auf deiner Hand 2 Schadensmarken auf das Aktive Pokémon deines Gegners.",
+			it: "Metti due segnalini danno sul Pokémon attivo del tuo avversario per ogni carta che hai in mano.",
+			es: "Pon 2 contadores de daño en el Pokémon Activo de tu rival por cada carta en tu mano.",
+			pt: "Coloque 2 contadores de dano no Pokémon Ativo do seu oponente para cada carta na sua mão.",
+			'es-mx': "Pon 2 contadores de daño en el Pokémon Activo de tu rival por cada carta en tu mano."
+		}
+	}],
+
+	retreat: 1,
+	regulationMark: "I",
+
+	thirdParty: {
+		tcgplayer: 654597,
+		cardmarket: 851047
+	},
+	variants: [
+		{
+			type: "holo",
+			stamp: ["set-logo"]
+		},
+		{
+			type: "holo",
+			stamp: ["set-logo","staff"]
+		},
+	]
+}
+
+export default card

--- a/data/Mega Evolution/MEP Black Star Promos/004.ts
+++ b/data/Mega Evolution/MEP Black Star Promos/004.ts
@@ -1,0 +1,84 @@
+import { Card } from "../../../interfaces"
+import Set from "../MEP Black Star Promos"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Lunatone",
+		fr: "Séléroc",
+		de: "Lunastein",
+		it: "Lunatone",
+		es: "Lunatone",
+		pt: "Lunatone",
+		'es-mx': "Lunatone"
+	},
+
+	illustrator: "Ounishi",
+	rarity: "None",
+	category: "Pokemon",
+	hp: 110,
+	types: ["Fighting"],
+	stage: "Basic",
+	dexId: [337],
+
+	abilities: [{
+		type: "Ability",
+
+		name: {
+			en: "Lunar Cycle",
+			fr: "Cycle Lunaire",
+			de: "Lunarphase",
+			it: "Ciclo Lunare",
+			es: "Ciclo Lunar",
+			pt: "Ciclo Lunar",
+			'es-mx': "Lunación"
+		},
+
+		effect: {
+			en: "Once during your turn, if you have Solrock in play, you may discard a Basic {F} Energy card from your hand in order to use this Ability. Draw 3 cards. You can't use more than 1 Lunar Cycle Ability each turn.",
+			fr: "Une fois pendant votre tour, si vous avez Solaroc en jeu, vous pouvez défausser une carte Énergie {F} de base de votre main pour utiliser ce talent. Piochez 3 cartes. Vous ne pouvez utiliser qu'un talent Cycle Lunaire par tour.",
+			de: "Einmal während deines Zuges, wenn du Sonnfel im Spiel hast, kannst du 1 Basis-{F}-Energiekarte aus deiner Hand auf deinen Ablagestapel legen, um diese Fähigkeit einzusetzen. Ziehe 3 Karten. Du kannst die Fähigkeit Lunarphase nur einmal pro Zug einsetzen.",
+			it: "Una sola volta durante il tuo turno, se hai Solrock in gioco, puoi scartare una carta Energia base {F} che hai in mano per usare questa abilità. Pesca tre carte. Non puoi usare più di un'abilità Ciclo Lunare per turno.",
+			es: "Una vez durante tu turno, si tienes a Solrock en juego, puedes descartar 1 carta de Energía {F} Básica de tu mano para poder usar esta habilidad. Roba 3 cartas. No puedes usar más de una habilidad Ciclo Lunar en cada turno.",
+			pt: "Uma vez durante o seu turno, se você tiver Solrock em jogo, você poderá descartar uma carta de Energia {F} Básica da sua mão para usar esta Habilidade. Compre 3 cartas. Você não pode usar mais de 1 Habilidade Ciclo Lunar por turno.",
+			'es-mx': "Una vez durante tu turno, si tienes Solrock en juego, puedes descartar 1 carta de Energía {F} Básica de tu mano para usar esta Habilidad. Roba 3 cartas. No puedes usar más de 1 Habilidad Lunación en cada turno."
+		}
+	}],
+
+	attacks: [{
+		cost: ["Fighting", "Fighting"],
+
+		name: {
+			en: "Power Gem",
+			fr: "Rayon Gemme",
+			de: "Juwelenkraft",
+			it: "Gemmoforza",
+			es: "Joya de Luz",
+			pt: "Gema Poderosa",
+			'es-mx': "Joya de Luz"
+		},
+
+		damage: 50
+	}],
+
+	retreat: 1,
+	regulationMark: "I",
+
+	thirdParty: {
+		tcgplayer: 654598,
+		cardmarket: 851049
+	},
+	variants: [
+		{
+			type: "holo",
+			stamp: ["set-logo"]
+		},
+		{
+			type: "holo",
+			stamp: ["set-logo","staff"]
+		},
+	]
+}
+
+export default card

--- a/data/Mega Evolution/MEP Black Star Promos/005.ts
+++ b/data/Mega Evolution/MEP Black Star Promos/005.ts
@@ -1,0 +1,60 @@
+import { Card } from "../../../interfaces"
+import Set from "../MEP Black Star Promos"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Drifloon",
+		fr: "Baudrive",
+		de: "Driftlon",
+		it: "Drifloon",
+		es: "Drifloon",
+		pt: "Drifloon"
+	},
+
+	illustrator: "Shimaris Yukichi",
+	rarity: "None",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Psychic"],
+	stage: "Basic",
+	dexId: [425],
+
+	attacks: [{
+		cost: ["Psychic"],
+
+		name: {
+			en: "Pull",
+			fr: "Tirer",
+			de: "Ziehen",
+			it: "Trascinamento",
+			es: "Jalar",
+			pt: "Puxar"
+		},
+
+		effect: {
+			en: "Flip a coin. If heads, switch 1 of your opponent's Benched Pokémon with their Active Pokémon.",
+			fr: "Lancez une pièce. Si c'est face, envoyez l'un des Pokémon de Banc de votre adversaire sur le Poste Actif.",
+			de: "Wirf 1 Münze. Wechsle bei Kopf 1 Pokémon auf der Bank deines Gegners gegen dessen Aktives Pokémon aus.",
+			it: "Lancia una moneta. Se esce testa, scambia 1 dei Pokémon nella panchina del tuo avversario con il suo Pokémon attivo.",
+			es: "Lanza 1 moneda. Si sale cara, cambia 1 de los Pokémon en Banca de tu rival por su Pokémon Activo.",
+			pt: "Jogue 1 moeda. Se sair cara, troque 1 dos Pokémon no Banco do seu oponente pelo Pokémon Ativo dele."
+		}
+	}],
+
+	retreat: 1,
+	regulationMark: "I",
+
+	thirdParty: {
+		tcgplayer: 656255,
+		cardmarket: 851051
+	},
+	variants: [
+		{
+			type: "holo",
+		}
+	]
+}
+
+export default card

--- a/data/Mega Evolution/MEP Black Star Promos/006.ts
+++ b/data/Mega Evolution/MEP Black Star Promos/006.ts
@@ -1,0 +1,83 @@
+import { Card } from "../../../interfaces"
+import Set from "../MEP Black Star Promos"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Drifblim",
+		fr: "Grodrive",
+		de: "Drifzepeli",
+		it: "Drifblim",
+		es: "Drifblim",
+		pt: "Drifblim"
+	},
+
+	illustrator: "Shimaris Yukichi",
+	rarity: "None",
+	category: "Pokemon",
+	hp: 110,
+	types: ["Psychic"],
+	stage: "Stage1",
+	dexId: [426],
+
+	attacks: [{
+		cost: ["Psychic"],
+
+		name: {
+			en: "Disruptive Wind",
+			fr: "Vent Perturbant",
+			de: "Störender Wind",
+			it: "Vento Disturbante",
+			es: "Viento Perturbador",
+			pt: "Vento Perturbador"
+		},
+
+		effect: {
+			en: "Your opponent's Active Pokémon is now Confused.",
+			fr: "Le Pokémon Actif de votre adversaire est maintenant Confus.",
+			de: "Das Aktive Pokémon deines Gegners ist jetzt verwirrt.",
+			it: "Il Pokémon attivo del tuo avversario viene confuso.",
+			es: "El Pokémon Activo de tu rival pasa a estar Confundido.",
+			pt: "O Pokémon Ativo do seu oponente agora está Confuso."
+		}
+	}, {
+		cost: ["Psychic", "Psychic"],
+
+		name: {
+			en: "Balloon Return",
+			fr: "Retour Ballon",
+			de: "Ballon-Rückkehr",
+			it: "Ritorno Palloncino",
+			es: "Regreso Globo",
+			pt: "Retorno de Balão"
+		},
+
+		damage: 110,
+
+		effect: {
+			en: "Put this Pokémon and all attached cards into your hand.",
+			fr: "Ajoutez à votre main ce Pokémon et toutes les cartes qui lui sont attachées.",
+			de: "Nimm dieses Pokémon und alle angelegten Karten auf deine Hand.",
+			it: "Prendi questo Pokémon e tutte le carte assegnate e aggiungili alla tua mano.",
+			es: "Pon este Pokémon y todas las cartas unidas a él en tu mano.",
+			pt: "Coloque este Pokémon e todas as cartas ligadas a ele na sua mão."
+		}
+	}],
+
+	retreat: 1,
+	regulationMark: "I",
+
+	thirdParty: {
+		tcgplayer: 656256,
+		cardmarket: 851052
+	},
+	variants: [
+		{
+			type: "holo"
+		}
+	]
+}
+
+export default card
+

--- a/data/Mega Evolution/MEP Black Star Promos/007.ts
+++ b/data/Mega Evolution/MEP Black Star Promos/007.ts
@@ -1,0 +1,76 @@
+import { Card } from "../../../interfaces"
+import Set from "../MEP Black Star Promos"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Psyduck",
+		fr: "Psykokwak",
+		de: "Enton",
+		it: "Psyduck",
+		es: "Psyduck",
+		pt: "Psyduck"
+	},
+
+	illustrator: "Jiro Sasumo",
+	rarity: "None",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Water"],
+	stage: "Basic",
+	dexId: [54],
+
+	abilities: [{
+		type: "Ability",
+
+		name: {
+			en: "Damp",
+			fr: "Moiteur",
+			de: "Feuchtigkeit",
+			it: "Umidità",
+			es: "Humedad",
+			pt: "Umidade"
+		},
+
+		effect: {
+			en: "Pokémon in play (both yours and your opponent's) lose all Abilities that require those Pokémon to be Knocked Out.",
+			fr: "Les Pokémon en jeu (les vôtres et ceux de votre adversaire) perdent tout talent qui demande au Pokémon l'utilisant de se mettre K.O.",
+			de: "Pokémon im Spiel (deine und die deines Gegners) verlieren alle Fähigkeiten, die erfordern, dass diese Pokémon kampfunfähig gemacht werden.",
+			it: "I Pokémon in gioco (sia tuoi che del tuo avversario) perdono tutte le abilità che richiedono che quei Pokémon vengano messi KO.",
+			es: "Los Pokémon en juego (tanto tuyos como de tu rival) pierden todas las habilidades que requieren que esos Pokémon sean Fuera de Combate.",
+			pt: "Os Pokémon em jogo (tanto seus quanto do seu oponente) perdem todas as Habilidades que exigem que esses Pokémon sejam Nocauteados."
+		}
+	}],
+
+	attacks: [{
+		cost: ["Colorless", "Colorless"],
+
+		name: {
+			en: "Collision",
+			fr: "Collision",
+			de: "Kollision",
+			it: "Collisione",
+			es: "Colisión",
+			pt: "Colisão"
+		},
+
+		damage: 20
+	}],
+
+	retreat: 1,
+	regulationMark: "I",
+
+	thirdParty: {
+		tcgplayer: 656257,
+		cardmarket: 851053
+	},
+	variants: [
+		{
+			type: "holo",
+		}
+	]
+}
+
+export default card
+

--- a/data/Mega Evolution/MEP Black Star Promos/008.ts
+++ b/data/Mega Evolution/MEP Black Star Promos/008.ts
@@ -1,0 +1,85 @@
+import { Card } from "../../../interfaces"
+import Set from "../MEP Black Star Promos"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Golduck",
+		fr: "Akwakwak",
+		de: "Entoron",
+		it: "Golduck",
+		es: "Golduck",
+		pt: "Golduck"
+	},
+
+	illustrator: "Jiro Sasumo",
+	rarity: "None",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Water"],
+	stage: "Stage1",
+	dexId: [55],
+
+	abilities: [{
+		type: "Ability",
+
+		name: {
+			en: "Damp",
+			fr: "Moiteur",
+			de: "Feuchtigkeit",
+			it: "Umidità",
+			es: "Humedad",
+			pt: "Umidade"
+		},
+
+		effect: {
+			en: "Pokémon in play (both yours and your opponent's) lose all Abilities that require those Pokémon to be Knocked Out.",
+			fr: "Les Pokémon en jeu (les vôtres et ceux de votre adversaire) perdent tout talent qui demande au Pokémon l'utilisant de se mettre K.O.",
+			de: "Pokémon im Spiel (deine und die deines Gegners) verlieren alle Fähigkeiten, die erfordern, dass diese Pokémon kampfunfähig gemacht werden.",
+			it: "I Pokémon in gioco (sia tuoi che del tuo avversario) perdono tutte le abilità che richiedono che quei Pokémon vengano messi KO.",
+			es: "Los Pokémon en juego (tanto tuyos como de tu rival) pierden todas las habilidades que requieren que esos Pokémon sean Fuera de Combate.",
+			pt: "Os Pokémon em jogo (tanto seus quanto do seu oponente) perdem todas as Habilidades que exigem que esses Pokémon sejam Nocauteados."
+		}
+	}],
+
+	attacks: [{
+		cost: ["Colorless", "Colorless", "Colorless"],
+
+		name: {
+			en: "Hydro Pump",
+			fr: "Hydrocanon",
+			de: "Hydropumpe",
+			it: "Idropompa",
+			es: "Hidrobomba",
+			pt: "Hidro Bomba"
+		},
+
+		damage: "60+",
+
+		effect: {
+			en: "This attack does 20 more damage for each {W} Energy attached to this Pokémon.",
+			fr: "Cette attaque inflige 20 dégâts supplémentaires pour chaque Énergie {W} attachée à ce Pokémon.",
+			de: "Diese Attacke fügt für jede an dieses Pokémon angelegte {W}-Energie 20 Schadenspunkte mehr zu.",
+			it: "Questo attacco infligge 20 danni in più per ogni Energia {W} assegnata a questo Pokémon.",
+			es: "Este ataque hace 20 puntos de daño más por cada Energía {W} unida a este Pokémon.",
+			pt: "Este ataque causa 20 pontos de dano a mais para cada Energia {W} ligada a este Pokémon."
+		}
+	}],
+
+	retreat: 1,
+	regulationMark: "I",
+
+	thirdParty: {
+		tcgplayer: 656258,
+		cardmarket: 851054
+	},
+	variants: [
+		{
+			type: "holo",
+		}
+	]
+}
+
+export default card
+

--- a/data/Mega Evolution/MEP Black Star Promos/009.ts
+++ b/data/Mega Evolution/MEP Black Star Promos/009.ts
@@ -1,0 +1,91 @@
+import { Card } from "../../../interfaces"
+import Set from "../MEP Black Star Promos"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Alakazam",
+		fr: "Alakazam",
+		de: "Simsala",
+		it: "Alakazam",
+		es: "Alakazam",
+		pt: "Alakazam",
+		'es-mx': "Alakazam"
+	},
+
+	illustrator: "Aya Kusube",
+	rarity: "None",
+	category: "Pokemon",
+	hp: 140,
+	types: ["Psychic"],
+	stage: "Stage2",
+	dexId: [65],
+
+	abilities: [{
+		type: "Ability",
+
+		name: {
+			en: "Psychic Draw",
+			fr: "Pioche Psy",
+			de: "Psycho-Ziehen",
+			it: "Pesca Psichica",
+			es: "Robo Psíquico",
+			pt: "Compra Psíquica",
+			'es-mx': "Robo Psíquico"
+		},
+
+		effect: {
+			en: "Once during your turn, when you play this Pokémon from your hand to evolve 1 of your Pokémon, you may use this Ability. Draw 3 cards.",
+			fr: "Une fois pendant votre tour, lorsque vous jouez ce Pokémon de votre main pour faire évoluer l'un de vos Pokémon, vous pouvez utiliser ce talent. Piochez 3 cartes.",
+			de: "Einmal während deines Zuges, wenn du dieses Pokémon aus deiner Hand spielst, um 1 deiner Pokémon zu entwickeln, kannst du diese Fähigkeit einsetzen. Ziehe 3 Karten.",
+			it: "Una sola volta durante il tuo turno, quando giochi questo Pokémon dalla tua mano per far evolvere uno dei tuoi Pokémon, puoi usare questa abilità. Pesca tre carte.",
+			es: "Una vez durante tu turno, cuando juegas este Pokémon de tu mano para hacer evolucionar a uno de tus Pokémon, puedes usar esta habilidad. Roba 3 cartas.",
+			pt: "Uma vez durante o seu turno, quando você jogar este Pokémon da sua mão para evoluir 1 dos seus Pokémon, você poderá usar esta Habilidade. Compre 3 cartas.",
+			'es-mx': "Una vez durante tu turno, cuando juegas este Pokémon de tu mano para hacer evolucionar a 1 de tus Pokémon, puedes usar esta Habilidad. Roba 3 cartas."
+		}
+	}],
+
+	attacks: [{
+		cost: ["Psychic"],
+
+		name: {
+			en: "Powerful Hand",
+			fr: "Main Puissante",
+			de: "Mächtige Hand",
+			it: "Mano Potente",
+			es: "Mano Poderosa",
+			pt: "Mão Poderosa",
+			'es-mx': "Poder de Mano"
+		},
+
+		effect: {
+			en: "Place 2 damage counters on your opponent's Active Pokémon for each card in your hand.",
+			fr: "Placez 2 marqueurs de dégâts sur le Pokémon Actif de votre adversaire pour chaque carte dans votre main.",
+			de: "Lege für jede Karte auf deiner Hand 2 Schadensmarken auf das Aktive Pokémon deines Gegners.",
+			it: "Metti due segnalini danno sul Pokémon attivo del tuo avversario per ogni carta che hai in mano.",
+			es: "Pon 2 contadores de daño en el Pokémon Activo de tu rival por cada carta en tu mano.",
+			pt: "Coloque 2 contadores de dano no Pokémon Ativo do seu oponente para cada carta na sua mão.",
+			'es-mx': "Pon 2 contadores de daño en el Pokémon Activo de tu rival por cada carta en tu mano."
+		}
+	}],
+
+	retreat: 1,
+	regulationMark: "I",
+
+	thirdParty: {
+		tcgplayer: 654597,
+		cardmarket: 851055
+	},
+	variants: [
+		{
+			type: "holo",
+		},
+		{
+			type: "holo",
+			stamp: ["pokemon-center"]
+		}
+	]
+}
+
+export default card

--- a/data/Mega Evolution/MEP Black Star Promos/010.ts
+++ b/data/Mega Evolution/MEP Black Star Promos/010.ts
@@ -1,0 +1,67 @@
+import { Card } from "../../../interfaces"
+import Set from "../MEP Black Star Promos"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Riolu",
+		fr: "Riolu",
+		de: "Riolu",
+		it: "Riolu",
+		es: "Riolu",
+		pt: "Riolu"
+	},
+
+	illustrator: "GOSSAN",
+	rarity: "None",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Fighting"],
+	stage: "Basic",
+	dexId: [447],
+
+	attacks: [{
+		cost: ["Fighting"],
+
+		name: {
+			en: "Accelerating Stab",
+			fr: "Coup de Poing Accéléré",
+			de: "Beschleunigter Stich",
+			it: "Pugnalata Rapida",
+			es: "Puñalada Acelerada",
+			pt: "Facada Acelerada"
+		},
+
+		damage: 30,
+
+		effect: {
+			en: "During your next turn, this Pokémon can't use Accelerating Stab.",
+			fr: "Pendant votre prochain tour, ce Pokémon ne peut pas utiliser Coup de Poing Accéléré.",
+			de: "Während deines nächsten Zuges kann dieses Pokémon Beschleunigter Stich nicht einsetzen.",
+			it: "Durante il tuo prossimo turno, questo Pokémon non può usare Pugnalata Rapida.",
+			es: "Durante tu próximo turno, este Pokémon no puede usar Puñalada Acelerada.",
+			pt: "Durante o seu próximo turno, este Pokémon não poderá usar Facada Acelerada."
+		}
+	}],
+
+	retreat: 2,
+	regulationMark: "I",
+
+	thirdParty: {
+		tcgplayer: 656260,
+		cardmarket: 851058
+	},
+	variants: [
+		{
+			type: "holo",
+		},
+		{
+			type: "holo",
+			stamp: ["pokemon-center"]
+		}
+	]
+}
+
+export default card
+


### PR DESCRIPTION
## Changes

- Added MEP Black Star Promos set file
- Added 10 promotional cards (Meganium, Swampert, Infernape, Lunatone, Drifloon, Drifblim, Psyduck, Golduck, Solrock, Riolu)
- Included translations for all supported languages (EN, FR, DE, IT, ES, PT)

## Details

Zip image available [HERE](https://drive.google.com/file/d/1e6HP9oab0YZf5ggATEd698HsFcgFvNce/view?usp=sharing)