### PR TITLE
fix: Add evolveFrom for Twilight Masquerade set

### DIFF
--- a/data/Scarlet & Violet/Twilight Masquerade/002.ts
+++ b/data/Scarlet & Violet/Twilight Masquerade/002.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 150,
 	types: ["Grass"],
+	evolveFrom: {
+		en: "Tangela",
+		fr: "Saquedeneu",
+		es: "Tangela",
+		it: "Tangela",
+		pt: "Tangela",
+		de: "Tangela"
+	},
 	stage: "Stage1",
 
 	abilities: [{

--- a/data/Scarlet & Violet/Twilight Masquerade/005.ts
+++ b/data/Scarlet & Violet/Twilight Masquerade/005.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 90,
 	types: ["Grass"],
+	evolveFrom: {
+		en: "Spinarak",
+		fr: "Mimigal",
+		es: "Spinarak",
+		it: "Spinarak",
+		pt: "Spinarak",
+		de: "Webarak"
+	},
 	stage: "Stage1",
 
 	abilities: [{

--- a/data/Scarlet & Violet/Twilight Masquerade/007.ts
+++ b/data/Scarlet & Violet/Twilight Masquerade/007.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 100,
 	types: ["Grass"],
+	evolveFrom: {
+		en: "Sunkern",
+		fr: "Tournegrin",
+		es: "Sunkern",
+		it: "Sunkern",
+		pt: "Sunkern",
+		de: "Sonnkern"
+	},
 	stage: "Stage1",
 
 	attacks: [{

--- a/data/Scarlet & Violet/Twilight Masquerade/011.ts
+++ b/data/Scarlet & Violet/Twilight Masquerade/011.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 120,
 	types: ["Grass"],
+	evolveFrom: {
+		en: "Eevee",
+		fr: "Évoli",
+		es: "Eevee",
+		it: "Eevee",
+		pt: "Eevee",
+		de: "Evoli"
+	},
 	stage: "Stage1",
 
 	attacks: [{

--- a/data/Scarlet & Violet/Twilight Masquerade/013.ts
+++ b/data/Scarlet & Violet/Twilight Masquerade/013.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 120,
 	types: ["Grass"],
+	evolveFrom: {
+		en: "Phantump",
+		fr: "Brocélôme",
+		es: "Phantump",
+		it: "Phantump",
+		pt: "Phantump",
+		de: "Paragoni"
+	},
 	stage: "Stage1",
 
 	attacks: [{

--- a/data/Scarlet & Violet/Twilight Masquerade/015.ts
+++ b/data/Scarlet & Violet/Twilight Masquerade/015.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 100,
 	types: ["Grass"],
+	evolveFrom: {
+		en: "Grookey",
+		fr: "Ouistempo",
+		es: "Grookey",
+		it: "Grookey",
+		pt: "Grookey",
+		de: "Chimpep"
+	},
 	stage: "Stage1",
 
 	abilities: [{

--- a/data/Scarlet & Violet/Twilight Masquerade/016.ts
+++ b/data/Scarlet & Violet/Twilight Masquerade/016.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 180,
 	types: ["Grass"],
+	evolveFrom: {
+		en: "Thwackey",
+		fr: "Badabouin",
+		es: "Thwackey",
+		it: "Thwackey",
+		pt: "Thwackey",
+		de: "Chimstix"
+	},
 	stage: "Stage2",
 
 	attacks: [{

--- a/data/Scarlet & Violet/Twilight Masquerade/018.ts
+++ b/data/Scarlet & Violet/Twilight Masquerade/018.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 80,
 	types: ["Grass"],
+	evolveFrom: {
+		en: "Applin",
+		fr: "Verpom",
+		es: "Applin",
+		it: "Applin",
+		pt: "Applin",
+		de: "Knapfel"
+	},
 	stage: "Stage1",
 
 	abilities: [{

--- a/data/Scarlet & Violet/Twilight Masquerade/022.ts
+++ b/data/Scarlet & Violet/Twilight Masquerade/022.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 70,
 	types: ["Grass"],
+	evolveFrom: {
+		en: "Poltchageist",
+		fr: "Poltchageist",
+		es: "Poltchageist",
+		it: "Poltchageist",
+		pt: "Poltchageist",
+		de: "Mortcha"
+	},
 	stage: "Stage1",
 
 	attacks: [{

--- a/data/Scarlet & Violet/Twilight Masquerade/023.ts
+++ b/data/Scarlet & Violet/Twilight Masquerade/023.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 240,
 	types: ["Grass"],
+	evolveFrom: {
+		en: "Poltchageist",
+		fr: "Poltchageist",
+		es: "Poltchageist",
+		it: "Poltchageist",
+		pt: "Poltchageist",
+		de: "Mortcha"
+	},
 	stage: "Stage1",
 
 	attacks: [{

--- a/data/Scarlet & Violet/Twilight Masquerade/027.ts
+++ b/data/Scarlet & Violet/Twilight Masquerade/027.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 120,
 	types: ["Fire"],
+	evolveFrom: {
+		en: "Vulpix",
+		fr: "Goupix",
+		es: "Vulpix",
+		it: "Vulpix",
+		pt: "Vulpix",
+		de: "Vulpix"
+	},
 	stage: "Stage1",
 
 	attacks: [{

--- a/data/Scarlet & Violet/Twilight Masquerade/029.ts
+++ b/data/Scarlet & Violet/Twilight Masquerade/029.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 270,
 	types: ["Fire"],
+	evolveFrom: {
+		en: "Slugma",
+		fr: "Limagma",
+		es: "Slugma",
+		it: "Slugma",
+		pt: "Slugma",
+		de: "Schneckmag"
+	},
 	stage: "Stage1",
 
 	attacks: [{

--- a/data/Scarlet & Violet/Twilight Masquerade/032.ts
+++ b/data/Scarlet & Violet/Twilight Masquerade/032.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 90,
 	types: ["Fire"],
+	evolveFrom: {
+		en: "Chimchar",
+		fr: "Ouisticram",
+		es: "Chimchar",
+		it: "Chimchar",
+		pt: "Chimchar",
+		de: "Panflam"
+	},
 	stage: "Stage1",
 
 	attacks: [{

--- a/data/Scarlet & Violet/Twilight Masquerade/033.ts
+++ b/data/Scarlet & Violet/Twilight Masquerade/033.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 140,
 	types: ["Fire"],
+	evolveFrom: {
+		en: "Monferno",
+		fr: "Chimpenfeu",
+		es: "Monferno",
+		it: "Monferno",
+		pt: "Monferno",
+		de: "Panpyro"
+	},
 	stage: "Stage2",
 
 	abilities: [{

--- a/data/Scarlet & Violet/Twilight Masquerade/035.ts
+++ b/data/Scarlet & Violet/Twilight Masquerade/035.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 140,
 	types: ["Fire"],
+	evolveFrom: {
+		en: "Darumaka",
+		fr: "Darumarond",
+		es: "Darumaka",
+		it: "Darumaka",
+		pt: "Darumaka",
+		de: "Flampion"
+	},
 	stage: "Stage1",
 
 	attacks: [{

--- a/data/Scarlet & Violet/Twilight Masquerade/037.ts
+++ b/data/Scarlet & Violet/Twilight Masquerade/037.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 80,
 	types: ["Fire"],
+	evolveFrom: {
+		en: "Litwick",
+		fr: "Funécire",
+		es: "Litwick",
+		it: "Litwick",
+		pt: "Litwick",
+		de: "Lichtel"
+	},
 	stage: "Stage1",
 
 	attacks: [{

--- a/data/Scarlet & Violet/Twilight Masquerade/038.ts
+++ b/data/Scarlet & Violet/Twilight Masquerade/038.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 130,
 	types: ["Fire"],
+	evolveFrom: {
+		en: "Lampent",
+		fr: "Mélancolux",
+		es: "Lampent",
+		it: "Lampent",
+		pt: "Lampent",
+		de: "Laternecto"
+	},
 	stage: "Stage2",
 
 	abilities: [{

--- a/data/Scarlet & Violet/Twilight Masquerade/042.ts
+++ b/data/Scarlet & Violet/Twilight Masquerade/042.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 100,
 	types: ["Water"],
+	evolveFrom: {
+		en: "Poliwag",
+		fr: "Ptitard",
+		es: "Poliwag",
+		it: "Poliwag",
+		pt: "Poliwag",
+		de: "Quapsel"
+	},
 	stage: "Stage1",
 
 	attacks: [{

--- a/data/Scarlet & Violet/Twilight Masquerade/043.ts
+++ b/data/Scarlet & Violet/Twilight Masquerade/043.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 170,
 	types: ["Water"],
+	evolveFrom: {
+		en: "Poliwhirl",
+		fr: "Têtarte",
+		es: "Poliwhirl",
+		it: "Poliwhirl",
+		pt: "Poliwhirl",
+		de: "Quaputzi"
+	},
 	stage: "Stage2",
 
 	attacks: [{

--- a/data/Scarlet & Violet/Twilight Masquerade/045.ts
+++ b/data/Scarlet & Violet/Twilight Masquerade/045.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 90,
 	types: ["Water"],
+	evolveFrom: {
+		en: "Goldeen",
+		fr: "Poissirène",
+		es: "Goldeen",
+		it: "Goldeen",
+		pt: "Goldeen",
+		de: "Goldini"
+	},
 	stage: "Stage1",
 
 	attacks: [{

--- a/data/Scarlet & Violet/Twilight Masquerade/048.ts
+++ b/data/Scarlet & Violet/Twilight Masquerade/048.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 130,
 	types: ["Water"],
+	evolveFrom: {
+		en: "Corphish",
+		fr: "Écrapince",
+		es: "Corphish",
+		it: "Corphish",
+		pt: "Corphish",
+		de: "Krebscorps"
+	},
 	stage: "Stage1",
 
 	attacks: [{

--- a/data/Scarlet & Violet/Twilight Masquerade/050.ts
+++ b/data/Scarlet & Violet/Twilight Masquerade/050.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 120,
 	types: ["Water"],
+	evolveFrom: {
+		en: "Feebas",
+		fr: "Barpau",
+		es: "Feebas",
+		it: "Feebas",
+		pt: "Feebas",
+		de: "Barschwa"
+	},
 	stage: "Stage1",
 
 	abilities: [{

--- a/data/Scarlet & Violet/Twilight Masquerade/052.ts
+++ b/data/Scarlet & Violet/Twilight Masquerade/052.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 120,
 	types: ["Water"],
+	evolveFrom: {
+		en: "Snorunt",
+		fr: "Stalgamin",
+		es: "Snorunt",
+		it: "Snorunt",
+		pt: "Snorunt",
+		de: "Schneppke"
+	},
 	stage: "Stage1",
 
 	attacks: [{

--- a/data/Scarlet & Violet/Twilight Masquerade/053.ts
+++ b/data/Scarlet & Violet/Twilight Masquerade/053.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 90,
 	types: ["Water"],
+	evolveFrom: {
+		en: "Snorunt",
+		fr: "Stalgamin",
+		es: "Snorunt",
+		it: "Snorunt",
+		pt: "Snorunt",
+		de: "Schneppke"
+	},
 	stage: "Stage1",
 
 	abilities: [{

--- a/data/Scarlet & Violet/Twilight Masquerade/054.ts
+++ b/data/Scarlet & Violet/Twilight Masquerade/054.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 120,
 	types: ["Water"],
+	evolveFrom: {
+		en: "Eevee",
+		fr: "Évoli",
+		es: "Eevee",
+		it: "Eevee",
+		pt: "Eevee",
+		de: "Evoli"
+	},
 	stage: "Stage1",
 
 	attacks: [{

--- a/data/Scarlet & Violet/Twilight Masquerade/057.ts
+++ b/data/Scarlet & Violet/Twilight Masquerade/057.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 90,
 	types: ["Water"],
+	evolveFrom: {
+		en: "Froakie",
+		fr: "Grenousse",
+		es: "Froakie",
+		it: "Froakie",
+		pt: "Froakie",
+		de: "Froxy"
+	},
 	stage: "Stage1",
 
 	attacks: [{

--- a/data/Scarlet & Violet/Twilight Masquerade/060.ts
+++ b/data/Scarlet & Violet/Twilight Masquerade/060.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 100,
 	types: ["Water"],
+	evolveFrom: {
+		en: "Finizen",
+		fr: "Dofin",
+		es: "Finizen",
+		it: "Finizen",
+		pt: "Finizen",
+		de: "Normifin"
+	},
 	stage: "Stage1",
 
 	abilities: [{

--- a/data/Scarlet & Violet/Twilight Masquerade/061.ts
+++ b/data/Scarlet & Violet/Twilight Masquerade/061.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 340,
 	types: ["Water"],
+	evolveFrom: {
+		en: "Finizen",
+		fr: "Dofin",
+		es: "Finizen",
+		it: "Finizen",
+		pt: "Finizen",
+		de: "Normifin"
+	},
 	stage: "Stage1",
 
 	abilities: [{

--- a/data/Scarlet & Violet/Twilight Masquerade/067.ts
+++ b/data/Scarlet & Violet/Twilight Masquerade/067.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 90,
 	types: ["Lightning"],
+	evolveFrom: {
+		en: "Shinx",
+		fr: "Lixy",
+		es: "Shinx",
+		it: "Shinx",
+		pt: "Shinx",
+		de: "Sheinux"
+	},
 	stage: "Stage1",
 
 	attacks: [{

--- a/data/Scarlet & Violet/Twilight Masquerade/068.ts
+++ b/data/Scarlet & Violet/Twilight Masquerade/068.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 310,
 	types: ["Lightning"],
+	evolveFrom: {
+		en: "Luxio",
+		fr: "Luxio",
+		es: "Luxio",
+		it: "Luxio",
+		pt: "Luxio",
+		de: "Luxio"
+	},
 	stage: "Stage2",
 
 	attacks: [{

--- a/data/Scarlet & Violet/Twilight Masquerade/071.ts
+++ b/data/Scarlet & Violet/Twilight Masquerade/071.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 100,
 	types: ["Lightning"],
+	evolveFrom: {
+		en: "Helioptile",
+		fr: "Galvaran",
+		es: "Helioptile",
+		it: "Helioptile",
+		pt: "Helioptile",
+		de: "Eguana"
+	},
 	stage: "Stage1",
 
 	attacks: [{

--- a/data/Scarlet & Violet/Twilight Masquerade/074.ts
+++ b/data/Scarlet & Violet/Twilight Masquerade/074.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 140,
 	types: ["Lightning"],
+	evolveFrom: {
+		en: "Tadbulb",
+		fr: "Têtampoule",
+		es: "Tadbulb",
+		it: "Tadbulb",
+		pt: "Tadbulb",
+		de: "Blipp"
+	},
 	stage: "Stage1",
 
 	attacks: [{

--- a/data/Scarlet & Violet/Twilight Masquerade/076.ts
+++ b/data/Scarlet & Violet/Twilight Masquerade/076.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 120,
 	types: ["Lightning"],
+	evolveFrom: {
+		en: "Wattrel",
+		fr: "Zapétrel",
+		es: "Wattrel",
+		it: "Wattrel",
+		pt: "Wattrel",
+		de: "Voltrel"
+	},
 	stage: "Stage1",
 
 	attacks: [{

--- a/data/Scarlet & Violet/Twilight Masquerade/079.ts
+++ b/data/Scarlet & Violet/Twilight Masquerade/079.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 120,
 	types: ["Psychic"],
+	evolveFrom: {
+		en: "Clefairy",
+		fr: "Mélofée",
+		es: "Clefairy",
+		it: "Clefairy",
+		pt: "Clefairy",
+		de: "Piepi"
+	},
 	stage: "Stage1",
 
 	attacks: [{

--- a/data/Scarlet & Violet/Twilight Masquerade/081.ts
+++ b/data/Scarlet & Violet/Twilight Masquerade/081.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 80,
 	types: ["Psychic"],
+	evolveFrom: {
+		en: "Abra",
+		fr: "Abra",
+		es: "Abra",
+		it: "Abra",
+		pt: "Abra",
+		de: "Abra"
+	},
 	stage: "Stage1",
 
 	attacks: [{

--- a/data/Scarlet & Violet/Twilight Masquerade/082.ts
+++ b/data/Scarlet & Violet/Twilight Masquerade/082.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 140,
 	types: ["Psychic"],
+	evolveFrom: {
+		en: "Kadabra",
+		fr: "Kadabra",
+		es: "Kadabra",
+		it: "Kadabra",
+		pt: "Kadabra",
+		de: "Kadabra"
+	},
 	stage: "Stage2",
 
 	attacks: [{

--- a/data/Scarlet & Violet/Twilight Masquerade/084.ts
+++ b/data/Scarlet & Violet/Twilight Masquerade/084.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 140,
 	types: ["Psychic"],
+	evolveFrom: {
+		en: "Girafarig",
+		fr: "Girafarig",
+		es: "Girafarig",
+		it: "Girafarig",
+		pt: "Girafarig",
+		de: "Girafarig"
+	},
 	stage: "Stage1",
 
 	attacks: [{

--- a/data/Scarlet & Violet/Twilight Masquerade/087.ts
+++ b/data/Scarlet & Violet/Twilight Masquerade/087.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 70,
 	types: ["Psychic"],
+	evolveFrom: {
+		en: "Flabébé",
+		fr: "Flabébé",
+		es: "Flabébé",
+		it: "Flabébé",
+		pt: "Flabébé",
+		de: "Flabébé"
+	},
 	stage: "Stage1",
 
 	attacks: [{

--- a/data/Scarlet & Violet/Twilight Masquerade/088.ts
+++ b/data/Scarlet & Violet/Twilight Masquerade/088.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 140,
 	types: ["Psychic"],
+	evolveFrom: {
+		en: "Floette",
+		fr: "Floette",
+		es: "Floette",
+		it: "Floette",
+		pt: "Floette",
+		de: "Floette"
+	},
 	stage: "Stage2",
 
 	abilities: [{

--- a/data/Scarlet & Violet/Twilight Masquerade/090.ts
+++ b/data/Scarlet & Violet/Twilight Masquerade/090.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 120,
 	types: ["Psychic"],
+	evolveFrom: {
+		en: "Swirlix",
+		fr: "Sucroquin",
+		es: "Swirlix",
+		it: "Swirlix",
+		pt: "Swirlix",
+		de: "Flauschling"
+	},
 	stage: "Stage1",
 
 	attacks: [{

--- a/data/Scarlet & Violet/Twilight Masquerade/092.ts
+++ b/data/Scarlet & Violet/Twilight Masquerade/092.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 150,
 	types: ["Psychic"],
+	evolveFrom: {
+		en: "Sandygast",
+		fr: "Bacabouh",
+		es: "Sandygast",
+		it: "Sandygast",
+		pt: "Sandygast",
+		de: "Sankabuh"
+	},
 	stage: "Stage1",
 
 	attacks: [{

--- a/data/Scarlet & Violet/Twilight Masquerade/098.ts
+++ b/data/Scarlet & Violet/Twilight Masquerade/098.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 120,
 	types: ["Fighting"],
+	evolveFrom: {
+		en: "Sandshrew",
+		fr: "Sabelette",
+		es: "Sandshrew",
+		it: "Sandshrew",
+		pt: "Sandshrew",
+		de: "Sandan"
+	},
 	stage: "Stage1",
 
 	attacks: [{

--- a/data/Scarlet & Violet/Twilight Masquerade/100.ts
+++ b/data/Scarlet & Violet/Twilight Masquerade/100.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 130,
 	types: ["Fighting"],
+	evolveFrom: {
+		en: "Hisuian Growlithe",
+		fr: "Caninos de Hisui",
+		es: "Growlithe de Hisui",
+		it: "Growlithe di Hisui",
+		pt: "Growlithe de Hisui",
+		de: "Hisui-Fukano"
+	},
 	stage: "Stage1",
 
 	attacks: [{

--- a/data/Scarlet & Violet/Twilight Masquerade/102.ts
+++ b/data/Scarlet & Violet/Twilight Masquerade/102.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 140,
 	types: ["Fighting"],
+	evolveFrom: {
+		en: "Nosepass",
+		fr: "Tarinor",
+		es: "Nosepass",
+		it: "Nosepass",
+		pt: "Nosepass",
+		de: "Nasgnet"
+	},
 	stage: "Stage1",
 
 	attacks: [{

--- a/data/Scarlet & Violet/Twilight Masquerade/104.ts
+++ b/data/Scarlet & Violet/Twilight Masquerade/104.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 100,
 	types: ["Fighting"],
+	evolveFrom: {
+		en: "Timburr",
+		fr: "Charpenti",
+		es: "Timburr",
+		it: "Timburr",
+		pt: "Timburr",
+		de: "Praktibalk"
+	},
 	stage: "Stage1",
 
 	attacks: [{

--- a/data/Scarlet & Violet/Twilight Masquerade/105.ts
+++ b/data/Scarlet & Violet/Twilight Masquerade/105.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 180,
 	types: ["Fighting"],
+	evolveFrom: {
+		en: "Gurdurr",
+		fr: "Ouvrifier",
+		es: "Gurdurr",
+		it: "Gurdurr",
+		pt: "Gurdurr",
+		de: "Strepoli"
+	},
 	stage: "Stage2",
 
 	attacks: [{

--- a/data/Scarlet & Violet/Twilight Masquerade/106.ts
+++ b/data/Scarlet & Violet/Twilight Masquerade/106.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 310,
 	types: ["Fighting"],
+	evolveFrom: {
+		en: "Frogadier",
+		fr: "Croâporal",
+		es: "Frogadier",
+		it: "Frogadier",
+		pt: "Frogadier",
+		de: "Amphizel"
+	},
 	stage: "Stage2",
 
 	attacks: [{

--- a/data/Scarlet & Violet/Twilight Masquerade/109.ts
+++ b/data/Scarlet & Violet/Twilight Masquerade/109.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 130,
 	types: ["Fighting"],
+	evolveFrom: {
+		en: "Glimmet",
+		fr: "Germéclat",
+		es: "Glimmet",
+		it: "Glimmet",
+		pt: "Glimmet",
+		de: "Lumispross"
+	},
 	stage: "Stage1",
 
 	attacks: [{

--- a/data/Scarlet & Violet/Twilight Masquerade/114.ts
+++ b/data/Scarlet & Violet/Twilight Masquerade/114.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 120,
 	types: ["Darkness"],
+	evolveFrom: {
+		en: "Poochyena",
+		fr: "Medhyèna",
+		es: "Poochyena",
+		it: "Poochyena",
+		pt: "Poochyena",
+		de: "Fiffyen"
+	},
 	stage: "Stage1",
 
 	attacks: [{

--- a/data/Scarlet & Violet/Twilight Masquerade/116.ts
+++ b/data/Scarlet & Violet/Twilight Masquerade/116.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 100,
 	types: ["Darkness"],
+	evolveFrom: {
+		en: "Venipede",
+		fr: "Venipatte",
+		es: "Venipede",
+		it: "Venipede",
+		pt: "Venipede",
+		de: "Toxiped"
+	},
 	stage: "Stage1",
 
 	attacks: [{

--- a/data/Scarlet & Violet/Twilight Masquerade/117.ts
+++ b/data/Scarlet & Violet/Twilight Masquerade/117.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 170,
 	types: ["Darkness"],
+	evolveFrom: {
+		en: "Whirlipede",
+		fr: "Scobolide",
+		es: "Whirlipede",
+		it: "Whirlipede",
+		pt: "Whirlipede",
+		de: "Rollum"
+	},
 	stage: "Stage2",
 
 	attacks: [{

--- a/data/Scarlet & Violet/Twilight Masquerade/121.ts
+++ b/data/Scarlet & Violet/Twilight Masquerade/121.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 110,
 	types: ["Metal"],
+	evolveFrom: {
+		en: "Aron",
+		fr: "Galekid",
+		es: "Aron",
+		it: "Aron",
+		pt: "Aron",
+		de: "Stollunior"
+	},
 	stage: "Stage1",
 
 	attacks: [{

--- a/data/Scarlet & Violet/Twilight Masquerade/122.ts
+++ b/data/Scarlet & Violet/Twilight Masquerade/122.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 180,
 	types: ["Metal"],
+	evolveFrom: {
+		en: "Lairon",
+		fr: "Galegon",
+		es: "Lairon",
+		it: "Lairon",
+		pt: "Lairon",
+		de: "Stollrak"
+	},
 	stage: "Stage2",
 
 	attacks: [{

--- a/data/Scarlet & Violet/Twilight Masquerade/125.ts
+++ b/data/Scarlet & Violet/Twilight Masquerade/125.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 140,
 	types: ["Metal"],
+	evolveFrom: {
+		en: "Varoom",
+		fr: "Vrombi",
+		es: "Varoom",
+		it: "Varoom",
+		pt: "Varoom",
+		de: "Knattox"
+	},
 	stage: "Stage1",
 
 	attacks: [{

--- a/data/Scarlet & Violet/Twilight Masquerade/127.ts
+++ b/data/Scarlet & Violet/Twilight Masquerade/127.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 80,
 	types: ["Dragon"],
+	evolveFrom: {
+		en: "Applin",
+		fr: "Verpom",
+		es: "Applin",
+		it: "Applin",
+		pt: "Applin",
+		de: "Knapfel"
+	},
 	stage: "Stage1",
 
 	attacks: [{

--- a/data/Scarlet & Violet/Twilight Masquerade/129.ts
+++ b/data/Scarlet & Violet/Twilight Masquerade/129.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 90,
 	types: ["Dragon"],
+	evolveFrom: {
+		en: "Dreepy",
+		fr: "Fantyrm",
+		es: "Dreepy",
+		it: "Dreepy",
+		pt: "Dreepy",
+		de: "Grolldra"
+	},
 	stage: "Stage1",
 
 	abilities: [{

--- a/data/Scarlet & Violet/Twilight Masquerade/130.ts
+++ b/data/Scarlet & Violet/Twilight Masquerade/130.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 320,
 	types: ["Dragon"],
+	evolveFrom: {
+		en: "Drakloak",
+		fr: "Dispareptil",
+		es: "Drakloak",
+		it: "Drakloak",
+		pt: "Drakloak",
+		de: "Phandra"
+	},
 	stage: "Stage2",
 
 	attacks: [{

--- a/data/Scarlet & Violet/Twilight Masquerade/134.ts
+++ b/data/Scarlet & Violet/Twilight Masquerade/134.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 300,
 	types: ["Colorless"],
+	evolveFrom: {
+		en: "Chansey",
+		fr: "Leveinard",
+		es: "Chansey",
+		it: "Chansey",
+		pt: "Chansey",
+		de: "Chaneira"
+	},
 	stage: "Stage1",
 
 	abilities: [{

--- a/data/Scarlet & Violet/Twilight Masquerade/138.ts
+++ b/data/Scarlet & Violet/Twilight Masquerade/138.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 110,
 	types: ["Colorless"],
+	evolveFrom: {
+		en: "Aipom",
+		fr: "Capumain",
+		es: "Aipom",
+		it: "Aipom",
+		pt: "Aipom",
+		de: "Griffel"
+	},
 	stage: "Stage1",
 
 	abilities: [{

--- a/data/Scarlet & Violet/Twilight Masquerade/140.ts
+++ b/data/Scarlet & Violet/Twilight Masquerade/140.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 110,
 	types: ["Colorless"],
+	evolveFrom: {
+		en: "Ducklett",
+		fr: "Couaneton",
+		es: "Ducklett",
+		it: "Ducklett",
+		pt: "Ducklett",
+		de: "Piccolente"
+	},
 	stage: "Stage1",
 
 	attacks: [{

--- a/data/Scarlet & Violet/Twilight Masquerade/169.ts
+++ b/data/Scarlet & Violet/Twilight Masquerade/169.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 100,
 	types: ["Grass"],
+	evolveFrom: {
+		en: "Sunkern",
+		fr: "Tournegrin",
+		es: "Sunkern",
+		it: "Sunkern",
+		pt: "Sunkern",
+		de: "Sonnkern"
+	},
 	stage: "Stage1",
 
 	attacks: [{

--- a/data/Scarlet & Violet/Twilight Masquerade/170.ts
+++ b/data/Scarlet & Violet/Twilight Masquerade/170.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 80,
 	types: ["Grass"],
+	evolveFrom: {
+		en: "Applin",
+		fr: "Verpom",
+		es: "Applin",
+		it: "Applin",
+		pt: "Applin",
+		de: "Knapfel"
+	},
 	stage: "Stage1",
 
 	abilities: [{

--- a/data/Scarlet & Violet/Twilight Masquerade/173.ts
+++ b/data/Scarlet & Violet/Twilight Masquerade/173.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 140,
 	types: ["Fire"],
+	evolveFrom: {
+		en: "Monferno",
+		fr: "Chimpenfeu",
+		es: "Monferno",
+		it: "Monferno",
+		pt: "Monferno",
+		de: "Panpyro"
+	},
 	stage: "Stage2",
 
 	abilities: [{

--- a/data/Scarlet & Violet/Twilight Masquerade/174.ts
+++ b/data/Scarlet & Violet/Twilight Masquerade/174.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 90,
 	types: ["Water"],
+	evolveFrom: {
+		en: "Snorunt",
+		fr: "Stalgamin",
+		es: "Snorunt",
+		it: "Snorunt",
+		pt: "Snorunt",
+		de: "Schneppke"
+	},
 	stage: "Stage1",
 
 	abilities: [{

--- a/data/Scarlet & Violet/Twilight Masquerade/177.ts
+++ b/data/Scarlet & Violet/Twilight Masquerade/177.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 100,
 	types: ["Lightning"],
+	evolveFrom: {
+		en: "Helioptile",
+		fr: "Galvaran",
+		es: "Helioptile",
+		it: "Helioptile",
+		pt: "Helioptile",
+		de: "Eguana"
+	},
 	stage: "Stage1",
 
 	attacks: [{

--- a/data/Scarlet & Violet/Twilight Masquerade/182.ts
+++ b/data/Scarlet & Violet/Twilight Masquerade/182.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 140,
 	types: ["Fighting"],
+	evolveFrom: {
+		en: "Nosepass",
+		fr: "Tarinor",
+		es: "Nosepass",
+		it: "Nosepass",
+		pt: "Nosepass",
+		de: "Nasgnet"
+	},
 	stage: "Stage1",
 
 	attacks: [{

--- a/data/Scarlet & Violet/Twilight Masquerade/184.ts
+++ b/data/Scarlet & Violet/Twilight Masquerade/184.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 110,
 	types: ["Metal"],
+	evolveFrom: {
+		en: "Aron",
+		fr: "Galekid",
+		es: "Aron",
+		it: "Aron",
+		pt: "Aron",
+		de: "Stollunior"
+	},
 	stage: "Stage1",
 
 	attacks: [{

--- a/data/Scarlet & Violet/Twilight Masquerade/189.ts
+++ b/data/Scarlet & Violet/Twilight Masquerade/189.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 240,
 	types: ["Grass"],
+	evolveFrom: {
+		en: "Poltchageist",
+		fr: "Poltchageist",
+		es: "Poltchageist",
+		it: "Poltchageist",
+		pt: "Poltchageist",
+		de: "Mortcha"
+	},
 	stage: "Stage1",
 
 	attacks: [{

--- a/data/Scarlet & Violet/Twilight Masquerade/191.ts
+++ b/data/Scarlet & Violet/Twilight Masquerade/191.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 270,
 	types: ["Fire"],
+	evolveFrom: {
+		en: "Slugma",
+		fr: "Limagma",
+		es: "Slugma",
+		it: "Slugma",
+		pt: "Slugma",
+		de: "Schneckmag"
+	},
 	stage: "Stage1",
 
 	attacks: [{

--- a/data/Scarlet & Violet/Twilight Masquerade/193.ts
+++ b/data/Scarlet & Violet/Twilight Masquerade/193.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 340,
 	types: ["Water"],
+	evolveFrom: {
+		en: "Finizen",
+		fr: "Dofin",
+		es: "Finizen",
+		it: "Finizen",
+		pt: "Finizen",
+		de: "Normifin"
+	},
 	stage: "Stage1",
 
 	abilities: [{

--- a/data/Scarlet & Violet/Twilight Masquerade/195.ts
+++ b/data/Scarlet & Violet/Twilight Masquerade/195.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 310,
 	types: ["Lightning"],
+	evolveFrom: {
+		en: "Luxio",
+		fr: "Luxio",
+		es: "Luxio",
+		it: "Luxio",
+		pt: "Luxio",
+		de: "Luxio"
+	},
 	stage: "Stage2",
 
 	attacks: [{

--- a/data/Scarlet & Violet/Twilight Masquerade/198.ts
+++ b/data/Scarlet & Violet/Twilight Masquerade/198.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 310,
 	types: ["Fighting"],
+	evolveFrom: {
+		en: "Frogadier",
+		fr: "Croâporal",
+		es: "Frogadier",
+		it: "Frogadier",
+		pt: "Frogadier",
+		de: "Amphizel"
+	},
 	stage: "Stage2",
 
 	attacks: [{

--- a/data/Scarlet & Violet/Twilight Masquerade/200.ts
+++ b/data/Scarlet & Violet/Twilight Masquerade/200.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 320,
 	types: ["Dragon"],
+	evolveFrom: {
+		en: "Drakloak",
+		fr: "Dispareptil",
+		es: "Drakloak",
+		it: "Drakloak",
+		pt: "Drakloak",
+		de: "Phandra"
+	},
 	stage: "Stage2",
 
 	attacks: [{

--- a/data/Scarlet & Violet/Twilight Masquerade/201.ts
+++ b/data/Scarlet & Violet/Twilight Masquerade/201.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 300,
 	types: ["Colorless"],
+	evolveFrom: {
+		en: "Chansey",
+		fr: "Leveinard",
+		es: "Chansey",
+		it: "Chansey",
+		pt: "Chansey",
+		de: "Chaneira"
+	},
 	stage: "Stage1",
 
 	abilities: [{

--- a/data/Scarlet & Violet/Twilight Masquerade/210.ts
+++ b/data/Scarlet & Violet/Twilight Masquerade/210.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 240,
 	types: ["Grass"],
+	evolveFrom: {
+		en: "Poltchageist",
+		fr: "Poltchageist",
+		es: "Poltchageist",
+		it: "Poltchageist",
+		pt: "Poltchageist",
+		de: "Mortcha"
+	},
 	stage: "Stage1",
 
 	attacks: [{

--- a/data/Scarlet & Violet/Twilight Masquerade/214.ts
+++ b/data/Scarlet & Violet/Twilight Masquerade/214.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 310,
 	types: ["Fighting"],
+	evolveFrom: {
+		en: "Frogadier",
+		fr: "Croâporal",
+		es: "Frogadier",
+		it: "Frogadier",
+		pt: "Frogadier",
+		de: "Amphizel"
+	},
 	stage: "Stage2",
 
 	attacks: [{


### PR DESCRIPTION
Add the "evolveFrom" field to multiple cards in the Twilight Masquerade set