### PR TITLE
fix: Add evolveFrom for Paradox Rift set

### DIFF
--- a/data/Scarlet & Violet/Paradox Rift/002.ts
+++ b/data/Scarlet & Violet/Paradox Rift/002.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 100,
 	types: ["Grass"],
+	evolveFrom: {
+		en: "Surskit",
+		fr: "Arakdo",
+		es: "Surskit",
+		it: "Surskit",
+		pt: "Surskit",
+		de: "Gehweiher"
+	},
 	stage: "Stage1",
 
 	attacks: [{

--- a/data/Scarlet & Violet/Paradox Rift/003.ts
+++ b/data/Scarlet & Violet/Paradox Rift/003.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 250,
 	types: ["Grass"],
+	evolveFrom: {
+		en: "Snorunt",
+		fr: "Stalgamin",
+		es: "Snorunt",
+		it: "Snorunt",
+		pt: "Snorunt",
+		de: "Schneppke"
+	},
 	stage: "Stage1",
 
 	abilities: [{

--- a/data/Scarlet & Violet/Paradox Rift/005.ts
+++ b/data/Scarlet & Violet/Paradox Rift/005.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 100,
 	types: ["Grass"],
+	evolveFrom: {
+		en: "Pansage",
+		fr: "Feuillajou",
+		es: "Pansage",
+		it: "Pansage",
+		pt: "Pansage",
+		de: "Vegimak"
+	},
 	stage: "Stage1",
 
 	abilities: [{

--- a/data/Scarlet & Violet/Paradox Rift/007.ts
+++ b/data/Scarlet & Violet/Paradox Rift/007.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 130,
 	types: ["Grass"],
+	evolveFrom: {
+		en: "Dwebble",
+		fr: "Crabicoque",
+		es: "Dwebble",
+		it: "Dwebble",
+		pt: "Dwebble",
+		de: "Lithomith"
+	},
 	stage: "Stage1",
 
 	attacks: [{

--- a/data/Scarlet & Violet/Paradox Rift/009.ts
+++ b/data/Scarlet & Violet/Paradox Rift/009.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 90,
 	types: ["Grass"],
+	evolveFrom: {
+		en: "Bounsweet",
+		fr: "Croquine",
+		es: "Bounsweet",
+		it: "Bounsweet",
+		pt: "Bounsweet",
+		de: "Frubberl"
+	},
 	stage: "Stage1",
 
 	attacks: [{

--- a/data/Scarlet & Violet/Paradox Rift/011.ts
+++ b/data/Scarlet & Violet/Paradox Rift/011.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 80,
 	types: ["Grass"],
+	evolveFrom: {
+		en: "Blipbug",
+		fr: "Larvadar",
+		es: "Blipbug",
+		it: "Blipbug",
+		pt: "Blipbug",
+		de: "Sensect"
+	},
 	stage: "Stage1",
 
 	attacks: [{

--- a/data/Scarlet & Violet/Paradox Rift/012.ts
+++ b/data/Scarlet & Violet/Paradox Rift/012.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 130,
 	types: ["Grass"],
+	evolveFrom: {
+		en: "Dottler",
+		fr: "Coléodôme",
+		es: "Dottler",
+		it: "Dottler",
+		pt: "Dottler",
+		de: "Keradar"
+	},
 	stage: "Stage2",
 
 	attacks: [{

--- a/data/Scarlet & Violet/Paradox Rift/017.ts
+++ b/data/Scarlet & Violet/Paradox Rift/017.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 120,
 	types: ["Grass"],
+	evolveFrom: {
+		en: "Toedscool",
+		fr: "Terracool",
+		es: "Toedscool",
+		it: "Toedscool",
+		pt: "Toedscool",
+		de: "Tentagra"
+	},
 	stage: "Stage1",
 
 	abilities: [{

--- a/data/Scarlet & Violet/Paradox Rift/021.ts
+++ b/data/Scarlet & Violet/Paradox Rift/021.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 100,
 	types: ["Fire"],
+	evolveFrom: {
+		en: "Pansear",
+		fr: "Flamajou",
+		es: "Pansear",
+		it: "Pansear",
+		pt: "Pansear",
+		de: "Grillmak"
+	},
 	stage: "Stage1",
 
 	abilities: [{

--- a/data/Scarlet & Violet/Paradox Rift/024.ts
+++ b/data/Scarlet & Violet/Paradox Rift/024.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 100,
 	types: ["Fire"],
+	evolveFrom: {
+		en: "Fuecoco",
+		fr: "Chochodile",
+		es: "Fuecoco",
+		it: "Fuecoco",
+		pt: "Fuecoco",
+		de: "Krokel"
+	},
 	stage: "Stage1",
 
 	attacks: [{

--- a/data/Scarlet & Violet/Paradox Rift/027.ts
+++ b/data/Scarlet & Violet/Paradox Rift/027.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 260,
 	types: ["Fire"],
+	evolveFrom: {
+		en: "Charcadet",
+		fr: "Charbambin",
+		es: "Charcadet",
+		it: "Charcadet",
+		pt: "Charcadet",
+		de: "Knarbon"
+	},
 	stage: "Stage1",
 
 	abilities: [{

--- a/data/Scarlet & Violet/Paradox Rift/031.ts
+++ b/data/Scarlet & Violet/Paradox Rift/031.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 90,
 	types: ["Water"],
+	evolveFrom: {
+		en: "Horsea",
+		fr: "Hypotrempe",
+		es: "Horsea",
+		it: "Horsea",
+		pt: "Horsea",
+		de: "Seeper"
+	},
 	stage: "Stage1",
 
 	attacks: [{

--- a/data/Scarlet & Violet/Paradox Rift/032.ts
+++ b/data/Scarlet & Violet/Paradox Rift/032.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 150,
 	types: ["Water"],
+	evolveFrom: {
+		en: "Seadra",
+		fr: "Hypocéan",
+		es: "Seadra",
+		it: "Seadra",
+		pt: "Seadra",
+		de: "Seemon"
+	},
 	stage: "Stage2",
 
 	attacks: [{

--- a/data/Scarlet & Violet/Paradox Rift/034.ts
+++ b/data/Scarlet & Violet/Paradox Rift/034.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 110,
 	types: ["Water"],
+	evolveFrom: {
+		en: "Remoraid",
+		fr: "Rémoraid",
+		es: "Remoraid",
+		it: "Remoraid",
+		pt: "Remoraid",
+		de: "Remoraid"
+	},
 	stage: "Stage1",
 
 	abilities: [{

--- a/data/Scarlet & Violet/Paradox Rift/036.ts
+++ b/data/Scarlet & Violet/Paradox Rift/036.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 120,
 	types: ["Water"],
+	evolveFrom: {
+		en: "Feebas",
+		fr: "Barpau",
+		es: "Feebas",
+		it: "Feebas",
+		pt: "Feebas",
+		de: "Barschwa"
+	},
 	stage: "Stage1",
 
 	abilities: [{

--- a/data/Scarlet & Violet/Paradox Rift/038.ts
+++ b/data/Scarlet & Violet/Paradox Rift/038.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 320,
 	types: ["Water"],
+	evolveFrom: {
+		en: "Gabite",
+		fr: "Carmache",
+		es: "Gabite",
+		it: "Gabite",
+		pt: "Gabite",
+		de: "Knarksel"
+	},
 	stage: "Stage2",
 
 	attacks: [{

--- a/data/Scarlet & Violet/Paradox Rift/042.ts
+++ b/data/Scarlet & Violet/Paradox Rift/042.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 100,
 	types: ["Water"],
+	evolveFrom: {
+		en: "Panpour",
+		fr: "Flotajou",
+		es: "Panpour",
+		it: "Panpour",
+		pt: "Panpour",
+		de: "Sodamak"
+	},
 	stage: "Stage1",
 
 	abilities: [{

--- a/data/Scarlet & Violet/Paradox Rift/044.ts
+++ b/data/Scarlet & Violet/Paradox Rift/044.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 90,
 	types: ["Water"],
+	evolveFrom: {
+		en: "Vanillite",
+		fr: "Sorbébé",
+		es: "Vanillite",
+		it: "Vanillite",
+		pt: "Vanillite",
+		de: "Gelatini"
+	},
 	stage: "Stage1",
 
 	attacks: [{

--- a/data/Scarlet & Violet/Paradox Rift/045.ts
+++ b/data/Scarlet & Violet/Paradox Rift/045.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 150,
 	types: ["Water"],
+	evolveFrom: {
+		en: "Vanillish",
+		fr: "Sorboul",
+		es: "Vanillish",
+		it: "Vanillish",
+		pt: "Vanillish",
+		de: "Gelatroppo"
+	},
 	stage: "Stage2",
 
 	abilities: [{

--- a/data/Scarlet & Violet/Paradox Rift/046.ts
+++ b/data/Scarlet & Violet/Paradox Rift/046.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 310,
 	types: ["Water"],
+	evolveFrom: {
+		en: "Steenee",
+		fr: "Candine",
+		es: "Steenee",
+		it: "Steenee",
+		pt: "Steenee",
+		de: "Frubaila"
+	},
 	stage: "Stage2",
 
 	attacks: [{

--- a/data/Scarlet & Violet/Paradox Rift/049.ts
+++ b/data/Scarlet & Violet/Paradox Rift/049.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 140,
 	types: ["Water"],
+	evolveFrom: {
+		en: "Wimpod",
+		fr: "Sovkipou",
+		es: "Wimpod",
+		it: "Wimpod",
+		pt: "Wimpod",
+		de: "Reißlaus"
+	},
 	stage: "Stage1",
 
 	attacks: [{

--- a/data/Scarlet & Violet/Paradox Rift/050.ts
+++ b/data/Scarlet & Violet/Paradox Rift/050.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 270,
 	types: ["Water"],
+	evolveFrom: {
+		en: "Wimpod",
+		fr: "Sovkipou",
+		es: "Wimpod",
+		it: "Wimpod",
+		pt: "Wimpod",
+		de: "Reißlaus"
+	},
 	stage: "Stage1",
 
 	attacks: [{

--- a/data/Scarlet & Violet/Paradox Rift/053.ts
+++ b/data/Scarlet & Violet/Paradox Rift/053.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 90,
 	types: ["Water"],
+	evolveFrom: {
+		en: "Wiglett",
+		fr: "Taupikeau",
+		es: "Wiglett",
+		it: "Wiglett",
+		pt: "Wiglett",
+		de: "Schligda"
+	},
 	stage: "Stage1",
 
 	abilities: [{

--- a/data/Scarlet & Violet/Paradox Rift/063.ts
+++ b/data/Scarlet & Violet/Paradox Rift/063.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 120,
 	types: ["Lightning"],
+	evolveFrom: {
+		en: "Blitzle",
+		fr: "Zébibron",
+		es: "Blitzle",
+		it: "Blitzle",
+		pt: "Blitzle",
+		de: "Elezeba"
+	},
 	stage: "Stage1",
 
 	attacks: [{

--- a/data/Scarlet & Violet/Paradox Rift/065.ts
+++ b/data/Scarlet & Violet/Paradox Rift/065.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 100,
 	types: ["Lightning"],
+	evolveFrom: {
+		en: "Joltik",
+		fr: "Statitik",
+		es: "Joltik",
+		it: "Joltik",
+		pt: "Joltik",
+		de: "Wattzapf"
+	},
 	stage: "Stage1",
 
 	attacks: [{

--- a/data/Scarlet & Violet/Paradox Rift/072.ts
+++ b/data/Scarlet & Violet/Paradox Rift/072.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 100,
 	types: ["Psychic"],
+	evolveFrom: {
+		en: "Natu",
+		fr: "Natu",
+		es: "Natu",
+		it: "Natu",
+		pt: "Natu",
+		de: "Natu"
+	},
 	stage: "Stage1",
 
 	abilities: [{

--- a/data/Scarlet & Violet/Paradox Rift/076.ts
+++ b/data/Scarlet & Violet/Paradox Rift/076.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 260,
 	types: ["Psychic"],
+	evolveFrom: {
+		en: "Yamask",
+		fr: "Tutafeh",
+		es: "Yamask",
+		it: "Yamask",
+		pt: "Yamask",
+		de: "Makabaja"
+	},
 	stage: "Stage1",
 
 	abilities: [{

--- a/data/Scarlet & Violet/Paradox Rift/078.ts
+++ b/data/Scarlet & Violet/Paradox Rift/078.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 110,
 	types: ["Psychic"],
+	evolveFrom: {
+		en: "Pumpkaboo",
+		fr: "Pitrouille",
+		es: "Pumpkaboo",
+		it: "Pumpkaboo",
+		pt: "Pumpkaboo",
+		de: "Irrbis"
+	},
 	stage: "Stage1",
 
 	abilities: [{

--- a/data/Scarlet & Violet/Paradox Rift/081.ts
+++ b/data/Scarlet & Violet/Paradox Rift/081.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 120,
 	types: ["Psychic"],
+	evolveFrom: {
+		en: "Flittle",
+		fr: "Flotillon",
+		es: "Flittle",
+		it: "Flittle",
+		pt: "Flittle",
+		de: "Flattutu"
+	},
 	stage: "Stage1",
 
 	abilities: [{

--- a/data/Scarlet & Violet/Paradox Rift/084.ts
+++ b/data/Scarlet & Violet/Paradox Rift/084.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 80,
 	types: ["Psychic"],
+	evolveFrom: {
+		en: "Tinkatink",
+		fr: "Forgerette",
+		es: "Tinkatink",
+		it: "Tinkatink",
+		pt: "Tinkatink",
+		de: "Forgita"
+	},
 	stage: "Stage1",
 
 	attacks: [{

--- a/data/Scarlet & Violet/Paradox Rift/085.ts
+++ b/data/Scarlet & Violet/Paradox Rift/085.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 130,
 	types: ["Psychic"],
+	evolveFrom: {
+		en: "Tinkatuff",
+		fr: "Forgella",
+		es: "Tinkatuff",
+		it: "Tinkatuff",
+		pt: "Tinkatuff",
+		de: "Tafforgita"
+	},
 	stage: "Stage2",
 
 	attacks: [{

--- a/data/Scarlet & Violet/Paradox Rift/092.ts
+++ b/data/Scarlet & Violet/Paradox Rift/092.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 120,
 	types: ["Fighting"],
+	evolveFrom: {
+		en: "Gligar",
+		fr: "Scorplane",
+		es: "Gligar",
+		it: "Gligar",
+		pt: "Gligar",
+		de: "Skorgla"
+	},
 	stage: "Stage1",
 
 	attacks: [{

--- a/data/Scarlet & Violet/Paradox Rift/095.ts
+++ b/data/Scarlet & Violet/Paradox Rift/095.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 100,
 	types: ["Fighting"],
+	evolveFrom: {
+		en: "Gible",
+		fr: "Griknot",
+		es: "Gible",
+		it: "Gible",
+		pt: "Gible",
+		de: "Kaumalat"
+	},
 	stage: "Stage1",
 
 	attacks: [{

--- a/data/Scarlet & Violet/Paradox Rift/097.ts
+++ b/data/Scarlet & Violet/Paradox Rift/097.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 100,
 	types: ["Fighting"],
+	evolveFrom: {
+		en: "Mienfoo",
+		fr: "Kungfouine",
+		es: "Mienfoo",
+		it: "Mienfoo",
+		pt: "Mienfoo",
+		de: "Lin-Fu"
+	},
 	stage: "Stage1",
 
 	attacks: [{

--- a/data/Scarlet & Violet/Paradox Rift/100.ts
+++ b/data/Scarlet & Violet/Paradox Rift/100.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 260,
 	types: ["Fighting"],
+	evolveFrom: {
+		en: "Toxel",
+		fr: "Toxizap",
+		es: "Toxel",
+		it: "Toxel",
+		pt: "Toxel",
+		de: "Toxel"
+	},
 	stage: "Stage1",
 
 	attacks: [{

--- a/data/Scarlet & Violet/Paradox Rift/103.ts
+++ b/data/Scarlet & Violet/Paradox Rift/103.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 100,
 	types: ["Fighting"],
+	evolveFrom: {
+		en: "Nacli",
+		fr: "Selutin",
+		es: "Nacli",
+		it: "Nacli",
+		pt: "Nacli",
+		de: "Geosali"
+	},
 	stage: "Stage1",
 
 	attacks: [{

--- a/data/Scarlet & Violet/Paradox Rift/104.ts
+++ b/data/Scarlet & Violet/Paradox Rift/104.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 160,
 	types: ["Fighting"],
+	evolveFrom: {
+		en: "Naclstack",
+		fr: "Amassel",
+		es: "Naclstack",
+		it: "Naclstack",
+		pt: "Naclstack",
+		de: "Sedisal"
+	},
 	stage: "Stage2",
 
 	abilities: [{

--- a/data/Scarlet & Violet/Paradox Rift/111.ts
+++ b/data/Scarlet & Violet/Paradox Rift/111.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 80,
 	types: ["Darkness"],
+	evolveFrom: {
+		en: "Zubat",
+		fr: "Nosferapti",
+		es: "Zubat",
+		it: "Zubat",
+		pt: "Zubat",
+		de: "Zubat"
+	},
 	stage: "Stage1",
 
 	attacks: [{

--- a/data/Scarlet & Violet/Paradox Rift/112.ts
+++ b/data/Scarlet & Violet/Paradox Rift/112.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 130,
 	types: ["Darkness"],
+	evolveFrom: {
+		en: "Golbat",
+		fr: "Nosferalto",
+		es: "Golbat",
+		it: "Golbat",
+		pt: "Golbat",
+		de: "Golbat"
+	},
 	stage: "Stage2",
 
 	attacks: [{

--- a/data/Scarlet & Violet/Paradox Rift/115.ts
+++ b/data/Scarlet & Violet/Paradox Rift/115.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 100,
 	types: ["Darkness"],
+	evolveFrom: {
+		en: "Purrloin",
+		fr: "Chacripan",
+		es: "Purrloin",
+		it: "Purrloin",
+		pt: "Purrloin",
+		de: "Felilou"
+	},
 	stage: "Stage1",
 
 	attacks: [{

--- a/data/Scarlet & Violet/Paradox Rift/117.ts
+++ b/data/Scarlet & Violet/Paradox Rift/117.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 120,
 	types: ["Darkness"],
+	evolveFrom: {
+		en: "Trubbish",
+		fr: "Miamiasme",
+		es: "Trubbish",
+		it: "Trubbish",
+		pt: "Trubbish",
+		de: "Unratütox"
+	},
 	stage: "Stage1",
 
 	attacks: [{

--- a/data/Scarlet & Violet/Paradox Rift/120.ts
+++ b/data/Scarlet & Violet/Paradox Rift/120.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 110,
 	types: ["Darkness"],
+	evolveFrom: {
+		en: "Nickit",
+		fr: "Goupilou",
+		es: "Nickit",
+		it: "Nickit",
+		pt: "Nickit",
+		de: "Kleptifux"
+	},
 	stage: "Stage1",
 
 	abilities: [{

--- a/data/Scarlet & Violet/Paradox Rift/122.ts
+++ b/data/Scarlet & Violet/Paradox Rift/122.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 120,
 	types: ["Darkness"],
+	evolveFrom: {
+		en: "Nymble",
+		fr: "Lilliterelle",
+		es: "Nymble",
+		it: "Nymble",
+		pt: "Nymble",
+		de: "Micrick"
+	},
 	stage: "Stage1",
 
 	attacks: [{

--- a/data/Scarlet & Violet/Paradox Rift/125.ts
+++ b/data/Scarlet & Violet/Paradox Rift/125.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 180,
 	types: ["Metal"],
+	evolveFrom: {
+		en: "Onix",
+		fr: "Onix",
+		es: "Onix",
+		it: "Onix",
+		pt: "Onix",
+		de: "Onix"
+	},
 	stage: "Stage1",
 
 	attacks: [{

--- a/data/Scarlet & Violet/Paradox Rift/128.ts
+++ b/data/Scarlet & Violet/Paradox Rift/128.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 140,
 	types: ["Metal"],
+	evolveFrom: {
+		en: "Ferroseed",
+		fr: "Grindur",
+		es: "Ferroseed",
+		it: "Ferroseed",
+		pt: "Ferroseed",
+		de: "Kastadur"
+	},
 	stage: "Stage1",
 
 	abilities: [{

--- a/data/Scarlet & Violet/Paradox Rift/132.ts
+++ b/data/Scarlet & Violet/Paradox Rift/132.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 90,
 	types: ["Metal"],
+	evolveFrom: {
+		en: "Honedge",
+		fr: "Monorpale",
+		es: "Honedge",
+		it: "Honedge",
+		pt: "Honedge",
+		de: "Gramokles"
+	},
 	stage: "Stage1",
 
 	attacks: [{

--- a/data/Scarlet & Violet/Paradox Rift/133.ts
+++ b/data/Scarlet & Violet/Paradox Rift/133.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 90,
 	types: ["Metal"],
+	evolveFrom: {
+		en: "Honedge",
+		fr: "Monorpale",
+		es: "Honedge",
+		it: "Honedge",
+		pt: "Honedge",
+		de: "Gramokles"
+	},
 	stage: "Stage1",
 
 	attacks: [{

--- a/data/Scarlet & Violet/Paradox Rift/134.ts
+++ b/data/Scarlet & Violet/Paradox Rift/134.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 150,
 	types: ["Metal"],
+	evolveFrom: {
+		en: "Doublade",
+		fr: "Dimoclès",
+		es: "Doublade",
+		it: "Doublade",
+		pt: "Doublade",
+		de: "Duokles"
+	},
 	stage: "Stage2",
 
 	abilities: [{

--- a/data/Scarlet & Violet/Paradox Rift/135.ts
+++ b/data/Scarlet & Violet/Paradox Rift/135.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 330,
 	types: ["Metal"],
+	evolveFrom: {
+		en: "Doublade",
+		fr: "Dimoclès",
+		es: "Doublade",
+		it: "Doublade",
+		pt: "Doublade",
+		de: "Duokles"
+	},
 	stage: "Stage2",
 
 	attacks: [{

--- a/data/Scarlet & Violet/Paradox Rift/137.ts
+++ b/data/Scarlet & Violet/Paradox Rift/137.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 330,
 	types: ["Metal"],
+	evolveFrom: {
+		en: "Crocalor",
+		fr: "Crocogril",
+		es: "Crocalor",
+		it: "Crocalor",
+		pt: "Crocalor",
+		de: "Lokroko"
+	},
 	stage: "Stage2",
 
 	abilities: [{

--- a/data/Scarlet & Violet/Paradox Rift/139.ts
+++ b/data/Scarlet & Violet/Paradox Rift/139.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 260,
 	types: ["Metal"],
+	evolveFrom: {
+		en: "Gimmighoul",
+		fr: "Mordudor",
+		es: "Gimmighoul",
+		it: "Gimmighoul",
+		pt: "Gimmighoul",
+		de: "Gierspenst"
+	},
 	stage: "Stage1",
 
 	abilities: [{

--- a/data/Scarlet & Violet/Paradox Rift/140.ts
+++ b/data/Scarlet & Violet/Paradox Rift/140.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 260,
 	types: ["Dragon"],
+	evolveFrom: {
+		en: "Swablu",
+		fr: "Tylton",
+		es: "Swablu",
+		it: "Swablu",
+		pt: "Swablu",
+		de: "Wablu"
+	},
 	stage: "Stage1",
 
 	abilities: [{

--- a/data/Scarlet & Violet/Paradox Rift/143.ts
+++ b/data/Scarlet & Violet/Paradox Rift/143.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 90,
 	types: ["Colorless"],
+	evolveFrom: {
+		en: "Porygon",
+		fr: "Porygon",
+		es: "Porygon",
+		it: "Porygon",
+		pt: "Porygon",
+		de: "Porygon"
+	},
 	stage: "Stage1",
 
 	attacks: [{

--- a/data/Scarlet & Violet/Paradox Rift/144.ts
+++ b/data/Scarlet & Violet/Paradox Rift/144.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 150,
 	types: ["Colorless"],
+	evolveFrom: {
+		en: "Porygon2",
+		fr: "Porygon2",
+		es: "Porygon2",
+		it: "Porygon2",
+		pt: "Porygon2",
+		de: "Porygon2"
+	},
 	stage: "Stage2",
 
 	abilities: [{

--- a/data/Scarlet & Violet/Paradox Rift/146.ts
+++ b/data/Scarlet & Violet/Paradox Rift/146.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 100,
 	types: ["Colorless"],
+	evolveFrom: {
+		en: "Aipom",
+		fr: "Capumain",
+		es: "Aipom",
+		it: "Aipom",
+		pt: "Aipom",
+		de: "Griffel"
+	},
 	stage: "Stage1",
 
 	attacks: [{

--- a/data/Scarlet & Violet/Paradox Rift/149.ts
+++ b/data/Scarlet & Violet/Paradox Rift/149.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 100,
 	types: ["Colorless"],
+	evolveFrom: {
+		en: "Whismur",
+		fr: "Chuchmur",
+		es: "Whismur",
+		it: "Whismur",
+		pt: "Whismur",
+		de: "Flurmel"
+	},
 	stage: "Stage1",
 
 	attacks: [{

--- a/data/Scarlet & Violet/Paradox Rift/150.ts
+++ b/data/Scarlet & Violet/Paradox Rift/150.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 160,
 	types: ["Colorless"],
+	evolveFrom: {
+		en: "Loudred",
+		fr: "Ramboum",
+		es: "Loudred",
+		it: "Loudred",
+		pt: "Loudred",
+		de: "Krakeelo"
+	},
 	stage: "Stage2",
 
 	attacks: [{

--- a/data/Scarlet & Violet/Paradox Rift/155.ts
+++ b/data/Scarlet & Violet/Paradox Rift/155.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 230,
 	types: ["Colorless"],
+	evolveFrom: {
+		en: "Tandemaus",
+		fr: "Compagnol",
+		es: "Tandemaus",
+		it: "Tandemaus",
+		pt: "Tandemaus",
+		de: "Zwieps"
+	},
 	stage: "Stage1",
 
 	abilities: [{

--- a/data/Scarlet & Violet/Paradox Rift/183.ts
+++ b/data/Scarlet & Violet/Paradox Rift/183.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 130,
 	types: ["Grass"],
+	evolveFrom: {
+		en: "Dwebble",
+		fr: "Crabicoque",
+		es: "Dwebble",
+		it: "Dwebble",
+		pt: "Dwebble",
+		de: "Lithomith"
+	},
 	stage: "Stage1",
 
 	attacks: [{

--- a/data/Scarlet & Violet/Paradox Rift/184.ts
+++ b/data/Scarlet & Violet/Paradox Rift/184.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 80,
 	types: ["Grass"],
+	evolveFrom: {
+		en: "Blipbug",
+		fr: "Larvadar",
+		es: "Blipbug",
+		it: "Blipbug",
+		pt: "Blipbug",
+		de: "Sensect"
+	},
 	stage: "Stage1",
 
 	attacks: [{

--- a/data/Scarlet & Violet/Paradox Rift/185.ts
+++ b/data/Scarlet & Violet/Paradox Rift/185.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 120,
 	types: ["Grass"],
+	evolveFrom: {
+		en: "Toedscool",
+		fr: "Terracool",
+		es: "Toedscool",
+		it: "Toedscool",
+		pt: "Toedscool",
+		de: "Tentagra"
+	},
 	stage: "Stage1",
 
 	abilities: [{

--- a/data/Scarlet & Violet/Paradox Rift/190.ts
+++ b/data/Scarlet & Violet/Paradox Rift/190.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 90,
 	types: ["Water"],
+	evolveFrom: {
+		en: "Vanillite",
+		fr: "Sorbébé",
+		es: "Vanillite",
+		it: "Vanillite",
+		pt: "Vanillite",
+		de: "Gelatini"
+	},
 	stage: "Stage1",
 
 	attacks: [{

--- a/data/Scarlet & Violet/Paradox Rift/197.ts
+++ b/data/Scarlet & Violet/Paradox Rift/197.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 120,
 	types: ["Psychic"],
+	evolveFrom: {
+		en: "Flittle",
+		fr: "Flotillon",
+		es: "Flittle",
+		it: "Flittle",
+		pt: "Flittle",
+		de: "Flattutu"
+	},
 	stage: "Stage1",
 
 	abilities: [{

--- a/data/Scarlet & Violet/Paradox Rift/200.ts
+++ b/data/Scarlet & Violet/Paradox Rift/200.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 100,
 	types: ["Fighting"],
+	evolveFrom: {
+		en: "Mienfoo",
+		fr: "Kungfouine",
+		es: "Mienfoo",
+		it: "Mienfoo",
+		pt: "Mienfoo",
+		de: "Lin-Fu"
+	},
 	stage: "Stage1",
 
 	attacks: [{

--- a/data/Scarlet & Violet/Paradox Rift/202.ts
+++ b/data/Scarlet & Violet/Paradox Rift/202.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 160,
 	types: ["Fighting"],
+	evolveFrom: {
+		en: "Naclstack",
+		fr: "Amassel",
+		es: "Naclstack",
+		it: "Naclstack",
+		pt: "Naclstack",
+		de: "Sedisal"
+	},
 	stage: "Stage2",
 
 	abilities: [{

--- a/data/Scarlet & Violet/Paradox Rift/204.ts
+++ b/data/Scarlet & Violet/Paradox Rift/204.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 120,
 	types: ["Darkness"],
+	evolveFrom: {
+		en: "Trubbish",
+		fr: "Miamiasme",
+		es: "Trubbish",
+		it: "Trubbish",
+		pt: "Trubbish",
+		de: "Unratütox"
+	},
 	stage: "Stage1",
 
 	attacks: [{

--- a/data/Scarlet & Violet/Paradox Rift/208.ts
+++ b/data/Scarlet & Violet/Paradox Rift/208.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 180,
 	types: ["Metal"],
+	evolveFrom: {
+		en: "Onix",
+		fr: "Onix",
+		es: "Onix",
+		it: "Onix",
+		pt: "Onix",
+		de: "Onix"
+	},
 	stage: "Stage1",
 
 	attacks: [{

--- a/data/Scarlet & Violet/Paradox Rift/209.ts
+++ b/data/Scarlet & Violet/Paradox Rift/209.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 140,
 	types: ["Metal"],
+	evolveFrom: {
+		en: "Ferroseed",
+		fr: "Grindur",
+		es: "Ferroseed",
+		it: "Ferroseed",
+		pt: "Ferroseed",
+		de: "Kastadur"
+	},
 	stage: "Stage1",
 
 	abilities: [{

--- a/data/Scarlet & Violet/Paradox Rift/210.ts
+++ b/data/Scarlet & Violet/Paradox Rift/210.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 150,
 	types: ["Metal"],
+	evolveFrom: {
+		en: "Doublade",
+		fr: "Dimoclès",
+		es: "Doublade",
+		it: "Doublade",
+		pt: "Doublade",
+		de: "Duokles"
+	},
 	stage: "Stage2",
 
 	abilities: [{

--- a/data/Scarlet & Violet/Paradox Rift/212.ts
+++ b/data/Scarlet & Violet/Paradox Rift/212.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 100,
 	types: ["Colorless"],
+	evolveFrom: {
+		en: "Whismur",
+		fr: "Chuchmur",
+		es: "Whismur",
+		it: "Whismur",
+		pt: "Whismur",
+		de: "Flurmel"
+	},
 	stage: "Stage1",
 
 	attacks: [{

--- a/data/Scarlet & Violet/Paradox Rift/214.ts
+++ b/data/Scarlet & Violet/Paradox Rift/214.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 150,
 	types: ["Colorless"],
+	evolveFrom: {
+		en: "Porygon2",
+		fr: "Porygon2",
+		es: "Porygon2",
+		it: "Porygon2",
+		pt: "Porygon2",
+		de: "Porygon2"
+	},
 	stage: "Stage2",
 
 	abilities: [{

--- a/data/Scarlet & Violet/Paradox Rift/217.ts
+++ b/data/Scarlet & Violet/Paradox Rift/217.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 250,
 	types: ["Grass"],
+	evolveFrom: {
+		en: "Snorunt",
+		fr: "Stalgamin",
+		es: "Snorunt",
+		it: "Snorunt",
+		pt: "Snorunt",
+		de: "Schneppke"
+	},
 	stage: "Stage1",
 
 	abilities: [{

--- a/data/Scarlet & Violet/Paradox Rift/218.ts
+++ b/data/Scarlet & Violet/Paradox Rift/218.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 260,
 	types: ["Fire"],
+	evolveFrom: {
+		en: "Charcadet",
+		fr: "Charbambin",
+		es: "Charcadet",
+		it: "Charcadet",
+		pt: "Charcadet",
+		de: "Knarbon"
+	},
 	stage: "Stage1",
 
 	abilities: [{

--- a/data/Scarlet & Violet/Paradox Rift/219.ts
+++ b/data/Scarlet & Violet/Paradox Rift/219.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 320,
 	types: ["Water"],
+	evolveFrom: {
+		en: "Gabite",
+		fr: "Carmache",
+		es: "Gabite",
+		it: "Gabite",
+		pt: "Gabite",
+		de: "Knarksel"
+	},
 	stage: "Stage2",
 
 	attacks: [{

--- a/data/Scarlet & Violet/Paradox Rift/220.ts
+++ b/data/Scarlet & Violet/Paradox Rift/220.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 310,
 	types: ["Water"],
+	evolveFrom: {
+		en: "Steenee",
+		fr: "Candine",
+		es: "Steenee",
+		it: "Steenee",
+		pt: "Steenee",
+		de: "Frubaila"
+	},
 	stage: "Stage2",
 
 	attacks: [{

--- a/data/Scarlet & Violet/Paradox Rift/221.ts
+++ b/data/Scarlet & Violet/Paradox Rift/221.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 270,
 	types: ["Water"],
+	evolveFrom: {
+		en: "Wimpod",
+		fr: "Sovkipou",
+		es: "Wimpod",
+		it: "Wimpod",
+		pt: "Wimpod",
+		de: "Reißlaus"
+	},
 	stage: "Stage1",
 
 	attacks: [{

--- a/data/Scarlet & Violet/Paradox Rift/224.ts
+++ b/data/Scarlet & Violet/Paradox Rift/224.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 260,
 	types: ["Psychic"],
+	evolveFrom: {
+		en: "Yamask",
+		fr: "Tutafeh",
+		es: "Yamask",
+		it: "Yamask",
+		pt: "Yamask",
+		de: "Makabaja"
+	},
 	stage: "Stage1",
 
 	abilities: [{

--- a/data/Scarlet & Violet/Paradox Rift/227.ts
+++ b/data/Scarlet & Violet/Paradox Rift/227.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 260,
 	types: ["Fighting"],
+	evolveFrom: {
+		en: "Toxel",
+		fr: "Toxizap",
+		es: "Toxel",
+		it: "Toxel",
+		pt: "Toxel",
+		de: "Toxel"
+	},
 	stage: "Stage1",
 
 	attacks: [{

--- a/data/Scarlet & Violet/Paradox Rift/230.ts
+++ b/data/Scarlet & Violet/Paradox Rift/230.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 330,
 	types: ["Metal"],
+	evolveFrom: {
+		en: "Doublade",
+		fr: "Dimoclès",
+		es: "Doublade",
+		it: "Doublade",
+		pt: "Doublade",
+		de: "Duokles"
+	},
 	stage: "Stage2",
 
 	attacks: [{

--- a/data/Scarlet & Violet/Paradox Rift/231.ts
+++ b/data/Scarlet & Violet/Paradox Rift/231.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 260,
 	types: ["Metal"],
+	evolveFrom: {
+		en: "Gimmighoul",
+		fr: "Mordudor",
+		es: "Gimmighoul",
+		it: "Gimmighoul",
+		pt: "Gimmighoul",
+		de: "Gierspenst"
+	},
 	stage: "Stage1",
 
 	abilities: [{

--- a/data/Scarlet & Violet/Paradox Rift/232.ts
+++ b/data/Scarlet & Violet/Paradox Rift/232.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 260,
 	types: ["Dragon"],
+	evolveFrom: {
+		en: "Swablu",
+		fr: "Tylton",
+		es: "Swablu",
+		it: "Swablu",
+		pt: "Swablu",
+		de: "Wablu"
+	},
 	stage: "Stage1",
 
 	abilities: [{

--- a/data/Scarlet & Violet/Paradox Rift/233.ts
+++ b/data/Scarlet & Violet/Paradox Rift/233.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 230,
 	types: ["Colorless"],
+	evolveFrom: {
+		en: "Tandemaus",
+		fr: "Compagnol",
+		es: "Tandemaus",
+		it: "Tandemaus",
+		pt: "Tandemaus",
+		de: "Zwieps"
+	},
 	stage: "Stage1",
 
 	abilities: [{

--- a/data/Scarlet & Violet/Paradox Rift/245.ts
+++ b/data/Scarlet & Violet/Paradox Rift/245.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 320,
 	types: ["Water"],
+	evolveFrom: {
+		en: "Gabite",
+		fr: "Carmache",
+		es: "Gabite",
+		it: "Gabite",
+		pt: "Gabite",
+		de: "Knarksel"
+	},
 	stage: "Stage2",
 
 	attacks: [{

--- a/data/Scarlet & Violet/Paradox Rift/246.ts
+++ b/data/Scarlet & Violet/Paradox Rift/246.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 270,
 	types: ["Water"],
+	evolveFrom: {
+		en: "Wimpod",
+		fr: "Sovkipou",
+		es: "Wimpod",
+		it: "Wimpod",
+		pt: "Wimpod",
+		de: "Reißlaus"
+	},
 	stage: "Stage1",
 
 	attacks: [{

--- a/data/Scarlet & Violet/Paradox Rift/252.ts
+++ b/data/Scarlet & Violet/Paradox Rift/252.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 260,
 	types: ["Metal"],
+	evolveFrom: {
+		en: "Gimmighoul",
+		fr: "Mordudor",
+		es: "Gimmighoul",
+		it: "Gimmighoul",
+		pt: "Gimmighoul",
+		de: "Gierspenst"
+	},
 	stage: "Stage1",
 
 	abilities: [{

--- a/data/Scarlet & Violet/Paradox Rift/253.ts
+++ b/data/Scarlet & Violet/Paradox Rift/253.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 260,
 	types: ["Dragon"],
+	evolveFrom: {
+		en: "Swablu",
+		fr: "Tylton",
+		es: "Swablu",
+		it: "Swablu",
+		pt: "Swablu",
+		de: "Wablu"
+	},
 	stage: "Stage1",
 
 	abilities: [{

--- a/data/Scarlet & Violet/Paradox Rift/260.ts
+++ b/data/Scarlet & Violet/Paradox Rift/260.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 320,
 	types: ["Water"],
+	evolveFrom: {
+		en: "Gabite",
+		fr: "Carmache",
+		es: "Gabite",
+		it: "Gabite",
+		pt: "Gabite",
+		de: "Knarksel"
+	},
 	stage: "Stage2",
 
 	attacks: [{


### PR DESCRIPTION
Add the "evolveFrom" field to multiple cards in the Paradox Rift set