### PR TITLE
Add missing dexId fields to Phantasmal Flames cards

### DIFF
--- a/data/Mega Evolution/Phantasmal Flames/001.ts
+++ b/data/Mega Evolution/Phantasmal Flames/001.ts
@@ -19,6 +19,7 @@ const card: Card = {
 	hp: 50,
 	types: ["Grass"],
 	stage: "Basic",
+	dexId: [43],
 
 	attacks: [{
 		cost: ["Grass"],

--- a/data/Mega Evolution/Phantasmal Flames/002.ts
+++ b/data/Mega Evolution/Phantasmal Flames/002.ts
@@ -19,6 +19,7 @@ const card: Card = {
 	hp: 70,
 	types: ["Grass"],
 	stage: "Stage1",
+	dexId: [44],
 
 	attacks: [{
 		cost: ["Grass"],

--- a/data/Mega Evolution/Phantasmal Flames/003.ts
+++ b/data/Mega Evolution/Phantasmal Flames/003.ts
@@ -19,6 +19,7 @@ const card: Card = {
 	hp: 150,
 	types: ["Grass"],
 	stage: "Stage2",
+	dexId: [45],
 
 	attacks: [{
 		cost: ["Grass"],

--- a/data/Mega Evolution/Phantasmal Flames/004.ts
+++ b/data/Mega Evolution/Phantasmal Flames/004.ts
@@ -19,6 +19,7 @@ const card: Card = {
 	hp: 280,
 	types: ["Grass"],
 	stage: "Basic",
+	dexId: [214],
 
 	attacks: [{
 		cost: ["Grass", "Grass"],

--- a/data/Mega Evolution/Phantasmal Flames/005.ts
+++ b/data/Mega Evolution/Phantasmal Flames/005.ts
@@ -19,6 +19,7 @@ const card: Card = {
 	hp: 70,
 	types: ["Grass"],
 	stage: "Basic",
+	dexId: [270],
 
 	attacks: [{
 		cost: ["Grass", "Colorless"],

--- a/data/Mega Evolution/Phantasmal Flames/006.ts
+++ b/data/Mega Evolution/Phantasmal Flames/006.ts
@@ -19,6 +19,7 @@ const card: Card = {
 	hp: 90,
 	types: ["Grass"],
 	stage: "Stage1",
+	dexId: [271],
 
 	attacks: [{
 		cost: ["Grass", "Colorless"],

--- a/data/Mega Evolution/Phantasmal Flames/007.ts
+++ b/data/Mega Evolution/Phantasmal Flames/007.ts
@@ -19,6 +19,7 @@ const card: Card = {
 	hp: 160,
 	types: ["Grass"],
 	stage: "Stage2",
+	dexId: [272],
 
 	abilities: [{
 		type: "Ability",

--- a/data/Mega Evolution/Phantasmal Flames/008.ts
+++ b/data/Mega Evolution/Phantasmal Flames/008.ts
@@ -19,6 +19,7 @@ const card: Card = {
 	hp: 120,
 	types: ["Grass"],
 	stage: "Basic",
+	dexId: [649],
 
 	attacks: [{
 		cost: ["Grass"],

--- a/data/Mega Evolution/Phantasmal Flames/009.ts
+++ b/data/Mega Evolution/Phantasmal Flames/009.ts
@@ -19,6 +19,7 @@ const card: Card = {
 	hp: 50,
 	types: ["Grass"],
 	stage: "Basic",
+	dexId: [919],
 
 	attacks: [{
 		cost: ["Grass"],

--- a/data/Mega Evolution/Phantasmal Flames/010.ts
+++ b/data/Mega Evolution/Phantasmal Flames/010.ts
@@ -19,6 +19,7 @@ const card: Card = {
 	hp: 120,
 	types: ["Grass"],
 	stage: "Stage1",
+	dexId: [920],
 
 	attacks: [{
 		cost: ["Grass"],

--- a/data/Mega Evolution/Phantasmal Flames/011.ts
+++ b/data/Mega Evolution/Phantasmal Flames/011.ts
@@ -19,6 +19,7 @@ const card: Card = {
 	hp: 80,
 	types: ["Fire"],
 	stage: "Basic",
+	dexId: [4],
 
 	abilities: [{
 		type: "Ability",

--- a/data/Mega Evolution/Phantasmal Flames/012.ts
+++ b/data/Mega Evolution/Phantasmal Flames/012.ts
@@ -19,6 +19,7 @@ const card: Card = {
 	hp: 110,
 	types: ["Fire"],
 	stage: "Stage1",
+	dexId: [5],
 
 	attacks: [{
 		cost: ["Fire"],

--- a/data/Mega Evolution/Phantasmal Flames/013.ts
+++ b/data/Mega Evolution/Phantasmal Flames/013.ts
@@ -19,6 +19,7 @@ const card: Card = {
 	hp: 360,
 	types: ["Fire"],
 	stage: "Stage2",
+	dexId: [6],
 
 	attacks: [{
 		cost: ["Fire", "Fire"],

--- a/data/Mega Evolution/Phantasmal Flames/014.ts
+++ b/data/Mega Evolution/Phantasmal Flames/014.ts
@@ -19,6 +19,7 @@ const card: Card = {
 	hp: 120,
 	types: ["Fire"],
 	stage: "Basic",
+	dexId: [146],
 
 	attacks: [{
 		cost: ["Fire"],

--- a/data/Mega Evolution/Phantasmal Flames/015.ts
+++ b/data/Mega Evolution/Phantasmal Flames/015.ts
@@ -19,6 +19,7 @@ const card: Card = {
 	hp: 80,
 	types: ["Fire"],
 	stage: "Basic",
+	dexId: [554],
 
 	attacks: [{
 		cost: ["Colorless", "Colorless", "Colorless"],

--- a/data/Mega Evolution/Phantasmal Flames/016.ts
+++ b/data/Mega Evolution/Phantasmal Flames/016.ts
@@ -19,6 +19,7 @@ const card: Card = {
 	hp: 150,
 	types: ["Fire"],
 	stage: "Stage1",
+	dexId: [555],
 
 	attacks: [{
 		cost: ["Colorless", "Colorless", "Colorless", "Colorless"],

--- a/data/Mega Evolution/Phantasmal Flames/017.ts
+++ b/data/Mega Evolution/Phantasmal Flames/017.ts
@@ -19,6 +19,7 @@ const card: Card = {
 	hp: 130,
 	types: ["Fire"],
 	stage: "Basic",
+	dexId: [643],
 
 	attacks: [{
 		cost: ["Fire"],

--- a/data/Mega Evolution/Phantasmal Flames/018.ts
+++ b/data/Mega Evolution/Phantasmal Flames/018.ts
@@ -19,6 +19,7 @@ const card: Card = {
 	hp: 190,
 	types: ["Fire"],
 	stage: "Basic",
+	dexId: [741],
 
 	abilities: [{
 		type: "Ability",

--- a/data/Mega Evolution/Phantasmal Flames/019.ts
+++ b/data/Mega Evolution/Phantasmal Flames/019.ts
@@ -19,6 +19,7 @@ const card: Card = {
 	hp: 70,
 	types: ["Fire"],
 	stage: "Basic",
+	dexId: [935],
 
 	attacks: [{
 		cost: ["Fire"],

--- a/data/Mega Evolution/Phantasmal Flames/020.ts
+++ b/data/Mega Evolution/Phantasmal Flames/020.ts
@@ -19,6 +19,7 @@ const card: Card = {
 	hp: 140,
 	types: ["Fire"],
 	stage: "Stage1",
+	dexId: [937],
 
 	attacks: [{
 		cost: ["Fire"],

--- a/data/Mega Evolution/Phantasmal Flames/021.ts
+++ b/data/Mega Evolution/Phantasmal Flames/021.ts
@@ -19,6 +19,7 @@ const card: Card = {
 	hp: 80,
 	types: ["Water"],
 	stage: "Basic",
+	dexId: [86],
 
 	attacks: [{
 		cost: ["Water", "Colorless"],

--- a/data/Mega Evolution/Phantasmal Flames/022.ts
+++ b/data/Mega Evolution/Phantasmal Flames/022.ts
@@ -19,6 +19,7 @@ const card: Card = {
 	hp: 130,
 	types: ["Water"],
 	stage: "Stage1",
+	dexId: [87],
 
 	abilities: [{
 		type: "Ability",

--- a/data/Mega Evolution/Phantasmal Flames/023.ts
+++ b/data/Mega Evolution/Phantasmal Flames/023.ts
@@ -19,6 +19,7 @@ const card: Card = {
 	hp: 70,
 	types: ["Water"],
 	stage: "Basic",
+	dexId: [220],
 
 	attacks: [{
 		cost: ["Colorless"],

--- a/data/Mega Evolution/Phantasmal Flames/024.ts
+++ b/data/Mega Evolution/Phantasmal Flames/024.ts
@@ -19,6 +19,7 @@ const card: Card = {
 	hp: 100,
 	types: ["Water"],
 	stage: "Stage1",
+	dexId: [221],
 
 	attacks: [{
 		cost: ["Colorless", "Colorless"],

--- a/data/Mega Evolution/Phantasmal Flames/025.ts
+++ b/data/Mega Evolution/Phantasmal Flames/025.ts
@@ -19,6 +19,7 @@ const card: Card = {
 	hp: 180,
 	types: ["Water"],
 	stage: "Stage2",
+	dexId: [473],
 
 	attacks: [{
 		cost: ["Colorless", "Colorless", "Colorless"],

--- a/data/Mega Evolution/Phantasmal Flames/026.ts
+++ b/data/Mega Evolution/Phantasmal Flames/026.ts
@@ -19,6 +19,7 @@ const card: Card = {
 	hp: 130,
 	types: ["Water"],
 	stage: "Basic",
+	dexId: [245],
 
 	attacks: [{
 		cost: ["Water", "Water"],

--- a/data/Mega Evolution/Phantasmal Flames/027.ts
+++ b/data/Mega Evolution/Phantasmal Flames/027.ts
@@ -19,6 +19,7 @@ const card: Card = {
 	hp: 70,
 	types: ["Water"],
 	stage: "Basic",
+	dexId: [393],
 
 	attacks: [{
 		cost: ["Colorless"],

--- a/data/Mega Evolution/Phantasmal Flames/028.ts
+++ b/data/Mega Evolution/Phantasmal Flames/028.ts
@@ -19,6 +19,7 @@ const card: Card = {
 	hp: 100,
 	types: ["Water"],
 	stage: "Stage1",
+	dexId: [394],
 
 	attacks: [{
 		cost: ["Colorless"],

--- a/data/Mega Evolution/Phantasmal Flames/029.ts
+++ b/data/Mega Evolution/Phantasmal Flames/029.ts
@@ -19,6 +19,7 @@ const card: Card = {
 	hp: 190,
 	types: ["Lightning"],
 	stage: "Basic",
+	dexId: [479],
 
 	abilities: [{
 		type: "Ability",

--- a/data/Mega Evolution/Phantasmal Flames/030.ts
+++ b/data/Mega Evolution/Phantasmal Flames/030.ts
@@ -19,6 +19,7 @@ const card: Card = {
 	hp: 70,
 	types: ["Lightning"],
 	stage: "Basic",
+	dexId: [835],
 
 	attacks: [{
 		cost: ["Lightning", "Colorless"],

--- a/data/Mega Evolution/Phantasmal Flames/031.ts
+++ b/data/Mega Evolution/Phantasmal Flames/031.ts
@@ -19,6 +19,7 @@ const card: Card = {
 	hp: 130,
 	types: ["Lightning"],
 	stage: "Stage1",
+	dexId: [836],
 
 	attacks: [{
 		cost: ["Lightning", "Colorless"],

--- a/data/Mega Evolution/Phantasmal Flames/032.ts
+++ b/data/Mega Evolution/Phantasmal Flames/032.ts
@@ -19,6 +19,7 @@ const card: Card = {
 	hp: 60,
 	types: ["Lightning"],
 	stage: "Basic",
+	dexId: [921],
 
 	attacks: [{
 		cost: ["Lightning"],

--- a/data/Mega Evolution/Phantasmal Flames/033.ts
+++ b/data/Mega Evolution/Phantasmal Flames/033.ts
@@ -19,6 +19,7 @@ const card: Card = {
 	hp: 90,
 	types: ["Lightning"],
 	stage: "Stage1",
+	dexId: [922],
 
 	attacks: [{
 		cost: ["Lightning", "Lightning"],

--- a/data/Mega Evolution/Phantasmal Flames/034.ts
+++ b/data/Mega Evolution/Phantasmal Flames/034.ts
@@ -19,6 +19,7 @@ const card: Card = {
 	hp: 140,
 	types: ["Lightning"],
 	stage: "Stage2",
+	dexId: [923],
 
 	attacks: [{
 		cost: ["Lightning", "Lightning"],

--- a/data/Mega Evolution/Phantasmal Flames/035.ts
+++ b/data/Mega Evolution/Phantasmal Flames/035.ts
@@ -19,6 +19,7 @@ const card: Card = {
 	hp: 70,
 	types: ["Psychic"],
 	stage: "Basic",
+	dexId: [200],
 
 	attacks: [{
 		cost: ["Psychic"],

--- a/data/Mega Evolution/Phantasmal Flames/036.ts
+++ b/data/Mega Evolution/Phantasmal Flames/036.ts
@@ -19,6 +19,7 @@ const card: Card = {
 	hp: 260,
 	types: ["Psychic"],
 	stage: "Stage1",
+	dexId: [429],
 
 	abilities: [{
 		type: "Ability",

--- a/data/Mega Evolution/Phantasmal Flames/037.ts
+++ b/data/Mega Evolution/Phantasmal Flames/037.ts
@@ -19,6 +19,7 @@ const card: Card = {
 	hp: 70,
 	types: ["Psychic"],
 	stage: "Basic",
+	dexId: [209],
 
 	attacks: [{
 		cost: ["Psychic", "Colorless"],

--- a/data/Mega Evolution/Phantasmal Flames/038.ts
+++ b/data/Mega Evolution/Phantasmal Flames/038.ts
@@ -19,6 +19,7 @@ const card: Card = {
 	hp: 130,
 	types: ["Psychic"],
 	stage: "Stage1",
+	dexId: [210],
 
 	attacks: [{
 		cost: ["Psychic", "Colorless"],

--- a/data/Mega Evolution/Phantasmal Flames/039.ts
+++ b/data/Mega Evolution/Phantasmal Flames/039.ts
@@ -19,6 +19,7 @@ const card: Card = {
 	hp: 120,
 	types: ["Psychic"],
 	stage: "Basic",
+	dexId: [488],
 
 	attacks: [{
 		cost: ["Psychic"],

--- a/data/Mega Evolution/Phantasmal Flames/040.ts
+++ b/data/Mega Evolution/Phantasmal Flames/040.ts
@@ -19,6 +19,7 @@ const card: Card = {
 	hp: 90,
 	types: ["Psychic"],
 	stage: "Basic",
+	dexId: [648],
 
 	attacks: [{
 		cost: ["Psychic"],

--- a/data/Mega Evolution/Phantasmal Flames/041.ts
+++ b/data/Mega Evolution/Phantasmal Flames/041.ts
@@ -19,6 +19,7 @@ const card: Card = {
 	hp: 270,
 	types: ["Psychic"],
 	stage: "Basic",
+	dexId: [719],
 
 	abilities: [{
 		type: "Ability",

--- a/data/Mega Evolution/Phantasmal Flames/042.ts
+++ b/data/Mega Evolution/Phantasmal Flames/042.ts
@@ -19,6 +19,7 @@ const card: Card = {
 	hp: 70,
 	types: ["Psychic"],
 	stage: "Basic",
+	dexId: [778],
 
 	attacks: [{
 		cost: ["Colorless"],

--- a/data/Mega Evolution/Phantasmal Flames/043.ts
+++ b/data/Mega Evolution/Phantasmal Flames/043.ts
@@ -19,6 +19,7 @@ const card: Card = {
 	hp: 50,
 	types: ["Psychic"],
 	stage: "Basic",
+	dexId: [868],
 
 	attacks: [{
 		cost: ["Psychic"],

--- a/data/Mega Evolution/Phantasmal Flames/044.ts
+++ b/data/Mega Evolution/Phantasmal Flames/044.ts
@@ -19,6 +19,7 @@ const card: Card = {
 	hp: 90,
 	types: ["Psychic"],
 	stage: "Stage1",
+	dexId: [869],
 
 	attacks: [{
 		cost: ["Psychic"],

--- a/data/Mega Evolution/Phantasmal Flames/045.ts
+++ b/data/Mega Evolution/Phantasmal Flames/045.ts
@@ -19,6 +19,7 @@ const card: Card = {
 	hp: 130,
 	types: ["Psychic"],
 	stage: "Basic",
+	dexId: [888],
 
 	attacks: [{
 		cost: ["Psychic", "Colorless"],

--- a/data/Mega Evolution/Phantasmal Flames/046.ts
+++ b/data/Mega Evolution/Phantasmal Flames/046.ts
@@ -19,6 +19,7 @@ const card: Card = {
 	hp: 50,
 	types: ["Psychic"],
 	stage: "Basic",
+	dexId: [946],
 
 	attacks: [{
 		cost: ["Psychic"],

--- a/data/Mega Evolution/Phantasmal Flames/047.ts
+++ b/data/Mega Evolution/Phantasmal Flames/047.ts
@@ -19,6 +19,7 @@ const card: Card = {
 	hp: 100,
 	types: ["Psychic"],
 	stage: "Stage1",
+	dexId: [947],
 
 	abilities: [{
 		type: "Ability",

--- a/data/Mega Evolution/Phantasmal Flames/048.ts
+++ b/data/Mega Evolution/Phantasmal Flames/048.ts
@@ -19,6 +19,7 @@ const card: Card = {
 	hp: 130,
 	types: ["Fighting"],
 	stage: "Basic",
+	dexId: [128],
 
 	attacks: [{
 		cost: ["Fighting"],

--- a/data/Mega Evolution/Phantasmal Flames/049.ts
+++ b/data/Mega Evolution/Phantasmal Flames/049.ts
@@ -19,6 +19,7 @@ const card: Card = {
 	hp: 70,
 	types: ["Fighting"],
 	stage: "Basic",
+	dexId: [207],
 
 	attacks: [{
 		cost: ["Fighting"],

--- a/data/Mega Evolution/Phantasmal Flames/050.ts
+++ b/data/Mega Evolution/Phantasmal Flames/050.ts
@@ -19,6 +19,7 @@ const card: Card = {
 	hp: 120,
 	types: ["Fighting"],
 	stage: "Stage1",
+	dexId: [472],
 
 	attacks: [{
 		cost: ["Fighting"],

--- a/data/Mega Evolution/Phantasmal Flames/051.ts
+++ b/data/Mega Evolution/Phantasmal Flames/051.ts
@@ -19,6 +19,7 @@ const card: Card = {
 	hp: 70,
 	types: ["Fighting"],
 	stage: "Basic",
+	dexId: [328],
 
 	attacks: [{
 		cost: ["Fighting"],

--- a/data/Mega Evolution/Phantasmal Flames/052.ts
+++ b/data/Mega Evolution/Phantasmal Flames/052.ts
@@ -19,6 +19,7 @@ const card: Card = {
 	hp: 90,
 	types: ["Fighting"],
 	stage: "Stage1",
+	dexId: [329],
 
 	attacks: [{
 		cost: ["Fighting", "Fighting"],

--- a/data/Mega Evolution/Phantasmal Flames/053.ts
+++ b/data/Mega Evolution/Phantasmal Flames/053.ts
@@ -19,6 +19,7 @@ const card: Card = {
 	hp: 150,
 	types: ["Fighting"],
 	stage: "Stage2",
+	dexId: [330],
 
 	abilities: [{
 		type: "Ability",

--- a/data/Mega Evolution/Phantasmal Flames/054.ts
+++ b/data/Mega Evolution/Phantasmal Flames/054.ts
@@ -19,6 +19,7 @@ const card: Card = {
 	hp: 70,
 	types: ["Darkness"],
 	stage: "Basic",
+	dexId: [92],
 
 	attacks: [{
 		cost: ["Darkness"],

--- a/data/Mega Evolution/Phantasmal Flames/055.ts
+++ b/data/Mega Evolution/Phantasmal Flames/055.ts
@@ -19,6 +19,7 @@ const card: Card = {
 	hp: 100,
 	types: ["Darkness"],
 	stage: "Stage1",
+	dexId: [93],
 
 	attacks: [{
 		cost: ["Darkness"],

--- a/data/Mega Evolution/Phantasmal Flames/056.ts
+++ b/data/Mega Evolution/Phantasmal Flames/056.ts
@@ -19,6 +19,7 @@ const card: Card = {
 	hp: 350,
 	types: ["Darkness"],
 	stage: "Stage2",
+	dexId: [94],
 
 	abilities: [{
 		type: "Ability",

--- a/data/Mega Evolution/Phantasmal Flames/057.ts
+++ b/data/Mega Evolution/Phantasmal Flames/057.ts
@@ -19,6 +19,7 @@ const card: Card = {
 	hp: 60,
 	types: ["Darkness"],
 	stage: "Basic",
+	dexId: [198],
 
 	attacks: [{
 		cost: ["Darkness"],

--- a/data/Mega Evolution/Phantasmal Flames/058.ts
+++ b/data/Mega Evolution/Phantasmal Flames/058.ts
@@ -19,6 +19,7 @@ const card: Card = {
 	hp: 130,
 	types: ["Darkness"],
 	stage: "Stage1",
+	dexId: [430],
 
 	attacks: [{
 		cost: ["Darkness"],

--- a/data/Mega Evolution/Phantasmal Flames/059.ts
+++ b/data/Mega Evolution/Phantasmal Flames/059.ts
@@ -19,6 +19,7 @@ const card: Card = {
 	hp: 80,
 	types: ["Darkness"],
 	stage: "Basic",
+	dexId: [302],
 
 	attacks: [{
 		cost: ["Darkness"],

--- a/data/Mega Evolution/Phantasmal Flames/060.ts
+++ b/data/Mega Evolution/Phantasmal Flames/060.ts
@@ -19,6 +19,7 @@ const card: Card = {
 	hp: 70,
 	types: ["Darkness"],
 	stage: "Basic",
+	dexId: [318],
 
 	attacks: [{
 		cost: ["Darkness"],

--- a/data/Mega Evolution/Phantasmal Flames/061.ts
+++ b/data/Mega Evolution/Phantasmal Flames/061.ts
@@ -19,6 +19,7 @@ const card: Card = {
 	hp: 330,
 	types: ["Darkness"],
 	stage: "Stage1",
+	dexId: [319],
 
 	attacks: [{
 		cost: ["Darkness"],

--- a/data/Mega Evolution/Phantasmal Flames/062.ts
+++ b/data/Mega Evolution/Phantasmal Flames/062.ts
@@ -19,6 +19,7 @@ const card: Card = {
 	hp: 120,
 	types: ["Darkness"],
 	stage: "Basic",
+	dexId: [336],
 
 	abilities: [{
 		type: "Ability",

--- a/data/Mega Evolution/Phantasmal Flames/063.ts
+++ b/data/Mega Evolution/Phantasmal Flames/063.ts
@@ -19,6 +19,7 @@ const card: Card = {
 	hp: 110,
 	types: ["Darkness"],
 	stage: "Basic",
+	dexId: [359],
 
 	attacks: [{
 		cost: ["Colorless"],

--- a/data/Mega Evolution/Phantasmal Flames/064.ts
+++ b/data/Mega Evolution/Phantasmal Flames/064.ts
@@ -19,6 +19,7 @@ const card: Card = {
 	hp: 70,
 	types: ["Darkness"],
 	stage: "Basic",
+	dexId: [551],
 
 	attacks: [{
 		cost: ["Darkness"],

--- a/data/Mega Evolution/Phantasmal Flames/065.ts
+++ b/data/Mega Evolution/Phantasmal Flames/065.ts
@@ -19,6 +19,7 @@ const card: Card = {
 	hp: 100,
 	types: ["Darkness"],
 	stage: "Stage1",
+	dexId: [552],
 
 	attacks: [{
 		cost: ["Darkness"],

--- a/data/Mega Evolution/Phantasmal Flames/066.ts
+++ b/data/Mega Evolution/Phantasmal Flames/066.ts
@@ -19,6 +19,7 @@ const card: Card = {
 	hp: 170,
 	types: ["Darkness"],
 	stage: "Stage2",
+	dexId: [553],
 
 	attacks: [{
 		cost: ["Darkness"],

--- a/data/Mega Evolution/Phantasmal Flames/067.ts
+++ b/data/Mega Evolution/Phantasmal Flames/067.ts
@@ -19,6 +19,7 @@ const card: Card = {
 	hp: 70,
 	types: ["Darkness"],
 	stage: "Basic",
+	dexId: [848],
 
 	attacks: [{
 		cost: ["Darkness"],

--- a/data/Mega Evolution/Phantasmal Flames/068.ts
+++ b/data/Mega Evolution/Phantasmal Flames/068.ts
@@ -19,6 +19,7 @@ const card: Card = {
 	hp: 140,
 	types: ["Darkness"],
 	stage: "Stage1",
+	dexId: [849],
 
 	abilities: [{
 		type: "Ability",

--- a/data/Mega Evolution/Phantasmal Flames/069.ts
+++ b/data/Mega Evolution/Phantasmal Flames/069.ts
@@ -19,6 +19,7 @@ const card: Card = {
 	hp: 150,
 	types: ["Darkness"],
 	stage: "Basic",
+	dexId: [890],
 
 	attacks: [{
 		cost: ["Darkness", "Darkness"],

--- a/data/Mega Evolution/Phantasmal Flames/070.ts
+++ b/data/Mega Evolution/Phantasmal Flames/070.ts
@@ -19,6 +19,7 @@ const card: Card = {
 	hp: 320,
 	types: ["Metal"],
 	stage: "Stage2",
+	dexId: [395],
 
 	abilities: [{
 		type: "Ability",

--- a/data/Mega Evolution/Phantasmal Flames/071.ts
+++ b/data/Mega Evolution/Phantasmal Flames/071.ts
@@ -19,6 +19,7 @@ const card: Card = {
 	hp: 80,
 	types: ["Metal"],
 	stage: "Basic",
+	dexId: [436],
 
 	attacks: [{
 		cost: ["Colorless"],

--- a/data/Mega Evolution/Phantasmal Flames/072.ts
+++ b/data/Mega Evolution/Phantasmal Flames/072.ts
@@ -19,6 +19,7 @@ const card: Card = {
 	hp: 140,
 	types: ["Metal"],
 	stage: "Stage1",
+	dexId: [437],
 
 	attacks: [{
 		cost: ["Colorless"],

--- a/data/Mega Evolution/Phantasmal Flames/073.ts
+++ b/data/Mega Evolution/Phantasmal Flames/073.ts
@@ -19,6 +19,7 @@ const card: Card = {
 	hp: 80,
 	types: ["Metal"],
 	stage: "Basic",
+	dexId: [777],
 
 	attacks: [{
 		cost: ["Colorless"],

--- a/data/Mega Evolution/Phantasmal Flames/074.ts
+++ b/data/Mega Evolution/Phantasmal Flames/074.ts
@@ -19,6 +19,7 @@ const card: Card = {
 	hp: 130,
 	types: ["Metal"],
 	stage: "Basic",
+	dexId: [884],
 
 	attacks: [{
 		cost: ["Metal", "Metal", "Metal"],

--- a/data/Mega Evolution/Phantasmal Flames/075.ts
+++ b/data/Mega Evolution/Phantasmal Flames/075.ts
@@ -19,6 +19,7 @@ const card: Card = {
 	hp: 180,
 	types: ["Metal"],
 	stage: "Stage1",
+	dexId: [1018],
 
 	attacks: [{
 		cost: ["Metal", "Metal", "Metal"],

--- a/data/Mega Evolution/Phantasmal Flames/076.ts
+++ b/data/Mega Evolution/Phantasmal Flames/076.ts
@@ -19,6 +19,7 @@ const card: Card = {
 	hp: 70,
 	types: ["Colorless"],
 	stage: "Basic",
+	dexId: [39],
 
 	attacks: [{
 		cost: ["Colorless"],

--- a/data/Mega Evolution/Phantasmal Flames/077.ts
+++ b/data/Mega Evolution/Phantasmal Flames/077.ts
@@ -19,6 +19,7 @@ const card: Card = {
 	hp: 120,
 	types: ["Colorless"],
 	stage: "Stage1",
+	dexId: [40],
 
 	attacks: [{
 		cost: ["Colorless", "Colorless"],

--- a/data/Mega Evolution/Phantasmal Flames/078.ts
+++ b/data/Mega Evolution/Phantasmal Flames/078.ts
@@ -19,6 +19,7 @@ const card: Card = {
 	hp: 70,
 	types: ["Colorless"],
 	stage: "Basic",
+	dexId: [190],
 
 	attacks: [{
 		cost: ["Colorless", "Colorless"],

--- a/data/Mega Evolution/Phantasmal Flames/079.ts
+++ b/data/Mega Evolution/Phantasmal Flames/079.ts
@@ -19,6 +19,7 @@ const card: Card = {
 	hp: 110,
 	types: ["Colorless"],
 	stage: "Stage1",
+	dexId: [424],
 
 	attacks: [{
 		cost: ["Colorless", "Colorless"],

--- a/data/Mega Evolution/Phantasmal Flames/080.ts
+++ b/data/Mega Evolution/Phantasmal Flames/080.ts
@@ -19,6 +19,7 @@ const card: Card = {
 	hp: 80,
 	types: ["Colorless"],
 	stage: "Basic",
+	dexId: [235],
 
 	attacks: [{
 		cost: ["Colorless"],

--- a/data/Mega Evolution/Phantasmal Flames/081.ts
+++ b/data/Mega Evolution/Phantasmal Flames/081.ts
@@ -19,6 +19,7 @@ const card: Card = {
 	hp: 70,
 	types: ["Colorless"],
 	stage: "Basic",
+	dexId: [263],
 
 	attacks: [{
 		cost: ["Colorless"],

--- a/data/Mega Evolution/Phantasmal Flames/082.ts
+++ b/data/Mega Evolution/Phantasmal Flames/082.ts
@@ -19,6 +19,7 @@ const card: Card = {
 	hp: 100,
 	types: ["Colorless"],
 	stage: "Stage1",
+	dexId: [264],
 
 	abilities: [{
 		type: "Ability",

--- a/data/Mega Evolution/Phantasmal Flames/083.ts
+++ b/data/Mega Evolution/Phantasmal Flames/083.ts
@@ -19,6 +19,7 @@ const card: Card = {
 	hp: 70,
 	types: ["Colorless"],
 	stage: "Basic",
+	dexId: [427],
 
 	attacks: [{
 		cost: ["Colorless"],

--- a/data/Mega Evolution/Phantasmal Flames/084.ts
+++ b/data/Mega Evolution/Phantasmal Flames/084.ts
@@ -19,6 +19,7 @@ const card: Card = {
 	hp: 330,
 	types: ["Colorless"],
 	stage: "Stage1",
+	dexId: [428],
 
 	attacks: [{
 		cost: ["Colorless"],

--- a/data/Mega Evolution/Phantasmal Flames/095.ts
+++ b/data/Mega Evolution/Phantasmal Flames/095.ts
@@ -19,6 +19,7 @@ const card: Card = {
 	hp: 160,
 	types: ["Grass"],
 	stage: "Stage2",
+	dexId: [272],
 
 	abilities: [{
 		type: "Ability",

--- a/data/Mega Evolution/Phantasmal Flames/096.ts
+++ b/data/Mega Evolution/Phantasmal Flames/096.ts
@@ -19,6 +19,7 @@ const card: Card = {
 	hp: 50,
 	types: ["Grass"],
 	stage: "Basic",
+	dexId: [919],
 
 	attacks: [{
 		cost: ["Grass"],

--- a/data/Mega Evolution/Phantasmal Flames/097.ts
+++ b/data/Mega Evolution/Phantasmal Flames/097.ts
@@ -19,6 +19,7 @@ const card: Card = {
 	hp: 130,
 	types: ["Water"],
 	stage: "Stage1",
+	dexId: [87],
 
 	abilities: [{
 		type: "Ability",

--- a/data/Mega Evolution/Phantasmal Flames/098.ts
+++ b/data/Mega Evolution/Phantasmal Flames/098.ts
@@ -19,6 +19,7 @@ const card: Card = {
 	hp: 70,
 	types: ["Water"],
 	stage: "Basic",
+	dexId: [393],
 
 	attacks: [{
 		cost: ["Colorless"],

--- a/data/Mega Evolution/Phantasmal Flames/099.ts
+++ b/data/Mega Evolution/Phantasmal Flames/099.ts
@@ -19,6 +19,7 @@ const card: Card = {
 	hp: 70,
 	types: ["Lightning"],
 	stage: "Basic",
+	dexId: [835],
 
 	attacks: [{
 		cost: ["Lightning", "Colorless"],

--- a/data/Mega Evolution/Phantasmal Flames/100.ts
+++ b/data/Mega Evolution/Phantasmal Flames/100.ts
@@ -19,6 +19,7 @@ const card: Card = {
 	hp: 130,
 	types: ["Psychic"],
 	stage: "Basic",
+	dexId: [888],
 
 	attacks: [{
 		cost: ["Psychic", "Colorless"],

--- a/data/Mega Evolution/Phantasmal Flames/101.ts
+++ b/data/Mega Evolution/Phantasmal Flames/101.ts
@@ -19,6 +19,7 @@ const card: Card = {
 	hp: 150,
 	types: ["Fighting"],
 	stage: "Stage2",
+	dexId: [330],
 
 	abilities: [{
 		type: "Ability",

--- a/data/Mega Evolution/Phantasmal Flames/102.ts
+++ b/data/Mega Evolution/Phantasmal Flames/102.ts
@@ -19,6 +19,7 @@ const card: Card = {
 	hp: 60,
 	types: ["Darkness"],
 	stage: "Basic",
+	dexId: [194],
 
 	attacks: [{
 		cost: ["Darkness"],

--- a/data/Mega Evolution/Phantasmal Flames/103.ts
+++ b/data/Mega Evolution/Phantasmal Flames/103.ts
@@ -19,6 +19,7 @@ const card: Card = {
 	hp: 140,
 	types: ["Darkness"],
 	stage: "Stage1",
+	dexId: [849],
 
 	abilities: [{
 		type: "Ability",

--- a/data/Mega Evolution/Phantasmal Flames/104.ts
+++ b/data/Mega Evolution/Phantasmal Flames/104.ts
@@ -19,6 +19,7 @@ const card: Card = {
 	hp: 80,
 	types: ["Metal"],
 	stage: "Basic",
+	dexId: [777],
 
 	attacks: [{
 		cost: ["Colorless"],

--- a/data/Mega Evolution/Phantasmal Flames/105.ts
+++ b/data/Mega Evolution/Phantasmal Flames/105.ts
@@ -19,6 +19,7 @@ const card: Card = {
 	hp: 120,
 	types: ["Colorless"],
 	stage: "Stage1",
+	dexId: [40],
 
 	attacks: [{
 		cost: ["Colorless", "Colorless"],

--- a/data/Mega Evolution/Phantasmal Flames/106.ts
+++ b/data/Mega Evolution/Phantasmal Flames/106.ts
@@ -19,6 +19,7 @@ const card: Card = {
 	hp: 70,
 	types: ["Colorless"],
 	stage: "Basic",
+	dexId: [52],
 
 	attacks: [{
 		cost: ["Colorless", "Colorless"],

--- a/data/Mega Evolution/Phantasmal Flames/107.ts
+++ b/data/Mega Evolution/Phantasmal Flames/107.ts
@@ -19,6 +19,7 @@ const card: Card = {
 	hp: 110,
 	types: ["Colorless"],
 	stage: "Stage1",
+	dexId: [424],
 
 	attacks: [{
 		cost: ["Colorless", "Colorless"],

--- a/data/Mega Evolution/Phantasmal Flames/108.ts
+++ b/data/Mega Evolution/Phantasmal Flames/108.ts
@@ -19,6 +19,7 @@ const card: Card = {
 	hp: 280,
 	types: ["Grass"],
 	stage: "Basic",
+	dexId: [214],
 
 	attacks: [{
 		cost: ["Grass", "Grass"],

--- a/data/Mega Evolution/Phantasmal Flames/109.ts
+++ b/data/Mega Evolution/Phantasmal Flames/109.ts
@@ -19,6 +19,7 @@ const card: Card = {
 	hp: 360,
 	types: ["Fire"],
 	stage: "Stage2",
+	dexId: [6],
 
 	attacks: [{
 		cost: ["Fire", "Fire"],

--- a/data/Mega Evolution/Phantasmal Flames/110.ts
+++ b/data/Mega Evolution/Phantasmal Flames/110.ts
@@ -19,6 +19,7 @@ const card: Card = {
 	hp: 190,
 	types: ["Fire"],
 	stage: "Basic",
+	dexId: [741],
 
 	abilities: [{
 		type: "Ability",

--- a/data/Mega Evolution/Phantasmal Flames/111.ts
+++ b/data/Mega Evolution/Phantasmal Flames/111.ts
@@ -19,6 +19,7 @@ const card: Card = {
 	hp: 190,
 	types: ["Lightning"],
 	stage: "Basic",
+	dexId: [479],
 
 	abilities: [{
 		type: "Ability",

--- a/data/Mega Evolution/Phantasmal Flames/112.ts
+++ b/data/Mega Evolution/Phantasmal Flames/112.ts
@@ -19,6 +19,7 @@ const card: Card = {
 	hp: 260,
 	types: ["Psychic"],
 	stage: "Stage1",
+	dexId: [429],
 
 	abilities: [{
 		type: "Ability",

--- a/data/Mega Evolution/Phantasmal Flames/113.ts
+++ b/data/Mega Evolution/Phantasmal Flames/113.ts
@@ -19,6 +19,7 @@ const card: Card = {
 	hp: 330,
 	types: ["Darkness"],
 	stage: "Stage1",
+	dexId: [319],
 
 	attacks: [{
 		cost: ["Darkness"],

--- a/data/Mega Evolution/Phantasmal Flames/114.ts
+++ b/data/Mega Evolution/Phantasmal Flames/114.ts
@@ -19,6 +19,7 @@ const card: Card = {
 	hp: 320,
 	types: ["Metal"],
 	stage: "Stage2",
+	dexId: [395],
 
 	abilities: [{
 		type: "Ability",

--- a/data/Mega Evolution/Phantasmal Flames/115.ts
+++ b/data/Mega Evolution/Phantasmal Flames/115.ts
@@ -19,6 +19,7 @@ const card: Card = {
 	hp: 330,
 	types: ["Colorless"],
 	stage: "Stage1",
+	dexId: [428],
 
 	attacks: [{
 		cost: ["Colorless"],

--- a/data/Mega Evolution/Phantasmal Flames/125.ts
+++ b/data/Mega Evolution/Phantasmal Flames/125.ts
@@ -19,6 +19,7 @@ const card: Card = {
 	hp: 360,
 	types: ["Fire"],
 	stage: "Stage2",
+	dexId: [6],
 
 	attacks: [{
 		cost: ["Fire", "Fire"],

--- a/data/Mega Evolution/Phantasmal Flames/126.ts
+++ b/data/Mega Evolution/Phantasmal Flames/126.ts
@@ -19,6 +19,7 @@ const card: Card = {
 	hp: 190,
 	types: ["Lightning"],
 	stage: "Basic",
+	dexId: [479],
 
 	abilities: [{
 		type: "Ability",

--- a/data/Mega Evolution/Phantasmal Flames/127.ts
+++ b/data/Mega Evolution/Phantasmal Flames/127.ts
@@ -19,6 +19,7 @@ const card: Card = {
 	hp: 330,
 	types: ["Darkness"],
 	stage: "Stage1",
+	dexId: [319],
 
 	attacks: [{
 		cost: ["Darkness"],

--- a/data/Mega Evolution/Phantasmal Flames/128.ts
+++ b/data/Mega Evolution/Phantasmal Flames/128.ts
@@ -19,6 +19,7 @@ const card: Card = {
 	hp: 330,
 	types: ["Colorless"],
 	stage: "Stage1",
+	dexId: [428],
 
 	attacks: [{
 		cost: ["Colorless"],

--- a/data/Mega Evolution/Phantasmal Flames/130.ts
+++ b/data/Mega Evolution/Phantasmal Flames/130.ts
@@ -19,6 +19,7 @@ const card: Card = {
 	hp: 360,
 	types: ["Fire"],
 	stage: "Stage2",
+	dexId: [6],
 
 	attacks: [{
 		cost: ["Fire", "Fire"],

--- a/data/Scarlet & Violet/SVP Black Star Promos/102.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/102.ts
@@ -14,6 +14,7 @@ const card: Card = {
 	hp: 60,
 	types: ["Grass"],
 	stage: "Basic",
+	dexId: [43],
 
 	attacks: [
 		{

--- a/data/Scarlet & Violet/SVP Black Star Promos/190.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/190.ts
@@ -14,6 +14,7 @@ const card: Card = {
 	hp: 50,
 	types: ["Lightning"],
 	stage: "Basic",
+	dexId: [25],
 
 	attacks: [
 		{


### PR DESCRIPTION
# Add missing dexId fields to Pokemon cards
The update was performed using the [tcg_dex_api_parser](https://github.com/Tydragon00/tcg_dex_api_parser) script, which:

1. Scanned all existing cards to build a name → dexId mapping
2. Identified cards missing the `dexId` field
3. Automatically populated the missing dexId based on the Pokemon name
4. Handled special cases like:
   - "Mega Charizard X" → uses Charizard's dexId (6)
   - "Pikachu ex" → uses Pikachu's dexId (25)
