### PR TITLE
fix: Add evolveFrom for Obsidian Flames set 

### DIFF
--- a/data/Scarlet & Violet/Obsidian Flames/002.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/002.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 80,
 	types: ["Grass"],
+	evolveFrom: {
+		fr: "Mystherbe",
+		en: "Oddish",
+		es: "Oddish",
+		it: "Oddish",
+		pt: "Oddish",
+		de: "Myrapla"
+	},
 	stage: "Stage1",
 
 	attacks: [{

--- a/data/Scarlet & Violet/Obsidian Flames/003.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/003.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 130,
 	types: ["Grass"],
+	evolveFrom: {
+		fr: "Ortide",
+		en: "Gloom",
+		es: "Gloom",
+		it: "Gloom",
+		pt: "Gloom",
+		de: "Duflor"
+	},
 	stage: "Stage2",
 
 	attacks: [{

--- a/data/Scarlet & Violet/Obsidian Flames/007.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/007.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 100,
 	types: ["Grass"],
+	evolveFrom: {
+		fr: "Arakdo",
+		en: "Surskit",
+		es: "Surskit",
+		it: "Surskit",
+		pt: "Surskit",
+		de: "Gehweiher"
+	},
 	stage: "Stage1",
 
 	attacks: [{

--- a/data/Scarlet & Violet/Obsidian Flames/010.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/010.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 110,
 	types: ["Grass"],
+	evolveFrom: {
+		fr: "Trompignon",
+		en: "Foongus",
+		es: "Foongus",
+		it: "Foongus",
+		pt: "Foongus",
+		de: "Tarnpignon"
+	},
 	stage: "Stage1",
 
 	attacks: [{

--- a/data/Scarlet & Violet/Obsidian Flames/012.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/012.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 140,
 	types: ["Grass"],
+	evolveFrom: {
+		fr: "Brocélôme",
+		en: "Phantump",
+		es: "Phantump",
+		it: "Phantump",
+		pt: "Phantump",
+		de: "Paragoni"
+	},
 	stage: "Stage1",
 
 	abilities: [{

--- a/data/Scarlet & Violet/Obsidian Flames/014.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/014.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 90,
 	types: ["Grass"],
+	evolveFrom: {
+		fr: "Brindibou",
+		en: "Rowlet",
+		es: "Rowlet",
+		it: "Rowlet",
+		pt: "Rowlet",
+		de: "Bauz"
+	},
 	stage: "Stage1",
 
 	attacks: [{

--- a/data/Scarlet & Violet/Obsidian Flames/015.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/015.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 320,
 	types: ["Grass"],
+	evolveFrom: {
+		fr: "Efflèche",
+		en: "Dartrix",
+		es: "Dartrix",
+		it: "Dartrix",
+		pt: "Dartrix",
+		de: "Arboretoss"
+	},
 	stage: "Stage2",
 
 	abilities: [{

--- a/data/Scarlet & Violet/Obsidian Flames/017.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/017.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 90,
 	types: ["Grass"],
+	evolveFrom: {
+		fr: "Croquine",
+		en: "Bounsweet",
+		es: "Bounsweet",
+		it: "Bounsweet",
+		pt: "Bounsweet",
+		de: "Frubberl"
+	},
 	stage: "Stage1",
 
 	attacks: [{

--- a/data/Scarlet & Violet/Obsidian Flames/018.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/018.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 160,
 	types: ["Grass"],
+	evolveFrom: {
+		fr: "Candine",
+		en: "Steenee",
+		es: "Steenee",
+		it: "Steenee",
+		pt: "Steenee",
+		de: "Frubaila"
+	},
 	stage: "Stage2",
 
 	attacks: [{

--- a/data/Scarlet & Violet/Obsidian Flames/020.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/020.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 80,
 	types: ["Grass"],
+	evolveFrom: {
+		fr: "Olivini",
+		en: "Smoliv",
+		es: "Smoliv",
+		it: "Smoliv",
+		pt: "Smoliv",
+		de: "Olini"
+	},
 	stage: "Stage1",
 
 	attacks: [{

--- a/data/Scarlet & Violet/Obsidian Flames/021.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/021.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 140,
 	types: ["Grass"],
+	evolveFrom: {
+		fr: "Olivado",
+		en: "Dolliv",
+		es: "Dolliv",
+		it: "Dolliv",
+		pt: "Dolliv",
+		de: "Olivinio"
+	},
 	stage: "Stage2",
 
 	attacks: [{

--- a/data/Scarlet & Violet/Obsidian Flames/022.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/022.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 270,
 	types: ["Grass"],
+	evolveFrom: {
+		fr: "Terracool",
+		en: "Toedscool",
+		es: "Toedscool",
+		it: "Toedscool",
+		pt: "Toedscool",
+		de: "Tentagra"
+	},
 	stage: "Stage1",
 
 	abilities: [{

--- a/data/Scarlet & Violet/Obsidian Flames/025.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/025.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 110,
 	types: ["Grass"],
+	evolveFrom: {
+		fr: "Pimito",
+		en: "Capsakid",
+		es: "Capsakid",
+		it: "Capsakid",
+		pt: "Capsakid",
+		de: "Chilingel"
+	},
 	stage: "Stage1",
 
 	abilities: [{

--- a/data/Scarlet & Violet/Obsidian Flames/027.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/027.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 90,
 	types: ["Fire"],
+	evolveFrom: {
+		fr: "Salamèche",
+		en: "Charmander",
+		es: "Charmander",
+		it: "Charmander",
+		pt: "Charmander",
+		de: "Glumanda"
+	},
 	stage: "Stage1",
 
 	attacks: [{

--- a/data/Scarlet & Violet/Obsidian Flames/029.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/029.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 120,
 	types: ["Fire"],
+	evolveFrom: {
+		fr: "Goupix",
+		en: "Vulpix",
+		es: "Vulpix",
+		it: "Vulpix",
+		pt: "Vulpix",
+		de: "Vulpix"
+	},
 	stage: "Stage1",
 
 	attacks: [{

--- a/data/Scarlet & Violet/Obsidian Flames/032.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/032.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 140,
 	types: ["Fire"],
+	evolveFrom: {
+		fr: "Chamallot",
+		en: "Numel",
+		es: "Numel",
+		it: "Numel",
+		pt: "Numel",
+		de: "Camaub"
+	},
 	stage: "Stage1",
 
 	attacks: [{

--- a/data/Scarlet & Violet/Obsidian Flames/035.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/035.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 140,
 	types: ["Fire"],
+	evolveFrom: {
+		fr: "Darumarond",
+		en: "Darumaka",
+		es: "Darumaka",
+		it: "Darumaka",
+		pt: "Darumaka",
+		de: "Flampion"
+	},
 	stage: "Stage1",
 
 	attacks: [{

--- a/data/Scarlet & Violet/Obsidian Flames/037.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/037.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 80,
 	types: ["Fire"],
+	evolveFrom: {
+		fr: "Funécire",
+		en: "Litwick",
+		es: "Litwick",
+		it: "Litwick",
+		pt: "Litwick",
+		de: "Lichtel"
+	},
 	stage: "Stage1",
 
 	attacks: [{

--- a/data/Scarlet & Violet/Obsidian Flames/038.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/038.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 150,
 	types: ["Fire"],
+	evolveFrom: {
+		fr: "Mélancolux",
+		en: "Lampent",
+		es: "Lampent",
+		it: "Lampent",
+		pt: "Lampent",
+		de: "Laternecto"
+	},
 	stage: "Stage2",
 
 	attacks: [{

--- a/data/Scarlet & Violet/Obsidian Flames/041.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/041.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 140,
 	types: ["Fire"],
+	evolveFrom: {
+		fr: "Pyronille",
+		en: "Larvesta",
+		es: "Larvesta",
+		it: "Larvesta",
+		pt: "Larvesta",
+		de: "Ignivor"
+	},
 	stage: "Stage1",
 
 	attacks: [{

--- a/data/Scarlet & Violet/Obsidian Flames/044.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/044.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 120,
 	types: ["Fire"],
+	evolveFrom: {
+		fr: "Charbambin",
+		en: "Charcadet",
+		es: "Charcadet",
+		it: "Charcadet",
+		pt: "Charcadet",
+		de: "Knarbon"
+	},
 	stage: "Stage1",
 
 	abilities: [{

--- a/data/Scarlet & Violet/Obsidian Flames/047.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/047.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 120,
 	types: ["Water"],
+	evolveFrom: {
+		fr: "Carvanha",
+		en: "Carvanha",
+		es: "Carvanha",
+		it: "Carvanha",
+		pt: "Carvanha",
+		de: "Kanivanha"
+	},
 	stage: "Stage1",
 
 	attacks: [{

--- a/data/Scarlet & Violet/Obsidian Flames/049.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/049.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 110,
 	types: ["Water"],
+	evolveFrom: {
+		fr: "Mustébouée",
+		en: "Buizel",
+		es: "Buizel",
+		it: "Buizel",
+		pt: "Buizel",
+		de: "Bamelin"
+	},
 	stage: "Stage1",
 
 	attacks: [{

--- a/data/Scarlet & Violet/Obsidian Flames/051.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/051.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 100,
 	types: ["Water"],
+	evolveFrom: {
+		fr: "Tritonde",
+		en: "Tympole",
+		es: "Tympole",
+		it: "Tympole",
+		pt: "Tympole",
+		de: "Schallquap"
+	},
 	stage: "Stage1",
 
 	attacks: [{

--- a/data/Scarlet & Violet/Obsidian Flames/052.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/052.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 170,
 	types: ["Water"],
+	evolveFrom: {
+		fr: "Batracné",
+		en: "Palpitoad",
+		es: "Palpitoad",
+		it: "Palpitoad",
+		pt: "Palpitoad",
+		de: "Mebrana"
+	},
 	stage: "Stage2",
 
 	abilities: [{

--- a/data/Scarlet & Violet/Obsidian Flames/054.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/054.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 150,
 	types: ["Water"],
+	evolveFrom: {
+		fr: "Polarhume",
+		en: "Cubchoo",
+		es: "Cubchoo",
+		it: "Cubchoo",
+		pt: "Cubchoo",
+		de: "Petznief"
+	},
 	stage: "Stage1",
 
 	attacks: [{

--- a/data/Scarlet & Violet/Obsidian Flames/057.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/057.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 90,
 	types: ["Water"],
+	evolveFrom: {
+		fr: "Grenousse",
+		en: "Froakie",
+		es: "Froakie",
+		it: "Froakie",
+		pt: "Froakie",
+		de: "Froxy"
+	},
 	stage: "Stage1",
 
 	attacks: [{

--- a/data/Scarlet & Violet/Obsidian Flames/059.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/059.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 90,
 	types: ["Water"],
+	evolveFrom: {
+		fr: "Taupikeau",
+		en: "Wiglett",
+		es: "Wiglett",
+		it: "Wiglett",
+		pt: "Wiglett",
+		de: "Schligda"
+	},
 	stage: "Stage1",
 
 	attacks: [{

--- a/data/Scarlet & Violet/Obsidian Flames/062.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/062.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 150,
 	types: ["Water"],
+	evolveFrom: {
+		fr: "Dofin",
+		en: "Finizen",
+		es: "Finizen",
+		it: "Finizen",
+		pt: "Finizen",
+		de: "Normifin"
+	},
 	stage: "Stage1",
 
 	attacks: [{

--- a/data/Scarlet & Violet/Obsidian Flames/064.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/064.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 90,
 	types: ["Lightning"],
+	evolveFrom: {
+		fr: "Magnéti",
+		en: "Magnemite",
+		es: "Magnemite",
+		it: "Magnemite",
+		pt: "Magnemite",
+		de: "Magnetilo"
+	},
 	stage: "Stage1",
 
 	attacks: [{

--- a/data/Scarlet & Violet/Obsidian Flames/065.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/065.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 170,
 	types: ["Lightning"],
+	evolveFrom: {
+		fr: "Magnéton",
+		en: "Magneton",
+		es: "Magneton",
+		it: "Magneton",
+		pt: "Magneton",
+		de: "Magneton"
+	},
 	stage: "Stage2",
 
 	attacks: [{

--- a/data/Scarlet & Violet/Obsidian Flames/066.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/066.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 340,
 	types: ["Lightning"],
+	evolveFrom: {
+		fr: "Ymphect",
+		en: "Pupitar",
+		es: "Pupitar",
+		it: "Pupitar",
+		pt: "Pupitar",
+		de: "Pupitar"
+	},
 	stage: "Stage2",
 
 	attacks: [{

--- a/data/Scarlet & Violet/Obsidian Flames/068.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/068.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 90,
 	types: ["Lightning"],
+	evolveFrom: {
+		fr: "Anchwatt",
+		en: "Tynamo",
+		es: "Tynamo",
+		it: "Tynamo",
+		pt: "Tynamo",
+		de: "Zapplardin"
+	},
 	stage: "Stage1",
 
 	attacks: [{

--- a/data/Scarlet & Violet/Obsidian Flames/069.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/069.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 160,
 	types: ["Lightning"],
+	evolveFrom: {
+		fr: "Lampéroie",
+		en: "Eelektrik",
+		es: "Eelektrik",
+		it: "Eelektrik",
+		pt: "Eelektrik",
+		de: "Zapplalek"
+	},
 	stage: "Stage2",
 
 	attacks: [{

--- a/data/Scarlet & Violet/Obsidian Flames/072.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/072.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 140,
 	types: ["Lightning"],
+	evolveFrom: {
+		fr: "Toxizap",
+		en: "Toxel",
+		es: "Toxel",
+		it: "Toxel",
+		pt: "Toxel",
+		de: "Toxel"
+	},
 	stage: "Stage1",
 
 	attacks: [{

--- a/data/Scarlet & Violet/Obsidian Flames/073.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/073.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 300,
 	types: ["Lightning"],
+	evolveFrom: {
+		fr: "Pohmotte",
+		en: "Pawmo",
+		es: "Pawmo",
+		it: "Pawmo",
+		pt: "Pawmo",
+		de: "Pamamo"
+	},
 	stage: "Stage2",
 
 	attacks: [{

--- a/data/Scarlet & Violet/Obsidian Flames/077.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/077.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 130,
 	types: ["Lightning"],
+	evolveFrom: {
+		fr: "Têtampoule",
+		en: "Tadbulb",
+		es: "Tadbulb",
+		it: "Tadbulb",
+		pt: "Tadbulb",
+		de: "Blipp"
+	},
 	stage: "Stage1",
 
 	attacks: [{

--- a/data/Scarlet & Violet/Obsidian Flames/078.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/078.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 140,
 	types: ["Lightning"],
+	evolveFrom: {
+		fr: "Têtampoule",
+		en: "Tadbulb",
+		es: "Tadbulb",
+		it: "Tadbulb",
+		pt: "Tadbulb",
+		de: "Blipp"
+	},
 	stage: "Stage1",
 
 	abilities: [{

--- a/data/Scarlet & Violet/Obsidian Flames/082.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/082.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 260,
 	types: ["Psychic"],
+	evolveFrom: {
+		fr: "Mélofée",
+		en: "Clefairy",
+		es: "Clefairy",
+		it: "Clefairy",
+		pt: "Clefairy",
+		de: "Piepi"
+	},
 	stage: "Stage1",
 
 	abilities: [{

--- a/data/Scarlet & Violet/Obsidian Flames/084.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/084.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 90,
 	types: ["Psychic"],
+	evolveFrom: {
+		fr: "Togepi",
+		en: "Togepi",
+		es: "Togepi",
+		it: "Togepi",
+		pt: "Togepi",
+		de: "Togepi"
+	},
 	stage: "Stage1",
 
 	attacks: [{

--- a/data/Scarlet & Violet/Obsidian Flames/085.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/085.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 150,
 	types: ["Psychic"],
+	evolveFrom: {
+		fr: "Togetic",
+		en: "Togetic",
+		es: "Togetic",
+		it: "Togetic",
+		pt: "Togetic",
+		de: "Togetic"
+	},
 	stage: "Stage2",
 
 	abilities: [{

--- a/data/Scarlet & Violet/Obsidian Flames/086.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/086.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 110,
 	types: ["Psychic"],
+	evolveFrom: {
+		fr: "Évoli",
+		en: "Eevee",
+		es: "Eevee",
+		it: "Eevee",
+		pt: "Eevee",
+		de: "Evoli"
+	},
 	stage: "Stage1",
 
 	attacks: [{

--- a/data/Scarlet & Violet/Obsidian Flames/088.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/088.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 130,
 	types: ["Psychic"],
+	evolveFrom: {
+		fr: "Snubbull",
+		en: "Snubbull",
+		es: "Snubbull",
+		it: "Snubbull",
+		pt: "Snubbull",
+		de: "Snubbull"
+	},
 	stage: "Stage1",
 
 	attacks: [{

--- a/data/Scarlet & Violet/Obsidian Flames/091.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/091.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 120,
 	types: ["Psychic"],
+	evolveFrom: {
+		fr: "Spoink",
+		en: "Spoink",
+		es: "Spoink",
+		it: "Spoink",
+		pt: "Spoink",
+		de: "Spoink"
+	},
 	stage: "Stage1",
 
 	attacks: [{

--- a/data/Scarlet & Violet/Obsidian Flames/095.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/095.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 120,
 	types: ["Psychic"],
+	evolveFrom: {
+		fr: "Balbuto",
+		en: "Baltoy",
+		es: "Baltoy",
+		it: "Baltoy",
+		pt: "Baltoy",
+		de: "Puppance"
+	},
 	stage: "Stage1",
 
 	attacks: [{

--- a/data/Scarlet & Violet/Obsidian Flames/096.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/096.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 270,
 	types: ["Psychic"],
+	evolveFrom: {
+		fr: "Apitrini",
+		en: "Combee",
+		es: "Combee",
+		it: "Combee",
+		pt: "Combee",
+		de: "Wadribie"
+	},
 	stage: "Stage1",
 
 	attacks: [{

--- a/data/Scarlet & Violet/Obsidian Flames/098.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/098.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 70,
 	types: ["Psychic"],
+	evolveFrom: {
+		fr: "Théffroi",
+		en: "Sinistea",
+		es: "Sinistea",
+		it: "Sinistea",
+		pt: "Sinistea",
+		de: "Fatalitee"
+	},
 	stage: "Stage1",
 
 	attacks: [{

--- a/data/Scarlet & Violet/Obsidian Flames/101.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/101.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 140,
 	types: ["Psychic"],
+	evolveFrom: {
+		fr: "Toutombe",
+		en: "Greavard",
+		es: "Greavard",
+		it: "Greavard",
+		pt: "Greavard",
+		de: "Gruff"
+	},
 	stage: "Stage1",
 
 	attacks: [{

--- a/data/Scarlet & Violet/Obsidian Flames/102.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/102.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 260,
 	types: ["Psychic"],
+	evolveFrom: {
+		fr: "Toutombe",
+		en: "Greavard",
+		es: "Greavard",
+		it: "Greavard",
+		pt: "Greavard",
+		de: "Gruff"
+	},
 	stage: "Stage1",
 
 	attacks: [{

--- a/data/Scarlet & Violet/Obsidian Flames/104.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/104.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 90,
 	types: ["Fighting"],
+	evolveFrom: {
+		fr: "Taupiqueur",
+		en: "Diglett",
+		es: "Diglett",
+		it: "Diglett",
+		pt: "Diglett",
+		de: "Digda"
+	},
 	stage: "Stage1",
 
 	attacks: [{

--- a/data/Scarlet & Violet/Obsidian Flames/106.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/106.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 80,
 	types: ["Fighting"],
+	evolveFrom: {
+		fr: "Embrylex",
+		en: "Larvitar",
+		es: "Larvitar",
+		it: "Larvitar",
+		pt: "Larvitar",
+		de: "Larvitar"
+	},
 	stage: "Stage1",
 
 	attacks: [{

--- a/data/Scarlet & Violet/Obsidian Flames/109.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/109.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 140,
 	types: ["Fighting"],
+	evolveFrom: {
+		fr: "Barloche",
+		en: "Barboach",
+		es: "Barboach",
+		it: "Barboach",
+		pt: "Barboach",
+		de: "Schmerbe"
+	},
 	stage: "Stage1",
 
 	attacks: [{

--- a/data/Scarlet & Violet/Obsidian Flames/113.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/113.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 140,
 	types: ["Fighting"],
+	evolveFrom: {
+		fr: "Sapereau",
+		en: "Bunnelby",
+		es: "Bunnelby",
+		it: "Bunnelby",
+		pt: "Bunnelby",
+		de: "Scoppel"
+	},
 	stage: "Stage1",
 
 	attacks: [{

--- a/data/Scarlet & Violet/Obsidian Flames/115.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/115.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 160,
 	types: ["Fighting"],
+	evolveFrom: {
+		fr: "Crabagarre",
+		en: "Crabrawler",
+		es: "Crabrawler",
+		it: "Crabrawler",
+		pt: "Crabrawler",
+		de: "Krabbox"
+	},
 	stage: "Stage1",
 
 	attacks: [{

--- a/data/Scarlet & Violet/Obsidian Flames/117.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/117.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 130,
 	types: ["Fighting"],
+	evolveFrom: {
+		fr: "Rocabot",
+		en: "Rockruff",
+		es: "Rockruff",
+		it: "Rockruff",
+		pt: "Rockruff",
+		de: "Wuffels"
+	},
 	stage: "Stage1",
 
 	attacks: [{

--- a/data/Scarlet & Violet/Obsidian Flames/119.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/119.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 130,
 	types: ["Fighting"],
+	evolveFrom: {
+		fr: "Terracool",
+		en: "Toedscool",
+		es: "Toedscool",
+		it: "Toedscool",
+		pt: "Toedscool",
+		de: "Tentagra"
+	},
 	stage: "Stage1",
 
 	attacks: [{

--- a/data/Scarlet & Violet/Obsidian Flames/123.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/123.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 270,
 	types: ["Fighting"],
+	evolveFrom: {
+		fr: "Germéclat",
+		en: "Glimmet",
+		es: "Glimmet",
+		it: "Glimmet",
+		pt: "Glimmet",
+		de: "Lumispross"
+	},
 	stage: "Stage1",
 
 	abilities: [{

--- a/data/Scarlet & Violet/Obsidian Flames/125.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/125.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 330,
 	types: ["Darkness"],
+	evolveFrom: {
+		fr: "Reptincel",
+		en: "Charmeleon",
+		es: "Charmeleon",
+		it: "Charmeleon",
+		pt: "Charmeleon",
+		de: "Glutexo"
+	},
 	stage: "Stage2",
 
 	abilities: [{

--- a/data/Scarlet & Violet/Obsidian Flames/128.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/128.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 140,
 	types: ["Darkness"],
+	evolveFrom: {
+		fr: "Axoloto de Paldea",
+		en: "Paldean Wooper",
+		es: "Wooper de Paldea",
+		it: "Wooper di Paldea",
+		pt: "Wooper de Paldea",
+		de: "Paldea-Felino"
+	},
 	stage: "Stage1",
 
 	attacks: [{

--- a/data/Scarlet & Violet/Obsidian Flames/129.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/129.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 140,
 	types: ["Darkness"],
+	evolveFrom: {
+		fr: "Axoloto de Paldea",
+		en: "Paldean Wooper",
+		es: "Wooper de Paldea",
+		it: "Wooper di Paldea",
+		pt: "Wooper de Paldea",
+		de: "Paldea-Felino"
+	},
 	stage: "Stage1",
 
 	attacks: [{

--- a/data/Scarlet & Violet/Obsidian Flames/130.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/130.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 110,
 	types: ["Darkness"],
+	evolveFrom: {
+		fr: "Évoli",
+		en: "Eevee",
+		es: "Eevee",
+		it: "Eevee",
+		pt: "Eevee",
+		de: "Evoli"
+	},
 	stage: "Stage1",
 
 	attacks: [{

--- a/data/Scarlet & Violet/Obsidian Flames/133.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/133.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 130,
 	types: ["Darkness"],
+	evolveFrom: {
+		fr: "Malosse",
+		en: "Houndour",
+		es: "Houndour",
+		it: "Houndour",
+		pt: "Houndour",
+		de: "Hunduster"
+	},
 	stage: "Stage1",
 
 	attacks: [{

--- a/data/Scarlet & Violet/Obsidian Flames/134.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/134.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 270,
 	types: ["Darkness"],
+	evolveFrom: {
+		fr: "Malosse",
+		en: "Houndour",
+		es: "Houndour",
+		it: "Houndour",
+		pt: "Houndour",
+		de: "Hunduster"
+	},
 	stage: "Stage1",
 
 	attacks: [{

--- a/data/Scarlet & Violet/Obsidian Flames/138.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/138.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 120,
 	types: ["Darkness"],
+	evolveFrom: {
+		fr: "Sepiatop",
+		en: "Inkay",
+		es: "Inkay",
+		it: "Inkay",
+		pt: "Inkay",
+		de: "Iscalar"
+	},
 	stage: "Stage1",
 
 	abilities: [{

--- a/data/Scarlet & Violet/Obsidian Flames/140.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/140.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 120,
 	types: ["Darkness"],
+	evolveFrom: {
+		fr: "Tritox",
+		en: "Salandit",
+		es: "Salandit",
+		it: "Salandit",
+		pt: "Salandit",
+		de: "Molunk"
+	},
 	stage: "Stage1",
 
 	attacks: [{

--- a/data/Scarlet & Violet/Obsidian Flames/141.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/141.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 140,
 	types: ["Metal"],
+	evolveFrom: {
+		fr: "Insécateur",
+		en: "Scyther",
+		es: "Scyther",
+		it: "Scyther",
+		pt: "Scyther",
+		de: "Sichlor"
+	},
 	stage: "Stage1",
 
 	attacks: [{

--- a/data/Scarlet & Violet/Obsidian Flames/145.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/145.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 140,
 	types: ["Metal"],
+	evolveFrom: {
+		fr: "Archéomire",
+		en: "Bronzor",
+		es: "Bronzor",
+		it: "Bronzor",
+		pt: "Bronzor",
+		de: "Bronzel"
+	},
 	stage: "Stage1",
 
 	attacks: [{

--- a/data/Scarlet & Violet/Obsidian Flames/146.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/146.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 150,
 	types: ["Metal"],
+	evolveFrom: {
+		fr: "Tarinor",
+		en: "Nosepass",
+		es: "Nosepass",
+		it: "Nosepass",
+		pt: "Nosepass",
+		de: "Nasgnet"
+	},
 	stage: "Stage1",
 
 	attacks: [{

--- a/data/Scarlet & Violet/Obsidian Flames/147.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/147.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 120,
 	types: ["Metal"],
+	evolveFrom: {
+		fr: "Rototaupe",
+		en: "Drilbur",
+		es: "Drilbur",
+		it: "Drilbur",
+		pt: "Drilbur",
+		de: "Rotomurf"
+	},
 	stage: "Stage1",
 
 	attacks: [{

--- a/data/Scarlet & Violet/Obsidian Flames/149.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/149.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 110,
 	types: ["Metal"],
+	evolveFrom: {
+		fr: "Scalpion",
+		en: "Pawniard",
+		es: "Pawniard",
+		it: "Pawniard",
+		pt: "Pawniard",
+		de: "Gladiantri"
+	},
 	stage: "Stage1",
 
 	attacks: [{

--- a/data/Scarlet & Violet/Obsidian Flames/150.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/150.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 180,
 	types: ["Metal"],
+	evolveFrom: {
+		fr: "Scalproie",
+		en: "Bisharp",
+		es: "Bisharp",
+		it: "Bisharp",
+		pt: "Bisharp",
+		de: "Caesurio"
+	},
 	stage: "Stage2",
 
 	attacks: [{

--- a/data/Scarlet & Violet/Obsidian Flames/153.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/153.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 300,
 	types: ["Metal"],
+	evolveFrom: {
+		fr: "Meltan",
+		en: "Meltan",
+		es: "Meltan",
+		it: "Meltan",
+		pt: "Meltan",
+		de: "Meltan"
+	},
 	stage: "Stage1",
 
 	attacks: [{

--- a/data/Scarlet & Violet/Obsidian Flames/156.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/156.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 280,
 	types: ["Metal"],
+	evolveFrom: {
+		fr: "Vrombi",
+		en: "Varoom",
+		es: "Varoom",
+		it: "Varoom",
+		pt: "Varoom",
+		de: "Knattox"
+	},
 	stage: "Stage1",
 
 	abilities: [{

--- a/data/Scarlet & Violet/Obsidian Flames/158.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/158.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 100,
 	types: ["Dragon"],
+	evolveFrom: {
+		fr: "Minidraco",
+		en: "Dratini",
+		es: "Dratini",
+		it: "Dratini",
+		pt: "Dratini",
+		de: "Dratini"
+	},
 	stage: "Stage1",
 
 	attacks: [{

--- a/data/Scarlet & Violet/Obsidian Flames/159.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/159.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 330,
 	types: ["Dragon"],
+	evolveFrom: {
+		fr: "Draco",
+		en: "Dragonair",
+		es: "Dragonair",
+		it: "Dragonair",
+		pt: "Dragonair",
+		de: "Dragonir"
+	},
 	stage: "Stage2",
 
 	attacks: [{

--- a/data/Scarlet & Violet/Obsidian Flames/160.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/160.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 120,
 	types: ["Dragon"],
+	evolveFrom: {
+		fr: "Tylton",
+		en: "Swablu",
+		es: "Swablu",
+		it: "Swablu",
+		pt: "Swablu",
+		de: "Wablu"
+	},
 	stage: "Stage1",
 
 	attacks: [{

--- a/data/Scarlet & Violet/Obsidian Flames/163.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/163.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 90,
 	types: ["Colorless"],
+	evolveFrom: {
+		fr: "Roucool",
+		en: "Pidgey",
+		es: "Pidgey",
+		it: "Pidgey",
+		pt: "Pidgey",
+		de: "Taubsi"
+	},
 	stage: "Stage1",
 
 	attacks: [{

--- a/data/Scarlet & Violet/Obsidian Flames/164.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/164.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 280,
 	types: ["Colorless"],
+	evolveFrom: {
+		fr: "Roucoups",
+		en: "Pidgeotto",
+		es: "Pidgeotto",
+		it: "Pidgeotto",
+		pt: "Pidgeotto",
+		de: "Tauboga"
+	},
 	stage: "Stage2",
 
 	abilities: [{

--- a/data/Scarlet & Violet/Obsidian Flames/168.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/168.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 110,
 	types: ["Colorless"],
+	evolveFrom: {
+		fr: "Zigzaton",
+		en: "Zigzagoon",
+		es: "Zigzagoon",
+		it: "Zigzagoon",
+		pt: "Zigzagoon",
+		de: "Zigzachs"
+	},
 	stage: "Stage1",
 
 	attacks: [{

--- a/data/Scarlet & Violet/Obsidian Flames/171.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/171.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 90,
 	types: ["Colorless"],
+	evolveFrom: {
+		fr: "Ponchiot",
+		en: "Lillipup",
+		es: "Lillipup",
+		it: "Lillipup",
+		pt: "Lillipup",
+		de: "Yorkleff"
+	},
 	stage: "Stage1",
 
 	attacks: [{

--- a/data/Scarlet & Violet/Obsidian Flames/172.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/172.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 160,
 	types: ["Colorless"],
+	evolveFrom: {
+		fr: "Ponchien",
+		en: "Herdier",
+		es: "Herdier",
+		it: "Herdier",
+		pt: "Herdier",
+		de: "Terribark"
+	},
 	stage: "Stage2",
 
 	attacks: [{

--- a/data/Scarlet & Violet/Obsidian Flames/177.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/177.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 120,
 	types: ["Colorless"],
+	evolveFrom: {
+		fr: "Manglouton",
+		en: "Yungoos",
+		es: "Yungoos",
+		it: "Yungoos",
+		pt: "Yungoos",
+		de: "Mangunior"
+	},
 	stage: "Stage1",
 
 	attacks: [{

--- a/data/Scarlet & Violet/Obsidian Flames/179.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/179.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 260,
 	types: ["Colorless"],
+	evolveFrom: {
+		fr: "Rongourmand",
+		en: "Skwovet",
+		es: "Skwovet",
+		it: "Skwovet",
+		pt: "Skwovet",
+		de: "Raffel"
+	},
 	stage: "Stage1",
 
 	attacks: [{

--- a/data/Scarlet & Violet/Obsidian Flames/183.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/183.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 120,
 	types: ["Colorless"],
+	evolveFrom: {
+		fr: "Gourmelet",
+		en: "Lechonk",
+		es: "Lechonk",
+		it: "Lechonk",
+		pt: "Lechonk",
+		de: "Ferkuli"
+	},
 	stage: "Stage1",
 
 	attacks: [{

--- a/data/Scarlet & Violet/Obsidian Flames/184.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/184.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 130,
 	types: ["Colorless"],
+	evolveFrom: {
+		fr: "Gourmelet",
+		en: "Lechonk",
+		es: "Lechonk",
+		it: "Lechonk",
+		pt: "Lechonk",
+		de: "Ferkuli"
+	},
 	stage: "Stage1",
 
 	attacks: [{

--- a/data/Scarlet & Violet/Obsidian Flames/198.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/198.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 80,
 	types: ["Grass"],
+	evolveFrom: {
+		fr: "Mystherbe",
+		en: "Oddish",
+		es: "Oddish",
+		it: "Oddish",
+		pt: "Oddish",
+		de: "Myrapla"
+	},
 	stage: "Stage1",
 
 	attacks: [{

--- a/data/Scarlet & Violet/Obsidian Flames/199.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/199.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 120,
 	types: ["Fire"],
+	evolveFrom: {
+		fr: "Goupix",
+		en: "Vulpix",
+		es: "Vulpix",
+		it: "Vulpix",
+		pt: "Vulpix",
+		de: "Vulpix"
+	},
 	stage: "Stage1",
 
 	attacks: [{

--- a/data/Scarlet & Violet/Obsidian Flames/200.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/200.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 150,
 	types: ["Water"],
+	evolveFrom: {
+		fr: "Dofin",
+		en: "Finizen",
+		es: "Finizen",
+		it: "Finizen",
+		pt: "Finizen",
+		de: "Normifin"
+	},
 	stage: "Stage1",
 
 	attacks: [{

--- a/data/Scarlet & Violet/Obsidian Flames/201.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/201.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 140,
 	types: ["Lightning"],
+	evolveFrom: {
+		fr: "Têtampoule",
+		en: "Tadbulb",
+		es: "Tadbulb",
+		it: "Tadbulb",
+		pt: "Tadbulb",
+		de: "Blipp"
+	},
 	stage: "Stage1",
 
 	abilities: [{

--- a/data/Scarlet & Violet/Obsidian Flames/205.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/205.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 140,
 	types: ["Metal"],
+	evolveFrom: {
+		fr: "Insécateur",
+		en: "Scyther",
+		es: "Scyther",
+		it: "Scyther",
+		pt: "Scyther",
+		de: "Sichlor"
+	},
 	stage: "Stage1",
 
 	attacks: [{

--- a/data/Scarlet & Violet/Obsidian Flames/208.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/208.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 90,
 	types: ["Colorless"],
+	evolveFrom: {
+		fr: "Roucool",
+		en: "Pidgey",
+		es: "Pidgey",
+		it: "Pidgey",
+		pt: "Pidgey",
+		de: "Taubsi"
+	},
 	stage: "Stage1",
 
 	attacks: [{

--- a/data/Scarlet & Violet/Obsidian Flames/211.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/211.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 340,
 	types: ["Lightning"],
+	evolveFrom: {
+		fr: "Ymphect",
+		en: "Pupitar",
+		es: "Pupitar",
+		it: "Pupitar",
+		pt: "Pupitar",
+		de: "Pupitar"
+	},
 	stage: "Stage2",
 
 	attacks: [{

--- a/data/Scarlet & Violet/Obsidian Flames/212.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/212.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 270,
 	types: ["Psychic"],
+	evolveFrom: {
+		fr: "Apitrini",
+		en: "Combee",
+		es: "Combee",
+		it: "Combee",
+		pt: "Combee",
+		de: "Wadribie"
+	},
 	stage: "Stage1",
 
 	attacks: [{

--- a/data/Scarlet & Violet/Obsidian Flames/213.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/213.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 270,
 	types: ["Fighting"],
+	evolveFrom: {
+		fr: "Germéclat",
+		en: "Glimmet",
+		es: "Glimmet",
+		it: "Glimmet",
+		pt: "Glimmet",
+		de: "Lumispross"
+	},
 	stage: "Stage1",
 
 	abilities: [{

--- a/data/Scarlet & Violet/Obsidian Flames/215.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/215.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 330,
 	types: ["Darkness"],
+	evolveFrom: {
+		fr: "Reptincel",
+		en: "Charmeleon",
+		es: "Charmeleon",
+		it: "Charmeleon",
+		pt: "Charmeleon",
+		de: "Glutexo"
+	},
 	stage: "Stage2",
 
 	abilities: [{

--- a/data/Scarlet & Violet/Obsidian Flames/216.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/216.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 280,
 	types: ["Metal"],
+	evolveFrom: {
+		fr: "Vrombi",
+		en: "Varoom",
+		es: "Varoom",
+		it: "Varoom",
+		pt: "Varoom",
+		de: "Knattox"
+	},
 	stage: "Stage1",
 
 	abilities: [{

--- a/data/Scarlet & Violet/Obsidian Flames/217.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/217.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 280,
 	types: ["Colorless"],
+	evolveFrom: {
+		fr: "Roucoups",
+		en: "Pidgeotto",
+		es: "Pidgeotto",
+		it: "Pidgeotto",
+		pt: "Pidgeotto",
+		de: "Tauboga"
+	},
 	stage: "Stage2",
 
 	abilities: [{

--- a/data/Scarlet & Violet/Obsidian Flames/223.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/223.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 330,
 	types: ["Darkness"],
+	evolveFrom: {
+		fr: "Reptincel",
+		en: "Charmeleon",
+		es: "Charmeleon",
+		it: "Charmeleon",
+		pt: "Charmeleon",
+		de: "Glutexo"
+	},
 	stage: "Stage2",
 
 	abilities: [{

--- a/data/Scarlet & Violet/Obsidian Flames/224.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/224.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 280,
 	types: ["Metal"],
+	evolveFrom: {
+		fr: "Vrombi",
+		en: "Varoom",
+		es: "Varoom",
+		it: "Varoom",
+		pt: "Varoom",
+		de: "Knattox"
+	},
 	stage: "Stage1",
 
 	abilities: [{

--- a/data/Scarlet & Violet/Obsidian Flames/225.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/225.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 280,
 	types: ["Colorless"],
+	evolveFrom: {
+		fr: "Roucoups",
+		en: "Pidgeotto",
+		es: "Pidgeotto",
+		it: "Pidgeotto",
+		pt: "Pidgeotto",
+		de: "Tauboga"
+	},
 	stage: "Stage2",
 
 	abilities: [{

--- a/data/Scarlet & Violet/Obsidian Flames/228.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/228.ts
@@ -18,6 +18,14 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 330,
 	types: ["Darkness"],
+	evolveFrom: {
+		fr: "Reptincel",
+		en: "Charmeleon",
+		es: "Charmeleon",
+		it: "Charmeleon",
+		pt: "Charmeleon",
+		de: "Glutexo"
+	},
 	stage: "Stage2",
 
 	abilities: [{


### PR DESCRIPTION
Add the "evolveFrom" field to multiple cards in the Obsidian Flames set