### PR TITLE
fix: Add Cardmarket IDs to Phantasmal Flames

### DIFF
--- a/data/Mega Evolution/Phantasmal Flames/001.ts
+++ b/data/Mega Evolution/Phantasmal Flames/001.ts
@@ -37,7 +37,11 @@ const card: Card = {
 	}],
 
 	retreat: 1,
-	regulationMark: "I"
+	regulationMark: "I",
+
+	thirdParty: {
+		cardmarket: 857576, 
+	}
 }
 
 export default card

--- a/data/Mega Evolution/Phantasmal Flames/002.ts
+++ b/data/Mega Evolution/Phantasmal Flames/002.ts
@@ -47,7 +47,11 @@ const card: Card = {
 	}],
 
 	retreat: 1,
-	regulationMark: "I"
+	regulationMark: "I", 
+
+	thirdParty: {
+		cardmarket: 857577
+	}
 }
 
 export default card

--- a/data/Mega Evolution/Phantasmal Flames/003.ts
+++ b/data/Mega Evolution/Phantasmal Flames/003.ts
@@ -71,7 +71,11 @@ const card: Card = {
 	}],
 
 	retreat: 2,
-	regulationMark: "I"
+	regulationMark: "I",
+
+	thirdParty: {
+		cardmarket: 857578,
+	}
 }
 
 export default card

--- a/data/Mega Evolution/Phantasmal Flames/004.ts
+++ b/data/Mega Evolution/Phantasmal Flames/004.ts
@@ -71,7 +71,11 @@ const card: Card = {
 	}],
 
 	retreat: 2,
-	regulationMark: "I"
+	regulationMark: "I",
+
+	thirdParty: {
+		cardmarket: 857579, 
+	}
 }
 
 export default card

--- a/data/Mega Evolution/Phantasmal Flames/005.ts
+++ b/data/Mega Evolution/Phantasmal Flames/005.ts
@@ -37,7 +37,11 @@ const card: Card = {
 	}],
 
 	retreat: 1,
-	regulationMark: "I"
+	regulationMark: "I",
+
+	thirdParty: {
+		cardmarket: 857580, 
+	}
 }
 
 export default card

--- a/data/Mega Evolution/Phantasmal Flames/006.ts
+++ b/data/Mega Evolution/Phantasmal Flames/006.ts
@@ -47,7 +47,11 @@ const card: Card = {
 	}],
 
 	retreat: 1,
-	regulationMark: "I"
+	regulationMark: "I",
+
+	thirdParty: {
+		cardmarket: 857581
+	}
 }
 
 export default card

--- a/data/Mega Evolution/Phantasmal Flames/007.ts
+++ b/data/Mega Evolution/Phantasmal Flames/007.ts
@@ -61,7 +61,11 @@ const card: Card = {
 	}],
 
 	retreat: 2,
-	regulationMark: "I"
+	regulationMark: "I",
+
+	thirdParty: {
+		cardmarket: 857582
+	}
 }
 
 export default card

--- a/data/Mega Evolution/Phantasmal Flames/008.ts
+++ b/data/Mega Evolution/Phantasmal Flames/008.ts
@@ -59,7 +59,11 @@ const card: Card = {
 	}],
 
 	retreat: 2,
-	regulationMark: "I"
+	regulationMark: "I",
+
+	thirdParty: {
+		cardmarket: 857583
+	}
 }
 
 export default card

--- a/data/Mega Evolution/Phantasmal Flames/009.ts
+++ b/data/Mega Evolution/Phantasmal Flames/009.ts
@@ -47,7 +47,11 @@ const card: Card = {
 	}],
 
 	retreat: 1,
-	regulationMark: "I"
+	regulationMark: "I",
+
+	thirdParty: {
+		cardmarket: 857584
+	}
 }
 
 export default card

--- a/data/Mega Evolution/Phantasmal Flames/010.ts
+++ b/data/Mega Evolution/Phantasmal Flames/010.ts
@@ -61,7 +61,11 @@ const card: Card = {
 	}],
 
 	retreat: 1,
-	regulationMark: "I"
+	regulationMark: "I",
+
+	thirdParty: {
+		cardmarket: 857585,
+	}
 }
 
 export default card

--- a/data/Mega Evolution/Phantasmal Flames/011.ts
+++ b/data/Mega Evolution/Phantasmal Flames/011.ts
@@ -61,7 +61,11 @@ const card: Card = {
 	}],
 
 	retreat: 2,
-	regulationMark: "I"
+	regulationMark: "I",
+
+	thirdParty: {
+		cardmarket: 857586
+	}
 }
 
 export default card

--- a/data/Mega Evolution/Phantasmal Flames/012.ts
+++ b/data/Mega Evolution/Phantasmal Flames/012.ts
@@ -37,7 +37,11 @@ const card: Card = {
 	}],
 
 	retreat: 2,
-	regulationMark: "I"
+	regulationMark: "I",
+
+	thirdParty: {
+		cardmarket: 857587
+	}
 }
 
 export default card

--- a/data/Mega Evolution/Phantasmal Flames/013.ts
+++ b/data/Mega Evolution/Phantasmal Flames/013.ts
@@ -47,7 +47,11 @@ const card: Card = {
 	}],
 
 	retreat: 2,
-	regulationMark: "I"
+	regulationMark: "I",
+
+	thirdParty: {
+		cardmarket: 857588
+	}
 }
 
 export default card

--- a/data/Mega Evolution/Phantasmal Flames/014.ts
+++ b/data/Mega Evolution/Phantasmal Flames/014.ts
@@ -47,7 +47,11 @@ const card: Card = {
 	}],
 
 	retreat: 1,
-	regulationMark: "I"
+	regulationMark: "I",
+
+	thirdParty: {
+		cardmarket: 857589
+	}
 }
 
 export default card

--- a/data/Mega Evolution/Phantasmal Flames/015.ts
+++ b/data/Mega Evolution/Phantasmal Flames/015.ts
@@ -47,7 +47,11 @@ const card: Card = {
 	}],
 
 	retreat: 2,
-	regulationMark: "I"
+	regulationMark: "I",
+
+	thirdParty: {
+		cardmarket: 857590
+	}
 }
 
 export default card

--- a/data/Mega Evolution/Phantasmal Flames/016.ts
+++ b/data/Mega Evolution/Phantasmal Flames/016.ts
@@ -47,7 +47,11 @@ const card: Card = {
 	}],
 
 	retreat: 3,
-	regulationMark: "I"
+	regulationMark: "I",
+
+	thirdParty: {
+		cardmarket: 857591
+	}
 }
 
 export default card

--- a/data/Mega Evolution/Phantasmal Flames/017.ts
+++ b/data/Mega Evolution/Phantasmal Flames/017.ts
@@ -61,7 +61,11 @@ const card: Card = {
 	}],
 
 	retreat: 2,
-	regulationMark: "I"
+	regulationMark: "I",
+
+	thirdParty: {
+		cardmarket: 857592
+	}
 }
 
 export default card

--- a/data/Mega Evolution/Phantasmal Flames/018.ts
+++ b/data/Mega Evolution/Phantasmal Flames/018.ts
@@ -61,7 +61,11 @@ const card: Card = {
 	}],
 
 	retreat: 1,
-	regulationMark: "I"
+	regulationMark: "I",
+
+	thirdParty: {
+		cardmarket: 857593
+	}
 }
 
 export default card

--- a/data/Mega Evolution/Phantasmal Flames/019.ts
+++ b/data/Mega Evolution/Phantasmal Flames/019.ts
@@ -59,7 +59,11 @@ const card: Card = {
 	}],
 
 	retreat: 2,
-	regulationMark: "I"
+	regulationMark: "I",
+
+	thirdParty: {
+		cardmarket: 857594
+	}
 }
 
 export default card

--- a/data/Mega Evolution/Phantasmal Flames/020.ts
+++ b/data/Mega Evolution/Phantasmal Flames/020.ts
@@ -47,7 +47,11 @@ const card: Card = {
 	}],
 
 	retreat: 2,
-	regulationMark: "I"
+	regulationMark: "I",
+
+	thirdParty: {
+		cardmarket: 857595
+	}
 }
 
 export default card

--- a/data/Mega Evolution/Phantasmal Flames/021.ts
+++ b/data/Mega Evolution/Phantasmal Flames/021.ts
@@ -47,7 +47,11 @@ const card: Card = {
 	}],
 
 	retreat: 2,
-	regulationMark: "I"
+	regulationMark: "I",
+
+	thirdParty: {
+		cardmarket: 857596
+	}
 }
 
 export default card

--- a/data/Mega Evolution/Phantasmal Flames/022.ts
+++ b/data/Mega Evolution/Phantasmal Flames/022.ts
@@ -71,7 +71,11 @@ const card: Card = {
 	}],
 
 	retreat: 2,
-	regulationMark: "I"
+	regulationMark: "I",
+
+	thirdParty: {
+		cardmarket: 857597
+	}
 }
 
 export default card

--- a/data/Mega Evolution/Phantasmal Flames/023.ts
+++ b/data/Mega Evolution/Phantasmal Flames/023.ts
@@ -51,7 +51,11 @@ const card: Card = {
 	}],
 
 	retreat: 2,
-	regulationMark: "I"
+	regulationMark: "I",
+
+	thirdParty: {
+		cardmarket: 857598
+	}
 }
 
 export default card

--- a/data/Mega Evolution/Phantasmal Flames/024.ts
+++ b/data/Mega Evolution/Phantasmal Flames/024.ts
@@ -61,7 +61,11 @@ const card: Card = {
 	}],
 
 	retreat: 3,
-	regulationMark: "I"
+	regulationMark: "I",
+
+	thirdParty: {
+		cardmarket: 857599
+	}
 }
 
 export default card

--- a/data/Mega Evolution/Phantasmal Flames/025.ts
+++ b/data/Mega Evolution/Phantasmal Flames/025.ts
@@ -71,7 +71,11 @@ const card: Card = {
 	}],
 
 	retreat: 4,
-	regulationMark: "I"
+	regulationMark: "I",
+
+	thirdParty: {
+		cardmarket: 857600
+	}
 }
 
 export default card

--- a/data/Mega Evolution/Phantasmal Flames/026.ts
+++ b/data/Mega Evolution/Phantasmal Flames/026.ts
@@ -47,7 +47,11 @@ const card: Card = {
 	}],
 
 	retreat: 2,
-	regulationMark: "I"
+	regulationMark: "I",
+
+	thirdParty: {
+		cardmarket: 857601
+	}
 }
 
 export default card

--- a/data/Mega Evolution/Phantasmal Flames/027.ts
+++ b/data/Mega Evolution/Phantasmal Flames/027.ts
@@ -59,7 +59,11 @@ const card: Card = {
 	}],
 
 	retreat: 1,
-	regulationMark: "I"
+	regulationMark: "I",
+
+	thirdParty: {
+		cardmarket: 857602
+	}
 }
 
 export default card

--- a/data/Mega Evolution/Phantasmal Flames/028.ts
+++ b/data/Mega Evolution/Phantasmal Flames/028.ts
@@ -59,7 +59,11 @@ const card: Card = {
 	}],
 
 	retreat: 2,
-	regulationMark: "I"
+	regulationMark: "I",
+
+	thirdParty: {
+		cardmarket: 857603
+	}
 }
 
 export default card

--- a/data/Mega Evolution/Phantasmal Flames/029.ts
+++ b/data/Mega Evolution/Phantasmal Flames/029.ts
@@ -71,7 +71,11 @@ const card: Card = {
 	}],
 
 	retreat: 1,
-	regulationMark: "I"
+	regulationMark: "I",
+
+	thirdParty: {
+		cardmarket: 857604
+	}
 }
 
 export default card

--- a/data/Mega Evolution/Phantasmal Flames/030.ts
+++ b/data/Mega Evolution/Phantasmal Flames/030.ts
@@ -47,7 +47,11 @@ const card: Card = {
 	}],
 
 	retreat: 1,
-	regulationMark: "I"
+	regulationMark: "I",
+
+	thirdParty: {
+		cardmarket: 857605
+	}
 }
 
 export default card

--- a/data/Mega Evolution/Phantasmal Flames/031.ts
+++ b/data/Mega Evolution/Phantasmal Flames/031.ts
@@ -47,7 +47,11 @@ const card: Card = {
 	}],
 
 	retreat: 1,
-	regulationMark: "I"
+	regulationMark: "I",
+
+	thirdParty: {
+		cardmarket: 857606
+	}
 }
 
 export default card

--- a/data/Mega Evolution/Phantasmal Flames/032.ts
+++ b/data/Mega Evolution/Phantasmal Flames/032.ts
@@ -59,7 +59,11 @@ const card: Card = {
 	}],
 
 	retreat: 1,
-	regulationMark: "I"
+	regulationMark: "I",
+
+	thirdParty: {
+		cardmarket: 857607
+	}
 }
 
 export default card

--- a/data/Mega Evolution/Phantasmal Flames/033.ts
+++ b/data/Mega Evolution/Phantasmal Flames/033.ts
@@ -37,7 +37,11 @@ const card: Card = {
 	}],
 
 	retreat: 1,
-	regulationMark: "I"
+	regulationMark: "I",
+
+	thirdParty: {
+		cardmarket: 857608
+	}
 }
 
 export default card

--- a/data/Mega Evolution/Phantasmal Flames/034.ts
+++ b/data/Mega Evolution/Phantasmal Flames/034.ts
@@ -47,7 +47,11 @@ const card: Card = {
 	}],
 
 	retreat: 1,
-	regulationMark: "I"
+	regulationMark: "I",
+
+	thirdParty: {
+		cardmarket: 857609
+	}
 }
 
 export default card

--- a/data/Mega Evolution/Phantasmal Flames/035.ts
+++ b/data/Mega Evolution/Phantasmal Flames/035.ts
@@ -37,7 +37,11 @@ const card: Card = {
 	}],
 
 	retreat: 1,
-	regulationMark: "I"
+	regulationMark: "I",
+
+	thirdParty: {
+		cardmarket: 857610
+	}
 }
 
 export default card

--- a/data/Mega Evolution/Phantasmal Flames/036.ts
+++ b/data/Mega Evolution/Phantasmal Flames/036.ts
@@ -71,7 +71,11 @@ const card: Card = {
 	}],
 
 	retreat: 1,
-	regulationMark: "I"
+	regulationMark: "I",
+
+	thirdParty: {
+		cardmarket: 857611
+	}
 }
 
 export default card

--- a/data/Mega Evolution/Phantasmal Flames/037.ts
+++ b/data/Mega Evolution/Phantasmal Flames/037.ts
@@ -37,7 +37,11 @@ const card: Card = {
 	}],
 
 	retreat: 1,
-	regulationMark: "I"
+	regulationMark: "I",
+
+	thirdParty: {
+		cardmarket: 857612
+	}
 }
 
 export default card

--- a/data/Mega Evolution/Phantasmal Flames/038.ts
+++ b/data/Mega Evolution/Phantasmal Flames/038.ts
@@ -61,7 +61,11 @@ const card: Card = {
 	}],
 
 	retreat: 2,
-	regulationMark: "I"
+	regulationMark: "I",
+
+	thirdParty: {
+		cardmarket: 857613
+	}
 }
 
 export default card

--- a/data/Mega Evolution/Phantasmal Flames/039.ts
+++ b/data/Mega Evolution/Phantasmal Flames/039.ts
@@ -59,7 +59,11 @@ const card: Card = {
 	}],
 
 	retreat: 1,
-	regulationMark: "I"
+	regulationMark: "I",
+
+	thirdParty: {
+		cardmarket: 857614
+	}
 }
 
 export default card

--- a/data/Mega Evolution/Phantasmal Flames/040.ts
+++ b/data/Mega Evolution/Phantasmal Flames/040.ts
@@ -59,7 +59,11 @@ const card: Card = {
 	}],
 
 	retreat: 1,
-	regulationMark: "I"
+	regulationMark: "I",
+
+	thirdParty: {
+		cardmarket: 857615
+	}
 }
 
 export default card

--- a/data/Mega Evolution/Phantasmal Flames/041.ts
+++ b/data/Mega Evolution/Phantasmal Flames/041.ts
@@ -71,7 +71,11 @@ const card: Card = {
 	}],
 
 	retreat: 1,
-	regulationMark: "I"
+	regulationMark: "I",
+
+	thirdParty: {
+		cardmarket: 857616
+	}
 }
 
 export default card

--- a/data/Mega Evolution/Phantasmal Flames/042.ts
+++ b/data/Mega Evolution/Phantasmal Flames/042.ts
@@ -59,7 +59,11 @@ const card: Card = {
 	}],
 
 	retreat: 1,
-	regulationMark: "I"
+	regulationMark: "I",
+
+	thirdParty: {
+		cardmarket: 857617
+	}
 }
 
 export default card

--- a/data/Mega Evolution/Phantasmal Flames/043.ts
+++ b/data/Mega Evolution/Phantasmal Flames/043.ts
@@ -47,7 +47,11 @@ const card: Card = {
 	}],
 
 	retreat: 1,
-	regulationMark: "I"
+	regulationMark: "I",
+
+	thirdParty: {
+		cardmarket: 857618
+	}
 }
 
 export default card

--- a/data/Mega Evolution/Phantasmal Flames/044.ts
+++ b/data/Mega Evolution/Phantasmal Flames/044.ts
@@ -47,7 +47,11 @@ const card: Card = {
 	}],
 
 	retreat: 1,
-	regulationMark: "I"
+	regulationMark: "I",
+
+	thirdParty: {
+		cardmarket: 857619
+	}
 }
 
 export default card

--- a/data/Mega Evolution/Phantasmal Flames/045.ts
+++ b/data/Mega Evolution/Phantasmal Flames/045.ts
@@ -47,7 +47,11 @@ const card: Card = {
 	}],
 
 	retreat: 2,
-	regulationMark: "I"
+	regulationMark: "I",
+
+	thirdParty: {
+		cardmarket: 857620
+	}
 }
 
 export default card

--- a/data/Mega Evolution/Phantasmal Flames/046.ts
+++ b/data/Mega Evolution/Phantasmal Flames/046.ts
@@ -45,7 +45,11 @@ const card: Card = {
 	}],
 
 	retreat: 1,
-	regulationMark: "I"
+	regulationMark: "I",
+
+	thirdParty: {
+		cardmarket: 857621
+	}
 }
 
 export default card

--- a/data/Mega Evolution/Phantasmal Flames/047.ts
+++ b/data/Mega Evolution/Phantasmal Flames/047.ts
@@ -61,7 +61,11 @@ const card: Card = {
 	}],
 
 	retreat: 2,
-	regulationMark: "I"
+	regulationMark: "I",
+
+	thirdParty: {
+		cardmarket: 857622
+	}
 }
 
 export default card

--- a/data/Mega Evolution/Phantasmal Flames/048.ts
+++ b/data/Mega Evolution/Phantasmal Flames/048.ts
@@ -71,7 +71,11 @@ const card: Card = {
 	}],
 
 	retreat: 2,
-	regulationMark: "I"
+	regulationMark: "I",
+
+	thirdParty: {
+		cardmarket: 857623
+	}
 }
 
 export default card

--- a/data/Mega Evolution/Phantasmal Flames/049.ts
+++ b/data/Mega Evolution/Phantasmal Flames/049.ts
@@ -47,7 +47,11 @@ const card: Card = {
 	}],
 
 	retreat: 1,
-	regulationMark: "I"
+	regulationMark: "I",
+
+	thirdParty: {
+		cardmarket: 857624
+	}
 }
 
 export default card

--- a/data/Mega Evolution/Phantasmal Flames/050.ts
+++ b/data/Mega Evolution/Phantasmal Flames/050.ts
@@ -47,7 +47,11 @@ const card: Card = {
 	}],
 
 	retreat: 1,
-	regulationMark: "I"
+	regulationMark: "I",
+
+	thirdParty: {
+		cardmarket: 857625
+	}
 }
 
 export default card

--- a/data/Mega Evolution/Phantasmal Flames/051.ts
+++ b/data/Mega Evolution/Phantasmal Flames/051.ts
@@ -47,7 +47,11 @@ const card: Card = {
 	}],
 
 	retreat: 1,
-	regulationMark: "I"
+	regulationMark: "I",
+
+	thirdParty: {
+		cardmarket: 857626
+	}
 }
 
 export default card

--- a/data/Mega Evolution/Phantasmal Flames/052.ts
+++ b/data/Mega Evolution/Phantasmal Flames/052.ts
@@ -37,7 +37,11 @@ const card: Card = {
 	}],
 
 	retreat: 1,
-	regulationMark: "I"
+	regulationMark: "I",
+
+	thirdParty: {
+		cardmarket: 857627
+	}
 }
 
 export default card

--- a/data/Mega Evolution/Phantasmal Flames/053.ts
+++ b/data/Mega Evolution/Phantasmal Flames/053.ts
@@ -61,7 +61,11 @@ const card: Card = {
 	}],
 
 	retreat: 1,
-	regulationMark: "I"
+	regulationMark: "I",
+
+	thirdParty: {
+		cardmarket: 857628
+	}
 }
 
 export default card

--- a/data/Mega Evolution/Phantasmal Flames/054.ts
+++ b/data/Mega Evolution/Phantasmal Flames/054.ts
@@ -37,7 +37,11 @@ const card: Card = {
 	}],
 
 	retreat: 1,
-	regulationMark: "I"
+	regulationMark: "I",
+
+	thirdParty: {
+		cardmarket: 857629
+	}
 }
 
 export default card

--- a/data/Mega Evolution/Phantasmal Flames/055.ts
+++ b/data/Mega Evolution/Phantasmal Flames/055.ts
@@ -37,7 +37,11 @@ const card: Card = {
 	}],
 
 	retreat: 1,
-	regulationMark: "I"
+	regulationMark: "I",
+
+	thirdParty: {
+		cardmarket: 857630
+	}
 }
 
 export default card

--- a/data/Mega Evolution/Phantasmal Flames/056.ts
+++ b/data/Mega Evolution/Phantasmal Flames/056.ts
@@ -71,7 +71,11 @@ const card: Card = {
 	}],
 
 	retreat: 2,
-	regulationMark: "I"
+	regulationMark: "I",
+
+	thirdParty: {
+		cardmarket: 857631
+	}
 }
 
 export default card

--- a/data/Mega Evolution/Phantasmal Flames/057.ts
+++ b/data/Mega Evolution/Phantasmal Flames/057.ts
@@ -47,7 +47,11 @@ const card: Card = {
 	}],
 
 	retreat: 1,
-	regulationMark: "I"
+	regulationMark: "I",
+
+	thirdParty: {
+		cardmarket: 857632
+	}
 }
 
 export default card

--- a/data/Mega Evolution/Phantasmal Flames/058.ts
+++ b/data/Mega Evolution/Phantasmal Flames/058.ts
@@ -59,7 +59,11 @@ const card: Card = {
 	}],
 
 	retreat: 1,
-	regulationMark: "I"
+	regulationMark: "I",
+
+	thirdParty: {
+		cardmarket: 857633
+	}
 }
 
 export default card

--- a/data/Mega Evolution/Phantasmal Flames/059.ts
+++ b/data/Mega Evolution/Phantasmal Flames/059.ts
@@ -47,7 +47,11 @@ const card: Card = {
 	}],
 
 	retreat: 1,
-	regulationMark: "I"
+	regulationMark: "I",
+
+	thirdParty: {
+		cardmarket: 857634
+	}
 }
 
 export default card

--- a/data/Mega Evolution/Phantasmal Flames/060.ts
+++ b/data/Mega Evolution/Phantasmal Flames/060.ts
@@ -47,7 +47,11 @@ const card: Card = {
 	}],
 
 	retreat: 1,
-	regulationMark: "I"
+	regulationMark: "I",
+
+	thirdParty: {
+		cardmarket: 857635
+	}
 }
 
 export default card

--- a/data/Mega Evolution/Phantasmal Flames/061.ts
+++ b/data/Mega Evolution/Phantasmal Flames/061.ts
@@ -71,7 +71,11 @@ const card: Card = {
 	}],
 
 	retreat: 0,
-	regulationMark: "I"
+	regulationMark: "I",
+
+	thirdParty: {
+		cardmarket: 857636
+	}
 }
 
 export default card

--- a/data/Mega Evolution/Phantasmal Flames/062.ts
+++ b/data/Mega Evolution/Phantasmal Flames/062.ts
@@ -61,7 +61,11 @@ const card: Card = {
 	}],
 
 	retreat: 1,
-	regulationMark: "I"
+	regulationMark: "I",
+
+	thirdParty: {
+		cardmarket: 857637
+	}
 }
 
 export default card

--- a/data/Mega Evolution/Phantasmal Flames/063.ts
+++ b/data/Mega Evolution/Phantasmal Flames/063.ts
@@ -59,7 +59,11 @@ const card: Card = {
 	}],
 
 	retreat: 1,
-	regulationMark: "I"
+	regulationMark: "I",
+
+	thirdParty: {
+		cardmarket: 857638
+	}
 }
 
 export default card

--- a/data/Mega Evolution/Phantasmal Flames/064.ts
+++ b/data/Mega Evolution/Phantasmal Flames/064.ts
@@ -51,7 +51,11 @@ const card: Card = {
 	}],
 
 	retreat: 2,
-	regulationMark: "I"
+	regulationMark: "I",
+
+	thirdParty: {
+		cardmarket: 857639
+	}
 }
 
 export default card

--- a/data/Mega Evolution/Phantasmal Flames/065.ts
+++ b/data/Mega Evolution/Phantasmal Flames/065.ts
@@ -51,7 +51,11 @@ const card: Card = {
 	}],
 
 	retreat: 2,
-	regulationMark: "I"
+	regulationMark: "I",
+
+	thirdParty: {
+		cardmarket: 857640
+	}
 }
 
 export default card

--- a/data/Mega Evolution/Phantasmal Flames/066.ts
+++ b/data/Mega Evolution/Phantasmal Flames/066.ts
@@ -61,7 +61,11 @@ const card: Card = {
 	}],
 
 	retreat: 3,
-	regulationMark: "I"
+	regulationMark: "I",
+
+	thirdParty: {
+		cardmarket: 857641
+	}
 }
 
 export default card

--- a/data/Mega Evolution/Phantasmal Flames/067.ts
+++ b/data/Mega Evolution/Phantasmal Flames/067.ts
@@ -59,7 +59,11 @@ const card: Card = {
 	}],
 
 	retreat: 1,
-	regulationMark: "I"
+	regulationMark: "I",
+
+	thirdParty: {
+		cardmarket: 857642
+	}
 }
 
 export default card

--- a/data/Mega Evolution/Phantasmal Flames/068.ts
+++ b/data/Mega Evolution/Phantasmal Flames/068.ts
@@ -61,7 +61,11 @@ const card: Card = {
 	}],
 
 	retreat: 2,
-	regulationMark: "I"
+	regulationMark: "I",
+
+	thirdParty: {
+		cardmarket: 857643
+	}
 }
 
 export default card

--- a/data/Mega Evolution/Phantasmal Flames/069.ts
+++ b/data/Mega Evolution/Phantasmal Flames/069.ts
@@ -71,7 +71,11 @@ const card: Card = {
 	}],
 
 	retreat: 2,
-	regulationMark: "I"
+	regulationMark: "I",
+
+	thirdParty: {
+		cardmarket: 857644
+	}
 }
 
 export default card

--- a/data/Mega Evolution/Phantasmal Flames/070.ts
+++ b/data/Mega Evolution/Phantasmal Flames/070.ts
@@ -71,7 +71,11 @@ const card: Card = {
 	}],
 
 	retreat: 2,
-	regulationMark: "I"
+	regulationMark: "I",
+
+	thirdParty: {
+		cardmarket: 857645
+	}
 }
 
 export default card

--- a/data/Mega Evolution/Phantasmal Flames/071.ts
+++ b/data/Mega Evolution/Phantasmal Flames/071.ts
@@ -59,7 +59,11 @@ const card: Card = {
 	}],
 
 	retreat: 2,
-	regulationMark: "I"
+	regulationMark: "I",
+
+	thirdParty: {
+		cardmarket: 857646
+	}
 }
 
 export default card

--- a/data/Mega Evolution/Phantasmal Flames/072.ts
+++ b/data/Mega Evolution/Phantasmal Flames/072.ts
@@ -69,7 +69,11 @@ const card: Card = {
 	}],
 
 	retreat: 3,
-	regulationMark: "I"
+	regulationMark: "I",
+
+	thirdParty: {
+		cardmarket: 857647
+	}
 }
 
 export default card

--- a/data/Mega Evolution/Phantasmal Flames/073.ts
+++ b/data/Mega Evolution/Phantasmal Flames/073.ts
@@ -59,7 +59,11 @@ const card: Card = {
 	}],
 
 	retreat: 1,
-	regulationMark: "I"
+	regulationMark: "I",
+
+	thirdParty: {
+		cardmarket: 857648
+	}
 }
 
 export default card

--- a/data/Mega Evolution/Phantasmal Flames/074.ts
+++ b/data/Mega Evolution/Phantasmal Flames/074.ts
@@ -47,7 +47,11 @@ const card: Card = {
 	}],
 
 	retreat: 2,
-	regulationMark: "I"
+	regulationMark: "I",
+
+	thirdParty: {
+		cardmarket: 857649
+	}
 }
 
 export default card

--- a/data/Mega Evolution/Phantasmal Flames/075.ts
+++ b/data/Mega Evolution/Phantasmal Flames/075.ts
@@ -47,7 +47,11 @@ const card: Card = {
 	}],
 
 	retreat: 2,
-	regulationMark: "I"
+	regulationMark: "I",
+
+	thirdParty: {
+		cardmarket: 857650
+	}
 }
 
 export default card

--- a/data/Mega Evolution/Phantasmal Flames/076.ts
+++ b/data/Mega Evolution/Phantasmal Flames/076.ts
@@ -47,7 +47,11 @@ const card: Card = {
 	}],
 
 	retreat: 1,
-	regulationMark: "I"
+	regulationMark: "I",
+
+	thirdParty: {
+		cardmarket: 857651
+	}
 }
 
 export default card

--- a/data/Mega Evolution/Phantasmal Flames/077.ts
+++ b/data/Mega Evolution/Phantasmal Flames/077.ts
@@ -61,7 +61,11 @@ const card: Card = {
 	}],
 
 	retreat: 2,
-	regulationMark: "I"
+	regulationMark: "I",
+
+	thirdParty: {
+		cardmarket: 857652
+	}
 }
 
 export default card

--- a/data/Mega Evolution/Phantasmal Flames/078.ts
+++ b/data/Mega Evolution/Phantasmal Flames/078.ts
@@ -47,7 +47,11 @@ const card: Card = {
 	}],
 
 	retreat: 1,
-	regulationMark: "I"
+	regulationMark: "I",
+
+	thirdParty: {
+		cardmarket: 857653
+	}
 }
 
 export default card

--- a/data/Mega Evolution/Phantasmal Flames/079.ts
+++ b/data/Mega Evolution/Phantasmal Flames/079.ts
@@ -59,7 +59,11 @@ const card: Card = {
 	}],
 
 	retreat: 1,
-	regulationMark: "I"
+	regulationMark: "I",
+
+	thirdParty: {
+		cardmarket: 857654
+	}
 }
 
 export default card

--- a/data/Mega Evolution/Phantasmal Flames/080.ts
+++ b/data/Mega Evolution/Phantasmal Flames/080.ts
@@ -59,7 +59,11 @@ const card: Card = {
 	}],
 
 	retreat: 1,
-	regulationMark: "I"
+	regulationMark: "I",
+
+	thirdParty: {
+		cardmarket: 857655
+	}
 }
 
 export default card

--- a/data/Mega Evolution/Phantasmal Flames/081.ts
+++ b/data/Mega Evolution/Phantasmal Flames/081.ts
@@ -47,7 +47,11 @@ const card: Card = {
 	}],
 
 	retreat: 1,
-	regulationMark: "I"
+	regulationMark: "I",
+
+	thirdParty: {
+		cardmarket: 857656
+	}
 }
 
 export default card

--- a/data/Mega Evolution/Phantasmal Flames/082.ts
+++ b/data/Mega Evolution/Phantasmal Flames/082.ts
@@ -61,7 +61,11 @@ const card: Card = {
 	}],
 
 	retreat: 1,
-	regulationMark: "I"
+	regulationMark: "I",
+
+	thirdParty: {
+		cardmarket: 857657
+	}
 }
 
 export default card

--- a/data/Mega Evolution/Phantasmal Flames/083.ts
+++ b/data/Mega Evolution/Phantasmal Flames/083.ts
@@ -59,7 +59,11 @@ const card: Card = {
 	}],
 
 	retreat: 1,
-	regulationMark: "I"
+	regulationMark: "I",
+
+	thirdParty: {
+		cardmarket: 857658
+	}
 }
 
 export default card

--- a/data/Mega Evolution/Phantasmal Flames/084.ts
+++ b/data/Mega Evolution/Phantasmal Flames/084.ts
@@ -71,7 +71,11 @@ const card: Card = {
 	}],
 
 	retreat: 1,
-	regulationMark: "I"
+	regulationMark: "I",
+
+	thirdParty: {
+		cardmarket: 857659
+	}
 }
 
 export default card

--- a/data/Mega Evolution/Phantasmal Flames/085.ts
+++ b/data/Mega Evolution/Phantasmal Flames/085.ts
@@ -28,7 +28,11 @@ const card: Card = {
 	},
 
 	trainerType: "Stadium",
-	regulationMark: "I"
+	regulationMark: "I",
+
+	thirdParty: {
+		cardmarket: 857660
+	}
 }
 
 export default card

--- a/data/Mega Evolution/Phantasmal Flames/086.ts
+++ b/data/Mega Evolution/Phantasmal Flames/086.ts
@@ -28,7 +28,11 @@ const card: Card = {
 	},
 
 	trainerType: "Item",
-	regulationMark: "I"
+	regulationMark: "I",
+
+	thirdParty: {
+		cardmarket: 857661
+	}
 }
 
 export default card

--- a/data/Mega Evolution/Phantasmal Flames/087.ts
+++ b/data/Mega Evolution/Phantasmal Flames/087.ts
@@ -28,7 +28,11 @@ const card: Card = {
 	},
 
 	trainerType: "Supporter",
-	regulationMark: "I"
+	regulationMark: "I",
+
+	thirdParty: {
+		cardmarket: 857662
+	}
 }
 
 export default card

--- a/data/Mega Evolution/Phantasmal Flames/088.ts
+++ b/data/Mega Evolution/Phantasmal Flames/088.ts
@@ -28,7 +28,11 @@ const card: Card = {
 	},
 
 	trainerType: "Stadium",
-	regulationMark: "I"
+	regulationMark: "I",
+
+	thirdParty: {
+		cardmarket: 857663
+	}
 }
 
 export default card

--- a/data/Mega Evolution/Phantasmal Flames/089.ts
+++ b/data/Mega Evolution/Phantasmal Flames/089.ts
@@ -28,7 +28,11 @@ const card: Card = {
 	},
 
 	trainerType: "Supporter",
-	regulationMark: "I"
+	regulationMark: "I",
+
+	thirdParty: {
+		cardmarket: 857664
+	}
 }
 
 export default card

--- a/data/Mega Evolution/Phantasmal Flames/090.ts
+++ b/data/Mega Evolution/Phantasmal Flames/090.ts
@@ -28,7 +28,11 @@ const card: Card = {
 	},
 
 	trainerType: "Supporter",
-	regulationMark: "I"
+	regulationMark: "I",
+
+	thirdParty: {
+		cardmarket: 857665
+	}
 }
 
 export default card

--- a/data/Mega Evolution/Phantasmal Flames/091.ts
+++ b/data/Mega Evolution/Phantasmal Flames/091.ts
@@ -28,7 +28,11 @@ const card: Card = {
 	},
 
 	trainerType: "Item",
-	regulationMark: "I"
+	regulationMark: "I",
+
+	thirdParty: {
+		cardmarket: 857666
+	}
 }
 
 export default card

--- a/data/Mega Evolution/Phantasmal Flames/092.ts
+++ b/data/Mega Evolution/Phantasmal Flames/092.ts
@@ -28,7 +28,11 @@ const card: Card = {
 	},
 
 	trainerType: "Tool",
-	regulationMark: "I"
+	regulationMark: "I",
+
+	thirdParty: {
+		cardmarket: 857667
+	}
 }
 
 export default card

--- a/data/Mega Evolution/Phantasmal Flames/093.ts
+++ b/data/Mega Evolution/Phantasmal Flames/093.ts
@@ -28,7 +28,11 @@ const card: Card = {
 	},
 
 	trainerType: "Tool",
-	regulationMark: "I"
+	regulationMark: "I",
+
+	thirdParty: {
+		cardmarket: 857668
+	}
 }
 
 export default card

--- a/data/Mega Evolution/Phantasmal Flames/094.ts
+++ b/data/Mega Evolution/Phantasmal Flames/094.ts
@@ -28,7 +28,11 @@ const card: Card = {
 	},
 
 	trainerType: "Item",
-	regulationMark: "I"
+	regulationMark: "I",
+
+	thirdParty: {
+		cardmarket: 857669
+	}
 }
 
 export default card

--- a/data/Mega Evolution/Phantasmal Flames/095.ts
+++ b/data/Mega Evolution/Phantasmal Flames/095.ts
@@ -61,7 +61,11 @@ const card: Card = {
 	}],
 
 	retreat: 2,
-	regulationMark: "I"
+	regulationMark: "I",
+
+	thirdParty: {
+		cardmarket: 857670
+	}
 }
 
 export default card

--- a/data/Mega Evolution/Phantasmal Flames/096.ts
+++ b/data/Mega Evolution/Phantasmal Flames/096.ts
@@ -47,7 +47,11 @@ const card: Card = {
 	}],
 
 	retreat: 1,
-	regulationMark: "I"
+	regulationMark: "I",
+
+	thirdParty: {
+		cardmarket: 857671
+	}
 }
 
 export default card

--- a/data/Mega Evolution/Phantasmal Flames/097.ts
+++ b/data/Mega Evolution/Phantasmal Flames/097.ts
@@ -71,7 +71,11 @@ const card: Card = {
 	}],
 
 	retreat: 2,
-	regulationMark: "I"
+	regulationMark: "I",
+
+	thirdParty: {
+		cardmarket: 857672
+	}
 }
 
 export default card

--- a/data/Mega Evolution/Phantasmal Flames/098.ts
+++ b/data/Mega Evolution/Phantasmal Flames/098.ts
@@ -59,7 +59,11 @@ const card: Card = {
 	}],
 
 	retreat: 1,
-	regulationMark: "I"
+	regulationMark: "I",
+
+	thirdParty: {
+		cardmarket: 857673
+	}
 }
 
 export default card

--- a/data/Mega Evolution/Phantasmal Flames/099.ts
+++ b/data/Mega Evolution/Phantasmal Flames/099.ts
@@ -47,7 +47,11 @@ const card: Card = {
 	}],
 
 	retreat: 1,
-	regulationMark: "I"
+	regulationMark: "I",
+
+	thirdParty: {
+		cardmarket: 857674
+	}
 }
 
 export default card

--- a/data/Mega Evolution/Phantasmal Flames/100.ts
+++ b/data/Mega Evolution/Phantasmal Flames/100.ts
@@ -47,7 +47,11 @@ const card: Card = {
 	}],
 
 	retreat: 2,
-	regulationMark: "I"
+	regulationMark: "I",
+
+	thirdParty: {
+		cardmarket: 857675
+	}
 }
 
 export default card

--- a/data/Mega Evolution/Phantasmal Flames/101.ts
+++ b/data/Mega Evolution/Phantasmal Flames/101.ts
@@ -61,7 +61,11 @@ const card: Card = {
 	}],
 
 	retreat: 1,
-	regulationMark: "I"
+	regulationMark: "I",
+
+	thirdParty: {
+		cardmarket: 857676
+	}
 }
 
 export default card

--- a/data/Mega Evolution/Phantasmal Flames/102.ts
+++ b/data/Mega Evolution/Phantasmal Flames/102.ts
@@ -47,7 +47,11 @@ const card: Card = {
 	}],
 
 	retreat: 1,
-	regulationMark: "H"
+	regulationMark: "H",
+
+	thirdParty: {
+		cardmarket: 857677
+	}
 }
 
 export default card

--- a/data/Mega Evolution/Phantasmal Flames/103.ts
+++ b/data/Mega Evolution/Phantasmal Flames/103.ts
@@ -61,7 +61,11 @@ const card: Card = {
 	}],
 
 	retreat: 2,
-	regulationMark: "I"
+	regulationMark: "I",
+
+	thirdParty: {
+		cardmarket: 857678
+	}
 }
 
 export default card

--- a/data/Mega Evolution/Phantasmal Flames/104.ts
+++ b/data/Mega Evolution/Phantasmal Flames/104.ts
@@ -59,7 +59,11 @@ const card: Card = {
 	}],
 
 	retreat: 1,
-	regulationMark: "I"
+	regulationMark: "I",
+
+	thirdParty: {
+		cardmarket: 857679
+	}
 }
 
 export default card

--- a/data/Mega Evolution/Phantasmal Flames/105.ts
+++ b/data/Mega Evolution/Phantasmal Flames/105.ts
@@ -61,7 +61,11 @@ const card: Card = {
 	}],
 
 	retreat: 2,
-	regulationMark: "I"
+	regulationMark: "I",
+
+	thirdParty: {
+		cardmarket: 857680
+	}
 }
 
 export default card

--- a/data/Mega Evolution/Phantasmal Flames/106.ts
+++ b/data/Mega Evolution/Phantasmal Flames/106.ts
@@ -47,7 +47,11 @@ const card: Card = {
 	}],
 
 	retreat: 1,
-	regulationMark: "H"
+	regulationMark: "H",
+
+	thirdParty: {
+		cardmarket: 857681
+	}
 }
 
 export default card

--- a/data/Mega Evolution/Phantasmal Flames/107.ts
+++ b/data/Mega Evolution/Phantasmal Flames/107.ts
@@ -59,7 +59,11 @@ const card: Card = {
 	}],
 
 	retreat: 1,
-	regulationMark: "I"
+	regulationMark: "I",
+
+	thirdParty: {
+		cardmarket: 857682
+	}
 }
 
 export default card

--- a/data/Mega Evolution/Phantasmal Flames/108.ts
+++ b/data/Mega Evolution/Phantasmal Flames/108.ts
@@ -71,7 +71,11 @@ const card: Card = {
 	}],
 
 	retreat: 2,
-	regulationMark: "I"
+	regulationMark: "I",
+
+	thirdParty: {
+		cardmarket: 857683
+	}
 }
 
 export default card

--- a/data/Mega Evolution/Phantasmal Flames/109.ts
+++ b/data/Mega Evolution/Phantasmal Flames/109.ts
@@ -47,7 +47,11 @@ const card: Card = {
 	}],
 
 	retreat: 2,
-	regulationMark: "I"
+	regulationMark: "I",
+
+	thirdParty: {
+		cardmarket: 857684
+	}
 }
 
 export default card

--- a/data/Mega Evolution/Phantasmal Flames/110.ts
+++ b/data/Mega Evolution/Phantasmal Flames/110.ts
@@ -61,7 +61,11 @@ const card: Card = {
 	}],
 
 	retreat: 1,
-	regulationMark: "I"
+	regulationMark: "I",
+
+	thirdParty: {
+		cardmarket: 857685
+	}
 }
 
 export default card

--- a/data/Mega Evolution/Phantasmal Flames/111.ts
+++ b/data/Mega Evolution/Phantasmal Flames/111.ts
@@ -71,7 +71,11 @@ const card: Card = {
 	}],
 
 	retreat: 1,
-	regulationMark: "I"
+	regulationMark: "I",
+
+	thirdParty: {
+		cardmarket: 857686
+	}
 }
 
 export default card

--- a/data/Mega Evolution/Phantasmal Flames/112.ts
+++ b/data/Mega Evolution/Phantasmal Flames/112.ts
@@ -71,7 +71,11 @@ const card: Card = {
 	}],
 
 	retreat: 1,
-	regulationMark: "I"
+	regulationMark: "I",
+
+	thirdParty: {
+		cardmarket: 857687
+	}
 }
 
 export default card

--- a/data/Mega Evolution/Phantasmal Flames/113.ts
+++ b/data/Mega Evolution/Phantasmal Flames/113.ts
@@ -71,7 +71,11 @@ const card: Card = {
 	}],
 
 	retreat: 0,
-	regulationMark: "I"
+	regulationMark: "I",
+
+	thirdParty: {
+		cardmarket: 857688
+	}
 }
 
 export default card

--- a/data/Mega Evolution/Phantasmal Flames/114.ts
+++ b/data/Mega Evolution/Phantasmal Flames/114.ts
@@ -71,7 +71,11 @@ const card: Card = {
 	}],
 
 	retreat: 2,
-	regulationMark: "I"
+	regulationMark: "I",
+
+	thirdParty: {
+		cardmarket: 857689
+	}
 }
 
 export default card

--- a/data/Mega Evolution/Phantasmal Flames/115.ts
+++ b/data/Mega Evolution/Phantasmal Flames/115.ts
@@ -71,7 +71,11 @@ const card: Card = {
 	}],
 
 	retreat: 1,
-	regulationMark: "I"
+	regulationMark: "I",
+
+	thirdParty: {
+		cardmarket: 857690
+	}
 }
 
 export default card

--- a/data/Mega Evolution/Phantasmal Flames/116.ts
+++ b/data/Mega Evolution/Phantasmal Flames/116.ts
@@ -28,7 +28,11 @@ const card: Card = {
 	},
 
 	trainerType: "Stadium",
-	regulationMark: "I"
+	regulationMark: "I",
+
+	thirdParty: {
+		cardmarket: 857691
+	}
 }
 
 export default card

--- a/data/Mega Evolution/Phantasmal Flames/117.ts
+++ b/data/Mega Evolution/Phantasmal Flames/117.ts
@@ -28,7 +28,11 @@ const card: Card = {
 	},
 
 	trainerType: "Item",
-	regulationMark: "I"
+	regulationMark: "I",
+
+	thirdParty: {
+		cardmarket: 857692
+	}
 }
 
 export default card

--- a/data/Mega Evolution/Phantasmal Flames/118.ts
+++ b/data/Mega Evolution/Phantasmal Flames/118.ts
@@ -28,7 +28,11 @@ const card: Card = {
 	},
 
 	trainerType: "Supporter",
-	regulationMark: "I"
+	regulationMark: "I",
+
+	thirdParty: {
+		cardmarket: 857693
+	}
 }
 
 export default card

--- a/data/Mega Evolution/Phantasmal Flames/119.ts
+++ b/data/Mega Evolution/Phantasmal Flames/119.ts
@@ -28,7 +28,11 @@ const card: Card = {
 	},
 
 	trainerType: "Supporter",
-	regulationMark: "I"
+	regulationMark: "I",
+
+	thirdParty: {
+		cardmarket: 857694
+	}
 }
 
 export default card

--- a/data/Mega Evolution/Phantasmal Flames/120.ts
+++ b/data/Mega Evolution/Phantasmal Flames/120.ts
@@ -28,7 +28,11 @@ const card: Card = {
 	},
 
 	trainerType: "Supporter",
-	regulationMark: "I"
+	regulationMark: "I",
+
+	thirdParty: {
+		cardmarket: 857695
+	}
 }
 
 export default card

--- a/data/Mega Evolution/Phantasmal Flames/121.ts
+++ b/data/Mega Evolution/Phantasmal Flames/121.ts
@@ -28,7 +28,11 @@ const card: Card = {
 	},
 
 	trainerType: "Tool",
-	regulationMark: "I"
+	regulationMark: "I",
+
+	thirdParty: {
+		cardmarket: 857696
+	}
 }
 
 export default card

--- a/data/Mega Evolution/Phantasmal Flames/122.ts
+++ b/data/Mega Evolution/Phantasmal Flames/122.ts
@@ -28,7 +28,11 @@ const card: Card = {
 	},
 
 	trainerType: "Tool",
-	regulationMark: "I"
+	regulationMark: "I",
+
+	thirdParty: {
+		cardmarket: 857697
+	}
 }
 
 export default card

--- a/data/Mega Evolution/Phantasmal Flames/123.ts
+++ b/data/Mega Evolution/Phantasmal Flames/123.ts
@@ -28,7 +28,11 @@ const card: Card = {
 	},
 
 	trainerType: "Item",
-	regulationMark: "I"
+	regulationMark: "I",
+
+	thirdParty: {
+		cardmarket: 857698
+	}
 }
 
 export default card

--- a/data/Mega Evolution/Phantasmal Flames/124.ts
+++ b/data/Mega Evolution/Phantasmal Flames/124.ts
@@ -28,7 +28,11 @@ const card: Card = {
 	},
 
 	energyType: "Normal",
-	regulationMark: "I"
+	regulationMark: "I",
+
+	thirdParty: {
+		cardmarket: 857699
+	}
 }
 
 export default card

--- a/data/Mega Evolution/Phantasmal Flames/125.ts
+++ b/data/Mega Evolution/Phantasmal Flames/125.ts
@@ -47,7 +47,11 @@ const card: Card = {
 	}],
 
 	retreat: 2,
-	regulationMark: "I"
+	regulationMark: "I",
+
+	thirdParty: {
+		cardmarket: 857700
+	}
 }
 
 export default card

--- a/data/Mega Evolution/Phantasmal Flames/126.ts
+++ b/data/Mega Evolution/Phantasmal Flames/126.ts
@@ -71,7 +71,11 @@ const card: Card = {
 	}],
 
 	retreat: 1,
-	regulationMark: "I"
+	regulationMark: "I",
+
+	thirdParty: {
+		cardmarket: 857701
+	}
 }
 
 export default card

--- a/data/Mega Evolution/Phantasmal Flames/127.ts
+++ b/data/Mega Evolution/Phantasmal Flames/127.ts
@@ -71,7 +71,11 @@ const card: Card = {
 	}],
 
 	retreat: 0,
-	regulationMark: "I"
+	regulationMark: "I",
+
+	thirdParty: {
+		cardmarket: 857702
+	}
 }
 
 export default card

--- a/data/Mega Evolution/Phantasmal Flames/128.ts
+++ b/data/Mega Evolution/Phantasmal Flames/128.ts
@@ -71,7 +71,11 @@ const card: Card = {
 	}],
 
 	retreat: 1,
-	regulationMark: "I"
+	regulationMark: "I",
+
+	thirdParty: {
+		cardmarket: 857703
+	}
 }
 
 export default card

--- a/data/Mega Evolution/Phantasmal Flames/129.ts
+++ b/data/Mega Evolution/Phantasmal Flames/129.ts
@@ -28,7 +28,11 @@ const card: Card = {
 	},
 
 	trainerType: "Supporter",
-	regulationMark: "I"
+	regulationMark: "I",
+
+	thirdParty: {
+		cardmarket: 857704
+	}
 }
 
 export default card

--- a/data/Mega Evolution/Phantasmal Flames/130.ts
+++ b/data/Mega Evolution/Phantasmal Flames/130.ts
@@ -47,7 +47,11 @@ const card: Card = {
 	}],
 
 	retreat: 2,
-	regulationMark: "I"
+	regulationMark: "I",
+
+	thirdParty: {
+		cardmarket: 857705
+	}
 }
 
 export default card


### PR DESCRIPTION
Added a 'thirdParty' field with Cardmarket IDs to all cards in the Mega Evolution/Phantasmal Flames

<!--
Contribution guide: https://github.com/tcgdex/cards-database/blob/master/CONTRIBUTING.md
please submit changes up to 1 set at most.
-->

## Changes

<!-- Quickly explain your changes -->

## Details

<!-- You can also give more details about your changes -->

