### PR TITLE
Fix: null releaseDate error in graphql

### DIFF
--- a/meta/definitions/graphql.gql
+++ b/meta/definitions/graphql.gql
@@ -386,7 +386,7 @@ type Set {
 	serie: Serie!
 
 	"""The set official release date"""
-	releaseDate: String!
+	releaseDate: String
 
 	"""The set tcgOnline code if available in the APP"""
 	tcgOnline: String


### PR DESCRIPTION
releaseDate when null is causing GraphQL to error and not return results