### PR TITLE
feat: Add TCGplayer product IDs to Scarlet & Violet Base set cards

### DIFF
--- a/data/Scarlet & Violet/Scarlet & Violet/001.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/001.ts
@@ -54,8 +54,9 @@ const card: Card = {
 	illustrator: "Shigenori Negishi",
 
 	thirdParty: {
-		cardmarket: 702298
-	}
+        cardmarket: 702298,
+        tcgplayer: 487828
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/002.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/002.ts
@@ -67,8 +67,9 @@ const card: Card = {
 	illustrator: "Taira Akitsu",
 
 	thirdParty: {
-		cardmarket: 702299
-	}
+        cardmarket: 702299,
+        tcgplayer: 487831
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/003.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/003.ts
@@ -54,8 +54,9 @@ const card: Card = {
 	illustrator: "kurumitsu",
 
 	thirdParty: {
-		cardmarket: 702300
-	}
+        cardmarket: 702300,
+        tcgplayer: 487832
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/004.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/004.ts
@@ -50,8 +50,9 @@ const card: Card = {
 	illustrator: "Ryuta Fuse",
 
 	thirdParty: {
-		cardmarket: 702301
-	}
+        cardmarket: 702301,
+        tcgplayer: 487833
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/005.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/005.ts
@@ -67,8 +67,9 @@ const card: Card = {
 	illustrator: "Tika Matsuno",
 
 	thirdParty: {
-		cardmarket: 702302
-	}
+        cardmarket: 702302,
+        tcgplayer: 487834
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/006.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/006.ts
@@ -72,8 +72,9 @@ const card: Card = {
 	illustrator: "DOM",
 
 	thirdParty: {
-		cardmarket: 702303
-	}
+        cardmarket: 702303,
+        tcgplayer: 487836
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/007.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/007.ts
@@ -65,8 +65,9 @@ const card: Card = {
 	illustrator: "aoki",
 
 	thirdParty: {
-		cardmarket: 702304
-	}
+        cardmarket: 702304,
+        tcgplayer: 487838
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/008.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/008.ts
@@ -67,8 +67,9 @@ const card: Card = {
 	illustrator: "sowsow",
 
 	thirdParty: {
-		cardmarket: 702305
-	}
+        cardmarket: 702305,
+        tcgplayer: 487839
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/009.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/009.ts
@@ -72,8 +72,9 @@ const card: Card = {
 	illustrator: "Kagemaru Himeno",
 
 	thirdParty: {
-		cardmarket: 702306
-	}
+        cardmarket: 702306,
+        tcgplayer: 487840
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/010.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/010.ts
@@ -72,8 +72,9 @@ const card: Card = {
 	illustrator: "Atsuko Nishida",
 
 	thirdParty: {
-		cardmarket: 702307
-	}
+        cardmarket: 702307,
+        tcgplayer: 487842
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/011.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/011.ts
@@ -58,8 +58,9 @@ const card: Card = {
 	illustrator: "Tika Matsuno",
 
 	thirdParty: {
-		cardmarket: 702308
-	}
+        cardmarket: 702308,
+        tcgplayer: 487053
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/012.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/012.ts
@@ -72,8 +72,9 @@ const card: Card = {
 	illustrator: "Gemi",
 
 	thirdParty: {
-		cardmarket: 702309
-	}
+        cardmarket: 702309,
+        tcgplayer: 487843
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/013.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/013.ts
@@ -58,8 +58,9 @@ const card: Card = {
 	illustrator: "Saya Tsuruta",
 
 	thirdParty: {
-		cardmarket: 689763
-	}
+        cardmarket: 689763,
+        tcgplayer: 475417
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/014.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/014.ts
@@ -63,8 +63,9 @@ const card: Card = {
 	illustrator: "Kouki Saitou",
 
 	thirdParty: {
-		cardmarket: 702310
-	}
+        cardmarket: 702310,
+        tcgplayer: 487846
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/015.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/015.ts
@@ -73,8 +73,9 @@ const card: Card = {
 	illustrator: "Ryota Murayama",
 
 	thirdParty: {
-		cardmarket: 702311
-	}
+        cardmarket: 702311,
+        tcgplayer: 487848
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/016.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/016.ts
@@ -65,8 +65,9 @@ const card: Card = {
 	illustrator: "Tika Matsuno",
 
 	thirdParty: {
-		cardmarket: 702312
-	}
+        cardmarket: 702312,
+        tcgplayer: 487851
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/017.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/017.ts
@@ -54,8 +54,9 @@ const card: Card = {
 	illustrator: "Pani Kobayashi",
 
 	thirdParty: {
-		cardmarket: 702312
-	}
+        cardmarket: 702312,
+        tcgplayer: 487854
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/018.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/018.ts
@@ -54,8 +54,9 @@ const card: Card = {
 	illustrator: "Kouki Saitou",
 
 	thirdParty: {
-		cardmarket: 702312
-	}
+        cardmarket: 702312,
+        tcgplayer: 487855
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/019.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/019.ts
@@ -82,8 +82,9 @@ const card: Card = {
 	illustrator: "takuyoa",
 
 	thirdParty: {
-		cardmarket: 702315
-	}
+        cardmarket: 702315,
+        tcgplayer: 487856
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/020.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/020.ts
@@ -45,8 +45,9 @@ const card: Card = {
 	illustrator: "yuu",
 
 	thirdParty: {
-		cardmarket: 702316
-	}
+        cardmarket: 702316,
+        tcgplayer: 487857
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/021.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/021.ts
@@ -65,8 +65,9 @@ const card: Card = {
 	illustrator: "Shibuzoh.",
 
 	thirdParty: {
-		cardmarket: 702316
-	}
+        cardmarket: 702316,
+        tcgplayer: 487858
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/022.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/022.ts
@@ -72,8 +72,9 @@ const card: Card = {
 	illustrator: "Mina Nakai",
 
 	thirdParty: {
-		cardmarket: 702318
-	}
+        cardmarket: 702318,
+        tcgplayer: 487859
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/023.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/023.ts
@@ -73,8 +73,9 @@ const card: Card = {
 	illustrator: "Kouki Saitou",
 
 	thirdParty: {
-		cardmarket: 702319
-	}
+        cardmarket: 702319,
+        tcgplayer: 487860
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/024.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/024.ts
@@ -54,8 +54,9 @@ const card: Card = {
 	illustrator: "Shin Nagasawa",
 
 	thirdParty: {
-		cardmarket: 702320
-	}
+        cardmarket: 702320,
+        tcgplayer: 487861
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/025.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/025.ts
@@ -65,8 +65,9 @@ const card: Card = {
 	illustrator: "Tika Matsuno",
 
 	thirdParty: {
-		cardmarket: 702320
-	}
+        cardmarket: 702320,
+        tcgplayer: 487862
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/026.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/026.ts
@@ -81,8 +81,9 @@ const card: Card = {
 	illustrator: "nagimiso",
 
 	thirdParty: {
-		cardmarket: 702322
-	}
+        cardmarket: 702322,
+        tcgplayer: 487864
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/027.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/027.ts
@@ -54,8 +54,9 @@ const card: Card = {
 	illustrator: "Kouki Saitou",
 
 	thirdParty: {
-		cardmarket: 702323
-	}
+        cardmarket: 702323,
+        tcgplayer: 487866
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/028.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/028.ts
@@ -65,8 +65,9 @@ const card: Card = {
 	illustrator: "GIDORA",
 
 	thirdParty: {
-		cardmarket: 702323
-	}
+        cardmarket: 702323,
+        tcgplayer: 487867
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/029.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/029.ts
@@ -81,8 +81,9 @@ const card: Card = {
 	illustrator: "KEIICHIRO ITO",
 
 	thirdParty: {
-		cardmarket: 702325
-	}
+        cardmarket: 702325,
+        tcgplayer: 487868
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/030.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/030.ts
@@ -54,8 +54,9 @@ const card: Card = {
 	illustrator: "kawayoo",
 
 	thirdParty: {
-		cardmarket: 702326
-	}
+        cardmarket: 702326,
+        tcgplayer: 487869
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/031.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/031.ts
@@ -65,8 +65,9 @@ const card: Card = {
 	illustrator: "Tika Matsuno",
 
 	thirdParty: {
-		cardmarket: 702326
-	}
+        cardmarket: 702326,
+        tcgplayer: 487870
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/032.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/032.ts
@@ -82,8 +82,9 @@ const card: Card = {
 	illustrator: "5ban Graphics",
 
 	thirdParty: {
-		cardmarket: 702328
-	}
+        cardmarket: 702328,
+        tcgplayer: 487872
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/033.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/033.ts
@@ -58,8 +58,9 @@ const card: Card = {
 	illustrator: "nagimiso",
 
 	thirdParty: {
-		cardmarket: 702329
-	}
+        cardmarket: 702329,
+        tcgplayer: 487873
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/034.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/034.ts
@@ -72,8 +72,9 @@ const card: Card = {
 	illustrator: "hncl",
 
 	thirdParty: {
-		cardmarket: 702330
-	}
+        cardmarket: 702330,
+        tcgplayer: 487874
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/035.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/035.ts
@@ -67,8 +67,9 @@ const card: Card = {
 	illustrator: "Kurata So",
 
 	thirdParty: {
-		cardmarket: 702331
-	}
+        cardmarket: 702331,
+        tcgplayer: 487875
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/036.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/036.ts
@@ -58,8 +58,9 @@ const card: Card = {
 	illustrator: "Akira Komayama",
 
 	thirdParty: {
-		cardmarket: 689764
-	}
+        cardmarket: 689764,
+        tcgplayer: 475418
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/037.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/037.ts
@@ -63,8 +63,9 @@ const card: Card = {
 	illustrator: "kantaro",
 
 	thirdParty: {
-		cardmarket: 702332
-	}
+        cardmarket: 702332,
+        tcgplayer: 487877
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/038.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/038.ts
@@ -82,8 +82,9 @@ const card: Card = {
 	illustrator: "nagimiso",
 
 	thirdParty: {
-		cardmarket: 702333
-	}
+        cardmarket: 702333,
+        tcgplayer: 487879
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/039.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/039.ts
@@ -54,8 +54,9 @@ const card: Card = {
 	illustrator: "Souichirou Gunjima",
 
 	thirdParty: {
-		cardmarket: 702334
-	}
+        cardmarket: 702334,
+        tcgplayer: 487881
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/040.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/040.ts
@@ -45,8 +45,9 @@ const card: Card = {
 	illustrator: "nagimiso",
 
 	thirdParty: {
-		cardmarket: 702334
-	}
+        cardmarket: 702334,
+        tcgplayer: 487882
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/041.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/041.ts
@@ -86,8 +86,9 @@ const card: Card = {
 	illustrator: "AKIRA EGAWA",
 
 	thirdParty: {
-		cardmarket: 702336
-	}
+        cardmarket: 702336,
+        tcgplayer: 487883
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/042.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/042.ts
@@ -65,8 +65,9 @@ const card: Card = {
 	illustrator: "Narumi Sato",
 
 	thirdParty: {
-		cardmarket: 702337
-	}
+        cardmarket: 702337,
+        tcgplayer: 487885
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/043.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/043.ts
@@ -86,8 +86,9 @@ const card: Card = {
 	illustrator: "Shinji Kanda",
 
 	thirdParty: {
-		cardmarket: 702338
-	}
+        cardmarket: 702338,
+        tcgplayer: 487887
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/044.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/044.ts
@@ -52,8 +52,9 @@ const card: Card = {
 	illustrator: "KIYOTAKA OSHIYAMA",
 
 	thirdParty: {
-		cardmarket: 702339
-	}
+        cardmarket: 702339,
+        tcgplayer: 487888
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/045.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/045.ts
@@ -73,8 +73,9 @@ const card: Card = {
 	illustrator: "5ban Graphics",
 
 	thirdParty: {
-		cardmarket: 702340
-	}
+        cardmarket: 702340,
+        tcgplayer: 487889
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/046.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/046.ts
@@ -58,8 +58,9 @@ const card: Card = {
 	illustrator: "Mizue",
 
 	thirdParty: {
-		cardmarket: 702341
-	}
+        cardmarket: 702341,
+        tcgplayer: 487891
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/047.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/047.ts
@@ -59,8 +59,9 @@ const card: Card = {
 	illustrator: "Gemi",
 
 	thirdParty: {
-		cardmarket: 702342
-	}
+        cardmarket: 702342,
+        tcgplayer: 487893
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/048.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/048.ts
@@ -67,8 +67,9 @@ const card: Card = {
 	illustrator: "Shinji Kanda",
 
 	thirdParty: {
-		cardmarket: 702343
-	}
+        cardmarket: 702343,
+        tcgplayer: 487894
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/049.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/049.ts
@@ -45,8 +45,9 @@ const card: Card = {
 	illustrator: "miki kudo",
 
 	thirdParty: {
-		cardmarket: 702344
-	}
+        cardmarket: 702344,
+        tcgplayer: 487895
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/050.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/050.ts
@@ -72,8 +72,9 @@ const card: Card = {
 	illustrator: "Souichirou Gunjima",
 
 	thirdParty: {
-		cardmarket: 702345
-	}
+        cardmarket: 702345,
+        tcgplayer: 487897
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/051.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/051.ts
@@ -65,8 +65,9 @@ const card: Card = {
 	illustrator: "kurumitsu",
 
 	thirdParty: {
-		cardmarket: 702346
-	}
+        cardmarket: 702346,
+        tcgplayer: 487898
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/052.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/052.ts
@@ -58,8 +58,9 @@ const card: Card = {
 	illustrator: "Mizue",
 
 	thirdParty: {
-		cardmarket: 689765
-	}
+        cardmarket: 689765,
+        tcgplayer: 475419
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/053.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/053.ts
@@ -63,8 +63,9 @@ const card: Card = {
 	illustrator: "kirisAki",
 
 	thirdParty: {
-		cardmarket: 702347
-	}
+        cardmarket: 702347,
+        tcgplayer: 487899
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/054.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/054.ts
@@ -73,8 +73,9 @@ const card: Card = {
 	illustrator: "Kouki Saitou",
 
 	thirdParty: {
-		cardmarket: 702348
-	}
+        cardmarket: 702348,
+        tcgplayer: 487902
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/055.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/055.ts
@@ -54,8 +54,9 @@ const card: Card = {
 	illustrator: "Shin Nagasawa",
 
 	thirdParty: {
-		cardmarket: 702350
-	}
+        cardmarket: 702350,
+        tcgplayer: 487903
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/056.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/056.ts
@@ -65,8 +65,9 @@ const card: Card = {
 	illustrator: "Tika Matsuno",
 
 	thirdParty: {
-		cardmarket: 702350
-	}
+        cardmarket: 702350,
+        tcgplayer: 487905
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/057.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/057.ts
@@ -70,8 +70,9 @@ const card: Card = {
 	illustrator: "KIYOTAKA OSHIYAMA",
 
 	thirdParty: {
-		cardmarket: 702352
-	}
+        cardmarket: 702352,
+        tcgplayer: 487906
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/058.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/058.ts
@@ -45,8 +45,9 @@ const card: Card = {
 	illustrator: "Shin Nagasawa",
 
 	thirdParty: {
-		cardmarket: 702353
-	}
+        cardmarket: 702353,
+        tcgplayer: 487908
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/059.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/059.ts
@@ -58,8 +58,9 @@ const card: Card = {
 	illustrator: "Kouki Saitou",
 
 	thirdParty: {
-		cardmarket: 702353
-	}
+        cardmarket: 702353,
+        tcgplayer: 487910
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/060.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/060.ts
@@ -72,8 +72,9 @@ const card: Card = {
 	illustrator: "Anesaki Dynamic",
 
 	thirdParty: {
-		cardmarket: 702355
-	}
+        cardmarket: 702355,
+        tcgplayer: 487912
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/061.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/061.ts
@@ -68,8 +68,9 @@ const card: Card = {
 	illustrator: "Souichirou Gunjima",
 
 	thirdParty: {
-		cardmarket: 702356
-	}
+        cardmarket: 702356,
+        tcgplayer: 487913
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/062.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/062.ts
@@ -74,8 +74,9 @@ const card: Card = {
 	illustrator: "OKACHEKE",
 
 	thirdParty: {
-		cardmarket: 702357
-	}
+        cardmarket: 702357,
+        tcgplayer: 487914
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/063.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/063.ts
@@ -65,8 +65,9 @@ const card: Card = {
 	illustrator: "KIYOTAKA OSHIYAMA",
 
 	thirdParty: {
-		cardmarket: 702359
-	}
+        cardmarket: 702359,
+        tcgplayer: 487916
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/064.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/064.ts
@@ -72,8 +72,9 @@ const card: Card = {
 	illustrator: "Shiburingaru",
 
 	thirdParty: {
-		cardmarket: 702360
-	}
+        cardmarket: 702360,
+        tcgplayer: 487917
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/065.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/065.ts
@@ -82,8 +82,9 @@ const card: Card = {
 	illustrator: "hncl",
 
 	thirdParty: {
-		cardmarket: 702361
-	}
+        cardmarket: 702361,
+        tcgplayer: 486612
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/066.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/066.ts
@@ -58,8 +58,9 @@ const card: Card = {
 	illustrator: "Narumi Sato",
 
 	thirdParty: {
-		cardmarket: 702362
-	}
+        cardmarket: 702362,
+        tcgplayer: 487919
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/067.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/067.ts
@@ -72,8 +72,9 @@ const card: Card = {
 	illustrator: "Kurata So",
 
 	thirdParty: {
-		cardmarket: 702363
-	}
+        cardmarket: 702363,
+        tcgplayer: 487920
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/068.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/068.ts
@@ -76,8 +76,9 @@ const card: Card = {
 	illustrator: "Naoki Saito",
 
 	thirdParty: {
-		cardmarket: 702364
-	}
+        cardmarket: 702364,
+        tcgplayer: 487922
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/069.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/069.ts
@@ -52,8 +52,9 @@ const card: Card = {
 	illustrator: "Nisota Niso",
 
 	thirdParty: {
-		cardmarket: 702365
-	}
+        cardmarket: 702365,
+        tcgplayer: 487923
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/070.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/070.ts
@@ -74,8 +74,9 @@ const card: Card = {
 	illustrator: "Kouki Saitou",
 
 	thirdParty: {
-		cardmarket: 702365
-	}
+        cardmarket: 702365,
+        tcgplayer: 487924
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/071.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/071.ts
@@ -45,8 +45,9 @@ const card: Card = {
 	illustrator: "Yuu Nishida",
 
 	thirdParty: {
-		cardmarket: 702367
-	}
+        cardmarket: 702367,
+        tcgplayer: 487925
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/072.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/072.ts
@@ -79,8 +79,9 @@ const card: Card = {
 	illustrator: "Atsushi Furusawa",
 
 	thirdParty: {
-		cardmarket: 702368
-	}
+        cardmarket: 702368,
+        tcgplayer: 487926
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/073.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/073.ts
@@ -52,8 +52,9 @@ const card: Card = {
 	illustrator: "Tika Matsuno",
 
 	thirdParty: {
-		cardmarket: 702369
-	}
+        cardmarket: 702369,
+        tcgplayer: 487927
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/074.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/074.ts
@@ -58,8 +58,9 @@ const card: Card = {
 	illustrator: "kantaro",
 
 	thirdParty: {
-		cardmarket: 702369
-	}
+        cardmarket: 702369,
+        tcgplayer: 487929
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/075.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/075.ts
@@ -72,8 +72,9 @@ const card: Card = {
 	illustrator: "Saya Tsuruta",
 
 	thirdParty: {
-		cardmarket: 702371
-	}
+        cardmarket: 702371,
+        tcgplayer: 487930
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/076.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/076.ts
@@ -82,8 +82,9 @@ const card: Card = {
 	illustrator: "Mizue",
 
 	thirdParty: {
-		cardmarket: 702372
-	}
+        cardmarket: 702372,
+        tcgplayer: 487931
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/077.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/077.ts
@@ -65,8 +65,9 @@ const card: Card = {
 	illustrator: "Saya Tsuruta",
 
 	thirdParty: {
-		cardmarket: 702374
-	}
+        cardmarket: 702374,
+        tcgplayer: 487932
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/078.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/078.ts
@@ -45,8 +45,9 @@ const card: Card = {
 	illustrator: "Shin Nagasawa",
 
 	thirdParty: {
-		cardmarket: 702374
-	}
+        cardmarket: 702374,
+        tcgplayer: 487933
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/079.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/079.ts
@@ -79,8 +79,9 @@ const card: Card = {
 	illustrator: "Kouki Saitou",
 
 	thirdParty: {
-		cardmarket: 702376
-	}
+        cardmarket: 702376,
+        tcgplayer: 487935
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/080.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/080.ts
@@ -68,8 +68,9 @@ const card: Card = {
 	illustrator: "Kouki Saitou",
 
 	thirdParty: {
-		cardmarket: 689766
-	}
+        cardmarket: 689766,
+        tcgplayer: 487942
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/081.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/081.ts
@@ -77,8 +77,9 @@ const card: Card = {
 	illustrator: "5ban Graphics",
 
 	thirdParty: {
-		cardmarket: 689766
-	}
+        cardmarket: 689766,
+        tcgplayer: 475420
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/082.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/082.ts
@@ -65,8 +65,9 @@ const card: Card = {
 	illustrator: "OKACHEKE",
 
 	thirdParty: {
-		cardmarket: 702378
-	}
+        cardmarket: 702378,
+        tcgplayer: 487944
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/083.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/083.ts
@@ -70,8 +70,9 @@ const card: Card = {
 	illustrator: "Toshinao Aoki",
 
 	thirdParty: {
-		cardmarket: 702379
-	}
+        cardmarket: 702379,
+        tcgplayer: 487946
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/084.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/084.ts
@@ -45,8 +45,9 @@ const card: Card = {
 	illustrator: "Tika Matsuno",
 
 	thirdParty: {
-		cardmarket: 702380
-	}
+        cardmarket: 702380,
+        tcgplayer: 487948
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/085.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/085.ts
@@ -72,8 +72,9 @@ const card: Card = {
 	illustrator: "kawayoo",
 
 	thirdParty: {
-		cardmarket: 702381
-	}
+        cardmarket: 702381,
+        tcgplayer: 487949
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/086.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/086.ts
@@ -82,8 +82,9 @@ const card: Card = {
 	illustrator: "N-DESIGN Inc.",
 
 	thirdParty: {
-		cardmarket: 702382
-	}
+        cardmarket: 702382,
+        tcgplayer: 487951
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/087.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/087.ts
@@ -54,8 +54,9 @@ const card: Card = {
 	illustrator: "Jerky",
 
 	thirdParty: {
-		cardmarket: 702383
-	}
+        cardmarket: 702383,
+        tcgplayer: 487952
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/088.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/088.ts
@@ -82,8 +82,9 @@ const card: Card = {
 	illustrator: "PLANETA Mochizuki",
 
 	thirdParty: {
-		cardmarket: 702384
-	}
+        cardmarket: 702384,
+        tcgplayer: 487954
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/089.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/089.ts
@@ -67,8 +67,9 @@ const card: Card = {
 	illustrator: "Taira Akitsu",
 
 	thirdParty: {
-		cardmarket: 702385
-	}
+        cardmarket: 702385,
+        tcgplayer: 487955
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/090.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/090.ts
@@ -70,8 +70,9 @@ const card: Card = {
 	illustrator: "Yuu Nishida",
 
 	thirdParty: {
-		cardmarket: 702386
-	}
+        cardmarket: 702386,
+        tcgplayer: 487956
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/091.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/091.ts
@@ -45,8 +45,9 @@ const card: Card = {
 	illustrator: "Mizue",
 
 	thirdParty: {
-		cardmarket: 702387
-	}
+        cardmarket: 702387,
+        tcgplayer: 487958
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/092.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/092.ts
@@ -59,8 +59,9 @@ const card: Card = {
 	illustrator: "saino misaki",
 
 	thirdParty: {
-		cardmarket: 702388
-	}
+        cardmarket: 702388,
+        tcgplayer: 487959
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/093.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/093.ts
@@ -81,8 +81,9 @@ const card: Card = {
 	illustrator: "Haru Akasaka",
 
 	thirdParty: {
-		cardmarket: 702389
-	}
+        cardmarket: 702389,
+        tcgplayer: 487960
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/094.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/094.ts
@@ -54,8 +54,9 @@ const card: Card = {
 	illustrator: "zig",
 
 	thirdParty: {
-		cardmarket: 702390
-	}
+        cardmarket: 702390,
+        tcgplayer: 487961
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/095.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/095.ts
@@ -54,8 +54,9 @@ const card: Card = {
 	illustrator: "Nelnal",
 
 	thirdParty: {
-		cardmarket: 702390
-	}
+        cardmarket: 702390,
+        tcgplayer: 487054
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/096.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/096.ts
@@ -77,8 +77,9 @@ const card: Card = {
 	illustrator: "GOSSAN",
 
 	thirdParty: {
-		cardmarket: 702392
-	}
+        cardmarket: 702392,
+        tcgplayer: 486602
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/097.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/097.ts
@@ -45,8 +45,9 @@ const card: Card = {
 	illustrator: "Mizue",
 
 	thirdParty: {
-		cardmarket: 702393
-	}
+        cardmarket: 702393,
+        tcgplayer: 487968
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/098.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/098.ts
@@ -65,8 +65,9 @@ const card: Card = {
 	illustrator: "Saya Tsuruta",
 
 	thirdParty: {
-		cardmarket: 702393
-	}
+        cardmarket: 702393,
+        tcgplayer: 487969
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/099.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/099.ts
@@ -72,8 +72,9 @@ const card: Card = {
 	illustrator: "You Iribi",
 
 	thirdParty: {
-		cardmarket: 702395
-	}
+        cardmarket: 702395,
+        tcgplayer: 487971
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/100.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/100.ts
@@ -54,8 +54,9 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 702396
-	}
+        cardmarket: 702396,
+        tcgplayer: 487973
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/101.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/101.ts
@@ -54,8 +54,9 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 702396
-	}
+        cardmarket: 702396,
+        tcgplayer: 487975
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/102.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/102.ts
@@ -63,8 +63,9 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 702396
-	}
+        cardmarket: 702396,
+        tcgplayer: 487976
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/103.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/103.ts
@@ -90,8 +90,9 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 702399
-	}
+        cardmarket: 702399,
+        tcgplayer: 487978
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/104.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/104.ts
@@ -63,8 +63,9 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 701132
-	}
+        cardmarket: 701132,
+        tcgplayer: 487980
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/105.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/105.ts
@@ -74,8 +74,9 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 701132
-	}
+        cardmarket: 701132,
+        tcgplayer: 487981
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/106.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/106.ts
@@ -69,8 +69,9 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 702402
-	}
+        cardmarket: 702402,
+        tcgplayer: 487983
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/107.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/107.ts
@@ -58,8 +58,9 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 702403
-	}
+        cardmarket: 702403,
+        tcgplayer: 487993
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/108.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/108.ts
@@ -63,8 +63,9 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 702404
-	}
+        cardmarket: 702404,
+        tcgplayer: 487994
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/109.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/109.ts
@@ -86,8 +86,9 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 702405
-	}
+        cardmarket: 702405,
+        tcgplayer: 486617
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/110.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/110.ts
@@ -58,8 +58,9 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 702406
-	}
+        cardmarket: 702406,
+        tcgplayer: 487999
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/111.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/111.ts
@@ -85,8 +85,9 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 702407
-	}
+        cardmarket: 702407,
+        tcgplayer: 488000
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/112.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/112.ts
@@ -62,8 +62,9 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 702408
-	}
+        cardmarket: 702408,
+        tcgplayer: 488001
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/113.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/113.ts
@@ -71,8 +71,9 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 702408
-	}
+        cardmarket: 702408,
+        tcgplayer: 488002
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/114.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/114.ts
@@ -85,8 +85,9 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 702410
-	}
+        cardmarket: 702410,
+        tcgplayer: 488003
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/115.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/115.ts
@@ -62,8 +62,9 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 702411
-	}
+        cardmarket: 702411,
+        tcgplayer: 488004
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/116.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/116.ts
@@ -76,8 +76,9 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 702412
-	}
+        cardmarket: 702412,
+        tcgplayer: 488005
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/117.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/117.ts
@@ -85,8 +85,9 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 702413
-	}
+        cardmarket: 702413,
+        tcgplayer: 488006
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/118.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/118.ts
@@ -72,8 +72,9 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 702414
-	}
+        cardmarket: 702414,
+        tcgplayer: 488007
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/119.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/119.ts
@@ -49,8 +49,9 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 702415
-	}
+        cardmarket: 702415,
+        tcgplayer: 488008
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/120.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/120.ts
@@ -74,8 +74,9 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 702416
-	}
+        cardmarket: 702416,
+        tcgplayer: 488009
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/121.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/121.ts
@@ -71,8 +71,9 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 702417
-	}
+        cardmarket: 702417,
+        tcgplayer: 488010
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/122.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/122.ts
@@ -72,8 +72,9 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 702418
-	}
+        cardmarket: 702418,
+        tcgplayer: 488011
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/123.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/123.ts
@@ -82,8 +82,9 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 702419
-	}
+        cardmarket: 702419,
+        tcgplayer: 488012
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/124.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/124.ts
@@ -72,8 +72,9 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 689767
-	}
+        cardmarket: 689767,
+        tcgplayer: 488013
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/125.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/125.ts
@@ -82,8 +82,9 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 689767
-	}
+        cardmarket: 689767,
+        tcgplayer: 475421
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/126.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/126.ts
@@ -58,8 +58,9 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 702421
-	}
+        cardmarket: 702421,
+        tcgplayer: 487055
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/127.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/127.ts
@@ -85,8 +85,9 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 702422
-	}
+        cardmarket: 702422,
+        tcgplayer: 488015
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/128.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/128.ts
@@ -78,8 +78,9 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 702423
-	}
+        cardmarket: 702423,
+        tcgplayer: 488016
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/129.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/129.ts
@@ -76,8 +76,9 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 702424
-	}
+        cardmarket: 702424,
+        tcgplayer: 488017
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/130.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/130.ts
@@ -62,8 +62,9 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 702425
-	}
+        cardmarket: 702425,
+        tcgplayer: 487056
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/131.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/131.ts
@@ -85,8 +85,9 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 702426
-	}
+        cardmarket: 702426,
+        tcgplayer: 488019
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/132.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/132.ts
@@ -62,8 +62,9 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 702427
-	}
+        cardmarket: 702427,
+        tcgplayer: 488021
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/133.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/133.ts
@@ -76,8 +76,9 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 702428
-	}
+        cardmarket: 702428,
+        tcgplayer: 488023
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/134.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/134.ts
@@ -71,8 +71,9 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 702429
-	}
+        cardmarket: 702429,
+        tcgplayer: 488024
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/135.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/135.ts
@@ -58,8 +58,9 @@ const card: Card = {
 	illustrator: "kantaro",
 
 	thirdParty: {
-		cardmarket: 702430
-	}
+        cardmarket: 702430,
+        tcgplayer: 488025
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/136.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/136.ts
@@ -54,8 +54,9 @@ const card: Card = {
 	illustrator: "KEIICHIRO ITO",
 
 	thirdParty: {
-		cardmarket: 702430
-	}
+        cardmarket: 702430,
+        tcgplayer: 485867
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/137.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/137.ts
@@ -81,8 +81,9 @@ const card: Card = {
 	illustrator: "KIYOTAKA OSHIYAMA",
 
 	thirdParty: {
-		cardmarket: 702432
-	}
+        cardmarket: 702432,
+        tcgplayer: 485871
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/138.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/138.ts
@@ -74,8 +74,9 @@ const card: Card = {
 	illustrator: "nagimiso",
 
 	thirdParty: {
-		cardmarket: 702433
-	}
+        cardmarket: 702433,
+        tcgplayer: 488026
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/139.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/139.ts
@@ -81,8 +81,9 @@ const card: Card = {
 	illustrator: "Lee HyunJung",
 
 	thirdParty: {
-		cardmarket: 702434
-	}
+        cardmarket: 702434,
+        tcgplayer: 488027
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/140.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/140.ts
@@ -52,8 +52,9 @@ const card: Card = {
 	illustrator: "Shin Nagasawa",
 
 	thirdParty: {
-		cardmarket: 702435
-	}
+        cardmarket: 702435,
+        tcgplayer: 488028
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/141.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/141.ts
@@ -45,8 +45,9 @@ const card: Card = {
 	illustrator: "nagimiso",
 
 	thirdParty: {
-		cardmarket: 702435
-	}
+        cardmarket: 702435,
+        tcgplayer: 488029
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/142.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/142.ts
@@ -82,8 +82,9 @@ const card: Card = {
 	illustrator: "Anesaki Dynamic",
 
 	thirdParty: {
-		cardmarket: 702437
-	}
+        cardmarket: 702437,
+        tcgplayer: 488030
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/143.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/143.ts
@@ -75,8 +75,9 @@ const card: Card = {
 	illustrator: "5ban Graphics",
 
 	thirdParty: {
-		cardmarket: 702439
-	}
+        cardmarket: 702439,
+        tcgplayer: 485106
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/144.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/144.ts
@@ -67,8 +67,9 @@ const card: Card = {
 	illustrator: "sui",
 
 	thirdParty: {
-		cardmarket: 702440
-	}
+        cardmarket: 702440,
+        tcgplayer: 488031
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/145.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/145.ts
@@ -81,8 +81,9 @@ const card: Card = {
 	illustrator: "chibi",
 
 	thirdParty: {
-		cardmarket: 702441
-	}
+        cardmarket: 702441,
+        tcgplayer: 488033
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/146.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/146.ts
@@ -45,8 +45,9 @@ const card: Card = {
 	illustrator: "Yuya Oka",
 
 	thirdParty: {
-		cardmarket: 702442
-	}
+        cardmarket: 702442,
+        tcgplayer: 488035
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/147.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/147.ts
@@ -65,8 +65,9 @@ const card: Card = {
 	illustrator: "aoki",
 
 	thirdParty: {
-		cardmarket: 702442
-	}
+        cardmarket: 702442,
+        tcgplayer: 488036
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/148.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/148.ts
@@ -45,8 +45,9 @@ const card: Card = {
 	illustrator: "Yuka Morii",
 
 	thirdParty: {
-		cardmarket: 702444
-	}
+        cardmarket: 702444,
+        tcgplayer: 488037
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/149.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/149.ts
@@ -63,8 +63,9 @@ const card: Card = {
 	illustrator: "kantaro",
 
 	thirdParty: {
-		cardmarket: 702445
-	}
+        cardmarket: 702445,
+        tcgplayer: 488038
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/150.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/150.ts
@@ -81,8 +81,9 @@ const card: Card = {
 	illustrator: "Atsushi Furusawa",
 
 	thirdParty: {
-		cardmarket: 702446
-	}
+        cardmarket: 702446,
+        tcgplayer: 488040
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/151.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/151.ts
@@ -67,8 +67,9 @@ const card: Card = {
 	illustrator: "HYOGONOSUKE",
 
 	thirdParty: {
-		cardmarket: 702447
-	}
+        cardmarket: 702447,
+        tcgplayer: 488041
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/152.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/152.ts
@@ -72,8 +72,9 @@ const card: Card = {
 	illustrator: "kantaro",
 
 	thirdParty: {
-		cardmarket: 702448
-	}
+        cardmarket: 702448,
+        tcgplayer: 488043
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/153.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/153.ts
@@ -74,8 +74,9 @@ const card: Card = {
 	illustrator: "Kagemaru Himeno",
 
 	thirdParty: {
-		cardmarket: 702449
-	}
+        cardmarket: 702449,
+        tcgplayer: 488045
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/154.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/154.ts
@@ -65,8 +65,9 @@ const card: Card = {
 	illustrator: "Teeziro",
 
 	thirdParty: {
-		cardmarket: 692087
-	}
+        cardmarket: 692087,
+        tcgplayer: 488048
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/155.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/155.ts
@@ -65,8 +65,9 @@ const card: Card = {
 	illustrator: "kodama",
 
 	thirdParty: {
-		cardmarket: 692087
-	}
+        cardmarket: 692087,
+        tcgplayer: 485108
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/156.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/156.ts
@@ -54,8 +54,9 @@ const card: Card = {
 	illustrator: "Mina Nakai",
 
 	thirdParty: {
-		cardmarket: 692087
-	}
+        cardmarket: 692087,
+        tcgplayer: 488050
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/157.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/157.ts
@@ -72,8 +72,9 @@ const card: Card = {
 	illustrator: "kirisAki",
 
 	thirdParty: {
-		cardmarket: 702453
-	}
+        cardmarket: 702453,
+        tcgplayer: 488052
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/158.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/158.ts
@@ -82,8 +82,9 @@ const card: Card = {
 	illustrator: "aky CG Works",
 
 	thirdParty: {
-		cardmarket: 702454
-	}
+        cardmarket: 702454,
+        tcgplayer: 488053
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/159.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/159.ts
@@ -45,8 +45,9 @@ const card: Card = {
 	illustrator: "Pani Kobayashi",
 
 	thirdParty: {
-		cardmarket: 702455
-	}
+        cardmarket: 702455,
+        tcgplayer: 488054
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/160.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/160.ts
@@ -54,8 +54,9 @@ const card: Card = {
 	illustrator: "yuu",
 
 	thirdParty: {
-		cardmarket: 702455
-	}
+        cardmarket: 702455,
+        tcgplayer: 488056
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/161.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/161.ts
@@ -72,8 +72,9 @@ const card: Card = {
 	illustrator: "KIYOTAKA OSHIYAMA",
 
 	thirdParty: {
-		cardmarket: 702457
-	}
+        cardmarket: 702457,
+        tcgplayer: 488057
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/162.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/162.ts
@@ -74,8 +74,9 @@ const card: Card = {
 	illustrator: "Oswaldo KATO",
 
 	thirdParty: {
-		cardmarket: 702458
-	}
+        cardmarket: 702458,
+        tcgplayer: 488058
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/163.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/163.ts
@@ -54,8 +54,9 @@ const card: Card = {
 	illustrator: "AKIRA EGAWA",
 
 	thirdParty: {
-		cardmarket: 702459
-	}
+        cardmarket: 702459,
+        tcgplayer: 488059
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/164.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/164.ts
@@ -66,8 +66,9 @@ const card: Card = {
 	illustrator: "Ryota Murayama",
 
 	thirdParty: {
-		cardmarket: 702459
-	}
+        cardmarket: 702459,
+        tcgplayer: 487059
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/165.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/165.ts
@@ -67,8 +67,9 @@ const card: Card = {
 	illustrator: "kantaro",
 
 	thirdParty: {
-		cardmarket: 702461
-	}
+        cardmarket: 702461,
+        tcgplayer: 488060
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/166.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/166.ts
@@ -35,8 +35,9 @@ const card: Card = {
 	illustrator: "GIDORA",
 
 	thirdParty: {
-		cardmarket: 702462
-	}
+        cardmarket: 702462,
+        tcgplayer: 488071
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/167.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/167.ts
@@ -35,8 +35,9 @@ const card: Card = {
 	illustrator: "Oswaldo KATO",
 
 	thirdParty: {
-		cardmarket: 702463
-	}
+        cardmarket: 702463,
+        tcgplayer: 488072
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/168.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/168.ts
@@ -35,8 +35,9 @@ const card: Card = {
 	illustrator: "Ayaka Yoshida",
 
 	thirdParty: {
-		cardmarket: 702464
-	}
+        cardmarket: 702464,
+        tcgplayer: 488073
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/169.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/169.ts
@@ -35,8 +35,9 @@ const card: Card = {
 	illustrator: "inose yukie",
 
 	thirdParty: {
-		cardmarket: 702465
-	}
+        cardmarket: 702465,
+        tcgplayer: 488074
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/170.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/170.ts
@@ -35,8 +35,9 @@ const card: Card = {
 	illustrator: "Toyste Beach",
 
 	thirdParty: {
-		cardmarket: 702466
-	}
+        cardmarket: 702466,
+        tcgplayer: 488075
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/171.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/171.ts
@@ -35,8 +35,9 @@ const card: Card = {
 	illustrator: "Studio Bora Inc.",
 
 	thirdParty: {
-		cardmarket: 702467
-	}
+        cardmarket: 702467,
+        tcgplayer: 488076
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/172.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/172.ts
@@ -35,8 +35,9 @@ const card: Card = {
 	illustrator: "Toyste Beach",
 
 	thirdParty: {
-		cardmarket: 702468
-	}
+        cardmarket: 702468,
+        tcgplayer: 488077
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/173.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/173.ts
@@ -35,8 +35,9 @@ const card: Card = {
 	illustrator: "Studio Bora Inc.",
 
 	thirdParty: {
-		cardmarket: 702469
-	}
+        cardmarket: 702469,
+        tcgplayer: 488078
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/174.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/174.ts
@@ -35,8 +35,9 @@ const card: Card = {
 	illustrator: "Toyste Beach",
 
 	thirdParty: {
-		cardmarket: 702470
-	}
+        cardmarket: 702470,
+        tcgplayer: 488079
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/175.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/175.ts
@@ -35,8 +35,9 @@ const card: Card = {
 	illustrator: "GIDORA",
 
 	thirdParty: {
-		cardmarket: 702471
-	}
+        cardmarket: 702471,
+        tcgplayer: 488080
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/176.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/176.ts
@@ -35,8 +35,9 @@ const card: Card = {
 	illustrator: "Hideki Ishikawa",
 
 	thirdParty: {
-		cardmarket: 702472
-	}
+        cardmarket: 702472,
+        tcgplayer: 488081
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/177.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/177.ts
@@ -35,8 +35,9 @@ const card: Card = {
 	illustrator: "Akira Komayama",
 
 	thirdParty: {
-		cardmarket: 702473
-	}
+        cardmarket: 702473,
+        tcgplayer: 488082
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/178.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/178.ts
@@ -35,8 +35,9 @@ const card: Card = {
 	illustrator: "Oswaldo KATO",
 
 	thirdParty: {
-		cardmarket: 702474
-	}
+        cardmarket: 702474,
+        tcgplayer: 488083
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/179.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/179.ts
@@ -35,8 +35,9 @@ const card: Card = {
 	illustrator: "Sanosuke Sakuma",
 
 	thirdParty: {
-		cardmarket: 702475
-	}
+        cardmarket: 702475,
+        tcgplayer: 488085
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/180.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/180.ts
@@ -35,8 +35,9 @@ const card: Card = {
 	illustrator: "Sanosuke Sakuma",
 
 	thirdParty: {
-		cardmarket: 702476
-	}
+        cardmarket: 702476,
+        tcgplayer: 488086
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/181.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/181.ts
@@ -35,8 +35,9 @@ const card: Card = {
 	illustrator: "Toyste Beach",
 
 	thirdParty: {
-		cardmarket: 702477
-	}
+        cardmarket: 702477,
+        tcgplayer: 488087
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/182.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/182.ts
@@ -35,8 +35,9 @@ const card: Card = {
 	illustrator: "Studio Bora Inc.",
 
 	thirdParty: {
-		cardmarket: 702478
-	}
+        cardmarket: 702478,
+        tcgplayer: 488088
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/183.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/183.ts
@@ -35,8 +35,9 @@ const card: Card = {
 	illustrator: "yuu",
 
 	thirdParty: {
-		cardmarket: 702479
-	}
+        cardmarket: 702479,
+        tcgplayer: 488089
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/184.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/184.ts
@@ -35,8 +35,9 @@ const card: Card = {
 	illustrator: "OKACHEKE",
 
 	thirdParty: {
-		cardmarket: 702480
-	}
+        cardmarket: 702480,
+        tcgplayer: 488090
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/185.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/185.ts
@@ -35,8 +35,9 @@ const card: Card = {
 	illustrator: "Studio Bora Inc.",
 
 	thirdParty: {
-		cardmarket: 702481
-	}
+        cardmarket: 702481,
+        tcgplayer: 488091
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/186.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/186.ts
@@ -35,8 +35,9 @@ const card: Card = {
 	illustrator: "Toyste Beach",
 
 	thirdParty: {
-		cardmarket: 702482
-	}
+        cardmarket: 702482,
+        tcgplayer: 488092
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/187.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/187.ts
@@ -35,8 +35,9 @@ const card: Card = {
 	illustrator: "Studio Bora Inc.",
 
 	thirdParty: {
-		cardmarket: 702483
-	}
+        cardmarket: 702483,
+        tcgplayer: 488093
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/188.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/188.ts
@@ -35,8 +35,9 @@ const card: Card = {
 	illustrator: "Ayaka Yoshida",
 
 	thirdParty: {
-		cardmarket: 702484
-	}
+        cardmarket: 702484,
+        tcgplayer: 488094
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/189.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/189.ts
@@ -36,8 +36,9 @@ const card: Card = {
 	illustrator: "kirisAki",
 
 	thirdParty: {
-		cardmarket: 689768
-	}
+        cardmarket: 689768,
+        tcgplayer: 475423
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/190.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/190.ts
@@ -35,8 +35,9 @@ const card: Card = {
 	illustrator: "kirisAki",
 
 	thirdParty: {
-		cardmarket: 689768
-	}
+        cardmarket: 689768,
+        tcgplayer: 475424
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/191.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/191.ts
@@ -35,8 +35,9 @@ const card: Card = {
 	illustrator: "Studio Bora Inc.",
 
 	thirdParty: {
-		cardmarket: 702487
-	}
+        cardmarket: 702487,
+        tcgplayer: 488098
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/192.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/192.ts
@@ -35,8 +35,9 @@ const card: Card = {
 	illustrator: "Toyste Beach",
 
 	thirdParty: {
-		cardmarket: 702488
-	}
+        cardmarket: 702488,
+        tcgplayer: 475443
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/193.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/193.ts
@@ -35,8 +35,9 @@ const card: Card = {
 	illustrator: "Ayaka Yoshida",
 
 	thirdParty: {
-		cardmarket: 702489
-	}
+        cardmarket: 702489,
+        tcgplayer: 488100
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/194.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/194.ts
@@ -35,8 +35,9 @@ const card: Card = {
 	illustrator: "Studio Bora Inc.",
 
 	thirdParty: {
-		cardmarket: 702490
-	}
+        cardmarket: 702490,
+        tcgplayer: 488102
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/195.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/195.ts
@@ -35,8 +35,9 @@ const card: Card = {
 	illustrator: "nagimiso",
 
 	thirdParty: {
-		cardmarket: 702491
-	}
+        cardmarket: 702491,
+        tcgplayer: 488104
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/196.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/196.ts
@@ -35,8 +35,9 @@ const card: Card = {
 	illustrator: "Ayaka Yoshida",
 
 	thirdParty: {
-		cardmarket: 702492
-	}
+        cardmarket: 702492,
+        tcgplayer: 488105
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/197.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/197.ts
@@ -35,8 +35,9 @@ const card: Card = {
 	illustrator: "Studio Bora Inc.",
 
 	thirdParty: {
-		cardmarket: 702493
-	}
+        cardmarket: 702493,
+        tcgplayer: 488107
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/198.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/198.ts
@@ -35,8 +35,9 @@ const card: Card = {
 	illustrator: "Hitoshi Ariga",
 
 	thirdParty: {
-		cardmarket: 702494
-	}
+        cardmarket: 702494,
+        tcgplayer: 488108
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/199.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/199.ts
@@ -55,8 +55,9 @@ const card: Card = {
 	illustrator: "Miki Tanaka",
 
 	thirdParty: {
-		cardmarket: 702312
-	}
+        cardmarket: 702312,
+        tcgplayer: 490293
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/200.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/200.ts
@@ -73,8 +73,9 @@ const card: Card = {
 	illustrator: "Oswaldo KATO",
 
 	thirdParty: {
-		cardmarket: 702318
-	}
+        cardmarket: 702318,
+        tcgplayer: 486622
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/201.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/201.ts
@@ -55,8 +55,9 @@ const card: Card = {
 	illustrator: "Akira Komayama",
 
 	thirdParty: {
-		cardmarket: 702320
-	}
+        cardmarket: 702320,
+        tcgplayer: 490049
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/202.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/202.ts
@@ -82,8 +82,9 @@ const card: Card = {
 	illustrator: "KIYOTAKA OSHIYAMA",
 
 	thirdParty: {
-		cardmarket: 702325
-	}
+        cardmarket: 702325,
+        tcgplayer: 490062
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/203.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/203.ts
@@ -82,8 +82,9 @@ const card: Card = {
 	illustrator: "nagimiso",
 
 	thirdParty: {
-		cardmarket: 702336
-	}
+        cardmarket: 702336,
+        tcgplayer: 490063
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/204.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/204.ts
@@ -66,8 +66,9 @@ const card: Card = {
 	illustrator: "Toshinao Aoki",
 
 	thirdParty: {
-		cardmarket: 702337
-	}
+        cardmarket: 702337,
+        tcgplayer: 490064
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/205.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/205.ts
@@ -46,8 +46,9 @@ const card: Card = {
 	illustrator: "Shinya Komatsu",
 
 	thirdParty: {
-		cardmarket: 702344
-	}
+        cardmarket: 702344,
+        tcgplayer: 490066
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/206.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/206.ts
@@ -55,8 +55,9 @@ const card: Card = {
 	illustrator: "You Iribi",
 
 	thirdParty: {
-		cardmarket: 702350
-	}
+        cardmarket: 702350,
+        tcgplayer: 490067
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/207.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/207.ts
@@ -68,8 +68,9 @@ const card: Card = {
 	illustrator: "AKIRA EGAWA",
 
 	thirdParty: {
-		cardmarket: 702356
-	}
+        cardmarket: 702356,
+        tcgplayer: 487060
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/208.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/208.ts
@@ -77,8 +77,9 @@ const card: Card = {
 	illustrator: "zig",
 
 	thirdParty: {
-		cardmarket: 702364
-	}
+        cardmarket: 702364,
+        tcgplayer: 490068
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/209.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/209.ts
@@ -82,8 +82,9 @@ const card: Card = {
 	illustrator: "Kouki Saitou",
 
 	thirdParty: {
-		cardmarket: 702372
-	}
+        cardmarket: 702372,
+        tcgplayer: 490069
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/210.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/210.ts
@@ -66,8 +66,9 @@ const card: Card = {
 	illustrator: "Tomokazu Komiya",
 
 	thirdParty: {
-		cardmarket: 702378
-	}
+        cardmarket: 702378,
+        tcgplayer: 490070
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/211.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/211.ts
@@ -46,8 +46,9 @@ const card: Card = {
 	illustrator: "Jiro Sasumo",
 
 	thirdParty: {
-		cardmarket: 702380
-	}
+        cardmarket: 702380,
+        tcgplayer: 490071
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/212.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/212.ts
@@ -73,8 +73,9 @@ const card: Card = {
 	illustrator: "Jiro Sasumo",
 
 	thirdParty: {
-		cardmarket: 702381
-	}
+        cardmarket: 702381,
+        tcgplayer: 490072
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/213.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/213.ts
@@ -66,8 +66,9 @@ const card: Card = {
 	illustrator: "Tika Matsuno",
 
 	thirdParty: {
-		cardmarket: 702393
-	}
+        cardmarket: 702393,
+        tcgplayer: 487086
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/214.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/214.ts
@@ -55,8 +55,9 @@ const card: Card = {
 	illustrator: "sowsow",
 
 	thirdParty: {
-		cardmarket: 701132
-	}
+        cardmarket: 701132,
+        tcgplayer: 490073
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/215.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/215.ts
@@ -68,8 +68,9 @@ const card: Card = {
 	illustrator: "Nelnal",
 
 	thirdParty: {
-		cardmarket: 702408
-	}
+        cardmarket: 702408,
+        tcgplayer: 490074
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/216.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/216.ts
@@ -59,8 +59,9 @@ const card: Card = {
 	illustrator: "Nurikabe",
 
 	thirdParty: {
-		cardmarket: 702411
-	}
+        cardmarket: 702411,
+        tcgplayer: 489631
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/217.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/217.ts
@@ -68,8 +68,9 @@ const card: Card = {
 	illustrator: "Mina Nakai",
 
 	thirdParty: {
-		cardmarket: 702418
-	}
+        cardmarket: 702418,
+        tcgplayer: 490075
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/218.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/218.ts
@@ -82,8 +82,9 @@ const card: Card = {
 	illustrator: "OKACHEKE",
 
 	thirdParty: {
-		cardmarket: 702432
-	}
+        cardmarket: 702432,
+        tcgplayer: 490076
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/219.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/219.ts
@@ -75,8 +75,9 @@ const card: Card = {
 	illustrator: "Shibuzoh.",
 
 	thirdParty: {
-		cardmarket: 702433
-	}
+        cardmarket: 702433,
+        tcgplayer: 490077
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/220.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/220.ts
@@ -73,8 +73,9 @@ const card: Card = {
 	illustrator: "Shin Nagasawa",
 
 	thirdParty: {
-		cardmarket: 702429
-	}
+        cardmarket: 702429,
+        tcgplayer: 490078
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/221.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/221.ts
@@ -46,8 +46,9 @@ const card: Card = {
 	illustrator: "saino misaki",
 
 	thirdParty: {
-		cardmarket: 702444
-	}
+        cardmarket: 702444,
+        tcgplayer: 490079
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/222.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/222.ts
@@ -68,8 +68,9 @@ const card: Card = {
 	illustrator: "Teeziro",
 
 	thirdParty: {
-		cardmarket: 702447
-	}
+        cardmarket: 702447,
+        tcgplayer: 490080
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/223.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/223.ts
@@ -82,8 +82,9 @@ const card: Card = {
 	illustrator: "takuyoa",
 
 	thirdParty: {
-		cardmarket: 702315
-	}
+        cardmarket: 702315,
+        tcgplayer: 490081
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/224.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/224.ts
@@ -82,8 +82,9 @@ const card: Card = {
 	illustrator: "5ban Graphics",
 
 	thirdParty: {
-		cardmarket: 702328
-	}
+        cardmarket: 702328,
+        tcgplayer: 490082
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/225.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/225.ts
@@ -73,8 +73,9 @@ const card: Card = {
 	illustrator: "5ban Graphics",
 
 	thirdParty: {
-		cardmarket: 702340
-	}
+        cardmarket: 702340,
+        tcgplayer: 490083
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/226.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/226.ts
@@ -82,8 +82,9 @@ const card: Card = {
 	illustrator: "PLANETA Tsuji",
 
 	thirdParty: {
-		cardmarket: 702361
-	}
+        cardmarket: 702361,
+        tcgplayer: 490084
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/227.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/227.ts
@@ -77,8 +77,9 @@ const card: Card = {
 	illustrator: "5ban Graphics",
 
 	thirdParty: {
-		cardmarket: 689766
-	}
+        cardmarket: 689766,
+        tcgplayer: 490085
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/228.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/228.ts
@@ -82,8 +82,9 @@ const card: Card = {
 	illustrator: "N-DESIGN Inc.",
 
 	thirdParty: {
-		cardmarket: 702382
-	}
+        cardmarket: 702382,
+        tcgplayer: 490086
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/229.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/229.ts
@@ -82,8 +82,9 @@ const card: Card = {
 	illustrator: "PLANETA Mochizuki",
 
 	thirdParty: {
-		cardmarket: 702384
-	}
+        cardmarket: 702384,
+        tcgplayer: 490087
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/230.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/230.ts
@@ -77,8 +77,9 @@ const card: Card = {
 	illustrator: "5ban Graphics",
 
 	thirdParty: {
-		cardmarket: 702419
-	}
+        cardmarket: 702419,
+        tcgplayer: 490088
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/231.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/231.ts
@@ -77,8 +77,9 @@ const card: Card = {
 	illustrator: "aky CG Works",
 
 	thirdParty: {
-		cardmarket: 689767
-	}
+        cardmarket: 689767,
+        tcgplayer: 490089
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/232.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/232.ts
@@ -80,8 +80,9 @@ const card: Card = {
 	illustrator: "PLANETA Hiiragi",
 
 	thirdParty: {
-		cardmarket: 702426
-	}
+        cardmarket: 702426,
+        tcgplayer: 490090
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/233.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/233.ts
@@ -75,8 +75,9 @@ const card: Card = {
 	illustrator: "5ban Graphics",
 
 	thirdParty: {
-		cardmarket: 702439
-	}
+        cardmarket: 702439,
+        tcgplayer: 490091
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/234.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/234.ts
@@ -82,8 +82,9 @@ const card: Card = {
 	illustrator: "aky CG Works",
 
 	thirdParty: {
-		cardmarket: 702454
-	}
+        cardmarket: 702454,
+        tcgplayer: 490092
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/235.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/235.ts
@@ -36,8 +36,9 @@ const card: Card = {
 	illustrator: "GIDORA",
 
 	thirdParty: {
-		cardmarket: 702462
-	}
+        cardmarket: 702462,
+        tcgplayer: 490093
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/236.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/236.ts
@@ -36,8 +36,9 @@ const card: Card = {
 	illustrator: "GIDORA",
 
 	thirdParty: {
-		cardmarket: 702471
-	}
+        cardmarket: 702471,
+        tcgplayer: 490094
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/237.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/237.ts
@@ -36,8 +36,9 @@ const card: Card = {
 	illustrator: "Akira Komayama",
 
 	thirdParty: {
-		cardmarket: 702473
-	}
+        cardmarket: 702473,
+        tcgplayer: 490095
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/238.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/238.ts
@@ -36,8 +36,9 @@ const card: Card = {
 	illustrator: "Sanosuke Sakuma",
 
 	thirdParty: {
-		cardmarket: 702475
-	}
+        cardmarket: 702475,
+        tcgplayer: 490096
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/239.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/239.ts
@@ -36,8 +36,9 @@ const card: Card = {
 	illustrator: "yuu",
 
 	thirdParty: {
-		cardmarket: 702479
-	}
+        cardmarket: 702479,
+        tcgplayer: 490097
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/240.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/240.ts
@@ -36,8 +36,9 @@ const card: Card = {
 	illustrator: "kirisAki",
 
 	thirdParty: {
-		cardmarket: 689768
-	}
+        cardmarket: 689768,
+        tcgplayer: 490098
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/241.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/241.ts
@@ -36,8 +36,9 @@ const card: Card = {
 	illustrator: "kirisAki",
 
 	thirdParty: {
-		cardmarket: 689768
-	}
+        cardmarket: 689768,
+        tcgplayer: 490099
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/242.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/242.ts
@@ -36,8 +36,9 @@ const card: Card = {
 	illustrator: "nagimiso",
 
 	thirdParty: {
-		cardmarket: 702491
-	}
+        cardmarket: 702491,
+        tcgplayer: 487149
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/243.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/243.ts
@@ -82,8 +82,9 @@ const card: Card = {
 	illustrator: "Miki Tanaka",
 
 	thirdParty: {
-		cardmarket: 702315
-	}
+        cardmarket: 702315,
+        tcgplayer: 487147
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/244.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/244.ts
@@ -77,8 +77,9 @@ const card: Card = {
 	illustrator: "kantaro",
 
 	thirdParty: {
-		cardmarket: 689766
-	}
+        cardmarket: 689766,
+        tcgplayer: 485259
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/245.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/245.ts
@@ -82,8 +82,9 @@ const card: Card = {
 	illustrator: "Jiro Sasumo",
 
 	thirdParty: {
-		cardmarket: 702382
-	}
+        cardmarket: 702382,
+        tcgplayer: 486623
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/246.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/246.ts
@@ -77,8 +77,9 @@ const card: Card = {
 	illustrator: "Pani Kobayashi",
 
 	thirdParty: {
-		cardmarket: 702419
-	}
+        cardmarket: 702419,
+        tcgplayer: 490290
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/247.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/247.ts
@@ -77,8 +77,9 @@ const card: Card = {
 	illustrator: "Ryota Murayama",
 
 	thirdParty: {
-		cardmarket: 689767
-	}
+        cardmarket: 689767,
+        tcgplayer: 490044
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/248.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/248.ts
@@ -75,8 +75,9 @@ const card: Card = {
 	illustrator: "KEIICHIRO ITO",
 
 	thirdParty: {
-		cardmarket: 702439
-	}
+        cardmarket: 702439,
+        tcgplayer: 490291
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/249.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/249.ts
@@ -36,8 +36,9 @@ const card: Card = {
 	illustrator: "kantaro",
 
 	thirdParty: {
-		cardmarket: 702462
-	}
+        cardmarket: 702462,
+        tcgplayer: 490292
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/250.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/250.ts
@@ -36,8 +36,9 @@ const card: Card = {
 	illustrator: "Oswaldo KATO",
 
 	thirdParty: {
-		cardmarket: 702471
-	}
+        cardmarket: 702471,
+        tcgplayer: 490289
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/251.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/251.ts
@@ -36,8 +36,9 @@ const card: Card = {
 	illustrator: "Akira Komayama",
 
 	thirdParty: {
-		cardmarket: 702475
-	}
+        cardmarket: 702475,
+        tcgplayer: 487061
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/252.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/252.ts
@@ -36,8 +36,9 @@ const card: Card = {
 	illustrator: "OKACHEKE",
 
 	thirdParty: {
-		cardmarket: 702479
-	}
+        cardmarket: 702479,
+        tcgplayer: 490041
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/253.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/253.ts
@@ -77,8 +77,9 @@ const card: Card = {
 	illustrator: "5ban Graphics",
 
 	thirdParty: {
-		cardmarket: 689766
-	}
+        cardmarket: 689766,
+        tcgplayer: 490043
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/254.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/254.ts
@@ -77,8 +77,9 @@ const card: Card = {
 	illustrator: "aky CG Works",
 
 	thirdParty: {
-		cardmarket: 689767
-	}
+        cardmarket: 689767,
+        tcgplayer: 490045
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/255.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/255.ts
@@ -36,8 +36,9 @@ const card: Card = {
 	illustrator: "Toyste Beach",
 
 	thirdParty: {
-		cardmarket: 702477
-	}
+        cardmarket: 702477,
+        tcgplayer: 490297
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/256.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/256.ts
@@ -36,8 +36,9 @@ const card: Card = {
 	illustrator: "Studio Bora Inc.",
 
 	thirdParty: {
-		cardmarket: 702487
-	}
+        cardmarket: 702487,
+        tcgplayer: 490296
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/257.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/257.ts
@@ -24,8 +24,9 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 702553
-	}
+        cardmarket: 702553,
+        tcgplayer: 490295
+    }
 }
 
 export default card

--- a/data/Scarlet & Violet/Scarlet & Violet/258.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/258.ts
@@ -24,8 +24,9 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 702554
-	}
+        cardmarket: 702554,
+        tcgplayer: 490294
+    }
 }
 
 export default card


### PR DESCRIPTION
## Changes

Added `tcgplayer` fields to all cards in the **Scarlet & Violet Base Set**.   Each card is mapped to its correct TCGplayer product ID.

## Details

- Only the **Scarlet & Violet Base Set** was modified, following the one-set-per-PR rule by adding the correct `tcgplayer` field into the `thirdParty` object for pricing.
