### PR TITLE
fix: Remove old server instructions

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -12,19 +12,15 @@ You will need NPM/NodeJS installed
 
 ```
 npm install
-cd ..
-npm install
-cd server
 ```
 
 2. Compile the database
 
 ```
-cd ..
-npm run compile
-cd server
 npm run compile
 ```
+
+If you do not have `bun` installed globally, you may need to install it with `npm install bun`.
 
 3. run the server !
 


### PR DESCRIPTION
<!--
Contribution guide: https://github.com/tcgdex/cards-database/blob/master/CONTRIBUTING.md
please submit changes up to 1 set at most.
-->

## Changes

The `server/README.md` contains old instructions that are not needed anymore or don't work at all.
- `npm run compile` does not work in the root as the `compile` script is not defined
- `bun` seems to be missing from the dependency list of `server/package.json`. It could be installed globally but maybe defining it in the `server/package.json` would be good, as `devDependencies` or `peerDependencies` or something? The scripts want to use `bun` but it is somewhat assumed that it exists somewhere. I added a NOTE in the meantime that users might need to install it themselves.

## Details

<!-- You can also give more details about your changes -->

