### PR TITLE
feat(pop5): Add French translations for POP Series 5

### DIFF
--- a/data/POP/POP Series 5.ts
+++ b/data/POP/POP Series 5.ts
@@ -6,6 +6,7 @@ const pop5: Set = {
 
 	name: {
 		en: "POP Series 5",
+		fr: "POP Série 5",
 		it: "POP Serie 5",
 		de: "POP Serie 5",
 	},

--- a/data/POP/POP Series 5/1.ts
+++ b/data/POP/POP Series 5/1.ts
@@ -4,6 +4,7 @@ import Set from '../POP Series 5'
 const card: Card = {
 	name: {
 		en: "Ho-Oh",
+		fr: "Ho-Oh",
 	},
 
 	illustrator: "Mitsuhiro Arita",
@@ -31,6 +32,7 @@ const card: Card = {
 			],
 			name: {
 				en: "Fire Wing",
+				fr: "Aile de Feu",
 			},
 
 			damage: 20,
@@ -45,9 +47,11 @@ const card: Card = {
 			],
 			name: {
 				en: "Fire Blast",
+				fr: "Déflagration",
 			},
 			effect: {
 				en: "Discard a Fire Energy attached to Ho-Oh.",
+				fr: "Défaussez une Énergie Feu attachée à Ho-Oh.",
 			},
 			damage: 60,
 

--- a/data/POP/POP Series 5/10.ts
+++ b/data/POP/POP Series 5/10.ts
@@ -4,6 +4,7 @@ import Set from '../POP Series 5'
 const card: Card = {
 	name: {
 		en: "Charmander δ",
+		fr: "Salamèche δ",
 	},
 
 	illustrator: "Mitsuhiro Arita",

--- a/data/POP/POP Series 5/11.ts
+++ b/data/POP/POP Series 5/11.ts
@@ -4,6 +4,7 @@ import Set from '../POP Series 5'
 const card: Card = {
 	name: {
 		en: "Meowth δ",
+		fr: "Miaouss δ",
 	},
 
 	illustrator: "Mitsuhiro Arita",

--- a/data/POP/POP Series 5/12.ts
+++ b/data/POP/POP Series 5/12.ts
@@ -4,6 +4,7 @@ import Set from '../POP Series 5'
 const card: Card = {
 	name: {
 		en: "Pikachu",
+		fr: "Pikachu",
 	},
 
 	illustrator: "Naoyo Kimura",
@@ -30,6 +31,7 @@ const card: Card = {
 			],
 			name: {
 				en: "Lightning Ball",
+				fr: "Boule Éclair",
 			},
 
 			damage: 10,
@@ -43,9 +45,11 @@ const card: Card = {
 			],
 			name: {
 				en: "Thunderbolt",
+				fr: "Tonnerre",
 			},
 			effect: {
 				en: "Discard all Energy cards attached to Pikachu.",
+				fr: "Défaussez toutes les cartes Énergie attachées à Pikachu.",
 			},
 			damage: 50,
 

--- a/data/POP/POP Series 5/13.ts
+++ b/data/POP/POP Series 5/13.ts
@@ -4,6 +4,7 @@ import Set from '../POP Series 5'
 const card: Card = {
 	name: {
 		en: "Pikachu δ",
+		fr: "Pikachu δ",
 	},
 
 	illustrator: "Ryo Ueda",

--- a/data/POP/POP Series 5/14.ts
+++ b/data/POP/POP Series 5/14.ts
@@ -4,6 +4,7 @@ import Set from '../POP Series 5'
 const card: Card = {
 	name: {
 		en: "Pelipper δ",
+		fr: "Bekipan δ",
 	},
 
 	illustrator: "Mitsuhiro Arita",

--- a/data/POP/POP Series 5/15.ts
+++ b/data/POP/POP Series 5/15.ts
@@ -4,6 +4,7 @@ import Set from '../POP Series 5'
 const card: Card = {
 	name: {
 		en: "Zangoose δ",
+		fr: "Mangriff δ",
 	},
 
 	illustrator: "Kouki Saitou",

--- a/data/POP/POP Series 5/16.ts
+++ b/data/POP/POP Series 5/16.ts
@@ -4,6 +4,7 @@ import Set from '../POP Series 5'
 const card: Card = {
 	name: {
 		en: "Espeon ★",
+		fr: "Mentali ★",
 	},
 
 	illustrator: "Masakazu Fukuda",
@@ -28,9 +29,11 @@ const card: Card = {
 			type: "Poke-POWER",
 			name: {
 				en: "Purple Ray",
+				fr: "Rayon Violet",
 			},
 			effect: {
-				en: "Once during your turn, when you put Espeon Star from your hand onto your Bench, you may use this power. Each Active Pokémon (both yours and your opponent’s) is now Confused.",
+				en: "Once during your turn, when you put Espeon Star from your hand onto your Bench, you may use this power. Each Active Pokémon (both yours and your opponent's) is now Confused.",
+				fr: "Une seule fois lors de votre tour, lorsque vous placez Mentali Star de votre main sur votre Banc, vous pouvez utiliser ce pouvoir. Chaque Pokémon Actif (les vôtres et ceux de votre adversaire) est maintenant Confus.",
 			},
 		},
 	],
@@ -44,9 +47,11 @@ const card: Card = {
 			],
 			name: {
 				en: "Psychic Boom",
+				fr: "Psycho-Boom",
 			},
 			effect: {
 				en: "Does 30 damage plus 10 more damage for each Energy attached to the Defending Pokémon.",
+				fr: "Inflige 30 dégâts plus 10 dégâts supplémentaires pour chaque Énergie attachée au Pokémon Défenseur.",
 			},
 			damage: "30+",
 

--- a/data/POP/POP Series 5/17.ts
+++ b/data/POP/POP Series 5/17.ts
@@ -4,6 +4,7 @@ import Set from '../POP Series 5'
 const card: Card = {
 	name: {
 		en: "Umbreon ★",
+		fr: "Noctali ★",
 	},
 
 	illustrator: "Masakazu Fukuda",
@@ -28,9 +29,11 @@ const card: Card = {
 			type: "Poke-POWER",
 			name: {
 				en: "Dark Ray",
+				fr: "Rayon Obscur",
 			},
 			effect: {
-				en: "Once during your turn, when you put Umbreon Star from your hand onto your Bench, you may choose 1 card from your opponent’s hand without looking and discard it.",
+				en: "Once during your turn, when you put Umbreon Star from your hand onto your Bench, you may choose 1 card from your opponent's hand without looking and discard it.",
+				fr: "Une seule fois lors de votre tour, lorsque vous placez Noctali Star de votre main sur votre Banc, vous pouvez choisir 1 carte de la main de votre adversaire sans regarder et la défausser.",
 			},
 		},
 	],
@@ -43,9 +46,11 @@ const card: Card = {
 			],
 			name: {
 				en: "Feint Attack",
+				fr: "Feinte",
 			},
 			effect: {
-				en: "Choose 1 of your opponent’s Pokémon. This attack does 30 damage to that Pokémon. This attack’s damage isn’t affected by Weakness, Resistance, Poké-Powers, Poké-Bodies, or any other effects on that Pokémon.",
+				en: "Choose 1 of your opponent's Pokémon. This attack does 30 damage to that Pokémon. This attack's damage isn't affected by Weakness, Resistance, Poké-Powers, Poké-Bodies, or any other effects on that Pokémon.",
+				fr: "Choisissez 1 des Pokémon de votre adversaire. Cette attaque inflige 30 dégâts à ce Pokémon-là. Les dégâts de cette attaque ne sont pas affectés par la Faiblesse, Résistance, Poké-Powers, Poké-Bodies ou tout autre effet sur ce Pokémon-là.",
 			},
 
 		},

--- a/data/POP/POP Series 5/2.ts
+++ b/data/POP/POP Series 5/2.ts
@@ -4,6 +4,7 @@ import Set from '../POP Series 5'
 const card: Card = {
 	name: {
 		en: "Lugia",
+		fr: "Lugia",
 	},
 
 	illustrator: "Mitsuhiro Arita",
@@ -31,6 +32,7 @@ const card: Card = {
 			],
 			name: {
 				en: "Super Psy Bolt",
+				fr: "Super Psy",
 			},
 
 			damage: 20,
@@ -45,10 +47,12 @@ const card: Card = {
 
 			name: {
 				en: "Aerowing",
+				fr: "Aéroaile",
 			},
 
 			effect: {
 				en: "Before doing damage, you may flip a coin. If tails, this attack does nothing. If heads, this attack does 60 damage instead.",
+				fr: "Avant d'infliger des dégâts, vous pouvez lancer une pièce. Si c'est face, cette attaque inflige 60 dégâts. Si c'est pile, cette attaque ne fait rien.",
 			},
 
 			damage: 30

--- a/data/POP/POP Series 5/3.ts
+++ b/data/POP/POP Series 5/3.ts
@@ -4,6 +4,7 @@ import Set from '../POP Series 5'
 const card: Card = {
 	name: {
 		en: "Mew δ",
+		fr: "Mew δ",
 	},
 
 	illustrator: "Masakazu Fukuda",
@@ -30,9 +31,11 @@ const card: Card = {
 			],
 			name: {
 				en: "Copy",
+				fr: "Copiage",
 			},
 			effect: {
-				en: "Choose 1 of the Defending Pokémon’s attacks. Copy copies that attack. This attack does nothing if Mew doesn’t have the Energy necessary to use that attack. (You must still do anything else required for that attack.) Mew performs that attack.",
+				en: "Choose 1 of the Defending Pokémon's attacks. Copy copies that attack. This attack does nothing if Mew doesn't have the Energy necessary to use that attack. (You must still do anything else required for that attack.) Mew performs that attack.",
+				fr: "Choisissez 1 des attaques du Pokémon Défenseur. Copiage copie cette attaque. Cette attaque est sans effet si Mew ne possède pas suffisamment d'Énergie pour utiliser cette attaque. (Vous devez toujours faire ce que l'attaque indique.) Mew utilise cette attaque.",
 			},
 
 		},
@@ -42,9 +45,11 @@ const card: Card = {
 			],
 			name: {
 				en: "Extra Draw",
+				fr: "Pioche Supplémentaire",
 			},
 			effect: {
 				en: "If your opponent has any Pokémon-ex in play, search your deck for up to 2 basic Energy cards and attach them to Mew. Shuffle your deck afterward.",
+				fr: "Si votre adversaire a des Pokémon-ex en jeu, cherchez dans votre deck jusqu'à 2 cartes Énergie de base et attachez-les à Mew. Ensuite, mélangez votre deck.",
 			},
 
 		},

--- a/data/POP/POP Series 5/4.ts
+++ b/data/POP/POP Series 5/4.ts
@@ -4,6 +4,7 @@ import Set from '../POP Series 5'
 const card: Card = {
 	name: {
 		en: "Double Rainbow Energy",
+		fr: "Double Énergie Multicolore",
 	},
 
 	illustrator: "Takumi Akabane",

--- a/data/POP/POP Series 5/5.ts
+++ b/data/POP/POP Series 5/5.ts
@@ -4,6 +4,7 @@ import Set from '../POP Series 5'
 const card: Card = {
 	name: {
 		en: "Charmeleon δ",
+		fr: "Reptincel δ",
 	},
 
 	illustrator: "Mitsuhiro Arita",

--- a/data/POP/POP Series 5/6.ts
+++ b/data/POP/POP Series 5/6.ts
@@ -3,7 +3,8 @@ import Set from '../POP Series 5'
 
 const card: Card = {
 	name: {
-		en: "Bill’s Maintenance",
+		en: "Bill's Maintenance",
+		fr: "Entretien de Léo",
 	},
 
 	illustrator: "Ken Sugimori",

--- a/data/POP/POP Series 5/7.ts
+++ b/data/POP/POP Series 5/7.ts
@@ -4,6 +4,7 @@ import Set from '../POP Series 5'
 const card: Card = {
 	name: {
 		en: "Rare Candy",
+		fr: "Super Bonbon",
 	},
 
 	illustrator: "Ryo Ueda",
@@ -12,7 +13,8 @@ const card: Card = {
 	set: Set,
 
 	effect: {
-		en: "Choose 1 of your Basic Pokémon in play. If you have a Stage 1 or Stage 2 card that evolves from that Pokémon in your hand, put that card on the Basic Pokémon. (This counts as evolving that Pokémon.)"
+		en: "Choose 1 of your Basic Pokémon in play. If you have a Stage 1 or Stage 2 card that evolves from that Pokémon in your hand, put that card on the Basic Pokémon. (This counts as evolving that Pokémon.)",
+		fr: "Choisissez 1 des Pokémon de base que vous avez en jeu. Si vous possédez dans votre main une carte de Niveau 1 ou de Niveau 2 qui évolue de ce Pokémon, placez cette carte sur le Pokémon de base (vous le faites ainsi évoluer).",
 	},
 
 	trainerType: "Item",

--- a/data/POP/POP Series 5/8.ts
+++ b/data/POP/POP Series 5/8.ts
@@ -4,6 +4,7 @@ import Set from '../POP Series 5'
 const card: Card = {
 	name: {
 		en: "Boost Energy",
+		fr: "Énergie Super",
 	},
 
 	illustrator: "Shin-ichi Yoshikawa",

--- a/data/POP/POP Series 5/9.ts
+++ b/data/POP/POP Series 5/9.ts
@@ -4,6 +4,7 @@ import Set from '../POP Series 5'
 const card: Card = {
 	name: {
 		en: "δ Rainbow Energy",
+		fr: "Énergie Multicolore δ",
 	},
 
 	illustrator: "Takumi Akabane",


### PR DESCRIPTION
## Summary
This PR adds French translations for POP Series 5 (pop5).

## Changes
- Add French name 'POP Série 5' to set file (`data/POP/POP Series 5.ts`)
- Add French translations for all 17 cards in POP Series 5
- Includes French translations for:
  - Card names
  - Attack names
  - Effect descriptions

## Files Changed
- `data/POP/POP Series 5.ts` - Set file with French name
- `data/POP/POP Series 5/1.ts` through `17.ts` - All 17 card files with French translations

## Related
This is part of adding French translations for POP sets. POP Series 6 will be submitted in a separate PR.