### PR TITLE
feat(svp): Add SVP Black Star Promos cards

### DIFF
--- a/data/Scarlet & Violet/SVP Black Star Promos.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos.ts
@@ -16,7 +16,7 @@ const set: Set = {
 	serie: serie,
 
 	cardCount: {
-		official: 0
+		official: 225
 	},
 
 	releaseDate: "2023-03-31",

--- a/data/Scarlet & Violet/SVP Black Star Promos/175.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/175.ts
@@ -1,0 +1,86 @@
+import { Card } from "../../../interfaces"
+import Set from "../SVP Black Star Promos"
+
+const card: Card = {
+	dexId: [196],
+	set: Set,
+	name: {
+		en: "Espeon ex",
+		fr: "Mentali-ex",
+		es: "Espeon ex",
+		pt: "Espeon ex",
+		it: "Espeon-ex",
+		de: "Psiana-ex"
+	},
+	rarity: "None",
+	category: "Pokemon",
+	hp: 270,
+	types: ["Psychic"],
+	evolveFrom: {
+		en: "Eevee",
+		fr: "Évoli",
+		es: "Eevee",
+		pt: "Eevee",
+		it: "Eevee",
+		de: "Evoli"
+	},
+	stage: "Stage1",
+	attacks: [
+		{
+			cost: ["Psychic", "Colorless", "Colorless"],
+			name: {
+				en: "Psych Out",
+				fr: "Déstabilisation",
+				es: "Psicointimidación",
+				pt: "Intimidar",
+				it: "Intimidazione",
+				de: "Nervös machen"
+			},
+			effect: {
+				en: "Discard a random card from your opponent's hand.",
+				fr: "Défaussez au hasard une carte de la main de votre adversaire.",
+				es: "Descarta 1 carta aleatoria de la mano de tu rival.",
+				pt: "Descarte uma carta aleatória da mão do seu oponente.",
+				it: "Scarta una carta a caso dalla mano del tuo avversario.",
+				de: "Lege 1 zufällige Karte aus der Hand deines Gegners auf seinen Ablagestapel."
+			},
+			damage: 160
+		},
+		{
+			cost: ["Grass", "Psychic", "Darkness"],
+			name: {
+				en: "Amazez",
+				fr: "Améthyste Chevron",
+				es: "Azeztulita",
+				pt: "Cacoxenita",
+				it: "Ametista Chevron",
+				de: "Amazez"
+			},
+			effect: {
+				en: "Devolve each of your opponent's evolved Pokémon by shuffling the highest Stage Evolution card on it into your opponent's deck.",
+				fr: "Faites dés-évoluer chacun des Pokémon évolués de votre adversaire en mélangeant avec le deck de votre adversaire la carte Évolution la plus élevée placée sur ceux-ci.",
+				es: "Haz involucionar a cada uno de los Pokémon evolucionados de tu rival poniendo la carta de Evolución de fase más alta que tengan sobre ellos en la baraja de tu rival, y barájalas todas.",
+				pt: "Reverta a evolução de cada um dos Pokémon evoluídos do seu oponente embaralhando a carta de Evolução de Estágio mais alto sobre ele no baralho do seu oponente.",
+				it: "Annulla l'evoluzione di ciascuno dei Pokémon evoluti del tuo avversario rimischiando la carta Evoluzione di fase più alta presente su di esso nel mazzo del tuo avversario.",
+				de: "Rückentwickle jedes entwickelte Pokémon deines Gegners, indem du deinem Gegner die Karte mit der höchsten Entwicklungsphase in sein Deck mischst."
+			}
+		}
+	],
+	weaknesses: [
+		{
+			type: "Darkness",
+			value: "×2"
+		}
+	],
+	resistances: [
+		{
+			type: "Fighting",
+			value: "-30"
+		}
+	],
+	retreat: 1,
+	regulationMark: "H",
+	illustrator: "5ban Graphics",
+}
+
+export default card

--- a/data/Scarlet & Violet/SVP Black Star Promos/176.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/176.ts
@@ -1,0 +1,80 @@
+import { Card } from "../../../interfaces"
+import Set from "../SVP Black Star Promos"
+
+const card: Card = {
+	dexId: [197],
+	set: Set,
+	name: {
+		en: "Umbreon ex",
+		fr: "Noctali-ex",
+		es: "Umbreon ex",
+		pt: "Umbreon ex",
+		it: "Umbreon-ex",
+		de: "Nachtara-ex"
+	},
+	rarity: "None",
+	category: "Pokemon",
+	hp: 280,
+	types: ["Darkness"],
+	evolveFrom: {
+		en: "Eevee",
+		fr: "Évoli",
+		es: "Eevee",
+		pt: "Eevee",
+		it: "Eevee",
+		de: "Evoli"
+	},
+	stage: "Stage1",
+	attacks: [
+		{
+			cost: ["Darkness", "Colorless", "Colorless"],
+			name: {
+				en: "Moon Mirage",
+				fr: "Mirage Lunaire",
+				es: "Espejismo Lunar",
+				pt: "Miragem Lunar",
+				it: "Miraggio Lunare",
+				de: "Mondillusion"
+			},
+			effect: {
+				en: "Your opponent's Active Pokémon is now Confused.",
+				fr: "Le Pokémon Actif de votre adversaire est maintenant Confus.",
+				es: "El Pokémon Activo de tu rival pasa a estar Confundido.",
+				pt: "O Pokémon Ativo do seu oponente agora está Confuso.",
+				it: "Il Pokémon attivo del tuo avversario viene confuso.",
+				de: "Das Aktive Pokémon deines Gegners ist jetzt verwirrt."
+			},
+			damage: 160
+		},
+		{
+			cost: ["Lightning", "Psychic", "Darkness"],
+			name: {
+				en: "Onyx",
+				fr: "Onyx",
+				es: "Ónice",
+				pt: "Ônix",
+				it: "Onice",
+				de: "Onyx"
+			},
+			effect: {
+				en: "Discard all Energy from this Pokémon, and take a Prize card.",
+				fr: "Défaussez toutes les Énergies attachées à ce Pokémon, puis récupérez une carte Récompense.",
+				es: "Descarta todas las Energías de este Pokémon y coge 1 carta de Premio.",
+				pt: "Descarte todas as Energias deste Pokémon e pegue uma carta de Prêmio.",
+				it: "Scarta tutte le Energie da questo Pokémon e prendi una carta Premio.",
+				de: "Lege alle Energien von diesem Pokémon auf deinen Ablagestapel und nimm 1 Preiskarte."
+			}
+		}
+	],
+	weaknesses: [
+		{
+			type: "Grass",
+			value: "×2"
+		}
+	],
+	retreat: 2,
+	regulationMark: "H",
+	illustrator: "5ban Graphics",
+}
+
+export default card

--- a/data/Scarlet & Violet/SVP Black Star Promos/219.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/219.ts
@@ -1,0 +1,35 @@
+import { Card } from "../../../interfaces"
+import Set from "../SVP Black Star Promos"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Black Belt's Training",
+		fr: "Entraînement de Karatéka",
+		es: "Entrenamiento de Karateka",
+		de: "Schwarzgurt-Training",
+		it: "Allenamento di Cinturanera",
+		pt: "Treino de Faixa Preta",
+		"es-mx": "Entrenamiento de Karateka"
+	},
+
+	rarity: "None",
+	category: "Trainer",
+
+	effect: {
+		en: "During this turn, attacks used by your Pokémon do 40 more damage to your opponent's Active Pokémon ex (before applying Weakness and Resistance).",
+		fr: "Pendant ce tour, les attaques utilisées par vos Pokémon infligent 40 dégâts supplémentaires au Pokémon-ex Actif de votre adversaire (avant application de la Faiblesse et de la Résistance).",
+		es: "Durante este turno, los ataques usados por tus Pokémon hacen 40 puntos de daño más al Pokémon ex Activo de tu rival (antes de aplicar Debilidad y Resistencia).",
+		de: "Während dieses Zuges fügen die von deinen Pokémon eingesetzten Attacken dem Aktiven Pokémon-ex deines Gegners 40 Schadenspunkte mehr zu (bevor Schwäche und Resistenz verrechnet werden).",
+		it: "Durante questo turno, gli attacchi usati dai tuoi Pokémon infliggono 40 danni in più al Pokémon-ex attivo del tuo avversario, prima di aver applicato debolezza e resistenza.",
+		pt: "Durante este turno, os ataques usados pelos seus Pokémon causarão 40 pontos de dano a mais ao Pokémon ex Ativo do seu oponente (antes de aplicar Fraqueza e Resistência).",
+		"es-mx": "Durante este turno, los ataques usados por tus Pokémon hacen 40 puntos de daño más al Pokémon ex Activo de tu rival (antes de aplicar Debilidad y Resistencia)."
+	},
+
+	trainerType: "Supporter",
+	regulationMark: "H",
+	illustrator: "GOSSAN"
+}
+
+export default card

--- a/data/Scarlet & Violet/SVP Black Star Promos/220.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/220.ts
@@ -1,0 +1,35 @@
+import { Card } from "../../../interfaces"
+import Set from "../SVP Black Star Promos"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Black Belt's Training",
+		fr: "Entraînement de Karatéka",
+		es: "Entrenamiento de Karateka",
+		de: "Schwarzgurt-Training",
+		it: "Allenamento di Cinturanera",
+		pt: "Treino de Faixa Preta",
+		"es-mx": "Entrenamiento de Karateka"
+	},
+
+	rarity: "None",
+	category: "Trainer",
+
+	effect: {
+		en: "During this turn, attacks used by your Pokémon do 40 more damage to your opponent's Active Pokémon ex (before applying Weakness and Resistance).",
+		fr: "Pendant ce tour, les attaques utilisées par vos Pokémon infligent 40 dégâts supplémentaires au Pokémon-ex Actif de votre adversaire (avant application de la Faiblesse et de la Résistance).",
+		es: "Durante este turno, los ataques usados por tus Pokémon hacen 40 puntos de daño más al Pokémon ex Activo de tu rival (antes de aplicar Debilidad y Resistencia).",
+		de: "Während dieses Zuges fügen die von deinen Pokémon eingesetzten Attacken dem Aktiven Pokémon-ex deines Gegners 40 Schadenspunkte mehr zu (bevor Schwäche und Resistenz verrechnet werden).",
+		it: "Durante questo turno, gli attacchi usati dai tuoi Pokémon infliggono 40 danni in più al Pokémon-ex attivo del tuo avversario, prima di aver applicato debolezza e resistenza.",
+		pt: "Durante este turno, os ataques usados pelos seus Pokémon causarão 40 pontos de dano a mais ao Pokémon ex Ativo do seu oponente (antes de aplicar Fraqueza e Resistência).",
+		"es-mx": "Durante este turno, los ataques usados por tus Pokémon hacen 40 puntos de daño más al Pokémon ex Activo de tu rival (antes de aplicar Debilidad y Resistencia)."
+	},
+
+	trainerType: "Supporter",
+	regulationMark: "H",
+	illustrator: "GOSSAN"
+}
+
+export default card

--- a/data/Scarlet & Violet/SVP Black Star Promos/221.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/221.ts
@@ -1,0 +1,33 @@
+import { Card } from "../../../interfaces"
+import Set from "../SVP Black Star Promos"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Professor's Research",
+		fr: "Recherches Professorales",
+		es: "Investigación de Profesores",
+		it: "Ricerca Accademica",
+		pt: "Pesquisa de Professores",
+		de: "Forschung des Professors"
+	},
+
+	rarity: "None",
+	category: "Trainer",
+
+	effect: {
+		en: "Discard your hand and draw 7 cards.",
+		fr: "Défaussez votre main, puis piochez 7 cartes.",
+		es: "Descarta las cartas de tu mano y roba 7 cartas.",
+		it: "Scarta le carte che hai in mano e pesca sette carte.",
+		pt: "Descarte a sua mão e compre 7 cartas.",
+		de: "Lege deine Handkarten auf deinen Ablagestapel und ziehe 7 Karten."
+	},
+
+	trainerType: "Supporter",
+	regulationMark: "G",
+	illustrator: "Hideki Ishikawa"
+}
+
+export default card

--- a/data/Scarlet & Violet/SVP Black Star Promos/222.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/222.ts
@@ -1,0 +1,33 @@
+import { Card } from "../../../interfaces"
+import Set from "../SVP Black Star Promos"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Professor's Research",
+		fr: "Recherches Professorales",
+		es: "Investigación de Profesores",
+		it: "Ricerca Accademica",
+		pt: "Pesquisa de Professores",
+		de: "Forschung des Professors"
+	},
+
+	rarity: "None",
+	category: "Trainer",
+
+	effect: {
+		en: "Discard your hand and draw 7 cards.",
+		fr: "Défaussez votre main, puis piochez 7 cartes.",
+		es: "Descarta las cartas de tu mano y roba 7 cartas.",
+		it: "Scarta le carte che hai in mano e pesca sette carte.",
+		pt: "Descarte a sua mão e compre 7 cartas.",
+		de: "Lege deine Handkarten auf deinen Ablagestapel und ziehe 7 Karten."
+	},
+
+	trainerType: "Supporter",
+	regulationMark: "G",
+	illustrator: "Hideki Ishikawa"
+}
+
+export default card

--- a/data/Scarlet & Violet/SVP Black Star Promos/223.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/223.ts
@@ -1,0 +1,33 @@
+import { Card } from "../../../interfaces"
+import Set from "../SVP Black Star Promos"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Professor's Research",
+		fr: "Recherches Professorales",
+		es: "Investigación de Profesores",
+		it: "Ricerca Accademica",
+		pt: "Pesquisa de Professores",
+		de: "Forschung des Professors"
+	},
+
+	rarity: "None",
+	category: "Trainer",
+
+	effect: {
+		en: "Discard your hand and draw 7 cards.",
+		fr: "Défaussez votre main, puis piochez 7 cartes.",
+		es: "Descarta las cartas de tu mano y roba 7 cartas.",
+		it: "Scarta le carte che hai in mano e pesca sette carte.",
+		pt: "Descarte a sua mão e compre 7 cartas.",
+		de: "Lege deine Handkarten auf deinen Ablagestapel und ziehe 7 Karten."
+	},
+
+	trainerType: "Supporter",
+	regulationMark: "G",
+	illustrator: "Taira Akitsu"
+}
+
+export default card


### PR DESCRIPTION
## Changes

- Add new cards to **SVP Black Star Promos** (SVP **175**, **176**, **219–223**)
- Update SVP set metadata (`cardCount.official`)

## Details

- Completed missing localized fields by mirroring the equivalent main-set entries (names/effects where available)
- Ensured Pokémon cards include `dexId` and required gameplay fields (types, attacks, etc.)
- Validation run:
  - `bun run validate`
  - `cd server && bun run --bun validate`
  - `cd server && bun run compile`
  - `cd .bruno && bru run --env Developpement` (67/67 requests, 118/118 assertions)