### PR TITLE
fix: correct dexId for 151 Caterpie IR

### DIFF
--- a/data/Scarlet & Violet/151/172.ts
+++ b/data/Scarlet & Violet/151/172.ts
@@ -2,7 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../151"
 
 const card: Card = {
-	dexId: [251],
+	dexId: [10],
 	set: Set,
 
 	name: {


### PR DESCRIPTION
## Changes

- correct pokedex id for 151 caterpie IR - should be 10
   - https://bulbapedia.bulbagarden.net/wiki/Caterpie_(Pok%C3%A9mon)
