### PR TITLE
fix: Add serie field to SetResume in setToSetSimple function

### DIFF
--- a/meta/definitions/api.d.ts
+++ b/meta/definitions/api.d.ts
@@ -69,6 +69,7 @@ export interface SetResume {
 	name: string;
 	logo?: string;
 	symbol?: string;
+	serie: SerieResume;
 	cardCount: {
 		/**
 		 * total of number of cards

--- a/server/compiler/utils/setUtil.ts
+++ b/server/compiler/utils/setUtil.ts
@@ -76,6 +76,10 @@ export async function setToSetSimple(set: Set, lang: SupportedLanguages): Promis
 		id: set.id,
 		logo: pics[0],
 		name: resolveText(set.name, lang),
+		serie: {
+			id: set.serie.id,
+			name: resolveText(set.serie.name, lang)
+		},
 		symbol: pics[1]
 	}
 }


### PR DESCRIPTION
## Problem

The GraphQL API was failing with the error:
```
Cannot return null for non-nullable field Set.serie
```

This was happening because the `setToSetSimple` function in `server/compiler/utils/setUtil.ts` was not including the `serie` field in the returned `SetResume` object. 

The GraphQL schema defines `Set.serie` as non-nullable (`serie: Serie!`), but cards were being compiled with set objects that had no `serie` field, causing GraphQL queries to fail.

## Solution

Added the `serie` field to the `SetResume` object returned by `setToSetSimple`:

```typescript
serie: {
    id: set.serie.id,
    name: resolveText(set.serie.name, lang)
}
```

This matches the structure used in `setToSetSingle` and ensures all card objects have the required `serie` reference in their set objects.

## Testing

- ✅ TypeScript validation passes
- ✅ Server compilation succeeds
- ✅ All cards now have `set.serie` field populated
- ✅ GraphQL queries should no longer fail with null serie errors

## Related Issues

This fixes the test failures in PR #1049 and any other PRs that were encountering the "Cannot return null for non-nullable field Set.serie" error.