### PR TITLE
fix(dc1): Add Portuguese translation

### DIFF
--- a/data/XY/Double Crisis/1.ts
+++ b/data/XY/Double Crisis/1.ts
@@ -5,6 +5,7 @@ const card: Card = {
 	name: {
 		en: "Team Magma's Numel",
 		fr: "Chamallot de la Team Magma",
+		pt: "Numel da Equipe Magma",
 	},
 
 	illustrator: "Akira Komayama",
@@ -33,10 +34,12 @@ const card: Card = {
 			name: {
 				en: "Ember",
 				fr: "Flammèche",
+				pt: "Brasa",
 			},
 			effect: {
 				en: "Discard an Energy attached to this Pokémon.",
 				fr: "Défaussez une Énergie attachée à ce Pokémon.",
+				pt: "Descarte uma Energia ligada a este Pokémon.",
 			},
 			damage: 30,
 

--- a/data/XY/Double Crisis/10.ts
+++ b/data/XY/Double Crisis/10.ts
@@ -5,6 +5,7 @@ const card: Card = {
 	name: {
 		en: "Team Magma's Baltoy",
 		fr: "Balbuto de la Team Magma",
+		pt: "Baltoy da Equipe Magma",
 	},
 
 	illustrator: "Mitsuhiro Arita",
@@ -33,10 +34,12 @@ const card: Card = {
 			name: {
 				en: "Telekinesis",
 				fr: "Lévikinésie",
+				pt: "Telecinese",
 			},
 			effect: {
 				en: "This attack does 20 damage to 1 of your opponent's Pokémon. This attack's damage isn't affected by Weakness or Resistance.",
 				fr: "Cette attaque inflige 20 dégâts à l'un des Pokémon de votre adversaire. Les dégâts de cette attaque ne sont pas affectés par la Faiblesse ou la Résistance.",
+				pt: "Este ataque causa 20 de danos a 1 dos Pokémon de seu oponente. Os danos desse ataque não são afetados por Fraqueza ou Resistência.",
 			},
 
 		},

--- a/data/XY/Double Crisis/11.ts
+++ b/data/XY/Double Crisis/11.ts
@@ -5,6 +5,7 @@ const card: Card = {
 	name: {
 		en: "Team Magma's Claydol",
 		fr: "Kaorine de la Team Magma",
+		pt: "Claydol da Equipe Magma",
 	},
 
 	illustrator: "Masakazu Fukuda",
@@ -25,6 +26,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Team Magma's Baltoy",
 		fr: "Balbuto de la Team Magma",
+		pt: "Baltoy da Equipe Magma",
 	},
 
 	stage: "Stage1",
@@ -35,10 +37,12 @@ const card: Card = {
 			name: {
 				en: "Magma Switch",
 				fr: "Échange de Magma",
+				pt: "Chave de Magma",
 			},
 			effect: {
 				en: "Once during your turn (before your attack), you may move a basic Energy from 1 of your Pokémon to 1 of your Team Magma Pokémon.",
 				fr: "Une seule fois pendant votre tour (avant votre attaque), vous pouvez déplacer une Énergie de base de l'un de vos Pokémon vers l'un de vos Pokémon de la Team Magma.",
+				pt: "Uma vez durante sua vez de jogar (antes de atacar), você poderá mover uma Energia básica de 1 dos seus Pokémon para 1 dos seus Pokémon da Equipe Magma.",
 			},
 		},
 	],
@@ -53,6 +57,7 @@ const card: Card = {
 			name: {
 				en: "Power Beam",
 				fr: "Puissant Rayon",
+				pt: "Raio de Poder"
 			},
 
 			damage: 70,

--- a/data/XY/Double Crisis/12.ts
+++ b/data/XY/Double Crisis/12.ts
@@ -5,6 +5,7 @@ const card: Card = {
 	name: {
 		en: "Team Magma's Aron",
 		fr: "Galekid de la Team Magma",
+		pt: "Aron da Equipe Magma",
 	},
 
 	illustrator: "Akira Komayama",
@@ -32,6 +33,7 @@ const card: Card = {
 			name: {
 				en: "Gnaw",
 				fr: "Ronge",
+				pt: "Roída",
 			},
 
 			damage: 10,

--- a/data/XY/Double Crisis/13.ts
+++ b/data/XY/Double Crisis/13.ts
@@ -5,6 +5,7 @@ const card: Card = {
 	name: {
 		en: "Team Magma's Lairon",
 		fr: "Galegon de la Team Magma",
+		pt: "Lairon da Equipe Magma",
 	},
 
 	illustrator: "Masakazu Fukuda",
@@ -25,6 +26,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Team Magma's Aron",
 		fr: "Galekid de la Team Magma",
+		pt: "Aron da Equipe Magma",
 	},
 
 	stage: "Stage1",
@@ -38,6 +40,7 @@ const card: Card = {
 			name: {
 				en: "Gnaw",
 				fr: "Ronge",
+				pt: "Roída",
 			},
 
 			damage: 30,
@@ -52,10 +55,12 @@ const card: Card = {
 			name: {
 				en: "Take Down",
 				fr: "Bélier",
+				pt: "Desmantelar",
 			},
 			effect: {
 				en: "This Pokémon does 10 damage to itself.",
 				fr: "Ce Pokémon s'inflige 10 dégâts.",
+				pt: "Esse Pokémon causa 10 de danos a ele mesmo.",
 			},
 			damage: 60,
 

--- a/data/XY/Double Crisis/14.ts
+++ b/data/XY/Double Crisis/14.ts
@@ -5,6 +5,7 @@ const card: Card = {
 	name: {
 		en: "Team Magma's Aggron",
 		fr: "Galeking de la Team Magma",
+		pt: "Aggron da Equipe Magma ",
 	},
 
 	illustrator: "TOKIYA",
@@ -25,6 +26,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Team Magma's Lairon",
 		fr: "Galegon de la Team Magma",
+		pt: "Lairon da Equipe Magma",
 	},
 
 	stage: "Stage2",
@@ -38,10 +40,12 @@ const card: Card = {
 			name: {
 				en: "Rock Stomp",
 				fr: "Écras'Roc",
+				pt: "Pisoteada de Pedra",
 			},
 			effect: {
 				en: "Discard as many Fighting Energy attached to your Pokémon as you like. This attack does 40 damage times the amount of Fighting Energy you discarded.",
 				fr: "Défaussez autant d'Énergies Fighting attachées à vos Pokémon que vous voulez. Cette attaque inflige 40 dégâts multipliés par le nombre de cartes Énergie Fighting que vous avez défaussées.",
+				pt: "Descarte tantas Energias de luta ligadas a seus Pokémon quanto desejar. Esse ataque causa 40 de danos vezes a quantidade de Energia de luta descartada.",
 			},
 			damage: "40×",
 
@@ -56,10 +60,12 @@ const card: Card = {
 			name: {
 				en: "Boulder Storm",
 				fr: "Tempête de Roche",
+				pt: "Tempestade de Rochas",
 			},
 			effect: {
 				en: "This attack does 20 damage to each of your opponent's Benched Pokémon that has any damage counters on it. (Don't apply Weakness and Resistance for Benched Pokémon.)",
 				fr: "Cette attaque inflige 20 dégâts à chacun des Pokémon de Banc de votre adversaire ayant au moins 1 marqueur de dégâts. (N'appliquez ni la Faiblesse ni la Résistance aux Pokémon de Banc.)",
+				pt: "Esse ataque causa 20 de danos a cada um dos Pokémon no Banco do seu oponente que já possui contadores de danos. (Não aplique Fraqueza e Resistência a Pokémon no Banco.)",
 			},
 			damage: 120,
 

--- a/data/XY/Double Crisis/15.ts
+++ b/data/XY/Double Crisis/15.ts
@@ -5,6 +5,7 @@ const card: Card = {
 	name: {
 		en: "Team Magma's Groudon EX",
 		fr: "Groudon-EX de la Team Magma",
+		pt: "Groudon-EX da Equipe Magma",
 	},
 
 	illustrator: "nagimiso",
@@ -30,10 +31,12 @@ const card: Card = {
 			name: {
 				en: "Power Saver",
 				fr: "Économie de Puissance",
+				pt: "Economizador de Energia",
 			},
 			effect: {
 				en: "If there are 4 or fewer Team Magma Pokémon in play, this Pokémon can't attack.",
 				fr: "S'il y a 4 Pokémon de la Team Magma en jeu ou moins, ce Pokémon ne peut pas attaquer.",
+				pt: "Se houver 4 ou menos Pokémon da Equipe Magma em jogo, esse Pokémon não poderá atacar.",
 			},
 		},
 	],
@@ -49,10 +52,12 @@ const card: Card = {
 			name: {
 				en: "Magma Quake",
 				fr: "Secousse Magma",
+				pt: "Terremoto de Magma",
 			},
 			effect: {
 				en: "If your opponent's Active Pokémon already has any damage counters on it, this attack does 80 more damage.",
 				fr: "Si le Pokémon Actif de votre adversaire a déjà des marqueurs de dégâts, cette attaque inflige 80 dégâts supplémentaires.",
+				pt: "Se o Pokémon Ativo do seu oponente já possuir contadores de danos, esse ataque causará 80 de danos adicionais.",
 			},
 			damage: "80＋",
 

--- a/data/XY/Double Crisis/16.ts
+++ b/data/XY/Double Crisis/16.ts
@@ -5,6 +5,7 @@ const card: Card = {
 	name: {
 		en: "Team Aqua's Poochyena",
 		fr: "Medhyèna de la Team Aqua",
+		pt: "Poochyena da Equipe Aqua",
 	},
 
 	illustrator: "Kouki Saitou",
@@ -32,10 +33,12 @@ const card: Card = {
 			name: {
 				en: "Roar",
 				fr: "Hurlement",
+				pt: "Rugido",
 			},
 			effect: {
 				en: "Your opponent switches his or her Active Pokémon with 1 of his or her Benched Pokémon.",
 				fr: "Votre adversaire échange son Pokémon Actif avec l'un de ses Pokémon de Banc.",
+				pt: "Seu oponente troca o Pokémon Ativo por 1 dos próprios Pokémon no Banco."
 			},
 
 		},
@@ -47,6 +50,7 @@ const card: Card = {
 			name: {
 				en: "Bite",
 				fr: "Morsure",
+				pt: "Mordida",
 			},
 
 			damage: 20,

--- a/data/XY/Double Crisis/17.ts
+++ b/data/XY/Double Crisis/17.ts
@@ -5,6 +5,7 @@ const card: Card = {
 	name: {
 		en: "Team Magma's Poochyena",
 		fr: "Medhyèna de la Team Magma",
+		pt: "Poochyena da Equipe Magma",
 	},
 
 	illustrator: "TOKIYA",
@@ -32,10 +33,12 @@ const card: Card = {
 			name: {
 				en: "Infiltrate",
 				fr: "Mission Infiltration",
+				pt: "Infiltrar",
 			},
 			effect: {
 				en: "Your opponent reveals his or her hand.",
 				fr: "Votre adversaire montre sa main.",
+				pt: "Seu oponente revela a própria mão",
 			},
 
 		},
@@ -47,6 +50,7 @@ const card: Card = {
 			name: {
 				en: "Bite",
 				fr: "Morsure",
+				pt: "mordida",
 			},
 
 			damage: 20,

--- a/data/XY/Double Crisis/18.ts
+++ b/data/XY/Double Crisis/18.ts
@@ -5,6 +5,7 @@ const card: Card = {
 	name: {
 		en: "Team Aqua's Mightyena",
 		fr: "Grahyèna de la Team Aqua",
+		pt: "Mightyena da Equipe Aqua",
 	},
 
 	illustrator: "Mitsuhiro Arita",
@@ -25,6 +26,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Team Aqua's Poochyena",
 		fr: "Medhyèna de la Team Aqua",
+		pt: "Poochyena da Equipe Aqua",
 	},
 
 	stage: "Stage1",
@@ -38,10 +40,12 @@ const card: Card = {
 			name: {
 				en: "Teampact",
 				fr: "Teampact",
+				pt: "Impacto em Equipe"
 			},
 			effect: {
 				en: "Flip a coin for each Team Aqua Pokémon you have in play. This attack does 30 damage times the number of heads.",
 				fr: "Lancez une pièce pour chaque Pokémon de la Team Aqua que vous avez en jeu. Cette attaque inflige 30 dégâts multipliés par le nombre de côtés face.",
+				pt: "Jogue uma moeda para cada Pokémon da Equipe Aqua que você tem em jogo. Esse ataque causa 30 de danos vezes o número de caras.",
 			},
 			damage: "30×",
 
@@ -55,10 +59,12 @@ const card: Card = {
 			name: {
 				en: "Crunch",
 				fr: "Mâchouille",
+				pt: "Mastigada",
 			},
 			effect: {
 				en: "Flip a coin. If heads, discard an Energy attached to your opponent's Active Pokémon.",
 				fr: "Lancez une pièce. Si c'est face, défaussez une Énergie attachée au Pokémon Actif de votre adversaire.",
+				pt: "Jogue uma moeda. Se sair cara, descarte uma Energia ligada ao Pokémon Ativo do seu oponente."
 			},
 			damage: 80,
 

--- a/data/XY/Double Crisis/19.ts
+++ b/data/XY/Double Crisis/19.ts
@@ -5,6 +5,7 @@ const card: Card = {
 	name: {
 		en: "Team Magma's Mightyena",
 		fr: "Grahyèna de la Team Magma",
+		pt: "Mightyena da Equipe Magma",
 	},
 
 	illustrator: "Hitoshi Ariga",
@@ -25,6 +26,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Team Magma's Poochyena",
 		fr: "Medhyèna de la Team Magma",
+		pt: "Poochyena da Equipe Magma",
 	},
 
 	stage: "Stage1",
@@ -38,6 +40,7 @@ const card: Card = {
 			name: {
 				en: "Bite",
 				fr: "Morsure",
+				pt: "Mordida",
 			},
 
 			damage: 30,
@@ -52,10 +55,12 @@ const card: Card = {
 			name: {
 				en: "Hostile Fang",
 				fr: "Croc Hostile",
+				pt: "Presa Hostil",
 			},
 			effect: {
 				en: "If your opponent's Active Pokémon is a Team Aqua Pokémon, this attack does 40 more damage.",
 				fr: "Si le Pokémon Actif de votre adversaire est un Pokémon de la Team Aqua, cette attaque inflige 40 dégâts supplémentaires.",
+				pt: "Se o Pokemon Ativo do seu oponente for um Pokemon da Equipe Aqua, esse ataque causará 40 de danos adicionais.",
 			},
 			damage: "80＋",
 

--- a/data/XY/Double Crisis/2.ts
+++ b/data/XY/Double Crisis/2.ts
@@ -5,6 +5,7 @@ const card: Card = {
 	name: {
 		en: "Team Magma's Camerupt",
 		fr: "Camérupt de la Team Magma",
+		pt: "Camerupt da Equipe Magma",
 	},
 
 	illustrator: "Shin Nagasawa",
@@ -25,6 +26,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Team Magma's Numel",
 		fr: "Chamallot de la Team Magma",
+		pt: "Numel da Equipe Magma",
 	},
 
 	stage: "Stage1",
@@ -35,10 +37,12 @@ const card: Card = {
 			name: {
 				en: "Burning Draft",
 				fr: "Souffle Enflammé",
+				pt: "Brisa Ardente",
 			},
 			effect: {
 				en: "Once during your turn (before your attack), you may attach a Fighting or Fire Energy card from your discard pile to this Pokémon.",
 				fr: "Une seule fois pendant votre tour (avant votre attaque), vous pouvez attacher une carte Énergie Fighting ou Fire de votre pile de défausse à ce Pokémon.",
+				pt: "Uma vez durante sua vez de jogar (antes de atacar), você poderá ligar um card de Energia de Luta ou Fogo da sua pilha de descarte a este Pokémon",
 			},
 		},
 	],
@@ -53,10 +57,12 @@ const card: Card = {
 			name: {
 				en: "Flame Ball",
 				fr: "Boule de Feu",
+				pt: "Bola de Chamas",
 			},
 			effect: {
 				en: "Move a basic Energy from this Pokémon to 1 of your Benched Pokémon.",
 				fr: "Déplacez une Énergie de base de ce Pokémon vers l'un de vos Pokémon de Banc.",
+				pt: "Mova uma Energia básica deste Pokémon para 1 dos seus Pokémon do Banco.",
 			},
 			damage: 60,
 

--- a/data/XY/Double Crisis/20.ts
+++ b/data/XY/Double Crisis/20.ts
@@ -5,6 +5,7 @@ const card: Card = {
 	name: {
 		en: "Team Aqua's Carvanha",
 		fr: "Carvanha de la Team Aqua",
+		pt: "Carvanha da Equipe Aqua",
 	},
 
 	illustrator: "Sanosuke Sakuma",
@@ -32,10 +33,12 @@ const card: Card = {
 			name: {
 				en: "Fin Smack",
 				fr: "Coup d'Aileron",
+				pt: "Beijo da Barbatana",
 			},
 			effect: {
 				en: "Flip 2 coins. This attack does 10 damage times the number of heads.",
 				fr: "Lancez 2 pièces. Cette attaque inflige 10 dégâts multipliés par le nombre de côtés face.",
+				pt: "Jogue 2 moedas. Esse ataque causa 10 de danos vezes o número de caras.",
 			},
 			damage: "10×",
 

--- a/data/XY/Double Crisis/21.ts
+++ b/data/XY/Double Crisis/21.ts
@@ -5,6 +5,7 @@ const card: Card = {
 	name: {
 		en: "Team Aqua's Sharpedo",
 		fr: "Sharpedo de la Team Aqua",
+		pt: "Sharpedo da Equipe Aqua",
 	},
 
 	illustrator: "kawayoo",
@@ -25,6 +26,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Team Aqua's Carvanha",
 		fr: "Carvanha de la Team Aqua",
+		pt: "Carvanha da Equipe Aqua",
 	},
 
 	stage: "Stage1",
@@ -35,10 +37,12 @@ const card: Card = {
 			name: {
 				en: "Aqua Search",
 				fr: "Recherche Aqua",
+				pt: "Busca Aqua",
 			},
 			effect: {
 				en: "Once during your turn (before your attack), you may search your deck for a Team Aqua Pokémon, reveal it, and put it into your hand. Shuffle your deck afterward.",
 				fr: "Une seule fois pendant votre tour (avant votre attaque), vous pouvez chercher un Pokémon de la Team Aqua dans votre deck, le montrer et l'ajouter à votre main. Mélangez ensuite votre deck.",
+				pt: "Uma vez durante sua vez de jogar (antes de atacar), você pode procurar um Pokémon da Equipe Aqua em seu baralho, revelá-lo e colocá-lo na sua mão. Em seguida, embaralhe seus cards.",
 			},
 		},
 	],

--- a/data/XY/Double Crisis/22.ts
+++ b/data/XY/Double Crisis/22.ts
@@ -5,6 +5,7 @@ const card: Card = {
 	name: {
 		en: "Team Magma's Zangoose",
 		fr: "Mangriff de la Team Magma",
+		pt: "Zangoose da Equipe Magma",
 	},
 
 	illustrator: "Shin Nagasawa",
@@ -32,10 +33,12 @@ const card: Card = {
 			name: {
 				en: "Call for Family",
 				fr: "Appel à la Famille",
+				pt: "Chamar a Família",
 			},
 			effect: {
 				en: "Search your deck for up to 2 Basic Team Magma Pokémon and put them onto your Bench. Shuffle your deck afterward.",
 				fr: "Cherchez jusqu'à 2 Pokémon de base de la Team Magma dans votre deck et placez-les sur votre Banc. Mélangez ensuite votre deck.",
+				pt: "Procure em seu baralho até 2 Pokémon da Equipe Magma Basico e coloque-os no seu Banco. Em seguida, embaralhe seus cards.",
 			},
 
 		},
@@ -48,10 +51,12 @@ const card: Card = {
 			name: {
 				en: "Team Play",
 				fr: "Jeu d'Équipe",
+				pt: "Jogo em Equipe",
 			},
 			effect: {
 				en: "This attack does 20 damage times the number of Team Magma Pokémon on your Bench.",
 				fr: "Cette attaque inflige 20 dégâts multipliés par le nombre de Pokémon de la Team Magma sur votre Banc.",
+				pt: "Esse ataque causa 20 de danos vezes o número de Pokémon da Equipe Magma no seu Banco.",
 			},
 			damage: "20×",
 

--- a/data/XY/Double Crisis/23.ts
+++ b/data/XY/Double Crisis/23.ts
@@ -5,6 +5,7 @@ const card: Card = {
 	name: {
 		en: "Aqua Diffuser",
 		fr: "Diffuseur Aqua",
+		pt: "Difusor Aqua",
 	},
 
 	illustrator: "Toyste Beach",
@@ -14,18 +15,21 @@ const card: Card = {
 
 	effect: {
 		fr: "Le Pokémon de la Team Aqua auquel cette carte est attachée peut aussi utiliser l'attaque sur cette carte. (Vous avez toujours besoin de l'Énergie nécessaire pour utiliser cette attaque.)",
-		en: "The Team Aqua Pokémon this card is attached to can also use the attack on this card. (You still need the necessary Energy to use this attack.)"
+		en: "The Team Aqua Pokémon this card is attached to can also use the attack on this card. (You still need the necessary Energy to use this attack.)",
+		pt: "O Pokémon da Equipe Aqua ao qual este card está ligado também pode usar o ataque neste card. (Você ainda precisa da Energia necessária para usar o ataque.)",
 	},
 
 	trainerType: "Tool",
 
 	attacks: [{
 		name: {
-			en: "Aqua Diffuser"
+			en: "Aqua Diffuser",
+			pt: "Difusor Aqua",
 		},
 
 		effect: {
-			en: "Your opponent's Active Pokémon is now Confused and Poisoned."
+			en: "Your opponent's Active Pokémon is now Confused and Poisoned.",
+			pt: "O Pokémon Ativo do seu oponente agora está Confuso e Envenenado,"
 		},
 
 		cost: ["Water"]

--- a/data/XY/Double Crisis/24.ts
+++ b/data/XY/Double Crisis/24.ts
@@ -5,6 +5,7 @@ const card: Card = {
 	name: {
 		en: "Magma Pointer",
 		fr: "Pointeur Magma",
+		pt: "Ponteiro Magma",
 	},
 
 	illustrator: "Toyste Beach",
@@ -14,18 +15,21 @@ const card: Card = {
 
 	effect: {
 		fr: "Le Pokémon de la Team Magma auquel cette carte est attachée peut aussi utiliser l'attaque sur cette carte. (Vous avez toujours besoin de l'Énergie nécessaire pour utiliser cette attaque.)",
-		en: "The Team Magma Pokémon this card is attached to can also use the attack on this card. (You still need the necessary Energy to use this attack.)"
+		en: "The Team Magma Pokémon this card is attached to can also use the attack on this card. (You still need the necessary Energy to use this attack.)",
+		pt: "O Pokémon da Equipe Magma ao qual este card está ligado também pode usar o ataque neste card. (Você ainda precisa da Energia necessaria para usar o ataque.)",
 	},
 
 	trainerType: "Tool",
 
 	attacks: [{
 		name: {
-			en: "Magma Pointer"
+			en: "Magma Pointer",
+			pt: "Ponteiro Magma",
 		},
 
 		effect: {
-			en: "This attack does 20 damage to 1 of your opponent's Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+			en: "This attack does 20 damage to 1 of your opponent's Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)",
+			pt: "Este ataque causa 20 de danos a I dos Pokémon de seu oponente. (Não aplique Fraqueza e Resistência a Pokémon no Banco.)",
 		},
 
 		cost: ["Fighting"]

--- a/data/XY/Double Crisis/25.ts
+++ b/data/XY/Double Crisis/25.ts
@@ -5,6 +5,7 @@ const card: Card = {
 	name: {
 		en: "Team Aqua Admin",
 		fr: "Admin Team Aqua",
+		pt: "Admin. da Equipe Aqua",
 	},
 
 	illustrator: "GAME FREAK inc.",
@@ -14,7 +15,8 @@ const card: Card = {
 
 	effect: {
 		fr: "Attachez une carte Énergie de base de votre pile de défausse à votre Pokémon Actif de la Team Aqua.",
-		en: "Attach a basic Energy card from your discard pile to your Active Team Aqua Pokémon."
+		en: "Attach a basic Energy card from your discard pile to your Active Team Aqua Pokémon.",
+		pt: "Ligue um card de Energia básica da sua pilha de descarte ao seu Pokémon da Equipe Aqua Ativo.",
 	},
 
 	trainerType: "Supporter",

--- a/data/XY/Double Crisis/26.ts
+++ b/data/XY/Double Crisis/26.ts
@@ -5,6 +5,7 @@ const card: Card = {
 	name: {
 		en: "Team Aqua Grunt",
 		fr: "Sbire de la Team Aqua",
+		pt: "Operário da Equipe Aqua",
 	},
 
 	illustrator: "GAME FREAK inc.",
@@ -14,7 +15,8 @@ const card: Card = {
 
 	effect: {
 		fr: "Défaussez une carte de votre main. (Si vous ne pouvez pas défausser de carte, vous ne pouvez pas jouer cette carte.) Piochez 3 cartes. Si vous avez défaussé un Pokémon de la Team Aqua, piochez une carte supplémentaire.",
-		en: "Discard a card from your hand. (If you can't discard a card, you can't play this card.) Draw 3 cards. If you discarded a Team Aqua Pokémon, draw 1 more card."
+		en: "Discard a card from your hand. (If you can't discard a card, you can't play this card.) Draw 3 cards. If you discarded a Team Aqua Pokémon, draw 1 more card.",
+		pt: "Descarte um card da sua mão. (Se você não puder descartar um card, não poderá jogar esse card.) Compre 3 cards. Se você descartou um Pokémon da Equipe Aqua, compre mais 1 card.",
 	},
 
 	trainerType: "Supporter",

--- a/data/XY/Double Crisis/27.ts
+++ b/data/XY/Double Crisis/27.ts
@@ -5,6 +5,7 @@ const card: Card = {
 	name: {
 		en: "Team Aqua's Great Ball",
 		fr: "Super Ball de la Team Aqua",
+		pt: "Grande Bola da Equipe Aqua",
 	},
 
 	illustrator: "Toyste Beach",
@@ -14,7 +15,8 @@ const card: Card = {
 
 	effect: {
 		fr: "Cherchez un Pokémon de base de la Team Aqua et une carte Énergie Water de base dans votre deck, montrez-les, puis ajoutez-les à votre main. Mélangez ensuite votre deck.",
-		en: "Search your deck for a Basic Team Aqua Pokémon and a basic Water Energy card, reveal them, and put them into your hand. Shuffle your deck afterward."
+		en: "Search your deck for a Basic Team Aqua Pokémon and a basic Water Energy card, reveal them, and put them into your hand. Shuffle your deck afterward.",
+		pt: "Procure no seu baralho um Pokémon da Equipe Aqua Básico e um card de Energia de Água básica, revele-os e coloque-os em sua mão. Em seguida, embaralhe seus cards.",
 	},
 
 	trainerType: "Item",

--- a/data/XY/Double Crisis/28.ts
+++ b/data/XY/Double Crisis/28.ts
@@ -5,6 +5,7 @@ const card: Card = {
 	name: {
 		en: "Team Aqua's Secret Base",
 		fr: "Base Secrète de la Team Aqua",
+		pt: "Base Secreta da Equipe Aqua",
 	},
 
 	illustrator: "Ryo Ueda",
@@ -14,7 +15,8 @@ const card: Card = {
 
 	effect: {
 		fr: "Le Coût de Retraite de chaque Pokémon en jeu (à part les Pokémon de la Team Aqua) est augmenté de Colorless.",
-		en: "The Retreat Cost of each Pokémon in play (except for Team Aqua Pokémon) is Colorless more."
+		en: "The Retreat Cost of each Pokémon in play (except for Team Aqua Pokémon) is Colorless more.",
+		pt: "O Custo para Recuar de cada um dos Pokémon em jogo (exceto os Pokémon da Equipe Aqua) será de Incolor a mais.",
 	},
 
 	trainerType: "Stadium",

--- a/data/XY/Double Crisis/29.ts
+++ b/data/XY/Double Crisis/29.ts
@@ -5,6 +5,7 @@ const card: Card = {
 	name: {
 		en: "Team Magma Admin",
 		fr: "Admin Team Magma",
+		pt: "Admin. da Equipe Magma",
 	},
 
 	illustrator: "GAME FREAK inc.",
@@ -14,7 +15,8 @@ const card: Card = {
 
 	effect: {
 		fr: "Ajoutez jusqu'à 3 Pokémon de la Team Magma de votre pile de défausse à votre main.",
-		en: "Put up to 3 Team Magma Pokémon from your discard pile into your hand."
+		en: "Put up to 3 Team Magma Pokémon from your discard pile into your hand.",
+		pt: "Coloque até 3 Pokémon da Equipe Magma da sua pilha de descarte em sua mão.",
 	},
 
 	trainerType: "Supporter",

--- a/data/XY/Double Crisis/3.ts
+++ b/data/XY/Double Crisis/3.ts
@@ -5,6 +5,7 @@ const card: Card = {
 	name: {
 		en: "Team Aqua's Spheal",
 		fr: "Obalie de la Team Aqua",
+		pt: "Spheal da Equipe Aqua",
 	},
 
 	illustrator: "Sanosuke Sakuma",
@@ -32,6 +33,7 @@ const card: Card = {
 			name: {
 				en: "Water Gun",
 				fr: "Pistolet à O",
+				pt: "Revólver d'Água"
 			},
 
 			damage: 10,

--- a/data/XY/Double Crisis/30.ts
+++ b/data/XY/Double Crisis/30.ts
@@ -5,6 +5,7 @@ const card: Card = {
 	name: {
 		en: "Team Magma Grunt",
 		fr: "Sbire de la Team Magma",
+		pt: "Operário da Equipe Magma",
 	},
 
 	illustrator: "GAME FREAK inc.",
@@ -14,7 +15,8 @@ const card: Card = {
 
 	effect: {
 		fr: "Défaussez une carte de votre main. (Si vous ne pouvez pas défausser de carte, vous ne pouvez pas jouer cette carte.) Piochez 3 cartes. Si vous avez défaussé un Pokémon de la Team Magma, piochez une carte supplémentaire.",
-		en: "Discard a card from your hand. (If you can't discard a card, you can't play this card.) Draw 3 cards. If you discarded a Team Magma Pokémon, draw 1 more card."
+		en: "Discard a card from your hand. (If you can't discard a card, you can't play this card.) Draw 3 cards. If you discarded a Team Magma Pokémon, draw 1 more card.",
+		pt: "Descarte um card da sua mão. (Se você não puder descartar um card, não poderá jogar esse card.) Compre 3 cards. Se você descartou um Pokémon da Equipe Magma, compre mais 1 card.",
 	},
 
 	trainerType: "Supporter",

--- a/data/XY/Double Crisis/31.ts
+++ b/data/XY/Double Crisis/31.ts
@@ -5,6 +5,7 @@ const card: Card = {
 	name: {
 		en: "Team Magma's Great Ball",
 		fr: "Super Ball de la Team Magma",
+		pt: "Grande Bola da Equipe Magma",
 	},
 
 	illustrator: "Toyste Beach",
@@ -14,7 +15,8 @@ const card: Card = {
 
 	effect: {
 		fr: "Cherchez un Pokémon de base de la Team Magma et une carte Énergie Fighting de base dans votre deck, montrez-les, puis ajoutez-les à votre main. Mélangez ensuite votre deck.",
-		en: "Search your deck for a Basic Team Magma Pokémon and a basic Fighting Energy card, reveal them, and put them into your hand. Shuffle your deck afterward."
+		en: "Search your deck for a Basic Team Magma Pokémon and a basic Fighting Energy card, reveal them, and put them into your hand. Shuffle your deck afterward.",
+		pt: "Procure no seu baralho um Pokémon da Equipe Magma Básico e um card de Energia de luta básica, revele-os e coloque-os em sua mão. Em seguida, embaralhe seus cards.",
 	},
 
 	trainerType: "Item",

--- a/data/XY/Double Crisis/32.ts
+++ b/data/XY/Double Crisis/32.ts
@@ -5,6 +5,7 @@ const card: Card = {
 	name: {
 		en: "Team Magma's Secret Base",
 		fr: "Base Secrète de la Team Magma",
+		pt: "Base Secreta da Equipe Magma",
 	},
 
 	illustrator: "Ryo Ueda",
@@ -14,7 +15,8 @@ const card: Card = {
 
 	effect: {
 		fr: "Chaque fois qu'un joueur place un Pokémon de base (à part les Pokémon de la Team Magma) de sa main sur son Banc, placez 2 marqueurs de dégâts sur ce Pokémon.",
-		en: "Whenever any player puts a Basic Pokémon (except for Team Magma Pokémon) from his or her hand onto his or her Bench, put 2 damage counters on that Pokémon."
+		en: "Whenever any player puts a Basic Pokémon (except for Team Magma Pokémon) from his or her hand onto his or her Bench, put 2 damage counters on that Pokémon.",
+		pt: "Sempre que um jogador colocar um Pokémon Básico (exceto Pokémon da Equipe Magma) da própria mão no Banco, coloque 2 contadores de danos nesse Pokémon.",
 	},
 
 	trainerType: "Stadium",

--- a/data/XY/Double Crisis/33.ts
+++ b/data/XY/Double Crisis/33.ts
@@ -5,6 +5,7 @@ const card: Card = {
 	name: {
 		en: "Double Aqua Energy",
 		fr: "Double Énergie Aqua",
+		pt: "Energia Aqua Dupla",
 	},
 
 	illustrator: "5ban Graphics",
@@ -14,7 +15,8 @@ const card: Card = {
 
 	effect: {
 		fr: "Cette carte ne peut être attachée qu'à un Pokémon de la Team Aqua. Défaussez cette carte à la fin du tour pendant lequel vous l'avez attachée.\n\nCette carte ne fournit de l'Énergie WaterWater que pendant qu'elle est attachée à un Pokémon de la Team Aqua.\n\n(Si cette carte est attachée à autre chose qu'un Pokémon de la Team Aqua, défaussez cette carte.)",
-		en: "This card can only be attached to Team Aqua Pokémon. Discard this card at the end of the turn you attached it.\n\nThis card provides WaterWater Energy only while it is attached to a Team Aqua Pokémon.\n\n(If this card is attached to anything other than a Team Aqua Pokémon, discard this card.)"
+		en: "This card can only be attached to Team Aqua Pokémon. Discard this card at the end of the turn you attached it.\n\nThis card provides WaterWater Energy only while it is attached to a Team Aqua Pokémon.\n\n(If this card is attached to anything other than a Team Aqua Pokémon, discard this card.)",
+		pt: "Este card só pode ser ligado a Pokémon da Equipe Aqua. Descarte-o no final da rodada em que foi ligado. \n\nEste card fornece 2 Energias de Água somente quando está ligado a um Pokémon da Equipe Aqua. \n\n(Se este card estiver ligado a qualquer coisa diferente de um Pokémon da Equipe Aqua, descarte-o.)",
 	},
 
 	energyType: "Special",

--- a/data/XY/Double Crisis/34.ts
+++ b/data/XY/Double Crisis/34.ts
@@ -5,6 +5,7 @@ const card: Card = {
 	name: {
 		en: "Double Magma Energy",
 		fr: "Double Énergie Magma",
+		pt: "Energia Magma Dupla",
 	},
 
 	illustrator: "5ban Graphics",
@@ -14,7 +15,8 @@ const card: Card = {
 
 	effect: {
 		fr: "Cette carte ne peut être attachée qu'à un Pokémon de la Team Magma. Défaussez cette carte à la fin du tour pendant lequel vous l'avez attachée.\n\nCette carte ne fournit de l'Énergie FightingFighting que pendant qu'elle est attachée à un Pokémon de la Team Magma.\n\n(Si cette carte est attachée à autre chose qu'un Pokémon de la Team Magma, défaussez cette carte.)",
-		en: "This card can only be attached to Team Magma Pokémon. Discard this card at the end of the turn you attached it.\n\nThis card provides FightingFighting Energy only while it is attached to a Team Magma Pokémon.\n\n(If this card is attached to anything other than a Team Magma Pokémon, discard this card.)"
+		en: "This card can only be attached to Team Magma Pokémon. Discard this card at the end of the turn you attached it.\n\nThis card provides FightingFighting Energy only while it is attached to a Team Magma Pokémon.\n\n(If this card is attached to anything other than a Team Magma Pokémon, discard this card.)",
+		pt: "Este card só pode ser ligado a Pokémon da Equipe Magma. Descarte-o no final da rodada em que foi ligado. \n\nEste card fornece 2 Energias de luta somente quando está ligado a um Pokémon da Equipe Magma. \n\n(Se este card estiver ligado a qualquer coisa diferente de um Pokémon da Equipe Magma, descarte-o.)",
 	},
 
 	energyType: "Special",

--- a/data/XY/Double Crisis/4.ts
+++ b/data/XY/Double Crisis/4.ts
@@ -5,6 +5,7 @@ const card: Card = {
 	name: {
 		en: "Team Aqua's Sealeo",
 		fr: "Phogleur de la Team Aqua",
+		pt: "Sealeo da Equipe Aqua",
 	},
 
 	illustrator: "Naoki Saito",
@@ -25,6 +26,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Team Aqua's Spheal",
 		fr: "Obalie de la Team Aqua",
+		pt: "Spheal da Equipe Aqua",
 	},
 
 	stage: "Stage1",
@@ -38,10 +40,12 @@ const card: Card = {
 			name: {
 				en: "Splatter",
 				fr: "Crépitement",
+				pt: "Respingo",
 			},
 			effect: {
 				en: "This attack does 20 damage to 1 of your opponent's Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)",
 				fr: "Cette attaque inflige 20 dégâts à l'un des Pokémon de votre adversaire. (N'appliquez ni la Faiblesse ni la Résistance aux Pokémon de Banc.)",
+				pt: "Este ataque causa 20 de danos a 1 dos Pokémon de seu oponente. (Não aplique Fraqueza e Resistência a Pokémon no Banco.)",
 			},
 
 		},
@@ -54,10 +58,12 @@ const card: Card = {
 			name: {
 				en: "Hail Storm",
 				fr: "Déluge de Grêle",
+				pt: "Tormenta de Granizo",
 			},
 			effect: {
 				en: "If your opponent's Active Pokémon is a Team Magma Pokémon, this attack does 60 more damage.",
 				fr: "Si le Pokémon Actif de votre adversaire est un Pokémon de la Team Magma, cette attaque inflige 60 dégâts supplémentaires.",
+				pt: "Se o Pokémon Ativo do seu oponente for um Pokémon da Equipe Magma, esse ataque causará 60 de danos adicionais.",
 			},
 			damage: "60＋",
 

--- a/data/XY/Double Crisis/5.ts
+++ b/data/XY/Double Crisis/5.ts
@@ -5,6 +5,7 @@ const card: Card = {
 	name: {
 		en: "Team Aqua's Walrein",
 		fr: "Kaimorse de la Team Aqua",
+		pt: "Walrein da Equipe Aqua",
 	},
 
 	illustrator: "Hitoshi Ariga",
@@ -25,6 +26,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Team Aqua's Sealeo",
 		fr: "Phogleur de la Team Aqua",
+		pt: "Sealeo da Equipe Aqua",
 	},
 
 	stage: "Stage2",
@@ -37,10 +39,12 @@ const card: Card = {
 			name: {
 				en: "Power Blow",
 				fr: "Coup Puissant",
+				pt: "Golpe Poderoso",
 			},
 			effect: {
 				en: "This attack does 30 damage times the amount of Energy attached to this Pokémon.",
 				fr: "Cette attaque inflige 30 dégâts multipliés par le nombre d'Énergies attachées à ce Pokémon.",
+				pt: "Esse ataque causa 30 de danos vezes a quantidade de Energia ligada a este Pokémon",
 			},
 			damage: "30×",
 
@@ -55,10 +59,12 @@ const card: Card = {
 			name: {
 				en: "Dual Blizzard",
 				fr: "Double Blizzard",
+				pt: "Nevasca Dupla",
 			},
 			effect: {
 				en: "Discard 2 Water Energy attached to this Pokémon. This attack does 80 damage to 2 of your opponent's Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)",
 				fr: "Défaussez 2 Énergies Water attachées à ce Pokémon. Cette attaque inflige 80 dégâts à 2 des Pokémon de votre adversaire. (N'appliquez ni la Faiblesse ni la Résistance aux Pokémon de Banc.)",
+				pt: "Descarte 2 Energias de Água ligadas a este Pokémon. Este ataque causa 80 de danos a 2 dos Pokémon de seu oponente. (Não aplique Fraqueza ou Resistência a Pokémon no Banco.)",
 			},
 
 		},

--- a/data/XY/Double Crisis/6.ts
+++ b/data/XY/Double Crisis/6.ts
@@ -5,6 +5,7 @@ const card: Card = {
 	name: {
 		en: "Team Aqua's Kyogre EX",
 		fr: "Kyogre-EX de la Team Aqua",
+		pt: "Kyogre-EX da Equipe Aqua",
 	},
 
 	illustrator: "nagimiso",
@@ -30,10 +31,12 @@ const card: Card = {
 			name: {
 				en: "Power Saver",
 				fr: "Économie de Puissance",
+				pt: "Economizador de Energia",
 			},
 			effect: {
 				en: "If there are 4 or fewer Team Aqua Pokémon in play, this Pokémon can't attack.",
 				fr: "S'il y a 4 Pokémon de la Team Aqua en jeu ou moins, ce Pokémon ne peut pas attaquer.",
+				pt: "Se houver 4 ou menos Pokémon da Equipe Aqua em jogo, esse Pokémon não poderá atacar",
 			},
 		},
 	],
@@ -49,10 +52,12 @@ const card: Card = {
 			name: {
 				en: "Aqua Impact",
 				fr: "Impact Aqua",
+				pt: "Impacto Aqua",
 			},
 			effect: {
 				en: "This attack does 20 more damage for each Colorless in your opponent's Active Pokémon's Retreat Cost.",
 				fr: "Cette attaque inflige 20 dégâts supplémentaires pour chaque Colorless dans le Coût de Retraite du Pokémon Actif de votre adversaire.",
+				pt: "Esse ataque causa 20 de danos adicionais para cada Incolor no Custo para Recuar do Pokémon Ativo do seu oponente."
 			},
 			damage: "80＋",
 

--- a/data/XY/Double Crisis/7.ts
+++ b/data/XY/Double Crisis/7.ts
@@ -5,6 +5,7 @@ const card: Card = {
 	name: {
 		en: "Team Aqua's Grimer",
 		fr: "Tadmorv de la Team Aqua",
+		pt: "Grimer da Equipe Aqua",
 	},
 
 	illustrator: "kawayoo",
@@ -32,6 +33,7 @@ const card: Card = {
 			name: {
 				en: "Pound",
 				fr: "Écras'Face",
+				pt: "Pancada",
 			},
 
 			damage: 10,
@@ -46,6 +48,7 @@ const card: Card = {
 			name: {
 				en: "Mud-Slap",
 				fr: "Coud'Boue",
+				pt: "Tapa de Lama",
 			},
 
 			damage: 30,

--- a/data/XY/Double Crisis/8.ts
+++ b/data/XY/Double Crisis/8.ts
@@ -5,6 +5,7 @@ const card: Card = {
 	name: {
 		en: "Team Aqua's Muk",
 		fr: "Grotadmorv de la Team Aqua",
+		pt: "Muk da Equipe Aqua",
 	},
 
 	illustrator: "Kouki Saitou",
@@ -25,6 +26,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Team Aqua's Grimer",
 		fr: "Tadmorv de la Team Aqua",
+		pt: "Grimer da Equipe Aqua",
 	},
 
 	stage: "Stage1",
@@ -35,10 +37,12 @@ const card: Card = {
 			name: {
 				en: "Sludge Festival",
 				fr: "Festival de Boue",
+				pt: "Festival de Lodo"
 			},
 			effect: {
 				en: "The Retreat Cost of each Pokémon in play (except for Team Aqua Pokémon) is Colorless more.",
 				fr: "Le Coût de Retraite de chaque Pokémon en jeu (à part les Pokémon de la Team Aqua) est augmenté de Colorless.",
+				pt: "O Custo para Recuar de cada um dos Pokémon em jogo (exceto os Pokémon da Equipe Aqua) será de Incolor a mais",
 			},
 		},
 	],
@@ -53,10 +57,12 @@ const card: Card = {
 			name: {
 				en: "Pester",
 				fr: "Tarabustage",
+				pt: "Importunar",
 			},
 			effect: {
 				en: "If your opponent's Active Pokémon is affected by a Special Condition, this attack does 60 more damage.",
 				fr: "Si le Pokémon Actif de votre adversaire est affecté par un État Spécial, cette attaque inflige 60 dégâts supplémentaires.",
+				pt: "Se o Pokémon Ativo do seu oponente estiver sendo afetado por uma Condição Especial, esse ataque causará 60 de danos adicionais.",
 			},
 			damage: "60＋",
 

--- a/data/XY/Double Crisis/9.ts
+++ b/data/XY/Double Crisis/9.ts
@@ -5,6 +5,7 @@ const card: Card = {
 	name: {
 		en: "Team Aqua's Seviper",
 		fr: "Séviper de la Team Aqua",
+		pt: "Seviper da Equipe Aqua",
 	},
 
 	illustrator: "Naoki Saito",
@@ -32,10 +33,12 @@ const card: Card = {
 			name: {
 				en: "Venomous Fang",
 				fr: "Croc-Poison",
+				pt: "Dente Venenoso",
 			},
 			effect: {
 				en: "Flip a coin. If heads, your opponent's Active Pokémon is now Poisoned.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Actif de votre adversaire est maintenant Empoisonné.",
+				pt: "Jogue uma moeda. Se sair cara, o Pokémon Ativo do seu oponente será Envenenado.",
 			},
 			damage: 10,
 
@@ -48,10 +51,12 @@ const card: Card = {
 			name: {
 				en: "Venom Tail",
 				fr: "Queue Venimeuse",
+				pt: "Cauda Envenenada",
 			},
 			effect: {
 				en: "If your opponent's Active Pokémon is affected by a Special Condition, discard an Energy attached to that Pokémon.",
 				fr: "Si le Pokémon Actif de votre adversaire est affecté par un État Spécial, défaussez une Énergie lui étant attachée.",
+				pt: "Se o Pokémon Ativo do seu oponente estiver sendo afetado por uma Condição Especial, descarte uma Energia ligada a esse Pokémon.",
 			},
 			damage: 30,
 


### PR DESCRIPTION
## Changes

Add Portuguese translations for the Double Crisis Set.

## Details

This PR adds Portuguese translations for Pokémon, Abilities, and Attacks on cards from the Double Crisis set.

The translations were obtained from limitlesstcg.com and checked for accuracy.

