### PR TITLE
Add missing dexId fields to Ascended Heroes 

### DIFF
--- a/data/Mega Evolution/Ascended Heroes/001.ts
+++ b/data/Mega Evolution/Ascended Heroes/001.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 60,
 	types: ["Grass"],
 	stage: "Basic",
+	dexId: [43],
 
 	attacks: [{
 		cost: ["Grass"],

--- a/data/Mega Evolution/Ascended Heroes/002.ts
+++ b/data/Mega Evolution/Ascended Heroes/002.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 90,
 	types: ["Grass"],
 	stage: "Stage1",
+	dexId: [44],
 
 	attacks: [{
 		cost: ["Grass", "Colorless"],

--- a/data/Mega Evolution/Ascended Heroes/004.ts
+++ b/data/Mega Evolution/Ascended Heroes/004.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 60,
 	types: ["Grass"],
 	stage: "Basic",
+	dexId: [69],
 
 	attacks: [{
 		cost: ["Grass"],

--- a/data/Mega Evolution/Ascended Heroes/005.ts
+++ b/data/Mega Evolution/Ascended Heroes/005.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 90,
 	types: ["Grass"],
 	stage: "Stage1",
+	dexId: [70],
 
 	attacks: [{
 		cost: ["Grass"],

--- a/data/Mega Evolution/Ascended Heroes/006.ts
+++ b/data/Mega Evolution/Ascended Heroes/006.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 150,
 	types: ["Grass"],
 	stage: "Stage2",
+	dexId: [71],
 
 	attacks: [{
 		cost: ["Grass", "Colorless"],

--- a/data/Mega Evolution/Ascended Heroes/007.ts
+++ b/data/Mega Evolution/Ascended Heroes/007.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 80,
 	types: ["Grass"],
 	stage: "Basic",
+	dexId: [114],
 
 	abilities: [{
 		type: "Ability",

--- a/data/Mega Evolution/Ascended Heroes/008.ts
+++ b/data/Mega Evolution/Ascended Heroes/008.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 70,
 	types: ["Grass"],
 	stage: "Basic",
+	dexId: [152],
 
 	attacks: [{
 		cost: ["Colorless"],

--- a/data/Mega Evolution/Ascended Heroes/009.ts
+++ b/data/Mega Evolution/Ascended Heroes/009.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 100,
 	types: ["Grass"],
 	stage: "Stage1",
+	dexId: [153],
 
 	attacks: [{
 		cost: ["Grass", "Grass"],

--- a/data/Mega Evolution/Ascended Heroes/010.ts
+++ b/data/Mega Evolution/Ascended Heroes/010.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 360,
 	types: ["Grass"],
 	stage: "Stage2",
+	dexId: [154],
 
 	attacks: [{
 		cost: ["Colorless", "Colorless", "Colorless"],

--- a/data/Mega Evolution/Ascended Heroes/011.ts
+++ b/data/Mega Evolution/Ascended Heroes/011.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 60,
 	types: ["Grass"],
 	stage: "Basic",
+	dexId: [265],
 
 	attacks: [{
 		cost: ["Grass"],

--- a/data/Mega Evolution/Ascended Heroes/012.ts
+++ b/data/Mega Evolution/Ascended Heroes/012.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 90,
 	types: ["Grass"],
 	stage: "Stage1",
+	dexId: [266],
 
 	abilities: [{
 		type: "Ability",

--- a/data/Mega Evolution/Ascended Heroes/013.ts
+++ b/data/Mega Evolution/Ascended Heroes/013.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 130,
 	types: ["Grass"],
 	stage: "Stage2",
+	dexId: [267],
 
 	attacks: [{
 		cost: ["Grass"],

--- a/data/Mega Evolution/Ascended Heroes/014.ts
+++ b/data/Mega Evolution/Ascended Heroes/014.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 90,
 	types: ["Grass"],
 	stage: "Stage1",
+	dexId: [268],
 
 	attacks: [{
 		cost: ["Grass"],

--- a/data/Mega Evolution/Ascended Heroes/015.ts
+++ b/data/Mega Evolution/Ascended Heroes/015.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 140,
 	types: ["Grass"],
 	stage: "Stage2",
+	dexId: [269],
 
 	abilities: [{
 		type: "Ability",

--- a/data/Mega Evolution/Ascended Heroes/016.ts
+++ b/data/Mega Evolution/Ascended Heroes/016.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 30,
 	types: ["Grass"],
 	stage: "Basic",
+	dexId: [406],
 
 	attacks: [{
 		name: {

--- a/data/Mega Evolution/Ascended Heroes/017.ts
+++ b/data/Mega Evolution/Ascended Heroes/017.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 70,
 	types: ["Grass"],
 	stage: "Basic",
+	dexId: [736],
 
 	attacks: [{
 		cost: ["Colorless", "Colorless"],

--- a/data/Mega Evolution/Ascended Heroes/018.ts
+++ b/data/Mega Evolution/Ascended Heroes/018.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 50,
 	types: ["Grass"],
 	stage: "Basic",
+	dexId: [917],
 
 	attacks: [{
 		cost: ["Grass"],

--- a/data/Mega Evolution/Ascended Heroes/019.ts
+++ b/data/Mega Evolution/Ascended Heroes/019.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 130,
 	types: ["Grass"],
 	stage: "Stage1",
+	dexId: [918],
 
 	abilities: [{
 		type: "Ability",

--- a/data/Mega Evolution/Ascended Heroes/020.ts
+++ b/data/Mega Evolution/Ascended Heroes/020.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 80,
 	types: ["Fire"],
 	stage: "Basic",
+	dexId: [4],
 
 	attacks: [{
 		cost: ["Fire", "Colorless"],

--- a/data/Mega Evolution/Ascended Heroes/021.ts
+++ b/data/Mega Evolution/Ascended Heroes/021.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 100,
 	types: ["Fire"],
 	stage: "Stage1",
+	dexId: [5],
 
 	attacks: [{
 		cost: ["Fire", "Colorless"],

--- a/data/Mega Evolution/Ascended Heroes/022.ts
+++ b/data/Mega Evolution/Ascended Heroes/022.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 360,
 	types: ["Fire"],
 	stage: "Stage2",
+	dexId: [6],
 
 	attacks: [{
 		cost: ["Fire", "Fire", "Colorless"],

--- a/data/Mega Evolution/Ascended Heroes/023.ts
+++ b/data/Mega Evolution/Ascended Heroes/023.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 80,
 	types: ["Fire"],
 	stage: "Basic",
+	dexId: [218],
 
 	attacks: [{
 		cost: ["Fire"],

--- a/data/Mega Evolution/Ascended Heroes/024.ts
+++ b/data/Mega Evolution/Ascended Heroes/024.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 130,
 	types: ["Fire"],
 	stage: "Stage1",
+	dexId: [219],
 
 	abilities: [{
 		type: "Ability",

--- a/data/Mega Evolution/Ascended Heroes/025.ts
+++ b/data/Mega Evolution/Ascended Heroes/025.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 140,
 	types: ["Fire"],
 	stage: "Basic",
+	dexId: [244],
 
 	attacks: [{
 		cost: ["Fire", "Fire"],

--- a/data/Mega Evolution/Ascended Heroes/027.ts
+++ b/data/Mega Evolution/Ascended Heroes/027.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 80,
 	types: ["Fire"],
 	stage: "Basic",
+	dexId: [322],
 
 	abilities: [{
 		type: "Ability",

--- a/data/Mega Evolution/Ascended Heroes/028.ts
+++ b/data/Mega Evolution/Ascended Heroes/028.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 140,
 	types: ["Fire"],
 	stage: "Stage1",
+	dexId: [323],
 
 	attacks: [{
 		cost: ["Fire"],

--- a/data/Mega Evolution/Ascended Heroes/029.ts
+++ b/data/Mega Evolution/Ascended Heroes/029.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 80,
 	types: ["Fire"],
 	stage: "Basic",
+	dexId: [498],
 
 	attacks: [{
 		cost: ["Fire"],

--- a/data/Mega Evolution/Ascended Heroes/030.ts
+++ b/data/Mega Evolution/Ascended Heroes/030.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 110,
 	types: ["Fire"],
 	stage: "Stage1",
+	dexId: [499],
 
 	attacks: [{
 		cost: ["Fire", "Fire", "Colorless"],

--- a/data/Mega Evolution/Ascended Heroes/031.ts
+++ b/data/Mega Evolution/Ascended Heroes/031.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 380,
 	types: ["Fire"],
 	stage: "Stage2",
+	dexId: [500],
 
 	attacks: [{
 		cost: ["Fire", "Fire", "Colorless"],

--- a/data/Mega Evolution/Ascended Heroes/032.ts
+++ b/data/Mega Evolution/Ascended Heroes/032.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 80,
 	types: ["Fire"],
 	stage: "Basic",
+	dexId: [554],
 
 	attacks: [{
 		cost: ["Colorless", "Colorless"],

--- a/data/Mega Evolution/Ascended Heroes/033.ts
+++ b/data/Mega Evolution/Ascended Heroes/033.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 140,
 	types: ["Fire"],
 	stage: "Stage1",
+	dexId: [555],
 
 	attacks: [{
 		cost: ["Colorless", "Colorless"],

--- a/data/Mega Evolution/Ascended Heroes/034.ts
+++ b/data/Mega Evolution/Ascended Heroes/034.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 70,
 	types: ["Fire"],
 	stage: "Basic",
+	dexId: [757],
 
 	attacks: [{
 		cost: ["Fire"],

--- a/data/Mega Evolution/Ascended Heroes/035.ts
+++ b/data/Mega Evolution/Ascended Heroes/035.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 120,
 	types: ["Fire"],
 	stage: "Stage1",
+	dexId: [758],
 
 	attacks: [{
 		cost: ["Colorless", "Colorless"],

--- a/data/Mega Evolution/Ascended Heroes/036.ts
+++ b/data/Mega Evolution/Ascended Heroes/036.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 70,
 	types: ["Fire"],
 	stage: "Basic",
+	dexId: [813],
 
 	attacks: [{
 		cost: ["Colorless"],

--- a/data/Mega Evolution/Ascended Heroes/037.ts
+++ b/data/Mega Evolution/Ascended Heroes/037.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 90,
 	types: ["Fire"],
 	stage: "Stage1",
+	dexId: [814],
 
 	attacks: [{
 		cost: ["Fire"],

--- a/data/Mega Evolution/Ascended Heroes/038.ts
+++ b/data/Mega Evolution/Ascended Heroes/038.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 320,
 	types: ["Fire"],
 	stage: "Stage2",
+	dexId: [815],
 
 	attacks: [{
 		cost: ["Fire", "Colorless", "Colorless"],

--- a/data/Mega Evolution/Ascended Heroes/039.ts
+++ b/data/Mega Evolution/Ascended Heroes/039.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 70,
 	types: ["Water"],
 	stage: "Basic",
+	dexId: [54],
 
 	abilities: [{
 		type: "Ability",

--- a/data/Mega Evolution/Ascended Heroes/040.ts
+++ b/data/Mega Evolution/Ascended Heroes/040.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 120,
 	types: ["Water"],
 	stage: "Stage1",
+	dexId: [55],
 
 	abilities: [{
 		type: "Ability",

--- a/data/Mega Evolution/Ascended Heroes/041.ts
+++ b/data/Mega Evolution/Ascended Heroes/041.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 80,
 	types: ["Water"],
 	stage: "Basic",
+	dexId: [158],
 
 	attacks: [{
 		cost: ["Water", "Water"],

--- a/data/Mega Evolution/Ascended Heroes/042.ts
+++ b/data/Mega Evolution/Ascended Heroes/042.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 100,
 	types: ["Water"],
 	stage: "Stage1",
+	dexId: [159],
 
 	attacks: [{
 		cost: ["Water", "Water"],

--- a/data/Mega Evolution/Ascended Heroes/043.ts
+++ b/data/Mega Evolution/Ascended Heroes/043.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 370,
 	types: ["Water"],
 	stage: "Stage2",
+	dexId: [160],
 
 	attacks: [{
 		cost: ["Water", "Water", "Colorless"],

--- a/data/Mega Evolution/Ascended Heroes/044.ts
+++ b/data/Mega Evolution/Ascended Heroes/044.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 70,
 	types: ["Water"],
 	stage: "Basic",
+	dexId: [215],
 
 	attacks: [{
 		cost: ["Water"],

--- a/data/Mega Evolution/Ascended Heroes/045.ts
+++ b/data/Mega Evolution/Ascended Heroes/045.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 100,
 	types: ["Water"],
 	stage: "Stage1",
+	dexId: [461],
 
 	attacks: [{
 		cost: ["Water"],

--- a/data/Mega Evolution/Ascended Heroes/046.ts
+++ b/data/Mega Evolution/Ascended Heroes/046.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 70,
 	types: ["Water"],
 	stage: "Basic",
+	dexId: [361],
 
 	attacks: [{
 		cost: ["Water"],

--- a/data/Mega Evolution/Ascended Heroes/047.ts
+++ b/data/Mega Evolution/Ascended Heroes/047.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 310,
 	types: ["Water"],
 	stage: "Stage1",
+	dexId: [478],
 
 	attacks: [{
 		cost: ["Water"],

--- a/data/Mega Evolution/Ascended Heroes/048.ts
+++ b/data/Mega Evolution/Ascended Heroes/048.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 230,
 	types: ["Water"],
 	stage: "Basic",
+	dexId: [378],
 
 	attacks: [{
 		cost: ["Colorless"],

--- a/data/Mega Evolution/Ascended Heroes/052.ts
+++ b/data/Mega Evolution/Ascended Heroes/052.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 50,
 	types: ["Water"],
 	stage: "Basic",
+	dexId: [872],
 
 	attacks: [{
 		cost: ["Water"],

--- a/data/Mega Evolution/Ascended Heroes/053.ts
+++ b/data/Mega Evolution/Ascended Heroes/053.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 110,
 	types: ["Water"],
 	stage: "Stage1",
+	dexId: [873],
 
 	abilities: [{
 		type: "Ability",

--- a/data/Mega Evolution/Ascended Heroes/054.ts
+++ b/data/Mega Evolution/Ascended Heroes/054.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 130,
 	types: ["Water"],
 	stage: "Basic",
+	dexId: [896],
 
 	attacks: [{
 		cost: ["Water"],

--- a/data/Mega Evolution/Ascended Heroes/055.ts
+++ b/data/Mega Evolution/Ascended Heroes/055.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 70,
 	types: ["Lightning"],
 	stage: "Basic",
+	dexId: [25],
 
 	attacks: [{
 		cost: ["Lightning"],

--- a/data/Mega Evolution/Ascended Heroes/056.ts
+++ b/data/Mega Evolution/Ascended Heroes/056.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 130,
 	types: ["Lightning"],
 	stage: "Stage1",
+	dexId: [26],
 
 	attacks: [{
 		cost: ["Lightning"],

--- a/data/Mega Evolution/Ascended Heroes/057.ts
+++ b/data/Mega Evolution/Ascended Heroes/057.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 200,
 	types: ["Lightning"],
 	stage: "Basic",
+	dexId: [25],
 
 	abilities: [{
 		type: "Ability",

--- a/data/Mega Evolution/Ascended Heroes/058.ts
+++ b/data/Mega Evolution/Ascended Heroes/058.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 170,
 	types: ["Lightning"],
 	stage: "Basic",
+	dexId: [100],
 
 	attacks: [{
 		cost: ["Colorless", "Colorless", "Colorless"],

--- a/data/Mega Evolution/Ascended Heroes/059.ts
+++ b/data/Mega Evolution/Ascended Heroes/059.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 40,
 	types: ["Lightning"],
 	stage: "Basic",
+	dexId: [602],
 
 	attacks: [{
 		cost: ["Colorless"],

--- a/data/Mega Evolution/Ascended Heroes/060.ts
+++ b/data/Mega Evolution/Ascended Heroes/060.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 90,
 	types: ["Lightning"],
 	stage: "Stage1",
+	dexId: [603],
 
 	abilities: [{
 		type: "Ability",

--- a/data/Mega Evolution/Ascended Heroes/061.ts
+++ b/data/Mega Evolution/Ascended Heroes/061.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 350,
 	types: ["Lightning"],
 	stage: "Stage2",
+	dexId: [604],
 
 	attacks: [{
 		cost: ["Lightning", "Lightning"],

--- a/data/Mega Evolution/Ascended Heroes/062.ts
+++ b/data/Mega Evolution/Ascended Heroes/062.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 110,
 	types: ["Lightning"],
 	stage: "Basic",
+	dexId: [618],
 
 	attacks: [{
 		cost: ["Lightning"],

--- a/data/Mega Evolution/Ascended Heroes/063.ts
+++ b/data/Mega Evolution/Ascended Heroes/063.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 70,
 	types: ["Lightning"],
 	stage: "Basic",
+	dexId: [694],
 
 	attacks: [{
 		cost: ["Lightning", "Colorless"],

--- a/data/Mega Evolution/Ascended Heroes/064.ts
+++ b/data/Mega Evolution/Ascended Heroes/064.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 120,
 	types: ["Lightning"],
 	stage: "Stage1",
+	dexId: [695],
 
 	abilities: [{
 		type: "Ability",

--- a/data/Mega Evolution/Ascended Heroes/065.ts
+++ b/data/Mega Evolution/Ascended Heroes/065.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 100,
 	types: ["Lightning"],
 	stage: "Stage1",
+	dexId: [737],
 
 	attacks: [{
 		cost: ["Lightning", "Lightning"],

--- a/data/Mega Evolution/Ascended Heroes/066.ts
+++ b/data/Mega Evolution/Ascended Heroes/066.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 160,
 	types: ["Lightning"],
 	stage: "Stage2",
+	dexId: [738],
 
 	attacks: [{
 		cost: ["Lightning"],

--- a/data/Mega Evolution/Ascended Heroes/067.ts
+++ b/data/Mega Evolution/Ascended Heroes/067.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 120,
 	types: ["Lightning"],
 	stage: "Basic",
+	dexId: [785],
 
 	attacks: [{
 		cost: ["Lightning"],

--- a/data/Mega Evolution/Ascended Heroes/069.ts
+++ b/data/Mega Evolution/Ascended Heroes/069.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 60,
 	types: ["Lightning"],
 	stage: "Basic",
+	dexId: [938],
 
 	attacks: [{
 		cost: ["Lightning", "Colorless"],

--- a/data/Mega Evolution/Ascended Heroes/071.ts
+++ b/data/Mega Evolution/Ascended Heroes/071.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 60,
 	types: ["Lightning"],
 	stage: "Basic",
+	dexId: [940],
 
 	attacks: [{
 		cost: ["Lightning"],

--- a/data/Mega Evolution/Ascended Heroes/072.ts
+++ b/data/Mega Evolution/Ascended Heroes/072.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 120,
 	types: ["Lightning"],
 	stage: "Stage1",
+	dexId: [941],
 
 	abilities: [{
 		type: "Ability",

--- a/data/Mega Evolution/Ascended Heroes/073.ts
+++ b/data/Mega Evolution/Ascended Heroes/073.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 220,
 	types: ["Lightning"],
 	stage: "Basic",
+	dexId: [1008],
 
 	attacks: [{
 		cost: ["Lightning"],

--- a/data/Mega Evolution/Ascended Heroes/074.ts
+++ b/data/Mega Evolution/Ascended Heroes/074.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 60,
 	types: ["Psychic"],
 	stage: "Basic",
+	dexId: [35],
 
 	attacks: [{
 		cost: ["Colorless", "Colorless"],

--- a/data/Mega Evolution/Ascended Heroes/075.ts
+++ b/data/Mega Evolution/Ascended Heroes/075.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 120,
 	types: ["Psychic"],
 	stage: "Stage1",
+	dexId: [36],
 
 	attacks: [{
 		cost: ["Colorless", "Colorless"],

--- a/data/Mega Evolution/Ascended Heroes/080.ts
+++ b/data/Mega Evolution/Ascended Heroes/080.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 50,
 	types: ["Psychic"],
 	stage: "Basic",
+	dexId: [175],
 
 	attacks: [{
 		cost: ["Colorless", "Colorless"],

--- a/data/Mega Evolution/Ascended Heroes/081.ts
+++ b/data/Mega Evolution/Ascended Heroes/081.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 90,
 	types: ["Psychic"],
 	stage: "Stage1",
+	dexId: [176],
 
 	attacks: [{
 		cost: ["Colorless", "Colorless"],

--- a/data/Mega Evolution/Ascended Heroes/082.ts
+++ b/data/Mega Evolution/Ascended Heroes/082.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 140,
 	types: ["Psychic"],
 	stage: "Stage2",
+	dexId: [468],
 
 	abilities: [{
 		type: "Ability",

--- a/data/Mega Evolution/Ascended Heroes/083.ts
+++ b/data/Mega Evolution/Ascended Heroes/083.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 70,
 	types: ["Psychic"],
 	stage: "Basic",
+	dexId: [183],
 
 	attacks: [{
 		cost: ["Colorless"],

--- a/data/Mega Evolution/Ascended Heroes/084.ts
+++ b/data/Mega Evolution/Ascended Heroes/084.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 270,
 	types: ["Psychic"],
 	stage: "Stage1",
+	dexId: [184],
 
 	abilities: [{
 		type: "Ability",

--- a/data/Mega Evolution/Ascended Heroes/085.ts
+++ b/data/Mega Evolution/Ascended Heroes/085.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 60,
 	types: ["Psychic"],
 	stage: "Basic",
+	dexId: [200],
 
 	attacks: [{
 		cost: ["Psychic"],

--- a/data/Mega Evolution/Ascended Heroes/086.ts
+++ b/data/Mega Evolution/Ascended Heroes/086.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 110,
 	types: ["Psychic"],
 	stage: "Stage1",
+	dexId: [429],
 
 	attacks: [{
 		cost: ["Psychic", "Colorless"],

--- a/data/Mega Evolution/Ascended Heroes/087.ts
+++ b/data/Mega Evolution/Ascended Heroes/087.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 70,
 	types: ["Psychic"],
 	stage: "Basic",
+	dexId: [280],
 
 	attacks: [{
 		cost: ["Colorless"],

--- a/data/Mega Evolution/Ascended Heroes/088.ts
+++ b/data/Mega Evolution/Ascended Heroes/088.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 100,
 	types: ["Psychic"],
 	stage: "Stage1",
+	dexId: [281],
 
 	attacks: [{
 		cost: ["Psychic"],

--- a/data/Mega Evolution/Ascended Heroes/089.ts
+++ b/data/Mega Evolution/Ascended Heroes/089.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 360,
 	types: ["Psychic"],
 	stage: "Stage2",
+	dexId: [282],
 
 	attacks: [{
 		cost: ["Psychic"],

--- a/data/Mega Evolution/Ascended Heroes/090.ts
+++ b/data/Mega Evolution/Ascended Heroes/090.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 60,
 	types: ["Psychic"],
 	stage: "Basic",
+	dexId: [353],
 
 	attacks: [{
 		cost: ["Psychic"],

--- a/data/Mega Evolution/Ascended Heroes/091.ts
+++ b/data/Mega Evolution/Ascended Heroes/091.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 90,
 	types: ["Psychic"],
 	stage: "Stage1",
+	dexId: [354],
 
 	attacks: [{
 		cost: ["Psychic"],

--- a/data/Mega Evolution/Ascended Heroes/092.ts
+++ b/data/Mega Evolution/Ascended Heroes/092.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 60,
 	types: ["Psychic"],
 	stage: "Basic",
+	dexId: [479],
 
 	attacks: [{
 		cost: ["Colorless"],

--- a/data/Mega Evolution/Ascended Heroes/093.ts
+++ b/data/Mega Evolution/Ascended Heroes/093.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 60,
 	types: ["Psychic"],
 	stage: "Basic",
+	dexId: [684],
 
 	attacks: [{
 		cost: ["Psychic"],

--- a/data/Mega Evolution/Ascended Heroes/094.ts
+++ b/data/Mega Evolution/Ascended Heroes/094.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 120,
 	types: ["Psychic"],
 	stage: "Stage1",
+	dexId: [685],
 
 	attacks: [{
 		cost: ["Psychic"],

--- a/data/Mega Evolution/Ascended Heroes/097.ts
+++ b/data/Mega Evolution/Ascended Heroes/097.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 60,
 	types: ["Psychic"],
 	stage: "Basic",
+	dexId: [778],
 
 	attacks: [{
 		cost: ["Psychic", "Colorless"],

--- a/data/Mega Evolution/Ascended Heroes/098.ts
+++ b/data/Mega Evolution/Ascended Heroes/098.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 120,
 	types: ["Psychic"],
 	stage: "Basic",
+	dexId: [897],
 
 	attacks: [{
 		cost: ["Psychic"],

--- a/data/Mega Evolution/Ascended Heroes/099.ts
+++ b/data/Mega Evolution/Ascended Heroes/099.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 110,
 	types: ["Psychic"],
 	stage: "Basic",
+	dexId: [1015],
 
 	abilities: [{
 		type: "Ability",

--- a/data/Mega Evolution/Ascended Heroes/102.ts
+++ b/data/Mega Evolution/Ascended Heroes/102.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 100,
 	types: ["Fighting"],
 	stage: "Basic",
+	dexId: [237],
 
 	attacks: [{
 		cost: ["Colorless"],

--- a/data/Mega Evolution/Ascended Heroes/103.ts
+++ b/data/Mega Evolution/Ascended Heroes/103.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 70,
 	types: ["Fighting"],
 	stage: "Basic",
+	dexId: [307],
 
 	attacks: [{
 		cost: ["Colorless"],

--- a/data/Mega Evolution/Ascended Heroes/104.ts
+++ b/data/Mega Evolution/Ascended Heroes/104.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 120,
 	types: ["Fighting"],
 	stage: "Stage1",
+	dexId: [308],
 
 	attacks: [{
 		cost: ["Fighting"],

--- a/data/Mega Evolution/Ascended Heroes/105.ts
+++ b/data/Mega Evolution/Ascended Heroes/105.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 110,
 	types: ["Fighting"],
 	stage: "Basic",
+	dexId: [337],
 
 	abilities: [{
 		type: "Ability",

--- a/data/Mega Evolution/Ascended Heroes/106.ts
+++ b/data/Mega Evolution/Ascended Heroes/106.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 110,
 	types: ["Fighting"],
 	stage: "Basic",
+	dexId: [338],
 
 	attacks: [{
 		cost: ["Fighting"],

--- a/data/Mega Evolution/Ascended Heroes/107.ts
+++ b/data/Mega Evolution/Ascended Heroes/107.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 230,
 	types: ["Fighting"],
 	stage: "Basic",
+	dexId: [377],
 
 	attacks: [{
 		cost: ["Colorless"],

--- a/data/Mega Evolution/Ascended Heroes/108.ts
+++ b/data/Mega Evolution/Ascended Heroes/108.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 140,
 	types: ["Fighting"],
 	stage: "Basic",
+	dexId: [383],
 
 	attacks: [{
 		cost: ["Fighting", "Fighting", "Colorless"],

--- a/data/Mega Evolution/Ascended Heroes/109.ts
+++ b/data/Mega Evolution/Ascended Heroes/109.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 70,
 	types: ["Fighting"],
 	stage: "Basic",
+	dexId: [443],
 
 	attacks: [{
 		cost: ["Fighting"],

--- a/data/Mega Evolution/Ascended Heroes/110.ts
+++ b/data/Mega Evolution/Ascended Heroes/110.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 100,
 	types: ["Fighting"],
 	stage: "Stage1",
+	dexId: [444],
 
 	abilities: [{
 		type: "Ability",

--- a/data/Mega Evolution/Ascended Heroes/112.ts
+++ b/data/Mega Evolution/Ascended Heroes/112.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 80,
 	types: ["Fighting"],
 	stage: "Basic",
+	dexId: [447],
 
 	attacks: [{
 		cost: ["Fighting"],

--- a/data/Mega Evolution/Ascended Heroes/113.ts
+++ b/data/Mega Evolution/Ascended Heroes/113.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 340,
 	types: ["Fighting"],
 	stage: "Stage1",
+	dexId: [448],
 
 	attacks: [{
 		cost: ["Fighting"],

--- a/data/Mega Evolution/Ascended Heroes/114.ts
+++ b/data/Mega Evolution/Ascended Heroes/114.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 210,
 	types: ["Fighting"],
 	stage: "Basic",
+	dexId: [618],
 
 	attacks: [{
 		cost: ["Fighting"],

--- a/data/Mega Evolution/Ascended Heroes/115.ts
+++ b/data/Mega Evolution/Ascended Heroes/115.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 70,
 	types: ["Fighting"],
 	stage: "Basic",
+	dexId: [674],
 
 	attacks: [{
 		cost: ["Colorless"],

--- a/data/Mega Evolution/Ascended Heroes/116.ts
+++ b/data/Mega Evolution/Ascended Heroes/116.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 250,
 	types: ["Fighting"],
 	stage: "Basic",
+	dexId: [701],
 
 	abilities: [{
 		type: "Ability",

--- a/data/Mega Evolution/Ascended Heroes/117.ts
+++ b/data/Mega Evolution/Ascended Heroes/117.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 90,
 	types: ["Fighting"],
 	stage: "Basic",
+	dexId: [703],
 
 	abilities: [{
 		type: "Ability",

--- a/data/Mega Evolution/Ascended Heroes/118.ts
+++ b/data/Mega Evolution/Ascended Heroes/118.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 80,
 	types: ["Fighting"],
 	stage: "Basic",
+	dexId: [837],
 
 	attacks: [{
 		cost: ["Fighting"],

--- a/data/Mega Evolution/Ascended Heroes/119.ts
+++ b/data/Mega Evolution/Ascended Heroes/119.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 110,
 	types: ["Fighting"],
 	stage: "Stage1",
+	dexId: [838],
 
 	attacks: [{
 		cost: ["Fighting"],

--- a/data/Mega Evolution/Ascended Heroes/120.ts
+++ b/data/Mega Evolution/Ascended Heroes/120.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 180,
 	types: ["Fighting"],
 	stage: "Stage2",
+	dexId: [839],
 
 	attacks: [{
 		cost: ["Fighting"],

--- a/data/Mega Evolution/Ascended Heroes/121.ts
+++ b/data/Mega Evolution/Ascended Heroes/121.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 230,
 	types: ["Fighting"],
 	stage: "Basic",
+	dexId: [1007],
 
 	attacks: [{
 		cost: ["Fighting", "Colorless"],

--- a/data/Mega Evolution/Ascended Heroes/122.ts
+++ b/data/Mega Evolution/Ascended Heroes/122.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 140,
 	types: ["Fighting"],
 	stage: "Basic",
+	dexId: [1014],
 
 	attacks: [{
 		cost: ["Fighting"],

--- a/data/Mega Evolution/Ascended Heroes/123.ts
+++ b/data/Mega Evolution/Ascended Heroes/123.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 70,
 	types: ["Darkness"],
 	stage: "Basic",
+	dexId: [92],
 
 	attacks: [{
 		cost: ["Darkness"],

--- a/data/Mega Evolution/Ascended Heroes/124.ts
+++ b/data/Mega Evolution/Ascended Heroes/124.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 100,
 	types: ["Darkness"],
 	stage: "Stage1",
+	dexId: [93],
 
 	attacks: [{
 		cost: ["Darkness"],

--- a/data/Mega Evolution/Ascended Heroes/125.ts
+++ b/data/Mega Evolution/Ascended Heroes/125.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 350,
 	types: ["Darkness"],
 	stage: "Stage2",
+	dexId: [94],
 
 	abilities: [{
 		type: "Ability",

--- a/data/Mega Evolution/Ascended Heroes/126.ts
+++ b/data/Mega Evolution/Ascended Heroes/126.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 80,
 	types: ["Darkness"],
 	stage: "Basic",
+	dexId: [198],
 
 	attacks: [{
 		cost: ["Colorless"],

--- a/data/Mega Evolution/Ascended Heroes/128.ts
+++ b/data/Mega Evolution/Ascended Heroes/128.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 70,
 	types: ["Darkness"],
 	stage: "Basic",
+	dexId: [261],
 
 	attacks: [{
 		cost: ["Darkness", "Colorless"],

--- a/data/Mega Evolution/Ascended Heroes/129.ts
+++ b/data/Mega Evolution/Ascended Heroes/129.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 120,
 	types: ["Darkness"],
 	stage: "Stage1",
+	dexId: [262],
 
 	attacks: [{
 		cost: ["Darkness", "Colorless"],

--- a/data/Mega Evolution/Ascended Heroes/130.ts
+++ b/data/Mega Evolution/Ascended Heroes/130.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 70,
 	types: ["Darkness"],
 	stage: "Basic",
+	dexId: [263],
 
 	attacks: [{
 		cost: ["Darkness"],

--- a/data/Mega Evolution/Ascended Heroes/131.ts
+++ b/data/Mega Evolution/Ascended Heroes/131.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 90,
 	types: ["Darkness"],
 	stage: "Stage1",
+	dexId: [264],
 
 	attacks: [{
 		cost: ["Darkness"],

--- a/data/Mega Evolution/Ascended Heroes/132.ts
+++ b/data/Mega Evolution/Ascended Heroes/132.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 170,
 	types: ["Darkness"],
 	stage: "Stage2",
+	dexId: [862],
 
 	attacks: [{
 		cost: ["Darkness", "Colorless"],

--- a/data/Mega Evolution/Ascended Heroes/133.ts
+++ b/data/Mega Evolution/Ascended Heroes/133.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 70,
 	types: ["Darkness"],
 	stage: "Basic",
+	dexId: [442],
 
 	attacks: [{
 		cost: ["Colorless"],

--- a/data/Mega Evolution/Ascended Heroes/134.ts
+++ b/data/Mega Evolution/Ascended Heroes/134.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 80,
 	types: ["Darkness"],
 	stage: "Basic",
+	dexId: [559],
 
 	attacks: [{
 		cost: ["Darkness", "Colorless"],

--- a/data/Mega Evolution/Ascended Heroes/135.ts
+++ b/data/Mega Evolution/Ascended Heroes/135.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 330,
 	types: ["Darkness"],
 	stage: "Stage1",
+	dexId: [560],
 
 	abilities: [{
 		type: "Ability",

--- a/data/Mega Evolution/Ascended Heroes/136.ts
+++ b/data/Mega Evolution/Ascended Heroes/136.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 70,
 	types: ["Darkness"],
 	stage: "Basic",
+	dexId: [570],
 
 	attacks: [{
 		cost: ["Darkness"],

--- a/data/Mega Evolution/Ascended Heroes/138.ts
+++ b/data/Mega Evolution/Ascended Heroes/138.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 70,
 	types: ["Darkness"],
 	stage: "Basic",
+	dexId: [629],
 
 	attacks: [{
 		cost: ["Colorless", "Colorless"],

--- a/data/Mega Evolution/Ascended Heroes/139.ts
+++ b/data/Mega Evolution/Ascended Heroes/139.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 260,
 	types: ["Darkness"],
 	stage: "Stage1",
+	dexId: [630],
 
 	attacks: [{
 		cost: ["Colorless", "Colorless"],

--- a/data/Mega Evolution/Ascended Heroes/140.ts
+++ b/data/Mega Evolution/Ascended Heroes/140.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 140,
 	types: ["Darkness"],
 	stage: "Stage1",
+	dexId: [675],
 
 	attacks: [{
 		cost: ["Darkness"],

--- a/data/Mega Evolution/Ascended Heroes/141.ts
+++ b/data/Mega Evolution/Ascended Heroes/141.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 120,
 	types: ["Darkness"],
 	stage: "Basic",
+	dexId: [720],
 
 	attacks: [{
 		cost: ["Colorless"],

--- a/data/Mega Evolution/Ascended Heroes/142.ts
+++ b/data/Mega Evolution/Ascended Heroes/142.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 210,
 	types: ["Darkness"],
 	stage: "Basic",
+	dexId: [1016],
 
 	abilities: [{
 		type: "Ability",

--- a/data/Mega Evolution/Ascended Heroes/143.ts
+++ b/data/Mega Evolution/Ascended Heroes/143.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 80,
 	types: ["Darkness"],
 	stage: "Basic",
+	dexId: [1025],
 
 	abilities: [{
 		type: "Ability",

--- a/data/Mega Evolution/Ascended Heroes/144.ts
+++ b/data/Mega Evolution/Ascended Heroes/144.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 90,
 	types: ["Metal"],
 	stage: "Basic",
+	dexId: [303],
 
 	attacks: [{
 		cost: ["Colorless"],

--- a/data/Mega Evolution/Ascended Heroes/145.ts
+++ b/data/Mega Evolution/Ascended Heroes/145.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 230,
 	types: ["Metal"],
 	stage: "Basic",
+	dexId: [379],
 
 	attacks: [{
 		cost: ["Colorless"],

--- a/data/Mega Evolution/Ascended Heroes/146.ts
+++ b/data/Mega Evolution/Ascended Heroes/146.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 70,
 	types: ["Metal"],
 	stage: "Basic",
+	dexId: [624],
 
 	attacks: [{
 		cost: ["Metal"],

--- a/data/Mega Evolution/Ascended Heroes/147.ts
+++ b/data/Mega Evolution/Ascended Heroes/147.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 120,
 	types: ["Metal"],
 	stage: "Stage1",
+	dexId: [625],
 
 	attacks: [{
 		cost: ["Metal"],

--- a/data/Mega Evolution/Ascended Heroes/148.ts
+++ b/data/Mega Evolution/Ascended Heroes/148.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 170,
 	types: ["Metal"],
 	stage: "Stage2",
+	dexId: [983],
 
 	abilities: [{
 		type: "Ability",

--- a/data/Mega Evolution/Ascended Heroes/149.ts
+++ b/data/Mega Evolution/Ascended Heroes/149.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 190,
 	types: ["Metal"],
 	stage: "Basic",
+	dexId: [777],
 
 	attacks: [{
 		cost: ["Metal"],

--- a/data/Mega Evolution/Ascended Heroes/150.ts
+++ b/data/Mega Evolution/Ascended Heroes/150.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 80,
 	types: ["Dragon"],
 	stage: "Basic",
+	dexId: [147],
 
 	attacks: [{
 		cost: ["Water", "Lightning"],

--- a/data/Mega Evolution/Ascended Heroes/151.ts
+++ b/data/Mega Evolution/Ascended Heroes/151.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 100,
 	types: ["Dragon"],
 	stage: "Stage1",
+	dexId: [148],
 
 	abilities: [{
 		type: "Ability",

--- a/data/Mega Evolution/Ascended Heroes/152.ts
+++ b/data/Mega Evolution/Ascended Heroes/152.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 370,
 	types: ["Dragon"],
 	stage: "Stage2",
+	dexId: [149],
 
 	abilities: [{
 		type: "Ability",

--- a/data/Mega Evolution/Ascended Heroes/153.ts
+++ b/data/Mega Evolution/Ascended Heroes/153.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 120,
 	types: ["Dragon"],
 	stage: "Basic",
+	dexId: [384],
 
 	attacks: [{
 		cost: ["Lightning", "Colorless"],

--- a/data/Mega Evolution/Ascended Heroes/154.ts
+++ b/data/Mega Evolution/Ascended Heroes/154.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 130,
 	types: ["Dragon"],
 	stage: "Basic",
+	dexId: [643],
 
 	attacks: [{
 		cost: ["Fire", "Lightning"],

--- a/data/Mega Evolution/Ascended Heroes/156.ts
+++ b/data/Mega Evolution/Ascended Heroes/156.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 70,
 	types: ["Dragon"],
 	stage: "Basic",
+	dexId: [714],
 
 	attacks: [{
 		cost: ["Colorless"],

--- a/data/Mega Evolution/Ascended Heroes/157.ts
+++ b/data/Mega Evolution/Ascended Heroes/157.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 120,
 	types: ["Dragon"],
 	stage: "Stage1",
+	dexId: [715],
 
 	attacks: [{
 		cost: ["Colorless", "Colorless"],

--- a/data/Mega Evolution/Ascended Heroes/158.ts
+++ b/data/Mega Evolution/Ascended Heroes/158.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 70,
 	types: ["Dragon"],
 	stage: "Basic",
+	dexId: [885],
 
 	attacks: [{
 		cost: ["Psychic"],

--- a/data/Mega Evolution/Ascended Heroes/159.ts
+++ b/data/Mega Evolution/Ascended Heroes/159.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 90,
 	types: ["Dragon"],
 	stage: "Stage1",
+	dexId: [886],
 
 	abilities: [{
 		type: "Ability",

--- a/data/Mega Evolution/Ascended Heroes/160.ts
+++ b/data/Mega Evolution/Ascended Heroes/160.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 320,
 	types: ["Dragon"],
 	stage: "Stage2",
+	dexId: [887],
 
 	attacks: [{
 		cost: ["Colorless"],

--- a/data/Mega Evolution/Ascended Heroes/161.ts
+++ b/data/Mega Evolution/Ascended Heroes/161.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 70,
 	types: ["Colorless"],
 	stage: "Basic",
+	dexId: [52],
 
 	attacks: [{
 		cost: ["Colorless"],

--- a/data/Mega Evolution/Ascended Heroes/165.ts
+++ b/data/Mega Evolution/Ascended Heroes/165.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 60,
 	types: ["Colorless"],
 	stage: "Basic",
+	dexId: [300],
 
 	attacks: [{
 		cost: ["Colorless"],

--- a/data/Mega Evolution/Ascended Heroes/166.ts
+++ b/data/Mega Evolution/Ascended Heroes/166.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 100,
 	types: ["Colorless"],
 	stage: "Stage1",
+	dexId: [301],
 
 	attacks: [{
 		cost: ["Colorless"],

--- a/data/Mega Evolution/Ascended Heroes/167.ts
+++ b/data/Mega Evolution/Ascended Heroes/167.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 200,
 	types: ["Colorless"],
 	stage: "Basic",
+	dexId: [335],
 
 	attacks: [{
 		cost: ["Colorless"],

--- a/data/Mega Evolution/Ascended Heroes/171.ts
+++ b/data/Mega Evolution/Ascended Heroes/171.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 70,
 	types: ["Colorless"],
 	stage: "Basic",
+	dexId: [479],
 
 	abilities: [{
 		type: "Ability",

--- a/data/Mega Evolution/Ascended Heroes/172.ts
+++ b/data/Mega Evolution/Ascended Heroes/172.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 270,
 	types: ["Colorless"],
 	stage: "Basic",
+	dexId: [531],
 
 	attacks: [{
 		cost: ["Colorless"],

--- a/data/Mega Evolution/Ascended Heroes/176.ts
+++ b/data/Mega Evolution/Ascended Heroes/176.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 130,
 	types: ["Colorless"],
 	stage: "Basic",
+	dexId: [780],
 
 	attacks: [{
 		cost: ["Colorless", "Colorless"],

--- a/data/Mega Evolution/Ascended Heroes/177.ts
+++ b/data/Mega Evolution/Ascended Heroes/177.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 110,
 	types: ["Colorless"],
 	stage: "Basic",
+	dexId: [845],
 
 	attacks: [{
 		cost: ["Colorless"],

--- a/data/Mega Evolution/Ascended Heroes/178.ts
+++ b/data/Mega Evolution/Ascended Heroes/178.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 120,
 	types: ["Colorless"],
 	stage: "Basic",
+	dexId: [1024],
 
 	attacks: [{
 		cost: ["Colorless"],

--- a/data/Mega Evolution/Ascended Heroes/179.ts
+++ b/data/Mega Evolution/Ascended Heroes/179.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 230,
 	types: ["Colorless"],
 	stage: "Basic",
+	dexId: [1024],
 
 	attacks: [{
 		cost: ["Colorless", "Colorless"],

--- a/data/Mega Evolution/Ascended Heroes/218.ts
+++ b/data/Mega Evolution/Ascended Heroes/218.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 80,
 	types: ["Grass"],
 	stage: "Basic",
+	dexId: [114],
 
 	abilities: [{
 		type: "Ability",

--- a/data/Mega Evolution/Ascended Heroes/219.ts
+++ b/data/Mega Evolution/Ascended Heroes/219.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 130,
 	types: ["Grass"],
 	stage: "Stage2",
+	dexId: [267],
 
 	attacks: [{
 		cost: ["Grass"],

--- a/data/Mega Evolution/Ascended Heroes/220.ts
+++ b/data/Mega Evolution/Ascended Heroes/220.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 140,
 	types: ["Grass"],
 	stage: "Stage2",
+	dexId: [269],
 
 	abilities: [{
 		type: "Ability",

--- a/data/Mega Evolution/Ascended Heroes/221.ts
+++ b/data/Mega Evolution/Ascended Heroes/221.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 30,
 	types: ["Grass"],
 	stage: "Basic",
+	dexId: [406],
 
 	attacks: [{
 		name: {

--- a/data/Mega Evolution/Ascended Heroes/222.ts
+++ b/data/Mega Evolution/Ascended Heroes/222.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 130,
 	types: ["Fire"],
 	stage: "Stage1",
+	dexId: [219],
 
 	abilities: [{
 		type: "Ability",

--- a/data/Mega Evolution/Ascended Heroes/223.ts
+++ b/data/Mega Evolution/Ascended Heroes/223.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 80,
 	types: ["Fire"],
 	stage: "Basic",
+	dexId: [322],
 
 	abilities: [{
 		type: "Ability",

--- a/data/Mega Evolution/Ascended Heroes/224.ts
+++ b/data/Mega Evolution/Ascended Heroes/224.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 120,
 	types: ["Fire"],
 	stage: "Stage1",
+	dexId: [758],
 
 	attacks: [{
 		cost: ["Colorless", "Colorless"],

--- a/data/Mega Evolution/Ascended Heroes/225.ts
+++ b/data/Mega Evolution/Ascended Heroes/225.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 70,
 	types: ["Fire"],
 	stage: "Basic",
+	dexId: [813],
 
 	attacks: [{
 		cost: ["Colorless"],

--- a/data/Mega Evolution/Ascended Heroes/226.ts
+++ b/data/Mega Evolution/Ascended Heroes/226.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 70,
 	types: ["Water"],
 	stage: "Basic",
+	dexId: [54],
 
 	abilities: [{
 		type: "Ability",

--- a/data/Mega Evolution/Ascended Heroes/227.ts
+++ b/data/Mega Evolution/Ascended Heroes/227.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 70,
 	types: ["Water"],
 	stage: "Basic",
+	dexId: [361],
 
 	attacks: [{
 		cost: ["Water"],

--- a/data/Mega Evolution/Ascended Heroes/228.ts
+++ b/data/Mega Evolution/Ascended Heroes/228.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 100,
 	types: ["Water"],
 	stage: "Stage1",
+	dexId: [461],
 
 	attacks: [{
 		cost: ["Water"],

--- a/data/Mega Evolution/Ascended Heroes/229.ts
+++ b/data/Mega Evolution/Ascended Heroes/229.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 120,
 	types: ["Lightning"],
 	stage: "Stage1",
+	dexId: [695],
 
 	abilities: [{
 		type: "Ability",

--- a/data/Mega Evolution/Ascended Heroes/230.ts
+++ b/data/Mega Evolution/Ascended Heroes/230.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 160,
 	types: ["Lightning"],
 	stage: "Stage2",
+	dexId: [738],
 
 	attacks: [{
 		cost: ["Lightning"],

--- a/data/Mega Evolution/Ascended Heroes/231.ts
+++ b/data/Mega Evolution/Ascended Heroes/231.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 60,
 	types: ["Lightning"],
 	stage: "Basic",
+	dexId: [940],
 
 	attacks: [{
 		cost: ["Lightning"],

--- a/data/Mega Evolution/Ascended Heroes/232.ts
+++ b/data/Mega Evolution/Ascended Heroes/232.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 70,
 	types: ["Psychic"],
 	stage: "Basic",
+	dexId: [183],
 
 	attacks: [{
 		cost: ["Colorless"],

--- a/data/Mega Evolution/Ascended Heroes/233.ts
+++ b/data/Mega Evolution/Ascended Heroes/233.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 60,
 	types: ["Psychic"],
 	stage: "Basic",
+	dexId: [200],
 
 	attacks: [{
 		cost: ["Psychic"],

--- a/data/Mega Evolution/Ascended Heroes/234.ts
+++ b/data/Mega Evolution/Ascended Heroes/234.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 90,
 	types: ["Psychic"],
 	stage: "Stage1",
+	dexId: [354],
 
 	attacks: [{
 		cost: ["Psychic"],

--- a/data/Mega Evolution/Ascended Heroes/235.ts
+++ b/data/Mega Evolution/Ascended Heroes/235.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 140,
 	types: ["Psychic"],
 	stage: "Stage2",
+	dexId: [468],
 
 	abilities: [{
 		type: "Ability",

--- a/data/Mega Evolution/Ascended Heroes/236.ts
+++ b/data/Mega Evolution/Ascended Heroes/236.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 120,
 	types: ["Psychic"],
 	stage: "Stage1",
+	dexId: [685],
 
 	attacks: [{
 		cost: ["Psychic"],

--- a/data/Mega Evolution/Ascended Heroes/238.ts
+++ b/data/Mega Evolution/Ascended Heroes/238.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 60,
 	types: ["Psychic"],
 	stage: "Basic",
+	dexId: [778],
 
 	attacks: [{
 		cost: ["Psychic", "Colorless"],

--- a/data/Mega Evolution/Ascended Heroes/240.ts
+++ b/data/Mega Evolution/Ascended Heroes/240.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 100,
 	types: ["Fighting"],
 	stage: "Basic",
+	dexId: [237],
 
 	attacks: [{
 		cost: ["Colorless"],

--- a/data/Mega Evolution/Ascended Heroes/241.ts
+++ b/data/Mega Evolution/Ascended Heroes/241.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 120,
 	types: ["Fighting"],
 	stage: "Stage1",
+	dexId: [308],
 
 	attacks: [{
 		cost: ["Fighting"],

--- a/data/Mega Evolution/Ascended Heroes/242.ts
+++ b/data/Mega Evolution/Ascended Heroes/242.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 90,
 	types: ["Fighting"],
 	stage: "Basic",
+	dexId: [703],
 
 	abilities: [{
 		type: "Ability",

--- a/data/Mega Evolution/Ascended Heroes/243.ts
+++ b/data/Mega Evolution/Ascended Heroes/243.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 120,
 	types: ["Darkness"],
 	stage: "Stage1",
+	dexId: [262],
 
 	attacks: [{
 		cost: ["Darkness", "Colorless"],

--- a/data/Mega Evolution/Ascended Heroes/244.ts
+++ b/data/Mega Evolution/Ascended Heroes/244.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 70,
 	types: ["Darkness"],
 	stage: "Basic",
+	dexId: [442],
 
 	attacks: [{
 		cost: ["Colorless"],

--- a/data/Mega Evolution/Ascended Heroes/245.ts
+++ b/data/Mega Evolution/Ascended Heroes/245.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 170,
 	types: ["Darkness"],
 	stage: "Stage2",
+	dexId: [862],
 
 	attacks: [{
 		cost: ["Darkness", "Colorless"],

--- a/data/Mega Evolution/Ascended Heroes/246.ts
+++ b/data/Mega Evolution/Ascended Heroes/246.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 90,
 	types: ["Metal"],
 	stage: "Basic",
+	dexId: [303],
 
 	attacks: [{
 		cost: ["Colorless"],

--- a/data/Mega Evolution/Ascended Heroes/247.ts
+++ b/data/Mega Evolution/Ascended Heroes/247.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 70,
 	types: ["Dragon"],
 	stage: "Basic",
+	dexId: [885],
 
 	attacks: [{
 		cost: ["Psychic"],

--- a/data/Mega Evolution/Ascended Heroes/248.ts
+++ b/data/Mega Evolution/Ascended Heroes/248.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 90,
 	types: ["Dragon"],
 	stage: "Stage1",
+	dexId: [886],
 
 	abilities: [{
 		type: "Ability",

--- a/data/Mega Evolution/Ascended Heroes/250.ts
+++ b/data/Mega Evolution/Ascended Heroes/250.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 70,
 	types: ["Colorless"],
 	stage: "Basic",
+	dexId: [479],
 
 	abilities: [{
 		type: "Ability",

--- a/data/Mega Evolution/Ascended Heroes/251.ts
+++ b/data/Mega Evolution/Ascended Heroes/251.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 200,
 	types: ["Grass"],
 	stage: "Basic",
+	dexId: [906],
 
 	attacks: [{
 		cost: ["Colorless"],

--- a/data/Mega Evolution/Ascended Heroes/252.ts
+++ b/data/Mega Evolution/Ascended Heroes/252.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 210,
 	types: ["Fighting"],
 	stage: "Basic",
+	dexId: [618],
 
 	attacks: [{
 		cost: ["Fighting"],

--- a/data/Mega Evolution/Ascended Heroes/253.ts
+++ b/data/Mega Evolution/Ascended Heroes/253.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 270,
 	types: ["Colorless"],
 	stage: "Basic",
+	dexId: [531],
 
 	attacks: [{
 		cost: ["Colorless"],

--- a/data/Mega Evolution/Ascended Heroes/265.ts
+++ b/data/Mega Evolution/Ascended Heroes/265.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 310,
 	types: ["Water"],
 	stage: "Stage1",
+	dexId: [478],
 
 	attacks: [{
 		cost: ["Water"],

--- a/data/Mega Evolution/Ascended Heroes/266.ts
+++ b/data/Mega Evolution/Ascended Heroes/266.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 350,
 	types: ["Lightning"],
 	stage: "Stage2",
+	dexId: [604],
 
 	attacks: [{
 		cost: ["Lightning", "Lightning"],

--- a/data/Mega Evolution/Ascended Heroes/267.ts
+++ b/data/Mega Evolution/Ascended Heroes/267.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 270,
 	types: ["Psychic"],
 	stage: "Basic",
+	dexId: [719],
 
 	abilities: [{
 		type: "Ability",

--- a/data/Mega Evolution/Ascended Heroes/268.ts
+++ b/data/Mega Evolution/Ascended Heroes/268.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 250,
 	types: ["Fighting"],
 	stage: "Basic",
+	dexId: [701],
 
 	abilities: [{
 		type: "Ability",

--- a/data/Mega Evolution/Ascended Heroes/269.ts
+++ b/data/Mega Evolution/Ascended Heroes/269.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 350,
 	types: ["Darkness"],
 	stage: "Stage2",
+	dexId: [94],
 
 	abilities: [{
 		type: "Ability",

--- a/data/Mega Evolution/Ascended Heroes/270.ts
+++ b/data/Mega Evolution/Ascended Heroes/270.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 330,
 	types: ["Darkness"],
 	stage: "Stage1",
+	dexId: [560],
 
 	abilities: [{
 		type: "Ability",

--- a/data/Mega Evolution/Ascended Heroes/271.ts
+++ b/data/Mega Evolution/Ascended Heroes/271.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 370,
 	types: ["Dragon"],
 	stage: "Stage2",
+	dexId: [149],
 
 	abilities: [{
 		type: "Ability",

--- a/data/Mega Evolution/Ascended Heroes/272.ts
+++ b/data/Mega Evolution/Ascended Heroes/272.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 360,
 	types: ["Grass"],
 	stage: "Stage2",
+	dexId: [154],
 
 	attacks: [{
 		cost: ["Colorless", "Colorless", "Colorless"],

--- a/data/Mega Evolution/Ascended Heroes/273.ts
+++ b/data/Mega Evolution/Ascended Heroes/273.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 380,
 	types: ["Fire"],
 	stage: "Stage2",
+	dexId: [500],
 
 	attacks: [{
 		cost: ["Fire", "Fire", "Colorless"],

--- a/data/Mega Evolution/Ascended Heroes/274.ts
+++ b/data/Mega Evolution/Ascended Heroes/274.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 370,
 	types: ["Water"],
 	stage: "Stage2",
+	dexId: [160],
 
 	attacks: [{
 		cost: ["Water", "Water", "Colorless"],

--- a/data/Mega Evolution/Ascended Heroes/275.ts
+++ b/data/Mega Evolution/Ascended Heroes/275.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 310,
 	types: ["Water"],
 	stage: "Stage1",
+	dexId: [478],
 
 	attacks: [{
 		cost: ["Water"],

--- a/data/Mega Evolution/Ascended Heroes/276.ts
+++ b/data/Mega Evolution/Ascended Heroes/276.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 200,
 	types: ["Lightning"],
 	stage: "Basic",
+	dexId: [25],
 
 	attacks: [{
 		cost: ["Lightning", "Lightning", "Colorless"],

--- a/data/Mega Evolution/Ascended Heroes/277.ts
+++ b/data/Mega Evolution/Ascended Heroes/277.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 200,
 	types: ["Lightning"],
 	stage: "Basic",
+	dexId: [25],
 
 	abilities: [{
 		type: "Ability",

--- a/data/Mega Evolution/Ascended Heroes/278.ts
+++ b/data/Mega Evolution/Ascended Heroes/278.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 350,
 	types: ["Lightning"],
 	stage: "Stage2",
+	dexId: [604],
 
 	attacks: [{
 		cost: ["Lightning", "Lightning"],

--- a/data/Mega Evolution/Ascended Heroes/282.ts
+++ b/data/Mega Evolution/Ascended Heroes/282.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 270,
 	types: ["Psychic"],
 	stage: "Basic",
+	dexId: [719],
 
 	abilities: [{
 		type: "Ability",

--- a/data/Mega Evolution/Ascended Heroes/283.ts
+++ b/data/Mega Evolution/Ascended Heroes/283.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 250,
 	types: ["Fighting"],
 	stage: "Basic",
+	dexId: [701],
 
 	abilities: [{
 		type: "Ability",

--- a/data/Mega Evolution/Ascended Heroes/284.ts
+++ b/data/Mega Evolution/Ascended Heroes/284.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 350,
 	types: ["Darkness"],
 	stage: "Stage2",
+	dexId: [94],
 
 	abilities: [{
 		type: "Ability",

--- a/data/Mega Evolution/Ascended Heroes/285.ts
+++ b/data/Mega Evolution/Ascended Heroes/285.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 330,
 	types: ["Darkness"],
 	stage: "Stage1",
+	dexId: [560],
 
 	abilities: [{
 		type: "Ability",

--- a/data/Mega Evolution/Ascended Heroes/288.ts
+++ b/data/Mega Evolution/Ascended Heroes/288.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 210,
 	types: ["Darkness"],
 	stage: "Basic",
+	dexId: [1016],
 
 	abilities: [{
 		type: "Ability",

--- a/data/Mega Evolution/Ascended Heroes/290.ts
+++ b/data/Mega Evolution/Ascended Heroes/290.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 370,
 	types: ["Dragon"],
 	stage: "Stage2",
+	dexId: [149],
 
 	abilities: [{
 		type: "Ability",

--- a/data/Mega Evolution/Ascended Heroes/294.ts
+++ b/data/Mega Evolution/Ascended Heroes/294.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 360,
 	types: ["Fire"],
 	stage: "Stage2",
+	dexId: [6],
 
 	attacks: [{
 		cost: ["Fire", "Fire", "Colorless"],

--- a/data/Mega Evolution/Ascended Heroes/295.ts
+++ b/data/Mega Evolution/Ascended Heroes/295.ts
@@ -20,6 +20,7 @@ const card: Card = {
 	hp: 370,
 	types: ["Dragon"],
 	stage: "Stage2",
+	dexId: [149],
 
 	abilities: [{
 		type: "Ability",


### PR DESCRIPTION
# Add missing dexId fields to Pokemon cards
The update was performed using the [tcg_dex_api_parser](https://github.com/Tydragon00/tcg_dex_api_parser) script, which:

1. Scanned all existing cards to build a name → dexId mapping
2. Identified cards missing the `dexId` field
3. Automatically populated the missing dexId based on the Pokemon name
4. Handled special cases like:
   - "Mega Charizard X" → uses Charizard's dexId (6)
   - "Pikachu ex" → uses Pikachu's dexId (25)
