### PR TITLE
fix(data): Populate missing card data for McDonald's Collection 2014

### DIFF
--- a/data/McDonald's Collection/Macdonald's Collection 2014/1.ts
+++ b/data/McDonald's Collection/Macdonald's Collection 2014/1.ts
@@ -6,6 +6,10 @@ const card: Card = {
 		13,
 	],
 	set: Set,
+	illustrator: 'Akira Komayama',
+	description: {
+		en: "Often found in forests and grasslands. It has a sharp, toxic barb of around two inches on top of its head."
+	},
 	variants: {
 		normal: false,
 		reverse: false,
@@ -32,14 +36,26 @@ const card: Card = {
 				"Grass",
 			],
 			name: {
+				en: "String Shot",
 				fr: "Sécrétion",
 			},
 			damage: "10",
 			effect: {
+				en: "Flip a coin. If heads, your opponent's Active Pokémon is now Paralyzed.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Actif de votre adversaire est maintenant Paralysé.",
 			},
 		},
 	],
+	weaknesses	: [
+		{
+			type: "Fire",
+			value: "×2"
+		},
+	],
+	resistances: [
+		
+	],
+	retreat: 1,
 }
 
 export default card

--- a/data/McDonald's Collection/Macdonald's Collection 2014/10.ts
+++ b/data/McDonald's Collection/Macdonald's Collection 2014/10.ts
@@ -5,6 +5,10 @@ const card: Card = {
 	dexId: [
 		659,
 	],
+	illustrator: "5ban Graphics",
+	description: {
+		en: "They use their large ears to dig burrows. They will dig the whole night through."
+	},
 	set: Set,
 	variants: {
 		normal: false,
@@ -33,11 +37,22 @@ const card: Card = {
 				"Colorless",
 			],
 			name: {
+				en: "Tackle",
 				fr: "Charge",
 			},
 			damage: "20",
 		},
 	],
+	weaknesses: [
+		{
+			type: "Fighting",
+			value: "×2"
+		},
+	],
+	resistances: [
+		
+	],
+	retreat: 2,
 }
 
 export default card

--- a/data/McDonald's Collection/Macdonald's Collection 2014/11.ts
+++ b/data/McDonald's Collection/Macdonald's Collection 2014/11.ts
@@ -5,6 +5,10 @@ const card: Card = {
 	dexId: [
 		661,
 	],
+	illustrator: "5ban Graphics",
+	description: {
+		en: "These friendly Pokémon send signals to one another with beautiful chirps and tail-feather movements."
+	},
 	set: Set,
 	variants: {
 		normal: false,
@@ -32,14 +36,29 @@ const card: Card = {
 				"Colorless",
 			],
 			name: {
+				en: "Razor Wind",
 				fr: "Coupe-Vent",
 			},
 			damage: "20",
 			effect: {
+				en: "Flip a coin. If tails, this attack does nothing.",
 				fr: "Lancez une pièce. Si c'est pile, cette attaque ne fait rien.",
 			},
 		},
 	],
+	weaknesses: [
+		{
+			type: "Lightning",
+			value: "×2"
+		}
+	],
+	resistances: [
+		{
+			type: "Fighting",
+			value: "-20"
+		}
+	],
+	retreat: 1,
 }
 
 export default card

--- a/data/McDonald's Collection/Macdonald's Collection 2014/12.ts
+++ b/data/McDonald's Collection/Macdonald's Collection 2014/12.ts
@@ -5,6 +5,10 @@ const card: Card = {
 	dexId: [
 		676,
 	],
+	illustrator: "5ban Graphics",
+	description: {
+		en: "Trimming its fluffy fur not only makes it more elegant but also increases the swiftness of its movements."
+	},
 	set: Set,
 	variants: {
 		normal: false,
@@ -33,10 +37,12 @@ const card: Card = {
 				"Colorless",
 			],
 			name: {
+				en: "Tight Jaw",
 				fr: "Mâchoire Serrée",
 			},
 			damage: "20",
 			effect: {
+				en: "Flip a coin. If heads, your opponent's Active Pokémon is now Paralyzed.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Actif de votre adversaire est maintenant Paralysé.",
 			},
 		},
@@ -47,11 +53,22 @@ const card: Card = {
 				"Colorless",
 			],
 			name: {
+				en: "Sharp Fang",
 				fr: "Croc Aiguisé",
 			},
 			damage: "50",
 		},
 	],
+	weaknesses: [
+		{
+			type: "Fighting",
+			value: "×2"
+		},
+	],
+	resistances: [
+
+	],
+	retreat: 1,
 }
 
 export default card

--- a/data/McDonald's Collection/Macdonald's Collection 2014/2.ts
+++ b/data/McDonald's Collection/Macdonald's Collection 2014/2.ts
@@ -6,6 +6,11 @@ const card: Card = {
 		650,
 	],
 	set: Set,
+	illustrator: '5ban Graphics',
+	category: "Pokemon",
+	description: {
+		en: "The quills on its head are usually soft. When it flexes them, the points become so hard and sharp that they can pierce rock.",
+	},
 	variants: {
 		normal: false,
 		reverse: false,
@@ -17,7 +22,7 @@ const card: Card = {
 		fr: "Marisson",
 	},
 	rarity: "None",
-	category: "Pokemon",
+	
 	hp: 60,
 	types: [
 		"Grass",
@@ -32,6 +37,7 @@ const card: Card = {
 				"Grass",
 			],
 			name: {
+				en: "Vine Whip",
 				fr: "Fouet Lianes",
 			},
 			damage: "10",
@@ -42,11 +48,22 @@ const card: Card = {
 				"Colorless",
 			],
 			name: {
+				en: "Seed Bomb",
 				fr: "Canon Graine",
 			},
 			damage: "20",
 		},
 	],
+	weaknesses: [
+		{
+			type: "Fire",
+			value: "×2"
+		},
+	],
+	resistances: [
+		
+	],
+	retreat: 1,
 }
 
 export default card

--- a/data/McDonald's Collection/Macdonald's Collection 2014/3.ts
+++ b/data/McDonald's Collection/Macdonald's Collection 2014/3.ts
@@ -5,7 +5,11 @@ const card: Card = {
 	dexId: [
 		653,
 	],
+	illustrator: "5ban Graphics",
 	set: Set,
+	description: {
+		en: "Eating a twig fills it with energy, and its roomy ears give vent to air hotter than 390 degrees Fahrenheit."
+	},
 	variants: {
 		normal: false,
 		reverse: false,
@@ -32,6 +36,7 @@ const card: Card = {
 				"Fire",
 			],
 			name: {
+				en: "Scratch",
 				fr: "Griffe",
 			},
 			damage: "10",
@@ -42,11 +47,22 @@ const card: Card = {
 				"Colorless",
 			],
 			name: {
+				en: "Live Coal",
 				fr: "Charbon Mutant",
 			},
 			damage: "20",
 		},
 	],
+	weaknesses: [
+		{
+			type: "Water",
+			value: "×2"
+		},
+	],
+	resistances: [
+		
+	],
+	retreat: 1,
 }
 
 export default card

--- a/data/McDonald's Collection/Macdonald's Collection 2014/4.ts
+++ b/data/McDonald's Collection/Macdonald's Collection 2014/4.ts
@@ -6,6 +6,10 @@ const card: Card = {
 		656,
 	],
 	set: Set,
+	illustrator: '5ban Graphics',
+	description: {
+		en: "It secretes flexible bubbles from its chest and back. The bubbles reduce the damage it would otherwise take when attacked."
+	},
 	variants: {
 		normal: false,
 		reverse: false,
@@ -32,6 +36,7 @@ const card: Card = {
 				"Water",
 			],
 			name: {
+				en: "Pound",
 				fr: "Écras'Face",
 			},
 			damage: "10",
@@ -42,11 +47,23 @@ const card: Card = {
 				"Colorless",
 			],
 			name: {
+				en: "Water Drip",
 				fr: "Goutte à Goutte",
 			},
 			damage: "20",
 		},
 	],
+	weaknesses: [
+		{
+			type: "Grass",
+			value: "×2"
+		},
+	],
+	resistances: [
+		
+	],
+	retreat: 1,
+
 }
 
 export default card

--- a/data/McDonald's Collection/Macdonald's Collection 2014/5.ts
+++ b/data/McDonald's Collection/Macdonald's Collection 2014/5.ts
@@ -6,6 +6,10 @@ const card: Card = {
 		25,
 	],
 	set: Set,
+	illustrator: "MAHOU",
+	description: {
+		en: "It raises its tail to check its surroundings. The tail is sometimes struck by lightning in this pose.",
+	},
 	variants: {
 		normal: false,
 		reverse: false,
@@ -32,9 +36,11 @@ const card: Card = {
 				"Colorless",
 			],
 			name: {
+				en: "Nuzzle",
 				fr: "Frotte-Frimousse",
 			},
 			effect: {
+				en: "Flip a coin. If heads, your opponent's Active Pokémon is now Paralyzed.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Actif de votre adversaire est maintenant Paralysé.",
 			},
 		},
@@ -44,14 +50,29 @@ const card: Card = {
 				"Colorless",
 			],
 			name: {
+				en: "Quick Attack",
 				fr: "Vive-Attaque",
 			},
 			damage: "20+",
 			effect: {
+				en: "Flip a coin. If heads, this attack does 10 more damage.",
 				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 10 dégâts supplémentaires.",
 			},
 		},
 	],
+	weaknesses: [
+		{
+			type: "Fighting",
+			value: "×2"
+		},
+	],
+	resistances: [
+		{
+			type: "Metal",
+			value: "-20"
+		}
+	],
+	retreat: 1,
 }
 
 export default card

--- a/data/McDonald's Collection/Macdonald's Collection 2014/6.ts
+++ b/data/McDonald's Collection/Macdonald's Collection 2014/6.ts
@@ -5,6 +5,10 @@ const card: Card = {
 	dexId: [
 		686,
 	],
+	illustrator: "5ban Graphics",
+	description: {
+		en: "Opponents who stare at the flashing of the light-emitting spots on its body become dazed and lose their will to fight."
+	},
 	set: Set,
 	variants: {
 		normal: false,
@@ -32,11 +36,25 @@ const card: Card = {
 				"Darkness",
 			],
 			name: {
+				en: "Peck",
 				fr: "Picpic",
 			},
 			damage: "10",
 		},
 	],
+	weaknesses: [
+		{
+			type: "Fighting",
+			value: "×2"
+		},
+	],
+	resistances: [
+		{
+			type: "Psychic",
+			value: "-20"
+		}
+	],
+	retreat: 1,
 }
 
 export default card

--- a/data/McDonald's Collection/Macdonald's Collection 2014/7.ts
+++ b/data/McDonald's Collection/Macdonald's Collection 2014/7.ts
@@ -5,6 +5,10 @@ const card: Card = {
 	dexId: [
 		679,
 	],
+	illustrator: "5ban Graphics",
+	description: {
+		en: "Apparently this Pokémon is born when a departed spirit inhabits a sword. It attaches itself to people and drinks their life force."
+	},
 	set: Set,
 	variants: {
 		normal: false,
@@ -33,14 +37,29 @@ const card: Card = {
 				"Colorless",
 			],
 			name: {
+				en: "Continuous Slice",
 				fr: "Perpétranche",
 			},
 			damage: "30×",
 			effect: {
+				en: "Flip a coin until you get tails. This attack does 30 damage times the number of heads.",
 				fr: "Lancez une pièce jusqu'à ce que vous obteniez un côté pile. Cette attaque inflige 30 dégâts multipliés par le nombre de côtés face.",
 			},
 		},
 	],
+	weaknesses: [
+		{
+			type: "Fire",
+			value: "×2"
+		},
+	],
+	resistances: [
+		{
+			type: "Psychic",
+			value: "-20"
+		}
+	],
+	retreat: 2,
 }
 
 export default card

--- a/data/McDonald's Collection/Macdonald's Collection 2014/8.ts
+++ b/data/McDonald's Collection/Macdonald's Collection 2014/8.ts
@@ -6,6 +6,10 @@ const card: Card = {
 		209,
 	],
 	set: Set,
+	illustrator: "Naoki Saito",
+	description: {
+		en: "It has an active, playful nature. Many women like to frolic with it because of its affectionate ways.",
+	},
 	variants: {
 		normal: false,
 		reverse: false,
@@ -33,11 +37,26 @@ const card: Card = {
 				"Colorless",
 			],
 			name: {
+				en: "Headbutt",
 				fr: "Coup d'Boule",
 			},
 			damage: "20",
 		},
 	],
+	weaknesses: [
+		{
+			type: "Metal",
+			value: "×2"
+		},
+	],
+	resistances: [
+		{
+			type: "Darkness",
+			value: "-20"
+		}
+	],
+	retreat: 2,
+
 }
 
 export default card

--- a/data/McDonald's Collection/Macdonald's Collection 2014/9.ts
+++ b/data/McDonald's Collection/Macdonald's Collection 2014/9.ts
@@ -5,6 +5,10 @@ const card: Card = {
 	dexId: [
 		684,
 	],
+	illustrator: "5ban Graphics",
+	description: {
+		en: "To entangle its opponents in battle, it extrudes white threads as sweet and sticky as cotton candy."
+	},
 	set: Set,
 	variants: {
 		normal: false,
@@ -32,11 +36,28 @@ const card: Card = {
 				"Fairy",
 			],
 			name: {
+				en: "Draining Kiss",
 				fr: "Vampibaiser",
 			},
 			damage: "10",
+			effect: {
+				en: "Heal 10 damage from this Pokémon."
+			}
 		},
 	],
+	weaknesses: [
+		{
+			type: "Metal",
+			value: "×2"
+		},
+	],
+	resistances: [
+		{
+			type: "Darkness",
+			value: "-20"
+		}
+	],
+	retreat: 1,
 }
 
 export default card


### PR DESCRIPTION
Added missing data for cards in McDonald's Collection 2014 (2014xy).
- Added missing Attack names (e.g., Weedle "String Shot").
- Added missing Illustrators (e.g., Akira Komayama).
- Added missing Flavor text descriptions
- Populated missing Weakness, Resistance, and Retreat Costs.

Verified data against physical card scans and Bulbapedia. Reference: https://bulbapedia.bulbagarden.net/wiki/McDonald%27s_Collection_2014_(TCG)

<!--
Contribution guide: https://github.com/tcgdex/cards-database/blob/master/CONTRIBUTING.md
please submit changes up to 1 set at most.
-->

closes # <!-- Indicate the issue number here -->

## Changes

<!-- Quickly explain your changes -->

## Details

<!-- You can also give more details about your changes -->

