### PR TITLE
feat(data-asia): Add Series and Sets for Simplified Chinese

### DIFF
--- a/data-asia/S.ts
+++ b/data-asia/S.ts
@@ -3,6 +3,7 @@ import { Serie } from '../interfaces'
 const serie: Serie = {
 	name: {
 		ja: '剣と盾',
+		'zh-cn': '剑&盾',
 		'zh-tw': '劍＆盾',
 		id: 'Pedang & Perisai',
 		th: 'ซอร์ด แอนด์ ชีลด์',

--- a/data-asia/S/CS1.5C.ts
+++ b/data-asia/S/CS1.5C.ts
@@ -1,0 +1,18 @@
+import { Set } from '../../interfaces'
+import serie from '../S'
+
+const set: Set = {
+	id: 'CS1.5C',
+	name: {
+		'zh-cn': '极巨攻防',
+	},
+
+	serie: serie,
+
+	cardCount: {
+		official: 55
+	},
+	releaseDate: '2023-06-28',
+}
+
+export default set

--- a/data-asia/S/CS1aC.ts
+++ b/data-asia/S/CS1aC.ts
@@ -1,0 +1,18 @@
+import { Set } from '../../interfaces'
+import serie from '../S'
+
+const set: Set = {
+	id: 'CS1aC',
+	name: {
+		'zh-cn': '横空出世 赫',
+	},
+
+	serie: serie,
+
+	cardCount: {
+		official: 135
+	},
+	releaseDate: '2023-05-19',
+}
+
+export default set

--- a/data-asia/S/CS1bC.ts
+++ b/data-asia/S/CS1bC.ts
@@ -1,0 +1,18 @@
+import { Set } from '../../interfaces'
+import serie from '../S'
+
+const set: Set = {
+	id: 'CS1bC',
+	name: {
+		'zh-cn': '极巨争锋 焰',
+	},
+
+	serie: serie,
+
+	cardCount: {
+		official: 136
+	},
+	releaseDate: '2023-05-19',
+}
+
+export default set

--- a/data-asia/S/CS2.5C.ts
+++ b/data-asia/S/CS2.5C.ts
@@ -1,0 +1,18 @@
+import { Set } from '../../interfaces'
+import serie from '../S'
+
+const set: Set = {
+	id: 'CS2.5C',
+	name: {
+		'zh-cn': '璀璨反击',
+	},
+
+	serie: serie,
+
+	cardCount: {
+		official: 59
+	},
+	releaseDate: '2023-09-29',
+}
+
+export default set

--- a/data-asia/S/CS2aC.ts
+++ b/data-asia/S/CS2aC.ts
@@ -1,0 +1,18 @@
+import { Set } from '../../interfaces'
+import serie from '../S'
+
+const set: Set = {
+	id: 'CS2aC',
+	name: {
+		'zh-cn': '浓墨重彩 黎',
+	},
+
+	serie: serie,
+
+	cardCount: {
+		official: 115
+	},
+	releaseDate: '2023-08-18',
+}
+
+export default set

--- a/data-asia/S/CS2bC.ts
+++ b/data-asia/S/CS2bC.ts
@@ -1,0 +1,18 @@
+import { Set } from '../../interfaces'
+import serie from '../S'
+
+const set: Set = {
+	id: 'CS2bC',
+	name: {
+		'zh-cn': '浓墨重彩 靛',
+	},
+
+	serie: serie,
+
+	cardCount: {
+		official: 115
+	},
+	releaseDate: '2023-08-18',
+}
+
+export default set

--- a/data-asia/S/CS3.5C.ts
+++ b/data-asia/S/CS3.5C.ts
@@ -1,0 +1,18 @@
+import { Set } from '../../interfaces'
+import serie from '../S'
+
+const set: Set = {
+	id: 'CS3.5C',
+	name: {
+		'zh-cn': '怒炎灼天',
+	},
+
+	serie: serie,
+
+	cardCount: {
+		official: 66
+	},
+	releaseDate: '2024-01-05',
+}
+
+export default set

--- a/data-asia/S/CS3aC.ts
+++ b/data-asia/S/CS3aC.ts
@@ -1,0 +1,18 @@
+import { Set } from '../../interfaces'
+import serie from '../S'
+
+const set: Set = {
+	id: 'CS3aC',
+	name: {
+		'zh-cn': '洪荒演武 茂',
+	},
+
+	serie: serie,
+
+	cardCount: {
+		official: 125
+	},
+	releaseDate: '2023-11-17',
+}
+
+export default set

--- a/data-asia/S/CS3bC.ts
+++ b/data-asia/S/CS3bC.ts
@@ -1,0 +1,18 @@
+import { Set } from '../../interfaces'
+import serie from '../S'
+
+const set: Set = {
+	id: 'CS3bC',
+	name: {
+		'zh-cn': '洪荒演武 激',
+	},
+
+	serie: serie,
+
+	cardCount: {
+		official: 122
+	},
+	releaseDate: '2023-11-17',
+}
+
+export default set

--- a/data-asia/S/CS4.5C.ts
+++ b/data-asia/S/CS4.5C.ts
@@ -1,0 +1,18 @@
+import { Set } from '../../interfaces'
+import serie from '../S'
+
+const set: Set = {
+	id: 'CS4.5C',
+	name: {
+		'zh-cn': '终末炎舞',
+	},
+
+	serie: serie,
+
+	cardCount: {
+		official: 63
+	},
+	releaseDate: '2024-04-26',
+}
+
+export default set

--- a/data-asia/S/CS4aC.ts
+++ b/data-asia/S/CS4aC.ts
@@ -1,0 +1,18 @@
+import { Set } from '../../interfaces'
+import serie from '../S'
+
+const set: Set = {
+	id: 'CS4aC',
+	name: {
+		'zh-cn': '九彩汇聚 朋',
+	},
+
+	serie: serie,
+
+	cardCount: {
+		official: 132
+	},
+	releaseDate: '2024-03-01',
+}
+
+export default set

--- a/data-asia/S/CS4bC.ts
+++ b/data-asia/S/CS4bC.ts
@@ -1,0 +1,18 @@
+import { Set } from '../../interfaces'
+import serie from '../S'
+
+const set: Set = {
+	id: 'CS4bC',
+	name: {
+		'zh-cn': '九彩汇聚 源',
+	},
+
+	serie: serie,
+
+	cardCount: {
+		official: 132
+	},
+	releaseDate: '2024-03-01',
+}
+
+export default set

--- a/data-asia/S/CS5.5C.ts
+++ b/data-asia/S/CS5.5C.ts
@@ -1,0 +1,18 @@
+import { Set } from '../../interfaces'
+import serie from '../S'
+
+const set: Set = {
+	id: 'CS5.5C',
+	name: {
+		'zh-cn': '暗影夺辉',
+	},
+
+	serie: serie,
+
+	cardCount: {
+		official: 66
+	},
+	releaseDate: '2024-08-02',
+}
+
+export default set

--- a/data-asia/S/CS5aC.ts
+++ b/data-asia/S/CS5aC.ts
@@ -1,0 +1,18 @@
+import { Set } from '../../interfaces'
+import serie from '../S'
+
+const set: Set = {
+	id: 'CS5aC',
+	name: {
+		'zh-cn': '勇魅群星 魅',
+	},
+
+	serie: serie,
+
+	cardCount: {
+		official: 127
+	},
+	releaseDate: '2024-06-18',
+}
+
+export default set

--- a/data-asia/S/CS5bC.ts
+++ b/data-asia/S/CS5bC.ts
@@ -1,0 +1,18 @@
+import { Set } from '../../interfaces'
+import serie from '../S'
+
+const set: Set = {
+	id: 'CS5bC',
+	name: {
+		'zh-cn': '勇魅群星 勇',
+	},
+
+	serie: serie,
+
+	cardCount: {
+		official: 128
+	},
+	releaseDate: '2024-06-18',
+}
+
+export default set

--- a/data-asia/S/CS6.5C.ts
+++ b/data-asia/S/CS6.5C.ts
@@ -1,0 +1,18 @@
+import { Set } from '../../interfaces'
+import serie from '../S'
+
+const set: Set = {
+	id: 'CS6.5C',
+	name: {
+		'zh-cn': '胜象星引',
+	},
+
+	serie: serie,
+
+	cardCount: {
+		official: 72
+	},
+	releaseDate: '2024-11-15',
+}
+
+export default set

--- a/data-asia/S/CS6aC.ts
+++ b/data-asia/S/CS6aC.ts
@@ -1,0 +1,18 @@
+import { Set } from '../../interfaces'
+import serie from '../S'
+
+const set: Set = {
+	id: 'CS6aC',
+	name: {
+		'zh-cn': '碧海暗影 啸',
+	},
+
+	serie: serie,
+
+	cardCount: {
+		official: 131
+	},
+	releaseDate: '2024-09-20',
+}
+
+export default set

--- a/data-asia/S/CS6bC.ts
+++ b/data-asia/S/CS6bC.ts
@@ -1,0 +1,18 @@
+import { Set } from '../../interfaces'
+import serie from '../S'
+
+const set: Set = {
+	id: 'CS6bC',
+	name: {
+		'zh-cn': '碧海暗影 逐',
+	},
+
+	serie: serie,
+
+	cardCount: {
+		official: 131
+	},
+	releaseDate: '2024-09-20',
+}
+
+export default set

--- a/data-asia/SM.ts
+++ b/data-asia/SM.ts
@@ -3,6 +3,7 @@ import { Serie } from '../interfaces'
 const serie: Serie = {
 	name: {
 		ja: 'サン＆ムーン',
+		'zh-cn': '太阳&月亮',
 		ko: '썬&문'
 	},
 	id: 'SM'

--- a/data-asia/SM/CSM1.5C.ts
+++ b/data-asia/SM/CSM1.5C.ts
@@ -1,0 +1,18 @@
+import { Set } from '../../interfaces'
+import serie from '../SM'
+
+const set: Set = {
+	id: 'CSM1.5C',
+	name: {
+		'zh-cn': '对战精英',
+	},
+
+	serie: serie,
+
+	cardCount: {
+		official: 60
+	},
+	releaseDate: '2022-12-16'
+}
+
+export default set

--- a/data-asia/SM/CSM1aC.ts
+++ b/data-asia/SM/CSM1aC.ts
@@ -1,0 +1,18 @@
+import { Set } from '../../interfaces'
+import serie from '../SM'
+
+const set: Set = {
+	id: 'CSM1aC',
+	name: {
+		'zh-cn': '横空出世 赫',
+	},
+
+	serie: serie,
+
+	cardCount: {
+		official: 151
+	},
+	releaseDate: '2020-10-28'
+}
+
+export default set

--- a/data-asia/SM/CSM1bC.ts
+++ b/data-asia/SM/CSM1bC.ts
@@ -1,0 +1,18 @@
+import { Set } from '../../interfaces'
+import serie from '../SM'
+
+const set: Set = {
+	id: 'CSM1bC',
+	name: {
+		'zh-cn': '横空出世 苍',
+	},
+
+	serie: serie,
+
+	cardCount: {
+		official: 151
+	},
+	releaseDate: '2020-10-28'
+}
+
+export default set

--- a/data-asia/SM/CSM1cC.ts
+++ b/data-asia/SM/CSM1cC.ts
@@ -1,0 +1,18 @@
+import { Set } from '../../interfaces'
+import serie from '../SM'
+
+const set: Set = {
+	id: 'CSM1cC',
+	name: {
+		'zh-cn': '横空出世 泽',
+	},
+
+	serie: serie,
+
+	cardCount: {
+		official: 151
+	},
+	releaseDate: '2020-10-28'
+}
+
+export default set

--- a/data-asia/SM/CSM2.5C.ts
+++ b/data-asia/SM/CSM2.5C.ts
@@ -1,0 +1,18 @@
+import { Set } from '../../interfaces'
+import serie from '../SM'
+
+const set: Set = {
+	id: 'CSM2.5C',
+	name: {
+		'zh-cn': '炫奇争胜',
+	},
+
+	serie: serie,
+
+	cardCount: {
+		official: 61
+	},
+	releaseDate: '2023-03-17'
+}
+
+export default set

--- a/data-asia/SM/CSM2aC.ts
+++ b/data-asia/SM/CSM2aC.ts
@@ -1,0 +1,18 @@
+import { Set } from '../../interfaces'
+import serie from '../SM'
+
+const set: Set = {
+	id: 'CSM2aC',
+	name: {
+		'zh-cn': '交相辉映 沐',
+	},
+
+	serie: serie,
+
+	cardCount: {
+		official: 150
+	},
+	releaseDate: '2023-01-18'
+}
+
+export default set

--- a/data-asia/SM/CSM2bC.ts
+++ b/data-asia/SM/CSM2bC.ts
@@ -1,0 +1,18 @@
+import { Set } from '../../interfaces'
+import serie from '../SM'
+
+const set: Set = {
+	id: 'CSM2bC',
+	name: {
+		'zh-cn': '交相辉映 魁',
+	},
+
+	serie: serie,
+
+	cardCount: {
+		official: 150
+	},
+	releaseDate: '2023-01-18'
+}
+
+export default set

--- a/data-asia/SM/CSM2cC.ts
+++ b/data-asia/SM/CSM2cC.ts
@@ -1,0 +1,18 @@
+import { Set } from '../../interfaces'
+import serie from '../SM'
+
+const set: Set = {
+	id: 'CSM2cC',
+	name: {
+		'zh-cn': '交相辉映 唤',
+	},
+
+	serie: serie,
+
+	cardCount: {
+		official: 150
+	},
+	releaseDate: '2023-01-18'
+}
+
+export default set

--- a/data-asia/SV.ts
+++ b/data-asia/SV.ts
@@ -3,7 +3,7 @@ import { Serie } from '../interfaces'
 const serie: Serie = {
 	name: {
 		ja: 'ポケモンカードゲーム スカーレット&バイオレット',
-		'zh-cn': '朱&紫系列',
+		'zh-cn': '朱&紫',
 		'zh-tw': '朱&紫系列',
 		th: 'สการ์เล็ต&ไวโอเล็ต',
 		id: 'Scarlet & Violet',

--- a/data-asia/SV/CSV1C.ts
+++ b/data-asia/SV/CSV1C.ts
@@ -1,0 +1,18 @@
+import { Set } from '../../interfaces'
+import serie from '../SV'
+
+const set: Set = {
+	id: 'CSV1C',
+	name: {
+		'zh-cn': '亘古开来',
+	},
+
+	serie: serie,
+
+	cardCount: {
+		official: 127
+	},
+	releaseDate: '2025-01-17',
+}
+
+export default set

--- a/data-asia/SV/CSV2C.ts
+++ b/data-asia/SV/CSV2C.ts
@@ -1,0 +1,18 @@
+import { Set } from '../../interfaces'
+import serie from '../SV'
+
+const set: Set = {
+	id: 'CSV2C',
+	name: {
+		'zh-cn': '奇迹启程',
+	},
+
+	serie: serie,
+
+	cardCount: {
+		official: 128
+	},
+	releaseDate: '2025-03-21',
+}
+
+export default set

--- a/data-asia/SV/CSV3C.ts
+++ b/data-asia/SV/CSV3C.ts
@@ -1,0 +1,18 @@
+import { Set } from '../../interfaces'
+import serie from '../SV'
+
+const set: Set = {
+	id: 'CSV3C',
+	name: {
+		'zh-cn': '无畏太晶',
+	},
+
+	serie: serie,
+
+	cardCount: {
+		official: 130
+	},
+	releaseDate: '2025-05-16',
+}
+
+export default set

--- a/data-asia/SV/CSV4C.ts
+++ b/data-asia/SV/CSV4C.ts
@@ -1,0 +1,18 @@
+import { Set } from '../../interfaces'
+import serie from '../SV'
+
+const set: Set = {
+	id: 'CSV4C',
+	name: {
+		'zh-cn': '嘉奖回合',
+	},
+
+	serie: serie,
+
+	cardCount: {
+		official: 129
+	},
+	releaseDate: '2025-07-18',
+}
+
+export default set

--- a/data-asia/SV/CSV5C.ts
+++ b/data-asia/SV/CSV5C.ts
@@ -1,0 +1,18 @@
+import { Set } from '../../interfaces'
+import serie from '../SV'
+
+const set: Set = {
+	id: 'CSV5C',
+	name: {
+		'zh-cn': '黑晶炽诚',
+	},
+
+	serie: serie,
+
+	cardCount: {
+		official: 129
+	},
+	releaseDate: '2025-09-12',
+}
+
+export default set

--- a/data-asia/SV/CSV6C.ts
+++ b/data-asia/SV/CSV6C.ts
@@ -1,0 +1,18 @@
+import { Set } from '../../interfaces'
+import serie from '../SV'
+
+const set: Set = {
+	id: 'CSV6C',
+	name: {
+		'zh-cn': '真实玄虚',
+	},
+
+	serie: serie,
+
+	cardCount: {
+		official: 128
+	},
+	releaseDate: '2025-11-07',
+}
+
+export default set

--- a/data-asia/SV/CSV7C.ts
+++ b/data-asia/SV/CSV7C.ts
@@ -1,0 +1,18 @@
+import { Set } from '../../interfaces'
+import serie from '../SV'
+
+const set: Set = {
+	id: 'CSV7C',
+	name: {
+		'zh-cn': '利刃猛醒',
+	},
+
+	serie: serie,
+
+	cardCount: {
+		official: 204
+	},
+	releaseDate: '2026-01-16',
+}
+
+export default set


### PR DESCRIPTION
## Changes

- Add 'zh-cn' translation keys for S/SM, update translation/name for SV
- Add main expansion sets for S/SM/SV
- No cards are being included here at the moment.

## Details

I cross-checked data with:
- https://www.pokemon.cn/products_category/products#expansionPack
- https://bulbapedia.bulbagarden.net/wiki/List_of_Pok%C3%A9mon_Trading_Card_Game_expansions_in_other_languages#Simplified_Chinese_Catch-up_sets
- https://tcg.mik.moe/cards

## Question

- No cards are included in this PR. Should I also bundle them here, in a separate PR or one PR for each set?