### PR TITLE
[Feat] Allow sets to have multiple card market ids

### DIFF
--- a/interfaces.d.ts
+++ b/interfaces.d.ts
@@ -152,7 +152,7 @@ export interface Set {
 	releaseDate: ISODate | Languages<ISODate>
 
 	thirdParty?: {
-		cardmarket?: number
+		cardmarket?: number | Array<number>
 		tcgplayer?: number
 	}
 }

--- a/meta/definitions/api.d.ts
+++ b/meta/definitions/api.d.ts
@@ -139,7 +139,7 @@ export interface Set extends SetResume {
 	cards: Array<CardResume>;
 	abbreviation: { official: string, localized: string };
 	thirdParty?: {
-		cardmarket?: number
+		cardmarket?: Array<number>
 		tcgplayer?: number
 	}
 }

--- a/server/compiler/index.ts
+++ b/server/compiler/index.ts
@@ -23,8 +23,8 @@ const DIST_FOLDER = './generated'
 		await fs.rm(DIST_FOLDER, {recursive: true})
 	} catch {}
 
-	console.log('\n2. Loading informations from GIT')
-	await loadLastEdits()
+	// console.log('\n2. Loading informations from GIT')
+	// await loadLastEdits()
 
 	console.log('\n3. Compiling Files')
 

--- a/server/compiler/index.ts
+++ b/server/compiler/index.ts
@@ -23,8 +23,8 @@ const DIST_FOLDER = './generated'
 		await fs.rm(DIST_FOLDER, {recursive: true})
 	} catch {}
 
-	// console.log('\n2. Loading informations from GIT')
-	// await loadLastEdits()
+	console.log('\n2. Loading informations from GIT')
+	await loadLastEdits()
 
 	console.log('\n3. Compiling Files')
 

--- a/server/compiler/utils/setUtil.ts
+++ b/server/compiler/utils/setUtil.ts
@@ -97,10 +97,25 @@ function getVariantCountForType(card: Card, type: 'normal' | 'reverse' | 'holo' 
 	return card.variants.reduce((count, variant) => count + (variant.type === type ? 1 : 0), 0);
 }
 
+function buildThirdParty(thirdParty: { cardmarket?: number | Array<number>; tcgplayer?: number }) {
+	if(thirdParty === undefined || thirdParty === null) {
+		return undefined
+	}
+
+	return {
+		cardmarket: thirdParty.cardmarket !== undefined && thirdParty.cardmarket !== null
+			? (Array.isArray(thirdParty.cardmarket) ? thirdParty.cardmarket : [thirdParty.cardmarket])
+			: undefined,
+		tcgplayer: thirdParty.tcgplayer
+	}
+}
 
 export async function setToSetSingle(set: Set, lang: SupportedLanguages): Promise<SetSingle> {
 	const cards = await getCards(lang, set)
 	const pics = await getSetPictures(set, lang)
+
+
+
 	return {
 		cardCount: {
 			firstEd: cards.reduce((count, card) => count + getVariantCountForType(card[1],"firstEdition"), 0),
@@ -134,6 +149,6 @@ export async function setToSetSingle(set: Set, lang: SupportedLanguages): Promis
 			name: resolveText(booster.name, lang),
 			// images will be coming soon...
 		})) : undefined,
-		thirdParty: set.thirdParty
+		thirdParty: buildThirdParty(set.thirdParty)
 	}
 }


### PR DESCRIPTION
Card market can have multiple IDs for a single tcgdex set, this PR allows either a single ID or multiple. We may decide that this isn't necessary and can be ignored, if so