### PR TITLE
Update Next Destinies official abbreviation from 'NEX' to 'NXD'

### DIFF
--- a/data/Black & White/Next Destinies.ts
+++ b/data/Black & White/Next Destinies.ts
@@ -23,7 +23,7 @@ const bw4: Set = {
 	releaseDate: "2012-02-08",
 
 	abbreviations: {
-		official: "NEX",
+		official: "NXD",
 		fr: "DFU"
 	},
 


### PR DESCRIPTION


<!--
Contribution guide: https://github.com/tcgdex/cards-database/blob/master/CONTRIBUTING.md
please submit changes up to 1 set at most.
-->

closes # <!-- Indicate the issue number here -->

## Changes

Changed the official abbreviation of Next Destinies to NXD.

## Details

In the tournament rules and resources the official abbreviation for Next Destinies is NXD.
https://www.pokemon.com/us/play-pokemon/about/tournaments-rules-and-resources see the deck list.