### PR TITLE
Fix: ECARD2 Add Cardmarket IDs

### DIFF
--- a/data/E-Card/Aquapolis/96.ts
+++ b/data/E-Card/Aquapolis/96.ts
@@ -62,6 +62,10 @@ const card: Card = {
 		},
 	],
 
+	thirdParty: {
+		cardmarket: 275171
+	},
+
 	variants: [
 		{
 			type: 'normal',


### PR DESCRIPTION
## Changes

Add Missing Cardmarket ID

## Details

Onmy had 1 cardmarket ID missing
