### PR TITLE
Add new ball reverse foil variants and translations introduced in ME

### DIFF
--- a/interfaces.d.ts
+++ b/interfaces.d.ts
@@ -80,7 +80,8 @@ interface variant_detailed {
 	 * for the holo & reverse, **optional** indicate which foil is used on the card
 	 */
 	foil?: 'pokeball' | 'ultraball' | 'masterball' | 'gold' | 'cosmos' | 'galaxy' | 'starlight' | 'energy' | 'cracked-ice'
-	| 'mirror' | 'league' | 'player-reward' | 'professor-program'
+	| 'mirror' | 'league' | 'player-reward' | 'professor-program' 
+	| 'loveball' | 'friendball' | 'quickball' | 'team-rocket' | 'duskball'
 
 	/**
 	 * list of languages for which this variant is available

--- a/meta/translations/de.json
+++ b/meta/translations/de.json
@@ -128,7 +128,12 @@
 		"mirror": "mirror",
 		"league": "league",
 		"player-reward": "player-reward",
-		"professor-program": "professor-program"
+		"professor-program": "professor-program",
+		"loveball": "Sympaball",
+		"friendball": "Freundesball",
+		"quickball": "Flottball",
+		"duskball": "Finsterball",
+		"team-rocket": "Team Rocket"
 	},
 	"variantStamp": {
 		"1st-edition": "1. Auflage",

--- a/meta/translations/es.json
+++ b/meta/translations/es.json
@@ -128,7 +128,12 @@
 		"mirror": "mirror",
 		"league": "league",
 		"player-reward": "player-reward",
-		"professor-program": "professor-program"
+		"professor-program": "professor-program",
+		"loveball": "Amor Ball",
+		"friendball": "Amigo Ball", 
+		"quickball": "Veloz Ball",
+		"duskball": "Ocaso Ball", 
+		"team-rocket": "Team Rocket"
 	},
 	"variantStamp": {
 		"1st-edition": "1ra Edición",

--- a/meta/translations/fr.json
+++ b/meta/translations/fr.json
@@ -127,7 +127,12 @@
 		"mirror": "mirror",
 		"league": "league",
 		"player-reward": "player-reward",
-		"professor-program": "professor-program"
+		"professor-program": "professor-program",
+		"loveball": "Love Ball",
+		"friendball": "Copain Ball", 
+		"quickball": "Rapide Ball",
+		"duskball": "Sombre Ball", 
+		"team-rocket": "Team Rocket"
 	},
 	"variantStamp": {
 		"1st-edition": "1re Édition",

--- a/meta/translations/it.json
+++ b/meta/translations/it.json
@@ -128,7 +128,12 @@
 		"mirror": "mirror",
 		"league": "league",
 		"player-reward": "player-reward",
-		"professor-program": "professor-program"
+		"professor-program": "professor-program",
+		"loveball": "Love Ball",
+		"friendball": "Friend Ball", 
+		"quickball": "Velox Ball",
+		"duskball": "Scuro Ball", 
+		"team-rocket": "Team Rocket"
 	},
 	"variantStamp": {
 		"1st-edition": "1a Edizione",

--- a/meta/translations/pt.json
+++ b/meta/translations/pt.json
@@ -127,7 +127,12 @@
 		"mirror": "mirror",
 		"league": "league",
 		"player-reward": "player-reward",
-		"professor-program": "professor-program"
+		"professor-program": "professor-program",
+		"loveball": "Bola de Amor",
+		"friendball": "Bola de Amizade", 
+		"quickball": "Bola Rápida",
+		"duskball": "Bola Crepúsculo", 
+		"team-rocket": "Team Rocket"
 	},
 	"variantStamp": {
 		"1st-edition": "1ª Edição",


### PR DESCRIPTION
Add five new foil options ('loveball', 'friendball', 'quickball', 'duskball', 'team-rocket') to the variant_detailed union in interfaces.d.ts and provide translations. This is in preperation for the variants_detailed pricing updates

<!--
Contribution guide: https://github.com/tcgdex/cards-database/blob/master/CONTRIBUTING.md
please submit changes up to 1 set at most.
-->

Partly addresses [#1131](https://github.com/tcgdex/cards-database/issues/1131) - Further work will be needed to address this fully 

## Changes

Add five new foil types to variant_detailed in interfaces.d.ts and corresponding translations for the Mega Evolution era reverse holo patterns.

## Details

The Mega Evolution series (MEGA Dream ex / Ascended Heroes) introduced new reverse holo foil patterns that aren't currently represented in the database. This adds:

loveball — Love Ball foil pattern
friendball — Friend Ball foil pattern (used for starter/first partner Pokémon)
quickball — Quick Ball foil pattern
duskball — Dusk Ball foil pattern
team-rocket — Team Rocket "R" foil pattern (used for Trainer's Pokémon belonging to Team Rocket)

Translations added to all five language files using official Pokémon localizations:

