### PR TITLE
Feat: Update SetResume interface

### DIFF
--- a/meta/definitions/api.d.ts
+++ b/meta/definitions/api.d.ts
@@ -69,6 +69,9 @@ export interface SetResume {
 	name: string;
 	logo?: string;
 	symbol?: string;
+	serie?: SerieResume;
+	releaseDate?: string;
+	abbreviation?: { official: string; localized: string };
 	cardCount: {
 		/**
 		 * total of number of cards

--- a/server/src/V2/Components/Set.ts
+++ b/server/src/V2/Components/Set.ts
@@ -1,78 +1,73 @@
-import type { Set as SDKSet, SetResume, SupportedLanguages } from "@tcgdex/sdk";
-import { executeQuery, type Query } from "../../libs/QueryEngine/filter";
-import { objectOmit } from "@dzeio/object-util";
+import type { Set as SDKSet, SetResume, SupportedLanguages } from '@tcgdex/sdk'
+import { executeQuery, type Query } from '../../libs/QueryEngine/filter'
+import { objectOmit } from '@dzeio/object-util'
 
-import de from "../../../generated/de/sets.json";
-import en from "../../../generated/en/sets.json";
-import es from "../../../generated/es/sets.json";
-import esmx from "../../../generated/es-mx/sets.json";
-import fr from "../../../generated/fr/sets.json";
-import id from "../../../generated/id/sets.json";
-import it from "../../../generated/it/sets.json";
-import ja from "../../../generated/ja/sets.json";
-import ko from "../../../generated/ko/sets.json";
-import nl from "../../../generated/nl/sets.json";
-import pl from "../../../generated/pl/sets.json";
-import ptbr from "../../../generated/pt-br/sets.json";
-import ptpt from "../../../generated/pt-pt/sets.json";
-import pt from "../../../generated/pt/sets.json";
-import ru from "../../../generated/ru/sets.json";
-import th from "../../../generated/th/sets.json";
-import zhcn from "../../../generated/zh-cn/sets.json";
-import zhtw from "../../../generated/zh-tw/sets.json";
+import de from '../../../generated/de/sets.json'
+import en from '../../../generated/en/sets.json'
+import es from '../../../generated/es/sets.json'
+import esmx from '../../../generated/es-mx/sets.json'
+import fr from '../../../generated/fr/sets.json'
+import id from '../../../generated/id/sets.json'
+import it from '../../../generated/it/sets.json'
+import ja from '../../../generated/ja/sets.json'
+import ko from '../../../generated/ko/sets.json'
+import nl from '../../../generated/nl/sets.json'
+import pl from '../../../generated/pl/sets.json'
+import ptbr from '../../../generated/pt-br/sets.json'
+import ptpt from '../../../generated/pt-pt/sets.json'
+import pt from '../../../generated/pt/sets.json'
+import ru from '../../../generated/ru/sets.json'
+import th from '../../../generated/th/sets.json'
+import zhcn from '../../../generated/zh-cn/sets.json'
+import zhtw from '../../../generated/zh-tw/sets.json'
 
 export const sets = {
 	en: en,
 	fr: fr,
 	es: es,
-	"es-mx": esmx,
+	'es-mx': esmx,
 	it: it,
 	pt: pt,
-	"pt-br": ptbr,
-	"pt-pt": ptpt,
+	'pt-br': ptbr,
+	'pt-pt': ptpt,
 	de: de,
 	nl: nl,
 	pl: pl,
 	ru: ru,
 	ja: ja,
 	ko: ko,
-	"zh-tw": zhtw,
+	'zh-tw': zhtw,
 	id: id,
 	th: th,
-	"zh-cn": zhcn,
-} as const;
+	'zh-cn': zhcn,
+} as const
 
-type MappedSet = any; // (typeof en)[number]
+type MappedSet = any // (typeof en)[number]
 
-export async function getAllSets(
-	lang: SupportedLanguages,
-): Promise<Array<SDKSet>> {
-	return Promise.all((sets[lang] as Array<MappedSet>).map(transformSet));
+export async function getAllSets(lang: SupportedLanguages): Promise<Array<SDKSet>> {
+	return Promise.all((sets[lang] as Array<MappedSet>).map(transformSet))
 }
 
 async function transformSet(set: MappedSet): Promise<SDKSet> {
 	return {
-		...objectOmit(set, "thirdParty"),
+		...objectOmit(set, 'thirdParty'),
 		// pricing: {
 		// 	cardmarket: await getCardMarketPrice(card),
 		// 	tcgplayer: await getTCGPlayerPrice(card)
 		// }
-	};
+	}
 }
 
 export async function findSets(lang: SupportedLanguages, query: Query<SDKSet>) {
-	return executeQuery(await getAllSets(lang), query).data;
+	return executeQuery(await getAllSets(lang), query).data
 }
 
-export async function findOneSet(
-	lang: SupportedLanguages,
-	query: Query<SDKSet>,
-) {
-	const res = await findSets(lang, query);
+export async function findOneSet(lang: SupportedLanguages, query: Query<SDKSet>) {
+	const res = await findSets(lang, query)
 	if (res.length === 0) {
-		return undefined;
+		return undefined
 	}
-	return res[0];
+	return res[0]
 }
 
 export function setToBrief(set: SDKSet): SetResume {
@@ -83,10 +78,11 @@ export function setToBrief(set: SDKSet): SetResume {
 		symbol: set.symbol,
 		serie: set.serie,
 		releaseDate: set.releaseDate,
+		legal: set.legal,
 		abbreviation: set.abbreviation,
 		cardCount: {
 			total: set.cardCount.total,
-			official: set.cardCount.official,
-		},
-	};
+			official: set.cardCount.official
+		}
+	}
 }


### PR DESCRIPTION
<!--
Contribution guide: https://github.com/tcgdex/cards-database/blob/master/CONTRIBUTING.md
please submit changes up to 1 set at most.
-->

closes https://github.com/tcgdex/cards-database/issues/1151


## Changes

<!-- Quickly explain your changes -->
Adding some extra values into the setToBrief function

## Details
<!-- You can also give more details about your changes -->
Pr to be paired with the SDK https://github.com/tcgdex/javascript-sdk/pull/314

Going off the issue I raised https://github.com/tcgdex/cards-database/issues/1151, I have extended the SetResume object to include "serie", "releaseDate" and "abbreviation" into the brief object.

The idea behind this is that from a 'view all' page. You you cant do things like group by serie or year without having to do another entire api call, which is a waste of a call if you already have all of the data (which since this api is quite fast, you would probably have anyway)

Abbreviation is also useful for being able to have the 'readable' name attached to the set as thats the one that is printed on the card.
