### PR TITLE
fix: Typo in XY Set Name (Yellow A Alternate)

### DIFF
--- a/data/XY/Yellow A Alternate.ts
+++ b/data/XY/Yellow A Alternate.ts
@@ -5,7 +5,7 @@ const xya: Set = {
 	id: "xya",
 
 	name: {
-		en: "Yello A Alternate",
+		en: "Yellow A Alternate",
 		fr: "carte alternative A Jaune",
 		es: "Cartas alternativas",
 		it: "Carta Alternatica A Gialla",

--- a/data/XY/Yellow A Alternate/107a.ts
+++ b/data/XY/Yellow A Alternate/107a.ts
@@ -1,8 +1,9 @@
 import { Card } from '../../../interfaces'
-import Set from '../Yello A Alternate'
+import Set from '../Yellow A Alternate'
 
 const card: Card = {
 	name: {
+		en: "Professor Sycamore",
 		fr: "Professeur Platane",
 	},
 	illustrator: "Naoki Saito",
@@ -22,6 +23,7 @@ const card: Card = {
 
 
 	effect: {
+		en: "Discard your hand and draw 7 cards.",
 		fr: "Défaussez votre main et piochez 7 cartes.",
 	},
 	trainerType: "Supporter",

--- a/data/XY/Yellow A Alternate/24a.ts
+++ b/data/XY/Yellow A Alternate/24a.ts
@@ -1,8 +1,9 @@
 import { Card } from '../../../interfaces'
-import Set from '../Yello A Alternate'
+import Set from '../Yellow A Alternate'
 
 const card: Card = {
 	name: {
+		en: "M Manectric-EX",
 		fr: "M-Élecsprint-ex",
 	},
 	illustrator: "5ban Graphics",
@@ -17,6 +18,7 @@ const card: Card = {
 		"Lightning",
 	],
 	evolveFrom: {
+		en: "Manectric-ex",
 		fr: "Élecsprint-ex",
 	},
 	stage: "MEGA",
@@ -29,9 +31,11 @@ const card: Card = {
 				"Colorless",
 			],
 			name: {
+				en: "Turbo Bolt",
 				fr: "Éclair Turbo",
 			},
 			effect: {
+				en: "Attach 2 basic Energy cards from your discard pile to 1 of your Benched Pokémon.",
 				fr: "Attachez 2 cartes Énergie de base de votre pile de défausse à l'un de vos Pokémon de Banc.",
 			},
 			damage: 110,

--- a/data/XY/Yellow A Alternate/28a.ts
+++ b/data/XY/Yellow A Alternate/28a.ts
@@ -1,8 +1,9 @@
 import { Card } from '../../../interfaces'
-import Set from '../Yello A Alternate'
+import Set from '../Yellow A Alternate'
 
 const card: Card = {
 	name: {
+		en: "Jolteon-EX",
 		fr: "Voltali-ex",
 	},
 	illustrator: "Ryo Ueda",
@@ -26,9 +27,11 @@ const card: Card = {
 				"Lightning",
 			],
 			name: {
+				en: "Swift",
 				fr: "Météores",
 			},
 			effect: {
+				en: "This attack’s damage isn’t affected by Weakness, Resistance, or any other effects on your opponent’s Active Pokémon.",
 				fr: "Les dégâts de cette attaque ne sont pas affectés par la Faiblesse, la Résistance ou tout autre effet en action sur le Pokémon Actif de votre adversaire.",
 			},
 			damage: 30,
@@ -37,9 +40,11 @@ const card: Card = {
 		{
 
 			name: {
+				en: "Flash Ray",
 				fr: "Rayon Flash",
 			},
 			effect: {
+				en: "During your opponent’s next turn, prevent all damage done to this Pokémon by attacks from Basic Pokémon.",
 				fr: "During your opponent's next turn, prevent all damage done to this Pokémon by attacks from Basic Pokémon.",
 			},
 			damage: "{L}{C}{C}",

--- a/data/XY/Yellow A Alternate/54a.ts
+++ b/data/XY/Yellow A Alternate/54a.ts
@@ -1,8 +1,9 @@
 import { Card } from '../../../interfaces'
-import Set from '../Yello A Alternate'
+import Set from '../Yellow A Alternate'
 
 const card: Card = {
 	name: {
+		en: "Zygarde-EX",
 		fr: "Zygarde-ex",
 	},
 	illustrator: "5ban Graphics",
@@ -26,9 +27,11 @@ const card: Card = {
 				"Fighting",
 			],
 			name: {
+				en: "Land’s Pulse",
 				fr: "Vibration Terrestre",
 			},
 			effect: {
+				en: "If there is any Stadium card in play, this attack does 20 more damage.",
 				fr: "S'il y a une carte Stade en jeu, cette attaque inflige 20 dégâts supplémentaires.",
 			},
 			damage: "20+",
@@ -40,9 +43,11 @@ const card: Card = {
 				"Colorless",
 			],
 			name: {
+				en: "Cell Storm",
 				fr: "Tempête Cellulaire",
 			},
 			effect: {
+				en: "Heal 30 damage from this Pokémon.",
 				fr: "Soignez 30 dégâts à ce Pokémon.",
 			},
 			damage: 60,
@@ -55,6 +60,7 @@ const card: Card = {
 				"Colorless",
 			],
 			name: {
+				en: "Land's Wrath",
 				fr: "Force Chtonienne",
 			},
 

--- a/data/XY/Yellow A Alternate/55a.ts
+++ b/data/XY/Yellow A Alternate/55a.ts
@@ -1,8 +1,9 @@
 import { Card } from '../../../interfaces'
-import Set from '../Yello A Alternate'
+import Set from '../Yellow A Alternate'
 
 const card: Card = {
 	name: {
+		en: "M Lucario-EX",
 		fr: "M-Lucario-ex",
 	},
 	illustrator: "5ban Graphics",
@@ -17,6 +18,7 @@ const card: Card = {
 		"Fighting",
 	],
 	evolveFrom: {
+		en: "Lucario-ex",
 		fr: "Lucario-ex",
 	},
 	stage: "MEGA",
@@ -30,9 +32,11 @@ const card: Card = {
 				"Fighting",
 			],
 			name: {
+				en: "Rising Fist",
 				fr: "Poing Imminent",
 			},
 			effect: {
+				en: "Discard an Energy attached to your opponent’s Active Pokémon.",
 				fr: "Défaussez une Énergie attachée au Pokémon Actif de votre adversaire.",
 			},
 			damage: 140,

--- a/data/XY/Yellow A Alternate/92a.ts
+++ b/data/XY/Yellow A Alternate/92a.ts
@@ -1,8 +1,9 @@
 import { Card } from '../../../interfaces'
-import Set from '../Yello A Alternate'
+import Set from '../Yellow A Alternate'
 
 const card: Card = {
 	name: {
+		en: "Trainers’ Mail",
 		fr: "Courrier du Dresseur",
 	},
 	illustrator: "Toyste Beach",
@@ -22,6 +23,7 @@ const card: Card = {
 
 
 	effect: {
+		en: "Look at the top 4 cards of your deck. You may reveal a Trainer card you find there (except for Trainers’ Mail) and put it into your hand. Shuffle the other cards back into your deck.",
 		fr: "Regardez les 4 cartes du dessus de votre deck. Vous pouvez montrer une carte Dresseur que vous y trouvez (à part Courrier du Dresseur) et l'ajouter à votre main. Mélangez les autres cartes avec votre deck.",
 	},
 	trainerType: "Item",


### PR DESCRIPTION
Fixes a typo from 'Yello A Alternate' to 'Yellow A Alternate'. 
Also adds English translation to cards in this set.

closes [#1076](https://github.com/tcgdex/cards-database/issues/1076)

## Changes

- Fixes typo for 'Yellow A Alternate' set under XY folder. Was previously 'Yello A Alternate'.
- Additionally adds English translations to cards.

