### PR TITLE
fix: correct Scar-Charged Smash damage from 80 to "80+" on Incineroar ex

### DIFF
--- a/data/Pokémon TCG Pocket/Celestial Guardians/182.ts
+++ b/data/Pokémon TCG Pocket/Celestial Guardians/182.ts
@@ -64,7 +64,7 @@ const card: Card = {
 			ko: "스카스매시"
 		},
 
-		damage: 80,
+		damage: "80+",
 		cost: ["Fire", "Fire", "Colorless"],
 
 		effect: {

--- a/data/Pokémon TCG Pocket/Celestial Guardians/200.ts
+++ b/data/Pokémon TCG Pocket/Celestial Guardians/200.ts
@@ -64,7 +64,7 @@ const card: Card = {
 			ko: "스카스매시"
 		},
 
-		damage: 80,
+		damage: "80+",
 		cost: ["Fire", "Fire", "Colorless"],
 
 		effect: {

--- a/data/Pokémon TCG Pocket/Mega Rising/318.ts
+++ b/data/Pokémon TCG Pocket/Mega Rising/318.ts
@@ -39,7 +39,7 @@ const card: Card = {
 			en: "Scar-Charged Smash"
 		},
 
-		damage: 80,
+		damage: "80+",
 		cost: ["Fire", "Fire", "Colorless"],
 
 		effect: {


### PR DESCRIPTION
The Scar-Charged Smash attack has a conditional effect that can add 60 more damage, making the base damage variable. The "+" suffix is required to reflect this. Three alternate-art versions of Incineroar ex had the damage stored as a plain integer (80) instead of the correct string ("80+"), inconsistent with the canonical entry.

Affected cards:
- Celestial Guardians/182.ts
- Celestial Guardians/200.ts
- Mega Rising/318.ts

<!--
Contribution guide: https://github.com/tcgdex/cards-database/blob/master/CONTRIBUTING.md
please submit changes up to 1 set at most.
-->

closes # <!-- Indicate the issue number here -->

## Changes

<!-- Quickly explain your changes -->

## Details

<!-- You can also give more details about your changes -->

