### PR TITLE
fix: Update Cardmarket IDs for Paldean Fates cards

### DIFF
--- a/data/Scarlet & Violet/Paldean Fates/099.ts
+++ b/data/Scarlet & Violet/Paldean Fates/099.ts
@@ -46,7 +46,7 @@ const card: Card = {
 	illustrator: "Scav",
 
 	thirdParty: {
-		cardmarket: 751527
+		cardmarket: 751638
 	}
 }
 

--- a/data/Scarlet & Violet/Paldean Fates/105.ts
+++ b/data/Scarlet & Violet/Paldean Fates/105.ts
@@ -55,7 +55,7 @@ const card: Card = {
 	illustrator: "Ryuta Fuse",
 
 	thirdParty: {
-		cardmarket: 751530
+		cardmarket: 751644
 	}
 }
 

--- a/data/Scarlet & Violet/Paldean Fates/109.ts
+++ b/data/Scarlet & Violet/Paldean Fates/109.ts
@@ -66,7 +66,7 @@ const card: Card = {
 	illustrator: "sowsow",
 
 	thirdParty: {
-		cardmarket: 751533
+		cardmarket: 751648
 	}
 }
 

--- a/data/Scarlet & Violet/Paldean Fates/110.ts
+++ b/data/Scarlet & Violet/Paldean Fates/110.ts
@@ -76,7 +76,7 @@ const card: Card = {
 	illustrator: "Kouki Saitou",
 
 	thirdParty: {
-		cardmarket: 751534
+		cardmarket: 751649
 	}
 }
 

--- a/data/Scarlet & Violet/Paldean Fates/114.ts
+++ b/data/Scarlet & Violet/Paldean Fates/114.ts
@@ -46,7 +46,7 @@ const card: Card = {
 	illustrator: "Masakazu Fukuda",
 
 	thirdParty: {
-		cardmarket: 751540
+		cardmarket: 751653
 	}
 }
 

--- a/data/Scarlet & Violet/Paldean Fates/115.ts
+++ b/data/Scarlet & Violet/Paldean Fates/115.ts
@@ -85,7 +85,7 @@ const card: Card = {
 	illustrator: "Atsushi Furusawa",
 
 	thirdParty: {
-		cardmarket: 751541
+		cardmarket: 751654
 	}
 }
 

--- a/data/Scarlet & Violet/Paldean Fates/120.ts
+++ b/data/Scarlet & Violet/Paldean Fates/120.ts
@@ -75,7 +75,7 @@ const card: Card = {
 	illustrator: "GOSSAN",
 
 	thirdParty: {
-		cardmarket: 751650
+		cardmarket: 751659
 	}
 }
 

--- a/data/Scarlet & Violet/Paldean Fates/128.ts
+++ b/data/Scarlet & Violet/Paldean Fates/128.ts
@@ -66,7 +66,7 @@ const card: Card = {
 	illustrator: "Taira Akitsu",
 
 	thirdParty: {
-		cardmarket: 751544
+		cardmarket: 751667
 	}
 }
 

--- a/data/Scarlet & Violet/Paldean Fates/131.ts
+++ b/data/Scarlet & Violet/Paldean Fates/131.ts
@@ -66,7 +66,7 @@ const card: Card = {
 	illustrator: "Yuu Nishida",
 
 	thirdParty: {
-		cardmarket: 751545
+		cardmarket: 751670
 	}
 }
 

--- a/data/Scarlet & Violet/Paldean Fates/132.ts
+++ b/data/Scarlet & Violet/Paldean Fates/132.ts
@@ -85,7 +85,7 @@ const card: Card = {
 	illustrator: "Sanosuke Sakuma",
 
 	thirdParty: {
-		cardmarket: 751546
+		cardmarket: 751671
 	}
 }
 

--- a/data/Scarlet & Violet/Paldean Fates/146.ts
+++ b/data/Scarlet & Violet/Paldean Fates/146.ts
@@ -74,7 +74,7 @@ const card: Card = {
 	illustrator: "Nisota Niso",
 
 	thirdParty: {
-		cardmarket: 751552
+		cardmarket: 751685
 	}
 }
 

--- a/data/Scarlet & Violet/Paldean Fates/151.ts
+++ b/data/Scarlet & Violet/Paldean Fates/151.ts
@@ -55,7 +55,7 @@ const card: Card = {
 	illustrator: "sowsow",
 
 	thirdParty: {
-		cardmarket: 751558
+		cardmarket: 751690
 	}
 }
 

--- a/data/Scarlet & Violet/Paldean Fates/152.ts
+++ b/data/Scarlet & Violet/Paldean Fates/152.ts
@@ -76,7 +76,7 @@ const card: Card = {
 	illustrator: "nagimiso",
 
 	thirdParty: {
-		cardmarket: 751559
+		cardmarket: 751691
 	}
 }
 

--- a/data/Scarlet & Violet/Paldean Fates/153.ts
+++ b/data/Scarlet & Violet/Paldean Fates/153.ts
@@ -46,7 +46,7 @@ const card: Card = {
 	illustrator: "yuu",
 
 	thirdParty: {
-		cardmarket: 751560
+		cardmarket: 751692
 	}
 }
 

--- a/data/Scarlet & Violet/Paldean Fates/154.ts
+++ b/data/Scarlet & Violet/Paldean Fates/154.ts
@@ -76,7 +76,7 @@ const card: Card = {
 	illustrator: "Ryuta Fuse",
 
 	thirdParty: {
-		cardmarket: 751561
+		cardmarket: 751693
 	}
 }
 

--- a/data/Scarlet & Violet/Paldean Fates/157.ts
+++ b/data/Scarlet & Violet/Paldean Fates/157.ts
@@ -51,7 +51,7 @@ const card: Card = {
 	illustrator: "Saya Tsuruta",
 
 	thirdParty: {
-		cardmarket: 751566
+		cardmarket: 751696
 	}
 }
 

--- a/data/Scarlet & Violet/Paldean Fates/160.ts
+++ b/data/Scarlet & Violet/Paldean Fates/160.ts
@@ -75,7 +75,7 @@ const card: Card = {
 	illustrator: "Nelnal",
 
 	thirdParty: {
-		cardmarket: 751574
+		cardmarket: 751699
 	}
 }
 

--- a/data/Scarlet & Violet/Paldean Fates/161.ts
+++ b/data/Scarlet & Violet/Paldean Fates/161.ts
@@ -76,7 +76,7 @@ const card: Card = {
 	illustrator: "Sanosuke Sakuma",
 
 	thirdParty: {
-		cardmarket: 751576
+		cardmarket: 751700
 	}
 }
 

--- a/data/Scarlet & Violet/Paldean Fates/162.ts
+++ b/data/Scarlet & Violet/Paldean Fates/162.ts
@@ -85,7 +85,7 @@ const card: Card = {
 	illustrator: "Kouki Saitou",
 
 	thirdParty: {
-		cardmarket: 751577
+		cardmarket: 751701
 	}
 }
 

--- a/data/Scarlet & Violet/Paldean Fates/164.ts
+++ b/data/Scarlet & Violet/Paldean Fates/164.ts
@@ -55,7 +55,7 @@ const card: Card = {
 	illustrator: "Kyoko Umemoto",
 
 	thirdParty: {
-		cardmarket: 751578
+		cardmarket: 751703
 	}
 }
 

--- a/data/Scarlet & Violet/Paldean Fates/168.ts
+++ b/data/Scarlet & Violet/Paldean Fates/168.ts
@@ -63,7 +63,7 @@ const card: Card = {
 	illustrator: "Shin Nagasawa",
 
 	thirdParty: {
-		cardmarket: 751580
+		cardmarket: 751707
 	}
 }
 

--- a/data/Scarlet & Violet/Paldean Fates/169.ts
+++ b/data/Scarlet & Violet/Paldean Fates/169.ts
@@ -55,7 +55,7 @@ const card: Card = {
 	illustrator: "nagimiso",
 
 	thirdParty: {
-		cardmarket: 751582
+		cardmarket: 751708
 	}
 }
 

--- a/data/Scarlet & Violet/Paldean Fates/170.ts
+++ b/data/Scarlet & Violet/Paldean Fates/170.ts
@@ -63,7 +63,7 @@ const card: Card = {
 	illustrator: "Scav",
 
 	thirdParty: {
-		cardmarket: 751583
+		cardmarket: 751709
 	}
 }
 

--- a/data/Scarlet & Violet/Paldean Fates/171.ts
+++ b/data/Scarlet & Violet/Paldean Fates/171.ts
@@ -85,7 +85,7 @@ const card: Card = {
 	illustrator: "Hitoshi Ariga",
 
 	thirdParty: {
-		cardmarket: 751584
+		cardmarket: 751710
 	}
 }
 

--- a/data/Scarlet & Violet/Paldean Fates/172.ts
+++ b/data/Scarlet & Violet/Paldean Fates/172.ts
@@ -77,7 +77,7 @@ const card: Card = {
 	illustrator: "nagimiso",
 
 	thirdParty: {
-		cardmarket: 751650
+		cardmarket: 751711
 	}
 }
 

--- a/data/Scarlet & Violet/Paldean Fates/180.ts
+++ b/data/Scarlet & Violet/Paldean Fates/180.ts
@@ -66,7 +66,7 @@ const card: Card = {
 	illustrator: "Nisota Niso",
 
 	thirdParty: {
-		cardmarket: 751596
+		cardmarket: 751719
 	}
 }
 

--- a/data/Scarlet & Violet/Paldean Fates/188.ts
+++ b/data/Scarlet & Violet/Paldean Fates/188.ts
@@ -85,7 +85,7 @@ const card: Card = {
 	illustrator: "Hitoshi Ariga",
 
 	thirdParty: {
-		cardmarket: 751601
+		cardmarket: 751727
 	}
 }
 

--- a/data/Scarlet & Violet/Paldean Fates/192.ts
+++ b/data/Scarlet & Violet/Paldean Fates/192.ts
@@ -66,7 +66,7 @@ const card: Card = {
 	illustrator: "Masakazu Fukuda",
 
 	thirdParty: {
-		cardmarket: 751602
+		cardmarket: 751731
 	}
 }
 

--- a/data/Scarlet & Violet/Paldean Fates/193.ts
+++ b/data/Scarlet & Violet/Paldean Fates/193.ts
@@ -85,7 +85,7 @@ const card: Card = {
 	illustrator: "GOSSAN",
 
 	thirdParty: {
-		cardmarket: 751603
+		cardmarket: 751732
 	}
 }
 

--- a/data/Scarlet & Violet/Paldean Fates/194.ts
+++ b/data/Scarlet & Violet/Paldean Fates/194.ts
@@ -46,7 +46,7 @@ const card: Card = {
 	illustrator: "Nelnal",
 
 	thirdParty: {
-		cardmarket: 751606
+		cardmarket: 751733
 	}
 }
 

--- a/data/Scarlet & Violet/Paldean Fates/195.ts
+++ b/data/Scarlet & Violet/Paldean Fates/195.ts
@@ -55,7 +55,7 @@ const card: Card = {
 	illustrator: "Souichirou Gunjima",
 
 	thirdParty: {
-		cardmarket: 751608
+		cardmarket: 751734
 	}
 }
 

--- a/data/Scarlet & Violet/Paldean Fates/207.ts
+++ b/data/Scarlet & Violet/Paldean Fates/207.ts
@@ -55,7 +55,7 @@ const card: Card = {
 	illustrator: "Akira Komayama",
 
 	thirdParty: {
-		cardmarket: 751609
+		cardmarket: 751746
 	}
 }
 

--- a/data/Scarlet & Violet/Paldean Fates/208.ts
+++ b/data/Scarlet & Violet/Paldean Fates/208.ts
@@ -83,7 +83,7 @@ const card: Card = {
 	illustrator: "Misa Tsutsui",
 
 	thirdParty: {
-		cardmarket: 751610
+		cardmarket: 751747
 	}
 }
 

--- a/data/Scarlet & Violet/Paldean Fates/209.ts
+++ b/data/Scarlet & Violet/Paldean Fates/209.ts
@@ -66,7 +66,7 @@ const card: Card = {
 	illustrator: "Lee HyunJung",
 
 	thirdParty: {
-		cardmarket: 751611
+		cardmarket: 751748
 	}
 }
 

--- a/data/Scarlet & Violet/Paldean Fates/210.ts
+++ b/data/Scarlet & Violet/Paldean Fates/210.ts
@@ -76,7 +76,7 @@ const card: Card = {
 	illustrator: "Shigenori Negishi",
 
 	thirdParty: {
-		cardmarket: 751612
+		cardmarket: 751749
 	}
 }
 

--- a/data/Scarlet & Violet/Paldean Fates/212.ts
+++ b/data/Scarlet & Violet/Paldean Fates/212.ts
@@ -85,7 +85,7 @@ const card: Card = {
 	illustrator: "5ban Graphics",
 
 	thirdParty: {
-		cardmarket: 751528
+		cardmarket: 751751
 	}
 }
 

--- a/data/Scarlet & Violet/Paldean Fates/213.ts
+++ b/data/Scarlet & Violet/Paldean Fates/213.ts
@@ -85,7 +85,7 @@ const card: Card = {
 	illustrator: "5ban Graphics",
 
 	thirdParty: {
-		cardmarket: 751531
+		cardmarket: 751752
 	}
 }
 

--- a/data/Scarlet & Violet/Paldean Fates/214.ts
+++ b/data/Scarlet & Violet/Paldean Fates/214.ts
@@ -85,7 +85,7 @@ const card: Card = {
 	illustrator: "takuyoa",
 
 	thirdParty: {
-		cardmarket: 751532
+		cardmarket: 751753
 	}
 }
 

--- a/data/Scarlet & Violet/Paldean Fates/217.ts
+++ b/data/Scarlet & Violet/Paldean Fates/217.ts
@@ -85,7 +85,7 @@ const card: Card = {
 	illustrator: "N-DESIGN Inc.",
 
 	thirdParty: {
-		cardmarket: 751562
+		cardmarket: 751764
 	}
 }
 

--- a/data/Scarlet & Violet/Paldean Fates/219.ts
+++ b/data/Scarlet & Violet/Paldean Fates/219.ts
@@ -85,7 +85,7 @@ const card: Card = {
 	illustrator: "PLANETA Mochizuki",
 
 	thirdParty: {
-		cardmarket: 751597
+		cardmarket: 751766
 	}
 }
 

--- a/data/Scarlet & Violet/Paldean Fates/220.ts
+++ b/data/Scarlet & Violet/Paldean Fates/220.ts
@@ -85,7 +85,7 @@ const card: Card = {
 	illustrator: "Eske Yoshinob",
 
 	thirdParty: {
-		cardmarket: 751607
+		cardmarket: 751767
 	}
 }
 

--- a/data/Scarlet & Violet/Paldean Fates/223.ts
+++ b/data/Scarlet & Violet/Paldean Fates/223.ts
@@ -77,7 +77,7 @@ const card: Card = {
 	illustrator: "PLANETA Mochizuki",
 
 	thirdParty: {
-		cardmarket: 751613
+		cardmarket: 751770
 	}
 }
 

--- a/data/Scarlet & Violet/Paldean Fates/224.ts
+++ b/data/Scarlet & Violet/Paldean Fates/224.ts
@@ -74,7 +74,7 @@ const card: Card = {
 	illustrator: "Tetsu Kayama",
 
 	thirdParty: {
-		cardmarket: 751661
+		cardmarket: 751771
 	}
 }
 

--- a/data/Scarlet & Violet/Paldean Fates/225.ts
+++ b/data/Scarlet & Violet/Paldean Fates/225.ts
@@ -85,7 +85,7 @@ const card: Card = {
 	illustrator: "akagi",
 
 	thirdParty: {
-		cardmarket: 751663
+		cardmarket: 751772
 	}
 }
 

--- a/data/Scarlet & Violet/Paldean Fates/226.ts
+++ b/data/Scarlet & Violet/Paldean Fates/226.ts
@@ -59,7 +59,7 @@ const card: Card = {
 	illustrator: "REND",
 
 	thirdParty: {
-		cardmarket: 751681
+		cardmarket: 751773
 	}
 }
 

--- a/data/Scarlet & Violet/Paldean Fates/227.ts
+++ b/data/Scarlet & Violet/Paldean Fates/227.ts
@@ -36,7 +36,7 @@ const card: Card = {
 	illustrator: "GOSSAN",
 
 	thirdParty: {
-		cardmarket: 751616
+		cardmarket: 751774
 	}
 }
 

--- a/data/Scarlet & Violet/Paldean Fates/229.ts
+++ b/data/Scarlet & Violet/Paldean Fates/229.ts
@@ -36,7 +36,7 @@ const card: Card = {
 	illustrator: "Sanosuke Sakuma",
 
 	thirdParty: {
-		cardmarket: 751621
+		cardmarket: 751776
 	}
 }
 

--- a/data/Scarlet & Violet/Paldean Fates/230.ts
+++ b/data/Scarlet & Violet/Paldean Fates/230.ts
@@ -36,7 +36,7 @@ const card: Card = {
 	illustrator: "Cona Nitanda",
 
 	thirdParty: {
-		cardmarket: 751624
+		cardmarket: 751777
 	}
 }
 

--- a/data/Scarlet & Violet/Paldean Fates/231.ts
+++ b/data/Scarlet & Violet/Paldean Fates/231.ts
@@ -36,7 +36,7 @@ const card: Card = {
 	illustrator: "Naoki Saito",
 
 	thirdParty: {
-		cardmarket: 751624
+		cardmarket: 751778
 	}
 }
 

--- a/data/Scarlet & Violet/Paldean Fates/232.ts
+++ b/data/Scarlet & Violet/Paldean Fates/232.ts
@@ -75,7 +75,7 @@ const card: Card = {
 	illustrator: "USGMEN",
 
 	thirdParty: {
-		cardmarket: 751763
+		cardmarket: 751779
 	}
 }
 

--- a/data/Scarlet & Violet/Paldean Fates/233.ts
+++ b/data/Scarlet & Violet/Paldean Fates/233.ts
@@ -85,7 +85,7 @@ const card: Card = {
 	illustrator: "Kuroimori",
 
 	thirdParty: {
-		cardmarket: 751562
+		cardmarket: 751780
 	}
 }
 

--- a/data/Scarlet & Violet/Paldean Fates/234.ts
+++ b/data/Scarlet & Violet/Paldean Fates/234.ts
@@ -85,7 +85,7 @@ const card: Card = {
 	illustrator: "AKIRA EGAWA",
 
 	thirdParty: {
-		cardmarket: 751591
+		cardmarket: 751781
 	}
 }
 

--- a/data/Scarlet & Violet/Paldean Fates/236.ts
+++ b/data/Scarlet & Violet/Paldean Fates/236.ts
@@ -36,7 +36,7 @@ const card: Card = {
 	illustrator: "Taiga Kayama",
 
 	thirdParty: {
-		cardmarket: 751616
+		cardmarket: 751783
 	}
 }
 

--- a/data/Scarlet & Violet/Paldean Fates/237.ts
+++ b/data/Scarlet & Violet/Paldean Fates/237.ts
@@ -36,7 +36,7 @@ const card: Card = {
 	illustrator: "hanabushi",
 
 	thirdParty: {
-		cardmarket: 751619
+		cardmarket: 751784
 	}
 }
 

--- a/data/Scarlet & Violet/Paldean Fates/238.ts
+++ b/data/Scarlet & Violet/Paldean Fates/238.ts
@@ -36,7 +36,7 @@ const card: Card = {
 	illustrator: "aspara",
 
 	thirdParty: {
-		cardmarket: 751621
+		cardmarket: 751785
 	}
 }
 


### PR DESCRIPTION
Corrected the 'cardmarket' thirdParty IDs for multiple cards in the Scarlet & Violet: Paldean Fates