### PR TITLE
fix: Update Cardmarket IDs for Paradox Rift cards

### DIFF
--- a/data/Scarlet & Violet/Paradox Rift/014.ts
+++ b/data/Scarlet & Violet/Paradox Rift/014.ts
@@ -45,7 +45,7 @@ const card: Card = {
 	illustrator: "Kouki Saitou",
 
 	thirdParty: {
-		cardmarket: 740489
+		cardmarket: 740490
 	}
 }
 

--- a/data/Scarlet & Violet/Paradox Rift/016.ts
+++ b/data/Scarlet & Violet/Paradox Rift/016.ts
@@ -67,7 +67,7 @@ const card: Card = {
 	illustrator: "Souichirou Gunjima",
 
 	thirdParty: {
-		cardmarket: 740491
+		cardmarket: 740492
 	}
 }
 

--- a/data/Scarlet & Violet/Paradox Rift/026.ts
+++ b/data/Scarlet & Violet/Paradox Rift/026.ts
@@ -65,7 +65,7 @@ const card: Card = {
 	illustrator: "Mizue",
 
 	thirdParty: {
-		cardmarket: 740501
+		cardmarket: 740502
 	}
 }
 

--- a/data/Scarlet & Violet/Paradox Rift/048.ts
+++ b/data/Scarlet & Violet/Paradox Rift/048.ts
@@ -65,7 +65,7 @@ const card: Card = {
 	illustrator: "sowsow",
 
 	thirdParty: {
-		cardmarket: 740527
+		cardmarket: 740530
 	}
 }
 

--- a/data/Scarlet & Violet/Paradox Rift/052.ts
+++ b/data/Scarlet & Violet/Paradox Rift/052.ts
@@ -45,7 +45,7 @@ const card: Card = {
 	illustrator: "Tomokazu Komiya",
 
 	thirdParty: {
-		cardmarket: 740539
+		cardmarket: 740542
 	}
 }
 

--- a/data/Scarlet & Violet/Paradox Rift/080.ts
+++ b/data/Scarlet & Violet/Paradox Rift/080.ts
@@ -54,7 +54,7 @@ const card: Card = {
 	illustrator: "kodama",
 
 	thirdParty: {
-		cardmarket: 740571
+		cardmarket: 740572
 	}
 }
 

--- a/data/Scarlet & Violet/Paradox Rift/083.ts
+++ b/data/Scarlet & Violet/Paradox Rift/083.ts
@@ -54,7 +54,7 @@ const card: Card = {
 	illustrator: "Oswaldo KATO",
 
 	thirdParty: {
-		cardmarket: 740574
+		cardmarket: 740575
 	}
 }
 

--- a/data/Scarlet & Violet/Paradox Rift/088.ts
+++ b/data/Scarlet & Violet/Paradox Rift/088.ts
@@ -54,7 +54,7 @@ const card: Card = {
 	illustrator: "Kouki Saitou",
 
 	thirdParty: {
-		cardmarket: 740579
+		cardmarket: 740580
 	}
 }
 

--- a/data/Scarlet & Violet/Paradox Rift/102.ts
+++ b/data/Scarlet & Violet/Paradox Rift/102.ts
@@ -54,7 +54,7 @@ const card: Card = {
 	illustrator: "Pani Kobayashi",
 
 	thirdParty: {
-		cardmarket: 740615
+		cardmarket: 740616
 	}
 }
 

--- a/data/Scarlet & Violet/Paradox Rift/131.ts
+++ b/data/Scarlet & Violet/Paradox Rift/131.ts
@@ -54,7 +54,7 @@ const card: Card = {
 	illustrator: "Nagomi Nijo",
 
 	thirdParty: {
-		cardmarket: 740668
+		cardmarket: 740669
 	}
 }
 

--- a/data/Scarlet & Violet/Paradox Rift/133.ts
+++ b/data/Scarlet & Violet/Paradox Rift/133.ts
@@ -73,7 +73,7 @@ const card: Card = {
 	illustrator: "Shigenori Negishi",
 
 	thirdParty: {
-		cardmarket: 740670
+		cardmarket: 740671
 	}
 }
 

--- a/data/Scarlet & Violet/Paradox Rift/154.ts
+++ b/data/Scarlet & Violet/Paradox Rift/154.ts
@@ -54,7 +54,7 @@ const card: Card = {
 	illustrator: "Akira Komayama",
 
 	thirdParty: {
-		cardmarket: 740693
+		cardmarket: 740694
 	}
 }
 

--- a/data/Scarlet & Violet/Paradox Rift/183.ts
+++ b/data/Scarlet & Violet/Paradox Rift/183.ts
@@ -76,7 +76,7 @@ const card: Card = {
 	illustrator: "OKUBO",
 
 	thirdParty: {
-		cardmarket: 740483
+		cardmarket: 740726
 	}
 }
 

--- a/data/Scarlet & Violet/Paradox Rift/184.ts
+++ b/data/Scarlet & Violet/Paradox Rift/184.ts
@@ -74,7 +74,7 @@ const card: Card = {
 	illustrator: "Tetsu Kayama",
 
 	thirdParty: {
-		cardmarket: 740487
+		cardmarket: 740727
 	}
 }
 

--- a/data/Scarlet & Violet/Paradox Rift/185.ts
+++ b/data/Scarlet & Violet/Paradox Rift/185.ts
@@ -85,7 +85,7 @@ const card: Card = {
 	illustrator: "KEIICHIRO ITO",
 
 	thirdParty: {
-		cardmarket: 740493
+		cardmarket: 740728
 	}
 }
 

--- a/data/Scarlet & Violet/Paradox Rift/186.ts
+++ b/data/Scarlet & Violet/Paradox Rift/186.ts
@@ -51,7 +51,7 @@ const card: Card = {
 	illustrator: "Mina Nakai",
 
 	thirdParty: {
-		cardmarket: 740495
+		cardmarket: 740729
 	}
 }
 

--- a/data/Scarlet & Violet/Paradox Rift/187.ts
+++ b/data/Scarlet & Violet/Paradox Rift/187.ts
@@ -77,7 +77,7 @@ const card: Card = {
 	illustrator: "Takeshi Nakamura",
 
 	thirdParty: {
-		cardmarket: 740504
+		cardmarket: 740730
 	}
 }
 

--- a/data/Scarlet & Violet/Paradox Rift/188.ts
+++ b/data/Scarlet & Violet/Paradox Rift/188.ts
@@ -55,7 +55,7 @@ const card: Card = {
 	illustrator: "Narumi Sato",
 
 	thirdParty: {
-		cardmarket: 740513
+		cardmarket: 740731
 	}
 }
 

--- a/data/Scarlet & Violet/Paradox Rift/189.ts
+++ b/data/Scarlet & Violet/Paradox Rift/189.ts
@@ -51,7 +51,7 @@ const card: Card = {
 	illustrator: "rika",
 
 	thirdParty: {
-		cardmarket: 740515
+		cardmarket: 740732
 	}
 }
 

--- a/data/Scarlet & Violet/Paradox Rift/190.ts
+++ b/data/Scarlet & Violet/Paradox Rift/190.ts
@@ -54,7 +54,7 @@ const card: Card = {
 	illustrator: "Taiga Kayama",
 
 	thirdParty: {
-		cardmarket: 740521
+		cardmarket: 740733
 	}
 }
 

--- a/data/Scarlet & Violet/Paradox Rift/191.ts
+++ b/data/Scarlet & Violet/Paradox Rift/191.ts
@@ -66,7 +66,7 @@ const card: Card = {
 	illustrator: "Oku",
 
 	thirdParty: {
-		cardmarket: 740527
+		cardmarket: 740734
 	}
 }
 

--- a/data/Scarlet & Violet/Paradox Rift/192.ts
+++ b/data/Scarlet & Violet/Paradox Rift/192.ts
@@ -77,7 +77,7 @@ const card: Card = {
 	illustrator: "Shibuzoh.",
 
 	thirdParty: {
-		cardmarket: 740544
+		cardmarket: 740735
 	}
 }
 

--- a/data/Scarlet & Violet/Paradox Rift/193.ts
+++ b/data/Scarlet & Violet/Paradox Rift/193.ts
@@ -55,7 +55,7 @@ const card: Card = {
 	illustrator: "OKACHEKE",
 
 	thirdParty: {
-		cardmarket: 740551
+		cardmarket: 740736
 	}
 }
 

--- a/data/Scarlet & Violet/Paradox Rift/194.ts
+++ b/data/Scarlet & Violet/Paradox Rift/194.ts
@@ -68,7 +68,7 @@ const card: Card = {
 	illustrator: "OKACHEKE",
 
 	thirdParty: {
-		cardmarket: 740552
+		cardmarket: 740737
 	}
 }
 

--- a/data/Scarlet & Violet/Paradox Rift/195.ts
+++ b/data/Scarlet & Violet/Paradox Rift/195.ts
@@ -68,7 +68,7 @@ const card: Card = {
 	illustrator: "matazo",
 
 	thirdParty: {
-		cardmarket: 740553
+		cardmarket: 740738
 	}
 }
 

--- a/data/Scarlet & Violet/Paradox Rift/196.ts
+++ b/data/Scarlet & Violet/Paradox Rift/196.ts
@@ -55,7 +55,7 @@ const card: Card = {
 	illustrator: "Atsushi Furusawa",
 
 	thirdParty: {
-		cardmarket: 740555
+		cardmarket: 740739
 	}
 }
 

--- a/data/Scarlet & Violet/Paradox Rift/197.ts
+++ b/data/Scarlet & Violet/Paradox Rift/197.ts
@@ -85,7 +85,7 @@ const card: Card = {
 	illustrator: "AKIRA EGAWA",
 
 	thirdParty: {
-		cardmarket: 740573
+		cardmarket: 740740
 	}
 }
 

--- a/data/Scarlet & Violet/Paradox Rift/198.ts
+++ b/data/Scarlet & Violet/Paradox Rift/198.ts
@@ -55,7 +55,7 @@ const card: Card = {
 	illustrator: "Akira Komayama",
 
 	thirdParty: {
-		cardmarket: 740579
+		cardmarket: 740741
 	}
 }
 

--- a/data/Scarlet & Violet/Paradox Rift/200.ts
+++ b/data/Scarlet & Violet/Paradox Rift/200.ts
@@ -85,7 +85,7 @@ const card: Card = {
 	illustrator: "Taira Akitsu",
 
 	thirdParty: {
-		cardmarket: 740609
+		cardmarket: 740743
 	}
 }
 

--- a/data/Scarlet & Violet/Paradox Rift/201.ts
+++ b/data/Scarlet & Violet/Paradox Rift/201.ts
@@ -77,7 +77,7 @@ const card: Card = {
 	illustrator: "0313",
 
 	thirdParty: {
-		cardmarket: 740613
+		cardmarket: 740744
 	}
 }
 

--- a/data/Scarlet & Violet/Paradox Rift/202.ts
+++ b/data/Scarlet & Violet/Paradox Rift/202.ts
@@ -76,7 +76,7 @@ const card: Card = {
 	illustrator: "kodama",
 
 	thirdParty: {
-		cardmarket: 740619
+		cardmarket: 740745
 	}
 }
 

--- a/data/Scarlet & Violet/Paradox Rift/203.ts
+++ b/data/Scarlet & Violet/Paradox Rift/203.ts
@@ -75,7 +75,7 @@ const card: Card = {
 	illustrator: "Takeshi Nakamura",
 
 	thirdParty: {
-		cardmarket: 740623
+		cardmarket: 740746
 	}
 }
 

--- a/data/Scarlet & Violet/Paradox Rift/204.ts
+++ b/data/Scarlet & Violet/Paradox Rift/204.ts
@@ -85,7 +85,7 @@ const card: Card = {
 	illustrator: "Shinya Komatsu",
 
 	thirdParty: {
-		cardmarket: 740644
+		cardmarket: 740747
 	}
 }
 

--- a/data/Scarlet & Violet/Paradox Rift/205.ts
+++ b/data/Scarlet & Violet/Paradox Rift/205.ts
@@ -77,7 +77,7 @@ const card: Card = {
 	illustrator: "Masako Tomii",
 
 	thirdParty: {
-		cardmarket: 740647
+		cardmarket: 740748
 	}
 }
 

--- a/data/Scarlet & Violet/Paradox Rift/206.ts
+++ b/data/Scarlet & Violet/Paradox Rift/206.ts
@@ -77,7 +77,7 @@ const card: Card = {
 	illustrator: "Yuu Nishida",
 
 	thirdParty: {
-		cardmarket: 740654
+		cardmarket: 740749
 	}
 }
 

--- a/data/Scarlet & Violet/Paradox Rift/207.ts
+++ b/data/Scarlet & Violet/Paradox Rift/207.ts
@@ -77,7 +77,7 @@ const card: Card = {
 	illustrator: "Tomokazu Komiya",
 
 	thirdParty: {
-		cardmarket: 740660
+		cardmarket: 740750
 	}
 }
 

--- a/data/Scarlet & Violet/Paradox Rift/208.ts
+++ b/data/Scarlet & Violet/Paradox Rift/208.ts
@@ -76,7 +76,7 @@ const card: Card = {
 	illustrator: "nisimono",
 
 	thirdParty: {
-		cardmarket: 740662
+		cardmarket: 740751
 	}
 }
 

--- a/data/Scarlet & Violet/Paradox Rift/209.ts
+++ b/data/Scarlet & Violet/Paradox Rift/209.ts
@@ -85,7 +85,7 @@ const card: Card = {
 	illustrator: "Kurata So",
 
 	thirdParty: {
-		cardmarket: 740665
+		cardmarket: 740752
 	}
 }
 

--- a/data/Scarlet & Violet/Paradox Rift/210.ts
+++ b/data/Scarlet & Violet/Paradox Rift/210.ts
@@ -85,7 +85,7 @@ const card: Card = {
 	illustrator: "Takumi Wada",
 
 	thirdParty: {
-		cardmarket: 740672
+		cardmarket: 740753
 	}
 }
 

--- a/data/Scarlet & Violet/Paradox Rift/211.ts
+++ b/data/Scarlet & Violet/Paradox Rift/211.ts
@@ -66,7 +66,7 @@ const card: Card = {
 	illustrator: "Yuka Morii",
 
 	thirdParty: {
-		cardmarket: 740684
+		cardmarket: 740754
 	}
 }
 

--- a/data/Scarlet & Violet/Paradox Rift/212.ts
+++ b/data/Scarlet & Violet/Paradox Rift/212.ts
@@ -76,7 +76,7 @@ const card: Card = {
 	illustrator: "NC Empire",
 
 	thirdParty: {
-		cardmarket: 740689
+		cardmarket: 740755
 	}
 }
 

--- a/data/Scarlet & Violet/Paradox Rift/213.ts
+++ b/data/Scarlet & Violet/Paradox Rift/213.ts
@@ -66,7 +66,7 @@ const card: Card = {
 	illustrator: "Jiro Sasumo",
 
 	thirdParty: {
-		cardmarket: 740692
+		cardmarket: 740756
 	}
 }
 

--- a/data/Scarlet & Violet/Paradox Rift/214.ts
+++ b/data/Scarlet & Violet/Paradox Rift/214.ts
@@ -85,7 +85,7 @@ const card: Card = {
 	illustrator: "GOSSAN",
 
 	thirdParty: {
-		cardmarket: 740682
+		cardmarket: 740757
 	}
 }
 

--- a/data/Scarlet & Violet/Paradox Rift/215.ts
+++ b/data/Scarlet & Violet/Paradox Rift/215.ts
@@ -68,7 +68,7 @@ const card: Card = {
 	illustrator: "Mina Nakai",
 
 	thirdParty: {
-		cardmarket: 740697
+		cardmarket: 740758
 	}
 }
 

--- a/data/Scarlet & Violet/Paradox Rift/216.ts
+++ b/data/Scarlet & Violet/Paradox Rift/216.ts
@@ -75,7 +75,7 @@ const card: Card = {
 	illustrator: "GIDORA",
 
 	thirdParty: {
-		cardmarket: 740698
+		cardmarket: 740759
 	}
 }
 

--- a/data/Scarlet & Violet/Paradox Rift/217.ts
+++ b/data/Scarlet & Violet/Paradox Rift/217.ts
@@ -85,7 +85,7 @@ const card: Card = {
 	illustrator: "5ban Graphics",
 
 	thirdParty: {
-		cardmarket: 740479
+		cardmarket: 740760
 	}
 }
 

--- a/data/Scarlet & Violet/Paradox Rift/218.ts
+++ b/data/Scarlet & Violet/Paradox Rift/218.ts
@@ -85,7 +85,7 @@ const card: Card = {
 	illustrator: "takuyoa",
 
 	thirdParty: {
-		cardmarket: 740503
+		cardmarket: 740761
 	}
 }
 

--- a/data/Scarlet & Violet/Paradox Rift/219.ts
+++ b/data/Scarlet & Violet/Paradox Rift/219.ts
@@ -83,7 +83,7 @@ const card: Card = {
 	illustrator: "5ban Graphics",
 
 	thirdParty: {
-		cardmarket: 740514
+		cardmarket: 740762
 	}
 }
 

--- a/data/Scarlet & Violet/Paradox Rift/220.ts
+++ b/data/Scarlet & Violet/Paradox Rift/220.ts
@@ -83,7 +83,7 @@ const card: Card = {
 	illustrator: "5ban Graphics",
 
 	thirdParty: {
-		cardmarket: 740526
+		cardmarket: 740763
 	}
 }
 

--- a/data/Scarlet & Violet/Paradox Rift/221.ts
+++ b/data/Scarlet & Violet/Paradox Rift/221.ts
@@ -76,7 +76,7 @@ const card: Card = {
 	illustrator: "N-DESIGN Inc.",
 
 	thirdParty: {
-		cardmarket: 740535
+		cardmarket: 740764
 	}
 }
 

--- a/data/Scarlet & Violet/Paradox Rift/222.ts
+++ b/data/Scarlet & Violet/Paradox Rift/222.ts
@@ -77,7 +77,7 @@ const card: Card = {
 	illustrator: "PLANETA Igarashi",
 
 	thirdParty: {
-		cardmarket: 740559
+		cardmarket: 740765
 	}
 }
 

--- a/data/Scarlet & Violet/Paradox Rift/223.ts
+++ b/data/Scarlet & Violet/Paradox Rift/223.ts
@@ -68,7 +68,7 @@ const card: Card = {
 	illustrator: "PLANETA Mochizuki",
 
 	thirdParty: {
-		cardmarket: 740562
+		cardmarket: 740766
 	}
 }
 

--- a/data/Scarlet & Violet/Paradox Rift/224.ts
+++ b/data/Scarlet & Violet/Paradox Rift/224.ts
@@ -85,7 +85,7 @@ const card: Card = {
 	illustrator: "Eske Yoshinob",
 
 	thirdParty: {
-		cardmarket: 740568
+		cardmarket: 740767
 	}
 }
 

--- a/data/Scarlet & Violet/Paradox Rift/225.ts
+++ b/data/Scarlet & Violet/Paradox Rift/225.ts
@@ -77,7 +77,7 @@ const card: Card = {
 	illustrator: "aky CG Works",
 
 	thirdParty: {
-		cardmarket: 740582
+		cardmarket: 740768
 	}
 }
 

--- a/data/Scarlet & Violet/Paradox Rift/226.ts
+++ b/data/Scarlet & Violet/Paradox Rift/226.ts
@@ -77,7 +77,7 @@ const card: Card = {
 	illustrator: "5ban Graphics",
 
 	thirdParty: {
-		cardmarket: 740611
+		cardmarket: 740769
 	}
 }
 

--- a/data/Scarlet & Violet/Paradox Rift/227.ts
+++ b/data/Scarlet & Violet/Paradox Rift/227.ts
@@ -85,7 +85,7 @@ const card: Card = {
 	illustrator: "5ban Graphics",
 
 	thirdParty: {
-		cardmarket: 740614
+		cardmarket: 740770
 	}
 }
 

--- a/data/Scarlet & Violet/Paradox Rift/228.ts
+++ b/data/Scarlet & Violet/Paradox Rift/228.ts
@@ -77,7 +77,7 @@ const card: Card = {
 	illustrator: "PLANETA Mochizuki",
 
 	thirdParty: {
-		cardmarket: 740625
+		cardmarket: 740771
 	}
 }
 

--- a/data/Scarlet & Violet/Paradox Rift/229.ts
+++ b/data/Scarlet & Violet/Paradox Rift/229.ts
@@ -75,7 +75,7 @@ const card: Card = {
 	illustrator: "takuyoa",
 
 	thirdParty: {
-		cardmarket: 740661
+		cardmarket: 740772
 	}
 }
 

--- a/data/Scarlet & Violet/Paradox Rift/230.ts
+++ b/data/Scarlet & Violet/Paradox Rift/230.ts
@@ -85,7 +85,7 @@ const card: Card = {
 	illustrator: "Satoshi Shirai",
 
 	thirdParty: {
-		cardmarket: 740673
+		cardmarket: 740773
 	}
 }
 

--- a/data/Scarlet & Violet/Paradox Rift/231.ts
+++ b/data/Scarlet & Violet/Paradox Rift/231.ts
@@ -85,7 +85,7 @@ const card: Card = {
 	illustrator: "takuyoa",
 
 	thirdParty: {
-		cardmarket: 740677
+		cardmarket: 740774
 	}
 }
 

--- a/data/Scarlet & Violet/Paradox Rift/232.ts
+++ b/data/Scarlet & Violet/Paradox Rift/232.ts
@@ -85,7 +85,7 @@ const card: Card = {
 	illustrator: "Saki Hayashiro",
 
 	thirdParty: {
-		cardmarket: 740678
+		cardmarket: 740775
 	}
 }
 

--- a/data/Scarlet & Violet/Paradox Rift/233.ts
+++ b/data/Scarlet & Violet/Paradox Rift/233.ts
@@ -85,7 +85,7 @@ const card: Card = {
 	illustrator: "5ban Graphics",
 
 	thirdParty: {
-		cardmarket: 740695
+		cardmarket: 740776
 	}
 }
 

--- a/data/Scarlet & Violet/Paradox Rift/234.ts
+++ b/data/Scarlet & Violet/Paradox Rift/234.ts
@@ -75,7 +75,7 @@ const card: Card = {
 	illustrator: "PLANETA Mochizuki",
 
 	thirdParty: {
-		cardmarket: 740696
+		cardmarket: 740777
 	}
 }
 

--- a/data/Scarlet & Violet/Paradox Rift/235.ts
+++ b/data/Scarlet & Violet/Paradox Rift/235.ts
@@ -36,7 +36,7 @@ const card: Card = {
 	illustrator: "Akira Komayama",
 
 	thirdParty: {
-		cardmarket: 740707
+		cardmarket: 740778
 	}
 }
 

--- a/data/Scarlet & Violet/Paradox Rift/236.ts
+++ b/data/Scarlet & Violet/Paradox Rift/236.ts
@@ -36,7 +36,7 @@ const card: Card = {
 	illustrator: "kirisAki",
 
 	thirdParty: {
-		cardmarket: 740709
+		cardmarket: 740779
 	}
 }
 

--- a/data/Scarlet & Violet/Paradox Rift/237.ts
+++ b/data/Scarlet & Violet/Paradox Rift/237.ts
@@ -36,7 +36,7 @@ const card: Card = {
 	illustrator: "Hideki Ishikawa",
 
 	thirdParty: {
-		cardmarket: 740710
+		cardmarket: 740780
 	}
 }
 

--- a/data/Scarlet & Violet/Paradox Rift/238.ts
+++ b/data/Scarlet & Violet/Paradox Rift/238.ts
@@ -36,7 +36,7 @@ const card: Card = {
 	illustrator: "Cona Nitanda",
 
 	thirdParty: {
-		cardmarket: 740711
+		cardmarket: 740781
 	}
 }
 

--- a/data/Scarlet & Violet/Paradox Rift/239.ts
+++ b/data/Scarlet & Violet/Paradox Rift/239.ts
@@ -36,7 +36,7 @@ const card: Card = {
 	illustrator: "Megumi Mizutani",
 
 	thirdParty: {
-		cardmarket: 740712
+		cardmarket: 740782
 	}
 }
 

--- a/data/Scarlet & Violet/Paradox Rift/240.ts
+++ b/data/Scarlet & Violet/Paradox Rift/240.ts
@@ -36,7 +36,7 @@ const card: Card = {
 	illustrator: "hncl",
 
 	thirdParty: {
-		cardmarket: 740713
+		cardmarket: 740783
 	}
 }
 

--- a/data/Scarlet & Violet/Paradox Rift/241.ts
+++ b/data/Scarlet & Violet/Paradox Rift/241.ts
@@ -36,7 +36,7 @@ const card: Card = {
 	illustrator: "GIDORA",
 
 	thirdParty: {
-		cardmarket: 740714
+		cardmarket: 740784
 	}
 }
 

--- a/data/Scarlet & Violet/Paradox Rift/242.ts
+++ b/data/Scarlet & Violet/Paradox Rift/242.ts
@@ -36,7 +36,7 @@ const card: Card = {
 	illustrator: "Ryuta Fuse",
 
 	thirdParty: {
-		cardmarket: 740716
+		cardmarket: 740785
 	}
 }
 

--- a/data/Scarlet & Violet/Paradox Rift/243.ts
+++ b/data/Scarlet & Violet/Paradox Rift/243.ts
@@ -36,7 +36,7 @@ const card: Card = {
 	illustrator: "En Morikura",
 
 	thirdParty: {
-		cardmarket: 740717
+		cardmarket: 740786
 	}
 }
 

--- a/data/Scarlet & Violet/Paradox Rift/244.ts
+++ b/data/Scarlet & Violet/Paradox Rift/244.ts
@@ -36,7 +36,7 @@ const card: Card = {
 	illustrator: "Naoki Saito",
 
 	thirdParty: {
-		cardmarket: 740724
+		cardmarket: 740787
 	}
 }
 

--- a/data/Scarlet & Violet/Paradox Rift/245.ts
+++ b/data/Scarlet & Violet/Paradox Rift/245.ts
@@ -83,7 +83,7 @@ const card: Card = {
 	illustrator: "Oswaldo KATO",
 
 	thirdParty: {
-		cardmarket: 740514
+		cardmarket: 740788
 	}
 }
 

--- a/data/Scarlet & Violet/Paradox Rift/246.ts
+++ b/data/Scarlet & Violet/Paradox Rift/246.ts
@@ -76,7 +76,7 @@ const card: Card = {
 	illustrator: "Oku",
 
 	thirdParty: {
-		cardmarket: 740535
+		cardmarket: 740789
 	}
 }
 

--- a/data/Scarlet & Violet/Paradox Rift/247.ts
+++ b/data/Scarlet & Violet/Paradox Rift/247.ts
@@ -77,7 +77,7 @@ const card: Card = {
 	illustrator: "Jerky",
 
 	thirdParty: {
-		cardmarket: 740559
+		cardmarket: 740790
 	}
 }
 

--- a/data/Scarlet & Violet/Paradox Rift/248.ts
+++ b/data/Scarlet & Violet/Paradox Rift/248.ts
@@ -68,7 +68,7 @@ const card: Card = {
 	illustrator: "Toshinao Aoki",
 
 	thirdParty: {
-		cardmarket: 740562
+		cardmarket: 740791
 	}
 }
 

--- a/data/Scarlet & Violet/Paradox Rift/249.ts
+++ b/data/Scarlet & Violet/Paradox Rift/249.ts
@@ -77,7 +77,7 @@ const card: Card = {
 	illustrator: "kantaro",
 
 	thirdParty: {
-		cardmarket: 740582
+		cardmarket: 740792
 	}
 }
 

--- a/data/Scarlet & Violet/Paradox Rift/250.ts
+++ b/data/Scarlet & Violet/Paradox Rift/250.ts
@@ -77,7 +77,7 @@ const card: Card = {
 	illustrator: "Toshinao Aoki",
 
 	thirdParty: {
-		cardmarket: 740625
+		cardmarket: 740793
 	}
 }
 

--- a/data/Scarlet & Violet/Paradox Rift/251.ts
+++ b/data/Scarlet & Violet/Paradox Rift/251.ts
@@ -75,7 +75,7 @@ const card: Card = {
 	illustrator: "Ryota Murayama",
 
 	thirdParty: {
-		cardmarket: 740661
+		cardmarket: 740794
 	}
 }
 

--- a/data/Scarlet & Violet/Paradox Rift/252.ts
+++ b/data/Scarlet & Violet/Paradox Rift/252.ts
@@ -85,7 +85,7 @@ const card: Card = {
 	illustrator: "Akira Komayama",
 
 	thirdParty: {
-		cardmarket: 740677
+		cardmarket: 740795
 	}
 }
 

--- a/data/Scarlet & Violet/Paradox Rift/253.ts
+++ b/data/Scarlet & Violet/Paradox Rift/253.ts
@@ -85,7 +85,7 @@ const card: Card = {
 	illustrator: "Jiro Sasumo",
 
 	thirdParty: {
-		cardmarket: 740678
+		cardmarket: 740796
 	}
 }
 

--- a/data/Scarlet & Violet/Paradox Rift/254.ts
+++ b/data/Scarlet & Violet/Paradox Rift/254.ts
@@ -36,7 +36,7 @@ const card: Card = {
 	illustrator: "rika",
 
 	thirdParty: {
-		cardmarket: 740709
+		cardmarket: 740797
 	}
 }
 

--- a/data/Scarlet & Violet/Paradox Rift/255.ts
+++ b/data/Scarlet & Violet/Paradox Rift/255.ts
@@ -36,7 +36,7 @@ const card: Card = {
 	illustrator: "En Morikura",
 
 	thirdParty: {
-		cardmarket: 740711
+		cardmarket: 740798
 	}
 }
 

--- a/data/Scarlet & Violet/Paradox Rift/256.ts
+++ b/data/Scarlet & Violet/Paradox Rift/256.ts
@@ -36,7 +36,7 @@ const card: Card = {
 	illustrator: "Ryota Murayama",
 
 	thirdParty: {
-		cardmarket: 740712
+		cardmarket: 740799
 	}
 }
 

--- a/data/Scarlet & Violet/Paradox Rift/257.ts
+++ b/data/Scarlet & Violet/Paradox Rift/257.ts
@@ -36,7 +36,7 @@ const card: Card = {
 	illustrator: "Atsushi Furusawa",
 
 	thirdParty: {
-		cardmarket: 740713
+		cardmarket: 740800
 	}
 }
 

--- a/data/Scarlet & Violet/Paradox Rift/258.ts
+++ b/data/Scarlet & Violet/Paradox Rift/258.ts
@@ -36,7 +36,7 @@ const card: Card = {
 	illustrator: "kantaro",
 
 	thirdParty: {
-		cardmarket: 740714
+		cardmarket: 740801
 	}
 }
 

--- a/data/Scarlet & Violet/Paradox Rift/259.ts
+++ b/data/Scarlet & Violet/Paradox Rift/259.ts
@@ -36,7 +36,7 @@ const card: Card = {
 	illustrator: "AKIRA EGAWA",
 
 	thirdParty: {
-		cardmarket: 740724
+		cardmarket: 740802
 	}
 }
 

--- a/data/Scarlet & Violet/Paradox Rift/260.ts
+++ b/data/Scarlet & Violet/Paradox Rift/260.ts
@@ -83,7 +83,7 @@ const card: Card = {
 	illustrator: "5ban Graphics",
 
 	thirdParty: {
-		cardmarket: 740514
+		cardmarket: 740803
 	}
 }
 

--- a/data/Scarlet & Violet/Paradox Rift/261.ts
+++ b/data/Scarlet & Violet/Paradox Rift/261.ts
@@ -77,7 +77,7 @@ const card: Card = {
 	illustrator: "aky CG Works",
 
 	thirdParty: {
-		cardmarket: 740582
+		cardmarket: 740804
 	}
 }
 

--- a/data/Scarlet & Violet/Paradox Rift/262.ts
+++ b/data/Scarlet & Violet/Paradox Rift/262.ts
@@ -75,7 +75,7 @@ const card: Card = {
 	illustrator: "takuyoa",
 
 	thirdParty: {
-		cardmarket: 740661
+		cardmarket: 740805
 	}
 }
 

--- a/data/Scarlet & Violet/Paradox Rift/264.ts
+++ b/data/Scarlet & Violet/Paradox Rift/264.ts
@@ -36,7 +36,7 @@ const card: Card = {
 	illustrator: "Toyste Beach",
 
 	thirdParty: {
-		cardmarket: 740701
+		cardmarket: 740807
 	}
 }
 

--- a/data/Scarlet & Violet/Paradox Rift/265.ts
+++ b/data/Scarlet & Violet/Paradox Rift/265.ts
@@ -36,7 +36,7 @@ const card: Card = {
 	illustrator: "Toyste Beach",
 
 	thirdParty: {
-		cardmarket: 740708
+		cardmarket: 740808
 	}
 }
 


### PR DESCRIPTION
Corrected the 'cardmarket' thirdParty IDs for multiple cards in the Scarlet & Violet: Paradox Rift