### PR TITLE
fix(data): Wizards Black Star Promos (Base)

### DIFF
--- a/data/Base/Wizards Black Star Promos/1.ts
+++ b/data/Base/Wizards Black Star Promos/1.ts
@@ -6,7 +6,7 @@ const card: Card = {
 		en: "Pikachu",
 	},
 	illustrator: "Keiji Kinebuchi",
-	rarity: "Common",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Base/Wizards Black Star Promos/10.ts
+++ b/data/Base/Wizards Black Star Promos/10.ts
@@ -6,7 +6,7 @@ const card: Card = {
 		en: "Meowth",
 	},
 	illustrator: "Kagemaru Himeno",
-	rarity: "Common",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Base/Wizards Black Star Promos/11.ts
+++ b/data/Base/Wizards Black Star Promos/11.ts
@@ -6,7 +6,7 @@ const card: Card = {
 		en: "Eevee",
 	},
 	illustrator: "Kagemaru Himeno",
-	rarity: "Common",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Base/Wizards Black Star Promos/12.ts
+++ b/data/Base/Wizards Black Star Promos/12.ts
@@ -6,7 +6,7 @@ const card: Card = {
 		en: "Mewtwo",
 	},
 	illustrator: "Christopher Rush",
-	rarity: "Common",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Base/Wizards Black Star Promos/13.ts
+++ b/data/Base/Wizards Black Star Promos/13.ts
@@ -6,7 +6,7 @@ const card: Card = {
 		en: "Venusaur",
 	},
 	illustrator: "Ken Sugimori",
-	rarity: "Common",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Base/Wizards Black Star Promos/14.ts
+++ b/data/Base/Wizards Black Star Promos/14.ts
@@ -8,7 +8,7 @@ const card: Card = {
 	},
 
 	illustrator: "Benimaru Itoh",
-	rarity: "Common",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	set: Set,
 

--- a/data/Base/Wizards Black Star Promos/15.ts
+++ b/data/Base/Wizards Black Star Promos/15.ts
@@ -6,7 +6,7 @@ const card: Card = {
 		en: "Cool Porygon",
 	},
 	illustrator: "Hiromichi Sugiyama",
-	rarity: "Common",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Base/Wizards Black Star Promos/16.ts
+++ b/data/Base/Wizards Black Star Promos/16.ts
@@ -6,7 +6,7 @@ const card: Card = {
 		en: "Computer Error",
 	},
 	illustrator: "Sumiyoshi Kizuki",
-	rarity: "Common",
+	rarity: "Black Star Promo",
 	category: "Trainer",
 
 	set: Set,

--- a/data/Base/Wizards Black Star Promos/17.ts
+++ b/data/Base/Wizards Black Star Promos/17.ts
@@ -6,7 +6,7 @@ const card: Card = {
 		en: "Dark Persian",
 	},
 	illustrator: "Ken Sugimori",
-	rarity: "Common",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Base/Wizards Black Star Promos/18.ts
+++ b/data/Base/Wizards Black Star Promos/18.ts
@@ -6,7 +6,7 @@ const card: Card = {
 		en: "Team Rocket's Meowth",
 	},
 	illustrator: "Kunihiko Yuyama",
-	rarity: "Common",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Base/Wizards Black Star Promos/19.ts
+++ b/data/Base/Wizards Black Star Promos/19.ts
@@ -6,7 +6,7 @@ const card: Card = {
 		en: "Sabrina's Abra",
 	},
 	illustrator: "Atsuko Nishida",
-	rarity: "Common",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Base/Wizards Black Star Promos/2.ts
+++ b/data/Base/Wizards Black Star Promos/2.ts
@@ -8,7 +8,7 @@ const card: Card = {
 	},
 
 	illustrator: "Ken Sugimori",
-	rarity: "Common",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	set: Set,
 

--- a/data/Base/Wizards Black Star Promos/20.ts
+++ b/data/Base/Wizards Black Star Promos/20.ts
@@ -8,7 +8,7 @@ const card: Card = {
 	},
 
 	illustrator: "Kagemaru Himeno",
-	rarity: "Common",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	set: Set,
 

--- a/data/Base/Wizards Black Star Promos/21.ts
+++ b/data/Base/Wizards Black Star Promos/21.ts
@@ -8,7 +8,7 @@ const card: Card = {
 	},
 
 	illustrator: "Naoyo Kimura",
-	rarity: "Common",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	set: Set,
 

--- a/data/Base/Wizards Black Star Promos/22.ts
+++ b/data/Base/Wizards Black Star Promos/22.ts
@@ -8,7 +8,7 @@ const card: Card = {
 	},
 
 	illustrator: "Naoyo Kimura",
-	rarity: "Common",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	set: Set,
 

--- a/data/Base/Wizards Black Star Promos/23.ts
+++ b/data/Base/Wizards Black Star Promos/23.ts
@@ -8,7 +8,7 @@ const card: Card = {
 	},
 
 	illustrator: "Naoyo Kimura",
-	rarity: "Common",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	set: Set,
 

--- a/data/Base/Wizards Black Star Promos/24.ts
+++ b/data/Base/Wizards Black Star Promos/24.ts
@@ -8,7 +8,7 @@ const card: Card = {
 	},
 
 	illustrator: "Kagemaru Himeno",
-	rarity: "Common",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	set: Set,
 

--- a/data/Base/Wizards Black Star Promos/25.ts
+++ b/data/Base/Wizards Black Star Promos/25.ts
@@ -8,7 +8,7 @@ const card: Card = {
 	},
 
 	illustrator: "Toshinao Aoki",
-	rarity: "Common",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	set: Set,
 

--- a/data/Base/Wizards Black Star Promos/26.ts
+++ b/data/Base/Wizards Black Star Promos/26.ts
@@ -8,7 +8,7 @@ const card: Card = {
 	},
 
 	illustrator: "Gakuji Nomoto",
-	rarity: "Common",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	set: Set,
 

--- a/data/Base/Wizards Black Star Promos/27.ts
+++ b/data/Base/Wizards Black Star Promos/27.ts
@@ -6,7 +6,7 @@ const card: Card = {
 		en: "Pikachu",
 	},
 	illustrator: "Atsuko Nishida",
-	rarity: "Common",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Base/Wizards Black Star Promos/28.ts
+++ b/data/Base/Wizards Black Star Promos/28.ts
@@ -8,7 +8,7 @@ const card: Card = {
 	},
 
 	illustrator: "Toshinao Aoki",
-	rarity: "Common",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	set: Set,
 

--- a/data/Base/Wizards Black Star Promos/29.ts
+++ b/data/Base/Wizards Black Star Promos/29.ts
@@ -8,7 +8,7 @@ const card: Card = {
 	},
 
 	illustrator: "Ken Sugimori",
-	rarity: "Common",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	set: Set,
 

--- a/data/Base/Wizards Black Star Promos/3.ts
+++ b/data/Base/Wizards Black Star Promos/3.ts
@@ -8,7 +8,7 @@ const card: Card = {
 	},
 
 	illustrator: "Ken Sugimori",
-	rarity: "Common",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	set: Set,
 

--- a/data/Base/Wizards Black Star Promos/30.ts
+++ b/data/Base/Wizards Black Star Promos/30.ts
@@ -8,7 +8,7 @@ const card: Card = {
 	},
 
 	illustrator: "Ken Sugimori",
-	rarity: "Common",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	set: Set,
 

--- a/data/Base/Wizards Black Star Promos/31.ts
+++ b/data/Base/Wizards Black Star Promos/31.ts
@@ -8,7 +8,7 @@ const card: Card = {
 	},
 
 	illustrator: "Ken Sugimori",
-	rarity: "Common",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	set: Set,
 

--- a/data/Base/Wizards Black Star Promos/32.ts
+++ b/data/Base/Wizards Black Star Promos/32.ts
@@ -8,7 +8,7 @@ const card: Card = {
 	},
 
 	illustrator: "Tomokazu Komiya",
-	rarity: "Common",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	set: Set,
 

--- a/data/Base/Wizards Black Star Promos/33.ts
+++ b/data/Base/Wizards Black Star Promos/33.ts
@@ -8,7 +8,7 @@ const card: Card = {
 	},
 
 	illustrator: "Hironobu Yoshida",
-	rarity: "Common",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	set: Set,
 

--- a/data/Base/Wizards Black Star Promos/34.ts
+++ b/data/Base/Wizards Black Star Promos/34.ts
@@ -6,7 +6,7 @@ const card: Card = {
 		en: "Entei",
 	},
 	illustrator: "Ken Sugimori",
-	rarity: "Common",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Base/Wizards Black Star Promos/35.ts
+++ b/data/Base/Wizards Black Star Promos/35.ts
@@ -8,7 +8,7 @@ const card: Card = {
 	},
 
 	illustrator: "Ken Sugimori",
-	rarity: "Common",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	set: Set,
 

--- a/data/Base/Wizards Black Star Promos/36.ts
+++ b/data/Base/Wizards Black Star Promos/36.ts
@@ -8,7 +8,7 @@ const card: Card = {
 	},
 
 	illustrator: "Kagemaru Himeno",
-	rarity: "Common",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	set: Set,
 

--- a/data/Base/Wizards Black Star Promos/37.ts
+++ b/data/Base/Wizards Black Star Promos/37.ts
@@ -8,7 +8,7 @@ const card: Card = {
 	},
 
 	illustrator: "Atsuko Nishida",
-	rarity: "Common",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	set: Set,
 

--- a/data/Base/Wizards Black Star Promos/38.ts
+++ b/data/Base/Wizards Black Star Promos/38.ts
@@ -8,7 +8,7 @@ const card: Card = {
 	},
 
 	illustrator: "Hideki Kazama",
-	rarity: "Common",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	set: Set,
 

--- a/data/Base/Wizards Black Star Promos/39.ts
+++ b/data/Base/Wizards Black Star Promos/39.ts
@@ -8,7 +8,7 @@ const card: Card = {
 	},
 
 	illustrator: "Shin-ichi Yoshida",
-	rarity: "Common",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	set: Set,
 

--- a/data/Base/Wizards Black Star Promos/4.ts
+++ b/data/Base/Wizards Black Star Promos/4.ts
@@ -8,7 +8,7 @@ const card: Card = {
 	},
 
 	illustrator: "Ken Sugimori",
-	rarity: "Common",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	set: Set,
 

--- a/data/Base/Wizards Black Star Promos/40.ts
+++ b/data/Base/Wizards Black Star Promos/40.ts
@@ -6,7 +6,7 @@ const card: Card = {
 		en: "Pokémon Center",
 	},
 	illustrator: "\"Big Mama\" Tagawa",
-	rarity: "Common",
+	rarity: "Black Star Promo",
 	category: "Trainer",
 
 	set: Set,

--- a/data/Base/Wizards Black Star Promos/41.ts
+++ b/data/Base/Wizards Black Star Promos/41.ts
@@ -6,7 +6,7 @@ const card: Card = {
 		en: "Lucky Stadium",
 	},
 	illustrator: "\"Big Mama\" Tagawa",
-	rarity: "Common",
+	rarity: "Black Star Promo",
 	category: "Trainer",
 
 	set: Set,

--- a/data/Base/Wizards Black Star Promos/42.ts
+++ b/data/Base/Wizards Black Star Promos/42.ts
@@ -6,7 +6,7 @@ const card: Card = {
 		en: "Pokémon Tower",
 	},
 	illustrator: "Keiji Kinebuchi",
-	rarity: "Common",
+	rarity: "Black Star Promo",
 	category: "Trainer",
 
 	set: Set,

--- a/data/Base/Wizards Black Star Promos/43.ts
+++ b/data/Base/Wizards Black Star Promos/43.ts
@@ -6,7 +6,7 @@ const card: Card = {
 		en: "Machamp",
 	},
 	illustrator: "Tomokazu Komiya",
-	rarity: "Common",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Base/Wizards Black Star Promos/44.ts
+++ b/data/Base/Wizards Black Star Promos/44.ts
@@ -6,7 +6,7 @@ const card: Card = {
 		en: "Magmar",
 	},
 	illustrator: "Atsuko Nishida",
-	rarity: "Common",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Base/Wizards Black Star Promos/45.ts
+++ b/data/Base/Wizards Black Star Promos/45.ts
@@ -6,7 +6,7 @@ const card: Card = {
 		en: "Scyther",
 	},
 	illustrator: "Hironobu Yoshida",
-	rarity: "Common",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Base/Wizards Black Star Promos/46.ts
+++ b/data/Base/Wizards Black Star Promos/46.ts
@@ -6,7 +6,7 @@ const card: Card = {
 		en: "Electabuzz",
 	},
 	illustrator: "Miki Tanaka",
-	rarity: "Common",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Base/Wizards Black Star Promos/47.ts
+++ b/data/Base/Wizards Black Star Promos/47.ts
@@ -6,7 +6,7 @@ const card: Card = {
 		en: "Mew",
 	},
 	illustrator: "Ken Sugimori",
-	rarity: "Common",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Base/Wizards Black Star Promos/48.ts
+++ b/data/Base/Wizards Black Star Promos/48.ts
@@ -6,7 +6,7 @@ const card: Card = {
 		en: "Articuno",
 	},
 	illustrator: "Atsuko Nishida",
-	rarity: "Common",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Base/Wizards Black Star Promos/49.ts
+++ b/data/Base/Wizards Black Star Promos/49.ts
@@ -6,7 +6,7 @@ const card: Card = {
 		en: "Snorlax",
 	},
 	illustrator: "Craig Turvey",
-	rarity: "Common",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Base/Wizards Black Star Promos/5.ts
+++ b/data/Base/Wizards Black Star Promos/5.ts
@@ -8,7 +8,7 @@ const card: Card = {
 	},
 
 	illustrator: "Toshinao Aoki",
-	rarity: "Common",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	set: Set,
 

--- a/data/Base/Wizards Black Star Promos/50.ts
+++ b/data/Base/Wizards Black Star Promos/50.ts
@@ -6,7 +6,7 @@ const card: Card = {
 		en: "Celebi",
 	},
 	illustrator: "Hajime Kusajima",
-	rarity: "Common",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Base/Wizards Black Star Promos/51.ts
+++ b/data/Base/Wizards Black Star Promos/51.ts
@@ -6,7 +6,7 @@ const card: Card = {
 		en: "Rapidash",
 	},
 	illustrator: "Mitsuhiro Arita",
-	rarity: "Common",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Base/Wizards Black Star Promos/52.ts
+++ b/data/Base/Wizards Black Star Promos/52.ts
@@ -6,7 +6,7 @@ const card: Card = {
 		en: "Ho-oh",
 	},
 	illustrator: "Mitsuhiro Arita",
-	rarity: "Common",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Base/Wizards Black Star Promos/53.ts
+++ b/data/Base/Wizards Black Star Promos/53.ts
@@ -6,7 +6,7 @@ const card: Card = {
 		en: "Suicune",
 	},
 	illustrator: "Atsuko Nishida",
-	rarity: "Common",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Base/Wizards Black Star Promos/6.ts
+++ b/data/Base/Wizards Black Star Promos/6.ts
@@ -8,7 +8,7 @@ const card: Card = {
 	},
 
 	illustrator: "Ken Sugimori",
-	rarity: "Common",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	set: Set,
 

--- a/data/Base/Wizards Black Star Promos/7.ts
+++ b/data/Base/Wizards Black Star Promos/7.ts
@@ -6,7 +6,7 @@ const card: Card = {
 		en: "Jigglypuff",
 	},
 	illustrator: "Keiji Kinebuchi",
-	rarity: "Common",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Base/Wizards Black Star Promos/8.ts
+++ b/data/Base/Wizards Black Star Promos/8.ts
@@ -8,7 +8,7 @@ const card: Card = {
 	},
 
 	illustrator: "Ken Sugimori",
-	rarity: "Common",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	set: Set,
 

--- a/data/Base/Wizards Black Star Promos/9.ts
+++ b/data/Base/Wizards Black Star Promos/9.ts
@@ -8,7 +8,7 @@ const card: Card = {
 	},
 
 	illustrator: "Ken Sugimori",
-	rarity: "Common",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	set: Set,
 


### PR DESCRIPTION
Set: **Wizards Black Star Promos**
Series folder: `Base`
Changed card files: **53**

### Validation
- [ ] `bun run validate`
- [ ] `cd server && bun run --bun validate`
- [ ] `cd server && bun run compile`
- [ ] Manual review: translations, energy types, TS syntax

### Card images
See follow-up comments with embedded TCGdex assets.