### PR TITLE
fix(data): BW Black Star Promos (Black & White)

### DIFF
--- a/data/Black & White/BW Black Star Promos/BW01.ts
+++ b/data/Black & White/BW Black Star Promos/BW01.ts
@@ -7,7 +7,7 @@ const card: Card = {
 		fr: "Vipélierre",
 	},
 	illustrator: "Ken Sugimori",
-	rarity: "Common",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Black & White/BW Black Star Promos/BW02.ts
+++ b/data/Black & White/BW Black Star Promos/BW02.ts
@@ -7,7 +7,7 @@ const card: Card = {
 		fr: "Gruikui",
 	},
 	illustrator: "Ken Sugimori",
-	rarity: "Common",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Black & White/BW Black Star Promos/BW03.ts
+++ b/data/Black & White/BW Black Star Promos/BW03.ts
@@ -7,7 +7,7 @@ const card: Card = {
 		fr: "Moustillon",
 	},
 	illustrator: "Ken Sugimori",
-	rarity: "Common",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Black & White/BW Black Star Promos/BW04.ts
+++ b/data/Black & White/BW Black Star Promos/BW04.ts
@@ -7,7 +7,7 @@ const card: Card = {
 		fr: "Reshiram",
 	},
 	illustrator: "5ban Graphics",
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Black & White/BW Black Star Promos/BW05.ts
+++ b/data/Black & White/BW Black Star Promos/BW05.ts
@@ -7,7 +7,7 @@ const card: Card = {
 		fr: "Zekrom",
 	},
 	illustrator: "5ban Graphics",
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Black & White/BW Black Star Promos/BW06.ts
+++ b/data/Black & White/BW Black Star Promos/BW06.ts
@@ -7,7 +7,7 @@ const card: Card = {
 		fr: "Vipélierre",
 	},
 	illustrator: "Shizurow",
-	rarity: "Common",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Black & White/BW Black Star Promos/BW07.ts
+++ b/data/Black & White/BW Black Star Promos/BW07.ts
@@ -7,7 +7,7 @@ const card: Card = {
 		fr: "Gruikui",
 	},
 	illustrator: "Shin Nagasawa",
-	rarity: "Common",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Black & White/BW Black Star Promos/BW08.ts
+++ b/data/Black & White/BW Black Star Promos/BW08.ts
@@ -7,7 +7,7 @@ const card: Card = {
 		fr: "Moustillon",
 	},
 	illustrator: "Mitsuhiro Arita",
-	rarity: "Common",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Black & White/BW Black Star Promos/BW09.ts
+++ b/data/Black & White/BW Black Star Promos/BW09.ts
@@ -7,7 +7,7 @@ const card: Card = {
 		fr: "Zoroark",
 	},
 	illustrator: "Naoki Saito",
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Black & White/BW Black Star Promos/BW10.ts
+++ b/data/Black & White/BW Black Star Promos/BW10.ts
@@ -7,7 +7,7 @@ const card: Card = {
 		fr: "Coupenotte",
 	},
 	illustrator: "Masakazu Fukuda",
-	rarity: "Common",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Black & White/BW Black Star Promos/BW100.ts
+++ b/data/Black & White/BW Black Star Promos/BW100.ts
@@ -7,7 +7,7 @@ const card: Card = {
 		fr: "N",
 	},
 	illustrator: "Yusuke Ohmura",
-	rarity: "Uncommon",
+	rarity: "Black Star Promo",
 	category: "Trainer",
 
 	set: Set,

--- a/data/Black & White/BW Black Star Promos/BW101.ts
+++ b/data/Black & White/BW Black Star Promos/BW101.ts
@@ -7,7 +7,7 @@ const card: Card = {
 		fr: "Genesect",
 	},
 	illustrator: "5ban Graphics",
-	rarity: "Common",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Black & White/BW Black Star Promos/BW11.ts
+++ b/data/Black & White/BW Black Star Promos/BW11.ts
@@ -7,7 +7,7 @@ const card: Card = {
 		fr: "Feuillajou",
 	},
 	illustrator: "Akira Komayama",
-	rarity: "Common",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Black & White/BW Black Star Promos/BW12.ts
+++ b/data/Black & White/BW Black Star Promos/BW12.ts
@@ -7,7 +7,7 @@ const card: Card = {
 		fr: "Zorua",
 	},
 	illustrator: "Tomokazu Komiya",
-	rarity: "Common",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Black & White/BW Black Star Promos/BW13.ts
+++ b/data/Black & White/BW Black Star Promos/BW13.ts
@@ -7,7 +7,7 @@ const card: Card = {
 		fr: "Chinchidou",
 	},
 	illustrator: "Atsuko Nishida",
-	rarity: "Common",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Black & White/BW Black Star Promos/BW14.ts
+++ b/data/Black & White/BW Black Star Promos/BW14.ts
@@ -7,7 +7,7 @@ const card: Card = {
 		fr: "Feuillajou",
 	},
 	illustrator: "Akira Komayama",
-	rarity: "Common",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Black & White/BW Black Star Promos/BW15.ts
+++ b/data/Black & White/BW Black Star Promos/BW15.ts
@@ -7,7 +7,7 @@ const card: Card = {
 		fr: "Poichigeon",
 	},
 	illustrator: "Naoki Saito",
-	rarity: "Common",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Black & White/BW Black Star Promos/BW16.ts
+++ b/data/Black & White/BW Black Star Promos/BW16.ts
@@ -7,7 +7,7 @@ const card: Card = {
 		fr: "Coupenotte",
 	},
 	illustrator: "Masakazu Fukuda",
-	rarity: "Common",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Black & White/BW Black Star Promos/BW17.ts
+++ b/data/Black & White/BW Black Star Promos/BW17.ts
@@ -7,7 +7,7 @@ const card: Card = {
 		fr: "Couaneton",
 	},
 	illustrator: "Kagemaru Himeno",
-	rarity: "Common",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Black & White/BW Black Star Promos/BW18.ts
+++ b/data/Black & White/BW Black Star Promos/BW18.ts
@@ -7,7 +7,7 @@ const card: Card = {
 		fr: "Darumarond",
 	},
 	illustrator: "Akira Komayama",
-	rarity: "Common",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Black & White/BW Black Star Promos/BW19.ts
+++ b/data/Black & White/BW Black Star Promos/BW19.ts
@@ -7,7 +7,7 @@ const card: Card = {
 		fr: "Zoroark",
 	},
 	illustrator: "5ban Graphics",
-	rarity: "Common",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Black & White/BW Black Star Promos/BW20.ts
+++ b/data/Black & White/BW Black Star Promos/BW20.ts
@@ -7,7 +7,7 @@ const card: Card = {
 		fr: "Majaspic",
 	},
 	illustrator: "5ban Graphics",
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Black & White/BW Black Star Promos/BW21.ts
+++ b/data/Black & White/BW Black Star Promos/BW21.ts
@@ -7,7 +7,7 @@ const card: Card = {
 		fr: "Roitiflam",
 	},
 	illustrator: "5ban Graphics",
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Black & White/BW Black Star Promos/BW22.ts
+++ b/data/Black & White/BW Black Star Promos/BW22.ts
@@ -7,7 +7,7 @@ const card: Card = {
 		fr: "Clamiral",
 	},
 	illustrator: "5ban Graphics",
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Black & White/BW Black Star Promos/BW23.ts
+++ b/data/Black & White/BW Black Star Promos/BW23.ts
@@ -7,7 +7,7 @@ const card: Card = {
 		fr: "Reshiram",
 	},
 	illustrator: "5ban Graphics",
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Black & White/BW Black Star Promos/BW24.ts
+++ b/data/Black & White/BW Black Star Promos/BW24.ts
@@ -7,7 +7,7 @@ const card: Card = {
 		fr: "Zekrom",
 	},
 	illustrator: "5ban Graphics",
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Black & White/BW Black Star Promos/BW25.ts
+++ b/data/Black & White/BW Black Star Promos/BW25.ts
@@ -7,7 +7,7 @@ const card: Card = {
 		fr: "Baggiguane",
 	},
 	illustrator: "Akira Komayama",
-	rarity: "Common",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Black & White/BW Black Star Promos/BW26.ts
+++ b/data/Black & White/BW Black Star Promos/BW26.ts
@@ -7,7 +7,7 @@ const card: Card = {
 		fr: "Coupenotte",
 	},
 	illustrator: "Akira Komayama",
-	rarity: "Common",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Black & White/BW Black Star Promos/BW27.ts
+++ b/data/Black & White/BW Black Star Promos/BW27.ts
@@ -7,7 +7,7 @@ const card: Card = {
 		fr: "Funécire",
 	},
 	illustrator: "Atsuko Nishida",
-	rarity: "Common",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Black & White/BW Black Star Promos/BW28.ts
+++ b/data/Black & White/BW Black Star Promos/BW28.ts
@@ -7,7 +7,7 @@ const card: Card = {
 		fr: "Plage Tropicale",
 	},
 	illustrator: undefined,
-	rarity: "Common",
+	rarity: "Black Star Promo",
 	category: "Trainer",
 
 	set: Set,

--- a/data/Black & White/BW Black Star Promos/BW29.ts
+++ b/data/Black & White/BW Black Star Promos/BW29.ts
@@ -7,7 +7,7 @@ const card: Card = {
 		fr: "Coupe Victoire",
 	},
 	illustrator: "5ban Graphics",
-	rarity: "Common",
+	rarity: "Black Star Promo",
 	category: "Trainer",
 
 	set: Set,

--- a/data/Black & White/BW Black Star Promos/BW30.ts
+++ b/data/Black & White/BW Black Star Promos/BW30.ts
@@ -7,7 +7,7 @@ const card: Card = {
 		fr: "Coupe Victoire",
 	},
 	illustrator: "5ban Graphics",
-	rarity: "Common",
+	rarity: "Black Star Promo",
 	category: "Trainer",
 
 	set: Set,

--- a/data/Black & White/BW Black Star Promos/BW31.ts
+++ b/data/Black & White/BW Black Star Promos/BW31.ts
@@ -7,7 +7,7 @@ const card: Card = {
 		fr: "Coupe Victoire",
 	},
 	illustrator: "5ban Graphics",
-	rarity: "Common",
+	rarity: "Black Star Promo",
 	category: "Trainer",
 
 	set: Set,

--- a/data/Black & White/BW Black Star Promos/BW32.ts
+++ b/data/Black & White/BW Black Star Promos/BW32.ts
@@ -7,7 +7,7 @@ const card: Card = {
 		fr: "Victini",
 	},
 	illustrator: "5ban Graphics",
-	rarity: "Common",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Black & White/BW Black Star Promos/BW33.ts
+++ b/data/Black & White/BW Black Star Promos/BW33.ts
@@ -7,7 +7,7 @@ const card: Card = {
 		fr: "Riolu",
 	},
 	illustrator: "sui",
-	rarity: "Common",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Black & White/BW Black Star Promos/BW34.ts
+++ b/data/Black & White/BW Black Star Promos/BW34.ts
@@ -7,7 +7,7 @@ const card: Card = {
 		fr: "Luxio",
 	},
 	illustrator: "Naoki Saito",
-	rarity: "Common",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Black & White/BW Black Star Promos/BW35.ts
+++ b/data/Black & White/BW Black Star Promos/BW35.ts
@@ -7,7 +7,7 @@ const card: Card = {
 		fr: "Miaouss",
 	},
 	illustrator: "Sumiyoshi Kizuki",
-	rarity: "Common",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Black & White/BW Black Star Promos/BW36.ts
+++ b/data/Black & White/BW Black Star Promos/BW36.ts
@@ -7,7 +7,7 @@ const card: Card = {
 		fr: "Reshiram ex",
 	},
 	illustrator: "Shizurow",
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Black & White/BW Black Star Promos/BW37.ts
+++ b/data/Black & White/BW Black Star Promos/BW37.ts
@@ -7,7 +7,7 @@ const card: Card = {
 		fr: "Kyurem ex",
 	},
 	illustrator: "Shizurow",
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Black & White/BW Black Star Promos/BW38.ts
+++ b/data/Black & White/BW Black Star Promos/BW38.ts
@@ -7,7 +7,7 @@ const card: Card = {
 		fr: "Zekrom ex",
 	},
 	illustrator: "Shizurow",
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Black & White/BW Black Star Promos/BW39.ts
+++ b/data/Black & White/BW Black Star Promos/BW39.ts
@@ -7,7 +7,7 @@ const card: Card = {
 		fr: "Ville Combat",
 	},
 	illustrator: "Hideaki Hakozaki",
-	rarity: "Common",
+	rarity: "Black Star Promo",
 	category: "Trainer",
 
 	set: Set,

--- a/data/Black & White/BW Black Star Promos/BW40.ts
+++ b/data/Black & White/BW Black Star Promos/BW40.ts
@@ -7,7 +7,7 @@ const card: Card = {
 		fr: "Pyrax",
 	},
 	illustrator: "Shin Nagasawa",
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Black & White/BW Black Star Promos/BW41.ts
+++ b/data/Black & White/BW Black Star Promos/BW41.ts
@@ -7,7 +7,7 @@ const card: Card = {
 		fr: "Fulguris",
 	},
 	illustrator: "5ban Graphics",
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Black & White/BW Black Star Promos/BW42.ts
+++ b/data/Black & White/BW Black Star Promos/BW42.ts
@@ -7,7 +7,7 @@ const card: Card = {
 		fr: "Boréas",
 	},
 	illustrator: "5ban Graphics",
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Black & White/BW Black Star Promos/BW43.ts
+++ b/data/Black & White/BW Black Star Promos/BW43.ts
@@ -7,7 +7,7 @@ const card: Card = {
 		fr: "Démétéros",
 	},
 	illustrator: "5ban Graphics",
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Black & White/BW Black Star Promos/BW44.ts
+++ b/data/Black & White/BW Black Star Promos/BW44.ts
@@ -7,7 +7,7 @@ const card: Card = {
 		fr: "Kyurem",
 	},
 	illustrator: "5ban Graphics",
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Black & White/BW Black Star Promos/BW45.ts
+++ b/data/Black & White/BW Black Star Promos/BW45.ts
@@ -7,7 +7,7 @@ const card: Card = {
 		fr: "Mewtwo ex",
 	},
 	illustrator: "Shizurow",
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Black & White/BW Black Star Promos/BW46.ts
+++ b/data/Black & White/BW Black Star Promos/BW46.ts
@@ -7,7 +7,7 @@ const card: Card = {
 		fr: "Darkrai ex",
 	},
 	illustrator: "Shizurow",
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Black & White/BW Black Star Promos/BW47.ts
+++ b/data/Black & White/BW Black Star Promos/BW47.ts
@@ -7,7 +7,7 @@ const card: Card = {
 		fr: "Rayquaza ex",
 	},
 	illustrator: "Eske Yoshinob",
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Black & White/BW Black Star Promos/BW48.ts
+++ b/data/Black & White/BW Black Star Promos/BW48.ts
@@ -7,7 +7,7 @@ const card: Card = {
 		fr: "Altaria",
 	},
 	illustrator: "HiRON",
-	rarity: "Common",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Black & White/BW Black Star Promos/BW49.ts
+++ b/data/Black & White/BW Black Star Promos/BW49.ts
@@ -7,7 +7,7 @@ const card: Card = {
 		fr: "Fragilady",
 	},
 	illustrator: "Naoki Saito",
-	rarity: "Common",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Black & White/BW Black Star Promos/BW50.ts
+++ b/data/Black & White/BW Black Star Promos/BW50.ts
@@ -7,7 +7,7 @@ const card: Card = {
 		fr: "Plage Tropicale",
 	},
 	illustrator: undefined,
-	rarity: "Common",
+	rarity: "Black Star Promo",
 	category: "Trainer",
 
 	set: Set,

--- a/data/Black & White/BW Black Star Promos/BW51.ts
+++ b/data/Black & White/BW Black Star Promos/BW51.ts
@@ -7,7 +7,7 @@ const card: Card = {
 		fr: "Nostenfer",
 	},
 	illustrator: "5ban Graphics",
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Black & White/BW Black Star Promos/BW52.ts
+++ b/data/Black & White/BW Black Star Promos/BW52.ts
@@ -7,7 +7,7 @@ const card: Card = {
 		fr: "Ponchiot",
 	},
 	illustrator: "Mizue",
-	rarity: "Common",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Black & White/BW Black Star Promos/BW53.ts
+++ b/data/Black & White/BW Black Star Promos/BW53.ts
@@ -7,7 +7,7 @@ const card: Card = {
 		fr: "Libégon",
 	},
 	illustrator: "BERUBURI",
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Black & White/BW Black Star Promos/BW54.ts
+++ b/data/Black & White/BW Black Star Promos/BW54.ts
@@ -7,7 +7,7 @@ const card: Card = {
 		fr: "Pikachu",
 	},
 	illustrator: "5ban Graphics",
-	rarity: "Common",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Black & White/BW Black Star Promos/BW55.ts
+++ b/data/Black & White/BW Black Star Promos/BW55.ts
@@ -7,7 +7,7 @@ const card: Card = {
 		fr: "Lewsor",
 	},
 	illustrator: "Mizue",
-	rarity: "Common",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Black & White/BW Black Star Promos/BW56.ts
+++ b/data/Black & White/BW Black Star Promos/BW56.ts
@@ -7,7 +7,7 @@ const card: Card = {
 		fr: "Pingoléon",
 	},
 	illustrator: "Shin Nagasawa",
-	rarity: "Common",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Black & White/BW Black Star Promos/BW57.ts
+++ b/data/Black & White/BW Black Star Promos/BW57.ts
@@ -7,7 +7,7 @@ const card: Card = {
 		fr: "Tranchodon",
 	},
 	illustrator: "kawayoo",
-	rarity: "Common",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Black & White/BW Black Star Promos/BW58.ts
+++ b/data/Black & White/BW Black Star Promos/BW58.ts
@@ -7,7 +7,7 @@ const card: Card = {
 		fr: "Kyurem Noir",
 	},
 	illustrator: "5ban Graphics",
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Black & White/BW Black Star Promos/BW59.ts
+++ b/data/Black & White/BW Black Star Promos/BW59.ts
@@ -7,7 +7,7 @@ const card: Card = {
 		fr: "Kyurem Blanc",
 	},
 	illustrator: "5ban Graphics",
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Black & White/BW Black Star Promos/BW60.ts
+++ b/data/Black & White/BW Black Star Promos/BW60.ts
@@ -7,7 +7,7 @@ const card: Card = {
 		fr: "Keldeo",
 	},
 	illustrator: "5ban Graphics",
-	rarity: "Common",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Black & White/BW Black Star Promos/BW61.ts
+++ b/data/Black & White/BW Black Star Promos/BW61.ts
@@ -7,7 +7,7 @@ const card: Card = {
 		fr: "Keldeo ex",
 	},
 	illustrator: "Toyste Beach",
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Black & White/BW Black Star Promos/BW62.ts
+++ b/data/Black & White/BW Black Star Promos/BW62.ts
@@ -7,7 +7,7 @@ const card: Card = {
 		fr: "Kyurem Noir ex",
 	},
 	illustrator: "Eske Yoshinob",
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Black & White/BW Black Star Promos/BW63.ts
+++ b/data/Black & White/BW Black Star Promos/BW63.ts
@@ -7,7 +7,7 @@ const card: Card = {
 		fr: "Kyurem Blanc ex",
 	},
 	illustrator: "Eske Yoshinob",
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Black & White/BW Black Star Promos/BW64.ts
+++ b/data/Black & White/BW Black Star Promos/BW64.ts
@@ -7,7 +7,7 @@ const card: Card = {
 		fr: "Grodrive",
 	},
 	illustrator: "Naoki Saito",
-	rarity: "Common",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Black & White/BW Black Star Promos/BW65.ts
+++ b/data/Black & White/BW Black Star Promos/BW65.ts
@@ -7,7 +7,7 @@ const card: Card = {
 		fr: "Rondoudou",
 	},
 	illustrator: "MAHOU",
-	rarity: "Common",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Black & White/BW Black Star Promos/BW66.ts
+++ b/data/Black & White/BW Black Star Promos/BW66.ts
@@ -7,7 +7,7 @@ const card: Card = {
 		fr: "Feunard",
 	},
 	illustrator: "Hideaki Hakozaki",
-	rarity: "Common",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Black & White/BW Black Star Promos/BW67.ts
+++ b/data/Black & White/BW Black Star Promos/BW67.ts
@@ -7,7 +7,7 @@ const card: Card = {
 		fr: "Pharamp",
 	},
 	illustrator: "Naoki Saito",
-	rarity: "Common",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Black & White/BW Black Star Promos/BW68.ts
+++ b/data/Black & White/BW Black Star Promos/BW68.ts
@@ -7,7 +7,7 @@ const card: Card = {
 		fr: "Meloetta",
 	},
 	illustrator: "Naoki Saito",
-	rarity: "Common",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Black & White/BW Black Star Promos/BW69.ts
+++ b/data/Black & White/BW Black Star Promos/BW69.ts
@@ -7,7 +7,7 @@ const card: Card = {
 		fr: "Meloetta",
 	},
 	illustrator: "Shin Nagasawa",
-	rarity: "Common",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Black & White/BW Black Star Promos/BW70.ts
+++ b/data/Black & White/BW Black Star Promos/BW70.ts
@@ -7,7 +7,7 @@ const card: Card = {
 		fr: "Viridium",
 	},
 	illustrator: "5ban Graphics",
-	rarity: "Common",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Black & White/BW Black Star Promos/BW71.ts
+++ b/data/Black & White/BW Black Star Promos/BW71.ts
@@ -7,7 +7,7 @@ const card: Card = {
 		fr: "Terrakium",
 	},
 	illustrator: "5ban Graphics",
-	rarity: "Common",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Black & White/BW Black Star Promos/BW72.ts
+++ b/data/Black & White/BW Black Star Promos/BW72.ts
@@ -7,7 +7,7 @@ const card: Card = {
 		fr: "Cobaltium",
 	},
 	illustrator: "5ban Graphics",
-	rarity: "Common",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Black & White/BW Black Star Promos/BW73.ts
+++ b/data/Black & White/BW Black Star Promos/BW73.ts
@@ -7,7 +7,7 @@ const card: Card = {
 		fr: "Darkrai",
 	},
 	illustrator: "5ban Graphics",
-	rarity: "Common",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Black & White/BW Black Star Promos/BW74.ts
+++ b/data/Black & White/BW Black Star Promos/BW74.ts
@@ -7,7 +7,7 @@ const card: Card = {
 		fr: "Giratina",
 	},
 	illustrator: "5ban Graphics",
-	rarity: "Common",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Black & White/BW Black Star Promos/BW75.ts
+++ b/data/Black & White/BW Black Star Promos/BW75.ts
@@ -7,7 +7,7 @@ const card: Card = {
 		fr: "Métalosse",
 	},
 	illustrator: "5ban Graphics",
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Black & White/BW Black Star Promos/BW76.ts
+++ b/data/Black & White/BW Black Star Promos/BW76.ts
@@ -7,7 +7,7 @@ const card: Card = {
 		fr: "Électrode",
 	},
 	illustrator: "5ban Graphics",
-	rarity: "Common",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Black & White/BW Black Star Promos/BW77.ts
+++ b/data/Black & White/BW Black Star Promos/BW77.ts
@@ -7,7 +7,7 @@ const card: Card = {
 		fr: "Pikachu"
 	},
 	illustrator: "Mizue",
-	rarity: "Common",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Black & White/BW Black Star Promos/BW78.ts
+++ b/data/Black & White/BW Black Star Promos/BW78.ts
@@ -7,7 +7,7 @@ const card: Card = {
 		fr: "Raichu"
 	},
 	illustrator: "Mizue",
-	rarity: "Common",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Black & White/BW Black Star Promos/BW79.ts
+++ b/data/Black & White/BW Black Star Promos/BW79.ts
@@ -7,7 +7,7 @@ const card: Card = {
 		fr: "Démétéros",
 	},
 	illustrator: "5ban Graphics",
-	rarity: "Common",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Black & White/BW Black Star Promos/BW80.ts
+++ b/data/Black & White/BW Black Star Promos/BW80.ts
@@ -7,7 +7,7 @@ const card: Card = {
 		fr: "Drakkarmin",
 	},
 	illustrator: "5ban Graphics",
-	rarity: "Common",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Black & White/BW Black Star Promos/BW81.ts
+++ b/data/Black & White/BW Black Star Promos/BW81.ts
@@ -7,7 +7,7 @@ const card: Card = {
 		fr: "Fulguris ex",
 	},
 	illustrator: "Eske Yoshinob",
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Black & White/BW Black Star Promos/BW82.ts
+++ b/data/Black & White/BW Black Star Promos/BW82.ts
@@ -7,7 +7,7 @@ const card: Card = {
 		fr: "Deoxys ex",
 	},
 	illustrator: "Eske Yoshinob",
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Black & White/BW Black Star Promos/BW83.ts
+++ b/data/Black & White/BW Black Star Promos/BW83.ts
@@ -7,7 +7,7 @@ const card: Card = {
 		fr: "Lugia ex",
 	},
 	illustrator: "Toyste Beach",
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Black & White/BW Black Star Promos/BW84.ts
+++ b/data/Black & White/BW Black Star Promos/BW84.ts
@@ -7,7 +7,7 @@ const card: Card = {
 		fr: "Porygon-Z",
 	},
 	illustrator: "5ban Graphics",
-	rarity: "Common",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Black & White/BW Black Star Promos/BW85.ts
+++ b/data/Black & White/BW Black Star Promos/BW85.ts
@@ -7,7 +7,7 @@ const card: Card = {
 		fr: "Lucario",
 	},
 	illustrator: "Masakazu Fukuda",
-	rarity: "Common",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Black & White/BW Black Star Promos/BW86.ts
+++ b/data/Black & White/BW Black Star Promos/BW86.ts
@@ -7,7 +7,7 @@ const card: Card = {
 		fr: "Genesect",
 	},
 	illustrator: "5ban Graphics",
-	rarity: "Common",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Black & White/BW Black Star Promos/BW87.ts
+++ b/data/Black & White/BW Black Star Promos/BW87.ts
@@ -7,7 +7,7 @@ const card: Card = {
 		fr: "Phyllali",
 	},
 	illustrator: "Illus.＆Direc.The Pokémon Company Art Team",
-	rarity: "Common",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Black & White/BW Black Star Promos/BW88.ts
+++ b/data/Black & White/BW Black Star Promos/BW88.ts
@@ -7,7 +7,7 @@ const card: Card = {
 		fr: "Pyroli",
 	},
 	illustrator: "Illus.＆Direc.The Pokémon Company Art Team",
-	rarity: "Common",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Black & White/BW Black Star Promos/BW89.ts
+++ b/data/Black & White/BW Black Star Promos/BW89.ts
@@ -7,7 +7,7 @@ const card: Card = {
 		fr: "Aquali",
 	},
 	illustrator: "Illus.＆Direc.The Pokémon Company Art Team",
-	rarity: "Common",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Black & White/BW Black Star Promos/BW90.ts
+++ b/data/Black & White/BW Black Star Promos/BW90.ts
@@ -7,7 +7,7 @@ const card: Card = {
 		fr: "Givrali",
 	},
 	illustrator: "Illus.＆Direc.The Pokémon Company Art Team",
-	rarity: "Common",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Black & White/BW Black Star Promos/BW91.ts
+++ b/data/Black & White/BW Black Star Promos/BW91.ts
@@ -7,7 +7,7 @@ const card: Card = {
 		fr: "Voltali",
 	},
 	illustrator: "Illus.＆Direc.The Pokémon Company Art Team",
-	rarity: "Common",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Black & White/BW Black Star Promos/BW92.ts
+++ b/data/Black & White/BW Black Star Promos/BW92.ts
@@ -7,7 +7,7 @@ const card: Card = {
 		fr: "Mentali",
 	},
 	illustrator: "Illus.＆Direc.The Pokémon Company Art Team",
-	rarity: "Common",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Black & White/BW Black Star Promos/BW93.ts
+++ b/data/Black & White/BW Black Star Promos/BW93.ts
@@ -7,7 +7,7 @@ const card: Card = {
 		fr: "Noctali",
 	},
 	illustrator: "Illus.＆Direc.The Pokémon Company Art Team",
-	rarity: "Common",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Black & White/BW Black Star Promos/BW94.ts
+++ b/data/Black & White/BW Black Star Promos/BW94.ts
@@ -7,7 +7,7 @@ const card: Card = {
 		fr: "Évoli",
 	},
 	illustrator: "Illus.＆Direc.The Pokémon Company Art Team",
-	rarity: "Common",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Black & White/BW Black Star Promos/BW95.ts
+++ b/data/Black & White/BW Black Star Promos/BW95.ts
@@ -7,7 +7,7 @@ const card: Card = {
 		fr: "Festival des Champions",
 	},
 	illustrator: "Naoki Saito",
-	rarity: "Common",
+	rarity: "Black Star Promo",
 	category: "Trainer",
 
 	set: Set,

--- a/data/Black & White/BW Black Star Promos/BW96.ts
+++ b/data/Black & White/BW Black Star Promos/BW96.ts
@@ -7,7 +7,7 @@ const card: Card = {
 		fr: "Boréas ex",
 	},
 	illustrator: "Ryo Ueda",
-	rarity: "Common",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Black & White/BW Black Star Promos/BW97.ts
+++ b/data/Black & White/BW Black Star Promos/BW97.ts
@@ -7,7 +7,7 @@ const card: Card = {
 		fr: "Évoli",
 	},
 	illustrator: "Akira Komayama",
-	rarity: "Common",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Black & White/BW Black Star Promos/BW98.ts
+++ b/data/Black & White/BW Black Star Promos/BW98.ts
@@ -7,7 +7,7 @@ const card: Card = {
 		fr: "Mew",
 	},
 	illustrator: "Naoki Saito",
-	rarity: "Common",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Black & White/BW Black Star Promos/BW99.ts
+++ b/data/Black & White/BW Black Star Promos/BW99.ts
@@ -7,7 +7,7 @@ const card: Card = {
 		fr: "Genesect",
 	},
 	illustrator: "5ban Graphics",
-	rarity: "Common",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,


### PR DESCRIPTION
Set: **BW Black Star Promos**
Series folder: `Black & White`
Changed card files: **101**

### Validation
- [ ] `bun run validate`
- [ ] `cd server && bun run --bun validate`
- [ ] `cd server && bun run compile`
- [ ] Manual review: translations, energy types, TS syntax

### Card images
See follow-up comments with embedded TCGdex assets.