### PR TITLE
fix(data): Legendary Treasures (Black & White)

### DIFF
--- a/data/Black & White/Legendary Treasures.ts
+++ b/data/Black & White/Legendary Treasures.ts
@@ -17,6 +17,18 @@ const bw11: Set = {
 		official: 113
 	},
 
+	subsets: {
+		RC: {
+			name: {
+				en: "Radiant Collection",
+				fr: "Radiant Collection"
+			},
+			cardCount: {
+				official: 25
+			}
+		}
+	},
+
 	releaseDate: "2013-11-06",
 
 	abbreviations: {


### PR DESCRIPTION
Set: **Legendary Treasures**
Series folder: `Black & White`
Changed card files: **0**

### Validation
- [ ] `bun run validate`
- [ ] `cd server && bun run --bun validate`
- [ ] `cd server && bun run compile`
- [ ] Manual review: translations, energy types, TS syntax

### Card images
See follow-up comments with embedded TCGdex assets.