### PR TITLE
fix(data): Stormfront (Diamond & Pearl)

### DIFF
--- a/data/Diamond & Pearl/Stormfront/82.ts
+++ b/data/Diamond & Pearl/Stormfront/82.ts
@@ -14,8 +14,8 @@ const card: Card = {
 	set: Set,
 
 	effect: {
-		fr: "Cette carte reste en jeu lorsque vous la jouez. Défaussez-la si une autre carte Stade est mise en jeu. Si une autre carte comportant le même nom est en jeu, vous le pouvez pas jouer cette carte.\n\nUne seule fois lors du tour de chaque joueur, ce joueur lance une pièce. Si c'est face, il cherche dans sa pile de défausse une carte Énergie  ou , la montre à son adversaire et la place dans sa main.",
-		de: "Einmal während seines Zuges kann jeder Spieler 1 Münze werfen. Bei \"Kopf\" durchsucht dieser Spieler seinen Ablagestapel nach 1 - oder -Energiekarte, zeigt sie seinem Gegner und nimmt sie auf die Hand."
+		fr: "Une seule fois lors du tour de chaque joueur, ce joueur lance une pièce. Si c'est face, il cherche dans sa pile de défausse une carte Énergie Électrique ou Métal, la montre à son adversaire et la place dans sa main.",
+		de: "Einmal während seines Zuges kann jeder Spieler 1 Münze werfen. Bei \"Kopf\" durchsucht dieser Spieler seinen Ablagestapel nach 1 - oder -Energiekarte, zeigt sie seinem Gegner und nimmt sie auf die Hand.",
 	},
 
 	trainerType: "Stadium",

--- a/data/Diamond & Pearl/Stormfront/87.ts
+++ b/data/Diamond & Pearl/Stormfront/87.ts
@@ -14,8 +14,8 @@ const card: Card = {
 	set: Set,
 
 	effect: {
-		fr: "Vous ne pouvez jouer qu'une seule carte Supporter par tour. Lorsque vous la jouez, placez-la à côté de votre Pokémon Actif. À la fin du tour, défaussez-la.\n\nChoisissez dans votre pile de défausse 2 cartes Dresseur, Supporter ou Stade différentes et montrez-les à votre adversaire. Celui-ci en choisit une. Placez cette carte dans votre main et défaussez l'autre. (Si toutes les cartes Dresseurs, Supporter et Stade dans votre pile de défausse ont le même nom, choisissez-en une. Montrez-la à votre adversaire et placez-la dans votre main.)",
-		de: "Durchsuche deinen Ablagestapel nach 2 unterschiedlichen Trainer-, Unterstützer- oder Stadion-Karten und zeige sie deinem Gegner. Dein Gegner wählt 1 davon. Nimm die gewählte Karte auf die Hand und lege die andere Karte auf deinen Ablagestapel. (Wenn alle Trainer-, Unterstützer- und Stadion-Karten in deinem Ablagestapel jeweils den gleichen Namen haben, wähle 1 von ihnen. Zeige die gewählte Karte deinem Gegner und nimm sie auf die Hand.)"
+		fr: "Choisissez dans votre pile de défausse 2 cartes Dresseur, Supporter ou Stade différentes et montrez-les à votre adversaire. Celui-ci en choisit une. Placez cette carte dans votre main et défaussez l'autre. (Si toutes les cartes Dresseurs, Supporter et Stade dans votre pile de défausse ont le même nom, choisissez-en une. Montrez-la à votre adversaire et placez-la dans votre main.)",
+		de: "Durchsuche deinen Ablagestapel nach 2 unterschiedlichen Trainer-, Unterstützer- oder Stadion-Karten und zeige sie deinem Gegner. Dein Gegner wählt 1 davon. Nimm die gewählte Karte auf die Hand und lege die andere Karte auf deinen Ablagestapel. (Wenn alle Trainer-, Unterstützer- und Stadion-Karten in deinem Ablagestapel jeweils den gleichen Namen haben, wähle 1 von ihnen. Zeige die gewählte Karte deinem Gegner und nimm sie auf die Hand.)",
 	},
 
 	trainerType: "Supporter",

--- a/data/Diamond & Pearl/Stormfront/97.ts
+++ b/data/Diamond & Pearl/Stormfront/97.ts
@@ -35,12 +35,21 @@ const card: Card = {
 			name: {
 				en: "Heat Metal",
 				fr: "Chaleur métallique",
-				de: "Metall erhitzen"
+				de: "Metall erhitzen",
 			},
 			effect: {
 				en: "Your opponent can't remove the Special Condition Burned by evolving or devolving his or her Burned Pokémon. (This also includes putting a Pokémon Level-Up card onto the Burned Pokémon.) Whenever your opponent flips a coin for the Special Condition Burned between turns, treat it as tails.",
 				fr: "Votre adversaire ne peut retirer l'État Spécial Brûlé en évoluant ou dés-évoluant son Pokémon Brûlé. (Cela comprend placer une Carte Pokémon Niveau Sup sur le Pokémon Brûlé.) Lorsque votre adversaire lance une pièce pour l'État Spécial Brûlé entre deux tours, considérez que c'est pile.",
-				de: "Dein Gegner kann den Speziellen Zustand \"verbrannt\" nicht durch Entwickeln oder Rückentwickeln von seinen Pokémon entfernen. (Dies gilt auch für das Spielen einer Pokémon Level-Up-Karte auf das verbrannte Pokémon.) Jedes Mal, wenn dein Gegner zwischen den Zügen eine Münze für den Speziellen Zustand \"verbrannt\" wirft, zählt das Ergebnis des Münzwurfs als \"Zahl\"."
+				de: "Dein Gegner kann den Speziellen Zustand \"verbrannt\" nicht durch Entwickeln oder Rückentwickeln von seinen Pokémon entfernen. (Dies gilt auch für das Spielen einer Pokémon Level-Up-Karte auf das verbrannte Pokémon.) Jedes Mal, wenn dein Gegner zwischen den Zügen eine Münze für den Speziellen Zustand \"verbrannt\" wirft, zählt das Ergebnis des Münzwurfs als \"Zahl\".",
+			},
+		},
+		{
+			type: "Poke-POWER",
+			name: {
+				fr: "Canicule",
+			},
+			effect: {
+				fr: "Une seule fois à la fin de votre tour, si Heatran se trouve sur votre Banc, vous pouvez utiliser ce pouvoir. Si vous avez défaussé des cartes Énergie de base attachées à vos Pokémon Actifs Feu ou Métal en utilisant l'attaque de ce Pokémon ce tour-ci, attachez à ce Pokémon jusqu'à 2 de ces cartes Énergie.",
 			},
 		},
 	],


### PR DESCRIPTION
Set: **Stormfront**
Series folder: `Diamond & Pearl`
Changed card files: **3**

### Validation
- [ ] `bun run validate`
- [ ] `cd server && bun run --bun validate`
- [ ] `cd server && bun run compile`
- [ ] Manual review: translations, energy types, TS syntax

### Card images
See follow-up comments with embedded TCGdex assets.