### PR TITLE
fix(data): Aquapolis (E-Card)

### DIFF
--- a/data/E-Card/Aquapolis/118.ts
+++ b/data/E-Card/Aquapolis/118.ts
@@ -14,8 +14,8 @@ const card: Card = {
 	set: Set,
 
 	effect: {
-		fr: "Cette carte reste en jeu lorsque vous la jouez. Défaussez-vous de cette carte si une autre carte Stade arrive en jeu.\n\nUne seule fois pendant le tour de chaque joueur (avant son attaque), si le Banc de ce joueur n'est pas plein, ce joueur lance une pièce. Si c'est face, ce joueur montre à son adversaire une carte Énergie de base de sa main. Ce joueur cherche ensuite dans son deck une Carte Pokémon de base du même type (la même couleur) que la carte Énergie révélée et la place sur son Banc. Enfin, ce joueur mélange son deck.",
-		de: "Once during each player´s turn (before attacking), if that player´s Bench isn´t full, that player flips a coin. If heads, that player shows hi or her opponent a basic Energy card from his or her hand. Then, that player searches his or her deck for a Basic Pokémon card of the same type (color) as the revealed Energy card and puts it onto his or her Bench. The player shuffle his or her deck afterward."
+		fr: "Cette carte reste en jeu lorsque vous la jouez. Défaussez -vous de cette carte si une autre carte Stade arrive en jeu.",
+		de: "Once during each player´s turn (before attacking), if that player´s Bench isn´t full, that player flips a coin. If heads, that player shows hi or her opponent a basic Energy card from his or her hand. Then, that player searches his or her deck for a Basic Pokémon card of the same type (color) as the revealed Energy card and puts it onto his or her Bench. The player shuffle his or her deck afterward.",
 	},
 
 	thirdParty: {

--- a/data/E-Card/Aquapolis/119.ts
+++ b/data/E-Card/Aquapolis/119.ts
@@ -18,19 +18,22 @@ const card: Card = {
 		de: "Lege diese Karte an 1 deiner  -Pokémon im Spiel an. Dieses Pokémon kann den Angriff dieser Karte anstatt seiner eigenen verwenden. Lege am Ende deines Zuges Unlicht-Würfel 01 auf deinen Ablagestapel."
 	},
 
-	attacks: [{
-		name: {
-			de: "Plunder"
+	attacks: [
+		{
+			name: {
+				de: "Plunder",
+				fr: "Pillage",
+			},
+			damage: 10,
+			effect: {
+				de: "Before doing damage, discard any Trainer cards attached to the Defending Pokémon.",
+				fr: "Avant d'infliger les dégâts, défaussez toutes les cartes Dresseur attachées au Pokémon Défenseur.",
+			},
+			cost: [
+				"Darkness",
+			],
 		},
-
-		damage: 10,
-
-		effect: {
-			de: "Before doing damage, discard any Trainer cards attached to the Defending Pokémon."
-		},
-
-		cost: ["Darkness"]
-	}],
+	],
 
 	thirdParty: {
 		cardmarket: 275195,

--- a/data/E-Card/Aquapolis/121.ts
+++ b/data/E-Card/Aquapolis/121.ts
@@ -18,19 +18,22 @@ const card: Card = {
 		de: "Lege diese Karte an 1 deiner -Pokémon im Spiel an. Dieses Pokémon kann den Angriff dieser Karte anstatt seiner eigenen verwenden. Lege am Ende deines Zuges Kampf-Würfel 01 auf deinen Ablagestapel."
 	},
 
-	attacks: [{
-		name: {
-			de: "Rasende Wut"
+	attacks: [
+		{
+			name: {
+				de: "Rasende Wut",
+				fr: "Rage violente",
+			},
+			damage: "10x",
+			effect: {
+				de: "Wirf so viele Münzen, wie Schadensmarken auf diesem Pokémon liegen. Dieser Angriff fügt 10 Schadenspunkte mal der Anzahl \"Kopf\" zu.",
+				fr: "Lancez un nombre de pièces égal au nombre de marqueurs de dégâts sur ce Pokémon. Cette attaque inflige 10 dégâts multipliés par le nombre de faces.",
+			},
+			cost: [
+				"Fighting",
+			],
 		},
-
-		damage: "10x",
-
-		effect: {
-			de: "Wirf so viele Münzen, wie Schadensmarken auf diesem Pokémon liegen. Dieser Angriff fügt 10 Schadenspunkte mal der Anzahl \"Kopf\" zu."
-		},
-
-		cost: ["Fighting"]
-	}],
+	],
 
 	thirdParty: {
 		cardmarket: 275197,

--- a/data/E-Card/Aquapolis/122.ts
+++ b/data/E-Card/Aquapolis/122.ts
@@ -18,17 +18,21 @@ const card: Card = {
 		de: "Lege diese Karte an 1 deiner -Pokémon im Spiel an. Dieses Pokémon kann den Angriff dieser Karte anstatt seiner eigenen verwenden. Lege am Ende deines Zuges Feuer-Würfel 01 auf deinen Ablagestapel."
 	},
 
-	attacks: [{
-		name: {
-			de: "Versengung"
+	attacks: [
+		{
+			name: {
+				de: "Versengung",
+				fr: "Roussir",
+			},
+			effect: {
+				de: "Das Verteidigende Pokémon ist jetzt verbrannt.",
+				fr: "Le Pokémon Défenseur est maintenant Brûlé.",
+			},
+			cost: [
+				"Fire",
+			],
 		},
-
-		effect: {
-			de: "Das Verteidigende Pokémon ist jetzt verbrannt."
-		},
-
-		cost: ["Fire"]
-	}],
+	],
 
 	thirdParty: {
 		cardmarket: 275198,

--- a/data/E-Card/Aquapolis/123.ts
+++ b/data/E-Card/Aquapolis/123.ts
@@ -14,8 +14,8 @@ const card: Card = {
 	set: Set,
 
 	effect: {
-		fr: "Vous ne pouvez jouer qu'une carte Supporter à chaque tour. Quand vous jouez cette carte, placez-la à côté de votre Pokémon Actif. À la fin de votre tour, défaussez-vous de cette carte.\n\nMélangez votre deck. Regardez ensuite les 7 cartes du dessus de votre deck. Choisissez une de ces cartes et ajoutez-la à votre main. Mélangez ensuite le reste à votre deck.",
-		de: "Mische dein Deck. Schaue dir dann die 7 obersten Karten deines Decks an. Wähle 1 dieser Karten und nimm sie auf deine Hand. Mische danach die anderen Karten in dein Deck."
+		fr: "Mélangez votre deck. Regardez ensuite les 7 cartes du dessus de votre deck. Choisissez une de ces cartes et ajoutez-la à votre main. Mélangez ensuite le reste à votre deck.",
+		de: "Mische dein Deck. Schaue dir dann die 7 obersten Karten deines Decks an. Wähle 1 dieser Karten und nimm sie auf deine Hand. Mische danach die anderen Karten in dein Deck.",
 	},
 
 	thirdParty: {

--- a/data/E-Card/Aquapolis/126.ts
+++ b/data/E-Card/Aquapolis/126.ts
@@ -14,8 +14,8 @@ const card: Card = {
 	set: Set,
 
 	effect: {
-		fr: "Vous ne pouvez jouer qu'une carte Supporter à chaque tour. Quand vous jouez cette carte, placez-la à côté de votre Pokémon Actif. À la fin de votre tour, défaussez-vous de cette carte.\n\nDéfaussez-vous de jusqu'à 2 cartes Énergies de base de votre main. Si vous vous êtes défaussé d'une carte Énergie de base, piochez 3 cartes. Si vous vous êtes défaussé de 2 cartes Énergie de base, piochez 5 cartes.",
-		de: "Lege bis zu 2 Basis-Energiekarten aus deiner Hand auf deinen Ablagestapel. Hast du auf diese Weise 1 Basis-Energiekarte abgelegt, ziehe 3 Karten. Hast du auf diese Weise 2 Basis-Energiekarten abgelegt, ziehe 5 Karten."
+		fr: "Défaussez -vous de jusqu'à 2 cartes Énergies de base de votre main. Si vous vous êtes défaussé d'une carte Énergie de base, piochez 3 cartes. Si vous vous êtes défaussé de 2 cartes Énergie de base, piochez 5 cartes.",
+		de: "Lege bis zu 2 Basis-Energiekarten aus deiner Hand auf deinen Ablagestapel. Hast du auf diese Weise 1 Basis-Energiekarte abgelegt, ziehe 3 Karten. Hast du auf diese Weise 2 Basis-Energiekarten abgelegt, ziehe 5 Karten.",
 	},
 
 	thirdParty: {

--- a/data/E-Card/Aquapolis/129.ts
+++ b/data/E-Card/Aquapolis/129.ts
@@ -18,19 +18,22 @@ const card: Card = {
 		de: "Lege diese Karte an 1 deiner -Pokémon im Spiel an. Dieses Pokémon kann den Angriff dieser Karte anstatt seiner eigenen verwenden. Lege am Ende deines Zuges Metall-Würfel 01 auf deinen Ablagestapel."
 	},
 
-	attacks: [{
-		name: {
-			de: "Metall-Umkehrung"
+	attacks: [
+		{
+			name: {
+				de: "Metall-Umkehrung",
+				fr: "Inversion métal",
+			},
+			damage: 10,
+			effect: {
+				de: "Bevor Schaden zugefügt wird, kannst du 1 der Pokémon auf der Bank deines Gegners wählen und es mit dem Verteidigenden Pokémon austauschen.",
+				fr: "Avant d'infliger les dégâts, vous pouvez choisir un des Pokémon du Banc de votre adversaire et l'échanger contre le Pokémon Défenseur.",
+			},
+			cost: [
+				"Metal",
+			],
 		},
-
-		damage: 10,
-
-		effect: {
-			de: "Bevor Schaden zugefügt wird, kannst du 1 der Pokémon auf der Bank deines Gegners wählen und es mit dem Verteidigenden Pokémon austauschen."
-		},
-
-		cost: ["Metal"]
-	}],
+	],
 
 	thirdParty: {
 		cardmarket: 275205,

--- a/data/E-Card/Aquapolis/130.ts
+++ b/data/E-Card/Aquapolis/130.ts
@@ -14,8 +14,8 @@ const card: Card = {
 	set: Set,
 
 	effect: {
-		fr: "Vous ne pouvez jouer qu'une carte Supporter à chaque tour. Quand vous jouez cette carte, placez-la à côté de votre Pokémon Actif. À la fin de votre tour, défaussez-vous de cette carte.\n\nCherchez dans votre deck jusqu'à deux cartes Bébé Pokémon et/ou Pokémon de base et placez-les sur votre Banc. Mélangez ensuite votre deck.",
-		de: "Durchsuche dein Deck nach bis zu 2 Baby- und/oder Basis-Pokémonkarten und lege sie auf deine Bank. Mische dein Deck danach."
+		fr: "Cherchez dans votre deck jusqu'à deux cartes Bébé Pokémon et/ou Pokémon de base et placez-les sur votre Banc. Mélangez ensuite votre deck.",
+		de: "Durchsuche dein Deck nach bis zu 2 Baby- und/oder Basis-Pokémonkarten und lege sie auf deine Bank. Mische dein Deck danach.",
 	},
 
 	thirdParty: {

--- a/data/E-Card/Aquapolis/131.ts
+++ b/data/E-Card/Aquapolis/131.ts
@@ -14,8 +14,8 @@ const card: Card = {
 	set: Set,
 
 	effect: {
-		fr: "Cette carte reste en jeu lorsque vous la jouez. Défaussez-vous de cette carte si une autre carte Stade arrive en jeu.\n\nUne seule fois pendant chacun de ses tours, à chaque fois qu'un joueur attache une carte Énergie de sa main à l'un des Pokémon de son Banc, il retire un marqueur de dégâts de ce Pokémon, s'il en a.",
-		de: "Once during each of his or her turns, whenever a player attaches an Energy card from his or her hand to 1 of his or her Benched Pokémon, he or she removes 1 damage counter, if any, from that Pokémon."
+		fr: "Cette carte reste en jeu lorsque vous la jouez. Défaussez -vous de cette carte si une autre carte Stade arrive en jeu.",
+		de: "Once during each of his or her turns, whenever a player attaches an Energy card from his or her hand to 1 of his or her Benched Pokémon, he or she removes 1 damage counter, if any, from that Pokémon.",
 	},
 
 	thirdParty: {

--- a/data/E-Card/Aquapolis/132.ts
+++ b/data/E-Card/Aquapolis/132.ts
@@ -18,17 +18,21 @@ const card: Card = {
 		de: "LLege diese Karte an 1 deiner -Pokémon im Spiel an. Dieses Pokémon kann den Angriff dieser Karte anstatt seiner eigenen verwenden. Lege am Ende deines Zuges Psycho-Würfel 01 auf deinen Ablagestapel."
 	},
 
-	attacks: [{
-		name: {
-			de: "Psy Confuse"
+	attacks: [
+		{
+			name: {
+				de: "Psy Confuse",
+				fr: "Confusion psy",
+			},
+			effect: {
+				de: "The Defending Pokémon is now Confused.",
+				fr: "Le Pokémon Défenseur est maintenant Confus.",
+			},
+			cost: [
+				"Psychic",
+			],
 		},
-
-		effect: {
-			de: "The Defending Pokémon is now Confused."
-		},
-
-		cost: ["Psychic"]
-	}],
+	],
 
 	thirdParty: {
 		cardmarket: 275208,

--- a/data/E-Card/Aquapolis/133.ts
+++ b/data/E-Card/Aquapolis/133.ts
@@ -14,8 +14,8 @@ const card: Card = {
 	set: Set,
 
 	effect: {
-		fr: "Vous ne pouvez jouer qu'une carte Supporter à chaque tour. Quand vous jouez cette carte, placez-la à côté de votre Pokémon Actif. À la fin de votre tour, défaussez-vous de cette carte.\n\nRegardez les 6 cartes du dessus de votre deck. Prenez-y toutes les cartes Énergie de base que vous y trouvez, montrez-les à votre adversaire et ajoutez-les à votre main. Mélangez ensuite votre deck.",
-		de: "Look at the top 6 cards of your deck. Take all basic Energy cards you find there, show them to your opponent, and then put them into your hand. Shuffle your deck afterward."
+		fr: "Regardez les 6 cartes du dessus de votre deck. Prenez-y toutes les cartes Énergie de base que vous y trouvez, montrez-les à votre adversaire et ajoutez-les à votre main. Mélangez ensuite votre deck.",
+		de: "Look at the top 6 cards of your deck. Take all basic Energy cards you find there, show them to your opponent, and then put them into your hand. Shuffle your deck afterward.",
 	},
 
 	thirdParty: {

--- a/data/E-Card/Aquapolis/136.ts
+++ b/data/E-Card/Aquapolis/136.ts
@@ -14,8 +14,8 @@ const card: Card = {
 	set: Set,
 
 	effect: {
-		fr: "Vous ne pouvez jouer qu'une carte Supporter à chaque tour. Quand vous jouez cette carte, placez-la à côté de votre Pokémon Actif. À la fin de votre tour, défaussez-vous de cette carte.\n\nPrenez 5 cartes Bébé Pokémon, Pokémon de base, Évolution et/ou Énergie de base de votre pile de défausse et montrez-les à votre adversaire. Mélangez-les ensuite à votre deck.",
-		de: "Nimm 5 Baby-Pokémon-,Basis-Pokémon-,Entwicklungs- und/oder Basis-Energiekarten aus deinem Ablagestapel und zeige sie deinem Gegner. Mische sie in dein Deck."
+		fr: "Prenez 5 cartes Bébé Pokémon, Pokémon de base, Évolution et/ou Énergie de base de votre pile de défausse et montrez-les à votre adversaire. Mélangez-les ensuite à votre deck.",
+		de: "Nimm 5 Baby-Pokémon-,Basis-Pokémon-,Entwicklungs- und/oder Basis-Energiekarten aus deinem Ablagestapel und zeige sie deinem Gegner. Mische sie in dein Deck.",
 	},
 
 	thirdParty: {

--- a/data/E-Card/Aquapolis/137.ts
+++ b/data/E-Card/Aquapolis/137.ts
@@ -14,8 +14,8 @@ const card: Card = {
 	set: Set,
 
 	effect: {
-		fr: "Vous ne pouvez jouer qu'une carte Supporter à chaque tour. Quand vous jouez cette carte, placez-la à côté de votre Pokémon Actif. À la fin de votre tour, défaussez-vous de cette carte.\n\nCherchez dans votre deck jusqu'à 2 cartes Machine technique ou Outil Pokémon, montrez-les à votre adversaire et ajoutez-les à votre main. Mélangez ensuite votre deck.",
-		de: "Search your deck for up to 2 Technical Machine and/or Pokémon Tool cards, show them to your opponent, and then put then into your hand. Shuffle your deck afterward."
+		fr: "Cherchez dans votre deck jusqu'à 2 cartes Machine technique ou Outil Pokémon, montrez-les à votre adversaire et ajoutez-les à votre main. Mélangez ensuite votre deck.",
+		de: "Search your deck for up to 2 Technical Machine and/or Pokémon Tool cards, show them to your opponent, and then put then into your hand. Shuffle your deck afterward.",
 	},
 
 	thirdParty: {

--- a/data/E-Card/Aquapolis/138.ts
+++ b/data/E-Card/Aquapolis/138.ts
@@ -14,8 +14,8 @@ const card: Card = {
 	set: Set,
 
 	effect: {
-		fr: "Cette carte reste en jeu lorsque vous la jouez. Défaussez-vous de cette carte si une autre carte Stade arrive en jeu.\n\nUne seule fois pendant le tour de chaque joueur (avant son attaque), ce joueur peut lancer une pièce. Si c'est face, ce joueur choisit une de ses Évolutions de Pokémon en jeu et se défausse de la carte Évolution du dessus de ce Pokémon, inversant son évolution.",
-		de: "Einmal in jedem eigenem Zug (vor dem Angriff) darf jeder Spieler eine Münze werfen. Bei 'Kopf' wählt der Spieler 1 seiner entwickelten Pokémon im Spiel und legt die oberste Entwicklungskarte dieses Pokémon auf seinen Ablagestapel, rückentwickelt es also. Diese Karte bleibt im Spiel, wenn du sie spielst. Lege diese Karte ab, sobald eine weitere Stadion-Karte ins Spiel kommt."
+		fr: "Cette carte reste en jeu lorsque vous la jouez. Défaussez -vous de cette carte si une autre carte Stade arrive en jeu.",
+		de: "Einmal in jedem eigenem Zug (vor dem Angriff) darf jeder Spieler eine Münze werfen. Bei 'Kopf' wählt der Spieler 1 seiner entwickelten Pokémon im Spiel und legt die oberste Entwicklungskarte dieses Pokémon auf seinen Ablagestapel, rückentwickelt es also. Diese Karte bleibt im Spiel, wenn du sie spielst. Lege diese Karte ab, sobald eine weitere Stadion-Karte ins Spiel kommt.",
 	},
 
 	thirdParty: {

--- a/data/E-Card/Aquapolis/139.ts
+++ b/data/E-Card/Aquapolis/139.ts
@@ -14,8 +14,8 @@ const card: Card = {
 	set: Set,
 
 	effect: {
-		fr: "Cette carte reste en jeu lorsque vous la jouez. Défaussez-vous de cette carte si une autre carte Stade arrive en jeu.\n\nUne seule fois pendant chacun de ses tours, un joueur peut se défausser d'une carte Énergie de base de sa main. S'il fait ainsi, il choisit une carte Énergie de base de sa pile de défausse, la montre à son adversaire et l'ajoute ensuite à sa main.",
-		de: "Once during each of his or her turns, a player may discard a basic Energy card from his or her hand. If that player does, he or she chooses a basic Energy card from his or her discard pile, shows it to his or her opponent, and then puts it into his or her hand."
+		fr: "Cette carte reste en jeu lorsque vous la jouez. Défaussez -vous de cette carte si une autre carte Stade arrive en jeu.",
+		de: "Once during each of his or her turns, a player may discard a basic Energy card from his or her hand. If that player does, he or she chooses a basic Energy card from his or her discard pile, shows it to his or her opponent, and then puts it into his or her hand.",
 	},
 
 	thirdParty: {

--- a/data/E-Card/Aquapolis/140.ts
+++ b/data/E-Card/Aquapolis/140.ts
@@ -18,17 +18,21 @@ const card: Card = {
 		de: "Lege diese Karte an 1 deiner -Pokémon im Spiel an. Dieses Pokémon kann den Angriff dieser Karte anstatt seiner eigenen verwenden. Lege am Ende deines Zuges Wasser-Würfel 01 auf deinen Ablagestapel."
 	},
 
-	attacks: [{
-		name: {
-			de: "Verspritzer"
+	attacks: [
+		{
+			name: {
+				de: "Verspritzer",
+				fr: "Crépitement",
+			},
+			effect: {
+				de: "Wähle 1 der Pokémon deines Gegners. Dieser Angriff fügt diesem Pokémon 20 Schadenspunkte zu. Wende Schwäche und Resistenz nicht an.",
+				fr: "Choisissez un des Pokémon de votre adversaire. Cette attaque inflige 20 dégâts à ce Pokémon. N'appliquez ni la Faiblesse, ni la Résistance.",
+			},
+			cost: [
+				"Water",
+			],
 		},
-
-		effect: {
-			de: "Wähle 1 der Pokémon deines Gegners. Dieser Angriff fügt diesem Pokémon 20 Schadenspunkte zu. Wende Schwäche und Resistenz nicht an."
-		},
-
-		cost: ["Water"]
-	}],
+	],
 
 	thirdParty: {
 		cardmarket: 275216,

--- a/data/E-Card/Aquapolis/141.ts
+++ b/data/E-Card/Aquapolis/141.ts
@@ -14,8 +14,8 @@ const card: Card = {
 	set: Set,
 
 	effect: {
-		fr: "Attachez cette carte à l'un de vos Pokémon. Défaussez-vous en à la fin du prochain tour de votre adversaire.\n\nTant que cette carte est attachée, ce Pokémon n'a pas de Faiblesse.",
-		de: "As long as this card is attached, this Pokémon has no Weakness."
+		fr: "Attachez cette carte à l'un de vos Pokémon. Défaussez-vous en à la fin du prochain tour de votre adversaire.",
+		de: "As long as this card is attached, this Pokémon has no Weakness.",
 	},
 
 	thirdParty: {

--- a/data/E-Card/Aquapolis/142.ts
+++ b/data/E-Card/Aquapolis/142.ts
@@ -15,7 +15,8 @@ const card: Card = {
 	energyType: "Special",
 
 	effect: {
-		de: "Falls das Pokémon, an das die Finsternis-Energie angelegt ist, dem Verteidigenden Pokémon Schadenspunkte zufügt (nachdem Schwäche und Resistenz verrechnet wurden), fügt der Angriff dem Verteidigenden Pokémon 10 weitere Schadenspunkte zu. Lege am Ende jedes Zugs eine Schadensmarke auf das Pokémon, an das die Finsternis-Energie angelegt ist, falls es nicht vom Typ  ist oder 'Dunkel' im Namen hat. Finsternis-Energie liefert - Energie. (Zählt nicht als Basis-Energiekarte.)"
+		de: "Falls das Pokémon, an das die Finsternis-Energie angelegt ist, dem Verteidigenden Pokémon Schadenspunkte zufügt (nachdem Schwäche und Resistenz verrechnet wurden), fügt der Angriff dem Verteidigenden Pokémon 10 weitere Schadenspunkte zu. Lege am Ende jedes Zugs eine Schadensmarke auf das Pokémon, an das die Finsternis-Energie angelegt ist, falls es nicht vom Typ  ist oder 'Dunkel' im Namen hat. Finsternis-Energie liefert - Energie. (Zählt nicht als Basis-Energiekarte.)",
+		fr: "Si le Pokémon sur lequel est attachée Énergie obscurité inflige des dégâts au Pokémon Défenseur (après application de la Faiblesse et de la Résistance), cette attaque inflige 10 dégâts supplémentaires au Pokémon Défenseur.",
 	},
 
 	thirdParty: {

--- a/data/E-Card/Aquapolis/143.ts
+++ b/data/E-Card/Aquapolis/143.ts
@@ -15,7 +15,8 @@ const card: Card = {
 	energyType: "Special",
 
 	effect: {
-		de: "Damage done to the Pokémon Metal Energy is attached to is reduced by 10 (after applying Weakness and Resistance). If the Pokémon metal Energy is attached to isn´t , whenever it damages a Pokémon, reduce that damage by 10 (before applying Weakness and Resistance). Metal Energy provides  Energy. (Doesn´t count as a basic Energy card.)"
+		de: "Damage done to the Pokémon Metal Energy is attached to is reduced by 10 (after applying Weakness and Resistance). If the Pokémon metal Energy is attached to isn´t , whenever it damages a Pokémon, reduce that damage by 10 (before applying Weakness and Resistance). Metal Energy provides  Energy. (Doesn´t count as a basic Energy card.)",
+		fr: "Les dégâts infligés au Pokémon sur lequel Énergie Métal est attachée sont réduits de 10 (avant application de la Faiblesse et de la Résistance). Si le Pokémon sur lequel Énergie Métal est attachée n'est pas Métal, à chaque fois qu'il inflige des dégâts à un Pokémon, réduisez ces dégâts de 10 (avant application de la Faiblesse et de la Résistance).",
 	},
 
 	thirdParty: {

--- a/data/E-Card/Aquapolis/144.ts
+++ b/data/E-Card/Aquapolis/144.ts
@@ -15,7 +15,8 @@ const card: Card = {
 	energyType: "Special",
 
 	effect: {
-		de: "Lege Regenbogen-Energie an 1 deiner Pokémon an. Solange Regenbogen-Energie im Spiel ist, erzeugt Regenbogen-Energie jeden Energietyp, aber nur 1 Energie auf einmal. (Zählt nicht als Basis-Energiekarte, wenn nicht im Spiel.) Wenn du diese Karte aus deiner Hand an 1 deiner Pokémon anlegst, lege 1 Schadensmarke auf dieses Pokémon."
+		de: "Lege Regenbogen-Energie an 1 deiner Pokémon an. Solange Regenbogen-Energie im Spiel ist, erzeugt Regenbogen-Energie jeden Energietyp, aber nur 1 Energie auf einmal. (Zählt nicht als Basis-Energiekarte, wenn nicht im Spiel.) Wenn du diese Karte aus deiner Hand an 1 deiner Pokémon anlegst, lege 1 Schadensmarke auf dieses Pokémon.",
+		fr: "Attachez Énergie multicolore à un de vos Pokémon. Tant qu'Énergie multicolore est en jeu, elle remplace n'importe quel type d'Énergie mais ne fournit que 1 Énergie différente à la fois. (N'est pas considérée comme une carte Énergie de base quand elle n'est pas en jeu.) Quand vous attachez cette carte depuis votre main à l'un de vos Pokémon, placez un marqueur de dégâts sur ce Pokémon.",
 	},
 
 	thirdParty: {

--- a/data/E-Card/Aquapolis/145.ts
+++ b/data/E-Card/Aquapolis/145.ts
@@ -15,7 +15,8 @@ const card: Card = {
 	energyType: "Special",
 
 	effect: {
-		de: "Boost Energy can be attached only to an Evolved Pokémon. Discard Boost Energy at the end of the turn it was attached.\nBoost Energy provides  Energy. The Pokémon Boost Energy is attached to can't retreat.\nWhen the Pokémon Boost Energy is attached to is no longer an Evolved Pokémon, discard Boost Energy."
+		de: "Boost Energy can be attached only to an Evolved Pokémon. Discard Boost Energy at the end of the turn it was attached.\nBoost Energy provides  Energy. The Pokémon Boost Energy is attached to can't retreat.\nWhen the Pokémon Boost Energy is attached to is no longer an Evolved Pokémon, discard Boost Energy.",
+		fr: "Énergie super ne peut être attachée qu'à une Évolution de Pokémon. Défaussez -vous d'Énergie super à la fin du tour auquel elle a été attachée. Énergie super fournit Incolore Incolore Incolore. Le Pokémon auquel Énergie super est attachée ne peut pas battre en retraite. Quand le Pokémon auquel Énergie super est attachée n'est plus une Évolution, défaussez-vous d'Énergie super.",
 	},
 
 	thirdParty: {

--- a/data/E-Card/Aquapolis/146.ts
+++ b/data/E-Card/Aquapolis/146.ts
@@ -15,7 +15,8 @@ const card: Card = {
 	energyType: "Special",
 
 	effect: {
-		de: "Kristall-Energie liefert 1 Energie aller Typen (Farben) von Basis-Energiekarten, die an das Pokémon angelegt sind, an das Kristall-Energie angelegt ist. Sind an das Pokémon, an das Kristall-Energie angelegt ist, keine Basis-Energiekarten angelegt, liefert Kristall-Energie -Energie."
+		de: "Kristall-Energie liefert 1 Energie aller Typen (Farben) von Basis-Energiekarten, die an das Pokémon angelegt sind, an das Kristall-Energie angelegt ist. Sind an das Pokémon, an das Kristall-Energie angelegt ist, keine Basis-Energiekarten angelegt, liefert Kristall-Energie -Energie.",
+		fr: "Énergie cristal fournit 1 Énergie de chaque type (couleur) de cartes Énergie de base attachées ay Pokémon auquel Énergie cristal est attachée. S'il n'y a aucune carte Énergie de base attachée au Pokémon auquel Énergie cristal est attachée, Énergie cristal fournit Incolore.",
 	},
 
 	thirdParty: {

--- a/data/E-Card/Aquapolis/147.ts
+++ b/data/E-Card/Aquapolis/147.ts
@@ -15,7 +15,8 @@ const card: Card = {
 	energyType: "Special",
 
 	effect: {
-		de: "Verkrümmungs-Energie liefert -Energie. Wenn du Verkrümmungs-Energie aus deiner Hand an dein Aktives Pokémon anlegst, tausche dein Aktives Pokémon mit 1 der Pokémon auf deiner Bank."
+		de: "Verkrümmungs-Energie liefert -Energie. Wenn du Verkrümmungs-Energie aus deiner Hand an dein Aktives Pokémon anlegst, tausche dein Aktives Pokémon mit 1 der Pokémon auf deiner Bank.",
+		fr: "Énergie de distorsion fournit Énergie Incolore. Quand vous attachez Énergie de distorsion depuis votre main à votre Pokémon Actif, échangez votre Pokémon Actif contre l'un des Pokémon de votre Banc.",
 	},
 
 	thirdParty: {


### PR DESCRIPTION
Set: **Aquapolis**
Series folder: `E-Card`
Changed card files: **23**

### Validation
- [ ] `bun run validate`
- [ ] `cd server && bun run --bun validate`
- [ ] `cd server && bun run compile`
- [ ] Manual review: translations, energy types, TS syntax

### Card images
See follow-up comments with embedded TCGdex assets.