### PR TITLE
fix(data): Sandstorm (EX)

### DIFF
--- a/data/EX/Sandstorm/87.ts
+++ b/data/EX/Sandstorm/87.ts
@@ -15,8 +15,8 @@ const card: Card = {
 	trainerType: "Supporter",
 
 	effect: {
-		fr: "Vous ne pouvez jouer qu'une seule carte Supporter par tour. Lorsque vous jouez cette carte, placez-la à côté de votre Pokémon Actif. À la fin de votre tour, défaussez-la.\n\nChoisissez dans votre deck jusqu'à trois types de cartes Pokémon de base différents (sauf les cartes Bébé Pokémon), montrez-les à votre adversaire et placez-les dans votre main. Ensuite, mélangez votre deck.",
-		de: "Durchsuche dein Deck nach bis zu 3 verschiedenen Basis-Pokémon (außer Baby-Pokémon), zeige sie deinem Gegner und nimm sie auf die Hand. Mische dein Deck danach."
+		fr: "Choisissez dans votre deck jusqu'à trois types de cartes Pokémon de base différents (sauf les cartes Bébé Pokémon), montrez-les à votre adversaire et placez-les dans votre main. Ensuite, mélangez votre deck.",
+		de: "Durchsuche dein Deck nach bis zu 3 verschiedenen Basis-Pokémon (außer Baby-Pokémon), zeige sie deinem Gegner und nimm sie auf die Hand. Mische dein Deck danach.",
 	},
 
 	thirdParty: {

--- a/data/EX/Sandstorm/89.ts
+++ b/data/EX/Sandstorm/89.ts
@@ -15,8 +15,8 @@ const card: Card = {
 	trainerType: "Supporter",
 
 	effect: {
-		fr: "Vous ne pouvez jouer qu'une seule carte Supporter par tour. Lorsque vous jouez cette carte, placez-la à côté de votre Pokémon Actif. À la fin de votre tour, défaussez-la.\n\nChoisissez dans votre deck une carte qui évolue de votre Pokémon Actif (choisissez un Pokémon Actif si vous en avez deux) et placez-la sur ce Pokémon (Vous le faites ainsi évoluer). Ensuite, mélangez votre deck.",
-		de: "Durchsuche dein Deck nach 1 Karte, die sich aus deinem Aktiven Pokémon entwickelt (wähle 1, falls 2 vorhanden sind) und lege sie auf dein Aktives Pokémon. (Das zählt als Entwickeln des gewählten Pokémon.) Mische dein Deck danach."
+		fr: "Choisissez dans votre deck une carte qui évolue de votre Pokémon Actif (choisissez un Pokémon Actif si vous en avez deux) et placez-la sur ce Pokémon (Vous le faites ainsi évoluer). Ensuite, mélangez votre deck.",
+		de: "Durchsuche dein Deck nach 1 Karte, die sich aus deinem Aktiven Pokémon entwickelt (wähle 1, falls 2 vorhanden sind) und lege sie auf dein Aktives Pokémon. (Das zählt als Entwickeln des gewählten Pokémon.) Mische dein Deck danach.",
 	},
 
 	thirdParty: {

--- a/data/EX/Sandstorm/90.ts
+++ b/data/EX/Sandstorm/90.ts
@@ -20,16 +20,19 @@ const card: Card = {
 		de: "Spiele Klauenfossil wie ein Basis-Pokémon. Während Klauenfossil im Spiel ist, zählt es als -Pokémon (anstatt einer Trainerkarte). Klauenfossil hat keine Angriffe, kann sich nicht zurückziehen und wird nicht von Speziellen Zuständen betroffen. Falls Klauenfossil kampfunfähig gemacht wird, zählt es nicht als kampfunfähig gemachtes Pokémon (lege es trotzdem ab). Jederzeit während deines Zuges vor deinem Angriff kannst du Klauenfossil aus dem Spiel ablegen."
 	},
 
-	abilities: [{
-		type: 'Poke-BODY',
-		name: {
-			de: "Gezackter Stein"
+	abilities: [
+		{
+			type: "Poke-BODY",
+			name: {
+				de: "Gezackter Stein",
+				fr: "Pierre tranchante",
+			},
+			effect: {
+				de: "Wenn Klauenfossil dein Aktives Pokémon ist und durch einen gegnerischen Angriff Schaden erhält (auch wenn Klauenfossil dadurch kampfunfähig wird), legst du 1 Schadensmarke auf das Angreifende Pokémon.",
+				fr: "Si Fossile Griffe est votre Pokémon Actif et qu'une attaque de votre adversaire lui inflige des dégâts (même si Fossile Griffe est mise K.O), placez un marqueur de dégât sur le Pokémon Attaquant.",
+			},
 		},
-
-		effect: {
-			de: "Wenn Klauenfossil dein Aktives Pokémon ist und durch einen gegnerischen Angriff Schaden erhält (auch wenn Klauenfossil dadurch kampfunfähig wird), legst du 1 Schadensmarke auf das Angreifende Pokémon."
-		}
-	}],
+	],
 
 	thirdParty: {
 		cardmarket: 275867,

--- a/data/EX/Sandstorm/92.ts
+++ b/data/EX/Sandstorm/92.ts
@@ -20,16 +20,19 @@ const card: Card = {
 		de: "Spiele Wurzelfossil wie ein Basis-Pokémon. Während Wurzelfossil im Spiel ist, zählt es als -Pokémon (anstatt einer Trainerkarte). Wurzelfossil hat keine Angriffe, kann sich nicht zurückziehen und wird nicht von Speziellen Zuständen betroffen. Falls Wurzelfossil kampfunfähig gemacht wird, zählt es nicht als kampfunfähig gemachtes Pokémon (lege es trotzdem ab). Jederzeit während deines Zuges vor deinem Angriff kannst du Wurzelfossil aus dem Spiel ablegen."
 	},
 
-	abilities: [{
-		type: 'Poke-BODY',
-		name: {
-			de: "Schwammiger Stein"
+	abilities: [
+		{
+			type: "Poke-BODY",
+			name: {
+				de: "Schwammiger Stein",
+				fr: "Pierre spongieuse",
+			},
+			effect: {
+				de: "Entferne zu einem beliebigen Zeitpunkt zwischen zwei Zügen 1 Schadensmarke von Wurzelfossil.",
+				fr: "N'importe quand entre deux tours, retirez à Fossile racine un marqueur de dégât.",
+			},
 		},
-
-		effect: {
-			de: "Entferne zu einem beliebigen Zeitpunkt zwischen zwei Zügen 1 Schadensmarke von Wurzelfossil."
-		}
-	}],
+	],
 
 	thirdParty: {
 		cardmarket: 275869,

--- a/data/EX/Sandstorm/93.ts
+++ b/data/EX/Sandstorm/93.ts
@@ -15,7 +15,8 @@ const card: Card = {
 	energyType: "Special",
 
 	effect: {
-		de: "Lege die Multienergiekarte an eines deiner Pokémon an. Die Multienergiekarte liefert jeden Typ von Energie, solange sie im Spiel ist, liefert aber nur eine Energie auf einmal. (Zählt außerhalb des Spiels nicht als Basaisenergiekarte.) Die Multienergiekarte liefert 1 Energie, wenn sie an ein Pokémon angelegt wird, das schon Spezialenergiekarten hat."
+		de: "Lege die Multienergiekarte an eines deiner Pokémon an. Die Multienergiekarte liefert jeden Typ von Energie, solange sie im Spiel ist, liefert aber nur eine Energie auf einmal. (Zählt außerhalb des Spiels nicht als Basaisenergiekarte.) Die Multienergiekarte liefert 1 Energie, wenn sie an ein Pokémon angelegt wird, das schon Spezialenergiekarten hat.",
+		fr: "Attachez Énergies multiples à un de vos Pokémon. Lorsqu'elle est en jeu, Énergies multiples fournit tous les types d'énergie (un seul à la fois). (Elle ne compte pas comme carte Énergie de base lorsqu'elle n'est pas en jeu). Énergies multiples fournit une Énergie Incolore lorsqu'elle est attachée à un Pokémon qui possède déjà des cartes Énergie Spéciales.",
 	},
 
 	thirdParty: {


### PR DESCRIPTION
Set: **Sandstorm**
Series folder: `EX`
Changed card files: **5**

### Validation
- [ ] `bun run validate`
- [ ] `cd server && bun run --bun validate`
- [ ] `cd server && bun run compile`
- [ ] Manual review: translations, energy types, TS syntax

### Card images
See follow-up comments with embedded TCGdex assets.