### PR TITLE
fix(data): Triumphant (HeartGold & SoulSilver)

### DIFF
--- a/data/HeartGold & SoulSilver/Triumphant/100.ts
+++ b/data/HeartGold & SoulSilver/Triumphant/100.ts
@@ -13,7 +13,17 @@ const card: Card = {
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [491, 488],
+	dexId: [
+
+
+		491,
+
+
+		488,
+
+
+	],
+
 	types: [
 		"Darkness",
 		"Psychic",

--- a/data/HeartGold & SoulSilver/Triumphant/101.ts
+++ b/data/HeartGold & SoulSilver/Triumphant/101.ts
@@ -23,29 +23,38 @@ const card: Card = {
 
 	suffix: "Legend",
 
-	attacks: [{
-		name: {
-			fr: "",
-			de: "Plötzliche Tilgung"
+	attacks: [
+		{
+			name: {
+				fr: "Disparition soudaine",
+				de: "Plötzliche Tilgung",
+			},
+			effect: {
+				fr: "Vous ne pouvez placer cette carte sur votre Banc que si vous placez en même temps l’autre moitié de Palkia & Dialga LÉGENDE.",
+				de: "Wähle 1 Pokémon auf der Bank deines Gegners. Dein Gegner nimmt das gewählte Pokémon und alle an es angelegten Karten auf seine Hand zurück.",
+			},
+			cost: [
+				"Water",
+				"Colorless",
+				"Colorless",
+			],
 		},
-
-		effect: {
-			fr: "Vous ne pouvez placer cette carte sur votre Banc que si vous placez en même temps l’autre moitié de Palkia & Dialga LÉGENDE.",
-			de: "Wähle 1 Pokémon auf der Bank deines Gegners. Dein Gegner nimmt das gewählte Pokémon und alle an es angelegten Karten auf seine Hand zurück."
+		{
+			name: {
+				de: "Zeitherrschaft",
+				fr: "Contrôle temporel",
+			},
+			effect: {
+				de: "Lege alle -Energien, die an Palkia- und Dialga-LEGENDE angelegt sind, auf deinen Ablagestapel. Füge die obersten 2 Karten vom Deck deines Gegner seinen Preiskarten hinzu.",
+				fr: "Défaussez toutes les cartes Énergie Métal attachées à Palkia & Dialga LÉGENDE. Ajoutez les 2 cartes du dessus du deck de votre adversaire à ses cartes Récompense.",
+			},
+			cost: [
+				"Metal",
+				"Metal",
+				"Colorless",
+			],
 		},
-
-		cost: ["Water", "Colorless", "Colorless"]
-	}, {
-		name: {
-			de: "Zeitherrschaft"
-		},
-
-		effect: {
-			de: "Lege alle -Energien, die an Palkia- und Dialga-LEGENDE angelegt sind, auf deinen Ablagestapel. Füge die obersten 2 Karten vom Deck deines Gegner seinen Preiskarten hinzu."
-		},
-
-		cost: ["Metal", "Metal", "Colorless"]
-	}],
+	],
 
 	stage: "Basic",
 	retreat: 0,

--- a/data/HeartGold & SoulSilver/Triumphant/102.ts
+++ b/data/HeartGold & SoulSilver/Triumphant/102.ts
@@ -13,7 +13,17 @@ const card: Card = {
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [484, 483],
+	dexId: [
+
+
+		484,
+
+
+		483,
+
+
+	],
+
 	types: [
 		"Water",
 		"Metal",

--- a/data/HeartGold & SoulSilver/Triumphant/99.ts
+++ b/data/HeartGold & SoulSilver/Triumphant/99.ts
@@ -23,30 +23,38 @@ const card: Card = {
 
 	suffix: "Legend",
 
-	attacks: [{
-		name: {
-			fr: "",
-			de: "Nirgendwo-Krise"
+	attacks: [
+		{
+			name: {
+				fr: "Crise perdue",
+				de: "Nirgendwo-Krise",
+			},
+			effect: {
+				fr: "Placez cette carte sur votre Banc uniquement avec l’autre moitié de Darkrai & Cresselia LÉGENDE.",
+				de: "Wähle 2 an Darkrai- & Cresselia-LEGENDE angelegte Energiekarten und lege sie ins Nirgendwo. Wenn ein Pokémon deines Gegners durch diesen Angriff kampfunfähig würde, lege dieses Pokémon und alle daran angelegten Karten nicht auf den Ablagestapel, sondern ins Nirgendwo.",
+			},
+			damage: 100,
+			cost: [
+				"Darkness",
+				"Darkness",
+				"Colorless",
+				"Colorless",
+			],
 		},
-
-		effect: {
-			fr: "Placez cette carte sur votre Banc uniquement avec l’autre moitié de Darkrai & Cresselia LÉGENDE.",
-			de: "Wähle 2 an Darkrai- & Cresselia-LEGENDE angelegte Energiekarten und lege sie ins Nirgendwo. Wenn ein Pokémon deines Gegners durch diesen Angriff kampfunfähig würde, lege dieses Pokémon und alle daran angelegten Karten nicht auf den Ablagestapel, sondern ins Nirgendwo."
+		{
+			name: {
+				de: "Mondeinladung",
+				fr: "Invitation lunaire",
+			},
+			effect: {
+				de: "Verschiebe beliebig viele Schadensmarken von Pokémon deines Gegners in beliebiger Verteilung auf andere gegnerische Pokémon.",
+				fr: "Retirez autant de marqueurs de dégât que vous le voulez aux Pokémon de votre adversaire et attribuez-les comme bon vous semble aux autres Pokémon de votre adversaire.",
+			},
+			cost: [
+				"Psychic",
+			],
 		},
-
-		damage: 100,
-		cost: ["Darkness", "Darkness", "Colorless", "Colorless"]
-	}, {
-		name: {
-			de: "Mondeinladung"
-		},
-
-		effect: {
-			de: "Verschiebe beliebig viele Schadensmarken von Pokémon deines Gegners in beliebiger Verteilung auf andere gegnerische Pokémon."
-		},
-
-		cost: ["Psychic"]
-	}],
+	],
 
 	stage: "Basic",
 	retreat: 0,


### PR DESCRIPTION
Set: **Triumphant**
Series folder: `HeartGold & SoulSilver`
Changed card files: **4**

### Validation
- [ ] `bun run validate`
- [ ] `cd server && bun run --bun validate`
- [ ] `cd server && bun run compile`
- [ ] Manual review: translations, energy types, TS syntax

### Card images
See follow-up comments with embedded TCGdex assets.