### PR TITLE
fix(data): Collection McDonald's 2013 (FR) (McDonald's Collection)

### DIFF
--- a/data/McDonald's Collection/Collection McDonald's 2013 (FR).ts
+++ b/data/McDonald's Collection/Collection McDonald's 2013 (FR).ts
@@ -1,0 +1,22 @@
+import { Set } from '../../interfaces'
+import serie from '../McDonald\'s Collection'
+
+const s2013bw: Set = {
+	id: "2013bw",
+
+	name: {
+		// French-only product; English name matches folder for compiler resolution.
+		en: "Collection McDonald's 2013 (FR)",
+		fr: "Collection McDonald's 2013",
+	},
+
+	serie: serie,
+
+	cardCount: {
+		official: 12
+	},
+
+	releaseDate: "2013-11-01"
+}
+
+export default s2013bw

--- a/data/McDonald's Collection/Collection McDonald's 2013 (FR)/1.ts
+++ b/data/McDonald's Collection/Collection McDonald's 2013 (FR)/1.ts
@@ -1,0 +1,48 @@
+import { Card } from '../../../interfaces'
+import Set from "../Collection McDonald's 2013 (FR)"
+
+const card: Card = {
+	name: {
+		fr: "Évoli",
+	},
+	illustrator: "Kagemaru Himeno",
+	rarity: "None",
+	category: "Pokemon",
+
+	set: Set,
+	dexId: [133],
+	hp: 50,
+	types: ["Colorless"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			cost: ["Colorless"],
+			name: {
+				fr: "Mimi-Queue",
+			},
+			effect: {
+				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur ne peut pas attaquer pendant le prochain tour de votre adversaire.",
+			},
+		},
+		{
+			cost: ["Colorless"],
+			name: {
+				fr: "Morsure",
+			},
+			damage: 10,
+		},
+	],
+	weaknesses: [
+		{
+			type: "Fighting",
+			value: "x2"
+		},
+	],
+
+	retreat: 1,
+}
+
+export default card
+

--- a/data/McDonald's Collection/Collection McDonald's 2013 (FR)/10.ts
+++ b/data/McDonald's Collection/Collection McDonald's 2013 (FR)/10.ts
@@ -1,0 +1,51 @@
+import { Card } from '../../../interfaces'
+import Set from "../Collection McDonald's 2013 (FR)"
+
+const card: Card = {
+	name: {
+		fr: "Pikachu",
+	},
+	illustrator: "5ban Graphics",
+	rarity: "None",
+	category: "Pokemon",
+
+	set: Set,
+	dexId: [25],
+	hp: 60,
+	types: ["Lightning"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			cost: ["Colorless"],
+			name: {
+				fr: "Groz'Yeux",
+			},
+			effect: {
+				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Paralysé.",
+			},
+		},
+		{
+			cost: ["Lightning", "Colorless"],
+			name: {
+				fr: "Électacle",
+			},
+			effect: {
+				fr: "Ce Pokémon s'inflige 10 dégâts.",
+			},
+			damage: 30,
+		},
+	],
+	weaknesses: [
+		{
+			type: "Fighting",
+			value: "x2"
+		},
+	],
+
+	retreat: 1,
+}
+
+export default card
+

--- a/data/McDonald's Collection/Collection McDonald's 2013 (FR)/11.ts
+++ b/data/McDonald's Collection/Collection McDonald's 2013 (FR)/11.ts
@@ -1,0 +1,49 @@
+import { Card } from '../../../interfaces'
+import Set from "../Collection McDonald's 2013 (FR)"
+
+const card: Card = {
+	name: {
+		fr: "Mewtwo",
+	},
+	illustrator: "5ban Graphics",
+	rarity: "None",
+	category: "Pokemon",
+
+	set: Set,
+	dexId: [150],
+	hp: 120,
+	types: ["Psychic"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			cost: ["Psychic", "Colorless"],
+			name: {
+				fr: "Choc Mental",
+			},
+			effect: {
+				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Paralysé.",
+			},
+			damage: 30,
+		},
+		{
+			cost: ["Psychic", "Psychic", "Colorless"],
+			name: {
+				fr: "Ball'Ombre",
+			},
+			damage: 80,
+		},
+	],
+	weaknesses: [
+		{
+			type: "Psychic",
+			value: "x2"
+		},
+	],
+
+	retreat: 2,
+}
+
+export default card
+

--- a/data/McDonald's Collection/Collection McDonald's 2013 (FR)/12.ts
+++ b/data/McDonald's Collection/Collection McDonald's 2013 (FR)/12.ts
@@ -1,0 +1,49 @@
+import { Card } from '../../../interfaces'
+import Set from "../Collection McDonald's 2013 (FR)"
+
+const card: Card = {
+	name: {
+		fr: "Genesect",
+	},
+	illustrator: "5ban Graphics",
+	rarity: "None",
+	category: "Pokemon",
+
+	set: Set,
+	dexId: [649],
+	hp: 110,
+	types: ["Grass"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			cost: ["Grass"],
+			name: {
+				fr: "Tranche",
+			},
+			damage: 20,
+		},
+		{
+			cost: ["Grass", "Grass", "Colorless"],
+			name: {
+				fr: "Techno Buster",
+			},
+			effect: {
+				fr: "Défaussez une Énergie attachée à ce Pokémon.",
+			},
+			damage: 80,
+		},
+	],
+	weaknesses: [
+		{
+			type: "Fire",
+			value: "x2"
+		},
+	],
+
+	retreat: 1,
+}
+
+export default card
+

--- a/data/McDonald's Collection/Collection McDonald's 2013 (FR)/2.ts
+++ b/data/McDonald's Collection/Collection McDonald's 2013 (FR)/2.ts
@@ -1,0 +1,49 @@
+import { Card } from '../../../interfaces'
+import Set from "../Collection McDonald's 2013 (FR)"
+
+const card: Card = {
+	name: {
+		fr: "Aquali",
+	},
+	illustrator: "Kouki Saitou",
+	rarity: "None",
+	category: "Pokemon",
+
+	set: Set,
+	dexId: [134],
+	hp: 100,
+	types: ["Water"],
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			cost: ["Water"],
+			name: {
+				fr: "Pistolet à O",
+			},
+			damage: 20,
+		},
+		{
+			cost: ["Water", "Colorless", "Colorless"],
+			name: {
+				fr: "Aqua-Jet",
+			},
+			effect: {
+				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 40 dégâts supplémentaires.",
+			},
+			damage: "40+",
+		},
+	],
+	weaknesses: [
+		{
+			type: "Grass",
+			value: "x2"
+		},
+	],
+
+	retreat: 2,
+}
+
+export default card
+

--- a/data/McDonald's Collection/Collection McDonald's 2013 (FR)/3.ts
+++ b/data/McDonald's Collection/Collection McDonald's 2013 (FR)/3.ts
@@ -1,0 +1,52 @@
+import { Card } from '../../../interfaces'
+import Set from "../Collection McDonald's 2013 (FR)"
+
+const card: Card = {
+	name: {
+		fr: "Voltali",
+	},
+	illustrator: "Kouki Saitou",
+	rarity: "None",
+	category: "Pokemon",
+
+	set: Set,
+	dexId: [135],
+	hp: 80,
+	types: ["Lightning"],
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			cost: ["Lightning"],
+			name: {
+				fr: "Coup d'Jus",
+			},
+			effect: {
+				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Paralysé.",
+			},
+			damage: 20,
+		},
+		{
+			cost: ["Colorless", "Colorless"],
+			name: {
+				fr: "Crocs Éclair",
+			},
+			effect: {
+				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 30 dégâts supplémentaires.",
+			},
+			damage: "30+",
+		},
+	],
+	weaknesses: [
+		{
+			type: "Fighting",
+			value: "x2"
+		},
+	],
+
+	retreat: 0,
+}
+
+export default card
+

--- a/data/McDonald's Collection/Collection McDonald's 2013 (FR)/4.ts
+++ b/data/McDonald's Collection/Collection McDonald's 2013 (FR)/4.ts
@@ -1,0 +1,66 @@
+import { Card } from '../../../interfaces'
+import Set from "../Collection McDonald's 2013 (FR)"
+
+const card: Card = {
+	name: {
+		fr: "Givrali",
+	},
+	illustrator: "Rya Ueda",
+	rarity: "None",
+	category: "Pokemon",
+
+	set: Set,
+	dexId: [
+		471,
+	],
+	hp: 90,
+	types: [
+		"Water",
+	],
+
+	stage: "Stage1",
+
+
+	attacks: [
+		{
+			cost: [
+				"Colorless",
+			],
+			name: {
+				fr: "Vive-Attaque",
+			},
+			effect: {
+				fr: "Lancez une pièce. Si c'est face, cetter attaque inflige 30 dégâts supplémentaires.",
+			},
+			damage: "10+",
+
+		},
+		{
+			cost: [
+				"Water",
+				"Colorless",
+			],
+			name: {
+				fr: "ranvoi d'Énergie",
+			},
+			effect: {
+				fr: "Déplacez une Énergie de ce Pokémon vers 1 de vos Pokémon de Banc.",
+			},
+			damage: 40,
+
+		},
+	],
+	weaknesses: [
+		{
+			type: "Metal",
+			value: "x2"
+		},
+	],
+
+	retreat: 1,
+
+
+
+}
+
+export default card

--- a/data/McDonald's Collection/Collection McDonald's 2013 (FR)/5.ts
+++ b/data/McDonald's Collection/Collection McDonald's 2013 (FR)/5.ts
@@ -1,0 +1,49 @@
+import { Card } from '../../../interfaces'
+import Set from "../Collection McDonald's 2013 (FR)"
+
+const card: Card = {
+	name: {
+		fr: "Mentali",
+	},
+	illustrator: "Kouki Saitou",
+	rarity: "None",
+	category: "Pokemon",
+
+	set: Set,
+	dexId: [196],
+	hp: 90,
+	types: ["Psychic"],
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			cost: ["Psychic"],
+			name: {
+				fr: "Psykoud'Boul",
+			},
+			damage: 20,
+		},
+		{
+			cost: ["Psychic", "Colorless"],
+			name: {
+				fr: "Rayon Psy",
+			},
+			effect: {
+				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Confus.",
+			},
+			damage: 40,
+		},
+	],
+	weaknesses: [
+		{
+			type: "Psychic",
+			value: "x2"
+		},
+	],
+
+	retreat: 1,
+}
+
+export default card
+

--- a/data/McDonald's Collection/Collection McDonald's 2013 (FR)/6.ts
+++ b/data/McDonald's Collection/Collection McDonald's 2013 (FR)/6.ts
@@ -1,0 +1,55 @@
+import { Card } from '../../../interfaces'
+import Set from "../Collection McDonald's 2013 (FR)"
+
+const card: Card = {
+	name: {
+		fr: "Noctali",
+	},
+	illustrator: "Kouki Saitou",
+	rarity: "None",
+	category: "Pokemon",
+
+	set: Set,
+	dexId: [197],
+	hp: 90,
+	types: ["Darkness"],
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			cost: ["Darkness"],
+			name: {
+				fr: "Morsure",
+			},
+			damage: 20,
+		},
+		{
+			cost: ["Darkness", "Colorless"],
+			name: {
+				fr: "Assaut Ténébreux",
+			},
+			effect: {
+				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 30 dégâts supplémentaires.",
+			},
+			damage: "30+",
+		},
+	],
+	weaknesses: [
+		{
+			type: "Fighting",
+			value: "x2"
+		},
+	],
+	resistances: [
+		{
+			type: "Psychic",
+			value: "-20"
+		},
+	],
+
+	retreat: 1,
+}
+
+export default card
+

--- a/data/McDonald's Collection/Collection McDonald's 2013 (FR)/7.ts
+++ b/data/McDonald's Collection/Collection McDonald's 2013 (FR)/7.ts
@@ -1,0 +1,55 @@
+import { Card } from '../../../interfaces'
+import Set from "../Collection McDonald's 2013 (FR)"
+
+const card: Card = {
+	name: {
+		fr: "Phyllali",
+	},
+	illustrator: "Masakazu Fukuda",
+	rarity: "None",
+	category: "Pokemon",
+
+	set: Set,
+	dexId: [470],
+	hp: 90,
+	types: ["Grass"],
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			cost: ["Colorless"],
+			name: {
+				fr: "Vive-Attaque",
+			},
+			effect: {
+				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 30 dégâts supplémentaires.",
+			},
+			damage: "10+",
+		},
+		{
+			cost: ["Grass", "Colorless"],
+			name: {
+				fr: "Lame-Feuille",
+			},
+			damage: 40,
+		},
+	],
+	weaknesses: [
+		{
+			type: "Fire",
+			value: "x2"
+		},
+	],
+	resistances: [
+		{
+			type: "Water",
+			value: "-20"
+		},
+	],
+
+	retreat: 1,
+}
+
+export default card
+

--- a/data/McDonald's Collection/Collection McDonald's 2013 (FR)/8.ts
+++ b/data/McDonald's Collection/Collection McDonald's 2013 (FR)/8.ts
@@ -1,0 +1,49 @@
+import { Card } from '../../../interfaces'
+import Set from "../Collection McDonald's 2013 (FR)"
+
+const card: Card = {
+	name: {
+		fr: "Pyroli",
+	},
+	illustrator: "Kouki Saitou",
+	rarity: "None",
+	category: "Pokemon",
+
+	set: Set,
+	dexId: [136],
+	hp: 90,
+	types: ["Fire"],
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			cost: ["Fire"],
+			name: {
+				fr: "Flammèche",
+			},
+			damage: 20,
+		},
+		{
+			cost: ["Fire", "Colorless", "Colorless"],
+			name: {
+				fr: "Déflagration",
+			},
+			effect: {
+				fr: "Défaussez une Énergie attachée à ce Pokémon.",
+			},
+			damage: 80,
+		},
+	],
+	weaknesses: [
+		{
+			type: "Water",
+			value: "x2"
+		},
+	],
+
+	retreat: 2,
+}
+
+export default card
+

--- a/data/McDonald's Collection/Collection McDonald's 2013 (FR)/9.ts
+++ b/data/McDonald's Collection/Collection McDonald's 2013 (FR)/9.ts
@@ -1,0 +1,58 @@
+import { Card } from '../../../interfaces'
+import Set from "../Collection McDonald's 2013 (FR)"
+
+const card: Card = {
+	name: {
+		fr: "Nymphali",
+	},
+	illustrator: "5ban Graphics",
+	rarity: "None",
+	category: "Pokemon",
+
+	set: Set,
+	dexId: [700],
+	hp: 90,
+	types: ["Fairy"],
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			cost: ["Fairy"],
+			name: {
+				fr: "Regard Touchant",
+			},
+			effect: {
+				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Paralysé.",
+			},
+			damage: 20,
+		},
+		{
+			cost: ["Fairy", "Colorless", "Colorless"],
+			name: {
+				fr: "Vent Féérique",
+			},
+			effect: {
+				fr: "Déplacez une Énergie du Pokémon Défenseur vers 1 des Pokémon de Banc de votre adversaire.",
+			},
+			damage: 60,
+		},
+	],
+	weaknesses: [
+		{
+			type: "Metal",
+			value: "x2"
+		},
+	],
+	resistances: [
+		{
+			type: "Darkness",
+			value: "-20"
+		},
+	],
+
+	retreat: 1,
+}
+
+export default card
+


### PR DESCRIPTION
Set: **Collection McDonald's 2013 (FR)**
Series folder: `McDonald's Collection`
Changed card files: **12**

### Validation
- [ ] `bun run validate`
- [ ] `cd server && bun run --bun validate`
- [ ] `cd server && bun run compile`
- [ ] Manual review: translations, energy types, TS syntax

### Card images
See follow-up comments with embedded TCGdex assets.