### PR TITLE
fix(data): Collection McDonald's 2018 (FR) (McDonald's Collection)

### DIFF
--- a/data/McDonald's Collection/Collection McDonald's 2018 (FR).ts
+++ b/data/McDonald's Collection/Collection McDonald's 2018 (FR).ts
@@ -1,0 +1,26 @@
+import { Set } from '../../interfaces'
+import serie from '../McDonald\'s Collection'
+
+const set: Set = {
+	id: "2018sm-fr",
+
+	name: {
+		// French-only product; English name matches folder for compiler resolution.
+		en: "Collection McDonald's 2018 (FR)",
+		fr: "Collection McDonald's 2018"
+	},
+
+	serie: serie,
+
+	cardCount: {
+		official: 40
+	},
+
+	releaseDate: "2018-06-13",
+
+	thirdParty: {
+		cardmarket: 2361
+	}
+}
+
+export default set

--- a/data/McDonald's Collection/Collection McDonald's 2018 (FR)/1.ts
+++ b/data/McDonald's Collection/Collection McDonald's 2018 (FR)/1.ts
@@ -1,0 +1,37 @@
+import { Card } from '../../../interfaces'
+import Set from "../Collection McDonald's 2018 (FR)"
+
+const card: Card = {
+	name: {
+		fr: "Bulbizarre",
+	},
+	rarity: "None",
+	category: "Pokemon",
+
+	set: Set,
+	dexId: [1],
+	hp: 60,
+	types: ["Grass"],
+
+	stage: "Basic",
+
+	variants: {
+		normal: false,
+		reverse: false,
+		holo: true,
+		firstEdition: false
+	},
+	attacks: [
+		{
+			cost: [
+				"Grass",
+			],
+			name: {
+				fr: "Fouet Lianes",
+			},
+			damage: "10",
+		},
+	],
+}
+
+export default card

--- a/data/McDonald's Collection/Collection McDonald's 2018 (FR)/10.ts
+++ b/data/McDonald's Collection/Collection McDonald's 2018 (FR)/10.ts
@@ -1,0 +1,39 @@
+import { Card } from '../../../interfaces'
+import Set from "../Collection McDonald's 2018 (FR)"
+
+const card: Card = {
+	name: {
+		fr: "Pikachu",
+	},
+	rarity: "None",
+	category: "Pokemon",
+
+	set: Set,
+	dexId: [25],
+	hp: 60,
+	types: ["Lightning"],
+
+	stage: "Basic",
+
+	variants: {
+		normal: false,
+		reverse: false,
+		holo: true,
+		firstEdition: false
+	},
+	attacks: [
+		{
+			cost: [
+				"Colorless",
+			],
+			name: {
+				fr: "Vague de Confusion",
+			},
+			effect: {
+				fr: "Les deux Pokémon Actifs sont maintenant Confus.",
+			},
+		},
+	],
+}
+
+export default card

--- a/data/McDonald's Collection/Collection McDonald's 2018 (FR)/11.ts
+++ b/data/McDonald's Collection/Collection McDonald's 2018 (FR)/11.ts
@@ -1,0 +1,51 @@
+import { Card } from '../../../interfaces'
+import Set from "../Collection McDonald's 2018 (FR)"
+
+const card: Card = {
+	name: {
+		fr: "Raichu",
+	},
+	rarity: "None",
+	category: "Pokemon",
+
+	set: Set,
+	dexId: [26],
+	hp: 100,
+	types: ["Lightning"],
+
+	stage: "Stage1",
+
+	variants: {
+		normal: false,
+		reverse: false,
+		holo: true,
+		firstEdition: false
+	},
+	attacks: [
+		{
+			cost: [
+				"Water",
+			],
+			name: {
+				fr: "Pistolet à O",
+			},
+			damage: "10",
+		},
+		{
+			cost: [
+				"Colorless",
+				"Colorless",
+				"Colorless",
+			],
+			name: {
+				fr: "Hydrocanon",
+			},
+			damage: "30+",
+			effect: {
+				fr: "Cette attaque inflige 10 dégâts supplémentaires multipliés par le nombre d'Énergies Eau attachées à ce Pokémon.",
+			},
+		},
+	],
+}
+
+export default card

--- a/data/McDonald's Collection/Collection McDonald's 2018 (FR)/12.ts
+++ b/data/McDonald's Collection/Collection McDonald's 2018 (FR)/12.ts
@@ -1,0 +1,51 @@
+import { Card } from '../../../interfaces'
+import Set from "../Collection McDonald's 2018 (FR)"
+
+const card: Card = {
+	name: {
+		fr: "Mélofée",
+	},
+	rarity: "None",
+	category: "Pokemon",
+
+	set: Set,
+	dexId: [35],
+	hp: 60,
+	types: ["Fairy"],
+
+	stage: "Basic",
+
+	variants: {
+		normal: false,
+		reverse: false,
+		holo: true,
+		firstEdition: false
+	},
+	attacks: [
+		{
+			cost: [
+				"Colorless",
+			],
+			name: {
+				fr: "Nombreux Cadeaux",
+			},
+			effect: {
+				fr: "Lancez une pièce jusqu'à ce que vous obteniez un côté pile. Pour chaque côté face, vous pouvez chercher une carte dans votre deck puis l'ajouter à votre main. Mélangez ensuite votre deck.",
+			},
+		},
+		{
+			cost: [
+				"Water",
+			],
+			name: {
+				fr: "Attaque Surprise",
+			},
+			damage: "40",
+			effect: {
+				fr: "Lancez une pièce. Si c'est pile, cette attaque ne fait rien.",
+			},
+		},
+	],
+}
+
+export default card

--- a/data/McDonald's Collection/Collection McDonald's 2018 (FR)/13.ts
+++ b/data/McDonald's Collection/Collection McDonald's 2018 (FR)/13.ts
@@ -1,0 +1,39 @@
+import { Card } from '../../../interfaces'
+import Set from "../Collection McDonald's 2018 (FR)"
+
+const card: Card = {
+	name: {
+		fr: "Mélodelfe",
+	},
+	rarity: "None",
+	category: "Pokemon",
+
+	set: Set,
+	dexId: [36],
+	hp: 100,
+	types: ["Fairy"],
+
+	stage: "Stage1",
+
+	variants: {
+		normal: false,
+		reverse: false,
+		holo: true,
+		firstEdition: false
+	},
+	attacks: [
+		{
+			cost: [
+				"Colorless",
+			],
+			name: {
+				fr: "Atterrissage",
+			},
+			effect: {
+				fr: "Soignez 30 dégâts à ce Pokémon. Il ne peut pas battre en retraite pendant votre prochain tour.",
+			},
+		},
+	],
+}
+
+export default card

--- a/data/McDonald's Collection/Collection McDonald's 2018 (FR)/14.ts
+++ b/data/McDonald's Collection/Collection McDonald's 2018 (FR)/14.ts
@@ -1,0 +1,50 @@
+import { Card } from '../../../interfaces'
+import Set from "../Collection McDonald's 2018 (FR)"
+
+const card: Card = {
+	name: {
+		fr: "Goupix",
+	},
+	rarity: "None",
+	category: "Pokemon",
+
+	set: Set,
+	dexId: [37],
+	hp: 60,
+	types: ["Fire"],
+
+	stage: "Basic",
+
+	variants: {
+		normal: false,
+		reverse: false,
+		holo: true,
+		firstEdition: false
+	},
+	attacks: [
+		{
+			cost: [
+				"Water",
+				"Colorless",
+			],
+			name: {
+				fr: "Trempette",
+			},
+			damage: "20",
+		},
+		{
+			cost: [
+				"Water",
+				"Water",
+				"Water",
+				"Colorless",
+			],
+			name: {
+				fr: "Surf",
+			},
+			damage: "70",
+		},
+	],
+}
+
+export default card

--- a/data/McDonald's Collection/Collection McDonald's 2018 (FR)/15.ts
+++ b/data/McDonald's Collection/Collection McDonald's 2018 (FR)/15.ts
@@ -1,0 +1,37 @@
+import { Card } from '../../../interfaces'
+import Set from "../Collection McDonald's 2018 (FR)"
+
+const card: Card = {
+	name: {
+		fr: "Feunard",
+	},
+	rarity: "None",
+	category: "Pokemon",
+
+	set: Set,
+	dexId: [38],
+	hp: 100,
+	types: ["Fire"],
+
+	stage: "Stage1",
+
+	variants: {
+		normal: false,
+		reverse: false,
+		holo: true,
+		firstEdition: false
+	},
+	attacks: [
+		{
+			cost: [
+				"Water",
+			],
+			name: {
+				fr: "Pistolet à O",
+			},
+			damage: "10",
+		},
+	],
+}
+
+export default card

--- a/data/McDonald's Collection/Collection McDonald's 2018 (FR)/16.ts
+++ b/data/McDonald's Collection/Collection McDonald's 2018 (FR)/16.ts
@@ -1,0 +1,51 @@
+import { Card } from '../../../interfaces'
+import Set from "../Collection McDonald's 2018 (FR)"
+
+const card: Card = {
+	name: {
+		fr: "Rondoudou",
+	},
+	rarity: "None",
+	category: "Pokemon",
+
+	set: Set,
+	dexId: [39],
+	hp: 60,
+	types: ["Fairy"],
+
+	stage: "Basic",
+
+	variants: {
+		normal: false,
+		reverse: false,
+		holo: true,
+		firstEdition: false
+	},
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				fr: "Banc",
+			},
+			effect: {
+				fr: "Une seule fois pendant votre tour (avant votre attaque), vous pouvez échanger ce Pokémon avec un Froussardine-GX dans votre main. Les cartes attachées, les marqueurs de dégâts, les États Spéciaux, le nombre de tours de jeu, et tous les autres effets restent sur le nouveau Pokémon.",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			cost: [
+				"Water",
+			],
+			name: {
+				fr: "Tir de Précision",
+			},
+			effect: {
+				fr: "Cette attaque inflige 10 dégâts à l'un des Pokémon de votre adversaire. (N'appliquez ni la Faiblesse ni la Résistance aux Pokémon de Banc.)",
+			},
+		},
+	],
+}
+
+export default card

--- a/data/McDonald's Collection/Collection McDonald's 2018 (FR)/17.ts
+++ b/data/McDonald's Collection/Collection McDonald's 2018 (FR)/17.ts
@@ -1,0 +1,50 @@
+import { Card } from '../../../interfaces'
+import Set from "../Collection McDonald's 2018 (FR)"
+
+const card: Card = {
+	name: {
+		fr: "Grodoudou",
+	},
+	rarity: "None",
+	category: "Pokemon",
+
+	set: Set,
+	dexId: [40],
+	hp: 100,
+	types: ["Fairy"],
+
+	stage: "Stage1",
+
+	variants: {
+		normal: false,
+		reverse: false,
+		holo: true,
+		firstEdition: false
+	},
+	attacks: [
+		{
+			cost: [
+				"Colorless",
+			],
+			name: {
+				fr: "Queue Battoir",
+			},
+			damage: "10",
+		},
+		{
+			cost: [
+				"Lightning",
+				"Colorless",
+			],
+			name: {
+				fr: "Éclair",
+			},
+			damage: "20",
+			effect: {
+				fr: "Lancez une pièce. Si c'est face, le Pokémon Actif de votre adversaire est maintenant Paralysé.",
+			},
+		},
+	],
+}
+
+export default card

--- a/data/McDonald's Collection/Collection McDonald's 2018 (FR)/18.ts
+++ b/data/McDonald's Collection/Collection McDonald's 2018 (FR)/18.ts
@@ -1,0 +1,48 @@
+import { Card } from '../../../interfaces'
+import Set from "../Collection McDonald's 2018 (FR)"
+
+const card: Card = {
+	name: {
+		fr: "Miaouss",
+	},
+	rarity: "None",
+	category: "Pokemon",
+
+	set: Set,
+	dexId: [52],
+	hp: 60,
+	types: ["Colorless"],
+
+	stage: "Basic",
+
+	variants: {
+		normal: false,
+		reverse: false,
+		holo: true,
+		firstEdition: false
+	},
+	attacks: [
+		{
+			cost: [],
+			name: {
+				fr: "Poliroche",
+			},
+			effect: {
+				fr: "Pendant votre prochain tour, ce Pokémon n'a pas de Coût de Retraite.",
+			},
+		},
+		{
+			cost: [
+				"Lightning",
+				"Colorless",
+				"Colorless",
+			],
+			name: {
+				fr: "Roulade",
+			},
+			damage: "40",
+		},
+	],
+}
+
+export default card

--- a/data/McDonald's Collection/Collection McDonald's 2018 (FR)/19.ts
+++ b/data/McDonald's Collection/Collection McDonald's 2018 (FR)/19.ts
@@ -1,0 +1,50 @@
+import { Card } from '../../../interfaces'
+import Set from "../Collection McDonald's 2018 (FR)"
+
+const card: Card = {
+	name: {
+		fr: "Persian",
+	},
+	rarity: "None",
+	category: "Pokemon",
+
+	set: Set,
+	dexId: [53],
+	hp: 90,
+	types: ["Colorless"],
+
+	stage: "Stage1",
+
+	variants: {
+		normal: false,
+		reverse: false,
+		holo: true,
+		firstEdition: false
+	},
+	attacks: [
+		{
+			cost: [
+				"Colorless",
+			],
+			name: {
+				fr: "Sonde Lumineuse",
+			},
+			effect: {
+				fr: "Regardez l'une de vos cartes Récompense (actuellement face cachée).",
+			},
+		},
+		{
+			cost: [
+				"Lightning",
+				"Colorless",
+				"Colorless",
+			],
+			name: {
+				fr: "Boule Élek",
+			},
+			damage: "30",
+		},
+	],
+}
+
+export default card

--- a/data/McDonald's Collection/Collection McDonald's 2018 (FR)/2.ts
+++ b/data/McDonald's Collection/Collection McDonald's 2018 (FR)/2.ts
@@ -1,0 +1,48 @@
+import { Card } from '../../../interfaces'
+import Set from "../Collection McDonald's 2018 (FR)"
+
+const card: Card = {
+	name: {
+		fr: "Herbizarre",
+	},
+	rarity: "None",
+	category: "Pokemon",
+
+	set: Set,
+	dexId: [2],
+	hp: 80,
+	types: ["Grass"],
+
+	stage: "Stage1",
+
+	variants: {
+		normal: false,
+		reverse: false,
+		holo: true,
+		firstEdition: false
+	},
+	attacks: [
+		{
+			cost: [
+				"Grass",
+			],
+			name: {
+				fr: "Doux Parfum",
+			},
+			effect: {
+				fr: "Soignez 30 dégâts à l'un de vos Pokémon.",
+			},
+		},
+		{
+			cost: [
+				"Colorless",
+			],
+			name: {
+				fr: "Trempette",
+			},
+			damage: "10",
+		},
+	],
+}
+
+export default card

--- a/data/McDonald's Collection/Collection McDonald's 2018 (FR)/20.ts
+++ b/data/McDonald's Collection/Collection McDonald's 2018 (FR)/20.ts
@@ -1,0 +1,50 @@
+import { Card } from '../../../interfaces'
+import Set from "../Collection McDonald's 2018 (FR)"
+
+const card: Card = {
+	name: {
+		fr: "Psykokwak",
+	},
+	rarity: "None",
+	category: "Pokemon",
+
+	set: Set,
+	dexId: [54],
+	hp: 70,
+	types: ["Water"],
+
+	stage: "Basic",
+
+	variants: {
+		normal: false,
+		reverse: false,
+		holo: true,
+		firstEdition: false
+	},
+	attacks: [
+		{
+			cost: [
+				"Lightning",
+			],
+			name: {
+				fr: "Roulade",
+			},
+			damage: "20",
+		},
+		{
+			cost: [
+				"Lightning",
+				"Colorless",
+			],
+			name: {
+				fr: "Électro Impact",
+			},
+			damage: "40+",
+			effect: {
+				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 20 dégâts supplémentaires.",
+			},
+		},
+	],
+}
+
+export default card

--- a/data/McDonald's Collection/Collection McDonald's 2018 (FR)/21.ts
+++ b/data/McDonald's Collection/Collection McDonald's 2018 (FR)/21.ts
@@ -1,0 +1,51 @@
+import { Card } from '../../../interfaces'
+import Set from "../Collection McDonald's 2018 (FR)"
+
+const card: Card = {
+	name: {
+		fr: "Akwakwak",
+	},
+	rarity: "None",
+	category: "Pokemon",
+
+	set: Set,
+	dexId: [55],
+	hp: 100,
+	types: ["Water"],
+
+	stage: "Stage1",
+
+	variants: {
+		normal: false,
+		reverse: false,
+		holo: true,
+		firstEdition: false
+	},
+	attacks: [
+		{
+			cost: [
+				"Colorless",
+			],
+			name: {
+				fr: "Coup d'Boule",
+			},
+			damage: "10",
+		},
+		{
+			cost: [
+				"Psychic",
+				"Colorless",
+				"Colorless",
+			],
+			name: {
+				fr: "Charge Bizarre",
+			},
+			damage: "60",
+			effect: {
+				fr: "Lancez une pièce. Si c'est pile, cette attaque ne fait rien.",
+			},
+		},
+	],
+}
+
+export default card

--- a/data/McDonald's Collection/Collection McDonald's 2018 (FR)/22.ts
+++ b/data/McDonald's Collection/Collection McDonald's 2018 (FR)/22.ts
@@ -1,0 +1,41 @@
+import { Card } from '../../../interfaces'
+import Set from "../Collection McDonald's 2018 (FR)"
+
+const card: Card = {
+	name: {
+		fr: "Caninos",
+	},
+	rarity: "None",
+	category: "Pokemon",
+
+	set: Set,
+	dexId: [58],
+	hp: 80,
+	types: ["Fire"],
+
+	stage: "Basic",
+
+	variants: {
+		normal: false,
+		reverse: false,
+		holo: true,
+		firstEdition: false
+	},
+	attacks: [
+		{
+			cost: [
+				"Fighting",
+				"Fighting",
+			],
+			name: {
+				fr: "Double Baffe",
+			},
+			damage: "30×",
+			effect: {
+				fr: "Lancez 2 pièces. Cette attaque inflige 30 dégâts multipliés par le nombre de côtés face.",
+			},
+		},
+	],
+}
+
+export default card

--- a/data/McDonald's Collection/Collection McDonald's 2018 (FR)/23.ts
+++ b/data/McDonald's Collection/Collection McDonald's 2018 (FR)/23.ts
@@ -1,0 +1,50 @@
+import { Card } from '../../../interfaces'
+import Set from "../Collection McDonald's 2018 (FR)"
+
+const card: Card = {
+	name: {
+		fr: "Arcanin",
+	},
+	rarity: "None",
+	category: "Pokemon",
+
+	set: Set,
+	dexId: [59],
+	hp: 130,
+	types: ["Fire"],
+
+	stage: "Stage1",
+
+	variants: {
+		normal: false,
+		reverse: false,
+		holo: true,
+		firstEdition: false
+	},
+	attacks: [
+		{
+			cost: [
+				"Fighting",
+			],
+			name: {
+				fr: "Attaque Surprise",
+			},
+			damage: "20",
+			effect: {
+				fr: "Lancez une pièce. Si c'est pile, cette attaque ne fait rien.",
+			},
+		},
+		{
+			cost: [
+				"Fighting",
+				"Colorless",
+			],
+			name: {
+				fr: "Force",
+			},
+			damage: "40",
+		},
+	],
+}
+
+export default card

--- a/data/McDonald's Collection/Collection McDonald's 2018 (FR)/24.ts
+++ b/data/McDonald's Collection/Collection McDonald's 2018 (FR)/24.ts
@@ -1,0 +1,47 @@
+import { Card } from '../../../interfaces'
+import Set from "../Collection McDonald's 2018 (FR)"
+
+const card: Card = {
+	name: {
+		fr: "Machoc",
+	},
+	rarity: "None",
+	category: "Pokemon",
+
+	set: Set,
+	dexId: [66],
+	hp: 70,
+	types: ["Fighting"],
+
+	stage: "Basic",
+
+	variants: {
+		normal: false,
+		reverse: false,
+		holo: true,
+		firstEdition: false
+	},
+	attacks: [
+		{
+			cost: [
+				"Fighting",
+			],
+			name: {
+				fr: "Koud'Poing",
+			},
+			damage: "10",
+		},
+		{
+			cost: [
+				"Fighting",
+				"Fighting",
+			],
+			name: {
+				fr: "Balayage",
+			},
+			damage: "30",
+		},
+	],
+}
+
+export default card

--- a/data/McDonald's Collection/Collection McDonald's 2018 (FR)/25.ts
+++ b/data/McDonald's Collection/Collection McDonald's 2018 (FR)/25.ts
@@ -1,0 +1,52 @@
+import { Card } from '../../../interfaces'
+import Set from "../Collection McDonald's 2018 (FR)"
+
+const card: Card = {
+	name: {
+		fr: "Machopeur",
+	},
+	rarity: "None",
+	category: "Pokemon",
+
+	set: Set,
+	dexId: [67],
+	hp: 90,
+	types: ["Fighting"],
+
+	stage: "Stage1",
+
+	variants: {
+		normal: false,
+		reverse: false,
+		holo: true,
+		firstEdition: false
+	},
+	attacks: [
+		{
+			cost: [
+				"Fighting",
+			],
+			name: {
+				fr: "Coinçage",
+			},
+			effect: {
+				fr: "Le Pokémon Défenseur ne peut pas battre en retraite pendant le prochain tour de votre adversaire.",
+			},
+		},
+		{
+			cost: [
+				"Colorless",
+				"Colorless",
+			],
+			name: {
+				fr: "Coup Déchaîné",
+			},
+			damage: "30",
+			effect: {
+				fr: "Lancez une pièce. Si c'est pile, cette attaque ne fait rien.",
+			},
+		},
+	],
+}
+
+export default card

--- a/data/McDonald's Collection/Collection McDonald's 2018 (FR)/26.ts
+++ b/data/McDonald's Collection/Collection McDonald's 2018 (FR)/26.ts
@@ -1,0 +1,41 @@
+import { Card } from '../../../interfaces'
+import Set from "../Collection McDonald's 2018 (FR)"
+
+const card: Card = {
+	name: {
+		fr: "Mackogneur",
+	},
+	rarity: "None",
+	category: "Pokemon",
+
+	set: Set,
+	dexId: [68],
+	hp: 150,
+	types: ["Fighting"],
+
+	stage: "Stage2",
+
+	variants: {
+		normal: false,
+		reverse: false,
+		holo: true,
+		firstEdition: false
+	},
+	attacks: [
+		{
+			cost: [
+				"Fighting",
+				"Fighting",
+			],
+			name: {
+				fr: "Double Pied",
+			},
+			damage: "30×",
+			effect: {
+				fr: "Lancez 2 pièces. Cette attaque inflige 30 dégâts multipliés par le nombre de côtés face.",
+			},
+		},
+	],
+}
+
+export default card

--- a/data/McDonald's Collection/Collection McDonald's 2018 (FR)/27.ts
+++ b/data/McDonald's Collection/Collection McDonald's 2018 (FR)/27.ts
@@ -1,0 +1,40 @@
+import { Card } from '../../../interfaces'
+import Set from "../Collection McDonald's 2018 (FR)"
+
+const card: Card = {
+	name: {
+		fr: "Tadmorv",
+	},
+	rarity: "None",
+	category: "Pokemon",
+
+	set: Set,
+	dexId: [88],
+	hp: 70,
+	types: ["Psychic"],
+
+	stage: "Basic",
+
+	variants: {
+		normal: false,
+		reverse: false,
+		holo: true,
+		firstEdition: false
+	},
+	attacks: [
+		{
+			cost: [
+				"Darkness",
+			],
+			name: {
+				fr: "Cyclone",
+			},
+			damage: "10",
+			effect: {
+				fr: "Votre adversaire échange son Pokémon Actif avec l'un de ses Pokémon de Banc.",
+			},
+		},
+	],
+}
+
+export default card

--- a/data/McDonald's Collection/Collection McDonald's 2018 (FR)/28.ts
+++ b/data/McDonald's Collection/Collection McDonald's 2018 (FR)/28.ts
@@ -1,0 +1,49 @@
+import { Card } from '../../../interfaces'
+import Set from "../Collection McDonald's 2018 (FR)"
+
+const card: Card = {
+	name: {
+		fr: "Grotadmorv",
+	},
+	rarity: "None",
+	category: "Pokemon",
+
+	set: Set,
+	dexId: [89],
+	hp: 120,
+	types: ["Psychic"],
+
+	stage: "Stage1",
+
+	variants: {
+		normal: false,
+		reverse: false,
+		holo: true,
+		firstEdition: false
+	},
+	attacks: [
+		{
+			cost: [
+				"Colorless",
+			],
+			name: {
+				fr: "Aiguisage",
+			},
+			effect: {
+				fr: "Pendant votre prochain tour, les dégâts de base de l'attaque Tranche de ce Pokémon sont de 80.",
+			},
+		},
+		{
+			cost: [
+				"Darkness",
+				"Colorless",
+			],
+			name: {
+				fr: "Tranche",
+			},
+			damage: "20",
+		},
+	],
+}
+
+export default card

--- a/data/McDonald's Collection/Collection McDonald's 2018 (FR)/29.ts
+++ b/data/McDonald's Collection/Collection McDonald's 2018 (FR)/29.ts
@@ -1,0 +1,54 @@
+import { Card } from '../../../interfaces'
+import Set from "../Collection McDonald's 2018 (FR)"
+
+const card: Card = {
+	name: {
+		fr: "Fantominus",
+	},
+	rarity: "None",
+	category: "Pokemon",
+
+	set: Set,
+	dexId: [92],
+	hp: 50,
+	types: ["Psychic"],
+
+	stage: "Basic",
+
+	variants: {
+		normal: false,
+		reverse: false,
+		holo: true,
+		firstEdition: false
+	},
+	attacks: [
+		{
+			cost: [
+				"Colorless",
+				"Colorless",
+			],
+			name: {
+				fr: "Résonance Métallique",
+			},
+			effect: {
+				fr: "Défaussez toute l'Énergie spéciale de chaque Pokémon.",
+			},
+		},
+		{
+			cost: [
+				"Metal",
+				"Colorless",
+				"Colorless",
+			],
+			name: {
+				fr: "Aéropique",
+			},
+			damage: "60+",
+			effect: {
+				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 30 dégâts supplémentaires.",
+			},
+		},
+	],
+}
+
+export default card

--- a/data/McDonald's Collection/Collection McDonald's 2018 (FR)/3.ts
+++ b/data/McDonald's Collection/Collection McDonald's 2018 (FR)/3.ts
@@ -1,0 +1,51 @@
+import { Card } from '../../../interfaces'
+import Set from "../Collection McDonald's 2018 (FR)"
+
+const card: Card = {
+	name: {
+		fr: "Florizarre",
+	},
+	rarity: "None",
+	category: "Pokemon",
+
+	set: Set,
+	dexId: [3],
+	hp: 140,
+	types: ["Grass"],
+
+	stage: "Stage2",
+
+	variants: {
+		normal: false,
+		reverse: false,
+		holo: true,
+		firstEdition: false
+	},
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				fr: "Escampette",
+			},
+			effect: {
+				fr: "Pendant votre premier tour, ce Pokémon n'a pas de Coût de Retraite.",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			cost: [
+				"Grass",
+				"Colorless",
+				"Colorless",
+			],
+			name: {
+				fr: "Ronge",
+			},
+			damage: "30",
+		},
+	],
+}
+
+export default card

--- a/data/McDonald's Collection/Collection McDonald's 2018 (FR)/30.ts
+++ b/data/McDonald's Collection/Collection McDonald's 2018 (FR)/30.ts
@@ -1,0 +1,49 @@
+import { Card } from '../../../interfaces'
+import Set from "../Collection McDonald's 2018 (FR)"
+
+const card: Card = {
+	name: {
+		fr: "Spectrum",
+	},
+	rarity: "None",
+	category: "Pokemon",
+
+	set: Set,
+	dexId: [93],
+	hp: 70,
+	types: ["Psychic"],
+
+	stage: "Stage1",
+
+	variants: {
+		normal: false,
+		reverse: false,
+		holo: true,
+		firstEdition: false
+	},
+	attacks: [
+		{
+			cost: [
+				"Fairy",
+			],
+			name: {
+				fr: "Gifle",
+			},
+			damage: "10",
+		},
+		{
+			cost: [
+				"Colorless",
+				"Colorless",
+			],
+			name: {
+				fr: "Par Ici",
+			},
+			effect: {
+				fr: "Échangez l'un des Pokémon de Banc de votre adversaire avec son Pokémon Actif.",
+			},
+		},
+	],
+}
+
+export default card

--- a/data/McDonald's Collection/Collection McDonald's 2018 (FR)/31.ts
+++ b/data/McDonald's Collection/Collection McDonald's 2018 (FR)/31.ts
@@ -1,0 +1,40 @@
+import { Card } from '../../../interfaces'
+import Set from "../Collection McDonald's 2018 (FR)"
+
+const card: Card = {
+	name: {
+		fr: "Ectoplasma",
+	},
+	rarity: "None",
+	category: "Pokemon",
+
+	set: Set,
+	dexId: [94],
+	hp: 130,
+	types: ["Psychic"],
+
+	stage: "Stage2",
+
+	variants: {
+		normal: false,
+		reverse: false,
+		holo: true,
+		firstEdition: false
+	},
+	attacks: [
+		{
+			cost: [
+				"Fairy",
+			],
+			name: {
+				fr: "Vampibaiser",
+			},
+			damage: "10",
+			effect: {
+				fr: "Soignez 10 dégâts à ce Pokémon.",
+			},
+		},
+	],
+}
+
+export default card

--- a/data/McDonald's Collection/Collection McDonald's 2018 (FR)/32.ts
+++ b/data/McDonald's Collection/Collection McDonald's 2018 (FR)/32.ts
@@ -1,0 +1,48 @@
+import { Card } from '../../../interfaces'
+import Set from "../Collection McDonald's 2018 (FR)"
+
+const card: Card = {
+	name: {
+		fr: "Évoli",
+	},
+	rarity: "None",
+	category: "Pokemon",
+
+	set: Set,
+	dexId: [133],
+	hp: 60,
+	types: ["Colorless"],
+
+	stage: "Basic",
+
+	variants: {
+		normal: false,
+		reverse: false,
+		holo: true,
+		firstEdition: false
+	},
+	attacks: [
+		{
+			cost: [
+				"Grass",
+			],
+			name: {
+				fr: "Signes d'Évolution",
+			},
+			effect: {
+				fr: "Cherchez un Minidraco, un Draco et un Dracolosse dans votre deck, montrez-les, puis ajoutez-les à votre main. Mélangez ensuite votre deck.",
+			},
+		},
+		{
+			cost: [
+				"Lightning",
+			],
+			name: {
+				fr: "Coup de Queue",
+			},
+			damage: "10",
+		},
+	],
+}
+
+export default card

--- a/data/McDonald's Collection/Collection McDonald's 2018 (FR)/33.ts
+++ b/data/McDonald's Collection/Collection McDonald's 2018 (FR)/33.ts
@@ -1,0 +1,49 @@
+import { Card } from '../../../interfaces'
+import Set from "../Collection McDonald's 2018 (FR)"
+
+const card: Card = {
+	name: {
+		fr: "Aquali",
+	},
+	rarity: "None",
+	category: "Pokemon",
+
+	set: Set,
+	dexId: [134],
+	hp: 110,
+	types: ["Water"],
+
+	stage: "Stage1",
+
+	variants: {
+		normal: false,
+		reverse: false,
+		holo: true,
+		firstEdition: false
+	},
+	attacks: [
+		{
+			cost: [
+				"Colorless",
+			],
+			name: {
+				fr: "Écume",
+			},
+			effect: {
+				fr: "Lancez une pièce. Si c'est face, le Pokémon Actif de votre adversaire est maintenant Paralysé.",
+			},
+		},
+		{
+			cost: [
+				"Water",
+				"Fairy",
+			],
+			name: {
+				fr: "Charge",
+			},
+			damage: "20",
+		},
+	],
+}
+
+export default card

--- a/data/McDonald's Collection/Collection McDonald's 2018 (FR)/34.ts
+++ b/data/McDonald's Collection/Collection McDonald's 2018 (FR)/34.ts
@@ -1,0 +1,50 @@
+import { Card } from '../../../interfaces'
+import Set from "../Collection McDonald's 2018 (FR)"
+
+const card: Card = {
+	name: {
+		fr: "Voltali",
+	},
+	rarity: "None",
+	category: "Pokemon",
+
+	set: Set,
+	dexId: [135],
+	hp: 90,
+	types: ["Lightning"],
+
+	stage: "Stage1",
+
+	variants: {
+		normal: false,
+		reverse: false,
+		holo: true,
+		firstEdition: false
+	},
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				fr: "Pare-Balles",
+			},
+			effect: {
+				fr: "Ce Pokémon subit 10 dégâts de moins provenant des attaques (après application de la Faiblesse et de la Résistance).",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			cost: [
+				"Lightning",
+				"Fighting",
+			],
+			name: {
+				fr: "Dracogriffe",
+			},
+			damage: "30",
+		},
+	],
+}
+
+export default card

--- a/data/McDonald's Collection/Collection McDonald's 2018 (FR)/35.ts
+++ b/data/McDonald's Collection/Collection McDonald's 2018 (FR)/35.ts
@@ -1,0 +1,40 @@
+import { Card } from '../../../interfaces'
+import Set from "../Collection McDonald's 2018 (FR)"
+
+const card: Card = {
+	name: {
+		fr: "Pyroli",
+	},
+	rarity: "None",
+	category: "Pokemon",
+
+	set: Set,
+	dexId: [136],
+	hp: 100,
+	types: ["Fire"],
+
+	stage: "Stage1",
+
+	variants: {
+		normal: false,
+		reverse: false,
+		holo: true,
+		firstEdition: false
+	},
+	attacks: [
+		{
+			cost: [
+				"Colorless",
+			],
+			name: {
+				fr: "Bluff",
+			},
+			damage: "10",
+			effect: {
+				fr: "Lancez une pièce. Si c'est face, le Pokémon Actif de votre adversaire est maintenant Paralysé.",
+			},
+		},
+	],
+}
+
+export default card

--- a/data/McDonald's Collection/Collection McDonald's 2018 (FR)/36.ts
+++ b/data/McDonald's Collection/Collection McDonald's 2018 (FR)/36.ts
@@ -1,0 +1,52 @@
+import { Card } from '../../../interfaces'
+import Set from "../Collection McDonald's 2018 (FR)"
+
+const card: Card = {
+	name: {
+		fr: "Mentali",
+	},
+	rarity: "None",
+	category: "Pokemon",
+
+	set: Set,
+	dexId: [196],
+	hp: 90,
+	types: ["Psychic"],
+
+	stage: "Stage1",
+
+	variants: {
+		normal: false,
+		reverse: false,
+		holo: true,
+		firstEdition: false
+	},
+	attacks: [
+		{
+			cost: [
+				"Colorless",
+				"Colorless",
+			],
+			name: {
+				fr: "Blessure Pansée",
+			},
+			effect: {
+				fr: "Lancez une pièce. Si c'est face, soignez 30 dégâts à l'un de vos Pokémon.",
+			},
+		},
+		{
+			cost: [
+				"Colorless",
+				"Colorless",
+				"Colorless",
+				"Colorless",
+			],
+			name: {
+				fr: "Enfoncement",
+			},
+			damage: "80",
+		},
+	],
+}
+
+export default card

--- a/data/McDonald's Collection/Collection McDonald's 2018 (FR)/37.ts
+++ b/data/McDonald's Collection/Collection McDonald's 2018 (FR)/37.ts
@@ -1,0 +1,51 @@
+import { Card } from '../../../interfaces'
+import Set from "../Collection McDonald's 2018 (FR)"
+
+const card: Card = {
+	name: {
+		fr: "Noctali",
+	},
+	rarity: "None",
+	category: "Pokemon",
+
+	set: Set,
+	dexId: [197],
+	hp: 100,
+	types: ["Darkness"],
+
+	stage: "Stage1",
+
+	variants: {
+		normal: false,
+		reverse: false,
+		holo: true,
+		firstEdition: false
+	},
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				fr: "Évolution de l'Énergie",
+			},
+			effect: {
+				fr: "Lorsque vous attachez pendant votre tour une carte Énergie de base de votre main à ce Pokémon, vous pouvez chercher dans votre deck une carte qui est l'évolution de ce Pokémon et du même type que cette carte Énergie. Mettez-la sur ce Pokémon pour le faire évoluer. Mélangez ensuite votre deck.",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			cost: [
+				"Colorless",
+			],
+			name: {
+				fr: "Pioche Rapide",
+			},
+			effect: {
+				fr: "Lancez une pièce. Si c'est face, piochez une carte.",
+			},
+		},
+	],
+}
+
+export default card

--- a/data/McDonald's Collection/Collection McDonald's 2018 (FR)/38.ts
+++ b/data/McDonald's Collection/Collection McDonald's 2018 (FR)/38.ts
@@ -1,0 +1,49 @@
+import { Card } from '../../../interfaces'
+import Set from "../Collection McDonald's 2018 (FR)"
+
+const card: Card = {
+	name: {
+		fr: "Phyllali",
+	},
+	rarity: "None",
+	category: "Pokemon",
+
+	set: Set,
+	dexId: [470],
+	hp: 90,
+	types: ["Grass"],
+
+	stage: "Stage1",
+
+	variants: {
+		normal: false,
+		reverse: false,
+		holo: true,
+		firstEdition: false
+	},
+	attacks: [
+		{
+			cost: [
+				"Colorless",
+			],
+			name: {
+				fr: "Rengorgement",
+			},
+			effect: {
+				fr: "Pendant votre prochain tour, les attaque de ce Pokémon infligent 20 dégâts supplémentaires au Pokémon Actif de votre adversaire (avant application de la Faiblesse et de la Résistance).",
+			},
+		},
+		{
+			cost: [
+				"Colorless",
+				"Colorless",
+			],
+			name: {
+				fr: "Morsure",
+			},
+			damage: "20",
+		},
+	],
+}
+
+export default card

--- a/data/McDonald's Collection/Collection McDonald's 2018 (FR)/39.ts
+++ b/data/McDonald's Collection/Collection McDonald's 2018 (FR)/39.ts
@@ -1,0 +1,49 @@
+import { Card } from '../../../interfaces'
+import Set from "../Collection McDonald's 2018 (FR)"
+
+const card: Card = {
+	name: {
+		fr: "Givrali",
+	},
+	rarity: "None",
+	category: "Pokemon",
+
+	set: Set,
+	dexId: [471],
+	hp: 90,
+	types: ["Water"],
+
+	stage: "Stage1",
+
+	variants: {
+		normal: false,
+		reverse: false,
+		holo: true,
+		firstEdition: false
+	},
+	attacks: [
+		{
+			cost: [
+				"Colorless",
+			],
+			name: {
+				fr: "Rugissement",
+			},
+			effect: {
+				fr: "Pendant le prochain tour de votre adversaire, les attaques du Pokémon Défenseur infligent 20 dégâts de moins (avant application de la Faiblesse et de la Résistance).",
+			},
+		},
+		{
+			cost: [
+				"Colorless",
+				"Colorless",
+			],
+			name: {
+				fr: "Battement",
+			},
+			damage: "20",
+		},
+	],
+}
+
+export default card

--- a/data/McDonald's Collection/Collection McDonald's 2018 (FR)/4.ts
+++ b/data/McDonald's Collection/Collection McDonald's 2018 (FR)/4.ts
@@ -1,0 +1,47 @@
+import { Card } from '../../../interfaces'
+import Set from "../Collection McDonald's 2018 (FR)"
+
+const card: Card = {
+	name: {
+		fr: "Salamèche",
+	},
+	rarity: "None",
+	category: "Pokemon",
+
+	set: Set,
+	dexId: [4],
+	hp: 70,
+	types: ["Fire"],
+
+	stage: "Basic",
+
+	variants: {
+		normal: false,
+		reverse: false,
+		holo: true,
+		firstEdition: false
+	},
+	attacks: [
+		{
+			cost: [
+				"Colorless",
+			],
+			name: {
+				fr: "Griffe",
+			},
+			damage: "10",
+		},
+		{
+			cost: [
+				"Fire",
+				"Colorless",
+			],
+			name: {
+				fr: "Queue de Flammes",
+			},
+			damage: "20",
+		},
+	],
+}
+
+export default card

--- a/data/McDonald's Collection/Collection McDonald's 2018 (FR)/40.ts
+++ b/data/McDonald's Collection/Collection McDonald's 2018 (FR)/40.ts
@@ -1,0 +1,49 @@
+import { Card } from '../../../interfaces'
+import Set from "../Collection McDonald's 2018 (FR)"
+
+const card: Card = {
+	name: {
+		fr: "Nymphali",
+	},
+	rarity: "None",
+	category: "Pokemon",
+
+	set: Set,
+	dexId: [700],
+	hp: 90,
+	types: ["Fairy"],
+
+	stage: "Stage1",
+
+	variants: {
+		normal: false,
+		reverse: false,
+		holo: true,
+		firstEdition: false
+	},
+	attacks: [
+		{
+			cost: [
+				"Colorless",
+			],
+			name: {
+				fr: "Regard Touchant",
+			},
+			effect: {
+				fr: "Le Pokémon Défenseur ne peut pas battre en retraite pendant le prochain tour de votre adversaire.",
+			},
+		},
+		{
+			cost: [
+				"Colorless",
+				"Colorless",
+			],
+			name: {
+				fr: "Charge",
+			},
+			damage: "20",
+		},
+	],
+}
+
+export default card

--- a/data/McDonald's Collection/Collection McDonald's 2018 (FR)/5.ts
+++ b/data/McDonald's Collection/Collection McDonald's 2018 (FR)/5.ts
@@ -1,0 +1,42 @@
+import { Card } from '../../../interfaces'
+import Set from "../Collection McDonald's 2018 (FR)"
+
+const card: Card = {
+	name: {
+		fr: "Reptincel",
+	},
+	rarity: "None",
+	category: "Pokemon",
+
+	set: Set,
+	dexId: [5],
+	hp: 90,
+	types: ["Fire"],
+
+	stage: "Stage1",
+
+	variants: {
+		normal: false,
+		reverse: false,
+		holo: true,
+		firstEdition: false
+	},
+	attacks: [
+		{
+			cost: [
+				"Fire",
+				"Colorless",
+				"Colorless",
+			],
+			name: {
+				fr: "Bélier",
+			},
+			damage: "60",
+			effect: {
+				fr: "Ce Pokémon s'inflige 20 dégâts.",
+			},
+		},
+	],
+}
+
+export default card

--- a/data/McDonald's Collection/Collection McDonald's 2018 (FR)/6.ts
+++ b/data/McDonald's Collection/Collection McDonald's 2018 (FR)/6.ts
@@ -1,0 +1,52 @@
+import { Card } from '../../../interfaces'
+import Set from "../Collection McDonald's 2018 (FR)"
+
+const card: Card = {
+	name: {
+		fr: "Dracaufeu",
+	},
+	rarity: "None",
+	category: "Pokemon",
+
+	set: Set,
+	dexId: [6],
+	hp: 150,
+	types: ["Fire"],
+
+	stage: "Stage2",
+
+	variants: {
+		normal: false,
+		reverse: false,
+		holo: true,
+		firstEdition: false
+	},
+	attacks: [
+		{
+			cost: [
+				"Fire",
+			],
+			name: {
+				fr: "Roussi",
+			},
+			effect: {
+				fr: "Le Pokémon Actif de votre adversaire est maintenant Brûlé.",
+			},
+		},
+		{
+			cost: [
+				"Fire",
+				"Colorless",
+			],
+			name: {
+				fr: "Plaquage",
+			},
+			damage: "50",
+			effect: {
+				fr: "Lancez une pièce. Si c'est face, le Pokémon Actif de votre adversaire est maintenant Paralysé.",
+			},
+		},
+	],
+}
+
+export default card

--- a/data/McDonald's Collection/Collection McDonald's 2018 (FR)/7.ts
+++ b/data/McDonald's Collection/Collection McDonald's 2018 (FR)/7.ts
@@ -1,0 +1,37 @@
+import { Card } from '../../../interfaces'
+import Set from "../Collection McDonald's 2018 (FR)"
+
+const card: Card = {
+	name: {
+		fr: "Carapuce",
+	},
+	rarity: "None",
+	category: "Pokemon",
+
+	set: Set,
+	dexId: [7],
+	hp: 60,
+	types: ["Water"],
+
+	stage: "Basic",
+
+	variants: {
+		normal: false,
+		reverse: false,
+		holo: true,
+		firstEdition: false
+	},
+	attacks: [
+		{
+			cost: [
+				"Fire",
+			],
+			name: {
+				fr: "Flamboiement",
+			},
+			damage: "10",
+		},
+	],
+}
+
+export default card

--- a/data/McDonald's Collection/Collection McDonald's 2018 (FR)/8.ts
+++ b/data/McDonald's Collection/Collection McDonald's 2018 (FR)/8.ts
@@ -1,0 +1,48 @@
+import { Card } from '../../../interfaces'
+import Set from "../Collection McDonald's 2018 (FR)"
+
+const card: Card = {
+	name: {
+		fr: "Carabaffe",
+	},
+	rarity: "None",
+	category: "Pokemon",
+
+	set: Set,
+	dexId: [8],
+	hp: 80,
+	types: ["Water"],
+
+	stage: "Stage1",
+
+	variants: {
+		normal: false,
+		reverse: false,
+		holo: true,
+		firstEdition: false
+	},
+	attacks: [
+		{
+			cost: [],
+			name: {
+				fr: "Boul'Armure",
+			},
+			effect: {
+				fr: "Lancez une pièce. Si c'est face, évitez tous les dégâts infligés à ce Pokémon par des attaques pendant le prochain tour de votre adversaire.",
+			},
+		},
+		{
+			cost: [
+				"Water",
+				"Colorless",
+				"Colorless",
+			],
+			name: {
+				fr: "Ball'Glace",
+			},
+			damage: "30",
+		},
+	],
+}
+
+export default card

--- a/data/McDonald's Collection/Collection McDonald's 2018 (FR)/9.ts
+++ b/data/McDonald's Collection/Collection McDonald's 2018 (FR)/9.ts
@@ -1,0 +1,47 @@
+import { Card } from '../../../interfaces'
+import Set from "../Collection McDonald's 2018 (FR)"
+
+const card: Card = {
+	name: {
+		fr: "Tortank",
+	},
+	rarity: "None",
+	category: "Pokemon",
+
+	set: Set,
+	dexId: [9],
+	hp: 140,
+	types: ["Water"],
+
+	stage: "Stage2",
+
+	variants: {
+		normal: false,
+		reverse: false,
+		holo: true,
+		firstEdition: false
+	},
+	attacks: [
+		{
+			cost: [],
+			name: {
+				fr: "Flambeau",
+			},
+			effect: {
+				fr: "Cherchez jusqu'à 2 Pokémon dans votre deck, montrez-les, puis ajoutez-les à votre main. Mélangez ensuite votre deck.",
+			},
+		},
+		{
+			cost: [
+				"Colorless",
+				"Colorless",
+			],
+			name: {
+				fr: "Verglas",
+			},
+			damage: "20",
+		},
+	],
+}
+
+export default card


### PR DESCRIPTION
Set: **Collection McDonald's 2018 (FR)**
Series folder: `McDonald's Collection`
Changed card files: **40**

### Validation
- [ ] `bun run validate`
- [ ] `cd server && bun run --bun validate`
- [ ] `cd server && bun run compile`
- [ ] Manual review: translations, energy types, TS syntax

### Card images
See follow-up comments with embedded TCGdex assets.