### PR TITLE
fix(data): Collection McDonald's 2019 (FR) (McDonald's Collection)

### DIFF
--- a/data/McDonald's Collection/Collection McDonald's 2019 (FR).ts
+++ b/data/McDonald's Collection/Collection McDonald's 2019 (FR).ts
@@ -1,0 +1,22 @@
+import { Set } from '../../interfaces'
+import serie from '../McDonald\'s Collection'
+
+const set: Set = {
+	id: "2019sm-fr",
+
+	name: {
+		// French-only product; English name matches folder for compiler resolution.
+		en: "Collection McDonald's 2019 (FR)",
+		fr: "Collection McDonald's 2019"
+	},
+
+	serie: serie,
+
+	cardCount: {
+		official: 40
+	},
+
+	releaseDate: "2019-10-30"
+}
+
+export default set

--- a/data/McDonald's Collection/Collection McDonald's 2019 (FR)/1.ts
+++ b/data/McDonald's Collection/Collection McDonald's 2019 (FR)/1.ts
@@ -1,0 +1,38 @@
+import { Card } from '../../../interfaces'
+import Set from "../Collection McDonald's 2019 (FR)"
+
+const card: Card = {
+	name: {
+		fr: "Bulbizarre",
+	},
+	rarity: "None",
+	category: "Pokemon",
+
+	set: Set,
+	dexId: [1],
+	hp: 60,
+	types: ["Grass"],
+
+	stage: "Basic",
+
+	variants: {
+		normal: false,
+		reverse: false,
+		holo: true,
+		firstEdition: false
+	},
+	attacks: [
+		{
+			cost: [
+				"Grass",
+				"Colorless",
+			],
+			name: {
+				fr: "Tranch'Herbe",
+			},
+			damage: "30",
+		},
+	],
+}
+
+export default card

--- a/data/McDonald's Collection/Collection McDonald's 2019 (FR)/10.ts
+++ b/data/McDonald's Collection/Collection McDonald's 2019 (FR)/10.ts
@@ -1,0 +1,53 @@
+import { Card } from '../../../interfaces'
+import Set from "../Collection McDonald's 2019 (FR)"
+
+const card: Card = {
+	name: {
+		fr: "Pikachu",
+	},
+	rarity: "None",
+	category: "Pokemon",
+
+	set: Set,
+	dexId: [25],
+	hp: 60,
+	types: ["Lightning"],
+
+	stage: "Basic",
+
+	variants: {
+		normal: false,
+		reverse: false,
+		holo: true,
+		firstEdition: false
+	},
+	attacks: [
+		{
+			cost: [
+				"Fire",
+			],
+			name: {
+				fr: "Feu Contrôlé",
+			},
+			effect: {
+				fr: "Défaussez la carte du dessus du deck de votre adversaire.",
+			},
+		},
+		{
+			cost: [
+				"Fire",
+				"Fire",
+				"Colorless",
+			],
+			name: {
+				fr: "Lance-Flammes",
+			},
+			damage: "80",
+			effect: {
+				fr: "Défaussez une Énergie de ce Pokémon.",
+			},
+		},
+	],
+}
+
+export default card

--- a/data/McDonald's Collection/Collection McDonald's 2019 (FR)/11.ts
+++ b/data/McDonald's Collection/Collection McDonald's 2019 (FR)/11.ts
@@ -1,0 +1,54 @@
+import { Card } from '../../../interfaces'
+import Set from "../Collection McDonald's 2019 (FR)"
+
+const card: Card = {
+	name: {
+		fr: "Raichu",
+	},
+	rarity: "None",
+	category: "Pokemon",
+
+	set: Set,
+	dexId: [26],
+	hp: 100,
+	types: ["Lightning"],
+
+	stage: "Stage1",
+
+	variants: {
+		normal: false,
+		reverse: false,
+		holo: true,
+		firstEdition: false
+	},
+	attacks: [
+		{
+			cost: [
+				"Fire",
+				"Colorless",
+				"Colorless",
+			],
+			name: {
+				fr: "Cru-Aile",
+			},
+			damage: "70",
+		},
+		{
+			cost: [
+				"Fire",
+				"Colorless",
+				"Colorless",
+				"Colorless",
+			],
+			name: {
+				fr: "Piqué",
+			},
+			damage: "150",
+			effect: {
+				fr: "Lancez une pièce. SI c'est pile, cette attaque ne fait rien.",
+			},
+		},
+	],
+}
+
+export default card

--- a/data/McDonald's Collection/Collection McDonald's 2019 (FR)/12.ts
+++ b/data/McDonald's Collection/Collection McDonald's 2019 (FR)/12.ts
@@ -1,0 +1,38 @@
+import { Card } from '../../../interfaces'
+import Set from "../Collection McDonald's 2019 (FR)"
+
+const card: Card = {
+	name: {
+		fr: "Mélofée",
+	},
+	rarity: "None",
+	category: "Pokemon",
+
+	set: Set,
+	dexId: [35],
+	hp: 60,
+	types: ["Fairy"],
+
+	stage: "Basic",
+
+	variants: {
+		normal: false,
+		reverse: false,
+		holo: true,
+		firstEdition: false
+	},
+	attacks: [
+		{
+			cost: [],
+			name: {
+				fr: "Combo-Griffe",
+			},
+			damage: "10×",
+			effect: {
+				fr: "Lancez 3 pièces. Cette attaque inflige 10 dégâts multipliés par le nombre de côtés face.",
+			},
+		},
+	],
+}
+
+export default card

--- a/data/McDonald's Collection/Collection McDonald's 2019 (FR)/13.ts
+++ b/data/McDonald's Collection/Collection McDonald's 2019 (FR)/13.ts
@@ -1,0 +1,46 @@
+import { Card } from '../../../interfaces'
+import Set from "../Collection McDonald's 2019 (FR)"
+
+const card: Card = {
+	name: {
+		fr: "Mélodelfe",
+	},
+	rarity: "None",
+	category: "Pokemon",
+
+	set: Set,
+	dexId: [36],
+	hp: 100,
+	types: ["Fairy"],
+
+	stage: "Stage1",
+
+	variants: {
+		normal: false,
+		reverse: false,
+		holo: true,
+		firstEdition: false
+	},
+	attacks: [
+		{
+			cost: [],
+			name: {
+				fr: "Hurlement",
+			},
+			effect: {
+				fr: "Votre adversaire échange son Pokémon Actif avec l'un de ses Pokémon de Banc.",
+			},
+		},
+		{
+			cost: [
+				"Water",
+			],
+			name: {
+				fr: "Verglas",
+			},
+			damage: "10",
+		},
+	],
+}
+
+export default card

--- a/data/McDonald's Collection/Collection McDonald's 2019 (FR)/14.ts
+++ b/data/McDonald's Collection/Collection McDonald's 2019 (FR)/14.ts
@@ -1,0 +1,39 @@
+import { Card } from '../../../interfaces'
+import Set from "../Collection McDonald's 2019 (FR)"
+
+const card: Card = {
+	name: {
+		fr: "Goupix",
+	},
+	rarity: "None",
+	category: "Pokemon",
+
+	set: Set,
+	dexId: [37],
+	hp: 60,
+	types: ["Fire"],
+
+	stage: "Basic",
+
+	variants: {
+		normal: false,
+		reverse: false,
+		holo: true,
+		firstEdition: false
+	},
+	attacks: [
+		{
+			cost: [
+				"Colorless",
+			],
+			name: {
+				fr: "Bâillement",
+			},
+			effect: {
+				fr: "Le Pokémon Actif de votre adversaire est maintenant Endormi.",
+			},
+		},
+	],
+}
+
+export default card

--- a/data/McDonald's Collection/Collection McDonald's 2019 (FR)/15.ts
+++ b/data/McDonald's Collection/Collection McDonald's 2019 (FR)/15.ts
@@ -1,0 +1,40 @@
+import { Card } from '../../../interfaces'
+import Set from "../Collection McDonald's 2019 (FR)"
+
+const card: Card = {
+	name: {
+		fr: "Feunard",
+	},
+	rarity: "None",
+	category: "Pokemon",
+
+	set: Set,
+	dexId: [38],
+	hp: 100,
+	types: ["Fire"],
+
+	stage: "Stage1",
+
+	variants: {
+		normal: false,
+		reverse: false,
+		holo: true,
+		firstEdition: false
+	},
+	attacks: [
+		{
+			cost: [
+				"Colorless",
+			],
+			name: {
+				fr: "Hydrocanon",
+			},
+			damage: "10+",
+			effect: {
+				fr: "Cette attaque inflige 10 dégâts supplémentaires multipliés par le nombre d'Énergies Eau attachées à ce Pokémon.",
+			},
+		},
+	],
+}
+
+export default card

--- a/data/McDonald's Collection/Collection McDonald's 2019 (FR)/16.ts
+++ b/data/McDonald's Collection/Collection McDonald's 2019 (FR)/16.ts
@@ -1,0 +1,37 @@
+import { Card } from '../../../interfaces'
+import Set from "../Collection McDonald's 2019 (FR)"
+
+const card: Card = {
+	name: {
+		fr: "Rondoudou",
+	},
+	rarity: "None",
+	category: "Pokemon",
+
+	set: Set,
+	dexId: [39],
+	hp: 60,
+	types: ["Fairy"],
+
+	stage: "Basic",
+
+	variants: {
+		normal: false,
+		reverse: false,
+		holo: true,
+		firstEdition: false
+	},
+	attacks: [
+		{
+			cost: [
+				"Colorless",
+			],
+			name: {
+				fr: "Attaque Tournante",
+			},
+			damage: "10",
+		},
+	],
+}
+
+export default card

--- a/data/McDonald's Collection/Collection McDonald's 2019 (FR)/17.ts
+++ b/data/McDonald's Collection/Collection McDonald's 2019 (FR)/17.ts
@@ -1,0 +1,40 @@
+import { Card } from '../../../interfaces'
+import Set from "../Collection McDonald's 2019 (FR)"
+
+const card: Card = {
+	name: {
+		fr: "Grodoudou",
+	},
+	rarity: "None",
+	category: "Pokemon",
+
+	set: Set,
+	dexId: [40],
+	hp: 100,
+	types: ["Fairy"],
+
+	stage: "Stage1",
+
+	variants: {
+		normal: false,
+		reverse: false,
+		holo: true,
+		firstEdition: false
+	},
+	attacks: [
+		{
+			cost: [
+				"Water",
+			],
+			name: {
+				fr: "Éclaboussure",
+			},
+			damage: "10+",
+			effect: {
+				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 10 dégâts supplémentaires.",
+			},
+		},
+	],
+}
+
+export default card

--- a/data/McDonald's Collection/Collection McDonald's 2019 (FR)/18.ts
+++ b/data/McDonald's Collection/Collection McDonald's 2019 (FR)/18.ts
@@ -1,0 +1,54 @@
+import { Card } from '../../../interfaces'
+import Set from "../Collection McDonald's 2019 (FR)"
+
+const card: Card = {
+	name: {
+		fr: "Miaouss",
+	},
+	rarity: "None",
+	category: "Pokemon",
+
+	set: Set,
+	dexId: [52],
+	hp: 60,
+	types: ["Colorless"],
+
+	stage: "Basic",
+
+	variants: {
+		normal: false,
+		reverse: false,
+		holo: true,
+		firstEdition: false
+	},
+	attacks: [
+		{
+			cost: [
+				"Water",
+			],
+			name: {
+				fr: "Aquaballe",
+			},
+			damage: "20",
+			effect: {
+				fr: "Cette attaque inflige 20 dégâts à l'un des Pokémon de Banc de votre adversaire. (N'appliquez ni la Faiblesse ni la Résistance aux Pokémon de Banc.)",
+			},
+		},
+		{
+			cost: [
+				"Colorless",
+				"Colorless",
+				"Colorless",
+			],
+			name: {
+				fr: "Hydrocanon",
+			},
+			damage: "70+",
+			effect: {
+				fr: "Cette attaque inflige 10 dégâts supplémentaires multipliés par le nombre d'Énergies Eau attachées à ce Pokémon.",
+			},
+		},
+	],
+}
+
+export default card

--- a/data/McDonald's Collection/Collection McDonald's 2019 (FR)/19.ts
+++ b/data/McDonald's Collection/Collection McDonald's 2019 (FR)/19.ts
@@ -1,0 +1,52 @@
+import { Card } from '../../../interfaces'
+import Set from "../Collection McDonald's 2019 (FR)"
+
+const card: Card = {
+	name: {
+		fr: "Persian",
+	},
+	rarity: "None",
+	category: "Pokemon",
+
+	set: Set,
+	dexId: [53],
+	hp: 90,
+	types: ["Colorless"],
+
+	stage: "Stage1",
+
+	variants: {
+		normal: false,
+		reverse: false,
+		holo: true,
+		firstEdition: false
+	},
+	attacks: [
+		{
+			cost: [
+				"Colorless",
+				"Colorless",
+			],
+			name: {
+				fr: "Tornade",
+			},
+			damage: "30",
+		},
+		{
+			cost: [
+				"Water",
+				"Water",
+				"Colorless",
+			],
+			name: {
+				fr: "Glaciation",
+			},
+			damage: "100",
+			effect: {
+				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur ne peut pas attaquer pendant le prochain tour de votre adversaire.",
+			},
+		},
+	],
+}
+
+export default card

--- a/data/McDonald's Collection/Collection McDonald's 2019 (FR)/2.ts
+++ b/data/McDonald's Collection/Collection McDonald's 2019 (FR)/2.ts
@@ -1,0 +1,40 @@
+import { Card } from '../../../interfaces'
+import Set from "../Collection McDonald's 2019 (FR)"
+
+const card: Card = {
+	name: {
+		fr: "Herbizarre",
+	},
+	rarity: "None",
+	category: "Pokemon",
+
+	set: Set,
+	dexId: [2],
+	hp: 80,
+	types: ["Grass"],
+
+	stage: "Stage1",
+
+	variants: {
+		normal: false,
+		reverse: false,
+		holo: true,
+		firstEdition: false
+	},
+	attacks: [
+		{
+			cost: [
+				"Grass",
+			],
+			name: {
+				fr: "Attaque Surprise",
+			},
+			damage: "20",
+			effect: {
+				fr: "Lancez une pièce. Si c'est pile, cette attaque ne fait rien.",
+			},
+		},
+	],
+}
+
+export default card

--- a/data/McDonald's Collection/Collection McDonald's 2019 (FR)/20.ts
+++ b/data/McDonald's Collection/Collection McDonald's 2019 (FR)/20.ts
@@ -1,0 +1,40 @@
+import { Card } from '../../../interfaces'
+import Set from "../Collection McDonald's 2019 (FR)"
+
+const card: Card = {
+	name: {
+		fr: "Psykokwak",
+	},
+	rarity: "None",
+	category: "Pokemon",
+
+	set: Set,
+	dexId: [54],
+	hp: 70,
+	types: ["Water"],
+
+	stage: "Basic",
+
+	variants: {
+		normal: false,
+		reverse: false,
+		holo: true,
+		firstEdition: false
+	},
+	attacks: [
+		{
+			cost: [
+				"Lightning",
+			],
+			name: {
+				fr: "Queue de Fer",
+			},
+			damage: "20×",
+			effect: {
+				fr: "Lancez une pièce jusqu'à ce que vous obteniez un côté pile. Cette attaque inflige 20 dégâts multipliés par le nombre de côtés face.",
+			},
+		},
+	],
+}
+
+export default card

--- a/data/McDonald's Collection/Collection McDonald's 2019 (FR)/21.ts
+++ b/data/McDonald's Collection/Collection McDonald's 2019 (FR)/21.ts
@@ -1,0 +1,54 @@
+import { Card } from '../../../interfaces'
+import Set from "../Collection McDonald's 2019 (FR)"
+
+const card: Card = {
+	name: {
+		fr: "Akwakwak",
+	},
+	rarity: "None",
+	category: "Pokemon",
+
+	set: Set,
+	dexId: [55],
+	hp: 100,
+	types: ["Water"],
+
+	stage: "Stage1",
+
+	variants: {
+		normal: false,
+		reverse: false,
+		holo: true,
+		firstEdition: false
+	},
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				fr: "Surf Caudal",
+			},
+			effect: {
+				fr: "S'il y a une carte Stade en jeu, ce Pokémon n'a pas de Coût de Retraite.",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			cost: [
+				"Colorless",
+				"Colorless",
+				"Colorless",
+			],
+			name: {
+				fr: "Psyko",
+			},
+			damage: "70+",
+			effect: {
+				fr: "Cette attaque inflige 20 dégâts supplémentaires multipliés par le nombre d'Énergies attachées au Pokémon Actif de votre adversaire.",
+			},
+		},
+	],
+}
+
+export default card

--- a/data/McDonald's Collection/Collection McDonald's 2019 (FR)/22.ts
+++ b/data/McDonald's Collection/Collection McDonald's 2019 (FR)/22.ts
@@ -1,0 +1,47 @@
+import { Card } from '../../../interfaces'
+import Set from "../Collection McDonald's 2019 (FR)"
+
+const card: Card = {
+	name: {
+		fr: "Caninos",
+	},
+	rarity: "None",
+	category: "Pokemon",
+
+	set: Set,
+	dexId: [58],
+	hp: 80,
+	types: ["Fire"],
+
+	stage: "Basic",
+
+	variants: {
+		normal: false,
+		reverse: false,
+		holo: true,
+		firstEdition: false
+	},
+	attacks: [
+		{
+			cost: [],
+			name: {
+				fr: "Boul'Armure",
+			},
+			effect: {
+				fr: "Lancez une pièce. Si c'est face, évitez tous les dégâts infligés à ce Pokémon par des attaques pendant le prochain tour de votre adversaire.",
+			},
+		},
+		{
+			cost: [
+				"Colorless",
+				"Colorless",
+			],
+			name: {
+				fr: "Charge",
+			},
+			damage: "20",
+		},
+	],
+}
+
+export default card

--- a/data/McDonald's Collection/Collection McDonald's 2019 (FR)/23.ts
+++ b/data/McDonald's Collection/Collection McDonald's 2019 (FR)/23.ts
@@ -1,0 +1,48 @@
+import { Card } from '../../../interfaces'
+import Set from "../Collection McDonald's 2019 (FR)"
+
+const card: Card = {
+	name: {
+		fr: "Arcanin",
+	},
+	rarity: "None",
+	category: "Pokemon",
+
+	set: Set,
+	dexId: [59],
+	hp: 130,
+	types: ["Fire"],
+
+	stage: "Stage1",
+
+	variants: {
+		normal: false,
+		reverse: false,
+		holo: true,
+		firstEdition: false
+	},
+	attacks: [
+		{
+			cost: [
+				"Colorless",
+			],
+			name: {
+				fr: "Aimant Inquisiteur",
+			},
+			effect: {
+				fr: "Cherchez jusqu'à 3 cartes Énergie Électrique dans votre deck, montrez-les, puis ajoutez-les à votre main. Mélangez ensuite votre deck.",
+			},
+		},
+		{
+			cost: [
+				"Lightning",
+			],
+			name: {
+				fr: "Charge",
+			},
+			damage: "10",
+		},
+	],
+}
+
+export default card

--- a/data/McDonald's Collection/Collection McDonald's 2019 (FR)/24.ts
+++ b/data/McDonald's Collection/Collection McDonald's 2019 (FR)/24.ts
@@ -1,0 +1,53 @@
+import { Card } from '../../../interfaces'
+import Set from "../Collection McDonald's 2019 (FR)"
+
+const card: Card = {
+	name: {
+		fr: "Machoc",
+	},
+	rarity: "None",
+	category: "Pokemon",
+
+	set: Set,
+	dexId: [66],
+	hp: 70,
+	types: ["Fighting"],
+
+	stage: "Basic",
+
+	variants: {
+		normal: false,
+		reverse: false,
+		holo: true,
+		firstEdition: false
+	},
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				fr: "Électrons Flottants",
+			},
+			effect: {
+				fr: "Si de l'Énergie est attachée à ce Pokémon, il n'a pas de Coût de Retraite.",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			cost: [
+				"Lightning",
+				"Colorless",
+			],
+			name: {
+				fr: "Éclair",
+			},
+			damage: "20",
+			effect: {
+				fr: "Lancez une pièce. Si c'est face, le Pokémon Actif de votre adversaire est maintenant Paralysé.",
+			},
+		},
+	],
+}
+
+export default card

--- a/data/McDonald's Collection/Collection McDonald's 2019 (FR)/25.ts
+++ b/data/McDonald's Collection/Collection McDonald's 2019 (FR)/25.ts
@@ -1,0 +1,52 @@
+import { Card } from '../../../interfaces'
+import Set from "../Collection McDonald's 2019 (FR)"
+
+const card: Card = {
+	name: {
+		fr: "Machopeur",
+	},
+	rarity: "None",
+	category: "Pokemon",
+
+	set: Set,
+	dexId: [67],
+	hp: 90,
+	types: ["Fighting"],
+
+	stage: "Stage1",
+
+	variants: {
+		normal: false,
+		reverse: false,
+		holo: true,
+		firstEdition: false
+	},
+	attacks: [
+		{
+			cost: [
+				"Lightning",
+				"Colorless",
+			],
+			name: {
+				fr: "Balayage",
+			},
+			damage: "30",
+		},
+		{
+			cost: [
+				"Lightning",
+				"Lightning",
+				"Colorless",
+			],
+			name: {
+				fr: "Fatal-Foudre",
+			},
+			damage: "90",
+			effect: {
+				fr: "Ce Pokémon s'inflige 30 dégâts.",
+			},
+		},
+	],
+}
+
+export default card

--- a/data/McDonald's Collection/Collection McDonald's 2019 (FR)/26.ts
+++ b/data/McDonald's Collection/Collection McDonald's 2019 (FR)/26.ts
@@ -1,0 +1,52 @@
+import { Card } from '../../../interfaces'
+import Set from "../Collection McDonald's 2019 (FR)"
+
+const card: Card = {
+	name: {
+		fr: "Mackogneur",
+	},
+	rarity: "None",
+	category: "Pokemon",
+
+	set: Set,
+	dexId: [68],
+	hp: 150,
+	types: ["Fighting"],
+
+	stage: "Stage2",
+
+	variants: {
+		normal: false,
+		reverse: false,
+		holo: true,
+		firstEdition: false
+	},
+	attacks: [
+		{
+			cost: [
+				"Lightning",
+			],
+			name: {
+				fr: "Éclair",
+			},
+			damage: "20",
+			effect: {
+				fr: "Lancez une pièce. Si c'est face, le Pokémon Actif de votre adversaire est maintenant Paralysé.",
+			},
+		},
+		{
+			cost: [
+				"Colorless",
+				"Colorless",
+				"Colorless",
+				"Colorless",
+			],
+			name: {
+				fr: "Bec Vrille",
+			},
+			damage: "120",
+		},
+	],
+}
+
+export default card

--- a/data/McDonald's Collection/Collection McDonald's 2019 (FR)/27.ts
+++ b/data/McDonald's Collection/Collection McDonald's 2019 (FR)/27.ts
@@ -1,0 +1,39 @@
+import { Card } from '../../../interfaces'
+import Set from "../Collection McDonald's 2019 (FR)"
+
+const card: Card = {
+	name: {
+		fr: "Tadmorv",
+	},
+	rarity: "None",
+	category: "Pokemon",
+
+	set: Set,
+	dexId: [88],
+	hp: 70,
+	types: ["Psychic"],
+
+	stage: "Basic",
+
+	variants: {
+		normal: false,
+		reverse: false,
+		holo: true,
+		firstEdition: false
+	},
+	attacks: [
+		{
+			cost: [
+				"Psychic",
+			],
+			name: {
+				fr: "Regard Menaçant",
+			},
+			effect: {
+				fr: "Placez un marqueur de dégâts sur l'un des Pokémon de votre adversaire.",
+			},
+		},
+	],
+}
+
+export default card

--- a/data/McDonald's Collection/Collection McDonald's 2019 (FR)/28.ts
+++ b/data/McDonald's Collection/Collection McDonald's 2019 (FR)/28.ts
@@ -1,0 +1,40 @@
+import { Card } from '../../../interfaces'
+import Set from "../Collection McDonald's 2019 (FR)"
+
+const card: Card = {
+	name: {
+		fr: "Grotadmorv",
+	},
+	rarity: "None",
+	category: "Pokemon",
+
+	set: Set,
+	dexId: [89],
+	hp: 120,
+	types: ["Psychic"],
+
+	stage: "Stage1",
+
+	variants: {
+		normal: false,
+		reverse: false,
+		holo: true,
+		firstEdition: false
+	},
+	attacks: [
+		{
+			cost: [
+				"Fighting",
+			],
+			name: {
+				fr: "Attaque en Trois Étapes",
+			},
+			damage: "10×",
+			effect: {
+				fr: "Lancez 3 pièces. Chaque attaque inflige 10 dégâts multipliés par le nombre de côtés face.",
+			},
+		},
+	],
+}
+
+export default card

--- a/data/McDonald's Collection/Collection McDonald's 2019 (FR)/29.ts
+++ b/data/McDonald's Collection/Collection McDonald's 2019 (FR)/29.ts
@@ -1,0 +1,52 @@
+import { Card } from '../../../interfaces'
+import Set from "../Collection McDonald's 2019 (FR)"
+
+const card: Card = {
+	name: {
+		fr: "Fantominus",
+	},
+	rarity: "None",
+	category: "Pokemon",
+
+	set: Set,
+	dexId: [92],
+	hp: 50,
+	types: ["Psychic"],
+
+	stage: "Basic",
+
+	variants: {
+		normal: false,
+		reverse: false,
+		holo: true,
+		firstEdition: false
+	},
+	attacks: [
+		{
+			cost: [
+				"Colorless",
+			],
+			name: {
+				fr: "Grincement",
+			},
+			effect: {
+				fr: "Pendant votre prochain tour, le Pokémon Défenseur subit 20 dégâts supplémentaires provenant des attaques (après application de la Faiblesse et de la Résistance).",
+			},
+		},
+		{
+			cost: [
+				"Fighting",
+				"Fighting",
+			],
+			name: {
+				fr: "Frénésie",
+			},
+			damage: "10+",
+			effect: {
+				fr: "Cette attaque inflige 10 dégâts supplémentaires pour chaque marqueur de dégâts placé sur ce Pokémon.",
+			},
+		},
+	],
+}
+
+export default card

--- a/data/McDonald's Collection/Collection McDonald's 2019 (FR)/3.ts
+++ b/data/McDonald's Collection/Collection McDonald's 2019 (FR)/3.ts
@@ -1,0 +1,38 @@
+import { Card } from '../../../interfaces'
+import Set from "../Collection McDonald's 2019 (FR)"
+
+const card: Card = {
+	name: {
+		fr: "Florizarre",
+	},
+	rarity: "None",
+	category: "Pokemon",
+
+	set: Set,
+	dexId: [3],
+	hp: 140,
+	types: ["Grass"],
+
+	stage: "Stage2",
+
+	variants: {
+		normal: false,
+		reverse: false,
+		holo: true,
+		firstEdition: false
+	},
+	attacks: [
+		{
+			cost: [
+				"Grass",
+				"Colorless",
+			],
+			name: {
+				fr: "Griffe",
+			},
+			damage: "30",
+		},
+	],
+}
+
+export default card

--- a/data/McDonald's Collection/Collection McDonald's 2019 (FR)/30.ts
+++ b/data/McDonald's Collection/Collection McDonald's 2019 (FR)/30.ts
@@ -1,0 +1,41 @@
+import { Card } from '../../../interfaces'
+import Set from "../Collection McDonald's 2019 (FR)"
+
+const card: Card = {
+	name: {
+		fr: "Spectrum",
+	},
+	rarity: "None",
+	category: "Pokemon",
+
+	set: Set,
+	dexId: [93],
+	hp: 70,
+	types: ["Psychic"],
+
+	stage: "Stage1",
+
+	variants: {
+		normal: false,
+		reverse: false,
+		holo: true,
+		firstEdition: false
+	},
+	attacks: [
+		{
+			cost: [
+				"Colorless",
+				"Colorless",
+			],
+			name: {
+				fr: "Os Pesant",
+			},
+			damage: "40",
+			effect: {
+				fr: "Ce Pokémon ne peut pas attaquer pendant votre prochain tour.",
+			},
+		},
+	],
+}
+
+export default card

--- a/data/McDonald's Collection/Collection McDonald's 2019 (FR)/31.ts
+++ b/data/McDonald's Collection/Collection McDonald's 2019 (FR)/31.ts
@@ -1,0 +1,49 @@
+import { Card } from '../../../interfaces'
+import Set from "../Collection McDonald's 2019 (FR)"
+
+const card: Card = {
+	name: {
+		fr: "Ectoplasma",
+	},
+	rarity: "None",
+	category: "Pokemon",
+
+	set: Set,
+	dexId: [94],
+	hp: 130,
+	types: ["Psychic"],
+
+	stage: "Stage2",
+
+	variants: {
+		normal: false,
+		reverse: false,
+		holo: true,
+		firstEdition: false
+	},
+	attacks: [
+		{
+			cost: [
+				"Colorless",
+				"Colorless",
+			],
+			name: {
+				fr: "Allonger",
+			},
+			damage: "20",
+		},
+		{
+			cost: [
+				"Fighting",
+				"Fighting",
+				"Colorless",
+			],
+			name: {
+				fr: "Empal'Korne",
+			},
+			damage: "60",
+		},
+	],
+}
+
+export default card

--- a/data/McDonald's Collection/Collection McDonald's 2019 (FR)/32.ts
+++ b/data/McDonald's Collection/Collection McDonald's 2019 (FR)/32.ts
@@ -1,0 +1,38 @@
+import { Card } from '../../../interfaces'
+import Set from "../Collection McDonald's 2019 (FR)"
+
+const card: Card = {
+	name: {
+		fr: "Évoli",
+	},
+	rarity: "None",
+	category: "Pokemon",
+
+	set: Set,
+	dexId: [133],
+	hp: 60,
+	types: ["Colorless"],
+
+	stage: "Basic",
+
+	variants: {
+		normal: false,
+		reverse: false,
+		holo: true,
+		firstEdition: false
+	},
+	attacks: [
+		{
+			cost: [],
+			name: {
+				fr: "Plaisir Gâché",
+			},
+			damage: "10+",
+			effect: {
+				fr: "Si vous jouez en second, cette attaque inflige 60 dégâts supplémentaires pendant votre premier tour.",
+			},
+		},
+	],
+}
+
+export default card

--- a/data/McDonald's Collection/Collection McDonald's 2019 (FR)/33.ts
+++ b/data/McDonald's Collection/Collection McDonald's 2019 (FR)/33.ts
@@ -1,0 +1,38 @@
+import { Card } from '../../../interfaces'
+import Set from "../Collection McDonald's 2019 (FR)"
+
+const card: Card = {
+	name: {
+		fr: "Aquali",
+	},
+	rarity: "None",
+	category: "Pokemon",
+
+	set: Set,
+	dexId: [134],
+	hp: 110,
+	types: ["Water"],
+
+	stage: "Stage1",
+
+	variants: {
+		normal: false,
+		reverse: false,
+		holo: true,
+		firstEdition: false
+	},
+	attacks: [
+		{
+			cost: [],
+			name: {
+				fr: "Tête de Fer",
+			},
+			damage: "10×",
+			effect: {
+				fr: "Lancez une pièce jusqu'à ce que vous obteniez un côté pile. Cette attaque inflige 10 dégâts multipliés par le nombre de côtés face.",
+			},
+		},
+	],
+}
+
+export default card

--- a/data/McDonald's Collection/Collection McDonald's 2019 (FR)/34.ts
+++ b/data/McDonald's Collection/Collection McDonald's 2019 (FR)/34.ts
@@ -1,0 +1,38 @@
+import { Card } from '../../../interfaces'
+import Set from "../Collection McDonald's 2019 (FR)"
+
+const card: Card = {
+	name: {
+		fr: "Voltali",
+	},
+	rarity: "None",
+	category: "Pokemon",
+
+	set: Set,
+	dexId: [135],
+	hp: 90,
+	types: ["Lightning"],
+
+	stage: "Stage1",
+
+	variants: {
+		normal: false,
+		reverse: false,
+		holo: true,
+		firstEdition: false
+	},
+	attacks: [
+		{
+			cost: [],
+			name: {
+				fr: "Ruée Vers l'Or",
+			},
+			damage: "30×",
+			effect: {
+				fr: "Défaussez autant de cartes Énergie Métal que vous voulez de votre main. Cette attaque inflige 30 dégâts pour chaque carte défaussée de cette façon.",
+			},
+		},
+	],
+}
+
+export default card

--- a/data/McDonald's Collection/Collection McDonald's 2019 (FR)/35.ts
+++ b/data/McDonald's Collection/Collection McDonald's 2019 (FR)/35.ts
@@ -1,0 +1,49 @@
+import { Card } from '../../../interfaces'
+import Set from "../Collection McDonald's 2019 (FR)"
+
+const card: Card = {
+	name: {
+		fr: "Pyroli",
+	},
+	rarity: "None",
+	category: "Pokemon",
+
+	set: Set,
+	dexId: [136],
+	hp: 100,
+	types: ["Fire"],
+
+	stage: "Stage1",
+
+	variants: {
+		normal: false,
+		reverse: false,
+		holo: true,
+		firstEdition: false
+	},
+	attacks: [
+		{
+			cost: [
+				"Fairy",
+			],
+			name: {
+				fr: "Écras'Face",
+			},
+			damage: "10",
+		},
+		{
+			cost: [
+				"Colorless",
+				"Colorless",
+			],
+			name: {
+				fr: "Berceuse",
+			},
+			effect: {
+				fr: "Le Pokémon Actif de votre adversaire est maintenant Endormi.",
+			},
+		},
+	],
+}
+
+export default card

--- a/data/McDonald's Collection/Collection McDonald's 2019 (FR)/36.ts
+++ b/data/McDonald's Collection/Collection McDonald's 2019 (FR)/36.ts
@@ -1,0 +1,40 @@
+import { Card } from '../../../interfaces'
+import Set from "../Collection McDonald's 2019 (FR)"
+
+const card: Card = {
+	name: {
+		fr: "Mentali",
+	},
+	rarity: "None",
+	category: "Pokemon",
+
+	set: Set,
+	dexId: [196],
+	hp: 90,
+	types: ["Psychic"],
+
+	stage: "Stage1",
+
+	variants: {
+		normal: false,
+		reverse: false,
+		holo: true,
+		firstEdition: false
+	},
+	attacks: [
+		{
+			cost: [
+				"Lightning",
+			],
+			name: {
+				fr: "Ligotage",
+			},
+			damage: "10",
+			effect: {
+				fr: "Lancez une pièce. Si c'est face, le Pokémon Actif de votre adversaire est maintenant Paralysé.",
+			},
+		},
+	],
+}
+
+export default card

--- a/data/McDonald's Collection/Collection McDonald's 2019 (FR)/37.ts
+++ b/data/McDonald's Collection/Collection McDonald's 2019 (FR)/37.ts
@@ -1,0 +1,54 @@
+import { Card } from '../../../interfaces'
+import Set from "../Collection McDonald's 2019 (FR)"
+
+const card: Card = {
+	name: {
+		fr: "Noctali",
+	},
+	rarity: "None",
+	category: "Pokemon",
+
+	set: Set,
+	dexId: [197],
+	hp: 100,
+	types: ["Darkness"],
+
+	stage: "Stage1",
+
+	variants: {
+		normal: false,
+		reverse: false,
+		holo: true,
+		firstEdition: false
+	},
+	attacks: [
+		{
+			cost: [
+				"Colorless",
+				"Colorless",
+			],
+			name: {
+				fr: "Gobeur",
+			},
+			effect: {
+				fr: "Piochez 3 cartes.",
+			},
+		},
+		{
+			cost: [
+				"Colorless",
+				"Colorless",
+				"Colorless",
+			],
+			name: {
+				fr: "Souplesse",
+			},
+			damage: "50x",
+			effect: {
+				fr: "Lancez 2 pièces. Cette attaque inflige 50 dégâts multipliés par le nombre de côtés face.",
+			},
+		},
+	],
+}
+
+export default card

--- a/data/McDonald's Collection/Collection McDonald's 2019 (FR)/38.ts
+++ b/data/McDonald's Collection/Collection McDonald's 2019 (FR)/38.ts
@@ -1,0 +1,53 @@
+import { Card } from '../../../interfaces'
+import Set from "../Collection McDonald's 2019 (FR)"
+
+const card: Card = {
+	name: {
+		fr: "Phyllali",
+	},
+	rarity: "None",
+	category: "Pokemon",
+
+	set: Set,
+	dexId: [470],
+	hp: 90,
+	types: ["Grass"],
+
+	stage: "Stage1",
+
+	variants: {
+		normal: false,
+		reverse: false,
+		holo: true,
+		firstEdition: false
+	},
+	attacks: [
+		{
+			cost: [
+				"Colorless",
+			],
+			name: {
+				fr: "Pirouette Apaisante",
+			},
+			effect: {
+				fr: "Soignez 20 dégâts à chacun de vos Pokémon.",
+			},
+		},
+		{
+			cost: [
+				"Colorless",
+				"Colorless",
+				"Colorless",
+			],
+			name: {
+				fr: "Gifle Cordiale",
+			},
+			damage: "100",
+			effect: {
+				fr: "Si le Pokémon Actif de votre adversaire a déjà des marqueurs de dégâts avant que cette attaque n'inflige des dégâts, cette attaque ne fait rien.",
+			},
+		},
+	],
+}
+
+export default card

--- a/data/McDonald's Collection/Collection McDonald's 2019 (FR)/39.ts
+++ b/data/McDonald's Collection/Collection McDonald's 2019 (FR)/39.ts
@@ -1,0 +1,63 @@
+import { Card } from '../../../interfaces'
+import Set from "../Collection McDonald's 2019 (FR)"
+
+const card: Card = {
+	name: {
+		fr: "Givrali",
+	},
+	rarity: "None",
+	category: "Pokemon",
+
+	set: Set,
+	dexId: [471],
+	hp: 90,
+	types: ["Water"],
+
+	stage: "Stage1",
+
+	variants: {
+		normal: false,
+		reverse: false,
+		holo: true,
+		firstEdition: false
+	},
+	attacks: [
+		{
+			cost: [
+				"Colorless",
+			],
+			name: {
+				fr: "Rapporte",
+			},
+			effect: {
+				fr: "Piochez une carte.",
+			},
+		},
+		{
+			cost: [
+				"Colorless",
+				"Colorless",
+			],
+			name: {
+				fr: "Coup d'Boule",
+			},
+			damage: "30",
+		},
+		{
+			cost: [
+				"Colorless",
+				"Colorless",
+				"Colorless",
+			],
+			name: {
+				fr: "En Deux Punch",
+			},
+			damage: "60+",
+			effect: {
+				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 30 dégâts supplémentaires.",
+			},
+		},
+	],
+}
+
+export default card

--- a/data/McDonald's Collection/Collection McDonald's 2019 (FR)/4.ts
+++ b/data/McDonald's Collection/Collection McDonald's 2019 (FR)/4.ts
@@ -1,0 +1,41 @@
+import { Card } from '../../../interfaces'
+import Set from "../Collection McDonald's 2019 (FR)"
+
+const card: Card = {
+	name: {
+		fr: "Salamèche",
+	},
+	rarity: "None",
+	category: "Pokemon",
+
+	set: Set,
+	dexId: [4],
+	hp: 70,
+	types: ["Fire"],
+
+	stage: "Basic",
+
+	variants: {
+		normal: false,
+		reverse: false,
+		holo: true,
+		firstEdition: false
+	},
+	attacks: [
+		{
+			cost: [
+				"Grass",
+				"Colorless",
+			],
+			name: {
+				fr: "Pâté",
+			},
+			damage: "20",
+			effect: {
+				fr: "Soignez 10 dégâts à ce Pokémon.",
+			},
+		},
+	],
+}
+
+export default card

--- a/data/McDonald's Collection/Collection McDonald's 2019 (FR)/40.ts
+++ b/data/McDonald's Collection/Collection McDonald's 2019 (FR)/40.ts
@@ -1,0 +1,37 @@
+import { Card } from '../../../interfaces'
+import Set from "../Collection McDonald's 2019 (FR)"
+
+const card: Card = {
+	name: {
+		fr: "Nymphali",
+	},
+	rarity: "None",
+	category: "Pokemon",
+
+	set: Set,
+	dexId: [700],
+	hp: 90,
+	types: ["Fairy"],
+
+	stage: "Stage1",
+
+	variants: {
+		normal: false,
+		reverse: false,
+		holo: true,
+		firstEdition: false
+	},
+	attacks: [
+		{
+			cost: [
+				"Colorless",
+			],
+			name: {
+				fr: "Ronge",
+			},
+			damage: "20",
+		},
+	],
+}
+
+export default card

--- a/data/McDonald's Collection/Collection McDonald's 2019 (FR)/5.ts
+++ b/data/McDonald's Collection/Collection McDonald's 2019 (FR)/5.ts
@@ -1,0 +1,40 @@
+import { Card } from '../../../interfaces'
+import Set from "../Collection McDonald's 2019 (FR)"
+
+const card: Card = {
+	name: {
+		fr: "Reptincel",
+	},
+	rarity: "None",
+	category: "Pokemon",
+
+	set: Set,
+	dexId: [5],
+	hp: 90,
+	types: ["Fire"],
+
+	stage: "Stage1",
+
+	variants: {
+		normal: false,
+		reverse: false,
+		holo: true,
+		firstEdition: false
+	},
+	attacks: [
+		{
+			cost: [
+				"Grass",
+			],
+			name: {
+				fr: "Balancement Tropical",
+			},
+			damage: "20+",
+			effect: {
+				fr: "Cette attaque inflige 20 dégâts supplémentaires pour chaque type de carte Énergie de base dans votre pile de défausse. Vous ne pouvez pas ajouter plus de 100 dégâts de cette façon.",
+			},
+		},
+	],
+}
+
+export default card

--- a/data/McDonald's Collection/Collection McDonald's 2019 (FR)/6.ts
+++ b/data/McDonald's Collection/Collection McDonald's 2019 (FR)/6.ts
@@ -1,0 +1,52 @@
+import { Card } from '../../../interfaces'
+import Set from "../Collection McDonald's 2019 (FR)"
+
+const card: Card = {
+	name: {
+		fr: "Dracaufeu",
+	},
+	rarity: "None",
+	category: "Pokemon",
+
+	set: Set,
+	dexId: [6],
+	hp: 150,
+	types: ["Fire"],
+
+	stage: "Stage2",
+
+	variants: {
+		normal: false,
+		reverse: false,
+		holo: true,
+		firstEdition: false
+	},
+	attacks: [
+		{
+			cost: [
+				"Colorless",
+				"Colorless",
+			],
+			name: {
+				fr: "Gifle Douce",
+			},
+			damage: "20",
+		},
+		{
+			cost: [
+				"Grass",
+				"Colorless",
+				"Colorless",
+			],
+			name: {
+				fr: "Étreinte",
+			},
+			damage: "40",
+			effect: {
+				fr: "Lancez une pièce. Si c'est face, le Pokémon Actif de votre adversaire est maintenant Paralysé.",
+			},
+		},
+	],
+}
+
+export default card

--- a/data/McDonald's Collection/Collection McDonald's 2019 (FR)/7.ts
+++ b/data/McDonald's Collection/Collection McDonald's 2019 (FR)/7.ts
@@ -1,0 +1,52 @@
+import { Card } from '../../../interfaces'
+import Set from "../Collection McDonald's 2019 (FR)"
+
+const card: Card = {
+	name: {
+		fr: "Carapuce",
+	},
+	rarity: "None",
+	category: "Pokemon",
+
+	set: Set,
+	dexId: [7],
+	hp: 60,
+	types: ["Water"],
+
+	stage: "Basic",
+
+	variants: {
+		normal: false,
+		reverse: false,
+		holo: true,
+		firstEdition: false
+	},
+	attacks: [
+		{
+			cost: [
+				"Colorless",
+			],
+			name: {
+				fr: "Duo",
+			},
+			effect: {
+				fr: "Cherchez jusqu'à 2 Insécateur dans votre deck et placez-les sur votre Banc. Mélangez ensuite votre deck.",
+			},
+		},
+		{
+			cost: [
+				"Colorless",
+				"Colorless",
+			],
+			name: {
+				fr: "Hâte",
+			},
+			damage: "20",
+			effect: {
+				fr: "Lancez une pièce. Si c'est face, évitez tous les effets d'attaques, y compris les dégâts, infligés à ce Pokémon pendant le prochain tour de votre adversaire.",
+			},
+		},
+	],
+}
+
+export default card

--- a/data/McDonald's Collection/Collection McDonald's 2019 (FR)/8.ts
+++ b/data/McDonald's Collection/Collection McDonald's 2019 (FR)/8.ts
@@ -1,0 +1,51 @@
+import { Card } from '../../../interfaces'
+import Set from "../Collection McDonald's 2019 (FR)"
+
+const card: Card = {
+	name: {
+		fr: "Carabaffe",
+	},
+	rarity: "None",
+	category: "Pokemon",
+
+	set: Set,
+	dexId: [8],
+	hp: 80,
+	types: ["Water"],
+
+	stage: "Stage1",
+
+	variants: {
+		normal: false,
+		reverse: false,
+		holo: true,
+		firstEdition: false
+	},
+	attacks: [
+		{
+			cost: [
+				"Grass",
+			],
+			name: {
+				fr: "Empoigne Puissante",
+			},
+			damage: "20",
+			effect: {
+				fr: "Le Pokémon Défenseur ne peut pas battre en retraite pendant le prochain tour de votre adversaire.",
+			},
+		},
+		{
+			cost: [
+				"Colorless",
+				"Colorless",
+				"Colorless",
+			],
+			name: {
+				fr: "Enfoncement",
+			},
+			damage: "70",
+		},
+	],
+}
+
+export default card

--- a/data/McDonald's Collection/Collection McDonald's 2019 (FR)/9.ts
+++ b/data/McDonald's Collection/Collection McDonald's 2019 (FR)/9.ts
@@ -1,0 +1,41 @@
+import { Card } from '../../../interfaces'
+import Set from "../Collection McDonald's 2019 (FR)"
+
+const card: Card = {
+	name: {
+		fr: "Tortank",
+	},
+	rarity: "None",
+	category: "Pokemon",
+
+	set: Set,
+	dexId: [9],
+	hp: 140,
+	types: ["Water"],
+
+	stage: "Stage2",
+
+	variants: {
+		normal: false,
+		reverse: false,
+		holo: true,
+		firstEdition: false
+	},
+	attacks: [
+		{
+			cost: [
+				"Fire",
+				"Colorless",
+			],
+			name: {
+				fr: "Crocs Feu",
+			},
+			damage: "20",
+			effect: {
+				fr: "Le Pokémon Actif de votre adversaire est maintenant Brûlé.",
+			},
+		},
+	],
+}
+
+export default card


### PR DESCRIPTION
Set: **Collection McDonald's 2019 (FR)**
Series folder: `McDonald's Collection`
Changed card files: **40**

### Validation
- [ ] `bun run validate`
- [ ] `cd server && bun run --bun validate`
- [ ] `cd server && bun run compile`
- [ ] Manual review: translations, energy types, TS syntax

### Card images
See follow-up comments with embedded TCGdex assets.