### PR TITLE
fix(data): McDonald's Collection 2012 (McDonald's Collection)

### DIFF
--- a/data/McDonald's Collection/McDonald's Collection 2012.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2012.ts
@@ -1,0 +1,32 @@
+import { Set } from '../../interfaces'
+import serie from '../McDonald\'s Collection'
+
+const s2012bw: Set = {
+	id: "2012bw",
+
+	name: {
+		en: "McDonald's Collection 2012",
+		fr: "Collection McDonald's 2012",
+		es: "Colección de McDonald's 2012",
+		it: "McDonald's Collection 2012",
+	},
+
+	serie: serie,
+
+	cardCount: {
+		official: 12
+	},
+
+	releaseDate: "2012-06-15",
+
+	abbreviations: {
+		official: "MCD12",
+		fr: "M12"
+	},
+
+	thirdParty: {
+		tcgplayer: 1427
+	}
+}
+
+export default s2012bw

--- a/data/McDonald's Collection/McDonald's Collection 2012/1.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2012/1.ts
@@ -1,0 +1,59 @@
+import { Card } from '../../../interfaces'
+import Set from '../McDonald\'s Collection 2012'
+
+const card: Card = {
+	set: Set,
+	illustrator: "Kagemaru Himeno",
+	category: "Pokemon",
+
+	dexId: [496],
+
+	description: {
+		en: "They avoid attacks by sinking into the shadows of thick foliage. They retaliate with masterful whipping techniques."
+	},
+
+	stage: "Stage1",
+
+	attacks: [{
+		name: {
+			en: "Wrap",
+			fr: "Ligotage"
+		},
+
+		damage: 20,
+
+		effect: {
+			en: "Flip a coin. If heads, the Defending Pokémon is now Paralyzed.",
+			fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Paralysé."
+		}
+	}, {
+		name: {
+			en: "Tackle",
+			fr: "Charge"
+		},
+
+		damage: 30
+	}],
+
+	variants: {
+		normal: false,
+		reverse: false,
+		holo: true,
+		firstEdition: false
+	},
+
+	name: {
+		en: "Servine",
+		fr: "Lianaja"
+	},
+
+	rarity: "None",
+	hp: 80,
+	types: ["Grass"],
+
+	thirdParty: {
+		tcgplayer: 89081
+	}
+}
+
+export default card

--- a/data/McDonald's Collection/McDonald's Collection 2012/10.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2012/10.ts
@@ -1,0 +1,47 @@
+import { Card } from '../../../interfaces'
+import Set from '../McDonald\'s Collection 2012'
+
+const card: Card = {
+	set: Set,
+	illustrator: "Masakazu Fukuda",
+	category: "Pokemon",
+
+	dexId: [559],
+
+	description: {
+		en: "Its skin has a rubbery elasticity, so it can reduce damage by defensively pulling its skin up to its neck."
+	},
+
+	stage: "Basic",
+
+	attacks: [{
+		name: {
+			en: "Headbutt",
+			fr: "Coup d'Boule"
+		},
+
+		damage: 10
+	}],
+
+	variants: {
+		normal: false,
+		reverse: false,
+		holo: false,
+		firstEdition: false
+	},
+
+	name: {
+		en: "Scraggy",
+		fr: "Baggiguane"
+	},
+
+	rarity: "None",
+	hp: 60,
+	types: ["Darkness"],
+
+	thirdParty: {
+		tcgplayer: 88986
+	}
+}
+
+export default card

--- a/data/McDonald's Collection/McDonald's Collection 2012/11.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2012/11.ts
@@ -1,0 +1,62 @@
+import { Card } from '../../../interfaces'
+import Set from '../McDonald\'s Collection 2012'
+
+const card: Card = {
+	set: Set,
+	illustrator: "Kouki Saitou",
+	category: "Pokemon",
+
+	dexId: [600],
+
+	description: {
+		en: "Spinning minigears are rotated at high speed and repeatedly fired away. It is dangerous if the gears don’t return."
+	},
+
+	stage: "Stage1",
+
+	attacks: [{
+		name: {
+			en: "Metal Sound",
+			fr: "Strido-Son"
+		},
+
+		effect: {
+			en: "The Defending Pokémon is now Confused.",
+			fr: "Le Pokémon Défenseur est maintenant Confus."
+		}
+	}, {
+		name: {
+			en: "Guard Press",
+			fr: "Pression de Garde"
+		},
+
+		damage: 60,
+
+		effect: {
+			en: "During your opponent’s next turn, any damage done to this Pokémon by attacks is reduced by 20 (after applying Weakness and Resistance).",
+			fr: "Pendant le prochain tour de votre adversaire, tous les dégâts infligés à ce Pokémon par des attaques sont réduits de 20 (après application de la Faiblesse et de la Résistance)."
+		}
+	}],
+
+	variants: {
+		normal: false,
+		reverse: false,
+		holo: false,
+		firstEdition: false
+	},
+
+	name: {
+		en: "Klang",
+		fr: "Clic"
+	},
+
+	rarity: "None",
+	hp: 80,
+	types: ["Metal"],
+
+	thirdParty: {
+		tcgplayer: 86478
+	}
+}
+
+export default card

--- a/data/McDonald's Collection/McDonald's Collection 2012/12.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2012/12.ts
@@ -1,0 +1,52 @@
+import { Card } from '../../../interfaces'
+import Set from '../McDonald\'s Collection 2012'
+
+const card: Card = {
+	set: Set,
+	illustrator: "Atsuko Nishida",
+	category: "Pokemon",
+
+	dexId: [610],
+
+	description: {
+		en: "They use their tusks to crush the berries they eat. Repeated regrowth makes their tusks strong and sharp."
+	},
+
+	stage: "Basic",
+
+	attacks: [{
+		name: {
+			en: "Dual Chop",
+			fr: "Double Baffe"
+		},
+
+		damage: "10×",
+
+		effect: {
+			en: "Flip 2 coins. This attack does 10 damage times the number of heads.",
+			fr: "Lancez 2 pièces. Cette attaque inflige 10 dégâts multipliés par le nombre de côtés face."
+		}
+	}],
+
+	variants: {
+		normal: false,
+		reverse: false,
+		holo: false,
+		firstEdition: false
+	},
+
+	name: {
+		en: "Axew",
+		fr: "Coupenotte"
+	},
+
+	rarity: "None",
+	hp: 60,
+	types: ["Colorless"],
+
+	thirdParty: {
+		tcgplayer: 83673
+	}
+}
+
+export default card

--- a/data/McDonald's Collection/McDonald's Collection 2012/2.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2012/2.ts
@@ -1,0 +1,57 @@
+import { Card } from '../../../interfaces'
+import Set from '../McDonald\'s Collection 2012'
+
+const card: Card = {
+	set: Set,
+	illustrator: "Kouki Saitou",
+	category: "Pokemon",
+
+	dexId: [511],
+
+	description: {
+		en: "This Pokémon dwells deep in the forest. Eating a leaf from its head whisks weariness away as if by magic."
+	},
+
+	stage: "Basic",
+
+	attacks: [{
+		name: {
+			en: "Collect",
+			fr: "Collecte"
+		},
+
+		effect: {
+			en: "Draw a card.",
+			fr: "Piochez une carte."
+		}
+	}, {
+		name: {
+			en: "Scratch",
+			fr: "Griffe"
+		},
+
+		damage: 20
+	}],
+
+	variants: {
+		normal: false,
+		reverse: false,
+		holo: true,
+		firstEdition: false
+	},
+
+	name: {
+		en: "Pansage",
+		fr: "Feuillajou"
+	},
+
+	rarity: "None",
+	hp: 70,
+	types: ["Grass"],
+
+	thirdParty: {
+		tcgplayer: 87937
+	}
+}
+
+export default card

--- a/data/McDonald's Collection/McDonald's Collection 2012/3.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2012/3.ts
@@ -1,0 +1,57 @@
+import { Card } from '../../../interfaces'
+import Set from '../McDonald\'s Collection 2012'
+
+const card: Card = {
+	set: Set,
+	illustrator: "MAHOU",
+	category: "Pokemon",
+
+	dexId: [557],
+
+	description: {
+		en: "The Pokémon can easily melt holes in hard rocks with a liquid secreted from its mouth."
+	},
+
+	stage: "Basic",
+
+	attacks: [{
+		name: {
+			en: "Withdraw",
+			fr: "Repli"
+		},
+
+		effect: {
+			en: "Flip a coin. If heads, prevent all damage done to this Pokémon by attacks during your opponent’s next turn.",
+			fr: "Lancez une pièce. Si c'est face, évitez tous les dégâts infligés à ce Pokémon par des attaques durant le prochain tour de votre adversaire."
+		}
+	}, {
+		name: {
+			en: "Slash",
+			fr: "Tranche"
+		},
+
+		damage: 20
+	}],
+
+	variants: {
+		normal: false,
+		reverse: false,
+		holo: true,
+		firstEdition: false
+	},
+
+	name: {
+		en: "Dwebble",
+		fr: "Crabicoque"
+	},
+
+	rarity: "None",
+	hp: 60,
+	types: ["Grass"],
+
+	thirdParty: {
+		tcgplayer: 85065
+	}
+}
+
+export default card

--- a/data/McDonald's Collection/McDonald's Collection 2012/4.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2012/4.ts
@@ -1,0 +1,57 @@
+import { Card } from '../../../interfaces'
+import Set from '../McDonald\'s Collection 2012'
+
+const card: Card = {
+	set: Set,
+	illustrator: "Kouki Saitou",
+	category: "Pokemon",
+
+	dexId: [499],
+
+	description: {
+		en: "When its internal fire flares up, its movements grow sharper and faster. When in trouble, it emits smoke."
+	},
+
+	stage: "Stage1",
+
+	attacks: [{
+		name: {
+			en: "Flame Charge",
+			fr: "Nitrocharge"
+		},
+
+		effect: {
+			en: "Search your deck for a Fire Energy card and attach it to this Pokémon. Shuffle your deck afterward.",
+			fr: "Cherchez une carte Énergie  dans votre deck et attachez-la à ce Pokémon. Mélangez ensuite votre deck."
+		}
+	}, {
+		name: {
+			en: "Heat Crash",
+			fr: "Tacle Feu"
+		},
+
+		damage: 50
+	}],
+
+	variants: {
+		normal: false,
+		reverse: false,
+		holo: false,
+		firstEdition: false
+	},
+
+	name: {
+		en: "Pignite",
+		fr: "Grotichon"
+	},
+
+	rarity: "None",
+	hp: 100,
+	types: ["Fire"],
+
+	thirdParty: {
+		tcgplayer: 88064
+	}
+}
+
+export default card

--- a/data/McDonald's Collection/McDonald's Collection 2012/5.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2012/5.ts
@@ -1,0 +1,59 @@
+import { Card } from '../../../interfaces'
+import Set from '../McDonald\'s Collection 2012'
+
+const card: Card = {
+	set: Set,
+	illustrator: "Masakazu Fukuda",
+	category: "Pokemon",
+
+	dexId: [502],
+
+	description: {
+		en: "Scalchop techniques differ from one Dewott to another. It never neglects maintaining its scalchops."
+	},
+
+	stage: "Stage1",
+
+	attacks: [{
+		name: {
+			en: "Water Gun",
+			fr: "Pistolet à O"
+		},
+
+		damage: 30
+	}, {
+		name: {
+			en: "Razor Shell",
+			fr: "Coquilame"
+		},
+
+		damage: "40+",
+
+		effect: {
+			en: "Flip a coin. If heads, this attack does 20 more damage.",
+			fr: "Lancez une pièce. Si c'est face, cette attaque inflige 20 dégâts supplémentaires."
+		}
+	}],
+
+	variants: {
+		normal: false,
+		reverse: false,
+		holo: false,
+		firstEdition: false
+	},
+
+	name: {
+		en: "Dewott",
+		fr: "Mateloutre"
+	},
+
+	rarity: "None",
+	hp: 90,
+	types: ["Water"],
+
+	thirdParty: {
+		tcgplayer: 84797
+	}
+}
+
+export default card

--- a/data/McDonald's Collection/McDonald's Collection 2012/6.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2012/6.ts
@@ -1,0 +1,64 @@
+import { Card } from '../../../interfaces'
+import Set from '../McDonald\'s Collection 2012'
+
+const card: Card = {
+	set: Set,
+	illustrator: "Kouki Saitou",
+	category: "Pokemon",
+
+	dexId: [587],
+
+	description: {
+		en: "The energy made in its cheeks’ electric pouches is stored inside its membranes and released while it is gliding."
+	},
+
+	stage: "Basic",
+
+	attacks: [{
+		name: {
+			en: "Thundershock",
+			fr: "Éclair"
+		},
+
+		damage: 10,
+
+		effect: {
+			en: "Flip a coin. If heads, the Defending Pokémon is now Paralyzed.",
+			fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est Paralysé."
+		}
+	}, {
+		name: {
+			en: "Acrobatics",
+			fr: "Acrobatie"
+		},
+
+		damage: "10+",
+
+		effect: {
+			en: "Flip 2 coins. This attack does 20 more damage for each heads.",
+			fr: "Lancez 2 pièces. Cette attaque inflige 20 dégâts supplémentaires pour chaque côté face."
+		}
+	}],
+
+	variants: {
+		normal: false,
+		reverse: false,
+		holo: true,
+		firstEdition: false
+	},
+
+	name: {
+		en: "Emolga",
+		fr: "Emolga"
+	},
+
+	rarity: "None",
+	hp: 70,
+	types: ["Lightning"],
+
+	thirdParty: {
+		tcgplayer: 85193
+	}
+}
+
+export default card

--- a/data/McDonald's Collection/McDonald's Collection 2012/7.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2012/7.ts
@@ -1,0 +1,52 @@
+import { Card } from '../../../interfaces'
+import Set from '../McDonald\'s Collection 2012'
+
+const card: Card = {
+	set: Set,
+	illustrator: "Masakazu Fukuda",
+	category: "Pokemon",
+
+	dexId: [527],
+
+	description: {
+		en: "Its habitat is dark forests and caves. It emits ultrasonic waves from its nose to learn about its surroundings."
+	},
+
+	stage: "Basic",
+
+	attacks: [{
+		name: {
+			en: "Psy Bolt",
+			fr: "Choc Mental"
+		},
+
+		damage: 20,
+
+		effect: {
+			en: "Flip a coin. If heads, the Defending Pokémon is now Paralyzed.",
+			fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Paralysé."
+		}
+	}],
+
+	variants: {
+		normal: false,
+		reverse: false,
+		holo: true,
+		firstEdition: false
+	},
+
+	name: {
+		en: "Woobat",
+		fr: "Chovsourir"
+	},
+
+	rarity: "None",
+	hp: 60,
+	types: ["Psychic"],
+
+	thirdParty: {
+		tcgplayer: 90629
+	}
+}
+
+export default card

--- a/data/McDonald's Collection/McDonald's Collection 2012/8.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2012/8.ts
@@ -1,0 +1,53 @@
+import { Card } from '../../../interfaces'
+import Set from '../McDonald\'s Collection 2012'
+
+const card: Card = {
+	set: Set,
+	illustrator: "match",
+	category: "Pokemon",
+	description: {
+		en: "It can dig through the ground at a speed of 30 mph. It could give a car running aboveground a good race.",
+	},
+	stage: "Basic",
+	attacks: [
+		{
+			name: {
+				en: "Hone Claws",
+				fr: "Aiguisage",
+			},
+			effect: {
+				en: "During your next turn, each of this Pokémon’s attacks does 30 more damage (before applying Weakness and Resistance).\nFighting",
+				fr: "Pendant votre prochain tour, chaque attaque de ce Pokémon inflige 30 dégâts supplémentaires (avant application de la Faiblesse et de la Résistance).",
+			},
+		},
+		{
+			cost: [
+				"Fighting",
+			],
+			name: {
+				fr: "Griffe",
+			},
+			damage: "10",
+		},
+	],
+	variants: {
+		normal: false,
+		reverse: false,
+		holo: true,
+		firstEdition: false,
+	},
+	name: {
+		en: "Drilbur",
+		fr: "Rototaupe",
+	},
+	rarity: "None",
+	hp: 70,
+	types: [
+		"Fighting",
+	],
+	thirdParty: {
+		tcgplayer: 84967,
+	},
+}
+
+export default card

--- a/data/McDonald's Collection/McDonald's Collection 2012/9.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2012/9.ts
@@ -1,0 +1,52 @@
+import { Card } from '../../../interfaces'
+import Set from '../McDonald\'s Collection 2012'
+
+const card: Card = {
+	set: Set,
+	illustrator: "Atsuko Nishida",
+	category: "Pokemon",
+
+	dexId: [509],
+
+	description: {
+		en: "They steal from people for fun, but their victims can’t help but forgive them. Their deceptively cute act is perfect."
+	},
+
+	stage: "Basic",
+
+	attacks: [{
+		name: {
+			en: "Knock Off",
+			fr: "Sabotage"
+		},
+
+		damage: 20,
+
+		effect: {
+			en: "Flip a coin. If heads, discard a random card from your opponent’s hand.",
+			fr: "Lancez une pièce. Si c'est face, défaussez au hasard une carte de la main de votre adversaire."
+		}
+	}],
+
+	variants: {
+		normal: false,
+		reverse: false,
+		holo: true,
+		firstEdition: false
+	},
+
+	name: {
+		en: "Purrloin",
+		fr: "Chacripan"
+	},
+
+	rarity: "None",
+	hp: 60,
+	types: ["Darkness"],
+
+	thirdParty: {
+		tcgplayer: 88463
+	}
+}
+
+export default card


### PR DESCRIPTION
Set: **McDonald's Collection 2012**
Series folder: `McDonald's Collection`
Changed card files: **12**

### Validation
- [ ] `bun run validate`
- [ ] `cd server && bun run --bun validate`
- [ ] `cd server && bun run compile`
- [ ] Manual review: translations, energy types, TS syntax

### Card images
See follow-up comments with embedded TCGdex assets.