### PR TITLE
fix(data): McDonald's Collection 2014 (McDonald's Collection)

### DIFF
--- a/data/McDonald's Collection/McDonald's Collection 2014.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2014.ts
@@ -1,0 +1,31 @@
+import { Set } from '../../interfaces'
+import serie from '../McDonald\'s Collection'
+
+const s2014xy: Set = {
+	id: "2014xy",
+
+	name: {
+		en: "McDonald's Collection 2014",
+		fr: "Collection McDonald's 2014",
+		it: "McDonald's Collection 2014",
+	},
+
+	serie: serie,
+
+	cardCount: {
+		official: 12
+	},
+
+	releaseDate: "2014-05-23",
+
+	abbreviations: {
+		official: "MCD14",
+		fr: "M14"
+	},
+
+	thirdParty: {
+		tcgplayer: 1692
+	}
+}
+
+export default s2014xy

--- a/data/McDonald's Collection/McDonald's Collection 2014/1.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2014/1.ts
@@ -1,0 +1,61 @@
+import { Card } from '../../../interfaces'
+import Set from '../McDonald\'s Collection 2014'
+
+const card: Card = {
+	dexId: [
+		13,
+	],
+	set: Set,
+	illustrator: 'Akira Komayama',
+	description: {
+		en: "Often found in forests and grasslands. It has a sharp, toxic barb of around two inches on top of its head."
+	},
+	variants: {
+		normal: false,
+		reverse: false,
+		holo: true,
+		firstEdition: false,
+	},
+	name: {
+		en: "Weedle",
+		fr: "Aspicot",
+	},
+	rarity: "None",
+	category: "Pokemon",
+	hp: 40,
+	types: [
+		"Grass",
+	],
+	stage: "Basic",
+	thirdParty: {
+		tcgplayer: 110406,
+	},
+	attacks: [
+		{
+			cost: [
+				"Grass",
+			],
+			name: {
+				en: "String Shot",
+				fr: "Sécrétion",
+			},
+			damage: "10",
+			effect: {
+				en: "Flip a coin. If heads, your opponent's Active Pokémon is now Paralyzed.",
+				fr: "Lancez une pièce. Si c'est face, le Pokémon Actif de votre adversaire est maintenant Paralysé.",
+			},
+		},
+	],
+	weaknesses	: [
+		{
+			type: "Fire",
+			value: "×2"
+		},
+	],
+	resistances: [
+		
+	],
+	retreat: 1,
+}
+
+export default card

--- a/data/McDonald's Collection/McDonald's Collection 2014/10.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2014/10.ts
@@ -1,0 +1,58 @@
+import { Card } from '../../../interfaces'
+import Set from '../McDonald\'s Collection 2014'
+
+const card: Card = {
+	dexId: [
+		659,
+	],
+	illustrator: "5ban Graphics",
+	description: {
+		en: "They use their large ears to dig burrows. They will dig the whole night through."
+	},
+	set: Set,
+	variants: {
+		normal: false,
+		reverse: false,
+		holo: true,
+		firstEdition: false,
+	},
+	name: {
+		en: "Bunnelby",
+		fr: "Sapereau",
+	},
+	rarity: "None",
+	category: "Pokemon",
+	hp: 60,
+	types: [
+		"Colorless",
+	],
+	stage: "Basic",
+	thirdParty: {
+		tcgplayer: 110415,
+	},
+	attacks: [
+		{
+			cost: [
+				"Colorless",
+				"Colorless",
+			],
+			name: {
+				en: "Tackle",
+				fr: "Charge",
+			},
+			damage: "20",
+		},
+	],
+	weaknesses: [
+		{
+			type: "Fighting",
+			value: "×2"
+		},
+	],
+	resistances: [
+		
+	],
+	retreat: 2,
+}
+
+export default card

--- a/data/McDonald's Collection/McDonald's Collection 2014/11.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2014/11.ts
@@ -1,0 +1,45 @@
+import { Card } from '../../../interfaces'
+import Set from '../McDonald\'s Collection 2014'
+
+const card: Card = {
+	dexId: [
+		661,
+	],
+	set: Set,
+	variants: {
+		normal: false,
+		reverse: false,
+		holo: true,
+		firstEdition: false,
+	},
+	name: {
+		en: "Fletchling",
+		fr: "Passerouge",
+	},
+	rarity: "None",
+	category: "Pokemon",
+	hp: 50,
+	types: [
+		"Colorless",
+	],
+	stage: "Basic",
+	thirdParty: {
+		tcgplayer: 110416,
+	},
+	attacks: [
+		{
+			cost: [
+				"Colorless",
+			],
+			name: {
+				fr: "Coupe-Vent",
+			},
+			damage: "20",
+			effect: {
+				fr: "Lancez une pièce. Si c'est pile, cette attaque ne fait rien.",
+			},
+		},
+	],
+}
+
+export default card

--- a/data/McDonald's Collection/McDonald's Collection 2014/12.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2014/12.ts
@@ -1,0 +1,74 @@
+import { Card } from '../../../interfaces'
+import Set from '../McDonald\'s Collection 2014'
+
+const card: Card = {
+	dexId: [
+		676,
+	],
+	illustrator: "5ban Graphics",
+	description: {
+		en: "Trimming its fluffy fur not only makes it more elegant but also increases the swiftness of its movements."
+	},
+	set: Set,
+	variants: {
+		normal: false,
+		reverse: false,
+		holo: true,
+		firstEdition: false,
+	},
+	name: {
+		en: "Furfrou",
+		fr: "Couafarel",
+	},
+	rarity: "None",
+	category: "Pokemon",
+	hp: 90,
+	types: [
+		"Colorless",
+	],
+	stage: "Basic",
+	thirdParty: {
+		tcgplayer: 110417,
+	},
+	attacks: [
+		{
+			cost: [
+				"Colorless",
+				"Colorless",
+			],
+			name: {
+				en: "Tight Jaw",
+				fr: "Mâchoire Serrée",
+			},
+			damage: "20",
+			effect: {
+				en: "Flip a coin. If heads, your opponent's Active Pokémon is now Paralyzed.",
+				fr: "Lancez une pièce. Si c'est face, le Pokémon Actif de votre adversaire est maintenant Paralysé.",
+			},
+		},
+		{
+			cost: [
+				"Colorless",
+				"Colorless",
+				"Colorless",
+			],
+			name: {
+				en: "Sharp Fang",
+				fr: "Croc Aiguisé",
+			},
+			damage: "50",
+		},
+	],
+	weaknesses: [
+		{
+			type: "Fighting",
+			value: "×2"
+		},
+	],
+	resistances: [
+
+	],
+	retreat: 1,
+}
+
+export default card

--- a/data/McDonald's Collection/McDonald's Collection 2014/2.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2014/2.ts
@@ -1,0 +1,69 @@
+import { Card } from '../../../interfaces'
+import Set from '../McDonald\'s Collection 2014'
+
+const card: Card = {
+	dexId: [
+		650,
+	],
+	set: Set,
+	illustrator: '5ban Graphics',
+	category: "Pokemon",
+	description: {
+		en: "The quills on its head are usually soft. When it flexes them, the points become so hard and sharp that they can pierce rock.",
+	},
+	variants: {
+		normal: false,
+		reverse: false,
+		holo: true,
+		firstEdition: false,
+	},
+	name: {
+		en: "Chespin",
+		fr: "Marisson",
+	},
+	rarity: "None",
+	
+	hp: 60,
+	types: [
+		"Grass",
+	],
+	stage: "Basic",
+	thirdParty: {
+		tcgplayer: 110407,
+	},
+	attacks: [
+		{
+			cost: [
+				"Grass",
+			],
+			name: {
+				en: "Vine Whip",
+				fr: "Fouet Lianes",
+			},
+			damage: "10",
+		},
+		{
+			cost: [
+				"Grass",
+				"Colorless",
+			],
+			name: {
+				en: "Seed Bomb",
+				fr: "Canon Graine",
+			},
+			damage: "20",
+		},
+	],
+	weaknesses: [
+		{
+			type: "Fire",
+			value: "×2"
+		},
+	],
+	resistances: [
+		
+	],
+	retreat: 1,
+}
+
+export default card

--- a/data/McDonald's Collection/McDonald's Collection 2014/3.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2014/3.ts
@@ -1,0 +1,68 @@
+import { Card } from '../../../interfaces'
+import Set from '../McDonald\'s Collection 2014'
+
+const card: Card = {
+	dexId: [
+		653,
+	],
+	illustrator: "5ban Graphics",
+	set: Set,
+	description: {
+		en: "Eating a twig fills it with energy, and its roomy ears give vent to air hotter than 390 degrees Fahrenheit."
+	},
+	variants: {
+		normal: false,
+		reverse: false,
+		holo: true,
+		firstEdition: false,
+	},
+	name: {
+		en: "Fennekin",
+		fr: "Feunnec",
+	},
+	rarity: "None",
+	category: "Pokemon",
+	hp: 60,
+	types: [
+		"Fire",
+	],
+	stage: "Basic",
+	thirdParty: {
+		tcgplayer: 110408,
+	},
+	attacks: [
+		{
+			cost: [
+				"Fire",
+			],
+			name: {
+				en: "Scratch",
+				fr: "Griffe",
+			},
+			damage: "10",
+		},
+		{
+			cost: [
+				"Fire",
+				"Colorless",
+			],
+			name: {
+				en: "Live Coal",
+				fr: "Charbon Mutant",
+			},
+			damage: "20",
+		},
+	],
+	weaknesses: [
+		{
+			type: "Water",
+			value: "×2"
+		},
+	],
+	resistances: [
+		
+	],
+	retreat: 1,
+}
+
+export default card

--- a/data/McDonald's Collection/McDonald's Collection 2014/4.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2014/4.ts
@@ -1,0 +1,69 @@
+import { Card } from '../../../interfaces'
+import Set from '../McDonald\'s Collection 2014'
+
+const card: Card = {
+	dexId: [
+		656,
+	],
+	set: Set,
+	illustrator: '5ban Graphics',
+	description: {
+		en: "It secretes flexible bubbles from its chest and back. The bubbles reduce the damage it would otherwise take when attacked."
+	},
+	variants: {
+		normal: false,
+		reverse: false,
+		holo: true,
+		firstEdition: false,
+	},
+	name: {
+		en: "Froakie",
+		fr: "Grenousse",
+	},
+	rarity: "None",
+	category: "Pokemon",
+	hp: 60,
+	types: [
+		"Water",
+	],
+	stage: "Basic",
+	thirdParty: {
+		tcgplayer: 110409,
+	},
+	attacks: [
+		{
+			cost: [
+				"Water",
+			],
+			name: {
+				en: "Pound",
+				fr: "Écras'Face",
+			},
+			damage: "10",
+		},
+		{
+			cost: [
+				"Water",
+				"Colorless",
+			],
+			name: {
+				en: "Water Drip",
+				fr: "Goutte à Goutte",
+			},
+			damage: "20",
+		},
+	],
+	weaknesses: [
+		{
+			type: "Grass",
+			value: "×2"
+		},
+	],
+	resistances: [
+		
+	],
+	retreat: 1,
+
+}
+
+export default card

--- a/data/McDonald's Collection/McDonald's Collection 2014/5.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2014/5.ts
@@ -1,0 +1,78 @@
+import { Card } from '../../../interfaces'
+import Set from '../McDonald\'s Collection 2014'
+
+const card: Card = {
+	dexId: [
+		25,
+	],
+	set: Set,
+	illustrator: "MAHOU",
+	description: {
+		en: "It raises its tail to check its surroundings. The tail is sometimes struck by lightning in this pose.",
+	},
+	variants: {
+		normal: false,
+		reverse: false,
+		holo: true,
+		firstEdition: false,
+	},
+	name: {
+		en: "Pikachu",
+		fr: "Pikachu",
+	},
+	rarity: "None",
+	category: "Pokemon",
+	hp: 60,
+	types: [
+		"Lightning",
+	],
+	stage: "Basic",
+	thirdParty: {
+		tcgplayer: 110410,
+	},
+	attacks: [
+		{
+			cost: [
+				"Colorless",
+			],
+			name: {
+				en: "Nuzzle",
+				fr: "Frotte-Frimousse",
+			},
+			effect: {
+				en: "Flip a coin. If heads, your opponent's Active Pokémon is now Paralyzed.",
+				fr: "Lancez une pièce. Si c'est face, le Pokémon Actif de votre adversaire est maintenant Paralysé.",
+			},
+		},
+		{
+			cost: [
+				"Colorless",
+				"Colorless",
+			],
+			name: {
+				en: "Quick Attack",
+				fr: "Vive-Attaque",
+			},
+			damage: "20+",
+			effect: {
+				en: "Flip a coin. If heads, this attack does 10 more damage.",
+				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 10 dégâts supplémentaires.",
+			},
+		},
+	],
+	weaknesses: [
+		{
+			type: "Fighting",
+			value: "×2"
+		},
+	],
+	resistances: [
+		{
+			type: "Metal",
+			value: "-20"
+		}
+	],
+	retreat: 1,
+}
+
+export default card

--- a/data/McDonald's Collection/McDonald's Collection 2014/6.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2014/6.ts
@@ -1,0 +1,60 @@
+import { Card } from '../../../interfaces'
+import Set from '../McDonald\'s Collection 2014'
+
+const card: Card = {
+	dexId: [
+		686,
+	],
+	illustrator: "5ban Graphics",
+	description: {
+		en: "Opponents who stare at the flashing of the light-emitting spots on its body become dazed and lose their will to fight."
+	},
+	set: Set,
+	variants: {
+		normal: false,
+		reverse: false,
+		holo: true,
+		firstEdition: false,
+	},
+	name: {
+		en: "Inkay",
+		fr: "Sepiatop",
+	},
+	rarity: "None",
+	category: "Pokemon",
+	hp: 60,
+	types: [
+		"Darkness",
+	],
+	stage: "Basic",
+	thirdParty: {
+		tcgplayer: 110411,
+	},
+	attacks: [
+		{
+			cost: [
+				"Darkness",
+			],
+			name: {
+				en: "Peck",
+				fr: "Picpic",
+			},
+			damage: "10",
+		},
+	],
+	weaknesses: [
+		{
+			type: "Fighting",
+			value: "×2"
+		},
+	],
+	resistances: [
+		{
+			type: "Psychic",
+			value: "-20"
+		}
+	],
+	retreat: 1,
+}
+
+export default card

--- a/data/McDonald's Collection/McDonald's Collection 2014/7.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2014/7.ts
@@ -1,0 +1,65 @@
+import { Card } from '../../../interfaces'
+import Set from '../McDonald\'s Collection 2014'
+
+const card: Card = {
+	dexId: [
+		679,
+	],
+	illustrator: "5ban Graphics",
+	description: {
+		en: "Apparently this Pokémon is born when a departed spirit inhabits a sword. It attaches itself to people and drinks their life force."
+	},
+	set: Set,
+	variants: {
+		normal: false,
+		reverse: false,
+		holo: true,
+		firstEdition: false,
+	},
+	name: {
+		en: "Honedge",
+		fr: "Monorpale",
+	},
+	rarity: "None",
+	category: "Pokemon",
+	hp: 60,
+	types: [
+		"Metal",
+	],
+	stage: "Basic",
+	thirdParty: {
+		tcgplayer: 110412,
+	},
+	attacks: [
+		{
+			cost: [
+				"Metal",
+				"Colorless",
+			],
+			name: {
+				en: "Continuous Slice",
+				fr: "Perpétranche",
+			},
+			damage: "30×",
+			effect: {
+				en: "Flip a coin until you get tails. This attack does 30 damage times the number of heads.",
+				fr: "Lancez une pièce jusqu'à ce que vous obteniez un côté pile. Cette attaque inflige 30 dégâts multipliés par le nombre de côtés face.",
+			},
+		},
+	],
+	weaknesses: [
+		{
+			type: "Fire",
+			value: "×2"
+		},
+	],
+	resistances: [
+		{
+			type: "Psychic",
+			value: "-20"
+		}
+	],
+	retreat: 2,
+}
+
+export default card

--- a/data/McDonald's Collection/McDonald's Collection 2014/8.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2014/8.ts
@@ -1,0 +1,62 @@
+import { Card } from '../../../interfaces'
+import Set from '../McDonald\'s Collection 2014'
+
+const card: Card = {
+	dexId: [
+		209,
+	],
+	set: Set,
+	illustrator: "Naoki Saito",
+	description: {
+		en: "It has an active, playful nature. Many women like to frolic with it because of its affectionate ways.",
+	},
+	variants: {
+		normal: false,
+		reverse: false,
+		holo: true,
+		firstEdition: false,
+	},
+	name: {
+		en: "Snubbull",
+		fr: "Snubbull",
+	},
+	rarity: "None",
+	category: "Pokemon",
+	hp: 70,
+	types: [
+		"Fairy",
+	],
+	stage: "Basic",
+	thirdParty: {
+		tcgplayer: 110413,
+	},
+	attacks: [
+		{
+			cost: [
+				"Fairy",
+				"Colorless",
+			],
+			name: {
+				en: "Headbutt",
+				fr: "Coup d'Boule",
+			},
+			damage: "20",
+		},
+	],
+	weaknesses: [
+		{
+			type: "Metal",
+			value: "×2"
+		},
+	],
+	resistances: [
+		{
+			type: "Darkness",
+			value: "-20"
+		}
+	],
+	retreat: 2,
+
+}
+
+export default card

--- a/data/McDonald's Collection/McDonald's Collection 2014/9.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2014/9.ts
@@ -1,0 +1,63 @@
+import { Card } from '../../../interfaces'
+import Set from '../McDonald\'s Collection 2014'
+
+const card: Card = {
+	dexId: [
+		684,
+	],
+	illustrator: "5ban Graphics",
+	description: {
+		en: "To entangle its opponents in battle, it extrudes white threads as sweet and sticky as cotton candy."
+	},
+	set: Set,
+	variants: {
+		normal: false,
+		reverse: false,
+		holo: true,
+		firstEdition: false,
+	},
+	name: {
+		en: "Swirlix",
+		fr: "Sucroquin",
+	},
+	rarity: "None",
+	category: "Pokemon",
+	hp: 60,
+	types: [
+		"Fairy",
+	],
+	stage: "Basic",
+	thirdParty: {
+		tcgplayer: 110414,
+	},
+	attacks: [
+		{
+			cost: [
+				"Fairy",
+			],
+			name: {
+				en: "Draining Kiss",
+				fr: "Vampibaiser",
+			},
+			damage: "10",
+			effect: {
+				en: "Heal 10 damage from this Pokémon."
+			}
+		},
+	],
+	weaknesses: [
+		{
+			type: "Metal",
+			value: "×2"
+		},
+	],
+	resistances: [
+		{
+			type: "Darkness",
+			value: "-20"
+		}
+	],
+	retreat: 1,
+}
+
+export default card


### PR DESCRIPTION
Set: **McDonald's Collection 2014**
Series folder: `McDonald's Collection`
Changed card files: **12**

### Validation
- [ ] `bun run validate`
- [ ] `cd server && bun run --bun validate`
- [ ] `cd server && bun run compile`
- [ ] Manual review: translations, energy types, TS syntax

### Card images
See follow-up comments with embedded TCGdex assets.