### PR TITLE
fix(data): McDonald's Collection 2015 (McDonald's Collection)

### DIFF
--- a/data/McDonald's Collection/McDonald's Collection 2015.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2015.ts
@@ -1,0 +1,31 @@
+import { Set } from '../../interfaces'
+import serie from '../McDonald\'s Collection'
+
+const s2015xy: Set = {
+	id: "2015xy",
+
+	name: {
+		en: "McDonald's Collection 2015",
+		fr: "Collection McDonald's 2015",
+		it: "McDonald's Collection 2015"
+	},
+
+	serie: serie,
+
+	cardCount: {
+		official: 12
+	},
+
+	releaseDate: "2015-11-27",
+
+	abbreviations: {
+		official: "MCD15",
+		fr: "M15"
+	},
+
+	thirdParty: {
+		tcgplayer: 1694
+	}
+}
+
+export default s2015xy

--- a/data/McDonald's Collection/McDonald's Collection 2015/1.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2015/1.ts
@@ -1,0 +1,45 @@
+import { Card } from '../../../interfaces'
+import Set from '../McDonald\'s Collection 2015'
+
+const card: Card = {
+	dexId: [
+		252,
+	],
+	set: Set,
+	variants: {
+		normal: false,
+		reverse: false,
+		holo: true,
+		firstEdition: false,
+	},
+	name: {
+		en: "Treecko",
+		fr: "Arcko",
+	},
+	rarity: "None",
+	category: "Pokemon",
+	hp: 60,
+	types: [
+		"Grass",
+	],
+	stage: "Basic",
+	thirdParty: {
+		tcgplayer: 110429,
+	},
+	attacks: [
+		{
+			cost: [
+				"Grass",
+			],
+			name: {
+				fr: "Vive-Attaque",
+			},
+			damage: "10+",
+			effect: {
+				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 10 dégâts supplémentaires.",
+			},
+		},
+	],
+}
+
+export default card

--- a/data/McDonald's Collection/McDonald's Collection 2015/10.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2015/10.ts
@@ -1,0 +1,52 @@
+import { Card } from '../../../interfaces'
+import Set from '../McDonald\'s Collection 2015'
+
+const card: Card = {
+	dexId: [
+		183,
+	],
+	set: Set,
+	variants: {
+		normal: false,
+		reverse: false,
+		holo: true,
+		firstEdition: false,
+	},
+	name: {
+		en: "Marill",
+		fr: "Marill",
+	},
+	rarity: "None",
+	category: "Pokemon",
+	hp: 70,
+	types: [
+		"Fairy",
+	],
+	stage: "Basic",
+	thirdParty: {
+		tcgplayer: 110430,
+	},
+	attacks: [
+		{
+			cost: [
+				"Colorless",
+			],
+			name: {
+				fr: "Charge",
+			},
+			damage: "10",
+		},
+		{
+			cost: [
+				"Fairy",
+				"Colorless",
+			],
+			name: {
+				fr: "Roulade",
+			},
+			damage: "20",
+		},
+	],
+}
+
+export default card

--- a/data/McDonald's Collection/McDonald's Collection 2015/11.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2015/11.ts
@@ -1,0 +1,54 @@
+import { Card } from '../../../interfaces'
+import Set from '../McDonald\'s Collection 2015'
+
+const card: Card = {
+	dexId: [
+		263,
+	],
+	set: Set,
+	variants: {
+		normal: false,
+		reverse: false,
+		holo: true,
+		firstEdition: false,
+	},
+	name: {
+		en: "Zigzagoon",
+		fr: "Zigzaton",
+	},
+	rarity: "None",
+	category: "Pokemon",
+	hp: 60,
+	types: [
+		"Colorless",
+	],
+	stage: "Basic",
+	thirdParty: {
+		tcgplayer: 110423,
+	},
+	attacks: [
+		{
+			cost: [
+				"Colorless",
+			],
+			name: {
+				fr: "Jet de Sable",
+			},
+			effect: {
+				fr: "Si le Pokémon Défenseur essaie d'attaquer pendant le prochain tour de votre adversaire, ce dernier lance une pièce. Si c'est pile, son attaque ne fait rien.",
+			},
+		},
+		{
+			cost: [
+				"Colorless",
+				"Colorless",
+			],
+			name: {
+				fr: "Coup d'Boule",
+			},
+			damage: "20",
+		},
+	],
+}
+
+export default card

--- a/data/McDonald's Collection/McDonald's Collection 2015/12.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2015/12.ts
@@ -1,0 +1,54 @@
+import { Card } from '../../../interfaces'
+import Set from '../McDonald\'s Collection 2015'
+
+const card: Card = {
+	dexId: [
+		300,
+	],
+	set: Set,
+	variants: {
+		normal: false,
+		reverse: false,
+		holo: true,
+		firstEdition: false,
+	},
+	name: {
+		en: "Skitty",
+		fr: "Skitty",
+	},
+	rarity: "None",
+	category: "Pokemon",
+	hp: 50,
+	types: [
+		"Colorless",
+	],
+	stage: "Basic",
+	thirdParty: {
+		tcgplayer: 110432,
+	},
+	attacks: [
+		{
+			cost: [
+				"Colorless",
+			],
+			name: {
+				fr: "Charme",
+			},
+			effect: {
+				fr: "Pendant le prochain tour de votre adversaire, tous les dégâts infligés par des attaques du Pokémon Défenseur sont réduits de 20 (avant application de la Faiblesse et de la Résistance).",
+			},
+		},
+		{
+			cost: [
+				"Colorless",
+				"Colorless",
+			],
+			name: {
+				fr: "Coup de Queue",
+			},
+			damage: "20",
+		},
+	],
+}
+
+export default card

--- a/data/McDonald's Collection/McDonald's Collection 2015/2.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2015/2.ts
@@ -1,0 +1,43 @@
+import { Card } from '../../../interfaces'
+import Set from '../McDonald\'s Collection 2015'
+
+const card: Card = {
+	dexId: [
+		270,
+	],
+	set: Set,
+	variants: {
+		normal: false,
+		reverse: false,
+		holo: false,
+		firstEdition: false,
+	},
+	name: {
+		en: "Lotad",
+		fr: "Nénupiot",
+	},
+	rarity: "None",
+	category: "Pokemon",
+	hp: 60,
+	types: [
+		"Grass",
+	],
+	stage: "Basic",
+	thirdParty: {
+		tcgplayer: 110422,
+	},
+	attacks: [
+		{
+			cost: [
+				"Colorless",
+				"Colorless",
+			],
+			name: {
+				fr: "Bataille",
+			},
+			damage: "20",
+		},
+	],
+}
+
+export default card

--- a/data/McDonald's Collection/McDonald's Collection 2015/3.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2015/3.ts
@@ -1,0 +1,45 @@
+import { Card } from '../../../interfaces'
+import Set from '../McDonald\'s Collection 2015'
+
+const card: Card = {
+	dexId: [
+		255,
+	],
+	set: Set,
+	variants: {
+		normal: true,
+		reverse: false,
+		holo: false,
+		firstEdition: false,
+	},
+	name: {
+		en: "Torchic",
+		fr: "Poussifeu",
+	},
+	rarity: "None",
+	category: "Pokemon",
+	hp: 60,
+	types: [
+		"Fire",
+	],
+	stage: "Basic",
+	thirdParty: {
+		tcgplayer: 110433,
+	},
+	attacks: [
+		{
+			cost: [
+				"Fire",
+			],
+			name: {
+				fr: "Flammèche",
+			},
+			damage: "20",
+			effect: {
+				fr: "Lancez une pièce. Si c'est pile, défaussez une Énergie  attachée à ce Pokémon.",
+			},
+		},
+	],
+}
+
+export default card

--- a/data/McDonald's Collection/McDonald's Collection 2015/4.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2015/4.ts
@@ -1,0 +1,45 @@
+import { Card } from '../../../interfaces'
+import Set from '../McDonald\'s Collection 2015'
+
+const card: Card = {
+	dexId: [
+		120,
+	],
+	set: Set,
+	variants: {
+		normal: false,
+		reverse: false,
+		holo: true,
+		firstEdition: false,
+	},
+	name: {
+		en: "Staryu",
+		fr: "Stari",
+	},
+	rarity: "None",
+	category: "Pokemon",
+	hp: 60,
+	types: [
+		"Water",
+	],
+	stage: "Basic",
+	thirdParty: {
+		tcgplayer: 110431,
+	},
+	attacks: [
+		{
+			cost: [
+				"Colorless",
+			],
+			name: {
+				fr: "Coup Rapide",
+			},
+			damage: "20",
+			effect: {
+				fr: "Lancez une pièce. Si c'est pile, cette attaque ne fait rien.",
+			},
+		},
+	],
+}
+
+export default card

--- a/data/McDonald's Collection/McDonald's Collection 2015/5.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2015/5.ts
@@ -1,0 +1,52 @@
+import { Card } from '../../../interfaces'
+import Set from '../McDonald\'s Collection 2015'
+
+const card: Card = {
+	dexId: [
+		258,
+	],
+	set: Set,
+	variants: {
+		normal: false,
+		reverse: false,
+		holo: true,
+		firstEdition: false,
+	},
+	name: {
+		en: "Mudkip",
+		fr: "Gobou",
+	},
+	rarity: "None",
+	category: "Pokemon",
+	hp: 60,
+	types: [
+		"Water",
+	],
+	stage: "Basic",
+	thirdParty: {
+		tcgplayer: 110427,
+	},
+	attacks: [
+		{
+			cost: [
+				"Water",
+			],
+			name: {
+				fr: "Charge",
+			},
+			damage: "10",
+		},
+		{
+			cost: [
+				"Water",
+				"Colorless",
+			],
+			name: {
+				fr: "Coud'Boue",
+			},
+			damage: "20",
+		},
+	],
+}
+
+export default card

--- a/data/McDonald's Collection/McDonald's Collection 2015/6.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2015/6.ts
@@ -1,0 +1,54 @@
+import { Card } from '../../../interfaces'
+import Set from '../McDonald\'s Collection 2015'
+
+const card: Card = {
+	dexId: [
+		25,
+	],
+	set: Set,
+	variants: {
+		normal: false,
+		reverse: false,
+		holo: true,
+		firstEdition: false,
+	},
+	name: {
+		en: "Pikachu",
+		fr: "Pikachu",
+	},
+	rarity: "None",
+	category: "Pokemon",
+	hp: 60,
+	types: [
+		"Lightning",
+	],
+	stage: "Basic",
+	thirdParty: {
+		tcgplayer: 110424,
+	},
+	attacks: [
+		{
+			cost: [
+				"Colorless",
+			],
+			name: {
+				fr: "Mimi-Queue",
+			},
+			effect: {
+				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur ne peut pas attaquer pendant le prochain tour de votre adversaire.",
+			},
+		},
+		{
+			cost: [
+				"Lightning",
+				"Colorless",
+			],
+			name: {
+				fr: "Boule Élek",
+			},
+			damage: "30",
+		},
+	],
+}
+
+export default card

--- a/data/McDonald's Collection/McDonald's Collection 2015/7.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2015/7.ts
@@ -1,0 +1,54 @@
+import { Card } from '../../../interfaces'
+import Set from '../McDonald\'s Collection 2015'
+
+const card: Card = {
+	dexId: [
+		309,
+	],
+	set: Set,
+	variants: {
+		normal: false,
+		reverse: false,
+		holo: false,
+		firstEdition: false,
+	},
+	name: {
+		en: "Electrike",
+		fr: "Dynavolt",
+	},
+	rarity: "None",
+	category: "Pokemon",
+	hp: 60,
+	types: [
+		"Lightning",
+	],
+	stage: "Basic",
+	thirdParty: {
+		tcgplayer: 110428,
+	},
+	attacks: [
+		{
+			cost: [
+				"Colorless",
+			],
+			name: {
+				fr: "Chargeur",
+			},
+			effect: {
+				fr: "Cherchez une carte Énergie  dans votre deck et attachez-la à ce Pokémon. Mélangez ensuite votre deck.",
+			},
+		},
+		{
+			cost: [
+				"Lightning",
+				"Colorless",
+			],
+			name: {
+				fr: "Morsure",
+			},
+			damage: "20",
+		},
+	],
+}
+
+export default card

--- a/data/McDonald's Collection/McDonald's Collection 2015/8.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2015/8.ts
@@ -1,0 +1,46 @@
+import { Card } from '../../../interfaces'
+import Set from '../McDonald\'s Collection 2015'
+
+const card: Card = {
+	dexId: [
+		111,
+	],
+	set: Set,
+	variants: {
+		normal: false,
+		reverse: false,
+		holo: true,
+		firstEdition: false,
+	},
+	name: {
+		en: "Rhyhorn",
+		fr: "Rhinocorne",
+	},
+	rarity: "None",
+	category: "Pokemon",
+	hp: 80,
+	types: [
+		"Fighting",
+	],
+	stage: "Basic",
+	thirdParty: {
+		tcgplayer: 110426,
+	},
+	attacks: [
+		{
+			cost: [
+				"Fighting",
+				"Fighting",
+			],
+			name: {
+				fr: "Bélier",
+			},
+			damage: "40",
+			effect: {
+				fr: "Ce Pokémon s'inflige 10 dégâts.",
+			},
+		},
+	],
+}
+
+export default card

--- a/data/McDonald's Collection/McDonald's Collection 2015/9.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2015/9.ts
@@ -1,0 +1,42 @@
+import { Card } from '../../../interfaces'
+import Set from '../McDonald\'s Collection 2015'
+
+const card: Card = {
+	dexId: [
+		307,
+	],
+	set: Set,
+	variants: {
+		normal: false,
+		reverse: false,
+		holo: true,
+		firstEdition: false,
+	},
+	name: {
+		en: "Meditite",
+		fr: "Méditikka",
+	},
+	rarity: "None",
+	category: "Pokemon",
+	hp: 50,
+	types: [
+		"Fighting",
+	],
+	stage: "Basic",
+	thirdParty: {
+		tcgplayer: 110425,
+	},
+	attacks: [
+		{
+			cost: [
+				"Fighting",
+			],
+			name: {
+				fr: "Claque",
+			},
+			damage: "20",
+		},
+	],
+}
+
+export default card


### PR DESCRIPTION
Set: **McDonald's Collection 2015**
Series folder: `McDonald's Collection`
Changed card files: **12**

### Validation
- [ ] `bun run validate`
- [ ] `cd server && bun run --bun validate`
- [ ] `cd server && bun run compile`
- [ ] Manual review: translations, energy types, TS syntax

### Card images
See follow-up comments with embedded TCGdex assets.