### PR TITLE
fix(data): McDonald's Collection 2016 (McDonald's Collection)

### DIFF
--- a/data/McDonald's Collection/McDonald's Collection 2016.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2016.ts
@@ -1,0 +1,31 @@
+import { Set } from '../../interfaces'
+import serie from '../McDonald\'s Collection'
+
+const s2016xy: Set = {
+	id: "2016xy",
+
+	name: {
+		en: "McDonald's Collection 2016",
+		fr: "Collection McDonald's 2016",
+		it: "McDonald's Collection 2016"
+	},
+
+	serie: serie,
+
+	cardCount: {
+		official: 12
+	},
+
+	releaseDate: "2016-08-20",
+
+	abbreviations: {
+		official: "MCD16",
+		fr: "M16"
+	},
+
+	thirdParty: {
+		tcgplayer: 3087
+	}
+}
+
+export default s2016xy

--- a/data/McDonald's Collection/McDonald's Collection 2016/1.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2016/1.ts
@@ -1,0 +1,50 @@
+import { Card } from '../../../interfaces'
+import Set from '../McDonald\'s Collection 2016'
+
+const card: Card = {
+	set: Set,
+	illustrator: "kirisAki",
+	category: "Pokemon",
+
+	dexId: [37],
+
+	description: {
+		en: "While young, it has six gorgeous tails. When it grows, several new tails are sprouted."
+	},
+	
+	hp: 60,
+
+	stage: "Basic",
+
+	attacks: [{
+		name: {
+			en: "Roar",
+			fr: "Hurlement"
+		},
+
+		effect: {
+			en: "Your opponent switches his or her Active Pokémon with 1 of his or her Benched Pokémon.",
+			fr: "Votre adversaire échange son Pokémon Actif avec l'un de ses Pokémon de Banc."
+		}
+	}, {
+		name: {
+			en: "Gnaw",
+			fr: "Ronge"
+		},
+
+		damage: 10
+	}],
+
+	name: {
+		en: "Vulpix",
+		fr: "Goupix"
+	},
+
+	rarity: "None",
+
+	thirdParty: {
+		tcgplayer: 275057
+	}
+}
+
+export default card

--- a/data/McDonald's Collection/McDonald's Collection 2016/10.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2016/10.ts
@@ -1,0 +1,55 @@
+import { Card } from '../../../interfaces'
+import Set from '../McDonald\'s Collection 2016'
+
+const card: Card = {
+	set: Set,
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+
+	dexId: [702],
+
+	description: {
+		en: "Its whiskers serve as antennas. By sending and receiving electrical waves, it can communicate with others over vast distances."
+	},
+	
+	hp: 70,
+
+	stage: "Basic",
+
+	attacks: [{
+		name: {
+			en: "Nuzzle",
+			fr: "Frotte-Frimousse"
+		},
+
+		effect: {
+			en: "Flip a coin. If heads, your opponent’s Active Pokémon is now Paralyzed.",
+			fr: "Lancez une pièce. Si c'est face, le Pokémon Actif de votre adversaire est maintenant Paralysé."
+		}
+	}, {
+		name: {
+			en: "Spiral Drain",
+			fr: "Spirale Épuisante"
+		},
+
+		damage: 60,
+
+		effect: {
+			en: "Heal 20 damage from this Pokémon.",
+			fr: "Soignez 20 dégâts à ce Pokémon."
+		}
+	}],
+
+	name: {
+		en: "Dedenne",
+		fr: "Dedenne"
+	},
+
+	rarity: "None",
+
+	thirdParty: {
+		tcgplayer: 275066
+	}
+}
+
+export default card

--- a/data/McDonald's Collection/McDonald's Collection 2016/11.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2016/11.ts
@@ -1,0 +1,45 @@
+import { Card } from '../../../interfaces'
+import Set from '../McDonald\'s Collection 2016'
+
+const card: Card = {
+	set: Set,
+	illustrator: "Kanako Eo",
+	category: "Pokemon",
+
+	dexId: [52],
+
+	description: {
+		en: "Adores round objects. It wanders the streets on a nightly basis to look for dropped loose change."
+	},
+	
+	hp: 60,
+
+	stage: "Basic",
+
+	attacks: [{
+		name: {
+			en: "Act Tough",
+			fr: "Dur à Cuire"
+		},
+
+		damage: "10+",
+
+		effect: {
+			en: "If this Pokémon has any Darkness Energy attached to it, this attack does 20 more damage.",
+			fr: "Si de l'Énergie  est attachée à ce Pokémon, cette attaque inflige 20 dégâts supplémentaires."
+		}
+	}],
+
+	name: {
+		en: "Meowth",
+		fr: "Miaouss"
+	},
+
+	rarity: "None",
+
+	thirdParty: {
+		tcgplayer: 275067
+	}
+}
+
+export default card

--- a/data/McDonald's Collection/McDonald's Collection 2016/12.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2016/12.ts
@@ -1,0 +1,52 @@
+import { Card } from '../../../interfaces'
+import Set from '../McDonald\'s Collection 2016'
+
+const card: Card = {
+	set: Set,
+	illustrator: "Kouki Saitou",
+	category: "Pokemon",
+
+	dexId: [133],
+
+	description: {
+		en: "Thanks to its unstable genetic makeup, this special Pokémon conceals many different possible evolutions."
+	},
+	
+	hp: 60,
+
+	stage: "Basic",
+
+	attacks: [{
+		name: {
+			en: "Tackle",
+			fr: "Charge"
+		},
+
+		damage: 10
+	}, {
+		name: {
+			en: "Lunge",
+			fr: "Coup Rapide"
+		},
+
+		damage: 30,
+
+		effect: {
+			en: "Flip a coin. If tails, this attack does nothing.",
+			fr: "Lancez une pièce. Si c'est pile, cette attaque ne fait rien."
+		}
+	}],
+
+	name: {
+		en: "Eevee",
+		fr: "Évoli"
+	},
+
+	rarity: "None",
+
+	thirdParty: {
+		tcgplayer: 275069
+	}
+}
+
+export default card

--- a/data/McDonald's Collection/McDonald's Collection 2016/2.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2016/2.ts
@@ -1,0 +1,45 @@
+import { Card } from '../../../interfaces'
+import Set from '../McDonald\'s Collection 2016'
+
+const card: Card = {
+	set: Set,
+	illustrator: "sui",
+	category: "Pokemon",
+
+	dexId: [255],
+
+	description: {
+		en: "A fire burns inside, so it feels very warm to hug. It launches fireballs of 1,800 degrees Fahrenheit."
+	},
+	
+	hp: 60,
+
+	stage: "Basic",
+
+	attacks: [{
+		name: {
+			en: "Ember",
+			fr: "Flammèche"
+		},
+
+		damage: 20,
+
+		effect: {
+			en: "Flip a coin. If tails, discard a Fire Energy attached to this Pokémon.",
+			fr: "Lancez une pièce. Si c'est pile défaussez une Énergie  attachée à ce Pokémon."
+		}
+	}],
+
+	name: {
+		en: "Torchic",
+		fr: "Poussifeu"
+	},
+
+	rarity: "None",
+
+	thirdParty: {
+		tcgplayer: 275058
+	}
+}
+
+export default card

--- a/data/McDonald's Collection/McDonald's Collection 2016/3.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2016/3.ts
@@ -1,0 +1,40 @@
+import { Card } from '../../../interfaces'
+import Set from '../McDonald\'s Collection 2016'
+
+const card: Card = {
+	set: Set,
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+
+	dexId: [653],
+
+	description: {
+		en: "Eating a twig fills it with energy, and its roomy ears give vent to air hotter than 390 degrees Fahrenheit."
+	},
+	
+	hp: 50,
+
+	stage: "Basic",
+
+	attacks: [{
+		name: {
+			en: "Will-O-Wisp",
+			fr: "Feu Follet"
+		},
+
+		damage: 20
+	}],
+
+	name: {
+		en: "Fennekin",
+		fr: "Feunnec"
+	},
+
+	rarity: "None",
+
+	thirdParty: {
+		tcgplayer: 275059
+	}
+}
+
+export default card

--- a/data/McDonald's Collection/McDonald's Collection 2016/4.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2016/4.ts
@@ -1,0 +1,45 @@
+import { Card } from '../../../interfaces'
+import Set from '../McDonald\'s Collection 2016'
+
+const card: Card = {
+	set: Set,
+	illustrator: "Akira Komayama",
+	category: "Pokemon",
+
+	dexId: [129],
+
+	description: {
+		en: "In the distant past, it was somewhat stronger than the horribly weak descendants that exist today."
+	},
+	
+	hp: 30,
+
+	stage: "Basic",
+
+	attacks: [{
+		name: {
+			en: "Epic Splash",
+			fr: "Trempette Épique"
+		},
+
+		damage: 30,
+
+		effect: {
+			en: "Flip 2 coins. If either of them is tails, this attack does nothing.",
+			fr: "Lancez 2 pièces. Si vous obtenez au moins un côté pile, cette attaque ne fait rien."
+		}
+	}],
+
+	name: {
+		en: "Magikarp",
+		fr: "Magicarpe"
+	},
+
+	rarity: "None",
+
+	thirdParty: {
+		tcgplayer: 275060
+	}
+}
+
+export default card

--- a/data/McDonald's Collection/McDonald's Collection 2016/5.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2016/5.ts
@@ -1,0 +1,45 @@
+import { Card } from '../../../interfaces'
+import Set from '../McDonald\'s Collection 2016'
+
+const card: Card = {
+	set: Set,
+	illustrator: "Kagemaru Himeno",
+	category: "Pokemon",
+
+	dexId: [158],
+
+	description: {
+		en: "It is small but rough and tough. It won’t hesitate to take a bite out of anything that moves."
+	},
+	
+	hp: 60,
+
+	stage: "Basic",
+
+	attacks: [{
+		name: {
+			en: "Fury Strikes",
+			fr: "Attaques Furieuses"
+		},
+
+		damage: "10×",
+
+		effect: {
+			en: "Flip 3 coins. This attack does 10 damage times the number of heads.",
+			fr: "Lancez 3 pièces. Cette attaque inflige 10 dégâts multipliés par le nombre de côtes face."
+		}
+	}],
+
+	name: {
+		en: "Totodile",
+		fr: "Kaiminus"
+	},
+
+	rarity: "None",
+
+	thirdParty: {
+		tcgplayer: 275061
+	}
+}
+
+export default card

--- a/data/McDonald's Collection/McDonald's Collection 2016/6.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2016/6.ts
@@ -1,0 +1,50 @@
+import { Card } from '../../../interfaces'
+import Set from '../McDonald\'s Collection 2016'
+
+const card: Card = {
+	set: Set,
+	illustrator: "Naoki Saito",
+	category: "Pokemon",
+
+	dexId: [25],
+
+	description: {
+		en: "It raises its tail to check its surroundings. The tail is sometimes struck by lightning in this pose."
+	},
+	
+	hp: 60,
+
+	stage: "Basic",
+
+	attacks: [{
+		name: {
+			en: "Tail Whip",
+			fr: "Mimi-Queue"
+		},
+
+		effect: {
+			en: "Flip a coin. If heads, the Defending Pokémon can’t attack during your opponent’s next turn.",
+			fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur ne peut pas attaquer pendant le prochain tour de votre adversaire."
+		}
+	}, {
+		name: {
+			en: "Electro Ball",
+			fr: "Boule Élek"
+		},
+
+		damage: 30
+	}],
+
+	name: {
+		en: "Pikachu",
+		fr: "Pikachu"
+	},
+
+	rarity: "None",
+
+	thirdParty: {
+		tcgplayer: 275062
+	}
+}
+
+export default card

--- a/data/McDonald's Collection/McDonald's Collection 2016/7.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2016/7.ts
@@ -1,0 +1,40 @@
+import { Card } from '../../../interfaces'
+import Set from '../McDonald\'s Collection 2016'
+
+const card: Card = {
+	set: Set,
+	illustrator: "Tomokazu Komiya",
+	category: "Pokemon",
+
+	dexId: [559],
+
+	description: {
+		en: "Its skin has a rubbery elasticity, so it can reduce damage by defensively pulling it skin up to its neck."
+	},
+	
+	hp: 60,
+
+	stage: "Basic",
+
+	attacks: [{
+		name: {
+			en: "Corkscrew Punch",
+			fr: "Poing Tire-Bouchon"
+		},
+
+		damage: 30
+	}],
+
+	name: {
+		en: "Scraggy",
+		fr: "Baggiguane"
+	},
+
+	rarity: "None",
+
+	thirdParty: {
+		tcgplayer: 275063
+	}
+}
+
+export default card

--- a/data/McDonald's Collection/McDonald's Collection 2016/8.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2016/8.ts
@@ -1,0 +1,50 @@
+import { Card } from '../../../interfaces'
+import Set from '../McDonald\'s Collection 2016'
+
+const card: Card = {
+	set: Set,
+	illustrator: "Kanako Eo",
+	category: "Pokemon",
+
+	dexId: [39],
+
+	description: {
+		en: "It captivates foes with its huge, round eyes, then lulls them to sleep by singing a soothing melody."
+	},
+	
+	hp: 60,
+
+	stage: "Basic",
+
+	attacks: [{
+		name: {
+			en: "Rollout",
+			fr: "Roulade"
+		},
+
+		damage: 10
+	}, {
+		name: {
+			en: "Heartfelt Song",
+			fr: "Chanson du Cœur"
+		},
+
+		effect: {
+			en: "Discard a Darkness Energy attached to your opponent’s Active Pokémon.",
+			fr: "Défaussez une Énergie  attachée au Pokémon Actif de votre adversaire."
+		}
+	}],
+
+	name: {
+		en: "Jigglypuff",
+		fr: "Rondoudou"
+	},
+
+	rarity: "None",
+
+	thirdParty: {
+		tcgplayer: 275064
+	}
+}
+
+export default card

--- a/data/McDonald's Collection/McDonald's Collection 2016/9.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2016/9.ts
@@ -1,0 +1,44 @@
+import { Card } from '../../../interfaces'
+import Set from '../McDonald\'s Collection 2016'
+
+const card: Card = {
+	set: Set,
+	illustrator: "HiRON",
+	category: "Pokemon",
+
+	dexId: [175],
+
+	description: {
+		en: "A proverb claims that happiness will come to anyone who can make a sleeping Togepi stand up."
+	},
+	
+	hp: 40,
+
+	stage: "Basic",
+
+	attacks: [{
+		name: {
+			en: "Sweet Kiss",
+			fr: "Doux Baiser"
+		},
+
+		damage: 10,
+
+		effect: {
+			en: "Your opponent draws a card."
+		}
+	}],
+
+	name: {
+		en: "Togepi",
+		fr: "Togepi"
+	},
+
+	rarity: "None",
+
+	thirdParty: {
+		tcgplayer: 275065
+	}
+}
+
+export default card


### PR DESCRIPTION
Set: **McDonald's Collection 2016**
Series folder: `McDonald's Collection`
Changed card files: **12**

### Validation
- [ ] `bun run validate`
- [ ] `cd server && bun run --bun validate`
- [ ] `cd server && bun run compile`
- [ ] Manual review: translations, energy types, TS syntax

### Card images
See follow-up comments with embedded TCGdex assets.