### PR TITLE
fix(data): McDonald's Collection 2017 (McDonald's Collection)

### DIFF
--- a/data/McDonald's Collection/McDonald's Collection 2017.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2017.ts
@@ -1,0 +1,32 @@
+import { Set } from '../../interfaces'
+import serie from '../McDonald\'s Collection'
+
+const s2017sm: Set = {
+	id: "2017sm",
+
+	name: {
+		en: "McDonald's Collection 2017",
+		fr: "Collection McDonald's 2017",
+		it: "McDonald's Collection 2017",
+		de: "McDonald’s Kollektion 2017",
+	},
+
+	serie: serie,
+
+	cardCount: {
+		official: 12
+	},
+
+	releaseDate: "2017-08-03",
+
+	abbreviations: {
+		official: "MCD17",
+		fr: "M17"
+	},
+
+	thirdParty: {
+		tcgplayer: 2148
+	}
+}
+
+export default s2017sm

--- a/data/McDonald's Collection/McDonald's Collection 2017/1.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2017/1.ts
@@ -1,0 +1,52 @@
+import { Card } from '../../../interfaces'
+import Set from '../McDonald\'s Collection 2017'
+
+const card: Card = {
+	dexId: [
+		722,
+	],
+	set: Set,
+	variants: {
+		normal: false,
+		reverse: false,
+		holo: false,
+		firstEdition: false,
+	},
+	name: {
+		en: "Rowlet",
+		fr: "Brindibou",
+	},
+	rarity: "None",
+	category: "Pokemon",
+	hp: 60,
+	types: [
+		"Grass",
+	],
+	stage: "Basic",
+	thirdParty: {
+		tcgplayer: 152681,
+	},
+	attacks: [
+		{
+			cost: [
+				"Colorless",
+			],
+			name: {
+				fr: "Charge",
+			},
+			damage: "10",
+		},
+		{
+			cost: [
+				"Grass",
+				"Colorless",
+			],
+			name: {
+				fr: "Feuillage",
+			},
+			damage: "20",
+		},
+	],
+}
+
+export default card

--- a/data/McDonald's Collection/McDonald's Collection 2017/10.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2017/10.ts
@@ -1,0 +1,45 @@
+import { Card } from '../../../interfaces'
+import Set from '../McDonald\'s Collection 2017'
+
+const card: Card = {
+	dexId: [
+		742,
+	],
+	set: Set,
+	variants: {
+		normal: false,
+		reverse: false,
+		holo: false,
+		firstEdition: false,
+	},
+	name: {
+		en: "Cutiefly",
+		fr: "Bombydou",
+	},
+	rarity: "None",
+	category: "Pokemon",
+	hp: 30,
+	types: [
+		"Fairy",
+	],
+	stage: "Basic",
+	thirdParty: {
+		tcgplayer: 152690,
+	},
+	attacks: [
+		{
+			cost: [
+				"Fairy",
+			],
+			name: {
+				fr: "Papillonnement",
+			},
+			damage: "10",
+			effect: {
+				fr: "Si des dégâts sont infligés à ce Pokémon par des attaques pendant le prochain tour de votre adversaire, lancez une pièce. Si c'est face, évitez ces dégâts.",
+			},
+		},
+	],
+}
+
+export default card

--- a/data/McDonald's Collection/McDonald's Collection 2017/11.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2017/11.ts
@@ -1,0 +1,45 @@
+import { Card } from '../../../interfaces'
+import Set from '../McDonald\'s Collection 2017'
+
+const card: Card = {
+	dexId: [
+		731,
+	],
+	set: Set,
+	variants: {
+		normal: false,
+		reverse: false,
+		holo: false,
+		firstEdition: false,
+	},
+	name: {
+		en: "Pikipek",
+		fr: "Picassaut",
+	},
+	rarity: "None",
+	category: "Pokemon",
+	hp: 50,
+	types: [
+		"Colorless",
+	],
+	stage: "Basic",
+	thirdParty: {
+		tcgplayer: 152692,
+	},
+	attacks: [
+		{
+			cost: [
+				"Colorless",
+			],
+			name: {
+				fr: "Éclate-Roc",
+			},
+			damage: "10+",
+			effect: {
+				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 10 dégâts supplémentaires.",
+			},
+		},
+	],
+}
+
+export default card

--- a/data/McDonald's Collection/McDonald's Collection 2017/12.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2017/12.ts
@@ -1,0 +1,52 @@
+import { Card } from '../../../interfaces'
+import Set from '../McDonald\'s Collection 2017'
+
+const card: Card = {
+	dexId: [
+		734,
+	],
+	set: Set,
+	variants: {
+		normal: false,
+		reverse: false,
+		holo: false,
+		firstEdition: false,
+	},
+	name: {
+		en: "Yungoos",
+		fr: "Manglouton",
+	},
+	rarity: "None",
+	category: "Pokemon",
+	hp: 70,
+	types: [
+		"Colorless",
+	],
+	stage: "Basic",
+	thirdParty: {
+		tcgplayer: 152693,
+	},
+	attacks: [
+		{
+			cost: [
+				"Colorless",
+			],
+			name: {
+				fr: "Charge",
+			},
+			damage: "10",
+		},
+		{
+			cost: [
+				"Colorless",
+				"Colorless",
+			],
+			name: {
+				fr: "Morsure",
+			},
+			damage: "20",
+		},
+	],
+}
+
+export default card

--- a/data/McDonald's Collection/McDonald's Collection 2017/2.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2017/2.ts
@@ -1,0 +1,43 @@
+import { Card } from '../../../interfaces'
+import Set from '../McDonald\'s Collection 2017'
+
+const card: Card = {
+	dexId: [
+		736,
+	],
+	set: Set,
+	variants: {
+		normal: false,
+		reverse: false,
+		holo: true,
+		firstEdition: false,
+	},
+	name: {
+		en: "Grubbin",
+		fr: "Larvibule",
+	},
+	rarity: "None",
+	category: "Pokemon",
+	hp: 70,
+	types: [
+		"Grass",
+	],
+	stage: "Basic",
+	thirdParty: {
+		tcgplayer: 152682,
+	},
+	attacks: [
+		{
+			cost: [
+				"Colorless",
+				"Colorless",
+			],
+			name: {
+				fr: "Force Poigne",
+			},
+			damage: "20",
+		},
+	],
+}
+
+export default card

--- a/data/McDonald's Collection/McDonald's Collection 2017/3.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2017/3.ts
@@ -1,0 +1,52 @@
+import { Card } from '../../../interfaces'
+import Set from '../McDonald\'s Collection 2017'
+
+const card: Card = {
+	dexId: [
+		725,
+	],
+	set: Set,
+	variants: {
+		normal: false,
+		reverse: false,
+		holo: false,
+		firstEdition: false,
+	},
+	name: {
+		en: "Litten",
+		fr: "Flamiaou",
+	},
+	rarity: "None",
+	category: "Pokemon",
+	hp: 70,
+	types: [
+		"Fire",
+	],
+	stage: "Basic",
+	thirdParty: {
+		tcgplayer: 152683,
+	},
+	attacks: [
+		{
+			cost: [
+				"Fire",
+			],
+			name: {
+				fr: "Morsure",
+			},
+			damage: "10",
+		},
+		{
+			cost: [
+				"Fire",
+				"Colorless",
+			],
+			name: {
+				fr: "Flamboiement",
+			},
+			damage: "20",
+		},
+	],
+}
+
+export default card

--- a/data/McDonald's Collection/McDonald's Collection 2017/4.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2017/4.ts
@@ -1,0 +1,52 @@
+import { Card } from '../../../interfaces'
+import Set from '../McDonald\'s Collection 2017'
+
+const card: Card = {
+	dexId: [
+		728,
+	],
+	set: Set,
+	variants: {
+		normal: false,
+		reverse: false,
+		holo: true,
+		firstEdition: false,
+	},
+	name: {
+		en: "Popplio",
+		fr: "Otaquin",
+	},
+	rarity: "None",
+	category: "Pokemon",
+	hp: 70,
+	types: [
+		"Water",
+	],
+	stage: "Basic",
+	thirdParty: {
+		tcgplayer: 152684,
+	},
+	attacks: [
+		{
+			cost: [
+				"Water",
+			],
+			name: {
+				fr: "Écras'Face",
+			},
+			damage: "10",
+		},
+		{
+			cost: [
+				"Water",
+				"Colorless",
+			],
+			name: {
+				fr: "Pistolet à O",
+			},
+			damage: "20",
+		},
+	],
+}
+
+export default card

--- a/data/McDonald's Collection/McDonald's Collection 2017/5.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2017/5.ts
@@ -1,0 +1,55 @@
+import { Card } from '../../../interfaces'
+import Set from '../McDonald\'s Collection 2017'
+
+const card: Card = {
+	dexId: [
+		25,
+	],
+	set: Set,
+	variants: {
+		normal: false,
+		reverse: false,
+		holo: true,
+		firstEdition: false,
+	},
+	name: {
+		en: "Pikachu",
+		fr: "Pikachu",
+	},
+	rarity: "None",
+	category: "Pokemon",
+	hp: 70,
+	types: [
+		"Lightning",
+	],
+	stage: "Basic",
+	thirdParty: {
+		tcgplayer: 152685,
+	},
+	attacks: [
+		{
+			cost: [
+				"Lightning",
+			],
+			name: {
+				fr: "Cage-Éclair",
+			},
+			effect: {
+				fr: "Lancez une pièce. Si c'est face, le Pokémon Actif de votre adversaire est maintenant Paralysé.",
+			},
+		},
+		{
+			cost: [
+				"Lightning",
+				"Colorless",
+				"Colorless",
+			],
+			name: {
+				fr: "Boule Élek",
+			},
+			damage: "50",
+		},
+	],
+}
+
+export default card

--- a/data/McDonald's Collection/McDonald's Collection 2017/6.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2017/6.ts
@@ -1,0 +1,44 @@
+import { Card } from '../../../interfaces'
+import Set from '../McDonald\'s Collection 2017'
+
+const card: Card = {
+	dexId: [
+		789,
+	],
+	set: Set,
+	variants: {
+		normal: false,
+		reverse: false,
+		holo: true,
+		firstEdition: false,
+	},
+	name: {
+		en: "Cosmog",
+		fr: "Cosmog",
+	},
+	rarity: "None",
+	category: "Pokemon",
+	hp: 60,
+	types: [
+		"Psychic",
+	],
+	stage: "Basic",
+	thirdParty: {
+		tcgplayer: 152686,
+	},
+	attacks: [
+		{
+			cost: [
+				"Colorless",
+			],
+			name: {
+				fr: "Ramasse Poussière",
+			},
+			effect: {
+				fr: "Piochez une carte.",
+			},
+		},
+	],
+}
+
+export default card

--- a/data/McDonald's Collection/McDonald's Collection 2017/7.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2017/7.ts
@@ -1,0 +1,54 @@
+import { Card } from '../../../interfaces'
+import Set from '../McDonald\'s Collection 2017'
+
+const card: Card = {
+	dexId: [
+		739,
+	],
+	set: Set,
+	variants: {
+		normal: false,
+		reverse: false,
+		holo: true,
+		firstEdition: false,
+	},
+	name: {
+		en: "Crabrawler",
+		fr: "Crabagarre",
+	},
+	rarity: "None",
+	category: "Pokemon",
+	hp: 80,
+	types: [
+		"Fighting",
+	],
+	stage: "Basic",
+	thirdParty: {
+		tcgplayer: 152687,
+	},
+	attacks: [
+		{
+			cost: [
+				"Colorless",
+				"Colorless",
+			],
+			name: {
+				fr: "Koud'Poing",
+			},
+			damage: "20",
+		},
+		{
+			cost: [
+				"Fighting",
+				"Colorless",
+				"Colorless",
+			],
+			name: {
+				fr: "Pince-Masse",
+			},
+			damage: "40",
+		},
+	],
+}
+
+export default card

--- a/data/McDonald's Collection/McDonald's Collection 2017/8.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2017/8.ts
@@ -1,0 +1,43 @@
+import { Card } from '../../../interfaces'
+import Set from '../McDonald\'s Collection 2017'
+
+const card: Card = {
+	dexId: [
+		52,
+	],
+	set: Set,
+	variants: {
+		normal: false,
+		reverse: false,
+		holo: false,
+		firstEdition: false,
+	},
+	name: {
+		en: "Alolan Meowth",
+		fr: "Miaouss d'Alola",
+	},
+	rarity: "None",
+	category: "Pokemon",
+	hp: 70,
+	types: [
+		"Darkness",
+	],
+	stage: "Basic",
+	thirdParty: {
+		tcgplayer: 152688,
+	},
+	attacks: [
+		{
+			cost: [],
+			name: {
+				fr: "Combo-Griffe",
+			},
+			damage: "10×",
+			effect: {
+				fr: "Lancez 3 pièces. Cette attaque inflige 10 dégâts multipliés par le nombre de côtés face.",
+			},
+		},
+	],
+}
+
+export default card

--- a/data/McDonald's Collection/McDonald's Collection 2017/9.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2017/9.ts
@@ -1,0 +1,51 @@
+import { Card } from '../../../interfaces'
+import Set from '../McDonald\'s Collection 2017'
+
+const card: Card = {
+	dexId: [
+		50,
+	],
+	set: Set,
+	variants: {
+		normal: false,
+		reverse: false,
+		holo: true,
+		firstEdition: false,
+	},
+	name: {
+		en: "Alolan Diglett",
+		fr: "Taupiqueur d'Alola",
+	},
+	rarity: "None",
+	category: "Pokemon",
+	hp: 50,
+	types: [
+		"Metal",
+	],
+	stage: "Basic",
+	thirdParty: {
+		tcgplayer: 152689,
+	},
+	attacks: [
+		{
+			cost: [],
+			name: {
+				fr: "Spéléologue",
+			},
+			effect: {
+				fr: "Regardez les 3 cartes du dessus de votre deck et replacez-les dans l'ordre de votre choix.",
+			},
+		},
+		{
+			cost: [
+				"Metal",
+			],
+			name: {
+				fr: "Coud'Boue",
+			},
+			damage: "10",
+		},
+	],
+}
+
+export default card


### PR DESCRIPTION
Set: **McDonald's Collection 2017**
Series folder: `McDonald's Collection`
Changed card files: **12**

### Validation
- [ ] `bun run validate`
- [ ] `cd server && bun run --bun validate`
- [ ] `cd server && bun run compile`
- [ ] Manual review: translations, energy types, TS syntax

### Card images
See follow-up comments with embedded TCGdex assets.