### PR TITLE
fix(data): McDonald's Collection 2018 (McDonald's Collection)

### DIFF
--- a/data/McDonald's Collection/McDonald's Collection 2018.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2018.ts
@@ -1,0 +1,29 @@
+import { Set } from '../../interfaces'
+import serie from '../McDonald\'s Collection'
+
+const s2018sm: Set = {
+	id: "2018sm",
+
+	name: {
+		en: "McDonald's Collection 2018",
+		it: "McDonald's Collection 2018"
+	},
+
+	serie: serie,
+
+	cardCount: {
+		official: 12
+	},
+
+	releaseDate: "2018-10-19",
+
+	abbreviations: {
+		official: "MCD18"
+	},
+
+	thirdParty: {
+		tcgplayer: 2364
+	}
+}
+
+export default s2018sm

--- a/data/McDonald's Collection/McDonald's Collection 2018/1.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2018/1.ts
@@ -1,0 +1,30 @@
+import { Card } from '../../../interfaces'
+import Set from '../McDonald\'s Collection 2018'
+
+const card: Card = {
+	dexId: [58],
+	set: Set,
+
+	variants: {
+		normal: false,
+		reverse: false,
+		holo: true,
+		firstEdition: false
+	},
+
+	name: {
+		en: "Growlithe"
+	},
+
+	rarity: "None",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Fire"],
+	stage: "Basic",
+
+	thirdParty: {
+		tcgplayer: 180450
+	}
+}
+
+export default card

--- a/data/McDonald's Collection/McDonald's Collection 2018/10.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2018/10.ts
@@ -1,0 +1,30 @@
+import { Card } from '../../../interfaces'
+import Set from '../McDonald\'s Collection 2018'
+
+const card: Card = {
+	dexId: [113],
+	set: Set,
+
+	variants: {
+		normal: false,
+		reverse: false,
+		holo: true,
+		firstEdition: false
+	},
+
+	name: {
+		en: "Chansey"
+	},
+
+	rarity: "None",
+	category: "Pokemon",
+	hp: 110,
+	types: ["Colorless"],
+	stage: "Basic",
+
+	thirdParty: {
+		tcgplayer: 180458
+	}
+}
+
+export default card

--- a/data/McDonald's Collection/McDonald's Collection 2018/11.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2018/11.ts
@@ -1,0 +1,30 @@
+import { Card } from '../../../interfaces'
+import Set from '../McDonald\'s Collection 2018'
+
+const card: Card = {
+	dexId: [133],
+	set: Set,
+
+	variants: {
+		normal: false,
+		reverse: false,
+		holo: false,
+		firstEdition: false
+	},
+
+	name: {
+		en: "Eevee"
+	},
+
+	rarity: "None",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Colorless"],
+	stage: "Basic",
+
+	thirdParty: {
+		tcgplayer: 180459
+	}
+}
+
+export default card

--- a/data/McDonald's Collection/McDonald's Collection 2018/12.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2018/12.ts
@@ -1,0 +1,30 @@
+import { Card } from '../../../interfaces'
+import Set from '../McDonald\'s Collection 2018'
+
+const card: Card = {
+	dexId: [137],
+	set: Set,
+
+	variants: {
+		normal: false,
+		reverse: false,
+		holo: true,
+		firstEdition: false
+	},
+
+	name: {
+		en: "Porygon"
+	},
+
+	rarity: "None",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Colorless"],
+	stage: "Basic",
+
+	thirdParty: {
+		tcgplayer: 180460
+	}
+}
+
+export default card

--- a/data/McDonald's Collection/McDonald's Collection 2018/2.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2018/2.ts
@@ -1,0 +1,30 @@
+import { Card } from '../../../interfaces'
+import Set from '../McDonald\'s Collection 2018'
+
+const card: Card = {
+	dexId: [54],
+	set: Set,
+
+	variants: {
+		normal: false,
+		reverse: false,
+		holo: true,
+		firstEdition: false
+	},
+
+	name: {
+		en: "Psyduck"
+	},
+
+	rarity: "None",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Water"],
+	stage: "Basic",
+
+	thirdParty: {
+		tcgplayer: 180451
+	}
+}
+
+export default card

--- a/data/McDonald's Collection/McDonald's Collection 2018/3.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2018/3.ts
@@ -1,0 +1,30 @@
+import { Card } from '../../../interfaces'
+import Set from '../McDonald\'s Collection 2018'
+
+const card: Card = {
+	dexId: [116],
+	set: Set,
+
+	variants: {
+		normal: false,
+		reverse: false,
+		holo: true,
+		firstEdition: false
+	},
+
+	name: {
+		en: "Horsea"
+	},
+
+	rarity: "None",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Water"],
+	stage: "Basic",
+
+	thirdParty: {
+		tcgplayer: 180449
+	}
+}
+
+export default card

--- a/data/McDonald's Collection/McDonald's Collection 2018/4.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2018/4.ts
@@ -1,0 +1,30 @@
+import { Card } from '../../../interfaces'
+import Set from '../McDonald\'s Collection 2018'
+
+const card: Card = {
+	dexId: [25],
+	set: Set,
+
+	variants: {
+		normal: false,
+		reverse: false,
+		holo: true,
+		firstEdition: false
+	},
+
+	name: {
+		en: "Pikachu"
+	},
+
+	rarity: "None",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Lightning"],
+	stage: "Basic",
+
+	thirdParty: {
+		tcgplayer: 180452
+	}
+}
+
+export default card

--- a/data/McDonald's Collection/McDonald's Collection 2018/5.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2018/5.ts
@@ -1,0 +1,30 @@
+import { Card } from '../../../interfaces'
+import Set from '../McDonald\'s Collection 2018'
+
+const card: Card = {
+	dexId: [79],
+	set: Set,
+
+	variants: {
+		normal: false,
+		reverse: false,
+		holo: true,
+		firstEdition: false
+	},
+
+	name: {
+		en: "Slowpoke"
+	},
+
+	rarity: "None",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Psychic"],
+	stage: "Basic",
+
+	thirdParty: {
+		tcgplayer: 180453
+	}
+}
+
+export default card

--- a/data/McDonald's Collection/McDonald's Collection 2018/6.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2018/6.ts
@@ -1,0 +1,30 @@
+import { Card } from '../../../interfaces'
+import Set from '../McDonald\'s Collection 2018'
+
+const card: Card = {
+	dexId: [66],
+	set: Set,
+
+	variants: {
+		normal: false,
+		reverse: false,
+		holo: true,
+		firstEdition: false
+	},
+
+	name: {
+		en: "Machop"
+	},
+
+	rarity: "None",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Fighting"],
+	stage: "Basic",
+
+	thirdParty: {
+		tcgplayer: 180454
+	}
+}
+
+export default card

--- a/data/McDonald's Collection/McDonald's Collection 2018/7.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2018/7.ts
@@ -1,0 +1,30 @@
+import { Card } from '../../../interfaces'
+import Set from '../McDonald\'s Collection 2018'
+
+const card: Card = {
+	dexId: [104],
+	set: Set,
+
+	variants: {
+		normal: false,
+		reverse: false,
+		holo: true,
+		firstEdition: false
+	},
+
+	name: {
+		en: "Cubone"
+	},
+
+	rarity: "None",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Fighting"],
+	stage: "Basic",
+
+	thirdParty: {
+		tcgplayer: 180455
+	}
+}
+
+export default card

--- a/data/McDonald's Collection/McDonald's Collection 2018/8.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2018/8.ts
@@ -1,0 +1,30 @@
+import { Card } from '../../../interfaces'
+import Set from '../McDonald\'s Collection 2018'
+
+const card: Card = {
+	dexId: [81],
+	set: Set,
+
+	variants: {
+		normal: false,
+		reverse: false,
+		holo: true,
+		firstEdition: false
+	},
+
+	name: {
+		en: "Magnemite"
+	},
+
+	rarity: "None",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Metal"],
+	stage: "Basic",
+
+	thirdParty: {
+		tcgplayer: 180456
+	}
+}
+
+export default card

--- a/data/McDonald's Collection/McDonald's Collection 2018/9.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2018/9.ts
@@ -1,0 +1,30 @@
+import { Card } from '../../../interfaces'
+import Set from '../McDonald\'s Collection 2018'
+
+const card: Card = {
+	dexId: [147],
+	set: Set,
+
+	variants: {
+		normal: false,
+		reverse: false,
+		holo: true,
+		firstEdition: false
+	},
+
+	name: {
+		en: "Dratini"
+	},
+
+	rarity: "None",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Dragon"],
+	stage: "Basic",
+
+	thirdParty: {
+		tcgplayer: 180457
+	}
+}
+
+export default card


### PR DESCRIPTION
Set: **McDonald's Collection 2018**
Series folder: `McDonald's Collection`
Changed card files: **12**

### Validation
- [ ] `bun run validate`
- [ ] `cd server && bun run --bun validate`
- [ ] `cd server && bun run compile`
- [ ] Manual review: translations, energy types, TS syntax

### Card images
See follow-up comments with embedded TCGdex assets.