### PR TITLE
fix(data): McDonald's Collection 2019 (McDonald's Collection)

### DIFF
--- a/data/McDonald's Collection/McDonald's Collection 2019.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2019.ts
@@ -1,0 +1,31 @@
+import { Set } from '../../interfaces'
+import serie from '../McDonald\'s Collection'
+
+const s2019sm: Set = {
+	id: "2019sm",
+
+	name: {
+		en: "McDonald's Collection 2019",
+		// No French here: French-only set is represented by \"Promo McDonald's 2019\"
+		it: "McDonald's Collection 2019",
+		de: "McDonald’s Kollektion 2019",
+	},
+
+	serie: serie,
+
+	cardCount: {
+		official: 12
+	},
+
+	releaseDate: "2019-10-15",
+
+	abbreviations: {
+		official: "MCD19"
+	},
+
+	thirdParty: {
+		tcgplayer: 2555
+	}
+}
+
+export default s2019sm

--- a/data/McDonald's Collection/McDonald's Collection 2019/1.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2019/1.ts
@@ -1,0 +1,49 @@
+import { Card } from '../../../interfaces'
+import Set from '../McDonald\'s Collection 2019'
+
+const card: Card = {
+	set: Set,
+	illustrator: "Sekio",
+	category: "Pokemon",
+
+	dexId: [10],
+
+	description: {
+		en: "When attacked by bird Pokémon, it resists by releasing a terrifically strong odor from its antennae, but it often becomes their prey."
+	},
+
+	stage: "Basic",
+
+	attacks: [{
+		name: {
+			en: "Surprise Attack"
+		},
+
+		damage: 20,
+
+		effect: {
+			en: "Flip a coin. If tails, this attack does nothing."
+		}
+	}],
+
+	variants: {
+		normal: false,
+		reverse: false,
+		holo: false,
+		firstEdition: false
+	},
+
+	name: {
+		en: "Caterpie"
+	},
+
+	rarity: "None",
+	hp: 50,
+	types: ["Grass"],
+
+	thirdParty: {
+		tcgplayer: 200960
+	}
+}
+
+export default card

--- a/data/McDonald's Collection/McDonald's Collection 2019/10.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2019/10.ts
@@ -1,0 +1,49 @@
+import { Card } from '../../../interfaces'
+import Set from '../McDonald\'s Collection 2019'
+
+const card: Card = {
+	set: Set,
+	illustrator: "Akira Komayama",
+	category: "Pokemon",
+
+	dexId: [52],
+
+	description: {
+		en: "When its delicate pride is wounded, or when the gold coin on its forehead is dirtied, it flies into a hysterical rage."
+	},
+
+	stage: "Basic",
+
+	attacks: [{
+		name: {
+			en: "Spoil the Fun"
+		},
+
+		damage: "10+",
+
+		effect: {
+			en: "If you go second, this attack does 60 more damage during your first turn."
+		}
+	}],
+
+	variants: {
+		normal: false,
+		reverse: false,
+		holo: false,
+		firstEdition: false
+	},
+
+	name: {
+		en: "Alolan Meowth"
+	},
+
+	rarity: "None",
+	hp: 60,
+	types: ["Darkness"],
+
+	thirdParty: {
+		tcgplayer: 200975
+	}
+}
+
+export default card

--- a/data/McDonald's Collection/McDonald's Collection 2019/11.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2019/11.ts
@@ -1,0 +1,49 @@
+import { Card } from '../../../interfaces'
+import Set from '../McDonald\'s Collection 2019'
+
+const card: Card = {
+	set: Set,
+	illustrator: "Megumi Mizutani",
+	category: "Pokemon",
+
+	dexId: [51],
+
+	description: {
+		en: "These Pokémon are cherished in the Alola region, where they are thought to be feminine deities of the land incarnate."
+	},
+
+	stage: "Stage1",
+
+	attacks: [{
+		name: {
+			en: "Gold Rush"
+		},
+
+		damage: "30×",
+
+		effect: {
+			en: "Discard any number of Metal Energy cards from your hand. This attack does 30 damage for each card you discarded in this way."
+		}
+	}],
+
+	variants: {
+		normal: false,
+		reverse: false,
+		holo: true,
+		firstEdition: false
+	},
+
+	name: {
+		en: "Alolan Dugtrio"
+	},
+
+	rarity: "None",
+	hp: 60,
+	types: ["Metal"],
+
+	thirdParty: {
+		tcgplayer: 200976
+	}
+}
+
+export default card

--- a/data/McDonald's Collection/McDonald's Collection 2019/12.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2019/12.ts
@@ -1,0 +1,45 @@
+import { Card } from '../../../interfaces'
+import Set from '../McDonald\'s Collection 2019'
+
+const card: Card = {
+	set: Set,
+	illustrator: "Atsuko Nishida",
+	category: "Pokemon",
+
+	dexId: [133],
+
+	description: {
+		en: "Current studies show it can evolve into an incredible eight different species of Pokémon."
+	},
+
+	stage: "Basic",
+
+	attacks: [{
+		name: {
+			en: "Gnaw"
+		},
+
+		damage: 20
+	}],
+
+	variants: {
+		normal: false,
+		reverse: false,
+		holo: true,
+		firstEdition: false
+	},
+
+	name: {
+		en: "Eevee"
+	},
+
+	rarity: "None",
+	hp: 60,
+	types: ["Colorless"],
+
+	thirdParty: {
+		tcgplayer: 200977
+	}
+}
+
+export default card

--- a/data/McDonald's Collection/McDonald's Collection 2019/2.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2019/2.ts
@@ -1,0 +1,49 @@
+import { Card } from '../../../interfaces'
+import Set from '../McDonald\'s Collection 2019'
+
+const card: Card = {
+	set: Set,
+	illustrator: "Satoshi Shirai",
+	category: "Pokemon",
+
+	dexId: [103],
+
+	description: {
+		en: "As it grew taller and taller, it outgrew its reliance on psychic powers, while within it awakened the power of the sleeping dragon."
+	},
+
+	stage: "Stage1",
+
+	attacks: [{
+		name: {
+			en: "Tropical Shake"
+		},
+
+		damage: "20+",
+
+		effect: {
+			en: "This attack does 20 more damage for each type of basic Energy card in your discard pile. You can’t add more than 100 damage in this way."
+		}
+	}],
+
+	variants: {
+		normal: false,
+		reverse: false,
+		holo: false,
+		firstEdition: false
+	},
+
+	name: {
+		en: "Alolan Exeggutor"
+	},
+
+	rarity: "None",
+	hp: 160,
+	types: ["Grass"],
+
+	thirdParty: {
+		tcgplayer: 200961
+	}
+}
+
+export default card

--- a/data/McDonald's Collection/McDonald's Collection 2019/3.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2019/3.ts
@@ -1,0 +1,57 @@
+import { Card } from '../../../interfaces'
+import Set from '../McDonald\'s Collection 2019'
+
+const card: Card = {
+	set: Set,
+	illustrator: "Yumi",
+	category: "Pokemon",
+
+	dexId: [126],
+
+	description: {
+		en: "When angered, it spouts brilliant fire from all over its body. It doesn’t calm down until its opponent has burned to ash."
+	},
+
+	stage: "Basic",
+
+	attacks: [{
+		name: {
+			en: "Controlled Burn"
+		},
+
+		effect: {
+			en: "Discard the top card of your opponent’s deck."
+		}
+	}, {
+		name: {
+			en: "Flamethrower"
+		},
+
+		damage: 80,
+
+		effect: {
+			en: "Discard an Energy from this Pokémon."
+		}
+	}],
+
+	variants: {
+		normal: false,
+		reverse: false,
+		holo: false,
+		firstEdition: false
+	},
+
+	name: {
+		en: "Magmar"
+	},
+
+	rarity: "None",
+	hp: 80,
+	types: ["Fire"],
+
+	thirdParty: {
+		tcgplayer: 200963
+	}
+}
+
+export default card

--- a/data/McDonald's Collection/McDonald's Collection 2019/4.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2019/4.ts
@@ -1,0 +1,49 @@
+import { Card } from '../../../interfaces'
+import Set from '../McDonald\'s Collection 2019'
+
+const card: Card = {
+	set: Set,
+	illustrator: "Shin Nagasawa",
+	category: "Pokemon",
+
+	dexId: [27],
+
+	description: {
+		en: "An ancient tradition of Alolan festivals, still carried on to this day, is a competition to slide Sandshrew across ice as far as one can."
+	},
+
+	stage: "Basic",
+
+	attacks: [{
+		name: {
+			en: "Fury Swipes"
+		},
+
+		damage: "10×",
+
+		effect: {
+			en: "Flip 3 coins. This attack does 10 damage for each heads."
+		}
+	}],
+
+	variants: {
+		normal: false,
+		reverse: false,
+		holo: false,
+		firstEdition: false
+	},
+
+	name: {
+		en: "Alolan Sandshrew"
+	},
+
+	rarity: "None",
+	hp: 60,
+	types: ["Water"],
+
+	thirdParty: {
+		tcgplayer: 200964
+	}
+}
+
+export default card

--- a/data/McDonald's Collection/McDonald's Collection 2019/5.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2019/5.ts
@@ -1,0 +1,59 @@
+import { Card } from '../../../interfaces'
+import Set from '../McDonald\'s Collection 2019'
+
+const card: Card = {
+	set: Set,
+	illustrator: "Saya Tsuruta",
+	category: "Pokemon",
+
+	dexId: [131],
+
+	description: {
+		en: "These Pokémon were once near extinction due to poaching. Following protective regulations, there is now an overabundance of them."
+	},
+
+	stage: "Basic",
+
+	attacks: [{
+		name: {
+			en: "Aqua Bullet"
+		},
+
+		damage: 20,
+
+		effect: {
+			en: "This attack does 20 damage to 1 of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)"
+		}
+	}, {
+		name: {
+			en: "Hydro Pump"
+		},
+
+		damage: "70+",
+
+		effect: {
+			en: "This attack does 10 more damage times the amount of Water Energy attached to this Pokémon."
+		}
+	}],
+
+	variants: {
+		normal: false,
+		reverse: false,
+		holo: false,
+		firstEdition: false
+	},
+
+	name: {
+		en: "Lapras"
+	},
+
+	rarity: "None",
+	hp: 120,
+	types: ["Water"],
+
+	thirdParty: {
+		tcgplayer: 200966
+	}
+}
+
+export default card

--- a/data/McDonald's Collection/McDonald's Collection 2019/6.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2019/6.ts
@@ -1,0 +1,49 @@
+import { Card } from '../../../interfaces'
+import Set from '../McDonald\'s Collection 2019'
+
+const card: Card = {
+	set: Set,
+	illustrator: "Kagemaru Himeno",
+	category: "Pokemon",
+
+	dexId: [25],
+
+	description: {
+		en: "A plan was recently announced to gather many Pikachu and make an electric power plant."
+	},
+
+	stage: "Basic",
+
+	attacks: [{
+		name: {
+			en: "Iron Tail"
+		},
+
+		damage: "20×",
+
+		effect: {
+			en: "Flip a coin until you get tails. This attack does 20 damage for each heads."
+		}
+	}],
+
+	variants: {
+		normal: false,
+		reverse: false,
+		holo: false,
+		firstEdition: false
+	},
+
+	name: {
+		en: "Pikachu"
+	},
+
+	rarity: "None",
+	hp: 60,
+	types: ["Lightning"],
+
+	thirdParty: {
+		tcgplayer: 200967
+	}
+}
+
+export default card

--- a/data/McDonald's Collection/McDonald's Collection 2019/7.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2019/7.ts
@@ -1,0 +1,47 @@
+import { Card } from '../../../interfaces'
+import Set from '../McDonald\'s Collection 2019'
+
+const card: Card = {
+	set: Set,
+	illustrator: "Shibuzoh.",
+	category: "Pokemon",
+
+	dexId: [92],
+
+	description: {
+		en: "Should a strange light be seen flickering in an abandoned building, Gastly is lurking there."
+	},
+
+	stage: "Basic",
+
+	attacks: [{
+		name: {
+			en: "Ominous Eyes"
+		},
+
+		effect: {
+			en: "Put 1 damage counter on 1 of your opponent’s Pokémon."
+		}
+	}],
+
+	variants: {
+		normal: false,
+		reverse: false,
+		holo: false,
+		firstEdition: false
+	},
+
+	name: {
+		en: "Gastly"
+	},
+
+	rarity: "None",
+	hp: 50,
+	types: ["Psychic"],
+
+	thirdParty: {
+		tcgplayer: 200969
+	}
+}
+
+export default card

--- a/data/McDonald's Collection/McDonald's Collection 2019/8.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2019/8.ts
@@ -1,0 +1,49 @@
+import { Card } from '../../../interfaces'
+import Set from '../McDonald\'s Collection 2019'
+
+const card: Card = {
+	set: Set,
+	illustrator: "Miki Tanaka",
+	category: "Pokemon",
+
+	dexId: [56],
+
+	description: {
+		en: "It can spontaneously become enraged. Everyone near it clears out as it rampages and the resulting loneliness makes it angrier still."
+	},
+
+	stage: "Basic",
+
+	attacks: [{
+		name: {
+			en: "Three-Step Strike"
+		},
+
+		damage: "10×",
+
+		effect: {
+			en: "Flip 3 coins. This attack does 10 damage for each heads."
+		}
+	}],
+
+	variants: {
+		normal: false,
+		reverse: false,
+		holo: true,
+		firstEdition: false
+	},
+
+	name: {
+		en: "Mankey"
+	},
+
+	rarity: "None",
+	hp: 50,
+	types: ["Fighting"],
+
+	thirdParty: {
+		tcgplayer: 200971
+	}
+}
+
+export default card

--- a/data/McDonald's Collection/McDonald's Collection 2019/9.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2019/9.ts
@@ -1,0 +1,57 @@
+import { Card } from '../../../interfaces'
+import Set from '../McDonald\'s Collection 2019'
+
+const card: Card = {
+	set: Set,
+	illustrator: "Mitsuhiro Arita",
+	category: "Pokemon",
+
+	dexId: [95],
+
+	description: {
+		en: "It usually lives underground. It searches for food while boring its way through the ground at 50 miles per hour."
+	},
+
+	stage: "Basic",
+
+	attacks: [{
+		name: {
+			en: "Screech"
+		},
+
+		effect: {
+			en: "During your next turn, the Defending Pokémon takes 20 more damage from attacks (after applying Weakness and Resistance)."
+		}
+	}, {
+		name: {
+			en: "Rage"
+		},
+
+		damage: "10+",
+
+		effect: {
+			en: "This attack does 10 more damage for each damage counter on this Pokémon."
+		}
+	}],
+
+	variants: {
+		normal: false,
+		reverse: false,
+		holo: true,
+		firstEdition: false
+	},
+
+	name: {
+		en: "Onix"
+	},
+
+	rarity: "None",
+	hp: 100,
+	types: ["Fighting"],
+
+	thirdParty: {
+		tcgplayer: 200973
+	}
+}
+
+export default card


### PR DESCRIPTION
Set: **McDonald's Collection 2019**
Series folder: `McDonald's Collection`
Changed card files: **12**

### Validation
- [ ] `bun run validate`
- [ ] `cd server && bun run --bun validate`
- [ ] `cd server && bun run compile`
- [ ] Manual review: translations, energy types, TS syntax

### Card images
See follow-up comments with embedded TCGdex assets.