### PR TITLE
fix(data): McDonald's Collection 2021 (McDonald's Collection)

### DIFF
--- a/data/McDonald's Collection/McDonald's Collection 2021.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2021.ts
@@ -1,0 +1,29 @@
+import { Set } from '../../interfaces'
+import serie from '../McDonald\'s Collection'
+
+const s2021swsh: Set = {
+	id: "2021swsh",
+
+	name: {
+		en: "McDonald's Collection 2021",
+		fr: "Collection McDonald's 2021",
+		es: "Colección de McDonald's 2021",
+		it: "McDonald's Collection 2021",
+		de: "McDonald’s Kollektion 2021",
+	},
+
+	serie: serie,
+
+	cardCount: {
+		official: 25
+	},
+
+	releaseDate: "2021-02-09",
+
+	abbreviations: {
+		official: "MCD21",
+		fr: "M21"
+	}
+}
+
+export default s2021swsh

--- a/data/McDonald's Collection/McDonald's Collection 2021/1.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2021/1.ts
@@ -1,0 +1,64 @@
+import { Card } from '../../../interfaces'
+import Set from '../McDonald\'s Collection 2021'
+
+const card: Card = {
+	name: {
+		en: "Bulbasaur",
+		fr: "Bulbizarre"
+	},
+
+	illustrator: "Mizue",
+	rarity: "None",
+	category: "Pokemon",
+	set: Set,
+
+	dexId: [
+		1,
+	],
+
+	hp: 70,
+
+	types: [
+		"Grass",
+	],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			cost: [
+				"Grass",
+				"Colorless",
+			],
+			name: {
+				en: "Razor Leaf",
+				fr: "Tranch'Herbe"
+			},
+
+			damage: 30,
+
+		},
+	],
+
+	weaknesses: [
+		{
+			type: "Fire",
+			value: "x2"
+		},
+	],
+
+	retreat: 2,
+
+	description: {
+		en: "A strange seed was planted on its back at birth. The plant sprouts and grows with this Pokémon."
+	},
+
+	variants: {
+		normal: true,
+		reverse: false,
+		holo: true,
+		firstEdition: false
+	}
+}
+
+export default card

--- a/data/McDonald's Collection/McDonald's Collection 2021/10.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2021/10.ts
@@ -1,0 +1,64 @@
+import { Card } from '../../../interfaces'
+import Set from '../McDonald\'s Collection 2021'
+
+const card: Card = {
+	name: {
+		en: "Cyndaquil",
+		fr: "Héricendre",
+	},
+
+	illustrator: "kirisAki",
+	rarity: "None",
+	category: "Pokemon",
+	set: Set,
+
+	dexId: [
+		155,
+	],
+
+	hp: 70,
+
+	types: [
+		"Fire",
+	],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			cost: [
+				"Colorless",
+				"Colorless",
+			],
+			name: {
+				en: "Hammer In",
+				fr: "Enfoncement",
+			},
+
+			damage: 30,
+
+		},
+	],
+
+	weaknesses: [
+		{
+			type: "Water",
+			value: "×2"
+		},
+	],
+
+	retreat: 1,
+
+	description: {
+		en: "It has a timid nature. If it is startled, the flames on its back burn more vigorously."
+	},
+
+	variants: {
+		normal: true,
+		reverse: false,
+		holo: true,
+		firstEdition: false
+	}
+}
+
+export default card

--- a/data/McDonald's Collection/McDonald's Collection 2021/11.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2021/11.ts
@@ -1,0 +1,66 @@
+import { Card } from '../../../interfaces'
+import Set from '../McDonald\'s Collection 2021'
+
+const card: Card = {
+	name: {
+		en: "Torchic",
+		fr: "Poussifeu",
+	},
+
+	illustrator: "sui",
+	rarity: "None",
+	category: "Pokemon",
+	set: Set,
+
+	dexId: [
+		255,
+	],
+
+	hp: 60,
+
+	types: [
+		"Fire",
+	],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			cost: [
+				"Fire",
+			],
+			name: {
+				en: "Ember",
+				fr: "Flammèche",
+			},
+			effect: {
+				en: "Flip a coin. If tails, discard a Fire Energy attached to this Pokémon.",
+				fr: "Lancez une pièce. Si c'est pile, défaussez une Énergie Fire attachée à ce Pokémon.",
+			},
+			damage: 20,
+
+		},
+	],
+
+	weaknesses: [
+		{
+			type: "Water",
+			value: "×2"
+		},
+	],
+
+	retreat: 1,
+
+	description: {
+		en: "A fire burns inside, so it feels very warm to hug. It launches fireballs of 1,800 degrees Fahrenheit."
+	},
+
+	variants: {
+		normal: true,
+		reverse: false,
+		holo: true,
+		firstEdition: false
+	}
+}
+
+export default card

--- a/data/McDonald's Collection/McDonald's Collection 2021/12.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2021/12.ts
@@ -1,0 +1,71 @@
+import { Card } from '../../../interfaces'
+import Set from '../McDonald\'s Collection 2021'
+
+const card: Card = {
+	name: {
+		en: "Chimchar",
+		fr: "Chimpenfeu",
+	},
+
+	illustrator: "Kouki Saitou",
+	rarity: "None",
+	category: "Pokemon",
+	set: Set,
+
+	dexId: [
+		391,
+	],
+
+	hp: 60,
+
+	types: [
+		"Fire",
+	],
+
+	evolveFrom: {
+		en: "Chimchar",
+		fr: "Ouisticram",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			cost: [
+				"Fire",
+			],
+			name: {
+				en: "Fury Swipes",
+				fr: "Super Roussi",
+			},
+			effect: {
+				en: "Flip 3 coins. This attack does 10 damage for each heads.",
+				fr: "Le Pokémon Actif de votre adversaire est maintenant Brûlé.",
+			},
+			damage: "10×",
+
+		},
+	],
+
+	weaknesses: [
+		{
+			type: "Water",
+			value: "×2"
+		},
+	],
+
+	retreat: 1,
+
+	description: {
+		en: "The gas made in its belly burns from its rear end. The fire burns weakly when it feels sick."
+	},
+
+	variants: {
+		normal: true,
+		reverse: false,
+		holo: true,
+		firstEdition: false
+	}
+}
+
+export default card

--- a/data/McDonald's Collection/McDonald's Collection 2021/13.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2021/13.ts
@@ -1,0 +1,67 @@
+import { Card } from '../../../interfaces'
+import Set from '../McDonald\'s Collection 2021'
+
+const card: Card = {
+	name: {
+		en: "Tepig",
+		fr: "Gruikui",
+	},
+
+	illustrator: "Ken Sugimori",
+	rarity: "None",
+	category: "Pokemon",
+	set: Set,
+
+	dexId: [
+		498,
+	],
+
+	hp: 70,
+
+	types: [
+		"Fire",
+	],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			cost: [
+				"Fire",
+				"Colorless",
+			],
+			name: {
+				en: "Ember",
+				fr: "Flammèche",
+			},
+			effect: {
+				en: "Discard an Energy attached to this Pokémon.",
+				fr: "Défaussez une Énergie attachée à ce Pokémon.",
+			},
+			damage: 30,
+
+		},
+	],
+
+	weaknesses: [
+		{
+			type: "Water",
+			value: "×2"
+		},
+	],
+
+	retreat: 2,
+
+	description: {
+		en: "It blows fire through its nose. When it catches a cold, the fire becomes pitch-black smoke instead."
+	},
+
+	variants: {
+		normal: true,
+		reverse: false,
+		holo: true,
+		firstEdition: false
+	}
+}
+
+export default card

--- a/data/McDonald's Collection/McDonald's Collection 2021/14.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2021/14.ts
@@ -1,0 +1,76 @@
+import { Card } from '../../../interfaces'
+import Set from '../McDonald\'s Collection 2021'
+
+const card: Card = {
+	name: {
+		en: "Fennekin",
+		fr: "Feunnec",
+	},
+
+	illustrator: "5ban Graphics",
+	rarity: "None",
+	category: "Pokemon",
+	set: Set,
+
+	dexId: [
+		653,
+	],
+
+	hp: 60,
+
+	types: [
+		"Fire",
+	],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			cost: [
+				"Fire",
+			],
+			name: {
+				en: "Scratch",
+				fr: "Griffe",
+			},
+
+			damage: 10,
+
+		},
+		{
+			cost: [
+				"Fire",
+				"Colorless",
+			],
+			name: {
+				en: "Live Coal",
+				fr: "Charbon Mutant",
+			},
+
+			damage: 20,
+
+		},
+	],
+
+	weaknesses: [
+		{
+			type: "Water",
+			value: "×2"
+		},
+	],
+
+	retreat: 1,
+
+	description: {
+		en: "Eating a twig fills it with energy, and its roomy ears give vent to air hotter than 390 degrees Fahrenheit."
+	},
+
+	variants: {
+		normal: true,
+		reverse: false,
+		holo: true,
+		firstEdition: false
+	}
+}
+
+export default card

--- a/data/McDonald's Collection/McDonald's Collection 2021/15.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2021/15.ts
@@ -1,0 +1,76 @@
+import { Card } from '../../../interfaces'
+import Set from '../McDonald\'s Collection 2021'
+
+const card: Card = {
+	name: {
+		en: "Litten",
+		fr: "Flamiaou",
+	},
+
+	illustrator: "Akira Komayama",
+	rarity: "None",
+	category: "Pokemon",
+	set: Set,
+
+	dexId: [
+		725,
+	],
+
+	hp: 70,
+
+	types: [
+		"Fire",
+	],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			cost: [
+				"Fire",
+			],
+			name: {
+				en: "Bite",
+				fr: "Morsure",
+			},
+
+			damage: 10,
+
+		},
+		{
+			cost: [
+				"Fire",
+				"Colorless",
+			],
+			name: {
+				en: "Flare",
+				fr: "Flamboiement",
+			},
+
+			damage: 20,
+
+		},
+	],
+
+	weaknesses: [
+		{
+			type: "Water",
+			value: "×2"
+		},
+	],
+
+	retreat: 1,
+
+	description: {
+		en: "While grooming itself, it builds up fur inside its stomach. It sets the fur alight and spews fiery attacks, which change based on how it coughs."
+	},
+
+	variants: {
+		normal: true,
+		reverse: false,
+		holo: true,
+		firstEdition: false
+	}
+}
+
+export default card

--- a/data/McDonald's Collection/McDonald's Collection 2021/16.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2021/16.ts
@@ -1,0 +1,62 @@
+import { Card } from '../../../interfaces'
+import Set from '../McDonald\'s Collection 2021'
+
+const card: Card = {
+	dexId: [813],
+	name: {
+		en: "Scorbunny",
+		fr: "Flambino",
+	},
+
+	illustrator: "Hitoshi Ariga",
+	rarity: "None",
+	category: "Pokemon",
+	set: Set,
+	hp: 60,
+
+	types: [
+		"Fire",
+	],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			cost: [
+				"Fire",
+			],
+			name: {
+				en: "Super Singe",
+				fr: "Super Roussi",
+			},
+			effect: {
+				en: "Flip a coin. If heads, your opponent’s Active Pokémon is now Burned.",
+				fr: "Lancez une pièce. Si c'est face, le Pokémon Actif de votre adversaire est maintenant Brûlé.",
+			},
+			damage: 10,
+
+		},
+	],
+
+	weaknesses: [
+		{
+			type: "Water",
+			value: "×2"
+		},
+	],
+
+	retreat: 1,
+
+	description: {
+		en: "A warm-up of running around gets fire energy coursing through this Pokémon’s body. Once that happens, it’s ready to fight at full power."
+	},
+
+	variants: {
+		normal: true,
+		reverse: false,
+		holo: true,
+		firstEdition: false
+	}
+}
+
+export default card

--- a/data/McDonald's Collection/McDonald's Collection 2021/17.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2021/17.ts
@@ -1,0 +1,66 @@
+import { Card } from '../../../interfaces'
+import Set from '../McDonald\'s Collection 2021'
+
+const card: Card = {
+	name: {
+		en: "Squirtle",
+		fr: "Carapuce",
+	},
+
+	illustrator: "tetsuya koizumi",
+	rarity: "None",
+	category: "Pokemon",
+	set: Set,
+
+	dexId: [
+		7,
+	],
+
+	hp: 60,
+
+	types: [
+		"Water",
+	],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			cost: [
+				"Water",
+			],
+			name: {
+				en: "Bubble",
+				fr: "Écume",
+			},
+			effect: {
+				en: "Flip a coin. If heads, your opponent’s Active Pokémon is now Paralyzed.",
+				fr: "Lancez une pièce. Si c’est face, le Pokémon Actif de votre adversaire est maintenant Paralysé.",
+			},
+			damage: 10,
+
+		},
+	],
+
+	weaknesses: [
+		{
+			type: "Grass",
+			value: "×2"
+		},
+	],
+
+	retreat: 1,
+
+	description: {
+		en: "It shelters itself in its shell, then strikes back with spouts of water at every opportunity."
+	},
+
+	variants: {
+		normal: true,
+		reverse: false,
+		holo: true,
+		firstEdition: false
+	}
+}
+
+export default card

--- a/data/McDonald's Collection/McDonald's Collection 2021/18.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2021/18.ts
@@ -1,0 +1,66 @@
+import { Card } from '../../../interfaces'
+import Set from '../McDonald\'s Collection 2021'
+
+const card: Card = {
+	name: {
+		en: "Totodile",
+		fr: "Kaiminus",
+	},
+
+	illustrator: "Kagemaru Himeno",
+	rarity: "None",
+	category: "Pokemon",
+	set: Set,
+
+	dexId: [
+		158,
+	],
+
+	hp: 60,
+
+	types: [
+		"Water",
+	],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			cost: [
+				"Water",
+			],
+			name: {
+				en: "Fury Strikes",
+				fr: "Attaques Furieuses",
+			},
+			effect: {
+				en: "Flip 3 coins. This attack does 10 damage times the number of heads.",
+				fr: "Lancez 3 pièces. Cette attaque inflige 10 dégâts multipliés par le nombre de côtés face.",
+			},
+			damage: "10×",
+
+		},
+	],
+
+	weaknesses: [
+		{
+			type: "Grass",
+			value: "×2"
+		},
+	],
+
+	retreat: 1,
+
+	description: {
+		en: "It is small but rough and tough. It won’t hesitate to take a bite out of anything that moves."
+	},
+
+	variants: {
+		normal: true,
+		reverse: false,
+		holo: true,
+		firstEdition: false
+	}
+}
+
+export default card

--- a/data/McDonald's Collection/McDonald's Collection 2021/19.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2021/19.ts
@@ -1,0 +1,76 @@
+import { Card } from '../../../interfaces'
+import Set from '../McDonald\'s Collection 2021'
+
+const card: Card = {
+	name: {
+		en: "Mudkip",
+		fr: "Gobou",
+	},
+
+	illustrator: "Aya Kusube",
+	rarity: "None",
+	category: "Pokemon",
+	set: Set,
+
+	dexId: [
+		258,
+	],
+
+	hp: 60,
+
+	types: [
+		"Water",
+	],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			cost: [
+				"Water",
+			],
+			name: {
+				en: "Tackle",
+				fr: "Charge",
+			},
+
+			damage: 10,
+
+		},
+		{
+			cost: [
+				"Water",
+				"Colorless",
+			],
+			name: {
+				en: "Mud-Slap",
+				fr: "Coud'Boue",
+			},
+
+			damage: 20,
+
+		},
+	],
+
+	weaknesses: [
+		{
+			type: "Grass",
+			value: "×2"
+		},
+	],
+
+	retreat: 1,
+
+	description: {
+		en: "To alert it, the fin on its head senses the flow of water. It has the strength to heft boulders."
+	},
+
+	variants: {
+		normal: true,
+		reverse: false,
+		holo: true,
+		firstEdition: false
+	}
+}
+
+export default card

--- a/data/McDonald's Collection/McDonald's Collection 2021/2.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2021/2.ts
@@ -1,0 +1,66 @@
+import { Card } from '../../../interfaces'
+import Set from '../McDonald\'s Collection 2021'
+
+const card: Card = {
+	name: {
+		en: "Chikorita",
+		fr: "Germignon"
+	},
+
+	illustrator: "sowsow",
+	rarity: "None",
+	category: "Pokemon",
+	set: Set,
+
+	dexId: [
+		152,
+	],
+
+	hp: 70,
+
+	types: [
+		"Grass",
+	],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			cost: [
+				"Grass",
+			],
+			name: {
+				en: "Mini Drain",
+				fr: "Mini-Assèchement"
+			},
+			effect: {
+				en: "Heal 10 damage from this Pokémon.",
+				fr: "Soignez 10 dégâts à ce Pokémon."
+			},
+			damage: 10,
+
+		},
+	],
+
+	weaknesses: [
+		{
+			type: "Fire",
+			value: "x2"
+		},
+	],
+
+	retreat: 1,
+
+	description: {
+		en: "It uses the leaf on its head to determine the temperature and humidity. It loves to sunbathe."
+	},
+
+	variants: {
+		normal: true,
+		reverse: false,
+		holo: true,
+		firstEdition: false
+	}
+}
+
+export default card

--- a/data/McDonald's Collection/McDonald's Collection 2021/20.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2021/20.ts
@@ -1,0 +1,76 @@
+import { Card } from '../../../interfaces'
+import Set from '../McDonald\'s Collection 2021'
+
+const card: Card = {
+	name: {
+		en: "Piplup",
+		fr: "Tiplouf",
+	},
+
+	illustrator: "Shibuzoh.",
+	rarity: "None",
+	category: "Pokemon",
+	set: Set,
+
+	dexId: [
+		393,
+	],
+
+	hp: 70,
+
+	types: [
+		"Water",
+	],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			cost: [
+				"Colorless",
+			],
+			name: {
+				en: "Peck",
+				fr: "Picpic",
+			},
+
+			damage: 10,
+
+		},
+		{
+			cost: [
+				"Water",
+				"Colorless",
+			],
+			name: {
+				en: "Wave Splash",
+				fr: "Grosse Vague",
+			},
+
+			damage: 20,
+
+		},
+	],
+
+	weaknesses: [
+		{
+			type: "Lightning",
+			value: "×2"
+		},
+	],
+
+	retreat: 1,
+
+	description: {
+		en: "Because it is very proud, it hates accepting food from people. Its thick down guards it from cold."
+	},
+
+	variants: {
+		normal: true,
+		reverse: false,
+		holo: true,
+		firstEdition: false
+	}
+}
+
+export default card

--- a/data/McDonald's Collection/McDonald's Collection 2021/21.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2021/21.ts
@@ -1,0 +1,67 @@
+import { Card } from '../../../interfaces'
+import Set from '../McDonald\'s Collection 2021'
+
+const card: Card = {
+	name: {
+		en: "Oshawott",
+		fr: "Moustillon",
+	},
+
+	illustrator: "Ken Sugimori",
+	rarity: "None",
+	category: "Pokemon",
+	set: Set,
+
+	dexId: [
+		501,
+	],
+
+	hp: 60,
+
+	types: [
+		"Water",
+	],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			cost: [
+				"Water",
+				"Colorless",
+			],
+			name: {
+				en: "Water Pulse",
+				fr: "Vibraqua",
+			},
+			effect: {
+				en: "Flip a coin. If heads, the Defending Pokémon is now Asleep.",
+				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Endormi.",
+			},
+			damage: 20,
+
+		},
+	],
+
+	weaknesses: [
+		{
+			type: "Lightning",
+			value: "×2"
+		},
+	],
+
+	retreat: 1,
+
+	description: {
+		en: "It fights using the scalchop on its stomach. In response to an attack, it retaliates immediately by slashing."
+	},
+
+	variants: {
+		normal: true,
+		reverse: false,
+		holo: true,
+		firstEdition: false
+	}
+}
+
+export default card

--- a/data/McDonald's Collection/McDonald's Collection 2021/22.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2021/22.ts
@@ -1,0 +1,76 @@
+import { Card } from '../../../interfaces'
+import Set from '../McDonald\'s Collection 2021'
+
+const card: Card = {
+	name: {
+		en: "Froakie",
+		fr: "Grenousse",
+	},
+
+	illustrator: "5ban Graphics",
+	rarity: "None",
+	category: "Pokemon",
+	set: Set,
+
+	dexId: [
+		656,
+	],
+
+	hp: 60,
+
+	types: [
+		"Water",
+	],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			cost: [
+				"Water",
+			],
+			name: {
+				en: "Pound",
+				fr: "Écras'Face",
+			},
+
+			damage: 10,
+
+		},
+		{
+			cost: [
+				"Water",
+				"Colorless",
+			],
+			name: {
+				en: "Water Drip",
+				fr: "Goutte à Goutte",
+			},
+
+			damage: 20,
+
+		},
+	],
+
+	weaknesses: [
+		{
+			type: "Grass",
+			value: "×2"
+		},
+	],
+
+	retreat: 1,
+
+	description: {
+		en: "It secretes flexible bubbles from its chest and back. The bubbles reduce the damage it would otherwise take when attacked."
+	},
+
+	variants: {
+		normal: true,
+		reverse: false,
+		holo: true,
+		firstEdition: false
+	}
+}
+
+export default card

--- a/data/McDonald's Collection/McDonald's Collection 2021/23.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2021/23.ts
@@ -1,0 +1,76 @@
+import { Card } from '../../../interfaces'
+import Set from '../McDonald\'s Collection 2021'
+
+const card: Card = {
+	name: {
+		en: "Popplio",
+		fr: "Otaquin",
+	},
+
+	illustrator: "Kouki Saitou",
+	rarity: "None",
+	category: "Pokemon",
+	set: Set,
+
+	dexId: [
+		728,
+	],
+
+	hp: 70,
+
+	types: [
+		"Water",
+	],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			cost: [
+				"Water",
+			],
+			name: {
+				en: "Pound",
+				fr: "Écras’Face",
+			},
+
+			damage: 10,
+
+		},
+		{
+			cost: [
+				"Water",
+				"Colorless",
+			],
+			name: {
+				en: "Water Gun",
+				fr: "Pistolet à O",
+			},
+
+			damage: 20,
+
+		},
+	],
+
+	weaknesses: [
+		{
+			type: "Grass",
+			value: "×2"
+		},
+	],
+
+	retreat: 1,
+
+	description: {
+		en: "This Pokémon snorts body fluids from its nose, blowing balloons to smash into its foes. It’s famous for being a hard worker."
+	},
+
+	variants: {
+		normal: true,
+		reverse: false,
+		holo: true,
+		firstEdition: false
+	}
+}
+
+export default card

--- a/data/McDonald's Collection/McDonald's Collection 2021/24.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2021/24.ts
@@ -1,0 +1,63 @@
+import { Card } from '../../../interfaces'
+import Set from '../McDonald\'s Collection 2021'
+
+const card: Card = {
+	dexId: [816],
+	name: {
+		en: "Sobble",
+		fr: "Larméléon",
+	},
+
+	illustrator: "Mizue",
+	rarity: "None",
+	category: "Pokemon",
+	set: Set,
+	hp: 60,
+
+	types: [
+		"Water",
+	],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			cost: [
+				"Water",
+				"Colorless",
+			],
+			name: {
+				en: "Bind",
+				fr: "Étreinte",
+			},
+			effect: {
+				en: "Flip a coin. If heads, your opponent’s Active Pokémon is now Paralyzed.",
+				fr: "Lancez une pièce. Si c'est face, le Pokémon Actif de votre adversaire est maintenant Paralysé.",
+			},
+			damage: 20,
+
+		},
+	],
+
+	weaknesses: [
+		{
+			type: "Lightning",
+			value: "×2"
+		},
+	],
+
+	retreat: 1,
+
+	description: {
+		en: "When scared, this Pokémon cries. Its tears pack the chemical punch of 100 onions, and attackers won’t be able to resist weeping."
+	},
+
+	variants: {
+		normal: true,
+		reverse: false,
+		holo: true,
+		firstEdition: false
+	}
+}
+
+export default card

--- a/data/McDonald's Collection/McDonald's Collection 2021/25.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2021/25.ts
@@ -1,0 +1,85 @@
+import { Card } from '../../../interfaces'
+import Set from '../McDonald\'s Collection 2021'
+
+const card: Card = {
+	name: {
+		en: "Pikachu",
+		fr: "Pikachu",
+	},
+
+	illustrator: "Sanosuke Sakuma",
+	rarity: "None",
+	category: "Pokemon",
+	set: Set,
+
+	dexId: [
+		25,
+	],
+
+	hp: 60,
+
+	types: [
+		"Lightning",
+	],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			cost: [
+				"Lightning",
+			],
+			name: {
+				en: "Meal Time",
+				fr: "À Belles Dents",
+			},
+			effect: {
+				en: "Flip a coin until you get tails. For each heads, draw a card.",
+				fr: "Lancez une pièce jusqu’à ce que vous obteniez un côté pile. Pour chaque côté face, piochez une carte.",
+			},
+
+		},
+		{
+			cost: [
+				"Lightning",
+				"Colorless",
+			],
+			name: {
+				en: "Gnaw",
+				fr: "Ronge",
+			},
+
+			damage: 20,
+
+		},
+	],
+
+	weaknesses: [
+		{
+			type: "Fighting",
+			value: "×2"
+		},
+	],
+
+	resistances: [
+		{
+			type: "Metal",
+			value: "-20"
+		},
+	],
+
+	retreat: 1,
+
+	description: {
+		en: "Its nature is to store up electricity. Forests where nests of Pikachu live are dangerous, since the trees are so often struck by lightning."
+	},
+
+	variants: {
+		normal: true,
+		reverse: false,
+		holo: true,
+		firstEdition: false
+	}
+}
+
+export default card

--- a/data/McDonald's Collection/McDonald's Collection 2021/3.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2021/3.ts
@@ -1,0 +1,67 @@
+import { Card } from '../../../interfaces'
+import Set from '../McDonald\'s Collection 2021'
+
+const card: Card = {
+	name: {
+		en: "Treecko",
+		fr: "Arcko"
+	},
+
+	illustrator: "Akira Komayama",
+	rarity: "None",
+	category: "Pokemon",
+	set: Set,
+
+	dexId: [
+		252,
+	],
+
+	hp: 60,
+
+	types: [
+		"Grass",
+	],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			cost: [
+				"Grass",
+				"Colorless",
+			],
+			name: {
+				en: "Quick Attack",
+				fr: "Vive-Attaque"
+			},
+			effect: {
+				en: "Flip a coin. If heads, this attack does 10 more damage.",
+				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 10 dégâts supplémentaires."
+			},
+			damage: "10+",
+
+		},
+	],
+
+	weaknesses: [
+		{
+			type: "Fire",
+			value: "x2"
+		},
+	],
+
+	retreat: 1,
+
+	description: {
+		en: "Small hooks on the bottom of its feet catch on walls and ceilings. That is how it can hang from above."
+	},
+
+	variants: {
+		normal: true,
+		reverse: false,
+		holo: true,
+		firstEdition: false
+	}
+}
+
+export default card

--- a/data/McDonald's Collection/McDonald's Collection 2021/4.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2021/4.ts
@@ -1,0 +1,78 @@
+import { Card } from '../../../interfaces'
+import Set from '../McDonald\'s Collection 2021'
+
+const card: Card = {
+	name: {
+		en: "Turtwig",
+		fr: "Tortipouss"
+	},
+
+	illustrator: "OOYAMA",
+	rarity: "None",
+	category: "Pokemon",
+	set: Set,
+
+	dexId: [
+		1,
+	],
+
+	hp: 80,
+
+	types: [
+		"Grass",
+	],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			cost: [
+				"Colorless",
+				"Colorless",
+			],
+			name: {
+				en: "Tackle",
+				fr: "Charge"
+			},
+
+			damage: 20,
+
+		},
+		{
+			cost: [
+				"Grass",
+				"Grass",
+				"Colorless",
+			],
+			name: {
+				en: "Razor Leaf",
+				fr: "Tranch'Herbe"
+			},
+
+			damage: 50,
+
+		},
+	],
+
+	weaknesses: [
+		{
+			type: "Fire",
+			value: "x2"
+		},
+	],
+
+	retreat: 2,
+
+	description: {
+		en: "It undertakes photosynthesis with its body, making oxygen. The leaf on its head wilts if it is thirsty."
+	},
+
+	variants: {
+		normal: true,
+		reverse: false,
+		holo: true,
+		firstEdition: false
+	}
+}
+
+export default card

--- a/data/McDonald's Collection/McDonald's Collection 2021/5.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2021/5.ts
@@ -1,0 +1,74 @@
+import { Card } from '../../../interfaces'
+import Set from '../McDonald\'s Collection 2021'
+
+const card: Card = {
+	name: {
+		en: "Snivy",
+		fr: "Vipélierre",
+	},
+
+	illustrator: "Ken Sugimori",
+	rarity: "None",
+	category: "Pokemon",
+	set: Set,
+
+	dexId: [
+		495,
+	],
+
+	hp: 60,
+
+	types: [
+		"Grass",
+	],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			cost: [
+				"Grass",
+				"Colorless",
+			],
+			name: {
+				en: "Slam",
+				fr: "Souplesse",
+			},
+			effect: {
+				en: "Flip 2 coins. This attack does 20 damage times the number of heads.",
+				fr: "Lancez 2 pièces. Cette attaque inflige 20 dégâts multipliés par le nombre de côtés face.",
+			},
+			damage: "20×",
+
+		},
+	],
+
+	weaknesses: [
+		{
+			type: "Fire",
+			value: "×2"
+		},
+	],
+
+	resistances: [
+		{
+			type: "Water",
+			value: "-20"
+		},
+	],
+
+	retreat: 1,
+
+	description: {
+		en: "It is very intelligent and calm. Being exposed to lots of sunlight makes its movements swifter."
+	},
+
+	variants: {
+		normal: true,
+		reverse: false,
+		holo: true,
+		firstEdition: false
+	}
+}
+
+export default card

--- a/data/McDonald's Collection/McDonald's Collection 2021/6.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2021/6.ts
@@ -1,0 +1,76 @@
+import { Card } from '../../../interfaces'
+import Set from '../McDonald\'s Collection 2021'
+
+const card: Card = {
+	name: {
+		en: "Chespin",
+		fr: "Marisson",
+	},
+
+	illustrator: "5ban Graphics",
+	rarity: "None",
+	category: "Pokemon",
+	set: Set,
+
+	dexId: [
+		650,
+	],
+
+	hp: 60,
+
+	types: [
+		"Grass",
+	],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			cost: [
+				"Grass",
+			],
+			name: {
+				en: "Vine Whip",
+				fr: "Fouet Lianes",
+			},
+
+			damage: 10,
+
+		},
+		{
+			cost: [
+				"Grass",
+				"Colorless",
+			],
+			name: {
+				en: "Seed Bomb",
+				fr: "Canon Graine",
+			},
+
+			damage: 20,
+
+		},
+	],
+
+	weaknesses: [
+		{
+			type: "Fire",
+			value: "×2"
+		},
+	],
+
+	retreat: 1,
+
+	description: {
+		en: "The quills on its head are usually soft. When it flexes them, the points become so hard and sharp that they can pierce rock."
+	},
+
+	variants: {
+		normal: true,
+		reverse: false,
+		holo: true,
+		firstEdition: false
+	}
+}
+
+export default card

--- a/data/McDonald's Collection/McDonald's Collection 2021/7.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2021/7.ts
@@ -1,0 +1,76 @@
+import { Card } from '../../../interfaces'
+import Set from '../McDonald\'s Collection 2021'
+
+const card: Card = {
+	name: {
+		en: "Rowlet",
+		fr: "Brindibou",
+	},
+
+	illustrator: "Megumi Mizutani",
+	rarity: "None",
+	category: "Pokemon",
+	set: Set,
+
+	dexId: [
+		722,
+	],
+
+	hp: 60,
+
+	types: [
+		"Grass",
+	],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			cost: [
+				"Colorless",
+			],
+			name: {
+				en: "Tackle",
+				fr: "Charge",
+			},
+
+			damage: 10,
+
+		},
+		{
+			cost: [
+				"Grass",
+				"Colorless",
+			],
+			name: {
+				en: "Leafage",
+				fr: "Feuillage",
+			},
+
+			damage: 20,
+
+		},
+	],
+
+	weaknesses: [
+		{
+			type: "Fire",
+			value: "×2"
+		},
+	],
+
+	retreat: 1,
+
+	description: {
+		en: "This wary Pokémon uses photosynthesis to store up energy during the day, while becoming active at night."
+	},
+
+	variants: {
+		normal: true,
+		reverse: false,
+		holo: true,
+		firstEdition: false
+	}
+}
+
+export default card

--- a/data/McDonald's Collection/McDonald's Collection 2021/8.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2021/8.ts
@@ -1,0 +1,60 @@
+import { Card } from '../../../interfaces'
+import Set from '../McDonald\'s Collection 2021'
+
+const card: Card = {
+	dexId: [810],
+	name: {
+		en: "Grookey",
+		fr: "Ouistempo",
+	},
+
+	illustrator: "kirisAki",
+	rarity: "None",
+	category: "Pokemon",
+	set: Set,
+	hp: 60,
+
+	types: [
+		"Grass",
+	],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			cost: [
+				"Grass",
+				"Colorless",
+			],
+			name: {
+				en: "Branch Poke",
+				fr: "Tapotige",
+			},
+
+			damage: 30,
+
+		},
+	],
+
+	weaknesses: [
+		{
+			type: "Fire",
+			value: "×2"
+		},
+	],
+
+	retreat: 1,
+
+	description: {
+		en: "When it uses its special stick to strike up a beat, the sound waves produced carry revitalizing energy to the plants and flowers in the area."
+	},
+
+	variants: {
+		normal: true,
+		reverse: false,
+		holo: true,
+		firstEdition: false
+	}
+}
+
+export default card

--- a/data/McDonald's Collection/McDonald's Collection 2021/9.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2021/9.ts
@@ -1,0 +1,76 @@
+import { Card } from '../../../interfaces'
+import Set from '../McDonald\'s Collection 2021'
+
+const card: Card = {
+	name: {
+		en: "Charmander",
+		fr: "Salamèche",
+	},
+
+	illustrator: "Kagemaru Himeno",
+	rarity: "None",
+	category: "Pokemon",
+	set: Set,
+
+	dexId: [
+		4,
+	],
+
+	hp: 70,
+
+	types: [
+		"Fire",
+	],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			cost: [
+				"Colorless",
+			],
+			name: {
+				en: "Scratch",
+				fr: "Griffe",
+			},
+
+			damage: 10,
+
+		},
+		{
+			cost: [
+				"Fire",
+				"Colorless",
+			],
+			name: {
+				en: "Flame Tail",
+				fr: "Queue de Flammes",
+			},
+
+			damage: 20,
+
+		},
+	],
+
+	weaknesses: [
+		{
+			type: "Water",
+			value: "×2"
+		},
+	],
+
+	retreat: 1,
+
+	description: {
+		en: "The flame on its tail indicates Charmander’s life force. If it is healthy, the flame burns brightly."
+	},
+
+	variants: {
+		normal: true,
+		reverse: false,
+		holo: true,
+		firstEdition: false
+	}
+}
+
+export default card


### PR DESCRIPTION
Set: **McDonald's Collection 2021**
Series folder: `McDonald's Collection`
Changed card files: **25**

### Validation
- [ ] `bun run validate`
- [ ] `cd server && bun run --bun validate`
- [ ] `cd server && bun run compile`
- [ ] Manual review: translations, energy types, TS syntax

### Card images
See follow-up comments with embedded TCGdex assets.