### PR TITLE
fix(data): Neo Revelation (Neo)

### DIFF
--- a/data/Neo/Neo Revelation/61.ts
+++ b/data/Neo/Neo Revelation/61.ts
@@ -14,8 +14,8 @@ const card: Card = {
 	set: Set,
 
 	effect: {
-		fr: "Cette carte reste en jeu lorsque vous la jouez. Défaussez cette carte si une autre carte Stade arrive en jeu.\n\nUne fois durant le tour de chaque joueur, celui-ci peut lancer une pièce. Si c'est face, ce joueur peut retirer 2 marqueurs de dégâts sur son Pokémon Actif (1 s'il n'en a qu'un seul).",
-		de: "Once during each player's turn, he or she may flip a coin. If heads, that player removes 2 damage counters from his or her Active Pokémon (1 if it only has 1)."
+		fr: "Cette carte reste en jeu lorsque vous la jouez. Défaussez cette carte si une autre carte Stade arrive en jeu.",
+		de: "Once during each player's turn, he or she may flip a coin. If heads, that player removes 2 damage counters from his or her Active Pokémon (1 if it only has 1).",
 	},
 
 	thirdParty: {

--- a/data/Neo/Neo Revelation/63.ts
+++ b/data/Neo/Neo Revelation/63.ts
@@ -14,8 +14,8 @@ const card: Card = {
 	set: Set,
 
 	effect: {
-		fr: "Cette carte reste en jeu lorsque vous la jouez. Défaussez cette carte si une autre carte Stade arrive en jeu.\n\nTout Pokémon en jeu ayant Obscur dans son nom (même chez votre adversaire) obtient +20 PV.",
-		de: "Each Pokémon in play with Dark in its name (even your opponent's) gets + 20 HP."
+		fr: "Cette carte reste en jeu lorsque vous la jouez. Défaussez cette carte si une autre carte Stade arrive en jeu.",
+		de: "Each Pokémon in play with Dark in its name (even your opponent's) gets + 20 HP.",
 	},
 
 	thirdParty: {


### PR DESCRIPTION
Set: **Neo Revelation**
Series folder: `Neo`
Changed card files: **2**

### Validation
- [ ] `bun run validate`
- [ ] `cd server && bun run --bun validate`
- [ ] `cd server && bun run compile`
- [ ] Manual review: translations, energy types, TS syntax

### Card images
See follow-up comments with embedded TCGdex assets.