### PR TITLE
fix(data): Nintendo Black Star Promos (POP)

### DIFF
--- a/data/POP/Nintendo Black Star Promos/1.ts
+++ b/data/POP/Nintendo Black Star Promos/1.ts
@@ -6,7 +6,7 @@ const card: Card = {
 		en: "Kyogre ex",
 	},
 	illustrator: "Hiromichi Sugiyama",
-	rarity: "Common",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/POP/Nintendo Black Star Promos/10.ts
+++ b/data/POP/Nintendo Black Star Promos/10.ts
@@ -7,7 +7,7 @@ const card: Card = {
 		fr: "Gobou"
 	},
 	illustrator: "Atsuko Nishida",
-	rarity: "Common",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/POP/Nintendo Black Star Promos/11.ts
+++ b/data/POP/Nintendo Black Star Promos/11.ts
@@ -7,7 +7,7 @@ const card: Card = {
 		fr: "Flobio"
 	},
 	illustrator: "Mitsuhiro Arita",
-	rarity: "Common",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/POP/Nintendo Black Star Promos/12.ts
+++ b/data/POP/Nintendo Black Star Promos/12.ts
@@ -6,7 +6,7 @@ const card: Card = {
 		en: "Pikachu",
 	},
 	illustrator: "Kouki Saitou",
-	rarity: "Common",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/POP/Nintendo Black Star Promos/13.ts
+++ b/data/POP/Nintendo Black Star Promos/13.ts
@@ -6,7 +6,7 @@ const card: Card = {
 		en: "Meowth",
 	},
 	illustrator: "Kouki Saitou",
-	rarity: "Common",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/POP/Nintendo Black Star Promos/14.ts
+++ b/data/POP/Nintendo Black Star Promos/14.ts
@@ -6,7 +6,7 @@ const card: Card = {
 		en: "Latias",
 	},
 	illustrator: "Ken Sugimori",
-	rarity: "Common",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/POP/Nintendo Black Star Promos/15.ts
+++ b/data/POP/Nintendo Black Star Promos/15.ts
@@ -6,7 +6,7 @@ const card: Card = {
 		en: "Latios",
 	},
 	illustrator: "Ken Sugimori",
-	rarity: "Common",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/POP/Nintendo Black Star Promos/16.ts
+++ b/data/POP/Nintendo Black Star Promos/16.ts
@@ -6,7 +6,7 @@ const card: Card = {
 		en: "Treecko",
 	},
 	illustrator: "Kagemaru Himeno",
-	rarity: "Common",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/POP/Nintendo Black Star Promos/17.ts
+++ b/data/POP/Nintendo Black Star Promos/17.ts
@@ -6,7 +6,7 @@ const card: Card = {
 		en: "Torchic",
 	},
 	illustrator: "Kagemaru Himeno",
-	rarity: "Common",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/POP/Nintendo Black Star Promos/18.ts
+++ b/data/POP/Nintendo Black Star Promos/18.ts
@@ -6,7 +6,7 @@ const card: Card = {
 		en: "Mudkip",
 	},
 	illustrator: "Kagemaru Himeno",
-	rarity: "Common",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/POP/Nintendo Black Star Promos/19.ts
+++ b/data/POP/Nintendo Black Star Promos/19.ts
@@ -6,7 +6,7 @@ const card: Card = {
 		en: "Whismur",
 	},
 	illustrator: "Kagemaru Himeno",
-	rarity: "Common",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/POP/Nintendo Black Star Promos/2.ts
+++ b/data/POP/Nintendo Black Star Promos/2.ts
@@ -6,7 +6,7 @@ const card: Card = {
 		en: "Groudon ex",
 	},
 	illustrator: "Kazuo Yazawa",
-	rarity: "Common",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/POP/Nintendo Black Star Promos/20.ts
+++ b/data/POP/Nintendo Black Star Promos/20.ts
@@ -6,7 +6,7 @@ const card: Card = {
 		en: "Ludicolo",
 	},
 	illustrator: "Kouki Saitou",
-	rarity: "Common",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/POP/Nintendo Black Star Promos/21.ts
+++ b/data/POP/Nintendo Black Star Promos/21.ts
@@ -6,7 +6,7 @@ const card: Card = {
 		en: "Jirachi",
 	},
 	illustrator: "Atsuko Nishida",
-	rarity: "Common",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/POP/Nintendo Black Star Promos/22.ts
+++ b/data/POP/Nintendo Black Star Promos/22.ts
@@ -6,7 +6,7 @@ const card: Card = {
 		en: "Beldum",
 	},
 	illustrator: "Mitsuhiro Arita",
-	rarity: "Common",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/POP/Nintendo Black Star Promos/23.ts
+++ b/data/POP/Nintendo Black Star Promos/23.ts
@@ -6,7 +6,7 @@ const card: Card = {
 		en: "Metang",
 	},
 	illustrator: "Mitsuhiro Arita",
-	rarity: "Common",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/POP/Nintendo Black Star Promos/24.ts
+++ b/data/POP/Nintendo Black Star Promos/24.ts
@@ -6,7 +6,7 @@ const card: Card = {
 		en: "Chimecho",
 	},
 	illustrator: "Atsuko Nishida",
-	rarity: "Common",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/POP/Nintendo Black Star Promos/25.ts
+++ b/data/POP/Nintendo Black Star Promos/25.ts
@@ -7,7 +7,7 @@ const card: Card = {
 		fr: "Libegon"
 	},
 	illustrator: "Kouki Saitou",
-	rarity: "Common",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/POP/Nintendo Black Star Promos/26.ts
+++ b/data/POP/Nintendo Black Star Promos/26.ts
@@ -7,7 +7,7 @@ const card: Card = {
 		fr: "Vent tropical"
 	},
 	illustrator: "Sumiyoshi Kizuki",
-	rarity: "Common",
+	rarity: "Black Star Promo",
 	category: "Trainer",
 
 	set: Set,

--- a/data/POP/Nintendo Black Star Promos/27.ts
+++ b/data/POP/Nintendo Black Star Promos/27.ts
@@ -7,7 +7,7 @@ const card: Card = {
 		fr: "Raz-de-marée tropical"
 	},
 	illustrator: undefined,
-	rarity: "Common",
+	rarity: "Black Star Promo",
 	category: "Trainer",
 
 	set: Set,

--- a/data/POP/Nintendo Black Star Promos/28.ts
+++ b/data/POP/Nintendo Black Star Promos/28.ts
@@ -6,7 +6,7 @@ const card: Card = {
 		en: "Championship Arena",
 	},
 	illustrator: "Ryo Ueda",
-	rarity: "Common",
+	rarity: "Black Star Promo",
 	category: "Trainer",
 
 	set: Set,

--- a/data/POP/Nintendo Black Star Promos/29.ts
+++ b/data/POP/Nintendo Black Star Promos/29.ts
@@ -7,7 +7,7 @@ const card: Card = {
 		fr: "Celebi"
 	},
 	illustrator: "Hajime Kusajima",
-	rarity: "Common",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/POP/Nintendo Black Star Promos/3.ts
+++ b/data/POP/Nintendo Black Star Promos/3.ts
@@ -7,7 +7,7 @@ const card: Card = {
 		fr: "Arcko"
 	},
 	illustrator: "Atsuko Nishida",
-	rarity: "Common",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/POP/Nintendo Black Star Promos/30.ts
+++ b/data/POP/Nintendo Black Star Promos/30.ts
@@ -7,7 +7,7 @@ const card: Card = {
 		fr: "Suicune"
 	},
 	illustrator: "Atsuko Nishida",
-	rarity: "Common",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/POP/Nintendo Black Star Promos/31.ts
+++ b/data/POP/Nintendo Black Star Promos/31.ts
@@ -7,7 +7,7 @@ const card: Card = {
 		fr: "Sulfura ex"
 	},
 	illustrator: "Ken Ikuji",
-	rarity: "Common",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/POP/Nintendo Black Star Promos/32.ts
+++ b/data/POP/Nintendo Black Star Promos/32.ts
@@ -7,7 +7,7 @@ const card: Card = {
 		fr: "Artikodin ex"
 	},
 	illustrator: "Nakaoka",
-	rarity: "Common",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/POP/Nintendo Black Star Promos/33.ts
+++ b/data/POP/Nintendo Black Star Promos/33.ts
@@ -7,7 +7,7 @@ const card: Card = {
 		fr: "Electhor ex"
 	},
 	illustrator: "K. Hoshiba",
-	rarity: "Common",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/POP/Nintendo Black Star Promos/34.ts
+++ b/data/POP/Nintendo Black Star Promos/34.ts
@@ -6,7 +6,7 @@ const card: Card = {
 		en: "Typhlosion",
 	},
 	illustrator: "Hajime Kusajima",
-	rarity: "Common",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/POP/Nintendo Black Star Promos/35.ts
+++ b/data/POP/Nintendo Black Star Promos/35.ts
@@ -6,7 +6,7 @@ const card: Card = {
 		en: "Pikachu δ",
 	},
 	illustrator: "Ryo Ueda",
-	rarity: "Common",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/POP/Nintendo Black Star Promos/36.ts
+++ b/data/POP/Nintendo Black Star Promos/36.ts
@@ -7,7 +7,7 @@ const card: Card = {
 		fr: "Raz-de-marée tropical"
 	},
 	illustrator: undefined,
-	rarity: "Common",
+	rarity: "Black Star Promo",
 	category: "Trainer",
 
 	set: Set,

--- a/data/POP/Nintendo Black Star Promos/37.ts
+++ b/data/POP/Nintendo Black Star Promos/37.ts
@@ -7,7 +7,7 @@ const card: Card = {
 		fr: "Kyogre ex"
 	},
 	illustrator: "Ryo Ueda",
-	rarity: "Common",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/POP/Nintendo Black Star Promos/38.ts
+++ b/data/POP/Nintendo Black Star Promos/38.ts
@@ -7,7 +7,7 @@ const card: Card = {
 		fr: "Groudon ex"
 	},
 	illustrator: "Ryo Ueda",
-	rarity: "Common",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/POP/Nintendo Black Star Promos/39.ts
+++ b/data/POP/Nintendo Black Star Promos/39.ts
@@ -7,7 +7,7 @@ const card: Card = {
 		fr: "Rayquaza ex"
 	},
 	illustrator: "Ryo Ueda",
-	rarity: "Common",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/POP/Nintendo Black Star Promos/4.ts
+++ b/data/POP/Nintendo Black Star Promos/4.ts
@@ -7,7 +7,7 @@ const card: Card = {
 		fr: "Massko"
 	},
 	illustrator: "Midori Harada",
-	rarity: "Common",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/POP/Nintendo Black Star Promos/40.ts
+++ b/data/POP/Nintendo Black Star Promos/40.ts
@@ -6,7 +6,7 @@ const card: Card = {
 		en: "Mew",
 	},
 	illustrator: "Masakazu Fukuda",
-	rarity: "Common",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/POP/Nintendo Black Star Promos/5.ts
+++ b/data/POP/Nintendo Black Star Promos/5.ts
@@ -7,7 +7,7 @@ const card: Card = {
 		fr: "Gobou"
 	},
 	illustrator: "Atsuko Nishida",
-	rarity: "Common",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/POP/Nintendo Black Star Promos/6.ts
+++ b/data/POP/Nintendo Black Star Promos/6.ts
@@ -7,7 +7,7 @@ const card: Card = {
 		fr: "Poussifeu"
 	},
 	illustrator: "Atsuko Nishida",
-	rarity: "Common",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/POP/Nintendo Black Star Promos/7.ts
+++ b/data/POP/Nintendo Black Star Promos/7.ts
@@ -7,7 +7,7 @@ const card: Card = {
 		fr: "Treecko"
 	},
 	illustrator: "Atsuko Nishida",
-	rarity: "Common",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/POP/Nintendo Black Star Promos/8.ts
+++ b/data/POP/Nintendo Black Star Promos/8.ts
@@ -7,7 +7,7 @@ const card: Card = {
 		fr: "Poussifeu"
 	},
 	illustrator: "Atsuko Nishida",
-	rarity: "Common",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/POP/Nintendo Black Star Promos/9.ts
+++ b/data/POP/Nintendo Black Star Promos/9.ts
@@ -7,7 +7,7 @@ const card: Card = {
 		fr: "Galifeu"
 	},
 	illustrator: "Kouki Saitou",
-	rarity: "Common",
+	rarity: "Black Star Promo",
 	category: "Trainer",
 
 	set: Set,
@@ -25,6 +25,32 @@ const card: Card = {
 	stage: "Stage1",
 
 
+
+	attacks: [
+		{
+			cost: [
+				"Fire",
+			],
+			name: {
+				fr: "Intimidation",
+			},
+			damage: "20",
+		},
+		{
+			cost: [
+				"Colorless",
+				"Colorless",
+				"Colorless",
+			],
+			name: {
+				fr: "Double pied",
+			},
+			damage: "40×",
+			effect: {
+				fr: "Lancez deux pièces. Cette attaque inflige 40 dégâts multipliés par le nombre de face.",
+			},
+		},
+	],
 
 	weaknesses: [
 		{


### PR DESCRIPTION
Set: **Nintendo Black Star Promos**
Series folder: `POP`
Changed card files: **40**

### Validation
- [ ] `bun run validate`
- [ ] `cd server && bun run --bun validate`
- [ ] `cd server && bun run compile`
- [ ] Manual review: translations, energy types, TS syntax

### Card images
See follow-up comments with embedded TCGdex assets.