### PR TITLE
fix(data): Paldean Fates (Scarlet & Violet)

### DIFF
--- a/data/Scarlet & Violet/Paldean Fates/091.ts
+++ b/data/Scarlet & Violet/Paldean Fates/091.ts
@@ -18,11 +18,11 @@ const card: Card = {
 
 	effect: {
 		en: "You can use this card only if you discard 2 other cards from your hand.\n\nSearch your deck for a Pokémon, reveal it, and put it into your hand. Then, shuffle your deck.",
-		fr: "Vous ne pouvez utiliser cette carte que si vous défaussez 2 autres cartes de votre main.\n\nCherchez dans votre deck un Pokémon, montrez-le, puis ajoutez-le à votre main. Mélangez ensuite votre deck.",
+		fr: "Vous ne pouvez utiliser cette carte que si vous défaussez 2 autres cartes de votre main.",
 		es: "Puedes usar esta carta solo si descartas otras 2 cartas de tu mano.\nBusca en tu baraja 1 Pokémon, enséñalo y ponlo en tu mano. Después, baraja las cartas de tu baraja.",
 		it: "Puoi usare questa carta solo se scarti altre due carte che hai in mano.\n\nCerca nel tuo mazzo un Pokémon, mostralo e aggiungilo alle carte che hai in mano. Poi rimischia le carte del tuo mazzo.",
 		pt: "Você só pode usar esta carta se descartar outras 2 cartas da sua mão.\nProcure por um Pokémon no seu baralho, revele-o e coloque-o na sua mão. Em seguida, embaralhe o seu baralho.",
-		de: "Du kannst diese Karte nur einsetzen, wenn du 2 andere Karten aus deiner Hand auf deinen Ablagestapel legst.\nDurchsuche dein Deck nach 1 Pokémon, zeige es deinem Gegner und nimm es auf deine Hand. Mische anschließend dein Deck."
+		de: "Du kannst diese Karte nur einsetzen, wenn du 2 andere Karten aus deiner Hand auf deinen Ablagestapel legst.\nDurchsuche dein Deck nach 1 Pokémon, zeige es deinem Gegner und nimm es auf deine Hand. Mische anschließend dein Deck.",
 	},
 
 	trainerType: "Item",


### PR DESCRIPTION
Set: **Paldean Fates**
Series folder: `Scarlet & Violet`
Changed card files: **1**

### Validation
- [ ] `bun run validate`
- [ ] `cd server && bun run --bun validate`
- [ ] `cd server && bun run compile`
- [ ] Manual review: translations, energy types, TS syntax

### Card images
See follow-up comments with embedded TCGdex assets.