### PR TITLE
fix(data): SVP Black Star Promos (Scarlet & Violet)

### DIFF
--- a/data/Scarlet & Violet/SVP Black Star Promos/001.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/001.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		de: "Felori"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 70,
 	types: ["Grass"],

--- a/data/Scarlet & Violet/SVP Black Star Promos/002.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/002.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		de: "Krokel"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 80,
 	types: ["Fire"],

--- a/data/Scarlet & Violet/SVP Black Star Promos/003.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/003.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		de: "Kwaks"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 70,
 	types: ["Water"],

--- a/data/Scarlet & Violet/SVP Black Star Promos/004.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/004.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		de: "Mimigma-ex"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 190,
 	types: ["Psychic"],

--- a/data/Scarlet & Violet/SVP Black Star Promos/005.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/005.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		de: "Bailonda"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 170,
 	types: ["Water"],

--- a/data/Scarlet & Violet/SVP Black Star Promos/006.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/006.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		de: "Pamomamo"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 130,
 	types: ["Lightning"],

--- a/data/Scarlet & Violet/SVP Black Star Promos/007.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/007.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		de: "Resladero"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 70,
 	types: ["Fighting"],

--- a/data/Scarlet & Violet/SVP Black Star Promos/008.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/008.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		de: "Knattatox"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 140,
 	types: ["Metal"],

--- a/data/Scarlet & Violet/SVP Black Star Promos/009.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/009.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		de: "Spinsidias"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 120,
 	types: ["Grass"],

--- a/data/Scarlet & Violet/SVP Black Star Promos/010.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/010.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		de: "Psiopatra"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 110,
 	types: ["Psychic"],

--- a/data/Scarlet & Violet/SVP Black Star Promos/011.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/011.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		de: "Arkani"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 130,
 	types: ["Fire"],

--- a/data/Scarlet & Violet/SVP Black Star Promos/012.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/012.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		de: "Heerashai"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 150,
 	types: ["Water"],

--- a/data/Scarlet & Violet/SVP Black Star Promos/013.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/013.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		de: "Miraidon"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 120,
 	types: ["Lightning"],

--- a/data/Scarlet & Violet/SVP Black Star Promos/014.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/014.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		de: "Koraidon"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 130,
 	types: ["Fighting"],

--- a/data/Scarlet & Violet/SVP Black Star Promos/015.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/015.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		de: "Waaty"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 90,
 	types: ["Lightning"],

--- a/data/Scarlet & Violet/SVP Black Star Promos/016.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/016.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		de: "Ampharos-ex"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 330,
 	types: ["Lightning"],

--- a/data/Scarlet & Violet/SVP Black Star Promos/017.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/017.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		de: "Lucario-ex"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 260,
 	types: ["Fighting"],

--- a/data/Scarlet & Violet/SVP Black Star Promos/018.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/018.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		de: "Mopex-ex"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 210,
 	types: ["Colorless"],

--- a/data/Scarlet & Violet/SVP Black Star Promos/019.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/019.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		de: "Espinodon"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 160,
 	types: ["Water"],

--- a/data/Scarlet & Violet/SVP Black Star Promos/020.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/020.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		de: "Granforgita"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 140,
 	types: ["Psychic"],

--- a/data/Scarlet & Violet/SVP Black Star Promos/021.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/021.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		de: "Kramurx"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 60,
 	types: ["Darkness"],

--- a/data/Scarlet & Violet/SVP Black Star Promos/022.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/022.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		de: "Pelipper"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 120,
 	types: ["Colorless"],

--- a/data/Scarlet & Violet/SVP Black Star Promos/023.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/023.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		de: "Olini"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 60,
 	types: ["Grass"],

--- a/data/Scarlet & Violet/SVP Black Star Promos/024.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/024.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		de: "Fukano"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 90,
 	types: ["Fire"],

--- a/data/Scarlet & Violet/SVP Black Star Promos/025.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/025.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		de: "Forgita"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 70,
 	types: ["Psychic"],

--- a/data/Scarlet & Violet/SVP Black Star Promos/026.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/026.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		de: "Knattox"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 60,
 	types: ["Metal"],

--- a/data/Scarlet & Violet/SVP Black Star Promos/027.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/027.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		de: "Pikachu"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 60,
 	types: ["Lightning"],

--- a/data/Scarlet & Violet/SVP Black Star Promos/028.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/028.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		de: "Miraidon-ex"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 220,
 	types: ["Lightning"],

--- a/data/Scarlet & Violet/SVP Black Star Promos/029.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/029.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		de: "Koraidon-ex"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 230,
 	types: ["Fighting"],

--- a/data/Scarlet & Violet/SVP Black Star Promos/030.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/030.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		de: "Baojian-ex"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 220,
 	types: ["Water"],

--- a/data/Scarlet & Violet/SVP Black Star Promos/031.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/031.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		de: "Granforgita-ex"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 300,
 	types: ["Psychic"],

--- a/data/Scarlet & Violet/SVP Black Star Promos/032.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/032.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		de: "Epitaff-ex"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 320,
 	types: ["Fighting"],

--- a/data/Scarlet & Violet/SVP Black Star Promos/033.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/033.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		de: "Maskagato-ex"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 310,
 	types: ["Grass"],

--- a/data/Scarlet & Violet/SVP Black Star Promos/034.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/034.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		de: "Skelokrok-ex"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 340,
 	types: ["Fire"],

--- a/data/Scarlet & Violet/SVP Black Star Promos/035.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/035.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		de: "Bailonda-ex"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 320,
 	types: ["Water"],

--- a/data/Scarlet & Violet/SVP Black Star Promos/036.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/036.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		de: "Delfinator"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 150,
 	types: ["Water"],

--- a/data/Scarlet & Violet/SVP Black Star Promos/037.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/037.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		de: "Pii"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 30,
 	types: ["Psychic"],

--- a/data/Scarlet & Violet/SVP Black Star Promos/038.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/038.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		de: "Togekiss"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 150,
 	types: ["Psychic"],

--- a/data/Scarlet & Violet/SVP Black Star Promos/039.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/039.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		de: "Flunkifer"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 90,
 	types: ["Metal"],

--- a/data/Scarlet & Violet/SVP Black Star Promos/040.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/040.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		de: "Pamo"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 50,
 	types: ["Lightning"],

--- a/data/Scarlet & Violet/SVP Black Star Promos/041.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/041.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		de: "Paldea-Felino"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 60,
 	types: ["Darkness"],

--- a/data/Scarlet & Violet/SVP Black Star Promos/042.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/042.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		de: "Friedwuff"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 130,
 	types: ["Psychic"],

--- a/data/Scarlet & Violet/SVP Black Star Promos/043.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/043.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		de: "Evoli"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 60,
 	types: ["Colorless"],

--- a/data/Scarlet & Violet/SVP Black Star Promos/044.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/044.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		de: "Glumanda"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 60,
 	types: ["Fire"],

--- a/data/Scarlet & Violet/SVP Black Star Promos/045.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/045.ts
@@ -13,7 +13,7 @@ const card: Card = {
 		de: "Paradies Resort"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Trainer",
 
 	effect: {

--- a/data/Scarlet & Violet/SVP Black Star Promos/046.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/046.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		de: "Bisasam"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 70,
 	types: ["Grass"],

--- a/data/Scarlet & Violet/SVP Black Star Promos/047.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/047.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		de: "Glumanda"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 70,
 	types: ["Fire"],

--- a/data/Scarlet & Violet/SVP Black Star Promos/048.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/048.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		de: "Schiggy"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 70,
 	types: ["Water"],

--- a/data/Scarlet & Violet/SVP Black Star Promos/049.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/049.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		de: "Zapdos-ex"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 200,
 	types: ["Lightning"],

--- a/data/Scarlet & Violet/SVP Black Star Promos/050.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/050.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		de: "Simsala-ex"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 310,
 	types: ["Psychic"],

--- a/data/Scarlet & Violet/SVP Black Star Promos/051.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/051.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		de: "Relaxo"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 150,
 	types: ["Colorless"],

--- a/data/Scarlet & Violet/SVP Black Star Promos/052.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/052.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		de: "Mewtu"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 130,
 	types: ["Psychic"],

--- a/data/Scarlet & Violet/SVP Black Star Promos/053.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/053.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		de: "Mew-ex"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 180,
 	types: ["Psychic"],

--- a/data/Scarlet & Violet/SVP Black Star Promos/054.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/054.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		de: "Quajutsu-ex"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 300,
 	types: ["Water"],

--- a/data/Scarlet & Violet/SVP Black Star Promos/055.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/055.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		de: "Kangama-ex"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 230,
 	types: ["Colorless"],

--- a/data/Scarlet & Violet/SVP Black Star Promos/056.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/056.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		de: "Glurak-ex"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 330,
 	types: ["Darkness"],

--- a/data/Scarlet & Violet/SVP Black Star Promos/057.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/057.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		de: "Yuyu"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 110,
 	types: ["Fire"],

--- a/data/Scarlet & Violet/SVP Black Star Promos/058.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/058.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		de: "Eisenbündel"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 100,
 	types: ["Water"],

--- a/data/Scarlet & Violet/SVP Black Star Promos/059.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/059.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		de: "Xatu"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 100,
 	types: ["Psychic"],

--- a/data/Scarlet & Violet/SVP Black Star Promos/060.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/060.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		de: "Durengard"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 150,
 	types: ["Metal"],

--- a/data/Scarlet & Violet/SVP Black Star Promos/061.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/061.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		de: "Tannza"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 70,
 	types: ["Grass"],

--- a/data/Scarlet & Violet/SVP Black Star Promos/062.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/062.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		de: "Fatalitee"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 30,
 	types: ["Psychic"],

--- a/data/Scarlet & Violet/SVP Black Star Promos/063.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/063.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		de: "Kolowal"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 170,
 	types: ["Water"],

--- a/data/Scarlet & Violet/SVP Black Star Promos/064.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/064.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		de: "Cryospino"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 90,
 	types: ["Water"],

--- a/data/Scarlet & Violet/SVP Black Star Promos/065.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/065.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		de: "Brüllschweif"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 90,
 	types: ["Psychic"],

--- a/data/Scarlet & Violet/SVP Black Star Promos/066.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/066.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		de: "Eisenbündel"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 100,
 	types: ["Water"],

--- a/data/Scarlet & Violet/SVP Black Star Promos/067.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/067.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		de: "Donnersichel-ex"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 230,
 	types: ["Darkness"],

--- a/data/Scarlet & Violet/SVP Black Star Promos/068.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/068.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		de: "Eisenkrieger-ex"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 220,
 	types: ["Psychic"],

--- a/data/Scarlet & Violet/SVP Black Star Promos/069.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/069.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		de: "Hefel"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 50,
 	types: ["Psychic"],

--- a/data/Scarlet & Violet/SVP Black Star Promos/070.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/070.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		de: "Gruff"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 70,
 	types: ["Psychic"],

--- a/data/Scarlet & Violet/SVP Black Star Promos/071.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/071.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		de: "Mobtiff"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 60,
 	types: ["Darkness"],

--- a/data/Scarlet & Violet/SVP Black Star Promos/072.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/072.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		de: "Riesenzahn-ex"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 250,
 	types: ["Fighting"],

--- a/data/Scarlet & Violet/SVP Black Star Promos/073.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/073.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		de: "Eisenrad-ex"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 220,
 	types: ["Metal"],

--- a/data/Scarlet & Violet/SVP Black Star Promos/074.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/074.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		de: "Glurak-ex"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 330,
 	types: ["Darkness"],

--- a/data/Scarlet & Violet/SVP Black Star Promos/075.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/075.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		de: "Mimigma"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 70,
 	types: ["Psychic"],

--- a/data/Scarlet & Violet/SVP Black Star Promos/076.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/076.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		de: "Felori"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 60,
 	types: ["Grass"],

--- a/data/Scarlet & Violet/SVP Black Star Promos/077.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/077.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		de: "Feliospa"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 90,
 	types: ["Grass"],

--- a/data/Scarlet & Violet/SVP Black Star Promos/078.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/078.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		de: "Maskagato-ex"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 310,
 	types: ["Grass"],

--- a/data/Scarlet & Violet/SVP Black Star Promos/079.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/079.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		de: "Krokel"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 80,
 	types: ["Fire"],

--- a/data/Scarlet & Violet/SVP Black Star Promos/080.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/080.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		de: "Lokroko"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 110,
 	types: ["Fire"],

--- a/data/Scarlet & Violet/SVP Black Star Promos/081.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/081.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		de: "Skelokrok-ex"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 340,
 	types: ["Fire"],

--- a/data/Scarlet & Violet/SVP Black Star Promos/082.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/082.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		de: "Kwaks"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 70,
 	types: ["Water"],

--- a/data/Scarlet & Violet/SVP Black Star Promos/083.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/083.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		de: "Fuentente"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 90,
 	types: ["Water"],

--- a/data/Scarlet & Violet/SVP Black Star Promos/084.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/084.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		de: "Bailonda-ex"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 320,
 	types: ["Water"],

--- a/data/Scarlet & Violet/SVP Black Star Promos/085.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/085.ts
@@ -12,7 +12,7 @@ const card: Card = {
 
 	illustrator: "Naoyo Kimura",
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	dexId: [25],

--- a/data/Scarlet & Violet/SVP Black Star Promos/086.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/086.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		de: "Mastifioso-ex"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 260,
 	types: ["Darkness"],

--- a/data/Scarlet & Violet/SVP Black Star Promos/087.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/087.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		de: "Felori-ex"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 200,
 	types: ["Grass"],

--- a/data/Scarlet & Violet/SVP Black Star Promos/088.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/088.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		de: "Pikachu"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 70,
 	types: ["Lightning"],

--- a/data/Scarlet & Violet/SVP Black Star Promos/089.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/089.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		de: "Impergator"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 180,
 	types: ["Water"],

--- a/data/Scarlet & Violet/SVP Black Star Promos/090.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/090.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		de: "Metang"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 100,
 	types: ["Metal"],

--- a/data/Scarlet & Violet/SVP Black Star Promos/091.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/091.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		de: "Koraidon"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 140,
 	types: ["Dragon"],

--- a/data/Scarlet & Violet/SVP Black Star Promos/092.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/092.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		de: "Miraidon"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 110,
 	types: ["Dragon"],

--- a/data/Scarlet & Violet/SVP Black Star Promos/093.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/093.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		de: "Kanivanha"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 50,
 	types: ["Water"],

--- a/data/Scarlet & Violet/SVP Black Star Promos/094.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/094.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		de: "Wampitz"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 130,
 	types: ["Lightning"],

--- a/data/Scarlet & Violet/SVP Black Star Promos/095.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/095.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		de: "Pii"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 30,
 	types: ["Psychic"],

--- a/data/Scarlet & Violet/SVP Black Star Promos/096.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/096.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		de: "Mopex"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 120,
 	types: ["Colorless"],

--- a/data/Scarlet & Violet/SVP Black Star Promos/097.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/097.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		de: "Flatterhaar"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 90,
 	types: ["Psychic"],

--- a/data/Scarlet & Violet/SVP Black Star Promos/098.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/098.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		de: "Eisendorn"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 140,
 	types: ["Lightning"],

--- a/data/Scarlet & Violet/SVP Black Star Promos/099.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/099.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		de: "Sproxi"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 50,
 	types: ["Colorless"],

--- a/data/Scarlet & Violet/SVP Black Star Promos/100.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/100.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		de: "Affiti-ex"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 250,
 	types: ["Colorless"],

--- a/data/Scarlet & Violet/SVP Black Star Promos/101.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/101.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		de: "Pikachu"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 70,
 	types: ["Lightning"],

--- a/data/Scarlet & Violet/SVP Black Star Promos/102.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/102.ts
@@ -12,7 +12,7 @@ const card: Card = {
 
 	illustrator: "Miranda Branley",
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	dexId: [43],

--- a/data/Scarlet & Violet/SVP Black Star Promos/103.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/103.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		de: "Hundemon-ex"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 270,
 	types: ["Darkness"],

--- a/data/Scarlet & Violet/SVP Black Star Promos/104.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/104.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		de: "Melmetal-ex"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 300,
 	types: ["Metal"],

--- a/data/Scarlet & Violet/SVP Black Star Promos/105.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/105.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		de: "Crimanzo-ex"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 260,
 	types: ["Fire"],

--- a/data/Scarlet & Violet/SVP Black Star Promos/106.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/106.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		de: "Pikachu-ex"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 200,
 	types: ["Lightning"],

--- a/data/Scarlet & Violet/SVP Black Star Promos/107.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/107.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		de: "Voltilamm"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 60,
 	types: ["Lightning"],

--- a/data/Scarlet & Violet/SVP Black Star Promos/108.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/108.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		de: "Waaty"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 90,
 	types: ["Lightning"],

--- a/data/Scarlet & Violet/SVP Black Star Promos/109.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/109.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		de: "Ampharos"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 160,
 	types: ["Lightning"],

--- a/data/Scarlet & Violet/SVP Black Star Promos/110.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/110.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		de: "Darkrai-ex"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 210,
 	types: ["Darkness"],

--- a/data/Scarlet & Violet/SVP Black Star Promos/111.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/111.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		de: "Gladiantri"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 70,
 	types: ["Darkness"],

--- a/data/Scarlet & Violet/SVP Black Star Promos/112.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/112.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		de: "Caesurio"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 100,
 	types: ["Darkness"],

--- a/data/Scarlet & Violet/SVP Black Star Promos/113.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/113.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		de: "Gladimperio"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 170,
 	types: ["Darkness"],

--- a/data/Scarlet & Violet/SVP Black Star Promos/114.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/114.ts
@@ -13,7 +13,7 @@ const card: Card = {
 		de: "Picknickerin"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Trainer",
 
 	effect: {

--- a/data/Scarlet & Violet/SVP Black Star Promos/115.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/115.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		de: "Chimstix"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 100,
 	types: ["Grass"],

--- a/data/Scarlet & Violet/SVP Black Star Promos/116.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/116.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		de: "Panferno"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 140,
 	types: ["Fire"],

--- a/data/Scarlet & Violet/SVP Black Star Promos/117.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/117.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		de: "Frosdedje"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 90,
 	types: ["Water"],

--- a/data/Scarlet & Violet/SVP Black Star Promos/118.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/118.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		de: "Nigiragi"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 70,
 	types: ["Dragon"],

--- a/data/Scarlet & Violet/SVP Black Star Promos/119.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/119.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		de: "Toxel"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 70,
 	types: ["Lightning"],

--- a/data/Scarlet & Violet/SVP Black Star Promos/120.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/120.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		de: "Pupitar"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 80,
 	types: ["Fighting"],

--- a/data/Scarlet & Violet/SVP Black Star Promos/121.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/121.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		de: "Knattatox"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 140,
 	types: ["Metal"],

--- a/data/Scarlet & Violet/SVP Black Star Promos/122.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/122.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		de: "Relaxo"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 160,
 	types: ["Colorless"],

--- a/data/Scarlet & Violet/SVP Black Star Promos/123.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/123.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		de: "Türkisgrüne-Maske-Ogerpon"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 110,
 	types: ["Grass"],

--- a/data/Scarlet & Violet/SVP Black Star Promos/124.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/124.ts
@@ -13,7 +13,7 @@ const card: Card = {
 		de: "Enigmara"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Trainer",
 
 	effect: {

--- a/data/Scarlet & Violet/SVP Black Star Promos/125.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/125.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		de: "Crimanzo-ex"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 260,
 	types: ["Fire"],

--- a/data/Scarlet & Violet/SVP Black Star Promos/126.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/126.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		de: "Delfinator-ex"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 340,
 	types: ["Water"],

--- a/data/Scarlet & Violet/SVP Black Star Promos/127.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/127.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		de: "Windewoge-ex"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 220,
 	types: ["Water"],

--- a/data/Scarlet & Violet/SVP Black Star Promos/128.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/128.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		de: "Eisenblatt-ex"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 220,
 	types: ["Grass"],

--- a/data/Scarlet & Violet/SVP Black Star Promos/129.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/129.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		de: "Infamomo"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 80,
 	types: ["Darkness"],

--- a/data/Scarlet & Violet/SVP Black Star Promos/130.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/130.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		de: "Gladimperio"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 180,
 	types: ["Metal"],

--- a/data/Scarlet & Violet/SVP Black Star Promos/131.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/131.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		de: "Seedraking-ex"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 310,
 	types: ["Water"],

--- a/data/Scarlet & Violet/SVP Black Star Promos/132.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/132.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		de: "Quajutsu-ex"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 300,
 	types: ["Water"],

--- a/data/Scarlet & Violet/SVP Black Star Promos/133.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/133.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		de: "Ledian"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 90,
 	types: ["Grass"],

--- a/data/Scarlet & Violet/SVP Black Star Promos/134.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/134.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		de: "Krawell"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 160,
 	types: ["Water"],

--- a/data/Scarlet & Violet/SVP Black Star Promos/135.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/135.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		de: "Drifzepeli"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 130,
 	types: ["Psychic"],

--- a/data/Scarlet & Violet/SVP Black Star Promos/136.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/136.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		de: "Bisofank"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 100,
 	types: ["Colorless"],

--- a/data/Scarlet & Violet/SVP Black Star Promos/137.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/137.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		de: "Seeper"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 60,
 	types: ["Water"],

--- a/data/Scarlet & Violet/SVP Black Star Promos/138.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/138.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		de: "Porygon2"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 90,
 	types: ["Colorless"],

--- a/data/Scarlet & Violet/SVP Black Star Promos/139.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/139.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		de: "Latias"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 110,
 	types: ["Psychic"],

--- a/data/Scarlet & Violet/SVP Black Star Promos/140.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/140.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		de: "Granforgita"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 140,
 	types: ["Psychic"],

--- a/data/Scarlet & Violet/SVP Black Star Promos/141.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/141.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		de: "Noctuh"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 100,
 	types: ["Colorless"],

--- a/data/Scarlet & Violet/SVP Black Star Promos/142.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/142.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		de: "Victini-ex"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 190,
 	types: ["Fire"],

--- a/data/Scarlet & Violet/SVP Black Star Promos/143.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/143.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		de: "Miraidon-ex"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 220,
 	types: ["Lightning"],

--- a/data/Scarlet & Violet/SVP Black Star Promos/144.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/144.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		de: "Keilflamme-ex"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 230,
 	types: ["Fire"],

--- a/data/Scarlet & Violet/SVP Black Star Promos/145.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/145.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		de: "Furienblitz-ex"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 240,
 	types: ["Dragon"],

--- a/data/Scarlet & Violet/SVP Black Star Promos/146.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/146.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		de: "Eisenhaupt-ex"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 220,
 	types: ["Psychic"],

--- a/data/Scarlet & Violet/SVP Black Star Promos/147.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/147.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		de: "Eisenfels-ex"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 240,
 	types: ["Fighting"],

--- a/data/Scarlet & Violet/SVP Black Star Promos/148.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/148.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		de: "Miraidon"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 120,
 	types: ["Lightning"],

--- a/data/Scarlet & Violet/SVP Black Star Promos/149.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/149.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		de: "Infamomo"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 80,
 	types: ["Darkness"],

--- a/data/Scarlet & Violet/SVP Black Star Promos/150.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/150.ts
@@ -13,7 +13,7 @@ const card: Card = {
 		de: "Paradies Resort"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Trainer",
 
 	effect: {

--- a/data/Scarlet & Violet/SVP Black Star Promos/151.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/151.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		de: "Keilflamme"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 130,
 	types: ["Fire"],

--- a/data/Scarlet & Violet/SVP Black Star Promos/152.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/152.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		de: "Baojian"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 120,
 	types: ["Water"],

--- a/data/Scarlet & Violet/SVP Black Star Promos/153.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/153.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		de: "Magneton"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 100,
 	types: ["Lightning"],

--- a/data/Scarlet & Violet/SVP Black Star Promos/154.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/154.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		de: "Servol"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 100,
 	types: ["Psychic"],

--- a/data/Scarlet & Violet/SVP Black Star Promos/155.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/155.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		de: "Felino"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 60,
 	types: ["Water"],

--- a/data/Scarlet & Violet/SVP Black Star Promos/156.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/156.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		de: "Morlord"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 120,
 	types: ["Water"],

--- a/data/Scarlet & Violet/SVP Black Star Promos/157.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/157.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		de: "Zapdos"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 110,
 	types: ["Lightning"],

--- a/data/Scarlet & Violet/SVP Black Star Promos/158.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/158.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		de: "Pachirisu"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 70,
 	types: ["Lightning"],

--- a/data/Scarlet & Violet/SVP Black Star Promos/159.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/159.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		de: "Magneton"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 100,
 	types: ["Lightning"],

--- a/data/Scarlet & Violet/SVP Black Star Promos/160.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/160.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		de: "Krawalloro-ex"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 160,
 	types: ["Colorless"],

--- a/data/Scarlet & Violet/SVP Black Star Promos/161.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/161.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		de: "Glurak-ex"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 330,
 	types: ["Fire"],

--- a/data/Scarlet & Violet/SVP Black Star Promos/162.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/162.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		de: "Friedwuff-ex"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 260,
 	types: ["Psychic"],

--- a/data/Scarlet & Violet/SVP Black Star Promos/163.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/163.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		de: "Liberlo-ex"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 320,
 	types: ["Fire"],

--- a/data/Scarlet & Violet/SVP Black Star Promos/164.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/164.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		de: "Lapras-ex"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 220,
 	types: ["Water"],

--- a/data/Scarlet & Violet/SVP Black Star Promos/165.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/165.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		de: "Terapagos-ex"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 230,
 	types: ["Colorless"],

--- a/data/Scarlet & Violet/SVP Black Star Promos/166.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/166.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		de: "Türkisgrüne-Maske-Ogerpon-ex"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 210,
 	types: ["Grass"],

--- a/data/Scarlet & Violet/SVP Black Star Promos/167.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/167.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		it: "Flareon"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 130,
 	types: ["Fire"],

--- a/data/Scarlet & Violet/SVP Black Star Promos/168.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/168.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		it: "Vaporeon"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 130,
 	types: ["Water"],

--- a/data/Scarlet & Violet/SVP Black Star Promos/169.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/169.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		it: "Jolteon"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 110,
 	types: ["Lightning"],

--- a/data/Scarlet & Violet/SVP Black Star Promos/170.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/170.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		it: "Leafeon"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 120,
 	types: ["Grass"],

--- a/data/Scarlet & Violet/SVP Black Star Promos/171.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/171.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		it: "Glaceon"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 120,
 	types: ["Water"],

--- a/data/Scarlet & Violet/SVP Black Star Promos/172.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/172.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		it: "Sylveon"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 120,
 	types: ["Psychic"],

--- a/data/Scarlet & Violet/SVP Black Star Promos/173.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/173.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		it: "Eevee"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 50,
 	types: ["Colorless"],

--- a/data/Scarlet & Violet/SVP Black Star Promos/174.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/174.ts
@@ -17,7 +17,7 @@ const card: Card = {
 
 	illustrator: "Natsuko Shoji été",
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 200,
 	types: ["Colorless"],

--- a/data/Scarlet & Violet/SVP Black Star Promos/175.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/175.ts
@@ -4,83 +4,97 @@ import Set from "../SVP Black Star Promos"
 const card: Card = {
 	dexId: [196],
 	set: Set,
+
 	name: {
 		en: "Espeon ex",
 		fr: "Mentali-ex",
 		es: "Espeon ex",
-		pt: "Espeon ex",
 		it: "Espeon-ex",
+		pt: "Espeon ex",
 		de: "Psiana-ex"
 	},
-	rarity: "None",
+
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 270,
 	types: ["Psychic"],
+
 	evolveFrom: {
 		en: "Eevee",
 		fr: "Évoli",
 		es: "Eevee",
-		pt: "Eevee",
 		it: "Eevee",
+		pt: "Eevee",
 		de: "Evoli"
 	},
+
 	stage: "Stage1",
+
 	attacks: [
 		{
 			cost: ["Psychic", "Colorless", "Colorless"],
+
 			name: {
 				en: "Psych Out",
 				fr: "Déstabilisation",
 				es: "Psicointimidación",
-				pt: "Intimidar",
 				it: "Intimidazione",
+				pt: "Intimidar",
 				de: "Nervös machen"
 			},
+
 			effect: {
 				en: "Discard a random card from your opponent's hand.",
 				fr: "Défaussez au hasard une carte de la main de votre adversaire.",
 				es: "Descarta 1 carta aleatoria de la mano de tu rival.",
-				pt: "Descarte uma carta aleatória da mão do seu oponente.",
 				it: "Scarta una carta a caso dalla mano del tuo avversario.",
+				pt: "Descarte uma carta aleatória da mão do seu oponente.",
 				de: "Lege 1 zufällige Karte aus der Hand deines Gegners auf seinen Ablagestapel."
 			},
+
 			damage: 160
 		},
 		{
 			cost: ["Grass", "Psychic", "Darkness"],
+
 			name: {
 				en: "Amazez",
 				fr: "Améthyste Chevron",
 				es: "Azeztulita",
-				pt: "Cacoxenita",
 				it: "Ametista Chevron",
+				pt: "Cacoxenita",
 				de: "Amazez"
 			},
+
 			effect: {
 				en: "Devolve each of your opponent's evolved Pokémon by shuffling the highest Stage Evolution card on it into your opponent's deck.",
 				fr: "Faites dés-évoluer chacun des Pokémon évolués de votre adversaire en mélangeant avec le deck de votre adversaire la carte Évolution la plus élevée placée sur ceux-ci.",
 				es: "Haz involucionar a cada uno de los Pokémon evolucionados de tu rival poniendo la carta de Evolución de fase más alta que tengan sobre ellos en la baraja de tu rival, y barájalas todas.",
-				pt: "Reverta a evolução de cada um dos Pokémon evoluídos do seu oponente embaralhando a carta de Evolução de Estágio mais alto sobre ele no baralho do seu oponente.",
 				it: "Annulla l'evoluzione di ciascuno dei Pokémon evoluti del tuo avversario rimischiando la carta Evoluzione di fase più alta presente su di esso nel mazzo del tuo avversario.",
+				pt: "Reverta a evolução de cada um dos Pokémon evoluídos do seu oponente embaralhando a carta de Evolução de Estágio mais alto sobre ele no baralho do seu oponente.",
 				de: "Rückentwickle jedes entwickelte Pokémon deines Gegners, indem du deinem Gegner die Karte mit der höchsten Entwicklungsphase in sein Deck mischst."
 			}
 		}
 	],
+
 	weaknesses: [
 		{
 			type: "Darkness",
 			value: "×2"
 		}
 	],
+
 	resistances: [
 		{
 			type: "Fighting",
 			value: "-30"
 		}
 	],
+
 	retreat: 1,
 	regulationMark: "H",
-	illustrator: "5ban Graphics",
+	illustrator: "5ban Graphics"
 }
 
 export default card
+

--- a/data/Scarlet & Violet/SVP Black Star Promos/176.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/176.ts
@@ -4,77 +4,90 @@ import Set from "../SVP Black Star Promos"
 const card: Card = {
 	dexId: [197],
 	set: Set,
+
 	name: {
 		en: "Umbreon ex",
 		fr: "Noctali-ex",
 		es: "Umbreon ex",
-		pt: "Umbreon ex",
 		it: "Umbreon-ex",
+		pt: "Umbreon ex",
 		de: "Nachtara-ex"
 	},
-	rarity: "None",
+
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 280,
 	types: ["Darkness"],
+
 	evolveFrom: {
 		en: "Eevee",
 		fr: "Évoli",
 		es: "Eevee",
-		pt: "Eevee",
 		it: "Eevee",
+		pt: "Eevee",
 		de: "Evoli"
 	},
+
 	stage: "Stage1",
+
 	attacks: [
 		{
 			cost: ["Darkness", "Colorless", "Colorless"],
+
 			name: {
 				en: "Moon Mirage",
 				fr: "Mirage Lunaire",
 				es: "Espejismo Lunar",
-				pt: "Miragem Lunar",
 				it: "Miraggio Lunare",
+				pt: "Miragem Lunar",
 				de: "Mondillusion"
 			},
+
 			effect: {
 				en: "Your opponent's Active Pokémon is now Confused.",
 				fr: "Le Pokémon Actif de votre adversaire est maintenant Confus.",
 				es: "El Pokémon Activo de tu rival pasa a estar Confundido.",
-				pt: "O Pokémon Ativo do seu oponente agora está Confuso.",
 				it: "Il Pokémon attivo del tuo avversario viene confuso.",
+				pt: "O Pokémon Ativo do seu oponente agora está Confuso.",
 				de: "Das Aktive Pokémon deines Gegners ist jetzt verwirrt."
 			},
+
 			damage: 160
 		},
 		{
 			cost: ["Lightning", "Psychic", "Darkness"],
+
 			name: {
 				en: "Onyx",
 				fr: "Onyx",
 				es: "Ónice",
-				pt: "Ônix",
 				it: "Onice",
+				pt: "Ônix",
 				de: "Onyx"
 			},
+
 			effect: {
 				en: "Discard all Energy from this Pokémon, and take a Prize card.",
 				fr: "Défaussez toutes les Énergies attachées à ce Pokémon, puis récupérez une carte Récompense.",
 				es: "Descarta todas las Energías de este Pokémon y coge 1 carta de Premio.",
-				pt: "Descarte todas as Energias deste Pokémon e pegue uma carta de Prêmio.",
 				it: "Scarta tutte le Energie da questo Pokémon e prendi una carta Premio.",
+				pt: "Descarte todas as Energias deste Pokémon e pegue uma carta de Prêmio.",
 				de: "Lege alle Energien von diesem Pokémon auf deinen Ablagestapel und nimm 1 Preiskarte."
 			}
 		}
 	],
+
 	weaknesses: [
 		{
 			type: "Grass",
 			value: "×2"
 		}
 	],
+
 	retreat: 2,
 	regulationMark: "H",
-	illustrator: "5ban Graphics",
+	illustrator: "5ban Graphics"
 }
 
 export default card
+

--- a/data/Scarlet & Violet/SVP Black Star Promos/177.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/177.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		de: "Blutmond-Ursaluna-ex"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 260,
 	types: ["Colorless"],

--- a/data/Scarlet & Violet/SVP Black Star Promos/178.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/178.ts
@@ -15,7 +15,7 @@ const card: Card = {
 	},
 
 	illustrator: "takuyoa",
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 230,
 	types: ["Water"],

--- a/data/Scarlet & Violet/SVP Black Star Promos/179.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/179.ts
@@ -15,7 +15,7 @@ const card: Card = {
 	},
 
 	illustrator: "PLANETA Igarashi",
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 210,
 	types: ["Psychic"],

--- a/data/Scarlet & Violet/SVP Black Star Promos/180.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/180.ts
@@ -15,7 +15,7 @@ const card: Card = {
 	},
 
 	illustrator: "PLANETA Tsuji",
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 220,
 	types: ["Metal"],

--- a/data/Scarlet & Violet/SVP Black Star Promos/181.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/181.ts
@@ -15,7 +15,7 @@ const card: Card = {
 	},
 
 	illustrator: "Takeshi Nakamura",
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 140,
 	types: ["Fire"],

--- a/data/Scarlet & Violet/SVP Black Star Promos/182.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/182.ts
@@ -15,7 +15,7 @@ const card: Card = {
 	},
 
 	illustrator: "DOM",
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 120,
 	types: ["Lightning"],

--- a/data/Scarlet & Violet/SVP Black Star Promos/183.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/183.ts
@@ -15,7 +15,7 @@ const card: Card = {
 	},
 
 	illustrator: "tono",
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 70,
 	types: ["Psychic"],

--- a/data/Scarlet & Violet/SVP Black Star Promos/184.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/184.ts
@@ -15,7 +15,7 @@ const card: Card = {
 	},
 
 	illustrator: "OKACHEKE",
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 150,
 	types: ["Colorless"],

--- a/data/Scarlet & Violet/SVP Black Star Promos/185.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/185.ts
@@ -15,7 +15,7 @@ const card: Card = {
 	},
 
 	illustrator: "Dsuke",
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 60,
 	types: ["Grass"],

--- a/data/Scarlet & Violet/SVP Black Star Promos/186.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/186.ts
@@ -15,7 +15,7 @@ const card: Card = {
 	},
 
 	illustrator: "OKUBO",
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 60,
 	types: ["Darkness"],

--- a/data/Scarlet & Violet/SVP Black Star Promos/187.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/187.ts
@@ -15,7 +15,7 @@ const card: Card = {
 	},
 
 	illustrator: "Dsuke",
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 130,
 	types: ["Grass"],

--- a/data/Scarlet & Violet/SVP Black Star Promos/188.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/188.ts
@@ -15,7 +15,7 @@ const card: Card = {
 	},
 
 	illustrator: "OKUBO",
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 120,
 	types: ["Darkness"],

--- a/data/Scarlet & Violet/SVP Black Star Promos/189.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/189.ts
@@ -15,7 +15,7 @@ const card: Card = {
 	},
 
 	illustrator: "Megumi Mizutani",
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 70,
 	types: ["Darkness"],

--- a/data/Scarlet & Violet/SVP Black Star Promos/190.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/190.ts
@@ -13,7 +13,7 @@ const card: Card = {
 
 	illustrator: "Atsushi Furusawa",
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	dexId: [25],

--- a/data/Scarlet & Violet/SVP Black Star Promos/191.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/191.ts
@@ -9,7 +9,7 @@ const card: Card = {
 		fr: "Poussacha"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 70,
 	types: ["Grass"],

--- a/data/Scarlet & Violet/SVP Black Star Promos/192.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/192.ts
@@ -9,7 +9,7 @@ const card: Card = {
 		fr: "Chochodile"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 80,
 	types: ["Fire"],

--- a/data/Scarlet & Violet/SVP Black Star Promos/193.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/193.ts
@@ -15,7 +15,7 @@ const card: Card = {
 	},
 
 	illustrator: "PLANETA Mochizuki",
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 230,
 	types: ["Metal"],

--- a/data/Scarlet & Violet/SVP Black Star Promos/194.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/194.ts
@@ -17,7 +17,7 @@ const card: Card = {
 
 	illustrator: "PLANETA Mochizuki",
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 280,
 	types: ["Lightning"],

--- a/data/Scarlet & Violet/SVP Black Star Promos/195.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/195.ts
@@ -17,7 +17,7 @@ const card: Card = {
 
 	illustrator: "PLANETA Tsuji",
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 190,
 	types: ["Psychic"],

--- a/data/Scarlet & Violet/SVP Black Star Promos/196.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/196.ts
@@ -10,7 +10,7 @@ const card: Card = {
 	},
 
 	suffix: "EX",
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 330,
 	types: ["Darkness"],
@@ -39,10 +39,10 @@ const card: Card = {
 				en: "Infernal Reign",
 				fr: "Règne Infernal"
 			},
-			effect: {
-				en: "When you play this Pokémon from your hand to evolve 1 of your Pokémon during your turn, you may search your deck for up to 3 Basic Fire Energy cards and attach them to your Pokémon in any way you like. Then, shuffle your deck.",
-				fr: "Lorsque vous jouez ce Pokémon de votre main pour faire évoluer l'un de vos Pokémon pendant votre tour, vous pouvez chercher dans votre deck jusqu'à 3 cartes Énergie  de base et les attacher à vos Pokémon comme il vous plaît. Mélangez ensuite votre deck."
-			},
+		effect: {
+			en: "When you play this Pokémon from your hand to evolve 1 of your Pokémon during your turn, you may search your deck for up to 3 Basic Fire Energy cards and attach them to your Pokémon in any way you like. Then, shuffle your deck.",
+			fr: "Lorsque vous jouez ce Pokémon de votre main pour faire évoluer l'un de vos Pokémon pendant votre tour, vous pouvez chercher dans votre deck jusqu'à 3 cartes Énergie  de base et les attacher à vos Pokémon comme il vous plaît. Mélangez ensuite votre deck."
+		},
 		}
 	],
 

--- a/data/Scarlet & Violet/SVP Black Star Promos/197.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/197.ts
@@ -17,7 +17,7 @@ const card: Card = {
 
 	illustrator: "PLANETA Tsuji",
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 230,
 	types: ["Fighting"],

--- a/data/Scarlet & Violet/SVP Black Star Promos/198.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/198.ts
@@ -17,7 +17,7 @@ const card: Card = {
 
 	illustrator: "PLANETA Mochizuki",
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 220,
 	types: ["Metal"],

--- a/data/Scarlet & Violet/SVP Black Star Promos/199.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/199.ts
@@ -9,7 +9,7 @@ const card: Card = {
 		fr: "Zarude"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 120,
 	types: ["Grass"],
@@ -23,10 +23,10 @@ const card: Card = {
 				en: "Pluck off",
 				fr: "Retrait"
 			},
-			effect: {
-				en: "Search your deck for up to 3 Basic Grass Energy cards, reveal them, and put them into your hand. Then, shuffle your deck.",
-				fr: "Cherchez dans votre deck jusqu'à 3 cartes Énergie  de base, montrez-les, puis ajoutez-les à votre main. Mélangez ensuite votre deck."
-			}
+		effect: {
+			en: "Search your deck for up to 3 Basic Grass Energy cards, reveal them, and put them into your hand. Then, shuffle your deck.",
+			fr: "Cherchez dans votre deck jusqu'à 3 cartes Énergie  de base, montrez-les, puis ajoutez-les à votre main. Mélangez ensuite votre deck."
+		}
 		},
 		{
 			cost: ["Grass", "Grass", "Grass"],

--- a/data/Scarlet & Violet/SVP Black Star Promos/200.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/200.ts
@@ -9,7 +9,7 @@ const card: Card = {
 		fr: "Évoli"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 60,
 	types: ["Colorless"],

--- a/data/Scarlet & Violet/SVP Black Star Promos/201.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/201.ts
@@ -9,7 +9,7 @@ const card: Card = {
 		fr: "Zéblitz"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 120,
 	types: ["Lightning"],

--- a/data/Scarlet & Violet/SVP Black Star Promos/202.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/202.ts
@@ -9,7 +9,7 @@ const card: Card = {
 		fr: "Kangourex"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 130,
 	types: ["Colorless"],

--- a/data/Scarlet & Violet/SVP Black Star Promos/203.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/203.ts
@@ -9,7 +9,7 @@ const card: Card = {
 		fr: "Qulbutoké de la Team Rocket"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 110,
 	types: ["Psychic"],
@@ -18,21 +18,31 @@ const card: Card = {
 	dexId: [202],
 	attacks: [
 		{
-			cost: ["Psychic","Colorless"],
+			cost: [
+				"Psychic",
+				"Colorless",
+			],
 			name: {
 				en: "Rocket Mirror",
+				fr: "Miroir Rocket",
 			},
 			effect: {
-				en: "Move all damage counters from 1 of your Benched Team Rocket's Pokémon to your opponent's Active Pokémon."
-			}
+				en: "Move all damage counters from 1 of your Benched Team Rocket's Pokémon to your opponent's Active Pokémon.",
+				fr: "Déplacez tous les marqueurs de dégâts de l'un de vos Pokémon de la Team Rocket de Banc vers le Pokémon Actif de votre adversaire.",
+			},
 		},
 		{
-			cost: ["Psychic", "Colorless","Colorless"],
+			cost: [
+				"Psychic",
+				"Colorless",
+				"Colorless",
+			],
 			name: {
 				en: "Headbutt Bounce",
+				fr: "Culbute Surprise",
 			},
 			damage: 70,
-		}
+		},
 	],
 
 	weaknesses: [

--- a/data/Scarlet & Violet/SVP Black Star Promos/204.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/204.ts
@@ -9,7 +9,7 @@ const card: Card = {
 		fr: "Carchacrok-ex de Cynthia"
 	},
 	suffix: "EX",
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 330,
 	types: ["Fighting"],
@@ -27,25 +27,34 @@ const card: Card = {
 	dexId: [445],
 	attacks: [
 		{
-			cost: ["Fighting"],
+			cost: [
+				"Fighting",
+			],
 			name: {
 				en: "Corkscrew Dive",
+				fr: "Plongée Tire-Bouchon",
 			},
 			effect: {
-				en: "You may draw cards until you have 6 cards in your hand."
+				en: "You may draw cards until you have 6 cards in your hand.",
+				fr: "Vous pouvez piocher des cartes jusqu'à en avoir 6 dans votre main.",
 			},
 			damage: 100,
 		},
 		{
-			cost: ["Fighting", "Fighting"],
+			cost: [
+				"Fighting",
+				"Fighting",
+			],
 			name: {
 				en: "Draconic Buster",
+				fr: "Buster Draconien",
 			},
 			effect: {
-				en: "Discard all Energy from this Pokémon."
+				en: "Discard all Energy from this Pokémon.",
+				fr: "Défaussez toutes les Énergies de ce Pokémon.",
 			},
 			damage: 260,
-		}
+		},
 	],
 
 	weaknesses: [

--- a/data/Scarlet & Violet/SVP Black Star Promos/205.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/205.ts
@@ -9,7 +9,7 @@ const card: Card = {
 		fr: "Mewtwo-ex de la Team Rocket"
 	},
 	suffix: "EX",
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 280,
 	types: ["Psychic"],
@@ -33,13 +33,18 @@ const card: Card = {
 
 	attacks: [
 		{
-			cost: ["Psychic","Psychic","Colorless"],
+			cost: [
+				"Psychic",
+				"Psychic",
+				"Colorless",
+			],
 			name: {
 				en: "Erasure Ball",
+				fr: "Boule Effacement",
 			},
 			effect: {
-				en: "You may discard up to 2 Energy from your Benched Pokémon. This attack does 60 more damage for each" +
-					" card you discarded in this way."
+				en: "You may discard up to 2 Energy from your Benched Pokémon. This attack does 60 more damage for each card you discarded in this way.",
+				fr: "Vous pouvez défausser jusqu'à 2 Énergies de vos Pokémon de Banc. Cette attaque inflige 60 dégâts supplémentaires pour chaque carte défaussée de cette façon.",
 			},
 			damage: "160+",
 		},

--- a/data/Scarlet & Violet/SVP Black Star Promos/206.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/206.ts
@@ -17,7 +17,7 @@ const card: Card = {
 
 	illustrator: "Susumu Maeya",
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 70,
 	types: ["Darkness"],

--- a/data/Scarlet & Violet/SVP Black Star Promos/207.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/207.ts
@@ -17,7 +17,7 @@ const card: Card = {
 
 	illustrator: "hncl",
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 70,
 	types: ["Metal"],

--- a/data/Scarlet & Violet/SVP Black Star Promos/208.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/208.ts
@@ -10,7 +10,7 @@ const card: Card = {
 		fr: "Victini"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 80,
 	types: ["Fire"],

--- a/data/Scarlet & Violet/SVP Black Star Promos/209.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/209.ts
@@ -10,7 +10,7 @@ const card: Card = {
 		fr: "Fulguris"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 120,
 	types: ["Lightning"],

--- a/data/Scarlet & Violet/SVP Black Star Promos/210.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/210.ts
@@ -10,7 +10,7 @@ const card: Card = {
 		fr: "Boréas"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 120,
 	types: ["Colorless"],

--- a/data/Scarlet & Violet/SVP Black Star Promos/211.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/211.ts
@@ -10,7 +10,7 @@ const card: Card = {
 		fr: "Sidérella"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 150,
 	types: ["Colorless"],

--- a/data/Scarlet & Violet/SVP Black Star Promos/212.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/212.ts
@@ -10,7 +10,7 @@ const card: Card = {
 		fr: "Symbios"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 140,
 	types: ["Psychic"],

--- a/data/Scarlet & Violet/SVP Black Star Promos/213.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/213.ts
@@ -7,7 +7,7 @@ const card: Card = {
 	name: {
 		en: "Feraligatr",
 	},
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 180,
 	types: ["Water"],

--- a/data/Scarlet & Violet/SVP Black Star Promos/214.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/214.ts
@@ -7,7 +7,7 @@ const card: Card = {
 	name: {
 		en: "Pikachu",
 	},
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 60,
 	types: ["Lightning"],

--- a/data/Scarlet & Violet/SVP Black Star Promos/215.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/215.ts
@@ -9,7 +9,7 @@ const card: Card = {
 	},
 
 	suffix: "EX",
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 260,
 	types: ["Lightning"],

--- a/data/Scarlet & Violet/SVP Black Star Promos/216.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/216.ts
@@ -9,7 +9,7 @@ const card: Card = {
 		fr: "Mewtwo-ex de la Team Rocket"
 	},
 	suffix: "EX",
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 280,
 	types: ["Psychic"],
@@ -33,13 +33,18 @@ const card: Card = {
 
 	attacks: [
 		{
-			cost: ["Psychic","Psychic","Colorless"],
+			cost: [
+				"Psychic",
+				"Psychic",
+				"Colorless",
+			],
 			name: {
 				en: "Erasure Ball",
+				fr: "Boule Effacement",
 			},
 			effect: {
-				en: "You may discard up to 2 Energy from your Benched Pokémon. This attack does 60 more damage for each" +
-					" card you discarded in this way."
+				en: "You may discard up to 2 Energy from your Benched Pokémon. This attack does 60 more damage for each card you discarded in this way.",
+				fr: "Vous pouvez défausser jusqu'à 2 Énergies de vos Pokémon de Banc. Cette attaque inflige 60 dégâts supplémentaires pour chaque carte défaussée de cette façon.",
 			},
 			damage: "160+",
 		},

--- a/data/Scarlet & Violet/SVP Black Star Promos/217.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/217.ts
@@ -9,7 +9,7 @@ const card: Card = {
 		fr: "Nidoking-ex de la Team Rocket"
 	},
 	suffix: "EX",
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 330,
 	types: ["Darkness"],
@@ -28,20 +28,31 @@ const card: Card = {
 
 	attacks: [
 		{
-			cost: ["Darkness","Darkness","Colorless"],
+			cost: [
+				"Darkness",
+				"Darkness",
+				"Colorless",
+			],
 			name: {
 				en: "Tainted Horn",
+				fr: "Corne Contaminante",
 			},
 			effect: {
-				en: "Your opponent's Active Pokémon is now Poisoned. During Pokémon Checkup, put 8 damage counters on " +
-					"that Pokémon instead of 1."
+				en: "Your opponent's Active Pokémon is now Poisoned. During Pokémon Checkup, put 8 damage counters on that Pokémon instead of 1.",
+				fr: "Le Pokémon Actif de votre adversaire est maintenant Empoisonné. Pendant le Contrôle Pokémon, placez 8 marqueurs de dégâts sur ce Pokémon-là au lieu d'un.",
 			},
 			damage: "100",
 		},
 		{
-			cost: ["Darkness","Darkness","Darkness","Colorless"],
+			cost: [
+				"Darkness",
+				"Darkness",
+				"Darkness",
+				"Colorless",
+			],
 			name: {
 				en: "Kingly Impact",
+				fr: "Impact Royal",
 			},
 			damage: "240",
 		},

--- a/data/Scarlet & Violet/SVP Black Star Promos/218.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/218.ts
@@ -9,7 +9,7 @@ const card: Card = {
 		fr: "Persian-ex de la Team Rocket"
 	},
 	suffix: "EX",
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 260,
 	types: ["Colorless"],
@@ -28,22 +28,32 @@ const card: Card = {
 
 	attacks: [
 		{
-			cost: ["Colorless","Colorless"],
+			cost: [
+				"Colorless",
+				"Colorless",
+			],
 			name: {
 				en: "Haughty Order",
+				fr: "Ordre Hautain",
 			},
 			effect: {
-				en: "Reveal the top 10 cards of your opponent's deck. You may choose an attack from a Pokémon you find" +
-					" there and use it as this attack. Shuffle the revealed cards into your opponent's deck."
+				en: "Reveal the top 10 cards of your opponent's deck. You may choose an attack from a Pokémon you find there and use it as this attack. Shuffle the revealed cards into your opponent's deck.",
+				fr: "Montrez les 10 cartes du dessus du deck de votre adversaire. Vous pouvez choisir une attaque d'un Pokémon que vous y trouvez et l'utiliser en tant que cette attaque. Mélangez les cartes montrées avec le deck de votre adversaire.",
 			},
 		},
 		{
-			cost: ["Colorless","Colorless","Colorless"],
+			cost: [
+				"Colorless",
+				"Colorless",
+				"Colorless",
+			],
 			name: {
 				en: "Cruel Slash",
+				fr: "Tranche Cruelle",
 			},
 			effect: {
-				en: "Your opponent's Active Pokémon is now Confused."
+				en: "Your opponent's Active Pokémon is now Confused.",
+				fr: "Le Pokémon Actif de votre adversaire est maintenant Confus.",
 			},
 			damage: "140",
 		},

--- a/data/Scarlet & Violet/SVP Black Star Promos/219.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/219.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		"es-mx": "Entrenamiento de Karateka"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Trainer",
 
 	effect: {

--- a/data/Scarlet & Violet/SVP Black Star Promos/220.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/220.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		"es-mx": "Entrenamiento de Karateka"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Trainer",
 
 	effect: {

--- a/data/Scarlet & Violet/SVP Black Star Promos/221.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/221.ts
@@ -13,7 +13,7 @@ const card: Card = {
 		de: "Forschung des Professors"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Trainer",
 
 	effect: {

--- a/data/Scarlet & Violet/SVP Black Star Promos/222.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/222.ts
@@ -13,7 +13,7 @@ const card: Card = {
 		de: "Forschung des Professors"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Trainer",
 
 	effect: {

--- a/data/Scarlet & Violet/SVP Black Star Promos/223.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/223.ts
@@ -13,7 +13,7 @@ const card: Card = {
 		de: "Forschung des Professors"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Trainer",
 
 	effect: {

--- a/data/Scarlet & Violet/SVP Black Star Promos/224.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/224.ts
@@ -8,7 +8,7 @@ const card: Card = {
 		en: "Paradise Resort",
 		fr: "Hôtel « Au paradis des Pokémon »"
 	},
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Trainer",
 	illustrator: "Naoki Saito",
 

--- a/data/Scarlet & Violet/SVP Black Star Promos/225.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/225.ts
@@ -8,7 +8,7 @@ const card: Card = {
 		en: "Pikachu",
 		fr: "Pikachu"
 	},
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 70,
 	types: ["Lightning"],

--- a/data/Scarlet & Violet/SVP Black Star Promos/UNNUMBERED-001.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/UNNUMBERED-001.ts
@@ -1,0 +1,52 @@
+import { Card } from "../../../interfaces"
+import Set from "../SVP Black Star Promos"
+
+// IMPORTANT: Keep this filename as UNNUMBERED-001.ts (project requirement).
+// Do not rename this card file to 500.ts again.
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Terapagos & Friends",
+		fr: "Terapagos et ses Amis"
+	},
+	rarity: "Black Star Promo",
+	category: "Pokemon",
+	types: ["Colorless"],
+	hp: 90,
+	stage: "Basic",
+	dexId: [1024, 25, 906, 909, 912],
+	illustrator: "Yamazaki Rei",
+
+	attacks:[
+		{
+			cost: ["Colorless","Colorless","Colorless","Colorless"],
+			name: {
+				en: "A Grand Adventure with Friends",
+				fr: "Une Aventure Grandiose Entre Amis"
+			},
+			effect:{
+				en: "This attack does 100 damage for each of your Pokémon in play.",
+				fr: "Cette attaque inflige 100 dégâts pour chacun de vos Pokémon en jeu."
+			},
+			damage: "100×",
+		}
+	],
+	weaknesses: [
+		{
+			type: "Fighting",
+			value: "×2"
+		}
+	],
+	retreat: 2,
+
+	variants: [
+		{
+			type: "normal",
+			size: "jumbo",
+			stamp: ["horizons"]
+		},
+	]
+}
+
+export default card


### PR DESCRIPTION
Set: **SVP Black Star Promos**
Series folder: `Scarlet & Violet`
Changed card files: **226**

### Validation
- [ ] `bun run validate`
- [ ] `cd server && bun run --bun validate`
- [ ] `cd server && bun run compile`
- [ ] Manual review: translations, energy types, TS syntax

### Card images
See follow-up comments with embedded TCGdex assets.