### PR TITLE
fix(data): Lost Thunder (Sun & Moon)

### DIFF
--- a/data/Sun & Moon/Lost Thunder/171.ts
+++ b/data/Sun & Moon/Lost Thunder/171.ts
@@ -17,12 +17,12 @@ const card: Card = {
 	set: Set,
 
 	effect: {
-		fr: "Vous pouvez jouer 2 cartes Attrape-Perso à la fois.\n\n• Si vous avez joué une carte, piochez des cartes jusqu’à ce que vous ayez 3 cartes en main.\n• Si vous avez joué 2 cartes, échangez l’un des Pokémon de Banc de votre adversaire avec son Pokémon Actif. (Cet effet agit une fois pour 2 cartes.)",
+		fr: "Si vous avez joué une carte, piochez des cartes jusqu'à ce que vous ayez 3 cartes en main.",
 		en: "You may play 2 Custom Catcher cards at once.\n\n• If you played 1 card, draw cards until you have 3 cards in your hand.\n• If you played 2 cards, switch 1 of your opponent’s Benched Pokémon with their Active Pokémon. (This effect works one time for 2 cards.)",
 		es: "Puedes jugar 2 cartas de Capturador Personalizado de una vez.\n\n• Si has jugado 1 carta, roba cartas hasta que tengas 3 cartas en tu mano.\n• Si has jugado 2 cartas, cambia 1 de los Pokémon en Banca de tu rival por su Pokémon Activo. (Este efecto funciona 1 vez por 2 cartas).",
 		it: "Puoi giocare due carte Acchiappa-Pokémon Modificato alla volta.\n\n• Se giochi una carta, pesca fino ad avere tre carte in mano.\n• Se giochi due carte, scambia uno dei Pokémon nella panchina del tuo avversario con il suo Pokémon attivo (questo effetto si applica una volta ogni due carte).",
 		pt: "Você pode jogar 2 cartas Pegador Personalizado de uma vez.\n\n• Se você jogou 1 carta, compre cartas até ter 3 cartas na sua mão.\n• Se você jogou 2 cartas, troque 1 dos Pokémon no Banco do seu oponente pelo Pokémon Ativo dele(a) (este efeito funciona uma vez para 2 cartas).",
-		de: "Du kannst 2 Flexfänger-Karten gleichzeitig spielen.\n\n• Wenn du 1 Karte gespielt hast, ziehe so lang Karten, bis du 3 Karten auf deiner Hand hast.\n• Wenn du 2 Karten gespielt hast, tausche 1 Pokémon auf der Bank deines Gegners gegen sein Aktives Pokémon aus. (Dieser Effekt funktioniert einmal für 2 Karten.)"
+		de: "Du kannst 2 Flexfänger-Karten gleichzeitig spielen.\n\n• Wenn du 1 Karte gespielt hast, ziehe so lang Karten, bis du 3 Karten auf deiner Hand hast.\n• Wenn du 2 Karten gespielt hast, tausche 1 Pokémon auf der Bank deines Gegners gegen sein Aktives Pokémon aus. (Dieser Effekt funktioniert einmal für 2 Karten.)",
 	},
 
 	trainerType: "Item",

--- a/data/Sun & Moon/Lost Thunder/178.ts
+++ b/data/Sun & Moon/Lost Thunder/178.ts
@@ -19,11 +19,11 @@ const card: Card = {
 
 	effect: {
 		en: "Once during each player’s turn, that player may discard a Fire Energy card from their hand. If they do, they draw 3 cards.\n\nWhenever any player plays an Item or Supporter card from their hand, prevent all effects of that card done to this Stadium card.",
-		fr: "Une seule fois pendant le tour de chaque joueur, ce joueur peut défausser une carte Énergie Fire de sa main. Dans ce cas, il pioche 3 cartes.\n\nChaque fois qu’un joueur joue une carte Objet ou une carte Supporter de sa main, évitez tous les effets de cette carte-là sur cette carte Stade.",
+		fr: "Une seule fois pendant le tour de chaque joueur, ce joueur peut défausser une carte Énergie Feu de sa main. Dans ce cas, il pioche 3 cartes.",
 		es: "Una vez durante el turno de cada jugador, ese jugador puede descartar 1 carta de Energía Fire de su mano. Si lo hace, roba 3 cartas.\n\nCada vez que algún jugador juegue 1 carta de Objeto o de Partidario de su mano, evita todos los efectos de esa carta infligidos a esta carta de Estadio.",
 		it: "Una sola volta durante il turno di ciascun giocatore, quel giocatore può scartare una delle carte Energia Fire che ha in mano. Se lo fa, quel giocatore pesca tre carte.\n\nOgni volta che un giocatore gioca una delle carte Strumento o Aiuto che ha in mano, previeni tutti gli effetti di quella carta su questa carta Stadio.",
 		pt: "Uma vez durante a vez de jogar de cada jogador, aquele jogador pode descartar 1 carta de Energia Fire da própria mão. Se fizer isto, comprará 3 cartas.\n\nSempre que algum jogador jogar uma carta de Item ou de Apoiador da própria mão, prevenirá todos os efeitos daquela carta causados a esta carta de Estádio.",
-		de: "Einmal während des Zuges jedes Spielers kann der Spieler 1 Fire-Energiekarte aus seiner Hand auf seinen Ablagestapel legen. Wenn er das macht, zieht er 3 Karten.\n\nVerhindere jedes Mal, wenn ein Spieler eine Item- oder Unterstützerkarte aus seiner Hand spielt, alle Effekte jener Karte, die dieser Stadionkarte zugefügt werden."
+		de: "Einmal während des Zuges jedes Spielers kann der Spieler 1 Fire-Energiekarte aus seiner Hand auf seinen Ablagestapel legen. Wenn er das macht, zieht er 3 Karten.\n\nVerhindere jedes Mal, wenn ein Spieler eine Item- oder Unterstützerkarte aus seiner Hand spielt, alle Effekte jener Karte, die dieser Stadionkarte zugefügt werden.",
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Lost Thunder/180.ts
+++ b/data/Sun & Moon/Lost Thunder/180.ts
@@ -19,11 +19,11 @@ const card: Card = {
 
 	effect: {
 		en: "Once during each player’s turn, that player may heal 60 damage and remove all Special Conditions from 1 of their Grass Pokémon.\n\nWhenever any player plays an Item or Supporter card from their hand, prevent all effects of that card done to this Stadium card.",
-		fr: "Une seule fois pendant le tour de chaque joueur, ce joueur peut soigner 60 dégâts et retirer tous les États Spéciaux de l’un de ses Pokémon Grass.\n\nChaque fois qu’un joueur joue une carte Objet ou une carte Supporter de sa main, évitez tous les effets de cette carte-là sur cette carte Stade.",
+		fr: "Une seule fois pendant le tour de chaque joueur, ce joueur peut soigner 60 dégâts et retirer tous les États Spéciaux de l'un de ses Pokémon Plante.",
 		es: "Una vez durante el turno de cada jugador, ese jugador puede curar 60 puntos de daño y eliminar todas las Condiciones Especiales de 1 de sus Pokémon Grass.\n\nCada vez que algún jugador juegue 1 carta de Objeto o de Partidario de su mano, evita todos los efectos de esa carta infligidos a esta carta de Estadio.",
 		it: "Una sola volta durante il turno di ciascun giocatore, quel giocatore può curare uno dei suoi Pokémon Grass da 60 danni e rimuovere tutte le condizioni speciali che lo influenzano.\n\nOgni volta che un giocatore gioca una delle carte Strumento o Aiuto che ha in mano, previeni tutti gli effetti di quella carta su questa carta Stadio.",
 		pt: "Uma vez durante a vez de jogar de cada jogador, aquele jogador pode curar 60 pontos de dano e remover todas as Condições Especiais de 1 dos próprios Pokémon Grass.\n\nSempre que algum jogador jogar uma carta de Item ou de Apoiador da própria mão, prevenirá todos os efeitos daquela carta causados a esta carta de Estádio.",
-		de: "Einmal während des Zuges jedes Spielers kann der Spieler bei 1 seiner Grass-Pokémon 60 Schadenspunkte heilen und alle Speziellen Zustände von jenem Pokémon entfernen.\n\nVerhindere jedes Mal, wenn ein Spieler eine Item- oder Unterstützerkarte aus seiner Hand spielt, alle Effekte jener Karte, die dieser Stadionkarte zugefügt werden."
+		de: "Einmal während des Zuges jedes Spielers kann der Spieler bei 1 seiner Grass-Pokémon 60 Schadenspunkte heilen und alle Speziellen Zustände von jenem Pokémon entfernen.\n\nVerhindere jedes Mal, wenn ein Spieler eine Item- oder Unterstützerkarte aus seiner Hand spielt, alle Effekte jener Karte, die dieser Stadionkarte zugefügt werden.",
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Lost Thunder/182.ts
+++ b/data/Sun & Moon/Lost Thunder/182.ts
@@ -19,11 +19,11 @@ const card: Card = {
 
 	effect: {
 		en: "You can play this card only if your opponent has exactly 3 Prize cards remaining.\n\nPrevent all damage done to your Ultra Beasts by attacks during your opponent’s next turn.",
-		fr: "Vous ne pouvez jouer cette carte que s’il reste exactement 3 cartes Récompense à votre adversaire.\n\nÉvitez tous les dégâts infligés à vos Ultra-Chimères par des attaques pendant le prochain tour de votre adversaire.",
+		fr: "Vous ne pouvez jouer cette carte que s'il reste exactement 3 cartes Récompense à votre adversaire.",
 		es: "Puedes jugar esta carta solo si a tu rival le quedan exactamente 3 cartas de Premio.\n\nEvita todo el daño infligido a tus Ultraentes por ataques durante el próximo turno de tu rival.",
 		it: "Puoi giocare questa carta solo se il tuo avversario ha esattamente tre carte Premio rimanenti.\n\nPrevieni tutti i danni inflitti alle tue Ultracreature da qualsiasi attacco durante il prossimo turno del tuo avversario.",
 		pt: "Você só pode jogar esta carta se seu oponente tiver exatamente 3 cartas de Prêmio restantes.\n\nPrevenirá todo o dano causado às suas Ultracriaturas por ataques durante a próxima vez de jogar do seu oponente.",
-		de: "Du kannst diese Karte nur spielen, wenn dein Gegner genau 3 verbleibende Preiskarten hat.\n\nVerhindere allen Schaden, der deinen Ultrabestien während des nächsten Zuges deines Gegners durch Attacken zugefügt wird."
+		de: "Du kannst diese Karte nur spielen, wenn dein Gegner genau 3 verbleibende Preiskarten hat.\n\nVerhindere allen Schaden, der deinen Ultrabestien während des nächsten Zuges deines Gegners durch Attacken zugefügt wird.",
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Lost Thunder/184.ts
+++ b/data/Sun & Moon/Lost Thunder/184.ts
@@ -17,12 +17,12 @@ const card: Card = {
 	set: Set,
 
 	effect: {
-		fr: "Vous pouvez jouer 2 cartes Mélange d’Herbes à la fois.\n\n• Si vous avez joué une carte, retirez un État Spécial de votre Pokémon Actif.\n• Si vous avez joué 2 cartes, soignez 90 dégâts et retirez tous les États Spéciaux de votre Pokémon Actif. (Cet effet agit une fois pour 2 cartes.)",
+		fr: "Si vous avez joué une carte, retirez un État Spécial de votre Pokémon Actif.",
 		en: "You may play 2 Mixed Herbs cards at once.\n\n• If you played 1 card, remove a Special Condition from your Active Pokémon.\n• If you played 2 cards, heal 90 damage and remove all Special Conditions from your Active Pokémon. (This effect works one time for 2 cards.)",
 		es: "Puedes jugar 2 cartas de Hierbas Combinadas de una vez.\n\n• Si has jugado 1 carta, elimina 1 Condición Especial de tu Pokémon Activo.\n• Si has jugado 2 cartas, cura 90 puntos de daño y elimina todas las Condiciones Especiales de tu Pokémon Activo. (Este efecto funciona 1 vez por 2 cartas).",
 		it: "Puoi giocare due carte Infuso di Erbe alla volta.\n\n• Se giochi una carta, rimuovi una condizione speciale dal tuo Pokémon attivo.\n• Se giochi due carte, cura il tuo Pokémon attivo da 90 danni e rimuovi tutte le condizioni speciali che lo influenzano (questo effetto si applica una volta ogni due carte).",
 		pt: "Você pode jogar 2 cartas Mistura de Ervas de uma vez.\n\n• Se você jogou 1 carta, remova 1 Condição Especial do seu Pokémon Ativo.\n• Se você jogou 2 cartas, cure 90 pontos de dano e remova todas as Condições Especiais do seu Pokémon Ativo (este efeito funciona uma vez para 2 cartas).",
-		de: "Du kannst 2 Kräutermischung-Karten gleichzeitig spielen.\n\n• Wenn du 1 Karte gespielt hast, entferne 1 Speziellen Zustand von deinem Aktiven Pokémon.\n• Wenn du 2 Karten gespielt hast, heile 90 Schadenspunkte und entferne alle Speziellen Zustände von deinem Aktiven Pokémon. (Dieser Effekt funktioniert einmal für 2 Karten.)"
+		de: "Du kannst 2 Kräutermischung-Karten gleichzeitig spielen.\n\n• Wenn du 1 Karte gespielt hast, entferne 1 Speziellen Zustand von deinem Aktiven Pokémon.\n• Wenn du 2 Karten gespielt hast, heile 90 Schadenspunkte und entferne alle Speziellen Zustände von deinem Aktiven Pokémon. (Dieser Effekt funktioniert einmal für 2 Karten.)",
 	},
 
 	trainerType: "Item",

--- a/data/Sun & Moon/Lost Thunder/186.ts
+++ b/data/Sun & Moon/Lost Thunder/186.ts
@@ -17,12 +17,12 @@ const card: Card = {
 	set: Set,
 
 	effect: {
-		fr: "Vous ne pouvez jouer cette carte que si l’un de vos Pokémon Psychic a été mis K.O. pendant le dernier tour de votre adversaire.\n\nVotre adversaire dévoile sa main. Choisissez 2 cartes que vous y trouvez. Votre adversaire mélange ces cartes avec son deck.",
+		fr: "Vous ne pouvez jouer cette carte que si l'un de vos Pokémon Psy a été mis K.O. pendant le dernier tour de votre adversaire.",
 		en: "You can play this card only if 1 of your Psychic Pokémon was Knocked Out during your opponent’s last turn.\n\nYour opponent reveals their hand. Choose 2 cards you find there. Your opponent shuffles those cards into their deck.",
 		es: "Puedes jugar esta carta solo si 1 de tus Pokémon Psychic quedó Fuera de Combate durante el último turno de tu rival.\n\nTu rival enseña las cartas de su mano. Elige 2 cartas que encuentres entre ellas. Tu rival pone esas cartas en su baraja y las baraja todas.",
 		it: "Puoi giocare questa carta solo se uno dei tuoi Pokémon Psychic è stato messo KO durante l’ultimo turno del tuo avversario.\n\nIl tuo avversario mostra le carte che ha in mano. Scegline due presenti tra esse. Il tuo avversario rimischia quelle carte nel suo mazzo.",
 		pt: "Você só pode jogar esta carta se 1 dos seus Pokémon Psychic tiver sido Nocauteado durante a última vez de jogar do seu oponente.\n\nSeu oponente revela a própria mão. Escolha 2 cartas que encontrar lá. Seu oponente embaralha aquelas cartas no próprio baralho.",
-		de: "Du kannst diese Karte nur spielen, wenn 1 deiner Psychic-Pokémon während des letzten Zuges deines Gegners kampfunfähig wurde.\n\nDein Gegner zeigt dir seine Handkarten. Wähle 2 Karten, die du dort findest. Dein Gegner mischt jene Karten in sein Deck."
+		de: "Du kannst diese Karte nur spielen, wenn 1 deiner Psychic-Pokémon während des letzten Zuges deines Gegners kampfunfähig wurde.\n\nDein Gegner zeigt dir seine Handkarten. Wähle 2 Karten, die du dort findest. Dein Gegner mischt jene Karten in sein Deck.",
 	},
 
 	trainerType: "Supporter",

--- a/data/Sun & Moon/Lost Thunder/191.ts
+++ b/data/Sun & Moon/Lost Thunder/191.ts
@@ -19,11 +19,11 @@ const card: Card = {
 
 	effect: {
 		en: "The attacks of Lightning Pokémon (both yours and your opponent’s) cost Lightning less.\n\nWhenever any player plays an Item or Supporter card from their hand, prevent all effects of that card done to this Stadium card.",
-		fr: "Les attaques des Pokémon Lightning (les vôtres et ceux de votre adversaire) coûtent Lightning de moins.\n\nChaque fois qu’un joueur joue une carte Objet ou une carte Supporter de sa main, évitez tous les effets de cette carte-là sur cette carte Stade.",
+		fr: "Les attaques des Pokémon Électrique (les vôtres et ceux de votre adversaire) coûtent Électrique de moins.",
 		es: "Los ataques de los Pokémon Lightning (tanto tuyos como de tu rival) cuestan Lightning menos.\n\nCada vez que algún jugador juegue 1 carta de Objeto o de Partidario de su mano, evita todos los efectos de esa carta infligidos a esta carta de Estadio.",
 		it: "Gli attacchi dei Pokémon Lightning, sia tuoi che del tuo avversario, costano Lightning in meno.\n\nOgni volta che un giocatore gioca una delle carte Strumento o Aiuto che ha in mano, previeni tutti gli effetti di quella carta su questa carta Stadio.",
 		pt: "Os ataques dos Pokémon Lightning (seus e do seu oponente) custam Lightning a menos.\n\nSempre que algum jogador jogar uma carta de Item ou de Apoiador da própria mão, prevenirá todos os efeitos daquela carta causados a esta carta de Estádio.",
-		de: "Die Kosten der Attacken der Lightning-Pokémon (deiner und der deines Gegners) verringern sich um Lightning.\n\nVerhindere jedes Mal, wenn ein Spieler eine Item- oder Unterstützerkarte aus seiner Hand spielt, alle Effekte jener Karte, die dieser Stadionkarte zugefügt werden."
+		de: "Die Kosten der Attacken der Lightning-Pokémon (deiner und der deines Gegners) verringern sich um Lightning.\n\nVerhindere jedes Mal, wenn ein Spieler eine Item- oder Unterstützerkarte aus seiner Hand spielt, alle Effekte jener Karte, die dieser Stadionkarte zugefügt werden.",
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Lost Thunder/192.ts
+++ b/data/Sun & Moon/Lost Thunder/192.ts
@@ -17,12 +17,12 @@ const card: Card = {
 	set: Set,
 
 	effect: {
-		fr: "Vous ne pouvez utiliser cette carte que si vous jouez en second et uniquement pendant votre premier tour. \n\nDéfaussez une Énergie de l’un des Pokémon de votre adversaire.",
+		fr: "Vous ne pouvez utiliser cette carte que si vous jouez en second et uniquement pendant votre premier tour.",
 		en: "You can use this card only if you go second, and only on your first turn. \n\nDiscard an Energy from 1 of your opponent’s Pokémon.",
 		es: "Puedes usar esta carta solo si sales segundo, y solo en tu primer turno.\n\nDescarta 1 Energía de 1 de los Pokémon de tu rival.",
 		it: "Puoi usare questa carta solo se inizi per secondo e solo durante il tuo primo turno.\n\nScarta un’Energia assegnata a uno dei Pokémon del tuo avversario.",
 		pt: "Você só pode usar esta carta se for o segundo a jogar e somente na sua primeira vez de jogar. \n\nDescarte 1 Energia de 1 dos Pokémon do seu oponente.",
-		de: "Du kannst diese Attacke nur einsetzen, wenn du als Zweiter am Zug bist, und nur während deines ersten Zuges. \n\nLege 1 Energie von 1 Pokémon deines Gegners auf seinen Ablagestapel."
+		de: "Du kannst diese Attacke nur einsetzen, wenn du als Zweiter am Zug bist, und nur während deines ersten Zuges. \n\nLege 1 Energie von 1 Pokémon deines Gegners auf seinen Ablagestapel.",
 	},
 
 	trainerType: "Item",

--- a/data/Sun & Moon/Lost Thunder/194.ts
+++ b/data/Sun & Moon/Lost Thunder/194.ts
@@ -17,12 +17,12 @@ const card: Card = {
 	set: Set,
 
 	effect: {
-		fr: "Cette carte fournit de l’Énergie Colorless.\n\nLe Pokémon auquel cette carte est attachée peut utiliser les attaques de ses précédentes Évolutions. (Vous avez toujours besoin de l’Énergie nécessaire pour utiliser chaque attaque.)",
+		fr: "Le Pokémon auquel cette carte est attachée peut utiliser les attaques de ses précédentes Évolutions. (Vous avez toujours besoin de l'Énergie nécessaire pour utiliser chaque attaque.)",
 		en: "This card provides Colorless Energy.\n\nThe Pokémon this card is attached to can use any attack from its previous Evolutions. (You still need the necessary Energy to use each attack.)",
 		es: "Esta carta proporciona 1 Energía Colorless.\n\nEl Pokémon al que esté unida esta carta puede usar cualquier ataque de sus Evoluciones anteriores. (Sigues necesitando la Energía necesaria para usar cada ataque).",
 		it: "Questa carta fornisce Energia Colorless.\n\nIl Pokémon a cui è assegnata questa carta può usare gli attacchi dei suoi stadi evolutivi precedenti. Devi comunque avere l’Energia necessaria per usare quegli attacchi.",
 		pt: "Esta carta fornece Energia Colorless.\n\nO Pokémon ao qual esta carta está ligada pode usar qualquer ataque de suas Evoluções anteriores (você ainda precisa da Energia necessária para usar cada ataque).",
-		de: "Diese Karte liefert Colorless-Energie.\n\nDas Pokémon, an das diese Karte angelegt ist, kann die Attacken aus vorangegangenen Entwicklungen einsetzen. (Du benötigst jedoch die jeweils für die Attacke notwendige Energie.)"
+		de: "Diese Karte liefert Colorless-Energie.\n\nDas Pokémon, an das diese Karte angelegt ist, kann die Attacken aus vorangegangenen Entwicklungen einsetzen. (Du benötigst jedoch die jeweils für die Attacke notwendige Energie.)",
 	},
 
 	energyType: "Special",

--- a/data/Sun & Moon/Lost Thunder/212.ts
+++ b/data/Sun & Moon/Lost Thunder/212.ts
@@ -17,18 +17,18 @@ const card: Card = {
 	set: Set,
 
 	effect: {
-		fr: "Vous ne pouvez jouer cette carte que si l’un de vos Pokémon Psychic a été mis K.O. pendant le dernier tour de votre adversaire.\n\nVotre adversaire dévoile sa main. Choisissez 2 cartes que vous y trouvez. Votre adversaire mélange ces cartes avec son deck.",
+		fr: "Vous ne pouvez jouer cette carte que si l'un de vos Pokémon Psy a été mis K.O. pendant le dernier tour de votre adversaire.",
 		en: "You can play this card only if 1 of your Psychic Pokémon was Knocked Out during your opponent’s last turn.\n\nYour opponent reveals their hand. Choose 2 cards you find there. Your opponent shuffles those cards into their deck.",
 		es: "Puedes jugar esta carta solo si 1 de tus Pokémon Psychic quedó Fuera de Combate durante el último turno de tu rival.\n\nTu rival enseña las cartas de su mano. Elige 2 cartas que encuentres entre ellas. Tu rival pone esas cartas en su baraja y las baraja todas.",
 		it: "Puoi giocare questa carta solo se uno dei tuoi Pokémon Psychic è stato messo KO durante l’ultimo turno del tuo avversario.\n\nIl tuo avversario mostra le carte che ha in mano. Scegline due presenti tra esse. Il tuo avversario rimischia quelle carte nel suo mazzo.",
 		pt: "Você só pode jogar esta carta se 1 dos seus Pokémon Psychic tiver sido Nocauteado durante a última vez de jogar do seu oponente.\n\nSeu oponente revela a própria mão. Escolha 2 cartas que encontrar lá. Seu oponente embaralha aquelas cartas no próprio baralho.",
-		de: "Du kannst diese Karte nur spielen, wenn 1 deiner Psychic-Pokémon während des letzten Zuges deines Gegners kampfunfähig wurde.\n\nDein Gegner zeigt dir seine Handkarten. Wähle 2 Karten, die du dort findest. Dein Gegner mischt jene Karten in sein Deck."
+		de: "Du kannst diese Karte nur spielen, wenn 1 deiner Psychic-Pokémon während des letzten Zuges deines Gegners kampfunfähig wurde.\n\nDein Gegner zeigt dir seine Handkarten. Wähle 2 Karten, die du dort findest. Dein Gegner mischt jene Karten in sein Deck.",
 	},
 
 	trainerType: "Supporter",
 
 	thirdParty: {
-		cardmarket: 365845,
+		cardmarket: 365820,
 		tcgplayer: 179020
 	}
 }

--- a/data/Sun & Moon/Lost Thunder/231.ts
+++ b/data/Sun & Moon/Lost Thunder/231.ts
@@ -17,18 +17,18 @@ const card: Card = {
 	set: Set,
 
 	effect: {
-		fr: "Vous pouvez jouer 2 cartes Attrape-Perso à la fois.\n\n• Si vous avez joué une carte, piochez des cartes jusqu’à ce que vous ayez 3 cartes en main.\n• Si vous avez joué 2 cartes, échangez l’un des Pokémon de Banc de votre adversaire avec son Pokémon Actif. (Cet effet agit une fois pour 2 cartes.)",
+		fr: "Si vous avez joué une carte, piochez des cartes jusqu'à ce que vous ayez 3 cartes en main.",
 		en: "You may play 2 Custom Catcher cards at once.\n\n• If you played 1 card, draw cards until you have 3 cards in your hand.\n• If you played 2 cards, switch 1 of your opponent’s Benched Pokémon with their Active Pokémon. (This effect works one time for 2 cards.)",
 		es: "Puedes jugar 2 cartas de Capturador Personalizado de una vez.\n\n• Si has jugado 1 carta, roba cartas hasta que tengas 3 cartas en tu mano.\n• Si has jugado 2 cartas, cambia 1 de los Pokémon en Banca de tu rival por su Pokémon Activo. (Este efecto funciona 1 vez por 2 cartas).",
 		it: "Puoi giocare due carte Acchiappa-Pokémon Modificato alla volta.\n\n• Se giochi una carta, pesca fino ad avere tre carte in mano.\n• Se giochi due carte, scambia uno dei Pokémon nella panchina del tuo avversario con il suo Pokémon attivo (questo effetto si applica una volta ogni due carte).",
 		pt: "Você pode jogar 2 cartas Pegador Personalizado de uma vez.\n\n• Se você jogou 1 carta, compre cartas até ter 3 cartas na sua mão.\n• Se você jogou 2 cartas, troque 1 dos Pokémon no Banco do seu oponente pelo Pokémon Ativo dele(a) (este efeito funciona uma vez para 2 cartas).",
-		de: "Du kannst 2 Flexfänger-Karten gleichzeitig spielen.\n\n• Wenn du 1 Karte gespielt hast, ziehe so lang Karten, bis du 3 Karten auf deiner Hand hast.\n• Wenn du 2 Karten gespielt hast, tausche 1 Pokémon auf der Bank deines Gegners gegen sein Aktives Pokémon aus. (Dieser Effekt funktioniert einmal für 2 Karten.)"
+		de: "Du kannst 2 Flexfänger-Karten gleichzeitig spielen.\n\n• Wenn du 1 Karte gespielt hast, ziehe so lang Karten, bis du 3 Karten auf deiner Hand hast.\n• Wenn du 2 Karten gespielt hast, tausche 1 Pokémon auf der Bank deines Gegners gegen sein Aktives Pokémon aus. (Dieser Effekt funktioniert einmal für 2 Karten.)",
 	},
 
 	trainerType: "Item",
 
 	thirdParty: {
-		cardmarket: 365864,
+		cardmarket: 365807,
 		tcgplayer: 178998
 	}
 }

--- a/data/Sun & Moon/Lost Thunder/236.ts
+++ b/data/Sun & Moon/Lost Thunder/236.ts
@@ -17,18 +17,18 @@ const card: Card = {
 	set: Set,
 
 	effect: {
-		fr: "Vous ne pouvez utiliser cette carte que si vous jouez en second et uniquement pendant votre premier tour. \n\nDéfaussez une Énergie de l’un des Pokémon de votre adversaire.",
+		fr: "Vous ne pouvez utiliser cette carte que si vous jouez en second et uniquement pendant votre premier tour.",
 		en: "You can use this card only if you go second, and only on your first turn. \n\nDiscard an Energy from 1 of your opponent’s Pokémon.",
 		es: "Puedes usar esta carta solo si sales segundo, y solo en tu primer turno.\n\nDescarta 1 Energía de 1 de los Pokémon de tu rival.",
 		it: "Puoi usare questa carta solo se inizi per secondo e solo durante il tuo primo turno.\n\nScarta un’Energia assegnata a uno dei Pokémon del tuo avversario.",
 		pt: "Você só pode usar esta carta se for o segundo a jogar e somente na sua primeira vez de jogar. \n\nDescarte 1 Energia de 1 dos Pokémon do seu oponente.",
-		de: "Du kannst diese Attacke nur einsetzen, wenn du als Zweiter am Zug bist, und nur während deines ersten Zuges. \n\nLege 1 Energie von 1 Pokémon deines Gegners auf seinen Ablagestapel."
+		de: "Du kannst diese Attacke nur einsetzen, wenn du als Zweiter am Zug bist, und nur während deines ersten Zuges. \n\nLege 1 Energie von 1 Pokémon deines Gegners auf seinen Ablagestapel.",
 	},
 
 	trainerType: "Item",
 
 	thirdParty: {
-		cardmarket: 365870,
+		cardmarket: 365825,
 		tcgplayer: 179068
 	}
 }


### PR DESCRIPTION
Set: **Lost Thunder**
Series folder: `Sun & Moon`
Changed card files: **12**

### Validation
- [ ] `bun run validate`
- [ ] `cd server && bun run --bun validate`
- [ ] `cd server && bun run compile`
- [ ] Manual review: translations, energy types, TS syntax

### Card images
See follow-up comments with embedded TCGdex assets.