### PR TITLE
fix(data): SM Black Star Promos (Sun & Moon)

### DIFF
--- a/data/Sun & Moon/SM Black Star Promos/SM01.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM01.ts
@@ -12,7 +12,7 @@ const card: Card = {
 	},
 
 	illustrator: "Mitsuhiro Arita",
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	set: Set,
 

--- a/data/Sun & Moon/SM Black Star Promos/SM02.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM02.ts
@@ -12,7 +12,7 @@ const card: Card = {
 	},
 
 	illustrator: "Megumi Mizutani",
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	set: Set,
 

--- a/data/Sun & Moon/SM Black Star Promos/SM03.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM03.ts
@@ -12,7 +12,7 @@ const card: Card = {
 	},
 
 	illustrator: "match",
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	set: Set,
 

--- a/data/Sun & Moon/SM Black Star Promos/SM04.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM04.ts
@@ -7,7 +7,7 @@ const card: Card = {
 		fr: "Pikachu"
 	},
 	illustrator: "kirisAki",
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Sun & Moon/SM Black Star Promos/SM05.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM05.ts
@@ -12,7 +12,7 @@ const card: Card = {
 	},
 
 	illustrator: "5ban Graphics",
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	set: Set,
 

--- a/data/Sun & Moon/SM Black Star Promos/SM06.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM06.ts
@@ -12,7 +12,7 @@ const card: Card = {
 	},
 
 	illustrator: "match",
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	set: Set,
 

--- a/data/Sun & Moon/SM Black Star Promos/SM07.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM07.ts
@@ -12,7 +12,7 @@ const card: Card = {
 	},
 
 	illustrator: "match",
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	set: Set,
 

--- a/data/Sun & Moon/SM Black Star Promos/SM08.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM08.ts
@@ -11,7 +11,7 @@ const card: Card = {
 		de: "Flamiau"
 	},
 	illustrator: "Kouki Saitou",
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Sun & Moon/SM Black Star Promos/SM09.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM09.ts
@@ -11,7 +11,7 @@ const card: Card = {
 		de: "Togedemaru"
 	},
 	illustrator: "match",
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Sun & Moon/SM Black Star Promos/SM10.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM10.ts
@@ -11,7 +11,7 @@ const card: Card = {
 		de: "Lamellux"
 	},
 	illustrator: "Mizue",
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Sun & Moon/SM Black Star Promos/SM100.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM100.ts
@@ -11,7 +11,7 @@ const card: Card = {
 		de: "Lucario GX"
 	},
 	illustrator: "5ban Graphics",
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Sun & Moon/SM Black Star Promos/SM101.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM101.ts
@@ -11,7 +11,7 @@ const card: Card = {
 		de: "Morgenschwingen-Necrozma GX"
 	},
 	illustrator: "5ban Graphics",
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Sun & Moon/SM Black Star Promos/SM102.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM102.ts
@@ -11,7 +11,7 @@ const card: Card = {
 		de: "Abendmähne-Necrozma GX"
 	},
 	illustrator: "5ban Graphics",
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Sun & Moon/SM Black Star Promos/SM103.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM103.ts
@@ -12,7 +12,7 @@ const card: Card = {
 	},
 
 	illustrator: "PLANETA",
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	set: Set,
 

--- a/data/Sun & Moon/SM Black Star Promos/SM104.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM104.ts
@@ -11,7 +11,7 @@ const card: Card = {
 		de: "Solgaleo GX"
 	},
 	illustrator: "PLANETA",
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Sun & Moon/SM Black Star Promos/SM105.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM105.ts
@@ -11,7 +11,7 @@ const card: Card = {
 		de: "Wolwerock"
 	},
 	illustrator: "Shin Nagasawa",
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Sun & Moon/SM Black Star Promos/SM106.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM106.ts
@@ -11,7 +11,7 @@ const card: Card = {
 		de: "Morgenschwingen-Necrozma"
 	},
 	illustrator: "Shin Nagasawa",
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Sun & Moon/SM Black Star Promos/SM107.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM107.ts
@@ -11,7 +11,7 @@ const card: Card = {
 		de: "Abendmähne-Necrozma"
 	},
 	illustrator: "Shin Nagasawa",
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Sun & Moon/SM Black Star Promos/SM108.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM108.ts
@@ -7,7 +7,7 @@ const card: Card = {
 		fr: "Pikachu de Sacha",
 	},
 	illustrator: "2017 Pikachu Project",
-	rarity: "Common",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Sun & Moon/SM Black Star Promos/SM109.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM109.ts
@@ -7,7 +7,7 @@ const card: Card = {
 		fr: "Pikachu de Sacha",
 	},
 	illustrator: "2017 Pikachu Project",
-	rarity: "Common",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Sun & Moon/SM Black Star Promos/SM11.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM11.ts
@@ -11,7 +11,7 @@ const card: Card = {
 		de: "Knirfish"
 	},
 	illustrator: "Mizue",
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Sun & Moon/SM Black Star Promos/SM110.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM110.ts
@@ -7,7 +7,7 @@ const card: Card = {
 		fr: "Pikachu de Sacha",
 	},
 	illustrator: "2017 Pikachu Project",
-	rarity: "Common",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Sun & Moon/SM Black Star Promos/SM111.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM111.ts
@@ -7,7 +7,7 @@ const card: Card = {
 		fr: "Pikachu de Sacha",
 	},
 	illustrator: "2017 Pikachu Project",
-	rarity: "Common",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Sun & Moon/SM Black Star Promos/SM112.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM112.ts
@@ -7,7 +7,7 @@ const card: Card = {
 		fr: "Pikachu de Sacha",
 	},
 	illustrator: "2017 Pikachu Project",
-	rarity: "Common",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Sun & Moon/SM Black Star Promos/SM113.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM113.ts
@@ -7,7 +7,7 @@ const card: Card = {
 		fr: "Pikachu de Sacha",
 	},
 	illustrator: "2017 Pikachu Project",
-	rarity: "Common",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Sun & Moon/SM Black Star Promos/SM114.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM114.ts
@@ -7,7 +7,7 @@ const card: Card = {
 		fr: "Pikachu de Sacha",
 	},
 	illustrator: "2017 Pikachu Project",
-	rarity: "Common",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Sun & Moon/SM Black Star Promos/SM115.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM115.ts
@@ -12,7 +12,7 @@ const card: Card = {
 	},
 
 	illustrator: "You Iribi",
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	set: Set,
 

--- a/data/Sun & Moon/SM Black Star Promos/SM116.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM116.ts
@@ -11,7 +11,7 @@ const card: Card = {
 		de: "Voltriant"
 	},
 	illustrator: "TOKIYA",
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Sun & Moon/SM Black Star Promos/SM117.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM117.ts
@@ -11,7 +11,7 @@ const card: Card = {
 		de: "Calamanero"
 	},
 	illustrator: "Shin Nagasawa",
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Sun & Moon/SM Black Star Promos/SM118.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM118.ts
@@ -11,7 +11,7 @@ const card: Card = {
 		de: "Wolwerock"
 	},
 	illustrator: "sui",
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Sun & Moon/SM Black Star Promos/SM119.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM119.ts
@@ -12,7 +12,7 @@ const card: Card = {
 	},
 
 	illustrator: "OOYAMA",
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	set: Set,
 

--- a/data/Sun & Moon/SM Black Star Promos/SM12.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM12.ts
@@ -11,7 +11,7 @@ const card: Card = {
 		de: "Quartermak"
 	},
 	illustrator: "Naoki Saito",
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Sun & Moon/SM Black Star Promos/SM120.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM120.ts
@@ -12,7 +12,7 @@ const card: Card = {
 	},
 
 	illustrator: "Hideki Ishikawa",
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	set: Set,
 

--- a/data/Sun & Moon/SM Black Star Promos/SM121.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM121.ts
@@ -11,7 +11,7 @@ const card: Card = {
 		de: "Raikou GX"
 	},
 	illustrator: "5ban Graphics",
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Sun & Moon/SM Black Star Promos/SM122.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM122.ts
@@ -11,7 +11,7 @@ const card: Card = {
 		de: "Zygarde GX"
 	},
 	illustrator: "5ban Graphics",
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Sun & Moon/SM Black Star Promos/SM123.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM123.ts
@@ -11,7 +11,7 @@ const card: Card = {
 		de: "Morgenschwingen-Necrozma"
 	},
 	illustrator: "nagimiso",
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Sun & Moon/SM Black Star Promos/SM124.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM124.ts
@@ -11,7 +11,7 @@ const card: Card = {
 		de: "Abendmähne-Necrozma"
 	},
 	illustrator: "nagimiso",
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Sun & Moon/SM Black Star Promos/SM125.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM125.ts
@@ -11,7 +11,7 @@ const card: Card = {
 		de: "Agoyon GX"
 	},
 	illustrator: "5ban Graphics",
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Sun & Moon/SM Black Star Promos/SM126.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM126.ts
@@ -11,7 +11,7 @@ const card: Card = {
 		de: "Ultra-Necrozma GX"
 	},
 	illustrator: "PLANETA Otani",
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Sun & Moon/SM Black Star Promos/SM127.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM127.ts
@@ -12,7 +12,7 @@ const card: Card = {
 	},
 
 	illustrator: "kirisAki",
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	set: Set,
 

--- a/data/Sun & Moon/SM Black Star Promos/SM128.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM128.ts
@@ -11,7 +11,7 @@ const card: Card = {
 		de: "Alola Vulnona"
 	},
 	illustrator: "kirisAki",
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Sun & Moon/SM Black Star Promos/SM129.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM129.ts
@@ -11,7 +11,7 @@ const card: Card = {
 		de: "Kyogre"
 	},
 	illustrator: "Anesaki Dynamic",
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Sun & Moon/SM Black Star Promos/SM13.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM13.ts
@@ -11,7 +11,7 @@ const card: Card = {
 		de: "Kommandutan"
 	},
 	illustrator: "Mitsuhiro Arita",
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Sun & Moon/SM Black Star Promos/SM130.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM130.ts
@@ -12,7 +12,7 @@ const card: Card = {
 	},
 
 	illustrator: "Ryota Murayama",
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	set: Set,
 

--- a/data/Sun & Moon/SM Black Star Promos/SM131.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM131.ts
@@ -11,7 +11,7 @@ const card: Card = {
 		de: "Kaguron"
 	},
 	illustrator: "Masakazu Fukuda",
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Sun & Moon/SM Black Star Promos/SM132.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM132.ts
@@ -11,7 +11,7 @@ const card: Card = {
 		de: "Enekoro"
 	},
 	illustrator: "0313",
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Sun & Moon/SM Black Star Promos/SM133.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM133.ts
@@ -11,7 +11,7 @@ const card: Card = {
 		de: "Voltolos GX"
 	},
 	illustrator: "5ban Graphics",
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Sun & Moon/SM Black Star Promos/SM134.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM134.ts
@@ -11,7 +11,7 @@ const card: Card = {
 		de: "Boreos GX"
 	},
 	illustrator: "5ban Graphics",
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Sun & Moon/SM Black Star Promos/SM135.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM135.ts
@@ -11,7 +11,7 @@ const card: Card = {
 		de: "Latias"
 	},
 	illustrator: "Kouki Saitou",
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Sun & Moon/SM Black Star Promos/SM136.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM136.ts
@@ -11,7 +11,7 @@ const card: Card = {
 		de: "Latios"
 	},
 	illustrator: "Kouki Saitou",
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Sun & Moon/SM Black Star Promos/SM137.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM137.ts
@@ -11,7 +11,7 @@ const card: Card = {
 		de: "Reshiram GX"
 	},
 	illustrator: "PLANETA Otani",
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Sun & Moon/SM Black Star Promos/SM138.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM138.ts
@@ -11,7 +11,7 @@ const card: Card = {
 		de: "Zekrom GX"
 	},
 	illustrator: "5ban Graphics",
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Sun & Moon/SM Black Star Promos/SM139.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM139.ts
@@ -11,7 +11,7 @@ const card: Card = {
 		de: "Brutalanda GX"
 	},
 	illustrator: "5ban Graphics",
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Sun & Moon/SM Black Star Promos/SM14.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM14.ts
@@ -11,7 +11,7 @@ const card: Card = {
 		de: "Wolwerock GX"
 	},
 	illustrator: "5ban Graphics",
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Sun & Moon/SM Black Star Promos/SM140.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM140.ts
@@ -11,7 +11,7 @@ const card: Card = {
 		de: "Brutalanda"
 	},
 	illustrator: "Mitsuhiro Arita",
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Sun & Moon/SM Black Star Promos/SM141.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM141.ts
@@ -11,7 +11,7 @@ const card: Card = {
 		de: "Weißes Kyurem GX"
 	},
 	illustrator: "5ban Graphics",
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Sun & Moon/SM Black Star Promos/SM142.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM142.ts
@@ -11,7 +11,7 @@ const card: Card = {
 		de: "Kyurem"
 	},
 	illustrator: "TOKIYA",
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Sun & Moon/SM Black Star Promos/SM143.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM143.ts
@@ -11,7 +11,7 @@ const card: Card = {
 		de: "Lavados"
 	},
 	illustrator: "Hitoshi Ariga",
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Sun & Moon/SM Black Star Promos/SM144.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM144.ts
@@ -11,7 +11,7 @@ const card: Card = {
 		de: "Arktos"
 	},
 	illustrator: "Hitoshi Ariga",
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Sun & Moon/SM Black Star Promos/SM145.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM145.ts
@@ -11,7 +11,7 @@ const card: Card = {
 		de: "Zapdos"
 	},
 	illustrator: "Hitoshi Ariga",
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Sun & Moon/SM Black Star Promos/SM146.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM146.ts
@@ -11,7 +11,7 @@ const card: Card = {
 		de: "Folipurba GX"
 	},
 	illustrator: "5ban Graphics",
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Sun & Moon/SM Black Star Promos/SM147.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM147.ts
@@ -11,7 +11,7 @@ const card: Card = {
 		de: "Glaziola GX"
 	},
 	illustrator: "5ban Graphics",
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Sun & Moon/SM Black Star Promos/SM148.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM148.ts
@@ -12,7 +12,7 @@ const card: Card = {
 	},
 
 	illustrator: "Naoki Saito",
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Trainer",
 	set: Set,
 	trainerType: "Stadium",

--- a/data/Sun & Moon/SM Black Star Promos/SM149.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM149.ts
@@ -11,7 +11,7 @@ const card: Card = {
 		de: "Suicune"
 	},
 	illustrator: "Anesaki Dynamic",
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Sun & Moon/SM Black Star Promos/SM15.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM15.ts
@@ -11,7 +11,7 @@ const card: Card = {
 		de: "Zygarde"
 	},
 	illustrator: "kawayoo",
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Sun & Moon/SM Black Star Promos/SM150.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM150.ts
@@ -11,7 +11,7 @@ const card: Card = {
 		de: "Raikou"
 	},
 	illustrator: "Kagemaru Himeno",
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Sun & Moon/SM Black Star Promos/SM151.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM151.ts
@@ -11,7 +11,7 @@ const card: Card = {
 		de: "Giratina"
 	},
 	illustrator: "Hasuno",
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Sun & Moon/SM Black Star Promos/SM152.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM152.ts
@@ -11,7 +11,7 @@ const card: Card = {
 		de: "Kapu-Fala"
 	},
 	illustrator: "Mizue",
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Sun & Moon/SM Black Star Promos/SM153.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM153.ts
@@ -11,7 +11,7 @@ const card: Card = {
 		de: "Bauz"
 	},
 	illustrator: "Masakazu Fukuda",
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Sun & Moon/SM Black Star Promos/SM154.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM154.ts
@@ -11,7 +11,7 @@ const card: Card = {
 		de: "Molunk"
 	},
 	illustrator: "Naoki Saito",
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Sun & Moon/SM Black Star Promos/SM155.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM155.ts
@@ -11,7 +11,7 @@ const card: Card = {
 		de: "Seedraking GX"
 	},
 	illustrator: "5ban Graphics",
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Sun & Moon/SM Black Star Promos/SM156.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM156.ts
@@ -11,7 +11,7 @@ const card: Card = {
 		de: "Dragoran GX"
 	},
 	illustrator: "5ban Graphics",
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Sun & Moon/SM Black Star Promos/SM157.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM157.ts
@@ -11,7 +11,7 @@ const card: Card = {
 		de: "Pikachu"
 	},
 	illustrator: "Megumi Mizutani",
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Sun & Moon/SM Black Star Promos/SM158.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM158.ts
@@ -11,7 +11,7 @@ const card: Card = {
 		de: "Glurak"
 	},
 	illustrator: "Anesaki Dynamic",
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Sun & Moon/SM Black Star Promos/SM159.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM159.ts
@@ -11,7 +11,7 @@ const card: Card = {
 		de: "Zapdos"
 	},
 	illustrator: "Misa Tsutsui",
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Sun & Moon/SM Black Star Promos/SM16.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM16.ts
@@ -11,7 +11,7 @@ const card: Card = {
 		de: "Solgaleo GX"
 	},
 	illustrator: "PLANETA",
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Sun & Moon/SM Black Star Promos/SM160.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM160.ts
@@ -11,7 +11,7 @@ const card: Card = {
 		de: "Nidoqueen"
 	},
 	illustrator: "Midori Harada",
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Sun & Moon/SM Black Star Promos/SM161.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM161.ts
@@ -11,7 +11,7 @@ const card: Card = {
 		de: "Jirachi"
 	},
 	illustrator: "Mizue",
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Sun & Moon/SM Black Star Promos/SM162.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM162.ts
@@ -11,7 +11,7 @@ const card: Card = {
 		de: "Pikachu"
 	},
 	illustrator: "Saya Tsuruta",
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Sun & Moon/SM Black Star Promos/SM163.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM163.ts
@@ -11,7 +11,7 @@ const card: Card = {
 		de: "Mimigma"
 	},
 	illustrator: "Saya Tsuruta",
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Sun & Moon/SM Black Star Promos/SM164.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM164.ts
@@ -11,7 +11,7 @@ const card: Card = {
 		de: "Deoxys"
 	},
 	illustrator: "You Iribi",
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Sun & Moon/SM Black Star Promos/SM165.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM165.ts
@@ -11,7 +11,7 @@ const card: Card = {
 		de: "Ultra-Necrozma"
 	},
 	illustrator: "Shin Nagasawa",
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Sun & Moon/SM Black Star Promos/SM166.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM166.ts
@@ -11,7 +11,7 @@ const card: Card = {
 		de: "Karpador & Wailord GX"
 	},
 	illustrator: "Mitsuhiro Arita",
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Sun & Moon/SM Black Star Promos/SM167.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM167.ts
@@ -12,7 +12,7 @@ const card: Card = {
 		de: "Celebi & Bisaflor GX"
 	},
 	illustrator: "Shin Nagasawa",
-	rarity: "Ultra Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Sun & Moon/SM Black Star Promos/SM168.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM168.ts
@@ -12,7 +12,7 @@ const card: Card = {
 		de: "Pikachu & Zekrom GX"
 	},
 	illustrator: "kawayoo",
-	rarity: "Ultra Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Sun & Moon/SM Black Star Promos/SM169.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM169.ts
@@ -12,7 +12,7 @@ const card: Card = {
 		de: "Evoli & Relaxo GX"
 	},
 	illustrator: "Tomokazu Komiya",
-	rarity: "Ultra Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Sun & Moon/SM Black Star Promos/SM17.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM17.ts
@@ -11,7 +11,7 @@ const card: Card = {
 		de: "Lunala GX"
 	},
 	illustrator: "PLANETA",
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Sun & Moon/SM Black Star Promos/SM170.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM170.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		de: "Meisterdetektiv Pikachu"
 	},
 
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 90,
 	types: ["Lightning"],

--- a/data/Sun & Moon/SM Black Star Promos/SM171.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM171.ts
@@ -11,7 +11,7 @@ const card: Card = {
 		de: "Flamara GX"
 	},
 	illustrator: "PLANETA Otani",
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Sun & Moon/SM Black Star Promos/SM172.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM172.ts
@@ -11,7 +11,7 @@ const card: Card = {
 		de: "Aquana GX"
 	},
 	illustrator: "PLANETA Otani",
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Sun & Moon/SM Black Star Promos/SM173.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM173.ts
@@ -12,7 +12,7 @@ const card: Card = {
 	},
 
 	illustrator: "PLANETA Otani",
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	set: Set,
 

--- a/data/Sun & Moon/SM Black Star Promos/SM174.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM174.ts
@@ -11,7 +11,7 @@ const card: Card = {
 		de: "Evoli GX"
 	},
 	illustrator: "PLANETA Otani",
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Sun & Moon/SM Black Star Promos/SM175.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM175.ts
@@ -11,7 +11,7 @@ const card: Card = {
 		de: "Evoli GX"
 	},
 	illustrator: "PLANETA Otani",
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Sun & Moon/SM Black Star Promos/SM176.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM176.ts
@@ -11,7 +11,7 @@ const card: Card = {
 		de: "Evoli GX"
 	},
 	illustrator: "PLANETA Otani",
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Sun & Moon/SM Black Star Promos/SM177.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM177.ts
@@ -11,7 +11,7 @@ const card: Card = {
 		de: "Meltan"
 	},
 	illustrator: "Shin Nagasawa",
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Sun & Moon/SM Black Star Promos/SM178.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM178.ts
@@ -11,7 +11,7 @@ const card: Card = {
 		de: "Melmetal GX"
 	},
 	illustrator: "PLANETA Otani",
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Sun & Moon/SM Black Star Promos/SM179.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM179.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		de: "Volcanion"
 	},
 
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 120,
 	types: ["Fire"],

--- a/data/Sun & Moon/SM Black Star Promos/SM18.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM18.ts
@@ -11,7 +11,7 @@ const card: Card = {
 		de: "Alola-Sandamer"
 	},
 	illustrator: "TOKIYA",
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Sun & Moon/SM Black Star Promos/SM180.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM180.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		de: "Muramura"
 	},
 
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 120,
 	types: ["Fighting"],

--- a/data/Sun & Moon/SM Black Star Promos/SM181.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM181.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		de: "Melmetal"
 	},
 
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 150,
 	types: ["Metal"],

--- a/data/Sun & Moon/SM Black Star Promos/SM182.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM182.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		de: "Snobilikat"
 	},
 
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 100,
 	types: ["Colorless"],

--- a/data/Sun & Moon/SM Black Star Promos/SM183.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM183.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		de: "Pikachu"
 	},
 
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 70,
 	types: ["Lightning"],

--- a/data/Sun & Moon/SM Black Star Promos/SM184.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM184.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		de: "Evoli"
 	},
 
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 50,
 	types: ["Colorless"],

--- a/data/Sun & Moon/SM Black Star Promos/SM185.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM185.ts
@@ -12,7 +12,7 @@ const card: Card = {
 		de: "Tornupto"
 	},
 	illustrator: "Hideki Ishikawa",
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Sun & Moon/SM Black Star Promos/SM186.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM186.ts
@@ -11,7 +11,7 @@ const card: Card = {
 		de: "Flamara"
 	},
 	illustrator: "Shin Nagasawa",
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Sun & Moon/SM Black Star Promos/SM187.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM187.ts
@@ -11,7 +11,7 @@ const card: Card = {
 		de: "Alola-Knogga GX"
 	},
 	illustrator: "5ban Graphics",
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Sun & Moon/SM Black Star Promos/SM188.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM188.ts
@@ -11,7 +11,7 @@ const card: Card = {
 		de: "Kangama GX"
 	},
 	illustrator: "aky CG Works",
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	dexId: [115],

--- a/data/Sun & Moon/SM Black Star Promos/SM189.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM189.ts
@@ -12,7 +12,7 @@ const card: Card = {
 		de: "Turtok GX"
 	},
 	illustrator: "sadaji",
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Sun & Moon/SM Black Star Promos/SM19.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM19.ts
@@ -11,7 +11,7 @@ const card: Card = {
 		de: "Choreogel"
 	},
 	illustrator: "TOKIYA",
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Sun & Moon/SM Black Star Promos/SM190.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM190.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		de: "Meisterdetektiv Pikachu"
 	},
 
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 90,
 	types: ["Lightning"],

--- a/data/Sun & Moon/SM Black Star Promos/SM191.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM191.ts
@@ -12,7 +12,7 @@ const card: Card = {
 	},
 
 	illustrator: "sui",
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	set: Set,
 

--- a/data/Sun & Moon/SM Black Star Promos/SM192.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM192.ts
@@ -12,11 +12,21 @@ const card: Card = {
 	},
 
 	illustrator: "nagimiso",
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [448, 809],
+	dexId: [
+
+
+		448,
+
+
+		809,
+
+
+	],
+
 	hp: 260,
 
 	types: [

--- a/data/Sun & Moon/SM Black Star Promos/SM193.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM193.ts
@@ -12,11 +12,21 @@ const card: Card = {
 	},
 
 	illustrator: "Anesaki Dynamic",
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [445, 487],
+	dexId: [
+
+
+		445,
+
+
+		487,
+
+
+	],
+
 	hp: 270,
 
 	types: [

--- a/data/Sun & Moon/SM Black Star Promos/SM194.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM194.ts
@@ -12,7 +12,7 @@ const card: Card = {
 	},
 
 	illustrator: "MPC Film",
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	set: Set,
 

--- a/data/Sun & Moon/SM Black Star Promos/SM195.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM195.ts
@@ -12,7 +12,7 @@ const card: Card = {
 	},
 
 	illustrator: "Framestore",
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	set: Set,
 

--- a/data/Sun & Moon/SM Black Star Promos/SM196.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM196.ts
@@ -12,7 +12,7 @@ const card: Card = {
 	},
 
 	illustrator: "MPC Film",
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	set: Set,
 

--- a/data/Sun & Moon/SM Black Star Promos/SM197.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM197.ts
@@ -12,7 +12,7 @@ const card: Card = {
 	},
 
 	illustrator: "MPC Film",
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	set: Set,
 

--- a/data/Sun & Moon/SM Black Star Promos/SM198.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM198.ts
@@ -12,7 +12,7 @@ const card: Card = {
 	},
 
 	illustrator: undefined,
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	set: Set,
 

--- a/data/Sun & Moon/SM Black Star Promos/SM199.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM199.ts
@@ -12,7 +12,7 @@ const card: Card = {
 	},
 
 	illustrator: undefined,
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	set: Set,
 

--- a/data/Sun & Moon/SM Black Star Promos/SM20.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM20.ts
@@ -11,7 +11,7 @@ const card: Card = {
 		de: "Pampross"
 	},
 	illustrator: "Mitsuhiro Arita",
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Sun & Moon/SM Black Star Promos/SM200.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM200.ts
@@ -12,7 +12,7 @@ const card: Card = {
 	},
 
 	illustrator: undefined,
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	set: Set,
 

--- a/data/Sun & Moon/SM Black Star Promos/SM201.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM201.ts
@@ -11,7 +11,7 @@ const card: Card = {
 		de: "Reshiram & Glurak GX"
 	},
 	illustrator: "Ryota Murayama",
-	rarity: "Ultra Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Sun & Moon/SM Black Star Promos/SM202.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM202.ts
@@ -12,7 +12,7 @@ const card: Card = {
 	},
 
 	illustrator: undefined,
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	set: Set,
 

--- a/data/Sun & Moon/SM Black Star Promos/SM203.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM203.ts
@@ -12,7 +12,7 @@ const card: Card = {
 	},
 
 	illustrator: undefined,
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	set: Set,
 

--- a/data/Sun & Moon/SM Black Star Promos/SM204.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM204.ts
@@ -12,7 +12,7 @@ const card: Card = {
 	},
 
 	illustrator: undefined,
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	set: Set,
 

--- a/data/Sun & Moon/SM Black Star Promos/SM205.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM205.ts
@@ -12,7 +12,7 @@ const card: Card = {
 	},
 
 	illustrator: undefined,
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	set: Set,
 

--- a/data/Sun & Moon/SM Black Star Promos/SM206.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM206.ts
@@ -12,7 +12,7 @@ const card: Card = {
 	},
 
 	illustrator: undefined,
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	set: Set,
 

--- a/data/Sun & Moon/SM Black Star Promos/SM207.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM207.ts
@@ -12,7 +12,7 @@ const card: Card = {
 	},
 
 	illustrator: undefined,
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	set: Set,
 

--- a/data/Sun & Moon/SM Black Star Promos/SM208.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM208.ts
@@ -11,7 +11,7 @@ const card: Card = {
 		de: "Donarion"
 	},
 	illustrator: "Misa Tsutsui",
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Sun & Moon/SM Black Star Promos/SM209.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM209.ts
@@ -11,7 +11,7 @@ const card: Card = {
 		de: "Muramura"
 	},
 	illustrator: "Shin Nagasawa",
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Sun & Moon/SM Black Star Promos/SM21.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM21.ts
@@ -11,7 +11,7 @@ const card: Card = {
 		de: "Sen-Long"
 	},
 	illustrator: "match",
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Sun & Moon/SM Black Star Promos/SM210.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM210.ts
@@ -11,7 +11,7 @@ const card: Card = {
 		de: "Lavados & Zapdos & Arktos GX"
 	},
 	illustrator: "HYOGONOSUKE",
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Sun & Moon/SM Black Star Promos/SM211.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM211.ts
@@ -12,7 +12,7 @@ const card: Card = {
 	},
 
 	illustrator: undefined,
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	set: Set,
 

--- a/data/Sun & Moon/SM Black Star Promos/SM212.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM212.ts
@@ -12,7 +12,7 @@ const card: Card = {
 	},
 
 	illustrator: undefined,
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	set: Set,
 

--- a/data/Sun & Moon/SM Black Star Promos/SM213.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM213.ts
@@ -12,7 +12,7 @@ const card: Card = {
 	},
 
 	illustrator: undefined,
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	set: Set,
 

--- a/data/Sun & Moon/SM Black Star Promos/SM214.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM214.ts
@@ -12,7 +12,7 @@ const card: Card = {
 	},
 
 	illustrator: undefined,
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	set: Set,
 

--- a/data/Sun & Moon/SM Black Star Promos/SM215.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM215.ts
@@ -12,7 +12,7 @@ const card: Card = {
 	},
 
 	illustrator: undefined,
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	set: Set,
 

--- a/data/Sun & Moon/SM Black Star Promos/SM216.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM216.ts
@@ -12,7 +12,7 @@ const card: Card = {
 	},
 
 	illustrator: undefined,
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	set: Set,
 

--- a/data/Sun & Moon/SM Black Star Promos/SM217.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM217.ts
@@ -12,11 +12,21 @@ const card: Card = {
 	},
 
 	illustrator: undefined,
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [709, 477],
+	dexId: [
+
+
+		709,
+
+
+		477,
+
+
+	],
+
 	hp: 270,
 
 	types: [

--- a/data/Sun & Moon/SM Black Star Promos/SM218.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM218.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		de: "Masskito"
 	},
 
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 130,
 	types: ["Grass"],

--- a/data/Sun & Moon/SM Black Star Promos/SM219.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM219.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		de: "Entei"
 	},
 
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 130,
 	types: ["Fire"],

--- a/data/Sun & Moon/SM Black Star Promos/SM22.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM22.ts
@@ -12,7 +12,7 @@ const card: Card = {
 	},
 
 	illustrator: "5ban Graphics",
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	set: Set,
 

--- a/data/Sun & Moon/SM Black Star Promos/SM220.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM220.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		de: "Phione"
 	},
 
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 70,
 	types: ["Water"],

--- a/data/Sun & Moon/SM Black Star Promos/SM221.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM221.ts
@@ -12,7 +12,7 @@ const card: Card = {
 	},
 
 	illustrator: "Shin Nagasawa",
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	set: Set,
 

--- a/data/Sun & Moon/SM Black Star Promos/SM222.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM222.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		de: "Traunmagil"
 	},
 
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 110,
 	types: ["Psychic"],

--- a/data/Sun & Moon/SM Black Star Promos/SM223.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM223.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		de: "Terrakium"
 	},
 
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 140,
 	types: ["Fighting"],

--- a/data/Sun & Moon/SM Black Star Promos/SM224.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM224.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		de: "Celebi"
 	},
 
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 70,
 	types: ["Psychic"],

--- a/data/Sun & Moon/SM Black Star Promos/SM225.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM225.ts
@@ -11,7 +11,7 @@ const card: Card = {
 		de: "Victini"
 	},
 	illustrator: "Nagimiso",
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Sun & Moon/SM Black Star Promos/SM226.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM226.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		de: "Glurak"
 	},
 
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 150,
 	types: ["Fire"],

--- a/data/Sun & Moon/SM Black Star Promos/SM227.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM227.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		de: "Pikachu"
 	},
 
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 60,
 	types: ["Lightning"],

--- a/data/Sun & Moon/SM Black Star Promos/SM228.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM228.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		de: "Armored Mewtwo"
 	},
 
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 120,
 	types: ["Psychic"],

--- a/data/Sun & Moon/SM Black Star Promos/SM229.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM229.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		de: "Bisaflor & Serpifeu GX"
 	},
 
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 270,
 	types: ["Grass"],

--- a/data/Sun & Moon/SM Black Star Promos/SM23.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM23.ts
@@ -12,7 +12,7 @@ const card: Card = {
 	},
 
 	illustrator: "5ban Graphics",
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	set: Set,
 

--- a/data/Sun & Moon/SM Black Star Promos/SM230.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM230.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		de: "Glurak & Rutena GX"
 	},
 
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 270,
 	types: ["Fire"],

--- a/data/Sun & Moon/SM Black Star Promos/SM231.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM231.ts
@@ -13,7 +13,7 @@ const card: Card = {
 		de: "Festival der Champions"
 	},
 
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Trainer",
 
 	effect: {

--- a/data/Sun & Moon/SM Black Star Promos/SM232.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM232.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		de: "Pikachu GX"
 	},
 
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 160,
 	types: ["Lightning"],

--- a/data/Sun & Moon/SM Black Star Promos/SM233.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM233.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		de: "Evoli GX"
 	},
 
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 160,
 	types: ["Colorless"],

--- a/data/Sun & Moon/SM Black Star Promos/SM234.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM234.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		de: "Pikachu"
 	},
 
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 60,
 	types: ["Lightning"],

--- a/data/Sun & Moon/SM Black Star Promos/SM235.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM235.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		de: "Evoli"
 	},
 
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 60,
 	types: ["Colorless"],

--- a/data/Sun & Moon/SM Black Star Promos/SM236.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM236.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		de: "Alola-Sandamer GX"
 	},
 
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 200,
 	types: ["Water"],

--- a/data/Sun & Moon/SM Black Star Promos/SM237.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM237.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		de: "Folipurba"
 	},
 
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 110,
 	types: ["Grass"],

--- a/data/Sun & Moon/SM Black Star Promos/SM238.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM238.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		de: "Glaziola"
 	},
 
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 110,
 	types: ["Water"],

--- a/data/Sun & Moon/SM Black Star Promos/SM239.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM239.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		de: "Karippas GX"
 	},
 
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 250,
 	types: ["Fighting"],

--- a/data/Sun & Moon/SM Black Star Promos/SM24.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM24.ts
@@ -12,7 +12,7 @@ const card: Card = {
 	},
 
 	illustrator: "5ban Graphics",
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	set: Set,
 

--- a/data/Sun & Moon/SM Black Star Promos/SM240.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM240.ts
@@ -2,7 +2,13 @@ import { Card } from '../../../interfaces'
 import Set from '../SM Black Star Promos'
 
 const card: Card = {
-	dexId: [196, 386],
+	dexId: [
+
+		196,
+
+		386,
+
+	],
 	set: Set,
 
 	name: {
@@ -14,7 +20,7 @@ const card: Card = {
 		de: "Psiana & Deoxys GX"
 	},
 
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 260,
 	types: ["Psychic"],

--- a/data/Sun & Moon/SM Black Star Promos/SM241.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM241.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		de: "Nachtara & Darkrai GX"
 	},
 
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 270,
 	types: ["Darkness"],

--- a/data/Sun & Moon/SM Black Star Promos/SM242.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM242.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		de: "Evoli GX"
 	},
 
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 160,
 	types: ["Colorless"],

--- a/data/Sun & Moon/SM Black Star Promos/SM243.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM243.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		de: "Regigigas"
 	},
 
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 150,
 	types: ["Colorless"],

--- a/data/Sun & Moon/SM Black Star Promos/SM244.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM244.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		de: "Griffel"
 	},
 
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 60,
 	types: ["Colorless"],

--- a/data/Sun & Moon/SM Black Star Promos/SM25.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM25.ts
@@ -11,7 +11,7 @@ const card: Card = {
 		de: "Mantidea"
 	},
 	illustrator: "Mitsuhiro Arita",
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Sun & Moon/SM Black Star Promos/SM26.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM26.ts
@@ -11,7 +11,7 @@ const card: Card = {
 		de: "Fruyal"
 	},
 	illustrator: "Naoki Saito",
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Sun & Moon/SM Black Star Promos/SM27.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM27.ts
@@ -11,7 +11,7 @@ const card: Card = {
 		de: "Tortunator"
 	},
 	illustrator: "TOKIYA",
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Sun & Moon/SM Black Star Promos/SM28.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM28.ts
@@ -11,7 +11,7 @@ const card: Card = {
 		de: "Donarion"
 	},
 	illustrator: "Shin Nagasawa",
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Sun & Moon/SM Black Star Promos/SM29.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM29.ts
@@ -11,7 +11,7 @@ const card: Card = {
 		de: "Mimigma"
 	},
 	illustrator: "Mitsuhiro Arita",
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Sun & Moon/SM Black Star Promos/SM30.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM30.ts
@@ -12,7 +12,7 @@ const card: Card = {
 	},
 
 	illustrator: "kirisAki",
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	set: Set,
 

--- a/data/Sun & Moon/SM Black Star Promos/SM31.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM31.ts
@@ -12,7 +12,7 @@ const card: Card = {
 	},
 
 	illustrator: "kirisAki",
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	set: Set,
 

--- a/data/Sun & Moon/SM Black Star Promos/SM32.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM32.ts
@@ -11,7 +11,7 @@ const card: Card = {
 		de: "Kapu-Toro GX"
 	},
 	illustrator: "PLANETA",
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Sun & Moon/SM Black Star Promos/SM33.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM33.ts
@@ -11,7 +11,7 @@ const card: Card = {
 		de: "Kapu-Riki GX"
 	},
 	illustrator: "5ban Graphics",
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Sun & Moon/SM Black Star Promos/SM34.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM34.ts
@@ -11,7 +11,7 @@ const card: Card = {
 		de: "Kosturso GX"
 	},
 	illustrator: "5ban Graphics",
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Sun & Moon/SM Black Star Promos/SM35.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM35.ts
@@ -11,7 +11,7 @@ const card: Card = {
 		de: "Psiana GX"
 	},
 	illustrator: "5ban Graphics",
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Sun & Moon/SM Black Star Promos/SM36.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM36.ts
@@ -11,7 +11,7 @@ const card: Card = {
 		de: "Nachtara GX"
 	},
 	illustrator: "5ban Graphics",
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Sun & Moon/SM Black Star Promos/SM37.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM37.ts
@@ -11,7 +11,7 @@ const card: Card = {
 		de: "Silvarro GX"
 	},
 	illustrator: "5ban Graphics",
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Sun & Moon/SM Black Star Promos/SM38.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM38.ts
@@ -11,7 +11,7 @@ const card: Card = {
 		de: "Fuegro GX"
 	},
 	illustrator: "5ban Graphics",
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Sun & Moon/SM Black Star Promos/SM39.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM39.ts
@@ -11,7 +11,7 @@ const card: Card = {
 		de: "Primarene GX"
 	},
 	illustrator: "5ban Graphics",
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Sun & Moon/SM Black Star Promos/SM40.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM40.ts
@@ -11,7 +11,7 @@ const card: Card = {
 		de: "Miniras"
 	},
 	illustrator: "Naoki Saito",
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Sun & Moon/SM Black Star Promos/SM41.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM41.ts
@@ -11,7 +11,7 @@ const card: Card = {
 		de: "Koalelu"
 	},
 	illustrator: "nagimiso",
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Sun & Moon/SM Black Star Promos/SM42.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM42.ts
@@ -11,7 +11,7 @@ const card: Card = {
 		de: "Cosmog"
 	},
 	illustrator: "Megumi Mizutani",
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Sun & Moon/SM Black Star Promos/SM43.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM43.ts
@@ -11,7 +11,7 @@ const card: Card = {
 		de: "Alola-Mauzi"
 	},
 	illustrator: "Megumi Mizutani",
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Sun & Moon/SM Black Star Promos/SM44.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM44.ts
@@ -12,7 +12,7 @@ const card: Card = {
 	},
 
 	illustrator: "Sanosuke Sakuma",
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	set: Set,
 

--- a/data/Sun & Moon/SM Black Star Promos/SM45.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM45.ts
@@ -11,7 +11,7 @@ const card: Card = {
 		de: "Kapu-Fala"
 	},
 	illustrator: "You Iribi",
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Sun & Moon/SM Black Star Promos/SM46.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM46.ts
@@ -11,7 +11,7 @@ const card: Card = {
 		de: "Vipitis"
 	},
 	illustrator: "Eri Yamaki",
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Sun & Moon/SM Black Star Promos/SM47.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM47.ts
@@ -11,7 +11,7 @@ const card: Card = {
 		de: "Krawell"
 	},
 	illustrator: "Mitsuhiro Arita",
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Sun & Moon/SM Black Star Promos/SM48.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM48.ts
@@ -11,7 +11,7 @@ const card: Card = {
 		de: "Zygarde"
 	},
 	illustrator: "Masakazu Fukuda",
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Sun & Moon/SM Black Star Promos/SM49.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM49.ts
@@ -11,7 +11,7 @@ const card: Card = {
 		de: "Kosturso"
 	},
 	illustrator: "Mitsuhiro Arita",
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Sun & Moon/SM Black Star Promos/SM50.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM50.ts
@@ -11,7 +11,7 @@ const card: Card = {
 		de: "Kapu-Riki GX"
 	},
 	illustrator: "5ban Graphics",
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Sun & Moon/SM Black Star Promos/SM51.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM51.ts
@@ -12,7 +12,7 @@ const card: Card = {
 	},
 
 	illustrator: "sui",
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	set: Set,
 

--- a/data/Sun & Moon/SM Black Star Promos/SM52.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM52.ts
@@ -11,7 +11,7 @@ const card: Card = {
 		de: "Tectass"
 	},
 	illustrator: "Naoki Saito",
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Sun & Moon/SM Black Star Promos/SM53.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM53.ts
@@ -12,7 +12,7 @@ const card: Card = {
 	},
 
 	illustrator: "Kouki Saitou",
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	set: Set,
 

--- a/data/Sun & Moon/SM Black Star Promos/SM54.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM54.ts
@@ -11,7 +11,7 @@ const card: Card = {
 		de: "Lucario"
 	},
 	illustrator: "Anesaki Dynamic",
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Sun & Moon/SM Black Star Promos/SM55.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM55.ts
@@ -11,7 +11,7 @@ const card: Card = {
 		de: "Silvarro"
 	},
 	illustrator: "Kouki Saitou",
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Sun & Moon/SM Black Star Promos/SM56.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM56.ts
@@ -11,7 +11,7 @@ const card: Card = {
 		de: "Fruyal GX"
 	},
 	illustrator: "5ban Graphics",
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Sun & Moon/SM Black Star Promos/SM57.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM57.ts
@@ -12,7 +12,7 @@ const card: Card = {
 	},
 
 	illustrator: "5ban Graphics",
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	set: Set,
 

--- a/data/Sun & Moon/SM Black Star Promos/SM58.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM58.ts
@@ -12,7 +12,7 @@ const card: Card = {
 	},
 
 	illustrator: "5ban Graphics",
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	set: Set,
 

--- a/data/Sun & Moon/SM Black Star Promos/SM59.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM59.ts
@@ -12,7 +12,7 @@ const card: Card = {
 	},
 
 	illustrator: "5ban Graphics",
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	set: Set,
 

--- a/data/Sun & Moon/SM Black Star Promos/SM60.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM60.ts
@@ -11,7 +11,7 @@ const card: Card = {
 		de: "Glurak GX"
 	},
 	illustrator: "5ban Graphics",
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Sun & Moon/SM Black Star Promos/SM61.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM61.ts
@@ -11,7 +11,7 @@ const card: Card = {
 		de: "Kapu-Toro"
 	},
 	illustrator: "Megumi Mizutani",
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Sun & Moon/SM Black Star Promos/SM62.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM62.ts
@@ -12,7 +12,7 @@ const card: Card = {
 	},
 
 	illustrator: "5ban Graphics",
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	set: Set,
 

--- a/data/Sun & Moon/SM Black Star Promos/SM63.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM63.ts
@@ -12,7 +12,7 @@ const card: Card = {
 	},
 
 	illustrator: "5ban Graphics",
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	set: Set,
 

--- a/data/Sun & Moon/SM Black Star Promos/SM64.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM64.ts
@@ -11,7 +11,7 @@ const card: Card = {
 		de: "Amigento"
 	},
 	illustrator: "Mitsuhiro Arita",
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Sun & Moon/SM Black Star Promos/SM65.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM65.ts
@@ -11,7 +11,7 @@ const card: Card = {
 		de: "Alola-Raichu"
 	},
 	illustrator: "5ban Graphics",
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Sun & Moon/SM Black Star Promos/SM66.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM66.ts
@@ -12,7 +12,7 @@ const card: Card = {
 	},
 
 	illustrator: "5ban Graphics",
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	set: Set,
 

--- a/data/Sun & Moon/SM Black Star Promos/SM67.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM67.ts
@@ -12,7 +12,7 @@ const card: Card = {
 	},
 
 	illustrator: "5ban Graphics",
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	set: Set,
 

--- a/data/Sun & Moon/SM Black Star Promos/SM68.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM68.ts
@@ -12,7 +12,7 @@ const card: Card = {
 	},
 
 	illustrator: "5ban Graphics",
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	set: Set,
 

--- a/data/Sun & Moon/SM Black Star Promos/SM69.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM69.ts
@@ -12,7 +12,7 @@ const card: Card = {
 	},
 
 	illustrator: "5ban Graphics",
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	set: Set,
 

--- a/data/Sun & Moon/SM Black Star Promos/SM70.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM70.ts
@@ -11,7 +11,7 @@ const card: Card = {
 		de: "Schimmerndes Ho-Oh"
 	},
 	illustrator: "Hitoshi Ariga",
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Sun & Moon/SM Black Star Promos/SM71.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM71.ts
@@ -11,7 +11,7 @@ const card: Card = {
 		de: "Grandiras GX"
 	},
 	illustrator: "5ban Graphics",
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Sun & Moon/SM Black Star Promos/SM72.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM72.ts
@@ -11,7 +11,7 @@ const card: Card = {
 		de: "Alola-Raichu"
 	},
 	illustrator: "Akira Komayama",
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Sun & Moon/SM Black Star Promos/SM73.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM73.ts
@@ -11,7 +11,7 @@ const card: Card = {
 		de: "Amfira"
 	},
 	illustrator: "Shin Nagasawa",
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Sun & Moon/SM Black Star Promos/SM74.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM74.ts
@@ -11,7 +11,7 @@ const card: Card = {
 		de: "Regirock"
 	},
 	illustrator: "kawayoo",
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Sun & Moon/SM Black Star Promos/SM75.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM75.ts
@@ -11,7 +11,7 @@ const card: Card = {
 		de: "Registeel"
 	},
 	illustrator: "Mitsuhiro Arita",
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Sun & Moon/SM Black Star Promos/SM76.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM76.ts
@@ -11,7 +11,7 @@ const card: Card = {
 		de: "Pikachu"
 	},
 	illustrator: "match",
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Sun & Moon/SM Black Star Promos/SM77.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM77.ts
@@ -11,7 +11,7 @@ const card: Card = {
 		de: "Mewtu"
 	},
 	illustrator: "Kouki Saitou",
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Sun & Moon/SM Black Star Promos/SM78.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM78.ts
@@ -12,7 +12,7 @@ const card: Card = {
 	},
 
 	illustrator: "Naoki Saito",
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Trainer",
 	set: Set,
 	trainerType: "Stadium",

--- a/data/Sun & Moon/SM Black Star Promos/SM79.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM79.ts
@@ -11,7 +11,7 @@ const card: Card = {
 		de: "Schimmerndes Celebi"
 	},
 	illustrator: "Sanosuke Sakuma",
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Sun & Moon/SM Black Star Promos/SM80.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM80.ts
@@ -11,7 +11,7 @@ const card: Card = {
 		de: "Ho-Oh GX"
 	},
 	illustrator: "5ban Graphics",
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Sun & Moon/SM Black Star Promos/SM81.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM81.ts
@@ -11,7 +11,7 @@ const card: Card = {
 		de: "Pikachu"
 	},
 	illustrator: "Sanosuke Sakuma",
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Sun & Moon/SM Black Star Promos/SM82.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM82.ts
@@ -11,7 +11,7 @@ const card: Card = {
 		de: "Schimmerndes Lugia"
 	},
 	illustrator: "Hitoshi Ariga",
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Sun & Moon/SM Black Star Promos/SM83.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM83.ts
@@ -11,7 +11,7 @@ const card: Card = {
 		de: "Zorua"
 	},
 	illustrator: "kodama",
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Sun & Moon/SM Black Star Promos/SM84.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM84.ts
@@ -11,7 +11,7 @@ const card: Card = {
 		de: "Zoroark GX"
 	},
 	illustrator: "5ban Graphics",
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Sun & Moon/SM Black Star Promos/SM85.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM85.ts
@@ -11,7 +11,7 @@ const card: Card = {
 		de: "Marshadow"
 	},
 	illustrator: "Emi Ando",
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Sun & Moon/SM Black Star Promos/SM86.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM86.ts
@@ -11,7 +11,7 @@ const card: Card = {
 		de: "Pikachu"
 	},
 	illustrator: "kodama",
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Sun & Moon/SM Black Star Promos/SM87.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM87.ts
@@ -11,7 +11,7 @@ const card: Card = {
 		de: "Latias"
 	},
 	illustrator: "Mitsuhiro Arita",
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Sun & Moon/SM Black Star Promos/SM88.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM88.ts
@@ -11,7 +11,7 @@ const card: Card = {
 		de: "Latios"
 	},
 	illustrator: "Mitsuhiro Arita",
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Sun & Moon/SM Black Star Promos/SM89.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM89.ts
@@ -11,7 +11,7 @@ const card: Card = {
 		de: "Zoroark"
 	},
 	illustrator: "Misa Tsutsui",
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Sun & Moon/SM Black Star Promos/SM90.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM90.ts
@@ -11,7 +11,7 @@ const card: Card = {
 		de: "Raichu GX"
 	},
 	illustrator: "5ban Graphics",
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Sun & Moon/SM Black Star Promos/SM91.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM91.ts
@@ -11,7 +11,7 @@ const card: Card = {
 		de: "Amigento GX"
 	},
 	illustrator: "5ban Graphics",
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Sun & Moon/SM Black Star Promos/SM92.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM92.ts
@@ -11,7 +11,7 @@ const card: Card = {
 		de: "Kapu-Kime"
 	},
 	illustrator: "Sanosuke Sakuma",
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Sun & Moon/SM Black Star Promos/SM93.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM93.ts
@@ -11,7 +11,7 @@ const card: Card = {
 		de: "Marshadow"
 	},
 	illustrator: "kirisAki",
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Sun & Moon/SM Black Star Promos/SM94.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM94.ts
@@ -11,7 +11,7 @@ const card: Card = {
 		de: "Wasch-Rotom"
 	},
 	illustrator: "Shigenori Negishi",
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Sun & Moon/SM Black Star Promos/SM95.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM95.ts
@@ -11,7 +11,7 @@ const card: Card = {
 		de: "Lucario"
 	},
 	illustrator: "Mitsuhiro Arita",
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Sun & Moon/SM Black Star Promos/SM96.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM96.ts
@@ -11,7 +11,7 @@ const card: Card = {
 		de: "Heatran"
 	},
 	illustrator: "tetsuya koizumi",
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Sun & Moon/SM Black Star Promos/SM97.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM97.ts
@@ -11,7 +11,7 @@ const card: Card = {
 		de: "Manguspektor"
 	},
 	illustrator: "nagimiso",
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 
 	set: Set,

--- a/data/Sun & Moon/SM Black Star Promos/SM98.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM98.ts
@@ -12,7 +12,7 @@ const card: Card = {
 	},
 
 	illustrator: "Saya Tsuruta",
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	set: Set,
 

--- a/data/Sun & Moon/SM Black Star Promos/SM99.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM99.ts
@@ -12,7 +12,7 @@ const card: Card = {
 	},
 
 	illustrator: "Megumi Mizutani",
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	set: Set,
 


### PR DESCRIPTION
Set: **SM Black Star Promos**
Series folder: `Sun & Moon`
Changed card files: **244**

### Validation
- [ ] `bun run validate`
- [ ] `cd server && bun run --bun validate`
- [ ] `cd server && bun run compile`
- [ ] Manual review: translations, energy types, TS syntax

### Card images
See follow-up comments with embedded TCGdex assets.