### PR TITLE
fix(data): Darkness Ablaze (Sword & Shield)

### DIFF
--- a/data/Sword & Shield/Darkness Ablaze/167.ts
+++ b/data/Sword & Shield/Darkness Ablaze/167.ts
@@ -18,11 +18,11 @@ const card: Card = {
 
 	effect: {
 		en: "Play this card as if it were a 70-HP Basic Colorless Pokémon. At any time during your turn, you may discard this card from play.\n\nThis card can't be affected by any Special Conditions, and it can't retreat.",
-		fr: "Jouez cette carte comme si c'était un Pokémon Colorless de base avec 70 PV. N'importe quand pendant votre tour, vous pouvez défausser cette carte du jeu.\n\nCette carte ne peut être affectée par aucun État Spécial, et elle ne peut pas battre en retraite.",
+		fr: "Jouez cette carte comme si c'était un Pokémon Incolore de base avec 70 PV. N'importe quand pendant votre tour, vous pouvez défausser cette carte du jeu.",
 		es: "Juega esta carta como si fuera un Pokémon Colorless Básico de 70 PS. En cualquier momento durante tu turno, puedes descartar esta carta del juego.\n\nEsta carta\n\nno puede verse afectada por ninguna Condición Especial y no puede retirarse.",
 		it: "Gioca questa carta come se fosse un Pokémon Base Colorless con 70 PS. Durante il tuo turno, in qualsiasi momento, puoi scartare questa carta dal gioco.\n\nQuesta carta non può essere influenzata da condizioni speciali e non può ritirarsi.",
 		pt: "Jogue esta carta como se fosse um Pokémon Colorless Básico com PS 70. A qualquer momento, durante o seu turno, você poderá descartar esta carta do jogo.\n\nEsta carta não pode ser afetada por quaisquer Condições Especiais e não pode recuar.",
-		de: "Spiele diese Karte, als ob sie ein Basis-Colorless-Pokémon mit 70 KP wäre. Du kannst diese Karte jederzeit während deines Zuges aus dem Spiel nehmen und auf deinen Ablagestapel legen.\n\nDiese Karte kann von keinen Speziellen Zuständen betroffen werden und sich nicht zurückziehen."
+		de: "Spiele diese Karte, als ob sie ein Basis-Colorless-Pokémon mit 70 KP wäre. Du kannst diese Karte jederzeit während deines Zuges aus dem Spiel nehmen und auf deinen Ablagestapel legen.\n\nDiese Karte kann von keinen Speziellen Zuständen betroffen werden und sich nicht zurückziehen.",
 	},
 
 	trainerType: "Item",

--- a/data/Sword & Shield/Darkness Ablaze/174.ts
+++ b/data/Sword & Shield/Darkness Ablaze/174.ts
@@ -18,11 +18,11 @@ const card: Card = {
 
 	effect: {
 		en: "As long as this card is attached to a Pokémon, it provides Fire Energy.\n\nThe Fire Pokémon this card is attached to gets +20 HP.",
-		fr: "Tant que cette carte est attachée à un Pokémon, elle fournit une Énergie Fire.\n\nCette carte ajoute 20 PV au Pokémon Fire auquel elle est attachée.",
+		fr: "Tant que cette carte est attachée à un Pokémon, elle fournit une Énergie Feu.",
 		es: "Mientras esta carta esté unida a 1 Pokémon, proporciona 1 Energía Fire.\n\nEl Pokémon Fire al que esté unida esta carta obtiene 20 PS más.",
 		it: "Fintanto che questa carta è assegnata a un Pokémon, fornisce Energia Fire.\n\nIl Pokémon Fire a cui è assegnata questa carta ha 20 PS in più.",
 		pt: "Enquanto esta carta estiver ligada a um Pokémon, ela fornecerá Energia Fire.\n\nO Pokémon Fire ao qual esta carta está ligada recebe 20 PS a mais.",
-		de: "Solange diese Karte an ein Pokémon angelegt ist, liefert sie Fire-Energie.\n\nDas Fire-Pokémon, an das diese Karte angelegt ist, erhält +20 KP."
+		de: "Solange diese Karte an ein Pokémon angelegt ist, liefert sie Fire-Energie.\n\nDas Fire-Pokémon, an das diese Karte angelegt ist, erhält +20 KP.",
 	},
 
 	energyType: "Special",

--- a/data/Sword & Shield/Darkness Ablaze/175.ts
+++ b/data/Sword & Shield/Darkness Ablaze/175.ts
@@ -18,11 +18,11 @@ const card: Card = {
 
 	effect: {
 		en: "As long as this card is attached to a Pokémon, it provides Darkness Energy.\n\nThe Darkness Pokémon this card is attached to has no Retreat Cost.",
-		fr: "Tant que cette carte est attachée à un Pokémon, elle fournit une Énergie Darkness.\n\nLe Pokémon Darkness auquel cette carte est attachée n'a pas de Coût de Retraite.",
+		fr: "Tant que cette carte est attachée à un Pokémon, elle fournit une Énergie Obscurité.",
 		es: "Mientras esta carta esté unida a 1 Pokémon, proporciona 1 Energía Darkness.\n\nEl Pokémon Darkness al que esté unida esta carta no tiene ningún Coste de Retirada.",
 		it: "Fintanto che questa carta è assegnata a un Pokémon, fornisce Energia Darkness.\n\nIl Pokémon Darkness a cui è assegnata questa carta non ha costo di ritirata.",
 		pt: "Enquanto esta carta estiver ligada a um Pokémon, ela fornecerá Energia Darkness.\n\nO Pokémon Darkness ao qual esta carta está ligada não tem custo de Recuo.",
-		de: "Solange diese Karte an ein Pokémon angelegt ist, liefert sie Darkness-Energie.\n\nDas Darkness-Pokémon, an das diese Karte angelegt ist, hat keine Rückzugskosten."
+		de: "Solange diese Karte an ein Pokémon angelegt ist, liefert sie Darkness-Energie.\n\nDas Darkness-Pokémon, an das diese Karte angelegt ist, hat keine Rückzugskosten.",
 	},
 
 	energyType: "Special",

--- a/data/Sword & Shield/Darkness Ablaze/176.ts
+++ b/data/Sword & Shield/Darkness Ablaze/176.ts
@@ -18,11 +18,11 @@ const card: Card = {
 
 	effect: {
 		en: "As long as this card is attached to a Pokémon, it provides Colorless Energy.\n\nThe attacks of the Colorless Pokémon this card is attached to do 20 more damage to your opponent's Active Pokémon (before applying Weakness and Resistance).",
-		fr: "Tant que cette carte est attachée à un Pokémon, elle fournit une Énergie Colorless.\n\nLes attaques du Pokémon Colorless auquel cette carte est attachée infligent 20 dégâts supplémentaires au Pokémon Actif de votre adversaire (avant application de la Faiblesse et de la Résistance).",
+		fr: "Tant que cette carte est attachée à un Pokémon, elle fournit une Énergie Incolore.",
 		es: "Mientras esta carta esté unida a 1 Pokémon, proporciona 1 Energía Colorless.\n\nLos ataques del Pokémon Colorless al que esté unida esta carta hacen 20 puntos de daño más al Pokémon Activo de tu rival\n\n(antes de aplicar Debilidad y Resistencia).",
 		it: "Fintanto che questa carta è assegnata a un Pokémon, fornisce Energia Colorless.\n\nGli attacchi del Pokémon Colorless a cui è assegnata questa carta infliggono 20 danni in più al Pokémon attivo del tuo avversario, prima di aver applicato debolezza e resistenza.",
 		pt: "Enquanto esta carta estiver ligada a um Pokémon, ela fornecerá Energia Colorless.\n\nOs ataques do Pokémon Colorless ao qual esta carta está ligada causam 20 pontos de dano a mais ao Pokémon Ativo do seu oponente\n\n(antes de aplicar Fraqueza e Resistência).",
-		de: "Solange diese Karte an ein Pokémon angelegt ist, liefert sie Colorless-Energie.\n\nDie Attacken des Colorless-Pokémon, an das diese Karte angelegt ist, fügen dem Aktiven Pokémon deines Gegners 20 Schadenspunkte mehr zu\n(bevor Schwäche und Resistenz verrechnet werden)."
+		de: "Solange diese Karte an ein Pokémon angelegt ist, liefert sie Colorless-Energie.\n\nDie Attacken des Colorless-Pokémon, an das diese Karte angelegt ist, fügen dem Aktiven Pokémon deines Gegners 20 Schadenspunkte mehr zu\n(bevor Schwäche und Resistenz verrechnet werden).",
 	},
 
 	energyType: "Special",

--- a/data/Sword & Shield/Darkness Ablaze/201.ts
+++ b/data/Sword & Shield/Darkness Ablaze/201.ts
@@ -18,11 +18,11 @@ const card: Card = {
 
 	effect: {
 		en: "As long as this card is attached to a Pokémon, it provides Colorless Energy.\n\nWhen you attach this card from your hand to a Pokémon, search your deck for a Basic Pokémon and put it onto your Bench. Then, shuffle your deck.",
-		fr: "Tant que cette carte est attachée à un Pokémon, elle fournit une Énergie Colorless.\n\nLorsque vous attachez cette carte de votre main à un Pokémon, cherchez dans votre deck un Pokémon de base, puis placez-le sur votre Banc. Mélangez ensuite votre deck.",
+		fr: "Tant que cette carte est attachée à un Pokémon, elle fournit une Énergie Incolore.",
 		es: "Mientras esta carta esté unida a 1 Pokémon, proporciona 1 Energía Colorless.\n\nCuando unes esta carta de tu mano a 1 Pokémon, busca en tu baraja 1 Pokémon Básico y ponlo en tu Banca. Después, baraja las cartas de tu baraja.",
 		it: "Fintanto che questa carta è assegnata a un Pokémon, fornisce Energia Colorless.\n\nQuando assegni questa carta dalla tua mano a un Pokémon, cerca nel tuo mazzo un Pokémon Base e mettilo nella tua panchina. Poi rimischia le carte del tuo mazzo.",
 		pt: "Enquanto esta carta estiver ligada a um Pokémon, ela fornecerá Energia Colorless.\n\nQuando você ligar esta carta da sua mão a 1 Pokémon, procure por 1 Pokémon Básico no seu baralho e coloque-o no seu Banco. Em seguida, embaralhe o seu baralho.",
-		de: "Solange diese Karte an ein Pokémon angelegt ist, liefert sie Colorless-Energie.\n\nWenn du diese Karte aus deiner Hand an ein Pokémon anlegst, durchsuche dein Deck nach 1 Basis-Pokémon und lege es auf deine Bank. Mische anschließend dein Deck."
+		de: "Solange diese Karte an ein Pokémon angelegt ist, liefert sie Colorless-Energie.\n\nWenn du diese Karte aus deiner Hand an ein Pokémon anlegst, durchsuche dein Deck nach 1 Basis-Pokémon und lege es auf deine Bank. Mische anschließend dein Deck.",
 	},
 
 	energyType: "Special",


### PR DESCRIPTION
Set: **Darkness Ablaze**
Series folder: `Sword & Shield`
Changed card files: **5**

### Validation
- [ ] `bun run validate`
- [ ] `cd server && bun run --bun validate`
- [ ] `cd server && bun run compile`
- [ ] Manual review: translations, energy types, TS syntax

### Card images
See follow-up comments with embedded TCGdex assets.