### PR TITLE
fix(data): Lost Origin (Sword & Shield)

### DIFF
--- a/data/Sword & Shield/Lost Origin.ts
+++ b/data/Sword & Shield/Lost Origin.ts
@@ -19,6 +19,17 @@ const set: Set = {
 		official: 196
 	},
 
+	subsets: {
+		TG: {
+			name: {
+				en: "Trainer Gallery"
+			},
+			cardCount: {
+				official: 30
+			}
+		}
+	},
+
 	releaseDate: "2022-09-09",
 
 	abbreviations: {


### PR DESCRIPTION
Set: **Lost Origin**
Series folder: `Sword & Shield`
Changed card files: **0**

### Validation
- [ ] `bun run validate`
- [ ] `cd server && bun run --bun validate`
- [ ] `cd server && bun run compile`
- [ ] Manual review: translations, energy types, TS syntax

### Card images
See follow-up comments with embedded TCGdex assets.