### PR TITLE
fix(data): SWSH Black Star Promos (Sword & Shield)

### DIFF
--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH001.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH001.ts
@@ -12,7 +12,7 @@ const card: Card = {
 	},
 
 	illustrator: "kirisAki",
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	set: Set,
 	hp: 60,

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH002.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH002.ts
@@ -12,7 +12,7 @@ const card: Card = {
 	},
 
 	illustrator: "Hitoshi Ariga",
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	set: Set,
 	hp: 60,

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH003.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH003.ts
@@ -12,7 +12,7 @@ const card: Card = {
 	},
 
 	illustrator: "Mizue",
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	set: Set,
 	hp: 60,

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH004.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH004.ts
@@ -12,7 +12,7 @@ const card: Card = {
 	},
 
 	illustrator: "aky CG Works",
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	set: Set,
 	hp: 180,

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH005.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH005.ts
@@ -12,7 +12,7 @@ const card: Card = {
 	},
 
 	illustrator: "aky CG Works",
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	set: Set,
 	hp: 300,

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH006.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH006.ts
@@ -12,7 +12,7 @@ const card: Card = {
 	},
 
 	illustrator: "Kouki Saitou",
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	set: Set,
 	hp: 170,

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH007.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH007.ts
@@ -12,7 +12,7 @@ const card: Card = {
 	},
 
 	illustrator: "kirisAki",
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	set: Set,
 	hp: 90,

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH008.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH008.ts
@@ -12,7 +12,7 @@ const card: Card = {
 	},
 
 	illustrator: "Akira Komayama",
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	set: Set,
 	hp: 120,

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH009.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH009.ts
@@ -12,7 +12,7 @@ const card: Card = {
 	},
 
 	illustrator: "Shibuzoh.",
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	set: Set,
 	hp: 90,

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH010.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH010.ts
@@ -12,7 +12,7 @@ const card: Card = {
 	},
 
 	illustrator: "Naoki Saito",
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	set: Set,
 	hp: 50,

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH011.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH011.ts
@@ -12,7 +12,7 @@ const card: Card = {
 	},
 
 	illustrator: "Hitoshi Ariga",
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	set: Set,
 	hp: 60,

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH012.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH012.ts
@@ -12,7 +12,7 @@ const card: Card = {
 	},
 
 	illustrator: "Kagemaru Himeno",
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	set: Set,
 	hp: 80,

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH013.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH013.ts
@@ -12,7 +12,7 @@ const card: Card = {
 	},
 
 	illustrator: "kirisAki",
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	set: Set,
 	hp: 70,

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH014.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH014.ts
@@ -14,7 +14,7 @@ const card: Card = {
 	},
 
 	illustrator: "5ban Graphics",
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 220,
 	types: ["Grass"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH015.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH015.ts
@@ -14,7 +14,7 @@ const card: Card = {
 	},
 
 	illustrator: "5ban Graphics",
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 210,
 	types: ["Fire"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH016.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH016.ts
@@ -14,7 +14,7 @@ const card: Card = {
 	},
 
 	illustrator: "5ban Graphics",
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 200,
 	types: ["Water"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH017.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH017.ts
@@ -14,7 +14,7 @@ const card: Card = {
 	},
 
 	illustrator: "5ban Graphics",
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 210,
 	types: ["Lightning"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH018.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH018.ts
@@ -14,7 +14,7 @@ const card: Card = {
 	},
 
 	illustrator: "5ban Graphics",
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 220,
 	types: ["Metal"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH019.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH019.ts
@@ -14,7 +14,7 @@ const card: Card = {
 	},
 
 	illustrator: "aky CG Works",
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 230,
 	types: ["Metal"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH020.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH020.ts
@@ -14,7 +14,7 @@ const card: Card = {
 	},
 
 	illustrator: "Hideki Ishikawa",
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 70,
 	types: ["Lightning"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH021.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH021.ts
@@ -14,7 +14,7 @@ const card: Card = {
 	},
 
 	illustrator: "PLANETA Igarashi",
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 170,
 	types: ["Psychic"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH022.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH022.ts
@@ -14,7 +14,7 @@ const card: Card = {
 	},
 
 	illustrator: "Hitoshi Ariga",
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 80,
 	types: ["Grass"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH023.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH023.ts
@@ -14,7 +14,7 @@ const card: Card = {
 	},
 
 	illustrator: "Megumi Higuchi",
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 160,
 	types: ["Lightning"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH024.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH024.ts
@@ -14,7 +14,7 @@ const card: Card = {
 	},
 
 	illustrator: "Kouki Saitou",
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 160,
 	types: ["Fighting"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH025.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH025.ts
@@ -14,7 +14,7 @@ const card: Card = {
 	},
 
 	illustrator: "tetsuya koizumi",
-	rarity: "Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 120,
 	types: ["Darkness"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH026.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH026.ts
@@ -14,7 +14,7 @@ const card: Card = {
 	},
 
 	illustrator: "0313",
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 110,
 	types: ["Water"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH027.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH027.ts
@@ -14,7 +14,7 @@ const card: Card = {
 	},
 
 	illustrator: "Misa Tsutsui",
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 110,
 	types: ["Colorless"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH028.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH028.ts
@@ -14,7 +14,7 @@ const card: Card = {
 	},
 
 	illustrator: "Ryuta Fuse",
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 130,
 	types: ["Metal"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH029.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH029.ts
@@ -14,7 +14,7 @@ const card: Card = {
 	},
 
 	illustrator: "so-taro",
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 130,
 	types: ["Colorless"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH030.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH030.ts
@@ -14,7 +14,7 @@ const card: Card = {
 	},
 
 	illustrator: "5ban Graphics",
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 220,
 	types: ["Metal"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH031.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH031.ts
@@ -14,7 +14,7 @@ const card: Card = {
 	},
 
 	illustrator: "Hitoshi Ariga",
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 80,
 	types: ["Lightning"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH032.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH032.ts
@@ -14,7 +14,7 @@ const card: Card = {
 	},
 
 	illustrator: "Tika Matsuno",
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 150,
 	types: ["Colorless"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH033.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH033.ts
@@ -14,7 +14,7 @@ const card: Card = {
 	},
 
 	illustrator: "Kouki Saitou",
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 130,
 	types: ["Metal"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH034.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH034.ts
@@ -14,7 +14,7 @@ const card: Card = {
 	},
 
 	illustrator: "Kouki Saitou",
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 130,
 	types: ["Metal"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH035.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH035.ts
@@ -14,7 +14,7 @@ const card: Card = {
 	},
 
 	illustrator: "Souichirou Gunjima",
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 140,
 	types: ["Grass"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH036.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH036.ts
@@ -14,7 +14,7 @@ const card: Card = {
 	},
 
 	illustrator: "Hasuno",
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 130,
 	types: ["Lightning"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH037.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH037.ts
@@ -14,7 +14,7 @@ const card: Card = {
 	},
 
 	illustrator: "Taira Akitsu",
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 160,
 	types: ["Darkness"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH038.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH038.ts
@@ -14,7 +14,7 @@ const card: Card = {
 	},
 
 	illustrator: "HYOGONOSUKE",
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 130,
 	types: ["Colorless"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH039.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH039.ts
@@ -14,7 +14,7 @@ const card: Card = {
 	},
 
 	illustrator: "Hitoshi Ariga",
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 60,
 	types: ["Lightning"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH040.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH040.ts
@@ -14,7 +14,7 @@ const card: Card = {
 	},
 
 	illustrator: "Misa Tsutsui",
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 60,
 	types: ["Psychic"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH041.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH041.ts
@@ -14,7 +14,7 @@ const card: Card = {
 	},
 
 	illustrator: "You Iribi",
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 110,
 	types: ["Fire"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH042.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH042.ts
@@ -14,7 +14,7 @@ const card: Card = {
 	},
 
 	illustrator: "You Iribi",
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 60,
 	types: ["Colorless"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH043.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH043.ts
@@ -14,7 +14,7 @@ const card: Card = {
 	},
 
 	illustrator: "PLANETA Tsuji",
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 210,
 	types: ["Fighting"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH044.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH044.ts
@@ -14,7 +14,7 @@ const card: Card = {
 	},
 
 	illustrator: "5ban Graphics",
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 220,
 	types: ["Darkness"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH045.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH045.ts
@@ -14,7 +14,7 @@ const card: Card = {
 	},
 
 	illustrator: "5ban Graphics",
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 340,
 	types: ["Darkness"],
@@ -92,7 +92,7 @@ const card: Card = {
 	regulationMark: "D",
 
 	thirdParty: {
-		cardmarket: 496325
+		cardmarket: 496315
 	}
 }
 

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH046.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH046.ts
@@ -14,7 +14,7 @@ const card: Card = {
 	},
 
 	illustrator: "Mina Nakai",
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 80,
 	types: ["Grass"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH047.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH047.ts
@@ -14,7 +14,7 @@ const card: Card = {
 	},
 
 	illustrator: "Anesaki Dynamic",
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 130,
 	types: ["Water"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH048.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH048.ts
@@ -14,7 +14,7 @@ const card: Card = {
 	},
 
 	illustrator: "nagimiso",
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 130,
 	types: ["Fire"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH049.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH049.ts
@@ -14,7 +14,7 @@ const card: Card = {
 	},
 
 	illustrator: "5ban Graphics",
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 210,
 	types: ["Colorless"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH050.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH050.ts
@@ -14,7 +14,7 @@ const card: Card = {
 	},
 
 	illustrator: "5ban Graphics",
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 220,
 	types: ["Fire"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH051.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH051.ts
@@ -14,7 +14,7 @@ const card: Card = {
 	},
 
 	illustrator: "Megumi Higuchi",
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 130,
 	types: ["Water"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH052.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH052.ts
@@ -14,7 +14,7 @@ const card: Card = {
 	},
 
 	illustrator: "Shibuzoh.",
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 110,
 	types: ["Psychic"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH053.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH053.ts
@@ -14,7 +14,7 @@ const card: Card = {
 	},
 
 	illustrator: "SATOSHI NAKAI",
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 170,
 	types: ["Fighting"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH054.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH054.ts
@@ -14,7 +14,7 @@ const card: Card = {
 	},
 
 	illustrator: "Shigenori Negishi",
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 160,
 	types: ["Fighting"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH055.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH055.ts
@@ -14,7 +14,7 @@ const card: Card = {
 	},
 
 	illustrator: "PLANETA Igarashi",
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 200,
 	types: ["Psychic"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH056.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH056.ts
@@ -14,7 +14,7 @@ const card: Card = {
 	},
 
 	illustrator: "5ban Graphics",
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 170,
 	types: ["Lightning"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH057.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH057.ts
@@ -14,7 +14,7 @@ const card: Card = {
 	},
 
 	illustrator: "5ban Graphics",
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 220,
 	types: ["Darkness"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH058.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH058.ts
@@ -14,7 +14,7 @@ const card: Card = {
 	},
 
 	illustrator: "sui",
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 110,
 	types: ["Psychic"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH059.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH059.ts
@@ -14,7 +14,7 @@ const card: Card = {
 	},
 
 	illustrator: "Hasuno",
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 160,
 	types: ["Darkness"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH060.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH060.ts
@@ -14,7 +14,7 @@ const card: Card = {
 	},
 
 	illustrator: "Kazuma Koda",
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 130,
 	types: ["Metal"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH061.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH061.ts
@@ -14,7 +14,7 @@ const card: Card = {
 	},
 
 	illustrator: "PLANETA Tsuji",
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 190,
 	types: ["Lightning"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH062.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH062.ts
@@ -21,7 +21,7 @@ const card: Card = {
 		it: "Pikachu VMAX"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 310,
 	types: ["Lightning"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH063.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH063.ts
@@ -14,7 +14,7 @@ const card: Card = {
 	},
 
 	illustrator: "Ryota Murayama",
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 190,
 	types: ["Lightning"],
@@ -74,7 +74,7 @@ const card: Card = {
 	suffix: "V",
 
 	thirdParty: {
-		cardmarket: 461594
+		cardmarket: 496545
 	}
 }
 

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH064.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH064.ts
@@ -14,7 +14,7 @@ const card: Card = {
 	},
 
 	illustrator: "5ban Graphics",
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 220,
 	types: ["Darkness"],
@@ -83,7 +83,7 @@ const card: Card = {
 	suffix: "V",
 
 	thirdParty: {
-		cardmarket: 496325
+		cardmarket: 496315
 	}
 }
 

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH065.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH065.ts
@@ -14,7 +14,7 @@ const card: Card = {
 	},
 
 	illustrator: "Kagemaru Himeno",
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 190,
 	types: ["Colorless"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH066.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH066.ts
@@ -14,7 +14,7 @@ const card: Card = {
 	},
 
 	illustrator: "NC Empire",
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 170,
 	types: ["Fire"],
@@ -97,7 +97,7 @@ const card: Card = {
 	regulationMark: "D",
 
 	thirdParty: {
-		cardmarket: 516329
+		cardmarket: 505255
 	}
 }
 

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH067.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH067.ts
@@ -14,7 +14,7 @@ const card: Card = {
 	},
 
 	illustrator: "Eri Yamaki",
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 150,
 	types: ["Fighting"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH068.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH068.ts
@@ -14,7 +14,7 @@ const card: Card = {
 	},
 
 	illustrator: "Narumi Sato",
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 130,
 	types: ["Colorless"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH069.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH069.ts
@@ -14,7 +14,7 @@ const card: Card = {
 	},
 
 	illustrator: "kodama",
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 130,
 	types: ["Colorless"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH070.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH070.ts
@@ -14,7 +14,7 @@ const card: Card = {
 	},
 
 	illustrator: "Akira Komayama",
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 60,
 	types: ["Grass"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH071.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH071.ts
@@ -14,7 +14,7 @@ const card: Card = {
 	},
 
 	illustrator: "Akira Komayama",
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 60,
 	types: ["Fire"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH072.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH072.ts
@@ -14,7 +14,7 @@ const card: Card = {
 	},
 
 	illustrator: "so-taro",
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 110,
 	types: ["Water"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH073.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH073.ts
@@ -14,7 +14,7 @@ const card: Card = {
 	},
 
 	illustrator: "Akira Komayama",
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 60,
 	types: ["Water"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH074.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH074.ts
@@ -10,7 +10,7 @@ const card: Card = {
 	},
 
 	illustrator: "Illus. & Direc. The Pokémon Company Art Team",
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 60,
 	types: ["Lightning"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH076.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH076.ts
@@ -14,7 +14,7 @@ const card: Card = {
 	},
 
 	illustrator: "5ban Graphics",
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 220,
 	types: ["Metal"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH077.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH077.ts
@@ -14,7 +14,7 @@ const card: Card = {
 	},
 
 	illustrator: "aky CG Works",
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 230,
 	types: ["Metal"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH078.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH078.ts
@@ -14,7 +14,7 @@ const card: Card = {
 	},
 
 	illustrator: "5ban Graphics",
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 180,
 	types: ["Grass"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH079.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH079.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		it: "Mr. Rime di Galar"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	hp: 120,
 	types: ["Water"],
 

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH080.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH080.ts
@@ -21,7 +21,7 @@ const card: Card = {
 		it: "Dedenne"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	dexId: [702],
 	hp: 70,
 	types: ["Psychic"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH081.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH081.ts
@@ -21,7 +21,7 @@ const card: Card = {
 		it: "Polteageist"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	dexId: [855],
 	hp: 60,
 	types: ["Psychic"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH082.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH082.ts
@@ -21,7 +21,7 @@ const card: Card = {
 		it: "Bunnelby"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	dexId: [659],
 	hp: 40,
 	types: ["Colorless"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH083.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH083.ts
@@ -14,7 +14,7 @@ const card: Card = {
 	},
 
 	illustrator: "Ayaka Yoshida",
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 190,
 	types: ["Psychic"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH084.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH084.ts
@@ -16,7 +16,7 @@ const card: Card = {
 		it: "Eldegoss V"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	dexId: [830],
 	hp: 180,
 	types: ["Grass"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH085.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH085.ts
@@ -16,7 +16,7 @@ const card: Card = {
 		it: "Boltund V"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	dexId: [836],
 	hp: 200,
 	types: ["Lightning"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH086.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH086.ts
@@ -16,7 +16,7 @@ const card: Card = {
 		it: "Cramorant V"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	dexId: [845],
 	hp: 200,
 	types: ["Colorless"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH087.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH087.ts
@@ -16,7 +16,7 @@ const card: Card = {
 		it: "Eevee VMAX"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	dexId: [133],
 	hp: 300,
 	types: ["Colorless"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH088.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH088.ts
@@ -14,7 +14,7 @@ const card: Card = {
 	},
 
 	illustrator: "Tika Matsuno",
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 80,
 	types: ["Grass"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH089.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH089.ts
@@ -14,7 +14,7 @@ const card: Card = {
 	},
 
 	illustrator: "KIYOTAKA OSHIYAMA",
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 110,
 	types: ["Water"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH090.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH090.ts
@@ -14,7 +14,7 @@ const card: Card = {
 	},
 
 	illustrator: "Uta",
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 130,
 	types: ["Darkness"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH091.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH091.ts
@@ -14,7 +14,7 @@ const card: Card = {
 	},
 
 	illustrator: "Atsushi Furusawa",
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 110,
 	types: ["Metal"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH092.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH092.ts
@@ -21,7 +21,7 @@ const card: Card = {
 		it: "Charmander"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	dexId: [4],
 	hp: 70,
 	types: ["Fire"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH093.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH093.ts
@@ -21,7 +21,7 @@ const card: Card = {
 		it: "Arrokuda"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	dexId: [846],
 	hp: 60,
 	types: ["Water"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH094.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH094.ts
@@ -14,7 +14,7 @@ const card: Card = {
 	},
 
 	illustrator: "Yuu Nishida",
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 100,
 	types: ["Lightning"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH095.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH095.ts
@@ -14,7 +14,7 @@ const card: Card = {
 	},
 
 	illustrator: "Naoki Saito",
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 60,
 	types: ["Colorless"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH096.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH096.ts
@@ -16,7 +16,7 @@ const card: Card = {
 		it: "Dragapult V"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	dexId: [887],
 	hp: 210,
 	types: ["Psychic"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH097.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH097.ts
@@ -16,7 +16,7 @@ const card: Card = {
 		it: "Dragapult VMAX"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	dexId: [887],
 	hp: 320,
 	types: ["Psychic"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH098.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH098.ts
@@ -16,7 +16,7 @@ const card: Card = {
 		it: "Crobat V"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	dexId: [169],
 	hp: 180,
 	types: ["Darkness"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH099.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH099.ts
@@ -16,7 +16,7 @@ const card: Card = {
 		it: "Crobat VMAX"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	dexId: [169],
 	hp: 300,
 	types: ["Darkness"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH100.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH100.ts
@@ -16,7 +16,7 @@ const card: Card = {
 		it: "Venusaur V"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	dexId: [3],
 	hp: 220,
 	types: ["Grass"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH101.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH101.ts
@@ -16,7 +16,7 @@ const card: Card = {
 		it: "Blastoise V"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	dexId: [9],
 	hp: 220,
 	types: ["Water"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH102.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH102.ts
@@ -14,7 +14,7 @@ const card: Card = {
 	},
 
 	illustrator: "aky CG Works",
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 330,
 	types: ["Grass"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH103.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH103.ts
@@ -14,7 +14,7 @@ const card: Card = {
 	},
 
 	illustrator: "5ban Graphics",
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 330,
 	types: ["Water"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH104.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH104.ts
@@ -16,7 +16,7 @@ const card: Card = {
 		it: "Victini V"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	hp: 190,
 	types: ["Fire"],
 

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH105.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH105.ts
@@ -16,7 +16,7 @@ const card: Card = {
 		it: "Gardevoir V"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	hp: 210,
 	types: ["Psychic"],
 

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH106.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH106.ts
@@ -14,7 +14,7 @@ const card: Card = {
 	},
 
 	illustrator: "5ban Graphics",
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 220,
 	types: ["Fighting"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH107.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH107.ts
@@ -14,7 +14,7 @@ const card: Card = {
 	},
 
 	illustrator: "5ban Graphics",
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 220,
 	types: ["Fighting"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH108.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH108.ts
@@ -14,7 +14,7 @@ const card: Card = {
 	},
 
 	illustrator: "PLANETA Mochizuki",
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 210,
 	types: ["Water"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH109.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH109.ts
@@ -14,7 +14,7 @@ const card: Card = {
 	},
 
 	illustrator: "PLANETA Tsuji",
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 230,
 	types: ["Darkness"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH110.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH110.ts
@@ -16,7 +16,7 @@ const card: Card = {
 		it: "Crobat V"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	dexId: [169],
 	hp: 180,
 	types: ["Darkness"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH111.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH111.ts
@@ -16,7 +16,7 @@ const card: Card = {
 		it: "Rapidash di Galar V"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	hp: 210,
 	types: ["Psychic"],
 

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH112.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH112.ts
@@ -21,7 +21,7 @@ const card: Card = {
 		it: "Cinderace"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	dexId: [815],
 	hp: 170,
 	types: ["Fire"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH113.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH113.ts
@@ -21,7 +21,7 @@ const card: Card = {
 		it: "Inteleon"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	dexId: [818],
 	hp: 150,
 	types: ["Water"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH114.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH114.ts
@@ -21,7 +21,7 @@ const card: Card = {
 		it: "Cresselia"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	dexId: [488],
 	hp: 120,
 	types: ["Psychic"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH115.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH115.ts
@@ -21,7 +21,7 @@ const card: Card = {
 		it: "Passimian"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	dexId: [766],
 	hp: 110,
 	types: ["Fighting"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH116.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH116.ts
@@ -21,7 +21,7 @@ const card: Card = {
 		it: "Morpeko"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	dexId: [877],
 	hp: 80,
 	types: ["Lightning"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH117.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH117.ts
@@ -21,7 +21,7 @@ const card: Card = {
 		it: "Phanpy"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	dexId: [231],
 	hp: 70,
 	types: ["Fighting"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH118.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH118.ts
@@ -21,7 +21,7 @@ const card: Card = {
 		it: "Eevee"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	dexId: [133],
 	hp: 60,
 	types: ["Colorless"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH119.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH119.ts
@@ -21,7 +21,7 @@ const card: Card = {
 		it: "Snorlax"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	dexId: [143],
 	hp: 140,
 	types: ["Colorless"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH120.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH120.ts
@@ -15,7 +15,7 @@ const card: Card = {
 		it: "Mary"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 
 	effect: {
 		en: "Each player shuffles their hand and puts it on the bottom of their deck. If either player put any cards on the bottom of their deck in this way, you draw 5 cards, and your opponent draws 4 cards.",

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH121.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH121.ts
@@ -15,7 +15,7 @@ const card: Card = {
 		it: "Mary"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 
 	effect: {
 		en: "Each player shuffles their hand and puts it on the bottom of their deck. If either player put any cards on the bottom of their deck in this way, you draw 5 cards, and your opponent draws 4 cards.",

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH122.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH122.ts
@@ -21,7 +21,7 @@ const card: Card = {
 		it: "Flaaffy"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	dexId: [180],
 	hp: 90,
 	types: ["Lightning"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH123.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH123.ts
@@ -21,7 +21,7 @@ const card: Card = {
 		it: "Articuno di Galar"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	dexId: [144],
 	hp: 120,
 	types: ["Psychic"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH124.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH124.ts
@@ -21,7 +21,7 @@ const card: Card = {
 		it: "Zapdos di Galar"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	dexId: [145],
 	hp: 110,
 	types: ["Fighting"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH125.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH125.ts
@@ -21,7 +21,7 @@ const card: Card = {
 		it: "Moltres di Galar"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	dexId: [146],
 	hp: 120,
 	types: ["Darkness"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH126.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH126.ts
@@ -21,7 +21,7 @@ const card: Card = {
 		it: "Slowpoke di Galar"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	dexId: [79],
 	hp: 70,
 	types: ["Psychic"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH127.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH127.ts
@@ -21,7 +21,7 @@ const card: Card = {
 		it: "Eevee"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	dexId: [133],
 	hp: 60,
 	types: ["Colorless"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH128.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH128.ts
@@ -21,7 +21,7 @@ const card: Card = {
 		it: "Eiscue"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	dexId: [875],
 	hp: 120,
 	types: ["Water"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH129.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH129.ts
@@ -21,7 +21,7 @@ const card: Card = {
 		it: "Umbreon"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	dexId: [197],
 	hp: 110,
 	types: ["Darkness"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH130.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH130.ts
@@ -17,7 +17,7 @@ const card: Card = {
 		it: "Calyrex Cavaliere Glaciale V"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	hp: 210,
 	types: ["Water"],
 

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH131.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH131.ts
@@ -17,7 +17,7 @@ const card: Card = {
 		it: "Calyrex Cavaliere Spettrale V"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	hp: 210,
 	types: ["Psychic"],
 

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH132.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH132.ts
@@ -15,7 +15,7 @@ const card: Card = {
 	},
 
 	illustrator: "5ban Graphics",
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	stage: "Stage2",
 

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH133.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH133.ts
@@ -15,7 +15,7 @@ const card: Card = {
 	},
 
 	illustrator: "Hideki Ishikawa",
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	stage: "Basic",
 

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH134.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH134.ts
@@ -15,7 +15,7 @@ const card: Card = {
 	},
 
 	illustrator: "Ryuta Fuse",
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	stage: "Basic",
 

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH135.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH135.ts
@@ -15,7 +15,7 @@ const card: Card = {
 	},
 
 	illustrator: "5ban Graphics",
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	stage: "BREAK",
 
@@ -69,7 +69,7 @@ const card: Card = {
 	retreat: 2,
 
 	thirdParty: {
-		cardmarket: 491179
+		cardmarket: 465529
 	}
 }
 

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH136.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH136.ts
@@ -21,7 +21,7 @@ const card: Card = {
 		it: "Mimikyu"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 70,
 	types: ["Water"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH137.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH137.ts
@@ -21,7 +21,7 @@ const card: Card = {
 		it: "Light Toxtricity"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 120,
 	types: ["Lightning"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH138.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH138.ts
@@ -21,7 +21,7 @@ const card: Card = {
 		it: "Hydreigon C"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 110,
 	types: ["Darkness"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH139.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH139.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		it: "Pikachu V UNIONE"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	stage: "V-UNION",
 

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH140.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH140.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		it: "Pikachu V UNIONE"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	stage: "V-UNION",
 

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH141.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH141.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		it: "Pikachu V UNIONE"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	stage: "V-UNION",
 

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH142.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH142.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		it: "Pikachu V UNIONE"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	stage: "V-UNION",
 

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH143.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH143.ts
@@ -21,7 +21,7 @@ const card: Card = {
 		it: "Pikachu V"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 190,
 	types: ["Lightning"],
@@ -56,7 +56,7 @@ const card: Card = {
 	regulationMark: "E",
 
 	thirdParty: {
-		cardmarket: 461594
+		cardmarket: 496545
 	}
 }
 

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH144.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH144.ts
@@ -21,7 +21,7 @@ const card: Card = {
 		it: "Greninja {star}"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 130,
 	types: ["Darkness"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH145.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH145.ts
@@ -21,7 +21,7 @@ const card: Card = {
 		it: "Pikachu V"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 190,
 	types: ["Lightning"],
@@ -56,7 +56,7 @@ const card: Card = {
 	regulationMark: "E",
 
 	thirdParty: {
-		cardmarket: 461594
+		cardmarket: 496545
 	}
 }
 

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH146.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH146.ts
@@ -20,7 +20,7 @@ const card: Card = {
 		it: "Poké Ball"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Trainer",
 	types: ["Lightning"],
 

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH147.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH147.ts
@@ -15,7 +15,7 @@ const card: Card = {
 	},
 
 	illustrator: "PLANETA Mochizuki",
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	stage: "Basic",
 

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH148.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH148.ts
@@ -15,7 +15,7 @@ const card: Card = {
 	},
 
 	illustrator: "PLANETA Yamashita",
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	stage: "Basic",
 

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH149.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH149.ts
@@ -24,7 +24,7 @@ const card: Card = {
 		it: "Flareon V"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	hp: 210,
 	types: ["Fire"],
 

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH150.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH150.ts
@@ -24,7 +24,7 @@ const card: Card = {
 		it: "Vaporeon V"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	hp: 210,
 	types: ["Water"],
 

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH151.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH151.ts
@@ -24,7 +24,7 @@ const card: Card = {
 		it: "Jolteon V"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	hp: 190,
 	types: ["Lightning"],
 

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH152.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH152.ts
@@ -13,7 +13,7 @@ const card: Card = {
 		en: "Professor's Research"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Trainer",
 
 	description: {

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH153.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH153.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		en: "Pikachu"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 60,
 	types: ["Lightning"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH154.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH154.ts
@@ -21,7 +21,7 @@ const card: Card = {
 		it: "Dragonite V"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 230,
 	types: ["Dragon"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH155.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH155.ts
@@ -24,7 +24,7 @@ const card: Card = {
 		it: "Greninja V UNIONE"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	hp: 300,
 	types: ["Water"],
 

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH156.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH156.ts
@@ -24,7 +24,7 @@ const card: Card = {
 		it: "Greninja V UNIONE"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	hp: 300,
 	types: ["Water"],
 

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH157.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH157.ts
@@ -24,7 +24,7 @@ const card: Card = {
 		it: "Greninja V UNIONE"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	hp: 300,
 	types: ["Water"],
 

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH158.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH158.ts
@@ -24,7 +24,7 @@ const card: Card = {
 		it: "Greninja V UNIONE"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	hp: 300,
 	types: ["Water"],
 

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH159.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH159.ts
@@ -24,7 +24,7 @@ const card: Card = {
 		it: "Mewtwo V UNIONE"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	hp: 310,
 	types: ["Psychic"],
 

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH160.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH160.ts
@@ -24,7 +24,7 @@ const card: Card = {
 		it: "Mewtwo V UNIONE"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	hp: 310,
 	types: ["Psychic"],
 

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH161.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH161.ts
@@ -24,7 +24,7 @@ const card: Card = {
 		it: "Mewtwo V UNIONE"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	hp: 310,
 	types: ["Psychic"],
 

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH162.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH162.ts
@@ -24,7 +24,7 @@ const card: Card = {
 		it: "Mewtwo V UNIONE"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	hp: 310,
 	types: ["Psychic"],
 

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH163.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH163.ts
@@ -24,7 +24,7 @@ const card: Card = {
 		it: "Zacian V UNIONE"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	hp: 320,
 	types: ["Metal"],
 

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH164.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH164.ts
@@ -24,7 +24,7 @@ const card: Card = {
 		it: "Zacian V UNIONE"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	hp: 320,
 	types: ["Metal"],
 

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH165.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH165.ts
@@ -24,7 +24,7 @@ const card: Card = {
 		it: "Zacian V UNIONE"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	hp: 320,
 	types: ["Metal"],
 

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH166.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH166.ts
@@ -24,7 +24,7 @@ const card: Card = {
 		it: "Zacian V UNIONE"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	hp: 320,
 	types: ["Metal"],
 

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH167.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH167.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		it: "Professoressa Magnolia"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	trainerType: "Supporter",
 
 	effect: {

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH168.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH168.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		en: "Oricorio"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 90,
 	types: ["Fire"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH169.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH169.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		en: "Pyukumuku"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 80,
 	types: ["Water"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH170.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH170.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		en: "Deoxys"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 120,
 	types: ["Psychic"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH171.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH171.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		en: "Latias"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 120,
 	types: ["Dragon"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH172.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH172.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		en: "Tepig"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 80,
 	types: ["Fire"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH173.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH173.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		en: "Blitzle"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 60,
 	types: ["Lightning"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH174.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH174.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		en: "Espeon"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 110,
 	types: ["Psychic"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH175.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH175.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		en: "Eevee"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 60,
 	types: ["Colorless"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH176.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH176.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		en: "Hoopa V"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 220,
 	types: ["Darkness"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH177.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH177.ts
@@ -24,7 +24,7 @@ const card: Card = {
 		en: "Special Delivery Bidoof"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	hp: 70,
 	types: ["Colorless"],
 

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH178.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH178.ts
@@ -15,7 +15,7 @@ const card: Card = {
 		it: "Ricerca Accademica"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 
 	effect: {
 		en: "Discard your hand and draw 7 cards.",

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH179.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH179.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		en: "Flareon V"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 210,
 	types: ["Fire"],
@@ -71,7 +71,7 @@ const card: Card = {
 	regulationMark: "E",
 
 	thirdParty: {
-		cardmarket: 491199
+		cardmarket: 576502
 	}
 }
 

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH180.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH180.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		en: "Flareon VMAX"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 320,
 	types: ["Fire"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH181.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH181.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		en: "Vaporeon V"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 210,
 	types: ["Water"],
@@ -69,7 +69,7 @@ const card: Card = {
 	regulationMark: "E",
 
 	thirdParty: {
-		cardmarket: 516359
+		cardmarket: 576503
 	}
 }
 

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH182.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH182.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		en: "Vaporeon VMAX"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 320,
 	types: ["Water"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH183.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH183.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		en: "Jolteon V"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 190,
 	types: ["Lightning"],
@@ -69,7 +69,7 @@ const card: Card = {
 	regulationMark: "E",
 
 	thirdParty: {
-		cardmarket: 547021
+		cardmarket: 576504
 	}
 }
 

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH184.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH184.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		en: "Jolteon VMAX"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 300,
 	types: ["Lightning"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH185.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH185.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		en: "Moltres"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 120,
 	types: ["Fire"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH186.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH186.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		en: "Lucario"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 120,
 	types: ["Fighting"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH187.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH187.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		en: "Liepard"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 100,
 	types: ["Darkness"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH188.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH188.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		en: "Bibarel"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 120,
 	types: ["Colorless"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH189.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH189.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		en: "Flapple"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 80,
 	types: ["Dragon"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH190.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH190.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		en: "Eevee"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 60,
 	types: ["Colorless"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH191.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH191.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		en: "Leafeon"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 110,
 	types: ["Grass"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH192.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH192.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		en: "Glaceon"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 110,
 	types: ["Water"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH193.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH193.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		en: "Galarian Obstagoon"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 170,
 	types: ["Darkness"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH194.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH194.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		en: "Leafeon V"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 210,
 	types: ["Grass"],
@@ -71,7 +71,7 @@ const card: Card = {
 	regulationMark: "F",
 
 	thirdParty: {
-		cardmarket: 606748
+		cardmarket: 604996
 	}
 }
 

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH195.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH195.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		en: "Leafeon VSTAR"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 260,
 	types: ["Grass"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH196.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH196.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		en: "Glaceon V"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 210,
 	types: ["Water"],
@@ -62,7 +62,7 @@ const card: Card = {
 	regulationMark: "F",
 
 	thirdParty: {
-		cardmarket: 606749
+		cardmarket: 604998
 	}
 }
 

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH197.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH197.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		en: "Glaceon VSTAR"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 260,
 	types: ["Water"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH198.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH198.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		en: "Pikachu V"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 190,
 	types: ["Lightning"],
@@ -49,7 +49,7 @@ const card: Card = {
 	regulationMark: "F",
 
 	thirdParty: {
-		cardmarket: 461594
+		cardmarket: 496545
 	}
 }
 

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH199.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH199.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		en: "Lycanroc V"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 200,
 	types: ["Fighting"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH200.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH200.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		en: "Corviknight V"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 210,
 	types: ["Metal"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH201.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH201.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		en: "Espeon V"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 200,
 	types: ["Psychic"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH202.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH202.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		en: "Sylveon V"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 200,
 	types: ["Psychic"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH203.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH203.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		en: "Umbreon V"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 200,
 	types: ["Darkness"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH204.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH204.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		en: "Arceus V"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 220,
 	types: ["Colorless"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH205.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH205.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		en: "Hisuian Basculegion"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 120,
 	types: ["Water"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH206.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH206.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		en: "Wyrdeer"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 140,
 	types: ["Psychic"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH207.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH207.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		en: "Hisuian Samurott"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 170,
 	types: ["Darkness"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH208.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH208.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		en: "Magnezone"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 150,
 	types: ["Metal"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH209.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH209.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		en: "Toxel"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 60,
 	types: ["Lightning"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH210.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH210.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		en: "Oricorio"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 90,
 	types: ["Psychic"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH211.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH211.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		en: "Sylveon"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 110,
 	types: ["Psychic"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH212.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH212.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		en: "Eevee"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 60,
 	types: ["Colorless"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH213.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH213.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		en: "Lucario V"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 210,
 	types: ["Fighting"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH214.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH214.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		en: "Lucario VSTAR"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 270,
 	types: ["Fighting"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH215.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH215.ts
@@ -14,10 +14,61 @@ const card: Card = {
 		en: "Morpeko V-UNION"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	suffix: "V",
 	hp: 310,
+	attacks: [
+		{
+			cost: [
+				"Colorless",
+			],
+			name: {
+				fr: "Gain UNION",
+			},
+			effect: {
+				fr: "Attachez jusqu'à 2 cartes Énergie Électrique de votre pile de défausse à ce Pokémon.",
+			},
+		},
+		{
+			cost: [
+				"Colorless",
+				"Colorless",
+			],
+			name: {
+				fr: "Buffet à Volonté",
+			},
+			effect: {
+				fr: "Piochez des cartes jusqu'å en avoir 10 en main.",
+			},
+		},
+		{
+			cost: [
+				"Lightning",
+				"Colorless",
+				"Colorless",
+			],
+			name: {
+				fr: "Roue Éclatante",
+			},
+			damage: "100×",
+			effect: {
+				fr: "Défaussez toute l'Énergie de ce Pokémon. Cette attaque inflige 100 dégâts pour chaque carte défaussée de cette façon.",
+			},
+		},
+		{
+			cost: [
+				"Lightning",
+				"Colorless",
+				"Colorless",
+			],
+			name: {
+				fr: "Boule de Foudre",
+			},
+			damage: "160",
+		},
+	],
+
 	retreat: 0,
 	regulationMark: "E",
 

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH216.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH216.ts
@@ -14,10 +14,61 @@ const card: Card = {
 		en: "Morpeko V-UNION"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	suffix: "V",
 	hp: 310,
+	attacks: [
+		{
+			cost: [
+				"Colorless",
+			],
+			name: {
+				fr: "Gain UNION",
+			},
+			effect: {
+				fr: "Attachez jusqu'à 2 cartes Énergie Électrique de votre pile de défausse à ce Pokémon.",
+			},
+		},
+		{
+			cost: [
+				"Colorless",
+				"Colorless",
+			],
+			name: {
+				fr: "Buffet à Volonté",
+			},
+			effect: {
+				fr: "Piochez des cartes jusqu'å en avoir 10 en main.",
+			},
+		},
+		{
+			cost: [
+				"Lightning",
+				"Colorless",
+				"Colorless",
+			],
+			name: {
+				fr: "Roue Éclatante",
+			},
+			damage: "100×",
+			effect: {
+				fr: "Défaussez toute l'Énergie de ce Pokémon. Cette attaque inflige 100 dégâts pour chaque carte défaussée de cette façon.",
+			},
+		},
+		{
+			cost: [
+				"Lightning",
+				"Colorless",
+				"Colorless",
+			],
+			name: {
+				fr: "Boule de Foudre",
+			},
+			damage: "160",
+		},
+	],
+
 	retreat: 0,
 	regulationMark: "E",
 

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH217.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH217.ts
@@ -14,10 +14,61 @@ const card: Card = {
 		en: "Morpeko V-UNION"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	suffix: "V",
 	hp: 310,
+	attacks: [
+		{
+			cost: [
+				"Colorless",
+			],
+			name: {
+				fr: "Gain UNION",
+			},
+			effect: {
+				fr: "Attachez jusqu'à 2 cartes Énergie Électrique de votre pile de défausse à ce Pokémon.",
+			},
+		},
+		{
+			cost: [
+				"Colorless",
+				"Colorless",
+			],
+			name: {
+				fr: "Buffet à Volonté",
+			},
+			effect: {
+				fr: "Piochez des cartes jusqu'å en avoir 10 en main.",
+			},
+		},
+		{
+			cost: [
+				"Lightning",
+				"Colorless",
+				"Colorless",
+			],
+			name: {
+				fr: "Roue Éclatante",
+			},
+			damage: "100×",
+			effect: {
+				fr: "Défaussez toute l'Énergie de ce Pokémon. Cette attaque inflige 100 dégâts pour chaque carte défaussée de cette façon.",
+			},
+		},
+		{
+			cost: [
+				"Lightning",
+				"Colorless",
+				"Colorless",
+			],
+			name: {
+				fr: "Boule de Foudre",
+			},
+			damage: "160",
+		},
+	],
+
 	retreat: 0,
 	regulationMark: "E",
 

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH218.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH218.ts
@@ -14,10 +14,61 @@ const card: Card = {
 		en: "Morpeko V-UNION"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	suffix: "V",
 	hp: 310,
+	attacks: [
+		{
+			cost: [
+				"Colorless",
+			],
+			name: {
+				fr: "Gain UNION",
+			},
+			effect: {
+				fr: "Attachez jusqu'à 2 cartes Énergie Électrique de votre pile de défausse à ce Pokémon.",
+			},
+		},
+		{
+			cost: [
+				"Colorless",
+				"Colorless",
+			],
+			name: {
+				fr: "Buffet à Volonté",
+			},
+			effect: {
+				fr: "Piochez des cartes jusqu'å en avoir 10 en main.",
+			},
+		},
+		{
+			cost: [
+				"Lightning",
+				"Colorless",
+				"Colorless",
+			],
+			name: {
+				fr: "Roue Éclatante",
+			},
+			damage: "100×",
+			effect: {
+				fr: "Défaussez toute l'Énergie de ce Pokémon. Cette attaque inflige 100 dégâts pour chaque carte défaussée de cette façon.",
+			},
+		},
+		{
+			cost: [
+				"Lightning",
+				"Colorless",
+				"Colorless",
+			],
+			name: {
+				fr: "Boule de Foudre",
+			},
+			damage: "160",
+		},
+	],
+
 	retreat: 0,
 	regulationMark: "E",
 

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH219.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH219.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		en: "Boltund V"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 200,
 	types: ["Lightning"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH220.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH220.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		en: "Rowlet"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 60,
 	types: ["Grass"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH221.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH221.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		en: "Cyndaquil"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 60,
 	types: ["Fire"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH222.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH222.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		en: "Oshawott"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 70,
 	types: ["Water"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH223.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH223.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		en: "Mewtwo V"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 220,
 	types: ["Psychic"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH224.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH224.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		en: "Melmetal V"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 220,
 	types: ["Metal"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH225.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH225.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		en: "Alolan Exeggutor V"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 240,
 	types: ["Grass"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH226.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH226.ts
@@ -13,7 +13,7 @@ const card: Card = {
 		en: "Spark"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Trainer",
 
 	effect: {

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH227.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH227.ts
@@ -13,7 +13,7 @@ const card: Card = {
 		en: "Blanche"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Trainer",
 
 	effect: {

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH228.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH228.ts
@@ -13,7 +13,7 @@ const card: Card = {
 		en: "Candela"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Trainer",
 
 	effect: {

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH229.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH229.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		en: "Mewtwo V"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 220,
 	types: ["Psychic"],
@@ -62,7 +62,7 @@ const card: Card = {
 	regulationMark: "F",
 
 	thirdParty: {
-		cardmarket: 653691
+		cardmarket: 572159
 	}
 }
 

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH230.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH230.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		en: "Radiant Eevee"
 	},
 
-	rarity: "Ultra Rare",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 90,
 	types: ["Colorless"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH231.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH231.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		en: "Bulbasaur"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 70,
 	types: ["Grass"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH232.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH232.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		en: "Charmander"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 60,
 	types: ["Fire"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH233.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH233.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		en: "Squirtle"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 70,
 	types: ["Water"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH234.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH234.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		en: "Pikachu"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 60,
 	types: ["Lightning"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH235.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH235.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		en: "Dragonite V"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 230,
 	types: ["Dragon"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH236.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH236.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		en: "Dragonite VSTAR"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 280,
 	types: ["Dragon"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH237.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH237.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		en: "Hisuian Typhlosion V"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 210,
 	types: ["Psychic"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH238.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH238.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		en: "Hisuian Decidueye V"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 220,
 	types: ["Fighting"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH239.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH239.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		en: "Hisuian Samurott V"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 220,
 	types: ["Darkness"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH240.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH240.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		en: "Finneon"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 50,
 	types: ["Water"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH241.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH241.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		en: "Gengar"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 120,
 	types: ["Psychic"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH242.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH242.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		en: "Comfey"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 70,
 	types: ["Psychic"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH243.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH243.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		en: "Machamp"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 150,
 	types: ["Fighting"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH244.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH244.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		en: "Scorbunny"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 60,
 	types: ["Fire"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH245.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH245.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		en: "Croagunk"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 60,
 	types: ["Darkness"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH246.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH246.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		en: "Weavile"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 110,
 	types: ["Darkness"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH247.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH247.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		en: "Regigigas"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 150,
 	types: ["Colorless"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH248.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH248.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		en: "Kleavor V"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 210,
 	types: ["Fighting"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH249.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH249.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		en: "Kleavor VSTAR"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 270,
 	types: ["Fighting"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH250.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH250.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		en: "Lumineon V"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 170,
 	types: ["Water"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH252.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH252.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		en: "Infernape V"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 200,
 	types: ["Fire"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH253.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH253.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		en: "Origin Forme Palkia V"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 220,
 	types: ["Water"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH254.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH254.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		en: "Origin Forme Palkia VSTAR"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 280,
 	types: ["Water"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH255.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH255.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		en: "Origin Forme Dialga V"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 220,
 	types: ["Metal"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH256.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH256.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		en: "Origin Forme Dialga VSTAR"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 280,
 	types: ["Metal"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH257.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH257.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		en: "Rotom V"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 190,
 	types: ["Lightning"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH258.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH258.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		en: "Gallade V"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 220,
 	types: ["Fighting"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH259.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH259.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		en: "Giratina V"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 220,
 	types: ["Dragon"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH260.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH260.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		en: "Charizard V"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 220,
 	types: ["Fire"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH261.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH261.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		en: "Charizard VMAX"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 330,
 	types: ["Fire"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH262.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH262.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		en: "Charizard VSTAR"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 280,
 	types: ["Fire"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH263.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH263.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		en: "Zeraora V"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 210,
 	types: ["Lightning"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH264.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH264.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		en: "Zeraora VMAX"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 320,
 	types: ["Lightning"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH265.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH265.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		en: "Zeraora VSTAR"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 270,
 	types: ["Lightning"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH266.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH266.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		en: "Deoxys V"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 210,
 	types: ["Psychic"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH267.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH267.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		en: "Deoxys VMAX"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 330,
 	types: ["Psychic"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH268.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH268.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		en: "Deoxys VSTAR"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 270,
 	types: ["Psychic"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH269.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH269.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		en: "Sunflora"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 90,
 	types: ["Grass"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH270.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH270.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		en: "Rapidash"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 100,
 	types: ["Fire"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH271.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH271.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		en: "Kirlia"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 80,
 	types: ["Psychic"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH272.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH272.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		en: "Archeops"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 150,
 	types: ["Colorless"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH273.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH273.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		en: "Hisuian Basculin"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 50,
 	types: ["Water"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH274.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH274.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		en: "Cranidos"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 90,
 	types: ["Fighting"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH275.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH275.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		en: "Manaphy"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 70,
 	types: ["Water"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH276.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH276.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		en: "Togetic"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 80,
 	types: ["Psychic"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH277.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH277.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		en: "Rillaboom"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 180,
 	types: ["Grass"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH278.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH278.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		en: "Cinderace"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 170,
 	types: ["Fire"],
@@ -80,7 +80,7 @@ const card: Card = {
 	regulationMark: "E",
 
 	thirdParty: {
-		cardmarket: 566760
+		cardmarket: 450578
 	}
 }
 

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH279.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH279.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		en: "Inteleon"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 150,
 	types: ["Water"],
@@ -71,7 +71,7 @@ const card: Card = {
 	regulationMark: "E",
 
 	thirdParty: {
-		cardmarket: 566761
+		cardmarket: 450618
 	}
 }
 

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH280.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH280.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		en: "Regieleki V"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 200,
 	types: ["Lightning"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH281.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH281.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		en: "Regidrago V"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 220,
 	types: ["Dragon"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH285.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH285.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		en: "Pikachu V"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 200,
 	types: ["Lightning"],
@@ -49,7 +49,7 @@ const card: Card = {
 	regulationMark: "F",
 
 	thirdParty: {
-		cardmarket: 461594
+		cardmarket: 496545
 	}
 }
 

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH286.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH286.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		en: "Pikachu VMAX"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 310,
 	types: ["Lightning"],
@@ -71,7 +71,7 @@ const card: Card = {
 	regulationMark: "F",
 
 	thirdParty: {
-		cardmarket: 461594
+		cardmarket: 576730
 	}
 }
 

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH291.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH291.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		en: "Lucario VSTAR"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 270,
 	types: ["Fighting"],
@@ -81,7 +81,7 @@ const card: Card = {
 	regulationMark: "F",
 
 	thirdParty: {
-		cardmarket: 606600
+		cardmarket: 606784
 	}
 }
 

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH294.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH294.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		en: "Hisuian Electrode V"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 210,
 	types: ["Grass"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH295.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH295.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		en: "Virizion V"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 200,
 	types: ["Grass"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH296.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH296.ts
@@ -13,7 +13,7 @@ const card: Card = {
 		en: "Champions Festival"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Trainer",
 
 	effect: {

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH297.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH297.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		en: "Hisuian Zoroark V"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 210,
 	types: ["Colorless"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH298.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH298.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		en: "Hisuian Zoroark VSTAR"
 	},
 
-	rarity: "None",
+	rarity: "Black Star Promo",
 	category: "Pokemon",
 	hp: 270,
 	types: ["Colorless"],


### PR DESCRIPTION
Set: **SWSH Black Star Promos**
Series folder: `Sword & Shield`
Changed card files: **287**

### Validation
- [ ] `bun run validate`
- [ ] `cd server && bun run --bun validate`
- [ ] `cd server && bun run compile`
- [ ] Manual review: translations, energy types, TS syntax

### Card images
See follow-up comments with embedded TCGdex assets.