### PR TITLE
fix(data): Vivid Voltage (Sword & Shield)

### DIFF
--- a/data/Sword & Shield/Vivid Voltage/148.ts
+++ b/data/Sword & Shield/Vivid Voltage/148.ts
@@ -18,11 +18,11 @@ const card: Card = {
 
 	effect: {
 		en: "If you go first, you may play this card during your first turn.\n\nDraw 2 cards.",
-		fr: "Si vous jouez en premier, vous pouvez jouer cette carte pendant votre premier tour.\n\nPiochez 2 cartes.",
+		fr: "Si vous jouez en premier, vous pouvez jouer cette carte pendant votre premier tour.",
 		es: "Si sales primero, puedes jugar esta carta durante tu primer turno.\n\nRoba 2 cartas.",
 		it: "Se inizi per primo, puoi giocare questa carta durante il tuo primo turno.\n\nPesca due carte.",
 		pt: "Se você for primeiro, poderá jogar esta carta no seu primeiro turno.\n\nCompre 2 cartas.",
-		de: "Wenn du als Erster am Zug bist, kannst du diese Karte während deines ersten Zuges spielen.\n\nZiehe 2 Karten."
+		de: "Wenn du als Erster am Zug bist, kannst du diese Karte während deines ersten Zuges spielen.\n\nZiehe 2 Karten.",
 	},
 
 	trainerType: "Supporter",

--- a/data/Sword & Shield/Vivid Voltage/162.ts
+++ b/data/Sword & Shield/Vivid Voltage/162.ts
@@ -18,11 +18,11 @@ const card: Card = {
 
 	effect: {
 		en: "As long as this card is attached to a Pokémon, it provides Grass Energy.\n\nThe Grass Pokémon this card is attached to recovers from all Special Conditions and can't be affected by any Special Conditions.",
-		fr: "Tant que cette carte est attachée à un Pokémon, elle fournit une Énergie Grass.\n\nLe Pokémon Grass auquel cette carte est attachée guérit de tous les États Spéciaux et ne peut être affecté par aucun État Spécial.",
+		fr: "Tant que cette carte est attachée à un Pokémon, elle fournit une Énergie Plante.",
 		es: "Mientras esta carta esté unida a 1 Pokémon, proporciona 1 Energía Grass.\n\nEl Pokémon Grass al que esté unida esta carta se recupera de todas las Condiciones Especiales y no puede verse afectado por ninguna Condición Especial.",
 		it: "Fintanto che questa carta è assegnata a un Pokémon, fornisce Energia Grass.\n\nIl Pokémon Grass a cui è assegnata questa carta guarisce da tutte le condizioni speciali e non può esserne influenzato.",
 		pt: "Enquanto esta carta estiver ligada a um Pokémon, ela fornecerá Energia Grass.\n\nO Pokémon Grass ao qual esta carta está ligada se recupera de todas as Condições Especiais e não pode ser afetado por quaisquer Condições Especiais.",
-		de: "Solange diese Karte an ein Pokémon angelegt ist, liefert sie Grass-Energie.\n\nDas Grass-Pokémon, an das diese Karte angelegt ist, erholt sich von allen Speziellen Zuständen und kann nicht von Speziellen Zuständen betroffen werden."
+		de: "Solange diese Karte an ein Pokémon angelegt ist, liefert sie Grass-Energie.\n\nDas Grass-Pokémon, an das diese Karte angelegt ist, erholt sich von allen Speziellen Zuständen und kann nicht von Speziellen Zuständen betroffen werden.",
 	},
 
 	energyType: "Special",

--- a/data/Sword & Shield/Vivid Voltage/163.ts
+++ b/data/Sword & Shield/Vivid Voltage/163.ts
@@ -18,11 +18,11 @@ const card: Card = {
 
 	effect: {
 		en: "As long as this card is attached to a Pokémon, it provides Metal Energy.\n\nThe Metal Pokémon this card is attached to has no Weakness.",
-		fr: "Tant que cette carte est attachée à un Pokémon, elle fournit une Énergie Metal.\n\nLe Pokémon Metal auquel cette carte est attachée n'a pas de Faiblesse.",
+		fr: "Tant que cette carte est attachée à un Pokémon, elle fournit une Énergie Métal.",
 		es: "Mientras esta carta esté unida a 1 Pokémon, proporciona 1 Energía Metal.\n\nEl Pokémon Metal al que\nesté unida esta carta no tiene Debilidad.",
 		it: "Fintanto che questa carta è assegnata a un Pokémon, fornisce Energia Metal.\n\nIl Pokémon Metal a cui è assegnata questa carta non ha debolezza.",
 		pt: "Enquanto esta carta estiver ligada a um Pokémon, ela fornecerá Energia Metal.\n\nO Pokémon Metal ao qual esta carta está ligada não tem Fraqueza.",
-		de: "Solange diese Karte an ein Pokémon angelegt ist, liefert sie Metal-Energie.\n\nDas Metal-Pokémon, an das diese Karte angelegt ist, hat keine Schwäche."
+		de: "Solange diese Karte an ein Pokémon angelegt ist, liefert sie Metal-Energie.\n\nDas Metal-Pokémon, an das diese Karte angelegt ist, hat keine Schwäche.",
 	},
 
 	energyType: "Special",

--- a/data/Sword & Shield/Vivid Voltage/164.ts
+++ b/data/Sword & Shield/Vivid Voltage/164.ts
@@ -18,11 +18,11 @@ const card: Card = {
 
 	effect: {
 		en: "As long as this card is attached to a Pokémon, it provides Fighting Energy.\n\nThe Fighting Pokémon this card is attached to takes 20 less damage from attacks from your opponent's Pokémon (after applying Weakness and Resistance).",
-		fr: "Tant que cette carte est attachée à un Pokémon, elle fournit une Énergie Fighting.\n\nLe Pokémon Fighting auquel cette carte est attachée subit 20 dégâts de moins provenant des attaques des Pokémon de votre adversaire (après application de la Faiblesse et de la Résistance).",
+		fr: "Tant que cette carte est attachée à un Pokémon, elle fournit une Énergie Combat.",
 		es: "Mientras esta carta esté unida a 1 Pokémon, proporciona 1 Energía Fighting.\n\nLos ataques de los Pokémon de tu rival hacen 20 puntos de daño menos al Pokémon Fighting al que esté unida esta carta\n(después de aplicar Debilidad y Resistencia).",
 		it: "Fintanto che questa carta è assegnata a un Pokémon, fornisce Energia Fighting.\n\nIl Pokémon Fighting a cui è assegnata questa carta subisce 20 danni in meno dagli attacchi dei Pokémon del tuo avversario,\ndopo aver applicato debolezza e resistenza.",
 		pt: "Enquanto esta carta estiver ligada a um Pokémon, ela fornecerá Energia Fighting.\n\nO Pokémon Fighting ao qual esta carta está ligada recebe 20 pontos de dano a menos dos ataques dos Pokémon do seu oponente\n(depois de aplicar Fraqueza e Resistência).",
-		de: "Solange diese Karte an ein Pokémon angelegt ist, liefert sie Fighting-Energie.\n\nDem Fighting-Pokémon, an das diese Karte angelegt ist, werden durch Attacken von Pokémon deines Gegners 20 Schadenspunkte weniger zugefügt\n(nachdem Schwäche und Resistenz verrechnet wurden)."
+		de: "Solange diese Karte an ein Pokémon angelegt ist, liefert sie Fighting-Energie.\n\nDem Fighting-Pokémon, an das diese Karte angelegt ist, werden durch Attacken von Pokémon deines Gegners 20 Schadenspunkte weniger zugefügt\n(nachdem Schwäche und Resistenz verrechnet wurden).",
 	},
 
 	energyType: "Special",

--- a/data/Sword & Shield/Vivid Voltage/165.ts
+++ b/data/Sword & Shield/Vivid Voltage/165.ts
@@ -18,11 +18,11 @@ const card: Card = {
 
 	effect: {
 		en: "As long as this card is attached to a Pokémon, it provides Water Energy.\n\nPrevent all effects of attacks from your opponent's Pokémon done to the Water Pokémon this card is attached to. (Existing effects are not removed. Damage is not an effect.)",
-		fr: "Tant que cette carte est attachée à un Pokémon, elle fournit une Énergie Water.\n\nÉvitez tous les effets d'attaques infligés au Pokémon Water, auquel cette carte est attachée, par les Pokémon de votre adversaire. (Les effets déjà en action ne sont pas retirés.Les dégâts ne sont pas un effet.)",
+		fr: "Tant que cette carte est attachée à un Pokémon, elle fournit une Énergie Eau.",
 		es: "Mientras esta carta esté unida a 1 Pokémon, proporciona 1 Energía Water.\n\nEvita todos los efectos de los ataques de los Pokémon de tu rival al Pokémon Water al que esté unida esta carta.\n(No se eliminan los efectos ya existentes. El daño no es un efecto).",
 		it: "Fintanto che questa carta è assegnata a un Pokémon, fornisce Energia Water.\n\nPrevieni tutti gli effetti degli attacchi inflitti al Pokémon Water a cui è assegnata questa carta dai Pokémon del tuo avversario.\nGli effetti esistenti non vengono rimossi. I danni non sono un effetto.",
 		pt: "Enquanto esta carta estiver ligada a um Pokémon, ela fornecerá Energia Water.\n\nPrevina todos os efeitos de ataques dos Pokémon do seu oponente causados ao Pokémon Water ao qual esta carta está ligada\n(efeitos existentes não são removidos e dano não é um efeito).",
-		de: "Solange diese Karte an ein Pokémon angelegt ist, liefert sie Water-Energie.\n\nVerhindere alle Effekte von Attacken der Pokémon deines Gegners, die dem Water-Pokémon, an das diese Karte angelegt ist, zugefügt werden.\n(Bestehende Effekte werden nicht entfernt. Schaden ist kein Effekt.)"
+		de: "Solange diese Karte an ein Pokémon angelegt ist, liefert sie Water-Energie.\n\nVerhindere alle Effekte von Attacken der Pokémon deines Gegners, die dem Water-Pokémon, an das diese Karte angelegt ist, zugefügt werden.\n(Bestehende Effekte werden nicht entfernt. Schaden ist kein Effekt.)",
 	},
 
 	energyType: "Special",

--- a/data/Sword & Shield/Vivid Voltage/181.ts
+++ b/data/Sword & Shield/Vivid Voltage/181.ts
@@ -18,11 +18,11 @@ const card: Card = {
 
 	effect: {
 		en: "If you go first, you may play this card during your first turn.\n\nDraw 2 cards.",
-		fr: "Si vous jouez en premier, vous pouvez jouer cette carte pendant votre premier tour.\n\nPiochez 2 cartes.",
+		fr: "Si vous jouez en premier, vous pouvez jouer cette carte pendant votre premier tour.",
 		es: "Si sales primero, puedes jugar esta carta durante tu primer turno.\n\nRoba 2 cartas.",
 		it: "Se inizi per primo, puoi giocare questa carta durante il tuo primo turno.\n\nPesca due carte.",
 		pt: "Se você for primeiro, poderá jogar esta carta no seu primeiro turno.\n\nCompre 2 cartas.",
-		de: "Wenn du als Erster am Zug bist, kannst du diese Karte während deines ersten Zuges spielen.\n\nZiehe 2 Karten."
+		de: "Wenn du als Erster am Zug bist, kannst du diese Karte während deines ersten Zuges spielen.\n\nZiehe 2 Karten.",
 	},
 
 	trainerType: "Supporter",
@@ -36,7 +36,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 512615,
+		cardmarket: 512450,
 		tcgplayer: 226500
 	}
 }

--- a/data/Sword & Shield/Vivid Voltage/194.ts
+++ b/data/Sword & Shield/Vivid Voltage/194.ts
@@ -18,12 +18,12 @@ const card: Card = {
 	category: "Trainer",
 
 	effect: {
-		fr: "Si vous jouez en premier, vous pouvez jouer cette carte pendant votre premier tour.\n\nPiochez 2 cartes.",
+		fr: "Si vous jouez en premier, vous pouvez jouer cette carte pendant votre premier tour.",
 		en: "If you go first, you may play this card during your first turn.\n\nDraw 2 cards.",
 		es: "Si sales primero, puedes jugar esta carta durante tu primer turno.\n\nRoba 2 cartas.",
 		it: "Se inizi per primo, puoi giocare questa carta durante il tuo primo turno.\n\nPesca due carte.",
 		pt: "Se você for primeiro, poderá jogar esta carta no seu primeiro turno.\n\nCompre 2 cartas.",
-		de: "Wenn du als Erster am Zug bist, kannst du diese Karte während deines ersten Zuges spielen.\n\nZiehe 2 Karten."
+		de: "Wenn du als Erster am Zug bist, kannst du diese Karte während deines ersten Zuges spielen.\n\nZiehe 2 Karten.",
 	},
 
 	trainerType: "Supporter",
@@ -37,7 +37,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 512680,
+		cardmarket: 512450,
 		tcgplayer: 226501
 	}
 }


### PR DESCRIPTION
Set: **Vivid Voltage**
Series folder: `Sword & Shield`
Changed card files: **7**

### Validation
- [ ] `bun run validate`
- [ ] `cd server && bun run --bun validate`
- [ ] `cd server && bun run compile`
- [ ] Manual review: translations, energy types, TS syntax

### Card images
See follow-up comments with embedded TCGdex assets.