### PR TITLE
fix(data): BW trainer Kit (Excadrill) (Trainer kits)

### DIFF
--- a/data/Trainer kits/BW trainer Kit (Excadrill)/11.ts
+++ b/data/Trainer kits/BW trainer Kit (Excadrill)/11.ts
@@ -21,6 +21,10 @@ const card: Card = {
 	types: ["Fighting"],
 	stage: "Basic",
 
+	effect: {
+		fr: "Pendant ce tour, les attaques de votre Pokémon infligent 10 dégâts supplémentaires aux Pokémon Actifs (avant application de la Faiblesse et de la Résistance).",
+	},
+
 	attacks: [{
 		cost: [
 			"Fighting",

--- a/data/Trainer kits/BW trainer Kit (Excadrill)/12.ts
+++ b/data/Trainer kits/BW trainer Kit (Excadrill)/12.ts
@@ -21,21 +21,33 @@ const card: Card = {
 	types: ["Colorless"],
 	stage: "Basic",
 
-	attacks: [{
-		cost: [
-			"Colorless",
-			"Colorless"
-		],
-		name: {
-			en: "Doubleslap",
-			fr: "Torgnoles"
+	attacks: [
+		{
+			cost: [
+				"Colorless",
+				"Colorless",
+			],
+			name: {
+				en: "Doubleslap",
+				fr: "Torgnoles",
+			},
+			effect: {
+				en: "Flip 2 coins. This attack does 30 damage times the number of heads.",
+				fr: "Lancez 2 pièces. Cette attaque inflige 30 dégâts multipliés par le nombre de côtés face.",
+			},
+			damage: "30x",
 		},
-		effect: {
-			en: "Flip 2 coins. This attack does 30 damage times the number of heads.",
-			fr: "Lancez 2 pièces. Cette attaque inflige 30 dégâts multipliés par le nombre de côtés face."
+		{
+			cost: [
+				"Colorless",
+				"Colorless",
+			],
+			name: {
+				fr: "Morsure",
+			},
+			damage: "20",
 		},
-		damage: "30x"
-	}],
+	],
 
 	weaknesses: [
 		{

--- a/data/Trainer kits/BW trainer Kit (Excadrill)/17.ts
+++ b/data/Trainer kits/BW trainer Kit (Excadrill)/17.ts
@@ -34,32 +34,37 @@ const card: Card = {
 		"Fighting"
 	],
 
-	attacks: [{
-		cost: [
-			"Colorless",
-		],
-		name: {
-			en: "Metal Claw",
-			fr: "Griffe Acier"
+	attacks: [
+		{
+			cost: [
+				"Colorless",
+			],
+			name: {
+				en: "Metal Claw",
+				fr: "Griffe Acier",
+			},
+			damage: 30,
+			effect: {
+				fr: "Lancez 3 pièces. Cette attaque inflige 20 dégâts multipliés par le nombre de côtés face.",
+			},
 		},
-
-		damage: 30
-	}, {
-		cost: [
-			"Fighting",
-			"Fighting",
-			"Fighting"
-		],
-		name: {
-			en: "Drill Run",
-			fr: "Tunnelier"
+		{
+			cost: [
+				"Fighting",
+				"Fighting",
+				"Fighting",
+			],
+			name: {
+				en: "Drill Run",
+				fr: "Tunnelier",
+			},
+			effect: {
+				en: "Discard an Energy attached to the Defending Pokémon.",
+				fr: "Défaussez une Énergie attachée au Pokémon Défenseur.",
+			},
+			damage: 80,
 		},
-		effect: {
-			en: "Discard an Energy attached to the Defending Pokémon.",
-			fr: "Défaussez une Énergie attachée au Pokémon Défenseur."
-		},
-		damage: 80,
-	}],
+	],
 
 	weaknesses: [{
 		type: "Water",

--- a/data/Trainer kits/BW trainer Kit (Excadrill)/18.ts
+++ b/data/Trainer kits/BW trainer Kit (Excadrill)/18.ts
@@ -21,6 +21,10 @@ const card: Card = {
 	types: ["Colorless"],
 	stage: "Basic",
 
+	effect: {
+		fr: "Montrez l'un des Pokémon de votre main et placez-le sur le dessus de votre deck. Dans ce cas, cherchez un Pokémon dans votre deck, montrez-le, puis ajoutez-le à votre main. Mélangez ensuite votre deck.",
+	},
+
 	attacks: [{
 		cost: [
 			"Colorless",

--- a/data/Trainer kits/BW trainer Kit (Excadrill)/27.ts
+++ b/data/Trainer kits/BW trainer Kit (Excadrill)/27.ts
@@ -25,6 +25,10 @@ const card: Card = {
 		"Colorless"
 	],
 
+	effect: {
+		fr: "Cherchez une carte Énergie de base dans votre deck, montrez-la, puis ajoutez-la à votre main. Mélangez ensuite votre deck.",
+	},
+
 	attacks: [{
 		cost: [
 			"Colorless",

--- a/data/Trainer kits/BW trainer Kit (Excadrill)/29.ts
+++ b/data/Trainer kits/BW trainer Kit (Excadrill)/29.ts
@@ -21,17 +21,29 @@ const card: Card = {
 	types: ["Fighting"],
 	stage: "Basic",
 
-	attacks: [{
-		cost: [
-			"Fighting",
-			"Fighting"
-		],
-		name: {
-			en: "Pound",
-			fr: "Écras'Face"
+	attacks: [
+		{
+			cost: [
+				"Fighting",
+				"Fighting",
+			],
+			name: {
+				en: "Pound",
+				fr: "Écras'Face",
+			},
+			damage: 30,
 		},
-		damage: 30
-	}],
+		{
+			cost: [
+				"Colorless",
+				"Colorless",
+			],
+			name: {
+				fr: "Morsure",
+			},
+			damage: "20",
+		},
+	],
 
 	weaknesses: [
 		{

--- a/data/Trainer kits/BW trainer Kit (Excadrill)/30.ts
+++ b/data/Trainer kits/BW trainer Kit (Excadrill)/30.ts
@@ -34,32 +34,37 @@ const card: Card = {
 		"Fighting"
 	],
 
-	attacks: [{
-		cost: [
-			"Colorless",
-		],
-		name: {
-			en: "Metal Claw",
-			fr: "Griffe Acier"
+	attacks: [
+		{
+			cost: [
+				"Colorless",
+			],
+			name: {
+				en: "Metal Claw",
+				fr: "Griffe Acier",
+			},
+			damage: 30,
+			effect: {
+				fr: "Lancez 3 pièces. Cette attaque inflige 20 dégâts multipliés par le nombre de côtés face.",
+			},
 		},
-
-		damage: 30
-	}, {
-		cost: [
-			"Fighting",
-			"Fighting",
-			"Fighting"
-		],
-		name: {
-			en: "Drill Run",
-			fr: "Tunnelier"
+		{
+			cost: [
+				"Fighting",
+				"Fighting",
+				"Fighting",
+			],
+			name: {
+				en: "Drill Run",
+				fr: "Tunnelier",
+			},
+			effect: {
+				en: "Discard an Energy attached to the Defending Pokémon.",
+				fr: "Défaussez une Énergie attachée au Pokémon Défenseur.",
+			},
+			damage: 80,
 		},
-		effect: {
-			en: "Discard an Energy attached to the Defending Pokémon.",
-			fr: "Défaussez une Énergie attachée au Pokémon Défenseur."
-		},
-		damage: 80,
-	}],
+	],
 
 	weaknesses: [{
 		type: "Water",


### PR DESCRIPTION
Set: **BW trainer Kit (Excadrill)**
Series folder: `Trainer kits`
Changed card files: **7**

### Validation
- [ ] `bun run validate`
- [ ] `cd server && bun run --bun validate`
- [ ] `cd server && bun run compile`
- [ ] Manual review: translations, energy types, TS syntax

### Card images
See follow-up comments with embedded TCGdex assets.