### PR TITLE
fix(data): DP trainer Kit (Lucario) (Trainer kits)

### DIFF
--- a/data/Trainer kits/DP trainer Kit (Lucario)/10.ts
+++ b/data/Trainer kits/DP trainer Kit (Lucario)/10.ts
@@ -13,8 +13,7 @@ const card: Card = {
 	set: Set,
 
 	effect: {
-		en: "Reveal cards from your deck until you reveal a Pokémon. Show that Pokémon to your opponent and put it into your hand. " +
-			"Shuffle the other revealed cards back into your deck. (If you don't reveal a Pokémon, shuffle all the revealed cards back into your deck.)",
+		en: "Reveal cards from your deck until you reveal a Pokémon. Show that Pokémon to your opponent and put it into your hand. Shuffle the other revealed cards back into your deck. (If you don't reveal a Pokémon, shuffle all the revealed cards back into your deck.)",
 		fr: "Retournez des cartes de votre deck jusqu'à ce que vous retourniez un Pokémon. Montrez-le à votre adversaire et placez-le dans votre main. Re-mélangez les autres cartes à votre deck. (Si vous ne retournez pas de Pokémon, re-mélangez toutes les cartes à votre deck.)"
 	}
 }

--- a/data/Trainer kits/DP trainer Kit (Lucario)/4.ts
+++ b/data/Trainer kits/DP trainer Kit (Lucario)/4.ts
@@ -34,13 +34,13 @@ const card: Card = {
 			],
 			name: {
 				en: "Karate Chop",
-				fr: "Poing-Karaté"
+				fr: "Poing-Karaté",
 			},
 			effect: {
 				en: "Does 40 damage minus 10 damage for each damage counter on Machoke.",
-				fr: "Inflige 40 dégâts moins 10 dégâts pour chaque marqueur de dégât sur Machopeur."
+				fr: "Inflige 40 dégâts moins 10 dégâts pour chaque marqueur de dégât sur Machopeur.",
 			},
-			damage: "40-"
+			damage: "40-",
 		},
 		{
 			cost: [
@@ -50,10 +50,13 @@ const card: Card = {
 			],
 			name: {
 				en: "Seismic Toss",
-				fr: "Frappe Atlas"
+				fr: "Frappe Atlas",
 			},
-			damage: "60"
-		}
+			damage: "60",
+			effect: {
+				fr: "Échangez Manaphy avec 1 des Pokémon de votre Banc.",
+			},
+		},
 	],
 
 	weaknesses: [

--- a/data/Trainer kits/DP trainer Kit (Lucario)/5.ts
+++ b/data/Trainer kits/DP trainer Kit (Lucario)/5.ts
@@ -28,10 +28,23 @@ const card: Card = {
 			],
 			name: {
 				en: "Low Kick",
-				fr: "Balayage"
+				fr: "Balayage",
 			},
-			damage: 20
-		}
+			damage: 20,
+		},
+		{
+			cost: [
+				"Water",
+				"Colorless",
+			],
+			name: {
+				fr: "Éclaboussure",
+			},
+			damage: "20+",
+			effect: {
+				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 20 dégâts plus 10 dégâts supplémentaires.",
+			},
+		},
 	],
 
 	weaknesses: [

--- a/data/Trainer kits/DP trainer Kit (Lucario)/6.ts
+++ b/data/Trainer kits/DP trainer Kit (Lucario)/6.ts
@@ -28,14 +28,26 @@ const card: Card = {
 			],
 			name: {
 				en: "Wild Kick",
-				fr: "Coup déchaîné"
+				fr: "Coup déchaîné",
 			},
 			effect: {
 				en: "Flip a coin. If tails, this attack does nothing.",
-				fr: "Lancez une pièce. Si c'est pile, cette attaque est sans effet."
+				fr: "Lancez une pièce. Si c'est pile, cette attaque est sans effet.",
 			},
-			damage: "30"
-		}
+			damage: "30",
+		},
+		{
+			cost: [
+				"Water",
+				"Water",
+			],
+			name: {
+				fr: "Saumure",
+			},
+			effect: {
+				fr: "Choisissez 1 des Pokémon de votre adversaire possédant des marqueurs de dégât. Cette attaque lui inflige 40 dégâts. (Vous ne pouvez pas appliquer la Faiblesse et la Résistance aux Pokémon de Banc.)",
+			},
+		},
 	],
 
 	weaknesses: [

--- a/data/Trainer kits/DP trainer Kit (Lucario)/7.ts
+++ b/data/Trainer kits/DP trainer Kit (Lucario)/7.ts
@@ -28,9 +28,12 @@ const card: Card = {
 			],
 			name: {
 				en: "Gust",
-				fr: "Tornade"
+				fr: "Tornade",
 			},
-			damage: 10
+			damage: 10,
+			effect: {
+				fr: "Inflige 10 dégâts multipliés par le nombre de marqueurs de dégât sur Poissoroy.",
+			},
 		},
 		{
 			cost: [
@@ -39,14 +42,14 @@ const card: Card = {
 			],
 			name: {
 				en: "Quick Attack",
-				fr: "Vive-attaque"
+				fr: "Vive-attaque",
 			},
 			effect: {
 				en: "Flip a coin. If heads, this attack does 10 damage plus 20 more damage.",
-				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 10 dégâts plus 20 dégâts supplémentaires."
+				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 10 dégâts plus 20 dégâts supplémentaires.",
 			},
-			damage: "10+"
-		}
+			damage: "10+",
+		},
 	],
 
 	weaknesses: [


### PR DESCRIPTION
Set: **DP trainer Kit (Lucario)**
Series folder: `Trainer kits`
Changed card files: **5**

### Validation
- [ ] `bun run validate`
- [ ] `cd server && bun run --bun validate`
- [ ] `cd server && bun run compile`
- [ ] Manual review: translations, energy types, TS syntax

### Card images
See follow-up comments with embedded TCGdex assets.