### PR TITLE
fix(data): SM trainer Kit (Alolan Raichu) (Trainer kits)

### DIFF
--- a/data/Trainer kits/EX trainer Kit 2 (Plusle)/10.ts
+++ b/data/Trainer kits/EX trainer Kit 2 (Plusle)/10.ts
@@ -15,7 +15,7 @@ const card: Card = {
 
 	effect: {
 		en: "Flip a coin. If heads, draw the bottom 3 cards of your deck. If tails, draw the top 2 cards of your deck.",
-		fr: "Vous ne pouvez jouer qu'une seule carte Supporter par tour. Lorsque vous la jouez, placez-la à côté de votre Pokémon Actif. À la fin du tour, défaussez-la."
+		fr: "Lancez une pièce. Si c'est face, piochez les 3 dernières cartes de votre deck. Si c'est pile, piochez les 2 cartes du dessus de votre deck.",
 	},
 
 	thirdParty: {

--- a/data/Trainer kits/SM trainer Kit (Alolan Raichu)/11.ts
+++ b/data/Trainer kits/SM trainer Kit (Alolan Raichu)/11.ts
@@ -21,6 +21,30 @@ const card: Card = {
 	stage: "Basic",
 	retreat: 1,
 
+	attacks: [
+		{
+			cost: [
+				"Colorless",
+			],
+			name: {
+				fr: "Rugissement",
+			},
+			effect: {
+				fr: "Pendant le prochain tour de votre adversaire, les attaques du Pokémon Défenseur infligent 20 dégâts de moins (avant application de la Faiblesse et de la Résistance).",
+			},
+		},
+		{
+			cost: [
+				"Colorless",
+				"Colorless",
+			],
+			name: {
+				fr: "Battement",
+			},
+			damage: "20",
+		},
+	],
+
 	weaknesses: [{
 		type: "Lightning",
 		value: "×2"

--- a/data/Trainer kits/SM trainer Kit (Alolan Raichu)/13.ts
+++ b/data/Trainer kits/SM trainer Kit (Alolan Raichu)/13.ts
@@ -21,6 +21,31 @@ const card: Card = {
 	stage: "Basic",
 	retreat: 1,
 
+	attacks: [
+		{
+			cost: [
+				"Colorless",
+			],
+			name: {
+				fr: "Battement",
+			},
+			damage: "20",
+		},
+		{
+			cost: [
+				"Colorless",
+				"Colorless",
+			],
+			name: {
+				fr: "Coupe-Vent",
+			},
+			damage: "40",
+			effect: {
+				fr: "Lancez une pièce. Si c'est pile, cette attaque ne fait rien.",
+			},
+		},
+	],
+
 	weaknesses: [{
 		type: "Lightning",
 		value: "×2"

--- a/data/Trainer kits/SM trainer Kit (Alolan Raichu)/16.ts
+++ b/data/Trainer kits/SM trainer Kit (Alolan Raichu)/16.ts
@@ -21,6 +21,30 @@ const card: Card = {
 	stage: "Basic",
 	retreat: 2,
 
+	attacks: [
+		{
+			cost: [
+				"Colorless",
+				"Colorless",
+			],
+			name: {
+				fr: "Morsure",
+			},
+			damage: "20",
+		},
+		{
+			cost: [
+				"Fighting",
+				"Fighting",
+				"Colorless",
+			],
+			name: {
+				fr: "Tranch'Griffe",
+			},
+			damage: "80",
+		},
+	],
+
 	weaknesses: [{
 		type: "Fire",
 		value: "×2"

--- a/data/Trainer kits/SM trainer Kit (Alolan Raichu)/18.ts
+++ b/data/Trainer kits/SM trainer Kit (Alolan Raichu)/18.ts
@@ -31,6 +31,31 @@ const card: Card = {
 	stage: "Stage1",
 	retreat: 3,
 
+	attacks: [
+		{
+			cost: [
+				"Fighting",
+			],
+			name: {
+				fr: "Attaque Surprise",
+			},
+			damage: "20",
+			effect: {
+				fr: "Lancez une pièce. Si c'est pile, cette attaque ne fait rien.",
+			},
+		},
+		{
+			cost: [
+				"Fighting",
+				"Colorless",
+			],
+			name: {
+				fr: "Force",
+			},
+			damage: "40",
+		},
+	],
+
 	weaknesses: [{
 		type: "Fighting",
 		value: "×2"

--- a/data/Trainer kits/SM trainer Kit (Alolan Raichu)/22.ts
+++ b/data/Trainer kits/SM trainer Kit (Alolan Raichu)/22.ts
@@ -21,6 +21,36 @@ const card: Card = {
 	stage: "Basic",
 	retreat: 2,
 
+	attacks: [
+		{
+			cost: [
+				"Colorless",
+				"Colorless",
+			],
+			name: {
+				fr: "Écho",
+			},
+			damage: "60",
+			effect: {
+				fr: "Pendant votre prochain tour, l'attaque Écho de ce Pokémon inflige 60 dégâts supplémentaires (avant application de la Faiblesse et de la Résistance).",
+			},
+		},
+		{
+			cost: [
+				"Colorless",
+				"Colorless",
+				"Colorless",
+			],
+			name: {
+				fr: "Bec-Canon",
+			},
+			damage: "100",
+			effect: {
+				fr: "Lancez une pièce. Si c'est face, le Pokémon Actif de votre adversaire et maintenant Brûlé.",
+			},
+		},
+	],
+
 	weaknesses: [{
 		type: "Psychic",
 		value: "×2"

--- a/data/Trainer kits/SM trainer Kit (Alolan Raichu)/4.ts
+++ b/data/Trainer kits/SM trainer Kit (Alolan Raichu)/4.ts
@@ -21,6 +21,21 @@ const card: Card = {
 	stage: "Basic",
 	retreat: 2,
 
+	attacks: [
+		{
+			cost: [
+				"Colorless",
+			],
+			name: {
+				fr: "Balle Graine",
+			},
+			damage: "20×",
+			effect: {
+				fr: "Lancez 4 pièces. Cette attaque inflige 20 dégâts multipliés par le nombre de côtés face.",
+			},
+		},
+	],
+
 	weaknesses: [{
 		type: "Fighting",
 		value: "×2"


### PR DESCRIPTION
Set: **SM trainer Kit (Alolan Raichu)**
Series folder: `Trainer kits`
Changed card files: **6**

### Validation
- [ ] `bun run validate`
- [ ] `cd server && bun run --bun validate`
- [ ] `cd server && bun run compile`
- [ ] Manual review: translations, energy types, TS syntax

### Card images
See follow-up comments with embedded TCGdex assets.