### PR TITLE
fix(data): SM trainer Kit (Lycanroc) (Trainer kits)

### DIFF
--- a/data/Trainer kits/SM trainer Kit (Lycanroc)/1.ts
+++ b/data/Trainer kits/SM trainer Kit (Lycanroc)/1.ts
@@ -21,6 +21,30 @@ const card: Card = {
 	stage: "Basic",
 	retreat: 1,
 
+	attacks: [
+		{
+			cost: [
+				"Colorless",
+			],
+			name: {
+				fr: "Tit'Sieste",
+			},
+			effect: {
+				fr: "Soignez 20 dégâts à ce Pokémon.",
+			},
+		},
+		{
+			cost: [
+				"Colorless",
+				"Colorless",
+			],
+			name: {
+				fr: "Ronge",
+			},
+			damage: "20",
+		},
+	],
+
 	weaknesses: [{
 		type: "Fire",
 		value: "×2"

--- a/data/Trainer kits/SM trainer Kit (Lycanroc)/11.ts
+++ b/data/Trainer kits/SM trainer Kit (Lycanroc)/11.ts
@@ -21,6 +21,30 @@ const card: Card = {
 	stage: "Basic",
 	retreat: 1,
 
+	attacks: [
+		{
+			cost: [
+				"Colorless",
+			],
+			name: {
+				fr: "Rugissement",
+			},
+			effect: {
+				fr: "Pendant le prochain tour de votre adversaire, les attaques du Pokémon Défenseur infligent 20 dégâts de moins (avant application de la Faiblesse et de la Résistance).",
+			},
+		},
+		{
+			cost: [
+				"Colorless",
+				"Colorless",
+			],
+			name: {
+				fr: "Battement",
+			},
+			damage: "20",
+		},
+	],
+
 	weaknesses: [{
 		type: "Lightning",
 		value: "×2"

--- a/data/Trainer kits/SM trainer Kit (Lycanroc)/12.ts
+++ b/data/Trainer kits/SM trainer Kit (Lycanroc)/12.ts
@@ -21,6 +21,28 @@ const card: Card = {
 	stage: "Basic",
 	retreat: 1,
 
+	attacks: [
+		{
+			cost: [
+				"Colorless",
+			],
+			name: {
+				fr: "Charge",
+			},
+			damage: "10",
+		},
+		{
+			cost: [
+				"Colorless",
+				"Colorless",
+			],
+			name: {
+				fr: "Morsure",
+			},
+			damage: "20",
+		},
+	],
+
 	weaknesses: [{
 		type: "Fighting",
 		value: "×2"

--- a/data/Trainer kits/SM trainer Kit (Lycanroc)/13.ts
+++ b/data/Trainer kits/SM trainer Kit (Lycanroc)/13.ts
@@ -31,6 +31,31 @@ const card: Card = {
 	stage: "Stage1",
 	retreat: 1,
 
+	attacks: [
+		{
+			cost: [
+				"Colorless",
+			],
+			name: {
+				fr: "Battement",
+			},
+			damage: "20",
+		},
+		{
+			cost: [
+				"Colorless",
+				"Colorless",
+			],
+			name: {
+				fr: "Coupe-Vent",
+			},
+			damage: "40",
+			effect: {
+				fr: "Lancez une pièce. Si c'est pile, cette attaque ne fait rien.",
+			},
+		},
+	],
+
 	weaknesses: [{
 		type: "Lightning",
 		value: "×2"

--- a/data/Trainer kits/SM trainer Kit (Lycanroc)/14.ts
+++ b/data/Trainer kits/SM trainer Kit (Lycanroc)/14.ts
@@ -21,6 +21,28 @@ const card: Card = {
 	stage: "Basic",
 	retreat: 1,
 
+	attacks: [
+		{
+			cost: [
+				"Colorless",
+			],
+			name: {
+				fr: "Charge",
+			},
+			damage: "10",
+		},
+		{
+			cost: [
+				"Fighting",
+				"Colorless",
+			],
+			name: {
+				fr: "Jet-Pierres",
+			},
+			damage: "20",
+		},
+	],
+
 	weaknesses: [{
 		type: "Grass",
 		value: "×2"

--- a/data/Trainer kits/SM trainer Kit (Lycanroc)/15.ts
+++ b/data/Trainer kits/SM trainer Kit (Lycanroc)/15.ts
@@ -21,6 +21,21 @@ const card: Card = {
 	stage: "Basic",
 	retreat: 1,
 
+	attacks: [
+		{
+			cost: [
+				"Colorless",
+			],
+			name: {
+				fr: "Éclate-Roc",
+			},
+			damage: "10+",
+			effect: {
+				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 10 dégâts supplémentaires.",
+			},
+		},
+	],
+
 	weaknesses: [{
 		type: "Lightning",
 		value: "×2"

--- a/data/Trainer kits/SM trainer Kit (Lycanroc)/18.ts
+++ b/data/Trainer kits/SM trainer Kit (Lycanroc)/18.ts
@@ -21,6 +21,31 @@ const card: Card = {
 	stage: "Basic",
 	retreat: 2,
 
+	attacks: [
+		{
+			cost: [
+				"Fighting",
+			],
+			name: {
+				fr: "Attaque Surprise",
+			},
+			damage: "20",
+			effect: {
+				fr: "Lancez une pièce. Si c'est pile, cette attaque ne fait rien.",
+			},
+		},
+		{
+			cost: [
+				"Fighting",
+				"Colorless",
+			],
+			name: {
+				fr: "Force",
+			},
+			damage: "40",
+		},
+	],
+
 	weaknesses: [{
 		type: "Psychic",
 		value: "×2"

--- a/data/Trainer kits/SM trainer Kit (Lycanroc)/22.ts
+++ b/data/Trainer kits/SM trainer Kit (Lycanroc)/22.ts
@@ -31,6 +31,36 @@ const card: Card = {
 	stage: "Stage2",
 	retreat: 2,
 
+	attacks: [
+		{
+			cost: [
+				"Colorless",
+				"Colorless",
+			],
+			name: {
+				fr: "Écho",
+			},
+			damage: "60",
+			effect: {
+				fr: "Pendant votre prochain tour, l'attaque Écho de ce Pokémon inflige 60 dégâts supplémentaires (avant application de la Faiblesse et de la Résistance).",
+			},
+		},
+		{
+			cost: [
+				"Colorless",
+				"Colorless",
+				"Colorless",
+			],
+			name: {
+				fr: "Bec-Canon",
+			},
+			damage: "100",
+			effect: {
+				fr: "Lancez une pièce. Si c'est face, le Pokémon Actif de votre adversaire et maintenant Brûlé.",
+			},
+		},
+	],
+
 	weaknesses: [{
 		type: "Lightning",
 		value: "×2"

--- a/data/Trainer kits/SM trainer Kit (Lycanroc)/29.ts
+++ b/data/Trainer kits/SM trainer Kit (Lycanroc)/29.ts
@@ -21,6 +21,28 @@ const card: Card = {
 	stage: "Basic",
 	retreat: 1,
 
+	attacks: [
+		{
+			cost: [
+				"Colorless",
+			],
+			name: {
+				fr: "Charge",
+			},
+			damage: "10",
+		},
+		{
+			cost: [
+				"Fighting",
+				"Colorless",
+			],
+			name: {
+				fr: "Jet-Pierres",
+			},
+			damage: "20",
+		},
+	],
+
 	weaknesses: [{
 		type: "Grass",
 		value: "×2"

--- a/data/Trainer kits/SM trainer Kit (Lycanroc)/4.ts
+++ b/data/Trainer kits/SM trainer Kit (Lycanroc)/4.ts
@@ -31,6 +31,21 @@ const card: Card = {
 	stage: "Stage1",
 	retreat: 1,
 
+	attacks: [
+		{
+			cost: [
+				"Colorless",
+			],
+			name: {
+				fr: "Balle Graine",
+			},
+			damage: "20×",
+			effect: {
+				fr: "Lancez 4 pièces. Cette attaque inflige 20 dégâts multipliés par le nombre de côtés face.",
+			},
+		},
+	],
+
 	weaknesses: [{
 		type: "Lightning",
 		value: "×2"


### PR DESCRIPTION
Set: **SM trainer Kit (Lycanroc)**
Series folder: `Trainer kits`
Changed card files: **10**

### Validation
- [ ] `bun run validate`
- [ ] `cd server && bun run --bun validate`
- [ ] `cd server && bun run compile`
- [ ] Manual review: translations, energy types, TS syntax

### Card images
See follow-up comments with embedded TCGdex assets.