### PR TITLE
fix(data): XY trainer Kit (Bisharp) (Trainer kits)

### DIFF
--- a/data/Trainer kits/XY trainer Kit (Bisharp)/1.ts
+++ b/data/Trainer kits/XY trainer Kit (Bisharp)/1.ts
@@ -21,6 +21,30 @@ const card: Card = {
 	stage: "Basic",
 	retreat: 1,
 
+	attacks: [
+		{
+			cost: [
+				"Colorless",
+			],
+			name: {
+				fr: "Moi d'Abord",
+			},
+			effect: {
+				fr: "Piochez une carte.",
+			},
+		},
+		{
+			cost: [
+				"Colorless",
+				"Colorless",
+			],
+			name: {
+				fr: "Picpic",
+			},
+			damage: "20",
+		},
+	],
+
 	weaknesses: [{
 		type: "Lightning",
 		value: "×2"

--- a/data/Trainer kits/XY trainer Kit (Bisharp)/11.ts
+++ b/data/Trainer kits/XY trainer Kit (Bisharp)/11.ts
@@ -21,6 +21,18 @@ const card: Card = {
 	stage: "Basic",
 	retreat: 2,
 
+	attacks: [
+		{
+			cost: [
+				"Metal",
+			],
+			name: {
+				fr: "Transpercement",
+			},
+			damage: "10",
+		},
+	],
+
 	weaknesses: [{
 		type: "Fire",
 		value: "×2"

--- a/data/Trainer kits/XY trainer Kit (Bisharp)/12.ts
+++ b/data/Trainer kits/XY trainer Kit (Bisharp)/12.ts
@@ -21,6 +21,22 @@ const card: Card = {
 	stage: "Basic",
 	retreat: 3,
 
+	attacks: [
+		{
+			cost: [
+				"Colorless",
+				"Colorless",
+			],
+			name: {
+				fr: "Croc de Mort",
+			},
+			damage: "40",
+			effect: {
+				fr: "Lancez une pièce. Si c'est pile, cette attaque ne fait rien.",
+			},
+		},
+	],
+
 	weaknesses: [{
 		type: "Fighting",
 		value: "×2"

--- a/data/Trainer kits/XY trainer Kit (Bisharp)/13.ts
+++ b/data/Trainer kits/XY trainer Kit (Bisharp)/13.ts
@@ -21,6 +21,28 @@ const card: Card = {
 	stage: "Basic",
 	retreat: 1,
 
+	attacks: [
+		{
+			cost: [
+				"Metal",
+			],
+			name: {
+				fr: "Transpercement",
+			},
+			damage: "10",
+		},
+		{
+			cost: [
+				"Colorless",
+				"Colorless",
+			],
+			name: {
+				fr: "Coupe",
+			},
+			damage: "20",
+		},
+	],
+
 	weaknesses: [{
 		type: "Fire",
 		value: "×2"

--- a/data/Trainer kits/XY trainer Kit (Bisharp)/14.ts
+++ b/data/Trainer kits/XY trainer Kit (Bisharp)/14.ts
@@ -31,6 +31,22 @@ const card: Card = {
 	stage: "Stage1",
 	retreat: 2,
 
+	attacks: [
+		{
+			cost: [
+				"Metal",
+				"Colorless",
+			],
+			name: {
+				fr: "Duo de Lames",
+			},
+			damage: "30×",
+			effect: {
+				fr: "Lancez 2 pièces. Cette attaque inflige 30 dégâts multipliés par le nombre de côtés face.",
+			},
+		},
+	],
+
 	weaknesses: [{
 		type: "Fire",
 		value: "×2"

--- a/data/Trainer kits/XY trainer Kit (Bisharp)/15.ts
+++ b/data/Trainer kits/XY trainer Kit (Bisharp)/15.ts
@@ -21,6 +21,21 @@ const card: Card = {
 	stage: "Basic",
 	retreat: 3,
 
+	attacks: [
+		{
+			cost: [
+				"Colorless",
+				"Colorless",
+			],
+			name: {
+				fr: "Gros Bâillement",
+			},
+			effect: {
+				fr: "Les deux Pokémon Actifs sont maintenant Endormis.",
+			},
+		},
+	],
+
 	weaknesses: [{
 		type: "Fighting",
 		value: "×2"

--- a/data/Trainer kits/XY trainer Kit (Bisharp)/16.ts
+++ b/data/Trainer kits/XY trainer Kit (Bisharp)/16.ts
@@ -31,6 +31,32 @@ const card: Card = {
 	stage: "Stage1",
 	retreat: 1,
 
+	attacks: [
+		{
+			cost: [
+				"Metal",
+			],
+			name: {
+				fr: "Piqûre Infernale",
+			},
+			damage: "20",
+			effect: {
+				fr: "Lancez une pièce. Si c'est face, le Pokémon Actif de votre adversaire est maintenant Paralysé.",
+			},
+		},
+		{
+			cost: [
+				"Metal",
+				"Colorless",
+				"Colorless",
+			],
+			name: {
+				fr: "Griffe Acier",
+			},
+			damage: "70",
+		},
+	],
+
 	weaknesses: [{
 		type: "Fire",
 		value: "×2"

--- a/data/Trainer kits/XY trainer Kit (Bisharp)/17.ts
+++ b/data/Trainer kits/XY trainer Kit (Bisharp)/17.ts
@@ -21,6 +21,20 @@ const card: Card = {
 	stage: "Basic",
 	retreat: 1,
 
+	attacks: [
+		{
+			cost: [
+				"Colorless",
+			],
+			name: {
+				fr: "Contrôle de Sécurité",
+			},
+			effect: {
+				fr: "Regardez l'une de vos cartes Récompense face cachée.",
+			},
+		},
+	],
+
 	weaknesses: [{
 		type: "Fighting",
 		value: "×2"

--- a/data/Trainer kits/XY trainer Kit (Bisharp)/21.ts
+++ b/data/Trainer kits/XY trainer Kit (Bisharp)/21.ts
@@ -21,6 +21,28 @@ const card: Card = {
 	stage: "Basic",
 	retreat: 1,
 
+	attacks: [
+		{
+			cost: [
+				"Metal",
+			],
+			name: {
+				fr: "Transpercement",
+			},
+			damage: "10",
+		},
+		{
+			cost: [
+				"Colorless",
+				"Colorless",
+			],
+			name: {
+				fr: "Coupe",
+			},
+			damage: "20",
+		},
+	],
+
 	weaknesses: [{
 		type: "Fire",
 		value: "×2"

--- a/data/Trainer kits/XY trainer Kit (Bisharp)/23.ts
+++ b/data/Trainer kits/XY trainer Kit (Bisharp)/23.ts
@@ -31,6 +31,22 @@ const card: Card = {
 	stage: "Stage1",
 	retreat: 2,
 
+	attacks: [
+		{
+			cost: [
+				"Metal",
+				"Colorless",
+			],
+			name: {
+				fr: "Duo de Lames",
+			},
+			damage: "30×",
+			effect: {
+				fr: "Lancez 2 pièces. Cette attaque inflige 30 dégâts multipliés par le nombre de côtés face.",
+			},
+		},
+	],
+
 	weaknesses: [{
 		type: "Fire",
 		value: "×2"

--- a/data/Trainer kits/XY trainer Kit (Bisharp)/26.ts
+++ b/data/Trainer kits/XY trainer Kit (Bisharp)/26.ts
@@ -21,6 +21,21 @@ const card: Card = {
 	stage: "Basic",
 	retreat: 3,
 
+	attacks: [
+		{
+			cost: [
+				"Colorless",
+				"Colorless",
+			],
+			name: {
+				fr: "Gros Bâillement",
+			},
+			effect: {
+				fr: "Les deux Pokémon Actifs sont maintenant Endormis.",
+			},
+		},
+	],
+
 	weaknesses: [{
 		type: "Fighting",
 		value: "×2"

--- a/data/Trainer kits/XY trainer Kit (Bisharp)/27.ts
+++ b/data/Trainer kits/XY trainer Kit (Bisharp)/27.ts
@@ -21,6 +21,18 @@ const card: Card = {
 	stage: "Basic",
 	retreat: 2,
 
+	attacks: [
+		{
+			cost: [
+				"Metal",
+			],
+			name: {
+				fr: "Transpercement",
+			},
+			damage: "10",
+		},
+	],
+
 	weaknesses: [{
 		type: "Fire",
 		value: "×2"

--- a/data/Trainer kits/XY trainer Kit (Bisharp)/28.ts
+++ b/data/Trainer kits/XY trainer Kit (Bisharp)/28.ts
@@ -31,6 +31,32 @@ const card: Card = {
 	stage: "Stage1",
 	retreat: 2,
 
+	attacks: [
+		{
+			cost: [
+				"Colorless",
+			],
+			name: {
+				fr: "Griffe",
+			},
+			damage: "20",
+		},
+		{
+			cost: [
+				"Colorless",
+				"Colorless",
+				"Colorless",
+			],
+			name: {
+				fr: "Attaque Imprudente",
+			},
+			damage: "70",
+			effect: {
+				fr: "Lancez une pièce. Si c'est pile, ce Pokémon s'inflige 20 dégâts.",
+			},
+		},
+	],
+
 	weaknesses: [{
 		type: "Fighting",
 		value: "×2"

--- a/data/Trainer kits/XY trainer Kit (Bisharp)/30.ts
+++ b/data/Trainer kits/XY trainer Kit (Bisharp)/30.ts
@@ -31,6 +31,32 @@ const card: Card = {
 	stage: "Stage1",
 	retreat: 1,
 
+	attacks: [
+		{
+			cost: [
+				"Metal",
+			],
+			name: {
+				fr: "Piqûre Infernale",
+			},
+			damage: "20",
+			effect: {
+				fr: "Lancez une pièce. Si c'est face, le Pokémon Actif de votre adversaire est maintenant Paralysé.",
+			},
+		},
+		{
+			cost: [
+				"Metal",
+				"Colorless",
+				"Colorless",
+			],
+			name: {
+				fr: "Griffe Acier",
+			},
+			damage: "70",
+		},
+	],
+
 	weaknesses: [{
 		type: "Fire",
 		value: "×2"

--- a/data/Trainer kits/XY trainer Kit (Bisharp)/4.ts
+++ b/data/Trainer kits/XY trainer Kit (Bisharp)/4.ts
@@ -31,6 +31,32 @@ const card: Card = {
 	stage: "Stage1",
 	retreat: 2,
 
+	attacks: [
+		{
+			cost: [
+				"Colorless",
+			],
+			name: {
+				fr: "Griffe",
+			},
+			damage: "20",
+		},
+		{
+			cost: [
+				"Colorless",
+				"Colorless",
+				"Colorless",
+			],
+			name: {
+				fr: "Attaque Imprudente",
+			},
+			damage: "70",
+			effect: {
+				fr: "Lancez une pièce. Si c'est pile, ce Pokémon s'inflige 20 dégâts.",
+			},
+		},
+	],
+
 	weaknesses: [{
 		type: "Fighting",
 		value: "×2"


### PR DESCRIPTION
Set: **XY trainer Kit (Bisharp)**
Series folder: `Trainer kits`
Changed card files: **15**

### Validation
- [ ] `bun run validate`
- [ ] `cd server && bun run --bun validate`
- [ ] `cd server && bun run compile`
- [ ] Manual review: translations, energy types, TS syntax

### Card images
See follow-up comments with embedded TCGdex assets.