### PR TITLE
fix(data): XY trainer Kit (Latias) (Trainer kits)

### DIFF
--- a/data/Trainer kits/XY trainer Kit (Latias)/11.ts
+++ b/data/Trainer kits/XY trainer Kit (Latias)/11.ts
@@ -21,6 +21,18 @@ const card: Card = {
 	stage: "Basic",
 	retreat: 1,
 
+	attacks: [
+		{
+			cost: [
+				"Fighting",
+			],
+			name: {
+				fr: "Coud'Phalange",
+			},
+			damage: "10",
+		},
+	],
+
 	weaknesses: [{
 		type: "Fire",
 		value: "×2"

--- a/data/Trainer kits/XY trainer Kit (Latias)/12.ts
+++ b/data/Trainer kits/XY trainer Kit (Latias)/12.ts
@@ -31,6 +31,33 @@ const card: Card = {
 	stage: "Stage1",
 	retreat: 4,
 
+	attacks: [
+		{
+			cost: [
+				"Colorless",
+			],
+			name: {
+				fr: "Générateur Solaire",
+			},
+			effect: {
+				fr: "Cherchez jusqu'à 2 cartes Énergie spéciale dans votre deck, montrez-les, puis ajoutez-les à votre main. Mélangez ensuite votre deck.",
+			},
+		},
+		{
+			cost: [
+				"Fighting",
+				"Colorless",
+			],
+			name: {
+				fr: "Asticotage",
+			},
+			damage: "20+",
+			effect: {
+				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 20 dégâts supplémentaires.",
+			},
+		},
+	],
+
 	weaknesses: [{
 		type: "Fire",
 		value: "×2"

--- a/data/Trainer kits/XY trainer Kit (Latias)/13.ts
+++ b/data/Trainer kits/XY trainer Kit (Latias)/13.ts
@@ -21,6 +21,33 @@ const card: Card = {
 	stage: "Basic",
 	retreat: 2,
 
+	attacks: [
+		{
+			cost: [
+				"Colorless",
+				"Colorless",
+			],
+			name: {
+				fr: "Voyage Supersonique",
+			},
+			damage: "40",
+			effect: {
+				fr: "Lancez une pièce. Si c'est pile, cette attaque ne fait rien.",
+			},
+		},
+		{
+			cost: [
+				"Psychic",
+				"Psychic",
+				"Colorless",
+			],
+			name: {
+				fr: "Brûlure Psy",
+			},
+			damage: "70",
+		},
+	],
+
 	weaknesses: [{
 		type: "Fire",
 		value: "×2"

--- a/data/Trainer kits/XY trainer Kit (Latias)/21.ts
+++ b/data/Trainer kits/XY trainer Kit (Latias)/21.ts
@@ -31,6 +31,10 @@ const card: Card = {
 	stage: "Stage1",
 	retreat: 2,
 
+	effect: {
+		fr: "Soignez 30 dégâts à l'un de vos Pokémon.",
+	},
+
 	weaknesses: [{
 		type: "Fire",
 		value: "×2"

--- a/data/Trainer kits/XY trainer Kit (Latias)/23.ts
+++ b/data/Trainer kits/XY trainer Kit (Latias)/23.ts
@@ -21,6 +21,22 @@ const card: Card = {
 	stage: "Basic",
 	retreat: 1,
 
+	attacks: [
+		{
+			cost: [
+				"Fighting",
+				"Fighting",
+			],
+			name: {
+				fr: "Bélier",
+			},
+			damage: "40",
+			effect: {
+				fr: "Ce Pokémon s'inflige 10 dégâts.",
+			},
+		},
+	],
+
 	weaknesses: [{
 		type: "Fire",
 		value: "×2"

--- a/data/Trainer kits/XY trainer Kit (Latias)/24.ts
+++ b/data/Trainer kits/XY trainer Kit (Latias)/24.ts
@@ -21,6 +21,33 @@ const card: Card = {
 	stage: "Basic",
 	retreat: 1,
 
+	attacks: [
+		{
+			cost: [
+				"Colorless",
+			],
+			name: {
+				fr: "Repositionnement",
+			},
+			effect: {
+				fr: "Déplacez autant d'Énergies attachées à vos Pokémon que vous voulez vers vos autres Pokémon, de la manière que vous voulez.",
+			},
+		},
+		{
+			cost: [
+				"Colorless",
+				"Colorless",
+			],
+			name: {
+				fr: "Câlinerie",
+			},
+			damage: "30+",
+			effect: {
+				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 30 dégâts supplémentaires.",
+			},
+		},
+	],
+
 	weaknesses: [{
 		type: "Fire",
 		value: "×2"

--- a/data/Trainer kits/XY trainer Kit (Latias)/25.ts
+++ b/data/Trainer kits/XY trainer Kit (Latias)/25.ts
@@ -31,6 +31,35 @@ const card: Card = {
 	stage: "Stage1",
 	retreat: 4,
 
+	attacks: [
+		{
+			cost: [
+				"Fighting",
+				"Colorless",
+				"Colorless",
+			],
+			name: {
+				fr: "Bélier",
+			},
+			damage: "50",
+			effect: {
+				fr: "Ce Pokémon s'inflige 10 dégâts.",
+			},
+		},
+		{
+			cost: [
+				"Fighting",
+				"Fighting",
+				"Colorless",
+				"Colorless",
+			],
+			name: {
+				fr: "Empal'Korne",
+			},
+			damage: "70",
+		},
+	],
+
 	weaknesses: [{
 		type: "Fire",
 		value: "×2"

--- a/data/Trainer kits/XY trainer Kit (Latias)/26.ts
+++ b/data/Trainer kits/XY trainer Kit (Latias)/26.ts
@@ -21,6 +21,33 @@ const card: Card = {
 	stage: "Basic",
 	retreat: 2,
 
+	attacks: [
+		{
+			cost: [
+				"Colorless",
+			],
+			name: {
+				fr: "Générateur Solaire",
+			},
+			effect: {
+				fr: "Cherchez jusqu'à 2 cartes Énergie spéciale dans votre deck, montrez-les, puis ajoutez-les à votre main. Mélangez ensuite votre deck.",
+			},
+		},
+		{
+			cost: [
+				"Fighting",
+				"Colorless",
+			],
+			name: {
+				fr: "Asticotage",
+			},
+			damage: "20+",
+			effect: {
+				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 20 dégâts supplémentaires.",
+			},
+		},
+	],
+
 	weaknesses: [{
 		type: "Fire",
 		value: "×2"

--- a/data/Trainer kits/XY trainer Kit (Latias)/27.ts
+++ b/data/Trainer kits/XY trainer Kit (Latias)/27.ts
@@ -31,6 +31,30 @@ const card: Card = {
 	stage: "Stage1",
 	retreat: 1,
 
+	attacks: [
+		{
+			cost: [
+				"Colorless",
+			],
+			name: {
+				fr: "Charme",
+			},
+			effect: {
+				fr: "Pendant le prochain tour de votre adversaire, tous les dégâts infligés par des attaques du Pokémon Défenseur sont réduits de 20 (avant application de la Faiblesse et de la Résistance).",
+			},
+		},
+		{
+			cost: [
+				"Colorless",
+				"Colorless",
+			],
+			name: {
+				fr: "Coup de Queue",
+			},
+			damage: "20",
+		},
+	],
+
 	weaknesses: [{
 		type: "Fire",
 		value: "×2"

--- a/data/Trainer kits/XY trainer Kit (Latias)/30.ts
+++ b/data/Trainer kits/XY trainer Kit (Latias)/30.ts
@@ -26,26 +26,29 @@ const card: Card = {
 		en: "It can telepathically communicate with people. It changes its appearance using its down that refracts light."
 	},
 
-	attacks: [{
-		name: {
-			en: "Psychic Sphere",
-			fr: "Sphère Psy"
+	attacks: [
+		{
+			name: {
+				en: "Psychic Sphere",
+				fr: "Sphère Psy",
+			},
+			damage: 20,
+			effect: {
+				fr: "Lancez une pièce. Si c'est pile, cette attaque ne fait rien.",
+			},
 		},
-
-		damage: 20
-	}, {
-		name: {
-			en: "Psychic Prism",
-			fr: "Prisme Psy"
+		{
+			name: {
+				en: "Psychic Prism",
+				fr: "Prisme Psy",
+			},
+			damage: "60+",
+			effect: {
+				en: "Flip a coin. If heads, this attack does 20 more damage.",
+				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 20 dégâts supplémentaires.",
+			},
 		},
-
-		damage: "60+",
-
-		effect: {
-			en: "Flip a coin. If heads, this attack does 20 more damage.",
-			fr: "Lancez une pièce. Si c'est face, cette attaque inflige 20 dégâts supplémentaires."
-		}
-	}],
+	],
 
 	weaknesses: [{
 		type: "Psychic",

--- a/data/Trainer kits/XY trainer Kit (Latias)/4.ts
+++ b/data/Trainer kits/XY trainer Kit (Latias)/4.ts
@@ -24,26 +24,29 @@ const card: Card = {
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			en: "Peck",
-			fr: "Picpic"
+	attacks: [
+		{
+			name: {
+				en: "Peck",
+				fr: "Picpic",
+			},
+			damage: 10,
+			effect: {
+				fr: "Ce Pokémon s'inflige 10 dégâts.",
+			},
 		},
-
-		damage: 10
-	}, {
-		name: {
-			en: "Quick Attack",
-			fr: "Vive-Attaque"
+		{
+			name: {
+				en: "Quick Attack",
+				fr: "Vive-Attaque",
+			},
+			damage: "10+",
+			effect: {
+				en: "Flip a coin. If heads, this attack does 20 more damage.",
+				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 20 dégâts supplémentaires.",
+			},
 		},
-
-		damage: "10+",
-
-		effect: {
-			en: "Flip a coin. If heads, this attack does 20 more damage.",
-			fr: "Lancez une pièce. Si c'est face, cette attaque inflige 20 dégâts supplémentaires."
-		}
-	}],
+	],
 
 	hp: 50,
 	types: ["Colorless"],


### PR DESCRIPTION
Set: **XY trainer Kit (Latias)**
Series folder: `Trainer kits`
Changed card files: **11**

### Validation
- [ ] `bun run validate`
- [ ] `cd server && bun run --bun validate`
- [ ] `cd server && bun run compile`
- [ ] Manual review: translations, energy types, TS syntax

### Card images
See follow-up comments with embedded TCGdex assets.