### PR TITLE
fix(data): XY trainer Kit (Latios) (Trainer kits)

### DIFF
--- a/data/Trainer kits/XY trainer Kit (Latios)/1.ts
+++ b/data/Trainer kits/XY trainer Kit (Latios)/1.ts
@@ -21,6 +21,30 @@ const card: Card = {
 	stage: "Basic",
 	retreat: 1,
 
+	attacks: [
+		{
+			cost: [
+				"Colorless",
+			],
+			name: {
+				fr: "Charme",
+			},
+			effect: {
+				fr: "Pendant le prochain tour de votre adversaire, tous les dégâts infligés par des attaques du Pokémon Défenseur sont réduits de 20 (avant application de la Faiblesse et de la Résistance).",
+			},
+		},
+		{
+			cost: [
+				"Colorless",
+				"Colorless",
+			],
+			name: {
+				fr: "Coup de Queue",
+			},
+			damage: "20",
+		},
+	],
+
 	weaknesses: [{
 		type: "Fighting",
 		value: "×2"

--- a/data/Trainer kits/XY trainer Kit (Latios)/11.ts
+++ b/data/Trainer kits/XY trainer Kit (Latios)/11.ts
@@ -21,6 +21,18 @@ const card: Card = {
 	stage: "Basic",
 	retreat: 2,
 
+	attacks: [
+		{
+			cost: [
+				"Fighting",
+			],
+			name: {
+				fr: "Coud'Phalange",
+			},
+			damage: "10",
+		},
+	],
+
 	weaknesses: [{
 		type: "Psychic",
 		value: "×2"

--- a/data/Trainer kits/XY trainer Kit (Latios)/12.ts
+++ b/data/Trainer kits/XY trainer Kit (Latios)/12.ts
@@ -21,6 +21,33 @@ const card: Card = {
 	stage: "Basic",
 	retreat: 1,
 
+	attacks: [
+		{
+			cost: [
+				"Colorless",
+			],
+			name: {
+				fr: "Générateur Solaire",
+			},
+			effect: {
+				fr: "Cherchez jusqu'à 2 cartes Énergie spéciale dans votre deck, montrez-les, puis ajoutez-les à votre main. Mélangez ensuite votre deck.",
+			},
+		},
+		{
+			cost: [
+				"Fighting",
+				"Colorless",
+			],
+			name: {
+				fr: "Asticotage",
+			},
+			damage: "20+",
+			effect: {
+				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 20 dégâts supplémentaires.",
+			},
+		},
+	],
+
 	weaknesses: [{
 		type: "Grass",
 		value: "×2"

--- a/data/Trainer kits/XY trainer Kit (Latios)/14.ts
+++ b/data/Trainer kits/XY trainer Kit (Latios)/14.ts
@@ -31,6 +31,19 @@ const card: Card = {
 	stage: "Stage1",
 	retreat: 2,
 
+	attacks: [
+		{
+			cost: [
+				"Fighting",
+				"Fighting",
+			],
+			name: {
+				fr: "Dérouillée",
+			},
+			damage: "40",
+		},
+	],
+
 	weaknesses: [{
 		type: "Psychic",
 		value: "×2"

--- a/data/Trainer kits/XY trainer Kit (Latios)/15.ts
+++ b/data/Trainer kits/XY trainer Kit (Latios)/15.ts
@@ -21,6 +21,22 @@ const card: Card = {
 	stage: "Basic",
 	retreat: 3,
 
+	attacks: [
+		{
+			cost: [
+				"Fighting",
+				"Fighting",
+			],
+			name: {
+				fr: "Bélier",
+			},
+			damage: "40",
+			effect: {
+				fr: "Ce Pokémon s'inflige 10 dégâts.",
+			},
+		},
+	],
+
 	weaknesses: [{
 		type: "Grass",
 		value: "×2"

--- a/data/Trainer kits/XY trainer Kit (Latios)/19.ts
+++ b/data/Trainer kits/XY trainer Kit (Latios)/19.ts
@@ -31,6 +31,33 @@ const card: Card = {
 	stage: "Stage1",
 	retreat: 1,
 
+	attacks: [
+		{
+			cost: [
+				"Colorless",
+			],
+			name: {
+				fr: "Repositionnement",
+			},
+			effect: {
+				fr: "Déplacez autant d'Énergies attachées à vos Pokémon que vous voulez vers vos autres Pokémon, de la manière que vous voulez.",
+			},
+		},
+		{
+			cost: [
+				"Colorless",
+				"Colorless",
+			],
+			name: {
+				fr: "Câlinerie",
+			},
+			damage: "30+",
+			effect: {
+				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 30 dégâts supplémentaires.",
+			},
+		},
+	],
+
 	weaknesses: [{
 		type: "Fighting",
 		value: "×2"

--- a/data/Trainer kits/XY trainer Kit (Latios)/22.ts
+++ b/data/Trainer kits/XY trainer Kit (Latios)/22.ts
@@ -31,6 +31,19 @@ const card: Card = {
 	stage: "Stage1",
 	retreat: 2,
 
+	attacks: [
+		{
+			cost: [
+				"Fighting",
+				"Fighting",
+			],
+			name: {
+				fr: "Dérouillée",
+			},
+			damage: "40",
+		},
+	],
+
 	weaknesses: [{
 		type: "Psychic",
 		value: "×2"

--- a/data/Trainer kits/XY trainer Kit (Latios)/23.ts
+++ b/data/Trainer kits/XY trainer Kit (Latios)/23.ts
@@ -21,6 +21,22 @@ const card: Card = {
 	stage: "Basic",
 	retreat: 3,
 
+	attacks: [
+		{
+			cost: [
+				"Fighting",
+				"Fighting",
+			],
+			name: {
+				fr: "Bélier",
+			},
+			damage: "40",
+			effect: {
+				fr: "Ce Pokémon s'inflige 10 dégâts.",
+			},
+		},
+	],
+
 	weaknesses: [{
 		type: "Grass",
 		value: "×2"

--- a/data/Trainer kits/XY trainer Kit (Latios)/24.ts
+++ b/data/Trainer kits/XY trainer Kit (Latios)/24.ts
@@ -31,6 +31,33 @@ const card: Card = {
 	stage: "Stage1",
 	retreat: 1,
 
+	attacks: [
+		{
+			cost: [
+				"Colorless",
+			],
+			name: {
+				fr: "Repositionnement",
+			},
+			effect: {
+				fr: "Déplacez autant d'Énergies attachées à vos Pokémon que vous voulez vers vos autres Pokémon, de la manière que vous voulez.",
+			},
+		},
+		{
+			cost: [
+				"Colorless",
+				"Colorless",
+			],
+			name: {
+				fr: "Câlinerie",
+			},
+			damage: "30+",
+			effect: {
+				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 30 dégâts supplémentaires.",
+			},
+		},
+	],
+
 	weaknesses: [{
 		type: "Fighting",
 		value: "×2"

--- a/data/Trainer kits/XY trainer Kit (Latios)/25.ts
+++ b/data/Trainer kits/XY trainer Kit (Latios)/25.ts
@@ -31,6 +31,35 @@ const card: Card = {
 	stage: "Stage1",
 	retreat: 4,
 
+	attacks: [
+		{
+			cost: [
+				"Fighting",
+				"Colorless",
+				"Colorless",
+			],
+			name: {
+				fr: "Bélier",
+			},
+			damage: "50",
+			effect: {
+				fr: "Ce Pokémon s'inflige 10 dégâts.",
+			},
+		},
+		{
+			cost: [
+				"Fighting",
+				"Fighting",
+				"Colorless",
+				"Colorless",
+			],
+			name: {
+				fr: "Empal'Korne",
+			},
+			damage: "70",
+		},
+	],
+
 	weaknesses: [{
 		type: "Grass",
 		value: "×2"

--- a/data/Trainer kits/XY trainer Kit (Latios)/26.ts
+++ b/data/Trainer kits/XY trainer Kit (Latios)/26.ts
@@ -21,6 +21,33 @@ const card: Card = {
 	stage: "Basic",
 	retreat: 1,
 
+	attacks: [
+		{
+			cost: [
+				"Colorless",
+			],
+			name: {
+				fr: "Générateur Solaire",
+			},
+			effect: {
+				fr: "Cherchez jusqu'à 2 cartes Énergie spéciale dans votre deck, montrez-les, puis ajoutez-les à votre main. Mélangez ensuite votre deck.",
+			},
+		},
+		{
+			cost: [
+				"Fighting",
+				"Colorless",
+			],
+			name: {
+				fr: "Asticotage",
+			},
+			damage: "20+",
+			effect: {
+				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 20 dégâts supplémentaires.",
+			},
+		},
+	],
+
 	weaknesses: [{
 		type: "Grass",
 		value: "×2"

--- a/data/Trainer kits/XY trainer Kit (Latios)/27.ts
+++ b/data/Trainer kits/XY trainer Kit (Latios)/27.ts
@@ -21,6 +21,30 @@ const card: Card = {
 	stage: "Basic",
 	retreat: 1,
 
+	attacks: [
+		{
+			cost: [
+				"Colorless",
+			],
+			name: {
+				fr: "Charme",
+			},
+			effect: {
+				fr: "Pendant le prochain tour de votre adversaire, tous les dégâts infligés par des attaques du Pokémon Défenseur sont réduits de 20 (avant application de la Faiblesse et de la Résistance).",
+			},
+		},
+		{
+			cost: [
+				"Colorless",
+				"Colorless",
+			],
+			name: {
+				fr: "Coup de Queue",
+			},
+			damage: "20",
+		},
+	],
+
 	weaknesses: [{
 		type: "Fighting",
 		value: "×2"

--- a/data/Trainer kits/XY trainer Kit (Latios)/28.ts
+++ b/data/Trainer kits/XY trainer Kit (Latios)/28.ts
@@ -21,6 +21,18 @@ const card: Card = {
 	stage: "Basic",
 	retreat: 2,
 
+	attacks: [
+		{
+			cost: [
+				"Fighting",
+			],
+			name: {
+				fr: "Coud'Phalange",
+			},
+			damage: "10",
+		},
+	],
+
 	weaknesses: [{
 		type: "Psychic",
 		value: "×2"

--- a/data/Trainer kits/XY trainer Kit (Latios)/4.ts
+++ b/data/Trainer kits/XY trainer Kit (Latios)/4.ts
@@ -31,6 +31,35 @@ const card: Card = {
 	stage: "Stage1",
 	retreat: 4,
 
+	attacks: [
+		{
+			cost: [
+				"Fighting",
+				"Colorless",
+				"Colorless",
+			],
+			name: {
+				fr: "Bélier",
+			},
+			damage: "50",
+			effect: {
+				fr: "Ce Pokémon s'inflige 10 dégâts.",
+			},
+		},
+		{
+			cost: [
+				"Fighting",
+				"Fighting",
+				"Colorless",
+				"Colorless",
+			],
+			name: {
+				fr: "Empal'Korne",
+			},
+			damage: "70",
+		},
+	],
+
 	weaknesses: [{
 		type: "Grass",
 		value: "×2"


### PR DESCRIPTION
Set: **XY trainer Kit (Latios)**
Series folder: `Trainer kits`
Changed card files: **14**

### Validation
- [ ] `bun run validate`
- [ ] `cd server && bun run --bun validate`
- [ ] `cd server && bun run compile`
- [ ] Manual review: translations, energy types, TS syntax

### Card images
See follow-up comments with embedded TCGdex assets.