### PR TITLE
fix(data): XY trainer Kit (Noivern) (Trainer kits)

### DIFF
--- a/data/Trainer kits/XY trainer Kit (Noivern)/1.ts
+++ b/data/Trainer kits/XY trainer Kit (Noivern)/1.ts
@@ -21,6 +21,21 @@ const card: Card = {
 	stage: "Basic",
 	retreat: 1,
 
+	attacks: [
+		{
+			cost: [
+				"Colorless",
+			],
+			name: {
+				fr: "Coupe-Vent",
+			},
+			damage: "20",
+			effect: {
+				fr: "Lancez une pièce. Si c'est pile, cette attaque ne fait rien.",
+			},
+		},
+	],
+
 	weaknesses: [{
 		type: "Psychic",
 		value: "×2"

--- a/data/Trainer kits/XY trainer Kit (Noivern)/11.ts
+++ b/data/Trainer kits/XY trainer Kit (Noivern)/11.ts
@@ -21,6 +21,19 @@ const card: Card = {
 	stage: "Basic",
 	retreat: 2,
 
+	attacks: [
+		{
+			cost: [
+				"Fairy",
+				"Colorless",
+			],
+			name: {
+				fr: "Coup d'Boule",
+			},
+			damage: "20",
+		},
+	],
+
 	weaknesses: [{
 		type: "Darkness",
 		value: "×2"

--- a/data/Trainer kits/XY trainer Kit (Noivern)/16.ts
+++ b/data/Trainer kits/XY trainer Kit (Noivern)/16.ts
@@ -21,6 +21,33 @@ const card: Card = {
 	stage: "Basic",
 	retreat: 2,
 
+	attacks: [
+		{
+			cost: [
+				"Colorless",
+				"Colorless",
+			],
+			name: {
+				fr: "Mâchoire Serrée",
+			},
+			damage: "20",
+			effect: {
+				fr: "Lancez une pièce. Si c'est face, le Pokémon Actif de votre adversaire est maintenant Paralysé.",
+			},
+		},
+		{
+			cost: [
+				"Colorless",
+				"Colorless",
+				"Colorless",
+			],
+			name: {
+				fr: "Croc Aiguisé",
+			},
+			damage: "50",
+		},
+	],
+
 	weaknesses: [{
 		type: "Psychic",
 		value: "×2"

--- a/data/Trainer kits/XY trainer Kit (Noivern)/20.ts
+++ b/data/Trainer kits/XY trainer Kit (Noivern)/20.ts
@@ -21,6 +21,10 @@ const card: Card = {
 	stage: "Basic",
 	retreat: 1,
 
+	effect: {
+		fr: "Soignez 30 dégâts à l'un de vos Pokémon.",
+	},
+
 	weaknesses: [{
 		type: "Fighting",
 		value: "×2"

--- a/data/Trainer kits/XY trainer Kit (Noivern)/23.ts
+++ b/data/Trainer kits/XY trainer Kit (Noivern)/23.ts
@@ -21,6 +21,10 @@ const card: Card = {
 	stage: "Basic",
 	retreat: 1,
 
+	effect: {
+		fr: "Lancez une pièce. Si c'est face, échangez l'un des Pokémon de Banc de votre adversaire avec son Pokémon Actif.",
+	},
+
 	weaknesses: [{
 		type: "Lightning",
 		value: "×2"

--- a/data/Trainer kits/XY trainer Kit (Noivern)/4.ts
+++ b/data/Trainer kits/XY trainer Kit (Noivern)/4.ts
@@ -21,6 +21,10 @@ const card: Card = {
 	stage: "Basic",
 	retreat: 1,
 
+	effect: {
+		fr: "Échangez votre Pokémon Actif contre l'un de vos Pokémon de Banc.",
+	},
+
 	weaknesses: [{
 		type: "Fighting",
 		value: "×2"


### PR DESCRIPTION
Set: **XY trainer Kit (Noivern)**
Series folder: `Trainer kits`
Changed card files: **6**

### Validation
- [ ] `bun run validate`
- [ ] `cd server && bun run --bun validate`
- [ ] `cd server && bun run compile`
- [ ] Manual review: translations, energy types, TS syntax

### Card images
See follow-up comments with embedded TCGdex assets.