### PR TITLE
fix(data): XY trainer Kit (Pikachu Libre) (Trainer kits)

### DIFF
--- a/data/Trainer kits/XY trainer Kit (Pikachu Libre)/1.ts
+++ b/data/Trainer kits/XY trainer Kit (Pikachu Libre)/1.ts
@@ -21,6 +21,30 @@ const card: Card = {
 	stage: "Basic",
 	retreat: 1,
 
+	attacks: [
+		{
+			cost: [
+				"Colorless",
+			],
+			name: {
+				fr: "Si Mignon",
+			},
+			effect: {
+				fr: "Votre adversaire place une carte de sa main en dessous de son deck.",
+			},
+		},
+		{
+			cost: [
+				"Colorless",
+				"Colorless",
+			],
+			name: {
+				fr: "Griffe",
+			},
+			damage: "20",
+		},
+	],
+
 	weaknesses: [{
 		type: "Fighting",
 		value: "×2"

--- a/data/Trainer kits/XY trainer Kit (Pikachu Libre)/12.ts
+++ b/data/Trainer kits/XY trainer Kit (Pikachu Libre)/12.ts
@@ -21,6 +21,21 @@ const card: Card = {
 	stage: "Basic",
 	retreat: 1,
 
+	attacks: [
+		{
+			cost: [
+				"Colorless",
+			],
+			name: {
+				fr: "Attaque Imprudente",
+			},
+			damage: "20",
+			effect: {
+				fr: "Ce Pokémon s'inflige 10 dégâts.",
+			},
+		},
+	],
+
 	weaknesses: [{
 		type: "Fighting",
 		value: "×2"

--- a/data/Trainer kits/XY trainer Kit (Pikachu Libre)/15.ts
+++ b/data/Trainer kits/XY trainer Kit (Pikachu Libre)/15.ts
@@ -21,6 +21,19 @@ const card: Card = {
 	stage: "Basic",
 	retreat: 2,
 
+	attacks: [
+		{
+			cost: [
+				"Colorless",
+				"Colorless",
+			],
+			name: {
+				fr: "Coud'Phalange",
+			},
+			damage: "20",
+		},
+	],
+
 	weaknesses: [{
 		type: "Fighting",
 		value: "×2"

--- a/data/Trainer kits/XY trainer Kit (Pikachu Libre)/19.ts
+++ b/data/Trainer kits/XY trainer Kit (Pikachu Libre)/19.ts
@@ -31,6 +31,33 @@ const card: Card = {
 	stage: "Stage1",
 	retreat: 2,
 
+	attacks: [
+		{
+			cost: [
+				"Colorless",
+				"Colorless",
+			],
+			name: {
+				fr: "Tranche",
+			},
+			damage: "30",
+		},
+		{
+			cost: [
+				"Colorless",
+				"Colorless",
+				"Colorless",
+			],
+			name: {
+				fr: "Charge Miaou",
+			},
+			damage: "40+",
+			effect: {
+				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 40 dégâts supplémentaires. Si c'est pile, le Pokémon Actif de votre adversaire est maintenant Paralysé.",
+			},
+		},
+	],
+
 	weaknesses: [{
 		type: "Fighting",
 		value: "×2"

--- a/data/Trainer kits/XY trainer Kit (Pikachu Libre)/23.ts
+++ b/data/Trainer kits/XY trainer Kit (Pikachu Libre)/23.ts
@@ -21,6 +21,19 @@ const card: Card = {
 	stage: "Basic",
 	retreat: 2,
 
+	attacks: [
+		{
+			cost: [
+				"Colorless",
+				"Colorless",
+			],
+			name: {
+				fr: "Coud'Phalange",
+			},
+			damage: "20",
+		},
+	],
+
 	weaknesses: [{
 		type: "Fighting",
 		value: "×2"

--- a/data/Trainer kits/XY trainer Kit (Pikachu Libre)/24.ts
+++ b/data/Trainer kits/XY trainer Kit (Pikachu Libre)/24.ts
@@ -31,6 +31,33 @@ const card: Card = {
 	stage: "Stage1",
 	retreat: 2,
 
+	attacks: [
+		{
+			cost: [
+				"Colorless",
+				"Colorless",
+			],
+			name: {
+				fr: "Tranche",
+			},
+			damage: "30",
+		},
+		{
+			cost: [
+				"Colorless",
+				"Colorless",
+				"Colorless",
+			],
+			name: {
+				fr: "Charge Miaou",
+			},
+			damage: "40+",
+			effect: {
+				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 40 dégâts supplémentaires. Si c'est pile, le Pokémon Actif de votre adversaire est maintenant Paralysé.",
+			},
+		},
+	],
+
 	weaknesses: [{
 		type: "Fighting",
 		value: "×2"

--- a/data/Trainer kits/XY trainer Kit (Pikachu Libre)/25.ts
+++ b/data/Trainer kits/XY trainer Kit (Pikachu Libre)/25.ts
@@ -31,6 +31,30 @@ const card: Card = {
 	stage: "Stage1",
 	retreat: 3,
 
+	attacks: [
+		{
+			cost: [
+				"Colorless",
+				"Colorless",
+			],
+			name: {
+				fr: "Coud'Phalange",
+			},
+			damage: "30",
+		},
+		{
+			cost: [
+				"Lightning",
+				"Lightning",
+				"Colorless",
+			],
+			name: {
+				fr: "Électro Frappe",
+			},
+			damage: "90",
+		},
+	],
+
 	weaknesses: [{
 		type: "Fighting",
 		value: "×2"

--- a/data/Trainer kits/XY trainer Kit (Pikachu Libre)/26.ts
+++ b/data/Trainer kits/XY trainer Kit (Pikachu Libre)/26.ts
@@ -21,6 +21,21 @@ const card: Card = {
 	stage: "Basic",
 	retreat: 1,
 
+	attacks: [
+		{
+			cost: [
+				"Colorless",
+			],
+			name: {
+				fr: "Attaque Imprudente",
+			},
+			damage: "20",
+			effect: {
+				fr: "Ce Pokémon s'inflige 10 dégâts.",
+			},
+		},
+	],
+
 	weaknesses: [{
 		type: "Fighting",
 		value: "×2"

--- a/data/Trainer kits/XY trainer Kit (Pikachu Libre)/27.ts
+++ b/data/Trainer kits/XY trainer Kit (Pikachu Libre)/27.ts
@@ -21,6 +21,30 @@ const card: Card = {
 	stage: "Basic",
 	retreat: 1,
 
+	attacks: [
+		{
+			cost: [
+				"Colorless",
+			],
+			name: {
+				fr: "Si Mignon",
+			},
+			effect: {
+				fr: "Votre adversaire place une carte de sa main en dessous de son deck.",
+			},
+		},
+		{
+			cost: [
+				"Colorless",
+				"Colorless",
+			],
+			name: {
+				fr: "Griffe",
+			},
+			damage: "20",
+		},
+	],
+
 	weaknesses: [{
 		type: "Fighting",
 		value: "×2"

--- a/data/Trainer kits/XY trainer Kit (Pikachu Libre)/4.ts
+++ b/data/Trainer kits/XY trainer Kit (Pikachu Libre)/4.ts
@@ -31,6 +31,30 @@ const card: Card = {
 	stage: "Stage1",
 	retreat: 3,
 
+	attacks: [
+		{
+			cost: [
+				"Colorless",
+				"Colorless",
+			],
+			name: {
+				fr: "Coud'Phalange",
+			},
+			damage: "30",
+		},
+		{
+			cost: [
+				"Lightning",
+				"Lightning",
+				"Colorless",
+			],
+			name: {
+				fr: "Électro Frappe",
+			},
+			damage: "90",
+		},
+	],
+
 	weaknesses: [{
 		type: "Fighting",
 		value: "×2"


### PR DESCRIPTION
Set: **XY trainer Kit (Pikachu Libre)**
Series folder: `Trainer kits`
Changed card files: **10**

### Validation
- [ ] `bun run validate`
- [ ] `cd server && bun run --bun validate`
- [ ] `cd server && bun run compile`
- [ ] Manual review: translations, energy types, TS syntax

### Card images
See follow-up comments with embedded TCGdex assets.