### PR TITLE
fix(data): XY trainer Kit (Suicune) (Trainer kits)

### DIFF
--- a/data/Trainer kits/XY trainer Kit (Suicune)/11.ts
+++ b/data/Trainer kits/XY trainer Kit (Suicune)/11.ts
@@ -21,6 +21,18 @@ const card: Card = {
 	stage: "Basic",
 	retreat: 1,
 
+	attacks: [
+		{
+			cost: [
+				"Colorless",
+			],
+			name: {
+				fr: "Morsure",
+			},
+			damage: "10",
+		},
+	],
+
 	weaknesses: [{
 		type: "Grass",
 		value: "×2"

--- a/data/Trainer kits/XY trainer Kit (Suicune)/12.ts
+++ b/data/Trainer kits/XY trainer Kit (Suicune)/12.ts
@@ -31,6 +31,21 @@ const card: Card = {
 	stage: "Stage1",
 	retreat: 2,
 
+	attacks: [
+		{
+			cost: [
+				"Colorless",
+			],
+			name: {
+				fr: "Attaque Imprudente",
+			},
+			damage: "20",
+			effect: {
+				fr: "Ce Pokémon s'inflige 10 dégâts.",
+			},
+		},
+	],
+
 	weaknesses: [{
 		type: "Grass",
 		value: "×2"

--- a/data/Trainer kits/XY trainer Kit (Suicune)/13.ts
+++ b/data/Trainer kits/XY trainer Kit (Suicune)/13.ts
@@ -21,6 +21,30 @@ const card: Card = {
 	stage: "Basic",
 	retreat: 1,
 
+	attacks: [
+		{
+			cost: [
+				"Lightning",
+			],
+			name: {
+				fr: "Étincelle Surprise",
+			},
+			effect: {
+				fr: "Cette attaque inflige 30 dégâts à l'un des Pokémon de votre adversaire. (N'appliquez ni la Faiblesse ni la Résistance aux Pokémon de Banc.)",
+			},
+		},
+		{
+			cost: [
+				"Colorless",
+				"Colorless",
+			],
+			name: {
+				fr: "Morsure",
+			},
+			damage: "40",
+		},
+	],
+
 	weaknesses: [{
 		type: "Grass",
 		value: "×2"

--- a/data/Trainer kits/XY trainer Kit (Suicune)/16.ts
+++ b/data/Trainer kits/XY trainer Kit (Suicune)/16.ts
@@ -21,6 +21,21 @@ const card: Card = {
 	stage: "Basic",
 	retreat: 1,
 
+	attacks: [
+		{
+			cost: [
+				"Colorless",
+			],
+			name: {
+				fr: "Acrobatie",
+			},
+			damage: "10+",
+			effect: {
+				fr: "Lancez 2 pièces. Cette attaque inflige 10 dégâts supplémentaires pour chaque côté face.",
+			},
+		},
+	],
+
 	weaknesses: [{
 		type: "Grass",
 		value: "×2"

--- a/data/Trainer kits/XY trainer Kit (Suicune)/21.ts
+++ b/data/Trainer kits/XY trainer Kit (Suicune)/21.ts
@@ -31,6 +31,10 @@ const card: Card = {
 	stage: "Stage1",
 	retreat: 1,
 
+	effect: {
+		fr: "Soignez 30 dégâts à l'un de vos Pokémon.",
+	},
+
 	weaknesses: [{
 		type: "Grass",
 		value: "×2"

--- a/data/Trainer kits/XY trainer Kit (Suicune)/23.ts
+++ b/data/Trainer kits/XY trainer Kit (Suicune)/23.ts
@@ -21,6 +21,19 @@ const card: Card = {
 	stage: "Basic",
 	retreat: 1,
 
+	attacks: [
+		{
+			cost: [
+				"Colorless",
+				"Colorless",
+			],
+			name: {
+				fr: "Coud'Phalange",
+			},
+			damage: "20",
+		},
+	],
+
 	weaknesses: [{
 		type: "Grass",
 		value: "×2"

--- a/data/Trainer kits/XY trainer Kit (Suicune)/24.ts
+++ b/data/Trainer kits/XY trainer Kit (Suicune)/24.ts
@@ -21,6 +21,33 @@ const card: Card = {
 	stage: "Basic",
 	retreat: 1,
 
+	attacks: [
+		{
+			cost: [
+				"Colorless",
+				"Colorless",
+			],
+			name: {
+				fr: "Tranche",
+			},
+			damage: "30",
+		},
+		{
+			cost: [
+				"Colorless",
+				"Colorless",
+				"Colorless",
+			],
+			name: {
+				fr: "Charge Miaou",
+			},
+			damage: "40+",
+			effect: {
+				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 40 dégâts supplémentaires. Si c'est pile, le Pokémon Actif de votre adversaire est maintenant Paralysé.",
+			},
+		},
+	],
+
 	weaknesses: [{
 		type: "Lightning",
 		value: "×2"

--- a/data/Trainer kits/XY trainer Kit (Suicune)/25.ts
+++ b/data/Trainer kits/XY trainer Kit (Suicune)/25.ts
@@ -31,6 +31,30 @@ const card: Card = {
 	stage: "Stage1",
 	retreat: 2,
 
+	attacks: [
+		{
+			cost: [
+				"Colorless",
+				"Colorless",
+			],
+			name: {
+				fr: "Coud'Phalange",
+			},
+			damage: "30",
+		},
+		{
+			cost: [
+				"Lightning",
+				"Lightning",
+				"Colorless",
+			],
+			name: {
+				fr: "Électro Frappe",
+			},
+			damage: "90",
+		},
+	],
+
 	weaknesses: [{
 		type: "Grass",
 		value: "×2"

--- a/data/Trainer kits/XY trainer Kit (Suicune)/26.ts
+++ b/data/Trainer kits/XY trainer Kit (Suicune)/26.ts
@@ -21,6 +21,21 @@ const card: Card = {
 	stage: "Basic",
 	retreat: 1,
 
+	attacks: [
+		{
+			cost: [
+				"Colorless",
+			],
+			name: {
+				fr: "Attaque Imprudente",
+			},
+			damage: "20",
+			effect: {
+				fr: "Ce Pokémon s'inflige 10 dégâts.",
+			},
+		},
+	],
+
 	weaknesses: [{
 		type: "Grass",
 		value: "×2"

--- a/data/Trainer kits/XY trainer Kit (Suicune)/27.ts
+++ b/data/Trainer kits/XY trainer Kit (Suicune)/27.ts
@@ -31,6 +31,30 @@ const card: Card = {
 	stage: "Stage1",
 	retreat: 0,
 
+	attacks: [
+		{
+			cost: [
+				"Colorless",
+			],
+			name: {
+				fr: "Si Mignon",
+			},
+			effect: {
+				fr: "Votre adversaire place une carte de sa main en dessous de son deck.",
+			},
+		},
+		{
+			cost: [
+				"Colorless",
+				"Colorless",
+			],
+			name: {
+				fr: "Griffe",
+			},
+			damage: "20",
+		},
+	],
+
 	weaknesses: [{
 		type: "Lightning",
 		value: "×2"

--- a/data/Trainer kits/XY trainer Kit (Suicune)/7.ts
+++ b/data/Trainer kits/XY trainer Kit (Suicune)/7.ts
@@ -21,6 +21,21 @@ const card: Card = {
 	stage: "Basic",
 	retreat: 1,
 
+	attacks: [
+		{
+			cost: [
+				"Colorless",
+			],
+			name: {
+				fr: "Double Picpic",
+			},
+			damage: "10×",
+			effect: {
+				fr: "Lancez 2 pièces. Cette attaque inflige 10 dégâts multipliés par le nombre de côtés face.",
+			},
+		},
+	],
+
 	weaknesses: [{
 		type: "Lightning",
 		value: "×2"


### PR DESCRIPTION
Set: **XY trainer Kit (Suicune)**
Series folder: `Trainer kits`
Changed card files: **11**

### Validation
- [ ] `bun run validate`
- [ ] `cd server && bun run --bun validate`
- [ ] `cd server && bun run compile`
- [ ] Manual review: translations, energy types, TS syntax

### Card images
See follow-up comments with embedded TCGdex assets.