### PR TITLE
fix(data): XY trainer Kit (Sylveon) (Trainer kits)

### DIFF
--- a/data/Trainer kits/XY trainer Kit (Sylveon)/1.ts
+++ b/data/Trainer kits/XY trainer Kit (Sylveon)/1.ts
@@ -21,6 +21,21 @@ const card: Card = {
 	stage: "Basic",
 	retreat: 1,
 
+	attacks: [
+		{
+			cost: [
+				"Colorless",
+			],
+			name: {
+				fr: "Coupe-Vent",
+			},
+			damage: "20",
+			effect: {
+				fr: "Lancez une pièce. Si c'est pile, cette attaque ne fait rien.",
+			},
+		},
+	],
+
 	weaknesses: [{
 		type: "Lightning",
 		value: "×2"

--- a/data/Trainer kits/XY trainer Kit (Sylveon)/11.ts
+++ b/data/Trainer kits/XY trainer Kit (Sylveon)/11.ts
@@ -21,6 +21,19 @@ const card: Card = {
 	stage: "Basic",
 	retreat: 2,
 
+	attacks: [
+		{
+			cost: [
+				"Fairy",
+				"Colorless",
+			],
+			name: {
+				fr: "Coup d'Boule",
+			},
+			damage: "20",
+		},
+	],
+
 	weaknesses: [{
 		type: "Metal",
 		value: "×2"

--- a/data/Trainer kits/XY trainer Kit (Sylveon)/13.ts
+++ b/data/Trainer kits/XY trainer Kit (Sylveon)/13.ts
@@ -21,6 +21,21 @@ const card: Card = {
 	stage: "Basic",
 	retreat: 1,
 
+	attacks: [
+		{
+			cost: [
+				"Colorless",
+			],
+			name: {
+				fr: "Attaque Surprise",
+			},
+			damage: "20",
+			effect: {
+				fr: "Lancez une pièce. Si c'est pile, cette attaque ne fait rien.",
+			},
+		},
+	],
+
 	weaknesses: [{
 		type: "Fighting",
 		value: "×2"

--- a/data/Trainer kits/XY trainer Kit (Sylveon)/14.ts
+++ b/data/Trainer kits/XY trainer Kit (Sylveon)/14.ts
@@ -31,6 +31,33 @@ const card: Card = {
 	stage: "Stage1",
 	retreat: 3,
 
+	attacks: [
+		{
+			cost: [
+				"Fairy",
+				"Colorless",
+			],
+			name: {
+				fr: "Coup d'Boule",
+			},
+			damage: "30",
+		},
+		{
+			cost: [
+				"Fairy",
+				"Colorless",
+				"Colorless",
+			],
+			name: {
+				fr: "Double Écrasement",
+			},
+			damage: "50+",
+			effect: {
+				fr: "Lancez 2 pièces. Cette attaque inflige 20 dégâts supplémentaires pour chaque côté face.",
+			},
+		},
+	],
+
 	weaknesses: [{
 		type: "Metal",
 		value: "×2"

--- a/data/Trainer kits/XY trainer Kit (Sylveon)/16.ts
+++ b/data/Trainer kits/XY trainer Kit (Sylveon)/16.ts
@@ -21,6 +21,33 @@ const card: Card = {
 	stage: "Basic",
 	retreat: 1,
 
+	attacks: [
+		{
+			cost: [
+				"Colorless",
+				"Colorless",
+			],
+			name: {
+				fr: "Mâchoire Serrée",
+			},
+			damage: "20",
+			effect: {
+				fr: "Lancez une pièce. Si c'est face, le Pokémon Actif de votre adversaire est maintenant Paralysé.",
+			},
+		},
+		{
+			cost: [
+				"Colorless",
+				"Colorless",
+				"Colorless",
+			],
+			name: {
+				fr: "Croc Aiguisé",
+			},
+			damage: "50",
+		},
+	],
+
 	weaknesses: [{
 		type: "Fighting",
 		value: "×2"

--- a/data/Trainer kits/XY trainer Kit (Sylveon)/19.ts
+++ b/data/Trainer kits/XY trainer Kit (Sylveon)/19.ts
@@ -21,6 +21,21 @@ const card: Card = {
 	stage: "Basic",
 	retreat: 1,
 
+	attacks: [
+		{
+			cost: [
+				"Colorless",
+			],
+			name: {
+				fr: "Coupe-Vent",
+			},
+			damage: "20",
+			effect: {
+				fr: "Lancez une pièce. Si c'est pile, cette attaque ne fait rien.",
+			},
+		},
+	],
+
 	weaknesses: [{
 		type: "Lightning",
 		value: "×2"

--- a/data/Trainer kits/XY trainer Kit (Sylveon)/21.ts
+++ b/data/Trainer kits/XY trainer Kit (Sylveon)/21.ts
@@ -21,6 +21,21 @@ const card: Card = {
 	stage: "Basic",
 	retreat: 1,
 
+	attacks: [
+		{
+			cost: [
+				"Colorless",
+			],
+			name: {
+				fr: "Attaque Surprise",
+			},
+			damage: "20",
+			effect: {
+				fr: "Lancez une pièce. Si c'est pile, cette attaque ne fait rien.",
+			},
+		},
+	],
+
 	weaknesses: [{
 		type: "Fighting",
 		value: "×2"

--- a/data/Trainer kits/XY trainer Kit (Sylveon)/22.ts
+++ b/data/Trainer kits/XY trainer Kit (Sylveon)/22.ts
@@ -21,6 +21,33 @@ const card: Card = {
 	stage: "Basic",
 	retreat: 1,
 
+	attacks: [
+		{
+			cost: [
+				"Colorless",
+				"Colorless",
+			],
+			name: {
+				fr: "Mâchoire Serrée",
+			},
+			damage: "20",
+			effect: {
+				fr: "Lancez une pièce. Si c'est face, le Pokémon Actif de votre adversaire est maintenant Paralysé.",
+			},
+		},
+		{
+			cost: [
+				"Colorless",
+				"Colorless",
+				"Colorless",
+			],
+			name: {
+				fr: "Croc Aiguisé",
+			},
+			damage: "50",
+		},
+	],
+
 	weaknesses: [{
 		type: "Fighting",
 		value: "×2"

--- a/data/Trainer kits/XY trainer Kit (Sylveon)/27.ts
+++ b/data/Trainer kits/XY trainer Kit (Sylveon)/27.ts
@@ -21,6 +21,19 @@ const card: Card = {
 	stage: "Basic",
 	retreat: 2,
 
+	attacks: [
+		{
+			cost: [
+				"Fairy",
+				"Colorless",
+			],
+			name: {
+				fr: "Coup d'Boule",
+			},
+			damage: "20",
+		},
+	],
+
 	weaknesses: [{
 		type: "Metal",
 		value: "×2"

--- a/data/Trainer kits/XY trainer Kit (Sylveon)/29.ts
+++ b/data/Trainer kits/XY trainer Kit (Sylveon)/29.ts
@@ -31,6 +31,33 @@ const card: Card = {
 	stage: "Stage1",
 	retreat: 3,
 
+	attacks: [
+		{
+			cost: [
+				"Fairy",
+				"Colorless",
+			],
+			name: {
+				fr: "Coup d'Boule",
+			},
+			damage: "30",
+		},
+		{
+			cost: [
+				"Fairy",
+				"Colorless",
+				"Colorless",
+			],
+			name: {
+				fr: "Double Écrasement",
+			},
+			damage: "50+",
+			effect: {
+				fr: "Lancez 2 pièces. Cette attaque inflige 20 dégâts supplémentaires pour chaque côté face.",
+			},
+		},
+	],
+
 	weaknesses: [{
 		type: "Metal",
 		value: "×2"


### PR DESCRIPTION
Set: **XY trainer Kit (Sylveon)**
Series folder: `Trainer kits`
Changed card files: **10**

### Validation
- [ ] `bun run validate`
- [ ] `cd server && bun run --bun validate`
- [ ] `cd server && bun run compile`
- [ ] Manual review: translations, energy types, TS syntax

### Card images
See follow-up comments with embedded TCGdex assets.