### PR TITLE
fix(data): Phantasmal Flames (Mega Evolution)

### DIFF
--- a/data/Mega Evolution/Phantasmal Flames/086.ts
+++ b/data/Mega Evolution/Phantasmal Flames/086.ts
@@ -19,12 +19,12 @@ const card: Card = {
 
 	effect: {
 		en: "You can use this card only if you discard a Basic {R} Energy card from your hand.\n\nDiscard a Pokémon Tool or Special Energy card from 1 of your opponent's Pokémon, or discard a Stadium in play.",
-		fr: "Vous ne pouvez utiliser cette carte que si vous défaussez une carte Énergie {R} de base de votre main.\n\nDéfaussez une carte Outil Pokémon ou Énergie spéciale de l'un des Pokémon de votre adversaire, ou défaussez un Stade en jeu.",
+		fr: "Vous ne pouvez utiliser cette carte que si vous défaussez une carte Énergie Feu de base de votre main.",
 		es: "Puedes usar esta carta solo si descartas una carta de Energía {R} Básica de tu mano.\n\nDescarta 1 carta de Herramienta Pokémon o de Energía Especial de uno de los Pokémon de tu rival, o descarta 1 Estadio en juego.",
 		'es-mx': "Solo puedes usar esta carta si descartas 1 carta de Energía {R} Básica de tu mano.\n\nDescarta 1 carta de Herramienta Pokémon o de Energía Especial de 1 de los Pokémon de tu rival, o descarta 1 Estadio en juego.",
 		de: "Du kannst diese Karte nur einsetzen, wenn du 1 Basis-{R}-Energiekarte aus deiner Hand auf deinen Ablagestapel legst.\n\nLege 1 Pokémon-Ausrüstung oder Spezial-Energiekarte von 1 Pokémon deines Gegners auf seinen Ablagestapel oder lege 1 Stadion im Spiel auf den Ablagestapel.",
 		it: "Puoi usare questa carta solo se scarti una carta Energia base {R} che hai in mano.\n\nScarta una carta Oggetto Pokémon o una carta Energia speciale da uno dei Pokémon del tuo avversario o scarta una carta Stadio in gioco.",
-		pt: "Você só pode usar esta carta se descartar uma carta de Energia {R} Básica da sua mão.\n\nDescarte uma carta de Ferramenta Pokémon ou Energia Especial de 1 dos Pokémon do seu oponente, ou descarte um Estádio em jogo."
+		pt: "Você só pode usar esta carta se descartar uma carta de Energia {R} Básica da sua mão.\n\nDescarte uma carta de Ferramenta Pokémon ou Energia Especial de 1 dos Pokémon do seu oponente, ou descarte um Estádio em jogo.",
 	},
 
 	trainerType: "Item",

--- a/data/Mega Evolution/Phantasmal Flames/117.ts
+++ b/data/Mega Evolution/Phantasmal Flames/117.ts
@@ -19,12 +19,12 @@ const card: Card = {
 
 	effect: {
 		en: "You can use this card only if you discard a Basic {R} Energy card from your hand.\n\nDiscard a Pokémon Tool or Special Energy card from 1 of your opponent's Pokémon, or discard a Stadium in play.",
-		fr: "Vous ne pouvez utiliser cette carte que si vous défaussez une carte Énergie {R} de base de votre main.\n\nDéfaussez une carte Outil Pokémon ou Énergie spéciale de l'un des Pokémon de votre adversaire, ou défaussez un Stade en jeu.",
+		fr: "Vous ne pouvez utiliser cette carte que si vous défaussez une carte Énergie Feu de base de votre main.",
 		es: "Puedes usar esta carta solo si descartas una carta de Energía {R} Básica de tu mano.\n\nDescarta 1 carta de Herramienta Pokémon o de Energía Especial de uno de los Pokémon de tu rival, o descarta 1 Estadio en juego.",
 		'es-mx': "Solo puedes usar esta carta si descartas 1 carta de Energía {R} Básica de tu mano.\n\nDescarta 1 carta de Herramienta Pokémon o de Energía Especial de 1 de los Pokémon de tu rival, o descarta 1 Estadio en juego.",
 		de: "Du kannst diese Karte nur einsetzen, wenn du 1 Basis-{R}-Energiekarte aus deiner Hand auf deinen Ablagestapel legst.\n\nLege 1 Pokémon-Ausrüstung oder Spezial-Energiekarte von 1 Pokémon deines Gegners auf seinen Ablagestapel oder lege 1 Stadion im Spiel auf den Ablagestapel.",
 		it: "Puoi usare questa carta solo se scarti una carta Energia base {R} che hai in mano.\n\nScarta una carta Oggetto Pokémon o una carta Energia speciale da uno dei Pokémon del tuo avversario o scarta una carta Stadio in gioco.",
-		pt: "Você só pode usar esta carta se descartar uma carta de Energia {R} Básica da sua mão.\n\nDescarte uma carta de Ferramenta Pokémon ou Energia Especial de 1 dos Pokémon do seu oponente, ou descarte um Estádio em jogo."
+		pt: "Você só pode usar esta carta se descartar uma carta de Energia {R} Básica da sua mão.\n\nDescarte uma carta de Ferramenta Pokémon ou Energia Especial de 1 dos Pokémon do seu oponente, ou descarte um Estádio em jogo.",
 	},
 
 	trainerType: "Item",

--- a/data/Mega Evolution/Phantasmal Flames/124.ts
+++ b/data/Mega Evolution/Phantasmal Flames/124.ts
@@ -19,12 +19,12 @@ const card: Card = {
 
 	effect: {
 		en: "If this card is attached to 1 of your Pokémon, discard it at the end of your turn.\n\nAs long as this card is attached to a Pokémon, it provides {C} Energy.\n\nIf this card is attached to an Evolution Pokémon, it provides {C}{C}{C} Energy instead.",
-		fr: "Si cette carte est attachée à l'un de vos Pokémon, défaussez-la à la fin de votre tour.\n\nTant que cette carte est attachée à un Pokémon, elle fournit une Énergie {C}.\n\nSi cette carte est attachée à un Pokémon Évolutif, elle fournit 3 Énergies {C} à la place.",
+		fr: "Si cette carte est attachée à l'un de vos Pokémon, défaussez -la à la fin de votre tour.",
 		es: "Si esta carta está unida a uno de tus Pokémon, descártala al final de tu turno.\n\nMientras esta carta esté unida a un Pokémon, proporciona 1 Energía {C}.\n\nSi esta carta está unida a un Pokémon Evolución, proporciona 3 Energías {C} en vez de una.",
 		'es-mx': "Si esta carta está unida a 1 de tus Pokémon, descártala al final de tu turno.\n\nMientras esta carta esté unida a un Pokémon, proporciona Energía {C}.\n\nSi esta carta está unida a un Pokémon Evolución, proporciona Energía {C}{C}{C} en lugar de {C}.",
 		de: "Wenn diese Karte an 1 deiner Pokémon angelegt ist, lege sie am Ende deines Zuges auf deinen Ablagestapel.\n\nSolange diese Karte an ein Pokémon angelegt ist, liefert sie {C}-Energie.\n\nWenn diese Karte an ein Entwicklungs-Pokémon angelegt ist, liefert sie stattdessen {C}{C}{C}-Energien.",
 		it: "Se questa carta è assegnata a uno dei tuoi Pokémon, scartala alla fine del tuo turno.\n\nFintanto che questa carta è assegnata a un Pokémon, fornisce Energia {C}.\n\nSe questa carta è assegnata a un Pokémon Evoluzione, invece fornisce Energie {C}{C}{C}.",
-		pt: "Se esta carta estiver ligada a 1 dos seus Pokémon, descarte-a no final do seu turno.\n\nEnquanto esta carta estiver ligada a um Pokémon, ela fornecerá Energia {C}.\n\nSe esta carta estiver ligada a um Pokémon de Evolução, ela fornecerá Energia {C}{C}{C}."
+		pt: "Se esta carta estiver ligada a 1 dos seus Pokémon, descarte-a no final do seu turno.\n\nEnquanto esta carta estiver ligada a um Pokémon, ela fornecerá Energia {C}.\n\nSe esta carta estiver ligada a um Pokémon de Evolução, ela fornecerá Energia {C}{C}{C}.",
 	},
 
 	energyType: "Normal",


### PR DESCRIPTION
## Summary
- Update only **Phantasmal Flames** in **Mega Evolution**.
- Scope is limited to this set definition and **3** changed card files.
- Queue-safe scope: no compiler/server/meta/global paths included.

## Review links
| Card | Number | Pokepedia picture |
|---|---:|---|
| 086 | 086 | [search](https://www.pokepedia.fr/index.php?search=086) |
| 117 | 117 | [search](https://www.pokepedia.fr/index.php?search=117) |
| 124 | 124 | [search](https://www.pokepedia.fr/index.php?search=124) |

_Note: 3 card(s) use page/search links because a direct Pokepedia picture URL was unavailable._
