### PR TITLE
fix(data): update Sword & Shield / Celebrations

### DIFF
--- a/data/Sword & Shield/Celebrations/107A.ts
+++ b/data/Sword & Shield/Celebrations/107A.ts
@@ -6,7 +6,8 @@ const card: Card = {
 	set: Set,
 
 	name: {
-		en: "Donphan"
+		en: "Donphan",
+		fr: "Donphan"
 	},
 
 	illustrator: "Kent Kanetsuna",
@@ -20,28 +21,33 @@ const card: Card = {
 		type: "Poke-BODY",
 
 		name: {
-			en: "Exoskeleton"
+			en: "Exoskeleton",
+			fr: "Exosquelette"
 		},
 
 		effect: {
-			en: "Any damage done to Donphan by attacks is reduced by 20 (after applying Weakness and Resistance)."
+			en: "Any damage done to Donphan by attacks is reduced by 20 (after applying Weakness and Resistance).",
+			fr: "Tout dégât infligé à Donphan par des attaques est réduit de 20 (après application de la Faiblesse et de la Résistance)."
 		}
 	}],
 
 	attacks: [{
 		name: {
-			en: "Earthquake"
+			en: "Earthquake",
+			fr: "Séisme"
 		},
 
 		effect: {
-			en: "Does 10 damage to each of your Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+			en: "Does 10 damage to each of your Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)",
+			fr: "Inflige 10 dégâts à chacun des Pokémon de votre Banc. (N'appliquez ni la Faiblesse ni la Résistance aux Pokémon de Banc.)"
 		},
 
 		damage: 60,
 		cost: ["Fighting"]
 	}, {
 		name: {
-			en: "Heavy Impact"
+			en: "Heavy Impact",
+			fr: "Gros impact"
 		},
 
 		damage: 90,

--- a/data/Sword & Shield/Celebrations/109A.ts
+++ b/data/Sword & Shield/Celebrations/109A.ts
@@ -6,7 +6,8 @@ const card: Card = {
 	set: Set,
 
 	name: {
-		en: "Luxray GL LV.X"
+		en: "Luxray GL LV.X",
+		fr: "Luxray GL NIV.X"
 	},
 
 	illustrator: "Mitsuhiro Arita",
@@ -20,21 +21,25 @@ const card: Card = {
 		type: "Poke-POWER",
 
 		name: {
-			en: "Bright Look"
+			en: "Bright Look",
+			fr: "Regard alerte"
 		},
 
 		effect: {
-			en: "Once during your turn (before your attack), when you put Luxray GL LV.X from your hand onto your Active Luxray GL, you may switch the Defending Pokémon with 1 of your opponent's Benched Pokémon."
+			en: "Once during your turn (before your attack), when you put Luxray GL LV.X from your hand onto your Active Luxray GL, you may switch the Defending Pokémon with 1 of your opponent's Benched Pokémon.",
+			fr: "Une seule fois lors de votre tour (avant votre attaque), lorsque vous placez Luxray  NIV.X de votre main sur votre Luxray  Actif, vous pouvez échanger le Pokémon Défenseur avec 1 des Pokémon de Banc de votre adversaire."
 		}
 	}],
 
 	attacks: [{
 		name: {
-			en: "Flash Impact"
+			en: "Flash Impact",
+			fr: "Impact-flash"
 		},
 
 		effect: {
-			en: "Does 30 damage to 1 of your Pokémon, and don't apply Weakness and Resistance to this damage."
+			en: "Does 30 damage to 1 of your Pokémon, and don't apply Weakness and Resistance to this damage.",
+			fr: "Inflige 30 dégâts à 1 de vos Pokémon. N'appliquez pas la Faiblesse et la Résistance à ces dégâts."
 		},
 
 		damage: 60,

--- a/data/Sword & Shield/Celebrations/145A.ts
+++ b/data/Sword & Shield/Celebrations/145A.ts
@@ -6,7 +6,8 @@ const card: Card = {
 	set: Set,
 
 	name: {
-		en: "Garchomp C LV.X"
+		en: "Garchomp C LV.X",
+		fr: "Carchacrok C NIV.X"
 	},
 
 	illustrator: "Shizurow",
@@ -20,21 +21,25 @@ const card: Card = {
 		type: "Poke-POWER",
 
 		name: {
-			en: "Healing Breath"
+			en: "Healing Breath",
+			fr: "Haleine guérisseuse"
 		},
 
 		effect: {
-			en: "Once during your turn (before your attack), when you put Garchomp C LV.X from your hand onto your Active Garchomp C, you may remove all damage counters from each of your Pokémon SP."
+			en: "Once during your turn (before your attack), when you put Garchomp C LV.X from your hand onto your Active Garchomp C, you may remove all damage counters from each of your Pokémon SP.",
+			fr: "Une seule fois lors de votre tour (avant votre attaque), lorsque vous placez Carchacrok  NIV.X de votre main sur votre Carchacrok  Actif, vous pouvez retirer tous ses marqueurs de dégât à chacun de vos Pokémon SP."
 		}
 	}],
 
 	attacks: [{
 		name: {
-			en: "Dragon Rush"
+			en: "Dragon Rush",
+			fr: "Dracocharge"
 		},
 
 		effect: {
-			en: "Discard 2 Energy attached to Garchomp C. Choose 1 of your opponent's Pokémon. This attack does 80 damage to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.) Garchomp C can't use Dragon Rush during your next turn."
+			en: "Discard 2 Energy attached to Garchomp C. Choose 1 of your opponent's Pokémon. This attack does 80 damage to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.) Garchomp C can't use Dragon Rush during your next turn.",
+			fr: "Défaussez 2 Énergies attachées à Carchacrok . Choisissez 1 des Pokémon de votre adversaire. Cette attaque lui inflige 80 dégâts. (Vous ne pouvez pas appliquer la Faiblesse et la Résistance aux Pokémon de Banc.) Carchacrok  ne peut pas utiliser Dracocharge lors de votre prochain tour."
 		},
 
 		cost: ["Colorless", "Colorless", "Colorless"]

--- a/data/Sword & Shield/Celebrations/15A.ts
+++ b/data/Sword & Shield/Celebrations/15A.ts
@@ -7,7 +7,7 @@ const card: Card = {
 
 	name: {
 		en: "Venusaur",
-		fr: "Lunala"
+		fr: "Florizarre",
 	},
 
 	illustrator: "Mitsuhiro Arita",
@@ -17,15 +17,21 @@ const card: Card = {
 	types: ["Grass"],
 	stage: "Stage2",
 
-	attacks: [{
-		name: {
-			en: "Solarbeam",
-			fr: "Douleur Lunaire"
+	attacks: [
+		{
+			name: {
+				en: "Solarbeam",
+				fr: "Lance-Soleil",
+			},
+			damage: 60,
+			cost: [
+				"Grass",
+				"Grass",
+				"Grass",
+				"Grass",
+			],
 		},
-
-		damage: 60,
-		cost: ["Grass", "Grass", "Grass", "Grass"]
-	}],
+	],
 
 	weaknesses: [{
 		type: "Fire",

--- a/data/Sword & Shield/Celebrations/15A1.ts
+++ b/data/Sword & Shield/Celebrations/15A1.ts
@@ -7,7 +7,7 @@ const card: Card = {
 
 	name: {
 		en: "Venusaur",
-		fr: "Lunala"
+		fr: "Florizarre",
 	},
 
 	illustrator: "Mitsuhiro Arita",
@@ -17,15 +17,21 @@ const card: Card = {
 	types: ["Grass"],
 	stage: "Stage2",
 
-	attacks: [{
-		name: {
-			en: "Solarbeam",
-			fr: "Douleur Lunaire"
+	attacks: [
+		{
+			name: {
+				en: "Solarbeam",
+				fr: "Lance-Soleil",
+			},
+			damage: 60,
+			cost: [
+				"Grass",
+				"Grass",
+				"Grass",
+				"Grass",
+			],
 		},
-
-		damage: 60,
-		cost: ["Grass", "Grass", "Grass", "Grass"]
-	}],
+	],
 
 	weaknesses: [{
 		type: "Fire",

--- a/data/Sword & Shield/Celebrations/15A2.ts
+++ b/data/Sword & Shield/Celebrations/15A2.ts
@@ -6,12 +6,16 @@ const card: Card = {
 
 	name: {
 		en: "Here Comes Team Rocket!",
-		fr: "Lunala"
+		fr: "Et voila les Team Rocket !",
 	},
 
 	illustrator: "Ken Sugimori",
 	rarity: "Classic Collection",
 	category: "Trainer",
+	effect: {
+		fr: "Chaque joueur joue avec ses cartes Récompenses découvertes jusqu'à la fin de la partie.",
+	},
+
 	trainerType: "Supporter",
 
 	variants: {

--- a/data/Sword & Shield/Celebrations/15A3.ts
+++ b/data/Sword & Shield/Celebrations/15A3.ts
@@ -7,7 +7,7 @@ const card: Card = {
 
 	name: {
 		en: "Rocket's Zapdos",
-		fr: "Lunala"
+		fr: "Électhor de Rocket",
 	},
 
 	illustrator: "Shin-ichi Yoshida",
@@ -17,33 +17,39 @@ const card: Card = {
 	types: ["Lightning"],
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			en: "Plasma",
-			fr: "Douleur Lunaire"
+	attacks: [
+		{
+			name: {
+				en: "Plasma",
+				fr: "Plasma",
+			},
+			effect: {
+				en: "If there are any Lightning Energy cards in your discard pile, attach 1 of them to Rocket's Zapdos.",
+				fr: "S'il y a au moins une carte Énergie Électrique dans votre pile de défausse, attachez l'une d'elles à Électhor de Rocket.",
+			},
+			damage: 20,
+			cost: [
+				"Lightning",
+			],
 		},
-
-		effect: {
-			en: "If there are any Lightning Energy cards in your discard pile, attach 1 of them to Rocket's Zapdos.",
-			fr: "Doublez le nombre de marqueurs de dégâts sur chacun des Pokémon de votre adversaire."
+		{
+			name: {
+				en: "Electroburn",
+				fr: "Électrobrûlure",
+			},
+			effect: {
+				en: "Rocket's Zapdos does damage to itself equal to 10 times the number of Lightning Energy cards attached to it.",
+				fr: "Électhor de Rocket s'inflige une quantité de dégâts égale à 10 fois le nombre de cartes Énergie Électrique qui lui sont attachées.",
+			},
+			damage: 70,
+			cost: [
+				"Lightning",
+				"Lightning",
+				"Lightning",
+				"Colorless",
+			],
 		},
-
-		damage: 20,
-		cost: ["Lightning"]
-	}, {
-		name: {
-			en: "Electroburn",
-			fr: "Attaque Psy"
-		},
-
-		effect: {
-			en: "Rocket's Zapdos does damage to itself equal to 10 times the number of Lightning Energy cards attached to it.",
-			fr: "Cette attaque inflige aussi 30 dégâts à l'un des Pokémon de Banc de votre adversaire. (N'appliquez ni la Faiblesse ni la Résistance aux Pokémon de Banc.)"
-		},
-
-		damage: 70,
-		cost: ["Lightning", "Lightning", "Lightning", "Colorless"]
-	}],
+	],
 
 	resistances: [{
 		type: "Fighting",

--- a/data/Sword & Shield/Celebrations/15A4.ts
+++ b/data/Sword & Shield/Celebrations/15A4.ts
@@ -7,7 +7,7 @@ const card: Card = {
 
 	name: {
 		en: "Claydol",
-		fr: "Lunala"
+		fr: "Kaorine",
 	},
 
 	illustrator: "Midori Harada",
@@ -17,27 +17,36 @@ const card: Card = {
 	types: ["Fighting"],
 	stage: "Stage1",
 
-	abilities: [{
-		type: "Poke-POWER",
-
-		name: {
-			en: "Cosmic Power"
+	abilities: [
+		{
+			type: "Poke-POWER",
+			name: {
+				en: "Cosmic Power",
+				fr: "Force cosmik",
+			},
+			effect: {
+				en: "Once during your turn (before your attack), you may choose up to 2 cards from your hand and put them on the bottom of your deck in any order. If you do, draw cards until you have 6 cards in your hand. This power can't be used if Claydol is affected by a Special Condition.",
+				fr: "Une seule fois lors de votre tour (avant votre attaque), vous pouvez choisir jusqu'à 2 cartes de votre main et les placer au dessous de votre deck dans n'importe quel ordre. Piochez alors des cartes jusqu'à ce que vous ayez 6 cartes en main. Ce pouvoir ne peut pas être utilisé si Kaorine est affecté par un État Spécial.",
+			},
 		},
+	],
 
-		effect: {
-			en: "Once during your turn (before your attack), you may choose up to 2 cards from your hand and put them on the bottom of your deck in any order. If you do, draw cards until you have 6 cards in your hand. This power can't be used if Claydol is affected by a Special Condition."
-		}
-	}],
-
-	attacks: [{
-		name: {
-			en: "Spinning Attack",
-			fr: "Douleur Lunaire"
+	attacks: [
+		{
+			name: {
+				en: "Spinning Attack",
+				fr: "Attaque tournante",
+			},
+			damage: 40,
+			cost: [
+				"Fighting",
+				"Colorless",
+			],
+			effect: {
+				fr: "Défaussez 2 cartes Énergie attachées à Dracaufeu pour pouvoir utiliser cette attaque.",
+			},
 		},
-
-		damage: 40,
-		cost: ["Fighting", "Colorless"]
-	}],
+	],
 
 	weaknesses: [{
 		type: "Grass",

--- a/data/Sword & Shield/Celebrations/17.ts
+++ b/data/Sword & Shield/Celebrations/17.ts
@@ -27,6 +27,18 @@ const card: Card = {
 	hp: 130,
 	stage: "Basic",
 
+	abilities: [
+		{
+			type: "Poke-POWER",
+			name: {
+				fr: "Rayon Obscur",
+			},
+			effect: {
+				fr: "Une seule fois lors de votre tour, lorsque vous placez Noctali Star de votre main sur votre Banc, vous pouvez choisir 1 carte de la main de votre adversaire sans regarder et la défausser.",
+			},
+		},
+	],
+
 	attacks: [{
 		name: {
 			en: "Magma Volcano",

--- a/data/Sword & Shield/Celebrations/17A.ts
+++ b/data/Sword & Shield/Celebrations/17A.ts
@@ -7,7 +7,7 @@ const card: Card = {
 
 	name: {
 		en: "Umbreon Star",
-		fr: "Groudon"
+		fr: "Noctali ☆",
 	},
 
 	illustrator: "Masakazu Fukuda",
@@ -17,31 +17,36 @@ const card: Card = {
 	types: ["Darkness"],
 	stage: "Basic",
 
-	abilities: [{
-		type: "Poke-POWER",
-
-		name: {
-			en: "Dark Ray"
+	abilities: [
+		{
+			type: "Poke-POWER",
+			name: {
+				en: "Dark Ray",
+				fr: "Rayon Obscur",
+			},
+			effect: {
+				en: "Once during your turn, when you put Umbreon Star from your hand onto your Bench, you may choose 1 card from your opponent's hand without looking and discard it.",
+				fr: "Une seule fois lors de votre tour, lorsque vous placez Noctali Star de votre main sur votre Banc, vous pouvez choisir 1 carte de la main de votre adversaire sans regarder et la défausser.",
+			},
 		},
+	],
 
-		effect: {
-			en: "Once during your turn, when you put Umbreon Star from your hand onto your Bench, you may choose 1 card from your opponent's hand without looking and discard it."
-		}
-	}],
-
-	attacks: [{
-		name: {
-			en: "Feint Attack",
-			fr: "Volcan Magma"
+	attacks: [
+		{
+			name: {
+				en: "Feint Attack",
+				fr: "Feinte",
+			},
+			effect: {
+				en: "Choose 1 of your opponent's Pokémon. This attack does 30 damage to that Pokémon. This attack's damage isn't affected by Weakness, Resistance, Poké-Powers, Poké-Bodies, or any other effects on that Pokémon.",
+				fr: "Choisissez 1 des Pokémon de votre adversaire. Cette attaque inflige 30 dégâts à ce Pokémon-là. Les dégâts de cette attaque ne sont pas affectés par la Faiblesse, Résistance, Poké-Powers, Poké-Bodies ou tout autre effet sur ce Pokémon-là.",
+			},
+			cost: [
+				"Darkness",
+				"Darkness",
+			],
 		},
-
-		effect: {
-			en: "Choose 1 of your opponent's Pokémon. This attack does 30 damage to that Pokémon. This attack's damage isn't affected by Weakness, Resistance, Poké-Powers, Poké-Bodies, or any other effects on that Pokémon.",
-			fr: "Défaussez les 5 cartes du dessus de votre deck. Cette attaque inflige 80 dégâts pour chaque carte Énergie défaussée de cette façon."
-		},
-
-		cost: ["Darkness", "Darkness"]
-	}],
+	],
 
 	weaknesses: [{
 		type: "Fighting",

--- a/data/Sword & Shield/Celebrations/20A.ts
+++ b/data/Sword & Shield/Celebrations/20A.ts
@@ -7,7 +7,7 @@ const card: Card = {
 
 	name: {
 		en: "Cleffa",
-		fr: "Dialga"
+		fr: "Mélo",
 	},
 
 	illustrator: "Kagemaru Himeno",
@@ -17,19 +17,21 @@ const card: Card = {
 	types: ["Colorless"],
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			en: "Eeeeeeek",
-			fr: "Reflux Temporel"
+	attacks: [
+		{
+			name: {
+				en: "Eeeeeeek",
+				fr: "Arheuuuuu",
+			},
+			effect: {
+				en: "Shuffle your hand into your deck, then draw 7 cards.",
+				fr: "Mélangez votre main avec votre deck, piochez ensuite 7 cartes.",
+			},
+			cost: [
+				"Colorless",
+			],
 		},
-
-		effect: {
-			en: "Shuffle your hand into your deck, then draw 7 cards.",
-			fr: "Ajoutez à votre main une carte de votre pile de défausse."
-		},
-
-		cost: ["Colorless"]
-	}],
+	],
 
 	retreat: 0,
 

--- a/data/Sword & Shield/Celebrations/24A.ts
+++ b/data/Sword & Shield/Celebrations/24A.ts
@@ -6,7 +6,7 @@ const card: Card = {
 
 	name: {
 		en: "_____'s Pikachu",
-		fr: "Recherches Professorales"
+		fr: "Pikachu de ________",
 	},
 
 	illustrator: "Kagemaru Himeno",
@@ -18,18 +18,23 @@ const card: Card = {
 	types: ["Lightning"],
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			en: "Birthday Surprise"
+	attacks: [
+		{
+			name: {
+				en: "Birthday Surprise",
+				fr: "Surprise d'anniversaire",
+			},
+			effect: {
+				en: "If it's not your birthday, this attack does 30 damage. If it is your birthday, flip a coin. If heads, this attack does 30 damage plus 50 more damage; if tails, this attack does 30 damage.",
+				fr: "Si ce n'est pas votre anniversaire, cette attaque inflige 30 dégâts. Si c'est votre anniversaire, lancez une pièce. Si c'est face, cette attaque inflige 30 dégâts plus 50 dégâts supplémentaires ; si c'est pile, cette attaque inflige 30 dégâts.",
+			},
+			damage: "30+",
+			cost: [
+				"Lightning",
+				"Lightning",
+			],
 		},
-
-		effect: {
-			en: "If it's not your birthday, this attack does 30 damage. If it is your birthday, flip a coin. If heads, this attack does 30 damage plus 50 more damage; if tails, this attack does 30 damage."
-		},
-
-		damage: "30+",
-		cost: ["Lightning", "Lightning"]
-	}],
+	],
 
 	weaknesses: [{
 		type: "Fighting",

--- a/data/Sword & Shield/Celebrations/2A.ts
+++ b/data/Sword & Shield/Celebrations/2A.ts
@@ -7,7 +7,7 @@ const card: Card = {
 
 	name: {
 		en: "Blastoise",
-		fr: "Reshiram"
+		fr: "Tortank",
 	},
 
 	illustrator: "Ken Sugimori",
@@ -17,20 +17,24 @@ const card: Card = {
 	types: ["Water"],
 	stage: "Stage2",
 
-	attacks: [{
-		name: {
-			en: "Hydro Pump",
-			fr: "Vent Brûlant"
+	attacks: [
+		{
+			name: {
+				en: "Hydro Pump",
+				fr: "Hydrocanon",
+			},
+			effect: {
+				en: "Does 40 damage plus 10 more damage for each Water Energy attached to Blastoise but not used to pay for this attack's Energy cost. Extra Water Energy after the 2nd doesn't count.",
+				fr: "Inflige 40 dégâts plus 10 dégâts supplémentaires pour chaque Énergie Eau attachée à Tortank en plus du coût en Énergie de cette attaque. Les Énergies Eau supplémentaires après la seconde ne comptent pas.",
+			},
+			damage: "40+",
+			cost: [
+				"Water",
+				"Water",
+				"Water",
+			],
 		},
-
-		effect: {
-			en: "Does 40 damage plus 10 more damage for each Water Energy attached to Blastoise but not used to pay for this attack's Energy cost. Extra Water Energy after the 2nd doesn't count.",
-			fr: "Cette attaque inflige 20 dégâts à chacun des Pokémon de Banc de votre adversaire. (N'appliquez ni la Faiblesse ni la Résistance aux Pokémon de Banc.)"
-		},
-
-		damage: "40+",
-		cost: ["Water", "Water", "Water"]
-	}],
+	],
 
 	weaknesses: [{
 		type: "Lightning",

--- a/data/Sword & Shield/Celebrations/4A.ts
+++ b/data/Sword & Shield/Celebrations/4A.ts
@@ -7,7 +7,7 @@ const card: Card = {
 
 	name: {
 		en: "Charizard",
-		fr: "Palkia"
+		fr: "Dracaufeu",
 	},
 
 	illustrator: "Mitsuhiro Arita",
@@ -17,20 +17,25 @@ const card: Card = {
 	types: ["Fire"],
 	stage: "Stage2",
 
-	attacks: [{
-		name: {
-			en: "Fire Spin",
-			fr: "Boost Atomisant"
+	attacks: [
+		{
+			name: {
+				en: "Fire Spin",
+				fr: "Danseflamme",
+			},
+			effect: {
+				en: "Discard 2 Energy cards attached to Charizard in order to use this attack.",
+				fr: "Défaussez 2 cartes Énergie attachées à Dracaufeu pour pouvoir utiliser cette attaque.",
+			},
+			damage: 100,
+			cost: [
+				"Fire",
+				"Fire",
+				"Fire",
+				"Fire",
+			],
 		},
-
-		effect: {
-			en: "Discard 2 Energy cards attached to Charizard in order to use this attack.",
-			fr: "Pendant votre prochain tour, l'attaque Boost Atomisant de ce Pokémon inflige 80 dégâts supplémentaires (avant application de la Faiblesse et de la Résistance)."
-		},
-
-		damage: 100,
-		cost: ["Fire", "Fire", "Fire", "Fire"]
-	}],
+	],
 
 	weaknesses: [{
 		type: "Water",

--- a/data/Sword & Shield/Celebrations/54A.ts
+++ b/data/Sword & Shield/Celebrations/54A.ts
@@ -6,7 +6,8 @@ const card: Card = {
 	set: Set,
 
 	name: {
-		en: "Mewtwo EX"
+		en: "Mewtwo EX",
+		fr: "Mewtwo-EX"
 	},
 
 	illustrator: "Shizurow",
@@ -19,22 +20,26 @@ const card: Card = {
 
 	attacks: [{
 		name: {
-			en: "X Ball"
+			en: "X Ball",
+			fr: "X Ball"
 		},
 
 		effect: {
-			en: "Does 20 damage times the amount of Energy attached to this Pokémon and the Defending Pokémon."
+			en: "Does 20 damage times the amount of Energy attached to this Pokémon and the Defending Pokémon.",
+			fr: "Inflige 20 dégâts multipliés par le nombre d'Énergies attachées à ce Pokémon et au Pokémon Défenseur."
 		},
 
 		damage: "20×",
 		cost: ["Colorless", "Colorless"]
 	}, {
 		name: {
-			en: "Psydrive"
+			en: "Psydrive",
+			fr: "Psykoforce"
 		},
 
 		effect: {
-			en: "Discard an Energy attached to this Pokémon."
+			en: "Discard an Energy attached to this Pokémon.",
+			fr: "Défaussez une Énergie attachées à ce Pokémon."
 		},
 
 		damage: 120,

--- a/data/Sword & Shield/Celebrations/60A.ts
+++ b/data/Sword & Shield/Celebrations/60A.ts
@@ -6,7 +6,8 @@ const card: Card = {
 	set: Set,
 
 	name: {
-		en: "Tapu Lele GX"
+		en: "Tapu Lele GX",
+		fr: "Tokopiyon-GX"
 	},
 
 	illustrator: "5ban Graphics",
@@ -21,32 +22,38 @@ const card: Card = {
 		type: "Ability",
 
 		name: {
-			en: "Wonder Tag"
+			en: "Wonder Tag",
+			fr: "Relais Miracle"
 		},
 
 		effect: {
-			en: "When you play this Pokémon from your hand onto your Bench during your turn, you may search your deck for a Supporter card, reveal it, and put it into your hand. Then, shuffle your deck."
+			en: "When you play this Pokémon from your hand onto your Bench during your turn, you may search your deck for a Supporter card, reveal it, and put it into your hand. Then, shuffle your deck.",
+			fr: "Lorsque vous jouez ce Pokémon de votre main sur votre Banc pendant votre tour, vous pouvez chercher une carte Supporter dans votre deck, la montrer et l'ajouter à votre main. Mélangez ensuite votre deck."
 		}
 	}],
 
 	attacks: [{
 		name: {
-			en: "Energy Drive"
+			en: "Energy Drive",
+			fr: "Propulsion d'Énergie"
 		},
 
 		effect: {
-			en: "This attack does 20 damage times the amount of Energy attached to both Active Pokémon. This damage isn't affected by Weakness or Resistance."
+			en: "This attack does 20 damage times the amount of Energy attached to both Active Pokémon. This damage isn't affected by Weakness or Resistance.",
+			fr: "Cette attaque inflige 20 dégâts multipliés par le nombre d'Énergies attachées aux deux Pokémon Actifs. Ces dégâts ne sont pas affectés par la Faiblesse ou la Résistance."
 		},
 
 		damage: "20×",
 		cost: ["Colorless", "Colorless"]
 	}, {
 		name: {
-			en: "Tapu Cure GX"
+			en: "Tapu Cure GX",
+			fr: "Toko Soins GX"
 		},
 
 		effect: {
-			en: "Heal all damage from 2 of your Benched Pokémon. (You can't use more than 1 GX attack in a game.)"
+			en: "Heal all damage from 2 of your Benched Pokémon. (You can't use more than 1 GX attack in a game.)",
+			fr: "Soignez tous les dégâts de 2 de vos Pokémon de Banc. (Vous ne pouvez utiliser qu'une attaque GX par partie.)"
 		},
 
 		cost: ["Psychic"]

--- a/data/Sword & Shield/Celebrations/66A.ts
+++ b/data/Sword & Shield/Celebrations/66A.ts
@@ -6,7 +6,8 @@ const card: Card = {
 	set: Set,
 
 	name: {
-		en: "Shining Magikarp"
+		en: "Shining Magikarp",
+		fr: "Magicarpe Brillant"
 	},
 
 	illustrator: "Ken Sugimori",
@@ -18,21 +19,25 @@ const card: Card = {
 
 	attacks: [{
 		name: {
-			en: "Gold Scale"
+			en: "Gold Scale",
+			fr: "Écaille d'or"
 		},
 
 		effect: {
-			en: "Your opponent may draw 2 cards. Either way, you may draw 2 cards."
+			en: "Your opponent may draw 2 cards. Either way, you may draw 2 cards.",
+			fr: "Votre adversaire peut piocher 2 cartes. Quoi qu'il décide, vous pouvez aussi piocher 2 cartes."
 		},
 
 		cost: ["Water"]
 	}, {
 		name: {
-			en: "Dragon Bond"
+			en: "Dragon Bond",
+			fr: "Lien du Dragon"
 		},
 
 		effect: {
-			en: "Search your deck for a card named Gyarados, Dark Gyarados, or Shining Gyarados. Show it to your opponent and put it into your hand. Shuffle your deck afterward."
+			en: "Search your deck for a card named Gyarados, Dark Gyarados, or Shining Gyarados. Show it to your opponent and put it into your hand. Shuffle your deck afterward.",
+			fr: "Cherchez une carte Léviator, Léviator Obscur ou Léviator Brillant dans votre deck. Montrez-la à votre adversaire et placez-la dans votre main. Mélangez ensuite votre deck."
 		},
 
 		cost: ["Psychic"]

--- a/data/Sword & Shield/Celebrations/73A.ts
+++ b/data/Sword & Shield/Celebrations/73A.ts
@@ -5,7 +5,8 @@ const card: Card = {
 	set: Set,
 
 	name: {
-		en: "Imposter Professor Oak"
+		en: "Imposter Professor Oak",
+		fr: "Faux Professeur Chen"
 	},
 
 	illustrator: "Ken Sugimori",
@@ -14,7 +15,8 @@ const card: Card = {
 	trainerType: "Supporter",
 
 	effect: {
-		en: "Your opponent shuffles his or her hand into his or her deck, then draws 7 cards."
+		en: "Your opponent shuffles his or her hand into his or her deck, then draws 7 cards.",
+		fr: "Votre adversaire mélange sa main avec son deck, puis pioche 7 cartes."
 	},
 
 	variants: {

--- a/data/Sword & Shield/Celebrations/76A.ts
+++ b/data/Sword & Shield/Celebrations/76A.ts
@@ -6,7 +6,8 @@ const card: Card = {
 	set: Set,
 
 	name: {
-		en: "M Rayquaza EX"
+		en: "M Rayquaza EX",
+		fr: "M-Rayquaza-EX"
 	},
 
 	illustrator: "5ban Graphics",
@@ -31,11 +32,13 @@ const card: Card = {
 
 	attacks: [{
 		name: {
-			en: "Emerald Break"
+			en: "Emerald Break",
+			fr: "Bris'Émeraude"
 		},
 
 		effect: {
-			en: "This attack does 30 damage times the number of your Benched Pokémon."
+			en: "This attack does 30 damage times the number of your Benched Pokémon.",
+			fr: "Cette attaque inflige 30 dégâts multipliés par le nombre de vos Pokémon de Banc."
 		},
 
 		damage: "30×",

--- a/data/Sword & Shield/Celebrations/86A.ts
+++ b/data/Sword & Shield/Celebrations/86A.ts
@@ -5,7 +5,8 @@ const card: Card = {
 	set: Set,
 
 	name: {
-		en: "Rocket's Admin."
+		en: "Rocket's Admin.",
+		fr: "Admin Rocket"
 	},
 
 	illustrator: "Ken Sugimori",
@@ -13,7 +14,8 @@ const card: Card = {
 	category: "Trainer",
 
 	effect: {
-		en: "Each player shuffles his or her hand into his or her deck. Then, each player counts his or her Prize cards left and draws up to that many cards. (You draw your cards first.)"
+		en: "Each player shuffles his or her hand into his or her deck. Then, each player counts his or her Prize cards left and draws up to that many cards. (You draw your cards first.)",
+		fr: "Chaque joueur mélange sa main avec son deck. Ensuite, chaque joueur compte ses cartes Récompenses restantes et pioche au maximum ce même nombre de cartes. (Vous piochez vos cartes en premier.)",
 	},
 
 	trainerType: "Supporter",

--- a/data/Sword & Shield/Celebrations/88A.ts
+++ b/data/Sword & Shield/Celebrations/88A.ts
@@ -6,7 +6,8 @@ const card: Card = {
 	set: Set,
 
 	name: {
-		en: "Mew ex"
+		en: "Mew ex",
+		fr: "Mew ex"
 	},
 
 	illustrator: "Ryo Ueda",
@@ -21,21 +22,25 @@ const card: Card = {
 		type: "Poke-BODY",
 
 		name: {
-			en: "Versatile"
+			en: "Versatile",
+			fr: "Polyvalent"
 		},
 
 		effect: {
-			en: "Mew ex can use the attacks of all Pokémon in play as its own. (You still need the necessary Energy to use each attack.)"
+			en: "Mew ex can use the attacks of all Pokémon in play as its own. (You still need the necessary Energy to use each attack.)",
+			fr: "Mew ex peut utiliser les attaques de tous les Pokémon en jeu à la place des siennes. (Vous devez toujours utiliser l'Énergie nécessaire pour chaque attaque.)"
 		}
 	}],
 
 	attacks: [{
 		name: {
-			en: "Power Move"
+			en: "Power Move",
+			fr: "Déplacement puissant"
 		},
 
 		effect: {
-			en: "Search your deck for an Energy card and attach it to Mew ex. Shuffle your deck afterward. Then, you may switch Mew ex with 1 of your Benched Pokémon."
+			en: "Search your deck for an Energy card and attach it to Mew ex. Shuffle your deck afterward. Then, you may switch Mew ex with 1 of your Benched Pokémon.",
+			fr: "Choisissez dans votre deck une carte Énergie et attachez-la à Mew ex. Ensuite, mélangez votre deck. Vous pouvez alors échanger Mew ex avec 1 des Pokémon de votre Banc."
 		},
 
 		cost: ["Psychic", "Colorless"]

--- a/data/Sword & Shield/Celebrations/8A.ts
+++ b/data/Sword & Shield/Celebrations/8A.ts
@@ -24,7 +24,8 @@ const card: Card = {
 		},
 
 		effect: {
-			en: "Flip a coin. If heads, the Defending Pokémon is now Paralyzed."
+			en: "Flip a coin. If heads, the Defending Pokémon is now Paralyzed.",
+			fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Paralysé."
 		},
 
 		damage: 30,

--- a/data/Sword & Shield/Celebrations/93A.ts
+++ b/data/Sword & Shield/Celebrations/93A.ts
@@ -6,7 +6,8 @@ const card: Card = {
 	set: Set,
 
 	name: {
-		en: "Gardevoir ex"
+		en: "Gardevoir ex",
+		fr: "Gardevoir ex δ"
 	},
 
 	illustrator: "Masahiko Ishii",
@@ -21,21 +22,25 @@ const card: Card = {
 		type: "Poke-POWER",
 
 		name: {
-			en: "Imprison"
+			en: "Imprison",
+			fr: "Possessif"
 		},
 
 		effect: {
-			en: "Once during your turn (before your attack), if Gardevoir ex is your Active Pokémon, you may put an Imprison marker on 1 of your opponent's Pokémon. Any Pokémon that has any Imprison markers on it can't use any Poké-Powers or Poké-Bodies. This power can't be used if Gardevoir ex is affected by a Special Condition."
+			en: "Once during your turn (before your attack), if Gardevoir ex is your Active Pokémon, you may put an Imprison marker on 1 of your opponent's Pokémon. Any Pokémon that has any Imprison markers on it can't use any Poké-Powers or Poké-Bodies. This power can't be used if Gardevoir ex is affected by a Special Condition.",
+			fr: "Une seule fois lors de votre tour (avant votre attaque), si Gardevoir ex est votre Pokémon Actif, vous pouvez placer 1 marqueur Possessif sur 1 des Pokémon de votre adversaire. Tout Pokémon possédant des marqueurs Possessif ne peut pas utiliser de Poké-Powers ou de Poké-Bodies. Ce pouvoir ne peut pas être utilisé si Gardevoir ex est affecté par un État Spécial."
 		}
 	}],
 
 	attacks: [{
 		name: {
-			en: "Flame Ball"
+			en: "Flame Ball",
+			fr: "Boule de feu"
 		},
 
 		effect: {
-			en: "You may move a Fire Energy card attached to Gardevoir ex to 1 of your Benched Pokémon."
+			en: "You may move a Fire Energy card attached to Gardevoir ex to 1 of your Benched Pokémon.",
+			fr: "Vous pouvez déplacer une carte Énergie  attachée à Gardevoir ex sur 1 des Pokémon de votre Banc."
 		},
 
 		damage: 80,

--- a/data/Sword & Shield/Celebrations/97A.ts
+++ b/data/Sword & Shield/Celebrations/97A.ts
@@ -6,7 +6,8 @@ const card: Card = {
 	set: Set,
 
 	name: {
-		en: "Xerneas EX"
+		en: "Xerneas EX",
+		fr: "Xerneas-EX"
 	},
 
 	illustrator: "5ban Graphics",
@@ -19,22 +20,26 @@ const card: Card = {
 
 	attacks: [{
 		name: {
-			en: "Break Through"
+			en: "Break Through",
+			fr: "Percée"
 		},
 
 		effect: {
-			en: "This attack does 30 damage to 1 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+			en: "This attack does 30 damage to 1 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)",
+			fr: "Cette attaque inflige 30 dégâts à l'un des Pokémon de Banc de votre adversaire. (N'appliquez ni la Faiblesse ni la Résistance aux Pokémon de Banc.)"
 		},
 
 		damage: 60,
 		cost: ["Fairy", "Colorless", "Colorless"]
 	}, {
 		name: {
-			en: "X Blast"
+			en: "X Blast",
+			fr: "Explosion X"
 		},
 
 		effect: {
-			en: "This Pokémon can't use X Blast during your next turn."
+			en: "This Pokémon can't use X Blast during your next turn.",
+			fr: "Ce Pokémon ne peut pas utiliser Explosion X pendant votre prochain tour."
 		},
 
 		damage: 140,

--- a/data/Sword & Shield/Celebrations/9A.ts
+++ b/data/Sword & Shield/Celebrations/9A.ts
@@ -21,38 +21,48 @@ const card: Card = {
 		type: "Poke-BODY",
 
 		name: {
-			en: "Power Saver"
+			en: "Power Saver",
+			fr: "Économisateur de puissance"
 		},
 
 		effect: {
-			en: "As long as the number of Pokémon in play (both yours and your opponent's) that has Team Magma in its name is 3 or less, Team Magma's Groudon can't attack."
+			en: "As long as the number of Pokémon in play (both yours and your opponent's) that has Team Magma in its name is 3 or less, Team Magma's Groudon can't attack.",
+			fr: "Tant que jusqu'à 3 Pokémon (les vôtres et ceux de votre adversaire) dont les noms comportent Team Magma sont en jeu, Groudon de Team Magma ne peut pas attaquer."
 		}
 	}],
 
-	attacks: [{
-		name: {
-			en: "Linear Attack",
-			fr: "Surfeuromax"
+	attacks: [
+		{
+			name: {
+				en: "Linear Attack",
+				fr: "Surfeuromax",
+			},
+			effect: {
+				en: "Choose 1 of your opponent's Pokémon. This attack does 20 damage to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)",
+				fr: "Cette attaque inflige aussi 30 dégâts à chacun des Pokémon de Banc de votre adversaire. (N'appliquez ni la Faiblesse ni la Résistance aux Pokémon de Banc.)",
+			},
+			cost: [
+				"Fighting",
+				"Colorless",
+			],
 		},
-
-		effect: {
-			en: "Choose 1 of your opponent's Pokémon. This attack does 20 damage to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)",
-			fr: "Cette attaque inflige aussi 30 dégâts à chacun des Pokémon de Banc de votre adversaire. (N'appliquez ni la Faiblesse ni la Résistance aux Pokémon de Banc.)"
+		{
+			name: {
+				en: "Pulverize",
+				fr: "Pulvériser",
+			},
+			effect: {
+				en: "If the Defending Pokémon already has at least 2 damage counters on it, this attack does 50 damage plus 20 more damage.",
+				fr: "Si le Pokémon Défenseur possède au moins 2 marqueurs de dégât, cette attaque inflige 50 dégâts plus 20 dégâts supplémentaires.",
+			},
+			damage: "50+",
+			cost: [
+				"Fighting",
+				"Fighting",
+				"Colorless",
+			],
 		},
-
-		cost: ["Fighting", "Colorless"]
-	}, {
-		name: {
-			en: "Pulverize"
-		},
-
-		effect: {
-			en: "If the Defending Pokémon already has at least 2 damage counters on it, this attack does 50 damage plus 20 more damage."
-		},
-
-		damage: "50+",
-		cost: ["Fighting", "Fighting", "Colorless"]
-	}],
+	],
 
 	weaknesses: [{
 		type: "Grass",


### PR DESCRIPTION
## Summary
- update Celebrations Classic Collection cards to align reprint identity mappings and localized text consistency
- include CEL25 correction pass across affected reprint files in `data/Sword & Shield/Celebrations`

## Test plan
- [x] `bun run validate`
- [x] `bun run --cwd server --bun validate`
- [x] `bun run --cwd server compile`
- [x] `cd .bruno && bru run --env Developpement` (67 requests, 118 assertions)