### PR TITLE
feat(data): add Japanese M4 (Ninja Spinner / ニンジャスピナー) set and cards

### DIFF
--- a/data-asia/M/M4.ts
+++ b/data-asia/M/M4.ts
@@ -1,0 +1,20 @@
+import { Set } from "../../interfaces";
+import serie from "../M";
+
+const set: Set = {
+	id: "M4",
+	name: {
+		ja: "ニンジャスピナー",
+	},
+
+	serie: serie,
+
+	cardCount: {
+		official: 120,
+	},
+	releaseDate: {
+		ja: "2026-03-13",
+	},
+};
+
+export default set;

--- a/data-asia/M/M4/001.ts
+++ b/data-asia/M/M4/001.ts
@@ -1,0 +1,43 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ビードル",
+	},
+
+	illustrator: "sowsow",
+	category: "Pokemon",
+	hp: 50,
+	types: ["Grass"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ふいをつく" },
+			damage: 30,
+			cost: ["Grass"],
+			effect: {
+				ja: "コインを1回投げ、ウラなら、このワザは失敗。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [{ type: "normal" }, { type: "reverse", foil: "pokeball" }, { type: "reverse", foil: "masterball" }],
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "Common",
+	dexId: [13],
+};
+
+export default card;

--- a/data-asia/M/M4/002.ts
+++ b/data-asia/M/M4/002.ts
@@ -1,0 +1,54 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "コクーン",
+	},
+
+	illustrator: "Mugi Hamada",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Grass"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "かたいからだ" },
+			effect: {
+				ja: "このポケモンが受けるワザのダメージは「20」少なくなる。（弱点・抵抗力を計算した後に適用する。）",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ぶらさがる" },
+			damage: 20,
+			cost: ["Grass"],
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	evolveFrom: {
+		ja: "ビードル",
+	},
+
+	variants: [{ type: "normal" }, { type: "reverse", foil: "pokeball" }, { type: "reverse", foil: "masterball" }],
+
+	retreat: 3,
+	regulationMark: "I",
+	rarity: "Common",
+	dexId: [14],
+};
+
+export default card;

--- a/data-asia/M/M4/003.ts
+++ b/data-asia/M/M4/003.ts
@@ -1,0 +1,49 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "スピアーex",
+	},
+
+	illustrator: "toriyufu",
+	category: "Pokemon",
+	hp: 310,
+	types: ["Grass"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Stage2",
+
+	attacks: [
+		{
+			name: { ja: "ビーランブル" },
+			damage: "110x",
+			cost: ["Grass"],
+			effect: {
+				ja: "このワザのダメージは、自分の場にいる名前に「スピアー」のつくポケモンの数×110。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	evolveFrom: {
+		ja: "コクーン",
+	},
+
+	variants: [{ type: "holo" }],
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "Double rare",
+	dexId: [15],
+
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/M/M4/004.ts
+++ b/data-asia/M/M4/004.ts
@@ -1,0 +1,43 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "マスキッパ",
+	},
+
+	illustrator: "Heisuke Kitazawa",
+	category: "Pokemon",
+	hp: 110,
+	types: ["Grass"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "まるかじり" },
+			damage: "80+",
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "このワザのダメージは、相手のバトルポケモンの逃げるコスト「エネルギー1個」につき「80」多くなる。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [{ type: "normal" }, { type: "reverse", foil: "pokeball" }, { type: "reverse", foil: "masterball" }],
+
+	retreat: 2,
+	regulationMark: "I",
+	rarity: "Common",
+	dexId: [455],
+};
+
+export default card;

--- a/data-asia/M/M4/005.ts
+++ b/data-asia/M/M4/005.ts
@@ -1,0 +1,45 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ハリマロン",
+	},
+
+	illustrator: "HACCAN",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Grass"],
+
+	description: {
+		ja: "普段 やわらかい 頭の トゲは 力を こめると 鋭く 尖り 岩をも つらぬくほど 硬くなる。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "たたく" },
+			damage: 10,
+			cost: ["Grass"],
+		},
+		{
+			name: { ja: "トゲでさす" },
+			damage: 30,
+			cost: ["Grass", "Grass"],
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [{ type: "normal" }, { type: "reverse", foil: "pokeball" }, { type: "reverse", foil: "masterball" }],
+
+	retreat: 2,
+	regulationMark: "I",
+	rarity: "Common",
+	dexId: [650],
+};
+
+export default card;

--- a/data-asia/M/M4/006.ts
+++ b/data-asia/M/M4/006.ts
@@ -1,0 +1,52 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ハリボーグ",
+	},
+
+	illustrator: "Hideki Ishikawa",
+	category: "Pokemon",
+	hp: 100,
+	types: ["Grass"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "リーフチャージ" },
+			damage: 20,
+			cost: ["Grass"],
+			effect: {
+				ja: "自分の山札から基本草エネルギーを1枚選び、このポケモンにつける。そして山札を切る。",
+			},
+		},
+		{
+			name: { ja: "つるのムチ" },
+			damage: 80,
+			cost: ["Grass", "Grass", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	evolveFrom: {
+		ja: "ハリマロン",
+	},
+
+	variants: [{ type: "normal" }, { type: "reverse", foil: "pokeball" }, { type: "reverse", foil: "masterball" }],
+
+	retreat: 3,
+	regulationMark: "I",
+	rarity: "Common",
+	dexId: [651],
+};
+
+export default card;

--- a/data-asia/M/M4/007.ts
+++ b/data-asia/M/M4/007.ts
@@ -1,0 +1,57 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ブリガロン",
+	},
+
+	illustrator: "Uta",
+	category: "Pokemon",
+	hp: 180,
+	types: ["Grass"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Stage2",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ニードルアーマー" },
+			effect: {
+				ja: "相手のポケモンのワザによるダメージを受けたとき、このポケモンについている草エネルギー1個につき、ワザを使ったポケモンにダメージカウンターを3個のせる。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "かこいこむ" },
+			damage: 160,
+			cost: ["Grass", "Grass", "Colorless"],
+			effect: {
+				ja: "次の相手の番、このワザを受けたポケモンは、にげられない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	evolveFrom: {
+		ja: "ハリボーグ",
+	},
+
+	variants: [{ type: "holo" }, { type: "reverse", foil: "pokeball" }, { type: "reverse", foil: "masterball" }],
+
+	retreat: 4,
+	regulationMark: "I",
+	rarity: "Rare",
+	dexId: [652],
+};
+
+export default card;

--- a/data-asia/M/M4/008.ts
+++ b/data-asia/M/M4/008.ts
@@ -1,0 +1,42 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ロコン",
+	},
+
+	illustrator: "Yoshimoto Yoshimon",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Fire"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "こがす" },
+			cost: ["Fire"],
+			effect: {
+				ja: "相手のバトルポケモンをやけどにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [{ type: "normal" }, { type: "reverse", foil: "pokeball" }, { type: "reverse", foil: "masterball" }],
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "Common",
+	dexId: [37],
+};
+
+export default card;

--- a/data-asia/M/M4/009.ts
+++ b/data-asia/M/M4/009.ts
@@ -1,0 +1,51 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "キュウコン",
+	},
+
+	illustrator: "Ryuta Fuse",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Fire"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "きゅうびうつし" },
+			cost: ["Fire"],
+			effect: {
+				ja: "自分のベンチポケモン1匹にのっているダメージカウンターを全部、相手のバトルポケモンに移す。",
+			},
+		},
+		{
+			name: { ja: "おにび" },
+			damage: 70,
+			cost: ["Fire", "Fire"],
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	evolveFrom: {
+		ja: "ロコン",
+	},
+
+	variants: [{ type: "normal" }, { type: "reverse", foil: "pokeball" }, { type: "reverse", foil: "masterball" }],
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "Uncommon",
+	dexId: [38],
+};
+
+export default card;

--- a/data-asia/M/M4/010.ts
+++ b/data-asia/M/M4/010.ts
@@ -1,0 +1,53 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ホウオウ",
+	},
+
+	illustrator: "Takumi Wada",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Fire"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "さいきのほのお" },
+			effect: {
+				ja: "自分の番に1回使える。自分の手札から基本炎エネルギーを1枚トラッシュする。そして自分のトラッシュからたねポケモンを3枚まで選び、ベンチに出す。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ぐれんのつばさ" },
+			damage: 130,
+			cost: ["Fire", "Fire", "Fire"],
+			effect: {
+				ja: "このポケモンについているエネルギーを1個トラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [{ type: "normal" }, { type: "reverse", foil: "pokeball" }, { type: "reverse", foil: "masterball" }],
+
+	retreat: 2,
+	regulationMark: "I",
+	rarity: "Uncommon",
+	dexId: [250],
+};
+
+export default card;

--- a/data-asia/M/M4/011.ts
+++ b/data-asia/M/M4/011.ts
@@ -1,0 +1,47 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "フォッコ",
+	},
+
+	illustrator: "saino misaki",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Fire"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "なかまをよぶ" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札からたねポケモンを2枚まで選び、ベンチに出す。そして山札を切る。",
+			},
+		},
+		{
+			name: { ja: "ひをはく" },
+			damage: 10,
+			cost: ["Fire"],
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [{ type: "normal" }, { type: "reverse", foil: "pokeball" }, { type: "reverse", foil: "masterball" }],
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "Common",
+	dexId: [653],
+};
+
+export default card;

--- a/data-asia/M/M4/012.ts
+++ b/data-asia/M/M4/012.ts
@@ -1,0 +1,47 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "テールナー",
+	},
+
+	illustrator: "Taiga Kasai",
+	category: "Pokemon",
+	hp: 100,
+	types: ["Fire"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "かえんほうしゃ" },
+			damage: 80,
+			cost: ["Fire", "Fire"],
+			effect: {
+				ja: "このポケモンについているエネルギーを1個トラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	evolveFrom: {
+		ja: "フォッコ",
+	},
+
+	variants: [{ type: "normal" }, { type: "reverse", foil: "pokeball" }, { type: "reverse", foil: "masterball" }],
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "Common",
+	dexId: [654],
+};
+
+export default card;

--- a/data-asia/M/M4/013.ts
+++ b/data-asia/M/M4/013.ts
@@ -1,0 +1,57 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "マフォクシー",
+	},
+
+	illustrator: "Gemi",
+	category: "Pokemon",
+	hp: 160,
+	types: ["Fire"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Stage2",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "フレアマジック" },
+			effect: {
+				ja: "自分の番に1回使える。自分の手札から基本炎エネルギーを1枚トラッシュする。そして自分の手札が7枚になるようにカードを引く。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "エナジーストーム" },
+			damage: "30x",
+			cost: ["Fire", "Fire"],
+			effect: {
+				ja: "このワザのダメージは、おたがいのポケモン全員についているエネルギーの合計数×30。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	evolveFrom: {
+		ja: "テールナー",
+	},
+
+	variants: [{ type: "holo" }, { type: "reverse", foil: "pokeball" }, { type: "reverse", foil: "masterball" }],
+
+	retreat: 2,
+	regulationMark: "I",
+	rarity: "Rare",
+	dexId: [655],
+};
+
+export default card;

--- a/data-asia/M/M4/014.ts
+++ b/data-asia/M/M4/014.ts
@@ -1,0 +1,40 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "シシコ",
+	},
+
+	illustrator: "Mina Nakai",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Fire"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "たいあたり" },
+			damage: 10,
+			cost: ["Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [{ type: "normal" }, { type: "reverse", foil: "pokeball" }, { type: "reverse", foil: "masterball" }],
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "Common",
+	dexId: [667],
+};
+
+export default card;

--- a/data-asia/M/M4/015.ts
+++ b/data-asia/M/M4/015.ts
@@ -1,0 +1,57 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "メガカエンジシex",
+	},
+
+	illustrator: "Keisuke Azuma",
+	category: "Pokemon",
+	hp: 340,
+	types: ["Fire"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "ほえたてる" },
+			damage: 80,
+			cost: ["Fire", "Colorless"],
+			effect: {
+				ja: "次の相手の番、このワザを受けたポケモンのワザのダメージは「50」少なくなる。",
+			},
+		},
+		{
+			name: { ja: "ビッグバンファイヤー" },
+			damage: "290-",
+			cost: ["Fire", "Fire", "Colorless"],
+			effect: {
+				ja: "このポケモンにのっているダメージカウンター1個につき、このワザのダメージは「10」少なくなる。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	evolveFrom: {
+		ja: "シシコ",
+	},
+
+	variants: [{ type: "holo" }],
+
+	retreat: 2,
+	regulationMark: "I",
+	rarity: "Double rare",
+	dexId: [668],
+
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/M/M4/016.ts
+++ b/data-asia/M/M4/016.ts
@@ -1,0 +1,40 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "テッポウオ",
+	},
+
+	illustrator: "Mori Yuu",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Water"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "するどいひれ" },
+			damage: 20,
+			cost: ["Water"],
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
+
+	variants: [{ type: "normal" }, { type: "reverse", foil: "pokeball" }, { type: "reverse", foil: "masterball" }],
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "Common",
+	dexId: [223],
+};
+
+export default card;

--- a/data-asia/M/M4/017.ts
+++ b/data-asia/M/M4/017.ts
@@ -1,0 +1,55 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "オクタン",
+	},
+
+	illustrator: "Matazo",
+	category: "Pokemon",
+	hp: 110,
+	types: ["Water"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "すみふんしゃ" },
+			damage: 30,
+			cost: ["Water"],
+			effect: {
+				ja: "次の相手の番、このワザを受けたポケモンの持ち主がワザを使おうとするとき、コインを2回投げ、2回ともウラなら、そのワザは失敗。",
+			},
+		},
+		{
+			name: { ja: "あばれまわる" },
+			damage: 120,
+			cost: ["Water", "Colorless"],
+			effect: {
+				ja: "このポケモンはこんらんになる。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
+
+	evolveFrom: {
+		ja: "テッポウオ",
+	},
+
+	variants: [{ type: "normal" }, { type: "reverse", foil: "pokeball" }, { type: "reverse", foil: "masterball" }],
+
+	retreat: 2,
+	regulationMark: "I",
+	rarity: "Common",
+	dexId: [224],
+};
+
+export default card;

--- a/data-asia/M/M4/018.ts
+++ b/data-asia/M/M4/018.ts
@@ -1,0 +1,47 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "デリバード",
+	},
+
+	illustrator: "Saboteri",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Water"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ハッピープレゼント" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "おたがいのプレイヤーは、それぞれ手札から基本エネルギーを3枚まで選び、自分のポケモンに好きなようにつけてよい。",
+			},
+		},
+		{
+			name: { ja: "はばたく" },
+			damage: 40,
+			cost: ["Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [{ type: "normal" }, { type: "reverse", foil: "pokeball" }, { type: "reverse", foil: "masterball" }],
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "Uncommon",
+	dexId: [225],
+};
+
+export default card;

--- a/data-asia/M/M4/019.ts
+++ b/data-asia/M/M4/019.ts
@@ -1,0 +1,51 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ケルディオ",
+	},
+
+	illustrator: "Mitsuhiro Arita",
+	category: "Pokemon",
+	hp: 110,
+	types: ["Water"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "つきぬける" },
+			damage: 20,
+			cost: ["Water"],
+			effect: {
+				ja: "相手のベンチポケモン1匹にも20ダメージ。",
+			},
+		},
+		{
+			name: { ja: "エネリフレクト" },
+			damage: 70,
+			cost: ["Water", "Water"],
+			effect: {
+				ja: "このポケモンについているエネルギーを1個、自分のベンチポケモン1匹に移す。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
+
+	variants: [{ type: "normal" }, { type: "reverse", foil: "pokeball" }, { type: "reverse", foil: "masterball" }],
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "Uncommon",
+	dexId: [647],
+};
+
+export default card;

--- a/data-asia/M/M4/020.ts
+++ b/data-asia/M/M4/020.ts
@@ -1,0 +1,47 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ケロマツ",
+	},
+
+	illustrator: "Kariya",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Water"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "もってくる" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "カードを1枚引く。",
+			},
+		},
+		{
+			name: { ja: "みずでっぽう" },
+			damage: 10,
+			cost: ["Water"],
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
+
+	variants: [{ type: "normal" }, { type: "reverse", foil: "pokeball" }, { type: "reverse", foil: "masterball" }],
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "Common",
+	dexId: [656],
+};
+
+export default card;

--- a/data-asia/M/M4/021.ts
+++ b/data-asia/M/M4/021.ts
@@ -1,0 +1,51 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ゲコガシラ",
+	},
+
+	illustrator: "Nelnal",
+	category: "Pokemon",
+	hp: 100,
+	types: ["Water"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "よびよせじゅつ" },
+			cost: ["Water"],
+			effect: {
+				ja: "自分の山札からポケモンを3枚まで選び、手札に加える。そして山札を切る。",
+			},
+		},
+		{
+			name: { ja: "アクアエッジ" },
+			damage: 50,
+			cost: ["Water", "Water"],
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
+
+	evolveFrom: {
+		ja: "ケロマツ",
+	},
+
+	variants: [{ type: "normal" }, { type: "reverse", foil: "pokeball" }, { type: "reverse", foil: "masterball" }],
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "Common",
+	dexId: [657],
+};
+
+export default card;

--- a/data-asia/M/M4/022.ts
+++ b/data-asia/M/M4/022.ts
@@ -1,0 +1,59 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "メガゲッコウガex",
+	},
+
+	illustrator: "takuyoa",
+	category: "Pokemon",
+	hp: 350,
+	types: ["Water"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Stage2",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ひっさつしゅりけん" },
+			effect: {
+				ja: "自分の番に1回、このポケモンがバトル場にいるとき使える。自分の手札から基本水エネルギーを1枚トラッシュする。そして相手のポケモンにダメージカウンターを合計6個、好きなように置く。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ニンジャスピナー" },
+			damage: "120+",
+			cost: ["Water", "Water"],
+			effect: {
+				ja: "このポケモンについている水エネルギーを1個手札に戻してよい。そうした場合、このワザのダメージは「80」多くなる。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
+
+	evolveFrom: {
+		ja: "ゲコガシラ",
+	},
+
+	variants: [{ type: "holo" }],
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "Double rare",
+	dexId: [658],
+
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/M/M4/023.ts
+++ b/data-asia/M/M4/023.ts
@@ -1,0 +1,45 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "カチコール",
+	},
+
+	illustrator: "Anesaki Dynamic",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Water"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ひんやり" },
+			damage: 10,
+			cost: ["Water"],
+		},
+		{
+			name: { ja: "こおりのいぶき" },
+			damage: 50,
+			cost: ["Water", "Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [{ type: "normal" }, { type: "reverse", foil: "pokeball" }, { type: "reverse", foil: "masterball" }],
+
+	retreat: 2,
+	regulationMark: "I",
+	rarity: "Common",
+	dexId: [712],
+};
+
+export default card;

--- a/data-asia/M/M4/024.ts
+++ b/data-asia/M/M4/024.ts
@@ -1,0 +1,52 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "クレベース",
+	},
+
+	illustrator: "Tomoki Sone",
+	category: "Pokemon",
+	hp: 160,
+	types: ["Water"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "ひょうざんくずし" },
+			damage: "60x",
+			cost: ["Water"],
+			effect: {
+				ja: "自分の山札の上から6枚トラッシュする。トラッシュした基本水エネルギーの数×60ダメージ。",
+			},
+		},
+		{
+			name: { ja: "フロストスタンプ" },
+			damage: 160,
+			cost: ["Water", "Water", "Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	evolveFrom: {
+		ja: "カチコール",
+	},
+
+	variants: [{ type: "normal" }, { type: "reverse", foil: "pokeball" }, { type: "reverse", foil: "masterball" }],
+
+	retreat: 4,
+	regulationMark: "I",
+	rarity: "Uncommon",
+	dexId: [713],
+};
+
+export default card;

--- a/data-asia/M/M4/025.ts
+++ b/data-asia/M/M4/025.ts
@@ -1,0 +1,45 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "コソクムシ",
+	},
+
+	illustrator: "0313",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Water"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "かじる" },
+			damage: 10,
+			cost: ["Water"],
+		},
+		{
+			name: { ja: "どつく" },
+			damage: 20,
+			cost: ["Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
+
+	variants: [{ type: "normal" }, { type: "reverse", foil: "pokeball" }, { type: "reverse", foil: "masterball" }],
+
+	retreat: 2,
+	regulationMark: "I",
+	rarity: "Common",
+	dexId: [767],
+};
+
+export default card;

--- a/data-asia/M/M4/026.ts
+++ b/data-asia/M/M4/026.ts
@@ -1,0 +1,55 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "グソクムシャ",
+	},
+
+	illustrator: "Takeshi Nakamura",
+	category: "Pokemon",
+	hp: 140,
+	types: ["Water"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "きゅうしょぎり" },
+			damage: 30,
+			cost: ["Water"],
+			effect: {
+				ja: "このワザでバトルポケモンがきぜつさせられたとき、次の相手の番、このポケモンはワザのダメージを受けない。",
+			},
+		},
+		{
+			name: { ja: "そこぢから" },
+			damage: 150,
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "次の自分の番、このポケモンはワザを使えない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
+
+	evolveFrom: {
+		ja: "コソクムシ",
+	},
+
+	variants: [{ type: "normal" }, { type: "reverse", foil: "pokeball" }, { type: "reverse", foil: "masterball" }],
+
+	retreat: 2,
+	regulationMark: "I",
+	rarity: "Uncommon",
+	dexId: [768],
+};
+
+export default card;

--- a/data-asia/M/M4/027.ts
+++ b/data-asia/M/M4/027.ts
@@ -1,0 +1,43 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "メリープ",
+	},
+
+	illustrator: "UKUMO uiti",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Lightning"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "でんじは" },
+			damage: 20,
+			cost: ["Lightning", "Colorless"],
+			effect: {
+				ja: "コインを1回投げ、オモテなら、相手のバトルポケモンをマヒにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [{ type: "normal" }, { type: "reverse", foil: "pokeball" }, { type: "reverse", foil: "masterball" }],
+
+	retreat: 2,
+	regulationMark: "I",
+	rarity: "Common",
+	dexId: [179],
+};
+
+export default card;

--- a/data-asia/M/M4/028.ts
+++ b/data-asia/M/M4/028.ts
@@ -1,0 +1,47 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "モココ",
+	},
+
+	illustrator: "miki kudo",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Lightning"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "でんじしょうがい" },
+			damage: 40,
+			cost: ["Lightning", "Colorless"],
+			effect: {
+				ja: "次の相手の番、相手は手札からグッズを使えない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	evolveFrom: {
+		ja: "メリープ",
+	},
+
+	variants: [{ type: "normal" }, { type: "reverse", foil: "pokeball" }, { type: "reverse", foil: "masterball" }],
+
+	retreat: 2,
+	regulationMark: "I",
+	rarity: "Common",
+	dexId: [180],
+};
+
+export default card;

--- a/data-asia/M/M4/029.ts
+++ b/data-asia/M/M4/029.ts
@@ -1,0 +1,57 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "デンリュウ",
+	},
+
+	illustrator: "CHORISO",
+	category: "Pokemon",
+	hp: 160,
+	types: ["Lightning"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Stage2",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "シンクロパルス" },
+			effect: {
+				ja: "自分の手札の枚数と相手の手札の枚数が同じなら、このポケモンのワザのダメージは「80」多くなる。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "フラッシュボルト" },
+			damage: 140,
+			cost: ["Lightning", "Colorless"],
+			effect: {
+				ja: "次の自分の番、このポケモンは「フラッシュボルト」を使えない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	evolveFrom: {
+		ja: "モココ",
+	},
+
+	variants: [{ type: "holo" }, { type: "reverse", foil: "pokeball" }, { type: "reverse", foil: "masterball" }],
+
+	retreat: 2,
+	regulationMark: "I",
+	rarity: "Rare",
+	dexId: [181],
+};
+
+export default card;

--- a/data-asia/M/M4/030.ts
+++ b/data-asia/M/M4/030.ts
@@ -1,0 +1,50 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "エモンガ",
+	},
+
+	illustrator: "Kazumasa Yasukuni",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Lightning"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ちいさなおつかい" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札から基本エネルギーを2枚まで選び、手札に加える。そして山札を切る。",
+			},
+		},
+		{
+			name: { ja: "スカイリターン" },
+			damage: 30,
+			cost: ["Lightning"],
+			effect: {
+				ja: "このポケモンとついているカードを全て手札に戻す。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [{ type: "normal" }, { type: "reverse", foil: "pokeball" }, { type: "reverse", foil: "masterball" }],
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "Common",
+	dexId: [587],
+};
+
+export default card;

--- a/data-asia/M/M4/031.ts
+++ b/data-asia/M/M4/031.ts
@@ -1,0 +1,50 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "デオキシス",
+	},
+
+	illustrator: "Shiburingaru",
+	category: "Pokemon",
+	hp: 110,
+	types: ["Psychic"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ゲノムチャージ" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札から基本サイコエネルギーを2枚まで選び、このポケモンにつける。そして山札を切る。",
+			},
+		},
+		{
+			name: { ja: "サイコキネシス" },
+			damage: "80+",
+			cost: ["Psychic", "Psychic", "Colorless"],
+			effect: {
+				ja: "このワザのダメージは、相手のバトルポケモンについているエネルギーの数×20多くなる。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [{ type: "normal" }, { type: "reverse", foil: "pokeball" }, { type: "reverse", foil: "masterball" }],
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "Uncommon",
+	dexId: [386],
+};
+
+export default card;

--- a/data-asia/M/M4/032.ts
+++ b/data-asia/M/M4/032.ts
@@ -1,0 +1,43 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "デオキシス",
+	},
+
+	illustrator: "nagimiso",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Psychic"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "サイコスピア" },
+			damage: 120,
+			cost: ["Psychic", "Psychic", "Psychic"],
+			effect: {
+				ja: "このポケモンについているエネルギーがこのワザのコストより2個以上多い場合、相手のベンチポケモン1匹にも120ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [{ type: "normal" }, { type: "reverse", foil: "pokeball" }, { type: "reverse", foil: "masterball" }],
+
+	retreat: 2,
+	regulationMark: "I",
+	rarity: "Uncommon",
+	dexId: [386],
+};
+
+export default card;

--- a/data-asia/M/M4/033.ts
+++ b/data-asia/M/M4/033.ts
@@ -1,0 +1,43 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "デオキシス",
+	},
+
+	illustrator: "GOSSAN",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Psychic"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "サイコプロテクト" },
+			damage: 80,
+			cost: ["Psychic", "Psychic", "Colorless"],
+			effect: {
+				ja: "次の相手の番、特性を持つ相手のポケモンのワザのダメージを受けない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [{ type: "normal" }, { type: "reverse", foil: "pokeball" }, { type: "reverse", foil: "masterball" }],
+
+	retreat: 3,
+	regulationMark: "I",
+	rarity: "Uncommon",
+	dexId: [386],
+};
+
+export default card;

--- a/data-asia/M/M4/034.ts
+++ b/data-asia/M/M4/034.ts
@@ -1,0 +1,43 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "デオキシス",
+	},
+
+	illustrator: "hncl",
+	category: "Pokemon",
+	hp: 100,
+	types: ["Psychic"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "サイコスピード" },
+			damage: 30,
+			cost: ["Psychic"],
+			effect: {
+				ja: "自分の手札が5枚になるようにカードを引く。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [{ type: "normal" }, { type: "reverse", foil: "pokeball" }, { type: "reverse", foil: "masterball" }],
+
+	retreat: 0,
+	regulationMark: "I",
+	rarity: "Uncommon",
+	dexId: [386],
+};
+
+export default card;

--- a/data-asia/M/M4/035.ts
+++ b/data-asia/M/M4/035.ts
@@ -1,0 +1,52 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "メガフラエッテex",
+	},
+
+	illustrator: "aky CG Works",
+	category: "Pokemon",
+	hp: 250,
+	types: ["Psychic"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "やさしいひかり" },
+			cost: ["Psychic"],
+			effect: {
+				ja: "おたがいのポケモン全員のダメージを「30」ずつ回復する。",
+			},
+		},
+		{
+			name: { ja: "エタニティブルーム" },
+			damage: 200,
+			cost: ["Psychic", "Psychic", "Psychic"],
+			effect: {
+				ja: "自分の山札から基本サイコエネルギーを4枚まで選び、自分のベンチポケモンに好きなようにつける。そして山札を切る。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [{ type: "holo" }],
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "Double rare",
+	dexId: [670],
+
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/M/M4/036.ts
+++ b/data-asia/M/M4/036.ts
@@ -1,0 +1,43 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ニャスパー",
+	},
+
+	illustrator: "sowsow",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Psychic"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "バディアタック" },
+			damage: "10+",
+			cost: ["Psychic"],
+			effect: {
+				ja: "この番、自分の手札からマチエールが使われているなら、このワザのダメージは「60」多くなる。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [{ type: "normal" }, { type: "reverse", foil: "pokeball" }, { type: "reverse", foil: "masterball" }],
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "Common",
+	dexId: [677],
+};
+
+export default card;

--- a/data-asia/M/M4/037.ts
+++ b/data-asia/M/M4/037.ts
@@ -1,0 +1,47 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ニャオニクス",
+	},
+
+	illustrator: "mingo",
+	category: "Pokemon",
+	hp: 100,
+	types: ["Psychic"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "トリックステップ" },
+			damage: 80,
+			cost: ["Psychic", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンについているエネルギーを1個選び、相手のベンチポケモン1匹に移す。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	evolveFrom: {
+		ja: "ニャスパー",
+	},
+
+	variants: [{ type: "normal" }, { type: "reverse", foil: "pokeball" }, { type: "reverse", foil: "masterball" }],
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "Uncommon",
+	dexId: [678],
+};
+
+export default card;

--- a/data-asia/M/M4/038.ts
+++ b/data-asia/M/M4/038.ts
@@ -1,0 +1,50 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ボクレー",
+	},
+
+	illustrator: "Taiga Kasai",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Psychic"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "うらみしんか" },
+			effect: {
+				ja: "自分の番に1回使える。自分の手札から、このポケモンに進化するカードを1枚選び、このポケモンの上に重ねる。この特性でしんかしたなら、このポケモンにダメージカウンターを2個のせる。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "つぶやく" },
+			damage: 10,
+			cost: ["Psychic"],
+		},
+	],
+
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [{ type: "normal" }, { type: "reverse", foil: "pokeball" }, { type: "reverse", foil: "masterball" }],
+
+	retreat: 2,
+	regulationMark: "I",
+	rarity: "Common",
+	dexId: [708],
+};
+
+export default card;

--- a/data-asia/M/M4/039.ts
+++ b/data-asia/M/M4/039.ts
@@ -1,0 +1,55 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "オーロット",
+	},
+
+	illustrator: "Uninori",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Psychic"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "のろいのねっこ" },
+			damage: 30,
+			cost: ["Psychic"],
+			effect: {
+				ja: "次の相手の番、このワザを受けたポケモンの持ち主は手札からエネルギーをつけられない。",
+			},
+		},
+		{
+			name: { ja: "オーバーペイン" },
+			damage: "60+",
+			cost: ["Psychic", "Psychic"],
+			effect: {
+				ja: "このワザのダメージは、相手のバトルポケモンにのっているダメージカウンター1個につき「10」多くなる。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	evolveFrom: {
+		ja: "ボクレー",
+	},
+
+	variants: [{ type: "holo" }, { type: "reverse", foil: "pokeball" }, { type: "reverse", foil: "masterball" }],
+
+	retreat: 3,
+	regulationMark: "I",
+	rarity: "Rare",
+	dexId: [709],
+};
+
+export default card;

--- a/data-asia/M/M4/040.ts
+++ b/data-asia/M/M4/040.ts
@@ -1,0 +1,40 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "バケッチャ",
+	},
+
+	illustrator: "Jerky",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Psychic"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ふむ" },
+			damage: 20,
+			cost: ["Psychic"],
+		},
+	],
+
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [{ type: "normal" }, { type: "reverse", foil: "pokeball" }, { type: "reverse", foil: "masterball" }],
+
+	retreat: 2,
+	regulationMark: "I",
+	rarity: "Common",
+	dexId: [710],
+};
+
+export default card;

--- a/data-asia/M/M4/041.ts
+++ b/data-asia/M/M4/041.ts
@@ -1,0 +1,57 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "パンプジンex",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 270,
+	types: ["Psychic"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "ホラーロンド" },
+			damage: "30+",
+			cost: ["Psychic"],
+			effect: {
+				ja: "このワザのダメージは、相手のベンチポケモンにのっているダメージカウンターの合計×50多くなる。",
+			},
+		},
+		{
+			name: { ja: "ゴーストタッチ" },
+			damage: 140,
+			cost: ["Psychic", "Psychic"],
+			effect: {
+				ja: "相手の手札をランダムに1枚選んでトラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	evolveFrom: {
+		ja: "バケッチャ",
+	},
+
+	variants: [{ type: "holo" }],
+
+	retreat: 2,
+	regulationMark: "I",
+	rarity: "Double rare",
+	dexId: [711],
+
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/M/M4/042.ts
+++ b/data-asia/M/M4/042.ts
@@ -1,0 +1,43 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ゼルネアス",
+	},
+
+	illustrator: "KEIICHIRO ITO",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Psychic"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ジオストーム" },
+			damage: "30x",
+			cost: ["Psychic", "Psychic", "Psychic"],
+			effect: {
+				ja: "このワザのダメージは、自分のポケモン全員についているサイコエネルギーの合計数×30。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [{ type: "holo" }, { type: "reverse", foil: "pokeball" }, { type: "reverse", foil: "masterball" }],
+
+	retreat: 2,
+	regulationMark: "I",
+	rarity: "Rare",
+	dexId: [716],
+};
+
+export default card;

--- a/data-asia/M/M4/043.ts
+++ b/data-asia/M/M4/043.ts
@@ -1,0 +1,50 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ウソッキー",
+	},
+
+	illustrator: "GOTO minori",
+	category: "Pokemon",
+	hp: 110,
+	types: ["Fighting"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "しれんのたび" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札から「へんかのしょ」を2枚まで選び、相手に見せてから手札に加える。そして山札を切る。",
+			},
+		},
+		{
+			name: { ja: "いわとばし" },
+			damage: 30,
+			cost: ["Fighting"],
+			effect: {
+				ja: "このワザのダメージは、相手の抵抗力の影響を受けない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [{ type: "normal" }, { type: "reverse", foil: "pokeball" }, { type: "reverse", foil: "masterball" }],
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "Uncommon",
+	dexId: [185],
+};
+
+export default card;

--- a/data-asia/M/M4/044.ts
+++ b/data-asia/M/M4/044.ts
@@ -1,0 +1,45 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ゴマゾウ",
+	},
+
+	illustrator: "Akino Fukuji",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Fighting"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "どろかけ" },
+			damage: 10,
+			cost: ["Fighting"],
+		},
+		{
+			name: { ja: "ころがる" },
+			damage: 40,
+			cost: ["Colorless", "Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [{ type: "normal" }, { type: "reverse", foil: "pokeball" }, { type: "reverse", foil: "masterball" }],
+
+	retreat: 2,
+	regulationMark: "I",
+	rarity: "Common",
+	dexId: [231],
+};
+
+export default card;

--- a/data-asia/M/M4/045.ts
+++ b/data-asia/M/M4/045.ts
@@ -1,0 +1,55 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ドンファン",
+	},
+
+	illustrator: "Julie Hang",
+	category: "Pokemon",
+	hp: 150,
+	types: ["Fighting"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "たたみかける" },
+			damage: 20,
+			cost: ["Fighting"],
+			effect: {
+				ja: "次の自分の番、このポケモンのワザのダメージは相手のバトルポケモンに「120」多くなる。",
+			},
+		},
+		{
+			name: { ja: "スマッシュヘッド" },
+			damage: 180,
+			cost: ["Fighting", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンについているエネルギーを2個トラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	evolveFrom: {
+		ja: "ゴマゾウ",
+	},
+
+	variants: [{ type: "normal" }, { type: "reverse", foil: "pokeball" }, { type: "reverse", foil: "masterball" }],
+
+	retreat: 3,
+	regulationMark: "I",
+	rarity: "Common",
+	dexId: [232],
+};
+
+export default card;

--- a/data-asia/M/M4/046.ts
+++ b/data-asia/M/M4/046.ts
@@ -1,0 +1,43 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヤジロン",
+	},
+
+	illustrator: "Tomomi Ozaki",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Fighting"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "れんぞくスピン" },
+			damage: "30x",
+			cost: ["Fighting"],
+			effect: {
+				ja: "コインを、表が出るまで投げ続ける。このワザのダメージは、表が出た回数×30。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [{ type: "normal" }, { type: "reverse", foil: "pokeball" }, { type: "reverse", foil: "masterball" }],
+
+	retreat: 2,
+	regulationMark: "I",
+	rarity: "Common",
+	dexId: [343],
+};
+
+export default card;

--- a/data-asia/M/M4/047.ts
+++ b/data-asia/M/M4/047.ts
@@ -1,0 +1,47 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ネンドール",
+	},
+
+	illustrator: "Oswaldo KATO",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Fighting"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "たいかこうせん" },
+			damage: 50,
+			cost: ["Fighting"],
+			effect: {
+				ja: "相手のバトルポケモンが進化していたなら、そのポケモンの一番上の進化カードを手札に戻す。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	evolveFrom: {
+		ja: "ヤジロン",
+	},
+
+	variants: [{ type: "normal" }, { type: "reverse", foil: "pokeball" }, { type: "reverse", foil: "masterball" }],
+
+	retreat: 2,
+	regulationMark: "I",
+	rarity: "Uncommon",
+	dexId: [344],
+};
+
+export default card;

--- a/data-asia/M/M4/048.ts
+++ b/data-asia/M/M4/048.ts
@@ -1,0 +1,42 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ズバット",
+	},
+
+	illustrator: "Mékayu",
+	category: "Pokemon",
+	hp: 40,
+	types: ["Darkness"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ちょうおんぱ" },
+			cost: ["Darkness"],
+			effect: {
+				ja: "相手のバトルポケモンをこんらんにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [{ type: "normal" }, { type: "reverse", foil: "pokeball" }, { type: "reverse", foil: "masterball" }],
+
+	retreat: 0,
+	regulationMark: "I",
+	rarity: "Common",
+	dexId: [41],
+};
+
+export default card;

--- a/data-asia/M/M4/049.ts
+++ b/data-asia/M/M4/049.ts
@@ -1,0 +1,47 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ゴルバット",
+	},
+
+	illustrator: "Mousho",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Darkness"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "おんみつひこう" },
+			damage: 30,
+			cost: ["Darkness"],
+			effect: {
+				ja: "次の相手の番、たねポケモンのワザのダメージを受けない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	evolveFrom: {
+		ja: "ズバット",
+	},
+
+	variants: [{ type: "normal" }, { type: "reverse", foil: "pokeball" }, { type: "reverse", foil: "masterball" }],
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "Common",
+	dexId: [42],
+};
+
+export default card;

--- a/data-asia/M/M4/050.ts
+++ b/data-asia/M/M4/050.ts
@@ -1,0 +1,57 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "クロバット",
+	},
+
+	illustrator: "IKEDA Saki",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Darkness"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Stage2",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "よるこうさく" },
+			effect: {
+				ja: "自分の番に、このポケモンがバトル場にいるとき、1回使える。自分の山札からカードを1枚選び、山札を切る。そして選んだカードを山札の一番上に置く。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "どくおんぱ" },
+			damage: 80,
+			cost: ["Darkness"],
+			effect: {
+				ja: "相手のバトルポケモンをどくとこんらんにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	evolveFrom: {
+		ja: "ゴルバット",
+	},
+
+	variants: [{ type: "normal" }, { type: "reverse", foil: "pokeball" }, { type: "reverse", foil: "masterball" }],
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "Uncommon",
+	dexId: [169],
+};
+
+export default card;

--- a/data-asia/M/M4/051.ts
+++ b/data-asia/M/M4/051.ts
@@ -1,0 +1,53 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ハリーセン",
+	},
+
+	illustrator: "nisimono",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Darkness"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "どくのトゲ" },
+			effect: {
+				ja: "このポケモンがバトル場にいるとき、相手のポケモンのワザのダメージを受けたなら、そのポケモンをどくにする。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ベノムショック" },
+			damage: "30+",
+			cost: ["Darkness"],
+			effect: {
+				ja: "相手のバトルポケモンがどくなら、このワザのダメージは「50」多くなる。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [{ type: "normal" }, { type: "reverse", foil: "pokeball" }, { type: "reverse", foil: "masterball" }],
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "Common",
+	dexId: [211],
+};
+
+export default card;

--- a/data-asia/M/M4/052.ts
+++ b/data-asia/M/M4/052.ts
@@ -1,0 +1,40 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "スカンプー",
+	},
+
+	illustrator: "Nobuhiro Imagawa",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Darkness"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ひっかく" },
+			damage: 20,
+			cost: ["Darkness"],
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [{ type: "normal" }, { type: "reverse", foil: "pokeball" }, { type: "reverse", foil: "masterball" }],
+
+	retreat: 2,
+	regulationMark: "I",
+	rarity: "Common",
+	dexId: [434],
+};
+
+export default card;

--- a/data-asia/M/M4/053.ts
+++ b/data-asia/M/M4/053.ts
@@ -1,0 +1,52 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "スカタンク",
+	},
+
+	illustrator: "Yuriko Akase",
+	category: "Pokemon",
+	hp: 110,
+	types: ["Darkness"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "うしろげり" },
+			damage: 40,
+			cost: ["Darkness"],
+		},
+		{
+			name: { ja: "スマッシュターン" },
+			damage: 100,
+			cost: ["Darkness", "Darkness", "Colorless"],
+			effect: {
+				ja: "このポケモンをベンチポケモン1匹と入れ替える。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	evolveFrom: {
+		ja: "スカンプー",
+	},
+
+	variants: [{ type: "normal" }, { type: "reverse", foil: "pokeball" }, { type: "reverse", foil: "masterball" }],
+
+	retreat: 2,
+	regulationMark: "I",
+	rarity: "Uncommon",
+	dexId: [435],
+};
+
+export default card;

--- a/data-asia/M/M4/054.ts
+++ b/data-asia/M/M4/054.ts
@@ -1,0 +1,43 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヤブクロン",
+	},
+
+	illustrator: "Souichirou Gunjima",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Darkness"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "アシッドボム" },
+			damage: 10,
+			cost: ["Darkness"],
+			effect: {
+				ja: "コインを1回投げ、オモテなら、相手のバトルポケモンについているエネルギーを1個トラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [{ type: "normal" }, { type: "reverse", foil: "pokeball" }, { type: "reverse", foil: "masterball" }],
+
+	retreat: 2,
+	regulationMark: "I",
+	rarity: "Common",
+	dexId: [568],
+};
+
+export default card;

--- a/data-asia/M/M4/055.ts
+++ b/data-asia/M/M4/055.ts
@@ -1,0 +1,54 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ダストダス",
+	},
+
+	illustrator: "HYOGONOSUKE",
+	category: "Pokemon",
+	hp: 140,
+	types: ["Darkness"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ゴミダウナー" },
+			effect: {
+				ja: "相手のバトルポケモンにポケモンのどうぐがついているなら、そのポケモンのワザのダメージは「20」少なくなる。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ヘドロばくだん" },
+			damage: 100,
+			cost: ["Darkness", "Darkness", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	evolveFrom: {
+		ja: "ヤブクロン",
+	},
+
+	variants: [{ type: "normal" }, { type: "reverse", foil: "pokeball" }, { type: "reverse", foil: "masterball" }],
+
+	retreat: 3,
+	regulationMark: "I",
+	rarity: "Uncommon",
+	dexId: [569],
+};
+
+export default card;

--- a/data-asia/M/M4/056.ts
+++ b/data-asia/M/M4/056.ts
@@ -1,0 +1,40 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "クズモー",
+	},
+
+	illustrator: "Shimaris Yukichi",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Darkness"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ひっかける" },
+			damage: 10,
+			cost: ["Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [{ type: "normal" }, { type: "reverse", foil: "pokeball" }, { type: "reverse", foil: "masterball" }],
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "Common",
+	dexId: [690],
+};
+
+export default card;

--- a/data-asia/M/M4/057.ts
+++ b/data-asia/M/M4/057.ts
@@ -1,0 +1,45 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ダンバル",
+	},
+
+	illustrator: "toi8",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Metal"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ずつき" },
+			damage: 10,
+			cost: ["Metal"],
+		},
+		{
+			name: { ja: "ビーム" },
+			damage: 20,
+			cost: ["Metal", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Grass", value: "-30" }],
+
+	variants: [{ type: "normal" }, { type: "reverse", foil: "pokeball" }, { type: "reverse", foil: "masterball" }],
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "Common",
+	dexId: [374],
+};
+
+export default card;

--- a/data-asia/M/M4/058.ts
+++ b/data-asia/M/M4/058.ts
@@ -1,0 +1,52 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "メタング",
+	},
+
+	illustrator: "Kazumasa Yasukuni",
+	category: "Pokemon",
+	hp: 100,
+	types: ["Metal"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "メタルクロー" },
+			damage: 30,
+			cost: ["Metal"],
+		},
+		{
+			name: { ja: "ガードプレス" },
+			damage: 70,
+			cost: ["Metal", "Metal", "Colorless"],
+			effect: {
+				ja: "次の相手の番、このポケモンが受けるワザのダメージは「30」少なくなる。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Grass", value: "-30" }],
+
+	evolveFrom: {
+		ja: "ダンバル",
+	},
+
+	variants: [{ type: "normal" }, { type: "reverse", foil: "pokeball" }, { type: "reverse", foil: "masterball" }],
+
+	retreat: 2,
+	regulationMark: "I",
+	rarity: "Common",
+	dexId: [375],
+};
+
+export default card;

--- a/data-asia/M/M4/059.ts
+++ b/data-asia/M/M4/059.ts
@@ -1,0 +1,55 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "メタグロス",
+	},
+
+	illustrator: "Bun Toujo",
+	category: "Pokemon",
+	hp: 180,
+	types: ["Metal"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Stage2",
+
+	attacks: [
+		{
+			name: { ja: "はねかえす" },
+			damage: 60,
+			cost: ["Metal"],
+			effect: {
+				ja: "相手のバトルポケモンをベンチに戻す。",
+			},
+		},
+		{
+			name: { ja: "メタリックハンマー" },
+			damage: "150+",
+			cost: ["Metal", "Metal", "Metal", "Colorless"],
+			effect: {
+				ja: "このポケモンについている鋼エネルギーを3個トラッシュしてもよい。そうした場合、このワザのダメージは「150」多くなる。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Grass", value: "-30" }],
+
+	evolveFrom: {
+		ja: "メタング",
+	},
+
+	variants: [{ type: "normal" }, { type: "reverse", foil: "pokeball" }, { type: "reverse", foil: "masterball" }],
+
+	retreat: 3,
+	regulationMark: "I",
+	rarity: "Uncommon",
+	dexId: [376],
+};
+
+export default card;

--- a/data-asia/M/M4/060.ts
+++ b/data-asia/M/M4/060.ts
@@ -1,0 +1,40 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "テッシード",
+	},
+
+	illustrator: "OKUBO",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Metal"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ころがりタックル" },
+			damage: 40,
+			cost: ["Metal", "Metal"],
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Grass", value: "-30" }],
+
+	variants: [{ type: "normal" }, { type: "reverse", foil: "pokeball" }, { type: "reverse", foil: "masterball" }],
+
+	retreat: 2,
+	regulationMark: "I",
+	rarity: "Common",
+	dexId: [597],
+};
+
+export default card;

--- a/data-asia/M/M4/061.ts
+++ b/data-asia/M/M4/061.ts
@@ -1,0 +1,57 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ナットレイ",
+	},
+
+	illustrator: "Haru Akasaka",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Metal"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "どっきりおとし" },
+			effect: {
+				ja: "相手のワザの効果やどうぐによって、このポケモンが山札からトラッシュされるとき、相手の山札の上から8枚トラッシュする。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "スペシャルウィップ" },
+			damage: "70+",
+			cost: ["Metal", "Metal"],
+			effect: {
+				ja: "このポケモンについている特殊エネルギーがあるなら、このワザのダメージは「70」多くなる。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Grass", value: "-30" }],
+
+	evolveFrom: {
+		ja: "テッシード",
+	},
+
+	variants: [{ type: "normal" }, { type: "reverse", foil: "pokeball" }, { type: "reverse", foil: "masterball" }],
+
+	retreat: 3,
+	regulationMark: "I",
+	rarity: "Uncommon",
+	dexId: [598],
+};
+
+export default card;

--- a/data-asia/M/M4/062.ts
+++ b/data-asia/M/M4/062.ts
@@ -1,0 +1,55 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "コバルオンex",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 210,
+	types: ["Metal"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "メタルロード" },
+			effect: {
+				ja: "自分の番に1回、このポケモンをベンチからバトル場に出したとき使える。自分の他のポケモンについている鋼エネルギーを好きなだけこのポケモンに移し替える。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "パワータックル" },
+			damage: 200,
+			cost: ["Metal", "Metal", "Colorless"],
+			effect: {
+				ja: "次の自分の番、このポケモンはワザを使えない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Grass", value: "-30" }],
+
+	variants: [{ type: "holo" }],
+
+	retreat: 2,
+	regulationMark: "I",
+	rarity: "Double rare",
+	dexId: [638],
+
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/M/M4/063.ts
+++ b/data-asia/M/M4/063.ts
@@ -1,0 +1,55 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "メガドラミドロex",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 330,
+	types: ["Dragon"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "ふしょくえき" },
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "相手のポケモン全員についているポケモンのどうぐと特殊エネルギーをすべてトラッシュする。",
+			},
+		},
+		{
+			name: { ja: "デッドリーポイズン" },
+			cost: ["Water", "Darkness"],
+			effect: {
+				ja: "相手のバトルポケモンをどくにする。その場合、ポケモンチェックのとき置くダメージカウンターは1個のかわり16個になる。",
+			},
+		},
+	],
+
+	weaknesses: [],
+	resistances: [],
+
+	evolveFrom: {
+		ja: "クズモー",
+	},
+
+	variants: [{ type: "holo" }],
+
+	retreat: 2,
+	regulationMark: "I",
+	rarity: "Double rare",
+	dexId: [691],
+
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/M/M4/064.ts
+++ b/data-asia/M/M4/064.ts
@@ -1,0 +1,43 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヌメラ",
+	},
+
+	illustrator: "Anesaki Dynamic",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Dragon"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "すいとる" },
+			damage: 30,
+			cost: ["Water", "Psychic"],
+			effect: {
+				ja: "このポケモンのダメージカウンターを3個取り除く。",
+			},
+		},
+	],
+
+	weaknesses: [],
+	resistances: [],
+
+	variants: [{ type: "normal" }, { type: "reverse", foil: "pokeball" }, { type: "reverse", foil: "masterball" }],
+
+	retreat: 2,
+	regulationMark: "I",
+	rarity: "Common",
+	dexId: [704],
+};
+
+export default card;

--- a/data-asia/M/M4/065.ts
+++ b/data-asia/M/M4/065.ts
@@ -1,0 +1,47 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヌメイル",
+	},
+
+	illustrator: "Wataru Kawahara",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Dragon"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "ねばりつく" },
+			damage: 50,
+			cost: ["Water", "Colorless"],
+			effect: {
+				ja: "次の相手の番、このワザを受けたポケモンは逃げられない。",
+			},
+		},
+	],
+
+	weaknesses: [],
+	resistances: [],
+
+	evolveFrom: {
+		ja: "ヌメラ",
+	},
+
+	variants: [{ type: "normal" }, { type: "reverse", foil: "pokeball" }, { type: "reverse", foil: "masterball" }],
+
+	retreat: 2,
+	regulationMark: "I",
+	rarity: "Common",
+	dexId: [705],
+};
+
+export default card;

--- a/data-asia/M/M4/066.ts
+++ b/data-asia/M/M4/066.ts
@@ -1,0 +1,52 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヌメルゴン",
+	},
+
+	illustrator: "Misa Tsutsui",
+	category: "Pokemon",
+	hp: 150,
+	types: ["Dragon"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Stage2",
+
+	attacks: [
+		{
+			name: { ja: "ドラゴンブレス" },
+			damage: 80,
+			cost: ["Water", "Psychic", "Colorless"],
+		},
+		{
+			name: { ja: "りゅうのはどう" },
+			damage: 150,
+			cost: ["Water", "Water", "Psychic", "Colorless"],
+			effect: {
+				ja: "次の自分の番、このポケモンはワザを使えない。",
+			},
+		},
+	],
+
+	weaknesses: [],
+	resistances: [],
+
+	evolveFrom: {
+		ja: "ヌメイル",
+	},
+
+	variants: [{ type: "normal" }, { type: "reverse", foil: "pokeball" }, { type: "reverse", foil: "masterball" }],
+
+	retreat: 3,
+	regulationMark: "I",
+	rarity: "Uncommon",
+	dexId: [706],
+};
+
+export default card;

--- a/data-asia/M/M4/067.ts
+++ b/data-asia/M/M4/067.ts
@@ -1,0 +1,45 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ケンタロス",
+	},
+
+	illustrator: "Katsunori Sato",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Colorless"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ちからずく" },
+			damage: 50,
+			cost: ["Colorless", "Colorless"],
+		},
+		{
+			name: { ja: "タックル" },
+			damage: 80,
+			cost: ["Colorless", "Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [{ type: "normal" }, { type: "reverse", foil: "pokeball" }, { type: "reverse", foil: "masterball" }],
+
+	retreat: 2,
+	regulationMark: "I",
+	rarity: "Uncommon",
+	dexId: [128],
+};
+
+export default card;

--- a/data-asia/M/M4/068.ts
+++ b/data-asia/M/M4/068.ts
@@ -1,0 +1,43 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ミネズミ",
+	},
+
+	illustrator: "SHIN NAGASAWA",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Colorless"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ちょっかい" },
+			damage: 10,
+			cost: ["Colorless"],
+			effect: {
+				ja: "コインを1回投げ、オモテなら、相手の山札の上から1枚トラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [{ type: "normal" }, { type: "reverse", foil: "pokeball" }, { type: "reverse", foil: "masterball" }],
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "Common",
+	dexId: [504],
+};
+
+export default card;

--- a/data-asia/M/M4/069.ts
+++ b/data-asia/M/M4/069.ts
@@ -1,0 +1,52 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ミルホッグ",
+	},
+
+	illustrator: "Yuka Morii",
+	category: "Pokemon",
+	hp: 100,
+	types: ["Colorless"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "みはる" },
+			damage: 40,
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "次の相手の番、このポケモンが受けるワザのダメージは「30」少なくなる。",
+			},
+		},
+		{
+			name: { ja: "ハイパーファング" },
+			damage: 80,
+			cost: ["Colorless", "Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	evolveFrom: {
+		ja: "ミネズミ",
+	},
+
+	variants: [{ type: "normal" }, { type: "reverse", foil: "pokeball" }, { type: "reverse", foil: "masterball" }],
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "Common",
+	dexId: [505],
+};
+
+export default card;

--- a/data-asia/M/M4/070.ts
+++ b/data-asia/M/M4/070.ts
@@ -1,0 +1,40 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "チラーミィ",
+	},
+
+	illustrator: "Aya Kusube",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Colorless"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "しっぽでたたく" },
+			damage: 20,
+			cost: ["Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [{ type: "normal" }, { type: "reverse", foil: "pokeball" }, { type: "reverse", foil: "masterball" }],
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "Common",
+	dexId: [572],
+};
+
+export default card;

--- a/data-asia/M/M4/071.ts
+++ b/data-asia/M/M4/071.ts
@@ -1,0 +1,59 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "チラチーノex",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 200,
+	types: ["Colorless"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "わたもうふ" },
+			effect: {
+				ja: "このポケモンがバトル場にいるかぎり、相手のワザのダメージを受けたとき、そのダメージを「30」少なくする。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "テールスラップ" },
+			damage: "60x",
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "コインを4回投げ、オモテの数×60ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	evolveFrom: {
+		ja: "チラーミィ",
+	},
+
+	variants: [{ type: "holo" }],
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "Double rare",
+	dexId: [573],
+
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/M/M4/072.ts
+++ b/data-asia/M/M4/072.ts
@@ -1,0 +1,24 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "スペシャルレッドカード",
+	},
+
+	illustrator: "Toyste Beach",
+	category: "Trainer",
+	trainerType: "Item",
+
+	effect: {
+		ja: "相手は手札をすべて山札に戻してよく切る。その後、お互いに山札の上から4枚引く。",
+	},
+
+	variants: [{ type: "normal" }, { type: "reverse", foil: "pokeball" }, { type: "reverse", foil: "masterball" }],
+
+	regulationMark: "I",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/M/M4/073.ts
+++ b/data-asia/M/M4/073.ts
@@ -1,0 +1,24 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "おおきなつりあみ",
+	},
+
+	illustrator: "Studio Bora Inc.",
+	category: "Trainer",
+	trainerType: "Item",
+
+	effect: {
+		ja: "相手のベンチのポケモンを1匹選ぶ。そのポケモンと、ついているカードをすべて相手の手札に戻す。",
+	},
+
+	variants: [{ type: "normal" }, { type: "reverse", foil: "pokeball" }, { type: "reverse", foil: "masterball" }],
+
+	regulationMark: "I",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/M/M4/074.ts
+++ b/data-asia/M/M4/074.ts
@@ -1,0 +1,24 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "へんかのしょ",
+	},
+
+	illustrator: "Studio Bora Inc.",
+	category: "Trainer",
+	trainerType: "Item",
+
+	effect: {
+		ja: "自分のバトルポケモンについているどうぐを1枚選んでトラッシュする。その後、自分の山札からどうぐを1枚選び、そのポケモンにつける。そして山札を切る。",
+	},
+
+	variants: [{ type: "normal" }, { type: "reverse", foil: "pokeball" }, { type: "reverse", foil: "masterball" }],
+
+	regulationMark: "I",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/M/M4/075.ts
+++ b/data-asia/M/M4/075.ts
@@ -1,0 +1,24 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "AZのやすらぎ",
+	},
+
+	illustrator: "Yusuke Ohmura",
+	category: "Trainer",
+	trainerType: "Supporter",
+
+	effect: {
+		ja: "自分のポケモンを1匹選ぶ。そのポケモンについているカードをすべて手札に加える。その後、そのポケモンを手札に加える。",
+	},
+
+	variants: [{ type: "normal" }, { type: "reverse", foil: "pokeball" }, { type: "reverse", foil: "masterball" }],
+
+	regulationMark: "I",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/M/M4/076.ts
+++ b/data-asia/M/M4/076.ts
@@ -1,0 +1,24 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ジプソ",
+	},
+
+	illustrator: "Yusuke Ohmura",
+	category: "Trainer",
+	trainerType: "Supporter",
+
+	effect: {
+		ja: "自分の山札を調べ、好きなカードを5枚まで選び、手札に加える。そして山札を切る。",
+	},
+
+	variants: [{ type: "holo" }],
+
+	regulationMark: "I",
+	rarity: "ACE SPEC Rare",
+};
+
+export default card;

--- a/data-asia/M/M4/077.ts
+++ b/data-asia/M/M4/077.ts
@@ -1,0 +1,24 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ホミカの演奏",
+	},
+
+	illustrator: "Yusuke Ohmura",
+	category: "Trainer",
+	trainerType: "Supporter",
+
+	effect: {
+		ja: "自分の山札から基本エネルギーを2枚まで選び、自分のポケモン1匹につける。そして山札を切る。",
+	},
+
+	variants: [{ type: "normal" }, { type: "reverse", foil: "pokeball" }, { type: "reverse", foil: "masterball" }],
+
+	regulationMark: "I",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/M/M4/078.ts
+++ b/data-asia/M/M4/078.ts
@@ -1,0 +1,24 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "マチエール",
+	},
+
+	illustrator: "Yusuke Ohmura",
+	category: "Trainer",
+	trainerType: "Supporter",
+
+	effect: {
+		ja: "自分の手札を好きな枚数トラッシュする。その後、手札が7枚になるようにカードを引く。",
+	},
+
+	variants: [{ type: "holo" }],
+
+	regulationMark: "I",
+	rarity: "ACE SPEC Rare",
+};
+
+export default card;

--- a/data-asia/M/M4/079.ts
+++ b/data-asia/M/M4/079.ts
@@ -1,0 +1,24 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ハイパールージュ アンジェ&フロエッテ",
+	},
+
+	illustrator: "Kazuya Fujishima",
+	category: "Trainer",
+	trainerType: "Stadium",
+
+	effect: {
+		ja: "自分のポケモンが相手のワザのダメージを受けてきぜつしたとき、そのポケモンについているエネルギーを2枚まで手札に加えることができる。",
+	},
+
+	variants: [{ type: "normal" }, { type: "reverse", foil: "pokeball" }, { type: "reverse", foil: "masterball" }],
+
+	regulationMark: "I",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/M/M4/080.ts
+++ b/data-asia/M/M4/080.ts
@@ -1,0 +1,24 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "プリズムタワー",
+	},
+
+	illustrator: "Kazuya Fujishima",
+	category: "Trainer",
+	trainerType: "Stadium",
+
+	effect: {
+		ja: "ドラゴンタイプのポケモンのにげるためのエネルギーを、それぞれ1個少なくする。",
+	},
+
+	variants: [{ type: "normal" }, { type: "reverse", foil: "pokeball" }, { type: "reverse", foil: "masterball" }],
+
+	regulationMark: "I",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/M/M4/081.ts
+++ b/data-asia/M/M4/081.ts
@@ -1,0 +1,24 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ニトロ炎エネルギー",
+	},
+
+	illustrator: "Ryo Ueda",
+	category: "Energy",
+	energyType: "Special",
+
+	effect: {
+		ja: "炎エネルギー1個分として使えるほか、このエネルギーをつけているポケモンが使うワザのダメージは「30」多くなる。",
+	},
+
+	variants: [{ type: "normal" }, { type: "reverse", foil: "pokeball" }, { type: "reverse", foil: "masterball" }],
+
+	regulationMark: "I",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/M/M4/082.ts
+++ b/data-asia/M/M4/082.ts
@@ -1,0 +1,24 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "バブル水エネルギー",
+	},
+
+	illustrator: "Ryo Ueda",
+	category: "Energy",
+	energyType: "Special",
+
+	effect: {
+		ja: "水エネルギー1個分として使えるほか、このエネルギーをつけているポケモンが攻撃で相手のバトルポケモンにダメージを与えたとき、コインを1回投げ、オモテなら、そのポケモンをねむりにする。",
+	},
+
+	variants: [{ type: "normal" }, { type: "reverse", foil: "pokeball" }, { type: "reverse", foil: "masterball" }],
+
+	regulationMark: "I",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/M/M4/083.ts
+++ b/data-asia/M/M4/083.ts
@@ -1,0 +1,24 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "マグネット鋼エネルギー",
+	},
+
+	illustrator: "Ryo Ueda",
+	category: "Energy",
+	energyType: "Special",
+
+	effect: {
+		ja: "鋼エネルギー1個分として使えるほか、このエネルギーをつけているポケモンが受けるワザのダメージは「20」少なくなる。",
+	},
+
+	variants: [{ type: "normal" }, { type: "reverse", foil: "pokeball" }, { type: "reverse", foil: "masterball" }],
+
+	regulationMark: "I",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/M/M4/084.ts
+++ b/data-asia/M/M4/084.ts
@@ -1,0 +1,45 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ハリマロン",
+	},
+
+	illustrator: "Naoyo Kimura",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Grass"],
+
+	description: {
+		ja: "普段 やわらかい 頭の トゲは 力を こめると 鋭く 尖り 岩をも つらぬくほど 硬くなる。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "たたく" },
+			damage: 10,
+			cost: ["Grass"],
+		},
+		{
+			name: { ja: "トゲでさす" },
+			damage: 30,
+			cost: ["Grass", "Grass"],
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [{ type: "holo" }],
+
+	retreat: 2,
+	regulationMark: "I",
+	rarity: "Illustration rare",
+	dexId: [650],
+};
+
+export default card;

--- a/data-asia/M/M4/085.ts
+++ b/data-asia/M/M4/085.ts
@@ -1,0 +1,47 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "フォッコ",
+	},
+
+	illustrator: "Saya Tsuruta",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Fire"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "なかまをよぶ" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札からたねポケモンを2枚まで選び、ベンチに出す。そして山札を切る。",
+			},
+		},
+		{
+			name: { ja: "ひをはく" },
+			damage: 10,
+			cost: ["Fire"],
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [{ type: "holo" }],
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "Illustration rare",
+	dexId: [653],
+};
+
+export default card;

--- a/data-asia/M/M4/086.ts
+++ b/data-asia/M/M4/086.ts
@@ -1,0 +1,47 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ケロマツ",
+	},
+
+	illustrator: "Shin Nagasawa",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Water"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "もってくる" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "カードを1枚引く。",
+			},
+		},
+		{
+			name: { ja: "みずでっぽう" },
+			damage: 10,
+			cost: ["Water"],
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
+
+	variants: [{ type: "holo" }],
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "Illustration rare",
+	dexId: [656],
+};
+
+export default card;

--- a/data-asia/M/M4/087.ts
+++ b/data-asia/M/M4/087.ts
@@ -1,0 +1,51 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ゲコガシラ",
+	},
+
+	illustrator: "Ryota Murayama",
+	category: "Pokemon",
+	hp: 100,
+	types: ["Water"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "よびよせじゅつ" },
+			cost: ["Water"],
+			effect: {
+				ja: "自分の山札からポケモンを3枚まで選び、手札に加える。そして山札を切る。",
+			},
+		},
+		{
+			name: { ja: "アクアエッジ" },
+			damage: 50,
+			cost: ["Water", "Water"],
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
+
+	evolveFrom: {
+		ja: "ケロマツ",
+	},
+
+	variants: [{ type: "holo" }],
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "Illustration rare",
+	dexId: [657],
+};
+
+export default card;

--- a/data-asia/M/M4/088.ts
+++ b/data-asia/M/M4/088.ts
@@ -1,0 +1,57 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "デンリュウ",
+	},
+
+	illustrator: "Akira Komayama",
+	category: "Pokemon",
+	hp: 160,
+	types: ["Lightning"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Stage2",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "シンクロパルス" },
+			effect: {
+				ja: "自分の手札の枚数と相手の手札の枚数が同じなら、このポケモンのワザのダメージは「80」多くなる。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "フラッシュボルト" },
+			damage: 140,
+			cost: ["Lightning", "Colorless"],
+			effect: {
+				ja: "次の自分の番、このポケモンは「フラッシュボルト」を使えない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	evolveFrom: {
+		ja: "モココ",
+	},
+
+	variants: [{ type: "holo" }],
+
+	retreat: 2,
+	regulationMark: "I",
+	rarity: "Illustration rare",
+	dexId: [181],
+};
+
+export default card;

--- a/data-asia/M/M4/089.ts
+++ b/data-asia/M/M4/089.ts
@@ -1,0 +1,43 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ゼルネアス",
+	},
+
+	illustrator: "nagimiso",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Psychic"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ジオストーム" },
+			damage: "30x",
+			cost: ["Psychic", "Psychic", "Psychic"],
+			effect: {
+				ja: "このワザのダメージは、自分のポケモン全員についているサイコエネルギーの合計数×30。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [{ type: "holo" }],
+
+	retreat: 2,
+	regulationMark: "I",
+	rarity: "Illustration rare",
+	dexId: [716],
+};
+
+export default card;

--- a/data-asia/M/M4/090.ts
+++ b/data-asia/M/M4/090.ts
@@ -1,0 +1,47 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ネンドール",
+	},
+
+	illustrator: "Shibuzoh.",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Fighting"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "たいかこうせん" },
+			damage: 50,
+			cost: ["Fighting"],
+			effect: {
+				ja: "相手のバトルポケモンが進化していたなら、そのポケモンの一番上の進化カードを手札に戻す。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	evolveFrom: {
+		ja: "ヤジロン",
+	},
+
+	variants: [{ type: "holo" }],
+
+	retreat: 2,
+	regulationMark: "I",
+	rarity: "Illustration rare",
+	dexId: [344],
+};
+
+export default card;

--- a/data-asia/M/M4/091.ts
+++ b/data-asia/M/M4/091.ts
@@ -1,0 +1,57 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "クロバット",
+	},
+
+	illustrator: "Toshinao Aoki",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Darkness"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Stage2",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "よるこうさく" },
+			effect: {
+				ja: "自分の番に、このポケモンがバトル場にいるとき、1回使える。自分の山札からカードを1枚選び、山札を切る。そして選んだカードを山札の一番上に置く。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "どくおんぱ" },
+			damage: 80,
+			cost: ["Darkness"],
+			effect: {
+				ja: "相手のバトルポケモンをどくとこんらんにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	evolveFrom: {
+		ja: "ゴルバット",
+	},
+
+	variants: [{ type: "holo" }],
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "Illustration rare",
+	dexId: [169],
+};
+
+export default card;

--- a/data-asia/M/M4/092.ts
+++ b/data-asia/M/M4/092.ts
@@ -1,0 +1,52 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "メタング",
+	},
+
+	illustrator: "Teeziro",
+	category: "Pokemon",
+	hp: 100,
+	types: ["Metal"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "メタルクロー" },
+			damage: 30,
+			cost: ["Metal"],
+		},
+		{
+			name: { ja: "ガードプレス" },
+			damage: 70,
+			cost: ["Metal", "Metal", "Colorless"],
+			effect: {
+				ja: "次の相手の番、このポケモンが受けるワザのダメージは「30」少なくなる。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Grass", value: "-30" }],
+
+	evolveFrom: {
+		ja: "ダンバル",
+	},
+
+	variants: [{ type: "holo" }],
+
+	retreat: 2,
+	regulationMark: "I",
+	rarity: "Illustration rare",
+	dexId: [375],
+};
+
+export default card;

--- a/data-asia/M/M4/093.ts
+++ b/data-asia/M/M4/093.ts
@@ -1,0 +1,47 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヌメイル",
+	},
+
+	illustrator: "Narumi Sato",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Dragon"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "ねばりつく" },
+			damage: 50,
+			cost: ["Water", "Colorless"],
+			effect: {
+				ja: "次の相手の番、このワザを受けたポケモンは逃げられない。",
+			},
+		},
+	],
+
+	weaknesses: [],
+	resistances: [],
+
+	evolveFrom: {
+		ja: "ヌメラ",
+	},
+
+	variants: [{ type: "holo" }],
+
+	retreat: 2,
+	regulationMark: "I",
+	rarity: "Illustration rare",
+	dexId: [705],
+};
+
+export default card;

--- a/data-asia/M/M4/094.ts
+++ b/data-asia/M/M4/094.ts
@@ -1,0 +1,40 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "チラーミィ",
+	},
+
+	illustrator: "Ryuta Fuse",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Colorless"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "しっぽでたたく" },
+			damage: 20,
+			cost: ["Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [{ type: "holo" }],
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "Illustration rare",
+	dexId: [572],
+};
+
+export default card;

--- a/data-asia/M/M4/095.ts
+++ b/data-asia/M/M4/095.ts
@@ -1,0 +1,52 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ミルホッグ",
+	},
+
+	illustrator: "Misa Tsutsui",
+	category: "Pokemon",
+	hp: 100,
+	types: ["Colorless"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "みはる" },
+			damage: 40,
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "次の相手の番、このポケモンが受けるワザのダメージは「30」少なくなる。",
+			},
+		},
+		{
+			name: { ja: "ハイパーファング" },
+			damage: 80,
+			cost: ["Colorless", "Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	evolveFrom: {
+		ja: "ミネズミ",
+	},
+
+	variants: [{ type: "holo" }],
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "Illustration rare",
+	dexId: [505],
+};
+
+export default card;

--- a/data-asia/M/M4/096.ts
+++ b/data-asia/M/M4/096.ts
@@ -1,0 +1,49 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "スピアーex",
+	},
+
+	illustrator: "Eri Yamaki",
+	category: "Pokemon",
+	hp: 310,
+	types: ["Grass"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Stage2",
+
+	attacks: [
+		{
+			name: { ja: "ビーランブル" },
+			damage: "110x",
+			cost: ["Grass"],
+			effect: {
+				ja: "このワザのダメージは、自分の場にいる名前に「スピアー」のつくポケモンの数×110。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	evolveFrom: {
+		ja: "コクーン",
+	},
+
+	variants: [{ type: "holo" }],
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "Ultra Rare",
+	dexId: [15],
+
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/M/M4/097.ts
+++ b/data-asia/M/M4/097.ts
@@ -1,0 +1,59 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "カエンジシex",
+	},
+
+	illustrator: "Eri Yamaki",
+	category: "Pokemon",
+	hp: 230,
+	types: ["Fire"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "リベンジフレイム" },
+			effect: {
+				ja: "自分の前の番に、自分のポケモンがきぜつしていたなら、このポケモンの「リベンジファング」のダメージは「180」多くなる。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "リベンジファング" },
+			damage: "80+",
+			cost: ["Fire", "Colorless"],
+			effect: {
+				ja: "このワザのダメージは、「リベンジフレイム」の効果で多くなる場合がある。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	evolveFrom: {
+		ja: "シシコ",
+	},
+
+	variants: [{ type: "holo" }],
+
+	retreat: 2,
+	regulationMark: "I",
+	rarity: "Ultra Rare",
+	dexId: [668],
+
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/M/M4/098.ts
+++ b/data-asia/M/M4/098.ts
@@ -1,0 +1,59 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "メガゲッコウガex",
+	},
+
+	illustrator: "Naomi Satō",
+	category: "Pokemon",
+	hp: 350,
+	types: ["Water"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Stage2",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ひっさつしゅりけん" },
+			effect: {
+				ja: "自分の番に1回、このポケモンがバトル場にいるとき使える。自分の手札から基本水エネルギーを1枚トラッシュする。そして相手のポケモンにダメージカウンターを合計6個、好きなように置く。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ニンジャスピナー" },
+			damage: "120+",
+			cost: ["Water", "Water"],
+			effect: {
+				ja: "このポケモンについている水エネルギーを1個手札に戻してよい。そうした場合、このワザのダメージは「80」多くなる。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
+
+	evolveFrom: {
+		ja: "ゲコガシラ",
+	},
+
+	variants: [{ type: "holo" }],
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "Ultra Rare",
+	dexId: [658],
+
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/M/M4/099.ts
+++ b/data-asia/M/M4/099.ts
@@ -1,0 +1,52 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "メガフラエッテex",
+	},
+
+	illustrator: "Saya Tsuruta",
+	category: "Pokemon",
+	hp: 250,
+	types: ["Psychic"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "やさしいひかり" },
+			cost: ["Psychic"],
+			effect: {
+				ja: "おたがいのポケモン全員のダメージを「30」ずつ回復する。",
+			},
+		},
+		{
+			name: { ja: "エタニティブルーム" },
+			damage: 200,
+			cost: ["Psychic", "Psychic", "Psychic"],
+			effect: {
+				ja: "自分の山札から基本サイコエネルギーを4枚まで選び、自分のベンチポケモンに好きなようにつける。そして山札を切る。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [{ type: "holo" }],
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "Ultra Rare",
+	dexId: [670],
+
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/M/M4/100.ts
+++ b/data-asia/M/M4/100.ts
@@ -1,0 +1,57 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "パンプジンex",
+	},
+
+	illustrator: "Ryo Ueda",
+	category: "Pokemon",
+	hp: 270,
+	types: ["Psychic"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "ホラーロンド" },
+			damage: "50x",
+			cost: ["Psychic", "Colorless"],
+			effect: {
+				ja: "このワザのダメージは、相手のベンチポケモンにのっているダメージカウンターの合計×50多くなる。",
+			},
+		},
+		{
+			name: { ja: "ゴーストタッチ" },
+			damage: 160,
+			cost: ["Psychic", "Psychic", "Colorless"],
+			effect: {
+				ja: "相手の手札をランダムに1枚選んでトラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	evolveFrom: {
+		ja: "バケッチャ",
+	},
+
+	variants: [{ type: "holo" }],
+
+	retreat: 2,
+	regulationMark: "I",
+	rarity: "Ultra Rare",
+	dexId: [711],
+
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/M/M4/101.ts
+++ b/data-asia/M/M4/101.ts
@@ -1,0 +1,55 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "コバルオンex",
+	},
+
+	illustrator: "Eske Yoshinob",
+	category: "Pokemon",
+	hp: 210,
+	types: ["Metal"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "メタルロード" },
+			effect: {
+				ja: "自分の番に1回、このポケモンをベンチからバトル場に出したとき使える。自分の他のポケモンについている鋼エネルギーを好きなだけこのポケモンに移し替える。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "パワータックル" },
+			damage: 200,
+			cost: ["Metal", "Metal", "Colorless"],
+			effect: {
+				ja: "次の自分の番、このポケモンはワザを使えない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Grass", value: "-30" }],
+
+	variants: [{ type: "holo" }],
+
+	retreat: 2,
+	regulationMark: "I",
+	rarity: "Ultra Rare",
+	dexId: [638],
+
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/M/M4/102.ts
+++ b/data-asia/M/M4/102.ts
@@ -1,0 +1,55 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "メガドラミドロex",
+	},
+
+	illustrator: "Naomi Satō",
+	category: "Pokemon",
+	hp: 330,
+	types: ["Dragon"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "ふしょくえき" },
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "相手のポケモン全員についているポケモンのどうぐと特殊エネルギーをすべてトラッシュする。",
+			},
+		},
+		{
+			name: { ja: "デッドリーポイズン" },
+			cost: ["Water", "Darkness"],
+			effect: {
+				ja: "相手のバトルポケモンをどくにする。その場合、ポケモンチェックのとき置くダメージカウンターは1個のかわり16個になる。",
+			},
+		},
+	],
+
+	weaknesses: [],
+	resistances: [],
+
+	evolveFrom: {
+		ja: "クズモー",
+	},
+
+	variants: [{ type: "holo" }],
+
+	retreat: 2,
+	regulationMark: "I",
+	rarity: "Ultra Rare",
+	dexId: [691],
+
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/M/M4/103.ts
+++ b/data-asia/M/M4/103.ts
@@ -1,0 +1,59 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "チラチーノex",
+	},
+
+	illustrator: "Sanosuke Sakuma",
+	category: "Pokemon",
+	hp: 200,
+	types: ["Colorless"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "わたもうふ" },
+			effect: {
+				ja: "このポケモンがバトル場にいるかぎり、相手のワザのダメージを受けたとき、そのダメージを「30」少なくする。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "テールスラップ" },
+			damage: "60x",
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "コインを4回投げ、オモテの数×60ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	evolveFrom: {
+		ja: "チラーミィ",
+	},
+
+	variants: [{ type: "holo" }],
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "Ultra Rare",
+	dexId: [573],
+
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/M/M4/104.ts
+++ b/data-asia/M/M4/104.ts
@@ -1,0 +1,24 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "エネルギーリターン",
+	},
+
+	illustrator: "Toyste Beach",
+	category: "Trainer",
+	trainerType: "Item",
+
+	effect: {
+		ja: "自分のトラッシュから基本エネルギーを2枚選び、手札に加える。",
+	},
+
+	variants: [{ type: "holo" }],
+
+	regulationMark: "I",
+	rarity: "Ultra Rare",
+};
+
+export default card;

--- a/data-asia/M/M4/105.ts
+++ b/data-asia/M/M4/105.ts
@@ -1,0 +1,24 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "でっかいソフトクリーム",
+	},
+
+	illustrator: "Toyste Beach",
+	category: "Trainer",
+	trainerType: "Item",
+
+	effect: {
+		ja: "自分のポケモン1匹のダメージカウンターを8個取り除く。",
+	},
+
+	variants: [{ type: "holo" }],
+
+	regulationMark: "I",
+	rarity: "Ultra Rare",
+};
+
+export default card;

--- a/data-asia/M/M4/106.ts
+++ b/data-asia/M/M4/106.ts
@@ -1,0 +1,24 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "スペシャルレッドカード",
+	},
+
+	illustrator: "Ryo Ueda",
+	category: "Trainer",
+	trainerType: "Item",
+
+	effect: {
+		ja: "相手は手札をすべて山札に戻してよく切る。その後、お互いに山札の上から4枚引く。",
+	},
+
+	variants: [{ type: "holo" }],
+
+	regulationMark: "I",
+	rarity: "Ultra Rare",
+};
+
+export default card;

--- a/data-asia/M/M4/107.ts
+++ b/data-asia/M/M4/107.ts
@@ -1,0 +1,24 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "どうぐのスクラッパー",
+	},
+
+	illustrator: "Toyste Beach",
+	category: "Trainer",
+	trainerType: "Item",
+
+	effect: {
+		ja: "相手のポケモンについているポケモンのどうぐを2枚まで選んでトラッシュする。",
+	},
+
+	variants: [{ type: "holo" }],
+
+	regulationMark: "I",
+	rarity: "Ultra Rare",
+};
+
+export default card;

--- a/data-asia/M/M4/108.ts
+++ b/data-asia/M/M4/108.ts
@@ -1,0 +1,24 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "AZのやすらぎ",
+	},
+
+	illustrator: "Naomi Satō",
+	category: "Trainer",
+	trainerType: "Supporter",
+
+	effect: {
+		ja: "自分のポケモンを1匹選ぶ。そのポケモンについているカードをすべて手札に加える。その後、そのポケモンを手札に加える。",
+	},
+
+	variants: [{ type: "holo" }],
+
+	regulationMark: "I",
+	rarity: "Ultra Rare",
+};
+
+export default card;

--- a/data-asia/M/M4/109.ts
+++ b/data-asia/M/M4/109.ts
@@ -1,0 +1,24 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ジプソ",
+	},
+
+	illustrator: "Sanosuke Sakuma",
+	category: "Trainer",
+	trainerType: "Supporter",
+
+	effect: {
+		ja: "自分の山札を調べ、好きなカードを5枚まで選び、手札に加える。そして山札を切る。",
+	},
+
+	variants: [{ type: "holo" }],
+
+	regulationMark: "I",
+	rarity: "ACE SPEC Rare",
+};
+
+export default card;

--- a/data-asia/M/M4/110.ts
+++ b/data-asia/M/M4/110.ts
@@ -1,0 +1,24 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ホミカの演奏",
+	},
+
+	illustrator: "Naomi Satō",
+	category: "Trainer",
+	trainerType: "Supporter",
+
+	effect: {
+		ja: "自分の山札から基本エネルギーを2枚まで選び、自分のポケモン1匹につける。そして山札を切る。",
+	},
+
+	variants: [{ type: "holo" }],
+
+	regulationMark: "I",
+	rarity: "Ultra Rare",
+};
+
+export default card;

--- a/data-asia/M/M4/111.ts
+++ b/data-asia/M/M4/111.ts
@@ -1,0 +1,24 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "マチエール",
+	},
+
+	illustrator: "Sanosuke Sakuma",
+	category: "Trainer",
+	trainerType: "Supporter",
+
+	effect: {
+		ja: "自分の手札を好きな枚数トラッシュする。その後、手札が7枚になるようにカードを引く。",
+	},
+
+	variants: [{ type: "holo" }],
+
+	regulationMark: "I",
+	rarity: "ACE SPEC Rare",
+};
+
+export default card;

--- a/data-asia/M/M4/112.ts
+++ b/data-asia/M/M4/112.ts
@@ -1,0 +1,24 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "サーフィンビーチ",
+	},
+
+	illustrator: "Kazuya Fujishima",
+	category: "Trainer",
+	trainerType: "Stadium",
+
+	effect: {
+		ja: "水タイプのポケモンのワザのダメージは「20」多くなる。",
+	},
+
+	variants: [{ type: "holo" }],
+
+	regulationMark: "I",
+	rarity: "Ultra Rare",
+};
+
+export default card;

--- a/data-asia/M/M4/113.ts
+++ b/data-asia/M/M4/113.ts
@@ -1,0 +1,24 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "プリズムタワー",
+	},
+
+	illustrator: "Naomi Satō",
+	category: "Trainer",
+	trainerType: "Stadium",
+
+	effect: {
+		ja: "ドラゴンタイプのポケモンのにげるためのエネルギーを、それぞれ1個少なくする。",
+	},
+
+	variants: [{ type: "holo" }],
+
+	regulationMark: "I",
+	rarity: "Ultra Rare",
+};
+
+export default card;

--- a/data-asia/M/M4/114.ts
+++ b/data-asia/M/M4/114.ts
@@ -1,0 +1,59 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "メガゲッコウガex",
+	},
+
+	illustrator: "Shinji Kanda",
+	category: "Pokemon",
+	hp: 350,
+	types: ["Water"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Stage2",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ひっさつしゅりけん" },
+			effect: {
+				ja: "自分の番に1回、このポケモンがバトル場にいるとき使える。自分の手札から基本水エネルギーを1枚トラッシュする。そして相手のポケモンにダメージカウンターを合計6個、好きなように置く。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ニンジャスピナー" },
+			damage: "120+",
+			cost: ["Water", "Water"],
+			effect: {
+				ja: "このポケモンについている水エネルギーを1個手札に戻してよい。そうした場合、このワザのダメージは「80」多くなる。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
+
+	evolveFrom: {
+		ja: "ゲコガシラ",
+	},
+
+	variants: [{ type: "holo" }],
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "Special illustration rare",
+	dexId: [658],
+
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/M/M4/115.ts
+++ b/data-asia/M/M4/115.ts
@@ -1,0 +1,52 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "メガフラエッテex",
+	},
+
+	illustrator: "Mitsuhiro Arita",
+	category: "Pokemon",
+	hp: 250,
+	types: ["Psychic"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "やさしいひかり" },
+			cost: ["Psychic"],
+			effect: {
+				ja: "おたがいのポケモン全員のダメージを「30」ずつ回復する。",
+			},
+		},
+		{
+			name: { ja: "エタニティブルーム" },
+			damage: 200,
+			cost: ["Psychic", "Psychic", "Psychic"],
+			effect: {
+				ja: "自分の山札から基本サイコエネルギーを4枚まで選び、自分のベンチポケモンに好きなようにつける。そして山札を切る。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [{ type: "holo" }],
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "Special illustration rare",
+	dexId: [670],
+
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/M/M4/116.ts
+++ b/data-asia/M/M4/116.ts
@@ -1,0 +1,55 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "メガドラミドロex",
+	},
+
+	illustrator: "Yuka Morii",
+	category: "Pokemon",
+	hp: 330,
+	types: ["Dragon"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "ふしょくえき" },
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "相手のポケモン全員についているポケモンのどうぐと特殊エネルギーをすべてトラッシュする。",
+			},
+		},
+		{
+			name: { ja: "デッドリーポイズン" },
+			cost: ["Water", "Darkness"],
+			effect: {
+				ja: "相手のバトルポケモンをどくにする。その場合、ポケモンチェックのとき置くダメージカウンターは1個のかわり16個になる。",
+			},
+		},
+	],
+
+	weaknesses: [],
+	resistances: [],
+
+	evolveFrom: {
+		ja: "クズモー",
+	},
+
+	variants: [{ type: "holo" }],
+
+	retreat: 2,
+	regulationMark: "I",
+	rarity: "Special illustration rare",
+	dexId: [691],
+
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/M/M4/117.ts
+++ b/data-asia/M/M4/117.ts
@@ -1,0 +1,59 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "チラチーノex",
+	},
+
+	illustrator: "Shinji Kanda",
+	category: "Pokemon",
+	hp: 200,
+	types: ["Colorless"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "わたもうふ" },
+			effect: {
+				ja: "このポケモンがバトル場にいるかぎり、相手のワザのダメージを受けたとき、そのダメージを「30」少なくする。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "テールスラップ" },
+			damage: "60x",
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "コインを4回投げ、オモテの数×60ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	evolveFrom: {
+		ja: "チラーミィ",
+	},
+
+	variants: [{ type: "holo" }],
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "Special illustration rare",
+	dexId: [573],
+
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/M/M4/118.ts
+++ b/data-asia/M/M4/118.ts
@@ -1,0 +1,24 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "AZのやすらぎ",
+	},
+
+	illustrator: "Naomi Satō",
+	category: "Trainer",
+	trainerType: "Supporter",
+
+	effect: {
+		ja: "自分のポケモンを1匹選ぶ。そのポケモンについているカードをすべて手札に加える。その後、そのポケモンを手札に加える。",
+	},
+
+	variants: [{ type: "holo" }],
+
+	regulationMark: "I",
+	rarity: "Special illustration rare",
+};
+
+export default card;

--- a/data-asia/M/M4/119.ts
+++ b/data-asia/M/M4/119.ts
@@ -1,0 +1,24 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ホミカの演奏",
+	},
+
+	illustrator: "Shinji Kanda",
+	category: "Trainer",
+	trainerType: "Supporter",
+
+	effect: {
+		ja: "自分の山札から基本エネルギーを2枚まで選び、自分のポケモン1匹につける。そして山札を切る。",
+	},
+
+	variants: [{ type: "holo" }],
+
+	regulationMark: "I",
+	rarity: "Special illustration rare",
+};
+
+export default card;

--- a/data-asia/M/M4/120.ts
+++ b/data-asia/M/M4/120.ts
@@ -1,0 +1,59 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "メガゲッコウガex",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 350,
+	types: ["Water"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Stage2",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ひっさつしゅりけん" },
+			effect: {
+				ja: "自分の番に1回、このポケモンがバトル場にいるとき使える。自分の手札から基本水エネルギーを1枚トラッシュする。そして相手のポケモンにダメージカウンターを合計6個、好きなように置く。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ニンジャスピナー" },
+			damage: "120+",
+			cost: ["Water", "Water"],
+			effect: {
+				ja: "このポケモンについている水エネルギーを1個手札に戻してよい。そうした場合、このワザのダメージは「80」多くなる。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
+
+	evolveFrom: {
+		ja: "ゲコガシラ",
+	},
+
+	variants: [{ type: "holo" }],
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "Mega Hyper Rare",
+	dexId: [658],
+
+	suffix: "EX",
+};
+
+export default card;


### PR DESCRIPTION
Closes #1177

## Changes

Added the Japanese M4 **Ninja Spinner** (ニンジャスピナー) set — the fourth expansion of the Japanese MEGA Series, featuring Mega Greninja. Released March 13, 2026.

### Files added
- `data-asia/M/M4.ts` — set definition
- `data-asia/M/M4/001.ts` through `data-asia/M/M4/120.ts` — all 120 cards

### Data source
Card data scraped from [jp.pokellector.com](https://jp.pokellector.com/Ninja-Spinner-Expansion/) and cross-referenced with Serebii.

### Card breakdown
- **001–083**: Normal cards (Common/Uncommon/Rare)
- **084–095**: Illustration Rare
- **096–103**: Ultra Rare (full art ex Pokémon)
- **104–113**: Ultra Rare (full art Trainer)
- **114–120**: Secret Rare / Hyper Rare

### Variants applied
Followed the same rarity→variant mapping as M3:
- Common/Uncommon: `normal` + `reverse` (pokeball) + `reverse` (masterball)
- Rare: `holo` + `reverse` (pokeball) + `reverse` (masterball)
- IR/UR/SR/Hyper Rare: `holo` only

`regulationMark: "I"` applied to all cards.