### PR TITLE
feat(data): add Japanese M1L (Mega Brave / メガブレイブ) set and cards

### DIFF
--- a/data-asia/M/M1L.ts
+++ b/data-asia/M/M1L.ts
@@ -1,0 +1,20 @@
+import { Set } from "../../interfaces";
+import serie from "../M";
+
+const set: Set = {
+	id: "M1L",
+	name: {
+		ja: "メガブレイブ",
+	},
+
+	serie: serie,
+
+	cardCount: {
+		official: 92,
+	},
+	releaseDate: {
+		ja: "2025-08-01",
+	},
+};
+
+export default set;

--- a/data-asia/M/M1L/001.ts
+++ b/data-asia/M/M1L/001.ts
@@ -1,0 +1,34 @@
+import { Card } from "../../../interfaces";
+import Set from "../M1L";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "フシギダネ",
+	},
+
+	illustrator: "HYOGONOSUKE",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Grass"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Basic",
+
+	attacks: [{"name": {"ja": "ねばるいと"}, "damage": 10, "cost": ["Grass"], "effect": {"ja": "During your opponent's next turn, the Defending Pokémon can't retreat."}}],
+
+	weaknesses: [{"type": "Fire", "value": "x2"}],
+	resistances: [],
+
+	variants: [{"type": "normal"}],
+
+	retreat: 2,
+	regulationMark: "I",
+	rarity: "Common",
+	dexId: [1],
+};
+
+export default card;

--- a/data-asia/M/M1L/002.ts
+++ b/data-asia/M/M1L/002.ts
@@ -1,0 +1,38 @@
+import { Card } from "../../../interfaces";
+import Set from "../M1L";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "フシギソウ",
+	},
+
+	illustrator: "Takumi Wada",
+	category: "Pokemon",
+	hp: 110,
+	types: ["Grass"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Stage1",
+
+	evolveFrom: {
+		ja: "フシギダネ",
+	},
+
+	attacks: [{"name": {"ja": "はっぱカッター"}, "damage": 60, "cost": ["Grass", "Grass"]}],
+
+	weaknesses: [{"type": "Fire", "value": "x2"}],
+	resistances: [],
+
+	variants: [{"type": "normal"}],
+
+	retreat: 3,
+	regulationMark: "I",
+	rarity: "Common",
+	dexId: [2],
+};
+
+export default card;

--- a/data-asia/M/M1L/003.ts
+++ b/data-asia/M/M1L/003.ts
@@ -1,0 +1,37 @@
+import { Card } from "../../../interfaces";
+import Set from "../M1L";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "メガフシギバナex",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 380,
+	types: ["Grass"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Basic",
+
+	abilities: [{"type": "Ability", "name": {"ja": "ソーラートランスファー"}, "effect": {"ja": "As many times as you like during your turn, you may move a Basic Grass Energy from one of your Pokémon to another one of your Pokémon."}}],
+
+	attacks: [{"name": {"ja": "ジャングルダンプ"}, "damage": 240, "cost": ["Grass", "Grass", "Grass", "Grass"], "effect": {"ja": "Heal 30 damage from this Pokémon"}}],
+
+	weaknesses: [{"type": "Fire", "value": "x2"}],
+	resistances: [],
+
+	variants: [{"type": "holo"}],
+
+	retreat: 4,
+	regulationMark: "I",
+	rarity: "Double rare",
+	dexId: [3],
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/M/M1L/004.ts
+++ b/data-asia/M/M1L/004.ts
@@ -1,0 +1,34 @@
+import { Card } from "../../../interfaces";
+import Set from "../M1L";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "タマタマ",
+	},
+
+	illustrator: "aspara",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Grass"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Basic",
+
+	attacks: [{"name": {"ja": "Clog"}, "cost": ["Colorless"], "effect": {"ja": "Search your deck for 1 Basic  Energy and attach it to this Pokémon. Then, shuffle your deck"}}],
+
+	weaknesses: [{"type": "Fire", "value": "x2"}],
+	resistances: [],
+
+	variants: [{"type": "normal"}],
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "Common",
+	dexId: [102],
+};
+
+export default card;

--- a/data-asia/M/M1L/005.ts
+++ b/data-asia/M/M1L/005.ts
@@ -1,0 +1,38 @@
+import { Card } from "../../../interfaces";
+import Set from "../M1L";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ナッシー",
+	},
+
+	illustrator: "Kazumasu Yasukuni",
+	category: "Pokemon",
+	hp: 140,
+	types: ["Grass"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Stage1",
+
+	evolveFrom: {
+		ja: "タマタマ",
+	},
+
+	attacks: [{"name": {"ja": "Guard Press"}, "damage": 30, "cost": ["Grass"], "effect": {"ja": "During your next turn, this Pokémon receives 30 less damage from attacks (after applying Weakness and Resistance)"}}, {"name": {"ja": "Wood Stamp"}, "damage": "60+", "cost": ["Colorless", "Colorless", "Colorless"], "effect": {"ja": "This attack does 30 more damage for each  Energy attached to this Pokémon"}}],
+
+	weaknesses: [{"type": "Fire", "value": "x2"}],
+	resistances: [],
+
+	variants: [{"type": "normal"}],
+
+	retreat: 2,
+	regulationMark: "I",
+	rarity: "Uncommon",
+	dexId: [103],
+};
+
+export default card;

--- a/data-asia/M/M1L/006.ts
+++ b/data-asia/M/M1L/006.ts
@@ -1,0 +1,34 @@
+import { Card } from "../../../interfaces";
+import Set from "../M1L";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "セレビィ",
+	},
+
+	illustrator: "Naoki Saito",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Grass"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Basic",
+
+	attacks: [{"name": {"ja": "Time Walk"}, "cost": ["Grass"], "effect": {"ja": "Search your deck for up to 3 in any combination of  Pokémon or Stadium cards, reveal them, and put them in your hand. Then, shuffle your deck"}}, {"name": {"ja": "Solar Cutter"}, "damage": 30, "cost": ["Grass"]}],
+
+	weaknesses: [{"type": "Fire", "value": "x2"}],
+	resistances: [],
+
+	variants: [{"type": "normal"}],
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "Uncommon",
+	dexId: [251],
+};
+
+export default card;

--- a/data-asia/M/M1L/007.ts
+++ b/data-asia/M/M1L/007.ts
@@ -1,0 +1,34 @@
+import { Card } from "../../../interfaces";
+import Set from "../M1L";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "タネボー",
+	},
+
+	illustrator: "Miki Tanaka",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Grass"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Basic",
+
+	attacks: [{"name": {"ja": "Nap"}, "cost": ["Colorless"], "effect": {"ja": "Heal 20 damage from this Pokémon"}}, {"name": {"ja": "タネばくだん"}, "damage": 20, "cost": ["Grass", "Colorless"]}],
+
+	weaknesses: [{"type": "Fire", "value": "x2"}],
+	resistances: [],
+
+	variants: [{"type": "normal"}],
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "Common",
+	dexId: [273],
+};
+
+export default card;

--- a/data-asia/M/M1L/008.ts
+++ b/data-asia/M/M1L/008.ts
@@ -1,0 +1,38 @@
+import { Card } from "../../../interfaces";
+import Set from "../M1L";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "コノハナ",
+	},
+
+	illustrator: "takashi shiraishi",
+	category: "Pokemon",
+	hp: 100,
+	types: ["Grass"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Stage1",
+
+	evolveFrom: {
+		ja: "タネボー",
+	},
+
+	attacks: [{"name": {"ja": "はたく"}, "damage": 30, "cost": ["Grass"]}, {"name": {"ja": "あしばらい"}, "damage": 50, "cost": ["Grass", "Colorless"]}],
+
+	weaknesses: [{"type": "Fire", "value": "x2"}],
+	resistances: [],
+
+	variants: [{"type": "normal"}],
+
+	retreat: 2,
+	regulationMark: "I",
+	rarity: "Common",
+	dexId: [274],
+};
+
+export default card;

--- a/data-asia/M/M1L/009.ts
+++ b/data-asia/M/M1L/009.ts
@@ -1,0 +1,38 @@
+import { Card } from "../../../interfaces";
+import Set from "../M1L";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ダーテング",
+	},
+
+	illustrator: "Uninori",
+	category: "Pokemon",
+	hp: 160,
+	types: ["Grass"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Stage2",
+
+	evolveFrom: {
+		ja: "コノハナ",
+	},
+
+	attacks: [{"name": {"ja": "Gust Return"}, "cost": ["Grass"], "effect": {"ja": "Flip a coin. If heads, pick 1 of your opponent's Pokémon. Your opponent shuffles that Pokémon and all cards attached to it into the deck"}}, {"name": {"ja": "Perplex"}, "damage": 100, "cost": ["Grass", "Colorless"], "effect": {"ja": "Your opponent's Active Pokémon is now Confused"}}],
+
+	weaknesses: [{"type": "Fire", "value": "x2"}],
+	resistances: [],
+
+	variants: [{"type": "normal"}],
+
+	retreat: 2,
+	regulationMark: "I",
+	rarity: "Uncommon",
+	dexId: [275],
+};
+
+export default card;

--- a/data-asia/M/M1L/010.ts
+++ b/data-asia/M/M1L/010.ts
@@ -1,0 +1,34 @@
+import { Card } from "../../../interfaces";
+import Set from "../M1L";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ロコン",
+	},
+
+	illustrator: "Naoyo Kimura",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Fire"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Basic",
+
+	attacks: [{"name": {"ja": "なだれ"}, "damage": 10, "cost": ["Colorless"]}, {"name": {"ja": "Combustion"}, "damage": 20, "cost": ["Fire", "Colorless"]}],
+
+	weaknesses: [{"type": "Water", "value": "x2"}],
+	resistances: [],
+
+	variants: [{"type": "normal"}],
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "Common",
+	dexId: [37],
+};
+
+export default card;

--- a/data-asia/M/M1L/011.ts
+++ b/data-asia/M/M1L/011.ts
@@ -1,0 +1,38 @@
+import { Card } from "../../../interfaces";
+import Set from "../M1L";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "キュウコン",
+	},
+
+	illustrator: "satoma",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Fire"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Stage1",
+
+	evolveFrom: {
+		ja: "ロコン",
+	},
+
+	attacks: [{"name": {"ja": "Suspicious Shapeshifting"}, "cost": ["Colorless"], "effect": {"ja": "Discard the top card of your deck. If that card is a Supporter, use its effect as the effect of this attack."}}, {"name": {"ja": "Blaze"}, "damage": 60, "cost": ["Fire", "Colorless"]}],
+
+	weaknesses: [{"type": "Water", "value": "x2"}],
+	resistances: [],
+
+	variants: [{"type": "normal"}],
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "Uncommon",
+	dexId: [38],
+};
+
+export default card;

--- a/data-asia/M/M1L/012.ts
+++ b/data-asia/M/M1L/012.ts
@@ -1,0 +1,34 @@
+import { Card } from "../../../interfaces";
+import Set from "../M1L";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ドンメル",
+	},
+
+	illustrator: "Wintr Wandr",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Fire"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Basic",
+
+	attacks: [{"name": {"ja": "Call for Family"}, "cost": ["Fire"], "effect": {"ja": "Search your deck for a Basic Pokémon and put it onto your Bench. Then, shuffle your deck."}}, {"name": {"ja": "Flare"}, "damage": 30, "cost": ["Fire", "Colorless", "Colorless"]}],
+
+	weaknesses: [{"type": "Water", "value": "x2"}],
+	resistances: [],
+
+	variants: [{"type": "normal"}],
+
+	retreat: 2,
+	regulationMark: "I",
+	rarity: "Common",
+	dexId: [322],
+};
+
+export default card;

--- a/data-asia/M/M1L/013.ts
+++ b/data-asia/M/M1L/013.ts
@@ -1,0 +1,35 @@
+import { Card } from "../../../interfaces";
+import Set from "../M1L";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "メガバクーダex",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 340,
+	types: ["Fire"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Basic",
+
+	attacks: [{"name": {"ja": "Roasting Heat"}, "damage": "80+", "cost": ["Fire"], "effect": {"ja": "If your opponent's Active Pokémon is Burned, this attack does 160 more damage."}}, {"name": {"ja": "Volcano Meteor"}, "damage": 280, "cost": ["Fire", "Colorless", "Colorless", "Colorless"], "effect": {"ja": "Discard 2 Energy from this Pokémon."}}],
+
+	weaknesses: [{"type": "Water", "value": "x2"}],
+	resistances: [],
+
+	variants: [{"type": "holo"}],
+
+	retreat: 4,
+	regulationMark: "I",
+	rarity: "Double rare",
+	dexId: [323],
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/M/M1L/014.ts
+++ b/data-asia/M/M1L/014.ts
@@ -1,0 +1,34 @@
+import { Card } from "../../../interfaces";
+import Set from "../M1L";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ボルケニオン",
+	},
+
+	illustrator: "GIDORA",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Fire"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Basic",
+
+	attacks: [{"name": {"ja": "Singe"}, "cost": ["Fire"], "effect": {"ja": "Your opponent's Active Pokémon is now Burned"}}, {"name": {"ja": "Backfire"}, "damage": 130, "cost": ["Fire", "Fire", "Colorless"], "effect": {"ja": "Put 2  Energy attached to this Pokémon back into your hand"}}],
+
+	weaknesses: [{"type": "Water", "value": "x2"}],
+	resistances: [],
+
+	variants: [{"type": "normal"}],
+
+	retreat: 2,
+	regulationMark: "I",
+	rarity: "Uncommon",
+	dexId: [721],
+};
+
+export default card;

--- a/data-asia/M/M1L/015.ts
+++ b/data-asia/M/M1L/015.ts
@@ -1,0 +1,34 @@
+import { Card } from "../../../interfaces";
+import Set from "../M1L";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヒバニー",
+	},
+
+	illustrator: "svlt",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Fire"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Basic",
+
+	attacks: [{"name": {"ja": "Wild Kick"}, "cost": ["Colorless"], "effect": {"ja": "Flip a coin. If tails, this attack does nothing"}}],
+
+	weaknesses: [{"type": "Water", "value": "x2"}],
+	resistances: [],
+
+	variants: [{"type": "normal"}],
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "Common",
+	dexId: [813],
+};
+
+export default card;

--- a/data-asia/M/M1L/016.ts
+++ b/data-asia/M/M1L/016.ts
@@ -1,0 +1,38 @@
+import { Card } from "../../../interfaces";
+import Set from "../M1L";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ラビフット",
+	},
+
+	illustrator: "Narumi Sato",
+	category: "Pokemon",
+	hp: 100,
+	types: ["Fire"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Stage1",
+
+	evolveFrom: {
+		ja: "ヒバニー",
+	},
+
+	attacks: [{"name": {"ja": "Jump Kick"}, "cost": ["Colorless"], "effect": {"ja": "This attack does 40 damage to 1 of your opponent's Benched Pokémon (Don't apply Weakness and Resistance for Benched Pokémon)"}}],
+
+	weaknesses: [{"type": "Water", "value": "x2"}],
+	resistances: [],
+
+	variants: [{"type": "normal"}],
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "Common",
+	dexId: [814],
+};
+
+export default card;

--- a/data-asia/M/M1L/017.ts
+++ b/data-asia/M/M1L/017.ts
@@ -1,0 +1,40 @@
+import { Card } from "../../../interfaces";
+import Set from "../M1L";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "エースバーン",
+	},
+
+	illustrator: "REND",
+	category: "Pokemon",
+	hp: 160,
+	types: ["Fire"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Stage2",
+
+	evolveFrom: {
+		ja: "ラビフット",
+	},
+
+	abilities: [{"type": "Ability", "name": {"ja": "Explosiveness"}, "effect": {"ja": "If this Pokémon is in your hand when you are setting up to play, you may put it face down as your Active Pokémon."}}],
+
+	attacks: [{"name": {"ja": "Flare Turbo"}, "damage": 50, "cost": ["Colorless"], "effect": {"ja": "Search your deck for up to 3 Basic Energy and attach them to your Benched Pokemon in any way you like. Shuffle your deck."}}],
+
+	weaknesses: [{"type": "Water", "value": "x2"}],
+	resistances: [],
+
+	variants: [{"type": "holo"}],
+
+	retreat: 0,
+	regulationMark: "I",
+	rarity: "Rare",
+	dexId: [815],
+};
+
+export default card;

--- a/data-asia/M/M1L/018.ts
+++ b/data-asia/M/M1L/018.ts
@@ -1,0 +1,34 @@
+import { Card } from "../../../interfaces";
+import Set from "../M1L";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヘイガニ",
+	},
+
+	illustrator: "Sanosuke Sakuma",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Water"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Basic",
+
+	attacks: [{"name": {"ja": "Irongrip"}, "damage": 10, "cost": ["Colorless"]}, {"name": {"ja": "とっしん"}, "damage": 30, "cost": ["Colorless", "Colorless"], "effect": {"ja": "This Pokémon also does 10 damage to itself"}}],
+
+	weaknesses: [{"type": "Electric", "value": "x2"}],
+	resistances: [],
+
+	variants: [{"type": "normal"}],
+
+	retreat: 2,
+	regulationMark: "I",
+	rarity: "Common",
+	dexId: [341],
+};
+
+export default card;

--- a/data-asia/M/M1L/019.ts
+++ b/data-asia/M/M1L/019.ts
@@ -1,0 +1,34 @@
+import { Card } from "../../../interfaces";
+import Set from "../M1L";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "コレクレー",
+	},
+
+	illustrator: "Takeshi Nakamura",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Psychic"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Basic",
+
+	attacks: [{"name": {"ja": "Slap"}, "damage": 10, "cost": ["Colorless"]}],
+
+	weaknesses: [{"type": "Darkness", "value": "x2"}],
+	resistances: [{"type": "Fighting", "value": "-30"}],
+
+	variants: [{"type": "normal"}],
+
+	retreat: 2,
+	regulationMark: "I",
+	rarity: "Common",
+	dexId: [999],
+};
+
+export default card;

--- a/data-asia/M/M1L/020.ts
+++ b/data-asia/M/M1L/020.ts
@@ -1,0 +1,34 @@
+import { Card } from "../../../interfaces";
+import Set from "../M1L";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "サンド",
+	},
+
+	illustrator: "Shinji Kanda",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Fighting"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Basic",
+
+	attacks: [{"name": {"ja": "Dig Claws"}, "damage": 10, "cost": ["Colorless"]}, {"name": {"ja": "Mud-Slap"}, "damage": 20, "cost": ["Fighting", "Colorless"]}],
+
+	weaknesses: [{"type": "Grass", "value": "x2"}],
+	resistances: [],
+
+	variants: [{"type": "normal"}],
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "Common",
+	dexId: [27],
+};
+
+export default card;

--- a/data-asia/M/M1L/021.ts
+++ b/data-asia/M/M1L/021.ts
@@ -1,0 +1,38 @@
+import { Card } from "../../../interfaces";
+import Set from "../M1L";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "サンドパン",
+	},
+
+	illustrator: "imoniii",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Fighting"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Stage1",
+
+	evolveFrom: {
+		ja: "サンド",
+	},
+
+	attacks: [{"name": {"ja": "すなかけ"}, "damage": 50, "cost": ["Colorless", "Colorless"], "effect": {"ja": "If the Defending Pokémon tries to attack during your opponent's next turn, your opponent flips a coin. If tails, the attack does nothing"}}, {"name": {"ja": "Mud Shot"}, "damage": 100, "cost": ["Fighting", "Colorless", "Colorless"]}],
+
+	weaknesses: [{"type": "Grass", "value": "x2"}],
+	resistances: [],
+
+	variants: [{"type": "normal"}],
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "Common",
+	dexId: [28],
+};
+
+export default card;

--- a/data-asia/M/M1L/022.ts
+++ b/data-asia/M/M1L/022.ts
@@ -1,0 +1,34 @@
+import { Card } from "../../../interfaces";
+import Set from "../M1L";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "イワーク",
+	},
+
+	illustrator: "Uta",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Fighting"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Basic",
+
+	attacks: [{"name": {"ja": "しめつける"}, "damage": 30, "cost": ["Colorless", "Colorless"], "effect": {"ja": "Flip a coin. If heads, your opponent's Active Pokémon is now Paralyzed"}}, {"name": {"ja": "Strength"}, "damage": 100, "cost": ["Colorless", "Colorless", "Colorless"]}],
+
+	weaknesses: [{"type": "Grass", "value": "x2"}],
+	resistances: [],
+
+	variants: [{"type": "normal"}],
+
+	retreat: 4,
+	regulationMark: "I",
+	rarity: "Common",
+	dexId: [95],
+};
+
+export default card;

--- a/data-asia/M/M1L/023.ts
+++ b/data-asia/M/M1L/023.ts
@@ -1,0 +1,34 @@
+import { Card } from "../../../interfaces";
+import Set from "../M1L";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "バルキー",
+	},
+
+	illustrator: "OKUBO",
+	category: "Pokemon",
+	hp: 30,
+	types: ["Fighting"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Basic",
+
+	attacks: [{"name": {"ja": "Eager Hits"}, "damage": "10+", "cost": [], "effect": {"ja": "Flip a coin until you get tails. This attack does 30 more damage for each heads."}}],
+
+	weaknesses: [{"type": "Psychic", "value": "x2"}],
+	resistances: [],
+
+	variants: [{"type": "normal"}],
+
+	retreat: 0,
+	regulationMark: "I",
+	rarity: "Common",
+	dexId: [236],
+};
+
+export default card;

--- a/data-asia/M/M1L/024.ts
+++ b/data-asia/M/M1L/024.ts
@@ -1,0 +1,34 @@
+import { Card } from "../../../interfaces";
+import Set from "../M1L";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "マクノシタ",
+	},
+
+	illustrator: "Jerky",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Fighting"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Basic",
+
+	attacks: [{"name": {"ja": "Corkscrew Punch"}, "damage": 10, "cost": ["Fighting"]}, {"name": {"ja": "Confront"}, "damage": 30, "cost": ["Fighting", "Fighting"]}],
+
+	weaknesses: [{"type": "Psychic", "value": "x2"}],
+	resistances: [],
+
+	variants: [{"type": "normal"}],
+
+	retreat: 2,
+	regulationMark: "I",
+	rarity: "Common",
+	dexId: [296],
+};
+
+export default card;

--- a/data-asia/M/M1L/025.ts
+++ b/data-asia/M/M1L/025.ts
@@ -1,0 +1,40 @@
+import { Card } from "../../../interfaces";
+import Set from "../M1L";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ハリテヤマ",
+	},
+
+	illustrator: "GOSSAN",
+	category: "Pokemon",
+	hp: 150,
+	types: ["Fighting"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Stage1",
+
+	evolveFrom: {
+		ja: "マクノシタ",
+	},
+
+	abilities: [{"type": "Ability", "name": {"ja": "Sumo Catcher"}, "effect": {"ja": "Once during your turn, when you play this card from your hand to evolve one of your Pokémon, you may switch one of your opponent's Benched Pokémon with their Active Pokémon."}}],
+
+	attacks: [{"name": {"ja": "Wild Press"}, "damage": 210, "cost": ["Fighting", "Fighting", "Fighting"], "effect": {"ja": "This Pokémon does 70 damage to itself."}}],
+
+	weaknesses: [{"type": "Psychic", "value": "x2"}],
+	resistances: [],
+
+	variants: [{"type": "holo"}],
+
+	retreat: 3,
+	regulationMark: "I",
+	rarity: "Rare",
+	dexId: [297],
+};
+
+export default card;

--- a/data-asia/M/M1L/026.ts
+++ b/data-asia/M/M1L/026.ts
@@ -1,0 +1,36 @@
+import { Card } from "../../../interfaces";
+import Set from "../M1L";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ルナトーン",
+	},
+
+	illustrator: "Whisker",
+	category: "Pokemon",
+	hp: 110,
+	types: ["Fighting"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Basic",
+
+	abilities: [{"type": "Ability", "name": {"ja": "Lunar Cycle"}, "effect": {"ja": "Once during your turn, if Solrock is on your Bench, you may discard a Basic Fighting Energy. If you do, draw 3 cards. You can't use more than one Lunar Cycle Ability during your turn."}}],
+
+	attacks: [{"name": {"ja": "パワージェム"}, "damage": 50, "cost": ["Fighting", "Fighting"]}],
+
+	weaknesses: [{"type": "Grass", "value": "x2"}],
+	resistances: [],
+
+	variants: [{"type": "normal"}],
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "Uncommon",
+	dexId: [337],
+};
+
+export default card;

--- a/data-asia/M/M1L/027.ts
+++ b/data-asia/M/M1L/027.ts
@@ -1,0 +1,34 @@
+import { Card } from "../../../interfaces";
+import Set from "../M1L";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ソルロック",
+	},
+
+	illustrator: "Whisker",
+	category: "Pokemon",
+	hp: 110,
+	types: ["Fighting"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Basic",
+
+	attacks: [{"name": {"ja": "Cosmo Beam"}, "damage": 70, "cost": ["Fighting"], "effect": {"ja": "If you don't have Lunatone on your Bench, this attack does nothing. Don't apply Weakness and Resistance for this attack's damage."}}],
+
+	weaknesses: [{"type": "Grass", "value": "x2"}],
+	resistances: [],
+
+	variants: [{"type": "normal"}],
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "Uncommon",
+	dexId: [338],
+};
+
+export default card;

--- a/data-asia/M/M1L/028.ts
+++ b/data-asia/M/M1L/028.ts
@@ -1,0 +1,34 @@
+import { Card } from "../../../interfaces";
+import Set from "../M1L";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "リオル",
+	},
+
+	illustrator: "hncl",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Fighting"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Basic",
+
+	attacks: [{"name": {"ja": "Accelerating Stab"}, "damage": 30, "cost": ["Fighting"], "effect": {"ja": "During your next turn, this Pokémon can't use Accelerating Stab."}}],
+
+	weaknesses: [{"type": "Psychic", "value": "x2"}],
+	resistances: [],
+
+	variants: [{"type": "normal"}],
+
+	retreat: 2,
+	regulationMark: "I",
+	rarity: "Common",
+	dexId: [447],
+};
+
+export default card;

--- a/data-asia/M/M1L/029.ts
+++ b/data-asia/M/M1L/029.ts
@@ -1,0 +1,35 @@
+import { Card } from "../../../interfaces";
+import Set from "../M1L";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "メガルカリオex",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 340,
+	types: ["Fighting"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Basic",
+
+	attacks: [{"name": {"ja": "オーラジャブ"}, "damage": 130, "cost": ["Fighting"], "effect": {"ja": "Attach up to 3 Basic  Energy from your discard pile to your Benched Pokémon in any way yuo like."}}, {"name": {"ja": "メガブレイブ"}, "damage": 270, "cost": ["Fighting", "Fighting"], "effect": {"ja": "During your next turn, this Pokémon can't use Mega Brave"}}],
+
+	weaknesses: [{"type": "Psychic", "value": "x2"}],
+	resistances: [],
+
+	variants: [{"type": "holo"}],
+
+	retreat: 2,
+	regulationMark: "I",
+	rarity: "Double rare",
+	dexId: [448],
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/M/M1L/030.ts
+++ b/data-asia/M/M1L/030.ts
@@ -1,0 +1,34 @@
+import { Card } from "../../../interfaces";
+import Set from "../M1L";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "グレッグル",
+	},
+
+	illustrator: "matazo",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Fighting"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Basic",
+
+	attacks: [{"name": {"ja": "Smack"}, "damage": 20, "cost": ["Fighting"]}],
+
+	weaknesses: [{"type": "Psychic", "value": "x2"}],
+	resistances: [],
+
+	variants: [{"type": "normal"}],
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "Common",
+	dexId: [453],
+};
+
+export default card;

--- a/data-asia/M/M1L/031.ts
+++ b/data-asia/M/M1L/031.ts
@@ -1,0 +1,38 @@
+import { Card } from "../../../interfaces";
+import Set from "../M1L";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ドクロッグ",
+	},
+
+	illustrator: "Hasuno",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Fighting"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Stage1",
+
+	evolveFrom: {
+		ja: "グレッグル",
+	},
+
+	attacks: [{"name": {"ja": "Reckless Charge"}, "damage": 70, "cost": ["Fighting"], "effect": {"ja": "This Pokémon also does 20 damage to itself"}}],
+
+	weaknesses: [{"type": "Psychic", "value": "x2"}],
+	resistances: [],
+
+	variants: [{"type": "normal"}],
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "Common",
+	dexId: [454],
+};
+
+export default card;

--- a/data-asia/M/M1L/032.ts
+++ b/data-asia/M/M1L/032.ts
@@ -1,0 +1,34 @@
+import { Card } from "../../../interfaces";
+import Set from "../M1L";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "マーシャドー",
+	},
+
+	illustrator: "Tomomi Ozaki",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Fighting"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Basic",
+
+	attacks: [{"name": {"ja": "Shadow Boxing"}, "damage": 60, "cost": ["Fighting", "Fighting"], "effect": {"ja": "If the Defending Pokémon is Knocked Out by damage from this attack, during your opponent's next turn this Pokémon receives no damage or effects from your opponent's Pokémon's attacks"}}],
+
+	weaknesses: [{"type": "Psychic", "value": "x2"}],
+	resistances: [],
+
+	variants: [{"type": "normal"}],
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "Uncommon",
+	dexId: [802],
+};
+
+export default card;

--- a/data-asia/M/M1L/033.ts
+++ b/data-asia/M/M1L/033.ts
@@ -1,0 +1,34 @@
+import { Card } from "../../../interfaces";
+import Set from "../M1L";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "イシヘンジン",
+	},
+
+	illustrator: "Hitoshi Ariga",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Fighting"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Basic",
+
+	attacks: [{"name": {"ja": "Stone Kick"}, "damage": 20, "cost": ["Fighting"], "effect": {"ja": "This attack also does 20 damage to 1 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon)"}}, {"name": {"ja": "Boundless Power"}, "damage": 140, "cost": ["Fighting", "Fighting", "Colorless"], "effect": {"ja": "During your next turn, this Pokémon can't attack."}}],
+
+	weaknesses: [{"type": "Grass", "value": "x2"}],
+	resistances: [],
+
+	variants: [{"type": "normal"}],
+
+	retreat: 2,
+	regulationMark: "I",
+	rarity: "Uncommon",
+	dexId: [874],
+};
+
+export default card;

--- a/data-asia/M/M1L/034.ts
+++ b/data-asia/M/M1L/034.ts
@@ -1,0 +1,34 @@
+import { Card } from "../../../interfaces";
+import Set from "../M1L";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "コジオ",
+	},
+
+	illustrator: "sowsow",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Fighting"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Basic",
+
+	attacks: [{"name": {"ja": "たいあたり"}, "cost": ["Colorless"]}],
+
+	weaknesses: [{"type": "Grass", "value": "x2"}],
+	resistances: [],
+
+	variants: [{"type": "normal"}],
+
+	retreat: 2,
+	regulationMark: "I",
+	rarity: "Common",
+	dexId: [932],
+};
+
+export default card;

--- a/data-asia/M/M1L/035.ts
+++ b/data-asia/M/M1L/035.ts
@@ -1,0 +1,38 @@
+import { Card } from "../../../interfaces";
+import Set from "../M1L";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ジオヅム",
+	},
+
+	illustrator: "kodama",
+	category: "Pokemon",
+	hp: 110,
+	types: ["Fighting"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Stage1",
+
+	evolveFrom: {
+		ja: "コジオ",
+	},
+
+	attacks: [{"name": {"ja": "Rock Hurl"}, "damage": 50, "cost": ["Fighting", "Colorless"], "effect": {"ja": "This attack's damage isn't affected by Resistance"}}],
+
+	weaknesses: [{"type": "Grass", "value": "x2"}],
+	resistances: [],
+
+	variants: [{"type": "normal"}],
+
+	retreat: 3,
+	regulationMark: "I",
+	rarity: "Common",
+	dexId: [933],
+};
+
+export default card;

--- a/data-asia/M/M1L/036.ts
+++ b/data-asia/M/M1L/036.ts
@@ -1,0 +1,40 @@
+import { Card } from "../../../interfaces";
+import Set from "../M1L";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "キョジオーン",
+	},
+
+	illustrator: "danciao",
+	category: "Pokemon",
+	hp: 180,
+	types: ["Fighting"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Stage2",
+
+	evolveFrom: {
+		ja: "ジオヅム",
+	},
+
+	abilities: [{"type": "Ability", "name": {"ja": "Power Salt"}, "effect": {"ja": "Attacks used by your Pokémon deal 30 more damage to your opponent's Active Pokémon."}}],
+
+	attacks: [{"name": {"ja": "Hammer In"}, "damage": 130, "cost": ["Fighting", "Fighting", "Colorless"]}],
+
+	weaknesses: [{"type": "Grass", "value": "x2"}],
+	resistances: [],
+
+	variants: [{"type": "holo"}],
+
+	retreat: 4,
+	regulationMark: "I",
+	rarity: "Rare",
+	dexId: [934],
+};
+
+export default card;

--- a/data-asia/M/M1L/037.ts
+++ b/data-asia/M/M1L/037.ts
@@ -1,0 +1,38 @@
+import { Card } from "../../../interfaces";
+import Set from "../M1L";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "シザリガー",
+	},
+
+	illustrator: "kawayoo",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Darkness"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Stage1",
+
+	evolveFrom: {
+		ja: "ヘイガニ",
+	},
+
+	attacks: [{"name": {"ja": "Vise Grip"}, "damage": 30, "cost": ["Colorless"]}, {"name": {"ja": "Payback Scissors"}, "damage": 130, "cost": ["Darkness", "Darkness", "Colorless"], "effect": {"ja": "If this Pokémon has any damage counters on it, this attack can be used for 1  Energy."}}],
+
+	weaknesses: [{"type": "Grass", "value": "x2"}],
+	resistances: [],
+
+	variants: [{"type": "normal"}],
+
+	retreat: 3,
+	regulationMark: "I",
+	rarity: "Uncommon",
+	dexId: [342],
+};
+
+export default card;

--- a/data-asia/M/M1L/038.ts
+++ b/data-asia/M/M1L/038.ts
@@ -1,0 +1,35 @@
+import { Card } from "../../../interfaces";
+import Set from "../M1L";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "メガアブソルex",
+	},
+
+	illustrator: "aky CG Works",
+	category: "Pokemon",
+	hp: 280,
+	types: ["Darkness"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Basic",
+
+	attacks: [{"name": {"ja": "Terminal Period"}, "cost": ["Darkness", "Colorless"], "effect": {"ja": "If your opponent's Active Pokémon has exactly 6 damage counters on it, it is now Knocked Out."}}, {"name": {"ja": "Claw of Darkness"}, "damage": 200, "cost": ["Darkness", "Darkness", "Colorless"], "effect": {"ja": "Look at your opponent's hand and discard 1 card you find there."}}],
+
+	weaknesses: [{"type": "Grass", "value": "x2"}],
+	resistances: [],
+
+	variants: [{"type": "holo"}],
+
+	retreat: 2,
+	regulationMark: "I",
+	rarity: "Double rare",
+	dexId: [359],
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/M/M1L/039.ts
+++ b/data-asia/M/M1L/039.ts
@@ -1,0 +1,36 @@
+import { Card } from "../../../interfaces";
+import Set from "../M1L";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ミカルゲ",
+	},
+
+	illustrator: "mingo",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Darkness"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Basic",
+
+	abilities: [{"type": "Ability", "name": {"ja": "Vengeful Swirl"}, "effect": {"ja": "Whenever your Active Darkness Pokémon takes damage from an opponent's Pokémon's attack, put 1 damage counter on the attacking Pokémon."}}],
+
+	attacks: [{"name": {"ja": "Top Breaker"}, "damage": 10, "cost": ["Darkness"], "effect": {"ja": "Discard the top card of your opponent's deck."}}],
+
+	weaknesses: [{"type": "Grass", "value": "x2"}],
+	resistances: [],
+
+	variants: [{"type": "normal"}],
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "Uncommon",
+	dexId: [442],
+};
+
+export default card;

--- a/data-asia/M/M1L/040.ts
+++ b/data-asia/M/M1L/040.ts
@@ -1,0 +1,34 @@
+import { Card } from "../../../interfaces";
+import Set from "../M1L";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "イベルタル",
+	},
+
+	illustrator: "akagi",
+	category: "Pokemon",
+	hp: 110,
+	types: ["Darkness"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Basic",
+
+	attacks: [{"name": {"ja": "Clutch"}, "damage": 20, "cost": ["Darkness"], "effect": {"ja": "During your opponent's next turn, the Defending Pokémon can't retreat."}}, {"name": {"ja": "Dark Feather"}, "damage": 110, "cost": ["Darkness", "Darkness", "Colorless"]}],
+
+	weaknesses: [{"type": "Electric", "value": "x2"}],
+	resistances: [{"type": "Fighting", "value": "-30"}],
+
+	variants: [{"type": "holo"}],
+
+	retreat: 0,
+	regulationMark: "I",
+	rarity: "Rare",
+	dexId: [717],
+};
+
+export default card;

--- a/data-asia/M/M1L/041.ts
+++ b/data-asia/M/M1L/041.ts
@@ -1,0 +1,34 @@
+import { Card } from "../../../interfaces";
+import Set from "../M1L";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "クスネ",
+	},
+
+	illustrator: "Souichirou Gunjima",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Darkness"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Basic",
+
+	attacks: [{"name": {"ja": "Darkness Fang"}, "damage": 20, "cost": ["Darkness"]}],
+
+	weaknesses: [{"type": "Grass", "value": "x2"}],
+	resistances: [],
+
+	variants: [{"type": "normal"}],
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "Common",
+	dexId: [827],
+};
+
+export default card;

--- a/data-asia/M/M1L/042.ts
+++ b/data-asia/M/M1L/042.ts
@@ -1,0 +1,38 @@
+import { Card } from "../../../interfaces";
+import Set from "../M1L";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "フォクスライ",
+	},
+
+	illustrator: "ryoma uratsuka",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Darkness"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Stage1",
+
+	evolveFrom: {
+		ja: "クスネ",
+	},
+
+	attacks: [{"name": {"ja": "Greedy Hunt"}, "damage": 20, "cost": ["Colorless"], "effect": {"ja": "You may draw cards until you have 6 cards in your hand"}}, {"name": {"ja": "Pitch-Black Fangs"}, "damage": 60, "cost": ["Darkness", "Colorless"]}],
+
+	weaknesses: [{"type": "Grass", "value": "x2"}],
+	resistances: [],
+
+	variants: [{"type": "normal"}],
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "Common",
+	dexId: [828],
+};
+
+export default card;

--- a/data-asia/M/M1L/043.ts
+++ b/data-asia/M/M1L/043.ts
@@ -1,0 +1,34 @@
+import { Card } from "../../../interfaces";
+import Set from "../M1L";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "シルシュルー",
+	},
+
+	illustrator: "osare",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Darkness"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Basic",
+
+	attacks: [{"name": {"ja": "Poison Jab"}, "damage": 20, "cost": ["Darkness", "Colorless"], "effect": {"ja": "Your opponent's Active Pokémon is now Poisoned."}}],
+
+	weaknesses: [{"type": "Fighting", "value": "x2"}],
+	resistances: [],
+
+	variants: [{"type": "normal"}],
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "Common",
+	dexId: [944],
+};
+
+export default card;

--- a/data-asia/M/M1L/044.ts
+++ b/data-asia/M/M1L/044.ts
@@ -1,0 +1,38 @@
+import { Card } from "../../../interfaces";
+import Set from "../M1L";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "タギングル",
+	},
+
+	illustrator: "Dsuke",
+	category: "Pokemon",
+	hp: 100,
+	types: ["Darkness"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Stage1",
+
+	evolveFrom: {
+		ja: "シルシュルー",
+	},
+
+	attacks: [{"name": {"ja": "Miracle Paint"}, "damage": 90, "cost": ["Darkness", "Colorless"], "effect": {"ja": "Flip a coin. If heads, pick a Special Condition. Your opponent's Active Pokémon now has that condition."}}],
+
+	weaknesses: [{"type": "Fighting", "value": "x2"}],
+	resistances: [],
+
+	variants: [{"type": "normal"}],
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "Common",
+	dexId: [945],
+};
+
+export default card;

--- a/data-asia/M/M1L/045.ts
+++ b/data-asia/M/M1L/045.ts
@@ -1,0 +1,38 @@
+import { Card } from "../../../interfaces";
+import Set from "../M1L";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ハガネール",
+	},
+
+	illustrator: "Anesaki Dynamic",
+	category: "Pokemon",
+	hp: 200,
+	types: ["Metal"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Stage1",
+
+	evolveFrom: {
+		ja: "イワーク",
+	},
+
+	attacks: [{"name": {"ja": "ウェルカムテール"}, "damage": "40+", "cost": ["Colorless", "Colorless"], "effect": {"ja": "If you have exactly 6 prize cards remaining, this attack does 200 more damage."}}, {"name": {"ja": "ロケットずつき"}, "damage": 140, "cost": ["Metal", "Metal", "Colorless", "Colorless"]}],
+
+	weaknesses: [{"type": "Fire", "value": "x2"}],
+	resistances: [{"type": "Grass", "value": "-30"}],
+
+	variants: [{"type": "holo"}],
+
+	retreat: 4,
+	regulationMark: "I",
+	rarity: "Rare",
+	dexId: [208],
+};
+
+export default card;

--- a/data-asia/M/M1L/046.ts
+++ b/data-asia/M/M1L/046.ts
@@ -1,0 +1,35 @@
+import { Card } from "../../../interfaces";
+import Set from "../M1L";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "メガクチートex",
+	},
+
+	illustrator: "aky CG Works",
+	category: "Pokemon",
+	hp: 270,
+	types: ["Metal"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Basic",
+
+	attacks: [{"name": {"ja": "Gobble Down"}, "damage": "80x", "cost": ["Metal", "Metal"], "effect": {"ja": "This attack does 80 damage for each prize card you've already taken."}}, {"name": {"ja": "Big Bite"}, "damage": 260, "cost": ["Metal", "Metal", "Colorless"], "effect": {"ja": "If your opponent's Active Pokémon already has any damage s on it, this attack does 30 damage instead."}}],
+
+	weaknesses: [{"type": "Fire", "value": "x2"}],
+	resistances: [{"type": "Grass", "value": "-30"}],
+
+	variants: [{"type": "holo"}],
+
+	retreat: 2,
+	regulationMark: "I",
+	rarity: "Double rare",
+	dexId: [303],
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/M/M1L/047.ts
+++ b/data-asia/M/M1L/047.ts
@@ -1,0 +1,34 @@
+import { Card } from "../../../interfaces";
+import Set from "../M1L";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ディアルガ",
+	},
+
+	illustrator: "Teeziro",
+	category: "Pokemon",
+	hp: 140,
+	types: ["Metal"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Basic",
+
+	attacks: [{"name": {"ja": "Beam"}, "damage": 30, "cost": ["Metal"]}, {"name": {"ja": "Chrono Burst"}, "damage": "80+", "cost": ["Metal", "Metal", "Colorless"], "effect": {"ja": "You may discard this Pokémon and shuffle all Energy attached to it into your deck. If you do, this attack does 80 more damage"}}],
+
+	weaknesses: [{"type": "Fire", "value": "x2"}],
+	resistances: [{"type": "Grass", "value": "-30"}],
+
+	variants: [{"type": "holo"}],
+
+	retreat: 2,
+	regulationMark: "I",
+	rarity: "Rare",
+	dexId: [483],
+};
+
+export default card;

--- a/data-asia/M/M1L/048.ts
+++ b/data-asia/M/M1L/048.ts
@@ -1,0 +1,34 @@
+import { Card } from "../../../interfaces";
+import Set from "../M1L";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "カヌチャン",
+	},
+
+	illustrator: "You Iribi",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Metal"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Basic",
+
+	attacks: [{"name": {"ja": "Slap"}, "damage": 20, "cost": ["Metal"]}],
+
+	weaknesses: [{"type": "Fire", "value": "x2"}],
+	resistances: [{"type": "Grass", "value": "-30"}],
+
+	variants: [{"type": "normal"}],
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "Common",
+	dexId: [957],
+};
+
+export default card;

--- a/data-asia/M/M1L/049.ts
+++ b/data-asia/M/M1L/049.ts
@@ -1,0 +1,40 @@
+import { Card } from "../../../interfaces";
+import Set from "../M1L";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ナカヌチャン",
+	},
+
+	illustrator: "KEIICHIRO ITO",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Metal"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Stage1",
+
+	evolveFrom: {
+		ja: "カヌチャン",
+	},
+
+	abilities: [{"type": "Ability", "name": {"ja": "Sudden Hammer"}, "effect": {"ja": "Once during your turn, when you play this card from your hand to evolve one of your Pokemon, you may flip a coin. If heads, discard an Energy from your opponent's Active Pokémon."}}],
+
+	attacks: [{"name": {"ja": "Wham"}, "damage": 30, "cost": ["Metal"]}],
+
+	weaknesses: [{"type": "Fire", "value": "x2"}],
+	resistances: [{"type": "Grass", "value": "-30"}],
+
+	variants: [{"type": "normal"}],
+
+	retreat: 2,
+	regulationMark: "I",
+	rarity: "Common",
+	dexId: [958],
+};
+
+export default card;

--- a/data-asia/M/M1L/050.ts
+++ b/data-asia/M/M1L/050.ts
@@ -1,0 +1,38 @@
+import { Card } from "../../../interfaces";
+import Set from "../M1L";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "デカヌチャン",
+	},
+
+	illustrator: "toriyufu",
+	category: "Pokemon",
+	hp: 160,
+	types: ["Metal"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Stage2",
+
+	evolveFrom: {
+		ja: "ナカヌチャン",
+	},
+
+	attacks: [{"name": {"ja": "Big Swing"}, "damage": "240-", "cost": ["Metal"], "effect": {"ja": "This attack does 60 less damage for each Energy attached to your opponent's Active Pokémon."}}],
+
+	weaknesses: [{"type": "Fire", "value": "x2"}],
+	resistances: [{"type": "Grass", "value": "-30"}],
+
+	variants: [{"type": "normal"}],
+
+	retreat: 2,
+	regulationMark: "I",
+	rarity: "Uncommon",
+	dexId: [959],
+};
+
+export default card;

--- a/data-asia/M/M1L/051.ts
+++ b/data-asia/M/M1L/051.ts
@@ -1,0 +1,38 @@
+import { Card } from "../../../interfaces";
+import Set from "../M1L";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "サーフゴー",
+	},
+
+	illustrator: "Yukihiro Tada",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Metal"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Stage1",
+
+	evolveFrom: {
+		ja: "コレクレー",
+	},
+
+	attacks: [{"name": {"ja": "All-You-Can-Grab"}, "cost": ["Colorless"]}, {"name": {"ja": "Speed Attack"}, "damage": 100, "cost": ["Metal", "Colorless", "Colorless"]}],
+
+	weaknesses: [{"type": "Fire", "value": "x2"}],
+	resistances: [{"type": "Grass", "value": "-30"}],
+
+	variants: [{"type": "normal"}],
+
+	retreat: 2,
+	regulationMark: "I",
+	rarity: "Uncommon",
+	dexId: [1000],
+};
+
+export default card;

--- a/data-asia/M/M1L/052.ts
+++ b/data-asia/M/M1L/052.ts
@@ -1,0 +1,34 @@
+import { Card } from "../../../interfaces";
+import Set from "../M1L";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "オニスズメ",
+	},
+
+	illustrator: "Scav",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Colorless"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Basic",
+
+	attacks: [{"name": {"ja": "ついばむ"}, "damage": 10, "cost": ["Colorless"], "effect": {"ja": "Before doing damage, discard all Pokémon Tools from your opponent's Active Pokémon."}}],
+
+	weaknesses: [{"type": "Electric", "value": "x2"}],
+	resistances: [{"type": "Fighting", "value": "-30"}],
+
+	variants: [{"type": "normal"}],
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "Common",
+	dexId: [21],
+};
+
+export default card;

--- a/data-asia/M/M1L/053.ts
+++ b/data-asia/M/M1L/053.ts
@@ -1,0 +1,38 @@
+import { Card } from "../../../interfaces";
+import Set from "../M1L";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "オニドリル",
+	},
+
+	illustrator: "Saboteri",
+	category: "Pokemon",
+	hp: 100,
+	types: ["Colorless"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Stage1",
+
+	evolveFrom: {
+		ja: "オニスズメ",
+	},
+
+	attacks: [{"name": {"ja": "Repeating Drill"}, "damage": "30x", "cost": ["Colorless"], "effect": {"ja": "Flip 5 coins. This attack does 30 damage for each heads"}}],
+
+	weaknesses: [{"type": "Electric", "value": "x2"}],
+	resistances: [{"type": "Fighting", "value": "-30"}],
+
+	variants: [{"type": "normal"}],
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "Common",
+	dexId: [22],
+};
+
+export default card;

--- a/data-asia/M/M1L/054.ts
+++ b/data-asia/M/M1L/054.ts
@@ -1,0 +1,34 @@
+import { Card } from "../../../interfaces";
+import Set from "../M1L";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ミルタンク",
+	},
+
+	illustrator: "Kouki Saitou",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Colorless"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Basic",
+
+	attacks: [{"name": {"ja": "Filling Milk"}, "cost": ["Colorless", "Colorless"], "effect": {"ja": "Flip 2 coins. If both are heads, heal all damage from 1 of your Pokémon"}}, {"name": {"ja": "たいあたり"}, "damage": 60, "cost": ["Colorless", "Colorless", "Colorless"]}],
+
+	weaknesses: [{"type": "Fighting", "value": "x2"}],
+	resistances: [],
+
+	variants: [{"type": "normal"}],
+
+	retreat: 2,
+	regulationMark: "I",
+	rarity: "Common",
+	dexId: [241],
+};
+
+export default card;

--- a/data-asia/M/M1L/055.ts
+++ b/data-asia/M/M1L/055.ts
@@ -1,0 +1,34 @@
+import { Card } from "../../../interfaces";
+import Set from "../M1L";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヤングース",
+	},
+
+	illustrator: "Mekayu",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Colorless"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Basic",
+
+	attacks: [{"name": {"ja": "Collect"}, "cost": ["Colorless"], "effect": {"ja": "Draw a card"}}, {"name": {"ja": "Gnaw"}, "damage": 20, "cost": ["Colorless", "Colorless"]}],
+
+	weaknesses: [{"type": "Fighting", "value": "x2"}],
+	resistances: [],
+
+	variants: [{"type": "normal"}],
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "Common",
+	dexId: [734],
+};
+
+export default card;

--- a/data-asia/M/M1L/056.ts
+++ b/data-asia/M/M1L/056.ts
@@ -1,0 +1,40 @@
+import { Card } from "../../../interfaces";
+import Set from "../M1L";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "デカグース",
+	},
+
+	illustrator: "Shigenori Negishi",
+	category: "Pokemon",
+	hp: 100,
+	types: ["Colorless"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Stage1",
+
+	evolveFrom: {
+		ja: "ヤングース",
+	},
+
+	abilities: [{"type": "Ability", "name": {"ja": "Look for Clues"}, "effect": {"ja": "Once during your turn, you may switch a card from your hand with the top card of your deck."}}],
+
+	attacks: [{"name": {"ja": "かみつく"}, "damage": 50, "cost": ["Colorless", "Colorless"]}],
+
+	weaknesses: [{"type": "Fighting", "value": "x2"}],
+	resistances: [],
+
+	variants: [{"type": "normal"}],
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "Uncommon",
+	dexId: [735],
+};
+
+export default card;

--- a/data-asia/M/M1L/057.ts
+++ b/data-asia/M/M1L/057.ts
@@ -1,0 +1,25 @@
+import { Card } from "../../../interfaces";
+import Set from "../M1L";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アイアンガード",
+	},
+
+	illustrator: "Studio Bora Inc.",
+	category: "Trainer",
+
+	effect: {
+		ja: "During your opponent's next turn, your Metal type Pokémon take 30 less damage from attacks from your opponent's Pokémon (including Pokémon put in play after you play this card).",
+	},
+
+
+	variants: [{"type": "normal"}],
+
+	trainerType: "Item",
+	regulationMark: "I",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/M/M1L/058.ts
+++ b/data-asia/M/M1L/058.ts
@@ -1,0 +1,25 @@
+import { Card } from "../../../interfaces";
+import Set from "../M1L";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "プレミアムパワープロ",
+	},
+
+	illustrator: "Toyste Beach",
+	category: "Trainer",
+
+	effect: {
+		ja: "During this turn, attacks used by your Pokémon do 30 more damage to your opponent's Active Pokémon (before applying Weakness and Resistance)",
+	},
+
+
+	variants: [{"type": "normal"}],
+
+	trainerType: "Item",
+	regulationMark: "I",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/M/M1L/059.ts
+++ b/data-asia/M/M1L/059.ts
@@ -1,0 +1,25 @@
+import { Card } from "../../../interfaces";
+import Set from "../M1L";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ファイトゴング",
+	},
+
+	illustrator: "Toyste Beach",
+	category: "Trainer",
+
+	effect: {
+		ja: "Search your deck for a Fighting type Basic Pokémon or for a Basic Fighting Energy, reveal it, and put it into your hand. Then shuffle your deck.",
+	},
+
+
+	variants: [{"type": "normal"}],
+
+	trainerType: "Item",
+	regulationMark: "I",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/M/M1L/060.ts
+++ b/data-asia/M/M1L/060.ts
@@ -1,0 +1,25 @@
+import { Card } from "../../../interfaces";
+import Set from "../M1L";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "むしよけスプレー",
+	},
+
+	illustrator: "Studio Bora Inc.",
+	category: "Energy",
+	energyType: "Special",
+
+	effect: {
+		ja: "Provides one energy",
+	},
+
+
+	variants: [{"type": "normal"}],
+
+	regulationMark: "I",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/M/M1L/061.ts
+++ b/data-asia/M/M1L/061.ts
@@ -1,0 +1,25 @@
+import { Card } from "../../../interfaces";
+import Set from "../M1L";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "マチスのかけひき",
+	},
+
+	illustrator: "Hideki Ishikawa",
+	category: "Trainer",
+
+	effect: {
+		ja: "Ask you opponent if they agree to have each player take a Prize card. If your opponent agrees, each take a Prize card. If they don't, you draw 4 cards.",
+	},
+
+
+	variants: [{"type": "normal"}],
+
+	trainerType: "Supporter",
+	regulationMark: "I",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/M/M1L/062.ts
+++ b/data-asia/M/M1L/062.ts
@@ -1,0 +1,25 @@
+import { Card } from "../../../interfaces";
+import Set from "../M1L";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "リーリエのきもち",
+	},
+
+	illustrator: "Atsushi Furusawa",
+	category: "Trainer",
+
+	effect: {
+		ja: "Shuffle your hand into your deck. Then, draw 6 cards. If you have 6 prize cards remaining, draw 8 cards instead.",
+	},
+
+
+	variants: [{"type": "normal"}],
+
+	trainerType: "Supporter",
+	regulationMark: "I",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/M/M1L/063.ts
+++ b/data-asia/M/M1L/063.ts
@@ -1,0 +1,25 @@
+import { Card } from "../../../interfaces";
+import Set from "../M1L";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "危険な廃墟ビル",
+	},
+
+	illustrator: "imoniii",
+	category: "Trainer",
+
+	effect: {
+		ja: "This card stays in play when you play it. Discard this card if another Stadium card comes into play. If another card with the same name is in play, you can't play this card.",
+	},
+
+
+	variants: [{"type": "normal"}],
+
+	trainerType: "Stadium",
+	regulationMark: "I",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/M/M1L/064.ts
+++ b/data-asia/M/M1L/064.ts
@@ -1,0 +1,34 @@
+import { Card } from "../../../interfaces";
+import Set from "../M1L";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "フシギダネ",
+	},
+
+	illustrator: "mashu",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Grass"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Basic",
+
+	attacks: [{"name": {"ja": "ねばるいと"}, "damage": 10, "cost": ["Grass"], "effect": {"ja": "During your opponent's next turn, the Defending Pokémon can't retreat."}}],
+
+	weaknesses: [{"type": "Fire", "value": "x2"}],
+	resistances: [],
+
+	variants: [{"type": "holo"}],
+
+	retreat: 2,
+	regulationMark: "I",
+	rarity: "Illustration rare",
+	dexId: [1],
+};
+
+export default card;

--- a/data-asia/M/M1L/065.ts
+++ b/data-asia/M/M1L/065.ts
@@ -1,0 +1,38 @@
+import { Card } from "../../../interfaces";
+import Set from "../M1L";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "フシギソウ",
+	},
+
+	illustrator: "mashu",
+	category: "Pokemon",
+	hp: 110,
+	types: ["Grass"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Stage1",
+
+	evolveFrom: {
+		ja: "フシギダネ",
+	},
+
+	attacks: [{"name": {"ja": "はっぱカッター"}, "damage": 60, "cost": ["Grass", "Grass"]}],
+
+	weaknesses: [{"type": "Fire", "value": "x2"}],
+	resistances: [],
+
+	variants: [{"type": "holo"}],
+
+	retreat: 3,
+	regulationMark: "I",
+	rarity: "Illustration rare",
+	dexId: [2],
+};
+
+export default card;

--- a/data-asia/M/M1L/066.ts
+++ b/data-asia/M/M1L/066.ts
@@ -1,0 +1,38 @@
+import { Card } from "../../../interfaces";
+import Set from "../M1L";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ナッシー",
+	},
+
+	illustrator: "Yukihiro Tada",
+	category: "Pokemon",
+	hp: 140,
+	types: ["Grass"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Stage1",
+
+	evolveFrom: {
+		ja: "タマタマ",
+	},
+
+	attacks: [{"name": {"ja": "Guard Press"}, "damage": 30, "cost": ["Grass"], "effect": {"ja": "During your next turn, this Pokémon receives 30 less damage from attacks (after applying Weakness and Resistance)"}}, {"name": {"ja": "Wood Stamp"}, "damage": "60+", "cost": ["Colorless", "Colorless", "Colorless"], "effect": {"ja": "This attack does 30 more damage for each  Energy attached to this Pokémon"}}],
+
+	weaknesses: [{"type": "Fire", "value": "x2"}],
+	resistances: [],
+
+	variants: [{"type": "holo"}],
+
+	retreat: 2,
+	regulationMark: "I",
+	rarity: "Illustration rare",
+	dexId: [103],
+};
+
+export default card;

--- a/data-asia/M/M1L/067.ts
+++ b/data-asia/M/M1L/067.ts
@@ -1,0 +1,34 @@
+import { Card } from "../../../interfaces";
+import Set from "../M1L";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ロコン",
+	},
+
+	illustrator: "saino misaki",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Fire"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Basic",
+
+	attacks: [{"name": {"ja": "なだれ"}, "damage": 10, "cost": ["Colorless"]}, {"name": {"ja": "Combustion"}, "damage": 20, "cost": ["Fire", "Colorless"]}],
+
+	weaknesses: [{"type": "Water", "value": "x2"}],
+	resistances: [],
+
+	variants: [{"type": "holo"}],
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "Illustration rare",
+	dexId: [37],
+};
+
+export default card;

--- a/data-asia/M/M1L/068.ts
+++ b/data-asia/M/M1L/068.ts
@@ -1,0 +1,34 @@
+import { Card } from "../../../interfaces";
+import Set from "../M1L";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "リオル",
+	},
+
+	illustrator: "GOSSAN",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Fighting"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Basic",
+
+	attacks: [{"name": {"ja": "Accelerating Stab"}, "damage": 30, "cost": ["Fighting"], "effect": {"ja": "During your next turn, this Pokémon can't use Accelerating Stab."}}],
+
+	weaknesses: [{"type": "Psychic", "value": "x2"}],
+	resistances: [],
+
+	variants: [{"type": "holo"}],
+
+	retreat: 2,
+	regulationMark: "I",
+	rarity: "Illustration rare",
+	dexId: [447],
+};
+
+export default card;

--- a/data-asia/M/M1L/069.ts
+++ b/data-asia/M/M1L/069.ts
@@ -1,0 +1,34 @@
+import { Card } from "../../../interfaces";
+import Set from "../M1L";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "マーシャドー",
+	},
+
+	illustrator: "0313",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Fighting"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Basic",
+
+	attacks: [{"name": {"ja": "Shadow Boxing"}, "damage": 60, "cost": ["Fighting", "Fighting"], "effect": {"ja": "If the Defending Pokémon is Knocked Out by damage from this attack, during your opponent's next turn this Pokémon receives no damage or effects from your opponent's Pokémon's attacks"}}],
+
+	weaknesses: [{"type": "Psychic", "value": "x2"}],
+	resistances: [],
+
+	variants: [{"type": "holo"}],
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "Illustration rare",
+	dexId: [802],
+};
+
+export default card;

--- a/data-asia/M/M1L/070.ts
+++ b/data-asia/M/M1L/070.ts
@@ -1,0 +1,40 @@
+import { Card } from "../../../interfaces";
+import Set from "../M1L";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "キョジオーン",
+	},
+
+	illustrator: "Yano Keiji",
+	category: "Pokemon",
+	hp: 180,
+	types: ["Fighting"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Stage2",
+
+	evolveFrom: {
+		ja: "ジオヅム",
+	},
+
+	abilities: [{"type": "Ability", "name": {"ja": "Power Salt"}, "effect": {"ja": "Attacks used by your Pokémon deal 30 more damage to your opponent's Active Pokémon."}}],
+
+	attacks: [{"name": {"ja": "Hammer In"}, "damage": 130, "cost": ["Fighting", "Fighting", "Colorless"]}],
+
+	weaknesses: [{"type": "Grass", "value": "x2"}],
+	resistances: [],
+
+	variants: [{"type": "holo"}],
+
+	retreat: 4,
+	regulationMark: "I",
+	rarity: "Illustration rare",
+	dexId: [934],
+};
+
+export default card;

--- a/data-asia/M/M1L/071.ts
+++ b/data-asia/M/M1L/071.ts
@@ -1,0 +1,36 @@
+import { Card } from "../../../interfaces";
+import Set from "../M1L";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ミカルゲ",
+	},
+
+	illustrator: "IKEDA Saki",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Darkness"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Basic",
+
+	abilities: [{"type": "Ability", "name": {"ja": "Vengeful Swirl"}, "effect": {"ja": "Whenever your Active Darkness Pokémon takes damage from an opponent's Pokémon's attack, put 1 damage counter on the attacking Pokémon."}}],
+
+	attacks: [{"name": {"ja": "Top Breaker"}, "damage": 10, "cost": ["Darkness"], "effect": {"ja": "Discard the top card of your opponent's deck."}}],
+
+	weaknesses: [{"type": "Grass", "value": "x2"}],
+	resistances: [],
+
+	variants: [{"type": "holo"}],
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "Illustration rare",
+	dexId: [442],
+};
+
+export default card;

--- a/data-asia/M/M1L/072.ts
+++ b/data-asia/M/M1L/072.ts
@@ -1,0 +1,34 @@
+import { Card } from "../../../interfaces";
+import Set from "../M1L";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "シルシュルー",
+	},
+
+	illustrator: "Shimaris Yukichi",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Darkness"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Basic",
+
+	attacks: [{"name": {"ja": "Poison Jab"}, "damage": 20, "cost": ["Darkness", "Colorless"], "effect": {"ja": "Your opponent's Active Pokémon is now Poisoned."}}],
+
+	weaknesses: [{"type": "Fighting", "value": "x2"}],
+	resistances: [],
+
+	variants: [{"type": "holo"}],
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "Illustration rare",
+	dexId: [944],
+};
+
+export default card;

--- a/data-asia/M/M1L/073.ts
+++ b/data-asia/M/M1L/073.ts
@@ -1,0 +1,38 @@
+import { Card } from "../../../interfaces";
+import Set from "../M1L";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ハガネール",
+	},
+
+	illustrator: "Tonji Matsuno",
+	category: "Pokemon",
+	hp: 200,
+	types: ["Metal"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Stage1",
+
+	evolveFrom: {
+		ja: "イワーク",
+	},
+
+	attacks: [{"name": {"ja": "ウェルカムテール"}, "damage": "40+", "cost": ["Colorless", "Colorless"], "effect": {"ja": "If you have exactly 6 prize cards remaining, this attack does 200 more damage."}}, {"name": {"ja": "ロケットずつき"}, "damage": 140, "cost": ["Metal", "Metal", "Colorless", "Colorless"]}],
+
+	weaknesses: [{"type": "Fire", "value": "x2"}],
+	resistances: [{"type": "Grass", "value": "-30"}],
+
+	variants: [{"type": "holo"}],
+
+	retreat: 4,
+	regulationMark: "I",
+	rarity: "Illustration rare",
+	dexId: [208],
+};
+
+export default card;

--- a/data-asia/M/M1L/074.ts
+++ b/data-asia/M/M1L/074.ts
@@ -1,0 +1,34 @@
+import { Card } from "../../../interfaces";
+import Set from "../M1L";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "オニスズメ",
+	},
+
+	illustrator: "MINAMINAMI Take",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Colorless"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Basic",
+
+	attacks: [{"name": {"ja": "ついばむ"}, "damage": 10, "cost": ["Colorless"], "effect": {"ja": "Before doing damage, discard all Pokémon Tools from your opponent's Active Pokémon."}}],
+
+	weaknesses: [{"type": "Electric", "value": "x2"}],
+	resistances: [{"type": "Fighting", "value": "-30"}],
+
+	variants: [{"type": "holo"}],
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "Illustration rare",
+	dexId: [21],
+};
+
+export default card;

--- a/data-asia/M/M1L/075.ts
+++ b/data-asia/M/M1L/075.ts
@@ -1,0 +1,34 @@
+import { Card } from "../../../interfaces";
+import Set from "../M1L";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヤングース",
+	},
+
+	illustrator: "Mina Nakai",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Colorless"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Basic",
+
+	attacks: [{"name": {"ja": "Collect"}, "cost": ["Colorless"], "effect": {"ja": "Draw a card"}}, {"name": {"ja": "Gnaw"}, "damage": 20, "cost": ["Colorless", "Colorless"]}],
+
+	weaknesses: [{"type": "Fighting", "value": "x2"}],
+	resistances: [],
+
+	variants: [{"type": "holo"}],
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "Illustration rare",
+	dexId: [734],
+};
+
+export default card;

--- a/data-asia/M/M1L/076.ts
+++ b/data-asia/M/M1L/076.ts
@@ -1,0 +1,37 @@
+import { Card } from "../../../interfaces";
+import Set from "../M1L";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "メガフシギバナex",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 380,
+	types: ["Grass"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Basic",
+
+	abilities: [{"type": "Ability", "name": {"ja": "ソーラートランスファー"}, "effect": {"ja": "As many times as you like during your turn, you may move a Basic Grass Energy from one of your Pokémon to another one of your Pokémon."}}],
+
+	attacks: [{"name": {"ja": "ジャングルダンプ"}, "damage": 240, "cost": ["Grass", "Grass", "Grass", "Grass"], "effect": {"ja": "Heal 30 damage from this Pokémon"}}],
+
+	weaknesses: [{"type": "Fire", "value": "x2"}],
+	resistances: [],
+
+	variants: [{"type": "holo"}],
+
+	retreat: 4,
+	regulationMark: "I",
+	rarity: "Special illustration rare",
+	dexId: [3],
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/M/M1L/077.ts
+++ b/data-asia/M/M1L/077.ts
@@ -1,0 +1,35 @@
+import { Card } from "../../../interfaces";
+import Set from "../M1L";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "メガバクーダex",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 340,
+	types: ["Fire"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Basic",
+
+	attacks: [{"name": {"ja": "Roasting Heat"}, "damage": "80+", "cost": ["Fire"], "effect": {"ja": "If your opponent's Active Pokémon is Burned, this attack does 160 more damage."}}, {"name": {"ja": "Volcano Meteor"}, "damage": 280, "cost": ["Fire", "Colorless", "Colorless", "Colorless"], "effect": {"ja": "Discard 2 Energy from this Pokémon."}}],
+
+	weaknesses: [{"type": "Water", "value": "x2"}],
+	resistances: [],
+
+	variants: [{"type": "holo"}],
+
+	retreat: 4,
+	regulationMark: "I",
+	rarity: "Special illustration rare",
+	dexId: [323],
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/M/M1L/078.ts
+++ b/data-asia/M/M1L/078.ts
@@ -1,0 +1,35 @@
+import { Card } from "../../../interfaces";
+import Set from "../M1L";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "メガルカリオex",
+	},
+
+	illustrator: "takuyoa",
+	category: "Pokemon",
+	hp: 340,
+	types: ["Fighting"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Basic",
+
+	attacks: [{"name": {"ja": "オーラジャブ"}, "damage": 130, "cost": ["Fighting"], "effect": {"ja": "Attach up to 3 Basic  Energy from your discard pile to your Benched Pokémon in any way yuo like."}}, {"name": {"ja": "メガブレイブ"}, "damage": 270, "cost": ["Fighting", "Fighting"], "effect": {"ja": "During your next turn, this Pokémon can't use Mega Brave"}}],
+
+	weaknesses: [{"type": "Psychic", "value": "x2"}],
+	resistances: [],
+
+	variants: [{"type": "holo"}],
+
+	retreat: 2,
+	regulationMark: "I",
+	rarity: "Special illustration rare",
+	dexId: [448],
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/M/M1L/079.ts
+++ b/data-asia/M/M1L/079.ts
@@ -1,0 +1,35 @@
+import { Card } from "../../../interfaces";
+import Set from "../M1L";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "メガアブソルex",
+	},
+
+	illustrator: "aky CG Works",
+	category: "Pokemon",
+	hp: 280,
+	types: ["Darkness"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Basic",
+
+	attacks: [{"name": {"ja": "Terminal Period"}, "cost": ["Darkness", "Colorless"], "effect": {"ja": "If your opponent's Active Pokémon has exactly 6 damage counters on it, it is now Knocked Out."}}, {"name": {"ja": "Claw of Darkness"}, "damage": 200, "cost": ["Darkness", "Darkness", "Colorless"], "effect": {"ja": "Look at your opponent's hand and discard 1 card you find there."}}],
+
+	weaknesses: [{"type": "Grass", "value": "x2"}],
+	resistances: [],
+
+	variants: [{"type": "holo"}],
+
+	retreat: 2,
+	regulationMark: "I",
+	rarity: "Special illustration rare",
+	dexId: [359],
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/M/M1L/080.ts
+++ b/data-asia/M/M1L/080.ts
@@ -1,0 +1,35 @@
+import { Card } from "../../../interfaces";
+import Set from "../M1L";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "メガクチートex",
+	},
+
+	illustrator: "aky CG Works",
+	category: "Pokemon",
+	hp: 270,
+	types: ["Metal"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Basic",
+
+	attacks: [{"name": {"ja": "Gobble Down"}, "damage": "80x", "cost": ["Metal", "Metal"], "effect": {"ja": "This attack does 80 damage for each prize card you've already taken."}}, {"name": {"ja": "Big Bite"}, "damage": 260, "cost": ["Metal", "Metal", "Colorless"], "effect": {"ja": "If your opponent's Active Pokémon already has any damage s on it, this attack does 30 damage instead."}}],
+
+	weaknesses: [{"type": "Fire", "value": "x2"}],
+	resistances: [{"type": "Grass", "value": "-30"}],
+
+	variants: [{"type": "holo"}],
+
+	retreat: 2,
+	regulationMark: "I",
+	rarity: "Special illustration rare",
+	dexId: [303],
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/M/M1L/081.ts
+++ b/data-asia/M/M1L/081.ts
@@ -1,0 +1,25 @@
+import { Card } from "../../../interfaces";
+import Set from "../M1L";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "プレミアムパワープロ",
+	},
+
+	illustrator: "Toyste Beach",
+	category: "Trainer",
+
+	effect: {
+		ja: "During this turn, attacks used by your Pokémon do 30 more damage to your opponent's Active Pokémon (before applying Weakness and Resistance)",
+	},
+
+
+	variants: [{"type": "holo"}],
+
+	trainerType: "Item",
+	regulationMark: "I",
+	rarity: "Illustration rare",
+};
+
+export default card;

--- a/data-asia/M/M1L/082.ts
+++ b/data-asia/M/M1L/082.ts
@@ -1,0 +1,25 @@
+import { Card } from "../../../interfaces";
+import Set from "../M1L";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ファイトゴング",
+	},
+
+	illustrator: "Toyste Beach",
+	category: "Trainer",
+
+	effect: {
+		ja: "Search your deck for a Fighting type Basic Pokémon or for a Basic Fighting Energy, reveal it, and put it into your hand. Then shuffle your deck.",
+	},
+
+
+	variants: [{"type": "holo"}],
+
+	trainerType: "Item",
+	regulationMark: "I",
+	rarity: "Illustration rare",
+};
+
+export default card;

--- a/data-asia/M/M1L/083.ts
+++ b/data-asia/M/M1L/083.ts
@@ -1,0 +1,25 @@
+import { Card } from "../../../interfaces";
+import Set from "../M1L";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ナイトストレッチャー",
+	},
+
+	illustrator: "Toyste Beach",
+	category: "Trainer",
+
+	effect: {
+		ja: "Put a Pokémon or a Basic Energy card from your discard pile into your hand",
+	},
+
+
+	variants: [{"type": "holo"}],
+
+	trainerType: "Item",
+	regulationMark: "I",
+	rarity: "Illustration rare",
+};
+
+export default card;

--- a/data-asia/M/M1L/084.ts
+++ b/data-asia/M/M1L/084.ts
@@ -1,0 +1,25 @@
+import { Card } from "../../../interfaces";
+import Set from "../M1L";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "エアバルーン",
+	},
+
+	illustrator: "Studio Bora Inc.",
+	category: "Trainer",
+
+	effect: {
+		ja: "The Retreat Cost of the Pokémon this card is attached to is less.",
+	},
+
+
+	variants: [{"type": "holo"}],
+
+	trainerType: "Item",
+	regulationMark: "I",
+	rarity: "Illustration rare",
+};
+
+export default card;

--- a/data-asia/M/M1L/085.ts
+++ b/data-asia/M/M1L/085.ts
@@ -1,0 +1,25 @@
+import { Card } from "../../../interfaces";
+import Set from "../M1L";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "マチスのかけひき",
+	},
+
+	illustrator: "Hideki Ishikawa",
+	category: "Trainer",
+
+	effect: {
+		ja: "Ask you opponent if they agree to have each player take a Prize card. If your opponent agrees, each take a Prize card. If they don't, you draw 4 cards.",
+	},
+
+
+	variants: [{"type": "holo"}],
+
+	trainerType: "Supporter",
+	regulationMark: "I",
+	rarity: "Illustration rare",
+};
+
+export default card;

--- a/data-asia/M/M1L/086.ts
+++ b/data-asia/M/M1L/086.ts
@@ -1,0 +1,25 @@
+import { Card } from "../../../interfaces";
+import Set from "../M1L";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "リーリエのきもち",
+	},
+
+	illustrator: "Atsushi Furusawa",
+	category: "Trainer",
+
+	effect: {
+		ja: "Shuffle your hand into your deck. Then, draw 6 cards. If you have 6 prize cards remaining, draw 8 cards instead.",
+	},
+
+
+	variants: [{"type": "holo"}],
+
+	trainerType: "Supporter",
+	regulationMark: "I",
+	rarity: "Illustration rare",
+};
+
+export default card;

--- a/data-asia/M/M1L/087.ts
+++ b/data-asia/M/M1L/087.ts
@@ -1,0 +1,37 @@
+import { Card } from "../../../interfaces";
+import Set from "../M1L";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "メガフシギバナex",
+	},
+
+	illustrator: "mashu",
+	category: "Pokemon",
+	hp: 380,
+	types: ["Grass"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Basic",
+
+	abilities: [{"type": "Ability", "name": {"ja": "ソーラートランスファー"}, "effect": {"ja": "As many times as you like during your turn, you may move a Basic Grass Energy from one of your Pokémon to another one of your Pokémon."}}],
+
+	attacks: [{"name": {"ja": "ジャングルダンプ"}, "damage": 240, "cost": ["Grass", "Grass", "Grass", "Grass"], "effect": {"ja": "Heal 30 damage from this Pokémon"}}],
+
+	weaknesses: [{"type": "Fire", "value": "x2"}],
+	resistances: [],
+
+	variants: [{"type": "holo"}],
+
+	retreat: 4,
+	regulationMark: "I",
+	rarity: "Special illustration rare",
+	dexId: [3],
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/M/M1L/088.ts
+++ b/data-asia/M/M1L/088.ts
@@ -1,0 +1,35 @@
+import { Card } from "../../../interfaces";
+import Set from "../M1L";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "メガルカリオex",
+	},
+
+	illustrator: "Atsushi Furusawa",
+	category: "Pokemon",
+	hp: 340,
+	types: ["Fighting"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Basic",
+
+	attacks: [{"name": {"ja": "オーラジャブ"}, "damage": 130, "cost": ["Fighting"], "effect": {"ja": "Attach up to 3 Basic  Energy from your discard pile to your Benched Pokémon in any way yuo like."}}, {"name": {"ja": "メガブレイブ"}, "damage": 270, "cost": ["Fighting", "Fighting"], "effect": {"ja": "During your next turn, this Pokémon can't use Mega Brave"}}],
+
+	weaknesses: [{"type": "Psychic", "value": "x2"}],
+	resistances: [],
+
+	variants: [{"type": "holo"}],
+
+	retreat: 2,
+	regulationMark: "I",
+	rarity: "Special illustration rare",
+	dexId: [448],
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/M/M1L/089.ts
+++ b/data-asia/M/M1L/089.ts
@@ -1,0 +1,35 @@
+import { Card } from "../../../interfaces";
+import Set from "../M1L";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "メガアブソルex",
+	},
+
+	illustrator: "Mitsuhiro Arita",
+	category: "Pokemon",
+	hp: 280,
+	types: ["Darkness"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Basic",
+
+	attacks: [{"name": {"ja": "Terminal Period"}, "cost": ["Darkness", "Colorless"], "effect": {"ja": "If your opponent's Active Pokémon has exactly 6 damage counters on it, it is now Knocked Out."}}, {"name": {"ja": "Claw of Darkness"}, "damage": 200, "cost": ["Darkness", "Darkness", "Colorless"], "effect": {"ja": "Look at your opponent's hand and discard 1 card you find there."}}],
+
+	weaknesses: [{"type": "Grass", "value": "x2"}],
+	resistances: [],
+
+	variants: [{"type": "holo"}],
+
+	retreat: 2,
+	regulationMark: "I",
+	rarity: "Special illustration rare",
+	dexId: [359],
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/M/M1L/090.ts
+++ b/data-asia/M/M1L/090.ts
@@ -1,0 +1,25 @@
+import { Card } from "../../../interfaces";
+import Set from "../M1L";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "マチスのかけひき",
+	},
+
+	illustrator: "osare",
+	category: "Trainer",
+
+	effect: {
+		ja: "Ask you opponent if they agree to have each player take a Prize card. If your opponent agrees, each take a Prize card. If they don't, you draw 4 cards.",
+	},
+
+
+	variants: [{"type": "holo"}],
+
+	trainerType: "Supporter",
+	regulationMark: "I",
+	rarity: "Special illustration rare",
+};
+
+export default card;

--- a/data-asia/M/M1L/091.ts
+++ b/data-asia/M/M1L/091.ts
@@ -1,0 +1,25 @@
+import { Card } from "../../../interfaces";
+import Set from "../M1L";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "リーリエのきもち",
+	},
+
+	illustrator: "satoma",
+	category: "Trainer",
+
+	effect: {
+		ja: "Shuffle your hand into your deck. Then, draw 6 cards. If you have 6 prize cards remaining, draw 8 cards instead.",
+	},
+
+
+	variants: [{"type": "holo"}],
+
+	trainerType: "Supporter",
+	regulationMark: "I",
+	rarity: "Special illustration rare",
+};
+
+export default card;

--- a/data-asia/M/M1L/092.ts
+++ b/data-asia/M/M1L/092.ts
@@ -1,0 +1,35 @@
+import { Card } from "../../../interfaces";
+import Set from "../M1L";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "メガルカリオex",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 340,
+	types: ["Fighting"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Basic",
+
+	attacks: [{"name": {"ja": "オーラジャブ"}, "damage": 130, "cost": ["Fighting"], "effect": {"ja": "Attach up to 3 Basic  Energy from your discard pile to your Benched Pokémon in any way yuo like."}}, {"name": {"ja": "メガブレイブ"}, "damage": 270, "cost": ["Fighting", "Fighting"], "effect": {"ja": "During your next turn, this Pokémon can't use Mega Brave"}}],
+
+	weaknesses: [{"type": "Psychic", "value": "x2"}],
+	resistances: [],
+
+	variants: [{"type": "holo"}],
+
+	retreat: 2,
+	regulationMark: "I",
+	rarity: "Mega Hyper Rare",
+	dexId: [448],
+	suffix: "EX",
+};
+
+export default card;


### PR DESCRIPTION
Closes #1173

## Changes

Added the Japanese M1L **Mega Brave** (メガブレイブ) set — the first expansion of the Japanese MEGA Series (paired with M1S Mega Symphonia), featuring Mega Lucario ex. Released August 1, 2025.

### Files added
- `data-asia/M/M1L.ts` — set definition
- `data-asia/M/M1L/001.ts` through `data-asia/M/M1L/092.ts` — all 92 cards

### Data source
Card data scraped from [serebii.net/card/megabrave](https://www.serebii.net/card/megabrave/).

### Card breakdown
- **001–082**: Normal cards (Common/Uncommon/Rare/Double Rare)
- **083–089**: Special Illustration Rares (Pokémon)
- **090–091**: Special Illustration Rares (Supporter)
- **092**: メガルカリオex — Mega Hyper Rare

### Notes
- English equivalent is already in TCGdex as ME01 (Mega Evolution), which combines M1L+M1S EN
- `regulationMark: "I"` applied to all cards
- Variants follow the same rarity→variant mapping as M3