### PR TITLE
feat(data): add Japanese M2 (Inferno X / インフェルノX) set and cards

### DIFF
--- a/data-asia/M/M2.ts
+++ b/data-asia/M/M2.ts
@@ -1,0 +1,20 @@
+import { Set } from "../../interfaces";
+import serie from "../M";
+
+const set: Set = {
+	id: "M2",
+	name: {
+		ja: "インフェルノX",
+	},
+
+	serie: serie,
+
+	cardCount: {
+		official: 116,
+	},
+	releaseDate: {
+		ja: "2025-09-26",
+	},
+};
+
+export default set;

--- a/data-asia/M/M2/001.ts
+++ b/data-asia/M/M2/001.ts
@@ -1,0 +1,40 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ナゾノクサ",
+	},
+
+	illustrator: "MINAMINAMI Take",
+	category: "Pokemon",
+	hp: 50,
+	types: ["Grass"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "タネばくだん" },
+			damage: 20,
+			cost: ["Grass"],
+		}
+	],
+
+	weaknesses: [{"type": "Fire", "value": "x2"}],
+	resistances: [],
+
+	variants: [{"type": "normal"}],
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "Common",
+	dexId: [43],
+};
+
+export default card;

--- a/data-asia/M/M2/002.ts
+++ b/data-asia/M/M2/002.ts
@@ -1,0 +1,45 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "クサイハナ",
+	},
+
+	illustrator: "Yoriyuki Ikegami",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Grass"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Stage1",
+
+	evolveFrom: {
+		ja: "ナゾノクサ",
+	},
+
+	attacks: [
+		{
+			name: { ja: "よだれながし" },
+			damage: 20,
+			cost: ["Grass"],
+			effect: { ja: "" },
+		}
+	],
+
+	weaknesses: [{"type": "Fire", "value": "x2"}],
+	resistances: [],
+
+	variants: [{"type": "normal"}],
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "Common",
+	dexId: [44],
+};
+
+export default card;

--- a/data-asia/M/M2/003.ts
+++ b/data-asia/M/M2/003.ts
@@ -1,0 +1,51 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ラフレシア",
+	},
+
+	illustrator: "Shibuzoh.",
+	category: "Pokemon",
+	hp: 150,
+	types: ["Grass"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Stage2",
+
+	evolveFrom: {
+		ja: "クサイハナ",
+	},
+
+	attacks: [
+		{
+			name: { ja: "かふんばくだん" },
+			damage: 30,
+			cost: ["Grass"],
+			effect: { ja: "" },
+		},
+		{
+			name: { ja: "いきいきはな" },
+			damage: 60,
+			cost: ["Grass"],
+			effect: { ja: "" },
+		}
+	],
+
+	weaknesses: [{"type": "Fire", "value": "x2"}],
+	resistances: [],
+
+	variants: [{"type": "normal"}],
+
+	retreat: 2,
+	regulationMark: "I",
+	rarity: "Uncommon",
+	dexId: [45],
+};
+
+export default card;

--- a/data-asia/M/M2/004.ts
+++ b/data-asia/M/M2/004.ts
@@ -1,0 +1,49 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "メガヘラクロスex",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 280,
+	types: ["Fighting"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "パンツァーホーン" },
+			damage: 100,
+			cost: ["Grass", "Grass"],
+			effect: { ja: "" },
+		},
+		{
+			name: { ja: "ミリングジャブ" },
+			damage: 170,
+			cost: ["Grass", "Grass", "Grass"],
+			effect: { ja: "" },
+		}
+	],
+
+	weaknesses: [{"type": "Fire", "value": "x2"}],
+	resistances: [],
+
+	variants: [{"type": "holo"}],
+
+	retreat: 2,
+	regulationMark: "I",
+	rarity: "Double rare",
+	dexId: [214],
+
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/M/M2/005.ts
+++ b/data-asia/M/M2/005.ts
@@ -1,0 +1,40 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ハスボー",
+	},
+
+	illustrator: "Wintr Wandr",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Grass"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ずつき" },
+			damage: 30,
+			cost: ["Grass", "Colorless"],
+		}
+	],
+
+	weaknesses: [{"type": "Fire", "value": "x2"}],
+	resistances: [],
+
+	variants: [{"type": "normal"}],
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "Common",
+	dexId: [270],
+};
+
+export default card;

--- a/data-asia/M/M2/006.ts
+++ b/data-asia/M/M2/006.ts
@@ -1,0 +1,45 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ハスブレロ",
+	},
+
+	illustrator: "Shigenori Negishi",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Grass"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Stage1",
+
+	evolveFrom: {
+		ja: "ハスボー",
+	},
+
+	attacks: [
+		{
+			name: { ja: "メガドレイン" },
+			damage: 30,
+			cost: ["Grass", "Colorless"],
+			effect: { ja: "" },
+		}
+	],
+
+	weaknesses: [{"type": "Fire", "value": "x2"}],
+	resistances: [],
+
+	variants: [{"type": "normal"}],
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "Common",
+	dexId: [271],
+};
+
+export default card;

--- a/data-asia/M/M2/007.ts
+++ b/data-asia/M/M2/007.ts
@@ -1,0 +1,44 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ルンパッパ",
+	},
+
+	illustrator: "Anesaki Dynamic",
+	category: "Pokemon",
+	hp: 160,
+	types: ["Grass"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Stage2",
+
+	evolveFrom: {
+		ja: "ハスブレロ",
+	},
+
+	attacks: [
+		{
+			name: { ja: "とびかかる" },
+			damage: 120,
+			cost: ["Grass", "Colorless"],
+		}
+	],
+
+	weaknesses: [{"type": "Fire", "value": "x2"}],
+	resistances: [],
+
+	variants: [{"type": "normal"}],
+
+	retreat: 2,
+	regulationMark: "I",
+	rarity: "Uncommon",
+	dexId: [272],
+};
+
+export default card;

--- a/data-asia/M/M2/008.ts
+++ b/data-asia/M/M2/008.ts
@@ -1,0 +1,45 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ゲノセクト",
+	},
+
+	illustrator: "Mitsuhiro Arita",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Grass"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "むしのほう" },
+			cost: ["Grass"],
+			effect: { ja: "" },
+		},
+		{
+			name: { ja: "スピードアタック" },
+			damage: 110,
+			cost: ["Grass", "Grass", "Colorless"],
+		}
+	],
+
+	weaknesses: [{"type": "Fire", "value": "x2"}],
+	resistances: [],
+
+	variants: [{"type": "holo"}],
+
+	retreat: 2,
+	regulationMark: "I",
+	rarity: "Rare Holo",
+	dexId: [649],
+};
+
+export default card;

--- a/data-asia/M/M2/009.ts
+++ b/data-asia/M/M2/009.ts
@@ -1,0 +1,41 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "マメバッタ",
+	},
+
+	illustrator: "Yuka Morii",
+	category: "Pokemon",
+	hp: 50,
+	types: ["Grass"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "バタバタもがく" },
+			damage: 10,
+			cost: ["Grass"],
+			effect: { ja: "" },
+		}
+	],
+
+	weaknesses: [{"type": "Fire", "value": "x2"}],
+	resistances: [],
+
+	variants: [{"type": "normal"}],
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "Common",
+	dexId: [919],
+};
+
+export default card;

--- a/data-asia/M/M2/010.ts
+++ b/data-asia/M/M2/010.ts
@@ -1,0 +1,50 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "エクスレッグ",
+	},
+
+	illustrator: "Taiga Kasai",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Grass"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Stage1",
+
+	evolveFrom: {
+		ja: "マメバッタ",
+	},
+
+	attacks: [
+		{
+			name: { ja: "あしばらい" },
+			damage: 30,
+			cost: ["Grass"],
+		},
+		{
+			name: { ja: "ジャンプショット" },
+			damage: 150,
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: { ja: "" },
+		}
+	],
+
+	weaknesses: [{"type": "Fire", "value": "x2"}],
+	resistances: [],
+
+	variants: [{"type": "normal"}],
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "Uncommon",
+	dexId: [920],
+};
+
+export default card;

--- a/data-asia/M/M2/011.ts
+++ b/data-asia/M/M2/011.ts
@@ -1,0 +1,40 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヒトカゲ",
+	},
+
+	illustrator: "HYOGONOSUKE",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Grass"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "おきび" },
+			damage: 20,
+			cost: ["Fire"],
+		}
+	],
+
+	weaknesses: [{"type": "Water", "value": "x2"}],
+	resistances: [],
+
+	variants: [{"type": "normal"}],
+
+	retreat: 2,
+	regulationMark: "I",
+	rarity: "Common",
+	dexId: [4],
+};
+
+export default card;

--- a/data-asia/M/M2/012.ts
+++ b/data-asia/M/M2/012.ts
@@ -1,0 +1,44 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "リザード",
+	},
+
+	illustrator: "Uninori",
+	category: "Pokemon",
+	hp: 110,
+	types: ["Grass"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Stage1",
+
+	evolveFrom: {
+		ja: "ヒトカゲ",
+	},
+
+	attacks: [
+		{
+			name: { ja: "ひっかく" },
+			damage: 40,
+			cost: ["Fire"],
+		}
+	],
+
+	weaknesses: [{"type": "Water", "value": "x2"}],
+	resistances: [],
+
+	variants: [{"type": "normal"}],
+
+	retreat: 2,
+	regulationMark: "I",
+	rarity: "Common",
+	dexId: [5],
+};
+
+export default card;

--- a/data-asia/M/M2/013.ts
+++ b/data-asia/M/M2/013.ts
@@ -1,0 +1,43 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "メガリザードンXex",
+	},
+
+	illustrator: "takuyoa",
+	category: "Pokemon",
+	hp: 360,
+	types: ["Fire"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "インフェルノX" },
+			damage: 90,
+			cost: ["Fire", "Fire"],
+			effect: { ja: "" },
+		}
+	],
+
+	weaknesses: [{"type": "Water", "value": "x2"}],
+	resistances: [],
+
+	variants: [{"type": "holo"}],
+
+	retreat: 2,
+	regulationMark: "I",
+	rarity: "Double rare",
+	dexId: [6],
+
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/M/M2/014.ts
+++ b/data-asia/M/M2/014.ts
@@ -1,0 +1,40 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ファイヤー",
+	},
+
+	illustrator: "Kazumasa Yasukuni",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Grass"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ファイティングウィング" },
+			cost: ["Fire"],
+			effect: { ja: "" },
+		}
+	],
+
+	weaknesses: [{"type": "Water", "value": "x2"}],
+	resistances: [],
+
+	variants: [{"type": "normal"}],
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "Uncommon",
+	dexId: [146],
+};
+
+export default card;

--- a/data-asia/M/M2/015.ts
+++ b/data-asia/M/M2/015.ts
@@ -1,0 +1,41 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ダルマッカ",
+	},
+
+	illustrator: "NC Empire",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Grass"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ほのおのたま" },
+			damage: 10,
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: { ja: "" },
+		}
+	],
+
+	weaknesses: [{"type": "Water", "value": "x2"}],
+	resistances: [],
+
+	variants: [{"type": "normal"}],
+
+	retreat: 2,
+	regulationMark: "I",
+	rarity: "Common",
+	dexId: [554],
+};
+
+export default card;

--- a/data-asia/M/M2/016.ts
+++ b/data-asia/M/M2/016.ts
@@ -1,0 +1,45 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヒヒダルマ",
+	},
+
+	illustrator: "Uta",
+	category: "Pokemon",
+	hp: 150,
+	types: ["Grass"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Stage1",
+
+	evolveFrom: {
+		ja: "ダルマッカ",
+	},
+
+	attacks: [
+		{
+			name: { ja: "ほのおのたま" },
+			damage: 40,
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: { ja: "" },
+		}
+	],
+
+	weaknesses: [{"type": "Water", "value": "x2"}],
+	resistances: [],
+
+	variants: [{"type": "normal"}],
+
+	retreat: 3,
+	regulationMark: "I",
+	rarity: "Uncommon",
+	dexId: [555],
+};
+
+export default card;

--- a/data-asia/M/M2/017.ts
+++ b/data-asia/M/M2/017.ts
@@ -1,0 +1,46 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "レシラム",
+	},
+
+	illustrator: "AKIRA EGAWA",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Grass"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "かえん" },
+			damage: 30,
+			cost: ["Fire"],
+		},
+		{
+			name: { ja: "バーニングフレア" },
+			damage: 240,
+			cost: ["Fire", "Fire", "Fire", "Fire"],
+			effect: { ja: "" },
+		}
+	],
+
+	weaknesses: [{"type": "Water", "value": "x2"}],
+	resistances: [],
+
+	variants: [{"type": "holo"}],
+
+	retreat: 2,
+	regulationMark: "I",
+	rarity: "Rare Holo",
+	dexId: [643],
+};
+
+export default card;

--- a/data-asia/M/M2/018.ts
+++ b/data-asia/M/M2/018.ts
@@ -1,0 +1,42 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "オドリドリex",
+	},
+
+	illustrator: "akagi",
+	category: "Pokemon",
+	hp: 190,
+	types: ["Grass"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ほのおのつばさ" },
+			damage: 110,
+			cost: ["Fire", "Fire", "Colorless"],
+		}
+	],
+
+	weaknesses: [{"type": "Water", "value": "x2"}],
+	resistances: [],
+
+	variants: [{"type": "holo"}],
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "Double rare",
+	dexId: [741],
+
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/M/M2/019.ts
+++ b/data-asia/M/M2/019.ts
@@ -1,0 +1,45 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "カルボウ",
+	},
+
+	illustrator: "Tomokazu Komiya",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Grass"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ちからをためる" },
+			cost: ["Fire"],
+			effect: { ja: "" },
+		},
+		{
+			name: { ja: "チョップ" },
+			damage: 10,
+			cost: ["Fire"],
+		}
+	],
+
+	weaknesses: [{"type": "Water", "value": "x2"}],
+	resistances: [],
+
+	variants: [{"type": "normal"}],
+
+	retreat: 2,
+	regulationMark: "I",
+	rarity: "Common",
+	dexId: [935],
+};
+
+export default card;

--- a/data-asia/M/M2/020.ts
+++ b/data-asia/M/M2/020.ts
@@ -1,0 +1,45 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ソウブレイズ",
+	},
+
+	illustrator: "Gemi",
+	category: "Pokemon",
+	hp: 140,
+	types: ["Grass"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Stage1",
+
+	evolveFrom: {
+		ja: "カルボウ",
+	},
+
+	attacks: [
+		{
+			name: { ja: "ごくねつぎり" },
+			damage: 220,
+			cost: ["Fire"],
+			effect: { ja: "" },
+		}
+	],
+
+	weaknesses: [{"type": "Water", "value": "x2"}],
+	resistances: [],
+
+	variants: [{"type": "normal"}],
+
+	retreat: 2,
+	regulationMark: "I",
+	rarity: "Uncommon",
+	dexId: [937],
+};
+
+export default card;

--- a/data-asia/M/M2/021.ts
+++ b/data-asia/M/M2/021.ts
@@ -1,0 +1,41 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "パウワウ",
+	},
+
+	illustrator: "svlt",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Water"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "バブルドレイン" },
+			damage: 20,
+			cost: ["Water", "Colorless"],
+			effect: { ja: "" },
+		}
+	],
+
+	weaknesses: [{"type": "Lightning", "value": "x2"}],
+	resistances: [],
+
+	variants: [{"type": "normal"}],
+
+	retreat: 2,
+	regulationMark: "I",
+	rarity: "Common",
+	dexId: [86],
+};
+
+export default card;

--- a/data-asia/M/M2/022.ts
+++ b/data-asia/M/M2/022.ts
@@ -1,0 +1,45 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ジュゴン",
+	},
+
+	illustrator: "Taira Akitsu",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Water"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Stage1",
+
+	evolveFrom: {
+		ja: "パウワウ",
+	},
+
+	attacks: [
+		{
+			name: { ja: "スラム" },
+			damage: 70,
+			cost: ["Water", "Colorless"],
+			effect: { ja: "" },
+		}
+	],
+
+	weaknesses: [{"type": "Lightning", "value": "x2"}],
+	resistances: [],
+
+	variants: [{"type": "normal"}],
+
+	retreat: 2,
+	regulationMark: "I",
+	rarity: "Common",
+	dexId: [87],
+};
+
+export default card;

--- a/data-asia/M/M2/023.ts
+++ b/data-asia/M/M2/023.ts
@@ -1,0 +1,45 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ウリムー",
+	},
+
+	illustrator: "imoniii",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Water"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "とびげり" },
+			damage: 10,
+			cost: ["Colorless"],
+		},
+		{
+			name: { ja: "こごえるゆき" },
+			damage: 20,
+			cost: ["Water", "Colorless"],
+		}
+	],
+
+	weaknesses: [{"type": "Metal", "value": "x2"}],
+	resistances: [],
+
+	variants: [{"type": "normal"}],
+
+	retreat: 2,
+	regulationMark: "I",
+	rarity: "Common",
+	dexId: [220],
+};
+
+export default card;

--- a/data-asia/M/M2/024.ts
+++ b/data-asia/M/M2/024.ts
@@ -1,0 +1,50 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "イノムー",
+	},
+
+	illustrator: "Shinya Komatsu",
+	category: "Pokemon",
+	hp: 100,
+	types: ["Water"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Stage1",
+
+	evolveFrom: {
+		ja: "ウリムー",
+	},
+
+	attacks: [
+		{
+			name: { ja: "ライジングランジ" },
+			damage: 30,
+			cost: ["Colorless", "Colorless"],
+			effect: { ja: "" },
+		},
+		{
+			name: { ja: "フロストスマッシュ" },
+			damage: 70,
+			cost: ["Water", "Colorless", "Colorless"],
+		}
+	],
+
+	weaknesses: [{"type": "Metal", "value": "x2"}],
+	resistances: [],
+
+	variants: [{"type": "normal"}],
+
+	retreat: 3,
+	regulationMark: "I",
+	rarity: "Common",
+	dexId: [221],
+};
+
+export default card;

--- a/data-asia/M/M2/025.ts
+++ b/data-asia/M/M2/025.ts
@@ -1,0 +1,51 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "マンムー",
+	},
+
+	illustrator: "Takumi Wada",
+	category: "Pokemon",
+	hp: 180,
+	types: ["Water"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Stage2",
+
+	evolveFrom: {
+		ja: "イノムー",
+	},
+
+	attacks: [
+		{
+			name: { ja: "ぶちこわす" },
+			damage: 120,
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: { ja: "" },
+		},
+		{
+			name: { ja: "ふぶきのつばさ" },
+			damage: 200,
+			cost: ["Water", "Colorless", "Colorless", "Colorless"],
+			effect: { ja: "" },
+		}
+	],
+
+	weaknesses: [{"type": "Metal", "value": "x2"}],
+	resistances: [],
+
+	variants: [{"type": "normal"}],
+
+	retreat: 4,
+	regulationMark: "I",
+	rarity: "Uncommon",
+	dexId: [473],
+};
+
+export default card;

--- a/data-asia/M/M2/026.ts
+++ b/data-asia/M/M2/026.ts
@@ -1,0 +1,41 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "スイクン",
+	},
+
+	illustrator: "Takeshia Nakamura",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Water"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "クリスタルフォール" },
+			damage: 30,
+			cost: ["Water", "Water"],
+			effect: { ja: "" },
+		}
+	],
+
+	weaknesses: [{"type": "Lightning", "value": "x2"}],
+	resistances: [],
+
+	variants: [{"type": "holo"}],
+
+	retreat: 2,
+	regulationMark: "I",
+	rarity: "Rare Holo",
+	dexId: [245],
+};
+
+export default card;

--- a/data-asia/M/M2/027.ts
+++ b/data-asia/M/M2/027.ts
@@ -1,0 +1,45 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ポッチャマ",
+	},
+
+	illustrator: "Hideki Ishikawa",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Water"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "なかまをよぶ" },
+			cost: ["Colorless"],
+			effect: { ja: "" },
+		},
+		{
+			name: { ja: "たいあたり" },
+			damage: 20,
+			cost: ["Colorless", "Colorless"],
+		}
+	],
+
+	weaknesses: [{"type": "Lightning", "value": "x2"}],
+	resistances: [],
+
+	variants: [{"type": "normal"}],
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "Common",
+	dexId: [393],
+};
+
+export default card;

--- a/data-asia/M/M2/028.ts
+++ b/data-asia/M/M2/028.ts
@@ -1,0 +1,49 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ポッタイシ",
+	},
+
+	illustrator: "Atsuya Uki",
+	category: "Pokemon",
+	hp: 100,
+	types: ["Water"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Stage1",
+
+	evolveFrom: {
+		ja: "ポッチャマ",
+	},
+
+	attacks: [
+		{
+			name: { ja: "つつく" },
+			damage: 20,
+			cost: ["Colorless"],
+		},
+		{
+			name: { ja: "ダイビング" },
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: { ja: "" },
+		}
+	],
+
+	weaknesses: [{"type": "Lightning", "value": "x2"}],
+	resistances: [],
+
+	variants: [{"type": "normal"}],
+
+	retreat: 2,
+	regulationMark: "I",
+	rarity: "Common",
+	dexId: [394],
+};
+
+export default card;

--- a/data-asia/M/M2/029.ts
+++ b/data-asia/M/M2/029.ts
@@ -1,0 +1,43 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ロトムex",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 190,
+	types: ["Lightning"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "かみなり" },
+			damage: 130,
+			cost: ["Lightning", "Colorless"],
+			effect: { ja: "" },
+		}
+	],
+
+	weaknesses: [{"type": "Fighting", "value": "x2"}],
+	resistances: [],
+
+	variants: [{"type": "holo"}],
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "Double rare",
+	dexId: [479],
+
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/M/M2/030.ts
+++ b/data-asia/M/M2/030.ts
@@ -1,0 +1,41 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ワンパチ",
+	},
+
+	illustrator: "Ayako Ozaki",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Fighting"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "じゃれつく" },
+			damage: 20,
+			cost: ["Lightning", "Colorless"],
+			effect: { ja: "" },
+		}
+	],
+
+	weaknesses: [{"type": "Fighting", "value": "x2"}],
+	resistances: [],
+
+	variants: [{"type": "normal"}],
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "Common",
+	dexId: [835],
+};
+
+export default card;

--- a/data-asia/M/M2/031.ts
+++ b/data-asia/M/M2/031.ts
@@ -1,0 +1,45 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "パルスワン",
+	},
+
+	illustrator: "Orca",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Fighting"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Stage1",
+
+	evolveFrom: {
+		ja: "ワンパチ",
+	},
+
+	attacks: [
+		{
+			name: { ja: "エレクトロラン" },
+			damage: 70,
+			cost: ["Lightning", "Colorless"],
+			effect: { ja: "" },
+		}
+	],
+
+	weaknesses: [{"type": "Fighting", "value": "x2"}],
+	resistances: [],
+
+	variants: [{"type": "normal"}],
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "Common",
+	dexId: [836],
+};
+
+export default card;

--- a/data-asia/M/M2/032.ts
+++ b/data-asia/M/M2/032.ts
@@ -1,0 +1,45 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "パモ",
+	},
+
+	illustrator: "Shimeris Yukichi",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Fighting"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "なきごえ" },
+			cost: ["Lightning"],
+			effect: { ja: "" },
+		},
+		{
+			name: { ja: "ちいさなでんき" },
+			damage: 10,
+			cost: ["Lightning"],
+		}
+	],
+
+	weaknesses: [{"type": "Fighting", "value": "x2"}],
+	resistances: [],
+
+	variants: [{"type": "normal"}],
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "Common",
+	dexId: [921],
+};
+
+export default card;

--- a/data-asia/M/M2/033.ts
+++ b/data-asia/M/M2/033.ts
@@ -1,0 +1,44 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "パモット",
+	},
+
+	illustrator: "Taiga Kayama",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Fighting"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Stage1",
+
+	evolveFrom: {
+		ja: "パモ",
+	},
+
+	attacks: [
+		{
+			name: { ja: "でんきパンチ" },
+			damage: 60,
+			cost: ["Lightning", "Lightning"],
+		}
+	],
+
+	weaknesses: [{"type": "Fighting", "value": "x2"}],
+	resistances: [],
+
+	variants: [{"type": "normal"}],
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "Common",
+	dexId: [922],
+};
+
+export default card;

--- a/data-asia/M/M2/034.ts
+++ b/data-asia/M/M2/034.ts
@@ -1,0 +1,45 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "パーモット",
+	},
+
+	illustrator: "satoma",
+	category: "Pokemon",
+	hp: 140,
+	types: ["Fighting"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Stage2",
+
+	evolveFrom: {
+		ja: "パモット",
+	},
+
+	attacks: [
+		{
+			name: { ja: "ボルテージフィスト" },
+			damage: 130,
+			cost: ["Lightning", "Lightning"],
+			effect: { ja: "" },
+		}
+	],
+
+	weaknesses: [{"type": "Fighting", "value": "x2"}],
+	resistances: [],
+
+	variants: [{"type": "holo"}],
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "Rare Holo",
+	dexId: [923],
+};
+
+export default card;

--- a/data-asia/M/M2/035.ts
+++ b/data-asia/M/M2/035.ts
@@ -1,0 +1,40 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ムウマ",
+	},
+
+	illustrator: "Mousho",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Psychic"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ちいさなうらみ" },
+			damage: 20,
+			cost: ["Psychic"],
+		}
+	],
+
+	weaknesses: [{"type": "Darkness", "value": "x2"}],
+	resistances: [],
+
+	variants: [{"type": "normal"}],
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "Common",
+	dexId: [200],
+};
+
+export default card;

--- a/data-asia/M/M2/036.ts
+++ b/data-asia/M/M2/036.ts
@@ -1,0 +1,43 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ムウマージex",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 260,
+	types: ["Psychic"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "むむむのたたり" },
+			damage: 150,
+			cost: ["Psychic", "Psychic"],
+			effect: { ja: "" },
+		}
+	],
+
+	weaknesses: [{"type": "Darkness", "value": "x2"}],
+	resistances: [],
+
+	variants: [{"type": "holo"}],
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "Double rare",
+	dexId: [429],
+
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/M/M2/037.ts
+++ b/data-asia/M/M2/037.ts
@@ -1,0 +1,40 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "モンメン",
+	},
+
+	illustrator: "Kariya",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Psychic"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "あつめる" },
+			cost: ["Colorless"],
+			effect: { ja: "" },
+		}
+	],
+
+	weaknesses: [{"type": "Metal", "value": "x2"}],
+	resistances: [],
+
+	variants: [{"type": "normal"}],
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "Common",
+	dexId: [546],
+};
+
+export default card;

--- a/data-asia/M/M2/038.ts
+++ b/data-asia/M/M2/038.ts
@@ -1,0 +1,50 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "エルフーン",
+	},
+
+	illustrator: "Yuka Tanaka",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Psychic"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Stage1",
+
+	evolveFrom: {
+		ja: "モンメン",
+	},
+
+	attacks: [
+		{
+			name: { ja: "いやしのわた" },
+			cost: ["Colorless"],
+			effect: { ja: "" },
+		},
+		{
+			name: { ja: "とんぼがえり" },
+			damage: 50,
+			cost: ["Psychic"],
+			effect: { ja: "" },
+		}
+	],
+
+	weaknesses: [{"type": "Metal", "value": "x2"}],
+	resistances: [],
+
+	variants: [{"type": "normal"}],
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "Uncommon",
+	dexId: [547],
+};
+
+export default card;

--- a/data-asia/M/M2/039.ts
+++ b/data-asia/M/M2/039.ts
@@ -1,0 +1,41 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ザシアン",
+	},
+
+	illustrator: "kawayoo",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Psychic"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "リミットブレイク" },
+			damage: 50,
+			cost: ["Psychic", "Colorless"],
+			effect: { ja: "" },
+		}
+	],
+
+	weaknesses: [{"type": "Metal", "value": "x2"}],
+	resistances: [],
+
+	variants: [{"type": "holo"}],
+
+	retreat: 2,
+	regulationMark: "I",
+	rarity: "Rare Holo",
+	dexId: [888],
+};
+
+export default card;

--- a/data-asia/M/M2/040.ts
+++ b/data-asia/M/M2/040.ts
@@ -1,0 +1,40 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アノクサ",
+	},
+
+	illustrator: "Takeshi Nakamura",
+	category: "Pokemon",
+	hp: 50,
+	types: ["Psychic"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "こそこそおく" },
+			cost: ["Psychic"],
+			effect: { ja: "" },
+		}
+	],
+
+	weaknesses: [{"type": "Darkness", "value": "x2"}],
+	resistances: [],
+
+	variants: [{"type": "normal"}],
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "Common",
+	dexId: [946],
+};
+
+export default card;

--- a/data-asia/M/M2/041.ts
+++ b/data-asia/M/M2/041.ts
@@ -1,0 +1,44 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アノホラグサ",
+	},
+
+	illustrator: "Tetsu Kayama",
+	category: "Pokemon",
+	hp: 100,
+	types: ["Psychic"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Stage1",
+
+	evolveFrom: {
+		ja: "アノクサ",
+	},
+
+	attacks: [
+		{
+			name: { ja: "サイコスフィア" },
+			damage: 80,
+			cost: ["Psychic", "Colorless", "Colorless"],
+		}
+	],
+
+	weaknesses: [{"type": "Darkness", "value": "x2"}],
+	resistances: [],
+
+	variants: [{"type": "normal"}],
+
+	retreat: 2,
+	regulationMark: "I",
+	rarity: "Uncommon",
+	dexId: [947],
+};
+
+export default card;

--- a/data-asia/M/M2/042.ts
+++ b/data-asia/M/M2/042.ts
@@ -1,0 +1,47 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ケンタロス",
+	},
+
+	illustrator: "Souichirou Gunjima",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Fighting"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "もうれつとつげき" },
+			damage: 40,
+			cost: ["Fighting"],
+			effect: { ja: "" },
+		},
+		{
+			name: { ja: "すてみタックル" },
+			damage: 70,
+			cost: ["Fighting", "Fighting"],
+			effect: { ja: "" },
+		}
+	],
+
+	weaknesses: [{"type": "Psychic", "value": "x2"}],
+	resistances: [],
+
+	variants: [{"type": "normal"}],
+
+	retreat: 2,
+	regulationMark: "I",
+	rarity: "Common",
+	dexId: [128],
+};
+
+export default card;

--- a/data-asia/M/M2/043.ts
+++ b/data-asia/M/M2/043.ts
@@ -1,0 +1,41 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "グライガー",
+	},
+
+	illustrator: "Kazumasa Yasukuni",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Fighting"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "どくづき" },
+			damage: 10,
+			cost: ["Fighting"],
+			effect: { ja: "" },
+		}
+	],
+
+	weaknesses: [{"type": "Grass", "value": "x2"}],
+	resistances: [],
+
+	variants: [{"type": "normal"}],
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "Common",
+	dexId: [207],
+};
+
+export default card;

--- a/data-asia/M/M2/044.ts
+++ b/data-asia/M/M2/044.ts
@@ -1,0 +1,45 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "グライオン",
+	},
+
+	illustrator: "Dsuke",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Fighting"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Stage1",
+
+	evolveFrom: {
+		ja: "グライガー",
+	},
+
+	attacks: [
+		{
+			name: { ja: "どくのサークル" },
+			damage: 50,
+			cost: ["Fighting"],
+			effect: { ja: "" },
+		}
+	],
+
+	weaknesses: [{"type": "Grass", "value": "x2"}],
+	resistances: [],
+
+	variants: [{"type": "normal"}],
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "Uncommon",
+	dexId: [472],
+};
+
+export default card;

--- a/data-asia/M/M2/045.ts
+++ b/data-asia/M/M2/045.ts
@@ -1,0 +1,41 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ナックラー",
+	},
+
+	illustrator: "Uta",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Fighting"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ダブルずつき" },
+			damage: 10,
+			cost: ["Fighting"],
+			effect: { ja: "" },
+		}
+	],
+
+	weaknesses: [{"type": "Grass", "value": "x2"}],
+	resistances: [],
+
+	variants: [{"type": "normal"}],
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "Common",
+	dexId: [328],
+};
+
+export default card;

--- a/data-asia/M/M2/046.ts
+++ b/data-asia/M/M2/046.ts
@@ -1,0 +1,44 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ビブラーバ",
+	},
+
+	illustrator: "Miki Tanaka",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Fighting"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Stage1",
+
+	evolveFrom: {
+		ja: "ナックラー",
+	},
+
+	attacks: [
+		{
+			name: { ja: "ちょうおんぱ" },
+			damage: 60,
+			cost: ["Fighting", "Fighting"],
+		}
+	],
+
+	weaknesses: [{"type": "Grass", "value": "x2"}],
+	resistances: [],
+
+	variants: [{"type": "normal"}],
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "Common",
+	dexId: [329],
+};
+
+export default card;

--- a/data-asia/M/M2/047.ts
+++ b/data-asia/M/M2/047.ts
@@ -1,0 +1,43 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "フライゴン",
+	},
+
+	illustrator: "Jerky",
+	category: "Pokemon",
+	hp: 150,
+	types: ["Fighting"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Stage2",
+
+	evolveFrom: {
+		ja: "ビブラーバ",
+	},
+
+	attacks: [
+		{
+			name: { ja: "かまいたち" },
+			damage: 130,
+		}
+	],
+
+	weaknesses: [{"type": "Grass", "value": "x2"}],
+	resistances: [],
+
+	variants: [{"type": "holo"}],
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "Rare Holo",
+	dexId: [330],
+};
+
+export default card;

--- a/data-asia/M/M2/048.ts
+++ b/data-asia/M/M2/048.ts
@@ -1,0 +1,45 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ニューラ",
+	},
+
+	illustrator: "Souichirou Gunjima",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Darkness"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "あなほりつめ" },
+			damage: 10,
+			cost: ["Darkness"],
+		},
+		{
+			name: { ja: "ひっかく" },
+			damage: 30,
+			cost: ["Darkness", "Darkness"],
+		}
+	],
+
+	weaknesses: [{"type": "Grass", "value": "x2"}],
+	resistances: [],
+
+	variants: [{"type": "normal"}],
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "Common",
+	dexId: [215],
+};
+
+export default card;

--- a/data-asia/M/M2/049.ts
+++ b/data-asia/M/M2/049.ts
@@ -1,0 +1,50 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "マニューラ",
+	},
+
+	illustrator: "matazo",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Darkness"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Stage1",
+
+	evolveFrom: {
+		ja: "ニューラ",
+	},
+
+	attacks: [
+		{
+			name: { ja: "しかえしのつめ" },
+			damage: 20,
+			cost: ["Darkness", "Darkness"],
+			effect: { ja: "" },
+		},
+		{
+			name: { ja: "きりさく" },
+			damage: 60,
+			cost: ["Darkness", "Darkness"],
+		}
+	],
+
+	weaknesses: [{"type": "Grass", "value": "x2"}],
+	resistances: [],
+
+	variants: [{"type": "normal"}],
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "Uncommon",
+	dexId: [461],
+};
+
+export default card;

--- a/data-asia/M/M2/050.ts
+++ b/data-asia/M/M2/050.ts
@@ -1,0 +1,41 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "キバニア",
+	},
+
+	illustrator: "Shin Nagasawa",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Darkness"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "むかちゅうとつげき" },
+			damage: 30,
+			cost: ["Darkness"],
+			effect: { ja: "" },
+		}
+	],
+
+	weaknesses: [{"type": "Grass", "value": "x2"}],
+	resistances: [],
+
+	variants: [{"type": "normal"}],
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "Common",
+	dexId: [318],
+};
+
+export default card;

--- a/data-asia/M/M2/051.ts
+++ b/data-asia/M/M2/051.ts
@@ -1,0 +1,49 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "メガサメハダーex",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 330,
+	types: ["Darkness"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "よくばりのきば" },
+			damage: 70,
+			cost: ["Darkness"],
+			effect: { ja: "" },
+		},
+		{
+			name: { ja: "ハングリージョーズ" },
+			damage: 120,
+			cost: ["Darkness", "Darkness"],
+			effect: { ja: "" },
+		}
+	],
+
+	weaknesses: [{"type": "Grass", "value": "x2"}],
+	resistances: [],
+
+	variants: [{"type": "holo"}],
+
+	retreat: 0,
+	regulationMark: "I",
+	rarity: "Double rare",
+	dexId: [319],
+
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/M/M2/052.ts
+++ b/data-asia/M/M2/052.ts
@@ -1,0 +1,40 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ハブネーク",
+	},
+
+	illustrator: "hncl",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Darkness"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "まっくろのきば" },
+			damage: 120,
+			cost: ["Darkness", "Darkness", "Darkness"],
+		}
+	],
+
+	weaknesses: [{"type": "Fighting", "value": "x2"}],
+	resistances: [],
+
+	variants: [{"type": "normal"}],
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "Common",
+	dexId: [336],
+};
+
+export default card;

--- a/data-asia/M/M2/053.ts
+++ b/data-asia/M/M2/053.ts
@@ -1,0 +1,45 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "メグロコ",
+	},
+
+	illustrator: "Taiga Kasai",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Darkness"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ぶつかる" },
+			damage: 10,
+			cost: ["Darkness"],
+		},
+		{
+			name: { ja: "リアキック" },
+			damage: 20,
+			cost: ["Darkness", "Colorless"],
+		}
+	],
+
+	weaknesses: [{"type": "Grass", "value": "x2"}],
+	resistances: [],
+
+	variants: [{"type": "normal"}],
+
+	retreat: 2,
+	regulationMark: "I",
+	rarity: "Common",
+	dexId: [551],
+};
+
+export default card;

--- a/data-asia/M/M2/054.ts
+++ b/data-asia/M/M2/054.ts
@@ -1,0 +1,49 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ワルビル",
+	},
+
+	illustrator: "Uninori",
+	category: "Pokemon",
+	hp: 100,
+	types: ["Darkness"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Stage1",
+
+	evolveFrom: {
+		ja: "メグロコ",
+	},
+
+	attacks: [
+		{
+			name: { ja: "かみつく" },
+			damage: 30,
+			cost: ["Darkness"],
+		},
+		{
+			name: { ja: "にらみつける" },
+			damage: 60,
+			cost: ["Darkness", "Colorless", "Colorless"],
+		}
+	],
+
+	weaknesses: [{"type": "Grass", "value": "x2"}],
+	resistances: [],
+
+	variants: [{"type": "normal"}],
+
+	retreat: 2,
+	regulationMark: "I",
+	rarity: "Common",
+	dexId: [552],
+};
+
+export default card;

--- a/data-asia/M/M2/055.ts
+++ b/data-asia/M/M2/055.ts
@@ -1,0 +1,50 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ワルビアル",
+	},
+
+	illustrator: "Ryuta Fuse",
+	category: "Pokemon",
+	hp: 170,
+	types: ["Darkness"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Stage2",
+
+	evolveFrom: {
+		ja: "ワルビル",
+	},
+
+	attacks: [
+		{
+			name: { ja: "しかえしのきば" },
+			damage: 60,
+			cost: ["Darkness"],
+			effect: { ja: "" },
+		},
+		{
+			name: { ja: "ハンマーイン" },
+			damage: 160,
+			cost: ["Darkness", "Colorless", "Colorless", "Colorless"],
+		}
+	],
+
+	weaknesses: [{"type": "Grass", "value": "x2"}],
+	resistances: [],
+
+	variants: [{"type": "normal"}],
+
+	retreat: 3,
+	regulationMark: "I",
+	rarity: "Uncommon",
+	dexId: [553],
+};
+
+export default card;

--- a/data-asia/M/M2/056.ts
+++ b/data-asia/M/M2/056.ts
@@ -1,0 +1,45 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "エレズン",
+	},
+
+	illustrator: "OKACHEKE",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Darkness"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "かぞくをよぶ" },
+			cost: ["Darkness"],
+			effect: { ja: "" },
+		},
+		{
+			name: { ja: "ラスカルキック" },
+			damage: 20,
+			cost: ["Darkness", "Colorless"],
+		}
+	],
+
+	weaknesses: [{"type": "Fighting", "value": "x2"}],
+	resistances: [],
+
+	variants: [{"type": "normal"}],
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "Common",
+	dexId: [848],
+};
+
+export default card;

--- a/data-asia/M/M2/057.ts
+++ b/data-asia/M/M2/057.ts
@@ -1,0 +1,44 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ストリンダー",
+	},
+
+	illustrator: "DOM",
+	category: "Pokemon",
+	hp: 140,
+	types: ["Darkness"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Stage1",
+
+	evolveFrom: {
+		ja: "エレズン",
+	},
+
+	attacks: [
+		{
+			name: { ja: "ポカリ" },
+			damage: 100,
+			cost: ["Darkness", "Darkness", "Colorless"],
+		}
+	],
+
+	weaknesses: [{"type": "Fighting", "value": "x2"}],
+	resistances: [],
+
+	variants: [{"type": "holo"}],
+
+	retreat: 2,
+	regulationMark: "I",
+	rarity: "Rare Holo",
+	dexId: [849],
+};
+
+export default card;

--- a/data-asia/M/M2/058.ts
+++ b/data-asia/M/M2/058.ts
@@ -1,0 +1,43 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "エンペルトex",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 320,
+	types: ["Metal"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "てつのはね" },
+			damage: 210,
+			cost: ["Metal", "Metal", "Colorless"],
+			effect: { ja: "" },
+		}
+	],
+
+	weaknesses: [{"type": "Fire", "value": "x2"}],
+	resistances: [],
+
+	variants: [{"type": "holo"}],
+
+	retreat: 2,
+	regulationMark: "I",
+	rarity: "Double rare",
+	dexId: [395],
+
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/M/M2/059.ts
+++ b/data-asia/M/M2/059.ts
@@ -1,0 +1,45 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ドーミラー",
+	},
+
+	illustrator: "OKUBO",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Metal"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "てっぺき" },
+			cost: ["Colorless"],
+			effect: { ja: "" },
+		},
+		{
+			name: { ja: "ころがる" },
+			damage: 30,
+			cost: ["Colorless", "Colorless", "Colorless"],
+		}
+	],
+
+	weaknesses: [{"type": "Fire", "value": "x2"}],
+	resistances: [],
+
+	variants: [{"type": "normal"}],
+
+	retreat: 2,
+	regulationMark: "I",
+	rarity: "Common",
+	dexId: [436],
+};
+
+export default card;

--- a/data-asia/M/M2/060.ts
+++ b/data-asia/M/M2/060.ts
@@ -1,0 +1,50 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ドータクン",
+	},
+
+	illustrator: "Masako Tomii",
+	category: "Pokemon",
+	hp: 140,
+	types: ["Metal"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Stage1",
+
+	evolveFrom: {
+		ja: "ドーミラー",
+	},
+
+	attacks: [
+		{
+			name: { ja: "トリプルドロー" },
+			cost: ["Colorless"],
+			effect: { ja: "" },
+		},
+		{
+			name: { ja: "ツールドロップ" },
+			damage: 40,
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: { ja: "" },
+		}
+	],
+
+	weaknesses: [{"type": "Fire", "value": "x2"}],
+	resistances: [],
+
+	variants: [{"type": "normal"}],
+
+	retreat: 3,
+	regulationMark: "I",
+	rarity: "Uncommon",
+	dexId: [437],
+};
+
+export default card;

--- a/data-asia/M/M2/061.ts
+++ b/data-asia/M/M2/061.ts
@@ -1,0 +1,45 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "トゲデマル",
+	},
+
+	illustrator: "Bun Toujo",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Metal"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "なかまをさがす" },
+			cost: ["Colorless"],
+			effect: { ja: "" },
+		},
+		{
+			name: { ja: "かじりつく" },
+			damage: 30,
+			cost: ["Metal"],
+		}
+	],
+
+	weaknesses: [{"type": "Fire", "value": "x2"}],
+	resistances: [],
+
+	variants: [{"type": "normal"}],
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "Common",
+	dexId: [777],
+};
+
+export default card;

--- a/data-asia/M/M2/062.ts
+++ b/data-asia/M/M2/062.ts
@@ -1,0 +1,41 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ジュラルドン",
+	},
+
+	illustrator: "Shinji Kanda",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Metal"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "はかいこうせん" },
+			damage: 70,
+			cost: ["Metal", "Metal", "Metal"],
+			effect: { ja: "" },
+		}
+	],
+
+	weaknesses: [{"type": "Fire", "value": "x2"}],
+	resistances: [],
+
+	variants: [{"type": "normal"}],
+
+	retreat: 2,
+	regulationMark: "I",
+	rarity: "Common",
+	dexId: [884],
+};
+
+export default card;

--- a/data-asia/M/M2/063.ts
+++ b/data-asia/M/M2/063.ts
@@ -1,0 +1,45 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ブリジュラス",
+	},
+
+	illustrator: "toriyufu",
+	category: "Pokemon",
+	hp: 180,
+	types: ["Metal"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Stage1",
+
+	evolveFrom: {
+		ja: "ジュラルドン",
+	},
+
+	attacks: [
+		{
+			name: { ja: "コーティングアタック" },
+			damage: 120,
+			cost: ["Metal", "Metal", "Metal"],
+			effect: { ja: "" },
+		}
+	],
+
+	weaknesses: [{"type": "Fire", "value": "x2"}],
+	resistances: [],
+
+	variants: [{"type": "normal"}],
+
+	retreat: 2,
+	regulationMark: "I",
+	rarity: "Uncommon",
+	dexId: [1018],
+};
+
+export default card;

--- a/data-asia/M/M2/064.ts
+++ b/data-asia/M/M2/064.ts
@@ -1,0 +1,41 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "プリン",
+	},
+
+	illustrator: "Naoyo Kimura",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Colorless"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "たまころがし" },
+			damage: 20,
+			cost: ["Colorless"],
+			effect: { ja: "" },
+		}
+	],
+
+	weaknesses: [{"type": "Fighting", "value": "x2"}],
+	resistances: [],
+
+	variants: [{"type": "normal"}],
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "Common",
+	dexId: [39],
+};
+
+export default card;

--- a/data-asia/M/M2/065.ts
+++ b/data-asia/M/M2/065.ts
@@ -1,0 +1,50 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "プクリン",
+	},
+
+	illustrator: "En Morikura",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Colorless"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Stage1",
+
+	evolveFrom: {
+		ja: "プリン",
+	},
+
+	attacks: [
+		{
+			name: { ja: "ラウンド" },
+			damage: 40,
+			cost: ["Colorless", "Colorless"],
+			effect: { ja: "" },
+		},
+		{
+			name: { ja: "ちきゅうなげ" },
+			damage: 100,
+			cost: ["Colorless", "Colorless", "Colorless"],
+		}
+	],
+
+	weaknesses: [{"type": "Fighting", "value": "x2"}],
+	resistances: [],
+
+	variants: [{"type": "normal"}],
+
+	retreat: 2,
+	regulationMark: "I",
+	rarity: "Uncommon",
+	dexId: [40],
+};
+
+export default card;

--- a/data-asia/M/M2/066.ts
+++ b/data-asia/M/M2/066.ts
@@ -1,0 +1,40 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "エイパム",
+	},
+
+	illustrator: "Saboteri",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Colorless"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "おどろかす" },
+			cost: ["Colorless", "Colorless"],
+			effect: { ja: "" },
+		}
+	],
+
+	weaknesses: [{"type": "Fighting", "value": "x2"}],
+	resistances: [],
+
+	variants: [{"type": "normal"}],
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "Common",
+	dexId: [190],
+};
+
+export default card;

--- a/data-asia/M/M2/067.ts
+++ b/data-asia/M/M2/067.ts
@@ -1,0 +1,50 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "エテボース",
+	},
+
+	illustrator: "hncl",
+	category: "Pokemon",
+	hp: 110,
+	types: ["Colorless"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Stage1",
+
+	evolveFrom: {
+		ja: "エイパム",
+	},
+
+	attacks: [
+		{
+			name: { ja: "はたく" },
+			damage: 50,
+			cost: ["Colorless", "Colorless"],
+		},
+		{
+			name: { ja: "ダブルテール" },
+			damage: 50,
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: { ja: "" },
+		}
+	],
+
+	weaknesses: [{"type": "Fighting", "value": "x2"}],
+	resistances: [],
+
+	variants: [{"type": "holo"}],
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "Rare Holo",
+	dexId: [424],
+};
+
+export default card;

--- a/data-asia/M/M2/068.ts
+++ b/data-asia/M/M2/068.ts
@@ -1,0 +1,45 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ドーブル",
+	},
+
+	illustrator: "REND",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Colorless"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "エネルギースケッチ" },
+			cost: ["Colorless"],
+			effect: { ja: "" },
+		},
+		{
+			name: { ja: "フック" },
+			damage: 40,
+			cost: ["Colorless", "Colorless"],
+		}
+	],
+
+	weaknesses: [{"type": "Fighting", "value": "x2"}],
+	resistances: [],
+
+	variants: [{"type": "normal"}],
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "Common",
+	dexId: [235],
+};
+
+export default card;

--- a/data-asia/M/M2/069.ts
+++ b/data-asia/M/M2/069.ts
@@ -1,0 +1,41 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ジグザグマ",
+	},
+
+	illustrator: "Dsuke",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Colorless"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "きしゅう" },
+			damage: 30,
+			cost: ["Colorless"],
+			effect: { ja: "" },
+		}
+	],
+
+	weaknesses: [{"type": "Fighting", "value": "x2"}],
+	resistances: [],
+
+	variants: [{"type": "normal"}],
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "Common",
+	dexId: [263],
+};
+
+export default card;

--- a/data-asia/M/M2/070.ts
+++ b/data-asia/M/M2/070.ts
@@ -1,0 +1,44 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "マッスグマ",
+	},
+
+	illustrator: "nagimiso",
+	category: "Pokemon",
+	hp: 100,
+	types: ["Colorless"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Stage1",
+
+	evolveFrom: {
+		ja: "ジグザグマ",
+	},
+
+	attacks: [
+		{
+			name: { ja: "きりさく" },
+			damage: 70,
+			cost: ["Colorless"],
+		}
+	],
+
+	weaknesses: [{"type": "Fighting", "value": "x2"}],
+	resistances: [],
+
+	variants: [{"type": "normal"}],
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "Uncommon",
+	dexId: [264],
+};
+
+export default card;

--- a/data-asia/M/M2/071.ts
+++ b/data-asia/M/M2/071.ts
@@ -1,0 +1,45 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ミミロル",
+	},
+
+	illustrator: "tono",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Colorless"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "もてあそぶ" },
+			cost: ["Colorless"],
+			effect: { ja: "" },
+		},
+		{
+			name: { ja: "キック" },
+			damage: 20,
+			cost: ["Colorless", "Colorless"],
+		}
+	],
+
+	weaknesses: [{"type": "Fighting", "value": "x2"}],
+	resistances: [],
+
+	variants: [{"type": "normal"}],
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "Common",
+	dexId: [427],
+};
+
+export default card;

--- a/data-asia/M/M2/072.ts
+++ b/data-asia/M/M2/072.ts
@@ -1,0 +1,49 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "メガミミロップex",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 330,
+	types: ["Colorless"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "つむじかぜつき" },
+			damage: 60,
+			cost: ["Colorless"],
+			effect: { ja: "" },
+		},
+		{
+			name: { ja: "スパイキーホッパー" },
+			damage: 160,
+			cost: ["Colorless", "Colorless"],
+			effect: { ja: "" },
+		}
+	],
+
+	weaknesses: [{"type": "Fighting", "value": "x2"}],
+	resistances: [],
+
+	variants: [{"type": "holo"}],
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "Double rare",
+	dexId: [428],
+
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/M/M2/073.ts
+++ b/data-asia/M/M2/073.ts
@@ -1,0 +1,24 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ジャンボソフト",
+	},
+
+	illustrator: "AYUMI ODASHIMA",
+	category: "Trainer",
+
+	effect: {
+		ja: "",
+	},
+
+	variants: [{"type": "normal"}],
+
+	trainerType: "Item",
+	regulationMark: "I",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/M/M2/074.ts
+++ b/data-asia/M/M2/074.ts
@@ -1,0 +1,24 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヒートバーナー",
+	},
+
+	illustrator: "Toyste Beach",
+	category: "Trainer",
+
+	effect: {
+		ja: "",
+	},
+
+	variants: [{"type": "normal"}],
+
+	trainerType: "Item",
+	regulationMark: "I",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/M/M2/075.ts
+++ b/data-asia/M/M2/075.ts
@@ -1,0 +1,24 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "セイクリッドチャーム",
+	},
+
+	illustrator: "Toyste Beach",
+	category: "Trainer",
+
+	effect: {
+		ja: "",
+	},
+
+	variants: [{"type": "normal"}],
+
+	trainerType: "Tool",
+	regulationMark: "I",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/M/M2/076.ts
+++ b/data-asia/M/M2/076.ts
@@ -1,0 +1,24 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ギーマのかけひき",
+	},
+
+	illustrator: "GIDORA",
+	category: "Trainer",
+
+	effect: {
+		ja: "",
+	},
+
+	variants: [{"type": "normal"}],
+
+	trainerType: "Supporter",
+	regulationMark: "I",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/M/M2/077.ts
+++ b/data-asia/M/M2/077.ts
@@ -1,0 +1,24 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヒカリ",
+	},
+
+	illustrator: "Yuu Nishida",
+	category: "Trainer",
+
+	effect: {
+		ja: "",
+	},
+
+	variants: [{"type": "normal"}],
+
+	trainerType: "Supporter",
+	regulationMark: "I",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/M/M2/078.ts
+++ b/data-asia/M/M2/078.ts
@@ -1,0 +1,24 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ファイアーブレーサー",
+	},
+
+	illustrator: "Naoki Saito",
+	category: "Trainer",
+
+	effect: {
+		ja: "",
+	},
+
+	variants: [{"type": "normal"}],
+
+	trainerType: "Supporter",
+	regulationMark: "I",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/M/M2/079.ts
+++ b/data-asia/M/M2/079.ts
@@ -1,0 +1,24 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "バトルコロシアム",
+	},
+
+	illustrator: "MARINA Chikazawa",
+	category: "Trainer",
+
+	effect: {
+		ja: "",
+	},
+
+	variants: [{"type": "normal"}],
+
+	trainerType: "Stadium",
+	regulationMark: "I",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/M/M2/080.ts
+++ b/data-asia/M/M2/080.ts
@@ -1,0 +1,24 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "めまいのたに",
+	},
+
+	illustrator: "AYUMI ODASHIMA",
+	category: "Trainer",
+
+	effect: {
+		ja: "",
+	},
+
+	variants: [{"type": "normal"}],
+
+	trainerType: "Stadium",
+	regulationMark: "I",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/M/M2/081.ts
+++ b/data-asia/M/M2/081.ts
@@ -1,0 +1,44 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ルンパッパ",
+	},
+
+	illustrator: "Jerky",
+	category: "Pokemon",
+	hp: 160,
+	types: ["Grass"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Stage2",
+
+	evolveFrom: {
+		ja: "ハスブレロ",
+	},
+
+	attacks: [
+		{
+			name: { ja: "とびかかる" },
+			damage: 120,
+			cost: ["Grass", "Colorless"],
+		}
+	],
+
+	weaknesses: [{"type": "Fire", "value": "x2"}],
+	resistances: [],
+
+	variants: [{"type": "holo"}],
+
+	retreat: 2,
+	regulationMark: "I",
+	rarity: "Illustration rare",
+	dexId: [272],
+};
+
+export default card;

--- a/data-asia/M/M2/082.ts
+++ b/data-asia/M/M2/082.ts
@@ -1,0 +1,41 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "マメバッタ",
+	},
+
+	illustrator: "Nakamura Ippan",
+	category: "Pokemon",
+	hp: 50,
+	types: ["Grass"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "バタバタもがく" },
+			damage: 10,
+			cost: ["Grass"],
+			effect: { ja: "" },
+		}
+	],
+
+	weaknesses: [{"type": "Fire", "value": "x2"}],
+	resistances: [],
+
+	variants: [{"type": "holo"}],
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "Illustration rare",
+	dexId: [919],
+};
+
+export default card;

--- a/data-asia/M/M2/083.ts
+++ b/data-asia/M/M2/083.ts
@@ -1,0 +1,45 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "カルボウ",
+	},
+
+	illustrator: "Teeziro",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Grass"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ちからをためる" },
+			cost: ["Fire"],
+			effect: { ja: "" },
+		},
+		{
+			name: { ja: "チョップ" },
+			damage: 10,
+			cost: ["Fire"],
+		}
+	],
+
+	weaknesses: [{"type": "Water", "value": "x2"}],
+	resistances: [],
+
+	variants: [{"type": "holo"}],
+
+	retreat: 2,
+	regulationMark: "I",
+	rarity: "Illustration rare",
+	dexId: [935],
+};
+
+export default card;

--- a/data-asia/M/M2/084.ts
+++ b/data-asia/M/M2/084.ts
@@ -1,0 +1,45 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ジュゴン",
+	},
+
+	illustrator: "satoma",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Water"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Stage1",
+
+	evolveFrom: {
+		ja: "パウワウ",
+	},
+
+	attacks: [
+		{
+			name: { ja: "スラム" },
+			damage: 70,
+			cost: ["Water", "Colorless"],
+			effect: { ja: "" },
+		}
+	],
+
+	weaknesses: [{"type": "Lightning", "value": "x2"}],
+	resistances: [],
+
+	variants: [{"type": "holo"}],
+
+	retreat: 2,
+	regulationMark: "I",
+	rarity: "Illustration rare",
+	dexId: [87],
+};
+
+export default card;

--- a/data-asia/M/M2/085.ts
+++ b/data-asia/M/M2/085.ts
@@ -1,0 +1,45 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ポッチャマ",
+	},
+
+	illustrator: "Jiro Sasumo",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Water"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "なかまをよぶ" },
+			cost: ["Colorless"],
+			effect: { ja: "" },
+		},
+		{
+			name: { ja: "たいあたり" },
+			damage: 20,
+			cost: ["Colorless", "Colorless"],
+		}
+	],
+
+	weaknesses: [{"type": "Lightning", "value": "x2"}],
+	resistances: [],
+
+	variants: [{"type": "holo"}],
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "Illustration rare",
+	dexId: [393],
+};
+
+export default card;

--- a/data-asia/M/M2/086.ts
+++ b/data-asia/M/M2/086.ts
@@ -1,0 +1,41 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ワンパチ",
+	},
+
+	illustrator: "tono",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Fighting"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "じゃれつく" },
+			damage: 20,
+			cost: ["Lightning", "Colorless"],
+			effect: { ja: "" },
+		}
+	],
+
+	weaknesses: [{"type": "Fighting", "value": "x2"}],
+	resistances: [],
+
+	variants: [{"type": "holo"}],
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "Illustration rare",
+	dexId: [835],
+};
+
+export default card;

--- a/data-asia/M/M2/087.ts
+++ b/data-asia/M/M2/087.ts
@@ -1,0 +1,41 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ザシアン",
+	},
+
+	illustrator: "Yoriyuki Ikegami",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Psychic"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "リミットブレイク" },
+			damage: 50,
+			cost: ["Psychic", "Colorless"],
+			effect: { ja: "" },
+		}
+	],
+
+	weaknesses: [{"type": "Metal", "value": "x2"}],
+	resistances: [],
+
+	variants: [{"type": "holo"}],
+
+	retreat: 2,
+	regulationMark: "I",
+	rarity: "Illustration rare",
+	dexId: [888],
+};
+
+export default card;

--- a/data-asia/M/M2/088.ts
+++ b/data-asia/M/M2/088.ts
@@ -1,0 +1,43 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "フライゴン",
+	},
+
+	illustrator: "Ryota Murayama",
+	category: "Pokemon",
+	hp: 150,
+	types: ["Fighting"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Stage2",
+
+	evolveFrom: {
+		ja: "ビブラーバ",
+	},
+
+	attacks: [
+		{
+			name: { ja: "かまいたち" },
+			damage: 130,
+		}
+	],
+
+	weaknesses: [{"type": "Grass", "value": "x2"}],
+	resistances: [],
+
+	variants: [{"type": "holo"}],
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "Illustration rare",
+	dexId: [330],
+};
+
+export default card;

--- a/data-asia/M/M2/089.ts
+++ b/data-asia/M/M2/089.ts
@@ -1,0 +1,44 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ストリンダー",
+	},
+
+	illustrator: "Terada Tera",
+	category: "Pokemon",
+	hp: 140,
+	types: ["Darkness"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Stage1",
+
+	evolveFrom: {
+		ja: "エレズン",
+	},
+
+	attacks: [
+		{
+			name: { ja: "ポカリ" },
+			damage: 100,
+			cost: ["Darkness", "Darkness", "Colorless"],
+		}
+	],
+
+	weaknesses: [{"type": "Fighting", "value": "x2"}],
+	resistances: [],
+
+	variants: [{"type": "holo"}],
+
+	retreat: 2,
+	regulationMark: "I",
+	rarity: "Illustration rare",
+	dexId: [849],
+};
+
+export default card;

--- a/data-asia/M/M2/090.ts
+++ b/data-asia/M/M2/090.ts
@@ -1,0 +1,45 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "トゲデマル",
+	},
+
+	illustrator: "Orca",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Metal"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "なかまをさがす" },
+			cost: ["Colorless"],
+			effect: { ja: "" },
+		},
+		{
+			name: { ja: "かじりつく" },
+			damage: 30,
+			cost: ["Metal"],
+		}
+	],
+
+	weaknesses: [{"type": "Fire", "value": "x2"}],
+	resistances: [],
+
+	variants: [{"type": "holo"}],
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "Illustration rare",
+	dexId: [777],
+};
+
+export default card;

--- a/data-asia/M/M2/091.ts
+++ b/data-asia/M/M2/091.ts
@@ -1,0 +1,50 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "プクリン",
+	},
+
+	illustrator: "REND",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Colorless"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Stage1",
+
+	evolveFrom: {
+		ja: "プリン",
+	},
+
+	attacks: [
+		{
+			name: { ja: "ラウンド" },
+			damage: 40,
+			cost: ["Colorless", "Colorless"],
+			effect: { ja: "" },
+		},
+		{
+			name: { ja: "ちきゅうなげ" },
+			damage: 100,
+			cost: ["Colorless", "Colorless", "Colorless"],
+		}
+	],
+
+	weaknesses: [{"type": "Fighting", "value": "x2"}],
+	resistances: [],
+
+	variants: [{"type": "holo"}],
+
+	retreat: 2,
+	regulationMark: "I",
+	rarity: "Illustration rare",
+	dexId: [40],
+};
+
+export default card;

--- a/data-asia/M/M2/092.ts
+++ b/data-asia/M/M2/092.ts
@@ -1,0 +1,50 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "エテボース",
+	},
+
+	illustrator: "Shigenori Negishi",
+	category: "Pokemon",
+	hp: 110,
+	types: ["Colorless"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Stage1",
+
+	evolveFrom: {
+		ja: "エイパム",
+	},
+
+	attacks: [
+		{
+			name: { ja: "はたく" },
+			damage: 50,
+			cost: ["Colorless", "Colorless"],
+		},
+		{
+			name: { ja: "ダブルテール" },
+			damage: 50,
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: { ja: "" },
+		}
+	],
+
+	weaknesses: [{"type": "Fighting", "value": "x2"}],
+	resistances: [],
+
+	variants: [{"type": "holo"}],
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "Illustration rare",
+	dexId: [424],
+};
+
+export default card;

--- a/data-asia/M/M2/093.ts
+++ b/data-asia/M/M2/093.ts
@@ -1,0 +1,49 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "メガヘラクロスex",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 280,
+	types: ["Fighting"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "パンツァーホーン" },
+			damage: 100,
+			cost: ["Grass", "Grass"],
+			effect: { ja: "" },
+		},
+		{
+			name: { ja: "ミリングジャブ" },
+			damage: 170,
+			cost: ["Grass", "Grass", "Grass"],
+			effect: { ja: "" },
+		}
+	],
+
+	weaknesses: [{"type": "Fire", "value": "x2"}],
+	resistances: [],
+
+	variants: [{"type": "holo"}],
+
+	retreat: 2,
+	regulationMark: "I",
+	rarity: "Ultra Rare",
+	dexId: [214],
+
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/M/M2/094.ts
+++ b/data-asia/M/M2/094.ts
@@ -1,0 +1,43 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "メガリザードンXex",
+	},
+
+	illustrator: "takuyoa",
+	category: "Pokemon",
+	hp: 360,
+	types: ["Fire"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "インフェルノX" },
+			damage: 90,
+			cost: ["Fire", "Fire"],
+			effect: { ja: "" },
+		}
+	],
+
+	weaknesses: [{"type": "Water", "value": "x2"}],
+	resistances: [],
+
+	variants: [{"type": "holo"}],
+
+	retreat: 2,
+	regulationMark: "I",
+	rarity: "Ultra Rare",
+	dexId: [6],
+
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/M/M2/095.ts
+++ b/data-asia/M/M2/095.ts
@@ -1,0 +1,42 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "オドリドリex",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 190,
+	types: ["Grass"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ほのおのつばさ" },
+			damage: 110,
+			cost: ["Fire", "Fire", "Colorless"],
+		}
+	],
+
+	weaknesses: [{"type": "Water", "value": "x2"}],
+	resistances: [],
+
+	variants: [{"type": "holo"}],
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "Ultra Rare",
+	dexId: [741],
+
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/M/M2/096.ts
+++ b/data-asia/M/M2/096.ts
@@ -1,0 +1,43 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ロトムex",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 190,
+	types: ["Lightning"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "かみなり" },
+			damage: 130,
+			cost: ["Lightning", "Colorless"],
+			effect: { ja: "" },
+		}
+	],
+
+	weaknesses: [{"type": "Fighting", "value": "x2"}],
+	resistances: [],
+
+	variants: [{"type": "holo"}],
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "Ultra Rare",
+	dexId: [479],
+
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/M/M2/097.ts
+++ b/data-asia/M/M2/097.ts
@@ -1,0 +1,43 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ムウマージex",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 260,
+	types: ["Psychic"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "むむむのたたり" },
+			damage: 150,
+			cost: ["Psychic", "Psychic"],
+			effect: { ja: "" },
+		}
+	],
+
+	weaknesses: [{"type": "Darkness", "value": "x2"}],
+	resistances: [],
+
+	variants: [{"type": "holo"}],
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "Ultra Rare",
+	dexId: [429],
+
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/M/M2/098.ts
+++ b/data-asia/M/M2/098.ts
@@ -1,0 +1,49 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "メガサメハダーex",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 330,
+	types: ["Darkness"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "よくばりのきば" },
+			damage: 70,
+			cost: ["Darkness"],
+			effect: { ja: "" },
+		},
+		{
+			name: { ja: "ハングリージョーズ" },
+			damage: 120,
+			cost: ["Darkness", "Darkness"],
+			effect: { ja: "" },
+		}
+	],
+
+	weaknesses: [{"type": "Grass", "value": "x2"}],
+	resistances: [],
+
+	variants: [{"type": "holo"}],
+
+	retreat: 0,
+	regulationMark: "I",
+	rarity: "Ultra Rare",
+	dexId: [319],
+
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/M/M2/099.ts
+++ b/data-asia/M/M2/099.ts
@@ -1,0 +1,43 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "エンペルトex",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 320,
+	types: ["Metal"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "てつのはね" },
+			damage: 210,
+			cost: ["Metal", "Metal", "Colorless"],
+			effect: { ja: "" },
+		}
+	],
+
+	weaknesses: [{"type": "Fire", "value": "x2"}],
+	resistances: [],
+
+	variants: [{"type": "holo"}],
+
+	retreat: 2,
+	regulationMark: "I",
+	rarity: "Ultra Rare",
+	dexId: [395],
+
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/M/M2/100.ts
+++ b/data-asia/M/M2/100.ts
@@ -1,0 +1,49 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "メガミミロップex",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 330,
+	types: ["Colorless"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "つむじかぜつき" },
+			damage: 60,
+			cost: ["Colorless"],
+			effect: { ja: "" },
+		},
+		{
+			name: { ja: "スパイキーホッパー" },
+			damage: 160,
+			cost: ["Colorless", "Colorless"],
+			effect: { ja: "" },
+		}
+	],
+
+	weaknesses: [{"type": "Fighting", "value": "x2"}],
+	resistances: [],
+
+	variants: [{"type": "holo"}],
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "Ultra Rare",
+	dexId: [428],
+
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/M/M2/101.ts
+++ b/data-asia/M/M2/101.ts
@@ -1,0 +1,24 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヒートバーナー",
+	},
+
+	illustrator: "Toyste Beach",
+	category: "Trainer",
+
+	effect: {
+		ja: "",
+	},
+
+	variants: [{"type": "holo"}],
+
+	trainerType: "Item",
+	regulationMark: "I",
+	rarity: "Special illustration rare",
+};
+
+export default card;

--- a/data-asia/M/M2/102.ts
+++ b/data-asia/M/M2/102.ts
@@ -1,0 +1,24 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "Switch",
+	},
+
+	illustrator: "Studio Bora Inc.",
+	category: "Trainer",
+
+	effect: {
+		ja: "",
+	},
+
+	variants: [{"type": "holo"}],
+
+	trainerType: "Item",
+	regulationMark: "I",
+	rarity: "Special illustration rare",
+};
+
+export default card;

--- a/data-asia/M/M2/103.ts
+++ b/data-asia/M/M2/103.ts
@@ -1,0 +1,24 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "セイクリッドチャーム",
+	},
+
+	illustrator: "Toyste Beach",
+	category: "Trainer",
+
+	effect: {
+		ja: "",
+	},
+
+	variants: [{"type": "holo"}],
+
+	trainerType: "Tool",
+	regulationMark: "I",
+	rarity: "Special illustration rare",
+};
+
+export default card;

--- a/data-asia/M/M2/104.ts
+++ b/data-asia/M/M2/104.ts
@@ -1,0 +1,24 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "Punk Helmet",
+	},
+
+	illustrator: "Studio Bora Inc",
+	category: "Trainer",
+
+	effect: {
+		ja: "",
+	},
+
+	variants: [{"type": "holo"}],
+
+	trainerType: "Tool",
+	regulationMark: "I",
+	rarity: "Special illustration rare",
+};
+
+export default card;

--- a/data-asia/M/M2/105.ts
+++ b/data-asia/M/M2/105.ts
@@ -1,0 +1,24 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ギーマのかけひき",
+	},
+
+	illustrator: "GIDORA",
+	category: "Trainer",
+
+	effect: {
+		ja: "",
+	},
+
+	variants: [{"type": "holo"}],
+
+	trainerType: "Supporter",
+	regulationMark: "I",
+	rarity: "Special illustration rare",
+};
+
+export default card;

--- a/data-asia/M/M2/106.ts
+++ b/data-asia/M/M2/106.ts
@@ -1,0 +1,24 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヒカリ",
+	},
+
+	illustrator: "Yuu Nishida",
+	category: "Trainer",
+
+	effect: {
+		ja: "",
+	},
+
+	variants: [{"type": "holo"}],
+
+	trainerType: "Supporter",
+	regulationMark: "I",
+	rarity: "Special illustration rare",
+};
+
+export default card;

--- a/data-asia/M/M2/107.ts
+++ b/data-asia/M/M2/107.ts
@@ -1,0 +1,24 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ファイアーブレーサー",
+	},
+
+	illustrator: "Naoki Saito",
+	category: "Trainer",
+
+	effect: {
+		ja: "",
+	},
+
+	variants: [{"type": "holo"}],
+
+	trainerType: "Supporter",
+	regulationMark: "I",
+	rarity: "Special illustration rare",
+};
+
+export default card;

--- a/data-asia/M/M2/108.ts
+++ b/data-asia/M/M2/108.ts
@@ -1,0 +1,24 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "バトルコロシアム",
+	},
+
+	illustrator: "MARINA Chikazawa",
+	category: "Trainer",
+
+	effect: {
+		ja: "",
+	},
+
+	variants: [{"type": "holo"}],
+
+	trainerType: "Stadium",
+	regulationMark: "I",
+	rarity: "Special illustration rare",
+};
+
+export default card;

--- a/data-asia/M/M2/109.ts
+++ b/data-asia/M/M2/109.ts
@@ -1,0 +1,24 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "Ignition Energy",
+	},
+
+	illustrator: "",
+	category: "Trainer",
+
+	effect: {
+		ja: "",
+	},
+
+	variants: [{"type": "holo"}],
+
+	trainerType: "Item",
+	regulationMark: "I",
+	rarity: "Special illustration rare",
+};
+
+export default card;

--- a/data-asia/M/M2/110.ts
+++ b/data-asia/M/M2/110.ts
@@ -1,0 +1,43 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "メガリザードンXex",
+	},
+
+	illustrator: "danciao",
+	category: "Pokemon",
+	hp: 360,
+	types: ["Fire"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "インフェルノX" },
+			damage: 90,
+			cost: ["Fire", "Fire"],
+			effect: { ja: "" },
+		}
+	],
+
+	weaknesses: [{"type": "Water", "value": "x2"}],
+	resistances: [],
+
+	variants: [{"type": "holo"}],
+
+	retreat: 2,
+	regulationMark: "I",
+	rarity: "Hyper rare",
+	dexId: [6],
+
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/M/M2/111.ts
+++ b/data-asia/M/M2/111.ts
@@ -1,0 +1,42 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "オドリドリex",
+	},
+
+	illustrator: "Shinji Kanda",
+	category: "Pokemon",
+	hp: 190,
+	types: ["Grass"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ほのおのつばさ" },
+			damage: 110,
+			cost: ["Fire", "Fire", "Colorless"],
+		}
+	],
+
+	weaknesses: [{"type": "Water", "value": "x2"}],
+	resistances: [],
+
+	variants: [{"type": "holo"}],
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "Hyper rare",
+	dexId: [741],
+
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/M/M2/112.ts
+++ b/data-asia/M/M2/112.ts
@@ -1,0 +1,43 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ロトムex",
+	},
+
+	illustrator: "Yoshimi Miyoshi",
+	category: "Pokemon",
+	hp: 190,
+	types: ["Lightning"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "かみなり" },
+			damage: 130,
+			cost: ["Lightning", "Colorless"],
+			effect: { ja: "" },
+		}
+	],
+
+	weaknesses: [{"type": "Fighting", "value": "x2"}],
+	resistances: [],
+
+	variants: [{"type": "holo"}],
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "Hyper rare",
+	dexId: [479],
+
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/M/M2/113.ts
+++ b/data-asia/M/M2/113.ts
@@ -1,0 +1,49 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "メガサメハダーex",
+	},
+
+	illustrator: "nagimiso",
+	category: "Pokemon",
+	hp: 330,
+	types: ["Darkness"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "よくばりのきば" },
+			damage: 70,
+			cost: ["Darkness"],
+			effect: { ja: "" },
+		},
+		{
+			name: { ja: "ハングリージョーズ" },
+			damage: 120,
+			cost: ["Darkness", "Darkness"],
+			effect: { ja: "" },
+		}
+	],
+
+	weaknesses: [{"type": "Grass", "value": "x2"}],
+	resistances: [],
+
+	variants: [{"type": "holo"}],
+
+	retreat: 0,
+	regulationMark: "I",
+	rarity: "Mega Hyper Rare",
+	dexId: [319],
+
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/M/M2/114.ts
+++ b/data-asia/M/M2/114.ts
@@ -1,0 +1,49 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "メガミミロップex",
+	},
+
+	illustrator: "Kinu Nishimura",
+	category: "Pokemon",
+	hp: 330,
+	types: ["Colorless"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "つむじかぜつき" },
+			damage: 60,
+			cost: ["Colorless"],
+			effect: { ja: "" },
+		},
+		{
+			name: { ja: "スパイキーホッパー" },
+			damage: 160,
+			cost: ["Colorless", "Colorless"],
+			effect: { ja: "" },
+		}
+	],
+
+	weaknesses: [{"type": "Fighting", "value": "x2"}],
+	resistances: [],
+
+	variants: [{"type": "holo"}],
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "Mega Hyper Rare",
+	dexId: [428],
+
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/M/M2/115.ts
+++ b/data-asia/M/M2/115.ts
@@ -1,0 +1,24 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヒカリ",
+	},
+
+	illustrator: "Atsushi Furusawa",
+	category: "Trainer",
+
+	effect: {
+		ja: "",
+	},
+
+	variants: [{"type": "holo"}],
+
+	trainerType: "Supporter",
+	regulationMark: "I",
+	rarity: "Special illustration rare",
+};
+
+export default card;

--- a/data-asia/M/M2/116.ts
+++ b/data-asia/M/M2/116.ts
@@ -1,0 +1,43 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "メガリザードンXex",
+	},
+
+	illustrator: "takuyoa",
+	category: "Pokemon",
+	hp: 360,
+	types: ["Fire"],
+
+	description: {
+		ja: "",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "インフェルノX" },
+			damage: 90,
+			cost: ["Fire", "Fire"],
+			effect: { ja: "" },
+		}
+	],
+
+	weaknesses: [{"type": "Water", "value": "x2"}],
+	resistances: [],
+
+	variants: [{"type": "holo"}],
+
+	retreat: 2,
+	regulationMark: "I",
+	rarity: "Mega Hyper Rare",
+	dexId: [6],
+
+	suffix: "EX",
+};
+
+export default card;


### PR DESCRIPTION
Closes #1174

## Changes

Added the Japanese M2 **Inferno X** (インフェルノX) set — the second expansion of the Japanese MEGA Series, featuring Mega Charizard X ex. Released September 26, 2025.

### Files added
- `data-asia/M/M2.ts` — set definition
- `data-asia/M/M2/001.ts` through `data-asia/M/M2/116.ts` — all 116 cards

### Data source
Card data scraped from [serebii.net/card/infernox](https://www.serebii.net/card/infernox/).

### Notes
- English equivalent is already in TCGdex as Phantasmal Flames (ME02)
- Pokémon names use verified Japanese names
- `regulationMark: "I"` applied to all cards
- Variants follow the same rarity→variant mapping as M3