### PR TITLE
fix: Change swsh2-1 (caterpie) dexId from 251 to 10

### DIFF
--- a/data/Sword & Shield/Rebel Clash/1.ts
+++ b/data/Sword & Shield/Rebel Clash/1.ts
@@ -82,7 +82,7 @@ const card: Card = {
 		en: "For protection, it releases a horrible stench from the antenna on its head to drive away enemies."
 	},
 
-	dexId: [251],
+	dexId: [10],
 
 	thirdParty: {
 		cardmarket: 457383,


### PR DESCRIPTION

## Changes

Fix incorrect dexId for Caterpie (swsh2-1) in Rebel Clash

