### PR TITLE
fix: Adding evolve from when missing in some ME cards files (ASC & PHF)

### DIFF
--- a/data/Mega Evolution/Ascended Heroes/010.ts
+++ b/data/Mega Evolution/Ascended Heroes/010.ts
@@ -13,6 +13,15 @@ const card: Card = {
 		it: "Mega Meganium-ex",
 		pt: "Mega Meganium ex"
 	},
+	evolveFrom: {
+		en: "Bayleef",
+		de: "Lorblatt",
+		es: "Bayleef",
+		'es-mx': "Bayleef",
+		fr: "Macronium",
+		it: "Bayleef",
+		pt: "Bayleef",
+	},
 
 	illustrator: "5ban Graphics",
 	rarity: "Double rare",

--- a/data/Mega Evolution/Ascended Heroes/031.ts
+++ b/data/Mega Evolution/Ascended Heroes/031.ts
@@ -13,6 +13,15 @@ const card: Card = {
 		it: "Mega Emboar-ex",
 		pt: "Mega Emboar ex"
 	},
+	evolveFrom: {
+		en: "Pignite",
+		de: "Ferkokel",
+		es: "Pignite",
+		'es-mx': "Pignite",
+		fr: "Grotichon",
+		it: "Pignite",
+		pt: "Pignite",
+	},
 
 	illustrator: "5ban Graphics",
 	rarity: "Double rare",

--- a/data/Mega Evolution/Ascended Heroes/038.ts
+++ b/data/Mega Evolution/Ascended Heroes/038.ts
@@ -13,6 +13,15 @@ const card: Card = {
 		it: "Cinderace-ex",
 		pt: "Cinderace ex"
 	},
+	evolveFrom: {
+		en: "Raboot",
+		de: "Kickerlo",
+		es: "Raboot",
+		'es-mx': "Raboot",
+		fr: "Lapyro",
+		it: "Raboot",
+		pt: "Raboot",
+	},
 
 	illustrator: "5ban Graphics",
 	rarity: "Double rare",

--- a/data/Mega Evolution/Ascended Heroes/043.ts
+++ b/data/Mega Evolution/Ascended Heroes/043.ts
@@ -13,6 +13,14 @@ const card: Card = {
 		it: "Mega Feraligatr-ex",
 		pt: "Mega Feraligatr ex"
 	},
+	evolveFrom: {
+		en: "Croconaw",
+		de: "Tyracroc",
+		es: "Croconaw",
+		fr: "Crocrodil",
+		it: "Croconaw",
+		pt: "Croconaw",
+	},
 
 	illustrator: "5ban Graphics",
 	rarity: "Double rare",

--- a/data/Mega Evolution/Ascended Heroes/047.ts
+++ b/data/Mega Evolution/Ascended Heroes/047.ts
@@ -13,6 +13,14 @@ const card: Card = {
 		it: "Mega Froslass-ex",
 		pt: "Mega Froslass ex"
 	},
+	evolveFrom: {
+		en: "Snorunt",
+		de: "Schneppke",
+		es: "Snorunt",
+		fr: "Stalgamin",
+		it: "Snorunt",
+		pt: "Snorunt",
+	},
 
 	illustrator: "5ban Graphics",
 	rarity: "Double rare",

--- a/data/Mega Evolution/Ascended Heroes/061.ts
+++ b/data/Mega Evolution/Ascended Heroes/061.ts
@@ -13,6 +13,15 @@ const card: Card = {
 		it: "Mega Eelektross-ex",
 		pt: "Mega Eelektross ex"
 	},
+	evolveFrom: {
+		en: "Eelektrik",
+		de: "Zapplalek",
+		es: "Eelektrik",
+		'es-mx': "Eelektrik",
+		fr: "Lampéroie",
+		it: "Eelektrik",
+		pt: "Eelektrik",
+	},
 
 	illustrator: "takuyoa",
 	rarity: "Double rare",

--- a/data/Mega Evolution/Ascended Heroes/084.ts
+++ b/data/Mega Evolution/Ascended Heroes/084.ts
@@ -13,6 +13,14 @@ const card: Card = {
 		it: "Azumarill-ex",
 		pt: "Azumarill ex"
 	},
+	evolveFrom: {
+		en: "Marill",
+		de: "Marill",
+		es: "Marill",
+		fr: "Marill",
+		it: "Marill",
+		pt: "Marill",
+	},
 
 	illustrator: "5ban Graphics",
 	rarity: "Double rare",

--- a/data/Mega Evolution/Ascended Heroes/113.ts
+++ b/data/Mega Evolution/Ascended Heroes/113.ts
@@ -13,6 +13,14 @@ const card: Card = {
 		it: "Mega Lucario-ex",
 		pt: "Mega Lucario ex"
 	},
+	evolveFrom: {
+		en: "Riolu",
+		de: "Riolu",
+		es: "Riolu",
+		fr: "Riolu",
+		it: "Riolu",
+		pt: "Riolu",
+	},
 
 	illustrator: "5ban Graphics",
 	rarity: "Double rare",

--- a/data/Mega Evolution/Ascended Heroes/125.ts
+++ b/data/Mega Evolution/Ascended Heroes/125.ts
@@ -13,6 +13,15 @@ const card: Card = {
 		it: "Mega Gengar-ex",
 		pt: "Mega Gengar ex"
 	},
+	evolveFrom: {
+		en: "Haunter",
+		de: "Alpollo",
+		es: "Haunter",
+		'es-mx': "Haunter",
+		fr: "Spectrum",
+		it: "Haunter",
+		pt: "Haunter",
+	},
 
 	illustrator: "5ban Graphics",
 	rarity: "Double rare",

--- a/data/Mega Evolution/Ascended Heroes/135.ts
+++ b/data/Mega Evolution/Ascended Heroes/135.ts
@@ -13,6 +13,15 @@ const card: Card = {
 		it: "Mega Scrafty-ex",
 		pt: "Mega Scrafty ex"
 	},
+	evolveFrom: {
+		en: "Scraggy",
+		de: "Zurrokex",
+		es: "Scraggy",
+		'es-mx': "Scraggy",
+		fr: "Baggiguane",
+		it: "Scraggy",
+		pt: "Scraggy",
+	},
 
 	illustrator: "5ban Graphics",
 	rarity: "Double rare",

--- a/data/Mega Evolution/Ascended Heroes/139.ts
+++ b/data/Mega Evolution/Ascended Heroes/139.ts
@@ -13,6 +13,15 @@ const card: Card = {
 		it: "Mandibuzz-ex",
 		pt: "Mandibuzz ex"
 	},
+	evolveFrom: {
+		en: "Vullaby",
+		de: "Skallyk",
+		es: "Vullaby",
+		'es-mx': "Vullaby",
+		fr: "Vostourno",
+		it: "Vullaby",
+		pt: "Vullaby",
+	},
 
 	illustrator: "Ultimateinudog",
 	rarity: "Double rare",

--- a/data/Mega Evolution/Ascended Heroes/152.ts
+++ b/data/Mega Evolution/Ascended Heroes/152.ts
@@ -13,6 +13,14 @@ const card: Card = {
 		it: "Mega Dragonite-ex",
 		pt: "Mega Dragonite ex"
 	},
+	evolveFrom: {
+		en: "Dragonair",
+		de: "Dragonir",
+		es: "Dragonair",
+		fr: "Draco",
+		it: "Dragonair",
+		pt: "Dragonair",
+	},
 
 	illustrator: "aky CG Works",
 	rarity: "Double rare",

--- a/data/Mega Evolution/Ascended Heroes/265.ts
+++ b/data/Mega Evolution/Ascended Heroes/265.ts
@@ -13,6 +13,14 @@ const card: Card = {
 		it: "Mega Froslass-ex",
 		pt: "Mega Froslass ex"
 	},
+	evolveFrom: {
+		en: "Snorunt",
+		de: "Schneppke",
+		es: "Snorunt",
+		fr: "Stalgamin",
+		it: "Snorunt",
+		pt: "Snorunt",
+	},
 
 	illustrator: "Saboteri",
 	rarity: "Ultra Rare",

--- a/data/Mega Evolution/Ascended Heroes/266.ts
+++ b/data/Mega Evolution/Ascended Heroes/266.ts
@@ -13,6 +13,15 @@ const card: Card = {
 		it: "Mega Eelektross-ex",
 		pt: "Mega Eelektross ex"
 	},
+	evolveFrom: {
+		en: "Eelektrik",
+		de: "Zapplalek",
+		es: "Eelektrik",
+		'es-mx': "Eelektrik",
+		fr: "Lampéroie",
+		it: "Eelektrik",
+		pt: "Eelektrik",
+	},
 
 	illustrator: "DOM",
 	rarity: "Ultra Rare",

--- a/data/Mega Evolution/Ascended Heroes/269.ts
+++ b/data/Mega Evolution/Ascended Heroes/269.ts
@@ -13,6 +13,15 @@ const card: Card = {
 		it: "Mega Gengar-ex",
 		pt: "Mega Gengar ex"
 	},
+	evolveFrom: {
+		en: "Haunter",
+		de: "Alpollo",
+		es: "Haunter",
+		'es-mx': "Haunter",
+		fr: "Spectrum",
+		it: "Haunter",
+		pt: "Haunter",
+	},
 
 	illustrator: "Taiga Kasai",
 	rarity: "Ultra Rare",

--- a/data/Mega Evolution/Ascended Heroes/270.ts
+++ b/data/Mega Evolution/Ascended Heroes/270.ts
@@ -13,6 +13,15 @@ const card: Card = {
 		it: "Mega Scrafty-ex",
 		pt: "Mega Scrafty ex"
 	},
+	evolveFrom: {
+		en: "Scraggy",
+		de: "Zurrokex",
+		es: "Scraggy",
+		'es-mx': "Scraggy",
+		fr: "Baggiguane",
+		it: "Scraggy",
+		pt: "Scraggy",
+	},
 
 	illustrator: "Taiga Kasai",
 	rarity: "Ultra Rare",

--- a/data/Mega Evolution/Ascended Heroes/271.ts
+++ b/data/Mega Evolution/Ascended Heroes/271.ts
@@ -13,6 +13,14 @@ const card: Card = {
 		it: "Mega Dragonite-ex",
 		pt: "Mega Dragonite ex"
 	},
+	evolveFrom: {
+		en: "Dragonair",
+		de: "Dragonir",
+		es: "Dragonair",
+		fr: "Draco",
+		it: "Dragonair",
+		pt: "Dragonair",
+	},
 
 	illustrator: "DOM",
 	rarity: "Ultra Rare",

--- a/data/Mega Evolution/Ascended Heroes/272.ts
+++ b/data/Mega Evolution/Ascended Heroes/272.ts
@@ -13,6 +13,15 @@ const card: Card = {
 		it: "Mega Meganium-ex",
 		pt: "Mega Meganium ex"
 	},
+	evolveFrom: {
+		en: "Bayleef",
+		de: "Lorblatt",
+		es: "Bayleef",
+		'es-mx': "Bayleef",
+		fr: "Macronium",
+		it: "Bayleef",
+		pt: "Bayleef",
+	},
 
 	illustrator: "Tika Matsuno",
 	rarity: "Special illustration rare",

--- a/data/Mega Evolution/Ascended Heroes/273.ts
+++ b/data/Mega Evolution/Ascended Heroes/273.ts
@@ -13,6 +13,15 @@ const card: Card = {
 		it: "Mega Emboar-ex",
 		pt: "Mega Emboar ex"
 	},
+	evolveFrom: {
+		en: "Pignite",
+		de: "Ferkokel",
+		es: "Pignite",
+		'es-mx': "Pignite",
+		fr: "Grotichon",
+		it: "Pignite",
+		pt: "Pignite",
+	},
 
 	illustrator: "nagimiso",
 	rarity: "Special illustration rare",

--- a/data/Mega Evolution/Ascended Heroes/274.ts
+++ b/data/Mega Evolution/Ascended Heroes/274.ts
@@ -13,6 +13,14 @@ const card: Card = {
 		it: "Mega Feraligatr-ex",
 		pt: "Mega Feraligatr ex"
 	},
+	evolveFrom: {
+		en: "Croconaw",
+		de: "Tyracroc",
+		es: "Croconaw",
+		fr: "Crocrodil",
+		it: "Croconaw",
+		pt: "Croconaw",
+	},
 
 	illustrator: "Souichirou Gunjima",
 	rarity: "Special illustration rare",

--- a/data/Mega Evolution/Ascended Heroes/275.ts
+++ b/data/Mega Evolution/Ascended Heroes/275.ts
@@ -13,6 +13,14 @@ const card: Card = {
 		it: "Mega Froslass-ex",
 		pt: "Mega Froslass ex"
 	},
+	evolveFrom: {
+		en: "Snorunt",
+		de: "Schneppke",
+		es: "Snorunt",
+		fr: "Stalgamin",
+		it: "Snorunt",
+		pt: "Snorunt",
+	},
 
 	illustrator: "Teeziro",
 	rarity: "Special illustration rare",

--- a/data/Mega Evolution/Ascended Heroes/278.ts
+++ b/data/Mega Evolution/Ascended Heroes/278.ts
@@ -13,6 +13,15 @@ const card: Card = {
 		it: "Mega Eelektross-ex",
 		pt: "Mega Eelektross ex"
 	},
+	evolveFrom: {
+		en: "Eelektrik",
+		de: "Zapplalek",
+		es: "Eelektrik",
+		'es-mx': "Eelektrik",
+		fr: "Lampéroie",
+		it: "Eelektrik",
+		pt: "Eelektrik",
+	},
 
 	illustrator: "akagi",
 	rarity: "Special illustration rare",

--- a/data/Mega Evolution/Ascended Heroes/284.ts
+++ b/data/Mega Evolution/Ascended Heroes/284.ts
@@ -13,6 +13,15 @@ const card: Card = {
 		it: "Mega Gengar-ex",
 		pt: "Mega Gengar ex"
 	},
+	evolveFrom: {
+		en: "Haunter",
+		de: "Alpollo",
+		es: "Haunter",
+		'es-mx': "Haunter",
+		fr: "Spectrum",
+		it: "Haunter",
+		pt: "Haunter",
+	},
 
 	illustrator: "danciao",
 	rarity: "Special illustration rare",

--- a/data/Mega Evolution/Ascended Heroes/285.ts
+++ b/data/Mega Evolution/Ascended Heroes/285.ts
@@ -13,6 +13,15 @@ const card: Card = {
 		it: "Mega Scrafty-ex",
 		pt: "Mega Scrafty ex"
 	},
+	evolveFrom: {
+		en: "Scraggy",
+		de: "Zurrokex",
+		es: "Scraggy",
+		'es-mx': "Scraggy",
+		fr: "Baggiguane",
+		it: "Scraggy",
+		pt: "Scraggy",
+	},
 
 	illustrator: "nagimiso",
 	rarity: "Special illustration rare",

--- a/data/Mega Evolution/Ascended Heroes/290.ts
+++ b/data/Mega Evolution/Ascended Heroes/290.ts
@@ -13,6 +13,14 @@ const card: Card = {
 		it: "Mega Dragonite-ex",
 		pt: "Mega Dragonite ex"
 	},
+	evolveFrom: {
+		en: "Dragonair",
+		de: "Dragonir",
+		es: "Dragonair",
+		fr: "Draco",
+		it: "Dragonair",
+		pt: "Dragonair",
+	},
 
 	illustrator: "DOM",
 	rarity: "Special illustration rare",

--- a/data/Mega Evolution/Ascended Heroes/295.ts
+++ b/data/Mega Evolution/Ascended Heroes/295.ts
@@ -13,6 +13,14 @@ const card: Card = {
 		it: "Mega Dragonite-ex",
 		pt: "Mega Dragonite ex"
 	},
+	evolveFrom: {
+		en: "Dragonair",
+		de: "Dragonir",
+		es: "Dragonair",
+		fr: "Draco",
+		it: "Dragonair",
+		pt: "Dragonair",
+	},
 
 	illustrator: "aky CG Works",
 	rarity: "Mega Hyper Rare",

--- a/data/Mega Evolution/Phantasmal Flames/036.ts
+++ b/data/Mega Evolution/Phantasmal Flames/036.ts
@@ -13,6 +13,14 @@ const card: Card = {
 		it: "Mismagius-ex",
 		pt: "Mismagius ex"
 	},
+	evolveFrom: {
+		en: "Misdreavus",
+		de: "Traunfugil",
+		es: "Misdreavus",
+		fr: "Feuforêve",
+		it: "Misdreavus",
+		pt: "Misdreavus",
+	},
 
 	rarity: "Double rare",
 	category: "Pokemon",

--- a/data/Mega Evolution/Phantasmal Flames/056.ts
+++ b/data/Mega Evolution/Phantasmal Flames/056.ts
@@ -13,6 +13,15 @@ const card: Card = {
 		it: "Mega Gengar-ex",
 		pt: "Mega Gengar ex"
 	},
+	evolveFrom: {
+		en: "Haunter",
+		de: "Alpollo",
+		es: "Haunter",
+		'es-mx': "Haunter",
+		fr: "Spectrum",
+		it: "Haunter",
+		pt: "Haunter",
+	},
 
 	rarity: "Double rare",
 	category: "Pokemon",

--- a/data/Mega Evolution/Phantasmal Flames/061.ts
+++ b/data/Mega Evolution/Phantasmal Flames/061.ts
@@ -13,6 +13,14 @@ const card: Card = {
 		it: "Mega Sharpedo-ex",
 		pt: "Mega Sharpedo ex"
 	},
+	evolveFrom: {
+		en: "Carvanha",
+		de: "Kanivanha",
+		es: "Carvanha",
+		fr: "Carvanha",
+		it: "Carvanha",
+		pt: "Carvanha",
+	},
 
 	rarity: "Double rare",
 	category: "Pokemon",

--- a/data/Mega Evolution/Phantasmal Flames/084.ts
+++ b/data/Mega Evolution/Phantasmal Flames/084.ts
@@ -13,6 +13,15 @@ const card: Card = {
 		it: "Mega Lopunny-ex",
 		pt: "Mega Lopunny ex"
 	},
+	evolveFrom: {
+		en: "Buneary",
+		de: "Haspiror",
+		es: "Buneary",
+		'es-mx': "Buneary",
+		fr: "Laporeille",
+		it: "Buneary",
+		pt: "Buneary",
+	},
 
 	rarity: "Double rare",
 	category: "Pokemon",

--- a/data/Mega Evolution/Phantasmal Flames/112.ts
+++ b/data/Mega Evolution/Phantasmal Flames/112.ts
@@ -13,6 +13,14 @@ const card: Card = {
 		it: "Mismagius-ex",
 		pt: "Mismagius ex"
 	},
+	evolveFrom: {
+		en: "Misdreavus",
+		de: "Traunfugil",
+		es: "Misdreavus",
+		fr: "Feuforêve",
+		it: "Misdreavus",
+		pt: "Misdreavus",
+	},
 
 	rarity: "Ultra Rare",
 	category: "Pokemon",

--- a/data/Mega Evolution/Phantasmal Flames/113.ts
+++ b/data/Mega Evolution/Phantasmal Flames/113.ts
@@ -13,6 +13,14 @@ const card: Card = {
 		it: "Mega Sharpedo-ex",
 		pt: "Mega Sharpedo ex"
 	},
+	evolveFrom: {
+		en: "Carvanha",
+		de: "Kanivanha",
+		es: "Carvanha",
+		fr: "Carvanha",
+		it: "Carvanha",
+		pt: "Carvanha",
+	},
 
 	rarity: "Ultra Rare",
 	category: "Pokemon",

--- a/data/Mega Evolution/Phantasmal Flames/115.ts
+++ b/data/Mega Evolution/Phantasmal Flames/115.ts
@@ -13,6 +13,15 @@ const card: Card = {
 		it: "Mega Lopunny-ex",
 		pt: "Mega Lopunny ex"
 	},
+	evolveFrom: {
+		en: "Buneary",
+		de: "Haspiror",
+		es: "Buneary",
+		'es-mx': "Buneary",
+		fr: "Laporeille",
+		it: "Buneary",
+		pt: "Buneary",
+	},
 
 	rarity: "Ultra Rare",
 	category: "Pokemon",

--- a/data/Mega Evolution/Phantasmal Flames/127.ts
+++ b/data/Mega Evolution/Phantasmal Flames/127.ts
@@ -13,6 +13,14 @@ const card: Card = {
 		it: "Mega Sharpedo-ex",
 		pt: "Mega Sharpedo ex"
 	},
+	evolveFrom: {
+		en: "Carvanha",
+		de: "Kanivanha",
+		es: "Carvanha",
+		fr: "Carvanha",
+		it: "Carvanha",
+		pt: "Carvanha",
+	},
 
 	rarity: "Special illustration rare",
 	category: "Pokemon",

--- a/data/Mega Evolution/Phantasmal Flames/128.ts
+++ b/data/Mega Evolution/Phantasmal Flames/128.ts
@@ -13,6 +13,15 @@ const card: Card = {
 		it: "Mega Lopunny-ex",
 		pt: "Mega Lopunny ex"
 	},
+	evolveFrom: {
+		en: "Buneary",
+		de: "Haspiror",
+		es: "Buneary",
+		'es-mx': "Buneary",
+		fr: "Laporeille",
+		it: "Buneary",
+		pt: "Buneary",
+	},
 
 	rarity: "Special illustration rare",
 	category: "Pokemon",


### PR DESCRIPTION
## Changes

Added missing "Evolve from" data for Pokémon cards across multiple sets:
- Ascended Heroes
- Phantasmal Flames

## Details

Some cards were missing the "Evolve from" field. The missing data has been populated to ensure complete evolution relationships across these card sets.
