### PR TITLE
feat(data): add me03 perfect order set

### DIFF
--- a/data/Mega Evolution/Perfect Order.ts
+++ b/data/Mega Evolution/Perfect Order.ts
@@ -5,8 +5,12 @@ const set: Set = {
 	id: "me03",
 
 	name: {
+		de: "Optimale Ordnung",
 		en: "Perfect Order",
-		fr: "Équilibre Parfait"
+		es: "Equilibrio Perfecto",
+		fr: "Équilibre Parfait",
+		it: "Equilibrio Perfetto",
+		pt: "Equilíbrio Perfeito"
 	},
 
 	serie: serie,
@@ -22,7 +26,8 @@ const set: Set = {
 	},
 
 	thirdParty: {
-		cardmarket: 6443
+		cardmarket: 6443,
+		tcgplayer: 24587
 	}
 }
 

--- a/data/Mega Evolution/Perfect Order/001.ts
+++ b/data/Mega Evolution/Perfect Order/001.ts
@@ -3,38 +3,67 @@ import Set from '../Perfect Order'
 
 const card: Card = {
 	name: {
+		en: "Spinarak",
 		fr: "Mimigal",
+		es: "Spinarak",
+		de: "Webarak",
+		it: "Spinarak",
+		pt: "Spinarak"
 	},
 	set: Set,
 	rarity: "Common",
 	category: "Pokemon",
+	dexId: [
+		167
+	],
 	hp: 60,
+	types: [
+		"Grass"
+	],
 	stage: "Basic",
 	attacks: [
 		{
 			cost: [
-				"Grass",
+				"Grass"
 			],
 			name: {
+				en: "Gooey Thread",
 				fr: "Fil Gluant",
+				es: "Hilo Pegajoso",
+				de: "Klebriger Faden",
+				it: "Tela Appiccicosa",
+				pt: "Fio Pegajoso"
 			},
 			damage: "10",
 			effect: {
+				en: "During your opponent's next turn, the Defending Pokémon can't retreat.",
 				fr: "Pendant le prochain tour de votre adversaire, le Pokémon Défenseur ne peut pas battre en retraite.",
-			},
-		},
+				es: "Durante el próximo turno de tu rival, el Pokémon Defensor no puede retirarse.",
+				de: "Während des nächsten Zuges deines Gegners kann sich das Verteidigende Pokémon nicht zurückziehen.",
+				it: "Durante il prossimo turno del tuo avversario, il Pokémon difensore non può ritirarsi.",
+				pt: "Durante o próximo turno do seu oponente, o Pokémon Defensor não poderá recuar."
+			}
+		}
 	],
 	weaknesses: [
 		{
 			type: "Fire",
-			value: "×2",
-		},
+			value: "×2"
+		}
 	],
 	retreat: 1,
 	regulationMark: "J",
 	illustrator: "Katsunori Sato",
-
+	variants: [
+		{
+			type: "normal"
+		},
+		{
+			type: "reverse"
+		}
+	],
 	thirdParty: {
+		tcgplayer: 684397,
 		cardmarket: 877413
 	}
 }

--- a/data/Mega Evolution/Perfect Order/002.ts
+++ b/data/Mega Evolution/Perfect Order/002.ts
@@ -3,41 +3,75 @@ import Set from '../Perfect Order'
 
 const card: Card = {
 	name: {
+		en: "Ariados",
 		fr: "Migalos",
+		es: "Ariados",
+		de: "Ariados",
+		it: "Ariados",
+		pt: "Ariados"
 	},
 	set: Set,
 	rarity: "Common",
 	category: "Pokemon",
+	dexId: [
+		168
+	],
 	hp: 110,
+	types: [
+		"Grass"
+	],
 	stage: "Stage1",
 	evolveFrom: {
+		en: "Spinarak",
 		fr: "Mimigal",
+		es: "Spinarak",
+		de: "Webarak",
+		it: "Spinarak",
+		pt: "Spinarak"
 	},
 	attacks: [
 		{
 			cost: [
-				"Grass",
+				"Grass"
 			],
 			name: {
+				en: "Poison Ring",
 				fr: "Anneau de Poison",
+				es: "Anillo Venenoso",
+				de: "Giftring",
+				it: "Velenanello",
+				pt: "Anel de Veneno"
 			},
 			damage: "50",
 			effect: {
+				en: "Your opponent's Active Pokémon is now Poisoned. During your opponent's next turn, that Pokémon can't retreat.",
 				fr: "Le Pokémon Actif de votre adversaire est maintenant Empoisonné. Pendant le prochain tour de votre adversaire, ce Pokémon-là ne peut pas battre en retraite.",
-			},
-		},
+				es: "El Pokémon Activo de tu rival pasa a estar Envenenado. Durante el próximo turno de tu rival, ese Pokémon no puede retirarse.",
+				de: "Das Aktive Pokémon deines Gegners ist jetzt vergiftet. Während des nächsten Zuges deines Gegners kann sich jenes Pokémon nicht zurückziehen.",
+				it: "Il Pokémon attivo del tuo avversario viene avvelenato. Durante il prossimo turno del tuo avversario, quel Pokémon non può ritirarsi.",
+				pt: "O Pokémon Ativo do seu oponente agora está Envenenado. Durante o próximo turno do seu oponente, aquele Pokémon não poderá recuar."
+			}
+		}
 	],
 	weaknesses: [
 		{
 			type: "Fire",
-			value: "×2",
-		},
+			value: "×2"
+		}
 	],
 	retreat: 1,
 	regulationMark: "J",
 	illustrator: "svlt",
-
+	variants: [
+		{
+			type: "normal"
+		},
+		{
+			type: "reverse"
+		}
+	],
 	thirdParty: {
+		tcgplayer: 684398,
 		cardmarket: 877414
 	}
 }

--- a/data/Mega Evolution/Perfect Order/003.ts
+++ b/data/Mega Evolution/Perfect Order/003.ts
@@ -3,45 +3,79 @@ import Set from '../Perfect Order'
 
 const card: Card = {
 	name: {
+		en: "Shaymin",
 		fr: "Shaymin",
+		es: "Shaymin",
+		de: "Shaymin",
+		it: "Shaymin",
+		pt: "Shaymin"
 	},
 	set: Set,
 	rarity: "Uncommon",
 	category: "Pokemon",
+	dexId: [
+		492
+	],
 	hp: 70,
+	types: [
+		"Grass"
+	],
 	stage: "Basic",
 	attacks: [
 		{
 			cost: [
-				"Grass",
+				"Grass"
 			],
 			name: {
+				en: "Send Flowers",
 				fr: "Envoi de Fleurs",
+				es: "Enviar Flores",
+				de: "Blumen schicken",
+				it: "Mandafiori",
+				pt: "Mandar Flores"
 			},
 			effect: {
-				fr: "Cherchez dans votre deck une carte Énergie, puis attachez-la à l'un de vos Pokémon Plante de Banc. Mélangez ensuite votre deck.",
-			},
+				en: "Search your deck for an Energy card and attach it to 1 of your Benched [G] Pokémon. Then, shuffle your deck.",
+				fr: "Cherchez dans votre deck une carte Énergie, puis attachez-la à l'un de vos Pokémon [G] de Banc. Mélangez ensuite votre deck.",
+				es: "Busca en tu baraja 1 carta de Energía y únela a uno de tus Pokémon [G] en Banca. Después, baraja las cartas de tu baraja.",
+				de: "Durchsuche dein Deck nach 1 Energiekarte und lege sie an 1 [G]-Pokémon auf deiner Bank an. Mische anschließend dein Deck.",
+				it: "Cerca nel tuo mazzo una carta Energia e assegnala a uno dei Pokémon [G] nella tua panchina. Poi rimischia il tuo mazzo.",
+				pt: "Procure por uma carta de Energia no seu baralho e ligue-a a 1 dos seus Pokémon [G] no Banco. Em seguida, embaralhe o seu baralho."
+			}
 		},
 		{
 			cost: [
-				"Grass",
+				"Grass"
 			],
 			name: {
+				en: "Leaf Step",
 				fr: "Enjambée de Feuillage",
+				es: "Paso Hoja",
+				de: "Blattschritt",
+				it: "Passofoglia",
+				pt: "Passo de Folha"
 			},
-			damage: "30",
-		},
+			damage: "30"
+		}
 	],
 	weaknesses: [
 		{
 			type: "Fire",
-			value: "×2",
-		},
+			value: "×2"
+		}
 	],
 	regulationMark: "J",
 	illustrator: "saino misaki",
-
+	variants: [
+		{
+			type: "normal"
+		},
+		{
+			type: "reverse"
+		}
+	],
 	thirdParty: {
+		tcgplayer: 684399,
 		cardmarket: 877415
 	}
 }

--- a/data/Mega Evolution/Perfect Order/004.ts
+++ b/data/Mega Evolution/Perfect Order/004.ts
@@ -3,38 +3,67 @@ import Set from '../Perfect Order'
 
 const card: Card = {
 	name: {
+		en: "Snivy",
 		fr: "Vipélierre",
+		es: "Snivy",
+		de: "Serpifeu",
+		it: "Snivy",
+		pt: "Snivy"
 	},
 	set: Set,
 	rarity: "Common",
 	category: "Pokemon",
+	dexId: [
+		495
+	],
 	hp: 70,
+	types: [
+		"Grass"
+	],
 	stage: "Basic",
 	attacks: [
 		{
 			cost: [
-				"Grass",
+				"Grass"
 			],
 			name: {
+				en: "Reckless Charge",
 				fr: "Attaque Imprudente",
+				es: "Carga Descuidada",
+				de: "Waghalsiger Sturmangriff",
+				it: "Carica Avventata",
+				pt: "Carga Indomável"
 			},
 			damage: "30",
 			effect: {
+				en: "This Pokémon also does 10 damage to itself.",
 				fr: "Ce Pokémon s'inflige aussi 10 dégâts.",
-			},
-		},
+				es: "Este Pokémon también se hace 10 puntos de daño a sí mismo.",
+				de: "Dieses Pokémon fügt auch sich selbst 10 Schadenspunkte zu.",
+				it: "Questo Pokémon infligge anche 10 danni a se stesso.",
+				pt: "Este Pokémon também causa 10 pontos de dano a si mesmo."
+			}
+		}
 	],
 	weaknesses: [
 		{
 			type: "Fire",
-			value: "×2",
-		},
+			value: "×2"
+		}
 	],
 	retreat: 1,
 	regulationMark: "J",
 	illustrator: "Narumi Sato",
-
+	variants: [
+		{
+			type: "reverse"
+		},
+		{
+			type: "normal"
+		}
+	],
 	thirdParty: {
+		tcgplayer: 684400,
 		cardmarket: 877416
 	}
 }

--- a/data/Mega Evolution/Perfect Order/005.ts
+++ b/data/Mega Evolution/Perfect Order/005.ts
@@ -3,38 +3,68 @@ import Set from '../Perfect Order'
 
 const card: Card = {
 	name: {
+		en: "Servine",
 		fr: "Lianaja",
+		es: "Servine",
+		de: "Efoserp",
+		it: "Servine",
+		pt: "Servine"
 	},
 	set: Set,
 	rarity: "Common",
 	category: "Pokemon",
+	dexId: [
+		496
+	],
 	hp: 100,
+	types: [
+		"Grass"
+	],
 	stage: "Stage1",
 	evolveFrom: {
+		en: "Snivy",
 		fr: "Vipélierre",
+		es: "Snivy",
+		"es-mx": "Snivy",
+		de: "Serpifeu",
+		it: "Snivy",
+		pt: "Snivy"
 	},
 	attacks: [
 		{
 			cost: [
-				"Grass",
+				"Grass"
 			],
 			name: {
+				en: "Solar Cutter",
 				fr: "Coupe Solaire",
+				es: "Corte Solar",
+				de: "Solarschneider",
+				it: "Taglio Solare",
+				pt: "Cortador Solar"
 			},
-			damage: "40",
-		},
+			damage: "40"
+		}
 	],
 	weaknesses: [
 		{
 			type: "Fire",
-			value: "×2",
-		},
+			value: "×2"
+		}
 	],
 	retreat: 1,
 	regulationMark: "J",
 	illustrator: "Kurata So",
-
+	variants: [
+		{
+			type: "reverse"
+		},
+		{
+			type: "normal"
+		}
+	],
 	thirdParty: {
+		tcgplayer: 684401,
 		cardmarket: 877417
 	}
 }

--- a/data/Mega Evolution/Perfect Order/006.ts
+++ b/data/Mega Evolution/Perfect Order/006.ts
@@ -3,55 +3,100 @@ import Set from '../Perfect Order'
 
 const card: Card = {
 	name: {
+		en: "Serperior",
 		fr: "Majaspic",
+		es: "Serperior",
+		de: "Serpiroyal",
+		it: "Serperior",
+		pt: "Serperior"
 	},
 	set: Set,
 	rarity: "Rare",
 	category: "Pokemon",
+	dexId: [
+		497
+	],
 	hp: 160,
+	types: [
+		"Grass"
+	],
 	stage: "Stage2",
 	evolveFrom: {
+		en: "Servine",
 		fr: "Lianaja",
+		es: "Servine",
+		"es-mx": "Servine",
+		de: "Efoserp",
+		it: "Servine",
+		pt: "Servine"
 	},
 	attacks: [
 		{
 			cost: [
-				"Grass",
+				"Grass"
 			],
 			name: {
+				en: "Regal Command",
 				fr: "Ordre Majestueux",
+				es: "Mandato Realeza",
+				de: "Hoheitlicher Befehl",
+				it: "Comando Regale",
+				pt: "Comando Real"
 			},
 			damage: "20×",
 			effect: {
+				en: "This attack does 20 damage for each of your Pokémon in play.",
 				fr: "Cette attaque inflige 20 dégâts pour chacun de vos Pokémon en jeu.",
-			},
+				es: "Este ataque hace 20 puntos de daño por cada uno de tus Pokémon en juego.",
+				de: "Diese Attacke fügt für jedes deiner Pokémon im Spiel 20 Schadenspunkte zu.",
+				it: "Questo attacco infligge 20 danni per ciascuno dei tuoi Pokémon in gioco.",
+				pt: "Este ataque causa 20 pontos de dano para cada um dos seus Pokémon em jogo."
+			}
 		},
 		{
 			cost: [
 				"Grass",
 				"Grass",
-				"Grass",
+				"Grass"
 			],
 			name: {
+				en: "Solar Coiling",
 				fr: "Enroulement Solaire",
+				es: "Enrosque Solar",
+				de: "Solarschlinge",
+				it: "Avvolgimento Solare",
+				pt: "Enrolada Solar"
 			},
 			damage: "100+",
 			effect: {
+				en: "If Rosa's Encouragement is in your discard pile, this attack does 150 more damage.",
 				fr: "Si Encouragement d'Écho est dans votre pile de défausse, cette attaque inflige 150 dégâts supplémentaires.",
-			},
-		},
+				es: "Si Apoyo de Nanci está en tu pila de descartes, este ataque hace 150 puntos de daño más.",
+				de: "Wenn Rosys Ermutigung in deinem Ablagestapel ist, fügt diese Attacke 150 Schadenspunkte mehr zu.",
+				it: "Se Incoraggiamento di Rina è nella tua pila degli scarti, questo attacco infligge 150 danni in più.",
+				pt: "Se Encorajamento da Rose estiver na sua pilha de descarte, este ataque causará 150 pontos de dano a mais."
+			}
+		}
 	],
 	weaknesses: [
 		{
 			type: "Fire",
-			value: "×2",
-		},
+			value: "×2"
+		}
 	],
 	retreat: 2,
 	regulationMark: "J",
 	illustrator: "kodama",
-
+	variants: [
+		{
+			type: "holo"
+		},
+		{
+			type: "reverse"
+		}
+	],
 	thirdParty: {
+		tcgplayer: 684402,
 		cardmarket: 877418
 	}
 }

--- a/data/Mega Evolution/Perfect Order/007.ts
+++ b/data/Mega Evolution/Perfect Order/007.ts
@@ -3,35 +3,59 @@ import Set from '../Perfect Order'
 
 const card: Card = {
 	name: {
+		en: "Scatterbug",
 		fr: "Lépidonille",
+		es: "Scatterbug",
+		de: "Purmel",
+		it: "Scatterbug",
+		pt: "Scatterbug"
 	},
 	set: Set,
 	rarity: "Common",
 	category: "Pokemon",
+	dexId: [
+		664
+	],
 	hp: 40,
+	types: [
+		"Grass"
+	],
 	stage: "Basic",
 	attacks: [
 		{
 			cost: [
-				"Grass",
+				"Grass"
 			],
 			name: {
+				en: "Gnaw",
 				fr: "Ronge",
+				es: "Roer",
+				de: "Nagen",
+				it: "Rosicchiamento",
+				pt: "Roída"
 			},
-			damage: "20",
-		},
+			damage: "20"
+		}
 	],
 	weaknesses: [
 		{
 			type: "Fire",
-			value: "×2",
-		},
+			value: "×2"
+		}
 	],
 	retreat: 1,
 	regulationMark: "J",
 	illustrator: "OKACHEKE",
-
+	variants: [
+		{
+			type: "normal"
+		},
+		{
+			type: "reverse"
+		}
+	],
 	thirdParty: {
+		tcgplayer: 684363,
 		cardmarket: 877419
 	}
 }

--- a/data/Mega Evolution/Perfect Order/008.ts
+++ b/data/Mega Evolution/Perfect Order/008.ts
@@ -3,40 +3,74 @@ import Set from '../Perfect Order'
 
 const card: Card = {
 	name: {
+		en: "Spewpa",
 		fr: "Pérégrain",
+		es: "Spewpa",
+		de: "Puponcho",
+		it: "Spewpa",
+		pt: "Spewpa"
 	},
 	set: Set,
 	rarity: "Common",
 	category: "Pokemon",
+	dexId: [
+		665
+	],
 	hp: 80,
+	types: [
+		"Grass"
+	],
 	stage: "Stage1",
 	evolveFrom: {
+		en: "Scatterbug",
 		fr: "Lépidonille",
+		es: "Scatterbug",
+		de: "Purmel",
+		it: "Scatterbug",
+		pt: "Scatterbug"
 	},
 	attacks: [
 		{
 			cost: [
-				"Grass",
+				"Grass"
 			],
 			name: {
+				en: "Hide",
 				fr: "Cachette",
+				es: "Ocultarse",
+				de: "Verstecken",
+				it: "Nascondino",
+				pt: "Esconder"
 			},
 			effect: {
+				en: "Flip a coin. If heads, during your opponent's next turn, prevent all damage from and effects of attacks done to this Pokémon.",
 				fr: "Lancez une pièce. Si c'est face, pendant le prochain tour de votre adversaire, évitez tous les dégâts et effets provenant d'attaques infligés à ce Pokémon.",
-			},
-		},
+				es: "Lanza 1 moneda. Si sale cara, durante el próximo turno de tu rival, se evitan todo el daño y todos los efectos de los ataques infligidos a este Pokémon.",
+				de: "Wirf 1 Münze. Verhindere bei Kopf während des nächsten Zuges deines Gegners allen Schaden durch und alle Effekte von Attacken, die diesem Pokémon zugefügt werden.",
+				it: "Lancia una moneta. Se esce testa, durante il prossimo turno del tuo avversario, previeni sia i danni che gli effetti degli attacchi inflitti a questo Pokémon.",
+				pt: "Jogue uma moeda. Se sair cara, durante o próximo turno do seu oponente, previna todo o dano e os efeitos de ataques causados a este Pokémon."
+			}
+		}
 	],
 	weaknesses: [
 		{
 			type: "Fire",
-			value: "×2",
-		},
+			value: "×2"
+		}
 	],
 	retreat: 3,
 	regulationMark: "J",
 	illustrator: "Ounishi",
-
+	variants: [
+		{
+			type: "reverse"
+		},
+		{
+			type: "normal"
+		}
+	],
 	thirdParty: {
+		tcgplayer: 684364,
 		cardmarket: 877420
 	}
 }

--- a/data/Mega Evolution/Perfect Order/009.ts
+++ b/data/Mega Evolution/Perfect Order/009.ts
@@ -3,52 +3,96 @@ import Set from '../Perfect Order'
 
 const card: Card = {
 	name: {
+		en: "Vivillon",
 		fr: "Prismillon",
+		es: "Vivillon",
+		de: "Vivillon",
+		it: "Vivillon",
+		pt: "Vivillon"
 	},
 	set: Set,
 	rarity: "Uncommon",
 	category: "Pokemon",
+	dexId: [
+		666
+	],
 	hp: 120,
+	types: [
+		"Grass"
+	],
 	stage: "Stage2",
 	evolveFrom: {
+		en: "Spewpa",
 		fr: "Pérégrain",
+		es: "Spewpa",
+		de: "Puponcho",
+		it: "Spewpa",
+		pt: "Spewpa"
 	},
 	abilities: [
 		{
 			type: "Ability",
 			name: {
+				en: "Grand Wing",
 				fr: "Aile Grandiose",
+				es: "Ala Colosal",
+				de: "Gewaltige Flügel",
+				it: "Ala Imponente",
+				pt: "Asa Grandiosa"
 			},
 			effect: {
+				en: "Once during your turn, you may use this Ability. Your opponent shuffles their hand and puts it on the bottom of their deck. If they put any cards on the bottom of their deck in this way, they draw 4 cards.",
 				fr: "Une fois pendant votre tour, vous pouvez utiliser ce talent. Votre adversaire mélange sa main, puis la place en dessous de son deck. Si au moins une carte est placée en dessous de son deck de cette façon, votre adversaire pioche 4 cartes.",
-			},
-		},
+				es: "Una vez durante tu turno, puedes usar esta habilidad. Tu rival baraja las cartas de su mano y las pone en la parte inferior de su baraja. Si pone alguna carta en la parte inferior de su baraja de esta manera, tu rival roba 4 cartas.",
+				de: "Einmal während deines Zuges kannst du diese Fähigkeit einsetzen. Dein Gegner mischt seine Handkarten und legt sie unter sein Deck. Wenn er auf diese Weise mindestens 1 Karte unter sein Deck gelegt hat, zieht er 4 Karten.",
+				it: "Una sola volta durante il tuo turno, puoi usare questa abilità. Il tuo avversario rimischia le carte che ha in mano e le mette in fondo al proprio mazzo. Se mette delle carte in fondo al proprio mazzo in questo modo, il tuo avversario pesca quattro carte.",
+				pt: "Uma vez durante o seu turno, você poderá usar esta Habilidade. Seu oponente embaralha a mão dele e a coloca como as cartas de baixo do baralho dele. Se o seu oponente colocar quaisquer cartas como as cartas de baixo do baralho dele desta forma, ele comprará 4 cartas."
+			}
+		}
 	],
 	attacks: [
 		{
 			cost: [
-				"Grass",
+				"Grass"
 			],
 			name: {
+				en: "Blow Through",
 				fr: "Grosse Bourrasque",
+				es: "Gran Torbellino",
+				de: "Durchdringender Strahl",
+				it: "Colposecco",
+				pt: "Sopro Intenso"
 			},
 			damage: "60+",
 			effect: {
+				en: "If a Stadium is in play, this attack does 60 more damage.",
 				fr: "Si un Stade est en jeu, cette attaque inflige 60 dégâts supplémentaires.",
-			},
-		},
+				es: "Si hay un Estadio en juego, este ataque hace 60 puntos de daño más.",
+				de: "Wenn ein Stadion im Spiel ist, fügt diese Attacke 60 Schadenspunkte mehr zu.",
+				it: "Se c'è una carta Stadio in gioco, questo attacco infligge 60 danni in più.",
+				pt: "Se um Estádio estiver em jogo, este ataque causará 60 pontos de dano a mais."
+			}
+		}
 	],
 	weaknesses: [
 		{
 			type: "Fire",
-			value: "×2",
-		},
+			value: "×2"
+		}
 	],
 	retreat: 1,
 	regulationMark: "J",
 	illustrator: "mingo",
-
+	variants: [
+		{
+			type: "normal"
+		},
+		{
+			type: "reverse"
+		}
+	],
 	thirdParty: {
+		tcgplayer: 684366,
 		cardmarket: 877421
 	}
 }

--- a/data/Mega Evolution/Perfect Order/010.ts
+++ b/data/Mega Evolution/Perfect Order/010.ts
@@ -3,48 +3,82 @@ import Set from '../Perfect Order'
 
 const card: Card = {
 	name: {
+		en: "Rowlet",
 		fr: "Brindibou",
+		es: "Rowlet",
+		de: "Bauz",
+		it: "Rowlet",
+		pt: "Rowlet"
 	},
 	set: Set,
 	rarity: "Common",
 	category: "Pokemon",
+	dexId: [
+		722
+	],
 	hp: 80,
+	types: [
+		"Grass"
+	],
 	stage: "Basic",
 	attacks: [
 		{
 			cost: [
-				"Grass",
+				"Grass"
 			],
 			name: {
+				en: "Find a Friend",
 				fr: "Trouver un Ami",
+				es: "Encontrar un Amigo",
+				de: "Freunde finden",
+				it: "Trovamico",
+				pt: "Encontre um Amigo"
 			},
 			effect: {
+				en: "Search your deck for a Pokémon, reveal it, and put it into your hand. Then, shuffle your deck.",
 				fr: "Cherchez dans votre deck un Pokémon, montrez-le, puis ajoutez-le à votre main. Mélangez ensuite votre deck.",
-			},
+				es: "Busca en tu baraja 1 Pokémon, enséñalo y ponlo en tu mano. Después, baraja las cartas de tu baraja.",
+				de: "Durchsuche dein Deck nach 1 Pokémon, zeige es deinem Gegner und nimm es auf deine Hand. Mische anschließend dein Deck.",
+				it: "Cerca nel tuo mazzo un Pokémon, mostralo e aggiungilo alle carte che hai in mano. Poi rimischia il tuo mazzo.",
+				pt: "Procure por um Pokémon no seu baralho, revele-o e coloque-o na sua mão. Em seguida, embaralhe o seu baralho."
+			}
 		},
 		{
 			cost: [
 				"Colorless",
 				"Colorless",
-				"Colorless",
+				"Colorless"
 			],
 			name: {
+				en: "Tackle",
 				fr: "Charge",
+				es: "Placaje",
+				de: "Tackle",
+				it: "Azione",
+				pt: "Investida"
 			},
-			damage: "30",
-		},
+			damage: "30"
+		}
 	],
 	weaknesses: [
 		{
 			type: "Fire",
-			value: "×2",
-		},
+			value: "×2"
+		}
 	],
 	retreat: 2,
 	regulationMark: "J",
 	illustrator: "Atsuya Uki",
-
+	variants: [
+		{
+			type: "reverse"
+		},
+		{
+			type: "normal"
+		}
+	],
 	thirdParty: {
+		tcgplayer: 684367,
 		cardmarket: 877422
 	}
 }

--- a/data/Mega Evolution/Perfect Order/011.ts
+++ b/data/Mega Evolution/Perfect Order/011.ts
@@ -3,51 +3,90 @@ import Set from '../Perfect Order'
 
 const card: Card = {
 	name: {
+		en: "Dartrix",
 		fr: "Efflèche",
+		es: "Dartrix",
+		de: "Arboretoss",
+		it: "Dartrix",
+		pt: "Dartrix"
 	},
 	set: Set,
 	rarity: "Common",
 	category: "Pokemon",
+	dexId: [
+		723
+	],
 	hp: 100,
+	types: [
+		"Grass"
+	],
 	stage: "Stage1",
 	evolveFrom: {
+		en: "Rowlet",
 		fr: "Brindibou",
+		es: "Rowlet",
+		de: "Bauz",
+		it: "Rowlet",
+		pt: "Rowlet"
 	},
 	attacks: [
 		{
 			cost: [
-				"Grass",
+				"Grass"
 			],
 			name: {
+				en: "Leafage",
 				fr: "Feuillage",
+				es: "Follaje",
+				de: "Blattwerk",
+				it: "Fogliame",
+				pt: "Folhagem"
 			},
-			damage: "20",
+			damage: "20"
 		},
 		{
 			cost: [
 				"Colorless",
 				"Colorless",
-				"Colorless",
+				"Colorless"
 			],
 			name: {
+				en: "Feather Shot",
 				fr: "Tir Plumeux",
+				es: "Disparo Pluma",
+				de: "Federschuss",
+				it: "Colpo di Piuma",
+				pt: "Disparo de Pena"
 			},
 			effect: {
+				en: "Discard all Energy from this Pokémon, and this attack does 90 damage to 1 of your opponent's Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)",
 				fr: "Défaussez toutes les Énergies de ce Pokémon. Cette attaque inflige 90 dégâts à l'un des Pokémon de votre adversaire. (N'appliquez ni la Faiblesse ni la Résistance aux Pokémon de Banc.)",
-			},
-		},
+				es: "Descarta todas las Energías de este Pokémon, y este ataque hace 90 puntos de daño a uno de los Pokémon de tu rival. (No apliques Debilidad y Resistencia a los Pokémon en Banca).",
+				de: "Lege alle Energien von diesem Pokémon auf deinen Ablagestapel, und diese Attacke fügt 1 Pokémon deines Gegners 90 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)",
+				it: "Scarta tutte le Energie da questo Pokémon e questo attacco infligge 90 danni a uno dei Pokémon del tuo avversario. Non applicare debolezza e resistenza ai Pokémon in panchina.",
+				pt: "Descarte todas as Energias deste Pokémon, e este ataque causa 90 pontos de dano a 1 dos Pokémon do seu oponente. (Não aplique Fraqueza e Resistência aos Pokémon no Banco.)"
+			}
+		}
 	],
 	weaknesses: [
 		{
 			type: "Fire",
-			value: "×2",
-		},
+			value: "×2"
+		}
 	],
 	retreat: 2,
 	regulationMark: "J",
 	illustrator: "aspara",
-
+	variants: [
+		{
+			type: "normal"
+		},
+		{
+			type: "reverse"
+		}
+	],
 	thirdParty: {
+		tcgplayer: 684369,
 		cardmarket: 877423
 	}
 }

--- a/data/Mega Evolution/Perfect Order/012.ts
+++ b/data/Mega Evolution/Perfect Order/012.ts
@@ -3,26 +3,52 @@ import Set from '../Perfect Order'
 
 const card: Card = {
 	name: {
+		en: "Decidueye ex",
 		fr: "Archéduc-ex",
+		es: "Decidueye ex",
+		de: "Silvarro-ex",
+		it: "Decidueye-ex",
+		pt: "Decidueye ex"
 	},
 	set: Set,
 	rarity: "Double rare",
 	category: "Pokemon",
+	dexId: [
+		724
+	],
 	hp: 320,
+	types: [
+		"Grass"
+	],
 	stage: "Stage2",
 	evolveFrom: {
+		en: "Dartrix",
 		fr: "Efflèche",
+		es: "Dartrix",
+		de: "Arboretoss",
+		it: "Dartrix",
+		pt: "Dartrix"
 	},
 	abilities: [
 		{
 			type: "Ability",
 			name: {
+				en: "Sniper's Eye",
 				fr: "Œil de Sniper",
+				es: "Ojo Certero",
+				de: "Auge des Superschützen",
+				it: "Occhio da Cecchino",
+				pt: "Mira de Franco-atirador"
 			},
 			effect: {
-				fr: "Si votre adversaire a exactement 4 cartes dans sa main, ignorez toutes les Énergies Incolore dans le coût des attaques utilisées par ce Pokémon.",
-			},
-		},
+				en: "If your opponent has exactly 4 cards in their hand, ignore all [C] Energy in the costs of attacks used by this Pokémon.",
+				fr: "Si votre adversaire a exactement 4 cartes dans sa main, ignorez toutes les Énergies [C] dans le coût des attaques utilisées par ce Pokémon.",
+				es: "Si tu rival tiene exactamente 4 cartas en su mano, ignora todas las Energías [C] en los costes de los ataques usados por este Pokémon.",
+				de: "Wenn dein Gegner genau 4 Karten auf seiner Hand hat, ignoriere alle [C]-Energien in den Kosten der von diesem Pokémon eingesetzten Attacken.",
+				it: "Se il tuo avversario ha esattamente quattro carte in mano, ignora tutte le Energie [C] necessarie per gli attacchi usati da questo Pokémon.",
+				pt: "Se o seu oponente tiver exatamente 4 cartas na mão dele, ignore todas as Energias [C] nos custos dos ataques usados por este Pokémon."
+			}
+		}
 	],
 	attacks: [
 		{
@@ -30,28 +56,43 @@ const card: Card = {
 				"Grass",
 				"Colorless",
 				"Colorless",
-				"Colorless",
+				"Colorless"
 			],
 			name: {
+				en: "Crushing Arrow",
 				fr: "Flèche Écrasante",
+				es: "Flecha Demoledora",
+				de: "Schmetterpfeil",
+				it: "Freccia Dirompente",
+				pt: "Flecha Esmagadora"
 			},
 			damage: "240",
 			effect: {
+				en: "Discard an Energy from your opponent's Active Pokémon.",
 				fr: "Défaussez une Énergie du Pokémon Actif de votre adversaire.",
-			},
-		},
+				es: "Descarta 1 Energía del Pokémon Activo de tu rival.",
+				de: "Lege 1 Energie vom Aktiven Pokémon deines Gegners auf seinen Ablagestapel.",
+				it: "Scarta un'Energia dal Pokémon attivo del tuo avversario.",
+				pt: "Descarte uma Energia do Pokémon Ativo do seu oponente."
+			}
+		}
 	],
 	weaknesses: [
 		{
 			type: "Fire",
-			value: "×2",
-		},
+			value: "×2"
+		}
 	],
 	retreat: 2,
 	regulationMark: "J",
 	illustrator: "aky CG Works",
-
+	variants: [
+		{
+			type: "holo"
+		}
+	],
 	thirdParty: {
+		tcgplayer: 684370,
 		cardmarket: 877424
 	}
 }

--- a/data/Mega Evolution/Perfect Order/013.ts
+++ b/data/Mega Evolution/Perfect Order/013.ts
@@ -3,45 +3,74 @@ import Set from '../Perfect Order'
 
 const card: Card = {
 	name: {
+		en: "Fletchinder",
 		fr: "Braisillon",
+		es: "Fletchinder",
+		de: "Dartignis",
+		it: "Fletchinder",
+		pt: "Fletchinder"
 	},
 	set: Set,
 	rarity: "Common",
 	category: "Pokemon",
+	dexId: [
+		662
+	],
 	hp: 90,
+	types: [
+		"Fire"
+	],
 	stage: "Stage1",
 	evolveFrom: {
+		en: "Fletchling",
 		fr: "Passerouge",
+		es: "Fletchling",
+		de: "Dartiri",
+		it: "Fletchling",
+		pt: "Fletchling"
 	},
 	attacks: [
 		{
 			cost: [
 				"Fire",
-				"Fire",
+				"Fire"
 			],
 			name: {
+				en: "Flare",
 				fr: "Flamboiement",
+				es: "Llama",
+				de: "Flackern",
+				it: "Fiammata",
+				pt: "Chama"
 			},
-			damage: "60",
-		},
+			damage: "60"
+		}
 	],
 	weaknesses: [
 		{
 			type: "Lightning",
-			value: "×2",
-		},
+			value: "×2"
+		}
 	],
 	resistances: [
 		{
 			type: "Fighting",
-			value: "-30",
-		},
+			value: "-30"
+		}
 	],
 	retreat: 1,
 	regulationMark: "J",
 	illustrator: "Sumiyoshi Kizuki",
-
+	variants: [
+		{
+			type: "normal"
+		},
+		{
+			type: "reverse"
+		}
+	],
 	thirdParty: {
+		tcgplayer: 684404,
 		cardmarket: 877425
 	}
 }

--- a/data/Mega Evolution/Perfect Order/014.ts
+++ b/data/Mega Evolution/Perfect Order/014.ts
@@ -3,56 +3,95 @@ import Set from '../Perfect Order'
 
 const card: Card = {
 	name: {
+		en: "Talonflame",
 		fr: "Flambusard",
+		es: "Talonflame",
+		de: "Fiaro",
+		it: "Talonflame",
+		pt: "Talonflame"
 	},
 	set: Set,
 	rarity: "Uncommon",
 	category: "Pokemon",
+	dexId: [
+		663
+	],
 	hp: 150,
+	types: [
+		"Fire"
+	],
 	stage: "Stage2",
 	evolveFrom: {
+		en: "Fletchinder",
 		fr: "Braisillon",
+		es: "Fletchinder",
+		de: "Dartignis",
+		it: "Fletchinder",
+		pt: "Fletchinder"
 	},
 	abilities: [
 		{
 			type: "Ability",
 			name: {
+				en: "Sky Hunt",
 				fr: "Chasse Céleste",
+				es: "Cacería Aérea",
+				de: "Jäger der Lüfte",
+				it: "Caccia Aerea",
+				pt: "Rapina Aérea"
 			},
 			effect: {
+				en: "Once during your turn, you may use this Ability. Flip a coin. If heads, discard a random card from your opponent's hand.",
 				fr: "Une fois pendant votre tour, vous pouvez utiliser ce talent. Lancez une pièce. Si c'est face, défaussez au hasard une carte de la main de votre adversaire.",
-			},
-		},
+				es: "Una vez durante tu turno, puedes usar esta habilidad. Lanza 1 moneda. Si sale cara, descarta 1 carta aleatoria de la mano de tu rival.",
+				de: "Einmal während deines Zuges kannst du diese Fähigkeit einsetzen. Wirf 1 Münze. Lege bei Kopf 1 zufällige Karte aus der Hand deines Gegners auf seinen Ablagestapel.",
+				it: "Una sola volta durante il tuo turno, puoi usare questa abilità. Lancia una moneta. Se esce testa, scarta una carta a caso dalla mano del tuo avversario.",
+				pt: "Uma vez durante o seu turno, você poderá usar esta Habilidade. Jogue uma moeda. Se sair cara, descarte uma carta aleatória da mão do seu oponente."
+			}
+		}
 	],
 	attacks: [
 		{
 			cost: [
 				"Fire",
-				"Fire",
+				"Fire"
 			],
 			name: {
+				en: "Fire Wing",
 				fr: "Aile de Feu",
+				es: "Ala Ígnea",
+				de: "Feuerflügel",
+				it: "Alafiamma",
+				pt: "Asa de Fogo"
 			},
-			damage: "110",
-		},
+			damage: "110"
+		}
 	],
 	weaknesses: [
 		{
 			type: "Lightning",
-			value: "×2",
-		},
+			value: "×2"
+		}
 	],
 	resistances: [
 		{
 			type: "Fighting",
-			value: "-30",
-		},
+			value: "-30"
+		}
 	],
 	retreat: 1,
 	regulationMark: "J",
 	illustrator: "Shinji Kanda",
-
+	variants: [
+		{
+			type: "reverse"
+		},
+		{
+			type: "normal"
+		}
+	],
 	thirdParty: {
+		tcgplayer: 684405,
 		cardmarket: 877426
 	}
 }

--- a/data/Mega Evolution/Perfect Order/015.ts
+++ b/data/Mega Evolution/Perfect Order/015.ts
@@ -3,35 +3,59 @@ import Set from '../Perfect Order'
 
 const card: Card = {
 	name: {
+		en: "Salandit",
 		fr: "Tritox",
+		es: "Salandit",
+		de: "Molunk",
+		it: "Salandit",
+		pt: "Salandit"
 	},
 	set: Set,
 	rarity: "Common",
 	category: "Pokemon",
+	dexId: [
+		757
+	],
 	hp: 70,
+	types: [
+		"Fire"
+	],
 	stage: "Basic",
 	attacks: [
 		{
 			cost: [
-				"Fire",
+				"Fire"
 			],
 			name: {
+				en: "Fire Claws",
 				fr: "Griffes Enflammées",
+				es: "Garras de Fuego",
+				de: "Feuerkrallen",
+				it: "Artigli Infuocati",
+				pt: "Garras de Fogo"
 			},
-			damage: "20",
-		},
+			damage: "20"
+		}
 	],
 	weaknesses: [
 		{
 			type: "Water",
-			value: "×2",
-		},
+			value: "×2"
+		}
 	],
 	retreat: 1,
 	regulationMark: "J",
 	illustrator: "Kazuhisa Uragami",
-
+	variants: [
+		{
+			type: "reverse"
+		},
+		{
+			type: "normal"
+		}
+	],
 	thirdParty: {
+		tcgplayer: 684382,
 		cardmarket: 877427
 	}
 }

--- a/data/Mega Evolution/Perfect Order/016.ts
+++ b/data/Mega Evolution/Perfect Order/016.ts
@@ -3,53 +3,95 @@ import Set from '../Perfect Order'
 
 const card: Card = {
 	name: {
+		en: "Salazzle ex",
 		fr: "Malamandre-ex",
+		es: "Salazzle ex",
+		de: "Amfira-ex",
+		it: "Salazzle-ex",
+		pt: "Salazzle ex"
 	},
 	set: Set,
 	rarity: "Double rare",
 	category: "Pokemon",
+	dexId: [
+		758
+	],
 	hp: 260,
+	types: [
+		"Fire"
+	],
 	stage: "Stage1",
 	evolveFrom: {
+		en: "Salandit",
 		fr: "Tritox",
+		es: "Salandit",
+		"es-mx": "Salandit",
+		de: "Molunk",
+		it: "Salandit",
+		pt: "Salandit"
 	},
 	attacks: [
 		{
 			cost: [
-				"Fire",
+				"Fire"
 			],
 			name: {
+				en: "Nasty Plot",
 				fr: "Machination",
+				es: "Maquinación",
+				de: "Ränkeschmied",
+				it: "Congiura",
+				pt: "Trama Maldosa"
 			},
 			effect: {
+				en: "Search your deck for up to 2 cards and put them into your hand. Then, shuffle your deck.",
 				fr: "Cherchez dans votre deck jusqu'à 2 cartes, puis ajoutez-les à votre main. Mélangez ensuite votre deck.",
-			},
+				es: "Busca en tu baraja hasta 2 cartas y ponlas en tu mano. Después, baraja las cartas de tu baraja.",
+				de: "Durchsuche dein Deck nach bis zu 2 Karten und nimm sie auf deine Hand. Mische anschließend dein Deck.",
+				it: "Cerca nel tuo mazzo fino a due carte e aggiungile a quelle che hai in mano. Poi rimischia il tuo mazzo.",
+				pt: "Procure por até 2 cartas no seu baralho e coloque-as na sua mão. Em seguida, embaralhe o seu baralho."
+			}
 		},
 		{
 			cost: [
 				"Fire",
-				"Fire",
+				"Fire"
 			],
 			name: {
+				en: "Dire Nails",
 				fr: "Ongles Funestes",
+				es: "Uñas Aciagas",
+				de: "Unheilskrallen",
+				it: "Unghie Fatali",
+				pt: "Unhas Perniciosas"
 			},
 			damage: "100",
 			effect: {
+				en: "Your opponent's Active Pokémon is now Burned and Poisoned. Switch this Pokémon with 1 of your Benched Pokémon.",
 				fr: "Le Pokémon Actif de votre adversaire est maintenant Brûlé et Empoisonné. Échangez ce Pokémon contre l'un de vos Pokémon de Banc.",
-			},
-		},
+				es: "El Pokémon Activo de tu rival pasa a estar Envenenado y Quemado. Cambia este Pokémon por uno de tus Pokémon en Banca.",
+				de: "Das Aktive Pokémon deines Gegners ist jetzt verbrannt und vergiftet. Tausche dieses Pokémon gegen 1 Pokémon auf deiner Bank aus.",
+				it: "Il Pokémon attivo del tuo avversario viene bruciato e avvelenato. Scambia questo Pokémon con uno nella tua panchina.",
+				pt: "O Pokémon Ativo do seu oponente agora está Envenenado e Queimado. Troque este Pokémon por 1 dos seus Pokémon no Banco."
+			}
+		}
 	],
 	weaknesses: [
 		{
 			type: "Water",
-			value: "×2",
-		},
+			value: "×2"
+		}
 	],
 	retreat: 1,
 	regulationMark: "J",
 	illustrator: "5ban Graphics",
-
+	variants: [
+		{
+			type: "holo"
+		}
+	],
 	thirdParty: {
+		tcgplayer: 684376,
 		cardmarket: 877428
 	}
 }

--- a/data/Mega Evolution/Perfect Order/017.ts
+++ b/data/Mega Evolution/Perfect Order/017.ts
@@ -3,51 +3,90 @@ import Set from '../Perfect Order'
 
 const card: Card = {
 	name: {
+		en: "Turtonator",
 		fr: "Boumata",
+		es: "Turtonator",
+		de: "Tortunator",
+		it: "Turtonator",
+		pt: "Turtonator"
 	},
 	set: Set,
 	rarity: "Uncommon",
 	category: "Pokemon",
+	dexId: [
+		776
+	],
 	hp: 120,
+	types: [
+		"Fire"
+	],
 	stage: "Basic",
 	abilities: [
 		{
 			type: "Ability",
 			name: {
+				en: "Shell Spikes",
 				fr: "Carapace à Piques",
+				es: "Púas del Caparazón",
+				de: "Panzerstacheln",
+				it: "Gusciopunte",
+				pt: "Espinhos de Carapaça"
 			},
 			effect: {
+				en: "If this Pokémon is in the Active Spot and is damaged by an attack from your opponent's Pokémon (even if this Pokémon is Knocked Out), discard an Energy from the Attacking Pokémon.",
 				fr: "Si ce Pokémon est sur le Poste Actif et qu'il subit les dégâts d'une attaque de l'un des Pokémon de votre adversaire (même si ce Pokémon est mis K.O.), défaussez une Énergie du Pokémon Attaquant.",
-			},
-		},
+				es: "Si este Pokémon está en el Puesto Activo y resulta dañado por un ataque de los Pokémon de tu rival (incluso si queda Fuera de Combate), descarta 1 Energía del Pokémon Atacante.",
+				de: "Wenn dieses Pokémon in der Aktiven Position ist und durch eine Attacke von Pokémon deines Gegners Schaden erhält (auch wenn dieses Pokémon dadurch kampfunfähig wird), lege 1 Energie vom Angreifenden Pokémon auf den Ablagestapel deines Gegners.",
+				it: "Se questo Pokémon è in posizione attiva e viene danneggiato da un attacco di un Pokémon del tuo avversario, anche se viene messo KO, scarta un'Energia dal Pokémon attaccante.",
+				pt: "Se este Pokémon estiver no Campo Ativo e for danificado por um ataque dos Pokémon do seu oponente (mesmo que este Pokémon seja Nocauteado), descarte uma Energia do Pokémon Atacante."
+			}
+		}
 	],
 	attacks: [
 		{
 			cost: [
 				"Fire",
 				"Fire",
-				"Colorless",
+				"Colorless"
 			],
 			name: {
+				en: "Heat Breath",
 				fr: "Souffle Ardent",
+				es: "Aliento Ardiente",
+				de: "Heißer Atem",
+				it: "Alitorovente",
+				pt: "Bafo de Calor"
 			},
 			damage: "80+",
 			effect: {
+				en: "Flip a coin. If heads, this attack does 80 more damage.",
 				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 80 dégâts supplémentaires.",
-			},
-		},
+				es: "Lanza 1 moneda. Si sale cara, este ataque hace 80 puntos de daño más.",
+				de: "Wirf 1 Münze. Bei Kopf fügt diese Attacke 80 Schadenspunkte mehr zu.",
+				it: "Lancia una moneta. Se esce testa, questo attacco infligge 80 danni in più.",
+				pt: "Jogue uma moeda. Se sair cara, este ataque causará 80 pontos de dano a mais."
+			}
+		}
 	],
 	weaknesses: [
 		{
 			type: "Water",
-			value: "×2",
-		},
+			value: "×2"
+		}
 	],
 	retreat: 2,
 	regulationMark: "J",
 	illustrator: "Hasuno",
-
+	variants: [
+		{
+			type: "normal"
+		},
+		{
+			type: "reverse"
+		}
+	],
 	thirdParty: {
+		tcgplayer: 684407,
 		cardmarket: 877429
 	}
 }

--- a/data/Mega Evolution/Perfect Order/018.ts
+++ b/data/Mega Evolution/Perfect Order/018.ts
@@ -3,45 +3,74 @@ import Set from '../Perfect Order'
 
 const card: Card = {
 	name: {
+		en: "Seel",
 		fr: "Otaria",
+		es: "Seel",
+		de: "Jurob",
+		it: "Seel",
+		pt: "Seel"
 	},
 	set: Set,
 	rarity: "Common",
 	category: "Pokemon",
+	dexId: [
+		86
+	],
 	hp: 80,
+	types: [
+		"Water"
+	],
 	stage: "Basic",
 	attacks: [
 		{
 			cost: [
-				"Water",
+				"Water"
 			],
 			name: {
+				en: "Rain Splash",
 				fr: "Pluie Éclaboussante",
+				es: "Golpe de Lluvia",
+				de: "Regenplatscher",
+				it: "Spruzzapioggia",
+				pt: "Chuva Borrifante"
 			},
-			damage: "10",
+			damage: "10"
 		},
 		{
 			cost: [
 				"Water",
-				"Water",
+				"Water"
 			],
 			name: {
+				en: "Wave Splash",
 				fr: "Grosse Vague",
+				es: "Chapoteo Ondulante",
+				de: "Wellenplatscher",
+				it: "Schizzi d'Onda",
+				pt: "Onda Borrifante"
 			},
-			damage: "30",
-		},
+			damage: "30"
+		}
 	],
 	weaknesses: [
 		{
 			type: "Lightning",
-			value: "×2",
-		},
+			value: "×2"
+		}
 	],
 	retreat: 2,
 	regulationMark: "J",
 	illustrator: "Kanami Ogata",
-
+	variants: [
+		{
+			type: "reverse"
+		},
+		{
+			type: "normal"
+		}
+	],
 	thirdParty: {
+		tcgplayer: 684372,
 		cardmarket: 877430
 	}
 }

--- a/data/Mega Evolution/Perfect Order/019.ts
+++ b/data/Mega Evolution/Perfect Order/019.ts
@@ -3,50 +3,90 @@ import Set from '../Perfect Order'
 
 const card: Card = {
 	name: {
+		en: "Dewgong",
 		fr: "Lamantine",
+		es: "Dewgong",
+		de: "Jugong",
+		it: "Dewgong",
+		pt: "Dewgong"
 	},
 	set: Set,
 	rarity: "Rare",
 	category: "Pokemon",
+	dexId: [
+		87
+	],
 	hp: 130,
+	types: [
+		"Water"
+	],
 	stage: "Stage1",
 	evolveFrom: {
+		en: "Seel",
 		fr: "Otaria",
+		es: "Seel",
+		"es-mx": "Seel",
+		de: "Jurob",
+		it: "Seel",
+		pt: "Seel"
 	},
 	abilities: [
 		{
 			type: "Ability",
 			name: {
+				en: "Wash Out",
 				fr: "Surlavage",
+				es: "Hacer Limpieza",
+				de: "Wegspülen",
+				it: "Sciacquare",
+				pt: "Lavagem"
 			},
 			effect: {
-				fr: "Autant de fois que vous le voulez pendant votre tour, vous pouvez utiliser ce talent. Déplacez une Énergie Eau de l'un de vos Pokémon de Banc vers votre Pokémon Actif.",
-			},
-		},
+				en: "As often as you like during your turn, you may use this Ability. Move a [W] Energy from 1 of your Benched Pokémon to your Active Pokémon.",
+				fr: "Autant de fois que vous le voulez pendant votre tour, vous pouvez utiliser ce talent. Déplacez une Énergie [W] de l'un de vos Pokémon de Banc vers votre Pokémon Actif.",
+				es: "Todas las veces que quieras durante tu turno, puedes usar esta habilidad. Mueve 1 Energía [W] de uno de tus Pokémon en Banca a tu Pokémon Activo.",
+				de: "Beliebig oft während deines Zuges kannst du diese Fähigkeit einsetzen. Verschiebe 1 [W]-Energie von 1 Pokémon auf deiner Bank auf dein Aktives Pokémon.",
+				it: "Durante il tuo turno, puoi usare questa abilità tutte le volte che vuoi. Sposta un'Energia [W] da uno dei Pokémon nella tua panchina al tuo Pokémon attivo.",
+				pt: "Quantas vezes desejar durante o seu turno, você poderá usar esta Habilidade. Mova uma Energia [W] de 1 dos seus Pokémon no Banco para o seu Pokémon Ativo."
+			}
+		}
 	],
 	attacks: [
 		{
 			cost: [
 				"Water",
-				"Water",
+				"Water"
 			],
 			name: {
+				en: "Wave Splash",
 				fr: "Grosse Vague",
+				es: "Chapoteo Ondulante",
+				de: "Wellenplatscher",
+				it: "Schizzi d'Onda",
+				pt: "Onda Borrifante"
 			},
-			damage: "60",
-		},
+			damage: "60"
+		}
 	],
 	weaknesses: [
 		{
 			type: "Lightning",
-			value: "×2",
-		},
+			value: "×2"
+		}
 	],
 	retreat: 2,
 	regulationMark: "J",
 	illustrator: "Yoshioka",
-
+	variants: [
+		{
+			type: "holo"
+		},
+		{
+			type: "reverse"
+		}
+	],
 	thirdParty: {
+		tcgplayer: 684373,
 		cardmarket: 877431
 	}
 }

--- a/data/Mega Evolution/Perfect Order/020.ts
+++ b/data/Mega Evolution/Perfect Order/020.ts
@@ -3,35 +3,59 @@ import Set from '../Perfect Order'
 
 const card: Card = {
 	name: {
+		en: "Staryu",
 		fr: "Stari",
+		es: "Staryu",
+		de: "Sterndu",
+		it: "Staryu",
+		pt: "Staryu"
 	},
 	set: Set,
 	rarity: "Common",
 	category: "Pokemon",
+	dexId: [
+		120
+	],
 	hp: 70,
+	types: [
+		"Water"
+	],
 	stage: "Basic",
 	attacks: [
 		{
 			cost: [
-				"Water",
+				"Water"
 			],
 			name: {
+				en: "Water Gun",
 				fr: "Pistolet à O",
+				es: "Pistola Agua",
+				de: "Aquaknarre",
+				it: "Pistolacqua",
+				pt: "Revólver d'Água"
 			},
-			damage: "20",
-		},
+			damage: "20"
+		}
 	],
 	weaknesses: [
 		{
 			type: "Lightning",
-			value: "×2",
-		},
+			value: "×2"
+		}
 	],
 	retreat: 1,
 	regulationMark: "J",
 	illustrator: "Takeshi Nakamura",
-
+	variants: [
+		{
+			type: "normal"
+		},
+		{
+			type: "reverse"
+		}
+	],
 	thirdParty: {
+		tcgplayer: 684374,
 		cardmarket: 877432
 	}
 }

--- a/data/Mega Evolution/Perfect Order/021.ts
+++ b/data/Mega Evolution/Perfect Order/021.ts
@@ -3,55 +3,96 @@ import Set from '../Perfect Order'
 
 const card: Card = {
 	name: {
+		en: "Mega Starmie ex",
 		fr: "Méga-Staross-ex",
+		es: "Mega-Starmie ex",
+		de: "Mega-Starmie-ex",
+		it: "Mega Starmie-ex",
+		pt: "Mega Starmie ex"
 	},
 	set: Set,
 	rarity: "Double rare",
 	category: "Pokemon",
+	dexId: [
+		121
+	],
 	hp: 330,
+	types: [
+		"Water"
+	],
 	stage: "Stage1",
 	evolveFrom: {
+		en: "Staryu",
 		fr: "Stari",
+		es: "Staryu",
+		de: "Sterndu",
+		it: "Staryu",
+		pt: "Staryu"
 	},
 	attacks: [
 		{
 			cost: [
-				"Water",
+				"Water"
 			],
 			name: {
+				en: "Jetting Blow",
 				fr: "Coup Éclaboussant",
+				es: "Golpe Propulsión",
+				de: "Wasserschwall",
+				it: "Colpogetto",
+				pt: "Golpe a Jato"
 			},
 			damage: "120",
 			effect: {
+				en: "This attack also does 50 damage to 1 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)",
 				fr: "Cette attaque inflige aussi 50 dégâts à l'un des Pokémon de Banc de votre adversaire. (N'appliquez ni la Faiblesse ni la Résistance aux Pokémon de Banc.)",
-			},
+				es: "Este ataque también hace 50 puntos de daño a uno de los Pokémon en Banca de tu rival. (No apliques Debilidad y Resistencia a los Pokémon en Banca).",
+				de: "Diese Attacke fügt auch 1 Pokémon auf der Bank deines Gegners 50 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)",
+				it: "Questo attacco infligge anche 50 danni a uno dei Pokémon nella panchina del tuo avversario. Non applicare debolezza e resistenza ai Pokémon in panchina.",
+				pt: "Este ataque também causa 50 pontos de dano a 1 dos Pokémon no Banco do seu oponente. (Não aplique Fraqueza e Resistência aos Pokémon no Banco.)"
+			}
 		},
 		{
 			cost: [
 				"Colorless",
 				"Colorless",
-				"Colorless",
+				"Colorless"
 			],
 			name: {
+				en: "Nebula Beam",
 				fr: "Rayon Nébuleux",
+				es: "Rayo Nebulosa",
+				de: "Nebelstrahl",
+				it: "Nebularaggio",
+				pt: "Feixe Celestial"
 			},
 			damage: "210",
 			effect: {
+				en: "This attack's damage isn't affected by Weakness or Resistance, or by any effects on your opponent's Active Pokémon.",
 				fr: "Les dégâts de cette attaque ne sont pas affectés par la Faiblesse, la Résistance ou tout effet en action sur le Pokémon Actif de votre adversaire.",
-			},
-		},
+				es: "El daño de este ataque no se ve afectado por Debilidad o Resistencia, ni por ningún efecto en el Pokémon Activo de tu rival.",
+				de: "Der Schaden dieser Attacke wird durch Schwäche oder Resistenz oder Effekte auf dem Aktiven Pokémon deines Gegners nicht verändert.",
+				it: "I danni di questo attacco non sono influenzati dalla debolezza o dalla resistenza, o da alcun effetto presente sul Pokémon attivo del tuo avversario.",
+				pt: "O dano deste ataque não é afetado por Fraqueza ou Resistência, ou por quaisquer efeitos no Pokémon Ativo do seu oponente."
+			}
+		}
 	],
 	weaknesses: [
 		{
 			type: "Lightning",
-			value: "×2",
-		},
+			value: "×2"
+		}
 	],
 	retreat: 2,
 	regulationMark: "J",
 	illustrator: "5ban Graphics",
-
+	variants: [
+		{
+			type: "holo"
+		}
+	],
 	thirdParty: {
+		tcgplayer: 684360,
 		cardmarket: 877433
 	}
 }

--- a/data/Mega Evolution/Perfect Order/022.ts
+++ b/data/Mega Evolution/Perfect Order/022.ts
@@ -3,49 +3,80 @@ import Set from '../Perfect Order'
 
 const card: Card = {
 	name: {
+		en: "Lapras ex",
 		fr: "Lokhlass-ex",
+		es: "Lapras ex",
+		de: "Lapras-ex",
+		it: "Lapras-ex",
+		pt: "Lapras ex"
 	},
 	set: Set,
 	rarity: "Double rare",
 	category: "Pokemon",
+	dexId: [
+		131
+	],
 	hp: 210,
+	types: [
+		"Water"
+	],
 	stage: "Basic",
 	attacks: [
 		{
 			cost: [
-				"Water",
+				"Water"
 			],
 			name: {
+				en: "Hydro Turn",
 				fr: "Hydro-Tour",
+				es: "Hidrogiro",
+				de: "Hydrowende",
+				it: "Idrovirata",
+				pt: "Revira Água"
 			},
 			damage: "30×",
 			effect: {
-				fr: "Cette attaque inflige 30 dégâts pour chaque Énergie Eau attachée à ce Pokémon. Échangez ce Pokémon contre l'un de vos Pokémon de Banc.",
-			},
+				en: "This attack does 30 damage for each [W] Energy attached to this Pokémon. Switch this Pokémon with 1 of your Benched Pokémon.",
+				fr: "Cette attaque inflige 30 dégâts pour chaque Énergie [W] attachée à ce Pokémon. Échangez ce Pokémon contre l'un de vos Pokémon de Banc.",
+				es: "Este ataque hace 30 puntos de daño por cada Energía [W] unida a este Pokémon. Cambia este Pokémon por uno de tus Pokémon en Banca.",
+				de: "Diese Attacke fügt für jede an dieses Pokémon angelegte [W]-Energie 30 Schadenspunkte zu. Tausche dieses Pokémon gegen 1 Pokémon auf deiner Bank aus.",
+				it: "Questo attacco infligge 30 danni per ogni Energia [W] assegnata a questo Pokémon. Scambia questo Pokémon con uno nella tua panchina.",
+				pt: "Este ataque causa 30 pontos de dano para cada Energia [W] ligada a este Pokémon. Troque este Pokémon por 1 dos seus Pokémon no Banco."
+			}
 		},
 		{
 			cost: [
 				"Water",
 				"Water",
-				"Water",
+				"Water"
 			],
 			name: {
+				en: "Surf",
 				fr: "Surf",
+				es: "Surf",
+				de: "Surfer",
+				it: "Surf",
+				pt: "Surfar"
 			},
-			damage: "140",
-		},
+			damage: "140"
+		}
 	],
 	weaknesses: [
 		{
 			type: "Lightning",
-			value: "×2",
-		},
+			value: "×2"
+		}
 	],
 	retreat: 2,
 	regulationMark: "I",
 	illustrator: "5ban Graphics",
-
+	variants: [
+		{
+			type: "holo"
+		}
+	],
 	thirdParty: {
+		tcgplayer: 684329,
 		cardmarket: 877434
 	}
 }

--- a/data/Mega Evolution/Perfect Order/023.ts
+++ b/data/Mega Evolution/Perfect Order/023.ts
@@ -3,42 +3,76 @@ import Set from '../Perfect Order'
 
 const card: Card = {
 	name: {
+		en: "Amaura",
 		fr: "Amagara",
+		es: "Amaura",
+		de: "Amarino",
+		it: "Amaura",
+		pt: "Amaura"
 	},
 	set: Set,
 	rarity: "Common",
 	category: "Pokemon",
+	dexId: [
+		698
+	],
 	hp: 100,
+	types: [
+		"Water"
+	],
 	stage: "Stage1",
 	evolveFrom: {
+		en: "Antique Sail Fossil",
 		fr: "Fossile Nageoire Ancien",
+		es: "Fósil Aleta Antiguo",
+		de: "Antikes Flossenfossil",
+		it: "Vecchio Fossilpinna",
+		pt: "Fóssil de Vela Arcaico"
 	},
 	attacks: [
 		{
 			cost: [
 				"Water",
-				"Colorless",
+				"Colorless"
 			],
 			name: {
+				en: "Icy Wind",
 				fr: "Vent Glace",
+				es: "Viento Hielo",
+				de: "Eissturm",
+				it: "Ventogelato",
+				pt: "Vento Congelante"
 			},
 			damage: "50",
 			effect: {
+				en: "Your opponent's Active Pokémon is now Asleep.",
 				fr: "Le Pokémon Actif de votre adversaire est maintenant Endormi.",
-			},
-		},
+				es: "El Pokémon Activo de tu rival pasa a estar Dormido.",
+				de: "Das Aktive Pokémon deines Gegners schläft jetzt.",
+				it: "Il Pokémon attivo del tuo avversario viene addormentato.",
+				pt: "O Pokémon Ativo do seu oponente agora está Adormecido."
+			}
+		}
 	],
 	weaknesses: [
 		{
 			type: "Metal",
-			value: "×2",
-		},
+			value: "×2"
+		}
 	],
 	retreat: 3,
 	regulationMark: "J",
 	illustrator: "Hitoshi Ariga",
-
+	variants: [
+		{
+			type: "reverse"
+		},
+		{
+			type: "normal"
+		}
+	],
 	thirdParty: {
+		tcgplayer: 684355,
 		cardmarket: 877435
 	}
 }

--- a/data/Mega Evolution/Perfect Order/024.ts
+++ b/data/Mega Evolution/Perfect Order/024.ts
@@ -3,54 +3,98 @@ import Set from '../Perfect Order'
 
 const card: Card = {
 	name: {
+		en: "Aurorus",
 		fr: "Dragmara",
+		es: "Aurorus",
+		de: "Amagarga",
+		it: "Aurorus",
+		pt: "Aurorus"
 	},
 	set: Set,
 	rarity: "Rare",
 	category: "Pokemon",
+	dexId: [
+		699
+	],
 	hp: 170,
+	types: [
+		"Water"
+	],
 	stage: "Stage2",
 	evolveFrom: {
+		en: "Amaura",
 		fr: "Amagara",
+		es: "Amaura",
+		de: "Amarino",
+		it: "Amaura",
+		pt: "Amaura"
 	},
 	abilities: [
 		{
 			type: "Ability",
 			name: {
+				en: "Tundra Wall",
 				fr: "Mur Toundra",
+				es: "Muro Tundra",
+				de: "Tundra-Wall",
+				it: "Murotundra",
+				pt: "Parede de Tundra"
 			},
 			effect: {
-				fr: "Vos Pokémon auxquels au moins une Énergie Eau est attachée subissent 50 dégâts de moins provenant des attaques des Pokémon de votre adversaire (après application de la Faiblesse et de la Résistance). L'effet de Mur Toundra n'est pas cumulable.",
-			},
-		},
+				en: "All of your Pokémon that have any [W] Energy attached take 50 less damage from attacks from your opponent's Pokémon (after applying Weakness and Resistance). The effect of Tundra Wall doesn't stack.",
+				fr: "Vos Pokémon auxquels au moins une Énergie [W] est attachée subissent 50 dégâts de moins provenant des attaques des Pokémon de votre adversaire (après application de la Faiblesse et de la Résistance). L'effet de Mur Toundra n'est pas cumulable.",
+				es: "Los ataques de los Pokémon de tu rival hacen 50 puntos de daño menos a todos tus Pokémon que tengan alguna Energía [W] unida (después de aplicar Debilidad y Resistencia). El efecto de Muro Tundra no se acumula.",
+				de: "Allen deinen Pokémon, an die mindestens 1 [W]-Energie angelegt ist, werden durch Attacken von Pokémon deines Gegners 50 Schadenspunkte weniger zugefügt (nachdem Schwäche und Resistenz verrechnet wurden). Der Effekt von Tundra-Wall stapelt sich nicht.",
+				it: "I tuoi Pokémon che hanno delle Energie [W] assegnate subiscono 50 danni in meno dagli attacchi dei Pokémon del tuo avversario, dopo aver applicato debolezza e resistenza. L'effetto di Murotundra non è cumulabile.",
+				pt: "Todos os seus Pokémon que têm alguma Energia [W] ligada a eles recebem 50 pontos de dano a menos de ataques dos Pokémon do seu oponente (depois de aplicar Fraqueza e Resistência). O efeito de Parede de Tundra não acumula."
+			}
+		}
 	],
 	attacks: [
 		{
 			cost: [
 				"Water",
 				"Water",
-				"Colorless",
+				"Colorless"
 			],
 			name: {
+				en: "Freezing Chill",
 				fr: "Frisson Glaçant",
+				es: "Frío Helador",
+				de: "Gefrierschock",
+				it: "Freddo Glaciale",
+				pt: "Frio de Arrepiar"
 			},
 			damage: "150",
 			effect: {
+				en: "During your opponent's next turn, the Defending Pokémon can't use attacks.",
 				fr: "Pendant le prochain tour de votre adversaire, le Pokémon Défenseur ne peut pas utiliser d'attaques.",
-			},
-		},
+				es: "Durante el próximo turno de tu rival, el Pokémon Defensor no puede usar ataques.",
+				de: "Während des nächsten Zuges deines Gegners kann das Verteidigende Pokémon keine Attacken einsetzen.",
+				it: "Durante il prossimo turno del tuo avversario, il Pokémon difensore non può usare attacchi.",
+				pt: "Durante o próximo turno do seu oponente, o Pokémon Defensor não poderá usar ataques."
+			}
+		}
 	],
 	weaknesses: [
 		{
 			type: "Metal",
-			value: "×2",
-		},
+			value: "×2"
+		}
 	],
 	retreat: 3,
 	regulationMark: "J",
 	illustrator: "HACCAN",
-
+	variants: [
+		{
+			type: "holo"
+		},
+		{
+			type: "reverse"
+		}
+	],
 	thirdParty: {
+		tcgplayer: 684356,
 		cardmarket: 877437
 	}
 }

--- a/data/Mega Evolution/Perfect Order/025.ts
+++ b/data/Mega Evolution/Perfect Order/025.ts
@@ -3,50 +3,84 @@ import Set from '../Perfect Order'
 
 const card: Card = {
 	name: {
+		en: "Volcanion",
 		fr: "Volcanion",
+		es: "Volcanion",
+		de: "Volcanion",
+		it: "Volcanion",
+		pt: "Volcanion"
 	},
 	set: Set,
 	rarity: "Uncommon",
 	category: "Pokemon",
+	dexId: [
+		721
+	],
 	hp: 130,
+	types: [
+		"Water"
+	],
 	stage: "Basic",
 	attacks: [
 		{
 			cost: [
 				"Water",
-				"Colorless",
+				"Colorless"
 			],
 			name: {
+				en: "Strength",
 				fr: "Force",
+				es: "Fuerza",
+				de: "Stärke",
+				it: "Forza",
+				pt: "Força"
 			},
-			damage: "50",
+			damage: "50"
 		},
 		{
 			cost: [
 				"Water",
 				"Water",
-				"Colorless",
+				"Colorless"
 			],
 			name: {
+				en: "Powerful Steam",
 				fr: "Vapeur Puissante",
+				es: "Vapor Poderoso",
+				de: "Mächtiger Dampf",
+				it: "Forzavapore",
+				pt: "Vaporderoso"
 			},
 			damage: "90×",
 			effect: {
-				fr: "Lancez une pièce pour chaque Énergie Eau attachée à ce Pokémon. Cette attaque inflige 90 dégâts pour chaque côté face.",
-			},
-		},
+				en: "Flip a coin for each [W] Energy attached to this Pokémon. This attack does 90 damage for each heads.",
+				fr: "Lancez une pièce pour chaque Énergie [W] attachée à ce Pokémon. Cette attaque inflige 90 dégâts pour chaque côté face.",
+				es: "Lanza 1 moneda por cada Energía [W] unida a este Pokémon. Este ataque hace 90 puntos de daño por cada cara.",
+				de: "Wirf 1 Münze für jede an dieses Pokémon angelegte [W]-Energie. Diese Attacke fügt 90 Schadenspunkte pro Kopf zu.",
+				it: "Lancia una moneta per ogni Energia [W] assegnata a questo Pokémon. Questo attacco infligge 90 danni ogni volta che esce testa.",
+				pt: "Jogue uma moeda para cada Energia [W] ligada a este Pokémon. Este ataque causa 90 pontos de dano para cada cara."
+			}
+		}
 	],
 	weaknesses: [
 		{
 			type: "Lightning",
-			value: "×2",
-		},
+			value: "×2"
+		}
 	],
 	retreat: 3,
 	regulationMark: "J",
 	illustrator: "AKIRA EGAWA",
-
+	variants: [
+		{
+			type: "normal"
+		},
+		{
+			type: "reverse"
+		}
+	],
 	thirdParty: {
+		tcgplayer: 684408,
 		cardmarket: 877438
 	}
 }

--- a/data/Mega Evolution/Perfect Order/026.ts
+++ b/data/Mega Evolution/Perfect Order/026.ts
@@ -3,38 +3,67 @@ import Set from '../Perfect Order'
 
 const card: Card = {
 	name: {
+		en: "Shinx",
 		fr: "Lixy",
+		es: "Shinx",
+		de: "Sheinux",
+		it: "Shinx",
+		pt: "Shinx"
 	},
 	set: Set,
 	rarity: "Common",
 	category: "Pokemon",
+	dexId: [
+		403
+	],
 	hp: 70,
+	types: [
+		"Lightning"
+	],
 	stage: "Basic",
 	attacks: [
 		{
 			cost: [
-				"Lightning",
+				"Lightning"
 			],
 			name: {
+				en: "Double Scratch",
 				fr: "Double Écorchure",
+				es: "Arañazo Doble",
+				de: "Doppelkratzer",
+				it: "Doppio Graffio",
+				pt: "Arranhão Duplo"
 			},
 			damage: "10×",
 			effect: {
+				en: "Flip 2 coins. This attack does 10 damage for each heads.",
 				fr: "Lancez 2 pièces. Cette attaque inflige 10 dégâts pour chaque côté face.",
-			},
-		},
+				es: "Lanza 2 monedas. Este ataque hace 10 puntos de daño por cada cara.",
+				de: "Wirf 2 Münzen. Diese Attacke fügt 10 Schadenspunkte pro Kopf zu.",
+				it: "Lancia due volte una moneta. Questo attacco infligge 10 danni ogni volta che esce testa.",
+				pt: "Jogue 2 moedas. Este ataque causa 10 pontos de dano para cada cara."
+			}
+		}
 	],
 	weaknesses: [
 		{
 			type: "Fighting",
-			value: "×2",
-		},
+			value: "×2"
+		}
 	],
 	retreat: 1,
 	regulationMark: "J",
 	illustrator: "Saboteri",
-
+	variants: [
+		{
+			type: "normal"
+		},
+		{
+			type: "reverse"
+		}
+	],
 	thirdParty: {
+		tcgplayer: 684409,
 		cardmarket: 877439
 	}
 }

--- a/data/Mega Evolution/Perfect Order/027.ts
+++ b/data/Mega Evolution/Perfect Order/027.ts
@@ -3,50 +3,89 @@ import Set from '../Perfect Order'
 
 const card: Card = {
 	name: {
+		en: "Luxio",
 		fr: "Luxio",
+		es: "Luxio",
+		de: "Luxio",
+		it: "Luxio",
+		pt: "Luxio"
 	},
 	set: Set,
 	rarity: "Uncommon",
 	category: "Pokemon",
+	dexId: [
+		404
+	],
 	hp: 90,
+	types: [
+		"Lightning"
+	],
 	stage: "Stage1",
 	evolveFrom: {
+		en: "Shinx",
 		fr: "Lixy",
+		es: "Shinx",
+		de: "Sheinux",
+		it: "Shinx",
+		pt: "Shinx"
 	},
 	abilities: [
 		{
 			type: "Ability",
 			name: {
+				en: "Fighting Roar",
 				fr: "Rugissement Combatif",
+				es: "Rugido de Lucha",
+				de: "Kampflustiges Gebrüll",
+				it: "Ruggito Combattente",
+				pt: "Rugido de Luta"
 			},
 			effect: {
+				en: "If your opponent's Active Pokémon is a Pokémon ex, this Pokémon can evolve during your first turn or the turn you play it.",
 				fr: "Si le Pokémon Actif de votre adversaire est un Pokémon-ex, ce Pokémon peut évoluer pendant votre premier tour ou pendant le tour où vous le jouez.",
-			},
-		},
+				es: "Si el Pokémon Activo de tu rival es un Pokémon ex, este Pokémon puede evolucionar durante tu primer turno o durante el turno en que lo pongas en juego.",
+				de: "Wenn das Aktive Pokémon deines Gegners ein Pokémon-ex ist, kann sich dieses Pokémon während deines ersten Zuges oder während des Zuges, in dem du es spielst, entwickeln.",
+				it: "Se il Pokémon attivo del tuo avversario è un Pokémon-ex, questo Pokémon può evolversi durante il tuo primo turno o il turno in cui lo giochi.",
+				pt: "Se o Pokémon Ativo do seu oponente for um Pokémon ex, este Pokémon poderá evoluir durante o seu primeiro turno ou durante o turno em que for colocado em jogo."
+			}
+		}
 	],
 	attacks: [
 		{
 			cost: [
 				"Lightning",
-				"Colorless",
+				"Colorless"
 			],
 			name: {
+				en: "Static Shock",
 				fr: "Choc Statique",
+				es: "Impacto Estático",
+				de: "Statischer Schock",
+				it: "Shock Statico",
+				pt: "Choque de Estática"
 			},
-			damage: "40",
-		},
+			damage: "40"
+		}
 	],
 	weaknesses: [
 		{
 			type: "Fighting",
-			value: "×2",
-		},
+			value: "×2"
+		}
 	],
 	retreat: 1,
 	regulationMark: "J",
 	illustrator: "Atsuko Nishida",
-
+	variants: [
+		{
+			type: "normal"
+		},
+		{
+			type: "reverse"
+		}
+	],
 	thirdParty: {
+		tcgplayer: 684410,
 		cardmarket: 877440
 	}
 }

--- a/data/Mega Evolution/Perfect Order/028.ts
+++ b/data/Mega Evolution/Perfect Order/028.ts
@@ -3,55 +3,99 @@ import Set from '../Perfect Order'
 
 const card: Card = {
 	name: {
+		en: "Luxray",
 		fr: "Luxray",
+		es: "Luxray",
+		de: "Luxtra",
+		it: "Luxray",
+		pt: "Luxray"
 	},
 	set: Set,
 	rarity: "Rare",
 	category: "Pokemon",
+	dexId: [
+		405
+	],
 	hp: 150,
+	types: [
+		"Lightning"
+	],
 	stage: "Stage2",
 	evolveFrom: {
+		en: "Luxio",
 		fr: "Luxio",
+		es: "Luxio",
+		de: "Luxio",
+		it: "Luxio",
+		pt: "Luxio"
 	},
 	attacks: [
 		{
 			cost: [
 				"Lightning",
-				"Colorless",
+				"Colorless"
 			],
 			name: {
+				en: "Incessant Onslaught",
 				fr: "Assauts Continuels",
+				es: "Embestida Incesante",
+				de: "Unablässiger Ansturm",
+				it: "Offensiva Continua",
+				pt: "Sova Sem Fim"
 			},
 			damage: "70×",
 			effect: {
+				en: "This attack does 70 damage for each Prize card you have taken.",
 				fr: "Cette attaque inflige 70 dégâts pour chaque carte Récompense que vous avez récupérée.",
-			},
+				es: "Este ataque hace 70 puntos de daño por cada carta de Premio que hayas cogido.",
+				de: "Diese Attacke fügt für jede von dir genommene Preiskarte 70 Schadenspunkte zu.",
+				it: "Questo attacco infligge 70 danni per ogni carta Premio che hai preso.",
+				pt: "Este ataque causa 70 pontos de dano para cada carta de Prêmio que você pegou."
+			}
 		},
 		{
 			cost: [
 				"Lightning",
 				"Colorless",
-				"Colorless",
+				"Colorless"
 			],
 			name: {
+				en: "Strong Volt",
 				fr: "Décharge Foudroyante",
+				es: "Descarga Fulminante",
+				de: "Voltkraft",
+				it: "Supervolt",
+				pt: "Tensão Intensa"
 			},
 			damage: "200",
 			effect: {
+				en: "Discard 2 Energy from this Pokémon.",
 				fr: "Défaussez 2 Énergies de ce Pokémon.",
-			},
-		},
+				es: "Descarta 2 Energías de este Pokémon.",
+				de: "Lege 2 Energien von diesem Pokémon auf deinen Ablagestapel.",
+				it: "Scarta due Energie da questo Pokémon.",
+				pt: "Descarte 2 Energias deste Pokémon."
+			}
+		}
 	],
 	weaknesses: [
 		{
 			type: "Fighting",
-			value: "×2",
-		},
+			value: "×2"
+		}
 	],
 	regulationMark: "J",
 	illustrator: "Taiga Kasai",
-
+	variants: [
+		{
+			type: "holo"
+		},
+		{
+			type: "reverse"
+		}
+	],
 	thirdParty: {
+		tcgplayer: 684411,
 		cardmarket: 877441
 	}
 }

--- a/data/Mega Evolution/Perfect Order/029.ts
+++ b/data/Mega Evolution/Perfect Order/029.ts
@@ -3,50 +3,89 @@ import Set from '../Perfect Order'
 
 const card: Card = {
 	name: {
+		en: "Dedenne",
 		fr: "Dedenne",
+		es: "Dedenne",
+		de: "Dedenne",
+		it: "Dedenne",
+		pt: "Dedenne"
 	},
 	set: Set,
 	rarity: "Common",
 	category: "Pokemon",
+	dexId: [
+		702
+	],
 	hp: 70,
+	types: [
+		"Lightning"
+	],
 	stage: "Basic",
 	attacks: [
 		{
 			cost: [
-				"Lightning",
+				"Lightning"
 			],
 			name: {
+				en: "Tail Generator",
 				fr: "Générateur Caudal",
+				es: "Generador Cola",
+				de: "Generatorschweif",
+				it: "Codageneratore",
+				pt: "Gerador de Cauda"
 			},
 			effect: {
-				fr: "Choisissez dans votre pile de défausse un nombre de cartes Énergie Électrique de base inférieur ou égal à la quantité d'Énergies attachées à tous les Pokémon de votre adversaire, puis attachez-les à vos Pokémon Électrique comme il vous plaît.",
-			},
+				en: "Choose Basic [L] Energy cards from your discard pile up to the amount of Energy attached to all of your opponent's Pokémon and attach them to your [L] Pokémon in any way you like.",
+				fr: "Choisissez dans votre pile de défausse un nombre de cartes Énergie [L] de base inférieur ou égal à la quantité d'Énergies attachées à tous les Pokémon de votre adversaire, puis attachez-les à vos Pokémon [L] comme il vous plaît.",
+				es: "Elige una cantidad de cartas de Energía [L] Básica de tu pila de descartes igual o inferior a la cantidad de Energías unidas a cada uno de los Pokémon de tu rival, y únelas a tus Pokémon [L] de la manera que desees.",
+				de: "Wähle bis zu so viele Basis-[L]-Energiekarten aus deinem Ablagestapel, wie Energien an alle Pokémon deines Gegners angelegt sind, und lege sie beliebig an deine [L]-Pokémon an.",
+				it: "Scegli un numero di carte Energia base [L] dalla tua pila degli scarti uguale o inferiore al numero di Energie assegnate ai Pokémon del tuo avversario e assegnale ai tuoi Pokémon [L] nel modo che preferisci.",
+				pt: "Escolha cartas de Energia [L] Básica da sua pilha de descarte até a quantidade de Energias ligadas a todos os Pokémon do seu oponente e ligue-as aos seus Pokémon [L] como desejar."
+			}
 		},
 		{
 			cost: [
 				"Lightning",
-				"Colorless",
+				"Colorless"
 			],
 			name: {
+				en: "Thunder Shock",
 				fr: "Éclair",
+				es: "Impactrueno",
+				de: "Donnerschock",
+				it: "Tuonoshock",
+				pt: "Trovoada de Choques"
 			},
 			damage: "30",
 			effect: {
+				en: "Flip a coin. If heads, your opponent's Active Pokémon is now Paralyzed.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Actif de votre adversaire est maintenant Paralysé.",
-			},
-		},
+				es: "Lanza 1 moneda. Si sale cara, el Pokémon Activo de tu rival pasa a estar Paralizado.",
+				de: "Wirf 1 Münze. Bei Kopf ist das Aktive Pokémon deines Gegners jetzt paralysiert.",
+				it: "Lancia una moneta. Se esce testa, il Pokémon attivo del tuo avversario viene paralizzato.",
+				pt: "Jogue uma moeda. Se sair cara, o Pokémon Ativo do seu oponente agora estará Paralisado."
+			}
+		}
 	],
 	weaknesses: [
 		{
 			type: "Fighting",
-			value: "×2",
-		},
+			value: "×2"
+		}
 	],
 	retreat: 1,
 	regulationMark: "J",
 	illustrator: "sowsow",
-
+	variants: [
+		{
+			type: "reverse"
+		},
+		{
+			type: "normal"
+		}
+	],
 	thirdParty: {
+		tcgplayer: 684412,
 		cardmarket: 877442
 	}
 }

--- a/data/Mega Evolution/Perfect Order/030.ts
+++ b/data/Mega Evolution/Perfect Order/030.ts
@@ -3,47 +3,81 @@ import Set from '../Perfect Order'
 
 const card: Card = {
 	name: {
+		en: "Clefairy",
 		fr: "Mélofée",
+		es: "Clefairy",
+		de: "Piepi",
+		it: "Clefairy",
+		pt: "Clefairy"
 	},
 	set: Set,
 	rarity: "Common",
 	category: "Pokemon",
+	dexId: [
+		35
+	],
 	hp: 70,
+	types: [
+		"Psychic"
+	],
 	stage: "Basic",
 	attacks: [
 		{
 			cost: [
-				"Psychic",
+				"Psychic"
 			],
 			name: {
+				en: "Follow Me",
 				fr: "Par Ici",
+				es: "Señuelo",
+				de: "Spotlight",
+				it: "Sonoqui",
+				pt: "Isca-viva"
 			},
 			effect: {
+				en: "Switch in 1 of your opponent's Benched Pokémon to the Active Spot.",
 				fr: "Envoyez l'un des Pokémon de Banc de votre adversaire sur le Poste Actif.",
-			},
+				es: "Cambia 1 de los Pokémon en Banca de tu rival por el Pokémon que esté en el Puesto Activo.",
+				de: "Wechsle 1 Pokémon von der Bank deines Gegners in die Aktive Position ein.",
+				it: "Sostituisci uno dei Pokémon nella panchina del tuo avversario con il suo Pokémon in posizione attiva.",
+				pt: "Mande 1 dos Pokémon no Banco do seu oponente para o Campo Ativo."
+			}
 		},
 		{
 			cost: [
 				"Psychic",
-				"Psychic",
+				"Psychic"
 			],
 			name: {
+				en: "Flop",
 				fr: "Flop",
+				es: "Vuelta",
+				de: "Plumps",
+				it: "Tonfo",
+				pt: "Baque"
 			},
-			damage: "30",
-		},
+			damage: "30"
+		}
 	],
 	weaknesses: [
 		{
 			type: "Metal",
-			value: "×2",
-		},
+			value: "×2"
+		}
 	],
 	retreat: 1,
 	regulationMark: "J",
 	illustrator: "Natsumi Yoshida",
-
+	variants: [
+		{
+			type: "reverse"
+		},
+		{
+			type: "normal"
+		}
+	],
 	thirdParty: {
+		tcgplayer: 684414,
 		cardmarket: 877444
 	}
 }

--- a/data/Mega Evolution/Perfect Order/031.ts
+++ b/data/Mega Evolution/Perfect Order/031.ts
@@ -3,53 +3,95 @@ import Set from '../Perfect Order'
 
 const card: Card = {
 	name: {
+		en: "Mega Clefable ex",
 		fr: "Méga-Mélodelfe-ex",
+		es: "Mega-Clefable ex",
+		de: "Mega-Pixi-ex",
+		it: "Mega Clefable-ex",
+		pt: "Mega Clefable ex"
 	},
 	set: Set,
 	rarity: "Double rare",
 	category: "Pokemon",
+	dexId: [
+		36
+	],
 	hp: 320,
+	types: [
+		"Psychic"
+	],
 	stage: "Stage1",
 	evolveFrom: {
+		en: "Clefairy",
 		fr: "Mélofée",
+		es: "Clefairy",
+		"es-mx": "Clefairy",
+		de: "Piepi",
+		it: "Clefairy",
+		pt: "Clefairy"
 	},
 	abilities: [
 		{
 			type: "Ability",
 			name: {
+				en: "Luminous Wing",
 				fr: "Aile Luminescente",
+				es: "Ala Luminosa",
+				de: "Luminöse Flügel",
+				it: "Ala Luminosa",
+				pt: "Asa Luminosa"
 			},
 			effect: {
+				en: "Prevent all effects of your opponent's Pokémon's Abilities done to this Pokémon.",
 				fr: "Évitez tous les effets des talents des Pokémon de votre adversaire infligés à ce Pokémon.",
-			},
-		},
+				es: "Se evitan todos los efectos de las habilidades de los Pokémon de tu rival infligidos a este Pokémon.",
+				de: "Verhindere alle Effekte von Fähigkeiten der Pokémon deines Gegners, die diesem Pokémon zugefügt werden.",
+				it: "Previeni tutti gli effetti delle abilità dei Pokémon del tuo avversario inflitti a questo Pokémon.",
+				pt: "Previna todos os efeitos das Habilidades dos Pokémon do seu oponente causados a este Pokémon."
+			}
+		}
 	],
 	attacks: [
 		{
 			cost: [
 				"Psychic",
-				"Psychic",
+				"Psychic"
 			],
 			name: {
+				en: "Shooting Moons",
 				fr: "Tirs de Lunes",
+				es: "Disparo Lunar",
+				de: "Mondschnuppen",
+				it: "Lune Cadenti",
+				pt: "Luas Cadentes"
 			},
 			damage: "120+",
 			effect: {
+				en: "You may discard up to 4 Energy cards from your hand, and this attack does 40 more damage for each card you discarded in this way.",
 				fr: "Vous pouvez défausser jusqu'à 4 cartes Énergie de votre main. Cette attaque inflige 40 dégâts supplémentaires pour chaque carte défaussée de cette façon.",
-			},
-		},
+				es: "Puedes descartar hasta 4 cartas de Energía de tu mano, y este ataque hace 40 puntos de daño más por cada carta que hayas descartado de esta manera.",
+				de: "Du kannst bis zu 4 Energiekarten aus deiner Hand auf deinen Ablagestapel legen, und diese Attacke fügt für jede auf diese Weise abgelegte Karte 40 Schadenspunkte mehr zu.",
+				it: "Puoi scartare fino a quattro carte Energia dalla tua mano e questo attacco infligge 40 danni in più per ogni carta che hai scartato in questo modo.",
+				pt: "Você pode descartar até 4 cartas de Energia da sua mão, e este ataque causa 40 pontos de dano a mais para cada carta descartada desta forma."
+			}
+		}
 	],
 	weaknesses: [
 		{
 			type: "Metal",
-			value: "×2",
-		},
+			value: "×2"
+		}
 	],
 	retreat: 1,
 	regulationMark: "J",
 	illustrator: "aky CG Works",
-
+	variants: [
+		{
+			type: "holo"
+		}
+	],
 	thirdParty: {
+		tcgplayer: 684383,
 		cardmarket: 877445
 	}
 }

--- a/data/Mega Evolution/Perfect Order/032.ts
+++ b/data/Mega Evolution/Perfect Order/032.ts
@@ -3,39 +3,68 @@ import Set from '../Perfect Order'
 
 const card: Card = {
 	name: {
+		en: "Mawile",
 		fr: "Mysdibule",
+		es: "Mawile",
+		de: "Flunkifer",
+		it: "Mawile",
+		pt: "Mawile"
 	},
 	set: Set,
 	rarity: "Common",
 	category: "Pokemon",
+	dexId: [
+		303
+	],
 	hp: 110,
+	types: [
+		"Psychic"
+	],
 	stage: "Basic",
 	attacks: [
 		{
 			cost: [
 				"Psychic",
-				"Colorless",
+				"Colorless"
 			],
 			name: {
+				en: "Double Eater",
 				fr: "Double Portion",
+				es: "Doble Ración",
+				de: "Doppelschmaus",
+				it: "Divoratore Doppio",
+				pt: "Comer em Dobro"
 			},
 			damage: "60×",
 			effect: {
+				en: "Discard up to 2 Energy cards from your hand, and this attack does 60 damage for each card you discarded in this way.",
 				fr: "Défaussez jusqu'à 2 cartes Énergie de votre main. Cette attaque inflige 60 dégâts pour chaque carte défaussée de cette façon.",
-			},
-		},
+				es: "Descarta hasta 2 cartas de Energía de tu mano, y este ataque hace 60 puntos de daño por cada carta que hayas descartado de esta manera.",
+				de: "Lege bis zu 2 Energiekarten aus deiner Hand auf deinen Ablagestapel, und diese Attacke fügt für jede auf diese Weise abgelegte Karte 60 Schadenspunkte zu.",
+				it: "Scarta fino a due carte Energia dalla tua mano e questo attacco infligge 60 danni per ogni carta che hai scartato in questo modo.",
+				pt: "Descarte até 2 cartas de Energia da sua mão, e este ataque causa 60 pontos de dano para cada carta descartada desta forma."
+			}
+		}
 	],
 	weaknesses: [
 		{
 			type: "Metal",
-			value: "×2",
-		},
+			value: "×2"
+		}
 	],
 	retreat: 2,
 	regulationMark: "J",
 	illustrator: "OKACHEKE",
-
+	variants: [
+		{
+			type: "normal"
+		},
+		{
+			type: "reverse"
+		}
+	],
 	thirdParty: {
+		tcgplayer: 684416,
 		cardmarket: 877446
 	}
 }

--- a/data/Mega Evolution/Perfect Order/033.ts
+++ b/data/Mega Evolution/Perfect Order/033.ts
@@ -3,52 +3,86 @@ import Set from '../Perfect Order'
 
 const card: Card = {
 	name: {
+		en: "Espurr",
 		fr: "Psystigri",
+		es: "Espurr",
+		de: "Psiau",
+		it: "Espurr",
+		pt: "Espurr"
 	},
 	set: Set,
 	rarity: "Common",
 	category: "Pokemon",
+	dexId: [
+		677
+	],
 	hp: 60,
+	types: [
+		"Psychic"
+	],
 	stage: "Basic",
 	attacks: [
 		{
 			cost: [
-				"Colorless",
+				"Colorless"
 			],
 			name: {
+				en: "Nap",
 				fr: "Tit'Sieste",
+				es: "Siesta",
+				de: "Nickerchen",
+				it: "Pausa",
+				pt: "Soneca"
 			},
 			effect: {
+				en: "Heal 20 damage from this Pokémon.",
 				fr: "Soignez 20 dégâts de ce Pokémon.",
-			},
+				es: "Cura 20 puntos de daño a este Pokémon.",
+				de: "Heile 20 Schadenspunkte bei diesem Pokémon.",
+				it: "Cura questo Pokémon da 20 danni.",
+				pt: "Cure 20 pontos de dano deste Pokémon."
+			}
 		},
 		{
 			cost: [
-				"Psychic",
+				"Psychic"
 			],
 			name: {
+				en: "Stampede",
 				fr: "Ruée",
+				es: "Estampida",
+				de: "Zertrampeln",
+				it: "Fuggi Fuggi",
+				pt: "Estouro"
 			},
-			damage: "10",
-		},
+			damage: "10"
+		}
 	],
 	weaknesses: [
 		{
 			type: "Darkness",
-			value: "×2",
-		},
+			value: "×2"
+		}
 	],
 	resistances: [
 		{
 			type: "Fighting",
-			value: "-30",
-		},
+			value: "-30"
+		}
 	],
 	retreat: 1,
 	regulationMark: "J",
 	illustrator: "Terada Tera",
-
+	variants: [
+		{
+			type: "normal"
+		},
+		{
+			type: "reverse"
+		}
+	],
 	thirdParty: {
+		tcgplayer: 684417,
 		cardmarket: 877447
 	}
 }

--- a/data/Mega Evolution/Perfect Order/034.ts
+++ b/data/Mega Evolution/Perfect Order/034.ts
@@ -3,58 +3,102 @@ import Set from '../Perfect Order'
 
 const card: Card = {
 	name: {
+		en: "Meowstic",
 		fr: "Mistigrix",
+		es: "Meowstic",
+		de: "Psiaugon",
+		it: "Meowstic",
+		pt: "Meowstic"
 	},
 	set: Set,
 	rarity: "Uncommon",
 	category: "Pokemon",
+	dexId: [
+		678
+	],
 	hp: 100,
+	types: [
+		"Psychic"
+	],
 	stage: "Stage1",
 	evolveFrom: {
+		en: "Espurr",
 		fr: "Psystigri",
+		es: "Espurr",
+		de: "Psiau",
+		it: "Espurr",
+		pt: "Espurr"
 	},
 	attacks: [
 		{
 			cost: [
-				"Psychic",
+				"Psychic"
 			],
 			name: {
+				en: "Perplex",
 				fr: "Affolement",
+				es: "Desconcierto",
+				de: "Perplex",
+				it: "Sconcerto",
+				pt: "Perplexo"
 			},
 			effect: {
+				en: "Your opponent's Active Pokémon is now Confused.",
 				fr: "Le Pokémon Actif de votre adversaire est maintenant Confus.",
-			},
+				es: "El Pokémon Activo de tu rival pasa a estar Confundido.",
+				de: "Das Aktive Pokémon deines Gegners ist jetzt verwirrt.",
+				it: "Il Pokémon attivo del tuo avversario viene confuso.",
+				pt: "O Pokémon Ativo do seu oponente agora está Confuso."
+			}
 		},
 		{
 			cost: [
-				"Psychic",
+				"Psychic"
 			],
 			name: {
+				en: "Psychic",
 				fr: "Psyko",
+				es: "Psíquico",
+				de: "Psychokinese",
+				it: "Psichico",
+				pt: "Psíquico"
 			},
 			damage: "30+",
 			effect: {
+				en: "This attack does 30 more damage for each Energy attached to your opponent's Active Pokémon.",
 				fr: "Cette attaque inflige 30 dégâts supplémentaires pour chaque Énergie attachée au Pokémon Actif de votre adversaire.",
-			},
-		},
+				es: "Este ataque hace 30 puntos de daño más por cada Energía unida al Pokémon Activo de tu rival.",
+				de: "Diese Attacke fügt für jede an das Aktive Pokémon deines Gegners angelegte Energie 30 Schadenspunkte mehr zu.",
+				it: "Questo attacco infligge 30 danni in più per ogni Energia assegnata al Pokémon attivo del tuo avversario.",
+				pt: "Este ataque causa 30 pontos de dano a mais para cada Energia ligada ao Pokémon Ativo do seu oponente."
+			}
+		}
 	],
 	weaknesses: [
 		{
 			type: "Darkness",
-			value: "×2",
-		},
+			value: "×2"
+		}
 	],
 	resistances: [
 		{
 			type: "Fighting",
-			value: "-30",
-		},
+			value: "-30"
+		}
 	],
 	retreat: 1,
 	regulationMark: "J",
 	illustrator: "Kannnu",
-
+	variants: [
+		{
+			type: "normal"
+		},
+		{
+			type: "reverse"
+		}
+	],
 	thirdParty: {
+		tcgplayer: 684419,
 		cardmarket: 877448
 	}
 }

--- a/data/Mega Evolution/Perfect Order/035.ts
+++ b/data/Mega Evolution/Perfect Order/035.ts
@@ -3,46 +3,80 @@ import Set from '../Perfect Order'
 
 const card: Card = {
 	name: {
+		en: "Spritzee",
 		fr: "Fluvetin",
+		es: "Spritzee",
+		de: "Parfi",
+		it: "Spritzee",
+		pt: "Spritzee"
 	},
 	set: Set,
 	rarity: "Common",
 	category: "Pokemon",
+	dexId: [
+		682
+	],
 	hp: 70,
+	types: [
+		"Psychic"
+	],
 	stage: "Basic",
 	attacks: [
 		{
 			cost: [
-				"Colorless",
+				"Colorless"
 			],
 			name: {
+				en: "Sweet Scent",
 				fr: "Doux Parfum",
+				es: "Dulce Aroma",
+				de: "Lockduft",
+				it: "Profumino",
+				pt: "Aroma Doce"
 			},
 			effect: {
+				en: "Heal 30 damage from 1 of your Pokémon.",
 				fr: "Soignez 30 dégâts de l'un de vos Pokémon.",
-			},
+				es: "Cura 30 puntos de daño a uno de tus Pokémon.",
+				de: "Heile 30 Schadenspunkte bei 1 deiner Pokémon.",
+				it: "Cura uno dei tuoi Pokémon da 30 danni.",
+				pt: "Cure 30 pontos de dano de 1 dos seus Pokémon."
+			}
 		},
 		{
 			cost: [
-				"Psychic",
+				"Psychic"
 			],
 			name: {
+				en: "Ram",
 				fr: "Collision",
+				es: "Apisonar",
+				de: "Ramme",
+				it: "Carica",
+				pt: "Aríete"
 			},
-			damage: "10",
-		},
+			damage: "10"
+		}
 	],
 	weaknesses: [
 		{
 			type: "Metal",
-			value: "×2",
-		},
+			value: "×2"
+		}
 	],
 	retreat: 1,
 	regulationMark: "J",
 	illustrator: "Pani Kobayashi",
-
+	variants: [
+		{
+			type: "reverse"
+		},
+		{
+			type: "normal"
+		}
+	],
 	thirdParty: {
+		tcgplayer: 684420,
 		cardmarket: 877449
 	}
 }

--- a/data/Mega Evolution/Perfect Order/036.ts
+++ b/data/Mega Evolution/Perfect Order/036.ts
@@ -3,53 +3,97 @@ import Set from '../Perfect Order'
 
 const card: Card = {
 	name: {
+		en: "Aromatisse",
 		fr: "Cocotine",
+		es: "Aromatisse",
+		de: "Parfinesse",
+		it: "Aromatisse",
+		pt: "Aromatisse"
 	},
 	set: Set,
 	rarity: "Uncommon",
 	category: "Pokemon",
+	dexId: [
+		683
+	],
 	hp: 120,
+	types: [
+		"Psychic"
+	],
 	stage: "Stage1",
 	evolveFrom: {
+		en: "Spritzee",
 		fr: "Fluvetin",
+		es: "Spritzee",
+		de: "Parfi",
+		it: "Spritzee",
+		pt: "Spritzee"
 	},
 	abilities: [
 		{
 			type: "Ability",
 			name: {
+				en: "Scent Collection",
 				fr: "Collection de Parfums",
+				es: "Colección Aromática",
+				de: "Dufte Sammlung",
+				it: "Aromaraccolta",
+				pt: "Perfumaria"
 			},
 			effect: {
-				fr: "Une fois pendant votre tour, vous pouvez utiliser ce talent. Cherchez dans votre deck jusqu'à 2 cartes Énergie Psy de base, montrez-les, puis ajoutez-les à votre main. Mélangez ensuite votre deck.",
-			},
-		},
+				en: "Once during your turn, you may use this Ability. Search your deck for up to 2 Basic [P] Energy cards, reveal them, and put them into your hand. Then, shuffle your deck.",
+				fr: "Une fois pendant votre tour, vous pouvez utiliser ce talent. Cherchez dans votre deck jusqu'à 2 cartes Énergie [P] de base, montrez-les, puis ajoutez-les à votre main. Mélangez ensuite votre deck.",
+				es: "Una vez durante tu turno, puedes usar esta habilidad. Busca en tu baraja hasta 2 cartas de Energía [P] Básica, enséñalas y ponlas en tu mano. Después, baraja las cartas de tu baraja.",
+				de: "Einmal während deines Zuges kannst du diese Fähigkeit einsetzen. Durchsuche dein Deck nach bis zu 2 Basis-[P]-Energiekarten, zeige sie deinem Gegner und nimm sie auf deine Hand. Mische anschließend dein Deck.",
+				it: "Una sola volta durante il tuo turno, puoi usare questa abilità. Cerca nel tuo mazzo fino a due carte Energia base [P], mostrale e aggiungile alle carte che hai in mano. Poi rimischia il tuo mazzo.",
+				pt: "Uma vez durante o seu turno, você poderá usar esta Habilidade. Procure por até 2 cartas de Energia [P] Básica no seu baralho, revele-as e coloque-as na sua mão. Em seguida, embaralhe o seu baralho."
+			}
+		}
 	],
 	attacks: [
 		{
 			cost: [
 				"Psychic",
-				"Colorless",
+				"Colorless"
 			],
 			name: {
+				en: "Draining Kiss",
 				fr: "Vampibaiser",
+				es: "Beso Drenaje",
+				de: "Diebeskuss",
+				it: "Assorbibacio",
+				pt: "Beijo Drenante"
 			},
 			damage: "50",
 			effect: {
+				en: "Heal 30 damage from this Pokémon.",
 				fr: "Soignez 30 dégâts de ce Pokémon.",
-			},
-		},
+				es: "Cura 30 puntos de daño a este Pokémon.",
+				de: "Heile 30 Schadenspunkte bei diesem Pokémon.",
+				it: "Cura questo Pokémon da 30 danni.",
+				pt: "Cure 30 pontos de dano deste Pokémon."
+			}
+		}
 	],
 	weaknesses: [
 		{
 			type: "Metal",
-			value: "×2",
-		},
+			value: "×2"
+		}
 	],
 	retreat: 1,
 	regulationMark: "J",
 	illustrator: "Mori Yuu",
-
+	variants: [
+		{
+			type: "normal"
+		},
+		{
+			type: "reverse"
+		}
+	],
 	thirdParty: {
+		tcgplayer: 684421,
 		cardmarket: 877450
 	}
 }

--- a/data/Mega Evolution/Perfect Order/037.ts
+++ b/data/Mega Evolution/Perfect Order/037.ts
@@ -3,36 +3,60 @@ import Set from '../Perfect Order'
 
 const card: Card = {
 	name: {
+		en: "Nosepass",
 		fr: "Tarinor",
+		es: "Nosepass",
+		de: "Nasgnet",
+		it: "Nosepass",
+		pt: "Nosepass"
 	},
 	set: Set,
 	rarity: "Common",
 	category: "Pokemon",
+	dexId: [
+		299
+	],
 	hp: 90,
+	types: [
+		"Fighting"
+	],
 	stage: "Basic",
 	attacks: [
 		{
 			cost: [
 				"Fighting",
-				"Fighting",
+				"Fighting"
 			],
 			name: {
+				en: "Rolling Rocks",
 				fr: "Rochers Roulants",
+				es: "Rocas Rodantes",
+				de: "Rollende Steine",
+				it: "Massi Rotolanti",
+				pt: "Pedras Rolantes"
 			},
-			damage: "40",
-		},
+			damage: "40"
+		}
 	],
 	weaknesses: [
 		{
 			type: "Grass",
-			value: "×2",
-		},
+			value: "×2"
+		}
 	],
 	retreat: 3,
 	regulationMark: "J",
 	illustrator: "Jerky",
-
+	variants: [
+		{
+			type: "normal"
+		},
+		{
+			type: "reverse"
+		}
+	],
 	thirdParty: {
+		tcgplayer: 684422,
 		cardmarket: 877451
 	}
 }

--- a/data/Mega Evolution/Perfect Order/038.ts
+++ b/data/Mega Evolution/Perfect Order/038.ts
@@ -3,54 +3,94 @@ import Set from '../Perfect Order'
 
 const card: Card = {
 	name: {
+		en: "Probopass",
 		fr: "Tarinorme",
+		es: "Probopass",
+		de: "Voluminas",
+		it: "Probopass",
+		pt: "Probopass"
 	},
 	set: Set,
 	rarity: "Common",
 	category: "Pokemon",
+	dexId: [
+		476
+	],
 	hp: 140,
+	types: [
+		"Fighting"
+	],
 	stage: "Stage1",
 	evolveFrom: {
+		en: "Nosepass",
 		fr: "Tarinor",
+		es: "Nosepass",
+		"es-mx": "Nosepass",
+		de: "Nasgnet",
+		it: "Nosepass",
+		pt: "Nosepass"
 	},
 	attacks: [
 		{
 			cost: [
 				"Fighting",
-				"Fighting",
+				"Fighting"
 			],
 			name: {
+				en: "Rolling Rocks",
 				fr: "Rochers Roulants",
+				es: "Rocas Rodantes",
+				de: "Rollende Steine",
+				it: "Massi Rotolanti",
+				pt: "Pedras Rolantes"
 			},
-			damage: "60",
+			damage: "60"
 		},
 		{
 			cost: [
 				"Fighting",
 				"Fighting",
 				"Fighting",
-				"Colorless",
+				"Colorless"
 			],
 			name: {
+				en: "Obliterating Nose",
 				fr: "Nez Destructeur",
+				es: "Nariz Destructora",
+				de: "Niederstreckende Nase",
+				it: "Naso Devastante",
+				pt: "Obliteração Nasal"
 			},
 			damage: "260",
 			effect: {
+				en: "Discard 3 Energy from this Pokémon.",
 				fr: "Défaussez 3 Énergies de ce Pokémon.",
-			},
-		},
+				es: "Descarta 3 Energías de este Pokémon.",
+				de: "Lege 3 Energien von diesem Pokémon auf deinen Ablagestapel.",
+				it: "Scarta tre Energie da questo Pokémon.",
+				pt: "Descarte 3 Energias deste Pokémon."
+			}
+		}
 	],
 	weaknesses: [
 		{
 			type: "Grass",
-			value: "×2",
-		},
+			value: "×2"
+		}
 	],
 	retreat: 3,
 	regulationMark: "J",
 	illustrator: "Nurikabe",
-
+	variants: [
+		{
+			type: "normal"
+		},
+		{
+			type: "reverse"
+		}
+	],
 	thirdParty: {
+		tcgplayer: 684423,
 		cardmarket: 877452
 	}
 }

--- a/data/Mega Evolution/Perfect Order/039.ts
+++ b/data/Mega Evolution/Perfect Order/039.ts
@@ -3,49 +3,83 @@ import Set from '../Perfect Order'
 
 const card: Card = {
 	name: {
+		en: "Hippopotas",
 		fr: "Hippopotas",
+		es: "Hippopotas",
+		de: "Hippopotas",
+		it: "Hippopotas",
+		pt: "Hippopotas"
 	},
 	set: Set,
 	rarity: "Common",
 	category: "Pokemon",
+	dexId: [
+		449
+	],
 	hp: 100,
+	types: [
+		"Fighting"
+	],
 	stage: "Basic",
 	attacks: [
 		{
 			cost: [
-				"Fighting",
+				"Fighting"
 			],
 			name: {
+				en: "Sand Attack",
 				fr: "Jet de Sable",
+				es: "Ataque Arena",
+				de: "Sandwirbel",
+				it: "Turbosabbia",
+				pt: "Ataque de Areia"
 			},
 			damage: "10",
 			effect: {
+				en: "During your opponent's next turn, if the Defending Pokémon tries to use an attack, your opponent flips a coin. If tails, that attack doesn't happen.",
 				fr: "Pendant le prochain tour de votre adversaire, si le Pokémon Défenseur essaie d'utiliser une attaque, votre adversaire lance une pièce. Si c'est pile, l'attaque n'est pas lancée.",
-			},
+				es: "Durante el próximo turno de tu rival, si el Pokémon Defensor intenta usar un ataque, tu rival lanza 1 moneda. Si sale cruz, ese ataque no se lleva a cabo.",
+				de: "Wenn das Verteidigende Pokémon während des nächsten Zuges deines Gegners versucht, eine Attacke einzusetzen, wirft dein Gegner 1 Münze. Bei Zahl wird jene Attacke nicht ausgeführt.",
+				it: "Durante il prossimo turno del tuo avversario, se il Pokémon difensore prova a usare un attacco, il tuo avversario lancia una moneta. Se esce croce, quell'attacco non ha luogo.",
+				pt: "Durante o próximo turno do seu oponente, se o Pokémon Defensor tentar usar um ataque, seu oponente jogará uma moeda. Se sair coroa, aquele ataque não acontecerá."
+			}
 		},
 		{
 			cost: [
 				"Fighting",
 				"Colorless",
-				"Colorless",
+				"Colorless"
 			],
 			name: {
+				en: "Bite",
 				fr: "Morsure",
+				es: "Mordisco",
+				de: "Biss",
+				it: "Morso",
+				pt: "Mordida"
 			},
-			damage: "60",
-		},
+			damage: "60"
+		}
 	],
 	weaknesses: [
 		{
 			type: "Grass",
-			value: "×2",
-		},
+			value: "×2"
+		}
 	],
 	retreat: 4,
 	regulationMark: "J",
 	illustrator: "Kagemaru Himeno",
-
+	variants: [
+		{
+			type: "reverse"
+		},
+		{
+			type: "normal"
+		}
+	],
 	thirdParty: {
+		tcgplayer: 684425,
 		cardmarket: 877453
 	}
 }

--- a/data/Mega Evolution/Perfect Order/040.ts
+++ b/data/Mega Evolution/Perfect Order/040.ts
@@ -3,55 +3,95 @@ import Set from '../Perfect Order'
 
 const card: Card = {
 	name: {
+		en: "Hippowdon",
 		fr: "Hippodocus",
+		es: "Hippowdon",
+		de: "Hippoterus",
+		it: "Hippowdon",
+		pt: "Hippowdon"
 	},
 	set: Set,
 	rarity: "Uncommon",
 	category: "Pokemon",
+	dexId: [
+		450
+	],
 	hp: 150,
+	types: [
+		"Fighting"
+	],
 	stage: "Stage1",
 	evolveFrom: {
+		en: "Hippopotas",
 		fr: "Hippopotas",
+		es: "Hippopotas",
+		"es-mx": "Hippopotas",
+		de: "Hippopotas",
+		it: "Hippopotas",
+		pt: "Hippopotas"
 	},
 	attacks: [
 		{
 			cost: [
 				"Fighting",
 				"Fighting",
-				"Colorless",
+				"Colorless"
 			],
 			name: {
+				en: "Twister Spewing",
 				fr: "Projection de Tornades",
+				es: "Tornado Regurgitante",
+				de: "Wirbelspeier",
+				it: "Espellivortice",
+				pt: "Lança Tornado"
 			},
 			damage: "80",
 			effect: {
+				en: "If you played Tarragon from your hand during this turn, discard the top 3 cards of your opponent's deck.",
 				fr: "Si vous avez joué Taragon de votre main pendant ce tour, défaussez les 3 cartes du dessus du deck de votre adversaire.",
-			},
+				es: "Si has jugado Estragón de tu mano durante este turno, descarta las 3 primeras cartas de la baraja de tu rival.",
+				de: "Wenn du Tarragon während dieses Zuges aus deiner Hand gespielt hast, lege die obersten 3 Karten des Decks deines Gegners auf seinen Ablagestapel.",
+				it: "Se hai giocato Tarragon dalla tua mano durante questo turno, scarta le prime tre carte del mazzo del tuo avversario.",
+				pt: "Se você jogou Tarragon da sua mão durante este turno, descarte as 3 cartas de cima do baralho do seu oponente."
+			}
 		},
 		{
 			cost: [
 				"Fighting",
 				"Fighting",
 				"Colorless",
-				"Colorless",
+				"Colorless"
 			],
 			name: {
+				en: "Heavy Impact",
 				fr: "Gros Impact",
+				es: "Impacto Pesado",
+				de: "Schwerer Einschlag",
+				it: "Impatto Pesante",
+				pt: "Impacto Pesado"
 			},
-			damage: "130",
-		},
+			damage: "130"
+		}
 	],
 	weaknesses: [
 		{
 			type: "Grass",
-			value: "×2",
-		},
+			value: "×2"
+		}
 	],
 	retreat: 4,
 	regulationMark: "J",
 	illustrator: "Souichirou Gunjima",
-
+	variants: [
+		{
+			type: "reverse"
+		},
+		{
+			type: "normal"
+		}
+	],
 	thirdParty: {
+		tcgplayer: 684426,
 		cardmarket: 877454
 	}
 }

--- a/data/Mega Evolution/Perfect Order/041.ts
+++ b/data/Mega Evolution/Perfect Order/041.ts
@@ -3,53 +3,92 @@ import Set from '../Perfect Order'
 
 const card: Card = {
 	name: {
+		en: "Landorus",
 		fr: "Démétéros",
+		es: "Landorus",
+		de: "Demeteros",
+		it: "Landorus",
+		pt: "Landorus"
 	},
 	set: Set,
 	rarity: "Rare",
 	category: "Pokemon",
+	dexId: [
+		645
+	],
 	hp: 120,
+	types: [
+		"Fighting"
+	],
 	stage: "Basic",
 	attacks: [
 		{
 			cost: [
 				"Fighting",
-				"Fighting",
+				"Fighting"
 			],
 			name: {
+				en: "Rock Tumble",
 				fr: "Roule-Pierre",
+				es: "Avalancha de Rocas",
+				de: "Rollende Felsen",
+				it: "Tiramassi",
+				pt: "Desabamento de Pedras"
 			},
 			damage: "50",
 			effect: {
+				en: "This attack's damage isn't affected by Resistance.",
 				fr: "Les dégâts de cette attaque ne sont pas affectés par la Résistance.",
-			},
+				es: "El daño de este ataque no se ve afectado por Resistencia.",
+				de: "Der Schaden dieser Attacke wird durch Resistenz nicht verändert.",
+				it: "I danni di questo attacco non sono influenzati dalla resistenza.",
+				pt: "O dano deste ataque não é afetado por Resistência."
+			}
 		},
 		{
 			cost: [
 				"Fighting",
 				"Fighting",
-				"Colorless",
+				"Colorless"
 			],
 			name: {
+				en: "Screw Knuckle",
 				fr: "Poing Vis",
+				es: "Nudillo Tornillo",
+				de: "Windende Faust",
+				it: "Avvitapugno",
+				pt: "Punho Parafuso"
 			},
 			damage: "120",
 			effect: {
+				en: "Put an Energy attached to this Pokémon into your hand.",
 				fr: "Ajoutez à votre main une Énergie attachée à ce Pokémon.",
-			},
-		},
+				es: "Pon 1 Energía unida a este Pokémon en tu mano.",
+				de: "Nimm 1 an dieses Pokémon angelegte Energie auf deine Hand.",
+				it: "Prendi un'Energia assegnata a questo Pokémon e aggiungila alle carte che hai in mano.",
+				pt: "Coloque uma Energia ligada a este Pokémon na sua mão."
+			}
+		}
 	],
 	weaknesses: [
 		{
 			type: "Grass",
-			value: "×2",
-		},
+			value: "×2"
+		}
 	],
 	retreat: 1,
 	regulationMark: "J",
 	illustrator: "aoki",
-
+	variants: [
+		{
+			type: "holo"
+		},
+		{
+			type: "reverse"
+		}
+	],
 	thirdParty: {
+		tcgplayer: 684427,
 		cardmarket: 877455
 	}
 }

--- a/data/Mega Evolution/Perfect Order/042.ts
+++ b/data/Mega Evolution/Perfect Order/042.ts
@@ -3,47 +3,81 @@ import Set from '../Perfect Order'
 
 const card: Card = {
 	name: {
+		en: "Binacle",
 		fr: "Opermine",
+		es: "Binacle",
+		de: "Bithora",
+		it: "Binacle",
+		pt: "Binacle"
 	},
 	set: Set,
 	rarity: "Common",
 	category: "Pokemon",
+	dexId: [
+		688
+	],
 	hp: 80,
+	types: [
+		"Fighting"
+	],
 	stage: "Basic",
 	attacks: [
 		{
 			cost: [
-				"Fighting",
+				"Fighting"
 			],
 			name: {
+				en: "Double Draw",
 				fr: "Double Pioche",
+				es: "Roba Doble",
+				de: "Zweifachzug",
+				it: "Pescata Doppia",
+				pt: "Compra Dupla"
 			},
 			effect: {
+				en: "Draw 2 cards.",
 				fr: "Piochez 2 cartes.",
-			},
+				es: "Roba 2 cartas.",
+				de: "Ziehe 2 Karten.",
+				it: "Pesca due carte.",
+				pt: "Compre 2 cartas."
+			}
 		},
 		{
 			cost: [
 				"Fighting",
-				"Fighting",
+				"Fighting"
 			],
 			name: {
+				en: "Scratch",
 				fr: "Griffe",
+				es: "Arañazo",
+				de: "Kratzer",
+				it: "Graffio",
+				pt: "Arranhão"
 			},
-			damage: "30",
-		},
+			damage: "30"
+		}
 	],
 	weaknesses: [
 		{
 			type: "Grass",
-			value: "×2",
-		},
+			value: "×2"
+		}
 	],
 	retreat: 2,
 	regulationMark: "J",
 	illustrator: "nagimiso",
-
+	variants: [
+		{
+			type: "reverse"
+		},
+		{
+			type: "normal"
+		}
+	],
 	thirdParty: {
+		tcgplayer: 684334,
 		cardmarket: 877456
 	}
 }

--- a/data/Mega Evolution/Perfect Order/043.ts
+++ b/data/Mega Evolution/Perfect Order/043.ts
@@ -3,51 +3,90 @@ import Set from '../Perfect Order'
 
 const card: Card = {
 	name: {
+		en: "Barbaracle",
 		fr: "Golgopathe",
+		es: "Barbaracle",
+		de: "Thanathora",
+		it: "Barbaracle",
+		pt: "Barbaracle"
 	},
 	set: Set,
 	rarity: "Uncommon",
 	category: "Pokemon",
+	dexId: [
+		689
+	],
 	hp: 130,
+	types: [
+		"Fighting"
+	],
 	stage: "Stage1",
 	evolveFrom: {
+		en: "Binacle",
 		fr: "Opermine",
+		es: "Binacle",
+		de: "Bithora",
+		it: "Binacle",
+		pt: "Binacle"
 	},
 	abilities: [
 		{
 			type: "Ability",
 			name: {
+				en: "Stone Arms",
 				fr: "Bras de Pierre",
+				es: "Brazos de Piedra",
+				de: "Arme aus Stein",
+				it: "Braccia di Pietra",
+				pt: "Braços de Pedra"
 			},
 			effect: {
-				fr: "Une fois pendant votre tour, vous pouvez utiliser ce talent. Attachez une carte Énergie Combat de base de votre main à l'un de vos Pokémon Combat.",
-			},
-		},
+				en: "Once during your turn, you may use this Ability. Attach a Basic [F] Energy card from your hand to 1 of your [F] Pokémon.",
+				fr: "Une fois pendant votre tour, vous pouvez utiliser ce talent. Attachez une carte Énergie [F] de base de votre main à l'un de vos Pokémon [F].",
+				es: "Una vez durante tu turno, puedes usar esta habilidad. Une 1 carta de Energía [F] Básica de tu mano a uno de tus Pokémon [F].",
+				de: "Einmal während deines Zuges kannst du diese Fähigkeit einsetzen. Lege 1 Basis-[F]-Energiekarte aus deiner Hand an 1 deiner [F]-Pokémon an.",
+				it: "Una sola volta durante il tuo turno, puoi usare questa abilità. Assegna a uno dei tuoi Pokémon [F] una carta Energia base [F] dalla tua mano.",
+				pt: "Uma vez durante o seu turno, você poderá usar esta Habilidade. Ligue uma carta de Energia [F] Básica da sua mão a 1 dos seus Pokémon [F]."
+			}
+		}
 	],
 	attacks: [
 		{
 			cost: [
 				"Fighting",
 				"Fighting",
-				"Colorless",
+				"Colorless"
 			],
 			name: {
+				en: "Hammer In",
 				fr: "Enfoncement",
+				es: "Martillear",
+				de: "Einhämmern",
+				it: "Martello",
+				pt: "Martelada"
 			},
-			damage: "80",
-		},
+			damage: "80"
+		}
 	],
 	weaknesses: [
 		{
 			type: "Grass",
-			value: "×2",
-		},
+			value: "×2"
+		}
 	],
 	retreat: 2,
 	regulationMark: "J",
 	illustrator: "Kazumasa Yasukuni",
-
+	variants: [
+		{
+			type: "reverse"
+		},
+		{
+			type: "normal"
+		}
+	],
 	thirdParty: {
+		tcgplayer: 684335,
 		cardmarket: 877457
 	}
 }

--- a/data/Mega Evolution/Perfect Order/044.ts
+++ b/data/Mega Evolution/Perfect Order/044.ts
@@ -3,42 +3,76 @@ import Set from '../Perfect Order'
 
 const card: Card = {
 	name: {
+		en: "Tyrunt",
 		fr: "Ptyranidur",
+		es: "Tyrunt",
+		de: "Balgoras",
+		it: "Tyrunt",
+		pt: "Tyrunt"
 	},
 	set: Set,
 	rarity: "Common",
 	category: "Pokemon",
+	dexId: [
+		696
+	],
 	hp: 100,
+	types: [
+		"Fighting"
+	],
 	stage: "Stage1",
 	evolveFrom: {
+		en: "Antique Jaw Fossil",
 		fr: "Fossile Mâchoire Ancien",
+		es: "Fósil Mandíbula Antiguo",
+		de: "Antikes Kieferfossil",
+		it: "Vecchio Fossilmascella",
+		pt: "Fóssil de Mandíbula Arcaico"
 	},
 	attacks: [
 		{
 			cost: [
 				"Fighting",
-				"Colorless",
+				"Colorless"
 			],
 			name: {
+				en: "Get Angry",
 				fr: "Coléreux",
+				es: "Enfadarse",
+				de: "Rotsehen",
+				it: "Tutte le Furie",
+				pt: "Dar Piti"
 			},
 			damage: "20×",
 			effect: {
+				en: "This attack does 20 damage for each damage counter on this Pokémon.",
 				fr: "Cette attaque inflige 20 dégâts pour chaque marqueur de dégâts sur ce Pokémon.",
-			},
-		},
+				es: "Este ataque hace 20 puntos de daño por cada contador de daño en este Pokémon.",
+				de: "Diese Attacke fügt für jede Schadensmarke auf diesem Pokémon 20 Schadenspunkte zu.",
+				it: "Questo attacco infligge 20 danni per ogni segnalino danno presente su questo Pokémon.",
+				pt: "Este ataque causa 20 pontos de dano para cada contador de dano neste Pokémon."
+			}
+		}
 	],
 	weaknesses: [
 		{
 			type: "Grass",
-			value: "×2",
-		},
+			value: "×2"
+		}
 	],
 	retreat: 3,
 	regulationMark: "J",
 	illustrator: "Tomoki Sone",
-
+	variants: [
+		{
+			type: "reverse"
+		},
+		{
+			type: "normal"
+		}
+	],
 	thirdParty: {
+		tcgplayer: 684358,
 		cardmarket: 877458
 	}
 }

--- a/data/Mega Evolution/Perfect Order/045.ts
+++ b/data/Mega Evolution/Perfect Order/045.ts
@@ -3,53 +3,97 @@ import Set from '../Perfect Order'
 
 const card: Card = {
 	name: {
+		en: "Tyrantrum",
 		fr: "Rexillius",
+		es: "Tyrantrum",
+		de: "Monargoras",
+		it: "Tyrantrum",
+		pt: "Tyrantrum"
 	},
 	set: Set,
 	rarity: "Rare",
 	category: "Pokemon",
+	dexId: [
+		697
+	],
 	hp: 180,
+	types: [
+		"Fighting"
+	],
 	stage: "Stage2",
 	evolveFrom: {
+		en: "Tyrunt",
 		fr: "Ptyranidur",
+		es: "Tyrunt",
+		de: "Balgoras",
+		it: "Tyrunt",
+		pt: "Tyrunt"
 	},
 	abilities: [
 		{
 			type: "Ability",
 			name: {
+				en: "Tyrannically Gutsy",
 				fr: "Tyrannie Musclée",
+				es: "Coraje Tiránico",
+				de: "Tyrannische Tapferkeit",
+				it: "Baldanza Tirannica",
+				pt: "Tenacidade Tirânica"
 			},
 			effect: {
+				en: "If this Pokémon has any Special Energy attached, it gets +150 HP.",
 				fr: "Si au moins une Énergie spéciale est attachée à ce Pokémon, il a +150 PV.",
-			},
-		},
+				es: "Si este Pokémon tiene alguna Energía Especial unida, obtiene 150 PS más.",
+				de: "Wenn an dieses Pokémon mindestens 1 Spezial-Energie angelegt ist, erhält es +150 KP.",
+				it: "Se questo Pokémon ha delle Energie speciali assegnate, ha 150 PS in più.",
+				pt: "Se este Pokémon tiver alguma Energia Especial ligada a ele, receberá +150 PS."
+			}
+		}
 	],
 	attacks: [
 		{
 			cost: [
 				"Fighting",
-				"Colorless",
+				"Colorless"
 			],
 			name: {
+				en: "Wreak Havoc",
 				fr: "Ravages",
+				es: "Sembrar el Caos",
+				de: "Chaos anrichten",
+				it: "Scombussolare",
+				pt: "Causar Estragos"
 			},
 			damage: "160",
 			effect: {
+				en: "Flip a coin until you get tails. For each heads, discard the top card of your opponent's deck.",
 				fr: "Lancez une pièce jusqu'à obtenir un côté pile. Pour chaque côté face, défaussez la carte du dessus du deck de votre adversaire.",
-			},
-		},
+				es: "Lanza 1 moneda hasta que salga cruz. Por cada cara, descarta la primera carta de la baraja de tu rival.",
+				de: "Wirf so lange 1 Münze, bis sie Zahl zeigt. Lege pro Kopf die oberste Karte des Decks deines Gegners auf seinen Ablagestapel.",
+				it: "Lancia una moneta finché non esce croce. Ogni volta che esce testa, scarta la prima carta del mazzo del tuo avversario.",
+				pt: "Jogue uma moeda até sair coroa. Para cada cara, descarte a carta de cima do baralho do seu oponente."
+			}
+		}
 	],
 	weaknesses: [
 		{
 			type: "Grass",
-			value: "×2",
-		},
+			value: "×2"
+		}
 	],
 	retreat: 3,
 	regulationMark: "J",
 	illustrator: "Dsuke",
-
+	variants: [
+		{
+			type: "reverse"
+		},
+		{
+			type: "holo"
+		}
+	],
 	thirdParty: {
+		tcgplayer: 684359,
 		cardmarket: 877459
 	}
 }

--- a/data/Mega Evolution/Perfect Order/046.ts
+++ b/data/Mega Evolution/Perfect Order/046.ts
@@ -3,37 +3,66 @@ import Set from '../Perfect Order'
 
 const card: Card = {
 	name: {
+		en: "Hawlucha",
 		fr: "Brutalibré",
+		es: "Hawlucha",
+		de: "Resladero",
+		it: "Hawlucha",
+		pt: "Hawlucha"
 	},
 	set: Set,
 	rarity: "Common",
 	category: "Pokemon",
+	dexId: [
+		701
+	],
 	hp: 70,
+	types: [
+		"Fighting"
+	],
 	stage: "Basic",
 	attacks: [
 		{
 			cost: [
-				"Fighting",
+				"Fighting"
 			],
 			name: {
+				en: "Vengeful Kick",
 				fr: "Coup de Pied Vengeur",
+				es: "Patada Vengativa",
+				de: "Rachekick",
+				it: "Calcio Vendicativo",
+				pt: "Chute Vingativo"
 			},
 			damage: "30+",
 			effect: {
+				en: "If your Benched Pokémon have any damage counters on them, this attack does 60 more damage.",
 				fr: "Si au moins un marqueur de dégâts est placé sur vos Pokémon de Banc, cette attaque inflige 60 dégâts supplémentaires.",
-			},
-		},
+				es: "Si tus Pokémon en Banca tienen algún contador de daño sobre ellos, este ataque hace 60 puntos de daño más.",
+				de: "Wenn auf den Pokémon auf deiner Bank mindestens 1 Schadensmarke liegt, fügt diese Attacke 60 Schadenspunkte mehr zu.",
+				it: "Se i Pokémon nella tua panchina hanno dei segnalini danno, questo attacco infligge 60 danni in più.",
+				pt: "Se os seus Pokémon no Banco tiverem algum contador de dano neles, este ataque causará 60 pontos de dano a mais."
+			}
+		}
 	],
 	weaknesses: [
 		{
 			type: "Psychic",
-			value: "×2",
-		},
+			value: "×2"
+		}
 	],
 	regulationMark: "J",
 	illustrator: "osare",
-
+	variants: [
+		{
+			type: "normal"
+		},
+		{
+			type: "reverse"
+		}
+	],
 	thirdParty: {
+		tcgplayer: 684428,
 		cardmarket: 877460
 	}
 }

--- a/data/Mega Evolution/Perfect Order/047.ts
+++ b/data/Mega Evolution/Perfect Order/047.ts
@@ -3,27 +3,48 @@ import Set from '../Perfect Order'
 
 const card: Card = {
 	name: {
+		en: "Mega Zygarde ex",
 		fr: "Méga-Zygarde-ex",
+		es: "Mega-Zygarde ex",
+		de: "Mega-Zygarde-ex",
+		it: "Mega Zygarde-ex",
+		pt: "Mega Zygarde ex"
 	},
 	set: Set,
 	rarity: "Double rare",
 	category: "Pokemon",
+	dexId: [
+		718
+	],
 	hp: 310,
+	types: [
+		"Fighting"
+	],
 	stage: "Basic",
 	attacks: [
 		{
 			cost: [
 				"Fighting",
 				"Fighting",
-				"Fighting",
+				"Fighting"
 			],
 			name: {
+				en: "Gaia Wave",
 				fr: "Onde de Gaïa",
+				es: "Onda Gaia",
+				de: "Gaia-Welle",
+				it: "Onda Gaia",
+				pt: "Onda de Gaia"
 			},
 			damage: "200",
 			effect: {
+				en: "During your opponent's next turn, this Pokémon takes 30 less damage from attacks (after applying Weakness and Resistance).",
 				fr: "Pendant le prochain tour de votre adversaire, ce Pokémon subit 30 dégâts de moins provenant des attaques (après application de la Faiblesse et de la Résistance).",
-			},
+				es: "Durante el próximo turno de tu rival, los ataques hacen 30 puntos de daño menos a este Pokémon (después de aplicar Debilidad y Resistencia).",
+				de: "Während des nächsten Zuges deines Gegners werden diesem Pokémon durch Attacken 30 Schadenspunkte weniger zugefügt (nachdem Schwäche und Resistenz verrechnet wurden).",
+				it: "Durante il prossimo turno del tuo avversario, questo Pokémon subisce 30 danni in meno dagli attacchi, dopo aver applicato debolezza e resistenza.",
+				pt: "Durante o próximo turno do seu oponente, este Pokémon receberá 30 pontos de dano a menos de ataques (depois de aplicar Fraqueza e Resistência)."
+			}
 		},
 		{
 			cost: [
@@ -31,27 +52,42 @@ const card: Card = {
 				"Fighting",
 				"Fighting",
 				"Fighting",
-				"Fighting",
+				"Fighting"
 			],
 			name: {
+				en: "Nullifying Zero",
 				fr: "Zéro Annihilant",
+				es: "Cero Devastador",
+				de: "Tilgendes Nichts",
+				it: "Tabula Zero",
+				pt: "Zero Anulador"
 			},
 			effect: {
+				en: "For each of your opponent's Pokémon, flip a coin. If heads, this attack does 150 damage to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)",
 				fr: "Pour chacun des Pokémon de votre adversaire, lancez une pièce. Si c'est face, cette attaque inflige 150 dégâts à ce Pokémon-là. (N'appliquez ni la Faiblesse ni la Résistance aux Pokémon de Banc.)",
-			},
-		},
+				es: "Por cada uno de los Pokémon de tu rival, lanza 1 moneda. Si sale cara, este ataque hace 150 puntos de daño a ese Pokémon. (No apliques Debilidad y Resistencia a los Pokémon en Banca).",
+				de: "Wirf für jedes Pokémon deines Gegners 1 Münze. Bei Kopf fügt diese Attacke jenem Pokémon 150 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)",
+				it: "Per ciascuno dei Pokémon del tuo avversario, lancia una moneta. Se esce testa, questo attacco infligge 150 danni a quel Pokémon. Non applicare debolezza e resistenza ai Pokémon in panchina.",
+				pt: "Para cada um dos Pokémon do seu oponente, jogue uma moeda. Se sair cara, este ataque causará 150 pontos de dano àquele Pokémon. (Não aplique Fraqueza e Resistência aos Pokémon no Banco.)"
+			}
+		}
 	],
 	weaknesses: [
 		{
 			type: "Grass",
-			value: "×2",
-		},
+			value: "×2"
+		}
 	],
 	retreat: 2,
 	regulationMark: "J",
 	illustrator: "takuyoa",
-
+	variants: [
+		{
+			type: "holo"
+		}
+	],
 	thirdParty: {
+		tcgplayer: 684336,
 		cardmarket: 877461
 	}
 }

--- a/data/Mega Evolution/Perfect Order/048.ts
+++ b/data/Mega Evolution/Perfect Order/048.ts
@@ -3,38 +3,67 @@ import Set from '../Perfect Order'
 
 const card: Card = {
 	name: {
+		en: "Gastly",
 		fr: "Fantominus",
+		es: "Gastly",
+		de: "Nebulak",
+		it: "Gastly",
+		pt: "Gastly"
 	},
 	set: Set,
 	rarity: "Common",
 	category: "Pokemon",
+	dexId: [
+		92
+	],
 	hp: 70,
+	types: [
+		"Darkness"
+	],
 	stage: "Basic",
 	attacks: [
 		{
 			cost: [
-				"Darkness",
+				"Darkness"
 			],
 			name: {
+				en: "Surprise Attack",
 				fr: "Attaque Surprise",
+				es: "Ataque Sorpresa",
+				de: "Überraschungsangriff",
+				it: "Attacco a Sorpresa",
+				pt: "Ataque Surpresa"
 			},
 			damage: "30",
 			effect: {
+				en: "Flip a coin. If tails, this attack does nothing.",
 				fr: "Lancez une pièce. Si c'est pile, cette attaque ne fait rien.",
-			},
-		},
+				es: "Lanza 1 moneda. Si sale cruz, este ataque no hace nada.",
+				de: "Wirf 1 Münze. Bei Zahl hat diese Attacke keine Auswirkungen.",
+				it: "Lancia una moneta. Se esce croce, questo attacco non ha effetto.",
+				pt: "Jogue uma moeda. Se sair coroa, este ataque não fará nada."
+			}
+		}
 	],
 	weaknesses: [
 		{
 			type: "Fighting",
-			value: "×2",
-		},
+			value: "×2"
+		}
 	],
 	retreat: 1,
 	regulationMark: "J",
 	illustrator: "MARINA Chikazawa",
-
+	variants: [
+		{
+			type: "normal"
+		},
+		{
+			type: "reverse"
+		}
+	],
 	thirdParty: {
+		tcgplayer: 684429,
 		cardmarket: 877463
 	}
 }

--- a/data/Mega Evolution/Perfect Order/049.ts
+++ b/data/Mega Evolution/Perfect Order/049.ts
@@ -3,40 +3,75 @@ import Set from '../Perfect Order'
 
 const card: Card = {
 	name: {
+		en: "Haunter",
 		fr: "Spectrum",
+		es: "Haunter",
+		de: "Alpollo",
+		it: "Haunter",
+		pt: "Haunter"
 	},
 	set: Set,
 	rarity: "Common",
 	category: "Pokemon",
+	dexId: [
+		93
+	],
 	hp: 100,
+	types: [
+		"Darkness"
+	],
 	stage: "Stage1",
 	evolveFrom: {
+		en: "Gastly",
 		fr: "Fantominus",
+		es: "Gastly",
+		"es-mx": "Gastly",
+		de: "Nebulak",
+		it: "Gastly",
+		pt: "Gastly"
 	},
 	attacks: [
 		{
 			cost: [
-				"Darkness",
+				"Darkness"
 			],
 			name: {
+				en: "Haunt",
 				fr: "Hanter",
+				es: "Espanto",
+				de: "Spuk",
+				it: "Infestare",
+				pt: "Assombrar"
 			},
 			effect: {
+				en: "Place 3 damage counters on your opponent's Active Pokémon.",
 				fr: "Placez 3 marqueurs de dégâts sur le Pokémon Actif de votre adversaire.",
-			},
-		},
+				es: "Pon 3 contadores de daño en el Pokémon Activo de tu rival.",
+				de: "Lege 3 Schadensmarken auf das Aktive Pokémon deines Gegners.",
+				it: "Metti tre segnalini danno sul Pokémon attivo del tuo avversario.",
+				pt: "Coloque 3 contadores de dano no Pokémon Ativo do seu oponente."
+			}
+		}
 	],
 	weaknesses: [
 		{
 			type: "Fighting",
-			value: "×2",
-		},
+			value: "×2"
+		}
 	],
 	retreat: 1,
 	regulationMark: "J",
 	illustrator: "Kedamahadaitai Yawarakai",
-
+	variants: [
+		{
+			type: "reverse"
+		},
+		{
+			type: "normal"
+		}
+	],
 	thirdParty: {
+		tcgplayer: 684430,
 		cardmarket: 877464
 	}
 }

--- a/data/Mega Evolution/Perfect Order/050.ts
+++ b/data/Mega Evolution/Perfect Order/050.ts
@@ -3,52 +3,97 @@ import Set from '../Perfect Order'
 
 const card: Card = {
 	name: {
+		en: "Gengar",
 		fr: "Ectoplasma",
+		es: "Gengar",
+		de: "Gengar",
+		it: "Gengar",
+		pt: "Gengar"
 	},
 	set: Set,
 	rarity: "Rare",
 	category: "Pokemon",
+	dexId: [
+		94
+	],
 	hp: 130,
+	types: [
+		"Darkness"
+	],
 	stage: "Stage2",
 	evolveFrom: {
+		en: "Haunter",
 		fr: "Spectrum",
+		es: "Haunter",
+		"es-mx": "Haunter",
+		de: "Alpollo",
+		it: "Haunter",
+		pt: "Haunter"
 	},
 	abilities: [
 		{
 			type: "Ability",
 			name: {
+				en: "Infinite Shadow",
 				fr: "Ombre Infinie",
+				es: "Sombra Infinita",
+				de: "Ewiger Schatten",
+				it: "Ombra Infinita",
+				pt: "Sombra Infinita"
 			},
 			effect: {
+				en: "If this Pokémon is Knocked Out by damage from an attack from your opponent's Pokémon, put it into your hand instead of the discard pile. (Discard all attached cards.)",
 				fr: "Si ce Pokémon est mis K.O. par les dégâts d'une attaque de l'un des Pokémon de votre adversaire, ajoutez-le à votre main plutôt que de le placer dans la pile de défausse. (Défaussez toutes les cartes attachées.)",
-			},
-		},
+				es: "Si este Pokémon queda Fuera de Combate por el daño de un ataque de los Pokémon de tu rival, ponlo en tu mano en vez de en la pila de descartes. (Descarta todas las cartas unidas a él).",
+				de: "Wenn dieses Pokémon durch Schaden einer Attacke von Pokémon deines Gegners kampfunfähig wird, nimm es auf deine Hand, anstatt es auf deinen Ablagestapel zu legen. (Lege alle angelegten Karten auf deinen Ablagestapel.)",
+				it: "Se questo Pokémon viene messo KO dai danni inflitti da un attacco di un Pokémon del tuo avversario, aggiungilo alle carte che hai in mano invece di metterlo nella pila degli scarti. Scarta tutte le carte assegnate.",
+				pt: "Se este Pokémon for Nocauteado pelo dano de um ataque dos Pokémon do seu oponente, coloque-o na sua mão em vez da pilha de descarte. (Descarte todas as cartas ligadas a ele.)"
+			}
+		}
 	],
 	attacks: [
 		{
 			cost: [
-				"Darkness",
+				"Darkness"
 			],
 			name: {
+				en: "Mind Jack",
 				fr: "Emprise Mentale",
+				es: "Levantamente",
+				de: "Gedankenstoß",
+				it: "Sollevamente",
+				pt: "Tomada Mental"
 			},
 			damage: "10+",
 			effect: {
+				en: "This attack does 30 more damage for each of your opponent's Benched Pokémon.",
 				fr: "Cette attaque inflige 30 dégâts supplémentaires pour chacun des Pokémon de Banc de votre adversaire.",
-			},
-		},
+				es: "Este ataque hace 30 puntos de daño más por cada uno de los Pokémon en Banca de tu rival.",
+				de: "Diese Attacke fügt für jedes Pokémon auf der Bank deines Gegners 30 Schadenspunkte mehr zu.",
+				it: "Questo attacco infligge 30 danni in più per ogni Pokémon nella panchina del tuo avversario.",
+				pt: "Este ataque causa 30 pontos de dano a mais para cada Pokémon no Banco do seu oponente."
+			}
+		}
 	],
 	weaknesses: [
 		{
 			type: "Fighting",
-			value: "×2",
-		},
+			value: "×2"
+		}
 	],
 	retreat: 1,
 	regulationMark: "J",
 	illustrator: "Masako Tomii",
-
+	variants: [
+		{
+			type: "reverse"
+		},
+		{
+			type: "holo"
+		}
+	],
 	thirdParty: {
+		tcgplayer: 684431,
 		cardmarket: 877465
 	}
 }

--- a/data/Mega Evolution/Perfect Order/051.ts
+++ b/data/Mega Evolution/Perfect Order/051.ts
@@ -3,39 +3,68 @@ import Set from '../Perfect Order'
 
 const card: Card = {
 	name: {
+		en: "Skorupi",
 		fr: "Rapion",
+		es: "Skorupi",
+		de: "Pionskora",
+		it: "Skorupi",
+		pt: "Skorupi"
 	},
 	set: Set,
 	rarity: "Common",
 	category: "Pokemon",
+	dexId: [
+		451
+	],
 	hp: 80,
+	types: [
+		"Darkness"
+	],
 	stage: "Basic",
 	attacks: [
 		{
 			cost: [
 				"Darkness",
-				"Darkness",
+				"Darkness"
 			],
 			name: {
+				en: "Poison Jab",
 				fr: "Direct Toxik",
+				es: "Puya Nociva",
+				de: "Gifthieb",
+				it: "Velenpuntura",
+				pt: "Golpe Envenenado"
 			},
 			damage: "20",
 			effect: {
+				en: "Your opponent's Active Pokémon is now Poisoned.",
 				fr: "Le Pokémon Actif de votre adversaire est maintenant Empoisonné.",
-			},
-		},
+				es: "El Pokémon Activo de tu rival pasa a estar Envenenado.",
+				de: "Das Aktive Pokémon deines Gegners ist jetzt vergiftet.",
+				it: "Il Pokémon attivo del tuo avversario viene avvelenato.",
+				pt: "O Pokémon Ativo do seu oponente agora está Envenenado."
+			}
+		}
 	],
 	weaknesses: [
 		{
 			type: "Fighting",
-			value: "×2",
-		},
+			value: "×2"
+		}
 	],
 	retreat: 2,
 	regulationMark: "J",
 	illustrator: "Aya Kusube",
-
+	variants: [
+		{
+			type: "normal"
+		},
+		{
+			type: "reverse"
+		}
+	],
 	thirdParty: {
+		tcgplayer: 684432,
 		cardmarket: 877467
 	}
 }

--- a/data/Mega Evolution/Perfect Order/052.ts
+++ b/data/Mega Evolution/Perfect Order/052.ts
@@ -3,53 +3,92 @@ import Set from '../Perfect Order'
 
 const card: Card = {
 	name: {
+		en: "Drapion",
 		fr: "Drascore",
+		es: "Drapion",
+		de: "Piondragi",
+		it: "Drapion",
+		pt: "Drapion"
 	},
 	set: Set,
 	rarity: "Uncommon",
 	category: "Pokemon",
+	dexId: [
+		452
+	],
 	hp: 140,
+	types: [
+		"Darkness"
+	],
 	stage: "Stage1",
 	evolveFrom: {
+		en: "Skorupi",
 		fr: "Rapion",
+		es: "Skorupi",
+		de: "Pionskora",
+		it: "Skorupi",
+		pt: "Skorupi"
 	},
 	attacks: [
 		{
 			cost: [
 				"Darkness",
-				"Darkness",
+				"Darkness"
 			],
 			name: {
+				en: "Wrack Down",
 				fr: "Réduire en Poussière",
+				es: "Desmoronar",
+				de: "Niederschleudern",
+				it: "Abbattere",
+				pt: "Desmoronar"
 			},
-			damage: "60",
+			damage: "60"
 		},
 		{
 			cost: [
 				"Darkness",
 				"Darkness",
-				"Darkness",
+				"Darkness"
 			],
 			name: {
+				en: "Hazardous Tail",
 				fr: "Queue Nocive",
+				es: "Cola Nociva",
+				de: "Bedrohlicher Schweif",
+				it: "Coda Insidiosa",
+				pt: "Cauda Periculosa"
 			},
 			damage: "100",
 			effect: {
+				en: "This Pokémon also does 70 damage to itself. Your opponent's Active Pokémon is now Paralyzed and Poisoned.",
 				fr: "Ce Pokémon s'inflige aussi 70 dégâts. Le Pokémon Actif de votre adversaire est maintenant Paralysé et Empoisonné.",
-			},
-		},
+				es: "Este Pokémon también se hace 70 puntos de daño a sí mismo. El Pokémon Activo de tu rival pasa a estar Envenenado y Paralizado.",
+				de: "Dieses Pokémon fügt auch sich selbst 70 Schadenspunkte zu. Das Aktive Pokémon deines Gegners ist jetzt paralysiert und vergiftet.",
+				it: "Questo Pokémon infligge anche 70 danni a se stesso. Il Pokémon attivo del tuo avversario viene paralizzato e avvelenato.",
+				pt: "Este Pokémon também causa 70 pontos de dano a si mesmo. O Pokémon Ativo do seu oponente agora está Envenenado e Paralisado."
+			}
+		}
 	],
 	weaknesses: [
 		{
 			type: "Fighting",
-			value: "×2",
-		},
+			value: "×2"
+		}
 	],
 	retreat: 3,
 	regulationMark: "J",
 	illustrator: "Nelnal",
-
+	variants: [
+		{
+			type: "reverse"
+		},
+		{
+			type: "normal"
+		}
+	],
 	thirdParty: {
+		tcgplayer: 684433,
 		cardmarket: 877468
 	}
 }

--- a/data/Mega Evolution/Perfect Order/053.ts
+++ b/data/Mega Evolution/Perfect Order/053.ts
@@ -3,59 +3,95 @@ import Set from '../Perfect Order'
 
 const card: Card = {
 	name: {
+		en: "Yveltal ex",
 		fr: "Yveltal-ex",
+		es: "Yveltal ex",
+		de: "Yveltal-ex",
+		it: "Yveltal-ex",
+		pt: "Yveltal ex"
 	},
 	set: Set,
 	rarity: "Double rare",
 	category: "Pokemon",
+	dexId: [
+		717
+	],
 	hp: 210,
+	types: [
+		"Darkness"
+	],
 	stage: "Basic",
 	attacks: [
 		{
 			cost: [
 				"Darkness",
 				"Darkness",
-				"Colorless",
+				"Colorless"
 			],
 			name: {
+				en: "Soul Destroyer",
 				fr: "Destructeur d'Âmes",
+				es: "Destructor de Almas",
+				de: "Seelenvernichter",
+				it: "Distruggianima",
+				pt: "Destruidor de Almas"
 			},
 			effect: {
+				en: "Knock Out each of your opponent's Pokémon that has 50 HP or less remaining.",
 				fr: "Mettez K.O. chacun des Pokémon de votre adversaire auxquels il reste 50 PV ou moins.",
-			},
+				es: "Deja Fuera de Combate a cada uno de los Pokémon de tu rival a los que les queden 50 PS o menos.",
+				de: "Mache jedes Pokémon deines Gegners, das 50 oder weniger verbleibende KP hat, kampfunfähig.",
+				it: "Metti KO ciascuno dei Pokémon del tuo avversario che ha 50 PS o meno rimanenti.",
+				pt: "Nocauteie cada um dos Pokémon do seu oponente que tiver PS restante de 50 ou menos."
+			}
 		},
 		{
 			cost: [
 				"Darkness",
 				"Darkness",
-				"Colorless",
+				"Colorless"
 			],
 			name: {
+				en: "Dark Strike",
 				fr: "Frappe Ténébreuse",
+				es: "Golpe Siniestro",
+				de: "Finsterschlag",
+				it: "Colpo Ombra",
+				pt: "Golpe de Escuridão"
 			},
 			damage: "210",
 			effect: {
+				en: "During your next turn, this Pokémon can't use Dark Strike.",
 				fr: "Pendant votre prochain tour, ce Pokémon ne peut pas utiliser Frappe Ténébreuse.",
-			},
-		},
+				es: "Durante tu próximo turno, este Pokémon no puede usar Golpe Siniestro.",
+				de: "Während deines nächsten Zuges kann dieses Pokémon Finsterschlag nicht einsetzen.",
+				it: "Durante il tuo prossimo turno, questo Pokémon non può usare Colpo Ombra.",
+				pt: "Durante o seu próximo turno, este Pokémon não poderá usar Golpe de Escuridão."
+			}
+		}
 	],
 	weaknesses: [
 		{
 			type: "Lightning",
-			value: "×2",
-		},
+			value: "×2"
+		}
 	],
 	resistances: [
 		{
 			type: "Fighting",
-			value: "-30",
-		},
+			value: "-30"
+		}
 	],
 	retreat: 1,
 	regulationMark: "J",
 	illustrator: "5ban Graphics",
-
+	variants: [
+		{
+			type: "holo"
+		}
+	],
 	thirdParty: {
+		tcgplayer: 684386,
 		cardmarket: 877469
 	}
 }

--- a/data/Mega Evolution/Perfect Order/054.ts
+++ b/data/Mega Evolution/Perfect Order/054.ts
@@ -3,52 +3,91 @@ import Set from '../Perfect Order'
 
 const card: Card = {
 	name: {
+		en: "Chien-Pao",
 		fr: "Baojian",
+		es: "Chien-Pao",
+		de: "Baojian",
+		it: "Chien-Pao",
+		pt: "Chien-Pao"
 	},
 	set: Set,
 	rarity: "Rare",
 	category: "Pokemon",
+	dexId: [
+		1002
+	],
 	hp: 120,
+	types: [
+		"Darkness"
+	],
 	stage: "Basic",
 	attacks: [
 		{
 			cost: [
-				"Darkness",
+				"Darkness"
 			],
 			name: {
+				en: "Strafe",
 				fr: "Bombarder",
+				es: "Pasada de Ataque",
+				de: "Beharken",
+				it: "Mitragliare",
+				pt: "Bombardear"
 			},
 			damage: "20",
 			effect: {
+				en: "You may switch this Pokémon with 1 of your Benched Pokémon.",
 				fr: "Vous pouvez échanger ce Pokémon contre l'un de vos Pokémon de Banc.",
-			},
+				es: "Puedes cambiar este Pokémon por uno de tus Pokémon en Banca.",
+				de: "Du kannst dieses Pokémon gegen 1 Pokémon auf deiner Bank austauschen.",
+				it: "Puoi scambiare questo Pokémon con uno nella tua panchina.",
+				pt: "Você pode trocar este Pokémon por 1 dos seus Pokémon no Banco."
+			}
 		},
 		{
 			cost: [
 				"Darkness",
 				"Darkness",
-				"Colorless",
+				"Colorless"
 			],
 			name: {
+				en: "Rising Blade",
 				fr: "Lame Ascendante",
+				es: "Hoja Creciente",
+				de: "Aufwärtsklinge",
+				it: "Lama Ascendente",
+				pt: "Lâmina Crescente"
 			},
 			damage: "80+",
 			effect: {
+				en: "If your opponent's Active Pokémon is a Pokémon ex, this attack does 80 more damage.",
 				fr: "Si le Pokémon Actif de votre adversaire est un Pokémon-ex, cette attaque inflige 80 dégâts supplémentaires.",
-			},
-		},
+				es: "Si el Pokémon Activo de tu rival es un Pokémon ex, este ataque hace 80 puntos de daño más.",
+				de: "Wenn das Aktive Pokémon deines Gegners ein Pokémon-ex ist, fügt diese Attacke 80 Schadenspunkte mehr zu.",
+				it: "Se il Pokémon attivo del tuo avversario è un Pokémon-ex, questo attacco infligge 80 danni in più.",
+				pt: "Se o Pokémon Ativo do seu oponente for um Pokémon ex, este ataque causará 80 pontos de dano a mais."
+			}
+		}
 	],
 	weaknesses: [
 		{
 			type: "Grass",
-			value: "×2",
-		},
+			value: "×2"
+		}
 	],
 	retreat: 1,
 	regulationMark: "J",
 	illustrator: "Satoshi Ito",
-
+	variants: [
+		{
+			type: "holo"
+		},
+		{
+			type: "reverse"
+		}
+	],
 	thirdParty: {
+		tcgplayer: 684435,
 		cardmarket: 877470
 	}
 }

--- a/data/Mega Evolution/Perfect Order/055.ts
+++ b/data/Mega Evolution/Perfect Order/055.ts
@@ -3,44 +3,70 @@ import Set from '../Perfect Order'
 
 const card: Card = {
 	name: {
+		en: "Mega Skarmory ex",
 		fr: "Méga-Airmure-ex",
+		es: "Mega-Skarmory ex",
+		de: "Mega-Panzaeron-ex",
+		it: "Mega Skarmory-ex",
+		pt: "Mega Skarmory ex"
 	},
 	set: Set,
 	rarity: "Double rare",
 	category: "Pokemon",
+	dexId: [
+		227
+	],
 	hp: 260,
+	types: [
+		"Metal"
+	],
 	stage: "Basic",
 	attacks: [
 		{
 			cost: [
 				"Metal",
 				"Metal",
-				"Colorless",
+				"Colorless"
 			],
 			name: {
+				en: "Sonic Ripper",
 				fr: "Étripage Sonique",
+				es: "Desgarro Sónico",
+				de: "Überschallreißer",
+				it: "Squarcio Sonico",
+				pt: "Talho Sônico"
 			},
 			effect: {
+				en: "Shuffle all Energy attached to this Pokémon into your deck, and this attack does 220 damage to 1 of your opponent's Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)",
 				fr: "Mélangez toutes les Énergies attachées à ce Pokémon avec votre deck. Cette attaque inflige 220 dégâts à l'un des Pokémon de votre adversaire. (N'appliquez ni la Faiblesse ni la Résistance aux Pokémon de Banc.)",
-			},
-		},
+				es: "Pon todas las Energías unidas a este Pokémon en tu baraja y baraja todas las cartas, y este ataque hace 220 puntos de daño a uno de los Pokémon de tu rival. (No apliques Debilidad y Resistencia a los Pokémon en Banca).",
+				de: "Mische alle an dieses Pokémon angelegten Energien in dein Deck, und diese Attacke fügt 1 Pokémon deines Gegners 220 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)",
+				it: "Rimischia tutte le Energie assegnate a questo Pokémon nel tuo mazzo e questo attacco infligge 220 danni a uno dei Pokémon del tuo avversario. Non applicare debolezza e resistenza ai Pokémon in panchina.",
+				pt: "Embaralhe todas as Energias ligadas a este Pokémon no seu baralho, e este ataque causa 220 pontos de dano a 1 dos Pokémon do seu oponente. (Não aplique Fraqueza e Resistência aos Pokémon no Banco.)"
+			}
+		}
 	],
 	weaknesses: [
 		{
 			type: "Lightning",
-			value: "×2",
-		},
+			value: "×2"
+		}
 	],
 	resistances: [
 		{
 			type: "Fighting",
-			value: "-30",
-		},
+			value: "-30"
+		}
 	],
 	regulationMark: "J",
 	illustrator: "5ban Graphics",
-
+	variants: [
+		{
+			type: "holo"
+		}
+	],
 	thirdParty: {
+		tcgplayer: 684351,
 		cardmarket: 877471
 	}
 }

--- a/data/Mega Evolution/Perfect Order/056.ts
+++ b/data/Mega Evolution/Perfect Order/056.ts
@@ -3,41 +3,65 @@ import Set from '../Perfect Order'
 
 const card: Card = {
 	name: {
+		en: "Honedge",
 		fr: "Monorpale",
+		es: "Honedge",
+		de: "Gramokles",
+		it: "Honedge",
+		pt: "Honedge"
 	},
 	set: Set,
 	rarity: "Common",
 	category: "Pokemon",
+	dexId: [
+		679
+	],
 	hp: 70,
+	types: [
+		"Metal"
+	],
 	stage: "Basic",
 	attacks: [
 		{
 			cost: [
-				"Colorless",
+				"Colorless"
 			],
 			name: {
+				en: "Cut",
 				fr: "Coupe",
+				es: "Corte",
+				de: "Zerschneider",
+				it: "Taglio",
+				pt: "Cortar"
 			},
-			damage: "10",
-		},
+			damage: "10"
+		}
 	],
 	weaknesses: [
 		{
 			type: "Fire",
-			value: "×2",
-		},
+			value: "×2"
+		}
 	],
 	resistances: [
 		{
 			type: "Grass",
-			value: "-30",
-		},
+			value: "-30"
+		}
 	],
 	retreat: 2,
 	regulationMark: "J",
 	illustrator: "Apios",
-
+	variants: [
+		{
+			type: "reverse"
+		},
+		{
+			type: "normal"
+		}
+	],
 	thirdParty: {
+		tcgplayer: 684378,
 		cardmarket: 877472
 	}
 }

--- a/data/Mega Evolution/Perfect Order/057.ts
+++ b/data/Mega Evolution/Perfect Order/057.ts
@@ -3,48 +3,82 @@ import Set from '../Perfect Order'
 
 const card: Card = {
 	name: {
+		en: "Doublade",
 		fr: "Dimoclès",
+		es: "Doublade",
+		de: "Duokles",
+		it: "Doublade",
+		pt: "Doublade"
 	},
 	set: Set,
 	rarity: "Common",
 	category: "Pokemon",
+	dexId: [
+		680
+	],
 	hp: 100,
+	types: [
+		"Metal"
+	],
 	stage: "Stage1",
 	evolveFrom: {
+		en: "Honedge",
 		fr: "Monorpale",
+		es: "Honedge",
+		de: "Gramokles",
+		it: "Honedge",
+		pt: "Honedge"
 	},
 	attacks: [
 		{
 			cost: [
 				"Colorless",
-				"Colorless",
+				"Colorless"
 			],
 			name: {
+				en: "Weaponized Swords",
 				fr: "Épées Armes",
+				es: "Espadas Pertrechadas",
+				de: "Kollektive Klingenkraft",
+				it: "Spade Belliche",
+				pt: "Espadas Armadas"
 			},
 			damage: "60×",
 			effect: {
+				en: "Reveal any number of Honedge, Doublade, and Aegislash from your hand, and this attack does 60 damage for each card you revealed in this way.",
 				fr: "Montrez le nombre voulu de Monorpale, de Dimoclès et d'Exagide de votre main. Cette attaque inflige 60 dégâts pour chaque carte montrée de cette façon.",
-			},
-		},
+				es: "Enseña cualquier cantidad de Honedge, Doublade y Aegislash de tu mano, y este ataque hace 60 puntos de daño por cada carta que hayas enseñado de esta manera.",
+				de: "Zeige deinem Gegner beliebig viele Gramokles, Duokles und Durengard auf deiner Hand, und diese Attacke fügt für jede auf diese Weise gezeigte Karte 60 Schadenspunkte zu.",
+				it: "Mostra un numero qualsiasi di Honedge, Doublade e Aegislash che hai in mano e questo attacco infligge 60 danni per ogni carta che hai mostrato in questo modo.",
+				pt: "Revele qualquer número de Honedge, Doublade e Aegislash na sua mão, e este ataque causa 60 pontos de dano para cada carta revelada desta forma."
+			}
+		}
 	],
 	weaknesses: [
 		{
 			type: "Fire",
-			value: "×2",
-		},
+			value: "×2"
+		}
 	],
 	resistances: [
 		{
 			type: "Grass",
-			value: "-30",
-		},
+			value: "-30"
+		}
 	],
 	retreat: 2,
 	regulationMark: "J",
 	illustrator: "Kamome Shirahama",
-
+	variants: [
+		{
+			type: "reverse"
+		},
+		{
+			type: "normal"
+		}
+	],
 	thirdParty: {
+		tcgplayer: 684379,
 		cardmarket: 877473
 	}
 }

--- a/data/Mega Evolution/Perfect Order/058.ts
+++ b/data/Mega Evolution/Perfect Order/058.ts
@@ -3,61 +3,100 @@ import Set from '../Perfect Order'
 
 const card: Card = {
 	name: {
+		en: "Aegislash",
 		fr: "Exagide",
+		es: "Aegislash",
+		de: "Durengard",
+		it: "Aegislash",
+		pt: "Aegislash"
 	},
 	set: Set,
 	rarity: "Uncommon",
 	category: "Pokemon",
+	dexId: [
+		681
+	],
 	hp: 150,
+	types: [
+		"Metal"
+	],
 	stage: "Stage2",
 	evolveFrom: {
+		en: "Doublade",
 		fr: "Dimoclès",
+		es: "Doublade",
+		de: "Duokles",
+		it: "Doublade",
+		pt: "Doublade"
 	},
 	attacks: [
 		{
 			cost: [
 				"Colorless",
 				"Colorless",
-				"Colorless",
+				"Colorless"
 			],
 			name: {
+				en: "Slash",
 				fr: "Tranche",
+				es: "Cuchillada",
+				de: "Schlitzer",
+				it: "Lacerazione",
+				pt: "Talho"
 			},
-			damage: "80",
+			damage: "80"
 		},
 		{
 			cost: [
 				"Metal",
 				"Colorless",
 				"Colorless",
-				"Colorless",
+				"Colorless"
 			],
 			name: {
+				en: "Metal Slash",
 				fr: "Tranche Métallique",
+				es: "Tajo Metálico",
+				de: "Metallschlitzer",
+				it: "Lacerametallo",
+				pt: "Talho de Metal"
 			},
 			damage: "230",
 			effect: {
+				en: "During your next turn, this Pokémon can't use attacks.",
 				fr: "Pendant votre prochain tour, ce Pokémon ne peut pas utiliser d'attaques.",
-			},
-		},
+				es: "Durante tu próximo turno, este Pokémon no puede usar ataques.",
+				de: "Während deines nächsten Zuges kann dieses Pokémon keine Attacken einsetzen.",
+				it: "Durante il tuo prossimo turno, questo Pokémon non può usare attacchi.",
+				pt: "Durante o seu próximo turno, este Pokémon não poderá usar ataques."
+			}
+		}
 	],
 	weaknesses: [
 		{
 			type: "Fire",
-			value: "×2",
-		},
+			value: "×2"
+		}
 	],
 	resistances: [
 		{
 			type: "Grass",
-			value: "-30",
-		},
+			value: "-30"
+		}
 	],
 	retreat: 3,
 	regulationMark: "J",
 	illustrator: "Mitsuhiro Arita",
-
+	variants: [
+		{
+			type: "reverse"
+		},
+		{
+			type: "normal"
+		}
+	],
 	thirdParty: {
+		tcgplayer: 684381,
 		cardmarket: 877474
 	}
 }

--- a/data/Mega Evolution/Perfect Order/059.ts
+++ b/data/Mega Evolution/Perfect Order/059.ts
@@ -3,44 +3,73 @@ import Set from '../Perfect Order'
 
 const card: Card = {
 	name: {
+		en: "Klefki",
 		fr: "Trousselin",
+		es: "Klefki",
+		de: "Clavion",
+		it: "Klefki",
+		pt: "Klefki"
 	},
 	set: Set,
 	rarity: "Common",
 	category: "Pokemon",
+	dexId: [
+		707
+	],
 	hp: 70,
+	types: [
+		"Metal"
+	],
 	stage: "Basic",
 	attacks: [
 		{
 			cost: [
-				"Metal",
+				"Metal"
 			],
 			name: {
+				en: "Memory Lock",
 				fr: "Verrou Mémoire",
+				es: "Bloqueo de Memoria",
+				de: "Gedächtnisschloss",
+				it: "Lucchetto Mnemonico",
+				pt: "Fechadura da Memória"
 			},
 			damage: "30",
 			effect: {
+				en: "Choose 1 of your opponent's Active Pokémon's attacks. During your opponent's next turn, that Pokémon can't use that attack.",
 				fr: "Choisissez l'une des attaques du Pokémon Actif de votre adversaire. Pendant le prochain tour de votre adversaire, ce Pokémon-là ne peut pas utiliser cette attaque.",
-			},
-		},
+				es: "Elige uno de los ataques del Pokémon Activo de tu rival. Durante el próximo turno de tu rival, dicho Pokémon no puede usar ese ataque.",
+				de: "Wähle 1 Attacke des Aktiven Pokémon deines Gegners. Während des nächsten Zuges deines Gegners kann jenes Pokémon jene Attacke nicht einsetzen.",
+				it: "Scegli un attacco del Pokémon attivo del tuo avversario. Durante il prossimo turno del tuo avversario, quel Pokémon non potrà utilizzarlo.",
+				pt: "Escolha 1 dos ataques do Pokémon Ativo do seu oponente. Durante o próximo turno do seu oponente, aquele Pokémon não poderá usar aquele ataque."
+			}
+		}
 	],
 	weaknesses: [
 		{
 			type: "Fire",
-			value: "×2",
-		},
+			value: "×2"
+		}
 	],
 	resistances: [
 		{
 			type: "Grass",
-			value: "-30",
-		},
+			value: "-30"
+		}
 	],
 	retreat: 1,
 	regulationMark: "J",
 	illustrator: "MINAMINAMI Take",
-
+	variants: [
+		{
+			type: "normal"
+		},
+		{
+			type: "reverse"
+		}
+	],
 	thirdParty: {
+		tcgplayer: 684436,
 		cardmarket: 877475
 	}
 }

--- a/data/Mega Evolution/Perfect Order/060.ts
+++ b/data/Mega Evolution/Perfect Order/060.ts
@@ -3,38 +3,67 @@ import Set from '../Perfect Order'
 
 const card: Card = {
 	name: {
+		en: "Rattata",
 		fr: "Rattata",
+		es: "Rattata",
+		de: "Rattfratz",
+		it: "Rattata",
+		pt: "Rattata"
 	},
 	set: Set,
 	rarity: "Common",
 	category: "Pokemon",
+	dexId: [
+		19
+	],
 	hp: 40,
+	types: [
+		"Colorless"
+	],
 	stage: "Basic",
 	attacks: [
 		{
 			cost: [
-				"Colorless",
+				"Colorless"
 			],
 			name: {
+				en: "Take Down",
 				fr: "Bélier",
+				es: "Derribo",
+				de: "Bodycheck",
+				it: "Riduttore",
+				pt: "Desmantelar"
 			},
 			damage: "30",
 			effect: {
+				en: "This Pokémon also does 10 damage to itself.",
 				fr: "Ce Pokémon s'inflige aussi 10 dégâts.",
-			},
-		},
+				es: "Este Pokémon también se hace 10 puntos de daño a sí mismo.",
+				de: "Dieses Pokémon fügt auch sich selbst 10 Schadenspunkte zu.",
+				it: "Questo Pokémon infligge anche 10 danni a se stesso.",
+				pt: "Este Pokémon também causa 10 pontos de dano a si mesmo."
+			}
+		}
 	],
 	weaknesses: [
 		{
 			type: "Fighting",
-			value: "×2",
-		},
+			value: "×2"
+		}
 	],
 	retreat: 1,
 	regulationMark: "J",
 	illustrator: "Shinya Komatsu",
-
+	variants: [
+		{
+			type: "reverse"
+		},
+		{
+			type: "normal"
+		}
+	],
 	thirdParty: {
+		tcgplayer: 684437,
 		cardmarket: 877476
 	}
 }

--- a/data/Mega Evolution/Perfect Order/061.ts
+++ b/data/Mega Evolution/Perfect Order/061.ts
@@ -3,53 +3,97 @@ import Set from '../Perfect Order'
 
 const card: Card = {
 	name: {
+		en: "Raticate",
 		fr: "Rattatac",
+		es: "Raticate",
+		de: "Rattikarl",
+		it: "Raticate",
+		pt: "Raticate"
 	},
 	set: Set,
 	rarity: "Uncommon",
 	category: "Pokemon",
+	dexId: [
+		20
+	],
 	hp: 90,
+	types: [
+		"Colorless"
+	],
 	stage: "Stage1",
 	evolveFrom: {
+		en: "Rattata",
 		fr: "Rattata",
+		es: "Rattata",
+		de: "Rattfratz",
+		it: "Rattata",
+		pt: "Rattata"
 	},
 	attacks: [
 		{
 			cost: [
-				"Colorless",
+				"Colorless"
 			],
 			name: {
+				en: "Scrape Off",
 				fr: "Racler",
+				es: "Raspadura",
+				de: "Wegkratzen",
+				it: "Raschiare",
+				pt: "Raspar o Tacho"
 			},
 			damage: "20",
 			effect: {
+				en: "Before doing damage, discard all Pokémon Tools from your opponent's Active Pokémon.",
 				fr: "Avant d'infliger des dégâts, défaussez tous les Outils Pokémon du Pokémon Actif de votre adversaire.",
-			},
+				es: "Antes de infligir daño, descarta todas las Herramientas Pokémon del Pokémon Activo de tu rival.",
+				de: "Bevor du Schaden zufügst, lege alle Pokémon-Ausrüstungen vom Aktiven Pokémon deines Gegners auf seinen Ablagestapel.",
+				it: "Prima di infliggere danni, scarta tutte le carte Oggetto Pokémon dal Pokémon attivo del tuo avversario.",
+				pt: "Antes de causar dano, descarte todas as Ferramentas Pokémon do Pokémon Ativo do seu oponente."
+			}
 		},
 		{
 			cost: [
-				"Colorless",
+				"Colorless"
 			],
 			name: {
+				en: "Retaliatory Incisors",
 				fr: "Incisives Vengeance",
+				es: "Incisivos Vengativos",
+				de: "Vergeltender Nager",
+				it: "Incisivi Ritorsivi",
+				pt: "Incisivos Retaliatórios"
 			},
 			damage: "40×",
 			effect: {
+				en: "This attack does 40 damage for each damage counter on all of your Benched Rattata.",
 				fr: "Cette attaque inflige 40 dégâts pour chaque marqueur de dégâts sur vos Rattata de Banc.",
-			},
-		},
+				es: "Este ataque hace 40 puntos de daño por cada contador de daño en cada uno de tus Rattata en Banca.",
+				de: "Diese Attacke fügt für jede Schadensmarke auf allen Rattfratz auf deiner Bank 40 Schadenspunkte zu.",
+				it: "Questo attacco infligge 40 danni per ogni segnalino danno presente sui Rattata nella tua panchina.",
+				pt: "Este ataque causa 40 pontos de dano para cada contador de dano em todos os seus Rattata no Banco."
+			}
+		}
 	],
 	weaknesses: [
 		{
 			type: "Fighting",
-			value: "×2",
-		},
+			value: "×2"
+		}
 	],
 	retreat: 1,
 	regulationMark: "J",
 	illustrator: "Minahamu",
-
+	variants: [
+		{
+			type: "normal"
+		},
+		{
+			type: "reverse"
+		}
+	],
 	thirdParty: {
+		tcgplayer: 684438,
 		cardmarket: 877477
 	}
 }

--- a/data/Mega Evolution/Perfect Order/062.ts
+++ b/data/Mega Evolution/Perfect Order/062.ts
@@ -3,51 +3,87 @@ import Set from '../Perfect Order'
 
 const card: Card = {
 	name: {
+		en: "Meowth ex",
 		fr: "Miaouss-ex",
+		es: "Meowth ex",
+		de: "Mauzi-ex",
+		it: "Meowth-ex",
+		pt: "Meowth ex"
 	},
 	set: Set,
 	rarity: "Double rare",
 	category: "Pokemon",
+	dexId: [
+		52
+	],
 	hp: 170,
+	types: [
+		"Colorless"
+	],
 	stage: "Basic",
 	abilities: [
 		{
 			type: "Ability",
 			name: {
+				en: "Last-Ditch Catch",
 				fr: "Prise Dernier Ressort",
+				es: "Captura a la Desesperada",
+				de: "Fang aus der Not",
+				it: "Cattura in Extremis",
+				pt: "Chance Final de Captura"
 			},
 			effect: {
+				en: "Once during your turn, when you play this Pokémon from your hand onto your Bench, you may use this Ability. Search your deck for a Supporter card, reveal it, and put it into your hand. Then, shuffle your deck. You can't use more than 1 Ability that has \"Last-Ditch\" in its name each turn.",
 				fr: "Une fois pendant votre tour, lorsque vous jouez ce Pokémon de votre main sur votre Banc, vous pouvez utiliser ce talent. Cherchez dans votre deck une carte Supporter, montrez-la, puis ajoutez-la à votre main. Mélangez ensuite votre deck. Vous ne pouvez utiliser qu'un talent ayant « Dernier Ressort » dans son nom par tour.",
-			},
-		},
+				es: "Una vez durante tu turno, cuando juegas este Pokémon de tu mano a tu Banca, puedes usar esta habilidad. Busca en tu baraja 1 carta de Partidario, enséñala y ponla en tu mano. Después, baraja las cartas de tu baraja. No puedes usar más de una habilidad que tenga \"a la Desesperada\" en su nombre en cada turno.",
+				de: "Einmal während deines Zuges, wenn du dieses Pokémon aus deiner Hand auf deine Bank spielst, kannst du diese Fähigkeit einsetzen. Durchsuche dein Deck nach 1 Unterstützerkarte, zeige sie deinem Gegner und nimm sie auf deine Hand. Mische anschließend dein Deck. Du kannst nur 1 Fähigkeit, bei der „aus der Not\" zum Namen gehört, pro Zug einsetzen.",
+				it: "Una sola volta durante il tuo turno, quando giochi questo Pokémon dalla tua mano e lo metti in panchina, puoi usare questa abilità. Cerca nel tuo mazzo una carta Aiuto, mostrala e aggiungila alle carte che hai in mano. Poi rimischia il tuo mazzo. Non puoi usare più di un'abilità che ha \"in Extremis\" nel nome per turno.",
+				pt: "Uma vez durante o seu turno, quando você jogar este Pokémon da sua mão para o seu Banco, você poderá usar esta Habilidade. Procure por uma carta de Apoiador no seu baralho, revele-a e coloque-a na sua mão. Em seguida, embaralhe o seu baralho. Você não pode usar mais de 1 Habilidade que tem \"Chance Final\" em seu nome por turno."
+			}
+		}
 	],
 	attacks: [
 		{
 			cost: [
 				"Colorless",
 				"Colorless",
-				"Colorless",
+				"Colorless"
 			],
 			name: {
+				en: "Tuck Tail",
 				fr: "Queue Repliée",
+				es: "Cola Asustadiza",
+				de: "Schweif einziehen",
+				it: "Ritiracoda",
+				pt: "Rabo Entre as Pernas"
 			},
 			damage: "60",
 			effect: {
+				en: "Put this Pokémon and all attached cards into your hand.",
 				fr: "Ajoutez à votre main ce Pokémon et toutes les cartes qui lui sont attachées.",
-			},
-		},
+				es: "Pon este Pokémon y todas las cartas unidas a él en tu mano.",
+				de: "Nimm dieses Pokémon und alle angelegten Karten auf deine Hand.",
+				it: "Riprendi in mano questo Pokémon e tutte le carte a esso assegnate.",
+				pt: "Coloque este Pokémon e todas as cartas ligadas a ele na sua mão."
+			}
+		}
 	],
 	weaknesses: [
 		{
 			type: "Fighting",
-			value: "×2",
-		},
+			value: "×2"
+		}
 	],
 	retreat: 1,
 	regulationMark: "J",
 	illustrator: "5ban Graphics",
-
+	variants: [
+		{
+			type: "holo"
+		}
+	],
 	thirdParty: {
+		tcgplayer: 684340,
 		cardmarket: 877478
 	}
 }

--- a/data/Mega Evolution/Perfect Order/063.ts
+++ b/data/Mega Evolution/Perfect Order/063.ts
@@ -3,52 +3,91 @@ import Set from '../Perfect Order'
 
 const card: Card = {
 	name: {
+		en: "Snorlax",
 		fr: "Ronflex",
+		es: "Snorlax",
+		de: "Relaxo",
+		it: "Snorlax",
+		pt: "Snorlax"
 	},
 	set: Set,
 	rarity: "Common",
 	category: "Pokemon",
+	dexId: [
+		143
+	],
 	hp: 160,
+	types: [
+		"Colorless"
+	],
 	stage: "Basic",
 	attacks: [
 		{
 			cost: [
-				"Colorless",
+				"Colorless"
 			],
 			name: {
+				en: "Gormandizer",
 				fr: "Vorace",
+				es: "Glotón",
+				de: "Schlemmermaul",
+				it: "Ghiottone",
+				pt: "Glutão"
 			},
 			effect: {
+				en: "Flip a coin until you get tails. Search your deck for an amount of Basic Energy up to the number of heads and attach it to this Pokémon. Then, shuffle your deck.",
 				fr: "Lancez une pièce jusqu'à obtenir un côté pile. Cherchez dans votre deck une quantité d'Énergies de base inférieure ou égale au nombre de côtés face obtenus, puis attachez celles-ci à ce Pokémon. Mélangez ensuite votre deck.",
-			},
+				es: "Lanza 1 moneda hasta que salga cruz. Busca en tu baraja una cantidad de Energías Básicas igual o inferior al número de caras que hayan salido y únelas a este Pokémon. Después, baraja las cartas de tu baraja.",
+				de: "Wirf so lange 1 Münze, bis sie Zahl zeigt. Durchsuche dein Deck nach bis zu so vielen Basis-Energien, wie du Kopf geworfen hast, und lege sie an dieses Pokémon an. Mische anschließend dein Deck.",
+				it: "Lancia una moneta finché non esce croce. Cerca nel tuo mazzo un numero di Energie base uguale o inferiore al numero di volte in cui è uscito testa e assegnale a questo Pokémon. Poi rimischia il tuo mazzo.",
+				pt: "Jogue uma moeda até sair coroa. Procure por uma quantidade de Energia Básica no seu baralho até o número de caras e ligue-as a este Pokémon. Em seguida, embaralhe o seu baralho."
+			}
 		},
 		{
 			cost: [
 				"Colorless",
 				"Colorless",
 				"Colorless",
-				"Colorless",
+				"Colorless"
 			],
 			name: {
+				en: "Collapse",
 				fr: "Effondrement",
+				es: "Colapso",
+				de: "Kollaps",
+				it: "Collassare",
+				pt: "Colapso"
 			},
 			damage: "160",
 			effect: {
+				en: "This Pokémon is now Asleep.",
 				fr: "Ce Pokémon est maintenant Endormi.",
-			},
-		},
+				es: "Este Pokémon pasa a estar Dormido.",
+				de: "Dieses Pokémon schläft jetzt.",
+				it: "Questo Pokémon viene addormentato.",
+				pt: "Este Pokémon agora está Adormecido."
+			}
+		}
 	],
 	weaknesses: [
 		{
 			type: "Fighting",
-			value: "×2",
-		},
+			value: "×2"
+		}
 	],
 	retreat: 4,
 	regulationMark: "J",
 	illustrator: "Toshinao Aoki",
-
+	variants: [
+		{
+			type: "reverse"
+		},
+		{
+			type: "normal"
+		}
+	],
 	thirdParty: {
+		tcgplayer: 684440,
 		cardmarket: 877479
 	}
 }

--- a/data/Mega Evolution/Perfect Order/064.ts
+++ b/data/Mega Evolution/Perfect Order/064.ts
@@ -3,35 +3,59 @@ import Set from '../Perfect Order'
 
 const card: Card = {
 	name: {
+		en: "Bunnelby",
 		fr: "Sapereau",
+		es: "Bunnelby",
+		de: "Scoppel",
+		it: "Bunnelby",
+		pt: "Bunnelby"
 	},
 	set: Set,
 	rarity: "Common",
 	category: "Pokemon",
+	dexId: [
+		659
+	],
 	hp: 70,
+	types: [
+		"Colorless"
+	],
 	stage: "Basic",
 	attacks: [
 		{
 			cost: [
-				"Colorless",
+				"Colorless"
 			],
 			name: {
+				en: "Smash Kick",
 				fr: "Coud'Pattes",
+				es: "Patada Destrucción",
+				de: "Schmetterkick",
+				it: "Calcio Esplosivo",
+				pt: "Chute Poderoso"
 			},
-			damage: "10",
-		},
+			damage: "10"
+		}
 	],
 	weaknesses: [
 		{
 			type: "Fighting",
-			value: "×2",
-		},
+			value: "×2"
+		}
 	],
 	retreat: 1,
 	regulationMark: "J",
 	illustrator: "MINAMINAMI Take",
-
+	variants: [
+		{
+			type: "reverse"
+		},
+		{
+			type: "normal"
+		}
+	],
 	thirdParty: {
+		tcgplayer: 684441,
 		cardmarket: 877480
 	}
 }

--- a/data/Mega Evolution/Perfect Order/065.ts
+++ b/data/Mega Evolution/Perfect Order/065.ts
@@ -3,52 +3,91 @@ import Set from '../Perfect Order'
 
 const card: Card = {
 	name: {
+		en: "Diggersby",
 		fr: "Excavarenne",
+		es: "Diggersby",
+		de: "Grebbit",
+		it: "Diggersby",
+		pt: "Diggersby"
 	},
 	set: Set,
 	rarity: "Uncommon",
 	category: "Pokemon",
+	dexId: [
+		660
+	],
 	hp: 150,
+	types: [
+		"Colorless"
+	],
 	stage: "Stage1",
 	evolveFrom: {
+		en: "Bunnelby",
 		fr: "Sapereau",
+		es: "Bunnelby",
+		de: "Scoppel",
+		it: "Bunnelby",
+		pt: "Bunnelby"
 	},
 	attacks: [
 		{
 			cost: [
-				"Colorless",
+				"Colorless"
 			],
 			name: {
+				en: "Earthquake",
 				fr: "Séisme",
+				es: "Terremoto",
+				de: "Erdbeben",
+				it: "Terremoto",
+				pt: "Terremoto"
 			},
 			damage: "140",
 			effect: {
+				en: "This attack also does 30 damage to each of your Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)",
 				fr: "Cette attaque inflige aussi 30 dégâts à chacun de vos Pokémon de Banc. (N'appliquez ni la Faiblesse ni la Résistance aux Pokémon de Banc.)",
-			},
+				es: "Este ataque también hace 30 puntos de daño a cada uno de tus Pokémon en Banca. (No apliques Debilidad y Resistencia a los Pokémon en Banca).",
+				de: "Diese Attacke fügt auch jedem Pokémon auf deiner Bank 30 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)",
+				it: "Questo attacco infligge anche 30 danni a ciascuno dei Pokémon nella tua panchina. Non applicare debolezza e resistenza ai Pokémon in panchina.",
+				pt: "Este ataque também causa 30 pontos de dano a cada um dos seus Pokémon no Banco. (Não aplique Fraqueza e Resistência aos Pokémon no Banco.)"
+			}
 		},
 		{
 			cost: [
 				"Colorless",
 				"Colorless",
-				"Colorless",
+				"Colorless"
 			],
 			name: {
+				en: "Whap Down",
 				fr: "Assommer",
+				es: "Zurrar",
+				de: "Verdreschen",
+				it: "Bastonata",
+				pt: "Golpe Ligeiro"
 			},
-			damage: "100",
-		},
+			damage: "100"
+		}
 	],
 	weaknesses: [
 		{
 			type: "Fighting",
-			value: "×2",
-		},
+			value: "×2"
+		}
 	],
 	retreat: 4,
 	regulationMark: "J",
 	illustrator: "Mousho",
-
+	variants: [
+		{
+			type: "normal"
+		},
+		{
+			type: "reverse"
+		}
+	],
 	thirdParty: {
+		tcgplayer: 684442,
 		cardmarket: 877481
 	}
 }

--- a/data/Mega Evolution/Perfect Order/066.ts
+++ b/data/Mega Evolution/Perfect Order/066.ts
@@ -3,53 +3,87 @@ import Set from '../Perfect Order'
 
 const card: Card = {
 	name: {
+		en: "Fletchling",
 		fr: "Passerouge",
+		es: "Fletchling",
+		de: "Dartiri",
+		it: "Fletchling",
+		pt: "Fletchling"
 	},
 	set: Set,
 	rarity: "Common",
 	category: "Pokemon",
+	dexId: [
+		661
+	],
 	hp: 60,
+	types: [
+		"Colorless"
+	],
 	stage: "Basic",
 	attacks: [
 		{
 			cost: [
-				"Colorless",
+				"Colorless"
 			],
 			name: {
+				en: "Chirp",
 				fr: "Gazouillis",
+				es: "Gorjeo",
+				de: "Zwitscherer",
+				it: "Cinguettio",
+				pt: "Gorjeio"
 			},
 			effect: {
-				fr: "Cherchez dans votre deck jusqu'à 2 Pokémon avec une Résistance à Combat, montrez-les, puis ajoutez-les à votre main. Mélangez ensuite votre deck.",
-			},
+				en: "Search your deck for up to 2 Pokémon with [F] Resistance, reveal them, and put them into your hand. Then, shuffle your deck.",
+				fr: "Cherchez dans votre deck jusqu'à 2 Pokémon avec une Résistance à [F], montrez-les, puis ajoutez-les à votre main. Mélangez ensuite votre deck.",
+				es: "Busca en tu baraja hasta 2 Pokémon con Resistencia a [F], enséñalos y ponlos en tu mano. Después, baraja las cartas de tu baraja.",
+				de: "Durchsuche dein Deck nach bis zu 2 Pokémon mit [F]-Resistenz, zeige sie deinem Gegner und nimm sie auf deine Hand. Mische anschließend dein Deck.",
+				it: "Cerca nel tuo mazzo fino a due Pokémon con resistenza al tipo [F], mostrali e aggiungili alle carte che hai in mano. Poi rimischia il tuo mazzo.",
+				pt: "Procure por até 2 Pokémon com Resistência [F] no seu baralho, revele-os e coloque-os na sua mão. Em seguida, embaralhe o seu baralho."
+			}
 		},
 		{
 			cost: [
 				"Colorless",
-				"Colorless",
+				"Colorless"
 			],
 			name: {
+				en: "Peck",
 				fr: "Picpic",
+				es: "Picotazo",
+				de: "Pikser",
+				it: "Beccata",
+				pt: "Bicada"
 			},
-			damage: "20",
-		},
+			damage: "20"
+		}
 	],
 	weaknesses: [
 		{
 			type: "Lightning",
-			value: "×2",
-		},
+			value: "×2"
+		}
 	],
 	resistances: [
 		{
 			type: "Fighting",
-			value: "-30",
-		},
+			value: "-30"
+		}
 	],
 	retreat: 1,
 	regulationMark: "J",
 	illustrator: "sowsow",
-
+	variants: [
+		{
+			type: "reverse"
+		},
+		{
+			type: "normal"
+		}
+	],
 	thirdParty: {
+		tcgplayer: 684403,
 		cardmarket: 877482
 	}
 }

--- a/data/Mega Evolution/Perfect Order/067.ts
+++ b/data/Mega Evolution/Perfect Order/067.ts
@@ -3,46 +3,80 @@ import Set from '../Perfect Order'
 
 const card: Card = {
 	name: {
+		en: "Furfrou",
 		fr: "Couafarel",
+		es: "Furfrou",
+		de: "Coiffwaff",
+		it: "Furfrou",
+		pt: "Furfrou"
 	},
 	set: Set,
 	rarity: "Common",
 	category: "Pokemon",
+	dexId: [
+		676
+	],
 	hp: 90,
+	types: [
+		"Colorless"
+	],
 	stage: "Basic",
 	attacks: [
 		{
 			cost: [
-				"Colorless",
+				"Colorless"
 			],
 			name: {
+				en: "Hand Trim",
 				fr: "Réduction de Main",
+				es: "Recorte de Mano",
+				de: "Handschnitt",
+				it: "Sfoltimano",
+				pt: "Tosa Manual"
 			},
 			effect: {
+				en: "Discard random cards from your opponent's hand until they have 5 cards in their hand.",
 				fr: "Défaussez au hasard des cartes de la main de votre adversaire jusqu'à ce qu'il reste 5 cartes dans sa main.",
-			},
+				es: "Descarta cartas aleatorias de la mano de tu rival hasta que tenga 5 cartas en su mano.",
+				de: "Lege so lange zufällige Karten aus der Hand deines Gegners auf seinen Ablagestapel, bis er 5 Karten auf seiner Hand hat.",
+				it: "Scarta delle carte a caso dalla mano del tuo avversario fino a lasciarlo con cinque carte in mano.",
+				pt: "Descarte cartas aleatórias da mão do seu oponente até que ele tenha 5 cartas na mão dele."
+			}
 		},
 		{
 			cost: [
-				"Colorless",
+				"Colorless"
 			],
 			name: {
+				en: "Headbutt",
 				fr: "Coup d'Boule",
+				es: "Golpe Cabeza",
+				de: "Kopfnuss",
+				it: "Bottintesta",
+				pt: "Cabeçada"
 			},
-			damage: "30",
-		},
+			damage: "30"
+		}
 	],
 	weaknesses: [
 		{
 			type: "Fighting",
-			value: "×2",
-		},
+			value: "×2"
+		}
 	],
 	retreat: 1,
 	regulationMark: "J",
 	illustrator: "Teeziro",
-
+	variants: [
+		{
+			type: "reverse"
+		},
+		{
+			type: "normal"
+		}
+	],
 	thirdParty: {
+		tcgplayer: 684443,
 		cardmarket: 877483
 	}
 }

--- a/data/Mega Evolution/Perfect Order/068.ts
+++ b/data/Mega Evolution/Perfect Order/068.ts
@@ -3,7 +3,12 @@ import Set from '../Perfect Order'
 
 const card: Card = {
 	name: {
+		en: "Antique Jaw Fossil",
 		fr: "Fossile Mâchoire Ancien",
+		es: "Fósil Mandíbula Antiguo",
+		de: "Antikes Kieferfossil",
+		it: "Vecchio Fossilmascella",
+		pt: "Fóssil de Mandíbula Arcaico"
 	},
 	set: Set,
 	rarity: "Common",
@@ -12,20 +17,44 @@ const card: Card = {
 		{
 			type: "Ability",
 			name: {
+				en: "Intimidating Jaw",
 				fr: "Mâchoire Intimidante",
+				es: "Mandíbula Intimidatoria",
+				de: "Bedrohlicher Kiefer",
+				it: "Mascella Prepotente",
+				pt: "Mandíbula Intimidadora"
 			},
 			effect: {
+				en: "As long as this Pokémon is in the Active Spot, attacks used by your opponent's Active Pokémon do 30 less damage (before applying Weakness and Resistance).",
 				fr: "Tant que ce Pokémon est sur le Poste Actif, les attaques utilisées par le Pokémon Actif de votre adversaire infligent 30 dégâts de moins (avant application de la Faiblesse et de la Résistance).",
-			},
-		},
+				es: "Mientras este Pokémon esté en el Puesto Activo, los ataques usados por el Pokémon Activo de tu rival hacen 30 puntos de daño menos (antes de aplicar Debilidad y Resistencia).",
+				de: "Solange dieses Pokémon in der Aktiven Position ist, fügen die vom Aktiven Pokémon deines Gegners eingesetzten Attacken 30 Schadenspunkte weniger zu (bevor Schwäche und Resistenz verrechnet werden).",
+				it: "Fintanto che questo Pokémon è in posizione attiva, gli attacchi usati dal Pokémon attivo del tuo avversario infliggono 30 danni in meno, prima di aver applicato debolezza e resistenza.",
+				pt: "Enquanto este Pokémon estiver no Campo Ativo, os ataques usados pelo Pokémon Ativo do seu oponente causarão 30 pontos de dano a menos (antes de aplicar Fraqueza e Resistência)."
+			}
+		}
 	],
+	trainerType: "Item",
 	regulationMark: "J",
 	illustrator: "AYUMI ODASHIMA",
 	effect: {
-		fr: "Jouez cette carte comme si c'était un Pokémon Incolore de base avec 60 PV. Cette carte ne peut être affectée par aucun État Spécial et ne peut pas battre en retraite.",
+		en: "Play this card as if it were a 60-HP Basic {C} Pokémon. This card can't be affected by any Special Conditions and can't retreat.",
+		fr: "Jouez cette carte comme si c'était un Pokémon {C} de base avec 60 PV. Cette carte ne peut être affectée par aucun État Spécial et ne peut pas battre en retraite.",
+		es: "Juega esta carta como si fuera un Pokémon {C} Básico de 60 PS. Esta carta no puede verse afectada por ninguna Condición Especial y no puede retirarse.",
+		de: "Spiele diese Karte, als ob sie ein Basis-{C}-Pokémon mit 60 KP wäre. Diese Karte kann von keinen Speziellen Zuständen betroffen werden und sich nicht zurückziehen.",
+		it: "Gioca questa carta come se fosse un Pokémon Base {C} con 60 PS. Questa carta non può essere influenzata da condizioni speciali e non può ritirarsi.",
+		pt: "Jogue esta carta como se fosse um Pokémon {C} Básico com PS 60. Esta carta não pode ser afetada por quaisquer Condições Especiais e não pode recuar."
 	},
-
+	variants: [
+		{
+			type: "reverse"
+		},
+		{
+			type: "normal"
+		}
+	],
 	thirdParty: {
+		tcgplayer: 684353,
 		cardmarket: 877484
 	}
 }

--- a/data/Mega Evolution/Perfect Order/069.ts
+++ b/data/Mega Evolution/Perfect Order/069.ts
@@ -3,7 +3,12 @@ import Set from '../Perfect Order'
 
 const card: Card = {
 	name: {
+		en: "Antique Sail Fossil",
 		fr: "Fossile Nageoire Ancien",
+		es: "Fósil Aleta Antiguo",
+		de: "Antikes Flossenfossil",
+		it: "Vecchio Fossilpinna",
+		pt: "Fóssil de Vela Arcaico"
 	},
 	set: Set,
 	rarity: "Common",
@@ -12,20 +17,44 @@ const card: Card = {
 		{
 			type: "Ability",
 			name: {
+				en: "Protective Sail",
 				fr: "Nageoire Protectrice",
+				es: "Aleta Protectora",
+				de: "Schützende Flosse",
+				it: "Pinna Protettiva",
+				pt: "Vela Protetora"
 			},
 			effect: {
+				en: "Whenever your opponent plays a Supporter card from their hand, prevent all effects of that card done to this Pokémon.",
 				fr: "Chaque fois que votre adversaire joue une carte Supporter de sa main, évitez tous les effets de cette carte infligés à ce Pokémon.",
-			},
-		},
+				es: "Cada vez que tu rival juegue una carta de Partidario de su mano, se evitan todos los efectos de esa carta infligidos a este Pokémon.",
+				de: "Verhindere jedes Mal, wenn dein Gegner 1 Unterstützerkarte aus seiner Hand spielt, alle Effekte jener Karte, die diesem Pokémon zugefügt werden.",
+				it: "Ogni volta che il tuo avversario gioca una carta Aiuto che ha in mano, previeni tutti gli effetti di quella carta su questo Pokémon.",
+				pt: "Sempre que seu oponente jogar uma carta de Apoiador da mão dele, previna todos os efeitos daquela carta causados a este Pokémon."
+			}
+		}
 	],
+	trainerType: "Item",
 	regulationMark: "J",
 	illustrator: "AYUMI ODASHIMA",
 	effect: {
-		fr: "Jouez cette carte comme si c'était un Pokémon Incolore de base avec 60 PV. Cette carte ne peut être affectée par aucun État Spécial et ne peut pas battre en retraite.",
+		en: "Play this card as if it were a 60-HP Basic {C} Pokémon. This card can't be affected by any Special Conditions and can't retreat.",
+		fr: "Jouez cette carte comme si c'était un Pokémon {C} de base avec 60 PV. Cette carte ne peut être affectée par aucun État Spécial et ne peut pas battre en retraite.",
+		es: "Juega esta carta como si fuera un Pokémon {C} Básico de 60 PS. Esta carta no puede verse afectada por ninguna Condición Especial y no puede retirarse.",
+		de: "Spiele diese Karte, als ob sie ein Basis-{C}-Pokémon mit 60 KP wäre. Diese Karte kann von keinen Speziellen Zuständen betroffen werden und sich nicht zurückziehen.",
+		it: "Gioca questa carta come se fosse un Pokémon Base {C} con 60 PS. Questa carta non può essere influenzata da condizioni speciali e non può ritirarsi.",
+		pt: "Jogue esta carta como se fosse um Pokémon {C} Básico com PS 60. Esta carta não pode ser afetada por quaisquer Condições Especiais e não pode recuar."
 	},
-
+	variants: [
+		{
+			type: "normal"
+		},
+		{
+			type: "reverse"
+		}
+	],
 	thirdParty: {
+		tcgplayer: 684354,
 		cardmarket: 877485
 	}
 }

--- a/data/Mega Evolution/Perfect Order/070.ts
+++ b/data/Mega Evolution/Perfect Order/070.ts
@@ -3,32 +3,59 @@ import Set from '../Perfect Order'
 
 const card: Card = {
 	name: {
+		en: "Core Memory",
 		fr: "Cœur Mémoire",
+		es: "Memoria Núcleo",
+		de: "Datenkern",
+		it: "Memoria Nucleare",
+		pt: "Núcleo de Memória"
 	},
 	set: Set,
 	rarity: "Uncommon",
-	category: "Pokemon",
+	category: "Trainer",
+	effect: {
+		en: "The Mega Zygarde ex this card is attached to can use the attack on this card. (You still need the necessary Energy to use this attack.)"
+	},
 	attacks: [
 		{
 			cost: [
 				"Fighting",
 				"Fighting",
 				"Fighting",
-				"Fighting",
+				"Fighting"
 			],
 			name: {
+				en: "Geobuster",
 				fr: "Géodestruction",
+				es: "Geodestrucción",
+				de: "Geosprenger",
+				it: "Geodistruzione",
+				pt: "Geodestruidor"
 			},
 			damage: "350",
 			effect: {
+				en: "Discard all Energy from this Pokémon.",
 				fr: "Défaussez toutes les Énergies de ce Pokémon.",
-			},
-		},
+				es: "Descarta todas las Energías de este Pokémon.",
+				de: "Lege alle Energien von diesem Pokémon auf deinen Ablagestapel.",
+				it: "Scarta tutte le Energie da questo Pokémon.",
+				pt: "Descarte todas as Energias deste Pokémon."
+			}
+		}
 	],
+	trainerType: "Tool",
 	regulationMark: "J",
 	illustrator: "Toyste Beach",
-
+	variants: [
+		{
+			type: "normal"
+		},
+		{
+			type: "reverse"
+		}
+	],
 	thirdParty: {
+		tcgplayer: 684343,
 		cardmarket: 877486
 	}
 }

--- a/data/Mega Evolution/Perfect Order/071.ts
+++ b/data/Mega Evolution/Perfect Order/071.ts
@@ -3,18 +3,37 @@ import Set from '../Perfect Order'
 
 const card: Card = {
 	name: {
+		en: "Crushing Hammer",
 		fr: "Maillet Écrasant",
+		es: "Martillo Demoledor",
+		de: "Schmetterhammer",
+		it: "Martello Dirompente",
+		pt: "Martelo Esmagador"
 	},
 	set: Set,
 	rarity: "Common",
 	category: "Trainer",
+	trainerType: "Item",
 	regulationMark: "J",
 	illustrator: "Ayaka Yoshida",
 	effect: {
+		en: "Flip a coin. If heads, discard an Energy attached to 1 of your opponent's Pokémon.",
 		fr: "Lancez une pièce. Si c'est face, défaussez une Énergie de l'un des Pokémon de votre adversaire.",
+		es: "Lanza 1 moneda. Si sale cara, descarta 1 Energía de uno de los Pokémon de tu rival.",
+		de: "Wirf 1 Münze. Lege bei Kopf 1 Energie von 1 Pokémon deines Gegners auf seinen Ablagestapel.",
+		it: "Lancia una moneta. Se esce testa, scarta un'Energia da uno dei Pokémon del tuo avversario.",
+		pt: "Jogue uma moeda. Se sair cara, descarte uma Energia de 1 dos Pokémon do seu oponente."
 	},
-
+	variants: [
+		{
+			type: "normal"
+		},
+		{
+			type: "reverse"
+		}
+	],
 	thirdParty: {
+		tcgplayer: 684325,
 		cardmarket: 877487
 	}
 }

--- a/data/Mega Evolution/Perfect Order/072.ts
+++ b/data/Mega Evolution/Perfect Order/072.ts
@@ -3,18 +3,37 @@ import Set from '../Perfect Order'
 
 const card: Card = {
 	name: {
+		en: "Energy Search",
 		fr: "Recherche d'Énergie",
+		es: "Búsqueda de Energía",
+		de: "Energiesuche",
+		it: "Ricerca di Energia",
+		pt: "Busca de Energia"
 	},
 	set: Set,
 	rarity: "Common",
 	category: "Trainer",
+	trainerType: "Item",
 	regulationMark: "J",
 	illustrator: "Toyste Beach",
 	effect: {
+		en: "Search your deck for a Basic Energy card, reveal it, and put it into your hand. Then, shuffle your deck.",
 		fr: "Cherchez dans votre deck une carte Énergie de base, montrez-la, puis ajoutez-la à votre main. Mélangez ensuite votre deck.",
+		es: "Busca en tu baraja 1 carta de Energía Básica, enséñala y ponla en tu mano. Después, baraja las cartas de tu baraja.",
+		de: "Durchsuche dein Deck nach 1 Basis-Energiekarte, zeige sie deinem Gegner und nimm sie auf deine Hand. Mische anschließend dein Deck.",
+		it: "Cerca nel tuo mazzo una carta Energia base, mostrala e aggiungila alle carte che hai in mano. Poi rimischia il tuo mazzo.",
+		pt: "Procure por uma carta de Energia Básica no seu baralho, revele-a e coloque-a na sua mão. Em seguida, embaralhe o seu baralho."
 	},
-
+	variants: [
+		{
+			type: "reverse"
+		},
+		{
+			type: "normal"
+		}
+	],
 	thirdParty: {
+		tcgplayer: 684322,
 		cardmarket: 877488
 	}
 }

--- a/data/Mega Evolution/Perfect Order/073.ts
+++ b/data/Mega Evolution/Perfect Order/073.ts
@@ -3,18 +3,37 @@ import Set from '../Perfect Order'
 
 const card: Card = {
 	name: {
+		en: "Energy Swatter",
 		fr: "Tape-Énergie",
+		es: "MataEnergías",
+		de: "Energieklatsche",
+		it: "Scaccia Energie",
+		pt: "Mata-Energia"
 	},
 	set: Set,
 	rarity: "Uncommon",
 	category: "Trainer",
+	trainerType: "Item",
 	regulationMark: "J",
 	illustrator: "Toyste Beach",
 	effect: {
+		en: "Your opponent reveals their hand, and you choose an Energy card you find there and put it on the bottom of their deck.",
 		fr: "Votre adversaire montre sa main. Choisissez une carte Énergie que vous y trouvez, puis placez-la en dessous de son deck.",
+		es: "Tu rival enseña las cartas de su mano, y tú eliges 1 carta de Energía que encuentres entre ellas y la pones en la parte inferior de su baraja.",
+		de: "Dein Gegner zeigt dir seine Handkarten und du wählst 1 Energiekarte, die du dort findest, und legst sie unter sein Deck.",
+		it: "Il tuo avversario mostra le carte che ha in mano, e tu scegli una carta Energia presente tra esse e la metti in fondo al suo mazzo.",
+		pt: "Seu oponente revela a mão dele, e você escolhe uma carta de Energia que encontrar lá e a coloca como a carta de baixo do baralho dele."
 	},
-
+	variants: [
+		{
+			type: "normal"
+		},
+		{
+			type: "reverse"
+		}
+	],
 	thirdParty: {
+		tcgplayer: 684388,
 		cardmarket: 877489
 	}
 }

--- a/data/Mega Evolution/Perfect Order/074.ts
+++ b/data/Mega Evolution/Perfect Order/074.ts
@@ -3,18 +3,37 @@ import Set from '../Perfect Order'
 
 const card: Card = {
 	name: {
+		en: "Hole-Digging Shovel",
 		fr: "Pelle à Creuser des Trous",
+		es: "Pala Cavahoyos",
+		de: "Buddelschaufel",
+		it: "Pala Scavabuche",
+		pt: "Pá de Cavar"
 	},
 	set: Set,
 	rarity: "Common",
 	category: "Trainer",
+	trainerType: "Item",
 	regulationMark: "I",
 	illustrator: "Toyste Beach",
 	effect: {
+		en: "Discard the top 2 cards of your deck.",
 		fr: "Défaussez les 2 cartes du dessus de votre deck.",
+		es: "Descarta las 2 primeras cartas de tu baraja.",
+		de: "Lege die obersten 2 Karten deines Decks auf deinen Ablagestapel.",
+		it: "Scarta le prime due carte del tuo mazzo.",
+		pt: "Descarte as 2 cartas de cima do seu baralho."
 	},
-
+	variants: [
+		{
+			type: "normal"
+		},
+		{
+			type: "reverse"
+		}
+	],
 	thirdParty: {
+		tcgplayer: 684330,
 		cardmarket: 877490
 	}
 }

--- a/data/Mega Evolution/Perfect Order/075.ts
+++ b/data/Mega Evolution/Perfect Order/075.ts
@@ -3,18 +3,37 @@ import Set from '../Perfect Order'
 
 const card: Card = {
 	name: {
+		en: "Jacinthe",
 		fr: "Violine",
+		es: "Lilette",
+		de: "Violette",
+		it: "Viola",
+		pt: "Jaci"
 	},
 	set: Set,
 	rarity: "Uncommon",
 	category: "Trainer",
+	trainerType: "Supporter",
 	regulationMark: "J",
 	illustrator: "Susumu Maeya",
 	effect: {
-		fr: "Soignez 150 dégâts de l'un de vos Pokémon Psy.",
+		en: "Heal 150 damage from 1 of your [P] Pokémon.",
+		fr: "Soignez 150 dégâts de l'un de vos Pokémon [P].",
+		es: "Cura 150 puntos de daño a uno de tus Pokémon [P].",
+		de: "Heile 150 Schadenspunkte bei 1 deiner [P]-Pokémon.",
+		it: "Cura uno dei tuoi Pokémon [P] da 150 danni.",
+		pt: "Cure 150 pontos de dano de 1 dos seus Pokémon [P]."
 	},
-
+	variants: [
+		{
+			type: "reverse"
+		},
+		{
+			type: "normal"
+		}
+	],
 	thirdParty: {
+		tcgplayer: 684393,
 		cardmarket: 877492
 	}
 }

--- a/data/Mega Evolution/Perfect Order/076.ts
+++ b/data/Mega Evolution/Perfect Order/076.ts
@@ -3,18 +3,37 @@ import Set from '../Perfect Order'
 
 const card: Card = {
 	name: {
+		en: "Judge",
 		fr: "Juge",
+		es: "Juez",
+		de: "Richter",
+		it: "Arbitro",
+		pt: "Juiz"
 	},
 	set: Set,
 	rarity: "Uncommon",
 	category: "Trainer",
+	trainerType: "Supporter",
 	regulationMark: "J",
 	illustrator: "kantaro",
 	effect: {
+		en: "Each player shuffles their hand into their deck and draws 4 cards.",
 		fr: "Chaque joueur mélange sa main avec son deck et pioche 4 cartes.",
+		es: "Cada jugador pone las cartas de su mano en su baraja, las baraja todas y roba 4 cartas.",
+		de: "Jeder Spieler mischt seine Handkarten in sein Deck und zieht 4 Karten.",
+		it: "Ciascun giocatore rimischia le carte che ha in mano nel proprio mazzo e pesca quattro carte.",
+		pt: "Cada jogador embaralha a própria mão no próprio baralho e compra 4 cartas."
 	},
-
+	variants: [
+		{
+			type: "normal"
+		},
+		{
+			type: "reverse"
+		}
+	],
 	thirdParty: {
+		tcgplayer: 684323,
 		cardmarket: 877493
 	}
 }

--- a/data/Mega Evolution/Perfect Order/077.ts
+++ b/data/Mega Evolution/Perfect Order/077.ts
@@ -3,18 +3,37 @@ import Set from '../Perfect Order'
 
 const card: Card = {
 	name: {
+		en: "Lumiose City",
 		fr: "Illumis",
+		es: "Ciudad Luminalia",
+		de: "Illumina City",
+		it: "Luminopoli",
+		pt: "Cidade de Lumiose"
 	},
 	set: Set,
 	rarity: "Uncommon",
 	category: "Trainer",
+	trainerType: "Stadium",
 	regulationMark: "J",
 	illustrator: "MARINA Chikazawa",
 	effect: {
+		en: "Once during each player's turn, that player may search their deck for a Basic Pokémon and put it onto their Bench. Then, that player shuffles their deck. If a player searches their deck in this way, their turn ends.",
 		fr: "Une fois pendant le tour de chaque personne, cette personne-là peut chercher dans son deck un Pokémon de base et le placer sur son Banc. Cette personne mélange ensuite son deck. Si une personne fait une recherche dans son deck de cette façon, son tour se termine.",
+		es: "Una vez durante el turno de cada jugador, ese jugador puede buscar en su baraja 1 Pokémon Básico y ponerlo en su Banca. Después, ese jugador baraja las cartas de su baraja. Si un jugador busca en su baraja de esta manera, su turno termina.",
+		de: "Einmal während des Zuges jedes Spielers kann jener Spieler sein Deck nach 1 Basis-Pokémon durchsuchen und es auf seine Bank legen. Jener Spieler mischt anschließend sein Deck. Wenn ein Spieler auf diese Weise sein Deck durchsucht, endet sein Zug.",
+		it: "Una sola volta durante il turno di ciascun giocatore, quel giocatore può cercare nel proprio mazzo un Pokémon Base e metterlo nella propria panchina. Poi quel giocatore rimischia il proprio mazzo. Se un giocatore cerca nel proprio mazzo in questo modo, il suo turno finisce.",
+		pt: "Uma vez durante o turno de cada jogador, aquele jogador poderá procurar no próprio baralho por um Pokémon Básico e colocá-lo no próprio Banco. Em seguida, aquele jogador embaralha o próprio baralho. Se um jogador procurar no próprio baralho desta forma, o turno dele acabará."
 	},
-
+	variants: [
+		{
+			type: "normal"
+		},
+		{
+			type: "reverse"
+		}
+	],
 	thirdParty: {
+		tcgplayer: 684348,
 		cardmarket: 877494
 	}
 }

--- a/data/Mega Evolution/Perfect Order/078.ts
+++ b/data/Mega Evolution/Perfect Order/078.ts
@@ -3,18 +3,37 @@ import Set from '../Perfect Order'
 
 const card: Card = {
 	name: {
+		en: "Lumiose Galette",
 		fr: "Galette Illumis",
+		es: "Galette Luminalia",
+		de: "Illumina-Galette",
+		it: "Pan di Lumi",
+		pt: "Crepe de Lumiose"
 	},
 	set: Set,
 	rarity: "Uncommon",
 	category: "Trainer",
+	trainerType: "Item",
 	regulationMark: "J",
 	illustrator: "5ban Graphics",
 	effect: {
+		en: "Heal 20 damage and remove a Special Condition from your Active Pokémon.",
 		fr: "Soignez 20 dégâts et retirez un État Spécial de votre Pokémon Actif.",
+		es: "Cura 20 puntos de daño y elimina una Condición Especial de tu Pokémon Activo.",
+		de: "Heile 20 Schadenspunkte und entferne 1 Speziellen Zustand von deinem Aktiven Pokémon.",
+		it: "Cura il tuo Pokémon attivo da 20 danni e rimuovi una condizione speciale che lo influenza.",
+		pt: "Cure 20 pontos de dano e remova uma Condição Especial do seu Pokémon Ativo."
 	},
-
+	variants: [
+		{
+			type: "reverse"
+		},
+		{
+			type: "normal"
+		}
+	],
 	thirdParty: {
+		tcgplayer: 684389,
 		cardmarket: 877495
 	}
 }

--- a/data/Mega Evolution/Perfect Order/079.ts
+++ b/data/Mega Evolution/Perfect Order/079.ts
@@ -3,18 +3,37 @@ import Set from '../Perfect Order'
 
 const card: Card = {
 	name: {
+		en: "Naveen",
 		fr: "Inno",
+		es: "Acris",
+		de: "Kaylen",
+		it: "Virgil",
+		pt: "Naveen"
 	},
 	set: Set,
 	rarity: "Uncommon",
 	category: "Trainer",
+	trainerType: "Supporter",
 	regulationMark: "J",
 	illustrator: "DOM",
 	effect: {
+		en: "Draw cards until you have 5 cards in your hand. Before drawing cards, you may discard any number of cards from your hand. (If you can't draw any cards in this way, you can't use this card.)",
 		fr: "Piochez des cartes jusqu'à en avoir 5 en main. Avant de piocher des cartes, vous pouvez défausser le nombre voulu de cartes de votre main. (Si vous ne pouvez pas piocher de cartes de cette façon, vous ne pouvez pas utiliser cette carte.)",
+		es: "Roba cartas hasta tener 5 cartas en tu mano. Antes de robar cartas, puedes descartar cualquier cantidad de cartas de tu mano. (Si no puedes robar ninguna carta de esta manera, no puedes usar esta carta).",
+		de: "Ziehe so lange Karten, bis du 5 Karten auf deiner Hand hast. Bevor du Karten ziehst, kannst du beliebig viele Karten aus deiner Hand auf deinen Ablagestapel legen. (Wenn du keine Karten auf diese Weise ziehen kannst, kannst du diese Karte nicht einsetzen.)",
+		it: "Pesca fino ad avere cinque carte in mano. Prima di pescare, puoi scartare un numero qualsiasi di carte dalla tua mano. Se non puoi pescare delle carte in questo modo, non puoi usare questa carta.",
+		pt: "Compre cartas até ter 5 cartas na sua mão. Antes de comprar cartas, você pode descartar qualquer número de cartas da sua mão. (Se você não puder comprar carta alguma desta forma, você não poderá usar esta carta.)"
 	},
-
+	variants: [
+		{
+			type: "normal"
+		},
+		{
+			type: "reverse"
+		}
+	],
 	thirdParty: {
+		tcgplayer: 684346,
 		cardmarket: 877496
 	}
 }

--- a/data/Mega Evolution/Perfect Order/080.ts
+++ b/data/Mega Evolution/Perfect Order/080.ts
@@ -3,18 +3,37 @@ import Set from '../Perfect Order'
 
 const card: Card = {
 	name: {
+		en: "Poké Ball",
 		fr: "Poké Ball",
+		es: "Poké Ball",
+		de: "Pokéball",
+		it: "Poké Ball",
+		pt: "Poké Bola"
 	},
 	set: Set,
 	rarity: "Common",
 	category: "Trainer",
+	trainerType: "Item",
 	regulationMark: "J",
 	illustrator: "Studio Bora Inc.",
 	effect: {
+		en: "Flip a coin. If heads, search your deck for a Pokémon, reveal it, and put it into your hand. Shuffle your deck afterward.",
 		fr: "Lancez une pièce. Si c'est face, cherchez dans votre deck un Pokémon, montrez-le, puis ajoutez-le à votre main. Mélangez ensuite votre deck.",
+		es: "Lanza 1 moneda. Si sale cara, busca en tu baraja 1 Pokémon, enséñalo y ponlo en tu mano. Después, baraja las cartas de tu baraja.",
+		de: "Wirf 1 Münze. Durchsuche bei Kopf dein Deck nach 1 Pokémon, zeige es deinem Gegner und nimm es auf deine Hand. Mische anschließend dein Deck.",
+		it: "Lancia una moneta. Se esce testa, cerca nel tuo mazzo un Pokémon, mostralo e aggiungilo alle carte che hai in mano. Poi rimischia il tuo mazzo.",
+		pt: "Jogue uma moeda. Se sair cara, procure por um Pokémon no seu baralho, revele-o e coloque-o na sua mão. Em seguida, embaralhe o seu baralho."
 	},
-
+	variants: [
+		{
+			type: "reverse"
+		},
+		{
+			type: "normal"
+		}
+	],
 	thirdParty: {
+		tcgplayer: 684321,
 		cardmarket: 877497
 	}
 }

--- a/data/Mega Evolution/Perfect Order/081.ts
+++ b/data/Mega Evolution/Perfect Order/081.ts
@@ -3,18 +3,37 @@ import Set from '../Perfect Order'
 
 const card: Card = {
 	name: {
+		en: "Poké Pad",
 		fr: "Poké Registre",
+		es: "Pokétableta",
+		de: "Poképad",
+		it: "Poké Pad",
+		pt: "Poké Tablet"
 	},
 	set: Set,
 	rarity: "Uncommon",
 	category: "Trainer",
+	trainerType: "Item",
 	regulationMark: "J",
 	illustrator: "Studio Bora Inc.",
 	effect: {
+		en: "Search your deck for a Pokémon that doesn't have a Rule Box, reveal it, and put it into your hand. Then, shuffle your deck. (Pokémon ex, Pokémon V, etc. have Rule Boxes.)",
 		fr: "Cherchez dans votre deck un Pokémon n'ayant pas d'encadré Règle, montrez-le, puis ajoutez-le à votre main. Mélangez ensuite votre deck. (Les Pokémon-ex, Pokémon-V, etc. ont des encadrés Règle.)",
+		es: "Busca en tu baraja 1 Pokémon que no tenga un recuadro de regla, enséñalo y ponlo en tu mano. Después, baraja las cartas de tu baraja. (Los Pokémon ex, Pokémon V, etc., tienen recuadros de regla).",
+		de: "Durchsuche dein Deck nach 1 Pokémon, das kein Regelfeld hat, zeige es deinem Gegner und nimm es auf deine Hand. Mische anschließend dein Deck. (Pokémon-ex, Pokémon-V usw. haben Regelfelder.)",
+		it: "Cerca nel tuo mazzo un Pokémon che non ha una regola speciale, mostralo e aggiungilo alle carte che hai in mano. Poi rimischia il tuo mazzo. I Pokémon-ex, i Pokémon-V, ecc. hanno regole speciali.",
+		pt: "Procure no seu baralho por um Pokémon que não tiver uma Caixa de Regras, revele-o e coloque-o na sua mão. Em seguida, embaralhe o seu baralho. (Pokémon ex, Pokémon V, etc. têm Caixas de Regras.)"
 	},
-
+	variants: [
+		{
+			type: "reverse"
+		},
+		{
+			type: "normal"
+		}
+	],
 	thirdParty: {
+		tcgplayer: 684332,
 		cardmarket: 877498
 	}
 }

--- a/data/Mega Evolution/Perfect Order/082.ts
+++ b/data/Mega Evolution/Perfect Order/082.ts
@@ -3,18 +3,37 @@ import Set from '../Perfect Order'
 
 const card: Card = {
 	name: {
+		en: "Pokémon Catcher",
 		fr: "Attrape-Pokémon",
+		es: "Capturapokémon",
+		de: "Pokémon-Fänger",
+		it: "Acchiappa-Pokémon",
+		pt: "Pegador de Pokémon"
 	},
 	set: Set,
 	rarity: "Common",
 	category: "Trainer",
+	trainerType: "Item",
 	regulationMark: "J",
 	illustrator: "Studio Bora Inc.",
 	effect: {
+		en: "Switch your opponent's Active Pokémon with 1 of their Benched Pokémon.",
 		fr: "Lancez une pièce. Si c'est face, envoyez l'un des Pokémon de Banc de votre adversaire sur le Poste Actif.",
+		es: "Lanza 1 moneda. Si sale cara, cambia 1 de los Pokémon en Banca de tu rival por el Pokémon que esté en el Puesto Activo.",
+		de: "Wirf 1 Münze. Wechsle bei Kopf 1 Pokémon von der Bank deines Gegners in die Aktive Position ein.",
+		it: "Lancia una moneta. Se esce testa, sostituisci uno dei Pokémon nella panchina del tuo avversario con il suo Pokémon in posizione attiva.",
+		pt: "Jogue uma moeda. Se sair cara, mande 1 dos Pokémon no Banco do seu oponente para o Campo Ativo."
 	},
-
+	variants: [
+		{
+			type: "reverse"
+		},
+		{
+			type: "normal"
+		}
+	],
 	thirdParty: {
+		tcgplayer: 684324,
 		cardmarket: 877499
 	}
 }

--- a/data/Mega Evolution/Perfect Order/083.ts
+++ b/data/Mega Evolution/Perfect Order/083.ts
@@ -3,18 +3,37 @@ import Set from '../Perfect Order'
 
 const card: Card = {
 	name: {
+		en: "Potion",
 		fr: "Potion",
+		es: "Poción",
+		de: "Trank",
+		it: "Pozione",
+		pt: "Poção"
 	},
 	set: Set,
 	rarity: "Common",
 	category: "Trainer",
+	trainerType: "Item",
 	regulationMark: "J",
 	illustrator: "Ayaka Yoshida",
 	effect: {
+		en: "Heal 30 damage from 1 of your Pokémon.",
 		fr: "Soignez 30 dégâts de l'un de vos Pokémon.",
+		es: "Cura 30 puntos de daño a uno de tus Pokémon.",
+		de: "Heile 30 Schadenspunkte bei 1 deiner Pokémon.",
+		it: "Cura uno dei tuoi Pokémon da 30 danni.",
+		pt: "Cure 30 pontos de dano de 1 dos seus Pokémon."
 	},
-
+	variants: [
+		{
+			type: "normal"
+		},
+		{
+			type: "reverse"
+		}
+	],
 	thirdParty: {
+		tcgplayer: 684320,
 		cardmarket: 877500
 	}
 }

--- a/data/Mega Evolution/Perfect Order/084.ts
+++ b/data/Mega Evolution/Perfect Order/084.ts
@@ -3,18 +3,37 @@ import Set from '../Perfect Order'
 
 const card: Card = {
 	name: {
+		en: "Rosa's Encouragement",
 		fr: "Encouragement d'Écho",
+		es: "Apoyo de Nanci",
+		de: "Rosys Ermutigung",
+		it: "Incoraggiamento di Rina",
+		pt: "Encorajamento da Rose"
 	},
 	set: Set,
 	rarity: "Uncommon",
 	category: "Trainer",
+	trainerType: "Supporter",
 	regulationMark: "J",
 	illustrator: "Atsushi Furusawa",
 	effect: {
-		fr: "Vous ne pouvez utiliser cette carte que s'il vous reste plus de cartes Récompense qu'à votre adversaire.",
+		en: "You can use this card only if you have more Prize cards remaining than your opponent.Attach up to 2 Basic Energy cards from your discard pile to 1 of your Stage 2 Pokémon.",
+		fr: "Vous ne pouvez utiliser cette carte que s'il vous reste plus de cartes Récompense qu'à votre adversaire.Attachez jusqu'à 2 cartes Énergie de base de votre pile de défausse à l'un de vos Pokémon de Niveau 2.",
+		es: "Puedes usar esta carta solo si te quedan más cartas de Premio que a tu rival.Une hasta 2 cartas de Energía Básica de tu pila de descartes a uno de tus Pokémon de Fase 2.",
+		de: "Du kannst diese Karte nur einsetzen, wenn du mehr verbleibende Preiskarten hast als dein Gegner.Lege bis zu 2 Basis-Energiekarten aus deinem Ablagestapel an 1 deiner Phase-2-Pokémon an.",
+		it: "Puoi usare questa carta solo se hai più carte Premio rimanenti del tuo avversario.Assegna a uno dei tuoi Pokémon di Fase 2 fino a due carte Energia base dalla tua pila degli scarti.",
+		pt: "Você só poderá usar esta carta se tiver mais cartas de Prêmio restantes que seu oponente.Ligue até 2 cartas de Energia Básica da sua pilha de descarte a 1 dos seus Pokémon Estágio 2."
 	},
-
+	variants: [
+		{
+			type: "reverse"
+		},
+		{
+			type: "normal"
+		}
+	],
 	thirdParty: {
+		tcgplayer: 684390,
 		cardmarket: 877501
 	}
 }

--- a/data/Mega Evolution/Perfect Order/085.ts
+++ b/data/Mega Evolution/Perfect Order/085.ts
@@ -3,18 +3,37 @@ import Set from '../Perfect Order'
 
 const card: Card = {
 	name: {
+		en: "Tarragon",
 		fr: "Taragon",
+		es: "Estragón",
+		de: "Tarragon",
+		it: "Tarragon",
+		pt: "Tarragon"
 	},
 	set: Set,
 	rarity: "Uncommon",
 	category: "Trainer",
+	trainerType: "Supporter",
 	regulationMark: "J",
 	illustrator: "Akira Komayama",
 	effect: {
-		fr: "Ajoutez à votre main une combinaison d'un maximum de 4 Pokémon Combat et/ou cartes Énergie Combat de base de votre pile de défausse.",
+		en: "Put up to 4 in any combination of [F] Pokémon and Basic [F] Energy cards from your discard pile into your hand.",
+		fr: "Ajoutez à votre main une combinaison d'un maximum de 4 Pokémon [F] et/ou cartes Énergie [F] de base de votre pile de défausse.",
+		es: "Pon, en cualquier combinación, hasta 4 cartas de Pokémon [F] y de Energía [F] Básica de tu pila de descartes en tu mano.",
+		de: "Nimm eine beliebige Kombination aus bis zu 4 [F]-Pokémon und Basis-[F]-Energiekarten aus deinem Ablagestapel auf deine Hand.",
+		it: "Prendi fino a quattro fra Pokémon [F] e carte Energia base [F] in qualsiasi combinazione dalla tua pila degli scarti e aggiungili alle carte che hai in mano.",
+		pt: "Coloque até 4 cartas de Pokémon [F] e de Energia [F] Básica da sua pilha de descarte na sua mão em qualquer combinação."
 	},
-
+	variants: [
+		{
+			type: "normal"
+		},
+		{
+			type: "reverse"
+		}
+	],
 	thirdParty: {
+		tcgplayer: 684344,
 		cardmarket: 877502
 	}
 }

--- a/data/Mega Evolution/Perfect Order/086.ts
+++ b/data/Mega Evolution/Perfect Order/086.ts
@@ -3,17 +3,30 @@ import Set from '../Perfect Order'
 
 const card: Card = {
 	name: {
+		en: "Growing Grass Energy",
 		fr: "Énergie Plante Croissante",
+		es: "Energía Planta Creciente",
+		de: "Wachsende Pflanzen-Energie",
+		it: "Energia Erba Rigogliosa",
+		pt: "Energia Grama Crescente"
 	},
 	set: Set,
 	rarity: "Rare",
 	category: "Energy",
 	regulationMark: "J",
 	effect: {
-		fr: "Tant que cette carte est attachée à un Pokémon, elle fournit une Énergie Plante.",
+		fr: "Tant que cette carte est attachée à un Pokémon, elle fournit une Énergie Plante."
 	},
-
+	variants: [
+		{
+			type: "holo"
+		},
+		{
+			type: "reverse"
+		}
+	],
 	thirdParty: {
+		tcgplayer: 684375,
 		cardmarket: 877503
 	}
 }

--- a/data/Mega Evolution/Perfect Order/087.ts
+++ b/data/Mega Evolution/Perfect Order/087.ts
@@ -3,17 +3,30 @@ import Set from '../Perfect Order'
 
 const card: Card = {
 	name: {
+		en: "Rocky Fighting Energy",
 		fr: "Énergie Combat Rocheuse",
+		es: "Energía Lucha Rocosa",
+		de: "Steinharte Kampf-Energie",
+		it: "Energia Lotta Rocciosa",
+		pt: "Energia Luta Rochosa"
 	},
 	set: Set,
 	rarity: "Rare",
 	category: "Energy",
 	regulationMark: "J",
 	effect: {
-		fr: "Tant que cette carte est attachée à un Pokémon, elle fournit une Énergie Combat.",
+		fr: "Tant que cette carte est attachée à un Pokémon, elle fournit une Énergie Combat."
 	},
-
+	variants: [
+		{
+			type: "reverse"
+		},
+		{
+			type: "holo"
+		}
+	],
 	thirdParty: {
+		tcgplayer: 684350,
 		cardmarket: 877504
 	}
 }

--- a/data/Mega Evolution/Perfect Order/088.ts
+++ b/data/Mega Evolution/Perfect Order/088.ts
@@ -3,17 +3,30 @@ import Set from '../Perfect Order'
 
 const card: Card = {
 	name: {
+		en: "Telepathic Psychic Energy",
 		fr: "Énergie Psy Télépathique",
+		es: "Energía Psíquica Telepática",
+		de: "Telepathische Psycho-Energie",
+		it: "Energia Psico Telepatica",
+		pt: "Energia Psíquico Telepática"
 	},
 	set: Set,
 	rarity: "Rare",
 	category: "Energy",
 	regulationMark: "J",
 	effect: {
-		fr: "Tant que cette carte est attachée à un Pokémon, elle fournit une Énergie Psy.",
+		fr: "Tant que cette carte est attachée à un Pokémon, elle fournit une Énergie Psy."
 	},
-
+	variants: [
+		{
+			type: "holo"
+		},
+		{
+			type: "reverse"
+		}
+	],
 	thirdParty: {
+		tcgplayer: 684396,
 		cardmarket: 877505
 	}
 }

--- a/data/Mega Evolution/Perfect Order/089.ts
+++ b/data/Mega Evolution/Perfect Order/089.ts
@@ -3,40 +3,71 @@ import Set from '../Perfect Order'
 
 const card: Card = {
 	name: {
+		en: "Spewpa",
 		fr: "Pérégrain",
+		es: "Spewpa",
+		de: "Puponcho",
+		it: "Spewpa",
+		pt: "Spewpa"
 	},
 	set: Set,
 	rarity: "Illustration rare",
 	category: "Pokemon",
+	dexId: [
+		665
+	],
 	hp: 80,
+	types: [
+		"Grass"
+	],
 	stage: "Stage1",
 	evolveFrom: {
+		en: "Scatterbug",
 		fr: "Lépidonille",
+		es: "Scatterbug",
+		de: "Purmel",
+		it: "Scatterbug",
+		pt: "Scatterbug"
 	},
 	attacks: [
 		{
 			cost: [
-				"Grass",
+				"Grass"
 			],
 			name: {
+				en: "Hide",
 				fr: "Cachette",
+				es: "Ocultarse",
+				de: "Verstecken",
+				it: "Nascondino",
+				pt: "Esconder"
 			},
 			effect: {
+				en: "Flip a coin. If heads, during your opponent's next turn, prevent all damage from and effects of attacks done to this Pokémon.",
 				fr: "Lancez une pièce. Si c'est face, pendant le prochain tour de votre adversaire, évitez tous les dégâts et effets provenant d'attaques infligés à ce Pokémon.",
-			},
-		},
+				es: "Lanza 1 moneda. Si sale cara, durante el próximo turno de tu rival, se evitan todo el daño y todos los efectos de los ataques infligidos a este Pokémon.",
+				de: "Wirf 1 Münze. Verhindere bei Kopf während des nächsten Zuges deines Gegners allen Schaden durch und alle Effekte von Attacken, die diesem Pokémon zugefügt werden.",
+				it: "Lancia una moneta. Se esce testa, durante il prossimo turno del tuo avversario, previeni sia i danni che gli effetti degli attacchi inflitti a questo Pokémon.",
+				pt: "Jogue uma moeda. Se sair cara, durante o próximo turno do seu oponente, previna todo o dano e os efeitos de ataques causados a este Pokémon."
+			}
+		}
 	],
 	weaknesses: [
 		{
 			type: "Fire",
-			value: "×2",
-		},
+			value: "×2"
+		}
 	],
 	retreat: 3,
 	regulationMark: "J",
 	illustrator: "kamonabe",
-
+	variants: [
+		{
+			type: "holo"
+		}
+	],
 	thirdParty: {
+		tcgplayer: 684365,
 		cardmarket: 877506
 	}
 }

--- a/data/Mega Evolution/Perfect Order/090.ts
+++ b/data/Mega Evolution/Perfect Order/090.ts
@@ -3,48 +3,79 @@ import Set from '../Perfect Order'
 
 const card: Card = {
 	name: {
+		en: "Rowlet",
 		fr: "Brindibou",
+		es: "Rowlet",
+		de: "Bauz",
+		it: "Rowlet",
+		pt: "Rowlet"
 	},
 	set: Set,
 	rarity: "Illustration rare",
 	category: "Pokemon",
+	dexId: [
+		722
+	],
 	hp: 80,
+	types: [
+		"Grass"
+	],
 	stage: "Basic",
 	attacks: [
 		{
 			cost: [
-				"Grass",
+				"Grass"
 			],
 			name: {
+				en: "Find a Friend",
 				fr: "Trouver un Ami",
+				es: "Encontrar un Amigo",
+				de: "Freunde finden",
+				it: "Trovamico",
+				pt: "Encontre um Amigo"
 			},
 			effect: {
+				en: "Search your deck for a Pokémon, reveal it, and put it into your hand. Then, shuffle your deck.",
 				fr: "Cherchez dans votre deck un Pokémon, montrez-le, puis ajoutez-le à votre main. Mélangez ensuite votre deck.",
-			},
+				es: "Busca en tu baraja 1 Pokémon, enséñalo y ponlo en tu mano. Después, baraja las cartas de tu baraja.",
+				de: "Durchsuche dein Deck nach 1 Pokémon, zeige es deinem Gegner und nimm es auf deine Hand. Mische anschließend dein Deck.",
+				it: "Cerca nel tuo mazzo un Pokémon, mostralo e aggiungilo alle carte che hai in mano. Poi rimischia il tuo mazzo.",
+				pt: "Procure por um Pokémon no seu baralho, revele-o e coloque-o na sua mão. Em seguida, embaralhe o seu baralho."
+			}
 		},
 		{
 			cost: [
 				"Colorless",
 				"Colorless",
-				"Colorless",
+				"Colorless"
 			],
 			name: {
+				en: "Tackle",
 				fr: "Charge",
+				es: "Placaje",
+				de: "Tackle",
+				it: "Azione",
+				pt: "Investida"
 			},
-			damage: "30",
-		},
+			damage: "30"
+		}
 	],
 	weaknesses: [
 		{
 			type: "Fire",
-			value: "×2",
-		},
+			value: "×2"
+		}
 	],
 	retreat: 2,
 	regulationMark: "J",
 	illustrator: "ryoma uratsuka",
-
+	variants: [
+		{
+			type: "holo"
+		}
+	],
 	thirdParty: {
+		tcgplayer: 684368,
 		cardmarket: 877507
 	}
 }

--- a/data/Mega Evolution/Perfect Order/091.ts
+++ b/data/Mega Evolution/Perfect Order/091.ts
@@ -3,56 +3,92 @@ import Set from '../Perfect Order'
 
 const card: Card = {
 	name: {
+		en: "Talonflame",
 		fr: "Flambusard",
+		es: "Talonflame",
+		de: "Fiaro",
+		it: "Talonflame",
+		pt: "Talonflame"
 	},
 	set: Set,
 	rarity: "Illustration rare",
 	category: "Pokemon",
+	dexId: [
+		663
+	],
 	hp: 150,
+	types: [
+		"Fire"
+	],
 	stage: "Stage2",
 	evolveFrom: {
+		en: "Fletchinder",
 		fr: "Braisillon",
+		es: "Fletchinder",
+		de: "Dartignis",
+		it: "Fletchinder",
+		pt: "Fletchinder"
 	},
 	abilities: [
 		{
 			type: "Ability",
 			name: {
+				en: "Sky Hunt",
 				fr: "Chasse Céleste",
+				es: "Cacería Aérea",
+				de: "Jäger der Lüfte",
+				it: "Caccia Aerea",
+				pt: "Rapina Aérea"
 			},
 			effect: {
+				en: "Once during your turn, you may use this Ability. Flip a coin. If heads, discard a random card from your opponent's hand.",
 				fr: "Une fois pendant votre tour, vous pouvez utiliser ce talent. Lancez une pièce. Si c'est face, défaussez au hasard une carte de la main de votre adversaire.",
-			},
-		},
+				es: "Una vez durante tu turno, puedes usar esta habilidad. Lanza 1 moneda. Si sale cara, descarta 1 carta aleatoria de la mano de tu rival.",
+				de: "Einmal während deines Zuges kannst du diese Fähigkeit einsetzen. Wirf 1 Münze. Lege bei Kopf 1 zufällige Karte aus der Hand deines Gegners auf seinen Ablagestapel.",
+				it: "Una sola volta durante il tuo turno, puoi usare questa abilità. Lancia una moneta. Se esce testa, scarta una carta a caso dalla mano del tuo avversario.",
+				pt: "Uma vez durante o seu turno, você poderá usar esta Habilidade. Jogue uma moeda. Se sair cara, descarte uma carta aleatória da mão do seu oponente."
+			}
+		}
 	],
 	attacks: [
 		{
 			cost: [
 				"Fire",
-				"Fire",
+				"Fire"
 			],
 			name: {
+				en: "Fire Wing",
 				fr: "Aile de Feu",
+				es: "Ala Ígnea",
+				de: "Feuerflügel",
+				it: "Alafiamma",
+				pt: "Asa de Fogo"
 			},
-			damage: "110",
-		},
+			damage: "110"
+		}
 	],
 	weaknesses: [
 		{
 			type: "Lightning",
-			value: "×2",
-		},
+			value: "×2"
+		}
 	],
 	resistances: [
 		{
 			type: "Fighting",
-			value: "-30",
-		},
+			value: "-30"
+		}
 	],
 	retreat: 1,
 	regulationMark: "J",
 	illustrator: "OKACHEKE",
-
+	variants: [
+		{
+			type: "holo"
+		}
+	],
 	thirdParty: {
+		tcgplayer: 684406,
 		cardmarket: 877508
 	}
 }

--- a/data/Mega Evolution/Perfect Order/092.ts
+++ b/data/Mega Evolution/Perfect Order/092.ts
@@ -3,54 +3,95 @@ import Set from '../Perfect Order'
 
 const card: Card = {
 	name: {
+		en: "Aurorus",
 		fr: "Dragmara",
+		es: "Aurorus",
+		de: "Amagarga",
+		it: "Aurorus",
+		pt: "Aurorus"
 	},
 	set: Set,
 	rarity: "Illustration rare",
 	category: "Pokemon",
+	dexId: [
+		699
+	],
 	hp: 170,
+	types: [
+		"Water"
+	],
 	stage: "Stage2",
 	evolveFrom: {
+		en: "Amaura",
 		fr: "Amagara",
+		es: "Amaura",
+		de: "Amarino",
+		it: "Amaura",
+		pt: "Amaura"
 	},
 	abilities: [
 		{
 			type: "Ability",
 			name: {
+				en: "Tundra Wall",
 				fr: "Mur Toundra",
+				es: "Muro Tundra",
+				de: "Tundra-Wall",
+				it: "Murotundra",
+				pt: "Parede de Tundra"
 			},
 			effect: {
-				fr: "Vos Pokémon auxquels au moins une Énergie Eau est attachée subissent 50 dégâts de moins provenant des attaques des Pokémon de votre adversaire (après application de la Faiblesse et de la Résistance). L'effet de Mur Toundra n'est pas cumulable.",
-			},
-		},
+				en: "All of your Pokémon that have any [W] Energy attached take 50 less damage from attacks from your opponent's Pokémon (after applying Weakness and Resistance). The effect of Tundra Wall doesn't stack.",
+				fr: "Vos Pokémon auxquels au moins une Énergie [W] est attachée subissent 50 dégâts de moins provenant des attaques des Pokémon de votre adversaire (après application de la Faiblesse et de la Résistance). L'effet de Mur Toundra n'est pas cumulable.",
+				es: "Los ataques de los Pokémon de tu rival hacen 50 puntos de daño menos a todos tus Pokémon que tengan alguna Energía [W] unida (después de aplicar Debilidad y Resistencia). El efecto de Muro Tundra no se acumula.",
+				de: "Allen deinen Pokémon, an die mindestens 1 [W]-Energie angelegt ist, werden durch Attacken von Pokémon deines Gegners 50 Schadenspunkte weniger zugefügt (nachdem Schwäche und Resistenz verrechnet wurden). Der Effekt von Tundra-Wall stapelt sich nicht.",
+				it: "I tuoi Pokémon che hanno delle Energie [W] assegnate subiscono 50 danni in meno dagli attacchi dei Pokémon del tuo avversario, dopo aver applicato debolezza e resistenza. L'effetto di Murotundra non è cumulabile.",
+				pt: "Todos os seus Pokémon que têm alguma Energia [W] ligada a eles recebem 50 pontos de dano a menos de ataques dos Pokémon do seu oponente (depois de aplicar Fraqueza e Resistência). O efeito de Parede de Tundra não acumula."
+			}
+		}
 	],
 	attacks: [
 		{
 			cost: [
 				"Water",
 				"Water",
-				"Colorless",
+				"Colorless"
 			],
 			name: {
+				en: "Freezing Chill",
 				fr: "Frisson Glaçant",
+				es: "Frío Helador",
+				de: "Gefrierschock",
+				it: "Freddo Glaciale",
+				pt: "Frio de Arrepiar"
 			},
 			damage: "150",
 			effect: {
+				en: "During your opponent's next turn, the Defending Pokémon can't use attacks.",
 				fr: "Pendant le prochain tour de votre adversaire, le Pokémon Défenseur ne peut pas utiliser d'attaques.",
-			},
-		},
+				es: "Durante el próximo turno de tu rival, el Pokémon Defensor no puede usar ataques.",
+				de: "Während des nächsten Zuges deines Gegners kann das Verteidigende Pokémon keine Attacken einsetzen.",
+				it: "Durante il prossimo turno del tuo avversario, il Pokémon difensore non può usare attacchi.",
+				pt: "Durante o próximo turno do seu oponente, o Pokémon Defensor não poderá usar ataques."
+			}
+		}
 	],
 	weaknesses: [
 		{
 			type: "Metal",
-			value: "×2",
-		},
+			value: "×2"
+		}
 	],
 	retreat: 3,
 	regulationMark: "J",
 	illustrator: "Masa",
-
+	variants: [
+		{
+			type: "holo"
+		}
+	],
 	thirdParty: {
+		tcgplayer: 684357,
 		cardmarket: 877509
 	}
 }

--- a/data/Mega Evolution/Perfect Order/093.ts
+++ b/data/Mega Evolution/Perfect Order/093.ts
@@ -3,50 +3,86 @@ import Set from '../Perfect Order'
 
 const card: Card = {
 	name: {
+		en: "Dedenne",
 		fr: "Dedenne",
+		es: "Dedenne",
+		de: "Dedenne",
+		it: "Dedenne",
+		pt: "Dedenne"
 	},
 	set: Set,
 	rarity: "Illustration rare",
 	category: "Pokemon",
+	dexId: [
+		702
+	],
 	hp: 70,
+	types: [
+		"Lightning"
+	],
 	stage: "Basic",
 	attacks: [
 		{
 			cost: [
-				"Lightning",
+				"Lightning"
 			],
 			name: {
+				en: "Tail Generator",
 				fr: "Générateur Caudal",
+				es: "Generador Cola",
+				de: "Generatorschweif",
+				it: "Codageneratore",
+				pt: "Gerador de Cauda"
 			},
 			effect: {
-				fr: "Choisissez dans votre pile de défausse un nombre de cartes Énergie Électrique de base inférieur ou égal à la quantité d'Énergies attachées à tous les Pokémon de votre adversaire, puis attachez-les à vos Pokémon Électrique comme il vous plaît.",
-			},
+				en: "Choose Basic [L] Energy cards from your discard pile up to the amount of Energy attached to all of your opponent's Pokémon and attach them to your [L] Pokémon in any way you like.",
+				fr: "Choisissez dans votre pile de défausse un nombre de cartes Énergie [L] de base inférieur ou égal à la quantité d'Énergies attachées à tous les Pokémon de votre adversaire, puis attachez-les à vos Pokémon [L] comme il vous plaît.",
+				es: "Elige una cantidad de cartas de Energía [L] Básica de tu pila de descartes igual o inferior a la cantidad de Energías unidas a cada uno de los Pokémon de tu rival, y únelas a tus Pokémon [L] de la manera que desees.",
+				de: "Wähle bis zu so viele Basis-[L]-Energiekarten aus deinem Ablagestapel, wie Energien an alle Pokémon deines Gegners angelegt sind, und lege sie beliebig an deine [L]-Pokémon an.",
+				it: "Scegli un numero di carte Energia base [L] dalla tua pila degli scarti uguale o inferiore al numero di Energie assegnate ai Pokémon del tuo avversario e assegnale ai tuoi Pokémon [L] nel modo che preferisci.",
+				pt: "Escolha cartas de Energia [L] Básica da sua pilha de descarte até a quantidade de Energias ligadas a todos os Pokémon do seu oponente e ligue-as aos seus Pokémon [L] como desejar."
+			}
 		},
 		{
 			cost: [
 				"Lightning",
-				"Colorless",
+				"Colorless"
 			],
 			name: {
+				en: "Thunder Shock",
 				fr: "Éclair",
+				es: "Impactrueno",
+				de: "Donnerschock",
+				it: "Tuonoshock",
+				pt: "Trovoada de Choques"
 			},
 			damage: "30",
 			effect: {
+				en: "Flip a coin. If heads, your opponent's Active Pokémon is now Paralyzed.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Actif de votre adversaire est maintenant Paralysé.",
-			},
-		},
+				es: "Lanza 1 moneda. Si sale cara, el Pokémon Activo de tu rival pasa a estar Paralizado.",
+				de: "Wirf 1 Münze. Bei Kopf ist das Aktive Pokémon deines Gegners jetzt paralysiert.",
+				it: "Lancia una moneta. Se esce testa, il Pokémon attivo del tuo avversario viene paralizzato.",
+				pt: "Jogue uma moeda. Se sair cara, o Pokémon Ativo do seu oponente agora estará Paralisado."
+			}
+		}
 	],
 	weaknesses: [
 		{
 			type: "Fighting",
-			value: "×2",
-		},
+			value: "×2"
+		}
 	],
 	retreat: 1,
 	regulationMark: "J",
 	illustrator: "HYOGONOSUKE",
-
+	variants: [
+		{
+			type: "holo"
+		}
+	],
 	thirdParty: {
+		tcgplayer: 684413,
 		cardmarket: 877510
 	}
 }

--- a/data/Mega Evolution/Perfect Order/094.ts
+++ b/data/Mega Evolution/Perfect Order/094.ts
@@ -3,47 +3,78 @@ import Set from '../Perfect Order'
 
 const card: Card = {
 	name: {
+		en: "Clefairy",
 		fr: "Mélofée",
+		es: "Clefairy",
+		de: "Piepi",
+		it: "Clefairy",
+		pt: "Clefairy"
 	},
 	set: Set,
 	rarity: "Illustration rare",
 	category: "Pokemon",
+	dexId: [
+		35
+	],
 	hp: 70,
+	types: [
+		"Psychic"
+	],
 	stage: "Basic",
 	attacks: [
 		{
 			cost: [
-				"Psychic",
+				"Psychic"
 			],
 			name: {
+				en: "Follow Me",
 				fr: "Par Ici",
+				es: "Señuelo",
+				de: "Spotlight",
+				it: "Sonoqui",
+				pt: "Isca-viva"
 			},
 			effect: {
+				en: "Switch in 1 of your opponent's Benched Pokémon to the Active Spot.",
 				fr: "Envoyez l'un des Pokémon de Banc de votre adversaire sur le Poste Actif.",
-			},
+				es: "Cambia 1 de los Pokémon en Banca de tu rival por el Pokémon que esté en el Puesto Activo.",
+				de: "Wechsle 1 Pokémon von der Bank deines Gegners in die Aktive Position ein.",
+				it: "Sostituisci uno dei Pokémon nella panchina del tuo avversario con il suo Pokémon in posizione attiva.",
+				pt: "Mande 1 dos Pokémon no Banco do seu oponente para o Campo Ativo."
+			}
 		},
 		{
 			cost: [
 				"Psychic",
-				"Psychic",
+				"Psychic"
 			],
 			name: {
+				en: "Flop",
 				fr: "Flop",
+				es: "Vuelta",
+				de: "Plumps",
+				it: "Tonfo",
+				pt: "Baque"
 			},
-			damage: "30",
-		},
+			damage: "30"
+		}
 	],
 	weaknesses: [
 		{
 			type: "Metal",
-			value: "×2",
-		},
+			value: "×2"
+		}
 	],
 	retreat: 1,
 	regulationMark: "J",
 	illustrator: "Cona Nitanda",
-
+	variants: [
+		{
+			type: "holo"
+		}
+	],
 	thirdParty: {
+		tcgplayer: 684415,
 		cardmarket: 877511
 	}
 }

--- a/data/Mega Evolution/Perfect Order/095.ts
+++ b/data/Mega Evolution/Perfect Order/095.ts
@@ -3,52 +3,83 @@ import Set from '../Perfect Order'
 
 const card: Card = {
 	name: {
+		en: "Espurr",
 		fr: "Psystigri",
+		es: "Espurr",
+		de: "Psiau",
+		it: "Espurr",
+		pt: "Espurr"
 	},
 	set: Set,
 	rarity: "Illustration rare",
 	category: "Pokemon",
+	dexId: [
+		677
+	],
 	hp: 60,
+	types: [
+		"Psychic"
+	],
 	stage: "Basic",
 	attacks: [
 		{
 			cost: [
-				"Colorless",
+				"Colorless"
 			],
 			name: {
+				en: "Nap",
 				fr: "Tit'Sieste",
+				es: "Siesta",
+				de: "Nickerchen",
+				it: "Pausa",
+				pt: "Soneca"
 			},
 			effect: {
+				en: "Heal 20 damage from this Pokémon.",
 				fr: "Soignez 20 dégâts de ce Pokémon.",
-			},
+				es: "Cura 20 puntos de daño a este Pokémon.",
+				de: "Heile 20 Schadenspunkte bei diesem Pokémon.",
+				it: "Cura questo Pokémon da 20 danni.",
+				pt: "Cure 20 pontos de dano deste Pokémon."
+			}
 		},
 		{
 			cost: [
-				"Psychic",
+				"Psychic"
 			],
 			name: {
+				en: "Stampede",
 				fr: "Ruée",
+				es: "Estampida",
+				de: "Zertrampeln",
+				it: "Fuggi Fuggi",
+				pt: "Estouro"
 			},
-			damage: "10",
-		},
+			damage: "10"
+		}
 	],
 	weaknesses: [
 		{
 			type: "Darkness",
-			value: "×2",
-		},
+			value: "×2"
+		}
 	],
 	resistances: [
 		{
 			type: "Fighting",
-			value: "-30",
-		},
+			value: "-30"
+		}
 	],
 	retreat: 1,
 	regulationMark: "J",
 	illustrator: "MINAMINAMI Take",
-
+	variants: [
+		{
+			type: "holo"
+		}
+	],
 	thirdParty: {
+		tcgplayer: 684418,
 		cardmarket: 877512
 	}
 }

--- a/data/Mega Evolution/Perfect Order/096.ts
+++ b/data/Mega Evolution/Perfect Order/096.ts
@@ -3,54 +3,91 @@ import Set from '../Perfect Order'
 
 const card: Card = {
 	name: {
+		en: "Probopass",
 		fr: "Tarinorme",
+		es: "Probopass",
+		de: "Voluminas",
+		it: "Probopass",
+		pt: "Probopass"
 	},
 	set: Set,
 	rarity: "Illustration rare",
 	category: "Pokemon",
+	dexId: [
+		476
+	],
 	hp: 140,
+	types: [
+		"Fighting"
+	],
 	stage: "Stage1",
 	evolveFrom: {
+		en: "Nosepass",
 		fr: "Tarinor",
+		es: "Nosepass",
+		"es-mx": "Nosepass",
+		de: "Nasgnet",
+		it: "Nosepass",
+		pt: "Nosepass"
 	},
 	attacks: [
 		{
 			cost: [
 				"Fighting",
-				"Fighting",
+				"Fighting"
 			],
 			name: {
+				en: "Rolling Rocks",
 				fr: "Rochers Roulants",
+				es: "Rocas Rodantes",
+				de: "Rollende Steine",
+				it: "Massi Rotolanti",
+				pt: "Pedras Rolantes"
 			},
-			damage: "60",
+			damage: "60"
 		},
 		{
 			cost: [
 				"Fighting",
 				"Fighting",
 				"Fighting",
-				"Colorless",
+				"Colorless"
 			],
 			name: {
+				en: "Obliterating Nose",
 				fr: "Nez Destructeur",
+				es: "Nariz Destructora",
+				de: "Niederstreckende Nase",
+				it: "Naso Devastante",
+				pt: "Obliteração Nasal"
 			},
 			damage: "260",
 			effect: {
+				en: "Discard 3 Energy from this Pokémon.",
 				fr: "Défaussez 3 Énergies de ce Pokémon.",
-			},
-		},
+				es: "Descarta 3 Energías de este Pokémon.",
+				de: "Lege 3 Energien von diesem Pokémon auf deinen Ablagestapel.",
+				it: "Scarta tre Energie da questo Pokémon.",
+				pt: "Descarte 3 Energias deste Pokémon."
+			}
+		}
 	],
 	weaknesses: [
 		{
 			type: "Grass",
-			value: "×2",
-		},
+			value: "×2"
+		}
 	],
 	retreat: 3,
 	regulationMark: "J",
 	illustrator: "Kinu Nishimura",
-
+	variants: [
+		{
+			type: "holo"
+		}
+	],
 	thirdParty: {
+		tcgplayer: 684424,
 		cardmarket: 877513
 	}
 }

--- a/data/Mega Evolution/Perfect Order/097.ts
+++ b/data/Mega Evolution/Perfect Order/097.ts
@@ -3,53 +3,89 @@ import Set from '../Perfect Order'
 
 const card: Card = {
 	name: {
+		en: "Drapion",
 		fr: "Drascore",
+		es: "Drapion",
+		de: "Piondragi",
+		it: "Drapion",
+		pt: "Drapion"
 	},
 	set: Set,
 	rarity: "Illustration rare",
 	category: "Pokemon",
+	dexId: [
+		452
+	],
 	hp: 140,
+	types: [
+		"Darkness"
+	],
 	stage: "Stage1",
 	evolveFrom: {
+		en: "Skorupi",
 		fr: "Rapion",
+		es: "Skorupi",
+		de: "Pionskora",
+		it: "Skorupi",
+		pt: "Skorupi"
 	},
 	attacks: [
 		{
 			cost: [
 				"Darkness",
-				"Darkness",
+				"Darkness"
 			],
 			name: {
+				en: "Wrack Down",
 				fr: "Réduire en Poussière",
+				es: "Desmoronar",
+				de: "Niederschleudern",
+				it: "Abbattere",
+				pt: "Desmoronar"
 			},
-			damage: "60",
+			damage: "60"
 		},
 		{
 			cost: [
 				"Darkness",
 				"Darkness",
-				"Darkness",
+				"Darkness"
 			],
 			name: {
+				en: "Hazardous Tail",
 				fr: "Queue Nocive",
+				es: "Cola Nociva",
+				de: "Bedrohlicher Schweif",
+				it: "Coda Insidiosa",
+				pt: "Cauda Periculosa"
 			},
 			damage: "100",
 			effect: {
+				en: "This Pokémon also does 70 damage to itself. Your opponent's Active Pokémon is now Paralyzed and Poisoned.",
 				fr: "Ce Pokémon s'inflige aussi 70 dégâts. Le Pokémon Actif de votre adversaire est maintenant Paralysé et Empoisonné.",
-			},
-		},
+				es: "Este Pokémon también se hace 70 puntos de daño a sí mismo. El Pokémon Activo de tu rival pasa a estar Envenenado y Paralizado.",
+				de: "Dieses Pokémon fügt auch sich selbst 70 Schadenspunkte zu. Das Aktive Pokémon deines Gegners ist jetzt paralysiert und vergiftet.",
+				it: "Questo Pokémon infligge anche 70 danni a se stesso. Il Pokémon attivo del tuo avversario viene paralizzato e avvelenato.",
+				pt: "Este Pokémon também causa 70 pontos de dano a si mesmo. O Pokémon Ativo do seu oponente agora está Envenenado e Paralisado."
+			}
+		}
 	],
 	weaknesses: [
 		{
 			type: "Fighting",
-			value: "×2",
-		},
+			value: "×2"
+		}
 	],
 	retreat: 3,
 	regulationMark: "J",
 	illustrator: "kawayoo",
-
+	variants: [
+		{
+			type: "holo"
+		}
+	],
 	thirdParty: {
+		tcgplayer: 684434,
 		cardmarket: 877514
 	}
 }

--- a/data/Mega Evolution/Perfect Order/098.ts
+++ b/data/Mega Evolution/Perfect Order/098.ts
@@ -3,48 +3,79 @@ import Set from '../Perfect Order'
 
 const card: Card = {
 	name: {
+		en: "Doublade",
 		fr: "Dimoclès",
+		es: "Doublade",
+		de: "Duokles",
+		it: "Doublade",
+		pt: "Doublade"
 	},
 	set: Set,
 	rarity: "Illustration rare",
 	category: "Pokemon",
+	dexId: [
+		680
+	],
 	hp: 100,
+	types: [
+		"Metal"
+	],
 	stage: "Stage1",
 	evolveFrom: {
+		en: "Honedge",
 		fr: "Monorpale",
+		es: "Honedge",
+		de: "Gramokles",
+		it: "Honedge",
+		pt: "Honedge"
 	},
 	attacks: [
 		{
 			cost: [
 				"Colorless",
-				"Colorless",
+				"Colorless"
 			],
 			name: {
+				en: "Weaponized Swords",
 				fr: "Épées Armes",
+				es: "Espadas Pertrechadas",
+				de: "Kollektive Klingenkraft",
+				it: "Spade Belliche",
+				pt: "Espadas Armadas"
 			},
 			damage: "60×",
 			effect: {
+				en: "Reveal any number of Honedge, Doublade, and Aegislash from your hand, and this attack does 60 damage for each card you revealed in this way.",
 				fr: "Montrez le nombre voulu de Monorpale, de Dimoclès et d'Exagide de votre main. Cette attaque inflige 60 dégâts pour chaque carte montrée de cette façon.",
-			},
-		},
+				es: "Enseña cualquier cantidad de Honedge, Doublade y Aegislash de tu mano, y este ataque hace 60 puntos de daño por cada carta que hayas enseñado de esta manera.",
+				de: "Zeige deinem Gegner beliebig viele Gramokles, Duokles und Durengard auf deiner Hand, und diese Attacke fügt für jede auf diese Weise gezeigte Karte 60 Schadenspunkte zu.",
+				it: "Mostra un numero qualsiasi di Honedge, Doublade e Aegislash che hai in mano e questo attacco infligge 60 danni per ogni carta che hai mostrato in questo modo.",
+				pt: "Revele qualquer número de Honedge, Doublade e Aegislash na sua mão, e este ataque causa 60 pontos de dano para cada carta revelada desta forma."
+			}
+		}
 	],
 	weaknesses: [
 		{
 			type: "Fire",
-			value: "×2",
-		},
+			value: "×2"
+		}
 	],
 	resistances: [
 		{
 			type: "Grass",
-			value: "-30",
-		},
+			value: "-30"
+		}
 	],
 	retreat: 2,
 	regulationMark: "J",
 	illustrator: "Anesaki Dynamic",
-
+	variants: [
+		{
+			type: "holo"
+		}
+	],
 	thirdParty: {
+		tcgplayer: 684380,
 		cardmarket: 877515
 	}
 }

--- a/data/Mega Evolution/Perfect Order/099.ts
+++ b/data/Mega Evolution/Perfect Order/099.ts
@@ -3,53 +3,94 @@ import Set from '../Perfect Order'
 
 const card: Card = {
 	name: {
+		en: "Raticate",
 		fr: "Rattatac",
+		es: "Raticate",
+		de: "Rattikarl",
+		it: "Raticate",
+		pt: "Raticate"
 	},
 	set: Set,
 	rarity: "Illustration rare",
 	category: "Pokemon",
+	dexId: [
+		20
+	],
 	hp: 90,
+	types: [
+		"Colorless"
+	],
 	stage: "Stage1",
 	evolveFrom: {
+		en: "Rattata",
 		fr: "Rattata",
+		es: "Rattata",
+		de: "Rattfratz",
+		it: "Rattata",
+		pt: "Rattata"
 	},
 	attacks: [
 		{
 			cost: [
-				"Colorless",
+				"Colorless"
 			],
 			name: {
+				en: "Scrape Off",
 				fr: "Racler",
+				es: "Raspadura",
+				de: "Wegkratzen",
+				it: "Raschiare",
+				pt: "Raspar o Tacho"
 			},
 			damage: "20",
 			effect: {
+				en: "Before doing damage, discard all Pokémon Tools from your opponent's Active Pokémon.",
 				fr: "Avant d'infliger des dégâts, défaussez tous les Outils Pokémon du Pokémon Actif de votre adversaire.",
-			},
+				es: "Antes de infligir daño, descarta todas las Herramientas Pokémon del Pokémon Activo de tu rival.",
+				de: "Bevor du Schaden zufügst, lege alle Pokémon-Ausrüstungen vom Aktiven Pokémon deines Gegners auf seinen Ablagestapel.",
+				it: "Prima di infliggere danni, scarta tutte le carte Oggetto Pokémon dal Pokémon attivo del tuo avversario.",
+				pt: "Antes de causar dano, descarte todas as Ferramentas Pokémon do Pokémon Ativo do seu oponente."
+			}
 		},
 		{
 			cost: [
-				"Colorless",
+				"Colorless"
 			],
 			name: {
+				en: "Retaliatory Incisors",
 				fr: "Incisives Vengeance",
+				es: "Incisivos Vengativos",
+				de: "Vergeltender Nager",
+				it: "Incisivi Ritorsivi",
+				pt: "Incisivos Retaliatórios"
 			},
 			damage: "40×",
 			effect: {
+				en: "This attack does 40 damage for each damage counter on all of your Benched Rattata.",
 				fr: "Cette attaque inflige 40 dégâts pour chaque marqueur de dégâts sur vos Rattata de Banc.",
-			},
-		},
+				es: "Este ataque hace 40 puntos de daño por cada contador de daño en cada uno de tus Rattata en Banca.",
+				de: "Diese Attacke fügt für jede Schadensmarke auf allen Rattfratz auf deiner Bank 40 Schadenspunkte zu.",
+				it: "Questo attacco infligge 40 danni per ogni segnalino danno presente sui Rattata nella tua panchina.",
+				pt: "Este ataque causa 40 pontos de dano para cada contador de dano em todos os seus Rattata no Banco."
+			}
+		}
 	],
 	weaknesses: [
 		{
 			type: "Fighting",
-			value: "×2",
-		},
+			value: "×2"
+		}
 	],
 	retreat: 1,
 	regulationMark: "J",
 	illustrator: "Mina Nakai",
-
+	variants: [
+		{
+			type: "holo"
+		}
+	],
 	thirdParty: {
+		tcgplayer: 684439,
 		cardmarket: 877516
 	}
 }

--- a/data/Mega Evolution/Perfect Order/100.ts
+++ b/data/Mega Evolution/Perfect Order/100.ts
@@ -3,26 +3,52 @@ import Set from '../Perfect Order'
 
 const card: Card = {
 	name: {
+		en: "Decidueye ex",
 		fr: "Archéduc-ex",
+		es: "Decidueye ex",
+		de: "Silvarro-ex",
+		it: "Decidueye-ex",
+		pt: "Decidueye ex"
 	},
 	set: Set,
 	rarity: "Ultra Rare",
 	category: "Pokemon",
+	dexId: [
+		724
+	],
 	hp: 320,
+	types: [
+		"Grass"
+	],
 	stage: "Stage2",
 	evolveFrom: {
+		en: "Dartrix",
 		fr: "Efflèche",
+		es: "Dartrix",
+		de: "Arboretoss",
+		it: "Dartrix",
+		pt: "Dartrix"
 	},
 	abilities: [
 		{
 			type: "Ability",
 			name: {
+				en: "Sniper's Eye",
 				fr: "Œil de Sniper",
+				es: "Ojo Certero",
+				de: "Auge des Superschützen",
+				it: "Occhio da Cecchino",
+				pt: "Mira de Franco-atirador"
 			},
 			effect: {
-				fr: "Si votre adversaire a exactement 4 cartes dans sa main, ignorez toutes les Énergies Incolore dans le coût des attaques utilisées par ce Pokémon.",
-			},
-		},
+				en: "If your opponent has exactly 4 cards in their hand, ignore all [C] Energy in the costs of attacks used by this Pokémon.",
+				fr: "Si votre adversaire a exactement 4 cartes dans sa main, ignorez toutes les Énergies [C] dans le coût des attaques utilisées par ce Pokémon.",
+				es: "Si tu rival tiene exactamente 4 cartas en su mano, ignora todas las Energías [C] en los costes de los ataques usados por este Pokémon.",
+				de: "Wenn dein Gegner genau 4 Karten auf seiner Hand hat, ignoriere alle [C]-Energien in den Kosten der von diesem Pokémon eingesetzten Attacken.",
+				it: "Se il tuo avversario ha esattamente quattro carte in mano, ignora tutte le Energie [C] necessarie per gli attacchi usati da questo Pokémon.",
+				pt: "Se o seu oponente tiver exatamente 4 cartas na mão dele, ignore todas as Energias [C] nos custos dos ataques usados por este Pokémon."
+			}
+		}
 	],
 	attacks: [
 		{
@@ -30,28 +56,43 @@ const card: Card = {
 				"Grass",
 				"Colorless",
 				"Colorless",
-				"Colorless",
+				"Colorless"
 			],
 			name: {
+				en: "Crushing Arrow",
 				fr: "Flèche Écrasante",
+				es: "Flecha Demoledora",
+				de: "Schmetterpfeil",
+				it: "Freccia Dirompente",
+				pt: "Flecha Esmagadora"
 			},
 			damage: "240",
 			effect: {
+				en: "Discard an Energy from your opponent's Active Pokémon.",
 				fr: "Défaussez une Énergie du Pokémon Actif de votre adversaire.",
-			},
-		},
+				es: "Descarta 1 Energía del Pokémon Activo de tu rival.",
+				de: "Lege 1 Energie vom Aktiven Pokémon deines Gegners auf seinen Ablagestapel.",
+				it: "Scarta un'Energia dal Pokémon attivo del tuo avversario.",
+				pt: "Descarte uma Energia do Pokémon Ativo do seu oponente."
+			}
+		}
 	],
 	weaknesses: [
 		{
 			type: "Fire",
-			value: "×2",
-		},
+			value: "×2"
+		}
 	],
 	retreat: 2,
 	regulationMark: "J",
 	illustrator: "5ban Graphics",
-
+	variants: [
+		{
+			type: "holo"
+		}
+	],
 	thirdParty: {
+		tcgplayer: 684371,
 		cardmarket: 877517
 	}
 }

--- a/data/Mega Evolution/Perfect Order/101.ts
+++ b/data/Mega Evolution/Perfect Order/101.ts
@@ -3,53 +3,95 @@ import Set from '../Perfect Order'
 
 const card: Card = {
 	name: {
+		en: "Salazzle ex",
 		fr: "Malamandre-ex",
+		es: "Salazzle ex",
+		de: "Amfira-ex",
+		it: "Salazzle-ex",
+		pt: "Salazzle ex"
 	},
 	set: Set,
 	rarity: "Ultra Rare",
 	category: "Pokemon",
+	dexId: [
+		758
+	],
 	hp: 260,
+	types: [
+		"Fire"
+	],
 	stage: "Stage1",
 	evolveFrom: {
+		en: "Salandit",
 		fr: "Tritox",
+		es: "Salandit",
+		"es-mx": "Salandit",
+		de: "Molunk",
+		it: "Salandit",
+		pt: "Salandit"
 	},
 	attacks: [
 		{
 			cost: [
-				"Fire",
+				"Fire"
 			],
 			name: {
+				en: "Nasty Plot",
 				fr: "Machination",
+				es: "Maquinación",
+				de: "Ränkeschmied",
+				it: "Congiura",
+				pt: "Trama Maldosa"
 			},
 			effect: {
+				en: "Search your deck for up to 2 cards and put them into your hand. Then, shuffle your deck.",
 				fr: "Cherchez dans votre deck jusqu'à 2 cartes, puis ajoutez-les à votre main. Mélangez ensuite votre deck.",
-			},
+				es: "Busca en tu baraja hasta 2 cartas y ponlas en tu mano. Después, baraja las cartas de tu baraja.",
+				de: "Durchsuche dein Deck nach bis zu 2 Karten und nimm sie auf deine Hand. Mische anschließend dein Deck.",
+				it: "Cerca nel tuo mazzo fino a due carte e aggiungile a quelle che hai in mano. Poi rimischia il tuo mazzo.",
+				pt: "Procure por até 2 cartas no seu baralho e coloque-as na sua mão. Em seguida, embaralhe o seu baralho."
+			}
 		},
 		{
 			cost: [
 				"Fire",
-				"Fire",
+				"Fire"
 			],
 			name: {
+				en: "Dire Nails",
 				fr: "Ongles Funestes",
+				es: "Uñas Aciagas",
+				de: "Unheilskrallen",
+				it: "Unghie Fatali",
+				pt: "Unhas Perniciosas"
 			},
 			damage: "100",
 			effect: {
+				en: "Your opponent's Active Pokémon is now Burned and Poisoned. Switch this Pokémon with 1 of your Benched Pokémon.",
 				fr: "Le Pokémon Actif de votre adversaire est maintenant Brûlé et Empoisonné. Échangez ce Pokémon contre l'un de vos Pokémon de Banc.",
-			},
-		},
+				es: "El Pokémon Activo de tu rival pasa a estar Envenenado y Quemado. Cambia este Pokémon por uno de tus Pokémon en Banca.",
+				de: "Das Aktive Pokémon deines Gegners ist jetzt verbrannt und vergiftet. Tausche dieses Pokémon gegen 1 Pokémon auf deiner Bank aus.",
+				it: "Il Pokémon attivo del tuo avversario viene bruciato e avvelenato. Scambia questo Pokémon con uno nella tua panchina.",
+				pt: "O Pokémon Ativo do seu oponente agora está Envenenado e Queimado. Troque este Pokémon por 1 dos seus Pokémon no Banco."
+			}
+		}
 	],
 	weaknesses: [
 		{
 			type: "Water",
-			value: "×2",
-		},
+			value: "×2"
+		}
 	],
 	retreat: 1,
 	regulationMark: "J",
 	illustrator: "5ban Graphics",
-
+	variants: [
+		{
+			type: "holo"
+		}
+	],
 	thirdParty: {
+		tcgplayer: 684377,
 		cardmarket: 877518
 	}
 }

--- a/data/Mega Evolution/Perfect Order/102.ts
+++ b/data/Mega Evolution/Perfect Order/102.ts
@@ -3,55 +3,96 @@ import Set from '../Perfect Order'
 
 const card: Card = {
 	name: {
+		en: "Mega Starmie ex",
 		fr: "Méga-Staross-ex",
+		es: "Mega-Starmie ex",
+		de: "Mega-Starmie-ex",
+		it: "Mega Starmie-ex",
+		pt: "Mega Starmie ex"
 	},
 	set: Set,
 	rarity: "Ultra Rare",
 	category: "Pokemon",
+	dexId: [
+		121
+	],
 	hp: 330,
+	types: [
+		"Water"
+	],
 	stage: "Stage1",
 	evolveFrom: {
+		en: "Staryu",
 		fr: "Stari",
+		es: "Staryu",
+		de: "Sterndu",
+		it: "Staryu",
+		pt: "Staryu"
 	},
 	attacks: [
 		{
 			cost: [
-				"Water",
+				"Water"
 			],
 			name: {
+				en: "Jetting Blow",
 				fr: "Coup Éclaboussant",
+				es: "Golpe Propulsión",
+				de: "Wasserschwall",
+				it: "Colpogetto",
+				pt: "Golpe a Jato"
 			},
 			damage: "120",
 			effect: {
+				en: "This attack also does 50 damage to 1 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)",
 				fr: "Cette attaque inflige aussi 50 dégâts à l'un des Pokémon de Banc de votre adversaire. (N'appliquez ni la Faiblesse ni la Résistance aux Pokémon de Banc.)",
-			},
+				es: "Este ataque también hace 50 puntos de daño a uno de los Pokémon en Banca de tu rival. (No apliques Debilidad y Resistencia a los Pokémon en Banca).",
+				de: "Diese Attacke fügt auch 1 Pokémon auf der Bank deines Gegners 50 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)",
+				it: "Questo attacco infligge anche 50 danni a uno dei Pokémon nella panchina del tuo avversario. Non applicare debolezza e resistenza ai Pokémon in panchina.",
+				pt: "Este ataque também causa 50 pontos de dano a 1 dos Pokémon no Banco do seu oponente. (Não aplique Fraqueza e Resistência aos Pokémon no Banco.)"
+			}
 		},
 		{
 			cost: [
 				"Colorless",
 				"Colorless",
-				"Colorless",
+				"Colorless"
 			],
 			name: {
+				en: "Nebula Beam",
 				fr: "Rayon Nébuleux",
+				es: "Rayo Nebulosa",
+				de: "Nebelstrahl",
+				it: "Nebularaggio",
+				pt: "Feixe Celestial"
 			},
 			damage: "210",
 			effect: {
+				en: "This attack's damage isn't affected by Weakness or Resistance, or by any effects on your opponent's Active Pokémon.",
 				fr: "Les dégâts de cette attaque ne sont pas affectés par la Faiblesse, la Résistance ou tout effet en action sur le Pokémon Actif de votre adversaire.",
-			},
-		},
+				es: "El daño de este ataque no se ve afectado por Debilidad o Resistencia, ni por ningún efecto en el Pokémon Activo de tu rival.",
+				de: "Der Schaden dieser Attacke wird durch Schwäche oder Resistenz oder Effekte auf dem Aktiven Pokémon deines Gegners nicht verändert.",
+				it: "I danni di questo attacco non sono influenzati dalla debolezza o dalla resistenza, o da alcun effetto presente sul Pokémon attivo del tuo avversario.",
+				pt: "O dano deste ataque não é afetado por Fraqueza ou Resistência, ou por quaisquer efeitos no Pokémon Ativo do seu oponente."
+			}
+		}
 	],
 	weaknesses: [
 		{
 			type: "Lightning",
-			value: "×2",
-		},
+			value: "×2"
+		}
 	],
 	retreat: 2,
 	regulationMark: "J",
 	illustrator: "5ban Graphics",
-
+	variants: [
+		{
+			type: "holo"
+		}
+	],
 	thirdParty: {
+		tcgplayer: 684361,
 		cardmarket: 877519
 	}
 }

--- a/data/Mega Evolution/Perfect Order/103.ts
+++ b/data/Mega Evolution/Perfect Order/103.ts
@@ -3,53 +3,95 @@ import Set from '../Perfect Order'
 
 const card: Card = {
 	name: {
+		en: "Mega Clefable ex",
 		fr: "Méga-Mélodelfe-ex",
+		es: "Mega-Clefable ex",
+		de: "Mega-Pixi-ex",
+		it: "Mega Clefable-ex",
+		pt: "Mega Clefable ex"
 	},
 	set: Set,
 	rarity: "Ultra Rare",
 	category: "Pokemon",
+	dexId: [
+		36
+	],
 	hp: 320,
+	types: [
+		"Psychic"
+	],
 	stage: "Stage1",
 	evolveFrom: {
+		en: "Clefairy",
 		fr: "Mélofée",
+		es: "Clefairy",
+		"es-mx": "Clefairy",
+		de: "Piepi",
+		it: "Clefairy",
+		pt: "Clefairy"
 	},
 	abilities: [
 		{
 			type: "Ability",
 			name: {
+				en: "Luminous Wing",
 				fr: "Aile Luminescente",
+				es: "Ala Luminosa",
+				de: "Luminöse Flügel",
+				it: "Ala Luminosa",
+				pt: "Asa Luminosa"
 			},
 			effect: {
+				en: "Prevent all effects of your opponent's Pokémon's Abilities done to this Pokémon.",
 				fr: "Évitez tous les effets des talents des Pokémon de votre adversaire infligés à ce Pokémon.",
-			},
-		},
+				es: "Se evitan todos los efectos de las habilidades de los Pokémon de tu rival infligidos a este Pokémon.",
+				de: "Verhindere alle Effekte von Fähigkeiten der Pokémon deines Gegners, die diesem Pokémon zugefügt werden.",
+				it: "Previeni tutti gli effetti delle abilità dei Pokémon del tuo avversario inflitti a questo Pokémon.",
+				pt: "Previna todos os efeitos das Habilidades dos Pokémon do seu oponente causados a este Pokémon."
+			}
+		}
 	],
 	attacks: [
 		{
 			cost: [
 				"Psychic",
-				"Psychic",
+				"Psychic"
 			],
 			name: {
+				en: "Shooting Moons",
 				fr: "Tirs de Lunes",
+				es: "Disparo Lunar",
+				de: "Mondschnuppen",
+				it: "Lune Cadenti",
+				pt: "Luas Cadentes"
 			},
 			damage: "120+",
 			effect: {
+				en: "You may discard up to 4 Energy cards from your hand, and this attack does 40 more damage for each card you discarded in this way.",
 				fr: "Vous pouvez défausser jusqu'à 4 cartes Énergie de votre main. Cette attaque inflige 40 dégâts supplémentaires pour chaque carte défaussée de cette façon.",
-			},
-		},
+				es: "Puedes descartar hasta 4 cartas de Energía de tu mano, y este ataque hace 40 puntos de daño más por cada carta que hayas descartado de esta manera.",
+				de: "Du kannst bis zu 4 Energiekarten aus deiner Hand auf deinen Ablagestapel legen, und diese Attacke fügt für jede auf diese Weise abgelegte Karte 40 Schadenspunkte mehr zu.",
+				it: "Puoi scartare fino a quattro carte Energia dalla tua mano e questo attacco infligge 40 danni in più per ogni carta che hai scartato in questo modo.",
+				pt: "Você pode descartar até 4 cartas de Energia da sua mão, e este ataque causa 40 pontos de dano a mais para cada carta descartada desta forma."
+			}
+		}
 	],
 	weaknesses: [
 		{
 			type: "Metal",
-			value: "×2",
-		},
+			value: "×2"
+		}
 	],
 	retreat: 1,
 	regulationMark: "J",
 	illustrator: "aky CG Works",
-
+	variants: [
+		{
+			type: "holo"
+		}
+	],
 	thirdParty: {
+		tcgplayer: 684384,
 		cardmarket: 877520
 	}
 }

--- a/data/Mega Evolution/Perfect Order/104.ts
+++ b/data/Mega Evolution/Perfect Order/104.ts
@@ -3,27 +3,48 @@ import Set from '../Perfect Order'
 
 const card: Card = {
 	name: {
+		en: "Mega Zygarde ex",
 		fr: "Méga-Zygarde-ex",
+		es: "Mega-Zygarde ex",
+		de: "Mega-Zygarde-ex",
+		it: "Mega Zygarde-ex",
+		pt: "Mega Zygarde ex"
 	},
 	set: Set,
 	rarity: "Ultra Rare",
 	category: "Pokemon",
+	dexId: [
+		718
+	],
 	hp: 310,
+	types: [
+		"Fighting"
+	],
 	stage: "Basic",
 	attacks: [
 		{
 			cost: [
 				"Fighting",
 				"Fighting",
-				"Fighting",
+				"Fighting"
 			],
 			name: {
+				en: "Gaia Wave",
 				fr: "Onde de Gaïa",
+				es: "Onda Gaia",
+				de: "Gaia-Welle",
+				it: "Onda Gaia",
+				pt: "Onda de Gaia"
 			},
 			damage: "200",
 			effect: {
+				en: "During your opponent's next turn, this Pokémon takes 30 less damage from attacks (after applying Weakness and Resistance).",
 				fr: "Pendant le prochain tour de votre adversaire, ce Pokémon subit 30 dégâts de moins provenant des attaques (après application de la Faiblesse et de la Résistance).",
-			},
+				es: "Durante el próximo turno de tu rival, los ataques hacen 30 puntos de daño menos a este Pokémon (después de aplicar Debilidad y Resistencia).",
+				de: "Während des nächsten Zuges deines Gegners werden diesem Pokémon durch Attacken 30 Schadenspunkte weniger zugefügt (nachdem Schwäche und Resistenz verrechnet wurden).",
+				it: "Durante il prossimo turno del tuo avversario, questo Pokémon subisce 30 danni in meno dagli attacchi, dopo aver applicato debolezza e resistenza.",
+				pt: "Durante o próximo turno do seu oponente, este Pokémon receberá 30 pontos de dano a menos de ataques (depois de aplicar Fraqueza e Resistência)."
+			}
 		},
 		{
 			cost: [
@@ -31,27 +52,42 @@ const card: Card = {
 				"Fighting",
 				"Fighting",
 				"Fighting",
-				"Fighting",
+				"Fighting"
 			],
 			name: {
+				en: "Nullifying Zero",
 				fr: "Zéro Annihilant",
+				es: "Cero Devastador",
+				de: "Tilgendes Nichts",
+				it: "Tabula Zero",
+				pt: "Zero Anulador"
 			},
 			effect: {
+				en: "For each of your opponent's Pokémon, flip a coin. If heads, this attack does 150 damage to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)",
 				fr: "Pour chacun des Pokémon de votre adversaire, lancez une pièce. Si c'est face, cette attaque inflige 150 dégâts à ce Pokémon-là. (N'appliquez ni la Faiblesse ni la Résistance aux Pokémon de Banc.)",
-			},
-		},
+				es: "Por cada uno de los Pokémon de tu rival, lanza 1 moneda. Si sale cara, este ataque hace 150 puntos de daño a ese Pokémon. (No apliques Debilidad y Resistencia a los Pokémon en Banca).",
+				de: "Wirf für jedes Pokémon deines Gegners 1 Münze. Bei Kopf fügt diese Attacke jenem Pokémon 150 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)",
+				it: "Per ciascuno dei Pokémon del tuo avversario, lancia una moneta. Se esce testa, questo attacco infligge 150 danni a quel Pokémon. Non applicare debolezza e resistenza ai Pokémon in panchina.",
+				pt: "Para cada um dos Pokémon do seu oponente, jogue uma moeda. Se sair cara, este ataque causará 150 pontos de dano àquele Pokémon. (Não aplique Fraqueza e Resistência aos Pokémon no Banco.)"
+			}
+		}
 	],
 	weaknesses: [
 		{
 			type: "Grass",
-			value: "×2",
-		},
+			value: "×2"
+		}
 	],
 	retreat: 2,
 	regulationMark: "J",
 	illustrator: "takuyoa",
-
+	variants: [
+		{
+			type: "holo"
+		}
+	],
 	thirdParty: {
+		tcgplayer: 684337,
 		cardmarket: 877521
 	}
 }

--- a/data/Mega Evolution/Perfect Order/105.ts
+++ b/data/Mega Evolution/Perfect Order/105.ts
@@ -3,59 +3,95 @@ import Set from '../Perfect Order'
 
 const card: Card = {
 	name: {
+		en: "Yveltal ex",
 		fr: "Yveltal-ex",
+		es: "Yveltal ex",
+		de: "Yveltal-ex",
+		it: "Yveltal-ex",
+		pt: "Yveltal ex"
 	},
 	set: Set,
 	rarity: "Ultra Rare",
 	category: "Pokemon",
+	dexId: [
+		717
+	],
 	hp: 210,
+	types: [
+		"Darkness"
+	],
 	stage: "Basic",
 	attacks: [
 		{
 			cost: [
 				"Darkness",
 				"Darkness",
-				"Colorless",
+				"Colorless"
 			],
 			name: {
+				en: "Soul Destroyer",
 				fr: "Destructeur d'Âmes",
+				es: "Destructor de Almas",
+				de: "Seelenvernichter",
+				it: "Distruggianima",
+				pt: "Destruidor de Almas"
 			},
 			effect: {
+				en: "Knock Out each of your opponent's Pokémon that has 50 HP or less remaining.",
 				fr: "Mettez K.O. chacun des Pokémon de votre adversaire auxquels il reste 50 PV ou moins.",
-			},
+				es: "Deja Fuera de Combate a cada uno de los Pokémon de tu rival a los que les queden 50 PS o menos.",
+				de: "Mache jedes Pokémon deines Gegners, das 50 oder weniger verbleibende KP hat, kampfunfähig.",
+				it: "Metti KO ciascuno dei Pokémon del tuo avversario che ha 50 PS o meno rimanenti.",
+				pt: "Nocauteie cada um dos Pokémon do seu oponente que tiver PS restante de 50 ou menos."
+			}
 		},
 		{
 			cost: [
 				"Darkness",
 				"Darkness",
-				"Colorless",
+				"Colorless"
 			],
 			name: {
+				en: "Dark Strike",
 				fr: "Frappe Ténébreuse",
+				es: "Golpe Siniestro",
+				de: "Finsterschlag",
+				it: "Colpo Ombra",
+				pt: "Golpe de Escuridão"
 			},
 			damage: "210",
 			effect: {
+				en: "During your next turn, this Pokémon can't use Dark Strike.",
 				fr: "Pendant votre prochain tour, ce Pokémon ne peut pas utiliser Frappe Ténébreuse.",
-			},
-		},
+				es: "Durante tu próximo turno, este Pokémon no puede usar Golpe Siniestro.",
+				de: "Während deines nächsten Zuges kann dieses Pokémon Finsterschlag nicht einsetzen.",
+				it: "Durante il tuo prossimo turno, questo Pokémon non può usare Colpo Ombra.",
+				pt: "Durante o seu próximo turno, este Pokémon não poderá usar Golpe de Escuridão."
+			}
+		}
 	],
 	weaknesses: [
 		{
 			type: "Lightning",
-			value: "×2",
-		},
+			value: "×2"
+		}
 	],
 	resistances: [
 		{
 			type: "Fighting",
-			value: "-30",
-		},
+			value: "-30"
+		}
 	],
 	retreat: 1,
 	regulationMark: "J",
 	illustrator: "5ban Graphics",
-
+	variants: [
+		{
+			type: "holo"
+		}
+	],
 	thirdParty: {
+		tcgplayer: 684387,
 		cardmarket: 877522
 	}
 }

--- a/data/Mega Evolution/Perfect Order/106.ts
+++ b/data/Mega Evolution/Perfect Order/106.ts
@@ -3,44 +3,70 @@ import Set from '../Perfect Order'
 
 const card: Card = {
 	name: {
+		en: "Mega Skarmory ex",
 		fr: "Méga-Airmure-ex",
+		es: "Mega-Skarmory ex",
+		de: "Mega-Panzaeron-ex",
+		it: "Mega Skarmory-ex",
+		pt: "Mega Skarmory ex"
 	},
 	set: Set,
 	rarity: "Ultra Rare",
 	category: "Pokemon",
+	dexId: [
+		227
+	],
 	hp: 260,
+	types: [
+		"Metal"
+	],
 	stage: "Basic",
 	attacks: [
 		{
 			cost: [
 				"Metal",
 				"Metal",
-				"Colorless",
+				"Colorless"
 			],
 			name: {
+				en: "Sonic Ripper",
 				fr: "Étripage Sonique",
+				es: "Desgarro Sónico",
+				de: "Überschallreißer",
+				it: "Squarcio Sonico",
+				pt: "Talho Sônico"
 			},
 			effect: {
+				en: "Shuffle all Energy attached to this Pokémon into your deck, and this attack does 220 damage to 1 of your opponent's Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)",
 				fr: "Mélangez toutes les Énergies attachées à ce Pokémon avec votre deck. Cette attaque inflige 220 dégâts à l'un des Pokémon de votre adversaire. (N'appliquez ni la Faiblesse ni la Résistance aux Pokémon de Banc.)",
-			},
-		},
+				es: "Pon todas las Energías unidas a este Pokémon en tu baraja y baraja todas las cartas, y este ataque hace 220 puntos de daño a uno de los Pokémon de tu rival. (No apliques Debilidad y Resistencia a los Pokémon en Banca).",
+				de: "Mische alle an dieses Pokémon angelegten Energien in dein Deck, und diese Attacke fügt 1 Pokémon deines Gegners 220 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)",
+				it: "Rimischia tutte le Energie assegnate a questo Pokémon nel tuo mazzo e questo attacco infligge 220 danni a uno dei Pokémon del tuo avversario. Non applicare debolezza e resistenza ai Pokémon in panchina.",
+				pt: "Embaralhe todas as Energias ligadas a este Pokémon no seu baralho, e este ataque causa 220 pontos de dano a 1 dos Pokémon do seu oponente. (Não aplique Fraqueza e Resistência aos Pokémon no Banco.)"
+			}
+		}
 	],
 	weaknesses: [
 		{
 			type: "Lightning",
-			value: "×2",
-		},
+			value: "×2"
+		}
 	],
 	resistances: [
 		{
 			type: "Fighting",
-			value: "-30",
-		},
+			value: "-30"
+		}
 	],
 	regulationMark: "J",
 	illustrator: "5ban Graphics",
-
+	variants: [
+		{
+			type: "holo"
+		}
+	],
 	thirdParty: {
+		tcgplayer: 684352,
 		cardmarket: 877523
 	}
 }

--- a/data/Mega Evolution/Perfect Order/107.ts
+++ b/data/Mega Evolution/Perfect Order/107.ts
@@ -3,51 +3,87 @@ import Set from '../Perfect Order'
 
 const card: Card = {
 	name: {
+		en: "Meowth ex",
 		fr: "Miaouss-ex",
+		es: "Meowth ex",
+		de: "Mauzi-ex",
+		it: "Meowth-ex",
+		pt: "Meowth ex"
 	},
 	set: Set,
 	rarity: "Ultra Rare",
 	category: "Pokemon",
+	dexId: [
+		52
+	],
 	hp: 170,
+	types: [
+		"Colorless"
+	],
 	stage: "Basic",
 	abilities: [
 		{
 			type: "Ability",
 			name: {
+				en: "Last-Ditch Catch",
 				fr: "Prise Dernier Ressort",
+				es: "Captura a la Desesperada",
+				de: "Fang aus der Not",
+				it: "Cattura in Extremis",
+				pt: "Chance Final de Captura"
 			},
 			effect: {
+				en: "Once during your turn, when you play this Pokémon from your hand onto your Bench, you may use this Ability. Search your deck for a Supporter card, reveal it, and put it into your hand. Then, shuffle your deck. You can't use more than 1 Ability that has \"Last-Ditch\" in its name each turn.",
 				fr: "Une fois pendant votre tour, lorsque vous jouez ce Pokémon de votre main sur votre Banc, vous pouvez utiliser ce talent. Cherchez dans votre deck une carte Supporter, montrez-la, puis ajoutez-la à votre main. Mélangez ensuite votre deck. Vous ne pouvez utiliser qu'un talent ayant « Dernier Ressort » dans son nom par tour.",
-			},
-		},
+				es: "Una vez durante tu turno, cuando juegas este Pokémon de tu mano a tu Banca, puedes usar esta habilidad. Busca en tu baraja 1 carta de Partidario, enséñala y ponla en tu mano. Después, baraja las cartas de tu baraja. No puedes usar más de una habilidad que tenga \"a la Desesperada\" en su nombre en cada turno.",
+				de: "Einmal während deines Zuges, wenn du dieses Pokémon aus deiner Hand auf deine Bank spielst, kannst du diese Fähigkeit einsetzen. Durchsuche dein Deck nach 1 Unterstützerkarte, zeige sie deinem Gegner und nimm sie auf deine Hand. Mische anschließend dein Deck. Du kannst nur 1 Fähigkeit, bei der „aus der Not\" zum Namen gehört, pro Zug einsetzen.",
+				it: "Una sola volta durante il tuo turno, quando giochi questo Pokémon dalla tua mano e lo metti in panchina, puoi usare questa abilità. Cerca nel tuo mazzo una carta Aiuto, mostrala e aggiungila alle carte che hai in mano. Poi rimischia il tuo mazzo. Non puoi usare più di un'abilità che ha \"in Extremis\" nel nome per turno.",
+				pt: "Uma vez durante o seu turno, quando você jogar este Pokémon da sua mão para o seu Banco, você poderá usar esta Habilidade. Procure por uma carta de Apoiador no seu baralho, revele-a e coloque-a na sua mão. Em seguida, embaralhe o seu baralho. Você não pode usar mais de 1 Habilidade que tem \"Chance Final\" em seu nome por turno."
+			}
+		}
 	],
 	attacks: [
 		{
 			cost: [
 				"Colorless",
 				"Colorless",
-				"Colorless",
+				"Colorless"
 			],
 			name: {
+				en: "Tuck Tail",
 				fr: "Queue Repliée",
+				es: "Cola Asustadiza",
+				de: "Schweif einziehen",
+				it: "Ritiracoda",
+				pt: "Rabo Entre as Pernas"
 			},
 			damage: "60",
 			effect: {
+				en: "Put this Pokémon and all attached cards into your hand.",
 				fr: "Ajoutez à votre main ce Pokémon et toutes les cartes qui lui sont attachées.",
-			},
-		},
+				es: "Pon este Pokémon y todas las cartas unidas a él en tu mano.",
+				de: "Nimm dieses Pokémon und alle angelegten Karten auf deine Hand.",
+				it: "Riprendi in mano questo Pokémon e tutte le carte a esso assegnate.",
+				pt: "Coloque este Pokémon e todas as cartas ligadas a ele na sua mão."
+			}
+		}
 	],
 	weaknesses: [
 		{
 			type: "Fighting",
-			value: "×2",
-		},
+			value: "×2"
+		}
 	],
 	retreat: 1,
 	regulationMark: "J",
 	illustrator: "5ban Graphics",
-
+	variants: [
+		{
+			type: "holo"
+		}
+	],
 	thirdParty: {
+		tcgplayer: 684341,
 		cardmarket: 877524
 	}
 }

--- a/data/Mega Evolution/Perfect Order/108.ts
+++ b/data/Mega Evolution/Perfect Order/108.ts
@@ -3,18 +3,34 @@ import Set from '../Perfect Order'
 
 const card: Card = {
 	name: {
+		en: "Energy Recycler",
 		fr: "Recycleur d'Énergie",
+		es: "Reciclaje de Energía",
+		de: "Energieaufbereitung",
+		it: "Riciclaggio di Energia",
+		pt: "Reciclador de Energia"
 	},
 	set: Set,
 	rarity: "Ultra Rare",
 	category: "Trainer",
+	trainerType: "Item",
 	regulationMark: "I",
 	illustrator: "Toyste Beach",
 	effect: {
+		en: "Shuffle up to 5 basic Energy cards from your discard pile into your deck.",
 		fr: "Mélangez jusqu'à 5 cartes Énergie de base de votre pile de défausse avec votre deck.",
+		es: "Pon hasta 5 cartas de Energía Básica de tu pila de descartes en tu baraja y barájalas todas.",
+		de: "Mische bis zu 5 Basis-Energiekarten aus deinem Ablagestapel in dein Deck.",
+		it: "Rimischia fino a cinque carte Energia base dalla tua pila degli scarti nel tuo mazzo.",
+		pt: "Embaralhe até 5 cartas de Energia Básica da sua pilha de descarte no seu baralho."
 	},
-
+	variants: [
+		{
+			type: "holo"
+		}
+	],
 	thirdParty: {
+		tcgplayer: 684327,
 		cardmarket: 877525
 	}
 }

--- a/data/Mega Evolution/Perfect Order/109.ts
+++ b/data/Mega Evolution/Perfect Order/109.ts
@@ -3,18 +3,34 @@ import Set from '../Perfect Order'
 
 const card: Card = {
 	name: {
+		en: "Forest of Vitality",
 		fr: "Forêt de Vitalité",
+		es: "Bosque Vitalidad",
+		de: "Wald der Vitalität",
+		it: "Bosco della Vitalità",
+		pt: "Floresta da Vitalidade"
 	},
 	set: Set,
 	rarity: "Ultra Rare",
 	category: "Trainer",
+	trainerType: "Stadium",
 	regulationMark: "I",
 	illustrator: "AYUMI ODASHIMA",
 	effect: {
-		fr: "Les Pokémon Plante de chaque personne peuvent évoluer en Pokémon Plante pendant le tour où elle les joue, sauf pendant son premier tour.",
+		en: "Each player's [G] Pokémon can evolve into [G] Pokémon during the turn they play those Pokémon, except during their first turn.",
+		fr: "Les Pokémon [G] de chaque personne peuvent évoluer en Pokémon [G] pendant le tour où elle les joue, sauf pendant son premier tour.",
+		es: "Los Pokémon [G] de cada jugador pueden evolucionar a Pokémon [G] durante el turno en que cada jugador los ponga en juego, excepto durante su primer turno.",
+		de: "Die [G]-Pokémon jedes Spielers können sich während des Zuges, in dem der Spieler jene Pokémon spielt, zu [G]-Pokémon entwickeln, außer während seines ersten Zuges.",
+		it: "I Pokémon [G] di ciascun giocatore possono evolversi in Pokémon [G] durante il turno in cui quei Pokémon vengono giocati, a eccezione del primo turno di ciascun giocatore.",
+		pt: "Os Pokémon [G] de cada jogador poderão evoluir para Pokémon [G] durante o turno em que eles jogaram aqueles Pokémon, exceto durante os primeiros turnos deles."
 	},
-
+	variants: [
+		{
+			type: "holo"
+		}
+	],
 	thirdParty: {
+		tcgplayer: 684328,
 		cardmarket: 877526
 	}
 }

--- a/data/Mega Evolution/Perfect Order/110.ts
+++ b/data/Mega Evolution/Perfect Order/110.ts
@@ -3,18 +3,34 @@ import Set from '../Perfect Order'
 
 const card: Card = {
 	name: {
+		en: "Jacinthe",
 		fr: "Violine",
+		es: "Lilette",
+		de: "Violette",
+		it: "Viola",
+		pt: "Jaci"
 	},
 	set: Set,
 	rarity: "Ultra Rare",
 	category: "Trainer",
+	trainerType: "Supporter",
 	regulationMark: "J",
 	illustrator: "Susumu Maeya",
 	effect: {
-		fr: "Soignez 150 dégâts de l'un de vos Pokémon Psy.",
+		en: "Heal 150 damage from 1 of your [P] Pokémon.",
+		fr: "Soignez 150 dégâts de l'un de vos Pokémon [P].",
+		es: "Cura 150 puntos de daño a uno de tus Pokémon [P].",
+		de: "Heile 150 Schadenspunkte bei 1 deiner [P]-Pokémon.",
+		it: "Cura uno dei tuoi Pokémon [P] da 150 danni.",
+		pt: "Cure 150 pontos de dano de 1 dos seus Pokémon [P]."
 	},
-
+	variants: [
+		{
+			type: "holo"
+		}
+	],
 	thirdParty: {
+		tcgplayer: 684394,
 		cardmarket: 877527
 	}
 }

--- a/data/Mega Evolution/Perfect Order/111.ts
+++ b/data/Mega Evolution/Perfect Order/111.ts
@@ -3,18 +3,34 @@ import Set from '../Perfect Order'
 
 const card: Card = {
 	name: {
+		en: "Lumiose City",
 		fr: "Illumis",
+		es: "Ciudad Luminalia",
+		de: "Illumina City",
+		it: "Luminopoli",
+		pt: "Cidade de Lumiose"
 	},
 	set: Set,
 	rarity: "Ultra Rare",
 	category: "Trainer",
+	trainerType: "Stadium",
 	regulationMark: "J",
 	illustrator: "MARINA Chikazawa",
 	effect: {
+		en: "Once during each player's turn, that player may search their deck for a Basic Pokémon and put it onto their Bench. Then, that player shuffles their deck. If a player searches their deck in this way, their turn ends.",
 		fr: "Une fois pendant le tour de chaque personne, cette personne-là peut chercher dans son deck un Pokémon de base et le placer sur son Banc. Cette personne mélange ensuite son deck. Si une personne fait une recherche dans son deck de cette façon, son tour se termine.",
+		es: "Una vez durante el turno de cada jugador, ese jugador puede buscar en su baraja 1 Pokémon Básico y ponerlo en su Banca. Después, ese jugador baraja las cartas de su baraja. Si un jugador busca en su baraja de esta manera, su turno termina.",
+		de: "Einmal während des Zuges jedes Spielers kann jener Spieler sein Deck nach 1 Basis-Pokémon durchsuchen und es auf seine Bank legen. Jener Spieler mischt anschließend sein Deck. Wenn ein Spieler auf diese Weise sein Deck durchsucht, endet sein Zug.",
+		it: "Una sola volta durante il turno di ciascun giocatore, quel giocatore può cercare nel proprio mazzo un Pokémon Base e metterlo nella propria panchina. Poi quel giocatore rimischia il proprio mazzo. Se un giocatore cerca nel proprio mazzo in questo modo, il suo turno finisce.",
+		pt: "Uma vez durante o turno de cada jogador, aquele jogador poderá procurar no próprio baralho por um Pokémon Básico e colocá-lo no próprio Banco. Em seguida, aquele jogador embaralha o próprio baralho. Se um jogador procurar no próprio baralho desta forma, o turno dele acabará."
 	},
-
+	variants: [
+		{
+			type: "holo"
+		}
+	],
 	thirdParty: {
+		tcgplayer: 684349,
 		cardmarket: 877528
 	}
 }

--- a/data/Mega Evolution/Perfect Order/112.ts
+++ b/data/Mega Evolution/Perfect Order/112.ts
@@ -3,18 +3,34 @@ import Set from '../Perfect Order'
 
 const card: Card = {
 	name: {
+		en: "Naveen",
 		fr: "Inno",
+		es: "Acris",
+		de: "Kaylen",
+		it: "Virgil",
+		pt: "Naveen"
 	},
 	set: Set,
 	rarity: "Ultra Rare",
 	category: "Trainer",
+	trainerType: "Supporter",
 	regulationMark: "J",
 	illustrator: "DOM",
 	effect: {
+		en: "Draw cards until you have 5 cards in your hand. Before drawing cards, you may discard any number of cards from your hand. (If you can't draw any cards in this way, you can't use this card.)",
 		fr: "Piochez des cartes jusqu'à en avoir 5 en main. Avant de piocher des cartes, vous pouvez défausser le nombre voulu de cartes de votre main. (Si vous ne pouvez pas piocher de cartes de cette façon, vous ne pouvez pas utiliser cette carte.)",
+		es: "Roba cartas hasta tener 5 cartas en tu mano. Antes de robar cartas, puedes descartar cualquier cantidad de cartas de tu mano. (Si no puedes robar ninguna carta de esta manera, no puedes usar esta carta).",
+		de: "Ziehe so lange Karten, bis du 5 Karten auf deiner Hand hast. Bevor du Karten ziehst, kannst du beliebig viele Karten aus deiner Hand auf deinen Ablagestapel legen. (Wenn du keine Karten auf diese Weise ziehen kannst, kannst du diese Karte nicht einsetzen.)",
+		it: "Pesca fino ad avere cinque carte in mano. Prima di pescare, puoi scartare un numero qualsiasi di carte dalla tua mano. Se non puoi pescare delle carte in questo modo, non puoi usare questa carta.",
+		pt: "Compre cartas até ter 5 cartas na sua mão. Antes de comprar cartas, você pode descartar qualquer número de cartas da sua mão. (Se você não puder comprar carta alguma desta forma, você não poderá usar esta carta.)"
 	},
-
+	variants: [
+		{
+			type: "holo"
+		}
+	],
 	thirdParty: {
+		tcgplayer: 684347,
 		cardmarket: 877529
 	}
 }

--- a/data/Mega Evolution/Perfect Order/113.ts
+++ b/data/Mega Evolution/Perfect Order/113.ts
@@ -3,18 +3,34 @@ import Set from '../Perfect Order'
 
 const card: Card = {
 	name: {
+		en: "Poké Pad",
 		fr: "Poké Registre",
+		es: "Pokétableta",
+		de: "Poképad",
+		it: "Poké Pad",
+		pt: "Poké Tablet"
 	},
 	set: Set,
 	rarity: "Ultra Rare",
 	category: "Trainer",
+	trainerType: "Item",
 	regulationMark: "J",
 	illustrator: "Studio Bora Inc.",
 	effect: {
+		en: "Search your deck for a Pokémon that doesn't have a Rule Box, reveal it, and put it into your hand. Then, shuffle your deck. (Pokémon ex, Pokémon V, etc. have Rule Boxes.)",
 		fr: "Cherchez dans votre deck un Pokémon n'ayant pas d'encadré Règle, montrez-le, puis ajoutez-le à votre main. Mélangez ensuite votre deck. (Les Pokémon-ex, Pokémon-V, etc. ont des encadrés Règle.)",
+		es: "Busca en tu baraja 1 Pokémon que no tenga un recuadro de regla, enséñalo y ponlo en tu mano. Después, baraja las cartas de tu baraja. (Los Pokémon ex, Pokémon V, etc., tienen recuadros de regla).",
+		de: "Durchsuche dein Deck nach 1 Pokémon, das kein Regelfeld hat, zeige es deinem Gegner und nimm es auf deine Hand. Mische anschließend dein Deck. (Pokémon-ex, Pokémon-V usw. haben Regelfelder.)",
+		it: "Cerca nel tuo mazzo un Pokémon che non ha una regola speciale, mostralo e aggiungilo alle carte che hai in mano. Poi rimischia il tuo mazzo. I Pokémon-ex, i Pokémon-V, ecc. hanno regole speciali.",
+		pt: "Procure no seu baralho por um Pokémon que não tiver uma Caixa de Regras, revele-o e coloque-o na sua mão. Em seguida, embaralhe o seu baralho. (Pokémon ex, Pokémon V, etc. têm Caixas de Regras.)"
 	},
-
+	variants: [
+		{
+			type: "holo"
+		}
+	],
 	thirdParty: {
+		tcgplayer: 684333,
 		cardmarket: 877530
 	}
 }

--- a/data/Mega Evolution/Perfect Order/114.ts
+++ b/data/Mega Evolution/Perfect Order/114.ts
@@ -3,18 +3,34 @@ import Set from '../Perfect Order'
 
 const card: Card = {
 	name: {
+		en: "Rosa's Encouragement",
 		fr: "Encouragement d'Écho",
+		es: "Apoyo de Nanci",
+		de: "Rosys Ermutigung",
+		it: "Incoraggiamento di Rina",
+		pt: "Encorajamento da Rose"
 	},
 	set: Set,
 	rarity: "Ultra Rare",
 	category: "Trainer",
+	trainerType: "Supporter",
 	regulationMark: "J",
 	illustrator: "Atsushi Furusawa",
 	effect: {
-		fr: "Vous ne pouvez utiliser cette carte que s'il vous reste plus de cartes Récompense qu'à votre adversaire.",
+		en: "You can use this card only if you have more Prize cards remaining than your opponent.Attach up to 2 Basic Energy cards from your discard pile to 1 of your Stage 2 Pokémon.",
+		fr: "Vous ne pouvez utiliser cette carte que s'il vous reste plus de cartes Récompense qu'à votre adversaire.Attachez jusqu'à 2 cartes Énergie de base de votre pile de défausse à l'un de vos Pokémon de Niveau 2.",
+		es: "Puedes usar esta carta solo si te quedan más cartas de Premio que a tu rival.Une hasta 2 cartas de Energía Básica de tu pila de descartes a uno de tus Pokémon de Fase 2.",
+		de: "Du kannst diese Karte nur einsetzen, wenn du mehr verbleibende Preiskarten hast als dein Gegner.Lege bis zu 2 Basis-Energiekarten aus deinem Ablagestapel an 1 deiner Phase-2-Pokémon an.",
+		it: "Puoi usare questa carta solo se hai più carte Premio rimanenti del tuo avversario.Assegna a uno dei tuoi Pokémon di Fase 2 fino a due carte Energia base dalla tua pila degli scarti.",
+		pt: "Você só poderá usar esta carta se tiver mais cartas de Prêmio restantes que seu oponente.Ligue até 2 cartas de Energia Básica da sua pilha de descarte a 1 dos seus Pokémon Estágio 2."
 	},
-
+	variants: [
+		{
+			type: "holo"
+		}
+	],
 	thirdParty: {
+		tcgplayer: 684391,
 		cardmarket: 877531
 	}
 }

--- a/data/Mega Evolution/Perfect Order/115.ts
+++ b/data/Mega Evolution/Perfect Order/115.ts
@@ -3,18 +3,34 @@ import Set from '../Perfect Order'
 
 const card: Card = {
 	name: {
+		en: "Sacred Ash",
 		fr: "Cendre Sacrée",
+		es: "Ceniza Sagrada",
+		de: "Zauberasche",
+		it: "Cenere magica",
+		pt: "Cinza Sagrada"
 	},
 	set: Set,
 	rarity: "Ultra Rare",
 	category: "Trainer",
+	trainerType: "Item",
 	regulationMark: "I",
 	illustrator: "Toyste Beach",
 	effect: {
+		en: "Shuffle 5 Pokémon from your discard pile into your deck.",
 		fr: "Mélangez avec votre deck jusqu'à 5 Pokémon de votre pile de défausse.",
+		es: "Pon hasta 5 Pokémon de tu pila de descartes en tu baraja y baraja todas las cartas.",
+		de: "Mische bis zu 5 Pokémon aus deinem Ablagestapel in dein Deck.",
+		it: "Rimischia fino a cinque Pokémon dalla tua pila degli scarti nel tuo mazzo.",
+		pt: "Embaralhe até 5 Pokémon da sua pilha de descarte no seu baralho."
 	},
-
+	variants: [
+		{
+			type: "holo"
+		}
+	],
 	thirdParty: {
+		tcgplayer: 684326,
 		cardmarket: 877532
 	}
 }

--- a/data/Mega Evolution/Perfect Order/116.ts
+++ b/data/Mega Evolution/Perfect Order/116.ts
@@ -3,18 +3,34 @@ import Set from '../Perfect Order'
 
 const card: Card = {
 	name: {
+		en: "Tarragon",
 		fr: "Taragon",
+		es: "Estragón",
+		de: "Tarragon",
+		it: "Tarragon",
+		pt: "Tarragon"
 	},
 	set: Set,
 	rarity: "Ultra Rare",
 	category: "Trainer",
+	trainerType: "Supporter",
 	regulationMark: "J",
 	illustrator: "Akira Komayama",
 	effect: {
-		fr: "Ajoutez à votre main une combinaison d'un maximum de 4 Pokémon Combat et/ou cartes Énergie Combat de base de votre pile de défausse.",
+		en: "Put up to 4 in any combination of [F] Pokémon and Basic [F] Energy cards from your discard pile into your hand.",
+		fr: "Ajoutez à votre main une combinaison d'un maximum de 4 Pokémon [F] et/ou cartes Énergie [F] de base de votre pile de défausse.",
+		es: "Pon, en cualquier combinación, hasta 4 cartas de Pokémon [F] y de Energía [F] Básica de tu pila de descartes en tu mano.",
+		de: "Nimm eine beliebige Kombination aus bis zu 4 [F]-Pokémon und Basis-[F]-Energiekarten aus deinem Ablagestapel auf deine Hand.",
+		it: "Prendi fino a quattro fra Pokémon [F] e carte Energia base [F] in qualsiasi combinazione dalla tua pila degli scarti e aggiungili alle carte che hai in mano.",
+		pt: "Coloque até 4 cartas de Pokémon [F] e de Energia [F] Básica da sua pilha de descarte na sua mão em qualquer combinação."
 	},
-
+	variants: [
+		{
+			type: "holo"
+		}
+	],
 	thirdParty: {
+		tcgplayer: 684345,
 		cardmarket: 877533
 	}
 }

--- a/data/Mega Evolution/Perfect Order/117.ts
+++ b/data/Mega Evolution/Perfect Order/117.ts
@@ -3,18 +3,34 @@ import Set from '../Perfect Order'
 
 const card: Card = {
 	name: {
+		en: "Wondrous Patch",
 		fr: "Fortifiant Merveilleux",
+		es: "Refuerzo Prodigioso",
+		de: "Wunderpflaster",
+		it: "Distintivo Meraviglioso",
+		pt: "Fragmento Encantado"
 	},
 	set: Set,
 	rarity: "Ultra Rare",
 	category: "Trainer",
+	trainerType: "Item",
 	regulationMark: "I",
 	illustrator: "Studio Bora Inc.",
 	effect: {
-		fr: "Attachez une carte Énergie Psy de base de votre pile de défausse à l'un de vos Pokémon Psy de Banc.",
+		en: "Attach a Basic [P] Energy card from your discard pile to 1 of your Benched [P] Pokémon.",
+		fr: "Attachez une carte Énergie [P] de base de votre pile de défausse à l'un de vos Pokémon [P] de Banc.",
+		es: "Une 1 carta de Energía [P] Básica de tu pila de descartes a uno de tus Pokémon [P] en Banca.",
+		de: "Lege 1 Basis-[P]-Energiekarte aus deinem Ablagestapel an 1 [P]-Pokémon auf deiner Bank an.",
+		it: "Assegna a uno dei Pokémon [P] nella tua panchina una carta Energia base [P] dalla tua pila degli scarti.",
+		pt: "Ligue uma carta de Energia [P] Básica da sua pilha de descarte a 1 dos seus Pokémon [P] no Banco."
 	},
-
+	variants: [
+		{
+			type: "holo"
+		}
+	],
 	thirdParty: {
+		tcgplayer: 684331,
 		cardmarket: 877534
 	}
 }

--- a/data/Mega Evolution/Perfect Order/118.ts
+++ b/data/Mega Evolution/Perfect Order/118.ts
@@ -3,55 +3,96 @@ import Set from '../Perfect Order'
 
 const card: Card = {
 	name: {
+		en: "Mega Starmie ex",
 		fr: "Méga-Staross-ex",
+		es: "Mega-Starmie ex",
+		de: "Mega-Starmie-ex",
+		it: "Mega Starmie-ex",
+		pt: "Mega Starmie ex"
 	},
 	set: Set,
 	rarity: "Special illustration rare",
 	category: "Pokemon",
+	dexId: [
+		121
+	],
 	hp: 330,
+	types: [
+		"Water"
+	],
 	stage: "Stage1",
 	evolveFrom: {
+		en: "Staryu",
 		fr: "Stari",
+		es: "Staryu",
+		de: "Sterndu",
+		it: "Staryu",
+		pt: "Staryu"
 	},
 	attacks: [
 		{
 			cost: [
-				"Water",
+				"Water"
 			],
 			name: {
+				en: "Jetting Blow",
 				fr: "Coup Éclaboussant",
+				es: "Golpe Propulsión",
+				de: "Wasserschwall",
+				it: "Colpogetto",
+				pt: "Golpe a Jato"
 			},
 			damage: "120",
 			effect: {
+				en: "This attack also does 50 damage to 1 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)",
 				fr: "Cette attaque inflige aussi 50 dégâts à l'un des Pokémon de Banc de votre adversaire. (N'appliquez ni la Faiblesse ni la Résistance aux Pokémon de Banc.)",
-			},
+				es: "Este ataque también hace 50 puntos de daño a uno de los Pokémon en Banca de tu rival. (No apliques Debilidad y Resistencia a los Pokémon en Banca).",
+				de: "Diese Attacke fügt auch 1 Pokémon auf der Bank deines Gegners 50 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)",
+				it: "Questo attacco infligge anche 50 danni a uno dei Pokémon nella panchina del tuo avversario. Non applicare debolezza e resistenza ai Pokémon in panchina.",
+				pt: "Este ataque também causa 50 pontos de dano a 1 dos Pokémon no Banco do seu oponente. (Não aplique Fraqueza e Resistência aos Pokémon no Banco.)"
+			}
 		},
 		{
 			cost: [
 				"Colorless",
 				"Colorless",
-				"Colorless",
+				"Colorless"
 			],
 			name: {
+				en: "Nebula Beam",
 				fr: "Rayon Nébuleux",
+				es: "Rayo Nebulosa",
+				de: "Nebelstrahl",
+				it: "Nebularaggio",
+				pt: "Feixe Celestial"
 			},
 			damage: "210",
 			effect: {
+				en: "This attack's damage isn't affected by Weakness or Resistance, or by any effects on your opponent's Active Pokémon.",
 				fr: "Les dégâts de cette attaque ne sont pas affectés par la Faiblesse, la Résistance ou tout effet en action sur le Pokémon Actif de votre adversaire.",
-			},
-		},
+				es: "El daño de este ataque no se ve afectado por Debilidad o Resistencia, ni por ningún efecto en el Pokémon Activo de tu rival.",
+				de: "Der Schaden dieser Attacke wird durch Schwäche oder Resistenz oder Effekte auf dem Aktiven Pokémon deines Gegners nicht verändert.",
+				it: "I danni di questo attacco non sono influenzati dalla debolezza o dalla resistenza, o da alcun effetto presente sul Pokémon attivo del tuo avversario.",
+				pt: "O dano deste ataque não é afetado por Fraqueza ou Resistência, ou por quaisquer efeitos no Pokémon Ativo do seu oponente."
+			}
+		}
 	],
 	weaknesses: [
 		{
 			type: "Lightning",
-			value: "×2",
-		},
+			value: "×2"
+		}
 	],
 	retreat: 2,
 	regulationMark: "J",
 	illustrator: "takuyoa",
-
+	variants: [
+		{
+			type: "holo"
+		}
+	],
 	thirdParty: {
+		tcgplayer: 684362,
 		cardmarket: 877535
 	}
 }

--- a/data/Mega Evolution/Perfect Order/119.ts
+++ b/data/Mega Evolution/Perfect Order/119.ts
@@ -3,53 +3,95 @@ import Set from '../Perfect Order'
 
 const card: Card = {
 	name: {
+		en: "Mega Clefable ex",
 		fr: "Méga-Mélodelfe-ex",
+		es: "Mega-Clefable ex",
+		de: "Mega-Pixi-ex",
+		it: "Mega Clefable-ex",
+		pt: "Mega Clefable ex"
 	},
 	set: Set,
 	rarity: "Special illustration rare",
 	category: "Pokemon",
+	dexId: [
+		36
+	],
 	hp: 320,
+	types: [
+		"Psychic"
+	],
 	stage: "Stage1",
 	evolveFrom: {
+		en: "Clefairy",
 		fr: "Mélofée",
+		es: "Clefairy",
+		"es-mx": "Clefairy",
+		de: "Piepi",
+		it: "Clefairy",
+		pt: "Clefairy"
 	},
 	abilities: [
 		{
 			type: "Ability",
 			name: {
+				en: "Luminous Wing",
 				fr: "Aile Luminescente",
+				es: "Ala Luminosa",
+				de: "Luminöse Flügel",
+				it: "Ala Luminosa",
+				pt: "Asa Luminosa"
 			},
 			effect: {
+				en: "Prevent all effects of your opponent's Pokémon's Abilities done to this Pokémon.",
 				fr: "Évitez tous les effets des talents des Pokémon de votre adversaire infligés à ce Pokémon.",
-			},
-		},
+				es: "Se evitan todos los efectos de las habilidades de los Pokémon de tu rival infligidos a este Pokémon.",
+				de: "Verhindere alle Effekte von Fähigkeiten der Pokémon deines Gegners, die diesem Pokémon zugefügt werden.",
+				it: "Previeni tutti gli effetti delle abilità dei Pokémon del tuo avversario inflitti a questo Pokémon.",
+				pt: "Previna todos os efeitos das Habilidades dos Pokémon do seu oponente causados a este Pokémon."
+			}
+		}
 	],
 	attacks: [
 		{
 			cost: [
 				"Psychic",
-				"Psychic",
+				"Psychic"
 			],
 			name: {
+				en: "Shooting Moons",
 				fr: "Tirs de Lunes",
+				es: "Disparo Lunar",
+				de: "Mondschnuppen",
+				it: "Lune Cadenti",
+				pt: "Luas Cadentes"
 			},
 			damage: "120+",
 			effect: {
+				en: "You may discard up to 4 Energy cards from your hand, and this attack does 40 more damage for each card you discarded in this way.",
 				fr: "Vous pouvez défausser jusqu'à 4 cartes Énergie de votre main. Cette attaque inflige 40 dégâts supplémentaires pour chaque carte défaussée de cette façon.",
-			},
-		},
+				es: "Puedes descartar hasta 4 cartas de Energía de tu mano, y este ataque hace 40 puntos de daño más por cada carta que hayas descartado de esta manera.",
+				de: "Du kannst bis zu 4 Energiekarten aus deiner Hand auf deinen Ablagestapel legen, und diese Attacke fügt für jede auf diese Weise abgelegte Karte 40 Schadenspunkte mehr zu.",
+				it: "Puoi scartare fino a quattro carte Energia dalla tua mano e questo attacco infligge 40 danni in più per ogni carta che hai scartato in questo modo.",
+				pt: "Você pode descartar até 4 cartas de Energia da sua mão, e este ataque causa 40 pontos de dano a mais para cada carta descartada desta forma."
+			}
+		}
 	],
 	weaknesses: [
 		{
 			type: "Metal",
-			value: "×2",
-		},
+			value: "×2"
+		}
 	],
 	retreat: 1,
 	regulationMark: "J",
 	illustrator: "Cona Nitanda",
-
+	variants: [
+		{
+			type: "holo"
+		}
+	],
 	thirdParty: {
+		tcgplayer: 684385,
 		cardmarket: 877536
 	}
 }

--- a/data/Mega Evolution/Perfect Order/120.ts
+++ b/data/Mega Evolution/Perfect Order/120.ts
@@ -3,27 +3,48 @@ import Set from '../Perfect Order'
 
 const card: Card = {
 	name: {
+		en: "Mega Zygarde ex",
 		fr: "Méga-Zygarde-ex",
+		es: "Mega-Zygarde ex",
+		de: "Mega-Zygarde-ex",
+		it: "Mega Zygarde-ex",
+		pt: "Mega Zygarde ex"
 	},
 	set: Set,
 	rarity: "Special illustration rare",
 	category: "Pokemon",
+	dexId: [
+		718
+	],
 	hp: 310,
+	types: [
+		"Fighting"
+	],
 	stage: "Basic",
 	attacks: [
 		{
 			cost: [
 				"Fighting",
 				"Fighting",
-				"Fighting",
+				"Fighting"
 			],
 			name: {
+				en: "Gaia Wave",
 				fr: "Onde de Gaïa",
+				es: "Onda Gaia",
+				de: "Gaia-Welle",
+				it: "Onda Gaia",
+				pt: "Onda de Gaia"
 			},
 			damage: "200",
 			effect: {
+				en: "During your opponent's next turn, this Pokémon takes 30 less damage from attacks (after applying Weakness and Resistance).",
 				fr: "Pendant le prochain tour de votre adversaire, ce Pokémon subit 30 dégâts de moins provenant des attaques (après application de la Faiblesse et de la Résistance).",
-			},
+				es: "Durante el próximo turno de tu rival, los ataques hacen 30 puntos de daño menos a este Pokémon (después de aplicar Debilidad y Resistencia).",
+				de: "Während des nächsten Zuges deines Gegners werden diesem Pokémon durch Attacken 30 Schadenspunkte weniger zugefügt (nachdem Schwäche und Resistenz verrechnet wurden).",
+				it: "Durante il prossimo turno del tuo avversario, questo Pokémon subisce 30 danni in meno dagli attacchi, dopo aver applicato debolezza e resistenza.",
+				pt: "Durante o próximo turno do seu oponente, este Pokémon receberá 30 pontos de dano a menos de ataques (depois de aplicar Fraqueza e Resistência)."
+			}
 		},
 		{
 			cost: [
@@ -31,27 +52,42 @@ const card: Card = {
 				"Fighting",
 				"Fighting",
 				"Fighting",
-				"Fighting",
+				"Fighting"
 			],
 			name: {
+				en: "Nullifying Zero",
 				fr: "Zéro Annihilant",
+				es: "Cero Devastador",
+				de: "Tilgendes Nichts",
+				it: "Tabula Zero",
+				pt: "Zero Anulador"
 			},
 			effect: {
+				en: "For each of your opponent's Pokémon, flip a coin. If heads, this attack does 150 damage to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)",
 				fr: "Pour chacun des Pokémon de votre adversaire, lancez une pièce. Si c'est face, cette attaque inflige 150 dégâts à ce Pokémon-là. (N'appliquez ni la Faiblesse ni la Résistance aux Pokémon de Banc.)",
-			},
-		},
+				es: "Por cada uno de los Pokémon de tu rival, lanza 1 moneda. Si sale cara, este ataque hace 150 puntos de daño a ese Pokémon. (No apliques Debilidad y Resistencia a los Pokémon en Banca).",
+				de: "Wirf für jedes Pokémon deines Gegners 1 Münze. Bei Kopf fügt diese Attacke jenem Pokémon 150 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)",
+				it: "Per ciascuno dei Pokémon del tuo avversario, lancia una moneta. Se esce testa, questo attacco infligge 150 danni a quel Pokémon. Non applicare debolezza e resistenza ai Pokémon in panchina.",
+				pt: "Para cada um dos Pokémon do seu oponente, jogue uma moeda. Se sair cara, este ataque causará 150 pontos de dano àquele Pokémon. (Não aplique Fraqueza e Resistência aos Pokémon no Banco.)"
+			}
+		}
 	],
 	weaknesses: [
 		{
 			type: "Grass",
-			value: "×2",
-		},
+			value: "×2"
+		}
 	],
 	retreat: 2,
 	regulationMark: "J",
 	illustrator: "kantaro",
-
+	variants: [
+		{
+			type: "holo"
+		}
+	],
 	thirdParty: {
+		tcgplayer: 684338,
 		cardmarket: 877537
 	}
 }

--- a/data/Mega Evolution/Perfect Order/121.ts
+++ b/data/Mega Evolution/Perfect Order/121.ts
@@ -3,51 +3,87 @@ import Set from '../Perfect Order'
 
 const card: Card = {
 	name: {
+		en: "Meowth ex",
 		fr: "Miaouss-ex",
+		es: "Meowth ex",
+		de: "Mauzi-ex",
+		it: "Meowth-ex",
+		pt: "Meowth ex"
 	},
 	set: Set,
 	rarity: "Special illustration rare",
 	category: "Pokemon",
+	dexId: [
+		52
+	],
 	hp: 170,
+	types: [
+		"Colorless"
+	],
 	stage: "Basic",
 	abilities: [
 		{
 			type: "Ability",
 			name: {
+				en: "Last-Ditch Catch",
 				fr: "Prise Dernier Ressort",
+				es: "Captura a la Desesperada",
+				de: "Fang aus der Not",
+				it: "Cattura in Extremis",
+				pt: "Chance Final de Captura"
 			},
 			effect: {
+				en: "Once during your turn, when you play this Pokémon from your hand onto your Bench, you may use this Ability. Search your deck for a Supporter card, reveal it, and put it into your hand. Then, shuffle your deck. You can't use more than 1 Ability that has \"Last-Ditch\" in its name each turn.",
 				fr: "Une fois pendant votre tour, lorsque vous jouez ce Pokémon de votre main sur votre Banc, vous pouvez utiliser ce talent. Cherchez dans votre deck une carte Supporter, montrez-la, puis ajoutez-la à votre main. Mélangez ensuite votre deck. Vous ne pouvez utiliser qu'un talent ayant « Dernier Ressort » dans son nom par tour.",
-			},
-		},
+				es: "Una vez durante tu turno, cuando juegas este Pokémon de tu mano a tu Banca, puedes usar esta habilidad. Busca en tu baraja 1 carta de Partidario, enséñala y ponla en tu mano. Después, baraja las cartas de tu baraja. No puedes usar más de una habilidad que tenga \"a la Desesperada\" en su nombre en cada turno.",
+				de: "Einmal während deines Zuges, wenn du dieses Pokémon aus deiner Hand auf deine Bank spielst, kannst du diese Fähigkeit einsetzen. Durchsuche dein Deck nach 1 Unterstützerkarte, zeige sie deinem Gegner und nimm sie auf deine Hand. Mische anschließend dein Deck. Du kannst nur 1 Fähigkeit, bei der „aus der Not\" zum Namen gehört, pro Zug einsetzen.",
+				it: "Una sola volta durante il tuo turno, quando giochi questo Pokémon dalla tua mano e lo metti in panchina, puoi usare questa abilità. Cerca nel tuo mazzo una carta Aiuto, mostrala e aggiungila alle carte che hai in mano. Poi rimischia il tuo mazzo. Non puoi usare più di un'abilità che ha \"in Extremis\" nel nome per turno.",
+				pt: "Uma vez durante o seu turno, quando você jogar este Pokémon da sua mão para o seu Banco, você poderá usar esta Habilidade. Procure por uma carta de Apoiador no seu baralho, revele-a e coloque-a na sua mão. Em seguida, embaralhe o seu baralho. Você não pode usar mais de 1 Habilidade que tem \"Chance Final\" em seu nome por turno."
+			}
+		}
 	],
 	attacks: [
 		{
 			cost: [
 				"Colorless",
 				"Colorless",
-				"Colorless",
+				"Colorless"
 			],
 			name: {
+				en: "Tuck Tail",
 				fr: "Queue Repliée",
+				es: "Cola Asustadiza",
+				de: "Schweif einziehen",
+				it: "Ritiracoda",
+				pt: "Rabo Entre as Pernas"
 			},
 			damage: "60",
 			effect: {
+				en: "Put this Pokémon and all attached cards into your hand.",
 				fr: "Ajoutez à votre main ce Pokémon et toutes les cartes qui lui sont attachées.",
-			},
-		},
+				es: "Pon este Pokémon y todas las cartas unidas a él en tu mano.",
+				de: "Nimm dieses Pokémon und alle angelegten Karten auf deine Hand.",
+				it: "Riprendi in mano questo Pokémon e tutte le carte a esso assegnate.",
+				pt: "Coloque este Pokémon e todas as cartas ligadas a ele na sua mão."
+			}
+		}
 	],
 	weaknesses: [
 		{
 			type: "Fighting",
-			value: "×2",
-		},
+			value: "×2"
+		}
 	],
 	retreat: 1,
 	regulationMark: "J",
 	illustrator: "Natsumi Yoshida",
-
+	variants: [
+		{
+			type: "holo"
+		}
+	],
 	thirdParty: {
+		tcgplayer: 684342,
 		cardmarket: 877538
 	}
 }

--- a/data/Mega Evolution/Perfect Order/122.ts
+++ b/data/Mega Evolution/Perfect Order/122.ts
@@ -3,18 +3,34 @@ import Set from '../Perfect Order'
 
 const card: Card = {
 	name: {
+		en: "Jacinthe",
 		fr: "Violine",
+		es: "Lilette",
+		de: "Violette",
+		it: "Viola",
+		pt: "Jaci"
 	},
 	set: Set,
 	rarity: "Special illustration rare",
 	category: "Trainer",
+	trainerType: "Supporter",
 	regulationMark: "J",
 	illustrator: "Souichirou Gunjima",
 	effect: {
-		fr: "Soignez 150 dégâts de l'un de vos Pokémon Psy.",
+		en: "Heal 150 damage from 1 of your [P] Pokémon.",
+		fr: "Soignez 150 dégâts de l'un de vos Pokémon [P].",
+		es: "Cura 150 puntos de daño a uno de tus Pokémon [P].",
+		de: "Heile 150 Schadenspunkte bei 1 deiner [P]-Pokémon.",
+		it: "Cura uno dei tuoi Pokémon [P] da 150 danni.",
+		pt: "Cure 150 pontos de dano de 1 dos seus Pokémon [P]."
 	},
-
+	variants: [
+		{
+			type: "holo"
+		}
+	],
 	thirdParty: {
+		tcgplayer: 684395,
 		cardmarket: 877539
 	}
 }

--- a/data/Mega Evolution/Perfect Order/123.ts
+++ b/data/Mega Evolution/Perfect Order/123.ts
@@ -3,18 +3,34 @@ import Set from '../Perfect Order'
 
 const card: Card = {
 	name: {
+		en: "Rosa's Encouragement",
 		fr: "Encouragement d'Écho",
+		es: "Apoyo de Nanci",
+		de: "Rosys Ermutigung",
+		it: "Incoraggiamento di Rina",
+		pt: "Encorajamento da Rose"
 	},
 	set: Set,
 	rarity: "Special illustration rare",
 	category: "Trainer",
+	trainerType: "Supporter",
 	regulationMark: "J",
 	illustrator: "Iori Suzuki",
 	effect: {
-		fr: "Vous ne pouvez utiliser cette carte que s'il vous reste plus de cartes Récompense qu'à votre adversaire.",
+		en: "You can use this card only if you have more Prize cards remaining than your opponent.Attach up to 2 Basic Energy cards from your discard pile to 1 of your Stage 2 Pokémon.",
+		fr: "Vous ne pouvez utiliser cette carte que s'il vous reste plus de cartes Récompense qu'à votre adversaire.Attachez jusqu'à 2 cartes Énergie de base de votre pile de défausse à l'un de vos Pokémon de Niveau 2.",
+		es: "Puedes usar esta carta solo si te quedan más cartas de Premio que a tu rival.Une hasta 2 cartas de Energía Básica de tu pila de descartes a uno de tus Pokémon de Fase 2.",
+		de: "Du kannst diese Karte nur einsetzen, wenn du mehr verbleibende Preiskarten hast als dein Gegner.Lege bis zu 2 Basis-Energiekarten aus deinem Ablagestapel an 1 deiner Phase-2-Pokémon an.",
+		it: "Puoi usare questa carta solo se hai più carte Premio rimanenti del tuo avversario.Assegna a uno dei tuoi Pokémon di Fase 2 fino a due carte Energia base dalla tua pila degli scarti.",
+		pt: "Você só poderá usar esta carta se tiver mais cartas de Prêmio restantes que seu oponente.Ligue até 2 cartas de Energia Básica da sua pilha de descarte a 1 dos seus Pokémon Estágio 2."
 	},
-
+	variants: [
+		{
+			type: "holo"
+		}
+	],
 	thirdParty: {
+		tcgplayer: 684392,
 		cardmarket: 877540
 	}
 }

--- a/data/Mega Evolution/Perfect Order/124.ts
+++ b/data/Mega Evolution/Perfect Order/124.ts
@@ -3,27 +3,48 @@ import Set from '../Perfect Order'
 
 const card: Card = {
 	name: {
+		en: "Mega Zygarde ex",
 		fr: "Méga-Zygarde-ex",
+		es: "Mega-Zygarde ex",
+		de: "Mega-Zygarde-ex",
+		it: "Mega Zygarde-ex",
+		pt: "Mega Zygarde ex"
 	},
 	set: Set,
 	rarity: "None",
 	category: "Pokemon",
+	dexId: [
+		718
+	],
 	hp: 310,
+	types: [
+		"Fighting"
+	],
 	stage: "Basic",
 	attacks: [
 		{
 			cost: [
 				"Fighting",
 				"Fighting",
-				"Fighting",
+				"Fighting"
 			],
 			name: {
+				en: "Gaia Wave",
 				fr: "Onde de Gaïa",
+				es: "Onda Gaia",
+				de: "Gaia-Welle",
+				it: "Onda Gaia",
+				pt: "Onda de Gaia"
 			},
 			damage: "200",
 			effect: {
+				en: "During your opponent's next turn, this Pokémon takes 30 less damage from attacks (after applying Weakness and Resistance).",
 				fr: "Pendant le prochain tour de votre adversaire, ce Pokémon subit 30 dégâts de moins provenant des attaques (après application de la Faiblesse et de la Résistance).",
-			},
+				es: "Durante el próximo turno de tu rival, los ataques hacen 30 puntos de daño menos a este Pokémon (después de aplicar Debilidad y Resistencia).",
+				de: "Während des nächsten Zuges deines Gegners werden diesem Pokémon durch Attacken 30 Schadenspunkte weniger zugefügt (nachdem Schwäche und Resistenz verrechnet wurden).",
+				it: "Durante il prossimo turno del tuo avversario, questo Pokémon subisce 30 danni in meno dagli attacchi, dopo aver applicato debolezza e resistenza.",
+				pt: "Durante o próximo turno do seu oponente, este Pokémon receberá 30 pontos de dano a menos de ataques (depois de aplicar Fraqueza e Resistência)."
+			}
 		},
 		{
 			cost: [
@@ -31,27 +52,42 @@ const card: Card = {
 				"Fighting",
 				"Fighting",
 				"Fighting",
-				"Fighting",
+				"Fighting"
 			],
 			name: {
+				en: "Nullifying Zero",
 				fr: "Zéro Annihilant",
+				es: "Cero Devastador",
+				de: "Tilgendes Nichts",
+				it: "Tabula Zero",
+				pt: "Zero Anulador"
 			},
 			effect: {
+				en: "For each of your opponent's Pokémon, flip a coin. If heads, this attack does 150 damage to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)",
 				fr: "Pour chacun des Pokémon de votre adversaire, lancez une pièce. Si c'est face, cette attaque inflige 150 dégâts à ce Pokémon-là. (N'appliquez ni la Faiblesse ni la Résistance aux Pokémon de Banc.)",
-			},
-		},
+				es: "Por cada uno de los Pokémon de tu rival, lanza 1 moneda. Si sale cara, este ataque hace 150 puntos de daño a ese Pokémon. (No apliques Debilidad y Resistencia a los Pokémon en Banca).",
+				de: "Wirf für jedes Pokémon deines Gegners 1 Münze. Bei Kopf fügt diese Attacke jenem Pokémon 150 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)",
+				it: "Per ciascuno dei Pokémon del tuo avversario, lancia una moneta. Se esce testa, questo attacco infligge 150 danni a quel Pokémon. Non applicare debolezza e resistenza ai Pokémon in panchina.",
+				pt: "Para cada um dos Pokémon do seu oponente, jogue uma moeda. Se sair cara, este ataque causará 150 pontos de dano àquele Pokémon. (Não aplique Fraqueza e Resistência aos Pokémon no Banco.)"
+			}
+		}
 	],
 	weaknesses: [
 		{
 			type: "Grass",
-			value: "×2",
-		},
+			value: "×2"
+		}
 	],
 	retreat: 2,
 	regulationMark: "J",
 	illustrator: "takuyoa",
-
+	variants: [
+		{
+			type: "holo"
+		}
+	],
 	thirdParty: {
+		tcgplayer: 684339,
 		cardmarket: 877541
 	}
 }


### PR DESCRIPTION
Add the full Mega Evolution Perfect Order (me03) set with 124 card
files and Cardmarket IDs, TCGplayer ids. 

Co-authored-by: Laurent AMPLIS <lamplis@yahoo.fr>
(cherry picked from commit 513945d)
<!--
Contribution guide: https://github.com/tcgdex/cards-database/blob/master/CONTRIBUTING.md
please submit changes up to 1 set at most.
-->

closes # <!-- Indicate the issue number here -->

## Changes

- Add the full `me03` Mega Evolution Perfect Order set definition and all 124 card files
- Preserve Cardmarket IDs from the original Lamplis import
- Rework the imported cards so the upstream-facing change does not include Cardium-only logo/symbol fallback structure
- Keep attribution to Lamplis' original work via cherry-pick provenance

## Details

This change is based on the original Lamplis import and keeps that contribution attributed accordingly.

I hope this lowers your work - thanks @Aviortheking 

Still missing / follow-up work:
- `es-mx` localizations are still not filled for this set
- Not sure abouht all the evolves
