### PR TITLE
fix(data): add missing dexId for me03 Perfect Order

### DIFF
--- a/data/Mega Evolution/Perfect Order/001.ts
+++ b/data/Mega Evolution/Perfect Order/001.ts
@@ -4,6 +4,8 @@ import Set from "../Perfect Order"
 const card: Card = {
 	set: Set,
 
+	dexId: [167],
+
 	name: {
 		en: "Spinarak",
 		fr: "Mimigal",

--- a/data/Mega Evolution/Perfect Order/002.ts
+++ b/data/Mega Evolution/Perfect Order/002.ts
@@ -4,6 +4,8 @@ import Set from "../Perfect Order"
 const card: Card = {
 	set: Set,
 
+	dexId: [168],
+
 	name: {
 		en: "Ariados",
 		fr: "Migalos",

--- a/data/Mega Evolution/Perfect Order/003.ts
+++ b/data/Mega Evolution/Perfect Order/003.ts
@@ -4,6 +4,8 @@ import Set from "../Perfect Order"
 const card: Card = {
 	set: Set,
 
+	dexId: [492],
+
 	name: {
 		en: "Shaymin",
 		fr: "Shaymin",

--- a/data/Mega Evolution/Perfect Order/004.ts
+++ b/data/Mega Evolution/Perfect Order/004.ts
@@ -4,6 +4,8 @@ import Set from "../Perfect Order"
 const card: Card = {
 	set: Set,
 
+	dexId: [495],
+
 	name: {
 		en: "Snivy",
 		fr: "Vipélierre",

--- a/data/Mega Evolution/Perfect Order/005.ts
+++ b/data/Mega Evolution/Perfect Order/005.ts
@@ -4,6 +4,8 @@ import Set from "../Perfect Order"
 const card: Card = {
 	set: Set,
 
+	dexId: [496],
+
 	name: {
 		en: "Servine",
 		fr: "Lianaja",

--- a/data/Mega Evolution/Perfect Order/006.ts
+++ b/data/Mega Evolution/Perfect Order/006.ts
@@ -4,6 +4,8 @@ import Set from "../Perfect Order"
 const card: Card = {
 	set: Set,
 
+	dexId: [497],
+
 	name: {
 		en: "Serperior",
 		fr: "Majaspic",

--- a/data/Mega Evolution/Perfect Order/007.ts
+++ b/data/Mega Evolution/Perfect Order/007.ts
@@ -4,6 +4,8 @@ import Set from "../Perfect Order"
 const card: Card = {
 	set: Set,
 
+	dexId: [664],
+
 	name: {
 		en: "Scatterbug",
 		fr: "Lépidonille",

--- a/data/Mega Evolution/Perfect Order/008.ts
+++ b/data/Mega Evolution/Perfect Order/008.ts
@@ -4,6 +4,8 @@ import Set from "../Perfect Order"
 const card: Card = {
 	set: Set,
 
+	dexId: [665],
+
 	name: {
 		en: "Spewpa",
 		fr: "Pérégrain",

--- a/data/Mega Evolution/Perfect Order/009.ts
+++ b/data/Mega Evolution/Perfect Order/009.ts
@@ -4,6 +4,8 @@ import Set from "../Perfect Order"
 const card: Card = {
 	set: Set,
 
+	dexId: [666],
+
 	name: {
 		en: "Vivillon",
 		fr: "Prismillon",

--- a/data/Mega Evolution/Perfect Order/010.ts
+++ b/data/Mega Evolution/Perfect Order/010.ts
@@ -4,6 +4,8 @@ import Set from "../Perfect Order"
 const card: Card = {
 	set: Set,
 
+	dexId: [722],
+
 	name: {
 		en: "Rowlet",
 		fr: "Brindibou",

--- a/data/Mega Evolution/Perfect Order/011.ts
+++ b/data/Mega Evolution/Perfect Order/011.ts
@@ -4,6 +4,8 @@ import Set from "../Perfect Order"
 const card: Card = {
 	set: Set,
 
+	dexId: [723],
+
 	name: {
 		en: "Dartrix",
 		fr: "Efflèche",

--- a/data/Mega Evolution/Perfect Order/012.ts
+++ b/data/Mega Evolution/Perfect Order/012.ts
@@ -4,6 +4,8 @@ import Set from "../Perfect Order"
 const card: Card = {
 	set: Set,
 
+	dexId: [724],
+
 	name: {
 		en: "Decidueye ex",
 		fr: "Archéduc-ex",

--- a/data/Mega Evolution/Perfect Order/013.ts
+++ b/data/Mega Evolution/Perfect Order/013.ts
@@ -4,6 +4,8 @@ import Set from "../Perfect Order"
 const card: Card = {
 	set: Set,
 
+	dexId: [662],
+
 	name: {
 		en: "Fletchinder",
 		fr: "Braisillon",

--- a/data/Mega Evolution/Perfect Order/014.ts
+++ b/data/Mega Evolution/Perfect Order/014.ts
@@ -4,6 +4,8 @@ import Set from "../Perfect Order"
 const card: Card = {
 	set: Set,
 
+	dexId: [663],
+
 	name: {
 		en: "Talonflame",
 		fr: "Flambusard",

--- a/data/Mega Evolution/Perfect Order/015.ts
+++ b/data/Mega Evolution/Perfect Order/015.ts
@@ -4,6 +4,8 @@ import Set from "../Perfect Order"
 const card: Card = {
 	set: Set,
 
+	dexId: [757],
+
 	name: {
 		en: "Salandit",
 		fr: "Tritox",

--- a/data/Mega Evolution/Perfect Order/016.ts
+++ b/data/Mega Evolution/Perfect Order/016.ts
@@ -4,6 +4,8 @@ import Set from "../Perfect Order"
 const card: Card = {
 	set: Set,
 
+	dexId: [758],
+
 	name: {
 		en: "Salazzle ex",
 		fr: "Malamandre-ex",

--- a/data/Mega Evolution/Perfect Order/017.ts
+++ b/data/Mega Evolution/Perfect Order/017.ts
@@ -4,6 +4,8 @@ import Set from "../Perfect Order"
 const card: Card = {
 	set: Set,
 
+	dexId: [776],
+
 	name: {
 		en: "Turtonator",
 		fr: "Boumata",

--- a/data/Mega Evolution/Perfect Order/018.ts
+++ b/data/Mega Evolution/Perfect Order/018.ts
@@ -4,6 +4,8 @@ import Set from "../Perfect Order"
 const card: Card = {
 	set: Set,
 
+	dexId: [86],
+
 	name: {
 		en: "Seel",
 		fr: "Otaria",

--- a/data/Mega Evolution/Perfect Order/019.ts
+++ b/data/Mega Evolution/Perfect Order/019.ts
@@ -4,6 +4,8 @@ import Set from "../Perfect Order"
 const card: Card = {
 	set: Set,
 
+	dexId: [87],
+
 	name: {
 		en: "Dewgong",
 		fr: "Lamantine",

--- a/data/Mega Evolution/Perfect Order/020.ts
+++ b/data/Mega Evolution/Perfect Order/020.ts
@@ -4,6 +4,8 @@ import Set from "../Perfect Order"
 const card: Card = {
 	set: Set,
 
+	dexId: [120],
+
 	name: {
 		en: "Staryu",
 		fr: "Stari",

--- a/data/Mega Evolution/Perfect Order/021.ts
+++ b/data/Mega Evolution/Perfect Order/021.ts
@@ -4,6 +4,8 @@ import Set from "../Perfect Order"
 const card: Card = {
 	set: Set,
 
+	dexId: [121],
+
 	name: {
 		en: "Mega Starmie ex",
 		fr: "Méga-Staross-ex",

--- a/data/Mega Evolution/Perfect Order/022.ts
+++ b/data/Mega Evolution/Perfect Order/022.ts
@@ -4,6 +4,8 @@ import Set from "../Perfect Order"
 const card: Card = {
 	set: Set,
 
+	dexId: [131],
+
 	name: {
 		en: "Lapras ex",
 		fr: "Lokhlass-ex",

--- a/data/Mega Evolution/Perfect Order/023.ts
+++ b/data/Mega Evolution/Perfect Order/023.ts
@@ -4,6 +4,8 @@ import Set from "../Perfect Order"
 const card: Card = {
 	set: Set,
 
+	dexId: [698],
+
 	name: {
 		en: "Amaura",
 		fr: "Amagara",

--- a/data/Mega Evolution/Perfect Order/024.ts
+++ b/data/Mega Evolution/Perfect Order/024.ts
@@ -4,6 +4,8 @@ import Set from "../Perfect Order"
 const card: Card = {
 	set: Set,
 
+	dexId: [699],
+
 	name: {
 		en: "Aurorus",
 		fr: "Dragmara",

--- a/data/Mega Evolution/Perfect Order/025.ts
+++ b/data/Mega Evolution/Perfect Order/025.ts
@@ -4,6 +4,8 @@ import Set from "../Perfect Order"
 const card: Card = {
 	set: Set,
 
+	dexId: [721],
+
 	name: {
 		en: "Volcanion",
 		fr: "Volcanion",

--- a/data/Mega Evolution/Perfect Order/026.ts
+++ b/data/Mega Evolution/Perfect Order/026.ts
@@ -4,6 +4,8 @@ import Set from "../Perfect Order"
 const card: Card = {
 	set: Set,
 
+	dexId: [403],
+
 	name: {
 		en: "Shinx",
 		fr: "Lixy",

--- a/data/Mega Evolution/Perfect Order/027.ts
+++ b/data/Mega Evolution/Perfect Order/027.ts
@@ -4,6 +4,8 @@ import Set from "../Perfect Order"
 const card: Card = {
 	set: Set,
 
+	dexId: [404],
+
 	name: {
 		en: "Luxio",
 		fr: "Luxio",

--- a/data/Mega Evolution/Perfect Order/028.ts
+++ b/data/Mega Evolution/Perfect Order/028.ts
@@ -4,6 +4,8 @@ import Set from "../Perfect Order"
 const card: Card = {
 	set: Set,
 
+	dexId: [405],
+
 	name: {
 		en: "Luxray",
 		fr: "Luxray",

--- a/data/Mega Evolution/Perfect Order/029.ts
+++ b/data/Mega Evolution/Perfect Order/029.ts
@@ -4,6 +4,8 @@ import Set from "../Perfect Order"
 const card: Card = {
 	set: Set,
 
+	dexId: [702],
+
 	name: {
 		en: "Dedenne",
 		fr: "Dedenne",

--- a/data/Mega Evolution/Perfect Order/030.ts
+++ b/data/Mega Evolution/Perfect Order/030.ts
@@ -4,6 +4,8 @@ import Set from "../Perfect Order"
 const card: Card = {
 	set: Set,
 
+	dexId: [35],
+
 	name: {
 		en: "Clefairy",
 		fr: "Mélofée",

--- a/data/Mega Evolution/Perfect Order/031.ts
+++ b/data/Mega Evolution/Perfect Order/031.ts
@@ -4,6 +4,8 @@ import Set from "../Perfect Order"
 const card: Card = {
 	set: Set,
 
+	dexId: [36],
+
 	name: {
 		en: "Mega Clefable ex",
 		fr: "Méga-Mélodelfe-ex",

--- a/data/Mega Evolution/Perfect Order/032.ts
+++ b/data/Mega Evolution/Perfect Order/032.ts
@@ -4,6 +4,8 @@ import Set from "../Perfect Order"
 const card: Card = {
 	set: Set,
 
+	dexId: [303],
+
 	name: {
 		en: "Mawile",
 		fr: "Mysdibule",

--- a/data/Mega Evolution/Perfect Order/033.ts
+++ b/data/Mega Evolution/Perfect Order/033.ts
@@ -4,6 +4,8 @@ import Set from "../Perfect Order"
 const card: Card = {
 	set: Set,
 
+	dexId: [677],
+
 	name: {
 		en: "Espurr",
 		fr: "Psystigri",

--- a/data/Mega Evolution/Perfect Order/034.ts
+++ b/data/Mega Evolution/Perfect Order/034.ts
@@ -4,6 +4,8 @@ import Set from "../Perfect Order"
 const card: Card = {
 	set: Set,
 
+	dexId: [678],
+
 	name: {
 		en: "Meowstic",
 		fr: "Mistigrix",

--- a/data/Mega Evolution/Perfect Order/035.ts
+++ b/data/Mega Evolution/Perfect Order/035.ts
@@ -4,6 +4,8 @@ import Set from "../Perfect Order"
 const card: Card = {
 	set: Set,
 
+	dexId: [682],
+
 	name: {
 		en: "Spritzee",
 		fr: "Fluvetin",

--- a/data/Mega Evolution/Perfect Order/036.ts
+++ b/data/Mega Evolution/Perfect Order/036.ts
@@ -4,6 +4,8 @@ import Set from "../Perfect Order"
 const card: Card = {
 	set: Set,
 
+	dexId: [683],
+
 	name: {
 		en: "Aromatisse",
 		fr: "Cocotine",

--- a/data/Mega Evolution/Perfect Order/037.ts
+++ b/data/Mega Evolution/Perfect Order/037.ts
@@ -4,6 +4,8 @@ import Set from "../Perfect Order"
 const card: Card = {
 	set: Set,
 
+	dexId: [299],
+
 	name: {
 		en: "Nosepass",
 		fr: "Tarinor",

--- a/data/Mega Evolution/Perfect Order/038.ts
+++ b/data/Mega Evolution/Perfect Order/038.ts
@@ -4,6 +4,8 @@ import Set from "../Perfect Order"
 const card: Card = {
 	set: Set,
 
+	dexId: [476],
+
 	name: {
 		en: "Probopass",
 		fr: "Tarinorme",

--- a/data/Mega Evolution/Perfect Order/039.ts
+++ b/data/Mega Evolution/Perfect Order/039.ts
@@ -4,6 +4,8 @@ import Set from "../Perfect Order"
 const card: Card = {
 	set: Set,
 
+	dexId: [449],
+
 	name: {
 		en: "Hippopotas",
 		fr: "Hippopotas",

--- a/data/Mega Evolution/Perfect Order/040.ts
+++ b/data/Mega Evolution/Perfect Order/040.ts
@@ -4,6 +4,8 @@ import Set from "../Perfect Order"
 const card: Card = {
 	set: Set,
 
+	dexId: [450],
+
 	name: {
 		en: "Hippowdon",
 		fr: "Hippodocus",

--- a/data/Mega Evolution/Perfect Order/041.ts
+++ b/data/Mega Evolution/Perfect Order/041.ts
@@ -4,6 +4,8 @@ import Set from "../Perfect Order"
 const card: Card = {
 	set: Set,
 
+	dexId: [645],
+
 	name: {
 		en: "Landorus",
 		fr: "Démétéros",

--- a/data/Mega Evolution/Perfect Order/042.ts
+++ b/data/Mega Evolution/Perfect Order/042.ts
@@ -4,6 +4,8 @@ import Set from "../Perfect Order"
 const card: Card = {
 	set: Set,
 
+	dexId: [688],
+
 	name: {
 		en: "Binacle",
 		fr: "Opermine",

--- a/data/Mega Evolution/Perfect Order/043.ts
+++ b/data/Mega Evolution/Perfect Order/043.ts
@@ -4,6 +4,8 @@ import Set from "../Perfect Order"
 const card: Card = {
 	set: Set,
 
+	dexId: [689],
+
 	name: {
 		en: "Barbaracle",
 		fr: "Golgopathe",

--- a/data/Mega Evolution/Perfect Order/044.ts
+++ b/data/Mega Evolution/Perfect Order/044.ts
@@ -4,6 +4,8 @@ import Set from "../Perfect Order"
 const card: Card = {
 	set: Set,
 
+	dexId: [696],
+
 	name: {
 		en: "Tyrunt",
 		fr: "Ptyranidur",

--- a/data/Mega Evolution/Perfect Order/045.ts
+++ b/data/Mega Evolution/Perfect Order/045.ts
@@ -4,6 +4,8 @@ import Set from "../Perfect Order"
 const card: Card = {
 	set: Set,
 
+	dexId: [697],
+
 	name: {
 		en: "Tyrantrum",
 		fr: "Rexillius",

--- a/data/Mega Evolution/Perfect Order/046.ts
+++ b/data/Mega Evolution/Perfect Order/046.ts
@@ -4,6 +4,8 @@ import Set from "../Perfect Order"
 const card: Card = {
 	set: Set,
 
+	dexId: [701],
+
 	name: {
 		en: "Hawlucha",
 		fr: "Brutalibré",

--- a/data/Mega Evolution/Perfect Order/047.ts
+++ b/data/Mega Evolution/Perfect Order/047.ts
@@ -4,6 +4,8 @@ import Set from "../Perfect Order"
 const card: Card = {
 	set: Set,
 
+	dexId: [718],
+
 	name: {
 		en: "Mega Zygarde ex",
 		fr: "Méga-Zygarde-ex",

--- a/data/Mega Evolution/Perfect Order/048.ts
+++ b/data/Mega Evolution/Perfect Order/048.ts
@@ -4,6 +4,8 @@ import Set from "../Perfect Order"
 const card: Card = {
 	set: Set,
 
+	dexId: [92],
+
 	name: {
 		en: "Gastly",
 		fr: "Fantominus",

--- a/data/Mega Evolution/Perfect Order/049.ts
+++ b/data/Mega Evolution/Perfect Order/049.ts
@@ -4,6 +4,8 @@ import Set from "../Perfect Order"
 const card: Card = {
 	set: Set,
 
+	dexId: [93],
+
 	name: {
 		en: "Haunter",
 		fr: "Spectrum",

--- a/data/Mega Evolution/Perfect Order/050.ts
+++ b/data/Mega Evolution/Perfect Order/050.ts
@@ -4,6 +4,8 @@ import Set from "../Perfect Order"
 const card: Card = {
 	set: Set,
 
+	dexId: [94],
+
 	name: {
 		en: "Gengar",
 		fr: "Ectoplasma",

--- a/data/Mega Evolution/Perfect Order/051.ts
+++ b/data/Mega Evolution/Perfect Order/051.ts
@@ -4,6 +4,8 @@ import Set from "../Perfect Order"
 const card: Card = {
 	set: Set,
 
+	dexId: [451],
+
 	name: {
 		en: "Skorupi",
 		fr: "Rapion",

--- a/data/Mega Evolution/Perfect Order/052.ts
+++ b/data/Mega Evolution/Perfect Order/052.ts
@@ -4,6 +4,8 @@ import Set from "../Perfect Order"
 const card: Card = {
 	set: Set,
 
+	dexId: [452],
+
 	name: {
 		en: "Drapion",
 		fr: "Drascore",

--- a/data/Mega Evolution/Perfect Order/053.ts
+++ b/data/Mega Evolution/Perfect Order/053.ts
@@ -4,6 +4,8 @@ import Set from "../Perfect Order"
 const card: Card = {
 	set: Set,
 
+	dexId: [717],
+
 	name: {
 		en: "Yveltal ex",
 		fr: "Yveltal-ex",

--- a/data/Mega Evolution/Perfect Order/054.ts
+++ b/data/Mega Evolution/Perfect Order/054.ts
@@ -4,6 +4,8 @@ import Set from "../Perfect Order"
 const card: Card = {
 	set: Set,
 
+	dexId: [1002],
+
 	name: {
 		en: "Chien-Pao",
 		fr: "Baojian",

--- a/data/Mega Evolution/Perfect Order/055.ts
+++ b/data/Mega Evolution/Perfect Order/055.ts
@@ -4,6 +4,8 @@ import Set from "../Perfect Order"
 const card: Card = {
 	set: Set,
 
+	dexId: [227],
+
 	name: {
 		en: "Mega Skarmory ex",
 		fr: "Méga-Airmure-ex",

--- a/data/Mega Evolution/Perfect Order/056.ts
+++ b/data/Mega Evolution/Perfect Order/056.ts
@@ -4,6 +4,8 @@ import Set from "../Perfect Order"
 const card: Card = {
 	set: Set,
 
+	dexId: [679],
+
 	name: {
 		en: "Honedge",
 		fr: "Monorpale",

--- a/data/Mega Evolution/Perfect Order/057.ts
+++ b/data/Mega Evolution/Perfect Order/057.ts
@@ -4,6 +4,8 @@ import Set from "../Perfect Order"
 const card: Card = {
 	set: Set,
 
+	dexId: [680],
+
 	name: {
 		en: "Doublade",
 		fr: "Dimoclès",

--- a/data/Mega Evolution/Perfect Order/058.ts
+++ b/data/Mega Evolution/Perfect Order/058.ts
@@ -4,6 +4,8 @@ import Set from "../Perfect Order"
 const card: Card = {
 	set: Set,
 
+	dexId: [681],
+
 	name: {
 		en: "Aegislash",
 		fr: "Exagide",

--- a/data/Mega Evolution/Perfect Order/059.ts
+++ b/data/Mega Evolution/Perfect Order/059.ts
@@ -4,6 +4,8 @@ import Set from "../Perfect Order"
 const card: Card = {
 	set: Set,
 
+	dexId: [707],
+
 	name: {
 		en: "Klefki",
 		fr: "Trousselin",

--- a/data/Mega Evolution/Perfect Order/060.ts
+++ b/data/Mega Evolution/Perfect Order/060.ts
@@ -4,6 +4,8 @@ import Set from "../Perfect Order"
 const card: Card = {
 	set: Set,
 
+	dexId: [19],
+
 	name: {
 		en: "Rattata",
 		fr: "Rattata",

--- a/data/Mega Evolution/Perfect Order/061.ts
+++ b/data/Mega Evolution/Perfect Order/061.ts
@@ -4,6 +4,8 @@ import Set from "../Perfect Order"
 const card: Card = {
 	set: Set,
 
+	dexId: [20],
+
 	name: {
 		en: "Raticate",
 		fr: "Rattatac",

--- a/data/Mega Evolution/Perfect Order/062.ts
+++ b/data/Mega Evolution/Perfect Order/062.ts
@@ -4,6 +4,8 @@ import Set from "../Perfect Order"
 const card: Card = {
 	set: Set,
 
+	dexId: [52],
+
 	name: {
 		en: "Meowth ex",
 		fr: "Miaouss-ex",

--- a/data/Mega Evolution/Perfect Order/063.ts
+++ b/data/Mega Evolution/Perfect Order/063.ts
@@ -4,6 +4,8 @@ import Set from "../Perfect Order"
 const card: Card = {
 	set: Set,
 
+	dexId: [143],
+
 	name: {
 		en: "Snorlax",
 		fr: "Ronflex",

--- a/data/Mega Evolution/Perfect Order/064.ts
+++ b/data/Mega Evolution/Perfect Order/064.ts
@@ -4,6 +4,8 @@ import Set from "../Perfect Order"
 const card: Card = {
 	set: Set,
 
+	dexId: [659],
+
 	name: {
 		en: "Bunnelby",
 		fr: "Sapereau",

--- a/data/Mega Evolution/Perfect Order/065.ts
+++ b/data/Mega Evolution/Perfect Order/065.ts
@@ -4,6 +4,8 @@ import Set from "../Perfect Order"
 const card: Card = {
 	set: Set,
 
+	dexId: [660],
+
 	name: {
 		en: "Diggersby",
 		fr: "Excavarenne",

--- a/data/Mega Evolution/Perfect Order/066.ts
+++ b/data/Mega Evolution/Perfect Order/066.ts
@@ -4,6 +4,8 @@ import Set from "../Perfect Order"
 const card: Card = {
 	set: Set,
 
+	dexId: [661],
+
 	name: {
 		en: "Fletchling",
 		fr: "Passerouge",

--- a/data/Mega Evolution/Perfect Order/067.ts
+++ b/data/Mega Evolution/Perfect Order/067.ts
@@ -4,6 +4,8 @@ import Set from "../Perfect Order"
 const card: Card = {
 	set: Set,
 
+	dexId: [676],
+
 	name: {
 		en: "Furfrou",
 		fr: "Couafarel",

--- a/data/Mega Evolution/Perfect Order/089.ts
+++ b/data/Mega Evolution/Perfect Order/089.ts
@@ -4,6 +4,8 @@ import Set from "../Perfect Order"
 const card: Card = {
 	set: Set,
 
+	dexId: [665],
+
 	name: {
 		en: "Spewpa",
 		fr: "Pérégrain",

--- a/data/Mega Evolution/Perfect Order/090.ts
+++ b/data/Mega Evolution/Perfect Order/090.ts
@@ -4,6 +4,8 @@ import Set from "../Perfect Order"
 const card: Card = {
 	set: Set,
 
+	dexId: [722],
+
 	name: {
 		en: "Rowlet",
 		fr: "Brindibou",

--- a/data/Mega Evolution/Perfect Order/091.ts
+++ b/data/Mega Evolution/Perfect Order/091.ts
@@ -4,6 +4,8 @@ import Set from "../Perfect Order"
 const card: Card = {
 	set: Set,
 
+	dexId: [663],
+
 	name: {
 		en: "Talonflame",
 		fr: "Flambusard",

--- a/data/Mega Evolution/Perfect Order/092.ts
+++ b/data/Mega Evolution/Perfect Order/092.ts
@@ -4,6 +4,8 @@ import Set from "../Perfect Order"
 const card: Card = {
 	set: Set,
 
+	dexId: [699],
+
 	name: {
 		en: "Aurorus",
 		fr: "Dragmara",

--- a/data/Mega Evolution/Perfect Order/093.ts
+++ b/data/Mega Evolution/Perfect Order/093.ts
@@ -4,6 +4,8 @@ import Set from "../Perfect Order"
 const card: Card = {
 	set: Set,
 
+	dexId: [702],
+
 	name: {
 		en: "Dedenne",
 		fr: "Dedenne",

--- a/data/Mega Evolution/Perfect Order/094.ts
+++ b/data/Mega Evolution/Perfect Order/094.ts
@@ -4,6 +4,8 @@ import Set from "../Perfect Order"
 const card: Card = {
 	set: Set,
 
+	dexId: [35],
+
 	name: {
 		en: "Clefairy",
 		fr: "Mélofée",

--- a/data/Mega Evolution/Perfect Order/095.ts
+++ b/data/Mega Evolution/Perfect Order/095.ts
@@ -4,6 +4,8 @@ import Set from "../Perfect Order"
 const card: Card = {
 	set: Set,
 
+	dexId: [677],
+
 	name: {
 		en: "Espurr",
 		fr: "Psystigri",

--- a/data/Mega Evolution/Perfect Order/096.ts
+++ b/data/Mega Evolution/Perfect Order/096.ts
@@ -4,6 +4,8 @@ import Set from "../Perfect Order"
 const card: Card = {
 	set: Set,
 
+	dexId: [476],
+
 	name: {
 		en: "Probopass",
 		fr: "Tarinorme",

--- a/data/Mega Evolution/Perfect Order/097.ts
+++ b/data/Mega Evolution/Perfect Order/097.ts
@@ -4,6 +4,8 @@ import Set from "../Perfect Order"
 const card: Card = {
 	set: Set,
 
+	dexId: [452],
+
 	name: {
 		en: "Drapion",
 		fr: "Drascore",

--- a/data/Mega Evolution/Perfect Order/098.ts
+++ b/data/Mega Evolution/Perfect Order/098.ts
@@ -4,6 +4,8 @@ import Set from "../Perfect Order"
 const card: Card = {
 	set: Set,
 
+	dexId: [680],
+
 	name: {
 		en: "Doublade",
 		fr: "Dimoclès",

--- a/data/Mega Evolution/Perfect Order/099.ts
+++ b/data/Mega Evolution/Perfect Order/099.ts
@@ -4,6 +4,8 @@ import Set from "../Perfect Order"
 const card: Card = {
 	set: Set,
 
+	dexId: [20],
+
 	name: {
 		en: "Raticate",
 		fr: "Rattatac",

--- a/data/Mega Evolution/Perfect Order/100.ts
+++ b/data/Mega Evolution/Perfect Order/100.ts
@@ -4,6 +4,8 @@ import Set from "../Perfect Order"
 const card: Card = {
 	set: Set,
 
+	dexId: [724],
+
 	name: {
 		en: "Decidueye ex",
 		fr: "Archéduc-ex",

--- a/data/Mega Evolution/Perfect Order/101.ts
+++ b/data/Mega Evolution/Perfect Order/101.ts
@@ -4,6 +4,8 @@ import Set from "../Perfect Order"
 const card: Card = {
 	set: Set,
 
+	dexId: [758],
+
 	name: {
 		en: "Salazzle ex",
 		fr: "Malamandre-ex",

--- a/data/Mega Evolution/Perfect Order/102.ts
+++ b/data/Mega Evolution/Perfect Order/102.ts
@@ -4,6 +4,8 @@ import Set from "../Perfect Order"
 const card: Card = {
 	set: Set,
 
+	dexId: [121],
+
 	name: {
 		en: "Mega Starmie ex",
 		fr: "Méga-Staross-ex",

--- a/data/Mega Evolution/Perfect Order/103.ts
+++ b/data/Mega Evolution/Perfect Order/103.ts
@@ -4,6 +4,8 @@ import Set from "../Perfect Order"
 const card: Card = {
 	set: Set,
 
+	dexId: [36],
+
 	name: {
 		en: "Mega Clefable ex",
 		fr: "Méga-Mélodelfe-ex",

--- a/data/Mega Evolution/Perfect Order/104.ts
+++ b/data/Mega Evolution/Perfect Order/104.ts
@@ -4,6 +4,8 @@ import Set from "../Perfect Order"
 const card: Card = {
 	set: Set,
 
+	dexId: [718],
+
 	name: {
 		en: "Mega Zygarde ex",
 		fr: "Méga-Zygarde-ex",

--- a/data/Mega Evolution/Perfect Order/105.ts
+++ b/data/Mega Evolution/Perfect Order/105.ts
@@ -4,6 +4,8 @@ import Set from "../Perfect Order"
 const card: Card = {
 	set: Set,
 
+	dexId: [717],
+
 	name: {
 		en: "Yveltal ex",
 		fr: "Yveltal-ex",

--- a/data/Mega Evolution/Perfect Order/106.ts
+++ b/data/Mega Evolution/Perfect Order/106.ts
@@ -4,6 +4,8 @@ import Set from "../Perfect Order"
 const card: Card = {
 	set: Set,
 
+	dexId: [227],
+
 	name: {
 		en: "Mega Skarmory ex",
 		fr: "Méga-Airmure-ex",

--- a/data/Mega Evolution/Perfect Order/107.ts
+++ b/data/Mega Evolution/Perfect Order/107.ts
@@ -4,6 +4,8 @@ import Set from "../Perfect Order"
 const card: Card = {
 	set: Set,
 
+	dexId: [52],
+
 	name: {
 		en: "Meowth ex",
 		fr: "Miaouss-ex",

--- a/data/Mega Evolution/Perfect Order/118.ts
+++ b/data/Mega Evolution/Perfect Order/118.ts
@@ -4,6 +4,8 @@ import Set from "../Perfect Order"
 const card: Card = {
 	set: Set,
 
+	dexId: [121],
+
 	name: {
 		en: "Mega Starmie ex",
 		fr: "Méga-Staross-ex",

--- a/data/Mega Evolution/Perfect Order/119.ts
+++ b/data/Mega Evolution/Perfect Order/119.ts
@@ -4,6 +4,8 @@ import Set from "../Perfect Order"
 const card: Card = {
 	set: Set,
 
+	dexId: [36],
+
 	name: {
 		en: "Mega Clefable ex",
 		fr: "Méga-Mélodelfe-ex",

--- a/data/Mega Evolution/Perfect Order/120.ts
+++ b/data/Mega Evolution/Perfect Order/120.ts
@@ -4,6 +4,8 @@ import Set from "../Perfect Order"
 const card: Card = {
 	set: Set,
 
+	dexId: [718],
+
 	name: {
 		en: "Mega Zygarde ex",
 		fr: "Méga-Zygarde-ex",

--- a/data/Mega Evolution/Perfect Order/121.ts
+++ b/data/Mega Evolution/Perfect Order/121.ts
@@ -4,6 +4,8 @@ import Set from "../Perfect Order"
 const card: Card = {
 	set: Set,
 
+	dexId: [52],
+
 	name: {
 		en: "Meowth ex",
 		fr: "Miaouss-ex",

--- a/data/Mega Evolution/Perfect Order/124.ts
+++ b/data/Mega Evolution/Perfect Order/124.ts
@@ -4,6 +4,8 @@ import Set from "../Perfect Order"
 const card: Card = {
 	set: Set,
 
+	dexId: [718],
+
 	name: {
 		en: "Mega Zygarde ex",
 		fr: "Méga-Zygarde-ex",


### PR DESCRIPTION
## Summary
- add missing `dexId` fields for Pokemon cards in `Mega Evolution/Perfect Order`
- branch is based on `upstream/master` and contains only this set scope
- generated with the dexId fixer workflow and validated for set-only diff scope

## Regenerate dexId process
1. `bun run dex:fix:dry-run` to preview missing/updated dexId assignments.
2. `bun run dex:fix:apply` to write dexId changes in card files.
3. `bun run dex:lint` to verify all Pokemon cards have valid dexId.
4. Optional: `bun run dex:audit:report` for a detailed audit report.

## Validation
- set-only scope verified: all changed files are under `data/Mega Evolution/Perfect Order/`
- all changed files contain `dexId`