### PR TITLE
fix(data): add missing dexId for tcgp Crimson Blaze

### DIFF
--- a/data/Pokémon TCG Pocket/Crimson Blaze/001.ts
+++ b/data/Pokémon TCG Pocket/Crimson Blaze/001.ts
@@ -4,6 +4,8 @@ import Set from "../Crimson Blaze"
 const card: Card = {
 	set: Set,
 
+	dexId: [1],
+
 	name: {
 		en: "Bulbasaur"
 	},

--- a/data/Pokémon TCG Pocket/Crimson Blaze/002.ts
+++ b/data/Pokémon TCG Pocket/Crimson Blaze/002.ts
@@ -4,6 +4,8 @@ import Set from "../Crimson Blaze"
 const card: Card = {
 	set: Set,
 
+	dexId: [2],
+
 	name: {
 		en: "Ivysaur"
 	},

--- a/data/Pokémon TCG Pocket/Crimson Blaze/003.ts
+++ b/data/Pokémon TCG Pocket/Crimson Blaze/003.ts
@@ -4,6 +4,8 @@ import Set from "../Crimson Blaze"
 const card: Card = {
 	set: Set,
 
+	dexId: [3],
+
 	name: {
 		en: "Venusaur"
 	},

--- a/data/Pokémon TCG Pocket/Crimson Blaze/004.ts
+++ b/data/Pokémon TCG Pocket/Crimson Blaze/004.ts
@@ -4,6 +4,8 @@ import Set from "../Crimson Blaze"
 const card: Card = {
 	set: Set,
 
+	dexId: [3],
+
 	name: {
 		en: "Mega Venusaur ex"
 	},

--- a/data/Pokémon TCG Pocket/Crimson Blaze/005.ts
+++ b/data/Pokémon TCG Pocket/Crimson Blaze/005.ts
@@ -4,6 +4,8 @@ import Set from "../Crimson Blaze"
 const card: Card = {
 	set: Set,
 
+	dexId: [167],
+
 	name: {
 		en: "Spinarak"
 	},

--- a/data/Pokémon TCG Pocket/Crimson Blaze/006.ts
+++ b/data/Pokémon TCG Pocket/Crimson Blaze/006.ts
@@ -4,6 +4,8 @@ import Set from "../Crimson Blaze"
 const card: Card = {
 	set: Set,
 
+	dexId: [168],
+
 	name: {
 		en: "Ariados"
 	},

--- a/data/Pokémon TCG Pocket/Crimson Blaze/007.ts
+++ b/data/Pokémon TCG Pocket/Crimson Blaze/007.ts
@@ -4,6 +4,8 @@ import Set from "../Crimson Blaze"
 const card: Card = {
 	set: Set,
 
+	dexId: [191],
+
 	name: {
 		en: "Sunkern"
 	},

--- a/data/Pokémon TCG Pocket/Crimson Blaze/008.ts
+++ b/data/Pokémon TCG Pocket/Crimson Blaze/008.ts
@@ -4,6 +4,8 @@ import Set from "../Crimson Blaze"
 const card: Card = {
 	set: Set,
 
+	dexId: [192],
+
 	name: {
 		en: "Sunflora"
 	},

--- a/data/Pokémon TCG Pocket/Crimson Blaze/009.ts
+++ b/data/Pokémon TCG Pocket/Crimson Blaze/009.ts
@@ -4,6 +4,8 @@ import Set from "../Crimson Blaze"
 const card: Card = {
 	set: Set,
 
+	dexId: [412],
+
 	name: {
 		en: "Burmy"
 	},

--- a/data/Pokémon TCG Pocket/Crimson Blaze/010.ts
+++ b/data/Pokémon TCG Pocket/Crimson Blaze/010.ts
@@ -4,6 +4,8 @@ import Set from "../Crimson Blaze"
 const card: Card = {
 	set: Set,
 
+	dexId: [414],
+
 	name: {
 		en: "Mothim"
 	},

--- a/data/Pokémon TCG Pocket/Crimson Blaze/011.ts
+++ b/data/Pokémon TCG Pocket/Crimson Blaze/011.ts
@@ -4,6 +4,8 @@ import Set from "../Crimson Blaze"
 const card: Card = {
 	set: Set,
 
+	dexId: [4],
+
 	name: {
 		en: "Charmander"
 	},

--- a/data/Pokémon TCG Pocket/Crimson Blaze/012.ts
+++ b/data/Pokémon TCG Pocket/Crimson Blaze/012.ts
@@ -4,6 +4,8 @@ import Set from "../Crimson Blaze"
 const card: Card = {
 	set: Set,
 
+	dexId: [5],
+
 	name: {
 		en: "Charmeleon"
 	},

--- a/data/Pokémon TCG Pocket/Crimson Blaze/013.ts
+++ b/data/Pokémon TCG Pocket/Crimson Blaze/013.ts
@@ -4,6 +4,8 @@ import Set from "../Crimson Blaze"
 const card: Card = {
 	set: Set,
 
+	dexId: [6],
+
 	name: {
 		en: "Charizard"
 	},

--- a/data/Pokémon TCG Pocket/Crimson Blaze/014.ts
+++ b/data/Pokémon TCG Pocket/Crimson Blaze/014.ts
@@ -4,6 +4,8 @@ import Set from "../Crimson Blaze"
 const card: Card = {
 	set: Set,
 
+	dexId: [6],
+
 	name: {
 		en: "Mega Charizard Y ex"
 	},

--- a/data/Pokémon TCG Pocket/Crimson Blaze/015.ts
+++ b/data/Pokémon TCG Pocket/Crimson Blaze/015.ts
@@ -4,6 +4,8 @@ import Set from "../Crimson Blaze"
 const card: Card = {
 	set: Set,
 
+	dexId: [228],
+
 	name: {
 		en: "Houndour"
 	},

--- a/data/Pokémon TCG Pocket/Crimson Blaze/016.ts
+++ b/data/Pokémon TCG Pocket/Crimson Blaze/016.ts
@@ -4,6 +4,8 @@ import Set from "../Crimson Blaze"
 const card: Card = {
 	set: Set,
 
+	dexId: [229],
+
 	name: {
 		en: "Houndoom"
 	},

--- a/data/Pokémon TCG Pocket/Crimson Blaze/017.ts
+++ b/data/Pokémon TCG Pocket/Crimson Blaze/017.ts
@@ -4,6 +4,8 @@ import Set from "../Crimson Blaze"
 const card: Card = {
 	set: Set,
 
+	dexId: [7],
+
 	name: {
 		en: "Squirtle"
 	},

--- a/data/Pokémon TCG Pocket/Crimson Blaze/018.ts
+++ b/data/Pokémon TCG Pocket/Crimson Blaze/018.ts
@@ -4,6 +4,8 @@ import Set from "../Crimson Blaze"
 const card: Card = {
 	set: Set,
 
+	dexId: [8],
+
 	name: {
 		en: "Wartortle"
 	},

--- a/data/Pokémon TCG Pocket/Crimson Blaze/019.ts
+++ b/data/Pokémon TCG Pocket/Crimson Blaze/019.ts
@@ -4,6 +4,8 @@ import Set from "../Crimson Blaze"
 const card: Card = {
 	set: Set,
 
+	dexId: [9],
+
 	name: {
 		en: "Blastoise"
 	},

--- a/data/Pokémon TCG Pocket/Crimson Blaze/020.ts
+++ b/data/Pokémon TCG Pocket/Crimson Blaze/020.ts
@@ -4,6 +4,8 @@ import Set from "../Crimson Blaze"
 const card: Card = {
 	set: Set,
 
+	dexId: [9],
+
 	name: {
 		en: "Mega Blastoise ex"
 	},

--- a/data/Pokémon TCG Pocket/Crimson Blaze/021.ts
+++ b/data/Pokémon TCG Pocket/Crimson Blaze/021.ts
@@ -4,6 +4,8 @@ import Set from "../Crimson Blaze"
 const card: Card = {
 	set: Set,
 
+	dexId: [550],
+
 	name: {
 		en: "Basculin"
 	},

--- a/data/Pokémon TCG Pocket/Crimson Blaze/022.ts
+++ b/data/Pokémon TCG Pocket/Crimson Blaze/022.ts
@@ -4,6 +4,8 @@ import Set from "../Crimson Blaze"
 const card: Card = {
 	set: Set,
 
+	dexId: [692],
+
 	name: {
 		en: "Clauncher"
 	},

--- a/data/Pokémon TCG Pocket/Crimson Blaze/023.ts
+++ b/data/Pokémon TCG Pocket/Crimson Blaze/023.ts
@@ -4,6 +4,8 @@ import Set from "../Crimson Blaze"
 const card: Card = {
 	set: Set,
 
+	dexId: [693],
+
 	name: {
 		en: "Clawitzer"
 	},

--- a/data/Pokémon TCG Pocket/Crimson Blaze/024.ts
+++ b/data/Pokémon TCG Pocket/Crimson Blaze/024.ts
@@ -4,6 +4,8 @@ import Set from "../Crimson Blaze"
 const card: Card = {
 	set: Set,
 
+	dexId: [81],
+
 	name: {
 		en: "Magnemite"
 	},

--- a/data/Pokémon TCG Pocket/Crimson Blaze/025.ts
+++ b/data/Pokémon TCG Pocket/Crimson Blaze/025.ts
@@ -4,6 +4,8 @@ import Set from "../Crimson Blaze"
 const card: Card = {
 	set: Set,
 
+	dexId: [82],
+
 	name: {
 		en: "Magneton"
 	},

--- a/data/Pokémon TCG Pocket/Crimson Blaze/026.ts
+++ b/data/Pokémon TCG Pocket/Crimson Blaze/026.ts
@@ -4,6 +4,8 @@ import Set from "../Crimson Blaze"
 const card: Card = {
 	set: Set,
 
+	dexId: [462],
+
 	name: {
 		en: "Magnezone"
 	},

--- a/data/Pokémon TCG Pocket/Crimson Blaze/027.ts
+++ b/data/Pokémon TCG Pocket/Crimson Blaze/027.ts
@@ -4,6 +4,8 @@ import Set from "../Crimson Blaze"
 const card: Card = {
 	set: Set,
 
+	dexId: [587],
+
 	name: {
 		en: "Emolga"
 	},

--- a/data/Pokémon TCG Pocket/Crimson Blaze/028.ts
+++ b/data/Pokémon TCG Pocket/Crimson Blaze/028.ts
@@ -4,6 +4,8 @@ import Set from "../Crimson Blaze"
 const card: Card = {
 	set: Set,
 
+	dexId: [694],
+
 	name: {
 		en: "Helioptile"
 	},

--- a/data/Pokémon TCG Pocket/Crimson Blaze/029.ts
+++ b/data/Pokémon TCG Pocket/Crimson Blaze/029.ts
@@ -4,6 +4,8 @@ import Set from "../Crimson Blaze"
 const card: Card = {
 	set: Set,
 
+	dexId: [695],
+
 	name: {
 		en: "Heliolisk"
 	},

--- a/data/Pokémon TCG Pocket/Crimson Blaze/030.ts
+++ b/data/Pokémon TCG Pocket/Crimson Blaze/030.ts
@@ -4,6 +4,8 @@ import Set from "../Crimson Blaze"
 const card: Card = {
 	set: Set,
 
+	dexId: [200],
+
 	name: {
 		en: "Misdreavus"
 	},

--- a/data/Pokémon TCG Pocket/Crimson Blaze/031.ts
+++ b/data/Pokémon TCG Pocket/Crimson Blaze/031.ts
@@ -4,6 +4,8 @@ import Set from "../Crimson Blaze"
 const card: Card = {
 	set: Set,
 
+	dexId: [429],
+
 	name: {
 		en: "Mismagius"
 	},

--- a/data/Pokémon TCG Pocket/Crimson Blaze/032.ts
+++ b/data/Pokémon TCG Pocket/Crimson Blaze/032.ts
@@ -4,6 +4,8 @@ import Set from "../Crimson Blaze"
 const card: Card = {
 	set: Set,
 
+	dexId: [577],
+
 	name: {
 		en: "Solosis"
 	},

--- a/data/Pokémon TCG Pocket/Crimson Blaze/033.ts
+++ b/data/Pokémon TCG Pocket/Crimson Blaze/033.ts
@@ -4,6 +4,8 @@ import Set from "../Crimson Blaze"
 const card: Card = {
 	set: Set,
 
+	dexId: [578],
+
 	name: {
 		en: "Duosion"
 	},

--- a/data/Pokémon TCG Pocket/Crimson Blaze/034.ts
+++ b/data/Pokémon TCG Pocket/Crimson Blaze/034.ts
@@ -4,6 +4,8 @@ import Set from "../Crimson Blaze"
 const card: Card = {
 	set: Set,
 
+	dexId: [579],
+
 	name: {
 		en: "Reuniclus"
 	},

--- a/data/Pokémon TCG Pocket/Crimson Blaze/035.ts
+++ b/data/Pokémon TCG Pocket/Crimson Blaze/035.ts
@@ -4,6 +4,8 @@ import Set from "../Crimson Blaze"
 const card: Card = {
 	set: Set,
 
+	dexId: [682],
+
 	name: {
 		en: "Spritzee"
 	},

--- a/data/Pokémon TCG Pocket/Crimson Blaze/036.ts
+++ b/data/Pokémon TCG Pocket/Crimson Blaze/036.ts
@@ -4,6 +4,8 @@ import Set from "../Crimson Blaze"
 const card: Card = {
 	set: Set,
 
+	dexId: [683],
+
 	name: {
 		en: "Aromatisse"
 	},

--- a/data/Pokémon TCG Pocket/Crimson Blaze/037.ts
+++ b/data/Pokémon TCG Pocket/Crimson Blaze/037.ts
@@ -4,6 +4,8 @@ import Set from "../Crimson Blaze"
 const card: Card = {
 	set: Set,
 
+	dexId: [716],
+
 	name: {
 		en: "Xerneas"
 	},

--- a/data/Pokémon TCG Pocket/Crimson Blaze/038.ts
+++ b/data/Pokémon TCG Pocket/Crimson Blaze/038.ts
@@ -4,6 +4,8 @@ import Set from "../Crimson Blaze"
 const card: Card = {
 	set: Set,
 
+	dexId: [95],
+
 	name: {
 		en: "Onix"
 	},

--- a/data/Pokémon TCG Pocket/Crimson Blaze/039.ts
+++ b/data/Pokémon TCG Pocket/Crimson Blaze/039.ts
@@ -4,6 +4,8 @@ import Set from "../Crimson Blaze"
 const card: Card = {
 	set: Set,
 
+	dexId: [296],
+
 	name: {
 		en: "Makuhita"
 	},

--- a/data/Pokémon TCG Pocket/Crimson Blaze/040.ts
+++ b/data/Pokémon TCG Pocket/Crimson Blaze/040.ts
@@ -4,6 +4,8 @@ import Set from "../Crimson Blaze"
 const card: Card = {
 	set: Set,
 
+	dexId: [297],
+
 	name: {
 		en: "Hariyama"
 	},

--- a/data/Pokémon TCG Pocket/Crimson Blaze/041.ts
+++ b/data/Pokémon TCG Pocket/Crimson Blaze/041.ts
@@ -4,6 +4,8 @@ import Set from "../Crimson Blaze"
 const card: Card = {
 	set: Set,
 
+	dexId: [299],
+
 	name: {
 		en: "Nosepass"
 	},

--- a/data/Pokémon TCG Pocket/Crimson Blaze/042.ts
+++ b/data/Pokémon TCG Pocket/Crimson Blaze/042.ts
@@ -4,6 +4,8 @@ import Set from "../Crimson Blaze"
 const card: Card = {
 	set: Set,
 
+	dexId: [428],
+
 	name: {
 		en: "Mega Lopunny ex"
 	},

--- a/data/Pokémon TCG Pocket/Crimson Blaze/043.ts
+++ b/data/Pokémon TCG Pocket/Crimson Blaze/043.ts
@@ -4,6 +4,8 @@ import Set from "../Crimson Blaze"
 const card: Card = {
 	set: Set,
 
+	dexId: [619],
+
 	name: {
 		en: "Mienfoo"
 	},

--- a/data/Pokémon TCG Pocket/Crimson Blaze/044.ts
+++ b/data/Pokémon TCG Pocket/Crimson Blaze/044.ts
@@ -4,6 +4,8 @@ import Set from "../Crimson Blaze"
 const card: Card = {
 	set: Set,
 
+	dexId: [620],
+
 	name: {
 		en: "Mienshao"
 	},

--- a/data/Pokémon TCG Pocket/Crimson Blaze/045.ts
+++ b/data/Pokémon TCG Pocket/Crimson Blaze/045.ts
@@ -4,6 +4,8 @@ import Set from "../Crimson Blaze"
 const card: Card = {
 	set: Set,
 
+	dexId: [88],
+
 	name: {
 		en: "Grimer"
 	},

--- a/data/Pokémon TCG Pocket/Crimson Blaze/046.ts
+++ b/data/Pokémon TCG Pocket/Crimson Blaze/046.ts
@@ -4,6 +4,8 @@ import Set from "../Crimson Blaze"
 const card: Card = {
 	set: Set,
 
+	dexId: [89],
+
 	name: {
 		en: "Muk"
 	},

--- a/data/Pokémon TCG Pocket/Crimson Blaze/047.ts
+++ b/data/Pokémon TCG Pocket/Crimson Blaze/047.ts
@@ -4,6 +4,8 @@ import Set from "../Crimson Blaze"
 const card: Card = {
 	set: Set,
 
+	dexId: [509],
+
 	name: {
 		en: "Purrloin"
 	},

--- a/data/Pokémon TCG Pocket/Crimson Blaze/048.ts
+++ b/data/Pokémon TCG Pocket/Crimson Blaze/048.ts
@@ -4,6 +4,8 @@ import Set from "../Crimson Blaze"
 const card: Card = {
 	set: Set,
 
+	dexId: [510],
+
 	name: {
 		en: "Liepard"
 	},

--- a/data/Pokémon TCG Pocket/Crimson Blaze/049.ts
+++ b/data/Pokémon TCG Pocket/Crimson Blaze/049.ts
@@ -4,6 +4,8 @@ import Set from "../Crimson Blaze"
 const card: Card = {
 	set: Set,
 
+	dexId: [568],
+
 	name: {
 		en: "Trubbish"
 	},

--- a/data/Pokémon TCG Pocket/Crimson Blaze/050.ts
+++ b/data/Pokémon TCG Pocket/Crimson Blaze/050.ts
@@ -4,6 +4,8 @@ import Set from "../Crimson Blaze"
 const card: Card = {
 	set: Set,
 
+	dexId: [569],
+
 	name: {
 		en: "Garbodor"
 	},

--- a/data/Pokémon TCG Pocket/Crimson Blaze/051.ts
+++ b/data/Pokémon TCG Pocket/Crimson Blaze/051.ts
@@ -4,6 +4,8 @@ import Set from "../Crimson Blaze"
 const card: Card = {
 	set: Set,
 
+	dexId: [208],
+
 	name: {
 		en: "Steelix"
 	},

--- a/data/Pokémon TCG Pocket/Crimson Blaze/052.ts
+++ b/data/Pokémon TCG Pocket/Crimson Blaze/052.ts
@@ -4,6 +4,8 @@ import Set from "../Crimson Blaze"
 const card: Card = {
 	set: Set,
 
+	dexId: [208],
+
 	name: {
 		en: "Mega Steelix ex"
 	},

--- a/data/Pokémon TCG Pocket/Crimson Blaze/053.ts
+++ b/data/Pokémon TCG Pocket/Crimson Blaze/053.ts
@@ -4,6 +4,8 @@ import Set from "../Crimson Blaze"
 const card: Card = {
 	set: Set,
 
+	dexId: [476],
+
 	name: {
 		en: "Probopass"
 	},

--- a/data/Pokémon TCG Pocket/Crimson Blaze/054.ts
+++ b/data/Pokémon TCG Pocket/Crimson Blaze/054.ts
@@ -4,6 +4,8 @@ import Set from "../Crimson Blaze"
 const card: Card = {
 	set: Set,
 
+	dexId: [649],
+
 	name: {
 		en: "Genesect"
 	},

--- a/data/Pokémon TCG Pocket/Crimson Blaze/055.ts
+++ b/data/Pokémon TCG Pocket/Crimson Blaze/055.ts
@@ -4,6 +4,8 @@ import Set from "../Crimson Blaze"
 const card: Card = {
 	set: Set,
 
+	dexId: [132],
+
 	name: {
 		en: "Ditto"
 	},

--- a/data/Pokémon TCG Pocket/Crimson Blaze/056.ts
+++ b/data/Pokémon TCG Pocket/Crimson Blaze/056.ts
@@ -4,6 +4,8 @@ import Set from "../Crimson Blaze"
 const card: Card = {
 	set: Set,
 
+	dexId: [137],
+
 	name: {
 		en: "Porygon"
 	},

--- a/data/Pokémon TCG Pocket/Crimson Blaze/057.ts
+++ b/data/Pokémon TCG Pocket/Crimson Blaze/057.ts
@@ -4,6 +4,8 @@ import Set from "../Crimson Blaze"
 const card: Card = {
 	set: Set,
 
+	dexId: [233],
+
 	name: {
 		en: "Porygon2"
 	},

--- a/data/Pokémon TCG Pocket/Crimson Blaze/058.ts
+++ b/data/Pokémon TCG Pocket/Crimson Blaze/058.ts
@@ -4,6 +4,8 @@ import Set from "../Crimson Blaze"
 const card: Card = {
 	set: Set,
 
+	dexId: [474],
+
 	name: {
 		en: "Porygon-Z"
 	},

--- a/data/Pokémon TCG Pocket/Crimson Blaze/059.ts
+++ b/data/Pokémon TCG Pocket/Crimson Blaze/059.ts
@@ -4,6 +4,8 @@ import Set from "../Crimson Blaze"
 const card: Card = {
 	set: Set,
 
+	dexId: [396],
+
 	name: {
 		en: "Starly"
 	},

--- a/data/Pokémon TCG Pocket/Crimson Blaze/060.ts
+++ b/data/Pokémon TCG Pocket/Crimson Blaze/060.ts
@@ -4,6 +4,8 @@ import Set from "../Crimson Blaze"
 const card: Card = {
 	set: Set,
 
+	dexId: [397],
+
 	name: {
 		en: "Staravia"
 	},

--- a/data/Pokémon TCG Pocket/Crimson Blaze/061.ts
+++ b/data/Pokémon TCG Pocket/Crimson Blaze/061.ts
@@ -4,6 +4,8 @@ import Set from "../Crimson Blaze"
 const card: Card = {
 	set: Set,
 
+	dexId: [398],
+
 	name: {
 		en: "Staraptor"
 	},

--- a/data/Pokémon TCG Pocket/Crimson Blaze/062.ts
+++ b/data/Pokémon TCG Pocket/Crimson Blaze/062.ts
@@ -4,6 +4,8 @@ import Set from "../Crimson Blaze"
 const card: Card = {
 	set: Set,
 
+	dexId: [427],
+
 	name: {
 		en: "Buneary"
 	},

--- a/data/Pokémon TCG Pocket/Crimson Blaze/063.ts
+++ b/data/Pokémon TCG Pocket/Crimson Blaze/063.ts
@@ -4,6 +4,8 @@ import Set from "../Crimson Blaze"
 const card: Card = {
 	set: Set,
 
+	dexId: [428],
+
 	name: {
 		en: "Lopunny"
 	},

--- a/data/Pokémon TCG Pocket/Crimson Blaze/064.ts
+++ b/data/Pokémon TCG Pocket/Crimson Blaze/064.ts
@@ -4,6 +4,8 @@ import Set from "../Crimson Blaze"
 const card: Card = {
 	set: Set,
 
+	dexId: [626],
+
 	name: {
 		en: "Bouffalant"
 	},

--- a/data/Pokémon TCG Pocket/Crimson Blaze/065.ts
+++ b/data/Pokémon TCG Pocket/Crimson Blaze/065.ts
@@ -4,6 +4,8 @@ import Set from "../Crimson Blaze"
 const card: Card = {
 	set: Set,
 
+	dexId: [676],
+
 	name: {
 		en: "Furfrou"
 	},

--- a/data/Pokémon TCG Pocket/Crimson Blaze/070.ts
+++ b/data/Pokémon TCG Pocket/Crimson Blaze/070.ts
@@ -4,6 +4,8 @@ import Set from "../Crimson Blaze"
 const card: Card = {
 	set: Set,
 
+	dexId: [168],
+
 	name: {
 		en: "Ariados"
 	},

--- a/data/Pokémon TCG Pocket/Crimson Blaze/071.ts
+++ b/data/Pokémon TCG Pocket/Crimson Blaze/071.ts
@@ -4,6 +4,8 @@ import Set from "../Crimson Blaze"
 const card: Card = {
 	set: Set,
 
+	dexId: [192],
+
 	name: {
 		en: "Sunflora"
 	},

--- a/data/Pokémon TCG Pocket/Crimson Blaze/072.ts
+++ b/data/Pokémon TCG Pocket/Crimson Blaze/072.ts
@@ -4,6 +4,8 @@ import Set from "../Crimson Blaze"
 const card: Card = {
 	set: Set,
 
+	dexId: [579],
+
 	name: {
 		en: "Reuniclus"
 	},

--- a/data/Pokémon TCG Pocket/Crimson Blaze/073.ts
+++ b/data/Pokémon TCG Pocket/Crimson Blaze/073.ts
@@ -4,6 +4,8 @@ import Set from "../Crimson Blaze"
 const card: Card = {
 	set: Set,
 
+	dexId: [716],
+
 	name: {
 		en: "Xerneas"
 	},

--- a/data/Pokémon TCG Pocket/Crimson Blaze/074.ts
+++ b/data/Pokémon TCG Pocket/Crimson Blaze/074.ts
@@ -4,6 +4,8 @@ import Set from "../Crimson Blaze"
 const card: Card = {
 	set: Set,
 
+	dexId: [568],
+
 	name: {
 		en: "Trubbish"
 	},

--- a/data/Pokémon TCG Pocket/Crimson Blaze/075.ts
+++ b/data/Pokémon TCG Pocket/Crimson Blaze/075.ts
@@ -4,6 +4,8 @@ import Set from "../Crimson Blaze"
 const card: Card = {
 	set: Set,
 
+	dexId: [427],
+
 	name: {
 		en: "Buneary"
 	},

--- a/data/Pokémon TCG Pocket/Crimson Blaze/076.ts
+++ b/data/Pokémon TCG Pocket/Crimson Blaze/076.ts
@@ -4,6 +4,8 @@ import Set from "../Crimson Blaze"
 const card: Card = {
 	set: Set,
 
+	dexId: [3],
+
 	name: {
 		en: "Mega Venusaur ex"
 	},

--- a/data/Pokémon TCG Pocket/Crimson Blaze/077.ts
+++ b/data/Pokémon TCG Pocket/Crimson Blaze/077.ts
@@ -4,6 +4,8 @@ import Set from "../Crimson Blaze"
 const card: Card = {
 	set: Set,
 
+	dexId: [6],
+
 	name: {
 		en: "Mega Charizard Y ex"
 	},

--- a/data/Pokémon TCG Pocket/Crimson Blaze/078.ts
+++ b/data/Pokémon TCG Pocket/Crimson Blaze/078.ts
@@ -4,6 +4,8 @@ import Set from "../Crimson Blaze"
 const card: Card = {
 	set: Set,
 
+	dexId: [9],
+
 	name: {
 		en: "Mega Blastoise ex"
 	},

--- a/data/Pokémon TCG Pocket/Crimson Blaze/079.ts
+++ b/data/Pokémon TCG Pocket/Crimson Blaze/079.ts
@@ -4,6 +4,8 @@ import Set from "../Crimson Blaze"
 const card: Card = {
 	set: Set,
 
+	dexId: [428],
+
 	name: {
 		en: "Mega Lopunny ex"
 	},

--- a/data/Pokémon TCG Pocket/Crimson Blaze/080.ts
+++ b/data/Pokémon TCG Pocket/Crimson Blaze/080.ts
@@ -4,6 +4,8 @@ import Set from "../Crimson Blaze"
 const card: Card = {
 	set: Set,
 
+	dexId: [208],
+
 	name: {
 		en: "Mega Steelix ex"
 	},

--- a/data/Pokémon TCG Pocket/Crimson Blaze/083.ts
+++ b/data/Pokémon TCG Pocket/Crimson Blaze/083.ts
@@ -4,6 +4,8 @@ import Set from "../Crimson Blaze"
 const card: Card = {
 	set: Set,
 
+	dexId: [3],
+
 	name: {
 		en: "Mega Venusaur ex"
 	},

--- a/data/Pokémon TCG Pocket/Crimson Blaze/084.ts
+++ b/data/Pokémon TCG Pocket/Crimson Blaze/084.ts
@@ -4,6 +4,8 @@ import Set from "../Crimson Blaze"
 const card: Card = {
 	set: Set,
 
+	dexId: [9],
+
 	name: {
 		en: "Mega Blastoise ex"
 	},

--- a/data/Pokémon TCG Pocket/Crimson Blaze/085.ts
+++ b/data/Pokémon TCG Pocket/Crimson Blaze/085.ts
@@ -4,6 +4,8 @@ import Set from "../Crimson Blaze"
 const card: Card = {
 	set: Set,
 
+	dexId: [428],
+
 	name: {
 		en: "Mega Lopunny ex"
 	},

--- a/data/Pokémon TCG Pocket/Crimson Blaze/086.ts
+++ b/data/Pokémon TCG Pocket/Crimson Blaze/086.ts
@@ -4,6 +4,8 @@ import Set from "../Crimson Blaze"
 const card: Card = {
 	set: Set,
 
+	dexId: [208],
+
 	name: {
 		en: "Mega Steelix ex"
 	},

--- a/data/Pokémon TCG Pocket/Crimson Blaze/087.ts
+++ b/data/Pokémon TCG Pocket/Crimson Blaze/087.ts
@@ -4,6 +4,8 @@ import Set from "../Crimson Blaze"
 const card: Card = {
 	set: Set,
 
+	dexId: [6],
+
 	name: {
 		en: "Mega Charizard Y ex"
 	},

--- a/data/Pokémon TCG Pocket/Crimson Blaze/088.ts
+++ b/data/Pokémon TCG Pocket/Crimson Blaze/088.ts
@@ -4,6 +4,8 @@ import Set from "../Crimson Blaze"
 const card: Card = {
 	set: Set,
 
+	dexId: [43],
+
 	name: {
 		en: "Oddish"
 	},

--- a/data/Pokémon TCG Pocket/Crimson Blaze/089.ts
+++ b/data/Pokémon TCG Pocket/Crimson Blaze/089.ts
@@ -4,6 +4,8 @@ import Set from "../Crimson Blaze"
 const card: Card = {
 	set: Set,
 
+	dexId: [44],
+
 	name: {
 		en: "Gloom"
 	},

--- a/data/Pokémon TCG Pocket/Crimson Blaze/090.ts
+++ b/data/Pokémon TCG Pocket/Crimson Blaze/090.ts
@@ -4,6 +4,8 @@ import Set from "../Crimson Blaze"
 const card: Card = {
 	set: Set,
 
+	dexId: [45],
+
 	name: {
 		en: "Vileplume"
 	},

--- a/data/Pokémon TCG Pocket/Crimson Blaze/091.ts
+++ b/data/Pokémon TCG Pocket/Crimson Blaze/091.ts
@@ -4,6 +4,8 @@ import Set from "../Crimson Blaze"
 const card: Card = {
 	set: Set,
 
+	dexId: [6],
+
 	name: {
 		en: "Charizard"
 	},

--- a/data/Pokémon TCG Pocket/Crimson Blaze/092.ts
+++ b/data/Pokémon TCG Pocket/Crimson Blaze/092.ts
@@ -4,6 +4,8 @@ import Set from "../Crimson Blaze"
 const card: Card = {
 	set: Set,
 
+	dexId: [90],
+
 	name: {
 		en: "Shellder"
 	},

--- a/data/Pokémon TCG Pocket/Crimson Blaze/093.ts
+++ b/data/Pokémon TCG Pocket/Crimson Blaze/093.ts
@@ -4,6 +4,8 @@ import Set from "../Crimson Blaze"
 const card: Card = {
 	set: Set,
 
+	dexId: [91],
+
 	name: {
 		en: "Cloyster"
 	},

--- a/data/Pokémon TCG Pocket/Crimson Blaze/094.ts
+++ b/data/Pokémon TCG Pocket/Crimson Blaze/094.ts
@@ -4,6 +4,8 @@ import Set from "../Crimson Blaze"
 const card: Card = {
 	set: Set,
 
+	dexId: [27],
+
 	name: {
 		en: "Sandshrew"
 	},

--- a/data/Pokémon TCG Pocket/Crimson Blaze/095.ts
+++ b/data/Pokémon TCG Pocket/Crimson Blaze/095.ts
@@ -4,6 +4,8 @@ import Set from "../Crimson Blaze"
 const card: Card = {
 	set: Set,
 
+	dexId: [28],
+
 	name: {
 		en: "Sandslash"
 	},

--- a/data/Pokémon TCG Pocket/Crimson Blaze/096.ts
+++ b/data/Pokémon TCG Pocket/Crimson Blaze/096.ts
@@ -4,6 +4,8 @@ import Set from "../Crimson Blaze"
 const card: Card = {
 	set: Set,
 
+	dexId: [772],
+
 	name: {
 		en: "Type: Null"
 	},

--- a/data/Pokémon TCG Pocket/Crimson Blaze/097.ts
+++ b/data/Pokémon TCG Pocket/Crimson Blaze/097.ts
@@ -4,6 +4,8 @@ import Set from "../Crimson Blaze"
 const card: Card = {
 	set: Set,
 
+	dexId: [773],
+
 	name: {
 		en: "Silvally"
 	},

--- a/data/Pokémon TCG Pocket/Crimson Blaze/098.ts
+++ b/data/Pokémon TCG Pocket/Crimson Blaze/098.ts
@@ -4,6 +4,8 @@ import Set from "../Crimson Blaze"
 const card: Card = {
 	set: Set,
 
+	dexId: [794],
+
 	name: {
 		en: "Buzzwole ex"
 	},

--- a/data/Pokémon TCG Pocket/Crimson Blaze/099.ts
+++ b/data/Pokémon TCG Pocket/Crimson Blaze/099.ts
@@ -4,6 +4,8 @@ import Set from "../Crimson Blaze"
 const card: Card = {
 	set: Set,
 
+	dexId: [792],
+
 	name: {
 		en: "Lunala ex"
 	},

--- a/data/Pokémon TCG Pocket/Crimson Blaze/100.ts
+++ b/data/Pokémon TCG Pocket/Crimson Blaze/100.ts
@@ -4,6 +4,8 @@ import Set from "../Crimson Blaze"
 const card: Card = {
 	set: Set,
 
+	dexId: [799],
+
 	name: {
 		en: "Guzzlord ex"
 	},

--- a/data/Pokémon TCG Pocket/Crimson Blaze/101.ts
+++ b/data/Pokémon TCG Pocket/Crimson Blaze/101.ts
@@ -4,6 +4,8 @@ import Set from "../Crimson Blaze"
 const card: Card = {
 	set: Set,
 
+	dexId: [791],
+
 	name: {
 		en: "Solgaleo ex"
 	},

--- a/data/Pokémon TCG Pocket/Crimson Blaze/102.ts
+++ b/data/Pokémon TCG Pocket/Crimson Blaze/102.ts
@@ -4,6 +4,8 @@ import Set from "../Crimson Blaze"
 const card: Card = {
 	set: Set,
 
+	dexId: [681],
+
 	name: {
 		en: "Aegislash"
 	},


### PR DESCRIPTION
## Summary
- add missing `dexId` fields for Pokemon cards in `Pokemon TCG Pocket/Crimson Blaze`
- branch is based on `upstream/master` and contains only this set scope
- generated with the dexId fixer workflow and validated for set-only diff scope

## Regenerate dexId process
1. `bun run dex:fix:dry-run` to preview missing/updated dexId assignments.
2. `bun run dex:fix:apply` to write dexId changes in card files.
3. `bun run dex:lint` to verify all Pokemon cards have valid dexId.
4. Optional: `bun run dex:audit:report` for a detailed audit report.

## Validation
- set-only scope verified: all changed files are under `data/Pokémon TCG Pocket/Crimson Blaze/`
- all changed files contain `dexId`