### PR TITLE
fix(data): add missing dexId for tcgp Fantastical Parade

### DIFF
--- a/data/Pokémon TCG Pocket/Fantastical Parade/001.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/001.ts
@@ -4,6 +4,8 @@ import Set from "../Fantastical Parade"
 const card: Card = {
 	set: Set,
 
+	dexId: [165],
+
 	name: {
 		en: "Ledyba"
 	},

--- a/data/Pokémon TCG Pocket/Fantastical Parade/002.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/002.ts
@@ -4,6 +4,8 @@ import Set from "../Fantastical Parade"
 const card: Card = {
 	set: Set,
 
+	dexId: [166],
+
 	name: {
 		en: "Ledian"
 	},

--- a/data/Pokémon TCG Pocket/Fantastical Parade/003.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/003.ts
@@ -4,6 +4,8 @@ import Set from "../Fantastical Parade"
 const card: Card = {
 	set: Set,
 
+	dexId: [213],
+
 	name: {
 		en: "Shuckle"
 	},

--- a/data/Pokémon TCG Pocket/Fantastical Parade/004.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/004.ts
@@ -4,6 +4,8 @@ import Set from "../Fantastical Parade"
 const card: Card = {
 	set: Set,
 
+	dexId: [315],
+
 	name: {
 		en: "Roselia"
 	},

--- a/data/Pokémon TCG Pocket/Fantastical Parade/005.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/005.ts
@@ -4,6 +4,8 @@ import Set from "../Fantastical Parade"
 const card: Card = {
 	set: Set,
 
+	dexId: [407],
+
 	name: {
 		en: "Roserade"
 	},

--- a/data/Pokémon TCG Pocket/Fantastical Parade/006.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/006.ts
@@ -4,6 +4,8 @@ import Set from "../Fantastical Parade"
 const card: Card = {
 	set: Set,
 
+	dexId: [331],
+
 	name: {
 		en: "Cacnea"
 	},

--- a/data/Pokémon TCG Pocket/Fantastical Parade/007.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/007.ts
@@ -4,6 +4,8 @@ import Set from "../Fantastical Parade"
 const card: Card = {
 	set: Set,
 
+	dexId: [332],
+
 	name: {
 		en: "Cacturne"
 	},

--- a/data/Pokémon TCG Pocket/Fantastical Parade/008.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/008.ts
@@ -4,6 +4,8 @@ import Set from "../Fantastical Parade"
 const card: Card = {
 	set: Set,
 
+	dexId: [650],
+
 	name: {
 		en: "Chespin"
 	},

--- a/data/Pokémon TCG Pocket/Fantastical Parade/009.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/009.ts
@@ -4,6 +4,8 @@ import Set from "../Fantastical Parade"
 const card: Card = {
 	set: Set,
 
+	dexId: [651],
+
 	name: {
 		en: "Quilladin"
 	},

--- a/data/Pokémon TCG Pocket/Fantastical Parade/010.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/010.ts
@@ -4,6 +4,8 @@ import Set from "../Fantastical Parade"
 const card: Card = {
 	set: Set,
 
+	dexId: [652],
+
 	name: {
 		en: "Chesnaught"
 	},

--- a/data/Pokémon TCG Pocket/Fantastical Parade/011.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/011.ts
@@ -4,6 +4,8 @@ import Set from "../Fantastical Parade"
 const card: Card = {
 	set: Set,
 
+	dexId: [664],
+
 	name: {
 		en: "Scatterbug"
 	},

--- a/data/Pokémon TCG Pocket/Fantastical Parade/012.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/012.ts
@@ -4,6 +4,8 @@ import Set from "../Fantastical Parade"
 const card: Card = {
 	set: Set,
 
+	dexId: [665],
+
 	name: {
 		en: "Spewpa"
 	},

--- a/data/Pokémon TCG Pocket/Fantastical Parade/013.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/013.ts
@@ -4,6 +4,8 @@ import Set from "../Fantastical Parade"
 const card: Card = {
 	set: Set,
 
+	dexId: [666],
+
 	name: {
 		en: "Vivillon"
 	},

--- a/data/Pokémon TCG Pocket/Fantastical Parade/014.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/014.ts
@@ -4,6 +4,8 @@ import Set from "../Fantastical Parade"
 const card: Card = {
 	set: Set,
 
+	dexId: [794],
+
 	name: {
 		en: "Buzzwole"
 	},

--- a/data/Pokémon TCG Pocket/Fantastical Parade/015.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/015.ts
@@ -4,6 +4,8 @@ import Set from "../Fantastical Parade"
 const card: Card = {
 	set: Set,
 
+	dexId: [829],
+
 	name: {
 		en: "Gossifleur"
 	},

--- a/data/Pokémon TCG Pocket/Fantastical Parade/016.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/016.ts
@@ -4,6 +4,8 @@ import Set from "../Fantastical Parade"
 const card: Card = {
 	set: Set,
 
+	dexId: [830],
+
 	name: {
 		en: "Eldegoss"
 	},

--- a/data/Pokémon TCG Pocket/Fantastical Parade/017.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/017.ts
@@ -4,6 +4,8 @@ import Set from "../Fantastical Parade"
 const card: Card = {
 	set: Set,
 
+	dexId: [1017],
+
 	name: {
 		en: "Teal Mask Ogerpon ex"
 	},

--- a/data/Pokémon TCG Pocket/Fantastical Parade/018.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/018.ts
@@ -4,6 +4,8 @@ import Set from "../Fantastical Parade"
 const card: Card = {
 	set: Set,
 
+	dexId: [105],
+
 	name: {
 		en: "Alolan Marowak"
 	},

--- a/data/Pokémon TCG Pocket/Fantastical Parade/019.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/019.ts
@@ -4,6 +4,8 @@ import Set from "../Fantastical Parade"
 const card: Card = {
 	set: Set,
 
+	dexId: [643],
+
 	name: {
 		en: "Reshiram"
 	},

--- a/data/Pokémon TCG Pocket/Fantastical Parade/020.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/020.ts
@@ -4,6 +4,8 @@ import Set from "../Fantastical Parade"
 const card: Card = {
 	set: Set,
 
+	dexId: [667],
+
 	name: {
 		en: "Litleo"
 	},

--- a/data/Pokémon TCG Pocket/Fantastical Parade/021.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/021.ts
@@ -4,6 +4,8 @@ import Set from "../Fantastical Parade"
 const card: Card = {
 	set: Set,
 
+	dexId: [668],
+
 	name: {
 		en: "Pyroar"
 	},

--- a/data/Pokémon TCG Pocket/Fantastical Parade/022.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/022.ts
@@ -4,6 +4,8 @@ import Set from "../Fantastical Parade"
 const card: Card = {
 	set: Set,
 
+	dexId: [741],
+
 	name: {
 		en: "Oricorio"
 	},

--- a/data/Pokémon TCG Pocket/Fantastical Parade/023.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/023.ts
@@ -4,6 +4,8 @@ import Set from "../Fantastical Parade"
 const card: Card = {
 	set: Set,
 
+	dexId: [806],
+
 	name: {
 		en: "Blacephalon ex"
 	},

--- a/data/Pokémon TCG Pocket/Fantastical Parade/024.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/024.ts
@@ -4,6 +4,8 @@ import Set from "../Fantastical Parade"
 const card: Card = {
 	set: Set,
 
+	dexId: [813],
+
 	name: {
 		en: "Scorbunny"
 	},

--- a/data/Pokémon TCG Pocket/Fantastical Parade/025.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/025.ts
@@ -4,6 +4,8 @@ import Set from "../Fantastical Parade"
 const card: Card = {
 	set: Set,
 
+	dexId: [814],
+
 	name: {
 		en: "Raboot"
 	},

--- a/data/Pokémon TCG Pocket/Fantastical Parade/026.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/026.ts
@@ -4,6 +4,8 @@ import Set from "../Fantastical Parade"
 const card: Card = {
 	set: Set,
 
+	dexId: [815],
+
 	name: {
 		en: "Cinderace"
 	},

--- a/data/Pokémon TCG Pocket/Fantastical Parade/027.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/027.ts
@@ -4,6 +4,8 @@ import Set from "../Fantastical Parade"
 const card: Card = {
 	set: Set,
 
+	dexId: [1017],
+
 	name: {
 		en: "Hearthflame Mask Ogerpon"
 	},

--- a/data/Pokémon TCG Pocket/Fantastical Parade/028.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/028.ts
@@ -4,6 +4,8 @@ import Set from "../Fantastical Parade"
 const card: Card = {
 	set: Set,
 
+	dexId: [37],
+
 	name: {
 		en: "Alolan Vulpix"
 	},

--- a/data/Pokémon TCG Pocket/Fantastical Parade/029.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/029.ts
@@ -4,6 +4,8 @@ import Set from "../Fantastical Parade"
 const card: Card = {
 	set: Set,
 
+	dexId: [38],
+
 	name: {
 		en: "Alolan Ninetales ex"
 	},

--- a/data/Pokémon TCG Pocket/Fantastical Parade/030.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/030.ts
@@ -4,6 +4,8 @@ import Set from "../Fantastical Parade"
 const card: Card = {
 	set: Set,
 
+	dexId: [122],
+
 	name: {
 		en: "Galarian Mr. Mime"
 	},

--- a/data/Pokémon TCG Pocket/Fantastical Parade/031.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/031.ts
@@ -4,6 +4,8 @@ import Set from "../Fantastical Parade"
 const card: Card = {
 	set: Set,
 
+	dexId: [866],
+
 	name: {
 		en: "Galarian Mr. Rime"
 	},

--- a/data/Pokémon TCG Pocket/Fantastical Parade/032.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/032.ts
@@ -4,6 +4,8 @@ import Set from "../Fantastical Parade"
 const card: Card = {
 	set: Set,
 
+	dexId: [225],
+
 	name: {
 		en: "Delibird"
 	},

--- a/data/Pokémon TCG Pocket/Fantastical Parade/033.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/033.ts
@@ -4,6 +4,8 @@ import Set from "../Fantastical Parade"
 const card: Card = {
 	set: Set,
 
+	dexId: [258],
+
 	name: {
 		en: "Mudkip"
 	},

--- a/data/Pokémon TCG Pocket/Fantastical Parade/034.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/034.ts
@@ -4,6 +4,8 @@ import Set from "../Fantastical Parade"
 const card: Card = {
 	set: Set,
 
+	dexId: [259],
+
 	name: {
 		en: "Marshtomp"
 	},

--- a/data/Pokémon TCG Pocket/Fantastical Parade/035.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/035.ts
@@ -4,6 +4,8 @@ import Set from "../Fantastical Parade"
 const card: Card = {
 	set: Set,
 
+	dexId: [260],
+
 	name: {
 		en: "Swampert"
 	},

--- a/data/Pokémon TCG Pocket/Fantastical Parade/036.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/036.ts
@@ -4,6 +4,8 @@ import Set from "../Fantastical Parade"
 const card: Card = {
 	set: Set,
 
+	dexId: [260],
+
 	name: {
 		en: "Mega Swampert ex"
 	},

--- a/data/Pokémon TCG Pocket/Fantastical Parade/037.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/037.ts
@@ -4,6 +4,8 @@ import Set from "../Fantastical Parade"
 const card: Card = {
 	set: Set,
 
+	dexId: [582],
+
 	name: {
 		en: "Vanillite"
 	},

--- a/data/Pokémon TCG Pocket/Fantastical Parade/038.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/038.ts
@@ -4,6 +4,8 @@ import Set from "../Fantastical Parade"
 const card: Card = {
 	set: Set,
 
+	dexId: [583],
+
 	name: {
 		en: "Vanillish"
 	},

--- a/data/Pokémon TCG Pocket/Fantastical Parade/039.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/039.ts
@@ -4,6 +4,8 @@ import Set from "../Fantastical Parade"
 const card: Card = {
 	set: Set,
 
+	dexId: [584],
+
 	name: {
 		en: "Vanilluxe"
 	},

--- a/data/Pokémon TCG Pocket/Fantastical Parade/040.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/040.ts
@@ -4,6 +4,8 @@ import Set from "../Fantastical Parade"
 const card: Card = {
 	set: Set,
 
+	dexId: [615],
+
 	name: {
 		en: "Cryogonal"
 	},

--- a/data/Pokémon TCG Pocket/Fantastical Parade/041.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/041.ts
@@ -4,6 +4,8 @@ import Set from "../Fantastical Parade"
 const card: Card = {
 	set: Set,
 
+	dexId: [698],
+
 	name: {
 		en: "Amaura"
 	},

--- a/data/Pokémon TCG Pocket/Fantastical Parade/042.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/042.ts
@@ -4,6 +4,8 @@ import Set from "../Fantastical Parade"
 const card: Card = {
 	set: Set,
 
+	dexId: [699],
+
 	name: {
 		en: "Aurorus"
 	},

--- a/data/Pokémon TCG Pocket/Fantastical Parade/043.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/043.ts
@@ -4,6 +4,8 @@ import Set from "../Fantastical Parade"
 const card: Card = {
 	set: Set,
 
+	dexId: [833],
+
 	name: {
 		en: "Chewtle"
 	},

--- a/data/Pokémon TCG Pocket/Fantastical Parade/044.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/044.ts
@@ -4,6 +4,8 @@ import Set from "../Fantastical Parade"
 const card: Card = {
 	set: Set,
 
+	dexId: [834],
+
 	name: {
 		en: "Drednaw"
 	},

--- a/data/Pokémon TCG Pocket/Fantastical Parade/045.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/045.ts
@@ -4,6 +4,8 @@ import Set from "../Fantastical Parade"
 const card: Card = {
 	set: Set,
 
+	dexId: [845],
+
 	name: {
 		en: "Cramorant"
 	},

--- a/data/Pokémon TCG Pocket/Fantastical Parade/046.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/046.ts
@@ -4,6 +4,8 @@ import Set from "../Fantastical Parade"
 const card: Card = {
 	set: Set,
 
+	dexId: [846],
+
 	name: {
 		en: "Arrokuda"
 	},

--- a/data/Pokémon TCG Pocket/Fantastical Parade/047.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/047.ts
@@ -4,6 +4,8 @@ import Set from "../Fantastical Parade"
 const card: Card = {
 	set: Set,
 
+	dexId: [847],
+
 	name: {
 		en: "Barraskewda"
 	},

--- a/data/Pokémon TCG Pocket/Fantastical Parade/048.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/048.ts
@@ -4,6 +4,8 @@ import Set from "../Fantastical Parade"
 const card: Card = {
 	set: Set,
 
+	dexId: [1017],
+
 	name: {
 		en: "Wellspring Mask Ogerpon"
 	},

--- a/data/Pokémon TCG Pocket/Fantastical Parade/049.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/049.ts
@@ -4,6 +4,8 @@ import Set from "../Fantastical Parade"
 const card: Card = {
 	set: Set,
 
+	dexId: [25],
+
 	name: {
 		en: "Pikachu"
 	},

--- a/data/Pokémon TCG Pocket/Fantastical Parade/050.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/050.ts
@@ -4,6 +4,8 @@ import Set from "../Fantastical Parade"
 const card: Card = {
 	set: Set,
 
+	dexId: [26],
+
 	name: {
 		en: "Alolan Raichu"
 	},

--- a/data/Pokémon TCG Pocket/Fantastical Parade/051.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/051.ts
@@ -4,6 +4,8 @@ import Set from "../Fantastical Parade"
 const card: Card = {
 	set: Set,
 
+	dexId: [145],
+
 	name: {
 		en: "Zapdos"
 	},

--- a/data/Pokémon TCG Pocket/Fantastical Parade/052.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/052.ts
@@ -4,6 +4,8 @@ import Set from "../Fantastical Parade"
 const card: Card = {
 	set: Set,
 
+	dexId: [311],
+
 	name: {
 		en: "Plusle"
 	},

--- a/data/Pokémon TCG Pocket/Fantastical Parade/053.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/053.ts
@@ -4,6 +4,8 @@ import Set from "../Fantastical Parade"
 const card: Card = {
 	set: Set,
 
+	dexId: [312],
+
 	name: {
 		en: "Minun"
 	},

--- a/data/Pokémon TCG Pocket/Fantastical Parade/054.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/054.ts
@@ -4,6 +4,8 @@ import Set from "../Fantastical Parade"
 const card: Card = {
 	set: Set,
 
+	dexId: [848],
+
 	name: {
 		en: "Toxel"
 	},

--- a/data/Pokémon TCG Pocket/Fantastical Parade/055.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/055.ts
@@ -4,6 +4,8 @@ import Set from "../Fantastical Parade"
 const card: Card = {
 	set: Set,
 
+	dexId: [849],
+
 	name: {
 		en: "Toxtricity ex"
 	},

--- a/data/Pokémon TCG Pocket/Fantastical Parade/056.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/056.ts
@@ -4,6 +4,8 @@ import Set from "../Fantastical Parade"
 const card: Card = {
 	set: Set,
 
+	dexId: [938],
+
 	name: {
 		en: "Tadbulb"
 	},

--- a/data/Pokémon TCG Pocket/Fantastical Parade/057.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/057.ts
@@ -4,6 +4,8 @@ import Set from "../Fantastical Parade"
 const card: Card = {
 	set: Set,
 
+	dexId: [939],
+
 	name: {
 		en: "Bellibolt"
 	},

--- a/data/Pokémon TCG Pocket/Fantastical Parade/058.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/058.ts
@@ -4,6 +4,8 @@ import Set from "../Fantastical Parade"
 const card: Card = {
 	set: Set,
 
+	dexId: [77],
+
 	name: {
 		en: "Galarian Ponyta"
 	},

--- a/data/Pokémon TCG Pocket/Fantastical Parade/059.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/059.ts
@@ -4,6 +4,8 @@ import Set from "../Fantastical Parade"
 const card: Card = {
 	set: Set,
 
+	dexId: [78],
+
 	name: {
 		en: "Galarian Rapidash"
 	},

--- a/data/Pokémon TCG Pocket/Fantastical Parade/060.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/060.ts
@@ -4,6 +4,8 @@ import Set from "../Fantastical Parade"
 const card: Card = {
 	set: Set,
 
+	dexId: [202],
+
 	name: {
 		en: "Wobbuffet"
 	},

--- a/data/Pokémon TCG Pocket/Fantastical Parade/061.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/061.ts
@@ -4,6 +4,8 @@ import Set from "../Fantastical Parade"
 const card: Card = {
 	set: Set,
 
+	dexId: [209],
+
 	name: {
 		en: "Snubbull"
 	},

--- a/data/Pokémon TCG Pocket/Fantastical Parade/062.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/062.ts
@@ -4,6 +4,8 @@ import Set from "../Fantastical Parade"
 const card: Card = {
 	set: Set,
 
+	dexId: [210],
+
 	name: {
 		en: "Granbull"
 	},

--- a/data/Pokémon TCG Pocket/Fantastical Parade/063.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/063.ts
@@ -4,6 +4,8 @@ import Set from "../Fantastical Parade"
 const card: Card = {
 	set: Set,
 
+	dexId: [280],
+
 	name: {
 		en: "Ralts"
 	},

--- a/data/Pokémon TCG Pocket/Fantastical Parade/064.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/064.ts
@@ -4,6 +4,8 @@ import Set from "../Fantastical Parade"
 const card: Card = {
 	set: Set,
 
+	dexId: [281],
+
 	name: {
 		en: "Kirlia"
 	},

--- a/data/Pokémon TCG Pocket/Fantastical Parade/065.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/065.ts
@@ -4,6 +4,8 @@ import Set from "../Fantastical Parade"
 const card: Card = {
 	set: Set,
 
+	dexId: [282],
+
 	name: {
 		en: "Gardevoir"
 	},

--- a/data/Pokémon TCG Pocket/Fantastical Parade/066.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/066.ts
@@ -4,6 +4,8 @@ import Set from "../Fantastical Parade"
 const card: Card = {
 	set: Set,
 
+	dexId: [282],
+
 	name: {
 		en: "Mega Gardevoir ex"
 	},

--- a/data/Pokémon TCG Pocket/Fantastical Parade/067.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/067.ts
@@ -4,6 +4,8 @@ import Set from "../Fantastical Parade"
 const card: Card = {
 	set: Set,
 
+	dexId: [607],
+
 	name: {
 		en: "Litwick"
 	},

--- a/data/Pokémon TCG Pocket/Fantastical Parade/068.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/068.ts
@@ -4,6 +4,8 @@ import Set from "../Fantastical Parade"
 const card: Card = {
 	set: Set,
 
+	dexId: [608],
+
 	name: {
 		en: "Lampent"
 	},

--- a/data/Pokémon TCG Pocket/Fantastical Parade/069.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/069.ts
@@ -4,6 +4,8 @@ import Set from "../Fantastical Parade"
 const card: Card = {
 	set: Set,
 
+	dexId: [609],
+
 	name: {
 		en: "Chandelure"
 	},

--- a/data/Pokémon TCG Pocket/Fantastical Parade/070.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/070.ts
@@ -4,6 +4,8 @@ import Set from "../Fantastical Parade"
 const card: Card = {
 	set: Set,
 
+	dexId: [648],
+
 	name: {
 		en: "Meloetta"
 	},

--- a/data/Pokémon TCG Pocket/Fantastical Parade/071.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/071.ts
@@ -4,6 +4,8 @@ import Set from "../Fantastical Parade"
 const card: Card = {
 	set: Set,
 
+	dexId: [710],
+
 	name: {
 		en: "Pumpkaboo"
 	},

--- a/data/Pokémon TCG Pocket/Fantastical Parade/072.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/072.ts
@@ -4,6 +4,8 @@ import Set from "../Fantastical Parade"
 const card: Card = {
 	set: Set,
 
+	dexId: [711],
+
 	name: {
 		en: "Gourgeist"
 	},

--- a/data/Pokémon TCG Pocket/Fantastical Parade/073.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/073.ts
@@ -4,6 +4,8 @@ import Set from "../Fantastical Parade"
 const card: Card = {
 	set: Set,
 
+	dexId: [778],
+
 	name: {
 		en: "Mimikyu ex"
 	},

--- a/data/Pokémon TCG Pocket/Fantastical Parade/074.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/074.ts
@@ -4,6 +4,8 @@ import Set from "../Fantastical Parade"
 const card: Card = {
 	set: Set,
 
+	dexId: [854],
+
 	name: {
 		en: "Sinistea"
 	},

--- a/data/Pokémon TCG Pocket/Fantastical Parade/075.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/075.ts
@@ -4,6 +4,8 @@ import Set from "../Fantastical Parade"
 const card: Card = {
 	set: Set,
 
+	dexId: [855],
+
 	name: {
 		en: "Polteageist"
 	},

--- a/data/Pokémon TCG Pocket/Fantastical Parade/076.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/076.ts
@@ -4,6 +4,8 @@ import Set from "../Fantastical Parade"
 const card: Card = {
 	set: Set,
 
+	dexId: [876],
+
 	name: {
 		en: "Indeedee"
 	},

--- a/data/Pokémon TCG Pocket/Fantastical Parade/077.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/077.ts
@@ -4,6 +4,8 @@ import Set from "../Fantastical Parade"
 const card: Card = {
 	set: Set,
 
+	dexId: [27],
+
 	name: {
 		en: "Sandshrew"
 	},

--- a/data/Pokémon TCG Pocket/Fantastical Parade/078.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/078.ts
@@ -4,6 +4,8 @@ import Set from "../Fantastical Parade"
 const card: Card = {
 	set: Set,
 
+	dexId: [28],
+
 	name: {
 		en: "Sandslash"
 	},

--- a/data/Pokémon TCG Pocket/Fantastical Parade/079.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/079.ts
@@ -4,6 +4,8 @@ import Set from "../Fantastical Parade"
 const card: Card = {
 	set: Set,
 
+	dexId: [66],
+
 	name: {
 		en: "Machop"
 	},

--- a/data/Pokémon TCG Pocket/Fantastical Parade/080.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/080.ts
@@ -4,6 +4,8 @@ import Set from "../Fantastical Parade"
 const card: Card = {
 	set: Set,
 
+	dexId: [67],
+
 	name: {
 		en: "Machoke"
 	},

--- a/data/Pokémon TCG Pocket/Fantastical Parade/081.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/081.ts
@@ -4,6 +4,8 @@ import Set from "../Fantastical Parade"
 const card: Card = {
 	set: Set,
 
+	dexId: [68],
+
 	name: {
 		en: "Machamp"
 	},

--- a/data/Pokémon TCG Pocket/Fantastical Parade/082.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/082.ts
@@ -4,6 +4,8 @@ import Set from "../Fantastical Parade"
 const card: Card = {
 	set: Set,
 
+	dexId: [104],
+
 	name: {
 		en: "Cubone"
 	},

--- a/data/Pokémon TCG Pocket/Fantastical Parade/083.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/083.ts
@@ -4,6 +4,8 @@ import Set from "../Fantastical Parade"
 const card: Card = {
 	set: Set,
 
+	dexId: [307],
+
 	name: {
 		en: "Meditite"
 	},

--- a/data/Pokémon TCG Pocket/Fantastical Parade/084.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/084.ts
@@ -4,6 +4,8 @@ import Set from "../Fantastical Parade"
 const card: Card = {
 	set: Set,
 
+	dexId: [308],
+
 	name: {
 		en: "Medicham"
 	},

--- a/data/Pokémon TCG Pocket/Fantastical Parade/085.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/085.ts
@@ -4,6 +4,8 @@ import Set from "../Fantastical Parade"
 const card: Card = {
 	set: Set,
 
+	dexId: [524],
+
 	name: {
 		en: "Roggenrola"
 	},

--- a/data/Pokémon TCG Pocket/Fantastical Parade/086.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/086.ts
@@ -4,6 +4,8 @@ import Set from "../Fantastical Parade"
 const card: Card = {
 	set: Set,
 
+	dexId: [525],
+
 	name: {
 		en: "Boldore"
 	},

--- a/data/Pokémon TCG Pocket/Fantastical Parade/087.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/087.ts
@@ -4,6 +4,8 @@ import Set from "../Fantastical Parade"
 const card: Card = {
 	set: Set,
 
+	dexId: [526],
+
 	name: {
 		en: "Gigalith ex"
 	},

--- a/data/Pokémon TCG Pocket/Fantastical Parade/088.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/088.ts
@@ -4,6 +4,8 @@ import Set from "../Fantastical Parade"
 const card: Card = {
 	set: Set,
 
+	dexId: [529],
+
 	name: {
 		en: "Drilbur"
 	},

--- a/data/Pokémon TCG Pocket/Fantastical Parade/089.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/089.ts
@@ -4,6 +4,8 @@ import Set from "../Fantastical Parade"
 const card: Card = {
 	set: Set,
 
+	dexId: [696],
+
 	name: {
 		en: "Tyrunt"
 	},

--- a/data/Pokémon TCG Pocket/Fantastical Parade/090.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/090.ts
@@ -4,6 +4,8 @@ import Set from "../Fantastical Parade"
 const card: Card = {
 	set: Set,
 
+	dexId: [697],
+
 	name: {
 		en: "Tyrantrum"
 	},

--- a/data/Pokémon TCG Pocket/Fantastical Parade/091.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/091.ts
@@ -4,6 +4,8 @@ import Set from "../Fantastical Parade"
 const card: Card = {
 	set: Set,
 
+	dexId: [766],
+
 	name: {
 		en: "Passimian"
 	},

--- a/data/Pokémon TCG Pocket/Fantastical Parade/092.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/092.ts
@@ -4,6 +4,8 @@ import Set from "../Fantastical Parade"
 const card: Card = {
 	set: Set,
 
+	dexId: [870],
+
 	name: {
 		en: "Falinks"
 	},

--- a/data/Pokémon TCG Pocket/Fantastical Parade/093.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/093.ts
@@ -4,6 +4,8 @@ import Set from "../Fantastical Parade"
 const card: Card = {
 	set: Set,
 
+	dexId: [1017],
+
 	name: {
 		en: "Cornerstone Mask Ogerpon"
 	},

--- a/data/Pokémon TCG Pocket/Fantastical Parade/094.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/094.ts
@@ -4,6 +4,8 @@ import Set from "../Fantastical Parade"
 const card: Card = {
 	set: Set,
 
+	dexId: [52],
+
 	name: {
 		en: "Alolan Meowth"
 	},

--- a/data/Pokémon TCG Pocket/Fantastical Parade/095.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/095.ts
@@ -4,6 +4,8 @@ import Set from "../Fantastical Parade"
 const card: Card = {
 	set: Set,
 
+	dexId: [53],
+
 	name: {
 		en: "Alolan Persian"
 	},

--- a/data/Pokémon TCG Pocket/Fantastical Parade/096.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/096.ts
@@ -4,6 +4,8 @@ import Set from "../Fantastical Parade"
 const card: Card = {
 	set: Set,
 
+	dexId: [88],
+
 	name: {
 		en: "Alolan Grimer"
 	},

--- a/data/Pokémon TCG Pocket/Fantastical Parade/097.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/097.ts
@@ -4,6 +4,8 @@ import Set from "../Fantastical Parade"
 const card: Card = {
 	set: Set,
 
+	dexId: [89],
+
 	name: {
 		en: "Alolan Muk"
 	},

--- a/data/Pokémon TCG Pocket/Fantastical Parade/098.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/098.ts
@@ -4,6 +4,8 @@ import Set from "../Fantastical Parade"
 const card: Card = {
 	set: Set,
 
+	dexId: [263],
+
 	name: {
 		en: "Galarian Zigzagoon"
 	},

--- a/data/Pokémon TCG Pocket/Fantastical Parade/099.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/099.ts
@@ -4,6 +4,8 @@ import Set from "../Fantastical Parade"
 const card: Card = {
 	set: Set,
 
+	dexId: [264],
+
 	name: {
 		en: "Galarian Linoone"
 	},

--- a/data/Pokémon TCG Pocket/Fantastical Parade/100.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/100.ts
@@ -4,6 +4,8 @@ import Set from "../Fantastical Parade"
 const card: Card = {
 	set: Set,
 
+	dexId: [862],
+
 	name: {
 		en: "Galarian Obstagoon"
 	},

--- a/data/Pokémon TCG Pocket/Fantastical Parade/101.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/101.ts
@@ -4,6 +4,8 @@ import Set from "../Fantastical Parade"
 const card: Card = {
 	set: Set,
 
+	dexId: [434],
+
 	name: {
 		en: "Stunky"
 	},

--- a/data/Pokémon TCG Pocket/Fantastical Parade/102.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/102.ts
@@ -4,6 +4,8 @@ import Set from "../Fantastical Parade"
 const card: Card = {
 	set: Set,
 
+	dexId: [435],
+
 	name: {
 		en: "Skuntank"
 	},

--- a/data/Pokémon TCG Pocket/Fantastical Parade/103.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/103.ts
@@ -4,6 +4,8 @@ import Set from "../Fantastical Parade"
 const card: Card = {
 	set: Set,
 
+	dexId: [442],
+
 	name: {
 		en: "Spiritomb"
 	},

--- a/data/Pokémon TCG Pocket/Fantastical Parade/104.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/104.ts
@@ -4,6 +4,8 @@ import Set from "../Fantastical Parade"
 const card: Card = {
 	set: Set,
 
+	dexId: [509],
+
 	name: {
 		en: "Purrloin"
 	},

--- a/data/Pokémon TCG Pocket/Fantastical Parade/105.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/105.ts
@@ -4,6 +4,8 @@ import Set from "../Fantastical Parade"
 const card: Card = {
 	set: Set,
 
+	dexId: [510],
+
 	name: {
 		en: "Liepard"
 	},

--- a/data/Pokémon TCG Pocket/Fantastical Parade/106.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/106.ts
@@ -4,6 +4,8 @@ import Set from "../Fantastical Parade"
 const card: Card = {
 	set: Set,
 
+	dexId: [559],
+
 	name: {
 		en: "Scraggy"
 	},

--- a/data/Pokémon TCG Pocket/Fantastical Parade/107.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/107.ts
@@ -4,6 +4,8 @@ import Set from "../Fantastical Parade"
 const card: Card = {
 	set: Set,
 
+	dexId: [560],
+
 	name: {
 		en: "Scrafty"
 	},

--- a/data/Pokémon TCG Pocket/Fantastical Parade/108.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/108.ts
@@ -4,6 +4,8 @@ import Set from "../Fantastical Parade"
 const card: Card = {
 	set: Set,
 
+	dexId: [717],
+
 	name: {
 		en: "Yveltal"
 	},

--- a/data/Pokémon TCG Pocket/Fantastical Parade/109.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/109.ts
@@ -4,6 +4,8 @@ import Set from "../Fantastical Parade"
 const card: Card = {
 	set: Set,
 
+	dexId: [799],
+
 	name: {
 		en: "Guzzlord"
 	},

--- a/data/Pokémon TCG Pocket/Fantastical Parade/110.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/110.ts
@@ -4,6 +4,8 @@ import Set from "../Fantastical Parade"
 const card: Card = {
 	set: Set,
 
+	dexId: [52],
+
 	name: {
 		en: "Galarian Meowth"
 	},

--- a/data/Pokémon TCG Pocket/Fantastical Parade/111.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/111.ts
@@ -4,6 +4,8 @@ import Set from "../Fantastical Parade"
 const card: Card = {
 	set: Set,
 
+	dexId: [863],
+
 	name: {
 		en: "Galarian Perrserker"
 	},

--- a/data/Pokémon TCG Pocket/Fantastical Parade/112.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/112.ts
@@ -4,6 +4,8 @@ import Set from "../Fantastical Parade"
 const card: Card = {
 	set: Set,
 
+	dexId: [303],
+
 	name: {
 		en: "Mawile"
 	},

--- a/data/Pokémon TCG Pocket/Fantastical Parade/113.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/113.ts
@@ -4,6 +4,8 @@ import Set from "../Fantastical Parade"
 const card: Card = {
 	set: Set,
 
+	dexId: [303],
+
 	name: {
 		en: "Mega Mawile ex"
 	},

--- a/data/Pokémon TCG Pocket/Fantastical Parade/114.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/114.ts
@@ -4,6 +4,8 @@ import Set from "../Fantastical Parade"
 const card: Card = {
 	set: Set,
 
+	dexId: [530],
+
 	name: {
 		en: "Excadrill"
 	},

--- a/data/Pokémon TCG Pocket/Fantastical Parade/115.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/115.ts
@@ -4,6 +4,8 @@ import Set from "../Fantastical Parade"
 const card: Card = {
 	set: Set,
 
+	dexId: [597],
+
 	name: {
 		en: "Ferroseed"
 	},

--- a/data/Pokémon TCG Pocket/Fantastical Parade/116.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/116.ts
@@ -4,6 +4,8 @@ import Set from "../Fantastical Parade"
 const card: Card = {
 	set: Set,
 
+	dexId: [598],
+
 	name: {
 		en: "Ferrothorn"
 	},

--- a/data/Pokémon TCG Pocket/Fantastical Parade/117.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/117.ts
@@ -4,6 +4,8 @@ import Set from "../Fantastical Parade"
 const card: Card = {
 	set: Set,
 
+	dexId: [618],
+
 	name: {
 		en: "Galarian Stunfisk"
 	},

--- a/data/Pokémon TCG Pocket/Fantastical Parade/118.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/118.ts
@@ -4,6 +4,8 @@ import Set from "../Fantastical Parade"
 const card: Card = {
 	set: Set,
 
+	dexId: [679],
+
 	name: {
 		en: "Honedge"
 	},

--- a/data/Pokémon TCG Pocket/Fantastical Parade/119.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/119.ts
@@ -4,6 +4,8 @@ import Set from "../Fantastical Parade"
 const card: Card = {
 	set: Set,
 
+	dexId: [680],
+
 	name: {
 		en: "Doublade"
 	},

--- a/data/Pokémon TCG Pocket/Fantastical Parade/120.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/120.ts
@@ -4,6 +4,8 @@ import Set from "../Fantastical Parade"
 const card: Card = {
 	set: Set,
 
+	dexId: [681],
+
 	name: {
 		en: "Aegislash"
 	},

--- a/data/Pokémon TCG Pocket/Fantastical Parade/121.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/121.ts
@@ -4,6 +4,8 @@ import Set from "../Fantastical Parade"
 const card: Card = {
 	set: Set,
 
+	dexId: [371],
+
 	name: {
 		en: "Bagon"
 	},

--- a/data/Pokémon TCG Pocket/Fantastical Parade/122.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/122.ts
@@ -4,6 +4,8 @@ import Set from "../Fantastical Parade"
 const card: Card = {
 	set: Set,
 
+	dexId: [372],
+
 	name: {
 		en: "Shelgon"
 	},

--- a/data/Pokémon TCG Pocket/Fantastical Parade/123.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/123.ts
@@ -4,6 +4,8 @@ import Set from "../Fantastical Parade"
 const card: Card = {
 	set: Set,
 
+	dexId: [373],
+
 	name: {
 		en: "Salamence"
 	},

--- a/data/Pokémon TCG Pocket/Fantastical Parade/124.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/124.ts
@@ -4,6 +4,8 @@ import Set from "../Fantastical Parade"
 const card: Card = {
 	set: Set,
 
+	dexId: [52],
+
 	name: {
 		en: "Meowth"
 	},

--- a/data/Pokémon TCG Pocket/Fantastical Parade/125.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/125.ts
@@ -4,6 +4,8 @@ import Set from "../Fantastical Parade"
 const card: Card = {
 	set: Set,
 
+	dexId: [53],
+
 	name: {
 		en: "Persian"
 	},

--- a/data/Pokémon TCG Pocket/Fantastical Parade/126.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/126.ts
@@ -4,6 +4,8 @@ import Set from "../Fantastical Parade"
 const card: Card = {
 	set: Set,
 
+	dexId: [115],
+
 	name: {
 		en: "Kangaskhan"
 	},

--- a/data/Pokémon TCG Pocket/Fantastical Parade/127.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/127.ts
@@ -4,6 +4,8 @@ import Set from "../Fantastical Parade"
 const card: Card = {
 	set: Set,
 
+	dexId: [115],
+
 	name: {
 		en: "Mega Kangaskhan ex"
 	},

--- a/data/Pokémon TCG Pocket/Fantastical Parade/128.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/128.ts
@@ -4,6 +4,8 @@ import Set from "../Fantastical Parade"
 const card: Card = {
 	set: Set,
 
+	dexId: [161],
+
 	name: {
 		en: "Sentret"
 	},

--- a/data/Pokémon TCG Pocket/Fantastical Parade/129.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/129.ts
@@ -4,6 +4,8 @@ import Set from "../Fantastical Parade"
 const card: Card = {
 	set: Set,
 
+	dexId: [162],
+
 	name: {
 		en: "Furret"
 	},

--- a/data/Pokémon TCG Pocket/Fantastical Parade/130.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/130.ts
@@ -4,6 +4,8 @@ import Set from "../Fantastical Parade"
 const card: Card = {
 	set: Set,
 
+	dexId: [235],
+
 	name: {
 		en: "Smeargle"
 	},

--- a/data/Pokémon TCG Pocket/Fantastical Parade/131.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/131.ts
@@ -4,6 +4,8 @@ import Set from "../Fantastical Parade"
 const card: Card = {
 	set: Set,
 
+	dexId: [249],
+
 	name: {
 		en: "Lugia"
 	},

--- a/data/Pokémon TCG Pocket/Fantastical Parade/132.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/132.ts
@@ -4,6 +4,8 @@ import Set from "../Fantastical Parade"
 const card: Card = {
 	set: Set,
 
+	dexId: [276],
+
 	name: {
 		en: "Taillow"
 	},

--- a/data/Pokémon TCG Pocket/Fantastical Parade/133.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/133.ts
@@ -4,6 +4,8 @@ import Set from "../Fantastical Parade"
 const card: Card = {
 	set: Set,
 
+	dexId: [277],
+
 	name: {
 		en: "Swellow"
 	},

--- a/data/Pokémon TCG Pocket/Fantastical Parade/134.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/134.ts
@@ -4,6 +4,8 @@ import Set from "../Fantastical Parade"
 const card: Card = {
 	set: Set,
 
+	dexId: [287],
+
 	name: {
 		en: "Slakoth"
 	},

--- a/data/Pokémon TCG Pocket/Fantastical Parade/135.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/135.ts
@@ -4,6 +4,8 @@ import Set from "../Fantastical Parade"
 const card: Card = {
 	set: Set,
 
+	dexId: [288],
+
 	name: {
 		en: "Vigoroth"
 	},

--- a/data/Pokémon TCG Pocket/Fantastical Parade/136.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/136.ts
@@ -4,6 +4,8 @@ import Set from "../Fantastical Parade"
 const card: Card = {
 	set: Set,
 
+	dexId: [289],
+
 	name: {
 		en: "Slaking"
 	},

--- a/data/Pokémon TCG Pocket/Fantastical Parade/137.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/137.ts
@@ -4,6 +4,8 @@ import Set from "../Fantastical Parade"
 const card: Card = {
 	set: Set,
 
+	dexId: [327],
+
 	name: {
 		en: "Spinda"
 	},

--- a/data/Pokémon TCG Pocket/Fantastical Parade/138.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/138.ts
@@ -4,6 +4,8 @@ import Set from "../Fantastical Parade"
 const card: Card = {
 	set: Set,
 
+	dexId: [641],
+
 	name: {
 		en: "Tornadus"
 	},

--- a/data/Pokémon TCG Pocket/Fantastical Parade/139.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/139.ts
@@ -4,6 +4,8 @@ import Set from "../Fantastical Parade"
 const card: Card = {
 	set: Set,
 
+	dexId: [659],
+
 	name: {
 		en: "Bunnelby"
 	},

--- a/data/Pokémon TCG Pocket/Fantastical Parade/140.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/140.ts
@@ -4,6 +4,8 @@ import Set from "../Fantastical Parade"
 const card: Card = {
 	set: Set,
 
+	dexId: [660],
+
 	name: {
 		en: "Diggersby"
 	},

--- a/data/Pokémon TCG Pocket/Fantastical Parade/141.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/141.ts
@@ -4,6 +4,8 @@ import Set from "../Fantastical Parade"
 const card: Card = {
 	set: Set,
 
+	dexId: [676],
+
 	name: {
 		en: "Furfrou"
 	},

--- a/data/Pokémon TCG Pocket/Fantastical Parade/142.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/142.ts
@@ -4,6 +4,8 @@ import Set from "../Fantastical Parade"
 const card: Card = {
 	set: Set,
 
+	dexId: [924],
+
 	name: {
 		en: "Tandemaus"
 	},

--- a/data/Pokémon TCG Pocket/Fantastical Parade/143.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/143.ts
@@ -4,6 +4,8 @@ import Set from "../Fantastical Parade"
 const card: Card = {
 	set: Set,
 
+	dexId: [925],
+
 	name: {
 		en: "Maushold"
 	},

--- a/data/Pokémon TCG Pocket/Fantastical Parade/156.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/156.ts
@@ -4,6 +4,8 @@ import Set from "../Fantastical Parade"
 const card: Card = {
 	set: Set,
 
+	dexId: [331],
+
 	name: {
 		en: "Cacnea"
 	},

--- a/data/Pokémon TCG Pocket/Fantastical Parade/157.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/157.ts
@@ -4,6 +4,8 @@ import Set from "../Fantastical Parade"
 const card: Card = {
 	set: Set,
 
+	dexId: [407],
+
 	name: {
 		en: "Roserade"
 	},

--- a/data/Pokémon TCG Pocket/Fantastical Parade/158.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/158.ts
@@ -4,6 +4,8 @@ import Set from "../Fantastical Parade"
 const card: Card = {
 	set: Set,
 
+	dexId: [666],
+
 	name: {
 		en: "Vivillon"
 	},

--- a/data/Pokémon TCG Pocket/Fantastical Parade/159.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/159.ts
@@ -4,6 +4,8 @@ import Set from "../Fantastical Parade"
 const card: Card = {
 	set: Set,
 
+	dexId: [794],
+
 	name: {
 		en: "Buzzwole"
 	},

--- a/data/Pokémon TCG Pocket/Fantastical Parade/160.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/160.ts
@@ -4,6 +4,8 @@ import Set from "../Fantastical Parade"
 const card: Card = {
 	set: Set,
 
+	dexId: [643],
+
 	name: {
 		en: "Reshiram"
 	},

--- a/data/Pokémon TCG Pocket/Fantastical Parade/161.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/161.ts
@@ -4,6 +4,8 @@ import Set from "../Fantastical Parade"
 const card: Card = {
 	set: Set,
 
+	dexId: [741],
+
 	name: {
 		en: "Oricorio"
 	},

--- a/data/Pokémon TCG Pocket/Fantastical Parade/162.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/162.ts
@@ -4,6 +4,8 @@ import Set from "../Fantastical Parade"
 const card: Card = {
 	set: Set,
 
+	dexId: [813],
+
 	name: {
 		en: "Scorbunny"
 	},

--- a/data/Pokémon TCG Pocket/Fantastical Parade/163.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/163.ts
@@ -4,6 +4,8 @@ import Set from "../Fantastical Parade"
 const card: Card = {
 	set: Set,
 
+	dexId: [699],
+
 	name: {
 		en: "Aurorus"
 	},

--- a/data/Pokémon TCG Pocket/Fantastical Parade/164.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/164.ts
@@ -4,6 +4,8 @@ import Set from "../Fantastical Parade"
 const card: Card = {
 	set: Set,
 
+	dexId: [845],
+
 	name: {
 		en: "Cramorant"
 	},

--- a/data/Pokémon TCG Pocket/Fantastical Parade/165.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/165.ts
@@ -4,6 +4,8 @@ import Set from "../Fantastical Parade"
 const card: Card = {
 	set: Set,
 
+	dexId: [312],
+
 	name: {
 		en: "Minun"
 	},

--- a/data/Pokémon TCG Pocket/Fantastical Parade/166.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/166.ts
@@ -4,6 +4,8 @@ import Set from "../Fantastical Parade"
 const card: Card = {
 	set: Set,
 
+	dexId: [848],
+
 	name: {
 		en: "Toxel"
 	},

--- a/data/Pokémon TCG Pocket/Fantastical Parade/167.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/167.ts
@@ -4,6 +4,8 @@ import Set from "../Fantastical Parade"
 const card: Card = {
 	set: Set,
 
+	dexId: [77],
+
 	name: {
 		en: "Galarian Ponyta"
 	},

--- a/data/Pokémon TCG Pocket/Fantastical Parade/168.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/168.ts
@@ -4,6 +4,8 @@ import Set from "../Fantastical Parade"
 const card: Card = {
 	set: Set,
 
+	dexId: [209],
+
 	name: {
 		en: "Snubbull"
 	},

--- a/data/Pokémon TCG Pocket/Fantastical Parade/169.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/169.ts
@@ -4,6 +4,8 @@ import Set from "../Fantastical Parade"
 const card: Card = {
 	set: Set,
 
+	dexId: [876],
+
 	name: {
 		en: "Indeedee"
 	},

--- a/data/Pokémon TCG Pocket/Fantastical Parade/170.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/170.ts
@@ -4,6 +4,8 @@ import Set from "../Fantastical Parade"
 const card: Card = {
 	set: Set,
 
+	dexId: [27],
+
 	name: {
 		en: "Sandshrew"
 	},

--- a/data/Pokémon TCG Pocket/Fantastical Parade/171.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/171.ts
@@ -4,6 +4,8 @@ import Set from "../Fantastical Parade"
 const card: Card = {
 	set: Set,
 
+	dexId: [697],
+
 	name: {
 		en: "Tyrantrum"
 	},

--- a/data/Pokémon TCG Pocket/Fantastical Parade/172.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/172.ts
@@ -4,6 +4,8 @@ import Set from "../Fantastical Parade"
 const card: Card = {
 	set: Set,
 
+	dexId: [870],
+
 	name: {
 		en: "Falinks"
 	},

--- a/data/Pokémon TCG Pocket/Fantastical Parade/173.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/173.ts
@@ -4,6 +4,8 @@ import Set from "../Fantastical Parade"
 const card: Card = {
 	set: Set,
 
+	dexId: [89],
+
 	name: {
 		en: "Alolan Muk"
 	},

--- a/data/Pokémon TCG Pocket/Fantastical Parade/174.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/174.ts
@@ -4,6 +4,8 @@ import Set from "../Fantastical Parade"
 const card: Card = {
 	set: Set,
 
+	dexId: [509],
+
 	name: {
 		en: "Purrloin"
 	},

--- a/data/Pokémon TCG Pocket/Fantastical Parade/175.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/175.ts
@@ -4,6 +4,8 @@ import Set from "../Fantastical Parade"
 const card: Card = {
 	set: Set,
 
+	dexId: [717],
+
 	name: {
 		en: "Yveltal"
 	},

--- a/data/Pokémon TCG Pocket/Fantastical Parade/176.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/176.ts
@@ -4,6 +4,8 @@ import Set from "../Fantastical Parade"
 const card: Card = {
 	set: Set,
 
+	dexId: [862],
+
 	name: {
 		en: "Galarian Obstagoon"
 	},

--- a/data/Pokémon TCG Pocket/Fantastical Parade/177.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/177.ts
@@ -4,6 +4,8 @@ import Set from "../Fantastical Parade"
 const card: Card = {
 	set: Set,
 
+	dexId: [863],
+
 	name: {
 		en: "Galarian Perrserker"
 	},

--- a/data/Pokémon TCG Pocket/Fantastical Parade/178.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/178.ts
@@ -4,6 +4,8 @@ import Set from "../Fantastical Parade"
 const card: Card = {
 	set: Set,
 
+	dexId: [373],
+
 	name: {
 		en: "Salamence"
 	},

--- a/data/Pokémon TCG Pocket/Fantastical Parade/179.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/179.ts
@@ -4,6 +4,8 @@ import Set from "../Fantastical Parade"
 const card: Card = {
 	set: Set,
 
+	dexId: [287],
+
 	name: {
 		en: "Slakoth"
 	},

--- a/data/Pokémon TCG Pocket/Fantastical Parade/180.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/180.ts
@@ -4,6 +4,8 @@ import Set from "../Fantastical Parade"
 const card: Card = {
 	set: Set,
 
+	dexId: [1017],
+
 	name: {
 		en: "Teal Mask Ogerpon ex"
 	},

--- a/data/Pokémon TCG Pocket/Fantastical Parade/181.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/181.ts
@@ -4,6 +4,8 @@ import Set from "../Fantastical Parade"
 const card: Card = {
 	set: Set,
 
+	dexId: [806],
+
 	name: {
 		en: "Blacephalon ex"
 	},

--- a/data/Pokémon TCG Pocket/Fantastical Parade/182.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/182.ts
@@ -4,6 +4,8 @@ import Set from "../Fantastical Parade"
 const card: Card = {
 	set: Set,
 
+	dexId: [38],
+
 	name: {
 		en: "Alolan Ninetales ex"
 	},

--- a/data/Pokémon TCG Pocket/Fantastical Parade/183.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/183.ts
@@ -4,6 +4,8 @@ import Set from "../Fantastical Parade"
 const card: Card = {
 	set: Set,
 
+	dexId: [260],
+
 	name: {
 		en: "Mega Swampert ex"
 	},

--- a/data/Pokémon TCG Pocket/Fantastical Parade/184.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/184.ts
@@ -4,6 +4,8 @@ import Set from "../Fantastical Parade"
 const card: Card = {
 	set: Set,
 
+	dexId: [849],
+
 	name: {
 		en: "Toxtricity ex"
 	},

--- a/data/Pokémon TCG Pocket/Fantastical Parade/185.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/185.ts
@@ -4,6 +4,8 @@ import Set from "../Fantastical Parade"
 const card: Card = {
 	set: Set,
 
+	dexId: [282],
+
 	name: {
 		en: "Mega Gardevoir ex"
 	},

--- a/data/Pokémon TCG Pocket/Fantastical Parade/186.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/186.ts
@@ -4,6 +4,8 @@ import Set from "../Fantastical Parade"
 const card: Card = {
 	set: Set,
 
+	dexId: [778],
+
 	name: {
 		en: "Mimikyu ex"
 	},

--- a/data/Pokémon TCG Pocket/Fantastical Parade/187.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/187.ts
@@ -4,6 +4,8 @@ import Set from "../Fantastical Parade"
 const card: Card = {
 	set: Set,
 
+	dexId: [526],
+
 	name: {
 		en: "Gigalith ex"
 	},

--- a/data/Pokémon TCG Pocket/Fantastical Parade/188.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/188.ts
@@ -4,6 +4,8 @@ import Set from "../Fantastical Parade"
 const card: Card = {
 	set: Set,
 
+	dexId: [303],
+
 	name: {
 		en: "Mega Mawile ex"
 	},

--- a/data/Pokémon TCG Pocket/Fantastical Parade/189.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/189.ts
@@ -4,6 +4,8 @@ import Set from "../Fantastical Parade"
 const card: Card = {
 	set: Set,
 
+	dexId: [115],
+
 	name: {
 		en: "Mega Kangaskhan ex"
 	},

--- a/data/Pokémon TCG Pocket/Fantastical Parade/194.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/194.ts
@@ -4,6 +4,8 @@ import Set from "../Fantastical Parade"
 const card: Card = {
 	set: Set,
 
+	dexId: [1017],
+
 	name: {
 		en: "Teal Mask Ogerpon ex"
 	},

--- a/data/Pokémon TCG Pocket/Fantastical Parade/195.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/195.ts
@@ -4,6 +4,8 @@ import Set from "../Fantastical Parade"
 const card: Card = {
 	set: Set,
 
+	dexId: [806],
+
 	name: {
 		en: "Blacephalon ex"
 	},

--- a/data/Pokémon TCG Pocket/Fantastical Parade/196.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/196.ts
@@ -4,6 +4,8 @@ import Set from "../Fantastical Parade"
 const card: Card = {
 	set: Set,
 
+	dexId: [38],
+
 	name: {
 		en: "Alolan Ninetales ex"
 	},

--- a/data/Pokémon TCG Pocket/Fantastical Parade/197.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/197.ts
@@ -4,6 +4,8 @@ import Set from "../Fantastical Parade"
 const card: Card = {
 	set: Set,
 
+	dexId: [260],
+
 	name: {
 		en: "Mega Swampert ex"
 	},

--- a/data/Pokémon TCG Pocket/Fantastical Parade/198.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/198.ts
@@ -4,6 +4,8 @@ import Set from "../Fantastical Parade"
 const card: Card = {
 	set: Set,
 
+	dexId: [849],
+
 	name: {
 		en: "Toxtricity ex"
 	},

--- a/data/Pokémon TCG Pocket/Fantastical Parade/199.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/199.ts
@@ -4,6 +4,8 @@ import Set from "../Fantastical Parade"
 const card: Card = {
 	set: Set,
 
+	dexId: [778],
+
 	name: {
 		en: "Mimikyu ex"
 	},

--- a/data/Pokémon TCG Pocket/Fantastical Parade/200.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/200.ts
@@ -4,6 +4,8 @@ import Set from "../Fantastical Parade"
 const card: Card = {
 	set: Set,
 
+	dexId: [526],
+
 	name: {
 		en: "Gigalith ex"
 	},

--- a/data/Pokémon TCG Pocket/Fantastical Parade/201.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/201.ts
@@ -4,6 +4,8 @@ import Set from "../Fantastical Parade"
 const card: Card = {
 	set: Set,
 
+	dexId: [303],
+
 	name: {
 		en: "Mega Mawile ex"
 	},

--- a/data/Pokémon TCG Pocket/Fantastical Parade/202.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/202.ts
@@ -4,6 +4,8 @@ import Set from "../Fantastical Parade"
 const card: Card = {
 	set: Set,
 
+	dexId: [115],
+
 	name: {
 		en: "Mega Kangaskhan ex"
 	},

--- a/data/Pokémon TCG Pocket/Fantastical Parade/203.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/203.ts
@@ -4,6 +4,8 @@ import Set from "../Fantastical Parade"
 const card: Card = {
 	set: Set,
 
+	dexId: [282],
+
 	name: {
 		en: "Mega Gardevoir ex"
 	},

--- a/data/Pokémon TCG Pocket/Fantastical Parade/204.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/204.ts
@@ -4,6 +4,8 @@ import Set from "../Fantastical Parade"
 const card: Card = {
 	set: Set,
 
+	dexId: [52],
+
 	name: {
 		en: "Meowth"
 	},

--- a/data/Pokémon TCG Pocket/Fantastical Parade/205.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/205.ts
@@ -4,6 +4,8 @@ import Set from "../Fantastical Parade"
 const card: Card = {
 	set: Set,
 
+	dexId: [114],
+
 	name: {
 		en: "Tangela"
 	},

--- a/data/Pokémon TCG Pocket/Fantastical Parade/206.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/206.ts
@@ -4,6 +4,8 @@ import Set from "../Fantastical Parade"
 const card: Card = {
 	set: Set,
 
+	dexId: [240],
+
 	name: {
 		en: "Magby"
 	},

--- a/data/Pokémon TCG Pocket/Fantastical Parade/207.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/207.ts
@@ -4,6 +4,8 @@ import Set from "../Fantastical Parade"
 const card: Card = {
 	set: Set,
 
+	dexId: [126],
+
 	name: {
 		en: "Magmar"
 	},

--- a/data/Pokémon TCG Pocket/Fantastical Parade/208.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/208.ts
@@ -4,6 +4,8 @@ import Set from "../Fantastical Parade"
 const card: Card = {
 	set: Set,
 
+	dexId: [116],
+
 	name: {
 		en: "Horsea"
 	},

--- a/data/Pokémon TCG Pocket/Fantastical Parade/209.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/209.ts
@@ -4,6 +4,8 @@ import Set from "../Fantastical Parade"
 const card: Card = {
 	set: Set,
 
+	dexId: [117],
+
 	name: {
 		en: "Seadra"
 	},

--- a/data/Pokémon TCG Pocket/Fantastical Parade/210.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/210.ts
@@ -4,6 +4,8 @@ import Set from "../Fantastical Parade"
 const card: Card = {
 	set: Set,
 
+	dexId: [458],
+
 	name: {
 		en: "Mantyke"
 	},

--- a/data/Pokémon TCG Pocket/Fantastical Parade/211.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/211.ts
@@ -4,6 +4,8 @@ import Set from "../Fantastical Parade"
 const card: Card = {
 	set: Set,
 
+	dexId: [138],
+
 	name: {
 		en: "Omanyte"
 	},

--- a/data/Pokémon TCG Pocket/Fantastical Parade/212.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/212.ts
@@ -4,6 +4,8 @@ import Set from "../Fantastical Parade"
 const card: Card = {
 	set: Set,
 
+	dexId: [139],
+
 	name: {
 		en: "Omastar"
 	},

--- a/data/Pokémon TCG Pocket/Fantastical Parade/213.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/213.ts
@@ -4,6 +4,8 @@ import Set from "../Fantastical Parade"
 const card: Card = {
 	set: Set,
 
+	dexId: [172],
+
 	name: {
 		en: "Pichu"
 	},

--- a/data/Pokémon TCG Pocket/Fantastical Parade/214.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/214.ts
@@ -4,6 +4,8 @@ import Set from "../Fantastical Parade"
 const card: Card = {
 	set: Set,
 
+	dexId: [35],
+
 	name: {
 		en: "Clefairy"
 	},

--- a/data/Pokémon TCG Pocket/Fantastical Parade/215.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/215.ts
@@ -4,6 +4,8 @@ import Set from "../Fantastical Parade"
 const card: Card = {
 	set: Set,
 
+	dexId: [36],
+
 	name: {
 		en: "Clefable"
 	},

--- a/data/Pokémon TCG Pocket/Fantastical Parade/216.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/216.ts
@@ -4,6 +4,8 @@ import Set from "../Fantastical Parade"
 const card: Card = {
 	set: Set,
 
+	dexId: [380],
+
 	name: {
 		en: "Latias"
 	},

--- a/data/Pokémon TCG Pocket/Fantastical Parade/217.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/217.ts
@@ -4,6 +4,8 @@ import Set from "../Fantastical Parade"
 const card: Card = {
 	set: Set,
 
+	dexId: [381],
+
 	name: {
 		en: "Latios"
 	},

--- a/data/Pokémon TCG Pocket/Fantastical Parade/218.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/218.ts
@@ -4,6 +4,8 @@ import Set from "../Fantastical Parade"
 const card: Card = {
 	set: Set,
 
+	dexId: [106],
+
 	name: {
 		en: "Hitmonlee"
 	},

--- a/data/Pokémon TCG Pocket/Fantastical Parade/219.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/219.ts
@@ -4,6 +4,8 @@ import Set from "../Fantastical Parade"
 const card: Card = {
 	set: Set,
 
+	dexId: [107],
+
 	name: {
 		en: "Hitmonchan"
 	},

--- a/data/Pokémon TCG Pocket/Fantastical Parade/220.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/220.ts
@@ -4,6 +4,8 @@ import Set from "../Fantastical Parade"
 const card: Card = {
 	set: Set,
 
+	dexId: [140],
+
 	name: {
 		en: "Kabuto"
 	},

--- a/data/Pokémon TCG Pocket/Fantastical Parade/221.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/221.ts
@@ -4,6 +4,8 @@ import Set from "../Fantastical Parade"
 const card: Card = {
 	set: Set,
 
+	dexId: [141],
+
 	name: {
 		en: "Kabutops"
 	},

--- a/data/Pokémon TCG Pocket/Fantastical Parade/222.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/222.ts
@@ -4,6 +4,8 @@ import Set from "../Fantastical Parade"
 const card: Card = {
 	set: Set,
 
+	dexId: [231],
+
 	name: {
 		en: "Phanpy"
 	},

--- a/data/Pokémon TCG Pocket/Fantastical Parade/223.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/223.ts
@@ -4,6 +4,8 @@ import Set from "../Fantastical Parade"
 const card: Card = {
 	set: Set,
 
+	dexId: [236],
+
 	name: {
 		en: "Tyrogue"
 	},

--- a/data/Pokémon TCG Pocket/Fantastical Parade/224.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/224.ts
@@ -4,6 +4,8 @@ import Set from "../Fantastical Parade"
 const card: Card = {
 	set: Set,
 
+	dexId: [128],
+
 	name: {
 		en: "Tauros"
 	},

--- a/data/Pokémon TCG Pocket/Fantastical Parade/225.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/225.ts
@@ -4,6 +4,8 @@ import Set from "../Fantastical Parade"
 const card: Card = {
 	set: Set,
 
+	dexId: [136],
+
 	name: {
 		en: "Flareon ex"
 	},

--- a/data/Pokémon TCG Pocket/Fantastical Parade/226.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/226.ts
@@ -4,6 +4,8 @@ import Set from "../Fantastical Parade"
 const card: Card = {
 	set: Set,
 
+	dexId: [250],
+
 	name: {
 		en: "Ho-Oh ex"
 	},

--- a/data/Pokémon TCG Pocket/Fantastical Parade/227.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/227.ts
@@ -4,6 +4,8 @@ import Set from "../Fantastical Parade"
 const card: Card = {
 	set: Set,
 
+	dexId: [230],
+
 	name: {
 		en: "Kingdra ex"
 	},

--- a/data/Pokémon TCG Pocket/Fantastical Parade/228.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/228.ts
@@ -4,6 +4,8 @@ import Set from "../Fantastical Parade"
 const card: Card = {
 	set: Set,
 
+	dexId: [196],
+
 	name: {
 		en: "Espeon ex"
 	},

--- a/data/Pokémon TCG Pocket/Fantastical Parade/229.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/229.ts
@@ -4,6 +4,8 @@ import Set from "../Fantastical Parade"
 const card: Card = {
 	set: Set,
 
+	dexId: [700],
+
 	name: {
 		en: "Sylveon ex"
 	},

--- a/data/Pokémon TCG Pocket/Fantastical Parade/230.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/230.ts
@@ -4,6 +4,8 @@ import Set from "../Fantastical Parade"
 const card: Card = {
 	set: Set,
 
+	dexId: [232],
+
 	name: {
 		en: "Donphan ex"
 	},

--- a/data/Pokémon TCG Pocket/Fantastical Parade/231.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/231.ts
@@ -4,6 +4,8 @@ import Set from "../Fantastical Parade"
 const card: Card = {
 	set: Set,
 
+	dexId: [197],
+
 	name: {
 		en: "Umbreon ex"
 	},

--- a/data/Pokémon TCG Pocket/Fantastical Parade/232.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/232.ts
@@ -4,6 +4,8 @@ import Set from "../Fantastical Parade"
 const card: Card = {
 	set: Set,
 
+	dexId: [249],
+
 	name: {
 		en: "Lugia ex"
 	},

--- a/data/Pokémon TCG Pocket/Fantastical Parade/233.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/233.ts
@@ -4,6 +4,8 @@ import Set from "../Fantastical Parade"
 const card: Card = {
 	set: Set,
 
+	dexId: [648],
+
 	name: {
 		en: "Meloetta"
 	},


### PR DESCRIPTION
## Summary
- add missing `dexId` fields for Pokemon cards in `Pokemon TCG Pocket/Fantastical Parade`
- branch is based on `upstream/master` and contains only this set scope
- generated with the dexId fixer workflow and validated for set-only diff scope

## Regenerate dexId process
1. `bun run dex:fix:dry-run` to preview missing/updated dexId assignments.
2. `bun run dex:fix:apply` to write dexId changes in card files.
3. `bun run dex:lint` to verify all Pokemon cards have valid dexId.
4. Optional: `bun run dex:audit:report` for a detailed audit report.

## Validation
- set-only scope verified: all changed files are under `data/Pokémon TCG Pocket/Fantastical Parade/`
- all changed files contain `dexId`