### PR TITLE
fix(data): add missing dexId for tcgp Paldean Wonders

### DIFF
--- a/data/Pokémon TCG Pocket/Paldean Wonders/003.ts
+++ b/data/Pokémon TCG Pocket/Paldean Wonders/003.ts
@@ -18,6 +18,8 @@ const card: Card = {
   illustrator: "5ban Graphics",
   rarity: "Four Diamond",
   category: "Pokemon",
+
+  dexId: [908],
   hp: 160,
   types: ["Grass"],
   evolveFrom: {

--- a/data/Pokémon TCG Pocket/Paldean Wonders/020.ts
+++ b/data/Pokémon TCG Pocket/Paldean Wonders/020.ts
@@ -15,6 +15,8 @@ const card: Card = {
   illustrator: "takuyoa",
   rarity: "Four Diamond",
   category: "Pokemon",
+
+  dexId: [936],
   hp: 140,
   types: ["Fire"],
   evolveFrom: {

--- a/data/Pokémon TCG Pocket/Paldean Wonders/037.ts
+++ b/data/Pokémon TCG Pocket/Paldean Wonders/037.ts
@@ -15,6 +15,8 @@ const card: Card = {
   illustrator: "aky CG Works",
   rarity: "Four Diamond",
   category: "Pokemon",
+
+  dexId: [1002],
   hp: 130,
   types: ["Water"],
   stage: "Basic",

--- a/data/Pokémon TCG Pocket/Paldean Wonders/042.ts
+++ b/data/Pokémon TCG Pocket/Paldean Wonders/042.ts
@@ -15,6 +15,8 @@ const card: Card = {
   illustrator: "PLANETA Yamashita",
   rarity: "Four Diamond",
   category: "Pokemon",
+
+  dexId: [939],
   hp: 160,
   types: ["Lightning"],
   evolveFrom: {

--- a/data/Pokémon TCG Pocket/Paldean Wonders/078.ts
+++ b/data/Pokémon TCG Pocket/Paldean Wonders/078.ts
@@ -16,6 +16,8 @@ const card: Card = {
   illustrator: "takuyoa",
   rarity: "Four Diamond",
   category: "Pokemon",
+
+  dexId: [1000],
   hp: 150,
   types: ["Metal"],
   evolveFrom: {


### PR DESCRIPTION
## Summary
- add missing `dexId` fields for Pokemon cards in `Pokemon TCG Pocket/Paldean Wonders`
- branch is based on `upstream/master` and contains only this set scope
- generated with the dexId fixer workflow and validated for set-only diff scope

## Regenerate dexId process
1. `bun run dex:fix:dry-run` to preview missing/updated dexId assignments.
2. `bun run dex:fix:apply` to write dexId changes in card files.
3. `bun run dex:lint` to verify all Pokemon cards have valid dexId.
4. Optional: `bun run dex:audit:report` for a detailed audit report.

## Validation
- set-only scope verified: all changed files are under `data/Pokémon TCG Pocket/Paldean Wonders/`
- all changed files contain `dexId`