### PR TITLE
Updated Card Count for hidden Treasures

### DIFF
--- a/data/Diamond & Pearl/Mysterious Treasures.ts
+++ b/data/Diamond & Pearl/Mysterious Treasures.ts
@@ -18,7 +18,7 @@ const dp2: Set = {
 	tcgOnline: "MT",
 
 	cardCount: {
-		official: 122
+		official: 123
 	},
 
 	releaseDate: "2007-08-01",


### PR DESCRIPTION
<!--
Contribution guide: https://github.com/tcgdex/cards-database/blob/master/CONTRIBUTING.md
please submit changes up to 1 set at most.
-->

closes # <!-- Indicate the issue number here -->

## Changes

Updated Card Count for hidden Treasures was showing as 122 but is 123.

## Details

<!-- You can also give more details about your changes -->

