### PR TITLE
refactor: remove variant type from Phantasmal Flames

### DIFF
--- a/data/Mega Evolution/Phantasmal Flames/014.ts
+++ b/data/Mega Evolution/Phantasmal Flames/014.ts
@@ -57,9 +57,6 @@ const card: Card = {
 		},
 		{
 			type: "reverse"
-		},
-		{
-			type: "normal"
 		}
 	],
 

--- a/data/Mega Evolution/Phantasmal Flames/045.ts
+++ b/data/Mega Evolution/Phantasmal Flames/045.ts
@@ -53,9 +53,6 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "normal"
-		},
-		{
 			type: "reverse"
 		},
 		{

--- a/data/Mega Evolution/Phantasmal Flames/053.ts
+++ b/data/Mega Evolution/Phantasmal Flames/053.ts
@@ -70,9 +70,6 @@ const card: Card = {
 			type: "holo"
 		},
 		{
-			type: "normal"
-		},
-		{
 			type: "reverse"
 		}
 	],

--- a/data/Mega Evolution/Phantasmal Flames/068.ts
+++ b/data/Mega Evolution/Phantasmal Flames/068.ts
@@ -70,9 +70,6 @@ const card: Card = {
 			type: "holo"
 		},
 		{
-			type: "normal"
-		},
-		{
 			type: "reverse"
 		}
 	],


### PR DESCRIPTION
## Changes

refactor: remove normal variant type from Phantasmal Flames card 14, 45, 53, 68

