### PR TITLE
fix(Aquapolis): add missing French energy symbols to cube cards

### DIFF
--- a/data/E-Card/Aquapolis/124.ts
+++ b/data/E-Card/Aquapolis/124.ts
@@ -14,7 +14,7 @@ const card: Card = {
 	set: Set,
 
 	effect: {
-		fr: "Attachez cette carte à l'un de vos Pokémon  en jeu. Ce Pokémon peut utiliser l'attaque de cette carte à la place de la sienne. À la fin de votre tour, défaussez-vous de Cube de plante 01.",
+		fr: "Attachez cette carte à l'un de vos Pokémon {G} en jeu. Ce Pokémon peut utiliser l'attaque de cette carte à la place de la sienne. À la fin de votre tour, défaussez-vous de Cube de plante 01.",
 		de: "Lege diese Karte an 1 deiner -Pokémon im Spiel an. Dieses Pokémon kann den Angriff dieser Karte anstatt seiner eigenen verwenden. Lege am Ende deines Zuges Gras-Würfel 01 auf deinen Ablagestapel."
 	},
 

--- a/data/E-Card/Aquapolis/127.ts
+++ b/data/E-Card/Aquapolis/127.ts
@@ -14,7 +14,7 @@ const card: Card = {
 	set: Set,
 
 	effect: {
-		fr: "Attachez cette carte à l'un de vos Pokémon  en jeu. Ce Pokémon peut utiliser l'attaque de cette carte à la place de la sienne. À la fin de votre tour, défaussez-vous de Cube électrik 01.",
+		fr: "Attachez cette carte à l'un de vos Pokémon {L} en jeu. Ce Pokémon peut utiliser l'attaque de cette carte à la place de la sienne. À la fin de votre tour, défaussez-vous de Cube électrik 01.",
 		de: "Lege diese Karte an 1 deiner -Pokémon im Spiel an. Dieses Pokémon kann den Angriff dieser Karte anstatt seiner eigenen verwenden. Lege am Ende deines Zuges Elektro-Würfel 01 auf deinen Ablagestapel."
 	},
 


### PR DESCRIPTION
## Summary
- add missing `{G}` and `{L}` in French text
- keep the same sentence, only add symbols
- only 2 Aquapolis card files are changed

## Why
These 2 French texts were missing the energy symbols.
This makes the card text clearer and consistent.

## Checks
- diff reviewed: only 2 files in `data/E-Card/Aquapolis/`
- `bun run compile` in `server/` passes