### PR TITLE
fix(Delta Species): complete French effect text for Holon Scientist

### DIFF
--- a/data/EX/Delta Species/97.ts
+++ b/data/EX/Delta Species/97.ts
@@ -15,7 +15,7 @@ const card: Card = {
 	trainerType: "Supporter",
 
 	effect: {
-		fr: "Défaussez une carte de votre main. Si vous ne pouvez pas défausser de carte de votre main, vous ne pouvez pas jouer cette carte.",
+		fr: "Défaussez une carte de votre main. Si vous ne pouvez pas défausser de carte de votre main, vous ne pouvez pas jouer cette carte.\n\nSi vous avez moins de cartes en main que votre adversaire, piochez des cartes jusqu'à ce que vous et votre adversaire ayez le même nombre de cartes en main.",
 		de: "Lege 1 Karte von deiner Hand auf den Ablagestapel. Wenn du das nicht machen kannst, kannst du diese Karte nicht spielen.\n\nWenn du weniger Karten auf der Hand hast als dein Gegner, ziehe so viele Karten von deinem Deck, bis ihr beide die gleiche Anzahl Karten auf der Hand habt.",
 	},
 


### PR DESCRIPTION
## Summary
- complete the French effect text for Holon Scientist
- add the missing second paragraph
- only 1 file changed in Delta Species

## Why
The French text was incomplete.
Now it matches the full card effect.

## Checks
- diff reviewed: only `data/EX/Delta Species/97.ts`
- `bun run compile` in `server/` passes