### PR TITLE
fix(EX): complete French effect text for Holon supporter cards

### DIFF
--- a/data/EX/Dragon Frontiers/75.ts
+++ b/data/EX/Dragon Frontiers/75.ts
@@ -15,7 +15,7 @@ const card: Card = {
 	trainerType: "Supporter",
 
 	effect: {
-		fr: "Défaussez une carte de votre main. Si vous ne pouvez pas défausser de carte, vous ne pouvez pas jouer cette carte.",
+		fr: "Défaussez une carte de votre main. Si vous ne pouvez pas défausser de carte, vous ne pouvez pas jouer cette carte.\n\nChoisissez dans votre deck jusqu'à 3 cartes Pokémon de base possédant chacun un maximum de 100 PV, montrez-les à votre adversaire et placez-les dans votre main. Ensuite, mélangez votre deck.",
 		de: "Lege 1 Karte von deiner Hand auf deinen Ablagestapel. Wenn du das nicht machen kannst, kannst du diese Karte nicht spielen.\n\nDurchsuche dein Deck nach bis zu 3 Basis-Pokémon, die jeweils 100 KP oder weniger haben, zeige sie deinem Gegner und nimm sie auf die Hand. Mische dein Deck danach.",
 	},
 

--- a/data/EX/Holon Phantoms/85.ts
+++ b/data/EX/Holon Phantoms/85.ts
@@ -15,7 +15,7 @@ const card: Card = {
 	trainerType: "Supporter",
 
 	effect: {
-		fr: "Défaussez une carte de votre main. Si vous ne pouvez pas défausser de carte de votre main, vous ne pouvez pas jouer cette carte.",
+		fr: "Défaussez une carte de votre main. Si vous ne pouvez pas défausser de carte de votre main, vous ne pouvez pas jouer cette carte.\n\nPiochez 3 cartes. Si vous avez défaussé un Pokémon possédant le symbole δ, piochez 4 cartes.",
 		de: "Lege 1 Karte von deiner Hand auf deinen Ablagestapel. Wenn du das nicht machen kannst, kannst du diese Karte nicht spielen.\n\nZiehe 3 Karten. Wenn du ein Pokémon, auf dem δ zu sehen ist, auf den Ablagestapel gelegt hast, ziehe stattdessen 4 Karten.",
 	},
 


### PR DESCRIPTION
## Summary
- complete French effect text in 2 EX cards
- add the missing second paragraph in each card
- only 2 files changed in EX

## Why
The French text was incomplete.
This makes both effects complete and clear.

## Checks
- diff reviewed: only 2 files in `data/EX/`
- `bun run compile` in `server/` passes