### PR TITLE
fix(data): normalize legacy trainer text formatting

### DIFF
--- a/data/Diamond & Pearl/Secret Wonders/121.ts
+++ b/data/Diamond & Pearl/Secret Wonders/121.ts
@@ -14,7 +14,7 @@ const card: Card = {
 	set: Set,
 
 	effect: {
-		fr: "Attachez PlusPower à 1 de vos Pokémon. Défaussez cette carte à la fin de votre tour. Lorsque le Pokémon auquel PlusPower est attachée attaque, cette attaque inflige 10 dégâts supplémentaires au Pokémon Actif (avant application de la Faiblesse et de la Résistance).",
+		fr: "Attachez PlusPower à 1 de vos Pokémon. Défaussez cette carte à la fin de votre tour.\n\nLorsque le Pokémon auquel PlusPower est attachée attaque, cette attaque inflige 10 dégâts supplémentaires au Pokémon Actif (avant application de la Faiblesse et de la Résistance).",
 		de: "Lege PlusPower an 1 deiner Pokémon an und lege diese Karte am Ende deines Zuges auf deinen Ablagestapel.\n\nFalls das Pokémon, an das PlusPower angelegt ist, angreift, fügt der Angriff den Aktiven Pokémon 10 weitere Schadenspunkte zu (bevor Schwäche und Resistenz verrechnet werden)."
 	},
 

--- a/data/Platinum/Platinum/112.ts
+++ b/data/Platinum/Platinum/112.ts
@@ -14,7 +14,7 @@ const card: Card = {
 	set: Set,
 
 	effect: {
-		fr: "Attachez PlusPower à 1 de vos Pokémon. Défaussez cette carte à la fin de votre tour. Si le Pokémon auquel PlusPower est attachée attaque, cette attaque inflige 10 dégâts supplémentaires au Pokémon Actif (avant application de la Faiblesse et de la Résistance).",
+		fr: "Attachez PlusPower à 1 de vos Pokémon. Défaussez cette carte à la fin de votre tour.\n\nSi le Pokémon auquel PlusPower est attachée attaque, cette attaque inflige 10 dégâts supplémentaires au Pokémon Actif (avant application de la Faiblesse et de la Résistance).",
 		de: "Attach PlusPower to 1 of your Pokémon. Discard this card at the end of your turn.\n\nIf the Pokémon PlusPower is attached to attacks, the attack does 10 more damage to the Active Pokémon (before applying Weakness and Resistance)."
 	},
 

--- a/data/Sun & Moon/Burning Shadows/165.ts
+++ b/data/Sun & Moon/Burning Shadows/165.ts
@@ -17,12 +17,12 @@ const card: Card = {
 	set: Set,
 
 	effect: {
-		fr: "Choisissez l’une de ces options :•Ajoutez un Pokémon de votre pile de défausse à votre main.•Mélangez 3 Pokémon de votre pile de défausse avec votre deck.",
-		en: "Choose 1:•Put a Pokémon from your discard pile into your hand.•Shuffle 3 Pokémon from your discard pile into your deck.",
-		es: "Elige 1 opción:• Pon 1 Pokémon de tu pila de descartes en tu mano.• Pon 3 Pokémon de tu pila de descartes en tu baraja y baraja todas las cartas.",
-		it: "Scegli:• Prendi un Pokémon dalla tua pila degli scarti e aggiungilo alle carte che hai in mano.• Rimischia tre Pokémon dalla tua pila degli scarti nel tuo mazzo.",
-		pt: "Escolha 1:• Coloque 1 Pokémon da sua pilha de descarte na sua mão.• Embaralhe 3 Pokémon da sua pilha de descarte no seu baralho.",
-		de: "Wähle 1 aus:•Nimm 1 Pokémon aus deinem Ablagestapel auf deine Hand.•Mische 3 Pokémon aus deinem Ablagestapel in dein Deck."
+		fr: "Choisissez l’une de ces options :\n\n• Ajoutez un Pokémon de votre pile de défausse à votre main.\n• Mélangez 3 Pokémon de votre pile de défausse avec votre deck.",
+		en: "Choose 1:\n\n• Put a Pokémon from your discard pile into your hand.\n• Shuffle 3 Pokémon from your discard pile into your deck.",
+		es: "Elige 1 opción:\n\n• Pon 1 Pokémon de tu pila de descartes en tu mano.\n• Pon 3 Pokémon de tu pila de descartes en tu baraja y baraja todas las cartas.",
+		it: "Scegli:\n\n• Prendi un Pokémon dalla tua pila degli scarti e aggiungilo alle carte che hai in mano.\n• Rimischia tre Pokémon dalla tua pila degli scarti nel tuo mazzo.",
+		pt: "Escolha 1:\n\n• Coloque 1 Pokémon da sua pilha de descarte na sua mão.\n• Embaralhe 3 Pokémon da sua pilha de descarte no seu baralho.",
+		de: "Wähle 1 aus:\n\n• Nimm 1 Pokémon aus deinem Ablagestapel auf deine Hand.\n• Mische 3 Pokémon aus deinem Ablagestapel in dein Deck."
 	},
 
 	trainerType: "Item",

--- a/data/Sun & Moon/Guardians Rising/130.ts
+++ b/data/Sun & Moon/Guardians Rising/130.ts
@@ -17,12 +17,12 @@ const card: Card = {
 	set: Set,
 
 	effect: {
-		fr: "Choisissez l’une de ces options :•Ajoutez un Pokémon de votre pile de défausse à votre main.•Mélangez 3 Pokémon de votre pile de défausse avec votre deck.",
-		en: "Choose 1:•Put a Pokémon from your discard pile into your hand.•Shuffle 3 Pokémon from your discard pile into your deck.",
-		es: "Elige 1 opción:• Pon 1 Pokémon de tu pila de descartes en tu mano.• Pon 3 Pokémon de tu pila de descartes en tu baraja y baraja todas las cartas.",
-		it: "Scegli:\n• Prendi un Pokémon dalla tua pila degli scarti e aggiungilo alle carte che hai in mano.\n• Rimischia tre Pokémon dalla tua pila degli scarti nel tuo mazzo.",
-		pt: "Escolha 1:• Coloque 1 Pokémon da sua pilha de descarte na sua mão.• Embaralhe 3 Pokémon da sua pilha de descarte no seu baralho.",
-		de: "Wähle 1 aus:•Nimm 1 Pokémon aus deinem Ablagestapel auf deine Hand.•Mische 3 Pokémon aus deinem Ablagestapel in dein Deck."
+		fr: "Choisissez l’une de ces options :\n\n• Ajoutez un Pokémon de votre pile de défausse à votre main.\n• Mélangez 3 Pokémon de votre pile de défausse avec votre deck.",
+		en: "Choose 1:\n\n• Put a Pokémon from your discard pile into your hand.\n• Shuffle 3 Pokémon from your discard pile into your deck.",
+		es: "Elige 1 opción:\n\n• Pon 1 Pokémon de tu pila de descartes en tu mano.\n• Pon 3 Pokémon de tu pila de descartes en tu baraja y baraja todas las cartas.",
+		it: "Scegli:\n\n• Prendi un Pokémon dalla tua pila degli scarti e aggiungilo alle carte che hai in mano.\n• Rimischia tre Pokémon dalla tua pila degli scarti nel tuo mazzo.",
+		pt: "Escolha 1:\n\n• Coloque 1 Pokémon da sua pilha de descarte na sua mão.\n• Embaralhe 3 Pokémon da sua pilha de descarte no seu baralho.",
+		de: "Wähle 1 aus:\n\n• Nimm 1 Pokémon aus deinem Ablagestapel auf deine Hand.\n• Mische 3 Pokémon aus deinem Ablagestapel in dein Deck."
 	},
 
 	trainerType: "Item",

--- a/data/XY/BREAKpoint/109.ts
+++ b/data/XY/BREAKpoint/109.ts
@@ -19,10 +19,10 @@ const card: Card = {
 	effect: {
 		fr: "Vous pouvez jouer 2 cartes Énigme du Temps à la fois.\n\n• Si vous avez joué 1 carte, regardez les 3 cartes du dessus de votre deck et replacez-les dans l'ordre de votre choix.\n• Si vous avez joué 2 cartes, ajoutez 2 cartes de votre pile de défausse à votre main.",
 		en: "You may play 2 Puzzle of Time cards at once.\n\n• If you played 1 card, look at the top 3 cards of your deck and put them back in any order.\n• If you played 2 cards, put 2 cards from your discard pile into your hand.",
-		es: "Puedes jugar 2 cartas de Puzle Temporal de una vez.• Si has jugado 1 carta, mira las 3 primeras cartas de tu baraja y vuelve a ponerlas en la parte superior de tu baraja en el orden que quieras.• Si has jugado 2 cartas, pon 2 cartas de tu pila de descartes en tu mano.",
-		it: "Puoi giocare due carte Enigma Cronologico alla volta.• Se hai giocato una carta, guarda le prime tre carte del tuo mazzo e rimettile in cima al tuo mazzo nell'ordine che preferisci.• Se hai giocato due carte, prendi due carte dalla tua pila degli scarti e aggiungile alle carte che hai in mano.",
-		pt: "Você pode jogar dois cards Enigma do Tempo de uma só vez.• Se você tiver jogado 1 card, olhe os 3 primeiros cards do seu baralho e coloque-os de volta em qualquer ordem.• Se você tiver jogado 2 cards, coloque 2 cards da sua pilha de descarte em sua mão.",
-		de: "Du kannst 2 Zeitpuzzle-Karten auf einmal spielen.• Wenn du 1 Karte gespielt hast, schau dir die obersten 3 Karten deines Decks an und lege sie in beliebiger Reihenfolge zurück auf dein Deck.• Wenn du 2 Karten gespielt hast, nimm 2 Karten von deinem Ablagestapel auf deine Hand."
+		es: "Puedes jugar 2 cartas de Puzle Temporal de una vez.\n\n• Si has jugado 1 carta, mira las 3 primeras cartas de tu baraja y vuelve a ponerlas en la parte superior de tu baraja en el orden que quieras.\n• Si has jugado 2 cartas, pon 2 cartas de tu pila de descartes en tu mano.",
+		it: "Puoi giocare due carte Enigma Cronologico alla volta.\n\n• Se hai giocato una carta, guarda le prime tre carte del tuo mazzo e rimettile in cima al tuo mazzo nell'ordine che preferisci.\n• Se hai giocato due carte, prendi due carte dalla tua pila degli scarti e aggiungile alle carte che hai in mano.",
+		pt: "Você pode jogar dois cards Enigma do Tempo de uma só vez.\n\n• Se você tiver jogado 1 card, olhe os 3 primeiros cards do seu baralho e coloque-os de volta em qualquer ordem.\n• Se você tiver jogado 2 cards, coloque 2 cards da sua pilha de descarte em sua mão.",
+		de: "Du kannst 2 Zeitpuzzle-Karten auf einmal spielen.\n\n• Wenn du 1 Karte gespielt hast, schau dir die obersten 3 Karten deines Decks an und lege sie in beliebiger Reihenfolge zurück auf dein Deck.\n• Wenn du 2 Karten gespielt hast, nimm 2 Karten von deinem Ablagestapel auf deine Hand."
 	},
 
 	trainerType: "Item",

--- a/data/XY/BREAKthrough/138.ts
+++ b/data/XY/BREAKthrough/138.ts
@@ -17,12 +17,12 @@ const card: Card = {
 	set: Set,
 
 	effect: {
-		fr: "Choisissez l'une de ces options : \n\n•Piochez des cartes jusqu'à ce que vous ayez 5 cartes en main.\n•Pendant ce tour, les attaques de votre Pokémon infligent 20 dégâts supplémentaires au Pokémon Actif de votre adversaire (avant application de la Faiblesse et de la Résistance).",
-		en: "Choose 1: \n\n•Draw cards until you have 5 cards in your hand.\n•During this turn, your Pokémon's attacks do 20 more damage to your opponent's Active Pokémon (before applying Weakness and Resistance).",
-		es: "Elige 1 opción:• Roba cartas hasta que tengas 5 cartas en tu mano.• Durante este turno, los ataques de tus Pokémon hacen 20 puntos de daño más al Pokémon Activo de tu rival (antes de aplicar Debilidad y Resistencia).",
-		it: "Scegli: • Pesca fino ad avere cinque carte in mano.• Durante questo turno, gli attacchi dei tuoi Pokémon infliggono 20 danni in più al Pokémon attivo del tuo avversario, prima di aver applicato debolezza e resistenza.",
-		pt: "Escolha 1: •Compre cards até ter 5 cards em sua mão.•Durante esta vez de jogar, os ataques dos seus Pokémon causam 20 de danos adicionais ao Pokémon Ativo do seu oponente (antes da aplicação de Fraqueza e Resistência).",
-		de: "Wähle 1 aus: • Ziehe so lang Karten, bis du 5 Karten auf der Hand hast.• Während dieses Zuges fügen die Angriffe deiner Pokémon dem Aktiven Pokémon deines Gegners 20 weitere Schadenspunkte zu (bevor Schwäche und Resistenz verrechnet werden)."
+		fr: "Choisissez l'une de ces options :\n\n• Piochez des cartes jusqu'à ce que vous ayez 5 cartes en main.\n• Pendant ce tour, les attaques de votre Pokémon infligent 20 dégâts supplémentaires au Pokémon Actif de votre adversaire (avant application de la Faiblesse et de la Résistance).",
+		en: "Choose 1:\n\n• Draw cards until you have 5 cards in your hand.\n• During this turn, your Pokémon's attacks do 20 more damage to your opponent's Active Pokémon (before applying Weakness and Resistance).",
+		es: "Elige 1 opción:\n\n• Roba cartas hasta que tengas 5 cartas en tu mano.\n• Durante este turno, los ataques de tus Pokémon hacen 20 puntos de daño más al Pokémon Activo de tu rival (antes de aplicar Debilidad y Resistencia).",
+		it: "Scegli:\n\n• Pesca fino ad avere cinque carte in mano.\n• Durante questo turno, gli attacchi dei tuoi Pokémon infliggono 20 danni in più al Pokémon attivo del tuo avversario, prima di aver applicato debolezza e resistenza.",
+		pt: "Escolha 1:\n\n• Compre cards até ter 5 cards em sua mão.\n• Durante esta vez de jogar, os ataques dos seus Pokémon causam 20 de danos adicionais ao Pokémon Ativo do seu oponente (antes da aplicação de Fraqueza e Resistência).",
+		de: "Wähle 1 aus:\n\n• Ziehe so lang Karten, bis du 5 Karten auf der Hand hast.\n• Während dieses Zuges fügen die Angriffe deiner Pokémon dem Aktiven Pokémon deines Gegners 20 weitere Schadenspunkte zu (bevor Schwäche und Resistenz verrechnet werden)."
 	},
 
 	trainerType: "Supporter",

--- a/data/XY/BREAKthrough/162.ts
+++ b/data/XY/BREAKthrough/162.ts
@@ -17,12 +17,12 @@ const card: Card = {
 	set: Set,
 
 	effect: {
-		fr: "Choisissez l'une de ces options : \n\n•Piochez des cartes jusqu'à ce que vous ayez 5 cartes en main.\n•Pendant ce tour, les attaques de votre Pokémon infligent 20 dégâts supplémentaires au Pokémon Actif de votre adversaire (avant application de la Faiblesse et de la Résistance).",
-		en: "Choose 1: \n\n•Draw cards until you have 5 cards in your hand.\n•During this turn, your Pokémon's attacks do 20 more damage to your opponent's Active Pokémon (before applying Weakness and Resistance).",
-		es: "Elige 1 opción:• Roba cartas hasta que tengas 5 cartas en tu mano.• Durante este turno, los ataques de tus Pokémon hacen 20 puntos de daño más al Pokémon Activo de tu rival (antes de aplicar Debilidad y Resistencia).",
-		it: "Scegli: • Pesca fino ad avere cinque carte in mano.• Durante questo turno, gli attacchi dei tuoi Pokémon infliggono 20 danni in più al Pokémon attivo del tuo avversario, prima di aver applicato debolezza e resistenza.",
-		pt: "Escolha 1: •Compre cards até ter 5 cards em sua mão.•Durante esta vez de jogar, os ataques dos seus Pokémon causam 20 de danos adicionais ao Pokémon Ativo do seu oponente (antes da aplicação de Fraqueza e Resistência).",
-		de: "Wähle 1 aus: • Ziehe so lang Karten, bis du 5 Karten auf der Hand hast.• Während dieses Zuges fügen die Angriffe deiner Pokémon dem Aktiven Pokémon deines Gegners 20 weitere Schadenspunkte zu (bevor Schwäche und Resistenz verrechnet werden)."
+		fr: "Choisissez l'une de ces options :\n\n• Piochez des cartes jusqu'à ce que vous ayez 5 cartes en main.\n• Pendant ce tour, les attaques de votre Pokémon infligent 20 dégâts supplémentaires au Pokémon Actif de votre adversaire (avant application de la Faiblesse et de la Résistance).",
+		en: "Choose 1:\n\n• Draw cards until you have 5 cards in your hand.\n• During this turn, your Pokémon's attacks do 20 more damage to your opponent's Active Pokémon (before applying Weakness and Resistance).",
+		es: "Elige 1 opción:\n\n• Roba cartas hasta que tengas 5 cartas en tu mano.\n• Durante este turno, los ataques de tus Pokémon hacen 20 puntos de daño más al Pokémon Activo de tu rival (antes de aplicar Debilidad y Resistencia).",
+		it: "Scegli:\n\n• Pesca fino ad avere cinque carte in mano.\n• Durante questo turno, gli attacchi dei tuoi Pokémon infliggono 20 danni in più al Pokémon attivo del tuo avversario, prima di aver applicato debolezza e resistenza.",
+		pt: "Escolha 1:\n\n• Compre cards até ter 5 cards em sua mão.\n• Durante esta vez de jogar, os ataques dos seus Pokémon causam 20 de danos adicionais ao Pokémon Ativo do seu oponente (antes da aplicação de Fraqueza e Resistência).",
+		de: "Wähle 1 aus:\n\n• Ziehe so lang Karten, bis du 5 Karten auf der Hand hast.\n• Während dieses Zuges fügen die Angriffe deiner Pokémon dem Aktiven Pokémon deines Gegners 20 weitere Schadenspunkte zu (bevor Schwäche und Resistenz verrechnet werden)."
 	},
 
 	trainerType: "Supporter",

--- a/data/XY/Primal Clash/124.ts
+++ b/data/XY/Primal Clash/124.ts
@@ -17,12 +17,12 @@ const card: Card = {
 	set: Set,
 
 	effect: {
-		fr: "Vous pouvez jouer cette carte seulement lorsque c'est la dernière carte dans votre main.\n\nPlacez un Pokémon Water de votre pile de défausse sur votre Banc. Ensuite, piochez 5 cartes.",
-		en: "You can play this card only when it is the last card in your hand.\n\nPut a Water Pokémon from your discard pile onto your Bench. Then, draw 5 cards.",
-		es: "Puedes jugar esta carta solo cuando es la última carta en tu mano. Pon 1 Pokémon Water de tu pila de descartes en tu Banca. Después, roba 5 cartas.",
-		it: "Puoi giocare questa carta solo se è l'ultima carta che hai in mano. Prendi un Pokémon Water dalla tua pila degli scarti e mettilo in panchina. Poi pesca cinque carte.",
-		pt: "Você poderá jogar este card somente quando ele for o último card da sua mão. Coloque um Pokémon Water da sua pilha de descarte no seu Banco. Em seguida, compre 5 cards.",
-		de: "Du kannst diese Karte nur dann spielen, wenn es die letzte Karte auf deiner Hand ist. Nimm 1 Water-Pokémon von deinem Ablagestapel und lege es auf deine Bank. Ziehe anschließend 5 Karten."
+		fr: "Vous pouvez jouer cette carte seulement lorsque c'est la dernière carte dans votre main.\n\nPlacez un Pokémon {W} de votre pile de défausse sur votre Banc. Ensuite, piochez 5 cartes.",
+		en: "You can play this card only when it is the last card in your hand.\n\nPut a {W} Pokémon from your discard pile onto your Bench. Then, draw 5 cards.",
+		es: "Puedes jugar esta carta solo cuando es la última carta en tu mano. Pon 1 Pokémon {W} de tu pila de descartes en tu Banca. Después, roba 5 cartas.",
+		it: "Puoi giocare questa carta solo se è l'ultima carta che hai in mano. Prendi un Pokémon {W} dalla tua pila degli scarti e mettilo in panchina. Poi pesca cinque carte.",
+		pt: "Você poderá jogar este card somente quando ele for o último card da sua mão. Coloque um Pokémon {W} da sua pilha de descarte no seu Banco. Em seguida, compre 5 cards.",
+		de: "Du kannst diese Karte nur dann spielen, wenn es die letzte Karte auf deiner Hand ist. Nimm 1 {W}-Pokémon von deinem Ablagestapel und lege es auf deine Bank. Ziehe anschließend 5 Karten."
 	},
 
 	trainerType: "Supporter",

--- a/data/XY/Primal Clash/133.ts
+++ b/data/XY/Primal Clash/133.ts
@@ -17,12 +17,12 @@ const card: Card = {
 	set: Set,
 
 	effect: {
-		fr: "Vous pouvez jouer cette carte seulement lorsque c'est la dernière carte dans votre main.\n\nPlacez un Pokémon Fighting de votre pile de défausse sur votre Banc. Ensuite, piochez 5 cartes.",
-		en: "You can play this card only when it is the last card in your hand.\n\nPut a Fighting Pokémon from your discard pile onto your Bench. Then, draw 5 cards.",
-		es: "Puedes jugar esta carta solo cuando es la última carta en tu mano. Pon 1 Pokémon Fighting de tu pila de descartes en tu Banca. Después, roba 5 cartas.",
-		it: "Puoi giocare questa carta solo se è l'ultima carta che hai in mano. Prendi un Pokémon Fighting dalla tua pila degli scarti e mettilo in panchina. Poi pesca cinque carte.",
-		pt: "Você poderá jogar este card somente quando ele for o último card da sua mão. Coloque um Pokémon Fighting da sua pilha de descarte no seu Banco. Em seguida, compre 5 cards.",
-		de: "Du kannst diese Karte nur dann spielen, wenn es die letzte Karte auf deiner Hand ist. Nimm 1 Fighting-Pokémon von deinem Ablagestapel und lege es auf deine Bank. Ziehe anschließend 5 Karten."
+		fr: "Vous pouvez jouer cette carte seulement lorsque c'est la dernière carte dans votre main.\n\nPlacez un Pokémon {F} de votre pile de défausse sur votre Banc. Ensuite, piochez 5 cartes.",
+		en: "You can play this card only when it is the last card in your hand.\n\nPut a {F} Pokémon from your discard pile onto your Bench. Then, draw 5 cards.",
+		es: "Puedes jugar esta carta solo cuando es la última carta en tu mano. Pon 1 Pokémon {F} de tu pila de descartes en tu Banca. Después, roba 5 cartas.",
+		it: "Puoi giocare questa carta solo se è l'ultima carta che hai in mano. Prendi un Pokémon {F} dalla tua pila degli scarti e mettilo in panchina. Poi pesca cinque carte.",
+		pt: "Você poderá jogar este card somente quando ele for o último card da sua mão. Coloque um Pokémon {F} da sua pilha de descarte no seu Banco. Em seguida, compre 5 cards.",
+		de: "Du kannst diese Karte nur dann spielen, wenn es die letzte Karte auf deiner Hand ist. Nimm 1 {F}-Pokémon von deinem Ablagestapel und lege es auf deine Bank. Ziehe anschließend 5 Karten."
 	},
 
 	trainerType: "Supporter",

--- a/data/XY/Primal Clash/157.ts
+++ b/data/XY/Primal Clash/157.ts
@@ -17,12 +17,12 @@ const card: Card = {
 	set: Set,
 
 	effect: {
-		fr: "Vous pouvez jouer cette carte seulement lorsque c'est la dernière carte dans votre main.\n\nPlacez un Pokémon Water de votre pile de défausse sur votre Banc. Ensuite, piochez 5 cartes.",
-		en: "You can play this card only when it is the last card in your hand.\n\nPut a Water Pokémon from your discard pile onto your Bench. Then, draw 5 cards.",
-		es: "Puedes jugar esta carta solo cuando es la última carta en tu mano. Pon 1 Pokémon Water de tu pila de descartes en tu Banca. Después, roba 5 cartas.",
-		it: "Puoi giocare questa carta solo se è l'ultima carta che hai in mano. Prendi un Pokémon Water dalla tua pila degli scarti e mettilo in panchina. Poi pesca cinque carte.",
-		pt: "Você poderá jogar este card somente quando ele for o último card da sua mão. Coloque um Pokémon Water da sua pilha de descarte no seu Banco. Em seguida, compre 5 cards.",
-		de: "Du kannst diese Karte nur dann spielen, wenn es die letzte Karte auf deiner Hand ist. Nimm 1 Water-Pokémon von deinem Ablagestapel und lege es auf deine Bank. Ziehe anschließend 5 Karten."
+		fr: "Vous pouvez jouer cette carte seulement lorsque c'est la dernière carte dans votre main.\n\nPlacez un Pokémon {W} de votre pile de défausse sur votre Banc. Ensuite, piochez 5 cartes.",
+		en: "You can play this card only when it is the last card in your hand.\n\nPut a {W} Pokémon from your discard pile onto your Bench. Then, draw 5 cards.",
+		es: "Puedes jugar esta carta solo cuando es la última carta en tu mano. Pon 1 Pokémon {W} de tu pila de descartes en tu Banca. Después, roba 5 cartas.",
+		it: "Puoi giocare questa carta solo se è l'ultima carta che hai in mano. Prendi un Pokémon {W} dalla tua pila degli scarti e mettilo in panchina. Poi pesca cinque carte.",
+		pt: "Você poderá jogar este card somente quando ele for o último card da sua mão. Coloque um Pokémon {W} da sua pilha de descarte no seu Banco. Em seguida, compre 5 cards.",
+		de: "Du kannst diese Karte nur dann spielen, wenn es die letzte Karte auf deiner Hand ist. Nimm 1 {W}-Pokémon von deinem Ablagestapel und lege es auf deine Bank. Ziehe anschließend 5 Karten."
 	},
 
 	trainerType: "Supporter",

--- a/data/XY/Primal Clash/158.ts
+++ b/data/XY/Primal Clash/158.ts
@@ -17,12 +17,12 @@ const card: Card = {
 	set: Set,
 
 	effect: {
-		fr: "Vous pouvez jouer cette carte seulement lorsque c'est la dernière carte dans votre main.\n\nPlacez un Pokémon Fighting de votre pile de défausse sur votre Banc. Ensuite, piochez 5 cartes.",
-		en: "You can play this card only when it is the last card in your hand.\n\nPut a Fighting Pokémon from your discard pile onto your Bench. Then, draw 5 cards.",
-		es: "Puedes jugar esta carta solo cuando es la última carta en tu mano. Pon 1 Pokémon Fighting de tu pila de descartes en tu Banca. Después, roba 5 cartas.",
-		it: "Puoi giocare questa carta solo se è l'ultima carta che hai in mano. Prendi un Pokémon Fighting dalla tua pila degli scarti e mettilo in panchina. Poi pesca cinque carte.",
-		pt: "Você poderá jogar este card somente quando ele for o último card da sua mão. Coloque um Pokémon Fighting da sua pilha de descarte no seu Banco. Em seguida, compre 5 cards.",
-		de: "Du kannst diese Karte nur dann spielen, wenn es die letzte Karte auf deiner Hand ist. Nimm 1 Fighting-Pokémon von deinem Ablagestapel und lege es auf deine Bank. Ziehe anschließend 5 Karten."
+		fr: "Vous pouvez jouer cette carte seulement lorsque c'est la dernière carte dans votre main.\n\nPlacez un Pokémon {F} de votre pile de défausse sur votre Banc. Ensuite, piochez 5 cartes.",
+		en: "You can play this card only when it is the last card in your hand.\n\nPut a {F} Pokémon from your discard pile onto your Bench. Then, draw 5 cards.",
+		es: "Puedes jugar esta carta solo cuando es la última carta en tu mano. Pon 1 Pokémon {F} de tu pila de descartes en tu Banca. Después, roba 5 cartas.",
+		it: "Puoi giocare questa carta solo se è l'ultima carta che hai in mano. Prendi un Pokémon {F} dalla tua pila degli scarti e mettilo in panchina. Poi pesca cinque carte.",
+		pt: "Você poderá jogar este card somente quando ele for o último card da sua mão. Coloque um Pokémon {F} da sua pilha de descarte no seu Banco. Em seguida, compre 5 cards.",
+		de: "Du kannst diese Karte nur dann spielen, wenn es die letzte Karte auf deiner Hand ist. Nimm 1 {F}-Pokémon von deinem Ablagestapel und lege es auf deine Bank. Ziehe anschließend 5 Karten."
 	},
 
 	trainerType: "Supporter",


### PR DESCRIPTION
## Summary
- normalize legacy Trainer effect formatting in Diamond & Pearl, Platinum, XY, and Sun & Moon cards
- restore bullet list structure for French text where the effect branches by option or card count
- replace glued `:•` / `.•` formatting and normalize legacy energy text tokens in the affected Primal Clash cards

## Test plan
- [x] Run `bun run validate`
- [x] Run `cd server && bun run --bun validate`
- [x] Run `cd server && bun run compile`
- [x] Run `cd .bruno && bru run --env Developpement`