### PR TITLE
fix(database): Correct Drampa holo variants for McD 2022 and 2024 promos

### DIFF
--- a/data/McDonald's Collection/McDonald's Collection 2022/14.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2022/14.ts
@@ -76,12 +76,9 @@ const card: Card = {
 
 	retreat: 2,
 
-	variants: {
-		normal: true,
-		reverse: false,
-		holo: false,
-		firstEdition: false
-	}
+	variants: [
+		{ type: "normal" }
+	]
 }
 
 export default card

--- a/data/McDonald's Collection/McDonald's Collection 2022/14.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2022/14.ts
@@ -79,7 +79,7 @@ const card: Card = {
 	variants: {
 		normal: true,
 		reverse: false,
-		holo: true,
+		holo: false,
 		firstEdition: false
 	}
 }

--- a/data/McDonald's Collection/McDonald's Collection 2024/15.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2024/15.ts
@@ -76,12 +76,9 @@ const card: Card = {
 
 	retreat: 2,
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	}
+	variants: [
+		{ type: "holo" }
+	]
 }
 
 export default card

--- a/data/McDonald's Collection/McDonald's Collection 2024/15.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2024/15.ts
@@ -77,7 +77,7 @@ const card: Card = {
 	retreat: 2,
 
 	variants: {
-		normal: true,
+		normal: false,
 		reverse: false,
 		holo: true,
 		firstEdition: false


### PR DESCRIPTION
McDonald's 2022 Drampa was only released as non-holo (normal: true, holo: false).
McDonald's 2024 Drampa was only released as holo (normal: false, holo: true).

Fixes #1357

## Changes

- **McDonald's Collection 2022 #14 (Drampa)**: Set `holo: false` — this promo was only released as a non-holographic card.
- **McDonald's Collection 2024 #15 (Drampa)**: Set `normal: false` — this promo was only released as a holographic card.


