### PR TITLE
fix(data): backfill set aliases and alias lookups

### DIFF
--- a/.bruno/regressions/card-set-alias-filter.bru
+++ b/.bruno/regressions/card-set-alias-filter.bru
@@ -1,0 +1,16 @@
+meta {
+  name: Card set alias filter
+  type: http
+  seq: 5
+}
+
+get {
+  url: {{BASE_URL}}/v2/fr/cards?set=eq:ev07
+  body: none
+  auth: none
+}
+
+assert {
+  res.status: eq 200
+  res.body.length: gt 150
+}

--- a/.bruno/regressions/series-set-abbreviation.bru
+++ b/.bruno/regressions/series-set-abbreviation.bru
@@ -1,0 +1,30 @@
+meta {
+  name: Series nested set abbreviation exposure
+  type: http
+  seq: 3
+}
+
+get {
+  url: {{BASE_URL}}/v2/fr/series/mc
+  body: none
+  auth: none
+}
+
+assert {
+  res.status: eq 200
+}
+
+tests {
+  test("series payload keeps the 2013 McDonald's official abbreviation", function() {
+    const body = res.getBody();
+    const data = typeof body === "string" ? JSON.parse(body) : body;
+    const target = data.sets.find((set) => set.id === "2013bw");
+
+    if (!target) {
+      throw new Error("Expected 2013bw to be present in the McDonald's series payload");
+    }
+
+    expect(target.abbreviation.official).to.equal("MCD13");
+    expect(target.abbreviation.localized).to.equal(undefined);
+  });
+}

--- a/.bruno/regressions/set-alias-lookup.bru
+++ b/.bruno/regressions/set-alias-lookup.bru
@@ -1,0 +1,17 @@
+meta {
+  name: Set alias lookup
+  type: http
+  seq: 4
+}
+
+get {
+  url: {{BASE_URL}}/v2/en/sets/svi
+  body: none
+  auth: none
+}
+
+assert {
+  res.status: eq 200
+  res.body.id: eq sv01
+  res.body.abbreviation.official: eq SVI
+}

--- a/data/Base/Base Set 2.ts
+++ b/data/Base/Base Set 2.ts
@@ -20,6 +20,9 @@ const base4: Set = {
 	abbreviations: {
 		official: "B2"
 	},
+	searchAliases: [
+		"B2"
+	],
 
 	thirdParty: {
 		cardmarket: 1527,

--- a/data/Base/Base Set.ts
+++ b/data/Base/Base Set.ts
@@ -27,6 +27,9 @@ const base1: Set = {
 		official: "BS",
 		fr: "BAS"
 	},
+	searchAliases: [
+		"BS"
+	],
 
 	thirdParty: {
 		cardmarket: 1523,

--- a/data/Base/Fossil.ts
+++ b/data/Base/Fossil.ts
@@ -27,6 +27,9 @@ const base3: Set = {
 		official: "FO",
 		fr: "FOS"
 	},
+	searchAliases: [
+		"FO"
+	],
 
 	thirdParty: {
 		cardmarket: 1526,

--- a/data/Base/Jungle.ts
+++ b/data/Base/Jungle.ts
@@ -27,6 +27,9 @@ const base2: Set = {
 		official: "JU",
 		fr: "JUN"
 	},
+	searchAliases: [
+		"JU"
+	],
 
 	thirdParty: {
 		cardmarket: 1525,

--- a/data/Base/Team Rocket.ts
+++ b/data/Base/Team Rocket.ts
@@ -24,6 +24,9 @@ const base5: Set = {
 		official: "RO",
 		fr: "ROC"
 	},
+	searchAliases: [
+		"RO"
+	],
 
 	thirdParty: {
 		cardmarket: 1528,

--- a/data/Base/W Promotional.ts
+++ b/data/Base/W Promotional.ts
@@ -20,7 +20,14 @@ const wp: Set = {
 		official: 7
 	},
 
-	releaseDate: "1999-09-01"
+	releaseDate: "1999-09-01",
+
+	abbreviations: {
+		official: "W"
+	},
+	searchAliases: [
+		"W"
+	],
 }
 
 export default wp

--- a/data/Base/Wizards Black Star Promos.ts
+++ b/data/Base/Wizards Black Star Promos.ts
@@ -21,6 +21,12 @@ const basep: Set = {
 
 	releaseDate: "1999-07-01",
 
+	abbreviations: {
+		official: "WP"
+	},
+	searchAliases: [
+		"WP"
+	],
 	thirdParty: {
 		cardmarket: 1607
 	}

--- a/data/Black & White/BW Black Star Promos.ts
+++ b/data/Black & White/BW Black Star Promos.ts
@@ -25,6 +25,9 @@ const bwp: Set = {
 		official: "BWP",
 		fr: "PBW"
 	},
+	searchAliases: [
+		"BWP"
+	],
 
 	thirdParty: {
 		tcgplayer: 1407

--- a/data/Black & White/Black & White.ts
+++ b/data/Black & White/Black & White.ts
@@ -26,6 +26,9 @@ const bw1: Set = {
 		official: "BLW",
 		fr: "N&B"
 	},
+	searchAliases: [
+		"BLW"
+	],
 
 	thirdParty: {
 		cardmarket: 1571,

--- a/data/Black & White/Boundaries Crossed.ts
+++ b/data/Black & White/Boundaries Crossed.ts
@@ -26,6 +26,9 @@ const bw7: Set = {
 		official: "BCR",
 		fr: "FFR"
 	},
+	searchAliases: [
+		"BCR"
+	],
 
 	thirdParty: {
 		cardmarket: 1577,

--- a/data/Black & White/Dark Explorers.ts
+++ b/data/Black & White/Dark Explorers.ts
@@ -26,6 +26,9 @@ const bw5: Set = {
 		official: "DEX",
 		fr: "EOB"
 	},
+	searchAliases: [
+		"DEX"
+	],
 
 	thirdParty: {
 		cardmarket: 1575,

--- a/data/Black & White/Dragon Vault.ts
+++ b/data/Black & White/Dragon Vault.ts
@@ -26,6 +26,9 @@ const dv1: Set = {
 		official: "DRV",
 		fr: "CDR"
 	},
+	searchAliases: [
+		"DRV"
+	],
 
 	thirdParty: {
 		cardmarket: 1636,

--- a/data/Black & White/Dragons Exalted.ts
+++ b/data/Black & White/Dragons Exalted.ts
@@ -26,6 +26,9 @@ const bw6: Set = {
 		official: "DRX",
 		fr: "DEX"
 	},
+	searchAliases: [
+		"DRX"
+	],
 
 	thirdParty: {
 		cardmarket: 1576,

--- a/data/Black & White/Emerging Powers.ts
+++ b/data/Black & White/Emerging Powers.ts
@@ -26,6 +26,9 @@ const bw2: Set = {
 		official: "EP",
 		fr: "PEM"
 	},
+	searchAliases: [
+		"EP"
+	],
 
 	thirdParty: {
 		cardmarket: 1572,

--- a/data/Black & White/Legendary Treasures.ts
+++ b/data/Black & White/Legendary Treasures.ts
@@ -22,6 +22,9 @@ const bw11: Set = {
 	abbreviations: {
 		official: "LTR"
 	},
+	searchAliases: [
+		"LTR"
+	],
 
 	thirdParty: {
 		cardmarket: 1581,

--- a/data/Black & White/Next Destinies.ts
+++ b/data/Black & White/Next Destinies.ts
@@ -26,6 +26,9 @@ const bw4: Set = {
 		official: "NXD",
 		fr: "DFU"
 	},
+	searchAliases: [
+		"NXD"
+	],
 
 	thirdParty: {
 		cardmarket: 1574,

--- a/data/Black & White/Noble Victories.ts
+++ b/data/Black & White/Noble Victories.ts
@@ -26,6 +26,9 @@ const bw3: Set = {
 		official: "NVI",
 		fr: "NVI"
 	},
+	searchAliases: [
+		"NVI"
+	],
 
 	thirdParty: {
 		cardmarket: 1573,

--- a/data/Black & White/Plasma Blast.ts
+++ b/data/Black & White/Plasma Blast.ts
@@ -24,6 +24,9 @@ const bw10: Set = {
 		official: "PLB",
 		fr: "EPL"
 	},
+	searchAliases: [
+		"PLB"
+	],
 
 	thirdParty: {
 		cardmarket: 1580,

--- a/data/Black & White/Plasma Freeze.ts
+++ b/data/Black & White/Plasma Freeze.ts
@@ -26,6 +26,9 @@ const bw9: Set = {
 		official: "PLF",
 		fr: "GPL"
 	},
+	searchAliases: [
+		"PLF"
+	],
 
 	thirdParty: {
 		cardmarket: 1579,

--- a/data/Black & White/Plasma Storm.ts
+++ b/data/Black & White/Plasma Storm.ts
@@ -25,6 +25,9 @@ const bw8: Set = {
 	abbreviations: {
 		official: "PLS"
 	},
+	searchAliases: [
+		"PLS"
+	],
 
 	thirdParty: {
 		cardmarket: 1578,

--- a/data/Black & White/Radiant Collection.ts
+++ b/data/Black & White/Radiant Collection.ts
@@ -15,7 +15,14 @@ const rc: Set = {
 		official: 25
 	},
 
-	releaseDate: "2013-11-06"
+	releaseDate: "2013-11-06",
+
+	abbreviations: {
+		official: "RC"
+	},
+	searchAliases: [
+		"RC"
+	]
 }
 
 export default rc

--- a/data/Call of Legends/Call of Legends.ts
+++ b/data/Call of Legends/Call of Legends.ts
@@ -26,6 +26,9 @@ const col1: Set = {
 		official: "COL",
 		fr: "LDL"
 	},
+	searchAliases: [
+		"COL"
+	],
 
 	thirdParty: {
 		cardmarket: 1570,

--- a/data/Diamond & Pearl/DP Black Star Promos.ts
+++ b/data/Diamond & Pearl/DP Black Star Promos.ts
@@ -21,6 +21,12 @@ const dpp: Set = {
 
 	releaseDate: "2007-05-01",
 
+	abbreviations: {
+		official: "DPP"
+	},
+	searchAliases: [
+		"DPP"
+	],
 	thirdParty: {
 		tcgplayer: 1421
 	}

--- a/data/Diamond & Pearl/Diamond & Pearl.ts
+++ b/data/Diamond & Pearl/Diamond & Pearl.ts
@@ -27,6 +27,9 @@ const dp1: Set = {
 		official: "DP",
 		fr: "D&P"
 	},
+	searchAliases: [
+		"DP"
+	],
 
 	thirdParty: {
 		cardmarket: 1555,

--- a/data/Diamond & Pearl/Great Encounters.ts
+++ b/data/Diamond & Pearl/Great Encounters.ts
@@ -25,6 +25,9 @@ const dp4: Set = {
 		official: "GE",
 		fr: "DAS"
 	},
+	searchAliases: [
+		"GE"
+	],
 
 	thirdParty: {
 		cardmarket: 1558,

--- a/data/Diamond & Pearl/Legends Awakened.ts
+++ b/data/Diamond & Pearl/Legends Awakened.ts
@@ -25,6 +25,9 @@ const dp6: Set = {
 		official: "LA",
 		fr: "EDL"
 	},
+	searchAliases: [
+		"LA"
+	],
 
 	thirdParty: {
 		cardmarket: 1560,

--- a/data/Diamond & Pearl/Majestic Dawn.ts
+++ b/data/Diamond & Pearl/Majestic Dawn.ts
@@ -24,6 +24,9 @@ const dp5: Set = {
 		official: "MD",
 		fr: "AMJ"
 	},
+	searchAliases: [
+		"MD"
+	],
 
 	thirdParty: {
 		cardmarket: 1559,

--- a/data/Diamond & Pearl/Mysterious Treasures.ts
+++ b/data/Diamond & Pearl/Mysterious Treasures.ts
@@ -27,6 +27,9 @@ const dp2: Set = {
 		official: "MT",
 		fr: "TMY"
 	},
+	searchAliases: [
+		"MT"
+	],
 
 	thirdParty: {
 		cardmarket: 1556,

--- a/data/Diamond & Pearl/Secret Wonders.ts
+++ b/data/Diamond & Pearl/Secret Wonders.ts
@@ -26,6 +26,9 @@ const dp3: Set = {
 		official: "SW",
 		fr: "MSQ"
 	},
+	searchAliases: [
+		"SW"
+	],
 
 	thirdParty: {
 		cardmarket: 1557,

--- a/data/Diamond & Pearl/Stormfront.ts
+++ b/data/Diamond & Pearl/Stormfront.ts
@@ -25,6 +25,9 @@ const dp7: Set = {
 		official: "SF",
 		fr: "TEM"
 	},
+	searchAliases: [
+		"SF"
+	],
 
 	thirdParty: {
 		cardmarket: 1561,

--- a/data/E-Card/Aquapolis.ts
+++ b/data/E-Card/Aquapolis.ts
@@ -24,6 +24,9 @@ const ecard2: Set = {
 		official: "AQ",
 		fr: "AQU"
 	},
+	searchAliases: [
+		"AQ"
+	],
 
 	thirdParty: {
 		cardmarket: 1537,

--- a/data/E-Card/Best of game.ts
+++ b/data/E-Card/Best of game.ts
@@ -16,6 +16,12 @@ const bog: Set = {
 
 	releaseDate: "2002-12-01",
 
+	abbreviations: {
+		official: "BG"
+	},
+	searchAliases: [
+		"BG"
+	],
 	thirdParty: {
 		cardmarket: 1605,
 		tcgplayer: 1455

--- a/data/E-Card/Expedition Base Set.ts
+++ b/data/E-Card/Expedition Base Set.ts
@@ -24,6 +24,9 @@ const ecard1: Set = {
 		official: "EX",
 		fr: "EXP"
 	},
+	searchAliases: [
+		"EX"
+	],
 
 	thirdParty: {
 		cardmarket: 1536,

--- a/data/E-Card/Sample.ts
+++ b/data/E-Card/Sample.ts
@@ -14,7 +14,14 @@ const sp: Set = {
 		official: 10
 	},
 
-	releaseDate: "2002-08-01"
+	releaseDate: "2002-08-01",
+
+	abbreviations: {
+		official: "SAMPLE"
+	},
+	searchAliases: [
+		"SAMPLE"
+	],
 }
 
 export default sp

--- a/data/E-Card/Skyridge.ts
+++ b/data/E-Card/Skyridge.ts
@@ -22,6 +22,9 @@ const ecard3: Set = {
 	abbreviations: {
 		official: "SK"
 	},
+	searchAliases: [
+		"SK"
+	],
 
 	thirdParty: {
 		cardmarket: 1538,

--- a/data/EX/Crystal Guardians.ts
+++ b/data/EX/Crystal Guardians.ts
@@ -24,6 +24,9 @@ const ex14: Set = {
 		official: "CG",
 		fr: "GDC"
 	},
+	searchAliases: [
+		"CG"
+	],
 
 	thirdParty: {
 		cardmarket: 1552,

--- a/data/EX/Delta Species.ts
+++ b/data/EX/Delta Species.ts
@@ -24,6 +24,9 @@ const ex11: Set = {
 		official: "DS",
 		fr: "ESD"
 	},
+	searchAliases: [
+		"DS"
+	],
 
 	thirdParty: {
 		cardmarket: 1549,

--- a/data/EX/Deoxys.ts
+++ b/data/EX/Deoxys.ts
@@ -25,6 +25,9 @@ const ex8: Set = {
 		official: "DX",
 		fr: "DEO"
 	},
+	searchAliases: [
+		"DX"
+	],
 
 	thirdParty: {
 		cardmarket: 1546,

--- a/data/EX/Dragon Frontiers.ts
+++ b/data/EX/Dragon Frontiers.ts
@@ -24,6 +24,9 @@ const ex15: Set = {
 		official: "DF",
 		fr: "IDR"
 	},
+	searchAliases: [
+		"DF"
+	],
 
 	thirdParty: {
 		cardmarket: 1553,

--- a/data/EX/Dragon.ts
+++ b/data/EX/Dragon.ts
@@ -24,6 +24,9 @@ const ex3: Set = {
 		official: "DR",
 		fr: "DRG"
 	},
+	searchAliases: [
+		"DR"
+	],
 
 	thirdParty: {
 		cardmarket: 1541,

--- a/data/EX/Emerald.ts
+++ b/data/EX/Emerald.ts
@@ -25,6 +25,9 @@ const ex9: Set = {
 		official: "EM",
 		fr: "EME"
 	},
+	searchAliases: [
+		"EM"
+	],
 
 	thirdParty: {
 		cardmarket: 1547,

--- a/data/EX/FireRed & LeafGreen.ts
+++ b/data/EX/FireRed & LeafGreen.ts
@@ -24,6 +24,9 @@ const ex6: Set = {
 		official: "RG",
 		fr: "RFV"
 	},
+	searchAliases: [
+		"RG"
+	],
 
 	thirdParty: {
 		cardmarket: 1544,

--- a/data/EX/Hidden Legends.ts
+++ b/data/EX/Hidden Legends.ts
@@ -23,6 +23,9 @@ const ex5: Set = {
 		official: "HL",
 		fr: "LOU"
 	},
+	searchAliases: [
+		"HL"
+	],
 
 	thirdParty: {
 		cardmarket: 1543,

--- a/data/EX/Holon Phantoms.ts
+++ b/data/EX/Holon Phantoms.ts
@@ -24,6 +24,9 @@ const ex13: Set = {
 		official: "HP",
 		fr: "FAN"
 	},
+	searchAliases: [
+		"HP"
+	],
 
 	thirdParty: {
 		cardmarket: 1551,

--- a/data/EX/Legend Maker.ts
+++ b/data/EX/Legend Maker.ts
@@ -24,6 +24,9 @@ const ex12: Set = {
 		official: "LM",
 		fr: "CDL"
 	},
+	searchAliases: [
+		"LM"
+	],
 
 	thirdParty: {
 		cardmarket: 1550,

--- a/data/EX/Poké Card Creator Pack.ts
+++ b/data/EX/Poké Card Creator Pack.ts
@@ -16,6 +16,12 @@ const pccp: Set = {
 
 	releaseDate: "2004-07-01",
 
+	abbreviations: {
+		official: "CC"
+	},
+	searchAliases: [
+		"CC"
+	],
 	thirdParty: {
 		cardmarket: 4505
 	}

--- a/data/EX/Power Keepers.ts
+++ b/data/EX/Power Keepers.ts
@@ -23,6 +23,9 @@ const ex16: Set = {
 		official: "PK",
 		fr: "GDP"
 	},
+	searchAliases: [
+		"PK"
+	],
 
 	thirdParty: {
 		cardmarket: 1554,

--- a/data/EX/Ruby & Sapphire.ts
+++ b/data/EX/Ruby & Sapphire.ts
@@ -26,6 +26,9 @@ const ex1: Set = {
 		official: "RS",
 		fr: "R&S"
 	},
+	searchAliases: [
+		"RS"
+	],
 
 	thirdParty: {
 		cardmarket: 1539,

--- a/data/EX/Sandstorm.ts
+++ b/data/EX/Sandstorm.ts
@@ -24,6 +24,9 @@ const ex2: Set = {
 		official: "SS",
 		fr: "TES"
 	},
+	searchAliases: [
+		"SS"
+	],
 
 	thirdParty: {
 		cardmarket: 1540,

--- a/data/EX/Team Magma vs Team Aqua.ts
+++ b/data/EX/Team Magma vs Team Aqua.ts
@@ -24,6 +24,9 @@ const ex4: Set = {
 		official: "MA",
 		fr: "M&A"
 	},
+	searchAliases: [
+		"MA"
+	],
 
 	thirdParty: {
 		cardmarket: 1542,

--- a/data/EX/Team Rocket Returns.ts
+++ b/data/EX/Team Rocket Returns.ts
@@ -21,6 +21,9 @@ const ex7: Set = {
 	abbreviations: {
 		official: "TR"
 	},
+	searchAliases: [
+		"TR"
+	],
 
 	thirdParty: {
 		cardmarket: 1545,

--- a/data/EX/Unseen Forces Unown Collection.ts
+++ b/data/EX/Unseen Forces Unown Collection.ts
@@ -18,7 +18,14 @@ const exu: Set = {
 		official: 28
 	},
 
-	releaseDate: "2005-08-22"
+	releaseDate: "2005-08-22",
+
+	abbreviations: {
+		official: "UF"
+	},
+	searchAliases: [
+		"UF"
+	],
 }
 
 export default exu

--- a/data/EX/Unseen Forces.ts
+++ b/data/EX/Unseen Forces.ts
@@ -26,6 +26,9 @@ const ex10: Set = {
 		official: "UF",
 		fr: "FCH"
 	},
+	searchAliases: [
+		"UF"
+	],
 
 	thirdParty: {
 		cardmarket: 1548,

--- a/data/Gym/Gym Challenge.ts
+++ b/data/Gym/Gym Challenge.ts
@@ -20,6 +20,9 @@ const gym2: Set = {
 	abbreviations: {
 		official: "G2"
 	},
+	searchAliases: [
+		"G2"
+	],
 
 	thirdParty: {
 		cardmarket: 1530,

--- a/data/Gym/Gym Heroes.ts
+++ b/data/Gym/Gym Heroes.ts
@@ -20,6 +20,9 @@ const gym1: Set = {
 	abbreviations: {
 		official: "G1"
 	},
+	searchAliases: [
+		"G1"
+	],
 
 	thirdParty: {
 		cardmarket: 1529,

--- a/data/HeartGold & SoulSilver/HGSS Black Star Promos.ts
+++ b/data/HeartGold & SoulSilver/HGSS Black Star Promos.ts
@@ -21,6 +21,13 @@ const hgssp: Set = {
 
 	releaseDate: "2010-02-11",
 
+	abbreviations: {
+		official: "HSP",
+		fr: "PHS"
+	},
+	searchAliases: [
+		"HSP"
+	],
 	thirdParty: {
 		tcgplayer: 1453
 	}

--- a/data/HeartGold & SoulSilver/HeartGold SoulSilver.ts
+++ b/data/HeartGold & SoulSilver/HeartGold SoulSilver.ts
@@ -26,6 +26,9 @@ const hgss1: Set = {
 		official: "HS",
 		fr: "HGS"
 	},
+	searchAliases: [
+		"HS"
+	],
 
 	thirdParty: {
 		cardmarket: 1566,

--- a/data/HeartGold & SoulSilver/Triumphant.ts
+++ b/data/HeartGold & SoulSilver/Triumphant.ts
@@ -25,6 +25,9 @@ const hgss4: Set = {
 		official: "TRI",
 		fr: "TRI"
 	},
+	searchAliases: [
+		"TRI"
+	],
 
 	thirdParty: {
 		cardmarket: 1569,

--- a/data/HeartGold & SoulSilver/Undaunted.ts
+++ b/data/HeartGold & SoulSilver/Undaunted.ts
@@ -25,6 +25,9 @@ const hgss3: Set = {
 		official: "UND",
 		fr: "IND"
 	},
+	searchAliases: [
+		"UND"
+	],
 
 	thirdParty: {
 		cardmarket: 1568,

--- a/data/HeartGold & SoulSilver/Unleashed.ts
+++ b/data/HeartGold & SoulSilver/Unleashed.ts
@@ -26,6 +26,9 @@ const hgss2: Set = {
 		official: "UL",
 		fr: "DCH"
 	},
+	searchAliases: [
+		"UL"
+	],
 
 	thirdParty: {
 		cardmarket: 1567,

--- a/data/Legendary Collection/Legendary Collection.ts
+++ b/data/Legendary Collection/Legendary Collection.ts
@@ -20,6 +20,9 @@ const lc: Set = {
 	abbreviations: {
 		official: "LC"
 	},
+	searchAliases: [
+		"LC"
+	],
 
 	thirdParty: {
 		cardmarket: 1535,

--- a/data/McDonald's Collection/Collection McDonald's 2013.ts
+++ b/data/McDonald's Collection/Collection McDonald's 2013.ts
@@ -14,7 +14,14 @@ const s2013bw: Set = {
 		official: 12
 	},
 
-	releaseDate: "2013-11-01"
+	releaseDate: "2013-11-01",
+
+	abbreviations: {
+		official: "MCD13"
+	},
+	searchAliases: [
+		"MCD13"
+	],
 }
 
 export default s2013bw

--- a/data/McDonald's Collection/Collection McDonald's 2018.ts
+++ b/data/McDonald's Collection/Collection McDonald's 2018.ts
@@ -16,6 +16,12 @@ const set: Set = {
 
 	releaseDate: "2018-06-13",
 
+	abbreviations: {
+		official: "MCD18"
+	},
+	searchAliases: [
+		"MCD18"
+	],
 	thirdParty: {
 		cardmarket: 2361
 	}

--- a/data/McDonald's Collection/Collection McDonald's 2019.ts
+++ b/data/McDonald's Collection/Collection McDonald's 2019.ts
@@ -14,7 +14,14 @@ const set: Set = {
 		official: 40
 	},
 
-	releaseDate: "2019-10-30"
+	releaseDate: "2019-10-30",
+
+	abbreviations: {
+		official: "MCD19"
+	},
+	searchAliases: [
+		"MCD19"
+	],
 }
 
 export default set

--- a/data/McDonald's Collection/McDonald's Collection 2011.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2011.ts
@@ -24,6 +24,9 @@ const s2011bw: Set = {
 		official: "MCD11",
 		fr: "M11"
 	},
+	searchAliases: [
+		"MCD11"
+	],
 	thirdParty: {
 		tcgplayer: 1401
 	}

--- a/data/McDonald's Collection/McDonald's Collection 2012.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2012.ts
@@ -23,6 +23,9 @@ const s2012bw: Set = {
 		official: "MCD12",
 		fr: "M12"
 	},
+	searchAliases: [
+		"MCD12"
+	],
 
 	thirdParty: {
 		tcgplayer: 1427

--- a/data/McDonald's Collection/McDonald's Collection 2014.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2014.ts
@@ -22,6 +22,9 @@ const s2014xy: Set = {
 		official: "MCD14",
 		fr: "M14"
 	},
+	searchAliases: [
+		"MCD14"
+	],
 
 	thirdParty: {
 		tcgplayer: 1692

--- a/data/McDonald's Collection/McDonald's Collection 2015.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2015.ts
@@ -22,6 +22,9 @@ const s2015xy: Set = {
 		official: "MCD15",
 		fr: "M15"
 	},
+	searchAliases: [
+		"MCD15"
+	],
 
 	thirdParty: {
 		tcgplayer: 1694

--- a/data/McDonald's Collection/McDonald's Collection 2016.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2016.ts
@@ -22,6 +22,9 @@ const s2016xy: Set = {
 		official: "MCD16",
 		fr: "M16"
 	},
+	searchAliases: [
+		"MCD16"
+	],
 
 	thirdParty: {
 		tcgplayer: 3087

--- a/data/McDonald's Collection/McDonald's Collection 2017.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2017.ts
@@ -23,6 +23,9 @@ const s2017sm: Set = {
 		official: "MCD17",
 		fr: "M17"
 	},
+	searchAliases: [
+		"MCD17"
+	],
 
 	thirdParty: {
 		tcgplayer: 2148

--- a/data/McDonald's Collection/McDonald's Collection 2018.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2018.ts
@@ -20,6 +20,9 @@ const s2018sm: Set = {
 	abbreviations: {
 		official: "MCD18"
 	},
+	searchAliases: [
+		"MCD18"
+	],
 
 	thirdParty: {
 		tcgplayer: 2364

--- a/data/McDonald's Collection/McDonald's Collection 2019.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2019.ts
@@ -22,6 +22,9 @@ const s2019sm: Set = {
 	abbreviations: {
 		official: "MCD19"
 	},
+	searchAliases: [
+		"MCD19"
+	],
 
 	thirdParty: {
 		tcgplayer: 2555

--- a/data/McDonald's Collection/McDonald's Collection 2021.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2021.ts
@@ -23,7 +23,10 @@ const s2021swsh: Set = {
 	abbreviations: {
 		official: "MCD21",
 		fr: "M21"
-	}
+	},
+	searchAliases: [
+		"MCD21"
+	],
 }
 
 export default s2021swsh

--- a/data/McDonald's Collection/McDonald's Collection 2022.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2022.ts
@@ -23,7 +23,10 @@ const s2022swsh: Set = {
 	abbreviations: {
 		official: "MCD22",
 		fr: "M22"
-	}
+	},
+	searchAliases: [
+		"MCD22"
+	],
 }
 
 export default s2022swsh

--- a/data/McDonald's Collection/McDonald's Collection 2023.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2023.ts
@@ -23,7 +23,10 @@ const s2023sv: Set = {
 	abbreviations: {
 		official: "MCD23",
 		fr: "M23"
-	}
+	},
+	searchAliases: [
+		"MCD23"
+	],
 }
 
 export default s2023sv

--- a/data/McDonald's Collection/McDonald's Collection 2024.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2024.ts
@@ -23,7 +23,10 @@ const s2024sv: Set = {
 	abbreviations: {
 		official: "MCD24",
 		fr: "M24"
-	}
+	},
+	searchAliases: [
+		"MCD24"
+	],
 }
 
 export default s2024sv

--- a/data/Mega Evolution/Ascended Heroes.ts
+++ b/data/Mega Evolution/Ascended Heroes.ts
@@ -24,8 +24,12 @@ const set: Set = {
 
 	abbreviations: {
 		official: "ASC",
-		fr: "HER"
+		fr: "ME02.5"
 	},
+	searchAliases: [
+		"M2.5"
+	],
+
 
 	thirdParty: {
 		cardmarket: 6395,

--- a/data/Mega Evolution/Chaos Rising.ts
+++ b/data/Mega Evolution/Chaos Rising.ts
@@ -1,0 +1,28 @@
+import { Set } from '../../interfaces'
+import serie from '../Mega Evolution'
+
+const set: Set = {
+	id: "me04",
+
+	name: {
+		en: "Chaos Rising",
+		fr: "Chaos Ascendant"
+	},
+
+	serie: serie,
+
+	cardCount: {
+		official: 0
+	},
+
+	releaseDate: "2026-06-19",
+
+	abbreviations: {
+		official: "CRI"
+	},
+	searchAliases: [
+		"CRI"
+	],
+}
+
+export default set

--- a/data/Mega Evolution/Eternals.ts
+++ b/data/Mega Evolution/Eternals.ts
@@ -1,0 +1,28 @@
+import { Set } from '../../interfaces'
+import serie from '../Mega Evolution'
+
+const set: Set = {
+	id: "me05",
+
+	name: {
+		en: "Eternals",
+		fr: "Éternels"
+	},
+
+	serie: serie,
+
+	cardCount: {
+		official: 0
+	},
+
+	releaseDate: "2026-10-16",
+
+	abbreviations: {
+		official: "ETE"
+	},
+	searchAliases: [
+		"ETE"
+	],
+}
+
+export default set

--- a/data/Mega Evolution/MEP Black Star Promos.ts
+++ b/data/Mega Evolution/MEP Black Star Promos.ts
@@ -25,6 +25,9 @@ const set: Set = {
 	abbreviations: {
 		official: "MEP"
 	},
+	searchAliases: [
+		"MEP"
+	],
 
 	thirdParty: {
 		cardmarket: 6232

--- a/data/Mega Evolution/Mega Evolution Energy.ts
+++ b/data/Mega Evolution/Mega Evolution Energy.ts
@@ -24,6 +24,9 @@ const set: Set = {
     abbreviations: {
         official: "MEE",
     },
+    searchAliases: [
+        "MEE"
+    ],
 
 
 }

--- a/data/Mega Evolution/Mega Evolution.ts
+++ b/data/Mega Evolution/Mega Evolution.ts
@@ -23,8 +23,13 @@ const set: Set = {
 	releaseDate: "2025-09-26",
 
 	abbreviations: {
-		official: "MEG"
+		official: "MEG",
+		fr: "ME01"
 	},
+	searchAliases: [
+		"M1"
+	],
+
 
 	thirdParty: {
 		cardmarket: 6209,

--- a/data/Mega Evolution/Perfect Order.ts
+++ b/data/Mega Evolution/Perfect Order.ts
@@ -24,8 +24,12 @@ const set: Set = {
 
 	abbreviations: {
 		official: "POR",
-		fr: "ORP"
+		fr: "ME03"
 	},
+	searchAliases: [
+		"M3"
+	],
+
 
 	thirdParty: {
 		cardmarket: 6443,

--- a/data/Mega Evolution/Phantasmal Flames.ts
+++ b/data/Mega Evolution/Phantasmal Flames.ts
@@ -23,8 +23,13 @@ const set: Set = {
 	releaseDate: "2025-11-14",
 
 	abbreviations: {
-		official: "PFL"
+		official: "PFL",
+		fr: "ME02"
 	},
+	searchAliases: [
+		"M2"
+	],
+
 
 	thirdParty: {
 		cardmarket: 6299,

--- a/data/Mega Evolution/Radiant Ruby & Shining Sapphire.ts
+++ b/data/Mega Evolution/Radiant Ruby & Shining Sapphire.ts
@@ -1,0 +1,28 @@
+import { Set } from '../../interfaces'
+import serie from '../Mega Evolution'
+
+const set: Set = {
+	id: "me04.5",
+
+	name: {
+		en: "Radiant Ruby & Shining Sapphire",
+		fr: "Rubis Radieux & Saphir Brillant"
+	},
+
+	serie: serie,
+
+	cardCount: {
+		official: 0
+	},
+
+	releaseDate: "2026-08-07",
+
+	abbreviations: {
+		official: "RRS"
+	},
+	searchAliases: [
+		"RRS"
+	],
+}
+
+export default set

--- a/data/Miscellaneous/Jumbo cards.ts
+++ b/data/Miscellaneous/Jumbo cards.ts
@@ -7,7 +7,6 @@ const jumbo: Set = {
 	name: {
 		en: "Jumbo cards",
 		fr: "Cartes Jumbo"
-,
 	},
 
 	serie: serie,
@@ -16,7 +15,14 @@ const jumbo: Set = {
 		official: 160
 	},
 
-	releaseDate: "2000-02-01"
+	releaseDate: "2000-02-01",
+
+	abbreviations: {
+		official: "JUM"
+	},
+	searchAliases: [
+		"JUM"
+	],
 }
 
 export default jumbo

--- a/data/Neo/Neo Destiny.ts
+++ b/data/Neo/Neo Destiny.ts
@@ -24,6 +24,9 @@ const neo4: Set = {
 		official: "N4",
 		fr: "NDT"
 	},
+	searchAliases: [
+		"N4"
+	],
 
 	thirdParty: {
 		cardmarket: 1534,

--- a/data/Neo/Neo Discovery.ts
+++ b/data/Neo/Neo Discovery.ts
@@ -24,6 +24,9 @@ const neo2: Set = {
 		official: "N2",
 		fr: "NDS"
 	},
+	searchAliases: [
+		"N2"
+	],
 
 	thirdParty: {
 		cardmarket: 1532,

--- a/data/Neo/Neo Genesis.ts
+++ b/data/Neo/Neo Genesis.ts
@@ -25,6 +25,9 @@ const neo1: Set = {
 		official: "N1",
 		fr: "NGS"
 	},
+	searchAliases: [
+		"N1"
+	],
 
 	thirdParty: {
 		cardmarket: 1531,

--- a/data/Neo/Neo Revelation.ts
+++ b/data/Neo/Neo Revelation.ts
@@ -24,6 +24,9 @@ const neo3: Set = {
 		official: "N3",
 		fr: "NRE"
 	},
+	searchAliases: [
+		"N3"
+	],
 
 	thirdParty: {
 		cardmarket: 1533,

--- a/data/Neo/Southern Islands.ts
+++ b/data/Neo/Southern Islands.ts
@@ -19,6 +19,9 @@ const si1: Set = {
 	abbreviations: {
 		official: "SI"
 	},
+	searchAliases: [
+		"SI"
+	],
 
 	thirdParty: {
 		cardmarket: 1633,

--- a/data/POP/Nintendo Black Star Promos.ts
+++ b/data/POP/Nintendo Black Star Promos.ts
@@ -21,6 +21,13 @@ const np: Set = {
 
 	releaseDate: "2003-10-01",
 
+	abbreviations: {
+		official: "NP",
+		fr: "PNI"
+	},
+	searchAliases: [
+		"NP"
+	],
 	thirdParty: {
 		tcgplayer: 1423
 	}

--- a/data/POP/POP Series 1.ts
+++ b/data/POP/POP Series 1.ts
@@ -23,6 +23,9 @@ const pop1: Set = {
 		official: "P1",
 		fr: "P01"
 	},
+	searchAliases: [
+		"P1"
+	],
 
 	thirdParty: {
 		cardmarket: 1613,

--- a/data/POP/POP Series 2.ts
+++ b/data/POP/POP Series 2.ts
@@ -23,6 +23,9 @@ const pop2: Set = {
 		official: "P2",
 		fr: "P02"
 	},
+	searchAliases: [
+		"P2"
+	],
 
 	thirdParty: {
 		cardmarket: 1614,

--- a/data/POP/POP Series 3.ts
+++ b/data/POP/POP Series 3.ts
@@ -23,6 +23,9 @@ const pop3: Set = {
 		official: "P3",
 		fr: "P03"
 	},
+	searchAliases: [
+		"P3"
+	],
 
 	thirdParty: {
 		cardmarket: 1615,

--- a/data/POP/POP Series 4.ts
+++ b/data/POP/POP Series 4.ts
@@ -23,6 +23,9 @@ const pop4: Set = {
 		official: "P4",
 		fr: "P04"
 	},
+	searchAliases: [
+		"P4"
+	],
 
 	thirdParty: {
 		cardmarket: 1616,

--- a/data/POP/POP Series 5.ts
+++ b/data/POP/POP Series 5.ts
@@ -21,6 +21,9 @@ const pop5: Set = {
 	abbreviations: {
 		official: "P5"
 	},
+	searchAliases: [
+		"P5"
+	],
 
 	thirdParty: {
 		cardmarket: 1617,

--- a/data/POP/POP Series 6.ts
+++ b/data/POP/POP Series 6.ts
@@ -20,6 +20,9 @@ const pop6: Set = {
 	abbreviations: {
 		official: "P6"
 	},
+	searchAliases: [
+		"P6"
+	],
 
 	thirdParty: {
 		cardmarket: 1618,

--- a/data/POP/POP Series 7.ts
+++ b/data/POP/POP Series 7.ts
@@ -23,6 +23,9 @@ const pop7: Set = {
 		official: "P7",
 		fr: "P07"
 	},
+	searchAliases: [
+		"P7"
+	],
 
 	thirdParty: {
 		cardmarket: 1619,

--- a/data/POP/POP Series 8.ts
+++ b/data/POP/POP Series 8.ts
@@ -20,6 +20,9 @@ const pop8: Set = {
 	abbreviations: {
 		official: "P8"
 	},
+	searchAliases: [
+		"P8"
+	],
 
 	thirdParty: {
 		cardmarket: 1620,

--- a/data/POP/POP Series 9.ts
+++ b/data/POP/POP Series 9.ts
@@ -23,6 +23,9 @@ const pop9: Set = {
 		official: "P9",
 		fr: "P09"
 	},
+	searchAliases: [
+		"P9"
+	],
 
 	thirdParty: {
 		cardmarket: 1621,

--- a/data/Platinum/Arceus.ts
+++ b/data/Platinum/Arceus.ts
@@ -23,6 +23,9 @@ const pl4: Set = {
 	abbreviations: {
 		official: "AR"
 	},
+	searchAliases: [
+		"AR"
+	],
 
 	thirdParty: {
 		cardmarket: 1565,

--- a/data/Platinum/Platinum.ts
+++ b/data/Platinum/Platinum.ts
@@ -25,6 +25,9 @@ const pl1: Set = {
 		official: "PL",
 		fr: "PLA"
 	},
+	searchAliases: [
+		"PL"
+	],
 
 	thirdParty: {
 		cardmarket: 1562,

--- a/data/Platinum/Pokémon Rumble.ts
+++ b/data/Platinum/Pokémon Rumble.ts
@@ -20,6 +20,9 @@ const ru1: Set = {
 	abbreviations: {
 		official: "RM"
 	},
+	searchAliases: [
+		"RM"
+	],
 
 	thirdParty: {
 		cardmarket: 1634,

--- a/data/Platinum/Rising Rivals.ts
+++ b/data/Platinum/Rising Rivals.ts
@@ -24,6 +24,9 @@ const pl2: Set = {
 		official: "RR",
 		fr: "REM"
 	},
+	searchAliases: [
+		"RR"
+	],
 
 	thirdParty: {
 		cardmarket: 1563,

--- a/data/Platinum/Supreme Victors.ts
+++ b/data/Platinum/Supreme Victors.ts
@@ -23,6 +23,9 @@ const pl3: Set = {
 		official: "SV",
 		fr: "VSU"
 	},
+	searchAliases: [
+		"SV"
+	],
 
 	thirdParty: {
 		cardmarket: 1564,

--- a/data/Pokémon TCG Pocket/Celestial Guardians.ts
+++ b/data/Pokémon TCG Pocket/Celestial Guardians.ts
@@ -45,7 +45,14 @@ const set: Set = {
 		}
 	},
 
-	releaseDate: "2025-04-30"
+	releaseDate: "2025-04-30",
+
+	abbreviations: {
+		official: "A3"
+	},
+	searchAliases: [
+		"A3"
+	],
 }
 
 export default set

--- a/data/Pokémon TCG Pocket/Crimson Blaze.ts
+++ b/data/Pokémon TCG Pocket/Crimson Blaze.ts
@@ -20,7 +20,14 @@ const set: Set = {
 		official: 69 // nice
 	},
 
-	releaseDate: "2025-12-17"
+	releaseDate: "2025-12-17",
+
+	abbreviations: {
+		official: "B1a"
+	},
+	searchAliases: [
+		"B1a"
+	],
 }
 
 export default set

--- a/data/Pokémon TCG Pocket/Eevee Grove.ts
+++ b/data/Pokémon TCG Pocket/Eevee Grove.ts
@@ -28,7 +28,14 @@ const set: Set = {
 		}
 	},
 
-	releaseDate: "2025-06-26"
+	releaseDate: "2025-06-26",
+
+	abbreviations: {
+		official: "A3b"
+	},
+	searchAliases: [
+		"A3b"
+	],
 }
 
 export default set

--- a/data/Pokémon TCG Pocket/Extradimensional Crisis.ts
+++ b/data/Pokémon TCG Pocket/Extradimensional Crisis.ts
@@ -28,7 +28,14 @@ const set: Set = {
 		}
 	},
 
-	releaseDate: "2025-05-29"
+	releaseDate: "2025-05-29",
+
+	abbreviations: {
+		official: "A3a"
+	},
+	searchAliases: [
+		"A3a"
+	],
 }
 
 export default set

--- a/data/Pokémon TCG Pocket/Fantastical Parade.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade.ts
@@ -34,7 +34,14 @@ const set: Set = {
 		}
 	},
 
-	releaseDate: "2026-01-29"
+	releaseDate: "2026-01-29",
+
+	abbreviations: {
+		official: "B2"
+	},
+	searchAliases: [
+		"B2"
+	],
 }
 
 export default set

--- a/data/Pokémon TCG Pocket/Genetic Apex.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex.ts
@@ -55,7 +55,14 @@ const set: Set = {
 		}
 	},
 
-	releaseDate: "2024-10-30"
+	releaseDate: "2024-10-30",
+
+	abbreviations: {
+		official: "A1"
+	},
+	searchAliases: [
+		"A1"
+	],
 }
 
 export default set

--- a/data/Pokémon TCG Pocket/Mega Rising.ts
+++ b/data/Pokémon TCG Pocket/Mega Rising.ts
@@ -17,6 +17,12 @@ const set: Set = {
 
 	releaseDate: "2025-10-30",
 
+	abbreviations: {
+		official: "B1"
+	},
+	searchAliases: [
+		"B1"
+	],
 	boosters: {
 		'mega-gyarados': {
 			name: {

--- a/data/Pokémon TCG Pocket/Mythical Island.ts
+++ b/data/Pokémon TCG Pocket/Mythical Island.ts
@@ -28,7 +28,14 @@ const set: Set = {
 		}
 	},
 
-	releaseDate: "2024-12-17"
+	releaseDate: "2024-12-17",
+
+	abbreviations: {
+		official: "A1a"
+	},
+	searchAliases: [
+		"A1a"
+	],
 }
 
 export default set

--- a/data/Pokémon TCG Pocket/Paldean Wonders.ts
+++ b/data/Pokémon TCG Pocket/Paldean Wonders.ts
@@ -34,7 +34,14 @@ const set: Set = {
 		}
 	},		
 
-	releaseDate: "2026-02-26"
+	releaseDate: "2026-02-26",
+
+	abbreviations: {
+		official: "B2a"
+	},
+	searchAliases: [
+		"B2a"
+	],
 }
 
 

--- a/data/Pokémon TCG Pocket/Promos-A.ts
+++ b/data/Pokémon TCG Pocket/Promos-A.ts
@@ -73,7 +73,14 @@ const set: Set = {
 		}
 	},
 
-	releaseDate: "2024-10-30"
+	releaseDate: "2024-10-30",
+
+	abbreviations: {
+		official: "P-A"
+	},
+	searchAliases: [
+		"P-A"
+	],
 }
 
 export default set

--- a/data/Pokémon TCG Pocket/Secluded Springs.ts
+++ b/data/Pokémon TCG Pocket/Secluded Springs.ts
@@ -31,7 +31,14 @@ const set: Set = {
 		}
 	},
 
-	releaseDate: "2025-08-28"
+	releaseDate: "2025-08-28",
+
+	abbreviations: {
+		official: "A4a"
+	},
+	searchAliases: [
+		"A4a"
+	],
 }
 
 export default set

--- a/data/Pokémon TCG Pocket/Shining Revelry.ts
+++ b/data/Pokémon TCG Pocket/Shining Revelry.ts
@@ -28,7 +28,14 @@ const set: Set = {
 		}
 	},
 
-	releaseDate: "2025-03-27"
+	releaseDate: "2025-03-27",
+
+	abbreviations: {
+		official: "A2b"
+	},
+	searchAliases: [
+		"A2b"
+	],
 }
 
 export default set

--- a/data/Pokémon TCG Pocket/Space-Time Smackdown.ts
+++ b/data/Pokémon TCG Pocket/Space-Time Smackdown.ts
@@ -46,6 +46,13 @@ const set: Set = {
 	},
 
 	releaseDate: "2025-01-30",
+
+	abbreviations: {
+		official: "A2"
+	},
+	searchAliases: [
+		"A2"
+	],
 };
 
 export default set;

--- a/data/Pokémon TCG Pocket/Triumphant Light.ts
+++ b/data/Pokémon TCG Pocket/Triumphant Light.ts
@@ -28,7 +28,14 @@ const set: Set = {
 		}
 	},
 
-	releaseDate: "2025-02-28"
+	releaseDate: "2025-02-28",
+
+	abbreviations: {
+		official: "A2a"
+	},
+	searchAliases: [
+		"A2a"
+	],
 }
 
 export default set

--- a/data/Pokémon TCG Pocket/Wisdom of Sea and Sky.ts
+++ b/data/Pokémon TCG Pocket/Wisdom of Sea and Sky.ts
@@ -22,6 +22,12 @@ const set: Set = {
 
 	releaseDate: "2025-07-30",
 
+	abbreviations: {
+		official: "A4"
+	},
+	searchAliases: [
+		"A4"
+	],
 	boosters: {
 		lugia: {
 			name: {

--- a/data/Scarlet & Violet/151.ts
+++ b/data/Scarlet & Violet/151.ts
@@ -23,8 +23,12 @@ const set: Set = {
 
 	abbreviations: {
 		official: "MEW",
-		fr: "151"
+		fr: "EV03.5"
 	},
+	searchAliases: [
+		"SV3.5"
+	],
+
 
 	thirdParty: {
 		cardmarket: 5402,

--- a/data/Scarlet & Violet/Black Bolt.ts
+++ b/data/Scarlet & Violet/Black Bolt.ts
@@ -22,8 +22,14 @@ const set: Set = {
 	releaseDate: "2025-07-17",
 
 	abbreviations: {
-		official: "BLK"
+		official: "BLK",
+		fr: "EV10.5N"
 	},
+	searchAliases: [
+		"SV10.5",
+		"SV10.5B"
+	],
+
 
 	thirdParty: {
 		cardmarket: 6134,

--- a/data/Scarlet & Violet/Destined Rivals.ts
+++ b/data/Scarlet & Violet/Destined Rivals.ts
@@ -24,8 +24,12 @@ const set: Set = {
 
 	abbreviations: {
 		official: "DRI",
-		fr: "RVD"
+		fr: "EV10"
 	},
+	searchAliases: [
+		"SV10"
+	],
+
 
 	thirdParty: {
 		tcgplayer: 24269

--- a/data/Scarlet & Violet/Journey Together.ts
+++ b/data/Scarlet & Violet/Journey Together.ts
@@ -23,8 +23,13 @@ const set: Set = {
 	releaseDate: "2025-03-28",
 
 	abbreviations: {
-		official: "JTG"
+		official: "JTG",
+		fr: "EV09"
 	},
+	searchAliases: [
+		"SV9"
+	],
+
 
 	thirdParty: {
 		cardmarket: 6006,

--- a/data/Scarlet & Violet/Obsidian Flames.ts
+++ b/data/Scarlet & Violet/Obsidian Flames.ts
@@ -23,8 +23,12 @@ const set: Set = {
 
 	abbreviations: {
 		official: "OBF",
-		fr: "FLO"
+		fr: "EV03"
 	},
+	searchAliases: [
+		"SV3"
+	],
+
 
 	thirdParty: {
 		cardmarket: 5385,

--- a/data/Scarlet & Violet/Paldea Evolved.ts
+++ b/data/Scarlet & Violet/Paldea Evolved.ts
@@ -23,8 +23,12 @@ const set: Set = {
 
 	abbreviations: {
 		official: "PAL",
-		fr: "EAP"
+		fr: "EV02"
 	},
+	searchAliases: [
+		"SV2"
+	],
+
 
 	thirdParty: {
 		cardmarket: 5318,

--- a/data/Scarlet & Violet/Paldean Fates.ts
+++ b/data/Scarlet & Violet/Paldean Fates.ts
@@ -23,8 +23,12 @@ const set: Set = {
 
 	abbreviations: {
 		official: "PAF",
-		fr: "DDP"
+		fr: "EV04.5"
 	},
+	searchAliases: [
+		"SV4.5"
+	],
+
 
 	thirdParty: {
 		cardmarket: 5546,

--- a/data/Scarlet & Violet/Paradox Rift.ts
+++ b/data/Scarlet & Violet/Paradox Rift.ts
@@ -23,8 +23,12 @@ const set: Set = {
 
 	abbreviations: {
 		official: "PAR",
-		fr: "FAP"
+		fr: "EV04"
 	},
+	searchAliases: [
+		"SV4"
+	],
+
 
 	thirdParty: {
 		cardmarket: 5444,

--- a/data/Scarlet & Violet/Prismatic Evolutions.ts
+++ b/data/Scarlet & Violet/Prismatic Evolutions.ts
@@ -22,8 +22,13 @@ const set: Set = {
 	releaseDate: "2025-01-17",
 
 	abbreviations: {
-		official: "PRE"
+		official: "PRE",
+		fr: "EV08.5"
 	},
+	searchAliases: [
+		"SV8.5"
+	],
+
 
 	thirdParty: {
 		cardmarket: 5944,

--- a/data/Scarlet & Violet/SVP Black Star Promos.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos.ts
@@ -24,6 +24,9 @@ const set: Set = {
 	abbreviations: {
 		official: "SVP"
 	},
+	searchAliases: [
+		"SVP"
+	],
 
 	thirdParty: {
 		cardmarket: 5241,

--- a/data/Scarlet & Violet/Scarlet & Violet Energy.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet Energy.ts
@@ -24,6 +24,9 @@ const set: Set = {
     abbreviations: {
         official: "SVE",
     },
+    searchAliases: [
+        "SVE"
+    ],
 
 
 }

--- a/data/Scarlet & Violet/Scarlet & Violet.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet.ts
@@ -23,8 +23,12 @@ const set: Set = {
 
 	abbreviations: {
 		official: "SVI",
-		fr: "E&V"
+		fr: "EV01"
 	},
+	searchAliases: [
+		"SV1"
+	],
+
 
 	thirdParty: {
 		cardmarket: 5223,

--- a/data/Scarlet & Violet/Shrouded Fable.ts
+++ b/data/Scarlet & Violet/Shrouded Fable.ts
@@ -23,8 +23,12 @@ const set: Set = {
 
 	abbreviations: {
 		official: "SFA",
-		fr: "FNE"
+		fr: "EV06.5"
 	},
+	searchAliases: [
+		"SV6.5"
+	],
+
 
 	thirdParty: {
 		cardmarket: 5760,

--- a/data/Scarlet & Violet/Stellar Crown.ts
+++ b/data/Scarlet & Violet/Stellar Crown.ts
@@ -22,8 +22,13 @@ const set: Set = {
 	releaseDate: "2024-09-13",
 
 	abbreviations: {
-		official: "SCR"
+		official: "SCR",
+		fr: "EV07"
 	},
+	searchAliases: [
+		"SV7"
+	],
+
 
 	thirdParty: {
 		cardmarket: 5802,

--- a/data/Scarlet & Violet/Surging Sparks.ts
+++ b/data/Scarlet & Violet/Surging Sparks.ts
@@ -23,8 +23,12 @@ const set: Set = {
 
 	abbreviations: {
 		official: "SSP",
-		fr: "ETD"
+		fr: "EV08"
 	},
+	searchAliases: [
+		"SV8"
+	],
+
 
 	thirdParty: {
 		cardmarket: 5879,

--- a/data/Scarlet & Violet/Temporal Forces.ts
+++ b/data/Scarlet & Violet/Temporal Forces.ts
@@ -23,8 +23,12 @@ const set: Set = {
 
 	abbreviations: {
 		official: "TEF",
-		fr: "FTP"
+		fr: "EV05"
 	},
+	searchAliases: [
+		"SV5"
+	],
+
 
 	thirdParty: {
 		cardmarket: 5589,

--- a/data/Scarlet & Violet/Twilight Masquerade.ts
+++ b/data/Scarlet & Violet/Twilight Masquerade.ts
@@ -23,8 +23,12 @@ const set: Set = {
 
 	abbreviations: {
 		official: "TWM",
-		fr: "MCR"
+		fr: "EV06"
 	},
+	searchAliases: [
+		"SV6"
+	],
+
 
 	thirdParty: {
 		cardmarket: 5691,

--- a/data/Scarlet & Violet/White Flare.ts
+++ b/data/Scarlet & Violet/White Flare.ts
@@ -22,8 +22,14 @@ const set: Set = {
 	releaseDate: "2025-07-17",
 
 	abbreviations: {
-		official: "WHT"
+		official: "WHT",
+		fr: "EV10.5B"
 	},
+	searchAliases: [
+		"SV10.5",
+		"SV10.5W"
+	],
+
 
 	thirdParty: {
 		cardmarket: 6135,

--- a/data/Sun & Moon/Burning Shadows.ts
+++ b/data/Sun & Moon/Burning Shadows.ts
@@ -24,8 +24,12 @@ const sm3: Set = {
 
 	abbreviations: {
 		official: "BUS",
-		fr: "OAR"
+		fr: "SL03"
 	},
+	searchAliases: [
+		"SM3"
+	],
+
 
 	thirdParty: {
 		cardmarket: 1824,

--- a/data/Sun & Moon/Celestial Storm.ts
+++ b/data/Sun & Moon/Celestial Storm.ts
@@ -24,8 +24,12 @@ const sm7: Set = {
 
 	abbreviations: {
 		official: "CES",
-		fr: "TCE"
+		fr: "SL07"
 	},
+	searchAliases: [
+		"SM7"
+	],
+
 
 	thirdParty: {
 		cardmarket: 2320,

--- a/data/Sun & Moon/Cosmic Eclipse.ts
+++ b/data/Sun & Moon/Cosmic Eclipse.ts
@@ -24,8 +24,12 @@ const sm12: Set = {
 
 	abbreviations: {
 		official: "CEC",
-		fr: "ECO"
+		fr: "SL12"
 	},
+	searchAliases: [
+		"SM12"
+	],
+
 
 	thirdParty: {
 		cardmarket: 2644,

--- a/data/Sun & Moon/Crimson Invasion.ts
+++ b/data/Sun & Moon/Crimson Invasion.ts
@@ -24,8 +24,12 @@ const sm4: Set = {
 
 	abbreviations: {
 		official: "CIN",
-		fr: "INC"
+		fr: "SL04"
 	},
+	searchAliases: [
+		"SM4"
+	],
+
 
 	thirdParty: {
 		cardmarket: 1843,

--- a/data/Sun & Moon/Detective Pikachu.ts
+++ b/data/Sun & Moon/Detective Pikachu.ts
@@ -26,6 +26,9 @@ const det1: Set = {
 		official: "DET",
 		fr: "DPI"
 	},
+	searchAliases: [
+		"DET"
+	],
 
 	thirdParty: {
 		cardmarket: 2438,

--- a/data/Sun & Moon/Dragon Majesty.ts
+++ b/data/Sun & Moon/Dragon Majesty.ts
@@ -24,8 +24,12 @@ const sm75: Set = {
 
 	abbreviations: {
 		official: "DRM",
-		fr: "MDD"
+		fr: "SL07.5"
 	},
+	searchAliases: [
+		"SM7.5"
+	],
+
 
 	thirdParty: {
 		cardmarket: 2351,

--- a/data/Sun & Moon/Forbidden Light.ts
+++ b/data/Sun & Moon/Forbidden Light.ts
@@ -24,8 +24,12 @@ const sm6: Set = {
 
 	abbreviations: {
 		official: "FLI",
-		fr: "LUI"
+		fr: "SL06"
 	},
+	searchAliases: [
+		"SM6"
+	],
+
 
 	thirdParty: {
 		cardmarket: 2075,

--- a/data/Sun & Moon/Guardians Rising.ts
+++ b/data/Sun & Moon/Guardians Rising.ts
@@ -24,8 +24,12 @@ const sm2: Set = {
 
 	abbreviations: {
 		official: "GRI",
-		fr: "GAS"
+		fr: "SL02"
 	},
+	searchAliases: [
+		"SM2"
+	],
+
 
 	thirdParty: {
 		cardmarket: 1800,

--- a/data/Sun & Moon/Hidden Fates Shiny Vault.ts
+++ b/data/Sun & Moon/Hidden Fates Shiny Vault.ts
@@ -19,7 +19,14 @@ const sma: Set = {
 		official: 94
 	},
 
-	releaseDate: "2019-08-23"
+	releaseDate: "2019-08-23",
+
+	abbreviations: {
+		official: "SV"
+	},
+	searchAliases: [
+		"SV"
+	],
 }
 
 export default sma

--- a/data/Sun & Moon/Hidden Fates.ts
+++ b/data/Sun & Moon/Hidden Fates.ts
@@ -24,8 +24,12 @@ const sm115: Set = {
 
 	abbreviations: {
 		official: "HIF",
-		fr: "DOC"
+		fr: "SL11.5"
 	},
+	searchAliases: [
+		"SM11.5"
+	],
+
 
 	thirdParty: {
 		cardmarket: 2514,

--- a/data/Sun & Moon/Lost Thunder.ts
+++ b/data/Sun & Moon/Lost Thunder.ts
@@ -24,8 +24,12 @@ const sm8: Set = {
 
 	abbreviations: {
 		official: "LOT",
-		fr: "TPD"
+		fr: "SL08"
 	},
+	searchAliases: [
+		"SM8"
+	],
+
 
 	thirdParty: {
 		cardmarket: 2370,

--- a/data/Sun & Moon/SM Black Star Promos.ts
+++ b/data/Sun & Moon/SM Black Star Promos.ts
@@ -25,6 +25,9 @@ const smp: Set = {
 		official: "SMP",
 		fr: "PSM"
 	},
+	searchAliases: [
+		"SMP"
+	],
 
 	thirdParty: {
 		tcgplayer: 1861

--- a/data/Sun & Moon/Shining Legends.ts
+++ b/data/Sun & Moon/Shining Legends.ts
@@ -24,8 +24,12 @@ const sm35: Set = {
 
 	abbreviations: {
 		official: "SLG",
-		fr: "LBR"
+		fr: "SL03.5"
 	},
+	searchAliases: [
+		"SM3.5"
+	],
+
 
 	thirdParty: {
 		cardmarket: 1842,

--- a/data/Sun & Moon/Sun & Moon.ts
+++ b/data/Sun & Moon/Sun & Moon.ts
@@ -24,8 +24,12 @@ const sm1: Set = {
 
 	abbreviations: {
 		official: "SUM",
-		fr: "S&L"
+		fr: "SL01"
 	},
+	searchAliases: [
+		"SM1"
+	],
+
 
 	thirdParty: {
 		cardmarket: 1745,

--- a/data/Sun & Moon/Team Up.ts
+++ b/data/Sun & Moon/Team Up.ts
@@ -24,8 +24,12 @@ const sm9: Set = {
 
 	abbreviations: {
 		official: "TEU",
-		fr: "DDC"
+		fr: "SL09"
 	},
+	searchAliases: [
+		"SM9"
+	],
+
 
 	thirdParty: {
 		cardmarket: 2407,

--- a/data/Sun & Moon/Ultra Prism.ts
+++ b/data/Sun & Moon/Ultra Prism.ts
@@ -24,8 +24,12 @@ const sm5: Set = {
 
 	abbreviations: {
 		official: "UPR",
-		fr: "UPR"
+		fr: "SL05"
 	},
+	searchAliases: [
+		"SM5"
+	],
+
 
 	thirdParty: {
 		cardmarket: 2065,

--- a/data/Sun & Moon/Unbroken Bonds.ts
+++ b/data/Sun & Moon/Unbroken Bonds.ts
@@ -24,8 +24,12 @@ const sm10: Set = {
 
 	abbreviations: {
 		official: "UNB",
-		fr: "AIF"
+		fr: "SL10"
 	},
+	searchAliases: [
+		"SM10"
+	],
+
 
 	thirdParty: {
 		cardmarket: 2437,

--- a/data/Sun & Moon/Unified Minds.ts
+++ b/data/Sun & Moon/Unified Minds.ts
@@ -24,8 +24,12 @@ const sm11: Set = {
 
 	abbreviations: {
 		official: "UNM",
-		fr: "HES"
+		fr: "SL11"
 	},
+	searchAliases: [
+		"SM11"
+	],
+
 
 	thirdParty: {
 		cardmarket: 2487,

--- a/data/Sword & Shield/Astral Radiance.ts
+++ b/data/Sword & Shield/Astral Radiance.ts
@@ -24,8 +24,12 @@ const set: Set = {
 
 	abbreviations: {
 		official: "ASR",
-		fr: "ASR"
+		fr: "EB10"
 	},
+	searchAliases: [
+		"SWSH10"
+	],
+
 
 	thirdParty: {
 		cardmarket: 4979,

--- a/data/Sword & Shield/Battle Styles.ts
+++ b/data/Sword & Shield/Battle Styles.ts
@@ -24,8 +24,12 @@ const swsh1: Set = {
 
 	abbreviations: {
 		official: "BST",
-		fr: "STC"
+		fr: "EB05"
 	},
+	searchAliases: [
+		"SWSH5"
+	],
+
 
 	thirdParty: {
 		cardmarket: 3675,

--- a/data/Sword & Shield/Brilliant Stars.ts
+++ b/data/Sword & Shield/Brilliant Stars.ts
@@ -24,8 +24,12 @@ const set: Set = {
 
 	abbreviations: {
 		official: "BRS",
-		fr: "STA"
+		fr: "EB09"
 	},
+	searchAliases: [
+		"SWSH9"
+	],
+
 
 	thirdParty: {
 		cardmarket: 4434,

--- a/data/Sword & Shield/Celebrations.ts
+++ b/data/Sword & Shield/Celebrations.ts
@@ -24,8 +24,12 @@ const set: Set = {
 
 	abbreviations: {
 		official: "CEL",
-		fr: "CEL"
+		fr: "EB07.5"
 	},
+	searchAliases: [
+		"SWSH7.5"
+	],
+
 
 	thirdParty: {
 		cardmarket: 4347,

--- a/data/Sword & Shield/Champion's Path.ts
+++ b/data/Sword & Shield/Champion's Path.ts
@@ -24,8 +24,12 @@ const swsh35: Set = {
 
 	abbreviations: {
 		official: "CPA",
-		fr: "VDM"
+		fr: "EB03.5"
 	},
+	searchAliases: [
+		"SWSH3.5"
+	],
+
 
 	thirdParty: {
 		cardmarket: 3419,

--- a/data/Sword & Shield/Chilling Reign.ts
+++ b/data/Sword & Shield/Chilling Reign.ts
@@ -24,8 +24,12 @@ const set: Set = {
 
 	abbreviations: {
 		official: "CRE",
-		fr: "REG"
+		fr: "EB06"
 	},
+	searchAliases: [
+		"SWSH6"
+	],
+
 
 	thirdParty: {
 		cardmarket: 4174,

--- a/data/Sword & Shield/Crown Zenith.ts
+++ b/data/Sword & Shield/Crown Zenith.ts
@@ -23,8 +23,12 @@ const swsh3: Set = {
 
 	abbreviations: {
 		official: "CRZ",
-		fr: "ZEN"
+		fr: "EB12.5"
 	},
+	searchAliases: [
+		"SWSH12.5"
+	],
+
 
 	thirdParty: {
 		cardmarket: 5201,

--- a/data/Sword & Shield/Darkness Ablaze.ts
+++ b/data/Sword & Shield/Darkness Ablaze.ts
@@ -24,8 +24,12 @@ const swsh3: Set = {
 
 	abbreviations: {
 		official: "DAA",
-		fr: "TEM"
+		fr: "EB03"
 	},
+	searchAliases: [
+		"SWSH3"
+	],
+
 
 	thirdParty: {
 		cardmarket: 3199,

--- a/data/Sword & Shield/Evolving Skies.ts
+++ b/data/Sword & Shield/Evolving Skies.ts
@@ -24,8 +24,12 @@ const swsh6: Set = {
 
 	abbreviations: {
 		official: "EVS",
-		fr: "EVC"
+		fr: "EB07"
 	},
+	searchAliases: [
+		"SWSH7"
+	],
+
 
 	thirdParty: {
 		cardmarket: 4328,

--- a/data/Sword & Shield/Fusion Strike.ts
+++ b/data/Sword & Shield/Fusion Strike.ts
@@ -24,8 +24,12 @@ const set: Set = {
 
 	abbreviations: {
 		official: "FST",
-		fr: "PDF"
+		fr: "EB08"
 	},
+	searchAliases: [
+		"SWSH8"
+	],
+
 
 	thirdParty: {
 		cardmarket: 4382,

--- a/data/Sword & Shield/Lost Origin.ts
+++ b/data/Sword & Shield/Lost Origin.ts
@@ -23,8 +23,12 @@ const set: Set = {
 
 	abbreviations: {
 		official: "LOR",
-		fr: "ORP"
+		fr: "EB11"
 	},
+	searchAliases: [
+		"SWSH11"
+	],
+
 
 	thirdParty: {
 		cardmarket: 5093,

--- a/data/Sword & Shield/Pokémon Futsal 2020.ts
+++ b/data/Sword & Shield/Pokémon Futsal 2020.ts
@@ -18,7 +18,10 @@ const swshp: Set = {
 
 	abbreviations: {
 		official: "FUT20"
-	}
+	},
+	searchAliases: [
+		"FUT20"
+	],
 }
 
 export default swshp

--- a/data/Sword & Shield/Pokémon GO.ts
+++ b/data/Sword & Shield/Pokémon GO.ts
@@ -24,8 +24,12 @@ const set: Set = {
 
 	abbreviations: {
 		official: "PGO",
-		fr: "PGO"
+		fr: "EB10.5"
 	},
+	searchAliases: [
+		"SWSH10.5"
+	],
+
 
 	thirdParty: {
 		cardmarket: 4786,

--- a/data/Sword & Shield/Rebel Clash.ts
+++ b/data/Sword & Shield/Rebel Clash.ts
@@ -24,8 +24,12 @@ const swsh2: Set = {
 
 	abbreviations: {
 		official: "RCL",
-		fr: "CDR"
+		fr: "EB02"
 	},
+	searchAliases: [
+		"SWSH2"
+	],
+
 
 	thirdParty: {
 		cardmarket: 3143,

--- a/data/Sword & Shield/SWSH Black Star Promos.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos.ts
@@ -21,6 +21,12 @@ const swshp: Set = {
 
 	releaseDate: "2019-11-15",
 
+	abbreviations: {
+		official: "SWSHP"
+	},
+	searchAliases: [
+		"SWSHP"
+	],
 	thirdParty: {
 		tcgplayer: 2545,
 		cardmarket: 2916

--- a/data/Sword & Shield/Shining Fates.ts
+++ b/data/Sword & Shield/Shining Fates.ts
@@ -24,8 +24,12 @@ const swsh1: Set = {
 
 	abbreviations: {
 		official: "SHF",
-		fr: "DRA"
+		fr: "EB04.5"
 	},
+	searchAliases: [
+		"SWSH4.5"
+	],
+
 
 	thirdParty: {
 		cardmarket: 3630,

--- a/data/Sword & Shield/Silver Tempest.ts
+++ b/data/Sword & Shield/Silver Tempest.ts
@@ -23,8 +23,12 @@ const set: Set = {
 
 	abbreviations: {
 		official: "SIT",
-		fr: "TAR"
+		fr: "EB12"
 	},
+	searchAliases: [
+		"SWSH12"
+	],
+
 
 	thirdParty: {
 		cardmarket: 5142,

--- a/data/Sword & Shield/Sword & Shield.ts
+++ b/data/Sword & Shield/Sword & Shield.ts
@@ -24,8 +24,12 @@ const swsh1: Set = {
 
 	abbreviations: {
 		official: "SSH",
-		fr: "E&B"
+		fr: "EB01"
 	},
+	searchAliases: [
+		"SWSH1"
+	],
+
 
 	thirdParty: {
 		cardmarket: 2921,

--- a/data/Sword & Shield/Vivid Voltage.ts
+++ b/data/Sword & Shield/Vivid Voltage.ts
@@ -24,8 +24,12 @@ const swsh4: Set = {
 
 	abbreviations: {
 		official: "VIV",
-		fr: "VOL"
+		fr: "EB04"
 	},
+	searchAliases: [
+		"SWSH4"
+	],
+
 
 	thirdParty: {
 		cardmarket: 3484,

--- a/data/Trainer kits/BW trainer Kit (Excadrill).ts
+++ b/data/Trainer kits/BW trainer Kit (Excadrill).ts
@@ -22,6 +22,9 @@ const set: Set = {
 		official: "TK5E",
 		fr: "MIN"
 	},
+	searchAliases: [
+		"TK5E"
+	],
 
 	thirdParty: {
 		tcgplayer: 1538

--- a/data/Trainer kits/BW trainer Kit (Zoroark).ts
+++ b/data/Trainer kits/BW trainer Kit (Zoroark).ts
@@ -22,6 +22,9 @@ const set: Set = {
 		official: "TK5Z",
 		fr: "ZOR"
 	},
+	searchAliases: [
+		"TK5Z"
+	],
 
 	thirdParty: {
 		tcgplayer: 1538

--- a/data/Trainer kits/DP trainer Kit (Lucario).ts
+++ b/data/Trainer kits/DP trainer Kit (Lucario).ts
@@ -23,6 +23,9 @@ const set: Set = {
 		official: "TK3L",
 		fr: "LUC"
 	},
+	searchAliases: [
+		"TK3L"
+	],
 	thirdParty: {
 		tcgplayer: 610
 	}

--- a/data/Trainer kits/DP trainer Kit (Manaphy).ts
+++ b/data/Trainer kits/DP trainer Kit (Manaphy).ts
@@ -23,6 +23,9 @@ const set: Set = {
 		official: "TK3M",
 		fr: "MAN"
 	},
+	searchAliases: [
+		"TK3M"
+	],
 	thirdParty: {
 		tcgplayer: 609
 	}

--- a/data/Trainer kits/EX trainer Kit (Latias).ts
+++ b/data/Trainer kits/EX trainer Kit (Latias).ts
@@ -24,6 +24,9 @@ const set: Set = {
 		official: "TK1A",
 		fr: "KDA"
 	},
+	searchAliases: [
+		"TK1A"
+	],
 
 	thirdParty: {
 		tcgplayer: 1543

--- a/data/Trainer kits/EX trainer Kit (Latios).ts
+++ b/data/Trainer kits/EX trainer Kit (Latios).ts
@@ -24,6 +24,9 @@ const set: Set = {
 		official: "TK1O",
 		fr: "KDL"
 	},
+	searchAliases: [
+		"TK1O"
+	],
 
 	thirdParty: {
 		tcgplayer: 1543

--- a/data/Trainer kits/EX trainer Kit 2 (Minun).ts
+++ b/data/Trainer kits/EX trainer Kit 2 (Minun).ts
@@ -23,6 +23,9 @@ const set: Set = {
 		official: "TK2M",
 		fr: "NEG"
 	},
+	searchAliases: [
+		"TK2M"
+	],
 
 	thirdParty: {
 		tcgplayer: 1542

--- a/data/Trainer kits/EX trainer Kit 2 (Plusle).ts
+++ b/data/Trainer kits/EX trainer Kit 2 (Plusle).ts
@@ -23,6 +23,9 @@ const set: Set = {
 		official: "TK2P",
 		fr: "POS"
 	},
+	searchAliases: [
+		"TK2P"
+	],
 
 	thirdParty: {
 		tcgplayer: 1542

--- a/data/Trainer kits/HS trainer Kit (Gyarados).ts
+++ b/data/Trainer kits/HS trainer Kit (Gyarados).ts
@@ -23,6 +23,9 @@ const set: Set = {
 		official: "TK4G",
 		fr: "LEV"
 	},
+	searchAliases: [
+		"TK4G"
+	],
 
 	thirdParty: {
 		tcgplayer: 1540

--- a/data/Trainer kits/HS trainer Kit (Raichu).ts
+++ b/data/Trainer kits/HS trainer Kit (Raichu).ts
@@ -23,6 +23,9 @@ const set: Set = {
 		official: "TK4R",
 		fr: "RAI"
 	},
+	searchAliases: [
+		"TK4R"
+	],
 
 	thirdParty: {
 		tcgplayer: 1540

--- a/data/Trainer kits/SM trainer Kit (Alolan Raichu).ts
+++ b/data/Trainer kits/SM trainer Kit (Alolan Raichu).ts
@@ -23,6 +23,9 @@ const set: Set = {
 		official: "TK10A",
 		fr: "RAL"
 	},
+	searchAliases: [
+		"TK10A"
+	],
 
 	thirdParty: {
 		tcgplayer: 2069

--- a/data/Trainer kits/SM trainer Kit (Lycanroc).ts
+++ b/data/Trainer kits/SM trainer Kit (Lycanroc).ts
@@ -23,6 +23,9 @@ const set: Set = {
 		official: "TK10L",
 		fr: "LOU"
 	},
+	searchAliases: [
+		"TK10L"
+	],
 
 	thirdParty: {
 		tcgplayer: 2069

--- a/data/Trainer kits/XY trainer Kit (Bisharp).ts
+++ b/data/Trainer kits/XY trainer Kit (Bisharp).ts
@@ -23,6 +23,9 @@ const set: Set = {
 		official: "TK7A",
 		fr: "SCA"
 	},
+	searchAliases: [
+		"TK7A"
+	],
 
 	thirdParty: {
 		tcgplayer: 1533

--- a/data/Trainer kits/XY trainer Kit (Latias).ts
+++ b/data/Trainer kits/XY trainer Kit (Latias).ts
@@ -23,6 +23,9 @@ const set: Set = {
 		official: "TK8A",
 		fr: "LTA"
 	},
+	searchAliases: [
+		"TK8A"
+	],
 
 	thirdParty: {
 		tcgplayer: 1536

--- a/data/Trainer kits/XY trainer Kit (Latios).ts
+++ b/data/Trainer kits/XY trainer Kit (Latios).ts
@@ -23,6 +23,9 @@ const set: Set = {
 		official: "TK8O",
 		fr: "LTS"
 	},
+	searchAliases: [
+		"TK8O"
+	],
 
 	thirdParty: {
 		tcgplayer: 1536

--- a/data/Trainer kits/XY trainer Kit (Noivern).ts
+++ b/data/Trainer kits/XY trainer Kit (Noivern).ts
@@ -23,6 +23,9 @@ const set: Set = {
 		official: "TK6N",
 		fr: "BRU"
 	},
+	searchAliases: [
+		"TK6N"
+	],
 
 	thirdParty: {
 		tcgplayer: 1532

--- a/data/Trainer kits/XY trainer Kit (Pikachu Libre).ts
+++ b/data/Trainer kits/XY trainer Kit (Pikachu Libre).ts
@@ -23,6 +23,9 @@ const set: Set = {
 		official: "TK9P",
 		fr: "PLB"
 	},
+	searchAliases: [
+		"TK9P"
+	],
 
 	thirdParty: {
 		tcgplayer: 1796

--- a/data/Trainer kits/XY trainer Kit (Suicune).ts
+++ b/data/Trainer kits/XY trainer Kit (Suicune).ts
@@ -23,6 +23,9 @@ const set: Set = {
 		official: "TK9S",
 		fr: "SUI"
 	},
+	searchAliases: [
+		"TK9S"
+	],
 
 	thirdParty: {
 		tcgplayer: 1796

--- a/data/Trainer kits/XY trainer Kit (Sylveon).ts
+++ b/data/Trainer kits/XY trainer Kit (Sylveon).ts
@@ -23,6 +23,9 @@ const set: Set = {
 		official: "TK6S",
 		fr: "NYM"
 	},
+	searchAliases: [
+		"TK6S"
+	],
 
 	thirdParty: {
 		tcgplayer: 1532

--- a/data/Trainer kits/XY trainer Kit (Wigglytuff).ts
+++ b/data/Trainer kits/XY trainer Kit (Wigglytuff).ts
@@ -23,6 +23,9 @@ const set: Set = {
 		official: "TK7B",
 		fr: "GRO"
 	},
+	searchAliases: [
+		"TK7B"
+	],
 
 	thirdParty: {
 		tcgplayer: 1533

--- a/data/XY/Ancient Origins.ts
+++ b/data/XY/Ancient Origins.ts
@@ -27,6 +27,9 @@ const xy7: Set = {
 		official: "AOR",
 		fr: "ORA"
 	},
+	searchAliases: [
+		"AOR"
+	],
 
 	thirdParty: {
 		cardmarket: 1660,

--- a/data/XY/BREAKpoint.ts
+++ b/data/XY/BREAKpoint.ts
@@ -26,6 +26,9 @@ const xy9: Set = {
 		official: "BKP",
 		fr: "RUP"
 	},
+	searchAliases: [
+		"BKP"
+	],
 
 	thirdParty: {
 		cardmarket: 1687,

--- a/data/XY/BREAKthrough.ts
+++ b/data/XY/BREAKthrough.ts
@@ -27,6 +27,9 @@ const xy8: Set = {
 		official: "BKT",
 		fr: "IMP"
 	},
+	searchAliases: [
+		"BKT"
+	],
 
 	thirdParty: {
 		cardmarket: 1678,

--- a/data/XY/Double Crisis.ts
+++ b/data/XY/Double Crisis.ts
@@ -23,6 +23,9 @@ const dc1: Set = {
 		official: "DCR",
 		fr: "DBD"
 	},
+	searchAliases: [
+		"DCR"
+	],
 
 	thirdParty: {
 		cardmarket: 1648,

--- a/data/XY/Evolutions.ts
+++ b/data/XY/Evolutions.ts
@@ -26,6 +26,9 @@ const xy12: Set = {
 		official: "EVO",
 		fr: "EVO"
 	},
+	searchAliases: [
+		"EVO"
+	],
 
 	thirdParty: {
 		cardmarket: 1742,

--- a/data/XY/Fates Collide.ts
+++ b/data/XY/Fates Collide.ts
@@ -26,6 +26,9 @@ const xy10: Set = {
 		official: "FCO",
 		fr: "IDD"
 	},
+	searchAliases: [
+		"FCO"
+	],
 
 	thirdParty: {
 		cardmarket: 1706,

--- a/data/XY/Flashfire.ts
+++ b/data/XY/Flashfire.ts
@@ -27,6 +27,9 @@ const xy2: Set = {
 		official: "FLF",
 		fr: "ETI"
 	},
+	searchAliases: [
+		"FLF"
+	],
 
 	thirdParty: {
 		cardmarket: 1583,

--- a/data/XY/Furious Fists.ts
+++ b/data/XY/Furious Fists.ts
@@ -27,6 +27,9 @@ const xy3: Set = {
 		official: "FFI",
 		fr: "PFU"
 	},
+	searchAliases: [
+		"FFI"
+	],
 
 	thirdParty: {
 		cardmarket: 1584,

--- a/data/XY/Generations.ts
+++ b/data/XY/Generations.ts
@@ -26,6 +26,9 @@ const g1: Set = {
 		official: "GEN",
 		fr: "GEN"
 	},
+	searchAliases: [
+		"GEN"
+	],
 
 	thirdParty: {
 		cardmarket: 1693,

--- a/data/XY/Kalos Starter Set.ts
+++ b/data/XY/Kalos Starter Set.ts
@@ -26,6 +26,9 @@ const xy0: Set = {
 		official: "KSS",
 		fr: "BAK"
 	},
+	searchAliases: [
+		"KSS"
+	],
 
 	thirdParty: {
 		cardmarket: 1637,

--- a/data/XY/Phantom Forces.ts
+++ b/data/XY/Phantom Forces.ts
@@ -27,6 +27,9 @@ const xy4: Set = {
 		official: "PHF",
 		fr: "VSP"
 	},
+	searchAliases: [
+		"PHF"
+	],
 
 	thirdParty: {
 		cardmarket: 1521,

--- a/data/XY/Primal Clash.ts
+++ b/data/XY/Primal Clash.ts
@@ -27,6 +27,9 @@ const xy5: Set = {
 		official: "PRC",
 		fr: "PRI"
 	},
+	searchAliases: [
+		"PRC"
+	],
 
 	thirdParty: {
 		cardmarket: 1585,

--- a/data/XY/Roaring Skies.ts
+++ b/data/XY/Roaring Skies.ts
@@ -27,6 +27,9 @@ const xy6: Set = {
 		official: "ROS",
 		fr: "CRU"
 	},
+	searchAliases: [
+		"ROS"
+	],
 
 	thirdParty: {
 		cardmarket: 1649,

--- a/data/XY/Steam Siege.ts
+++ b/data/XY/Steam Siege.ts
@@ -26,6 +26,9 @@ const xy11: Set = {
 		official: "STS",
 		fr: "OFV"
 	},
+	searchAliases: [
+		"STS"
+	],
 
 	thirdParty: {
 		cardmarket: 1716,

--- a/data/XY/XY Black Star Promos.ts
+++ b/data/XY/XY Black Star Promos.ts
@@ -25,6 +25,9 @@ const xyp: Set = {
 		official: 'XYP',
 		fr: "PXY"
 	},
+	searchAliases: [
+		"XYP"
+	],
 
 	thirdParty: {
 		cardmarket: 1612,

--- a/data/XY/XY.ts
+++ b/data/XY/XY.ts
@@ -27,6 +27,9 @@ const xy1: Set = {
 		official: "XY",
 		fr: "XY"
 	},
+	searchAliases: [
+		"XY"
+	],
 
 	thirdParty: {
 		cardmarket: 1582,

--- a/data/XY/Yellow A Alternate.ts
+++ b/data/XY/Yellow A Alternate.ts
@@ -20,6 +20,13 @@ const xya: Set = {
 
 	releaseDate: "2014-02-05",
 
+	abbreviations: {
+		official: "YAA"
+	},
+	searchAliases: [
+		"YAA"
+	],
+
 	thirdParty: {
 		tcgplayer: 1938
 	}

--- a/interfaces.d.ts
+++ b/interfaces.d.ts
@@ -60,7 +60,7 @@ interface variant_detailed {
 	 * - ace-trainer: a card that is stamped with a golden ACE TRAINER, won by getting 200 championship points in the season since 2025 season.
 	 * - player-rewards-program: a card that is stamped with the player reward logo, available in the yearly player rewards program (play! pokemon prize pack)
 	 */
-	stamp?: Array<'1st-edition' | 'w-promo' | 'pre-release' | 'pokemon-center' | 'set-logo' | 'staff' | 'pikachu-tail'
+	stamp?: Array<'1st-edition' | 'w-promo' | 'pre-release' | 'pokemon-center' | 'set-logo' | 'staff' | 'ace-trainer' | 'pikachu-tail'
 		| 'wotc' | 'd-edition-error' | '1st-edition-scratch-error' | "1st-edition-error" | '1st-movie' | '1st-movie-inverted'
 		| 'pokemon-4-ever' | 'pokemon-center-ny' | "winner" | '25th-celebration' | 'chris-fulop' | 'tsuguyoshi-yamato'
 		| 'reed-weichler' | 'kevin-nguyen' | 'professor-program' | 'takashi-yoneda' | 'michael-gonzalez' | 'curran-hill'
@@ -83,6 +83,19 @@ interface variant_detailed {
 	 */
 	foil?: 'pokeball' | 'greatball' | 'ultraball' | 'masterball' | 'gold' | 'cosmos' | 'galaxy' | 'starlight' | 'energy' | 'cracked-ice'
 	| 'mirror' | 'league' | 'player-reward' | 'professor-program'
+
+	/**
+	 * external identifiers for specific variants
+	 */
+	thirdParty?: {
+		cardmarket?: number
+		tcgplayer?: number
+	}
+
+	/**
+	 * explicit image for this variant
+	 */
+	image?: string
 
 	/**
 	 * list of languages for which this variant is available
@@ -139,15 +152,39 @@ export interface Set {
 	id: string
 	name: Languages
 	/**
+	 * Optional remote set logo URL used when the app has no bundled local asset.
+	 */
+	logo?: string
+	/**
+	 * Optional remote set symbol URL used when the app has no bundled local asset.
+	 */
+	symbol?: string
+	/**
 	 * Partial list of abbreviations, this is currently a Work in Progress feature
 	 */
 	abbreviations?: Partial<Omit<Languages, 'en'> & { official?: string }>
+	/**
+	 * Internal alias list used to resolve set searches without exposing extra
+	 * fields in API payloads.
+	 */
+	searchAliases?: Array<string>
 	serie: Serie
 	tcgOnline?: string
 
 	cardCount: {
 		official: number
 	}
+
+	/**
+	 * Subset numbering groups embedded in this set.
+	 * Key is a localId prefix such as RC, TG, GG, SV, SH.
+	 */
+	subsets?: Record<string, {
+		name?: Languages
+		cardCount: {
+			official: number
+		}
+	}>
 
 	boosters?: Record<string, {
 		name: Languages<string>
@@ -222,7 +259,10 @@ export interface Card {
 			'Shiny rare VMAX' | 'Special illustration rare' | 'Ultra Rare' | 'Uncommon'
 			// Black White rare
 			| 'Black White Rare'
+			// Black Star Promo
+			| 'Black Star Promo'
 			| 'Mega Hyper Rare'
+			| 'Mega Attack Rare'
 			// Pokémon TCG Pocket Rarities
 			| 'One Diamond' | 'Two Diamond' | 'Three Diamond' | 'Four Diamond' | 'One Star' | 'Two Star' | 'Three Star' | 'Crown' | 'One Shiny' | 'Two Shiny'
 

--- a/meta/definitions/api.d.ts
+++ b/meta/definitions/api.d.ts
@@ -57,11 +57,26 @@ interface variants {
 	wPromo?: boolean
 }
 
-interface variant_detailed {
+export interface variant_detailed {
 	type: string
 	size?: string
 	stamp?: Array<string>
 	foil?: string
+	thirdParty?: {
+		cardmarket?: number
+		tcgplayer?: number
+	}
+	image?: string
+}
+
+export interface SubsetCardCount {
+	official: number;
+}
+
+export interface SubsetInfo {
+	id: string;
+	name?: string;
+	cardCount: SubsetCardCount;
 }
 
 export interface SetResume {
@@ -79,13 +94,22 @@ export interface SetResume {
 		 */
 		official: number;
 	};
+	abbreviation?: {
+		official?: string;
+		localized?: string;
+	};
+	subsets?: Array<SubsetInfo>;
+	/**
+	 * Present on API payloads so GraphQL can resolve Set.serie on nested sets
+	 * (e.g. Card.set) without a separate field resolver.
+	 */
+	serie: SerieResume;
 }
 
 /**
  * /sets/:id
  */
 export interface Set extends SetResume {
-	serie: SerieResume;
 	tcgOnline?: string;
 	variants?: variants;
 	releaseDate: string;
@@ -137,7 +161,10 @@ export interface Set extends SetResume {
 		firstEd?: number;
 	};
 	cards: Array<CardResume>;
-	abbreviation: { official: string, localized: string };
+	abbreviation?: {
+		official?: string,
+		localized?: string
+	};
 	thirdParty?: {
 		cardmarket?: number
 		tcgplayer?: number
@@ -332,6 +359,28 @@ export interface Card extends CardResume {
 	 * the boosters in which the card is available
 	 */
 	boosters?: Array<Booster>
+
+	/**
+	 * The card set number that appears on the card (e.g. 065/162, GG12/GG30)
+	 */
+	set_number: {
+		/**
+		 * Full textual representation, including prefixes and denominator
+		 */
+		text: string
+		/**
+		 * The numerator portion (everything before a slash, or the whole text if there is no slash)
+		 */
+		nominator: string
+		/**
+		 * Parsed numeric component when available (e.g. 65 for 065, 12 for GG12/GG30)
+		 */
+		numeric?: number
+		/**
+		 * Denominator text (only present when the card number includes `/denominator`)
+		 */
+		denominator?: string
+	}
 
 	updated: string
 }

--- a/meta/set-alias-research.snapshot.json
+++ b/meta/set-alias-research.snapshot.json
@@ -1,0 +1,3239 @@
+{
+  "generatedAt": "2026-04-11",
+  "notes": [
+    "This snapshot records the disputed or non-obvious set-code mappings that were approved during the issue #1369 follow-up work.",
+    "Visible abbreviations stay in the existing abbreviation payload, while searchAliases carry extra lookup forms.",
+    "The backlog backfill records explicit source-backed searchAliases for files that previously relied only on derived runtime aliases."
+  ],
+  "entries": [
+    {
+      "id": "2011bw",
+      "file": "data/McDonald's Collection/McDonald's Collection 2011.ts",
+      "visible": {
+        "official": "MCD11",
+        "fr": "M11"
+      },
+      "searchAliases": [
+        "MCD11"
+      ],
+      "sources": [
+        "https://www.pokepedia.fr/Abr%C3%A9viation_d%27extension",
+        "https://pkmncards.com/advanced/"
+      ],
+      "reason": "Backlog backfill: expose the attested visible official abbreviation as an explicit source-backed search alias."
+    },
+    {
+      "id": "2012bw",
+      "file": "data/McDonald's Collection/McDonald's Collection 2012.ts",
+      "visible": {
+        "official": "MCD12",
+        "fr": "M12"
+      },
+      "searchAliases": [
+        "MCD12"
+      ],
+      "sources": [
+        "https://www.pokepedia.fr/Abr%C3%A9viation_d%27extension",
+        "https://pkmncards.com/advanced/"
+      ],
+      "reason": "Backlog backfill: expose the attested visible official abbreviation as an explicit source-backed search alias."
+    },
+    {
+      "id": "2013bw",
+      "file": "data/McDonald's Collection/Collection McDonald's 2013.ts",
+      "visible": {
+        "official": "MCD13"
+      },
+      "searchAliases": [
+        "MCD13"
+      ],
+      "sources": [
+        "https://www.pokepedia.fr/Abr%C3%A9viation_d%27extension",
+        "https://pkmncards.com/advanced/"
+      ],
+      "reason": "Backlog backfill: expose the attested visible official abbreviation as an explicit source-backed search alias."
+    },
+    {
+      "id": "2014xy",
+      "file": "data/McDonald's Collection/McDonald's Collection 2014.ts",
+      "visible": {
+        "official": "MCD14",
+        "fr": "M14"
+      },
+      "searchAliases": [
+        "MCD14"
+      ],
+      "sources": [
+        "https://www.pokepedia.fr/Abr%C3%A9viation_d%27extension",
+        "https://pkmncards.com/advanced/"
+      ],
+      "reason": "Backlog backfill: expose the attested visible official abbreviation as an explicit source-backed search alias."
+    },
+    {
+      "id": "2015xy",
+      "file": "data/McDonald's Collection/McDonald's Collection 2015.ts",
+      "visible": {
+        "official": "MCD15",
+        "fr": "M15"
+      },
+      "searchAliases": [
+        "MCD15"
+      ],
+      "sources": [
+        "https://www.pokepedia.fr/Abr%C3%A9viation_d%27extension",
+        "https://pkmncards.com/advanced/"
+      ],
+      "reason": "Backlog backfill: expose the attested visible official abbreviation as an explicit source-backed search alias."
+    },
+    {
+      "id": "2016xy",
+      "file": "data/McDonald's Collection/McDonald's Collection 2016.ts",
+      "visible": {
+        "official": "MCD16",
+        "fr": "M16"
+      },
+      "searchAliases": [
+        "MCD16"
+      ],
+      "sources": [
+        "https://www.pokepedia.fr/Abr%C3%A9viation_d%27extension",
+        "https://pkmncards.com/advanced/"
+      ],
+      "reason": "Backlog backfill: expose the attested visible official abbreviation as an explicit source-backed search alias."
+    },
+    {
+      "id": "2017sm",
+      "file": "data/McDonald's Collection/McDonald's Collection 2017.ts",
+      "visible": {
+        "official": "MCD17",
+        "fr": "M17"
+      },
+      "searchAliases": [
+        "MCD17"
+      ],
+      "sources": [
+        "https://www.pokepedia.fr/Abr%C3%A9viation_d%27extension",
+        "https://pkmncards.com/advanced/"
+      ],
+      "reason": "Backlog backfill: expose the attested visible official abbreviation as an explicit source-backed search alias."
+    },
+    {
+      "id": "2018sm",
+      "file": "data/McDonald's Collection/McDonald's Collection 2018.ts",
+      "visible": {
+        "official": "MCD18"
+      },
+      "searchAliases": [
+        "MCD18"
+      ],
+      "sources": [
+        "https://www.pokepedia.fr/Abr%C3%A9viation_d%27extension",
+        "https://pkmncards.com/advanced/"
+      ],
+      "reason": "Backlog backfill: expose the attested visible official abbreviation as an explicit source-backed search alias."
+    },
+    {
+      "id": "2018sm-fr",
+      "file": "data/McDonald's Collection/Collection McDonald's 2018.ts",
+      "visible": {
+        "official": "MCD18"
+      },
+      "searchAliases": [
+        "MCD18"
+      ],
+      "sources": [
+        "https://www.pokepedia.fr/Abr%C3%A9viation_d%27extension",
+        "https://pkmncards.com/advanced/"
+      ],
+      "reason": "Backlog backfill: expose the attested visible official abbreviation as an explicit source-backed search alias."
+    },
+    {
+      "id": "2019sm",
+      "file": "data/McDonald's Collection/McDonald's Collection 2019.ts",
+      "visible": {
+        "official": "MCD19"
+      },
+      "searchAliases": [
+        "MCD19"
+      ],
+      "sources": [
+        "https://www.pokepedia.fr/Abr%C3%A9viation_d%27extension",
+        "https://pkmncards.com/advanced/"
+      ],
+      "reason": "Backlog backfill: expose the attested visible official abbreviation as an explicit source-backed search alias."
+    },
+    {
+      "id": "2019sm-fr",
+      "file": "data/McDonald's Collection/Collection McDonald's 2019.ts",
+      "visible": {
+        "official": "MCD19"
+      },
+      "searchAliases": [
+        "MCD19"
+      ],
+      "sources": [
+        "https://www.pokepedia.fr/Abr%C3%A9viation_d%27extension",
+        "https://pkmncards.com/advanced/"
+      ],
+      "reason": "Backlog backfill: expose the attested visible official abbreviation as an explicit source-backed search alias."
+    },
+    {
+      "id": "2021swsh",
+      "file": "data/McDonald's Collection/McDonald's Collection 2021.ts",
+      "visible": {
+        "official": "MCD21",
+        "fr": "M21"
+      },
+      "searchAliases": [
+        "MCD21"
+      ],
+      "sources": [
+        "https://www.pokepedia.fr/Abr%C3%A9viation_d%27extension",
+        "https://pkmncards.com/advanced/"
+      ],
+      "reason": "Backlog backfill: expose the attested visible official abbreviation as an explicit source-backed search alias."
+    },
+    {
+      "id": "2022swsh",
+      "file": "data/McDonald's Collection/McDonald's Collection 2022.ts",
+      "visible": {
+        "official": "MCD22",
+        "fr": "M22"
+      },
+      "searchAliases": [
+        "MCD22"
+      ],
+      "sources": [
+        "https://www.pokepedia.fr/Abr%C3%A9viation_d%27extension",
+        "https://pkmncards.com/advanced/"
+      ],
+      "reason": "Backlog backfill: expose the attested visible official abbreviation as an explicit source-backed search alias."
+    },
+    {
+      "id": "2023sv",
+      "file": "data/McDonald's Collection/McDonald's Collection 2023.ts",
+      "visible": {
+        "official": "MCD23",
+        "fr": "M23"
+      },
+      "searchAliases": [
+        "MCD23"
+      ],
+      "sources": [
+        "https://www.pokepedia.fr/Abr%C3%A9viation_d%27extension",
+        "https://pkmncards.com/advanced/"
+      ],
+      "reason": "Backlog backfill: expose the attested visible official abbreviation as an explicit source-backed search alias."
+    },
+    {
+      "id": "2024sv",
+      "file": "data/McDonald's Collection/McDonald's Collection 2024.ts",
+      "visible": {
+        "official": "MCD24",
+        "fr": "M24"
+      },
+      "searchAliases": [
+        "MCD24"
+      ],
+      "sources": [
+        "https://www.pokepedia.fr/Abr%C3%A9viation_d%27extension",
+        "https://pkmncards.com/advanced/"
+      ],
+      "reason": "Backlog backfill: expose the attested visible official abbreviation as an explicit source-backed search alias."
+    },
+    {
+      "id": "A1",
+      "file": "data/Pokémon TCG Pocket/Genetic Apex.ts",
+      "visible": {
+        "official": "A1"
+      },
+      "searchAliases": [
+        "A1"
+      ],
+      "sources": [
+        "https://bulbapedia.bulbagarden.net/wiki/List_of_Pok%C3%A9mon_Trading_Card_Game_Pocket_expansions"
+      ],
+      "reason": "Backlog backfill: expose the attested visible official abbreviation as an explicit source-backed search alias."
+    },
+    {
+      "id": "A1a",
+      "file": "data/Pokémon TCG Pocket/Mythical Island.ts",
+      "visible": {
+        "official": "A1a"
+      },
+      "searchAliases": [
+        "A1a"
+      ],
+      "sources": [
+        "https://bulbapedia.bulbagarden.net/wiki/List_of_Pok%C3%A9mon_Trading_Card_Game_Pocket_expansions"
+      ],
+      "reason": "Backlog backfill: expose the attested visible official abbreviation as an explicit source-backed search alias."
+    },
+    {
+      "id": "A2",
+      "file": "data/Pokémon TCG Pocket/Space-Time Smackdown.ts",
+      "visible": {
+        "official": "A2"
+      },
+      "searchAliases": [
+        "A2"
+      ],
+      "sources": [
+        "https://bulbapedia.bulbagarden.net/wiki/List_of_Pok%C3%A9mon_Trading_Card_Game_Pocket_expansions"
+      ],
+      "reason": "Backlog backfill: expose the attested visible official abbreviation as an explicit source-backed search alias."
+    },
+    {
+      "id": "A2a",
+      "file": "data/Pokémon TCG Pocket/Triumphant Light.ts",
+      "visible": {
+        "official": "A2a"
+      },
+      "searchAliases": [
+        "A2a"
+      ],
+      "sources": [
+        "https://bulbapedia.bulbagarden.net/wiki/List_of_Pok%C3%A9mon_Trading_Card_Game_Pocket_expansions"
+      ],
+      "reason": "Backlog backfill: expose the attested visible official abbreviation as an explicit source-backed search alias."
+    },
+    {
+      "id": "A2b",
+      "file": "data/Pokémon TCG Pocket/Shining Revelry.ts",
+      "visible": {
+        "official": "A2b"
+      },
+      "searchAliases": [
+        "A2b"
+      ],
+      "sources": [
+        "https://bulbapedia.bulbagarden.net/wiki/List_of_Pok%C3%A9mon_Trading_Card_Game_Pocket_expansions"
+      ],
+      "reason": "Backlog backfill: expose the attested visible official abbreviation as an explicit source-backed search alias."
+    },
+    {
+      "id": "A3",
+      "file": "data/Pokémon TCG Pocket/Celestial Guardians.ts",
+      "visible": {
+        "official": "A3"
+      },
+      "searchAliases": [
+        "A3"
+      ],
+      "sources": [
+        "https://bulbapedia.bulbagarden.net/wiki/List_of_Pok%C3%A9mon_Trading_Card_Game_Pocket_expansions"
+      ],
+      "reason": "Backlog backfill: expose the attested visible official abbreviation as an explicit source-backed search alias."
+    },
+    {
+      "id": "A3a",
+      "file": "data/Pokémon TCG Pocket/Extradimensional Crisis.ts",
+      "visible": {
+        "official": "A3a"
+      },
+      "searchAliases": [
+        "A3a"
+      ],
+      "sources": [
+        "https://bulbapedia.bulbagarden.net/wiki/List_of_Pok%C3%A9mon_Trading_Card_Game_Pocket_expansions"
+      ],
+      "reason": "Backlog backfill: expose the attested visible official abbreviation as an explicit source-backed search alias."
+    },
+    {
+      "id": "A3b",
+      "file": "data/Pokémon TCG Pocket/Eevee Grove.ts",
+      "visible": {
+        "official": "A3b"
+      },
+      "searchAliases": [
+        "A3b"
+      ],
+      "sources": [
+        "https://bulbapedia.bulbagarden.net/wiki/List_of_Pok%C3%A9mon_Trading_Card_Game_Pocket_expansions"
+      ],
+      "reason": "Backlog backfill: expose the attested visible official abbreviation as an explicit source-backed search alias."
+    },
+    {
+      "id": "A4",
+      "file": "data/Pokémon TCG Pocket/Wisdom of Sea and Sky.ts",
+      "visible": {
+        "official": "A4"
+      },
+      "searchAliases": [
+        "A4"
+      ],
+      "sources": [
+        "https://bulbapedia.bulbagarden.net/wiki/List_of_Pok%C3%A9mon_Trading_Card_Game_Pocket_expansions"
+      ],
+      "reason": "Backlog backfill: expose the attested visible official abbreviation as an explicit source-backed search alias."
+    },
+    {
+      "id": "A4a",
+      "file": "data/Pokémon TCG Pocket/Secluded Springs.ts",
+      "visible": {
+        "official": "A4a"
+      },
+      "searchAliases": [
+        "A4a"
+      ],
+      "sources": [
+        "https://bulbapedia.bulbagarden.net/wiki/List_of_Pok%C3%A9mon_Trading_Card_Game_Pocket_expansions"
+      ],
+      "reason": "Backlog backfill: expose the attested visible official abbreviation as an explicit source-backed search alias."
+    },
+    {
+      "id": "B1",
+      "file": "data/Pokémon TCG Pocket/Mega Rising.ts",
+      "visible": {
+        "official": "B1"
+      },
+      "searchAliases": [
+        "B1"
+      ],
+      "sources": [
+        "https://bulbapedia.bulbagarden.net/wiki/List_of_Pok%C3%A9mon_Trading_Card_Game_Pocket_expansions"
+      ],
+      "reason": "Backlog backfill: expose the attested visible official abbreviation as an explicit source-backed search alias."
+    },
+    {
+      "id": "B1a",
+      "file": "data/Pokémon TCG Pocket/Crimson Blaze.ts",
+      "visible": {
+        "official": "B1a"
+      },
+      "searchAliases": [
+        "B1a"
+      ],
+      "sources": [
+        "https://bulbapedia.bulbagarden.net/wiki/List_of_Pok%C3%A9mon_Trading_Card_Game_Pocket_expansions"
+      ],
+      "reason": "Backlog backfill: expose the attested visible official abbreviation as an explicit source-backed search alias."
+    },
+    {
+      "id": "B2",
+      "file": "data/Pokémon TCG Pocket/Fantastical Parade.ts",
+      "visible": {
+        "official": "B2"
+      },
+      "searchAliases": [
+        "B2"
+      ],
+      "sources": [
+        "https://bulbapedia.bulbagarden.net/wiki/List_of_Pok%C3%A9mon_Trading_Card_Game_Pocket_expansions"
+      ],
+      "reason": "Backlog backfill: expose the attested visible official abbreviation as an explicit source-backed search alias."
+    },
+    {
+      "id": "B2a",
+      "file": "data/Pokémon TCG Pocket/Paldean Wonders.ts",
+      "visible": {
+        "official": "B2a"
+      },
+      "searchAliases": [
+        "B2a"
+      ],
+      "sources": [
+        "https://bulbapedia.bulbagarden.net/wiki/List_of_Pok%C3%A9mon_Trading_Card_Game_Pocket_expansions"
+      ],
+      "reason": "Backlog backfill: expose the attested visible official abbreviation as an explicit source-backed search alias."
+    },
+    {
+      "id": "P-A",
+      "file": "data/Pokémon TCG Pocket/Promos-A.ts",
+      "visible": {
+        "official": "P-A"
+      },
+      "searchAliases": [
+        "P-A"
+      ],
+      "sources": [
+        "https://bulbapedia.bulbagarden.net/wiki/List_of_Pok%C3%A9mon_Trading_Card_Game_Pocket_expansions"
+      ],
+      "reason": "Backlog backfill: expose the attested visible official abbreviation as an explicit source-backed search alias."
+    },
+    {
+      "id": "base1",
+      "file": "data/Base/Base Set.ts",
+      "visible": {
+        "official": "BS",
+        "fr": "BAS"
+      },
+      "searchAliases": [
+        "BS"
+      ],
+      "sources": [
+        "https://www.pokepedia.fr/Abr%C3%A9viation_d%27extension"
+      ],
+      "reason": "Backlog backfill: expose the attested visible official abbreviation as an explicit source-backed search alias."
+    },
+    {
+      "id": "base2",
+      "file": "data/Base/Jungle.ts",
+      "visible": {
+        "official": "JU",
+        "fr": "JUN"
+      },
+      "searchAliases": [
+        "JU"
+      ],
+      "sources": [
+        "https://www.pokepedia.fr/Abr%C3%A9viation_d%27extension"
+      ],
+      "reason": "Backlog backfill: expose the attested visible official abbreviation as an explicit source-backed search alias."
+    },
+    {
+      "id": "base3",
+      "file": "data/Base/Fossil.ts",
+      "visible": {
+        "official": "FO",
+        "fr": "FOS"
+      },
+      "searchAliases": [
+        "FO"
+      ],
+      "sources": [
+        "https://www.pokepedia.fr/Abr%C3%A9viation_d%27extension"
+      ],
+      "reason": "Backlog backfill: expose the attested visible official abbreviation as an explicit source-backed search alias."
+    },
+    {
+      "id": "base4",
+      "file": "data/Base/Base Set 2.ts",
+      "visible": {
+        "official": "B2"
+      },
+      "searchAliases": [
+        "B2"
+      ],
+      "sources": [
+        "https://www.pokepedia.fr/Abr%C3%A9viation_d%27extension"
+      ],
+      "reason": "Backlog backfill: expose the attested visible official abbreviation as an explicit source-backed search alias."
+    },
+    {
+      "id": "base5",
+      "file": "data/Base/Team Rocket.ts",
+      "visible": {
+        "official": "RO",
+        "fr": "ROC"
+      },
+      "searchAliases": [
+        "RO"
+      ],
+      "sources": [
+        "https://www.pokepedia.fr/Abr%C3%A9viation_d%27extension"
+      ],
+      "reason": "Backlog backfill: expose the attested visible official abbreviation as an explicit source-backed search alias."
+    },
+    {
+      "id": "basep",
+      "file": "data/Base/Wizards Black Star Promos.ts",
+      "visible": {
+        "official": "WP"
+      },
+      "searchAliases": [
+        "WP"
+      ],
+      "sources": [
+        "https://www.pokepedia.fr/Abr%C3%A9viation_d%27extension"
+      ],
+      "reason": "Backlog backfill: expose the attested visible official abbreviation as an explicit source-backed search alias."
+    },
+    {
+      "id": "bog",
+      "file": "data/E-Card/Best of game.ts",
+      "visible": {
+        "official": "BG"
+      },
+      "searchAliases": [
+        "BG"
+      ],
+      "sources": [
+        "https://www.pokepedia.fr/Abr%C3%A9viation_d%27extension"
+      ],
+      "reason": "Backlog backfill: expose the attested visible official abbreviation as an explicit source-backed search alias."
+    },
+    {
+      "id": "bw1",
+      "file": "data/Black & White/Black & White.ts",
+      "visible": {
+        "official": "BLW",
+        "fr": "N&B"
+      },
+      "searchAliases": [
+        "BLW"
+      ],
+      "sources": [
+        "https://www.pokepedia.fr/Abr%C3%A9viation_d%27extension"
+      ],
+      "reason": "Backlog backfill: expose the attested visible official abbreviation as an explicit source-backed search alias."
+    },
+    {
+      "id": "bw10",
+      "file": "data/Black & White/Plasma Blast.ts",
+      "visible": {
+        "official": "PLB",
+        "fr": "EPL"
+      },
+      "searchAliases": [
+        "PLB"
+      ],
+      "sources": [
+        "https://www.pokepedia.fr/Abr%C3%A9viation_d%27extension"
+      ],
+      "reason": "Backlog backfill: expose the attested visible official abbreviation as an explicit source-backed search alias."
+    },
+    {
+      "id": "bw11",
+      "file": "data/Black & White/Legendary Treasures.ts",
+      "visible": {
+        "official": "LTR"
+      },
+      "searchAliases": [
+        "LTR"
+      ],
+      "sources": [
+        "https://www.pokepedia.fr/Abr%C3%A9viation_d%27extension"
+      ],
+      "reason": "Backlog backfill: expose the attested visible official abbreviation as an explicit source-backed search alias."
+    },
+    {
+      "id": "bw2",
+      "file": "data/Black & White/Emerging Powers.ts",
+      "visible": {
+        "official": "EP",
+        "fr": "PEM"
+      },
+      "searchAliases": [
+        "EP"
+      ],
+      "sources": [
+        "https://www.pokepedia.fr/Abr%C3%A9viation_d%27extension"
+      ],
+      "reason": "Backlog backfill: expose the attested visible official abbreviation as an explicit source-backed search alias."
+    },
+    {
+      "id": "bw3",
+      "file": "data/Black & White/Noble Victories.ts",
+      "visible": {
+        "official": "NVI",
+        "fr": "NVI"
+      },
+      "searchAliases": [
+        "NVI"
+      ],
+      "sources": [
+        "https://www.pokepedia.fr/Abr%C3%A9viation_d%27extension"
+      ],
+      "reason": "Backlog backfill: expose the attested visible official abbreviation as an explicit source-backed search alias."
+    },
+    {
+      "id": "bw4",
+      "file": "data/Black & White/Next Destinies.ts",
+      "visible": {
+        "official": "NXD",
+        "fr": "DFU"
+      },
+      "searchAliases": [
+        "NXD"
+      ],
+      "sources": [
+        "https://www.pokepedia.fr/Abr%C3%A9viation_d%27extension"
+      ],
+      "reason": "Backlog backfill: expose the attested visible official abbreviation as an explicit source-backed search alias."
+    },
+    {
+      "id": "bw5",
+      "file": "data/Black & White/Dark Explorers.ts",
+      "visible": {
+        "official": "DEX",
+        "fr": "EOB"
+      },
+      "searchAliases": [
+        "DEX"
+      ],
+      "sources": [
+        "https://www.pokepedia.fr/Abr%C3%A9viation_d%27extension"
+      ],
+      "reason": "Backlog backfill: expose the attested visible official abbreviation as an explicit source-backed search alias."
+    },
+    {
+      "id": "bw6",
+      "file": "data/Black & White/Dragons Exalted.ts",
+      "visible": {
+        "official": "DRX",
+        "fr": "DEX"
+      },
+      "searchAliases": [
+        "DRX"
+      ],
+      "sources": [
+        "https://www.pokepedia.fr/Abr%C3%A9viation_d%27extension"
+      ],
+      "reason": "Backlog backfill: expose the attested visible official abbreviation as an explicit source-backed search alias."
+    },
+    {
+      "id": "bw7",
+      "file": "data/Black & White/Boundaries Crossed.ts",
+      "visible": {
+        "official": "BCR",
+        "fr": "FFR"
+      },
+      "searchAliases": [
+        "BCR"
+      ],
+      "sources": [
+        "https://www.pokepedia.fr/Abr%C3%A9viation_d%27extension"
+      ],
+      "reason": "Backlog backfill: expose the attested visible official abbreviation as an explicit source-backed search alias."
+    },
+    {
+      "id": "bw8",
+      "file": "data/Black & White/Plasma Storm.ts",
+      "visible": {
+        "official": "PLS"
+      },
+      "searchAliases": [
+        "PLS"
+      ],
+      "sources": [
+        "https://www.pokepedia.fr/Abr%C3%A9viation_d%27extension"
+      ],
+      "reason": "Backlog backfill: expose the attested visible official abbreviation as an explicit source-backed search alias."
+    },
+    {
+      "id": "bw9",
+      "file": "data/Black & White/Plasma Freeze.ts",
+      "visible": {
+        "official": "PLF",
+        "fr": "GPL"
+      },
+      "searchAliases": [
+        "PLF"
+      ],
+      "sources": [
+        "https://www.pokepedia.fr/Abr%C3%A9viation_d%27extension"
+      ],
+      "reason": "Backlog backfill: expose the attested visible official abbreviation as an explicit source-backed search alias."
+    },
+    {
+      "id": "bwp",
+      "file": "data/Black & White/BW Black Star Promos.ts",
+      "visible": {
+        "official": "BWP",
+        "fr": "PBW"
+      },
+      "searchAliases": [
+        "BWP"
+      ],
+      "sources": [
+        "https://www.pokepedia.fr/Abr%C3%A9viation_d%27extension"
+      ],
+      "reason": "Backlog backfill: expose the attested visible official abbreviation as an explicit source-backed search alias."
+    },
+    {
+      "id": "cel25",
+      "file": "data/Sword & Shield/Celebrations.ts",
+      "visible": {
+        "official": "CEL",
+        "fr": "EB07.5"
+      },
+      "searchAliases": [
+        "SWSH7.5"
+      ],
+      "sources": [
+        "https://www.pokepedia.fr/Abr%C3%A9viation_d%27extension",
+        "https://pkmncards.com/advanced/"
+      ],
+      "reason": "Backlog backfill: expose the attested visible official abbreviation as an explicit source-backed search alias."
+    },
+    {
+      "id": "col1",
+      "file": "data/Call of Legends/Call of Legends.ts",
+      "visible": {
+        "official": "COL",
+        "fr": "LDL"
+      },
+      "searchAliases": [
+        "COL"
+      ],
+      "sources": [
+        "https://www.pokepedia.fr/Abr%C3%A9viation_d%27extension"
+      ],
+      "reason": "Backlog backfill: expose the attested visible official abbreviation as an explicit source-backed search alias."
+    },
+    {
+      "id": "dc1",
+      "file": "data/XY/Double Crisis.ts",
+      "visible": {
+        "official": "DCR",
+        "fr": "DBD"
+      },
+      "searchAliases": [
+        "DCR"
+      ],
+      "sources": [
+        "https://www.pokepedia.fr/Abr%C3%A9viation_d%27extension",
+        "https://pkmncards.com/advanced/"
+      ],
+      "reason": "Backlog backfill: expose the attested visible official abbreviation as an explicit source-backed search alias."
+    },
+    {
+      "id": "det1",
+      "file": "data/Sun & Moon/Detective Pikachu.ts",
+      "visible": {
+        "official": "DET",
+        "fr": "DPI"
+      },
+      "searchAliases": [
+        "DET"
+      ],
+      "sources": [
+        "https://www.pokepedia.fr/Abr%C3%A9viation_d%27extension",
+        "https://pkmncards.com/advanced/"
+      ],
+      "reason": "Backlog backfill: expose the attested visible official abbreviation as an explicit source-backed search alias."
+    },
+    {
+      "id": "dp1",
+      "file": "data/Diamond & Pearl/Diamond & Pearl.ts",
+      "visible": {
+        "official": "DP",
+        "fr": "D&P"
+      },
+      "searchAliases": [
+        "DP"
+      ],
+      "sources": [
+        "https://www.pokepedia.fr/Abr%C3%A9viation_d%27extension"
+      ],
+      "reason": "Backlog backfill: expose the attested visible official abbreviation as an explicit source-backed search alias."
+    },
+    {
+      "id": "dp2",
+      "file": "data/Diamond & Pearl/Mysterious Treasures.ts",
+      "visible": {
+        "official": "MT",
+        "fr": "TMY"
+      },
+      "searchAliases": [
+        "MT"
+      ],
+      "sources": [
+        "https://www.pokepedia.fr/Abr%C3%A9viation_d%27extension"
+      ],
+      "reason": "Backlog backfill: expose the attested visible official abbreviation as an explicit source-backed search alias."
+    },
+    {
+      "id": "dp3",
+      "file": "data/Diamond & Pearl/Secret Wonders.ts",
+      "visible": {
+        "official": "SW",
+        "fr": "MSQ"
+      },
+      "searchAliases": [
+        "SW"
+      ],
+      "sources": [
+        "https://www.pokepedia.fr/Abr%C3%A9viation_d%27extension"
+      ],
+      "reason": "Backlog backfill: expose the attested visible official abbreviation as an explicit source-backed search alias."
+    },
+    {
+      "id": "dp4",
+      "file": "data/Diamond & Pearl/Great Encounters.ts",
+      "visible": {
+        "official": "GE",
+        "fr": "DAS"
+      },
+      "searchAliases": [
+        "GE"
+      ],
+      "sources": [
+        "https://www.pokepedia.fr/Abr%C3%A9viation_d%27extension"
+      ],
+      "reason": "Backlog backfill: expose the attested visible official abbreviation as an explicit source-backed search alias."
+    },
+    {
+      "id": "dp5",
+      "file": "data/Diamond & Pearl/Majestic Dawn.ts",
+      "visible": {
+        "official": "MD",
+        "fr": "AMJ"
+      },
+      "searchAliases": [
+        "MD"
+      ],
+      "sources": [
+        "https://www.pokepedia.fr/Abr%C3%A9viation_d%27extension"
+      ],
+      "reason": "Backlog backfill: expose the attested visible official abbreviation as an explicit source-backed search alias."
+    },
+    {
+      "id": "dp6",
+      "file": "data/Diamond & Pearl/Legends Awakened.ts",
+      "visible": {
+        "official": "LA",
+        "fr": "EDL"
+      },
+      "searchAliases": [
+        "LA"
+      ],
+      "sources": [
+        "https://www.pokepedia.fr/Abr%C3%A9viation_d%27extension"
+      ],
+      "reason": "Backlog backfill: expose the attested visible official abbreviation as an explicit source-backed search alias."
+    },
+    {
+      "id": "dp7",
+      "file": "data/Diamond & Pearl/Stormfront.ts",
+      "visible": {
+        "official": "SF",
+        "fr": "TEM"
+      },
+      "searchAliases": [
+        "SF"
+      ],
+      "sources": [
+        "https://www.pokepedia.fr/Abr%C3%A9viation_d%27extension"
+      ],
+      "reason": "Backlog backfill: expose the attested visible official abbreviation as an explicit source-backed search alias."
+    },
+    {
+      "id": "dpp",
+      "file": "data/Diamond & Pearl/DP Black Star Promos.ts",
+      "visible": {
+        "official": "DPP"
+      },
+      "searchAliases": [
+        "DPP"
+      ],
+      "sources": [
+        "https://www.pokepedia.fr/Abr%C3%A9viation_d%27extension"
+      ],
+      "reason": "Backlog backfill: expose the attested visible official abbreviation as an explicit source-backed search alias."
+    },
+    {
+      "id": "dv1",
+      "file": "data/Black & White/Dragon Vault.ts",
+      "visible": {
+        "official": "DRV",
+        "fr": "CDR"
+      },
+      "searchAliases": [
+        "DRV"
+      ],
+      "sources": [
+        "https://www.pokepedia.fr/Abr%C3%A9viation_d%27extension"
+      ],
+      "reason": "Backlog backfill: expose the attested visible official abbreviation as an explicit source-backed search alias."
+    },
+    {
+      "id": "ecard1",
+      "file": "data/E-Card/Expedition Base Set.ts",
+      "visible": {
+        "official": "EX",
+        "fr": "EXP"
+      },
+      "searchAliases": [
+        "EX"
+      ],
+      "sources": [
+        "https://www.pokepedia.fr/Abr%C3%A9viation_d%27extension"
+      ],
+      "reason": "Backlog backfill: expose the attested visible official abbreviation as an explicit source-backed search alias."
+    },
+    {
+      "id": "ecard2",
+      "file": "data/E-Card/Aquapolis.ts",
+      "visible": {
+        "official": "AQ",
+        "fr": "AQU"
+      },
+      "searchAliases": [
+        "AQ"
+      ],
+      "sources": [
+        "https://www.pokepedia.fr/Abr%C3%A9viation_d%27extension"
+      ],
+      "reason": "Backlog backfill: expose the attested visible official abbreviation as an explicit source-backed search alias."
+    },
+    {
+      "id": "ecard3",
+      "file": "data/E-Card/Skyridge.ts",
+      "visible": {
+        "official": "SK"
+      },
+      "searchAliases": [
+        "SK"
+      ],
+      "sources": [
+        "https://www.pokepedia.fr/Abr%C3%A9viation_d%27extension"
+      ],
+      "reason": "Backlog backfill: expose the attested visible official abbreviation as an explicit source-backed search alias."
+    },
+    {
+      "id": "ex1",
+      "file": "data/EX/Ruby & Sapphire.ts",
+      "visible": {
+        "official": "RS",
+        "fr": "R&S"
+      },
+      "searchAliases": [
+        "RS"
+      ],
+      "sources": [
+        "https://www.pokepedia.fr/Abr%C3%A9viation_d%27extension"
+      ],
+      "reason": "Backlog backfill: expose the attested visible official abbreviation as an explicit source-backed search alias."
+    },
+    {
+      "id": "ex10",
+      "file": "data/EX/Unseen Forces.ts",
+      "visible": {
+        "official": "UF",
+        "fr": "FCH"
+      },
+      "searchAliases": [
+        "UF"
+      ],
+      "sources": [
+        "https://www.pokepedia.fr/Abr%C3%A9viation_d%27extension"
+      ],
+      "reason": "Backlog backfill: expose the attested visible official abbreviation as an explicit source-backed search alias."
+    },
+    {
+      "id": "ex11",
+      "file": "data/EX/Delta Species.ts",
+      "visible": {
+        "official": "DS",
+        "fr": "ESD"
+      },
+      "searchAliases": [
+        "DS"
+      ],
+      "sources": [
+        "https://www.pokepedia.fr/Abr%C3%A9viation_d%27extension"
+      ],
+      "reason": "Backlog backfill: expose the attested visible official abbreviation as an explicit source-backed search alias."
+    },
+    {
+      "id": "ex12",
+      "file": "data/EX/Legend Maker.ts",
+      "visible": {
+        "official": "LM",
+        "fr": "CDL"
+      },
+      "searchAliases": [
+        "LM"
+      ],
+      "sources": [
+        "https://www.pokepedia.fr/Abr%C3%A9viation_d%27extension"
+      ],
+      "reason": "Backlog backfill: expose the attested visible official abbreviation as an explicit source-backed search alias."
+    },
+    {
+      "id": "ex13",
+      "file": "data/EX/Holon Phantoms.ts",
+      "visible": {
+        "official": "HP",
+        "fr": "FAN"
+      },
+      "searchAliases": [
+        "HP"
+      ],
+      "sources": [
+        "https://www.pokepedia.fr/Abr%C3%A9viation_d%27extension"
+      ],
+      "reason": "Backlog backfill: expose the attested visible official abbreviation as an explicit source-backed search alias."
+    },
+    {
+      "id": "ex14",
+      "file": "data/EX/Crystal Guardians.ts",
+      "visible": {
+        "official": "CG",
+        "fr": "GDC"
+      },
+      "searchAliases": [
+        "CG"
+      ],
+      "sources": [
+        "https://www.pokepedia.fr/Abr%C3%A9viation_d%27extension"
+      ],
+      "reason": "Backlog backfill: expose the attested visible official abbreviation as an explicit source-backed search alias."
+    },
+    {
+      "id": "ex15",
+      "file": "data/EX/Dragon Frontiers.ts",
+      "visible": {
+        "official": "DF",
+        "fr": "IDR"
+      },
+      "searchAliases": [
+        "DF"
+      ],
+      "sources": [
+        "https://www.pokepedia.fr/Abr%C3%A9viation_d%27extension"
+      ],
+      "reason": "Backlog backfill: expose the attested visible official abbreviation as an explicit source-backed search alias."
+    },
+    {
+      "id": "ex16",
+      "file": "data/EX/Power Keepers.ts",
+      "visible": {
+        "official": "PK",
+        "fr": "GDP"
+      },
+      "searchAliases": [
+        "PK"
+      ],
+      "sources": [
+        "https://www.pokepedia.fr/Abr%C3%A9viation_d%27extension"
+      ],
+      "reason": "Backlog backfill: expose the attested visible official abbreviation as an explicit source-backed search alias."
+    },
+    {
+      "id": "ex2",
+      "file": "data/EX/Sandstorm.ts",
+      "visible": {
+        "official": "SS",
+        "fr": "TES"
+      },
+      "searchAliases": [
+        "SS"
+      ],
+      "sources": [
+        "https://www.pokepedia.fr/Abr%C3%A9viation_d%27extension"
+      ],
+      "reason": "Backlog backfill: expose the attested visible official abbreviation as an explicit source-backed search alias."
+    },
+    {
+      "id": "ex3",
+      "file": "data/EX/Dragon.ts",
+      "visible": {
+        "official": "DR",
+        "fr": "DRG"
+      },
+      "searchAliases": [
+        "DR"
+      ],
+      "sources": [
+        "https://www.pokepedia.fr/Abr%C3%A9viation_d%27extension"
+      ],
+      "reason": "Backlog backfill: expose the attested visible official abbreviation as an explicit source-backed search alias."
+    },
+    {
+      "id": "ex4",
+      "file": "data/EX/Team Magma vs Team Aqua.ts",
+      "visible": {
+        "official": "MA",
+        "fr": "M&A"
+      },
+      "searchAliases": [
+        "MA"
+      ],
+      "sources": [
+        "https://www.pokepedia.fr/Abr%C3%A9viation_d%27extension"
+      ],
+      "reason": "Backlog backfill: expose the attested visible official abbreviation as an explicit source-backed search alias."
+    },
+    {
+      "id": "ex5",
+      "file": "data/EX/Hidden Legends.ts",
+      "visible": {
+        "official": "HL",
+        "fr": "LOU"
+      },
+      "searchAliases": [
+        "HL"
+      ],
+      "sources": [
+        "https://www.pokepedia.fr/Abr%C3%A9viation_d%27extension"
+      ],
+      "reason": "Backlog backfill: expose the attested visible official abbreviation as an explicit source-backed search alias."
+    },
+    {
+      "id": "ex5.5",
+      "file": "data/EX/Poké Card Creator Pack.ts",
+      "visible": {
+        "official": "CC"
+      },
+      "searchAliases": [
+        "CC"
+      ],
+      "sources": [
+        "https://www.pokepedia.fr/Abr%C3%A9viation_d%27extension"
+      ],
+      "reason": "Backlog backfill: expose the attested visible official abbreviation as an explicit source-backed search alias."
+    },
+    {
+      "id": "ex6",
+      "file": "data/EX/FireRed & LeafGreen.ts",
+      "visible": {
+        "official": "RG",
+        "fr": "RFV"
+      },
+      "searchAliases": [
+        "RG"
+      ],
+      "sources": [
+        "https://www.pokepedia.fr/Abr%C3%A9viation_d%27extension"
+      ],
+      "reason": "Backlog backfill: expose the attested visible official abbreviation as an explicit source-backed search alias."
+    },
+    {
+      "id": "ex7",
+      "file": "data/EX/Team Rocket Returns.ts",
+      "visible": {
+        "official": "TR"
+      },
+      "searchAliases": [
+        "TR"
+      ],
+      "sources": [
+        "https://www.pokepedia.fr/Abr%C3%A9viation_d%27extension"
+      ],
+      "reason": "Backlog backfill: expose the attested visible official abbreviation as an explicit source-backed search alias."
+    },
+    {
+      "id": "ex8",
+      "file": "data/EX/Deoxys.ts",
+      "visible": {
+        "official": "DX",
+        "fr": "DEO"
+      },
+      "searchAliases": [
+        "DX"
+      ],
+      "sources": [
+        "https://www.pokepedia.fr/Abr%C3%A9viation_d%27extension"
+      ],
+      "reason": "Backlog backfill: expose the attested visible official abbreviation as an explicit source-backed search alias."
+    },
+    {
+      "id": "ex9",
+      "file": "data/EX/Emerald.ts",
+      "visible": {
+        "official": "EM",
+        "fr": "EME"
+      },
+      "searchAliases": [
+        "EM"
+      ],
+      "sources": [
+        "https://www.pokepedia.fr/Abr%C3%A9viation_d%27extension"
+      ],
+      "reason": "Backlog backfill: expose the attested visible official abbreviation as an explicit source-backed search alias."
+    },
+    {
+      "id": "exu",
+      "file": "data/EX/Unseen Forces Unown Collection.ts",
+      "visible": {
+        "official": "UF"
+      },
+      "searchAliases": [
+        "UF"
+      ],
+      "sources": [
+        "https://www.pokepedia.fr/Abr%C3%A9viation_d%27extension"
+      ],
+      "reason": "Backlog backfill: expose the attested visible official abbreviation as an explicit source-backed search alias."
+    },
+    {
+      "id": "fut2020",
+      "file": "data/Sword & Shield/Pokémon Futsal 2020.ts",
+      "visible": {
+        "official": "FUT20"
+      },
+      "searchAliases": [
+        "FUT20"
+      ],
+      "sources": [
+        "https://www.pokepedia.fr/Abr%C3%A9viation_d%27extension",
+        "https://pkmncards.com/advanced/"
+      ],
+      "reason": "Backlog backfill: expose the attested visible official abbreviation as an explicit source-backed search alias."
+    },
+    {
+      "id": "g1",
+      "file": "data/XY/Generations.ts",
+      "visible": {
+        "official": "GEN",
+        "fr": "GEN"
+      },
+      "searchAliases": [
+        "GEN"
+      ],
+      "sources": [
+        "https://www.pokepedia.fr/Abr%C3%A9viation_d%27extension",
+        "https://pkmncards.com/advanced/"
+      ],
+      "reason": "Backlog backfill: expose the attested visible official abbreviation as an explicit source-backed search alias."
+    },
+    {
+      "id": "gym1",
+      "file": "data/Gym/Gym Heroes.ts",
+      "visible": {
+        "official": "G1"
+      },
+      "searchAliases": [
+        "G1"
+      ],
+      "sources": [
+        "https://www.pokepedia.fr/Abr%C3%A9viation_d%27extension"
+      ],
+      "reason": "Backlog backfill: expose the attested visible official abbreviation as an explicit source-backed search alias."
+    },
+    {
+      "id": "gym2",
+      "file": "data/Gym/Gym Challenge.ts",
+      "visible": {
+        "official": "G2"
+      },
+      "searchAliases": [
+        "G2"
+      ],
+      "sources": [
+        "https://www.pokepedia.fr/Abr%C3%A9viation_d%27extension"
+      ],
+      "reason": "Backlog backfill: expose the attested visible official abbreviation as an explicit source-backed search alias."
+    },
+    {
+      "id": "hgss1",
+      "file": "data/HeartGold & SoulSilver/HeartGold SoulSilver.ts",
+      "visible": {
+        "official": "HS",
+        "fr": "HGS"
+      },
+      "searchAliases": [
+        "HS"
+      ],
+      "sources": [
+        "https://www.pokepedia.fr/Abr%C3%A9viation_d%27extension"
+      ],
+      "reason": "Backlog backfill: expose the attested visible official abbreviation as an explicit source-backed search alias."
+    },
+    {
+      "id": "hgss2",
+      "file": "data/HeartGold & SoulSilver/Unleashed.ts",
+      "visible": {
+        "official": "UL",
+        "fr": "DCH"
+      },
+      "searchAliases": [
+        "UL"
+      ],
+      "sources": [
+        "https://www.pokepedia.fr/Abr%C3%A9viation_d%27extension"
+      ],
+      "reason": "Backlog backfill: expose the attested visible official abbreviation as an explicit source-backed search alias."
+    },
+    {
+      "id": "hgss3",
+      "file": "data/HeartGold & SoulSilver/Undaunted.ts",
+      "visible": {
+        "official": "UND",
+        "fr": "IND"
+      },
+      "searchAliases": [
+        "UND"
+      ],
+      "sources": [
+        "https://www.pokepedia.fr/Abr%C3%A9viation_d%27extension"
+      ],
+      "reason": "Backlog backfill: expose the attested visible official abbreviation as an explicit source-backed search alias."
+    },
+    {
+      "id": "hgss4",
+      "file": "data/HeartGold & SoulSilver/Triumphant.ts",
+      "visible": {
+        "official": "TRI",
+        "fr": "TRI"
+      },
+      "searchAliases": [
+        "TRI"
+      ],
+      "sources": [
+        "https://www.pokepedia.fr/Abr%C3%A9viation_d%27extension"
+      ],
+      "reason": "Backlog backfill: expose the attested visible official abbreviation as an explicit source-backed search alias."
+    },
+    {
+      "id": "hgssp",
+      "file": "data/HeartGold & SoulSilver/HGSS Black Star Promos.ts",
+      "visible": {
+        "official": "HSP",
+        "fr": "PHS"
+      },
+      "searchAliases": [
+        "HSP"
+      ],
+      "sources": [
+        "https://www.pokepedia.fr/Abr%C3%A9viation_d%27extension"
+      ],
+      "reason": "Backlog backfill: expose the attested visible official abbreviation as an explicit source-backed search alias."
+    },
+    {
+      "id": "jumbo",
+      "file": "data/Miscellaneous/Jumbo cards.ts",
+      "visible": {
+        "official": "JUM"
+      },
+      "searchAliases": [
+        "JUM"
+      ],
+      "sources": [
+        "https://www.pokepedia.fr/Abr%C3%A9viation_d%27extension"
+      ],
+      "reason": "Backlog backfill: expose the attested visible official abbreviation as an explicit source-backed search alias."
+    },
+    {
+      "id": "lc",
+      "file": "data/Legendary Collection/Legendary Collection.ts",
+      "visible": {
+        "official": "LC"
+      },
+      "searchAliases": [
+        "LC"
+      ],
+      "sources": [
+        "https://www.pokepedia.fr/Abr%C3%A9viation_d%27extension"
+      ],
+      "reason": "Backlog backfill: expose the attested visible official abbreviation as an explicit source-backed search alias."
+    },
+    {
+      "id": "me01",
+      "file": "data/Mega Evolution/Mega Evolution.ts",
+      "visible": {
+        "official": "MEG",
+        "fr": "ME01"
+      },
+      "searchAliases": [
+        "M1"
+      ],
+      "sources": [
+        "https://www.pokepedia.fr/Abr%C3%A9viation_d%27extension",
+        "https://pkmncards.com/advanced/"
+      ],
+      "reason": "Backlog backfill: expose the attested visible official abbreviation as an explicit source-backed search alias."
+    },
+    {
+      "id": "me02",
+      "file": "data/Mega Evolution/Phantasmal Flames.ts",
+      "visible": {
+        "official": "PFL",
+        "fr": "ME02"
+      },
+      "searchAliases": [
+        "M2"
+      ],
+      "sources": [
+        "https://www.pokepedia.fr/Abr%C3%A9viation_d%27extension",
+        "https://pkmncards.com/advanced/"
+      ],
+      "reason": "Backlog backfill: expose the attested visible official abbreviation as an explicit source-backed search alias."
+    },
+    {
+      "id": "me02.5",
+      "visible": {
+        "official": "ASC",
+        "fr": "ME02.5"
+      },
+      "searchAliases": [
+        "ME2.5",
+        "ME02.5",
+        "M2.5"
+      ],
+      "reason": "Ascended Heroes uses ASC for visible output while the API also accepts the generic Mega Evolution numbering family."
+    },
+    {
+      "id": "me03",
+      "file": "data/Mega Evolution/Perfect Order.ts",
+      "visible": {
+        "official": "POR",
+        "fr": "ME03"
+      },
+      "searchAliases": [
+        "M3"
+      ],
+      "sources": [
+        "https://www.pokepedia.fr/Abr%C3%A9viation_d%27extension",
+        "https://pkmncards.com/advanced/"
+      ],
+      "reason": "Backlog backfill: expose the attested visible official abbreviation as an explicit source-backed search alias."
+    },
+    {
+      "id": "me04",
+      "file": "data/Mega Evolution/Chaos Rising.ts",
+      "visible": {
+        "official": "CRI"
+      },
+      "searchAliases": [
+        "CRI"
+      ],
+      "sources": [
+        "https://www.pokepedia.fr/Abr%C3%A9viation_d%27extension",
+        "https://pkmncards.com/advanced/"
+      ],
+      "reason": "Backlog backfill: expose the attested visible official abbreviation as an explicit source-backed search alias."
+    },
+    {
+      "id": "me04.5",
+      "file": "data/Mega Evolution/Radiant Ruby & Shining Sapphire.ts",
+      "visible": {
+        "official": "RRS"
+      },
+      "searchAliases": [
+        "RRS"
+      ],
+      "sources": [
+        "https://www.pokepedia.fr/Abr%C3%A9viation_d%27extension",
+        "https://pkmncards.com/advanced/"
+      ],
+      "reason": "Backlog backfill: expose the attested visible official abbreviation as an explicit source-backed search alias."
+    },
+    {
+      "id": "me05",
+      "file": "data/Mega Evolution/Eternals.ts",
+      "visible": {
+        "official": "ETE"
+      },
+      "searchAliases": [
+        "ETE"
+      ],
+      "sources": [
+        "https://www.pokepedia.fr/Abr%C3%A9viation_d%27extension",
+        "https://pkmncards.com/advanced/"
+      ],
+      "reason": "Backlog backfill: expose the attested visible official abbreviation as an explicit source-backed search alias."
+    },
+    {
+      "id": "mee",
+      "file": "data/Mega Evolution/Mega Evolution Energy.ts",
+      "visible": {
+        "official": "MEE"
+      },
+      "searchAliases": [
+        "MEE"
+      ],
+      "sources": [
+        "https://www.pokepedia.fr/Abr%C3%A9viation_d%27extension",
+        "https://pkmncards.com/advanced/"
+      ],
+      "reason": "Backlog backfill: expose the attested visible official abbreviation as an explicit source-backed search alias."
+    },
+    {
+      "id": "mep",
+      "file": "data/Mega Evolution/MEP Black Star Promos.ts",
+      "visible": {
+        "official": "MEP"
+      },
+      "searchAliases": [
+        "MEP"
+      ],
+      "sources": [
+        "https://www.pokepedia.fr/Abr%C3%A9viation_d%27extension",
+        "https://pkmncards.com/advanced/"
+      ],
+      "reason": "Backlog backfill: expose the attested visible official abbreviation as an explicit source-backed search alias."
+    },
+    {
+      "id": "neo1",
+      "file": "data/Neo/Neo Genesis.ts",
+      "visible": {
+        "official": "N1",
+        "fr": "NGS"
+      },
+      "searchAliases": [
+        "N1"
+      ],
+      "sources": [
+        "https://www.pokepedia.fr/Abr%C3%A9viation_d%27extension"
+      ],
+      "reason": "Backlog backfill: expose the attested visible official abbreviation as an explicit source-backed search alias."
+    },
+    {
+      "id": "neo2",
+      "file": "data/Neo/Neo Discovery.ts",
+      "visible": {
+        "official": "N2",
+        "fr": "NDS"
+      },
+      "searchAliases": [
+        "N2"
+      ],
+      "sources": [
+        "https://www.pokepedia.fr/Abr%C3%A9viation_d%27extension"
+      ],
+      "reason": "Backlog backfill: expose the attested visible official abbreviation as an explicit source-backed search alias."
+    },
+    {
+      "id": "neo3",
+      "file": "data/Neo/Neo Revelation.ts",
+      "visible": {
+        "official": "N3",
+        "fr": "NRE"
+      },
+      "searchAliases": [
+        "N3"
+      ],
+      "sources": [
+        "https://www.pokepedia.fr/Abr%C3%A9viation_d%27extension"
+      ],
+      "reason": "Backlog backfill: expose the attested visible official abbreviation as an explicit source-backed search alias."
+    },
+    {
+      "id": "neo4",
+      "file": "data/Neo/Neo Destiny.ts",
+      "visible": {
+        "official": "N4",
+        "fr": "NDT"
+      },
+      "searchAliases": [
+        "N4"
+      ],
+      "sources": [
+        "https://www.pokepedia.fr/Abr%C3%A9viation_d%27extension"
+      ],
+      "reason": "Backlog backfill: expose the attested visible official abbreviation as an explicit source-backed search alias."
+    },
+    {
+      "id": "np",
+      "file": "data/POP/Nintendo Black Star Promos.ts",
+      "visible": {
+        "official": "NP",
+        "fr": "PNI"
+      },
+      "searchAliases": [
+        "NP"
+      ],
+      "sources": [
+        "https://www.pokepedia.fr/Abr%C3%A9viation_d%27extension"
+      ],
+      "reason": "Backlog backfill: expose the attested visible official abbreviation as an explicit source-backed search alias."
+    },
+    {
+      "id": "pl1",
+      "file": "data/Platinum/Platinum.ts",
+      "visible": {
+        "official": "PL",
+        "fr": "PLA"
+      },
+      "searchAliases": [
+        "PL"
+      ],
+      "sources": [
+        "https://www.pokepedia.fr/Abr%C3%A9viation_d%27extension"
+      ],
+      "reason": "Backlog backfill: expose the attested visible official abbreviation as an explicit source-backed search alias."
+    },
+    {
+      "id": "pl2",
+      "file": "data/Platinum/Rising Rivals.ts",
+      "visible": {
+        "official": "RR",
+        "fr": "REM"
+      },
+      "searchAliases": [
+        "RR"
+      ],
+      "sources": [
+        "https://www.pokepedia.fr/Abr%C3%A9viation_d%27extension"
+      ],
+      "reason": "Backlog backfill: expose the attested visible official abbreviation as an explicit source-backed search alias."
+    },
+    {
+      "id": "pl3",
+      "file": "data/Platinum/Supreme Victors.ts",
+      "visible": {
+        "official": "SV",
+        "fr": "VSU"
+      },
+      "searchAliases": [
+        "SV"
+      ],
+      "sources": [
+        "https://www.pokepedia.fr/Abr%C3%A9viation_d%27extension"
+      ],
+      "reason": "Backlog backfill: expose the attested visible official abbreviation as an explicit source-backed search alias."
+    },
+    {
+      "id": "pl4",
+      "file": "data/Platinum/Arceus.ts",
+      "visible": {
+        "official": "AR"
+      },
+      "searchAliases": [
+        "AR"
+      ],
+      "sources": [
+        "https://www.pokepedia.fr/Abr%C3%A9viation_d%27extension"
+      ],
+      "reason": "Backlog backfill: expose the attested visible official abbreviation as an explicit source-backed search alias."
+    },
+    {
+      "id": "pop1",
+      "file": "data/POP/POP Series 1.ts",
+      "visible": {
+        "official": "P1",
+        "fr": "P01"
+      },
+      "searchAliases": [
+        "P1"
+      ],
+      "sources": [
+        "https://www.pokepedia.fr/Abr%C3%A9viation_d%27extension"
+      ],
+      "reason": "Backlog backfill: expose the attested visible official abbreviation as an explicit source-backed search alias."
+    },
+    {
+      "id": "pop2",
+      "file": "data/POP/POP Series 2.ts",
+      "visible": {
+        "official": "P2",
+        "fr": "P02"
+      },
+      "searchAliases": [
+        "P2"
+      ],
+      "sources": [
+        "https://www.pokepedia.fr/Abr%C3%A9viation_d%27extension"
+      ],
+      "reason": "Backlog backfill: expose the attested visible official abbreviation as an explicit source-backed search alias."
+    },
+    {
+      "id": "pop3",
+      "file": "data/POP/POP Series 3.ts",
+      "visible": {
+        "official": "P3",
+        "fr": "P03"
+      },
+      "searchAliases": [
+        "P3"
+      ],
+      "sources": [
+        "https://www.pokepedia.fr/Abr%C3%A9viation_d%27extension"
+      ],
+      "reason": "Backlog backfill: expose the attested visible official abbreviation as an explicit source-backed search alias."
+    },
+    {
+      "id": "pop4",
+      "file": "data/POP/POP Series 4.ts",
+      "visible": {
+        "official": "P4",
+        "fr": "P04"
+      },
+      "searchAliases": [
+        "P4"
+      ],
+      "sources": [
+        "https://www.pokepedia.fr/Abr%C3%A9viation_d%27extension"
+      ],
+      "reason": "Backlog backfill: expose the attested visible official abbreviation as an explicit source-backed search alias."
+    },
+    {
+      "id": "pop5",
+      "file": "data/POP/POP Series 5.ts",
+      "visible": {
+        "official": "P5"
+      },
+      "searchAliases": [
+        "P5"
+      ],
+      "sources": [
+        "https://www.pokepedia.fr/Abr%C3%A9viation_d%27extension"
+      ],
+      "reason": "Backlog backfill: expose the attested visible official abbreviation as an explicit source-backed search alias."
+    },
+    {
+      "id": "pop6",
+      "file": "data/POP/POP Series 6.ts",
+      "visible": {
+        "official": "P6"
+      },
+      "searchAliases": [
+        "P6"
+      ],
+      "sources": [
+        "https://www.pokepedia.fr/Abr%C3%A9viation_d%27extension"
+      ],
+      "reason": "Backlog backfill: expose the attested visible official abbreviation as an explicit source-backed search alias."
+    },
+    {
+      "id": "pop7",
+      "file": "data/POP/POP Series 7.ts",
+      "visible": {
+        "official": "P7",
+        "fr": "P07"
+      },
+      "searchAliases": [
+        "P7"
+      ],
+      "sources": [
+        "https://www.pokepedia.fr/Abr%C3%A9viation_d%27extension"
+      ],
+      "reason": "Backlog backfill: expose the attested visible official abbreviation as an explicit source-backed search alias."
+    },
+    {
+      "id": "pop8",
+      "file": "data/POP/POP Series 8.ts",
+      "visible": {
+        "official": "P8"
+      },
+      "searchAliases": [
+        "P8"
+      ],
+      "sources": [
+        "https://www.pokepedia.fr/Abr%C3%A9viation_d%27extension"
+      ],
+      "reason": "Backlog backfill: expose the attested visible official abbreviation as an explicit source-backed search alias."
+    },
+    {
+      "id": "pop9",
+      "file": "data/POP/POP Series 9.ts",
+      "visible": {
+        "official": "P9",
+        "fr": "P09"
+      },
+      "searchAliases": [
+        "P9"
+      ],
+      "sources": [
+        "https://www.pokepedia.fr/Abr%C3%A9viation_d%27extension"
+      ],
+      "reason": "Backlog backfill: expose the attested visible official abbreviation as an explicit source-backed search alias."
+    },
+    {
+      "id": "ru1",
+      "file": "data/Platinum/Pokémon Rumble.ts",
+      "visible": {
+        "official": "RM"
+      },
+      "searchAliases": [
+        "RM"
+      ],
+      "sources": [
+        "https://www.pokepedia.fr/Abr%C3%A9viation_d%27extension"
+      ],
+      "reason": "Backlog backfill: expose the attested visible official abbreviation as an explicit source-backed search alias."
+    },
+    {
+      "id": "si1",
+      "file": "data/Neo/Southern Islands.ts",
+      "visible": {
+        "official": "SI"
+      },
+      "searchAliases": [
+        "SI"
+      ],
+      "sources": [
+        "https://www.pokepedia.fr/Abr%C3%A9viation_d%27extension"
+      ],
+      "reason": "Backlog backfill: expose the attested visible official abbreviation as an explicit source-backed search alias."
+    },
+    {
+      "id": "sm1",
+      "file": "data/Sun & Moon/Sun & Moon.ts",
+      "visible": {
+        "official": "SUM",
+        "fr": "SL01"
+      },
+      "searchAliases": [
+        "SM1"
+      ],
+      "sources": [
+        "https://www.pokepedia.fr/Abr%C3%A9viation_d%27extension",
+        "https://pkmncards.com/advanced/"
+      ],
+      "reason": "Backlog backfill: expose the attested visible official abbreviation as an explicit source-backed search alias."
+    },
+    {
+      "id": "sm10",
+      "file": "data/Sun & Moon/Unbroken Bonds.ts",
+      "visible": {
+        "official": "UNB",
+        "fr": "SL10"
+      },
+      "searchAliases": [
+        "SM10"
+      ],
+      "sources": [
+        "https://www.pokepedia.fr/Abr%C3%A9viation_d%27extension",
+        "https://pkmncards.com/advanced/"
+      ],
+      "reason": "Backlog backfill: expose the attested visible official abbreviation as an explicit source-backed search alias."
+    },
+    {
+      "id": "sm11",
+      "file": "data/Sun & Moon/Unified Minds.ts",
+      "visible": {
+        "official": "UNM",
+        "fr": "SL11"
+      },
+      "searchAliases": [
+        "SM11"
+      ],
+      "sources": [
+        "https://www.pokepedia.fr/Abr%C3%A9viation_d%27extension",
+        "https://pkmncards.com/advanced/"
+      ],
+      "reason": "Backlog backfill: expose the attested visible official abbreviation as an explicit source-backed search alias."
+    },
+    {
+      "id": "sm115",
+      "file": "data/Sun & Moon/Hidden Fates.ts",
+      "visible": {
+        "official": "HIF",
+        "fr": "SL11.5"
+      },
+      "searchAliases": [
+        "SM11.5"
+      ],
+      "sources": [
+        "https://www.pokepedia.fr/Abr%C3%A9viation_d%27extension",
+        "https://pkmncards.com/advanced/"
+      ],
+      "reason": "Backlog backfill: expose the attested visible official abbreviation as an explicit source-backed search alias."
+    },
+    {
+      "id": "sm12",
+      "file": "data/Sun & Moon/Cosmic Eclipse.ts",
+      "visible": {
+        "official": "CEC",
+        "fr": "SL12"
+      },
+      "searchAliases": [
+        "SM12"
+      ],
+      "sources": [
+        "https://www.pokepedia.fr/Abr%C3%A9viation_d%27extension",
+        "https://pkmncards.com/advanced/"
+      ],
+      "reason": "Backlog backfill: expose the attested visible official abbreviation as an explicit source-backed search alias."
+    },
+    {
+      "id": "sm2",
+      "file": "data/Sun & Moon/Guardians Rising.ts",
+      "visible": {
+        "official": "GRI",
+        "fr": "SL02"
+      },
+      "searchAliases": [
+        "SM2"
+      ],
+      "sources": [
+        "https://www.pokepedia.fr/Abr%C3%A9viation_d%27extension",
+        "https://pkmncards.com/advanced/"
+      ],
+      "reason": "Backlog backfill: expose the attested visible official abbreviation as an explicit source-backed search alias."
+    },
+    {
+      "id": "sm3",
+      "file": "data/Sun & Moon/Burning Shadows.ts",
+      "visible": {
+        "official": "BUS",
+        "fr": "SL03"
+      },
+      "searchAliases": [
+        "SM3"
+      ],
+      "sources": [
+        "https://www.pokepedia.fr/Abr%C3%A9viation_d%27extension",
+        "https://pkmncards.com/advanced/"
+      ],
+      "reason": "Backlog backfill: expose the attested visible official abbreviation as an explicit source-backed search alias."
+    },
+    {
+      "id": "sm3.5",
+      "file": "data/Sun & Moon/Shining Legends.ts",
+      "visible": {
+        "official": "SLG",
+        "fr": "SL03.5"
+      },
+      "searchAliases": [
+        "SM3.5"
+      ],
+      "sources": [
+        "https://www.pokepedia.fr/Abr%C3%A9viation_d%27extension",
+        "https://pkmncards.com/advanced/"
+      ],
+      "reason": "Backlog backfill: expose the attested visible official abbreviation as an explicit source-backed search alias."
+    },
+    {
+      "id": "sm4",
+      "file": "data/Sun & Moon/Crimson Invasion.ts",
+      "visible": {
+        "official": "CIN",
+        "fr": "SL04"
+      },
+      "searchAliases": [
+        "SM4"
+      ],
+      "sources": [
+        "https://www.pokepedia.fr/Abr%C3%A9viation_d%27extension",
+        "https://pkmncards.com/advanced/"
+      ],
+      "reason": "Backlog backfill: expose the attested visible official abbreviation as an explicit source-backed search alias."
+    },
+    {
+      "id": "sm5",
+      "file": "data/Sun & Moon/Ultra Prism.ts",
+      "visible": {
+        "official": "UPR",
+        "fr": "SL05"
+      },
+      "searchAliases": [
+        "SM5"
+      ],
+      "sources": [
+        "https://www.pokepedia.fr/Abr%C3%A9viation_d%27extension",
+        "https://pkmncards.com/advanced/"
+      ],
+      "reason": "Backlog backfill: expose the attested visible official abbreviation as an explicit source-backed search alias."
+    },
+    {
+      "id": "sm6",
+      "file": "data/Sun & Moon/Forbidden Light.ts",
+      "visible": {
+        "official": "FLI",
+        "fr": "SL06"
+      },
+      "searchAliases": [
+        "SM6"
+      ],
+      "sources": [
+        "https://www.pokepedia.fr/Abr%C3%A9viation_d%27extension",
+        "https://pkmncards.com/advanced/"
+      ],
+      "reason": "Backlog backfill: expose the attested visible official abbreviation as an explicit source-backed search alias."
+    },
+    {
+      "id": "sm7",
+      "file": "data/Sun & Moon/Celestial Storm.ts",
+      "visible": {
+        "official": "CES",
+        "fr": "SL07"
+      },
+      "searchAliases": [
+        "SM7"
+      ],
+      "sources": [
+        "https://www.pokepedia.fr/Abr%C3%A9viation_d%27extension",
+        "https://pkmncards.com/advanced/"
+      ],
+      "reason": "Backlog backfill: expose the attested visible official abbreviation as an explicit source-backed search alias."
+    },
+    {
+      "id": "sm7.5",
+      "file": "data/Sun & Moon/Dragon Majesty.ts",
+      "visible": {
+        "official": "DRM",
+        "fr": "SL07.5"
+      },
+      "searchAliases": [
+        "SM7.5"
+      ],
+      "sources": [
+        "https://www.pokepedia.fr/Abr%C3%A9viation_d%27extension",
+        "https://pkmncards.com/advanced/"
+      ],
+      "reason": "Backlog backfill: expose the attested visible official abbreviation as an explicit source-backed search alias."
+    },
+    {
+      "id": "sm8",
+      "file": "data/Sun & Moon/Lost Thunder.ts",
+      "visible": {
+        "official": "LOT",
+        "fr": "SL08"
+      },
+      "searchAliases": [
+        "SM8"
+      ],
+      "sources": [
+        "https://www.pokepedia.fr/Abr%C3%A9viation_d%27extension",
+        "https://pkmncards.com/advanced/"
+      ],
+      "reason": "Backlog backfill: expose the attested visible official abbreviation as an explicit source-backed search alias."
+    },
+    {
+      "id": "sm9",
+      "file": "data/Sun & Moon/Team Up.ts",
+      "visible": {
+        "official": "TEU",
+        "fr": "SL09"
+      },
+      "searchAliases": [
+        "SM9"
+      ],
+      "sources": [
+        "https://www.pokepedia.fr/Abr%C3%A9viation_d%27extension",
+        "https://pkmncards.com/advanced/"
+      ],
+      "reason": "Backlog backfill: expose the attested visible official abbreviation as an explicit source-backed search alias."
+    },
+    {
+      "id": "sma",
+      "file": "data/Sun & Moon/Hidden Fates Shiny Vault.ts",
+      "visible": {
+        "official": "SV"
+      },
+      "searchAliases": [
+        "SV"
+      ],
+      "sources": [
+        "https://www.pokepedia.fr/Abr%C3%A9viation_d%27extension",
+        "https://pkmncards.com/advanced/"
+      ],
+      "reason": "Backlog backfill: expose the attested visible official abbreviation as an explicit source-backed search alias."
+    },
+    {
+      "id": "smp",
+      "file": "data/Sun & Moon/SM Black Star Promos.ts",
+      "visible": {
+        "official": "SMP",
+        "fr": "PSM"
+      },
+      "searchAliases": [
+        "SMP"
+      ],
+      "sources": [
+        "https://www.pokepedia.fr/Abr%C3%A9viation_d%27extension",
+        "https://pkmncards.com/advanced/"
+      ],
+      "reason": "Backlog backfill: expose the attested visible official abbreviation as an explicit source-backed search alias."
+    },
+    {
+      "id": "sp",
+      "file": "data/E-Card/Sample.ts",
+      "visible": {
+        "official": "SAMPLE"
+      },
+      "searchAliases": [
+        "SAMPLE"
+      ],
+      "sources": [
+        "https://www.pokepedia.fr/Abr%C3%A9viation_d%27extension"
+      ],
+      "reason": "Backlog backfill: expose the attested visible official abbreviation as an explicit source-backed search alias."
+    },
+    {
+      "id": "sv01",
+      "visible": {
+        "official": "SVI",
+        "fr": "EV01"
+      },
+      "searchAliases": [
+        "SV1",
+        "SV01",
+        "EV1",
+        "EV01"
+      ],
+      "reason": "Base Scarlet & Violet set keeps the printed official code while also accepting localized and generic numeric families."
+    },
+    {
+      "id": "sv02",
+      "file": "data/Scarlet & Violet/Paldea Evolved.ts",
+      "visible": {
+        "official": "PAL",
+        "fr": "EV02"
+      },
+      "searchAliases": [
+        "SV2"
+      ],
+      "sources": [
+        "https://www.pokepedia.fr/Abr%C3%A9viation_d%27extension",
+        "https://pkmncards.com/advanced/"
+      ],
+      "reason": "Backlog backfill: expose the attested visible official abbreviation as an explicit source-backed search alias."
+    },
+    {
+      "id": "sv03",
+      "file": "data/Scarlet & Violet/Obsidian Flames.ts",
+      "visible": {
+        "official": "OBF",
+        "fr": "EV03"
+      },
+      "searchAliases": [
+        "SV3"
+      ],
+      "sources": [
+        "https://www.pokepedia.fr/Abr%C3%A9viation_d%27extension",
+        "https://pkmncards.com/advanced/"
+      ],
+      "reason": "Backlog backfill: expose the attested visible official abbreviation as an explicit source-backed search alias."
+    },
+    {
+      "id": "sv03.5",
+      "visible": {
+        "official": "MEW",
+        "fr": "EV03.5"
+      },
+      "searchAliases": [
+        "SV3.5",
+        "SV03.5",
+        "EV3.5",
+        "EV03.5"
+      ],
+      "reason": "151 keeps MEW as the visible official code but must remain searchable through the shared Scarlet & Violet numeric family."
+    },
+    {
+      "id": "sv04",
+      "file": "data/Scarlet & Violet/Paradox Rift.ts",
+      "visible": {
+        "official": "PAR",
+        "fr": "EV04"
+      },
+      "searchAliases": [
+        "SV4"
+      ],
+      "sources": [
+        "https://www.pokepedia.fr/Abr%C3%A9viation_d%27extension",
+        "https://pkmncards.com/advanced/"
+      ],
+      "reason": "Backlog backfill: expose the attested visible official abbreviation as an explicit source-backed search alias."
+    },
+    {
+      "id": "sv04.5",
+      "file": "data/Scarlet & Violet/Paldean Fates.ts",
+      "visible": {
+        "official": "PAF",
+        "fr": "EV04.5"
+      },
+      "searchAliases": [
+        "SV4.5"
+      ],
+      "sources": [
+        "https://www.pokepedia.fr/Abr%C3%A9viation_d%27extension",
+        "https://pkmncards.com/advanced/"
+      ],
+      "reason": "Backlog backfill: expose the attested visible official abbreviation as an explicit source-backed search alias."
+    },
+    {
+      "id": "sv05",
+      "file": "data/Scarlet & Violet/Temporal Forces.ts",
+      "visible": {
+        "official": "TEF",
+        "fr": "EV05"
+      },
+      "searchAliases": [
+        "SV5"
+      ],
+      "sources": [
+        "https://www.pokepedia.fr/Abr%C3%A9viation_d%27extension",
+        "https://pkmncards.com/advanced/"
+      ],
+      "reason": "Backlog backfill: expose the attested visible official abbreviation as an explicit source-backed search alias."
+    },
+    {
+      "id": "sv06",
+      "file": "data/Scarlet & Violet/Twilight Masquerade.ts",
+      "visible": {
+        "official": "TWM",
+        "fr": "EV06"
+      },
+      "searchAliases": [
+        "SV6"
+      ],
+      "sources": [
+        "https://www.pokepedia.fr/Abr%C3%A9viation_d%27extension",
+        "https://pkmncards.com/advanced/"
+      ],
+      "reason": "Backlog backfill: expose the attested visible official abbreviation as an explicit source-backed search alias."
+    },
+    {
+      "id": "sv06.5",
+      "file": "data/Scarlet & Violet/Shrouded Fable.ts",
+      "visible": {
+        "official": "SFA",
+        "fr": "EV06.5"
+      },
+      "searchAliases": [
+        "SV6.5"
+      ],
+      "sources": [
+        "https://www.pokepedia.fr/Abr%C3%A9viation_d%27extension",
+        "https://pkmncards.com/advanced/"
+      ],
+      "reason": "Backlog backfill: expose the attested visible official abbreviation as an explicit source-backed search alias."
+    },
+    {
+      "id": "sv07",
+      "file": "data/Scarlet & Violet/Stellar Crown.ts",
+      "visible": {
+        "official": "SCR",
+        "fr": "EV07"
+      },
+      "searchAliases": [
+        "SV7"
+      ],
+      "sources": [
+        "https://www.pokepedia.fr/Abr%C3%A9viation_d%27extension",
+        "https://pkmncards.com/advanced/"
+      ],
+      "reason": "Backlog backfill: expose the attested visible official abbreviation as an explicit source-backed search alias."
+    },
+    {
+      "id": "sv08",
+      "file": "data/Scarlet & Violet/Surging Sparks.ts",
+      "visible": {
+        "official": "SSP",
+        "fr": "EV08"
+      },
+      "searchAliases": [
+        "SV8"
+      ],
+      "sources": [
+        "https://www.pokepedia.fr/Abr%C3%A9viation_d%27extension",
+        "https://pkmncards.com/advanced/"
+      ],
+      "reason": "Backlog backfill: expose the attested visible official abbreviation as an explicit source-backed search alias."
+    },
+    {
+      "id": "sv08.5",
+      "file": "data/Scarlet & Violet/Prismatic Evolutions.ts",
+      "visible": {
+        "official": "PRE",
+        "fr": "EV08.5"
+      },
+      "searchAliases": [
+        "SV8.5"
+      ],
+      "sources": [
+        "https://www.pokepedia.fr/Abr%C3%A9viation_d%27extension",
+        "https://pkmncards.com/advanced/"
+      ],
+      "reason": "Backlog backfill: expose the attested visible official abbreviation as an explicit source-backed search alias."
+    },
+    {
+      "id": "sv09",
+      "file": "data/Scarlet & Violet/Journey Together.ts",
+      "visible": {
+        "official": "JTG",
+        "fr": "EV09"
+      },
+      "searchAliases": [
+        "SV9"
+      ],
+      "sources": [
+        "https://www.pokepedia.fr/Abr%C3%A9viation_d%27extension",
+        "https://pkmncards.com/advanced/"
+      ],
+      "reason": "Backlog backfill: expose the attested visible official abbreviation as an explicit source-backed search alias."
+    },
+    {
+      "id": "sv10",
+      "file": "data/Scarlet & Violet/Destined Rivals.ts",
+      "visible": {
+        "official": "DRI",
+        "fr": "EV10"
+      },
+      "searchAliases": [
+        "SV10"
+      ],
+      "sources": [
+        "https://www.pokepedia.fr/Abr%C3%A9viation_d%27extension",
+        "https://pkmncards.com/advanced/"
+      ],
+      "reason": "Backlog backfill: expose the attested visible official abbreviation as an explicit source-backed search alias."
+    },
+    {
+      "id": "sv10.5b",
+      "visible": {
+        "official": "BLK",
+        "fr": "EV10.5"
+      },
+      "searchAliases": [
+        "SV10.5",
+        "SV10.5B"
+      ],
+      "reason": "Black Bolt shares the split-set family code SV10.5, with a B suffix reserved for the disambiguated lookup."
+    },
+    {
+      "id": "sv10.5w",
+      "visible": {
+        "official": "WHT",
+        "fr": "EV10.5"
+      },
+      "searchAliases": [
+        "SV10.5",
+        "SV10.5W"
+      ],
+      "reason": "White Flare shares the split-set family code SV10.5, with a W suffix reserved for the disambiguated lookup."
+    },
+    {
+      "id": "sve",
+      "file": "data/Scarlet & Violet/Scarlet & Violet Energy.ts",
+      "visible": {
+        "official": "SVE"
+      },
+      "searchAliases": [
+        "SVE"
+      ],
+      "sources": [
+        "https://www.pokepedia.fr/Abr%C3%A9viation_d%27extension",
+        "https://pkmncards.com/advanced/"
+      ],
+      "reason": "Backlog backfill: expose the attested visible official abbreviation as an explicit source-backed search alias."
+    },
+    {
+      "id": "svp",
+      "file": "data/Scarlet & Violet/SVP Black Star Promos.ts",
+      "visible": {
+        "official": "SVP"
+      },
+      "searchAliases": [
+        "SVP"
+      ],
+      "sources": [
+        "https://www.pokepedia.fr/Abr%C3%A9viation_d%27extension",
+        "https://pkmncards.com/advanced/"
+      ],
+      "reason": "Backlog backfill: expose the attested visible official abbreviation as an explicit source-backed search alias."
+    },
+    {
+      "id": "swsh1",
+      "file": "data/Sword & Shield/Sword & Shield.ts",
+      "visible": {
+        "official": "SSH",
+        "fr": "EB01"
+      },
+      "searchAliases": [
+        "SWSH1"
+      ],
+      "sources": [
+        "https://www.pokepedia.fr/Abr%C3%A9viation_d%27extension",
+        "https://pkmncards.com/advanced/"
+      ],
+      "reason": "Backlog backfill: expose the attested visible official abbreviation as an explicit source-backed search alias."
+    },
+    {
+      "id": "swsh10",
+      "file": "data/Sword & Shield/Astral Radiance.ts",
+      "visible": {
+        "official": "ASR",
+        "fr": "EB10"
+      },
+      "searchAliases": [
+        "SWSH10"
+      ],
+      "sources": [
+        "https://www.pokepedia.fr/Abr%C3%A9viation_d%27extension",
+        "https://pkmncards.com/advanced/"
+      ],
+      "reason": "Backlog backfill: expose the attested visible official abbreviation as an explicit source-backed search alias."
+    },
+    {
+      "id": "swsh10.5",
+      "file": "data/Sword & Shield/Pokémon GO.ts",
+      "visible": {
+        "official": "PGO",
+        "fr": "EB10.5"
+      },
+      "searchAliases": [
+        "SWSH10.5"
+      ],
+      "sources": [
+        "https://www.pokepedia.fr/Abr%C3%A9viation_d%27extension",
+        "https://pkmncards.com/advanced/"
+      ],
+      "reason": "Backlog backfill: expose the attested visible official abbreviation as an explicit source-backed search alias."
+    },
+    {
+      "id": "swsh11",
+      "file": "data/Sword & Shield/Lost Origin.ts",
+      "visible": {
+        "official": "LOR",
+        "fr": "EB11"
+      },
+      "searchAliases": [
+        "SWSH11"
+      ],
+      "sources": [
+        "https://www.pokepedia.fr/Abr%C3%A9viation_d%27extension",
+        "https://pkmncards.com/advanced/"
+      ],
+      "reason": "Backlog backfill: expose the attested visible official abbreviation as an explicit source-backed search alias."
+    },
+    {
+      "id": "swsh12",
+      "file": "data/Sword & Shield/Silver Tempest.ts",
+      "visible": {
+        "official": "SIT",
+        "fr": "EB12"
+      },
+      "searchAliases": [
+        "SWSH12"
+      ],
+      "sources": [
+        "https://www.pokepedia.fr/Abr%C3%A9viation_d%27extension",
+        "https://pkmncards.com/advanced/"
+      ],
+      "reason": "Backlog backfill: expose the attested visible official abbreviation as an explicit source-backed search alias."
+    },
+    {
+      "id": "swsh12.5",
+      "file": "data/Sword & Shield/Crown Zenith.ts",
+      "visible": {
+        "official": "CRZ",
+        "fr": "EB12.5"
+      },
+      "searchAliases": [
+        "SWSH12.5"
+      ],
+      "sources": [
+        "https://www.pokepedia.fr/Abr%C3%A9viation_d%27extension",
+        "https://pkmncards.com/advanced/"
+      ],
+      "reason": "Backlog backfill: expose the attested visible official abbreviation as an explicit source-backed search alias."
+    },
+    {
+      "id": "swsh2",
+      "file": "data/Sword & Shield/Rebel Clash.ts",
+      "visible": {
+        "official": "RCL",
+        "fr": "EB02"
+      },
+      "searchAliases": [
+        "SWSH2"
+      ],
+      "sources": [
+        "https://www.pokepedia.fr/Abr%C3%A9viation_d%27extension",
+        "https://pkmncards.com/advanced/"
+      ],
+      "reason": "Backlog backfill: expose the attested visible official abbreviation as an explicit source-backed search alias."
+    },
+    {
+      "id": "swsh3",
+      "file": "data/Sword & Shield/Darkness Ablaze.ts",
+      "visible": {
+        "official": "DAA",
+        "fr": "EB03"
+      },
+      "searchAliases": [
+        "SWSH3"
+      ],
+      "sources": [
+        "https://www.pokepedia.fr/Abr%C3%A9viation_d%27extension",
+        "https://pkmncards.com/advanced/"
+      ],
+      "reason": "Backlog backfill: expose the attested visible official abbreviation as an explicit source-backed search alias."
+    },
+    {
+      "id": "swsh3.5",
+      "file": "data/Sword & Shield/Champion's Path.ts",
+      "visible": {
+        "official": "CPA",
+        "fr": "EB03.5"
+      },
+      "searchAliases": [
+        "SWSH3.5"
+      ],
+      "sources": [
+        "https://www.pokepedia.fr/Abr%C3%A9viation_d%27extension",
+        "https://pkmncards.com/advanced/"
+      ],
+      "reason": "Backlog backfill: expose the attested visible official abbreviation as an explicit source-backed search alias."
+    },
+    {
+      "id": "swsh4",
+      "file": "data/Sword & Shield/Vivid Voltage.ts",
+      "visible": {
+        "official": "VIV",
+        "fr": "EB04"
+      },
+      "searchAliases": [
+        "SWSH4"
+      ],
+      "sources": [
+        "https://www.pokepedia.fr/Abr%C3%A9viation_d%27extension",
+        "https://pkmncards.com/advanced/"
+      ],
+      "reason": "Backlog backfill: expose the attested visible official abbreviation as an explicit source-backed search alias."
+    },
+    {
+      "id": "swsh4.5",
+      "file": "data/Sword & Shield/Shining Fates.ts",
+      "visible": {
+        "official": "SHF",
+        "fr": "EB04.5"
+      },
+      "searchAliases": [
+        "SWSH4.5"
+      ],
+      "sources": [
+        "https://www.pokepedia.fr/Abr%C3%A9viation_d%27extension",
+        "https://pkmncards.com/advanced/"
+      ],
+      "reason": "Backlog backfill: expose the attested visible official abbreviation as an explicit source-backed search alias."
+    },
+    {
+      "id": "swsh5",
+      "file": "data/Sword & Shield/Battle Styles.ts",
+      "visible": {
+        "official": "BST",
+        "fr": "EB05"
+      },
+      "searchAliases": [
+        "SWSH5"
+      ],
+      "sources": [
+        "https://www.pokepedia.fr/Abr%C3%A9viation_d%27extension",
+        "https://pkmncards.com/advanced/"
+      ],
+      "reason": "Backlog backfill: expose the attested visible official abbreviation as an explicit source-backed search alias."
+    },
+    {
+      "id": "swsh6",
+      "file": "data/Sword & Shield/Chilling Reign.ts",
+      "visible": {
+        "official": "CRE",
+        "fr": "EB06"
+      },
+      "searchAliases": [
+        "SWSH6"
+      ],
+      "sources": [
+        "https://www.pokepedia.fr/Abr%C3%A9viation_d%27extension",
+        "https://pkmncards.com/advanced/"
+      ],
+      "reason": "Backlog backfill: expose the attested visible official abbreviation as an explicit source-backed search alias."
+    },
+    {
+      "id": "swsh7",
+      "file": "data/Sword & Shield/Evolving Skies.ts",
+      "visible": {
+        "official": "EVS",
+        "fr": "EB07"
+      },
+      "searchAliases": [
+        "SWSH7"
+      ],
+      "sources": [
+        "https://www.pokepedia.fr/Abr%C3%A9viation_d%27extension",
+        "https://pkmncards.com/advanced/"
+      ],
+      "reason": "Backlog backfill: expose the attested visible official abbreviation as an explicit source-backed search alias."
+    },
+    {
+      "id": "swsh8",
+      "file": "data/Sword & Shield/Fusion Strike.ts",
+      "visible": {
+        "official": "FST",
+        "fr": "EB08"
+      },
+      "searchAliases": [
+        "SWSH8"
+      ],
+      "sources": [
+        "https://www.pokepedia.fr/Abr%C3%A9viation_d%27extension",
+        "https://pkmncards.com/advanced/"
+      ],
+      "reason": "Backlog backfill: expose the attested visible official abbreviation as an explicit source-backed search alias."
+    },
+    {
+      "id": "swsh9",
+      "file": "data/Sword & Shield/Brilliant Stars.ts",
+      "visible": {
+        "official": "BRS",
+        "fr": "EB09"
+      },
+      "searchAliases": [
+        "SWSH9"
+      ],
+      "sources": [
+        "https://www.pokepedia.fr/Abr%C3%A9viation_d%27extension",
+        "https://pkmncards.com/advanced/"
+      ],
+      "reason": "Backlog backfill: expose the attested visible official abbreviation as an explicit source-backed search alias."
+    },
+    {
+      "id": "swshp",
+      "file": "data/Sword & Shield/SWSH Black Star Promos.ts",
+      "visible": {
+        "official": "SWSHP"
+      },
+      "searchAliases": [
+        "SWSHP"
+      ],
+      "sources": [
+        "https://www.pokepedia.fr/Abr%C3%A9viation_d%27extension",
+        "https://pkmncards.com/advanced/"
+      ],
+      "reason": "Backlog backfill: expose the attested visible official abbreviation as an explicit source-backed search alias."
+    },
+    {
+      "id": "tk-bw-e",
+      "file": "data/Trainer kits/BW trainer Kit (Excadrill).ts",
+      "visible": {
+        "official": "TK5E",
+        "fr": "MIN"
+      },
+      "searchAliases": [
+        "TK5E"
+      ],
+      "sources": [
+        "https://www.pokepedia.fr/Abr%C3%A9viation_d%27extension",
+        "https://pkmncards.com/advanced/"
+      ],
+      "reason": "Backlog backfill: expose the attested visible official abbreviation as an explicit source-backed search alias."
+    },
+    {
+      "id": "tk-bw-z",
+      "file": "data/Trainer kits/BW trainer Kit (Zoroark).ts",
+      "visible": {
+        "official": "TK5Z",
+        "fr": "ZOR"
+      },
+      "searchAliases": [
+        "TK5Z"
+      ],
+      "sources": [
+        "https://www.pokepedia.fr/Abr%C3%A9viation_d%27extension",
+        "https://pkmncards.com/advanced/"
+      ],
+      "reason": "Backlog backfill: expose the attested visible official abbreviation as an explicit source-backed search alias."
+    },
+    {
+      "id": "tk-dp-l",
+      "file": "data/Trainer kits/DP trainer Kit (Lucario).ts",
+      "visible": {
+        "official": "TK3L",
+        "fr": "LUC"
+      },
+      "searchAliases": [
+        "TK3L"
+      ],
+      "sources": [
+        "https://www.pokepedia.fr/Abr%C3%A9viation_d%27extension",
+        "https://pkmncards.com/advanced/"
+      ],
+      "reason": "Backlog backfill: expose the attested visible official abbreviation as an explicit source-backed search alias."
+    },
+    {
+      "id": "tk-dp-m",
+      "file": "data/Trainer kits/DP trainer Kit (Manaphy).ts",
+      "visible": {
+        "official": "TK3M",
+        "fr": "MAN"
+      },
+      "searchAliases": [
+        "TK3M"
+      ],
+      "sources": [
+        "https://www.pokepedia.fr/Abr%C3%A9viation_d%27extension",
+        "https://pkmncards.com/advanced/"
+      ],
+      "reason": "Backlog backfill: expose the attested visible official abbreviation as an explicit source-backed search alias."
+    },
+    {
+      "id": "tk-ex-latia",
+      "file": "data/Trainer kits/EX trainer Kit (Latias).ts",
+      "visible": {
+        "official": "TK1A",
+        "fr": "KDA"
+      },
+      "searchAliases": [
+        "TK1A"
+      ],
+      "sources": [
+        "https://www.pokepedia.fr/Abr%C3%A9viation_d%27extension",
+        "https://pkmncards.com/advanced/"
+      ],
+      "reason": "Backlog backfill: expose the attested visible official abbreviation as an explicit source-backed search alias."
+    },
+    {
+      "id": "tk-ex-latio",
+      "file": "data/Trainer kits/EX trainer Kit (Latios).ts",
+      "visible": {
+        "official": "TK1O",
+        "fr": "KDL"
+      },
+      "searchAliases": [
+        "TK1O"
+      ],
+      "sources": [
+        "https://www.pokepedia.fr/Abr%C3%A9viation_d%27extension",
+        "https://pkmncards.com/advanced/"
+      ],
+      "reason": "Backlog backfill: expose the attested visible official abbreviation as an explicit source-backed search alias."
+    },
+    {
+      "id": "tk-ex-m",
+      "file": "data/Trainer kits/EX trainer Kit 2 (Minun).ts",
+      "visible": {
+        "official": "TK2M",
+        "fr": "NEG"
+      },
+      "searchAliases": [
+        "TK2M"
+      ],
+      "sources": [
+        "https://www.pokepedia.fr/Abr%C3%A9viation_d%27extension",
+        "https://pkmncards.com/advanced/"
+      ],
+      "reason": "Backlog backfill: expose the attested visible official abbreviation as an explicit source-backed search alias."
+    },
+    {
+      "id": "tk-ex-p",
+      "file": "data/Trainer kits/EX trainer Kit 2 (Plusle).ts",
+      "visible": {
+        "official": "TK2P",
+        "fr": "POS"
+      },
+      "searchAliases": [
+        "TK2P"
+      ],
+      "sources": [
+        "https://www.pokepedia.fr/Abr%C3%A9viation_d%27extension",
+        "https://pkmncards.com/advanced/"
+      ],
+      "reason": "Backlog backfill: expose the attested visible official abbreviation as an explicit source-backed search alias."
+    },
+    {
+      "id": "tk-hs-g",
+      "file": "data/Trainer kits/HS trainer Kit (Gyarados).ts",
+      "visible": {
+        "official": "TK4G",
+        "fr": "LEV"
+      },
+      "searchAliases": [
+        "TK4G"
+      ],
+      "sources": [
+        "https://www.pokepedia.fr/Abr%C3%A9viation_d%27extension",
+        "https://pkmncards.com/advanced/"
+      ],
+      "reason": "Backlog backfill: expose the attested visible official abbreviation as an explicit source-backed search alias."
+    },
+    {
+      "id": "tk-hs-r",
+      "file": "data/Trainer kits/HS trainer Kit (Raichu).ts",
+      "visible": {
+        "official": "TK4R",
+        "fr": "RAI"
+      },
+      "searchAliases": [
+        "TK4R"
+      ],
+      "sources": [
+        "https://www.pokepedia.fr/Abr%C3%A9viation_d%27extension",
+        "https://pkmncards.com/advanced/"
+      ],
+      "reason": "Backlog backfill: expose the attested visible official abbreviation as an explicit source-backed search alias."
+    },
+    {
+      "id": "tk-sm-l",
+      "file": "data/Trainer kits/SM trainer Kit (Lycanroc).ts",
+      "visible": {
+        "official": "TK10L",
+        "fr": "LOU"
+      },
+      "searchAliases": [
+        "TK10L"
+      ],
+      "sources": [
+        "https://www.pokepedia.fr/Abr%C3%A9viation_d%27extension",
+        "https://pkmncards.com/advanced/"
+      ],
+      "reason": "Backlog backfill: expose the attested visible official abbreviation as an explicit source-backed search alias."
+    },
+    {
+      "id": "tk-sm-r",
+      "file": "data/Trainer kits/SM trainer Kit (Alolan Raichu).ts",
+      "visible": {
+        "official": "TK10A",
+        "fr": "RAL"
+      },
+      "searchAliases": [
+        "TK10A"
+      ],
+      "sources": [
+        "https://www.pokepedia.fr/Abr%C3%A9viation_d%27extension",
+        "https://pkmncards.com/advanced/"
+      ],
+      "reason": "Backlog backfill: expose the attested visible official abbreviation as an explicit source-backed search alias."
+    },
+    {
+      "id": "tk-xy-b",
+      "file": "data/Trainer kits/XY trainer Kit (Bisharp).ts",
+      "visible": {
+        "official": "TK7A",
+        "fr": "SCA"
+      },
+      "searchAliases": [
+        "TK7A"
+      ],
+      "sources": [
+        "https://www.pokepedia.fr/Abr%C3%A9viation_d%27extension",
+        "https://pkmncards.com/advanced/"
+      ],
+      "reason": "Backlog backfill: expose the attested visible official abbreviation as an explicit source-backed search alias."
+    },
+    {
+      "id": "tk-xy-latia",
+      "file": "data/Trainer kits/XY trainer Kit (Latias).ts",
+      "visible": {
+        "official": "TK8A",
+        "fr": "LTA"
+      },
+      "searchAliases": [
+        "TK8A"
+      ],
+      "sources": [
+        "https://www.pokepedia.fr/Abr%C3%A9viation_d%27extension",
+        "https://pkmncards.com/advanced/"
+      ],
+      "reason": "Backlog backfill: expose the attested visible official abbreviation as an explicit source-backed search alias."
+    },
+    {
+      "id": "tk-xy-latio",
+      "file": "data/Trainer kits/XY trainer Kit (Latios).ts",
+      "visible": {
+        "official": "TK8O",
+        "fr": "LTS"
+      },
+      "searchAliases": [
+        "TK8O"
+      ],
+      "sources": [
+        "https://www.pokepedia.fr/Abr%C3%A9viation_d%27extension",
+        "https://pkmncards.com/advanced/"
+      ],
+      "reason": "Backlog backfill: expose the attested visible official abbreviation as an explicit source-backed search alias."
+    },
+    {
+      "id": "tk-xy-n",
+      "file": "data/Trainer kits/XY trainer Kit (Noivern).ts",
+      "visible": {
+        "official": "TK6N",
+        "fr": "BRU"
+      },
+      "searchAliases": [
+        "TK6N"
+      ],
+      "sources": [
+        "https://www.pokepedia.fr/Abr%C3%A9viation_d%27extension",
+        "https://pkmncards.com/advanced/"
+      ],
+      "reason": "Backlog backfill: expose the attested visible official abbreviation as an explicit source-backed search alias."
+    },
+    {
+      "id": "tk-xy-p",
+      "file": "data/Trainer kits/XY trainer Kit (Pikachu Libre).ts",
+      "visible": {
+        "official": "TK9P",
+        "fr": "PLB"
+      },
+      "searchAliases": [
+        "TK9P"
+      ],
+      "sources": [
+        "https://www.pokepedia.fr/Abr%C3%A9viation_d%27extension",
+        "https://pkmncards.com/advanced/"
+      ],
+      "reason": "Backlog backfill: expose the attested visible official abbreviation as an explicit source-backed search alias."
+    },
+    {
+      "id": "tk-xy-su",
+      "file": "data/Trainer kits/XY trainer Kit (Suicune).ts",
+      "visible": {
+        "official": "TK9S",
+        "fr": "SUI"
+      },
+      "searchAliases": [
+        "TK9S"
+      ],
+      "sources": [
+        "https://www.pokepedia.fr/Abr%C3%A9viation_d%27extension",
+        "https://pkmncards.com/advanced/"
+      ],
+      "reason": "Backlog backfill: expose the attested visible official abbreviation as an explicit source-backed search alias."
+    },
+    {
+      "id": "tk-xy-sy",
+      "file": "data/Trainer kits/XY trainer Kit (Sylveon).ts",
+      "visible": {
+        "official": "TK6S",
+        "fr": "NYM"
+      },
+      "searchAliases": [
+        "TK6S"
+      ],
+      "sources": [
+        "https://www.pokepedia.fr/Abr%C3%A9viation_d%27extension",
+        "https://pkmncards.com/advanced/"
+      ],
+      "reason": "Backlog backfill: expose the attested visible official abbreviation as an explicit source-backed search alias."
+    },
+    {
+      "id": "tk-xy-w",
+      "file": "data/Trainer kits/XY trainer Kit (Wigglytuff).ts",
+      "visible": {
+        "official": "TK7B",
+        "fr": "GRO"
+      },
+      "searchAliases": [
+        "TK7B"
+      ],
+      "sources": [
+        "https://www.pokepedia.fr/Abr%C3%A9viation_d%27extension",
+        "https://pkmncards.com/advanced/"
+      ],
+      "reason": "Backlog backfill: expose the attested visible official abbreviation as an explicit source-backed search alias."
+    },
+    {
+      "id": "wp",
+      "file": "data/Base/W Promotional.ts",
+      "visible": {
+        "official": "W"
+      },
+      "searchAliases": [
+        "W"
+      ],
+      "sources": [
+        "https://www.pokepedia.fr/Abr%C3%A9viation_d%27extension"
+      ],
+      "reason": "Backlog backfill: expose the attested visible official abbreviation as an explicit source-backed search alias."
+    },
+    {
+      "id": "xy0",
+      "file": "data/XY/Kalos Starter Set.ts",
+      "visible": {
+        "official": "KSS",
+        "fr": "BAK"
+      },
+      "searchAliases": [
+        "KSS"
+      ],
+      "sources": [
+        "https://www.pokepedia.fr/Abr%C3%A9viation_d%27extension",
+        "https://pkmncards.com/advanced/"
+      ],
+      "reason": "Backlog backfill: expose the attested visible official abbreviation as an explicit source-backed search alias."
+    },
+    {
+      "id": "xy1",
+      "file": "data/XY/XY.ts",
+      "visible": {
+        "official": "XY",
+        "fr": "XY"
+      },
+      "searchAliases": [
+        "XY"
+      ],
+      "sources": [
+        "https://www.pokepedia.fr/Abr%C3%A9viation_d%27extension",
+        "https://pkmncards.com/advanced/"
+      ],
+      "reason": "Backlog backfill: expose the attested visible official abbreviation as an explicit source-backed search alias."
+    },
+    {
+      "id": "xy10",
+      "file": "data/XY/Fates Collide.ts",
+      "visible": {
+        "official": "FCO",
+        "fr": "IDD"
+      },
+      "searchAliases": [
+        "FCO"
+      ],
+      "sources": [
+        "https://www.pokepedia.fr/Abr%C3%A9viation_d%27extension",
+        "https://pkmncards.com/advanced/"
+      ],
+      "reason": "Backlog backfill: expose the attested visible official abbreviation as an explicit source-backed search alias."
+    },
+    {
+      "id": "xy11",
+      "file": "data/XY/Steam Siege.ts",
+      "visible": {
+        "official": "STS",
+        "fr": "OFV"
+      },
+      "searchAliases": [
+        "STS"
+      ],
+      "sources": [
+        "https://www.pokepedia.fr/Abr%C3%A9viation_d%27extension",
+        "https://pkmncards.com/advanced/"
+      ],
+      "reason": "Backlog backfill: expose the attested visible official abbreviation as an explicit source-backed search alias."
+    },
+    {
+      "id": "xy12",
+      "file": "data/XY/Evolutions.ts",
+      "visible": {
+        "official": "EVO",
+        "fr": "EVO"
+      },
+      "searchAliases": [
+        "EVO"
+      ],
+      "sources": [
+        "https://www.pokepedia.fr/Abr%C3%A9viation_d%27extension",
+        "https://pkmncards.com/advanced/"
+      ],
+      "reason": "Backlog backfill: expose the attested visible official abbreviation as an explicit source-backed search alias."
+    },
+    {
+      "id": "xy2",
+      "file": "data/XY/Flashfire.ts",
+      "visible": {
+        "official": "FLF",
+        "fr": "ETI"
+      },
+      "searchAliases": [
+        "FLF"
+      ],
+      "sources": [
+        "https://www.pokepedia.fr/Abr%C3%A9viation_d%27extension",
+        "https://pkmncards.com/advanced/"
+      ],
+      "reason": "Backlog backfill: expose the attested visible official abbreviation as an explicit source-backed search alias."
+    },
+    {
+      "id": "xy3",
+      "file": "data/XY/Furious Fists.ts",
+      "visible": {
+        "official": "FFI",
+        "fr": "PFU"
+      },
+      "searchAliases": [
+        "FFI"
+      ],
+      "sources": [
+        "https://www.pokepedia.fr/Abr%C3%A9viation_d%27extension",
+        "https://pkmncards.com/advanced/"
+      ],
+      "reason": "Backlog backfill: expose the attested visible official abbreviation as an explicit source-backed search alias."
+    },
+    {
+      "id": "xy4",
+      "file": "data/XY/Phantom Forces.ts",
+      "visible": {
+        "official": "PHF",
+        "fr": "VSP"
+      },
+      "searchAliases": [
+        "PHF"
+      ],
+      "sources": [
+        "https://www.pokepedia.fr/Abr%C3%A9viation_d%27extension",
+        "https://pkmncards.com/advanced/"
+      ],
+      "reason": "Backlog backfill: expose the attested visible official abbreviation as an explicit source-backed search alias."
+    },
+    {
+      "id": "xy5",
+      "file": "data/XY/Primal Clash.ts",
+      "visible": {
+        "official": "PRC",
+        "fr": "PRI"
+      },
+      "searchAliases": [
+        "PRC"
+      ],
+      "sources": [
+        "https://www.pokepedia.fr/Abr%C3%A9viation_d%27extension",
+        "https://pkmncards.com/advanced/"
+      ],
+      "reason": "Backlog backfill: expose the attested visible official abbreviation as an explicit source-backed search alias."
+    },
+    {
+      "id": "xy6",
+      "file": "data/XY/Roaring Skies.ts",
+      "visible": {
+        "official": "ROS",
+        "fr": "CRU"
+      },
+      "searchAliases": [
+        "ROS"
+      ],
+      "sources": [
+        "https://www.pokepedia.fr/Abr%C3%A9viation_d%27extension",
+        "https://pkmncards.com/advanced/"
+      ],
+      "reason": "Backlog backfill: expose the attested visible official abbreviation as an explicit source-backed search alias."
+    },
+    {
+      "id": "xy7",
+      "file": "data/XY/Ancient Origins.ts",
+      "visible": {
+        "official": "AOR",
+        "fr": "ORA"
+      },
+      "searchAliases": [
+        "AOR"
+      ],
+      "sources": [
+        "https://www.pokepedia.fr/Abr%C3%A9viation_d%27extension",
+        "https://pkmncards.com/advanced/"
+      ],
+      "reason": "Backlog backfill: expose the attested visible official abbreviation as an explicit source-backed search alias."
+    },
+    {
+      "id": "xy8",
+      "file": "data/XY/BREAKthrough.ts",
+      "visible": {
+        "official": "BKT",
+        "fr": "IMP"
+      },
+      "searchAliases": [
+        "BKT"
+      ],
+      "sources": [
+        "https://www.pokepedia.fr/Abr%C3%A9viation_d%27extension",
+        "https://pkmncards.com/advanced/"
+      ],
+      "reason": "Backlog backfill: expose the attested visible official abbreviation as an explicit source-backed search alias."
+    },
+    {
+      "id": "xy9",
+      "file": "data/XY/BREAKpoint.ts",
+      "visible": {
+        "official": "BKP",
+        "fr": "RUP"
+      },
+      "searchAliases": [
+        "BKP"
+      ],
+      "sources": [
+        "https://www.pokepedia.fr/Abr%C3%A9viation_d%27extension",
+        "https://pkmncards.com/advanced/"
+      ],
+      "reason": "Backlog backfill: expose the attested visible official abbreviation as an explicit source-backed search alias."
+    },
+    {
+      "id": "xya",
+      "file": "data/XY/Yellow A Alternate.ts",
+      "visible": {
+        "official": "YAA"
+      },
+      "searchAliases": [
+        "YAA"
+      ],
+      "sources": [
+        "https://www.pokepedia.fr/Abr%C3%A9viation_d%27extension",
+        "https://pkmncards.com/advanced/"
+      ],
+      "reason": "Backlog backfill: expose the attested visible official abbreviation as an explicit source-backed search alias."
+    },
+    {
+      "id": "xyp",
+      "file": "data/XY/XY Black Star Promos.ts",
+      "visible": {
+        "official": "XYP",
+        "fr": "PXY"
+      },
+      "searchAliases": [
+        "XYP"
+      ],
+      "sources": [
+        "https://www.pokepedia.fr/Abr%C3%A9viation_d%27extension",
+        "https://pkmncards.com/advanced/",
+        "https://pkmncards.com/set/xy-promos/"
+      ],
+      "reason": "Backlog backfill: expose the attested visible official abbreviation as an explicit source-backed search alias."
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -2,6 +2,8 @@
 	"private": true,
 	"scripts": {
 		"validate": "tsc --noEmit --project tsconfig.json",
+		"set-alias:audit": "bun scripts/audit-set-aliases.ts",
+		"set-alias:audit:strict": "bun scripts/audit-set-aliases.ts --strict",
 		"check-missing": "ts-node meta/scripts/check-missing.ts",
 		"check-missing:help": "echo 'Usage: npm run check-missing \"<pattern>\" \"<property>\" [output-file]'",
 		"link-cardmarket": "ts-node meta/scripts/linkCardToCardmarket.ts",

--- a/scripts/audit-set-aliases.ts
+++ b/scripts/audit-set-aliases.ts
@@ -1,0 +1,67 @@
+import path from 'node:path'
+import { pathToFileURL } from 'node:url'
+import { glob } from 'glob'
+import type { Set } from '../interfaces'
+
+type AuditEntry = {
+	file: string
+	id: string
+	issues: Array<string>
+}
+
+const root = process.cwd()
+const strict = process.argv.includes('--strict')
+
+function hasVisibleAbbreviation(set: Set): boolean {
+	if (!set.abbreviations) {
+		return false
+	}
+
+	return Object.entries(set.abbreviations).some(([, value]) => Boolean(value))
+}
+
+async function loadSet(file: string): Promise<Set> {
+	return (await import(pathToFileURL(file).href)).default as Set
+}
+
+const files = await glob('data/*/*.ts', {
+	cwd: root,
+	absolute: true,
+	posix: false
+})
+
+const entries: Array<AuditEntry> = []
+for (const file of files.sort()) {
+	const set = await loadSet(file)
+	const issues: Array<string> = []
+
+	if (!hasVisibleAbbreviation(set)) {
+		issues.push('missing visible abbreviation')
+	}
+
+	if (!set.searchAliases?.length) {
+		issues.push('missing searchAliases')
+	}
+
+	if (issues.length > 0) {
+		entries.push({
+			file: path.relative(root, file),
+			id: set.id,
+			issues
+		})
+	}
+}
+
+if (entries.length === 0) {
+	console.log('[OK] set alias audit found no gaps')
+	process.exit(0)
+}
+
+console.log(`[!] set alias audit found ${entries.length} gap(s)`)
+for (const entry of entries) {
+	console.log(`${entry.file} (${entry.id}): ${entry.issues.join(', ')}`)
+}
+
+if (strict) {
+	process.exit(1)
+}

--- a/server/compiler/utils/cardUtil.ts
+++ b/server/compiler/utils/cardUtil.ts
@@ -72,6 +72,24 @@ function variantsToVariantsDetailed(variants: CardSingle['variants'],lang: Suppo
 	return result.length > 0 ? result : undefined;
 }
 
+function buildSetNumber(localId: string, card: Card): CardSingle['set_number'] {
+	const normalizedId = localId.toString()
+	const prefix = normalizedId.match(/^([A-Z]+)\d/)?.[1]
+	const subsetCount = prefix ? card.set.subsets?.[prefix]?.cardCount?.official : undefined
+	const officialCount = subsetCount ?? card.set.cardCount?.official
+	const numericMatch = normalizedId.match(/(\d+)/)
+	const denominator = officialCount && officialCount > 0
+		? (prefix && subsetCount ? `${prefix}${officialCount}` : officialCount.toString())
+		: undefined
+
+	return {
+		text: denominator ? `${normalizedId}/${denominator}` : normalizedId,
+		nominator: normalizedId,
+		numeric: numericMatch ? parseInt(numericMatch[1], 10) : undefined,
+		denominator
+	}
+}
+
 // eslint-disable-next-line max-lines-per-function
 export async function cardToCardSingle(localId: string, card: Card, lang: SupportedLanguages): Promise<CardSingle> {
 	const image = await getCardPictures(localId, card, lang)
@@ -167,6 +185,7 @@ export async function cardToCardSingle(localId: string, card: Card, lang: Suppor
 			// images will be coming soon...
 		})) : undefined,
 		updated: await getCardLastEdit(localId, card, lang),
+		set_number: buildSetNumber(localId, card),
 
 		thirdParty: card.thirdParty
 	}

--- a/server/compiler/utils/setUtil.ts
+++ b/server/compiler/utils/setUtil.ts
@@ -4,6 +4,7 @@ import { SetResume, Set as SetSingle } from '../../../meta/definitions/api'
 import { cardToCardSimple, getCards } from './cardUtil'
 import { DB_PATH, fetchRemoteFile, getDataFolder, resolveText, setIsLegal, smartGlob } from './util'
 import path from 'node:path'
+import { buildSetSearchAliases as buildInternalSetSearchAliases } from '../../src/setAliases'
 
 
 interface t {
@@ -14,6 +15,41 @@ const setCache: t = {}
 
 export function isSetAvailable(set: Set, lang: SupportedLanguages): boolean {
 	return !!resolveText(set.name, lang) && !!resolveText(set.serie.name, lang)
+}
+
+export function buildSetAbbreviation(set: Set, lang: SupportedLanguages): SetResume['abbreviation'] {
+	const localized = resolveText(set.abbreviations, lang)
+	if (!set.abbreviations?.official && !localized) {
+		return undefined
+	}
+	return {
+		official: set.abbreviations?.official,
+		localized
+	}
+}
+
+export function buildSetSubsets(set: Set, lang: SupportedLanguages): SetResume['subsets'] {
+	if (!set.subsets) {
+		return undefined
+	}
+
+	const subsets = Object.entries(set.subsets).map(([id, subset]) => ({
+		id,
+		name: subset.name ? resolveText(subset.name, lang) : undefined,
+		cardCount: {
+			official: subset.cardCount?.official ?? 0
+		}
+	}))
+
+	return subsets.length > 0 ? subsets : undefined
+}
+
+type CompiledSetSingle = SetSingle & {
+	searchAliases?: Array<string>
+}
+
+export function buildSetSearchAliases(set: Set): Array<string> | undefined {
+	return buildInternalSetSearchAliases(set)
 }
 
 /**
@@ -57,30 +93,39 @@ export async function getSetPictures(set: Set, lang: SupportedLanguages): Promis
 		const logoExists = file[lang]?.[set.serie.id]?.[set.id]?.logo ? `https://assets.tcgdex.net/${lang}/${set.serie.id}/${set.id}/logo` : undefined
 		const symbolExists = file.univ?.[set.serie.id]?.[set.id]?.symbol ? `https://assets.tcgdex.net/univ/${set.serie.id}/${set.id}/symbol` : undefined
 		return [
-			logoExists,
-			symbolExists
+			logoExists ?? set.logo,
+			symbolExists ?? set.symbol
 		]
 	} catch {
-		return [undefined, undefined]
+		return [set.logo, set.symbol]
 	}
 }
 
 export async function setToSetSimple(set: Set, lang: SupportedLanguages): Promise<SetResume> {
 	const cards = await getCards(lang, set)
 	const pics = await getSetPictures(set, lang)
+	const abbreviation = buildSetAbbreviation(set, lang)
+	const subsets = buildSetSubsets(set, lang)
+
 	return {
 		cardCount: {
-			official: set.cardCount.official,
-			total: Math.max(set.cardCount.official, cards.length)
+			official: set.cardCount?.official ?? 0,
+			total: Math.max(set.cardCount?.official ?? 0, cards.length)
 		},
 		id: set.id,
 		logo: pics[0],
 		name: resolveText(set.name, lang),
-		symbol: pics[1]
+		symbol: pics[1],
+		abbreviation,
+		subsets,
+		serie: {
+			id: set.serie.id,
+			name: resolveText(set.serie.name, lang)
+		}
 	}
 }
 
-function getVariantCountForType(card: Card, type: 'normal' | 'reverse' | 'holo' | 'firstEdition'): number {
+export function getVariantCountForType(card: Card, type: 'normal' | 'reverse' | 'holo' | 'firstEdition'): number {
 	if( card.variants === undefined || card.variants === null) {
 		return 0;
 	}
@@ -98,17 +143,19 @@ function getVariantCountForType(card: Card, type: 'normal' | 'reverse' | 'holo' 
 }
 
 
-export async function setToSetSingle(set: Set, lang: SupportedLanguages): Promise<SetSingle> {
+export async function setToSetSingle(set: Set, lang: SupportedLanguages): Promise<CompiledSetSingle> {
 	const cards = await getCards(lang, set)
 	const pics = await getSetPictures(set, lang)
+	const subsets = buildSetSubsets(set, lang)
+	const searchAliases = buildSetSearchAliases(set)
 	return {
 		cardCount: {
 			firstEd: cards.reduce((count, card) => count + getVariantCountForType(card[1],"firstEdition"), 0),
 			holo: cards.reduce((count, card) => count + getVariantCountForType(card[1],"holo"), 0),
 			normal: cards.reduce((count, card) => count + getVariantCountForType(card[1],"normal"), 0),
-			official: set.cardCount.official,
+			official: set.cardCount?.official ?? 0,
 			reverse: cards.reduce((count, card) => count + getVariantCountForType(card[1],"reverse"), 0),
-			total: Math.max(set.cardCount.official, cards.length)
+			total: Math.max(set.cardCount?.official ?? 0, cards.length)
 		},
 		cards: await Promise.all(cards.map(([id, card]) => cardToCardSimple(id, card, lang))),
 		id: set.id,
@@ -125,10 +172,9 @@ export async function setToSetSingle(set: Set, lang: SupportedLanguages): Promis
 		},
 		symbol: pics[1],
 		tcgOnline: set.tcgOnline,
-		abbreviation: (set.abbreviations?.official || resolveText(set.abbreviations, lang)) ? {
-			official: set.abbreviations?.official,
-			localized: resolveText(set.abbreviations, lang)
-		} : undefined,
+		abbreviation: buildSetAbbreviation(set, lang),
+		subsets,
+		searchAliases,
 		boosters: set.boosters ? objectMap(set.boosters, (booster, id) => ({
 			id: `boo_${set.id}-${id}`,
 			name: resolveText(booster.name, lang),

--- a/server/src/V2/Components/Set.ts
+++ b/server/src/V2/Components/Set.ts
@@ -1,6 +1,7 @@
 import type { Set as SDKSet, SetResume, SupportedLanguages } from '@tcgdex/sdk'
 import { executeQuery, type Query } from '../../libs/QueryEngine/filter'
 import { objectOmit } from '@dzeio/object-util'
+import { buildAliasIndex, normalizeSetAlias, remapSetAliasQueryValue } from '../../setAliases'
 
 import de from '../../../generated/de/sets.json'
 import en from '../../../generated/en/sets.json'
@@ -44,13 +45,54 @@ export const sets = {
 
 type MappedSet = any // (typeof en)[number]
 
+const aliasIndexes = new Map<SupportedLanguages, Map<string, Array<string>>>()
+
+function getAliasIndex(lang: SupportedLanguages): Map<string, Array<string>> {
+	const cached = aliasIndexes.get(lang)
+	if (cached) {
+		return cached
+	}
+
+	const index = buildAliasIndex(
+		sets[lang] as Array<MappedSet>,
+		(set) => set.searchAliases ?? [set.id]
+	)
+
+	aliasIndexes.set(lang, index)
+	return index
+}
+
+export function resolveSetAliasIds(lang: SupportedLanguages, value: string): Array<string> | undefined {
+	return getAliasIndex(lang).get(normalizeSetAlias(value))
+}
+
+export function resolveSetAliasId(lang: SupportedLanguages, value: string): string | undefined {
+	const ids = resolveSetAliasIds(lang, value)
+	return ids?.length === 1 ? ids[0] : undefined
+}
+
+export function remapSetIdQueryValue<T>(lang: SupportedLanguages, value: T): T {
+	return remapSetAliasQueryValue(value, (candidate) => resolveSetAliasId(lang, candidate))
+}
+
+function rewriteSetQuery(lang: SupportedLanguages, query: Query<SDKSet>): Query<SDKSet> {
+	if (!('id' in query)) {
+		return query
+	}
+
+	return {
+		...query,
+		id: remapSetIdQueryValue(lang, query.id)
+	}
+}
+
 export async function getAllSets(lang: SupportedLanguages): Promise<Array<SDKSet>> {
 	return Promise.all((sets[lang] as Array<MappedSet>).map(transformSet))
 }
 
 async function transformSet(set: MappedSet): Promise<SDKSet> {
 	return {
-		...objectOmit(set, 'thirdParty'),
+		...objectOmit(objectOmit(set, 'thirdParty'), 'searchAliases'),
 		// pricing: {
 		// 	cardmarket: await getCardMarketPrice(card),
 		// 	tcgplayer: await getTCGPlayerPrice(card)
@@ -59,7 +101,7 @@ async function transformSet(set: MappedSet): Promise<SDKSet> {
 }
 
 export async function findSets(lang: SupportedLanguages, query: Query<SDKSet>) {
-	return executeQuery(await getAllSets(lang), query).data
+	return executeQuery(await getAllSets(lang), rewriteSetQuery(lang, query)).data
 }
 
 export async function findOneSet(lang: SupportedLanguages, query: Query<SDKSet>) {

--- a/server/src/V2/endpoints/jsonEndpoints.ts
+++ b/server/src/V2/endpoints/jsonEndpoints.ts
@@ -1,13 +1,13 @@
 import { objectKeys } from '@dzeio/object-util'
-import type { Card as SDKCard } from '@tcgdex/sdk'
+import type { Card as SDKCard, SupportedLanguages } from '@tcgdex/sdk'
 import apicache from 'apicache'
-import express, { type Request } from 'express'
+import express, { type Request, type Response } from 'express'
 import { Errors, sendError } from '../../libs/Errors'
 import type { Query } from '../../libs/QueryEngine/filter'
 import { recordToQuery } from '../../libs/QueryEngine/parsers'
 import { betterSorter, checkLanguage, unique } from '../../util'
 import { getAllCards, findOneCard, findCards, toBrief, getCardById, getCompiledCard } from '../Components/Card'
-import { findOneSet, findSets, setToBrief } from '../Components/Set'
+import { findOneSet, findSets, remapSetIdQueryValue, resolveSetAliasIds, setToBrief } from '../Components/Set'
 import { findOneSerie, findSeries, serieToBrief } from '../Components/Serie'
 import { listSKUs } from '../../libs/providers/tcgplayer'
 
@@ -40,9 +40,38 @@ const endpointToField: Record<string, keyof SDKCard> = {
 	variants: "variants",
 }
 
+export function buildSetIdClauses(lang: SupportedLanguages, value: unknown): Array<Record<string, unknown>> {
+	const aliases = new Set<string>()
+
+	const collect = (entry: unknown) => {
+		if (typeof entry === 'string') {
+			for (const id of resolveSetAliasIds(lang, entry) ?? []) {
+				aliases.add(id)
+			}
+			return
+		}
+
+		if (Array.isArray(entry)) {
+			entry.forEach(collect)
+			return
+		}
+
+		if (entry && typeof entry === 'object') {
+			Object.values(entry).forEach(collect)
+		}
+	}
+
+	collect(value)
+	if (aliases.size > 0) {
+		return [...aliases].map((id) => ({ 'set.id': { $eq: id } }))
+	}
+
+	return [{ 'set.id': remapSetIdQueryValue(lang, value) }]
+}
+
 server
 	// Midleware that handle caching only in production and on GET requests
-	.use(apicache.middleware('1 day', (req: CustomRequest, res: Response) => !req.DO_NOT_CACHE && res.status < 400 && process.env.NODE_ENV === 'production' && req.method === 'GET', {}))
+	.use(apicache.middleware('1 day', (req: CustomRequest, res: Response) => !req.DO_NOT_CACHE && res.statusCode < 400 && process.env.NODE_ENV === 'production' && req.method === 'GET', {}))
 
 	// .get('/cache/performance', (req, res) => {
 	// 	res.json(apicache.getPerformance())
@@ -133,11 +162,10 @@ server
 				if ('set' in query) {
 					const tmp = query.set
 					delete query.set
-					query.$or = [{
-						'set.id': tmp
-					}, {
-						'set.name': tmp
-					}]
+					query.$or = [
+						...buildSetIdClauses(lang, tmp),
+						{ 'set.name': tmp }
+					] as any
 				}
 				result = (await findCards(lang, query))
 					.map(toBrief)
@@ -235,7 +263,7 @@ server
 				break
 
 			case 'sets':
-				result = await findOneSet(lang, { id })
+				result = await findOneSet(lang, { id: remapSetIdQueryValue(lang, id) })
 				if (!result) {
 					result = await findOneSet(lang, { name: id })
 				}
@@ -303,8 +331,13 @@ server
 				break
 			case 'sets':
 				// allow the dev to use a non prefixed value like `10` instead of `010` for newer sets
-				// @ts-expect-error normal behavior until the filtering is more fiable
-				result = await findOneCard(lang, { localId: { $or: [subid.padStart(3, '0'), subid] }, $or: [{ 'set.id': id }, { 'set.name': id }] })
+				result = await findOneCard(lang, {
+					localId: { $or: [subid.padStart(3, '0'), subid] },
+					$or: [
+						...buildSetIdClauses(lang, id),
+						{ 'set.name': id }
+					]
+				} as any)
 				break
 		}
 		if (!result) {

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -16,6 +16,8 @@ Sentry.init({
 	environment: process.env.NODE_ENV
 })
 
+const PORT = Number.parseInt(process.env.PORT ?? '3000', 10)
+
 if (cluster.isPrimary) {
 	console.log(`Primary ${process.pid} is running`)
 
@@ -41,7 +43,7 @@ if (cluster.isPrimary) {
 		console.log(`Worker ${worker.id} exited with code ${code} and signal ${signal}`);
 		cluster.fork()
 	})
-	console.log('🚀 Server ready at localhost:3000');
+	console.log(`🚀 Server ready at localhost:${PORT}`);
 } else {
 
 	// Current API version
@@ -157,5 +159,5 @@ if (cluster.isPrimary) {
 	})
 
 	// Start server
-	server.listen(3000)
+	server.listen(PORT)
 }

--- a/server/src/setAliases.ts
+++ b/server/src/setAliases.ts
@@ -1,0 +1,122 @@
+import type { Set } from '../../interfaces'
+
+type SearchableSet = Pick<Set, 'id' | 'serie' | 'abbreviations'> & {
+	searchAliases?: Array<string>
+}
+
+type AliasIndexedItem = {
+	id: string
+}
+
+const GENERIC_ALIAS_PREFIXES: Record<string, Array<string>> = {
+	me: ['me'],
+	sv: ['sv', 'ev']
+}
+
+export function normalizeSetAlias(value: string): string {
+	return value
+		.trim()
+		.toLowerCase()
+		.replace(/[\s_-]+/g, '')
+}
+
+function collectNormalizedAliases(values: Iterable<string | null | undefined>): Map<string, string> {
+	const aliases = new Map<string, string>()
+
+	for (const value of values) {
+		if (!value) {
+			continue
+		}
+
+		const normalized = normalizeSetAlias(value)
+		if (!normalized || aliases.has(normalized)) {
+			continue
+		}
+
+		aliases.set(normalized, value)
+	}
+
+	return aliases
+}
+
+function buildNumericIdAliases(set: SearchableSet): Array<string> {
+	const prefixes = GENERIC_ALIAS_PREFIXES[set.serie.id]
+	if (!prefixes) {
+		return []
+	}
+
+	const pattern = new RegExp(`^${set.serie.id}(\\d+)(\\.\\d+)?$`, 'i')
+	const match = set.id.match(pattern)
+	if (!match) {
+		return []
+	}
+
+	const [, wholePart, decimalPart = ''] = match
+	const unpaddedWholePart = String(Number.parseInt(wholePart, 10))
+	const numericParts = new Set<string>([
+		`${wholePart}${decimalPart}`,
+		`${unpaddedWholePart}${decimalPart}`
+	])
+
+	return prefixes.flatMap((prefix) => [...numericParts].map((value) => `${prefix}${value}`))
+}
+
+function getSetAliasCandidates(set: SearchableSet): Array<string | undefined> {
+	return [
+		set.id,
+		set.abbreviations?.official,
+		...Object.entries(set.abbreviations ?? {})
+			.filter(([key]) => key !== 'official')
+			.map(([, value]) => value),
+		...(set.searchAliases ?? []),
+		...buildNumericIdAliases(set)
+	]
+}
+
+export function buildSetSearchAliases(set: SearchableSet): Array<string> | undefined {
+	const values = [...collectNormalizedAliases(getSetAliasCandidates(set)).values()]
+	return values.length > 0 ? values : undefined
+}
+
+export function buildAliasIndex<T extends AliasIndexedItem>(
+	items: Array<T>,
+	getAliases: (item: T) => Iterable<string | null | undefined>
+): Map<string, Array<string>> {
+	const index = new Map<string, Array<string>>()
+
+	for (const item of items) {
+		for (const normalized of collectNormalizedAliases(getAliases(item)).keys()) {
+			const existing = index.get(normalized) ?? []
+			if (!existing.includes(item.id)) {
+				existing.push(item.id)
+			}
+			index.set(normalized, existing)
+		}
+	}
+
+	return index
+}
+
+export function remapSetAliasQueryValue<T>(
+	value: T,
+	resolveAlias: (candidate: string) => string | undefined
+): T {
+	if (typeof value === 'string') {
+		return (resolveAlias(value) ?? value) as T
+	}
+
+	if (Array.isArray(value)) {
+		return value.map((entry) => remapSetAliasQueryValue(entry, resolveAlias)) as T
+	}
+
+	if (!value || typeof value !== 'object') {
+		return value
+	}
+
+	return Object.fromEntries(
+		Object.entries(value).map(([key, entry]) => [
+			key,
+			remapSetAliasQueryValue(entry, resolveAlias)
+		])
+	) as T
+}

--- a/server/tests/setAliasQuery.test.ts
+++ b/server/tests/setAliasQuery.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'bun:test'
+import { findOneSet } from '../src/V2/Components/Set'
+import { buildSetIdClauses } from '../src/V2/endpoints/jsonEndpoints'
+
+describe('set alias query layer', () => {
+	it('resolves official, generic, and localized aliases to the same canonical set', async () => {
+		const official = await findOneSet('en', { id: 'svi' })
+		const generic = await findOneSet('en', { id: 'sv1' })
+		const localized = await findOneSet('fr', { id: 'ev01' })
+
+		expect(official?.id).toBe('sv01')
+		expect(generic?.id).toBe('sv01')
+		expect(localized?.id).toBe('sv01')
+	})
+
+	it('fans out ambiguous split-set aliases for card filtering', () => {
+		const clauses = buildSetIdClauses('en', { $eq: 'sv10.5' })
+		const ids = clauses
+			.map((clause) => ((clause['set.id'] as { $eq?: string } | undefined)?.$eq))
+			.filter((id): id is string => Boolean(id))
+			.sort()
+
+		expect(ids).toEqual(['sv10.5b', 'sv10.5w'])
+	})
+
+	it('keeps explicit Black and White suffix aliases targeted', () => {
+		const blackBolt = buildSetIdClauses('en', { $eq: 'sv10.5b' })
+		const whiteFlare = buildSetIdClauses('en', { $eq: 'sv10.5w' })
+
+		expect(blackBolt).toEqual([{ 'set.id': { $eq: 'sv10.5b' } }])
+		expect(whiteFlare).toEqual([{ 'set.id': { $eq: 'sv10.5w' } }])
+	})
+})

--- a/server/tests/setUtil.test.ts
+++ b/server/tests/setUtil.test.ts
@@ -1,0 +1,204 @@
+import { describe, expect, it } from 'bun:test'
+import type { Card, Serie, Set } from '../../interfaces'
+import { buildSetAbbreviation, buildSetSearchAliases, buildSetSubsets, getVariantCountForType, setToSetSimple, setToSetSingle } from '../compiler/utils/setUtil'
+
+const serie: Serie = {
+	id: 'test-serie',
+	name: { en: 'Test Serie' }
+}
+
+const buildSet = (overrides: Partial<Set> = {}): Set => ({
+	id: 'test-set',
+	name: { en: 'Test Set' },
+	serie,
+	cardCount: { official: 0 },
+	releaseDate: '2024-01-01',
+	...overrides
+})
+
+const buildCard = (overrides: Partial<Card> = {}): Card => ({
+	name: { en: 'Test Card' },
+	category: 'Pokemon',
+	rarity: 'Common',
+	set: buildSet(),
+	stage: 'Basic',
+	...overrides
+})
+
+async function withRejectedFetch<T>(fn: () => Promise<T>): Promise<T> {
+	const originalFetch = globalThis.fetch
+	;(globalThis as any).fetch = async () => {
+		throw new Error('offline-test')
+	}
+	try {
+		return await fn()
+	} finally {
+		globalThis.fetch = originalFetch
+	}
+}
+
+describe('buildSetAbbreviation', () => {
+	it('returns undefined when both official and localized abbreviations are missing', () => {
+		const set = buildSet()
+		expect(buildSetAbbreviation(set, 'en')).toBeUndefined()
+	})
+
+	it('re-uses the localized entry for the requested language', () => {
+		const set = buildSet({
+			abbreviations: {
+				official: 'DAA',
+				fr: 'TEM'
+			}
+		})
+
+		expect(buildSetAbbreviation(set, 'en')).toEqual({
+			official: 'DAA',
+			localized: undefined
+		})
+
+		expect(buildSetAbbreviation(set, 'fr')).toEqual({
+			official: 'DAA',
+			localized: 'TEM'
+		})
+	})
+})
+
+describe('buildSetSearchAliases', () => {
+	it('collects visible abbreviations and generic Scarlet & Violet aliases', () => {
+		const set = buildSet({
+			id: 'sv03.5',
+			serie: {
+				id: 'sv',
+				name: { en: 'Scarlet & Violet' }
+			},
+			abbreviations: {
+				official: 'MEW',
+				fr: 'EV3.5'
+			}
+		})
+
+		expect(buildSetSearchAliases(set)).toEqual([
+			'sv03.5',
+			'MEW',
+			'EV3.5',
+			'sv3.5',
+			'ev03.5'
+		])
+	})
+
+	it('derives Mega Evolution numeric aliases without duplicating explicit codes', () => {
+		const set = buildSet({
+			id: 'me02.5',
+			serie: {
+				id: 'me',
+				name: { en: 'Mega Evolution' }
+			},
+			abbreviations: {
+				official: 'ASC',
+				fr: 'HER'
+			}
+		})
+
+		expect(buildSetSearchAliases(set)).toEqual([
+			'me02.5',
+			'ASC',
+			'HER',
+			'me2.5'
+		])
+	})
+})
+
+describe('subset propagation', () => {
+	it('builds localized subset entries from set metadata', () => {
+		const set = buildSet({
+			subsets: {
+				RC: {
+					name: { en: 'Radiant Collection', fr: 'Radiant Collection' },
+					cardCount: { official: 32 }
+				}
+			}
+		})
+
+		expect(buildSetSubsets(set, 'en')).toEqual([
+			{
+				id: 'RC',
+				name: 'Radiant Collection',
+				cardCount: { official: 32 }
+			}
+		])
+	})
+
+	it('propagates subsets in setToSetSimple', async () => {
+		const set = buildSet({
+			subsets: {
+				TG: {
+					name: { en: 'Trainer Gallery' },
+					cardCount: { official: 30 }
+				}
+			}
+		})
+
+		const result = await withRejectedFetch(() => setToSetSimple(set, 'en'))
+		expect(result.serie).toEqual({ id: 'test-serie', name: 'Test Serie' })
+		expect(result.subsets).toEqual([
+			{
+				id: 'TG',
+				name: 'Trainer Gallery',
+				cardCount: { official: 30 }
+			}
+		])
+	})
+
+	it('propagates subsets in setToSetSingle', async () => {
+		const set = buildSet({
+			subsets: {
+				GG: {
+					name: { en: 'Galarian Gallery' },
+					cardCount: { official: 70 }
+				}
+			}
+		})
+
+		const result = await withRejectedFetch(() => setToSetSingle(set, 'en'))
+		expect(result.subsets).toEqual([
+			{
+				id: 'GG',
+				name: 'Galarian Gallery',
+				cardCount: { official: 70 }
+			}
+		])
+	})
+})
+
+describe('getVariantCountForType', () => {
+	it('counts variants directly from the boolean structure', () => {
+		const card = buildCard({
+			variants: {
+				firstEdition: true,
+				holo: false,
+				normal: true,
+				reverse: false
+			}
+		})
+
+		expect(getVariantCountForType(card, 'normal')).toBe(1)
+		expect(getVariantCountForType(card, 'reverse')).toBe(0)
+		expect(getVariantCountForType(card, 'firstEdition')).toBe(1)
+	})
+
+	it('counts variants from the detailed array, including first edition stamps', () => {
+		const card = buildCard({
+			variants: [
+				{ type: 'normal', stamp: ['1st-edition'] },
+				{ type: 'reverse' },
+				{ type: 'holo' }
+			]
+		})
+
+		expect(getVariantCountForType(card, 'normal')).toBe(1)
+		expect(getVariantCountForType(card, 'reverse')).toBe(1)
+		expect(getVariantCountForType(card, 'holo')).toBe(1)
+		expect(getVariantCountForType(card, 'firstEdition')).toBe(1)
+	})
+})
+


### PR DESCRIPTION
## Summary
- backfill visible abbreviations and source-backed `searchAliases` across remaining legacy, modern, promo, McDonald's, Trainer Kit, and TCG Pocket sets
- resolve set aliases consistently in direct set routes and card `set=` filters without exposing the internal alias list in public API payloads
- add supporting audit/research artifacts, unit tests, Bruno regressions, and `PORT` override support for isolated API validation

## Test plan
- [x] `bun run set-alias:audit`
- [x] `bun run validate`
- [x] `cd server && bun run --bun validate`
- [x] `cd server && bun test`
- [x] `cd server && bun run compile`
- [x] `cd .bruno && bru run --env Developpement --env-var BASE_URL=http://127.0.0.1:3322`