### PR TITLE
fix(data): complete missing french text for legacy trainer cards

### DIFF
--- a/data/E-Card/Aquapolis/124.ts
+++ b/data/E-Card/Aquapolis/124.ts
@@ -18,17 +18,21 @@ const card: Card = {
 		de: "Lege diese Karte an 1 deiner -Pokémon im Spiel an. Dieses Pokémon kann den Angriff dieser Karte anstatt seiner eigenen verwenden. Lege am Ende deines Zuges Gras-Würfel 01 auf deinen Ablagestapel."
 	},
 
-	attacks: [{
-		name: {
-			de: "Schlafgift"
+	attacks: [
+		{
+			name: {
+				de: "Schlafgift",
+				fr: "Poison dodo"
+			},
+			effect: {
+				de: "Das Verteidigende Pokémon ist jetzt vergiftet und schläft.",
+				fr: "Le Pokémon Défenseur est maintenant Endormi et Empoisonné."
+			},
+			cost: [
+				"Grass",
+			]
 		},
-
-		effect: {
-			de: "Das Verteidigende Pokémon ist jetzt vergiftet und schläft."
-		},
-
-		cost: ["Grass"]
-	}],
+	],
 
 	thirdParty: {
 		cardmarket: 275200,

--- a/data/E-Card/Aquapolis/127.ts
+++ b/data/E-Card/Aquapolis/127.ts
@@ -15,7 +15,7 @@ const card: Card = {
 
 	effect: {
 		fr: "Attachez cette carte à l'un de vos Pokémon {L} en jeu. Ce Pokémon peut utiliser l'attaque de cette carte à la place de la sienne. À la fin de votre tour, défaussez-vous de Cube électrik 01.",
-		de: "Lege diese Karte an 1 deiner -Pokémon im Spiel an. Dieses Pokémon kann den Angriff dieser Karte anstatt seiner eigenen verwenden. Lege am Ende deines Zuges Elektro-Würfel 01 auf deinen Ablagestapel."
+		de: "Lege diese Karte an 1 deiner {L}-Pokémon im Spiel an. Dieses Pokémon kann den Angriff dieser Karte anstatt seiner eigenen verwenden. Lege am Ende deines Zuges Elektro-Würfel 01 auf deinen Ablagestapel."
 	},
 
 	attacks: [
@@ -26,8 +26,8 @@ const card: Card = {
 			},
 			damage: "40x",
 			effect: {
-				de: "Discard all -Energy cards attached to this Pokémon. Then, flip a number of coins equal to the nuber of Energy cards discarded that way. This attack does 40 damage times the number of heads.",
-				fr: "Défaussez -vous de toutes les cartes Énergie {L} attachées à ce Pokémon. Lancez ensuite un nombre de pièces égal au nombre de cartes Énergie que vous avez défaussé de cette manière. Cette attaque fait 40 dégâts multipliés par le nombre de faces."
+				de: "Discard all {L}-Energy cards attached to this Pokémon. Then, flip a number of coins equal to the number of Energy cards discarded that way. This attack does 40 damage times the number of heads.",
+				fr: "Défaussez-vous de toutes les cartes Énergie {L} attachées à ce Pokémon. Lancez ensuite un nombre de pièces égal au nombre de cartes Énergie que vous avez défaussé de cette manière. Cette attaque fait 40 dégâts multipliés par le nombre de faces."
 			},
 			cost: [
 				"Lightning",

--- a/data/E-Card/Aquapolis/127.ts
+++ b/data/E-Card/Aquapolis/127.ts
@@ -18,19 +18,22 @@ const card: Card = {
 		de: "Lege diese Karte an 1 deiner -Pokémon im Spiel an. Dieses Pokémon kann den Angriff dieser Karte anstatt seiner eigenen verwenden. Lege am Ende deines Zuges Elektro-Würfel 01 auf deinen Ablagestapel."
 	},
 
-	attacks: [{
-		name: {
-			de: "Discharge"
+	attacks: [
+		{
+			name: {
+				de: "Discharge",
+				fr: "Décharge"
+			},
+			damage: "40x",
+			effect: {
+				de: "Discard all -Energy cards attached to this Pokémon. Then, flip a number of coins equal to the nuber of Energy cards discarded that way. This attack does 40 damage times the number of heads.",
+				fr: "Défaussez -vous de toutes les cartes Énergie {L} attachées à ce Pokémon. Lancez ensuite un nombre de pièces égal au nombre de cartes Énergie que vous avez défaussé de cette manière. Cette attaque fait 40 dégâts multipliés par le nombre de faces."
+			},
+			cost: [
+				"Lightning",
+			]
 		},
-
-		damage: "40x",
-
-		effect: {
-			de: "Discard all -Energy cards attached to this Pokémon. Then, flip a number of coins equal to the nuber of Energy cards discarded that way. This attack does 40 damage times the number of heads."
-		},
-
-		cost: ["Lightning"]
-	}],
+	],
 
 	thirdParty: {
 		cardmarket: 275203,

--- a/data/E-Card/Aquapolis/128.ts
+++ b/data/E-Card/Aquapolis/128.ts
@@ -14,7 +14,7 @@ const card: Card = {
 	set: Set,
 
 	effect: {
-		fr: "Attachez Baie de mémoire à un de vos Pokémon qui n'a pas d'Outil Pokémon attaché à lui. Si ce Pokémon est mis K.O., défaussez-vous de cette carte.\n\nLe Pokémon auquel cette carte est attachée peut utiliser n'importe quelle attaque de la carte Pokémon de base ou de la carte Évolution dont ce Pokémon a évolué. (You still have to pay for that attack's Energy cost.) Discard this card at the end of any turn the Pokémon attacks.",
+		fr: "Le Pokémon auquel cette carte est attachée peut utiliser n'importe quelle attaque de la carte Pokémon de base ou de la carte Évolution dont ce Pokémon a évolué. (You still have to pay for that attack's Energy cost.) Discard this card at the end of any turn the Pokémon attacks.",
 		de: "The Pokémon this card is attached to can use any attack from its Basic Pokémon card or any Evolution card from which the Pokémon evolved. (You still have to pay for that attack´s Energy cost.) Discard this card at the end of any turn the Pokémon attacks."
 	},
 

--- a/data/E-Card/Aquapolis/128.ts
+++ b/data/E-Card/Aquapolis/128.ts
@@ -3,9 +3,8 @@ import Set from '../Aquapolis'
 
 const card: Card = {
 	name: {
-		en: "Memory Berry",
-		fr: "Baie de mémoire",
-		de: "Memory Berry*"
+		de: "Memory Berry",
+		fr: "Baie de mémoire"
 	},
 
 	illustrator: "Shin-ichi Yoshikawa",
@@ -14,8 +13,8 @@ const card: Card = {
 	set: Set,
 
 	effect: {
-		fr: "Le Pokémon auquel cette carte est attachée peut utiliser n'importe quelle attaque de la carte Pokémon de base ou de la carte Évolution dont ce Pokémon a évolué. (You still have to pay for that attack's Energy cost.) Discard this card at the end of any turn the Pokémon attacks.",
-		de: "The Pokémon this card is attached to can use any attack from its Basic Pokémon card or any Evolution card from which the Pokémon evolved. (You still have to pay for that attack´s Energy cost.) Discard this card at the end of any turn the Pokémon attacks."
+		de: "Attach Memory Berry to I of your Pokémon that doesn't have a Pokémon Tool attached to it. If that Pokémon is Knocked Out, discard this card.\n\nThe Pokémon this card is attached to can use any attack from its Basic Pokémon card or any Evolution card from which the Pokémon evolved. (You still have to pay for that attack´s Energy cost.) Discard this card at the end of any turn the Pokémon attacks.",
+		fr: "Attachez Baie de mémoire à un de vos Pokémon qui n'a pas d'Outil Pokémon attaché à lui. Si ce Pokémon est mis K.O., défaussez-vous de cette carte.\n\nLe Pokémon auquel cette carte est attachée peut utiliser n'importe quelle attaque de la carte Pokémon de base ou de la carte Évolution dont ce Pokémon a évolué. (You still have to pay for that attack's Energy cost.) Discard this card at the end of any turn the Pokémon attacks."
 	},
 
 	thirdParty: {

--- a/data/EX/Holon Phantoms/87.ts
+++ b/data/EX/Holon Phantoms/87.ts
@@ -19,17 +19,21 @@ const card: Card = {
 		de: "Jedes Pokémon, auf dem δ zu sehen ist, kann die Angriffe auf dieser Karte anstelle seiner eigenen benutzen.",
 	},
 
-	attacks: [{
-		name: {
-			de: "Delta-Ruf"
+	attacks: [
+		{
+			name: {
+				de: "Delta-Ruf",
+				fr: "Appel Delta"
+			},
+			effect: {
+				de: "Durchsuche dein Deck nach einem Pokémon, auf dem δ zu sehen ist, zeige es deinem Gegner und nimm es auf die Hand. Mische dein Deck danach.",
+				fr: "Cherchez dans votre deck un Pokémon possédant le symbole δ, montrez-le à votre adversaire et placez-le dans votre main. Ensuite, mélangez votre deck."
+			},
+			cost: [
+				"Colorless",
+			]
 		},
-
-		effect: {
-			de: "Durchsuche dein Deck nach einem Pokémon, auf dem δ zu sehen ist, zeige es deinem Gegner und nimm es auf die Hand. Mische dein Deck danach."
-		},
-
-		cost: ["Colorless"]
-	}],
+	],
 
 	thirdParty: {
 		cardmarket: 277057,

--- a/data/EX/Team Magma vs Team Aqua/79.ts
+++ b/data/EX/Team Magma vs Team Aqua/79.ts
@@ -19,19 +19,22 @@ const card: Card = {
 		de: "Attach this card to 1 of your Pokémon that has Team Aqua in its name. That Pokémon may use this card's attack instead of its own. At the end of your turn, discard Team Aqua Technical Machine 01."
 	},
 
-	attacks: [{
-		name: {
-			de: "Miracle"
+	attacks: [
+		{
+			name: {
+				de: "Miracle",
+				fr: "Miracle"
+			},
+			damage: 10,
+			effect: {
+				de: "Choose 1 Special Condition. The Defending Pokémon is now affected by that Special Condition.",
+				fr: "Choisissez un État Spécial. Le Pokémon Défenseur est maintenant affecté par cet État Spécial."
+			},
+			cost: [
+				"Colorless",
+			]
 		},
-
-		damage: 10,
-
-		effect: {
-			de: "Choose 1 Special Condition. The Defending Pokémon is now affected by that Special Condition."
-		},
-
-		cost: ["Colorless"]
-	}],
+	],
 
 	variants: [
 		{

--- a/data/EX/Team Magma vs Team Aqua/84.ts
+++ b/data/EX/Team Magma vs Team Aqua/84.ts
@@ -19,19 +19,22 @@ const card: Card = {
 		de: "Attach this card to 1 of your Pokémon that has Team Magma in its name. That Pokémon may use this card´s attack instead of its own. At the end of your turn, discard Team Magma Technical Machine 01."
 	},
 
-	attacks: [{
-		name: {
-			de: "Crushing Magma"
+	attacks: [
+		{
+			name: {
+				de: "Crushing Magma",
+				fr: "Magma écrasant"
+			},
+			damage: 10,
+			effect: {
+				de: "Choose Energy card attached to the Defending Pokémon and put that card at the bottom of your opponent´s deck.",
+				fr: "Choisissez une carte Énergie attachée au Pokémon Défenseur et placez-la à la fin du deck de votre adversaire."
+			},
+			cost: [
+				"Colorless",
+			]
 		},
-
-		damage: 10,
-
-		effect: {
-			de: "Choose Energy card attached to the Defending Pokémon and put that card at the bottom of your opponent´s deck."
-		},
-
-		cost: ["Colorless"]
-	}],
+	],
 
 	variants: [
 		{

--- a/data/XY/Fates Collide/108.ts
+++ b/data/XY/Fates Collide/108.ts
@@ -17,12 +17,12 @@ const card: Card = {
 	set: Set,
 
 	effect: {
-		fr: "Le Zygarde-EX auquel cette carte est attachée peut aussi utiliser l'attaque sur cette carte. (Vous avez toujours besoin de l'Énergie nécessaire pour utiliser cette attaque.)Brûlure Polycellule FightingFightingColorless 200Défaussez 3 Énergies attachées à ce Pokémon.",
-		en: "The Zygarde-EX this card is attached to can also use the attack on this card. (You still need the necessary Energy to use this attack.)\n\nAll Cells Burn FightingFightingColorless 200\nDiscard 3 Energy attached to this Pokémon.",
-		es: "El Zygarde-EX al que esté unida esta carta también puede usar el ataque de esta carta. (Sigues necesitando la Energía necesaria para usar este ataque).Quemadura Multicelular FightingFightingColorless 200Descarta 3 Energías unidas a este Pokémon.",
-		it: "Lo Zygarde-EX a cui è assegnata questa carta può usare anche l'attacco di questa carta. Devi comunque avere l'Energia necessaria per usare questo attacco.Cellule Incendiarie FightingFightingColorless 200Scarta tre Energie assegnate a questo Pokémon.",
-		pt: "O Zygarde-EX ao qual este card está ligado, pode também usar o ataque deste card. (Você ainda precisa da Energia necessária para usar este ataque.)Queimadura Multicelular FightingFightingColorless 200Descarte 3 Energias ligadas a este Pokémon.",
-		de: "Das Zygarde-EX, an das diese Karte angelegt ist, kann auch den Angriff auf dieser Karte einsetzen. (Du benötigst jedoch die für diesen Angriff notwendige Energie.)Alle Zellen brennen FightingFightingColorless 200Lege 3 an dieses Pokémon angelegte Energien auf deinen Ablagestapel."
+		fr: "Le Zygarde-EX auquel cette carte est attachée peut aussi utiliser l'attaque sur cette carte. (Vous avez toujours besoin de l'Énergie nécessaire pour utiliser cette attaque.)",
+		en: "The Zygarde-EX this card is attached to can also use the attack on this card. (You still need the necessary Energy to use this attack.)",
+		es: "El Zygarde-EX al que esté unida esta carta también puede usar el ataque de esta carta. (Sigues necesitando la Energía necesaria para usar este ataque).",
+		it: "Lo Zygarde-EX a cui è assegnata questa carta può usare anche l'attacco di questa carta. Devi comunque avere l'Energia necessaria per usare questo attacco.",
+		pt: "O Zygarde-EX ao qual este card está ligado, pode também usar o ataque deste card. (Você ainda precisa da Energia necessária para usar este ataque.)",
+		de: "Das Zygarde-EX, an das diese Karte angelegt ist, kann auch den Angriff auf dieser Karte einsetzen. (Du benötigst jedoch die für diesen Angriff notwendige Energie.)"
 	},
 
 	trainerType: "Tool",
@@ -39,11 +39,21 @@ const card: Card = {
 				"Colorless",
 			],
 			name: {
-				fr: "Brûlure Polycellule"
+				fr: "Brûlure Polycellule",
+				en: "All Cells Burn",
+				es: "Quemadura Multicelular",
+				it: "Cellule Incendiarie",
+				pt: "Queimadura Multicelular",
+				de: "Alle Zellen brennen"
 			},
 			damage: "200",
 			effect: {
-				fr: "Défaussez 3 Énergies attachées à ce Pokémon."
+				fr: "Défaussez 3 Énergies attachées à ce Pokémon.",
+				en: "Discard 3 Energy attached to this Pokémon.",
+				es: "Descarta 3 Energías unidas a este Pokémon.",
+				it: "Scarta tre Energie assegnate a questo Pokémon.",
+				pt: "Descarte 3 Energias ligadas a este Pokémon.",
+				de: "Lege 3 an dieses Pokémon angelegte Energien auf deinen Ablagestapel."
 			}
 		},
 	],

--- a/data/XY/Fates Collide/108.ts
+++ b/data/XY/Fates Collide/108.ts
@@ -30,7 +30,23 @@ const card: Card = {
 	thirdParty: {
 		cardmarket: 289928,
 		tcgplayer: 117517
-	}
+	},
+	attacks: [
+		{
+			cost: [
+				"Fighting",
+				"Fighting",
+				"Colorless",
+			],
+			name: {
+				fr: "Brûlure Polycellule"
+			},
+			damage: "200",
+			effect: {
+				fr: "Défaussez 3 Énergies attachées à ce Pokémon."
+			}
+		},
+	],
 }
 
 export default card


### PR DESCRIPTION
## Summary
- add missing French attack name/effect translations for:
  - Aquapolis `124` (Technical Machine 01)
  - Aquapolis `127` (Technical Machine Lightning Cube 01)
  - Holon Phantoms `87` (Technical Machine 01)
  - Team Magma vs Team Aqua `79` (Team Aqua Technical Machine 01)
  - Team Magma vs Team Aqua `84` (Team Magma Technical Machine 01)
- normalize Aquapolis `128` (Memory Berry) French effect text by removing the duplicated attachment/KO sentence and keeping the effect wording consistent

## Test plan
- [x] `bun run validate`
- [x] `cd server && bun run --bun validate`
- [x] `cd server && bun run compile`
- [x] `cd .bruno && bru run --env Developpement`