### PR TITLE
Destined Rivals (DRI) Variants and Pricing 

### DIFF
--- a/data/Scarlet & Violet/Destined Rivals/001.ts
+++ b/data/Scarlet & Violet/Destined Rivals/001.ts
@@ -67,16 +67,20 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'normal'
+			type: "normal",
+			thirdParty: {
+				cardmarket: 825875,
+				tcgplayer: 632829
+			}
 		},
 		{
-			type: 'reverse'
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 825875,
+				tcgplayer: 632829
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 825875,
-	}
 
 }
 

--- a/data/Scarlet & Violet/Destined Rivals/002.ts
+++ b/data/Scarlet & Violet/Destined Rivals/002.ts
@@ -65,16 +65,20 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'normal'
+			type: "normal",
+			thirdParty: {
+				cardmarket: 825876,
+				tcgplayer: 632830
+			}
 		},
 		{
-			type: 'reverse'
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 825876,
+				tcgplayer: 632830
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 825876
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/003.ts
+++ b/data/Scarlet & Violet/Destined Rivals/003.ts
@@ -86,13 +86,13 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'holo'
-		}
+			type: "holo",
+			thirdParty: {
+				cardmarket: 825877,
+				tcgplayer: 632831
+			}
+		},
 	],
-
-	thirdParty: {
-		cardmarket: 825877
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/004.ts
+++ b/data/Scarlet & Violet/Destined Rivals/004.ts
@@ -42,16 +42,20 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'normal'
+			type: "normal",
+			thirdParty: {
+				cardmarket: 825878,
+				tcgplayer: 632832
+			}
 		},
 		{
-			type: 'reverse'
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 825878,
+				tcgplayer: 632832
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 825878,
-	},
 
 	illustrator: "YASHIRO Nanaco"
 }

--- a/data/Scarlet & Violet/Destined Rivals/005.ts
+++ b/data/Scarlet & Violet/Destined Rivals/005.ts
@@ -43,16 +43,20 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'normal'
+			type: "normal",
+			thirdParty: {
+				cardmarket: 825879,
+				tcgplayer: 632833
+			}
 		},
 		{
-			type: 'reverse'
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 825879,
+				tcgplayer: 632833
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 825879
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/006.ts
+++ b/data/Scarlet & Violet/Destined Rivals/006.ts
@@ -86,16 +86,20 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'normal'
+			type: "normal",
+			thirdParty: {
+				cardmarket: 825880,
+				tcgplayer: 632834
+			}
 		},
 		{
-			type: 'reverse'
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 825880,
+				tcgplayer: 632834
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 825880
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/007.ts
+++ b/data/Scarlet & Violet/Destined Rivals/007.ts
@@ -43,16 +43,20 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'normal'
+			type: "normal",
+			thirdParty: {
+				cardmarket: 825881,
+				tcgplayer: 630803
+			}
 		},
 		{
-			type: 'reverse'
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 825881,
+				tcgplayer: 630803
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 825881
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/008.ts
+++ b/data/Scarlet & Violet/Destined Rivals/008.ts
@@ -76,16 +76,20 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'reverse'
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 825882,
+				tcgplayer: 630804
+			}
 		},
 		{
-			type: 'holo'
+			type: "holo",
+			thirdParty: {
+				cardmarket: 825882,
+				tcgplayer: 630804
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 825882
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/009.ts
+++ b/data/Scarlet & Violet/Destined Rivals/009.ts
@@ -77,16 +77,20 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'normal'
+			type: "normal",
+			thirdParty: {
+				cardmarket: 825883,
+				tcgplayer: 632835
+			}
 		},
 		{
-			type: 'reverse'
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 825883,
+				tcgplayer: 632835
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 825883
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/010.ts
+++ b/data/Scarlet & Violet/Destined Rivals/010.ts
@@ -67,16 +67,20 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'normal'
+			type: "normal",
+			thirdParty: {
+				cardmarket: 825884,
+				tcgplayer: 632836
+			}
 		},
 		{
-			type: 'reverse'
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 825884,
+				tcgplayer: 632836
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 825884
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/011.ts
+++ b/data/Scarlet & Violet/Destined Rivals/011.ts
@@ -51,16 +51,20 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'normal'
+			type: "normal",
+			thirdParty: {
+				cardmarket: 825885,
+				tcgplayer: 632837
+			}
 		},
 		{
-			type: 'reverse'
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 825885,
+				tcgplayer: 632837
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 825885
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/012.ts
+++ b/data/Scarlet & Violet/Destined Rivals/012.ts
@@ -86,16 +86,20 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'reverse'
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 825886,
+				tcgplayer: 632838
+			}
 		},
 		{
-			type: 'holo'
+			type: "holo",
+			thirdParty: {
+				cardmarket: 825886,
+				tcgplayer: 632838
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 825886
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/013.ts
+++ b/data/Scarlet & Violet/Destined Rivals/013.ts
@@ -43,16 +43,20 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'normal'
+			type: "normal",
+			thirdParty: {
+				cardmarket: 825887,
+				tcgplayer: 632839
+			}
 		},
 		{
-			type: 'reverse'
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 825887,
+				tcgplayer: 632839
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 825887
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/014.ts
+++ b/data/Scarlet & Violet/Destined Rivals/014.ts
@@ -76,16 +76,20 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'normal'
+			type: "normal",
+			thirdParty: {
+				cardmarket: 825888,
+				tcgplayer: 632840
+			}
 		},
 		{
-			type: 'reverse'
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 825888,
+				tcgplayer: 632840
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 825888
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/015.ts
+++ b/data/Scarlet & Violet/Destined Rivals/015.ts
@@ -51,16 +51,20 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'normal'
+			type: "normal",
+			thirdParty: {
+				cardmarket: 825889,
+				tcgplayer: 632841
+			}
 		},
 		{
-			type: 'reverse'
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 825889,
+				tcgplayer: 632841
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 825889
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/016.ts
+++ b/data/Scarlet & Violet/Destined Rivals/016.ts
@@ -53,16 +53,20 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'normal'
+			type: "normal",
+			thirdParty: {
+				cardmarket: 825890,
+				tcgplayer: 632842
+			}
 		},
 		{
-			type: 'reverse'
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 825890,
+				tcgplayer: 632842
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 825890
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/017.ts
+++ b/data/Scarlet & Violet/Destined Rivals/017.ts
@@ -62,16 +62,20 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'normal'
+			type: "normal",
+			thirdParty: {
+				cardmarket: 825891,
+				tcgplayer: 632843
+			}
 		},
 		{
-			type: 'reverse'
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 825891,
+				tcgplayer: 632843
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 825891
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/018.ts
+++ b/data/Scarlet & Violet/Destined Rivals/018.ts
@@ -74,16 +74,27 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'reverse'
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 825892,
+				tcgplayer: 632844
+			}
 		},
 		{
-			type: 'holo'
+			type: "holo",
+			thirdParty: {
+				cardmarket: 825892,
+				tcgplayer: 632844
+			}
+		},
+		{
+			type: "holo",
+			foil: "cosmos",
+			thirdParty: {
+				cardmarket: 859006,
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 825892
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/019.ts
+++ b/data/Scarlet & Violet/Destined Rivals/019.ts
@@ -53,16 +53,20 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'normal'
+			type: "normal",
+			thirdParty: {
+				cardmarket: 825893,
+				tcgplayer: 632845
+			}
 		},
 		{
-			type: 'reverse'
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 825893,
+				tcgplayer: 632845
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 825893
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/020.ts
+++ b/data/Scarlet & Violet/Destined Rivals/020.ts
@@ -86,16 +86,26 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'reverse'
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 825894,
+				tcgplayer: 632846
+			}
 		},
 		{
-			type: 'holo'
+			type: "holo",
+			thirdParty: {
+				cardmarket: 825894,
+				tcgplayer: 632846
+			}
+		},
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 871156,
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 825894
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/021.ts
+++ b/data/Scarlet & Violet/Destined Rivals/021.ts
@@ -43,16 +43,20 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'normal'
+			type: "normal",
+			thirdParty: {
+				cardmarket: 825895,
+				tcgplayer: 630805
+			}
 		},
 		{
-			type: 'reverse'
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 825895,
+				tcgplayer: 630805
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 825895
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/022.ts
+++ b/data/Scarlet & Violet/Destined Rivals/022.ts
@@ -74,16 +74,20 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'normal'
+			type: "normal",
+			thirdParty: {
+				cardmarket: 825896,
+				tcgplayer: 630806
+			}
 		},
 		{
-			type: 'reverse'
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 825896,
+				tcgplayer: 630806
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 825896
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/023.ts
+++ b/data/Scarlet & Violet/Destined Rivals/023.ts
@@ -84,13 +84,13 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'holo'
+			type: "holo",
+			thirdParty: {
+				cardmarket: 825897,
+				tcgplayer: 630807
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 825897
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/024.ts
+++ b/data/Scarlet & Violet/Destined Rivals/024.ts
@@ -62,18 +62,30 @@ const card: Card = {
 
 	retreat: 1,
 	regulationMark: "H",
+
 	variants: [
 		{
-			type: 'normal'
+			type: "normal",
+			thirdParty: {
+				cardmarket: 825898,
+				tcgplayer: 632847
+			}
 		},
 		{
-			type: 'reverse'
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 825898,
+				tcgplayer: 632847
+			}
+		},
+		{
+			type: "holo",
+			foil: "cosmos",
+			thirdParty: {
+				cardmarket: 878005,
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 825898
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/025.ts
+++ b/data/Scarlet & Violet/Destined Rivals/025.ts
@@ -81,15 +81,16 @@ const card: Card = {
 
 	retreat: 1,
 	regulationMark: "H",
+
 	variants: [
 		{
-			type: 'holo'
+			type: "holo",
+			thirdParty: {
+				cardmarket: 825899,
+				tcgplayer: 632848
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 825899
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/026.ts
+++ b/data/Scarlet & Violet/Destined Rivals/026.ts
@@ -75,16 +75,20 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'normal'
+			type: "normal",
+			thirdParty: {
+				cardmarket: 825908,
+				tcgplayer: 632849
+			}
 		},
 		{
-			type: 'reverse'
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 825908,
+				tcgplayer: 632849
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 825900
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/027.ts
+++ b/data/Scarlet & Violet/Destined Rivals/027.ts
@@ -57,16 +57,20 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'normal'
+			type: "normal",
+			thirdParty: {
+				cardmarket: 825900,
+				tcgplayer: 632850
+			}
 		},
 		{
-			type: 'reverse'
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 825900,
+				tcgplayer: 632850
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 825901
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/028.ts
+++ b/data/Scarlet & Violet/Destined Rivals/028.ts
@@ -76,16 +76,20 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'normal'
+			type: "normal",
+			thirdParty: {
+				cardmarket: 825901,
+				tcgplayer: 632851
+			}
 		},
 		{
-			type: 'reverse'
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 825901,
+				tcgplayer: 632851
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 825902
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/029.ts
+++ b/data/Scarlet & Violet/Destined Rivals/029.ts
@@ -53,16 +53,20 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'normal'
+			type: "normal",
+			thirdParty: {
+				cardmarket: 825902,
+				tcgplayer: 632852
+			}
 		},
 		{
-			type: 'reverse'
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 825902,
+				tcgplayer: 632852
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 825903
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/030.ts
+++ b/data/Scarlet & Violet/Destined Rivals/030.ts
@@ -76,16 +76,20 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'normal'
+			type: "normal",
+			thirdParty: {
+				cardmarket: 825903,
+				tcgplayer: 632853
+			}
 		},
 		{
-			type: 'reverse'
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 825903,
+				tcgplayer: 632853
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 825904
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/031.ts
+++ b/data/Scarlet & Violet/Destined Rivals/031.ts
@@ -83,7 +83,7 @@ const card: Card = {
 		},
 		{
 			type: "holo",
-			stamp: "set-logo",
+			stamp: ["set-logo"],
 			thirdParty: {
 				cardmarket: 858284,
 			}

--- a/data/Scarlet & Violet/Destined Rivals/031.ts
+++ b/data/Scarlet & Violet/Destined Rivals/031.ts
@@ -75,13 +75,20 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'holo'
+			type: "holo",
+			thirdParty: {
+				cardmarket: 825904,
+				tcgplayer: 630808
+			}
+		},
+		{
+			type: "holo",
+			stamp: "set-logo",
+			thirdParty: {
+				cardmarket: 858284,
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 825905
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/032.ts
+++ b/data/Scarlet & Violet/Destined Rivals/032.ts
@@ -53,16 +53,20 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'normal'
+			type: "normal",
+			thirdParty: {
+				cardmarket: 825905,
+				tcgplayer: 632854
+			}
 		},
 		{
-			type: 'reverse'
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 825905,
+				tcgplayer: 632854
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 825906
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/033.ts
+++ b/data/Scarlet & Violet/Destined Rivals/033.ts
@@ -76,16 +76,20 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'normal'
+			type: "normal",
+			thirdParty: {
+				cardmarket: 825906,
+				tcgplayer: 632855
+			}
 		},
 		{
-			type: 'reverse'
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 825906,
+				tcgplayer: 632855
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 825907
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/034.ts
+++ b/data/Scarlet & Violet/Destined Rivals/034.ts
@@ -91,7 +91,7 @@ const card: Card = {
 		},
 		{
 			type: "holo",
-			stamp: "set-logo",
+			stamp: ["set-logo"],
 			thirdParty: {
 				cardmarket: 826179,
 			}
@@ -104,7 +104,7 @@ const card: Card = {
 		},
 		{
 			type: "holo",
-			stamp: "staff",
+			stamp: ["staff"],
 			thirdParty: {
 				cardmarket: 833942,
 			}

--- a/data/Scarlet & Violet/Destined Rivals/034.ts
+++ b/data/Scarlet & Violet/Destined Rivals/034.ts
@@ -76,29 +76,40 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'reverse'
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 825907,
+				tcgplayer: 630809
+			}
 		},
 		{
-			type: 'holo'
+			type: "holo",
+			thirdParty: {
+				cardmarket: 825907,
+				tcgplayer: 630809
+			}
 		},
 		{
-			type: 'holo',
-			stamp: [
-				"set-logo"
-			]
+			type: "holo",
+			stamp: "set-logo",
+			thirdParty: {
+				cardmarket: 826179,
+			}
 		},
 		{
-			type: 'holo',
-			stamp: [
-				"set-logo",
-				"staff"
-			]
-		}
+			type: "normal",
+			thirdParty: {
+				cardmarket: 828100,
+			}
+		},
+		{
+			type: "holo",
+			stamp: "staff",
+			thirdParty: {
+				cardmarket: 833942,
+			}
+		},
 	],
-
-	thirdParty: {
-		cardmarket: 825908
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/035.ts
+++ b/data/Scarlet & Violet/Destined Rivals/035.ts
@@ -43,16 +43,20 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'normal'
+			type: "normal",
+			thirdParty: {
+				cardmarket: 825909,
+				tcgplayer: 630810
+			}
 		},
 		{
-			type: 'reverse'
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 825909,
+				tcgplayer: 630810
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 825909
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/036.ts
+++ b/data/Scarlet & Violet/Destined Rivals/036.ts
@@ -86,16 +86,20 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'reverse'
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 825910,
+				tcgplayer: 630811
+			}
 		},
 		{
-			type: 'holo'
+			type: "holo",
+			thirdParty: {
+				cardmarket: 825910,
+				tcgplayer: 630811
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 825910
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/037.ts
+++ b/data/Scarlet & Violet/Destined Rivals/037.ts
@@ -43,16 +43,20 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'normal'
+			type: "normal",
+			thirdParty: {
+				cardmarket: 825911,
+				tcgplayer: 632856
+			}
 		},
 		{
-			type: 'reverse'
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 825911,
+				tcgplayer: 632856
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 825911
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/038.ts
+++ b/data/Scarlet & Violet/Destined Rivals/038.ts
@@ -84,16 +84,20 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'normal'
+			type: "normal",
+			thirdParty: {
+				cardmarket: 825912,
+				tcgplayer: 632857
+			}
 		},
 		{
-			type: 'reverse'
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 825912,
+				tcgplayer: 632857
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 825912
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/039.ts
+++ b/data/Scarlet & Violet/Destined Rivals/039.ts
@@ -77,13 +77,13 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'holo'
-		}
+			type: "holo",
+			thirdParty: {
+				cardmarket: 825913,
+				tcgplayer: 632858
+			}
+		},
 	],
-
-	thirdParty: {
-		cardmarket: 825913
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/040.ts
+++ b/data/Scarlet & Violet/Destined Rivals/040.ts
@@ -65,16 +65,20 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'normal'
+			type: "normal",
+			thirdParty: {
+				cardmarket: 825914,
+				tcgplayer: 632859
+			}
 		},
 		{
-			type: 'reverse'
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 825914,
+				tcgplayer: 632859
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 825914
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/041.ts
+++ b/data/Scarlet & Violet/Destined Rivals/041.ts
@@ -76,16 +76,20 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'normal'
+			type: "normal",
+			thirdParty: {
+				cardmarket: 825915,
+				tcgplayer: 632860
+			}
 		},
 		{
-			type: 'reverse'
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 825915,
+				tcgplayer: 632860
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 825915
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/042.ts
+++ b/data/Scarlet & Violet/Destined Rivals/042.ts
@@ -76,16 +76,27 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'reverse'
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 825916,
+				tcgplayer: 632861
+			}
 		},
 		{
-			type: 'holo'
+			type: "holo",
+			thirdParty: {
+				cardmarket: 825916,
+				tcgplayer: 632861
+			}
+		},
+		{
+			type: "holo",
+			foil: "cosmos",
+			thirdParty: {
+				cardmarket: 859008,
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 825916
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/043.ts
+++ b/data/Scarlet & Violet/Destined Rivals/043.ts
@@ -75,16 +75,20 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'normal'
+			type: "normal",
+			thirdParty: {
+				cardmarket: 825917,
+				tcgplayer: 632862
+			}
 		},
 		{
-			type: 'reverse'
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 825917,
+				tcgplayer: 632862
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 825917
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/044.ts
+++ b/data/Scarlet & Violet/Destined Rivals/044.ts
@@ -75,16 +75,20 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'normal'
+			type: "normal",
+			thirdParty: {
+				cardmarket: 825918,
+				tcgplayer: 632863
+			}
 		},
 		{
-			type: 'reverse'
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 825918,
+				tcgplayer: 632863
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 825918
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/045.ts
+++ b/data/Scarlet & Violet/Destined Rivals/045.ts
@@ -67,16 +67,20 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'normal'
+			type: "normal",
+			thirdParty: {
+				cardmarket: 825919,
+				tcgplayer: 630812
+			}
 		},
 		{
-			type: 'reverse'
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 825919,
+				tcgplayer: 630812
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 825919
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/046.ts
+++ b/data/Scarlet & Violet/Destined Rivals/046.ts
@@ -53,16 +53,20 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'normal'
+			type: "normal",
+			thirdParty: {
+				cardmarket: 825920,
+				tcgplayer: 630813
+			}
 		},
 		{
-			type: 'reverse'
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 825920,
+				tcgplayer: 630813
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 825920
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/047.ts
+++ b/data/Scarlet & Violet/Destined Rivals/047.ts
@@ -62,16 +62,20 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'normal'
+			type: "normal",
+			thirdParty: {
+				cardmarket: 825921,
+				tcgplayer: 630814
+			}
 		},
 		{
-			type: 'reverse'
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 825921,
+				tcgplayer: 630814
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 825921
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/048.ts
+++ b/data/Scarlet & Violet/Destined Rivals/048.ts
@@ -67,16 +67,20 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'normal'
+			type: "normal",
+			thirdParty: {
+				cardmarket: 825922,
+				tcgplayer: 630815
+			}
 		},
 		{
-			type: 'reverse'
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 825922,
+				tcgplayer: 630815
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 825922
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/049.ts
+++ b/data/Scarlet & Violet/Destined Rivals/049.ts
@@ -76,29 +76,40 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'reverse'
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 825923,
+				tcgplayer: 630816
+			}
 		},
 		{
-			type: 'holo'
+			type: "holo",
+			thirdParty: {
+				cardmarket: 825923,
+				tcgplayer: 630816
+			}
 		},
 		{
-			type: 'holo',
-			stamp: [
-				"set-logo"
-			]
+			type: "holo",
+			stamp: "set-logo",
+			thirdParty: {
+				cardmarket: 826180,
+			}
 		},
 		{
-			type: 'holo',
-			stamp: [
-				"set-logo",
-				"staff"
-			]
-		}
+			type: "normal",
+			thirdParty: {
+				cardmarket: 828101,
+			}
+		},
+		{
+			type: "holo",
+			stamp: ["set-logo", "staff"],
+			thirdParty: {
+				cardmarket: 833945,
+			}
+		},
 	],
-
-	thirdParty: {
-		cardmarket: 825923
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/049.ts
+++ b/data/Scarlet & Violet/Destined Rivals/049.ts
@@ -91,7 +91,7 @@ const card: Card = {
 		},
 		{
 			type: "holo",
-			stamp: "set-logo",
+			stamp: ["set-logo"],
 			thirdParty: {
 				cardmarket: 826180,
 			}

--- a/data/Scarlet & Violet/Destined Rivals/050.ts
+++ b/data/Scarlet & Violet/Destined Rivals/050.ts
@@ -64,17 +64,21 @@ const card: Card = {
 	regulationMark: "I",
 
 	variants: [
-		{
-			type: 'normal'
-		},
-		{
-			type: 'reverse'
-		},
-	],
-
-	thirdParty: {
-		cardmarket: 825924
-	}
+	{
+		type: "normal",
+		thirdParty: {
+			cardmarket: 825924,
+			tcgplayer: 630817
+		}
+	},
+	{
+		type: "reverse",
+		thirdParty: {
+			cardmarket: 825924,
+			tcgplayer: 630817
+		}
+	},
+],
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/051.ts
+++ b/data/Scarlet & Violet/Destined Rivals/051.ts
@@ -77,16 +77,40 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'reverse'
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 825925,
+				tcgplayer: 632864
+			}
 		},
 		{
-			type: 'holo'
+			type: "holo",
+			thirdParty: {
+				cardmarket: 825925,
+				tcgplayer: 632864
+			}
+		},
+		{
+			type: "holo",
+			stamp: "set-logo",
+			thirdParty: {
+				cardmarket: 826177,
+			}
+		},
+		{
+			type: "holo",
+			foil: "cosmos",
+			thirdParty: {
+				cardmarket: 862170,
+			}
+		},
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 871155,
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 825925
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/051.ts
+++ b/data/Scarlet & Violet/Destined Rivals/051.ts
@@ -92,7 +92,7 @@ const card: Card = {
 		},
 		{
 			type: "holo",
-			stamp: "set-logo",
+			stamp: ["set-logo"],
 			thirdParty: {
 				cardmarket: 826177,
 			}

--- a/data/Scarlet & Violet/Destined Rivals/052.ts
+++ b/data/Scarlet & Violet/Destined Rivals/052.ts
@@ -53,16 +53,20 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'normal'
+			type: "normal",
+			thirdParty: {
+				cardmarket: 825926,
+				tcgplayer: 632865
+			}
 		},
 		{
-			type: 'reverse'
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 825926,
+				tcgplayer: 632865
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 825926
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/053.ts
+++ b/data/Scarlet & Violet/Destined Rivals/053.ts
@@ -62,16 +62,20 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'normal'
+			type: "normal",
+			thirdParty: {
+				cardmarket: 825927,
+				tcgplayer: 632866
+			}
 		},
 		{
-			type: 'reverse'
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 825927,
+				tcgplayer: 632866
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 825927
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/054.ts
+++ b/data/Scarlet & Violet/Destined Rivals/054.ts
@@ -53,16 +53,20 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'normal'
+			type: "normal",
+			thirdParty: {
+				cardmarket: 825928,
+				tcgplayer: 632867
+			}
 		},
 		{
-			type: 'reverse'
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 825928,
+				tcgplayer: 632867
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 825928
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/055.ts
+++ b/data/Scarlet & Violet/Destined Rivals/055.ts
@@ -76,16 +76,20 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'normal'
+			type: "normal",
+			thirdParty: {
+				cardmarket: 825929,
+				tcgplayer: 632868
+			}
 		},
 		{
-			type: 'reverse'
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 825929,
+				tcgplayer: 632868
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 825929
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/056.ts
+++ b/data/Scarlet & Violet/Destined Rivals/056.ts
@@ -64,16 +64,20 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'reverse'
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 825930,
+				tcgplayer: 632869
+			}
 		},
 		{
-			type: 'holo'
+			type: "holo",
+			thirdParty: {
+				cardmarket: 825930,
+				tcgplayer: 632869
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 825930
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/057.ts
+++ b/data/Scarlet & Violet/Destined Rivals/057.ts
@@ -59,16 +59,20 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'normal'
+			type: "normal",
+			thirdParty: {
+				cardmarket: 825931,
+				tcgplayer: 632870
+			}
 		},
 		{
-			type: 'reverse'
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 825931,
+				tcgplayer: 632870
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 825931
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/058.ts
+++ b/data/Scarlet & Violet/Destined Rivals/058.ts
@@ -88,16 +88,20 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'normal'
+			type: "normal",
+			thirdParty: {
+				cardmarket: 825932,
+				tcgplayer: 632871
+			}
 		},
 		{
-			type: 'reverse'
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 825932,
+				tcgplayer: 632871
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 825932
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/059.ts
+++ b/data/Scarlet & Violet/Destined Rivals/059.ts
@@ -59,16 +59,20 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'normal'
+			type: "normal",
+			thirdParty: {
+				cardmarket: 825933,
+				tcgplayer: 632872
+			}
 		},
 		{
-			type: 'reverse'
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 825933,
+				tcgplayer: 632872
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 825933
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/060.ts
+++ b/data/Scarlet & Violet/Destined Rivals/060.ts
@@ -78,16 +78,20 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'normal'
+			type: "normal",
+			thirdParty: {
+				cardmarket: 825934,
+				tcgplayer: 632873
+			}
 		},
 		{
-			type: 'reverse'
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 825934,
+				tcgplayer: 632873
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 825934
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/061.ts
+++ b/data/Scarlet & Violet/Destined Rivals/061.ts
@@ -79,16 +79,20 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'normal'
+			type: "normal",
+			thirdParty: {
+				cardmarket: 825935,
+				tcgplayer: 632874
+			}
 		},
 		{
-			type: 'reverse'
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 825935,
+				tcgplayer: 632874
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 825935
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/062.ts
+++ b/data/Scarlet & Violet/Destined Rivals/062.ts
@@ -55,16 +55,20 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'normal'
+			type: "normal",
+			thirdParty: {
+				cardmarket: 825936,
+				tcgplayer: 632875
+			}
 		},
 		{
-			type: 'reverse'
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 825936,
+				tcgplayer: 632875
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 825936
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/063.ts
+++ b/data/Scarlet & Violet/Destined Rivals/063.ts
@@ -78,16 +78,20 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'normal'
+			type: "normal",
+			thirdParty: {
+				cardmarket: 825937,
+				tcgplayer: 632876
+			}
 		},
 		{
-			type: 'reverse'
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 825937,
+				tcgplayer: 632876
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 825937
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/064.ts
+++ b/data/Scarlet & Violet/Destined Rivals/064.ts
@@ -59,16 +59,20 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'normal'
+			type: "normal",
+			thirdParty: {
+				cardmarket: 825938,
+				tcgplayer: 632877
+			}
 		},
 		{
-			type: 'reverse'
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 825938,
+				tcgplayer: 632877
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 825938
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/065.ts
+++ b/data/Scarlet & Violet/Destined Rivals/065.ts
@@ -88,16 +88,13 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'reverse'
-		},
-		{
-			type: 'holo'
+			type: "holo",
+			thirdParty: {
+				cardmarket: 825939,
+				tcgplayer: 632878
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 825939
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/066.ts
+++ b/data/Scarlet & Violet/Destined Rivals/066.ts
@@ -79,16 +79,13 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'reverse'
-		},
-		{
-			type: 'holo'
+			type: "holo",
+			thirdParty: {
+				cardmarket: 825940,
+				tcgplayer: 632879
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 825940
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/067.ts
+++ b/data/Scarlet & Violet/Destined Rivals/067.ts
@@ -77,16 +77,20 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'normal'
+			type: "normal",
+			thirdParty: {
+				cardmarket: 825941,
+				tcgplayer: 632880
+			}
 		},
 		{
-			type: 'reverse'
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 825941,
+				tcgplayer: 632880
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 825941
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/068.ts
+++ b/data/Scarlet & Violet/Destined Rivals/068.ts
@@ -45,16 +45,20 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'normal'
+			type: "normal",
+			thirdParty: {
+				cardmarket: 825942,
+				tcgplayer: 632881
+			}
 		},
 		{
-			type: 'reverse'
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 825942,
+				tcgplayer: 632881
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 825942
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/069.ts
+++ b/data/Scarlet & Violet/Destined Rivals/069.ts
@@ -86,16 +86,13 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'reverse'
-		},
-		{
-			type: 'holo'
+			type: "holo",
+			thirdParty: {
+				cardmarket: 825943,
+				tcgplayer: 632882
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 825943
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/070.ts
+++ b/data/Scarlet & Violet/Destined Rivals/070.ts
@@ -79,16 +79,42 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'reverse'
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 825944,
+				tcgplayer: 630818
+			}
 		},
 		{
-			type: 'holo'
+			type: "holo",
+			thirdParty: {
+				cardmarket: 825944,
+				tcgplayer: 630818
+			}
+		},
+		{
+			type: "holo",
+			stamp: "set-logo",
+			thirdParty: {
+				cardmarket: 827836,
+			}
+		},
+		{
+			type: "holo",
+			foil: "cosmos",
+			stamp: "eb-games",
+			thirdParty: {
+				cardmarket: 848308,
+			}
+		},
+		{
+			type: "holo",
+			foil: "cosmos",
+			thirdParty: {
+				cardmarket: 862171,
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 825944
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/070.ts
+++ b/data/Scarlet & Violet/Destined Rivals/070.ts
@@ -94,7 +94,7 @@ const card: Card = {
 		},
 		{
 			type: "holo",
-			stamp: "set-logo",
+			stamp: ["set-logo"],
 			thirdParty: {
 				cardmarket: 827836,
 			}
@@ -102,7 +102,7 @@ const card: Card = {
 		{
 			type: "holo",
 			foil: "cosmos",
-			stamp: "eb-games",
+			stamp: ["eb-games"],
 			thirdParty: {
 				cardmarket: 848308,
 			}

--- a/data/Scarlet & Violet/Destined Rivals/071.ts
+++ b/data/Scarlet & Violet/Destined Rivals/071.ts
@@ -53,16 +53,20 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'normal'
+			type: "normal",
+			thirdParty: {
+				cardmarket: 825945,
+				tcgplayer: 630819
+			}
 		},
 		{
-			type: 'reverse'
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 825945,
+				tcgplayer: 630819
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 825945
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/072.ts
+++ b/data/Scarlet & Violet/Destined Rivals/072.ts
@@ -67,16 +67,20 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'normal'
+			type: "normal",
+			thirdParty: {
+				cardmarket: 825946,
+				tcgplayer: 630820
+			}
 		},
 		{
-			type: 'reverse'
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 825946,
+				tcgplayer: 630820
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 825946
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/073.ts
+++ b/data/Scarlet & Violet/Destined Rivals/073.ts
@@ -64,16 +64,20 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'normal'
+			type: "normal",
+			thirdParty: {
+				cardmarket: 825947,
+				tcgplayer: 632883
+			}
 		},
 		{
-			type: 'reverse'
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 825947,
+				tcgplayer: 632883
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 825947
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/074.ts
+++ b/data/Scarlet & Violet/Destined Rivals/074.ts
@@ -78,16 +78,20 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'normal'
+			type: "normal",
+			thirdParty: {
+				cardmarket: 825948,
+				tcgplayer: 632884
+			}
 		},
 		{
-			type: 'reverse'
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 825948,
+				tcgplayer: 632884
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 825948
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/075.ts
+++ b/data/Scarlet & Violet/Destined Rivals/075.ts
@@ -59,16 +59,20 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'normal'
+			type: "normal",
+			thirdParty: {
+				cardmarket: 825949,
+				tcgplayer: 632885
+			}
 		},
 		{
-			type: 'reverse'
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 825949,
+				tcgplayer: 632885
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 825949
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/076.ts
+++ b/data/Scarlet & Violet/Destined Rivals/076.ts
@@ -78,16 +78,20 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'normal'
+			type: "normal",
+			thirdParty: {
+				cardmarket: 825950,
+				tcgplayer: 632886
+			}
 		},
 		{
-			type: 'reverse'
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 825950,
+				tcgplayer: 632886
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 825950
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/077.ts
+++ b/data/Scarlet & Violet/Destined Rivals/077.ts
@@ -79,16 +79,20 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'normal'
+			type: "normal",
+			thirdParty: {
+				cardmarket: 825951,
+				tcgplayer: 632887
+			}
 		},
 		{
-			type: 'reverse'
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 825951,
+				tcgplayer: 632887
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 825951
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/078.ts
+++ b/data/Scarlet & Violet/Destined Rivals/078.ts
@@ -67,16 +67,20 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'reverse'
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 825952,
+				tcgplayer: 632888
+			}
 		},
 		{
-			type: 'holo'
+			type: "holo",
+			thirdParty: {
+				cardmarket: 825952,
+				tcgplayer: 632888
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 825952
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/079.ts
+++ b/data/Scarlet & Violet/Destined Rivals/079.ts
@@ -55,16 +55,20 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'normal'
+			type: "normal",
+			thirdParty: {
+				cardmarket: 825953,
+				tcgplayer: 632889
+			}
 		},
 		{
-			type: 'reverse'
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 825953,
+				tcgplayer: 632889
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 825953
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/080.ts
+++ b/data/Scarlet & Violet/Destined Rivals/080.ts
@@ -78,16 +78,20 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'normal'
+			type: "normal",
+			thirdParty: {
+				cardmarket: 825954,
+				tcgplayer: 632890
+			}
 		},
 		{
-			type: 'reverse'
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 825954,
+				tcgplayer: 632890
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 825954
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/081.ts
+++ b/data/Scarlet & Violet/Destined Rivals/081.ts
@@ -79,16 +79,13 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'reverse'
-		},
-		{
-			type: 'holo'
+			type: "holo",
+			thirdParty: {
+				cardmarket: 825955,
+				tcgplayer: 632891
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 825955
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/082.ts
+++ b/data/Scarlet & Violet/Destined Rivals/082.ts
@@ -67,16 +67,20 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'reverse'
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 825956,
+				tcgplayer: 632892
+			}
 		},
 		{
-			type: 'holo'
+			type: "holo",
+			thirdParty: {
+				cardmarket: 825956,
+				tcgplayer: 632892
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 825956
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/083.ts
+++ b/data/Scarlet & Violet/Destined Rivals/083.ts
@@ -67,16 +67,20 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'normal'
+			type: "normal",
+			thirdParty: {
+				cardmarket: 825957,
+				tcgplayer: 632893
+			}
 		},
 		{
-			type: 'reverse'
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 825957,
+				tcgplayer: 632893
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 825957
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/084.ts
+++ b/data/Scarlet & Violet/Destined Rivals/084.ts
@@ -88,16 +88,20 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'normal'
+			type: "normal",
+			thirdParty: {
+				cardmarket: 825958,
+				tcgplayer: 632894
+			}
 		},
 		{
-			type: 'reverse'
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 825958,
+				tcgplayer: 632894
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 825958
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/085.ts
+++ b/data/Scarlet & Violet/Destined Rivals/085.ts
@@ -51,16 +51,20 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'normal'
+			type: "normal",
+			thirdParty: {
+				cardmarket: 825959,
+				tcgplayer: 632895
+			}
 		},
 		{
-			type: 'reverse'
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 825959,
+				tcgplayer: 632895
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 825959
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/086.ts
+++ b/data/Scarlet & Violet/Destined Rivals/086.ts
@@ -69,16 +69,20 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'normal'
+			type: "normal",
+			thirdParty: {
+				cardmarket: 825960,
+				tcgplayer: 632896
+			}
 		},
 		{
-			type: 'reverse'
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 825960,
+				tcgplayer: 632896
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 825960
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/087.ts
+++ b/data/Scarlet & Violet/Destined Rivals/087.ts
@@ -53,27 +53,34 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'normal'
+			type: "normal",
+			thirdParty: {
+				cardmarket: 825961,
+				tcgplayer: 630821
+			}
 		},
 		{
-			type: 'reverse'
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 825961,
+				tcgplayer: 630821
+			}
 		},
 		{
-			type: 'holo',
+			type: "holo",
+			stamp: ["set-logo"],
+			thirdParty: {
+				cardmarket: 826182,
+			}
 		},
 		{
-			type: 'holo',
-			stamp: ["set-logo"]
+			type: "holo",
+			stamp: ["set-logo", "staff"],
+			thirdParty: {
+				cardmarket: 833946,
+			}
 		},
-		{
-			type: 'holo',
-			stamp: ["set-logo", "staff"]
-		},
-	],
-
-	thirdParty: {
-		cardmarket: 825961
-	}
+	],	
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/088.ts
+++ b/data/Scarlet & Violet/Destined Rivals/088.ts
@@ -76,16 +76,20 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'normal'
+			type: "normal",
+			thirdParty: {
+				cardmarket: 825962,
+				tcgplayer: 632897
+			}
 		},
 		{
-			type: 'reverse'
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 825962,
+				tcgplayer: 632897
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 825962
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/089.ts
+++ b/data/Scarlet & Violet/Destined Rivals/089.ts
@@ -88,16 +88,20 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'normal'
+			type: "normal",
+			thirdParty: {
+				cardmarket: 825963,
+				tcgplayer: 632898
+			}
 		},
 		{
-			type: 'reverse'
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 825963,
+				tcgplayer: 632898
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 825963
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/090.ts
+++ b/data/Scarlet & Violet/Destined Rivals/090.ts
@@ -55,16 +55,20 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'normal'
+			type: "normal",
+			thirdParty: {
+				cardmarket: 825964,
+				tcgplayer: 632899
+			}
 		},
 		{
-			type: 'reverse'
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 825964,
+				tcgplayer: 632899
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 825964
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/091.ts
+++ b/data/Scarlet & Violet/Destined Rivals/091.ts
@@ -62,16 +62,20 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'normal'
+			type: "normal",
+			thirdParty: {
+				cardmarket: 825965,
+				tcgplayer: 632900
+			}
 		},
 		{
-			type: 'reverse'
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 825965,
+				tcgplayer: 632900
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 825965
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/092.ts
+++ b/data/Scarlet & Violet/Destined Rivals/092.ts
@@ -88,16 +88,20 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'reverse'
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 825966,
+				tcgplayer: 632901
+			}
 		},
 		{
-			type: 'holo'
+			type: "holo",
+			thirdParty: {
+				cardmarket: 825966,
+				tcgplayer: 632901
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 825966
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/093.ts
+++ b/data/Scarlet & Violet/Destined Rivals/093.ts
@@ -77,16 +77,20 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'normal'
+			type: "normal",
+			thirdParty: {
+				cardmarket: 825970,
+				tcgplayer: 632902
+			}
 		},
 		{
-			type: 'reverse'
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 825970,
+				tcgplayer: 632902
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 825967
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/094.ts
+++ b/data/Scarlet & Violet/Destined Rivals/094.ts
@@ -55,16 +55,20 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'normal'
+			type: "normal",
+			thirdParty: {
+				cardmarket: 825967,
+				tcgplayer: 632903
+			}
 		},
 		{
-			type: 'reverse'
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 825967,
+				tcgplayer: 632903
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 825968
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/095.ts
+++ b/data/Scarlet & Violet/Destined Rivals/095.ts
@@ -64,16 +64,20 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'normal'
+			type: "normal",
+			thirdParty: {
+				cardmarket: 825968,
+				tcgplayer: 632904
+			}
 		},
 		{
-			type: 'reverse'
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 825968,
+				tcgplayer: 632904
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 825969
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/096.ts
+++ b/data/Scarlet & Violet/Destined Rivals/096.ts
@@ -103,7 +103,7 @@ const card: Card = {
 		},
 		{
 			type: "holo",
-			stamp: "set-logo",
+			stamp: ["set-logo"],
 			thirdParty: {
 				cardmarket: 826181,
 			}
@@ -116,7 +116,6 @@ const card: Card = {
 		},
 		{
 			type: "holo",
-			stamp: "pokemon-center",
 			thirdParty: {
 				cardmarket: 828209,
 			}

--- a/data/Scarlet & Violet/Destined Rivals/096.ts
+++ b/data/Scarlet & Violet/Destined Rivals/096.ts
@@ -88,24 +88,54 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'normal'
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 825969,
+				tcgplayer: 630822
+			}
 		},
 		{
-			type: 'reverse'
+			type: "holo",
+			thirdParty: {
+				cardmarket: 825969,
+				tcgplayer: 630822
+			}
 		},
 		{
-			type: 'holo',
-			stamp: ["set-logo"]
+			type: "holo",
+			stamp: "set-logo",
+			thirdParty: {
+				cardmarket: 826181,
+			}
 		},
 		{
-			type: 'holo',
-			stamp: ["set-logo", "staff"]
+			type: "normal",
+			thirdParty: {
+				cardmarket: 828102,
+			}
+		},
+		{
+			type: "holo",
+			stamp: "pokemon-center",
+			thirdParty: {
+				cardmarket: 828209,
+			}
+		},
+		{
+			type: "holo",
+			stamp: ["set-logo", "staff"],
+			thirdParty: {
+				cardmarket: 833948,
+			}
+		},
+		{
+			type: "holo",
+			foil: "cosmos",
+			thirdParty: {
+				cardmarket: 862172,
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 825970
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/097.ts
+++ b/data/Scarlet & Violet/Destined Rivals/097.ts
@@ -59,16 +59,20 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'normal'
+			type: "normal",
+			thirdParty: {
+				cardmarket: 825971,
+				tcgplayer: 632905
+			}
 		},
 		{
-			type: 'reverse'
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 825971,
+				tcgplayer: 632905
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 825971
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/098.ts
+++ b/data/Scarlet & Violet/Destined Rivals/098.ts
@@ -78,16 +78,20 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'normal'
+			type: "normal",
+			thirdParty: {
+				cardmarket: 825972,
+				tcgplayer: 632906
+			}
 		},
 		{
-			type: 'reverse'
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 825972,
+				tcgplayer: 632906
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 825972
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/099.ts
+++ b/data/Scarlet & Violet/Destined Rivals/099.ts
@@ -55,16 +55,20 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'normal'
+			type: "normal",
+			thirdParty: {
+				cardmarket: 825973,
+				tcgplayer: 632907
+			}
 		},
 		{
-			type: 'reverse'
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 825973,
+				tcgplayer: 632907
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 825973
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/100.ts
+++ b/data/Scarlet & Violet/Destined Rivals/100.ts
@@ -64,16 +64,20 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'normal'
+			type: "normal",
+			thirdParty: {
+				cardmarket: 825974,
+				tcgplayer: 632908
+			}
 		},
 		{
-			type: 'reverse'
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 825974,
+				tcgplayer: 632908
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 825974
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/101.ts
+++ b/data/Scarlet & Violet/Destined Rivals/101.ts
@@ -77,13 +77,13 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'holo'
+			type: "holo",
+			thirdParty: {
+				cardmarket: 825975,
+				tcgplayer: 632909
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 825975
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/102.ts
+++ b/data/Scarlet & Violet/Destined Rivals/102.ts
@@ -55,16 +55,20 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'normal'
+			type: "normal",
+			thirdParty: {
+				cardmarket: 825976,
+				tcgplayer: 632910
+			}
 		},
 		{
-			type: 'reverse'
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 825976,
+				tcgplayer: 632910
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 825976
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/103.ts
+++ b/data/Scarlet & Violet/Destined Rivals/103.ts
@@ -78,16 +78,20 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'normal'
+			type: "normal",
+			thirdParty: {
+				cardmarket: 825977,
+				tcgplayer: 632911
+			}
 		},
 		{
-			type: 'reverse'
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 825977,
+				tcgplayer: 632911
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 825977
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/104.ts
+++ b/data/Scarlet & Violet/Destined Rivals/104.ts
@@ -88,13 +88,13 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'holo'
+			type: "holo",
+			thirdParty: {
+				cardmarket: 825978,
+				tcgplayer: 632912
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 825978
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/105.ts
+++ b/data/Scarlet & Violet/Destined Rivals/105.ts
@@ -52,18 +52,23 @@ const card: Card = {
 
 	retreat: 3,
 	regulationMark: "H",
+	
 	variants: [
 		{
-			type: 'normal'
+			type: "normal",
+			thirdParty: {
+				cardmarket: 825979,
+				tcgplayer: 632913
+			}
 		},
 		{
-			type: 'reverse'
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 825979,
+				tcgplayer: 632913
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 825979
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/106.ts
+++ b/data/Scarlet & Violet/Destined Rivals/106.ts
@@ -75,18 +75,23 @@ const card: Card = {
 
 	retreat: 4,
 	regulationMark: "H",
+	
 	variants: [
 		{
-			type: 'normal'
+			type: "normal",
+			thirdParty: {
+				cardmarket: 825980,
+				tcgplayer: 632914
+			}
 		},
 		{
-			type: 'reverse'
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 825980,
+				tcgplayer: 632914
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 825980
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/107.ts
+++ b/data/Scarlet & Violet/Destined Rivals/107.ts
@@ -55,16 +55,20 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'normal'
+			type: "normal",
+			thirdParty: {
+				cardmarket: 825981,
+				tcgplayer: 632915
+			}
 		},
 		{
-			type: 'reverse'
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 825981,
+				tcgplayer: 632915
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 825981
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/108.ts
+++ b/data/Scarlet & Violet/Destined Rivals/108.ts
@@ -78,16 +78,20 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'normal'
+			type: "normal",
+			thirdParty: {
+				cardmarket: 825982,
+				tcgplayer: 632916
+			}
 		},
 		{
-			type: 'reverse'
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 825982,
+				tcgplayer: 632916
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 825982
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/109.ts
+++ b/data/Scarlet & Violet/Destined Rivals/109.ts
@@ -55,16 +55,20 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'normal'
+			type: "normal",
+			thirdParty: {
+				cardmarket: 825983,
+				tcgplayer: 632917
+			}
 		},
 		{
-			type: 'reverse'
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 825983,
+				tcgplayer: 632917
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 825983
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/110.ts
+++ b/data/Scarlet & Violet/Destined Rivals/110.ts
@@ -86,16 +86,20 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'normal'
+			type: "normal",
+			thirdParty: {
+				cardmarket: 825984,
+				tcgplayer: 632918
+			}
 		},
 		{
-			type: 'reverse'
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 825984,
+				tcgplayer: 632918
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 825984
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/111.ts
+++ b/data/Scarlet & Violet/Destined Rivals/111.ts
@@ -77,16 +77,20 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'normal'
+			type: "normal",
+			thirdParty: {
+				cardmarket: 825985,
+				tcgplayer: 632919
+			}
 		},
 		{
-			type: 'reverse'
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 825985,
+				tcgplayer: 632919
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 825985
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/112.ts
+++ b/data/Scarlet & Violet/Destined Rivals/112.ts
@@ -67,16 +67,20 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'normal'
+			type: "normal",
+			thirdParty: {
+				cardmarket: 825986,
+				tcgplayer: 632920
+			}
 		},
 		{
-			type: 'reverse'
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 825986,
+				tcgplayer: 632920
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 825986
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/113.ts
+++ b/data/Scarlet & Violet/Destined Rivals/113.ts
@@ -86,16 +86,20 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'normal'
+			type: "normal",
+			thirdParty: {
+				cardmarket: 825987,
+				tcgplayer: 632921
+			}
 		},
 		{
-			type: 'reverse'
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 825987,
+				tcgplayer: 632921
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 825987
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/114.ts
+++ b/data/Scarlet & Violet/Destined Rivals/114.ts
@@ -55,16 +55,20 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'normal'
+			type: "normal",
+			thirdParty: {
+				cardmarket: 825988,
+				tcgplayer: 632922
+			}
 		},
 		{
-			type: 'reverse'
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 825988,
+				tcgplayer: 632922
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 825988
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/115.ts
+++ b/data/Scarlet & Violet/Destined Rivals/115.ts
@@ -76,16 +76,20 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'normal'
+			type: "normal",
+			thirdParty: {
+				cardmarket: 825989,
+				tcgplayer: 632923
+			}
 		},
 		{
-			type: 'reverse'
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 825989,
+				tcgplayer: 632923
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 825989
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/116.ts
+++ b/data/Scarlet & Violet/Destined Rivals/116.ts
@@ -78,16 +78,20 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'normal'
+			type: "normal",
+			thirdParty: {
+				cardmarket: 825990,
+				tcgplayer: 632924
+			}
 		},
 		{
-			type: 'reverse'
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 825990,
+				tcgplayer: 632924
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 825990
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/117.ts
+++ b/data/Scarlet & Violet/Destined Rivals/117.ts
@@ -59,16 +59,20 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'normal'
+			type: "normal",
+			thirdParty: {
+				cardmarket: 825991,
+				tcgplayer: 632925
+			}
 		},
 		{
-			type: 'reverse'
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 825991,
+				tcgplayer: 632925
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 825991
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/118.ts
+++ b/data/Scarlet & Violet/Destined Rivals/118.ts
@@ -78,16 +78,20 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'normal'
+			type: "normal",
+			thirdParty: {
+				cardmarket: 825992,
+				tcgplayer: 632926
+			}
 		},
 		{
-			type: 'reverse'
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 825992,
+				tcgplayer: 632926
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 825992
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/119.ts
+++ b/data/Scarlet & Violet/Destined Rivals/119.ts
@@ -78,13 +78,13 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'holo'
+			type: "holo",
+			thirdParty: {
+				cardmarket: 825993,
+				tcgplayer: 632927
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 825993
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/120.ts
+++ b/data/Scarlet & Violet/Destined Rivals/120.ts
@@ -53,16 +53,20 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'normal'
+			type: "normal",
+			thirdParty: {
+				cardmarket: 825994,
+				tcgplayer: 632928
+			}
 		},
 		{
-			type: 'reverse'
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 825994,
+				tcgplayer: 632928
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 825994
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/121.ts
+++ b/data/Scarlet & Violet/Destined Rivals/121.ts
@@ -88,16 +88,20 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'normal'
+			type: "normal",
+			thirdParty: {
+				cardmarket: 825995,
+				tcgplayer: 632929
+			}
 		},
 		{
-			type: 'reverse'
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 825995,
+				tcgplayer: 632929
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 825995
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/122.ts
+++ b/data/Scarlet & Violet/Destined Rivals/122.ts
@@ -88,13 +88,13 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'holo'
+			type: "holo",
+			thirdParty: {
+				cardmarket: 825996,
+				tcgplayer: 632930
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 825996
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/123.ts
+++ b/data/Scarlet & Violet/Destined Rivals/123.ts
@@ -53,16 +53,20 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'normal'
+			type: "normal",
+			thirdParty: {
+				cardmarket: 825997,
+				tcgplayer: 632931
+			}
 		},
 		{
-			type: 'reverse'
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 825997,
+				tcgplayer: 632931
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 825997
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/124.ts
+++ b/data/Scarlet & Violet/Destined Rivals/124.ts
@@ -88,16 +88,20 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'normal'
+			type: "normal",
+			thirdParty: {
+				cardmarket: 825998,
+				tcgplayer: 632932
+			}
 		},
 		{
-			type: 'reverse'
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 825998,
+				tcgplayer: 632932
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 825998
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/125.ts
+++ b/data/Scarlet & Violet/Destined Rivals/125.ts
@@ -69,16 +69,20 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'normal'
+			type: "normal",
+			thirdParty: {
+				cardmarket: 825999,
+				tcgplayer: 632933
+			}
 		},
 		{
-			type: 'reverse'
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 825999,
+				tcgplayer: 632933
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 825999
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/126.ts
+++ b/data/Scarlet & Violet/Destined Rivals/126.ts
@@ -64,16 +64,20 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'normal'
+			type: "normal",
+			thirdParty: {
+				cardmarket: 826000,
+				tcgplayer: 632934
+			}
 		},
 		{
-			type: 'reverse'
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 826000,
+				tcgplayer: 632934
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 826000
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/127.ts
+++ b/data/Scarlet & Violet/Destined Rivals/127.ts
@@ -77,16 +77,20 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'normal'
+			type: "normal",
+			thirdParty: {
+				cardmarket: 826001,
+				tcgplayer: 632935
+			}
 		},
 		{
-			type: 'reverse'
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 826001,
+				tcgplayer: 632935
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 826001
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/128.ts
+++ b/data/Scarlet & Violet/Destined Rivals/128.ts
@@ -67,16 +67,20 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'reverse'
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 826002,
+				tcgplayer: 632936
+			}
 		},
 		{
-			type: 'holo'
+			type: "holo",
+			thirdParty: {
+				cardmarket: 826002,
+				tcgplayer: 632936
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 826002
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/129.ts
+++ b/data/Scarlet & Violet/Destined Rivals/129.ts
@@ -55,16 +55,20 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'normal'
+			type: "normal",
+			thirdParty: {
+				cardmarket: 826003,
+				tcgplayer: 632937
+			}
 		},
 		{
-			type: 'reverse'
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 826003,
+				tcgplayer: 632937
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 826003
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/130.ts
+++ b/data/Scarlet & Violet/Destined Rivals/130.ts
@@ -55,16 +55,20 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'normal'
+			type: "normal",
+			thirdParty: {
+				cardmarket: 826004,
+				tcgplayer: 632938
+			}
 		},
 		{
-			type: 'reverse'
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 826004,
+				tcgplayer: 632938
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 826004
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/131.ts
+++ b/data/Scarlet & Violet/Destined Rivals/131.ts
@@ -64,16 +64,20 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'normal'
+			type: "normal",
+			thirdParty: {
+				cardmarket: 826005,
+				tcgplayer: 632939
+			}
 		},
 		{
-			type: 'reverse'
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 826005,
+				tcgplayer: 632939
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 826005
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/132.ts
+++ b/data/Scarlet & Violet/Destined Rivals/132.ts
@@ -55,16 +55,20 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'normal'
+			type: "normal",
+			thirdParty: {
+				cardmarket: 826006,
+				tcgplayer: 632940
+			}
 		},
 		{
-			type: 'reverse'
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 826006,
+				tcgplayer: 632940
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 826006
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/133.ts
+++ b/data/Scarlet & Violet/Destined Rivals/133.ts
@@ -78,16 +78,20 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'normal'
+			type: "normal",
+			thirdParty: {
+				cardmarket: 826007,
+				tcgplayer: 632941
+			}
 		},
 		{
-			type: 'reverse'
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 826007,
+				tcgplayer: 632941
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 826007
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/134.ts
+++ b/data/Scarlet & Violet/Destined Rivals/134.ts
@@ -67,16 +67,20 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'normal'
+			type: "normal",
+			thirdParty: {
+				cardmarket: 826008,
+				tcgplayer: 632942
+			}
 		},
 		{
-			type: 'reverse'
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 826008,
+				tcgplayer: 632942
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 826008
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/135.ts
+++ b/data/Scarlet & Violet/Destined Rivals/135.ts
@@ -54,16 +54,20 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'normal'
+			type: "normal",
+			thirdParty: {
+				cardmarket: 826009,
+				tcgplayer: 632943
+			}
 		},
 		{
-			type: 'reverse'
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 826009,
+				tcgplayer: 632943
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 826009
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/136.ts
+++ b/data/Scarlet & Violet/Destined Rivals/136.ts
@@ -88,13 +88,13 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'holo'
+			type: "holo",
+			thirdParty: {
+				cardmarket: 826010,
+				tcgplayer: 630823
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 826010
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/137.ts
+++ b/data/Scarlet & Violet/Destined Rivals/137.ts
@@ -55,16 +55,20 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'normal'
+			type: "normal",
+			thirdParty: {
+				cardmarket: 826011,
+				tcgplayer: 632944
+			}
 		},
 		{
-			type: 'reverse'
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 826011,
+				tcgplayer: 632944
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 826011
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/138.ts
+++ b/data/Scarlet & Violet/Destined Rivals/138.ts
@@ -59,16 +59,20 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'normal'
+			type: "normal",
+			thirdParty: {
+				cardmarket: 826012,
+				tcgplayer: 632945
+			}
 		},
 		{
-			type: 'reverse'
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 826012,
+				tcgplayer: 632945
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 826012
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/139.ts
+++ b/data/Scarlet & Violet/Destined Rivals/139.ts
@@ -88,13 +88,13 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'holo'
+			type: "holo",
+			thirdParty: {
+				cardmarket: 826013,
+				tcgplayer: 632946
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 826013
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/140.ts
+++ b/data/Scarlet & Violet/Destined Rivals/140.ts
@@ -88,16 +88,20 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'normal'
+			type: "normal",
+			thirdParty: {
+				cardmarket: 826014,
+				tcgplayer: 632947
+			}
 		},
 		{
-			type: 'reverse'
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 826014,
+				tcgplayer: 632947
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 826014
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/141.ts
+++ b/data/Scarlet & Violet/Destined Rivals/141.ts
@@ -67,16 +67,20 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'normal'
+			type: "normal",
+			thirdParty: {
+				cardmarket: 826015,
+				tcgplayer: 632948
+			}
 		},
 		{
-			type: 'reverse'
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 826015,
+				tcgplayer: 632948
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 826015
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/142.ts
+++ b/data/Scarlet & Violet/Destined Rivals/142.ts
@@ -67,16 +67,20 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'normal'
+			type: "normal",
+			thirdParty: {
+				cardmarket: 826016,
+				tcgplayer: 632949
+			}
 		},
 		{
-			type: 'reverse'
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 826016,
+				tcgplayer: 632949
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 826016
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/143.ts
+++ b/data/Scarlet & Violet/Destined Rivals/143.ts
@@ -45,16 +45,20 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'normal'
+			type: "normal",
+			thirdParty: {
+				cardmarket: 826017,
+				tcgplayer: 632950
+			}
 		},
 		{
-			type: 'reverse'
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 826017,
+				tcgplayer: 632950
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 826017
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/144.ts
+++ b/data/Scarlet & Violet/Destined Rivals/144.ts
@@ -64,16 +64,20 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'normal'
+			type: "normal",
+			thirdParty: {
+				cardmarket: 826018,
+				tcgplayer: 632951
+			}
 		},
 		{
-			type: 'reverse'
-		}
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 826018,
+				tcgplayer: 632951
+			}
+		},
 	],
-
-	thirdParty: {
-		cardmarket: 826018
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/145.ts
+++ b/data/Scarlet & Violet/Destined Rivals/145.ts
@@ -78,13 +78,13 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'holo'
+			type: "holo",
+			thirdParty: {
+				cardmarket: 826019,
+				tcgplayer: 630824
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 826019
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/146.ts
+++ b/data/Scarlet & Violet/Destined Rivals/146.ts
@@ -55,16 +55,20 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'normal'
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 826020,
+				tcgplayer: 632952
+			}
 		},
 		{
-			type: 'reverse'
+			type: "holo",
+			thirdParty: {
+				cardmarket: 826020,
+				tcgplayer: 632952
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 826020
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/147.ts
+++ b/data/Scarlet & Violet/Destined Rivals/147.ts
@@ -55,16 +55,20 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'normal'
+			type: "normal",
+			thirdParty: {
+				cardmarket: 826021,
+				tcgplayer: 632953
+			}
 		},
 		{
-			type: 'reverse'
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 826021,
+				tcgplayer: 632953
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 826021
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/148.ts
+++ b/data/Scarlet & Violet/Destined Rivals/148.ts
@@ -64,16 +64,20 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'normal'
+			type: "normal",
+			thirdParty: {
+				cardmarket: 826022,
+				tcgplayer: 632954
+			}
 		},
 		{
-			type: 'reverse'
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 826022,
+				tcgplayer: 632954
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 826022
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/149.ts
+++ b/data/Scarlet & Violet/Destined Rivals/149.ts
@@ -77,16 +77,20 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'normal'
+			type: "normal",
+			thirdParty: {
+				cardmarket: 826023,
+				tcgplayer: 630825
+			}
 		},
 		{
-			type: 'reverse'
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 826023,
+				tcgplayer: 630825
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 826023
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/150.ts
+++ b/data/Scarlet & Violet/Destined Rivals/150.ts
@@ -86,13 +86,13 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'holo'
+			type: "holo",
+			thirdParty: {
+				cardmarket: 826024,
+				tcgplayer: 632955
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 826024
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/151.ts
+++ b/data/Scarlet & Violet/Destined Rivals/151.ts
@@ -69,16 +69,20 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'normal'
+			type: "normal",
+			thirdParty: {
+				cardmarket: 826025,
+				tcgplayer: 632956
+			}
 		},
 		{
-			type: 'reverse'
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 826025,
+				tcgplayer: 632956
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 826025
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/152.ts
+++ b/data/Scarlet & Violet/Destined Rivals/152.ts
@@ -69,16 +69,20 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'normal'
+			type: "normal",
+			thirdParty: {
+				cardmarket: 826026,
+				tcgplayer: 632957
+			}
 		},
 		{
-			type: 'reverse'
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 826026,
+				tcgplayer: 632957
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 826026
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/153.ts
+++ b/data/Scarlet & Violet/Destined Rivals/153.ts
@@ -53,16 +53,20 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'normal'
+			type: "normal",
+			thirdParty: {
+				cardmarket: 826027,
+				tcgplayer: 630826
+			}
 		},
 		{
-			type: 'reverse'
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 826027,
+				tcgplayer: 630826
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 826027
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/154.ts
+++ b/data/Scarlet & Violet/Destined Rivals/154.ts
@@ -64,16 +64,20 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'normal'
+			type: "normal",
+			thirdParty: {
+				cardmarket: 826028,
+				tcgplayer: 630827
+			}
 		},
 		{
-			type: 'reverse'
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 826028,
+				tcgplayer: 630827
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 826028
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/155.ts
+++ b/data/Scarlet & Violet/Destined Rivals/155.ts
@@ -88,16 +88,20 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'normal'
+			type: "normal",
+			thirdParty: {
+				cardmarket: 826029,
+				tcgplayer: 630828
+			}
 		},
 		{
-			type: 'reverse'
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 826029,
+				tcgplayer: 630828
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 826029
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/156.ts
+++ b/data/Scarlet & Violet/Destined Rivals/156.ts
@@ -45,16 +45,20 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'normal'
+			type: "normal",
+			thirdParty: {
+				cardmarket: 826030,
+				tcgplayer: 632958
+			}
 		},
 		{
-			type: 'reverse'
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 826030,
+				tcgplayer: 632958
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 826030
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/157.ts
+++ b/data/Scarlet & Violet/Destined Rivals/157.ts
@@ -76,16 +76,20 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'normal'
+			type: "normal",
+			thirdParty: {
+				cardmarket: 826031,
+				tcgplayer: 632959
+			}
 		},
 		{
-			type: 'reverse'
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 826031,
+				tcgplayer: 632959
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 826031
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/158.ts
+++ b/data/Scarlet & Violet/Destined Rivals/158.ts
@@ -55,16 +55,20 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'normal'
+			type: "normal",
+			thirdParty: {
+				cardmarket: 826032,
+				tcgplayer: 632960
+			}
 		},
 		{
-			type: 'reverse'
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 826032,
+				tcgplayer: 632960
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 826032
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/159.ts
+++ b/data/Scarlet & Violet/Destined Rivals/159.ts
@@ -78,16 +78,27 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'reverse'
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 826033,
+				tcgplayer: 632961
+			}
 		},
 		{
-			type: 'holo'
+			type: "holo",
+			thirdParty: {
+				cardmarket: 826033,
+				tcgplayer: 632961
+			}
+		},
+		{
+			type: "holo",
+			foil: "cosmos",
+			thirdParty: {
+				cardmarket: 878006,
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 826033
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/160.ts
+++ b/data/Scarlet & Violet/Destined Rivals/160.ts
@@ -55,16 +55,20 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'normal'
+			type: "normal",
+			thirdParty: {
+				cardmarket: 826034,
+				tcgplayer: 632962
+			}
 		},
 		{
-			type: 'reverse'
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 826034,
+				tcgplayer: 632962
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 826034
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/161.ts
+++ b/data/Scarlet & Violet/Destined Rivals/161.ts
@@ -35,16 +35,20 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'normal'
+			type: "normal",
+			thirdParty: {
+				cardmarket: 826035,
+				tcgplayer: 632963
+			}
 		},
 		{
-			type: 'reverse'
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 826035,
+				tcgplayer: 632963
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 826035
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/162.ts
+++ b/data/Scarlet & Violet/Destined Rivals/162.ts
@@ -35,16 +35,20 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'normal'
+			type: "normal",
+			thirdParty: {
+				cardmarket: 826036,
+				tcgplayer: 632964
+			}
 		},
 		{
-			type: 'reverse'
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 826036,
+				tcgplayer: 632964
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 826036
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/163.ts
+++ b/data/Scarlet & Violet/Destined Rivals/163.ts
@@ -35,16 +35,20 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'normal'
+			type: "normal",
+			thirdParty: {
+				cardmarket: 826037,
+				tcgplayer: 632965
+			}
 		},
 		{
-			type: 'reverse'
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 826037,
+				tcgplayer: 632965
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 826037
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/164.ts
+++ b/data/Scarlet & Violet/Destined Rivals/164.ts
@@ -35,16 +35,20 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'normal'
+			type: "normal",
+			thirdParty: {
+				cardmarket: 826038,
+				tcgplayer: 632966
+			}
 		},
 		{
-			type: 'reverse'
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 826038,
+				tcgplayer: 632966
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 826038
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/165.ts
+++ b/data/Scarlet & Violet/Destined Rivals/165.ts
@@ -35,16 +35,20 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'normal'
+			type: "normal",
+			thirdParty: {
+				cardmarket: 826039,
+				tcgplayer: 632967
+			}
 		},
 		{
-			type: 'reverse'
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 826039,
+				tcgplayer: 632967
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 826039
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/166.ts
+++ b/data/Scarlet & Violet/Destined Rivals/166.ts
@@ -35,16 +35,20 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'normal'
+			type: "normal",
+			thirdParty: {
+				cardmarket: 826040,
+				tcgplayer: 632968
+			}
 		},
 		{
-			type: 'reverse'
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 826040,
+				tcgplayer: 632968
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 826040
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/167.ts
+++ b/data/Scarlet & Violet/Destined Rivals/167.ts
@@ -32,18 +32,23 @@ const card: Card = {
 
 	trainerType: "Supporter",
 	regulationMark: "G",
+
 	variants: [
 		{
-			type: 'normal'
+			type: "normal",
+			thirdParty: {
+				cardmarket: 826041,
+				tcgplayer: 632969
+			}
 		},
 		{
-			type: 'reverse'
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 826041,
+				tcgplayer: 632969
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 826041
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/168.ts
+++ b/data/Scarlet & Violet/Destined Rivals/168.ts
@@ -35,16 +35,20 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'normal'
+			type: "normal",
+			thirdParty: {
+				cardmarket: 826042,
+				tcgplayer: 632970
+			}
 		},
 		{
-			type: 'reverse'
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 826042,
+				tcgplayer: 632970
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 826042
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/169.ts
+++ b/data/Scarlet & Violet/Destined Rivals/169.ts
@@ -35,16 +35,20 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'normal'
+			type: "normal",
+			thirdParty: {
+				cardmarket: 826043,
+				tcgplayer: 630829
+			}
 		},
 		{
-			type: 'reverse'
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 826043,
+				tcgplayer: 630829
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 826043
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/170.ts
+++ b/data/Scarlet & Violet/Destined Rivals/170.ts
@@ -35,16 +35,20 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'normal'
+			type: "normal",
+			thirdParty: {
+				cardmarket: 826044,
+				tcgplayer: 632971
+			}
 		},
 		{
-			type: 'reverse'
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 826044,
+				tcgplayer: 632971
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 826044
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/171.ts
+++ b/data/Scarlet & Violet/Destined Rivals/171.ts
@@ -35,16 +35,20 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'normal'
+			type: "normal",
+			thirdParty: {
+				cardmarket: 826045,
+				tcgplayer: 632972
+			}
 		},
 		{
-			type: 'reverse'
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 826045,
+				tcgplayer: 632972
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 826045
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/172.ts
+++ b/data/Scarlet & Violet/Destined Rivals/172.ts
@@ -35,16 +35,20 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'normal'
+			type: "normal",
+			thirdParty: {
+				cardmarket: 826046,
+				tcgplayer: 632973
+			}
 		},
 		{
-			type: 'reverse'
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 826046,
+				tcgplayer: 632973
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 826046
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/173.ts
+++ b/data/Scarlet & Violet/Destined Rivals/173.ts
@@ -35,16 +35,20 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'normal'
+			type: "normal",
+			thirdParty: {
+				cardmarket: 826047,
+				tcgplayer: 632974
+			}
 		},
 		{
-			type: 'reverse'
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 826047,
+				tcgplayer: 632974
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 826047
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/174.ts
+++ b/data/Scarlet & Violet/Destined Rivals/174.ts
@@ -35,16 +35,20 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'normal'
+			type: "normal",
+			thirdParty: {
+				cardmarket: 826048,
+				tcgplayer: 630830
+			}
 		},
 		{
-			type: 'reverse'
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 826048,
+				tcgplayer: 630830
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 826048
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/175.ts
+++ b/data/Scarlet & Violet/Destined Rivals/175.ts
@@ -35,16 +35,20 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'normal'
+			type: "normal",
+			thirdParty: {
+				cardmarket: 826049,
+				tcgplayer: 632975
+			}
 		},
 		{
-			type: 'reverse'
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 826049,
+				tcgplayer: 632975
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 826049
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/176.ts
+++ b/data/Scarlet & Violet/Destined Rivals/176.ts
@@ -35,16 +35,20 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'normal'
+			type: "normal",
+			thirdParty: {
+				cardmarket: 826050,
+				tcgplayer: 632976
+			}
 		},
 		{
-			type: 'reverse'
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 826050,
+				tcgplayer: 632976
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 826050
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/177.ts
+++ b/data/Scarlet & Violet/Destined Rivals/177.ts
@@ -35,16 +35,20 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'normal'
+			type: "normal",
+			thirdParty: {
+				cardmarket: 826051,
+				tcgplayer: 632977
+			}
 		},
 		{
-			type: 'reverse'
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 826051,
+				tcgplayer: 632977
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 826051
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/178.ts
+++ b/data/Scarlet & Violet/Destined Rivals/178.ts
@@ -35,16 +35,20 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'normal'
+			type: "normal",
+			thirdParty: {
+				cardmarket: 826052,
+				tcgplayer: 632978
+			}
 		},
 		{
-			type: 'reverse'
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 826052,
+				tcgplayer: 632978
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 826052
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/179.ts
+++ b/data/Scarlet & Violet/Destined Rivals/179.ts
@@ -35,16 +35,20 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'normal'
+			type: "normal",
+			thirdParty: {
+				cardmarket: 826053,
+				tcgplayer: 632979
+			}
 		},
 		{
-			type: 'reverse'
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 826053,
+				tcgplayer: 632979
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 826053
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/180.ts
+++ b/data/Scarlet & Violet/Destined Rivals/180.ts
@@ -35,16 +35,20 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'normal'
+			type: "normal",
+			thirdParty: {
+				cardmarket: 826054,
+				tcgplayer: 632980
+			}
 		},
 		{
-			type: 'reverse'
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 826054,
+				tcgplayer: 632980
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 826054
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/181.ts
+++ b/data/Scarlet & Violet/Destined Rivals/181.ts
@@ -32,18 +32,23 @@ const card: Card = {
 
 	trainerType: "Item",
 	regulationMark: "H",
+
 	variants: [
 		{
-			type: 'normal'
+			type: "normal",
+			thirdParty: {
+				cardmarket: 826055,
+				tcgplayer: 632981
+			}
 		},
 		{
-			type: 'reverse'
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 826055,
+				tcgplayer: 632981
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 826055
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/182.ts
+++ b/data/Scarlet & Violet/Destined Rivals/182.ts
@@ -32,16 +32,20 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'normal'
+			type: "normal",
+			thirdParty: {
+				cardmarket: 826056,
+				tcgplayer: 632982
+			}
 		},
 		{
-			type: 'reverse'
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 826056,
+				tcgplayer: 632982
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 826056
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/183.ts
+++ b/data/Scarlet & Violet/Destined Rivals/183.ts
@@ -67,13 +67,13 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'holo'
+			type: "holo",
+			thirdParty: {
+				cardmarket: 826057,
+				tcgplayer: 632983
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 826057
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/184.ts
+++ b/data/Scarlet & Violet/Destined Rivals/184.ts
@@ -78,13 +78,13 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'holo'
+			type: "holo",
+			thirdParty: {
+				cardmarket: 826058,
+				tcgplayer: 632984
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 826058
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/185.ts
+++ b/data/Scarlet & Violet/Destined Rivals/185.ts
@@ -69,13 +69,13 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'holo'
+			type: "holo",
+			thirdParty: {
+				cardmarket: 826059,
+				tcgplayer: 632985
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 826059
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/186.ts
+++ b/data/Scarlet & Violet/Destined Rivals/186.ts
@@ -88,13 +88,13 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'holo'
+			type: "holo",
+			thirdParty: {
+				cardmarket: 826060,
+				tcgplayer: 632986
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 826060
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/187.ts
+++ b/data/Scarlet & Violet/Destined Rivals/187.ts
@@ -88,13 +88,13 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'holo'
+			type: "holo",
+			thirdParty: {
+				cardmarket: 826062,
+				tcgplayer: 632987
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 826061
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/188.ts
+++ b/data/Scarlet & Violet/Destined Rivals/188.ts
@@ -76,13 +76,13 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'holo'
+			type: "holo",
+			thirdParty: {
+				cardmarket: 826061,
+				tcgplayer: 632988
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 826062
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/189.ts
+++ b/data/Scarlet & Violet/Destined Rivals/189.ts
@@ -78,13 +78,13 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'holo'
+			type: "holo",
+			thirdParty: {
+				cardmarket: 826063,
+				tcgplayer: 632989
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 826063
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/190.ts
+++ b/data/Scarlet & Violet/Destined Rivals/190.ts
@@ -78,13 +78,13 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'holo'
+			type: "holo",
+			thirdParty: {
+				cardmarket: 826064,
+				tcgplayer: 632990
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 826064
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/191.ts
+++ b/data/Scarlet & Violet/Destined Rivals/191.ts
@@ -86,13 +86,13 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'holo'
+			type: "holo",
+			thirdParty: {
+				cardmarket: 826065,
+				tcgplayer: 632991
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 826065
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/192.ts
+++ b/data/Scarlet & Violet/Destined Rivals/192.ts
@@ -78,13 +78,13 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'holo'
+			type: "holo",
+			thirdParty: {
+				cardmarket: 826066,
+				tcgplayer: 632992
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 826066
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/193.ts
+++ b/data/Scarlet & Violet/Destined Rivals/193.ts
@@ -69,13 +69,13 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'holo'
+			type: "holo",
+			thirdParty: {
+				cardmarket: 826067,
+				tcgplayer: 632993
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 826067
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/194.ts
+++ b/data/Scarlet & Violet/Destined Rivals/194.ts
@@ -67,13 +67,13 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'holo'
+			type: "holo",
+			thirdParty: {
+				cardmarket: 826068,
+				tcgplayer: 632994
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 826068
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/195.ts
+++ b/data/Scarlet & Violet/Destined Rivals/195.ts
@@ -55,13 +55,13 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'holo'
+			type: "holo",
+			thirdParty: {
+				cardmarket: 826069,
+				tcgplayer: 632995
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 826069
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/196.ts
+++ b/data/Scarlet & Violet/Destined Rivals/196.ts
@@ -59,13 +59,13 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'holo'
+			type: "holo",
+			thirdParty: {
+				cardmarket: 826070,
+				tcgplayer: 632996
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 826070
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/197.ts
+++ b/data/Scarlet & Violet/Destined Rivals/197.ts
@@ -79,13 +79,13 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'holo'
+			type: "holo",
+			thirdParty: {
+				cardmarket: 826071,
+				tcgplayer: 632997
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 826071
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/198.ts
+++ b/data/Scarlet & Violet/Destined Rivals/198.ts
@@ -88,13 +88,13 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'holo'
+			type: "holo",
+			thirdParty: {
+				cardmarket: 826072,
+				tcgplayer: 632998
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 826072
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/199.ts
+++ b/data/Scarlet & Violet/Destined Rivals/199.ts
@@ -64,13 +64,13 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'holo'
+			type: "holo",
+			thirdParty: {
+				cardmarket: 826073,
+				tcgplayer: 632999
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 826073
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/200.ts
+++ b/data/Scarlet & Violet/Destined Rivals/200.ts
@@ -77,13 +77,13 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'holo'
+			type: "holo",
+			thirdParty: {
+				cardmarket: 826074,
+				tcgplayer: 633000
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 826074
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/201.ts
+++ b/data/Scarlet & Violet/Destined Rivals/201.ts
@@ -55,13 +55,13 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'holo'
+			type: "holo",
+			thirdParty: {
+				cardmarket: 826075,
+				tcgplayer: 633001
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 826075
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/202.ts
+++ b/data/Scarlet & Violet/Destined Rivals/202.ts
@@ -64,13 +64,13 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'holo'
+			type: "holo",
+			thirdParty: {
+				cardmarket: 826076,
+				tcgplayer: 633002
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 826076
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/203.ts
+++ b/data/Scarlet & Violet/Destined Rivals/203.ts
@@ -77,13 +77,13 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'holo'
+			type: "holo",
+			thirdParty: {
+				cardmarket: 826077,
+				tcgplayer: 633003
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 826077
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/204.ts
+++ b/data/Scarlet & Violet/Destined Rivals/204.ts
@@ -69,13 +69,13 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'holo'
+			type: "holo",
+			thirdParty: {
+				cardmarket: 826078,
+				tcgplayer: 633004
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 826078
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/205.ts
+++ b/data/Scarlet & Violet/Destined Rivals/205.ts
@@ -78,13 +78,13 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'holo'
+			type: "holo",
+			thirdParty: {
+				cardmarket: 826079,
+				tcgplayer: 633005
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 826079
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/206.ts
+++ b/data/Scarlet & Violet/Destined Rivals/206.ts
@@ -88,13 +88,13 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'holo'
+			type: "holo",
+			thirdParty: {
+				cardmarket: 826080,
+				tcgplayer: 633006
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 826080
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/207.ts
+++ b/data/Scarlet & Violet/Destined Rivals/207.ts
@@ -86,13 +86,13 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'holo'
+			type: "holo",
+			thirdParty: {
+				cardmarket: 826081,
+				tcgplayer: 633007
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 826081
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/208.ts
+++ b/data/Scarlet & Violet/Destined Rivals/208.ts
@@ -77,13 +77,20 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'holo'
+			type: "holo",
+			thirdParty: {
+				cardmarket: 826082,
+				tcgplayer: 633008
+			}
+		},
+		{
+			type: "holo",
+			stamp: "set-logo",
+			thirdParty: {
+				cardmarket: 858285,
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 826082
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/208.ts
+++ b/data/Scarlet & Violet/Destined Rivals/208.ts
@@ -85,7 +85,7 @@ const card: Card = {
 		},
 		{
 			type: "holo",
-			stamp: "set-logo",
+			stamp: ["set-logo"],
 			thirdParty: {
 				cardmarket: 858285,
 			}

--- a/data/Scarlet & Violet/Destined Rivals/209.ts
+++ b/data/Scarlet & Violet/Destined Rivals/209.ts
@@ -79,13 +79,13 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'holo'
+			type: "holo",
+			thirdParty: {
+				cardmarket: 826083,
+				tcgplayer: 633009
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 826083
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/210.ts
+++ b/data/Scarlet & Violet/Destined Rivals/210.ts
@@ -88,13 +88,13 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'holo'
+			type: "holo",
+			thirdParty: {
+				cardmarket: 826084,
+				tcgplayer: 633010
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 826084
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/211.ts
+++ b/data/Scarlet & Violet/Destined Rivals/211.ts
@@ -79,13 +79,13 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'holo'
+			type: "holo",
+			thirdParty: {
+				cardmarket: 826085,
+				tcgplayer: 633011
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 826085
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/212.ts
+++ b/data/Scarlet & Violet/Destined Rivals/212.ts
@@ -86,13 +86,13 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'holo'
+			type: "holo",
+			thirdParty: {
+				cardmarket: 826086,
+				tcgplayer: 633012
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 826086
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/213.ts
+++ b/data/Scarlet & Violet/Destined Rivals/213.ts
@@ -79,13 +79,13 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'holo'
+			type: "holo",
+			thirdParty: {
+				cardmarket: 826087,
+				tcgplayer: 633013
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 826087
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/214.ts
+++ b/data/Scarlet & Violet/Destined Rivals/214.ts
@@ -77,13 +77,13 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'holo'
+			type: "holo",
+			thirdParty: {
+				cardmarket: 826088,
+				tcgplayer: 633014
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 826088
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/215.ts
+++ b/data/Scarlet & Violet/Destined Rivals/215.ts
@@ -88,13 +88,13 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'holo'
+			type: "holo",
+			thirdParty: {
+				cardmarket: 826089,
+				tcgplayer: 633015
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 826089
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/216.ts
+++ b/data/Scarlet & Violet/Destined Rivals/216.ts
@@ -78,13 +78,13 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'holo'
+			type: "holo",
+			thirdParty: {
+				cardmarket: 826090,
+				tcgplayer: 633016
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 826090
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/217.ts
+++ b/data/Scarlet & Violet/Destined Rivals/217.ts
@@ -88,13 +88,13 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'holo'
+			type: "holo",
+			thirdParty: {
+				cardmarket: 826091,
+				tcgplayer: 633017
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 826091
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/218.ts
+++ b/data/Scarlet & Violet/Destined Rivals/218.ts
@@ -88,13 +88,13 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'holo'
+			type: "holo",
+			thirdParty: {
+				cardmarket: 826092,
+				tcgplayer: 633018
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 826092
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/219.ts
+++ b/data/Scarlet & Violet/Destined Rivals/219.ts
@@ -86,13 +86,13 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'holo'
+			type: "holo",
+			thirdParty: {
+				cardmarket: 826093,
+				tcgplayer: 633019
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 826093
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/220.ts
+++ b/data/Scarlet & Violet/Destined Rivals/220.ts
@@ -35,13 +35,13 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'holo'
+			type: "holo",
+			thirdParty: {
+				cardmarket: 826094,
+				tcgplayer: 633020
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 826094
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/221.ts
+++ b/data/Scarlet & Violet/Destined Rivals/221.ts
@@ -35,13 +35,13 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'holo'
+			type: "holo",
+			thirdParty: {
+				cardmarket: 826095,
+				tcgplayer: 633021
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 826095
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/222.ts
+++ b/data/Scarlet & Violet/Destined Rivals/222.ts
@@ -32,15 +32,16 @@ const card: Card = {
 
 	trainerType: "Supporter",
 	regulationMark: "G",
+
 	variants: [
 		{
-			type: 'holo'
+			type: "holo",
+			thirdParty: {
+				cardmarket: 826096,
+				tcgplayer: 633022
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 826096
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/223.ts
+++ b/data/Scarlet & Violet/Destined Rivals/223.ts
@@ -35,13 +35,13 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'holo'
+			type: "holo",
+			thirdParty: {
+				cardmarket: 826097,
+				tcgplayer: 633023
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 826097
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/224.ts
+++ b/data/Scarlet & Violet/Destined Rivals/224.ts
@@ -35,13 +35,13 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'holo'
+			type: "holo",
+			thirdParty: {
+				cardmarket: 826098,
+				tcgplayer: 633024
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 826098
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/225.ts
+++ b/data/Scarlet & Violet/Destined Rivals/225.ts
@@ -35,13 +35,13 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'holo'
+			type: "holo",
+			thirdParty: {
+				cardmarket: 826099,
+				tcgplayer: 633025
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 826099
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/226.ts
+++ b/data/Scarlet & Violet/Destined Rivals/226.ts
@@ -35,13 +35,13 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'holo'
+			type: "holo",
+			thirdParty: {
+				cardmarket: 826100,
+				tcgplayer: 633026
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 826100
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/227.ts
+++ b/data/Scarlet & Violet/Destined Rivals/227.ts
@@ -35,13 +35,13 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'holo'
+			type: "holo",
+			thirdParty: {
+				cardmarket: 826101,
+				tcgplayer: 633027
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 826101
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/228.ts
+++ b/data/Scarlet & Violet/Destined Rivals/228.ts
@@ -88,13 +88,13 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'holo'
+			type: "holo",
+			thirdParty: {
+				cardmarket: 826102,
+				tcgplayer: 633028
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 826102
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/229.ts
+++ b/data/Scarlet & Violet/Destined Rivals/229.ts
@@ -85,7 +85,7 @@ const card: Card = {
 		},
 		{
 			type: "holo",
-			stamp: "set-logo",
+			stamp: ["set-logo"],
 			thirdParty: {
 				cardmarket: 858286,
 			}

--- a/data/Scarlet & Violet/Destined Rivals/229.ts
+++ b/data/Scarlet & Violet/Destined Rivals/229.ts
@@ -77,13 +77,20 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'holo'
+			type: "holo",
+			thirdParty: {
+				cardmarket: 826103,
+				tcgplayer: 633029
+			}
+		},
+		{
+			type: "holo",
+			stamp: "set-logo",
+			thirdParty: {
+				cardmarket: 858286,
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 826103
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/230.ts
+++ b/data/Scarlet & Violet/Destined Rivals/230.ts
@@ -79,13 +79,13 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'holo'
+			type: "holo",
+			thirdParty: {
+				cardmarket: 826104,
+				tcgplayer: 633030
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 826104
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/231.ts
+++ b/data/Scarlet & Violet/Destined Rivals/231.ts
@@ -79,13 +79,13 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'holo'
+			type: "holo",
+			thirdParty: {
+				cardmarket: 826105,
+				tcgplayer: 633031
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 826105
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/232.ts
+++ b/data/Scarlet & Violet/Destined Rivals/232.ts
@@ -88,13 +88,13 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'holo'
+			type: "holo",
+			thirdParty: {
+				cardmarket: 826106,
+				tcgplayer: 633032
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 826106
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/233.ts
+++ b/data/Scarlet & Violet/Destined Rivals/233.ts
@@ -78,13 +78,13 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'holo'
+			type: "holo",
+			thirdParty: {
+				cardmarket: 826107,
+				tcgplayer: 633033
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 826107
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/234.ts
+++ b/data/Scarlet & Violet/Destined Rivals/234.ts
@@ -88,13 +88,13 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'holo'
+			type: "holo",
+			thirdParty: {
+				cardmarket: 826108,
+				tcgplayer: 633034
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 826108
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/235.ts
+++ b/data/Scarlet & Violet/Destined Rivals/235.ts
@@ -88,13 +88,13 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'holo'
+			type: "holo",
+			thirdParty: {
+				cardmarket: 826109,
+				tcgplayer: 633035
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 826109
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/236.ts
+++ b/data/Scarlet & Violet/Destined Rivals/236.ts
@@ -35,13 +35,13 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'holo'
+			type: "holo",
+			thirdParty: {
+				cardmarket: 826110,
+				tcgplayer: 633036
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 826110
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/237.ts
+++ b/data/Scarlet & Violet/Destined Rivals/237.ts
@@ -35,13 +35,13 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'holo'
+			type: "holo",
+			thirdParty: {
+				cardmarket: 826111,
+				tcgplayer: 633037
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 826111
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/238.ts
+++ b/data/Scarlet & Violet/Destined Rivals/238.ts
@@ -35,13 +35,13 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'holo'
+			type: "holo",
+			thirdParty: {
+				cardmarket: 826112,
+				tcgplayer: 633038
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 826112
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/239.ts
+++ b/data/Scarlet & Violet/Destined Rivals/239.ts
@@ -79,14 +79,14 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'holo',
-			foil: 'gold'
+			type: "holo",
+			foil: "gold",
+			thirdParty: {
+				cardmarket: 826113,
+				tcgplayer: 633039
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 826113
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/240.ts
+++ b/data/Scarlet & Violet/Destined Rivals/240.ts
@@ -79,14 +79,14 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'holo',
-			foil: 'gold'
+			type: "holo",
+			foil: "gold",
+			thirdParty: {
+				cardmarket: 826114,
+				tcgplayer: 633040
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 826114
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/241.ts
+++ b/data/Scarlet & Violet/Destined Rivals/241.ts
@@ -88,14 +88,14 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'holo',
-			foil: 'gold'
+			type: "holo",
+			foil: "gold",
+			thirdParty: {
+				cardmarket: 826115,
+				tcgplayer: 633041
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 826115
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/242.ts
+++ b/data/Scarlet & Violet/Destined Rivals/242.ts
@@ -88,14 +88,14 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'holo',
-			foil: 'gold'
+			type: "holo",
+			foil: "gold",
+			thirdParty: {
+				cardmarket: 826116,
+				tcgplayer: 633042
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 826116
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/243.ts
+++ b/data/Scarlet & Violet/Destined Rivals/243.ts
@@ -32,16 +32,17 @@ const card: Card = {
 
 	trainerType: "Stadium",
 	regulationMark: "H",
+
 	variants: [
 		{
-			type: 'holo',
-			foil: 'gold'
+			type: "holo",
+			foil: "gold",
+			thirdParty: {
+				cardmarket: 826117,
+				tcgplayer: 633043
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 826117
-	}
 }
 
 export default card

--- a/data/Scarlet & Violet/Destined Rivals/244.ts
+++ b/data/Scarlet & Violet/Destined Rivals/244.ts
@@ -35,14 +35,14 @@ const card: Card = {
 
 	variants: [
 		{
-			type: 'holo',
-			foil: 'gold'
+			type: "holo",
+			foil: "gold",
+			thirdParty: {
+				cardmarket: 826118,
+				tcgplayer: 633044
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 826118
-	}
 }
 
 export default card


### PR DESCRIPTION
Populate thirdParty metadata for each variant across Scarlet & Violet - Destined Rivals cards: add cardmarket and tcgplayer IDs per variant, remove redundant top-level thirdParty objects, and standardize variant string quotes. Also add a few special foil/cosmos variants and correct marketplace IDs where needed. Changes apply to the set files (001–244).
