### PR TITLE
Fix: Correct malformed attack array & translations for SVP 195 (Lillie's Clefairy ex)

### DIFF
--- a/data/Scarlet & Violet/SVP Black Star Promos/195.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/195.ts
@@ -50,24 +50,20 @@ const card: Card = {
 
 		name: {
 			en: "Full Moon Rondo",
-			fr: "Zone Féérique"
+			fr: "Rondo Pleine Lune",
+			de: "Vollmondrondo",
+			es: "Rondó Luna Llena",
+			it: "Rondò Luna Piena",
+			pt: "Cântico da Lua Cheia"
 		},
 
 		effect: {
 			en: "This attack does 20 more damage for each Benched Pokémon (both yours and your opponent's).",
-			fr: "La Faiblesse de chacun des Pokémon {N} en jeu de votre adversaire est maintenant de type {P}. (Appliquez une Faiblesse de ×2.)"
-		},
-
-		damage: "20+"
-	}, {
-		cost: ["Psychic", "Colorless"],
-
-		name: {
-			fr: "Rondo Pleine Lune"
-		},
-
-		effect: {
-			fr: "Cette attaque inflige 20 dégâts supplémentaires pour chaque Pokémon de Banc (les vôtres et ceux de votre adversaire)."
+			fr: "Cette attaque inflige 20 dégâts supplémentaires pour chaque Pokémon de Banc (les vôtres et ceux de votre adversaire).",
+			de: "Diese Attacke fügt für jedes Pokémon auf der Bank (deiner und der deines Gegners) 20 Schadenspunkte mehr zu.",
+			es: "Este ataque hace 20 puntos de daño más por cada Pokémon en Banca (tanto tuyos como de tu rival).",
+			it: "Questo attacco infligge 20 danni in più per ogni Pokémon in panchina, sia tuo che del tuo avversario.",
+			pt: "Este ataque causa 20 pontos de dano a mais para cada Pokémon no Banco (seus e do seu oponente)." 
 		},
 
 		damage: "20+"


### PR DESCRIPTION
Fixed incorrect french translation; removed additional incorrect attack; added translations for missing languages

closes N/A ## Changes

- **Fixed** the French translation mismatch for the attack "Full Moon Rondo" on `SVP Black Star Promos 195` (Lillie's Clefairy ex). The Ability text had been mistakenly placed in the Attack block.
- **Removed** a redundant and malformed second attack block that was acting as a band-aid for the French translation.
- **Added** missing `de`, `es`, `it`, and `pt` translations for the attack name and effect.

## Details

The previous structure contained a critical data formatting error that was crashing the GraphQL API for English users. 

Because the French translation was added as an entirely separate attack block *without* an English name counterpart, querying the API via the English endpoint (`Accept-Language: en`) resulted in a `null` attack name for that index. This violated the strict non-nullable `AttacksListItem.name` GraphQL schema, causing the server to throw a `Cannot return null for non-nullable field AttacksListItem.name` error and dropping the entire paginated batch for any user scraping Mark I cards.

By consolidating all translations into the single, correct attack block, this PR not only cleans up the local data but permanently resolves the GraphQL API crash.