### PR TITLE
fix(Ascended Heroes): drop duplicate plain-reverse on Carkol (119)

### DIFF
--- a/data/Mega Evolution/Ascended Heroes/119.ts
+++ b/data/Mega Evolution/Ascended Heroes/119.ts
@@ -74,13 +74,6 @@ const card: Card = {
 	},
 	{
 		type: "reverse",
-		thirdParty: {
-			cardmarket: 869730,
-			tcgplayer: 675931
-		}
-	},
-	{
-		type: "reverse",
 		foil: "duskball",
 		thirdParty: {
 			cardmarket: 870323,


### PR DESCRIPTION
Carkol 119 still has a plain `reverse` variant with the same cardmarket/tcgplayer IDs as its `normal` variant. #1167 cleaned these up across the rest of Ascended Heroes but missed this one. Real reverse prints are `reverse|duskball` and `reverse|energy`.