### PR TITLE
Fix(data): Added MEP Black Star Promo cards / Fixed Set in #17 file

### DIFF
--- a/data/Mega Evolution/MEP Black Star Promos/017.ts
+++ b/data/Mega Evolution/MEP Black Star Promos/017.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Phantasmal Flames"
+import Set from "../MEP Black Star Promos"
 
 const card: Card = {
 	set: Set,
@@ -14,11 +14,22 @@ const card: Card = {
 		pt: "Toxtricity"
 	},
 
-	rarity: "Rare",
+	rarity: "None",
 	category: "Pokemon",
 	hp: 140,
 	types: ["Darkness"],
 	stage: "Stage1",
+	dexId: [849],
+
+	evolveFrom: {
+		en: "Toxel",
+		fr: "Toxizap",
+		es: "Toxel",
+		'es-mx': "Toxel",
+		de: "Toxel",
+		it: "Toxel",
+		pt: "Toxel"
+	},
 
 	abilities: [{
 		type: "Ability",
@@ -65,21 +76,26 @@ const card: Card = {
 
 	illustrator: "Krgc",
 
+	weaknesses: [{
+		type: "Fighting",
+		value: "x2"
+	}],
+
 	thirdParty: {
-        tcgplayer: 663193,
-        cardmarket: 857400
+		tcgplayer: 663193,
+		cardmarket: 857400
 	},
 
-    variants: [
+	variants: [
 		{
 			type: "holo",
 			stamp: ["set-logo"]
 		},
 		{
 			type: "holo",
-			stamp: ["set-logo","staff"]
+			stamp: ["set-logo", "staff"]
 		},
-    ]
+	]
 }
 
 export default card

--- a/data/Mega Evolution/MEP Black Star Promos/017.ts
+++ b/data/Mega Evolution/MEP Black Star Promos/017.ts
@@ -14,22 +14,11 @@ const card: Card = {
 		pt: "Toxtricity"
 	},
 
-	rarity: "None",
+	rarity: "Rare",
 	category: "Pokemon",
 	hp: 140,
 	types: ["Darkness"],
 	stage: "Stage1",
-	dexId: [849],
-
-	evolveFrom: {
-		en: "Toxel",
-		fr: "Toxizap",
-		es: "Toxel",
-		'es-mx': "Toxel",
-		de: "Toxel",
-		it: "Toxel",
-		pt: "Toxel"
-	},
 
 	abilities: [{
 		type: "Ability",
@@ -76,26 +65,21 @@ const card: Card = {
 
 	illustrator: "Krgc",
 
-	weaknesses: [{
-		type: "Fighting",
-		value: "x2"
-	}],
-
 	thirdParty: {
-		tcgplayer: 663193,
-		cardmarket: 857400
+        tcgplayer: 663193,
+        cardmarket: 857400
 	},
 
-	variants: [
+    variants: [
 		{
 			type: "holo",
 			stamp: ["set-logo"]
 		},
 		{
 			type: "holo",
-			stamp: ["set-logo", "staff"]
+			stamp: ["set-logo","staff"]
 		},
-	]
+    ]
 }
 
 export default card

--- a/data/Mega Evolution/MEP Black Star Promos/029.ts
+++ b/data/Mega Evolution/MEP Black Star Promos/029.ts
@@ -1,0 +1,73 @@
+import { Card } from "../../../interfaces"
+import Set from "../MEP Black Star Promos"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Mega Charizard X ex",
+		fr: "Méga-Dracaufeu X-ex",
+		de: "Mega-Glurak X-ex",
+		it: "Mega Charizard X-ex",
+		es: "Mega-Charizard X ex",
+		pt: "Mega Charizard X ex"
+	},
+
+	suffix: "EX",
+	illustrator: "takuyoa",
+	rarity: "None",
+	category: "Pokemon",
+	hp: 360,
+	types: ["Fire"],
+	stage: "Stage2",
+	dexId: [6],
+
+	evolveFrom: {
+		en: "Charmeleon",
+		fr: "Reptincel",
+		de: "Glutexo",
+		it: "Charmeleon",
+		es: "Charmeleon",
+		pt: "Charmeleon"
+	},
+
+	attacks: [{
+		cost: ["Fire", "Fire"],
+
+		name: {
+			en: "Inferno X",
+			fr: "Inferno X",
+			de: "Inferno X",
+			it: "Inferno X",
+			es: "Inferno X",
+			pt: "Inferno X"
+		},
+
+		damage: "90×",
+
+		effect: {
+			en: "Discard any amount of [R] Energy from among your Pokémon, and this attack does 90 damage for each card you discarded in this way.",
+			fr: "Défaussez autant d'Énergies [R] que vous le voulez parmi vos Pokémon. Cette attaque inflige 90 dégâts pour chaque carte défaussée de cette façon.",
+			de: "Lege beliebig viele [R] Energiekarten von deinen Pokémon auf deinen Ablagestapel und diese Attacke fügt für jede auf diese Weise abgelegte Karte 90 Schadenspunkte zu.",
+			it: "Scarta qualsiasi numero di carte Energia [R] dai tuoi Pokémon. Questo attacco infligge 90 danni per ogni carta che hai scartato in questo modo.",
+			es: "Descarta cualquier cantidad de cartas de Energía [R] de entre tus Pokémon, y este ataque hace 90 puntos de daño por cada carta que hayas descartado de esta manera.",
+			pt: "Descarte qualquer quantidade de cartas de Energia [R] dentre seus Pokémon, e este ataque causará 90 pontos de dano para cada carta descartada desta forma."
+		}
+	}],
+
+	retreat: 2,
+	regulationMark: "I",
+
+	weaknesses: [{
+		type: "Water",
+		value: "x2"
+	}],
+
+	variants: [
+		{
+			type: "holo"
+		}
+	]
+}
+
+export default card

--- a/data/Mega Evolution/MEP Black Star Promos/030.ts
+++ b/data/Mega Evolution/MEP Black Star Promos/030.ts
@@ -1,0 +1,71 @@
+import { Card } from "../../../interfaces"
+import Set from "../MEP Black Star Promos"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Mega Charizard Y ex",
+		fr: "Méga-Dracaufeu Y-ex",
+		de: "Mega-Glurak Y-ex",
+		it: "Mega Charizard Y-ex",
+		es: "Mega-Charizard Y ex",
+		pt: "Mega Charizard Y ex"
+	},
+
+	suffix: "EX",
+	illustrator: "Ultimateinudog",
+	rarity: "None",
+	category: "Pokemon",
+	hp: 360,
+	types: ["Fire"],
+	stage: "Stage2",
+	dexId: [6],
+
+	evolveFrom: {
+		en: "Charmeleon",
+		fr: "Reptincel",
+		de: "Glutexo",
+		it: "Charmeleon",
+		es: "Charmeleon",
+		pt: "Charmeleon"
+	},
+
+	attacks: [{
+		cost: ["Fire", "Fire", "Colorless"],
+
+		name: {
+			en: "Explosion Y",
+			fr: "Explosion Y",
+			de: "Explosion Y",
+			it: "Esplosione Y",
+			es: "Explosión Y",
+			pt: "Explosão Y"
+		},
+
+		effect: {
+			en: "Discard 3 Energy from this Pokémon, and this attack does 280 damage to 1 of your opponent's Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)",
+			fr: "Défaussez 3 Énergies de ce Pokémon. Cette attaque inflige 280 dégâts à l'un des Pokémon de votre adversaire. (N'appliquez ni la Faiblesse ni la Résistance aux Pokémon de Banc.)",
+			de: "Lege 3 Energien von diesem Pokémon auf deinen Ablagestapel, und diese Attacke fügt 1 Pokémon deines Gegners 280 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)",
+			it: "Scarta tre Energie da questo Pokémon e questo attacco infligge 280 danni a uno dei Pokémon del tuo avversario. Non applicare debolezza e resistenza ai Pokémon in panchina.",
+			es: "Descarta 3 Energías de este Pokémon, y este ataque hace 280 puntos de daño a uno de los Pokémon de tu rival. (No apliques Debilidad y Resistencia a los Pokémon en Banca).",
+			pt: "Descarte 3 Energias deste Pokémon, e este ataque causa 280 pontos de dano a 1 dos Pokémon do seu oponente. (Não aplique Fraqueza e Resistência aos Pokémon no Banco.)"
+		}
+	}],
+
+	retreat: 1,
+	regulationMark: "J",
+
+	weaknesses: [{
+		type: "Water",
+		value: "x2"
+	}],
+
+	variants: [
+		{
+			type: "holo"
+		}
+	]
+}
+
+export default card

--- a/data/Mega Evolution/MEP Black Star Promos/031.ts
+++ b/data/Mega Evolution/MEP Black Star Promos/031.ts
@@ -1,0 +1,84 @@
+import { Card } from "../../../interfaces"
+import Set from "../MEP Black Star Promos"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "N's Zekrom",
+		fr: "Zekrom de N",
+		es: "Zekrom de N",
+		de: "Ns Zekrom",
+		it: "Zekrom di N",
+		pt: "Zekrom do N"
+	},
+
+	illustrator: "Bun Toujo",
+	rarity: "None",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Dragon"],
+	stage: "Basic",
+	dexId: [644],
+
+	attacks: [{
+		cost: ["Colorless", "Colorless", "Colorless"],
+
+		name: {
+			en: "Shred",
+			fr: "Déchiquetage",
+			es: "Hacer Trizas",
+			de: "Zerfetzer",
+			it: "Tritatutto",
+			pt: "Triturar"
+		},
+
+		effect: {
+			en: "This attack's damage isn't affected by any effects on your opponent's Active Pokémon.",
+			fr: "Les dégâts de cette attaque ne sont affectés par aucun effet en action sur le Pokémon Actif de votre adversaire.",
+			es: "El daño de este ataque no se ve afectado por ningún efecto en el Pokémon Activo de tu rival.",
+			de: "Der Schaden dieser Attacke wird durch Effekte auf dem Aktiven Pokémon deines Gegners nicht verändert.",
+			it: "I danni di questo attacco non sono influenzati da alcun effetto presente sul Pokémon attivo del tuo avversario.",
+			pt: "O dano deste ataque não é afetado por quaisquer efeitos no Pokémon Ativo do seu oponente."
+		},
+
+		damage: 70
+	}, {
+		cost: ["Fire", "Lightning", "Lightning", "Colorless"],
+
+		name: {
+			en: "Rampaging Thunder",
+			fr: "Tonnerre Saccageur",
+			es: "Furia Trueno",
+			de: "Wütender Donner",
+			it: "Tuono Impazzito",
+			pt: "Trovão Voraz"
+		},
+
+		effect: {
+			en: "During your next turn, this Pokémon can't use attacks.",
+			fr: "Pendant votre prochain tour, ce Pokémon ne peut pas utiliser d'attaques.",
+			es: "Durante tu próximo turno, este Pokémon no puede usar ataques.",
+			de: "Während deines nächsten Zuges kann dieses Pokémon keine Attacken einsetzen.",
+			it: "Durante il tuo prossimo turno, questo Pokémon non può usare attacchi.",
+			pt: "Durante o seu próximo turno, este Pokémon não poderá usar ataques."
+		},
+
+		damage: 250
+	}],
+
+	retreat: 2,
+	regulationMark: "I",
+
+	variants: [
+		{
+			type: "holo"
+		},
+		{
+			type: "holo",
+			stamp: ["pokemon-center"]
+		}
+	]
+}
+
+export default card

--- a/data/Mega Evolution/MEP Black Star Promos/032.ts
+++ b/data/Mega Evolution/MEP Black Star Promos/032.ts
@@ -1,0 +1,91 @@
+import { Card } from "../../../interfaces"
+import Set from "../MEP Black Star Promos"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Mega Gardevoir ex",
+		fr: "Méga-Gardevoir-ex",
+		de: "Mega-Guardevoir-ex",
+		it: "Mega Gardevoir-ex",
+		es: "Mega-Gardevoir ex",
+		pt: "Mega Gardevoir ex"
+	},
+
+	illustrator: "Saboteri",
+	rarity: "None",
+	category: "Pokemon",
+	hp: 360,
+	types: ["Psychic"],
+	evolveFrom: {
+		en: "Kirlia",
+		fr: "Kirlia",
+		de: "Kirlia",
+		it: "Kirlia",
+		es: "Kirlia",
+		pt: "Kirlia"
+	},
+	stage: "Stage2",
+	dexId: [282],
+
+	attacks: [{
+		cost: ["Psychic"],
+
+		name: {
+			en: "Overflowing Wishes",
+			fr: "Vœux Débordants",
+			de: "Überquellende Wünsche",
+			it: "Desideri Straripanti",
+			es: "Deseos Desbordantes",
+			pt: "Desejos Transbordantes"
+		},
+
+		effect: {
+			en: "For each of your Benched Pokémon, search your deck for a Basic {P} Energy card and attach it to that Pokémon. Then, shuffle your deck.",
+			fr: "Pour chacun de vos Pokémon de Banc, cherchez dans votre deck une carte Énergie {P} de base, puis attachez-la à ce Pokémon-là. Mélangez ensuite votre deck.",
+			de: "Durchsuche für jedes Pokémon auf deiner Bank dein Deck nach 1 Basis-{P}-Energiekarte und lege sie an jenes Pokémon an. Mische anschließend dein Deck.",
+			it: "Cerca nel tuo mazzo una carta Energia base {P} per ciascuno dei Pokémon nella tua panchina e assegnala a quel Pokémon. Poi rimischia il tuo mazzo.",
+			es: "Para cada uno de tus Pokémon en Banca, busca en tu baraja 1 carta de Energía {P} Básica y únela a ese Pokémon. Después, baraja las cartas de tu baraja.",
+			pt: "Para cada um dos seus Pokémon no Banco, procure por uma carta de Energia {P} Básica no seu baralho e ligue-a àquele Pokémon. Em seguida, embaralhe o seu baralho."
+		}
+	}, {
+		cost: ["Psychic"],
+
+		name: {
+			en: "Mega Symphonia",
+			fr: "Méga Symphonie",
+			de: "Mega-Symphonia",
+			it: "Megasinfonia",
+			es: "Megasinfonía",
+			pt: "Megassinfonia"
+		},
+
+		effect: {
+			en: "This attack does 50 damage for each {P} Energy attached to all of your Pokémon.",
+			fr: "Cette attaque inflige 50 dégâts pour chaque Énergie {P} attachée à tous vos Pokémon.",
+			de: "Diese Attacke fügt für jede an alle deine Pokémon angelegte {P}-Energie 50 Schadenspunkte zu.",
+			it: "Questo attacco infligge 50 danni per ogni Energia {P} assegnata ai tuoi Pokémon.",
+			es: "Este ataque hace 50 puntos de daño por cada Energía {P} unida a cada uno de tus Pokémon.",
+			pt: "Este ataque causa 50 pontos de dano para cada Energia {P} ligada a todos os seus Pokémon."
+		},
+
+		damage: "50×"
+	}],
+
+	retreat: 2,
+	regulationMark: "I",
+
+	weaknesses: [{
+		type: "Darkness",
+		value: "x2"
+	}],
+
+	variants: [
+		{
+			type: "holo"
+		}
+	]
+}
+
+export default card

--- a/data/Mega Evolution/MEP Black Star Promos/033.ts
+++ b/data/Mega Evolution/MEP Black Star Promos/033.ts
@@ -1,0 +1,93 @@
+import { Card } from "../../../interfaces"
+import Set from "../MEP Black Star Promos"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Mega Lucario ex",
+		fr: "Méga-Lucario-ex",
+		de: "Mega-Lucario-ex",
+		it: "Mega Lucario-ex",
+		es: "Mega-Lucario ex",
+		pt: "Mega Lucario ex"
+	},
+
+	illustrator: "5ban Graphics",
+	rarity: "None",
+	category: "Pokemon",
+	hp: 340,
+	types: ["Fighting"],
+	evolveFrom: {
+		en: "Riolu",
+		fr: "Riolu",
+		de: "Riolu",
+		it: "Riolu",
+		es: "Riolu",
+		pt: "Riolu"
+	},
+	stage: "Stage1",
+	dexId: [448],
+
+	attacks: [{
+		cost: ["Fighting"],
+
+		name: {
+			en: "Aura Jab",
+			fr: "Coup Aura",
+			de: "Aura-Hieb",
+			it: "Aurastoccata",
+			es: "Puya Aural",
+			pt: "Soco Aura"
+		},
+
+		effect: {
+			en: "Attach up to 3 Basic {F} Energy cards from your discard pile to your Benched Pokémon in any way you like.",
+			fr: "Attachez jusqu'à 3 cartes Énergie {F} de base de votre pile de défausse à vos Pokémon de Banc comme il vous plaît.",
+			de: "Lege bis zu 3 Basis-{F}-Energiekarten aus deinem Ablagestapel beliebig an die Pokémon auf deiner Bank an.",
+			it: "Assegna ai Pokémon nella tua panchina fino a tre carte Energia base {F} dalla tua pila degli scarti nel modo che preferisci.",
+			es: "Une hasta 3 cartas de Energía {F} Básica de tu pila de descartes a tus Pokémon en Banca de la manera que desees.",
+			pt: "Ligue até 3 cartas de Energia {F} Básica da sua pilha de descarte aos seus Pokémon no Banco como desejar."
+		},
+
+		damage: 130
+	}, {
+		cost: ["Fighting", "Fighting"],
+
+		name: {
+			en: "Mega Brave",
+			fr: "Méga Vaillant",
+			de: "Mega-Mut",
+			it: "Megacoraggio",
+			es: "Megavalentía",
+			pt: "Megavalentia"
+		},
+
+		effect: {
+			en: "During your next turn, this Pokémon can't use Mega Brave.",
+			fr: "Pendant votre prochain tour, ce Pokémon ne peut pas utiliser Méga Vaillant.",
+			de: "Während deines nächsten Zuges kann dieses Pokémon Mega-Mut nicht einsetzen.",
+			it: "Durante il tuo prossimo turno, questo Pokémon non può usare Megacoraggio.",
+			es: "Durante tu próximo turno, este Pokémon no puede usar Megavalentía.",
+			pt: "Durante o seu próximo turno, este Pokémon não poderá usar Megavalentia."
+		},
+
+		damage: 270
+	}],
+
+	retreat: 2,
+	regulationMark: "I",
+
+	weaknesses: [{
+		type: "Psychic",
+		value: "x2"
+	}],
+
+	variants: [
+		{
+			type: "holo"
+		}
+	]
+}
+
+export default card

--- a/data/Mega Evolution/MEP Black Star Promos/034.ts
+++ b/data/Mega Evolution/MEP Black Star Promos/034.ts
@@ -1,0 +1,75 @@
+import { Card } from "../../../interfaces"
+import Set from "../MEP Black Star Promos"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Mega Meganium ex",
+		fr: "Méga-Méganium-ex",
+		es: "Mega-Meganium ex",
+		de: "Mega-Meganie-ex",
+		it: "Mega Meganium-ex",
+		pt: "Mega Meganium ex"
+	},
+	evolveFrom: {
+		en: "Bayleef",
+		de: "Lorblatt",
+		es: "Bayleef",
+		fr: "Macronium",
+		it: "Bayleef",
+		pt: "Bayleef",
+	},
+
+	illustrator: "5ban Graphics",
+	rarity: "None",
+	category: "Pokemon",
+	hp: 360,
+	types: ["Grass"],
+	stage: "Stage2",
+	dexId: [154],
+
+	attacks: [{
+		cost: ["Colorless", "Colorless", "Colorless"],
+
+		name: {
+			en: "Giant Bouquet",
+			fr: "Bouquet Géant",
+			es: "Ramo Gigante",
+			de: "Gigantisches Bouquet",
+			it: "Bouquet Gigante",
+			pt: "Buquê Gigante"
+		},
+
+		effect: {
+			en: "This attack does 50 more damage for each {G} Energy attached to this Pokémon.",
+			fr: "Cette attaque inflige 50 dégâts supplémentaires pour chaque Énergie {G} attachée à ce Pokémon.",
+			es: "Este ataque hace 50 puntos de daño más por cada Energía {G} unida a este Pokémon.",
+			de: "Diese Attacke fügt für jede an dieses Pokémon angelegte {G}-Energie 50 Schadenspunkte mehr zu.",
+			it: "Questo attacco infligge 50 danni in più per ogni Energia {G} assegnata a questo Pokémon.",
+			pt: "Este ataque causa 50 pontos de dano a mais para cada Energia {G} ligada a este Pokémon."
+		},
+
+		damage: "70+"
+	}],
+
+	retreat: 2,
+	regulationMark: "J",
+
+	weaknesses: [{
+		type: "Fire",
+		value: "x2"
+	}],
+
+	variants: [
+		{
+			type: "holo"
+		},
+		{
+			type: "holo",
+			size: "jumbo"
+		}
+	]
+}
+
+export default card

--- a/data/Mega Evolution/MEP Black Star Promos/035.ts
+++ b/data/Mega Evolution/MEP Black Star Promos/035.ts
@@ -1,0 +1,75 @@
+import { Card } from "../../../interfaces"
+import Set from "../MEP Black Star Promos"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Mega Emboar ex",
+		fr: "Méga-Roitiflam-ex",
+		es: "Mega-Emboar ex",
+		de: "Mega-Flambirex-ex",
+		it: "Mega Emboar-ex",
+		pt: "Mega Emboar ex"
+	},
+	evolveFrom: {
+		en: "Pignite",
+		de: "Ferkokel",
+		es: "Pignite",
+		fr: "Grotichon",
+		it: "Pignite",
+		pt: "Pignite",
+	},
+
+	illustrator: "5ban Graphics",
+	rarity: "None",
+	category: "Pokemon",
+	hp: 380,
+	types: ["Fire"],
+	stage: "Stage2",
+	dexId: [500],
+
+	attacks: [{
+		cost: ["Fire", "Fire", "Colorless"],
+
+		name: {
+			en: "Crimson Blast",
+			fr: "Explosion Écarlate",
+			es: "Estallido Carmesí",
+			de: "Feuerrote Explosion",
+			it: "Vermiglioscoppio",
+			pt: "Explosão Carmim"
+		},
+
+		effect: {
+			en: "This Pokémon also does 60 damage to itself.",
+			fr: "Ce Pokémon s'inflige aussi 60 dégâts.",
+			es: "Este Pokémon también se hace 60 puntos de daño a sí mismo.",
+			de: "Dieses Pokémon fügt auch sich selbst 60 Schadenspunkte zu.",
+			it: "Questo Pokémon infligge anche 60 danni a se stesso.",
+			pt: "Este Pokémon também causa 60 pontos de dano a si mesmo."
+		},
+
+		damage: 320
+	}],
+
+	retreat: 4,
+	regulationMark: "J",
+
+	weaknesses: [{
+		type: "Water",
+		value: "x2"
+	}],
+
+	variants: [
+		{
+			type: "holo"
+		},
+		{
+			type: "holo",
+			size: "jumbo"
+		}
+	]
+}
+
+export default card

--- a/data/Mega Evolution/MEP Black Star Promos/036.ts
+++ b/data/Mega Evolution/MEP Black Star Promos/036.ts
@@ -1,0 +1,75 @@
+import { Card } from "../../../interfaces"
+import Set from "../MEP Black Star Promos"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Mega Feraligatr ex",
+		fr: "Méga-Aligatueur-ex",
+		es: "Mega-Feraligatr ex",
+		de: "Mega-Impergator-ex",
+		it: "Mega Feraligatr-ex",
+		pt: "Mega Feraligatr ex"
+	},
+	evolveFrom: {
+		en: "Croconaw",
+		de: "Tyracroc",
+		es: "Croconaw",
+		fr: "Crocrodil",
+		it: "Croconaw",
+		pt: "Croconaw",
+	},
+
+	illustrator: "5ban Graphics",
+	rarity: "None",
+	category: "Pokemon",
+	hp: 370,
+	types: ["Water"],
+	stage: "Stage2",
+	dexId: [160],
+
+	attacks: [{
+		cost: ["Water", "Water", "Colorless"],
+
+		name: {
+			en: "Mortal Crunch",
+			fr: "Mâchouille Mortelle",
+			es: "Trituración Mortífera",
+			de: "Letalknirscher",
+			it: "Sgranocchio Letale",
+			pt: "Mastigada Mortal"
+		},
+
+		effect: {
+			en: "If your opponent's Active Pokémon already has any damage counters on it, this attack does 200 more damage.",
+			fr: "Si le Pokémon Actif de votre adversaire a déjà au moins un marqueur de dégâts, cette attaque inflige 200 dégâts supplémentaires.",
+			es: "Si el Pokémon Activo de tu rival ya tiene algún contador de daño sobre él, este ataque hace 200 puntos de daño más.",
+			de: "Wenn auf dem Aktiven Pokémon deines Gegners mindestens 1 Schadensmarke liegt, fügt diese Attacke 200 Schadenspunkte mehr zu.",
+			it: "Se il Pokémon attivo del tuo avversario ha già dei segnalini danno, questo attacco infligge 200 danni in più.",
+			pt: "Se o Pokémon Ativo do seu oponente já tiver algum contador de dano nele, este ataque causará 200 pontos de dano a mais."
+		},
+
+		damage: "200+"
+	}],
+
+	retreat: 3,
+	regulationMark: "J",
+
+	weaknesses: [{
+		type: "Lightning",
+		value: "x2"
+	}],
+
+	variants: [
+		{
+			type: "holo"
+		},
+		{
+			type: "holo",
+			size: "jumbo"
+		}
+	]
+}
+
+export default card

--- a/data/Mega Evolution/MEP Black Star Promos/064.ts
+++ b/data/Mega Evolution/MEP Black Star Promos/064.ts
@@ -1,0 +1,100 @@
+import { Card } from "../../../interfaces"
+import Set from "../MEP Black Star Promos"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Serperior",
+		fr: "Majaspic",
+		es: "Serperior",
+		'es-mx': "Serperior",
+		de: "Serpiroyal",
+		it: "Serperior",
+		pt: "Serperior"
+	},
+
+	illustrator: "LINNE",
+	rarity: "None",
+	category: "Pokemon",
+	hp: 160,
+	types: ["Grass"],
+	stage: "Stage2",
+	dexId: [497],
+
+	evolveFrom: {
+		en: "Servine",
+		fr: "Lianaja",
+		es: "Servine",
+		'es-mx': "Servine",
+		de: "Efoserp",
+		it: "Servine",
+		pt: "Servine"
+	},
+
+	attacks: [{
+		cost: ["Grass"],
+
+		name: {
+			en: "Regal Command",
+			fr: "Ordre Majestueux",
+			es: "Mandato Realeza",
+			'es-mx': "Mandato de Realeza",
+			de: "Hoheitlicher Befehl",
+			it: "Comando Regale",
+			pt: "Comando Real"
+		},
+
+		effect: {
+			en: "This attack does 20 damage for each of your Pokémon in play.",
+			fr: "Cette attaque inflige 20 dégâts pour chacun de vos Pokémon en jeu.",
+			es: "Este ataque hace 20 puntos de daño por cada uno de tus Pokémon en juego.",
+			'es-mx': "Este ataque hace 20 puntos de daño por cada uno de tus Pokémon en juego.",
+			de: "Diese Attacke fügt für jedes deiner Pokémon im Spiel 20 Schadenspunkte zu.",
+			it: "Questo attacco infligge 20 danni per ciascuno dei tuoi Pokémon in gioco.",
+			pt: "Este ataque causa 20 pontos de dano para cada um dos seus Pokémon em jogo."
+		},
+
+		damage: "20×"
+	}, {
+		cost: ["Grass", "Grass", "Grass"],
+
+		name: {
+			en: "Solar Coiling",
+			fr: "Enroulement Solaire",
+			es: "Enrosque Solar",
+			'es-mx': "Enrosque Solar",
+			de: "Solarschlinge",
+			it: "Avvolgimento Solare",
+			pt: "Enrolada Solar"
+		},
+
+		effect: {
+			en: "If Rosa's Encouragement is in your discard pile, this attack does 150 more damage.",
+			fr: "Si Encouragement d'Écho est dans votre pile de défausse, cette attaque inflige 150 dégâts supplémentaires.",
+			es: "Si Apoyo de Nanci está en tu pila de descartes, este ataque hace 150 puntos de daño más.",
+			'es-mx': "Si Motivación de Nanci está en tu pila de descartes, este ataque hace 150 puntos de daño más.",
+			de: "Wenn Rosys Ermutigung in deinem Ablagestapel ist, fügt diese Attacke 150 Schadenspunkte mehr zu.",
+			it: "Se Incoraggiamento di Rina è nella tua pila degli scarti, questo attacco infligge 150 danni in più.",
+			pt: "Se Encorajamento da Rose estiver na sua pilha de descarte, este ataque causará 150 pontos de dano a mais."
+		},
+
+		damage: "100+"
+	}],
+
+	retreat: 2,
+	regulationMark: "J",
+
+	weaknesses: [{
+		type: "Fire",
+		value: "x2"
+	}],
+
+	variants: [
+		{
+			type: "holo"
+		}
+	]
+}
+
+export default card

--- a/data/Mega Evolution/MEP Black Star Promos/065.ts
+++ b/data/Mega Evolution/MEP Black Star Promos/065.ts
@@ -1,0 +1,90 @@
+import { Card } from "../../../interfaces"
+import Set from "../MEP Black Star Promos"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Barbaracle",
+		fr: "Golgopathe",
+		es: "Barbaracle",
+		'es-mx': "Barbaracle",
+		de: "Thanathora",
+		it: "Barbaracle",
+		pt: "Barbaracle"
+	},
+
+	illustrator: "Hasuno",
+	rarity: "None",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Fighting"],
+	stage: "Stage1",
+	dexId: [689],
+
+	evolveFrom: {
+		en: "Binacle",
+		fr: "Opermine",
+		es: "Binacle",
+		'es-mx': "Binacle",
+		de: "Bithora",
+		it: "Binacle",
+		pt: "Binacle"
+	},
+
+	abilities: [{
+		type: "Ability",
+
+		name: {
+			en: "Stone Arms",
+			fr: "Bras de Pierre",
+			es: "Brazos de Piedra",
+			'es-mx': "Extremidades Pétreas",
+			de: "Arme aus Stein",
+			it: "Braccia di Pietra",
+			pt: "Braços de Pedra"
+		},
+
+		effect: {
+			en: "Once during your turn, you may use this Ability. Attach a Basic {F} Energy card from your hand to 1 of your {F} Pokémon.",
+			fr: "Une fois pendant votre tour, vous pouvez utiliser ce talent. Attachez une carte Énergie {F} de base de votre main à l'un de vos Pokémon {F}.",
+			es: "Una vez durante tu turno, puedes usar esta habilidad. Une 1 carta de Energía {F} Básica de tu mano a uno de tus Pokémon {F}.",
+			'es-mx': "Una vez durante tu turno, puedes usar esta Habilidad. Une 1 carta de Energía {F} Básica de tu mano a 1 de tus Pokémon {F}.",
+			de: "Einmal während deines Zuges kannst du diese Fähigkeit einsetzen. Lege 1 Basis-{F}-Energiekarte aus deiner Hand an 1 deiner {F}-Pokémon an.",
+			it: "Una sola volta durante il tuo turno, puoi usare questa abilità. Assegna a uno dei tuoi Pokémon {F} una carta Energia base {F} dalla tua mano.",
+			pt: "Uma vez durante o seu turno, você poderá usar esta Habilidade. Ligue uma carta de Energia {F} Básica da sua mão a 1 dos seus Pokémon {F}."
+		}
+	}],
+
+	attacks: [{
+		cost: ["Fighting", "Fighting", "Colorless"],
+
+		name: {
+			en: "Hammer In",
+			fr: "Enfoncement",
+			es: "Martillear",
+			'es-mx': "Martillar",
+			de: "Einhämmern",
+			it: "Martello",
+			pt: "Martelada"
+		},
+
+		damage: 80
+	}],
+
+	retreat: 2,
+	regulationMark: "J",
+
+	weaknesses: [{
+		type: "Grass",
+		value: "x2"
+	}],
+
+	variants: [
+		{
+			type: "holo"
+		}
+	]
+}
+
+export default card

--- a/data/Mega Evolution/MEP Black Star Promos/066.ts
+++ b/data/Mega Evolution/MEP Black Star Promos/066.ts
@@ -1,0 +1,100 @@
+import { Card } from "../../../interfaces"
+import Set from "../MEP Black Star Promos"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Tyrantrum",
+		fr: "Rexillius",
+		es: "Tyrantrum",
+		'es-mx': "Tyrantrum",
+		de: "Monargoras",
+		it: "Tyrantrum",
+		pt: "Tyrantrum"
+	},
+
+	illustrator: "Nisota Niso",
+	rarity: "None",
+	category: "Pokemon",
+	hp: 180,
+	types: ["Fighting"],
+	stage: "Stage2",
+	dexId: [697],
+
+	evolveFrom: {
+		en: "Tyrunt",
+		fr: "Ptyranidur",
+		es: "Tyrunt",
+		'es-mx': "Tyrunt",
+		de: "Balgoras",
+		it: "Tyrunt",
+		pt: "Tyrunt"
+	},
+
+	abilities: [{
+		type: "Ability",
+
+		name: {
+			en: "Tyrannically Gutsy",
+			fr: "Tyrannie Musclée",
+			es: "Coraje Tiránico",
+			'es-mx': "Agallas Tiránicas",
+			de: "Tyrannische Tapferkeit",
+			it: "Baldanza Tirannica",
+			pt: "Tenacidade Tirânica"
+		},
+
+		effect: {
+			en: "If this Pokémon has any Special Energy attached, it gets +150 HP.",
+			fr: "Si au moins une Énergie spéciale est attachée à ce Pokémon, il a +150 PV.",
+			es: "Si este Pokémon tiene alguna Energía Especial unida, obtiene 150 PS más.",
+			'es-mx': "Si este Pokémon tiene alguna Energía Especial unida, obtiene 150 PS más.",
+			de: "Wenn an dieses Pokémon mindestens 1 Spezial-Energie angelegt ist, erhält es +150 KP.",
+			it: "Se questo Pokémon ha delle Energie speciali assegnate, ha 150 PS in più.",
+			pt: "Se este Pokémon tiver alguma Energia Especial ligada a ele, receberá +150 PS."
+		}
+	}],
+
+	attacks: [{
+		cost: ["Fighting", "Colorless"],
+
+		name: {
+			en: "Wreak Havoc",
+			fr: "Ravages",
+			es: "Sembrar el Caos",
+			'es-mx': "Sembrar el Caos",
+			de: "Chaos anrichten",
+			it: "Scombussolare",
+			pt: "Causar Estragos"
+		},
+
+		effect: {
+			en: "Flip a coin until you get tails. For each heads, discard the top card of your opponent's deck.",
+			fr: "Lancez une pièce jusqu'à obtenir un côté pile. Pour chaque côté face, défaussez la carte du dessus du deck de votre adversaire.",
+			es: "Lanza 1 moneda hasta que salga cruz. Por cada cara, descarta la primera carta de la baraja de tu rival.",
+			'es-mx': "Lanza 1 moneda hasta que salga cruz. Por cada cara, descarta la primera carta del mazo de tu rival.",
+			de: "Wirf so lange 1 Münze, bis sie Zahl zeigt. Lege pro Kopf die oberste Karte des Decks deines Gegners auf seinen Ablagestapel.",
+			it: "Lancia una moneta finché non esce croce. Ogni volta che esce testa, scarta la prima carta del mazzo del tuo avversario.",
+			pt: "Jogue uma moeda até sair coroa. Para cada cara, descarte a carta de cima do baralho do seu oponente."
+		},
+
+		damage: 160
+	}],
+
+	retreat: 3,
+	regulationMark: "J",
+
+	weaknesses: [{
+		type: "Grass",
+		value: "x2"
+	}],
+
+	variants: [
+		{
+			type: "holo"
+		}
+	]
+}
+
+export default card

--- a/data/Mega Evolution/MEP Black Star Promos/067.ts
+++ b/data/Mega Evolution/MEP Black Star Promos/067.ts
@@ -1,0 +1,81 @@
+import { Card } from "../../../interfaces"
+import Set from "../MEP Black Star Promos"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Doublade",
+		fr: "Dimoclès",
+		es: "Doublade",
+		'es-mx': "Doublade",
+		de: "Duokles",
+		it: "Doublade",
+		pt: "Doublade"
+	},
+
+	illustrator: "Yukihiro Tada",
+	rarity: "None",
+	category: "Pokemon",
+	hp: 100,
+	types: ["Metal"],
+	stage: "Stage1",
+	dexId: [680],
+
+	evolveFrom: {
+		en: "Honedge",
+		fr: "Monorpale",
+		es: "Honedge",
+		'es-mx': "Honedge",
+		de: "Gramokles",
+		it: "Honedge",
+		pt: "Honedge"
+	},
+
+	attacks: [{
+		cost: ["Colorless", "Colorless"],
+
+		name: {
+			en: "Weaponized Swords",
+			fr: "Épées Armes",
+			es: "Espadas Pertrechadas",
+			'es-mx': "Espadas Pertrechadas",
+			de: "Kollektive Klingenkraft",
+			it: "Spade Belliche",
+			pt: "Espadas Armadas"
+		},
+
+		effect: {
+			en: "Reveal any number of Honedge, Doublade, and Aegislash from your hand, and this attack does 60 damage for each card you revealed in this way.",
+			fr: "Montrez le nombre voulu de Monorpale, de Dimoclès et d'Exagide de votre main. Cette attaque inflige 60 dégâts pour chaque carte montrée de cette façon.",
+			es: "Enseña cualquier cantidad de Honedge, Doublade y Aegislash de tu mano, y este ataque hace 60 puntos de daño por cada carta que hayas enseñado de esta manera.",
+			'es-mx': "Muestra cualquier cantidad de Honedge, Doublade y Aegislash de tu mano, y este ataque hace 60 puntos de daño por cada carta que mostraste de esta manera.",
+			de: "Zeige deinem Gegner beliebig viele Gramokles, Duokles und Durengard auf deiner Hand, und diese Attacke fügt für jede auf diese Weise gezeigte Karte 60 Schadenspunkte zu.",
+			it: "Mostra un numero qualsiasi di Honedge, Doublade e Aegislash che hai in mano e questo attacco infligge 60 danni per ogni carta che hai mostrato in questo modo.",
+			pt: "Revele qualquer número de Honedge, Doublade e Aegislash na sua mão, e este ataque causa 60 pontos de dano para cada carta revelada desta forma."
+		},
+
+		damage: "60×"
+	}],
+
+	retreat: 2,
+	regulationMark: "J",
+
+	weaknesses: [{
+		type: "Fire",
+		value: "x2"
+	}],
+
+	resistances: [{
+		type: "Grass",
+		value: "-30"
+	}],
+
+	variants: [
+		{
+			type: "holo"
+		}
+	]
+}
+
+export default card

--- a/data/Mega Evolution/MEP Black Star Promos/068.ts
+++ b/data/Mega Evolution/MEP Black Star Promos/068.ts
@@ -1,0 +1,70 @@
+import { Card } from "../../../interfaces"
+import Set from "../MEP Black Star Promos"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Makuhita",
+		fr: "Makuhita",
+		de: "Makuhita",
+		it: "Makuhita",
+		es: "Makuhita",
+		pt: "Makuhita",
+		'es-mx': "Makuhita"
+	},
+
+	illustrator: "Takeshi Nakamura",
+	rarity: "None",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Fighting"],
+	stage: "Basic",
+	dexId: [296],
+
+	attacks: [{
+		cost: ["Fighting"],
+
+		name: {
+			en: "Corkscrew Punch",
+			fr: "Poing Tire-Bouchon",
+			de: "Korkenzieherhieb",
+			it: "Pugno Rotante",
+			es: "Puño Tirabuzón",
+			pt: "Soco Saca-rolha",
+			'es-mx': "Puño Sacacorchos"
+		},
+
+		damage: 10
+	}, {
+		cost: ["Fighting", "Fighting"],
+
+		name: {
+			en: "Confront",
+			fr: "Confrontation",
+			de: "Konfrontieren",
+			it: "Confronto",
+			es: "Confrontar",
+			pt: "Confrontar",
+			'es-mx': "Confrontar"
+		},
+
+		damage: 30
+	}],
+
+	retreat: 2,
+	regulationMark: "I",
+
+	weaknesses: [{
+		type: "Psychic",
+		value: "x2"
+	}],
+
+	variants: [
+		{
+			type: "holo"
+		}
+	]
+}
+
+export default card

--- a/data/Mega Evolution/MEP Black Star Promos/069.ts
+++ b/data/Mega Evolution/MEP Black Star Promos/069.ts
@@ -1,0 +1,56 @@
+import { Card } from "../../../interfaces"
+import Set from "../MEP Black Star Promos"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Chikorita",
+		fr: "Germignon",
+		de: "Endivie",
+		it: "Chikorita",
+		es: "Chikorita",
+		pt: "Chikorita",
+		'es-mx': "Chikorita"
+	},
+
+	illustrator: "Makura Tami",
+	rarity: "None",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Grass"],
+	stage: "Basic",
+	dexId: [152],
+
+	attacks: [{
+		cost: ["Grass"],
+
+		name: {
+			en: "Razor Leaf",
+			fr: "Tranch'Herbe",
+			de: "Rasierblatt",
+			it: "Foglielama",
+			es: "Hoja Afilada",
+			pt: "Folha Navalha",
+			'es-mx': "Hojas Navaja"
+		},
+
+		damage: 20
+	}],
+
+	retreat: 1,
+	regulationMark: "I",
+
+	weaknesses: [{
+		type: "Fire",
+		value: "x2"
+	}],
+
+	variants: [
+		{
+			type: "holo"
+		}
+	]
+}
+
+export default card

--- a/data/Mega Evolution/MEP Black Star Promos/070.ts
+++ b/data/Mega Evolution/MEP Black Star Promos/070.ts
@@ -1,0 +1,76 @@
+import { Card } from "../../../interfaces"
+import Set from "../MEP Black Star Promos"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Tyrunt",
+		fr: "Ptyranidur",
+		es: "Tyrunt",
+		'es-mx': "Tyrunt",
+		de: "Balgoras",
+		it: "Tyrunt",
+		pt: "Tyrunt"
+	},
+
+	illustrator: "Shimaris Yukichi",
+	rarity: "None",
+	category: "Pokemon",
+	hp: 100,
+	types: ["Fighting"],
+	stage: "Stage1",
+	dexId: [696],
+
+	evolveFrom: {
+		en: "Antique Jaw Fossil",
+		fr: "Fossile Mâchoire Ancien",
+		es: "Fósil Mandíbula Antiguo",
+		'es-mx': "Fósil Mandíbula Antiguo",
+		de: "Antikes Kieferfossil",
+		it: "Vecchio Fossilmascella",
+		pt: "Fóssil de Mandíbula Arcaico"
+	},
+
+	attacks: [{
+		cost: ["Fighting", "Colorless"],
+
+		name: {
+			en: "Get Angry",
+			fr: "Coléreux",
+			es: "Enfadarse",
+			'es-mx': "Enojarse",
+			de: "Rotsehen",
+			it: "Tutte le Furie",
+			pt: "Dar Piti"
+		},
+
+		effect: {
+			en: "This attack does 20 damage for each damage counter on this Pokémon.",
+			fr: "Cette attaque inflige 20 dégâts pour chaque marqueur de dégâts sur ce Pokémon.",
+			es: "Este ataque hace 20 puntos de daño por cada contador de daño en este Pokémon.",
+			'es-mx': "Este ataque hace 20 puntos de daño por cada contador de daño en este Pokémon.",
+			de: "Diese Attacke fügt für jede Schadensmarke auf diesem Pokémon 20 Schadenspunkte zu.",
+			it: "Questo attacco infligge 20 danni per ogni segnalino danno presente su questo Pokémon.",
+			pt: "Este ataque causa 20 pontos de dano para cada contador de dano neste Pokémon."
+		},
+
+		damage: "20×"
+	}],
+
+	retreat: 3,
+	regulationMark: "J",
+
+	weaknesses: [{
+		type: "Grass",
+		value: "x2"
+	}],
+
+	variants: [
+		{
+			type: "holo"
+		}
+	]
+}
+
+export default card


### PR DESCRIPTION
## Summary

This PR adds missing cards to the Mega Evolution MEP Black Star Promos dataset and fixes an incorrect set reference.

## Changes

- Added MEP Black Star Promo cards 029-036:
  - Mega Charizard X ex
  - Mega Charizard Y ex
  - N's Zekrom
  - Mega Gardevoir ex
  - Mega Lucario ex
  - Mega Meganium ex
  - Mega Emboar ex
  - Mega Feraligatr ex

- Added MEP Black Star Promo cards 064-070:
  - Serperior
  - Barbaracle
  - Tyrantrum
  - Doublade
  - Makuhita
  - Chikorita
  - Tyrunt

- Fixed card 017 by updating its set reference from Phantasmal Flames to MEP Black Star Promos.


