### PR TITLE
fix(Ascended Heroes): correct Rare cards from type:normal to type:holo

### DIFF
--- a/data/Mega Evolution/Ascended Heroes/006.ts
+++ b/data/Mega Evolution/Ascended Heroes/006.ts
@@ -66,7 +66,7 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "normal",
+			type: "holo",
 			thirdParty: {
 				cardmarket: 869617,
 				tcgplayer: 675818

--- a/data/Mega Evolution/Ascended Heroes/024.ts
+++ b/data/Mega Evolution/Ascended Heroes/024.ts
@@ -76,7 +76,7 @@ const card: Card = {
 
 	variants: [
 	{
-		type: "normal",
+		type: "holo",
 		thirdParty: {
 			cardmarket: 869635,
 			tcgplayer: 675836

--- a/data/Mega Evolution/Ascended Heroes/025.ts
+++ b/data/Mega Evolution/Ascended Heroes/025.ts
@@ -52,7 +52,7 @@ const card: Card = {
 
 	variants: [
 	{
-		type: "normal",
+		type: "holo",
 		thirdParty: {
 			cardmarket: 869636,
 			tcgplayer: 675837

--- a/data/Mega Evolution/Ascended Heroes/067.ts
+++ b/data/Mega Evolution/Ascended Heroes/067.ts
@@ -74,7 +74,7 @@ const card: Card = {
 
 	variants: [
 	{
-		type: "normal",
+		type: "holo",
 		thirdParty: {
 			cardmarket: 869678,
 			tcgplayer: 675879

--- a/data/Mega Evolution/Ascended Heroes/072.ts
+++ b/data/Mega Evolution/Ascended Heroes/072.ts
@@ -66,7 +66,7 @@ const card: Card = {
 
 	variants: [
 	{
-		type: "normal",
+		type: "holo",
 		thirdParty: {
 			cardmarket: 869683,
 			tcgplayer: 675884

--- a/data/Mega Evolution/Ascended Heroes/082.ts
+++ b/data/Mega Evolution/Ascended Heroes/082.ts
@@ -66,7 +66,7 @@ const card: Card = {
 
 	variants: [
 	{
-		type: "normal",
+		type: "holo",
 		thirdParty: {
 			cardmarket: 869693,
 			tcgplayer: 675894

--- a/data/Mega Evolution/Ascended Heroes/086.ts
+++ b/data/Mega Evolution/Ascended Heroes/086.ts
@@ -52,7 +52,7 @@ const card: Card = {
 
 	variants: [
 	{
-		type: "normal",
+		type: "holo",
 		thirdParty: {
 			cardmarket: 869697,
 			tcgplayer: 675898

--- a/data/Mega Evolution/Ascended Heroes/096.ts
+++ b/data/Mega Evolution/Ascended Heroes/096.ts
@@ -76,7 +76,7 @@ const card: Card = {
 
 	variants: [
 	{
-		type: "normal",
+		type: "holo",
 		thirdParty: {
 			cardmarket: 869707,
 			tcgplayer: 675908

--- a/data/Mega Evolution/Ascended Heroes/098.ts
+++ b/data/Mega Evolution/Ascended Heroes/098.ts
@@ -64,7 +64,7 @@ const card: Card = {
 
 	variants: [
 	{
-		type: "normal",
+		type: "holo",
 		thirdParty: {
 			cardmarket: 869709,
 			tcgplayer: 675910

--- a/data/Mega Evolution/Ascended Heroes/099.ts
+++ b/data/Mega Evolution/Ascended Heroes/099.ts
@@ -76,7 +76,7 @@ const card: Card = {
 
 	variants: [
 	{
-		type: "normal",
+		type: "holo",
 		thirdParty: {
 			cardmarket: 869710,
 			tcgplayer: 675911

--- a/data/Mega Evolution/Ascended Heroes/105.ts
+++ b/data/Mega Evolution/Ascended Heroes/105.ts
@@ -66,7 +66,7 @@ const card: Card = {
 
 	variants: [
 	{
-		type: "normal",
+		type: "holo",
 		thirdParty: {
 			cardmarket: 869716,
 			tcgplayer: 675917

--- a/data/Mega Evolution/Ascended Heroes/108.ts
+++ b/data/Mega Evolution/Ascended Heroes/108.ts
@@ -66,7 +66,7 @@ const card: Card = {
 
 	variants: [
 	{
-		type: "normal",
+		type: "holo",
 		thirdParty: {
 			cardmarket: 869719,
 			tcgplayer: 675920

--- a/data/Mega Evolution/Ascended Heroes/120.ts
+++ b/data/Mega Evolution/Ascended Heroes/120.ts
@@ -74,7 +74,7 @@ const card: Card = {
 
 	variants: [
 	{
-		type: "normal",
+		type: "holo",
 		thirdParty: {
 			cardmarket: 869731,
 			tcgplayer: 675932

--- a/data/Mega Evolution/Ascended Heroes/122.ts
+++ b/data/Mega Evolution/Ascended Heroes/122.ts
@@ -66,7 +66,7 @@ const card: Card = {
 
 	variants: [
 	{
-		type: "normal",
+		type: "holo",
 		thirdParty: {
 			cardmarket: 869733,
 			tcgplayer: 675934

--- a/data/Mega Evolution/Ascended Heroes/141.ts
+++ b/data/Mega Evolution/Ascended Heroes/141.ts
@@ -74,7 +74,7 @@ const card: Card = {
 
 	variants: [
 	{
-		type: "normal",
+		type: "holo",
 		thirdParty: {
 			cardmarket: 869752,
 			tcgplayer: 675953

--- a/data/Mega Evolution/Ascended Heroes/143.ts
+++ b/data/Mega Evolution/Ascended Heroes/143.ts
@@ -76,7 +76,7 @@ const card: Card = {
 
 	variants: [
 	{
-		type: "normal",
+		type: "holo",
 		thirdParty: {
 			cardmarket: 869754,
 			tcgplayer: 675955

--- a/data/Mega Evolution/Ascended Heroes/148.ts
+++ b/data/Mega Evolution/Ascended Heroes/148.ts
@@ -76,7 +76,7 @@ const card: Card = {
 
 	variants: [
 	{
-		type: "normal",
+		type: "holo",
 		thirdParty: {
 			cardmarket: 869759,
 			tcgplayer: 675960

--- a/data/Mega Evolution/Ascended Heroes/153.ts
+++ b/data/Mega Evolution/Ascended Heroes/153.ts
@@ -66,7 +66,7 @@ const card: Card = {
 
 	variants: [
 	{
-		type: "normal",
+		type: "holo",
 		thirdParty: {
 			cardmarket: 869764,
 			tcgplayer: 675965

--- a/data/Mega Evolution/Ascended Heroes/154.ts
+++ b/data/Mega Evolution/Ascended Heroes/154.ts
@@ -66,7 +66,7 @@ const card: Card = {
 
 	variants: [
 	{
-		type: "normal",
+		type: "holo",
 		thirdParty: {
 			cardmarket: 869765,
 			tcgplayer: 675966

--- a/data/Mega Evolution/Ascended Heroes/155.ts
+++ b/data/Mega Evolution/Ascended Heroes/155.ts
@@ -76,7 +76,7 @@ const card: Card = {
 
 	variants: [
 	{
-		type: "normal",
+		type: "holo",
 		thirdParty: {
 			cardmarket: 869766,
 			tcgplayer: 675967

--- a/data/Mega Evolution/Ascended Heroes/170.ts
+++ b/data/Mega Evolution/Ascended Heroes/170.ts
@@ -76,7 +76,7 @@ const card: Card = {
 
 	variants: [
 	{
-		type: "normal",
+		type: "holo",
 		thirdParty: {
 			cardmarket: 869781,
 			tcgplayer: 675982

--- a/data/Mega Evolution/Ascended Heroes/178.ts
+++ b/data/Mega Evolution/Ascended Heroes/178.ts
@@ -64,7 +64,7 @@ const card: Card = {
 
 	variants: [
 	{
-		type: "normal",
+		type: "holo",
 		thirdParty: {
 			cardmarket: 869789,
 			tcgplayer: 675990


### PR DESCRIPTION
## Summary

PR #1167 mislabeled 22 of the 25 Rare cards in Ascended Heroes with `type: "normal"` instead of `type: "holo"`. All Rare cards in this set are Rare Holo prints. This PR flips the single variant entry from `"normal"` to `"holo"` on the 22 affected cards. No other fields are touched.

## Cards changed

006, 024, 025, 067, 072, 082, 086, 096, 098, 099, 105, 108, 120, 122, 141, 143, 148, 153, 154, 155, 170, 178

After this change, all 25 Rare cards (these 22 + 019, 078, 127 which were already correct) have `type: "holo"`.