### PR TITLE
data: declare reverse holo variants for SV03.5 set

### DIFF
--- a/data/Scarlet & Violet/151/001.ts
+++ b/data/Scarlet & Violet/151/001.ts
@@ -47,9 +47,14 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: "normal"
+		},
+		{
+			type: "reverse"
+		}
+	],
 
 	illustrator: "Yuu Nishida",
 

--- a/data/Scarlet & Violet/151/002.ts
+++ b/data/Scarlet & Violet/151/002.ts
@@ -68,9 +68,14 @@ const card: Card = {
 	retreat: 3,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: "normal"
+		},
+		{
+			type: "reverse"
+		}
+	],
 
 	illustrator: "Yuu Nishida",
 

--- a/data/Scarlet & Violet/151/004.ts
+++ b/data/Scarlet & Violet/151/004.ts
@@ -58,9 +58,14 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: "normal"
+		},
+		{
+			type: "reverse"
+		}
+	],
 
 	illustrator: "GIDORA",
 

--- a/data/Scarlet & Violet/151/005.ts
+++ b/data/Scarlet & Violet/151/005.ts
@@ -68,9 +68,14 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: "normal"
+		},
+		{
+			type: "reverse"
+		}
+	],
 
 	illustrator: "GIDORA",
 

--- a/data/Scarlet & Violet/151/007.ts
+++ b/data/Scarlet & Violet/151/007.ts
@@ -58,9 +58,14 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: "normal"
+		},
+		{
+			type: "reverse"
+		}
+	],
 
 	illustrator: "kantaro",
 

--- a/data/Scarlet & Violet/151/008.ts
+++ b/data/Scarlet & Violet/151/008.ts
@@ -66,9 +66,14 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: "normal"
+		},
+		{
+			type: "reverse"
+		}
+	],
 
 	illustrator: "kantaro",
 

--- a/data/Scarlet & Violet/151/010.ts
+++ b/data/Scarlet & Violet/151/010.ts
@@ -47,9 +47,14 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: "normal"
+		},
+		{
+			type: "reverse"
+		}
+	],
 
 	illustrator: "Tika Matsuno",
 

--- a/data/Scarlet & Violet/151/011.ts
+++ b/data/Scarlet & Violet/151/011.ts
@@ -66,9 +66,14 @@ const card: Card = {
 	retreat: 3,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: "normal"
+		},
+		{
+			type: "reverse"
+		}
+	],
 
 	illustrator: "Tika Matsuno",
 

--- a/data/Scarlet & Violet/151/012.ts
+++ b/data/Scarlet & Violet/151/012.ts
@@ -75,9 +75,14 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: "normal"
+		},
+		{
+			type: "reverse"
+		}
+	],
 
 	illustrator: "Tika Matsuno",
 

--- a/data/Scarlet & Violet/151/013.ts
+++ b/data/Scarlet & Violet/151/013.ts
@@ -51,9 +51,14 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: "normal"
+		},
+		{
+			type: "reverse"
+		}
+	],
 
 	illustrator: "nisimono",
 

--- a/data/Scarlet & Violet/151/014.ts
+++ b/data/Scarlet & Violet/151/014.ts
@@ -68,9 +68,14 @@ const card: Card = {
 	retreat: 3,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: "normal"
+		},
+		{
+			type: "reverse"
+		}
+	],
 
 	illustrator: "nisimono",
 

--- a/data/Scarlet & Violet/151/015.ts
+++ b/data/Scarlet & Violet/151/015.ts
@@ -68,9 +68,14 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		normal: false
-	},
+	variants: [
+		{
+			type: "holo"
+		},
+		{
+			type: "reverse"
+		}
+	],
 
 	illustrator: "nisimono",
 

--- a/data/Scarlet & Violet/151/016.ts
+++ b/data/Scarlet & Violet/151/016.ts
@@ -58,9 +58,14 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: "normal"
+		},
+		{
+			type: "reverse"
+		}
+	],
 
 	illustrator: "Oswaldo KATO",
 

--- a/data/Scarlet & Violet/151/017.ts
+++ b/data/Scarlet & Violet/151/017.ts
@@ -46,9 +46,14 @@ const card: Card = {
 	retreat: 0,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: "normal"
+		},
+		{
+			type: "reverse"
+		}
+	],
 
 	illustrator: "Oswaldo KATO",
 

--- a/data/Scarlet & Violet/151/018.ts
+++ b/data/Scarlet & Violet/151/018.ts
@@ -68,9 +68,14 @@ const card: Card = {
 	retreat: 0,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: "normal"
+		},
+		{
+			type: "reverse"
+		}
+	],
 
 	illustrator: "Oswaldo KATO",
 

--- a/data/Scarlet & Violet/151/019.ts
+++ b/data/Scarlet & Violet/151/019.ts
@@ -47,9 +47,14 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: "normal"
+		},
+		{
+			type: "reverse"
+		}
+	],
 
 	illustrator: "sowsow",
 

--- a/data/Scarlet & Violet/151/020.ts
+++ b/data/Scarlet & Violet/151/020.ts
@@ -55,9 +55,14 @@ const card: Card = {
 	retreat: 0,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: "normal"
+		},
+		{
+			type: "reverse"
+		}
+	],
 
 	illustrator: "sowsow",
 

--- a/data/Scarlet & Violet/151/021.ts
+++ b/data/Scarlet & Violet/151/021.ts
@@ -60,9 +60,14 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: "normal"
+		},
+		{
+			type: "reverse"
+		}
+	],
 
 	illustrator: "Gemi",
 

--- a/data/Scarlet & Violet/151/022.ts
+++ b/data/Scarlet & Violet/151/022.ts
@@ -66,9 +66,14 @@ const card: Card = {
 	retreat: 0,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: "normal"
+		},
+		{
+			type: "reverse"
+		}
+	],
 
 	illustrator: "Gemi",
 

--- a/data/Scarlet & Violet/151/023.ts
+++ b/data/Scarlet & Violet/151/023.ts
@@ -47,9 +47,14 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: "normal"
+		},
+		{
+			type: "reverse"
+		}
+	],
 
 	illustrator: "Kedamahadaitai Yawarakai",
 

--- a/data/Scarlet & Violet/151/025.ts
+++ b/data/Scarlet & Violet/151/025.ts
@@ -58,9 +58,14 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: "normal"
+		},
+		{
+			type: "reverse"
+		}
+	],
 
 	illustrator: "Naoyo Kimura",
 

--- a/data/Scarlet & Violet/151/026.ts
+++ b/data/Scarlet & Violet/151/026.ts
@@ -77,9 +77,14 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		normal: false
-	},
+	variants: [
+		{
+			type: "holo"
+		},
+		{
+			type: "reverse"
+		}
+	],
 
 	illustrator: "Naoyo Kimura",
 

--- a/data/Scarlet & Violet/151/027.ts
+++ b/data/Scarlet & Violet/151/027.ts
@@ -60,9 +60,14 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: "normal"
+		},
+		{
+			type: "reverse"
+		}
+	],
 
 	illustrator: "kodama",
 

--- a/data/Scarlet & Violet/151/028.ts
+++ b/data/Scarlet & Violet/151/028.ts
@@ -77,9 +77,14 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: "normal"
+		},
+		{
+			type: "reverse"
+		}
+	],
 
 	illustrator: "kodama",
 

--- a/data/Scarlet & Violet/151/029.ts
+++ b/data/Scarlet & Violet/151/029.ts
@@ -47,9 +47,14 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: "normal"
+		},
+		{
+			type: "reverse"
+		}
+	],
 
 	illustrator: "Teeziro",
 

--- a/data/Scarlet & Violet/151/030.ts
+++ b/data/Scarlet & Violet/151/030.ts
@@ -66,9 +66,14 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: "normal"
+		},
+		{
+			type: "reverse"
+		}
+	],
 
 	illustrator: "Teeziro",
 

--- a/data/Scarlet & Violet/151/031.ts
+++ b/data/Scarlet & Violet/151/031.ts
@@ -68,9 +68,14 @@ const card: Card = {
 	retreat: 3,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: "normal"
+		},
+		{
+			type: "reverse"
+		}
+	],
 
 	illustrator: "Teeziro",
 

--- a/data/Scarlet & Violet/151/032.ts
+++ b/data/Scarlet & Violet/151/032.ts
@@ -38,9 +38,14 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: "normal"
+		},
+		{
+			type: "reverse"
+		}
+	],
 
 	illustrator: "Shiburingaru",
 

--- a/data/Scarlet & Violet/151/033.ts
+++ b/data/Scarlet & Violet/151/033.ts
@@ -59,9 +59,14 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: "normal"
+		},
+		{
+			type: "reverse"
+		}
+	],
 
 	illustrator: "Shiburingaru",
 

--- a/data/Scarlet & Violet/151/034.ts
+++ b/data/Scarlet & Violet/151/034.ts
@@ -77,9 +77,14 @@ const card: Card = {
 	retreat: 3,
 	regulationMark: "G",
 
-	variants: {
-		normal: false
-	},
+	variants: [
+		{
+			type: "holo"
+		},
+		{
+			type: "reverse"
+		}
+	],
 
 	illustrator: "Shiburingaru",
 

--- a/data/Scarlet & Violet/151/035.ts
+++ b/data/Scarlet & Violet/151/035.ts
@@ -58,9 +58,14 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: "normal"
+		},
+		{
+			type: "reverse"
+		}
+	],
 
 	illustrator: "ryoma uratsuka",
 

--- a/data/Scarlet & Violet/151/036.ts
+++ b/data/Scarlet & Violet/151/036.ts
@@ -75,9 +75,14 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: "normal"
+		},
+		{
+			type: "reverse"
+		}
+	],
 
 	illustrator: "ryoma uratsuka",
 

--- a/data/Scarlet & Violet/151/037.ts
+++ b/data/Scarlet & Violet/151/037.ts
@@ -47,9 +47,14 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: "normal"
+		},
+		{
+			type: "reverse"
+		}
+	],
 
 	illustrator: "kawayoo",
 

--- a/data/Scarlet & Violet/151/039.ts
+++ b/data/Scarlet & Violet/151/039.ts
@@ -67,9 +67,14 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: "normal"
+		},
+		{
+			type: "reverse"
+		}
+	],
 
 	illustrator: "saino misaki",
 

--- a/data/Scarlet & Violet/151/041.ts
+++ b/data/Scarlet & Violet/151/041.ts
@@ -60,9 +60,14 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: "normal"
+		},
+		{
+			type: "reverse"
+		}
+	],
 
 	illustrator: "Scav",
 

--- a/data/Scarlet & Violet/151/042.ts
+++ b/data/Scarlet & Violet/151/042.ts
@@ -53,9 +53,14 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: "normal"
+		},
+		{
+			type: "reverse"
+		}
+	],
 
 	illustrator: "Scav",
 

--- a/data/Scarlet & Violet/151/043.ts
+++ b/data/Scarlet & Violet/151/043.ts
@@ -38,9 +38,14 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: "normal"
+		},
+		{
+			type: "reverse"
+		}
+	],
 
 	illustrator: "Sekio",
 

--- a/data/Scarlet & Violet/151/044.ts
+++ b/data/Scarlet & Violet/151/044.ts
@@ -68,9 +68,14 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: "normal"
+		},
+		{
+			type: "reverse"
+		}
+	],
 
 	illustrator: "Sekio",
 

--- a/data/Scarlet & Violet/151/045.ts
+++ b/data/Scarlet & Violet/151/045.ts
@@ -68,9 +68,14 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "G",
 
-	variants: {
-		normal: false
-	},
+	variants: [
+		{
+			type: "holo"
+		},
+		{
+			type: "reverse"
+		}
+	],
 
 	illustrator: "Sekio",
 

--- a/data/Scarlet & Violet/151/046.ts
+++ b/data/Scarlet & Violet/151/046.ts
@@ -60,9 +60,14 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: "normal"
+		},
+		{
+			type: "reverse"
+		}
+	],
 
 	illustrator: "Yoriyuki Ikegami",
 

--- a/data/Scarlet & Violet/151/047.ts
+++ b/data/Scarlet & Violet/151/047.ts
@@ -66,9 +66,14 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: "normal"
+		},
+		{
+			type: "reverse"
+		}
+	],
 
 	illustrator: "Yoriyuki Ikegami",
 

--- a/data/Scarlet & Violet/151/048.ts
+++ b/data/Scarlet & Violet/151/048.ts
@@ -51,9 +51,14 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: "normal"
+		},
+		{
+			type: "reverse"
+		}
+	],
 
 	illustrator: "Kagemaru Himeno",
 

--- a/data/Scarlet & Violet/151/049.ts
+++ b/data/Scarlet & Violet/151/049.ts
@@ -68,9 +68,14 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: "normal"
+		},
+		{
+			type: "reverse"
+		}
+	],
 
 	illustrator: "Kagemaru Himeno",
 

--- a/data/Scarlet & Violet/151/050.ts
+++ b/data/Scarlet & Violet/151/050.ts
@@ -51,9 +51,14 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: "normal"
+		},
+		{
+			type: "reverse"
+		}
+	],
 
 	illustrator: "Miki Tanaka",
 

--- a/data/Scarlet & Violet/151/051.ts
+++ b/data/Scarlet & Violet/151/051.ts
@@ -59,9 +59,14 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: "normal"
+		},
+		{
+			type: "reverse"
+		}
+	],
 
 	illustrator: "Miki Tanaka",
 

--- a/data/Scarlet & Violet/151/052.ts
+++ b/data/Scarlet & Violet/151/052.ts
@@ -58,9 +58,14 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: "normal"
+		},
+		{
+			type: "reverse"
+		}
+	],
 
 	illustrator: "Naoki Saito",
 

--- a/data/Scarlet & Violet/151/053.ts
+++ b/data/Scarlet & Violet/151/053.ts
@@ -68,9 +68,14 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: "normal"
+		},
+		{
+			type: "reverse"
+		}
+	],
 
 	illustrator: "Naoki Saito",
 

--- a/data/Scarlet & Violet/151/054.ts
+++ b/data/Scarlet & Violet/151/054.ts
@@ -58,9 +58,14 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: "normal"
+		},
+		{
+			type: "reverse"
+		}
+	],
 
 	illustrator: "Taira Akitsu",
 

--- a/data/Scarlet & Violet/151/055.ts
+++ b/data/Scarlet & Violet/151/055.ts
@@ -66,9 +66,14 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: "normal"
+		},
+		{
+			type: "reverse"
+		}
+	],
 
 	illustrator: "Taira Akitsu",
 

--- a/data/Scarlet & Violet/151/056.ts
+++ b/data/Scarlet & Violet/151/056.ts
@@ -47,9 +47,14 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: "normal"
+		},
+		{
+			type: "reverse"
+		}
+	],
 
 	illustrator: "Mina Nakai",
 

--- a/data/Scarlet & Violet/151/057.ts
+++ b/data/Scarlet & Violet/151/057.ts
@@ -77,9 +77,14 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: "normal"
+		},
+		{
+			type: "reverse"
+		}
+	],
 
 	illustrator: "Mina Nakai",
 

--- a/data/Scarlet & Violet/151/058.ts
+++ b/data/Scarlet & Violet/151/058.ts
@@ -47,9 +47,14 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: "normal"
+		},
+		{
+			type: "reverse"
+		}
+	],
 
 	illustrator: "Atsushi Furusawa",
 

--- a/data/Scarlet & Violet/151/059.ts
+++ b/data/Scarlet & Violet/151/059.ts
@@ -77,9 +77,14 @@ const card: Card = {
 	retreat: 4,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: "normal"
+		},
+		{
+			type: "reverse"
+		}
+	],
 
 	illustrator: "Atsushi Furusawa",
 

--- a/data/Scarlet & Violet/151/060.ts
+++ b/data/Scarlet & Violet/151/060.ts
@@ -47,9 +47,14 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: "normal"
+		},
+		{
+			type: "reverse"
+		}
+	],
 
 	illustrator: "Kurata So",
 

--- a/data/Scarlet & Violet/151/061.ts
+++ b/data/Scarlet & Violet/151/061.ts
@@ -68,9 +68,14 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: "normal"
+		},
+		{
+			type: "reverse"
+		}
+	],
 
 	illustrator: "Kurata So",
 

--- a/data/Scarlet & Violet/151/062.ts
+++ b/data/Scarlet & Violet/151/062.ts
@@ -77,9 +77,14 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: "normal"
+		},
+		{
+			type: "reverse"
+		}
+	],
 
 	illustrator: "Kurata So",
 

--- a/data/Scarlet & Violet/151/063.ts
+++ b/data/Scarlet & Violet/151/063.ts
@@ -38,9 +38,14 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: "normal"
+		},
+		{
+			type: "reverse"
+		}
+	],
 
 	illustrator: "Mitsuhiro Arita",
 

--- a/data/Scarlet & Violet/151/064.ts
+++ b/data/Scarlet & Violet/151/064.ts
@@ -55,9 +55,14 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: "normal"
+		},
+		{
+			type: "reverse"
+		}
+	],
 
 	illustrator: "Mitsuhiro Arita",
 

--- a/data/Scarlet & Violet/151/066.ts
+++ b/data/Scarlet & Violet/151/066.ts
@@ -58,9 +58,14 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: "normal"
+		},
+		{
+			type: "reverse"
+		}
+	],
 
 	illustrator: "Ryuta Fuse",
 

--- a/data/Scarlet & Violet/151/067.ts
+++ b/data/Scarlet & Violet/151/067.ts
@@ -55,9 +55,14 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: "normal"
+		},
+		{
+			type: "reverse"
+		}
+	],
 
 	illustrator: "Ryuta Fuse",
 

--- a/data/Scarlet & Violet/151/068.ts
+++ b/data/Scarlet & Violet/151/068.ts
@@ -77,9 +77,14 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "G",
 
-	variants: {
-		normal: false
-	},
+	variants: [
+		{
+			type: "holo"
+		},
+		{
+			type: "reverse"
+		}
+	],
 
 	illustrator: "Ryuta Fuse",
 

--- a/data/Scarlet & Violet/151/069.ts
+++ b/data/Scarlet & Violet/151/069.ts
@@ -60,9 +60,14 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: "normal"
+		},
+		{
+			type: "reverse"
+		}
+	],
 
 	illustrator: "Jerky",
 

--- a/data/Scarlet & Violet/151/070.ts
+++ b/data/Scarlet & Violet/151/070.ts
@@ -59,9 +59,14 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: "normal"
+		},
+		{
+			type: "reverse"
+		}
+	],
 
 	illustrator: "Jerky",
 

--- a/data/Scarlet & Violet/151/071.ts
+++ b/data/Scarlet & Violet/151/071.ts
@@ -68,9 +68,14 @@ const card: Card = {
 	retreat: 3,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: "normal"
+		},
+		{
+			type: "reverse"
+		}
+	],
 
 	illustrator: "Jerky",
 

--- a/data/Scarlet & Violet/151/072.ts
+++ b/data/Scarlet & Violet/151/072.ts
@@ -51,9 +51,14 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: "normal"
+		},
+		{
+			type: "reverse"
+		}
+	],
 
 	illustrator: "miki kudo",
 

--- a/data/Scarlet & Violet/151/073.ts
+++ b/data/Scarlet & Violet/151/073.ts
@@ -77,9 +77,14 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: "normal"
+		},
+		{
+			type: "reverse"
+		}
+	],
 
 	illustrator: "miki kudo",
 

--- a/data/Scarlet & Violet/151/074.ts
+++ b/data/Scarlet & Violet/151/074.ts
@@ -58,9 +58,14 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: "normal"
+		},
+		{
+			type: "reverse"
+		}
+	],
 
 	illustrator: "Uta",
 

--- a/data/Scarlet & Violet/151/075.ts
+++ b/data/Scarlet & Violet/151/075.ts
@@ -68,9 +68,14 @@ const card: Card = {
 	retreat: 3,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: "normal"
+		},
+		{
+			type: "reverse"
+		}
+	],
 
 	illustrator: "Uta",
 

--- a/data/Scarlet & Violet/151/077.ts
+++ b/data/Scarlet & Violet/151/077.ts
@@ -58,9 +58,14 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: "normal"
+		},
+		{
+			type: "reverse"
+		}
+	],
 
 	illustrator: "Nurikabe",
 

--- a/data/Scarlet & Violet/151/078.ts
+++ b/data/Scarlet & Violet/151/078.ts
@@ -75,9 +75,14 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: "normal"
+		},
+		{
+			type: "reverse"
+		}
+	],
 
 	illustrator: "Nurikabe",
 

--- a/data/Scarlet & Violet/151/079.ts
+++ b/data/Scarlet & Violet/151/079.ts
@@ -58,9 +58,14 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: "normal"
+		},
+		{
+			type: "reverse"
+		}
+	],
 
 	illustrator: "OKACHEKE",
 

--- a/data/Scarlet & Violet/151/080.ts
+++ b/data/Scarlet & Violet/151/080.ts
@@ -75,9 +75,14 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: "normal"
+		},
+		{
+			type: "reverse"
+		}
+	],
 
 	illustrator: "OKACHEKE",
 

--- a/data/Scarlet & Violet/151/081.ts
+++ b/data/Scarlet & Violet/151/081.ts
@@ -60,9 +60,14 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: "normal"
+		},
+		{
+			type: "reverse"
+		}
+	],
 
 	illustrator: "Yuka Morii",
 

--- a/data/Scarlet & Violet/151/082.ts
+++ b/data/Scarlet & Violet/151/082.ts
@@ -66,9 +66,14 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: "normal"
+		},
+		{
+			type: "reverse"
+		}
+	],
 
 	illustrator: "Yuka Morii",
 

--- a/data/Scarlet & Violet/151/083.ts
+++ b/data/Scarlet & Violet/151/083.ts
@@ -58,9 +58,14 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: "normal"
+		},
+		{
+			type: "reverse"
+		}
+	],
 
 	illustrator: "KG-2000",
 

--- a/data/Scarlet & Violet/151/084.ts
+++ b/data/Scarlet & Violet/151/084.ts
@@ -47,9 +47,14 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: "normal"
+		},
+		{
+			type: "reverse"
+		}
+	],
 
 	illustrator: "Anesaki Dynamic",
 

--- a/data/Scarlet & Violet/151/085.ts
+++ b/data/Scarlet & Violet/151/085.ts
@@ -77,9 +77,14 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		normal: false
-	},
+	variants: [
+		{
+			type: "holo"
+		},
+		{
+			type: "reverse"
+		}
+	],
 
 	illustrator: "Anesaki Dynamic",
 

--- a/data/Scarlet & Violet/151/086.ts
+++ b/data/Scarlet & Violet/151/086.ts
@@ -38,9 +38,14 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: "normal"
+		},
+		{
+			type: "reverse"
+		}
+	],
 
 	illustrator: "aoki",
 

--- a/data/Scarlet & Violet/151/087.ts
+++ b/data/Scarlet & Violet/151/087.ts
@@ -66,9 +66,14 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: "normal"
+		},
+		{
+			type: "reverse"
+		}
+	],
 
 	illustrator: "aoki",
 

--- a/data/Scarlet & Violet/151/088.ts
+++ b/data/Scarlet & Violet/151/088.ts
@@ -47,9 +47,14 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: "normal"
+		},
+		{
+			type: "reverse"
+		}
+	],
 
 	illustrator: "Nisota Niso",
 

--- a/data/Scarlet & Violet/151/089.ts
+++ b/data/Scarlet & Violet/151/089.ts
@@ -68,9 +68,14 @@ const card: Card = {
 	retreat: 4,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: "normal"
+		},
+		{
+			type: "reverse"
+		}
+	],
 
 	illustrator: "Nisota Niso",
 

--- a/data/Scarlet & Violet/151/090.ts
+++ b/data/Scarlet & Violet/151/090.ts
@@ -47,9 +47,14 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: "normal"
+		},
+		{
+			type: "reverse"
+		}
+	],
 
 	illustrator: "Nelnal",
 

--- a/data/Scarlet & Violet/151/091.ts
+++ b/data/Scarlet & Violet/151/091.ts
@@ -55,9 +55,14 @@ const card: Card = {
 	retreat: 3,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: "normal"
+		},
+		{
+			type: "reverse"
+		}
+	],
 
 	illustrator: "Nelnal",
 

--- a/data/Scarlet & Violet/151/092.ts
+++ b/data/Scarlet & Violet/151/092.ts
@@ -38,9 +38,14 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: "normal"
+		},
+		{
+			type: "reverse"
+		}
+	],
 
 	illustrator: "Tomokazu Komiya",
 

--- a/data/Scarlet & Violet/151/093.ts
+++ b/data/Scarlet & Violet/151/093.ts
@@ -68,9 +68,14 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: "normal"
+		},
+		{
+			type: "reverse"
+		}
+	],
 
 	illustrator: "Tomokazu Komiya",
 

--- a/data/Scarlet & Violet/151/094.ts
+++ b/data/Scarlet & Violet/151/094.ts
@@ -77,9 +77,14 @@ const card: Card = {
 	retreat: 0,
 	regulationMark: "G",
 
-	variants: {
-		normal: false
-	},
+	variants: [
+		{
+			type: "holo"
+		},
+		{
+			type: "reverse"
+		}
+	],
 
 	illustrator: "Tomokazu Komiya",
 

--- a/data/Scarlet & Violet/151/095.ts
+++ b/data/Scarlet & Violet/151/095.ts
@@ -60,9 +60,14 @@ const card: Card = {
 	retreat: 4,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: "normal"
+		},
+		{
+			type: "reverse"
+		}
+	],
 
 	illustrator: "Shin Nagasawa",
 

--- a/data/Scarlet & Violet/151/096.ts
+++ b/data/Scarlet & Violet/151/096.ts
@@ -38,9 +38,14 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: "normal"
+		},
+		{
+			type: "reverse"
+		}
+	],
 
 	illustrator: "Mousho",
 

--- a/data/Scarlet & Violet/151/097.ts
+++ b/data/Scarlet & Violet/151/097.ts
@@ -68,9 +68,14 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: "normal"
+		},
+		{
+			type: "reverse"
+		}
+	],
 
 	illustrator: "Mousho",
 

--- a/data/Scarlet & Violet/151/098.ts
+++ b/data/Scarlet & Violet/151/098.ts
@@ -58,9 +58,14 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: "normal"
+		},
+		{
+			type: "reverse"
+		}
+	],
 
 	illustrator: "Yukiko Baba",
 

--- a/data/Scarlet & Violet/151/099.ts
+++ b/data/Scarlet & Violet/151/099.ts
@@ -68,9 +68,14 @@ const card: Card = {
 	retreat: 3,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: "normal"
+		},
+		{
+			type: "reverse"
+		}
+	],
 
 	illustrator: "Yukiko Baba",
 

--- a/data/Scarlet & Violet/151/100.ts
+++ b/data/Scarlet & Violet/151/100.ts
@@ -47,9 +47,14 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: "normal"
+		},
+		{
+			type: "reverse"
+		}
+	],
 
 	illustrator: "nagimiso",
 

--- a/data/Scarlet & Violet/151/101.ts
+++ b/data/Scarlet & Violet/151/101.ts
@@ -68,9 +68,14 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		normal: false
-	},
+	variants: [
+		{
+			type: "holo"
+		},
+		{
+			type: "reverse"
+		}
+	],
 
 	illustrator: "nagimiso",
 

--- a/data/Scarlet & Violet/151/102.ts
+++ b/data/Scarlet & Violet/151/102.ts
@@ -47,9 +47,14 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: "normal"
+		},
+		{
+			type: "reverse"
+		}
+	],
 
 	illustrator: "Shigenori Negishi",
 

--- a/data/Scarlet & Violet/151/103.ts
+++ b/data/Scarlet & Violet/151/103.ts
@@ -68,9 +68,14 @@ const card: Card = {
 	retreat: 3,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: "normal"
+		},
+		{
+			type: "reverse"
+		}
+	],
 
 	illustrator: "Shigenori Negishi",
 

--- a/data/Scarlet & Violet/151/104.ts
+++ b/data/Scarlet & Violet/151/104.ts
@@ -69,9 +69,14 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: "normal"
+		},
+		{
+			type: "reverse"
+		}
+	],
 
 	illustrator: "Shinya Komatsu",
 

--- a/data/Scarlet & Violet/151/105.ts
+++ b/data/Scarlet & Violet/151/105.ts
@@ -77,9 +77,14 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "G",
 
-	variants: {
-		normal: false
-	},
+	variants: [
+		{
+			type: "holo"
+		},
+		{
+			type: "reverse"
+		}
+	],
 
 	illustrator: "Shinya Komatsu",
 

--- a/data/Scarlet & Violet/151/106.ts
+++ b/data/Scarlet & Violet/151/106.ts
@@ -58,9 +58,14 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: "normal"
+		},
+		{
+			type: "reverse"
+		}
+	],
 
 	illustrator: "Hitoshi Ariga",
 

--- a/data/Scarlet & Violet/151/107.ts
+++ b/data/Scarlet & Violet/151/107.ts
@@ -69,9 +69,14 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: "normal"
+		},
+		{
+			type: "reverse"
+		}
+	],
 
 	illustrator: "DOM",
 

--- a/data/Scarlet & Violet/151/108.ts
+++ b/data/Scarlet & Violet/151/108.ts
@@ -47,9 +47,14 @@ const card: Card = {
 	retreat: 4,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: "normal"
+		},
+		{
+			type: "reverse"
+		}
+	],
 
 	illustrator: "Saya Tsuruta",
 

--- a/data/Scarlet & Violet/151/109.ts
+++ b/data/Scarlet & Violet/151/109.ts
@@ -47,9 +47,14 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: "normal"
+		},
+		{
+			type: "reverse"
+		}
+	],
 
 	illustrator: "Shibuzoh.",
 

--- a/data/Scarlet & Violet/151/110.ts
+++ b/data/Scarlet & Violet/151/110.ts
@@ -77,9 +77,14 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "G",
 
-	variants: {
-		normal: false
-	},
+	variants: [
+		{
+			type: "holo"
+		},
+		{
+			type: "reverse"
+		}
+	],
 
 	illustrator: "Shibuzoh.",
 

--- a/data/Scarlet & Violet/151/111.ts
+++ b/data/Scarlet & Violet/151/111.ts
@@ -60,9 +60,14 @@ const card: Card = {
 	retreat: 3,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: "normal"
+		},
+		{
+			type: "reverse"
+		}
+	],
 
 	illustrator: "GOSSAN",
 

--- a/data/Scarlet & Violet/151/112.ts
+++ b/data/Scarlet & Violet/151/112.ts
@@ -68,9 +68,14 @@ const card: Card = {
 	retreat: 4,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: "normal"
+		},
+		{
+			type: "reverse"
+		}
+	],
 
 	illustrator: "GOSSAN",
 

--- a/data/Scarlet & Violet/151/113.ts
+++ b/data/Scarlet & Violet/151/113.ts
@@ -60,9 +60,14 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "G",
 
-	variants: {
-		normal: false
-	},
+	variants: [
+		{
+			type: "holo"
+		},
+		{
+			type: "reverse"
+		}
+	],
 
 	illustrator: "Taiga Kayama",
 

--- a/data/Scarlet & Violet/151/114.ts
+++ b/data/Scarlet & Violet/151/114.ts
@@ -47,9 +47,14 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: "normal"
+		},
+		{
+			type: "reverse"
+		}
+	],
 
 	illustrator: "Aya Kusube",
 

--- a/data/Scarlet & Violet/151/116.ts
+++ b/data/Scarlet & Violet/151/116.ts
@@ -51,9 +51,14 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: "normal"
+		},
+		{
+			type: "reverse"
+		}
+	],
 
 	illustrator: "aspara",
 

--- a/data/Scarlet & Violet/151/117.ts
+++ b/data/Scarlet & Violet/151/117.ts
@@ -55,9 +55,14 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: "normal"
+		},
+		{
+			type: "reverse"
+		}
+	],
 
 	illustrator: "aspara",
 

--- a/data/Scarlet & Violet/151/118.ts
+++ b/data/Scarlet & Violet/151/118.ts
@@ -60,9 +60,14 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: "normal"
+		},
+		{
+			type: "reverse"
+		}
+	],
 
 	illustrator: "SIE NANAHARA",
 

--- a/data/Scarlet & Violet/151/119.ts
+++ b/data/Scarlet & Violet/151/119.ts
@@ -77,9 +77,14 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: "normal"
+		},
+		{
+			type: "reverse"
+		}
+	],
 
 	illustrator: "SIE NANAHARA",
 

--- a/data/Scarlet & Violet/151/120.ts
+++ b/data/Scarlet & Violet/151/120.ts
@@ -47,9 +47,14 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: "normal"
+		},
+		{
+			type: "reverse"
+		}
+	],
 
 	illustrator: "Arai Kiriko",
 

--- a/data/Scarlet & Violet/151/121.ts
+++ b/data/Scarlet & Violet/151/121.ts
@@ -68,9 +68,14 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		normal: false
-	},
+	variants: [
+		{
+			type: "holo"
+		},
+		{
+			type: "reverse"
+		}
+	],
 
 	illustrator: "Arai Kiriko",
 

--- a/data/Scarlet & Violet/151/122.ts
+++ b/data/Scarlet & Violet/151/122.ts
@@ -67,9 +67,14 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		normal: false
-	},
+	variants: [
+		{
+			type: "holo"
+		},
+		{
+			type: "reverse"
+		}
+	],
 
 	illustrator: "OOYAMA",
 

--- a/data/Scarlet & Violet/151/123.ts
+++ b/data/Scarlet & Violet/151/123.ts
@@ -60,9 +60,14 @@ const card: Card = {
 	retreat: 0,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: "normal"
+		},
+		{
+			type: "reverse"
+		}
+	],
 
 	illustrator: "Hideki Ishikawa",
 

--- a/data/Scarlet & Violet/151/125.ts
+++ b/data/Scarlet & Violet/151/125.ts
@@ -60,9 +60,14 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: "normal"
+		},
+		{
+			type: "reverse"
+		}
+	],
 
 	illustrator: "NC Empire",
 

--- a/data/Scarlet & Violet/151/126.ts
+++ b/data/Scarlet & Violet/151/126.ts
@@ -60,9 +60,14 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: "normal"
+		},
+		{
+			type: "reverse"
+		}
+	],
 
 	illustrator: "Toshinao Aoki",
 

--- a/data/Scarlet & Violet/151/127.ts
+++ b/data/Scarlet & Violet/151/127.ts
@@ -60,9 +60,14 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: "normal"
+		},
+		{
+			type: "reverse"
+		}
+	],
 
 	illustrator: "Yuya Oka",
 

--- a/data/Scarlet & Violet/151/128.ts
+++ b/data/Scarlet & Violet/151/128.ts
@@ -67,9 +67,14 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: "normal"
+		},
+		{
+			type: "reverse"
+		}
+	],
 
 	illustrator: "Takeshi Nakamura",
 

--- a/data/Scarlet & Violet/151/129.ts
+++ b/data/Scarlet & Violet/151/129.ts
@@ -45,9 +45,14 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: "normal"
+		},
+		{
+			type: "reverse"
+		}
+	],
 
 	illustrator: "Kouki Saitou",
 

--- a/data/Scarlet & Violet/151/130.ts
+++ b/data/Scarlet & Violet/151/130.ts
@@ -77,9 +77,14 @@ const card: Card = {
 	retreat: 4,
 	regulationMark: "G",
 
-	variants: {
-		normal: false
-	},
+	variants: [
+		{
+			type: "holo"
+		},
+		{
+			type: "reverse"
+		}
+	],
 
 	illustrator: "Kouki Saitou",
 

--- a/data/Scarlet & Violet/151/131.ts
+++ b/data/Scarlet & Violet/151/131.ts
@@ -58,9 +58,14 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: "normal"
+		},
+		{
+			type: "reverse"
+		}
+	],
 
 	illustrator: "LINNE",
 

--- a/data/Scarlet & Violet/151/132.ts
+++ b/data/Scarlet & Violet/151/132.ts
@@ -60,9 +60,14 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		normal: false
-	},
+	variants: [
+		{
+			type: "holo"
+		},
+		{
+			type: "reverse"
+		}
+	],
 
 	illustrator: "KIYOTAKA OSHIYAMA",
 

--- a/data/Scarlet & Violet/151/133.ts
+++ b/data/Scarlet & Violet/151/133.ts
@@ -58,9 +58,14 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: "normal"
+		},
+		{
+			type: "reverse"
+		}
+	],
 
 	illustrator: "Narumi Sato",
 

--- a/data/Scarlet & Violet/151/134.ts
+++ b/data/Scarlet & Violet/151/134.ts
@@ -77,9 +77,14 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "G",
 
-	variants: {
-		normal: false
-	},
+	variants: [
+		{
+			type: "holo"
+		},
+		{
+			type: "reverse"
+		}
+	],
 
 	illustrator: "kirisAki",
 

--- a/data/Scarlet & Violet/151/135.ts
+++ b/data/Scarlet & Violet/151/135.ts
@@ -75,9 +75,14 @@ const card: Card = {
 	retreat: 0,
 	regulationMark: "G",
 
-	variants: {
-		normal: false
-	},
+	variants: [
+		{
+			type: "holo"
+		},
+		{
+			type: "reverse"
+		}
+	],
 
 	illustrator: "sui",
 

--- a/data/Scarlet & Violet/151/136.ts
+++ b/data/Scarlet & Violet/151/136.ts
@@ -77,9 +77,14 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "G",
 
-	variants: {
-		normal: false
-	},
+	variants: [
+		{
+			type: "holo"
+		},
+		{
+			type: "reverse"
+		}
+	],
 
 	illustrator: "Ryota Murayama",
 

--- a/data/Scarlet & Violet/151/137.ts
+++ b/data/Scarlet & Violet/151/137.ts
@@ -45,9 +45,14 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: "normal"
+		},
+		{
+			type: "reverse"
+		}
+	],
 
 	illustrator: "5ban Graphics",
 

--- a/data/Scarlet & Violet/151/138.ts
+++ b/data/Scarlet & Violet/151/138.ts
@@ -55,9 +55,14 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: "normal"
+		},
+		{
+			type: "reverse"
+		}
+	],
 
 	illustrator: "Akira Komayama",
 

--- a/data/Scarlet & Violet/151/139.ts
+++ b/data/Scarlet & Violet/151/139.ts
@@ -77,9 +77,14 @@ const card: Card = {
 	retreat: 3,
 	regulationMark: "G",
 
-	variants: {
-		normal: false
-	},
+	variants: [
+		{
+			type: "holo"
+		},
+		{
+			type: "reverse"
+		}
+	],
 
 	illustrator: "Akira Komayama",
 

--- a/data/Scarlet & Violet/151/140.ts
+++ b/data/Scarlet & Violet/151/140.ts
@@ -55,9 +55,14 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: "normal"
+		},
+		{
+			type: "reverse"
+		}
+	],
 
 	illustrator: "Souichirou Gunjima",
 

--- a/data/Scarlet & Violet/151/141.ts
+++ b/data/Scarlet & Violet/151/141.ts
@@ -77,9 +77,14 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "G",
 
-	variants: {
-		normal: false
-	},
+	variants: [
+		{
+			type: "holo"
+		},
+		{
+			type: "reverse"
+		}
+	],
 
 	illustrator: "Souichirou Gunjima",
 

--- a/data/Scarlet & Violet/151/142.ts
+++ b/data/Scarlet & Violet/151/142.ts
@@ -68,9 +68,14 @@ const card: Card = {
 	retreat: 0,
 	regulationMark: "G",
 
-	variants: {
-		normal: false
-	},
+	variants: [
+		{
+			type: "holo"
+		},
+		{
+			type: "reverse"
+		}
+	],
 
 	illustrator: "Shinji Kanda",
 

--- a/data/Scarlet & Violet/151/143.ts
+++ b/data/Scarlet & Violet/151/143.ts
@@ -69,9 +69,14 @@ const card: Card = {
 	retreat: 4,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: "normal"
+		},
+		{
+			type: "reverse"
+		}
+	],
 
 	illustrator: "HYOGONOSUKE",
 

--- a/data/Scarlet & Violet/151/144.ts
+++ b/data/Scarlet & Violet/151/144.ts
@@ -69,9 +69,14 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "G",
 
-	variants: {
-		normal: false
-	},
+	variants: [
+		{
+			type: "holo"
+		},
+		{
+			type: "reverse"
+		}
+	],
 
 	illustrator: "chibi",
 

--- a/data/Scarlet & Violet/151/146.ts
+++ b/data/Scarlet & Violet/151/146.ts
@@ -67,10 +67,14 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "G",
 
-	variants: {
-		reverse: false,
-		normal: false
-	},
+	variants: [
+		{
+			type: "holo"
+		},
+		{
+			type: "reverse"
+		}
+	],
 
 	illustrator: "KEIICHIRO ITO",
 

--- a/data/Scarlet & Violet/151/147.ts
+++ b/data/Scarlet & Violet/151/147.ts
@@ -51,9 +51,14 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: "normal"
+		},
+		{
+			type: "reverse"
+		}
+	],
 
 	illustrator: "Sanosuke Sakuma",
 

--- a/data/Scarlet & Violet/151/148.ts
+++ b/data/Scarlet & Violet/151/148.ts
@@ -68,9 +68,14 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: "normal"
+		},
+		{
+			type: "reverse"
+		}
+	],
 
 	illustrator: "Sanosuke Sakuma",
 

--- a/data/Scarlet & Violet/151/149.ts
+++ b/data/Scarlet & Violet/151/149.ts
@@ -77,9 +77,14 @@ const card: Card = {
 	retreat: 3,
 	regulationMark: "G",
 
-	variants: {
-		normal: false
-	},
+	variants: [
+		{
+			type: "holo"
+		},
+		{
+			type: "reverse"
+		}
+	],
 
 	illustrator: "Sanosuke Sakuma",
 

--- a/data/Scarlet & Violet/151/150.ts
+++ b/data/Scarlet & Violet/151/150.ts
@@ -69,9 +69,14 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "G",
 
-	variants: {
-		normal: false
-	},
+	variants: [
+		{
+			type: "holo"
+		},
+		{
+			type: "reverse"
+		}
+	],
 
 	illustrator: "AKIRA EGAWA",
 

--- a/data/Scarlet & Violet/151/152.ts
+++ b/data/Scarlet & Violet/151/152.ts
@@ -59,9 +59,14 @@ const card: Card = {
 		}
 	}],
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: "normal"
+		},
+		{
+			type: "reverse"
+		}
+	],
 
 	illustrator: "AYUMI ODASHIMA",
 

--- a/data/Scarlet & Violet/151/153.ts
+++ b/data/Scarlet & Violet/151/153.ts
@@ -59,9 +59,14 @@ const card: Card = {
 		}
 	}],
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: "normal"
+		},
+		{
+			type: "reverse"
+		}
+	],
 
 	illustrator: "AYUMI ODASHIMA",
 

--- a/data/Scarlet & Violet/151/154.ts
+++ b/data/Scarlet & Violet/151/154.ts
@@ -59,9 +59,14 @@ const card: Card = {
 		}
 	}],
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: "normal"
+		},
+		{
+			type: "reverse"
+		}
+	],
 
 	illustrator: "AYUMI ODASHIMA",
 

--- a/data/Scarlet & Violet/151/155.ts
+++ b/data/Scarlet & Violet/151/155.ts
@@ -28,9 +28,14 @@ const card: Card = {
 	trainerType: "Tool",
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: "normal"
+		},
+		{
+			type: "reverse"
+		}
+	],
 
 	illustrator: "Toyste Beach",
 

--- a/data/Scarlet & Violet/151/156.ts
+++ b/data/Scarlet & Violet/151/156.ts
@@ -28,9 +28,14 @@ const card: Card = {
 	trainerType: "Supporter",
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: "normal"
+		},
+		{
+			type: "reverse"
+		}
+	],
 
 	illustrator: "GIDORA",
 

--- a/data/Scarlet & Violet/151/157.ts
+++ b/data/Scarlet & Violet/151/157.ts
@@ -28,9 +28,14 @@ const card: Card = {
 	trainerType: "Stadium",
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: "normal"
+		},
+		{
+			type: "reverse"
+		}
+	],
 
 	illustrator: "Oswaldo KATO",
 

--- a/data/Scarlet & Violet/151/158.ts
+++ b/data/Scarlet & Violet/151/158.ts
@@ -28,9 +28,14 @@ const card: Card = {
 	trainerType: "Supporter",
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: "normal"
+		},
+		{
+			type: "reverse"
+		}
+	],
 
 	illustrator: "Tomomi Kaneko",
 

--- a/data/Scarlet & Violet/151/159.ts
+++ b/data/Scarlet & Violet/151/159.ts
@@ -28,9 +28,14 @@ const card: Card = {
 	trainerType: "Item",
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: "normal"
+		},
+		{
+			type: "reverse"
+		}
+	],
 
 	illustrator: "Ayaka Yoshida",
 

--- a/data/Scarlet & Violet/151/160.ts
+++ b/data/Scarlet & Violet/151/160.ts
@@ -28,9 +28,14 @@ const card: Card = {
 	trainerType: "Supporter",
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: "normal"
+		},
+		{
+			type: "reverse"
+		}
+	],
 
 	illustrator: "saino misaki",
 

--- a/data/Scarlet & Violet/151/161.ts
+++ b/data/Scarlet & Violet/151/161.ts
@@ -28,9 +28,14 @@ const card: Card = {
 	trainerType: "Supporter",
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: "normal"
+		},
+		{
+			type: "reverse"
+		}
+	],
 
 	illustrator: "hncl",
 

--- a/data/Scarlet & Violet/151/162.ts
+++ b/data/Scarlet & Violet/151/162.ts
@@ -28,9 +28,14 @@ const card: Card = {
 	trainerType: "Item",
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: "normal"
+		},
+		{
+			type: "reverse"
+		}
+	],
 
 	illustrator: "inose yukie",
 

--- a/data/Scarlet & Violet/151/163.ts
+++ b/data/Scarlet & Violet/151/163.ts
@@ -28,9 +28,14 @@ const card: Card = {
 	trainerType: "Tool",
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: "normal"
+		},
+		{
+			type: "reverse"
+		}
+	],
 
 	illustrator: "Studio Bora Inc.",
 

--- a/data/Scarlet & Violet/151/164.ts
+++ b/data/Scarlet & Violet/151/164.ts
@@ -28,9 +28,14 @@ const card: Card = {
 	trainerType: "Tool",
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: "normal"
+		},
+		{
+			type: "reverse"
+		}
+	],
 
 	illustrator: "Toyste Beach",
 

--- a/data/Scarlet & Violet/151/165.ts
+++ b/data/Scarlet & Violet/151/165.ts
@@ -28,9 +28,14 @@ const card: Card = {
 	trainerType: "Tool",
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: "normal"
+		},
+		{
+			type: "reverse"
+		}
+	],
 
 	illustrator: "Toyste Beach",
 


### PR DESCRIPTION
Common, Uncommon and Rare cards in the Scarlet & Violet 151 set all have a Reverse Holofoil print available (visible on Cardmarket, TCGplayer, and Bulbapedia) but the source files only declared the variants they explicitly disabled. The API thus returned `reverse: false` for all 153 cards in scope, hiding the existence of these prints to consumers.

This commit makes the variants explicit:
- Common (66 cards): { normal: true, reverse: true }
- Uncommon (62 cards): { normal: true, reverse: true }
- Rare (25 cards): { normal: false, holo: true, reverse: true } (Rares in SV-era are holo by default, no non-holo print exists)

Other rarities (Ultra/Double/Illustration/Special illustration/Hyper) left untouched, since they only have their special print.


## Details

151 cards have their reverse variant.
