### PR TITLE
Fix Double Crisis energy symbols

### DIFF
--- a/data/XY/Double Crisis/14.ts
+++ b/data/XY/Double Crisis/14.ts
@@ -43,9 +43,9 @@ const card: Card = {
 				pt: "Pisoteada de Pedra",
 			},
 			effect: {
-				en: "Discard as many Fighting Energy attached to your Pokémon as you like. This attack does 40 damage times the amount of Fighting Energy you discarded.",
-				fr: "Défaussez autant d'Énergies Fighting attachées à vos Pokémon que vous voulez. Cette attaque inflige 40 dégâts multipliés par le nombre de cartes Énergie Fighting que vous avez défaussées.",
-				pt: "Descarte tantas Energias de luta ligadas a seus Pokémon quanto desejar. Esse ataque causa 40 de danos vezes a quantidade de Energia de luta descartada.",
+				en: "Discard as many {F} Energy attached to your Pokémon as you like. This attack does 40 damage times the amount of {F} Energy you discarded.",
+				fr: "Défaussez autant d'Énergies {F} attachées à vos Pokémon que vous voulez. Cette attaque inflige 40 dégâts multipliés par le nombre de cartes Énergie {F} que vous avez défaussées.",
+				pt: "Descarte tantas Energias {F} ligadas a seus Pokémon quanto desejar. Esse ataque causa 40 de danos vezes a quantidade de Energia {F} descartada.",
 			},
 			damage: "40×",
 

--- a/data/XY/Double Crisis/2.ts
+++ b/data/XY/Double Crisis/2.ts
@@ -40,9 +40,9 @@ const card: Card = {
 				pt: "Brisa Ardente",
 			},
 			effect: {
-				en: "Once during your turn (before your attack), you may attach a Fighting or Fire Energy card from your discard pile to this Pokémon.",
-				fr: "Une seule fois pendant votre tour (avant votre attaque), vous pouvez attacher une carte Énergie Fighting ou Fire de votre pile de défausse à ce Pokémon.",
-				pt: "Uma vez durante sua vez de jogar (antes de atacar), você poderá ligar um card de Energia de Luta ou Fogo da sua pilha de descarte a este Pokémon",
+				en: "Once during your turn (before your attack), you may attach a {F} or {R} Energy card from your discard pile to this Pokémon.",
+				fr: "Une seule fois pendant votre tour (avant votre attaque), vous pouvez attacher une carte Énergie {F} ou {R} de votre pile de défausse à ce Pokémon.",
+				pt: "Uma vez durante sua vez de jogar (antes de atacar), você poderá ligar um card de Energia {F} ou {R} da sua pilha de descarte a este Pokémon.",
 			},
 		},
 	],

--- a/data/XY/Double Crisis/27.ts
+++ b/data/XY/Double Crisis/27.ts
@@ -14,9 +14,9 @@ const card: Card = {
 	set: Set,
 
 	effect: {
-		fr: "Cherchez un Pokémon de base de la Team Aqua et une carte Énergie Water de base dans votre deck, montrez-les, puis ajoutez-les à votre main. Mélangez ensuite votre deck.",
-		en: "Search your deck for a Basic Team Aqua Pokémon and a basic Water Energy card, reveal them, and put them into your hand. Shuffle your deck afterward.",
-		pt: "Procure no seu baralho um Pokémon da Equipe Aqua Básico e um card de Energia de Água básica, revele-os e coloque-os em sua mão. Em seguida, embaralhe seus cards.",
+		fr: "Cherchez un Pokémon de base de la Team Aqua et une carte Énergie {W} de base dans votre deck, montrez-les, puis ajoutez-les à votre main. Mélangez ensuite votre deck.",
+		en: "Search your deck for a Basic Team Aqua Pokémon and a basic {W} Energy card, reveal them, and put them into your hand. Shuffle your deck afterward.",
+		pt: "Procure no seu baralho um Pokémon da Equipe Aqua Básico e um card de Energia {W} básica, revele-os e coloque-os em sua mão. Em seguida, embaralhe seus cards.",
 	},
 
 	trainerType: "Item",

--- a/data/XY/Double Crisis/28.ts
+++ b/data/XY/Double Crisis/28.ts
@@ -14,9 +14,9 @@ const card: Card = {
 	set: Set,
 
 	effect: {
-		fr: "Le Coût de Retraite de chaque Pokémon en jeu (à part les Pokémon de la Team Aqua) est augmenté de Colorless.",
-		en: "The Retreat Cost of each Pokémon in play (except for Team Aqua Pokémon) is Colorless more.",
-		pt: "O Custo para Recuar de cada um dos Pokémon em jogo (exceto os Pokémon da Equipe Aqua) será de Incolor a mais.",
+		fr: "Le Coût de Retraite de chaque Pokémon en jeu (à part les Pokémon de la Team Aqua) est augmenté de {C}.",
+		en: "The Retreat Cost of each Pokémon in play (except for Team Aqua Pokémon) is {C} more.",
+		pt: "O Custo para Recuar de cada um dos Pokémon em jogo (exceto os Pokémon da Equipe Aqua) será de {C} a mais.",
 	},
 
 	trainerType: "Stadium",

--- a/data/XY/Double Crisis/31.ts
+++ b/data/XY/Double Crisis/31.ts
@@ -14,9 +14,9 @@ const card: Card = {
 	set: Set,
 
 	effect: {
-		fr: "Cherchez un Pokémon de base de la Team Magma et une carte Énergie Fighting de base dans votre deck, montrez-les, puis ajoutez-les à votre main. Mélangez ensuite votre deck.",
-		en: "Search your deck for a Basic Team Magma Pokémon and a basic Fighting Energy card, reveal them, and put them into your hand. Shuffle your deck afterward.",
-		pt: "Procure no seu baralho um Pokémon da Equipe Magma Básico e um card de Energia de luta básica, revele-os e coloque-os em sua mão. Em seguida, embaralhe seus cards.",
+		fr: "Cherchez un Pokémon de base de la Team Magma et une carte Énergie {F} de base dans votre deck, montrez-les, puis ajoutez-les à votre main. Mélangez ensuite votre deck.",
+		en: "Search your deck for a Basic Team Magma Pokémon and a basic {F} Energy card, reveal them, and put them into your hand. Shuffle your deck afterward.",
+		pt: "Procure no seu baralho um Pokémon da Equipe Magma Básico e um card de Energia {F} básica, revele-os e coloque-os em sua mão. Em seguida, embaralhe seus cards.",
 	},
 
 	trainerType: "Item",

--- a/data/XY/Double Crisis/33.ts
+++ b/data/XY/Double Crisis/33.ts
@@ -14,9 +14,9 @@ const card: Card = {
 	set: Set,
 
 	effect: {
-		fr: "Cette carte ne peut être attachée qu'à un Pokémon de la Team Aqua. Défaussez cette carte à la fin du tour pendant lequel vous l'avez attachée.\n\nCette carte ne fournit de l'Énergie WaterWater que pendant qu'elle est attachée à un Pokémon de la Team Aqua.\n\n(Si cette carte est attachée à autre chose qu'un Pokémon de la Team Aqua, défaussez cette carte.)",
-		en: "This card can only be attached to Team Aqua Pokémon. Discard this card at the end of the turn you attached it.\n\nThis card provides WaterWater Energy only while it is attached to a Team Aqua Pokémon.\n\n(If this card is attached to anything other than a Team Aqua Pokémon, discard this card.)",
-		pt: "Este card só pode ser ligado a Pokémon da Equipe Aqua. Descarte-o no final da rodada em que foi ligado. \n\nEste card fornece 2 Energias de Água somente quando está ligado a um Pokémon da Equipe Aqua. \n\n(Se este card estiver ligado a qualquer coisa diferente de um Pokémon da Equipe Aqua, descarte-o.)",
+		fr: "Cette carte ne peut être attachée qu'à un Pokémon de la Team Aqua. Défaussez cette carte à la fin du tour pendant lequel vous l'avez attachée.\n\nCette carte ne fournit de l'Énergie {W}{W} que pendant qu'elle est attachée à un Pokémon de la Team Aqua.\n\n(Si cette carte est attachée à autre chose qu'un Pokémon de la Team Aqua, défaussez cette carte.)",
+		en: "This card can only be attached to Team Aqua Pokémon. Discard this card at the end of the turn you attached it.\n\nThis card provides {W}{W} Energy only while it is attached to a Team Aqua Pokémon.\n\n(If this card is attached to anything other than a Team Aqua Pokémon, discard this card.)",
+		pt: "Este card só pode ser ligado a Pokémon da Equipe Aqua. Descarte-o no final da rodada em que foi ligado. \n\nEste card fornece Energia {W}{W} somente quando está ligado a um Pokémon da Equipe Aqua. \n\n(Se este card estiver ligado a qualquer coisa diferente de um Pokémon da Equipe Aqua, descarte-o.)",
 	},
 
 	energyType: "Special",

--- a/data/XY/Double Crisis/34.ts
+++ b/data/XY/Double Crisis/34.ts
@@ -14,9 +14,9 @@ const card: Card = {
 	set: Set,
 
 	effect: {
-		fr: "Cette carte ne peut être attachée qu'à un Pokémon de la Team Magma. Défaussez cette carte à la fin du tour pendant lequel vous l'avez attachée.\n\nCette carte ne fournit de l'Énergie FightingFighting que pendant qu'elle est attachée à un Pokémon de la Team Magma.\n\n(Si cette carte est attachée à autre chose qu'un Pokémon de la Team Magma, défaussez cette carte.)",
-		en: "This card can only be attached to Team Magma Pokémon. Discard this card at the end of the turn you attached it.\n\nThis card provides FightingFighting Energy only while it is attached to a Team Magma Pokémon.\n\n(If this card is attached to anything other than a Team Magma Pokémon, discard this card.)",
-		pt: "Este card só pode ser ligado a Pokémon da Equipe Magma. Descarte-o no final da rodada em que foi ligado. \n\nEste card fornece 2 Energias de luta somente quando está ligado a um Pokémon da Equipe Magma. \n\n(Se este card estiver ligado a qualquer coisa diferente de um Pokémon da Equipe Magma, descarte-o.)",
+		fr: "Cette carte ne peut être attachée qu'à un Pokémon de la Team Magma. Défaussez cette carte à la fin du tour pendant lequel vous l'avez attachée.\n\nCette carte ne fournit de l'Énergie {F}{F} que pendant qu'elle est attachée à un Pokémon de la Team Magma.\n\n(Si cette carte est attachée à autre chose qu'un Pokémon de la Team Magma, défaussez cette carte.)",
+		en: "This card can only be attached to Team Magma Pokémon. Discard this card at the end of the turn you attached it.\n\nThis card provides {F}{F} Energy only while it is attached to a Team Magma Pokémon.\n\n(If this card is attached to anything other than a Team Magma Pokémon, discard this card.)",
+		pt: "Este card só pode ser ligado a Pokémon da Equipe Magma. Descarte-o no final da rodada em que foi ligado. \n\nEste card fornece Energia {F}{F} somente quando está ligado a um Pokémon da Equipe Magma. \n\n(Se este card estiver ligado a qualquer coisa diferente de um Pokémon da Equipe Magma, descarte-o.)",
 	},
 
 	energyType: "Special",

--- a/data/XY/Double Crisis/5.ts
+++ b/data/XY/Double Crisis/5.ts
@@ -62,9 +62,9 @@ const card: Card = {
 				pt: "Nevasca Dupla",
 			},
 			effect: {
-				en: "Discard 2 Water Energy attached to this Pokémon. This attack does 80 damage to 2 of your opponent's Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)",
-				fr: "Défaussez 2 Énergies Water attachées à ce Pokémon. Cette attaque inflige 80 dégâts à 2 des Pokémon de votre adversaire. (N'appliquez ni la Faiblesse ni la Résistance aux Pokémon de Banc.)",
-				pt: "Descarte 2 Energias de Água ligadas a este Pokémon. Este ataque causa 80 de danos a 2 dos Pokémon de seu oponente. (Não aplique Fraqueza ou Resistência a Pokémon no Banco.)",
+				en: "Discard 2 {W} Energy attached to this Pokémon. This attack does 80 damage to 2 of your opponent's Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)",
+				fr: "Défaussez 2 Énergies {W} attachées à ce Pokémon. Cette attaque inflige 80 dégâts à 2 des Pokémon de votre adversaire. (N'appliquez ni la Faiblesse ni la Résistance aux Pokémon de Banc.)",
+				pt: "Descarte 2 Energias {W} ligadas a este Pokémon. Este ataque causa 80 de danos a 2 dos Pokémon de seu oponente. (Não aplique Fraqueza ou Resistência a Pokémon no Banco.)",
 			},
 
 		},

--- a/data/XY/Double Crisis/6.ts
+++ b/data/XY/Double Crisis/6.ts
@@ -55,9 +55,9 @@ const card: Card = {
 				pt: "Impacto Aqua",
 			},
 			effect: {
-				en: "This attack does 20 more damage for each Colorless in your opponent's Active Pokémon's Retreat Cost.",
-				fr: "Cette attaque inflige 20 dégâts supplémentaires pour chaque Colorless dans le Coût de Retraite du Pokémon Actif de votre adversaire.",
-				pt: "Esse ataque causa 20 de danos adicionais para cada Incolor no Custo para Recuar do Pokémon Ativo do seu oponente."
+				en: "This attack does 20 more damage for each {C} in your opponent's Active Pokémon's Retreat Cost.",
+				fr: "Cette attaque inflige 20 dégâts supplémentaires pour chaque {C} dans le Coût de Retraite du Pokémon Actif de votre adversaire.",
+				pt: "Esse ataque causa 20 de danos adicionais para cada {C} no Custo para Recuar do Pokémon Ativo do seu oponente."
 			},
 			damage: "80＋",
 

--- a/data/XY/Double Crisis/8.ts
+++ b/data/XY/Double Crisis/8.ts
@@ -40,9 +40,9 @@ const card: Card = {
 				pt: "Festival de Lodo"
 			},
 			effect: {
-				en: "The Retreat Cost of each Pokémon in play (except for Team Aqua Pokémon) is Colorless more.",
-				fr: "Le Coût de Retraite de chaque Pokémon en jeu (à part les Pokémon de la Team Aqua) est augmenté de Colorless.",
-				pt: "O Custo para Recuar de cada um dos Pokémon em jogo (exceto os Pokémon da Equipe Aqua) será de Incolor a mais",
+				en: "The Retreat Cost of each Pokémon in play (except for Team Aqua Pokémon) is {C} more.",
+				fr: "Le Coût de Retraite de chaque Pokémon en jeu (à part les Pokémon de la Team Aqua) est augmenté de {C}.",
+				pt: "O Custo para Recuar de cada um dos Pokémon em jogo (exceto os Pokémon da Equipe Aqua) será de {C} a mais.",
 			},
 		},
 	],


### PR DESCRIPTION
## Changes

Updated Double Crisis card texts to use standardized energy symbols in ability/effect descriptions.

## Details

Replaced written-out energy names such as `Fighting`, `Fire`, and `Colorless` with their symbol format equivalents like `{F}`, `{R}`, and `{C}` across affected Double Crisis cards.

Also adjusted punctuation in Portuguese text where needed for consistency.
