### PR TITLE
Add missing SM Black Star Promos

### DIFF
--- a/data/Sun & Moon/SM Black Star Promos.ts
+++ b/data/Sun & Moon/SM Black Star Promos.ts
@@ -16,7 +16,7 @@ const smp: Set = {
 	tcgOnline: "PR-SM",
 
 	cardCount: {
-		official: 236
+		official: 248
 	},
 
 	releaseDate: "2017-02-03",

--- a/data/Sun & Moon/SM Black Star Promos/SM245.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM245.ts
@@ -86,9 +86,14 @@ const card: Card = {
 
 	retreat: 1,
 
-	thirdParty: {
-		tcgplayer: 245874
-	}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 245874
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sun & Moon/SM Black Star Promos/SM245.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM245.ts
@@ -1,0 +1,94 @@
+import { Card } from '../../../interfaces'
+import Set from '../SM Black Star Promos'
+
+const card: Card = {
+	dexId: [429],
+	set: Set,
+
+	name: {
+		en: "Mismagius",
+		fr: "Magirêve",
+		es: "Mismagius",
+		it: "Mismagius",
+		pt: "Mismagius",
+		de: "Traunmagil"
+	},
+
+	illustrator: "NC Empire",
+	rarity: "Rare",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Psychic"],
+
+	evolveFrom: {
+		en: "Misdreavus",
+		fr: "Feuforêve",
+		es: "Misdreavus",
+		it: "Misdreavus",
+		pt: "Misdreavus",
+		de: "Traunfugil"
+	},
+	stage: "Stage1",
+
+	attacks: [{
+		name: {
+			en: "Psybeam",
+			fr: "Rafale Psy",
+			es: "Psicorrayo",
+			it: "Psicoraggio",
+			pt: "Feixe Psíquico",
+			de: "Psystrahl"
+		},
+
+		damage: 20,
+
+		effect: {
+			en: "Your opponent's Active Pokémon is now Confused.",
+			fr: "Le Pokémon Actif de votre adversaire est maintenant Confus.",
+			es: "El Pokémon Activo de tu rival pasa a estar Confundido.",
+			it: "Il Pokémon attivo del tuo avversario viene confuso.",
+			pt: "O Pokémon Ativo do seu oponente agora está Confuso.",
+			de: "Das Aktive Pokémon deines Gegners ist jetzt verwirrt."
+		},
+
+		cost: ["Psychic"]
+	}, {
+		name: {
+			en: "Nohahex",
+			fr: "Nohahex",
+			es: "Nohahex",
+			it: "Nohahex",
+			pt: "Nohahex",
+			de: "Nohahex"
+		},
+
+		effect: {
+			en: "If your opponent's Active Pokémon has exactly 9 damage counters on it, that Pokémon is Knocked Out.",
+			fr: "Si le Pokémon Actif de votre adversaire a exactement 9 marqueurs de dégâts sur lui, ce Pokémon est mis K.O.",
+			es: "Si el Pokémon Activo de tu rival tiene exactamente 9 contadores de daño sobre él, ese Pokémon queda Fuera de Combate.",
+			it: "Se il Pokémon attivo del tuo avversario ha esattamente 9 segnalini danno, quel Pokémon viene messo KO.",
+			pt: "Se o Pokémon Ativo do seu oponente tiver exatamente 9 contadores de dano nele, aquele Pokémon será Nocauteado.",
+			de: "Wenn auf dem Aktiven Pokémon deines Gegners genau 9 Schadensmarken liegen, ist jenes Pokémon kampfunfähig."
+		},
+
+		cost: ["Psychic", "Colorless"]
+	}],
+
+	weaknesses: [{
+		type: "Darkness",
+		value: "×2"
+	}],
+
+	resistances: [{
+		type: "Fighting",
+		value: "-20"
+	}],
+
+	retreat: 1,
+
+	thirdParty: {
+		tcgplayer: 245874
+	}
+}
+
+export default card

--- a/data/Sun & Moon/SM Black Star Promos/SM246.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM246.ts
@@ -1,0 +1,36 @@
+import { Card } from '../../../interfaces'
+import Set from '../SM Black Star Promos'
+
+const card: Card = {
+	name: {
+		en: "Sabrina & Brycen",
+		fr: "Morgane et Zhu",
+		es: "Sabrina y Junco",
+		it: "Sabrina e Silvestro",
+		pt: "Sabrina e Brycen",
+		de: "Sabrina & Sandro"
+	},
+
+	illustrator: "Ryuta Fuse",
+	rarity: "Uncommon",
+	category: "Trainer",
+
+	set: Set,
+
+	effect: {
+		en: "Search your deck for up to 2 basic Energy cards, reveal them, and put them into your hand. Then, shuffle your deck.\n\nWhen you play this card, you may discard 5 other cards from your hand. If you do, you may also search for up to 3 Pokémon of different types in this way.",
+		fr: "Cherchez dans votre deck jusqu'à 2 cartes Énergie de base, montrez-les, puis ajoutez-les à votre main. Mélangez ensuite votre deck.\n\nLorsque vous jouez cette carte, vous pouvez défausser 5 autres cartes de votre main. Dans ce cas, vous pouvez aussi chercher jusqu'à 3 Pokémon de types différents de cette façon.",
+		es: "Busca en tu baraja hasta 2 cartas de Energía Básica, enséñalas y ponlas en tu mano. Después, baraja las cartas de tu baraja.\n\nCuando juegues esta carta, puedes descartar otras 5 cartas de tu mano. Si lo haces, también puedes buscar hasta 3 Pokémon de diferentes tipos de esta manera.",
+		it: "Cerca nel tuo mazzo fino a 2 carte Energia base, mostrale e aggiungile alle carte che hai in mano. Poi rimischia le carte del tuo mazzo.\n\nQuando giochi questa carta, puoi scartare altre 5 carte che hai in mano. Se lo fai, puoi anche cercare fino a 3 Pokémon di tipi diversi in questo modo.",
+		pt: "Procure por até 2 cartas de Energia básica no seu baralho, revele-as e coloque-as na sua mão. Em seguida, embaralhe o seu baralho.\n\nQuando você jogar este card, você poderá descartar 5 outras cartas da sua mão. Se fizer isto, você também poderá procurar por até 3 Pokémon de tipos diferentes desta forma.",
+		de: "Durchsuche dein Deck nach bis zu 2 Basis-Energiekarten, zeige sie deinem Gegner und nimm sie auf deine Hand. Mische anschließend dein Deck.\n\nWenn du diese Karte spielst, kannst du 5 andere Karten aus deiner Hand auf deinen Ablagestapel legen. Wenn du das machst, kannst du auf diese Weise auch nach bis zu 3 Pokémon unterschiedlichen Typs suchen."
+	},
+
+	trainerType: "Supporter",
+
+	thirdParty: {
+		tcgplayer: 245873
+	}
+}
+
+export default card

--- a/data/Sun & Moon/SM Black Star Promos/SM246.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM246.ts
@@ -28,9 +28,14 @@ const card: Card = {
 
 	trainerType: "Supporter",
 
-	thirdParty: {
-		tcgplayer: 245873
-	}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 245873
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sun & Moon/SM Black Star Promos/SM247.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM247.ts
@@ -113,9 +113,14 @@ const card: Card = {
 
 	retreat: 3,
 
-	thirdParty: {
-		tcgplayer: 253394
-	}
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				tcgplayer: 253394
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sun & Moon/SM Black Star Promos/SM247.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM247.ts
@@ -1,0 +1,121 @@
+import { Card } from '../../../interfaces'
+import Set from '../SM Black Star Promos'
+
+const card: Card = {
+	name: {
+		en: "Reshiram & Charizard GX",
+		fr: "Reshiram et Dracaufeu GX",
+		es: "Reshiram y Charizard GX",
+		it: "Reshiram e Charizard GX",
+		pt: "Reshiram e Charizard GX",
+		de: "Reshiram & Glurak GX"
+	},
+	illustrator: "aky CG Works",
+	rarity: "Ultra Rare",
+	category: "Pokemon",
+
+	set: Set,
+	dexId: [
+		6,
+		643
+	],
+	hp: 270,
+	types: [
+		"Fire",
+	],
+
+	stage: "Basic",
+	suffix: "TAG TEAM-GX",
+
+	attacks: [
+		{
+			cost: [
+				"Fire",
+				"Colorless",
+			],
+			name: {
+				en: "Outrage",
+				fr: "Colère",
+				es: "Enfado",
+				it: "Oltraggio",
+				pt: "Ultraje",
+				de: "Wutanfall"
+			},
+			effect: {
+				en: "This attack does 10 more damage for each damage counter on this Pokémon.",
+				fr: "Cette attaque inflige 10 dégâts supplémentaires pour chaque marqueur de dégâts placé sur ce Pokémon.",
+				es: "Este ataque hace 10 puntos de daño más por cada contador de daño en este Pokémon.",
+				it: "Questo attacco infligge 10 danni in più per ogni segnalino danno presente su questo Pokémon.",
+				pt: "Este ataque causa 10 pontos de dano a mais para cada contador de dano neste Pokémon.",
+				de: "Diese Attacke fügt 10 Schadenspunkte mehr mal der Anzahl der Schadensmarken auf diesem Pokémon zu."
+			},
+			damage: "30+",
+
+		},
+		{
+			cost: [
+				"Fire",
+				"Fire",
+				"Fire",
+				"Colorless",
+			],
+			name: {
+				en: "Flare Strike",
+				fr: "Attaque Flamboyante",
+				es: "Impacto Ígneo",
+				it: "Colpo Fiammante",
+				pt: "Golpe de Chamas",
+				de: "Feuergeschoss"
+			},
+			effect: {
+				en: "This Pokémon can't use Flare Strike during your next turn.",
+				fr: "Ce Pokémon ne peut pas utiliser Attaque Flamboyante pendant votre prochain tour.",
+				es: "Este Pokémon no puede usar Impacto Ígneo durante tu próximo turno.",
+				it: "Durante il tuo prossimo turno, questo Pokémon non può usare Colpo Fiammante.",
+				pt: "Este Pokémon não poderá usar Golpe de Chamas durante a sua próxima vez de jogar.",
+				de: "Dieses Pokémon kann Feuergeschoss während deines nächsten Zuges nicht einsetzen."
+			},
+			damage: 230,
+
+		},
+		{
+			cost: [
+				"Fire",
+				"Fire",
+				"Fire",
+			],
+			name: {
+				en: "Double Blaze GX",
+				fr: "Double Brasier GX",
+				es: "Doble Llama GX",
+				it: "Doppia Vampata GX",
+				pt: "Labareda Dupla GX",
+				de: "Doppelbrand GX"
+			},
+			effect: {
+				en: "If this Pokémon has at least 3 extra Fire Energy attached to it (in addition to this attack's cost), this attack does 100 more damage, and this attack's damage isn't affected by any effects on your opponent's Active Pokémon. (You can't use more than 1 GX attack in a game.)",
+				fr: "Si au moins 3 Énergies Fire supplémentaires sont attachées à ce Pokémon (en plus du coût de cette attaque), cette attaque inflige 100 dégâts supplémentaires, et les dégâts de cette attaque ne sont affectés par aucun effet en action sur le Pokémon Actif de votre adversaire. (Vous ne pouvez utiliser qu'une attaque GX par partie.)",
+				es: "Si este Pokémon tiene por lo menos 3 Energías Fire adicionales unidas a él (además de las del coste de este ataque), este ataque hace 100 puntos de daño más, y el daño de este ataque no se ve afectado por ningún efecto en el Pokémon Activo de tu rival. (No puedes usar más de 1 ataque GX en una partida).",
+				it: "Se questo Pokémon ha almeno tre Energie Fire extra assegnate, in aggiunta a quelle del costo di questo attacco, questo attacco infligge 100 danni in più e i suoi danni non sono influenzati da alcun effetto presente sul Pokémon attivo del tuo avversario. Non puoi usare più di un attacco GX a partita.",
+				pt: "Se este Pokémon tiver pelo menos 3 Energias Fire adicionais ligadas a ele (além do custo deste ataque), este ataque causará 100 pontos de dano a mais e o dano deste ataque não será afetado por quaisquer efeitos no Pokémon Ativo do seu oponente (você não pode usar mais de 1 ataque GX por partida).",
+				de: "Wenn an dieses Pokémon mindestens 3 extra Fire-Energien angelegt sind (zusätzlich zu den Kosten dieser Attacke), fügt diese Attacke 100 Schadenspunkte mehr zu und der Schaden dieser Attacke wird durch Effekte auf dem Aktiven Pokémon deines Gegners nicht verändert. (Du kannst pro Spiel nur 1 GX-Attacke einsetzen.)"
+			},
+			damage: "200+",
+
+		},
+	],
+	weaknesses: [
+		{
+			type: "Water",
+			value: "×2"
+		},
+	],
+
+	retreat: 3,
+
+	thirdParty: {
+		tcgplayer: 253394
+	}
+}
+
+export default card

--- a/data/Sun & Moon/SM Black Star Promos/SM248.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM248.ts
@@ -89,9 +89,14 @@ const card: Card = {
 	],
 	retreat: 3,
 
-	thirdParty: {
-		tcgplayer: 253397
-	}
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				tcgplayer: 253397
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sun & Moon/SM Black Star Promos/SM248.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM248.ts
@@ -1,0 +1,97 @@
+import { Card } from '../../../interfaces'
+import Set from '../SM Black Star Promos'
+
+const card: Card = {
+	dexId: [25, 644],
+	name: {
+		fr: "Pikachu et Zekrom GX",
+		en: "Pikachu & Zekrom GX",
+		es: "Pikachu y Zekrom GX",
+		it: "Pikachu e Zekrom GX",
+		pt: "Pikachu e Zekrom GX",
+		de: "Pikachu & Zekrom GX"
+	},
+	illustrator: "5ban Graphics",
+	rarity: "Ultra Rare",
+	category: "Pokemon",
+
+	set: Set,
+
+	hp: 240,
+	types: [
+		"Lightning",
+	],
+
+	stage: "Basic",
+	suffix: "TAG TEAM-GX",
+
+	attacks: [
+		{
+			name: {
+				fr: "Attaque Absolue",
+				en: "Full Blitz",
+				es: "Envite Total",
+				it: "Carica Totale",
+				pt: "Bombardeio Geral",
+				de: "Mächtiger Blitz"
+			},
+
+			damage: 150,
+
+			effect: {
+				en: "Search your deck for up to 3 Lightning Energy cards and attach them to 1 of your Pokémon. Then, shuffle your deck.",
+				fr: "Cherchez jusqu'à 3 cartes Énergie Lightning dans votre deck et attachez-les à l'un de vos Pokémon. Mélangez ensuite votre deck.",
+				es: "Busca en tu baraja hasta 3 cartas de Energía Lightning y únelas a 1 de tus Pokémon. Después, baraja las cartas de tu baraja.",
+				it: "Cerca nel tuo mazzo fino a tre carte Energia Lightning e assegnale a uno dei tuoi Pokémon. Poi rimischia le carte del tuo mazzo.",
+				pt: "Procure por até 3 cartas de Energia Lightning no seu baralho e ligue-as a 1 dos seus Pokémon. Em seguida, embaralhe o seu baralho.",
+				de: "Durchsuche dein Deck nach bis zu 3 Lightning-Energiekarten und lege sie an 1 deiner Pokémon an. Mische anschließend dein Deck."
+			},
+
+			cost: ["Lightning", "Lightning", "Lightning"]
+		},
+		{
+			cost: [
+				"Lightning",
+				"Lightning",
+				"Lightning",
+			],
+			name: {
+				fr: "Escouade Foudroyante GX",
+				en: "Tag Bolt GX",
+				es: "Rayo Relevo GX",
+				it: "Bolide Alleato GX",
+				pt: "Relâmpago de Aliados GX",
+				de: "Doppel-Blitzschlag GX"
+			},
+			effect: {
+				fr: "Si au moins 3 Énergies Lightning supplémentaires sont attachées à ce Pokémon (en plus du coût de cette attaque), cette attaque inflige 170 dégâts à l'un des Pokémon de Banc de votre adversaire. (N'appliquez ni la Faiblesse ni la Résistance aux Pokémon de Banc.) (Vous ne pouvez utiliser qu'une attaque GX par partie.)",
+				en: "If this Pokémon has at least 3 extra Lightning Energy attached to it (in addition to this attack's cost), this attack does 170 damage to 1 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.) (You can't use more than 1 GX attack in a game.)",
+				es: "Si este Pokémon tiene por lo menos 3 Energías Lightning adicionales unidas a él (además de las del coste de este ataque), este ataque hace 170 puntos de daño a 1 de los Pokémon en Banca de tu rival. (No apliques Debilidad y Resistencia a los Pokémon en Banca). (No puedes usar más de 1 ataque GX en una partida).",
+				it: "Se questo Pokémon ha almeno tre Energie Lightning extra assegnate, in aggiunta a quelle del costo di questo attacco, questo attacco infligge 170 danni a uno dei Pokémon nella panchina del tuo avversario. Ricorda che non puoi applicare debolezza e resistenza ai Pokémon in panchina. Non puoi usare più di un attacco GX a partita.",
+				pt: "Se este Pokémon tiver pelo menos 3 Energias Lightning adicionais ligadas a ele (além do custo deste ataque), este ataque causará 170 pontos de dano a 1 dos Pokémon no Banco do seu oponente (não aplique Fraqueza e Resistência aos Pokémon no Banco). (Você não pode usar mais de 1 ataque GX por partida.)",
+				de: "Wenn an dieses Pokémon mindestens 3 extra Lightning-Energien angelegt sind (zusätzlich zu den Kosten dieser Attacke), fügt diese Attacke 1 Pokémon auf der Bank deines Gegners 170 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.) (Du kannst pro Spiel nur 1 GX-Attacke einsetzen.)"
+			},
+			damage: 200,
+
+		},
+	],
+	weaknesses: [
+		{
+			type: "Fighting",
+			value: "×2"
+		},
+	],
+	resistances: [
+		{
+			type: "Metal",
+			value: "-20"
+		},
+	],
+	retreat: 3,
+
+	thirdParty: {
+		tcgplayer: 253397
+	}
+}
+
+export default card


### PR DESCRIPTION
## Changes

Added the missing SM Black Star Promos cards from `SM245` to `SM248`.

## Details

Added data for:

- `SM245` Mismagius
- `SM246` Sabrina & Brycen
- `SM247` Reshiram & Charizard GX
- `SM248` Pikachu & Zekrom GX

Also updated the official card count for SM Black Star Promos to `248`.

Card information was completed using Limitless TCG as reference, including multilingual names/text where available.

