### PR TITLE
Added missing cards to SWSH Promos

### DIFF
--- a/data/Sword & Shield/SWSH Black Star Promos.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos.ts
@@ -16,7 +16,7 @@ const swshp: Set = {
 	serie: serie,
 
 	cardCount: {
-		official: 107
+		official: 307
 	},
 
 	releaseDate: "2019-11-15",

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH075.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH075.ts
@@ -1,0 +1,69 @@
+import { Card } from "../../../interfaces"
+import Set from "../SWSH Black Star Promos"
+
+const card: Card = {
+	dexId: [6],
+	set: Set,
+	illustrator: "The Pokémon Company Art Team",
+
+	name: {
+		en: "Special Delivery Charizard"
+	},
+
+	description: {
+		en: "It spits fire that is hot enough to melt boulders. It may cause forest fires by blowing flames."
+	},
+
+	rarity: "None",
+	category: "Pokemon",
+	hp: 160,
+	types: ["Fire"],
+
+	evolveFrom: {
+		en: "Charmeleon"
+	},
+
+	stage: "Stage2",
+
+	attacks: [{
+		cost: ["Colorless"],
+
+		name: {
+			en: "Happy Delivery"
+		},
+
+		effect: {
+			en: "Search your deck for up to 2 Item cards, reveal them, and put them into your hand. Then, shuffle your deck."
+		}
+	}, {
+		cost: ["Fire", "Fire", "Colorless"],
+
+		name: {
+			en: "Flamethrower"
+		},
+
+		effect: {
+			en: "Discard an Energy from this Pokémon."
+		},
+
+		damage: 160
+	}],
+
+	weaknesses: [{
+		type: "Water",
+		value: "×2"
+	}],
+
+	retreat: 3,
+
+	variants: {
+		normal: false,
+		reverse: false,
+		holo: true,
+		firstEdition: false
+	},
+
+	regulationMark: "D"
+}
+
+export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH075.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH075.ts
@@ -56,13 +56,6 @@ const card: Card = {
 
 	retreat: 3,
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	variants: [
 			{
 				type: "holo",

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH075.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH075.ts
@@ -63,6 +63,12 @@ const card: Card = {
 		firstEdition: false
 	},
 
+	variants: [
+			{
+				type: "holo",
+			}
+		],
+		
 	regulationMark: "D"
 }
 

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH282.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH282.ts
@@ -1,0 +1,95 @@
+import { Card } from "../../../interfaces"
+import Set from "../SWSH Black Star Promos"
+
+const card: Card = {
+	set: Set,
+	illustrator: "Shiburingaru",
+	category: "Pokemon",
+
+	description: {
+		en: "Known as Articuno, this Pokémon fires beams that can immobilize opponents as if they had been frozen solid."
+	},
+
+	stage: "Basic",
+
+	name: {
+		en: "Galarian Articuno",
+		fr: "Artikodin de Galar",
+		de: "Galar-Arktos",
+		es: "Articuno de Galar",
+		pt: "Articuno de Galar",
+		it: "Articuno di Galar"
+	},
+
+	rarity: "None",
+	dexId: [144],
+	hp: 120,
+	types: ["Psychic"],
+
+	abilities: [{
+		type: "Ability",
+
+		name: {
+			en: "Cruel Charge",
+			fr: "Charge Implacable",
+			de: "Gefühlskalter Ansturm",
+			es: "Carga Calculadora",
+			pt: "Carga Cruel",
+			it: "Carica Sanguefreddo"
+		},
+
+		effect: {
+			en: "When you play this Pokémon from your hand onto your Bench during your turn, you may attach up to 2 {P} Energy cards from your hand to this Pokémon.",
+			fr: "Lorsque vous jouez ce Pokémon de votre main sur votre Banc pendant votre tour, vous pouvez attacher jusqu'à 2 cartes Énergie {P} de votre main à ce Pokémon.",
+			de: "Wenn du dieses Pokémon während deines Zuges aus deiner Hand auf deine Bank spielst, kannst du bis zu 2 {P}-Energiekarten aus deiner Hand an dieses Pokémon anlegen.",
+			es: "Cuando juegas este Pokémon de tu mano a tu Banca durante tu turno, puedes unir hasta 2 cartas de Energía {P} de tu mano a este Pokémon.",
+			pt: "Quando você jogar este Pokémon da sua mão para o seu Banco durante o seu turno, você poderá ligar até 2 cartas de Energia {P} da sua mão a este Pokémon.",
+			it: "Quando giochi questo Pokémon dalla tua mano e lo metti in panchina durante il tuo turno, puoi assegnargli fino a due carte Energia {P} dalla tua mano."
+		}
+	}],
+
+	attacks: [{
+		cost: ["Psychic", "Psychic", "Colorless"],
+
+		name: {
+			en: "Psylaser",
+			fr: "Laser Psy",
+			de: "Psilaser",
+			es: "Psicoláser",
+			pt: "Psicolaser",
+			it: "Psicolaser"
+		},
+
+		effect: {
+			en: "Discard all {P} Energy from this Pokémon. This attack does 120 damage to 1 of your opponent's Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)",
+			fr: "Défaussez toute l'Énergie {P} de ce Pokémon. Cette attaque inflige 120 dégâts à l'un des Pokémon de votre adversaire. (N'appliquez ni la Faiblesse ni la Résistance aux Pokémon de Banc.)",
+			de: "Lege alle {P}-Energien von diesem Pokémon auf deinen Ablagestapel. Diese Attacke fügt 1 Pokémon deines Gegners 120 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)",
+			es: "Descarta todas las Energías {P} de este Pokémon. Este ataque hace 120 puntos de daño a 1 de los Pokémon de tu rival. (No apliques Debilidad y Resistencia a los Pokémon en Banca).",
+			pt: "Descarte todas as Energias {P} deste Pokémon. Este ataque causa 120 pontos de dano a 1 dos Pokémon do seu oponente (não aplique Fraqueza e Resistência aos Pokémon no Banco).",
+			it: "Scarta tutte le Energie {P} da questo Pokémon. Questo attacco infligge 120 danni a uno dei Pokémon del tuo avversario. Non applicare debolezza e resistenza ai Pokémon in panchina."
+		}
+	}],
+
+	weaknesses: [{
+		type: "Darkness",
+		value: "×2"
+	}],
+
+	resistances: [{
+		type: "Fighting",
+		value: "-30"
+	}],
+
+	retreat: 2,
+
+	variants: {
+		normal: false,
+		reverse: false,
+		holo: true,
+		firstEdition: false
+	},
+
+	regulationMark: "E"
+}
+
+export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH282.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH282.ts
@@ -82,12 +82,11 @@ const card: Card = {
 
 	retreat: 2,
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
+	variants: [
+			{
+				type: "holo",
+			}
+		],
 
 	regulationMark: "E"
 }

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH283.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH283.ts
@@ -1,0 +1,92 @@
+import { Card } from "../../../interfaces"
+import Set from "../SWSH Black Star Promos"
+
+const card: Card = {
+	set: Set,
+	illustrator: "Rianti Hidayat",
+	category: "Pokemon",
+
+	description: {
+		en: "One kick from its powerful legs will pulverize a dump truck. Supposedly, this Pokémon runs through the mountains at over 180 mph."
+	},
+
+	stage: "Basic",
+
+	name: {
+		en: "Galarian Zapdos",
+		fr: "Électhor de Galar",
+		de: "Galar-Zapdos",
+		es: "Zapdos de Galar",
+		pt: "Zapdos de Galar",
+		it: "Zapdos di Galar"
+	},
+
+	rarity: "None",
+	dexId: [145],
+	hp: 110,
+	types: ["Fighting"],
+
+	abilities: [{
+		type: "Ability",
+
+		name: {
+			en: "Strong Legs Charge",
+			fr: "Charge Fort-Pied",
+			de: "Laufender Ansturm",
+			es: "Carga Patas Recias",
+			pt: "Carga de Pernas Fortes",
+			it: "Carica Zampeforti"
+		},
+
+		effect: {
+			en: "When you play this Pokémon from your hand onto your Bench during your turn, you may attach up to 2 {F} Energy cards from your hand to this Pokémon.",
+			fr: "Lorsque vous jouez ce Pokémon de votre main sur votre Banc pendant votre tour, vous pouvez attacher jusqu'à 2 cartes Énergie {F} de votre main à ce Pokémon.",
+			de: "Wenn du dieses Pokémon während deines Zuges aus deiner Hand auf deine Bank spielst, kannst du bis zu 2 {F}-Energiekarten aus deiner Hand an dieses Pokémon anlegen.",
+			es: "Cuando juegas este Pokémon de tu mano a tu Banca durante tu turno, puedes unir hasta 2 cartas de Energía {F} de tu mano a este Pokémon.",
+			pt: "Quando você jogar este Pokémon da sua mão para o seu Banco durante o seu turno, você poderá ligar até 2 cartas de Energia {F} da sua mão a este Pokémon.",
+			it: "Quando giochi questo Pokémon dalla tua mano e lo metti in panchina durante il tuo turno, puoi assegnargli fino a due carte Energia {F} dalla tua mano."
+		}
+	}],
+
+	attacks: [{
+		cost: ["Fighting", "Fighting", "Colorless"],
+
+		name: {
+			en: "Zapper Kick",
+			fr: "Pied Électrisant",
+			de: "Stromkick",
+			es: "Patada Exterminadora",
+			pt: "Chute Elétrico",
+			it: "Scaricalcio"
+		},
+
+		effect: {
+			en: "You may discard all Energy from this Pokémon. If you do, your opponent's Active Pokémon is now Paralyzed.",
+			fr: "Vous pouvez défausser toute l'Énergie de ce Pokémon. Dans ce cas, le Pokémon Actif de votre adversaire est maintenant Paralysé.",
+			de: "Du kannst alle Energien von diesem Pokémon auf deinen Ablagestapel legen. Wenn du das machst, ist das Aktive Pokémon deines Gegners jetzt paralysiert.",
+			es: "Puedes descartar todas las Energías de este Pokémon. Si lo haces, el Pokémon Activo de tu rival pasa a estar Paralizado.",
+			pt: "Você pode descartar todas as Energias deste Pokémon. Se fizer isto, o Pokémon Ativo do seu oponente ficará Paralisado.",
+			it: "Puoi scartare tutte le Energie da questo Pokémon. Se lo fai, il Pokémon attivo del tuo avversario viene paralizzato."
+		},
+
+		damage: 70
+	}],
+
+	weaknesses: [{
+		type: "Psychic",
+		value: "×2"
+	}],
+
+	retreat: 0,
+
+	variants: {
+		normal: false,
+		reverse: false,
+		holo: true,
+		firstEdition: false
+	},
+
+	regulationMark: "E"
+}
+
+export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH283.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH283.ts
@@ -79,12 +79,11 @@ const card: Card = {
 
 	retreat: 0,
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
+	variants: [
+			{
+				type: "holo",
+			}
+		],
 
 	regulationMark: "E"
 }

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH284.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH284.ts
@@ -1,0 +1,92 @@
+import { Card } from "../../../interfaces"
+import Set from "../SWSH Black Star Promos"
+
+const card: Card = {
+	set: Set,
+	illustrator: "Shinji Kanda",
+	category: "Pokemon",
+
+	description: {
+		en: "The sinister aura that blazes like molten fire around this Pokémon is what inspired the name Moltres."
+	},
+
+	stage: "Basic",
+
+	name: {
+		en: "Galarian Moltres",
+		fr: "Sulfura de Galar",
+		de: "Galar-Lavados",
+		es: "Moltres de Galar",
+		pt: "Moltres de Galar",
+		it: "Moltres di Galar"
+	},
+
+	rarity: "None",
+	dexId: [146],
+	hp: 120,
+	types: ["Darkness"],
+
+	abilities: [{
+		type: "Ability",
+
+		name: {
+			en: "Malevolent Charge",
+			fr: "Charge Maléfique",
+			de: "Boshafter Ansturm",
+			es: "Carga Malignidad",
+			pt: "Carga Malevolente",
+			it: "Carica Malvagità"
+		},
+
+		effect: {
+			en: "When you play this Pokémon from your hand onto your Bench during your turn, you may attach up to 2 {D} Energy cards from your hand to this Pokémon.",
+			fr: "Lorsque vous jouez ce Pokémon de votre main sur votre Banc pendant votre tour, vous pouvez attacher jusqu'à 2 cartes Énergie {D} de votre main à ce Pokémon.",
+			de: "Wenn du dieses Pokémon während deines Zuges aus deiner Hand auf deine Bank spielst, kannst du bis zu 2 {D}-Energiekarten aus deiner Hand an dieses Pokémon anlegen.",
+			es: "Cuando juegas este Pokémon de tu mano a tu Banca durante tu turno, puedes unir hasta 2 cartas de Energía {D} de tu mano a este Pokémon.",
+			pt: "Quando você jogar este Pokémon da sua mão para o seu Banco durante o seu turno, você poderá ligar até 2 cartas de Energia {D} da sua mão a este Pokémon.",
+			it: "Quando giochi questo Pokémon dalla tua mano e lo metti in panchina durante il tuo turno, puoi assegnargli fino a due carte Energia {D} dalla tua mano."
+		}
+	}],
+
+	attacks: [{
+		cost: ["Darkness", "Darkness", "Colorless"],
+
+		name: {
+			en: "Fiery Wrath",
+			fr: "Fureur Ardente",
+			de: "Brennender Zorn",
+			es: "Furia Candente",
+			pt: "Fúria Ardente",
+			it: "Furia Ardente"
+		},
+
+		effect: {
+			en: "This attack does 50 more damage for each Prize card your opponent has taken.",
+			fr: "Cette attaque inflige 50 dégâts supplémentaires pour chaque carte Récompense que votre adversaire a récupérée.",
+			de: "Diese Attacke fügt für jede von deinem Gegner genommene Preiskarte 50 Schadenspunkte mehr zu.",
+			es: "Este ataque hace 50 puntos de daño más por cada carta de Premio que haya cogido tu rival.",
+			pt: "Este ataque causa 50 pontos de dano a mais para cada carta de Prêmio que seu oponente pegou.",
+			it: "Questo attacco infligge 50 danni in più per ogni carta Premio presa dal tuo avversario."
+		},
+
+		damage: "20+"
+	}],
+
+	weaknesses: [{
+		type: "Grass",
+		value: "×2"
+	}],
+
+	retreat: 2,
+
+	variants: {
+		normal: false,
+		reverse: false,
+		holo: true,
+		firstEdition: false
+	},
+
+	regulationMark: "E"
+}
+
+export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH284.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH284.ts
@@ -79,12 +79,11 @@ const card: Card = {
 
 	retreat: 2,
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
+	variants: [
+			{
+				type: "holo",
+			}
+		],
 
 	regulationMark: "E"
 }

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH287.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH287.ts
@@ -1,0 +1,56 @@
+import { Card } from "../../../interfaces"
+import Set from "../SWSH Black Star Promos"
+
+const card: Card = {
+	dexId: [877],
+	set: Set,
+	illustrator: "Yuu Nishida",
+
+	name: {
+		fr: "Morpeko V-UNION",
+		de: "Morpeko V-UNION",
+		es: "Morpeko V-UNIÓN",
+		pt: "Morpeko V-UNIÃO",
+		it: "Morpeko V UNIONE",
+		en: "Morpeko V-UNION"
+	},
+
+	rarity: "None",
+	category: "Pokemon",
+	hp: 310,
+	types: ["Lightning"],
+	stage: "V-UNION",
+	suffix: "V",
+
+	attacks: [{
+		cost: ["Colorless"],
+
+		name: {
+			en: "Union Gain",
+			pt: "Conquista de União"
+		},
+
+		effect: {
+			en: "Attach up to 2 {L} Energy cards from your discard pile to this Pokémon.",
+			pt: "Ligue até 2 cartas de Energia {L} da sua pilha de descarte a este Pokémon."
+		}
+	}],
+
+	weaknesses: [{
+		type: "Fighting",
+		value: "×2"
+	}],
+
+	retreat: 2,
+
+	variants: {
+		normal: false,
+		reverse: false,
+		holo: true,
+		firstEdition: false
+	},
+
+	regulationMark: "E"
+}
+
+export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH287.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH287.ts
@@ -43,12 +43,11 @@ const card: Card = {
 
 	retreat: 2,
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
+	variants: [
+			{
+				type: "holo",
+			}
+		],
 
 	regulationMark: "E"
 }

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH288.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH288.ts
@@ -1,0 +1,56 @@
+import { Card } from "../../../interfaces"
+import Set from "../SWSH Black Star Promos"
+
+const card: Card = {
+	dexId: [877],
+	set: Set,
+	illustrator: "Yuu Nishida",
+
+	name: {
+		fr: "Morpeko V-UNION",
+		de: "Morpeko V-UNION",
+		es: "Morpeko V-UNIÓN",
+		pt: "Morpeko V-UNIÃO",
+		it: "Morpeko V UNIONE",
+		en: "Morpeko V-UNION"
+	},
+
+	rarity: "None",
+	category: "Pokemon",
+	hp: 310,
+	types: ["Lightning"],
+	stage: "V-UNION",
+	suffix: "V",
+
+	attacks: [{
+		cost: ["Colorless", "Colorless"],
+
+		name: {
+			en: "All You Can Eat",
+			pt: "Comilança"
+		},
+
+		effect: {
+			en: "Draw cards until you have 10 cards in your hand.",
+			pt: "Compre cartas até ter 10 cartas na sua mão."
+		}
+	}],
+
+	weaknesses: [{
+		type: "Fighting",
+		value: "×2"
+	}],
+
+	retreat: 2,
+
+	variants: {
+		normal: false,
+		reverse: false,
+		holo: true,
+		firstEdition: false
+	},
+
+	regulationMark: "E"
+}
+
+export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH288.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH288.ts
@@ -43,12 +43,11 @@ const card: Card = {
 
 	retreat: 2,
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
+	variants: [
+			{
+				type: "holo",
+			}
+		],
 
 	regulationMark: "E"
 }

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH289.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH289.ts
@@ -1,0 +1,58 @@
+import { Card } from "../../../interfaces"
+import Set from "../SWSH Black Star Promos"
+
+const card: Card = {
+	dexId: [877],
+	set: Set,
+	illustrator: "Yuu Nishida",
+
+	name: {
+		fr: "Morpeko V-UNION",
+		de: "Morpeko V-UNION",
+		es: "Morpeko V-UNIÓN",
+		pt: "Morpeko V-UNIÃO",
+		it: "Morpeko V UNIONE",
+		en: "Morpeko V-UNION"
+	},
+
+	rarity: "None",
+	category: "Pokemon",
+	hp: 310,
+	types: ["Lightning"],
+	stage: "V-UNION",
+	suffix: "V",
+
+	attacks: [{
+		cost: ["Lightning", "Colorless", "Colorless"],
+
+		name: {
+			en: "Burst Wheel",
+			pt: "Roda Explosiva"
+		},
+
+		effect: {
+			en: "Discard all Energy from this Pokémon. This attack does 100 damage for each card you discarded in this way.",
+			pt: "Descarte todas as Energias deste Pokémon. Este ataque causa 100 pontos de dano para cada carta descartada desta forma."
+		},
+
+		damage: "100×"
+	}],
+
+	weaknesses: [{
+		type: "Fighting",
+		value: "×2"
+	}],
+
+	retreat: 2,
+
+	variants: {
+		normal: false,
+		reverse: false,
+		holo: true,
+		firstEdition: false
+	},
+
+	regulationMark: "E"
+}
+
+export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH289.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH289.ts
@@ -45,12 +45,11 @@ const card: Card = {
 
 	retreat: 2,
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
+	variants: [
+			{
+				type: "holo",
+			}
+		],
 
 	regulationMark: "E"
 }

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH290.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH290.ts
@@ -1,0 +1,53 @@
+import { Card } from "../../../interfaces"
+import Set from "../SWSH Black Star Promos"
+
+const card: Card = {
+	dexId: [877],
+	set: Set,
+	illustrator: "Yuu Nishida",
+
+	name: {
+		fr: "Morpeko V-UNION",
+		de: "Morpeko V-UNION",
+		es: "Morpeko V-UNIÓN",
+		pt: "Morpeko V-UNIÃO",
+		it: "Morpeko V UNIONE",
+		en: "Morpeko V-UNION"
+	},
+
+	rarity: "None",
+	category: "Pokemon",
+	hp: 310,
+	types: ["Lightning"],
+	stage: "V-UNION",
+	suffix: "V",
+
+	attacks: [{
+		cost: ["Lightning", "Colorless", "Colorless"],
+
+		name: {
+			en: "Electric Ball",
+			pt: "Bola de Eletricidade"
+		},
+
+		damage: 160
+	}],
+
+	weaknesses: [{
+		type: "Fighting",
+		value: "×2"
+	}],
+
+	retreat: 2,
+
+	variants: {
+		normal: false,
+		reverse: false,
+		holo: true,
+		firstEdition: false
+	},
+
+	regulationMark: "E"
+}
+
+export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH290.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH290.ts
@@ -40,12 +40,11 @@ const card: Card = {
 
 	retreat: 2,
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
+	variants: [
+			{
+				type: "holo",
+			}
+		],
 
 	regulationMark: "E"
 }

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH292.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH292.ts
@@ -1,0 +1,92 @@
+import { Card } from "../../../interfaces"
+import Set from "../SWSH Black Star Promos"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Zacian V",
+		fr: "Zacian V",
+		es: "Zacian V",
+		it: "Zacian V",
+		pt: "Zacian V",
+		de: "Zacian V"
+	},
+
+	illustrator: "5ban Graphics",
+	rarity: "None",
+	category: "Pokemon",
+	hp: 220,
+	types: ["Metal"],
+
+	abilities: [{
+		type: "Ability",
+
+		name: {
+			en: "Intrepid Sword",
+			fr: "Lame Indomptable",
+			es: "Espada Indómita",
+			it: "Spada Indomita",
+			pt: "Espada Intrépida",
+			de: "Kühnes Schwert"
+		},
+
+		effect: {
+			en: "Once during your turn, you may look at the top 3 cards of your deck and attach any number of {M} Energy cards you find there to this Pokémon. Put the other cards into your hand. If you use this Ability, your turn ends.",
+			fr: "Une fois pendant votre tour, vous pouvez regarder les 3 cartes du dessus de votre deck, puis attacher à ce Pokémon le nombre voulu de cartes Énergie {M} que vous y trouvez. Ajoutez les autres cartes à votre main. Si vous utilisez ce talent, votre tour se termine.",
+			es: "Una vez durante tu turno, puedes mirar las 3 primeras cartas de tu baraja y unir cualquier cantidad de cartas de Energía {M} que encuentres entre ellas a este Pokémon. Pon el resto de las cartas en tu mano. Si usas esta habilidad, tu turno termina.",
+			it: "Una sola volta durante il tuo turno, puoi guardare le prime tre carte del tuo mazzo e assegnare un numero qualsiasi di carte Energia {M} presenti tra esse a questo Pokémon. Aggiungi le altre carte a quelle che hai in mano. Se usi questa abilità, il tuo turno finisce.",
+			pt: "Uma vez durante o seu turno, você poderá olhar as 3 cartas de cima do seu baralho e ligar qualquer número de cartas de Energia {M} que encontrar lá a este Pokémon. Coloque as outras cartas na sua mão. Se você usar esta Habilidade, o seu turno acabará.",
+			de: "Einmal während deines Zuges kannst du dir die obersten 3 Karten deines Decks anschauen und beliebig viele {M}-Energiekarten, die du dort findest, an dieses Pokémon anlegen. Nimm die anderen Karten auf deine Hand. Wenn du diese Fähigkeit einsetzt, endet dein Zug."
+		}
+	}],
+
+	attacks: [{
+		name: {
+			en: "Brave Blade",
+			fr: "Lame Vaillante",
+			es: "Cuchilla Osada",
+			it: "Baldalama",
+			pt: "Lâmina Valente",
+			de: "Couragierte Klinge"
+		},
+
+		effect: {
+			en: "During your next turn, this Pokémon can't attack.",
+			fr: "Pendant votre prochain tour, ce Pokémon ne peut pas attaquer.",
+			es: "Durante tu próximo turno, este Pokémon no puede atacar.",
+			it: "Durante il tuo prossimo turno, questo Pokémon non può attaccare.",
+			pt: "Durante o seu próximo turno, este Pokémon não poderá atacar.",
+			de: "Während deines nächsten Zuges kann dieses Pokémon nicht angreifen."
+		},
+
+		damage: 230,
+		cost: ["Metal", "Metal", "Metal"]
+	}],
+
+	weaknesses: [{
+		type: "Fire",
+		value: "×2"
+	}],
+
+	resistances: [{
+		type: "Grass",
+		value: "-30"
+	}],
+
+	retreat: 2,
+	stage: "Basic",
+	dexId: [888],
+
+	variants: {
+		normal: false,
+		reverse: false,
+		holo: true,
+		firstEdition: false
+	},
+
+	regulationMark: "D",
+	suffix: "V"
+}
+
+export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH292.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH292.ts
@@ -78,12 +78,11 @@ const card: Card = {
 	stage: "Basic",
 	dexId: [888],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
+	variants: [
+			{
+				type: "holo",
+			}
+		],
 
 	regulationMark: "D",
 	suffix: "V"

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH293.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH293.ts
@@ -1,0 +1,92 @@
+import { Card } from "../../../interfaces"
+import Set from "../SWSH Black Star Promos"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Zamazenta V",
+		fr: "Zamazenta V",
+		es: "Zamazenta V",
+		it: "Zamazenta V",
+		pt: "Zamazenta V",
+		de: "Zamazenta V"
+	},
+
+	illustrator: "aky CG Works",
+	rarity: "None",
+	category: "Pokemon",
+	hp: 230,
+	types: ["Metal"],
+
+	abilities: [{
+		type: "Ability",
+
+		name: {
+			en: "Dauntless Shield",
+			fr: "Égide Inflexible",
+			es: "Escudo Recio",
+			it: "Scudo Saldo",
+			pt: "Escudo Destemido",
+			de: "Wackerer Schild"
+		},
+
+		effect: {
+			en: "Prevent all damage done to this Pokémon by attacks from your opponent's Pokémon VMAX.",
+			fr: "Évitez tous les dégâts infligés à ce Pokémon par les attaques des Pokémon-VMAX de votre adversaire.",
+			es: "Evita todo el daño infligido a este Pokémon por ataques de los Pokémon VMAX de tu rival.",
+			it: "Previeni tutti i danni inflitti a questo Pokémon dagli attacchi dei Pokémon-VMAX del tuo avversario.",
+			pt: "Previna todo o dano causado a este Pokémon por ataques dos Pokémon VMAX do seu oponente.",
+			de: "Verhindere allen Schaden, der diesem Pokémon durch Attacken von Pokémon-VMAX deines Gegners zugefügt wird."
+		}
+	}],
+
+	attacks: [{
+		name: {
+			en: "Assault Tackle",
+			fr: "Tacle Assaillant",
+			es: "Placaje Asalto",
+			it: "Azione d'Assalto",
+			pt: "Investida Ofensiva",
+			de: "Überfalltackle"
+		},
+
+		effect: {
+			en: "Discard a Special Energy from your opponent's Active Pokémon.",
+			fr: "Défaussez une Énergie spéciale du Pokémon Actif de votre adversaire.",
+			es: "Descarta 1 Energía Especial del Pokémon Activo de tu rival.",
+			it: "Scarta un'Energia speciale dal Pokémon attivo del tuo avversario.",
+			pt: "Descarte 1 Energia Especial do Pokémon Ativo do seu oponente.",
+			de: "Lege 1 Spezial-Energie vom Aktiven Pokémon deines Gegners auf seinen Ablagestapel."
+		},
+
+		damage: 130,
+		cost: ["Metal", "Metal", "Colorless"]
+	}],
+
+	weaknesses: [{
+		type: "Fire",
+		value: "×2"
+	}],
+
+	resistances: [{
+		type: "Grass",
+		value: "-30"
+	}],
+
+	retreat: 2,
+	stage: "Basic",
+	dexId: [889],
+
+	variants: {
+		normal: false,
+		reverse: false,
+		holo: true,
+		firstEdition: false
+	},
+
+	regulationMark: "D",
+	suffix: "V"
+}
+
+export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH293.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH293.ts
@@ -78,12 +78,11 @@ const card: Card = {
 	stage: "Basic",
 	dexId: [889],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
+	variants: [
+			{
+				type: "holo",
+			}
+		],
 
 	regulationMark: "D",
 	suffix: "V"

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH301.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH301.ts
@@ -1,0 +1,91 @@
+import { Card } from "../../../interfaces"
+import Set from "../SWSH Black Star Promos"
+
+const card: Card = {
+	dexId: [249],
+	set: Set,
+	illustrator: "PLANETA Mochizuki",
+
+	name: {
+		en: "Lugia V",
+		fr: "Lugia V",
+		es: "Lugia V",
+		it: "Lugia V",
+		pt: "Lugia V",
+		de: "Lugia V"
+	},
+
+	rarity: "None",
+	category: "Pokemon",
+	hp: 220,
+	types: ["Colorless"],
+	stage: "Basic",
+	suffix: "V",
+
+	attacks: [{
+		cost: ["Colorless"],
+
+		name: {
+			en: "Read the Wind",
+			fr: "Lecture des Vents",
+			es: "Leer el Viento",
+			it: "Leggivento",
+			pt: "Leitura dos Ventos",
+			de: "Winddeutung"
+		},
+
+		effect: {
+			en: "Discard a card from your hand. If you do, draw 3 cards.",
+			fr: "Défaussez une carte de votre main. Dans ce cas, piochez 3 cartes.",
+			es: "Descarta 1 carta de tu mano. Si lo haces, roba 3 cartas.",
+			it: "Scarta una delle carte che hai in mano. Se lo fai, pesca tre carte.",
+			pt: "Descarte 1 carta da sua mão. Se fizer isto, compre 3 cartas.",
+			de: "Lege 1 Karte aus deiner Hand auf deinen Ablagestapel. Wenn du das machst, ziehe 3 Karten."
+		}
+	}, {
+		cost: ["Colorless", "Colorless", "Colorless", "Colorless"],
+
+		name: {
+			en: "Aero Dive",
+			fr: "Plongée Aérienne",
+			es: "Aerozambullida",
+			it: "Aerotuffo",
+			pt: "Mergulho Aéreo",
+			de: "Aero-Sturzflug"
+		},
+
+		effect: {
+			en: "You may discard a Stadium in play.",
+			fr: "Vous pouvez défausser un Stade en jeu.",
+			es: "Puedes descartar un Estadio en juego.",
+			it: "Puoi scartare una carta Stadio in gioco.",
+			pt: "Você pode descartar 1 Estádio em jogo.",
+			de: "Du kannst 1 Stadionkarte im Spiel auf den Ablagestapel legen."
+		},
+
+		damage: 130
+	}],
+
+	weaknesses: [{
+		type: "Lightning",
+		value: "×2"
+	}],
+
+	resistances: [{
+		type: "Fighting",
+		value: "-30"
+	}],
+
+	retreat: 2,
+
+	variants: {
+		normal: false,
+		reverse: false,
+		holo: true,
+		firstEdition: false
+	},
+
+	regulationMark: "F"
+}
+
+export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH301.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH301.ts
@@ -78,12 +78,11 @@ const card: Card = {
 
 	retreat: 2,
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
+	variants: [
+			{
+				type: "holo",
+			}
+		],
 
 	regulationMark: "F"
 }

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH302.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH302.ts
@@ -1,0 +1,41 @@
+import { Card } from "../../../interfaces"
+import Set from "../SWSH Black Star Promos"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		fr: "Sophora",
+		en: "Klara",
+		es: "Sófora",
+		it: "Sofora",
+		pt: "Klara",
+		de: "Sophora"
+	},
+
+	illustrator: "Yuu Nishida",
+	rarity: "None",
+	category: "Trainer",
+
+	effect: {
+		fr: "Choisissez l'une de ces options ou les deux :\n• Ajoutez jusqu'à 2 Pokémon de votre pile de défausse à votre main.\n• Ajoutez jusqu'à 2 cartes Énergie de base de votre pile de défausse à votre main.",
+		en: "Choose 1 or both:\n• Put up to 2 Pokémon from your discard pile into your hand.\n• Put up to 2 basic Energy cards from your discard pile into your hand.",
+		es: "Elige 1 o ambas opciones:\n• Pon hasta 2 Pokémon de tu pila de descartes en tu mano.\n• Pon hasta 2 cartas de Energía Básica de tu pila de descartes en tu mano.",
+		it: "Scegli uno o entrambi gli effetti:\n• Prendi fino a due Pokémon dalla tua pila degli scarti e aggiungili alle carte che hai in mano.\n• Prendi fino a due carte Energia base dalla tua pila degli scarti e aggiungile alle carte che hai in mano.",
+		pt: "Escolha 1 ou ambas:\n• Coloque até 2 Pokémon da sua pilha de descarte na sua mão.\n• Coloque até 2 cartas de Energia básica da sua pilha de descarte na sua mão.",
+		de: "Wähle 1 oder beide aus:\n• Nimm bis zu 2 Pokémon aus deinem Ablagestapel auf deine Hand.\n• Nimm bis zu 2 Basis-Energiekarten aus deinem Ablagestapel auf deine Hand."
+	},
+
+	trainerType: "Supporter",
+
+	variants: {
+		normal: false,
+		reverse: false,
+		holo: true,
+		firstEdition: false
+	},
+
+	regulationMark: "E"
+}
+
+export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH302.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH302.ts
@@ -28,12 +28,11 @@ const card: Card = {
 
 	trainerType: "Supporter",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
+	variants: [
+			{
+				type: "holo",
+			}
+		],
 
 	regulationMark: "E"
 }

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH306.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH306.ts
@@ -1,0 +1,77 @@
+import { Card } from "../../../interfaces"
+import Set from "../SWSH Black Star Promos"
+
+const card: Card = {
+	dexId: [493],
+	set: Set,
+	illustrator: "5ban Graphics",
+
+	name: {
+		en: "Arceus V",
+		fr: "Arceus V",
+		es: "Arceus V",
+		it: "Arceus V",
+		pt: "Arceus V",
+		de: "Arceus V"
+	},
+
+	rarity: "None",
+	category: "Pokemon",
+	hp: 220,
+	types: ["Colorless"],
+	stage: "Basic",
+	suffix: "V",
+
+	attacks: [{
+		cost: ["Colorless", "Colorless"],
+
+		name: {
+			en: "Trinity Charge",
+			fr: "Charge Trinité",
+			es: "Carga Trinidad",
+			it: "Carica Triade",
+			pt: "Carga Tríptica",
+			de: "Ladevorgang der Dreiheit"
+		},
+
+		effect: {
+			en: "Search your deck for up to 3 basic Energy cards and attach them to your Pokémon V in any way you like. Then, shuffle your deck.",
+			fr: "Cherchez dans votre deck jusqu'à 3 cartes Énergie de base, puis attachez-les à vos Pokémon-V comme il vous plaît. Mélangez ensuite votre deck.",
+			es: "Busca en tu baraja hasta 3 cartas de Energía Básica y únelas a tus Pokémon V de la manera que desees. Después, baraja las cartas de tu baraja.",
+			it: "Cerca nel tuo mazzo fino a tre carte Energia base e assegnale ai tuoi Pokémon-V nel modo che preferisci. Poi rimischia le carte del tuo mazzo.",
+			pt: "Procure por até 3 cartas de Energia básica no seu baralho e ligue-as aos seus Pokémon V como desejar. Em seguida, embaralhe o seu baralho.",
+			de: "Durchsuche dein Deck nach bis zu 3 Basis-Energiekarten und lege sie beliebig an deine Pokémon-V an. Mische anschließend dein Deck."
+		}
+	}, {
+		cost: ["Colorless", "Colorless", "Colorless"],
+
+		name: {
+			en: "Power Edge",
+			fr: "Lame Puissante",
+			es: "Filo Poderoso",
+			it: "Colpotente",
+			pt: "Gume Poderoso",
+			de: "Kraftklinge"
+		},
+
+		damage: 130
+	}],
+
+	weaknesses: [{
+		type: "Fighting",
+		value: "×2"
+	}],
+
+	retreat: 2,
+
+	variants: {
+		normal: false,
+		reverse: false,
+		holo: true,
+		firstEdition: false
+	},
+
+	regulationMark: "F"
+}
+
+export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH306.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH306.ts
@@ -64,12 +64,11 @@ const card: Card = {
 
 	retreat: 2,
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
+	variants: [
+			{
+				type: "holo",
+			}
+		],
 
 	regulationMark: "F"
 }

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH307.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH307.ts
@@ -1,0 +1,98 @@
+import { Card } from "../../../interfaces"
+import Set from "../SWSH Black Star Promos"
+
+const card: Card = {
+	dexId: [493],
+	set: Set,
+	illustrator: "5ban Graphics",
+
+	name: {
+		en: "Arceus VSTAR",
+		fr: "Arceus VSTAR",
+		es: "Arceus V-ASTRO",
+		it: "Arceus V ASTRO",
+		pt: "Arceus V-ASTRO",
+		de: "Arceus VSTAR"
+	},
+
+	rarity: "None",
+	category: "Pokemon",
+	hp: 280,
+	types: ["Colorless"],
+
+	evolveFrom: {
+		en: "Arceus V",
+		fr: "Arceus-V",
+		es: "Arceus V",
+		it: "Arceus-V",
+		pt: "Arceus V",
+		de: "Arceus-V"
+	},
+
+	stage: "VSTAR",
+	suffix: "V",
+
+	abilities: [{
+		type: "Ability",
+
+		name: {
+			en: "Starbirth",
+			fr: "Naissance Star",
+			es: "Astroalbor",
+			it: "Astro Nascita",
+			pt: "Nascimento Astral",
+			de: "Sternengeburt"
+		},
+
+		effect: {
+			en: "During your turn, you may search your deck for up to 2 cards and put them into your hand. Then, shuffle your deck. (You can't use more than 1 VSTAR Power in a game.)",
+			fr: "Pendant votre tour, vous pouvez chercher dans votre deck jusqu'à 2 cartes, puis les ajouter à votre main. Mélangez ensuite votre deck. (Vous ne pouvez utiliser qu'une seule Puissance VSTAR par partie.)",
+			es: "Durante tu turno, puedes buscar en tu baraja hasta 2 cartas y ponerlas en tu mano. Después, baraja las cartas de tu baraja. (No puedes usar más de 1 Poder V-ASTRO en una partida).",
+			it: "Durante il tuo turno, puoi cercare nel tuo mazzo fino a due carte e aggiungerle a quelle che hai in mano. Poi rimischia le carte del tuo mazzo. Non puoi usare più di un Potere V ASTRO a partita.",
+			pt: "Durante o seu turno, você poderá procurar por até 2 cartas no seu baralho e colocá-las na sua mão. Em seguida, embaralhe o seu baralho (você não pode usar mais de 1 Poder V-ASTRO por partida).",
+			de: "Während deines Zuges kannst du dein Deck nach bis zu 2 Karten durchsuchen und sie auf deine Hand nehmen. Mische anschließend dein Deck. (Du kannst pro Spiel nur 1 VSTAR-Power einsetzen.)"
+		}
+	}],
+
+	attacks: [{
+		cost: ["Colorless", "Colorless", "Colorless"],
+
+		name: {
+			en: "Trinity Nova",
+			fr: "Nova Trinité",
+			es: "Lucero Trinidad",
+			it: "Nova Triade",
+			pt: "Supernova Tríptica",
+			de: "Nova der Dreiheit"
+		},
+
+		effect: {
+			en: "Search your deck for up to 3 basic Energy cards and attach them to your Pokémon V in any way you like. Then, shuffle your deck.",
+			fr: "Cherchez dans votre deck jusqu'à 3 cartes Énergie de base, puis attachez-les à vos Pokémon-V comme il vous plaît. Mélangez ensuite votre deck.",
+			es: "Busca en tu baraja hasta 3 cartas de Energía Básica y únelas a tus Pokémon V de la manera que desees. Después, baraja las cartas de tu baraja.",
+			it: "Cerca nel tuo mazzo fino a tre carte Energia base e assegnale ai tuoi Pokémon-V nel modo che preferisci. Poi rimischia le carte del tuo mazzo.",
+			pt: "Procure por até 3 cartas de Energia básica no seu baralho e ligue-as aos seus Pokémon V como desejar. Em seguida, embaralhe o seu baralho.",
+			de: "Durchsuche dein Deck nach bis zu 3 Basis-Energiekarten und lege sie beliebig an deine Pokémon-V an. Mische anschließend dein Deck."
+		},
+
+		damage: 200
+	}],
+
+	weaknesses: [{
+		type: "Fighting",
+		value: "×2"
+	}],
+
+	retreat: 2,
+
+	variants: {
+		normal: false,
+		reverse: false,
+		holo: true,
+		firstEdition: false
+	},
+
+	regulationMark: "F"
+}
+
+export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH307.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH307.ts
@@ -85,12 +85,11 @@ const card: Card = {
 
 	retreat: 2,
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
+	variants: [
+			{
+				type: "holo",
+			}
+		],
 
 	regulationMark: "F"
 }


### PR DESCRIPTION
## Changes

Added missing cards to Sword & Shield / SWSH Black Star Promos.

## Details

Added SWSH075, SWSH282-SWSH284, SWSH287-SWSH290, SWSH292-SWSH293, SWSH301-SWSH302, and SWSH306-SWSH307.

The new entries include available card data, variants, Portuguese attack text for Morpeko V-UNION SWSH287-SWSH290, and localized data where available from official Pokémon/Limitless sources.