### PR TITLE
(data): Move thirdParty into variants for Base Set

### DIFF
--- a/data/Base/Base Set/1.ts
+++ b/data/Base/Base Set/1.ts
@@ -86,7 +86,15 @@ const card: Card = {
 	variants: [
 		{
 			type: "holo",
-			subtype: "unlimited",
+			subtype: "1999-2000-copyright",
+			thirdParty: {
+				cardmarket: 273696,
+				tcgplayer: 42346
+			}
+		},
+		{
+			type: "holo",
+			subtype: "unlimited"
 		},
 		{
 			type: "holo",
@@ -96,10 +104,9 @@ const card: Card = {
 		{
 			type: "holo",
 			subtype: "shadowless",
-		},
-		{
-			type: "holo",
-			subtype: "1999-2000-copyright",
+			thirdParty: {
+				cardmarket: 660227
+			}
 		}
 	],
 
@@ -108,10 +115,6 @@ const card: Card = {
 		it: "Il suo cervello è più potente di un supercomputer. Dicono che abbia un quoziente di intelligenza di 5.000. LIV 42 N.65"
 	},
 
-	thirdParty: {
-		cardmarket: 273696,
-		tcgplayer: 42346
-	}
 }
 
 export default card

--- a/data/Base/Base Set/1.ts
+++ b/data/Base/Base Set/1.ts
@@ -86,15 +86,11 @@ const card: Card = {
 	variants: [
 		{
 			type: "holo",
-			subtype: "1999-2000-copyright",
+			subtype: "unlimited",
 			thirdParty: {
 				cardmarket: 273696,
 				tcgplayer: 42346
 			}
-		},
-		{
-			type: "holo",
-			subtype: "unlimited"
 		},
 		{
 			type: "holo",
@@ -107,6 +103,10 @@ const card: Card = {
 			thirdParty: {
 				cardmarket: 660227
 			}
+		},
+		{
+			type: "holo",
+			subtype: "1999-2000-copyright"
 		}
 	],
 

--- a/data/Base/Base Set/1.ts
+++ b/data/Base/Base Set/1.ts
@@ -86,7 +86,16 @@ const card: Card = {
 	variants: [
 		{
 			type: "holo",
-			subtype: "unlimited",
+			subtype: "1999-2000-copyright",
+		},
+		{
+			type: "holo",
+			subtype: "unlimited"
+		},
+		{
+			type: "holo",
+			subtype: "shadowless",
+			stamp: ["1st-edition"],
 			thirdParty: {
 				cardmarket: 273696,
 				tcgplayer: 42346
@@ -95,18 +104,9 @@ const card: Card = {
 		{
 			type: "holo",
 			subtype: "shadowless",
-			stamp: ["1st-edition"]
-		},
-		{
-			type: "holo",
-			subtype: "shadowless",
 			thirdParty: {
 				cardmarket: 660227
 			}
-		},
-		{
-			type: "holo",
-			subtype: "1999-2000-copyright"
 		}
 	],
 

--- a/data/Base/Base Set/10.ts
+++ b/data/Base/Base Set/10.ts
@@ -83,15 +83,11 @@ const card: Card = {
 	variants: [
 		{
 			type: "holo",
-			subtype: "1999-2000-copyright",
+			subtype: "unlimited",
 			thirdParty: {
 				cardmarket: 273705,
 				tcgplayer: 42347
 			}
-		},
-		{
-			type: "holo",
-			subtype: "unlimited"
 		},
 		{
 			type: "holo",
@@ -104,6 +100,10 @@ const card: Card = {
 			thirdParty: {
 				cardmarket: 660218
 			}
+		},
+		{
+			type: "holo",
+			subtype: "1999-2000-copyright"
 		}
 	],
 

--- a/data/Base/Base Set/10.ts
+++ b/data/Base/Base Set/10.ts
@@ -83,7 +83,15 @@ const card: Card = {
 	variants: [
 		{
 			type: "holo",
-			subtype: "unlimited",
+			subtype: "1999-2000-copyright",
+			thirdParty: {
+				cardmarket: 273705,
+				tcgplayer: 42347
+			}
+		},
+		{
+			type: "holo",
+			subtype: "unlimited"
 		},
 		{
 			type: "holo",
@@ -93,18 +101,13 @@ const card: Card = {
 		{
 			type: "holo",
 			subtype: "shadowless",
-		},
-		{
-			type: "holo",
-			subtype: "1999-2000-copyright",
+			thirdParty: {
+				cardmarket: 660218
+			}
 		}
 	],
 
 
-	thirdParty: {
-		cardmarket: 273705,
-		tcgplayer: 42347
-	}
 }
 
 export default card

--- a/data/Base/Base Set/10.ts
+++ b/data/Base/Base Set/10.ts
@@ -83,7 +83,16 @@ const card: Card = {
 	variants: [
 		{
 			type: "holo",
-			subtype: "unlimited",
+			subtype: "1999-2000-copyright",
+		},
+		{
+			type: "holo",
+			subtype: "unlimited"
+		},
+		{
+			type: "holo",
+			subtype: "shadowless",
+			stamp: ["1st-edition"],
 			thirdParty: {
 				cardmarket: 273705,
 				tcgplayer: 42347
@@ -92,18 +101,9 @@ const card: Card = {
 		{
 			type: "holo",
 			subtype: "shadowless",
-			stamp: ["1st-edition"]
-		},
-		{
-			type: "holo",
-			subtype: "shadowless",
 			thirdParty: {
 				cardmarket: 660218
 			}
-		},
-		{
-			type: "holo",
-			subtype: "1999-2000-copyright"
 		}
 	],
 

--- a/data/Base/Base Set/100.ts
+++ b/data/Base/Base Set/100.ts
@@ -16,14 +16,18 @@ const card: Card = {
 	stage: "Basic",
 	energyType: "Normal",
 
-	thirdParty: {
-		cardmarket: 273795,
-		tcgplayer: 42348
-	},
 	variants: [
 		{
 			type: "normal",
-			subtype: "unlimited",
+			subtype: "1999-2000-copyright",
+			thirdParty: {
+				cardmarket: 273795,
+				tcgplayer: 42348
+			}
+		},
+		{
+			type: "normal",
+			subtype: "unlimited"
 		},
 		{
 			type: "normal",
@@ -33,10 +37,9 @@ const card: Card = {
 		{
 			type: "normal",
 			subtype: "shadowless",
-		},
-		{
-			type: "normal",
-			subtype: "1999-2000-copyright",
+			thirdParty: {
+				cardmarket: 660101
+			}
 		}
 	],
 }

--- a/data/Base/Base Set/100.ts
+++ b/data/Base/Base Set/100.ts
@@ -19,15 +19,11 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
-			subtype: "1999-2000-copyright",
+			subtype: "unlimited",
 			thirdParty: {
 				cardmarket: 273795,
 				tcgplayer: 42348
 			}
-		},
-		{
-			type: "normal",
-			subtype: "unlimited"
 		},
 		{
 			type: "normal",
@@ -40,6 +36,10 @@ const card: Card = {
 			thirdParty: {
 				cardmarket: 660101
 			}
+		},
+		{
+			type: "normal",
+			subtype: "1999-2000-copyright"
 		}
 	],
 }

--- a/data/Base/Base Set/100.ts
+++ b/data/Base/Base Set/100.ts
@@ -19,7 +19,16 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
-			subtype: "unlimited",
+			subtype: "1999-2000-copyright",
+		},
+		{
+			type: "normal",
+			subtype: "unlimited"
+		},
+		{
+			type: "normal",
+			subtype: "shadowless",
+			stamp: ["1st-edition"],
 			thirdParty: {
 				cardmarket: 273795,
 				tcgplayer: 42348
@@ -28,18 +37,9 @@ const card: Card = {
 		{
 			type: "normal",
 			subtype: "shadowless",
-			stamp: ["1st-edition"]
-		},
-		{
-			type: "normal",
-			subtype: "shadowless",
 			thirdParty: {
 				cardmarket: 660101
 			}
-		},
-		{
-			type: "normal",
-			subtype: "1999-2000-copyright"
 		}
 	],
 }

--- a/data/Base/Base Set/101.ts
+++ b/data/Base/Base Set/101.ts
@@ -16,14 +16,18 @@ const card: Card = {
 	stage: "Basic",
 	energyType: "Normal",
 
-	thirdParty: {
-		cardmarket: 273796,
-		tcgplayer: 42349
-	},
 	variants: [
 		{
 			type: "normal",
-			subtype: "unlimited",
+			subtype: "1999-2000-copyright",
+			thirdParty: {
+				cardmarket: 273796,
+				tcgplayer: 42349
+			}
+		},
+		{
+			type: "normal",
+			subtype: "unlimited"
 		},
 		{
 			type: "normal",
@@ -33,10 +37,9 @@ const card: Card = {
 		{
 			type: "normal",
 			subtype: "shadowless",
-		},
-		{
-			type: "normal",
-			subtype: "1999-2000-copyright",
+			thirdParty: {
+				cardmarket: 660098
+			}
 		}
 	],
 }

--- a/data/Base/Base Set/101.ts
+++ b/data/Base/Base Set/101.ts
@@ -19,15 +19,11 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
-			subtype: "1999-2000-copyright",
+			subtype: "unlimited",
 			thirdParty: {
 				cardmarket: 273796,
 				tcgplayer: 42349
 			}
-		},
-		{
-			type: "normal",
-			subtype: "unlimited"
 		},
 		{
 			type: "normal",
@@ -40,6 +36,10 @@ const card: Card = {
 			thirdParty: {
 				cardmarket: 660098
 			}
+		},
+		{
+			type: "normal",
+			subtype: "1999-2000-copyright"
 		}
 	],
 }

--- a/data/Base/Base Set/101.ts
+++ b/data/Base/Base Set/101.ts
@@ -19,7 +19,16 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
-			subtype: "unlimited",
+			subtype: "1999-2000-copyright",
+		},
+		{
+			type: "normal",
+			subtype: "unlimited"
+		},
+		{
+			type: "normal",
+			subtype: "shadowless",
+			stamp: ["1st-edition"],
 			thirdParty: {
 				cardmarket: 273796,
 				tcgplayer: 42349
@@ -28,18 +37,9 @@ const card: Card = {
 		{
 			type: "normal",
 			subtype: "shadowless",
-			stamp: ["1st-edition"]
-		},
-		{
-			type: "normal",
-			subtype: "shadowless",
 			thirdParty: {
 				cardmarket: 660098
 			}
-		},
-		{
-			type: "normal",
-			subtype: "1999-2000-copyright"
 		}
 	],
 }

--- a/data/Base/Base Set/102.ts
+++ b/data/Base/Base Set/102.ts
@@ -16,14 +16,18 @@ const card: Card = {
 	stage: "Basic",
 	energyType: "Normal",
 
-	thirdParty: {
-		cardmarket: 273797,
-		tcgplayer: 42350
-	},
 	variants: [
 		{
 			type: "normal",
-			subtype: "unlimited",
+			subtype: "1999-2000-copyright",
+			thirdParty: {
+				cardmarket: 273797,
+				tcgplayer: 42350
+			}
+		},
+		{
+			type: "normal",
+			subtype: "unlimited"
 		},
 		{
 			type: "normal",
@@ -33,10 +37,9 @@ const card: Card = {
 		{
 			type: "normal",
 			subtype: "shadowless",
-		},
-		{
-			type: "normal",
-			subtype: "1999-2000-copyright",
+			thirdParty: {
+				cardmarket: 660096
+			}
 		}
 	],
 }

--- a/data/Base/Base Set/102.ts
+++ b/data/Base/Base Set/102.ts
@@ -19,15 +19,11 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
-			subtype: "1999-2000-copyright",
+			subtype: "unlimited",
 			thirdParty: {
 				cardmarket: 273797,
 				tcgplayer: 42350
 			}
-		},
-		{
-			type: "normal",
-			subtype: "unlimited"
 		},
 		{
 			type: "normal",
@@ -40,6 +36,10 @@ const card: Card = {
 			thirdParty: {
 				cardmarket: 660096
 			}
+		},
+		{
+			type: "normal",
+			subtype: "1999-2000-copyright"
 		}
 	],
 }

--- a/data/Base/Base Set/102.ts
+++ b/data/Base/Base Set/102.ts
@@ -19,7 +19,16 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
-			subtype: "unlimited",
+			subtype: "1999-2000-copyright",
+		},
+		{
+			type: "normal",
+			subtype: "unlimited"
+		},
+		{
+			type: "normal",
+			subtype: "shadowless",
+			stamp: ["1st-edition"],
 			thirdParty: {
 				cardmarket: 273797,
 				tcgplayer: 42350
@@ -28,18 +37,9 @@ const card: Card = {
 		{
 			type: "normal",
 			subtype: "shadowless",
-			stamp: ["1st-edition"]
-		},
-		{
-			type: "normal",
-			subtype: "shadowless",
 			thirdParty: {
 				cardmarket: 660096
 			}
-		},
-		{
-			type: "normal",
-			subtype: "1999-2000-copyright"
 		}
 	],
 }

--- a/data/Base/Base Set/11.ts
+++ b/data/Base/Base Set/11.ts
@@ -92,15 +92,11 @@ const card: Card = {
 	variants: [
 		{
 			type: "holo",
-			subtype: "1999-2000-copyright",
+			subtype: "unlimited",
 			thirdParty: {
 				cardmarket: 273706,
 				tcgplayer: 42351
 			}
-		},
-		{
-			type: "holo",
-			subtype: "unlimited"
 		},
 		{
 			type: "holo",
@@ -113,6 +109,10 @@ const card: Card = {
 			thirdParty: {
 				cardmarket: 660217
 			}
+		},
+		{
+			type: "holo",
+			subtype: "1999-2000-copyright"
 		}
 	],
 

--- a/data/Base/Base Set/11.ts
+++ b/data/Base/Base Set/11.ts
@@ -92,7 +92,15 @@ const card: Card = {
 	variants: [
 		{
 			type: "holo",
-			subtype: "unlimited",
+			subtype: "1999-2000-copyright",
+			thirdParty: {
+				cardmarket: 273706,
+				tcgplayer: 42351
+			}
+		},
+		{
+			type: "holo",
+			subtype: "unlimited"
 		},
 		{
 			type: "holo",
@@ -102,18 +110,13 @@ const card: Card = {
 		{
 			type: "holo",
 			subtype: "shadowless",
-		},
-		{
-			type: "holo",
-			subtype: "1999-2000-copyright",
+			thirdParty: {
+				cardmarket: 660217
+			}
 		}
 	],
 
 
-	thirdParty: {
-		cardmarket: 273706,
-		tcgplayer: 42351
-	}
 }
 
 export default card

--- a/data/Base/Base Set/11.ts
+++ b/data/Base/Base Set/11.ts
@@ -92,7 +92,16 @@ const card: Card = {
 	variants: [
 		{
 			type: "holo",
-			subtype: "unlimited",
+			subtype: "1999-2000-copyright",
+		},
+		{
+			type: "holo",
+			subtype: "unlimited"
+		},
+		{
+			type: "holo",
+			subtype: "shadowless",
+			stamp: ["1st-edition"],
 			thirdParty: {
 				cardmarket: 273706,
 				tcgplayer: 42351
@@ -101,18 +110,9 @@ const card: Card = {
 		{
 			type: "holo",
 			subtype: "shadowless",
-			stamp: ["1st-edition"]
-		},
-		{
-			type: "holo",
-			subtype: "shadowless",
 			thirdParty: {
 				cardmarket: 660217
 			}
-		},
-		{
-			type: "holo",
-			subtype: "1999-2000-copyright"
 		}
 	],
 

--- a/data/Base/Base Set/12.ts
+++ b/data/Base/Base Set/12.ts
@@ -86,7 +86,15 @@ const card: Card = {
 	variants: [
 		{
 			type: "holo",
-			subtype: "unlimited",
+			subtype: "1999-2000-copyright",
+			thirdParty: {
+				cardmarket: 273707,
+				tcgplayer: 42352
+			}
+		},
+		{
+			type: "holo",
+			subtype: "unlimited"
 		},
 		{
 			type: "holo",
@@ -96,10 +104,9 @@ const card: Card = {
 		{
 			type: "holo",
 			subtype: "shadowless",
-		},
-		{
-			type: "holo",
-			subtype: "1999-2000-copyright",
+			thirdParty: {
+				cardmarket: 660216
+			}
 		}
 	],
 
@@ -109,10 +116,6 @@ const card: Card = {
 		it: "Molto intelligente, ma anche molto vendicativo. Chi osa afferrare una delle sue numerose code viene punito con una maledizione che durerà 1.000 anni. LIV 32 N.38"
 	},
 
-	thirdParty: {
-		cardmarket: 273707,
-		tcgplayer: 42352
-	}
 }
 
 export default card

--- a/data/Base/Base Set/12.ts
+++ b/data/Base/Base Set/12.ts
@@ -86,15 +86,11 @@ const card: Card = {
 	variants: [
 		{
 			type: "holo",
-			subtype: "1999-2000-copyright",
+			subtype: "unlimited",
 			thirdParty: {
 				cardmarket: 273707,
 				tcgplayer: 42352
 			}
-		},
-		{
-			type: "holo",
-			subtype: "unlimited"
 		},
 		{
 			type: "holo",
@@ -107,6 +103,10 @@ const card: Card = {
 			thirdParty: {
 				cardmarket: 660216
 			}
+		},
+		{
+			type: "holo",
+			subtype: "1999-2000-copyright"
 		}
 	],
 

--- a/data/Base/Base Set/12.ts
+++ b/data/Base/Base Set/12.ts
@@ -86,7 +86,16 @@ const card: Card = {
 	variants: [
 		{
 			type: "holo",
-			subtype: "unlimited",
+			subtype: "1999-2000-copyright",
+		},
+		{
+			type: "holo",
+			subtype: "unlimited"
+		},
+		{
+			type: "holo",
+			subtype: "shadowless",
+			stamp: ["1st-edition"],
 			thirdParty: {
 				cardmarket: 273707,
 				tcgplayer: 42352
@@ -95,18 +104,9 @@ const card: Card = {
 		{
 			type: "holo",
 			subtype: "shadowless",
-			stamp: ["1st-edition"]
-		},
-		{
-			type: "holo",
-			subtype: "shadowless",
 			thirdParty: {
 				cardmarket: 660216
 			}
-		},
-		{
-			type: "holo",
-			subtype: "1999-2000-copyright"
 		}
 	],
 

--- a/data/Base/Base Set/13.ts
+++ b/data/Base/Base Set/13.ts
@@ -93,7 +93,15 @@ const card: Card = {
 	variants: [
 		{
 			type: "holo",
-			subtype: "unlimited",
+			subtype: "1999-2000-copyright",
+			thirdParty: {
+				cardmarket: 273708,
+				tcgplayer: 42353
+			}
+		},
+		{
+			type: "holo",
+			subtype: "unlimited"
 		},
 		{
 			type: "holo",
@@ -103,18 +111,13 @@ const card: Card = {
 		{
 			type: "holo",
 			subtype: "shadowless",
-		},
-		{
-			type: "holo",
-			subtype: "1999-2000-copyright",
+			thirdParty: {
+				cardmarket: 660215
+			}
 		}
 	],
 
 
-	thirdParty: {
-		cardmarket: 273708,
-		tcgplayer: 42353
-	}
 }
 
 export default card

--- a/data/Base/Base Set/13.ts
+++ b/data/Base/Base Set/13.ts
@@ -93,15 +93,11 @@ const card: Card = {
 	variants: [
 		{
 			type: "holo",
-			subtype: "1999-2000-copyright",
+			subtype: "unlimited",
 			thirdParty: {
 				cardmarket: 273708,
 				tcgplayer: 42353
 			}
-		},
-		{
-			type: "holo",
-			subtype: "unlimited"
 		},
 		{
 			type: "holo",
@@ -114,6 +110,10 @@ const card: Card = {
 			thirdParty: {
 				cardmarket: 660215
 			}
+		},
+		{
+			type: "holo",
+			subtype: "1999-2000-copyright"
 		}
 	],
 

--- a/data/Base/Base Set/13.ts
+++ b/data/Base/Base Set/13.ts
@@ -93,7 +93,16 @@ const card: Card = {
 	variants: [
 		{
 			type: "holo",
-			subtype: "unlimited",
+			subtype: "1999-2000-copyright",
+		},
+		{
+			type: "holo",
+			subtype: "unlimited"
+		},
+		{
+			type: "holo",
+			subtype: "shadowless",
+			stamp: ["1st-edition"],
 			thirdParty: {
 				cardmarket: 273708,
 				tcgplayer: 42353
@@ -102,18 +111,9 @@ const card: Card = {
 		{
 			type: "holo",
 			subtype: "shadowless",
-			stamp: ["1st-edition"]
-		},
-		{
-			type: "holo",
-			subtype: "shadowless",
 			thirdParty: {
 				cardmarket: 660215
 			}
-		},
-		{
-			type: "holo",
-			subtype: "1999-2000-copyright"
 		}
 	],
 

--- a/data/Base/Base Set/14.ts
+++ b/data/Base/Base Set/14.ts
@@ -93,15 +93,11 @@ const card: Card = {
 	variants: [
 		{
 			type: "holo",
-			subtype: "1999-2000-copyright",
+			subtype: "unlimited",
 			thirdParty: {
 				cardmarket: 273709,
 				tcgplayer: 42354
 			}
-		},
-		{
-			type: "holo",
-			subtype: "unlimited"
 		},
 		{
 			type: "holo",
@@ -114,6 +110,10 @@ const card: Card = {
 			thirdParty: {
 				cardmarket: 660214
 			}
+		},
+		{
+			type: "holo",
+			subtype: "1999-2000-copyright"
 		}
 	],
 

--- a/data/Base/Base Set/14.ts
+++ b/data/Base/Base Set/14.ts
@@ -93,7 +93,15 @@ const card: Card = {
 	variants: [
 		{
 			type: "holo",
-			subtype: "unlimited",
+			subtype: "1999-2000-copyright",
+			thirdParty: {
+				cardmarket: 273709,
+				tcgplayer: 42354
+			}
+		},
+		{
+			type: "holo",
+			subtype: "unlimited"
 		},
 		{
 			type: "holo",
@@ -103,18 +111,13 @@ const card: Card = {
 		{
 			type: "holo",
 			subtype: "shadowless",
-		},
-		{
-			type: "holo",
-			subtype: "1999-2000-copyright",
+			thirdParty: {
+				cardmarket: 660214
+			}
 		}
 	],
 
 
-	thirdParty: {
-		cardmarket: 273709,
-		tcgplayer: 42354
-	}
 }
 
 export default card

--- a/data/Base/Base Set/14.ts
+++ b/data/Base/Base Set/14.ts
@@ -93,7 +93,16 @@ const card: Card = {
 	variants: [
 		{
 			type: "holo",
-			subtype: "unlimited",
+			subtype: "1999-2000-copyright",
+		},
+		{
+			type: "holo",
+			subtype: "unlimited"
+		},
+		{
+			type: "holo",
+			subtype: "shadowless",
+			stamp: ["1st-edition"],
 			thirdParty: {
 				cardmarket: 273709,
 				tcgplayer: 42354
@@ -102,18 +111,9 @@ const card: Card = {
 		{
 			type: "holo",
 			subtype: "shadowless",
-			stamp: ["1st-edition"]
-		},
-		{
-			type: "holo",
-			subtype: "shadowless",
 			thirdParty: {
 				cardmarket: 660214
 			}
-		},
-		{
-			type: "holo",
-			subtype: "1999-2000-copyright"
 		}
 	],
 

--- a/data/Base/Base Set/15.ts
+++ b/data/Base/Base Set/15.ts
@@ -85,7 +85,15 @@ const card: Card = {
 	variants: [
 		{
 			type: "holo",
-			subtype: "unlimited",
+			subtype: "1999-2000-copyright",
+			thirdParty: {
+				cardmarket: 273710,
+				tcgplayer: 42355
+			}
+		},
+		{
+			type: "holo",
+			subtype: "unlimited"
 		},
 		{
 			type: "holo",
@@ -95,18 +103,20 @@ const card: Card = {
 		{
 			type: "holo",
 			subtype: "shadowless",
+			thirdParty: {
+				cardmarket: 660213
+			}
 		},
 		{
 			type: "holo",
-			subtype: "1999-2000-copyright",
+			cardmarketLabels: ["Defencing Pckemon"],
+			thirdParty: {
+				cardmarket: 273938
+			}
 		}
 	],
 
 
-	thirdParty: {
-		cardmarket: 273710,
-		tcgplayer: 42355
-	}
 }
 
 export default card

--- a/data/Base/Base Set/15.ts
+++ b/data/Base/Base Set/15.ts
@@ -85,15 +85,11 @@ const card: Card = {
 	variants: [
 		{
 			type: "holo",
-			subtype: "1999-2000-copyright",
+			subtype: "unlimited",
 			thirdParty: {
 				cardmarket: 273710,
 				tcgplayer: 42355
 			}
-		},
-		{
-			type: "holo",
-			subtype: "unlimited"
 		},
 		{
 			type: "holo",
@@ -109,10 +105,7 @@ const card: Card = {
 		},
 		{
 			type: "holo",
-			cardmarketLabels: ["Defencing Pckemon"],
-			thirdParty: {
-				cardmarket: 273938
-			}
+			subtype: "1999-2000-copyright"
 		}
 	],
 

--- a/data/Base/Base Set/15.ts
+++ b/data/Base/Base Set/15.ts
@@ -85,7 +85,16 @@ const card: Card = {
 	variants: [
 		{
 			type: "holo",
-			subtype: "unlimited",
+			subtype: "1999-2000-copyright",
+		},
+		{
+			type: "holo",
+			subtype: "unlimited"
+		},
+		{
+			type: "holo",
+			subtype: "shadowless",
+			stamp: ["1st-edition"],
 			thirdParty: {
 				cardmarket: 273710,
 				tcgplayer: 42355
@@ -94,19 +103,10 @@ const card: Card = {
 		{
 			type: "holo",
 			subtype: "shadowless",
-			stamp: ["1st-edition"]
-		},
-		{
-			type: "holo",
-			subtype: "shadowless",
 			thirdParty: {
 				cardmarket: 660213
 			}
 		},
-		{
-			type: "holo",
-			subtype: "1999-2000-copyright"
-		}
 	],
 
 

--- a/data/Base/Base Set/16.ts
+++ b/data/Base/Base Set/16.ts
@@ -88,15 +88,11 @@ const card: Card = {
 	variants: [
 		{
 			type: "holo",
-			subtype: "1999-2000-copyright",
+			subtype: "unlimited",
 			thirdParty: {
 				cardmarket: 273711,
 				tcgplayer: 42356
 			}
-		},
-		{
-			type: "holo",
-			subtype: "unlimited"
 		},
 		{
 			type: "holo",
@@ -109,6 +105,10 @@ const card: Card = {
 			thirdParty: {
 				cardmarket: 660212
 			}
+		},
+		{
+			type: "holo",
+			subtype: "1999-2000-copyright"
 		}
 	],
 

--- a/data/Base/Base Set/16.ts
+++ b/data/Base/Base Set/16.ts
@@ -88,7 +88,15 @@ const card: Card = {
 	variants: [
 		{
 			type: "holo",
-			subtype: "unlimited",
+			subtype: "1999-2000-copyright",
+			thirdParty: {
+				cardmarket: 273711,
+				tcgplayer: 42356
+			}
+		},
+		{
+			type: "holo",
+			subtype: "unlimited"
 		},
 		{
 			type: "holo",
@@ -98,18 +106,13 @@ const card: Card = {
 		{
 			type: "holo",
 			subtype: "shadowless",
-		},
-		{
-			type: "holo",
-			subtype: "1999-2000-copyright",
+			thirdParty: {
+				cardmarket: 660212
+			}
 		}
 	],
 
 
-	thirdParty: {
-		cardmarket: 273711,
-		tcgplayer: 42356
-	}
 }
 
 export default card

--- a/data/Base/Base Set/16.ts
+++ b/data/Base/Base Set/16.ts
@@ -88,7 +88,16 @@ const card: Card = {
 	variants: [
 		{
 			type: "holo",
-			subtype: "unlimited",
+			subtype: "1999-2000-copyright",
+		},
+		{
+			type: "holo",
+			subtype: "unlimited"
+		},
+		{
+			type: "holo",
+			subtype: "shadowless",
+			stamp: ["1st-edition"],
 			thirdParty: {
 				cardmarket: 273711,
 				tcgplayer: 42356
@@ -97,18 +106,9 @@ const card: Card = {
 		{
 			type: "holo",
 			subtype: "shadowless",
-			stamp: ["1st-edition"]
-		},
-		{
-			type: "holo",
-			subtype: "shadowless",
 			thirdParty: {
 				cardmarket: 660212
 			}
-		},
-		{
-			type: "holo",
-			subtype: "1999-2000-copyright"
 		}
 	],
 

--- a/data/Base/Base Set/17.ts
+++ b/data/Base/Base Set/17.ts
@@ -94,15 +94,11 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
-			subtype: "1999-2000-copyright",
+			subtype: "unlimited",
 			thirdParty: {
 				cardmarket: 273712,
 				tcgplayer: 42357
 			}
-		},
-		{
-			type: "normal",
-			subtype: "unlimited"
 		},
 		{
 			type: "normal",
@@ -111,18 +107,14 @@ const card: Card = {
 		},
 		{
 			type: "normal",
-			subtype: "shadowless"
-		},
-		{
-			type: "V2",
-			cardmarketLabels: ["Eyliesiieeieeemaiie", "Resis", "Speed Cod Strack"]
-		},
-		{
-			type: "V2",
-			cardmarketLabels: ["Eyliesiieeieeemaiie", "Resis", "Speed Cod Strack"],
+			subtype: "shadowless",
 			thirdParty: {
 				cardmarket: 660211
 			}
+		},
+		{
+			type: "normal",
+			subtype: "1999-2000-copyright"
 		}
 	],
 

--- a/data/Base/Base Set/17.ts
+++ b/data/Base/Base Set/17.ts
@@ -94,7 +94,15 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
-			subtype: "unlimited",
+			subtype: "1999-2000-copyright",
+			thirdParty: {
+				cardmarket: 273712,
+				tcgplayer: 42357
+			}
+		},
+		{
+			type: "normal",
+			subtype: "unlimited"
 		},
 		{
 			type: "normal",
@@ -103,11 +111,18 @@ const card: Card = {
 		},
 		{
 			type: "normal",
-			subtype: "shadowless",
+			subtype: "shadowless"
 		},
 		{
-			type: "normal",
-			subtype: "1999-2000-copyright",
+			type: "V2",
+			cardmarketLabels: ["Eyliesiieeieeemaiie", "Resis", "Speed Cod Strack"]
+		},
+		{
+			type: "V2",
+			cardmarketLabels: ["Eyliesiieeieeemaiie", "Resis", "Speed Cod Strack"],
+			thirdParty: {
+				cardmarket: 660211
+			}
 		}
 	],
 
@@ -116,10 +131,6 @@ const card: Card = {
 		it: " Vola ad alta velocità e attacca con i grandi pungiglioni velenosi che ha sulle zampe anteriori e sulla coda. LIV 32 N.15"
 	},
 
-	thirdParty: {
-		cardmarket: 273712,
-		tcgplayer: 42357
-	}
 }
 
 export default card

--- a/data/Base/Base Set/17.ts
+++ b/data/Base/Base Set/17.ts
@@ -94,7 +94,16 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
-			subtype: "unlimited",
+			subtype: "1999-2000-copyright",
+		},
+		{
+			type: "normal",
+			subtype: "unlimited"
+		},
+		{
+			type: "normal",
+			subtype: "shadowless",
+			stamp: ["1st-edition"],
 			thirdParty: {
 				cardmarket: 273712,
 				tcgplayer: 42357
@@ -102,20 +111,8 @@ const card: Card = {
 		},
 		{
 			type: "normal",
-			subtype: "shadowless",
-			stamp: ["1st-edition"]
+			subtype: "shadowless"
 		},
-		{
-			type: "normal",
-			subtype: "shadowless",
-			thirdParty: {
-				cardmarket: 660211
-			}
-		},
-		{
-			type: "normal",
-			subtype: "1999-2000-copyright"
-		}
 	],
 
 	description: {

--- a/data/Base/Base Set/18.ts
+++ b/data/Base/Base Set/18.ts
@@ -81,15 +81,11 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
-			subtype: "1999-2000-copyright",
+			subtype: "unlimited",
 			thirdParty: {
 				cardmarket: 273713,
 				tcgplayer: 42358
 			}
-		},
-		{
-			type: "normal",
-			subtype: "unlimited"
 		},
 		{
 			type: "normal",
@@ -102,6 +98,10 @@ const card: Card = {
 			thirdParty: {
 				cardmarket: 660210
 			}
+		},
+		{
+			type: "normal",
+			subtype: "1999-2000-copyright"
 		}
 	],
 

--- a/data/Base/Base Set/18.ts
+++ b/data/Base/Base Set/18.ts
@@ -81,7 +81,15 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
-			subtype: "unlimited",
+			subtype: "1999-2000-copyright",
+			thirdParty: {
+				cardmarket: 273713,
+				tcgplayer: 42358
+			}
+		},
+		{
+			type: "normal",
+			subtype: "unlimited"
 		},
 		{
 			type: "normal",
@@ -91,10 +99,9 @@ const card: Card = {
 		{
 			type: "normal",
 			subtype: "shadowless",
-		},
-		{
-			type: "normal",
-			subtype: "1999-2000-copyright",
+			thirdParty: {
+				cardmarket: 660210
+			}
 		}
 	],
 
@@ -110,10 +117,6 @@ const card: Card = {
 		it: "Pokémon mistico con un'indole gentile. Ha l'abilità di cambiare le condizioni climatiche. LIV 33 N.148"
 	},
 
-	thirdParty: {
-		cardmarket: 273713,
-		tcgplayer: 42358
-	}
 }
 
 export default card

--- a/data/Base/Base Set/18.ts
+++ b/data/Base/Base Set/18.ts
@@ -81,7 +81,16 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
-			subtype: "unlimited",
+			subtype: "1999-2000-copyright",
+		},
+		{
+			type: "normal",
+			subtype: "unlimited"
+		},
+		{
+			type: "normal",
+			subtype: "shadowless",
+			stamp: ["1st-edition"],
 			thirdParty: {
 				cardmarket: 273713,
 				tcgplayer: 42358
@@ -90,18 +99,9 @@ const card: Card = {
 		{
 			type: "normal",
 			subtype: "shadowless",
-			stamp: ["1st-edition"]
-		},
-		{
-			type: "normal",
-			subtype: "shadowless",
 			thirdParty: {
 				cardmarket: 660210
 			}
-		},
-		{
-			type: "normal",
-			subtype: "1999-2000-copyright"
 		}
 	],
 

--- a/data/Base/Base Set/19.ts
+++ b/data/Base/Base Set/19.ts
@@ -90,15 +90,11 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
-			subtype: "1999-2000-copyright",
+			subtype: "unlimited",
 			thirdParty: {
 				cardmarket: 273714,
 				tcgplayer: 42359
 			}
-		},
-		{
-			type: "normal",
-			subtype: "unlimited"
 		},
 		{
 			type: "normal",
@@ -111,6 +107,10 @@ const card: Card = {
 			thirdParty: {
 				cardmarket: 660209
 			}
+		},
+		{
+			type: "normal",
+			subtype: "1999-2000-copyright"
 		}
 	],
 

--- a/data/Base/Base Set/19.ts
+++ b/data/Base/Base Set/19.ts
@@ -90,7 +90,15 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
-			subtype: "unlimited",
+			subtype: "1999-2000-copyright",
+			thirdParty: {
+				cardmarket: 273714,
+				tcgplayer: 42359
+			}
+		},
+		{
+			type: "normal",
+			subtype: "unlimited"
 		},
 		{
 			type: "normal",
@@ -100,10 +108,9 @@ const card: Card = {
 		{
 			type: "normal",
 			subtype: "shadowless",
-		},
-		{
-			type: "normal",
-			subtype: "1999-2000-copyright",
+			thirdParty: {
+				cardmarket: 660209
+			}
 		}
 	],
 
@@ -112,10 +119,6 @@ const card: Card = {
 		it: "Terzetto di Diglett che scatena disastrosi terremoti. LIV 36 N.51"
 	},
 
-	thirdParty: {
-		cardmarket: 273714,
-		tcgplayer: 42359
-	}
 }
 
 export default card

--- a/data/Base/Base Set/19.ts
+++ b/data/Base/Base Set/19.ts
@@ -90,7 +90,16 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
-			subtype: "unlimited",
+			subtype: "1999-2000-copyright",
+		},
+		{
+			type: "normal",
+			subtype: "unlimited"
+		},
+		{
+			type: "normal",
+			subtype: "shadowless",
+			stamp: ["1st-edition"],
 			thirdParty: {
 				cardmarket: 273714,
 				tcgplayer: 42359
@@ -99,18 +108,9 @@ const card: Card = {
 		{
 			type: "normal",
 			subtype: "shadowless",
-			stamp: ["1st-edition"]
-		},
-		{
-			type: "normal",
-			subtype: "shadowless",
 			thirdParty: {
 				cardmarket: 660209
 			}
-		},
-		{
-			type: "normal",
-			subtype: "1999-2000-copyright"
 		}
 	],
 

--- a/data/Base/Base Set/2.ts
+++ b/data/Base/Base Set/2.ts
@@ -91,7 +91,15 @@ const card: Card = {
 	variants: [
 		{
 			type: "holo",
-			subtype: "unlimited",
+			subtype: "1999-2000-copyright",
+			thirdParty: {
+				cardmarket: 273697,
+				tcgplayer: 42360
+			}
+		},
+		{
+			type: "holo",
+			subtype: "unlimited"
 		},
 		{
 			type: "holo",
@@ -101,18 +109,13 @@ const card: Card = {
 		{
 			type: "holo",
 			subtype: "shadowless",
-		},
-		{
-			type: "holo",
-			subtype: "1999-2000-copyright",
+			thirdParty: {
+				cardmarket: 660226
+			}
 		}
 	],
 
 
-	thirdParty: {
-		cardmarket: 273697,
-		tcgplayer: 42360
-	}
 }
 
 export default card

--- a/data/Base/Base Set/2.ts
+++ b/data/Base/Base Set/2.ts
@@ -91,15 +91,11 @@ const card: Card = {
 	variants: [
 		{
 			type: "holo",
-			subtype: "1999-2000-copyright",
+			subtype: "unlimited",
 			thirdParty: {
 				cardmarket: 273697,
 				tcgplayer: 42360
 			}
-		},
-		{
-			type: "holo",
-			subtype: "unlimited"
 		},
 		{
 			type: "holo",
@@ -112,6 +108,10 @@ const card: Card = {
 			thirdParty: {
 				cardmarket: 660226
 			}
+		},
+		{
+			type: "holo",
+			subtype: "1999-2000-copyright"
 		}
 	],
 

--- a/data/Base/Base Set/2.ts
+++ b/data/Base/Base Set/2.ts
@@ -91,7 +91,16 @@ const card: Card = {
 	variants: [
 		{
 			type: "holo",
-			subtype: "unlimited",
+			subtype: "1999-2000-copyright",
+		},
+		{
+			type: "holo",
+			subtype: "unlimited"
+		},
+		{
+			type: "holo",
+			subtype: "shadowless",
+			stamp: ["1st-edition"],
 			thirdParty: {
 				cardmarket: 273697,
 				tcgplayer: 42360
@@ -100,18 +109,9 @@ const card: Card = {
 		{
 			type: "holo",
 			subtype: "shadowless",
-			stamp: ["1st-edition"]
-		},
-		{
-			type: "holo",
-			subtype: "shadowless",
 			thirdParty: {
 				cardmarket: 660226
 			}
-		},
-		{
-			type: "holo",
-			subtype: "1999-2000-copyright"
 		}
 	],
 

--- a/data/Base/Base Set/20.ts
+++ b/data/Base/Base Set/20.ts
@@ -78,7 +78,15 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
-			subtype: "unlimited",
+			subtype: "1999-2000-copyright",
+			thirdParty: {
+				cardmarket: 273715,
+				tcgplayer: 42361
+			}
+		},
+		{
+			type: "normal",
+			subtype: "unlimited"
 		},
 		{
 			type: "normal",
@@ -88,10 +96,9 @@ const card: Card = {
 		{
 			type: "normal",
 			subtype: "shadowless",
-		},
-		{
-			type: "normal",
-			subtype: "1999-2000-copyright",
+			thirdParty: {
+				cardmarket: 660208
+			}
 		}
 	],
 
@@ -100,10 +107,6 @@ const card: Card = {
 		it: "Si trova in genere vicino a centrali elettriche, ma può allontanarsi e causare gravissimi blackout nelle città. LIV 35 N.125"
 	},
 
-	thirdParty: {
-		cardmarket: 273715,
-		tcgplayer: 42361
-	}
 }
 
 export default card

--- a/data/Base/Base Set/20.ts
+++ b/data/Base/Base Set/20.ts
@@ -78,15 +78,11 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
-			subtype: "1999-2000-copyright",
+			subtype: "unlimited",
 			thirdParty: {
 				cardmarket: 273715,
 				tcgplayer: 42361
 			}
-		},
-		{
-			type: "normal",
-			subtype: "unlimited"
 		},
 		{
 			type: "normal",
@@ -99,6 +95,10 @@ const card: Card = {
 			thirdParty: {
 				cardmarket: 660208
 			}
+		},
+		{
+			type: "normal",
+			subtype: "1999-2000-copyright"
 		}
 	],
 

--- a/data/Base/Base Set/20.ts
+++ b/data/Base/Base Set/20.ts
@@ -78,7 +78,16 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
-			subtype: "unlimited",
+			subtype: "1999-2000-copyright",
+		},
+		{
+			type: "normal",
+			subtype: "unlimited"
+		},
+		{
+			type: "normal",
+			subtype: "shadowless",
+			stamp: ["1st-edition"],
 			thirdParty: {
 				cardmarket: 273715,
 				tcgplayer: 42361
@@ -87,18 +96,9 @@ const card: Card = {
 		{
 			type: "normal",
 			subtype: "shadowless",
-			stamp: ["1st-edition"]
-		},
-		{
-			type: "normal",
-			subtype: "shadowless",
 			thirdParty: {
 				cardmarket: 660208
 			}
-		},
-		{
-			type: "normal",
-			subtype: "1999-2000-copyright"
 		}
 	],
 

--- a/data/Base/Base Set/21.ts
+++ b/data/Base/Base Set/21.ts
@@ -77,15 +77,11 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
-			subtype: "1999-2000-copyright",
+			subtype: "unlimited",
 			thirdParty: {
 				cardmarket: 273716,
 				tcgplayer: 42362
 			}
-		},
-		{
-			type: "normal",
-			subtype: "unlimited"
 		},
 		{
 			type: "normal",
@@ -98,6 +94,10 @@ const card: Card = {
 			thirdParty: {
 				cardmarket: 660207
 			}
+		},
+		{
+			type: "normal",
+			subtype: "1999-2000-copyright"
 		}
 	],
 

--- a/data/Base/Base Set/21.ts
+++ b/data/Base/Base Set/21.ts
@@ -77,7 +77,15 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
-			subtype: "unlimited",
+			subtype: "1999-2000-copyright",
+			thirdParty: {
+				cardmarket: 273716,
+				tcgplayer: 42362
+			}
+		},
+		{
+			type: "normal",
+			subtype: "unlimited"
 		},
 		{
 			type: "normal",
@@ -87,10 +95,9 @@ const card: Card = {
 		{
 			type: "normal",
 			subtype: "shadowless",
-		},
-		{
-			type: "normal",
-			subtype: "1999-2000-copyright",
+			thirdParty: {
+				cardmarket: 660207
+			}
 		}
 	],
 
@@ -106,10 +113,6 @@ const card: Card = {
 		it: "Conserva energia elettrica sotto altissima pressione. Spesso esplode senza o con minima provocazione. LIV 40 N.102"
 	},
 
-	thirdParty: {
-		cardmarket: 273716,
-		tcgplayer: 42362
-	}
 }
 
 export default card

--- a/data/Base/Base Set/21.ts
+++ b/data/Base/Base Set/21.ts
@@ -77,7 +77,16 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
-			subtype: "unlimited",
+			subtype: "1999-2000-copyright",
+		},
+		{
+			type: "normal",
+			subtype: "unlimited"
+		},
+		{
+			type: "normal",
+			subtype: "shadowless",
+			stamp: ["1st-edition"],
 			thirdParty: {
 				cardmarket: 273716,
 				tcgplayer: 42362
@@ -86,18 +95,9 @@ const card: Card = {
 		{
 			type: "normal",
 			subtype: "shadowless",
-			stamp: ["1st-edition"]
-		},
-		{
-			type: "normal",
-			subtype: "shadowless",
 			thirdParty: {
 				cardmarket: 660207
 			}
-		},
-		{
-			type: "normal",
-			subtype: "1999-2000-copyright"
 		}
 	],
 

--- a/data/Base/Base Set/22.ts
+++ b/data/Base/Base Set/22.ts
@@ -79,15 +79,11 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
-			subtype: "1999-2000-copyright",
+			subtype: "unlimited",
 			thirdParty: {
 				cardmarket: 273717,
 				tcgplayer: 42363
 			}
-		},
-		{
-			type: "normal",
-			subtype: "unlimited"
 		},
 		{
 			type: "normal",
@@ -100,6 +96,10 @@ const card: Card = {
 			thirdParty: {
 				cardmarket: 660206
 			}
+		},
+		{
+			type: "normal",
+			subtype: "1999-2000-copyright"
 		}
 	],
 

--- a/data/Base/Base Set/22.ts
+++ b/data/Base/Base Set/22.ts
@@ -79,7 +79,15 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
-			subtype: "unlimited",
+			subtype: "1999-2000-copyright",
+			thirdParty: {
+				cardmarket: 273717,
+				tcgplayer: 42363
+			}
+		},
+		{
+			type: "normal",
+			subtype: "unlimited"
 		},
 		{
 			type: "normal",
@@ -89,10 +97,9 @@ const card: Card = {
 		{
 			type: "normal",
 			subtype: "shadowless",
-		},
-		{
-			type: "normal",
-			subtype: "1999-2000-copyright",
+			thirdParty: {
+				cardmarket: 660206
+			}
 		}
 	],
 
@@ -115,10 +122,6 @@ const card: Card = {
 		it:"Istintivamente protettivo del suo ampio territorio di caccia, questo Pokémon si serve del suo becco appuntito per attaccare con forza qualsiasi nuovo intruso. LIV 36 N.17"
 	},
 
-	thirdParty: {
-		cardmarket: 273717,
-		tcgplayer: 42363
-	}
 }
 
 export default card

--- a/data/Base/Base Set/22.ts
+++ b/data/Base/Base Set/22.ts
@@ -79,7 +79,16 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
-			subtype: "unlimited",
+			subtype: "1999-2000-copyright",
+		},
+		{
+			type: "normal",
+			subtype: "unlimited"
+		},
+		{
+			type: "normal",
+			subtype: "shadowless",
+			stamp: ["1st-edition"],
 			thirdParty: {
 				cardmarket: 273717,
 				tcgplayer: 42363
@@ -88,18 +97,9 @@ const card: Card = {
 		{
 			type: "normal",
 			subtype: "shadowless",
-			stamp: ["1st-edition"]
-		},
-		{
-			type: "normal",
-			subtype: "shadowless",
 			thirdParty: {
 				cardmarket: 660206
 			}
-		},
-		{
-			type: "normal",
-			subtype: "1999-2000-copyright"
 		}
 	],
 

--- a/data/Base/Base Set/23.ts
+++ b/data/Base/Base Set/23.ts
@@ -81,15 +81,11 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
-			subtype: "1999-2000-copyright",
+			subtype: "unlimited",
 			thirdParty: {
 				cardmarket: 273718,
 				tcgplayer: 42364
 			}
-		},
-		{
-			type: "normal",
-			subtype: "unlimited"
 		},
 		{
 			type: "normal",
@@ -102,6 +98,10 @@ const card: Card = {
 			thirdParty: {
 				cardmarket: 660205
 			}
+		},
+		{
+			type: "normal",
+			subtype: "1999-2000-copyright"
 		}
 	],
 

--- a/data/Base/Base Set/23.ts
+++ b/data/Base/Base Set/23.ts
@@ -81,7 +81,15 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
-			subtype: "unlimited",
+			subtype: "1999-2000-copyright",
+			thirdParty: {
+				cardmarket: 273718,
+				tcgplayer: 42364
+			}
+		},
+		{
+			type: "normal",
+			subtype: "unlimited"
 		},
 		{
 			type: "normal",
@@ -91,10 +99,9 @@ const card: Card = {
 		{
 			type: "normal",
 			subtype: "shadowless",
-		},
-		{
-			type: "normal",
-			subtype: "1999-2000-copyright",
+			thirdParty: {
+				cardmarket: 660205
+			}
 		}
 	],
 
@@ -110,10 +117,6 @@ const card: Card = {
 		it: "Pokémon da sempre ammirato per il suo fiero aspetto. Corre con grande agilità, come se avesse le ali. LIV 45 N.59"
 	},
 
-	thirdParty: {
-		cardmarket: 273718,
-		tcgplayer: 42364
-	}
 }
 
 export default card

--- a/data/Base/Base Set/23.ts
+++ b/data/Base/Base Set/23.ts
@@ -81,7 +81,16 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
-			subtype: "unlimited",
+			subtype: "1999-2000-copyright",
+		},
+		{
+			type: "normal",
+			subtype: "unlimited"
+		},
+		{
+			type: "normal",
+			subtype: "shadowless",
+			stamp: ["1st-edition"],
 			thirdParty: {
 				cardmarket: 273718,
 				tcgplayer: 42364
@@ -90,18 +99,9 @@ const card: Card = {
 		{
 			type: "normal",
 			subtype: "shadowless",
-			stamp: ["1st-edition"]
-		},
-		{
-			type: "normal",
-			subtype: "shadowless",
 			thirdParty: {
 				cardmarket: 660205
 			}
-		},
-		{
-			type: "normal",
-			subtype: "1999-2000-copyright"
 		}
 	],
 

--- a/data/Base/Base Set/24.ts
+++ b/data/Base/Base Set/24.ts
@@ -75,15 +75,11 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
-			subtype: "1999-2000-copyright",
+			subtype: "unlimited",
 			thirdParty: {
 				cardmarket: 273719,
 				tcgplayer: 42365
 			}
-		},
-		{
-			type: "normal",
-			subtype: "unlimited"
 		},
 		{
 			type: "normal",
@@ -96,6 +92,10 @@ const card: Card = {
 			thirdParty: {
 				cardmarket: 660204
 			}
+		},
+		{
+			type: "normal",
+			subtype: "1999-2000-copyright"
 		}
 	],
 	weaknesses: [

--- a/data/Base/Base Set/24.ts
+++ b/data/Base/Base Set/24.ts
@@ -75,7 +75,15 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
-			subtype: "unlimited",
+			subtype: "1999-2000-copyright",
+			thirdParty: {
+				cardmarket: 273719,
+				tcgplayer: 42365
+			}
+		},
+		{
+			type: "normal",
+			subtype: "unlimited"
 		},
 		{
 			type: "normal",
@@ -85,10 +93,9 @@ const card: Card = {
 		{
 			type: "normal",
 			subtype: "shadowless",
-		},
-		{
-			type: "normal",
-			subtype: "1999-2000-copyright",
+			thirdParty: {
+				cardmarket: 660204
+			}
 		}
 	],
 	weaknesses: [
@@ -103,10 +110,6 @@ const card: Card = {
 		it: "Quando rotea la coda incandescente, aumenta la temperatura a livelli insopportabilmente alti. LIV 32 N.5"
 	},
 
-	thirdParty: {
-		cardmarket: 273719,
-		tcgplayer: 42365
-	}
 }
 
 export default card

--- a/data/Base/Base Set/24.ts
+++ b/data/Base/Base Set/24.ts
@@ -75,7 +75,16 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
-			subtype: "unlimited",
+			subtype: "1999-2000-copyright",
+		},
+		{
+			type: "normal",
+			subtype: "unlimited"
+		},
+		{
+			type: "normal",
+			subtype: "shadowless",
+			stamp: ["1st-edition"],
 			thirdParty: {
 				cardmarket: 273719,
 				tcgplayer: 42365
@@ -84,18 +93,9 @@ const card: Card = {
 		{
 			type: "normal",
 			subtype: "shadowless",
-			stamp: ["1st-edition"]
-		},
-		{
-			type: "normal",
-			subtype: "shadowless",
 			thirdParty: {
 				cardmarket: 660204
 			}
-		},
-		{
-			type: "normal",
-			subtype: "1999-2000-copyright"
 		}
 	],
 	weaknesses: [

--- a/data/Base/Base Set/25.ts
+++ b/data/Base/Base Set/25.ts
@@ -76,15 +76,11 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
-			subtype: "1999-2000-copyright",
+			subtype: "unlimited",
 			thirdParty: {
 				cardmarket: 273720,
 				tcgplayer: 42366
 			}
-		},
-		{
-			type: "normal",
-			subtype: "unlimited"
 		},
 		{
 			type: "normal",
@@ -97,6 +93,10 @@ const card: Card = {
 			thirdParty: {
 				cardmarket: 660203
 			}
+		},
+		{
+			type: "normal",
+			subtype: "1999-2000-copyright"
 		}
 	],
 	weaknesses: [

--- a/data/Base/Base Set/25.ts
+++ b/data/Base/Base Set/25.ts
@@ -76,7 +76,15 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
-			subtype: "unlimited",
+			subtype: "1999-2000-copyright",
+			thirdParty: {
+				cardmarket: 273720,
+				tcgplayer: 42366
+			}
+		},
+		{
+			type: "normal",
+			subtype: "unlimited"
 		},
 		{
 			type: "normal",
@@ -86,10 +94,9 @@ const card: Card = {
 		{
 			type: "normal",
 			subtype: "shadowless",
-		},
-		{
-			type: "normal",
-			subtype: "1999-2000-copyright",
+			thirdParty: {
+				cardmarket: 660203
+			}
 		}
 	],
 	weaknesses: [
@@ -104,10 +111,6 @@ const card: Card = {
 		it: "Conserva energia termica nel suo corpo. Nuota ad una velocità costante di 8 nodi anche in acque estremamente fredde. LIV 42 N.87"
 	},
 
-	thirdParty: {
-		cardmarket: 273720,
-		tcgplayer: 42366
-	}
 }
 
 export default card

--- a/data/Base/Base Set/25.ts
+++ b/data/Base/Base Set/25.ts
@@ -76,7 +76,16 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
-			subtype: "unlimited",
+			subtype: "1999-2000-copyright",
+		},
+		{
+			type: "normal",
+			subtype: "unlimited"
+		},
+		{
+			type: "normal",
+			subtype: "shadowless",
+			stamp: ["1st-edition"],
 			thirdParty: {
 				cardmarket: 273720,
 				tcgplayer: 42366
@@ -85,18 +94,9 @@ const card: Card = {
 		{
 			type: "normal",
 			subtype: "shadowless",
-			stamp: ["1st-edition"]
-		},
-		{
-			type: "normal",
-			subtype: "shadowless",
 			thirdParty: {
 				cardmarket: 660203
 			}
-		},
-		{
-			type: "normal",
-			subtype: "1999-2000-copyright"
 		}
 	],
 	weaknesses: [

--- a/data/Base/Base Set/26.ts
+++ b/data/Base/Base Set/26.ts
@@ -46,15 +46,11 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
-			subtype: "1999-2000-copyright",
+			subtype: "unlimited",
 			thirdParty: {
 				cardmarket: 273721,
 				tcgplayer: 42367
 			}
-		},
-		{
-			type: "normal",
-			subtype: "unlimited"
 		},
 		{
 			type: "normal",
@@ -67,6 +63,10 @@ const card: Card = {
 			thirdParty: {
 				cardmarket: 660202
 			}
+		},
+		{
+			type: "normal",
+			subtype: "1999-2000-copyright"
 		}
 	],
 	resistances: [

--- a/data/Base/Base Set/26.ts
+++ b/data/Base/Base Set/26.ts
@@ -46,7 +46,15 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
-			subtype: "unlimited",
+			subtype: "1999-2000-copyright",
+			thirdParty: {
+				cardmarket: 273721,
+				tcgplayer: 42367
+			}
+		},
+		{
+			type: "normal",
+			subtype: "unlimited"
 		},
 		{
 			type: "normal",
@@ -56,10 +64,9 @@ const card: Card = {
 		{
 			type: "normal",
 			subtype: "shadowless",
-		},
-		{
-			type: "normal",
-			subtype: "1999-2000-copyright",
+			thirdParty: {
+				cardmarket: 660202
+			}
 		}
 	],
 	resistances: [
@@ -74,10 +81,6 @@ const card: Card = {
 		it: "Da lungo tempo considerato un Pokémon mitologico fino a quando, recentemente, ne è stata rinvenuta una piccola colonia abitante sott'acqua."
 	},
 
-	thirdParty: {
-		cardmarket: 273721,
-		tcgplayer: 42367
-	}
 }
 
 export default card

--- a/data/Base/Base Set/26.ts
+++ b/data/Base/Base Set/26.ts
@@ -46,7 +46,16 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
-			subtype: "unlimited",
+			subtype: "1999-2000-copyright",
+		},
+		{
+			type: "normal",
+			subtype: "unlimited"
+		},
+		{
+			type: "normal",
+			subtype: "shadowless",
+			stamp: ["1st-edition"],
 			thirdParty: {
 				cardmarket: 273721,
 				tcgplayer: 42367
@@ -55,18 +64,9 @@ const card: Card = {
 		{
 			type: "normal",
 			subtype: "shadowless",
-			stamp: ["1st-edition"]
-		},
-		{
-			type: "normal",
-			subtype: "shadowless",
 			thirdParty: {
 				cardmarket: 660202
 			}
-		},
-		{
-			type: "normal",
-			subtype: "1999-2000-copyright"
 		}
 	],
 	resistances: [

--- a/data/Base/Base Set/27.ts
+++ b/data/Base/Base Set/27.ts
@@ -81,7 +81,15 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
-			subtype: "unlimited",
+			subtype: "1999-2000-copyright",
+			thirdParty: {
+				cardmarket: 273722,
+				tcgplayer: 42368
+			}
+		},
+		{
+			type: "normal",
+			subtype: "unlimited"
 		},
 		{
 			type: "normal",
@@ -91,10 +99,9 @@ const card: Card = {
 		{
 			type: "normal",
 			subtype: "shadowless",
-		},
-		{
-			type: "normal",
-			subtype: "1999-2000-copyright",
+			thirdParty: {
+				cardmarket: 660201
+			}
 		}
 	],
 	description: {
@@ -102,10 +109,6 @@ const card: Card = {
 		it: "Il porro che impugna è il suo simbolo e lo usa come una spada d'acciaio. LIV 20 N.83"
 	},
 
-	thirdParty: {
-		cardmarket: 273722,
-		tcgplayer: 42368
-	}
 }
 
 export default card

--- a/data/Base/Base Set/27.ts
+++ b/data/Base/Base Set/27.ts
@@ -81,15 +81,11 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
-			subtype: "1999-2000-copyright",
+			subtype: "unlimited",
 			thirdParty: {
 				cardmarket: 273722,
 				tcgplayer: 42368
 			}
-		},
-		{
-			type: "normal",
-			subtype: "unlimited"
 		},
 		{
 			type: "normal",
@@ -102,6 +98,10 @@ const card: Card = {
 			thirdParty: {
 				cardmarket: 660201
 			}
+		},
+		{
+			type: "normal",
+			subtype: "1999-2000-copyright"
 		}
 	],
 	description: {

--- a/data/Base/Base Set/27.ts
+++ b/data/Base/Base Set/27.ts
@@ -81,7 +81,16 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
-			subtype: "unlimited",
+			subtype: "1999-2000-copyright",
+		},
+		{
+			type: "normal",
+			subtype: "unlimited"
+		},
+		{
+			type: "normal",
+			subtype: "shadowless",
+			stamp: ["1st-edition"],
 			thirdParty: {
 				cardmarket: 273722,
 				tcgplayer: 42368
@@ -90,18 +99,9 @@ const card: Card = {
 		{
 			type: "normal",
 			subtype: "shadowless",
-			stamp: ["1st-edition"]
-		},
-		{
-			type: "normal",
-			subtype: "shadowless",
 			thirdParty: {
 				cardmarket: 660201
 			}
-		},
-		{
-			type: "normal",
-			subtype: "1999-2000-copyright"
 		}
 	],
 	description: {

--- a/data/Base/Base Set/28.ts
+++ b/data/Base/Base Set/28.ts
@@ -56,14 +56,18 @@ const card: Card = {
 		it: "Difende con tenacia il suo territorio. Abbaia e morde per cacciare gli intrusi che osano avvicinarsi. LIV 18 N.58"
 	},
 
-	thirdParty: {
-		cardmarket: 273723,
-		tcgplayer: 42369
-	},
 	variants: [
 		{
 			type: "normal",
-			subtype: "unlimited",
+			subtype: "1999-2000-copyright",
+			thirdParty: {
+				cardmarket: 273723,
+				tcgplayer: 42369
+			}
+		},
+		{
+			type: "normal",
+			subtype: "unlimited"
 		},
 		{
 			type: "normal",
@@ -73,10 +77,9 @@ const card: Card = {
 		{
 			type: "normal",
 			subtype: "shadowless",
-		},
-		{
-			type: "normal",
-			subtype: "1999-2000-copyright",
+			thirdParty: {
+				cardmarket: 660200
+			}
 		}
 	],
 }

--- a/data/Base/Base Set/28.ts
+++ b/data/Base/Base Set/28.ts
@@ -59,15 +59,11 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
-			subtype: "1999-2000-copyright",
+			subtype: "unlimited",
 			thirdParty: {
 				cardmarket: 273723,
 				tcgplayer: 42369
 			}
-		},
-		{
-			type: "normal",
-			subtype: "unlimited"
 		},
 		{
 			type: "normal",
@@ -80,6 +76,10 @@ const card: Card = {
 			thirdParty: {
 				cardmarket: 660200
 			}
+		},
+		{
+			type: "normal",
+			subtype: "1999-2000-copyright"
 		}
 	],
 }

--- a/data/Base/Base Set/28.ts
+++ b/data/Base/Base Set/28.ts
@@ -59,7 +59,16 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
-			subtype: "unlimited",
+			subtype: "1999-2000-copyright",
+		},
+		{
+			type: "normal",
+			subtype: "unlimited"
+		},
+		{
+			type: "normal",
+			subtype: "shadowless",
+			stamp: ["1st-edition"],
 			thirdParty: {
 				cardmarket: 273723,
 				tcgplayer: 42369
@@ -68,18 +77,9 @@ const card: Card = {
 		{
 			type: "normal",
 			subtype: "shadowless",
-			stamp: ["1st-edition"]
-		},
-		{
-			type: "normal",
-			subtype: "shadowless",
 			thirdParty: {
 				cardmarket: 660200
 			}
-		},
-		{
-			type: "normal",
-			subtype: "1999-2000-copyright"
 		}
 	],
 }

--- a/data/Base/Base Set/29.ts
+++ b/data/Base/Base Set/29.ts
@@ -88,15 +88,11 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
-			subtype: "1999-2000-copyright",
+			subtype: "unlimited",
 			thirdParty: {
 				cardmarket: 273724,
 				tcgplayer: 42370
 			}
-		},
-		{
-			type: "normal",
-			subtype: "unlimited"
 		},
 		{
 			type: "normal",
@@ -109,6 +105,10 @@ const card: Card = {
 			thirdParty: {
 				cardmarket: 660199
 			}
+		},
+		{
+			type: "normal",
+			subtype: "1999-2000-copyright"
 		}
 	],
 }

--- a/data/Base/Base Set/29.ts
+++ b/data/Base/Base Set/29.ts
@@ -85,14 +85,18 @@ const card: Card = {
 		it: "Per la sua abilità di passare attraverso i muri, si dice che venga da un'altra dimensione."
 	},
 
-	thirdParty: {
-		cardmarket: 273724,
-		tcgplayer: 42370
-	},
 	variants: [
 		{
 			type: "normal",
-			subtype: "unlimited",
+			subtype: "1999-2000-copyright",
+			thirdParty: {
+				cardmarket: 273724,
+				tcgplayer: 42370
+			}
+		},
+		{
+			type: "normal",
+			subtype: "unlimited"
 		},
 		{
 			type: "normal",
@@ -102,10 +106,9 @@ const card: Card = {
 		{
 			type: "normal",
 			subtype: "shadowless",
-		},
-		{
-			type: "normal",
-			subtype: "1999-2000-copyright",
+			thirdParty: {
+				cardmarket: 660199
+			}
 		}
 	],
 }

--- a/data/Base/Base Set/29.ts
+++ b/data/Base/Base Set/29.ts
@@ -88,7 +88,16 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
-			subtype: "unlimited",
+			subtype: "1999-2000-copyright",
+		},
+		{
+			type: "normal",
+			subtype: "unlimited"
+		},
+		{
+			type: "normal",
+			subtype: "shadowless",
+			stamp: ["1st-edition"],
 			thirdParty: {
 				cardmarket: 273724,
 				tcgplayer: 42370
@@ -97,18 +106,9 @@ const card: Card = {
 		{
 			type: "normal",
 			subtype: "shadowless",
-			stamp: ["1st-edition"]
-		},
-		{
-			type: "normal",
-			subtype: "shadowless",
 			thirdParty: {
 				cardmarket: 660199
 			}
-		},
-		{
-			type: "normal",
-			subtype: "1999-2000-copyright"
 		}
 	],
 }

--- a/data/Base/Base Set/3.ts
+++ b/data/Base/Base Set/3.ts
@@ -87,15 +87,11 @@ const card: Card = {
 	variants: [
 		{
 			type: "holo",
-			subtype: "1999-2000-copyright",
+			subtype: "unlimited",
 			thirdParty: {
 				cardmarket: 273698,
 				tcgplayer: 42371
 			}
-		},
-		{
-			type: "holo",
-			subtype: "unlimited"
 		},
 		{
 			type: "holo",
@@ -108,6 +104,10 @@ const card: Card = {
 			thirdParty: {
 				cardmarket: 660225
 			}
+		},
+		{
+			type: "holo",
+			subtype: "1999-2000-copyright"
 		}
 	],
 

--- a/data/Base/Base Set/3.ts
+++ b/data/Base/Base Set/3.ts
@@ -87,7 +87,15 @@ const card: Card = {
 	variants: [
 		{
 			type: "holo",
-			subtype: "unlimited",
+			subtype: "1999-2000-copyright",
+			thirdParty: {
+				cardmarket: 273698,
+				tcgplayer: 42371
+			}
+		},
+		{
+			type: "holo",
+			subtype: "unlimited"
 		},
 		{
 			type: "holo",
@@ -97,10 +105,9 @@ const card: Card = {
 		{
 			type: "holo",
 			subtype: "shadowless",
-		},
-		{
-			type: "holo",
-			subtype: "1999-2000-copyright",
+			thirdParty: {
+				cardmarket: 660225
+			}
 		}
 	],
 
@@ -110,10 +117,6 @@ const card: Card = {
 		it: "Pokémon raro ed elusivo; di lui si dice che porti felicità a coloro che riescono ad acchiapparlo. LIV 55 N.113"
 	},
 
-	thirdParty: {
-		cardmarket: 273698,
-		tcgplayer: 42371
-	}
 }
 
 export default card

--- a/data/Base/Base Set/3.ts
+++ b/data/Base/Base Set/3.ts
@@ -87,7 +87,16 @@ const card: Card = {
 	variants: [
 		{
 			type: "holo",
-			subtype: "unlimited",
+			subtype: "1999-2000-copyright",
+		},
+		{
+			type: "holo",
+			subtype: "unlimited"
+		},
+		{
+			type: "holo",
+			subtype: "shadowless",
+			stamp: ["1st-edition"],
 			thirdParty: {
 				cardmarket: 273698,
 				tcgplayer: 42371
@@ -96,18 +105,9 @@ const card: Card = {
 		{
 			type: "holo",
 			subtype: "shadowless",
-			stamp: ["1st-edition"]
-		},
-		{
-			type: "holo",
-			subtype: "shadowless",
 			thirdParty: {
 				cardmarket: 660225
 			}
-		},
-		{
-			type: "holo",
-			subtype: "1999-2000-copyright"
 		}
 	],
 

--- a/data/Base/Base Set/30.ts
+++ b/data/Base/Base Set/30.ts
@@ -87,15 +87,11 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
-			subtype: "1999-2000-copyright",
+			subtype: "unlimited",
 			thirdParty: {
 				cardmarket: 273725,
 				tcgplayer: 42372
 			}
-		},
-		{
-			type: "normal",
-			subtype: "unlimited"
 		},
 		{
 			type: "normal",
@@ -108,6 +104,10 @@ const card: Card = {
 			thirdParty: {
 				cardmarket: 660198
 			}
+		},
+		{
+			type: "normal",
+			subtype: "1999-2000-copyright"
 		}
 	],
 }

--- a/data/Base/Base Set/30.ts
+++ b/data/Base/Base Set/30.ts
@@ -84,14 +84,18 @@ const card: Card = {
 		it: "Quando la pianta che ha sul dorso cresce, questo Pokémon non è più in grado di mantenersi eretto sulle zampe posteriori. LIV 20 N.2"
 	},
 
-	thirdParty: {
-		cardmarket: 273725,
-		tcgplayer: 42372
-	},
 	variants: [
 		{
 			type: "normal",
-			subtype: "unlimited",
+			subtype: "1999-2000-copyright",
+			thirdParty: {
+				cardmarket: 273725,
+				tcgplayer: 42372
+			}
+		},
+		{
+			type: "normal",
+			subtype: "unlimited"
 		},
 		{
 			type: "normal",
@@ -101,10 +105,9 @@ const card: Card = {
 		{
 			type: "normal",
 			subtype: "shadowless",
-		},
-		{
-			type: "normal",
-			subtype: "1999-2000-copyright",
+			thirdParty: {
+				cardmarket: 660198
+			}
 		}
 	],
 }

--- a/data/Base/Base Set/30.ts
+++ b/data/Base/Base Set/30.ts
@@ -87,7 +87,16 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
-			subtype: "unlimited",
+			subtype: "1999-2000-copyright",
+		},
+		{
+			type: "normal",
+			subtype: "unlimited"
+		},
+		{
+			type: "normal",
+			subtype: "shadowless",
+			stamp: ["1st-edition"],
 			thirdParty: {
 				cardmarket: 273725,
 				tcgplayer: 42372
@@ -96,18 +105,9 @@ const card: Card = {
 		{
 			type: "normal",
 			subtype: "shadowless",
-			stamp: ["1st-edition"]
-		},
-		{
-			type: "normal",
-			subtype: "shadowless",
 			thirdParty: {
 				cardmarket: 660198
 			}
-		},
-		{
-			type: "normal",
-			subtype: "1999-2000-copyright"
 		}
 	],
 }

--- a/data/Base/Base Set/31.ts
+++ b/data/Base/Base Set/31.ts
@@ -85,15 +85,11 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
-			subtype: "1999-2000-copyright",
+			subtype: "unlimited",
 			thirdParty: {
 				cardmarket: 273726,
 				tcgplayer: 42373
 			}
-		},
-		{
-			type: "normal",
-			subtype: "unlimited"
 		},
 		{
 			type: "normal",
@@ -106,6 +102,10 @@ const card: Card = {
 			thirdParty: {
 				cardmarket: 660197
 			}
+		},
+		{
+			type: "normal",
+			subtype: "1999-2000-copyright"
 		}
 	],
 }

--- a/data/Base/Base Set/31.ts
+++ b/data/Base/Base Set/31.ts
@@ -82,14 +82,18 @@ const card: Card = {
 		it: "Con la sola forza del pensiero, Questo Pokémon lancia un potente attacco di energia psichica. LIV 23 N.124"
 	},
 
-	thirdParty: {
-		cardmarket: 273726,
-		tcgplayer: 42373
-	},
 	variants: [
 		{
 			type: "normal",
-			subtype: "unlimited",
+			subtype: "1999-2000-copyright",
+			thirdParty: {
+				cardmarket: 273726,
+				tcgplayer: 42373
+			}
+		},
+		{
+			type: "normal",
+			subtype: "unlimited"
 		},
 		{
 			type: "normal",
@@ -99,10 +103,9 @@ const card: Card = {
 		{
 			type: "normal",
 			subtype: "shadowless",
-		},
-		{
-			type: "normal",
-			subtype: "1999-2000-copyright",
+			thirdParty: {
+				cardmarket: 660197
+			}
 		}
 	],
 }

--- a/data/Base/Base Set/31.ts
+++ b/data/Base/Base Set/31.ts
@@ -85,7 +85,16 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
-			subtype: "unlimited",
+			subtype: "1999-2000-copyright",
+		},
+		{
+			type: "normal",
+			subtype: "unlimited"
+		},
+		{
+			type: "normal",
+			subtype: "shadowless",
+			stamp: ["1st-edition"],
 			thirdParty: {
 				cardmarket: 273726,
 				tcgplayer: 42373
@@ -94,18 +103,9 @@ const card: Card = {
 		{
 			type: "normal",
 			subtype: "shadowless",
-			stamp: ["1st-edition"]
-		},
-		{
-			type: "normal",
-			subtype: "shadowless",
 			thirdParty: {
 				cardmarket: 660197
 			}
-		},
-		{
-			type: "normal",
-			subtype: "1999-2000-copyright"
 		}
 	],
 }

--- a/data/Base/Base Set/32.ts
+++ b/data/Base/Base Set/32.ts
@@ -82,14 +82,18 @@ const card: Card = {
 		it: "Emette dal corpo speciali onde alfa che causano mal di testa a chiunque gli sia vicino. LIV 38 N.64"
 	},
 
-	thirdParty: {
-		cardmarket: 273727,
-		tcgplayer: 42374
-	},
 	variants: [
 		{
 			type: "normal",
-			subtype: "unlimited",
+			subtype: "1999-2000-copyright",
+			thirdParty: {
+				cardmarket: 273727,
+				tcgplayer: 42374
+			}
+		},
+		{
+			type: "normal",
+			subtype: "unlimited"
 		},
 		{
 			type: "normal",
@@ -99,10 +103,9 @@ const card: Card = {
 		{
 			type: "normal",
 			subtype: "shadowless",
-		},
-		{
-			type: "normal",
-			subtype: "1999-2000-copyright",
+			thirdParty: {
+				cardmarket: 660196
+			}
 		}
 	],
 }

--- a/data/Base/Base Set/32.ts
+++ b/data/Base/Base Set/32.ts
@@ -85,15 +85,11 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
-			subtype: "1999-2000-copyright",
+			subtype: "unlimited",
 			thirdParty: {
 				cardmarket: 273727,
 				tcgplayer: 42374
 			}
-		},
-		{
-			type: "normal",
-			subtype: "unlimited"
 		},
 		{
 			type: "normal",
@@ -106,6 +102,10 @@ const card: Card = {
 			thirdParty: {
 				cardmarket: 660196
 			}
+		},
+		{
+			type: "normal",
+			subtype: "1999-2000-copyright"
 		}
 	],
 }

--- a/data/Base/Base Set/32.ts
+++ b/data/Base/Base Set/32.ts
@@ -85,7 +85,16 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
-			subtype: "unlimited",
+			subtype: "1999-2000-copyright",
+		},
+		{
+			type: "normal",
+			subtype: "unlimited"
+		},
+		{
+			type: "normal",
+			subtype: "shadowless",
+			stamp: ["1st-edition"],
 			thirdParty: {
 				cardmarket: 273727,
 				tcgplayer: 42374
@@ -94,18 +103,9 @@ const card: Card = {
 		{
 			type: "normal",
 			subtype: "shadowless",
-			stamp: ["1st-edition"]
-		},
-		{
-			type: "normal",
-			subtype: "shadowless",
 			thirdParty: {
 				cardmarket: 660196
 			}
-		},
-		{
-			type: "normal",
-			subtype: "1999-2000-copyright"
 		}
 	],
 }

--- a/data/Base/Base Set/33.ts
+++ b/data/Base/Base Set/33.ts
@@ -87,14 +87,18 @@ const card: Card = {
 		it: "Dato che non ha molta libertà di movimento, questo Pokémon può proteggersi contro i predatori solo indurendo la sua corazza. LIV 23 N.14"
 	},
 
-	thirdParty: {
-		cardmarket: 273728,
-		tcgplayer: 42375
-	},
 	variants: [
 		{
 			type: "normal",
-			subtype: "unlimited",
+			subtype: "1999-2000-copyright",
+			thirdParty: {
+				cardmarket: 273728,
+				tcgplayer: 42375
+			}
+		},
+		{
+			type: "normal",
+			subtype: "unlimited"
 		},
 		{
 			type: "normal",
@@ -104,10 +108,9 @@ const card: Card = {
 		{
 			type: "normal",
 			subtype: "shadowless",
-		},
-		{
-			type: "normal",
-			subtype: "1999-2000-copyright",
+			thirdParty: {
+				cardmarket: 660195
+			}
 		}
 	],
 }

--- a/data/Base/Base Set/33.ts
+++ b/data/Base/Base Set/33.ts
@@ -90,15 +90,11 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
-			subtype: "1999-2000-copyright",
+			subtype: "unlimited",
 			thirdParty: {
 				cardmarket: 273728,
 				tcgplayer: 42375
 			}
-		},
-		{
-			type: "normal",
-			subtype: "unlimited"
 		},
 		{
 			type: "normal",
@@ -111,6 +107,10 @@ const card: Card = {
 			thirdParty: {
 				cardmarket: 660195
 			}
+		},
+		{
+			type: "normal",
+			subtype: "1999-2000-copyright"
 		}
 	],
 }

--- a/data/Base/Base Set/33.ts
+++ b/data/Base/Base Set/33.ts
@@ -90,7 +90,16 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
-			subtype: "unlimited",
+			subtype: "1999-2000-copyright",
+		},
+		{
+			type: "normal",
+			subtype: "unlimited"
+		},
+		{
+			type: "normal",
+			subtype: "shadowless",
+			stamp: ["1st-edition"],
 			thirdParty: {
 				cardmarket: 273728,
 				tcgplayer: 42375
@@ -99,18 +108,9 @@ const card: Card = {
 		{
 			type: "normal",
 			subtype: "shadowless",
-			stamp: ["1st-edition"]
-		},
-		{
-			type: "normal",
-			subtype: "shadowless",
 			thirdParty: {
 				cardmarket: 660195
 			}
-		},
-		{
-			type: "normal",
-			subtype: "1999-2000-copyright"
 		}
 	],
 }

--- a/data/Base/Base Set/34.ts
+++ b/data/Base/Base Set/34.ts
@@ -93,15 +93,11 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
-			subtype: "1999-2000-copyright",
+			subtype: "unlimited",
 			thirdParty: {
 				cardmarket: 273729,
 				tcgplayer: 42376
 			}
-		},
-		{
-			type: "normal",
-			subtype: "unlimited"
 		},
 		{
 			type: "normal",
@@ -114,6 +110,10 @@ const card: Card = {
 			thirdParty: {
 				cardmarket: 660194
 			}
+		},
+		{
+			type: "normal",
+			subtype: "1999-2000-copyright"
 		}
 	],
 }

--- a/data/Base/Base Set/34.ts
+++ b/data/Base/Base Set/34.ts
@@ -90,14 +90,18 @@ const card: Card = {
 		it: "Il suo corpo è talmente muscoloso che è costretto ad indossare una cintura salva-energia per regolare i suoi movimenti. LIV 40 N.67"
 	},
 
-	thirdParty: {
-		cardmarket: 273729,
-		tcgplayer: 42376
-	},
 	variants: [
 		{
 			type: "normal",
-			subtype: "unlimited",
+			subtype: "1999-2000-copyright",
+			thirdParty: {
+				cardmarket: 273729,
+				tcgplayer: 42376
+			}
+		},
+		{
+			type: "normal",
+			subtype: "unlimited"
 		},
 		{
 			type: "normal",
@@ -107,10 +111,9 @@ const card: Card = {
 		{
 			type: "normal",
 			subtype: "shadowless",
-		},
-		{
-			type: "normal",
-			subtype: "1999-2000-copyright",
+			thirdParty: {
+				cardmarket: 660194
+			}
 		}
 	],
 }

--- a/data/Base/Base Set/34.ts
+++ b/data/Base/Base Set/34.ts
@@ -93,7 +93,16 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
-			subtype: "unlimited",
+			subtype: "1999-2000-copyright",
+		},
+		{
+			type: "normal",
+			subtype: "unlimited"
+		},
+		{
+			type: "normal",
+			subtype: "shadowless",
+			stamp: ["1st-edition"],
 			thirdParty: {
 				cardmarket: 273729,
 				tcgplayer: 42376
@@ -102,18 +111,9 @@ const card: Card = {
 		{
 			type: "normal",
 			subtype: "shadowless",
-			stamp: ["1st-edition"]
-		},
-		{
-			type: "normal",
-			subtype: "shadowless",
 			thirdParty: {
 				cardmarket: 660194
 			}
-		},
-		{
-			type: "normal",
-			subtype: "1999-2000-copyright"
 		}
 	],
 }

--- a/data/Base/Base Set/35.ts
+++ b/data/Base/Base Set/35.ts
@@ -77,15 +77,11 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
-			subtype: "1999-2000-copyright",
+			subtype: "unlimited",
 			thirdParty: {
 				cardmarket: 273730,
 				tcgplayer: 42377
 			}
-		},
-		{
-			type: "normal",
-			subtype: "unlimited"
 		},
 		{
 			type: "normal",
@@ -98,6 +94,10 @@ const card: Card = {
 			thirdParty: {
 				cardmarket: 660193
 			}
+		},
+		{
+			type: "normal",
+			subtype: "1999-2000-copyright"
 		}
 	],
 }

--- a/data/Base/Base Set/35.ts
+++ b/data/Base/Base Set/35.ts
@@ -74,14 +74,18 @@ const card: Card = {
 		it: "In un passato remoto era molto più forte dei suoi debolissimi discendenti."
 	},
 
-	thirdParty: {
-		cardmarket: 273730,
-		tcgplayer: 42377
-	},
 	variants: [
 		{
 			type: "normal",
-			subtype: "unlimited",
+			subtype: "1999-2000-copyright",
+			thirdParty: {
+				cardmarket: 273730,
+				tcgplayer: 42377
+			}
+		},
+		{
+			type: "normal",
+			subtype: "unlimited"
 		},
 		{
 			type: "normal",
@@ -91,10 +95,9 @@ const card: Card = {
 		{
 			type: "normal",
 			subtype: "shadowless",
-		},
-		{
-			type: "normal",
-			subtype: "1999-2000-copyright",
+			thirdParty: {
+				cardmarket: 660193
+			}
 		}
 	],
 }

--- a/data/Base/Base Set/35.ts
+++ b/data/Base/Base Set/35.ts
@@ -77,7 +77,16 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
-			subtype: "unlimited",
+			subtype: "1999-2000-copyright",
+		},
+		{
+			type: "normal",
+			subtype: "unlimited"
+		},
+		{
+			type: "normal",
+			subtype: "shadowless",
+			stamp: ["1st-edition"],
 			thirdParty: {
 				cardmarket: 273730,
 				tcgplayer: 42377
@@ -86,18 +95,9 @@ const card: Card = {
 		{
 			type: "normal",
 			subtype: "shadowless",
-			stamp: ["1st-edition"]
-		},
-		{
-			type: "normal",
-			subtype: "shadowless",
 			thirdParty: {
 				cardmarket: 660193
 			}
-		},
-		{
-			type: "normal",
-			subtype: "1999-2000-copyright"
 		}
 	],
 }

--- a/data/Base/Base Set/36.ts
+++ b/data/Base/Base Set/36.ts
@@ -77,14 +77,18 @@ const card: Card = {
 		it: "La luce arancione che emana dal suo corpo gli permette di mimetizzarsi perfettamente tra le fiamme. LIV 24 N.126"
 	},
 
-	thirdParty: {
-		cardmarket: 273731,
-		tcgplayer: 42378
-	},
 	variants: [
 		{
 			type: "normal",
-			subtype: "unlimited",
+			subtype: "1999-2000-copyright",
+			thirdParty: {
+				cardmarket: 273731,
+				tcgplayer: 42378
+			}
+		},
+		{
+			type: "normal",
+			subtype: "unlimited"
 		},
 		{
 			type: "normal",
@@ -94,10 +98,9 @@ const card: Card = {
 		{
 			type: "normal",
 			subtype: "shadowless",
-		},
-		{
-			type: "normal",
-			subtype: "1999-2000-copyright",
+			thirdParty: {
+				cardmarket: 660192
+			}
 		}
 	],
 }

--- a/data/Base/Base Set/36.ts
+++ b/data/Base/Base Set/36.ts
@@ -80,15 +80,11 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
-			subtype: "1999-2000-copyright",
+			subtype: "unlimited",
 			thirdParty: {
 				cardmarket: 273731,
 				tcgplayer: 42378
 			}
-		},
-		{
-			type: "normal",
-			subtype: "unlimited"
 		},
 		{
 			type: "normal",
@@ -101,6 +97,10 @@ const card: Card = {
 			thirdParty: {
 				cardmarket: 660192
 			}
+		},
+		{
+			type: "normal",
+			subtype: "1999-2000-copyright"
 		}
 	],
 }

--- a/data/Base/Base Set/36.ts
+++ b/data/Base/Base Set/36.ts
@@ -80,7 +80,16 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
-			subtype: "unlimited",
+			subtype: "1999-2000-copyright",
+		},
+		{
+			type: "normal",
+			subtype: "unlimited"
+		},
+		{
+			type: "normal",
+			subtype: "shadowless",
+			stamp: ["1st-edition"],
 			thirdParty: {
 				cardmarket: 273731,
 				tcgplayer: 42378
@@ -89,18 +98,9 @@ const card: Card = {
 		{
 			type: "normal",
 			subtype: "shadowless",
-			stamp: ["1st-edition"]
-		},
-		{
-			type: "normal",
-			subtype: "shadowless",
 			thirdParty: {
 				cardmarket: 660192
 			}
-		},
-		{
-			type: "normal",
-			subtype: "1999-2000-copyright"
 		}
 	],
 }

--- a/data/Base/Base Set/37.ts
+++ b/data/Base/Base Set/37.ts
@@ -85,14 +85,18 @@ const card: Card = {
 		it: "Pokémon aggressivo che attacca con rapidità. Il corno sulla sua testa secerne un potente veleno. LIV 25 N.33"
 	},
 
-	thirdParty: {
-		cardmarket: 273732,
-		tcgplayer: 42379
-	},
 	variants: [
 		{
 			type: "normal",
-			subtype: "unlimited",
+			subtype: "1999-2000-copyright",
+			thirdParty: {
+				cardmarket: 273732,
+				tcgplayer: 42379
+			}
+		},
+		{
+			type: "normal",
+			subtype: "unlimited"
 		},
 		{
 			type: "normal",
@@ -102,10 +106,9 @@ const card: Card = {
 		{
 			type: "normal",
 			subtype: "shadowless",
-		},
-		{
-			type: "normal",
-			subtype: "1999-2000-copyright",
+			thirdParty: {
+				cardmarket: 660191
+			}
 		}
 	],
 }

--- a/data/Base/Base Set/37.ts
+++ b/data/Base/Base Set/37.ts
@@ -88,15 +88,11 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
-			subtype: "1999-2000-copyright",
+			subtype: "unlimited",
 			thirdParty: {
 				cardmarket: 273732,
 				tcgplayer: 42379
 			}
-		},
-		{
-			type: "normal",
-			subtype: "unlimited"
 		},
 		{
 			type: "normal",
@@ -109,6 +105,10 @@ const card: Card = {
 			thirdParty: {
 				cardmarket: 660191
 			}
+		},
+		{
+			type: "normal",
+			subtype: "1999-2000-copyright"
 		}
 	],
 }

--- a/data/Base/Base Set/37.ts
+++ b/data/Base/Base Set/37.ts
@@ -88,7 +88,16 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
-			subtype: "unlimited",
+			subtype: "1999-2000-copyright",
+		},
+		{
+			type: "normal",
+			subtype: "unlimited"
+		},
+		{
+			type: "normal",
+			subtype: "shadowless",
+			stamp: ["1st-edition"],
 			thirdParty: {
 				cardmarket: 273732,
 				tcgplayer: 42379
@@ -97,18 +106,9 @@ const card: Card = {
 		{
 			type: "normal",
 			subtype: "shadowless",
-			stamp: ["1st-edition"]
-		},
-		{
-			type: "normal",
-			subtype: "shadowless",
 			thirdParty: {
 				cardmarket: 660191
 			}
-		},
-		{
-			type: "normal",
-			subtype: "1999-2000-copyright"
 		}
 	],
 }

--- a/data/Base/Base Set/38.ts
+++ b/data/Base/Base Set/38.ts
@@ -87,14 +87,18 @@ const card: Card = {
 		it: "Capace di vivere sia sulla terra che sott'acqua. Quando non è in acqua, suda in continuazione per mantenere lubrificato il suo corpo. LIV 28 N.61"
 	},
 
-	thirdParty: {
-		cardmarket: 273733,
-		tcgplayer: 42380
-	},
 	variants: [
 		{
 			type: "normal",
-			subtype: "unlimited",
+			subtype: "1999-2000-copyright",
+			thirdParty: {
+				cardmarket: 273733,
+				tcgplayer: 42380
+			}
+		},
+		{
+			type: "normal",
+			subtype: "unlimited"
 		},
 		{
 			type: "normal",
@@ -104,10 +108,9 @@ const card: Card = {
 		{
 			type: "normal",
 			subtype: "shadowless",
-		},
-		{
-			type: "normal",
-			subtype: "1999-2000-copyright",
+			thirdParty: {
+				cardmarket: 660190
+			}
 		}
 	],
 }

--- a/data/Base/Base Set/38.ts
+++ b/data/Base/Base Set/38.ts
@@ -90,15 +90,11 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
-			subtype: "1999-2000-copyright",
+			subtype: "unlimited",
 			thirdParty: {
 				cardmarket: 273733,
 				tcgplayer: 42380
 			}
-		},
-		{
-			type: "normal",
-			subtype: "unlimited"
 		},
 		{
 			type: "normal",
@@ -111,6 +107,10 @@ const card: Card = {
 			thirdParty: {
 				cardmarket: 660190
 			}
+		},
+		{
+			type: "normal",
+			subtype: "1999-2000-copyright"
 		}
 	],
 }

--- a/data/Base/Base Set/38.ts
+++ b/data/Base/Base Set/38.ts
@@ -90,7 +90,16 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
-			subtype: "unlimited",
+			subtype: "1999-2000-copyright",
+		},
+		{
+			type: "normal",
+			subtype: "unlimited"
+		},
+		{
+			type: "normal",
+			subtype: "shadowless",
+			stamp: ["1st-edition"],
 			thirdParty: {
 				cardmarket: 273733,
 				tcgplayer: 42380
@@ -99,18 +108,9 @@ const card: Card = {
 		{
 			type: "normal",
 			subtype: "shadowless",
-			stamp: ["1st-edition"]
-		},
-		{
-			type: "normal",
-			subtype: "shadowless",
 			thirdParty: {
 				cardmarket: 660190
 			}
-		},
-		{
-			type: "normal",
-			subtype: "1999-2000-copyright"
 		}
 	],
 }

--- a/data/Base/Base Set/39.ts
+++ b/data/Base/Base Set/39.ts
@@ -85,14 +85,18 @@ const card: Card = {
 		it: "Pokémon costituito interamente da codici di programmazione. Capace di muoversi liberamente nel ciberspazio. LIV 12 N.137"
 	},
 
-	thirdParty: {
-		cardmarket: 273734,
-		tcgplayer: 42381
-	},
 	variants: [
 		{
 			type: "normal",
-			subtype: "unlimited",
+			subtype: "1999-2000-copyright",
+			thirdParty: {
+				cardmarket: 273734,
+				tcgplayer: 42381
+			}
+		},
+		{
+			type: "normal",
+			subtype: "unlimited"
 		},
 		{
 			type: "normal",
@@ -102,10 +106,9 @@ const card: Card = {
 		{
 			type: "normal",
 			subtype: "shadowless",
-		},
-		{
-			type: "normal",
-			subtype: "1999-2000-copyright",
+			thirdParty: {
+				cardmarket: 660189
+			}
 		}
 	],
 }

--- a/data/Base/Base Set/39.ts
+++ b/data/Base/Base Set/39.ts
@@ -88,15 +88,11 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
-			subtype: "1999-2000-copyright",
+			subtype: "unlimited",
 			thirdParty: {
 				cardmarket: 273734,
 				tcgplayer: 42381
 			}
-		},
-		{
-			type: "normal",
-			subtype: "unlimited"
 		},
 		{
 			type: "normal",
@@ -109,6 +105,10 @@ const card: Card = {
 			thirdParty: {
 				cardmarket: 660189
 			}
+		},
+		{
+			type: "normal",
+			subtype: "1999-2000-copyright"
 		}
 	],
 }

--- a/data/Base/Base Set/39.ts
+++ b/data/Base/Base Set/39.ts
@@ -88,7 +88,16 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
-			subtype: "unlimited",
+			subtype: "1999-2000-copyright",
+		},
+		{
+			type: "normal",
+			subtype: "unlimited"
+		},
+		{
+			type: "normal",
+			subtype: "shadowless",
+			stamp: ["1st-edition"],
 			thirdParty: {
 				cardmarket: 273734,
 				tcgplayer: 42381
@@ -97,18 +106,9 @@ const card: Card = {
 		{
 			type: "normal",
 			subtype: "shadowless",
-			stamp: ["1st-edition"]
-		},
-		{
-			type: "normal",
-			subtype: "shadowless",
 			thirdParty: {
 				cardmarket: 660189
 			}
-		},
-		{
-			type: "normal",
-			subtype: "1999-2000-copyright"
 		}
 	],
 }

--- a/data/Base/Base Set/4.ts
+++ b/data/Base/Base Set/4.ts
@@ -99,15 +99,11 @@ const card: Card = {
 	variants: [
 		{
 			type: "holo",
-			subtype: "1999-2000-copyright",
+			subtype: "unlimited",
 			thirdParty: {
 				cardmarket: 273699,
 				tcgplayer: 42382
 			}
-		},
-		{
-			type: "holo",
-			subtype: "unlimited"
 		},
 		{
 			type: "holo",
@@ -116,18 +112,14 @@ const card: Card = {
 		},
 		{
 			type: "holo",
-			subtype: "shadowless"
-		},
-		{
-			type: "V2",
-			cardmarketLabels: ["Firc Spin Decu"]
-		},
-		{
-			type: "V2",
-			cardmarketLabels: ["Firc Spin Decu"],
+			subtype: "shadowless",
 			thirdParty: {
 				cardmarket: 660224
 			}
+		},
+		{
+			type: "holo",
+			subtype: "1999-2000-copyright"
 		}
 	],
 

--- a/data/Base/Base Set/4.ts
+++ b/data/Base/Base Set/4.ts
@@ -96,15 +96,18 @@ const card: Card = {
 		it: "Sputa fiamme così intense da sciogliere le rocce. Senza volerlo, a volte causa incendi boschivi. LIV 76 N.6"
 	},
 
-	thirdParty: {
-		cardmarket: 273699,
-		tcgplayer: 42382
-	},
-
 	variants: [
 		{
 			type: "holo",
-			subtype: "unlimited",
+			subtype: "1999-2000-copyright",
+			thirdParty: {
+				cardmarket: 273699,
+				tcgplayer: 42382
+			}
+		},
+		{
+			type: "holo",
+			subtype: "unlimited"
 		},
 		{
 			type: "holo",
@@ -113,11 +116,18 @@ const card: Card = {
 		},
 		{
 			type: "holo",
-			subtype: "shadowless",
+			subtype: "shadowless"
 		},
 		{
-			type: "holo",
-			subtype: "1999-2000-copyright",
+			type: "V2",
+			cardmarketLabels: ["Firc Spin Decu"]
+		},
+		{
+			type: "V2",
+			cardmarketLabels: ["Firc Spin Decu"],
+			thirdParty: {
+				cardmarket: 660224
+			}
 		}
 	],
 

--- a/data/Base/Base Set/4.ts
+++ b/data/Base/Base Set/4.ts
@@ -99,7 +99,16 @@ const card: Card = {
 	variants: [
 		{
 			type: "holo",
-			subtype: "unlimited",
+			subtype: "1999-2000-copyright",
+		},
+		{
+			type: "holo",
+			subtype: "unlimited"
+		},
+		{
+			type: "holo",
+			subtype: "shadowless",
+			stamp: ["1st-edition"],
 			thirdParty: {
 				cardmarket: 273699,
 				tcgplayer: 42382
@@ -107,20 +116,8 @@ const card: Card = {
 		},
 		{
 			type: "holo",
-			subtype: "shadowless",
-			stamp: ["1st-edition"]
+			subtype: "shadowless"
 		},
-		{
-			type: "holo",
-			subtype: "shadowless",
-			thirdParty: {
-				cardmarket: 660224
-			}
-		},
-		{
-			type: "holo",
-			subtype: "1999-2000-copyright"
-		}
 	],
 
 }

--- a/data/Base/Base Set/40.ts
+++ b/data/Base/Base Set/40.ts
@@ -89,14 +89,18 @@ const card: Card = {
 		it: "Usa i suoi baffi per mantenere l'equilibrio. Sembra che rallenti se i baffi gli vengono tagliati. LIV 41 N.20"
 	},
 
-	thirdParty: {
-		cardmarket: 273735,
-		tcgplayer: 42383
-	},
 	variants: [
 		{
 			type: "normal",
-			subtype: "unlimited",
+			subtype: "1999-2000-copyright",
+			thirdParty: {
+				cardmarket: 273735,
+				tcgplayer: 42383
+			}
+		},
+		{
+			type: "normal",
+			subtype: "unlimited"
 		},
 		{
 			type: "normal",
@@ -106,10 +110,9 @@ const card: Card = {
 		{
 			type: "normal",
 			subtype: "shadowless",
-		},
-		{
-			type: "normal",
-			subtype: "1999-2000-copyright",
+			thirdParty: {
+				cardmarket: 660188
+			}
 		}
 	],
 }

--- a/data/Base/Base Set/40.ts
+++ b/data/Base/Base Set/40.ts
@@ -92,15 +92,11 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
-			subtype: "1999-2000-copyright",
+			subtype: "unlimited",
 			thirdParty: {
 				cardmarket: 273735,
 				tcgplayer: 42383
 			}
-		},
-		{
-			type: "normal",
-			subtype: "unlimited"
 		},
 		{
 			type: "normal",
@@ -113,6 +109,10 @@ const card: Card = {
 			thirdParty: {
 				cardmarket: 660188
 			}
+		},
+		{
+			type: "normal",
+			subtype: "1999-2000-copyright"
 		}
 	],
 }

--- a/data/Base/Base Set/40.ts
+++ b/data/Base/Base Set/40.ts
@@ -92,7 +92,16 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
-			subtype: "unlimited",
+			subtype: "1999-2000-copyright",
+		},
+		{
+			type: "normal",
+			subtype: "unlimited"
+		},
+		{
+			type: "normal",
+			subtype: "shadowless",
+			stamp: ["1st-edition"],
 			thirdParty: {
 				cardmarket: 273735,
 				tcgplayer: 42383
@@ -101,18 +110,9 @@ const card: Card = {
 		{
 			type: "normal",
 			subtype: "shadowless",
-			stamp: ["1st-edition"]
-		},
-		{
-			type: "normal",
-			subtype: "shadowless",
 			thirdParty: {
 				cardmarket: 660188
 			}
-		},
-		{
-			type: "normal",
-			subtype: "1999-2000-copyright"
 		}
 	],
 }

--- a/data/Base/Base Set/41.ts
+++ b/data/Base/Base Set/41.ts
@@ -58,15 +58,11 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
-			subtype: "1999-2000-copyright",
+			subtype: "unlimited",
 			thirdParty: {
 				cardmarket: 273736,
 				tcgplayer: 42384
 			}
-		},
-		{
-			type: "normal",
-			subtype: "unlimited"
 		},
 		{
 			type: "normal",
@@ -79,6 +75,10 @@ const card: Card = {
 			thirdParty: {
 				cardmarket: 660187
 			}
+		},
+		{
+			type: "normal",
+			subtype: "1999-2000-copyright"
 		}
 	],
 }

--- a/data/Base/Base Set/41.ts
+++ b/data/Base/Base Set/41.ts
@@ -55,14 +55,18 @@ const card: Card = {
 		it: "Il corno che ha sulla testa è molto resistente e gli permette di sfondare anche le superfici di ghiaccio. LIV 12 N.86",
 	},
 
-	thirdParty: {
-		cardmarket: 273736,
-		tcgplayer: 42384
-	},
 	variants: [
 		{
 			type: "normal",
-			subtype: "unlimited",
+			subtype: "1999-2000-copyright",
+			thirdParty: {
+				cardmarket: 273736,
+				tcgplayer: 42384
+			}
+		},
+		{
+			type: "normal",
+			subtype: "unlimited"
 		},
 		{
 			type: "normal",
@@ -72,10 +76,9 @@ const card: Card = {
 		{
 			type: "normal",
 			subtype: "shadowless",
-		},
-		{
-			type: "normal",
-			subtype: "1999-2000-copyright",
+			thirdParty: {
+				cardmarket: 660187
+			}
 		}
 	],
 }

--- a/data/Base/Base Set/41.ts
+++ b/data/Base/Base Set/41.ts
@@ -58,7 +58,16 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
-			subtype: "unlimited",
+			subtype: "1999-2000-copyright",
+		},
+		{
+			type: "normal",
+			subtype: "unlimited"
+		},
+		{
+			type: "normal",
+			subtype: "shadowless",
+			stamp: ["1st-edition"],
 			thirdParty: {
 				cardmarket: 273736,
 				tcgplayer: 42384
@@ -67,18 +76,9 @@ const card: Card = {
 		{
 			type: "normal",
 			subtype: "shadowless",
-			stamp: ["1st-edition"]
-		},
-		{
-			type: "normal",
-			subtype: "shadowless",
 			thirdParty: {
 				cardmarket: 660187
 			}
-		},
-		{
-			type: "normal",
-			subtype: "1999-2000-copyright"
 		}
 	],
 }

--- a/data/Base/Base Set/42.ts
+++ b/data/Base/Base Set/42.ts
@@ -85,15 +85,11 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
-			subtype: "1999-2000-copyright",
+			subtype: "unlimited",
 			thirdParty: {
 				cardmarket: 273737,
 				tcgplayer: 42385
 			}
-		},
-		{
-			type: "normal",
-			subtype: "unlimited"
 		},
 		{
 			type: "normal",
@@ -106,6 +102,10 @@ const card: Card = {
 			thirdParty: {
 				cardmarket: 660186
 			}
+		},
+		{
+			type: "normal",
+			subtype: "1999-2000-copyright"
 		}
 	],
 }

--- a/data/Base/Base Set/42.ts
+++ b/data/Base/Base Set/42.ts
@@ -82,14 +82,18 @@ const card: Card = {
 		it: "Spesso di nasconde nell'acqua per sorprendere le prede. Quando nuota rapidamente, muove le orecchie per mantenersi in equilibrio. LIV 22 N.8"
 	},
 
-	thirdParty: {
-		cardmarket: 273737,
-		tcgplayer: 42385
-	},
 	variants: [
 		{
 			type: "normal",
-			subtype: "unlimited",
+			subtype: "1999-2000-copyright",
+			thirdParty: {
+				cardmarket: 273737,
+				tcgplayer: 42385
+			}
+		},
+		{
+			type: "normal",
+			subtype: "unlimited"
 		},
 		{
 			type: "normal",
@@ -99,10 +103,9 @@ const card: Card = {
 		{
 			type: "normal",
 			subtype: "shadowless",
-		},
-		{
-			type: "normal",
-			subtype: "1999-2000-copyright",
+			thirdParty: {
+				cardmarket: 660186
+			}
 		}
 	],
 }

--- a/data/Base/Base Set/42.ts
+++ b/data/Base/Base Set/42.ts
@@ -85,7 +85,16 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
-			subtype: "unlimited",
+			subtype: "1999-2000-copyright",
+		},
+		{
+			type: "normal",
+			subtype: "unlimited"
+		},
+		{
+			type: "normal",
+			subtype: "shadowless",
+			stamp: ["1st-edition"],
 			thirdParty: {
 				cardmarket: 273737,
 				tcgplayer: 42385
@@ -94,18 +103,9 @@ const card: Card = {
 		{
 			type: "normal",
 			subtype: "shadowless",
-			stamp: ["1st-edition"]
-		},
-		{
-			type: "normal",
-			subtype: "shadowless",
 			thirdParty: {
 				cardmarket: 660186
 			}
-		},
-		{
-			type: "normal",
-			subtype: "1999-2000-copyright"
 		}
 	],
 }

--- a/data/Base/Base Set/43.ts
+++ b/data/Base/Base Set/43.ts
@@ -64,15 +64,11 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
-			subtype: "1999-2000-copyright",
+			subtype: "unlimited",
 			thirdParty: {
 				cardmarket: 273738,
 				tcgplayer: 42386
 			}
-		},
-		{
-			type: "normal",
-			subtype: "unlimited"
 		},
 		{
 			type: "normal",
@@ -85,6 +81,10 @@ const card: Card = {
 			thirdParty: {
 				cardmarket: 660185
 			}
+		},
+		{
+			type: "normal",
+			subtype: "1999-2000-copyright"
 		}
 	],
 }

--- a/data/Base/Base Set/43.ts
+++ b/data/Base/Base Set/43.ts
@@ -61,14 +61,18 @@ const card: Card = {
 		it: "Le sue abilità telepatiche gli consentono di individuare eventuali pericoli e teletrasportarsi al sicuro."
 	},
 
-	thirdParty: {
-		cardmarket: 273738,
-		tcgplayer: 42386
-	},
 	variants: [
 		{
 			type: "normal",
-			subtype: "unlimited",
+			subtype: "1999-2000-copyright",
+			thirdParty: {
+				cardmarket: 273738,
+				tcgplayer: 42386
+			}
+		},
+		{
+			type: "normal",
+			subtype: "unlimited"
 		},
 		{
 			type: "normal",
@@ -78,10 +82,9 @@ const card: Card = {
 		{
 			type: "normal",
 			subtype: "shadowless",
-		},
-		{
-			type: "normal",
-			subtype: "1999-2000-copyright",
+			thirdParty: {
+				cardmarket: 660185
+			}
 		}
 	],
 }

--- a/data/Base/Base Set/43.ts
+++ b/data/Base/Base Set/43.ts
@@ -64,7 +64,16 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
-			subtype: "unlimited",
+			subtype: "1999-2000-copyright",
+		},
+		{
+			type: "normal",
+			subtype: "unlimited"
+		},
+		{
+			type: "normal",
+			subtype: "shadowless",
+			stamp: ["1st-edition"],
 			thirdParty: {
 				cardmarket: 273738,
 				tcgplayer: 42386
@@ -73,18 +82,9 @@ const card: Card = {
 		{
 			type: "normal",
 			subtype: "shadowless",
-			stamp: ["1st-edition"]
-		},
-		{
-			type: "normal",
-			subtype: "shadowless",
 			thirdParty: {
 				cardmarket: 660185
 			}
-		},
-		{
-			type: "normal",
-			subtype: "1999-2000-copyright"
 		}
 	],
 }

--- a/data/Base/Base Set/44.ts
+++ b/data/Base/Base Set/44.ts
@@ -61,14 +61,18 @@ const card: Card = {
 		it: "Lo strano seme piantato sul suo dorso dalla nascita è germogliato in una pianta che continua a crescere insieme a questo Pokémon. LIV 13 N.1"
 	},
 
-	thirdParty: {
-		cardmarket: 273739,
-		tcgplayer: 42387
-	},
 	variants: [
 		{
 			type: "normal",
-			subtype: "unlimited",
+			subtype: "1999-2000-copyright",
+			thirdParty: {
+				cardmarket: 273739,
+				tcgplayer: 42387
+			}
+		},
+		{
+			type: "normal",
+			subtype: "unlimited"
 		},
 		{
 			type: "normal",
@@ -78,10 +82,20 @@ const card: Card = {
 		{
 			type: "normal",
 			subtype: "shadowless",
+			thirdParty: {
+				cardmarket: 660184
+			}
 		},
 		{
-			type: "normal",
-			subtype: "1999-2000-copyright",
+			type: "V3",
+			cardmarketLabels: ["Attention: Oversized Card", "Not Tournament Legal"]
+		},
+		{
+			type: "V3",
+			cardmarketLabels: ["Attention: Oversized Card", "Not Tournament Legal"],
+			thirdParty: {
+				cardmarket: 547236
+			}
 		}
 	],
 }

--- a/data/Base/Base Set/44.ts
+++ b/data/Base/Base Set/44.ts
@@ -64,15 +64,11 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
-			subtype: "1999-2000-copyright",
+			subtype: "unlimited",
 			thirdParty: {
 				cardmarket: 273739,
 				tcgplayer: 42387
 			}
-		},
-		{
-			type: "normal",
-			subtype: "unlimited"
 		},
 		{
 			type: "normal",
@@ -87,15 +83,8 @@ const card: Card = {
 			}
 		},
 		{
-			type: "V3",
-			cardmarketLabels: ["Attention: Oversized Card", "Not Tournament Legal"]
-		},
-		{
-			type: "V3",
-			cardmarketLabels: ["Attention: Oversized Card", "Not Tournament Legal"],
-			thirdParty: {
-				cardmarket: 547236
-			}
+			type: "normal",
+			subtype: "1999-2000-copyright"
 		}
 	],
 }

--- a/data/Base/Base Set/44.ts
+++ b/data/Base/Base Set/44.ts
@@ -64,16 +64,20 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
-			subtype: "unlimited",
-			thirdParty: {
-				cardmarket: 273739,
-				tcgplayer: 42387
-			}
+			subtype: "1999-2000-copyright",
+		},
+		{
+			type: "normal",
+			subtype: "unlimited"
 		},
 		{
 			type: "normal",
 			subtype: "shadowless",
-			stamp: ["1st-edition"]
+			stamp: ["1st-edition"],
+			thirdParty: {
+				cardmarket: 273739,
+				tcgplayer: 42387
+			}
 		},
 		{
 			type: "normal",
@@ -84,7 +88,10 @@ const card: Card = {
 		},
 		{
 			type: "normal",
-			subtype: "1999-2000-copyright"
+			size: "jumbo",
+			thirdParty: {
+				cardmarket: 547236
+			}
 		}
 	],
 }

--- a/data/Base/Base Set/45.ts
+++ b/data/Base/Base Set/45.ts
@@ -63,15 +63,11 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
-			subtype: "1999-2000-copyright",
+			subtype: "unlimited",
 			thirdParty: {
 				cardmarket: 273740,
 				tcgplayer: 42388
 			}
-		},
-		{
-			type: "normal",
-			subtype: "unlimited"
 		},
 		{
 			type: "normal",
@@ -84,6 +80,10 @@ const card: Card = {
 			thirdParty: {
 				cardmarket: 660183
 			}
+		},
+		{
+			type: "normal",
+			subtype: "1999-2000-copyright"
 		}
 	],
 }

--- a/data/Base/Base Set/45.ts
+++ b/data/Base/Base Set/45.ts
@@ -60,14 +60,18 @@ const card: Card = {
 		it: "La punta dei suoi piedini è costituita da ventose che gli consentono di arrampicarsi senza fatica su muri e pendenze. LIV 13 N.10"
 	},
 
-	thirdParty: {
-		cardmarket: 273740,
-		tcgplayer: 42388
-	},
 	variants: [
 		{
 			type: "normal",
-			subtype: "unlimited",
+			subtype: "1999-2000-copyright",
+			thirdParty: {
+				cardmarket: 273740,
+				tcgplayer: 42388
+			}
+		},
+		{
+			type: "normal",
+			subtype: "unlimited"
 		},
 		{
 			type: "normal",
@@ -77,10 +81,9 @@ const card: Card = {
 		{
 			type: "normal",
 			subtype: "shadowless",
-		},
-		{
-			type: "normal",
-			subtype: "1999-2000-copyright",
+			thirdParty: {
+				cardmarket: 660183
+			}
 		}
 	],
 }

--- a/data/Base/Base Set/45.ts
+++ b/data/Base/Base Set/45.ts
@@ -63,7 +63,16 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
-			subtype: "unlimited",
+			subtype: "1999-2000-copyright",
+		},
+		{
+			type: "normal",
+			subtype: "unlimited"
+		},
+		{
+			type: "normal",
+			subtype: "shadowless",
+			stamp: ["1st-edition"],
 			thirdParty: {
 				cardmarket: 273740,
 				tcgplayer: 42388
@@ -72,18 +81,9 @@ const card: Card = {
 		{
 			type: "normal",
 			subtype: "shadowless",
-			stamp: ["1st-edition"]
-		},
-		{
-			type: "normal",
-			subtype: "shadowless",
 			thirdParty: {
 				cardmarket: 660183
 			}
-		},
-		{
-			type: "normal",
-			subtype: "1999-2000-copyright"
 		}
 	],
 }

--- a/data/Base/Base Set/46.ts
+++ b/data/Base/Base Set/46.ts
@@ -78,15 +78,11 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
-			subtype: "1999-2000-copyright",
+			subtype: "unlimited",
 			thirdParty: {
 				cardmarket: 273741,
 				tcgplayer: 42389
 			}
-		},
-		{
-			type: "normal",
-			subtype: "unlimited"
 		},
 		{
 			type: "normal",
@@ -101,15 +97,8 @@ const card: Card = {
 			}
 		},
 		{
-			type: "V3",
-			cardmarketLabels: ["Attention: Oversized Card", "Not Tournament Legal"]
-		},
-		{
-			type: "V3",
-			cardmarketLabels: ["Attention: Oversized Card", "Not Tournament Legal"],
-			thirdParty: {
-				cardmarket: 547241
-			}
+			type: "normal",
+			subtype: "1999-2000-copyright"
 		}
 	],
 }

--- a/data/Base/Base Set/46.ts
+++ b/data/Base/Base Set/46.ts
@@ -75,14 +75,18 @@ const card: Card = {
 		it: "Ovviamente preferisce luoghi molto caldi. Se gli capita di trovarsi sotto la pioggia, si dice che esca vapore dalla punta della sua coda."
 	},
 
-	thirdParty: {
-		cardmarket: 273741,
-		tcgplayer: 42389
-	},
 	variants: [
 		{
 			type: "normal",
-			subtype: "unlimited",
+			subtype: "1999-2000-copyright",
+			thirdParty: {
+				cardmarket: 273741,
+				tcgplayer: 42389
+			}
+		},
+		{
+			type: "normal",
+			subtype: "unlimited"
 		},
 		{
 			type: "normal",
@@ -92,10 +96,20 @@ const card: Card = {
 		{
 			type: "normal",
 			subtype: "shadowless",
+			thirdParty: {
+				cardmarket: 660182
+			}
 		},
 		{
-			type: "normal",
-			subtype: "1999-2000-copyright",
+			type: "V3",
+			cardmarketLabels: ["Attention: Oversized Card", "Not Tournament Legal"]
+		},
+		{
+			type: "V3",
+			cardmarketLabels: ["Attention: Oversized Card", "Not Tournament Legal"],
+			thirdParty: {
+				cardmarket: 547241
+			}
 		}
 	],
 }

--- a/data/Base/Base Set/46.ts
+++ b/data/Base/Base Set/46.ts
@@ -78,16 +78,20 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
-			subtype: "unlimited",
-			thirdParty: {
-				cardmarket: 273741,
-				tcgplayer: 42389
-			}
+			subtype: "1999-2000-copyright",
+		},
+		{
+			type: "normal",
+			subtype: "unlimited"
 		},
 		{
 			type: "normal",
 			subtype: "shadowless",
-			stamp: ["1st-edition"]
+			stamp: ["1st-edition"],
+			thirdParty: {
+				cardmarket: 273741,
+				tcgplayer: 42389
+			}
 		},
 		{
 			type: "normal",
@@ -98,7 +102,10 @@ const card: Card = {
 		},
 		{
 			type: "normal",
-			subtype: "1999-2000-copyright"
+			size: "jumbo",
+			thirdParty: {
+				cardmarket: 547241
+			}
 		}
 	],
 }

--- a/data/Base/Base Set/47.ts
+++ b/data/Base/Base Set/47.ts
@@ -80,15 +80,11 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
-			subtype: "1999-2000-copyright",
+			subtype: "unlimited",
 			thirdParty: {
 				cardmarket: 273742,
 				tcgplayer: 42390
 			}
-		},
-		{
-			type: "normal",
-			subtype: "unlimited"
 		},
 		{
 			type: "normal",
@@ -101,6 +97,10 @@ const card: Card = {
 			thirdParty: {
 				cardmarket: 660181
 			}
+		},
+		{
+			type: "normal",
+			subtype: "1999-2000-copyright"
 		}
 	],
 }

--- a/data/Base/Base Set/47.ts
+++ b/data/Base/Base Set/47.ts
@@ -77,14 +77,18 @@ const card: Card = {
 		it: "Vive sotto terra, dove sopravvive mangiando le radici di varie piante. Ogni tanto risale in superficie. LIV 8 N.50"
 	},
 
-	thirdParty: {
-		cardmarket: 273742,
-		tcgplayer: 42390
-	},
 	variants: [
 		{
 			type: "normal",
-			subtype: "unlimited",
+			subtype: "1999-2000-copyright",
+			thirdParty: {
+				cardmarket: 273742,
+				tcgplayer: 42390
+			}
+		},
+		{
+			type: "normal",
+			subtype: "unlimited"
 		},
 		{
 			type: "normal",
@@ -94,10 +98,9 @@ const card: Card = {
 		{
 			type: "normal",
 			subtype: "shadowless",
-		},
-		{
-			type: "normal",
-			subtype: "1999-2000-copyright",
+			thirdParty: {
+				cardmarket: 660181
+			}
 		}
 	],
 }

--- a/data/Base/Base Set/47.ts
+++ b/data/Base/Base Set/47.ts
@@ -80,7 +80,16 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
-			subtype: "unlimited",
+			subtype: "1999-2000-copyright",
+		},
+		{
+			type: "normal",
+			subtype: "unlimited"
+		},
+		{
+			type: "normal",
+			subtype: "shadowless",
+			stamp: ["1st-edition"],
 			thirdParty: {
 				cardmarket: 273742,
 				tcgplayer: 42390
@@ -89,18 +98,9 @@ const card: Card = {
 		{
 			type: "normal",
 			subtype: "shadowless",
-			stamp: ["1st-edition"]
-		},
-		{
-			type: "normal",
-			subtype: "shadowless",
 			thirdParty: {
 				cardmarket: 660181
 			}
-		},
-		{
-			type: "normal",
-			subtype: "1999-2000-copyright"
 		}
 	],
 }

--- a/data/Base/Base Set/48.ts
+++ b/data/Base/Base Set/48.ts
@@ -70,15 +70,11 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
-			subtype: "1999-2000-copyright",
+			subtype: "unlimited",
 			thirdParty: {
 				cardmarket: 273743,
 				tcgplayer: 42391
 			}
-		},
-		{
-			type: "normal",
-			subtype: "unlimited"
 		},
 		{
 			type: "normal",
@@ -91,6 +87,10 @@ const card: Card = {
 			thirdParty: {
 				cardmarket: 660180
 			}
+		},
+		{
+			type: "normal",
+			subtype: "1999-2000-copyright"
 		}
 	],
 }

--- a/data/Base/Base Set/48.ts
+++ b/data/Base/Base Set/48.ts
@@ -67,14 +67,18 @@ const card: Card = {
 		it: "Uccello non molto abile nel volo, ma imbattibile nella corsa. Le sue orme giganteschene segnalano il passaggio. LIV 10 N.84"
 	},
 
-	thirdParty: {
-		cardmarket: 273743,
-		tcgplayer: 42391
-	},
 	variants: [
 		{
 			type: "normal",
-			subtype: "unlimited",
+			subtype: "1999-2000-copyright",
+			thirdParty: {
+				cardmarket: 273743,
+				tcgplayer: 42391
+			}
+		},
+		{
+			type: "normal",
+			subtype: "unlimited"
 		},
 		{
 			type: "normal",
@@ -84,10 +88,9 @@ const card: Card = {
 		{
 			type: "normal",
 			subtype: "shadowless",
-		},
-		{
-			type: "normal",
-			subtype: "1999-2000-copyright",
+			thirdParty: {
+				cardmarket: 660180
+			}
 		}
 	],
 }

--- a/data/Base/Base Set/48.ts
+++ b/data/Base/Base Set/48.ts
@@ -70,7 +70,16 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
-			subtype: "unlimited",
+			subtype: "1999-2000-copyright",
+		},
+		{
+			type: "normal",
+			subtype: "unlimited"
+		},
+		{
+			type: "normal",
+			subtype: "shadowless",
+			stamp: ["1st-edition"],
 			thirdParty: {
 				cardmarket: 273743,
 				tcgplayer: 42391
@@ -79,18 +88,9 @@ const card: Card = {
 		{
 			type: "normal",
 			subtype: "shadowless",
-			stamp: ["1st-edition"]
-		},
-		{
-			type: "normal",
-			subtype: "shadowless",
 			thirdParty: {
 				cardmarket: 660180
 			}
-		},
-		{
-			type: "normal",
-			subtype: "1999-2000-copyright"
 		}
 	],
 }

--- a/data/Base/Base Set/49.ts
+++ b/data/Base/Base Set/49.ts
@@ -75,14 +75,18 @@ const card: Card = {
 		it: "Addormenta i suoi nemici e poi mangia i loro sogni. A volte si sente male dopo aver mangiato dei brutti sogni. LIV 12 N.96",
 	},
 
-	thirdParty: {
-		cardmarket: 273744,
-		tcgplayer: 42392
-	},
 	variants: [
 		{
 			type: "normal",
-			subtype: "unlimited",
+			subtype: "1999-2000-copyright",
+			thirdParty: {
+				cardmarket: 273744,
+				tcgplayer: 42392
+			}
+		},
+		{
+			type: "normal",
+			subtype: "unlimited"
 		},
 		{
 			type: "normal",
@@ -92,10 +96,9 @@ const card: Card = {
 		{
 			type: "normal",
 			subtype: "shadowless",
-		},
-		{
-			type: "normal",
-			subtype: "1999-2000-copyright",
+			thirdParty: {
+				cardmarket: 660179
+			}
 		}
 	],
 }

--- a/data/Base/Base Set/49.ts
+++ b/data/Base/Base Set/49.ts
@@ -78,15 +78,11 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
-			subtype: "1999-2000-copyright",
+			subtype: "unlimited",
 			thirdParty: {
 				cardmarket: 273744,
 				tcgplayer: 42392
 			}
-		},
-		{
-			type: "normal",
-			subtype: "unlimited"
 		},
 		{
 			type: "normal",
@@ -99,6 +95,10 @@ const card: Card = {
 			thirdParty: {
 				cardmarket: 660179
 			}
+		},
+		{
+			type: "normal",
+			subtype: "1999-2000-copyright"
 		}
 	],
 }

--- a/data/Base/Base Set/49.ts
+++ b/data/Base/Base Set/49.ts
@@ -78,7 +78,16 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
-			subtype: "unlimited",
+			subtype: "1999-2000-copyright",
+		},
+		{
+			type: "normal",
+			subtype: "unlimited"
+		},
+		{
+			type: "normal",
+			subtype: "shadowless",
+			stamp: ["1st-edition"],
 			thirdParty: {
 				cardmarket: 273744,
 				tcgplayer: 42392
@@ -87,18 +96,9 @@ const card: Card = {
 		{
 			type: "normal",
 			subtype: "shadowless",
-			stamp: ["1st-edition"]
-		},
-		{
-			type: "normal",
-			subtype: "shadowless",
 			thirdParty: {
 				cardmarket: 660179
 			}
-		},
-		{
-			type: "normal",
-			subtype: "1999-2000-copyright"
 		}
 	],
 }

--- a/data/Base/Base Set/5.ts
+++ b/data/Base/Base Set/5.ts
@@ -89,7 +89,15 @@ const card: Card = {
 	variants: [
 		{
 			type: "holo",
-			subtype: "unlimited",
+			subtype: "1999-2000-copyright",
+			thirdParty: {
+				cardmarket: 273700,
+				tcgplayer: 42393
+			}
+		},
+		{
+			type: "holo",
+			subtype: "unlimited"
 		},
 		{
 			type: "holo",
@@ -99,18 +107,13 @@ const card: Card = {
 		{
 			type: "holo",
 			subtype: "shadowless",
-		},
-		{
-			type: "holo",
-			subtype: "1999-2000-copyright",
+			thirdParty: {
+				cardmarket: 660223
+			}
 		}
 	],
 
 
-	thirdParty: {
-		cardmarket: 273700,
-		tcgplayer: 42393
-	}
 }
 
 export default card

--- a/data/Base/Base Set/5.ts
+++ b/data/Base/Base Set/5.ts
@@ -89,15 +89,11 @@ const card: Card = {
 	variants: [
 		{
 			type: "holo",
-			subtype: "1999-2000-copyright",
+			subtype: "unlimited",
 			thirdParty: {
 				cardmarket: 273700,
 				tcgplayer: 42393
 			}
-		},
-		{
-			type: "holo",
-			subtype: "unlimited"
 		},
 		{
 			type: "holo",
@@ -110,6 +106,10 @@ const card: Card = {
 			thirdParty: {
 				cardmarket: 660223
 			}
+		},
+		{
+			type: "holo",
+			subtype: "1999-2000-copyright"
 		}
 	],
 

--- a/data/Base/Base Set/5.ts
+++ b/data/Base/Base Set/5.ts
@@ -89,7 +89,16 @@ const card: Card = {
 	variants: [
 		{
 			type: "holo",
-			subtype: "unlimited",
+			subtype: "1999-2000-copyright",
+		},
+		{
+			type: "holo",
+			subtype: "unlimited"
+		},
+		{
+			type: "holo",
+			subtype: "shadowless",
+			stamp: ["1st-edition"],
 			thirdParty: {
 				cardmarket: 273700,
 				tcgplayer: 42393
@@ -98,18 +107,9 @@ const card: Card = {
 		{
 			type: "holo",
 			subtype: "shadowless",
-			stamp: ["1st-edition"]
-		},
-		{
-			type: "holo",
-			subtype: "shadowless",
 			thirdParty: {
 				cardmarket: 660223
 			}
-		},
-		{
-			type: "holo",
-			subtype: "1999-2000-copyright"
 		}
 	],
 

--- a/data/Base/Base Set/50.ts
+++ b/data/Base/Base Set/50.ts
@@ -78,14 +78,18 @@ const card: Card = {
 		it: "Praticamente invisibile, questo Pokémon gassoso avvolge la sua preda in una nuvola di gas che la fa immediatamente addormentare. LIV 8 N.92"
 	},
 
-	thirdParty: {
-		cardmarket: 273745,
-		tcgplayer: 42394
-	},
 	variants: [
 		{
 			type: "normal",
-			subtype: "unlimited",
+			subtype: "1999-2000-copyright",
+			thirdParty: {
+				cardmarket: 273745,
+				tcgplayer: 42394
+			}
+		},
+		{
+			type: "normal",
+			subtype: "unlimited"
 		},
 		{
 			type: "normal",
@@ -95,10 +99,9 @@ const card: Card = {
 		{
 			type: "normal",
 			subtype: "shadowless",
-		},
-		{
-			type: "normal",
-			subtype: "1999-2000-copyright",
+			thirdParty: {
+				cardmarket: 660178
+			}
 		}
 	],
 }

--- a/data/Base/Base Set/50.ts
+++ b/data/Base/Base Set/50.ts
@@ -81,15 +81,11 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
-			subtype: "1999-2000-copyright",
+			subtype: "unlimited",
 			thirdParty: {
 				cardmarket: 273745,
 				tcgplayer: 42394
 			}
-		},
-		{
-			type: "normal",
-			subtype: "unlimited"
 		},
 		{
 			type: "normal",
@@ -102,6 +98,10 @@ const card: Card = {
 			thirdParty: {
 				cardmarket: 660178
 			}
+		},
+		{
+			type: "normal",
+			subtype: "1999-2000-copyright"
 		}
 	],
 }

--- a/data/Base/Base Set/50.ts
+++ b/data/Base/Base Set/50.ts
@@ -81,7 +81,16 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
-			subtype: "unlimited",
+			subtype: "1999-2000-copyright",
+		},
+		{
+			type: "normal",
+			subtype: "unlimited"
+		},
+		{
+			type: "normal",
+			subtype: "shadowless",
+			stamp: ["1st-edition"],
 			thirdParty: {
 				cardmarket: 273745,
 				tcgplayer: 42394
@@ -90,18 +99,9 @@ const card: Card = {
 		{
 			type: "normal",
 			subtype: "shadowless",
-			stamp: ["1st-edition"]
-		},
-		{
-			type: "normal",
-			subtype: "shadowless",
 			thirdParty: {
 				cardmarket: 660178
 			}
-		},
-		{
-			type: "normal",
-			subtype: "1999-2000-copyright"
 		}
 	],
 }

--- a/data/Base/Base Set/51.ts
+++ b/data/Base/Base Set/51.ts
@@ -64,15 +64,11 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
-			subtype: "1999-2000-copyright",
+			subtype: "unlimited",
 			thirdParty: {
 				cardmarket: 273746,
 				tcgplayer: 42395
 			}
-		},
-		{
-			type: "normal",
-			subtype: "unlimited"
 		},
 		{
 			type: "normal",
@@ -85,6 +81,10 @@ const card: Card = {
 			thirdParty: {
 				cardmarket: 660177
 			}
+		},
+		{
+			type: "normal",
+			subtype: "1999-2000-copyright"
 		}
 	],
 }

--- a/data/Base/Base Set/51.ts
+++ b/data/Base/Base Set/51.ts
@@ -61,14 +61,18 @@ const card: Card = {
 		it: "Il suo corpo contiene vari tipi di gas tossici ed è per questo che spesso esplode senza alcun preavviso. LIV 13 N.109",
 	},
 
-	thirdParty: {
-		cardmarket: 273746,
-		tcgplayer: 42395
-	},
 	variants: [
 		{
 			type: "normal",
-			subtype: "unlimited",
+			subtype: "1999-2000-copyright",
+			thirdParty: {
+				cardmarket: 273746,
+				tcgplayer: 42395
+			}
+		},
+		{
+			type: "normal",
+			subtype: "unlimited"
 		},
 		{
 			type: "normal",
@@ -78,10 +82,9 @@ const card: Card = {
 		{
 			type: "normal",
 			subtype: "shadowless",
-		},
-		{
-			type: "normal",
-			subtype: "1999-2000-copyright",
+			thirdParty: {
+				cardmarket: 660177
+			}
 		}
 	],
 }

--- a/data/Base/Base Set/51.ts
+++ b/data/Base/Base Set/51.ts
@@ -64,7 +64,16 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
-			subtype: "unlimited",
+			subtype: "1999-2000-copyright",
+		},
+		{
+			type: "normal",
+			subtype: "unlimited"
+		},
+		{
+			type: "normal",
+			subtype: "shadowless",
+			stamp: ["1st-edition"],
 			thirdParty: {
 				cardmarket: 273746,
 				tcgplayer: 42395
@@ -73,18 +82,9 @@ const card: Card = {
 		{
 			type: "normal",
 			subtype: "shadowless",
-			stamp: ["1st-edition"]
-		},
-		{
-			type: "normal",
-			subtype: "shadowless",
 			thirdParty: {
 				cardmarket: 660177
 			}
-		},
-		{
-			type: "normal",
-			subtype: "1999-2000-copyright"
 		}
 	],
 }

--- a/data/Base/Base Set/52.ts
+++ b/data/Base/Base Set/52.ts
@@ -58,15 +58,11 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
-			subtype: "1999-2000-copyright",
+			subtype: "unlimited",
 			thirdParty: {
 				cardmarket: 273747,
 				tcgplayer: 42396
 			}
-		},
-		{
-			type: "normal",
-			subtype: "unlimited"
 		},
 		{
 			type: "normal",
@@ -79,6 +75,10 @@ const card: Card = {
 			thirdParty: {
 				cardmarket: 660176
 			}
+		},
+		{
+			type: "normal",
+			subtype: "1999-2000-copyright"
 		}
 	],
 }

--- a/data/Base/Base Set/52.ts
+++ b/data/Base/Base Set/52.ts
@@ -55,14 +55,18 @@ const card: Card = {
 		it: "Si allena continuamente per sviluppare al massimo i suoi muscoli d'acciaio. Pratica tutte le arti marziali per diventare sempre più invincibile. LIV 20 N.66",
 	},
 
-	thirdParty: {
-		cardmarket: 273747,
-		tcgplayer: 42396
-	},
 	variants: [
 		{
 			type: "normal",
-			subtype: "unlimited",
+			subtype: "1999-2000-copyright",
+			thirdParty: {
+				cardmarket: 273747,
+				tcgplayer: 42396
+			}
+		},
+		{
+			type: "normal",
+			subtype: "unlimited"
 		},
 		{
 			type: "normal",
@@ -72,10 +76,9 @@ const card: Card = {
 		{
 			type: "normal",
 			subtype: "shadowless",
-		},
-		{
-			type: "normal",
-			subtype: "1999-2000-copyright",
+			thirdParty: {
+				cardmarket: 660176
+			}
 		}
 	],
 }

--- a/data/Base/Base Set/52.ts
+++ b/data/Base/Base Set/52.ts
@@ -58,7 +58,16 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
-			subtype: "unlimited",
+			subtype: "1999-2000-copyright",
+		},
+		{
+			type: "normal",
+			subtype: "unlimited"
+		},
+		{
+			type: "normal",
+			subtype: "shadowless",
+			stamp: ["1st-edition"],
 			thirdParty: {
 				cardmarket: 273747,
 				tcgplayer: 42396
@@ -67,18 +76,9 @@ const card: Card = {
 		{
 			type: "normal",
 			subtype: "shadowless",
-			stamp: ["1st-edition"]
-		},
-		{
-			type: "normal",
-			subtype: "shadowless",
 			thirdParty: {
 				cardmarket: 660176
 			}
-		},
-		{
-			type: "normal",
-			subtype: "1999-2000-copyright"
 		}
 	],
 }

--- a/data/Base/Base Set/53.ts
+++ b/data/Base/Base Set/53.ts
@@ -83,15 +83,11 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
-			subtype: "1999-2000-copyright",
+			subtype: "unlimited",
 			thirdParty: {
 				cardmarket: 273748,
 				tcgplayer: 42397
 			}
-		},
-		{
-			type: "normal",
-			subtype: "unlimited"
 		},
 		{
 			type: "normal",
@@ -104,6 +100,10 @@ const card: Card = {
 			thirdParty: {
 				cardmarket: 660175
 			}
+		},
+		{
+			type: "normal",
+			subtype: "1999-2000-copyright"
 		}
 	],
 }

--- a/data/Base/Base Set/53.ts
+++ b/data/Base/Base Set/53.ts
@@ -80,14 +80,18 @@ const card: Card = {
 		it: "Usa l'antigravità per rimanere sospeso. Appare senza preavviso e usa attacchi come Tuononda. LIV 13 N.81"
 	},
 
-	thirdParty: {
-		cardmarket: 273748,
-		tcgplayer: 42397
-	},
 	variants: [
 		{
 			type: "normal",
-			subtype: "unlimited",
+			subtype: "1999-2000-copyright",
+			thirdParty: {
+				cardmarket: 273748,
+				tcgplayer: 42397
+			}
+		},
+		{
+			type: "normal",
+			subtype: "unlimited"
 		},
 		{
 			type: "normal",
@@ -97,10 +101,9 @@ const card: Card = {
 		{
 			type: "normal",
 			subtype: "shadowless",
-		},
-		{
-			type: "normal",
-			subtype: "1999-2000-copyright",
+			thirdParty: {
+				cardmarket: 660175
+			}
 		}
 	],
 }

--- a/data/Base/Base Set/53.ts
+++ b/data/Base/Base Set/53.ts
@@ -83,7 +83,16 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
-			subtype: "unlimited",
+			subtype: "1999-2000-copyright",
+		},
+		{
+			type: "normal",
+			subtype: "unlimited"
+		},
+		{
+			type: "normal",
+			subtype: "shadowless",
+			stamp: ["1st-edition"],
 			thirdParty: {
 				cardmarket: 273748,
 				tcgplayer: 42397
@@ -92,18 +101,9 @@ const card: Card = {
 		{
 			type: "normal",
 			subtype: "shadowless",
-			stamp: ["1st-edition"]
-		},
-		{
-			type: "normal",
-			subtype: "shadowless",
 			thirdParty: {
 				cardmarket: 660175
 			}
-		},
-		{
-			type: "normal",
-			subtype: "1999-2000-copyright"
 		}
 	],
 }

--- a/data/Base/Base Set/54.ts
+++ b/data/Base/Base Set/54.ts
@@ -89,15 +89,11 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
-			subtype: "1999-2000-copyright",
+			subtype: "unlimited",
 			thirdParty: {
 				cardmarket: 273749,
 				tcgplayer: 42398
 			}
-		},
-		{
-			type: "normal",
-			subtype: "unlimited"
 		},
 		{
 			type: "normal",
@@ -110,6 +106,10 @@ const card: Card = {
 			thirdParty: {
 				cardmarket: 660174
 			}
+		},
+		{
+			type: "normal",
+			subtype: "1999-2000-copyright"
 		}
 	],
 }

--- a/data/Base/Base Set/54.ts
+++ b/data/Base/Base Set/54.ts
@@ -86,14 +86,18 @@ const card: Card = {
 		it: "È vulnerabile agli attacchi a causa del suo guscio morbido, che non protegge il suo corpo debole e molle. LIV 21 N.11"
 	},
 
-	thirdParty: {
-		cardmarket: 273749,
-		tcgplayer: 42398
-	},
 	variants: [
 		{
 			type: "normal",
-			subtype: "unlimited",
+			subtype: "1999-2000-copyright",
+			thirdParty: {
+				cardmarket: 273749,
+				tcgplayer: 42398
+			}
+		},
+		{
+			type: "normal",
+			subtype: "unlimited"
 		},
 		{
 			type: "normal",
@@ -103,10 +107,9 @@ const card: Card = {
 		{
 			type: "normal",
 			subtype: "shadowless",
-		},
-		{
-			type: "normal",
-			subtype: "1999-2000-copyright",
+			thirdParty: {
+				cardmarket: 660174
+			}
 		}
 	],
 }

--- a/data/Base/Base Set/54.ts
+++ b/data/Base/Base Set/54.ts
@@ -89,7 +89,16 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
-			subtype: "unlimited",
+			subtype: "1999-2000-copyright",
+		},
+		{
+			type: "normal",
+			subtype: "unlimited"
+		},
+		{
+			type: "normal",
+			subtype: "shadowless",
+			stamp: ["1st-edition"],
 			thirdParty: {
 				cardmarket: 273749,
 				tcgplayer: 42398
@@ -98,18 +107,9 @@ const card: Card = {
 		{
 			type: "normal",
 			subtype: "shadowless",
-			stamp: ["1st-edition"]
-		},
-		{
-			type: "normal",
-			subtype: "shadowless",
 			thirdParty: {
 				cardmarket: 660174
 			}
-		},
-		{
-			type: "normal",
-			subtype: "1999-2000-copyright"
 		}
 	],
 }

--- a/data/Base/Base Set/55.ts
+++ b/data/Base/Base Set/55.ts
@@ -59,20 +59,13 @@ const card: Card = {
 		fr: "Son ouïe très fine l'avertit du danger. Plus ses cornes sont grandes, plus son poison est mortel.",
 		it: "Drizza le orecchie per sentire il pericolo. Il più grande e potente dei suoi corni secerne veleno.",
 	},
-
-
-
 	variants: [
 		{
 			type: "normal",
-			subtype: "1999-2000-copyright",
+			subtype: "unlimited",
 			thirdParty: {
 				cardmarket: 273750
 			}
-		},
-		{
-			type: "normal",
-			subtype: "unlimited"
 		},
 		{
 			type: "normal",
@@ -85,6 +78,10 @@ const card: Card = {
 			thirdParty: {
 				cardmarket: 660173
 			}
+		},
+		{
+			type: "normal",
+			subtype: "1999-2000-copyright"
 		}
 	],
 }

--- a/data/Base/Base Set/55.ts
+++ b/data/Base/Base Set/55.ts
@@ -59,10 +59,20 @@ const card: Card = {
 		fr: "Son ouïe très fine l'avertit du danger. Plus ses cornes sont grandes, plus son poison est mortel.",
 		it: "Drizza le orecchie per sentire il pericolo. Il più grande e potente dei suoi corni secerne veleno.",
 	},
+
+
+
 	variants: [
 		{
 			type: "normal",
-			subtype: "unlimited",
+			subtype: "1999-2000-copyright",
+			thirdParty: {
+				cardmarket: 273750
+			}
+		},
+		{
+			type: "normal",
+			subtype: "unlimited"
 		},
 		{
 			type: "normal",
@@ -72,10 +82,9 @@ const card: Card = {
 		{
 			type: "normal",
 			subtype: "shadowless",
-		},
-		{
-			type: "normal",
-			subtype: "1999-2000-copyright",
+			thirdParty: {
+				cardmarket: 660173
+			}
 		}
 	],
 }

--- a/data/Base/Base Set/55.ts
+++ b/data/Base/Base Set/55.ts
@@ -59,10 +59,22 @@ const card: Card = {
 		fr: "Son ouïe très fine l'avertit du danger. Plus ses cornes sont grandes, plus son poison est mortel.",
 		it: "Drizza le orecchie per sentire il pericolo. Il più grande e potente dei suoi corni secerne veleno.",
 	},
+
+
+
 	variants: [
 		{
 			type: "normal",
-			subtype: "unlimited",
+			subtype: "1999-2000-copyright",
+		},
+		{
+			type: "normal",
+			subtype: "unlimited"
+		},
+		{
+			type: "normal",
+			subtype: "shadowless",
+			stamp: ["1st-edition"],
 			thirdParty: {
 				cardmarket: 273750
 			}
@@ -70,18 +82,9 @@ const card: Card = {
 		{
 			type: "normal",
 			subtype: "shadowless",
-			stamp: ["1st-edition"]
-		},
-		{
-			type: "normal",
-			subtype: "shadowless",
 			thirdParty: {
 				cardmarket: 660173
 			}
-		},
-		{
-			type: "normal",
-			subtype: "1999-2000-copyright"
 		}
 	],
 }

--- a/data/Base/Base Set/56.ts
+++ b/data/Base/Base Set/56.ts
@@ -77,15 +77,11 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
-			subtype: "1999-2000-copyright",
+			subtype: "unlimited",
 			thirdParty: {
 				cardmarket: 273751,
 				tcgplayer: 42400
 			}
-		},
-		{
-			type: "normal",
-			subtype: "unlimited"
 		},
 		{
 			type: "normal",
@@ -98,6 +94,10 @@ const card: Card = {
 			thirdParty: {
 				cardmarket: 660172
 			}
+		},
+		{
+			type: "normal",
+			subtype: "1999-2000-copyright"
 		}
 	],
 }

--- a/data/Base/Base Set/56.ts
+++ b/data/Base/Base Set/56.ts
@@ -74,14 +74,18 @@ const card: Card = {
 		it: "Man mano che cresce, la parte di pietra del suo corpo si indurisce fino a diventare simile al diamante, ma di colore nero. LIV 12 N.95"
 	},
 
-	thirdParty: {
-		cardmarket: 273751,
-		tcgplayer: 42400
-	},
 	variants: [
 		{
 			type: "normal",
-			subtype: "unlimited",
+			subtype: "1999-2000-copyright",
+			thirdParty: {
+				cardmarket: 273751,
+				tcgplayer: 42400
+			}
+		},
+		{
+			type: "normal",
+			subtype: "unlimited"
 		},
 		{
 			type: "normal",
@@ -91,10 +95,9 @@ const card: Card = {
 		{
 			type: "normal",
 			subtype: "shadowless",
-		},
-		{
-			type: "normal",
-			subtype: "1999-2000-copyright",
+			thirdParty: {
+				cardmarket: 660172
+			}
 		}
 	],
 }

--- a/data/Base/Base Set/56.ts
+++ b/data/Base/Base Set/56.ts
@@ -77,7 +77,16 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
-			subtype: "unlimited",
+			subtype: "1999-2000-copyright",
+		},
+		{
+			type: "normal",
+			subtype: "unlimited"
+		},
+		{
+			type: "normal",
+			subtype: "shadowless",
+			stamp: ["1st-edition"],
 			thirdParty: {
 				cardmarket: 273751,
 				tcgplayer: 42400
@@ -86,18 +95,9 @@ const card: Card = {
 		{
 			type: "normal",
 			subtype: "shadowless",
-			stamp: ["1st-edition"]
-		},
-		{
-			type: "normal",
-			subtype: "shadowless",
 			thirdParty: {
 				cardmarket: 660172
 			}
-		},
-		{
-			type: "normal",
-			subtype: "1999-2000-copyright"
 		}
 	],
 }

--- a/data/Base/Base Set/57.ts
+++ b/data/Base/Base Set/57.ts
@@ -71,15 +71,11 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
-			subtype: "1999-2000-copyright",
+			subtype: "unlimited",
 			thirdParty: {
 				cardmarket: 273752,
 				tcgplayer: 42401
 			}
-		},
-		{
-			type: "normal",
-			subtype: "unlimited"
 		},
 		{
 			type: "normal",
@@ -92,6 +88,10 @@ const card: Card = {
 			thirdParty: {
 				cardmarket: 660171
 			}
+		},
+		{
+			type: "normal",
+			subtype: "1999-2000-copyright"
 		}
 	],
 }

--- a/data/Base/Base Set/57.ts
+++ b/data/Base/Base Set/57.ts
@@ -68,14 +68,18 @@ const card: Card = {
 		it: "È una presenza comune nelle foreste e nei boschi. Sbatte le ali quando è a terra per alzare sabbia accecante. LIV 8 N.16"
 	},
 
-	thirdParty: {
-		cardmarket: 273752,
-		tcgplayer: 42401
-	},
 	variants: [
 		{
 			type: "normal",
-			subtype: "unlimited",
+			subtype: "1999-2000-copyright",
+			thirdParty: {
+				cardmarket: 273752,
+				tcgplayer: 42401
+			}
+		},
+		{
+			type: "normal",
+			subtype: "unlimited"
 		},
 		{
 			type: "normal",
@@ -85,10 +89,9 @@ const card: Card = {
 		{
 			type: "normal",
 			subtype: "shadowless",
-		},
-		{
-			type: "normal",
-			subtype: "1999-2000-copyright",
+			thirdParty: {
+				cardmarket: 660171
+			}
 		}
 	],
 }

--- a/data/Base/Base Set/57.ts
+++ b/data/Base/Base Set/57.ts
@@ -71,7 +71,16 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
-			subtype: "unlimited",
+			subtype: "1999-2000-copyright",
+		},
+		{
+			type: "normal",
+			subtype: "unlimited"
+		},
+		{
+			type: "normal",
+			subtype: "shadowless",
+			stamp: ["1st-edition"],
 			thirdParty: {
 				cardmarket: 273752,
 				tcgplayer: 42401
@@ -80,18 +89,9 @@ const card: Card = {
 		{
 			type: "normal",
 			subtype: "shadowless",
-			stamp: ["1st-edition"]
-		},
-		{
-			type: "normal",
-			subtype: "shadowless",
 			thirdParty: {
 				cardmarket: 660171
 			}
-		},
-		{
-			type: "normal",
-			subtype: "1999-2000-copyright"
 		}
 	],
 }

--- a/data/Base/Base Set/58.ts
+++ b/data/Base/Base Set/58.ts
@@ -78,15 +78,11 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
-			subtype: "1999-2000-copyright",
+			subtype: "unlimited",
 			thirdParty: {
 				cardmarket: 273753,
 				tcgplayer: 42402
 			}
-		},
-		{
-			type: "normal",
-			subtype: "unlimited"
 		},
 		{
 			type: "normal",
@@ -95,51 +91,14 @@ const card: Card = {
 		},
 		{
 			type: "normal",
-			subtype: "shadowless"
-		},
-		{
-			type: "V2",
-			cardmarketLabels: ["Leh D", "Reustance", "Rete"]
-		},
-		{
-			type: "V4",
-			cardmarketLabels: ["Thunder Jolt Flip a coin. If", "tails. Pikachu does I0 damage", "icself;"]
-		},
-		{
-			type: "V5",
-			cardmarketLabels: ["itsell: Pikachu does I0 damage Su"]
-		},
-		{
-			type: "V6",
-			cardmarketLabels: ["Attention: Oversized Card", "Not Tournament Legal"]
-		},
-		{
-			type: "V2",
-			cardmarketLabels: ["Leh D", "Reustance", "Rete"],
+			subtype: "shadowless",
 			thirdParty: {
 				cardmarket: 660169
 			}
 		},
 		{
-			type: "V4",
-			cardmarketLabels: ["Thunder Jolt Flip a coin. If", "tails. Pikachu does I0 damage", "icself;"],
-			thirdParty: {
-				cardmarket: 275568
-			}
-		},
-		{
-			type: "V5",
-			cardmarketLabels: ["itsell: Pikachu does I0 damage Su"],
-			thirdParty: {
-				cardmarket: 275586
-			}
-		},
-		{
-			type: "V6",
-			cardmarketLabels: ["Attention: Oversized Card", "Not Tournament Legal"],
-			thirdParty: {
-				cardmarket: 362859
-			}
+			type: "normal",
+			subtype: "1999-2000-copyright"
 		}
 	],
 }

--- a/data/Base/Base Set/58.ts
+++ b/data/Base/Base Set/58.ts
@@ -75,14 +75,18 @@ const card: Card = {
 		it: "Quando diversi Pokémon di questo tipo si riuniscono, generano tanta energia elettrica da scatenare delle tempeste di fulmini. LIV 12 N.25"
 	},
 
-	thirdParty: {
-		cardmarket: 273753,
-		tcgplayer: 42402
-	},
 	variants: [
 		{
 			type: "normal",
-			subtype: "unlimited",
+			subtype: "1999-2000-copyright",
+			thirdParty: {
+				cardmarket: 273753,
+				tcgplayer: 42402
+			}
+		},
+		{
+			type: "normal",
+			subtype: "unlimited"
 		},
 		{
 			type: "normal",
@@ -91,11 +95,51 @@ const card: Card = {
 		},
 		{
 			type: "normal",
-			subtype: "shadowless",
+			subtype: "shadowless"
 		},
 		{
-			type: "normal",
-			subtype: "1999-2000-copyright",
+			type: "V2",
+			cardmarketLabels: ["Leh D", "Reustance", "Rete"]
+		},
+		{
+			type: "V4",
+			cardmarketLabels: ["Thunder Jolt Flip a coin. If", "tails. Pikachu does I0 damage", "icself;"]
+		},
+		{
+			type: "V5",
+			cardmarketLabels: ["itsell: Pikachu does I0 damage Su"]
+		},
+		{
+			type: "V6",
+			cardmarketLabels: ["Attention: Oversized Card", "Not Tournament Legal"]
+		},
+		{
+			type: "V2",
+			cardmarketLabels: ["Leh D", "Reustance", "Rete"],
+			thirdParty: {
+				cardmarket: 660169
+			}
+		},
+		{
+			type: "V4",
+			cardmarketLabels: ["Thunder Jolt Flip a coin. If", "tails. Pikachu does I0 damage", "icself;"],
+			thirdParty: {
+				cardmarket: 275568
+			}
+		},
+		{
+			type: "V5",
+			cardmarketLabels: ["itsell: Pikachu does I0 damage Su"],
+			thirdParty: {
+				cardmarket: 275586
+			}
+		},
+		{
+			type: "V6",
+			cardmarketLabels: ["Attention: Oversized Card", "Not Tournament Legal"],
+			thirdParty: {
+				cardmarket: 362859
+			}
 		}
 	],
 }

--- a/data/Base/Base Set/58.ts
+++ b/data/Base/Base Set/58.ts
@@ -78,7 +78,16 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
-			subtype: "unlimited",
+			subtype: "1999-2000-copyright",
+		},
+		{
+			type: "normal",
+			subtype: "unlimited"
+		},
+		{
+			type: "normal",
+			subtype: "shadowless",
+			stamp: ["1st-edition"],
 			thirdParty: {
 				cardmarket: 273753,
 				tcgplayer: 42402
@@ -86,19 +95,14 @@ const card: Card = {
 		},
 		{
 			type: "normal",
-			subtype: "shadowless",
-			stamp: ["1st-edition"]
+			subtype: "shadowless"
 		},
 		{
 			type: "normal",
-			subtype: "shadowless",
+			size: "jumbo",
 			thirdParty: {
-				cardmarket: 660169
+				cardmarket: 362859
 			}
-		},
-		{
-			type: "normal",
-			subtype: "1999-2000-copyright"
 		}
 	],
 }

--- a/data/Base/Base Set/59.ts
+++ b/data/Base/Base Set/59.ts
@@ -60,14 +60,18 @@ const card: Card = {
 		it: "Le sue gambe appena sviluppate non riescono a sostenerlo nella corsa; preferisce nuotare inceve di stare in piedi. LIV 13 N.60"
 	},
 
-	thirdParty: {
-		cardmarket: 273754,
-		tcgplayer: 42403
-	},
 	variants: [
 		{
 			type: "normal",
-			subtype: "unlimited",
+			subtype: "1999-2000-copyright",
+			thirdParty: {
+				cardmarket: 273754,
+				tcgplayer: 42403
+			}
+		},
+		{
+			type: "normal",
+			subtype: "unlimited"
 		},
 		{
 			type: "normal",
@@ -77,10 +81,9 @@ const card: Card = {
 		{
 			type: "normal",
 			subtype: "shadowless",
-		},
-		{
-			type: "normal",
-			subtype: "1999-2000-copyright",
+			thirdParty: {
+				cardmarket: 660168
+			}
 		}
 	],
 }

--- a/data/Base/Base Set/59.ts
+++ b/data/Base/Base Set/59.ts
@@ -63,15 +63,11 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
-			subtype: "1999-2000-copyright",
+			subtype: "unlimited",
 			thirdParty: {
 				cardmarket: 273754,
 				tcgplayer: 42403
 			}
-		},
-		{
-			type: "normal",
-			subtype: "unlimited"
 		},
 		{
 			type: "normal",
@@ -84,6 +80,10 @@ const card: Card = {
 			thirdParty: {
 				cardmarket: 660168
 			}
+		},
+		{
+			type: "normal",
+			subtype: "1999-2000-copyright"
 		}
 	],
 }

--- a/data/Base/Base Set/59.ts
+++ b/data/Base/Base Set/59.ts
@@ -63,7 +63,16 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
-			subtype: "unlimited",
+			subtype: "1999-2000-copyright",
+		},
+		{
+			type: "normal",
+			subtype: "unlimited"
+		},
+		{
+			type: "normal",
+			subtype: "shadowless",
+			stamp: ["1st-edition"],
 			thirdParty: {
 				cardmarket: 273754,
 				tcgplayer: 42403
@@ -72,18 +81,9 @@ const card: Card = {
 		{
 			type: "normal",
 			subtype: "shadowless",
-			stamp: ["1st-edition"]
-		},
-		{
-			type: "normal",
-			subtype: "shadowless",
 			thirdParty: {
 				cardmarket: 660168
 			}
-		},
-		{
-			type: "normal",
-			subtype: "1999-2000-copyright"
 		}
 	],
 }

--- a/data/Base/Base Set/6.ts
+++ b/data/Base/Base Set/6.ts
@@ -90,15 +90,11 @@ const card: Card = {
 	variants: [
 		{
 			type: "holo",
-			subtype: "1999-2000-copyright",
+			subtype: "unlimited",
 			thirdParty: {
 				cardmarket: 273701,
 				tcgplayer: 42404
 			}
-		},
-		{
-			type: "holo",
-			subtype: "unlimited"
 		},
 		{
 			type: "holo",
@@ -111,6 +107,10 @@ const card: Card = {
 			thirdParty: {
 				cardmarket: 660222
 			}
+		},
+		{
+			type: "holo",
+			subtype: "1999-2000-copyright"
 		}
 	],
 

--- a/data/Base/Base Set/6.ts
+++ b/data/Base/Base Set/6.ts
@@ -90,7 +90,15 @@ const card: Card = {
 	variants: [
 		{
 			type: "holo",
-			subtype: "unlimited",
+			subtype: "1999-2000-copyright",
+			thirdParty: {
+				cardmarket: 273701,
+				tcgplayer: 42404
+			}
+		},
+		{
+			type: "holo",
+			subtype: "unlimited"
 		},
 		{
 			type: "holo",
@@ -100,10 +108,9 @@ const card: Card = {
 		{
 			type: "holo",
 			subtype: "shadowless",
-		},
-		{
-			type: "holo",
-			subtype: "1999-2000-copyright",
+			thirdParty: {
+				cardmarket: 660222
+			}
 		}
 	],
 
@@ -113,10 +120,6 @@ const card: Card = {
 		it: "Appare raramente nelle regioni selvagge. Enorme e feroce, se si infuria è capace di distruggere intere città. LIV 41 N.130"
 	},
 
-	thirdParty: {
-		cardmarket: 273701,
-		tcgplayer: 42404
-	}
 }
 
 export default card

--- a/data/Base/Base Set/6.ts
+++ b/data/Base/Base Set/6.ts
@@ -90,7 +90,16 @@ const card: Card = {
 	variants: [
 		{
 			type: "holo",
-			subtype: "unlimited",
+			subtype: "1999-2000-copyright",
+		},
+		{
+			type: "holo",
+			subtype: "unlimited"
+		},
+		{
+			type: "holo",
+			subtype: "shadowless",
+			stamp: ["1st-edition"],
 			thirdParty: {
 				cardmarket: 273701,
 				tcgplayer: 42404
@@ -99,18 +108,9 @@ const card: Card = {
 		{
 			type: "holo",
 			subtype: "shadowless",
-			stamp: ["1st-edition"]
-		},
-		{
-			type: "holo",
-			subtype: "shadowless",
 			thirdParty: {
 				cardmarket: 660222
 			}
-		},
-		{
-			type: "holo",
-			subtype: "1999-2000-copyright"
 		}
 	],
 

--- a/data/Base/Base Set/60.ts
+++ b/data/Base/Base Set/60.ts
@@ -71,14 +71,18 @@ const card: Card = {
 		it: "I suoi zoccoli sono più duri dei diamanti e schiacciano qualsiasi ostacolo in pochi secondi. LIV 10 N.77"
 	},
 
-	thirdParty: {
-		cardmarket: 273755,
-		tcgplayer: 42405
-	},
 	variants: [
 		{
 			type: "normal",
-			subtype: "unlimited",
+			subtype: "1999-2000-copyright",
+			thirdParty: {
+				cardmarket: 273755,
+				tcgplayer: 42405
+			}
+		},
+		{
+			type: "normal",
+			subtype: "unlimited"
 		},
 		{
 			type: "normal",
@@ -88,10 +92,9 @@ const card: Card = {
 		{
 			type: "normal",
 			subtype: "shadowless",
-		},
-		{
-			type: "normal",
-			subtype: "1999-2000-copyright",
+			thirdParty: {
+				cardmarket: 660167
+			}
 		}
 	],
 }

--- a/data/Base/Base Set/60.ts
+++ b/data/Base/Base Set/60.ts
@@ -74,15 +74,11 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
-			subtype: "1999-2000-copyright",
+			subtype: "unlimited",
 			thirdParty: {
 				cardmarket: 273755,
 				tcgplayer: 42405
 			}
-		},
-		{
-			type: "normal",
-			subtype: "unlimited"
 		},
 		{
 			type: "normal",
@@ -95,6 +91,10 @@ const card: Card = {
 			thirdParty: {
 				cardmarket: 660167
 			}
+		},
+		{
+			type: "normal",
+			subtype: "1999-2000-copyright"
 		}
 	],
 }

--- a/data/Base/Base Set/60.ts
+++ b/data/Base/Base Set/60.ts
@@ -74,7 +74,16 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
-			subtype: "unlimited",
+			subtype: "1999-2000-copyright",
+		},
+		{
+			type: "normal",
+			subtype: "unlimited"
+		},
+		{
+			type: "normal",
+			subtype: "shadowless",
+			stamp: ["1st-edition"],
 			thirdParty: {
 				cardmarket: 273755,
 				tcgplayer: 42405
@@ -83,18 +92,9 @@ const card: Card = {
 		{
 			type: "normal",
 			subtype: "shadowless",
-			stamp: ["1st-edition"]
-		},
-		{
-			type: "normal",
-			subtype: "shadowless",
 			thirdParty: {
 				cardmarket: 660167
 			}
-		},
-		{
-			type: "normal",
-			subtype: "1999-2000-copyright"
 		}
 	],
 }

--- a/data/Base/Base Set/61.ts
+++ b/data/Base/Base Set/61.ts
@@ -65,15 +65,11 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
-			subtype: "1999-2000-copyright",
+			subtype: "unlimited",
 			thirdParty: {
 				cardmarket: 273756,
 				tcgplayer: 42406
 			}
-		},
-		{
-			type: "normal",
-			subtype: "unlimited"
 		},
 		{
 			type: "normal",
@@ -86,6 +82,10 @@ const card: Card = {
 			thirdParty: {
 				cardmarket: 660166
 			}
+		},
+		{
+			type: "normal",
+			subtype: "1999-2000-copyright"
 		}
 	],
 }

--- a/data/Base/Base Set/61.ts
+++ b/data/Base/Base Set/61.ts
@@ -62,14 +62,18 @@ const card: Card = {
 		it: "Morde quasiasi cosa quando attacca. Piccolo e velocissimo, è una presenza comune in molti luoghi. LIV 9 N.19"
 	},
 
-	thirdParty: {
-		cardmarket: 273756,
-		tcgplayer: 42406
-	},
 	variants: [
 		{
 			type: "normal",
-			subtype: "unlimited",
+			subtype: "1999-2000-copyright",
+			thirdParty: {
+				cardmarket: 273756,
+				tcgplayer: 42406
+			}
+		},
+		{
+			type: "normal",
+			subtype: "unlimited"
 		},
 		{
 			type: "normal",
@@ -79,10 +83,9 @@ const card: Card = {
 		{
 			type: "normal",
 			subtype: "shadowless",
-		},
-		{
-			type: "normal",
-			subtype: "1999-2000-copyright",
+			thirdParty: {
+				cardmarket: 660166
+			}
 		}
 	],
 }

--- a/data/Base/Base Set/61.ts
+++ b/data/Base/Base Set/61.ts
@@ -65,7 +65,16 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
-			subtype: "unlimited",
+			subtype: "1999-2000-copyright",
+		},
+		{
+			type: "normal",
+			subtype: "unlimited"
+		},
+		{
+			type: "normal",
+			subtype: "shadowless",
+			stamp: ["1st-edition"],
 			thirdParty: {
 				cardmarket: 273756,
 				tcgplayer: 42406
@@ -74,18 +83,9 @@ const card: Card = {
 		{
 			type: "normal",
 			subtype: "shadowless",
-			stamp: ["1st-edition"]
-		},
-		{
-			type: "normal",
-			subtype: "shadowless",
 			thirdParty: {
 				cardmarket: 660166
 			}
-		},
-		{
-			type: "normal",
-			subtype: "1999-2000-copyright"
 		}
 	],
 }

--- a/data/Base/Base Set/62.ts
+++ b/data/Base/Base Set/62.ts
@@ -68,14 +68,18 @@ const card: Card = {
 		it: "Vive in tane sotterranee in località aride, lontano da fonti d'acqua. Riappare solo quando è alla ricerca di cibo. LIV 12, N.27"
 	},
 
-	thirdParty: {
-		cardmarket: 273757,
-		tcgplayer: 42407
-	},
 	variants: [
 		{
 			type: "normal",
-			subtype: "unlimited",
+			subtype: "1999-2000-copyright",
+			thirdParty: {
+				cardmarket: 273757,
+				tcgplayer: 42407
+			}
+		},
+		{
+			type: "normal",
+			subtype: "unlimited"
 		},
 		{
 			type: "normal",
@@ -85,10 +89,9 @@ const card: Card = {
 		{
 			type: "normal",
 			subtype: "shadowless",
-		},
-		{
-			type: "normal",
-			subtype: "1999-2000-copyright",
+			thirdParty: {
+				cardmarket: 660165
+			}
 		}
 	],
 }

--- a/data/Base/Base Set/62.ts
+++ b/data/Base/Base Set/62.ts
@@ -71,15 +71,11 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
-			subtype: "1999-2000-copyright",
+			subtype: "unlimited",
 			thirdParty: {
 				cardmarket: 273757,
 				tcgplayer: 42407
 			}
-		},
-		{
-			type: "normal",
-			subtype: "unlimited"
 		},
 		{
 			type: "normal",
@@ -92,6 +88,10 @@ const card: Card = {
 			thirdParty: {
 				cardmarket: 660165
 			}
+		},
+		{
+			type: "normal",
+			subtype: "1999-2000-copyright"
 		}
 	],
 }

--- a/data/Base/Base Set/62.ts
+++ b/data/Base/Base Set/62.ts
@@ -71,7 +71,16 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
-			subtype: "unlimited",
+			subtype: "1999-2000-copyright",
+		},
+		{
+			type: "normal",
+			subtype: "unlimited"
+		},
+		{
+			type: "normal",
+			subtype: "shadowless",
+			stamp: ["1st-edition"],
 			thirdParty: {
 				cardmarket: 273757,
 				tcgplayer: 42407
@@ -80,18 +89,9 @@ const card: Card = {
 		{
 			type: "normal",
 			subtype: "shadowless",
-			stamp: ["1st-edition"]
-		},
-		{
-			type: "normal",
-			subtype: "shadowless",
 			thirdParty: {
 				cardmarket: 660165
 			}
-		},
-		{
-			type: "normal",
-			subtype: "1999-2000-copyright"
 		}
 	],
 }

--- a/data/Base/Base Set/63.ts
+++ b/data/Base/Base Set/63.ts
@@ -79,14 +79,18 @@ const card: Card = {
 		it: "Dopo la nascita, il suo dorso si gonfia e si indurisce in un guscio. Sprizza potenti schizzi di schiuma dalla bocca. LIV 8 N.7"
 	},
 
-	thirdParty: {
-		cardmarket: 273758,
-		tcgplayer: 42408
-	},
 	variants: [
 		{
 			type: "normal",
-			subtype: "unlimited",
+			subtype: "1999-2000-copyright",
+			thirdParty: {
+				cardmarket: 273758,
+				tcgplayer: 42408
+			}
+		},
+		{
+			type: "normal",
+			subtype: "unlimited"
 		},
 		{
 			type: "normal",
@@ -96,10 +100,20 @@ const card: Card = {
 		{
 			type: "normal",
 			subtype: "shadowless",
+			thirdParty: {
+				cardmarket: 660164
+			}
 		},
 		{
-			type: "normal",
-			subtype: "1999-2000-copyright",
+			type: "V3",
+			cardmarketLabels: ["Attention: Oversized Card", "Not Tournament Legal"]
+		},
+		{
+			type: "V3",
+			cardmarketLabels: ["Attention: Oversized Card", "Not Tournament Legal"],
+			thirdParty: {
+				cardmarket: 547246
+			}
 		}
 	],
 }

--- a/data/Base/Base Set/63.ts
+++ b/data/Base/Base Set/63.ts
@@ -82,15 +82,11 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
-			subtype: "1999-2000-copyright",
+			subtype: "unlimited",
 			thirdParty: {
 				cardmarket: 273758,
 				tcgplayer: 42408
 			}
-		},
-		{
-			type: "normal",
-			subtype: "unlimited"
 		},
 		{
 			type: "normal",
@@ -105,15 +101,8 @@ const card: Card = {
 			}
 		},
 		{
-			type: "V3",
-			cardmarketLabels: ["Attention: Oversized Card", "Not Tournament Legal"]
-		},
-		{
-			type: "V3",
-			cardmarketLabels: ["Attention: Oversized Card", "Not Tournament Legal"],
-			thirdParty: {
-				cardmarket: 547246
-			}
+			type: "normal",
+			subtype: "1999-2000-copyright"
 		}
 	],
 }

--- a/data/Base/Base Set/63.ts
+++ b/data/Base/Base Set/63.ts
@@ -82,16 +82,20 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
-			subtype: "unlimited",
-			thirdParty: {
-				cardmarket: 273758,
-				tcgplayer: 42408
-			}
+			subtype: "1999-2000-copyright",
+		},
+		{
+			type: "normal",
+			subtype: "unlimited"
 		},
 		{
 			type: "normal",
 			subtype: "shadowless",
-			stamp: ["1st-edition"]
+			stamp: ["1st-edition"],
+			thirdParty: {
+				cardmarket: 273758,
+				tcgplayer: 42408
+			}
 		},
 		{
 			type: "normal",
@@ -102,7 +106,10 @@ const card: Card = {
 		},
 		{
 			type: "normal",
-			subtype: "1999-2000-copyright"
+			size: "jumbo",
+			thirdParty: {
+				cardmarket: 547246
+			}
 		}
 	],
 }

--- a/data/Base/Base Set/64.ts
+++ b/data/Base/Base Set/64.ts
@@ -90,15 +90,11 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
-			subtype: "1999-2000-copyright",
+			subtype: "unlimited",
 			thirdParty: {
 				cardmarket: 273759,
 				tcgplayer: 42409
 			}
-		},
-		{
-			type: "normal",
-			subtype: "unlimited"
 		},
 		{
 			type: "normal",
@@ -111,6 +107,10 @@ const card: Card = {
 			thirdParty: {
 				cardmarket: 660163
 			}
+		},
+		{
+			type: "normal",
+			subtype: "1999-2000-copyright"
 		}
 	],
 }

--- a/data/Base/Base Set/64.ts
+++ b/data/Base/Base Set/64.ts
@@ -87,14 +87,18 @@ const card: Card = {
 		it: "Il suo nucleo centrale brilla  dei sette colori dell'arcobaleno. Valutato da alcuni come una gemma preziosa. LIV 28 N.121"
 	},
 
-	thirdParty: {
-		cardmarket: 273759,
-		tcgplayer: 42409
-	},
 	variants: [
 		{
 			type: "normal",
-			subtype: "unlimited",
+			subtype: "1999-2000-copyright",
+			thirdParty: {
+				cardmarket: 273759,
+				tcgplayer: 42409
+			}
+		},
+		{
+			type: "normal",
+			subtype: "unlimited"
 		},
 		{
 			type: "normal",
@@ -104,10 +108,9 @@ const card: Card = {
 		{
 			type: "normal",
 			subtype: "shadowless",
-		},
-		{
-			type: "normal",
-			subtype: "1999-2000-copyright",
+			thirdParty: {
+				cardmarket: 660163
+			}
 		}
 	],
 }

--- a/data/Base/Base Set/64.ts
+++ b/data/Base/Base Set/64.ts
@@ -90,7 +90,16 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
-			subtype: "unlimited",
+			subtype: "1999-2000-copyright",
+		},
+		{
+			type: "normal",
+			subtype: "unlimited"
+		},
+		{
+			type: "normal",
+			subtype: "shadowless",
+			stamp: ["1st-edition"],
 			thirdParty: {
 				cardmarket: 273759,
 				tcgplayer: 42409
@@ -99,18 +108,9 @@ const card: Card = {
 		{
 			type: "normal",
 			subtype: "shadowless",
-			stamp: ["1st-edition"]
-		},
-		{
-			type: "normal",
-			subtype: "shadowless",
 			thirdParty: {
 				cardmarket: 660163
 			}
-		},
-		{
-			type: "normal",
-			subtype: "1999-2000-copyright"
 		}
 	],
 }

--- a/data/Base/Base Set/65.ts
+++ b/data/Base/Base Set/65.ts
@@ -58,15 +58,11 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
-			subtype: "1999-2000-copyright",
+			subtype: "unlimited",
 			thirdParty: {
 				cardmarket: 273760,
 				tcgplayer: 42410
 			}
-		},
-		{
-			type: "normal",
-			subtype: "unlimited"
 		},
 		{
 			type: "normal",
@@ -79,6 +75,10 @@ const card: Card = {
 			thirdParty: {
 				cardmarket: 660162
 			}
+		},
+		{
+			type: "normal",
+			subtype: "1999-2000-copyright"
 		}
 	],
 }

--- a/data/Base/Base Set/65.ts
+++ b/data/Base/Base Set/65.ts
@@ -55,14 +55,18 @@ const card: Card = {
 		it: "Pokémon enigmatico che può rigenerare senza sforzo qualsiasi parte del corpo persa in combattimento. LIV 15 N.120"
 	},
 
-	thirdParty: {
-		cardmarket: 273760,
-		tcgplayer: 42410
-	},
 	variants: [
 		{
 			type: "normal",
-			subtype: "unlimited",
+			subtype: "1999-2000-copyright",
+			thirdParty: {
+				cardmarket: 273760,
+				tcgplayer: 42410
+			}
+		},
+		{
+			type: "normal",
+			subtype: "unlimited"
 		},
 		{
 			type: "normal",
@@ -72,10 +76,9 @@ const card: Card = {
 		{
 			type: "normal",
 			subtype: "shadowless",
-		},
-		{
-			type: "normal",
-			subtype: "1999-2000-copyright",
+			thirdParty: {
+				cardmarket: 660162
+			}
 		}
 	],
 }

--- a/data/Base/Base Set/65.ts
+++ b/data/Base/Base Set/65.ts
@@ -58,7 +58,16 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
-			subtype: "unlimited",
+			subtype: "1999-2000-copyright",
+		},
+		{
+			type: "normal",
+			subtype: "unlimited"
+		},
+		{
+			type: "normal",
+			subtype: "shadowless",
+			stamp: ["1st-edition"],
 			thirdParty: {
 				cardmarket: 273760,
 				tcgplayer: 42410
@@ -67,18 +76,9 @@ const card: Card = {
 		{
 			type: "normal",
 			subtype: "shadowless",
-			stamp: ["1st-edition"]
-		},
-		{
-			type: "normal",
-			subtype: "shadowless",
 			thirdParty: {
 				cardmarket: 660162
 			}
-		},
-		{
-			type: "normal",
-			subtype: "1999-2000-copyright"
 		}
 	],
 }

--- a/data/Base/Base Set/66.ts
+++ b/data/Base/Base Set/66.ts
@@ -83,14 +83,18 @@ const card: Card = {
 
 	},
 
-	thirdParty: {
-		cardmarket: 273761,
-		tcgplayer: 42411
-	},
 	variants: [
 		{
 			type: "normal",
-			subtype: "unlimited",
+			subtype: "1999-2000-copyright",
+			thirdParty: {
+				cardmarket: 273761,
+				tcgplayer: 42411
+			}
+		},
+		{
+			type: "normal",
+			subtype: "unlimited"
 		},
 		{
 			type: "normal",
@@ -100,10 +104,9 @@ const card: Card = {
 		{
 			type: "normal",
 			subtype: "shadowless",
-		},
-		{
-			type: "normal",
-			subtype: "1999-2000-copyright",
+			thirdParty: {
+				cardmarket: 660161
+			}
 		}
 	],
 }

--- a/data/Base/Base Set/66.ts
+++ b/data/Base/Base Set/66.ts
@@ -86,15 +86,11 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
-			subtype: "1999-2000-copyright",
+			subtype: "unlimited",
 			thirdParty: {
 				cardmarket: 273761,
 				tcgplayer: 42411
 			}
-		},
-		{
-			type: "normal",
-			subtype: "unlimited"
 		},
 		{
 			type: "normal",
@@ -107,6 +103,10 @@ const card: Card = {
 			thirdParty: {
 				cardmarket: 660161
 			}
+		},
+		{
+			type: "normal",
+			subtype: "1999-2000-copyright"
 		}
 	],
 }

--- a/data/Base/Base Set/66.ts
+++ b/data/Base/Base Set/66.ts
@@ -86,7 +86,16 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
-			subtype: "unlimited",
+			subtype: "1999-2000-copyright",
+		},
+		{
+			type: "normal",
+			subtype: "unlimited"
+		},
+		{
+			type: "normal",
+			subtype: "shadowless",
+			stamp: ["1st-edition"],
 			thirdParty: {
 				cardmarket: 273761,
 				tcgplayer: 42411
@@ -95,18 +104,9 @@ const card: Card = {
 		{
 			type: "normal",
 			subtype: "shadowless",
-			stamp: ["1st-edition"]
-		},
-		{
-			type: "normal",
-			subtype: "shadowless",
 			thirdParty: {
 				cardmarket: 660161
 			}
-		},
-		{
-			type: "normal",
-			subtype: "1999-2000-copyright"
 		}
 	],
 }

--- a/data/Base/Base Set/67.ts
+++ b/data/Base/Base Set/67.ts
@@ -58,15 +58,11 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
-			subtype: "1999-2000-copyright",
+			subtype: "unlimited",
 			thirdParty: {
 				cardmarket: 273762,
 				tcgplayer: 42412
 			}
-		},
-		{
-			type: "normal",
-			subtype: "unlimited"
 		},
 		{
 			type: "normal",
@@ -79,6 +75,10 @@ const card: Card = {
 			thirdParty: {
 				cardmarket: 660160
 			}
+		},
+		{
+			type: "normal",
+			subtype: "1999-2000-copyright"
 		}
 	],
 }

--- a/data/Base/Base Set/67.ts
+++ b/data/Base/Base Set/67.ts
@@ -55,14 +55,18 @@ const card: Card = {
 		it: "Si trova generalmente nelle centrali elettriche. Facilmente confondibile per una Poké Ball, ha fulminato molte persone. LIV 10 N.100"
 	},
 
-	thirdParty: {
-		cardmarket: 273762,
-		tcgplayer: 42412
-	},
 	variants: [
 		{
 			type: "normal",
-			subtype: "unlimited",
+			subtype: "1999-2000-copyright",
+			thirdParty: {
+				cardmarket: 273762,
+				tcgplayer: 42412
+			}
+		},
+		{
+			type: "normal",
+			subtype: "unlimited"
 		},
 		{
 			type: "normal",
@@ -72,10 +76,9 @@ const card: Card = {
 		{
 			type: "normal",
 			subtype: "shadowless",
-		},
-		{
-			type: "normal",
-			subtype: "1999-2000-copyright",
+			thirdParty: {
+				cardmarket: 660160
+			}
 		}
 	],
 }

--- a/data/Base/Base Set/67.ts
+++ b/data/Base/Base Set/67.ts
@@ -58,7 +58,16 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
-			subtype: "unlimited",
+			subtype: "1999-2000-copyright",
+		},
+		{
+			type: "normal",
+			subtype: "unlimited"
+		},
+		{
+			type: "normal",
+			subtype: "shadowless",
+			stamp: ["1st-edition"],
 			thirdParty: {
 				cardmarket: 273762,
 				tcgplayer: 42412
@@ -67,18 +76,9 @@ const card: Card = {
 		{
 			type: "normal",
 			subtype: "shadowless",
-			stamp: ["1st-edition"]
-		},
-		{
-			type: "normal",
-			subtype: "shadowless",
 			thirdParty: {
 				cardmarket: 660160
 			}
-		},
-		{
-			type: "normal",
-			subtype: "1999-2000-copyright"
 		}
 	],
 }

--- a/data/Base/Base Set/68.ts
+++ b/data/Base/Base Set/68.ts
@@ -64,15 +64,11 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
-			subtype: "1999-2000-copyright",
+			subtype: "unlimited",
 			thirdParty: {
 				cardmarket: 273763,
 				tcgplayer: 42413
 			}
-		},
-		{
-			type: "normal",
-			subtype: "unlimited"
 		},
 		{
 			type: "normal",
@@ -85,6 +81,10 @@ const card: Card = {
 			thirdParty: {
 				cardmarket: 660159
 			}
+		},
+		{
+			type: "normal",
+			subtype: "1999-2000-copyright"
 		}
 	],
 }

--- a/data/Base/Base Set/68.ts
+++ b/data/Base/Base Set/68.ts
@@ -61,14 +61,18 @@ const card: Card = {
 		it: "Alla nascita aveva solo una coda, ma con il passare del tempo la coda si è aperta a ventaglio. LIV 11 N.37"
 	},
 
-	thirdParty: {
-		cardmarket: 273763,
-		tcgplayer: 42413
-	},
 	variants: [
 		{
 			type: "normal",
-			subtype: "unlimited",
+			subtype: "1999-2000-copyright",
+			thirdParty: {
+				cardmarket: 273763,
+				tcgplayer: 42413
+			}
+		},
+		{
+			type: "normal",
+			subtype: "unlimited"
 		},
 		{
 			type: "normal",
@@ -78,10 +82,9 @@ const card: Card = {
 		{
 			type: "normal",
 			subtype: "shadowless",
-		},
-		{
-			type: "normal",
-			subtype: "1999-2000-copyright",
+			thirdParty: {
+				cardmarket: 660159
+			}
 		}
 	],
 }

--- a/data/Base/Base Set/68.ts
+++ b/data/Base/Base Set/68.ts
@@ -64,7 +64,16 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
-			subtype: "unlimited",
+			subtype: "1999-2000-copyright",
+		},
+		{
+			type: "normal",
+			subtype: "unlimited"
+		},
+		{
+			type: "normal",
+			subtype: "shadowless",
+			stamp: ["1st-edition"],
 			thirdParty: {
 				cardmarket: 273763,
 				tcgplayer: 42413
@@ -73,18 +82,9 @@ const card: Card = {
 		{
 			type: "normal",
 			subtype: "shadowless",
-			stamp: ["1st-edition"]
-		},
-		{
-			type: "normal",
-			subtype: "shadowless",
 			thirdParty: {
 				cardmarket: 660159
 			}
-		},
-		{
-			type: "normal",
-			subtype: "1999-2000-copyright"
 		}
 	],
 }

--- a/data/Base/Base Set/69.ts
+++ b/data/Base/Base Set/69.ts
@@ -63,15 +63,11 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
-			subtype: "1999-2000-copyright",
+			subtype: "unlimited",
 			thirdParty: {
 				cardmarket: 273764,
 				tcgplayer: 42414
 			}
-		},
-		{
-			type: "normal",
-			subtype: "unlimited"
 		},
 		{
 			type: "normal",
@@ -84,6 +80,10 @@ const card: Card = {
 			thirdParty: {
 				cardmarket: 660158
 			}
+		},
+		{
+			type: "normal",
+			subtype: "1999-2000-copyright"
 		}
 	],
 }

--- a/data/Base/Base Set/69.ts
+++ b/data/Base/Base Set/69.ts
@@ -60,14 +60,18 @@ const card: Card = {
 		it: "Lo si incontra spesso nei boschi dove si nutre di foglie. Ha sulla testa un pungiglione aguzzo e velenoso. LIV 12 N.13"
 	},
 
-	thirdParty: {
-		cardmarket: 273764,
-		tcgplayer: 42414
-	},
 	variants: [
 		{
 			type: "normal",
-			subtype: "unlimited",
+			subtype: "1999-2000-copyright",
+			thirdParty: {
+				cardmarket: 273764,
+				tcgplayer: 42414
+			}
+		},
+		{
+			type: "normal",
+			subtype: "unlimited"
 		},
 		{
 			type: "normal",
@@ -77,10 +81,9 @@ const card: Card = {
 		{
 			type: "normal",
 			subtype: "shadowless",
-		},
-		{
-			type: "normal",
-			subtype: "1999-2000-copyright",
+			thirdParty: {
+				cardmarket: 660158
+			}
 		}
 	],
 }

--- a/data/Base/Base Set/69.ts
+++ b/data/Base/Base Set/69.ts
@@ -63,7 +63,16 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
-			subtype: "unlimited",
+			subtype: "1999-2000-copyright",
+		},
+		{
+			type: "normal",
+			subtype: "unlimited"
+		},
+		{
+			type: "normal",
+			subtype: "shadowless",
+			stamp: ["1st-edition"],
 			thirdParty: {
 				cardmarket: 273764,
 				tcgplayer: 42414
@@ -72,18 +81,9 @@ const card: Card = {
 		{
 			type: "normal",
 			subtype: "shadowless",
-			stamp: ["1st-edition"]
-		},
-		{
-			type: "normal",
-			subtype: "shadowless",
 			thirdParty: {
 				cardmarket: 660158
 			}
-		},
-		{
-			type: "normal",
-			subtype: "1999-2000-copyright"
 		}
 	],
 }

--- a/data/Base/Base Set/7.ts
+++ b/data/Base/Base Set/7.ts
@@ -74,15 +74,11 @@ const card: Card = {
 	variants: [
 		{
 			type: "holo",
-			subtype: "1999-2000-copyright",
+			subtype: "unlimited",
 			thirdParty: {
 				cardmarket: 273702,
 				tcgplayer: 42415
 			}
-		},
-		{
-			type: "holo",
-			subtype: "unlimited"
 		},
 		{
 			type: "holo",
@@ -95,6 +91,10 @@ const card: Card = {
 			thirdParty: {
 				cardmarket: 660221
 			}
+		},
+		{
+			type: "holo",
+			subtype: "1999-2000-copyright"
 		}
 	],
 

--- a/data/Base/Base Set/7.ts
+++ b/data/Base/Base Set/7.ts
@@ -74,7 +74,15 @@ const card: Card = {
 	variants: [
 		{
 			type: "holo",
-			subtype: "unlimited",
+			subtype: "1999-2000-copyright",
+			thirdParty: {
+				cardmarket: 273702,
+				tcgplayer: 42415
+			}
+		},
+		{
+			type: "holo",
+			subtype: "unlimited"
 		},
 		{
 			type: "holo",
@@ -84,18 +92,13 @@ const card: Card = {
 		{
 			type: "holo",
 			subtype: "shadowless",
-		},
-		{
-			type: "holo",
-			subtype: "1999-2000-copyright",
+			thirdParty: {
+				cardmarket: 660221
+			}
 		}
 	],
 
 
-	thirdParty: {
-		cardmarket: 273702,
-		tcgplayer: 42415
-	}
 }
 
 export default card

--- a/data/Base/Base Set/7.ts
+++ b/data/Base/Base Set/7.ts
@@ -74,7 +74,16 @@ const card: Card = {
 	variants: [
 		{
 			type: "holo",
-			subtype: "unlimited",
+			subtype: "1999-2000-copyright",
+		},
+		{
+			type: "holo",
+			subtype: "unlimited"
+		},
+		{
+			type: "holo",
+			subtype: "shadowless",
+			stamp: ["1st-edition"],
 			thirdParty: {
 				cardmarket: 273702,
 				tcgplayer: 42415
@@ -83,18 +92,9 @@ const card: Card = {
 		{
 			type: "holo",
 			subtype: "shadowless",
-			stamp: ["1st-edition"]
-		},
-		{
-			type: "holo",
-			subtype: "shadowless",
 			thirdParty: {
 				cardmarket: 660221
 			}
-		},
-		{
-			type: "holo",
-			subtype: "1999-2000-copyright"
 		}
 	],
 

--- a/data/Base/Base Set/70.ts
+++ b/data/Base/Base Set/70.ts
@@ -21,14 +21,18 @@ const card: Card = {
 		it: "Gioca questa carta come se fosse un Pokémon Base. Mentre è in gioco, Clefairy Doll conta come un Pokémon (non come una carta Addestramento). Clefairy Doll non ha attacchi, non può ritirarsi e non può essere Addormentato, Confuso, Paralizzato o Avvelenato. Se Clefairy Doll viene messo K.O., non conta come un Pokémon messo K.O. In qualsiasi momento durante il tuo turno, prima di attaccare, puoi scartare Clefairy Doll."
 	},
 
-	thirdParty: {
-		cardmarket: 273765,
-		tcgplayer: 42416
-	},
 	variants: [
 		{
 			type: "normal",
-			subtype: "unlimited",
+			subtype: "1999-2000-copyright",
+			thirdParty: {
+				cardmarket: 273765,
+				tcgplayer: 42416
+			}
+		},
+		{
+			type: "normal",
+			subtype: "unlimited"
 		},
 		{
 			type: "normal",
@@ -38,10 +42,9 @@ const card: Card = {
 		{
 			type: "normal",
 			subtype: "shadowless",
-		},
-		{
-			type: "normal",
-			subtype: "1999-2000-copyright",
+			thirdParty: {
+				cardmarket: 660150
+			}
 		}
 	],
 }

--- a/data/Base/Base Set/70.ts
+++ b/data/Base/Base Set/70.ts
@@ -24,15 +24,11 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
-			subtype: "1999-2000-copyright",
+			subtype: "unlimited",
 			thirdParty: {
 				cardmarket: 273765,
 				tcgplayer: 42416
 			}
-		},
-		{
-			type: "normal",
-			subtype: "unlimited"
 		},
 		{
 			type: "normal",
@@ -45,6 +41,10 @@ const card: Card = {
 			thirdParty: {
 				cardmarket: 660150
 			}
+		},
+		{
+			type: "normal",
+			subtype: "1999-2000-copyright"
 		}
 	],
 }

--- a/data/Base/Base Set/70.ts
+++ b/data/Base/Base Set/70.ts
@@ -24,7 +24,16 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
-			subtype: "unlimited",
+			subtype: "1999-2000-copyright",
+		},
+		{
+			type: "normal",
+			subtype: "unlimited"
+		},
+		{
+			type: "normal",
+			subtype: "shadowless",
+			stamp: ["1st-edition"],
 			thirdParty: {
 				cardmarket: 273765,
 				tcgplayer: 42416
@@ -33,18 +42,9 @@ const card: Card = {
 		{
 			type: "normal",
 			subtype: "shadowless",
-			stamp: ["1st-edition"]
-		},
-		{
-			type: "normal",
-			subtype: "shadowless",
 			thirdParty: {
 				cardmarket: 660150
 			}
-		},
-		{
-			type: "normal",
-			subtype: "1999-2000-copyright"
 		}
 	],
 }

--- a/data/Base/Base Set/71.ts
+++ b/data/Base/Base Set/71.ts
@@ -23,15 +23,11 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
-			subtype: "1999-2000-copyright",
+			subtype: "unlimited",
 			thirdParty: {
 				cardmarket: 273766,
 				tcgplayer: 42417
 			}
-		},
-		{
-			type: "normal",
-			subtype: "unlimited"
 		},
 		{
 			type: "normal",
@@ -44,6 +40,10 @@ const card: Card = {
 			thirdParty: {
 				cardmarket: 660149
 			}
+		},
+		{
+			type: "normal",
+			subtype: "1999-2000-copyright"
 		}
 	],
 }

--- a/data/Base/Base Set/71.ts
+++ b/data/Base/Base Set/71.ts
@@ -20,14 +20,18 @@ const card: Card = {
 		it: "Scarta 2 delle altre carte che hai in mano, cerca nel tuo mazzo una carta a scelta e pescala. Poi rimischia le carte del mazzo."
 	},
 
-	thirdParty: {
-		cardmarket: 273766,
-		tcgplayer: 42417
-	},
 	variants: [
 		{
 			type: "normal",
-			subtype: "unlimited",
+			subtype: "1999-2000-copyright",
+			thirdParty: {
+				cardmarket: 273766,
+				tcgplayer: 42417
+			}
+		},
+		{
+			type: "normal",
+			subtype: "unlimited"
 		},
 		{
 			type: "normal",
@@ -37,10 +41,9 @@ const card: Card = {
 		{
 			type: "normal",
 			subtype: "shadowless",
-		},
-		{
-			type: "normal",
-			subtype: "1999-2000-copyright",
+			thirdParty: {
+				cardmarket: 660149
+			}
 		}
 	],
 }

--- a/data/Base/Base Set/71.ts
+++ b/data/Base/Base Set/71.ts
@@ -23,7 +23,16 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
-			subtype: "unlimited",
+			subtype: "1999-2000-copyright",
+		},
+		{
+			type: "normal",
+			subtype: "unlimited"
+		},
+		{
+			type: "normal",
+			subtype: "shadowless",
+			stamp: ["1st-edition"],
 			thirdParty: {
 				cardmarket: 273766,
 				tcgplayer: 42417
@@ -32,18 +41,9 @@ const card: Card = {
 		{
 			type: "normal",
 			subtype: "shadowless",
-			stamp: ["1st-edition"]
-		},
-		{
-			type: "normal",
-			subtype: "shadowless",
 			thirdParty: {
 				cardmarket: 660149
 			}
-		},
-		{
-			type: "normal",
-			subtype: "1999-2000-copyright"
 		}
 	],
 }

--- a/data/Base/Base Set/72.ts
+++ b/data/Base/Base Set/72.ts
@@ -20,14 +20,18 @@ const card: Card = {
 		it: "Scegli uno dei tuoi Pokémon in gioco e una fase di Evoluzione. Scarta tutte le carte Evoluzione assegnate a quella Fase o a Fasi superiori. Quel Pokémon non è più Addormentato, Confuso, Paralizzato, Avvelenato e non ha altri effetti causati da un attacco (proprio come se si fosse evoluto)"
 		},
 
-	thirdParty: {
-		cardmarket: 273767,
-		tcgplayer: 42418
-	},
 	variants: [
 		{
 			type: "normal",
-			subtype: "unlimited",
+			subtype: "1999-2000-copyright",
+			thirdParty: {
+				cardmarket: 273767,
+				tcgplayer: 42418
+			}
+		},
+		{
+			type: "normal",
+			subtype: "unlimited"
 		},
 		{
 			type: "normal",
@@ -36,11 +40,7 @@ const card: Card = {
 		},
 		{
 			type: "normal",
-			subtype: "shadowless",
-		},
-		{
-			type: "normal",
-			subtype: "1999-2000-copyright",
+			subtype: "shadowless"
 		}
 	],
 }

--- a/data/Base/Base Set/72.ts
+++ b/data/Base/Base Set/72.ts
@@ -23,15 +23,11 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
-			subtype: "1999-2000-copyright",
+			subtype: "unlimited",
 			thirdParty: {
 				cardmarket: 273767,
 				tcgplayer: 42418
 			}
-		},
-		{
-			type: "normal",
-			subtype: "unlimited"
 		},
 		{
 			type: "normal",
@@ -41,6 +37,10 @@ const card: Card = {
 		{
 			type: "normal",
 			subtype: "shadowless"
+		},
+		{
+			type: "normal",
+			subtype: "1999-2000-copyright"
 		}
 	],
 }

--- a/data/Base/Base Set/72.ts
+++ b/data/Base/Base Set/72.ts
@@ -23,7 +23,16 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
-			subtype: "unlimited",
+			subtype: "1999-2000-copyright",
+		},
+		{
+			type: "normal",
+			subtype: "unlimited"
+		},
+		{
+			type: "normal",
+			subtype: "shadowless",
+			stamp: ["1st-edition"],
 			thirdParty: {
 				cardmarket: 273767,
 				tcgplayer: 42418
@@ -31,16 +40,7 @@ const card: Card = {
 		},
 		{
 			type: "normal",
-			subtype: "shadowless",
-			stamp: ["1st-edition"]
-		},
-		{
-			type: "normal",
 			subtype: "shadowless"
-		},
-		{
-			type: "normal",
-			subtype: "1999-2000-copyright"
 		}
 	],
 }

--- a/data/Base/Base Set/73.ts
+++ b/data/Base/Base Set/73.ts
@@ -19,10 +19,20 @@ const card: Card = {
 		de: "Dein Gegner mischt die Karten seiner Hand in seinen Stapel und zieht sieben neue Karten",
 		it: "Il tuo avversario rimette le carte che ha in mano nel proprio mazzo, le mischia e poi pesca 7 carte."
 	},
+
+
+
 	variants: [
 		{
 			type: "normal",
-			subtype: "unlimited",
+			subtype: "1999-2000-copyright",
+			thirdParty: {
+				cardmarket: 273768
+			}
+		},
+		{
+			type: "normal",
+			subtype: "unlimited"
 		},
 		{
 			type: "normal",
@@ -32,10 +42,9 @@ const card: Card = {
 		{
 			type: "normal",
 			subtype: "shadowless",
-		},
-		{
-			type: "normal",
-			subtype: "1999-2000-copyright",
+			thirdParty: {
+				cardmarket: 660146
+			}
 		}
 	],
 }

--- a/data/Base/Base Set/73.ts
+++ b/data/Base/Base Set/73.ts
@@ -19,20 +19,13 @@ const card: Card = {
 		de: "Dein Gegner mischt die Karten seiner Hand in seinen Stapel und zieht sieben neue Karten",
 		it: "Il tuo avversario rimette le carte che ha in mano nel proprio mazzo, le mischia e poi pesca 7 carte."
 	},
-
-
-
 	variants: [
 		{
 			type: "normal",
-			subtype: "1999-2000-copyright",
+			subtype: "unlimited",
 			thirdParty: {
 				cardmarket: 273768
 			}
-		},
-		{
-			type: "normal",
-			subtype: "unlimited"
 		},
 		{
 			type: "normal",
@@ -45,6 +38,10 @@ const card: Card = {
 			thirdParty: {
 				cardmarket: 660146
 			}
+		},
+		{
+			type: "normal",
+			subtype: "1999-2000-copyright"
 		}
 	],
 }

--- a/data/Base/Base Set/73.ts
+++ b/data/Base/Base Set/73.ts
@@ -19,10 +19,22 @@ const card: Card = {
 		de: "Dein Gegner mischt die Karten seiner Hand in seinen Stapel und zieht sieben neue Karten",
 		it: "Il tuo avversario rimette le carte che ha in mano nel proprio mazzo, le mischia e poi pesca 7 carte."
 	},
+
+
+
 	variants: [
 		{
 			type: "normal",
-			subtype: "unlimited",
+			subtype: "1999-2000-copyright",
+		},
+		{
+			type: "normal",
+			subtype: "unlimited"
+		},
+		{
+			type: "normal",
+			subtype: "shadowless",
+			stamp: ["1st-edition"],
 			thirdParty: {
 				cardmarket: 273768
 			}
@@ -30,18 +42,9 @@ const card: Card = {
 		{
 			type: "normal",
 			subtype: "shadowless",
-			stamp: ["1st-edition"]
-		},
-		{
-			type: "normal",
-			subtype: "shadowless",
 			thirdParty: {
 				cardmarket: 660146
 			}
-		},
-		{
-			type: "normal",
-			subtype: "1999-2000-copyright"
 		}
 	],
 }

--- a/data/Base/Base Set/74.ts
+++ b/data/Base/Base Set/74.ts
@@ -20,14 +20,18 @@ const card: Card = {
 		it: "Scarta 2 delle altre carte che hai in mano e sostituiscile con una carta Addestramento presa dalla tua pila degli scarti."
 	},
 
-	thirdParty: {
-		cardmarket: 273769,
-		tcgplayer: 42420
-	},
 	variants: [
 		{
 			type: "normal",
-			subtype: "unlimited",
+			subtype: "1999-2000-copyright",
+			thirdParty: {
+				cardmarket: 273769,
+				tcgplayer: 42420
+			}
+		},
+		{
+			type: "normal",
+			subtype: "unlimited"
 		},
 		{
 			type: "normal",
@@ -37,10 +41,9 @@ const card: Card = {
 		{
 			type: "normal",
 			subtype: "shadowless",
-		},
-		{
-			type: "normal",
-			subtype: "1999-2000-copyright",
+			thirdParty: {
+				cardmarket: 660144
+			}
 		}
 	],
 }

--- a/data/Base/Base Set/74.ts
+++ b/data/Base/Base Set/74.ts
@@ -23,15 +23,11 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
-			subtype: "1999-2000-copyright",
+			subtype: "unlimited",
 			thirdParty: {
 				cardmarket: 273769,
 				tcgplayer: 42420
 			}
-		},
-		{
-			type: "normal",
-			subtype: "unlimited"
 		},
 		{
 			type: "normal",
@@ -44,6 +40,10 @@ const card: Card = {
 			thirdParty: {
 				cardmarket: 660144
 			}
+		},
+		{
+			type: "normal",
+			subtype: "1999-2000-copyright"
 		}
 	],
 }

--- a/data/Base/Base Set/74.ts
+++ b/data/Base/Base Set/74.ts
@@ -23,7 +23,16 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
-			subtype: "unlimited",
+			subtype: "1999-2000-copyright",
+		},
+		{
+			type: "normal",
+			subtype: "unlimited"
+		},
+		{
+			type: "normal",
+			subtype: "shadowless",
+			stamp: ["1st-edition"],
 			thirdParty: {
 				cardmarket: 273769,
 				tcgplayer: 42420
@@ -32,18 +41,9 @@ const card: Card = {
 		{
 			type: "normal",
 			subtype: "shadowless",
-			stamp: ["1st-edition"]
-		},
-		{
-			type: "normal",
-			subtype: "shadowless",
 			thirdParty: {
 				cardmarket: 660144
 			}
-		},
-		{
-			type: "normal",
-			subtype: "1999-2000-copyright"
 		}
 	],
 }

--- a/data/Base/Base Set/75.ts
+++ b/data/Base/Base Set/75.ts
@@ -23,15 +23,11 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
-			subtype: "1999-2000-copyright",
+			subtype: "unlimited",
 			thirdParty: {
 				cardmarket: 273770,
 				tcgplayer: 42421
 			}
-		},
-		{
-			type: "normal",
-			subtype: "unlimited"
 		},
 		{
 			type: "normal",
@@ -44,6 +40,10 @@ const card: Card = {
 			thirdParty: {
 				cardmarket: 660143
 			}
+		},
+		{
+			type: "normal",
+			subtype: "1999-2000-copyright"
 		}
 	],
 }

--- a/data/Base/Base Set/75.ts
+++ b/data/Base/Base Set/75.ts
@@ -20,14 +20,18 @@ const card: Card = {
 		it: "Tu e il tuo avversario vi mostrate le carte che avete in mano; poi ognuno rimette tutte le carte Addestramento che ha in mano nel proprio mazzo e lo rimischia."
 	},
 
-	thirdParty: {
-		cardmarket: 273770,
-		tcgplayer: 42421
-	},
 	variants: [
 		{
 			type: "normal",
-			subtype: "unlimited",
+			subtype: "1999-2000-copyright",
+			thirdParty: {
+				cardmarket: 273770,
+				tcgplayer: 42421
+			}
+		},
+		{
+			type: "normal",
+			subtype: "unlimited"
 		},
 		{
 			type: "normal",
@@ -37,10 +41,9 @@ const card: Card = {
 		{
 			type: "normal",
 			subtype: "shadowless",
-		},
-		{
-			type: "normal",
-			subtype: "1999-2000-copyright",
+			thirdParty: {
+				cardmarket: 660143
+			}
 		}
 	],
 }

--- a/data/Base/Base Set/75.ts
+++ b/data/Base/Base Set/75.ts
@@ -23,7 +23,16 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
-			subtype: "unlimited",
+			subtype: "1999-2000-copyright",
+		},
+		{
+			type: "normal",
+			subtype: "unlimited"
+		},
+		{
+			type: "normal",
+			subtype: "shadowless",
+			stamp: ["1st-edition"],
 			thirdParty: {
 				cardmarket: 273770,
 				tcgplayer: 42421
@@ -32,18 +41,9 @@ const card: Card = {
 		{
 			type: "normal",
 			subtype: "shadowless",
-			stamp: ["1st-edition"]
-		},
-		{
-			type: "normal",
-			subtype: "shadowless",
 			thirdParty: {
 				cardmarket: 660143
 			}
-		},
-		{
-			type: "normal",
-			subtype: "1999-2000-copyright"
 		}
 	],
 }

--- a/data/Base/Base Set/76.ts
+++ b/data/Base/Base Set/76.ts
@@ -20,13 +20,18 @@ const card: Card = {
 		it: "Metti una carta Evoluzione di Fase 2 che hai in mano direttamente sul Pokémon Base corrispondente. Puoi giocare questa carta solo quando ti sarebbe comunque permesso evolvere quel Pokémon.",
 	},
 
-	thirdParty: {
-		cardmarket: 273771
-	},
+
 	variants: [
 		{
 			type: "normal",
-			subtype: "unlimited",
+			subtype: "1999-2000-copyright",
+			thirdParty: {
+				cardmarket: 273771
+			}
+		},
+		{
+			type: "normal",
+			subtype: "unlimited"
 		},
 		{
 			type: "normal",
@@ -36,10 +41,9 @@ const card: Card = {
 		{
 			type: "normal",
 			subtype: "shadowless",
-		},
-		{
-			type: "normal",
-			subtype: "1999-2000-copyright",
+			thirdParty: {
+				cardmarket: 660142
+			}
 		}
 	],
 }

--- a/data/Base/Base Set/76.ts
+++ b/data/Base/Base Set/76.ts
@@ -20,18 +20,13 @@ const card: Card = {
 		it: "Metti una carta Evoluzione di Fase 2 che hai in mano direttamente sul Pokémon Base corrispondente. Puoi giocare questa carta solo quando ti sarebbe comunque permesso evolvere quel Pokémon.",
 	},
 
-
 	variants: [
 		{
 			type: "normal",
-			subtype: "1999-2000-copyright",
+			subtype: "unlimited",
 			thirdParty: {
 				cardmarket: 273771
 			}
-		},
-		{
-			type: "normal",
-			subtype: "unlimited"
 		},
 		{
 			type: "normal",
@@ -44,6 +39,10 @@ const card: Card = {
 			thirdParty: {
 				cardmarket: 660142
 			}
+		},
+		{
+			type: "normal",
+			subtype: "1999-2000-copyright"
 		}
 	],
 }

--- a/data/Base/Base Set/76.ts
+++ b/data/Base/Base Set/76.ts
@@ -20,10 +20,20 @@ const card: Card = {
 		it: "Metti una carta Evoluzione di Fase 2 che hai in mano direttamente sul Pokémon Base corrispondente. Puoi giocare questa carta solo quando ti sarebbe comunque permesso evolvere quel Pokémon.",
 	},
 
+
 	variants: [
 		{
 			type: "normal",
-			subtype: "unlimited",
+			subtype: "1999-2000-copyright",
+		},
+		{
+			type: "normal",
+			subtype: "unlimited"
+		},
+		{
+			type: "normal",
+			subtype: "shadowless",
+			stamp: ["1st-edition"],
 			thirdParty: {
 				cardmarket: 273771
 			}
@@ -31,18 +41,9 @@ const card: Card = {
 		{
 			type: "normal",
 			subtype: "shadowless",
-			stamp: ["1st-edition"]
-		},
-		{
-			type: "normal",
-			subtype: "shadowless",
 			thirdParty: {
 				cardmarket: 660142
 			}
-		},
-		{
-			type: "normal",
-			subtype: "1999-2000-copyright"
 		}
 	],
 }

--- a/data/Base/Base Set/77.ts
+++ b/data/Base/Base Set/77.ts
@@ -20,18 +20,13 @@ const card: Card = {
 		it: "Scambia una carta Pokémon Base o una carta Evoluzione che hai in mano con una carta Pokémon Base o una carta Evoluzione nel tuo mazzo. Mostra entrambe le carte al tuo avversario e poi mischia il mazzo.",	
 	},
 
-
 	variants: [
 		{
 			type: "normal",
-			subtype: "1999-2000-copyright",
+			subtype: "unlimited",
 			thirdParty: {
 				cardmarket: 273772
 			}
-		},
-		{
-			type: "normal",
-			subtype: "unlimited"
 		},
 		{
 			type: "normal",
@@ -44,6 +39,10 @@ const card: Card = {
 			thirdParty: {
 				cardmarket: 660140
 			}
+		},
+		{
+			type: "normal",
+			subtype: "1999-2000-copyright"
 		}
 	],
 }

--- a/data/Base/Base Set/77.ts
+++ b/data/Base/Base Set/77.ts
@@ -20,13 +20,18 @@ const card: Card = {
 		it: "Scambia una carta Pokémon Base o una carta Evoluzione che hai in mano con una carta Pokémon Base o una carta Evoluzione nel tuo mazzo. Mostra entrambe le carte al tuo avversario e poi mischia il mazzo.",	
 	},
 
-	thirdParty: {
-		cardmarket: 273772
-	},
+
 	variants: [
 		{
 			type: "normal",
-			subtype: "unlimited",
+			subtype: "1999-2000-copyright",
+			thirdParty: {
+				cardmarket: 273772
+			}
+		},
+		{
+			type: "normal",
+			subtype: "unlimited"
 		},
 		{
 			type: "normal",
@@ -36,10 +41,9 @@ const card: Card = {
 		{
 			type: "normal",
 			subtype: "shadowless",
-		},
-		{
-			type: "normal",
-			subtype: "1999-2000-copyright",
+			thirdParty: {
+				cardmarket: 660140
+			}
 		}
 	],
 }

--- a/data/Base/Base Set/77.ts
+++ b/data/Base/Base Set/77.ts
@@ -20,10 +20,20 @@ const card: Card = {
 		it: "Scambia una carta Pokémon Base o una carta Evoluzione che hai in mano con una carta Pokémon Base o una carta Evoluzione nel tuo mazzo. Mostra entrambe le carte al tuo avversario e poi mischia il mazzo.",	
 	},
 
+
 	variants: [
 		{
 			type: "normal",
-			subtype: "unlimited",
+			subtype: "1999-2000-copyright",
+		},
+		{
+			type: "normal",
+			subtype: "unlimited"
+		},
+		{
+			type: "normal",
+			subtype: "shadowless",
+			stamp: ["1st-edition"],
 			thirdParty: {
 				cardmarket: 273772
 			}
@@ -31,18 +41,9 @@ const card: Card = {
 		{
 			type: "normal",
 			subtype: "shadowless",
-			stamp: ["1st-edition"]
-		},
-		{
-			type: "normal",
-			subtype: "shadowless",
 			thirdParty: {
 				cardmarket: 660140
 			}
-		},
-		{
-			type: "normal",
-			subtype: "1999-2000-copyright"
 		}
 	],
 }

--- a/data/Base/Base Set/78.ts
+++ b/data/Base/Base Set/78.ts
@@ -20,14 +20,18 @@ const card: Card = {
 		it: "Scegli uno dei tuoi Pokémon in gioco e riprendi in mano la carta del suo Pokémon Base. (Scarta tutte le altre carte assegnate a quel Pokémon Base.)"
 	},
 
-	thirdParty: {
-		cardmarket: 273773,
-		tcgplayer: 42423
-	},
 	variants: [
 		{
 			type: "normal",
-			subtype: "unlimited",
+			subtype: "1999-2000-copyright",
+			thirdParty: {
+				cardmarket: 273773,
+				tcgplayer: 42423
+			}
+		},
+		{
+			type: "normal",
+			subtype: "unlimited"
 		},
 		{
 			type: "normal",
@@ -37,10 +41,9 @@ const card: Card = {
 		{
 			type: "normal",
 			subtype: "shadowless",
-		},
-		{
-			type: "normal",
-			subtype: "1999-2000-copyright",
+			thirdParty: {
+				cardmarket: 660138
+			}
 		}
 	],
 }

--- a/data/Base/Base Set/78.ts
+++ b/data/Base/Base Set/78.ts
@@ -23,15 +23,11 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
-			subtype: "1999-2000-copyright",
+			subtype: "unlimited",
 			thirdParty: {
 				cardmarket: 273773,
 				tcgplayer: 42423
 			}
-		},
-		{
-			type: "normal",
-			subtype: "unlimited"
 		},
 		{
 			type: "normal",
@@ -44,6 +40,10 @@ const card: Card = {
 			thirdParty: {
 				cardmarket: 660138
 			}
+		},
+		{
+			type: "normal",
+			subtype: "1999-2000-copyright"
 		}
 	],
 }

--- a/data/Base/Base Set/78.ts
+++ b/data/Base/Base Set/78.ts
@@ -23,7 +23,16 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
-			subtype: "unlimited",
+			subtype: "1999-2000-copyright",
+		},
+		{
+			type: "normal",
+			subtype: "unlimited"
+		},
+		{
+			type: "normal",
+			subtype: "shadowless",
+			stamp: ["1st-edition"],
 			thirdParty: {
 				cardmarket: 273773,
 				tcgplayer: 42423
@@ -32,18 +41,9 @@ const card: Card = {
 		{
 			type: "normal",
 			subtype: "shadowless",
-			stamp: ["1st-edition"]
-		},
-		{
-			type: "normal",
-			subtype: "shadowless",
 			thirdParty: {
 				cardmarket: 660138
 			}
-		},
-		{
-			type: "normal",
-			subtype: "1999-2000-copyright"
 		}
 	],
 }

--- a/data/Base/Base Set/79.ts
+++ b/data/Base/Base Set/79.ts
@@ -20,14 +20,18 @@ const card: Card = {
 		it: "Scarta una carta Energia assegnata a uno dei tuoi Pokémon per scartare fino a 2 carte Energia assegnate a uno dei Pokémon del tuo avversario. Scarta quelle carte Energia.",
 	},
 
-	thirdParty: {
-		cardmarket: 273774,
-		tcgplayer: 42424
-	},
 	variants: [
 		{
 			type: "normal",
-			subtype: "unlimited",
+			subtype: "1999-2000-copyright",
+			thirdParty: {
+				cardmarket: 273774,
+				tcgplayer: 42424
+			}
+		},
+		{
+			type: "normal",
+			subtype: "unlimited"
 		},
 		{
 			type: "normal",
@@ -37,10 +41,9 @@ const card: Card = {
 		{
 			type: "normal",
 			subtype: "shadowless",
-		},
-		{
-			type: "normal",
-			subtype: "1999-2000-copyright",
+			thirdParty: {
+				cardmarket: 660137
+			}
 		}
 	],
 }

--- a/data/Base/Base Set/79.ts
+++ b/data/Base/Base Set/79.ts
@@ -23,15 +23,11 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
-			subtype: "1999-2000-copyright",
+			subtype: "unlimited",
 			thirdParty: {
 				cardmarket: 273774,
 				tcgplayer: 42424
 			}
-		},
-		{
-			type: "normal",
-			subtype: "unlimited"
 		},
 		{
 			type: "normal",
@@ -44,6 +40,10 @@ const card: Card = {
 			thirdParty: {
 				cardmarket: 660137
 			}
+		},
+		{
+			type: "normal",
+			subtype: "1999-2000-copyright"
 		}
 	],
 }

--- a/data/Base/Base Set/79.ts
+++ b/data/Base/Base Set/79.ts
@@ -23,7 +23,16 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
-			subtype: "unlimited",
+			subtype: "1999-2000-copyright",
+		},
+		{
+			type: "normal",
+			subtype: "unlimited"
+		},
+		{
+			type: "normal",
+			subtype: "shadowless",
+			stamp: ["1st-edition"],
 			thirdParty: {
 				cardmarket: 273774,
 				tcgplayer: 42424
@@ -32,18 +41,9 @@ const card: Card = {
 		{
 			type: "normal",
 			subtype: "shadowless",
-			stamp: ["1st-edition"]
-		},
-		{
-			type: "normal",
-			subtype: "shadowless",
 			thirdParty: {
 				cardmarket: 660137
 			}
-		},
-		{
-			type: "normal",
-			subtype: "1999-2000-copyright"
 		}
 	],
 }

--- a/data/Base/Base Set/8.ts
+++ b/data/Base/Base Set/8.ts
@@ -82,10 +82,18 @@ const card: Card = {
 		it: "I suoi muscoli supersviluppati gli permettono di tirare pugni capaci di mandare in orbita gli avversari. LIV 67 N.68"
 	},
 
+
 	variants: [
 		{
 			type: "holo",
-			subtype: "unlimited",
+			subtype: "1999-2000-copyright",
+			thirdParty: {
+				cardmarket: 273703
+			}
+		},
+		{
+			type: "holo",
+			subtype: "unlimited"
 		},
 		{
 			type: "holo",
@@ -95,17 +103,13 @@ const card: Card = {
 		{
 			type: "holo",
 			subtype: "shadowless",
-		},
-		{
-			type: "holo",
-			subtype: "1999-2000-copyright",
+			thirdParty: {
+				cardmarket: 660220
+			}
 		}
 	],
 
 
-	thirdParty: {
-		cardmarket: 273703
-	}
 }
 
 export default card

--- a/data/Base/Base Set/8.ts
+++ b/data/Base/Base Set/8.ts
@@ -82,18 +82,13 @@ const card: Card = {
 		it: "I suoi muscoli supersviluppati gli permettono di tirare pugni capaci di mandare in orbita gli avversari. LIV 67 N.68"
 	},
 
-
 	variants: [
 		{
 			type: "holo",
-			subtype: "1999-2000-copyright",
+			subtype: "unlimited",
 			thirdParty: {
 				cardmarket: 273703
 			}
-		},
-		{
-			type: "holo",
-			subtype: "unlimited"
 		},
 		{
 			type: "holo",
@@ -106,6 +101,10 @@ const card: Card = {
 			thirdParty: {
 				cardmarket: 660220
 			}
+		},
+		{
+			type: "holo",
+			subtype: "1999-2000-copyright"
 		}
 	],
 

--- a/data/Base/Base Set/8.ts
+++ b/data/Base/Base Set/8.ts
@@ -82,10 +82,20 @@ const card: Card = {
 		it: "I suoi muscoli supersviluppati gli permettono di tirare pugni capaci di mandare in orbita gli avversari. LIV 67 N.68"
 	},
 
+
 	variants: [
 		{
 			type: "holo",
-			subtype: "unlimited",
+			subtype: "1999-2000-copyright",
+		},
+		{
+			type: "holo",
+			subtype: "unlimited"
+		},
+		{
+			type: "holo",
+			subtype: "shadowless",
+			stamp: ["1st-edition"],
 			thirdParty: {
 				cardmarket: 273703
 			}
@@ -93,18 +103,9 @@ const card: Card = {
 		{
 			type: "holo",
 			subtype: "shadowless",
-			stamp: ["1st-edition"]
-		},
-		{
-			type: "holo",
-			subtype: "shadowless",
 			thirdParty: {
 				cardmarket: 660220
 			}
-		},
-		{
-			type: "holo",
-			subtype: "1999-2000-copyright"
 		}
 	],
 

--- a/data/Base/Base Set/80.ts
+++ b/data/Base/Base Set/80.ts
@@ -20,14 +20,18 @@ const card: Card = {
 		it: "Assegna il Difensore a uno dei tuoi Pokémon. Alla fine del prossimo turno del tuo avversario, scarta il Difensore. I danni inflitti a quel Pokémon dagli attacchi vengono ridotti di 20 (dopo aver applicato Debolezza e Resistenza)."
 	},
 
-	thirdParty: {
-		cardmarket: 273775,
-		tcgplayer: 42426
-	},
 	variants: [
 		{
 			type: "normal",
-			subtype: "unlimited",
+			subtype: "1999-2000-copyright",
+			thirdParty: {
+				cardmarket: 273775,
+				tcgplayer: 42426
+			}
+		},
+		{
+			type: "normal",
+			subtype: "unlimited"
 		},
 		{
 			type: "normal",
@@ -37,10 +41,9 @@ const card: Card = {
 		{
 			type: "normal",
 			subtype: "shadowless",
-		},
-		{
-			type: "normal",
-			subtype: "1999-2000-copyright",
+			thirdParty: {
+				cardmarket: 660135
+			}
 		}
 	],
 }

--- a/data/Base/Base Set/80.ts
+++ b/data/Base/Base Set/80.ts
@@ -23,15 +23,11 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
-			subtype: "1999-2000-copyright",
+			subtype: "unlimited",
 			thirdParty: {
 				cardmarket: 273775,
 				tcgplayer: 42426
 			}
-		},
-		{
-			type: "normal",
-			subtype: "unlimited"
 		},
 		{
 			type: "normal",
@@ -44,6 +40,10 @@ const card: Card = {
 			thirdParty: {
 				cardmarket: 660135
 			}
+		},
+		{
+			type: "normal",
+			subtype: "1999-2000-copyright"
 		}
 	],
 }

--- a/data/Base/Base Set/80.ts
+++ b/data/Base/Base Set/80.ts
@@ -23,7 +23,16 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
-			subtype: "unlimited",
+			subtype: "1999-2000-copyright",
+		},
+		{
+			type: "normal",
+			subtype: "unlimited"
+		},
+		{
+			type: "normal",
+			subtype: "shadowless",
+			stamp: ["1st-edition"],
 			thirdParty: {
 				cardmarket: 273775,
 				tcgplayer: 42426
@@ -32,18 +41,9 @@ const card: Card = {
 		{
 			type: "normal",
 			subtype: "shadowless",
-			stamp: ["1st-edition"]
-		},
-		{
-			type: "normal",
-			subtype: "shadowless",
 			thirdParty: {
 				cardmarket: 660135
 			}
-		},
-		{
-			type: "normal",
-			subtype: "1999-2000-copyright"
 		}
 	],
 }

--- a/data/Base/Base Set/81.ts
+++ b/data/Base/Base Set/81.ts
@@ -23,15 +23,11 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
-			subtype: "1999-2000-copyright",
+			subtype: "unlimited",
 			thirdParty: {
 				cardmarket: 273776,
 				tcgplayer: 42427
 			}
-		},
-		{
-			type: "normal",
-			subtype: "unlimited"
 		},
 		{
 			type: "normal",
@@ -44,6 +40,10 @@ const card: Card = {
 			thirdParty: {
 				cardmarket: 660134
 			}
+		},
+		{
+			type: "normal",
+			subtype: "1999-2000-copyright"
 		}
 	],
 }

--- a/data/Base/Base Set/81.ts
+++ b/data/Base/Base Set/81.ts
@@ -20,14 +20,18 @@ const card: Card = {
 		it: "Scambia una delle altre carte che hai in mano con un massimo di 2 carte Energia base dalla tua pila degli scarti.",
 	},
 
-	thirdParty: {
-		cardmarket: 273776,
-		tcgplayer: 42427
-	},
 	variants: [
 		{
 			type: "normal",
-			subtype: "unlimited",
+			subtype: "1999-2000-copyright",
+			thirdParty: {
+				cardmarket: 273776,
+				tcgplayer: 42427
+			}
+		},
+		{
+			type: "normal",
+			subtype: "unlimited"
 		},
 		{
 			type: "normal",
@@ -37,10 +41,9 @@ const card: Card = {
 		{
 			type: "normal",
 			subtype: "shadowless",
-		},
-		{
-			type: "normal",
-			subtype: "1999-2000-copyright",
+			thirdParty: {
+				cardmarket: 660134
+			}
 		}
 	],
 }

--- a/data/Base/Base Set/81.ts
+++ b/data/Base/Base Set/81.ts
@@ -23,7 +23,16 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
-			subtype: "unlimited",
+			subtype: "1999-2000-copyright",
+		},
+		{
+			type: "normal",
+			subtype: "unlimited"
+		},
+		{
+			type: "normal",
+			subtype: "shadowless",
+			stamp: ["1st-edition"],
 			thirdParty: {
 				cardmarket: 273776,
 				tcgplayer: 42427
@@ -32,18 +41,9 @@ const card: Card = {
 		{
 			type: "normal",
 			subtype: "shadowless",
-			stamp: ["1st-edition"]
-		},
-		{
-			type: "normal",
-			subtype: "shadowless",
 			thirdParty: {
 				cardmarket: 660134
 			}
-		},
-		{
-			type: "normal",
-			subtype: "1999-2000-copyright"
 		}
 	],
 }

--- a/data/Base/Base Set/82.ts
+++ b/data/Base/Base Set/82.ts
@@ -23,15 +23,11 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
-			subtype: "1999-2000-copyright",
+			subtype: "unlimited",
 			thirdParty: {
 				cardmarket: 273777,
 				tcgplayer: 42428
 			}
-		},
-		{
-			type: "normal",
-			subtype: "unlimited"
 		},
 		{
 			type: "normal",
@@ -44,6 +40,10 @@ const card: Card = {
 			thirdParty: {
 				cardmarket: 660132
 			}
+		},
+		{
+			type: "normal",
+			subtype: "1999-2000-copyright"
 		}
 	],
 }

--- a/data/Base/Base Set/82.ts
+++ b/data/Base/Base Set/82.ts
@@ -20,14 +20,18 @@ const card: Card = {
 		it: "Il tuo Pokémon Attivo non è più Addormentato, Confuso, Paralizzato o Avvelenato."
 	},
 
-	thirdParty: {
-		cardmarket: 273777,
-		tcgplayer: 42428
-	},
 	variants: [
 		{
 			type: "normal",
-			subtype: "unlimited",
+			subtype: "1999-2000-copyright",
+			thirdParty: {
+				cardmarket: 273777,
+				tcgplayer: 42428
+			}
+		},
+		{
+			type: "normal",
+			subtype: "unlimited"
 		},
 		{
 			type: "normal",
@@ -37,10 +41,9 @@ const card: Card = {
 		{
 			type: "normal",
 			subtype: "shadowless",
-		},
-		{
-			type: "normal",
-			subtype: "1999-2000-copyright",
+			thirdParty: {
+				cardmarket: 660132
+			}
 		}
 	],
 }

--- a/data/Base/Base Set/82.ts
+++ b/data/Base/Base Set/82.ts
@@ -23,7 +23,16 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
-			subtype: "unlimited",
+			subtype: "1999-2000-copyright",
+		},
+		{
+			type: "normal",
+			subtype: "unlimited"
+		},
+		{
+			type: "normal",
+			subtype: "shadowless",
+			stamp: ["1st-edition"],
 			thirdParty: {
 				cardmarket: 273777,
 				tcgplayer: 42428
@@ -32,18 +41,9 @@ const card: Card = {
 		{
 			type: "normal",
 			subtype: "shadowless",
-			stamp: ["1st-edition"]
-		},
-		{
-			type: "normal",
-			subtype: "shadowless",
 			thirdParty: {
 				cardmarket: 660132
 			}
-		},
-		{
-			type: "normal",
-			subtype: "1999-2000-copyright"
 		}
 	],
 }

--- a/data/Base/Base Set/83.ts
+++ b/data/Base/Base Set/83.ts
@@ -23,15 +23,11 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
-			subtype: "1999-2000-copyright",
+			subtype: "unlimited",
 			thirdParty: {
 				cardmarket: 273778,
 				tcgplayer: 42429
 			}
-		},
-		{
-			type: "normal",
-			subtype: "unlimited"
 		},
 		{
 			type: "normal",
@@ -44,6 +40,10 @@ const card: Card = {
 			thirdParty: {
 				cardmarket: 660123
 			}
+		},
+		{
+			type: "normal",
+			subtype: "1999-2000-copyright"
 		}
 	],
 }

--- a/data/Base/Base Set/83.ts
+++ b/data/Base/Base Set/83.ts
@@ -20,14 +20,18 @@ const card: Card = {
 		it: "Rimetti 2 delle altre carte che hai in mano nel tuo mazzo, rimischialo e poi pesca una carta."
 	},
 
-	thirdParty: {
-		cardmarket: 273778,
-		tcgplayer: 42429
-	},
 	variants: [
 		{
 			type: "normal",
-			subtype: "unlimited",
+			subtype: "1999-2000-copyright",
+			thirdParty: {
+				cardmarket: 273778,
+				tcgplayer: 42429
+			}
+		},
+		{
+			type: "normal",
+			subtype: "unlimited"
 		},
 		{
 			type: "normal",
@@ -37,10 +41,9 @@ const card: Card = {
 		{
 			type: "normal",
 			subtype: "shadowless",
-		},
-		{
-			type: "normal",
-			subtype: "1999-2000-copyright",
+			thirdParty: {
+				cardmarket: 660123
+			}
 		}
 	],
 }

--- a/data/Base/Base Set/83.ts
+++ b/data/Base/Base Set/83.ts
@@ -23,7 +23,16 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
-			subtype: "unlimited",
+			subtype: "1999-2000-copyright",
+		},
+		{
+			type: "normal",
+			subtype: "unlimited"
+		},
+		{
+			type: "normal",
+			subtype: "shadowless",
+			stamp: ["1st-edition"],
 			thirdParty: {
 				cardmarket: 273778,
 				tcgplayer: 42429
@@ -32,18 +41,9 @@ const card: Card = {
 		{
 			type: "normal",
 			subtype: "shadowless",
-			stamp: ["1st-edition"]
-		},
-		{
-			type: "normal",
-			subtype: "shadowless",
 			thirdParty: {
 				cardmarket: 660123
 			}
-		},
-		{
-			type: "normal",
-			subtype: "1999-2000-copyright"
 		}
 	],
 }

--- a/data/Base/Base Set/84.ts
+++ b/data/Base/Base Set/84.ts
@@ -23,15 +23,11 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
-			subtype: "1999-2000-copyright",
+			subtype: "unlimited",
 			thirdParty: {
 				cardmarket: 273779,
 				tcgplayer: 42430
 			}
-		},
-		{
-			type: "normal",
-			subtype: "unlimited"
 		},
 		{
 			type: "normal",
@@ -44,6 +40,10 @@ const card: Card = {
 			thirdParty: {
 				cardmarket: 660122
 			}
+		},
+		{
+			type: "normal",
+			subtype: "1999-2000-copyright"
 		}
 	],
 }

--- a/data/Base/Base Set/84.ts
+++ b/data/Base/Base Set/84.ts
@@ -20,14 +20,18 @@ const card: Card = {
 		it: "Assegna la PlusPotenza al tuo Pokémon Attivo. Alla fine del tuo turno, scarta PlusPotenza. Se l'attacco di questo Pokémon danneggia il Pokémon Difensore (dopo aver applicato Debolezza e Resistenza), l'attacco infligge altri 10 danni al Pokémon Difensore."
 	},
 
-	thirdParty: {
-		cardmarket: 273779,
-		tcgplayer: 42430
-	},
 	variants: [
 		{
 			type: "normal",
-			subtype: "unlimited",
+			subtype: "1999-2000-copyright",
+			thirdParty: {
+				cardmarket: 273779,
+				tcgplayer: 42430
+			}
+		},
+		{
+			type: "normal",
+			subtype: "unlimited"
 		},
 		{
 			type: "normal",
@@ -37,10 +41,9 @@ const card: Card = {
 		{
 			type: "normal",
 			subtype: "shadowless",
-		},
-		{
-			type: "normal",
-			subtype: "1999-2000-copyright",
+			thirdParty: {
+				cardmarket: 660122
+			}
 		}
 	],
 }

--- a/data/Base/Base Set/84.ts
+++ b/data/Base/Base Set/84.ts
@@ -23,7 +23,16 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
-			subtype: "unlimited",
+			subtype: "1999-2000-copyright",
+		},
+		{
+			type: "normal",
+			subtype: "unlimited"
+		},
+		{
+			type: "normal",
+			subtype: "shadowless",
+			stamp: ["1st-edition"],
 			thirdParty: {
 				cardmarket: 273779,
 				tcgplayer: 42430
@@ -32,18 +41,9 @@ const card: Card = {
 		{
 			type: "normal",
 			subtype: "shadowless",
-			stamp: ["1st-edition"]
-		},
-		{
-			type: "normal",
-			subtype: "shadowless",
 			thirdParty: {
 				cardmarket: 660122
 			}
-		},
-		{
-			type: "normal",
-			subtype: "1999-2000-copyright"
 		}
 	],
 }

--- a/data/Base/Base Set/85.ts
+++ b/data/Base/Base Set/85.ts
@@ -20,13 +20,18 @@ const card: Card = {
 		it: "Togli tutti i segnalini danno da tutti i tuoi Pokémon e poi scarta tutte le carte Energia assegnate a quei Pokémon."
 	},
 
-	thirdParty: {
-		cardmarket: 273780
-	},
+
 	variants: [
 		{
 			type: "normal",
-			subtype: "unlimited",
+			subtype: "1999-2000-copyright",
+			thirdParty: {
+				cardmarket: 273780
+			}
+		},
+		{
+			type: "normal",
+			subtype: "unlimited"
 		},
 		{
 			type: "normal",
@@ -36,10 +41,9 @@ const card: Card = {
 		{
 			type: "normal",
 			subtype: "shadowless",
-		},
-		{
-			type: "normal",
-			subtype: "1999-2000-copyright",
+			thirdParty: {
+				cardmarket: 660121
+			}
 		}
 	],
 }

--- a/data/Base/Base Set/85.ts
+++ b/data/Base/Base Set/85.ts
@@ -20,18 +20,13 @@ const card: Card = {
 		it: "Togli tutti i segnalini danno da tutti i tuoi Pokémon e poi scarta tutte le carte Energia assegnate a quei Pokémon."
 	},
 
-
 	variants: [
 		{
 			type: "normal",
-			subtype: "1999-2000-copyright",
+			subtype: "unlimited",
 			thirdParty: {
 				cardmarket: 273780
 			}
-		},
-		{
-			type: "normal",
-			subtype: "unlimited"
 		},
 		{
 			type: "normal",
@@ -44,6 +39,10 @@ const card: Card = {
 			thirdParty: {
 				cardmarket: 660121
 			}
+		},
+		{
+			type: "normal",
+			subtype: "1999-2000-copyright"
 		}
 	],
 }

--- a/data/Base/Base Set/85.ts
+++ b/data/Base/Base Set/85.ts
@@ -20,10 +20,20 @@ const card: Card = {
 		it: "Togli tutti i segnalini danno da tutti i tuoi Pokémon e poi scarta tutte le carte Energia assegnate a quei Pokémon."
 	},
 
+
 	variants: [
 		{
 			type: "normal",
-			subtype: "unlimited",
+			subtype: "1999-2000-copyright",
+		},
+		{
+			type: "normal",
+			subtype: "unlimited"
+		},
+		{
+			type: "normal",
+			subtype: "shadowless",
+			stamp: ["1st-edition"],
 			thirdParty: {
 				cardmarket: 273780
 			}
@@ -31,18 +41,9 @@ const card: Card = {
 		{
 			type: "normal",
 			subtype: "shadowless",
-			stamp: ["1st-edition"]
-		},
-		{
-			type: "normal",
-			subtype: "shadowless",
 			thirdParty: {
 				cardmarket: 660121
 			}
-		},
-		{
-			type: "normal",
-			subtype: "1999-2000-copyright"
 		}
 	],
 }

--- a/data/Base/Base Set/86.ts
+++ b/data/Base/Base Set/86.ts
@@ -20,13 +20,18 @@ const card: Card = {
 		it: "Scegli un Pokémon Base dalla pila degli scarti del tuo avversario e mettilo nella sua Panchina. (Se la Panchina del tuo avversario è già completa, non puoi giocare Poké Flauto.)",
 	},
 
-	thirdParty: {
-		cardmarket: 273781
-	},
+
 	variants: [
 		{
 			type: "normal",
-			subtype: "unlimited",
+			subtype: "1999-2000-copyright",
+			thirdParty: {
+				cardmarket: 273781
+			}
+		},
+		{
+			type: "normal",
+			subtype: "unlimited"
 		},
 		{
 			type: "normal",
@@ -36,10 +41,9 @@ const card: Card = {
 		{
 			type: "normal",
 			subtype: "shadowless",
-		},
-		{
-			type: "normal",
-			subtype: "1999-2000-copyright",
+			thirdParty: {
+				cardmarket: 660120
+			}
 		}
 	],
 }

--- a/data/Base/Base Set/86.ts
+++ b/data/Base/Base Set/86.ts
@@ -20,18 +20,13 @@ const card: Card = {
 		it: "Scegli un Pokémon Base dalla pila degli scarti del tuo avversario e mettilo nella sua Panchina. (Se la Panchina del tuo avversario è già completa, non puoi giocare Poké Flauto.)",
 	},
 
-
 	variants: [
 		{
 			type: "normal",
-			subtype: "1999-2000-copyright",
+			subtype: "unlimited",
 			thirdParty: {
 				cardmarket: 273781
 			}
-		},
-		{
-			type: "normal",
-			subtype: "unlimited"
 		},
 		{
 			type: "normal",
@@ -44,6 +39,10 @@ const card: Card = {
 			thirdParty: {
 				cardmarket: 660120
 			}
+		},
+		{
+			type: "normal",
+			subtype: "1999-2000-copyright"
 		}
 	],
 }

--- a/data/Base/Base Set/86.ts
+++ b/data/Base/Base Set/86.ts
@@ -20,10 +20,20 @@ const card: Card = {
 		it: "Scegli un Pokémon Base dalla pila degli scarti del tuo avversario e mettilo nella sua Panchina. (Se la Panchina del tuo avversario è già completa, non puoi giocare Poké Flauto.)",
 	},
 
+
 	variants: [
 		{
 			type: "normal",
-			subtype: "unlimited",
+			subtype: "1999-2000-copyright",
+		},
+		{
+			type: "normal",
+			subtype: "unlimited"
+		},
+		{
+			type: "normal",
+			subtype: "shadowless",
+			stamp: ["1st-edition"],
 			thirdParty: {
 				cardmarket: 273781
 			}
@@ -31,18 +41,9 @@ const card: Card = {
 		{
 			type: "normal",
 			subtype: "shadowless",
-			stamp: ["1st-edition"]
-		},
-		{
-			type: "normal",
-			subtype: "shadowless",
 			thirdParty: {
 				cardmarket: 660120
 			}
-		},
-		{
-			type: "normal",
-			subtype: "1999-2000-copyright"
 		}
 	],
 }

--- a/data/Base/Base Set/87.ts
+++ b/data/Base/Base Set/87.ts
@@ -20,18 +20,13 @@ const card: Card = {
 		it: "Guarda un massimo di 5 carte in cima al tuo mazzo e rimettile nell'ordine che vuoi."
 	},
 
-
 	variants: [
 		{
 			type: "normal",
-			subtype: "1999-2000-copyright",
+			subtype: "unlimited",
 			thirdParty: {
 				cardmarket: 273782
 			}
-		},
-		{
-			type: "normal",
-			subtype: "unlimited"
 		},
 		{
 			type: "normal",
@@ -44,6 +39,10 @@ const card: Card = {
 			thirdParty: {
 				cardmarket: 660119
 			}
+		},
+		{
+			type: "normal",
+			subtype: "1999-2000-copyright"
 		}
 	],
 }

--- a/data/Base/Base Set/87.ts
+++ b/data/Base/Base Set/87.ts
@@ -20,13 +20,18 @@ const card: Card = {
 		it: "Guarda un massimo di 5 carte in cima al tuo mazzo e rimettile nell'ordine che vuoi."
 	},
 
-	thirdParty: {
-		cardmarket: 273782
-	},
+
 	variants: [
 		{
 			type: "normal",
-			subtype: "unlimited",
+			subtype: "1999-2000-copyright",
+			thirdParty: {
+				cardmarket: 273782
+			}
+		},
+		{
+			type: "normal",
+			subtype: "unlimited"
 		},
 		{
 			type: "normal",
@@ -36,10 +41,9 @@ const card: Card = {
 		{
 			type: "normal",
 			subtype: "shadowless",
-		},
-		{
-			type: "normal",
-			subtype: "1999-2000-copyright",
+			thirdParty: {
+				cardmarket: 660119
+			}
 		}
 	],
 }

--- a/data/Base/Base Set/87.ts
+++ b/data/Base/Base Set/87.ts
@@ -20,10 +20,20 @@ const card: Card = {
 		it: "Guarda un massimo di 5 carte in cima al tuo mazzo e rimettile nell'ordine che vuoi."
 	},
 
+
 	variants: [
 		{
 			type: "normal",
-			subtype: "unlimited",
+			subtype: "1999-2000-copyright",
+		},
+		{
+			type: "normal",
+			subtype: "unlimited"
+		},
+		{
+			type: "normal",
+			subtype: "shadowless",
+			stamp: ["1st-edition"],
 			thirdParty: {
 				cardmarket: 273782
 			}
@@ -31,18 +41,9 @@ const card: Card = {
 		{
 			type: "normal",
 			subtype: "shadowless",
-			stamp: ["1st-edition"]
-		},
-		{
-			type: "normal",
-			subtype: "shadowless",
 			thirdParty: {
 				cardmarket: 660119
 			}
-		},
-		{
-			type: "normal",
-			subtype: "1999-2000-copyright"
 		}
 	],
 }

--- a/data/Base/Base Set/88.ts
+++ b/data/Base/Base Set/88.ts
@@ -24,15 +24,11 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
-			subtype: "1999-2000-copyright",
+			subtype: "unlimited",
 			thirdParty: {
 				cardmarket: 273783,
 				tcgplayer: 42431
 			}
-		},
-		{
-			type: "normal",
-			subtype: "unlimited"
 		},
 		{
 			type: "normal",
@@ -45,6 +41,10 @@ const card: Card = {
 			thirdParty: {
 				cardmarket: 660118
 			}
+		},
+		{
+			type: "normal",
+			subtype: "1999-2000-copyright"
 		}
 	],
 }

--- a/data/Base/Base Set/88.ts
+++ b/data/Base/Base Set/88.ts
@@ -21,14 +21,18 @@ const card: Card = {
 		it: "Scarta le carte che hai in mano e pescane altre 7."
 	},
 
-	thirdParty: {
-		cardmarket: 273783,
-		tcgplayer: 42431
-	},
 	variants: [
 		{
 			type: "normal",
-			subtype: "unlimited",
+			subtype: "1999-2000-copyright",
+			thirdParty: {
+				cardmarket: 273783,
+				tcgplayer: 42431
+			}
+		},
+		{
+			type: "normal",
+			subtype: "unlimited"
 		},
 		{
 			type: "normal",
@@ -38,10 +42,9 @@ const card: Card = {
 		{
 			type: "normal",
 			subtype: "shadowless",
-		},
-		{
-			type: "normal",
-			subtype: "1999-2000-copyright",
+			thirdParty: {
+				cardmarket: 660118
+			}
 		}
 	],
 }

--- a/data/Base/Base Set/88.ts
+++ b/data/Base/Base Set/88.ts
@@ -24,7 +24,16 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
-			subtype: "unlimited",
+			subtype: "1999-2000-copyright",
+		},
+		{
+			type: "normal",
+			subtype: "unlimited"
+		},
+		{
+			type: "normal",
+			subtype: "shadowless",
+			stamp: ["1st-edition"],
 			thirdParty: {
 				cardmarket: 273783,
 				tcgplayer: 42431
@@ -33,18 +42,9 @@ const card: Card = {
 		{
 			type: "normal",
 			subtype: "shadowless",
-			stamp: ["1st-edition"]
-		},
-		{
-			type: "normal",
-			subtype: "shadowless",
 			thirdParty: {
 				cardmarket: 660118
 			}
-		},
-		{
-			type: "normal",
-			subtype: "1999-2000-copyright"
 		}
 	],
 }

--- a/data/Base/Base Set/89.ts
+++ b/data/Base/Base Set/89.ts
@@ -23,15 +23,11 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
-			subtype: "1999-2000-copyright",
+			subtype: "unlimited",
 			thirdParty: {
 				cardmarket: 273784,
 				tcgplayer: 42432
 			}
-		},
-		{
-			type: "normal",
-			subtype: "unlimited"
 		},
 		{
 			type: "normal",
@@ -44,6 +40,10 @@ const card: Card = {
 			thirdParty: {
 				cardmarket: 660116
 			}
+		},
+		{
+			type: "normal",
+			subtype: "1999-2000-copyright"
 		}
 	],
 }

--- a/data/Base/Base Set/89.ts
+++ b/data/Base/Base Set/89.ts
@@ -20,14 +20,18 @@ const card: Card = {
 		it: "Metti in Panchina un Pokémon Base dalla tua pila degli scarti. Metti su quel Pokémon un numero di segnalini danno pari alla metà dei suoi PV (arrotondati per difetto alla decina più vicina). (Non puoi giocare questa carta se la tua Panchina è piena.)"
 	},
 
-	thirdParty: {
-		cardmarket: 273784,
-		tcgplayer: 42432
-	},
 	variants: [
 		{
 			type: "normal",
-			subtype: "unlimited",
+			subtype: "1999-2000-copyright",
+			thirdParty: {
+				cardmarket: 273784,
+				tcgplayer: 42432
+			}
+		},
+		{
+			type: "normal",
+			subtype: "unlimited"
 		},
 		{
 			type: "normal",
@@ -37,10 +41,9 @@ const card: Card = {
 		{
 			type: "normal",
 			subtype: "shadowless",
-		},
-		{
-			type: "normal",
-			subtype: "1999-2000-copyright",
+			thirdParty: {
+				cardmarket: 660116
+			}
 		}
 	],
 }

--- a/data/Base/Base Set/89.ts
+++ b/data/Base/Base Set/89.ts
@@ -23,7 +23,16 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
-			subtype: "unlimited",
+			subtype: "1999-2000-copyright",
+		},
+		{
+			type: "normal",
+			subtype: "unlimited"
+		},
+		{
+			type: "normal",
+			subtype: "shadowless",
+			stamp: ["1st-edition"],
 			thirdParty: {
 				cardmarket: 273784,
 				tcgplayer: 42432
@@ -32,18 +41,9 @@ const card: Card = {
 		{
 			type: "normal",
 			subtype: "shadowless",
-			stamp: ["1st-edition"]
-		},
-		{
-			type: "normal",
-			subtype: "shadowless",
 			thirdParty: {
 				cardmarket: 660116
 			}
-		},
-		{
-			type: "normal",
-			subtype: "1999-2000-copyright"
 		}
 	],
 }

--- a/data/Base/Base Set/9.ts
+++ b/data/Base/Base Set/9.ts
@@ -93,7 +93,15 @@ const card: Card = {
 	variants: [
 		{
 			type: "holo",
-			subtype: "unlimited",
+			subtype: "1999-2000-copyright",
+			thirdParty: {
+				cardmarket: 273704,
+				tcgplayer: 42433
+			}
+		},
+		{
+			type: "holo",
+			subtype: "unlimited"
 		},
 		{
 			type: "holo",
@@ -103,18 +111,13 @@ const card: Card = {
 		{
 			type: "holo",
 			subtype: "shadowless",
-		},
-		{
-			type: "holo",
-			subtype: "1999-2000-copyright",
+			thirdParty: {
+				cardmarket: 660219
+			}
 		}
 	],
 
 
-	thirdParty: {
-		cardmarket: 273704,
-		tcgplayer: 42433
-	}
 }
 
 export default card

--- a/data/Base/Base Set/9.ts
+++ b/data/Base/Base Set/9.ts
@@ -93,15 +93,11 @@ const card: Card = {
 	variants: [
 		{
 			type: "holo",
-			subtype: "1999-2000-copyright",
+			subtype: "unlimited",
 			thirdParty: {
 				cardmarket: 273704,
 				tcgplayer: 42433
 			}
-		},
-		{
-			type: "holo",
-			subtype: "unlimited"
 		},
 		{
 			type: "holo",
@@ -114,6 +110,10 @@ const card: Card = {
 			thirdParty: {
 				cardmarket: 660219
 			}
+		},
+		{
+			type: "holo",
+			subtype: "1999-2000-copyright"
 		}
 	],
 

--- a/data/Base/Base Set/9.ts
+++ b/data/Base/Base Set/9.ts
@@ -93,7 +93,16 @@ const card: Card = {
 	variants: [
 		{
 			type: "holo",
-			subtype: "unlimited",
+			subtype: "1999-2000-copyright",
+		},
+		{
+			type: "holo",
+			subtype: "unlimited"
+		},
+		{
+			type: "holo",
+			subtype: "shadowless",
+			stamp: ["1st-edition"],
 			thirdParty: {
 				cardmarket: 273704,
 				tcgplayer: 42433
@@ -102,18 +111,9 @@ const card: Card = {
 		{
 			type: "holo",
 			subtype: "shadowless",
-			stamp: ["1st-edition"]
-		},
-		{
-			type: "holo",
-			subtype: "shadowless",
 			thirdParty: {
 				cardmarket: 660219
 			}
-		},
-		{
-			type: "holo",
-			subtype: "1999-2000-copyright"
 		}
 	],
 

--- a/data/Base/Base Set/90.ts
+++ b/data/Base/Base Set/90.ts
@@ -20,14 +20,18 @@ const card: Card = {
 		it: "Scarta una carta Energia assegnata a uno dei tuoi Pokémon per poter togliere al massimo 4 segnalini danno da quel Pokémon." 
 	},
 
-	thirdParty: {
-		cardmarket: 273785,
-		tcgplayer: 42434
-	},
 	variants: [
 		{
 			type: "normal",
-			subtype: "unlimited",
+			subtype: "1999-2000-copyright",
+			thirdParty: {
+				cardmarket: 273785,
+				tcgplayer: 42434
+			}
+		},
+		{
+			type: "normal",
+			subtype: "unlimited"
 		},
 		{
 			type: "normal",
@@ -37,10 +41,9 @@ const card: Card = {
 		{
 			type: "normal",
 			subtype: "shadowless",
-		},
-		{
-			type: "normal",
-			subtype: "1999-2000-copyright",
+			thirdParty: {
+				cardmarket: 660115
+			}
 		}
 	],
 }

--- a/data/Base/Base Set/90.ts
+++ b/data/Base/Base Set/90.ts
@@ -23,15 +23,11 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
-			subtype: "1999-2000-copyright",
+			subtype: "unlimited",
 			thirdParty: {
 				cardmarket: 273785,
 				tcgplayer: 42434
 			}
-		},
-		{
-			type: "normal",
-			subtype: "unlimited"
 		},
 		{
 			type: "normal",
@@ -44,6 +40,10 @@ const card: Card = {
 			thirdParty: {
 				cardmarket: 660115
 			}
+		},
+		{
+			type: "normal",
+			subtype: "1999-2000-copyright"
 		}
 	],
 }

--- a/data/Base/Base Set/90.ts
+++ b/data/Base/Base Set/90.ts
@@ -23,7 +23,16 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
-			subtype: "unlimited",
+			subtype: "1999-2000-copyright",
+		},
+		{
+			type: "normal",
+			subtype: "unlimited"
+		},
+		{
+			type: "normal",
+			subtype: "shadowless",
+			stamp: ["1st-edition"],
 			thirdParty: {
 				cardmarket: 273785,
 				tcgplayer: 42434
@@ -32,18 +41,9 @@ const card: Card = {
 		{
 			type: "normal",
 			subtype: "shadowless",
-			stamp: ["1st-edition"]
-		},
-		{
-			type: "normal",
-			subtype: "shadowless",
 			thirdParty: {
 				cardmarket: 660115
 			}
-		},
-		{
-			type: "normal",
-			subtype: "1999-2000-copyright"
 		}
 	],
 }

--- a/data/Base/Base Set/91.ts
+++ b/data/Base/Base Set/91.ts
@@ -23,15 +23,11 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
-			subtype: "1999-2000-copyright",
+			subtype: "unlimited",
 			thirdParty: {
 				cardmarket: 273786,
 				tcgplayer: 42435
 			}
-		},
-		{
-			type: "normal",
-			subtype: "unlimited"
 		},
 		{
 			type: "normal",
@@ -44,6 +40,10 @@ const card: Card = {
 			thirdParty: {
 				cardmarket: 660113
 			}
+		},
+		{
+			type: "normal",
+			subtype: "1999-2000-copyright"
 		}
 	],
 }

--- a/data/Base/Base Set/91.ts
+++ b/data/Base/Base Set/91.ts
@@ -20,14 +20,18 @@ const card: Card = {
 		it: "Pesca 2 carte."
 	},
 
-	thirdParty: {
-		cardmarket: 273786,
-		tcgplayer: 42435
-	},
 	variants: [
 		{
 			type: "normal",
-			subtype: "unlimited",
+			subtype: "1999-2000-copyright",
+			thirdParty: {
+				cardmarket: 273786,
+				tcgplayer: 42435
+			}
+		},
+		{
+			type: "normal",
+			subtype: "unlimited"
 		},
 		{
 			type: "normal",
@@ -37,10 +41,9 @@ const card: Card = {
 		{
 			type: "normal",
 			subtype: "shadowless",
-		},
-		{
-			type: "normal",
-			subtype: "1999-2000-copyright",
+			thirdParty: {
+				cardmarket: 660113
+			}
 		}
 	],
 }

--- a/data/Base/Base Set/91.ts
+++ b/data/Base/Base Set/91.ts
@@ -23,7 +23,16 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
-			subtype: "unlimited",
+			subtype: "1999-2000-copyright",
+		},
+		{
+			type: "normal",
+			subtype: "unlimited"
+		},
+		{
+			type: "normal",
+			subtype: "shadowless",
+			stamp: ["1st-edition"],
 			thirdParty: {
 				cardmarket: 273786,
 				tcgplayer: 42435
@@ -32,18 +41,9 @@ const card: Card = {
 		{
 			type: "normal",
 			subtype: "shadowless",
-			stamp: ["1st-edition"]
-		},
-		{
-			type: "normal",
-			subtype: "shadowless",
 			thirdParty: {
 				cardmarket: 660113
 			}
-		},
-		{
-			type: "normal",
-			subtype: "1999-2000-copyright"
 		}
 	],
 }

--- a/data/Base/Base Set/92.ts
+++ b/data/Base/Base Set/92.ts
@@ -20,14 +20,18 @@ const card: Card = {
 		it: "Scegli una carta Energia assegnata a uno dei Pokémon del tuo avversario e scartala."
 	},
 
-	thirdParty: {
-		cardmarket: 273787,
-		tcgplayer: 42436
-	},
 	variants: [
 		{
 			type: "normal",
-			subtype: "unlimited",
+			subtype: "1999-2000-copyright",
+			thirdParty: {
+				cardmarket: 273787,
+				tcgplayer: 42436
+			}
+		},
+		{
+			type: "normal",
+			subtype: "unlimited"
 		},
 		{
 			type: "normal",
@@ -37,10 +41,9 @@ const card: Card = {
 		{
 			type: "normal",
 			subtype: "shadowless",
-		},
-		{
-			type: "normal",
-			subtype: "1999-2000-copyright",
+			thirdParty: {
+				cardmarket: 660112
+			}
 		}
 	],
 }

--- a/data/Base/Base Set/92.ts
+++ b/data/Base/Base Set/92.ts
@@ -23,15 +23,11 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
-			subtype: "1999-2000-copyright",
+			subtype: "unlimited",
 			thirdParty: {
 				cardmarket: 273787,
 				tcgplayer: 42436
 			}
-		},
-		{
-			type: "normal",
-			subtype: "unlimited"
 		},
 		{
 			type: "normal",
@@ -44,6 +40,10 @@ const card: Card = {
 			thirdParty: {
 				cardmarket: 660112
 			}
+		},
+		{
+			type: "normal",
+			subtype: "1999-2000-copyright"
 		}
 	],
 }

--- a/data/Base/Base Set/92.ts
+++ b/data/Base/Base Set/92.ts
@@ -23,7 +23,16 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
-			subtype: "unlimited",
+			subtype: "1999-2000-copyright",
+		},
+		{
+			type: "normal",
+			subtype: "unlimited"
+		},
+		{
+			type: "normal",
+			subtype: "shadowless",
+			stamp: ["1st-edition"],
 			thirdParty: {
 				cardmarket: 273787,
 				tcgplayer: 42436
@@ -32,18 +41,9 @@ const card: Card = {
 		{
 			type: "normal",
 			subtype: "shadowless",
-			stamp: ["1st-edition"]
-		},
-		{
-			type: "normal",
-			subtype: "shadowless",
 			thirdParty: {
 				cardmarket: 660112
 			}
-		},
-		{
-			type: "normal",
-			subtype: "1999-2000-copyright"
 		}
 	],
 }

--- a/data/Base/Base Set/93.ts
+++ b/data/Base/Base Set/93.ts
@@ -20,14 +20,18 @@ const card: Card = {
 		it: "Scegli un Pokémon nella Panchina del tuo avversario e scambialo con il suo Pokémon Attivo."
 	},
 
-	thirdParty: {
-		cardmarket: 273788,
-		tcgplayer: 42437
-	},
 	variants: [
 		{
 			type: "normal",
-			subtype: "unlimited",
+			subtype: "1999-2000-copyright",
+			thirdParty: {
+				cardmarket: 273788,
+				tcgplayer: 42437
+			}
+		},
+		{
+			type: "normal",
+			subtype: "unlimited"
 		},
 		{
 			type: "normal",
@@ -37,10 +41,9 @@ const card: Card = {
 		{
 			type: "normal",
 			subtype: "shadowless",
-		},
-		{
-			type: "normal",
-			subtype: "1999-2000-copyright",
+			thirdParty: {
+				cardmarket: 660110
+			}
 		}
 	],
 }

--- a/data/Base/Base Set/93.ts
+++ b/data/Base/Base Set/93.ts
@@ -23,15 +23,11 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
-			subtype: "1999-2000-copyright",
+			subtype: "unlimited",
 			thirdParty: {
 				cardmarket: 273788,
 				tcgplayer: 42437
 			}
-		},
-		{
-			type: "normal",
-			subtype: "unlimited"
 		},
 		{
 			type: "normal",
@@ -44,6 +40,10 @@ const card: Card = {
 			thirdParty: {
 				cardmarket: 660110
 			}
+		},
+		{
+			type: "normal",
+			subtype: "1999-2000-copyright"
 		}
 	],
 }

--- a/data/Base/Base Set/93.ts
+++ b/data/Base/Base Set/93.ts
@@ -23,7 +23,16 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
-			subtype: "unlimited",
+			subtype: "1999-2000-copyright",
+		},
+		{
+			type: "normal",
+			subtype: "unlimited"
+		},
+		{
+			type: "normal",
+			subtype: "shadowless",
+			stamp: ["1st-edition"],
 			thirdParty: {
 				cardmarket: 273788,
 				tcgplayer: 42437
@@ -32,18 +41,9 @@ const card: Card = {
 		{
 			type: "normal",
 			subtype: "shadowless",
-			stamp: ["1st-edition"]
-		},
-		{
-			type: "normal",
-			subtype: "shadowless",
 			thirdParty: {
 				cardmarket: 660110
 			}
-		},
-		{
-			type: "normal",
-			subtype: "1999-2000-copyright"
 		}
 	],
 }

--- a/data/Base/Base Set/94.ts
+++ b/data/Base/Base Set/94.ts
@@ -23,15 +23,11 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
-			subtype: "1999-2000-copyright",
+			subtype: "unlimited",
 			thirdParty: {
 				cardmarket: 273789,
 				tcgplayer: 42438
 			}
-		},
-		{
-			type: "normal",
-			subtype: "unlimited"
 		},
 		{
 			type: "normal",
@@ -44,6 +40,10 @@ const card: Card = {
 			thirdParty: {
 				cardmarket: 660109
 			}
+		},
+		{
+			type: "normal",
+			subtype: "1999-2000-copyright"
 		}
 	],
 }

--- a/data/Base/Base Set/94.ts
+++ b/data/Base/Base Set/94.ts
@@ -20,14 +20,18 @@ const card: Card = {
 		it: "Togli al massimo 2 segnalini danno da uno dei tuoi Pokémon."
 	},
 
-	thirdParty: {
-		cardmarket: 273789,
-		tcgplayer: 42438
-	},
 	variants: [
 		{
 			type: "normal",
-			subtype: "unlimited",
+			subtype: "1999-2000-copyright",
+			thirdParty: {
+				cardmarket: 273789,
+				tcgplayer: 42438
+			}
+		},
+		{
+			type: "normal",
+			subtype: "unlimited"
 		},
 		{
 			type: "normal",
@@ -37,10 +41,9 @@ const card: Card = {
 		{
 			type: "normal",
 			subtype: "shadowless",
-		},
-		{
-			type: "normal",
-			subtype: "1999-2000-copyright",
+			thirdParty: {
+				cardmarket: 660109
+			}
 		}
 	],
 }

--- a/data/Base/Base Set/94.ts
+++ b/data/Base/Base Set/94.ts
@@ -23,7 +23,16 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
-			subtype: "unlimited",
+			subtype: "1999-2000-copyright",
+		},
+		{
+			type: "normal",
+			subtype: "unlimited"
+		},
+		{
+			type: "normal",
+			subtype: "shadowless",
+			stamp: ["1st-edition"],
 			thirdParty: {
 				cardmarket: 273789,
 				tcgplayer: 42438
@@ -32,18 +41,9 @@ const card: Card = {
 		{
 			type: "normal",
 			subtype: "shadowless",
-			stamp: ["1st-edition"]
-		},
-		{
-			type: "normal",
-			subtype: "shadowless",
 			thirdParty: {
 				cardmarket: 660109
 			}
-		},
-		{
-			type: "normal",
-			subtype: "1999-2000-copyright"
 		}
 	],
 }

--- a/data/Base/Base Set/95.ts
+++ b/data/Base/Base Set/95.ts
@@ -23,15 +23,11 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
-			subtype: "1999-2000-copyright",
+			subtype: "unlimited",
 			thirdParty: {
 				cardmarket: 273790,
 				tcgplayer: 42439
 			}
-		},
-		{
-			type: "normal",
-			subtype: "unlimited"
 		},
 		{
 			type: "normal",
@@ -44,6 +40,10 @@ const card: Card = {
 			thirdParty: {
 				cardmarket: 660107
 			}
+		},
+		{
+			type: "normal",
+			subtype: "1999-2000-copyright"
 		}
 	],
 }

--- a/data/Base/Base Set/95.ts
+++ b/data/Base/Base Set/95.ts
@@ -20,14 +20,18 @@ const card: Card = {
 		it: "Scambia uno dei tuoi Pokémon in Panchina con il tuo Pokémon Attivo."
 	},
 
-	thirdParty: {
-		cardmarket: 273790,
-		tcgplayer: 42439
-	},
 	variants: [
 		{
 			type: "normal",
-			subtype: "unlimited",
+			subtype: "1999-2000-copyright",
+			thirdParty: {
+				cardmarket: 273790,
+				tcgplayer: 42439
+			}
+		},
+		{
+			type: "normal",
+			subtype: "unlimited"
 		},
 		{
 			type: "normal",
@@ -37,10 +41,9 @@ const card: Card = {
 		{
 			type: "normal",
 			subtype: "shadowless",
-		},
-		{
-			type: "normal",
-			subtype: "1999-2000-copyright",
+			thirdParty: {
+				cardmarket: 660107
+			}
 		}
 	],
 }

--- a/data/Base/Base Set/95.ts
+++ b/data/Base/Base Set/95.ts
@@ -23,7 +23,16 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
-			subtype: "unlimited",
+			subtype: "1999-2000-copyright",
+		},
+		{
+			type: "normal",
+			subtype: "unlimited"
+		},
+		{
+			type: "normal",
+			subtype: "shadowless",
+			stamp: ["1st-edition"],
 			thirdParty: {
 				cardmarket: 273790,
 				tcgplayer: 42439
@@ -32,18 +41,9 @@ const card: Card = {
 		{
 			type: "normal",
 			subtype: "shadowless",
-			stamp: ["1st-edition"]
-		},
-		{
-			type: "normal",
-			subtype: "shadowless",
 			thirdParty: {
 				cardmarket: 660107
 			}
-		},
-		{
-			type: "normal",
-			subtype: "1999-2000-copyright"
 		}
 	],
 }

--- a/data/Base/Base Set/96.ts
+++ b/data/Base/Base Set/96.ts
@@ -21,14 +21,18 @@ const card: Card = {
 		fr: "Fournit Incolore Incolore énergies. Ne compte pas comme une carte Énergie de base.",
 	},
 
-	thirdParty: {
-		cardmarket: 273791,
-		tcgplayer: 42440
-	},
 	variants: [
 		{
 			type: "normal",
-			subtype: "unlimited",
+			subtype: "1999-2000-copyright",
+			thirdParty: {
+				cardmarket: 273791,
+				tcgplayer: 42440
+			}
+		},
+		{
+			type: "normal",
+			subtype: "unlimited"
 		},
 		{
 			type: "normal",
@@ -38,10 +42,9 @@ const card: Card = {
 		{
 			type: "normal",
 			subtype: "shadowless",
-		},
-		{
-			type: "normal",
-			subtype: "1999-2000-copyright",
+			thirdParty: {
+				cardmarket: 660106
+			}
 		}
 	],
 }

--- a/data/Base/Base Set/96.ts
+++ b/data/Base/Base Set/96.ts
@@ -24,15 +24,11 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
-			subtype: "1999-2000-copyright",
+			subtype: "unlimited",
 			thirdParty: {
 				cardmarket: 273791,
 				tcgplayer: 42440
 			}
-		},
-		{
-			type: "normal",
-			subtype: "unlimited"
 		},
 		{
 			type: "normal",
@@ -45,6 +41,10 @@ const card: Card = {
 			thirdParty: {
 				cardmarket: 660106
 			}
+		},
+		{
+			type: "normal",
+			subtype: "1999-2000-copyright"
 		}
 	],
 }

--- a/data/Base/Base Set/96.ts
+++ b/data/Base/Base Set/96.ts
@@ -24,7 +24,16 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
-			subtype: "unlimited",
+			subtype: "1999-2000-copyright",
+		},
+		{
+			type: "normal",
+			subtype: "unlimited"
+		},
+		{
+			type: "normal",
+			subtype: "shadowless",
+			stamp: ["1st-edition"],
 			thirdParty: {
 				cardmarket: 273791,
 				tcgplayer: 42440
@@ -33,18 +42,9 @@ const card: Card = {
 		{
 			type: "normal",
 			subtype: "shadowless",
-			stamp: ["1st-edition"]
-		},
-		{
-			type: "normal",
-			subtype: "shadowless",
 			thirdParty: {
 				cardmarket: 660106
 			}
-		},
-		{
-			type: "normal",
-			subtype: "1999-2000-copyright"
 		}
 	],
 }

--- a/data/Base/Base Set/97.ts
+++ b/data/Base/Base Set/97.ts
@@ -19,15 +19,11 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
-			subtype: "1999-2000-copyright",
+			subtype: "unlimited",
 			thirdParty: {
 				cardmarket: 273792,
 				tcgplayer: 42441
 			}
-		},
-		{
-			type: "normal",
-			subtype: "unlimited"
 		},
 		{
 			type: "normal",
@@ -40,6 +36,10 @@ const card: Card = {
 			thirdParty: {
 				cardmarket: 660105
 			}
+		},
+		{
+			type: "normal",
+			subtype: "1999-2000-copyright"
 		}
 	],
 }

--- a/data/Base/Base Set/97.ts
+++ b/data/Base/Base Set/97.ts
@@ -16,14 +16,18 @@ const card: Card = {
 	stage: "Basic",
 	energyType: "Normal",
 
-	thirdParty: {
-		cardmarket: 273792,
-		tcgplayer: 42441
-	},
 	variants: [
 		{
 			type: "normal",
-			subtype: "unlimited",
+			subtype: "1999-2000-copyright",
+			thirdParty: {
+				cardmarket: 273792,
+				tcgplayer: 42441
+			}
+		},
+		{
+			type: "normal",
+			subtype: "unlimited"
 		},
 		{
 			type: "normal",
@@ -33,10 +37,9 @@ const card: Card = {
 		{
 			type: "normal",
 			subtype: "shadowless",
-		},
-		{
-			type: "normal",
-			subtype: "1999-2000-copyright",
+			thirdParty: {
+				cardmarket: 660105
+			}
 		}
 	],
 }

--- a/data/Base/Base Set/97.ts
+++ b/data/Base/Base Set/97.ts
@@ -19,7 +19,16 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
-			subtype: "unlimited",
+			subtype: "1999-2000-copyright",
+		},
+		{
+			type: "normal",
+			subtype: "unlimited"
+		},
+		{
+			type: "normal",
+			subtype: "shadowless",
+			stamp: ["1st-edition"],
 			thirdParty: {
 				cardmarket: 273792,
 				tcgplayer: 42441
@@ -28,18 +37,9 @@ const card: Card = {
 		{
 			type: "normal",
 			subtype: "shadowless",
-			stamp: ["1st-edition"]
-		},
-		{
-			type: "normal",
-			subtype: "shadowless",
 			thirdParty: {
 				cardmarket: 660105
 			}
-		},
-		{
-			type: "normal",
-			subtype: "1999-2000-copyright"
 		}
 	],
 }

--- a/data/Base/Base Set/98.ts
+++ b/data/Base/Base Set/98.ts
@@ -16,14 +16,18 @@ const card: Card = {
 	stage: "Basic",
 	energyType: "Normal",
 
-	thirdParty: {
-		cardmarket: 273793,
-		tcgplayer: 42442
-	},
 	variants: [
 		{
 			type: "normal",
-			subtype: "unlimited",
+			subtype: "1999-2000-copyright",
+			thirdParty: {
+				cardmarket: 273793,
+				tcgplayer: 42442
+			}
+		},
+		{
+			type: "normal",
+			subtype: "unlimited"
 		},
 		{
 			type: "normal",
@@ -32,11 +36,18 @@ const card: Card = {
 		},
 		{
 			type: "normal",
-			subtype: "shadowless",
+			subtype: "shadowless"
 		},
 		{
-			type: "normal",
-			subtype: "1999-2000-copyright",
+			type: "V2",
+			cardmarketLabels: ["Soy"]
+		},
+		{
+			type: "V2",
+			cardmarketLabels: ["Soy"],
+			thirdParty: {
+				cardmarket: 660103
+			}
 		}
 	],
 }

--- a/data/Base/Base Set/98.ts
+++ b/data/Base/Base Set/98.ts
@@ -19,15 +19,11 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
-			subtype: "1999-2000-copyright",
+			subtype: "unlimited",
 			thirdParty: {
 				cardmarket: 273793,
 				tcgplayer: 42442
 			}
-		},
-		{
-			type: "normal",
-			subtype: "unlimited"
 		},
 		{
 			type: "normal",
@@ -36,18 +32,14 @@ const card: Card = {
 		},
 		{
 			type: "normal",
-			subtype: "shadowless"
-		},
-		{
-			type: "V2",
-			cardmarketLabels: ["Soy"]
-		},
-		{
-			type: "V2",
-			cardmarketLabels: ["Soy"],
+			subtype: "shadowless",
 			thirdParty: {
 				cardmarket: 660103
 			}
+		},
+		{
+			type: "normal",
+			subtype: "1999-2000-copyright"
 		}
 	],
 }

--- a/data/Base/Base Set/98.ts
+++ b/data/Base/Base Set/98.ts
@@ -19,7 +19,16 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
-			subtype: "unlimited",
+			subtype: "1999-2000-copyright",
+		},
+		{
+			type: "normal",
+			subtype: "unlimited"
+		},
+		{
+			type: "normal",
+			subtype: "shadowless",
+			stamp: ["1st-edition"],
 			thirdParty: {
 				cardmarket: 273793,
 				tcgplayer: 42442
@@ -27,20 +36,8 @@ const card: Card = {
 		},
 		{
 			type: "normal",
-			subtype: "shadowless",
-			stamp: ["1st-edition"]
+			subtype: "shadowless"
 		},
-		{
-			type: "normal",
-			subtype: "shadowless",
-			thirdParty: {
-				cardmarket: 660103
-			}
-		},
-		{
-			type: "normal",
-			subtype: "1999-2000-copyright"
-		}
 	],
 }
 

--- a/data/Base/Base Set/99.ts
+++ b/data/Base/Base Set/99.ts
@@ -19,15 +19,11 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
-			subtype: "1999-2000-copyright",
+			subtype: "unlimited",
 			thirdParty: {
 				cardmarket: 273794,
 				tcgplayer: 42443
 			}
-		},
-		{
-			type: "normal",
-			subtype: "unlimited"
 		},
 		{
 			type: "normal",
@@ -40,6 +36,10 @@ const card: Card = {
 			thirdParty: {
 				cardmarket: 660102
 			}
+		},
+		{
+			type: "normal",
+			subtype: "1999-2000-copyright"
 		}
 	],
 }

--- a/data/Base/Base Set/99.ts
+++ b/data/Base/Base Set/99.ts
@@ -16,14 +16,18 @@ const card: Card = {
 	stage: "Basic",
 	energyType: "Normal",
 
-	thirdParty: {
-		cardmarket: 273794,
-		tcgplayer: 42443
-	},
 	variants: [
 		{
 			type: "normal",
-			subtype: "unlimited",
+			subtype: "1999-2000-copyright",
+			thirdParty: {
+				cardmarket: 273794,
+				tcgplayer: 42443
+			}
+		},
+		{
+			type: "normal",
+			subtype: "unlimited"
 		},
 		{
 			type: "normal",
@@ -33,10 +37,9 @@ const card: Card = {
 		{
 			type: "normal",
 			subtype: "shadowless",
-		},
-		{
-			type: "normal",
-			subtype: "1999-2000-copyright",
+			thirdParty: {
+				cardmarket: 660102
+			}
 		}
 	],
 }

--- a/data/Base/Base Set/99.ts
+++ b/data/Base/Base Set/99.ts
@@ -19,7 +19,16 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
-			subtype: "unlimited",
+			subtype: "1999-2000-copyright",
+		},
+		{
+			type: "normal",
+			subtype: "unlimited"
+		},
+		{
+			type: "normal",
+			subtype: "shadowless",
+			stamp: ["1st-edition"],
 			thirdParty: {
 				cardmarket: 273794,
 				tcgplayer: 42443
@@ -28,18 +37,9 @@ const card: Card = {
 		{
 			type: "normal",
 			subtype: "shadowless",
-			stamp: ["1st-edition"]
-		},
-		{
-			type: "normal",
-			subtype: "shadowless",
 			thirdParty: {
 				cardmarket: 660102
 			}
-		},
-		{
-			type: "normal",
-			subtype: "1999-2000-copyright"
 		}
 	],
 }


### PR DESCRIPTION
## Summary
- move Base Set root `thirdParty` ids onto existing `variants` entries only
- keep the change pure data: no schema, server, workflow, or tooling files
- align generic marketplace ids with the intended Base Set print order and keep clear jumbo listings with existing variant fields

## Test plan
- [x] `bun run validate`
- [x] `cd server && bun run compile`
- [x] `cd server && bun run --bun validate`
- [x] `cd .bruno && bru run --env Developpement`