### PR TITLE
(data): Move thirdParty into vairants - OBF & new id Source

### DIFF
--- a/data/Scarlet & Violet/Obsidian Flames/001.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/001.ts
@@ -58,15 +58,28 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 725081,
+				tcgplayer: 509637,
+				cardtrader: 255561
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 725081,
+				tcgplayer: 509637,
+				cardtrader: 255561
+			}
+		},
+	],
 
 	illustrator: "Midori Harada",
 
-	thirdParty: {
-		cardmarket: 725081
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/002.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/002.ts
@@ -66,15 +66,28 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 725082,
+				tcgplayer: 509653,
+				cardtrader: 255562
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 725082,
+				tcgplayer: 509653,
+				cardtrader: 255562
+			}
+		},
+	],
 
 	illustrator: "Haru Akasaka",
 
-	thirdParty: {
-		cardmarket: 725082
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/003.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/003.ts
@@ -77,15 +77,28 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 725083,
+				tcgplayer: 509654,
+				cardtrader: 255563
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 725083,
+				tcgplayer: 509654,
+				cardtrader: 255563
+			}
+		},
+	],
 
 	illustrator: "sui",
 
-	thirdParty: {
-		cardmarket: 725083
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/004.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/004.ts
@@ -60,15 +60,28 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 725084,
+				tcgplayer: 509655,
+				cardtrader: 255564
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 725084,
+				tcgplayer: 509655,
+				cardtrader: 255564
+			}
+		},
+	],
 
 	illustrator: "Shin Nagasawa",
 
-	thirdParty: {
-		cardmarket: 725084
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/005.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/005.ts
@@ -67,15 +67,28 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 725085,
+				tcgplayer: 509657,
+				cardtrader: 255565
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 725085,
+				tcgplayer: 509657,
+				cardtrader: 255565
+			}
+		},
+	],
 
 	illustrator: "Kurata So",
 
-	thirdParty: {
-		cardmarket: 725085
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/006.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/006.ts
@@ -47,15 +47,28 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 725086,
+				tcgplayer: 509658,
+				cardtrader: 255566
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 725086,
+				tcgplayer: 509658,
+				cardtrader: 255566
+			}
+		},
+	],
 
 	illustrator: "Saya Tsuruta",
 
-	thirdParty: {
-		cardmarket: 725086
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/007.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/007.ts
@@ -66,15 +66,28 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 725087,
+				tcgplayer: 509660,
+				cardtrader: 255567
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 725087,
+				tcgplayer: 509660,
+				cardtrader: 255567
+			}
+		},
+	],
 
 	illustrator: "Haru Akasaka",
 
-	thirdParty: {
-		cardmarket: 725087
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/008.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/008.ts
@@ -58,15 +58,28 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 725088,
+				tcgplayer: 509662,
+				cardtrader: 255568
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 725088,
+				tcgplayer: 509662,
+				cardtrader: 255568
+			}
+		},
+	],
 
 	illustrator: "HYOGONOSUKE",
 
-	thirdParty: {
-		cardmarket: 725088
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/009.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/009.ts
@@ -58,15 +58,28 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 725089,
+				tcgplayer: 509665,
+				cardtrader: 255569
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 725089,
+				tcgplayer: 509665,
+				cardtrader: 255569
+			}
+		},
+	],
 
 	illustrator: "You Iribi",
 
-	thirdParty: {
-		cardmarket: 725089
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/010.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/010.ts
@@ -55,15 +55,28 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 725090,
+				tcgplayer: 509700,
+				cardtrader: 255570
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 725090,
+				tcgplayer: 509700,
+				cardtrader: 255570
+			}
+		},
+	],
 
 	illustrator: "Nobuhiro Imagawa",
 
-	thirdParty: {
-		cardmarket: 725090
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/011.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/011.ts
@@ -38,15 +38,28 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 725091,
+				tcgplayer: 509671,
+				cardtrader: 255571
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 725091,
+				tcgplayer: 509671,
+				cardtrader: 255571
+			}
+		},
+	],
 
 	illustrator: "Narumi Sato",
 
-	thirdParty: {
-		cardmarket: 725091
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/012.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/012.ts
@@ -77,15 +77,28 @@ const card: Card = {
 	retreat: 3,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 725092,
+				tcgplayer: 509672,
+				cardtrader: 255572
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 725092,
+				tcgplayer: 509672,
+				cardtrader: 255572
+			}
+		},
+	],
 
 	illustrator: "Anesaki Dynamic",
 
-	thirdParty: {
-		cardmarket: 725092
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/013.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/013.ts
@@ -38,14 +38,35 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 725093,
+				tcgplayer: 509692,
+				cardtrader: 255573
+			}
+		},
+		{
+			type: 'holo',
+			foil: 'cosmos',
+			thirdParty: {
+				cardmarket: 789503
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 725093,
+				tcgplayer: 509692,
+				cardtrader: 255573
+			}
+		},
+	],
 
 	illustrator: "Tomokazu Komiya",
 
-	thirdParty: {
-		cardmarket: 725093
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/014.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/014.ts
@@ -55,14 +55,35 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 789504,
+				tcgplayer: 509705,
+				cardtrader: 255574
+			}
+		},
+		{
+			type: 'holo',
+			foil: 'cosmos',
+			thirdParty: {
+				cardmarket: 725094
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 725094,
+				tcgplayer: 509705,
+				cardtrader: 255574
+			}
+		},
+	],
 
 	illustrator: "sui",
 
-	thirdParty: {
-		cardmarket: 725094
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/015.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/015.ts
@@ -77,17 +77,28 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "G",
 
-	variants: {
-		reverse: false,
-		normal: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 789506,
+				tcgplayer: 509719,
+				cardtrader: 255575
+			}
+		},
+		{
+			type: 'holo',
+			size: 'jumbo',
+			thirdParty: {
+				cardmarket: 725095
+			}
+		},
+	],
 
 	suffix: "ex",
 	illustrator: "PLANETA Mochizuki",
 
-	thirdParty: {
-		cardmarket: 725095
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/016.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/016.ts
@@ -60,15 +60,28 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 725096,
+				tcgplayer: 509734,
+				cardtrader: 255576
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 725096,
+				tcgplayer: 509734,
+				cardtrader: 255576
+			}
+		},
+	],
 
 	illustrator: "Kurata So",
 
-	thirdParty: {
-		cardmarket: 725096
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/017.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/017.ts
@@ -66,15 +66,28 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 725097,
+				tcgplayer: 509748,
+				cardtrader: 255577
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 725097,
+				tcgplayer: 509748,
+				cardtrader: 255577
+			}
+		},
+	],
 
 	illustrator: "nagimiso",
 
-	thirdParty: {
-		cardmarket: 725097
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/018.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/018.ts
@@ -77,15 +77,28 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 725098,
+				tcgplayer: 509751,
+				cardtrader: 255578
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 725098,
+				tcgplayer: 509751,
+				cardtrader: 255578
+			}
+		},
+	],
 
 	illustrator: "Atsushi Furusawa",
 
-	thirdParty: {
-		cardmarket: 725098
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/019.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/019.ts
@@ -47,15 +47,28 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 725099,
+				tcgplayer: 509754,
+				cardtrader: 255579
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 725099,
+				tcgplayer: 509754,
+				cardtrader: 255579
+			}
+		},
+	],
 
 	illustrator: "Masako Tomii",
 
-	thirdParty: {
-		cardmarket: 725099
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/020.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/020.ts
@@ -55,15 +55,28 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 725100,
+				tcgplayer: 509757,
+				cardtrader: 255580
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 725100,
+				tcgplayer: 509757,
+				cardtrader: 255580
+			}
+		},
+	],
 
 	illustrator: "Mizue",
 
-	thirdParty: {
-		cardmarket: 725100
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/021.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/021.ts
@@ -66,15 +66,28 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 725101,
+				tcgplayer: 509762,
+				cardtrader: 255581
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 725101,
+				tcgplayer: 509762,
+				cardtrader: 255581
+			}
+		},
+	],
 
 	illustrator: "KEIICHIRO ITO",
 
-	thirdParty: {
-		cardmarket: 725101
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/022.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/022.ts
@@ -77,17 +77,21 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "G",
 
-	variants: {
-		reverse: false,
-		normal: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 725102,
+				tcgplayer: 509767,
+				cardtrader: 255582
+			}
+		},
+	],
 
 	suffix: "ex",
 	illustrator: "5ban Graphics",
 
-	thirdParty: {
-		cardmarket: 725102
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/023.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/023.ts
@@ -47,15 +47,28 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 725103,
+				tcgplayer: 509771,
+				cardtrader: 255583
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 725103,
+				tcgplayer: 509771,
+				cardtrader: 255583
+			}
+		},
+	],
 
 	illustrator: "Shin Nagasawa",
 
-	thirdParty: {
-		cardmarket: 725103
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/024.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/024.ts
@@ -47,15 +47,28 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 725104,
+				tcgplayer: 510900,
+				cardtrader: 255584
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 725104,
+				tcgplayer: 510900,
+				cardtrader: 255584
+			}
+		},
+	],
 
 	illustrator: "Pani Kobayashi",
 
-	thirdParty: {
-		cardmarket: 725104
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/025.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/025.ts
@@ -77,15 +77,28 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "G",
 
-	variants: {
-		normal: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 725105,
+				tcgplayer: 509776,
+				cardtrader: 255585
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 725105,
+				tcgplayer: 509776,
+				cardtrader: 255585
+			}
+		},
+	],
 
 	illustrator: "kodama",
 
-	thirdParty: {
-		cardmarket: 725105
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/026.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/026.ts
@@ -47,17 +47,34 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: true,
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 725106,
+				tcgplayer: 509703,
+				cardtrader: 255586
+			}
+		},
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 727116
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 725106,
+				tcgplayer: 509703,
+				cardtrader: 255586
+			}
+		},
+	],
 
 	illustrator: "DOM",
 
-	thirdParty: {
-		cardmarket: 725106
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/027.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/027.ts
@@ -55,17 +55,34 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "G",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: true,
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 727117,
+				tcgplayer: 509708,
+				cardtrader: 255587
+			}
+		},
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 725107
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 725107,
+				tcgplayer: 509708,
+				cardtrader: 255587
+			}
+		},
+	],
 
 	illustrator: "Ryota Murayama",
 
-	thirdParty: {
-		cardmarket: 725107
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/028.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/028.ts
@@ -60,15 +60,28 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 725108,
+				tcgplayer: 509717,
+				cardtrader: 255588
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 725108,
+				tcgplayer: 509717,
+				cardtrader: 255588
+			}
+		},
+	],
 
 	illustrator: "0313",
 
-	thirdParty: {
-		cardmarket: 725108
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/029.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/029.ts
@@ -66,15 +66,28 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 725109,
+				tcgplayer: 509724,
+				cardtrader: 255589
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 725109,
+				tcgplayer: 509724,
+				cardtrader: 255589
+			}
+		},
+	],
 
 	illustrator: "Yoshioka",
 
-	thirdParty: {
-		cardmarket: 725109
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/030.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/030.ts
@@ -69,15 +69,28 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "G",
 
-	variants: {
-		normal: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 725110,
+				tcgplayer: 509725,
+				cardtrader: 255590
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 725110,
+				tcgplayer: 509725,
+				cardtrader: 255590
+			}
+		},
+	],
 
 	illustrator: "toriyufu",
 
-	thirdParty: {
-		cardmarket: 725110
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/031.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/031.ts
@@ -47,15 +47,28 @@ const card: Card = {
 	retreat: 3,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 725111,
+				tcgplayer: 509726,
+				cardtrader: 255591
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 725111,
+				tcgplayer: 509726,
+				cardtrader: 255591
+			}
+		},
+	],
 
 	illustrator: "Mizue",
 
-	thirdParty: {
-		cardmarket: 725111
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/032.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/032.ts
@@ -68,15 +68,28 @@ const card: Card = {
 	retreat: 3,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 725112,
+				tcgplayer: 509728,
+				cardtrader: 255592
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 725112,
+				tcgplayer: 509728,
+				cardtrader: 255592
+			}
+		},
+	],
 
 	illustrator: "Shiburingaru",
 
-	thirdParty: {
-		cardmarket: 725112
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/033.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/033.ts
@@ -69,17 +69,21 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		reverse: false,
-		normal: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 725113,
+				tcgplayer: 509731,
+				cardtrader: 255593
+			}
+		},
+	],
 
 	suffix: "ex",
 	illustrator: "Saki Hayashiro",
 
-	thirdParty: {
-		cardmarket: 725113
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/034.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/034.ts
@@ -60,15 +60,28 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 725114,
+				tcgplayer: 509733,
+				cardtrader: 255594
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 725114,
+				tcgplayer: 509733,
+				cardtrader: 255594
+			}
+		},
+	],
 
 	illustrator: "Miki Tanaka",
 
-	thirdParty: {
-		cardmarket: 725114
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/035.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/035.ts
@@ -68,15 +68,28 @@ const card: Card = {
 	retreat: 3,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 725115,
+				tcgplayer: 509735,
+				cardtrader: 255595
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 725115,
+				tcgplayer: 509735,
+				cardtrader: 255595
+			}
+		},
+	],
 
 	illustrator: "Yuya Oka",
 
-	thirdParty: {
-		cardmarket: 725115
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/036.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/036.ts
@@ -47,15 +47,28 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 725116,
+				tcgplayer: 509737,
+				cardtrader: 255596
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 725116,
+				tcgplayer: 509737,
+				cardtrader: 255596
+			}
+		},
+	],
 
 	illustrator: "Nagomi Nijo",
 
-	thirdParty: {
-		cardmarket: 725116
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/037.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/037.ts
@@ -66,15 +66,28 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 725117,
+				tcgplayer: 509739,
+				cardtrader: 255597
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 725117,
+				tcgplayer: 509739,
+				cardtrader: 255597
+			}
+		},
+	],
 
 	illustrator: "Aya Kusube",
 
-	thirdParty: {
-		cardmarket: 725117
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/038.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/038.ts
@@ -68,15 +68,28 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 725118,
+				tcgplayer: 509742,
+				cardtrader: 255598
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 725118,
+				tcgplayer: 509742,
+				cardtrader: 255598
+			}
+		},
+	],
 
 	illustrator: "Haru Akasaka",
 
-	thirdParty: {
-		cardmarket: 725118
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/039.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/039.ts
@@ -47,15 +47,28 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 725119,
+				tcgplayer: 509744,
+				cardtrader: 255599
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 725119,
+				tcgplayer: 509744,
+				cardtrader: 255599
+			}
+		},
+	],
 
 	illustrator: "otumami",
 
-	thirdParty: {
-		cardmarket: 725119
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/040.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/040.ts
@@ -60,15 +60,28 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 725120,
+				tcgplayer: 509746,
+				cardtrader: 255600
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 725120,
+				tcgplayer: 509746,
+				cardtrader: 255600
+			}
+		},
+	],
 
 	illustrator: "Yuka Morii",
 
-	thirdParty: {
-		cardmarket: 725120
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/041.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/041.ts
@@ -68,15 +68,28 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 725121,
+				tcgplayer: 509747,
+				cardtrader: 255601
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 725121,
+				tcgplayer: 509747,
+				cardtrader: 255601
+			}
+		},
+	],
 
 	illustrator: "Yukiko Baba",
 
-	thirdParty: {
-		cardmarket: 725121
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/042.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/042.ts
@@ -47,17 +47,21 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "G",
 
-	variants: {
-		reverse: false,
-		normal: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 725122,
+				tcgplayer: 509753,
+				cardtrader: 255602
+			}
+		},
+	],
 
 	suffix: "ex",
 	illustrator: "5ban Graphics",
 
-	thirdParty: {
-		cardmarket: 725122
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/043.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/043.ts
@@ -51,15 +51,28 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 725123,
+				tcgplayer: 509755,
+				cardtrader: 255603
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 725123,
+				tcgplayer: 509755,
+				cardtrader: 255603
+			}
+		},
+	],
 
 	illustrator: "Saya Tsuruta",
 
-	thirdParty: {
-		cardmarket: 725123
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/044.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/044.ts
@@ -68,15 +68,28 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 725124,
+				tcgplayer: 509756,
+				cardtrader: 255604
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 725124,
+				tcgplayer: 509756,
+				cardtrader: 255604
+			}
+		},
+	],
 
 	illustrator: "Souichirou Gunjima",
 
-	thirdParty: {
-		cardmarket: 725124
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/045.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/045.ts
@@ -58,15 +58,28 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 725125,
+				tcgplayer: 509761,
+				cardtrader: 255605
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 725125,
+				tcgplayer: 509761,
+				cardtrader: 255605
+			}
+		},
+	],
 
 	illustrator: "matazo",
 
-	thirdParty: {
-		cardmarket: 725125
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/046.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/046.ts
@@ -38,15 +38,28 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 725126,
+				tcgplayer: 509763,
+				cardtrader: 255606
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 725126,
+				tcgplayer: 509763,
+				cardtrader: 255606
+			}
+		},
+	],
 
 	illustrator: "Jerky",
 
-	thirdParty: {
-		cardmarket: 725126
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/047.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/047.ts
@@ -68,15 +68,28 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 725127,
+				tcgplayer: 509770,
+				cardtrader: 255607
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 725127,
+				tcgplayer: 509770,
+				cardtrader: 255607
+			}
+		},
+	],
 
 	illustrator: "Tonji Matsuno",
 
-	thirdParty: {
-		cardmarket: 725127
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/048.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/048.ts
@@ -47,15 +47,28 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 725128,
+				tcgplayer: 509772,
+				cardtrader: 255608
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 725128,
+				tcgplayer: 509772,
+				cardtrader: 255608
+			}
+		},
+	],
 
 	illustrator: "Jerky",
 
-	thirdParty: {
-		cardmarket: 725128
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/049.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/049.ts
@@ -66,15 +66,28 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 725129,
+				tcgplayer: 509774,
+				cardtrader: 255609
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 725129,
+				tcgplayer: 509774,
+				cardtrader: 255609
+			}
+		},
+	],
 
 	illustrator: "Kouki Saitou",
 
-	thirdParty: {
-		cardmarket: 725129
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/050.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/050.ts
@@ -47,15 +47,28 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 725130,
+				tcgplayer: 509775,
+				cardtrader: 255610
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 725130,
+				tcgplayer: 509775,
+				cardtrader: 255610
+			}
+		},
+	],
 
 	illustrator: "OKUBO",
 
-	thirdParty: {
-		cardmarket: 725130
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/051.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/051.ts
@@ -46,15 +46,28 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 725131,
+				tcgplayer: 509794,
+				cardtrader: 255611
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 725131,
+				tcgplayer: 509794,
+				cardtrader: 255611
+			}
+		},
+	],
 
 	illustrator: "sowsow",
 
-	thirdParty: {
-		cardmarket: 725131
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/052.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/052.ts
@@ -77,15 +77,28 @@ const card: Card = {
 	retreat: 3,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 725132,
+				tcgplayer: 509796,
+				cardtrader: 255612
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 725132,
+				tcgplayer: 509796,
+				cardtrader: 255612
+			}
+		},
+	],
 
 	illustrator: "Misa Tsutsui",
 
-	thirdParty: {
-		cardmarket: 725132
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/053.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/053.ts
@@ -60,15 +60,28 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 725133,
+				tcgplayer: 509798,
+				cardtrader: 255613
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 725133,
+				tcgplayer: 509798,
+				cardtrader: 255613
+			}
+		},
+	],
 
 	illustrator: "Mizue",
 
-	thirdParty: {
-		cardmarket: 725133
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/054.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/054.ts
@@ -68,15 +68,28 @@ const card: Card = {
 	retreat: 3,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 725134,
+				tcgplayer: 509800,
+				cardtrader: 255614
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 725134,
+				tcgplayer: 509800,
+				cardtrader: 255614
+			}
+		},
+	],
 
 	illustrator: "Misa Tsutsui",
 
-	thirdParty: {
-		cardmarket: 725134
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/055.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/055.ts
@@ -47,15 +47,28 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 725135,
+				tcgplayer: 509802,
+				cardtrader: 255615
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 725135,
+				tcgplayer: 509802,
+				cardtrader: 255615
+			}
+		},
+	],
 
 	illustrator: "kirisAki",
 
-	thirdParty: {
-		cardmarket: 725135
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/056.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/056.ts
@@ -47,15 +47,35 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 781857,
+				tcgplayer: 509803,
+				cardtrader: 255616
+			}
+		},
+		{
+			type: 'holo',
+			foil: 'cosmos',
+			thirdParty: {
+				cardmarket: 725136
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 725136,
+				tcgplayer: 509803,
+				cardtrader: 255616
+			}
+		},
+	],
 
 	illustrator: "Atsuya Uki",
 
-	thirdParty: {
-		cardmarket: 725136
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/057.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/057.ts
@@ -55,15 +55,35 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 725137,
+				tcgplayer: 509805,
+				cardtrader: 255617
+			}
+		},
+		{
+			type: 'holo',
+			foil: 'cosmos',
+			thirdParty: {
+				cardmarket: 781858
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 725137,
+				tcgplayer: 509805,
+				cardtrader: 255617
+			}
+		},
+	],
 
 	illustrator: "Tonji Matsuno",
 
-	thirdParty: {
-		cardmarket: 725137
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/058.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/058.ts
@@ -38,15 +38,28 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 725138,
+				tcgplayer: 509807,
+				cardtrader: 255618
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 725138,
+				tcgplayer: 509807,
+				cardtrader: 255618
+			}
+		},
+	],
 
 	illustrator: "Pani Kobayashi",
 
-	thirdParty: {
-		cardmarket: 725138
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/059.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/059.ts
@@ -55,15 +55,28 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 725139,
+				tcgplayer: 509810,
+				cardtrader: 255619
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 725139,
+				tcgplayer: 509810,
+				cardtrader: 255619
+			}
+		},
+	],
 
 	illustrator: "Akira Komayama",
 
-	thirdParty: {
-		cardmarket: 725139
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/060.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/060.ts
@@ -58,15 +58,28 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 725140,
+				tcgplayer: 509812,
+				cardtrader: 255620
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 725140,
+				tcgplayer: 509812,
+				cardtrader: 255620
+			}
+		},
+	],
 
 	illustrator: "kodama",
 
-	thirdParty: {
-		cardmarket: 725140
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/061.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/061.ts
@@ -38,15 +38,28 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 725141,
+				tcgplayer: 509816,
+				cardtrader: 255621
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 725141,
+				tcgplayer: 509816,
+				cardtrader: 255621
+			}
+		},
+	],
 
 	illustrator: "Kouki Saitou",
 
-	thirdParty: {
-		cardmarket: 725141
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/062.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/062.ts
@@ -77,17 +77,34 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "G",
 
-	variants: {
-		normal: true,
-		holo: true,
-		reverse: true,
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 785704
+			}
+		},
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 725142,
+				tcgplayer: 509819,
+				cardtrader: 255622
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 725142,
+				tcgplayer: 509819,
+				cardtrader: 255622
+			}
+		},
+	],
 
 	illustrator: "Souichirou Gunjima",
 
-	thirdParty: {
-		cardmarket: 725142
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/063.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/063.ts
@@ -51,15 +51,28 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 725143,
+				tcgplayer: 509823,
+				cardtrader: 255623
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 725143,
+				tcgplayer: 509823,
+				cardtrader: 255623
+			}
+		},
+	],
 
 	illustrator: "Masakazu Fukuda",
 
-	thirdParty: {
-		cardmarket: 725143
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/064.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/064.ts
@@ -59,15 +59,28 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 725144,
+				tcgplayer: 509826,
+				cardtrader: 255624
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 725144,
+				tcgplayer: 509826,
+				cardtrader: 255624
+			}
+		},
+	],
 
 	illustrator: "kurumitsu",
 
-	thirdParty: {
-		cardmarket: 725144
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/065.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/065.ts
@@ -77,15 +77,28 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 725145,
+				tcgplayer: 509829,
+				cardtrader: 255625
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 725145,
+				tcgplayer: 509829,
+				cardtrader: 255625
+			}
+		},
+	],
 
 	illustrator: "Anesaki Dynamic",
 
-	thirdParty: {
-		cardmarket: 725145
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/066.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/066.ts
@@ -77,17 +77,21 @@ const card: Card = {
 	retreat: 4,
 	regulationMark: "G",
 
-	variants: {
-		reverse: false,
-		normal: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 725146,
+				tcgplayer: 509831,
+				cardtrader: 255626
+			}
+		},
+	],
 
 	suffix: "ex",
 	illustrator: "5ban Graphics",
 
-	thirdParty: {
-		cardmarket: 725146
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/067.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/067.ts
@@ -51,15 +51,28 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 725147,
+				tcgplayer: 509832,
+				cardtrader: 255627
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 725147,
+				tcgplayer: 509832,
+				cardtrader: 255627
+			}
+		},
+	],
 
 	illustrator: "Kagemaru Himeno",
 
-	thirdParty: {
-		cardmarket: 725147
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/068.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/068.ts
@@ -68,15 +68,28 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 725148,
+				tcgplayer: 509834,
+				cardtrader: 255628
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 725148,
+				tcgplayer: 509834,
+				cardtrader: 255628
+			}
+		},
+	],
 
 	illustrator: "Souichirou Gunjima",
 
-	thirdParty: {
-		cardmarket: 725148
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/069.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/069.ts
@@ -66,15 +66,28 @@ const card: Card = {
 	retreat: 3,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 725149,
+				tcgplayer: 509835,
+				cardtrader: 255629
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 725149,
+				tcgplayer: 509835,
+				cardtrader: 255629
+			}
+		},
+	],
 
 	illustrator: "Masakazu Fukuda",
 
-	thirdParty: {
-		cardmarket: 725149
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/070.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/070.ts
@@ -69,15 +69,28 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "G",
 
-	variants: {
-		normal: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 725150,
+				tcgplayer: 509837,
+				cardtrader: 255630
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 725150,
+				tcgplayer: 509837,
+				cardtrader: 255630
+			}
+		},
+	],
 
 	illustrator: "GOSSAN",
 
-	thirdParty: {
-		cardmarket: 725150
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/071.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/071.ts
@@ -47,15 +47,28 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 725151,
+				tcgplayer: 509841,
+				cardtrader: 255631
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 725151,
+				tcgplayer: 509841,
+				cardtrader: 255631
+			}
+		},
+	],
 
 	illustrator: "AKIRA EGAWA",
 
-	thirdParty: {
-		cardmarket: 725151
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/072.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/072.ts
@@ -75,17 +75,28 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "G",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: true,
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 725152,
+				tcgplayer: 509844,
+				cardtrader: 255632
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 725152,
+				tcgplayer: 509844,
+				cardtrader: 255632
+			}
+		},
+	],
 
 	illustrator: "Anesaki Dynamic",
 
-	thirdParty: {
-		cardmarket: 725152
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/073.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/073.ts
@@ -66,17 +66,21 @@ const card: Card = {
 	retreat: 0,
 	regulationMark: "G",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 725153,
+				tcgplayer: 509846,
+				cardtrader: 255633
+			}
+		},
+	],
 
 	suffix: "ex",
 	illustrator: "aky CG Works",
 
-	thirdParty: {
-		cardmarket: 725153
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/074.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/074.ts
@@ -58,15 +58,28 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 725154,
+				tcgplayer: 509850,
+				cardtrader: 255634
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 725154,
+				tcgplayer: 509850,
+				cardtrader: 255634
+			}
+		},
+	],
 
 	illustrator: "kirisAki",
 
-	thirdParty: {
-		cardmarket: 725154
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/075.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/075.ts
@@ -47,15 +47,28 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 725155,
+				tcgplayer: 509851,
+				cardtrader: 255635
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 725155,
+				tcgplayer: 509851,
+				cardtrader: 255635
+			}
+		},
+	],
 
 	illustrator: "Saya Tsuruta",
 
-	thirdParty: {
-		cardmarket: 725155
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/076.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/076.ts
@@ -47,15 +47,28 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 725156,
+				tcgplayer: 509853,
+				cardtrader: 255636
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 725156,
+				tcgplayer: 509853,
+				cardtrader: 255636
+			}
+		},
+	],
 
 	illustrator: "Shin Nagasawa",
 
-	thirdParty: {
-		cardmarket: 725156
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/077.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/077.ts
@@ -55,15 +55,28 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 725157,
+				tcgplayer: 509858,
+				cardtrader: 255637
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 725157,
+				tcgplayer: 509858,
+				cardtrader: 255637
+			}
+		},
+	],
 
 	illustrator: "Kouki Saitou",
 
-	thirdParty: {
-		cardmarket: 725157
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/078.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/078.ts
@@ -77,15 +77,28 @@ const card: Card = {
 	retreat: 3,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 725158,
+				tcgplayer: 509862,
+				cardtrader: 255638
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 725158,
+				tcgplayer: 509862,
+				cardtrader: 255638
+			}
+		},
+	],
 
 	illustrator: "Toshinao Aoki",
 
-	thirdParty: {
-		cardmarket: 725158
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/079.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/079.ts
@@ -69,17 +69,21 @@ const card: Card = {
 	retreat: 0,
 	regulationMark: "G",
 
-	variants: {
-		reverse: false,
-		normal: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 725159,
+				tcgplayer: 509864,
+				cardtrader: 255639
+			}
+		},
+	],
 
 	suffix: "ex",
 	illustrator: "5ban Graphics",
 
-	thirdParty: {
-		cardmarket: 725159
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/080.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/080.ts
@@ -43,15 +43,28 @@ const card: Card = {
 	retreat: 0,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 725160,
+				tcgplayer: 509809,
+				cardtrader: 255765
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 725160,
+				tcgplayer: 509809,
+				cardtrader: 255765
+			}
+		},
+	],
 
 	illustrator: "kurumitsu",
 
-	thirdParty: {
-		cardmarket: 725160
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/081.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/081.ts
@@ -47,15 +47,28 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 725161,
+				tcgplayer: 509811,
+				cardtrader: 255766
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 725161,
+				tcgplayer: 509811,
+				cardtrader: 255766
+			}
+		},
+	],
 
 	illustrator: "Yuka Morii",
 
-	thirdParty: {
-		cardmarket: 725161
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/082.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/082.ts
@@ -77,17 +77,21 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "G",
 
-	variants: {
-		reverse: false,
-		normal: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 725162,
+				tcgplayer: 509821,
+				cardtrader: 255767
+			}
+		},
+	],
 
 	suffix: "ex",
 	illustrator: "Satoshi Shirai",
 
-	thirdParty: {
-		cardmarket: 725162
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/083.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/083.ts
@@ -58,15 +58,28 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 725163,
+				tcgplayer: 509825,
+				cardtrader: 255768
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 725163,
+				tcgplayer: 509825,
+				cardtrader: 255768
+			}
+		},
+	],
 
 	illustrator: "Natsumi Yoshida",
 
-	thirdParty: {
-		cardmarket: 725163
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/084.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/084.ts
@@ -66,15 +66,28 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 725164,
+				tcgplayer: 509833,
+				cardtrader: 255769
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 725164,
+				tcgplayer: 509833,
+				cardtrader: 255769
+			}
+		},
+	],
 
 	illustrator: "Kyoko Umemoto",
 
-	thirdParty: {
-		cardmarket: 725164
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/085.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/085.ts
@@ -77,15 +77,42 @@ const card: Card = {
 	retreat: 0,
 	regulationMark: "G",
 
-	variants: {
-		normal: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 725165,
+				tcgplayer: 509840,
+				cardtrader: 255770
+			}
+		},
+		{
+			type: 'holo',
+			foil: 'cosmos',
+			thirdParty: {
+				cardmarket: 785705
+			}
+		},
+		{
+			type: 'holo',
+			stamp: ['pre-release'],
+			thirdParty: {
+				cardmarket: 727120
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 725165,
+				tcgplayer: 509840,
+				cardtrader: 255770
+			}
+		},
+	],
 
 	illustrator: "Cona Nitanda",
 
-	thirdParty: {
-		cardmarket: 725165
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/086.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/086.ts
@@ -77,15 +77,42 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 725166,
+				tcgplayer: 509848,
+				cardtrader: 255771
+			}
+		},
+		{
+			type: 'holo',
+			stamp: ['set-logo'],
+			thirdParty: {
+				cardmarket: 727069
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 725166,
+				tcgplayer: 509848,
+				cardtrader: 255771
+			}
+		},
+		{
+			type: 'reverse',
+			stamp: ['set-logo'],
+			thirdParty: {
+				cardmarket: 804328
+			}
+		},
+	],
 
 	illustrator: "Cona Nitanda",
 
-	thirdParty: {
-		cardmarket: 725166
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/087.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/087.ts
@@ -60,15 +60,28 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 725167,
+				tcgplayer: 509854,
+				cardtrader: 255772
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 725167,
+				tcgplayer: 509854,
+				cardtrader: 255772
+			}
+		},
+	],
 
 	illustrator: "Sekio",
 
-	thirdParty: {
-		cardmarket: 725167
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/088.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/088.ts
@@ -68,15 +68,28 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 725168,
+				tcgplayer: 509860,
+				cardtrader: 255773
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 725168,
+				tcgplayer: 509860,
+				cardtrader: 255773
+			}
+		},
+	],
 
 	illustrator: "Lee HyunJung",
 
-	thirdParty: {
-		cardmarket: 725168
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/089.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/089.ts
@@ -47,15 +47,28 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 725169,
+				tcgplayer: 511758,
+				cardtrader: 255774
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 725169,
+				tcgplayer: 511758,
+				cardtrader: 255774
+			}
+		},
+	],
 
 	illustrator: "0313",
 
-	thirdParty: {
-		cardmarket: 725169
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/090.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/090.ts
@@ -51,15 +51,28 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 725170,
+				tcgplayer: 509863,
+				cardtrader: 255775
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 725170,
+				tcgplayer: 509863,
+				cardtrader: 255775
+			}
+		},
+	],
 
 	illustrator: "GOSSAN",
 
-	thirdParty: {
-		cardmarket: 725170
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/091.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/091.ts
@@ -66,15 +66,28 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 725171,
+				tcgplayer: 509867,
+				cardtrader: 255776
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 725171,
+				tcgplayer: 509867,
+				cardtrader: 255776
+			}
+		},
+	],
 
 	illustrator: "Scav",
 
-	thirdParty: {
-		cardmarket: 725171
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/092.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/092.ts
@@ -60,15 +60,28 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 725172,
+				tcgplayer: 509871,
+				cardtrader: 255777
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 725172,
+				tcgplayer: 509871,
+				cardtrader: 255777
+			}
+		},
+	],
 
 	illustrator: "Tetsu Kayama",
 
-	thirdParty: {
-		cardmarket: 725172
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/093.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/093.ts
@@ -58,15 +58,28 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 725173,
+				tcgplayer: 509872,
+				cardtrader: 255778
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 725173,
+				tcgplayer: 509872,
+				cardtrader: 255778
+			}
+		},
+	],
 
 	illustrator: "Tetsu Kayama",
 
-	thirdParty: {
-		cardmarket: 725173
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/094.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/094.ts
@@ -47,15 +47,28 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 725174,
+				tcgplayer: 509876,
+				cardtrader: 255779
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 725174,
+				tcgplayer: 509876,
+				cardtrader: 255779
+			}
+		},
+	],
 
 	illustrator: "Scav",
 
-	thirdParty: {
-		cardmarket: 725174
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/095.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/095.ts
@@ -75,15 +75,28 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "G",
 
-	variants: {
-		normal: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 725175,
+				tcgplayer: 509924,
+				cardtrader: 255780
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 725175,
+				tcgplayer: 509924,
+				cardtrader: 255780
+			}
+		},
+	],
 
 	illustrator: "Shigenori Negishi",
 
-	thirdParty: {
-		cardmarket: 725175
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/096.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/096.ts
@@ -75,17 +75,21 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "G",
 
-	variants: {
-		reverse: false,
-		normal: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 725176,
+				tcgplayer: 509926,
+				cardtrader: 255781
+			}
+		},
+	],
 
 	suffix: "ex",
 	illustrator: "5ban Graphics",
 
-	thirdParty: {
-		cardmarket: 725176
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/097.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/097.ts
@@ -47,15 +47,28 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 725177,
+				tcgplayer: 509930,
+				cardtrader: 255782
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 725177,
+				tcgplayer: 509930,
+				cardtrader: 255782
+			}
+		},
+	],
 
 	illustrator: "Yuka Morii",
 
-	thirdParty: {
-		cardmarket: 725177
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/098.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/098.ts
@@ -73,15 +73,28 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 725178,
+				tcgplayer: 509931,
+				cardtrader: 255783
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 725178,
+				tcgplayer: 509931,
+				cardtrader: 255783
+			}
+		},
+	],
 
 	illustrator: "Megumi Mizutani",
 
-	thirdParty: {
-		cardmarket: 725178
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/099.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/099.ts
@@ -51,15 +51,28 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 725179,
+				tcgplayer: 509933,
+				cardtrader: 255784
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 725179,
+				tcgplayer: 509933,
+				cardtrader: 255784
+			}
+		},
+	],
 
 	illustrator: "Shibuzoh.",
 
-	thirdParty: {
-		cardmarket: 725179
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/100.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/100.ts
@@ -47,17 +47,35 @@ const card: Card = {
 	retreat: 3,
 	regulationMark: "G",
 
-	variants: {
-		normal: true,
-		holo: true,
-		reverse: true
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 725180,
+				tcgplayer: 509947,
+				cardtrader: 255785
+			}
+		},
+		{
+			type: 'holo',
+			foil: 'cosmos',
+			thirdParty: {
+				cardmarket: 791826
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 725180,
+				tcgplayer: 509947,
+				cardtrader: 255785
+			}
+		},
+	],
 
 	illustrator: "Pani Kobayashi",
 
-	thirdParty: {
-		cardmarket: 791826
-	}
+	
 };
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/101.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/101.ts
@@ -68,15 +68,28 @@ const card: Card = {
 	retreat: 3,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 725181,
+				tcgplayer: 509953,
+				cardtrader: 255786
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 725181,
+				tcgplayer: 509953,
+				cardtrader: 255786
+			}
+		},
+	],
 
 	illustrator: "Saya Tsuruta",
 
-	thirdParty: {
-		cardmarket: 725181
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/102.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/102.ts
@@ -77,17 +77,21 @@ const card: Card = {
 	retreat: 3,
 	regulationMark: "G",
 
-	variants: {
-		reverse: false,
-		normal: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 725182,
+				tcgplayer: 509958,
+				cardtrader: 255787
+			}
+		},
+	],
 
 	suffix: "ex",
 	illustrator: "5ban Graphics",
 
-	thirdParty: {
-		cardmarket: 725182
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/103.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/103.ts
@@ -47,15 +47,28 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 725183,
+				tcgplayer: 509790,
+				cardtrader: 255788
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 725183,
+				tcgplayer: 509790,
+				cardtrader: 255788
+			}
+		},
+	],
 
 	illustrator: "OKACHEKE",
 
-	thirdParty: {
-		cardmarket: 725183
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/104.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/104.ts
@@ -55,15 +55,28 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 725184,
+				tcgplayer: 509791,
+				cardtrader: 255789
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 725184,
+				tcgplayer: 509791,
+				cardtrader: 255789
+			}
+		},
+	],
 
 	illustrator: "Nelnal",
 
-	thirdParty: {
-		cardmarket: 725184
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/105.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/105.ts
@@ -51,15 +51,28 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 725185,
+				tcgplayer: 509792,
+				cardtrader: 255790
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 725185,
+				tcgplayer: 509792,
+				cardtrader: 255790
+			}
+		},
+	],
 
 	illustrator: "KYUPIYAMA",
 
-	thirdParty: {
-		cardmarket: 725185
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/106.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/106.ts
@@ -68,15 +68,35 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 786050,
+				tcgplayer: 509793,
+				cardtrader: 255791
+			}
+		},
+		{
+			type: 'holo',
+			foil: 'cosmos',
+			thirdParty: {
+				cardmarket: 725186
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 725186,
+				tcgplayer: 509793,
+				cardtrader: 255791
+			}
+		},
+	],
 
 	illustrator: "Souichirou Gunjima",
 
-	thirdParty: {
-		cardmarket: 725186
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/107.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/107.ts
@@ -58,15 +58,28 @@ const card: Card = {
 	retreat: 3,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 725187,
+				tcgplayer: 509795,
+				cardtrader: 255792
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 725187,
+				tcgplayer: 509795,
+				cardtrader: 255792
+			}
+		},
+	],
 
 	illustrator: "Nobuhiro Imagawa",
 
-	thirdParty: {
-		cardmarket: 725187
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/108.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/108.ts
@@ -58,15 +58,28 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 725188,
+				tcgplayer: 509797,
+				cardtrader: 255793
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 725188,
+				tcgplayer: 509797,
+				cardtrader: 255793
+			}
+		},
+	],
 
 	illustrator: "Scav",
 
-	thirdParty: {
-		cardmarket: 725188
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/109.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/109.ts
@@ -66,15 +66,28 @@ const card: Card = {
 	retreat: 3,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 725189,
+				tcgplayer: 509801,
+				cardtrader: 255794
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 725189,
+				tcgplayer: 509801,
+				cardtrader: 255794
+			}
+		},
+	],
 
 	illustrator: "0313",
 
-	thirdParty: {
-		cardmarket: 725189
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/110.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/110.ts
@@ -45,15 +45,28 @@ const card: Card = {
 	retreat: 0,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 725190,
+				tcgplayer: 509804,
+				cardtrader: 255795
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 725190,
+				tcgplayer: 509804,
+				cardtrader: 255795
+			}
+		},
+	],
 
 	illustrator: "Mizue",
 
-	thirdParty: {
-		cardmarket: 725190
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/111.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/111.ts
@@ -47,15 +47,28 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 725191,
+				tcgplayer: 509808,
+				cardtrader: 255796
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 725191,
+				tcgplayer: 509808,
+				cardtrader: 255796
+			}
+		},
+	],
 
 	illustrator: "sowsow",
 
-	thirdParty: {
-		cardmarket: 725191
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/112.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/112.ts
@@ -69,15 +69,28 @@ const card: Card = {
 	retreat: 3,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 725192,
+				tcgplayer: 509814,
+				cardtrader: 255797
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 725192,
+				tcgplayer: 509814,
+				cardtrader: 255797
+			}
+		},
+	],
 
 	illustrator: "Sumiyoshi Kizuki",
 
-	thirdParty: {
-		cardmarket: 725192
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/113.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/113.ts
@@ -68,15 +68,28 @@ const card: Card = {
 	retreat: 4,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 725193,
+				tcgplayer: 509836,
+				cardtrader: 255798
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 725193,
+				tcgplayer: 509836,
+				cardtrader: 255798
+			}
+		},
+	],
 
 	illustrator: "SATOSHI NAKAI",
 
-	thirdParty: {
-		cardmarket: 725193
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/114.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/114.ts
@@ -51,15 +51,28 @@ const card: Card = {
 	retreat: 3,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 725194,
+				tcgplayer: 509839,
+				cardtrader: 255799
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 725194,
+				tcgplayer: 509839,
+				cardtrader: 255799
+			}
+		},
+	],
 
 	illustrator: "Nagomi Nijo",
 
-	thirdParty: {
-		cardmarket: 725194
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/115.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/115.ts
@@ -68,15 +68,28 @@ const card: Card = {
 	retreat: 4,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 725195,
+				tcgplayer: 509842,
+				cardtrader: 255800
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 725195,
+				tcgplayer: 509842,
+				cardtrader: 255800
+			}
+		},
+	],
 
 	illustrator: "Misa Tsutsui",
 
-	thirdParty: {
-		cardmarket: 725195
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/116.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/116.ts
@@ -38,15 +38,28 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 725196,
+				tcgplayer: 509856,
+				cardtrader: 255801
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 725196,
+				tcgplayer: 509856,
+				cardtrader: 255801
+			}
+		},
+	],
 
 	illustrator: "Jerky",
 
-	thirdParty: {
-		cardmarket: 725196
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/117.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/117.ts
@@ -68,15 +68,28 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 725197,
+				tcgplayer: 509865,
+				cardtrader: 255802
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 725197,
+				tcgplayer: 509865,
+				cardtrader: 255802
+			}
+		},
+	],
 
 	illustrator: "Mitsuhiro Arita",
 
-	thirdParty: {
-		cardmarket: 725197
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/118.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/118.ts
@@ -51,15 +51,28 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 725198,
+				tcgplayer: 509866,
+				cardtrader: 255803
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 725198,
+				tcgplayer: 509866,
+				cardtrader: 255803
+			}
+		},
+	],
 
 	illustrator: "Oswaldo KATO",
 
-	thirdParty: {
-		cardmarket: 725198
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/119.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/119.ts
@@ -68,15 +68,28 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 725199,
+				tcgplayer: 509868,
+				cardtrader: 255804
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 725199,
+				tcgplayer: 509868,
+				cardtrader: 255804
+			}
+		},
+	],
 
 	illustrator: "Kouki Saitou",
 
-	thirdParty: {
-		cardmarket: 725199
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/120.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/120.ts
@@ -69,17 +69,21 @@ const card: Card = {
 	retreat: 3,
 	regulationMark: "G",
 
-	variants: {
-		reverse: false,
-		normal: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 725200,
+				tcgplayer: 509869,
+				cardtrader: 255805
+			}
+		},
+	],
 
 	suffix: "ex",
 	illustrator: "aky CG Works",
 
-	thirdParty: {
-		cardmarket: 725200
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/121.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/121.ts
@@ -58,15 +58,28 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 725201,
+				tcgplayer: 509873,
+				cardtrader: 255806
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 725201,
+				tcgplayer: 509873,
+				cardtrader: 255806
+			}
+		},
+	],
 
 	illustrator: "Sanosuke Sakuma",
 
-	thirdParty: {
-		cardmarket: 725201
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/122.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/122.ts
@@ -47,15 +47,28 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 725202,
+				tcgplayer: 509875,
+				cardtrader: 255807
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 725202,
+				tcgplayer: 509875,
+				cardtrader: 255807
+			}
+		},
+	],
 
 	illustrator: "GIDORA",
 
-	thirdParty: {
-		cardmarket: 725202
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/123.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/123.ts
@@ -77,17 +77,21 @@ const card: Card = {
 	retreat: 3,
 	regulationMark: "G",
 
-	variants: {
-		reverse: false,
-		normal: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 725203,
+				tcgplayer: 509877,
+				cardtrader: 255808
+			}
+		},
+	],
 
 	suffix: "ex",
 	illustrator: "5ban Graphics",
 
-	thirdParty: {
-		cardmarket: 725203
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/124.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/124.ts
@@ -69,17 +69,21 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "G",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 725204,
+				tcgplayer: 509878,
+				cardtrader: 255809
+			}
+		},
+	],
 
 	suffix: "ex",
 	illustrator: "aky CG Works",
 
-	thirdParty: {
-		cardmarket: 725204
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/125.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/125.ts
@@ -77,17 +77,21 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "G",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 725205,
+				tcgplayer: 509879,
+				cardtrader: 255810
+			}
+		},
+	],
 
 	suffix: "ex",
 	illustrator: "5ban Graphics",
 
-	thirdParty: {
-		cardmarket: 725205
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/126.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/126.ts
@@ -45,15 +45,28 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 725206,
+				tcgplayer: 509880,
+				cardtrader: 255811
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 725206,
+				tcgplayer: 509880,
+				cardtrader: 255811
+			}
+		},
+	],
 
 	illustrator: "Shibuzoh.",
 
-	thirdParty: {
-		cardmarket: 725206
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/127.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/127.ts
@@ -38,15 +38,28 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 725207,
+				tcgplayer: 509883,
+				cardtrader: 255812
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 725207,
+				tcgplayer: 509883,
+				cardtrader: 255812
+			}
+		},
+	],
 
 	illustrator: "Pani Kobayashi",
 
-	thirdParty: {
-		cardmarket: 725207
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/128.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/128.ts
@@ -77,15 +77,28 @@ const card: Card = {
 	retreat: 3,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 725208,
+				tcgplayer: 509884,
+				cardtrader: 255813
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 725208,
+				tcgplayer: 509884,
+				cardtrader: 255813
+			}
+		},
+	],
 
 	illustrator: "Kouki Saitou",
 
-	thirdParty: {
-		cardmarket: 725208
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/129.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/129.ts
@@ -75,15 +75,28 @@ const card: Card = {
 	retreat: 3,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 725209,
+				tcgplayer: 509887,
+				cardtrader: 255814
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 725209,
+				tcgplayer: 509887,
+				cardtrader: 255814
+			}
+		},
+	],
 
 	illustrator: "Shin Nagasawa",
 
-	thirdParty: {
-		cardmarket: 725209
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/130.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/130.ts
@@ -75,15 +75,49 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 725210,
+				tcgplayer: 509888,
+				cardtrader: 255815
+			}
+		},
+		{
+			type: 'normal',
+			stamp: ['eb-games'],
+			thirdParty: {
+				cardmarket: 727071
+			}
+		},
+		{
+			type: 'normal',
+			stamp: ['gamestop'],
+			thirdParty: {
+				cardmarket: 727070
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 725210,
+				tcgplayer: 509888,
+				cardtrader: 255815
+			}
+		},
+		{
+			type: 'reverse',
+			stamp: ['set-logo'],
+			thirdParty: {
+				cardmarket: 742043
+			}
+		},
+	],
 
 	illustrator: "rika",
 
-	thirdParty: {
-		cardmarket: 725210
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/131.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/131.ts
@@ -67,15 +67,28 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 725211,
+				tcgplayer: 509890,
+				cardtrader: 255816
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 725211,
+				tcgplayer: 509890,
+				cardtrader: 255816
+			}
+		},
+	],
 
 	illustrator: "Scav",
 
-	thirdParty: {
-		cardmarket: 725211
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/132.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/132.ts
@@ -51,15 +51,28 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 725212,
+				tcgplayer: 509891,
+				cardtrader: 255817
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 725212,
+				tcgplayer: 509891,
+				cardtrader: 255817
+			}
+		},
+	],
 
 	illustrator: "Kurata So",
 
-	thirdParty: {
-		cardmarket: 725212
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/133.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/133.ts
@@ -77,15 +77,28 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 725213,
+				tcgplayer: 509893,
+				cardtrader: 255818
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 725213,
+				tcgplayer: 509893,
+				cardtrader: 255818
+			}
+		},
+	],
 
 	illustrator: "Haru Akasaka",
 
-	thirdParty: {
-		cardmarket: 725213
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/134.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/134.ts
@@ -77,17 +77,21 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "G",
 
-	variants: {
-		reverse: false,
-		normal: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 725214,
+				tcgplayer: 509894,
+				cardtrader: 255819
+			}
+		},
+	],
 
 	suffix: "ex",
 	illustrator: "PLANETA Tsuji",
 
-	thirdParty: {
-		cardmarket: 725214
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/135.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/135.ts
@@ -67,17 +67,21 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 725215,
+				tcgplayer: 509898,
+				cardtrader: 255820
+			}
+		},
+	],
 
 	suffix: "ex",
 	illustrator: "Nisota Niso",
 
-	thirdParty: {
-		cardmarket: 725215
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/136.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/136.ts
@@ -69,15 +69,35 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "G",
 
-	variants: {
-		normal: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 725216,
+				tcgplayer: 509900,
+				cardtrader: 255821
+			}
+		},
+		{
+			type: 'holo',
+			foil: 'galaxy',
+			thirdParty: {
+				cardmarket: 858721
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 725216,
+				tcgplayer: 509900,
+				cardtrader: 255821
+			}
+		},
+	],
 
 	illustrator: "Bun Toujo",
 
-	thirdParty: {
-		cardmarket: 725216
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/137.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/137.ts
@@ -47,15 +47,28 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 725217,
+				tcgplayer: 509901,
+				cardtrader: 255822
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 725217,
+				tcgplayer: 509901,
+				cardtrader: 255822
+			}
+		},
+	],
 
 	illustrator: "Kedamahadaitai Yawarakai",
 
-	thirdParty: {
-		cardmarket: 725217
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/138.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/138.ts
@@ -77,15 +77,28 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 725218,
+				tcgplayer: 509909,
+				cardtrader: 255823
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 725218,
+				tcgplayer: 509909,
+				cardtrader: 255823
+			}
+		},
+	],
 
 	illustrator: "Nelnal",
 
-	thirdParty: {
-		cardmarket: 725218
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/139.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/139.ts
@@ -51,15 +51,28 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 725219,
+				tcgplayer: 509911,
+				cardtrader: 255824
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 725219,
+				tcgplayer: 509911,
+				cardtrader: 255824
+			}
+		},
+	],
 
 	illustrator: "Shiburingaru",
 
-	thirdParty: {
-		cardmarket: 725219
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/140.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/140.ts
@@ -59,15 +59,28 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 725220,
+				tcgplayer: 509912,
+				cardtrader: 255825
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 725220,
+				tcgplayer: 509912,
+				cardtrader: 255825
+			}
+		},
+	],
 
 	illustrator: "Shigenori Negishi",
 
-	thirdParty: {
-		cardmarket: 725220
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/141.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/141.ts
@@ -68,15 +68,35 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "G",
 
-	variants: {
-		normal: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 725221,
+				tcgplayer: 509919,
+				cardtrader: 255826
+			}
+		},
+		{
+			type: 'holo',
+			foil: 'galaxy',
+			thirdParty: {
+				cardmarket: 858722
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 725221,
+				tcgplayer: 509919,
+				cardtrader: 255826
+			}
+		},
+	],
 
 	illustrator: "otumami",
 
-	thirdParty: {
-		cardmarket: 725221
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/142.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/142.ts
@@ -60,15 +60,28 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 725222,
+				tcgplayer: 509920,
+				cardtrader: 255827
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 725222,
+				tcgplayer: 509920,
+				cardtrader: 255827
+			}
+		},
+	],
 
 	illustrator: "Takeshi Nakamura",
 
-	thirdParty: {
-		cardmarket: 725222
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/143.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/143.ts
@@ -60,15 +60,28 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 725223,
+				tcgplayer: 509922,
+				cardtrader: 255828
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 725223,
+				tcgplayer: 509922,
+				cardtrader: 255828
+			}
+		},
+	],
 
 	illustrator: "sowsow",
 
-	thirdParty: {
-		cardmarket: 725223
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/144.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/144.ts
@@ -58,15 +58,28 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 725224,
+				tcgplayer: 509928,
+				cardtrader: 255829
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 725224,
+				tcgplayer: 509928,
+				cardtrader: 255829
+			}
+		},
+	],
 
 	illustrator: "Shinji Kanda",
 
-	thirdParty: {
-		cardmarket: 725224
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/145.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/145.ts
@@ -77,15 +77,28 @@ const card: Card = {
 	retreat: 3,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 725225,
+				tcgplayer: 509929,
+				cardtrader: 255830
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 725225,
+				tcgplayer: 509929,
+				cardtrader: 255830
+			}
+		},
+	],
 
 	illustrator: "Nobuhiro Imagawa",
 
-	thirdParty: {
-		cardmarket: 725225
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/146.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/146.ts
@@ -77,15 +77,28 @@ const card: Card = {
 	retreat: 4,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 725226,
+				tcgplayer: 509932,
+				cardtrader: 255831
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 725226,
+				tcgplayer: 509932,
+				cardtrader: 255831
+			}
+		},
+	],
 
 	illustrator: "takuyoa",
 
-	thirdParty: {
-		cardmarket: 725226
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/147.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/147.ts
@@ -46,15 +46,28 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 725227,
+				tcgplayer: 509934,
+				cardtrader: 255832
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 725227,
+				tcgplayer: 509934,
+				cardtrader: 255832
+			}
+		},
+	],
 
 	illustrator: "kawayoo",
 
-	thirdParty: {
-		cardmarket: 725227
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/148.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/148.ts
@@ -47,17 +47,35 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: true,
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 725228,
+				tcgplayer: 509935,
+				cardtrader: 255833
+			}
+		},
+		{
+			type: 'normal',
+			foil: 'cosmos',
+			thirdParty: {
+				cardmarket: 781859
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 725228,
+				tcgplayer: 509935,
+				cardtrader: 255833
+			}
+		},
+	],
 
 	illustrator: "Hitoshi Ariga",
 
-	thirdParty: {
-		cardmarket: 781859
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/149.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/149.ts
@@ -68,17 +68,35 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "G",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: true,
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 781860,
+				tcgplayer: 509936,
+				cardtrader: 255834
+			}
+		},
+		{
+			type: 'holo',
+			foil: 'cosmos',
+			thirdParty: {
+				cardmarket: 725229
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 725229,
+				tcgplayer: 509936,
+				cardtrader: 255834
+			}
+		},
+	],
 
 	illustrator: "GIDORA",
 
-	thirdParty: {
-		cardmarket: 781860
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/150.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/150.ts
@@ -66,15 +66,28 @@ const card: Card = {
 	retreat: 4,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 725230,
+				tcgplayer: 509937,
+				cardtrader: 255835
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 725230,
+				tcgplayer: 509937,
+				cardtrader: 255835
+			}
+		},
+	],
 
 	illustrator: "Ryota Murayama",
 
-	thirdParty: {
-		cardmarket: 725230
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/151.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/151.ts
@@ -58,15 +58,28 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 725231,
+				tcgplayer: 509938,
+				cardtrader: 255836
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 725231,
+				tcgplayer: 509938,
+				cardtrader: 255836
+			}
+		},
+	],
 
 	illustrator: "Sekio",
 
-	thirdParty: {
-		cardmarket: 725231
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/152.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/152.ts
@@ -38,15 +38,28 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 725232,
+				tcgplayer: 509939,
+				cardtrader: 255837
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 725232,
+				tcgplayer: 509939,
+				cardtrader: 255837
+			}
+		},
+	],
 
 	illustrator: "Nobuhiro Imagawa",
 
-	thirdParty: {
-		cardmarket: 725232
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/153.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/153.ts
@@ -75,17 +75,21 @@ const card: Card = {
 	retreat: 4,
 	regulationMark: "G",
 
-	variants: {
-		reverse: false,
-		normal: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 725233,
+				tcgplayer: 509940,
+				cardtrader: 255838
+			}
+		},
+	],
 
 	suffix: "ex",
 	illustrator: "PLANETA Igarashi",
 
-	thirdParty: {
-		cardmarket: 725233
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/154.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/154.ts
@@ -47,15 +47,28 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 725234,
+				tcgplayer: 509941,
+				cardtrader: 255839
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 725234,
+				tcgplayer: 509941,
+				cardtrader: 255839
+			}
+		},
+	],
 
 	illustrator: "Kouki Saitou",
 
-	thirdParty: {
-		cardmarket: 725234
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/155.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/155.ts
@@ -38,15 +38,28 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 725235,
+				tcgplayer: 509942,
+				cardtrader: 255840
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 725235,
+				tcgplayer: 509942,
+				cardtrader: 255840
+			}
+		},
+	],
 
 	illustrator: "Saya Tsuruta",
 
-	thirdParty: {
-		cardmarket: 725235
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/156.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/156.ts
@@ -77,17 +77,21 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		reverse: false,
-		normal: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 725236,
+				tcgplayer: 509943,
+				cardtrader: 255841
+			}
+		},
+	],
 
 	suffix: "ex",
 	illustrator: "takuyoa",
 
-	thirdParty: {
-		cardmarket: 725236
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/157.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/157.ts
@@ -38,15 +38,28 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 725237,
+				tcgplayer: 509636,
+				cardtrader: 255842
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 725237,
+				tcgplayer: 509636,
+				cardtrader: 255842
+			}
+		},
+	],
 
 	illustrator: "satoma",
 
-	thirdParty: {
-		cardmarket: 725237
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/158.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/158.ts
@@ -68,15 +68,28 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 725238,
+				tcgplayer: 509644,
+				cardtrader: 255843
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 725238,
+				tcgplayer: 509644,
+				cardtrader: 255843
+			}
+		},
+	],
 
 	illustrator: "Misa Tsutsui",
 
-	thirdParty: {
-		cardmarket: 725238
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/159.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/159.ts
@@ -68,17 +68,21 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "G",
 
-	variants: {
-		reverse: false,
-		normal: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 725239,
+				tcgplayer: 509646,
+				cardtrader: 255844
+			}
+		},
+	],
 
 	suffix: "ex",
 	illustrator: "5ban Graphics",
 
-	thirdParty: {
-		cardmarket: 725239
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/160.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/160.ts
@@ -68,15 +68,28 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 725240,
+				tcgplayer: 509663,
+				cardtrader: 255845
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 725240,
+				tcgplayer: 509663,
+				cardtrader: 255845
+			}
+		},
+	],
 
 	illustrator: "kurumitsu",
 
-	thirdParty: {
-		cardmarket: 725240
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/161.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/161.ts
@@ -47,15 +47,28 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 725241,
+				tcgplayer: 509664,
+				cardtrader: 255846
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 725241,
+				tcgplayer: 509664,
+				cardtrader: 255846
+			}
+		},
+	],
 
 	illustrator: "hatachu",
 
-	thirdParty: {
-		cardmarket: 725241
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/162.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/162.ts
@@ -38,15 +38,28 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 725242,
+				tcgplayer: 509666,
+				cardtrader: 255847
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 725242,
+				tcgplayer: 509666,
+				cardtrader: 255847
+			}
+		},
+	],
 
 	illustrator: "Naoyo Kimura",
 
-	thirdParty: {
-		cardmarket: 725242
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/163.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/163.ts
@@ -46,15 +46,28 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 725243,
+				tcgplayer: 509669,
+				cardtrader: 255848
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 725243,
+				tcgplayer: 509669,
+				cardtrader: 255848
+			}
+		},
+	],
 
 	illustrator: "Kariya",
 
-	thirdParty: {
-		cardmarket: 725243
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/164.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/164.ts
@@ -77,17 +77,21 @@ const card: Card = {
 	retreat: 0,
 	regulationMark: "G",
 
-	variants: {
-		reverse: false,
-		normal: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 725244,
+				tcgplayer: 509670,
+				cardtrader: 255849
+			}
+		},
+	],
 
 	suffix: "ex",
 	illustrator: "takuyoa",
 
-	thirdParty: {
-		cardmarket: 725244
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/165.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/165.ts
@@ -60,15 +60,28 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 725245,
+				tcgplayer: 509673,
+				cardtrader: 255850
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 725245,
+				tcgplayer: 509673,
+				cardtrader: 255850
+			}
+		},
+	],
 
 	illustrator: "Yuya Oka",
 
-	thirdParty: {
-		cardmarket: 725245
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/166.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/166.ts
@@ -58,15 +58,28 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 725246,
+				tcgplayer: 509689,
+				cardtrader: 255851
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 725246,
+				tcgplayer: 509689,
+				cardtrader: 255851
+			}
+		},
+	],
 
 	illustrator: "ryoma uratsuka",
 
-	thirdParty: {
-		cardmarket: 725246
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/167.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/167.ts
@@ -51,15 +51,28 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 725247,
+				tcgplayer: 509690,
+				cardtrader: 256063
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 725247,
+				tcgplayer: 509690,
+				cardtrader: 256063
+			}
+		},
+	],
 
 	illustrator: "Kagemaru Himeno",
 
-	thirdParty: {
-		cardmarket: 725247
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/168.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/168.ts
@@ -68,15 +68,28 @@ const card: Card = {
 	retreat: 0,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 725248,
+				tcgplayer: 509696,
+				cardtrader: 256064
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 725248,
+				tcgplayer: 509696,
+				cardtrader: 256064
+			}
+		},
+	],
 
 	illustrator: "Nagomi Nijo",
 
-	thirdParty: {
-		cardmarket: 725248
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/169.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/169.ts
@@ -58,15 +58,28 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 725249,
+				tcgplayer: 509698,
+				cardtrader: 256065
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 725249,
+				tcgplayer: 509698,
+				cardtrader: 256065
+			}
+		},
+	],
 
 	illustrator: "Oswaldo KATO",
 
-	thirdParty: {
-		cardmarket: 725249
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/170.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/170.ts
@@ -38,15 +38,28 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 725250,
+				tcgplayer: 509707,
+				cardtrader: 256066
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 725250,
+				tcgplayer: 509707,
+				cardtrader: 256066
+			}
+		},
+	],
 
 	illustrator: "Yuka Morii",
 
-	thirdParty: {
-		cardmarket: 725250
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/171.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/171.ts
@@ -59,15 +59,28 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 725251,
+				tcgplayer: 509711,
+				cardtrader: 256067
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 725251,
+				tcgplayer: 509711,
+				cardtrader: 256067
+			}
+		},
+	],
 
 	illustrator: "Kariya",
 
-	thirdParty: {
-		cardmarket: 725251
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/172.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/172.ts
@@ -68,15 +68,28 @@ const card: Card = {
 	retreat: 3,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 725252,
+				tcgplayer: 509713,
+				cardtrader: 256068
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 725252,
+				tcgplayer: 509713,
+				cardtrader: 256068
+			}
+		},
+	],
 
 	illustrator: "Keisin",
 
-	thirdParty: {
-		cardmarket: 725252
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/173.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/173.ts
@@ -58,15 +58,28 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 725253,
+				tcgplayer: 509714,
+				cardtrader: 256069
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 725253,
+				tcgplayer: 509714,
+				cardtrader: 256069
+			}
+		},
+	],
 
 	illustrator: "Tika Matsuno",
 
-	thirdParty: {
-		cardmarket: 725253
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/174.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/174.ts
@@ -69,15 +69,28 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 725254,
+				tcgplayer: 509718,
+				cardtrader: 256070
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 725254,
+				tcgplayer: 509718,
+				cardtrader: 256070
+			}
+		},
+	],
 
 	illustrator: "Yuya Oka",
 
-	thirdParty: {
-		cardmarket: 725254
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/175.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/175.ts
@@ -47,15 +47,28 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 725255,
+				tcgplayer: 509727,
+				cardtrader: 256071
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 725255,
+				tcgplayer: 509727,
+				cardtrader: 256071
+			}
+		},
+	],
 
 	illustrator: "Lee HyunJung",
 
-	thirdParty: {
-		cardmarket: 725255
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/176.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/176.ts
@@ -47,15 +47,28 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 725256,
+				tcgplayer: 509729,
+				cardtrader: 256072
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 725256,
+				tcgplayer: 509729,
+				cardtrader: 256072
+			}
+		},
+	],
 
 	illustrator: "saino misaki",
 
-	thirdParty: {
-		cardmarket: 725256
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/177.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/177.ts
@@ -68,15 +68,28 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 725257,
+				tcgplayer: 509730,
+				cardtrader: 256073
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 725257,
+				tcgplayer: 509730,
+				cardtrader: 256073
+			}
+		},
+	],
 
 	illustrator: "Eri Yamaki",
 
-	thirdParty: {
-		cardmarket: 725257
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/178.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/178.ts
@@ -58,15 +58,28 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 725258,
+				tcgplayer: 509732,
+				cardtrader: 256074
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 725258,
+				tcgplayer: 509732,
+				cardtrader: 256074
+			}
+		},
+	],
 
 	illustrator: "Taiga Kayama",
 
-	thirdParty: {
-		cardmarket: 725258
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/179.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/179.ts
@@ -75,17 +75,21 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "G",
 
-	variants: {
-		reverse: false,
-		normal: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 725259,
+				tcgplayer: 509759,
+				cardtrader: 256075
+			}
+		},
+	],
 
 	suffix: "ex",
 	illustrator: "5ban Graphics",
 
-	thirdParty: {
-		cardmarket: 725259
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/180.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/180.ts
@@ -38,15 +38,28 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 725260,
+				tcgplayer: 509760,
+				cardtrader: 256076
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 725260,
+				tcgplayer: 509760,
+				cardtrader: 256076
+			}
+		},
+	],
 
 	illustrator: "HYOGONOSUKE",
 
-	thirdParty: {
-		cardmarket: 725260
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/181.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/181.ts
@@ -47,15 +47,28 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 725261,
+				tcgplayer: 509764,
+				cardtrader: 256077
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 725261,
+				tcgplayer: 509764,
+				cardtrader: 256077
+			}
+		},
+	],
 
 	illustrator: "Tomokazu Komiya",
 
-	thirdParty: {
-		cardmarket: 725261
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/182.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/182.ts
@@ -51,15 +51,28 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 725262,
+				tcgplayer: 509766,
+				cardtrader: 256078
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 725262,
+				tcgplayer: 509766,
+				cardtrader: 256078
+			}
+		},
+	],
 
 	illustrator: "Atsuko Nishida",
 
-	thirdParty: {
-		cardmarket: 725262
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/183.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/183.ts
@@ -77,15 +77,28 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 725263,
+				tcgplayer: 509769,
+				cardtrader: 256079
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 725263,
+				tcgplayer: 509769,
+				cardtrader: 256079
+			}
+		},
+	],
 
 	illustrator: "Pani Kobayashi",
 
-	thirdParty: {
-		cardmarket: 725263
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/184.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/184.ts
@@ -75,15 +75,28 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 725264,
+				tcgplayer: 509773,
+				cardtrader: 256080
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 725264,
+				tcgplayer: 509773,
+				cardtrader: 256080
+			}
+		},
+	],
 
 	illustrator: "Akira Komayama",
 
-	thirdParty: {
-		cardmarket: 725264
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/185.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/185.ts
@@ -60,15 +60,28 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 725265,
+				tcgplayer: 510901,
+				cardtrader: 256081
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 725265,
+				tcgplayer: 510901,
+				cardtrader: 256081
+			}
+		},
+	],
 
 	illustrator: "Hiroki Asanuma",
 
-	thirdParty: {
-		cardmarket: 725265
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/186.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/186.ts
@@ -28,15 +28,28 @@ const card: Card = {
 	trainerType: "Supporter",
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 725266,
+				tcgplayer: 509778,
+				cardtrader: 256082
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 725266,
+				tcgplayer: 509778,
+				cardtrader: 256082
+			}
+		},
+	],
 
 	illustrator: "GIDORA",
 
-	thirdParty: {
-		cardmarket: 725266
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/187.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/187.ts
@@ -28,15 +28,28 @@ const card: Card = {
 	trainerType: "Supporter",
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 725267,
+				tcgplayer: 509779,
+				cardtrader: 256083
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 725267,
+				tcgplayer: 509779,
+				cardtrader: 256083
+			}
+		},
+	],
 
 	illustrator: "GIDORA",
 
-	thirdParty: {
-		cardmarket: 725267
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/188.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/188.ts
@@ -28,15 +28,35 @@ const card: Card = {
 	trainerType: "Supporter",
 	regulationMark: "G",
 
-	variants: {
-		normal: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 742991,
+				tcgplayer: 509780,
+				cardtrader: 256084
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 725268,
+				tcgplayer: 509780,
+				cardtrader: 256084
+			}
+		},
+		{
+			type: 'reverse',
+			stamp: ['regional-championships'],
+			thirdParty: {
+				cardmarket: 725268
+			}
+		},
+	],
 
 	illustrator: "kirisAki",
 
-	thirdParty: {
-		cardmarket: 725268
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/189.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/189.ts
@@ -28,15 +28,28 @@ const card: Card = {
 	trainerType: "Item",
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 725269,
+				tcgplayer: 509781,
+				cardtrader: 256085
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 725269,
+				tcgplayer: 509781,
+				cardtrader: 256085
+			}
+		},
+	],
 
 	illustrator: "Toyste Beach",
 
-	thirdParty: {
-		cardmarket: 725269
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/190.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/190.ts
@@ -28,15 +28,28 @@ const card: Card = {
 	trainerType: "Supporter",
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 725270,
+				tcgplayer: 509782,
+				cardtrader: 256086
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 725270,
+				tcgplayer: 509782,
+				cardtrader: 256086
+			}
+		},
+	],
 
 	illustrator: "Naoki Saito",
 
-	thirdParty: {
-		cardmarket: 725270
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/191.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/191.ts
@@ -28,15 +28,28 @@ const card: Card = {
 	trainerType: "Tool",
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 725271,
+				tcgplayer: 509783,
+				cardtrader: 256087
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 725271,
+				tcgplayer: 509783,
+				cardtrader: 256087
+			}
+		},
+	],
 
 	illustrator: "Toyste Beach",
 
-	thirdParty: {
-		cardmarket: 725271
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/192.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/192.ts
@@ -28,15 +28,28 @@ const card: Card = {
 	trainerType: "Stadium",
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 725272,
+				tcgplayer: 509784,
+				cardtrader: 256088
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 725272,
+				tcgplayer: 509784,
+				cardtrader: 256088
+			}
+		},
+	],
 
 	illustrator: "Oswaldo KATO",
 
-	thirdParty: {
-		cardmarket: 725272
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/193.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/193.ts
@@ -28,15 +28,28 @@ const card: Card = {
 	trainerType: "Supporter",
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 725273,
+				tcgplayer: 509785,
+				cardtrader: 256089
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 725273,
+				tcgplayer: 509785,
+				cardtrader: 256089
+			}
+		},
+	],
 
 	illustrator: "yuu",
 
-	thirdParty: {
-		cardmarket: 725273
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/194.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/194.ts
@@ -28,15 +28,28 @@ const card: Card = {
 	trainerType: "Supporter",
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 725274,
+				tcgplayer: 509786,
+				cardtrader: 256090
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 725274,
+				tcgplayer: 509786,
+				cardtrader: 256090
+			}
+		},
+	],
 
 	illustrator: "nagimiso",
 
-	thirdParty: {
-		cardmarket: 725274
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/195.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/195.ts
@@ -28,15 +28,28 @@ const card: Card = {
 	trainerType: "Supporter",
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 725275,
+				tcgplayer: 509787,
+				cardtrader: 256091
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 725275,
+				tcgplayer: 509787,
+				cardtrader: 256091
+			}
+		},
+	],
 
 	illustrator: "nagimiso",
 
-	thirdParty: {
-		cardmarket: 725275
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/196.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/196.ts
@@ -28,15 +28,28 @@ const card: Card = {
 	trainerType: "Stadium",
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 725276,
+				tcgplayer: 509788,
+				cardtrader: 256092
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 725276,
+				tcgplayer: 509788,
+				cardtrader: 256092
+			}
+		},
+	],
 
 	illustrator: "Oswaldo KATO",
 
-	thirdParty: {
-		cardmarket: 725276
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/197.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/197.ts
@@ -28,15 +28,28 @@ const card: Card = {
 	trainerType: "Tool",
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 725277,
+				tcgplayer: 510898,
+				cardtrader: 256093
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 725277,
+				tcgplayer: 510898,
+				cardtrader: 256093
+			}
+		},
+	],
 
 	illustrator: "Ayaka Yoshida",
 
-	thirdParty: {
-		cardmarket: 725277
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/198.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/198.ts
@@ -66,16 +66,20 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "G",
 
-	variants: {
-		reverse: false,
-		normal: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 725278,
+				tcgplayer: 509944,
+				cardtrader: 255640
+			}
+		},
+	],
 
 	illustrator: "Masako Tomii",
 
-	thirdParty: {
-		cardmarket: 725278
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/199.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/199.ts
@@ -66,16 +66,20 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		reverse: false,
-		normal: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 725279,
+				tcgplayer: 509945,
+				cardtrader: 255641
+			}
+		},
+	],
 
 	illustrator: "SIE NANAHARA",
 
-	thirdParty: {
-		cardmarket: 725279
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/200.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/200.ts
@@ -77,16 +77,20 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "G",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 725280,
+				tcgplayer: 509946,
+				cardtrader: 255642
+			}
+		},
+	],
 
 	illustrator: "Akira Komayama",
 
-	thirdParty: {
-		cardmarket: 725280
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/201.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/201.ts
@@ -77,16 +77,20 @@ const card: Card = {
 	retreat: 3,
 	regulationMark: "G",
 
-	variants: {
-		reverse: false,
-		normal: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 725281,
+				tcgplayer: 509948,
+				cardtrader: 255643
+			}
+		},
+	],
 
 	illustrator: "KEIICHIRO ITO",
 
-	thirdParty: {
-		cardmarket: 725281
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/202.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/202.ts
@@ -43,16 +43,20 @@ const card: Card = {
 	retreat: 0,
 	regulationMark: "G",
 
-	variants: {
-		reverse: false,
-		normal: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 725282,
+				tcgplayer: 509949,
+				cardtrader: 255644
+			}
+		},
+	],
 
 	illustrator: "HYOGONOSUKE",
 
-	thirdParty: {
-		cardmarket: 725282
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/203.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/203.ts
@@ -51,16 +51,20 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		reverse: false,
-		normal: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 725283,
+				tcgplayer: 509950,
+				cardtrader: 255645
+			}
+		},
+	],
 
 	illustrator: "Miki Tanaka",
 
-	thirdParty: {
-		cardmarket: 725283
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/204.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/204.ts
@@ -67,16 +67,20 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		reverse: false,
-		normal: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 725284,
+				tcgplayer: 509951,
+				cardtrader: 255646
+			}
+		},
+	],
 
 	illustrator: "KYUPIYAMA",
 
-	thirdParty: {
-		cardmarket: 725284
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/205.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/205.ts
@@ -68,16 +68,20 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "G",
 
-	variants: {
-		reverse: false,
-		normal: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 725285,
+				tcgplayer: 509952,
+				cardtrader: 255647
+			}
+		},
+	],
 
 	illustrator: "Oku",
 
-	thirdParty: {
-		cardmarket: 725285
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/206.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/206.ts
@@ -47,16 +47,20 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		reverse: false,
-		normal: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 725286,
+				tcgplayer: 509954,
+				cardtrader: 255648
+			}
+		},
+	],
 
 	illustrator: "Souichirou Gunjima",
 
-	thirdParty: {
-		cardmarket: 725286
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/207.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/207.ts
@@ -38,16 +38,20 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		reverse: false,
-		normal: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 725287,
+				tcgplayer: 509955,
+				cardtrader: 255649
+			}
+		},
+	],
 
 	illustrator: "Jerky",
 
-	thirdParty: {
-		cardmarket: 725287
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/208.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/208.ts
@@ -46,16 +46,20 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		reverse: false,
-		normal: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 725288,
+				tcgplayer: 509956,
+				cardtrader: 255650
+			}
+		},
+	],
 
 	illustrator: "Jerky",
 
-	thirdParty: {
-		cardmarket: 725288
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/209.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/209.ts
@@ -38,16 +38,20 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		reverse: false,
-		normal: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 725289,
+				tcgplayer: 509957,
+				cardtrader: 255651
+			}
+		},
+	],
 
 	illustrator: "Narumi Sato",
 
-	thirdParty: {
-		cardmarket: 725289
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/210.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/210.ts
@@ -47,17 +47,21 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "G",
 
-	variants: {
-		reverse: false,
-		normal: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 725290,
+				tcgplayer: 509959,
+				cardtrader: 255652
+			}
+		},
+	],
 
 	suffix: "ex",
 	illustrator: "5ban Graphics",
 
-	thirdParty: {
-		cardmarket: 725290
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/211.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/211.ts
@@ -77,17 +77,21 @@ const card: Card = {
 	retreat: 4,
 	regulationMark: "G",
 
-	variants: {
-		reverse: false,
-		normal: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 725291,
+				tcgplayer: 509960,
+				cardtrader: 255653
+			}
+		},
+	],
 
 	suffix: "ex",
 	illustrator: "5ban Graphics",
 
-	thirdParty: {
-		cardmarket: 725291
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/212.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/212.ts
@@ -75,17 +75,21 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "G",
 
-	variants: {
-		reverse: false,
-		normal: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 725292,
+				tcgplayer: 509961,
+				cardtrader: 255654
+			}
+		},
+	],
 
 	suffix: "ex",
 	illustrator: "5ban Graphics",
 
-	thirdParty: {
-		cardmarket: 725292
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/213.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/213.ts
@@ -77,17 +77,21 @@ const card: Card = {
 	retreat: 3,
 	regulationMark: "G",
 
-	variants: {
-		reverse: false,
-		normal: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 725293,
+				tcgplayer: 509962,
+				cardtrader: 255655
+			}
+		},
+	],
 
 	suffix: "ex",
 	illustrator: "5ban Graphics",
 
-	thirdParty: {
-		cardmarket: 725293
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/214.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/214.ts
@@ -67,17 +67,21 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		reverse: false,
-		normal: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 725295,
+				tcgplayer: 509964,
+				cardtrader: 255656
+			}
+		},
+	],
 
 	suffix: "ex",
 	illustrator: "PLANETA Mochizuki",
 
-	thirdParty: {
-		cardmarket: 725294
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/215.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/215.ts
@@ -77,17 +77,21 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "G",
 
-	variants: {
-		reverse: false,
-		normal: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 725294,
+				tcgplayer: 509963,
+				cardtrader: 255657
+			}
+		},
+	],
 
 	suffix: "ex",
 	illustrator: "5ban Graphics",
 
-	thirdParty: {
-		cardmarket: 725295
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/216.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/216.ts
@@ -77,17 +77,21 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		reverse: false,
-		normal: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 725296,
+				tcgplayer: 509965,
+				cardtrader: 255658
+			}
+		},
+	],
 
 	suffix: "ex",
 	illustrator: "takuyoa",
 
-	thirdParty: {
-		cardmarket: 725296
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/217.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/217.ts
@@ -77,17 +77,21 @@ const card: Card = {
 	retreat: 0,
 	regulationMark: "G",
 
-	variants: {
-		reverse: false,
-		normal: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 725297,
+				tcgplayer: 509966,
+				cardtrader: 255659
+			}
+		},
+	],
 
 	suffix: "ex",
 	illustrator: "takuyoa",
 
-	thirdParty: {
-		cardmarket: 725297
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/218.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/218.ts
@@ -28,16 +28,20 @@ const card: Card = {
 	trainerType: "Supporter",
 	regulationMark: "G",
 
-	variants: {
-		reverse: false,
-		normal: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 725298,
+				tcgplayer: 509967,
+				cardtrader: 255660
+			}
+		},
+	],
 
 	illustrator: "kirisAki",
 
-	thirdParty: {
-		cardmarket: 725298
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/219.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/219.ts
@@ -28,16 +28,20 @@ const card: Card = {
 	trainerType: "Supporter",
 	regulationMark: "G",
 
-	variants: {
-		reverse: false,
-		normal: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 725299,
+				tcgplayer: 509970,
+				cardtrader: 255661
+			}
+		},
+	],
 
 	illustrator: "Naoki Saito",
 
-	thirdParty: {
-		cardmarket: 725299
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/220.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/220.ts
@@ -28,16 +28,20 @@ const card: Card = {
 	trainerType: "Supporter",
 	regulationMark: "G",
 
-	variants: {
-		reverse: false,
-		normal: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 725300,
+				tcgplayer: 509973,
+				cardtrader: 255662
+			}
+		},
+	],
 
 	illustrator: "yuu",
 
-	thirdParty: {
-		cardmarket: 725300
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/221.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/221.ts
@@ -28,16 +28,20 @@ const card: Card = {
 	trainerType: "Supporter",
 	regulationMark: "G",
 
-	variants: {
-		reverse: false,
-		normal: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 725301,
+				tcgplayer: 509975,
+				cardtrader: 255663
+			}
+		},
+	],
 
 	illustrator: "nagimiso",
 
-	thirdParty: {
-		cardmarket: 725301
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/222.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/222.ts
@@ -47,17 +47,21 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "G",
 
-	variants: {
-		reverse: false,
-		normal: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 725302,
+				tcgplayer: 509979,
+				cardtrader: 255664
+			}
+		},
+	],
 
 	suffix: "ex",
 	illustrator: "Toshinao Aoki",
 
-	thirdParty: {
-		cardmarket: 725302
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/223.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/223.ts
@@ -77,17 +77,21 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "G",
 
-	variants: {
-		reverse: false,
-		normal: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 725303,
+				tcgplayer: 509980,
+				cardtrader: 255402
+			}
+		},
+	],
 
 	suffix: "ex",
 	illustrator: "AKIRA EGAWA",
 
-	thirdParty: {
-		cardmarket: 725303
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/224.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/224.ts
@@ -77,17 +77,21 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		reverse: false,
-		normal: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 725304,
+				tcgplayer: 509982,
+				cardtrader: 255665
+			}
+		},
+	],
 
 	suffix: "ex",
 	illustrator: "Souichirou Gunjima",
 
-	thirdParty: {
-		cardmarket: 725304
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/225.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/225.ts
@@ -77,17 +77,21 @@ const card: Card = {
 	retreat: 0,
 	regulationMark: "G",
 
-	variants: {
-		reverse: false,
-		normal: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 725305,
+				tcgplayer: 509983,
+				cardtrader: 255666
+			}
+		},
+	],
 
 	suffix: "ex",
 	illustrator: "Jerky",
 
-	thirdParty: {
-		cardmarket: 725305
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/226.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/226.ts
@@ -28,16 +28,20 @@ const card: Card = {
 	trainerType: "Supporter",
 	regulationMark: "G",
 
-	variants: {
-		reverse: false,
-		normal: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 725306,
+				tcgplayer: 509986,
+				cardtrader: 255667
+			}
+		},
+	],
 
 	illustrator: "DOM",
 
-	thirdParty: {
-		cardmarket: 725306
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/227.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/227.ts
@@ -28,16 +28,20 @@ const card: Card = {
 	trainerType: "Supporter",
 	regulationMark: "G",
 
-	variants: {
-		reverse: false,
-		normal: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 725307,
+				tcgplayer: 509987,
+				cardtrader: 255668
+			}
+		},
+	],
 
 	illustrator: "Ryota Murayama",
 
-	thirdParty: {
-		cardmarket: 725307
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/228.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/228.ts
@@ -77,17 +77,21 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "G",
 
-	variants: {
-		reverse: false,
-		normal: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 725308,
+				tcgplayer: 509989,
+				cardtrader: 255401
+			}
+		},
+	],
 
 	suffix: "ex",
 	illustrator: "5ban Graphics",
 
-	thirdParty: {
-		cardmarket: 725308
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/229.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/229.ts
@@ -28,16 +28,20 @@ const card: Card = {
 	trainerType: "Stadium",
 	regulationMark: "G",
 
-	variants: {
-		reverse: false,
-		normal: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 725309,
+				tcgplayer: 509990,
+				cardtrader: 255669
+			}
+		},
+	],
 
 	illustrator: "Oswaldo KATO",
 
-	thirdParty: {
-		cardmarket: 725309
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Obsidian Flames/230.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/230.ts
@@ -18,14 +18,18 @@ const card: Card = {
 	types: ["Fire"],
 	energyType: "Normal",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 725310,
+				tcgplayer: 509992,
+				cardtrader: 255670
+			}
+		},
+	],
 
-	thirdParty: {
-		cardmarket: 725310
-	}
+	
 }
 
 export default card

--- a/interfaces.d.ts
+++ b/interfaces.d.ts
@@ -97,6 +97,7 @@ export interface variant_detailed {
 	thirdParty?: {
 		tcgplayer?: number
 		cardmarket?: number
+		cardtrader?: number
 	}
 }
 
@@ -167,6 +168,7 @@ export interface Set {
 	thirdParty?: {
 		cardmarket?: number
 		tcgplayer?: number
+		cardtrader?: number
 	}
 }
 
@@ -403,6 +405,7 @@ export interface Card {
 	thirdParty?: {
 		tcgplayer?: number
 		cardmarket?: number
+		cardtrader?: number
 	}
 }
 


### PR DESCRIPTION
Moved all thirdparty IDs into variants and added cardtrader id source for all Obsidian Flames 


