### PR TITLE
(data): Variants & Pricing for 151

### DIFF
--- a/data/Scarlet & Violet/151/001.ts
+++ b/data/Scarlet & Violet/151/001.ts
@@ -49,18 +49,40 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "normal"
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 733596,
+				tcgplayer: 502552,
+				cardtrader: 261065
+			}
 		},
 		{
-			type: "reverse"
-		}
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 733596,
+				tcgplayer: 502552,
+				cardtrader: 261065
+			}
+		},
+		{
+			type: 'normal',
+			stamp: ['set-logo'],
+			thirdParty: {
+				cardmarket: 720365
+			}
+		},
+		{
+			type: 'reverse',
+			foil: 'cosmos',
+			thirdParty: {
+				cardmarket: 794908
+			}
+		},
 	],
 
 	illustrator: "Yuu Nishida",
 
-	thirdParty: {
-		cardmarket: 733596
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/151/002.ts
+++ b/data/Scarlet & Violet/151/002.ts
@@ -70,18 +70,26 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "normal"
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 733597,
+				tcgplayer: 502553,
+				cardtrader: 261186
+			}
 		},
 		{
-			type: "reverse"
-		}
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 733597,
+				tcgplayer: 502553,
+				cardtrader: 261186
+			}
+		},
 	],
 
 	illustrator: "Yuu Nishida",
 
-	thirdParty: {
-		cardmarket: 733597
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/151/003.ts
+++ b/data/Scarlet & Violet/151/003.ts
@@ -77,17 +77,21 @@ const card: Card = {
 	retreat: 4,
 	regulationMark: "G",
 
-	variants: {
-		reverse: false,
-		normal: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 733598,
+				tcgplayer: 502554,
+				cardtrader: 261103
+			}
+		},
+	],
 
 	suffix: "ex",
 	illustrator: "5ban Graphics",
 
-	thirdParty: {
-		cardmarket: 733751
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/151/004.ts
+++ b/data/Scarlet & Violet/151/004.ts
@@ -60,18 +60,54 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "normal"
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 733599,
+				tcgplayer: 502555,
+				cardtrader: 261106
+			}
 		},
 		{
-			type: "reverse"
-		}
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 733599,
+				tcgplayer: 502555,
+				cardtrader: 261106
+			}
+		},
+		{
+			type: 'normal',
+			stamp: ['gamestop'],
+			thirdParty: {
+				cardmarket: 720366
+			}
+		},
+		{
+			type: 'holo',
+			foil: 'cosmos',
+			thirdParty: {
+				cardmarket: 791827
+			}
+		},
+		{
+			type: 'reverse',
+			stamp: ['eb-games'],
+			thirdParty: {
+				cardmarket: 759873
+			}
+		},
+		{
+			type: 'reverse',
+			foil: 'cosmos',
+			thirdParty: {
+				cardmarket: 794909
+			}
+		},
 	],
 
 	illustrator: "GIDORA",
 
-	thirdParty: {
-		cardmarket: 733599
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/151/005.ts
+++ b/data/Scarlet & Violet/151/005.ts
@@ -70,18 +70,33 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "normal"
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 733600,
+				tcgplayer: 502557,
+				cardtrader: 261162
+			}
 		},
 		{
-			type: "reverse"
-		}
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 733600,
+				tcgplayer: 502557,
+				cardtrader: 261162
+			}
+		},
+		{
+			type: 'holo',
+			foil: 'cosmos',
+			thirdParty: {
+				cardmarket: 791828
+			}
+		},
 	],
 
 	illustrator: "GIDORA",
 
-	thirdParty: {
-		cardmarket: 733600
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/151/006.ts
+++ b/data/Scarlet & Violet/151/006.ts
@@ -84,17 +84,21 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "G",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 733601,
+				tcgplayer: 502558,
+				cardtrader: 261069
+			}
+		},
+	],
 
 	suffix: "ex",
 	illustrator: "PLANETA Mochizuki",
 
-	thirdParty: {
-		cardmarket: 733601
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/151/007.ts
+++ b/data/Scarlet & Violet/151/007.ts
@@ -60,18 +60,40 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "normal"
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 733602,
+				tcgplayer: 502548,
+				cardtrader: 261151
+			}
 		},
 		{
-			type: "reverse"
-		}
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 733602,
+				tcgplayer: 502548,
+				cardtrader: 261151
+			}
+		},
+		{
+			type: 'normal',
+			stamp: ['pokemon-center'],
+			thirdParty: {
+				cardmarket: 721198
+			}
+		},
+		{
+			type: 'reverse',
+			foil: 'cosmos',
+			thirdParty: {
+				cardmarket: 794910
+			}
+		},
 	],
 
 	illustrator: "kantaro",
 
-	thirdParty: {
-		cardmarket: 733602
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/151/008.ts
+++ b/data/Scarlet & Violet/151/008.ts
@@ -68,18 +68,26 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "normal"
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 733603,
+				tcgplayer: 502550,
+				cardtrader: 261224
+			}
 		},
 		{
-			type: "reverse"
-		}
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 733603,
+				tcgplayer: 502550,
+				cardtrader: 261224
+			}
+		},
 	],
 
 	illustrator: "kantaro",
 
-	thirdParty: {
-		cardmarket: 733603
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/151/009.ts
+++ b/data/Scarlet & Violet/151/009.ts
@@ -77,17 +77,28 @@ const card: Card = {
 	retreat: 3,
 	regulationMark: "G",
 
-	variants: {
-		reverse: false,
-		normal: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 733604,
+				tcgplayer: 502551,
+				cardtrader: 261064
+			}
+		},
+		{
+			type: 'holo',
+			size: 'jumbo',
+			thirdParty: {
+				cardmarket: 816812
+			}
+		},
+	],
 
 	suffix: "ex",
 	illustrator: "PLANETA Yamashita",
 
-	thirdParty: {
-		cardmarket: 733604
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/151/010.ts
+++ b/data/Scarlet & Violet/151/010.ts
@@ -49,18 +49,26 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "normal"
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 733605,
+				tcgplayer: 502559,
+				cardtrader: 261067
+			}
 		},
 		{
-			type: "reverse"
-		}
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 733605,
+				tcgplayer: 502559,
+				cardtrader: 261067
+			}
+		},
 	],
 
 	illustrator: "Tika Matsuno",
 
-	thirdParty: {
-		cardmarket: 733743
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/151/011.ts
+++ b/data/Scarlet & Violet/151/011.ts
@@ -68,18 +68,26 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "normal"
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 733606,
+				tcgplayer: 502560,
+				cardtrader: 261195
+			}
 		},
 		{
-			type: "reverse"
-		}
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 733606,
+				tcgplayer: 502560,
+				cardtrader: 261195
+			}
+		},
 	],
 
 	illustrator: "Tika Matsuno",
 
-	thirdParty: {
-		cardmarket: 733606
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/151/012.ts
+++ b/data/Scarlet & Violet/151/012.ts
@@ -77,18 +77,26 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "normal"
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 733607,
+				tcgplayer: 502561,
+				cardtrader: 261066
+			}
 		},
 		{
-			type: "reverse"
-		}
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 733607,
+				tcgplayer: 502561,
+				cardtrader: 261066
+			}
+		},
 	],
 
 	illustrator: "Tika Matsuno",
 
-	thirdParty: {
-		cardmarket: 733735
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/151/013.ts
+++ b/data/Scarlet & Violet/151/013.ts
@@ -53,18 +53,26 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "normal"
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 733608,
+				tcgplayer: 502562,
+				cardtrader: 261158
+			}
 		},
 		{
-			type: "reverse"
-		}
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 733608,
+				tcgplayer: 502562,
+				cardtrader: 261158
+			}
+		},
 	],
 
 	illustrator: "nisimono",
 
-	thirdParty: {
-		cardmarket: 733738
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/151/014.ts
+++ b/data/Scarlet & Violet/151/014.ts
@@ -70,18 +70,26 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "normal"
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 733609,
+				tcgplayer: 502563,
+				cardtrader: 261125
+			}
 		},
 		{
-			type: "reverse"
-		}
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 733609,
+				tcgplayer: 502563,
+				cardtrader: 261125
+			}
+		},
 	],
 
 	illustrator: "nisimono",
 
-	thirdParty: {
-		cardmarket: 733625
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/151/015.ts
+++ b/data/Scarlet & Violet/151/015.ts
@@ -70,18 +70,26 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "holo"
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 733610,
+				tcgplayer: 502564,
+				cardtrader: 261062
+			}
 		},
 		{
-			type: "reverse"
-		}
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 733610,
+				tcgplayer: 502564,
+				cardtrader: 261062
+			}
+		},
 	],
 
 	illustrator: "nisimono",
 
-	thirdParty: {
-		cardmarket: 733610
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/151/016.ts
+++ b/data/Scarlet & Violet/151/016.ts
@@ -60,18 +60,26 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "normal"
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 733611,
+				tcgplayer: 502565,
+				cardtrader: 261139
+			}
 		},
 		{
-			type: "reverse"
-		}
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 733611,
+				tcgplayer: 502565,
+				cardtrader: 261139
+			}
+		},
 	],
 
 	illustrator: "Oswaldo KATO",
 
-	thirdParty: {
-		cardmarket: 733611
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/151/017.ts
+++ b/data/Scarlet & Violet/151/017.ts
@@ -48,18 +48,26 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "normal"
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 733612,
+				tcgplayer: 502566,
+				cardtrader: 261138
+			}
 		},
 		{
-			type: "reverse"
-		}
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 733612,
+				tcgplayer: 502566,
+				cardtrader: 261138
+			}
+		},
 	],
 
 	illustrator: "Oswaldo KATO",
 
-	thirdParty: {
-		cardmarket: 733612
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/151/018.ts
+++ b/data/Scarlet & Violet/151/018.ts
@@ -70,18 +70,26 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "normal"
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 733613,
+				tcgplayer: 502567,
+				cardtrader: 261204
+			}
 		},
 		{
-			type: "reverse"
-		}
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 733613,
+				tcgplayer: 502567,
+				cardtrader: 261204
+			}
+		},
 	],
 
 	illustrator: "Oswaldo KATO",
 
-	thirdParty: {
-		cardmarket: 733613
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/151/019.ts
+++ b/data/Scarlet & Violet/151/019.ts
@@ -49,18 +49,26 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "normal"
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 733614,
+				tcgplayer: 502568,
+				cardtrader: 261145
+			}
 		},
 		{
-			type: "reverse"
-		}
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 733614,
+				tcgplayer: 502568,
+				cardtrader: 261145
+			}
+		},
 	],
 
 	illustrator: "sowsow",
 
-	thirdParty: {
-		cardmarket: 733614
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/151/020.ts
+++ b/data/Scarlet & Violet/151/020.ts
@@ -57,18 +57,26 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "normal"
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 733615,
+				tcgplayer: 502569,
+				cardtrader: 261212
+			}
 		},
 		{
-			type: "reverse"
-		}
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 733615,
+				tcgplayer: 502569,
+				cardtrader: 261212
+			}
+		},
 	],
 
 	illustrator: "sowsow",
 
-	thirdParty: {
-		cardmarket: 733615
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/151/021.ts
+++ b/data/Scarlet & Violet/151/021.ts
@@ -62,18 +62,26 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "normal"
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 733616,
+				tcgplayer: 502587,
+				cardtrader: 261150
+			}
 		},
 		{
-			type: "reverse"
-		}
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 733616,
+				tcgplayer: 502587,
+				cardtrader: 261150
+			}
+		},
 	],
 
 	illustrator: "Gemi",
 
-	thirdParty: {
-		cardmarket: 733616
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/151/022.ts
+++ b/data/Scarlet & Violet/151/022.ts
@@ -68,18 +68,26 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "normal"
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 733617,
+				tcgplayer: 502589,
+				cardtrader: 261177
+			}
 		},
 		{
-			type: "reverse"
-		}
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 733617,
+				tcgplayer: 502589,
+				cardtrader: 261177
+			}
+		},
 	],
 
 	illustrator: "Gemi",
 
-	thirdParty: {
-		cardmarket: 733623
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/151/023.ts
+++ b/data/Scarlet & Violet/151/023.ts
@@ -49,18 +49,26 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "normal"
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 733618,
+				tcgplayer: 515955,
+				cardtrader: 261113
+			}
 		},
 		{
-			type: "reverse"
-		}
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 733618,
+				tcgplayer: 515955,
+				cardtrader: 261113
+			}
+		},
 	],
 
 	illustrator: "Kedamahadaitai Yawarakai",
 
-	thirdParty: {
-		cardmarket: 733618
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/151/024.ts
+++ b/data/Scarlet & Violet/151/024.ts
@@ -77,17 +77,21 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "G",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 733619,
+				tcgplayer: 515956,
+				cardtrader: 261060
+			}
+		},
+	],
 
 	suffix: "ex",
 	illustrator: "Eske Yoshinob",
 
-	thirdParty: {
-		cardmarket: 733619
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/151/025.ts
+++ b/data/Scarlet & Violet/151/025.ts
@@ -60,18 +60,47 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "normal"
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 733620,
+				tcgplayer: 517033,
+				cardtrader: 261140
+			}
 		},
 		{
-			type: "reverse"
-		}
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 733620,
+				tcgplayer: 517033,
+				cardtrader: 261140
+			}
+		},
+		{
+			type: 'normal',
+			stamp: ['pokemon-together'],
+			thirdParty: {
+				cardmarket: 748474
+			}
+		},
+		{
+			type: 'normal',
+			stamp: ['snowflake'],
+			thirdParty: {
+				cardmarket: 845404
+			}
+		},
+		{
+			type: 'reverse',
+			foil: 'cosmos',
+			thirdParty: {
+				cardmarket: 794911
+			}
+		},
 	],
 
 	illustrator: "Naoyo Kimura",
 
-	thirdParty: {
-		cardmarket: 733620
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/151/026.ts
+++ b/data/Scarlet & Violet/151/026.ts
@@ -79,18 +79,33 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "holo"
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 733621,
+				tcgplayer: 515957,
+				cardtrader: 261244
+			}
 		},
 		{
-			type: "reverse"
-		}
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 733621,
+				tcgplayer: 515957,
+				cardtrader: 261244
+			}
+		},
+		{
+			type: 'holo',
+			foil: 'cosmos',
+			thirdParty: {
+				cardmarket: 864950
+			}
+		},
 	],
 
 	illustrator: "Naoyo Kimura",
 
-	thirdParty: {
-		cardmarket: 733621
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/151/027.ts
+++ b/data/Scarlet & Violet/151/027.ts
@@ -62,18 +62,26 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "normal"
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 733622,
+				tcgplayer: 515978,
+				cardtrader: 261627
+			}
 		},
 		{
-			type: "reverse"
-		}
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 733622,
+				tcgplayer: 515978,
+				cardtrader: 261627
+			}
+		},
 	],
 
 	illustrator: "kodama",
 
-	thirdParty: {
-		cardmarket: 733714
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/151/028.ts
+++ b/data/Scarlet & Violet/151/028.ts
@@ -79,18 +79,26 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "normal"
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 733623,
+				tcgplayer: 515989,
+				cardtrader: 261214
+			}
 		},
 		{
-			type: "reverse"
-		}
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 733623,
+				tcgplayer: 515989,
+				cardtrader: 261214
+			}
+		},
 	],
 
 	illustrator: "kodama",
 
-	thirdParty: {
-		cardmarket: 733631
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/151/029.ts
+++ b/data/Scarlet & Violet/151/029.ts
@@ -49,18 +49,26 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "normal"
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 733624,
+				tcgplayer: 515994,
+				cardtrader: 261134
+			}
 		},
 		{
-			type: "reverse"
-		}
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 733624,
+				tcgplayer: 515994,
+				cardtrader: 261134
+			}
+		},
 	],
 
 	illustrator: "Teeziro",
 
-	thirdParty: {
-		cardmarket: 733624
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/151/030.ts
+++ b/data/Scarlet & Violet/151/030.ts
@@ -68,18 +68,26 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "normal"
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 733625,
+				tcgplayer: 516000,
+				cardtrader: 261198
+			}
 		},
 		{
-			type: "reverse"
-		}
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 733625,
+				tcgplayer: 516000,
+				cardtrader: 261198
+			}
+		},
 	],
 
 	illustrator: "Teeziro",
 
-	thirdParty: {
-		cardmarket: 733625
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/151/031.ts
+++ b/data/Scarlet & Violet/151/031.ts
@@ -70,18 +70,26 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "normal"
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 733626,
+				tcgplayer: 516004,
+				cardtrader: 261197
+			}
 		},
 		{
-			type: "reverse"
-		}
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 733626,
+				tcgplayer: 516004,
+				cardtrader: 261197
+			}
+		},
 	],
 
 	illustrator: "Teeziro",
 
-	thirdParty: {
-		cardmarket: 733626
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/151/032.ts
+++ b/data/Scarlet & Violet/151/032.ts
@@ -40,18 +40,26 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "normal"
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 733627,
+				tcgplayer: 516006,
+				cardtrader: 261135
+			}
 		},
 		{
-			type: "reverse"
-		}
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 733627,
+				tcgplayer: 516006,
+				cardtrader: 261135
+			}
+		},
 	],
 
 	illustrator: "Shiburingaru",
 
-	thirdParty: {
-		cardmarket: 733627,
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/151/033.ts
+++ b/data/Scarlet & Violet/151/033.ts
@@ -61,18 +61,26 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "normal"
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 733628,
+				tcgplayer: 516016,
+				cardtrader: 261199
+			}
 		},
 		{
-			type: "reverse"
-		}
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 733628,
+				tcgplayer: 516016,
+				cardtrader: 261199
+			}
+		},
 	],
 
 	illustrator: "Shiburingaru",
 
-	thirdParty: {
-		cardmarket: 733628
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/151/034.ts
+++ b/data/Scarlet & Violet/151/034.ts
@@ -79,18 +79,26 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "holo"
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 733629,
+				tcgplayer: 516024,
+				cardtrader: 261242
+			}
 		},
 		{
-			type: "reverse"
-		}
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 733629,
+				tcgplayer: 516024,
+				cardtrader: 261242
+			}
+		},
 	],
 
 	illustrator: "Shiburingaru",
 
-	thirdParty: {
-		cardmarket: 733629
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/151/035.ts
+++ b/data/Scarlet & Violet/151/035.ts
@@ -60,18 +60,26 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "normal"
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 733630,
+				tcgplayer: 516030,
+				cardtrader: 261107
+			}
 		},
 		{
-			type: "reverse"
-		}
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 733630,
+				tcgplayer: 516030,
+				cardtrader: 261107
+			}
+		},
 	],
 
 	illustrator: "ryoma uratsuka",
 
-	thirdParty: {
-		cardmarket: 733701
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/151/036.ts
+++ b/data/Scarlet & Violet/151/036.ts
@@ -77,18 +77,26 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "normal"
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 733631,
+				tcgplayer: 516036,
+				cardtrader: 261164
+			}
 		},
 		{
-			type: "reverse"
-		}
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 733631,
+				tcgplayer: 516036,
+				cardtrader: 261164
+			}
+		},
 	],
 
 	illustrator: "ryoma uratsuka",
 
-	thirdParty: {
-		cardmarket: 733631
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/151/037.ts
+++ b/data/Scarlet & Violet/151/037.ts
@@ -49,18 +49,26 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "normal"
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 733632,
+				tcgplayer: 516060,
+				cardtrader: 261157
+			}
 		},
 		{
-			type: "reverse"
-		}
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 733632,
+				tcgplayer: 516060,
+				cardtrader: 261157
+			}
+		},
 	],
 
 	illustrator: "kawayoo",
 
-	thirdParty: {
-		cardmarket: 733632
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/151/038.ts
+++ b/data/Scarlet & Violet/151/038.ts
@@ -77,17 +77,21 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "G",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 733633,
+				tcgplayer: 516072,
+				cardtrader: 261100
+			}
+		},
+	],
 
 	suffix: "ex",
 	illustrator: "kawayoo",
 
-	thirdParty: {
-		cardmarket: 733633
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/151/039.ts
+++ b/data/Scarlet & Violet/151/039.ts
@@ -69,18 +69,26 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "normal"
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 733634,
+				tcgplayer: 516108,
+				cardtrader: 261124
+			}
 		},
 		{
-			type: "reverse"
-		}
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 733634,
+				tcgplayer: 516108,
+				cardtrader: 261124
+			}
+		},
 	],
 
 	illustrator: "saino misaki",
 
-	thirdParty: {
-		cardmarket: 733634
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/151/040.ts
+++ b/data/Scarlet & Violet/151/040.ts
@@ -77,17 +77,21 @@ const card: Card = {
 	retreat: 3,
 	regulationMark: "G",
 
-	variants: {
-		reverse: false,
-		normal: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 733635,
+				tcgplayer: 516145,
+				cardtrader: 261104
+			}
+		},
+	],
 
 	suffix: "ex",
 	illustrator: "Saki Hayashiro",
 
-	thirdParty: {
-		cardmarket: 733635
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/151/041.ts
+++ b/data/Scarlet & Violet/151/041.ts
@@ -62,18 +62,26 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "normal"
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 733636,
+				tcgplayer: 516150,
+				cardtrader: 261160
+			}
 		},
 		{
-			type: "reverse"
-		}
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 733636,
+				tcgplayer: 516150,
+				cardtrader: 261160
+			}
+		},
 	],
 
 	illustrator: "Scav",
 
-	thirdParty: {
-		cardmarket: 733673
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/151/042.ts
+++ b/data/Scarlet & Violet/151/042.ts
@@ -55,18 +55,26 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "normal"
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 733637,
+				tcgplayer: 516152,
+				cardtrader: 261179
+			}
 		},
 		{
-			type: "reverse"
-		}
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 733637,
+				tcgplayer: 516152,
+				cardtrader: 261179
+			}
+		},
 	],
 
 	illustrator: "Scav",
 
-	thirdParty: {
-		cardmarket: 733637
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/151/043.ts
+++ b/data/Scarlet & Violet/151/043.ts
@@ -40,18 +40,26 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "normal"
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 733638,
+				tcgplayer: 516156,
+				cardtrader: 261136
+			}
 		},
 		{
-			type: "reverse"
-		}
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 733638,
+				tcgplayer: 516156,
+				cardtrader: 261136
+			}
+		},
 	],
 
 	illustrator: "Sekio",
 
-	thirdParty: {
-		cardmarket: 733638
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/151/044.ts
+++ b/data/Scarlet & Violet/151/044.ts
@@ -70,18 +70,26 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "normal"
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 733639,
+				tcgplayer: 516157,
+				cardtrader: 261178
+			}
 		},
 		{
-			type: "reverse"
-		}
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 733639,
+				tcgplayer: 516157,
+				cardtrader: 261178
+			}
+		},
 	],
 
 	illustrator: "Sekio",
 
-	thirdParty: {
-		cardmarket: 733639
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/151/045.ts
+++ b/data/Scarlet & Violet/151/045.ts
@@ -70,18 +70,26 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "holo"
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 733640,
+				tcgplayer: 516159,
+				cardtrader: 261623
+			}
 		},
 		{
-			type: "reverse"
-		}
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 733640,
+				tcgplayer: 516159,
+				cardtrader: 261623
+			}
+		},
 	],
 
 	illustrator: "Sekio",
 
-	thirdParty: {
-		cardmarket: 733640
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/151/046.ts
+++ b/data/Scarlet & Violet/151/046.ts
@@ -62,18 +62,26 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "normal"
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 733641,
+				tcgplayer: 516163,
+				cardtrader: 261137
+			}
 		},
 		{
-			type: "reverse"
-		}
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 733641,
+				tcgplayer: 516163,
+				cardtrader: 261137
+			}
+		},
 	],
 
 	illustrator: "Yoriyuki Ikegami",
 
-	thirdParty: {
-		cardmarket: 733753
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/151/047.ts
+++ b/data/Scarlet & Violet/151/047.ts
@@ -68,18 +68,26 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "normal"
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 733642,
+				tcgplayer: 516170,
+				cardtrader: 261202
+			}
 		},
 		{
-			type: "reverse"
-		}
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 733642,
+				tcgplayer: 516170,
+				cardtrader: 261202
+			}
+		},
 	],
 
 	illustrator: "Yoriyuki Ikegami",
 
-	thirdParty: {
-		cardmarket: 733642
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/151/048.ts
+++ b/data/Scarlet & Violet/151/048.ts
@@ -53,18 +53,26 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "normal"
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 733643,
+				tcgplayer: 516206,
+				cardtrader: 261155
+			}
 		},
 		{
-			type: "reverse"
-		}
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 733643,
+				tcgplayer: 516206,
+				cardtrader: 261155
+			}
+		},
 	],
 
 	illustrator: "Kagemaru Himeno",
 
-	thirdParty: {
-		cardmarket: 733643
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/151/049.ts
+++ b/data/Scarlet & Violet/151/049.ts
@@ -70,18 +70,26 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "normal"
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 733644,
+				tcgplayer: 516213,
+				cardtrader: 261222
+			}
 		},
 		{
-			type: "reverse"
-		}
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 733644,
+				tcgplayer: 516213,
+				cardtrader: 261222
+			}
+		},
 	],
 
 	illustrator: "Kagemaru Himeno",
 
-	thirdParty: {
-		cardmarket: 733723
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/151/050.ts
+++ b/data/Scarlet & Violet/151/050.ts
@@ -53,18 +53,26 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "normal"
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 733645,
+				tcgplayer: 516215,
+				cardtrader: 261108
+			}
 		},
 		{
-			type: "reverse"
-		}
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 733645,
+				tcgplayer: 516215,
+				cardtrader: 261108
+			}
+		},
 	],
 
 	illustrator: "Miki Tanaka",
 
-	thirdParty: {
-		cardmarket: 733722
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/151/051.ts
+++ b/data/Scarlet & Violet/151/051.ts
@@ -61,18 +61,26 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "normal"
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 733646,
+				tcgplayer: 516216,
+				cardtrader: 261171
+			}
 		},
 		{
-			type: "reverse"
-		}
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 733646,
+				tcgplayer: 516216,
+				cardtrader: 261171
+			}
+		},
 	],
 
 	illustrator: "Miki Tanaka",
 
-	thirdParty: {
-		cardmarket: 733646
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/151/052.ts
+++ b/data/Scarlet & Violet/151/052.ts
@@ -60,18 +60,26 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "normal"
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 733647,
+				tcgplayer: 516221,
+				cardtrader: 261133
+			}
 		},
 		{
-			type: "reverse"
-		}
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 733647,
+				tcgplayer: 516221,
+				cardtrader: 261133
+			}
+		},
 	],
 
 	illustrator: "Naoki Saito",
 
-	thirdParty: {
-		cardmarket: 733758
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/151/053.ts
+++ b/data/Scarlet & Violet/151/053.ts
@@ -70,18 +70,26 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "normal"
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 733648,
+				tcgplayer: 516223,
+				cardtrader: 261203
+			}
 		},
 		{
-			type: "reverse"
-		}
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 733648,
+				tcgplayer: 516223,
+				cardtrader: 261203
+			}
+		},
 	],
 
 	illustrator: "Naoki Saito",
 
-	thirdParty: {
-		cardmarket: 733712
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/151/054.ts
+++ b/data/Scarlet & Violet/151/054.ts
@@ -60,18 +60,26 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "normal"
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 733649,
+				tcgplayer: 516231,
+				cardtrader: 261144
+			}
 		},
 		{
-			type: "reverse"
-		}
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 733649,
+				tcgplayer: 516231,
+				cardtrader: 261144
+			}
+		},
 	],
 
 	illustrator: "Taira Akitsu",
 
-	thirdParty: {
-		cardmarket: 733649
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/151/055.ts
+++ b/data/Scarlet & Violet/151/055.ts
@@ -68,18 +68,26 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "normal"
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 733650,
+				tcgplayer: 516232,
+				cardtrader: 261180
+			}
 		},
 		{
-			type: "reverse"
-		}
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 733650,
+				tcgplayer: 516232,
+				cardtrader: 261180
+			}
+		},
 	],
 
 	illustrator: "Taira Akitsu",
 
-	thirdParty: {
-		cardmarket: 733639
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/151/056.ts
+++ b/data/Scarlet & Violet/151/056.ts
@@ -49,18 +49,26 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "normal"
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 733651,
+				tcgplayer: 516242,
+				cardtrader: 261132
+			}
 		},
 		{
-			type: "reverse"
-		}
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 733651,
+				tcgplayer: 516242,
+				cardtrader: 261132
+			}
+		},
 	],
 
 	illustrator: "Mina Nakai",
 
-	thirdParty: {
-		cardmarket: 733651
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/151/057.ts
+++ b/data/Scarlet & Violet/151/057.ts
@@ -79,18 +79,26 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "normal"
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 733652,
+				tcgplayer: 516246,
+				cardtrader: 261208
+			}
 		},
 		{
-			type: "reverse"
-		}
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 733652,
+				tcgplayer: 516246,
+				cardtrader: 261208
+			}
+		},
 	],
 
 	illustrator: "Mina Nakai",
 
-	thirdParty: {
-		cardmarket: 733652
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/151/058.ts
+++ b/data/Scarlet & Violet/151/058.ts
@@ -49,18 +49,26 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "normal"
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 733653,
+				tcgplayer: 516247,
+				cardtrader: 261122
+			}
 		},
 		{
-			type: "reverse"
-		}
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 733653,
+				tcgplayer: 516247,
+				cardtrader: 261122
+			}
+		},
 	],
 
 	illustrator: "Atsushi Furusawa",
 
-	thirdParty: {
-		cardmarket: 733653
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/151/059.ts
+++ b/data/Scarlet & Violet/151/059.ts
@@ -79,18 +79,26 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "normal"
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 733654,
+				tcgplayer: 516248,
+				cardtrader: 261061
+			}
 		},
 		{
-			type: "reverse"
-		}
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 733654,
+				tcgplayer: 516248,
+				cardtrader: 261061
+			}
+		},
 	],
 
 	illustrator: "Atsushi Furusawa",
 
-	thirdParty: {
-		cardmarket: 733654
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/151/060.ts
+++ b/data/Scarlet & Violet/151/060.ts
@@ -49,18 +49,26 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "normal"
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 733655,
+				tcgplayer: 516249,
+				cardtrader: 261141
+			}
 		},
 		{
-			type: "reverse"
-		}
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 733655,
+				tcgplayer: 516249,
+				cardtrader: 261141
+			}
+		},
 	],
 
 	illustrator: "Kurata So",
 
-	thirdParty: {
-		cardmarket: 733655
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/151/061.ts
+++ b/data/Scarlet & Violet/151/061.ts
@@ -70,18 +70,26 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "normal"
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 733656,
+				tcgplayer: 516250,
+				cardtrader: 261206
+			}
 		},
 		{
-			type: "reverse"
-		}
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 733656,
+				tcgplayer: 516250,
+				cardtrader: 261206
+			}
+		},
 	],
 
 	illustrator: "Kurata So",
 
-	thirdParty: {
-		cardmarket: 733656
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/151/062.ts
+++ b/data/Scarlet & Violet/151/062.ts
@@ -79,18 +79,26 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "normal"
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 733657,
+				tcgplayer: 516251,
+				cardtrader: 261207
+			}
 		},
 		{
-			type: "reverse"
-		}
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 733657,
+				tcgplayer: 516251,
+				cardtrader: 261207
+			}
+		},
 	],
 
 	illustrator: "Kurata So",
 
-	thirdParty: {
-		cardmarket: 733657
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/151/063.ts
+++ b/data/Scarlet & Violet/151/063.ts
@@ -40,18 +40,26 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "normal"
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 733658,
+				tcgplayer: 516268,
+				cardtrader: 261058
+			}
 		},
 		{
-			type: "reverse"
-		}
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 733658,
+				tcgplayer: 516268,
+				cardtrader: 261058
+			}
+		},
 	],
 
 	illustrator: "Mitsuhiro Arita",
 
-	thirdParty: {
-		cardmarket: 733658
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/151/064.ts
+++ b/data/Scarlet & Violet/151/064.ts
@@ -57,18 +57,26 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "normal"
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 733659,
+				tcgplayer: 516269,
+				cardtrader: 261188
+			}
 		},
 		{
-			type: "reverse"
-		}
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 733659,
+				tcgplayer: 516269,
+				cardtrader: 261188
+			}
+		},
 	],
 
 	illustrator: "Mitsuhiro Arita",
 
-	thirdParty: {
-		cardmarket: 733659
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/151/065.ts
+++ b/data/Scarlet & Violet/151/065.ts
@@ -77,17 +77,21 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 733660,
+				tcgplayer: 516381,
+				cardtrader: 261070
+			}
+		},
+	],
 
 	suffix: "ex",
 	illustrator: "Mitsuhiro Arita",
 
-	thirdParty: {
-		cardmarket: 733660
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/151/066.ts
+++ b/data/Scarlet & Violet/151/066.ts
@@ -60,18 +60,26 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "normal"
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 733661,
+				tcgplayer: 516382,
+				cardtrader: 261129
+			}
 		},
 		{
-			type: "reverse"
-		}
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 733661,
+				tcgplayer: 516382,
+				cardtrader: 261129
+			}
+		},
 	],
 
 	illustrator: "Ryuta Fuse",
 
-	thirdParty: {
-		cardmarket: 733661
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/151/067.ts
+++ b/data/Scarlet & Violet/151/067.ts
@@ -57,18 +57,26 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "normal"
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 733662,
+				tcgplayer: 516383,
+				cardtrader: 261192
+			}
 		},
 		{
-			type: "reverse"
-		}
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 733662,
+				tcgplayer: 516383,
+				cardtrader: 261192
+			}
+		},
 	],
 
 	illustrator: "Ryuta Fuse",
 
-	thirdParty: {
-		cardmarket: 733662
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/151/068.ts
+++ b/data/Scarlet & Violet/151/068.ts
@@ -79,18 +79,33 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "holo"
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 733663,
+				tcgplayer: 516385,
+				cardtrader: 261239
+			}
 		},
 		{
-			type: "reverse"
-		}
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 733663,
+				tcgplayer: 516385,
+				cardtrader: 261239
+			}
+		},
+		{
+			type: 'holo',
+			foil: 'cosmos',
+			thirdParty: {
+				cardmarket: 864951
+			}
+		},
 	],
 
 	illustrator: "Ryuta Fuse",
 
-	thirdParty: {
-		cardmarket: 733663
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/151/069.ts
+++ b/data/Scarlet & Violet/151/069.ts
@@ -62,18 +62,26 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "normal"
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 733664,
+				tcgplayer: 516560,
+				cardtrader: 261063
+			}
 		},
 		{
-			type: "reverse"
-		}
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 733664,
+				tcgplayer: 516560,
+				cardtrader: 261063
+			}
+		},
 	],
 
 	illustrator: "Jerky",
 
-	thirdParty: {
-		cardmarket: 733664
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/151/070.ts
+++ b/data/Scarlet & Violet/151/070.ts
@@ -61,18 +61,26 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "normal"
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 733665,
+				tcgplayer: 516563,
+				cardtrader: 261159
+			}
 		},
 		{
-			type: "reverse"
-		}
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 733665,
+				tcgplayer: 516563,
+				cardtrader: 261159
+			}
+		},
 	],
 
 	illustrator: "Jerky",
 
-	thirdParty: {
-		cardmarket: 733665
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/151/071.ts
+++ b/data/Scarlet & Violet/151/071.ts
@@ -70,18 +70,26 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "normal"
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 733666,
+				tcgplayer: 516564,
+				cardtrader: 261223
+			}
 		},
 		{
-			type: "reverse"
-		}
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 733666,
+				tcgplayer: 516564,
+				cardtrader: 261223
+			}
+		},
 	],
 
 	illustrator: "Jerky",
 
-	thirdParty: {
-		cardmarket: 733650
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/151/072.ts
+++ b/data/Scarlet & Violet/151/072.ts
@@ -53,18 +53,26 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "normal"
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 733667,
+				tcgplayer: 516565,
+				cardtrader: 261154
+			}
 		},
 		{
-			type: "reverse"
-		}
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 733667,
+				tcgplayer: 516565,
+				cardtrader: 261154
+			}
+		},
 	],
 
 	illustrator: "miki kudo",
 
-	thirdParty: {
-		cardmarket: 733733
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/151/073.ts
+++ b/data/Scarlet & Violet/151/073.ts
@@ -79,18 +79,26 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "normal"
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 733668,
+				tcgplayer: 516567,
+				cardtrader: 261221
+			}
 		},
 		{
-			type: "reverse"
-		}
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 733668,
+				tcgplayer: 516567,
+				cardtrader: 261221
+			}
+		},
 	],
 
 	illustrator: "miki kudo",
 
-	thirdParty: {
-		cardmarket: 733668
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/151/074.ts
+++ b/data/Scarlet & Violet/151/074.ts
@@ -60,18 +60,26 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "normal"
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 733669,
+				tcgplayer: 516569,
+				cardtrader: 261119
+			}
 		},
 		{
-			type: "reverse"
-		}
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 733669,
+				tcgplayer: 516569,
+				cardtrader: 261119
+			}
+		},
 	],
 
 	illustrator: "Uta",
 
-	thirdParty: {
-		cardmarket: 733669
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/151/075.ts
+++ b/data/Scarlet & Violet/151/075.ts
@@ -70,18 +70,26 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "normal"
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 733670,
+				tcgplayer: 516572,
+				cardtrader: 261181
+			}
 		},
 		{
-			type: "reverse"
-		}
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 733670,
+				tcgplayer: 516572,
+				cardtrader: 261181
+			}
+		},
 	],
 
 	illustrator: "Uta",
 
-	thirdParty: {
-		cardmarket: 733670
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/151/076.ts
+++ b/data/Scarlet & Violet/151/076.ts
@@ -77,17 +77,21 @@ const card: Card = {
 	retreat: 4,
 	regulationMark: "G",
 
-	variants: {
-		reverse: false,
-		normal: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 733671,
+				tcgplayer: 516574,
+				cardtrader: 261071
+			}
+		},
+	],
 
 	suffix: "ex",
 	illustrator: "Uta",
 
-	thirdParty: {
-		cardmarket: 733671
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/151/077.ts
+++ b/data/Scarlet & Violet/151/077.ts
@@ -60,18 +60,26 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "normal"
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 733672,
+				tcgplayer: 516601,
+				cardtrader: 261142
+			}
 		},
 		{
-			type: "reverse"
-		}
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 733672,
+				tcgplayer: 516601,
+				cardtrader: 261142
+			}
+		},
 	],
 
 	illustrator: "Nurikabe",
 
-	thirdParty: {
-		cardmarket: 733672
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/151/078.ts
+++ b/data/Scarlet & Violet/151/078.ts
@@ -77,18 +77,26 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "normal"
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 733673,
+				tcgplayer: 516607,
+				cardtrader: 261211
+			}
 		},
 		{
-			type: "reverse"
-		}
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 733673,
+				tcgplayer: 516607,
+				cardtrader: 261211
+			}
+		},
 	],
 
 	illustrator: "Nurikabe",
 
-	thirdParty: {
-		cardmarket: 733673
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/151/079.ts
+++ b/data/Scarlet & Violet/151/079.ts
@@ -60,18 +60,26 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "normal"
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 733674,
+				tcgplayer: 516650,
+				cardtrader: 261149
+			}
 		},
 		{
-			type: "reverse"
-		}
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 733674,
+				tcgplayer: 516650,
+				cardtrader: 261149
+			}
+		},
 	],
 
 	illustrator: "OKACHEKE",
 
-	thirdParty: {
-		cardmarket: 733674
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/151/080.ts
+++ b/data/Scarlet & Violet/151/080.ts
@@ -77,18 +77,26 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "normal"
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 733675,
+				tcgplayer: 516651,
+				cardtrader: 261218
+			}
 		},
 		{
-			type: "reverse"
-		}
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 733675,
+				tcgplayer: 516651,
+				cardtrader: 261218
+			}
+		},
 	],
 
 	illustrator: "OKACHEKE",
 
-	thirdParty: {
-		cardmarket: 733675
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/151/081.ts
+++ b/data/Scarlet & Violet/151/081.ts
@@ -62,18 +62,26 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "normal"
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 733676,
+				tcgplayer: 516648,
+				cardtrader: 261193
+			}
 		},
 		{
-			type: "reverse"
-		}
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 733676,
+				tcgplayer: 516648,
+				cardtrader: 261193
+			}
+		},
 	],
 
 	illustrator: "Yuka Morii",
 
-	thirdParty: {
-		cardmarket: 733676
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/151/082.ts
+++ b/data/Scarlet & Violet/151/082.ts
@@ -68,18 +68,26 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "normal"
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 733677,
+				tcgplayer: 516649,
+				cardtrader: 261194
+			}
 		},
 		{
-			type: "reverse"
-		}
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 733677,
+				tcgplayer: 516649,
+				cardtrader: 261194
+			}
+		},
 	],
 
 	illustrator: "Yuka Morii",
 
-	thirdParty: {
-		cardmarket: 733677
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/151/083.ts
+++ b/data/Scarlet & Violet/151/083.ts
@@ -60,18 +60,26 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "normal"
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 733678,
+				tcgplayer: 516652,
+				cardtrader: 261117
+			}
 		},
 		{
-			type: "reverse"
-		}
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 733678,
+				tcgplayer: 516652,
+				cardtrader: 261117
+			}
+		},
 	],
 
 	illustrator: "KG-2000",
 
-	thirdParty: {
-		cardmarket: 733678
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/151/084.ts
+++ b/data/Scarlet & Violet/151/084.ts
@@ -49,18 +49,26 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "normal"
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 733679,
+				tcgplayer: 516653,
+				cardtrader: 261109
+			}
 		},
 		{
-			type: "reverse"
-		}
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 733679,
+				tcgplayer: 516653,
+				cardtrader: 261109
+			}
+		},
 	],
 
 	illustrator: "Anesaki Dynamic",
 
-	thirdParty: {
-		cardmarket: 733702
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/151/085.ts
+++ b/data/Scarlet & Violet/151/085.ts
@@ -79,18 +79,26 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "holo"
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 733680,
+				tcgplayer: 516654,
+				cardtrader: 261227
+			}
 		},
 		{
-			type: "reverse"
-		}
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 733680,
+				tcgplayer: 516654,
+				cardtrader: 261227
+			}
+		},
 	],
 
 	illustrator: "Anesaki Dynamic",
 
-	thirdParty: {
-		cardmarket: 733680
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/151/086.ts
+++ b/data/Scarlet & Violet/151/086.ts
@@ -40,18 +40,26 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "normal"
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 733681,
+				tcgplayer: 516655,
+				cardtrader: 261147
+			}
 		},
 		{
-			type: "reverse"
-		}
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 733681,
+				tcgplayer: 516655,
+				cardtrader: 261147
+			}
+		},
 	],
 
 	illustrator: "aoki",
 
-	thirdParty: {
-		cardmarket: 733681
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/151/087.ts
+++ b/data/Scarlet & Violet/151/087.ts
@@ -68,18 +68,26 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "normal"
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 733682,
+				tcgplayer: 516656,
+				cardtrader: 261169
+			}
 		},
 		{
-			type: "reverse"
-		}
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 733682,
+				tcgplayer: 516656,
+				cardtrader: 261169
+			}
+		},
 	],
 
 	illustrator: "aoki",
 
-	thirdParty: {
-		cardmarket: 733682
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/151/088.ts
+++ b/data/Scarlet & Violet/151/088.ts
@@ -49,18 +49,26 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "normal"
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 733683,
+				tcgplayer: 516657,
+				cardtrader: 261121
+			}
 		},
 		{
-			type: "reverse"
-		}
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 733683,
+				tcgplayer: 516657,
+				cardtrader: 261121
+			}
+		},
 	],
 
 	illustrator: "Nisota Niso",
 
-	thirdParty: {
-		cardmarket: 733683
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/151/089.ts
+++ b/data/Scarlet & Violet/151/089.ts
@@ -70,18 +70,26 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "normal"
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 733684,
+				tcgplayer: 516658,
+				cardtrader: 261196
+			}
 		},
 		{
-			type: "reverse"
-		}
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 733684,
+				tcgplayer: 516658,
+				cardtrader: 261196
+			}
+		},
 	],
 
 	illustrator: "Nisota Niso",
 
-	thirdParty: {
-		cardmarket: 733684
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/151/090.ts
+++ b/data/Scarlet & Violet/151/090.ts
@@ -49,18 +49,26 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "normal"
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 733685,
+				tcgplayer: 516659,
+				cardtrader: 261148
+			}
 		},
 		{
-			type: "reverse"
-		}
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 733685,
+				tcgplayer: 516659,
+				cardtrader: 261148
+			}
+		},
 	],
 
 	illustrator: "Nelnal",
 
-	thirdParty: {
-		cardmarket: 733607
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/151/091.ts
+++ b/data/Scarlet & Violet/151/091.ts
@@ -57,18 +57,26 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "normal"
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 733686,
+				tcgplayer: 516660,
+				cardtrader: 261163
+			}
 		},
 		{
-			type: "reverse"
-		}
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 733686,
+				tcgplayer: 516660,
+				cardtrader: 261163
+			}
+		},
 	],
 
 	illustrator: "Nelnal",
 
-	thirdParty: {
-		cardmarket: 733686
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/151/092.ts
+++ b/data/Scarlet & Violet/151/092.ts
@@ -40,18 +40,26 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "normal"
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 733687,
+				tcgplayer: 516661,
+				cardtrader: 261118
+			}
 		},
 		{
-			type: "reverse"
-		}
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 733687,
+				tcgplayer: 516661,
+				cardtrader: 261118
+			}
+		},
 	],
 
 	illustrator: "Tomokazu Komiya",
 
-	thirdParty: {
-		cardmarket: 733687
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/151/093.ts
+++ b/data/Scarlet & Violet/151/093.ts
@@ -70,18 +70,26 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "normal"
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 733688,
+				tcgplayer: 516662,
+				cardtrader: 261182
+			}
 		},
 		{
-			type: "reverse"
-		}
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 733688,
+				tcgplayer: 516662,
+				cardtrader: 261182
+			}
+		},
 	],
 
 	illustrator: "Tomokazu Komiya",
 
-	thirdParty: {
-		cardmarket: 733688
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/151/094.ts
+++ b/data/Scarlet & Violet/151/094.ts
@@ -79,18 +79,33 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "holo"
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 733689,
+				tcgplayer: 516663,
+				cardtrader: 261231
+			}
 		},
 		{
-			type: "reverse"
-		}
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 733689,
+				tcgplayer: 516663,
+				cardtrader: 261231
+			}
+		},
+		{
+			type: 'holo',
+			foil: 'galaxy',
+			thirdParty: {
+				cardmarket: 861151
+			}
+		},
 	],
 
 	illustrator: "Tomokazu Komiya",
 
-	thirdParty: {
-		cardmarket: 733689
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/151/095.ts
+++ b/data/Scarlet & Violet/151/095.ts
@@ -62,18 +62,26 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "normal"
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 733690,
+				tcgplayer: 516664,
+				cardtrader: 261201
+			}
 		},
 		{
-			type: "reverse"
-		}
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 733690,
+				tcgplayer: 516664,
+				cardtrader: 261201
+			}
+		},
 	],
 
 	illustrator: "Shin Nagasawa",
 
-	thirdParty: {
-		cardmarket: 733690
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/151/096.ts
+++ b/data/Scarlet & Violet/151/096.ts
@@ -40,18 +40,26 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "normal"
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 733691,
+				tcgplayer: 516665,
+				cardtrader: 261111
+			}
 		},
 		{
-			type: "reverse"
-		}
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 733691,
+				tcgplayer: 516665,
+				cardtrader: 261111
+			}
+		},
 	],
 
 	illustrator: "Mousho",
 
-	thirdParty: {
-		cardmarket: 733750
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/151/097.ts
+++ b/data/Scarlet & Violet/151/097.ts
@@ -70,18 +70,26 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "normal"
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 733692,
+				tcgplayer: 516666,
+				cardtrader: 261185
+			}
 		},
 		{
-			type: "reverse"
-		}
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 733692,
+				tcgplayer: 516666,
+				cardtrader: 261185
+			}
+		},
 	],
 
 	illustrator: "Mousho",
 
-	thirdParty: {
-		cardmarket: 733692
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/151/098.ts
+++ b/data/Scarlet & Violet/151/098.ts
@@ -60,18 +60,26 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "normal"
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 733693,
+				tcgplayer: 516667,
+				cardtrader: 261127
+			}
 		},
 		{
-			type: "reverse"
-		}
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 733693,
+				tcgplayer: 516667,
+				cardtrader: 261127
+			}
+		},
 	],
 
 	illustrator: "Yukiko Baba",
 
-	thirdParty: {
-		cardmarket: 733693
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/151/099.ts
+++ b/data/Scarlet & Violet/151/099.ts
@@ -70,18 +70,26 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "normal"
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 733694,
+				tcgplayer: 516668,
+				cardtrader: 261189
+			}
 		},
 		{
-			type: "reverse"
-		}
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 733694,
+				tcgplayer: 516668,
+				cardtrader: 261189
+			}
+		},
 	],
 
 	illustrator: "Yukiko Baba",
 
-	thirdParty: {
-		cardmarket: 733726
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/151/100.ts
+++ b/data/Scarlet & Violet/151/100.ts
@@ -49,18 +49,26 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "normal"
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 733695,
+				tcgplayer: 516669,
+				cardtrader: 261156
+			}
 		},
 		{
-			type: "reverse"
-		}
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 733695,
+				tcgplayer: 516669,
+				cardtrader: 261156
+			}
+		},
 	],
 
 	illustrator: "nagimiso",
 
-	thirdParty: {
-		cardmarket: 733718
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/151/101.ts
+++ b/data/Scarlet & Violet/151/101.ts
@@ -70,18 +70,26 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "holo"
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 733696,
+				tcgplayer: 516670,
+				cardtrader: 261229
+			}
 		},
 		{
-			type: "reverse"
-		}
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 733696,
+				tcgplayer: 516670,
+				cardtrader: 261229
+			}
+		},
 	],
 
 	illustrator: "nagimiso",
 
-	thirdParty: {
-		cardmarket: 733696
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/151/102.ts
+++ b/data/Scarlet & Violet/151/102.ts
@@ -49,18 +49,26 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "normal"
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 733697,
+				tcgplayer: 516671,
+				cardtrader: 261116
+			}
 		},
 		{
-			type: "reverse"
-		}
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 733697,
+				tcgplayer: 516671,
+				cardtrader: 261116
+			}
+		},
 	],
 
 	illustrator: "Shigenori Negishi",
 
-	thirdParty: {
-		cardmarket: 733697
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/151/103.ts
+++ b/data/Scarlet & Violet/151/103.ts
@@ -70,18 +70,26 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "normal"
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 733698,
+				tcgplayer: 516672,
+				cardtrader: 261176
+			}
 		},
 		{
-			type: "reverse"
-		}
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 733698,
+				tcgplayer: 516672,
+				cardtrader: 261176
+			}
+		},
 	],
 
 	illustrator: "Shigenori Negishi",
 
-	thirdParty: {
-		cardmarket: 733684
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/151/104.ts
+++ b/data/Scarlet & Violet/151/104.ts
@@ -71,18 +71,26 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "normal"
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 733699,
+				tcgplayer: 516673,
+				cardtrader: 261628
+			}
 		},
 		{
-			type: "reverse"
-		}
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 733699,
+				tcgplayer: 516673,
+				cardtrader: 261628
+			}
+		},
 	],
 
 	illustrator: "Shinya Komatsu",
 
-	thirdParty: {
-		cardmarket: 733699
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/151/105.ts
+++ b/data/Scarlet & Violet/151/105.ts
@@ -79,18 +79,26 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "holo"
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 733700,
+				tcgplayer: 516674,
+				cardtrader: 261240
+			}
 		},
 		{
-			type: "reverse"
-		}
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 733700,
+				tcgplayer: 516674,
+				cardtrader: 261240
+			}
+		},
 	],
 
 	illustrator: "Shinya Komatsu",
 
-	thirdParty: {
-		cardmarket: 733700
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/151/106.ts
+++ b/data/Scarlet & Violet/151/106.ts
@@ -60,18 +60,26 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "normal"
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 733701,
+				tcgplayer: 516675,
+				cardtrader: 261184
+			}
 		},
 		{
-			type: "reverse"
-		}
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 733701,
+				tcgplayer: 516675,
+				cardtrader: 261184
+			}
+		},
 	],
 
 	illustrator: "Hitoshi Ariga",
 
-	thirdParty: {
-		cardmarket: 733701
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/151/107.ts
+++ b/data/Scarlet & Violet/151/107.ts
@@ -71,18 +71,26 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "normal"
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 733702,
+				tcgplayer: 516676,
+				cardtrader: 261183
+			}
 		},
 		{
-			type: "reverse"
-		}
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 733702,
+				tcgplayer: 516676,
+				cardtrader: 261183
+			}
+		},
 	],
 
 	illustrator: "DOM",
 
-	thirdParty: {
-		cardmarket: 733702
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/151/108.ts
+++ b/data/Scarlet & Violet/151/108.ts
@@ -49,18 +49,26 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "normal"
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 733703,
+				tcgplayer: 516677,
+				cardtrader: 261128
+			}
 		},
 		{
-			type: "reverse"
-		}
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 733703,
+				tcgplayer: 516677,
+				cardtrader: 261128
+			}
+		},
 	],
 
 	illustrator: "Saya Tsuruta",
 
-	thirdParty: {
-		cardmarket: 733703
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/151/109.ts
+++ b/data/Scarlet & Violet/151/109.ts
@@ -49,18 +49,26 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "normal"
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 733704,
+				tcgplayer: 516679,
+				cardtrader: 261126
+			}
 		},
 		{
-			type: "reverse"
-		}
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 733704,
+				tcgplayer: 516679,
+				cardtrader: 261126
+			}
+		},
 	],
 
 	illustrator: "Shibuzoh.",
 
-	thirdParty: {
-		cardmarket: 733654
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/151/110.ts
+++ b/data/Scarlet & Violet/151/110.ts
@@ -79,18 +79,26 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "holo"
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 733705,
+				tcgplayer: 516680,
+				cardtrader: 261243
+			}
 		},
 		{
-			type: "reverse"
-		}
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 733705,
+				tcgplayer: 516680,
+				cardtrader: 261243
+			}
+		},
 	],
 
 	illustrator: "Shibuzoh.",
 
-	thirdParty: {
-		cardmarket: 733705
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/151/111.ts
+++ b/data/Scarlet & Violet/151/111.ts
@@ -62,18 +62,26 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "normal"
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 733706,
+				tcgplayer: 516570,
+				cardtrader: 261146
+			}
 		},
 		{
-			type: "reverse"
-		}
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 733706,
+				tcgplayer: 516570,
+				cardtrader: 261146
+			}
+		},
 	],
 
 	illustrator: "GOSSAN",
 
-	thirdParty: {
-		cardmarket: 733706
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/151/112.ts
+++ b/data/Scarlet & Violet/151/112.ts
@@ -70,18 +70,26 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "normal"
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 733707,
+				tcgplayer: 516573,
+				cardtrader: 261213
+			}
 		},
 		{
-			type: "reverse"
-		}
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 733707,
+				tcgplayer: 516573,
+				cardtrader: 261213
+			}
+		},
 	],
 
 	illustrator: "GOSSAN",
 
-	thirdParty: {
-		cardmarket: 733707
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/151/113.ts
+++ b/data/Scarlet & Violet/151/113.ts
@@ -62,18 +62,26 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "holo"
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 733708,
+				tcgplayer: 516575,
+				cardtrader: 261068
+			}
 		},
 		{
-			type: "reverse"
-		}
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 733708,
+				tcgplayer: 516575,
+				cardtrader: 261068
+			}
+		},
 	],
 
 	illustrator: "Taiga Kayama",
 
-	thirdParty: {
-		cardmarket: 733708
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/151/114.ts
+++ b/data/Scarlet & Violet/151/114.ts
@@ -49,18 +49,26 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "normal"
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 733709,
+				tcgplayer: 516579,
+				cardtrader: 261153
+			}
 		},
 		{
-			type: "reverse"
-		}
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 733709,
+				tcgplayer: 516579,
+				cardtrader: 261153
+			}
+		},
 	],
 
 	illustrator: "Aya Kusube",
 
-	thirdParty: {
-		cardmarket: 733709
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/151/115.ts
+++ b/data/Scarlet & Violet/151/115.ts
@@ -67,17 +67,21 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "G",
 
-	variants: {
-		reverse: false,
-		normal: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 733710,
+				tcgplayer: 516581,
+				cardtrader: 261073
+			}
+		},
+	],
 
 	suffix: "ex",
 	illustrator: "N-DESIGN Inc.",
 
-	thirdParty: {
-		cardmarket: 733710
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/151/116.ts
+++ b/data/Scarlet & Violet/151/116.ts
@@ -53,18 +53,26 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "normal"
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 733711,
+				tcgplayer: 516583,
+				cardtrader: 261123
+			}
 		},
 		{
-			type: "reverse"
-		}
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 733711,
+				tcgplayer: 516583,
+				cardtrader: 261123
+			}
+		},
 	],
 
 	illustrator: "aspara",
 
-	thirdParty: {
-		cardmarket: 733759
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/151/117.ts
+++ b/data/Scarlet & Violet/151/117.ts
@@ -57,18 +57,26 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "normal"
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 733712,
+				tcgplayer: 516584,
+				cardtrader: 261216
+			}
 		},
 		{
-			type: "reverse"
-		}
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 733712,
+				tcgplayer: 516584,
+				cardtrader: 261216
+			}
+		},
 	],
 
 	illustrator: "aspara",
 
-	thirdParty: {
-		cardmarket: 733712
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/151/118.ts
+++ b/data/Scarlet & Violet/151/118.ts
@@ -62,18 +62,26 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "normal"
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 733713,
+				tcgplayer: 516681,
+				cardtrader: 261120
+			}
 		},
 		{
-			type: "reverse"
-		}
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 733713,
+				tcgplayer: 516681,
+				cardtrader: 261120
+			}
+		},
 	],
 
 	illustrator: "SIE NANAHARA",
 
-	thirdParty: {
-		cardmarket: 733694
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/151/119.ts
+++ b/data/Scarlet & Violet/151/119.ts
@@ -79,18 +79,26 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "normal"
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 733714,
+				tcgplayer: 516682,
+				cardtrader: 261217
+			}
 		},
 		{
-			type: "reverse"
-		}
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 733714,
+				tcgplayer: 516682,
+				cardtrader: 261217
+			}
+		},
 	],
 
 	illustrator: "SIE NANAHARA",
 
-	thirdParty: {
-		cardmarket: 733714
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/151/120.ts
+++ b/data/Scarlet & Violet/151/120.ts
@@ -49,18 +49,26 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "normal"
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 733715,
+				tcgplayer: 516683,
+				cardtrader: 261152
+			}
 		},
 		{
-			type: "reverse"
-		}
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 733715,
+				tcgplayer: 516683,
+				cardtrader: 261152
+			}
+		},
 	],
 
 	illustrator: "Arai Kiriko",
 
-	thirdParty: {
-		cardmarket: 733715
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/151/121.ts
+++ b/data/Scarlet & Violet/151/121.ts
@@ -70,18 +70,26 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "holo"
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 733716,
+				tcgplayer: 516684,
+				cardtrader: 261622
+			}
 		},
 		{
-			type: "reverse"
-		}
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 733716,
+				tcgplayer: 516684,
+				cardtrader: 261622
+			}
+		},
 	],
 
 	illustrator: "Arai Kiriko",
 
-	thirdParty: {
-		cardmarket: 733716
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/151/122.ts
+++ b/data/Scarlet & Violet/151/122.ts
@@ -69,18 +69,26 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "holo"
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 733717,
+				tcgplayer: 516685,
+				cardtrader: 261241
+			}
 		},
 		{
-			type: "reverse"
-		}
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 733717,
+				tcgplayer: 516685,
+				cardtrader: 261241
+			}
+		},
 	],
 
 	illustrator: "OOYAMA",
 
-	thirdParty: {
-		cardmarket: 733717
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/151/123.ts
+++ b/data/Scarlet & Violet/151/123.ts
@@ -62,18 +62,26 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "normal"
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 733718,
+				tcgplayer: 516686,
+				cardtrader: 261215
+			}
 		},
 		{
-			type: "reverse"
-		}
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 733718,
+				tcgplayer: 516686,
+				cardtrader: 261215
+			}
+		},
 	],
 
 	illustrator: "Hideki Ishikawa",
 
-	thirdParty: {
-		cardmarket: 733666
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/151/124.ts
+++ b/data/Scarlet & Violet/151/124.ts
@@ -67,17 +67,21 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "G",
 
-	variants: {
-		reverse: false,
-		normal: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 733719,
+				tcgplayer: 516687,
+				cardtrader: 261072
+			}
+		},
+	],
 
 	suffix: "ex",
 	illustrator: "Ayaka Yoshida",
 
-	thirdParty: {
-		cardmarket: 733719
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/151/125.ts
+++ b/data/Scarlet & Violet/151/125.ts
@@ -62,18 +62,26 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "normal"
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 733720,
+				tcgplayer: 516688,
+				cardtrader: 261114
+			}
 		},
 		{
-			type: "reverse"
-		}
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 733720,
+				tcgplayer: 516688,
+				cardtrader: 261114
+			}
+		},
 	],
 
 	illustrator: "NC Empire",
 
-	thirdParty: {
-		cardmarket: 733720
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/151/126.ts
+++ b/data/Scarlet & Violet/151/126.ts
@@ -62,18 +62,26 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "normal"
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 733721,
+				tcgplayer: 516689,
+				cardtrader: 261131
+			}
 		},
 		{
-			type: "reverse"
-		}
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 733721,
+				tcgplayer: 516689,
+				cardtrader: 261131
+			}
+		},
 	],
 
 	illustrator: "Toshinao Aoki",
 
-	thirdParty: {
-		cardmarket: 733721
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/151/127.ts
+++ b/data/Scarlet & Violet/151/127.ts
@@ -62,18 +62,26 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "normal"
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 733722,
+				tcgplayer: 516690,
+				cardtrader: 261205
+			}
 		},
 		{
-			type: "reverse"
-		}
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 733722,
+				tcgplayer: 516690,
+				cardtrader: 261205
+			}
+		},
 	],
 
 	illustrator: "Yuya Oka",
 
-	thirdParty: {
-		cardmarket: 733722
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/151/128.ts
+++ b/data/Scarlet & Violet/151/128.ts
@@ -69,18 +69,26 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "normal"
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 733723,
+				tcgplayer: 516691,
+				cardtrader: 261220
+			}
 		},
 		{
-			type: "reverse"
-		}
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 733723,
+				tcgplayer: 516691,
+				cardtrader: 261220
+			}
+		},
 	],
 
 	illustrator: "Takeshi Nakamura",
 
-	thirdParty: {
-		cardmarket: 733723
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/151/129.ts
+++ b/data/Scarlet & Violet/151/129.ts
@@ -47,18 +47,26 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "normal"
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 733724,
+				tcgplayer: 516692,
+				cardtrader: 261130
+			}
 		},
 		{
-			type: "reverse"
-		}
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 733724,
+				tcgplayer: 516692,
+				cardtrader: 261130
+			}
+		},
 	],
 
 	illustrator: "Kouki Saitou",
 
-	thirdParty: {
-		cardmarket: 733724
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/151/130.ts
+++ b/data/Scarlet & Violet/151/130.ts
@@ -79,18 +79,26 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "holo"
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 733725,
+				tcgplayer: 516693,
+				cardtrader: 261232
+			}
 		},
 		{
-			type: "reverse"
-		}
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 733725,
+				tcgplayer: 516693,
+				cardtrader: 261232
+			}
+		},
 	],
 
 	illustrator: "Kouki Saitou",
 
-	thirdParty: {
-		cardmarket: 733725
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/151/131.ts
+++ b/data/Scarlet & Violet/151/131.ts
@@ -60,18 +60,26 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "normal"
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 733726,
+				tcgplayer: 516694,
+				cardtrader: 261190
+			}
 		},
 		{
-			type: "reverse"
-		}
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 733726,
+				tcgplayer: 516694,
+				cardtrader: 261190
+			}
+		},
 	],
 
 	illustrator: "LINNE",
 
-	thirdParty: {
-		cardmarket: 733726
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/151/132.ts
+++ b/data/Scarlet & Violet/151/132.ts
@@ -62,18 +62,26 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "holo"
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 733727,
+				tcgplayer: 516695,
+				cardtrader: 261226
+			}
 		},
 		{
-			type: "reverse"
-		}
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 733727,
+				tcgplayer: 516695,
+				cardtrader: 261226
+			}
+		},
 	],
 
 	illustrator: "KIYOTAKA OSHIYAMA",
 
-	thirdParty: {
-		cardmarket: 794900
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/151/133.ts
+++ b/data/Scarlet & Violet/151/133.ts
@@ -60,18 +60,40 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "normal"
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 733728,
+				tcgplayer: 516696,
+				cardtrader: 261112
+			}
 		},
 		{
-			type: "reverse"
-		}
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 733728,
+				tcgplayer: 516696,
+				cardtrader: 261112
+			}
+		},
+		{
+			type: 'normal',
+			stamp: ['pokemon-together'],
+			thirdParty: {
+				cardmarket: 748475
+			}
+		},
+		{
+			type: 'normal',
+			stamp: ['snowflake'],
+			thirdParty: {
+				cardmarket: 845405
+			}
+		},
 	],
 
 	illustrator: "Narumi Sato",
 
-	thirdParty: {
-		cardmarket: 733728
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/151/134.ts
+++ b/data/Scarlet & Violet/151/134.ts
@@ -79,18 +79,26 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "holo"
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 733729,
+				tcgplayer: 516697,
+				cardtrader: 261238
+			}
 		},
 		{
-			type: "reverse"
-		}
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 733729,
+				tcgplayer: 516697,
+				cardtrader: 261238
+			}
+		},
 	],
 
 	illustrator: "kirisAki",
 
-	thirdParty: {
-		cardmarket: 733729
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/151/135.ts
+++ b/data/Scarlet & Violet/151/135.ts
@@ -77,18 +77,26 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "holo"
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 733730,
+				tcgplayer: 516698,
+				cardtrader: 261233
+			}
 		},
 		{
-			type: "reverse"
-		}
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 733730,
+				tcgplayer: 516698,
+				cardtrader: 261233
+			}
+		},
 	],
 
 	illustrator: "sui",
 
-	thirdParty: {
-		cardmarket: 733730
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/151/136.ts
+++ b/data/Scarlet & Violet/151/136.ts
@@ -79,18 +79,26 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "holo"
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 733731,
+				tcgplayer: 516699,
+				cardtrader: 261230
+			}
 		},
 		{
-			type: "reverse"
-		}
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 733731,
+				tcgplayer: 516699,
+				cardtrader: 261230
+			}
+		},
 	],
 
 	illustrator: "Ryota Murayama",
 
-	thirdParty: {
-		cardmarket: 733731
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/151/137.ts
+++ b/data/Scarlet & Violet/151/137.ts
@@ -47,18 +47,26 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "normal"
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 733732,
+				tcgplayer: 516700,
+				cardtrader: 261143
+			}
 		},
 		{
-			type: "reverse"
-		}
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 733732,
+				tcgplayer: 516700,
+				cardtrader: 261143
+			}
+		},
 	],
 
 	illustrator: "5ban Graphics",
 
-	thirdParty: {
-		cardmarket: 733752
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/151/138.ts
+++ b/data/Scarlet & Violet/151/138.ts
@@ -57,18 +57,26 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "normal"
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 733733,
+				tcgplayer: 516701,
+				cardtrader: 261200
+			}
 		},
 		{
-			type: "reverse"
-		}
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 733733,
+				tcgplayer: 516701,
+				cardtrader: 261200
+			}
+		},
 	],
 
 	illustrator: "Akira Komayama",
 
-	thirdParty: {
-		cardmarket: 733733
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/151/139.ts
+++ b/data/Scarlet & Violet/151/139.ts
@@ -79,18 +79,26 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "holo"
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 733734,
+				tcgplayer: 516702,
+				cardtrader: 261237
+			}
 		},
 		{
-			type: "reverse"
-		}
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 733734,
+				tcgplayer: 516702,
+				cardtrader: 261237
+			}
+		},
 	],
 
 	illustrator: "Akira Komayama",
 
-	thirdParty: {
-		cardmarket: 733734
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/151/140.ts
+++ b/data/Scarlet & Violet/151/140.ts
@@ -57,18 +57,26 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "normal"
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 733735,
+				tcgplayer: 516703,
+				cardtrader: 261187
+			}
 		},
 		{
-			type: "reverse"
-		}
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 733735,
+				tcgplayer: 516703,
+				cardtrader: 261187
+			}
+		},
 	],
 
 	illustrator: "Souichirou Gunjima",
 
-	thirdParty: {
-		cardmarket: 733735
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/151/141.ts
+++ b/data/Scarlet & Violet/151/141.ts
@@ -79,18 +79,26 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "holo"
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 733736,
+				tcgplayer: 516704,
+				cardtrader: 261234
+			}
 		},
 		{
-			type: "reverse"
-		}
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 733736,
+				tcgplayer: 516704,
+				cardtrader: 261234
+			}
+		},
 	],
 
 	illustrator: "Souichirou Gunjima",
 
-	thirdParty: {
-		cardmarket: 733736
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/151/142.ts
+++ b/data/Scarlet & Violet/151/142.ts
@@ -70,18 +70,26 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "holo"
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 733737,
+				tcgplayer: 516705,
+				cardtrader: 261059
+			}
 		},
 		{
-			type: "reverse"
-		}
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 733737,
+				tcgplayer: 516705,
+				cardtrader: 261059
+			}
+		},
 	],
 
 	illustrator: "Shinji Kanda",
 
-	thirdParty: {
-		cardmarket: 733737
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/151/143.ts
+++ b/data/Scarlet & Violet/151/143.ts
@@ -71,18 +71,26 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "normal"
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 733738,
+				tcgplayer: 516706,
+				cardtrader: 261219
+			}
 		},
 		{
-			type: "reverse"
-		}
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 733738,
+				tcgplayer: 516706,
+				cardtrader: 261219
+			}
+		},
 	],
 
 	illustrator: "HYOGONOSUKE",
 
-	thirdParty: {
-		cardmarket: 733738
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/151/144.ts
+++ b/data/Scarlet & Violet/151/144.ts
@@ -71,18 +71,26 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "holo"
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 733739,
+				tcgplayer: 516707,
+				cardtrader: 261225
+			}
 		},
 		{
-			type: "reverse"
-		}
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 733739,
+				tcgplayer: 516707,
+				cardtrader: 261225
+			}
+		},
 	],
 
 	illustrator: "chibi",
 
-	thirdParty: {
-		cardmarket: 733739
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/151/145.ts
+++ b/data/Scarlet & Violet/151/145.ts
@@ -69,16 +69,21 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "G",
 
-	variants: {
-		normal: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 733740,
+				tcgplayer: 516708,
+				cardtrader: 261105
+			}
+		},
+	],
 
 	suffix: "ex",
 	illustrator: "takuyoa",
 
-	thirdParty: {
-		cardmarket: 733740
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/151/146.ts
+++ b/data/Scarlet & Violet/151/146.ts
@@ -69,18 +69,26 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "holo"
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 733741,
+				tcgplayer: 516709,
+				cardtrader: 261236
+			}
 		},
 		{
-			type: "reverse"
-		}
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 733741,
+				tcgplayer: 516709,
+				cardtrader: 261236
+			}
+		},
 	],
 
 	illustrator: "KEIICHIRO ITO",
 
-	thirdParty: {
-		cardmarket: 733741
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/151/147.ts
+++ b/data/Scarlet & Violet/151/147.ts
@@ -53,18 +53,26 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "normal"
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 733742,
+				tcgplayer: 516710,
+				cardtrader: 261110
+			}
 		},
 		{
-			type: "reverse"
-		}
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 733742,
+				tcgplayer: 516710,
+				cardtrader: 261110
+			}
+		},
 	],
 
 	illustrator: "Sanosuke Sakuma",
 
-	thirdParty: {
-		cardmarket: 733742
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/151/148.ts
+++ b/data/Scarlet & Violet/151/148.ts
@@ -70,18 +70,26 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "normal"
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 733743,
+				tcgplayer: 516711,
+				cardtrader: 261170
+			}
 		},
 		{
-			type: "reverse"
-		}
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 733743,
+				tcgplayer: 516711,
+				cardtrader: 261170
+			}
+		},
 	],
 
 	illustrator: "Sanosuke Sakuma",
 
-	thirdParty: {
-		cardmarket: 733743
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/151/149.ts
+++ b/data/Scarlet & Violet/151/149.ts
@@ -79,18 +79,33 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "holo"
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 733744,
+				tcgplayer: 516712,
+				cardtrader: 261228
+			}
 		},
 		{
-			type: "reverse"
-		}
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 733744,
+				tcgplayer: 516712,
+				cardtrader: 261228
+			}
+		},
+		{
+			type: 'holo',
+			foil: 'cosmos',
+			thirdParty: {
+				cardmarket: 864952
+			}
+		},
 	],
 
 	illustrator: "Sanosuke Sakuma",
 
-	thirdParty: {
-		cardmarket: 733744
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/151/150.ts
+++ b/data/Scarlet & Violet/151/150.ts
@@ -71,18 +71,26 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "holo"
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 733745,
+				tcgplayer: 516713,
+				cardtrader: 261235
+			}
 		},
 		{
-			type: "reverse"
-		}
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 733745,
+				tcgplayer: 516713,
+				cardtrader: 261235
+			}
+		},
 	],
 
 	illustrator: "AKIRA EGAWA",
 
-	thirdParty: {
-		cardmarket: 733745
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/151/151.ts
+++ b/data/Scarlet & Violet/151/151.ts
@@ -67,17 +67,21 @@ const card: Card = {
 	retreat: 0,
 	regulationMark: "G",
 
-	variants: {
-		reverse: false,
-		normal: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 733746,
+				tcgplayer: 516566,
+				cardtrader: 258695
+			}
+		},
+	],
 
 	suffix: "ex",
 	illustrator: "aky CG Works",
 
-	thirdParty: {
-		cardmarket: 733746
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/151/152.ts
+++ b/data/Scarlet & Violet/151/152.ts
@@ -61,18 +61,26 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "normal"
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 733747,
+				tcgplayer: 516714,
+				cardtrader: 261624
+			}
 		},
 		{
-			type: "reverse"
-		}
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 733747,
+				tcgplayer: 516714,
+				cardtrader: 261624
+			}
+		},
 	],
 
 	illustrator: "AYUMI ODASHIMA",
 
-	thirdParty: {
-		cardmarket: 733747
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/151/153.ts
+++ b/data/Scarlet & Violet/151/153.ts
@@ -61,18 +61,26 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "normal"
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 733748,
+				tcgplayer: 516715,
+				cardtrader: 261625
+			}
 		},
 		{
-			type: "reverse"
-		}
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 733748,
+				tcgplayer: 516715,
+				cardtrader: 261625
+			}
+		},
 	],
 
 	illustrator: "AYUMI ODASHIMA",
 
-	thirdParty: {
-		cardmarket: 733748
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/151/154.ts
+++ b/data/Scarlet & Violet/151/154.ts
@@ -61,18 +61,26 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "normal"
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 733749,
+				tcgplayer: 516716,
+				cardtrader: 261626
+			}
 		},
 		{
-			type: "reverse"
-		}
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 733749,
+				tcgplayer: 516716,
+				cardtrader: 261626
+			}
+		},
 	],
 
 	illustrator: "AYUMI ODASHIMA",
 
-	thirdParty: {
-		cardmarket: 733749
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/151/155.ts
+++ b/data/Scarlet & Violet/151/155.ts
@@ -30,18 +30,26 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "normal"
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 733750,
+				tcgplayer: 516717,
+				cardtrader: 261166
+			}
 		},
 		{
-			type: "reverse"
-		}
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 733750,
+				tcgplayer: 516717,
+				cardtrader: 261166
+			}
+		},
 	],
 
 	illustrator: "Toyste Beach",
 
-	thirdParty: {
-		cardmarket: 733648
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/151/156.ts
+++ b/data/Scarlet & Violet/151/156.ts
@@ -30,18 +30,26 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "normal"
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 733751,
+				tcgplayer: 516718,
+				cardtrader: 261167
+			}
 		},
 		{
-			type: "reverse"
-		}
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 733751,
+				tcgplayer: 516718,
+				cardtrader: 261167
+			}
+		},
 	],
 
 	illustrator: "GIDORA",
 
-	thirdParty: {
-		cardmarket: 733751
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/151/157.ts
+++ b/data/Scarlet & Violet/151/157.ts
@@ -30,18 +30,26 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "normal"
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 733752,
+				tcgplayer: 516719,
+				cardtrader: 261165
+			}
 		},
 		{
-			type: "reverse"
-		}
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 733752,
+				tcgplayer: 516719,
+				cardtrader: 261165
+			}
+		},
 	],
 
 	illustrator: "Oswaldo KATO",
 
-	thirdParty: {
-		cardmarket: 733752
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/151/158.ts
+++ b/data/Scarlet & Violet/151/158.ts
@@ -30,18 +30,26 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "normal"
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 733753,
+				tcgplayer: 516720,
+				cardtrader: 261168
+			}
 		},
 		{
-			type: "reverse"
-		}
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 733753,
+				tcgplayer: 516720,
+				cardtrader: 261168
+			}
+		},
 	],
 
 	illustrator: "Tomomi Kaneko",
 
-	thirdParty: {
-		cardmarket: 733753
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/151/159.ts
+++ b/data/Scarlet & Violet/151/159.ts
@@ -30,18 +30,26 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "normal"
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 733754,
+				tcgplayer: 516721,
+				cardtrader: 261172
+			}
 		},
 		{
-			type: "reverse"
-		}
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 733754,
+				tcgplayer: 516721,
+				cardtrader: 261172
+			}
+		},
 	],
 
 	illustrator: "Ayaka Yoshida",
 
-	thirdParty: {
-		cardmarket: 733754
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/151/160.ts
+++ b/data/Scarlet & Violet/151/160.ts
@@ -30,18 +30,26 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "normal"
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 733755,
+				tcgplayer: 516722,
+				cardtrader: 261173
+			}
 		},
 		{
-			type: "reverse"
-		}
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 733755,
+				tcgplayer: 516722,
+				cardtrader: 261173
+			}
+		},
 	],
 
 	illustrator: "saino misaki",
 
-	thirdParty: {
-		cardmarket: 733755
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/151/161.ts
+++ b/data/Scarlet & Violet/151/161.ts
@@ -30,18 +30,26 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "normal"
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 733756,
+				tcgplayer: 516723,
+				cardtrader: 261174
+			}
 		},
 		{
-			type: "reverse"
-		}
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 733756,
+				tcgplayer: 516723,
+				cardtrader: 261174
+			}
+		},
 	],
 
 	illustrator: "hncl",
 
-	thirdParty: {
-		cardmarket: 733756
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/151/162.ts
+++ b/data/Scarlet & Violet/151/162.ts
@@ -30,18 +30,26 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "normal"
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 733757,
+				tcgplayer: 516724,
+				cardtrader: 261175
+			}
 		},
 		{
-			type: "reverse"
-		}
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 733757,
+				tcgplayer: 516724,
+				cardtrader: 261175
+			}
+		},
 	],
 
 	illustrator: "inose yukie",
 
-	thirdParty: {
-		cardmarket: 733757
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/151/163.ts
+++ b/data/Scarlet & Violet/151/163.ts
@@ -30,18 +30,26 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "normal"
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 733758,
+				tcgplayer: 516725,
+				cardtrader: 261191
+			}
 		},
 		{
-			type: "reverse"
-		}
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 733758,
+				tcgplayer: 516725,
+				cardtrader: 261191
+			}
+		},
 	],
 
 	illustrator: "Studio Bora Inc.",
 
-	thirdParty: {
-		cardmarket: 733758
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/151/164.ts
+++ b/data/Scarlet & Violet/151/164.ts
@@ -30,18 +30,26 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "normal"
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 733759,
+				tcgplayer: 516726,
+				cardtrader: 261209
+			}
 		},
 		{
-			type: "reverse"
-		}
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 733759,
+				tcgplayer: 516726,
+				cardtrader: 261209
+			}
+		},
 	],
 
 	illustrator: "Toyste Beach",
 
-	thirdParty: {
-		cardmarket: 733759
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/151/165.ts
+++ b/data/Scarlet & Violet/151/165.ts
@@ -30,18 +30,26 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "normal"
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 733760,
+				tcgplayer: 516727,
+				cardtrader: 261210
+			}
 		},
 		{
-			type: "reverse"
-		}
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 733760,
+				tcgplayer: 516727,
+				cardtrader: 261210
+			}
+		},
 	],
 
 	illustrator: "Toyste Beach",
 
-	thirdParty: {
-		cardmarket: 733760
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/151/166.ts
+++ b/data/Scarlet & Violet/151/166.ts
@@ -47,16 +47,20 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "G",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 733761,
+				tcgplayer: 516997,
+				cardtrader: 261291
+			}
+		},
+	],
 
 	illustrator: "Yoriyuki Ikegami",
 
-	thirdParty: {
-		cardmarket: 733761
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/151/167.ts
+++ b/data/Scarlet & Violet/151/167.ts
@@ -68,16 +68,20 @@ const card: Card = {
 	retreat: 3,
 	regulationMark: "G",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 733762,
+				tcgplayer: 516998,
+				cardtrader: 261292
+			}
+		},
+	],
 
 	illustrator: "Yoriyuki Ikegami",
 
-	thirdParty: {
-		cardmarket: 733762
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/151/168.ts
+++ b/data/Scarlet & Violet/151/168.ts
@@ -58,16 +58,20 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 733763,
+				tcgplayer: 502556,
+				cardtrader: 261290
+			}
+		},
+	],
 
 	illustrator: "miki kudo",
 
-	thirdParty: {
-		cardmarket: 733763
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/151/169.ts
+++ b/data/Scarlet & Violet/151/169.ts
@@ -68,16 +68,20 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "G",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 733764,
+				tcgplayer: 517018,
+				cardtrader: 261328
+			}
+		},
+	],
 
 	illustrator: "miki kudo",
 
-	thirdParty: {
-		cardmarket: 733757
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/151/170.ts
+++ b/data/Scarlet & Violet/151/170.ts
@@ -58,16 +58,20 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 733765,
+				tcgplayer: 502549,
+				cardtrader: 261310
+			}
+		},
+	],
 
 	illustrator: "Mitsuhiro Arita",
 
-	thirdParty: {
-		cardmarket: 733765
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/151/171.ts
+++ b/data/Scarlet & Violet/151/171.ts
@@ -66,16 +66,20 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "G",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 733766,
+				tcgplayer: 517038,
+				cardtrader: 261332
+			}
+		},
+	],
 
 	illustrator: "Mitsuhiro Arita",
 
-	thirdParty: {
-		cardmarket: 733766
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/151/172.ts
+++ b/data/Scarlet & Violet/151/172.ts
@@ -47,16 +47,20 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 733767,
+				tcgplayer: 517016,
+				cardtrader: 261334
+			}
+		},
+	],
 
 	illustrator: "Teeziro",
 
-	thirdParty: {
-		cardmarket: 733767
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/151/173.ts
+++ b/data/Scarlet & Violet/151/173.ts
@@ -58,16 +58,20 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 733768,
+				tcgplayer: 513721,
+				cardtrader: 261321
+			}
+		},
+	],
 
 	illustrator: "Hiroyuki Yamamoto",
 
-	thirdParty: {
-		cardmarket: 733768
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/151/174.ts
+++ b/data/Scarlet & Violet/151/174.ts
@@ -77,16 +77,20 @@ const card: Card = {
 	retreat: 3,
 	regulationMark: "G",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 733769,
+				tcgplayer: 517029,
+				cardtrader: 261323
+			}
+		},
+	],
 
 	illustrator: "Misaki Hashimoto",
 
-	thirdParty: {
-		cardmarket: 733698
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/151/175.ts
+++ b/data/Scarlet & Violet/151/175.ts
@@ -58,16 +58,20 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 733770,
+				tcgplayer: 517035,
+				cardtrader: 261331
+			}
+		},
+	],
 
 	illustrator: "Whisker",
 
-	thirdParty: {
-		cardmarket: 733770
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/151/176.ts
+++ b/data/Scarlet & Violet/151/176.ts
@@ -68,16 +68,20 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 733771,
+				tcgplayer: 517034,
+				cardtrader: 261295
+			}
+		},
+	],
 
 	illustrator: "Gemi",
 
-	thirdParty: {
-		cardmarket: 733771
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/151/177.ts
+++ b/data/Scarlet & Violet/151/177.ts
@@ -55,16 +55,20 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "G",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 733772,
+				tcgplayer: 517025,
+				cardtrader: 261300
+			}
+		},
+	],
 
 	illustrator: "Tetsu Kayama",
 
-	thirdParty: {
-		cardmarket: 733772
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/151/178.ts
+++ b/data/Scarlet & Violet/151/178.ts
@@ -47,16 +47,20 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "G",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 733773,
+				tcgplayer: 517036,
+				cardtrader: 261294
+			}
+		},
+	],
 
 	illustrator: "Oswaldo KATO",
 
-	thirdParty: {
-		cardmarket: 733773
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/151/179.ts
+++ b/data/Scarlet & Violet/151/179.ts
@@ -67,16 +67,20 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 733774,
+				tcgplayer: 517028,
+				cardtrader: 261311
+			}
+		},
+	],
 
 	illustrator: "OKACHEKE",
 
-	thirdParty: {
-		cardmarket: 733774
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/151/180.ts
+++ b/data/Scarlet & Violet/151/180.ts
@@ -55,16 +55,20 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "G",
 
-	variants: {
-		reverse: false,
-		normal: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 733775,
+				tcgplayer: 517031,
+				cardtrader: 261327
+			}
+		},
+	],
 
 	illustrator: "Yano Keiji",
 
-	thirdParty: {
-		cardmarket: 733775
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/151/181.ts
+++ b/data/Scarlet & Violet/151/181.ts
@@ -68,16 +68,20 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "G",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 733776,
+				tcgplayer: 517020,
+				cardtrader: 261308
+			}
+		},
+	],
 
 	illustrator: "rika",
 
-	thirdParty: {
-		cardmarket: 733776
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/151/182.ts
+++ b/data/Scarlet & Violet/151/182.ts
@@ -77,17 +77,21 @@ const card: Card = {
 	retreat: 4,
 	regulationMark: "G",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 733777,
+				tcgplayer: 517037,
+				cardtrader: 261257
+			}
+		},
+	],
 
 	suffix: "ex",
 	illustrator: "PLANETA Yamashita",
 
-	thirdParty: {
-		cardmarket: 733777
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/151/183.ts
+++ b/data/Scarlet & Violet/151/183.ts
@@ -77,17 +77,21 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "G",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 733778,
+				tcgplayer: 517017,
+				cardtrader: 261283
+			}
+		},
+	],
 
 	suffix: "ex",
 	illustrator: "PLANETA Mochizuki",
 
-	thirdParty: {
-		cardmarket: 733778
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/151/184.ts
+++ b/data/Scarlet & Violet/151/184.ts
@@ -77,17 +77,21 @@ const card: Card = {
 	retreat: 3,
 	regulationMark: "G",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 733779,
+				tcgplayer: 517015,
+				cardtrader: 261288
+			}
+		},
+	],
 
 	suffix: "ex",
 	illustrator: "PLANETA Yamashita",
 
-	thirdParty: {
-		cardmarket: 733779
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/151/185.ts
+++ b/data/Scarlet & Violet/151/185.ts
@@ -77,17 +77,21 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "G",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 733780,
+				tcgplayer: 517014,
+				cardtrader: 261277
+			}
+		},
+	],
 
 	suffix: "ex",
 	illustrator: "Eske Yoshinob",
 
-	thirdParty: {
-		cardmarket: 733780
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/151/186.ts
+++ b/data/Scarlet & Violet/151/186.ts
@@ -77,17 +77,21 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "G",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 733781,
+				tcgplayer: 517030,
+				cardtrader: 261265
+			}
+		},
+	],
 
 	suffix: "ex",
 	illustrator: "PLANETA Tsuji",
 
-	thirdParty: {
-		cardmarket: 733781
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/151/187.ts
+++ b/data/Scarlet & Violet/151/187.ts
@@ -77,17 +77,21 @@ const card: Card = {
 	retreat: 3,
 	regulationMark: "G",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 733782,
+				tcgplayer: 517039,
+				cardtrader: 261275
+			}
+		},
+	],
 
 	suffix: "ex",
 	illustrator: "Saki Hayashiro",
 
-	thirdParty: {
-		cardmarket: 733782
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/151/188.ts
+++ b/data/Scarlet & Violet/151/188.ts
@@ -77,17 +77,21 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 733783,
+				tcgplayer: 517013,
+				cardtrader: 261248
+			}
+		},
+	],
 
 	suffix: "ex",
 	illustrator: "PLANETA Tsuji",
 
-	thirdParty: {
-		cardmarket: 733783
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/151/189.ts
+++ b/data/Scarlet & Violet/151/189.ts
@@ -77,17 +77,21 @@ const card: Card = {
 	retreat: 4,
 	regulationMark: "G",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 733784,
+				tcgplayer: 517021,
+				cardtrader: 261282
+			}
+		},
+	],
 
 	suffix: "ex",
 	illustrator: "PLANETA Igarashi",
 
-	thirdParty: {
-		cardmarket: 733784
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/151/190.ts
+++ b/data/Scarlet & Violet/151/190.ts
@@ -67,17 +67,21 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "G",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 733785,
+				tcgplayer: 517024,
+				cardtrader: 261271
+			}
+		},
+	],
 
 	suffix: "ex",
 	illustrator: "N-DESIGN Inc.",
 
-	thirdParty: {
-		cardmarket: 733785
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/151/191.ts
+++ b/data/Scarlet & Violet/151/191.ts
@@ -67,17 +67,21 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "G",
 
-	variants: {
-		reverse: false,
-		normal: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 733786,
+				tcgplayer: 517023,
+				cardtrader: 261273
+			}
+		},
+	],
 
 	suffix: "ex",
 	illustrator: "Ayaka Yoshida",
 
-	thirdParty: {
-		cardmarket: 733786
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/151/192.ts
+++ b/data/Scarlet & Violet/151/192.ts
@@ -69,17 +69,21 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "G",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 733787,
+				tcgplayer: 517040,
+				cardtrader: 261286
+			}
+		},
+	],
 
 	suffix: "ex",
 	illustrator: "takuyoa",
 
-	thirdParty: {
-		cardmarket: 733787
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/151/193.ts
+++ b/data/Scarlet & Violet/151/193.ts
@@ -67,17 +67,21 @@ const card: Card = {
 	retreat: 0,
 	regulationMark: "G",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 733788,
+				tcgplayer: 517027,
+				cardtrader: 261253
+			}
+		},
+	],
 
 	suffix: "ex",
 	illustrator: "aky CG Works",
 
-	thirdParty: {
-		cardmarket: 733788
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/151/194.ts
+++ b/data/Scarlet & Violet/151/194.ts
@@ -28,16 +28,20 @@ const card: Card = {
 	trainerType: "Supporter",
 	regulationMark: "G",
 
-	variants: {
-		reverse: false,
-		normal: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 733789,
+				tcgplayer: 517041,
+				cardtrader: 261285
+			}
+		},
+	],
 
 	illustrator: "GIDORA",
 
-	thirdParty: {
-		cardmarket: 733644
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/151/195.ts
+++ b/data/Scarlet & Violet/151/195.ts
@@ -28,16 +28,20 @@ const card: Card = {
 	trainerType: "Supporter",
 	regulationMark: "G",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 733790,
+				tcgplayer: 517042,
+				cardtrader: 261280
+			}
+		},
+	],
 
 	illustrator: "Fumie Kittaka",
 
-	thirdParty: {
-		cardmarket: 733790
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/151/196.ts
+++ b/data/Scarlet & Violet/151/196.ts
@@ -28,16 +28,20 @@ const card: Card = {
 	trainerType: "Supporter",
 	regulationMark: "G",
 
-	variants: {
-		reverse: false,
-		normal: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 733791,
+				tcgplayer: 517176,
+				cardtrader: 261250
+			}
+		},
+	],
 
 	illustrator: "saino misaki",
 
-	thirdParty: {
-		cardmarket: 733791
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/151/197.ts
+++ b/data/Scarlet & Violet/151/197.ts
@@ -28,16 +28,20 @@ const card: Card = {
 	trainerType: "Supporter",
 	regulationMark: "G",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 733792,
+				tcgplayer: 517043,
+				cardtrader: 261252
+			}
+		},
+	],
 
 	illustrator: "hncl",
 
-	thirdParty: {
-		cardmarket: 733792
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/151/198.ts
+++ b/data/Scarlet & Violet/151/198.ts
@@ -77,17 +77,21 @@ const card: Card = {
 	retreat: 4,
 	regulationMark: "G",
 
-	variants: {
-		reverse: false,
-		normal: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 733793,
+				tcgplayer: 517044,
+				cardtrader: 261352
+			}
+		},
+	],
 
 	suffix: "ex",
 	illustrator: "Yoriyuki Ikegami",
 
-	thirdParty: {
-		cardmarket: 733793
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/151/199.ts
+++ b/data/Scarlet & Violet/151/199.ts
@@ -80,17 +80,21 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "G",
 
-	variants: {
-		normal: false,
-		reverse: false,
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 733794,
+				tcgplayer: 517045,
+				cardtrader: 261377
+			}
+		},
+	],
 
 	suffix: "ex",
 	illustrator: "miki kudo",
 
-	thirdParty: {
-		cardmarket: 733794,
-	},
+	
 };
 
 export default card;

--- a/data/Scarlet & Violet/151/200.ts
+++ b/data/Scarlet & Violet/151/200.ts
@@ -77,17 +77,21 @@ const card: Card = {
 	retreat: 3,
 	regulationMark: "G",
 
-	variants: {
-		reverse: false,
-		normal: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 733795,
+				tcgplayer: 517046,
+				cardtrader: 261384
+			}
+		},
+	],
 
 	suffix: "ex",
 	illustrator: "Mitsuhiro Arita",
 
-	thirdParty: {
-		cardmarket: 733795
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/151/201.ts
+++ b/data/Scarlet & Violet/151/201.ts
@@ -77,17 +77,21 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 733796,
+				tcgplayer: 517047,
+				cardtrader: 261382
+			}
+		},
+	],
 
 	suffix: "ex",
 	illustrator: "Shinya Komatsu",
 
-	thirdParty: {
-		cardmarket: 733796
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/151/202.ts
+++ b/data/Scarlet & Violet/151/202.ts
@@ -69,17 +69,21 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "G",
 
-	variants: {
-		reverse: false,
-		normal: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 733797,
+				tcgplayer: 517048,
+				cardtrader: 261380
+			}
+		},
+	],
 
 	suffix: "ex",
 	illustrator: "Shiburingaru",
 
-	thirdParty: {
-		cardmarket: 733797
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/151/203.ts
+++ b/data/Scarlet & Violet/151/203.ts
@@ -28,16 +28,20 @@ const card: Card = {
 	trainerType: "Supporter",
 	regulationMark: "G",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 733798,
+				tcgplayer: 517049,
+				cardtrader: 261336
+			}
+		},
+	],
 
 	illustrator: "Cona Nitanda",
 
-	thirdParty: {
-		cardmarket: 733798
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/151/204.ts
+++ b/data/Scarlet & Violet/151/204.ts
@@ -28,16 +28,20 @@ const card: Card = {
 	trainerType: "Supporter",
 	regulationMark: "G",
 
-	variants: {
-		reverse: false,
-		normal: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 733799,
+				tcgplayer: 517050,
+				cardtrader: 261349
+			}
+		},
+	],
 
 	illustrator: "Hideki Ishikawa",
 
-	thirdParty: {
-		cardmarket: 733799
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/151/205.ts
+++ b/data/Scarlet & Violet/151/205.ts
@@ -67,17 +67,43 @@ const card: Card = {
 	retreat: 0,
 	regulationMark: "G",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 720951,
+				tcgplayer: 517051,
+				cardtrader: 258698
+			}
+		},
+		{
+			type: 'holo',
+			foil: 'gold',
+			thirdParty: {
+				cardmarket: 733800
+			}
+		},
+		{
+			type: 'holo',
+			foil: 'gold',
+			size: 'jumbo',
+			thirdParty: {
+				cardmarket: 814545
+			}
+		},
+		{
+			type: 'metal',
+			foil: 'gold',
+			thirdParty: {
+				cardmarket: 720951
+			}
+		},
+	],
 
 	suffix: "ex",
 	illustrator: "aky CG Works",
 
-	thirdParty: {
-		cardmarket: 733746
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/151/206.ts
+++ b/data/Scarlet & Violet/151/206.ts
@@ -28,16 +28,27 @@ const card: Card = {
 	trainerType: "Item",
 	regulationMark: "G",
 
-	variants: {
-		reverse: false,
-		normal: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 733801,
+				tcgplayer: 517052,
+				cardtrader: 261387
+			}
+		},
+		{
+			type: 'holo',
+			foil: 'gold',
+			thirdParty: {
+				cardmarket: 733801
+			}
+		},
+	],
 
 	illustrator: "Studio Bora Inc.",
 
-	thirdParty: {
-		cardmarket: 733801
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/151/207.ts
+++ b/data/Scarlet & Violet/151/207.ts
@@ -18,14 +18,25 @@ const card: Card = {
 	types: ["Psychic"],
 	energyType: "Normal",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 733802,
+				tcgplayer: 517053,
+				cardtrader: 261385
+			}
+		},
+		{
+			type: 'holo',
+			foil: 'gold',
+			thirdParty: {
+				cardmarket: 733802
+			}
+		},
+	],
 
-	thirdParty: {
-		cardmarket: 733802
-	}
+	
 }
 
 export default card

--- a/interfaces.d.ts
+++ b/interfaces.d.ts
@@ -34,7 +34,7 @@ export type VariantStamps = '1st-edition' | 'w-promo' | 'pre-release' | 'pokemon
 	| 'zachary-bokhari' | 'shuto-itagaki' | 'snowflake' | 'trick-or-trade' | 'horizons' | 'gamestop' | 'eb-games'
 	| 'illustration-contest-2024' | 'worlds-2025' | 'top-eight' | "champion" | "master-ball-league" | "ultra-ball-league" | "judge" | "asia-promo"
 	| "international-championship-europe" | "international-championship-latin-america" | "international-championship-north-america" | 'ace-trainer'
-	| 'pikachu' | 'bulbasaur' | 'squirtle' | 'charmander' | 'pokeball' | '30th-pokeday' | 'mcdonalds'
+	| 'pikachu' | 'bulbasaur' | 'squirtle' | 'charmander' | 'pokeball' | '30th-pokeday' | 'mcdonalds' | 'pokemon-together'
 
 export interface variant_detailed {
 	/**

--- a/meta/translations/de.json
+++ b/meta/translations/de.json
@@ -245,7 +245,8 @@
 		"squirtle": "squirtle",
 		"charmander": "charmander",
 		"pokeball": "pokeball",
-		"mcdonalds": "mcdonalds"
+		"mcdonalds": "mcdonalds",
+		"pokemon-together" : "pokemon-together"
 	},
 	"variantSubtype": {
 		"shadowless": "schattenlos",

--- a/meta/translations/es.json
+++ b/meta/translations/es.json
@@ -245,7 +245,8 @@
 		"squirtle": "squirtle",
 		"charmander": "charmander",
 		"pokeball": "pokeball",
-		"mcdonalds": "mcdonalds"
+		"mcdonalds": "mcdonalds",
+		"pokemon-together" : "pokemon-together"
 	},
 	"variantSubtype": {
 		"shadowless": "sin sombra",

--- a/meta/translations/fr.json
+++ b/meta/translations/fr.json
@@ -244,7 +244,8 @@
 		"squirtle": "carapuce",
 		"charmander": "salamèche",
 		"pokeball": "pokeball",
-		"mcdonalds": "mcdonalds"
+		"mcdonalds": "mcdonalds",
+		"pokemon-together" : "pokemon-together"
 	},
 	"variantSubtype": {
 		"shadowless": "sans ombre",

--- a/meta/translations/it.json
+++ b/meta/translations/it.json
@@ -245,7 +245,8 @@
 		"squirtle": "squirtle",
 		"charmander": "charmander",
 		"pokeball": "pokeball",
-		"mcdonalds": "mcdonalds"
+		"mcdonalds": "mcdonalds",
+		"pokemon-together" : "pokemon-together"
 	},
 	"variantSubtype": {
 		"shadowless": "senza ombra",

--- a/meta/translations/pt.json
+++ b/meta/translations/pt.json
@@ -244,7 +244,8 @@
 		"squirtle": "squirtle",
 		"charmander": "charmander",
 		"pokeball": "pokeball",
-		"mcdonalds": "mcdonalds"
+		"mcdonalds": "mcdonalds",
+		"pokemon-together" : "pokemon-together"
 	},
 	"variantSubtype": {
 		"shadowless": "sem sombra",


### PR DESCRIPTION
Moved all `thirdParty` IDs into variants for all 151 cards. 
- New variations pulled from cardmarket 
- New `pokemon-together` stamp 
