### PR TITLE
fix(Ascended Heroes): correct duplicated pricing IDs on Mega Scrafty ex (285)

### DIFF
--- a/data/Mega Evolution/Ascended Heroes/285.ts
+++ b/data/Mega Evolution/Ascended Heroes/285.ts
@@ -88,8 +88,8 @@ const card: Card = {
 		{
 			type: "holo",
 			thirdParty: {
-				cardmarket: 869895,
-				tcgplayer: 676096
+				cardmarket: 869896,
+				tcgplayer: 676097
 			}
 		}
 	],


### PR DESCRIPTION
`Ascended Heroes/285.ts` (Mega Scrafty ex) has 284's `thirdParty` IDs copy-pasted, so 285 and 284 resolve to the same Cardmarket / TCGplayer prices.

The set's IDs run one-per-card in sequence, and TCGplayer's product URLs confirm `676096`→284, `676097`→285:

- `cardmarket: 869895 → 869896`
- `tcgplayer: 676096 → 676097`