### PR TITLE
(data): Moved `thirdParty` into variants - PAF

### DIFF
--- a/data/Scarlet & Violet/Paldean Fates/001.ts
+++ b/data/Scarlet & Violet/Paldean Fates/001.ts
@@ -38,15 +38,28 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 751527,
+				tcgplayer: 534132,
+				cardtrader: 274134
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 751527,
+				tcgplayer: 534132,
+				cardtrader: 274134
+			}
+		},
+	],
 
 	illustrator: "Kouki Saitou",
 
-	thirdParty: {
-		cardmarket: 751527
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/002.ts
+++ b/data/Scarlet & Violet/Paldean Fates/002.ts
@@ -77,17 +77,21 @@ const card: Card = {
 	retreat: 3,
 	regulationMark: "G",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 751528,
+				tcgplayer: 534133,
+				cardtrader: 274186
+			}
+		},
+	],
 
 	suffix: "ex",
 	illustrator: "5ban Graphics",
 
-	thirdParty: {
-		cardmarket: 751528
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/003.ts
+++ b/data/Scarlet & Violet/Paldean Fates/003.ts
@@ -67,15 +67,28 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 751529,
+				tcgplayer: 534136,
+				cardtrader: 274187
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 751529,
+				tcgplayer: 534136,
+				cardtrader: 274187
+			}
+		},
+	],
 
 	illustrator: "Masako Tomii",
 
-	thirdParty: {
-		cardmarket: 751529
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/004.ts
+++ b/data/Scarlet & Violet/Paldean Fates/004.ts
@@ -47,15 +47,28 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 751530,
+				tcgplayer: 534137,
+				cardtrader: 274188
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 751530,
+				tcgplayer: 534137,
+				cardtrader: 274188
+			}
+		},
+	],
 
 	illustrator: "Shin Nagasawa",
 
-	thirdParty: {
-		cardmarket: 751530
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/005.ts
+++ b/data/Scarlet & Violet/Paldean Fates/005.ts
@@ -77,17 +77,21 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "G",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 751531,
+				tcgplayer: 534139,
+				cardtrader: 274189
+			}
+		},
+	],
 
 	suffix: "ex",
 	illustrator: "5ban Graphics",
 
-	thirdParty: {
-		cardmarket: 751531
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/006.ts
+++ b/data/Scarlet & Violet/Paldean Fates/006.ts
@@ -77,17 +77,21 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 751532,
+				tcgplayer: 534140,
+				cardtrader: 274190
+			}
+		},
+	],
 
 	suffix: "ex",
 	illustrator: "takuyoa",
 
-	thirdParty: {
-		cardmarket: 751532
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/007.ts
+++ b/data/Scarlet & Violet/Paldean Fates/007.ts
@@ -58,15 +58,35 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 751533,
+				tcgplayer: 534142,
+				cardtrader: 274191
+			}
+		},
+		{
+			type: 'holo',
+			foil: 'cosmos',
+			thirdParty: {
+				cardmarket: 833339
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 751533,
+				tcgplayer: 534142,
+				cardtrader: 274191
+			}
+		},
+	],
 
 	illustrator: "GIDORA",
 
-	thirdParty: {
-		cardmarket: 751533
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/008.ts
+++ b/data/Scarlet & Violet/Paldean Fates/008.ts
@@ -68,15 +68,35 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 751534,
+				tcgplayer: 534143,
+				cardtrader: 274192
+			}
+		},
+		{
+			type: 'holo',
+			foil: 'cosmos',
+			thirdParty: {
+				cardmarket: 833342
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 751534,
+				tcgplayer: 534143,
+				cardtrader: 274192
+			}
+		},
+	],
 
 	illustrator: "Tonji Matsuno",
 
-	thirdParty: {
-		cardmarket: 751534
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/009.ts
+++ b/data/Scarlet & Violet/Paldean Fates/009.ts
@@ -58,15 +58,28 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 751535,
+				tcgplayer: 534149,
+				cardtrader: 274193
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 751535,
+				tcgplayer: 534149,
+				cardtrader: 274193
+			}
+		},
+	],
 
 	illustrator: "miki kudo",
 
-	thirdParty: {
-		cardmarket: 751535
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/010.ts
+++ b/data/Scarlet & Violet/Paldean Fates/010.ts
@@ -68,15 +68,28 @@ const card: Card = {
 	retreat: 3,
 	regulationMark: "G",
 
-	variants: {
-		normal: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 751536,
+				tcgplayer: 534150,
+				cardtrader: 274194
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 751536,
+				tcgplayer: 534150,
+				cardtrader: 274194
+			}
+		},
+	],
 
 	illustrator: "Hasuno",
 
-	thirdParty: {
-		cardmarket: 751536
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/011.ts
+++ b/data/Scarlet & Violet/Paldean Fates/011.ts
@@ -58,15 +58,28 @@ const card: Card = {
 	retreat: 3,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 751537,
+				tcgplayer: 534152,
+				cardtrader: 274195
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 751537,
+				tcgplayer: 534152,
+				cardtrader: 274195
+			}
+		},
+	],
 
 	illustrator: "Mina Nakai",
 
-	thirdParty: {
-		cardmarket: 751537
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/012.ts
+++ b/data/Scarlet & Violet/Paldean Fates/012.ts
@@ -75,15 +75,28 @@ const card: Card = {
 	retreat: 3,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 751538,
+				tcgplayer: 534153,
+				cardtrader: 274196
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 751538,
+				tcgplayer: 534153,
+				cardtrader: 274196
+			}
+		},
+	],
 
 	illustrator: "satoma",
 
-	thirdParty: {
-		cardmarket: 751538
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/013.ts
+++ b/data/Scarlet & Violet/Paldean Fates/013.ts
@@ -47,15 +47,28 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		normal: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 751539,
+				tcgplayer: 534154,
+				cardtrader: 274197
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 751539,
+				tcgplayer: 534154,
+				cardtrader: 274197
+			}
+		},
+	],
 
 	illustrator: "Scav",
 
-	thirdParty: {
-		cardmarket: 751539
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/014.ts
+++ b/data/Scarlet & Violet/Paldean Fates/014.ts
@@ -38,15 +38,28 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 751540,
+				tcgplayer: 534155,
+				cardtrader: 274198
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 751540,
+				tcgplayer: 534155,
+				cardtrader: 274198
+			}
+		},
+	],
 
 	illustrator: "nagimiso",
 
-	thirdParty: {
-		cardmarket: 751540
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/015.ts
+++ b/data/Scarlet & Violet/Paldean Fates/015.ts
@@ -77,15 +77,28 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "G",
 
-	variants: {
-		normal: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 751541,
+				tcgplayer: 534156,
+				cardtrader: 274199
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 751541,
+				tcgplayer: 534156,
+				cardtrader: 274199
+			}
+		},
+	],
 
 	illustrator: "AKIRA EGAWA",
 
-	thirdParty: {
-		cardmarket: 751541
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/016.ts
+++ b/data/Scarlet & Violet/Paldean Fates/016.ts
@@ -67,15 +67,28 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 751543,
+				tcgplayer: 534158,
+				cardtrader: 274200
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 751543,
+				tcgplayer: 534158,
+				cardtrader: 274200
+			}
+		},
+	],
 
 	illustrator: "Gemi",
 
-	thirdParty: {
-		cardmarket: 751543
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/017.ts
+++ b/data/Scarlet & Violet/Paldean Fates/017.ts
@@ -58,15 +58,28 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 751544,
+				tcgplayer: 534161,
+				cardtrader: 274201
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 751544,
+				tcgplayer: 534161,
+				cardtrader: 274201
+			}
+		},
+	],
 
 	illustrator: "rika",
 
-	thirdParty: {
-		cardmarket: 751544
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/018.ts
+++ b/data/Scarlet & Violet/Paldean Fates/018.ts
@@ -58,15 +58,35 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 751545,
+				tcgplayer: 534163,
+				cardtrader: 274202
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 751545,
+				tcgplayer: 534163,
+				cardtrader: 274202
+			}
+		},
+		{
+			type: 'reverse',
+			foil: 'cosmos',
+			thirdParty: {
+				cardmarket: 794904
+			}
+		},
+	],
 
 	illustrator: "OKACHEKE",
 
-	thirdParty: {
-		cardmarket: 751545
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/019.ts
+++ b/data/Scarlet & Violet/Paldean Fates/019.ts
@@ -77,15 +77,28 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		normal: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 751546,
+				tcgplayer: 534165,
+				cardtrader: 274203
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 751546,
+				tcgplayer: 534165,
+				cardtrader: 274203
+			}
+		},
+	],
 
 	illustrator: "Naoyo Kimura",
 
-	thirdParty: {
-		cardmarket: 751546
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/020.ts
+++ b/data/Scarlet & Violet/Paldean Fates/020.ts
@@ -58,15 +58,28 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 751549,
+				tcgplayer: 534166,
+				cardtrader: 274204
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 751549,
+				tcgplayer: 534166,
+				cardtrader: 274204
+			}
+		},
+	],
 
 	illustrator: "yuu",
 
-	thirdParty: {
-		cardmarket: 751549
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/021.ts
+++ b/data/Scarlet & Violet/Paldean Fates/021.ts
@@ -68,15 +68,28 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 751551,
+				tcgplayer: 534167,
+				cardtrader: 274205
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 751551,
+				tcgplayer: 534167,
+				cardtrader: 274205
+			}
+		},
+	],
 
 	illustrator: "aspara",
 
-	thirdParty: {
-		cardmarket: 751551
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/022.ts
+++ b/data/Scarlet & Violet/Paldean Fates/022.ts
@@ -66,15 +66,28 @@ const card: Card = {
 	retreat: 0,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 751552,
+				tcgplayer: 534168,
+				cardtrader: 274206
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 751552,
+				tcgplayer: 534168,
+				cardtrader: 274206
+			}
+		},
+	],
 
 	illustrator: "AKIRA EGAWA",
 
-	thirdParty: {
-		cardmarket: 751552
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/023.ts
+++ b/data/Scarlet & Violet/Paldean Fates/023.ts
@@ -58,15 +58,28 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 751556,
+				tcgplayer: 534169,
+				cardtrader: 274207
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 751556,
+				tcgplayer: 534169,
+				cardtrader: 274207
+			}
+		},
+	],
 
 	illustrator: "Kariya",
 
-	thirdParty: {
-		cardmarket: 751556
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/024.ts
+++ b/data/Scarlet & Violet/Paldean Fates/024.ts
@@ -77,15 +77,28 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "G",
 
-	variants: {
-		normal: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 751557,
+				tcgplayer: 534170,
+				cardtrader: 274208
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 751557,
+				tcgplayer: 534170,
+				cardtrader: 274208
+			}
+		},
+	],
 
 	illustrator: "Yoriyuki Ikegami",
 
-	thirdParty: {
-		cardmarket: 751557
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/025.ts
+++ b/data/Scarlet & Violet/Paldean Fates/025.ts
@@ -47,15 +47,28 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 751558,
+				tcgplayer: 535993,
+				cardtrader: 274209
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 751558,
+				tcgplayer: 535993,
+				cardtrader: 274209
+			}
+		},
+	],
 
 	illustrator: "Teeziro",
 
-	thirdParty: {
-		cardmarket: 751558
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/026.ts
+++ b/data/Scarlet & Violet/Paldean Fates/026.ts
@@ -68,15 +68,28 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		normal: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 751559,
+				tcgplayer: 534171,
+				cardtrader: 274210
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 751559,
+				tcgplayer: 534171,
+				cardtrader: 274210
+			}
+		},
+	],
 
 	illustrator: "DOM",
 
-	thirdParty: {
-		cardmarket: 751559
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/027.ts
+++ b/data/Scarlet & Violet/Paldean Fates/027.ts
@@ -38,15 +38,28 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 751560,
+				tcgplayer: 534173,
+				cardtrader: 274211
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 751560,
+				tcgplayer: 534173,
+				cardtrader: 274211
+			}
+		},
+	],
 
 	illustrator: "Tika Matsuno",
 
-	thirdParty: {
-		cardmarket: 751560
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/028.ts
+++ b/data/Scarlet & Violet/Paldean Fates/028.ts
@@ -68,15 +68,28 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 751561,
+				tcgplayer: 534174,
+				cardtrader: 274212
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 751561,
+				tcgplayer: 534174,
+				cardtrader: 274212
+			}
+		},
+	],
 
 	illustrator: "kawayoo",
 
-	thirdParty: {
-		cardmarket: 751561
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/029.ts
+++ b/data/Scarlet & Violet/Paldean Fates/029.ts
@@ -77,17 +77,21 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "G",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 751562,
+				tcgplayer: 534175,
+				cardtrader: 274213
+			}
+		},
+	],
 
 	suffix: "ex",
 	illustrator: "N-DESIGN Inc.",
 
-	thirdParty: {
-		cardmarket: 751562
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/030.ts
+++ b/data/Scarlet & Violet/Paldean Fates/030.ts
@@ -58,15 +58,28 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 751563,
+				tcgplayer: 534176,
+				cardtrader: 274214
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 751563,
+				tcgplayer: 534176,
+				cardtrader: 274214
+			}
+		},
+	],
 
 	illustrator: "sui",
 
-	thirdParty: {
-		cardmarket: 751563
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/031.ts
+++ b/data/Scarlet & Violet/Paldean Fates/031.ts
@@ -43,15 +43,28 @@ const card: Card = {
 	retreat: 0,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 751566,
+				tcgplayer: 534177,
+				cardtrader: 274215
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 751566,
+				tcgplayer: 534177,
+				cardtrader: 274215
+			}
+		},
+	],
 
 	illustrator: "HYOGONOSUKE",
 
-	thirdParty: {
-		cardmarket: 751566
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/032.ts
+++ b/data/Scarlet & Violet/Paldean Fates/032.ts
@@ -47,15 +47,28 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 751568,
+				tcgplayer: 534178,
+				cardtrader: 274216
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 751568,
+				tcgplayer: 534178,
+				cardtrader: 274216
+			}
+		},
+	],
 
 	illustrator: "Kagemaru Himeno",
 
-	thirdParty: {
-		cardmarket: 751568
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/033.ts
+++ b/data/Scarlet & Violet/Paldean Fates/033.ts
@@ -55,15 +55,28 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 751570,
+				tcgplayer: 534179,
+				cardtrader: 274217
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 751570,
+				tcgplayer: 534179,
+				cardtrader: 274217
+			}
+		},
+	],
 
 	illustrator: "Narumi Sato",
 
-	thirdParty: {
-		cardmarket: 751570
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/034.ts
+++ b/data/Scarlet & Violet/Paldean Fates/034.ts
@@ -47,15 +47,28 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 751571,
+				tcgplayer: 534180,
+				cardtrader: 274218
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 751571,
+				tcgplayer: 534180,
+				cardtrader: 274218
+			}
+		},
+	],
 
 	illustrator: "kurumitsu",
 
-	thirdParty: {
-		cardmarket: 751571
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/035.ts
+++ b/data/Scarlet & Violet/Paldean Fates/035.ts
@@ -46,15 +46,28 @@ const card: Card = {
 	retreat: 0,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 751572,
+				tcgplayer: 534181,
+				cardtrader: 274219
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 751572,
+				tcgplayer: 534181,
+				cardtrader: 274219
+			}
+		},
+	],
 
 	illustrator: "KYUPIYAMA",
 
-	thirdParty: {
-		cardmarket: 751572
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/036.ts
+++ b/data/Scarlet & Violet/Paldean Fates/036.ts
@@ -67,15 +67,28 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 751573,
+				tcgplayer: 534182,
+				cardtrader: 274220
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 751573,
+				tcgplayer: 534182,
+				cardtrader: 274220
+			}
+		},
+	],
 
 	illustrator: "Tika Matsuno",
 
-	thirdParty: {
-		cardmarket: 751573
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/037.ts
+++ b/data/Scarlet & Violet/Paldean Fates/037.ts
@@ -67,15 +67,28 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		normal: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 751574,
+				tcgplayer: 534183,
+				cardtrader: 274221
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 751574,
+				tcgplayer: 534183,
+				cardtrader: 274221
+			}
+		},
+	],
 
 	illustrator: "Kagemaru Himeno",
 
-	thirdParty: {
-		cardmarket: 751574
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/038.ts
+++ b/data/Scarlet & Violet/Paldean Fates/038.ts
@@ -38,15 +38,35 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 751575,
+				tcgplayer: 534184,
+				cardtrader: 274222
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 751575,
+				tcgplayer: 534184,
+				cardtrader: 274222
+			}
+		},
+		{
+			type: 'reverse',
+			foil: 'cosmos',
+			thirdParty: {
+				cardmarket: 794905
+			}
+		},
+	],
 
 	illustrator: "Mizue",
 
-	thirdParty: {
-		cardmarket: 751575
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/039.ts
+++ b/data/Scarlet & Violet/Paldean Fates/039.ts
@@ -68,15 +68,28 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 751576,
+				tcgplayer: 534185,
+				cardtrader: 274223
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 751576,
+				tcgplayer: 534185,
+				cardtrader: 274223
+			}
+		},
+	],
 
 	illustrator: "You Iribi",
 
-	thirdParty: {
-		cardmarket: 751576
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/040.ts
+++ b/data/Scarlet & Violet/Paldean Fates/040.ts
@@ -77,15 +77,35 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "G",
 
-	variants: {
-		normal: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 751577,
+				tcgplayer: 534186,
+				cardtrader: 274224
+			}
+		},
+		{
+			type: 'holo',
+			stamp: ['pokemon-day'],
+			thirdParty: {
+				cardmarket: 756335
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 751577,
+				tcgplayer: 534186,
+				cardtrader: 274224
+			}
+		},
+	],
 
 	illustrator: "Ryota Murayama",
 
-	thirdParty: {
-		cardmarket: 751577
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/041.ts
+++ b/data/Scarlet & Violet/Paldean Fates/041.ts
@@ -47,15 +47,28 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 751578,
+				tcgplayer: 534187,
+				cardtrader: 274225
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 751578,
+				tcgplayer: 534187,
+				cardtrader: 274225
+			}
+		},
+	],
 
 	illustrator: "kawayoo",
 
-	thirdParty: {
-		cardmarket: 751578
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/042.ts
+++ b/data/Scarlet & Violet/Paldean Fates/042.ts
@@ -47,15 +47,35 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 751579,
+				tcgplayer: 534188,
+				cardtrader: 274226
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 751579,
+				tcgplayer: 534188,
+				cardtrader: 274226
+			}
+		},
+		{
+			type: 'reverse',
+			foil: 'cosmos',
+			thirdParty: {
+				cardmarket: 794906
+			}
+		},
+	],
 
 	illustrator: "yuu",
 
-	thirdParty: {
-		cardmarket: 751579
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/043.ts
+++ b/data/Scarlet & Violet/Paldean Fates/043.ts
@@ -55,15 +55,28 @@ const card: Card = {
 	retreat: 3,
 	regulationMark: "G",
 
-	variants: {
-		normal: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 751580,
+				tcgplayer: 534190,
+				cardtrader: 274227
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 751580,
+				tcgplayer: 534190,
+				cardtrader: 274227
+			}
+		},
+	],
 
 	illustrator: "Kouki Saitou",
 
-	thirdParty: {
-		cardmarket: 751580
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/044.ts
+++ b/data/Scarlet & Violet/Paldean Fates/044.ts
@@ -58,15 +58,28 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 751581,
+				tcgplayer: 534191,
+				cardtrader: 274228
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 751581,
+				tcgplayer: 534191,
+				cardtrader: 274228
+			}
+		},
+	],
 
 	illustrator: "OKUBO",
 
-	thirdParty: {
-		cardmarket: 751581
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/045.ts
+++ b/data/Scarlet & Violet/Paldean Fates/045.ts
@@ -47,15 +47,28 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 751582,
+				tcgplayer: 534192,
+				cardtrader: 274229
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 751582,
+				tcgplayer: 534192,
+				cardtrader: 274229
+			}
+		},
+	],
 
 	illustrator: "nagimiso",
 
-	thirdParty: {
-		cardmarket: 751582
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/046.ts
+++ b/data/Scarlet & Violet/Paldean Fates/046.ts
@@ -55,15 +55,28 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 751583,
+				tcgplayer: 534194,
+				cardtrader: 274230
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 751583,
+				tcgplayer: 534194,
+				cardtrader: 274230
+			}
+		},
+	],
 
 	illustrator: "Ryuta Fuse",
 
-	thirdParty: {
-		cardmarket: 751583
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/047.ts
+++ b/data/Scarlet & Violet/Paldean Fates/047.ts
@@ -77,15 +77,28 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "G",
 
-	variants: {
-		normal: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 751584,
+				tcgplayer: 534197,
+				cardtrader: 274231
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 751584,
+				tcgplayer: 534197,
+				cardtrader: 274231
+			}
+		},
+	],
 
 	illustrator: "Anesaki Dynamic",
 
-	thirdParty: {
-		cardmarket: 751584
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/048.ts
+++ b/data/Scarlet & Violet/Paldean Fates/048.ts
@@ -51,15 +51,28 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 751585,
+				tcgplayer: 534198,
+				cardtrader: 274232
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 751585,
+				tcgplayer: 534198,
+				cardtrader: 274232
+			}
+		},
+	],
 
 	illustrator: "Atsuko Nishida",
 
-	thirdParty: {
-		cardmarket: 751585
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/049.ts
+++ b/data/Scarlet & Violet/Paldean Fates/049.ts
@@ -77,15 +77,28 @@ const card: Card = {
 	retreat: 3,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 751586,
+				tcgplayer: 534210,
+				cardtrader: 274233
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 751586,
+				tcgplayer: 534210,
+				cardtrader: 274233
+			}
+		},
+	],
 
 	illustrator: "Shin Nagasawa",
 
-	thirdParty: {
-		cardmarket: 751586
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/050.ts
+++ b/data/Scarlet & Violet/Paldean Fates/050.ts
@@ -58,15 +58,28 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 751587,
+				tcgplayer: 534211,
+				cardtrader: 274234
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 751587,
+				tcgplayer: 534211,
+				cardtrader: 274234
+			}
+		},
+	],
 
 	illustrator: "ryoma uratsuka",
 
-	thirdParty: {
-		cardmarket: 751587
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/051.ts
+++ b/data/Scarlet & Violet/Paldean Fates/051.ts
@@ -47,15 +47,28 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 751588,
+				tcgplayer: 534387,
+				cardtrader: 274235
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 751588,
+				tcgplayer: 534387,
+				cardtrader: 274235
+			}
+		},
+	],
 
 	illustrator: "Kedamahadaitai Yawarakai",
 
-	thirdParty: {
-		cardmarket: 751588
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/052.ts
+++ b/data/Scarlet & Violet/Paldean Fates/052.ts
@@ -68,15 +68,28 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 751589,
+				tcgplayer: 534414,
+				cardtrader: 274236
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 751589,
+				tcgplayer: 534414,
+				cardtrader: 274236
+			}
+		},
+	],
 
 	illustrator: "Sanosuke Sakuma",
 
-	thirdParty: {
-		cardmarket: 751589
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/053.ts
+++ b/data/Scarlet & Violet/Paldean Fates/053.ts
@@ -69,17 +69,21 @@ const card: Card = {
 	retreat: 4,
 	regulationMark: "G",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 751590,
+				tcgplayer: 534415,
+				cardtrader: 274237
+			}
+		},
+	],
 
 	suffix: "ex",
 	illustrator: "kawayoo",
 
-	thirdParty: {
-		cardmarket: 751590
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/054.ts
+++ b/data/Scarlet & Violet/Paldean Fates/054.ts
@@ -77,17 +77,21 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "G",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 751591,
+				tcgplayer: 534416,
+				cardtrader: 274238
+			}
+		},
+	],
 
 	suffix: "ex",
 	illustrator: "5ban Graphics",
 
-	thirdParty: {
-		cardmarket: 751591
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/055.ts
+++ b/data/Scarlet & Violet/Paldean Fates/055.ts
@@ -58,15 +58,28 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 751592,
+				tcgplayer: 534417,
+				cardtrader: 274239
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 751592,
+				tcgplayer: 534417,
+				cardtrader: 274239
+			}
+		},
+	],
 
 	illustrator: "Nobuhiro Imagawa",
 
-	thirdParty: {
-		cardmarket: 751592
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/056.ts
+++ b/data/Scarlet & Violet/Paldean Fates/056.ts
@@ -55,15 +55,28 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 751593,
+				tcgplayer: 534418,
+				cardtrader: 274240
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 751593,
+				tcgplayer: 534418,
+				cardtrader: 274240
+			}
+		},
+	],
 
 	illustrator: "DOM",
 
-	thirdParty: {
-		cardmarket: 751593
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/057.ts
+++ b/data/Scarlet & Violet/Paldean Fates/057.ts
@@ -77,15 +77,28 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 751595,
+				tcgplayer: 534419,
+				cardtrader: 274241
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 751595,
+				tcgplayer: 534419,
+				cardtrader: 274241
+			}
+		},
+	],
 
 	illustrator: "Nelnal",
 
-	thirdParty: {
-		cardmarket: 751595
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/058.ts
+++ b/data/Scarlet & Violet/Paldean Fates/058.ts
@@ -58,15 +58,28 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 751596,
+				tcgplayer: 534420,
+				cardtrader: 274242
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 751596,
+				tcgplayer: 534420,
+				cardtrader: 274242
+			}
+		},
+	],
 
 	illustrator: "Kouki Saitou",
 
-	thirdParty: {
-		cardmarket: 751596
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/059.ts
+++ b/data/Scarlet & Violet/Paldean Fates/059.ts
@@ -77,17 +77,21 @@ const card: Card = {
 	retreat: 3,
 	regulationMark: "G",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 751597,
+				tcgplayer: 534421,
+				cardtrader: 274243
+			}
+		},
+	],
 
 	suffix: "ex",
 	illustrator: "PLANETA Mochizuki",
 
-	thirdParty: {
-		cardmarket: 751597
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/060.ts
+++ b/data/Scarlet & Violet/Paldean Fates/060.ts
@@ -51,15 +51,28 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 751598,
+				tcgplayer: 534422,
+				cardtrader: 274244
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 751598,
+				tcgplayer: 534422,
+				cardtrader: 274244
+			}
+		},
+	],
 
 	illustrator: "sowsow",
 
-	thirdParty: {
-		cardmarket: 751598
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/061.ts
+++ b/data/Scarlet & Violet/Paldean Fates/061.ts
@@ -68,15 +68,28 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 751599,
+				tcgplayer: 534423,
+				cardtrader: 274245
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 751599,
+				tcgplayer: 534423,
+				cardtrader: 274245
+			}
+		},
+	],
 
 	illustrator: "Mousho",
 
-	thirdParty: {
-		cardmarket: 751599
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/062.ts
+++ b/data/Scarlet & Violet/Paldean Fates/062.ts
@@ -47,15 +47,35 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 751600,
+				tcgplayer: 534424,
+				cardtrader: 274246
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 751600,
+				tcgplayer: 534424,
+				cardtrader: 274246
+			}
+		},
+		{
+			type: 'reverse',
+			foil: 'cosmos',
+			thirdParty: {
+				cardmarket: 794907
+			}
+		},
+	],
 
 	illustrator: "DOM",
 
-	thirdParty: {
-		cardmarket: 751600
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/063.ts
+++ b/data/Scarlet & Violet/Paldean Fates/063.ts
@@ -77,15 +77,28 @@ const card: Card = {
 	retreat: 3,
 	regulationMark: "G",
 
-	variants: {
-		normal: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 751601,
+				tcgplayer: 534425,
+				cardtrader: 274247
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 751601,
+				tcgplayer: 534425,
+				cardtrader: 274247
+			}
+		},
+	],
 
 	illustrator: "KIYOTAKA OSHIYAMA",
 
-	thirdParty: {
-		cardmarket: 751601
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/064.ts
+++ b/data/Scarlet & Violet/Paldean Fates/064.ts
@@ -58,15 +58,28 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 751602,
+				tcgplayer: 534426,
+				cardtrader: 274248
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 751602,
+				tcgplayer: 534426,
+				cardtrader: 274248
+			}
+		},
+	],
 
 	illustrator: "Tetsu Kayama",
 
-	thirdParty: {
-		cardmarket: 751602
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/065.ts
+++ b/data/Scarlet & Violet/Paldean Fates/065.ts
@@ -77,15 +77,28 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "G",
 
-	variants: {
-		normal: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 751603,
+				tcgplayer: 534427,
+				cardtrader: 274249
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 751603,
+				tcgplayer: 534427,
+				cardtrader: 274249
+			}
+		},
+	],
 
 	illustrator: "Anesaki Dynamic",
 
-	thirdParty: {
-		cardmarket: 751603
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/066.ts
+++ b/data/Scarlet & Violet/Paldean Fates/066.ts
@@ -47,17 +47,21 @@ const card: Card = {
 	retreat: 3,
 	regulationMark: "G",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 751604,
+				tcgplayer: 534428,
+				cardtrader: 274250
+			}
+		},
+	],
 
 	suffix: "ex",
 	illustrator: "toriyufu",
 
-	thirdParty: {
-		cardmarket: 751604
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/067.ts
+++ b/data/Scarlet & Violet/Paldean Fates/067.ts
@@ -75,15 +75,28 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "G",
 
-	variants: {
-		normal: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 751605,
+				tcgplayer: 534429,
+				cardtrader: 274251
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 751605,
+				tcgplayer: 534429,
+				cardtrader: 274251
+			}
+		},
+	],
 
 	illustrator: "Mitsuhiro Arita",
 
-	thirdParty: {
-		cardmarket: 751605
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/068.ts
+++ b/data/Scarlet & Violet/Paldean Fates/068.ts
@@ -38,15 +38,28 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 751606,
+				tcgplayer: 534430,
+				cardtrader: 274252
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 751606,
+				tcgplayer: 534430,
+				cardtrader: 274252
+			}
+		},
+	],
 
 	illustrator: "chibi",
 
-	thirdParty: {
-		cardmarket: 751606
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/069.ts
+++ b/data/Scarlet & Violet/Paldean Fates/069.ts
@@ -77,17 +77,21 @@ const card: Card = {
 	retreat: 0,
 	regulationMark: "G",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 751607,
+				tcgplayer: 534431,
+				cardtrader: 274253
+			}
+		},
+	],
 
 	suffix: "ex",
 	illustrator: "Nisota Niso",
 
-	thirdParty: {
-		cardmarket: 751607
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/070.ts
+++ b/data/Scarlet & Violet/Paldean Fates/070.ts
@@ -47,15 +47,28 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		normal: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 751608,
+				tcgplayer: 534432,
+				cardtrader: 274254
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 751608,
+				tcgplayer: 534432,
+				cardtrader: 274254
+			}
+		},
+	],
 
 	illustrator: "GIDORA",
 
-	thirdParty: {
-		cardmarket: 751608
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/071.ts
+++ b/data/Scarlet & Violet/Paldean Fates/071.ts
@@ -47,15 +47,28 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 751609,
+				tcgplayer: 534433,
+				cardtrader: 274255
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 751609,
+				tcgplayer: 534433,
+				cardtrader: 274255
+			}
+		},
+	],
 
 	illustrator: "Mina Nakai",
 
-	thirdParty: {
-		cardmarket: 751609
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/072.ts
+++ b/data/Scarlet & Violet/Paldean Fates/072.ts
@@ -75,15 +75,28 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 751610,
+				tcgplayer: 534434,
+				cardtrader: 274256
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 751610,
+				tcgplayer: 534434,
+				cardtrader: 274256
+			}
+		},
+	],
 
 	illustrator: "Akira Komayama",
 
-	thirdParty: {
-		cardmarket: 751610
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/073.ts
+++ b/data/Scarlet & Violet/Paldean Fates/073.ts
@@ -58,15 +58,28 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 751611,
+				tcgplayer: 534435,
+				cardtrader: 274257
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 751611,
+				tcgplayer: 534435,
+				cardtrader: 274257
+			}
+		},
+	],
 
 	illustrator: "Oswaldo KATO",
 
-	thirdParty: {
-		cardmarket: 751611
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/074.ts
+++ b/data/Scarlet & Violet/Paldean Fates/074.ts
@@ -68,15 +68,28 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 751612,
+				tcgplayer: 534436,
+				cardtrader: 274258
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 751612,
+				tcgplayer: 534436,
+				cardtrader: 274258
+			}
+		},
+	],
 
 	illustrator: "KIYOTAKA OSHIYAMA",
 
-	thirdParty: {
-		cardmarket: 751612
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/075.ts
+++ b/data/Scarlet & Violet/Paldean Fates/075.ts
@@ -69,17 +69,21 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 751613,
+				tcgplayer: 534437,
+				cardtrader: 274259
+			}
+		},
+	],
 
 	suffix: "ex",
 	illustrator: "PLANETA Mochizuki",
 
-	thirdParty: {
-		cardmarket: 751613
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/076.ts
+++ b/data/Scarlet & Violet/Paldean Fates/076.ts
@@ -28,15 +28,28 @@ const card: Card = {
 	trainerType: "Stadium",
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 751614,
+				tcgplayer: 534438,
+				cardtrader: 274260
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 751614,
+				tcgplayer: 534438,
+				cardtrader: 274260
+			}
+		},
+	],
 
 	illustrator: "Oswaldo KATO",
 
-	thirdParty: {
-		cardmarket: 751614
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/077.ts
+++ b/data/Scarlet & Violet/Paldean Fates/077.ts
@@ -28,15 +28,28 @@ const card: Card = {
 	trainerType: "Supporter",
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 751615,
+				tcgplayer: 534439,
+				cardtrader: 274261
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 751615,
+				tcgplayer: 534439,
+				cardtrader: 274261
+			}
+		},
+	],
 
 	illustrator: "kantaro",
 
-	thirdParty: {
-		cardmarket: 751615
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/078.ts
+++ b/data/Scarlet & Violet/Paldean Fates/078.ts
@@ -28,15 +28,28 @@ const card: Card = {
 	trainerType: "Supporter",
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 751616,
+				tcgplayer: 534440,
+				cardtrader: 274262
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 751616,
+				tcgplayer: 534440,
+				cardtrader: 274262
+			}
+		},
+	],
 
 	illustrator: "GOSSAN",
 
-	thirdParty: {
-		cardmarket: 751616
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/079.ts
+++ b/data/Scarlet & Violet/Paldean Fates/079.ts
@@ -28,15 +28,28 @@ const card: Card = {
 	trainerType: "Item",
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 751617,
+				tcgplayer: 534441,
+				cardtrader: 274263
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 751617,
+				tcgplayer: 534441,
+				cardtrader: 274263
+			}
+		},
+	],
 
 	illustrator: "Toyste Beach",
 
-	thirdParty: {
-		cardmarket: 751617
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/080.ts
+++ b/data/Scarlet & Violet/Paldean Fates/080.ts
@@ -28,15 +28,28 @@ const card: Card = {
 	trainerType: "Supporter",
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 751619,
+				tcgplayer: 534442,
+				cardtrader: 274264
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 751619,
+				tcgplayer: 534442,
+				cardtrader: 274264
+			}
+		},
+	],
 
 	illustrator: "Sanosuke Sakuma",
 
-	thirdParty: {
-		cardmarket: 751619
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/081.ts
+++ b/data/Scarlet & Violet/Paldean Fates/081.ts
@@ -28,15 +28,28 @@ const card: Card = {
 	trainerType: "Stadium",
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 751620,
+				tcgplayer: 534443,
+				cardtrader: 274265
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 751620,
+				tcgplayer: 534443,
+				cardtrader: 274265
+			}
+		},
+	],
 
 	illustrator: "AYUMI ODASHIMA",
 
-	thirdParty: {
-		cardmarket: 751620
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/082.ts
+++ b/data/Scarlet & Violet/Paldean Fates/082.ts
@@ -28,15 +28,28 @@ const card: Card = {
 	trainerType: "Supporter",
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 751621,
+				tcgplayer: 534444,
+				cardtrader: 274266
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 751621,
+				tcgplayer: 534444,
+				cardtrader: 274266
+			}
+		},
+	],
 
 	illustrator: "Sanosuke Sakuma",
 
-	thirdParty: {
-		cardmarket: 751621
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/083.ts
+++ b/data/Scarlet & Violet/Paldean Fates/083.ts
@@ -28,15 +28,28 @@ const card: Card = {
 	trainerType: "Item",
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 751622,
+				tcgplayer: 534445,
+				cardtrader: 274267
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 751622,
+				tcgplayer: 534445,
+				cardtrader: 274267
+			}
+		},
+	],
 
 	illustrator: "AYUMI ODASHIMA",
 
-	thirdParty: {
-		cardmarket: 751622
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/084.ts
+++ b/data/Scarlet & Violet/Paldean Fates/084.ts
@@ -28,15 +28,28 @@ const card: Card = {
 	trainerType: "Item",
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 751623,
+				tcgplayer: 534446,
+				cardtrader: 274268
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 751623,
+				tcgplayer: 534446,
+				cardtrader: 274268
+			}
+		},
+	],
 
 	illustrator: "Toyste Beach",
 
-	thirdParty: {
-		cardmarket: 751623
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/085.ts
+++ b/data/Scarlet & Violet/Paldean Fates/085.ts
@@ -28,15 +28,28 @@ const card: Card = {
 	trainerType: "Supporter",
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 751624,
+				tcgplayer: 534447,
+				cardtrader: 274269
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 751624,
+				tcgplayer: 534447,
+				cardtrader: 274269
+			}
+		},
+	],
 
 	illustrator: "Cona Nitanda",
 
-	thirdParty: {
-		cardmarket: 751624
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/086.ts
+++ b/data/Scarlet & Violet/Paldean Fates/086.ts
@@ -28,15 +28,28 @@ const card: Card = {
 	trainerType: "Supporter",
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 751625,
+				tcgplayer: 534448,
+				cardtrader: 274270
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 751625,
+				tcgplayer: 534448,
+				cardtrader: 274270
+			}
+		},
+	],
 
 	illustrator: "Naoki Saito",
 
-	thirdParty: {
-		cardmarket: 751624
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/087.ts
+++ b/data/Scarlet & Violet/Paldean Fates/087.ts
@@ -28,15 +28,28 @@ const card: Card = {
 	trainerType: "Supporter",
 	regulationMark: "G",
 
-	variants: {
-		normal: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 751626,
+				tcgplayer: 534449,
+				cardtrader: 274271
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 751626,
+				tcgplayer: 534449,
+				cardtrader: 274271
+			}
+		},
+	],
 
 	illustrator: "kirisAki",
 
-	thirdParty: {
-		cardmarket: 751626
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/088.ts
+++ b/data/Scarlet & Violet/Paldean Fates/088.ts
@@ -28,15 +28,28 @@ const card: Card = {
 	trainerType: "Supporter",
 	regulationMark: "G",
 
-	variants: {
-		normal: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 751627,
+				tcgplayer: 534450,
+				cardtrader: 274272
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 751627,
+				tcgplayer: 534450,
+				cardtrader: 274272
+			}
+		},
+	],
 
 	illustrator: "kirisAki",
 
-	thirdParty: {
-		cardmarket: 751626
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/089.ts
+++ b/data/Scarlet & Violet/Paldean Fates/089.ts
@@ -28,15 +28,28 @@ const card: Card = {
 	trainerType: "Item",
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 751628,
+				tcgplayer: 534451,
+				cardtrader: 274273
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 751628,
+				tcgplayer: 534451,
+				cardtrader: 274273
+			}
+		},
+	],
 
 	illustrator: "Studio Bora Inc.",
 
-	thirdParty: {
-		cardmarket: 751628
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/090.ts
+++ b/data/Scarlet & Violet/Paldean Fates/090.ts
@@ -52,15 +52,28 @@ const card: Card = {
 	trainerType: "Tool",
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 751629,
+				tcgplayer: 534452,
+				cardtrader: 274274
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 751629,
+				tcgplayer: 534452,
+				cardtrader: 274274
+			}
+		},
+	],
 
 	illustrator: "Studio Bora Inc.",
 
-	thirdParty: {
-		cardmarket: 751629
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/091.ts
+++ b/data/Scarlet & Violet/Paldean Fates/091.ts
@@ -28,15 +28,28 @@ const card: Card = {
 	trainerType: "Item",
 	regulationMark: "G",
 
-	variants: {
-		holo: false
-	},
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 751630,
+				tcgplayer: 534453,
+				cardtrader: 274275
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 751630,
+				tcgplayer: 534453,
+				cardtrader: 274275
+			}
+		},
+	],
 
 	illustrator: "Ayaka Yoshida",
 
-	thirdParty: {
-		cardmarket: 751630
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/092.ts
+++ b/data/Scarlet & Violet/Paldean Fates/092.ts
@@ -38,16 +38,20 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 751631,
+				tcgplayer: 534459,
+				cardtrader: 274276
+			}
+		},
+	],
 
 	illustrator: "otumami",
 
-	thirdParty: {
-		cardmarket: 751631
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/093.ts
+++ b/data/Scarlet & Violet/Paldean Fates/093.ts
@@ -68,16 +68,20 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 751632,
+				tcgplayer: 534460,
+				cardtrader: 274277
+			}
+		},
+	],
 
 	illustrator: "OKACHEKE",
 
-	thirdParty: {
-		cardmarket: 751632
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/094.ts
+++ b/data/Scarlet & Violet/Paldean Fates/094.ts
@@ -68,16 +68,20 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "G",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 751633,
+				tcgplayer: 534462,
+				cardtrader: 274278
+			}
+		},
+	],
 
 	illustrator: "0313",
 
-	thirdParty: {
-		cardmarket: 751633
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/095.ts
+++ b/data/Scarlet & Violet/Paldean Fates/095.ts
@@ -60,16 +60,20 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 751634,
+				tcgplayer: 534463,
+				cardtrader: 274279
+			}
+		},
+	],
 
 	illustrator: "Hitoshi Ariga",
 
-	thirdParty: {
-		cardmarket: 751634
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/096.ts
+++ b/data/Scarlet & Violet/Paldean Fates/096.ts
@@ -47,16 +47,20 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 751635,
+				tcgplayer: 534465,
+				cardtrader: 274280
+			}
+		},
+	],
 
 	illustrator: "Saya Tsuruta",
 
-	thirdParty: {
-		cardmarket: 751635
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/097.ts
+++ b/data/Scarlet & Violet/Paldean Fates/097.ts
@@ -77,16 +77,20 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 751636,
+				tcgplayer: 534466,
+				cardtrader: 274281
+			}
+		},
+	],
 
 	illustrator: "Mizue",
 
-	thirdParty: {
-		cardmarket: 751636
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/098.ts
+++ b/data/Scarlet & Violet/Paldean Fates/098.ts
@@ -77,16 +77,20 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 751637,
+				tcgplayer: 534469,
+				cardtrader: 274282
+			}
+		},
+	],
 
 	illustrator: "Lee HyunJung",
 
-	thirdParty: {
-		cardmarket: 751637
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/099.ts
+++ b/data/Scarlet & Violet/Paldean Fates/099.ts
@@ -38,16 +38,20 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "G",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 751638,
+				tcgplayer: 534470,
+				cardtrader: 274283
+			}
+		},
+	],
 
 	illustrator: "Scav",
 
-	thirdParty: {
-		cardmarket: 751527
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/100.ts
+++ b/data/Scarlet & Violet/Paldean Fates/100.ts
@@ -38,16 +38,20 @@ const card: Card = {
 	retreat: 3,
 	regulationMark: "G",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 751639,
+				tcgplayer: 534471,
+				cardtrader: 274284
+			}
+		},
+	],
 
 	illustrator: "Saya Tsuruta",
 
-	thirdParty: {
-		cardmarket: 751639
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/101.ts
+++ b/data/Scarlet & Violet/Paldean Fates/101.ts
@@ -68,16 +68,20 @@ const card: Card = {
 	retreat: 3,
 	regulationMark: "G",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 751640,
+				tcgplayer: 534472,
+				cardtrader: 274285
+			}
+		},
+	],
 
 	illustrator: "Hitoshi Ariga",
 
-	thirdParty: {
-		cardmarket: 751640
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/102.ts
+++ b/data/Scarlet & Violet/Paldean Fates/102.ts
@@ -58,16 +58,20 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 751641,
+				tcgplayer: 534473,
+				cardtrader: 274286
+			}
+		},
+	],
 
 	illustrator: "otumami",
 
-	thirdParty: {
-		cardmarket: 751641
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/103.ts
+++ b/data/Scarlet & Violet/Paldean Fates/103.ts
@@ -68,16 +68,20 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 751642,
+				tcgplayer: 534475,
+				cardtrader: 274287
+			}
+		},
+	],
 
 	illustrator: "saino misaki",
 
-	thirdParty: {
-		cardmarket: 751642
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/104.ts
+++ b/data/Scarlet & Violet/Paldean Fates/104.ts
@@ -68,16 +68,20 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "G",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 751643,
+				tcgplayer: 534476,
+				cardtrader: 274288
+			}
+		},
+	],
 
 	illustrator: "Hideki Ishikawa",
 
-	thirdParty: {
-		cardmarket: 751643
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/105.ts
+++ b/data/Scarlet & Violet/Paldean Fates/105.ts
@@ -47,16 +47,20 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 751644,
+				tcgplayer: 534478,
+				cardtrader: 274289
+			}
+		},
+	],
 
 	illustrator: "Ryuta Fuse",
 
-	thirdParty: {
-		cardmarket: 751644
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/106.ts
+++ b/data/Scarlet & Violet/Paldean Fates/106.ts
@@ -58,16 +58,20 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 751645,
+				tcgplayer: 534479,
+				cardtrader: 274290
+			}
+		},
+	],
 
 	illustrator: "OKACHEKE",
 
-	thirdParty: {
-		cardmarket: 751645
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/107.ts
+++ b/data/Scarlet & Violet/Paldean Fates/107.ts
@@ -77,16 +77,20 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "G",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 751646,
+				tcgplayer: 534481,
+				cardtrader: 274291
+			}
+		},
+	],
 
 	illustrator: "Kouki Saitou",
 
-	thirdParty: {
-		cardmarket: 751646
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/108.ts
+++ b/data/Scarlet & Violet/Paldean Fates/108.ts
@@ -47,16 +47,20 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 751647,
+				tcgplayer: 534482,
+				cardtrader: 274292
+			}
+		},
+	],
 
 	illustrator: "Misa Tsutsui",
 
-	thirdParty: {
-		cardmarket: 751647
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/109.ts
+++ b/data/Scarlet & Violet/Paldean Fates/109.ts
@@ -58,16 +58,20 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 751648,
+				tcgplayer: 534483,
+				cardtrader: 274293
+			}
+		},
+	],
 
 	illustrator: "sowsow",
 
-	thirdParty: {
-		cardmarket: 751648
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/110.ts
+++ b/data/Scarlet & Violet/Paldean Fates/110.ts
@@ -68,16 +68,20 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "G",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 751649,
+				tcgplayer: 534484,
+				cardtrader: 274294
+			}
+		},
+	],
 
 	illustrator: "Kouki Saitou",
 
-	thirdParty: {
-		cardmarket: 751649
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/111.ts
+++ b/data/Scarlet & Violet/Paldean Fates/111.ts
@@ -69,16 +69,20 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "G",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 751650,
+				tcgplayer: 534485,
+				cardtrader: 274295
+			}
+		},
+	],
 
 	illustrator: "Hitoshi Ariga",
 
-	thirdParty: {
-		cardmarket: 751650
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/112.ts
+++ b/data/Scarlet & Violet/Paldean Fates/112.ts
@@ -69,16 +69,20 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "G",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 751651,
+				tcgplayer: 534493,
+				cardtrader: 274296
+			}
+		},
+	],
 
 	illustrator: "Ryuta Fuse",
 
-	thirdParty: {
-		cardmarket: 751651
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/113.ts
+++ b/data/Scarlet & Violet/Paldean Fates/113.ts
@@ -60,16 +60,20 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 751652,
+				tcgplayer: 534494,
+				cardtrader: 274297
+			}
+		},
+	],
 
 	illustrator: "Akira Komayama",
 
-	thirdParty: {
-		cardmarket: 751652
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/114.ts
+++ b/data/Scarlet & Violet/Paldean Fates/114.ts
@@ -38,16 +38,20 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 751653,
+				tcgplayer: 534496,
+				cardtrader: 274298
+			}
+		},
+	],
 
 	illustrator: "Masakazu Fukuda",
 
-	thirdParty: {
-		cardmarket: 751653
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/115.ts
+++ b/data/Scarlet & Violet/Paldean Fates/115.ts
@@ -77,16 +77,20 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "G",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 751654,
+				tcgplayer: 534497,
+				cardtrader: 274299
+			}
+		},
+	],
 
 	illustrator: "Atsushi Furusawa",
 
-	thirdParty: {
-		cardmarket: 751654
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/116.ts
+++ b/data/Scarlet & Violet/Paldean Fates/116.ts
@@ -58,16 +58,20 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "G",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 751655,
+				tcgplayer: 534504,
+				cardtrader: 274300
+			}
+		},
+	],
 
 	illustrator: "Taira Akitsu",
 
-	thirdParty: {
-		cardmarket: 751655
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/117.ts
+++ b/data/Scarlet & Violet/Paldean Fates/117.ts
@@ -77,16 +77,20 @@ const card: Card = {
 	retreat: 3,
 	regulationMark: "G",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 751656,
+				tcgplayer: 534507,
+				cardtrader: 274301
+			}
+		},
+	],
 
 	illustrator: "Souichirou Gunjima",
 
-	thirdParty: {
-		cardmarket: 751656
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/118.ts
+++ b/data/Scarlet & Violet/Paldean Fates/118.ts
@@ -47,16 +47,20 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 751657,
+				tcgplayer: 534508,
+				cardtrader: 274302
+			}
+		},
+	],
 
 	illustrator: "Nisota Niso",
 
-	thirdParty: {
-		cardmarket: 751657
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/119.ts
+++ b/data/Scarlet & Violet/Paldean Fates/119.ts
@@ -68,16 +68,20 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 751658,
+				tcgplayer: 534510,
+				cardtrader: 274303
+			}
+		},
+	],
 
 	illustrator: "Shigenori Negishi",
 
-	thirdParty: {
-		cardmarket: 751658
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/120.ts
+++ b/data/Scarlet & Violet/Paldean Fates/120.ts
@@ -67,16 +67,20 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "G",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 751659,
+				tcgplayer: 534511,
+				cardtrader: 274304
+			}
+		},
+	],
 
 	illustrator: "GOSSAN",
 
-	thirdParty: {
-		cardmarket: 751659
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/121.ts
+++ b/data/Scarlet & Violet/Paldean Fates/121.ts
@@ -47,16 +47,20 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 751660,
+				tcgplayer: 534512,
+				cardtrader: 274305
+			}
+		},
+	],
 
 	illustrator: "Misa Tsutsui",
 
-	thirdParty: {
-		cardmarket: 751660
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/122.ts
+++ b/data/Scarlet & Violet/Paldean Fates/122.ts
@@ -66,16 +66,20 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "G",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 751661,
+				tcgplayer: 534513,
+				cardtrader: 274306
+			}
+		},
+	],
 
 	illustrator: "Kyoko Umemoto",
 
-	thirdParty: {
-		cardmarket: 751661
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/123.ts
+++ b/data/Scarlet & Violet/Paldean Fates/123.ts
@@ -58,16 +58,20 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "G",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 751662,
+				tcgplayer: 534514,
+				cardtrader: 274307
+			}
+		},
+	],
 
 	illustrator: "kurumitsu",
 
-	thirdParty: {
-		cardmarket: 751662
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/124.ts
+++ b/data/Scarlet & Violet/Paldean Fates/124.ts
@@ -77,16 +77,20 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "G",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 751663,
+				tcgplayer: 534515,
+				cardtrader: 274308
+			}
+		},
+	],
 
 	illustrator: "Shin Nagasawa",
 
-	thirdParty: {
-		cardmarket: 751663
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/125.ts
+++ b/data/Scarlet & Violet/Paldean Fates/125.ts
@@ -60,16 +60,20 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "G",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 751664,
+				tcgplayer: 534516,
+				cardtrader: 274309
+			}
+		},
+	],
 
 	illustrator: "Nelnal",
 
-	thirdParty: {
-		cardmarket: 751664
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/126.ts
+++ b/data/Scarlet & Violet/Paldean Fates/126.ts
@@ -60,16 +60,20 @@ const card: Card = {
 	retreat: 4,
 	regulationMark: "G",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 751665,
+				tcgplayer: 534517,
+				cardtrader: 274310
+			}
+		},
+	],
 
 	illustrator: "Shigenori Negishi",
 
-	thirdParty: {
-		cardmarket: 751665
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/127.ts
+++ b/data/Scarlet & Violet/Paldean Fates/127.ts
@@ -67,16 +67,20 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 751666,
+				tcgplayer: 534518,
+				cardtrader: 274311
+			}
+		},
+	],
 
 	illustrator: "Kagemaru Himeno",
 
-	thirdParty: {
-		cardmarket: 751666
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/128.ts
+++ b/data/Scarlet & Violet/Paldean Fates/128.ts
@@ -58,16 +58,20 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "G",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 751667,
+				tcgplayer: 534519,
+				cardtrader: 274312
+			}
+		},
+	],
 
 	illustrator: "Taira Akitsu",
 
-	thirdParty: {
-		cardmarket: 751667
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/129.ts
+++ b/data/Scarlet & Violet/Paldean Fates/129.ts
@@ -59,16 +59,20 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "G",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 751668,
+				tcgplayer: 534520,
+				cardtrader: 274313
+			}
+		},
+	],
 
 	illustrator: "Kouki Saitou",
 
-	thirdParty: {
-		cardmarket: 751668
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/130.ts
+++ b/data/Scarlet & Violet/Paldean Fates/130.ts
@@ -68,16 +68,20 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "G",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 751669,
+				tcgplayer: 534521,
+				cardtrader: 274314
+			}
+		},
+	],
 
 	illustrator: "GOSSAN",
 
-	thirdParty: {
-		cardmarket: 751669
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/131.ts
+++ b/data/Scarlet & Violet/Paldean Fates/131.ts
@@ -58,16 +58,20 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 751670,
+				tcgplayer: 534522,
+				cardtrader: 274315
+			}
+		},
+	],
 
 	illustrator: "Yuu Nishida",
 
-	thirdParty: {
-		cardmarket: 751670
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/132.ts
+++ b/data/Scarlet & Violet/Paldean Fates/132.ts
@@ -77,16 +77,20 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 751671,
+				tcgplayer: 534523,
+				cardtrader: 272983
+			}
+		},
+	],
 
 	illustrator: "Sanosuke Sakuma",
 
-	thirdParty: {
-		cardmarket: 751671
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/133.ts
+++ b/data/Scarlet & Violet/Paldean Fates/133.ts
@@ -47,16 +47,20 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 751672,
+				tcgplayer: 534525,
+				cardtrader: 274316
+			}
+		},
+	],
 
 	illustrator: "Misa Tsutsui",
 
-	thirdParty: {
-		cardmarket: 751672
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/134.ts
+++ b/data/Scarlet & Violet/Paldean Fates/134.ts
@@ -68,16 +68,20 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 751673,
+				tcgplayer: 534527,
+				cardtrader: 274317
+			}
+		},
+	],
 
 	illustrator: "Masakazu Fukuda",
 
-	thirdParty: {
-		cardmarket: 751673
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/135.ts
+++ b/data/Scarlet & Violet/Paldean Fates/135.ts
@@ -47,16 +47,20 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 751674,
+				tcgplayer: 534528,
+				cardtrader: 274318
+			}
+		},
+	],
 
 	illustrator: "Saya Tsuruta",
 
-	thirdParty: {
-		cardmarket: 751674
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/136.ts
+++ b/data/Scarlet & Violet/Paldean Fates/136.ts
@@ -59,16 +59,20 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 751675,
+				tcgplayer: 534529,
+				cardtrader: 274319
+			}
+		},
+	],
 
 	illustrator: "Souichirou Gunjima",
 
-	thirdParty: {
-		cardmarket: 751675
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/137.ts
+++ b/data/Scarlet & Violet/Paldean Fates/137.ts
@@ -77,16 +77,20 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 751676,
+				tcgplayer: 534533,
+				cardtrader: 274320
+			}
+		},
+	],
 
 	illustrator: "kantaro",
 
-	thirdParty: {
-		cardmarket: 751676
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/138.ts
+++ b/data/Scarlet & Violet/Paldean Fates/138.ts
@@ -69,16 +69,20 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 751677,
+				tcgplayer: 534538,
+				cardtrader: 274321
+			}
+		},
+	],
 
 	illustrator: "saino misaki",
 
-	thirdParty: {
-		cardmarket: 751677
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/139.ts
+++ b/data/Scarlet & Violet/Paldean Fates/139.ts
@@ -69,16 +69,20 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "G",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 751678,
+				tcgplayer: 534540,
+				cardtrader: 274322
+			}
+		},
+	],
 
 	illustrator: "Shin Nagasawa",
 
-	thirdParty: {
-		cardmarket: 751678
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/140.ts
+++ b/data/Scarlet & Violet/Paldean Fates/140.ts
@@ -47,16 +47,20 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 751679,
+				tcgplayer: 534574,
+				cardtrader: 274323
+			}
+		},
+	],
 
 	illustrator: "Lee HyunJung",
 
-	thirdParty: {
-		cardmarket: 751679
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/141.ts
+++ b/data/Scarlet & Violet/Paldean Fates/141.ts
@@ -75,16 +75,20 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "G",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 751680,
+				tcgplayer: 534576,
+				cardtrader: 274324
+			}
+		},
+	],
 
 	illustrator: "GIDORA",
 
-	thirdParty: {
-		cardmarket: 751680
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/142.ts
+++ b/data/Scarlet & Violet/Paldean Fates/142.ts
@@ -51,16 +51,20 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 751681,
+				tcgplayer: 534577,
+				cardtrader: 274325
+			}
+		},
+	],
 
 	illustrator: "kurumitsu",
 
-	thirdParty: {
-		cardmarket: 751681
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/143.ts
+++ b/data/Scarlet & Violet/Paldean Fates/143.ts
@@ -68,16 +68,20 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 751682,
+				tcgplayer: 534579,
+				cardtrader: 274326
+			}
+		},
+	],
 
 	illustrator: "Mizue",
 
-	thirdParty: {
-		cardmarket: 751682
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/144.ts
+++ b/data/Scarlet & Violet/Paldean Fates/144.ts
@@ -77,16 +77,20 @@ const card: Card = {
 	retreat: 0,
 	regulationMark: "G",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 751683,
+				tcgplayer: 534581,
+				cardtrader: 274327
+			}
+		},
+	],
 
 	illustrator: "Atsushi Furusawa",
 
-	thirdParty: {
-		cardmarket: 751683
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/145.ts
+++ b/data/Scarlet & Violet/Paldean Fates/145.ts
@@ -60,16 +60,20 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 751684,
+				tcgplayer: 534582,
+				cardtrader: 274328
+			}
+		},
+	],
 
 	illustrator: "Scav",
 
-	thirdParty: {
-		cardmarket: 751684
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/146.ts
+++ b/data/Scarlet & Violet/Paldean Fates/146.ts
@@ -66,16 +66,20 @@ const card: Card = {
 	retreat: 0,
 	regulationMark: "G",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 751685,
+				tcgplayer: 534584,
+				cardtrader: 274329
+			}
+		},
+	],
 
 	illustrator: "Nisota Niso",
 
-	thirdParty: {
-		cardmarket: 751685
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/147.ts
+++ b/data/Scarlet & Violet/Paldean Fates/147.ts
@@ -68,16 +68,20 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "G",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 751686,
+				tcgplayer: 534616,
+				cardtrader: 274330
+			}
+		},
+	],
 
 	illustrator: "Kagemaru Himeno",
 
-	thirdParty: {
-		cardmarket: 751686
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/148.ts
+++ b/data/Scarlet & Violet/Paldean Fates/148.ts
@@ -38,16 +38,20 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 751687,
+				tcgplayer: 534631,
+				cardtrader: 274331
+			}
+		},
+	],
 
 	illustrator: "Kouki Saitou",
 
-	thirdParty: {
-		cardmarket: 751687
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/149.ts
+++ b/data/Scarlet & Violet/Paldean Fates/149.ts
@@ -55,16 +55,20 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 751688,
+				tcgplayer: 534634,
+				cardtrader: 274332
+			}
+		},
+	],
 
 	illustrator: "Souichirou Gunjima",
 
-	thirdParty: {
-		cardmarket: 751688
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/150.ts
+++ b/data/Scarlet & Violet/Paldean Fates/150.ts
@@ -43,16 +43,20 @@ const card: Card = {
 	retreat: 0,
 	regulationMark: "G",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 751689,
+				tcgplayer: 534636,
+				cardtrader: 274333
+			}
+		},
+	],
 
 	illustrator: "Mizue",
 
-	thirdParty: {
-		cardmarket: 751689
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/151.ts
+++ b/data/Scarlet & Violet/Paldean Fates/151.ts
@@ -47,16 +47,19 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 751690,
+				tcgplayer: 534642
+			}
+		},
+	],
 
 	illustrator: "sowsow",
 
-	thirdParty: {
-		cardmarket: 751690
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/152.ts
+++ b/data/Scarlet & Violet/Paldean Fates/152.ts
@@ -68,16 +68,20 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 751691,
+				tcgplayer: 534646,
+				cardtrader: 274337
+			}
+		},
+	],
 
 	illustrator: "nagimiso",
 
-	thirdParty: {
-		cardmarket: 751691
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/153.ts
+++ b/data/Scarlet & Violet/Paldean Fates/153.ts
@@ -38,16 +38,20 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 751692,
+				tcgplayer: 534650,
+				cardtrader: 274338
+			}
+		},
+	],
 
 	illustrator: "yuu",
 
-	thirdParty: {
-		cardmarket: 751692
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/154.ts
+++ b/data/Scarlet & Violet/Paldean Fates/154.ts
@@ -68,16 +68,20 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 751693,
+				tcgplayer: 534659,
+				cardtrader: 274339
+			}
+		},
+	],
 
 	illustrator: "Ryuta Fuse",
 
-	thirdParty: {
-		cardmarket: 751693
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/155.ts
+++ b/data/Scarlet & Violet/Paldean Fates/155.ts
@@ -60,16 +60,20 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 751694,
+				tcgplayer: 534662,
+				cardtrader: 274340
+			}
+		},
+	],
 
 	illustrator: "Kyoko Umemoto",
 
-	thirdParty: {
-		cardmarket: 751694
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/156.ts
+++ b/data/Scarlet & Violet/Paldean Fates/156.ts
@@ -66,16 +66,20 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 751695,
+				tcgplayer: 534670,
+				cardtrader: 274341
+			}
+		},
+	],
 
 	illustrator: "otumami",
 
-	thirdParty: {
-		cardmarket: 751695
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/157.ts
+++ b/data/Scarlet & Violet/Paldean Fates/157.ts
@@ -43,16 +43,20 @@ const card: Card = {
 	retreat: 0,
 	regulationMark: "G",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 751696,
+				tcgplayer: 534671,
+				cardtrader: 274342
+			}
+		},
+	],
 
 	illustrator: "Saya Tsuruta",
 
-	thirdParty: {
-		cardmarket: 751696
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/158.ts
+++ b/data/Scarlet & Violet/Paldean Fates/158.ts
@@ -69,16 +69,20 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 751697,
+				tcgplayer: 534680,
+				cardtrader: 274343
+			}
+		},
+	],
 
 	illustrator: "MAHOU",
 
-	thirdParty: {
-		cardmarket: 751697
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/159.ts
+++ b/data/Scarlet & Violet/Paldean Fates/159.ts
@@ -69,16 +69,20 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 751698,
+				tcgplayer: 534681,
+				cardtrader: 274344
+			}
+		},
+	],
 
 	illustrator: "yuu",
 
-	thirdParty: {
-		cardmarket: 751698
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/160.ts
+++ b/data/Scarlet & Violet/Paldean Fates/160.ts
@@ -67,16 +67,20 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 751699,
+				tcgplayer: 534683,
+				cardtrader: 274345
+			}
+		},
+	],
 
 	illustrator: "Nelnal",
 
-	thirdParty: {
-		cardmarket: 751699
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/161.ts
+++ b/data/Scarlet & Violet/Paldean Fates/161.ts
@@ -68,16 +68,20 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 751700,
+				tcgplayer: 534685,
+				cardtrader: 274346
+			}
+		},
+	],
 
 	illustrator: "Sanosuke Sakuma",
 
-	thirdParty: {
-		cardmarket: 751700
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/162.ts
+++ b/data/Scarlet & Violet/Paldean Fates/162.ts
@@ -77,16 +77,20 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "G",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 751701,
+				tcgplayer: 534687,
+				cardtrader: 274347
+			}
+		},
+	],
 
 	illustrator: "Kouki Saitou",
 
-	thirdParty: {
-		cardmarket: 751701
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/163.ts
+++ b/data/Scarlet & Violet/Paldean Fates/163.ts
@@ -75,16 +75,20 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 751702,
+				tcgplayer: 534693,
+				cardtrader: 274348
+			}
+		},
+	],
 
 	illustrator: "Nelnal",
 
-	thirdParty: {
-		cardmarket: 751702
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/164.ts
+++ b/data/Scarlet & Violet/Paldean Fates/164.ts
@@ -47,16 +47,20 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 751703,
+				tcgplayer: 534694,
+				cardtrader: 274349
+			}
+		},
+	],
 
 	illustrator: "Kyoko Umemoto",
 
-	thirdParty: {
-		cardmarket: 751703
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/165.ts
+++ b/data/Scarlet & Violet/Paldean Fates/165.ts
@@ -58,16 +58,20 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 751704,
+				tcgplayer: 534697,
+				cardtrader: 274350
+			}
+		},
+	],
 
 	illustrator: "yuu",
 
-	thirdParty: {
-		cardmarket: 751704
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/166.ts
+++ b/data/Scarlet & Violet/Paldean Fates/166.ts
@@ -77,16 +77,20 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "G",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 751705,
+				tcgplayer: 534699,
+				cardtrader: 274351
+			}
+		},
+	],
 
 	illustrator: "Yuu Nishida",
 
-	thirdParty: {
-		cardmarket: 751705
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/167.ts
+++ b/data/Scarlet & Violet/Paldean Fates/167.ts
@@ -77,16 +77,20 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "G",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 751706,
+				tcgplayer: 534704,
+				cardtrader: 274352
+			}
+		},
+	],
 
 	illustrator: "Kagemaru Himeno",
 
-	thirdParty: {
-		cardmarket: 751706
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/168.ts
+++ b/data/Scarlet & Violet/Paldean Fates/168.ts
@@ -55,16 +55,20 @@ const card: Card = {
 	retreat: 3,
 	regulationMark: "G",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 751707,
+				tcgplayer: 534724,
+				cardtrader: 274353
+			}
+		},
+	],
 
 	illustrator: "Shin Nagasawa",
 
-	thirdParty: {
-		cardmarket: 751707
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/169.ts
+++ b/data/Scarlet & Violet/Paldean Fates/169.ts
@@ -47,16 +47,20 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 751708,
+				tcgplayer: 534728,
+				cardtrader: 274354
+			}
+		},
+	],
 
 	illustrator: "nagimiso",
 
-	thirdParty: {
-		cardmarket: 751708
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/170.ts
+++ b/data/Scarlet & Violet/Paldean Fates/170.ts
@@ -55,16 +55,20 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 751709,
+				tcgplayer: 534730,
+				cardtrader: 274355
+			}
+		},
+	],
 
 	illustrator: "Scav",
 
-	thirdParty: {
-		cardmarket: 751709
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/171.ts
+++ b/data/Scarlet & Violet/Paldean Fates/171.ts
@@ -77,16 +77,20 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "G",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 751710,
+				tcgplayer: 534733,
+				cardtrader: 274356
+			}
+		},
+	],
 
 	illustrator: "Hitoshi Ariga",
 
-	thirdParty: {
-		cardmarket: 751710
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/172.ts
+++ b/data/Scarlet & Violet/Paldean Fates/172.ts
@@ -69,16 +69,19 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "G",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 751711,
+				tcgplayer: 535956
+			}
+		},
+	],
 
 	illustrator: "nagimiso",
 
-	thirdParty: {
-		cardmarket: 751711
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/173.ts
+++ b/data/Scarlet & Violet/Paldean Fates/173.ts
@@ -60,16 +60,20 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 751712,
+				tcgplayer: 534749,
+				cardtrader: 274358
+			}
+		},
+	],
 
 	illustrator: "sowsow",
 
-	thirdParty: {
-		cardmarket: 751712
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/174.ts
+++ b/data/Scarlet & Violet/Paldean Fates/174.ts
@@ -77,16 +77,20 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "G",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 751713,
+				tcgplayer: 534753,
+				cardtrader: 274359
+			}
+		},
+	],
 
 	illustrator: "Shin Nagasawa",
 
-	thirdParty: {
-		cardmarket: 751713
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/175.ts
+++ b/data/Scarlet & Violet/Paldean Fates/175.ts
@@ -60,16 +60,20 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 751714,
+				tcgplayer: 534755,
+				cardtrader: 274360
+			}
+		},
+	],
 
 	illustrator: "Souichirou Gunjima",
 
-	thirdParty: {
-		cardmarket: 751714
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/176.ts
+++ b/data/Scarlet & Violet/Paldean Fates/176.ts
@@ -58,16 +58,20 @@ const card: Card = {
 	retreat: 3,
 	regulationMark: "G",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 751715,
+				tcgplayer: 534762,
+				cardtrader: 274361
+			}
+		},
+	],
 
 	illustrator: "Yuu Nishida",
 
-	thirdParty: {
-		cardmarket: 751715
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/177.ts
+++ b/data/Scarlet & Violet/Paldean Fates/177.ts
@@ -55,16 +55,20 @@ const card: Card = {
 	retreat: 3,
 	regulationMark: "G",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 751716,
+				tcgplayer: 534921,
+				cardtrader: 274362
+			}
+		},
+	],
 
 	illustrator: "otumami",
 
-	thirdParty: {
-		cardmarket: 751716
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/178.ts
+++ b/data/Scarlet & Violet/Paldean Fates/178.ts
@@ -77,16 +77,20 @@ const card: Card = {
 	retreat: 3,
 	regulationMark: "G",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 751717,
+				tcgplayer: 534923,
+				cardtrader: 274363
+			}
+		},
+	],
 
 	illustrator: "Kouki Saitou",
 
-	thirdParty: {
-		cardmarket: 751717
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/179.ts
+++ b/data/Scarlet & Violet/Paldean Fates/179.ts
@@ -45,16 +45,20 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 751718,
+				tcgplayer: 535089,
+				cardtrader: 274364
+			}
+		},
+	],
 
 	illustrator: "nagimiso",
 
-	thirdParty: {
-		cardmarket: 751718
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/180.ts
+++ b/data/Scarlet & Violet/Paldean Fates/180.ts
@@ -58,16 +58,20 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "G",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 751719,
+				tcgplayer: 535093,
+				cardtrader: 274365
+			}
+		},
+	],
 
 	illustrator: "Nisota Niso",
 
-	thirdParty: {
-		cardmarket: 751719
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/181.ts
+++ b/data/Scarlet & Violet/Paldean Fates/181.ts
@@ -69,16 +69,20 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 751720,
+				tcgplayer: 535097,
+				cardtrader: 274366
+			}
+		},
+	],
 
 	illustrator: "Hitoshi Ariga",
 
-	thirdParty: {
-		cardmarket: 751720
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/182.ts
+++ b/data/Scarlet & Violet/Paldean Fates/182.ts
@@ -38,16 +38,20 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 751721,
+				tcgplayer: 535110,
+				cardtrader: 274367
+			}
+		},
+	],
 
 	illustrator: "Kagemaru Himeno",
 
-	thirdParty: {
-		cardmarket: 751721
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/183.ts
+++ b/data/Scarlet & Violet/Paldean Fates/183.ts
@@ -68,16 +68,20 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 751722,
+				tcgplayer: 535118,
+				cardtrader: 274368
+			}
+		},
+	],
 
 	illustrator: "Shin Nagasawa",
 
-	thirdParty: {
-		cardmarket: 751722
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/184.ts
+++ b/data/Scarlet & Violet/Paldean Fates/184.ts
@@ -67,16 +67,20 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 751723,
+				tcgplayer: 535122,
+				cardtrader: 274369
+			}
+		},
+	],
 
 	illustrator: "nagimiso",
 
-	thirdParty: {
-		cardmarket: 751723
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/185.ts
+++ b/data/Scarlet & Violet/Paldean Fates/185.ts
@@ -51,16 +51,20 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 751724,
+				tcgplayer: 535126,
+				cardtrader: 274370
+			}
+		},
+	],
 
 	illustrator: "Misa Tsutsui",
 
-	thirdParty: {
-		cardmarket: 751724
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/186.ts
+++ b/data/Scarlet & Violet/Paldean Fates/186.ts
@@ -68,16 +68,20 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 751725,
+				tcgplayer: 535130,
+				cardtrader: 274371
+			}
+		},
+	],
 
 	illustrator: "Souichirou Gunjima",
 
-	thirdParty: {
-		cardmarket: 751725
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/187.ts
+++ b/data/Scarlet & Violet/Paldean Fates/187.ts
@@ -68,16 +68,20 @@ const card: Card = {
 	retreat: 3,
 	regulationMark: "G",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 751726,
+				tcgplayer: 535132,
+				cardtrader: 274372
+			}
+		},
+	],
 
 	illustrator: "Shin Nagasawa",
 
-	thirdParty: {
-		cardmarket: 751726
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/188.ts
+++ b/data/Scarlet & Violet/Paldean Fates/188.ts
@@ -77,16 +77,20 @@ const card: Card = {
 	retreat: 3,
 	regulationMark: "G",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 751727,
+				tcgplayer: 535135,
+				cardtrader: 274373
+			}
+		},
+	],
 
 	illustrator: "Hitoshi Ariga",
 
-	thirdParty: {
-		cardmarket: 751727
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/189.ts
+++ b/data/Scarlet & Violet/Paldean Fates/189.ts
@@ -58,16 +58,20 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 751728,
+				tcgplayer: 535143,
+				cardtrader: 274374
+			}
+		},
+	],
 
 	illustrator: "otumami",
 
-	thirdParty: {
-		cardmarket: 751728
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/190.ts
+++ b/data/Scarlet & Violet/Paldean Fates/190.ts
@@ -75,16 +75,20 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 751729,
+				tcgplayer: 535145,
+				cardtrader: 274375
+			}
+		},
+	],
 
 	illustrator: "Scav",
 
-	thirdParty: {
-		cardmarket: 751729
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/191.ts
+++ b/data/Scarlet & Violet/Paldean Fates/191.ts
@@ -68,16 +68,20 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "G",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 751730,
+				tcgplayer: 535149,
+				cardtrader: 274376
+			}
+		},
+	],
 
 	illustrator: "GOSSAN",
 
-	thirdParty: {
-		cardmarket: 751730
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/192.ts
+++ b/data/Scarlet & Violet/Paldean Fates/192.ts
@@ -58,16 +58,20 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 751731,
+				tcgplayer: 535151,
+				cardtrader: 274377
+			}
+		},
+	],
 
 	illustrator: "Masakazu Fukuda",
 
-	thirdParty: {
-		cardmarket: 751731
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/193.ts
+++ b/data/Scarlet & Violet/Paldean Fates/193.ts
@@ -77,16 +77,20 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "G",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 751732,
+				tcgplayer: 535153,
+				cardtrader: 274378
+			}
+		},
+	],
 
 	illustrator: "GOSSAN",
 
-	thirdParty: {
-		cardmarket: 751732
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/194.ts
+++ b/data/Scarlet & Violet/Paldean Fates/194.ts
@@ -38,16 +38,20 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 751733,
+				tcgplayer: 535155,
+				cardtrader: 274379
+			}
+		},
+	],
 
 	illustrator: "Nelnal",
 
-	thirdParty: {
-		cardmarket: 751733
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/195.ts
+++ b/data/Scarlet & Violet/Paldean Fates/195.ts
@@ -47,16 +47,20 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 751734,
+				tcgplayer: 535157,
+				cardtrader: 274380
+			}
+		},
+	],
 
 	illustrator: "Souichirou Gunjima",
 
-	thirdParty: {
-		cardmarket: 751734
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/196.ts
+++ b/data/Scarlet & Violet/Paldean Fates/196.ts
@@ -58,16 +58,20 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 751735,
+				tcgplayer: 535163,
+				cardtrader: 274381
+			}
+		},
+	],
 
 	illustrator: "sowsow",
 
-	thirdParty: {
-		cardmarket: 751735
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/197.ts
+++ b/data/Scarlet & Violet/Paldean Fates/197.ts
@@ -46,16 +46,20 @@ const card: Card = {
 	retreat: 0,
 	regulationMark: "G",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 751736,
+				tcgplayer: 535165,
+				cardtrader: 274382
+			}
+		},
+	],
 
 	illustrator: "Kouki Saitou",
 
-	thirdParty: {
-		cardmarket: 751736
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/198.ts
+++ b/data/Scarlet & Violet/Paldean Fates/198.ts
@@ -67,16 +67,20 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 751737,
+				tcgplayer: 535174,
+				cardtrader: 274383
+			}
+		},
+	],
 
 	illustrator: "Misa Tsutsui",
 
-	thirdParty: {
-		cardmarket: 751737
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/199.ts
+++ b/data/Scarlet & Violet/Paldean Fates/199.ts
@@ -47,16 +47,20 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 751738,
+				tcgplayer: 535183,
+				cardtrader: 274384
+			}
+		},
+	],
 
 	illustrator: "Saya Tsuruta",
 
-	thirdParty: {
-		cardmarket: 751738
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/200.ts
+++ b/data/Scarlet & Violet/Paldean Fates/200.ts
@@ -77,16 +77,20 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 751739,
+				tcgplayer: 535185,
+				cardtrader: 274385
+			}
+		},
+	],
 
 	illustrator: "nagimiso",
 
-	thirdParty: {
-		cardmarket: 751739
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/201.ts
+++ b/data/Scarlet & Violet/Paldean Fates/201.ts
@@ -60,16 +60,20 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 751740,
+				tcgplayer: 535191,
+				cardtrader: 274386
+			}
+		},
+	],
 
 	illustrator: "0313",
 
-	thirdParty: {
-		cardmarket: 751740
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/202.ts
+++ b/data/Scarlet & Violet/Paldean Fates/202.ts
@@ -69,16 +69,20 @@ const card: Card = {
 	retreat: 4,
 	regulationMark: "G",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 751741,
+				tcgplayer: 535193,
+				cardtrader: 274387
+			}
+		},
+	],
 
 	illustrator: "Shigenori Negishi",
 
-	thirdParty: {
-		cardmarket: 751741
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/203.ts
+++ b/data/Scarlet & Violet/Paldean Fates/203.ts
@@ -38,16 +38,20 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 751742,
+				tcgplayer: 535196,
+				cardtrader: 274388
+			}
+		},
+	],
 
 	illustrator: "kurumitsu",
 
-	thirdParty: {
-		cardmarket: 751742
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/204.ts
+++ b/data/Scarlet & Violet/Paldean Fates/204.ts
@@ -68,16 +68,20 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "G",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 751743,
+				tcgplayer: 535200,
+				cardtrader: 274389
+			}
+		},
+	],
 
 	illustrator: "Masakazu Fukuda",
 
-	thirdParty: {
-		cardmarket: 751743
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/205.ts
+++ b/data/Scarlet & Violet/Paldean Fates/205.ts
@@ -60,16 +60,20 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 751744,
+				tcgplayer: 535201,
+				cardtrader: 274390
+			}
+		},
+	],
 
 	illustrator: "Sanosuke Sakuma",
 
-	thirdParty: {
-		cardmarket: 751744
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/206.ts
+++ b/data/Scarlet & Violet/Paldean Fates/206.ts
@@ -68,16 +68,20 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "G",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 751745,
+				tcgplayer: 535203,
+				cardtrader: 274391
+			}
+		},
+	],
 
 	illustrator: "Kagemaru Himeno",
 
-	thirdParty: {
-		cardmarket: 751745
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/207.ts
+++ b/data/Scarlet & Violet/Paldean Fates/207.ts
@@ -47,16 +47,20 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 751746,
+				tcgplayer: 535213,
+				cardtrader: 274392
+			}
+		},
+	],
 
 	illustrator: "Akira Komayama",
 
-	thirdParty: {
-		cardmarket: 751746
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/208.ts
+++ b/data/Scarlet & Violet/Paldean Fates/208.ts
@@ -75,16 +75,20 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "G",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 751747,
+				tcgplayer: 535955,
+				cardtrader: 274393
+			}
+		},
+	],
 
 	illustrator: "Misa Tsutsui",
 
-	thirdParty: {
-		cardmarket: 751747
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/209.ts
+++ b/data/Scarlet & Violet/Paldean Fates/209.ts
@@ -58,16 +58,20 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 751748,
+				tcgplayer: 535214,
+				cardtrader: 274394
+			}
+		},
+	],
 
 	illustrator: "Lee HyunJung",
 
-	thirdParty: {
-		cardmarket: 751748
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/210.ts
+++ b/data/Scarlet & Violet/Paldean Fates/210.ts
@@ -68,16 +68,20 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 751749,
+				tcgplayer: 535215,
+				cardtrader: 274395
+			}
+		},
+	],
 
 	illustrator: "Shigenori Negishi",
 
-	thirdParty: {
-		cardmarket: 751749
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/211.ts
+++ b/data/Scarlet & Violet/Paldean Fates/211.ts
@@ -69,16 +69,20 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 751750,
+				tcgplayer: 535217,
+				cardtrader: 274396
+			}
+		},
+	],
 
 	illustrator: "Akira Komayama",
 
-	thirdParty: {
-		cardmarket: 751750
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/212.ts
+++ b/data/Scarlet & Violet/Paldean Fates/212.ts
@@ -77,17 +77,21 @@ const card: Card = {
 	retreat: 3,
 	regulationMark: "G",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 751751,
+				tcgplayer: 535297,
+				cardtrader: 274398
+			}
+		},
+	],
 
 	suffix: "ex",
 	illustrator: "5ban Graphics",
 
-	thirdParty: {
-		cardmarket: 751751
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/213.ts
+++ b/data/Scarlet & Violet/Paldean Fates/213.ts
@@ -77,17 +77,21 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "G",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 751752,
+				tcgplayer: 535299,
+				cardtrader: 274399
+			}
+		},
+	],
 
 	suffix: "ex",
 	illustrator: "5ban Graphics",
 
-	thirdParty: {
-		cardmarket: 751752
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/214.ts
+++ b/data/Scarlet & Violet/Paldean Fates/214.ts
@@ -77,17 +77,21 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 751753,
+				tcgplayer: 535303,
+				cardtrader: 274400
+			}
+		},
+	],
 
 	suffix: "ex",
 	illustrator: "takuyoa",
 
-	thirdParty: {
-		cardmarket: 751753
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/215.ts
+++ b/data/Scarlet & Violet/Paldean Fates/215.ts
@@ -77,17 +77,21 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 751754,
+				tcgplayer: 535524,
+				cardtrader: 274401
+			}
+		},
+	],
 
 	suffix: "ex",
 	illustrator: "PLANETA Tsuji",
 
-	thirdParty: {
-		cardmarket: 751754
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/216.ts
+++ b/data/Scarlet & Violet/Paldean Fates/216.ts
@@ -67,17 +67,21 @@ const card: Card = {
 	retreat: 0,
 	regulationMark: "G",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 751763,
+				tcgplayer: 535527,
+				cardtrader: 274402
+			}
+		},
+	],
 
 	suffix: "ex",
 	illustrator: "aky CG Works",
 
-	thirdParty: {
-		cardmarket: 751763
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/217.ts
+++ b/data/Scarlet & Violet/Paldean Fates/217.ts
@@ -77,17 +77,21 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "G",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 751764,
+				tcgplayer: 535530,
+				cardtrader: 272981
+			}
+		},
+	],
 
 	suffix: "ex",
 	illustrator: "N-DESIGN Inc.",
 
-	thirdParty: {
-		cardmarket: 751764
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/218.ts
+++ b/data/Scarlet & Violet/Paldean Fates/218.ts
@@ -77,17 +77,21 @@ const card: Card = {
 	retreat: 3,
 	regulationMark: "G",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 751765,
+				tcgplayer: 535534,
+				cardtrader: 274403
+			}
+		},
+	],
 
 	suffix: "ex",
 	illustrator: "5ban Graphics",
 
-	thirdParty: {
-		cardmarket: 751765
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/219.ts
+++ b/data/Scarlet & Violet/Paldean Fates/219.ts
@@ -77,17 +77,21 @@ const card: Card = {
 	retreat: 3,
 	regulationMark: "G",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 751766,
+				tcgplayer: 535537,
+				cardtrader: 272982
+			}
+		},
+	],
 
 	suffix: "ex",
 	illustrator: "PLANETA Mochizuki",
 
-	thirdParty: {
-		cardmarket: 751766
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/220.ts
+++ b/data/Scarlet & Violet/Paldean Fates/220.ts
@@ -77,17 +77,21 @@ const card: Card = {
 	retreat: 0,
 	regulationMark: "G",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 751767,
+				tcgplayer: 535541,
+				cardtrader: 274404
+			}
+		},
+	],
 
 	suffix: "ex",
 	illustrator: "Eske Yoshinob",
 
-	thirdParty: {
-		cardmarket: 751767
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/221.ts
+++ b/data/Scarlet & Violet/Paldean Fates/221.ts
@@ -77,17 +77,21 @@ const card: Card = {
 	retreat: 0,
 	regulationMark: "G",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 751768,
+				tcgplayer: 535559,
+				cardtrader: 274405
+			}
+		},
+	],
 
 	suffix: "ex",
 	illustrator: "takuyoa",
 
-	thirdParty: {
-		cardmarket: 751768
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/222.ts
+++ b/data/Scarlet & Violet/Paldean Fates/222.ts
@@ -77,17 +77,21 @@ const card: Card = {
 	retreat: 3,
 	regulationMark: "G",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 751769,
+				tcgplayer: 535562,
+				cardtrader: 274406
+			}
+		},
+	],
 
 	suffix: "ex",
 	illustrator: "Saki Hayashiro",
 
-	thirdParty: {
-		cardmarket: 751769
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/223.ts
+++ b/data/Scarlet & Violet/Paldean Fates/223.ts
@@ -69,17 +69,21 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 751770,
+				tcgplayer: 535654,
+				cardtrader: 274407
+			}
+		},
+	],
 
 	suffix: "ex",
 	illustrator: "PLANETA Mochizuki",
 
-	thirdParty: {
-		cardmarket: 751770
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/224.ts
+++ b/data/Scarlet & Violet/Paldean Fates/224.ts
@@ -66,16 +66,20 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "G",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 751771,
+				tcgplayer: 534731,
+				cardtrader: 274408
+			}
+		},
+	],
 
 	illustrator: "Tetsu Kayama",
 
-	thirdParty: {
-		cardmarket: 751771
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/225.ts
+++ b/data/Scarlet & Violet/Paldean Fates/225.ts
@@ -77,16 +77,20 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "G",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 751772,
+				tcgplayer: 534736,
+				cardtrader: 274409
+			}
+		},
+	],
 
 	illustrator: "akagi",
 
-	thirdParty: {
-		cardmarket: 751772
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/226.ts
+++ b/data/Scarlet & Violet/Paldean Fates/226.ts
@@ -51,16 +51,20 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 751773,
+				tcgplayer: 534739,
+				cardtrader: 274410
+			}
+		},
+	],
 
 	illustrator: "REND",
 
-	thirdParty: {
-		cardmarket: 751773
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/227.ts
+++ b/data/Scarlet & Violet/Paldean Fates/227.ts
@@ -28,16 +28,20 @@ const card: Card = {
 	trainerType: "Supporter",
 	regulationMark: "G",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 751774,
+				tcgplayer: 534743,
+				cardtrader: 274411
+			}
+		},
+	],
 
 	illustrator: "GOSSAN",
 
-	thirdParty: {
-		cardmarket: 751774
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/228.ts
+++ b/data/Scarlet & Violet/Paldean Fates/228.ts
@@ -28,16 +28,20 @@ const card: Card = {
 	trainerType: "Supporter",
 	regulationMark: "G",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 751775,
+				tcgplayer: 534748,
+				cardtrader: 274412
+			}
+		},
+	],
 
 	illustrator: "Hideki Ishikawa",
 
-	thirdParty: {
-		cardmarket: 751775
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/229.ts
+++ b/data/Scarlet & Violet/Paldean Fates/229.ts
@@ -28,16 +28,20 @@ const card: Card = {
 	trainerType: "Supporter",
 	regulationMark: "G",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 751776,
+				tcgplayer: 534754,
+				cardtrader: 274413
+			}
+		},
+	],
 
 	illustrator: "Sanosuke Sakuma",
 
-	thirdParty: {
-		cardmarket: 751776
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/230.ts
+++ b/data/Scarlet & Violet/Paldean Fates/230.ts
@@ -28,16 +28,20 @@ const card: Card = {
 	trainerType: "Supporter",
 	regulationMark: "G",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 751777,
+				tcgplayer: 534757,
+				cardtrader: 274414
+			}
+		},
+	],
 
 	illustrator: "Cona Nitanda",
 
-	thirdParty: {
-		cardmarket: 751777
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/231.ts
+++ b/data/Scarlet & Violet/Paldean Fates/231.ts
@@ -28,16 +28,20 @@ const card: Card = {
 	trainerType: "Supporter",
 	regulationMark: "G",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 751778,
+				tcgplayer: 534758,
+				cardtrader: 274415
+			}
+		},
+	],
 
 	illustrator: "Naoki Saito",
 
-	thirdParty: {
-		cardmarket: 751778
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/232.ts
+++ b/data/Scarlet & Violet/Paldean Fates/232.ts
@@ -67,17 +67,21 @@ const card: Card = {
 	retreat: 0,
 	regulationMark: "G",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 751779,
+				tcgplayer: 534919,
+				cardtrader: 274416
+			}
+		},
+	],
 
 	suffix: "ex",
 	illustrator: "USGMEN",
 
-	thirdParty: {
-		cardmarket: 751779
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/233.ts
+++ b/data/Scarlet & Violet/Paldean Fates/233.ts
@@ -77,17 +77,21 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "G",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 751780,
+				tcgplayer: 535085,
+				cardtrader: 274417
+			}
+		},
+	],
 
 	suffix: "ex",
 	illustrator: "Kuroimori",
 
-	thirdParty: {
-		cardmarket: 751780
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/234.ts
+++ b/data/Scarlet & Violet/Paldean Fates/234.ts
@@ -77,17 +77,21 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "G",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 751781,
+				tcgplayer: 535090,
+				cardtrader: 274418
+			}
+		},
+	],
 
 	suffix: "ex",
 	illustrator: "AKIRA EGAWA",
 
-	thirdParty: {
-		cardmarket: 751781
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/235.ts
+++ b/data/Scarlet & Violet/Paldean Fates/235.ts
@@ -28,16 +28,20 @@ const card: Card = {
 	trainerType: "Supporter",
 	regulationMark: "G",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 751782,
+				tcgplayer: 535095,
+				cardtrader: 274419
+			}
+		},
+	],
 
 	illustrator: "aspara",
 
-	thirdParty: {
-		cardmarket: 751782
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/236.ts
+++ b/data/Scarlet & Violet/Paldean Fates/236.ts
@@ -28,16 +28,20 @@ const card: Card = {
 	trainerType: "Supporter",
 	regulationMark: "G",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 751783,
+				tcgplayer: 535098,
+				cardtrader: 274420
+			}
+		},
+	],
 
 	illustrator: "Taiga Kayama",
 
-	thirdParty: {
-		cardmarket: 751783
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/237.ts
+++ b/data/Scarlet & Violet/Paldean Fates/237.ts
@@ -28,16 +28,20 @@ const card: Card = {
 	trainerType: "Supporter",
 	regulationMark: "G",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 751784,
+				tcgplayer: 535101,
+				cardtrader: 274421
+			}
+		},
+	],
 
 	illustrator: "hanabushi",
 
-	thirdParty: {
-		cardmarket: 751784
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/238.ts
+++ b/data/Scarlet & Violet/Paldean Fates/238.ts
@@ -28,16 +28,20 @@ const card: Card = {
 	trainerType: "Supporter",
 	regulationMark: "G",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 751785,
+				tcgplayer: 535104,
+				cardtrader: 274422
+			}
+		},
+	],
 
 	illustrator: "aspara",
 
-	thirdParty: {
-		cardmarket: 751785
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/239.ts
+++ b/data/Scarlet & Violet/Paldean Fates/239.ts
@@ -28,16 +28,20 @@ const card: Card = {
 	trainerType: "Supporter",
 	regulationMark: "G",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 751786,
+				tcgplayer: 535108,
+				cardtrader: 274423
+			}
+		},
+	],
 
 	illustrator: "aspara",
 
-	thirdParty: {
-		cardmarket: 751786
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/240.ts
+++ b/data/Scarlet & Violet/Paldean Fates/240.ts
@@ -58,17 +58,21 @@ const card: Card = {
 	retreat: 4,
 	regulationMark: "G",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 751787,
+				tcgplayer: 535112,
+				cardtrader: 274424
+			}
+		},
+	],
 
 	suffix: "ex",
 	illustrator: "5ban Graphics",
 
-	thirdParty: {
-		cardmarket: 751787
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/241.ts
+++ b/data/Scarlet & Violet/Paldean Fates/241.ts
@@ -67,17 +67,21 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 751788,
+				tcgplayer: 535116,
+				cardtrader: 274425
+			}
+		},
+	],
 
 	suffix: "ex",
 	illustrator: "PLANETA Yamashita",
 
-	thirdParty: {
-		cardmarket: 751788
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/242.ts
+++ b/data/Scarlet & Violet/Paldean Fates/242.ts
@@ -69,17 +69,21 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "G",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 751789,
+				tcgplayer: 535120,
+				cardtrader: 274426
+			}
+		},
+	],
 
 	suffix: "ex",
 	illustrator: "aky CG Works",
 
-	thirdParty: {
-		cardmarket: 751789
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/243.ts
+++ b/data/Scarlet & Violet/Paldean Fates/243.ts
@@ -69,17 +69,21 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "G",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 751790,
+				tcgplayer: 535124,
+				cardtrader: 274427
+			}
+		},
+	],
 
 	suffix: "ex",
 	illustrator: "5ban Graphics",
 
-	thirdParty: {
-		cardmarket: 751790
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/244.ts
+++ b/data/Scarlet & Violet/Paldean Fates/244.ts
@@ -69,17 +69,21 @@ const card: Card = {
 	retreat: 4,
 	regulationMark: "G",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 751791,
+				tcgplayer: 535127,
+				cardtrader: 274428
+			}
+		},
+	],
 
 	suffix: "ex",
 	illustrator: "5ban Graphics",
 
-	thirdParty: {
-		cardmarket: 751791
-	}
+	
 }
 
 export default card

--- a/data/Scarlet & Violet/Paldean Fates/245.ts
+++ b/data/Scarlet & Violet/Paldean Fates/245.ts
@@ -69,17 +69,21 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "G",
 
-	variants: {
-		normal: false,
-		reverse: false
-	},
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 751792,
+				tcgplayer: 535134,
+				cardtrader: 274429
+			}
+		},
+	],
 
 	suffix: "ex",
 	illustrator: "aky CG Works",
 
-	thirdParty: {
-		cardmarket: 751792
-	}
+	
 }
 
 export default card


### PR DESCRIPTION
Moved all `thirdParty` IDs into variants and added variations from cardmarket for all Paldean Fates cards 