### PR TITLE
patch(data): Corrected Artist Name Typo 0313 zh-tw S-S6a

### DIFF
--- a/data-asia/S/S6a/005.ts
+++ b/data-asia/S/S6a/005.ts
@@ -8,7 +8,7 @@ const card: Card = {
 		'zh-tw': "寶包繭"
 	},
 
-	illustrator: "313",
+	illustrator: "0313",
 	category: "Pokemon",
 	hp: 80,
 	types: ["Grass"],


### PR DESCRIPTION
## Issues Addressed
https://github.com/tcgdex/cards-database/issues/1515

## Changes

Rename `313` to `0313`