### PR TITLE
feat: migrate Mega Evolution Energy to new variant format

### DIFF
--- a/data/Mega Evolution/Mega Evolution Energy/001.ts
+++ b/data/Mega Evolution/Mega Evolution Energy/001.ts
@@ -15,6 +15,20 @@ const card: Card = {
     category: "Energy",
     set: Set,
     energyType: "Normal",
+    variants: [
+        {
+            type: "normal",
+            thirdParty: {
+                tcgplayer: 656263
+            }
+        },
+        {
+            type: "reverse",
+            thirdParty: {
+                tcgplayer: 656263
+            }
+        }
+    ],
 
 }
 

--- a/data/Mega Evolution/Mega Evolution Energy/002.ts
+++ b/data/Mega Evolution/Mega Evolution Energy/002.ts
@@ -16,6 +16,20 @@ const card: Card = {
     set: Set,
     energyType: "Normal",
 
+    variants: [
+        {
+            type: "normal",
+            thirdParty: {
+                tcgplayer: 656264
+            }
+        },
+        {
+            type: "reverse",
+            thirdParty: {
+                tcgplayer: 656264
+            }
+        }
+    ],
 
 }
 

--- a/data/Mega Evolution/Mega Evolution Energy/003.ts
+++ b/data/Mega Evolution/Mega Evolution Energy/003.ts
@@ -16,6 +16,20 @@ const card: Card = {
     set: Set,
     energyType: "Normal",
 
+    variants: [
+        {
+            type: "normal",
+            thirdParty: {
+                tcgplayer: 656265
+            }
+        },
+        {
+            type: "reverse",
+            thirdParty: {
+                tcgplayer: 656265
+            }
+        }
+    ],
 
 }
 

--- a/data/Mega Evolution/Mega Evolution Energy/004.ts
+++ b/data/Mega Evolution/Mega Evolution Energy/004.ts
@@ -16,6 +16,20 @@ const card: Card = {
     set: Set,
     energyType: "Normal",
 
+    variants: [
+        {
+            type: "normal",
+            thirdParty: {
+                tcgplayer: 656266
+            }
+        },
+        {
+            type: "reverse",
+            thirdParty: {
+                tcgplayer: 656266
+            }
+        }
+    ],
 
 }
 

--- a/data/Mega Evolution/Mega Evolution Energy/005.ts
+++ b/data/Mega Evolution/Mega Evolution Energy/005.ts
@@ -16,6 +16,20 @@ const card: Card = {
     set: Set,
     energyType: "Normal",
 
+    variants: [
+        {
+            type: "normal",
+            thirdParty: {
+                tcgplayer: 656267
+            }
+        },
+        {
+            type: "reverse",
+            thirdParty: {
+                tcgplayer: 656267
+            }
+        }
+    ],
 
 }
 

--- a/data/Mega Evolution/Mega Evolution Energy/006.ts
+++ b/data/Mega Evolution/Mega Evolution Energy/006.ts
@@ -16,6 +16,20 @@ const card: Card = {
     set: Set,
     energyType: "Normal",
 
+    variants: [
+        {
+            type: "normal",
+            thirdParty: {
+                tcgplayer: 656268
+            }
+        },
+        {
+            type: "reverse",
+            thirdParty: {
+                tcgplayer: 656268
+            }
+        }
+    ],
 
 }
 

--- a/data/Mega Evolution/Mega Evolution Energy/007.ts
+++ b/data/Mega Evolution/Mega Evolution Energy/007.ts
@@ -16,6 +16,20 @@ const card: Card = {
     set: Set,
     energyType: "Normal",
 
+    variants: [
+        {
+            type: "normal",
+            thirdParty: {
+                tcgplayer: 656269
+            }
+        },
+        {
+            type: "reverse",
+            thirdParty: {
+                tcgplayer: 656269
+            }
+        }
+    ],
 
 }
 

--- a/data/Mega Evolution/Mega Evolution Energy/008.ts
+++ b/data/Mega Evolution/Mega Evolution Energy/008.ts
@@ -16,6 +16,20 @@ const card: Card = {
     set: Set,
     energyType: "Normal",
 
+    variants: [
+        {
+            type: "normal",
+            thirdParty: {
+                tcgplayer: 656270
+            }
+        },
+        {
+            type: "reverse",
+            thirdParty: {
+                tcgplayer: 656270
+            }
+        }
+    ],
 
 }
 


### PR DESCRIPTION
## Summary
- Moves `thirdParty` tcgplayer IDs into the `variants` array for all 8 cards
- Removes old boolean `variants` object fields (`normal`, `reverse`, `holo`, `firstEdition`)