### PR TITLE
feat: migrate Chaos Rising (MEP) to new variant format

### DIFF
--- a/data/Mega Evolution/Chaos Rising/001.ts
+++ b/data/Mega Evolution/Chaos Rising/001.ts
@@ -4,13 +4,6 @@ import Set from "../Chaos Rising"
 const card: Card = {
 	set: Set,
 
-	variants: {
-		normal: true,
-		reverse: false,
-		holo: false,
-		firstEdition: false
-	},
-
 	name: {
 		en: "Weedle"
 	},
@@ -44,9 +37,14 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "J",
 
-	thirdParty: {
-		tcgplayer: 693561
-	}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 693561
+			}
+		}
+	],
 }
 
 export default card

--- a/data/Mega Evolution/Chaos Rising/002.ts
+++ b/data/Mega Evolution/Chaos Rising/002.ts
@@ -4,13 +4,6 @@ import Set from "../Chaos Rising"
 const card: Card = {
 	set: Set,
 
-	variants: {
-		normal: true,
-		reverse: false,
-		holo: false,
-		firstEdition: false
-	},
-
 	name: {
 		en: "Kakuna"
 	},
@@ -57,9 +50,14 @@ const card: Card = {
 	retreat: 3,
 	regulationMark: "J",
 
-	thirdParty: {
-		tcgplayer: 693502
-	}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 693502
+			}
+		}
+	],
 }
 
 export default card

--- a/data/Mega Evolution/Chaos Rising/003.ts
+++ b/data/Mega Evolution/Chaos Rising/003.ts
@@ -4,13 +4,6 @@ import Set from "../Chaos Rising"
 const card: Card = {
 	set: Set,
 
-	variants: {
-		normal: true,
-		reverse: false,
-		holo: false,
-		firstEdition: false
-	},
-
 	name: {
 		en: "Beedrill ex"
 	},
@@ -50,9 +43,14 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "J",
 
-	thirdParty: {
-		tcgplayer: 693453
-	}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 693453
+			}
+		}
+	],
 }
 
 export default card

--- a/data/Mega Evolution/Chaos Rising/004.ts
+++ b/data/Mega Evolution/Chaos Rising/004.ts
@@ -4,13 +4,6 @@ import Set from "../Chaos Rising"
 const card: Card = {
 	set: Set,
 
-	variants: {
-		normal: true,
-		reverse: false,
-		holo: false,
-		firstEdition: false
-	},
-
 	name: {
 		en: "Carnivine"
 	},
@@ -44,9 +37,14 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "J",
 
-	thirdParty: {
-		tcgplayer: 693459
-	}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 693459
+			}
+		}
+	],
 }
 
 export default card

--- a/data/Mega Evolution/Chaos Rising/005.ts
+++ b/data/Mega Evolution/Chaos Rising/005.ts
@@ -4,13 +4,6 @@ import Set from "../Chaos Rising"
 const card: Card = {
 	set: Set,
 
-	variants: {
-		normal: true,
-		reverse: false,
-		holo: false,
-		firstEdition: false
-	},
-
 	name: {
 		en: "Chespin"
 	},
@@ -47,9 +40,14 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "J",
 
-	thirdParty: {
-		tcgplayer: 693461
-	}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 693461
+			}
+		}
+	],
 }
 
 export default card

--- a/data/Mega Evolution/Chaos Rising/006.ts
+++ b/data/Mega Evolution/Chaos Rising/006.ts
@@ -4,13 +4,6 @@ import Set from "../Chaos Rising"
 const card: Card = {
 	set: Set,
 
-	variants: {
-		normal: true,
-		reverse: false,
-		holo: false,
-		firstEdition: false
-	},
-
 	name: {
 		en: "Quilladin"
 	},
@@ -56,9 +49,14 @@ const card: Card = {
 	retreat: 3,
 	regulationMark: "J",
 
-	thirdParty: {
-		tcgplayer: 693537
-	}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 693537
+			}
+		}
+	],
 }
 
 export default card

--- a/data/Mega Evolution/Chaos Rising/007.ts
+++ b/data/Mega Evolution/Chaos Rising/007.ts
@@ -4,13 +4,6 @@ import Set from "../Chaos Rising"
 const card: Card = {
 	set: Set,
 
-	variants: {
-		normal: true,
-		reverse: false,
-		holo: false,
-		firstEdition: false
-	},
-
 	name: {
 		en: "Chesnaught"
 	},
@@ -61,9 +54,14 @@ const card: Card = {
 	retreat: 4,
 	regulationMark: "J",
 
-	thirdParty: {
-		tcgplayer: 693460
-	}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 693460
+			}
+		}
+	],
 }
 
 export default card

--- a/data/Mega Evolution/Chaos Rising/008.ts
+++ b/data/Mega Evolution/Chaos Rising/008.ts
@@ -4,13 +4,6 @@ import Set from "../Chaos Rising"
 const card: Card = {
 	set: Set,
 
-	variants: {
-		normal: true,
-		reverse: false,
-		holo: false,
-		firstEdition: false
-	},
-
 	name: {
 		en: "Vulpix"
 	},
@@ -43,9 +36,14 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "J",
 
-	thirdParty: {
-		tcgplayer: 693558
-	}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 693558
+			}
+		}
+	],
 }
 
 export default card

--- a/data/Mega Evolution/Chaos Rising/009.ts
+++ b/data/Mega Evolution/Chaos Rising/009.ts
@@ -4,13 +4,6 @@ import Set from "../Chaos Rising"
 const card: Card = {
 	set: Set,
 
-	variants: {
-		normal: true,
-		reverse: false,
-		holo: false,
-		firstEdition: false
-	},
-
 	name: {
 		en: "Ninetales"
 	},
@@ -55,9 +48,14 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "J",
 
-	thirdParty: {
-		tcgplayer: 693526
-	}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 693526
+			}
+		}
+	],
 }
 
 export default card

--- a/data/Mega Evolution/Chaos Rising/010.ts
+++ b/data/Mega Evolution/Chaos Rising/010.ts
@@ -4,13 +4,6 @@ import Set from "../Chaos Rising"
 const card: Card = {
 	set: Set,
 
-	variants: {
-		normal: true,
-		reverse: false,
-		holo: false,
-		firstEdition: false
-	},
-
 	name: {
 		en: "Ho-Oh"
 	},
@@ -54,9 +47,14 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "J",
 
-	thirdParty: {
-		tcgplayer: 693500
-	}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 693500
+			}
+		}
+	],
 }
 
 export default card

--- a/data/Mega Evolution/Chaos Rising/011.ts
+++ b/data/Mega Evolution/Chaos Rising/011.ts
@@ -4,13 +4,6 @@ import Set from "../Chaos Rising"
 const card: Card = {
 	set: Set,
 
-	variants: {
-		normal: true,
-		reverse: false,
-		holo: false,
-		firstEdition: false
-	},
-
 	name: {
 		en: "Fennekin"
 	},
@@ -50,9 +43,14 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "J",
 
-	thirdParty: {
-		tcgplayer: 693484
-	}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 693484
+			}
+		}
+	],
 }
 
 export default card

--- a/data/Mega Evolution/Chaos Rising/012.ts
+++ b/data/Mega Evolution/Chaos Rising/012.ts
@@ -4,13 +4,6 @@ import Set from "../Chaos Rising"
 const card: Card = {
 	set: Set,
 
-	variants: {
-		normal: true,
-		reverse: false,
-		holo: false,
-		firstEdition: false
-	},
-
 	name: {
 		en: "Braixen"
 	},
@@ -49,9 +42,14 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "J",
 
-	thirdParty: {
-		tcgplayer: 693457
-	}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 693457
+			}
+		}
+	],
 }
 
 export default card

--- a/data/Mega Evolution/Chaos Rising/013.ts
+++ b/data/Mega Evolution/Chaos Rising/013.ts
@@ -4,13 +4,6 @@ import Set from "../Chaos Rising"
 const card: Card = {
 	set: Set,
 
-	variants: {
-		normal: true,
-		reverse: false,
-		holo: false,
-		firstEdition: false
-	},
-
 	name: {
 		en: "Delphox"
 	},
@@ -61,9 +54,14 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "J",
 
-	thirdParty: {
-		tcgplayer: 693473
-	}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 693473
+			}
+		}
+	],
 }
 
 export default card

--- a/data/Mega Evolution/Chaos Rising/014.ts
+++ b/data/Mega Evolution/Chaos Rising/014.ts
@@ -4,13 +4,6 @@ import Set from "../Chaos Rising"
 const card: Card = {
 	set: Set,
 
-	variants: {
-		normal: true,
-		reverse: false,
-		holo: false,
-		firstEdition: false
-	},
-
 	name: {
 		en: "Litleo"
 	},
@@ -40,9 +33,14 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "J",
 
-	thirdParty: {
-		tcgplayer: 693505
-	}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 693505
+			}
+		}
+	],
 }
 
 export default card

--- a/data/Mega Evolution/Chaos Rising/015.ts
+++ b/data/Mega Evolution/Chaos Rising/015.ts
@@ -4,13 +4,6 @@ import Set from "../Chaos Rising"
 const card: Card = {
 	set: Set,
 
-	variants: {
-		normal: true,
-		reverse: false,
-		holo: false,
-		firstEdition: false
-	},
-
 	name: {
 		en: "Mega Pyroar ex"
 	},
@@ -61,9 +54,14 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "J",
 
-	thirdParty: {
-		tcgplayer: 693519
-	}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 693519
+			}
+		}
+	],
 }
 
 export default card

--- a/data/Mega Evolution/Chaos Rising/016.ts
+++ b/data/Mega Evolution/Chaos Rising/016.ts
@@ -4,13 +4,6 @@ import Set from "../Chaos Rising"
 const card: Card = {
 	set: Set,
 
-	variants: {
-		normal: true,
-		reverse: false,
-		holo: false,
-		firstEdition: false
-	},
-
 	name: {
 		en: "Remoraid"
 	},
@@ -40,9 +33,14 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "J",
 
-	thirdParty: {
-		tcgplayer: 693539
-	}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 693539
+			}
+		}
+	],
 }
 
 export default card

--- a/data/Mega Evolution/Chaos Rising/017.ts
+++ b/data/Mega Evolution/Chaos Rising/017.ts
@@ -4,13 +4,6 @@ import Set from "../Chaos Rising"
 const card: Card = {
 	set: Set,
 
-	variants: {
-		normal: true,
-		reverse: false,
-		holo: false,
-		firstEdition: false
-	},
-
 	name: {
 		en: "Octillery"
 	},
@@ -60,9 +53,14 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "J",
 
-	thirdParty: {
-		tcgplayer: 693528
-	}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 693528
+			}
+		}
+	],
 }
 
 export default card

--- a/data/Mega Evolution/Chaos Rising/018.ts
+++ b/data/Mega Evolution/Chaos Rising/018.ts
@@ -4,13 +4,6 @@ import Set from "../Chaos Rising"
 const card: Card = {
 	set: Set,
 
-	variants: {
-		normal: true,
-		reverse: false,
-		holo: false,
-		firstEdition: false
-	},
-
 	name: {
 		en: "Delibird"
 	},
@@ -50,9 +43,14 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "J",
 
-	thirdParty: {
-		tcgplayer: 693472
-	}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 693472
+			}
+		}
+	],
 }
 
 export default card

--- a/data/Mega Evolution/Chaos Rising/019.ts
+++ b/data/Mega Evolution/Chaos Rising/019.ts
@@ -4,13 +4,6 @@ import Set from "../Chaos Rising"
 const card: Card = {
 	set: Set,
 
-	variants: {
-		normal: true,
-		reverse: false,
-		holo: false,
-		firstEdition: false
-	},
-
 	name: {
 		en: "Keldeo"
 	},
@@ -55,9 +48,14 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "J",
 
-	thirdParty: {
-		tcgplayer: 693503
-	}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 693503
+			}
+		}
+	],
 }
 
 export default card

--- a/data/Mega Evolution/Chaos Rising/020.ts
+++ b/data/Mega Evolution/Chaos Rising/020.ts
@@ -4,13 +4,6 @@ import Set from "../Chaos Rising"
 const card: Card = {
 	set: Set,
 
-	variants: {
-		normal: true,
-		reverse: false,
-		holo: false,
-		firstEdition: false
-	},
-
 	name: {
 		en: "Froakie"
 	},
@@ -50,9 +43,14 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "J",
 
-	thirdParty: {
-		tcgplayer: 693488
-	}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 693488
+			}
+		}
+	],
 }
 
 export default card

--- a/data/Mega Evolution/Chaos Rising/021.ts
+++ b/data/Mega Evolution/Chaos Rising/021.ts
@@ -4,13 +4,6 @@ import Set from "../Chaos Rising"
 const card: Card = {
 	set: Set,
 
-	variants: {
-		normal: true,
-		reverse: false,
-		holo: false,
-		firstEdition: false
-	},
-
 	name: {
 		en: "Frogadier"
 	},
@@ -55,9 +48,14 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "J",
 
-	thirdParty: {
-		tcgplayer: 693490
-	}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 693490
+			}
+		}
+	],
 }
 
 export default card

--- a/data/Mega Evolution/Chaos Rising/022.ts
+++ b/data/Mega Evolution/Chaos Rising/022.ts
@@ -4,13 +4,6 @@ import Set from "../Chaos Rising"
 const card: Card = {
 	set: Set,
 
-	variants: {
-		normal: true,
-		reverse: false,
-		holo: false,
-		firstEdition: false
-	},
-
 	name: {
 		en: "Mega Greninja ex"
 	},
@@ -62,9 +55,14 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "J",
 
-	thirdParty: {
-		tcgplayer: 693515
-	}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 693515
+			}
+		}
+	],
 }
 
 export default card

--- a/data/Mega Evolution/Chaos Rising/023.ts
+++ b/data/Mega Evolution/Chaos Rising/023.ts
@@ -4,13 +4,6 @@ import Set from "../Chaos Rising"
 const card: Card = {
 	set: Set,
 
-	variants: {
-		normal: true,
-		reverse: false,
-		holo: false,
-		firstEdition: false
-	},
-
 	name: {
 		en: "Bergmite"
 	},
@@ -47,9 +40,14 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "J",
 
-	thirdParty: {
-		tcgplayer: 693456
-	}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 693456
+			}
+		}
+	],
 }
 
 export default card

--- a/data/Mega Evolution/Chaos Rising/024.ts
+++ b/data/Mega Evolution/Chaos Rising/024.ts
@@ -4,13 +4,6 @@ import Set from "../Chaos Rising"
 const card: Card = {
 	set: Set,
 
-	variants: {
-		normal: true,
-		reverse: false,
-		holo: false,
-		firstEdition: false
-	},
-
 	name: {
 		en: "Avalugg"
 	},
@@ -55,9 +48,14 @@ const card: Card = {
 	retreat: 4,
 	regulationMark: "J",
 
-	thirdParty: {
-		tcgplayer: 693448
-	}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 693448
+			}
+		}
+	],
 }
 
 export default card

--- a/data/Mega Evolution/Chaos Rising/025.ts
+++ b/data/Mega Evolution/Chaos Rising/025.ts
@@ -4,13 +4,6 @@ import Set from "../Chaos Rising"
 const card: Card = {
 	set: Set,
 
-	variants: {
-		normal: true,
-		reverse: false,
-		holo: false,
-		firstEdition: false
-	},
-
 	name: {
 		en: "Wimpod"
 	},
@@ -47,9 +40,14 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "J",
 
-	thirdParty: {
-		tcgplayer: 693562
-	}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 693562
+			}
+		}
+	],
 }
 
 export default card

--- a/data/Mega Evolution/Chaos Rising/026.ts
+++ b/data/Mega Evolution/Chaos Rising/026.ts
@@ -4,13 +4,6 @@ import Set from "../Chaos Rising"
 const card: Card = {
 	set: Set,
 
-	variants: {
-		normal: true,
-		reverse: false,
-		holo: false,
-		firstEdition: false
-	},
-
 	name: {
 		en: "Golisopod"
 	},
@@ -60,9 +53,14 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "J",
 
-	thirdParty: {
-		tcgplayer: 693494
-	}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 693494
+			}
+		}
+	],
 }
 
 export default card

--- a/data/Mega Evolution/Chaos Rising/027.ts
+++ b/data/Mega Evolution/Chaos Rising/027.ts
@@ -4,13 +4,6 @@ import Set from "../Chaos Rising"
 const card: Card = {
 	set: Set,
 
-	variants: {
-		normal: true,
-		reverse: false,
-		holo: false,
-		firstEdition: false
-	},
-
 	name: {
 		en: "Mareep"
 	},
@@ -44,9 +37,14 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "J",
 
-	thirdParty: {
-		tcgplayer: 693507
-	}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 693507
+			}
+		}
+	],
 }
 
 export default card

--- a/data/Mega Evolution/Chaos Rising/028.ts
+++ b/data/Mega Evolution/Chaos Rising/028.ts
@@ -4,13 +4,6 @@ import Set from "../Chaos Rising"
 const card: Card = {
 	set: Set,
 
-	variants: {
-		normal: true,
-		reverse: false,
-		holo: false,
-		firstEdition: false
-	},
-
 	name: {
 		en: "Flaaffy"
 	},
@@ -49,9 +42,14 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "J",
 
-	thirdParty: {
-		tcgplayer: 693487
-	}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 693487
+			}
+		}
+	],
 }
 
 export default card

--- a/data/Mega Evolution/Chaos Rising/029.ts
+++ b/data/Mega Evolution/Chaos Rising/029.ts
@@ -4,13 +4,6 @@ import Set from "../Chaos Rising"
 const card: Card = {
 	set: Set,
 
-	variants: {
-		normal: true,
-		reverse: false,
-		holo: false,
-		firstEdition: false
-	},
-
 	name: {
 		en: "Ampharos"
 	},
@@ -61,9 +54,14 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "J",
 
-	thirdParty: {
-		tcgplayer: 693445
-	}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 693445
+			}
+		}
+	],
 }
 
 export default card

--- a/data/Mega Evolution/Chaos Rising/030.ts
+++ b/data/Mega Evolution/Chaos Rising/030.ts
@@ -4,13 +4,6 @@ import Set from "../Chaos Rising"
 const card: Card = {
 	set: Set,
 
-	variants: {
-		normal: true,
-		reverse: false,
-		holo: false,
-		firstEdition: false
-	},
-
 	name: {
 		en: "Emolga"
 	},
@@ -54,9 +47,14 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "J",
 
-	thirdParty: {
-		tcgplayer: 693481
-	}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 693481
+			}
+		}
+	],
 }
 
 export default card

--- a/data/Mega Evolution/Chaos Rising/031.ts
+++ b/data/Mega Evolution/Chaos Rising/031.ts
@@ -4,13 +4,6 @@ import Set from "../Chaos Rising"
 const card: Card = {
 	set: Set,
 
-	variants: {
-		normal: true,
-		reverse: false,
-		holo: false,
-		firstEdition: false
-	},
-
 	name: {
 		en: "Deoxys"
 	},
@@ -59,9 +52,14 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "J",
 
-	thirdParty: {
-		tcgplayer: 693474
-	}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 693474
+			}
+		}
+	],
 }
 
 export default card

--- a/data/Mega Evolution/Chaos Rising/032.ts
+++ b/data/Mega Evolution/Chaos Rising/032.ts
@@ -4,13 +4,6 @@ import Set from "../Chaos Rising"
 const card: Card = {
 	set: Set,
 
-	variants: {
-		normal: true,
-		reverse: false,
-		holo: false,
-		firstEdition: false
-	},
-
 	name: {
 		en: "Deoxys"
 	},
@@ -49,9 +42,14 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "J",
 
-	thirdParty: {
-		tcgplayer: 693475
-	}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 693475
+			}
+		}
+	],
 }
 
 export default card

--- a/data/Mega Evolution/Chaos Rising/033.ts
+++ b/data/Mega Evolution/Chaos Rising/033.ts
@@ -4,13 +4,6 @@ import Set from "../Chaos Rising"
 const card: Card = {
 	set: Set,
 
-	variants: {
-		normal: true,
-		reverse: false,
-		holo: false,
-		firstEdition: false
-	},
-
 	name: {
 		en: "Deoxys"
 	},
@@ -49,9 +42,14 @@ const card: Card = {
 	retreat: 3,
 	regulationMark: "J",
 
-	thirdParty: {
-		tcgplayer: 693476
-	}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 693476
+			}
+		}
+	],
 }
 
 export default card

--- a/data/Mega Evolution/Chaos Rising/034.ts
+++ b/data/Mega Evolution/Chaos Rising/034.ts
@@ -4,13 +4,6 @@ import Set from "../Chaos Rising"
 const card: Card = {
 	set: Set,
 
-	variants: {
-		normal: true,
-		reverse: false,
-		holo: false,
-		firstEdition: false
-	},
-
 	name: {
 		en: "Deoxys"
 	},
@@ -49,9 +42,14 @@ const card: Card = {
 	retreat: 0,
 	regulationMark: "J",
 
-	thirdParty: {
-		tcgplayer: 693477
-	}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 693477
+			}
+		}
+	],
 }
 
 export default card

--- a/data/Mega Evolution/Chaos Rising/035.ts
+++ b/data/Mega Evolution/Chaos Rising/035.ts
@@ -4,13 +4,6 @@ import Set from "../Chaos Rising"
 const card: Card = {
 	set: Set,
 
-	variants: {
-		normal: true,
-		reverse: false,
-		holo: false,
-		firstEdition: false
-	},
-
 	name: {
 		en: "Mega Floette ex"
 	},
@@ -55,9 +48,14 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "J",
 
-	thirdParty: {
-		tcgplayer: 693511
-	}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 693511
+			}
+		}
+	],
 }
 
 export default card

--- a/data/Mega Evolution/Chaos Rising/036.ts
+++ b/data/Mega Evolution/Chaos Rising/036.ts
@@ -4,13 +4,6 @@ import Set from "../Chaos Rising"
 const card: Card = {
 	set: Set,
 
-	variants: {
-		normal: true,
-		reverse: false,
-		holo: false,
-		firstEdition: false
-	},
-
 	name: {
 		en: "Espurr"
 	},
@@ -49,9 +42,14 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "J",
 
-	thirdParty: {
-		tcgplayer: 693483
-	}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 693483
+			}
+		}
+	],
 }
 
 export default card

--- a/data/Mega Evolution/Chaos Rising/037.ts
+++ b/data/Mega Evolution/Chaos Rising/037.ts
@@ -4,13 +4,6 @@ import Set from "../Chaos Rising"
 const card: Card = {
 	set: Set,
 
-	variants: {
-		normal: true,
-		reverse: false,
-		holo: false,
-		firstEdition: false
-	},
-
 	name: {
 		en: "Meowstic"
 	},
@@ -54,9 +47,14 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "J",
 
-	thirdParty: {
-		tcgplayer: 693521
-	}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 693521
+			}
+		}
+	],
 }
 
 export default card

--- a/data/Mega Evolution/Chaos Rising/038.ts
+++ b/data/Mega Evolution/Chaos Rising/038.ts
@@ -4,13 +4,6 @@ import Set from "../Chaos Rising"
 const card: Card = {
 	set: Set,
 
-	variants: {
-		normal: true,
-		reverse: false,
-		holo: false,
-		firstEdition: false
-	},
-
 	name: {
 		en: "Phantump"
 	},
@@ -57,9 +50,14 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "J",
 
-	thirdParty: {
-		tcgplayer: 693531
-	}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 693531
+			}
+		}
+	],
 }
 
 export default card

--- a/data/Mega Evolution/Chaos Rising/039.ts
+++ b/data/Mega Evolution/Chaos Rising/039.ts
@@ -4,13 +4,6 @@ import Set from "../Chaos Rising"
 const card: Card = {
 	set: Set,
 
-	variants: {
-		normal: true,
-		reverse: false,
-		holo: false,
-		firstEdition: false
-	},
-
 	name: {
 		en: "Trevenant"
 	},
@@ -65,9 +58,14 @@ const card: Card = {
 	retreat: 3,
 	regulationMark: "J",
 
-	thirdParty: {
-		tcgplayer: 693556
-	}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 693556
+			}
+		}
+	],
 }
 
 export default card

--- a/data/Mega Evolution/Chaos Rising/040.ts
+++ b/data/Mega Evolution/Chaos Rising/040.ts
@@ -4,13 +4,6 @@ import Set from "../Chaos Rising"
 const card: Card = {
 	set: Set,
 
-	variants: {
-		normal: true,
-		reverse: false,
-		holo: false,
-		firstEdition: false
-	},
-
 	name: {
 		en: "Pumpkaboo"
 	},
@@ -45,9 +38,14 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "J",
 
-	thirdParty: {
-		tcgplayer: 693536
-	}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 693536
+			}
+		}
+	],
 }
 
 export default card

--- a/data/Mega Evolution/Chaos Rising/041.ts
+++ b/data/Mega Evolution/Chaos Rising/041.ts
@@ -4,13 +4,6 @@ import Set from "../Chaos Rising"
 const card: Card = {
 	set: Set,
 
-	variants: {
-		normal: true,
-		reverse: false,
-		holo: false,
-		firstEdition: false
-	},
-
 	name: {
 		en: "Gourgeist ex"
 	},
@@ -66,9 +59,14 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "J",
 
-	thirdParty: {
-		tcgplayer: 693497
-	}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 693497
+			}
+		}
+	],
 }
 
 export default card

--- a/data/Mega Evolution/Chaos Rising/042.ts
+++ b/data/Mega Evolution/Chaos Rising/042.ts
@@ -4,13 +4,6 @@ import Set from "../Chaos Rising"
 const card: Card = {
 	set: Set,
 
-	variants: {
-		normal: true,
-		reverse: false,
-		holo: false,
-		firstEdition: false
-	},
-
 	name: {
 		en: "Xerneas"
 	},
@@ -44,9 +37,14 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "J",
 
-	thirdParty: {
-		tcgplayer: 693563
-	}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 693563
+			}
+		}
+	],
 }
 
 export default card

--- a/data/Mega Evolution/Chaos Rising/043.ts
+++ b/data/Mega Evolution/Chaos Rising/043.ts
@@ -4,13 +4,6 @@ import Set from "../Chaos Rising"
 const card: Card = {
 	set: Set,
 
-	variants: {
-		normal: true,
-		reverse: false,
-		holo: false,
-		firstEdition: false
-	},
-
 	name: {
 		en: "Sudowoodo"
 	},
@@ -54,9 +47,14 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "J",
 
-	thirdParty: {
-		tcgplayer: 693550
-	}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 693550
+			}
+		}
+	],
 }
 
 export default card

--- a/data/Mega Evolution/Chaos Rising/044.ts
+++ b/data/Mega Evolution/Chaos Rising/044.ts
@@ -4,13 +4,6 @@ import Set from "../Chaos Rising"
 const card: Card = {
 	set: Set,
 
-	variants: {
-		normal: true,
-		reverse: false,
-		holo: false,
-		firstEdition: false
-	},
-
 	name: {
 		en: "Phanpy"
 	},
@@ -47,9 +40,14 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "J",
 
-	thirdParty: {
-		tcgplayer: 693530
-	}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 693530
+			}
+		}
+	],
 }
 
 export default card

--- a/data/Mega Evolution/Chaos Rising/045.ts
+++ b/data/Mega Evolution/Chaos Rising/045.ts
@@ -4,13 +4,6 @@ import Set from "../Chaos Rising"
 const card: Card = {
 	set: Set,
 
-	variants: {
-		normal: true,
-		reverse: false,
-		holo: false,
-		firstEdition: false
-	},
-
 	name: {
 		en: "Donphan"
 	},
@@ -60,9 +53,14 @@ const card: Card = {
 	retreat: 3,
 	regulationMark: "J",
 
-	thirdParty: {
-		tcgplayer: 693478
-	}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 693478
+			}
+		}
+	],
 }
 
 export default card

--- a/data/Mega Evolution/Chaos Rising/046.ts
+++ b/data/Mega Evolution/Chaos Rising/046.ts
@@ -4,13 +4,6 @@ import Set from "../Chaos Rising"
 const card: Card = {
 	set: Set,
 
-	variants: {
-		normal: true,
-		reverse: false,
-		holo: false,
-		firstEdition: false
-	},
-
 	name: {
 		en: "Baltoy"
 	},
@@ -44,9 +37,14 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "J",
 
-	thirdParty: {
-		tcgplayer: 693452
-	}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 693452
+			}
+		}
+	],
 }
 
 export default card

--- a/data/Mega Evolution/Chaos Rising/047.ts
+++ b/data/Mega Evolution/Chaos Rising/047.ts
@@ -4,13 +4,6 @@ import Set from "../Chaos Rising"
 const card: Card = {
 	set: Set,
 
-	variants: {
-		normal: true,
-		reverse: false,
-		holo: false,
-		firstEdition: false
-	},
-
 	name: {
 		en: "Claydol"
 	},
@@ -49,9 +42,14 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "J",
 
-	thirdParty: {
-		tcgplayer: 693466
-	}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 693466
+			}
+		}
+	],
 }
 
 export default card

--- a/data/Mega Evolution/Chaos Rising/048.ts
+++ b/data/Mega Evolution/Chaos Rising/048.ts
@@ -4,13 +4,6 @@ import Set from "../Chaos Rising"
 const card: Card = {
 	set: Set,
 
-	variants: {
-		normal: true,
-		reverse: false,
-		holo: false,
-		firstEdition: false
-	},
-
 	name: {
 		en: "Mega Gallade ex"
 	},
@@ -57,9 +50,14 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "J",
 
-	thirdParty: {
-		tcgplayer: 693514
-	}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 693514
+			}
+		}
+	],
 }
 
 export default card

--- a/data/Mega Evolution/Chaos Rising/049.ts
+++ b/data/Mega Evolution/Chaos Rising/049.ts
@@ -4,13 +4,6 @@ import Set from "../Chaos Rising"
 const card: Card = {
 	set: Set,
 
-	variants: {
-		normal: true,
-		reverse: false,
-		holo: false,
-		firstEdition: false
-	},
-
 	name: {
 		en: "Zubat"
 	},
@@ -48,9 +41,14 @@ const card: Card = {
 	retreat: 0,
 	regulationMark: "J",
 
-	thirdParty: {
-		tcgplayer: 693565
-	}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 693565
+			}
+		}
+	],
 }
 
 export default card

--- a/data/Mega Evolution/Chaos Rising/050.ts
+++ b/data/Mega Evolution/Chaos Rising/050.ts
@@ -4,13 +4,6 @@ import Set from "../Chaos Rising"
 const card: Card = {
 	set: Set,
 
-	variants: {
-		normal: true,
-		reverse: false,
-		holo: false,
-		firstEdition: false
-	},
-
 	name: {
 		en: "Golbat"
 	},
@@ -54,9 +47,14 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "J",
 
-	thirdParty: {
-		tcgplayer: 693493
-	}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 693493
+			}
+		}
+	],
 }
 
 export default card

--- a/data/Mega Evolution/Chaos Rising/051.ts
+++ b/data/Mega Evolution/Chaos Rising/051.ts
@@ -4,13 +4,6 @@ import Set from "../Chaos Rising"
 const card: Card = {
 	set: Set,
 
-	variants: {
-		normal: true,
-		reverse: false,
-		holo: false,
-		firstEdition: false
-	},
-
 	name: {
 		en: "Crobat"
 	},
@@ -66,9 +59,14 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "J",
 
-	thirdParty: {
-		tcgplayer: 693470
-	}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 693470
+			}
+		}
+	],
 }
 
 export default card

--- a/data/Mega Evolution/Chaos Rising/052.ts
+++ b/data/Mega Evolution/Chaos Rising/052.ts
@@ -4,13 +4,6 @@ import Set from "../Chaos Rising"
 const card: Card = {
 	set: Set,
 
-	variants: {
-		normal: true,
-		reverse: false,
-		holo: false,
-		firstEdition: false
-	},
-
 	name: {
 		en: "Qwilfish"
 	},
@@ -56,9 +49,14 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "J",
 
-	thirdParty: {
-		tcgplayer: 693538
-	}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 693538
+			}
+		}
+	],
 }
 
 export default card

--- a/data/Mega Evolution/Chaos Rising/053.ts
+++ b/data/Mega Evolution/Chaos Rising/053.ts
@@ -4,13 +4,6 @@ import Set from "../Chaos Rising"
 const card: Card = {
 	set: Set,
 
-	variants: {
-		normal: true,
-		reverse: false,
-		holo: false,
-		firstEdition: false
-	},
-
 	name: {
 		en: "Stunky"
 	},
@@ -40,9 +33,14 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "J",
 
-	thirdParty: {
-		tcgplayer: 693549
-	}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 693549
+			}
+		}
+	],
 }
 
 export default card

--- a/data/Mega Evolution/Chaos Rising/054.ts
+++ b/data/Mega Evolution/Chaos Rising/054.ts
@@ -4,13 +4,6 @@ import Set from "../Chaos Rising"
 const card: Card = {
 	set: Set,
 
-	variants: {
-		normal: true,
-		reverse: false,
-		holo: false,
-		firstEdition: false
-	},
-
 	name: {
 		en: "Skuntank"
 	},
@@ -56,9 +49,14 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "J",
 
-	thirdParty: {
-		tcgplayer: 693544
-	}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 693544
+			}
+		}
+	],
 }
 
 export default card

--- a/data/Mega Evolution/Chaos Rising/055.ts
+++ b/data/Mega Evolution/Chaos Rising/055.ts
@@ -4,13 +4,6 @@ import Set from "../Chaos Rising"
 const card: Card = {
 	set: Set,
 
-	variants: {
-		normal: true,
-		reverse: false,
-		holo: false,
-		firstEdition: false
-	},
-
 	name: {
 		en: "Krookodile ex"
 	},
@@ -61,9 +54,14 @@ const card: Card = {
 	retreat: 3,
 	regulationMark: "I",
 
-	thirdParty: {
-		tcgplayer: 693504
-	}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 693504
+			}
+		}
+	],
 }
 
 export default card

--- a/data/Mega Evolution/Chaos Rising/056.ts
+++ b/data/Mega Evolution/Chaos Rising/056.ts
@@ -4,13 +4,6 @@ import Set from "../Chaos Rising"
 const card: Card = {
 	set: Set,
 
-	variants: {
-		normal: true,
-		reverse: false,
-		holo: false,
-		firstEdition: false
-	},
-
 	name: {
 		en: "Trubbish"
 	},
@@ -44,9 +37,14 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "J",
 
-	thirdParty: {
-		tcgplayer: 693557
-	}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 693557
+			}
+		}
+	],
 }
 
 export default card

--- a/data/Mega Evolution/Chaos Rising/057.ts
+++ b/data/Mega Evolution/Chaos Rising/057.ts
@@ -4,13 +4,6 @@ import Set from "../Chaos Rising"
 const card: Card = {
 	set: Set,
 
-	variants: {
-		normal: true,
-		reverse: false,
-		holo: false,
-		firstEdition: false
-	},
-
 	name: {
 		en: "Garbodor"
 	},
@@ -57,9 +50,14 @@ const card: Card = {
 	retreat: 3,
 	regulationMark: "J",
 
-	thirdParty: {
-		tcgplayer: 693492
-	}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 693492
+			}
+		}
+	],
 }
 
 export default card

--- a/data/Mega Evolution/Chaos Rising/058.ts
+++ b/data/Mega Evolution/Chaos Rising/058.ts
@@ -4,13 +4,6 @@ import Set from "../Chaos Rising"
 const card: Card = {
 	set: Set,
 
-	variants: {
-		normal: true,
-		reverse: false,
-		holo: false,
-		firstEdition: false
-	},
-
 	name: {
 		en: "Skrelp"
 	},
@@ -40,9 +33,14 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "J",
 
-	thirdParty: {
-		tcgplayer: 693543
-	}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 693543
+			}
+		}
+	],
 }
 
 export default card

--- a/data/Mega Evolution/Chaos Rising/059.ts
+++ b/data/Mega Evolution/Chaos Rising/059.ts
@@ -4,13 +4,6 @@ import Set from "../Chaos Rising"
 const card: Card = {
 	set: Set,
 
-	variants: {
-		normal: true,
-		reverse: false,
-		holo: false,
-		firstEdition: false
-	},
-
 	name: {
 		en: "Beldum"
 	},
@@ -52,9 +45,14 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "J",
 
-	thirdParty: {
-		tcgplayer: 693455
-	}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 693455
+			}
+		}
+	],
 }
 
 export default card

--- a/data/Mega Evolution/Chaos Rising/060.ts
+++ b/data/Mega Evolution/Chaos Rising/060.ts
@@ -4,13 +4,6 @@ import Set from "../Chaos Rising"
 const card: Card = {
 	set: Set,
 
-	variants: {
-		normal: true,
-		reverse: false,
-		holo: false,
-		firstEdition: false
-	},
-
 	name: {
 		en: "Metang"
 	},
@@ -61,9 +54,14 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "J",
 
-	thirdParty: {
-		tcgplayer: 693523
-	}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 693523
+			}
+		}
+	],
 }
 
 export default card

--- a/data/Mega Evolution/Chaos Rising/061.ts
+++ b/data/Mega Evolution/Chaos Rising/061.ts
@@ -4,13 +4,6 @@ import Set from "../Chaos Rising"
 const card: Card = {
 	set: Set,
 
-	variants: {
-		normal: true,
-		reverse: false,
-		holo: false,
-		firstEdition: false
-	},
-
 	name: {
 		en: "Metagross"
 	},
@@ -65,9 +58,14 @@ const card: Card = {
 	retreat: 3,
 	regulationMark: "J",
 
-	thirdParty: {
-		tcgplayer: 693522
-	}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 693522
+			}
+		}
+	],
 }
 
 export default card

--- a/data/Mega Evolution/Chaos Rising/062.ts
+++ b/data/Mega Evolution/Chaos Rising/062.ts
@@ -4,13 +4,6 @@ import Set from "../Chaos Rising"
 const card: Card = {
 	set: Set,
 
-	variants: {
-		normal: true,
-		reverse: false,
-		holo: false,
-		firstEdition: false
-	},
-
 	name: {
 		en: "Ferroseed"
 	},
@@ -45,9 +38,14 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "J",
 
-	thirdParty: {
-		tcgplayer: 693485
-	}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 693485
+			}
+		}
+	],
 }
 
 export default card

--- a/data/Mega Evolution/Chaos Rising/063.ts
+++ b/data/Mega Evolution/Chaos Rising/063.ts
@@ -4,13 +4,6 @@ import Set from "../Chaos Rising"
 const card: Card = {
 	set: Set,
 
-	variants: {
-		normal: true,
-		reverse: false,
-		holo: false,
-		firstEdition: false
-	},
-
 	name: {
 		en: "Ferrothorn"
 	},
@@ -66,9 +59,14 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "J",
 
-	thirdParty: {
-		tcgplayer: 693486
-	}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 693486
+			}
+		}
+	],
 }
 
 export default card

--- a/data/Mega Evolution/Chaos Rising/064.ts
+++ b/data/Mega Evolution/Chaos Rising/064.ts
@@ -4,13 +4,6 @@ import Set from "../Chaos Rising"
 const card: Card = {
 	set: Set,
 
-	variants: {
-		normal: true,
-		reverse: false,
-		holo: false,
-		firstEdition: false
-	},
-
 	name: {
 		en: "Cobalion ex"
 	},
@@ -62,9 +55,14 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "J",
 
-	thirdParty: {
-		tcgplayer: 693468
-	}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 693468
+			}
+		}
+	],
 }
 
 export default card

--- a/data/Mega Evolution/Chaos Rising/065.ts
+++ b/data/Mega Evolution/Chaos Rising/065.ts
@@ -4,13 +4,6 @@ import Set from "../Chaos Rising"
 const card: Card = {
 	set: Set,
 
-	variants: {
-		normal: true,
-		reverse: false,
-		holo: false,
-		firstEdition: false
-	},
-
 	name: {
 		en: "Mega Dragalge ex"
 	},
@@ -54,9 +47,14 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "J",
 
-	thirdParty: {
-		tcgplayer: 693508
-	}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 693508
+			}
+		}
+	],
 }
 
 export default card

--- a/data/Mega Evolution/Chaos Rising/066.ts
+++ b/data/Mega Evolution/Chaos Rising/066.ts
@@ -4,13 +4,6 @@ import Set from "../Chaos Rising"
 const card: Card = {
 	set: Set,
 
-	variants: {
-		normal: true,
-		reverse: false,
-		holo: false,
-		firstEdition: false
-	},
-
 	name: {
 		en: "Goomy"
 	},
@@ -39,9 +32,14 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "J",
 
-	thirdParty: {
-		tcgplayer: 693496
-	}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 693496
+			}
+		}
+	],
 }
 
 export default card

--- a/data/Mega Evolution/Chaos Rising/067.ts
+++ b/data/Mega Evolution/Chaos Rising/067.ts
@@ -4,13 +4,6 @@ import Set from "../Chaos Rising"
 const card: Card = {
 	set: Set,
 
-	variants: {
-		normal: true,
-		reverse: false,
-		holo: false,
-		firstEdition: false
-	},
-
 	name: {
 		en: "Sliggoo"
 	},
@@ -40,9 +33,14 @@ const card: Card = {
 	retreat: 3,
 	regulationMark: "J",
 
-	thirdParty: {
-		tcgplayer: 693545
-	}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 693545
+			}
+		}
+	],
 }
 
 export default card

--- a/data/Mega Evolution/Chaos Rising/068.ts
+++ b/data/Mega Evolution/Chaos Rising/068.ts
@@ -4,13 +4,6 @@ import Set from "../Chaos Rising"
 const card: Card = {
 	set: Set,
 
-	variants: {
-		normal: true,
-		reverse: false,
-		holo: false,
-		firstEdition: false
-	},
-
 	name: {
 		en: "Goodra"
 	},
@@ -56,9 +49,14 @@ const card: Card = {
 	retreat: 3,
 	regulationMark: "J",
 
-	thirdParty: {
-		tcgplayer: 693495
-	}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 693495
+			}
+		}
+	],
 }
 
 export default card

--- a/data/Mega Evolution/Chaos Rising/069.ts
+++ b/data/Mega Evolution/Chaos Rising/069.ts
@@ -4,13 +4,6 @@ import Set from "../Chaos Rising"
 const card: Card = {
 	set: Set,
 
-	variants: {
-		normal: true,
-		reverse: false,
-		holo: false,
-		firstEdition: false
-	},
-
 	name: {
 		en: "Tauros"
 	},
@@ -43,9 +36,14 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "J",
 
-	thirdParty: {
-		tcgplayer: 693552
-	}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 693552
+			}
+		}
+	],
 }
 
 export default card

--- a/data/Mega Evolution/Chaos Rising/070.ts
+++ b/data/Mega Evolution/Chaos Rising/070.ts
@@ -4,13 +4,6 @@ import Set from "../Chaos Rising"
 const card: Card = {
 	set: Set,
 
-	variants: {
-		normal: true,
-		reverse: false,
-		holo: false,
-		firstEdition: false
-	},
-
 	name: {
 		en: "Patrat"
 	},
@@ -52,9 +45,14 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "J",
 
-	thirdParty: {
-		tcgplayer: 693529
-	}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 693529
+			}
+		}
+	],
 }
 
 export default card

--- a/data/Mega Evolution/Chaos Rising/071.ts
+++ b/data/Mega Evolution/Chaos Rising/071.ts
@@ -4,13 +4,6 @@ import Set from "../Chaos Rising"
 const card: Card = {
 	set: Set,
 
-	variants: {
-		normal: true,
-		reverse: false,
-		holo: false,
-		firstEdition: false
-	},
-
 	name: {
 		en: "Watchog"
 	},
@@ -55,9 +48,14 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "J",
 
-	thirdParty: {
-		tcgplayer: 693559
-	}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 693559
+			}
+		}
+	],
 }
 
 export default card

--- a/data/Mega Evolution/Chaos Rising/072.ts
+++ b/data/Mega Evolution/Chaos Rising/072.ts
@@ -4,13 +4,6 @@ import Set from "../Chaos Rising"
 const card: Card = {
 	set: Set,
 
-	variants: {
-		normal: true,
-		reverse: false,
-		holo: false,
-		firstEdition: false
-	},
-
 	name: {
 		en: "Minccino"
 	},
@@ -44,9 +37,14 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "J",
 
-	thirdParty: {
-		tcgplayer: 693525
-	}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 693525
+			}
+		}
+	],
 }
 
 export default card

--- a/data/Mega Evolution/Chaos Rising/073.ts
+++ b/data/Mega Evolution/Chaos Rising/073.ts
@@ -4,13 +4,6 @@ import Set from "../Chaos Rising"
 const card: Card = {
 	set: Set,
 
-	variants: {
-		normal: true,
-		reverse: false,
-		holo: false,
-		firstEdition: false
-	},
-
 	name: {
 		en: "Cinccino ex"
 	},
@@ -62,9 +55,14 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "J",
 
-	thirdParty: {
-		tcgplayer: 693463
-	}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 693463
+			}
+		}
+	],
 }
 
 export default card

--- a/data/Mega Evolution/Chaos Rising/074.ts
+++ b/data/Mega Evolution/Chaos Rising/074.ts
@@ -4,13 +4,6 @@ import Set from "../Chaos Rising"
 const card: Card = {
 	set: Set,
 
-	variants: {
-		normal: true,
-		reverse: false,
-		holo: false,
-		firstEdition: false
-	},
-
 	name: {
 		en: "Adversity Policy"
 	},
@@ -21,9 +14,14 @@ const card: Card = {
 	trainerType: "Tool",
 	regulationMark: "I",
 
-	thirdParty: {
-		tcgplayer: 693444
-	}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 693444
+			}
+		}
+	],
 }
 
 export default card

--- a/data/Mega Evolution/Chaos Rising/075.ts
+++ b/data/Mega Evolution/Chaos Rising/075.ts
@@ -4,13 +4,6 @@ import Set from "../Chaos Rising"
 const card: Card = {
 	set: Set,
 
-	variants: {
-		normal: true,
-		reverse: false,
-		holo: false,
-		firstEdition: false
-	},
-
 	name: {
 		en: "Ange Floette"
 	},
@@ -21,9 +14,14 @@ const card: Card = {
 	trainerType: "Stadium",
 	regulationMark: "J",
 
-	thirdParty: {
-		tcgplayer: 693447
-	}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 693447
+			}
+		}
+	],
 }
 
 export default card

--- a/data/Mega Evolution/Chaos Rising/076.ts
+++ b/data/Mega Evolution/Chaos Rising/076.ts
@@ -4,13 +4,6 @@ import Set from "../Chaos Rising"
 const card: Card = {
 	set: Set,
 
-	variants: {
-		normal: true,
-		reverse: false,
-		holo: false,
-		firstEdition: false
-	},
-
 	name: {
 		en: "AZ's Tranquility"
 	},
@@ -21,9 +14,14 @@ const card: Card = {
 	trainerType: "Supporter",
 	regulationMark: "J",
 
-	thirdParty: {
-		tcgplayer: 693449
-	}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 693449
+			}
+		}
+	],
 }
 
 export default card

--- a/data/Mega Evolution/Chaos Rising/077.ts
+++ b/data/Mega Evolution/Chaos Rising/077.ts
@@ -4,13 +4,6 @@ import Set from "../Chaos Rising"
 const card: Card = {
 	set: Set,
 
-	variants: {
-		normal: true,
-		reverse: false,
-		holo: false,
-		firstEdition: false
-	},
-
 	name: {
 		en: "Emma"
 	},
@@ -21,9 +14,14 @@ const card: Card = {
 	trainerType: "Supporter",
 	regulationMark: "J",
 
-	thirdParty: {
-		tcgplayer: 693479
-	}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 693479
+			}
+		}
+	],
 }
 
 export default card

--- a/data/Mega Evolution/Chaos Rising/078.ts
+++ b/data/Mega Evolution/Chaos Rising/078.ts
@@ -4,13 +4,6 @@ import Set from "../Chaos Rising"
 const card: Card = {
 	set: Set,
 
-	variants: {
-		normal: true,
-		reverse: false,
-		holo: false,
-		firstEdition: false
-	},
-
 	name: {
 		en: "Great Haul Net"
 	},
@@ -21,9 +14,14 @@ const card: Card = {
 	trainerType: "Item",
 	regulationMark: "J",
 
-	thirdParty: {
-		tcgplayer: 693499
-	}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 693499
+			}
+		}
+	],
 }
 
 export default card

--- a/data/Mega Evolution/Chaos Rising/079.ts
+++ b/data/Mega Evolution/Chaos Rising/079.ts
@@ -4,13 +4,6 @@ import Set from "../Chaos Rising"
 const card: Card = {
 	set: Set,
 
-	variants: {
-		normal: true,
-		reverse: false,
-		holo: false,
-		firstEdition: false
-	},
-
 	name: {
 		en: "Philippe"
 	},
@@ -21,9 +14,14 @@ const card: Card = {
 	trainerType: "Supporter",
 	regulationMark: "J",
 
-	thirdParty: {
-		tcgplayer: 693532
-	}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 693532
+			}
+		}
+	],
 }
 
 export default card

--- a/data/Mega Evolution/Chaos Rising/080.ts
+++ b/data/Mega Evolution/Chaos Rising/080.ts
@@ -4,13 +4,6 @@ import Set from "../Chaos Rising"
 const card: Card = {
 	set: Set,
 
-	variants: {
-		normal: true,
-		reverse: false,
-		holo: false,
-		firstEdition: false
-	},
-
 	name: {
 		en: "Prism Tower"
 	},
@@ -21,9 +14,14 @@ const card: Card = {
 	trainerType: "Stadium",
 	regulationMark: "J",
 
-	thirdParty: {
-		tcgplayer: 693534
-	}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 693534
+			}
+		}
+	],
 }
 
 export default card

--- a/data/Mega Evolution/Chaos Rising/081.ts
+++ b/data/Mega Evolution/Chaos Rising/081.ts
@@ -4,13 +4,6 @@ import Set from "../Chaos Rising"
 const card: Card = {
 	set: Set,
 
-	variants: {
-		normal: true,
-		reverse: false,
-		holo: false,
-		firstEdition: false
-	},
-
 	name: {
 		en: "Roxie's Performance"
 	},
@@ -21,9 +14,14 @@ const card: Card = {
 	trainerType: "Supporter",
 	regulationMark: "J",
 
-	thirdParty: {
-		tcgplayer: 693540
-	}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 693540
+			}
+		}
+	],
 }
 
 export default card

--- a/data/Mega Evolution/Chaos Rising/082.ts
+++ b/data/Mega Evolution/Chaos Rising/082.ts
@@ -4,13 +4,6 @@ import Set from "../Chaos Rising"
 const card: Card = {
 	set: Set,
 
-	variants: {
-		normal: true,
-		reverse: false,
-		holo: false,
-		firstEdition: false
-	},
-
 	name: {
 		en: "Special Red Card"
 	},
@@ -21,9 +14,14 @@ const card: Card = {
 	trainerType: "Item",
 	regulationMark: "J",
 
-	thirdParty: {
-		tcgplayer: 693547
-	}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 693547
+			}
+		}
+	],
 }
 
 export default card

--- a/data/Mega Evolution/Chaos Rising/083.ts
+++ b/data/Mega Evolution/Chaos Rising/083.ts
@@ -4,13 +4,6 @@ import Set from "../Chaos Rising"
 const card: Card = {
 	set: Set,
 
-	variants: {
-		normal: true,
-		reverse: false,
-		holo: false,
-		firstEdition: false
-	},
-
 	name: {
 		en: "Transformation Tome"
 	},
@@ -21,9 +14,14 @@ const card: Card = {
 	trainerType: "Item",
 	regulationMark: "J",
 
-	thirdParty: {
-		tcgplayer: 693555
-	}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 693555
+			}
+		}
+	],
 }
 
 export default card

--- a/data/Mega Evolution/Chaos Rising/084.ts
+++ b/data/Mega Evolution/Chaos Rising/084.ts
@@ -4,13 +4,6 @@ import Set from "../Chaos Rising"
 const card: Card = {
 	set: Set,
 
-	variants: {
-		normal: true,
-		reverse: false,
-		holo: false,
-		firstEdition: false
-	},
-
 	name: {
 		en: "Bubbly Water Energy"
 	},
@@ -20,9 +13,14 @@ const card: Card = {
 	energyType: "Special",
 	regulationMark: "J",
 
-	thirdParty: {
-		tcgplayer: 693458
-	}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 693458
+			}
+		}
+	],
 }
 
 export default card

--- a/data/Mega Evolution/Chaos Rising/085.ts
+++ b/data/Mega Evolution/Chaos Rising/085.ts
@@ -4,13 +4,6 @@ import Set from "../Chaos Rising"
 const card: Card = {
 	set: Set,
 
-	variants: {
-		normal: true,
-		reverse: false,
-		holo: false,
-		firstEdition: false
-	},
-
 	name: {
 		en: "Magnetic Metal Energy"
 	},
@@ -20,9 +13,14 @@ const card: Card = {
 	energyType: "Special",
 	regulationMark: "J",
 
-	thirdParty: {
-		tcgplayer: 693506
-	}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 693506
+			}
+		}
+	],
 }
 
 export default card

--- a/data/Mega Evolution/Chaos Rising/086.ts
+++ b/data/Mega Evolution/Chaos Rising/086.ts
@@ -4,13 +4,6 @@ import Set from "../Chaos Rising"
 const card: Card = {
 	set: Set,
 
-	variants: {
-		normal: true,
-		reverse: false,
-		holo: false,
-		firstEdition: false
-	},
-
 	name: {
 		en: "Nitro Fire Energy"
 	},
@@ -20,9 +13,14 @@ const card: Card = {
 	energyType: "Special",
 	regulationMark: "J",
 
-	thirdParty: {
-		tcgplayer: 693527
-	}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 693527
+			}
+		}
+	],
 }
 
 export default card

--- a/data/Mega Evolution/Chaos Rising/087.ts
+++ b/data/Mega Evolution/Chaos Rising/087.ts
@@ -4,13 +4,6 @@ import Set from "../Chaos Rising"
 const card: Card = {
 	set: Set,
 
-	variants: {
-		normal: true,
-		reverse: false,
-		holo: false,
-		firstEdition: false
-	},
-
 	name: {
 		en: "Chespin"
 	},
@@ -47,9 +40,14 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "J",
 
-	thirdParty: {
-		tcgplayer: 693462
-	}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 693462
+			}
+		}
+	],
 }
 
 export default card

--- a/data/Mega Evolution/Chaos Rising/088.ts
+++ b/data/Mega Evolution/Chaos Rising/088.ts
@@ -4,13 +4,6 @@ import Set from "../Chaos Rising"
 const card: Card = {
 	set: Set,
 
-	variants: {
-		normal: true,
-		reverse: false,
-		holo: false,
-		firstEdition: false
-	},
-
 	name: {
 		en: "Froakie"
 	},
@@ -50,9 +43,14 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "J",
 
-	thirdParty: {
-		tcgplayer: 693489
-	}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 693489
+			}
+		}
+	],
 }
 
 export default card

--- a/data/Mega Evolution/Chaos Rising/089.ts
+++ b/data/Mega Evolution/Chaos Rising/089.ts
@@ -4,13 +4,6 @@ import Set from "../Chaos Rising"
 const card: Card = {
 	set: Set,
 
-	variants: {
-		normal: true,
-		reverse: false,
-		holo: false,
-		firstEdition: false
-	},
-
 	name: {
 		en: "Frogadier"
 	},
@@ -55,9 +48,14 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "J",
 
-	thirdParty: {
-		tcgplayer: 693491
-	}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 693491
+			}
+		}
+	],
 }
 
 export default card

--- a/data/Mega Evolution/Chaos Rising/090.ts
+++ b/data/Mega Evolution/Chaos Rising/090.ts
@@ -4,13 +4,6 @@ import Set from "../Chaos Rising"
 const card: Card = {
 	set: Set,
 
-	variants: {
-		normal: true,
-		reverse: false,
-		holo: false,
-		firstEdition: false
-	},
-
 	name: {
 		en: "Ampharos"
 	},
@@ -61,9 +54,14 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "J",
 
-	thirdParty: {
-		tcgplayer: 693446
-	}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 693446
+			}
+		}
+	],
 }
 
 export default card

--- a/data/Mega Evolution/Chaos Rising/091.ts
+++ b/data/Mega Evolution/Chaos Rising/091.ts
@@ -4,13 +4,6 @@ import Set from "../Chaos Rising"
 const card: Card = {
 	set: Set,
 
-	variants: {
-		normal: true,
-		reverse: false,
-		holo: false,
-		firstEdition: false
-	},
-
 	name: {
 		en: "Xerneas"
 	},
@@ -44,9 +37,14 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "J",
 
-	thirdParty: {
-		tcgplayer: 693564
-	}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 693564
+			}
+		}
+	],
 }
 
 export default card

--- a/data/Mega Evolution/Chaos Rising/092.ts
+++ b/data/Mega Evolution/Chaos Rising/092.ts
@@ -4,13 +4,6 @@ import Set from "../Chaos Rising"
 const card: Card = {
 	set: Set,
 
-	variants: {
-		normal: true,
-		reverse: false,
-		holo: false,
-		firstEdition: false
-	},
-
 	name: {
 		en: "Claydol"
 	},
@@ -49,9 +42,14 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "J",
 
-	thirdParty: {
-		tcgplayer: 693467
-	}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 693467
+			}
+		}
+	],
 }
 
 export default card

--- a/data/Mega Evolution/Chaos Rising/093.ts
+++ b/data/Mega Evolution/Chaos Rising/093.ts
@@ -4,13 +4,6 @@ import Set from "../Chaos Rising"
 const card: Card = {
 	set: Set,
 
-	variants: {
-		normal: true,
-		reverse: false,
-		holo: false,
-		firstEdition: false
-	},
-
 	name: {
 		en: "Crobat"
 	},
@@ -66,9 +59,14 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "J",
 
-	thirdParty: {
-		tcgplayer: 693471
-	}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 693471
+			}
+		}
+	],
 }
 
 export default card

--- a/data/Mega Evolution/Chaos Rising/094.ts
+++ b/data/Mega Evolution/Chaos Rising/094.ts
@@ -4,13 +4,6 @@ import Set from "../Chaos Rising"
 const card: Card = {
 	set: Set,
 
-	variants: {
-		normal: true,
-		reverse: false,
-		holo: false,
-		firstEdition: false
-	},
-
 	name: {
 		en: "Metang"
 	},
@@ -61,9 +54,14 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "J",
 
-	thirdParty: {
-		tcgplayer: 693524
-	}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 693524
+			}
+		}
+	],
 }
 
 export default card

--- a/data/Mega Evolution/Chaos Rising/095.ts
+++ b/data/Mega Evolution/Chaos Rising/095.ts
@@ -4,13 +4,6 @@ import Set from "../Chaos Rising"
 const card: Card = {
 	set: Set,
 
-	variants: {
-		normal: true,
-		reverse: false,
-		holo: false,
-		firstEdition: false
-	},
-
 	name: {
 		en: "Sliggoo"
 	},
@@ -40,9 +33,14 @@ const card: Card = {
 	retreat: 3,
 	regulationMark: "J",
 
-	thirdParty: {
-		tcgplayer: 693546
-	}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 693546
+			}
+		}
+	],
 }
 
 export default card

--- a/data/Mega Evolution/Chaos Rising/096.ts
+++ b/data/Mega Evolution/Chaos Rising/096.ts
@@ -4,13 +4,6 @@ import Set from "../Chaos Rising"
 const card: Card = {
 	set: Set,
 
-	variants: {
-		normal: true,
-		reverse: false,
-		holo: false,
-		firstEdition: false
-	},
-
 	name: {
 		en: "Tauros"
 	},
@@ -43,9 +36,14 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "J",
 
-	thirdParty: {
-		tcgplayer: 693553
-	}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 693553
+			}
+		}
+	],
 }
 
 export default card

--- a/data/Mega Evolution/Chaos Rising/097.ts
+++ b/data/Mega Evolution/Chaos Rising/097.ts
@@ -4,13 +4,6 @@ import Set from "../Chaos Rising"
 const card: Card = {
 	set: Set,
 
-	variants: {
-		normal: true,
-		reverse: false,
-		holo: false,
-		firstEdition: false
-	},
-
 	name: {
 		en: "Watchog"
 	},
@@ -55,9 +48,14 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "J",
 
-	thirdParty: {
-		tcgplayer: 693560
-	}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 693560
+			}
+		}
+	],
 }
 
 export default card

--- a/data/Mega Evolution/Chaos Rising/098.ts
+++ b/data/Mega Evolution/Chaos Rising/098.ts
@@ -4,13 +4,6 @@ import Set from "../Chaos Rising"
 const card: Card = {
 	set: Set,
 
-	variants: {
-		normal: true,
-		reverse: false,
-		holo: false,
-		firstEdition: false
-	},
-
 	name: {
 		en: "Beedrill ex"
 	},
@@ -50,9 +43,14 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "J",
 
-	thirdParty: {
-		tcgplayer: 693454
-	}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 693454
+			}
+		}
+	],
 }
 
 export default card

--- a/data/Mega Evolution/Chaos Rising/099.ts
+++ b/data/Mega Evolution/Chaos Rising/099.ts
@@ -4,13 +4,6 @@ import Set from "../Chaos Rising"
 const card: Card = {
 	set: Set,
 
-	variants: {
-		normal: true,
-		reverse: false,
-		holo: false,
-		firstEdition: false
-	},
-
 	name: {
 		en: "Mega Pyroar ex"
 	},
@@ -61,9 +54,14 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "J",
 
-	thirdParty: {
-		tcgplayer: 693520
-	}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 693520
+			}
+		}
+	],
 }
 
 export default card

--- a/data/Mega Evolution/Chaos Rising/100.ts
+++ b/data/Mega Evolution/Chaos Rising/100.ts
@@ -4,13 +4,6 @@ import Set from "../Chaos Rising"
 const card: Card = {
 	set: Set,
 
-	variants: {
-		normal: true,
-		reverse: false,
-		holo: false,
-		firstEdition: false
-	},
-
 	name: {
 		en: "Mega Greninja ex"
 	},
@@ -62,9 +55,14 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "J",
 
-	thirdParty: {
-		tcgplayer: 693516
-	}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 693516
+			}
+		}
+	],
 }
 
 export default card

--- a/data/Mega Evolution/Chaos Rising/101.ts
+++ b/data/Mega Evolution/Chaos Rising/101.ts
@@ -4,13 +4,6 @@ import Set from "../Chaos Rising"
 const card: Card = {
 	set: Set,
 
-	variants: {
-		normal: true,
-		reverse: false,
-		holo: false,
-		firstEdition: false
-	},
-
 	name: {
 		en: "Mega Floette ex"
 	},
@@ -55,9 +48,14 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "J",
 
-	thirdParty: {
-		tcgplayer: 693512
-	}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 693512
+			}
+		}
+	],
 }
 
 export default card

--- a/data/Mega Evolution/Chaos Rising/102.ts
+++ b/data/Mega Evolution/Chaos Rising/102.ts
@@ -4,13 +4,6 @@ import Set from "../Chaos Rising"
 const card: Card = {
 	set: Set,
 
-	variants: {
-		normal: true,
-		reverse: false,
-		holo: false,
-		firstEdition: false
-	},
-
 	name: {
 		en: "Gourgeist ex"
 	},
@@ -66,9 +59,14 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "J",
 
-	thirdParty: {
-		tcgplayer: 693498
-	}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 693498
+			}
+		}
+	],
 }
 
 export default card

--- a/data/Mega Evolution/Chaos Rising/103.ts
+++ b/data/Mega Evolution/Chaos Rising/103.ts
@@ -4,13 +4,6 @@ import Set from "../Chaos Rising"
 const card: Card = {
 	set: Set,
 
-	variants: {
-		normal: true,
-		reverse: false,
-		holo: false,
-		firstEdition: false
-	},
-
 	name: {
 		en: "Cobalion ex"
 	},
@@ -62,9 +55,14 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "J",
 
-	thirdParty: {
-		tcgplayer: 693469
-	}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 693469
+			}
+		}
+	],
 }
 
 export default card

--- a/data/Mega Evolution/Chaos Rising/104.ts
+++ b/data/Mega Evolution/Chaos Rising/104.ts
@@ -4,13 +4,6 @@ import Set from "../Chaos Rising"
 const card: Card = {
 	set: Set,
 
-	variants: {
-		normal: true,
-		reverse: false,
-		holo: false,
-		firstEdition: false
-	},
-
 	name: {
 		en: "Mega Dragalge ex"
 	},
@@ -54,9 +47,14 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "J",
 
-	thirdParty: {
-		tcgplayer: 693509
-	}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 693509
+			}
+		}
+	],
 }
 
 export default card

--- a/data/Mega Evolution/Chaos Rising/105.ts
+++ b/data/Mega Evolution/Chaos Rising/105.ts
@@ -4,13 +4,6 @@ import Set from "../Chaos Rising"
 const card: Card = {
 	set: Set,
 
-	variants: {
-		normal: true,
-		reverse: false,
-		holo: false,
-		firstEdition: false
-	},
-
 	name: {
 		en: "Cinccino ex"
 	},
@@ -62,9 +55,14 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "J",
 
-	thirdParty: {
-		tcgplayer: 693464
-	}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 693464
+			}
+		}
+	],
 }
 
 export default card

--- a/data/Mega Evolution/Chaos Rising/106.ts
+++ b/data/Mega Evolution/Chaos Rising/106.ts
@@ -4,13 +4,6 @@ import Set from "../Chaos Rising"
 const card: Card = {
 	set: Set,
 
-	variants: {
-		normal: true,
-		reverse: false,
-		holo: false,
-		firstEdition: false
-	},
-
 	name: {
 		en: "AZ's Tranquility"
 	},
@@ -21,9 +14,14 @@ const card: Card = {
 	trainerType: "Supporter",
 	regulationMark: "J",
 
-	thirdParty: {
-		tcgplayer: 693450
-	}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 693450
+			}
+		}
+	],
 }
 
 export default card

--- a/data/Mega Evolution/Chaos Rising/107.ts
+++ b/data/Mega Evolution/Chaos Rising/107.ts
@@ -4,13 +4,6 @@ import Set from "../Chaos Rising"
 const card: Card = {
 	set: Set,
 
-	variants: {
-		normal: true,
-		reverse: false,
-		holo: false,
-		firstEdition: false
-	},
-
 	name: {
 		en: "Emma"
 	},
@@ -21,9 +14,14 @@ const card: Card = {
 	trainerType: "Supporter",
 	regulationMark: "J",
 
-	thirdParty: {
-		tcgplayer: 693480
-	}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 693480
+			}
+		}
+	],
 }
 
 export default card

--- a/data/Mega Evolution/Chaos Rising/108.ts
+++ b/data/Mega Evolution/Chaos Rising/108.ts
@@ -4,13 +4,6 @@ import Set from "../Chaos Rising"
 const card: Card = {
 	set: Set,
 
-	variants: {
-		normal: true,
-		reverse: false,
-		holo: false,
-		firstEdition: false
-	},
-
 	name: {
 		en: "Energy Retrieval"
 	},
@@ -21,9 +14,14 @@ const card: Card = {
 	trainerType: "Item",
 	regulationMark: "I",
 
-	thirdParty: {
-		tcgplayer: 693482
-	}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 693482
+			}
+		}
+	],
 }
 
 export default card

--- a/data/Mega Evolution/Chaos Rising/109.ts
+++ b/data/Mega Evolution/Chaos Rising/109.ts
@@ -4,13 +4,6 @@ import Set from "../Chaos Rising"
 const card: Card = {
 	set: Set,
 
-	variants: {
-		normal: true,
-		reverse: false,
-		holo: false,
-		firstEdition: false
-	},
-
 	name: {
 		en: "Jumbo Ice Cream"
 	},
@@ -21,9 +14,14 @@ const card: Card = {
 	trainerType: "Item",
 	regulationMark: "I",
 
-	thirdParty: {
-		tcgplayer: 693501
-	}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 693501
+			}
+		}
+	],
 }
 
 export default card

--- a/data/Mega Evolution/Chaos Rising/110.ts
+++ b/data/Mega Evolution/Chaos Rising/110.ts
@@ -4,13 +4,6 @@ import Set from "../Chaos Rising"
 const card: Card = {
 	set: Set,
 
-	variants: {
-		normal: true,
-		reverse: false,
-		holo: false,
-		firstEdition: false
-	},
-
 	name: {
 		en: "Philippe"
 	},
@@ -21,9 +14,14 @@ const card: Card = {
 	trainerType: "Supporter",
 	regulationMark: "J",
 
-	thirdParty: {
-		tcgplayer: 693533
-	}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 693533
+			}
+		}
+	],
 }
 
 export default card

--- a/data/Mega Evolution/Chaos Rising/111.ts
+++ b/data/Mega Evolution/Chaos Rising/111.ts
@@ -4,13 +4,6 @@ import Set from "../Chaos Rising"
 const card: Card = {
 	set: Set,
 
-	variants: {
-		normal: true,
-		reverse: false,
-		holo: false,
-		firstEdition: false
-	},
-
 	name: {
 		en: "Prism Tower"
 	},
@@ -21,9 +14,14 @@ const card: Card = {
 	trainerType: "Stadium",
 	regulationMark: "J",
 
-	thirdParty: {
-		tcgplayer: 693535
-	}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 693535
+			}
+		}
+	],
 }
 
 export default card

--- a/data/Mega Evolution/Chaos Rising/112.ts
+++ b/data/Mega Evolution/Chaos Rising/112.ts
@@ -4,13 +4,6 @@ import Set from "../Chaos Rising"
 const card: Card = {
 	set: Set,
 
-	variants: {
-		normal: true,
-		reverse: false,
-		holo: false,
-		firstEdition: false
-	},
-
 	name: {
 		en: "Roxie's Performance"
 	},
@@ -21,9 +14,14 @@ const card: Card = {
 	trainerType: "Supporter",
 	regulationMark: "J",
 
-	thirdParty: {
-		tcgplayer: 693541
-	}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 693541
+			}
+		}
+	],
 }
 
 export default card

--- a/data/Mega Evolution/Chaos Rising/113.ts
+++ b/data/Mega Evolution/Chaos Rising/113.ts
@@ -4,13 +4,6 @@ import Set from "../Chaos Rising"
 const card: Card = {
 	set: Set,
 
-	variants: {
-		normal: true,
-		reverse: false,
-		holo: false,
-		firstEdition: false
-	},
-
 	name: {
 		en: "Special Red Card"
 	},
@@ -21,9 +14,14 @@ const card: Card = {
 	trainerType: "Item",
 	regulationMark: "J",
 
-	thirdParty: {
-		tcgplayer: 693548
-	}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 693548
+			}
+		}
+	],
 }
 
 export default card

--- a/data/Mega Evolution/Chaos Rising/114.ts
+++ b/data/Mega Evolution/Chaos Rising/114.ts
@@ -4,13 +4,6 @@ import Set from "../Chaos Rising"
 const card: Card = {
 	set: Set,
 
-	variants: {
-		normal: true,
-		reverse: false,
-		holo: false,
-		firstEdition: false
-	},
-
 	name: {
 		en: "Surfing Beach"
 	},
@@ -21,9 +14,14 @@ const card: Card = {
 	trainerType: "Stadium",
 	regulationMark: "I",
 
-	thirdParty: {
-		tcgplayer: 693551
-	}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 693551
+			}
+		}
+	],
 }
 
 export default card

--- a/data/Mega Evolution/Chaos Rising/115.ts
+++ b/data/Mega Evolution/Chaos Rising/115.ts
@@ -4,13 +4,6 @@ import Set from "../Chaos Rising"
 const card: Card = {
 	set: Set,
 
-	variants: {
-		normal: true,
-		reverse: false,
-		holo: false,
-		firstEdition: false
-	},
-
 	name: {
 		en: "Tool Scrapper"
 	},
@@ -21,9 +14,14 @@ const card: Card = {
 	trainerType: "Item",
 	regulationMark: "I",
 
-	thirdParty: {
-		tcgplayer: 693554
-	}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 693554
+			}
+		}
+	],
 }
 
 export default card

--- a/data/Mega Evolution/Chaos Rising/116.ts
+++ b/data/Mega Evolution/Chaos Rising/116.ts
@@ -4,13 +4,6 @@ import Set from "../Chaos Rising"
 const card: Card = {
 	set: Set,
 
-	variants: {
-		normal: true,
-		reverse: false,
-		holo: false,
-		firstEdition: false
-	},
-
 	name: {
 		en: "Mega Greninja ex"
 	},
@@ -62,9 +55,14 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "J",
 
-	thirdParty: {
-		tcgplayer: 693517
-	}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 693517
+			}
+		}
+	],
 }
 
 export default card

--- a/data/Mega Evolution/Chaos Rising/117.ts
+++ b/data/Mega Evolution/Chaos Rising/117.ts
@@ -4,13 +4,6 @@ import Set from "../Chaos Rising"
 const card: Card = {
 	set: Set,
 
-	variants: {
-		normal: true,
-		reverse: false,
-		holo: false,
-		firstEdition: false
-	},
-
 	name: {
 		en: "Mega Floette ex"
 	},
@@ -55,9 +48,14 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "J",
 
-	thirdParty: {
-		tcgplayer: 693513
-	}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 693513
+			}
+		}
+	],
 }
 
 export default card

--- a/data/Mega Evolution/Chaos Rising/118.ts
+++ b/data/Mega Evolution/Chaos Rising/118.ts
@@ -4,13 +4,6 @@ import Set from "../Chaos Rising"
 const card: Card = {
 	set: Set,
 
-	variants: {
-		normal: true,
-		reverse: false,
-		holo: false,
-		firstEdition: false
-	},
-
 	name: {
 		en: "Mega Dragalge ex"
 	},
@@ -54,9 +47,14 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "J",
 
-	thirdParty: {
-		tcgplayer: 693510
-	}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 693510
+			}
+		}
+	],
 }
 
 export default card

--- a/data/Mega Evolution/Chaos Rising/119.ts
+++ b/data/Mega Evolution/Chaos Rising/119.ts
@@ -4,13 +4,6 @@ import Set from "../Chaos Rising"
 const card: Card = {
 	set: Set,
 
-	variants: {
-		normal: true,
-		reverse: false,
-		holo: false,
-		firstEdition: false
-	},
-
 	name: {
 		en: "Cinccino ex"
 	},
@@ -62,9 +55,14 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "J",
 
-	thirdParty: {
-		tcgplayer: 693465
-	}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 693465
+			}
+		}
+	],
 }
 
 export default card

--- a/data/Mega Evolution/Chaos Rising/120.ts
+++ b/data/Mega Evolution/Chaos Rising/120.ts
@@ -4,13 +4,6 @@ import Set from "../Chaos Rising"
 const card: Card = {
 	set: Set,
 
-	variants: {
-		normal: true,
-		reverse: false,
-		holo: false,
-		firstEdition: false
-	},
-
 	name: {
 		en: "AZ's Tranquility"
 	},
@@ -21,9 +14,14 @@ const card: Card = {
 	trainerType: "Supporter",
 	regulationMark: "J",
 
-	thirdParty: {
-		tcgplayer: 693451
-	}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 693451
+			}
+		}
+	],
 }
 
 export default card

--- a/data/Mega Evolution/Chaos Rising/121.ts
+++ b/data/Mega Evolution/Chaos Rising/121.ts
@@ -4,13 +4,6 @@ import Set from "../Chaos Rising"
 const card: Card = {
 	set: Set,
 
-	variants: {
-		normal: true,
-		reverse: false,
-		holo: false,
-		firstEdition: false
-	},
-
 	name: {
 		en: "Roxie's Performance"
 	},
@@ -21,9 +14,14 @@ const card: Card = {
 	trainerType: "Supporter",
 	regulationMark: "J",
 
-	thirdParty: {
-		tcgplayer: 693542
-	}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 693542
+			}
+		}
+	],
 }
 
 export default card

--- a/data/Mega Evolution/Chaos Rising/122.ts
+++ b/data/Mega Evolution/Chaos Rising/122.ts
@@ -4,13 +4,6 @@ import Set from "../Chaos Rising"
 const card: Card = {
 	set: Set,
 
-	variants: {
-		normal: true,
-		reverse: false,
-		holo: false,
-		firstEdition: false
-	},
-
 	name: {
 		en: "Mega Greninja ex"
 	},
@@ -62,9 +55,14 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "J",
 
-	thirdParty: {
-		tcgplayer: 693518
-	}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 693518
+			}
+		}
+	],
 }
 
 export default card


### PR DESCRIPTION
## Summary
- Moves `thirdParty` tcgplayer IDs into the `variants` array for all 122 cards
- Removes old boolean `variants` object fields (`normal`, `reverse`, `holo`, `firstEdition`)