### PR TITLE
feat: migrate Lost Origin (SWSH11) to new variant format with illustrators and TG tcgplayer IDs

### DIFF
--- a/data/Sword & Shield/Lost Origin/001.ts
+++ b/data/Sword & Shield/Lost Origin/001.ts
@@ -38,16 +38,23 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "F",
 
-	variants: {
-		"normal": true,
-		"reverse": true,
-		"holo": false
-	},
-
-	thirdParty: {
-		cardmarket: 674013,
-		tcgplayer: 283861
-	}
+	illustrator: "Miki Tanaka",
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 674013,
+				tcgplayer: 283861
+			}
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 674013,
+				tcgplayer: 283861
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/002.ts
+++ b/data/Sword & Shield/Lost Origin/002.ts
@@ -57,16 +57,23 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "F",
 
-	variants: {
-		"normal": true,
-		"reverse": true,
-		"holo": false
-	},
-
-	thirdParty: {
-		cardmarket: 674014,
-		tcgplayer: 283862
-	}
+	illustrator: "Tomokazu Komiya",
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 674014,
+				tcgplayer: 283862
+			}
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 674014,
+				tcgplayer: 283862
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/003.ts
+++ b/data/Sword & Shield/Lost Origin/003.ts
@@ -79,16 +79,23 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "F",
 
-	variants: {
-		"normal": false,
-		"reverse": true,
-		"holo": true
-	},
-
-	thirdParty: {
-		cardmarket: 674015,
-		tcgplayer: 283865
-	}
+	illustrator: "Jiro Sasumo",
+	variants: [
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 674015,
+				tcgplayer: 283865
+			}
+		},
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 674015,
+				tcgplayer: 283865
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/004.ts
+++ b/data/Sword & Shield/Lost Origin/004.ts
@@ -47,16 +47,23 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "F",
 
-	variants: {
-		"normal": true,
-		"reverse": true,
-		"holo": false
-	},
-
-	thirdParty: {
-		cardmarket: 670810,
-		tcgplayer: 283866
-	}
+	illustrator: "Mizue",
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 670810,
+				tcgplayer: 283866
+			}
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 670810,
+				tcgplayer: 283866
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/005.ts
+++ b/data/Sword & Shield/Lost Origin/005.ts
@@ -79,16 +79,23 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "F",
 
-	variants: {
-		"normal": true,
-		"reverse": true,
-		"holo": false
-	},
-
-	thirdParty: {
-		cardmarket: 670810,
-		tcgplayer: 283868
-	}
+	illustrator: "Pani Kobayashi",
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 670810,
+				tcgplayer: 283868
+			}
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 670810,
+				tcgplayer: 283868
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/006.ts
+++ b/data/Sword & Shield/Lost Origin/006.ts
@@ -58,16 +58,23 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "F",
 
-	variants: {
-		"normal": true,
-		"reverse": true,
-		"holo": false
-	},
-
-	thirdParty: {
-		cardmarket: 674017,
-		tcgplayer: 283870
-	}
+	illustrator: "ryoma uratsuka",
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 674017,
+				tcgplayer: 283870
+			}
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 674017,
+				tcgplayer: 283870
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/007.ts
+++ b/data/Sword & Shield/Lost Origin/007.ts
@@ -68,16 +68,23 @@ const card: Card = {
 	retreat: 3,
 	regulationMark: "F",
 
-	variants: {
-		"normal": true,
-		"reverse": true,
-		"holo": false
-	},
-
-	thirdParty: {
-		cardmarket: 674018,
-		tcgplayer: 283871
-	}
+	illustrator: "Kagemaru Himeno",
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 674018,
+				tcgplayer: 283871
+			}
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 674018,
+				tcgplayer: 283871
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/008.ts
+++ b/data/Sword & Shield/Lost Origin/008.ts
@@ -79,16 +79,23 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "F",
 
-	variants: {
-		"normal": false,
-		"reverse": true,
-		"holo": true
-	},
-
-	thirdParty: {
-		cardmarket: 674019,
-		tcgplayer: 283872
-	}
+	illustrator: "Yuu Nishida",
+	variants: [
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 674019,
+				tcgplayer: 283872
+			}
+		},
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 674019,
+				tcgplayer: 283872
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/009.ts
+++ b/data/Sword & Shield/Lost Origin/009.ts
@@ -68,16 +68,23 @@ const card: Card = {
 	retreat: 3,
 	regulationMark: "F",
 
-	variants: {
-		"normal": true,
-		"reverse": true,
-		"holo": false
-	},
-
-	thirdParty: {
-		cardmarket: 674020,
-		tcgplayer: 283873
-	}
+	illustrator: "GOSSAN",
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 674020,
+				tcgplayer: 283873
+			}
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 674020,
+				tcgplayer: 283873
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/010.ts
+++ b/data/Sword & Shield/Lost Origin/010.ts
@@ -68,16 +68,23 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "F",
 
-	variants: {
-		"normal": true,
-		"reverse": true,
-		"holo": false
-	},
-
-	thirdParty: {
-		cardmarket: 674021,
-		tcgplayer: 283874
-	}
+	illustrator: "Mitsuhiro Arita",
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 674021,
+				tcgplayer: 283874
+			}
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 674021,
+				tcgplayer: 283874
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/011.ts
+++ b/data/Sword & Shield/Lost Origin/011.ts
@@ -47,16 +47,23 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "F",
 
-	variants: {
-		"normal": true,
-		"reverse": true,
-		"holo": false
-	},
-
-	thirdParty: {
-		cardmarket: 674022,
-		tcgplayer: 283875
-	}
+	illustrator: "Yuka",
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 674022,
+				tcgplayer: 283875
+			}
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 674022,
+				tcgplayer: 283875
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/012.ts
+++ b/data/Sword & Shield/Lost Origin/012.ts
@@ -57,16 +57,23 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "F",
 
-	variants: {
-		"normal": true,
-		"reverse": true,
-		"holo": false
-	},
-
-	thirdParty: {
-		cardmarket: 674023,
-		tcgplayer: 283877
-	}
+	illustrator: "Mizue",
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 674023,
+				tcgplayer: 283877
+			}
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 674023,
+				tcgplayer: 283877
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/013.ts
+++ b/data/Sword & Shield/Lost Origin/013.ts
@@ -79,16 +79,23 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "F",
 
-	variants: {
-		"normal": false,
-		"reverse": true,
-		"holo": true
-	},
-
-	thirdParty: {
-		cardmarket: 674024,
-		tcgplayer: 283879
-	}
+	illustrator: "kawayoo",
+	variants: [
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 674024,
+				tcgplayer: 283879
+			}
+		},
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 674024,
+				tcgplayer: 283879
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/014.ts
+++ b/data/Sword & Shield/Lost Origin/014.ts
@@ -45,16 +45,23 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "F",
 
-	variants: {
-		"normal": true,
-		"reverse": true,
-		"holo": false
-	},
-
-	thirdParty: {
-		cardmarket: 674025,
-		tcgplayer: 283881
-	}
+	illustrator: "Yukiko Baba",
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 674025,
+				tcgplayer: 283881
+			}
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 674025,
+				tcgplayer: 283881
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/015.ts
+++ b/data/Sword & Shield/Lost Origin/015.ts
@@ -79,16 +79,23 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "F",
 
-	variants: {
-		"normal": true,
-		"reverse": true,
-		"holo": false
-	},
-
-	thirdParty: {
-		cardmarket: 674026,
-		tcgplayer: 283882
-	}
+	illustrator: "0313",
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 674026,
+				tcgplayer: 283882
+			}
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 674026,
+				tcgplayer: 283882
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/016.ts
+++ b/data/Sword & Shield/Lost Origin/016.ts
@@ -38,16 +38,23 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "F",
 
-	variants: {
-		"normal": true,
-		"reverse": true,
-		"holo": false
-	},
-
-	thirdParty: {
-		cardmarket: 674027,
-		tcgplayer: 283883
-	}
+	illustrator: "AKIRA EGAWA",
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 674027,
+				tcgplayer: 283883
+			}
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 674027,
+				tcgplayer: 283883
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/017.ts
+++ b/data/Sword & Shield/Lost Origin/017.ts
@@ -79,16 +79,23 @@ const card: Card = {
 	retreat: 3,
 	regulationMark: "F",
 
-	variants: {
-		"normal": false,
-		"reverse": true,
-		"holo": true
-	},
-
-	thirdParty: {
-		cardmarket: 674028,
-		tcgplayer: 283884
-	}
+	illustrator: "Yuya Oka",
+	variants: [
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 674028,
+				tcgplayer: 283884
+			}
+		},
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 674028,
+				tcgplayer: 283884
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/018.ts
+++ b/data/Sword & Shield/Lost Origin/018.ts
@@ -38,16 +38,23 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "F",
 
-	variants: {
-		"normal": true,
-		"reverse": true,
-		"holo": false
-	},
-
-	thirdParty: {
-		cardmarket: 674029,
-		tcgplayer: 283885
-	}
+	illustrator: "Asako Ito",
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 674029,
+				tcgplayer: 283885
+			}
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 674029,
+				tcgplayer: 283885
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/019.ts
+++ b/data/Sword & Shield/Lost Origin/019.ts
@@ -57,16 +57,23 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "F",
 
-	variants: {
-		"normal": true,
-		"reverse": true,
-		"holo": false
-	},
-
-	thirdParty: {
-		cardmarket: 674030,
-		tcgplayer: 283887
-	}
+	illustrator: "Kyoko Umemoto",
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 674030,
+				tcgplayer: 283887
+			}
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 674030,
+				tcgplayer: 283887
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/020.ts
+++ b/data/Sword & Shield/Lost Origin/020.ts
@@ -79,16 +79,23 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "F",
 
-	variants: {
-		"normal": false,
-		"reverse": true,
-		"holo": true
-	},
-
-	thirdParty: {
-		cardmarket: 674031,
-		tcgplayer: 283890
-	}
+	illustrator: "yuu",
+	variants: [
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 674031,
+				tcgplayer: 283890
+			}
+		},
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 674031,
+				tcgplayer: 283890
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/021.ts
+++ b/data/Sword & Shield/Lost Origin/021.ts
@@ -58,16 +58,23 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "F",
 
-	variants: {
-		"normal": true,
-		"reverse": true,
-		"holo": false
-	},
-
-	thirdParty: {
-		cardmarket: 674032,
-		tcgplayer: 283892
-	}
+	illustrator: "Scav",
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 674032,
+				tcgplayer: 283892
+			}
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 674032,
+				tcgplayer: 283892
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/022.ts
+++ b/data/Sword & Shield/Lost Origin/022.ts
@@ -70,16 +70,23 @@ const card: Card = {
 	retreat: 3,
 	regulationMark: "F",
 
-	variants: {
-		"normal": true,
-		"reverse": true,
-		"holo": false
-	},
-
-	thirdParty: {
-		cardmarket: 674033,
-		tcgplayer: 283893
-	}
+	illustrator: "Pani Kobayashi",
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 674033,
+				tcgplayer: 283893
+			}
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 674033,
+				tcgplayer: 283893
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/023.ts
+++ b/data/Sword & Shield/Lost Origin/023.ts
@@ -60,16 +60,23 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "F",
 
-	variants: {
-		"normal": true,
-		"reverse": true,
-		"holo": false
-	},
-
-	thirdParty: {
-		cardmarket: 674034,
-		tcgplayer: 283894
-	}
+	illustrator: "Naoyo Kimura",
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 674034,
+				tcgplayer: 283894
+			}
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 674034,
+				tcgplayer: 283894
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/024.ts
+++ b/data/Sword & Shield/Lost Origin/024.ts
@@ -45,16 +45,23 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "F",
 
-	variants: {
-		"normal": true,
-		"reverse": true,
-		"holo": false
-	},
-
-	thirdParty: {
-		cardmarket: 674035,
-		tcgplayer: 283895
-	}
+	illustrator: "Yuka Morii",
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 674035,
+				tcgplayer: 283895
+			}
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 674035,
+				tcgplayer: 283895
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/025.ts
+++ b/data/Sword & Shield/Lost Origin/025.ts
@@ -57,16 +57,23 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "F",
 
-	variants: {
-		"normal": true,
-		"reverse": true,
-		"holo": false
-	},
-
-	thirdParty: {
-		cardmarket: 674036,
-		tcgplayer: 283896
-	}
+	illustrator: "kurumitsu",
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 674036,
+				tcgplayer: 283896
+			}
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 674036,
+				tcgplayer: 283896
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/026.ts
+++ b/data/Sword & Shield/Lost Origin/026.ts
@@ -70,16 +70,23 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "F",
 
-	variants: {
-		"normal": false,
-		"reverse": true,
-		"holo": true
-	},
-
-	thirdParty: {
-		cardmarket: 670828,
-		tcgplayer: 283897
-	}
+	illustrator: "sui",
+	variants: [
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 670828,
+				tcgplayer: 283897
+			}
+		},
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 670828,
+				tcgplayer: 283897
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/027.ts
+++ b/data/Sword & Shield/Lost Origin/027.ts
@@ -68,16 +68,15 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "F",
 
-	variants: {
-		"normal": false,
-		"reverse": false,
-		"holo": true
-	},
-
-	thirdParty: {
-		cardmarket: 674038,
-		tcgplayer: 283898
-	}
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 674038,
+				tcgplayer: 283898
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/028.ts
+++ b/data/Sword & Shield/Lost Origin/028.ts
@@ -45,16 +45,23 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "F",
 
-	variants: {
-		"normal": true,
-		"reverse": true,
-		"holo": false
-	},
-
-	thirdParty: {
-		cardmarket: 674039,
-		tcgplayer: 283899
-	}
+	illustrator: "Sekio",
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 674039,
+				tcgplayer: 283899
+			}
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 674039,
+				tcgplayer: 283899
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/029.ts
+++ b/data/Sword & Shield/Lost Origin/029.ts
@@ -79,16 +79,23 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "F",
 
-	variants: {
-		"normal": false,
-		"reverse": true,
-		"holo": true
-	},
-
-	thirdParty: {
-		cardmarket: 674040,
-		tcgplayer: 283901
-	}
+	illustrator: "Misa Tsutsui",
+	variants: [
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 674040,
+				tcgplayer: 283901
+			}
+		},
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 674040,
+				tcgplayer: 283901
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/030.ts
+++ b/data/Sword & Shield/Lost Origin/030.ts
@@ -47,16 +47,23 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "F",
 
-	variants: {
-		"normal": true,
-		"reverse": true,
-		"holo": false
-	},
-
-	thirdParty: {
-		cardmarket: 674041,
-		tcgplayer: 283903
-	}
+	illustrator: "Miki Tanaka",
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 674041,
+				tcgplayer: 283903
+			}
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 674041,
+				tcgplayer: 283903
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/031.ts
+++ b/data/Sword & Shield/Lost Origin/031.ts
@@ -70,16 +70,23 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "F",
 
-	variants: {
-		"normal": true,
-		"reverse": true,
-		"holo": false
-	},
-
-	thirdParty: {
-		cardmarket: 674042,
-		tcgplayer: 283904
-	}
+	illustrator: "Scav",
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 674042,
+				tcgplayer: 283904
+			}
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 674042,
+				tcgplayer: 283904
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/032.ts
+++ b/data/Sword & Shield/Lost Origin/032.ts
@@ -70,16 +70,23 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "F",
 
-	variants: {
-		"normal": true,
-		"reverse": true,
-		"holo": false
-	},
-
-	thirdParty: {
-		cardmarket: 674043,
-		tcgplayer: 283905
-	}
+	illustrator: "ryoma uratsuka",
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 674043,
+				tcgplayer: 283905
+			}
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 674043,
+				tcgplayer: 283905
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/033.ts
+++ b/data/Sword & Shield/Lost Origin/033.ts
@@ -51,16 +51,23 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "F",
 
-	variants: {
-		"normal": true,
-		"reverse": true,
-		"holo": false
-	},
-
-	thirdParty: {
-		cardmarket: 674044,
-		tcgplayer: 283906
-	}
+	illustrator: "GIDORA",
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 674044,
+				tcgplayer: 283906
+			}
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 674044,
+				tcgplayer: 283906
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/034.ts
+++ b/data/Sword & Shield/Lost Origin/034.ts
@@ -79,16 +79,23 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "F",
 
-	variants: {
-		"normal": true,
-		"reverse": true,
-		"holo": false
-	},
-
-	thirdParty: {
-		cardmarket: 674045,
-		tcgplayer: 283908
-	}
+	illustrator: "chibi",
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 674045,
+				tcgplayer: 283908
+			}
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 674045,
+				tcgplayer: 283908
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/035.ts
+++ b/data/Sword & Shield/Lost Origin/035.ts
@@ -47,16 +47,23 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "F",
 
-	variants: {
-		"normal": true,
-		"reverse": true,
-		"holo": false
-	},
-
-	thirdParty: {
-		cardmarket: 674046,
-		tcgplayer: 283909
-	}
+	illustrator: "Tika Matsuna",
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 674046,
+				tcgplayer: 283909
+			}
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 674046,
+				tcgplayer: 283909
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/036.ts
+++ b/data/Sword & Shield/Lost Origin/036.ts
@@ -77,16 +77,23 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "F",
 
-	variants: {
-		"normal": true,
-		"reverse": true,
-		"holo": false
-	},
-
-	thirdParty: {
-		cardmarket: 674047,
-		tcgplayer: 283910
-	}
+	illustrator: "sui",
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 674047,
+				tcgplayer: 283910
+			}
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 674047,
+				tcgplayer: 283910
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/037.ts
+++ b/data/Sword & Shield/Lost Origin/037.ts
@@ -70,16 +70,23 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "F",
 
-	variants: {
-		"normal": false,
-		"reverse": true,
-		"holo": true
-	},
-
-	thirdParty: {
-		cardmarket: 670811,
-		tcgplayer: 283911
-	}
+	illustrator: "AKIRA EGAWA",
+	variants: [
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 670811,
+				tcgplayer: 283911
+			}
+		},
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 670811,
+				tcgplayer: 283911
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/038.ts
+++ b/data/Sword & Shield/Lost Origin/038.ts
@@ -58,16 +58,23 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "F",
 
-	variants: {
-		"normal": true,
-		"reverse": true,
-		"holo": false
-	},
-
-	thirdParty: {
-		cardmarket: 674048,
-		tcgplayer: 283912
-	}
+	illustrator: "Sekio",
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 674048,
+				tcgplayer: 283912
+			}
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 674048,
+				tcgplayer: 283912
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/039.ts
+++ b/data/Sword & Shield/Lost Origin/039.ts
@@ -51,16 +51,23 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "F",
 
-	variants: {
-		"normal": true,
-		"reverse": true,
-		"holo": false
-	},
-
-	thirdParty: {
-		cardmarket: 674049,
-		tcgplayer: 283913
-	}
+	illustrator: "Saya Tsuruta",
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 674049,
+				tcgplayer: 283913
+			}
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 674049,
+				tcgplayer: 283913
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/040.ts
+++ b/data/Sword & Shield/Lost Origin/040.ts
@@ -60,16 +60,23 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "F",
 
-	variants: {
-		"normal": true,
-		"reverse": true,
-		"holo": false
-	},
-
-	thirdParty: {
-		cardmarket: 674050,
-		tcgplayer: 283914
-	}
+	illustrator: "Taira Akitsu",
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 674050,
+				tcgplayer: 283914
+			}
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 674050,
+				tcgplayer: 283914
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/041.ts
+++ b/data/Sword & Shield/Lost Origin/041.ts
@@ -70,16 +70,23 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "F",
 
-	variants: {
-		"normal": true,
-		"reverse": true,
-		"holo": false
-	},
-
-	thirdParty: {
-		cardmarket: 674051,
-		tcgplayer: 283915
-	}
+	illustrator: "zig",
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 674051,
+				tcgplayer: 283915
+			}
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 674051,
+				tcgplayer: 283915
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/042.ts
+++ b/data/Sword & Shield/Lost Origin/042.ts
@@ -51,16 +51,23 @@ const card: Card = {
 	retreat: 3,
 	regulationMark: "F",
 
-	variants: {
-		"normal": true,
-		"reverse": true,
-		"holo": false
-	},
-
-	thirdParty: {
-		cardmarket: 674052,
-		tcgplayer: 283916
-	}
+	illustrator: "Mitsuhiro Arita",
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 674052,
+				tcgplayer: 283916
+			}
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 674052,
+				tcgplayer: 283916
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/043.ts
+++ b/data/Sword & Shield/Lost Origin/043.ts
@@ -70,16 +70,23 @@ const card: Card = {
 	retreat: 4,
 	regulationMark: "F",
 
-	variants: {
-		"normal": true,
-		"reverse": true,
-		"holo": false
-	},
-
-	thirdParty: {
-		cardmarket: 674053,
-		tcgplayer: 283917
-	}
+	illustrator: "kodama",
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 674053,
+				tcgplayer: 283917
+			}
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 674053,
+				tcgplayer: 283917
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/044.ts
+++ b/data/Sword & Shield/Lost Origin/044.ts
@@ -45,16 +45,23 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "F",
 
-	variants: {
-		"normal": true,
-		"reverse": true,
-		"holo": false
-	},
-
-	thirdParty: {
-		cardmarket: 674054,
-		tcgplayer: 283918
-	}
+	illustrator: "Oswaldo KATO",
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 674054,
+				tcgplayer: 283918
+			}
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 674054,
+				tcgplayer: 283918
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/045.ts
+++ b/data/Sword & Shield/Lost Origin/045.ts
@@ -77,16 +77,23 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "F",
 
-	variants: {
-		"normal": false,
-		"reverse": true,
-		"holo": true
-	},
-
-	thirdParty: {
-		cardmarket: 674055,
-		tcgplayer: 283919
-	}
+	illustrator: "AKIRA EGAWA",
+	variants: [
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 674055,
+				tcgplayer: 283919
+			}
+		},
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 674055,
+				tcgplayer: 283919
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/046.ts
+++ b/data/Sword & Shield/Lost Origin/046.ts
@@ -38,16 +38,23 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "F",
 
-	variants: {
-		"normal": true,
-		"reverse": true,
-		"holo": false
-	},
-
-	thirdParty: {
-		cardmarket: 674056,
-		tcgplayer: 283920
-	}
+	illustrator: "Yuka Morii",
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 674056,
+				tcgplayer: 283920
+			}
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 674056,
+				tcgplayer: 283920
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/047.ts
+++ b/data/Sword & Shield/Lost Origin/047.ts
@@ -79,16 +79,23 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "F",
 
-	variants: {
-		"normal": true,
-		"reverse": true,
-		"holo": false
-	},
-
-	thirdParty: {
-		cardmarket: 674057,
-		tcgplayer: 283921
-	}
+	illustrator: "Sekio",
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 674057,
+				tcgplayer: 283921
+			}
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 674057,
+				tcgplayer: 283921
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/048.ts
+++ b/data/Sword & Shield/Lost Origin/048.ts
@@ -59,16 +59,16 @@ const card: Card = {
 	retreat: 3,
 	regulationMark: "F",
 
-	variants: {
-		"normal": false,
-		"reverse": false,
-		"holo": true
-	},
-
-	thirdParty: {
-		cardmarket: 674058,
-		tcgplayer: 283922
-	}
+	illustrator: "takuyoa",
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 674058,
+				tcgplayer: 283922
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/049.ts
+++ b/data/Sword & Shield/Lost Origin/049.ts
@@ -79,16 +79,16 @@ const card: Card = {
 	retreat: 3,
 	regulationMark: "F",
 
-	variants: {
-		"normal": false,
-		"reverse": false,
-		"holo": true
-	},
-
-	thirdParty: {
-		cardmarket: 674059,
-		tcgplayer: 283923
-	}
+	illustrator: "N-DESIGN Inc.",
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 674059,
+				tcgplayer: 283923
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/050.ts
+++ b/data/Sword & Shield/Lost Origin/050.ts
@@ -69,16 +69,23 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "F",
 
-	variants: {
-		"normal": true,
-		"reverse": true,
-		"holo": false
-	},
-
-	thirdParty: {
-		cardmarket: 674060,
-		tcgplayer: 283924
-	}
+	illustrator: "Midori Harada",
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 674060,
+				tcgplayer: 283924
+			}
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 674060,
+				tcgplayer: 283924
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/051.ts
+++ b/data/Sword & Shield/Lost Origin/051.ts
@@ -69,16 +69,23 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "F",
 
-	variants: {
-		"normal": false,
-		"reverse": true,
-		"holo": true
-	},
-
-	thirdParty: {
-		cardmarket: 674061,
-		tcgplayer: 283925
-	}
+	illustrator: "Jiro Sasumo",
+	variants: [
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 674061,
+				tcgplayer: 283925
+			}
+		},
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 674061,
+				tcgplayer: 283925
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/052.ts
+++ b/data/Sword & Shield/Lost Origin/052.ts
@@ -69,16 +69,23 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "F",
 
-	variants: {
-		"normal": true,
-		"reverse": true,
-		"holo": false
-	},
-
-	thirdParty: {
-		cardmarket: 674062,
-		tcgplayer: 283926
-	}
+	illustrator: "kurumitsu",
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 674062,
+				tcgplayer: 283926
+			}
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 674062,
+				tcgplayer: 283926
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/053.ts
+++ b/data/Sword & Shield/Lost Origin/053.ts
@@ -79,16 +79,23 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "F",
 
-	variants: {
-		"normal": true,
-		"reverse": true,
-		"holo": false
-	},
-
-	thirdParty: {
-		cardmarket: 674063,
-		tcgplayer: 283927
-	}
+	illustrator: "GIDORA",
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 674063,
+				tcgplayer: 283927
+			}
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 674063,
+				tcgplayer: 283927
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/054.ts
+++ b/data/Sword & Shield/Lost Origin/054.ts
@@ -60,16 +60,23 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "F",
 
-	variants: {
-		"normal": true,
-		"reverse": true,
-		"holo": false
-	},
-
-	thirdParty: {
-		cardmarket: 674064,
-		tcgplayer: 283928
-	}
+	illustrator: "otumami",
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 674064,
+				tcgplayer: 283928
+			}
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 674064,
+				tcgplayer: 283928
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/055.ts
+++ b/data/Sword & Shield/Lost Origin/055.ts
@@ -70,16 +70,23 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "F",
 
-	variants: {
-		"normal": true,
-		"reverse": true,
-		"holo": false
-	},
-
-	thirdParty: {
-		cardmarket: 674065,
-		tcgplayer: 283929
-	}
+	illustrator: "GIDORA",
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 674065,
+				tcgplayer: 283929
+			}
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 674065,
+				tcgplayer: 283929
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/056.ts
+++ b/data/Sword & Shield/Lost Origin/056.ts
@@ -68,16 +68,16 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "F",
 
-	variants: {
-		"normal": false,
-		"reverse": false,
-		"holo": true
-	},
-
-	thirdParty: {
-		cardmarket: 674066,
-		tcgplayer: 283930
-	}
+	illustrator: "N-DESIGN Inc.",
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 674066,
+				tcgplayer: 283930
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/057.ts
+++ b/data/Sword & Shield/Lost Origin/057.ts
@@ -78,16 +78,16 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "F",
 
-	variants: {
-		"normal": false,
-		"reverse": false,
-		"holo": true
-	},
-
-	thirdParty: {
-		cardmarket: 674067,
-		tcgplayer: 283931
-	}
+	illustrator: "PLANETA Mochizuki",
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 674067,
+				tcgplayer: 283931
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/058.ts
+++ b/data/Sword & Shield/Lost Origin/058.ts
@@ -70,16 +70,16 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "F",
 
-	variants: {
-		"normal": false,
-		"reverse": false,
-		"holo": true
-	},
-
-	thirdParty: {
-		cardmarket: 670812,
-		tcgplayer: 283932
-	}
+	illustrator: "5ban Graphics",
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 670812,
+				tcgplayer: 283932
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/059.ts
+++ b/data/Sword & Shield/Lost Origin/059.ts
@@ -58,16 +58,23 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "F",
 
-	variants: {
-		"normal": true,
-		"reverse": true,
-		"holo": false
-	},
-
-	thirdParty: {
-		cardmarket: 674068,
-		tcgplayer: 283933
-	}
+	illustrator: "Yukiko Baba",
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 674068,
+				tcgplayer: 283933
+			}
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 674068,
+				tcgplayer: 283933
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/060.ts
+++ b/data/Sword & Shield/Lost Origin/060.ts
@@ -70,16 +70,23 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "F",
 
-	variants: {
-		"normal": true,
-		"reverse": true,
-		"holo": false
-	},
-
-	thirdParty: {
-		cardmarket: 674069,
-		tcgplayer: 283934
-	}
+	illustrator: "Uta",
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 674069,
+				tcgplayer: 283934
+			}
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 674069,
+				tcgplayer: 283934
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/061.ts
+++ b/data/Sword & Shield/Lost Origin/061.ts
@@ -79,16 +79,23 @@ const card: Card = {
 	retreat: 3,
 	regulationMark: "F",
 
-	variants: {
-		"normal": true,
-		"reverse": true,
-		"holo": false
-	},
-
-	thirdParty: {
-		cardmarket: 674070,
-		tcgplayer: 283935
-	}
+	illustrator: "Shin Nagasawa",
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 674070,
+				tcgplayer: 283935
+			}
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 674070,
+				tcgplayer: 283935
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/062.ts
+++ b/data/Sword & Shield/Lost Origin/062.ts
@@ -69,16 +69,23 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "F",
 
-	variants: {
-		"normal": true,
-		"reverse": true,
-		"holo": false
-	},
-
-	thirdParty: {
-		cardmarket: 674071,
-		tcgplayer: 283936
-	}
+	illustrator: "Kouki Saitou",
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 674071,
+				tcgplayer: 283936
+			}
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 674071,
+				tcgplayer: 283936
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/063.ts
+++ b/data/Sword & Shield/Lost Origin/063.ts
@@ -70,16 +70,23 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "F",
 
-	variants: {
-		"normal": true,
-		"reverse": true,
-		"holo": false
-	},
-
-	thirdParty: {
-		cardmarket: 674072,
-		tcgplayer: 283937
-	}
+	illustrator: "Sekia",
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 674072,
+				tcgplayer: 283937
+			}
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 674072,
+				tcgplayer: 283937
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/064.ts
+++ b/data/Sword & Shield/Lost Origin/064.ts
@@ -45,16 +45,23 @@ const card: Card = {
 	retreat: 0,
 	regulationMark: "F",
 
-	variants: {
-		"normal": true,
-		"reverse": true,
-		"holo": false
-	},
-
-	thirdParty: {
-		cardmarket: 674073,
-		tcgplayer: 283938
-	}
+	illustrator: "Tika Matsuno",
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 674073,
+				tcgplayer: 283938
+			}
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 674073,
+				tcgplayer: 283938
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/065.ts
+++ b/data/Sword & Shield/Lost Origin/065.ts
@@ -55,16 +55,23 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "F",
 
-	variants: {
-		"normal": true,
-		"reverse": true,
-		"holo": false
-	},
-
-	thirdParty: {
-		cardmarket: 674074,
-		tcgplayer: 283939
-	}
+	illustrator: "Kouki Saitou",
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 674074,
+				tcgplayer: 283939
+			}
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 674074,
+				tcgplayer: 283939
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/066.ts
+++ b/data/Sword & Shield/Lost Origin/066.ts
@@ -77,16 +77,23 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "F",
 
-	variants: {
-		"normal": true,
-		"reverse": true,
-		"holo": false
-	},
-
-	thirdParty: {
-		cardmarket: 674075,
-		tcgplayer: 283941
-	}
+	illustrator: "Narumi Sato",
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 674075,
+				tcgplayer: 283941
+			}
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 674075,
+				tcgplayer: 283941
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/067.ts
+++ b/data/Sword & Shield/Lost Origin/067.ts
@@ -60,16 +60,23 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "F",
 
-	variants: {
-		"normal": true,
-		"reverse": true,
-		"holo": false
-	},
-
-	thirdParty: {
-		cardmarket: 674076,
-		tcgplayer: 283942
-	}
+	illustrator: "Souichirou Gunjima",
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 674076,
+				tcgplayer: 283942
+			}
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 674076,
+				tcgplayer: 283942
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/068.ts
+++ b/data/Sword & Shield/Lost Origin/068.ts
@@ -58,16 +58,23 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "F",
 
-	variants: {
-		"normal": true,
-		"reverse": true,
-		"holo": false
-	},
-
-	thirdParty: {
-		cardmarket: 674078,
-		tcgplayer: 283943
-	}
+	illustrator: "Nagomi Nijo",
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 674078,
+				tcgplayer: 283943
+			}
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 674078,
+				tcgplayer: 283943
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/069.ts
+++ b/data/Sword & Shield/Lost Origin/069.ts
@@ -69,16 +69,15 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "F",
 
-	variants: {
-		"normal": false,
-		"reverse": false,
-		"holo": true
-	},
-
-	thirdParty: {
-		cardmarket: 670813,
-		tcgplayer: 283945
-	}
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 670813,
+				tcgplayer: 283945
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/070.ts
+++ b/data/Sword & Shield/Lost Origin/070.ts
@@ -58,16 +58,23 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "F",
 
-	variants: {
-		"normal": false,
-		"reverse": true,
-		"holo": true
-	},
-
-	thirdParty: {
-		cardmarket: 674079,
-		tcgplayer: 283946
-	}
+	illustrator: "Shibuzoh.",
+	variants: [
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 674079,
+				tcgplayer: 283946
+			}
+		},
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 674079,
+				tcgplayer: 283946
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/071.ts
+++ b/data/Sword & Shield/Lost Origin/071.ts
@@ -58,16 +58,23 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "F",
 
-	variants: {
-		"normal": true,
-		"reverse": true,
-		"holo": false
-	},
-
-	thirdParty: {
-		cardmarket: 674080,
-		tcgplayer: 283948
-	}
+	illustrator: "kurumitsu",
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 674080,
+				tcgplayer: 283948
+			}
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 674080,
+				tcgplayer: 283948
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/072.ts
+++ b/data/Sword & Shield/Lost Origin/072.ts
@@ -38,16 +38,22 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "F",
 
-	variants: {
-		"normal": true,
-		"reverse": true,
-		"holo": false
-	},
-
-	thirdParty: {
-		cardmarket: 674081,
-		tcgplayer: 283949
-	}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 674081,
+				tcgplayer: 283949
+			}
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 674081,
+				tcgplayer: 283949
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/073.ts
+++ b/data/Sword & Shield/Lost Origin/073.ts
@@ -70,16 +70,23 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "F",
 
-	variants: {
-		"normal": true,
-		"reverse": true,
-		"holo": false
-	},
-
-	thirdParty: {
-		cardmarket: 674084,
-		tcgplayer: 283951
-	}
+	illustrator: "Kagemaru Himeno",
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 674084,
+				tcgplayer: 283951
+			}
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 674084,
+				tcgplayer: 283951
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/074.ts
+++ b/data/Sword & Shield/Lost Origin/074.ts
@@ -58,16 +58,23 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "F",
 
-	variants: {
-		"normal": true,
-		"reverse": true,
-		"holo": false
-	},
-
-	thirdParty: {
-		cardmarket: 674086,
-		tcgplayer: 283953
-	}
+	illustrator: "saino misaki",
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 674086,
+				tcgplayer: 283953
+			}
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 674086,
+				tcgplayer: 283953
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/075.ts
+++ b/data/Sword & Shield/Lost Origin/075.ts
@@ -56,16 +56,23 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "F",
 
-	variants: {
-		"normal": true,
-		"reverse": true,
-		"holo": false
-	},
-
-	thirdParty: {
-		cardmarket: 674088,
-		tcgplayer: 283954
-	}
+	illustrator: "Akira Komayama",
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 674088,
+				tcgplayer: 283954
+			}
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 674088,
+				tcgplayer: 283954
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/076.ts
+++ b/data/Sword & Shield/Lost Origin/076.ts
@@ -73,16 +73,23 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "F",
 
-	variants: {
-		"normal": false,
-		"reverse": true,
-		"holo": true
-	},
-
-	thirdParty: {
-		cardmarket: 670814,
-		tcgplayer: 283957
-	}
+	illustrator: "Kouki Saitou",
+	variants: [
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 670814,
+				tcgplayer: 283957
+			}
+		},
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 670814,
+				tcgplayer: 283957
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/077.ts
+++ b/data/Sword & Shield/Lost Origin/077.ts
@@ -47,16 +47,23 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "F",
 
-	variants: {
-		"normal": true,
-		"reverse": true,
-		"holo": false
-	},
-
-	thirdParty: {
-		cardmarket: 674090,
-		tcgplayer: 283958
-	}
+	illustrator: "miki kudo",
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 674090,
+				tcgplayer: 283958
+			}
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 674090,
+				tcgplayer: 283958
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/078.ts
+++ b/data/Sword & Shield/Lost Origin/078.ts
@@ -70,16 +70,23 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "F",
 
-	variants: {
-		"normal": true,
-		"reverse": true,
-		"holo": false
-	},
-
-	thirdParty: {
-		cardmarket: 674091,
-		tcgplayer: 283959
-	}
+	illustrator: "Tomokazu Komiya",
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 674091,
+				tcgplayer: 283959
+			}
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 674091,
+				tcgplayer: 283959
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/079.ts
+++ b/data/Sword & Shield/Lost Origin/079.ts
@@ -60,16 +60,23 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "F",
 
-	variants: {
-		"normal": true,
-		"reverse": true,
-		"holo": false
-	},
-
-	thirdParty: {
-		cardmarket: 674092,
-		tcgplayer: 283960
-	}
+	illustrator: "Aya Kusube",
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 674092,
+				tcgplayer: 283960
+			}
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 674092,
+				tcgplayer: 283960
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/080.ts
+++ b/data/Sword & Shield/Lost Origin/080.ts
@@ -67,16 +67,23 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "F",
 
-	variants: {
-		"normal": true,
-		"reverse": true,
-		"holo": false
-	},
-
-	thirdParty: {
-		cardmarket: 674093,
-		tcgplayer: 283961
-	}
+	illustrator: "Ligton",
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 674093,
+				tcgplayer: 283961
+			}
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 674093,
+				tcgplayer: 283961
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/081.ts
+++ b/data/Sword & Shield/Lost Origin/081.ts
@@ -67,16 +67,23 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "F",
 
-	variants: {
-		"normal": false,
-		"reverse": true,
-		"holo": true
-	},
-
-	thirdParty: {
-		cardmarket: 674094,
-		tcgplayer: 283963
-	}
+	illustrator: "Narumi Sato",
+	variants: [
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 674094,
+				tcgplayer: 283963
+			}
+		},
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 674094,
+				tcgplayer: 283963
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/082.ts
+++ b/data/Sword & Shield/Lost Origin/082.ts
@@ -70,16 +70,16 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "F",
 
-	variants: {
-		"normal": false,
-		"reverse": false,
-		"holo": true
-	},
-
-	thirdParty: {
-		cardmarket: 674095,
-		tcgplayer: 283964
-	}
+	illustrator: "5ban Graphics",
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 674095,
+				tcgplayer: 283964
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/083.ts
+++ b/data/Sword & Shield/Lost Origin/083.ts
@@ -43,16 +43,23 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "F",
 
-	variants: {
-		"normal": true,
-		"reverse": true,
-		"holo": false
-	},
-
-	thirdParty: {
-		cardmarket: 674096,
-		tcgplayer: 283967
-	}
+	illustrator: "Kouki Saitou",
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 674096,
+				tcgplayer: 283967
+			}
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 674096,
+				tcgplayer: 283967
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/084.ts
+++ b/data/Sword & Shield/Lost Origin/084.ts
@@ -68,16 +68,23 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "F",
 
-	variants: {
-		"normal": false,
-		"reverse": true,
-		"holo": true
-	},
-
-	thirdParty: {
-		cardmarket: 674097,
-		tcgplayer: 283968
-	}
+	illustrator: "Oswaldo KATO",
+	variants: [
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 674097,
+				tcgplayer: 283968
+			}
+		},
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 674097,
+				tcgplayer: 283968
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/085.ts
+++ b/data/Sword & Shield/Lost Origin/085.ts
@@ -79,16 +79,23 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "F",
 
-	variants: {
-		"normal": true,
-		"reverse": true,
-		"holo": false
-	},
-
-	thirdParty: {
-		cardmarket: 674098,
-		tcgplayer: 283970
-	}
+	illustrator: "Teeziro",
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 674098,
+				tcgplayer: 283970
+			}
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 674098,
+				tcgplayer: 283970
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/086.ts
+++ b/data/Sword & Shield/Lost Origin/086.ts
@@ -38,16 +38,23 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "F",
 
-	variants: {
-		"normal": true,
-		"reverse": true,
-		"holo": false
-	},
-
-	thirdParty: {
-		cardmarket: 674099,
-		tcgplayer: 283971
-	}
+	illustrator: "Yuka Morii",
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 674099,
+				tcgplayer: 283971
+			}
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 674099,
+				tcgplayer: 283971
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/087.ts
+++ b/data/Sword & Shield/Lost Origin/087.ts
@@ -61,16 +61,23 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "F",
 
-	variants: {
-		"normal": true,
-		"reverse": true,
-		"holo": false
-	},
-
-	thirdParty: {
-		cardmarket: 674100,
-		tcgplayer: 283973
-	}
+	illustrator: "Mitsuhiro Arita",
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 674100,
+				tcgplayer: 283973
+			}
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 674100,
+				tcgplayer: 283973
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/088.ts
+++ b/data/Sword & Shield/Lost Origin/088.ts
@@ -79,16 +79,22 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "F",
 
-	variants: {
-		"normal": false,
-		"reverse": true,
-		"holo": true
-	},
-
-	thirdParty: {
-		cardmarket: 674101,
-		tcgplayer: 283974
-	}
+	variants: [
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 674101,
+				tcgplayer: 283974
+			}
+		},
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 674101,
+				tcgplayer: 283974
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/089.ts
+++ b/data/Sword & Shield/Lost Origin/089.ts
@@ -47,16 +47,23 @@ const card: Card = {
 	retreat: 3,
 	regulationMark: "F",
 
-	variants: {
-		"normal": true,
-		"reverse": true,
-		"holo": false
-	},
-
-	thirdParty: {
-		cardmarket: 674102,
-		tcgplayer: 283976
-	}
+	illustrator: "Scav",
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 674102,
+				tcgplayer: 283976
+			}
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 674102,
+				tcgplayer: 283976
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/090.ts
+++ b/data/Sword & Shield/Lost Origin/090.ts
@@ -70,16 +70,23 @@ const card: Card = {
 	retreat: 3,
 	regulationMark: "F",
 
-	variants: {
-		"normal": true,
-		"reverse": true,
-		"holo": false
-	},
-
-	thirdParty: {
-		cardmarket: 674103,
-		tcgplayer: 283978
-	}
+	illustrator: "HYOGONOSUKE",
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 674103,
+				tcgplayer: 283978
+			}
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 674103,
+				tcgplayer: 283978
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/091.ts
+++ b/data/Sword & Shield/Lost Origin/091.ts
@@ -79,16 +79,23 @@ const card: Card = {
 	retreat: 4,
 	regulationMark: "F",
 
-	variants: {
-		"normal": true,
-		"reverse": true,
-		"holo": false
-	},
-
-	thirdParty: {
-		cardmarket: 674104,
-		tcgplayer: 283979
-	}
+	illustrator: "GOSSAN",
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 674104,
+				tcgplayer: 283979
+			}
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 674104,
+				tcgplayer: 283979
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/092.ts
+++ b/data/Sword & Shield/Lost Origin/092.ts
@@ -61,16 +61,16 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "F",
 
-	variants: {
-		"normal": false,
-		"reverse": false,
-		"holo": true
-	},
-
-	thirdParty: {
-		cardmarket: 670815,
-		tcgplayer: 283980
-	}
+	illustrator: "N-DESIGN Inc.",
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 670815,
+				tcgplayer: 283980
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/093.ts
+++ b/data/Sword & Shield/Lost Origin/093.ts
@@ -78,16 +78,16 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "F",
 
-	variants: {
-		"normal": false,
-		"reverse": false,
-		"holo": true
-	},
-
-	thirdParty: {
-		cardmarket: 670815,
-		tcgplayer: 282255
-	}
+	illustrator: "5ban Graphics",
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 670815,
+				tcgplayer: 282255
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/094.ts
+++ b/data/Sword & Shield/Lost Origin/094.ts
@@ -69,16 +69,23 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "F",
 
-	variants: {
-		"normal": true,
-		"reverse": true,
-		"holo": false
-	},
-
-	thirdParty: {
-		cardmarket: 674106,
-		tcgplayer: 283982
-	}
+	illustrator: "AKIRA EGAWA",
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 674106,
+				tcgplayer: 283982
+			}
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 674106,
+				tcgplayer: 283982
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/095.ts
+++ b/data/Sword & Shield/Lost Origin/095.ts
@@ -47,16 +47,23 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "F",
 
-	variants: {
-		"normal": true,
-		"reverse": true,
-		"holo": false
-	},
-
-	thirdParty: {
-		cardmarket: 674107,
-		tcgplayer: 283983
-	}
+	illustrator: "Miki Tanaka",
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 674107,
+				tcgplayer: 283983
+			}
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 674107,
+				tcgplayer: 283983
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/096.ts
+++ b/data/Sword & Shield/Lost Origin/096.ts
@@ -57,16 +57,23 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "F",
 
-	variants: {
-		"normal": true,
-		"reverse": true,
-		"holo": false
-	},
-
-	thirdParty: {
-		cardmarket: 674108,
-		tcgplayer: 283985
-	}
+	illustrator: "Shiburingaru",
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 674108,
+				tcgplayer: 283985
+			}
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 674108,
+				tcgplayer: 283985
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/097.ts
+++ b/data/Sword & Shield/Lost Origin/097.ts
@@ -47,16 +47,23 @@ const card: Card = {
 	retreat: 3,
 	regulationMark: "F",
 
-	variants: {
-		"normal": true,
-		"reverse": true,
-		"holo": false
-	},
-
-	thirdParty: {
-		cardmarket: 674109,
-		tcgplayer: 283987
-	}
+	illustrator: "Shigenori Negishi",
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 674109,
+				tcgplayer: 283987
+			}
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 674109,
+				tcgplayer: 283987
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/098.ts
+++ b/data/Sword & Shield/Lost Origin/098.ts
@@ -79,16 +79,23 @@ const card: Card = {
 	retreat: 3,
 	regulationMark: "F",
 
-	variants: {
-		"normal": true,
-		"reverse": true,
-		"holo": false
-	},
-
-	thirdParty: {
-		cardmarket: 674110,
-		tcgplayer: 283988
-	}
+	illustrator: "Scav",
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 674110,
+				tcgplayer: 283988
+			}
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 674110,
+				tcgplayer: 283988
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/099.ts
+++ b/data/Sword & Shield/Lost Origin/099.ts
@@ -47,16 +47,23 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "F",
 
-	variants: {
-		"normal": true,
-		"reverse": true,
-		"holo": false
-	},
-
-	thirdParty: {
-		cardmarket: 674111,
-		tcgplayer: 283992
-	}
+	illustrator: "0313",
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 674111,
+				tcgplayer: 283992
+			}
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 674111,
+				tcgplayer: 283992
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/100.ts
+++ b/data/Sword & Shield/Lost Origin/100.ts
@@ -57,16 +57,23 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "F",
 
-	variants: {
-		"normal": true,
-		"reverse": true,
-		"holo": false
-	},
-
-	thirdParty: {
-		cardmarket: 674112,
-		tcgplayer: 283993
-	}
+	illustrator: "Kouki Saitou",
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 674112,
+				tcgplayer: 283993
+			}
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 674112,
+				tcgplayer: 283993
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/101.ts
+++ b/data/Sword & Shield/Lost Origin/101.ts
@@ -58,16 +58,23 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "F",
 
-	variants: {
-		"normal": true,
-		"reverse": true,
-		"holo": false
-	},
-
-	thirdParty: {
-		cardmarket: 674113,
-		tcgplayer: 283994
-	}
+	illustrator: "ryoma uratsuka",
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 674113,
+				tcgplayer: 283994
+			}
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 674113,
+				tcgplayer: 283994
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/102.ts
+++ b/data/Sword & Shield/Lost Origin/102.ts
@@ -77,16 +77,23 @@ const card: Card = {
 	retreat: 3,
 	regulationMark: "F",
 
-	variants: {
-		"normal": true,
-		"reverse": true,
-		"holo": false
-	},
-
-	thirdParty: {
-		cardmarket: 674115,
-		tcgplayer: 283995
-	}
+	illustrator: "Sanosuke Sakuma",
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 674115,
+				tcgplayer: 283995
+			}
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 674115,
+				tcgplayer: 283995
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/103.ts
+++ b/data/Sword & Shield/Lost Origin/103.ts
@@ -51,16 +51,23 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "F",
 
-	variants: {
-		"normal": true,
-		"reverse": true,
-		"holo": false
-	},
-
-	thirdParty: {
-		cardmarket: 674116,
-		tcgplayer: 283997
-	}
+	illustrator: "yuu",
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 674116,
+				tcgplayer: 283997
+			}
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 674116,
+				tcgplayer: 283997
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/104.ts
+++ b/data/Sword & Shield/Lost Origin/104.ts
@@ -70,16 +70,23 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "F",
 
-	variants: {
-		"normal": true,
-		"reverse": true,
-		"holo": false
-	},
-
-	thirdParty: {
-		cardmarket: 674117,
-		tcgplayer: 283998
-	}
+	illustrator: "Shibuzoh.",
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 674117,
+				tcgplayer: 283998
+			}
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 674117,
+				tcgplayer: 283998
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/105.ts
+++ b/data/Sword & Shield/Lost Origin/105.ts
@@ -60,16 +60,23 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "F",
 
-	variants: {
-		"normal": true,
-		"reverse": true,
-		"holo": false
-	},
-
-	thirdParty: {
-		cardmarket: 674118,
-		tcgplayer: 283999
-	}
+	illustrator: "KEIICHIRO ITO",
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 674118,
+				tcgplayer: 283999
+			}
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 674118,
+				tcgplayer: 283999
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/106.ts
+++ b/data/Sword & Shield/Lost Origin/106.ts
@@ -51,16 +51,23 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "F",
 
-	variants: {
-		"normal": true,
-		"reverse": true,
-		"holo": false
-	},
-
-	thirdParty: {
-		cardmarket: 674119,
-		tcgplayer: 284001
-	}
+	illustrator: "Scav",
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 674119,
+				tcgplayer: 284001
+			}
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 674119,
+				tcgplayer: 284001
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/107.ts
+++ b/data/Sword & Shield/Lost Origin/107.ts
@@ -70,16 +70,23 @@ const card: Card = {
 	retreat: 3,
 	regulationMark: "F",
 
-	variants: {
-		"normal": false,
-		"reverse": true,
-		"holo": true
-	},
-
-	thirdParty: {
-		cardmarket: 674120,
-		tcgplayer: 284002
-	}
+	illustrator: "KEIICHIRO ITO",
+	variants: [
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 674120,
+				tcgplayer: 284002
+			}
+		},
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 674120,
+				tcgplayer: 284002
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/108.ts
+++ b/data/Sword & Shield/Lost Origin/108.ts
@@ -58,16 +58,23 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "F",
 
-	variants: {
-		"normal": true,
-		"reverse": true,
-		"holo": false
-	},
-
-	thirdParty: {
-		cardmarket: 674121,
-		tcgplayer: 284003
-	}
+	illustrator: "Tika Matsunoo",
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 674121,
+				tcgplayer: 284003
+			}
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 674121,
+				tcgplayer: 284003
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/109.ts
+++ b/data/Sword & Shield/Lost Origin/109.ts
@@ -58,16 +58,23 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "F",
 
-	variants: {
-		"normal": true,
-		"reverse": true,
-		"holo": false
-	},
-
-	thirdParty: {
-		cardmarket: 674122,
-		tcgplayer: 284004
-	}
+	illustrator: "Miki Tanaka",
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 674122,
+				tcgplayer: 284004
+			}
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 674122,
+				tcgplayer: 284004
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/110.ts
+++ b/data/Sword & Shield/Lost Origin/110.ts
@@ -60,16 +60,23 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "F",
 
-	variants: {
-		"normal": true,
-		"reverse": true,
-		"holo": false
-	},
-
-	thirdParty: {
-		cardmarket: 674123,
-		tcgplayer: 284005
-	}
+	illustrator: "sowsow",
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 674123,
+				tcgplayer: 284005
+			}
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 674123,
+				tcgplayer: 284005
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/111.ts
+++ b/data/Sword & Shield/Lost Origin/111.ts
@@ -67,16 +67,23 @@ const card: Card = {
 	retreat: 4,
 	regulationMark: "F",
 
-	variants: {
-		"normal": true,
-		"reverse": true,
-		"holo": false
-	},
-
-	thirdParty: {
-		cardmarket: 674124,
-		tcgplayer: 284006
-	}
+	illustrator: "HYOGONOSUKE",
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 674124,
+				tcgplayer: 284006
+			}
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 674124,
+				tcgplayer: 284006
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/112.ts
+++ b/data/Sword & Shield/Lost Origin/112.ts
@@ -47,16 +47,23 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "F",
 
-	variants: {
-		"normal": true,
-		"reverse": true,
-		"holo": false
-	},
-
-	thirdParty: {
-		cardmarket: 674125,
-		tcgplayer: 284007
-	}
+	illustrator: "Atsuko Nishida",
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 674125,
+				tcgplayer: 284007
+			}
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 674125,
+				tcgplayer: 284007
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/113.ts
+++ b/data/Sword & Shield/Lost Origin/113.ts
@@ -79,16 +79,23 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "F",
 
-	variants: {
-		"normal": true,
-		"reverse": true,
-		"holo": false
-	},
-
-	thirdParty: {
-		cardmarket: 674126,
-		tcgplayer: 284009
-	}
+	illustrator: "Shinji Kanda",
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 674126,
+				tcgplayer: 284009
+			}
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 674126,
+				tcgplayer: 284009
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/114.ts
+++ b/data/Sword & Shield/Lost Origin/114.ts
@@ -51,16 +51,23 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "F",
 
-	variants: {
-		"normal": true,
-		"reverse": true,
-		"holo": false
-	},
-
-	thirdParty: {
-		cardmarket: 674127,
-		tcgplayer: 284011
-	}
+	illustrator: "Yuka Morii",
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 674127,
+				tcgplayer: 284011
+			}
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 674127,
+				tcgplayer: 284011
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/115.ts
+++ b/data/Sword & Shield/Lost Origin/115.ts
@@ -70,16 +70,23 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "F",
 
-	variants: {
-		"normal": true,
-		"reverse": true,
-		"holo": false
-	},
-
-	thirdParty: {
-		cardmarket: 674128,
-		tcgplayer: 284013
-	}
+	illustrator: "Shiburingaru",
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 674128,
+				tcgplayer: 284013
+			}
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 674128,
+				tcgplayer: 284013
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/116.ts
+++ b/data/Sword & Shield/Lost Origin/116.ts
@@ -47,16 +47,23 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "F",
 
-	variants: {
-		"normal": true,
-		"reverse": true,
-		"holo": false
-	},
-
-	thirdParty: {
-		cardmarket: 674129,
-		tcgplayer: 284015
-	}
+	illustrator: "Tomokazu Komiya",
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 674129,
+				tcgplayer: 284015
+			}
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 674129,
+				tcgplayer: 284015
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/117.ts
+++ b/data/Sword & Shield/Lost Origin/117.ts
@@ -69,16 +69,23 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "F",
 
-	variants: {
-		"normal": true,
-		"reverse": true,
-		"holo": false
-	},
-
-	thirdParty: {
-		cardmarket: 674130,
-		tcgplayer: 284017
-	}
+	illustrator: "sui",
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 674130,
+				tcgplayer: 284017
+			}
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 674130,
+				tcgplayer: 284017
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/118.ts
+++ b/data/Sword & Shield/Lost Origin/118.ts
@@ -70,16 +70,16 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "F",
 
-	variants: {
-		"normal": false,
-		"reverse": false,
-		"holo": true
-	},
-
-	thirdParty: {
-		cardmarket: 674131,
-		tcgplayer: 284018
-	}
+	illustrator: "N-DESIGN Inc.",
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 674131,
+				tcgplayer: 284018
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/119.ts
+++ b/data/Sword & Shield/Lost Origin/119.ts
@@ -58,16 +58,16 @@ const card: Card = {
 	retreat: 3,
 	regulationMark: "F",
 
-	variants: {
-		"normal": false,
-		"reverse": false,
-		"holo": true
-	},
-
-	thirdParty: {
-		cardmarket: 674132,
-		tcgplayer: 284021
-	}
+	illustrator: "PLANETA Mochizuki",
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 674132,
+				tcgplayer: 284021
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/120.ts
+++ b/data/Sword & Shield/Lost Origin/120.ts
@@ -69,16 +69,23 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "F",
 
-	variants: {
-		"normal": false,
-		"reverse": true,
-		"holo": true
-	},
-
-	thirdParty: {
-		cardmarket: 674133,
-		tcgplayer: 284025
-	}
+	illustrator: "Shin Nagasawa",
+	variants: [
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 674133,
+				tcgplayer: 284025
+			}
+		},
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 674133,
+				tcgplayer: 284025
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/121.ts
+++ b/data/Sword & Shield/Lost Origin/121.ts
@@ -58,16 +58,22 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "F",
 
-	variants: {
-		"normal": true,
-		"reverse": true,
-		"holo": false
-	},
-
-	thirdParty: {
-		cardmarket: 674090,
-		tcgplayer: 284029
-	}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 674090,
+				tcgplayer: 284029
+			}
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 674090,
+				tcgplayer: 284029
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/122.ts
+++ b/data/Sword & Shield/Lost Origin/122.ts
@@ -58,16 +58,22 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "F",
 
-	variants: {
-		"normal": true,
-		"reverse": true,
-		"holo": false
-	},
-
-	thirdParty: {
-		cardmarket: 674135,
-		tcgplayer: 284030
-	}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 674135,
+				tcgplayer: 284030
+			}
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 674135,
+				tcgplayer: 284030
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/123.ts
+++ b/data/Sword & Shield/Lost Origin/123.ts
@@ -69,16 +69,15 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "F",
 
-	variants: {
-		"normal": false,
-		"reverse": false,
-		"holo": true
-	},
-
-	thirdParty: {
-		cardmarket: 674136,
-		tcgplayer: 284031
-	}
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 674136,
+				tcgplayer: 284031
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/124.ts
+++ b/data/Sword & Shield/Lost Origin/124.ts
@@ -69,16 +69,16 @@ const card: Card = {
 	retreat: 4,
 	regulationMark: "F",
 
-	variants: {
-		"normal": false,
-		"reverse": false,
-		"holo": true
-	},
-
-	thirdParty: {
-		cardmarket: 674137,
-		tcgplayer: 284032
-	}
+	illustrator: "Sanosuke Sakuma",
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 674137,
+				tcgplayer: 284032
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/125.ts
+++ b/data/Sword & Shield/Lost Origin/125.ts
@@ -38,16 +38,23 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "F",
 
-	variants: {
-		"normal": true,
-		"reverse": true,
-		"holo": false
-	},
-
-	thirdParty: {
-		cardmarket: 674138,
-		tcgplayer: 284041
-	}
+	illustrator: "Tomokazu Komiya",
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 674138,
+				tcgplayer: 284041
+			}
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 674138,
+				tcgplayer: 284041
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/126.ts
+++ b/data/Sword & Shield/Lost Origin/126.ts
@@ -70,16 +70,23 @@ const card: Card = {
 	retreat: 3,
 	regulationMark: "F",
 
-	variants: {
-		"normal": true,
-		"reverse": true,
-		"holo": false
-	},
-
-	thirdParty: {
-		cardmarket: 674139,
-		tcgplayer: 284042
-	}
+	illustrator: "AKIRA EGAWA",
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 674139,
+				tcgplayer: 284042
+			}
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 674139,
+				tcgplayer: 284042
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/127.ts
+++ b/data/Sword & Shield/Lost Origin/127.ts
@@ -60,16 +60,23 @@ const card: Card = {
 	retreat: 3,
 	regulationMark: "F",
 
-	variants: {
-		"normal": true,
-		"reverse": true,
-		"holo": false
-	},
-
-	thirdParty: {
-		cardmarket: 674140,
-		tcgplayer: 284044
-	}
+	illustrator: "Shigenori Negishi",
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 674140,
+				tcgplayer: 284044
+			}
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 674140,
+				tcgplayer: 284044
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/128.ts
+++ b/data/Sword & Shield/Lost Origin/128.ts
@@ -60,16 +60,23 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "F",
 
-	variants: {
-		"normal": true,
-		"reverse": true,
-		"holo": false
-	},
-
-	thirdParty: {
-		cardmarket: 674141,
-		tcgplayer: 284045
-	}
+	illustrator: "Rianti Hidayat",
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 674141,
+				tcgplayer: 284045
+			}
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 674141,
+				tcgplayer: 284045
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/129.ts
+++ b/data/Sword & Shield/Lost Origin/129.ts
@@ -68,16 +68,16 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "F",
 
-	variants: {
-		"normal": false,
-		"reverse": false,
-		"holo": true
-	},
-
-	thirdParty: {
-		cardmarket: 674142,
-		tcgplayer: 284047
-	}
+	illustrator: "PLANETA Yamashita",
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 674142,
+				tcgplayer: 284047
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/130.ts
+++ b/data/Sword & Shield/Lost Origin/130.ts
@@ -68,16 +68,16 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "F",
 
-	variants: {
-		"normal": false,
-		"reverse": false,
-		"holo": true
-	},
-
-	thirdParty: {
-		cardmarket: 670816,
-		tcgplayer: 284050
-	}
+	illustrator: "5ban Graphics",
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 670816,
+				tcgplayer: 284050
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/131.ts
+++ b/data/Sword & Shield/Lost Origin/131.ts
@@ -78,16 +78,16 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "F",
 
-	variants: {
-		"normal": false,
-		"reverse": false,
-		"holo": true
-	},
-
-	thirdParty: {
-		cardmarket: 674143,
-		tcgplayer: 284051
-	}
+	illustrator: "5ban Graphics",
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 674143,
+				tcgplayer: 284051
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/132.ts
+++ b/data/Sword & Shield/Lost Origin/132.ts
@@ -51,16 +51,23 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "F",
 
-	variants: {
-		"normal": true,
-		"reverse": true,
-		"holo": false
-	},
-
-	thirdParty: {
-		cardmarket: 674144,
-		tcgplayer: 284053
-	}
+	illustrator: "Oswaldo KATO",
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 674144,
+				tcgplayer: 284053
+			}
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 674144,
+				tcgplayer: 284053
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/133.ts
+++ b/data/Sword & Shield/Lost Origin/133.ts
@@ -66,16 +66,23 @@ const card: Card = {
 	retreat: 3,
 	regulationMark: "F",
 
-	variants: {
-		"normal": true,
-		"reverse": true,
-		"holo": false
-	},
-
-	thirdParty: {
-		cardmarket: 674145,
-		tcgplayer: 284054
-	}
+	illustrator: "Kouki Saitou",
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 674145,
+				tcgplayer: 284054
+			}
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 674145,
+				tcgplayer: 284054
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/134.ts
+++ b/data/Sword & Shield/Lost Origin/134.ts
@@ -70,16 +70,23 @@ const card: Card = {
 	retreat: 3,
 	regulationMark: "F",
 
-	variants: {
-		"normal": false,
-		"reverse": true,
-		"holo": true
-	},
-
-	thirdParty: {
-		cardmarket: 670817,
-		tcgplayer: 284055
-	}
+	illustrator: "Akira Komayama",
+	variants: [
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 670817,
+				tcgplayer: 284055
+			}
+		},
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 670817,
+				tcgplayer: 284055
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/135.ts
+++ b/data/Sword & Shield/Lost Origin/135.ts
@@ -70,16 +70,16 @@ const card: Card = {
 	retreat: 3,
 	regulationMark: "F",
 
-	variants: {
-		"normal": false,
-		"reverse": false,
-		"holo": true
-	},
-
-	thirdParty: {
-		cardmarket: 670818,
-		tcgplayer: 284058
-	}
+	illustrator: "5ban Graphics",
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 670818,
+				tcgplayer: 284058
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/136.ts
+++ b/data/Sword & Shield/Lost Origin/136.ts
@@ -58,16 +58,16 @@ const card: Card = {
 	retreat: 3,
 	regulationMark: "F",
 
-	variants: {
-		"normal": false,
-		"reverse": false,
-		"holo": true
-	},
-
-	thirdParty: {
-		cardmarket: 670818,
-		tcgplayer: 284059
-	}
+	illustrator: "5ban Graphics",
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 670818,
+				tcgplayer: 284059
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/137.ts
+++ b/data/Sword & Shield/Lost Origin/137.ts
@@ -70,16 +70,16 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "F",
 
-	variants: {
-		"normal": false,
-		"reverse": false,
-		"holo": true
-	},
-
-	thirdParty: {
-		cardmarket: 674147,
-		tcgplayer: 284060
-	}
+	illustrator: "Saki Hayashiro",
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 674147,
+				tcgplayer: 284060
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/138.ts
+++ b/data/Sword & Shield/Lost Origin/138.ts
@@ -38,16 +38,23 @@ const card: Card = {
 	retreat: 4,
 	regulationMark: "F",
 
-	variants: {
-		"normal": true,
-		"reverse": true,
-		"holo": false
-	},
-
-	thirdParty: {
-		cardmarket: 674148,
-		tcgplayer: 284061
-	}
+	illustrator: "KIYOTAKA OSHIYAMA",
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 674148,
+				tcgplayer: 284061
+			}
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 674148,
+				tcgplayer: 284061
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/139.ts
+++ b/data/Sword & Shield/Lost Origin/139.ts
@@ -61,16 +61,23 @@ const card: Card = {
 	retreat: 4,
 	regulationMark: "F",
 
-	variants: {
-		"normal": true,
-		"reverse": true,
-		"holo": false
-	},
-
-	thirdParty: {
-		cardmarket: 674149,
-		tcgplayer: 284062
-	}
+	illustrator: "Shibuzoh.",
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 674149,
+				tcgplayer: 284062
+			}
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 674149,
+				tcgplayer: 284062
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/140.ts
+++ b/data/Sword & Shield/Lost Origin/140.ts
@@ -58,16 +58,23 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "F",
 
-	variants: {
-		"normal": true,
-		"reverse": true,
-		"holo": false
-	},
-
-	thirdParty: {
-		cardmarket: 674150,
-		tcgplayer: 284063
-	}
+	illustrator: "kurumitsu",
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 674150,
+				tcgplayer: 284063
+			}
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 674150,
+				tcgplayer: 284063
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/141.ts
+++ b/data/Sword & Shield/Lost Origin/141.ts
@@ -57,16 +57,23 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "F",
 
-	variants: {
-		"normal": true,
-		"reverse": true,
-		"holo": false
-	},
-
-	thirdParty: {
-		cardmarket: 674151,
-		tcgplayer: 284064
-	}
+	illustrator: "OKACHEKE",
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 674151,
+				tcgplayer: 284064
+			}
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 674151,
+				tcgplayer: 284064
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/142.ts
+++ b/data/Sword & Shield/Lost Origin/142.ts
@@ -68,16 +68,23 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "F",
 
-	variants: {
-		"normal": true,
-		"reverse": true,
-		"holo": false
-	},
-
-	thirdParty: {
-		cardmarket: 674152,
-		tcgplayer: 284066
-	}
+	illustrator: "Shibuzoh.",
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 674152,
+				tcgplayer: 284066
+			}
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 674152,
+				tcgplayer: 284066
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/143.ts
+++ b/data/Sword & Shield/Lost Origin/143.ts
@@ -69,16 +69,23 @@ const card: Card = {
 	retreat: 4,
 	regulationMark: "F",
 
-	variants: {
-		"normal": false,
-		"reverse": true,
-		"holo": true
-	},
-
-	thirdParty: {
-		cardmarket: 670829,
-		tcgplayer: 284068
-	}
+	illustrator: "0313",
+	variants: [
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 670829,
+				tcgplayer: 284068
+			}
+		},
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 670829,
+				tcgplayer: 284068
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/144.ts
+++ b/data/Sword & Shield/Lost Origin/144.ts
@@ -58,16 +58,23 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "F",
 
-	variants: {
-		"normal": true,
-		"reverse": true,
-		"holo": false
-	},
-
-	thirdParty: {
-		cardmarket: 674154,
-		tcgplayer: 284070
-	}
+	illustrator: "Kouki Saitou",
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 674154,
+				tcgplayer: 284070
+			}
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 674154,
+				tcgplayer: 284070
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/145.ts
+++ b/data/Sword & Shield/Lost Origin/145.ts
@@ -77,16 +77,23 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "F",
 
-	variants: {
-		"normal": true,
-		"reverse": true,
-		"holo": false
-	},
-
-	thirdParty: {
-		cardmarket: 674155,
-		tcgplayer: 284071
-	}
+	illustrator: "Atsushi Furusawa",
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 674155,
+				tcgplayer: 284071
+			}
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 674155,
+				tcgplayer: 284071
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/146.ts
+++ b/data/Sword & Shield/Lost Origin/146.ts
@@ -68,16 +68,16 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "F",
 
-	variants: {
-		"normal": false,
-		"reverse": false,
-		"holo": true
-	},
-
-	thirdParty: {
-		cardmarket: 670819,
-		tcgplayer: 284074
-	}
+	illustrator: "aky CG Works",
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 670819,
+				tcgplayer: 284074
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/147.ts
+++ b/data/Sword & Shield/Lost Origin/147.ts
@@ -58,16 +58,16 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "F",
 
-	variants: {
-		"normal": false,
-		"reverse": false,
-		"holo": true
-	},
-
-	thirdParty: {
-		cardmarket: 670819,
-		tcgplayer: 282256
-	}
+	illustrator: "aky CG Works",
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 670819,
+				tcgplayer: 282256
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/148.ts
+++ b/data/Sword & Shield/Lost Origin/148.ts
@@ -60,16 +60,23 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "F",
 
-	variants: {
-		"normal": true,
-		"reverse": true,
-		"holo": false
-	},
-
-	thirdParty: {
-		cardmarket: 674157,
-		tcgplayer: 284075
-	}
+	illustrator: "Nisota Nisa",
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 674157,
+				tcgplayer: 284075
+			}
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 674157,
+				tcgplayer: 284075
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/149.ts
+++ b/data/Sword & Shield/Lost Origin/149.ts
@@ -69,16 +69,23 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "F",
 
-	variants: {
-		"normal": true,
-		"reverse": true,
-		"holo": false
-	},
-
-	thirdParty: {
-		cardmarket: 674158,
-		tcgplayer: 284077
-	}
+	illustrator: "HYOGONOSUKE",
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 674158,
+				tcgplayer: 284077
+			}
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 674158,
+				tcgplayer: 284077
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/150.ts
+++ b/data/Sword & Shield/Lost Origin/150.ts
@@ -38,16 +38,23 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "F",
 
-	variants: {
-		"normal": true,
-		"reverse": true,
-		"holo": false
-	},
-
-	thirdParty: {
-		cardmarket: 674159,
-		tcgplayer: 284078
-	}
+	illustrator: "Miki Tanaka",
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 674159,
+				tcgplayer: 284078
+			}
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 674159,
+				tcgplayer: 284078
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/151.ts
+++ b/data/Sword & Shield/Lost Origin/151.ts
@@ -77,16 +77,23 @@ const card: Card = {
 	retreat: 3,
 	regulationMark: "F",
 
-	variants: {
-		"normal": true,
-		"reverse": true,
-		"holo": false
-	},
-
-	thirdParty: {
-		cardmarket: 674160,
-		tcgplayer: 284079
-	}
+	illustrator: "sui",
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 674160,
+				tcgplayer: 284079
+			}
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 674160,
+				tcgplayer: 284079
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/152.ts
+++ b/data/Sword & Shield/Lost Origin/152.ts
@@ -28,16 +28,23 @@ const card: Card = {
 	trainerType: "Item",
 	regulationMark: "F",
 
-	variants: {
-		"normal": true,
-		"reverse": true,
-		"holo": false
-	},
-
-	thirdParty: {
-		cardmarket: 674161,
-		tcgplayer: 284082
-	}
+	illustrator: "5ban Graphics",
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 674161,
+				tcgplayer: 284082
+			}
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 674161,
+				tcgplayer: 284082
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/153.ts
+++ b/data/Sword & Shield/Lost Origin/153.ts
@@ -28,16 +28,23 @@ const card: Card = {
 	trainerType: "Supporter",
 	regulationMark: "F",
 
-	variants: {
-		"normal": true,
-		"reverse": true,
-		"holo": false
-	},
-
-	thirdParty: {
-		cardmarket: 674162,
-		tcgplayer: 284083
-	}
+	illustrator: "kirisAki",
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 674162,
+				tcgplayer: 284083
+			}
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 674162,
+				tcgplayer: 284083
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/154.ts
+++ b/data/Sword & Shield/Lost Origin/154.ts
@@ -28,16 +28,23 @@ const card: Card = {
 	trainerType: "Tool",
 	regulationMark: "F",
 
-	variants: {
-		"normal": true,
-		"reverse": true,
-		"holo": false
-	},
-
-	thirdParty: {
-		cardmarket: 674163,
-		tcgplayer: 284084
-	}
+	illustrator: "Toyste Beach",
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 674163,
+				tcgplayer: 284084
+			}
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 674163,
+				tcgplayer: 284084
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/155.ts
+++ b/data/Sword & Shield/Lost Origin/155.ts
@@ -28,16 +28,23 @@ const card: Card = {
 	trainerType: "Supporter",
 	regulationMark: "F",
 
-	variants: {
-		"normal": true,
-		"reverse": true,
-		"holo": false
-	},
-
-	thirdParty: {
-		cardmarket: 670820,
-		tcgplayer: 284085
-	}
+	illustrator: "Naoki Saito",
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 670820,
+				tcgplayer: 284085
+			}
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 670820,
+				tcgplayer: 284085
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/156.ts
+++ b/data/Sword & Shield/Lost Origin/156.ts
@@ -28,16 +28,23 @@ const card: Card = {
 	trainerType: "Item",
 	regulationMark: "F",
 
-	variants: {
-		"normal": true,
-		"reverse": true,
-		"holo": false
-	},
-
-	thirdParty: {
-		cardmarket: 674164,
-		tcgplayer: 284087
-	}
+	illustrator: "sadaji",
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 674164,
+				tcgplayer: 284087
+			}
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 674164,
+				tcgplayer: 284087
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/157.ts
+++ b/data/Sword & Shield/Lost Origin/157.ts
@@ -28,16 +28,23 @@ const card: Card = {
 	trainerType: "Supporter",
 	regulationMark: "F",
 
-	variants: {
-		"normal": true,
-		"reverse": true,
-		"holo": false
-	},
-
-	thirdParty: {
-		cardmarket: 674165,
-		tcgplayer: 284088
-	}
+	illustrator: "Ryuta Fuse",
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 674165,
+				tcgplayer: 284088
+			}
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 674165,
+				tcgplayer: 284088
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/158.ts
+++ b/data/Sword & Shield/Lost Origin/158.ts
@@ -28,16 +28,23 @@ const card: Card = {
 	trainerType: "Supporter",
 	regulationMark: "F",
 
-	variants: {
-		"normal": true,
-		"reverse": true,
-		"holo": false
-	},
-
-	thirdParty: {
-		cardmarket: 674166,
-		tcgplayer: 284089
-	}
+	illustrator: "Akira Komayama",
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 674166,
+				tcgplayer: 284089
+			}
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 674166,
+				tcgplayer: 284089
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/159.ts
+++ b/data/Sword & Shield/Lost Origin/159.ts
@@ -27,16 +27,23 @@ const card: Card = {
 
 	trainerType: "Supporter",
 
-	variants: {
-		"normal": true,
-		"reverse": true,
-		"holo": false
-	},
-
-	thirdParty: {
-		cardmarket: 674167,
-		tcgplayer: 284090
-	}
+	illustrator: "saino misaki",
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 674167,
+				tcgplayer: 284090
+			}
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 674167,
+				tcgplayer: 284090
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/160.ts
+++ b/data/Sword & Shield/Lost Origin/160.ts
@@ -28,16 +28,23 @@ const card: Card = {
 	trainerType: "Stadium",
 	regulationMark: "F",
 
-	variants: {
-		"normal": true,
-		"reverse": true,
-		"holo": false
-	},
-
-	thirdParty: {
-		cardmarket: 674168,
-		tcgplayer: 284092
-	}
+	illustrator: "Oswaldo KATO",
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 674168,
+				tcgplayer: 284092
+			}
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 674168,
+				tcgplayer: 284092
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/161.ts
+++ b/data/Sword & Shield/Lost Origin/161.ts
@@ -28,16 +28,23 @@ const card: Card = {
 	trainerType: "Stadium",
 	regulationMark: "F",
 
-	variants: {
-		"normal": true,
-		"reverse": true,
-		"holo": false
-	},
-
-	thirdParty: {
-		cardmarket: 674170,
-		tcgplayer: 284093
-	}
+	illustrator: "AYUMI ODASHIMA",
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 674170,
+				tcgplayer: 284093
+			}
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 674170,
+				tcgplayer: 284093
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/162.ts
+++ b/data/Sword & Shield/Lost Origin/162.ts
@@ -28,16 +28,23 @@ const card: Card = {
 	trainerType: "Item",
 	regulationMark: "F",
 
-	variants: {
-		"normal": true,
-		"reverse": true,
-		"holo": false
-	},
-
-	thirdParty: {
-		cardmarket: 674171,
-		tcgplayer: 284094
-	}
+	illustrator: "Toyste Beach",
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 674171,
+				tcgplayer: 284094
+			}
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 674171,
+				tcgplayer: 284094
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/163.ts
+++ b/data/Sword & Shield/Lost Origin/163.ts
@@ -28,16 +28,23 @@ const card: Card = {
 	trainerType: "Item",
 	regulationMark: "F",
 
-	variants: {
-		"normal": true,
-		"reverse": true,
-		"holo": false
-	},
-
-	thirdParty: {
-		cardmarket: 670821,
-		tcgplayer: 282257
-	}
+	illustrator: "sadaji",
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 670821,
+				tcgplayer: 282257
+			}
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 670821,
+				tcgplayer: 282257
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/164.ts
+++ b/data/Sword & Shield/Lost Origin/164.ts
@@ -28,16 +28,23 @@ const card: Card = {
 	trainerType: "Supporter",
 	regulationMark: "F",
 
-	variants: {
-		"normal": true,
-		"reverse": true,
-		"holo": false
-	},
-
-	thirdParty: {
-		cardmarket: 674172,
-		tcgplayer: 284096
-	}
+	illustrator: "Souichirou Gunjima",
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 674172,
+				tcgplayer: 284096
+			}
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 674172,
+				tcgplayer: 284096
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/165.ts
+++ b/data/Sword & Shield/Lost Origin/165.ts
@@ -28,16 +28,23 @@ const card: Card = {
 	trainerType: "Tool",
 	regulationMark: "F",
 
-	variants: {
-		"normal": true,
-		"reverse": true,
-		"holo": false
-	},
-
-	thirdParty: {
-		cardmarket: 674173,
-		tcgplayer: 284097
-	}
+	illustrator: "Studio Bora Inc.",
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 674173,
+				tcgplayer: 284097
+			}
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 674173,
+				tcgplayer: 284097
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/166.ts
+++ b/data/Sword & Shield/Lost Origin/166.ts
@@ -28,16 +28,23 @@ const card: Card = {
 	trainerType: "Supporter",
 	regulationMark: "F",
 
-	variants: {
-		"normal": true,
-		"reverse": true,
-		"holo": false
-	},
-
-	thirdParty: {
-		cardmarket: 674174,
-		tcgplayer: 284099
-	}
+	illustrator: "Ken Sugimori",
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 674174,
+				tcgplayer: 284099
+			}
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 674174,
+				tcgplayer: 284099
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/167.ts
+++ b/data/Sword & Shield/Lost Origin/167.ts
@@ -28,16 +28,23 @@ const card: Card = {
 	trainerType: "Supporter",
 	regulationMark: "F",
 
-	variants: {
-		"normal": true,
-		"reverse": true,
-		"holo": false
-	},
-
-	thirdParty: {
-		cardmarket: 674175,
-		tcgplayer: 284100
-	}
+	illustrator: "Hideki Ishikawa",
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 674175,
+				tcgplayer: 284100
+			}
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 674175,
+				tcgplayer: 284100
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/168.ts
+++ b/data/Sword & Shield/Lost Origin/168.ts
@@ -28,16 +28,23 @@ const card: Card = {
 	trainerType: "Item",
 	regulationMark: "F",
 
-	variants: {
-		"normal": true,
-		"reverse": true,
-		"holo": false
-	},
-
-	thirdParty: {
-		cardmarket: 674176,
-		tcgplayer: 284101
-	}
+	illustrator: "AYUMI ODASHIMA",
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 674176,
+				tcgplayer: 284101
+			}
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 674176,
+				tcgplayer: 284101
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/169.ts
+++ b/data/Sword & Shield/Lost Origin/169.ts
@@ -28,16 +28,23 @@ const card: Card = {
 	trainerType: "Supporter",
 	regulationMark: "F",
 
-	variants: {
-		"normal": false,
-		"reverse": true,
-		"holo": true
-	},
-
-	thirdParty: {
-		cardmarket: 670825,
-		tcgplayer: 284104
-	}
+	illustrator: "kirisAki",
+	variants: [
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 670825,
+				tcgplayer: 284104
+			}
+		},
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 670825,
+				tcgplayer: 284104
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/170.ts
+++ b/data/Sword & Shield/Lost Origin/170.ts
@@ -28,16 +28,23 @@ const card: Card = {
 	trainerType: "Tool",
 	regulationMark: "F",
 
-	variants: {
-		"normal": true,
-		"reverse": true,
-		"holo": false
-	},
-
-	thirdParty: {
-		cardmarket: 670822,
-		tcgplayer: 284106
-	}
+	illustrator: "Toyste Beach",
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 670822,
+				tcgplayer: 284106
+			}
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 670822,
+				tcgplayer: 284106
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/171.ts
+++ b/data/Sword & Shield/Lost Origin/171.ts
@@ -28,16 +28,22 @@ const card: Card = {
 	energyType: "Special",
 	regulationMark: "F",
 
-	variants: {
-		"normal": true,
-		"reverse": true,
-		"holo": false
-	},
-
-	thirdParty: {
-		cardmarket: 674178,
-		tcgplayer: 284108
-	}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 674178,
+				tcgplayer: 284108
+			}
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 674178,
+				tcgplayer: 284108
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/172.ts
+++ b/data/Sword & Shield/Lost Origin/172.ts
@@ -68,16 +68,16 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "F",
 
-	variants: {
-		"normal": false,
-		"reverse": false,
-		"holo": true
-	},
-
-	thirdParty: {
-		cardmarket: 670823,
-		tcgplayer: 284110
-	}
+	illustrator: "5ban Graphics",
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 670823,
+				tcgplayer: 284110
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/173.ts
+++ b/data/Sword & Shield/Lost Origin/173.ts
@@ -68,16 +68,16 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "F",
 
-	variants: {
-		"normal": false,
-		"reverse": false,
-		"holo": true
-	},
-
-	thirdParty: {
-		cardmarket: 674179,
-		tcgplayer: 284115
-	}
+	illustrator: "PLANETA Yamashita",
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 674179,
+				tcgplayer: 284115
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/174.ts
+++ b/data/Sword & Shield/Lost Origin/174.ts
@@ -59,16 +59,16 @@ const card: Card = {
 	retreat: 3,
 	regulationMark: "F",
 
-	variants: {
-		"normal": false,
-		"reverse": false,
-		"holo": true
-	},
-
-	thirdParty: {
-		cardmarket: 674180,
-		tcgplayer: 284116
-	}
+	illustrator: "takuyoa",
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 674180,
+				tcgplayer: 284116
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/175.ts
+++ b/data/Sword & Shield/Lost Origin/175.ts
@@ -68,16 +68,16 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "F",
 
-	variants: {
-		"normal": false,
-		"reverse": false,
-		"holo": true
-	},
-
-	thirdParty: {
-		cardmarket: 674181,
-		tcgplayer: 284117
-	}
+	illustrator: "N-DESIGN Inc.",
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 674181,
+				tcgplayer: 284117
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/176.ts
+++ b/data/Sword & Shield/Lost Origin/176.ts
@@ -70,16 +70,16 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "F",
 
-	variants: {
-		"normal": false,
-		"reverse": false,
-		"holo": true
-	},
-
-	thirdParty: {
-		cardmarket: 674182,
-		tcgplayer: 284120
-	}
+	illustrator: "PLANETA Mochizuki",
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 674182,
+				tcgplayer: 284120
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/177.ts
+++ b/data/Sword & Shield/Lost Origin/177.ts
@@ -70,16 +70,16 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "F",
 
-	variants: {
-		"normal": false,
-		"reverse": false,
-		"holo": true
-	},
-
-	thirdParty: {
-		cardmarket: 674183,
-		tcgplayer: 284119
-	}
+	illustrator: "Yuu Nishida",
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 674183,
+				tcgplayer: 284119
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/178.ts
+++ b/data/Sword & Shield/Lost Origin/178.ts
@@ -70,16 +70,16 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "F",
 
-	variants: {
-		"normal": false,
-		"reverse": false,
-		"holo": true
-	},
-
-	thirdParty: {
-		cardmarket: 674187,
-		tcgplayer: 284131
-	}
+	illustrator: "5ban Graphics",
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 674187,
+				tcgplayer: 284131
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/179.ts
+++ b/data/Sword & Shield/Lost Origin/179.ts
@@ -61,16 +61,16 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "F",
 
-	variants: {
-		"normal": false,
-		"reverse": false,
-		"holo": true
-	},
-
-	thirdParty: {
-		cardmarket: 674184,
-		tcgplayer: 284123
-	}
+	illustrator: "N-DESIGN Inc.",
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 674184,
+				tcgplayer: 284123
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/180.ts
+++ b/data/Sword & Shield/Lost Origin/180.ts
@@ -61,16 +61,16 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "F",
 
-	variants: {
-		"normal": false,
-		"reverse": false,
-		"holo": true
-	},
-
-	thirdParty: {
-		cardmarket: 674185,
-		tcgplayer: 284122
-	}
+	illustrator: "Nurikabe",
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 674185,
+				tcgplayer: 284122
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/181.ts
+++ b/data/Sword & Shield/Lost Origin/181.ts
@@ -70,16 +70,16 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "F",
 
-	variants: {
-		"normal": false,
-		"reverse": false,
-		"holo": true
-	},
-
-	thirdParty: {
-		cardmarket: 670831,
-		tcgplayer: 284124
-	}
+	illustrator: "takuyoa",
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 670831,
+				tcgplayer: 284124
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/182.ts
+++ b/data/Sword & Shield/Lost Origin/182.ts
@@ -70,16 +70,16 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "F",
 
-	variants: {
-		"normal": false,
-		"reverse": false,
-		"holo": true
-	},
-
-	thirdParty: {
-		cardmarket: 674188,
-		tcgplayer: 284127
-	}
+	illustrator: "N-DESIGN Inc.",
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 674188,
+				tcgplayer: 284127
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/183.ts
+++ b/data/Sword & Shield/Lost Origin/183.ts
@@ -68,16 +68,16 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "F",
 
-	variants: {
-		"normal": false,
-		"reverse": false,
-		"holo": true
-	},
-
-	thirdParty: {
-		cardmarket: 674189,
-		tcgplayer: 284134
-	}
+	illustrator: "PLANETA Yamashita",
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 674189,
+				tcgplayer: 284134
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/184.ts
+++ b/data/Sword & Shield/Lost Origin/184.ts
@@ -68,16 +68,16 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "F",
 
-	variants: {
-		"normal": false,
-		"reverse": false,
-		"holo": true
-	},
-
-	thirdParty: {
-		cardmarket: 674190,
-		tcgplayer: 284135
-	}
+	illustrator: "GOSSAN",
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 674190,
+				tcgplayer: 284135
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/185.ts
+++ b/data/Sword & Shield/Lost Origin/185.ts
@@ -68,16 +68,16 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "F",
 
-	variants: {
-		"normal": false,
-		"reverse": false,
-		"holo": true
-	},
-
-	thirdParty: {
-		cardmarket: 674191,
-		tcgplayer: 284136
-	}
+	illustrator: "N-DESIGN Inc.",
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 674191,
+				tcgplayer: 284136
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/186.ts
+++ b/data/Sword & Shield/Lost Origin/186.ts
@@ -68,16 +68,16 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "F",
 
-	variants: {
-		"normal": false,
-		"reverse": false,
-		"holo": true
-	},
-
-	thirdParty: {
-		cardmarket: 674192,
-		tcgplayer: 284137
-	}
+	illustrator: "Shinji Kanda",
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 674192,
+				tcgplayer: 284137
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/187.ts
+++ b/data/Sword & Shield/Lost Origin/187.ts
@@ -70,16 +70,16 @@ const card: Card = {
 	retreat: 3,
 	regulationMark: "F",
 
-	variants: {
-		"normal": false,
-		"reverse": false,
-		"holo": true
-	},
-
-	thirdParty: {
-		cardmarket: 670824,
-		tcgplayer: 284138
-	}
+	illustrator: "5ban Graphics",
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 670824,
+				tcgplayer: 284138
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/188.ts
+++ b/data/Sword & Shield/Lost Origin/188.ts
@@ -70,16 +70,16 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "F",
 
-	variants: {
-		"normal": false,
-		"reverse": false,
-		"holo": true
-	},
-
-	thirdParty: {
-		cardmarket: 674193,
-		tcgplayer: 284139
-	}
+	illustrator: "Saki Hayashiro",
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 674193,
+				tcgplayer: 284139
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/189.ts
+++ b/data/Sword & Shield/Lost Origin/189.ts
@@ -28,16 +28,16 @@ const card: Card = {
 	trainerType: "Supporter",
 	regulationMark: "F",
 
-	variants: {
-		"normal": false,
-		"reverse": false,
-		"holo": true
-	},
-
-	thirdParty: {
-		cardmarket: 674194,
-		tcgplayer: 284141
-	}
+	illustrator: "You Iribi",
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 674194,
+				tcgplayer: 284141
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/190.ts
+++ b/data/Sword & Shield/Lost Origin/190.ts
@@ -28,16 +28,16 @@ const card: Card = {
 	trainerType: "Supporter",
 	regulationMark: "F",
 
-	variants: {
-		"normal": false,
-		"reverse": false,
-		"holo": true
-	},
-
-	thirdParty: {
-		cardmarket: 674195,
-		tcgplayer: 284142
-	}
+	illustrator: "Naoki Saito",
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 674195,
+				tcgplayer: 284142
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/191.ts
+++ b/data/Sword & Shield/Lost Origin/191.ts
@@ -28,16 +28,16 @@ const card: Card = {
 	trainerType: "Supporter",
 	regulationMark: "F",
 
-	variants: {
-		"normal": false,
-		"reverse": false,
-		"holo": true
-	},
-
-	thirdParty: {
-		cardmarket: 674196,
-		tcgplayer: 284144
-	}
+	illustrator: "Ryuta Fuse",
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 674196,
+				tcgplayer: 284144
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/192.ts
+++ b/data/Sword & Shield/Lost Origin/192.ts
@@ -28,16 +28,16 @@ const card: Card = {
 	trainerType: "Supporter",
 	regulationMark: "F",
 
-	variants: {
-		"normal": false,
-		"reverse": false,
-		"holo": true
-	},
-
-	thirdParty: {
-		cardmarket: 674197,
-		tcgplayer: 284145
-	}
+	illustrator: "Hitoshi Ariga",
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 674197,
+				tcgplayer: 284145
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/193.ts
+++ b/data/Sword & Shield/Lost Origin/193.ts
@@ -27,16 +27,16 @@ const card: Card = {
 
 	trainerType: "Supporter",
 
-	variants: {
-		"normal": false,
-		"reverse": false,
-		"holo": true
-	},
-
-	thirdParty: {
-		cardmarket: 674198,
-		tcgplayer: 284146
-	}
+	illustrator: "saino misaki",
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 674198,
+				tcgplayer: 284146
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/194.ts
+++ b/data/Sword & Shield/Lost Origin/194.ts
@@ -28,16 +28,16 @@ const card: Card = {
 	trainerType: "Supporter",
 	regulationMark: "F",
 
-	variants: {
-		"normal": false,
-		"reverse": false,
-		"holo": true
-	},
-
-	thirdParty: {
-		cardmarket: 674199,
-		tcgplayer: 284147
-	}
+	illustrator: "Souichirou Gunjima",
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 674199,
+				tcgplayer: 284147
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/195.ts
+++ b/data/Sword & Shield/Lost Origin/195.ts
@@ -28,16 +28,16 @@ const card: Card = {
 	trainerType: "Supporter",
 	regulationMark: "F",
 
-	variants: {
-		"normal": false,
-		"reverse": false,
-		"holo": true
-	},
-
-	thirdParty: {
-		cardmarket: 674200,
-		tcgplayer: 284148
-	}
+	illustrator: "Hideki Ishikawa",
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 674200,
+				tcgplayer: 284148
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/196.ts
+++ b/data/Sword & Shield/Lost Origin/196.ts
@@ -28,16 +28,16 @@ const card: Card = {
 	trainerType: "Supporter",
 	regulationMark: "F",
 
-	variants: {
-		"normal": false,
-		"reverse": false,
-		"holo": true
-	},
-
-	thirdParty: {
-		cardmarket: 670825,
-		tcgplayer: 284150
-	}
+	illustrator: "kirisAki",
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 670825,
+				tcgplayer: 284150
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/197.ts
+++ b/data/Sword & Shield/Lost Origin/197.ts
@@ -79,16 +79,16 @@ const card: Card = {
 	retreat: 3,
 	regulationMark: "F",
 
-	variants: {
-		"normal": false,
-		"reverse": false,
-		"holo": true
-	},
-
-	thirdParty: {
-		cardmarket: 674201,
-		tcgplayer: 284152
-	}
+	illustrator: "N-DESIGN Inc.",
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 674201,
+				tcgplayer: 284152
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/198.ts
+++ b/data/Sword & Shield/Lost Origin/198.ts
@@ -78,16 +78,16 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "F",
 
-	variants: {
-		"normal": false,
-		"reverse": false,
-		"holo": true
-	},
-
-	thirdParty: {
-		cardmarket: 674202,
-		tcgplayer: 284153
-	}
+	illustrator: "PLANETA Mochizuki",
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 674202,
+				tcgplayer: 284153
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/199.ts
+++ b/data/Sword & Shield/Lost Origin/199.ts
@@ -78,16 +78,16 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "F",
 
-	variants: {
-		"normal": false,
-		"reverse": false,
-		"holo": true
-	},
-
-	thirdParty: {
-		cardmarket: 674203,
-		tcgplayer: 284154
-	}
+	illustrator: "5ban Graphics",
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 674203,
+				tcgplayer: 284154
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/200.ts
+++ b/data/Sword & Shield/Lost Origin/200.ts
@@ -58,16 +58,16 @@ const card: Card = {
 	retreat: 3,
 	regulationMark: "F",
 
-	variants: {
-		"normal": false,
-		"reverse": false,
-		"holo": true
-	},
-
-	thirdParty: {
-		cardmarket: 674206,
-		tcgplayer: 284155
-	}
+	illustrator: "PLANETA Mochizuki",
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 674206,
+				tcgplayer: 284155
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/201.ts
+++ b/data/Sword & Shield/Lost Origin/201.ts
@@ -78,16 +78,16 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "F",
 
-	variants: {
-		"normal": false,
-		"reverse": false,
-		"holo": true
-	},
-
-	thirdParty: {
-		cardmarket: 670816,
-		tcgplayer: 284156
-	}
+	illustrator: "5ban Graphics",
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 670816,
+				tcgplayer: 284156
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/202.ts
+++ b/data/Sword & Shield/Lost Origin/202.ts
@@ -58,16 +58,16 @@ const card: Card = {
 	retreat: 3,
 	regulationMark: "F",
 
-	variants: {
-		"normal": false,
-		"reverse": false,
-		"holo": true
-	},
-
-	thirdParty: {
-		cardmarket: 674208,
-		tcgplayer: 284157
-	}
+	illustrator: "5ban Graphics",
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 674208,
+				tcgplayer: 284157
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/203.ts
+++ b/data/Sword & Shield/Lost Origin/203.ts
@@ -58,16 +58,16 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "F",
 
-	variants: {
-		"normal": false,
-		"reverse": false,
-		"holo": true
-	},
-
-	thirdParty: {
-		cardmarket: 674209,
-		tcgplayer: 284158
-	}
+	illustrator: "aky CG Works",
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 674209,
+				tcgplayer: 284158
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/204.ts
+++ b/data/Sword & Shield/Lost Origin/204.ts
@@ -28,16 +28,16 @@ const card: Card = {
 	trainerType: "Supporter",
 	regulationMark: "F",
 
-	variants: {
-		"normal": false,
-		"reverse": false,
-		"holo": true
-	},
-
-	thirdParty: {
-		cardmarket: 674210,
-		tcgplayer: 284159
-	}
+	illustrator: "You Iribi",
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 674210,
+				tcgplayer: 284159
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/205.ts
+++ b/data/Sword & Shield/Lost Origin/205.ts
@@ -28,16 +28,16 @@ const card: Card = {
 	trainerType: "Supporter",
 	regulationMark: "F",
 
-	variants: {
-		"normal": false,
-		"reverse": false,
-		"holo": true
-	},
-
-	thirdParty: {
-		cardmarket: 674211,
-		tcgplayer: 284160
-	}
+	illustrator: "Naoki Saito",
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 674211,
+				tcgplayer: 284160
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/206.ts
+++ b/data/Sword & Shield/Lost Origin/206.ts
@@ -28,16 +28,16 @@ const card: Card = {
 	trainerType: "Supporter",
 	regulationMark: "F",
 
-	variants: {
-		"normal": false,
-		"reverse": false,
-		"holo": true
-	},
-
-	thirdParty: {
-		cardmarket: 674212,
-		tcgplayer: 284161
-	}
+	illustrator: "Ryuta Fuse",
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 674212,
+				tcgplayer: 284161
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/207.ts
+++ b/data/Sword & Shield/Lost Origin/207.ts
@@ -28,16 +28,16 @@ const card: Card = {
 	trainerType: "Supporter",
 	regulationMark: "F",
 
-	variants: {
-		"normal": false,
-		"reverse": false,
-		"holo": true
-	},
-
-	thirdParty: {
-		cardmarket: 674213,
-		tcgplayer: 284162
-	}
+	illustrator: "Hitoshi Ariga",
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 674213,
+				tcgplayer: 284162
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/208.ts
+++ b/data/Sword & Shield/Lost Origin/208.ts
@@ -27,16 +27,16 @@ const card: Card = {
 
 	trainerType: "Supporter",
 
-	variants: {
-		"normal": false,
-		"reverse": false,
-		"holo": true
-	},
-
-	thirdParty: {
-		cardmarket: 674214,
-		tcgplayer: 284163
-	}
+	illustrator: "saino misaki",
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 674214,
+				tcgplayer: 284163
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/209.ts
+++ b/data/Sword & Shield/Lost Origin/209.ts
@@ -28,16 +28,16 @@ const card: Card = {
 	trainerType: "Supporter",
 	regulationMark: "F",
 
-	variants: {
-		"normal": false,
-		"reverse": false,
-		"holo": true
-	},
-
-	thirdParty: {
-		cardmarket: 674215,
-		tcgplayer: 284164
-	}
+	illustrator: "Souichirou Gunjima",
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 674215,
+				tcgplayer: 284164
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/210.ts
+++ b/data/Sword & Shield/Lost Origin/210.ts
@@ -28,16 +28,16 @@ const card: Card = {
 	trainerType: "Supporter",
 	regulationMark: "F",
 
-	variants: {
-		"normal": false,
-		"reverse": false,
-		"holo": true
-	},
-
-	thirdParty: {
-		cardmarket: 674216,
-		tcgplayer: 284165
-	}
+	illustrator: "Hideki Ishikawa",
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 674216,
+				tcgplayer: 284165
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/211.ts
+++ b/data/Sword & Shield/Lost Origin/211.ts
@@ -28,16 +28,16 @@ const card: Card = {
 	trainerType: "Supporter",
 	regulationMark: "F",
 
-	variants: {
-		"normal": false,
-		"reverse": false,
-		"holo": true
-	},
-
-	thirdParty: {
-		cardmarket: 674217,
-		tcgplayer: 284166
-	}
+	illustrator: "kirisAki",
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 674217,
+				tcgplayer: 284166
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/212.ts
+++ b/data/Sword & Shield/Lost Origin/212.ts
@@ -78,16 +78,16 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "F",
 
-	variants: {
-		"normal": false,
-		"reverse": false,
-		"holo": true
-	},
-
-	thirdParty: {
-		cardmarket: 670816,
-		tcgplayer: 284167
-	}
+	illustrator: "5ban Graphics",
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 670816,
+				tcgplayer: 284167
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/213.ts
+++ b/data/Sword & Shield/Lost Origin/213.ts
@@ -58,16 +58,16 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "F",
 
-	variants: {
-		"normal": false,
-		"reverse": false,
-		"holo": true
-	},
-
-	thirdParty: {
-		cardmarket: 670814,
-		tcgplayer: 284168
-	}
+	illustrator: "aky CG Works",
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 670814,
+				tcgplayer: 284168
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/214.ts
+++ b/data/Sword & Shield/Lost Origin/214.ts
@@ -28,16 +28,16 @@ const card: Card = {
 	trainerType: "Tool",
 	regulationMark: "F",
 
-	variants: {
-		"normal": false,
-		"reverse": false,
-		"holo": true
-	},
-
-	thirdParty: {
-		cardmarket: 674220,
-		tcgplayer: 284169
-	}
+	illustrator: "Toyste Beach",
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 674220,
+				tcgplayer: 284169
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/215.ts
+++ b/data/Sword & Shield/Lost Origin/215.ts
@@ -28,16 +28,16 @@ const card: Card = {
 	trainerType: "Stadium",
 	regulationMark: "F",
 
-	variants: {
-		"normal": false,
-		"reverse": false,
-		"holo": true
-	},
-
-	thirdParty: {
-		cardmarket: 674221,
-		tcgplayer: 284170
-	}
+	illustrator: "Oswaldo KATO",
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 674221,
+				tcgplayer: 284170
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/216.ts
+++ b/data/Sword & Shield/Lost Origin/216.ts
@@ -27,16 +27,16 @@ const card: Card = {
 
 	trainerType: "Item",
 
-	variants: {
-		"normal": false,
-		"reverse": false,
-		"holo": true
-	},
-
-	thirdParty: {
-		cardmarket: 674222,
-		tcgplayer: 284171
-	}
+	illustrator: "Ryo Ueda",
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 674222,
+				tcgplayer: 284171
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/217.ts
+++ b/data/Sword & Shield/Lost Origin/217.ts
@@ -28,16 +28,16 @@ const card: Card = {
 	trainerType: "Item",
 	regulationMark: "F",
 
-	variants: {
-		"normal": false,
-		"reverse": false,
-		"holo": true
-	},
-
-	thirdParty: {
-		cardmarket: 674223,
-		tcgplayer: 284172
-	}
+	illustrator: "Toyste Beach",
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 674223,
+				tcgplayer: 284172
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/TG01.ts
+++ b/data/Sword & Shield/Lost Origin/TG01.ts
@@ -79,15 +79,16 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "F",
 
-	variants: {
-		"normal": false,
-		"reverse": false,
-		"holo": true
-	},
-
-	thirdParty: {
-		cardmarket: 670810
-	}
+	illustrator: "Oswaldo KATO",
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 670810,
+				tcgplayer: 284253
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/TG02.ts
+++ b/data/Sword & Shield/Lost Origin/TG02.ts
@@ -79,15 +79,16 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "F",
 
-	variants: {
-		"normal": false,
-		"reverse": false,
-		"holo": true
-	},
-
-	thirdParty: {
-		cardmarket: 674026
-	}
+	illustrator: "saino misaki",
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 674026,
+				tcgplayer: 284254
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/TG03.ts
+++ b/data/Sword & Shield/Lost Origin/TG03.ts
@@ -79,15 +79,16 @@ const card: Card = {
 	retreat: 3,
 	regulationMark: "D",
 
-	variants: {
-		"normal": false,
-		"reverse": false,
-		"holo": true
-	},
-
-	thirdParty: {
-		cardmarket: 670827
-	}
+	illustrator: "GIDORA",
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 670827,
+				tcgplayer: 284251
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/TG04.ts
+++ b/data/Sword & Shield/Lost Origin/TG04.ts
@@ -70,15 +70,16 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "F",
 
-	variants: {
-		"normal": false,
-		"reverse": false,
-		"holo": true
-	},
-
-	thirdParty: {
-		cardmarket: 670828
-	}
+	illustrator: "chibi",
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 670828,
+				tcgplayer: 284255
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/TG05.ts
+++ b/data/Sword & Shield/Lost Origin/TG05.ts
@@ -69,15 +69,16 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "F",
 
-	variants: {
-		"normal": false,
-		"reverse": false,
-		"holo": true
-	},
-
-	thirdParty: {
-		cardmarket: 674062
-	}
+	illustrator: "Atsushi Furusawa",
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 674062,
+				tcgplayer: 284258
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/TG06.ts
+++ b/data/Sword & Shield/Lost Origin/TG06.ts
@@ -77,15 +77,16 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "F",
 
-	variants: {
-		"normal": false,
-		"reverse": false,
-		"holo": true
-	},
-
-	thirdParty: {
-		cardmarket: 674075
-	}
+	illustrator: "Akira Komayama",
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 674075,
+				tcgplayer: 284266
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/TG07.ts
+++ b/data/Sword & Shield/Lost Origin/TG07.ts
@@ -79,15 +79,16 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "E",
 
-	variants: {
-		"normal": false,
-		"reverse": false,
-		"holo": true
-	},
-
-	thirdParty: {
-		cardmarket: 674084
-	}
+	illustrator: "Tomomi Kaneko",
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 674084,
+				tcgplayer: 284267
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/TG08.ts
+++ b/data/Sword & Shield/Lost Origin/TG08.ts
@@ -68,15 +68,16 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "F",
 
-	variants: {
-		"normal": false,
-		"reverse": false,
-		"holo": true
-	},
-
-	thirdParty: {
-		cardmarket: 674097
-	}
+	illustrator: "You Iribi",
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 674097,
+				tcgplayer: 284268
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/TG09.ts
+++ b/data/Sword & Shield/Lost Origin/TG09.ts
@@ -69,15 +69,16 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "F",
 
-	variants: {
-		"normal": false,
-		"reverse": false,
-		"holo": true
-	},
-
-	thirdParty: {
-		cardmarket: 674130
-	}
+	illustrator: "Hitoshi Ariga",
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 674130,
+				tcgplayer: 284269
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/TG10.ts
+++ b/data/Sword & Shield/Lost Origin/TG10.ts
@@ -69,15 +69,16 @@ const card: Card = {
 	retreat: 4,
 	regulationMark: "F",
 
-	variants: {
-		"normal": false,
-		"reverse": false,
-		"holo": true
-	},
-
-	thirdParty: {
-		cardmarket: 670829
-	}
+	illustrator: "Kouki Saitou",
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 670829,
+				tcgplayer: 284270
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/TG11.ts
+++ b/data/Sword & Shield/Lost Origin/TG11.ts
@@ -69,15 +69,16 @@ const card: Card = {
 	retreat: 0,
 	regulationMark: "E",
 
-	variants: {
-		"normal": false,
-		"reverse": false,
-		"holo": true
-	},
-
-	thirdParty: {
-		cardmarket: 674230
-	}
+	illustrator: "Atsushi Furasawa",
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 674230,
+				tcgplayer: 284271
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/TG12.ts
+++ b/data/Sword & Shield/Lost Origin/TG12.ts
@@ -70,15 +70,16 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "D",
 
-	variants: {
-		"normal": false,
-		"reverse": false,
-		"holo": true
-	},
-
-	thirdParty: {
-		cardmarket: 674231
-	}
+	illustrator: "Nisota Niso",
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 674231,
+				tcgplayer: 284272
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/TG13.ts
+++ b/data/Sword & Shield/Lost Origin/TG13.ts
@@ -79,15 +79,16 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "D",
 
-	variants: {
-		"normal": false,
-		"reverse": false,
-		"holo": true
-	},
-
-	thirdParty: {
-		cardmarket: 674232
-	}
+	illustrator: "Teeziro",
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 674232,
+				tcgplayer: 284273
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/TG14.ts
+++ b/data/Sword & Shield/Lost Origin/TG14.ts
@@ -61,15 +61,16 @@ const card: Card = {
 	retreat: 3,
 	regulationMark: "D",
 
-	variants: {
-		"normal": false,
-		"reverse": false,
-		"holo": true
-	},
-
-	thirdParty: {
-		cardmarket: 670830
-	}
+	illustrator: "Yuya Oka",
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 670830,
+				tcgplayer: 284275
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/TG15.ts
+++ b/data/Sword & Shield/Lost Origin/TG15.ts
@@ -57,15 +57,16 @@ const card: Card = {
 	retreat: 3,
 	regulationMark: "D",
 
-	variants: {
-		"normal": false,
-		"reverse": false,
-		"holo": true
-	},
-
-	thirdParty: {
-		cardmarket: 674233
-	}
+	illustrator: "Oswaldo KATO",
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 674233,
+				tcgplayer: 284276
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/TG16.ts
+++ b/data/Sword & Shield/Lost Origin/TG16.ts
@@ -68,15 +68,16 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "D",
 
-	variants: {
-		"normal": false,
-		"reverse": false,
-		"holo": true
-	},
-
-	thirdParty: {
-		cardmarket: 674234
-	}
+	illustrator: "Ryota Murayama",
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 674234,
+				tcgplayer: 284278
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/TG17.ts
+++ b/data/Sword & Shield/Lost Origin/TG17.ts
@@ -57,15 +57,16 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "D",
 
-	variants: {
-		"normal": false,
-		"reverse": false,
-		"holo": true
-	},
-
-	thirdParty: {
-		cardmarket: 674235
-	}
+	illustrator: "Souichirou Gunjima",
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 674235,
+				tcgplayer: 284283
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/TG18.ts
+++ b/data/Sword & Shield/Lost Origin/TG18.ts
@@ -70,15 +70,16 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "F",
 
-	variants: {
-		"normal": false,
-		"reverse": false,
-		"holo": true
-	},
-
-	thirdParty: {
-		cardmarket: 674095
-	}
+	illustrator: "AKIRA EGAWA",
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 674095,
+				tcgplayer: 284284
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/TG19.ts
+++ b/data/Sword & Shield/Lost Origin/TG19.ts
@@ -70,15 +70,16 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "F",
 
-	variants: {
-		"normal": false,
-		"reverse": false,
-		"holo": true
-	},
-
-	thirdParty: {
-		cardmarket: 670831
-	}
+	illustrator: "Souichirou Gunjima",
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 670831,
+				tcgplayer: 284286
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/TG20.ts
+++ b/data/Sword & Shield/Lost Origin/TG20.ts
@@ -70,15 +70,16 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "D",
 
-	variants: {
-		"normal": false,
-		"reverse": false,
-		"holo": true
-	},
-
-	thirdParty: {
-		cardmarket: 674237
-	}
+	illustrator: "GOSSAN",
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 674237,
+				tcgplayer: 284290
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/TG21.ts
+++ b/data/Sword & Shield/Lost Origin/TG21.ts
@@ -70,15 +70,16 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "D",
 
-	variants: {
-		"normal": false,
-		"reverse": false,
-		"holo": true
-	},
-
-	thirdParty: {
-		cardmarket: 674238
-	}
+	illustrator: "kodama",
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 674238,
+				tcgplayer: 284294
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/TG22.ts
+++ b/data/Sword & Shield/Lost Origin/TG22.ts
@@ -79,15 +79,16 @@ const card: Card = {
 	retreat: 3,
 	regulationMark: "D",
 
-	variants: {
-		"normal": false,
-		"reverse": false,
-		"holo": true
-	},
-
-	thirdParty: {
-		cardmarket: 674239
-	}
+	illustrator: "Mitsuhiro Arita",
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 674239,
+				tcgplayer: 284295
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/TG23.ts
+++ b/data/Sword & Shield/Lost Origin/TG23.ts
@@ -28,15 +28,16 @@ const card: Card = {
 	trainerType: "Supporter",
 	regulationMark: "E",
 
-	variants: {
-		"normal": false,
-		"reverse": false,
-		"holo": true
-	},
-
-	thirdParty: {
-		cardmarket: 674240
-	}
+	illustrator: "Taira Akitsu",
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 674240,
+				tcgplayer: 284296
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/TG24.ts
+++ b/data/Sword & Shield/Lost Origin/TG24.ts
@@ -28,15 +28,16 @@ const card: Card = {
 	trainerType: "Supporter",
 	regulationMark: "D",
 
-	variants: {
-		"normal": false,
-		"reverse": false,
-		"holo": true
-	},
-
-	thirdParty: {
-		cardmarket: 674241
-	}
+	illustrator: "NC Empire",
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 674241,
+				tcgplayer: 284297
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/TG25.ts
+++ b/data/Sword & Shield/Lost Origin/TG25.ts
@@ -28,15 +28,16 @@ const card: Card = {
 	trainerType: "Supporter",
 	regulationMark: "E",
 
-	variants: {
-		"normal": false,
-		"reverse": false,
-		"holo": true
-	},
-
-	thirdParty: {
-		cardmarket: 670832
-	}
+	illustrator: "Sanosuke Sakuma",
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 670832,
+				tcgplayer: 284298
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/TG26.ts
+++ b/data/Sword & Shield/Lost Origin/TG26.ts
@@ -28,15 +28,16 @@ const card: Card = {
 	trainerType: "Supporter",
 	regulationMark: "D",
 
-	variants: {
-		"normal": false,
-		"reverse": false,
-		"holo": true
-	},
-
-	thirdParty: {
-		cardmarket: 674242
-	}
+	illustrator: "Hideki Ishikawa",
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 674242,
+				tcgplayer: 284299
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/TG27.ts
+++ b/data/Sword & Shield/Lost Origin/TG27.ts
@@ -28,15 +28,16 @@ const card: Card = {
 	trainerType: "Supporter",
 	regulationMark: "D",
 
-	variants: {
-		"normal": false,
-		"reverse": false,
-		"holo": true
-	},
-
-	thirdParty: {
-		cardmarket: 670833
-	}
+	illustrator: "saino misaki",
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 670833,
+				tcgplayer: 284300
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/TG28.ts
+++ b/data/Sword & Shield/Lost Origin/TG28.ts
@@ -28,15 +28,16 @@ const card: Card = {
 	trainerType: "Supporter",
 	regulationMark: "D",
 
-	variants: {
-		"normal": false,
-		"reverse": false,
-		"holo": true
-	},
-
-	thirdParty: {
-		cardmarket: 674243
-	}
+	illustrator: "Taira Akitsu",
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 674243,
+				tcgplayer: 284301
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/TG29.ts
+++ b/data/Sword & Shield/Lost Origin/TG29.ts
@@ -57,15 +57,16 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "D",
 
-	variants: {
-		"normal": false,
-		"reverse": false,
-		"holo": true
-	},
-
-	thirdParty: {
-		cardmarket: 674235
-	}
+	illustrator: "aky CG Works",
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 674235,
+				tcgplayer: 284302
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Lost Origin/TG30.ts
+++ b/data/Sword & Shield/Lost Origin/TG30.ts
@@ -77,15 +77,16 @@ const card: Card = {
 	retreat: 0,
 	regulationMark: "E",
 
-	variants: {
-		"normal": false,
-		"reverse": false,
-		"holo": true
-	},
-
-	thirdParty: {
-		cardmarket: 674245
-	}
+	illustrator: "5ban Graphics",
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 674245,
+				tcgplayer: 284303
+			}
+		},
+	],
 }
 
 export default card


### PR DESCRIPTION
## Summary
- Moves `thirdParty` tcgplayer IDs into the `variants` array for all main set cards
- Adds illustrator fields to cards
- Migrates all 30 TG cards to new variant format with tcgplayer IDs