### PR TITLE
fix(data): Correct types on Ninetales and Bewear

### DIFF
--- a/data/EX/Hidden Legends/22.ts
+++ b/data/EX/Hidden Legends/22.ts
@@ -20,7 +20,7 @@ const card: Card = {
 	hp: 70,
 
 	types: [
-		"Fighting",
+		"Fire",
 	],
 
 	evolveFrom: {
@@ -89,7 +89,7 @@ const card: Card = {
 		},
 	],
 
-	
+
 	retreat: 1,
 
 	thirdParty: {

--- a/data/McDonald's Collection/McDonald's Collection 2022/12.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2022/12.ts
@@ -20,7 +20,7 @@ const card: Card = {
 
 	hp: 130,
 
-	types: ["Colorless"],
+	types: ["Fighting"],
 
 	stage: "Stage1",
 
@@ -61,7 +61,7 @@ const card: Card = {
 	],
 
 	retreat: 3,
-	
+
 	variants: [
 		{
 			type: 'holo',


### PR DESCRIPTION
## Summary
- `EX/Hidden Legends` 22 (Ninetales): corrects `types`  from `Fighting` to `Fire`. Ninetales is a Fire-type Pokémon and the card's Will-o'-the-wisp attack already costs Fire energy.
- `McDonald's Collection 2022` 12 (Bewear): corrects  `types` from `Colorless` to `Fighting`. Both of the card's attacks cost Fighting energy.

## Sources
- https://www.cardmarket.com/en/Pokemon/Products/Singles/EX-Hidden-Legends/Ninetales-HL22
- https://www.cardmarket.com/en/Pokemon/Products/Singles/McDonalds-Collection-2022/Bewear-MCD2212