### PR TITLE
fix(data): Cardmarket IDs for Sword & Shield - Brilliant Stars

### DIFF
--- a/data/Sword & Shield/Brilliant Stars/077.ts
+++ b/data/Sword & Shield/Brilliant Stars/077.ts
@@ -87,7 +87,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 608434,
+		cardmarket: 608527,
 		tcgplayer: 263793
 	}
 }

--- a/data/Sword & Shield/Brilliant Stars/098.ts
+++ b/data/Sword & Shield/Brilliant Stars/098.ts
@@ -78,7 +78,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 608434,
+		cardmarket: 608644,
 		tcgplayer: 263817
 	}
 }

--- a/data/Sword & Shield/Brilliant Stars/176.ts
+++ b/data/Sword & Shield/Brilliant Stars/176.ts
@@ -66,7 +66,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 608668,
+		cardmarket: 608722,
 		tcgplayer: 263896
 	}
 }

--- a/data/Sword & Shield/Brilliant Stars/184.ts
+++ b/data/Sword & Shield/Brilliant Stars/184.ts
@@ -66,7 +66,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 608668,
+		cardmarket: 608730,
 		tcgplayer: 263904
 	}
 }

--- a/data/Sword & Shield/Brilliant Stars/TG06.ts
+++ b/data/Sword & Shield/Brilliant Stars/TG06.ts
@@ -78,7 +78,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 608512
+		cardmarket: 608738
 	}
 }
 

--- a/data/Sword & Shield/Brilliant Stars/TG07.ts
+++ b/data/Sword & Shield/Brilliant Stars/TG07.ts
@@ -55,7 +55,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 608517
+		cardmarket: 608739
 	}
 }
 

--- a/data/Sword & Shield/Brilliant Stars/TG08.ts
+++ b/data/Sword & Shield/Brilliant Stars/TG08.ts
@@ -87,7 +87,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 608521
+		cardmarket: 608740
 	}
 }
 

--- a/data/Sword & Shield/Brilliant Stars/TG16.ts
+++ b/data/Sword & Shield/Brilliant Stars/TG16.ts
@@ -76,7 +76,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 608518
+		cardmarket: 608748
 	}
 }
 

--- a/data/Sword & Shield/Brilliant Stars/TG17.ts
+++ b/data/Sword & Shield/Brilliant Stars/TG17.ts
@@ -85,7 +85,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 608519
+		cardmarket: 608749
 	}
 }
 

--- a/data/Sword & Shield/Brilliant Stars/TG24.ts
+++ b/data/Sword & Shield/Brilliant Stars/TG24.ts
@@ -36,7 +36,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 608675
+		cardmarket: 608756
 	}
 }
 

--- a/data/Sword & Shield/Brilliant Stars/TG25.ts
+++ b/data/Sword & Shield/Brilliant Stars/TG25.ts
@@ -36,7 +36,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 608679
+		cardmarket: 608757
 	}
 }
 

--- a/data/Sword & Shield/Brilliant Stars/TG26.ts
+++ b/data/Sword & Shield/Brilliant Stars/TG26.ts
@@ -36,7 +36,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 608687
+		cardmarket: 608758
 	}
 }
 

--- a/data/Sword & Shield/Brilliant Stars/TG29.ts
+++ b/data/Sword & Shield/Brilliant Stars/TG29.ts
@@ -78,7 +78,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 608751
+		cardmarket: 608761
 	}
 }
 

--- a/data/Sword & Shield/Brilliant Stars/TG30.ts
+++ b/data/Sword & Shield/Brilliant Stars/TG30.ts
@@ -85,7 +85,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 608753
+		cardmarket: 608762
 	}
 }
 


### PR DESCRIPTION
## Changes
- update duplicate cardmarket ids in this set. 

## Details

Cards with the same name but different printing were assigned the same cardmarket id. This PR fixes those occurrences. 

Set 1/112