### PR TITLE
fix(svp): add missing variant(s) for Iron Thorns (svp-098)

### DIFF
--- a/data/Scarlet & Violet/SVP Black Star Promos/098.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/098.ts
@@ -2,6 +2,16 @@ import { Card } from "../../../interfaces"
 import Set from "../SVP Black Star Promos"
 
 const card: Card = {
+	variants: [
+		{
+			type: 'normal'
+		},
+		{
+			type: 'normal',
+			stamp: ['pokemon-center']
+		},
+	],
+
 	dexId: [995],
 	set: Set,
 


### PR DESCRIPTION
This PR adds missing printing variant(s) for **Iron Thorns** (`svp-098`).

File: `data/Scarlet & Violet/SVP Black Star Promos/098.ts`

Variants added:
- `normal stamp:pokemon-center`

_Submitted via the Slab collection app's variant contributor._
