### PR TITLE
fix(svp): add missing variant(s) for Iron Thorns (svp-098)

### DIFF
--- a/data/Scarlet & Violet/SVP Black Star Promos/098.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/098.ts
@@ -2,6 +2,27 @@ import { Card } from "../../../interfaces"
 import Set from "../SVP Black Star Promos"
 
 const card: Card = {
+	variants: [
+		{
+			type: 'normal'
+		},
+		{
+			type: 'holo',
+			languages: ['en'],
+			thirdParty: {
+				tcgplayer: 543948
+			}
+		},
+		{
+			type: 'holo',
+			stamp: ['pokemon-center'],
+			languages: ['en'],
+			thirdParty: {
+				tcgplayer: 543949
+			}
+		},
+	],
+
 	dexId: [995],
 	set: Set,
 


### PR DESCRIPTION
This PR adds missing printing variant(s) for **Iron Thorns** (`svp-098`).

File: `data/Scarlet & Violet/SVP Black Star Promos/098.ts`

Variants added:
- `holo lang:en`
- `holo stamp:pokemon-center lang:en`

_Submitted via the Slab collection app's variant contributor._
