### PR TITLE
fix(svp): add missing variant(s) for Iron Thorns (svp-098)

### DIFF
--- a/data/Scarlet & Violet/SVP Black Star Promos/098.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/098.ts
@@ -62,7 +62,6 @@ const card: Card = {
 	variants: [
 		{
 			type: 'holo',
-			languages: ['en'],
 			thirdParty: {
 				tcgplayer: 543948
 			}
@@ -70,7 +69,6 @@ const card: Card = {
 		{
 			type: 'holo',
 			stamp: ['pokemon-center'],
-			languages: ['en'],
 			thirdParty: {
 				tcgplayer: 543949
 			}

--- a/data/Scarlet & Violet/SVP Black Star Promos/098.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/098.ts
@@ -61,9 +61,6 @@ const card: Card = {
 	regulationMark: "H",
 	variants: [
 		{
-			type: 'normal'
-		},
-		{
 			type: 'holo',
 			languages: ['en'],
 			thirdParty: {

--- a/data/Scarlet & Violet/SVP Black Star Promos/098.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/098.ts
@@ -59,6 +59,26 @@ const card: Card = {
 
 	retreat: 3,
 	regulationMark: "H",
+	variants: [
+		{
+			type: 'normal'
+		},
+		{
+			type: 'holo',
+			languages: ['en'],
+			thirdParty: {
+				tcgplayer: 543948
+			}
+		},
+		{
+			type: 'holo',
+			stamp: ['pokemon-center'],
+			languages: ['en'],
+			thirdParty: {
+				tcgplayer: 543949
+			}
+		},
+	],
 	illustrator: "Tonji Matsuno"
 }
 


### PR DESCRIPTION
This PR adds missing printing variant(s) for **Iron Thorns** (`svp-098`).

File: `data/Scarlet & Violet/SVP Black Star Promos/098.ts`

Variants added:
- `holo lang:en`
- `holo stamp:pokemon-center lang:en`

_Submitted via the Slab collection app's variant contributor._
