### PR TITLE
Add missing Reverse Holofoil variants for Larvitar

### DIFF
--- a/data/Scarlet & Violet/Paldea Evolved/110.ts
+++ b/data/Scarlet & Violet/Paldea Evolved/110.ts
@@ -48,13 +48,17 @@ const card: Card = {
 	regulationMark: "G",
 
 	variants: {
-		holo: false
+		normal: true,
+		reverse: true,
+		holo: false,
+		firstEdition: false
 	},
 
 	illustrator: "Haru Akasaka",
 
 	thirdParty: {
-		cardmarket: 715585
+		cardmarket: 715585,
+		tcgplayer: 497525
 	}
 }
 

--- a/data/Sun & Moon/Celestial Storm/74.ts
+++ b/data/Sun & Moon/Celestial Storm/74.ts
@@ -79,6 +79,13 @@ const card: Card = {
 
 	retreat: 1,
 
+	variants: {
+		normal: true,
+		reverse: true,
+		holo: false,
+		firstEdition: false
+	},
+
 	thirdParty: {
 		cardmarket: 361319,
 		tcgplayer: 170896

--- a/data/Sun & Moon/Lost Thunder/114.ts
+++ b/data/Sun & Moon/Lost Thunder/114.ts
@@ -78,6 +78,13 @@ const card: Card = {
 
 	retreat: 1,
 
+	variants: {
+		normal: true,
+		reverse: true,
+		holo: false,
+		firstEdition: false
+	},
+
 	thirdParty: {
 		cardmarket: 365751,
 		tcgplayer: 178927

--- a/data/Sun & Moon/Lost Thunder/115.ts
+++ b/data/Sun & Moon/Lost Thunder/115.ts
@@ -64,6 +64,13 @@ const card: Card = {
 
 	retreat: 1,
 
+	variants: {
+		normal: true,
+		reverse: true,
+		holo: false,
+		firstEdition: false
+	},
+
 	thirdParty: {
 		cardmarket: 365751,
 		tcgplayer: 178928

--- a/data/Sun & Moon/Team Up/79.ts
+++ b/data/Sun & Moon/Team Up/79.ts
@@ -64,6 +64,13 @@ const card: Card = {
 
 	retreat: 2,
 
+	variants: {
+		normal: true,
+		reverse: true,
+		holo: false,
+		firstEdition: false
+	},
+
 	thirdParty: {
 		cardmarket: 369009,
 		tcgplayer: 183857

--- a/data/XY/Fates Collide/40.ts
+++ b/data/XY/Fates Collide/40.ts
@@ -63,6 +63,13 @@ const card: Card = {
 
 	retreat: 1,
 
+	variants: {
+		normal: true,
+		reverse: true,
+		holo: false,
+		firstEdition: false
+	},
+
 	description: {
 		en: "Born deep underground, it comes aboveground and becomes a pupa once it has finished eating the surrounding soil.",
 	},

--- a/data/XY/Fates Collide/41.ts
+++ b/data/XY/Fates Collide/41.ts
@@ -79,6 +79,13 @@ const card: Card = {
 
 	retreat: 1,
 
+	variants: {
+		normal: true,
+		reverse: true,
+		holo: false,
+		firstEdition: false
+	},
+
 	description: {
 		en: "Born deep underground, it comes aboveground and becomes a pupa once it has finished eating the surrounding soil.",
 	},


### PR DESCRIPTION
These Larvitar cards are missing their Reverse Holofoil printing. Each exists on TCGplayer with a Reverse Holofoil listing:

| Card | tcgplayer |
|------|-----------|
| Fates Collide 40/124 | 117800 |
| Fates Collide 41/124 | 117801 |
| Celestial Storm 74/168 | 170896 |
| Lost Thunder 114/214 | 178927 |
| Lost Thunder 115/214 | 178928 |
| Team Up 79/181 | 183857 |
| Paldea Evolved 110/193 | 497525 |

Added `reverse: true` to each. Also added the missing tcgplayer ID for Paldea Evolved 110.