### PR TITLE
patch(data): ja address duplicate SV1as

### DIFF
--- a/data-asia/S/CS3D.ts
+++ b/data-asia/S/CS3D.ts
@@ -2,7 +2,7 @@ import { Set } from '../../interfaces'
 import serie from '../S'
 
 const set: Set = {
-	id: 'sv1a',
+	id: 'CS3D',
 	name: {
 		ja: 'トリプレットビート',
 		ko: '트리플렛비트',

--- a/data-asia/S/CS3a.ts
+++ b/data-asia/S/CS3a.ts
@@ -2,7 +2,7 @@ import { Set } from '../../interfaces'
 import serie from '../S'
 
 const set: Set = {
-	id: 'sv1a',
+	id: 'CS3a',
 	name: {
 		ja: 'トリプレットビート',
 		ko: '트리플렛비트',

--- a/data-asia/S/CS3b.ts
+++ b/data-asia/S/CS3b.ts
@@ -2,7 +2,7 @@ import { Set } from '../../interfaces'
 import serie from '../S'
 
 const set: Set = {
-	id: 'sv1a',
+	id: 'CS3b',
 	name: {
 		ja: 'トリプレットビート',
 		ko: '트리플렛비트',

--- a/data-asia/S/CS4.5.ts
+++ b/data-asia/S/CS4.5.ts
@@ -2,7 +2,7 @@ import { Set } from '../../interfaces'
 import serie from '../S'
 
 const set: Set = {
-	id: 'sv1a',
+	id: 'CS4',
 	name: {
 		ja: 'トリプレットビート',
 		ko: '트리플렛비트',

--- a/data-asia/S/CS4Da.ts
+++ b/data-asia/S/CS4Da.ts
@@ -2,7 +2,7 @@ import { Set } from '../../interfaces'
 import serie from '../S'
 
 const set: Set = {
-	id: 'sv1a',
+	id: 'CS4Da',
 	name: {
 		ja: 'トリプレットビート',
 		ko: '트리플렛비트',

--- a/data-asia/S/CS4a.ts
+++ b/data-asia/S/CS4a.ts
@@ -2,7 +2,7 @@ import { Set } from '../../interfaces'
 import serie from '../S'
 
 const set: Set = {
-	id: 'sv1a',
+	id: 'CS4a',
 	name: {
 		ja: 'トリプレットビート',
 		ko: '트리플렛비트',

--- a/data-asia/S/CS4b.ts
+++ b/data-asia/S/CS4b.ts
@@ -2,7 +2,7 @@ import { Set } from '../../interfaces'
 import serie from '../S'
 
 const set: Set = {
-	id: 'sv1a',
+	id: 'CS4b',
 	name: {
 		ja: 'トリプレットビート',
 		ko: '트리플렛비트',

--- a/data-asia/S/CSA.ts
+++ b/data-asia/S/CSA.ts
@@ -2,7 +2,7 @@ import { Set } from '../../interfaces'
 import serie from '../S'
 
 const set: Set = {
-	id: 'sv1a',
+	id: 'CSA',
 	name: {
 		ja: 'トリプレットビート',
 		ko: '트리플렛비트',


### PR DESCRIPTION
closes #1636

## Changes

- Updated sets which had SV1a to their correct set id

## Details

SV1a was being returned several times when requesting sets for `ja`. The set id needed to be updated.
