### PR TITLE
Feat: Added MEP Cards

### DIFF
--- a/data/Mega Evolution/MEP Black Star Promos/071.ts
+++ b/data/Mega Evolution/MEP Black Star Promos/071.ts
@@ -1,0 +1,89 @@
+import { Card } from "../../../interfaces"
+import Set from "../MEP Black Star Promos"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Mega Zygarde ex",
+		fr: "Méga-Zygarde-ex",
+		es: "Mega-Zygarde ex",
+		'es-mx': "Mega-Zygarde ex",
+		de: "Mega-Zygarde-ex",
+		it: "Mega Zygarde-ex",
+		pt: "Mega Zygarde ex"
+	},
+
+	illustrator: "takuyoa",
+	rarity: "None",
+	category: "Pokemon",
+	hp: 310,
+	types: ["Fighting"],
+	stage: "Basic",
+	suffix: "ex",
+	dexId: [718],
+
+	attacks: [{
+		cost: ["Fighting", "Fighting", "Fighting"],
+
+		name: {
+			en: "Gaia Wave",
+			fr: "Onde de Gaïa",
+			es: "Onda Gaia",
+			'es-mx': "Onda Gaia",
+			de: "Gaia-Welle",
+			it: "Onda Gaia",
+			pt: "Onda de Gaia"
+		},
+
+		effect: {
+			en: "During your opponent's next turn, this Pokémon takes 30 less damage from attacks (after applying Weakness and Resistance).",
+			fr: "Pendant le prochain tour de votre adversaire, ce Pokémon subit 30 dégâts de moins provenant des attaques (après application de la Faiblesse et de la Résistance).",
+			es: "Durante el próximo turno de tu rival, los ataques hacen 30 puntos de daño menos a este Pokémon (después de aplicar Debilidad y Resistencia).",
+			'es-mx': "Durante el próximo turno de tu rival, los ataques hacen 30 puntos de daño menos a este Pokémon (después de aplicar Debilidad y Resistencia).",
+			de: "Während des nächsten Zuges deines Gegners werden diesem Pokémon durch Attacken 30 Schadenspunkte weniger zugefügt (nachdem Schwäche und Resistenz verrechnet wurden).",
+			it: "Durante il prossimo turno del tuo avversario, questo Pokémon subisce 30 danni in meno dagli attacchi, dopo aver applicato debolezza e resistenza.",
+			pt: "Durante o próximo turno do seu oponente, este Pokémon receberá 30 pontos de dano a menos de ataques (depois de aplicar Fraqueza e Resistência)."
+		},
+
+		damage: 200
+	}, {
+		cost: ["Fighting", "Fighting", "Fighting", "Fighting", "Fighting"],
+
+		name: {
+			en: "Nullifying Zero",
+			fr: "Zéro Annihilant",
+			es: "Cero Devastador",
+			'es-mx': "Cero Devastador",
+			de: "Tilgendes Nichts",
+			it: "Tabula Zero",
+			pt: "Zero Anulador"
+		},
+
+		effect: {
+			en: "For each of your opponent's Pokémon, flip a coin. If heads, this attack does 150 damage to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)",
+			fr: "Pour chacun des Pokémon de votre adversaire, lancez une pièce. Si c'est face, cette attaque inflige 150 dégâts à ce Pokémon-là. (N'appliquez ni la Faiblesse ni la Résistance aux Pokémon de Banc.)",
+			es: "Por cada uno de los Pokémon de tu rival, lanza 1 moneda. Si sale cara, este ataque hace 150 puntos de daño a ese Pokémon. (No apliques Debilidad y Resistencia a los Pokémon en Banca).",
+			'es-mx': "Por cada uno de los Pokémon de tu rival, lanza 1 moneda. Si sale cara, este ataque hace 150 puntos de daño a ese Pokémon. (No apliques Debilidad y Resistencia a los Pokémon en Banca).",
+			de: "Wirf für jedes Pokémon deines Gegners 1 Münze. Bei Kopf fügt diese Attacke jenem Pokémon 150 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)",
+			it: "Per ciascuno dei Pokémon del tuo avversario, lancia una moneta. Se esce testa, questo attacco infligge 150 danni a quel Pokémon. Non applicare debolezza e resistenza ai Pokémon in panchina.",
+			pt: "Para cada um dos Pokémon do seu oponente, jogue uma moeda. Se sair cara, este ataque causará 150 pontos de dano àquele Pokémon. (Não aplique Fraqueza e Resistência aos Pokémon no Banco.)"
+		}
+	}],
+
+	retreat: 2,
+	regulationMark: "J",
+
+	weaknesses: [{
+		type: "Grass",
+		value: "x2"
+	}],
+
+	variants: [
+		{
+			type: "holo"
+		}
+	]
+}
+
+export default card

--- a/data/Mega Evolution/MEP Black Star Promos/074.ts
+++ b/data/Mega Evolution/MEP Black Star Promos/074.ts
@@ -1,0 +1,100 @@
+import { Card } from "../../../interfaces"
+import Set from "../MEP Black Star Promos"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Delphox",
+		fr: "Goupelin",
+		es: "Delphox",
+		'es-mx': "Delphox",
+		de: "Fennexis",
+		it: "Delphox",
+		pt: "Delphox"
+	},
+
+	illustrator: "Souichirou Gunjima",
+	rarity: "None",
+	category: "Pokemon",
+	hp: 160,
+	types: ["Fire"],
+	stage: "Stage2",
+	dexId: [655],
+
+	evolveFrom: {
+		en: "Braixen",
+		fr: "Roussil",
+		es: "Braixen",
+		'es-mx': "Braixen",
+		de: "Rutena",
+		it: "Braixen",
+		pt: "Braixen"
+	},
+
+	abilities: [{
+		type: "Ability",
+
+		name: {
+			en: "Flaring Magic",
+			fr: "Magie Flamboyante",
+			es: "Magia Ígnea",
+			'es-mx': "Magia Ígnea",
+			de: "Feuerzauber",
+			it: "Magia Fiammante",
+			pt: "Magia Flamejante"
+		},
+
+		effect: {
+			en: "Once during your turn, you may discard a Basic Fire Energy card from your hand in order to use this Ability. Draw cards until you have 7 cards in your hand.",
+			fr: "Une fois pendant votre tour, vous pouvez défausser une carte Énergie Fire de base de votre main pour utiliser ce talent. Piochez des cartes jusqu'à en avoir 7 en main.",
+			es: "Una vez durante tu turno, puedes descartar 1 carta de Energía Fire Básica de tu mano para poder usar esta habilidad. Roba cartas hasta tener 7 cartas en tu mano.",
+			'es-mx': "Una vez durante tu turno, puedes descartar 1 carta de Energía Fire Básica de tu mano para poder usar esta habilidad. Roba cartas hasta tener 7 cartas en tu mano.",
+			de: "Einmal während deines Zuges kannst du 1 Basis-Fire-Energiekarte aus deiner Hand auf deinen Ablagestapel legen, um diese Fähigkeit einzusetzen. Ziehe so lange Karten, bis du 7 Karten auf deiner Hand hast.",
+			it: "Una sola volta durante il tuo turno, puoi scartare una carta Energia base Fire che hai in mano per usare questa abilità. Pesca fino ad avere sette carte in mano.",
+			pt: "Uma vez durante o seu turno, você poderá descartar uma carta de Energia Fire Básica da sua mão para usar esta Habilidade. Compre cartas até ter 7 cartas na sua mão."
+		}
+	}],
+
+	attacks: [{
+		cost: ["Fire", "Fire"],
+
+		name: {
+			en: "Energized Storm",
+			fr: "Tempête Énergisée",
+			es: "Tormenta Energética",
+			'es-mx': "Tormenta Energética",
+			de: "Energiegeladener Sturm",
+			it: "Tempesta Energizzata",
+			pt: "Tormenta Energizada"
+		},
+
+		effect: {
+			en: "This attack does 30 damage for each Energy attached to all Pokémon.",
+			fr: "Cette attaque inflige 30 dégâts pour chaque Énergie attachée à tous les Pokémon.",
+			es: "Este ataque hace 30 puntos de daño por cada Energía unida a cada Pokémon.",
+			'es-mx': "Este ataque hace 30 puntos de daño por cada Energía unida a cada Pokémon.",
+			de: "Diese Attacke fügt für jede an alle Pokémon angelegte Energie 30 Schadenspunkte zu.",
+			it: "Questo attacco infligge 30 danni per ogni Energia assegnata a tutti i Pokémon.",
+			pt: "Este ataque causa 30 pontos de dano para cada Energia ligada a todos os Pokémon."
+		},
+
+		damage: "30×"
+	}],
+
+	retreat: 2,
+	regulationMark: "J",
+
+	weaknesses: [{
+		type: "Water",
+		value: "x2"
+	}],
+
+	variants: [
+		{
+			type: "holo"
+		}
+	]
+}
+
+export default card

--- a/data/Mega Evolution/MEP Black Star Promos/075.ts
+++ b/data/Mega Evolution/MEP Black Star Promos/075.ts
@@ -1,0 +1,100 @@
+import { Card } from "../../../interfaces"
+import Set from "../MEP Black Star Promos"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Ampharos",
+		fr: "Pharamp",
+		es: "Ampharos",
+		'es-mx': "Ampharos",
+		de: "Ampharos",
+		it: "Ampharos",
+		pt: "Ampharos"
+	},
+
+	illustrator: "Taiga Kasai",
+	rarity: "None",
+	category: "Pokemon",
+	hp: 160,
+	types: ["Lightning"],
+	stage: "Stage2",
+	dexId: [181],
+
+	evolveFrom: {
+		en: "Flaaffy",
+		fr: "Lainergie",
+		es: "Flaaffy",
+		'es-mx': "Flaaffy",
+		de: "Waaty",
+		it: "Flaaffy",
+		pt: "Flaaffy"
+	},
+
+	abilities: [{
+		type: "Ability",
+
+		name: {
+			en: "Synchro Pulse",
+			fr: "Pulsation Synchronisée",
+			es: "Pulso Sincronizado",
+			'es-mx': "Pulso Sincronizado",
+			de: "Synchropuls",
+			it: "Impulso Sincronizzato",
+			pt: "Pulso Sincronizado"
+		},
+
+		effect: {
+			en: "If you have the same number of cards in your hand as your opponent, attacks used by this Pokémon do 80 more damage to your opponent's Active Pokémon (before applying Weakness and Resistance).",
+			fr: "Si vous avez le même nombre de cartes dans votre main que votre adversaire, les attaques utilisées par ce Pokémon infligent 80 dégâts supplémentaires au Pokémon Actif de votre adversaire (avant application de la Faiblesse et de la Résistance).",
+			es: "Si tienes la misma cantidad de cartas en tu mano que tu rival, los ataques usados por este Pokémon hacen 80 puntos de daño más al Pokémon Activo de tu rival (antes de aplicar Debilidad y Resistencia).",
+			'es-mx': "Si tienes la misma cantidad de cartas en tu mano que tu rival, los ataques usados por este Pokémon hacen 80 puntos de daño más al Pokémon Activo de tu rival (antes de aplicar Debilidad y Resistencia).",
+			de: "Wenn du genauso viele Karten auf der Hand hast wie dein Gegner, fügen die von diesem Pokémon eingesetzten Attacken dem Aktiven Pokémon deines Gegners 80 Schadenspunkte mehr zu (bevor Schwäche und Resistenz verrechnet werden).",
+			it: "Se hai lo stesso numero di carte in mano del tuo avversario, gli attacchi usati da questo Pokémon infliggono 80 danni in più al Pokémon attivo del tuo avversario, prima di aver applicato debolezza e resistenza.",
+			pt: "Se você tiver o mesmo número de cartas na sua mão que seu oponente, os ataques usados por este Pokémon causarão 80 pontos de dano a mais ao Pokémon Ativo do seu oponente (antes de aplicar Fraqueza e Resistência)."
+		}
+	}],
+
+	attacks: [{
+		cost: ["Lightning", "Colorless"],
+
+		name: {
+			en: "Flashing Bolt",
+			fr: "Éclair Aveuglant",
+			es: "Rayo Destellante",
+			'es-mx': "Rayo Destellante",
+			de: "Leuchtblitz",
+			it: "Bolide Abbagliante",
+			pt: "Raio Piscante"
+		},
+
+		effect: {
+			en: "During your next turn, this Pokémon can't use Flashing Bolt.",
+			fr: "Pendant votre prochain tour, ce Pokémon ne peut pas utiliser Éclair Aveuglant.",
+			es: "Durante tu próximo turno, este Pokémon no puede usar Rayo Destellante.",
+			'es-mx': "Durante tu próximo turno, este Pokémon no puede usar Rayo Destellante.",
+			de: "Während deines nächsten Zuges kann dieses Pokémon Leuchtblitz nicht einsetzen.",
+			it: "Durante il tuo prossimo turno, questo Pokémon non può usare Bolide Abbagliante.",
+			pt: "Durante o seu próximo turno, este Pokémon não poderá usar Raio Piscante."
+		},
+
+		damage: 140
+	}],
+
+	retreat: 2,
+	regulationMark: "J",
+
+	weaknesses: [{
+		type: "Fighting",
+		value: "x2"
+	}],
+
+	variants: [
+		{
+			type: "holo"
+		}
+	]
+}
+
+export default card

--- a/data/Mega Evolution/MEP Black Star Promos/076.ts
+++ b/data/Mega Evolution/MEP Black Star Promos/076.ts
@@ -1,0 +1,105 @@
+import { Card } from "../../../interfaces"
+import Set from "../MEP Black Star Promos"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Crobat",
+		fr: "Nostenfer",
+		es: "Crobat",
+		'es-mx': "Crobat",
+		de: "Iksbat",
+		it: "Crobat",
+		pt: "Crobat"
+	},
+
+	illustrator: "Apios",
+	rarity: "None",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Darkness"],
+	stage: "Stage2",
+	dexId: [169],
+
+	evolveFrom: {
+		en: "Golbat",
+		fr: "Nosferalto",
+		es: "Golbat",
+		'es-mx': "Golbat",
+		de: "Golbat",
+		it: "Golbat",
+		pt: "Golbat"
+	},
+
+	abilities: [{
+		type: "Ability",
+
+		name: {
+			en: "Nighttime Maneuvers",
+			fr: "Manigances Nocturnes",
+			es: "Maniobras de Medianoche",
+			'es-mx': "Maniobras de Medianoche",
+			de: "Manöver bei Nacht",
+			it: "Manovre nell'Oscurità",
+			pt: "Manobras na Penumbra"
+		},
+
+		effect: {
+			en: "Once during your turn, if this Pokémon is in the Active Spot, you may use this Ability. Search your deck for a card. Shuffle your deck, then put that card on top of it.",
+			fr: "Une fois pendant votre tour, si ce Pokémon est sur le Poste Actif, vous pouvez utiliser ce talent. Cherchez dans votre deck une carte. Mélangez votre deck, puis placez cette carte sur le dessus de votre deck.",
+			es: "Una vez durante tu turno, si este Pokémon está en el Puesto Activo, puedes usar esta habilidad. Busca en tu baraja 1 carta. Baraja las cartas de tu baraja y, luego, pon esa carta en la parte superior de tu baraja.",
+			'es-mx': "Una vez durante tu turno, si este Pokémon está en el Puesto Activo, puedes usar esta habilidad. Busca en tu baraja 1 carta. Baraja las cartas de tu baraja y, luego, pon esa carta en la parte superior de tu baraja.",
+			de: "Einmal während deines Zuges, wenn dieses Pokémon in der Aktiven Position ist, kannst du diese Fähigkeit einsetzen. Durchsuche dein Deck nach 1 Karte. Mische dein Deck und lege anschließend jene Karte darauf.",
+			it: "Una sola volta durante il tuo turno, se questo Pokémon è in posizione attiva, puoi usare questa abilità. Cerca nel tuo mazzo una carta. Rimischia il tuo mazzo, poi metti quella carta in cima al mazzo.",
+			pt: "Uma vez durante o seu turno, se este Pokémon estiver no Campo Ativo, você poderá usar esta Habilidade. Procure por 1 carta no seu baralho. Embaralhe o seu baralho e, em seguida, coloque aquela carta como a carta de cima do seu baralho."
+		}
+	}],
+
+	attacks: [{
+		cost: ["Darkness"],
+
+		name: {
+			en: "Poison Sound Wave",
+			fr: "Onde Sonore Toxique",
+			es: "Onda Sónica Venenosa",
+			'es-mx': "Onda Sónica Venenosa",
+			de: "Gift-Schallwelle",
+			it: "Onda Sonora Velenosa",
+			pt: "Vibração Venenosa"
+		},
+
+		effect: {
+			en: "Your opponent's Active Pokémon is now Confused and Poisoned.",
+			fr: "Le Pokémon Actif de votre adversaire est maintenant Confus et Empoisonné.",
+			es: "El Pokémon Activo de tu rival pasa a estar Confundido y Envenenado.",
+			'es-mx': "El Pokémon Activo de tu rival pasa a estar Confundido y Envenenado.",
+			de: "Das Aktive Pokémon deines Gegners ist jetzt verwirrt und vergiftet.",
+			it: "Il Pokémon attivo del tuo avversario viene confuso e avvelenato.",
+			pt: "O Pokémon Ativo do seu oponente agora está Confuso e Envenenado."
+		},
+
+		damage: 80
+	}],
+
+	retreat: 1,
+	regulationMark: "J",
+
+	weaknesses: [{
+		type: "Lightning",
+		value: "x2"
+	}],
+
+	resistances: [{
+		type: "Fighting",
+		value: "-30"
+	}],
+
+	variants: [
+		{
+			type: "holo"
+		}
+	]
+}
+
+export default card

--- a/data/Mega Evolution/MEP Black Star Promos/077.ts
+++ b/data/Mega Evolution/MEP Black Star Promos/077.ts
@@ -1,0 +1,95 @@
+import { Card } from "../../../interfaces"
+import Set from "../MEP Black Star Promos"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Goodra",
+		fr: "Muplodocus",
+		es: "Goodra",
+		'es-mx': "Goodra",
+		de: "Viscogon",
+		it: "Goodra",
+		pt: "Goodra"
+	},
+
+	illustrator: "okayamatakatoshi",
+	rarity: "None",
+	category: "Pokemon",
+	hp: 160,
+	types: ["Dragon"],
+	stage: "Stage2",
+	dexId: [706],
+
+	evolveFrom: {
+		en: "Sliggoo",
+		fr: "Colimucus",
+		es: "Sliggoo",
+		'es-mx': "Sliggoo",
+		de: "Viscargot",
+		it: "Sliggoo",
+		pt: "Sliggoo"
+	},
+
+	abilities: [{
+		type: "Ability",
+
+		name: {
+			en: "Slimy Sliding",
+			fr: "Glissade Gluante",
+			es: "Deslizamiento Viscoso",
+			'es-mx': "Deslizamiento Viscoso",
+			de: "Schleimiges Schlittern",
+			it: "Scivolata Vischiosa",
+			pt: "Deslizamento Gosmento"
+		},
+
+		effect: {
+			en: "When your opponent's Active Pokémon retreats, your opponent flips a coin. If tails, Energy for its Retreat Cost is not discarded, and they don't switch Pokémon. The effect of Slimy Sliding doesn't stack.",
+			fr: "Lorsque le Pokémon Actif de votre adversaire bat en retraite, votre adversaire lance une pièce. Si c'est pile, les Énergies pour son Coût de Retraite ne sont pas défaussées, et le Pokémon n'est pas échangé. L'effet de Glissade Gluante n'est pas cumulable.",
+			es: "Cuando el Pokémon Activo de tu rival se retira, tu rival lanza 1 moneda. Si sale cruz, no se descartan Energías por su Coste de Retirada, y tu rival no cambia su Pokémon. El efecto de Deslizamiento Viscoso no se acumula.",
+			'es-mx': "Cuando el Pokémon Activo de tu rival se retira, tu rival lanza 1 moneda. Si sale cruz, no se descartan Energías por su Coste de Retirada, y tu rival no cambia su Pokémon. El efecto de Deslizamiento Viscoso no se acumula.",
+			de: "Wenn sich das Aktive Pokémon deines Gegners zurückzieht, wirft dein Gegner 1 Münze. Bei Zahl wird keine Energie für dessen Rückzugskosten auf den Ablagestapel deines Gegners gelegt, und er tauscht keine Pokémon aus. Der Effekt von Schleimiges Schlittern stapelt sich nicht.",
+			it: "Quando il Pokémon attivo del tuo avversario si ritira, il tuo avversario lancia una moneta. Se esce croce, l'Energia per il suo costo di ritirata non viene scartata e il Pokémon non viene scambiato. L'effetto di Scivolata Vischiosa non è cumulabile.",
+			pt: "Quando o Pokémon Ativo do seu oponente recuar, seu oponente jogará uma moeda. Se sair coroa, a Energia usada para o Custo de Recuo não será descartada e ele não trocará o Pokémon. O efeito de Deslizamento Gosmento não acumula."
+		}
+	}],
+
+	attacks: [{
+		cost: ["Water", "Psychic"],
+
+		name: {
+			en: "Dragon Pulse",
+			fr: "Draco-Choc",
+			es: "Pulso Dragón",
+			'es-mx': "Pulso Dragón",
+			de: "Drachenpuls",
+			it: "Dragopulsar",
+			pt: "Pulso do Dragão"
+		},
+
+		effect: {
+			en: "Discard the top card of your deck.",
+			fr: "Défaussez la carte du dessus de votre deck.",
+			es: "Descarta la primera carta de tu baraja.",
+			'es-mx': "Descarta la primera carta de tu baraja.",
+			de: "Lege die oberste Karte deines Decks auf deinen Ablagestapel.",
+			it: "Scarta la prima carta del tuo mazzo.",
+			pt: "Descarte a carta de cima do seu baralho."
+		},
+
+		damage: 160
+	}],
+
+	retreat: 3,
+	regulationMark: "J",
+
+	variants: [
+		{
+			type: "holo"
+		}
+	]
+}
+
+export default card

--- a/data/Mega Evolution/MEP Black Star Promos/078.ts
+++ b/data/Mega Evolution/MEP Black Star Promos/078.ts
@@ -1,0 +1,78 @@
+import { Card } from "../../../interfaces"
+import Set from "../MEP Black Star Promos"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Toxel",
+		fr: "Toxizap",
+		es: "Toxel",
+		'es-mx': "Toxel",
+		de: "Toxel",
+		it: "Toxel",
+		pt: "Toxel"
+	},
+
+	illustrator: "Mina Nakai",
+	rarity: "None",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Darkness"],
+	stage: "Basic",
+	dexId: [848],
+
+	attacks: [{
+		cost: ["Darkness"],
+
+		name: {
+			en: "Call for Family",
+			fr: "Appel à la Famille",
+			es: "Llamar a la Familia",
+			'es-mx': "Llamar a la Familia",
+			de: "Familienruf",
+			it: "Cerca Famiglia",
+			pt: "Chamar a Família"
+		},
+
+		effect: {
+			en: "Search your deck for up to 2 Basic Pokémon and put them onto your Bench. Then, shuffle your deck.",
+			fr: "Cherchez dans votre deck jusqu'à 2 Pokémon de base, puis placez-les sur votre Banc. Mélangez ensuite votre deck.",
+			es: "Busca en tu baraja hasta 2 Pokémon Básicos y ponlos en tu Banca. Después, baraja las cartas de tu baraja.",
+			'es-mx': "Busca en tu baraja hasta 2 Pokémon Básicos y ponlos en tu Banca. Después, baraja las cartas de tu baraja.",
+			de: "Durchsuche dein Deck nach bis zu 2 Basis-Pokémon und lege sie auf deine Bank. Mische anschließend dein Deck.",
+			it: "Cerca nel tuo mazzo fino a due Pokémon Base e mettili nella tua panchina. Poi rimischia il tuo mazzo.",
+			pt: "Procure por até 2 Pokémon Básicos no seu baralho e coloque-os no seu Banco. Em seguida, embaralhe o seu baralho."
+		}
+	}, {
+		cost: ["Darkness", "Colorless"],
+
+		name: {
+			en: "Playful Kick",
+			fr: "Coup de Pied de Garnement",
+			es: "Patada Juguetona",
+			'es-mx': "Patada Juguetona",
+			de: "Verspielter Kick",
+			it: "Calcio Briccone",
+			pt: "Chute Brincalhão"
+		},
+
+		damage: 20
+	}],
+
+	retreat: 1,
+	regulationMark: "I",
+
+	weaknesses: [{
+		type: "Fighting",
+		value: "x2"
+	}],
+
+	variants: [
+		{
+			type: "holo"
+		}
+	]
+}
+
+export default card

--- a/data/Mega Evolution/MEP Black Star Promos/079.ts
+++ b/data/Mega Evolution/MEP Black Star Promos/079.ts
@@ -1,0 +1,66 @@
+import { Card } from "../../../interfaces"
+import Set from "../MEP Black Star Promos"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Charmeleon",
+		fr: "Reptincel",
+		es: "Charmeleon",
+		'es-mx': "Charmeleon",
+		de: "Glutexo",
+		it: "Charmeleon",
+		pt: "Charmeleon"
+	},
+
+	illustrator: "Teeziro",
+	rarity: "None",
+	category: "Pokemon",
+	hp: 110,
+	types: ["Fire"],
+	stage: "Stage1",
+	dexId: [5],
+
+	evolveFrom: {
+		en: "Charmander",
+		fr: "Salamèche",
+		es: "Charmander",
+		'es-mx': "Charmander",
+		de: "Glumanda",
+		it: "Charmander",
+		pt: "Charmander"
+	},
+
+	attacks: [{
+		cost: ["Fire"],
+
+		name: {
+			en: "Steady Firebreathing",
+			fr: "Crachage de Feu Régulier",
+			es: "Lanzallamas Continuo",
+			'es-mx': "Lanzallamas Continuo",
+			de: "Stetiger Feuerhauch",
+			it: "Soffiofuoco Mirato",
+			pt: "Hálito de Fogo Constante"
+		},
+
+		damage: 40
+	}],
+
+	retreat: 2,
+	regulationMark: "I",
+
+	weaknesses: [{
+		type: "Water",
+		value: "x2"
+	}],
+
+	variants: [
+		{
+			type: "holo"
+		}
+	]
+}
+
+export default card

--- a/data/Mega Evolution/MEP Black Star Promos/080.ts
+++ b/data/Mega Evolution/MEP Black Star Promos/080.ts
@@ -1,0 +1,78 @@
+import { Card } from "../../../interfaces"
+import Set from "../MEP Black Star Promos"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Fennekin",
+		fr: "Feunnec",
+		es: "Fennekin",
+		'es-mx': "Fennekin",
+		de: "Fynx",
+		it: "Fennekin",
+		pt: "Fennekin"
+	},
+
+	illustrator: "satoma",
+	rarity: "None",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Fire"],
+	stage: "Basic",
+	dexId: [653],
+
+	attacks: [{
+		cost: ["Colorless"],
+
+		name: {
+			en: "Call for Family",
+			fr: "Appel à la Famille",
+			es: "Llamar a la Familia",
+			'es-mx': "Llamar a la Familia",
+			de: "Familienruf",
+			it: "Cerca Famiglia",
+			pt: "Chamar a Família"
+		},
+
+		effect: {
+			en: "Search your deck for up to 2 Basic Pokémon and put them onto your Bench. Then, shuffle your deck.",
+			fr: "Cherchez dans votre deck jusqu'à 2 Pokémon de base, puis placez-les sur votre Banc. Mélangez ensuite votre deck.",
+			es: "Busca en tu baraja hasta 2 Pokémon Básicos y ponlos en tu Banca. Después, baraja las cartas de tu baraja.",
+			'es-mx': "Busca en tu baraja hasta 2 Pokémon Básicos y ponlos en tu Banca. Después, baraja las cartas de tu baraja.",
+			de: "Durchsuche dein Deck nach bis zu 2 Basis-Pokémon und lege sie auf deine Bank. Mische anschließend dein Deck.",
+			it: "Cerca nel tuo mazzo fino a due Pokémon Base e mettili nella tua panchina. Poi rimischia il tuo mazzo.",
+			pt: "Procure por até 2 Pokémon Básicos no seu baralho e coloque-os no seu Banco. Em seguida, embaralhe o seu baralho."
+		}
+	}, {
+		cost: ["Fire"],
+
+		name: {
+			en: "Steady Firebreathing",
+			fr: "Crachage de Feu Régulier",
+			es: "Lanzallamas Continuo",
+			'es-mx': "Lanzallamas Continuo",
+			de: "Stetiger Feuerhauch",
+			it: "Soffiofuoco Mirato",
+			pt: "Hálito de Fogo Constante"
+		},
+
+		damage: 10
+	}],
+
+	retreat: 1,
+	regulationMark: "J",
+
+	weaknesses: [{
+		type: "Water",
+		value: "x2"
+	}],
+
+	variants: [
+		{
+			type: "holo"
+		}
+	]
+}
+
+export default card


### PR DESCRIPTION
## Changes

Added missing cards for `MEP Black Star Promos` from MEP 071 through MEP 080.

## Details

This adds entries for MEP 071, 074, 075, 076, 077, 078, 079, and 080, including localized card names and text for the available languages: English, German, French, Spanish, Italian, and Portuguese.