### PR TITLE
Add otherPrintings field to Card interface

### DIFF
--- a/interfaces.d.ts
+++ b/interfaces.d.ts
@@ -259,6 +259,11 @@ export interface Card {
 	set: Set
 
 	/**
+	 * Other printings of the card (card IDs)
+	 */
+	otherPrintings?: Array<string>
+
+	/**
 	 * Card regulation Mark
 	 *
 	 * note: added from Sword & Shield

--- a/meta/definitions/api.d.ts
+++ b/meta/definitions/api.d.ts
@@ -212,6 +212,12 @@ export interface Card extends CardResume {
 	 * Card Set
 	 */
 	set: SetResume;
+
+	/**
+	 * Other printings of the card (card IDs)
+	 */
+	otherPrintings?: Array<string>;
+
 	/**
 	 * Pokemon only elements
 	 */

--- a/meta/definitions/graphql.gql
+++ b/meta/definitions/graphql.gql
@@ -225,6 +225,9 @@ type Card {
 	"""The boosters in which the card is available"""
 	boosters: [Booster]
 
+	"""Other printings of the card (card IDs)"""
+	otherPrintings: [String]
+
 	"""The pokémon weaknesses"""
 	weaknesses: [WeakResListItem]
 

--- a/meta/definitions/openapi.yaml
+++ b/meta/definitions/openapi.yaml
@@ -1536,6 +1536,12 @@ components:
                         type: string
                         description: The foil of the variant (e.g., 'Pokeball', 'MasterBall', etc.)
                         nullable: true
+        otherPrintings:
+          type: [array, null]
+          description: Other printings of the card (card IDs)
+          items:
+            type: string
+          example: ["base1-58", "base2-58"]
         hp:
           type: [number, "null"]
           description: Hit Points (HP) of the Pokemon

--- a/server/compiler/utils/cardUtil.ts
+++ b/server/compiler/utils/cardUtil.ts
@@ -168,6 +168,7 @@ export async function cardToCardSingle(localId: string, card: Card, lang: Suppor
 		})) : undefined,
 		updated: await getCardLastEdit(localId, card, lang),
 
+		otherPrintings: card.otherPrintings,
 		thirdParty: card.thirdParty
 	}
 }


### PR DESCRIPTION

## Changes

Adds otherPrintings field to the Card interface to track other printings/reprints of a card using the card IDs 

Example:
```otherPrintings: ["base1-58", "base2-58"]```
