### PR TITLE
fix(data): Add missing types to 16 Pokémon cards

### DIFF
--- a/data/E-Card/Best of game/1.ts
+++ b/data/E-Card/Best of game/1.ts
@@ -26,6 +26,7 @@ const card: Card = {
 	},
 	
 	hp: 70,
+	types: ["Lightning"],
 
 	stage: "Basic",
 

--- a/data/McDonald's Collection/McDonald's Collection 2016/1.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2016/1.ts
@@ -13,6 +13,7 @@ const card: Card = {
 	},
 
 	hp: 60,
+	types: ["Fire"],
 
 	stage: "Basic",
 

--- a/data/McDonald's Collection/McDonald's Collection 2016/10.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2016/10.ts
@@ -13,6 +13,7 @@ const card: Card = {
 	},
 
 	hp: 70,
+	types: ["Fairy"],
 
 	stage: "Basic",
 

--- a/data/McDonald's Collection/McDonald's Collection 2016/11.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2016/11.ts
@@ -13,6 +13,7 @@ const card: Card = {
 	},
 
 	hp: 60,
+	types: ["Colorless"],
 
 	stage: "Basic",
 

--- a/data/McDonald's Collection/McDonald's Collection 2016/12.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2016/12.ts
@@ -13,6 +13,7 @@ const card: Card = {
 	},
 
 	hp: 60,
+	types: ["Colorless"],
 
 	stage: "Basic",
 

--- a/data/McDonald's Collection/McDonald's Collection 2016/2.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2016/2.ts
@@ -13,6 +13,7 @@ const card: Card = {
 	},
 
 	hp: 60,
+	types: ["Fire"],
 
 	stage: "Basic",
 

--- a/data/McDonald's Collection/McDonald's Collection 2016/3.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2016/3.ts
@@ -13,6 +13,7 @@ const card: Card = {
 	},
 
 	hp: 50,
+	types: ["Fire"],
 
 	stage: "Basic",
 

--- a/data/McDonald's Collection/McDonald's Collection 2016/4.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2016/4.ts
@@ -13,6 +13,7 @@ const card: Card = {
 	},
 
 	hp: 30,
+	types: ["Water"],
 
 	stage: "Basic",
 

--- a/data/McDonald's Collection/McDonald's Collection 2016/5.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2016/5.ts
@@ -13,6 +13,7 @@ const card: Card = {
 	},
 
 	hp: 60,
+	types: ["Water"],
 
 	stage: "Basic",
 

--- a/data/McDonald's Collection/McDonald's Collection 2016/6.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2016/6.ts
@@ -13,6 +13,7 @@ const card: Card = {
 	},
 
 	hp: 60,
+	types: ["Lightning"],
 
 	stage: "Basic",
 

--- a/data/McDonald's Collection/McDonald's Collection 2016/7.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2016/7.ts
@@ -13,6 +13,7 @@ const card: Card = {
 	},
 
 	hp: 60,
+	types: ["Darkness"],
 
 	stage: "Basic",
 

--- a/data/McDonald's Collection/McDonald's Collection 2016/8.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2016/8.ts
@@ -13,6 +13,7 @@ const card: Card = {
 	},
 
 	hp: 60,
+	types: ["Fairy"],
 
 	stage: "Basic",
 

--- a/data/McDonald's Collection/McDonald's Collection 2016/9.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2016/9.ts
@@ -13,6 +13,7 @@ const card: Card = {
 	},
 
 	hp: 40,
+	types: ["Fairy"],
 
 	stage: "Basic",
 

--- a/data/Trainer kits/DP trainer Kit (Manaphy)/4.ts
+++ b/data/Trainer kits/DP trainer Kit (Manaphy)/4.ts
@@ -16,6 +16,7 @@ const card: Card = {
 	stage: "Basic",
 
 	hp: 70,
+	types: ["Water"],
 
 	attacks: [{
 		cost: [

--- a/data/Trainer kits/HS trainer Kit (Gyarados)/20.ts
+++ b/data/Trainer kits/HS trainer Kit (Gyarados)/20.ts
@@ -19,6 +19,7 @@ const card: Card = {
 	},
 	
 	hp: 130,
+	types: ["Water"],
 
 	stage: "Stage1",
 

--- a/data/Trainer kits/HS trainer Kit (Raichu)/19.ts
+++ b/data/Trainer kits/HS trainer Kit (Raichu)/19.ts
@@ -19,6 +19,7 @@ const card: Card = {
 	},
 	
 	hp: 90,
+	types: ["Lightning"],
 
 	stage: "Stage1",
 


### PR DESCRIPTION
Adds the missing `types` field to the 16 Pokémon cards listed in the CSV attached to #1567. Each card is `category: "Pokemon"` but had no `types` array, which broke type-based matching of equivalent prints.

The expected type for each card comes from the issue's CSV and was cross-checked against card scans (see image links below). All values are valid members of the `Types` union in `interfaces.d.ts`, and `tsc --noEmit` passes.

Closes #1567

## Cards fixed — McDonald's Collection 2016 (`2016xy`)

| Card | Type added | Image |
|------|-----------|-------|
| 1 Vulpix | Fire | https://product-images.tcgplayer.com/275057.jpg |
| 2 Torchic | Fire | https://product-images.tcgplayer.com/275058.jpg |
| 3 Fennekin | Fire | https://product-images.tcgplayer.com/275059.jpg |
| 4 Magikarp | Water | https://product-images.tcgplayer.com/275060.jpg |
| 5 Totodile | Water | https://product-images.tcgplayer.com/275061.jpg |
| 6 Pikachu | Lightning | https://product-images.tcgplayer.com/275062.jpg |
| 7 Scraggy | Darkness | https://product-images.tcgplayer.com/275063.jpg |
| 8 Jigglypuff | Fairy | https://product-images.tcgplayer.com/275064.jpg |
| 9 Togepi | Fairy | https://product-images.tcgplayer.com/275065.jpg |
| 10 Dedenne | Fairy | https://product-images.tcgplayer.com/275066.jpg |
| 11 Meowth | Colorless | https://product-images.tcgplayer.com/275067.jpg |
| 12 Eevee | Colorless | https://product-images.tcgplayer.com/275069.jpg |

## Cards fixed — other sets

| Card | Type added | Image |
|------|-----------|-------|
| Electabuzz (`bog-1`) | Lightning | https://product-images.tcgplayer.com/85106.jpg |
| Gyarados (`tk-hs-g-20`) | Water | https://product-images.tcgplayer.com/85997.jpg |
| Raichu (`tk-hs-r-19`) | Lightning | https://product-images.tcgplayer.com/88520.jpg |
| Manaphy (`tk-dp-m-4`) | Water | https://archives.bulbagarden.net/media/upload/1/10/ManaphyDPTrainerKit4.jpg |

Image links are sourced from TCGplayer (product IDs already present in each card's `variants`) and, for Manaphy, Bulbapedia.
