### PR TITLE
(data): Variants and Pricing Rebel Clash

### DIFF
--- a/data/Sword & Shield/Rebel Clash/1.ts
+++ b/data/Sword & Shield/Rebel Clash/1.ts
@@ -69,12 +69,6 @@ const card: Card = {
 	types: ["Grass"],
 	regulationMark: "D",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	stage: "Basic",
 
@@ -84,10 +78,22 @@ const card: Card = {
 
 	dexId: [10],
 
-	thirdParty: {
-		cardmarket: 457383,
-		tcgplayer: 213071
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 457383,
+				tcgplayer: 213071
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 457383,
+				tcgplayer: 213071
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Rebel Clash/10.ts
+++ b/data/Sword & Shield/Rebel Clash/10.ts
@@ -56,12 +56,6 @@ const card: Card = {
 	types: ["Grass"],
 	regulationMark: "D",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	stage: "Basic",
 
@@ -69,10 +63,22 @@ const card: Card = {
 		en: "It lives in ponds and marshes that feature lots of plant life. It often fights with Dewpider, whose habitat and diet are similar."
 	},
 
-	thirdParty: {
-		cardmarket: 457443,
-		tcgplayer: 213080
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 457443,
+				tcgplayer: 213080
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 457443,
+				tcgplayer: 213080
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Rebel Clash/100.ts
+++ b/data/Sword & Shield/Rebel Clash/100.ts
@@ -88,12 +88,6 @@ const card: Card = {
 	types: ["Fighting"],
 	regulationMark: "D",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	stage: "Stage1",
 
@@ -101,10 +95,22 @@ const card: Card = {
 		en: "It makes its nest at the bottom of swamps. It will eat anything—if it is alive, Whiscash will eat it."
 	},
 
-	thirdParty: {
-		cardmarket: 457913,
-		tcgplayer: 213188
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 457913,
+				tcgplayer: 213188
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 457913,
+				tcgplayer: 213188
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Rebel Clash/101.ts
+++ b/data/Sword & Shield/Rebel Clash/101.ts
@@ -56,12 +56,6 @@ const card: Card = {
 	types: ["Fighting"],
 	regulationMark: "D",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	stage: "Basic",
 
@@ -69,10 +63,22 @@ const card: Card = {
 		en: "A clay slab with cursed engravings took possession of a Yamask. The slab is said to be absorbing the Yamask's dark power."
 	},
 
-	thirdParty: {
-		cardmarket: 457918,
-		tcgplayer: 213189
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 457918,
+				tcgplayer: 213189
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 457918,
+				tcgplayer: 213189
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Rebel Clash/102.ts
+++ b/data/Sword & Shield/Rebel Clash/102.ts
@@ -89,12 +89,6 @@ const card: Card = {
 	types: ["Fighting"],
 	regulationMark: "D",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	stage: "Stage1",
 
@@ -102,10 +96,22 @@ const card: Card = {
 		en: "A powerful curse was woven into an ancient painting. After absorbing the spirit of a Yamask, the painting began to move."
 	},
 
-	thirdParty: {
-		cardmarket: 457923,
-		tcgplayer: 213190
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 457923,
+				tcgplayer: 213190
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 457923,
+				tcgplayer: 213190
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Rebel Clash/103.ts
+++ b/data/Sword & Shield/Rebel Clash/103.ts
@@ -58,12 +58,6 @@ const card: Card = {
 	types: ["Fighting"],
 	regulationMark: "D",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	stage: "Basic",
 
@@ -71,10 +65,22 @@ const card: Card = {
 		en: "After two Binacle find a suitably sized rock, they adhere themselves to it and live together. They cooperate to gather food during high tide."
 	},
 
-	thirdParty: {
-		cardmarket: 457928,
-		tcgplayer: 213191
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 457928,
+				tcgplayer: 213191
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 457928,
+				tcgplayer: 213191
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Rebel Clash/104.ts
+++ b/data/Sword & Shield/Rebel Clash/104.ts
@@ -91,12 +91,6 @@ const card: Card = {
 	types: ["Fighting"],
 	regulationMark: "D",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	stage: "Stage1",
 
@@ -104,10 +98,22 @@ const card: Card = {
 		en: "Seven Binacle come together to form one Barbaracle. The Binacle that serves as the head gives orders to those serving as the limbs."
 	},
 
-	thirdParty: {
-		cardmarket: 457933,
-		tcgplayer: 213192
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 457933,
+				tcgplayer: 213192
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 457933,
+				tcgplayer: 213192
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Rebel Clash/105.ts
+++ b/data/Sword & Shield/Rebel Clash/105.ts
@@ -48,12 +48,6 @@ const card: Card = {
 	types: ["Fighting"],
 	regulationMark: "D",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	stage: "Basic",
 
@@ -61,10 +55,22 @@ const card: Card = {
 		en: "Most of its body has the same composition as coal. Fittingly, this Pokémon was first discovered in coal mines about 400 years ago."
 	},
 
-	thirdParty: {
-		cardmarket: 457938,
-		tcgplayer: 213193
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 457938,
+				tcgplayer: 213193
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 457938,
+				tcgplayer: 213193
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Rebel Clash/106.ts
+++ b/data/Sword & Shield/Rebel Clash/106.ts
@@ -76,12 +76,6 @@ const card: Card = {
 	types: ["Fighting"],
 	regulationMark: "D",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	stage: "Stage1",
 
@@ -89,10 +83,22 @@ const card: Card = {
 		en: "It forms coal inside its body. Coal dropped by this Pokémon once helped fuel the lives of people in the Galar region."
 	},
 
-	thirdParty: {
-		cardmarket: 457943,
-		tcgplayer: 213194
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 457943,
+				tcgplayer: 213194
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 457943,
+				tcgplayer: 213194
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Rebel Clash/107.ts
+++ b/data/Sword & Shield/Rebel Clash/107.ts
@@ -83,12 +83,6 @@ const card: Card = {
 	types: ["Fighting"],
 	regulationMark: "D",
 
-	variants: {
-		normal: false,
-		reverse: true,
-		holo: true,
-		firstEdition: false
-	},
 
 	stage: "Stage2",
 
@@ -96,10 +90,22 @@ const card: Card = {
 		en: "It's usually peaceful, but the vandalism of mines enrages it. Offenders will be incinerated with flames that reach 2,700 degrees Fahrenheit."
 	},
 
-	thirdParty: {
-		cardmarket: 457948,
-		tcgplayer: 213195
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 457948,
+				tcgplayer: 213195
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 457948,
+				tcgplayer: 213195
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Rebel Clash/108.ts
+++ b/data/Sword & Shield/Rebel Clash/108.ts
@@ -80,20 +80,19 @@ const card: Card = {
 	types: ["Fighting"],
 	regulationMark: "D",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
 	stage: "Basic",
 	suffix: "V",
 
-	thirdParty: {
-		cardmarket: 457953,
-		tcgplayer: 213198
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 457953,
+				tcgplayer: 213198
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Rebel Clash/109.ts
+++ b/data/Sword & Shield/Rebel Clash/109.ts
@@ -78,12 +78,6 @@ const card: Card = {
 	types: ["Fighting"],
 	regulationMark: "D",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	stage: "Basic",
 
@@ -91,10 +85,22 @@ const card: Card = {
 		en: "Five of them are troopers, and one is the brass. The brass's orders are absolute."
 	},
 
-	thirdParty: {
-		cardmarket: 456493,
-		tcgplayer: 213200
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 457958,
+				tcgplayer: 213200
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 457958,
+				tcgplayer: 213200
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Rebel Clash/11.ts
+++ b/data/Sword & Shield/Rebel Clash/11.ts
@@ -89,12 +89,6 @@ const card: Card = {
 	types: ["Grass"],
 	regulationMark: "D",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	stage: "Stage1",
 
@@ -102,10 +96,22 @@ const card: Card = {
 		en: "Its thin, winglike antennae are highly absorbent. It waits out rainy days in tree hollows."
 	},
 
-	thirdParty: {
-		cardmarket: 457448,
-		tcgplayer: 213081
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 457448,
+				tcgplayer: 213081
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 457448,
+				tcgplayer: 213081
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Rebel Clash/110.ts
+++ b/data/Sword & Shield/Rebel Clash/110.ts
@@ -79,20 +79,19 @@ const card: Card = {
 	types: ["Fighting"],
 	regulationMark: "D",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
 	stage: "Basic",
 	suffix: "V",
 
-	thirdParty: {
-		cardmarket: 456493,
-		tcgplayer: 213201
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 456493,
+				tcgplayer: 213201
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Rebel Clash/111.ts
+++ b/data/Sword & Shield/Rebel Clash/111.ts
@@ -77,12 +77,6 @@ const card: Card = {
 	types: ["Fighting"],
 	regulationMark: "D",
 
-	variants: {
-		normal: false,
-		reverse: true,
-		holo: true,
-		firstEdition: false
-	},
 
 	stage: "Basic",
 
@@ -90,10 +84,22 @@ const card: Card = {
 		en: "It stands in grasslands, watching the sun's descent from zenith to horizon. This Pokémon has a talent for delivering dynamic kicks."
 	},
 
-	thirdParty: {
-		cardmarket: 457963,
-		tcgplayer: 213203
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 457963,
+				tcgplayer: 213203
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 457963,
+				tcgplayer: 213203
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Rebel Clash/112.ts
+++ b/data/Sword & Shield/Rebel Clash/112.ts
@@ -49,12 +49,6 @@ const card: Card = {
 	types: ["Darkness"],
 	regulationMark: "D",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	stage: "Basic",
 
@@ -62,10 +56,22 @@ const card: Card = {
 		en: "Its body is full of poisonous gas. It floats into garbage dumps, seeking out the fumes of raw, rotting trash."
 	},
 
-	thirdParty: {
-		cardmarket: 457968,
-		tcgplayer: 213204
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 457968,
+				tcgplayer: 213204
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 457968,
+				tcgplayer: 213204
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Rebel Clash/113.ts
+++ b/data/Sword & Shield/Rebel Clash/113.ts
@@ -85,12 +85,6 @@ const card: Card = {
 	types: ["Darkness"],
 	regulationMark: "D",
 
-	variants: {
-		normal: false,
-		reverse: true,
-		holo: true,
-		firstEdition: false
-	},
 
 	stage: "Stage1",
 
@@ -98,10 +92,22 @@ const card: Card = {
 		en: "This Pokémon consumes particles that contaminate the air. Instead of leaving droppings, it expels clean air."
 	},
 
-	thirdParty: {
-		cardmarket: 457973,
-		tcgplayer: 213205
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 457973,
+				tcgplayer: 213205
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 457973,
+				tcgplayer: 213205
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Rebel Clash/114.ts
+++ b/data/Sword & Shield/Rebel Clash/114.ts
@@ -57,12 +57,6 @@ const card: Card = {
 	types: ["Darkness"],
 	regulationMark: "D",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	stage: "Basic",
 
@@ -70,10 +64,22 @@ const card: Card = {
 		en: "From its rear, it sprays a foul-smelling liquid at opponents. It aims for their faces, and it can hit them from over 16 feet away."
 	},
 
-	thirdParty: {
-		cardmarket: 457978,
-		tcgplayer: 213206
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 457978,
+				tcgplayer: 213206
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 457978,
+				tcgplayer: 213206
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Rebel Clash/115.ts
+++ b/data/Sword & Shield/Rebel Clash/115.ts
@@ -84,12 +84,6 @@ const card: Card = {
 	types: ["Darkness"],
 	regulationMark: "D",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	stage: "Stage1",
 
@@ -97,10 +91,22 @@ const card: Card = {
 		en: "In its belly, it reserves stinky fluid that it shoots from its tail during battle. As this Pokémon's diet varies, so does the stench of its fluid."
 	},
 
-	thirdParty: {
-		cardmarket: 457983,
-		tcgplayer: 213207
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 457983,
+				tcgplayer: 213207
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 457983,
+				tcgplayer: 213207
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Rebel Clash/116.ts
+++ b/data/Sword & Shield/Rebel Clash/116.ts
@@ -78,12 +78,6 @@ const card: Card = {
 	types: ["Darkness"],
 	regulationMark: "D",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	stage: "Basic",
 
@@ -91,10 +85,22 @@ const card: Card = {
 		en: "It was bound to a fissure in an Odd Keystone as punishment for misdeeds 500 years ago."
 	},
 
-	thirdParty: {
-		cardmarket: 457988,
-		tcgplayer: 213208
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 457988,
+				tcgplayer: 213208
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 457988,
+				tcgplayer: 213208
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Rebel Clash/117.ts
+++ b/data/Sword & Shield/Rebel Clash/117.ts
@@ -57,12 +57,6 @@ const card: Card = {
 	types: ["Darkness"],
 	regulationMark: "D",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	stage: "Basic",
 
@@ -70,10 +64,22 @@ const card: Card = {
 		en: "Its favorite places are unsanitary ones. If you leave trash lying around, you could even find one of these Pokémon living in your room."
 	},
 
-	thirdParty: {
-		cardmarket: 457993,
-		tcgplayer: 213209
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 457993,
+				tcgplayer: 213209
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 457993,
+				tcgplayer: 213209
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Rebel Clash/118.ts
+++ b/data/Sword & Shield/Rebel Clash/118.ts
@@ -81,12 +81,6 @@ const card: Card = {
 	types: ["Darkness"],
 	regulationMark: "D",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	stage: "Stage1",
 
@@ -94,10 +88,22 @@ const card: Card = {
 		en: "This Pokémon eats trash, which turns into poison inside its body. The main component of the poison depends on what sort of trash was eaten."
 	},
 
-	thirdParty: {
-		cardmarket: 457998,
-		tcgplayer: 213210
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 457998,
+				tcgplayer: 213210
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 457998,
+				tcgplayer: 213210
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Rebel Clash/119.ts
+++ b/data/Sword & Shield/Rebel Clash/119.ts
@@ -63,12 +63,6 @@ const card: Card = {
 	types: ["Darkness"],
 	regulationMark: "D",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	stage: "Basic",
 
@@ -76,10 +70,22 @@ const card: Card = {
 		en: "It wears a bone to protect its rear. It often squabbles with others of its kind over particularly comfy bones."
 	},
 
-	thirdParty: {
-		cardmarket: 458003,
-		tcgplayer: 213213
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 458003,
+				tcgplayer: 213213
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 458003,
+				tcgplayer: 213213
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Rebel Clash/12.ts
+++ b/data/Sword & Shield/Rebel Clash/12.ts
@@ -68,12 +68,6 @@ const card: Card = {
 	types: ["Grass"],
 	regulationMark: "D",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	stage: "Basic",
 
@@ -81,10 +75,22 @@ const card: Card = {
 		en: "It lives on snowy mountains. It sinks its legs into the snow to absorb water and keep its own temperature down."
 	},
 
-	thirdParty: {
-		cardmarket: 457453,
-		tcgplayer: 213082
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 457453,
+				tcgplayer: 213082
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 457453,
+				tcgplayer: 213082
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Rebel Clash/120.ts
+++ b/data/Sword & Shield/Rebel Clash/120.ts
@@ -95,12 +95,6 @@ const card: Card = {
 	types: ["Darkness"],
 	regulationMark: "D",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	stage: "Stage1",
 
@@ -108,10 +102,22 @@ const card: Card = {
 		en: "Although it's a bit of a ruffian, this Pokémon will take lost Vullaby under its wing and care for them till they're ready to leave the nest."
 	},
 
-	thirdParty: {
-		cardmarket: 458008,
-		tcgplayer: 213214
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 458008,
+				tcgplayer: 213214
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 458008,
+				tcgplayer: 213214
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Rebel Clash/121.ts
+++ b/data/Sword & Shield/Rebel Clash/121.ts
@@ -80,20 +80,19 @@ const card: Card = {
 	types: ["Darkness"],
 	regulationMark: "D",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
 	stage: "Basic",
 	suffix: "V",
 
-	thirdParty: {
-		cardmarket: 456513,
-		tcgplayer: 213215
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 456513,
+				tcgplayer: 213215
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Rebel Clash/122.ts
+++ b/data/Sword & Shield/Rebel Clash/122.ts
@@ -66,19 +66,18 @@ const card: Card = {
 	types: ["Darkness"],
 	regulationMark: "D",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
 	stage: "VMAX",
 
-	thirdParty: {
-		cardmarket: 456518,
-		tcgplayer: 213217
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 456518,
+				tcgplayer: 213217
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Rebel Clash/123.ts
+++ b/data/Sword & Shield/Rebel Clash/123.ts
@@ -65,12 +65,6 @@ const card: Card = {
 	types: ["Darkness"],
 	regulationMark: "D",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	stage: "Basic",
 
@@ -78,10 +72,22 @@ const card: Card = {
 		en: "Through its nose, it sucks in the emanations produced by people and Pokémon when they feel annoyed. It thrives off this negative energy."
 	},
 
-	thirdParty: {
-		cardmarket: 458013,
-		tcgplayer: 213219
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 458013,
+				tcgplayer: 213219
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 458013,
+				tcgplayer: 213219
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Rebel Clash/124.ts
+++ b/data/Sword & Shield/Rebel Clash/124.ts
@@ -82,12 +82,6 @@ const card: Card = {
 	types: ["Darkness"],
 	regulationMark: "D",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	stage: "Stage1",
 
@@ -95,10 +89,22 @@ const card: Card = {
 		en: "When it gets down on all fours as if to beg for forgiveness, it's trying to lure opponents in so that it can stab them with its spear-like hair."
 	},
 
-	thirdParty: {
-		cardmarket: 458018,
-		tcgplayer: 213220
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 458018,
+				tcgplayer: 213220
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 458018,
+				tcgplayer: 213220
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Rebel Clash/125.ts
+++ b/data/Sword & Shield/Rebel Clash/125.ts
@@ -88,12 +88,6 @@ const card: Card = {
 	types: ["Darkness"],
 	regulationMark: "D",
 
-	variants: {
-		normal: false,
-		reverse: true,
-		holo: true,
-		firstEdition: false
-	},
 
 	stage: "Stage2",
 
@@ -101,10 +95,22 @@ const card: Card = {
 		en: "With the hair wrapped around its body helping to enhance its muscles, this Pokémon can overwhelm even Machamp."
 	},
 
-	thirdParty: {
-		cardmarket: 458023,
-		tcgplayer: 213221
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 458023,
+				tcgplayer: 213221
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 458023,
+				tcgplayer: 213221
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Rebel Clash/126.ts
+++ b/data/Sword & Shield/Rebel Clash/126.ts
@@ -79,12 +79,6 @@ const card: Card = {
 	types: ["Metal"],
 	regulationMark: "D",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	stage: "Basic",
 
@@ -92,10 +86,22 @@ const card: Card = {
 		en: "Living with a savage, seafaring people has toughened this Pokémon's body so much that parts of it have turned to iron."
 	},
 
-	thirdParty: {
-		cardmarket: 458028,
-		tcgplayer: 213222
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 458028,
+				tcgplayer: 213222
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 458028,
+				tcgplayer: 213222
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Rebel Clash/127.ts
+++ b/data/Sword & Shield/Rebel Clash/127.ts
@@ -91,12 +91,6 @@ const card: Card = {
 	types: ["Metal"],
 	regulationMark: "D",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	stage: "Stage1",
 
@@ -104,10 +98,22 @@ const card: Card = {
 		en: "What appears to be an iron helmet is actually hardened hair. This Pokémon lives for the thrill of battle."
 	},
 
-	thirdParty: {
-		cardmarket: 457308,
-		tcgplayer: 213223
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 458033,
+				tcgplayer: 213223
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 458033,
+				tcgplayer: 213223
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Rebel Clash/128.ts
+++ b/data/Sword & Shield/Rebel Clash/128.ts
@@ -97,12 +97,6 @@ const card: Card = {
 	types: ["Metal"],
 	regulationMark: "D",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	stage: "Stage1",
 
@@ -110,10 +104,22 @@ const card: Card = {
 		en: "Once it has identified something as an enemy, it will continue beating them with its steel-hard pincers until there's nothing left but scraps."
 	},
 
-	thirdParty: {
-		cardmarket: 458038,
-		tcgplayer: 213224
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 458038,
+				tcgplayer: 213224
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 458038,
+				tcgplayer: 213224
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Rebel Clash/129.ts
+++ b/data/Sword & Shield/Rebel Clash/129.ts
@@ -73,12 +73,6 @@ const card: Card = {
 	types: ["Metal"],
 	regulationMark: "D",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	stage: "Basic",
 
@@ -86,10 +80,22 @@ const card: Card = {
 		en: "It appears in ancient ruins. The pattern on its body doesn't come from any culture in the Galar region, so it remains shrouded in mystery."
 	},
 
-	thirdParty: {
-		cardmarket: 458043,
-		tcgplayer: 213225
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 458043,
+				tcgplayer: 213225
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 458043,
+				tcgplayer: 213225
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Rebel Clash/13.ts
+++ b/data/Sword & Shield/Rebel Clash/13.ts
@@ -86,12 +86,6 @@ const card: Card = {
 	types: ["Grass"],
 	regulationMark: "D",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	stage: "Stage1",
 
@@ -99,10 +93,22 @@ const card: Card = {
 		en: "If it sees any packs of Darumaka going after Snover, it chases them off, swinging its sizable arms like hammers."
 	},
 
-	thirdParty: {
-		cardmarket: 457458,
-		tcgplayer: 213083
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 457458,
+				tcgplayer: 213083
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 457458,
+				tcgplayer: 213083
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Rebel Clash/130.ts
+++ b/data/Sword & Shield/Rebel Clash/130.ts
@@ -90,12 +90,6 @@ const card: Card = {
 	types: ["Metal"],
 	regulationMark: "D",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	stage: "Stage1",
 
@@ -103,10 +97,22 @@ const card: Card = {
 		en: "Some believe it to be a deity that summons rain clouds. When angered, it lets out a warning cry that rings out like the tolling of a bell."
 	},
 
-	thirdParty: {
-		cardmarket: 458048,
-		tcgplayer: 213226
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 458048,
+				tcgplayer: 213226
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 458048,
+				tcgplayer: 213226
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Rebel Clash/131.ts
+++ b/data/Sword & Shield/Rebel Clash/131.ts
@@ -90,12 +90,6 @@ const card: Card = {
 	types: ["Metal"],
 	regulationMark: "D",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	stage: "Stage1",
 
@@ -103,10 +97,22 @@ const card: Card = {
 		en: "It uses three small units to catch prey and battle enemies. The main body mostly just gives orders."
 	},
 
-	thirdParty: {
-		cardmarket: 458053,
-		tcgplayer: 213227
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 458053,
+				tcgplayer: 213227
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 458053,
+				tcgplayer: 213227
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Rebel Clash/132.ts
+++ b/data/Sword & Shield/Rebel Clash/132.ts
@@ -80,12 +80,6 @@ const card: Card = {
 	types: ["Metal"],
 	regulationMark: "D",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	stage: "Basic",
 
@@ -93,10 +87,22 @@ const card: Card = {
 		en: "They lay their eggs deep inside their nests. When attacked by Heatmor, they retaliate using their massive mandibles."
 	},
 
-	thirdParty: {
-		cardmarket: 458058,
-		tcgplayer: 213228
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 458058,
+				tcgplayer: 213228
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 458058,
+				tcgplayer: 213228
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Rebel Clash/133.ts
+++ b/data/Sword & Shield/Rebel Clash/133.ts
@@ -57,12 +57,6 @@ const card: Card = {
 	types: ["Metal"],
 	regulationMark: "D",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	stage: "Basic",
 
@@ -70,10 +64,22 @@ const card: Card = {
 		en: "Honedge's soul once belonged to a person who was killed a long time ago by the sword that makes up Honedge's body."
 	},
 
-	thirdParty: {
-		cardmarket: 458063,
-		tcgplayer: 213229
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 458063,
+				tcgplayer: 213229
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 458063,
+				tcgplayer: 213229
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Rebel Clash/134.ts
+++ b/data/Sword & Shield/Rebel Clash/134.ts
@@ -91,12 +91,6 @@ const card: Card = {
 	types: ["Metal"],
 	regulationMark: "D",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	stage: "Stage1",
 
@@ -104,10 +98,22 @@ const card: Card = {
 		en: "Honedge evolves into twins. The two blades rub together to emit a metallic sound that unnerves opponents."
 	},
 
-	thirdParty: {
-		cardmarket: 458068,
-		tcgplayer: 213230
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 458068,
+				tcgplayer: 213230
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 458068,
+				tcgplayer: 213230
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Rebel Clash/135.ts
+++ b/data/Sword & Shield/Rebel Clash/135.ts
@@ -89,12 +89,6 @@ const card: Card = {
 	types: ["Metal"],
 	regulationMark: "D",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	stage: "Stage2",
 
@@ -102,10 +96,22 @@ const card: Card = {
 		en: "In this defensive stance, Aegislash uses its steel body and a force field of spectral power to reduce the damage of any attack."
 	},
 
-	thirdParty: {
-		cardmarket: 458073,
-		tcgplayer: 213231
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 458073,
+				tcgplayer: 213231
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 458073,
+				tcgplayer: 213231
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Rebel Clash/136.ts
+++ b/data/Sword & Shield/Rebel Clash/136.ts
@@ -84,20 +84,19 @@ const card: Card = {
 	types: ["Metal"],
 	regulationMark: "D",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
 	stage: "Basic",
 	suffix: "V",
 
-	thirdParty: {
-		cardmarket: 456523,
-		tcgplayer: 213232
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 458078,
+				tcgplayer: 213232
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Rebel Clash/137.ts
+++ b/data/Sword & Shield/Rebel Clash/137.ts
@@ -92,19 +92,18 @@ const card: Card = {
 	types: ["Metal"],
 	regulationMark: "D",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
 	stage: "VMAX",
 
-	thirdParty: {
-		cardmarket: 456523,
-		tcgplayer: 213234
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 456523,
+				tcgplayer: 213234
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Rebel Clash/138.ts
+++ b/data/Sword & Shield/Rebel Clash/138.ts
@@ -81,12 +81,6 @@ const card: Card = {
 	types: ["Metal"],
 	regulationMark: "D",
 
-	variants: {
-		normal: false,
-		reverse: true,
-		holo: true,
-		firstEdition: false
-	},
 
 	stage: "Basic",
 
@@ -94,10 +88,22 @@ const card: Card = {
 		en: "Its body resembles polished metal, and it's both lightweight and strong. The only drawback is that it rusts easily."
 	},
 
-	thirdParty: {
-		cardmarket: 458083,
-		tcgplayer: 213236
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 458083,
+				tcgplayer: 213236
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 458083,
+				tcgplayer: 213236
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Rebel Clash/139.ts
+++ b/data/Sword & Shield/Rebel Clash/139.ts
@@ -89,12 +89,6 @@ const card: Card = {
 	types: ["Metal"],
 	regulationMark: "D",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	stage: "Basic",
 
@@ -102,10 +96,22 @@ const card: Card = {
 		en: "Now armed with a weapon it used in ancient times, this Pokémon needs only a single strike to fell even Gigantamax Pokémon."
 	},
 
-	thirdParty: {
-		cardmarket: 453298,
-		tcgplayer: 213237
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 453298,
+				tcgplayer: 213237
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 453298,
+				tcgplayer: 213237
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Rebel Clash/14.ts
+++ b/data/Sword & Shield/Rebel Clash/14.ts
@@ -72,12 +72,6 @@ const card: Card = {
 	types: ["Grass"],
 	regulationMark: "D",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	stage: "Basic",
 
@@ -85,10 +79,22 @@ const card: Card = {
 		en: "After a lost child perished in the forest, their spirit possessed a tree stump, causing the spirit's rebirth as this Pokémon."
 	},
 
-	thirdParty: {
-		cardmarket: 457463,
-		tcgplayer: 213084
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 457463,
+				tcgplayer: 213084
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 457463,
+				tcgplayer: 213084
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Rebel Clash/140.ts
+++ b/data/Sword & Shield/Rebel Clash/140.ts
@@ -89,12 +89,6 @@ const card: Card = {
 	types: ["Metal"],
 	regulationMark: "D",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	stage: "Basic",
 
@@ -102,10 +96,22 @@ const card: Card = {
 		en: "Its ability to deflect any attack led to it being known as the Fighting Master's Shield. It was feared and respected by all."
 	},
 
-	thirdParty: {
-		cardmarket: 453303,
-		tcgplayer: 213240
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 453303,
+				tcgplayer: 213240
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 453303,
+				tcgplayer: 213240
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Rebel Clash/141.ts
+++ b/data/Sword & Shield/Rebel Clash/141.ts
@@ -80,12 +80,6 @@ const card: Card = {
 	types: ["Colorless"],
 	regulationMark: "D",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	stage: "Basic",
 
@@ -93,10 +87,22 @@ const card: Card = {
 		en: "It is not satisfied unless it eats over 880 pounds of food every day. When it is done eating, it goes promptly to sleep."
 	},
 
-	thirdParty: {
-		cardmarket: 458093,
-		tcgplayer: 213241
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 458093,
+				tcgplayer: 213241
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 458093,
+				tcgplayer: 213241
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Rebel Clash/142.ts
+++ b/data/Sword & Shield/Rebel Clash/142.ts
@@ -79,12 +79,6 @@ const card: Card = {
 	types: ["Colorless"],
 	regulationMark: "D",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	stage: "Basic",
 
@@ -92,10 +86,22 @@ const card: Card = {
 		en: "It can learn and speak human words. If they gather, they all learn the same saying."
 	},
 
-	thirdParty: {
-		cardmarket: 458098,
-		tcgplayer: 213242
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 458098,
+				tcgplayer: 213242
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 458098,
+				tcgplayer: 213242
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Rebel Clash/143.ts
+++ b/data/Sword & Shield/Rebel Clash/143.ts
@@ -79,12 +79,6 @@ const card: Card = {
 	types: ["Colorless"],
 	regulationMark: "D",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	stage: "Basic",
 
@@ -92,10 +86,22 @@ const card: Card = {
 		en: "Where people go, these Pokémon follow. If you're scattering food for them, be careful—several hundred of them can gather at once."
 	},
 
-	thirdParty: {
-		cardmarket: 458103,
-		tcgplayer: 213243
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 458103,
+				tcgplayer: 213243
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 458103,
+				tcgplayer: 213243
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Rebel Clash/144.ts
+++ b/data/Sword & Shield/Rebel Clash/144.ts
@@ -84,12 +84,6 @@ const card: Card = {
 	types: ["Colorless"],
 	regulationMark: "D",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	stage: "Stage1",
 
@@ -97,10 +91,22 @@ const card: Card = {
 		en: "It can fly moderately quickly. No matter how far it travels, it can always find its way back to its master and its nest."
 	},
 
-	thirdParty: {
-		cardmarket: 458108,
-		tcgplayer: 213244
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 458108,
+				tcgplayer: 213244
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 458108,
+				tcgplayer: 213244
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Rebel Clash/145.ts
+++ b/data/Sword & Shield/Rebel Clash/145.ts
@@ -98,12 +98,6 @@ const card: Card = {
 	types: ["Colorless"],
 	regulationMark: "D",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	stage: "Stage2",
 
@@ -111,10 +105,22 @@ const card: Card = {
 		en: "Unfezant are exceptional fliers. The females are known for their stamina, while the males outclass them in terms of speed."
 	},
 
-	thirdParty: {
-		cardmarket: 458123,
-		tcgplayer: 213245
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 458123,
+				tcgplayer: 213245
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 458123,
+				tcgplayer: 213245
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Rebel Clash/146.ts
+++ b/data/Sword & Shield/Rebel Clash/146.ts
@@ -73,12 +73,6 @@ const card: Card = {
 	types: ["Colorless"],
 	regulationMark: "D",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	stage: "Basic",
 
@@ -86,10 +80,22 @@ const card: Card = {
 		en: "It excels at digging holes. Using its ears, it can dig a nest 33 feet deep in one night."
 	},
 
-	thirdParty: {
-		cardmarket: 458128,
-		tcgplayer: 213246
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 458128,
+				tcgplayer: 213246
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 458128,
+				tcgplayer: 213246
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Rebel Clash/147.ts
+++ b/data/Sword & Shield/Rebel Clash/147.ts
@@ -86,12 +86,6 @@ const card: Card = {
 	types: ["Colorless"],
 	regulationMark: "D",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	stage: "Stage1",
 
@@ -99,10 +93,22 @@ const card: Card = {
 		en: "With power equal to an excavator, it can dig through dense bedrock. It's a huge help during tunnel construction."
 	},
 
-	thirdParty: {
-		cardmarket: 458133,
-		tcgplayer: 213247
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 458133,
+				tcgplayer: 213247
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 458133,
+				tcgplayer: 213247
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Rebel Clash/148.ts
+++ b/data/Sword & Shield/Rebel Clash/148.ts
@@ -78,12 +78,6 @@ const card: Card = {
 	types: ["Colorless"],
 	regulationMark: "D",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	stage: "Basic",
 
@@ -91,10 +85,22 @@ const card: Card = {
 		en: "It drives its opponents to exhaustion with its agile maneuvers, then ends the fight with a flashy finishing move."
 	},
 
-	thirdParty: {
-		cardmarket: 458138,
-		tcgplayer: 213248
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 458138,
+				tcgplayer: 213248
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 458138,
+				tcgplayer: 213248
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Rebel Clash/149.ts
+++ b/data/Sword & Shield/Rebel Clash/149.ts
@@ -74,12 +74,6 @@ const card: Card = {
 	types: ["Colorless"],
 	regulationMark: "D",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	stage: "Basic",
 
@@ -87,10 +81,22 @@ const card: Card = {
 		en: "Its fluffy fur is a delight to pet, but carelessly reaching out to touch this Pokémon could result in painful retaliation."
 	},
 
-	thirdParty: {
-		cardmarket: 458143,
-		tcgplayer: 213249
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 458143,
+				tcgplayer: 213249
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 458143,
+				tcgplayer: 213249
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Rebel Clash/15.ts
+++ b/data/Sword & Shield/Rebel Clash/15.ts
@@ -83,12 +83,6 @@ const card: Card = {
 	types: ["Grass"],
 	regulationMark: "D",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	stage: "Stage1",
 
@@ -96,10 +90,22 @@ const card: Card = {
 		en: "People fear it due to a belief that it devours any who try to cut down trees in its forest, but to the Pokémon it shares its woods with, it's kind."
 	},
 
-	thirdParty: {
-		cardmarket: 457468,
-		tcgplayer: 213085
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 457468,
+				tcgplayer: 213085
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 457468,
+				tcgplayer: 213085
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Rebel Clash/150.ts
+++ b/data/Sword & Shield/Rebel Clash/150.ts
@@ -92,12 +92,6 @@ const card: Card = {
 	types: ["Colorless"],
 	regulationMark: "D",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	stage: "Stage1",
 
@@ -105,10 +99,22 @@ const card: Card = {
 		en: "Once it accepts you as a friend, it tries to show its affection with a hug. Letting it do that is dangerous—it could easily shatter your bones."
 	},
 
-	thirdParty: {
-		cardmarket: 458148,
-		tcgplayer: 213250
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 458148,
+				tcgplayer: 213250
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 458148,
+				tcgplayer: 213250
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Rebel Clash/151.ts
+++ b/data/Sword & Shield/Rebel Clash/151.ts
@@ -65,12 +65,6 @@ const card: Card = {
 	types: ["Colorless"],
 	regulationMark: "D",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	stage: "Basic",
 
@@ -78,10 +72,22 @@ const card: Card = {
 		en: "Found throughout the Galar region, this Pokémon becomes uneasy if its cheeks are ever completely empty of berries."
 	},
 
-	thirdParty: {
-		cardmarket: 458153,
-		tcgplayer: 213251
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 458153,
+				tcgplayer: 213251
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 458153,
+				tcgplayer: 213251
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Rebel Clash/152.ts
+++ b/data/Sword & Shield/Rebel Clash/152.ts
@@ -81,12 +81,6 @@ const card: Card = {
 	types: ["Colorless"],
 	regulationMark: "D",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	stage: "Stage1",
 
@@ -94,10 +88,22 @@ const card: Card = {
 		en: "It stashes berries in its tail—so many berries that they fall out constantly. But this Pokémon is a bit slow-witted, so it doesn't notice the loss."
 	},
 
-	thirdParty: {
-		cardmarket: 458158,
-		tcgplayer: 213252
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 458158,
+				tcgplayer: 213252
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 458158,
+				tcgplayer: 213252
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Rebel Clash/153.ts
+++ b/data/Sword & Shield/Rebel Clash/153.ts
@@ -80,20 +80,19 @@ const card: Card = {
 	types: ["Colorless"],
 	regulationMark: "D",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
 	stage: "Basic",
 	suffix: "V",
 
-	thirdParty: {
-		cardmarket: 456528,
-		tcgplayer: 213253
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 456528,
+				tcgplayer: 213253
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Rebel Clash/154.ts
+++ b/data/Sword & Shield/Rebel Clash/154.ts
@@ -28,12 +28,36 @@ const card: Card = {
 	trainerType: "Supporter",
 	regulationMark: "D",
 
-	variants: {
-		normal: false,
-		reverse: true,
-		holo: true,
-		firstEdition: false
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 458163,
+				tcgplayer: 213255
+			}
+		},
+		{
+			type: 'holo',
+			stamp: ['regional-championships'],
+			thirdParty: {
+				cardmarket: 653294
+			}
+		},
+		{
+			type: 'holo',
+			stamp: ['regional-championships', 'staff'],
+			thirdParty: {
+				cardmarket: 653295
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 458163,
+				tcgplayer: 213255
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Rebel Clash/155.ts
+++ b/data/Sword & Shield/Rebel Clash/155.ts
@@ -28,17 +28,23 @@ const card: Card = {
 	trainerType: "Tool",
 	regulationMark: "D",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 458168,
-		tcgplayer: 213258
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 458168,
+				tcgplayer: 213258
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 458168,
+				tcgplayer: 213258
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Rebel Clash/156.ts
+++ b/data/Sword & Shield/Rebel Clash/156.ts
@@ -28,17 +28,23 @@ const card: Card = {
 	trainerType: "Item",
 	regulationMark: "D",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 458173,
-		tcgplayer: 213259
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 458173,
+				tcgplayer: 213259
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 458173,
+				tcgplayer: 213259
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Rebel Clash/157.ts
+++ b/data/Sword & Shield/Rebel Clash/157.ts
@@ -28,17 +28,23 @@ const card: Card = {
 	trainerType: "Tool",
 	regulationMark: "D",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 458178,
-		tcgplayer: 213260
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 458178,
+				tcgplayer: 213260
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 458178,
+				tcgplayer: 213260
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Rebel Clash/158.ts
+++ b/data/Sword & Shield/Rebel Clash/158.ts
@@ -28,17 +28,23 @@ const card: Card = {
 	trainerType: "Supporter",
 	regulationMark: "D",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 458183,
-		tcgplayer: 213261
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 458183,
+				tcgplayer: 213261
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 458183,
+				tcgplayer: 213261
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Rebel Clash/159.ts
+++ b/data/Sword & Shield/Rebel Clash/159.ts
@@ -28,17 +28,23 @@ const card: Card = {
 	trainerType: "Item",
 	regulationMark: "D",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 458188,
-		tcgplayer: 213262
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 458188,
+				tcgplayer: 213262
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 458188,
+				tcgplayer: 213262
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Rebel Clash/16.ts
+++ b/data/Sword & Shield/Rebel Clash/16.ts
@@ -49,12 +49,6 @@ const card: Card = {
 	types: ["Grass"],
 	regulationMark: "D",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	stage: "Basic",
 
@@ -62,10 +56,22 @@ const card: Card = {
 		en: "Its natural enemies, like Rookidee, may flee rather than risk getting caught in its large mandibles that can snap thick tree branches."
 	},
 
-	thirdParty: {
-		cardmarket: 457473,
-		tcgplayer: 213086
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 457473,
+				tcgplayer: 213086
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 457473,
+				tcgplayer: 213086
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Rebel Clash/160.ts
+++ b/data/Sword & Shield/Rebel Clash/160.ts
@@ -28,17 +28,23 @@ const card: Card = {
 	trainerType: "Stadium",
 	regulationMark: "D",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 458193,
-		tcgplayer: 213263
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 458193,
+				tcgplayer: 213263
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 458193,
+				tcgplayer: 213263
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Rebel Clash/161.ts
+++ b/data/Sword & Shield/Rebel Clash/161.ts
@@ -28,17 +28,23 @@ const card: Card = {
 	trainerType: "Supporter",
 	regulationMark: "D",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 457328,
-		tcgplayer: 213264
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 458198,
+				tcgplayer: 213264
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 458198,
+				tcgplayer: 213264
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Rebel Clash/162.ts
+++ b/data/Sword & Shield/Rebel Clash/162.ts
@@ -28,17 +28,23 @@ const card: Card = {
 	trainerType: "Item",
 	regulationMark: "D",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 458203,
-		tcgplayer: 213267
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 458203,
+				tcgplayer: 213267
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 458203,
+				tcgplayer: 213267
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Rebel Clash/163.ts
+++ b/data/Sword & Shield/Rebel Clash/163.ts
@@ -28,17 +28,23 @@ const card: Card = {
 	trainerType: "Supporter",
 	regulationMark: "D",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 456583,
-		tcgplayer: 213268
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 458208,
+				tcgplayer: 213268
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 458208,
+				tcgplayer: 213268
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Rebel Clash/164.ts
+++ b/data/Sword & Shield/Rebel Clash/164.ts
@@ -28,16 +28,23 @@ const card: Card = {
 	trainerType: "Item",
 	regulationMark: "D",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 458213
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 458213,
+				tcgplayer: 213271
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 458213,
+				tcgplayer: 213271
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Rebel Clash/165.ts
+++ b/data/Sword & Shield/Rebel Clash/165.ts
@@ -28,17 +28,23 @@ const card: Card = {
 	trainerType: "Item",
 	regulationMark: "D",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 456533,
-		tcgplayer: 213272
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 456533,
+				tcgplayer: 213272
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 456533,
+				tcgplayer: 213272
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Rebel Clash/166.ts
+++ b/data/Sword & Shield/Rebel Clash/166.ts
@@ -28,17 +28,23 @@ const card: Card = {
 	trainerType: "Supporter",
 	regulationMark: "D",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 458218,
-		tcgplayer: 213274
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 458218,
+				tcgplayer: 213274
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 458218,
+				tcgplayer: 213274
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Rebel Clash/167.ts
+++ b/data/Sword & Shield/Rebel Clash/167.ts
@@ -28,17 +28,23 @@ const card: Card = {
 	trainerType: "Supporter",
 	regulationMark: "D",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 457318,
-		tcgplayer: 213275
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 458223,
+				tcgplayer: 213275
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 458223,
+				tcgplayer: 213275
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Rebel Clash/168.ts
+++ b/data/Sword & Shield/Rebel Clash/168.ts
@@ -28,17 +28,23 @@ const card: Card = {
 	trainerType: "Item",
 	regulationMark: "D",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 456538,
-		tcgplayer: 213278
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 456538,
+				tcgplayer: 213278
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 456538,
+				tcgplayer: 213278
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Rebel Clash/169.ts
+++ b/data/Sword & Shield/Rebel Clash/169.ts
@@ -28,17 +28,23 @@ const card: Card = {
 	trainerType: "Stadium",
 	regulationMark: "D",
 
-	variants: {
-		normal: true,
-		reverse: false,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 458228,
-		tcgplayer: 213280
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 458228,
+				tcgplayer: 213280
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 458228,
+				tcgplayer: 213280
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Rebel Clash/17.ts
+++ b/data/Sword & Shield/Rebel Clash/17.ts
@@ -81,20 +81,19 @@ const card: Card = {
 	types: ["Grass"],
 	regulationMark: "D",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
 	stage: "Basic",
 	suffix: "V",
 
-	thirdParty: {
-		cardmarket: 456408,
-		tcgplayer: 213087
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 457478,
+				tcgplayer: 213087
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Rebel Clash/170.ts
+++ b/data/Sword & Shield/Rebel Clash/170.ts
@@ -28,17 +28,23 @@ const card: Card = {
 	trainerType: "Stadium",
 	regulationMark: "D",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 458233,
-		tcgplayer: 213281
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 458233,
+				tcgplayer: 213281
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 458233,
+				tcgplayer: 213281
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Rebel Clash/171.ts
+++ b/data/Sword & Shield/Rebel Clash/171.ts
@@ -28,17 +28,23 @@ const card: Card = {
 	energyType: "Special",
 	regulationMark: "D",
 
-	variants: {
-		normal: true,
-		reverse: false,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 456553,
-		tcgplayer: 213282
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 456553,
+				tcgplayer: 213282
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 456553,
+				tcgplayer: 213282
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Rebel Clash/172.ts
+++ b/data/Sword & Shield/Rebel Clash/172.ts
@@ -28,12 +28,22 @@ const card: Card = {
 	energyType: "Special",
 	regulationMark: "D",
 
-	variants: {
-		normal: true,
-		reverse: false,
-		holo: false,
-		firstEdition: false
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 458238,
+				tcgplayer: 213283
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 458238,
+				tcgplayer: 213283
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Rebel Clash/173.ts
+++ b/data/Sword & Shield/Rebel Clash/173.ts
@@ -28,12 +28,22 @@ const card: Card = {
 	energyType: "Special",
 	regulationMark: "D",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 458243,
+				tcgplayer: 213284
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 458243,
+				tcgplayer: 213284
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Rebel Clash/174.ts
+++ b/data/Sword & Shield/Rebel Clash/174.ts
@@ -28,17 +28,30 @@ const card: Card = {
 	energyType: "Special",
 	regulationMark: "D",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 456563,
-		tcgplayer: 213285
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 456563,
+				tcgplayer: 213285
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 456563,
+				tcgplayer: 213285
+			}
+		},
+		{
+			type: 'reverse',
+			stamp: ['poke-ball-league'],
+			thirdParty: {
+				cardmarket: 701484
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Rebel Clash/175.ts
+++ b/data/Sword & Shield/Rebel Clash/175.ts
@@ -81,20 +81,19 @@ const card: Card = {
 	types: ["Grass"],
 	regulationMark: "D",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
 	stage: "Basic",
 	suffix: "V",
 
-	thirdParty: {
-		cardmarket: 458248,
-		tcgplayer: 213088
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 458248,
+				tcgplayer: 213088
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Rebel Clash/176.ts
+++ b/data/Sword & Shield/Rebel Clash/176.ts
@@ -79,20 +79,19 @@ const card: Card = {
 	types: ["Grass"],
 	regulationMark: "D",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
 	stage: "Basic",
 	suffix: "V",
 
-	thirdParty: {
-		cardmarket: 458253,
-		tcgplayer: 213092
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 458253,
+				tcgplayer: 213092
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Rebel Clash/177.ts
+++ b/data/Sword & Shield/Rebel Clash/177.ts
@@ -82,20 +82,19 @@ const card: Card = {
 	types: ["Fire"],
 	regulationMark: "D",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
 	stage: "Basic",
 	suffix: "V",
 
-	thirdParty: {
-		cardmarket: 458258,
-		tcgplayer: 213102
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 458258,
+				tcgplayer: 213102
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Rebel Clash/178.ts
+++ b/data/Sword & Shield/Rebel Clash/178.ts
@@ -73,20 +73,19 @@ const card: Card = {
 	types: ["Fire"],
 	regulationMark: "D",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
 	stage: "Basic",
 	suffix: "V",
 
-	thirdParty: {
-		cardmarket: 458263,
-		tcgplayer: 213112
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 458263,
+				tcgplayer: 213112
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Rebel Clash/179.ts
+++ b/data/Sword & Shield/Rebel Clash/179.ts
@@ -83,20 +83,19 @@ const card: Card = {
 	types: ["Water"],
 	regulationMark: "D",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
 	stage: "Basic",
 	suffix: "V",
 
-	thirdParty: {
-		cardmarket: 458268,
-		tcgplayer: 213122
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 458268,
+				tcgplayer: 213122
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Rebel Clash/18.ts
+++ b/data/Sword & Shield/Rebel Clash/18.ts
@@ -82,19 +82,18 @@ const card: Card = {
 	types: ["Grass"],
 	regulationMark: "D",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
 	stage: "VMAX",
 
-	thirdParty: {
-		cardmarket: 456408,
-		tcgplayer: 213089
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 456408,
+				tcgplayer: 213089
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Rebel Clash/180.ts
+++ b/data/Sword & Shield/Rebel Clash/180.ts
@@ -80,20 +80,19 @@ const card: Card = {
 	types: ["Water"],
 	regulationMark: "D",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
 	stage: "Basic",
 	suffix: "V",
 
-	thirdParty: {
-		cardmarket: 458273,
-		tcgplayer: 213129
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 458273,
+				tcgplayer: 213129
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Rebel Clash/181.ts
+++ b/data/Sword & Shield/Rebel Clash/181.ts
@@ -79,20 +79,19 @@ const card: Card = {
 	types: ["Lightning"],
 	regulationMark: "D",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
 	stage: "Basic",
 	suffix: "V",
 
-	thirdParty: {
-		cardmarket: 458278,
-		tcgplayer: 213151
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 458278,
+				tcgplayer: 213151
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Rebel Clash/182.ts
+++ b/data/Sword & Shield/Rebel Clash/182.ts
@@ -81,20 +81,19 @@ const card: Card = {
 	types: ["Lightning"],
 	regulationMark: "D",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
 	stage: "Basic",
 	suffix: "V",
 
-	thirdParty: {
-		cardmarket: 458283,
-		tcgplayer: 213155
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 458283,
+				tcgplayer: 213155
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Rebel Clash/183.ts
+++ b/data/Sword & Shield/Rebel Clash/183.ts
@@ -80,20 +80,19 @@ const card: Card = {
 	types: ["Psychic"],
 	regulationMark: "D",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
 	stage: "Basic",
 	suffix: "V",
 
-	thirdParty: {
-		cardmarket: 458288,
-		tcgplayer: 213179
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 458288,
+				tcgplayer: 213179
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Rebel Clash/184.ts
+++ b/data/Sword & Shield/Rebel Clash/184.ts
@@ -80,20 +80,19 @@ const card: Card = {
 	types: ["Fighting"],
 	regulationMark: "D",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
 	stage: "Basic",
 	suffix: "V",
 
-	thirdParty: {
-		cardmarket: 458293,
-		tcgplayer: 213199
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 458293,
+				tcgplayer: 213199
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Rebel Clash/185.ts
+++ b/data/Sword & Shield/Rebel Clash/185.ts
@@ -79,20 +79,19 @@ const card: Card = {
 	types: ["Fighting"],
 	regulationMark: "D",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
 	stage: "Basic",
 	suffix: "V",
 
-	thirdParty: {
-		cardmarket: 458298,
-		tcgplayer: 213202
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 458298,
+				tcgplayer: 213202
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Rebel Clash/186.ts
+++ b/data/Sword & Shield/Rebel Clash/186.ts
@@ -80,20 +80,19 @@ const card: Card = {
 	types: ["Darkness"],
 	regulationMark: "D",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
 	stage: "Basic",
 	suffix: "V",
 
-	thirdParty: {
-		cardmarket: 458303,
-		tcgplayer: 213216
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 458303,
+				tcgplayer: 213216
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Rebel Clash/187.ts
+++ b/data/Sword & Shield/Rebel Clash/187.ts
@@ -84,20 +84,19 @@ const card: Card = {
 	types: ["Metal"],
 	regulationMark: "D",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
 	stage: "Basic",
 	suffix: "V",
 
-	thirdParty: {
-		cardmarket: 458308,
-		tcgplayer: 213233
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 458308,
+				tcgplayer: 213233
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Rebel Clash/188.ts
+++ b/data/Sword & Shield/Rebel Clash/188.ts
@@ -80,20 +80,19 @@ const card: Card = {
 	types: ["Colorless"],
 	regulationMark: "D",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
 	stage: "Basic",
 	suffix: "V",
 
-	thirdParty: {
-		cardmarket: 458313,
-		tcgplayer: 213254
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 458313,
+				tcgplayer: 213254
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Rebel Clash/189.ts
+++ b/data/Sword & Shield/Rebel Clash/189.ts
@@ -28,12 +28,15 @@ const card: Card = {
 	trainerType: "Supporter",
 	regulationMark: "D",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: false,
-		firstEdition: false
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 456578,
+				tcgplayer: 213256
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Rebel Clash/19.ts
+++ b/data/Sword & Shield/Rebel Clash/19.ts
@@ -79,20 +79,19 @@ const card: Card = {
 	types: ["Grass"],
 	regulationMark: "D",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
 	stage: "Basic",
 	suffix: "V",
 
-	thirdParty: {
-		cardmarket: 457553,
-		tcgplayer: 213091
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 457553,
+				tcgplayer: 213091
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Rebel Clash/190.ts
+++ b/data/Sword & Shield/Rebel Clash/190.ts
@@ -28,17 +28,16 @@ const card: Card = {
 	trainerType: "Supporter",
 	regulationMark: "D",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 457378,
-		tcgplayer: 213265
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 457378,
+				tcgplayer: 213265
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Rebel Clash/191.ts
+++ b/data/Sword & Shield/Rebel Clash/191.ts
@@ -28,17 +28,16 @@ const card: Card = {
 	trainerType: "Supporter",
 	regulationMark: "D",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 456583,
-		tcgplayer: 213269
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 456583,
+				tcgplayer: 213269
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Rebel Clash/192.ts
+++ b/data/Sword & Shield/Rebel Clash/192.ts
@@ -28,17 +28,16 @@ const card: Card = {
 	trainerType: "Supporter",
 	regulationMark: "D",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 457373,
-		tcgplayer: 213276
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 457373,
+				tcgplayer: 213276
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Rebel Clash/193.ts
+++ b/data/Sword & Shield/Rebel Clash/193.ts
@@ -72,19 +72,19 @@ const card: Card = {
 	retreat: 3,
 	regulationMark: "D",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
 	stage: "VMAX",
 
-	thirdParty: {
-		cardmarket: 457368,
-		tcgplayer: 213090
-	}
+	variants: [
+		{
+			type: 'holo',
+			foil: 'rainbow',
+			thirdParty: {
+				cardmarket: 457368,
+				tcgplayer: 213090
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Rebel Clash/194.ts
+++ b/data/Sword & Shield/Rebel Clash/194.ts
@@ -81,19 +81,19 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "D",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
 	stage: "VMAX",
 
-	thirdParty: {
-		cardmarket: 457363,
-		tcgplayer: 213114
-	}
+	variants: [
+		{
+			type: 'holo',
+			foil: 'rainbow',
+			thirdParty: {
+				cardmarket: 457363,
+				tcgplayer: 213114
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Rebel Clash/195.ts
+++ b/data/Sword & Shield/Rebel Clash/195.ts
@@ -81,19 +81,19 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "D",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
 	stage: "VMAX",
 
-	thirdParty: {
-		cardmarket: 457358,
-		tcgplayer: 213131
-	}
+	variants: [
+		{
+			type: 'holo',
+			foil: 'rainbow',
+			thirdParty: {
+				cardmarket: 457358,
+				tcgplayer: 213131
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Rebel Clash/196.ts
+++ b/data/Sword & Shield/Rebel Clash/196.ts
@@ -60,19 +60,19 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "D",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
 	stage: "VMAX",
 
-	thirdParty: {
-		cardmarket: 457353,
-		tcgplayer: 213157
-	}
+	variants: [
+		{
+			type: 'holo',
+			foil: 'rainbow',
+			thirdParty: {
+				cardmarket: 457353,
+				tcgplayer: 213157
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Rebel Clash/197.ts
+++ b/data/Sword & Shield/Rebel Clash/197.ts
@@ -86,19 +86,19 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "D",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
 	stage: "VMAX",
 
-	thirdParty: {
-		cardmarket: 457348,
-		tcgplayer: 213181
-	}
+	variants: [
+		{
+			type: 'holo',
+			foil: 'rainbow',
+			thirdParty: {
+				cardmarket: 457348,
+				tcgplayer: 213181
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Rebel Clash/198.ts
+++ b/data/Sword & Shield/Rebel Clash/198.ts
@@ -60,19 +60,19 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "D",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
 	stage: "VMAX",
 
-	thirdParty: {
-		cardmarket: 457343,
-		tcgplayer: 213218
-	}
+	variants: [
+		{
+			type: 'holo',
+			foil: 'rainbow',
+			thirdParty: {
+				cardmarket: 457343,
+				tcgplayer: 213218
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Rebel Clash/199.ts
+++ b/data/Sword & Shield/Rebel Clash/199.ts
@@ -77,19 +77,19 @@ const card: Card = {
 	retreat: 4,
 	regulationMark: "D",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
 	stage: "VMAX",
 
-	thirdParty: {
-		cardmarket: 457338,
-		tcgplayer: 213235
-	}
+	variants: [
+		{
+			type: 'holo',
+			foil: 'rainbow',
+			thirdParty: {
+				cardmarket: 457338,
+				tcgplayer: 213235
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Rebel Clash/2.ts
+++ b/data/Sword & Shield/Rebel Clash/2.ts
@@ -81,12 +81,6 @@ const card: Card = {
 	types: ["Grass"],
 	regulationMark: "D",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	stage: "Stage1",
 
@@ -94,10 +88,22 @@ const card: Card = {
 		en: "It is waiting for the moment to evolve. At this stage, it can only harden, so it remains motionless to avoid attack."
 	},
 
-	thirdParty: {
-		cardmarket: 457388,
-		tcgplayer: 213072
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 457388,
+				tcgplayer: 213072
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 457388,
+				tcgplayer: 213072
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Rebel Clash/20.ts
+++ b/data/Sword & Shield/Rebel Clash/20.ts
@@ -57,12 +57,6 @@ const card: Card = {
 	types: ["Grass"],
 	regulationMark: "D",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	stage: "Basic",
 
@@ -70,10 +64,22 @@ const card: Card = {
 		en: "It spends its entire life inside an apple. It hides from its natural enemies, bird Pokémon, by pretending it's just an apple and nothing more."
 	},
 
-	thirdParty: {
-		cardmarket: 457558,
-		tcgplayer: 213093
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 457558,
+				tcgplayer: 213093
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 457558,
+				tcgplayer: 213093
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Rebel Clash/200.ts
+++ b/data/Sword & Shield/Rebel Clash/200.ts
@@ -29,12 +29,16 @@ const card: Card = {
 	trainerType: "Supporter",
 	regulationMark: "D",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	}
+	variants: [
+		{
+			type: 'holo',
+			foil: 'rainbow',
+			thirdParty: {
+				cardmarket: 457333,
+				tcgplayer: 213257
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Rebel Clash/201.ts
+++ b/data/Sword & Shield/Rebel Clash/201.ts
@@ -29,17 +29,17 @@ const card: Card = {
 	trainerType: "Supporter",
 	regulationMark: "D",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 457328,
-		tcgplayer: 213266
-	}
+	variants: [
+		{
+			type: 'holo',
+			foil: 'rainbow',
+			thirdParty: {
+				cardmarket: 457328,
+				tcgplayer: 213266
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Rebel Clash/202.ts
+++ b/data/Sword & Shield/Rebel Clash/202.ts
@@ -29,17 +29,17 @@ const card: Card = {
 	trainerType: "Supporter",
 	regulationMark: "D",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 457323,
-		tcgplayer: 213270
-	}
+	variants: [
+		{
+			type: 'holo',
+			foil: 'rainbow',
+			thirdParty: {
+				cardmarket: 457323,
+				tcgplayer: 213270
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Rebel Clash/203.ts
+++ b/data/Sword & Shield/Rebel Clash/203.ts
@@ -29,17 +29,17 @@ const card: Card = {
 	trainerType: "Supporter",
 	regulationMark: "D",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 457318,
-		tcgplayer: 213277
-	}
+	variants: [
+		{
+			type: 'holo',
+			foil: 'rainbow',
+			thirdParty: {
+				cardmarket: 457318,
+				tcgplayer: 213277
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Rebel Clash/204.ts
+++ b/data/Sword & Shield/Rebel Clash/204.ts
@@ -73,12 +73,6 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "D",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
 	stage: "Stage1",
 
@@ -86,10 +80,16 @@ const card: Card = {
 		en: "It shows no mercy to any who desecrate fields and mountains. It will fly around on its icy wings, causing a blizzard to chase offenders away."
 	},
 
-	thirdParty: {
-		cardmarket: 457313,
-		tcgplayer: 213287
-	}
+	variants: [
+		{
+			type: 'holo',
+			foil: 'gold',
+			thirdParty: {
+				cardmarket: 457313,
+				tcgplayer: 213287
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Rebel Clash/205.ts
+++ b/data/Sword & Shield/Rebel Clash/205.ts
@@ -78,12 +78,6 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "D",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
 	stage: "Stage1",
 
@@ -91,10 +85,16 @@ const card: Card = {
 		en: "What appears to be an iron helmet is actually hardened hair. This Pokémon lives for the thrill of battle."
 	},
 
-	thirdParty: {
-		cardmarket: 457308,
-		tcgplayer: 213288
-	}
+	variants: [
+		{
+			type: 'holo',
+			foil: 'gold',
+			thirdParty: {
+				cardmarket: 457308,
+				tcgplayer: 213288
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Rebel Clash/206.ts
+++ b/data/Sword & Shield/Rebel Clash/206.ts
@@ -29,17 +29,17 @@ const card: Card = {
 	trainerType: "Tool",
 	regulationMark: "D",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 457303,
-		tcgplayer: 213289
-	}
+	variants: [
+		{
+			type: 'holo',
+			foil: 'gold',
+			thirdParty: {
+				cardmarket: 457303,
+				tcgplayer: 213289
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Rebel Clash/207.ts
+++ b/data/Sword & Shield/Rebel Clash/207.ts
@@ -29,17 +29,17 @@ const card: Card = {
 	trainerType: "Item",
 	regulationMark: "D",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 457298,
-		tcgplayer: 213273
-	}
+	variants: [
+		{
+			type: 'holo',
+			foil: 'gold',
+			thirdParty: {
+				cardmarket: 457298,
+				tcgplayer: 213273
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Rebel Clash/208.ts
+++ b/data/Sword & Shield/Rebel Clash/208.ts
@@ -29,17 +29,17 @@ const card: Card = {
 	trainerType: "Item",
 	regulationMark: "D",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 457293,
-		tcgplayer: 213279
-	}
+	variants: [
+		{
+			type: 'holo',
+			foil: 'gold',
+			thirdParty: {
+				cardmarket: 457293,
+				tcgplayer: 213279
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Rebel Clash/209.ts
+++ b/data/Sword & Shield/Rebel Clash/209.ts
@@ -28,17 +28,17 @@ const card: Card = {
 	energyType: "Special",
 	regulationMark: "D",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 457288,
-		tcgplayer: 213286
-	}
+	variants: [
+		{
+			type: 'holo',
+			foil: 'gold',
+			thirdParty: {
+				cardmarket: 457288,
+				tcgplayer: 213286
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Rebel Clash/21.ts
+++ b/data/Sword & Shield/Rebel Clash/21.ts
@@ -55,12 +55,6 @@ const card: Card = {
 	types: ["Grass"],
 	regulationMark: "D",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	stage: "Basic",
 
@@ -68,10 +62,22 @@ const card: Card = {
 		en: "It spends its entire life inside an apple. It hides from its natural enemies, bird Pokémon, by pretending it's just an apple and nothing more."
 	},
 
-	thirdParty: {
-		cardmarket: 457558,
-		tcgplayer: 213094
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 457563,
+				tcgplayer: 213094
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 457563,
+				tcgplayer: 213094
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Rebel Clash/22.ts
+++ b/data/Sword & Shield/Rebel Clash/22.ts
@@ -88,12 +88,6 @@ const card: Card = {
 	types: ["Grass"],
 	regulationMark: "D",
 
-	variants: {
-		normal: false,
-		reverse: true,
-		holo: true,
-		firstEdition: false
-	},
 
 	stage: "Stage1",
 
@@ -101,10 +95,36 @@ const card: Card = {
 		en: "It ate a sour apple, and that induced its evolution. In its cheeks, it stores an acid capable of causing chemical burns."
 	},
 
-	thirdParty: {
-		cardmarket: 456413,
-		tcgplayer: 213095
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 456413,
+				tcgplayer: 213095
+			}
+		},
+		{
+			type: 'holo',
+			stamp: ['gamestop'],
+			thirdParty: {
+				cardmarket: 550346
+			}
+		},
+		{
+			type: 'holo',
+			stamp: ['eb-games'],
+			thirdParty: {
+				cardmarket: 569896
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 456413,
+				tcgplayer: 213095
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Rebel Clash/23.ts
+++ b/data/Sword & Shield/Rebel Clash/23.ts
@@ -81,12 +81,6 @@ const card: Card = {
 	types: ["Grass"],
 	regulationMark: "D",
 
-	variants: {
-		normal: false,
-		reverse: true,
-		holo: true,
-		firstEdition: false
-	},
 
 	stage: "Stage1",
 
@@ -94,10 +88,22 @@ const card: Card = {
 		en: "Eating a sweet apple caused its evolution. A nectarous scent wafts from its body, luring in the bug Pokémon it preys on."
 	},
 
-	thirdParty: {
-		cardmarket: 456418,
-		tcgplayer: 213098
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 456418,
+				tcgplayer: 213098
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 456418,
+				tcgplayer: 213098
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Rebel Clash/24.ts
+++ b/data/Sword & Shield/Rebel Clash/24.ts
@@ -72,12 +72,6 @@ const card: Card = {
 	types: ["Fire"],
 	regulationMark: "D",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	stage: "Basic",
 
@@ -85,10 +79,22 @@ const card: Card = {
 		en: "While young, it has six gorgeous tails. When it grows, several new tails are sprouted."
 	},
 
-	thirdParty: {
-		cardmarket: 457568,
-		tcgplayer: 213099
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 457568,
+				tcgplayer: 213099
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 457568,
+				tcgplayer: 213099
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Rebel Clash/25.ts
+++ b/data/Sword & Shield/Rebel Clash/25.ts
@@ -90,12 +90,6 @@ const card: Card = {
 	types: ["Fire"],
 	regulationMark: "D",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	stage: "Stage1",
 
@@ -103,10 +97,22 @@ const card: Card = {
 		en: "It is said to live 1,000 years, and each of its tails is loaded with supernatural powers."
 	},
 
-	thirdParty: {
-		cardmarket: 457573,
-		tcgplayer: 213100
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 457573,
+				tcgplayer: 213100
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 457573,
+				tcgplayer: 213100
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Rebel Clash/26.ts
+++ b/data/Sword & Shield/Rebel Clash/26.ts
@@ -82,20 +82,19 @@ const card: Card = {
 	types: ["Fire"],
 	regulationMark: "D",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
 	stage: "Basic",
 	suffix: "V",
 
-	thirdParty: {
-		cardmarket: 457578,
-		tcgplayer: 213101
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 457578,
+				tcgplayer: 213101
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Rebel Clash/27.ts
+++ b/data/Sword & Shield/Rebel Clash/27.ts
@@ -73,12 +73,6 @@ const card: Card = {
 	types: ["Fire"],
 	regulationMark: "D",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	stage: "Basic",
 
@@ -86,10 +80,22 @@ const card: Card = {
 		en: "It has a brave and trustworthy nature. It fearlessly stands up to bigger and stronger foes."
 	},
 
-	thirdParty: {
-		cardmarket: 457588,
-		tcgplayer: 213103
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 457588,
+				tcgplayer: 213103
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 457588,
+				tcgplayer: 213103
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Rebel Clash/28.ts
+++ b/data/Sword & Shield/Rebel Clash/28.ts
@@ -82,12 +82,6 @@ const card: Card = {
 	types: ["Fire"],
 	regulationMark: "D",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	stage: "Stage1",
 
@@ -95,10 +89,22 @@ const card: Card = {
 		en: "The sight of it running over 6,200 miles in a single day and night has captivated many people."
 	},
 
-	thirdParty: {
-		cardmarket: 457593,
-		tcgplayer: 213104
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 457593,
+				tcgplayer: 213104
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 457593,
+				tcgplayer: 213104
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Rebel Clash/29.ts
+++ b/data/Sword & Shield/Rebel Clash/29.ts
@@ -73,12 +73,6 @@ const card: Card = {
 	types: ["Fire"],
 	regulationMark: "D",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	stage: "Basic",
 
@@ -86,10 +80,22 @@ const card: Card = {
 		en: "Its entire body is burning. When it breathes, the temperature rises. When it sneezes, flames shoot out!"
 	},
 
-	thirdParty: {
-		cardmarket: 457603,
-		tcgplayer: 213105
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 457603,
+				tcgplayer: 213105
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 457603,
+				tcgplayer: 213105
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Rebel Clash/3.ts
+++ b/data/Sword & Shield/Rebel Clash/3.ts
@@ -82,12 +82,6 @@ const card: Card = {
 	types: ["Grass"],
 	regulationMark: "D",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: true,
-		firstEdition: false
-	},
 
 	stage: "Stage2",
 
@@ -95,10 +89,28 @@ const card: Card = {
 		en: "In battle, it flaps its wings at great speed to release highly toxic dust into the air."
 	},
 
-	thirdParty: {
-		cardmarket: 457393,
-		tcgplayer: 213073
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 457393,
+				tcgplayer: 213073
+			}
+		},
+		{
+			type: 'holo',
+			thirdParty: {
+				tcgplayer: 213073
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 457393,
+				tcgplayer: 213073
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Rebel Clash/30.ts
+++ b/data/Sword & Shield/Rebel Clash/30.ts
@@ -91,12 +91,6 @@ const card: Card = {
 	types: ["Fire"],
 	regulationMark: "D",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	stage: "Stage1",
 
@@ -104,10 +98,22 @@ const card: Card = {
 		en: "Magmortar takes down its enemies by shooting fireballs, which burn them to a blackened crisp. It avoids this method when hunting prey."
 	},
 
-	thirdParty: {
-		cardmarket: 457608,
-		tcgplayer: 213106
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 457608,
+				tcgplayer: 213106
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 457608,
+				tcgplayer: 213106
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Rebel Clash/31.ts
+++ b/data/Sword & Shield/Rebel Clash/31.ts
@@ -55,12 +55,6 @@ const card: Card = {
 	types: ["Fire"],
 	regulationMark: "D",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	stage: "Basic",
 
@@ -68,10 +62,22 @@ const card: Card = {
 		en: "The flame on its head keeps its body slightly warm. This Pokémon takes lost children by the hand to guide them to the spirit world."
 	},
 
-	thirdParty: {
-		cardmarket: 457613,
-		tcgplayer: 213107
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 457613,
+				tcgplayer: 213107
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 457613,
+				tcgplayer: 213107
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Rebel Clash/32.ts
+++ b/data/Sword & Shield/Rebel Clash/32.ts
@@ -87,12 +87,6 @@ const card: Card = {
 	types: ["Fire"],
 	regulationMark: "D",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	stage: "Stage1",
 
@@ -100,10 +94,22 @@ const card: Card = {
 		en: "This Pokémon appears just before someone passes away, so it's feared as an emissary of death."
 	},
 
-	thirdParty: {
-		cardmarket: 457618,
-		tcgplayer: 213108
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 457618,
+				tcgplayer: 213108
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 457618,
+				tcgplayer: 213108
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Rebel Clash/33.ts
+++ b/data/Sword & Shield/Rebel Clash/33.ts
@@ -88,12 +88,6 @@ const card: Card = {
 	types: ["Fire"],
 	regulationMark: "D",
 
-	variants: {
-		normal: false,
-		reverse: true,
-		holo: true,
-		firstEdition: false
-	},
 
 	stage: "Stage2",
 
@@ -101,10 +95,22 @@ const card: Card = {
 		en: "This Pokémon haunts dilapidated mansions. It sways its arms to hypnotize opponents with the ominous dancing of its flames."
 	},
 
-	thirdParty: {
-		cardmarket: 457623,
-		tcgplayer: 213109
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 457623,
+				tcgplayer: 213109
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 457623,
+				tcgplayer: 213109
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Rebel Clash/34.ts
+++ b/data/Sword & Shield/Rebel Clash/34.ts
@@ -81,12 +81,6 @@ const card: Card = {
 	types: ["Fire"],
 	regulationMark: "D",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	stage: "Basic",
 
@@ -94,10 +88,22 @@ const card: Card = {
 		en: "There's a hole in its tail that allows it to draw in the air it needs to keep its fire burning. If the hole gets blocked, this Pokémon will fall ill."
 	},
 
-	thirdParty: {
-		cardmarket: 457628,
-		tcgplayer: 213110
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 457628,
+				tcgplayer: 213110
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 457628,
+				tcgplayer: 213110
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Rebel Clash/35.ts
+++ b/data/Sword & Shield/Rebel Clash/35.ts
@@ -73,20 +73,19 @@ const card: Card = {
 	types: ["Fire"],
 	regulationMark: "D",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
 	stage: "Basic",
 	suffix: "V",
 
-	thirdParty: {
-		cardmarket: 456423,
-		tcgplayer: 213111
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 457633,
+				tcgplayer: 213111
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Rebel Clash/36.ts
+++ b/data/Sword & Shield/Rebel Clash/36.ts
@@ -90,19 +90,18 @@ const card: Card = {
 	types: ["Fire"],
 	regulationMark: "D",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
 	stage: "VMAX",
 
-	thirdParty: {
-		cardmarket: 456423,
-		tcgplayer: 213113
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 456423,
+				tcgplayer: 213113
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Rebel Clash/37.ts
+++ b/data/Sword & Shield/Rebel Clash/37.ts
@@ -79,12 +79,6 @@ const card: Card = {
 	types: ["Water"],
 	regulationMark: "D",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	stage: "Basic",
 
@@ -92,10 +86,22 @@ const card: Card = {
 		en: "Its talent is tap-dancing. It can also manipulate temperatures to create a floor of ice, which this Pokémon can kick up to use as a barrier."
 	},
 
-	thirdParty: {
-		cardmarket: 456433,
-		tcgplayer: 213115
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 456433,
+				tcgplayer: 213115
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 456433,
+				tcgplayer: 213115
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Rebel Clash/38.ts
+++ b/data/Sword & Shield/Rebel Clash/38.ts
@@ -87,12 +87,6 @@ const card: Card = {
 	types: ["Water"],
 	regulationMark: "D",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	stage: "Stage1",
 
@@ -100,10 +94,22 @@ const card: Card = {
 		en: "It's highly skilled at tap-dancing. It waves its cane of ice in time with its graceful movements."
 	},
 
-	thirdParty: {
-		cardmarket: 456428,
-		tcgplayer: 213116
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 456428,
+				tcgplayer: 213116
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 456428,
+				tcgplayer: 213116
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Rebel Clash/39.ts
+++ b/data/Sword & Shield/Rebel Clash/39.ts
@@ -55,12 +55,6 @@ const card: Card = {
 	types: ["Water"],
 	regulationMark: "D",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	stage: "Basic",
 
@@ -68,10 +62,22 @@ const card: Card = {
 		en: "It is virtually worthless in terms of both power and speed. It is the most weak and pathetic Pokémon in the world."
 	},
 
-	thirdParty: {
-		cardmarket: 457638,
-		tcgplayer: 213117
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 457638,
+				tcgplayer: 213117
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 457638,
+				tcgplayer: 213117
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Rebel Clash/4.ts
+++ b/data/Sword & Shield/Rebel Clash/4.ts
@@ -71,12 +71,6 @@ const card: Card = {
 	types: ["Grass"],
 	regulationMark: "D",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	stage: "Basic",
 
@@ -84,10 +78,22 @@ const card: Card = {
 		en: "Its two sharp scythes are more than just weapons. It uses them with dexterity to dress its prey before eating."
 	},
 
-	thirdParty: {
-		cardmarket: 457398,
-		tcgplayer: 213074
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 457398,
+				tcgplayer: 213074
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 457398,
+				tcgplayer: 213074
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Rebel Clash/40.ts
+++ b/data/Sword & Shield/Rebel Clash/40.ts
@@ -87,12 +87,6 @@ const card: Card = {
 	types: ["Water"],
 	regulationMark: "D",
 
-	variants: {
-		normal: false,
-		reverse: true,
-		holo: true,
-		firstEdition: false
-	},
 
 	stage: "Stage1",
 
@@ -100,10 +94,22 @@ const card: Card = {
 		en: "It has an extremely aggressive nature. The Hyper Beam it shoots from its mouth totally incinerates all targets."
 	},
 
-	thirdParty: {
-		cardmarket: 457643,
-		tcgplayer: 213118
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 457643,
+				tcgplayer: 213118
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 457643,
+				tcgplayer: 213118
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Rebel Clash/41.ts
+++ b/data/Sword & Shield/Rebel Clash/41.ts
@@ -79,12 +79,6 @@ const card: Card = {
 	types: ["Water"],
 	regulationMark: "D",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	stage: "Basic",
 
@@ -92,10 +86,22 @@ const card: Card = {
 		en: "It makes its nest on sheer cliffs. Riding the sea breeze, it glides up into the expansive skies."
 	},
 
-	thirdParty: {
-		cardmarket: 457648,
-		tcgplayer: 213119
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 457648,
+				tcgplayer: 213119
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 457648,
+				tcgplayer: 213119
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Rebel Clash/42.ts
+++ b/data/Sword & Shield/Rebel Clash/42.ts
@@ -91,12 +91,6 @@ const card: Card = {
 	types: ["Water"],
 	regulationMark: "D",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	stage: "Stage1",
 
@@ -104,10 +98,22 @@ const card: Card = {
 		en: "It is a messenger of the skies, carrying small Pokémon and eggs to safety in its bill."
 	},
 
-	thirdParty: {
-		cardmarket: 457653,
-		tcgplayer: 213120
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 457653,
+				tcgplayer: 213120
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 457653,
+				tcgplayer: 213120
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Rebel Clash/43.ts
+++ b/data/Sword & Shield/Rebel Clash/43.ts
@@ -83,20 +83,19 @@ const card: Card = {
 	types: ["Water"],
 	regulationMark: "D",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
 	stage: "Basic",
 	suffix: "V",
 
-	thirdParty: {
-		cardmarket: 457658,
-		tcgplayer: 213121
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 457658,
+				tcgplayer: 213121
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Rebel Clash/44.ts
+++ b/data/Sword & Shield/Rebel Clash/44.ts
@@ -55,12 +55,6 @@ const card: Card = {
 	types: ["Water"],
 	regulationMark: "D",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	stage: "Basic",
 
@@ -68,10 +62,22 @@ const card: Card = {
 		en: "Graceful ripples running across the water's surface are a sure sign that Tympole are singing in high-pitched voices below."
 	},
 
-	thirdParty: {
-		cardmarket: 457663,
-		tcgplayer: 213123
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 457663,
+				tcgplayer: 213123
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 457663,
+				tcgplayer: 213123
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Rebel Clash/45.ts
+++ b/data/Sword & Shield/Rebel Clash/45.ts
@@ -66,12 +66,6 @@ const card: Card = {
 	types: ["Water"],
 	regulationMark: "D",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	stage: "Stage1",
 
@@ -79,10 +73,22 @@ const card: Card = {
 		en: "It weakens its prey with sound waves intense enough to cause headaches, then entangles them with its sticky tongue."
 	},
 
-	thirdParty: {
-		cardmarket: 457668,
-		tcgplayer: 213124
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 457668,
+				tcgplayer: 213124
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 457668,
+				tcgplayer: 213124
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Rebel Clash/46.ts
+++ b/data/Sword & Shield/Rebel Clash/46.ts
@@ -91,12 +91,6 @@ const card: Card = {
 	types: ["Water"],
 	regulationMark: "D",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	stage: "Stage2",
 
@@ -104,10 +98,22 @@ const card: Card = {
 		en: "The vibrating of the bumps all over its body causes earthquake-like tremors. Seismitoad and Croagunk are similar species."
 	},
 
-	thirdParty: {
-		cardmarket: 457673,
-		tcgplayer: 213125
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 457673,
+				tcgplayer: 213125
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 457673,
+				tcgplayer: 213125
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Rebel Clash/47.ts
+++ b/data/Sword & Shield/Rebel Clash/47.ts
@@ -56,12 +56,6 @@ const card: Card = {
 	types: ["Water"],
 	regulationMark: "D",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	stage: "Basic",
 
@@ -69,10 +63,22 @@ const card: Card = {
 		en: "It lived in snowy areas for so long that its fire sac cooled off and atrophied. It now has an organ that generates cold instead."
 	},
 
-	thirdParty: {
-		cardmarket: 457678,
-		tcgplayer: 213126
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 457678,
+				tcgplayer: 213126
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 457678,
+				tcgplayer: 213126
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Rebel Clash/48.ts
+++ b/data/Sword & Shield/Rebel Clash/48.ts
@@ -92,12 +92,6 @@ const card: Card = {
 	types: ["Water"],
 	regulationMark: "D",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	stage: "Stage1",
 
@@ -105,10 +99,22 @@ const card: Card = {
 		en: "On days when blizzards blow through, it comes down to where people live. It stashes food in the snowball on its head, taking it home for later."
 	},
 
-	thirdParty: {
-		cardmarket: 457683,
-		tcgplayer: 213127
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 457683,
+				tcgplayer: 213127
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 457683,
+				tcgplayer: 213127
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Rebel Clash/49.ts
+++ b/data/Sword & Shield/Rebel Clash/49.ts
@@ -80,20 +80,19 @@ const card: Card = {
 	types: ["Water"],
 	regulationMark: "D",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
 	stage: "Basic",
 	suffix: "V",
 
-	thirdParty: {
-		cardmarket: 456438,
-		tcgplayer: 213128
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 457688,
+				tcgplayer: 213128
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Rebel Clash/5.ts
+++ b/data/Sword & Shield/Rebel Clash/5.ts
@@ -80,12 +80,6 @@ const card: Card = {
 	types: ["Grass"],
 	regulationMark: "D",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	stage: "Basic",
 
@@ -93,10 +87,22 @@ const card: Card = {
 		en: "It stores berries inside its shell. To avoid attacks, it hides beneath rocks and remains completely still."
 	},
 
-	thirdParty: {
-		cardmarket: 457403,
-		tcgplayer: 213075
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 457403,
+				tcgplayer: 213075
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 457403,
+				tcgplayer: 213075
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Rebel Clash/50.ts
+++ b/data/Sword & Shield/Rebel Clash/50.ts
@@ -98,17 +98,16 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "D",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 456438,
-		tcgplayer: 213130
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 456438,
+				tcgplayer: 213130
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Rebel Clash/51.ts
+++ b/data/Sword & Shield/Rebel Clash/51.ts
@@ -88,12 +88,6 @@ const card: Card = {
 	types: ["Water"],
 	regulationMark: "D",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	stage: "Basic",
 
@@ -101,10 +95,22 @@ const card: Card = {
 		en: "It's so strong that it can knock out some opponents in a single hit, but it also may forget what it's battling midfight."
 	},
 
-	thirdParty: {
-		cardmarket: 457693,
-		tcgplayer: 213132
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 457693,
+				tcgplayer: 213132
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 457693,
+				tcgplayer: 213132
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Rebel Clash/52.ts
+++ b/data/Sword & Shield/Rebel Clash/52.ts
@@ -49,12 +49,6 @@ const card: Card = {
 	types: ["Water"],
 	regulationMark: "D",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	stage: "Basic",
 
@@ -62,10 +56,22 @@ const card: Card = {
 		en: "If it sees any movement around it, this Pokémon charges for it straightaway, leading with its sharply pointed jaw. It's very proud of that jaw."
 	},
 
-	thirdParty: {
-		cardmarket: 457698,
-		tcgplayer: 213133
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 457698,
+				tcgplayer: 213133
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 457698,
+				tcgplayer: 213133
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Rebel Clash/53.ts
+++ b/data/Sword & Shield/Rebel Clash/53.ts
@@ -80,12 +80,6 @@ const card: Card = {
 	types: ["Water"],
 	regulationMark: "D",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	stage: "Stage1",
 
@@ -93,10 +87,22 @@ const card: Card = {
 		en: "This Pokémon has a jaw that's as sharp as a spear and as strong as steel. Apparently Barraskewda's flesh is surprisingly tasty, too."
 	},
 
-	thirdParty: {
-		cardmarket: 457703,
-		tcgplayer: 213134
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 457703,
+				tcgplayer: 213134
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 457703,
+				tcgplayer: 213134
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Rebel Clash/54.ts
+++ b/data/Sword & Shield/Rebel Clash/54.ts
@@ -80,12 +80,6 @@ const card: Card = {
 	types: ["Water"],
 	regulationMark: "D",
 
-	variants: {
-		normal: false,
-		reverse: true,
-		holo: true,
-		firstEdition: false
-	},
 
 	stage: "Basic",
 
@@ -93,10 +87,29 @@ const card: Card = {
 		en: "It drifted in on the flow of ocean waters from a frigid place. It keeps its head iced constantly to make sure it stays nice and cold."
 	},
 
-	thirdParty: {
-		cardmarket: 456448,
-		tcgplayer: 213135
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 457708,
+				tcgplayer: 213135
+			}
+		},
+		{
+			type: 'holo',
+			foil: 'cosmos',
+			thirdParty: {
+				cardmarket: 883767
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 457708,
+				tcgplayer: 213135
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Rebel Clash/55.ts
+++ b/data/Sword & Shield/Rebel Clash/55.ts
@@ -79,20 +79,26 @@ const card: Card = {
 	types: ["Water"],
 	regulationMark: "D",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
 	stage: "Basic",
 	suffix: "V",
 
-	thirdParty: {
-		cardmarket: 456448,
-		tcgplayer: 213136
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 456448,
+				tcgplayer: 213136
+			}
+		},
+		{
+			type: 'holo',
+			stamp: ['snowflake'],
+			thirdParty: {
+				cardmarket: 672383
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Rebel Clash/56.ts
+++ b/data/Sword & Shield/Rebel Clash/56.ts
@@ -56,12 +56,6 @@ const card: Card = {
 	types: ["Lightning"],
 	regulationMark: "D",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	stage: "Basic",
 
@@ -69,10 +63,22 @@ const card: Card = {
 		en: "Usually found in power plants. Easily mistaken for a Poké Ball, it has zapped many people."
 	},
 
-	thirdParty: {
-		cardmarket: 457713,
-		tcgplayer: 213137
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 457713,
+				tcgplayer: 213137
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 457713,
+				tcgplayer: 213137
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Rebel Clash/57.ts
+++ b/data/Sword & Shield/Rebel Clash/57.ts
@@ -81,12 +81,6 @@ const card: Card = {
 	regulationMark: "D",
 	retreat: 0,
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	stage: "Stage1",
 
@@ -94,10 +88,22 @@ const card: Card = {
 		en: "It stores an overflowing amount of electric energy inside its body. Even a small shock makes it explode."
 	},
 
-	thirdParty: {
-		cardmarket: 457718,
-		tcgplayer: 213138
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 457718,
+				tcgplayer: 213138
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 457718,
+				tcgplayer: 213138
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Rebel Clash/58.ts
+++ b/data/Sword & Shield/Rebel Clash/58.ts
@@ -67,12 +67,6 @@ const card: Card = {
 	types: ["Lightning"],
 	regulationMark: "D",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	stage: "Basic",
 
@@ -80,10 +74,22 @@ const card: Card = {
 		en: "While it's often blamed for power outages, the truth is the cause of outages is more often an error on the part of the electric company."
 	},
 
-	thirdParty: {
-		cardmarket: 457723,
-		tcgplayer: 213139
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 457723,
+				tcgplayer: 213139
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 457723,
+				tcgplayer: 213139
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Rebel Clash/59.ts
+++ b/data/Sword & Shield/Rebel Clash/59.ts
@@ -91,12 +91,6 @@ const card: Card = {
 	types: ["Lightning"],
 	regulationMark: "D",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	stage: "Stage1",
 
@@ -104,10 +98,22 @@ const card: Card = {
 		en: "A single Electivire can provide enough electricity for all the buildings in a big city for a year."
 	},
 
-	thirdParty: {
-		cardmarket: 457728,
-		tcgplayer: 213140
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 457728,
+				tcgplayer: 213140
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 457728,
+				tcgplayer: 213140
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Rebel Clash/6.ts
+++ b/data/Sword & Shield/Rebel Clash/6.ts
@@ -75,12 +75,6 @@ const card: Card = {
 	types: ["Grass"],
 	regulationMark: "D",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	stage: "Basic",
 
@@ -88,10 +82,22 @@ const card: Card = {
 		en: "It roams through forests searching for sweet nectar. Although it boasts fantastic physical strength, it's not that good at flying."
 	},
 
-	thirdParty: {
-		cardmarket: 457408,
-		tcgplayer: 213076
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 457408,
+				tcgplayer: 213076
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 457408,
+				tcgplayer: 213076
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Rebel Clash/60.ts
+++ b/data/Sword & Shield/Rebel Clash/60.ts
@@ -56,12 +56,6 @@ const card: Card = {
 	types: ["Lightning"],
 	regulationMark: "D",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	stage: "Basic",
 
@@ -69,10 +63,22 @@ const card: Card = {
 		en: "All of its fur dazzles if danger is sensed. It flees while the foe is momentarily blinded."
 	},
 
-	thirdParty: {
-		cardmarket: 457733,
-		tcgplayer: 213141
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 457733,
+				tcgplayer: 213141
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 457733,
+				tcgplayer: 213141
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Rebel Clash/61.ts
+++ b/data/Sword & Shield/Rebel Clash/61.ts
@@ -80,12 +80,6 @@ const card: Card = {
 	types: ["Lightning"],
 	regulationMark: "D",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	stage: "Stage1",
 
@@ -93,10 +87,22 @@ const card: Card = {
 		en: "Strong electricity courses through the tips of its sharp claws. A light scratch causes fainting in foes."
 	},
 
-	thirdParty: {
-		cardmarket: 457738,
-		tcgplayer: 213142
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 457738,
+				tcgplayer: 213142
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 457738,
+				tcgplayer: 213142
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Rebel Clash/62.ts
+++ b/data/Sword & Shield/Rebel Clash/62.ts
@@ -82,12 +82,6 @@ const card: Card = {
 	types: ["Lightning"],
 	regulationMark: "D",
 
-	variants: {
-		normal: false,
-		reverse: true,
-		holo: true,
-		firstEdition: false
-	},
 
 	stage: "Stage2",
 
@@ -95,10 +89,22 @@ const card: Card = {
 		en: "Luxray's ability to see through objects comes in handy when it's scouting for danger."
 	},
 
-	thirdParty: {
-		cardmarket: 457743,
-		tcgplayer: 213143
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 457743,
+				tcgplayer: 213143
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 457743,
+				tcgplayer: 213143
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Rebel Clash/63.ts
+++ b/data/Sword & Shield/Rebel Clash/63.ts
@@ -56,12 +56,6 @@ const card: Card = {
 	types: ["Lightning"],
 	regulationMark: "D",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	stage: "Basic",
 
@@ -69,10 +63,22 @@ const card: Card = {
 		en: "When spread, the frills on its head act like solar panels, generating the power behind this Pokémon's electric moves."
 	},
 
-	thirdParty: {
-		cardmarket: 457748,
-		tcgplayer: 213146
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 457748,
+				tcgplayer: 213146
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 457748,
+				tcgplayer: 213146
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Rebel Clash/64.ts
+++ b/data/Sword & Shield/Rebel Clash/64.ts
@@ -88,12 +88,6 @@ const card: Card = {
 	types: ["Lightning"],
 	regulationMark: "D",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	stage: "Stage1",
 
@@ -101,10 +95,22 @@ const card: Card = {
 		en: "A now-vanished desert culture treasured these Pokémon. Appropriately, when Heliolisk came to the Galar region, treasure came with them."
 	},
 
-	thirdParty: {
-		cardmarket: 457753,
-		tcgplayer: 213147
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 457753,
+				tcgplayer: 213147
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 457753,
+				tcgplayer: 213147
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Rebel Clash/65.ts
+++ b/data/Sword & Shield/Rebel Clash/65.ts
@@ -82,12 +82,6 @@ const card: Card = {
 	types: ["Lightning"],
 	regulationMark: "D",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	stage: "Stage1",
 
@@ -95,10 +89,22 @@ const card: Card = {
 		en: "While its durable shell protects it from attacks, Charjabug strikes at enemies with jolts of electricity discharged from the tips of its jaws."
 	},
 
-	thirdParty: {
-		cardmarket: 457758,
-		tcgplayer: 213148
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 457758,
+				tcgplayer: 213148
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 457758,
+				tcgplayer: 213148
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Rebel Clash/66.ts
+++ b/data/Sword & Shield/Rebel Clash/66.ts
@@ -93,12 +93,6 @@ const card: Card = {
 	types: ["Lightning"],
 	regulationMark: "D",
 
-	variants: {
-		normal: false,
-		reverse: true,
-		holo: true,
-		firstEdition: false
-	},
 
 	stage: "Stage2",
 
@@ -106,10 +100,22 @@ const card: Card = {
 		en: "It builds up electricity in its abdomen, focuses it through its jaws, and then fires the electricity off in concentrated beams."
 	},
 
-	thirdParty: {
-		cardmarket: 457763,
-		tcgplayer: 213149
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 457763,
+				tcgplayer: 213149
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 457763,
+				tcgplayer: 213149
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Rebel Clash/67.ts
+++ b/data/Sword & Shield/Rebel Clash/67.ts
@@ -79,20 +79,19 @@ const card: Card = {
 	types: ["Lightning"],
 	regulationMark: "D",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
 	stage: "Basic",
 	suffix: "V",
 
-	thirdParty: {
-		cardmarket: 456453,
-		tcgplayer: 213150
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 456453,
+				tcgplayer: 213150
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Rebel Clash/68.ts
+++ b/data/Sword & Shield/Rebel Clash/68.ts
@@ -55,12 +55,6 @@ const card: Card = {
 	types: ["Lightning"],
 	regulationMark: "D",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	stage: "Basic",
 
@@ -68,10 +62,22 @@ const card: Card = {
 		en: "It stores poison in an internal poison sac and secretes that poison through its skin. If you touch this Pokémon, a tingling sensation follows."
 	},
 
-	thirdParty: {
-		cardmarket: 457768,
-		tcgplayer: 213152
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 457768,
+				tcgplayer: 213152
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 457768,
+				tcgplayer: 213152
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Rebel Clash/69.ts
+++ b/data/Sword & Shield/Rebel Clash/69.ts
@@ -81,12 +81,6 @@ const card: Card = {
 	types: ["Lightning"],
 	regulationMark: "D",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	stage: "Stage1",
 
@@ -94,10 +88,22 @@ const card: Card = {
 		en: "When this Pokémon sounds as if it's strumming a guitar, it's actually clawing at the protrusions on its chest to generate electricity."
 	},
 
-	thirdParty: {
-		cardmarket: 456468,
-		tcgplayer: 213153
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 457773,
+				tcgplayer: 213153
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 457773,
+				tcgplayer: 213153
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Rebel Clash/7.ts
+++ b/data/Sword & Shield/Rebel Clash/7.ts
@@ -73,12 +73,6 @@ const card: Card = {
 	types: ["Grass"],
 	regulationMark: "D",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	stage: "Basic",
 
@@ -86,10 +80,22 @@ const card: Card = {
 		en: "It searches about for clean water. If it does not drink water for too long, the leaf on its head wilts."
 	},
 
-	thirdParty: {
-		cardmarket: 457423,
-		tcgplayer: 213077
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 457423,
+				tcgplayer: 213077
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 457423,
+				tcgplayer: 213077
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Rebel Clash/70.ts
+++ b/data/Sword & Shield/Rebel Clash/70.ts
@@ -81,20 +81,27 @@ const card: Card = {
 	types: ["Lightning"],
 	regulationMark: "D",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
 	stage: "Basic",
 	suffix: "V",
 
-	thirdParty: {
-		cardmarket: 456468,
-		tcgplayer: 213154
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 456468,
+				tcgplayer: 213154
+			}
+		},
+		{
+			type: 'holo',
+			size: 'jumbo',
+			stamp: ['set-logo'],
+			thirdParty: {
+				cardmarket: 819399
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Rebel Clash/71.ts
+++ b/data/Sword & Shield/Rebel Clash/71.ts
@@ -66,19 +66,18 @@ const card: Card = {
 	types: ["Lightning"],
 	regulationMark: "D",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
 	stage: "VMAX",
 
-	thirdParty: {
-		cardmarket: 456478,
-		tcgplayer: 213156
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 456478,
+				tcgplayer: 213156
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Rebel Clash/72.ts
+++ b/data/Sword & Shield/Rebel Clash/72.ts
@@ -72,20 +72,19 @@ const card: Card = {
 	types: ["Lightning"],
 	regulationMark: "D",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
 	stage: "Basic",
 	suffix: "V",
 
-	thirdParty: {
-		cardmarket: 457778,
-		tcgplayer: 213158
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 457778,
+				tcgplayer: 213158
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Rebel Clash/73.ts
+++ b/data/Sword & Shield/Rebel Clash/73.ts
@@ -80,12 +80,6 @@ const card: Card = {
 	types: ["Lightning"],
 	regulationMark: "D",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	stage: "Basic",
 
@@ -93,10 +87,22 @@ const card: Card = {
 		en: "As it eats the seeds stored up in its pocket-like pouches, this Pokémon is not just satisfying its constant hunger. It's also generating electricity."
 	},
 
-	thirdParty: {
-		cardmarket: 457783,
-		tcgplayer: 213159
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 457783,
+				tcgplayer: 213159
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 457783,
+				tcgplayer: 213159
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Rebel Clash/74.ts
+++ b/data/Sword & Shield/Rebel Clash/74.ts
@@ -71,12 +71,6 @@ const card: Card = {
 	types: ["Psychic"],
 	regulationMark: "D",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	stage: "Basic",
 
@@ -84,10 +78,22 @@ const card: Card = {
 		en: "It is said that happiness will come to those who see a gathering of Clefairy dancing under a full moon."
 	},
 
-	thirdParty: {
-		cardmarket: 457788,
-		tcgplayer: 213160
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 457788,
+				tcgplayer: 213160
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 457788,
+				tcgplayer: 213160
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Rebel Clash/75.ts
+++ b/data/Sword & Shield/Rebel Clash/75.ts
@@ -81,12 +81,6 @@ const card: Card = {
 	types: ["Psychic"],
 	regulationMark: "D",
 
-	variants: {
-		normal: false,
-		reverse: true,
-		holo: true,
-		firstEdition: false
-	},
 
 	stage: "Stage1",
 
@@ -94,10 +88,22 @@ const card: Card = {
 		en: "A timid fairy Pokémon that is rarely seen, it will run and hide the moment it senses people."
 	},
 
-	thirdParty: {
-		cardmarket: 457793,
-		tcgplayer: 213161
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 457793,
+				tcgplayer: 213161
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 457793,
+				tcgplayer: 213161
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Rebel Clash/76.ts
+++ b/data/Sword & Shield/Rebel Clash/76.ts
@@ -62,12 +62,6 @@ const card: Card = {
 	types: ["Psychic"],
 	regulationMark: "D",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	stage: "Basic",
 
@@ -75,10 +69,22 @@ const card: Card = {
 		en: "It is extremely good at climbing tree trunks and likes to eat the new sprouts on the trees."
 	},
 
-	thirdParty: {
-		cardmarket: 457798,
-		tcgplayer: 213162
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 457798,
+				tcgplayer: 213162
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 457798,
+				tcgplayer: 213162
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Rebel Clash/77.ts
+++ b/data/Sword & Shield/Rebel Clash/77.ts
@@ -94,12 +94,6 @@ const card: Card = {
 	types: ["Psychic"],
 	regulationMark: "D",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	stage: "Stage1",
 
@@ -107,10 +101,22 @@ const card: Card = {
 		en: "They say that it stays still and quiet because it is seeing both the past and future at the same time."
 	},
 
-	thirdParty: {
-		cardmarket: 457803,
-		tcgplayer: 213163
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 457803,
+				tcgplayer: 213163
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 457803,
+				tcgplayer: 213163
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Rebel Clash/78.ts
+++ b/data/Sword & Shield/Rebel Clash/78.ts
@@ -61,12 +61,6 @@ const card: Card = {
 	types: ["Psychic"],
 	regulationMark: "D",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	stage: "Basic",
 
@@ -74,10 +68,22 @@ const card: Card = {
 		en: "Watch your step when wandering areas oceans once covered. What looks like a stone could be this Pokémon, and it will curse you if you kick it."
 	},
 
-	thirdParty: {
-		cardmarket: 457808,
-		tcgplayer: 213164
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 457808,
+				tcgplayer: 213164
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 457808,
+				tcgplayer: 213164
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Rebel Clash/79.ts
+++ b/data/Sword & Shield/Rebel Clash/79.ts
@@ -94,12 +94,6 @@ const card: Card = {
 	types: ["Psychic"],
 	regulationMark: "D",
 
-	variants: {
-		normal: false,
-		reverse: true,
-		holo: true,
-		firstEdition: false
-	},
 
 	stage: "Stage1",
 
@@ -107,10 +101,22 @@ const card: Card = {
 		en: "Its shell is overflowing with its heightened otherworldly energy. The ectoplasm serves as protection for this Pokémon's core spirit."
 	},
 
-	thirdParty: {
-		cardmarket: 457813,
-		tcgplayer: 213165
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 457813,
+				tcgplayer: 213165
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 457813,
+				tcgplayer: 213165
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Rebel Clash/8.ts
+++ b/data/Sword & Shield/Rebel Clash/8.ts
@@ -89,12 +89,6 @@ const card: Card = {
 	types: ["Grass"],
 	regulationMark: "D",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	stage: "Stage1",
 
@@ -102,10 +96,22 @@ const card: Card = {
 		en: "It is nocturnal and becomes active at nightfall. It feeds on aquatic mosses that grow in the riverbed."
 	},
 
-	thirdParty: {
-		cardmarket: 457433,
-		tcgplayer: 213078
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 457433,
+				tcgplayer: 213078
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 457433,
+				tcgplayer: 213078
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Rebel Clash/80.ts
+++ b/data/Sword & Shield/Rebel Clash/80.ts
@@ -86,12 +86,6 @@ const card: Card = {
 	types: ["Psychic"],
 	regulationMark: "D",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	stage: "Basic",
 
@@ -99,10 +93,22 @@ const card: Card = {
 		en: "Psychic power allows these Pokémon to fly. Some say they were the guardians of an ancient city. Others say they were the guardians' emissaries."
 	},
 
-	thirdParty: {
-		cardmarket: 457818,
-		tcgplayer: 213166
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 457818,
+				tcgplayer: 213166
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 457818,
+				tcgplayer: 213166
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Rebel Clash/81.ts
+++ b/data/Sword & Shield/Rebel Clash/81.ts
@@ -62,12 +62,6 @@ const card: Card = {
 	types: ["Psychic"],
 	regulationMark: "D",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	stage: "Basic",
 
@@ -75,10 +69,22 @@ const card: Card = {
 		en: "If you build sand mounds when you're playing, destroy them before you go home, or they may get possessed and become Sandygast."
 	},
 
-	thirdParty: {
-		cardmarket: 457823,
-		tcgplayer: 213167
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 457823,
+				tcgplayer: 213167
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 457823,
+				tcgplayer: 213167
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Rebel Clash/82.ts
+++ b/data/Sword & Shield/Rebel Clash/82.ts
@@ -97,12 +97,6 @@ const card: Card = {
 	types: ["Psychic"],
 	regulationMark: "D",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	stage: "Stage1",
 
@@ -110,10 +104,22 @@ const card: Card = {
 		en: "Once it has whipped up a sandstorm to halt its opponents in their tracks, this terrifying Pokémon snatches away their vitality."
 	},
 
-	thirdParty: {
-		cardmarket: 457828,
-		tcgplayer: 213168
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 457828,
+				tcgplayer: 213168
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 457828,
+				tcgplayer: 213168
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Rebel Clash/83.ts
+++ b/data/Sword & Shield/Rebel Clash/83.ts
@@ -79,12 +79,6 @@ const card: Card = {
 	types: ["Psychic"],
 	regulationMark: "D",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	stage: "Basic",
 
@@ -92,10 +86,22 @@ const card: Card = {
 		en: "Via the protrusion on its head, it senses other creatures' emotions. If you don't have a calm disposition, it will never warm up to you."
 	},
 
-	thirdParty: {
-		cardmarket: 457833,
-		tcgplayer: 213169
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 457833,
+				tcgplayer: 213169
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 457833,
+				tcgplayer: 213169
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Rebel Clash/84.ts
+++ b/data/Sword & Shield/Rebel Clash/84.ts
@@ -94,12 +94,6 @@ const card: Card = {
 	types: ["Psychic"],
 	regulationMark: "D",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	stage: "Stage1",
 
@@ -107,10 +101,22 @@ const card: Card = {
 		en: "No matter who you are, if you bring strong emotions near this Pokémon, it will silence you violently."
 	},
 
-	thirdParty: {
-		cardmarket: 457838,
-		tcgplayer: 213170
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 457838,
+				tcgplayer: 213170
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 457838,
+				tcgplayer: 213170
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Rebel Clash/85.ts
+++ b/data/Sword & Shield/Rebel Clash/85.ts
@@ -92,12 +92,6 @@ const card: Card = {
 	types: ["Psychic"],
 	regulationMark: "D",
 
-	variants: {
-		normal: false,
-		reverse: true,
-		holo: true,
-		firstEdition: false
-	},
 
 	stage: "Stage2",
 
@@ -105,10 +99,22 @@ const card: Card = {
 		en: "It emits psychic power strong enough to cause headaches as a deterrent to the approach of others."
 	},
 
-	thirdParty: {
-		cardmarket: 457843,
-		tcgplayer: 213171
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 457843,
+				tcgplayer: 213171
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 457843,
+				tcgplayer: 213171
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Rebel Clash/86.ts
+++ b/data/Sword & Shield/Rebel Clash/86.ts
@@ -71,12 +71,6 @@ const card: Card = {
 	types: ["Psychic"],
 	regulationMark: "D",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	stage: "Basic",
 
@@ -84,10 +78,22 @@ const card: Card = {
 		en: "This Pokémon was born from sweet-smelling particles in the air. Its body is made of cream."
 	},
 
-	thirdParty: {
-		cardmarket: 457848,
-		tcgplayer: 213172
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 457848,
+				tcgplayer: 213172
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 457848,
+				tcgplayer: 213172
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Rebel Clash/87.ts
+++ b/data/Sword & Shield/Rebel Clash/87.ts
@@ -88,12 +88,6 @@ const card: Card = {
 	types: ["Psychic"],
 	regulationMark: "D",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	stage: "Stage1",
 
@@ -101,10 +95,22 @@ const card: Card = {
 		en: "When it trusts a Trainer, it will treat them to berries it's decorated with cream."
 	},
 
-	thirdParty: {
-		cardmarket: 457853,
-		tcgplayer: 213173
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 457853,
+				tcgplayer: 213173
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 457853,
+				tcgplayer: 213173
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Rebel Clash/88.ts
+++ b/data/Sword & Shield/Rebel Clash/88.ts
@@ -85,12 +85,6 @@ const card: Card = {
 	types: ["Psychic"],
 	regulationMark: "D",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	stage: "Basic",
 
@@ -98,10 +92,22 @@ const card: Card = {
 		en: "These intelligent Pokémon touch horns with each other to share information between them."
 	},
 
-	thirdParty: {
-		cardmarket: 457858,
-		tcgplayer: 213174
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 457858,
+				tcgplayer: 213174
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 457858,
+				tcgplayer: 213174
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Rebel Clash/89.ts
+++ b/data/Sword & Shield/Rebel Clash/89.ts
@@ -62,12 +62,6 @@ const card: Card = {
 	types: ["Psychic"],
 	regulationMark: "D",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	stage: "Basic",
 
@@ -75,10 +69,22 @@ const card: Card = {
 		en: "After being reborn as a ghost Pokémon, Dreepy wanders the areas it used to inhabit back when it was alive in prehistoric seas."
 	},
 
-	thirdParty: {
-		cardmarket: 457863,
-		tcgplayer: 213175
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 457863,
+				tcgplayer: 213175
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 457863,
+				tcgplayer: 213175
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Rebel Clash/9.ts
+++ b/data/Sword & Shield/Rebel Clash/9.ts
@@ -91,12 +91,6 @@ const card: Card = {
 	types: ["Grass"],
 	regulationMark: "D",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	stage: "Stage2",
 
@@ -104,10 +98,22 @@ const card: Card = {
 		en: "The rhythm of bright, festive music activates Ludicolo's cells, making it more powerful."
 	},
 
-	thirdParty: {
-		cardmarket: 457438,
-		tcgplayer: 213079
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 457438,
+				tcgplayer: 213079
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 457438,
+				tcgplayer: 213079
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Rebel Clash/90.ts
+++ b/data/Sword & Shield/Rebel Clash/90.ts
@@ -87,12 +87,6 @@ const card: Card = {
 	types: ["Psychic"],
 	regulationMark: "D",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	stage: "Stage1",
 
@@ -100,10 +94,22 @@ const card: Card = {
 		en: "It's capable of flying faster than 120 mph. It battles alongside Dreepy and dotes on them until they successfully evolve."
 	},
 
-	thirdParty: {
-		cardmarket: 457868,
-		tcgplayer: 213176
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 457868,
+				tcgplayer: 213176
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 457868,
+				tcgplayer: 213176
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Rebel Clash/91.ts
+++ b/data/Sword & Shield/Rebel Clash/91.ts
@@ -94,12 +94,6 @@ const card: Card = {
 	regulationMark: "D",
 	retreat: 0,
 
-	variants: {
-		normal: false,
-		reverse: true,
-		holo: true,
-		firstEdition: false
-	},
 
 	stage: "Stage2",
 
@@ -107,10 +101,29 @@ const card: Card = {
 		en: "When it isn't battling, it keeps Dreepy in the holes on its horns. Once a fight starts, it launches the Dreepy like supersonic missiles."
 	},
 
-	thirdParty: {
-		cardmarket: 456498,
-		tcgplayer: 213177
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 457873,
+				tcgplayer: 213177
+			}
+		},
+		{
+			type: 'holo',
+			stamp: ['set-logo'],
+			thirdParty: {
+				cardmarket: 709526
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 457873,
+				tcgplayer: 213177
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Rebel Clash/92.ts
+++ b/data/Sword & Shield/Rebel Clash/92.ts
@@ -80,20 +80,19 @@ const card: Card = {
 	types: ["Psychic"],
 	regulationMark: "D",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
 	stage: "Basic",
 	suffix: "V",
 
-	thirdParty: {
-		cardmarket: 457878,
-		tcgplayer: 213178
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 457878,
+				tcgplayer: 213178
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Rebel Clash/93.ts
+++ b/data/Sword & Shield/Rebel Clash/93.ts
@@ -96,19 +96,18 @@ const card: Card = {
 	types: ["Psychic"],
 	regulationMark: "D",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
 	stage: "VMAX",
 
-	thirdParty: {
-		cardmarket: 456498,
-		tcgplayer: 213180
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 456498,
+				tcgplayer: 213180
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Rebel Clash/94.ts
+++ b/data/Sword & Shield/Rebel Clash/94.ts
@@ -72,12 +72,6 @@ const card: Card = {
 	types: ["Fighting"],
 	regulationMark: "D",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	stage: "Basic",
 
@@ -85,10 +79,22 @@ const card: Card = {
 		en: "The Farfetch'd of the Galar region are brave warriors, and they wield thick, tough leeks in battle."
 	},
 
-	thirdParty: {
-		cardmarket: 457883,
-		tcgplayer: 213182
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 457883,
+				tcgplayer: 213182
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 457883,
+				tcgplayer: 213182
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Rebel Clash/95.ts
+++ b/data/Sword & Shield/Rebel Clash/95.ts
@@ -82,12 +82,6 @@ const card: Card = {
 	types: ["Fighting"],
 	regulationMark: "D",
 
-	variants: {
-		normal: false,
-		reverse: true,
-		holo: true,
-		firstEdition: false
-	},
 
 	stage: "Stage1",
 
@@ -95,10 +89,29 @@ const card: Card = {
 		en: "Only Farfetch'd that have survived many battles can attain this evolution. When this Pokémon's leek withers, it will retire from combat."
 	},
 
-	thirdParty: {
-		cardmarket: 457888,
-		tcgplayer: 213183
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 457888,
+				tcgplayer: 213183
+			}
+		},
+		{
+			type: 'holo',
+			foil: 'cosmos',
+			thirdParty: {
+				cardmarket: 883772
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 457888,
+				tcgplayer: 213183
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Rebel Clash/96.ts
+++ b/data/Sword & Shield/Rebel Clash/96.ts
@@ -67,12 +67,6 @@ const card: Card = {
 	types: ["Fighting"],
 	regulationMark: "D",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	stage: "Basic",
 
@@ -80,10 +74,22 @@ const card: Card = {
 		en: "It hunts without twitching a muscle by pulling in its prey with powerful magnetism. But sometimes it pulls natural enemies in close."
 	},
 
-	thirdParty: {
-		cardmarket: 457893,
-		tcgplayer: 213184
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 457893,
+				tcgplayer: 213184
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 457893,
+				tcgplayer: 213184
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Rebel Clash/97.ts
+++ b/data/Sword & Shield/Rebel Clash/97.ts
@@ -56,12 +56,6 @@ const card: Card = {
 	types: ["Fighting"],
 	regulationMark: "D",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	stage: "Basic",
 
@@ -69,10 +63,22 @@ const card: Card = {
 		en: "It eats just one berry a day. By enduring hunger, its spirit is tempered and made sharper."
 	},
 
-	thirdParty: {
-		cardmarket: 457898,
-		tcgplayer: 213185
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 457898,
+				tcgplayer: 213185
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 457898,
+				tcgplayer: 213185
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Rebel Clash/98.ts
+++ b/data/Sword & Shield/Rebel Clash/98.ts
@@ -90,12 +90,6 @@ const card: Card = {
 	types: ["Fighting"],
 	regulationMark: "D",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	stage: "Stage1",
 
@@ -103,10 +97,22 @@ const card: Card = {
 		en: "Through yoga training, it gained the psychic power to predict its foe's next move."
 	},
 
-	thirdParty: {
-		cardmarket: 457903,
-		tcgplayer: 213186
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 457903,
+				tcgplayer: 213186
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 457903,
+				tcgplayer: 213186
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Rebel Clash/99.ts
+++ b/data/Sword & Shield/Rebel Clash/99.ts
@@ -49,12 +49,6 @@ const card: Card = {
 	types: ["Fighting"],
 	regulationMark: "D",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	stage: "Basic",
 
@@ -62,10 +56,22 @@ const card: Card = {
 		en: "Its slimy body is hard to grasp. In one region, it is said to have been born from hardened mud."
 	},
 
-	thirdParty: {
-		cardmarket: 457908,
-		tcgplayer: 213187
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 457908,
+				tcgplayer: 213187
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 457908,
+				tcgplayer: 213187
+			}
+		},
+	],
 }
 
 export default card

--- a/interfaces.d.ts
+++ b/interfaces.d.ts
@@ -32,7 +32,7 @@ export type VariantStamps = '1st-edition' | 'w-promo' | 'pre-release' | 'pokemon
 	| 'yuka-furusawa' | 'jason-martinez' | 'yuta-komatsuda' | 'origins-2008' | 'platinum' | 'worlds-2010'
 	| 'ross-cawthorn' | 'gustavo-wada' | 'christopher-kan' | 'player-rewards-program' | 'igor-costa'
 	| 'zachary-bokhari' | 'shuto-itagaki' | 'snowflake' | 'trick-or-trade' | 'horizons' | 'gamestop' | 'eb-games'
-	| 'illustration-contest-2024' | 'worlds-2025' | 'top-eight' | "champion" | "master-ball-league" | "ultra-ball-league" | "judge" | "asia-promo"
+	| 'illustration-contest-2024' | 'worlds-2025' | 'top-eight' | "champion" | "poke-ball-league" | "master-ball-league" | "ultra-ball-league" | "judge" | "asia-promo"
 	| "international-championship-europe" | "international-championship-latin-america" | "international-championship-north-america" | 'ace-trainer'
 	| 'pikachu' | 'bulbasaur' | 'squirtle' | 'charmander' | 'pokeball' | '30th-pokeday' | 'mcdonalds' | 'pokemon-together' | 'rain-city' | 'tournament-collection'
 	| 'worlds-2024' | 'worlds-2023' | 'asia-2023-24'

--- a/meta/translations/de.json
+++ b/meta/translations/de.json
@@ -235,6 +235,7 @@
 		"champion": "champion",
 		"master-ball-league": "master-ball-league",
 		"ultra-ball-league": "ultra-ball-league",
+		"poke-ball-league": "poke-ball-league",
 		"asia-promo": "asia-promo",
 		"judge": "richter",
 		"international-championship-europe": "international-championship-europe",

--- a/meta/translations/es.json
+++ b/meta/translations/es.json
@@ -235,6 +235,7 @@
 		"champion": "campeón",
 		"master-ball-league": "liga-master-ball",
 		"ultra-ball-league": "liga-ultra-ball",
+		"poke-ball-league": "liga-poke-ball",
 		"asia-promo": "asia-promo",
 		"judge": "juez",
 		"international-championship-europe": "campeonato-internacional-europa",

--- a/meta/translations/fr.json
+++ b/meta/translations/fr.json
@@ -234,6 +234,7 @@
 		"champion": "champion",
 		"master-ball-league": "ligue-master-ball",
 		"ultra-ball-league": "ligue-ultra-ball",
+		"poke-ball-league": "ligue-poke-ball",
 		"asia-promo": "asia-promo",
 		"judge": "juge",
 		"international-championship-europe": "championnat-international-europe",

--- a/meta/translations/it.json
+++ b/meta/translations/it.json
@@ -235,6 +235,7 @@
 		"champion": "campione",
 		"master-ball-league": "lega-master-ball",
 		"ultra-ball-league": "lega-ultra-ball",
+		"poke-ball-league": "lega-poke-ball",
 		"asia-promo": "asia-promo",
 		"judge": "giudice",
 		"international-championship-europe": "campionato-internazionale-europa",

--- a/meta/translations/pt.json
+++ b/meta/translations/pt.json
@@ -234,6 +234,7 @@
 		"champion": "campeão",
 		"master-ball-league": "liga-master-ball",
 		"ultra-ball-league": "liga-ultra-ball",
+		"poke-ball-league": "liga-poke-ball",
 		"asia-promo": "asia-promo",
 		"judge": "juiz",
 		"international-championship-europe": "campeonato-internacional-europa",


### PR DESCRIPTION
## Changes

- Added a new stamp `poke-ball-league` and added translations
- Added `rainbow` and `gold` foil types to relevant cards
- Added additional variants
- Moved all `thirdParty` into variants block with updated IDs


