### PR TITLE
(data): Fusion Strike Variants and Pricing

### DIFF
--- a/data/Sword & Shield/Fusion Strike/1.ts
+++ b/data/Sword & Shield/Fusion Strike/1.ts
@@ -68,17 +68,23 @@ const card: Card = {
 		damage: 10
 	}],
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582029,
-		tcgplayer: 253069
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 582029,
+				tcgplayer: 253069
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 582029,
+				tcgplayer: 253069
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/10.ts
+++ b/data/Sword & Shield/Fusion Strike/10.ts
@@ -80,17 +80,23 @@ const card: Card = {
 		damage: 60
 	}],
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582038,
-		tcgplayer: 253080
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 582038,
+				tcgplayer: 253080
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 582038,
+				tcgplayer: 253080
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/100.ts
+++ b/data/Sword & Shield/Fusion Strike/100.ts
@@ -71,17 +71,23 @@ const card: Card = {
 		damage: 60
 	}],
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582493,
-		tcgplayer: 253256
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 582493,
+				tcgplayer: 253256
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 582493,
+				tcgplayer: 253256
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/101.ts
+++ b/data/Sword & Shield/Fusion Strike/101.ts
@@ -78,17 +78,23 @@ const card: Card = {
 		}
 	}],
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582494,
-		tcgplayer: 253257
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 582494,
+				tcgplayer: 253257
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 582494,
+				tcgplayer: 253257
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/102.ts
+++ b/data/Sword & Shield/Fusion Strike/102.ts
@@ -57,17 +57,23 @@ const card: Card = {
 		}
 	}],
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582495,
-		tcgplayer: 253258
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 582495,
+				tcgplayer: 253258
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 582495,
+				tcgplayer: 253258
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/103.ts
+++ b/data/Sword & Shield/Fusion Strike/103.ts
@@ -76,17 +76,16 @@ const card: Card = {
 		}
 	}],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582496,
-		tcgplayer: 253259
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 582496,
+				tcgplayer: 253259
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/104.ts
+++ b/data/Sword & Shield/Fusion Strike/104.ts
@@ -84,17 +84,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582497,
-		tcgplayer: 253260
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 582497,
+				tcgplayer: 253260
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/105.ts
+++ b/data/Sword & Shield/Fusion Strike/105.ts
@@ -48,17 +48,23 @@ const card: Card = {
 		damage: 20
 	}],
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582498,
-		tcgplayer: 253261
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 582498,
+				tcgplayer: 253261
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 582498,
+				tcgplayer: 253261
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/106.ts
+++ b/data/Sword & Shield/Fusion Strike/106.ts
@@ -68,17 +68,23 @@ const card: Card = {
 		damage: 10
 	}],
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582498,
-		tcgplayer: 253262
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 582499,
+				tcgplayer: 253262
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 582499,
+				tcgplayer: 253262
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/107.ts
+++ b/data/Sword & Shield/Fusion Strike/107.ts
@@ -67,17 +67,23 @@ const card: Card = {
 		}
 	}],
 
-	variants: {
-		normal: false,
-		reverse: true,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582500,
-		tcgplayer: 253263
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 582500,
+				tcgplayer: 253263
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 582500,
+				tcgplayer: 253263
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/108.ts
+++ b/data/Sword & Shield/Fusion Strike/108.ts
@@ -80,17 +80,23 @@ const card: Card = {
 		damage: 90
 	}],
 
-	variants: {
-		normal: false,
-		reverse: true,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582500,
-		tcgplayer: 253264
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 582501,
+				tcgplayer: 253264
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 582501,
+				tcgplayer: 253264
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/109.ts
+++ b/data/Sword & Shield/Fusion Strike/109.ts
@@ -55,17 +55,23 @@ const card: Card = {
 		}
 	}],
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582502,
-		tcgplayer: 253267
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 582502,
+				tcgplayer: 253267
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 582502,
+				tcgplayer: 253267
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/11.ts
+++ b/data/Sword & Shield/Fusion Strike/11.ts
@@ -78,17 +78,23 @@ const card: Card = {
 		damage: 120
 	}],
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582039,
-		tcgplayer: 253081
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 582039,
+				tcgplayer: 253081
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 582039,
+				tcgplayer: 253081
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/110.ts
+++ b/data/Sword & Shield/Fusion Strike/110.ts
@@ -70,17 +70,23 @@ const card: Card = {
 		}
 	}],
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582601,
-		tcgplayer: 253268
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 582601,
+				tcgplayer: 253268
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 582601,
+				tcgplayer: 253268
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/111.ts
+++ b/data/Sword & Shield/Fusion Strike/111.ts
@@ -78,17 +78,23 @@ const card: Card = {
 		damage: 90
 	}],
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582603,
-		tcgplayer: 253269
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 582603,
+				tcgplayer: 253269
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 582603,
+				tcgplayer: 253269
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/112.ts
+++ b/data/Sword & Shield/Fusion Strike/112.ts
@@ -83,17 +83,23 @@ const card: Card = {
 		}
 	}],
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582604,
-		tcgplayer: 253273
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 582604,
+				tcgplayer: 253273
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 582604,
+				tcgplayer: 253273
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/113.ts
+++ b/data/Sword & Shield/Fusion Strike/113.ts
@@ -80,17 +80,16 @@ const card: Card = {
 		}
 	}],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582611,
-		tcgplayer: 253274
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 582611,
+				tcgplayer: 253274
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/114.ts
+++ b/data/Sword & Shield/Fusion Strike/114.ts
@@ -87,17 +87,16 @@ const card: Card = {
 		value: "-30"
 	}],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582613,
-		tcgplayer: 253275
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 582613,
+				tcgplayer: 253275
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/115.ts
+++ b/data/Sword & Shield/Fusion Strike/115.ts
@@ -61,17 +61,23 @@ const card: Card = {
 		damage: 30
 	}],
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582615,
-		tcgplayer: 253278
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 582615,
+				tcgplayer: 253278
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 582615,
+				tcgplayer: 253278
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/116.ts
+++ b/data/Sword & Shield/Fusion Strike/116.ts
@@ -80,17 +80,23 @@ const card: Card = {
 		damage: 90
 	}],
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582618,
-		tcgplayer: 253282
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 582618,
+				tcgplayer: 253282
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 582618,
+				tcgplayer: 253282
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/117.ts
+++ b/data/Sword & Shield/Fusion Strike/117.ts
@@ -54,17 +54,23 @@ const card: Card = {
 		damage: 30
 	}],
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582622,
-		tcgplayer: 253283
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 582622,
+				tcgplayer: 253283
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 582622,
+				tcgplayer: 253283
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/118.ts
+++ b/data/Sword & Shield/Fusion Strike/118.ts
@@ -84,17 +84,23 @@ const card: Card = {
 		damage: 80
 	}],
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582632,
-		tcgplayer: 253288
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 582632,
+				tcgplayer: 253288
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 582632,
+				tcgplayer: 253288
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/119.ts
+++ b/data/Sword & Shield/Fusion Strike/119.ts
@@ -57,17 +57,23 @@ const card: Card = {
 		}
 	}],
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582635,
-		tcgplayer: 253290
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 582635,
+				tcgplayer: 253290
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 582635,
+				tcgplayer: 253290
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/12.ts
+++ b/data/Sword & Shield/Fusion Strike/12.ts
@@ -70,17 +70,23 @@ const card: Card = {
 		}
 	}],
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582040,
-		tcgplayer: 253086
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 582040,
+				tcgplayer: 253086
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 582040,
+				tcgplayer: 253086
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/120.ts
+++ b/data/Sword & Shield/Fusion Strike/120.ts
@@ -63,17 +63,23 @@ const card: Card = {
 		}
 	}],
 
-	variants: {
-		normal: false,
-		reverse: true,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582638,
-		tcgplayer: 253293
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 582638,
+				tcgplayer: 253293
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 582638,
+				tcgplayer: 253293
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/121.ts
+++ b/data/Sword & Shield/Fusion Strike/121.ts
@@ -54,17 +54,23 @@ const card: Card = {
 		damage: 10
 	}],
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582644,
-		tcgplayer: 253294
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 582644,
+				tcgplayer: 253294
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 582644,
+				tcgplayer: 253294
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/122.ts
+++ b/data/Sword & Shield/Fusion Strike/122.ts
@@ -93,17 +93,23 @@ const card: Card = {
 		}
 	}],
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582647,
-		tcgplayer: 253299
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 582647,
+				tcgplayer: 253299
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 582647,
+				tcgplayer: 253299
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/123.ts
+++ b/data/Sword & Shield/Fusion Strike/123.ts
@@ -85,17 +85,23 @@ const card: Card = {
 		}
 	}],
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582649,
-		tcgplayer: 253303
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 582649,
+				tcgplayer: 253303
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 582649,
+				tcgplayer: 253303
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/124.ts
+++ b/data/Sword & Shield/Fusion Strike/124.ts
@@ -63,17 +63,23 @@ const card: Card = {
 		}
 	}],
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582652,
-		tcgplayer: 253308
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 582652,
+				tcgplayer: 253308
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 582652,
+				tcgplayer: 253308
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/125.ts
+++ b/data/Sword & Shield/Fusion Strike/125.ts
@@ -67,17 +67,23 @@ const card: Card = {
 		damage: 30
 	}],
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582655,
-		tcgplayer: 253311
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 582655,
+				tcgplayer: 253311
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 582655,
+				tcgplayer: 253311
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/126.ts
+++ b/data/Sword & Shield/Fusion Strike/126.ts
@@ -84,17 +84,23 @@ const card: Card = {
 		}
 	}],
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582660,
-		tcgplayer: 253313
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 582660,
+				tcgplayer: 253313
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 582660,
+				tcgplayer: 253313
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/127.ts
+++ b/data/Sword & Shield/Fusion Strike/127.ts
@@ -74,17 +74,23 @@ const card: Card = {
 		damage: 80
 	}],
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582663,
-		tcgplayer: 253318
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 582663,
+				tcgplayer: 253318
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 582663,
+				tcgplayer: 253318
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/128.ts
+++ b/data/Sword & Shield/Fusion Strike/128.ts
@@ -63,17 +63,23 @@ const card: Card = {
 		}
 	}],
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582666,
-		tcgplayer: 253321
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 582666,
+				tcgplayer: 253321
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 582666,
+				tcgplayer: 253321
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/129.ts
+++ b/data/Sword & Shield/Fusion Strike/129.ts
@@ -86,17 +86,23 @@ const card: Card = {
 		}
 	}],
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582668,
-		tcgplayer: 253325
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 582668,
+				tcgplayer: 253325
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 582668,
+				tcgplayer: 253325
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/13.ts
+++ b/data/Sword & Shield/Fusion Strike/13.ts
@@ -48,17 +48,23 @@ const card: Card = {
 		damage: 20
 	}],
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582050,
-		tcgplayer: 253087
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 582050,
+				tcgplayer: 253087
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 582050,
+				tcgplayer: 253087
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/130.ts
+++ b/data/Sword & Shield/Fusion Strike/130.ts
@@ -84,17 +84,30 @@ const card: Card = {
 		value: "-30"
 	}],
 
-	variants: {
-		normal: false,
-		reverse: true,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582671,
-		tcgplayer: 253327
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 582671,
+				tcgplayer: 253327
+			}
+		},
+		{
+			type: 'holo',
+			foil: 'cosmos',
+			thirdParty: {
+				cardmarket: 883763
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 582671,
+				tcgplayer: 253327
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/131.ts
+++ b/data/Sword & Shield/Fusion Strike/131.ts
@@ -77,17 +77,23 @@ const card: Card = {
 		}
 	}],
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582709,
-		tcgplayer: 253330
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 582709,
+				tcgplayer: 253330
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 582709,
+				tcgplayer: 253330
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/132.ts
+++ b/data/Sword & Shield/Fusion Strike/132.ts
@@ -67,17 +67,23 @@ const card: Card = {
 		}
 	}],
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582710,
-		tcgplayer: 253449
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 582710,
+				tcgplayer: 253449
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 582710,
+				tcgplayer: 253449
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/133.ts
+++ b/data/Sword & Shield/Fusion Strike/133.ts
@@ -48,17 +48,23 @@ const card: Card = {
 		damage: 10
 	}],
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582711,
-		tcgplayer: 253334
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 582711,
+				tcgplayer: 253334
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 582711,
+				tcgplayer: 253334
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/134.ts
+++ b/data/Sword & Shield/Fusion Strike/134.ts
@@ -67,17 +67,23 @@ const card: Card = {
 		}
 	}],
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582712,
-		tcgplayer: 253337
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 582712,
+				tcgplayer: 253337
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 582712,
+				tcgplayer: 253337
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/135.ts
+++ b/data/Sword & Shield/Fusion Strike/135.ts
@@ -61,17 +61,23 @@ const card: Card = {
 		damage: 20
 	}],
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582714,
-		tcgplayer: 253339
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 582714,
+				tcgplayer: 253339
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 582714,
+				tcgplayer: 253339
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/136.ts
+++ b/data/Sword & Shield/Fusion Strike/136.ts
@@ -71,17 +71,23 @@ const card: Card = {
 		damage: 70
 	}],
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582718,
-		tcgplayer: 253341
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 582718,
+				tcgplayer: 253341
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 582718,
+				tcgplayer: 253341
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/137.ts
+++ b/data/Sword & Shield/Fusion Strike/137.ts
@@ -89,17 +89,23 @@ const card: Card = {
 		}
 	}],
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582736,
-		tcgplayer: 253342
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 582736,
+				tcgplayer: 253342
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 582736,
+				tcgplayer: 253342
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/138.ts
+++ b/data/Sword & Shield/Fusion Strike/138.ts
@@ -70,17 +70,23 @@ const card: Card = {
 		damage: 90
 	}],
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582746,
-		tcgplayer: 253343
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 582746,
+				tcgplayer: 253343
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 582746,
+				tcgplayer: 253343
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/139.ts
+++ b/data/Sword & Shield/Fusion Strike/139.ts
@@ -89,17 +89,23 @@ const card: Card = {
 		}
 	}],
 
-	variants: {
-		normal: false,
-		reverse: true,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582748,
-		tcgplayer: 253346
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 582748,
+				tcgplayer: 253346
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 582748,
+				tcgplayer: 253346
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/14.ts
+++ b/data/Sword & Shield/Fusion Strike/14.ts
@@ -66,17 +66,23 @@ const card: Card = {
 		value: "×2"
 	}],
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582053,
-		tcgplayer: 253090
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 582053,
+				tcgplayer: 253090
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 582053,
+				tcgplayer: 253090
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/140.ts
+++ b/data/Sword & Shield/Fusion Strike/140.ts
@@ -68,17 +68,23 @@ const card: Card = {
 		damage: 30
 	}],
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582752,
-		tcgplayer: 253348
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 582752,
+				tcgplayer: 253348
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 582752,
+				tcgplayer: 253348
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/141.ts
+++ b/data/Sword & Shield/Fusion Strike/141.ts
@@ -89,17 +89,23 @@ const card: Card = {
 		}
 	}],
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582755,
-		tcgplayer: 253350
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 582755,
+				tcgplayer: 253350
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 582755,
+				tcgplayer: 253350
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/142.ts
+++ b/data/Sword & Shield/Fusion Strike/142.ts
@@ -61,17 +61,23 @@ const card: Card = {
 		damage: 60
 	}],
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582759,
-		tcgplayer: 253352
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 582759,
+				tcgplayer: 253352
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 582759,
+				tcgplayer: 253352
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/143.ts
+++ b/data/Sword & Shield/Fusion Strike/143.ts
@@ -80,17 +80,23 @@ const card: Card = {
 		damage: 100
 	}],
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582766,
-		tcgplayer: 253355
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 582766,
+				tcgplayer: 253355
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 582766,
+				tcgplayer: 253355
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/144.ts
+++ b/data/Sword & Shield/Fusion Strike/144.ts
@@ -48,17 +48,23 @@ const card: Card = {
 		damage: 20
 	}],
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582768,
-		tcgplayer: 253356
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 582768,
+				tcgplayer: 253356
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 582768,
+				tcgplayer: 253356
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/145.ts
+++ b/data/Sword & Shield/Fusion Strike/145.ts
@@ -87,17 +87,23 @@ const card: Card = {
 		}
 	}],
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582772,
-		tcgplayer: 253359
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 582772,
+				tcgplayer: 253359
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 582772,
+				tcgplayer: 253359
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/146.ts
+++ b/data/Sword & Shield/Fusion Strike/146.ts
@@ -45,17 +45,16 @@ const card: Card = {
 		damage: 120
 	}],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582774,
-		tcgplayer: 253360
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 582774,
+				tcgplayer: 253360
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/147.ts
+++ b/data/Sword & Shield/Fusion Strike/147.ts
@@ -48,17 +48,23 @@ const card: Card = {
 		damage: 20
 	}],
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582775,
-		tcgplayer: 253361
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 582775,
+				tcgplayer: 253361
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 582775,
+				tcgplayer: 253361
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/148.ts
+++ b/data/Sword & Shield/Fusion Strike/148.ts
@@ -79,17 +79,23 @@ const card: Card = {
 		}
 	}],
 
-	variants: {
-		normal: false,
-		reverse: true,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582776,
-		tcgplayer: 253362
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 582776,
+				tcgplayer: 253362
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 582776,
+				tcgplayer: 253362
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/149.ts
+++ b/data/Sword & Shield/Fusion Strike/149.ts
@@ -68,17 +68,23 @@ const card: Card = {
 		damage: 30
 	}],
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582777,
-		tcgplayer: 253363
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 582777,
+				tcgplayer: 253363
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 582777,
+				tcgplayer: 253363
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/15.ts
+++ b/data/Sword & Shield/Fusion Strike/15.ts
@@ -68,17 +68,23 @@ const card: Card = {
 		damage: 90
 	}],
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582056,
-		tcgplayer: 253092
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 582056,
+				tcgplayer: 253092
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 582056,
+				tcgplayer: 253092
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/150.ts
+++ b/data/Sword & Shield/Fusion Strike/150.ts
@@ -61,17 +61,23 @@ const card: Card = {
 		damage: 30
 	}],
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582778,
-		tcgplayer: 253364
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 582778,
+				tcgplayer: 253364
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 582778,
+				tcgplayer: 253364
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/151.ts
+++ b/data/Sword & Shield/Fusion Strike/151.ts
@@ -80,17 +80,23 @@ const card: Card = {
 		damage: 130
 	}],
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582779,
-		tcgplayer: 253365
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 582779,
+				tcgplayer: 253365
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 582779,
+				tcgplayer: 253365
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/152.ts
+++ b/data/Sword & Shield/Fusion Strike/152.ts
@@ -61,17 +61,23 @@ const card: Card = {
 		damage: 20
 	}],
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582780,
-		tcgplayer: 253366
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 582780,
+				tcgplayer: 253366
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 582780,
+				tcgplayer: 253366
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/153.ts
+++ b/data/Sword & Shield/Fusion Strike/153.ts
@@ -71,17 +71,23 @@ const card: Card = {
 		damage: 90
 	}],
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582781,
-		tcgplayer: 253367
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 582781,
+				tcgplayer: 253367
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 582781,
+				tcgplayer: 253367
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/154.ts
+++ b/data/Sword & Shield/Fusion Strike/154.ts
@@ -70,17 +70,23 @@ const card: Card = {
 		}
 	}],
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582782,
-		tcgplayer: 253368
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 582782,
+				tcgplayer: 253368
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 582782,
+				tcgplayer: 253368
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/155.ts
+++ b/data/Sword & Shield/Fusion Strike/155.ts
@@ -48,17 +48,23 @@ const card: Card = {
 		damage: 30
 	}],
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582782,
-		tcgplayer: 253369
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 582783,
+				tcgplayer: 253369
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 582783,
+				tcgplayer: 253369
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/156.ts
+++ b/data/Sword & Shield/Fusion Strike/156.ts
@@ -76,17 +76,16 @@ const card: Card = {
 		}
 	}],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582784,
-		tcgplayer: 253370
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 582784,
+				tcgplayer: 253370
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/157.ts
+++ b/data/Sword & Shield/Fusion Strike/157.ts
@@ -84,17 +84,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582785,
-		tcgplayer: 253371
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 582785,
+				tcgplayer: 253371
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/158.ts
+++ b/data/Sword & Shield/Fusion Strike/158.ts
@@ -58,17 +58,16 @@ const card: Card = {
 		damage: 150
 	}],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582786,
-		tcgplayer: 253372
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 582786,
+				tcgplayer: 253372
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/159.ts
+++ b/data/Sword & Shield/Fusion Strike/159.ts
@@ -57,17 +57,23 @@ const card: Card = {
 		}
 	}],
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582787,
-		tcgplayer: 253373
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 582787,
+				tcgplayer: 253373
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 582787,
+				tcgplayer: 253373
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/16.ts
+++ b/data/Sword & Shield/Fusion Strike/16.ts
@@ -61,17 +61,23 @@ const card: Card = {
 		damage: 20
 	}],
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582059,
-		tcgplayer: 253094
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 582059,
+				tcgplayer: 253094
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 582059,
+				tcgplayer: 253094
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/160.ts
+++ b/data/Sword & Shield/Fusion Strike/160.ts
@@ -58,17 +58,23 @@ const card: Card = {
 		damage: 30
 	}],
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582788,
-		tcgplayer: 253374
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 582788,
+				tcgplayer: 253374
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 582788,
+				tcgplayer: 253374
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/161.ts
+++ b/data/Sword & Shield/Fusion Strike/161.ts
@@ -89,17 +89,30 @@ const card: Card = {
 		}
 	}],
 
-	variants: {
-		normal: false,
-		reverse: true,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582789,
-		tcgplayer: 253375
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 582789,
+				tcgplayer: 253375
+			}
+		},
+		{
+			type: 'holo',
+			foil: 'cosmos',
+			thirdParty: {
+				cardmarket: 883765
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 582789,
+				tcgplayer: 253375
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/162.ts
+++ b/data/Sword & Shield/Fusion Strike/162.ts
@@ -48,17 +48,23 @@ const card: Card = {
 		damage: 10
 	}],
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582790,
-		tcgplayer: 253376
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 582790,
+				tcgplayer: 253376
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 582790,
+				tcgplayer: 253376
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/163.ts
+++ b/data/Sword & Shield/Fusion Strike/163.ts
@@ -58,17 +58,23 @@ const card: Card = {
 		damage: 70
 	}],
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582791,
-		tcgplayer: 253377
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 582791,
+				tcgplayer: 253377
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 582791,
+				tcgplayer: 253377
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/164.ts
+++ b/data/Sword & Shield/Fusion Strike/164.ts
@@ -68,17 +68,23 @@ const card: Card = {
 		damage: 80
 	}],
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582792,
-		tcgplayer: 253378
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 582792,
+				tcgplayer: 253378
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 582792,
+				tcgplayer: 253378
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/165.ts
+++ b/data/Sword & Shield/Fusion Strike/165.ts
@@ -48,17 +48,23 @@ const card: Card = {
 		damage: 20
 	}],
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582793,
-		tcgplayer: 253379
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 582793,
+				tcgplayer: 253379
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 582793,
+				tcgplayer: 253379
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/166.ts
+++ b/data/Sword & Shield/Fusion Strike/166.ts
@@ -78,17 +78,23 @@ const card: Card = {
 		damage: 90
 	}],
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582794,
-		tcgplayer: 253380
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 582794,
+				tcgplayer: 253380
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 582794,
+				tcgplayer: 253380
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/167.ts
+++ b/data/Sword & Shield/Fusion Strike/167.ts
@@ -48,17 +48,23 @@ const card: Card = {
 		damage: 90
 	}],
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582795,
-		tcgplayer: 253381
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 582795,
+				tcgplayer: 253381
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 582795,
+				tcgplayer: 253381
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/168.ts
+++ b/data/Sword & Shield/Fusion Strike/168.ts
@@ -77,17 +77,23 @@ const card: Card = {
 		}
 	}],
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582796,
-		tcgplayer: 253382
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 582796,
+				tcgplayer: 253382
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 582796,
+				tcgplayer: 253382
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/169.ts
+++ b/data/Sword & Shield/Fusion Strike/169.ts
@@ -80,17 +80,23 @@ const card: Card = {
 		damage: 130
 	}],
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582797,
-		tcgplayer: 253383
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 582797,
+				tcgplayer: 253383
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 582797,
+				tcgplayer: 253383
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/17.ts
+++ b/data/Sword & Shield/Fusion Strike/17.ts
@@ -71,17 +71,23 @@ const card: Card = {
 		damage: 90
 	}],
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582061,
-		tcgplayer: 253096
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 582061,
+				tcgplayer: 253096
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 582061,
+				tcgplayer: 253096
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/170.ts
+++ b/data/Sword & Shield/Fusion Strike/170.ts
@@ -61,17 +61,23 @@ const card: Card = {
 		damage: 20
 	}],
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582798,
-		tcgplayer: 253384
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 582798,
+				tcgplayer: 253384
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 582798,
+				tcgplayer: 253384
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/171.ts
+++ b/data/Sword & Shield/Fusion Strike/171.ts
@@ -80,17 +80,23 @@ const card: Card = {
 		damage: 100
 	}],
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582799,
-		tcgplayer: 253385
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 582799,
+				tcgplayer: 253385
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 582799,
+				tcgplayer: 253385
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/172.ts
+++ b/data/Sword & Shield/Fusion Strike/172.ts
@@ -76,17 +76,23 @@ const card: Card = {
 		}
 	}],
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582800,
-		tcgplayer: 253386
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 582800,
+				tcgplayer: 253386
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 582800,
+				tcgplayer: 253386
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/173.ts
+++ b/data/Sword & Shield/Fusion Strike/173.ts
@@ -86,17 +86,23 @@ const card: Card = {
 		damage: 70
 	}],
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582801,
-		tcgplayer: 253387
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 582801,
+				tcgplayer: 253387
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 582801,
+				tcgplayer: 253387
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/174.ts
+++ b/data/Sword & Shield/Fusion Strike/174.ts
@@ -89,17 +89,23 @@ const card: Card = {
 		}
 	}],
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582802,
-		tcgplayer: 253388
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 582802,
+				tcgplayer: 253388
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 582802,
+				tcgplayer: 253388
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/175.ts
+++ b/data/Sword & Shield/Fusion Strike/175.ts
@@ -67,17 +67,23 @@ const card: Card = {
 		damage: 110
 	}],
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582803,
-		tcgplayer: 253389
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 582803,
+				tcgplayer: 253389
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 582803,
+				tcgplayer: 253389
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/176.ts
+++ b/data/Sword & Shield/Fusion Strike/176.ts
@@ -57,17 +57,23 @@ const card: Card = {
 		}
 	}],
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582804,
-		tcgplayer: 253390
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 582804,
+				tcgplayer: 253390
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 582804,
+				tcgplayer: 253390
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/177.ts
+++ b/data/Sword & Shield/Fusion Strike/177.ts
@@ -80,17 +80,23 @@ const card: Card = {
 		}
 	}],
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582805,
-		tcgplayer: 253391
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 582805,
+				tcgplayer: 253391
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 582805,
+				tcgplayer: 253391
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/178.ts
+++ b/data/Sword & Shield/Fusion Strike/178.ts
@@ -79,17 +79,23 @@ const card: Card = {
 		value: "×2"
 	}],
 
-	variants: {
-		normal: false,
-		reverse: true,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582806,
-		tcgplayer: 253392
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 582806,
+				tcgplayer: 253392
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 582806,
+				tcgplayer: 253392
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/179.ts
+++ b/data/Sword & Shield/Fusion Strike/179.ts
@@ -57,17 +57,23 @@ const card: Card = {
 		}
 	}],
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582502,
-		tcgplayer: 253393
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 582807,
+				tcgplayer: 253393
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 582807,
+				tcgplayer: 253393
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/18.ts
+++ b/data/Sword & Shield/Fusion Strike/18.ts
@@ -77,17 +77,23 @@ const card: Card = {
 		}
 	}],
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582064,
-		tcgplayer: 253098
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 582064,
+				tcgplayer: 253098
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 582064,
+				tcgplayer: 253098
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/180.ts
+++ b/data/Sword & Shield/Fusion Strike/180.ts
@@ -74,17 +74,23 @@ const card: Card = {
 		damage: 20
 	}],
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582808,
-		tcgplayer: 253326
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 582808,
+				tcgplayer: 253326
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 582808,
+				tcgplayer: 253326
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/181.ts
+++ b/data/Sword & Shield/Fusion Strike/181.ts
@@ -84,17 +84,23 @@ const card: Card = {
 		damage: 80
 	}],
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582809,
-		tcgplayer: 253328
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 582809,
+				tcgplayer: 253328
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 582809,
+				tcgplayer: 253328
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/182.ts
+++ b/data/Sword & Shield/Fusion Strike/182.ts
@@ -76,17 +76,23 @@ const card: Card = {
 		damage: 110
 	}],
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582810,
-		tcgplayer: 253329
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 582810,
+				tcgplayer: 253329
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 582810,
+				tcgplayer: 253329
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/183.ts
+++ b/data/Sword & Shield/Fusion Strike/183.ts
@@ -86,17 +86,23 @@ const card: Card = {
 		}
 	}],
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582811,
-		tcgplayer: 253331
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 582811,
+				tcgplayer: 253331
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 582811,
+				tcgplayer: 253331
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/184.ts
+++ b/data/Sword & Shield/Fusion Strike/184.ts
@@ -63,17 +63,23 @@ const card: Card = {
 		}
 	}],
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582812,
-		tcgplayer: 253332
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 582812,
+				tcgplayer: 253332
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 582812,
+				tcgplayer: 253332
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/185.ts
+++ b/data/Sword & Shield/Fusion Strike/185.ts
@@ -80,17 +80,16 @@ const card: Card = {
 		value: "-30"
 	}],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582813,
-		tcgplayer: 253333
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 582813,
+				tcgplayer: 253333
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/186.ts
+++ b/data/Sword & Shield/Fusion Strike/186.ts
@@ -63,17 +63,23 @@ const card: Card = {
 		}
 	}],
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582814,
-		tcgplayer: 253335
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 582814,
+				tcgplayer: 253335
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 582814,
+				tcgplayer: 253335
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/187.ts
+++ b/data/Sword & Shield/Fusion Strike/187.ts
@@ -76,17 +76,23 @@ const card: Card = {
 		damage: 50
 	}],
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582815,
-		tcgplayer: 253336
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 582815,
+				tcgplayer: 253336
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 582815,
+				tcgplayer: 253336
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/188.ts
+++ b/data/Sword & Shield/Fusion Strike/188.ts
@@ -74,17 +74,23 @@ const card: Card = {
 		damage: 20
 	}],
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582819,
-		tcgplayer: 253338
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 582819,
+				tcgplayer: 253338
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 582819,
+				tcgplayer: 253338
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/189.ts
+++ b/data/Sword & Shield/Fusion Strike/189.ts
@@ -95,17 +95,23 @@ const card: Card = {
 		}
 	}],
 
-	variants: {
-		normal: false,
-		reverse: true,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582863,
-		tcgplayer: 253340
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 582863,
+				tcgplayer: 253340
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 582863,
+				tcgplayer: 253340
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/19.ts
+++ b/data/Sword & Shield/Fusion Strike/19.ts
@@ -48,17 +48,23 @@ const card: Card = {
 		damage: 20
 	}],
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582067,
-		tcgplayer: 253102
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 582067,
+				tcgplayer: 253102
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 582067,
+				tcgplayer: 253102
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/190.ts
+++ b/data/Sword & Shield/Fusion Strike/190.ts
@@ -95,17 +95,23 @@ const card: Card = {
 		}
 	}],
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582864,
-		tcgplayer: 253344
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 582864,
+				tcgplayer: 253344
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 582864,
+				tcgplayer: 253344
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/191.ts
+++ b/data/Sword & Shield/Fusion Strike/191.ts
@@ -76,17 +76,23 @@ const card: Card = {
 		}
 	}],
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582865,
-		tcgplayer: 253345
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 582865,
+				tcgplayer: 253345
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 582865,
+				tcgplayer: 253345
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/192.ts
+++ b/data/Sword & Shield/Fusion Strike/192.ts
@@ -86,17 +86,23 @@ const card: Card = {
 		}
 	}],
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582866,
-		tcgplayer: 253347
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 582866,
+				tcgplayer: 253347
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 582866,
+				tcgplayer: 253347
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/193.ts
+++ b/data/Sword & Shield/Fusion Strike/193.ts
@@ -73,17 +73,23 @@ const card: Card = {
 		}
 	}],
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582867,
-		tcgplayer: 253349
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 582867,
+				tcgplayer: 253349
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 582867,
+				tcgplayer: 253349
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/194.ts
+++ b/data/Sword & Shield/Fusion Strike/194.ts
@@ -73,17 +73,23 @@ const card: Card = {
 		}
 	}],
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582868,
-		tcgplayer: 253351
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 582868,
+				tcgplayer: 253351
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 582868,
+				tcgplayer: 253351
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/195.ts
+++ b/data/Sword & Shield/Fusion Strike/195.ts
@@ -55,17 +55,23 @@ const card: Card = {
 		damage: 20
 	}],
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582869,
-		tcgplayer: 253353
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 582869,
+				tcgplayer: 253353
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 582869,
+				tcgplayer: 253353
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/196.ts
+++ b/data/Sword & Shield/Fusion Strike/196.ts
@@ -74,17 +74,23 @@ const card: Card = {
 		}
 	}],
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582870,
-		tcgplayer: 253354
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 582870,
+				tcgplayer: 253354
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 582870,
+				tcgplayer: 253354
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/197.ts
+++ b/data/Sword & Shield/Fusion Strike/197.ts
@@ -74,17 +74,23 @@ const card: Card = {
 		damage: 120
 	}],
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582871,
-		tcgplayer: 253357
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 582871,
+				tcgplayer: 253357
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 582871,
+				tcgplayer: 253357
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/198.ts
+++ b/data/Sword & Shield/Fusion Strike/198.ts
@@ -64,17 +64,23 @@ const card: Card = {
 		damage: 80
 	}],
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582872,
-		tcgplayer: 253358
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 582872,
+				tcgplayer: 253358
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 582872,
+				tcgplayer: 253358
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/199.ts
+++ b/data/Sword & Shield/Fusion Strike/199.ts
@@ -57,17 +57,23 @@ const card: Card = {
 		}
 	}],
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582873,
-		tcgplayer: 253291
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 582873,
+				tcgplayer: 253291
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 582873,
+				tcgplayer: 253291
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/2.ts
+++ b/data/Sword & Shield/Fusion Strike/2.ts
@@ -80,17 +80,23 @@ const card: Card = {
 		damage: 10
 	}],
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582030,
-		tcgplayer: 253072
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 582030,
+				tcgplayer: 253072
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 582030,
+				tcgplayer: 253072
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/20.ts
+++ b/data/Sword & Shield/Fusion Strike/20.ts
@@ -80,17 +80,23 @@ const card: Card = {
 		}
 	}],
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582072,
-		tcgplayer: 253105
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 582072,
+				tcgplayer: 253105
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 582072,
+				tcgplayer: 253105
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/200.ts
+++ b/data/Sword & Shield/Fusion Strike/200.ts
@@ -80,17 +80,23 @@ const card: Card = {
 		damage: 70
 	}],
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582874,
-		tcgplayer: 253292
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 582874,
+				tcgplayer: 253292
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 582874,
+				tcgplayer: 253292
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/201.ts
+++ b/data/Sword & Shield/Fusion Strike/201.ts
@@ -82,17 +82,16 @@ const card: Card = {
 		}
 	}],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582876,
-		tcgplayer: 253295
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 582876,
+				tcgplayer: 253295
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/202.ts
+++ b/data/Sword & Shield/Fusion Strike/202.ts
@@ -70,17 +70,23 @@ const card: Card = {
 		damage: 70
 	}],
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582877,
-		tcgplayer: 253296
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 582877,
+				tcgplayer: 253296
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 582877,
+				tcgplayer: 253296
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/203.ts
+++ b/data/Sword & Shield/Fusion Strike/203.ts
@@ -89,17 +89,23 @@ const card: Card = {
 		}
 	}],
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582878,
-		tcgplayer: 253297
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 582878,
+				tcgplayer: 253297
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 582878,
+				tcgplayer: 253297
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/204.ts
+++ b/data/Sword & Shield/Fusion Strike/204.ts
@@ -70,17 +70,23 @@ const card: Card = {
 		}
 	}],
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582880,
-		tcgplayer: 253298
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 582880,
+				tcgplayer: 253298
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 582880,
+				tcgplayer: 253298
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/205.ts
+++ b/data/Sword & Shield/Fusion Strike/205.ts
@@ -57,17 +57,23 @@ const card: Card = {
 		}
 	}],
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582900,
-		tcgplayer: 253300
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 582900,
+				tcgplayer: 253300
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 582900,
+				tcgplayer: 253300
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/206.ts
+++ b/data/Sword & Shield/Fusion Strike/206.ts
@@ -48,17 +48,23 @@ const card: Card = {
 		damage: 80
 	}],
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582903,
-		tcgplayer: 253301
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 582903,
+				tcgplayer: 253301
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 582903,
+				tcgplayer: 253301
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/207.ts
+++ b/data/Sword & Shield/Fusion Strike/207.ts
@@ -70,17 +70,23 @@ const card: Card = {
 		damage: 30
 	}],
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582940,
-		tcgplayer: 253302
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 582940,
+				tcgplayer: 253302
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 582940,
+				tcgplayer: 253302
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/208.ts
+++ b/data/Sword & Shield/Fusion Strike/208.ts
@@ -70,17 +70,23 @@ const card: Card = {
 		}
 	}],
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582941,
-		tcgplayer: 253304
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 582941,
+				tcgplayer: 253304
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 582941,
+				tcgplayer: 253304
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/209.ts
+++ b/data/Sword & Shield/Fusion Strike/209.ts
@@ -68,17 +68,23 @@ const card: Card = {
 		damage: 80
 	}],
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582944,
-		tcgplayer: 253305
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 582944,
+				tcgplayer: 253305
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 582944,
+				tcgplayer: 253305
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/21.ts
+++ b/data/Sword & Shield/Fusion Strike/21.ts
@@ -54,17 +54,16 @@ const card: Card = {
 		}
 	}],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582075,
-		tcgplayer: 253109
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 582075,
+				tcgplayer: 253109
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/210.ts
+++ b/data/Sword & Shield/Fusion Strike/210.ts
@@ -57,17 +57,23 @@ const card: Card = {
 		}
 	}],
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582946,
-		tcgplayer: 253306
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 582946,
+				tcgplayer: 253306
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 582946,
+				tcgplayer: 253306
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/211.ts
+++ b/data/Sword & Shield/Fusion Strike/211.ts
@@ -87,17 +87,23 @@ const card: Card = {
 		}
 	}],
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582947,
-		tcgplayer: 253307
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 582947,
+				tcgplayer: 253307
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 582947,
+				tcgplayer: 253307
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/212.ts
+++ b/data/Sword & Shield/Fusion Strike/212.ts
@@ -57,17 +57,23 @@ const card: Card = {
 		}
 	}],
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582948,
-		tcgplayer: 253309
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 582948,
+				tcgplayer: 253309
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 582948,
+				tcgplayer: 253309
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/213.ts
+++ b/data/Sword & Shield/Fusion Strike/213.ts
@@ -58,17 +58,23 @@ const card: Card = {
 		damage: 70
 	}],
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582949,
-		tcgplayer: 253310
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 582949,
+				tcgplayer: 253310
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 582949,
+				tcgplayer: 253310
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/214.ts
+++ b/data/Sword & Shield/Fusion Strike/214.ts
@@ -77,17 +77,23 @@ const card: Card = {
 		}
 	}],
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582950,
-		tcgplayer: 253312
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 582950,
+				tcgplayer: 253312
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 582950,
+				tcgplayer: 253312
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/215.ts
+++ b/data/Sword & Shield/Fusion Strike/215.ts
@@ -80,17 +80,23 @@ const card: Card = {
 		}
 	}],
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582951,
-		tcgplayer: 253314
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 582951,
+				tcgplayer: 253314
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 582951,
+				tcgplayer: 253314
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/216.ts
+++ b/data/Sword & Shield/Fusion Strike/216.ts
@@ -63,17 +63,23 @@ const card: Card = {
 		}
 	}],
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582952,
-		tcgplayer: 253315
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 582952,
+				tcgplayer: 253315
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 582952,
+				tcgplayer: 253315
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/217.ts
+++ b/data/Sword & Shield/Fusion Strike/217.ts
@@ -76,17 +76,16 @@ const card: Card = {
 		}
 	}],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582953,
-		tcgplayer: 253316
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 582953,
+				tcgplayer: 253316
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/218.ts
+++ b/data/Sword & Shield/Fusion Strike/218.ts
@@ -85,17 +85,16 @@ const card: Card = {
 		}
 	}],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582954,
-		tcgplayer: 253317
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 582954,
+				tcgplayer: 253317
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/219.ts
+++ b/data/Sword & Shield/Fusion Strike/219.ts
@@ -63,17 +63,23 @@ const card: Card = {
 		}
 	}],
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582955,
-		tcgplayer: 253319
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 582955,
+				tcgplayer: 253319
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 582955,
+				tcgplayer: 253319
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/22.ts
+++ b/data/Sword & Shield/Fusion Strike/22.ts
@@ -67,17 +67,16 @@ const card: Card = {
 		damage: 160
 	}],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582081,
-		tcgplayer: 253113
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 582081,
+				tcgplayer: 253113
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/220.ts
+++ b/data/Sword & Shield/Fusion Strike/220.ts
@@ -73,17 +73,23 @@ const card: Card = {
 		}
 	}],
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582956,
-		tcgplayer: 253320
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 582956,
+				tcgplayer: 253320
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 582956,
+				tcgplayer: 253320
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/221.ts
+++ b/data/Sword & Shield/Fusion Strike/221.ts
@@ -79,17 +79,23 @@ const card: Card = {
 		}
 	}],
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582957,
-		tcgplayer: 253322
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 582957,
+				tcgplayer: 253322
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 582957,
+				tcgplayer: 253322
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/222.ts
+++ b/data/Sword & Shield/Fusion Strike/222.ts
@@ -57,17 +57,30 @@ const card: Card = {
 		}
 	}],
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582957,
-		tcgplayer: 253323
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 582958,
+				tcgplayer: 253323
+			}
+		},
+		{
+			type: 'holo',
+			foil: 'cosmos',
+			thirdParty: {
+				cardmarket: 878475
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 582958,
+				tcgplayer: 253323
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/223.ts
+++ b/data/Sword & Shield/Fusion Strike/223.ts
@@ -80,17 +80,23 @@ const card: Card = {
 		damage: 70
 	}],
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582959,
-		tcgplayer: 253324
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 582959,
+				tcgplayer: 253324
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 582959,
+				tcgplayer: 253324
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/224.ts
+++ b/data/Sword & Shield/Fusion Strike/224.ts
@@ -29,17 +29,23 @@ const card: Card = {
 	regulationMark: "E",
 	illustrator: "Taira Akitsu",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582960,
-		tcgplayer: 253089
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 582960,
+				tcgplayer: 253089
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 582960,
+				tcgplayer: 253089
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/225.ts
+++ b/data/Sword & Shield/Fusion Strike/225.ts
@@ -29,17 +29,23 @@ const card: Card = {
 	regulationMark: "E",
 	illustrator: "Ryo Ueda",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582961,
-		tcgplayer: 253091
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 582961,
+				tcgplayer: 253091
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 582961,
+				tcgplayer: 253091
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/226.ts
+++ b/data/Sword & Shield/Fusion Strike/226.ts
@@ -28,17 +28,23 @@ const card: Card = {
 	trainerType: "Supporter",
 	illustrator: "Yuu Nishida",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582962,
-		tcgplayer: 253093
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 582962,
+				tcgplayer: 253093
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 582962,
+				tcgplayer: 253093
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/227.ts
+++ b/data/Sword & Shield/Fusion Strike/227.ts
@@ -29,17 +29,23 @@ const card: Card = {
 	regulationMark: "E",
 	illustrator: "Yusuke Ohmura",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582963,
-		tcgplayer: 253097
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 582963,
+				tcgplayer: 253097
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 582963,
+				tcgplayer: 253097
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/228.ts
+++ b/data/Sword & Shield/Fusion Strike/228.ts
@@ -29,17 +29,23 @@ const card: Card = {
 	regulationMark: "E",
 	illustrator: "Sanosuke Sakuma",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582964,
-		tcgplayer: 253099
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 582964,
+				tcgplayer: 253099
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 582964,
+				tcgplayer: 253099
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/229.ts
+++ b/data/Sword & Shield/Fusion Strike/229.ts
@@ -29,17 +29,23 @@ const card: Card = {
 	regulationMark: "E",
 	illustrator: "Ryo Ueda",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582965,
-		tcgplayer: 253100
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 582965,
+				tcgplayer: 253100
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 582965,
+				tcgplayer: 253100
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/23.ts
+++ b/data/Sword & Shield/Fusion Strike/23.ts
@@ -63,17 +63,16 @@ const card: Card = {
 		}
 	}],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582085,
-		tcgplayer: 253108
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 582085,
+				tcgplayer: 253108
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/230.ts
+++ b/data/Sword & Shield/Fusion Strike/230.ts
@@ -29,17 +29,23 @@ const card: Card = {
 	regulationMark: "E",
 	illustrator: "inose yukie",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582966,
-		tcgplayer: 253101
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 582966,
+				tcgplayer: 253101
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 582966,
+				tcgplayer: 253101
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/231.ts
+++ b/data/Sword & Shield/Fusion Strike/231.ts
@@ -29,17 +29,23 @@ const card: Card = {
 	regulationMark: "E",
 	illustrator: "Studio Bora Inc.",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582967,
-		tcgplayer: 253103
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 582967,
+				tcgplayer: 253103
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 582967,
+				tcgplayer: 253103
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/232.ts
+++ b/data/Sword & Shield/Fusion Strike/232.ts
@@ -29,17 +29,23 @@ const card: Card = {
 	regulationMark: "E",
 	illustrator: "Sanosuke Sakuma",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582968,
-		tcgplayer: 253104
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 582968,
+				tcgplayer: 253104
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 582968,
+				tcgplayer: 253104
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/233.ts
+++ b/data/Sword & Shield/Fusion Strike/233.ts
@@ -29,17 +29,23 @@ const card: Card = {
 	regulationMark: "E",
 	illustrator: "Yusuke Ohmura",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582969,
-		tcgplayer: 253106
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 582969,
+				tcgplayer: 253106
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 582969,
+				tcgplayer: 253106
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/234.ts
+++ b/data/Sword & Shield/Fusion Strike/234.ts
@@ -29,17 +29,23 @@ const card: Card = {
 	regulationMark: "E",
 	illustrator: "AYUMI ODASHIMA",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582970,
-		tcgplayer: 253107
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 582970,
+				tcgplayer: 253107
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 582970,
+				tcgplayer: 253107
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/235.ts
+++ b/data/Sword & Shield/Fusion Strike/235.ts
@@ -28,17 +28,23 @@ const card: Card = {
 	trainerType: "Supporter",
 	illustrator: "Ryuta Fuse",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582971,
-		tcgplayer: 253110
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 582971,
+				tcgplayer: 253110
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 582971,
+				tcgplayer: 253110
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/236.ts
+++ b/data/Sword & Shield/Fusion Strike/236.ts
@@ -29,17 +29,23 @@ const card: Card = {
 	regulationMark: "E",
 	illustrator: "Toyste Beach",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582972,
-		tcgplayer: 253111
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 582972,
+				tcgplayer: 253111
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 582972,
+				tcgplayer: 253111
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/237.ts
+++ b/data/Sword & Shield/Fusion Strike/237.ts
@@ -29,17 +29,37 @@ const card: Card = {
 	regulationMark: "D",
 	illustrator: "Ryo Ueda",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582973,
-		tcgplayer: 253112
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 582973,
+				tcgplayer: 253112
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 582973,
+				tcgplayer: 253112
+			}
+		},
+		{
+			type: 'reverse',
+			stamp: ['national-championships'],
+			thirdParty: {
+				cardmarket: 653292
+			}
+		},
+		{
+			type: 'reverse',
+			stamp: ['national-championships', 'staff'],
+			thirdParty: {
+				cardmarket: 653293
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/238.ts
+++ b/data/Sword & Shield/Fusion Strike/238.ts
@@ -29,17 +29,23 @@ const card: Card = {
 	regulationMark: "E",
 	illustrator: "kirisAki",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582974,
-		tcgplayer: 253114
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 582974,
+				tcgplayer: 253114
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 582974,
+				tcgplayer: 253114
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/239.ts
+++ b/data/Sword & Shield/Fusion Strike/239.ts
@@ -29,17 +29,23 @@ const card: Card = {
 	regulationMark: "E",
 	illustrator: "kirisAki",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582975,
-		tcgplayer: 253116
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 582975,
+				tcgplayer: 253116
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 582975,
+				tcgplayer: 253116
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/24.ts
+++ b/data/Sword & Shield/Fusion Strike/24.ts
@@ -48,17 +48,23 @@ const card: Card = {
 		damage: 10
 	}],
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582089,
-		tcgplayer: 253115
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 582089,
+				tcgplayer: 253115
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 582089,
+				tcgplayer: 253115
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/240.ts
+++ b/data/Sword & Shield/Fusion Strike/240.ts
@@ -28,17 +28,23 @@ const card: Card = {
 	trainerType: "Supporter",
 	illustrator: "Yuu Nishida",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582976,
-		tcgplayer: 253117
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 582976,
+				tcgplayer: 253117
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 582976,
+				tcgplayer: 253117
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/241.ts
+++ b/data/Sword & Shield/Fusion Strike/241.ts
@@ -29,17 +29,23 @@ const card: Card = {
 	regulationMark: "E",
 	illustrator: "Hideki Ishikawa",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582977,
-		tcgplayer: 253119
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 582977,
+				tcgplayer: 253119
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 582977,
+				tcgplayer: 253119
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/242.ts
+++ b/data/Sword & Shield/Fusion Strike/242.ts
@@ -29,17 +29,23 @@ const card: Card = {
 	regulationMark: "E",
 	illustrator: "Oswaldo KATO",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582978,
-		tcgplayer: 253121
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 582978,
+				tcgplayer: 253121
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 582978,
+				tcgplayer: 253121
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/243.ts
+++ b/data/Sword & Shield/Fusion Strike/243.ts
@@ -29,17 +29,23 @@ const card: Card = {
 	regulationMark: "E",
 	illustrator: "Toyste Beach",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582979,
-		tcgplayer: 253123
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 582979,
+				tcgplayer: 253123
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 582979,
+				tcgplayer: 253123
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/244.ts
+++ b/data/Sword & Shield/Fusion Strike/244.ts
@@ -28,17 +28,23 @@ const card: Card = {
 	energyType: "Special",
 	regulationMark: "E",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582980,
-		tcgplayer: 253127
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 582980,
+				tcgplayer: 253127
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 582980,
+				tcgplayer: 253127
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/245.ts
+++ b/data/Sword & Shield/Fusion Strike/245.ts
@@ -74,17 +74,16 @@ const card: Card = {
 		}
 	}],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582981,
-		tcgplayer: 253138
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 582981,
+				tcgplayer: 253138
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/246.ts
+++ b/data/Sword & Shield/Fusion Strike/246.ts
@@ -54,17 +54,16 @@ const card: Card = {
 		}
 	}],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582982,
-		tcgplayer: 253139
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 582982,
+				tcgplayer: 253139
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/247.ts
+++ b/data/Sword & Shield/Fusion Strike/247.ts
@@ -74,17 +74,16 @@ const card: Card = {
 		}
 	}],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582983,
-		tcgplayer: 253141
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 582983,
+				tcgplayer: 253141
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/248.ts
+++ b/data/Sword & Shield/Fusion Strike/248.ts
@@ -74,17 +74,16 @@ const card: Card = {
 		}
 	}],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582984,
-		tcgplayer: 253143
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 582984,
+				tcgplayer: 253143
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/249.ts
+++ b/data/Sword & Shield/Fusion Strike/249.ts
@@ -76,17 +76,16 @@ const card: Card = {
 		}
 	}],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582985,
-		tcgplayer: 253144
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 582985,
+				tcgplayer: 253144
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/25.ts
+++ b/data/Sword & Shield/Fusion Strike/25.ts
@@ -67,17 +67,23 @@ const card: Card = {
 		}
 	}],
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582092,
-		tcgplayer: 253118
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 582092,
+				tcgplayer: 253118
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 582092,
+				tcgplayer: 253118
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/250.ts
+++ b/data/Sword & Shield/Fusion Strike/250.ts
@@ -80,17 +80,16 @@ const card: Card = {
 		}
 	}],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582986,
-		tcgplayer: 253146
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 582986,
+				tcgplayer: 253146
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/251.ts
+++ b/data/Sword & Shield/Fusion Strike/251.ts
@@ -80,17 +80,16 @@ const card: Card = {
 		}
 	}],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582987,
-		tcgplayer: 253147
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 582987,
+				tcgplayer: 253147
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/252.ts
+++ b/data/Sword & Shield/Fusion Strike/252.ts
@@ -67,17 +67,16 @@ const card: Card = {
 		damage: 140
 	}],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582988,
-		tcgplayer: 253149
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 582988,
+				tcgplayer: 253149
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/253.ts
+++ b/data/Sword & Shield/Fusion Strike/253.ts
@@ -76,17 +76,16 @@ const card: Card = {
 		}
 	}],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582989,
-		tcgplayer: 253152
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 582989,
+				tcgplayer: 253152
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/254.ts
+++ b/data/Sword & Shield/Fusion Strike/254.ts
@@ -82,17 +82,16 @@ const card: Card = {
 		}
 	}],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582990,
-		tcgplayer: 253154
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 582990,
+				tcgplayer: 253154
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/255.ts
+++ b/data/Sword & Shield/Fusion Strike/255.ts
@@ -82,17 +82,16 @@ const card: Card = {
 		}
 	}],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582991,
-		tcgplayer: 253155
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 582991,
+				tcgplayer: 253155
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/256.ts
+++ b/data/Sword & Shield/Fusion Strike/256.ts
@@ -76,17 +76,16 @@ const card: Card = {
 		}
 	}],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582992,
-		tcgplayer: 253156
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 582992,
+				tcgplayer: 253156
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/257.ts
+++ b/data/Sword & Shield/Fusion Strike/257.ts
@@ -76,17 +76,16 @@ const card: Card = {
 		}
 	}],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582994,
-		tcgplayer: 253157
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 582994,
+				tcgplayer: 253157
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/258.ts
+++ b/data/Sword & Shield/Fusion Strike/258.ts
@@ -29,17 +29,16 @@ const card: Card = {
 	regulationMark: "E",
 	illustrator: "Sanosuke Sakuma",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582995,
-		tcgplayer: 253159
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 582995,
+				tcgplayer: 253159
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/259.ts
+++ b/data/Sword & Shield/Fusion Strike/259.ts
@@ -29,17 +29,16 @@ const card: Card = {
 	regulationMark: "E",
 	illustrator: "Yuu Nishida",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582996,
-		tcgplayer: 253160
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 582996,
+				tcgplayer: 253160
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/26.ts
+++ b/data/Sword & Shield/Fusion Strike/26.ts
@@ -67,17 +67,16 @@ const card: Card = {
 		}
 	}],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582095,
-		tcgplayer: 253120
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 582095,
+				tcgplayer: 253120
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/260.ts
+++ b/data/Sword & Shield/Fusion Strike/260.ts
@@ -29,17 +29,16 @@ const card: Card = {
 	regulationMark: "E",
 	illustrator: "Ryuta Fuse",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582998,
-		tcgplayer: 253161
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 582998,
+				tcgplayer: 253161
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/261.ts
+++ b/data/Sword & Shield/Fusion Strike/261.ts
@@ -29,17 +29,16 @@ const card: Card = {
 	regulationMark: "E",
 	illustrator: "Hideki Ishikawa",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582999,
-		tcgplayer: 253162
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 582999,
+				tcgplayer: 253162
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/262.ts
+++ b/data/Sword & Shield/Fusion Strike/262.ts
@@ -29,17 +29,16 @@ const card: Card = {
 	regulationMark: "E",
 	illustrator: "Hideki Ishikawa",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 583001,
-		tcgplayer: 253163
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 583001,
+				tcgplayer: 253163
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/263.ts
+++ b/data/Sword & Shield/Fusion Strike/263.ts
@@ -28,17 +28,16 @@ const card: Card = {
 	trainerType: "Supporter",
 	illustrator: "Yuu Nishida",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 583003,
-		tcgplayer: 253165
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 583003,
+				tcgplayer: 253165
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/264.ts
+++ b/data/Sword & Shield/Fusion Strike/264.ts
@@ -29,17 +29,16 @@ const card: Card = {
 	regulationMark: "E",
 	illustrator: "Hideki Ishikawa",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 583005,
-		tcgplayer: 253166
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 583005,
+				tcgplayer: 253166
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/265.ts
+++ b/data/Sword & Shield/Fusion Strike/265.ts
@@ -85,17 +85,16 @@ const card: Card = {
 		}
 	}],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 583008,
-		tcgplayer: 253167
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 583008,
+				tcgplayer: 253167
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/266.ts
+++ b/data/Sword & Shield/Fusion Strike/266.ts
@@ -85,17 +85,16 @@ const card: Card = {
 		}
 	}],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 583012,
-		tcgplayer: 253171
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 583012,
+				tcgplayer: 253171
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/267.ts
+++ b/data/Sword & Shield/Fusion Strike/267.ts
@@ -85,17 +85,17 @@ const card: Card = {
 		}
 	}],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 583014,
-		tcgplayer: 253174
-	}
+	variants: [
+		{
+			type: 'holo',
+			foil: 'rainbow',
+			thirdParty: {
+				cardmarket: 583014,
+				tcgplayer: 253174
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/268.ts
+++ b/data/Sword & Shield/Fusion Strike/268.ts
@@ -89,17 +89,17 @@ const card: Card = {
 		}
 	}],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 583016,
-		tcgplayer: 253176
-	}
+	variants: [
+		{
+			type: 'holo',
+			foil: 'rainbow',
+			thirdParty: {
+				cardmarket: 583016,
+				tcgplayer: 253176
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/269.ts
+++ b/data/Sword & Shield/Fusion Strike/269.ts
@@ -89,17 +89,16 @@ const card: Card = {
 		}
 	}],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 583019,
-		tcgplayer: 253177
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 583019,
+				tcgplayer: 253177
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/27.ts
+++ b/data/Sword & Shield/Fusion Strike/27.ts
@@ -70,17 +70,23 @@ const card: Card = {
 		}
 	}],
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582098,
-		tcgplayer: 253122
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 582098,
+				tcgplayer: 253122
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 582098,
+				tcgplayer: 253122
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/270.ts
+++ b/data/Sword & Shield/Fusion Strike/270.ts
@@ -91,17 +91,16 @@ const card: Card = {
 		}
 	}],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 583020,
-		tcgplayer: 253265
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 583020,
+				tcgplayer: 253265
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/271.ts
+++ b/data/Sword & Shield/Fusion Strike/271.ts
@@ -85,17 +85,16 @@ const card: Card = {
 		}
 	}],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 583024,
-		tcgplayer: 253266
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 583024,
+				tcgplayer: 253266
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/272.ts
+++ b/data/Sword & Shield/Fusion Strike/272.ts
@@ -85,10 +85,16 @@ const card: Card = {
 		}
 	}],
 
-	thirdParty: {
-		cardmarket: 583026,
-		tcgplayer: 253270
-	}
+	variants: [
+		{
+			type: 'holo',
+			foil: 'rainbow',
+			thirdParty: {
+				cardmarket: 583026,
+				tcgplayer: 253270
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/273.ts
+++ b/data/Sword & Shield/Fusion Strike/273.ts
@@ -29,10 +29,16 @@ const card: Card = {
 	regulationMark: "E",
 	illustrator: "Sanosuke Sakuma",
 
-	thirdParty: {
-		cardmarket: 583028,
-		tcgplayer: 253271
-	}
+	variants: [
+		{
+			type: 'holo',
+			foil: 'rainbow',
+			thirdParty: {
+				cardmarket: 583028,
+				tcgplayer: 253271
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/274.ts
+++ b/data/Sword & Shield/Fusion Strike/274.ts
@@ -29,10 +29,16 @@ const card: Card = {
 	regulationMark: "E",
 	illustrator: "Yuu Nishida",
 
-	thirdParty: {
-		cardmarket: 583030,
-		tcgplayer: 253272
-	}
+	variants: [
+		{
+			type: 'holo',
+			foil: 'rainbow',
+			thirdParty: {
+				cardmarket: 583030,
+				tcgplayer: 253272
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/275.ts
+++ b/data/Sword & Shield/Fusion Strike/275.ts
@@ -29,10 +29,16 @@ const card: Card = {
 	regulationMark: "E",
 	illustrator: "Ryuta Fuse",
 
-	thirdParty: {
-		cardmarket: 583032,
-		tcgplayer: 253276
-	}
+	variants: [
+		{
+			type: 'holo',
+			foil: 'rainbow',
+			thirdParty: {
+				cardmarket: 583032,
+				tcgplayer: 253276
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/276.ts
+++ b/data/Sword & Shield/Fusion Strike/276.ts
@@ -29,10 +29,16 @@ const card: Card = {
 	regulationMark: "E",
 	illustrator: "Hideki Ishikawa",
 
-	thirdParty: {
-		cardmarket: 583034,
-		tcgplayer: 253277
-	}
+	variants: [
+		{
+			type: 'holo',
+			foil: 'rainbow',
+			thirdParty: {
+				cardmarket: 583034,
+				tcgplayer: 253277
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/277.ts
+++ b/data/Sword & Shield/Fusion Strike/277.ts
@@ -29,10 +29,16 @@ const card: Card = {
 	regulationMark: "E",
 	illustrator: "Hideki Ishikawa",
 
-	thirdParty: {
-		cardmarket: 583036,
-		tcgplayer: 253279
-	}
+	variants: [
+		{
+			type: 'holo',
+			foil: 'rainbow',
+			thirdParty: {
+				cardmarket: 583036,
+				tcgplayer: 253279
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/278.ts
+++ b/data/Sword & Shield/Fusion Strike/278.ts
@@ -28,10 +28,16 @@ const card: Card = {
 	trainerType: "Supporter",
 	illustrator: "Yuu Nishida",
 
-	thirdParty: {
-		cardmarket: 583039,
-		tcgplayer: 253280
-	}
+	variants: [
+		{
+			type: 'holo',
+			foil: 'rainbow',
+			thirdParty: {
+				cardmarket: 583039,
+				tcgplayer: 253280
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/279.ts
+++ b/data/Sword & Shield/Fusion Strike/279.ts
@@ -29,10 +29,16 @@ const card: Card = {
 	regulationMark: "E",
 	illustrator: "Hideki Ishikawa",
 
-	thirdParty: {
-		cardmarket: 583040,
-		tcgplayer: 253281
-	}
+	variants: [
+		{
+			type: 'holo',
+			foil: 'rainbow',
+			thirdParty: {
+				cardmarket: 583040,
+				tcgplayer: 253281
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/28.ts
+++ b/data/Sword & Shield/Fusion Strike/28.ts
@@ -48,17 +48,23 @@ const card: Card = {
 		damage: 30
 	}],
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582162,
-		tcgplayer: 253124
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 582162,
+				tcgplayer: 253124
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 582162,
+				tcgplayer: 253124
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/280.ts
+++ b/data/Sword & Shield/Fusion Strike/280.ts
@@ -80,10 +80,16 @@ const card: Card = {
 		damage: 50
 	}],
 
-	thirdParty: {
-		cardmarket: 583041,
-		tcgplayer: 253284
-	}
+	variants: [
+		{
+			type: 'holo',
+			foil: 'gold',
+			thirdParty: {
+				cardmarket: 583041,
+				tcgplayer: 253284
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/281.ts
+++ b/data/Sword & Shield/Fusion Strike/281.ts
@@ -29,10 +29,16 @@ const card: Card = {
 	regulationMark: "E",
 	illustrator: "Toyste Beach",
 
-	thirdParty: {
-		cardmarket: 583043,
-		tcgplayer: 253285
-	}
+	variants: [
+		{
+			type: 'holo',
+			foil: 'gold',
+			thirdParty: {
+				cardmarket: 583043,
+				tcgplayer: 253285
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/282.ts
+++ b/data/Sword & Shield/Fusion Strike/282.ts
@@ -29,10 +29,16 @@ const card: Card = {
 	regulationMark: "D",
 	illustrator: "5ban Graphics",
 
-	thirdParty: {
-		cardmarket: 583046,
-		tcgplayer: 253286
-	}
+	variants: [
+		{
+			type: 'holo',
+			foil: 'gold',
+			thirdParty: {
+				cardmarket: 583046,
+				tcgplayer: 253286
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/283.ts
+++ b/data/Sword & Shield/Fusion Strike/283.ts
@@ -17,10 +17,16 @@ const card: Card = {
 	category: "Energy",
 	energyType: "Normal",
 
-	thirdParty: {
-		cardmarket: 583047,
-		tcgplayer: 253287
-	}
+	variants: [
+		{
+			type: 'holo',
+			foil: 'gold',
+			thirdParty: {
+				cardmarket: 583047,
+				tcgplayer: 253287
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/284.ts
+++ b/data/Sword & Shield/Fusion Strike/284.ts
@@ -17,10 +17,16 @@ const card: Card = {
 	category: "Energy",
 	energyType: "Normal",
 
-	thirdParty: {
-		cardmarket: 583048,
-		tcgplayer: 253289
-	}
+	variants: [
+		{
+			type: 'holo',
+			foil: 'gold',
+			thirdParty: {
+				cardmarket: 583048,
+				tcgplayer: 253289
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/29.ts
+++ b/data/Sword & Shield/Fusion Strike/29.ts
@@ -48,17 +48,23 @@ const card: Card = {
 		damage: 10
 	}],
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582162,
-		tcgplayer: 253125
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 582163,
+				tcgplayer: 253125
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 582163,
+				tcgplayer: 253125
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/3.ts
+++ b/data/Sword & Shield/Fusion Strike/3.ts
@@ -80,17 +80,23 @@ const card: Card = {
 		damage: 90
 	}],
 
-	variants: {
-		normal: false,
-		reverse: true,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582031,
-		tcgplayer: 253073
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 582031,
+				tcgplayer: 253073
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 582031,
+				tcgplayer: 253073
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/30.ts
+++ b/data/Sword & Shield/Fusion Strike/30.ts
@@ -58,17 +58,23 @@ const card: Card = {
 		damage: 70
 	}],
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582164,
-		tcgplayer: 253126
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 582164,
+				tcgplayer: 253126
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 582164,
+				tcgplayer: 253126
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/31.ts
+++ b/data/Sword & Shield/Fusion Strike/31.ts
@@ -80,17 +80,23 @@ const card: Card = {
 		damage: 60
 	}],
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582164,
-		tcgplayer: 253128
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 582165,
+				tcgplayer: 253128
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 582165,
+				tcgplayer: 253128
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/32.ts
+++ b/data/Sword & Shield/Fusion Strike/32.ts
@@ -68,17 +68,23 @@ const card: Card = {
 		damage: 30
 	}],
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582166,
-		tcgplayer: 253129
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 582166,
+				tcgplayer: 253129
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 582166,
+				tcgplayer: 253129
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/33.ts
+++ b/data/Sword & Shield/Fusion Strike/33.ts
@@ -80,17 +80,23 @@ const card: Card = {
 		}
 	}],
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582167,
-		tcgplayer: 253130
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 582167,
+				tcgplayer: 253130
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 582167,
+				tcgplayer: 253130
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/34.ts
+++ b/data/Sword & Shield/Fusion Strike/34.ts
@@ -61,17 +61,23 @@ const card: Card = {
 		damage: 20
 	}],
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582168,
-		tcgplayer: 253131
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 582168,
+				tcgplayer: 253131
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 582168,
+				tcgplayer: 253131
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/35.ts
+++ b/data/Sword & Shield/Fusion Strike/35.ts
@@ -80,17 +80,23 @@ const card: Card = {
 		}
 	}],
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582169,
-		tcgplayer: 253132
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 582169,
+				tcgplayer: 253132
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 582169,
+				tcgplayer: 253132
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/36.ts
+++ b/data/Sword & Shield/Fusion Strike/36.ts
@@ -68,17 +68,23 @@ const card: Card = {
 		damage: 20
 	}],
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582170,
-		tcgplayer: 253136
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 582170,
+				tcgplayer: 253136
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 582170,
+				tcgplayer: 253136
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/37.ts
+++ b/data/Sword & Shield/Fusion Strike/37.ts
@@ -57,17 +57,23 @@ const card: Card = {
 		}
 	}],
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582171,
-		tcgplayer: 253137
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 582171,
+				tcgplayer: 253137
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 582171,
+				tcgplayer: 253137
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/38.ts
+++ b/data/Sword & Shield/Fusion Strike/38.ts
@@ -80,17 +80,23 @@ const card: Card = {
 		}
 	}],
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582172,
-		tcgplayer: 253140
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 582172,
+				tcgplayer: 253140
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 582172,
+				tcgplayer: 253140
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/39.ts
+++ b/data/Sword & Shield/Fusion Strike/39.ts
@@ -74,17 +74,16 @@ const card: Card = {
 		}
 	}],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582173,
-		tcgplayer: 253142
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 582173,
+				tcgplayer: 253142
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/4.ts
+++ b/data/Sword & Shield/Fusion Strike/4.ts
@@ -61,17 +61,23 @@ const card: Card = {
 		damage: 20
 	}],
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582032,
-		tcgplayer: 253074
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 582032,
+				tcgplayer: 253074
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 582032,
+				tcgplayer: 253074
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/40.ts
+++ b/data/Sword & Shield/Fusion Strike/40.ts
@@ -84,17 +84,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582174,
-		tcgplayer: 253145
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 582174,
+				tcgplayer: 253145
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/41.ts
+++ b/data/Sword & Shield/Fusion Strike/41.ts
@@ -79,17 +79,23 @@ const card: Card = {
 		}
 	}],
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582175,
-		tcgplayer: 253150
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 582175,
+				tcgplayer: 253150
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 582175,
+				tcgplayer: 253150
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/42.ts
+++ b/data/Sword & Shield/Fusion Strike/42.ts
@@ -77,17 +77,23 @@ const card: Card = {
 		}
 	}],
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582176,
-		tcgplayer: 253158
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 582176,
+				tcgplayer: 253158
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 582176,
+				tcgplayer: 253158
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/43.ts
+++ b/data/Sword & Shield/Fusion Strike/43.ts
@@ -54,17 +54,16 @@ const card: Card = {
 		}
 	}],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582177,
-		tcgplayer: 253164
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 582177,
+				tcgplayer: 253164
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/44.ts
+++ b/data/Sword & Shield/Fusion Strike/44.ts
@@ -67,17 +67,16 @@ const card: Card = {
 		}
 	}],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582177,
-		tcgplayer: 253168
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 582178,
+				tcgplayer: 253168
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/45.ts
+++ b/data/Sword & Shield/Fusion Strike/45.ts
@@ -63,17 +63,16 @@ const card: Card = {
 		}
 	}],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582179,
-		tcgplayer: 253170
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 582179,
+				tcgplayer: 253170
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/46.ts
+++ b/data/Sword & Shield/Fusion Strike/46.ts
@@ -61,17 +61,23 @@ const card: Card = {
 		damage: 20
 	}],
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582180,
-		tcgplayer: 253172
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 582180,
+				tcgplayer: 253172
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 582180,
+				tcgplayer: 253172
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/47.ts
+++ b/data/Sword & Shield/Fusion Strike/47.ts
@@ -55,17 +55,23 @@ const card: Card = {
 		}
 	}],
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582180,
-		tcgplayer: 253175
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 582181,
+				tcgplayer: 253175
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 582181,
+				tcgplayer: 253175
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/48.ts
+++ b/data/Sword & Shield/Fusion Strike/48.ts
@@ -80,17 +80,23 @@ const card: Card = {
 		damage: 120
 	}],
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582182,
-		tcgplayer: 253179
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 582182,
+				tcgplayer: 253179
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 582182,
+				tcgplayer: 253179
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/49.ts
+++ b/data/Sword & Shield/Fusion Strike/49.ts
@@ -71,17 +71,23 @@ const card: Card = {
 		damage: 100
 	}],
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582182,
-		tcgplayer: 253180
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 582183,
+				tcgplayer: 253180
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 582183,
+				tcgplayer: 253180
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/5.ts
+++ b/data/Sword & Shield/Fusion Strike/5.ts
@@ -80,17 +80,23 @@ const card: Card = {
 		}
 	}],
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582033,
-		tcgplayer: 253075
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 582033,
+				tcgplayer: 253075
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 582033,
+				tcgplayer: 253075
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/50.ts
+++ b/data/Sword & Shield/Fusion Strike/50.ts
@@ -61,17 +61,23 @@ const card: Card = {
 		damage: 20
 	}],
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582184,
-		tcgplayer: 253181
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 582184,
+				tcgplayer: 253181
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 582184,
+				tcgplayer: 253181
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/51.ts
+++ b/data/Sword & Shield/Fusion Strike/51.ts
@@ -89,17 +89,23 @@ const card: Card = {
 		}
 	}],
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582185,
-		tcgplayer: 253182
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 582185,
+				tcgplayer: 253182
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 582185,
+				tcgplayer: 253182
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/52.ts
+++ b/data/Sword & Shield/Fusion Strike/52.ts
@@ -68,17 +68,23 @@ const card: Card = {
 		damage: 10
 	}],
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582186,
-		tcgplayer: 253183
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 582186,
+				tcgplayer: 253183
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 582186,
+				tcgplayer: 253183
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/53.ts
+++ b/data/Sword & Shield/Fusion Strike/53.ts
@@ -65,17 +65,23 @@ const card: Card = {
 		}
 	}],
 
-	variants: {
-		normal: false,
-		reverse: true,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582187,
-		tcgplayer: 253184
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 582187,
+				tcgplayer: 253184
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 582187,
+				tcgplayer: 253184
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/54.ts
+++ b/data/Sword & Shield/Fusion Strike/54.ts
@@ -75,17 +75,23 @@ const card: Card = {
 		}
 	}],
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582188,
-		tcgplayer: 253185
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 582188,
+				tcgplayer: 253185
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 582188,
+				tcgplayer: 253185
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/55.ts
+++ b/data/Sword & Shield/Fusion Strike/55.ts
@@ -48,17 +48,23 @@ const card: Card = {
 		damage: 20
 	}],
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582189,
-		tcgplayer: 253186
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 582189,
+				tcgplayer: 253186
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 582189,
+				tcgplayer: 253186
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/56.ts
+++ b/data/Sword & Shield/Fusion Strike/56.ts
@@ -71,17 +71,23 @@ const card: Card = {
 		damage: 60
 	}],
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582190,
-		tcgplayer: 253187
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 582190,
+				tcgplayer: 253187
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 582190,
+				tcgplayer: 253187
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/57.ts
+++ b/data/Sword & Shield/Fusion Strike/57.ts
@@ -89,17 +89,23 @@ const card: Card = {
 		}
 	}],
 
-	variants: {
-		normal: false,
-		reverse: true,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582191,
-		tcgplayer: 253188
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 582191,
+				tcgplayer: 253188
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 582191,
+				tcgplayer: 253188
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/58.ts
+++ b/data/Sword & Shield/Fusion Strike/58.ts
@@ -77,17 +77,23 @@ const card: Card = {
 		}
 	}],
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582192,
-		tcgplayer: 253189
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 582192,
+				tcgplayer: 253189
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 582192,
+				tcgplayer: 253189
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/59.ts
+++ b/data/Sword & Shield/Fusion Strike/59.ts
@@ -78,17 +78,23 @@ const card: Card = {
 		damage: 90
 	}],
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582193,
-		tcgplayer: 253190
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 582193,
+				tcgplayer: 253190
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 582193,
+				tcgplayer: 253190
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/6.ts
+++ b/data/Sword & Shield/Fusion Strike/6.ts
@@ -67,17 +67,16 @@ const card: Card = {
 		damage: 140
 	}],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582034,
-		tcgplayer: 253076
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 582034,
+				tcgplayer: 253076
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/60.ts
+++ b/data/Sword & Shield/Fusion Strike/60.ts
@@ -68,17 +68,23 @@ const card: Card = {
 		damage: 30
 	}],
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582194,
-		tcgplayer: 253192
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 582194,
+				tcgplayer: 253192
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 582194,
+				tcgplayer: 253192
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/61.ts
+++ b/data/Sword & Shield/Fusion Strike/61.ts
@@ -70,17 +70,23 @@ const card: Card = {
 		damage: 80
 	}],
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582195,
-		tcgplayer: 253195
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 582195,
+				tcgplayer: 253195
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 582195,
+				tcgplayer: 253195
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/62.ts
+++ b/data/Sword & Shield/Fusion Strike/62.ts
@@ -61,17 +61,23 @@ const card: Card = {
 		damage: 30
 	}],
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582196,
-		tcgplayer: 253199
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 582196,
+				tcgplayer: 253199
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 582196,
+				tcgplayer: 253199
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/63.ts
+++ b/data/Sword & Shield/Fusion Strike/63.ts
@@ -80,17 +80,23 @@ const card: Card = {
 		}
 	}],
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582197,
-		tcgplayer: 253201
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 582197,
+				tcgplayer: 253201
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 582197,
+				tcgplayer: 253201
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/64.ts
+++ b/data/Sword & Shield/Fusion Strike/64.ts
@@ -89,17 +89,23 @@ const card: Card = {
 		}
 	}],
 
-	variants: {
-		normal: false,
-		reverse: true,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582198,
-		tcgplayer: 253205
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 582198,
+				tcgplayer: 253205
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 582198,
+				tcgplayer: 253205
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/65.ts
+++ b/data/Sword & Shield/Fusion Strike/65.ts
@@ -48,17 +48,23 @@ const card: Card = {
 		damage: 10
 	}],
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582199,
-		tcgplayer: 253208
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 582199,
+				tcgplayer: 253208
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 582199,
+				tcgplayer: 253208
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/66.ts
+++ b/data/Sword & Shield/Fusion Strike/66.ts
@@ -79,17 +79,23 @@ const card: Card = {
 		value: "×2"
 	}],
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582200,
-		tcgplayer: 253209
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 582200,
+				tcgplayer: 253209
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 582200,
+				tcgplayer: 253209
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/67.ts
+++ b/data/Sword & Shield/Fusion Strike/67.ts
@@ -88,17 +88,23 @@ const card: Card = {
 		value: "×2"
 	}],
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582201,
-		tcgplayer: 253210
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 582201,
+				tcgplayer: 253210
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 582201,
+				tcgplayer: 253210
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/68.ts
+++ b/data/Sword & Shield/Fusion Strike/68.ts
@@ -57,17 +57,23 @@ const card: Card = {
 		}
 	}],
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582202,
-		tcgplayer: 253211
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 582202,
+				tcgplayer: 253211
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 582202,
+				tcgplayer: 253211
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/69.ts
+++ b/data/Sword & Shield/Fusion Strike/69.ts
@@ -89,17 +89,23 @@ const card: Card = {
 		}
 	}],
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582203,
-		tcgplayer: 253212
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 582203,
+				tcgplayer: 253212
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 582203,
+				tcgplayer: 253212
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/7.ts
+++ b/data/Sword & Shield/Fusion Strike/7.ts
@@ -48,17 +48,23 @@ const card: Card = {
 		damage: 20
 	}],
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582035,
-		tcgplayer: 253077
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 582035,
+				tcgplayer: 253077
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 582035,
+				tcgplayer: 253077
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/70.ts
+++ b/data/Sword & Shield/Fusion Strike/70.ts
@@ -57,17 +57,23 @@ const card: Card = {
 		}
 	}],
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582204,
-		tcgplayer: 253215
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 582204,
+				tcgplayer: 253215
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 582204,
+				tcgplayer: 253215
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/71.ts
+++ b/data/Sword & Shield/Fusion Strike/71.ts
@@ -57,17 +57,23 @@ const card: Card = {
 		}
 	}],
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582205,
-		tcgplayer: 253218
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 582205,
+				tcgplayer: 253218
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 582205,
+				tcgplayer: 253218
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/72.ts
+++ b/data/Sword & Shield/Fusion Strike/72.ts
@@ -89,17 +89,23 @@ const card: Card = {
 		}
 	}],
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582206,
-		tcgplayer: 253222
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 582206,
+				tcgplayer: 253222
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 582206,
+				tcgplayer: 253222
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/73.ts
+++ b/data/Sword & Shield/Fusion Strike/73.ts
@@ -67,17 +67,16 @@ const card: Card = {
 		}
 	}],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582207,
-		tcgplayer: 253223
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 582207,
+				tcgplayer: 253223
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/74.ts
+++ b/data/Sword & Shield/Fusion Strike/74.ts
@@ -61,17 +61,23 @@ const card: Card = {
 		damage: 20
 	}],
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582208,
-		tcgplayer: 253224
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 582208,
+				tcgplayer: 253224
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 582208,
+				tcgplayer: 253224
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/75.ts
+++ b/data/Sword & Shield/Fusion Strike/75.ts
@@ -78,17 +78,23 @@ const card: Card = {
 		damage: 110
 	}],
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582209,
-		tcgplayer: 253225
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 582209,
+				tcgplayer: 253225
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 582209,
+				tcgplayer: 253225
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/76.ts
+++ b/data/Sword & Shield/Fusion Strike/76.ts
@@ -74,17 +74,16 @@ const card: Card = {
 		}
 	}],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582210,
-		tcgplayer: 253226
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 582210,
+				tcgplayer: 253226
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/77.ts
+++ b/data/Sword & Shield/Fusion Strike/77.ts
@@ -70,17 +70,23 @@ const card: Card = {
 		damage: 50
 	}],
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582211,
-		tcgplayer: 253229
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 582211,
+				tcgplayer: 253229
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 582211,
+				tcgplayer: 253229
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/78.ts
+++ b/data/Sword & Shield/Fusion Strike/78.ts
@@ -67,17 +67,16 @@ const card: Card = {
 		}
 	}],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582212,
-		tcgplayer: 253232
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 582212,
+				tcgplayer: 253232
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/79.ts
+++ b/data/Sword & Shield/Fusion Strike/79.ts
@@ -85,17 +85,16 @@ const card: Card = {
 		}
 	}],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582213,
-		tcgplayer: 253233
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 582213,
+				tcgplayer: 253233
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/8.ts
+++ b/data/Sword & Shield/Fusion Strike/8.ts
@@ -80,17 +80,23 @@ const card: Card = {
 		damage: 70
 	}],
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582036,
-		tcgplayer: 253078
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 582036,
+				tcgplayer: 253078
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 582036,
+				tcgplayer: 253078
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/80.ts
+++ b/data/Sword & Shield/Fusion Strike/80.ts
@@ -48,17 +48,23 @@ const card: Card = {
 		damage: 30
 	}],
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582214,
-		tcgplayer: 253234
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 582214,
+				tcgplayer: 253234
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 582214,
+				tcgplayer: 253234
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/81.ts
+++ b/data/Sword & Shield/Fusion Strike/81.ts
@@ -67,17 +67,23 @@ const card: Card = {
 		}
 	}],
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582215,
-		tcgplayer: 253235
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 582215,
+				tcgplayer: 253235
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 582215,
+				tcgplayer: 253235
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/82.ts
+++ b/data/Sword & Shield/Fusion Strike/82.ts
@@ -48,17 +48,23 @@ const card: Card = {
 		damage: 10
 	}],
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582216,
-		tcgplayer: 253236
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 582216,
+				tcgplayer: 253236
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 582216,
+				tcgplayer: 253236
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/83.ts
+++ b/data/Sword & Shield/Fusion Strike/83.ts
@@ -58,17 +58,23 @@ const card: Card = {
 		damage: 50
 	}],
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582217,
-		tcgplayer: 253237
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 582217,
+				tcgplayer: 253237
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 582217,
+				tcgplayer: 253237
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/84.ts
+++ b/data/Sword & Shield/Fusion Strike/84.ts
@@ -55,17 +55,30 @@ const card: Card = {
 		}
 	}],
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582218,
-		tcgplayer: 253238
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 582218,
+				tcgplayer: 253238
+			}
+		},
+		{
+			type: 'normal',
+			stamp: ['snowflake'],
+			thirdParty: {
+				cardmarket: 740470
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 582218,
+				tcgplayer: 253238
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/85.ts
+++ b/data/Sword & Shield/Fusion Strike/85.ts
@@ -87,17 +87,23 @@ const card: Card = {
 		}
 	}],
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582219,
-		tcgplayer: 253240
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 582219,
+				tcgplayer: 253240
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 582219,
+				tcgplayer: 253240
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/86.ts
+++ b/data/Sword & Shield/Fusion Strike/86.ts
@@ -58,17 +58,16 @@ const card: Card = {
 		damage: 100
 	}],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582411,
-		tcgplayer: 253241
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 582411,
+				tcgplayer: 253241
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/87.ts
+++ b/data/Sword & Shield/Fusion Strike/87.ts
@@ -57,17 +57,23 @@ const card: Card = {
 		}
 	}],
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582412,
-		tcgplayer: 253243
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 582412,
+				tcgplayer: 253243
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 582412,
+				tcgplayer: 253243
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/88.ts
+++ b/data/Sword & Shield/Fusion Strike/88.ts
@@ -89,17 +89,23 @@ const card: Card = {
 		}
 	}],
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582413,
-		tcgplayer: 253244
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 582413,
+				tcgplayer: 253244
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 582413,
+				tcgplayer: 253244
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/89.ts
+++ b/data/Sword & Shield/Fusion Strike/89.ts
@@ -57,17 +57,23 @@ const card: Card = {
 		}
 	}],
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582481,
-		tcgplayer: 253245
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 582481,
+				tcgplayer: 253245
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 582481,
+				tcgplayer: 253245
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/9.ts
+++ b/data/Sword & Shield/Fusion Strike/9.ts
@@ -57,17 +57,23 @@ const card: Card = {
 		}
 	}],
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582037,
-		tcgplayer: 253079
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 582037,
+				tcgplayer: 253079
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 582037,
+				tcgplayer: 253079
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/90.ts
+++ b/data/Sword & Shield/Fusion Strike/90.ts
@@ -68,17 +68,23 @@ const card: Card = {
 		damage: 20
 	}],
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582482,
-		tcgplayer: 253246
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 582482,
+				tcgplayer: 253246
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 582482,
+				tcgplayer: 253246
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/91.ts
+++ b/data/Sword & Shield/Fusion Strike/91.ts
@@ -61,17 +61,23 @@ const card: Card = {
 		damage: 20
 	}],
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582483,
-		tcgplayer: 253247
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 582483,
+				tcgplayer: 253247
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 582483,
+				tcgplayer: 253247
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/92.ts
+++ b/data/Sword & Shield/Fusion Strike/92.ts
@@ -58,17 +58,23 @@ const card: Card = {
 		damage: 50
 	}],
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582484,
-		tcgplayer: 253248
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 582484,
+				tcgplayer: 253248
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 582484,
+				tcgplayer: 253248
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/93.ts
+++ b/data/Sword & Shield/Fusion Strike/93.ts
@@ -58,17 +58,23 @@ const card: Card = {
 		damage: 90
 	}],
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582485,
-		tcgplayer: 253249
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 582485,
+				tcgplayer: 253249
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 582485,
+				tcgplayer: 253249
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/94.ts
+++ b/data/Sword & Shield/Fusion Strike/94.ts
@@ -68,17 +68,23 @@ const card: Card = {
 		damage: 30
 	}],
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582487,
-		tcgplayer: 253250
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 582487,
+				tcgplayer: 253250
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 582487,
+				tcgplayer: 253250
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/95.ts
+++ b/data/Sword & Shield/Fusion Strike/95.ts
@@ -68,17 +68,23 @@ const card: Card = {
 		damage: 20
 	}],
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582488,
-		tcgplayer: 253251
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 582488,
+				tcgplayer: 253251
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 582488,
+				tcgplayer: 253251
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/96.ts
+++ b/data/Sword & Shield/Fusion Strike/96.ts
@@ -80,17 +80,23 @@ const card: Card = {
 		}
 	}],
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582489,
-		tcgplayer: 253252
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 582489,
+				tcgplayer: 253252
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 582489,
+				tcgplayer: 253252
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/97.ts
+++ b/data/Sword & Shield/Fusion Strike/97.ts
@@ -89,17 +89,23 @@ const card: Card = {
 		}
 	}],
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582490,
-		tcgplayer: 253253
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 582490,
+				tcgplayer: 253253
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 582490,
+				tcgplayer: 253253
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/98.ts
+++ b/data/Sword & Shield/Fusion Strike/98.ts
@@ -61,17 +61,23 @@ const card: Card = {
 		damage: 20
 	}],
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582491,
-		tcgplayer: 253254
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 582491,
+				tcgplayer: 253254
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 582491,
+				tcgplayer: 253254
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Fusion Strike/99.ts
+++ b/data/Sword & Shield/Fusion Strike/99.ts
@@ -80,17 +80,23 @@ const card: Card = {
 		}
 	}],
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 582492,
-		tcgplayer: 253255
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 582492,
+				tcgplayer: 253255
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 582492,
+				tcgplayer: 253255
+			}
+		},
+	],
 }
 
 export default card


### PR DESCRIPTION
## Changes

- Added rainbow and gold foil types to relevant cards
- Added additional variants
- Moved all thirdParty into variants block with updated IDs