### PR TITLE
Update 260.ts

### DIFF
--- a/data/Pokémon TCG Pocket/Genetic Apex/260.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/260.ts
@@ -24,29 +24,43 @@ const card: Card = {
 	suffix: "EX",
 
 	attacks: [{
-		cost: ["Lightning", "Lightning", "Colorless"],
+		cost: ["Lightning"],
 
 		name: {
-			en: "Raging Thunder",
-			fr: "Tonnerre Déchaîné",
-			es: "Trueno Rabioso",
-			it: "Rombotuono",
-			de: "Tosender Donner",
-			'pt-br': "Trovão Devastador",
-			ko: "낙뢰"
+			en: "Peck",
+			fr: "Picpic",
+			es: "Picotazo",
+			it: "Beccata",
+			de: "Pikser",
+			'pt-br': "Bicada",
+			ko: "쪼기"
+		},
+
+		damage: "20"
+	}, {
+		cost: ["Lightning", "Lightning", "Lightning"],
+
+		name: {
+			en: "Thundering Hurricane",
+			fr: "Rafale d'Éclairs",
+			es: "Huracán Atronador",
+			it: "Tuonuragano",
+			de: "Donnernder Orkan",
+			'pt-br': "Furacão Trovejante",
+			ko: "허리케인 썬더"
 		},
 
 		effect: {
-			en: "This attack also does 30 damage to 1 of your Benched Pokémon.",
-			fr: "Cette attaque inflige aussi 30 dégâts à un de vos Pokémon de Banc.",
-			es: "Este ataque también hace 30 puntos de daño a 1 de tus Pokémon en Banca.",
-			it: "Questo attacco infligge anche 30 danni a uno dei tuoi Pokémon in panchina.",
-			de: "Diese Attacke fügt auch 1 Pokémon auf deiner Bank 30 Schadenspunkte zu.",
-			'pt-br': "Este ataque também causa 30 pontos de dano a 1 dos seus Pokémon no Banco.",
-			ko: "자신의 벤치 포켓몬 1마리에게도 30데미지를 준다."
+			en: "Flip 4 coins. This attack does 50 damage for each heads.",
+			fr: "Lancez 4 pièces. Cette attaque inflige 50 dégâts pour chaque côté face.",
+			es: "Lanza 4 monedas. Este ataque hace 50 puntos de daño por cada cara.",
+			it: "Lancia 4 volte una moneta. Questo attacco infligge 50 danni ogni volta che esce testa.",
+			de: "Wirf 4 Münzen. Diese Attacke fügt 50 Schadenspunkte pro Kopf zu.",
+			'pt-br': "Jogue 4 moedas. Este ataque causa 50 pontos de dano para cada cara.",
+			ko: "동전을 4번 던져서 앞면이 나온 수 × 50데미지를 준다."
 		},
 
-		damage: "100"
+		damage: "50×"
 	}],
 
 	weaknesses: [{


### PR DESCRIPTION
<!--
Contribution guide: https://github.com/tcgdex/cards-database/blob/master/CONTRIBUTING.md
please submit changes up to 1 set at most.
-->

<!-- Indicate the issue number here -->
issue: card in PTCGP dataset has incorrect attacks list #1683

## Changes

<!-- Quickly explain your changes -->

Replaced incorrect attack "Raging Thunder" (most likely incorrectly picked from the non ex variant) with the actual attacks:  Peck and Thundering Hurricane - same as 104.ts and 276.ts from the same set.
