### PR TITLE
fix(data): Fix illustrator details for Sun & Moon Black Star promo

### DIFF
--- a/data/Sun & Moon/SM Black Star Promos/SM126.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM126.ts
@@ -10,7 +10,7 @@ const card: Card = {
 		pt: "Ultra Necrozma GX",
 		de: "Ultra-Necrozma GX"
 	},
-	illustrator: "PLANETA Otani",
+	illustrator: "PLANETA",
 	rarity: "Promo",
 	category: "Pokemon",
 

--- a/data/Sun & Moon/SM Black Star Promos/SM140.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM140.ts
@@ -10,7 +10,7 @@ const card: Card = {
 		pt: "Salamence",
 		de: "Brutalanda"
 	},
-	illustrator: "Mitsuhiro Arita",
+	illustrator: "kawayoo",
 	rarity: "Promo",
 	category: "Pokemon",
 

--- a/data/Sun & Moon/SM Black Star Promos/SM142.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM142.ts
@@ -10,7 +10,7 @@ const card: Card = {
 		pt: "Kyurem",
 		de: "Kyurem"
 	},
-	illustrator: "TOKIYA",
+	illustrator: "Masakazu Fukuda",
 	rarity: "Promo",
 	category: "Pokemon",
 

--- a/data/Sun & Moon/SM Black Star Promos/SM149.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM149.ts
@@ -10,7 +10,7 @@ const card: Card = {
 		pt: "Suicune",
 		de: "Suicune"
 	},
-	illustrator: "Anesaki Dynamic",
+	illustrator: "Kouki Saitou",
 	rarity: "Promo",
 	category: "Pokemon",
 

--- a/data/Sun & Moon/SM Black Star Promos/SM150.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM150.ts
@@ -10,7 +10,7 @@ const card: Card = {
 		pt: "Raikou",
 		de: "Raikou"
 	},
-	illustrator: "Kagemaru Himeno",
+	illustrator: "nagimiso",
 	rarity: "Promo",
 	category: "Pokemon",
 

--- a/data/Sun & Moon/SM Black Star Promos/SM151.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM151.ts
@@ -10,7 +10,7 @@ const card: Card = {
 		pt: "Giratina",
 		de: "Giratina"
 	},
-	illustrator: "Hasuno",
+	illustrator: "Shin Nagasawa",
 	rarity: "Promo",
 	category: "Pokemon",
 

--- a/data/Sun & Moon/SM Black Star Promos/SM152.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM152.ts
@@ -10,7 +10,7 @@ const card: Card = {
 		pt: "Tapu Lele",
 		de: "Kapu-Fala"
 	},
-	illustrator: "Mizue",
+	illustrator: "HYOGONOSUKE",
 	rarity: "Promo",
 	category: "Pokemon",
 

--- a/data/Sun & Moon/SM Black Star Promos/SM16.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM16.ts
@@ -10,7 +10,7 @@ const card: Card = {
 		pt: "Solgaleo GX",
 		de: "Solgaleo GX"
 	},
-	illustrator: "PLANETA",
+	illustrator: "5ban Graphics",
 	rarity: "Promo",
 	category: "Pokemon",
 

--- a/data/Sun & Moon/SM Black Star Promos/SM17.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM17.ts
@@ -10,7 +10,7 @@ const card: Card = {
 		pt: "Lunala GX",
 		de: "Lunala GX"
 	},
-	illustrator: "PLANETA",
+	illustrator: "5ban Graphics",
 	rarity: "Promo",
 	category: "Pokemon",
 

--- a/data/Sun & Moon/SM Black Star Promos/SM179.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM179.ts
@@ -14,6 +14,7 @@ const card: Card = {
 		de: "Volcanion"
 	},
 
+	illustrator: "Hasuno",
 	rarity: "Promo",
 	category: "Pokemon",
 	hp: 120,

--- a/data/Sun & Moon/SM Black Star Promos/SM180.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM180.ts
@@ -14,6 +14,7 @@ const card: Card = {
 		de: "Muramura"
 	},
 
+	illustrator: "Hiroki Asanuma",
 	rarity: "Promo",
 	category: "Pokemon",
 	hp: 120,

--- a/data/Sun & Moon/SM Black Star Promos/SM181.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM181.ts
@@ -14,6 +14,7 @@ const card: Card = {
 		de: "Melmetal"
 	},
 
+	illustrator: "TOKIYA",
 	rarity: "Promo",
 	category: "Pokemon",
 	hp: 150,

--- a/data/Sun & Moon/SM Black Star Promos/SM182.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM182.ts
@@ -14,6 +14,7 @@ const card: Card = {
 		de: "Snobilikat"
 	},
 
+	illustrator: "tetsuya koizumi",
 	rarity: "Promo",
 	category: "Pokemon",
 	hp: 100,

--- a/data/Sun & Moon/SM Black Star Promos/SM183.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM183.ts
@@ -14,6 +14,7 @@ const card: Card = {
 		de: "Pikachu"
 	},
 
+	illustrator: "Aya Kusube",
 	rarity: "Promo",
 	category: "Pokemon",
 	hp: 70,

--- a/data/Sun & Moon/SM Black Star Promos/SM184.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM184.ts
@@ -14,6 +14,7 @@ const card: Card = {
 		de: "Evoli"
 	},
 
+	illustrator: "Mizue",
 	rarity: "Promo",
 	category: "Pokemon",
 	hp: 50,

--- a/data/Sun & Moon/SM Black Star Promos/SM190.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM190.ts
@@ -14,6 +14,7 @@ const card: Card = {
 		de: "Meisterdetektiv Pikachu"
 	},
 
+	illustrator: "Framestore",
 	rarity: "Promo",
 	category: "Pokemon",
 	hp: 90,

--- a/data/Sun & Moon/SM Black Star Promos/SM198.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM198.ts
@@ -11,7 +11,7 @@ const card: Card = {
 		de: "Bisasam"
 	},
 
-	illustrator: undefined,
+	illustrator: "MPC Film",
 	rarity: "Promo",
 	category: "Pokemon",
 	set: Set,

--- a/data/Sun & Moon/SM Black Star Promos/SM199.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM199.ts
@@ -11,7 +11,7 @@ const card: Card = {
 		de: "Enton"
 	},
 
-	illustrator: undefined,
+	illustrator: "Framestore",
 	rarity: "Promo",
 	category: "Pokemon",
 	set: Set,

--- a/data/Sun & Moon/SM Black Star Promos/SM200.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM200.ts
@@ -11,7 +11,7 @@ const card: Card = {
 		de: "Snubbull"
 	},
 
-	illustrator: undefined,
+	illustrator: "Framestore",
 	rarity: "Promo",
 	category: "Pokemon",
 	set: Set,

--- a/data/Sun & Moon/SM Black Star Promos/SM202.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM202.ts
@@ -11,7 +11,7 @@ const card: Card = {
 		de: "Hutsassa"
 	},
 
-	illustrator: undefined,
+	illustrator: "MAHOU",
 	rarity: "Promo",
 	category: "Pokemon",
 	set: Set,

--- a/data/Sun & Moon/SM Black Star Promos/SM203.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM203.ts
@@ -11,7 +11,7 @@ const card: Card = {
 		de: "Kapu-Kime"
 	},
 
-	illustrator: undefined,
+	illustrator: "Ryuta Fuse",
 	rarity: "Promo",
 	category: "Pokemon",
 	set: Set,

--- a/data/Sun & Moon/SM Black Star Promos/SM204.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM204.ts
@@ -11,7 +11,7 @@ const card: Card = {
 		de: "Necrozma"
 	},
 
-	illustrator: undefined,
+	illustrator: "Hasuno",
 	rarity: "Promo",
 	category: "Pokemon",
 	set: Set,

--- a/data/Sun & Moon/SM Black Star Promos/SM205.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM205.ts
@@ -11,7 +11,7 @@ const card: Card = {
 		de: "Terrakium"
 	},
 
-	illustrator: undefined,
+	illustrator: "Shin Nagasawa",
 	rarity: "Promo",
 	category: "Pokemon",
 	set: Set,

--- a/data/Sun & Moon/SM Black Star Promos/SM206.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM206.ts
@@ -11,7 +11,7 @@ const card: Card = {
 		de: "Pikachu"
 	},
 
-	illustrator: undefined,
+	illustrator: "Akira Komayama",
 	rarity: "Promo",
 	category: "Pokemon",
 	set: Set,

--- a/data/Sun & Moon/SM Black Star Promos/SM207.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM207.ts
@@ -11,7 +11,7 @@ const card: Card = {
 		de: "Mogelbaum"
 	},
 
-	illustrator: undefined,
+	illustrator: "Akira Komayama",
 	rarity: "Promo",
 	category: "Pokemon",
 	set: Set,

--- a/data/Sun & Moon/SM Black Star Promos/SM211.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM211.ts
@@ -11,7 +11,7 @@ const card: Card = {
 		de: "Glurak GX"
 	},
 
-	illustrator: undefined,
+	illustrator: "aky CG Works",
 	rarity: "Promo",
 	category: "Pokemon",
 	set: Set,

--- a/data/Sun & Moon/SM Black Star Promos/SM212.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM212.ts
@@ -11,7 +11,7 @@ const card: Card = {
 		de: "Garados GX"
 	},
 
-	illustrator: undefined,
+	illustrator: "5ban Graphics",
 	rarity: "Promo",
 	category: "Pokemon",
 	set: Set,

--- a/data/Sun & Moon/SM Black Star Promos/SM213.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM213.ts
@@ -11,7 +11,7 @@ const card: Card = {
 		de: "Raichu GX"
 	},
 
-	illustrator: undefined,
+	illustrator: "5ban Graphics",
 	rarity: "Promo",
 	category: "Pokemon",
 	set: Set,

--- a/data/Sun & Moon/SM Black Star Promos/SM214.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM214.ts
@@ -11,7 +11,7 @@ const card: Card = {
 		de: "Mewtu"
 	},
 
-	illustrator: undefined,
+	illustrator: "kawayoo",
 	rarity: "Promo",
 	category: "Pokemon",
 	set: Set,

--- a/data/Sun & Moon/SM Black Star Promos/SM215.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM215.ts
@@ -11,7 +11,7 @@ const card: Card = {
 		de: "Mew"
 	},
 
-	illustrator: undefined,
+	illustrator: "Masakazu Fukuda",
 	rarity: "Promo",
 	category: "Pokemon",
 	set: Set,

--- a/data/Sun & Moon/SM Black Star Promos/SM216.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM216.ts
@@ -11,7 +11,7 @@ const card: Card = {
 		de: "Porygon-Z GX"
 	},
 
-	illustrator: undefined,
+	illustrator: "PLANETA Tsuji",
 	rarity: "Promo",
 	category: "Pokemon",
 	set: Set,

--- a/data/Sun & Moon/SM Black Star Promos/SM217.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM217.ts
@@ -11,7 +11,7 @@ const card: Card = {
 		de: "Trombork & Zwirrfinst GX"
 	},
 
-	illustrator: undefined,
+	illustrator: "Mitsuhiro Arita",
 	rarity: "Promo",
 	category: "Pokemon",
 	set: Set,

--- a/data/Sun & Moon/SM Black Star Promos/SM218.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM218.ts
@@ -14,6 +14,7 @@ const card: Card = {
 		de: "Masskito"
 	},
 
+	illustrator: "Kouki Saitou",
 	rarity: "Promo",
 	category: "Pokemon",
 	hp: 130,

--- a/data/Sun & Moon/SM Black Star Promos/SM219.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM219.ts
@@ -14,6 +14,7 @@ const card: Card = {
 		de: "Entei"
 	},
 
+	illustrator: "Ryuta Fuse",
 	rarity: "Promo",
 	category: "Pokemon",
 	hp: 130,

--- a/data/Sun & Moon/SM Black Star Promos/SM220.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM220.ts
@@ -14,6 +14,7 @@ const card: Card = {
 		de: "Phione"
 	},
 
+	illustrator: "Kagemaru Himeno",
 	rarity: "Promo",
 	category: "Pokemon",
 	hp: 70,

--- a/data/Sun & Moon/SM Black Star Promos/SM222.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM222.ts
@@ -14,6 +14,7 @@ const card: Card = {
 		de: "Traunmagil"
 	},
 
+	illustrator: "Sumiyoshi Kizuki",
 	rarity: "Promo",
 	category: "Pokemon",
 	hp: 110,

--- a/data/Sun & Moon/SM Black Star Promos/SM223.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM223.ts
@@ -14,6 +14,7 @@ const card: Card = {
 		de: "Terrakium"
 	},
 
+	illustrator: "Masakazu Fukuda",
 	rarity: "Promo",
 	category: "Pokemon",
 	hp: 140,

--- a/data/Sun & Moon/SM Black Star Promos/SM224.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM224.ts
@@ -14,6 +14,7 @@ const card: Card = {
 		de: "Celebi"
 	},
 
+	illustrator: "Mizue",
 	rarity: "Promo",
 	category: "Pokemon",
 	hp: 70,

--- a/data/Sun & Moon/SM Black Star Promos/SM225.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM225.ts
@@ -10,7 +10,7 @@ const card: Card = {
 		pt: "Victini",
 		de: "Victini"
 	},
-	illustrator: "Nagimiso",
+	illustrator: "nagimiso",
 	rarity: "Promo",
 	category: "Pokemon",
 

--- a/data/Sun & Moon/SM Black Star Promos/SM226.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM226.ts
@@ -14,6 +14,7 @@ const card: Card = {
 		de: "Glurak"
 	},
 
+	illustrator: "2019 Pikachu Project",
 	rarity: "Promo",
 	category: "Pokemon",
 	hp: 150,

--- a/data/Sun & Moon/SM Black Star Promos/SM227.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM227.ts
@@ -14,6 +14,7 @@ const card: Card = {
 		de: "Pikachu"
 	},
 
+	illustrator: "2019 Pikachu Project",
 	rarity: "Promo",
 	category: "Pokemon",
 	hp: 60,

--- a/data/Sun & Moon/SM Black Star Promos/SM228.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM228.ts
@@ -14,6 +14,7 @@ const card: Card = {
 		de: "Armored Mewtwo"
 	},
 
+	illustrator: "2019 Pikachu Project",
 	rarity: "Promo",
 	category: "Pokemon",
 	hp: 120,

--- a/data/Sun & Moon/SM Black Star Promos/SM229.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM229.ts
@@ -14,6 +14,7 @@ const card: Card = {
 		de: "Bisaflor & Serpifeu GX"
 	},
 
+	illustrator: "Yuka Morii",
 	rarity: "Promo",
 	category: "Pokemon",
 	hp: 270,

--- a/data/Sun & Moon/SM Black Star Promos/SM230.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM230.ts
@@ -14,6 +14,7 @@ const card: Card = {
 		de: "Glurak & Rutena GX"
 	},
 
+	illustrator: "Kagemaru Himeno",
 	rarity: "Promo",
 	category: "Pokemon",
 	hp: 270,

--- a/data/Sun & Moon/SM Black Star Promos/SM231.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM231.ts
@@ -13,6 +13,7 @@ const card: Card = {
 		de: "Festival der Champions"
 	},
 
+	illustrator: "Naoki Saito",
 	rarity: "Promo",
 	category: "Trainer",
 

--- a/data/Sun & Moon/SM Black Star Promos/SM232.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM232.ts
@@ -14,6 +14,7 @@ const card: Card = {
 		de: "Pikachu GX"
 	},
 
+	illustrator: "aky CG Works",
 	rarity: "Promo",
 	category: "Pokemon",
 	hp: 160,

--- a/data/Sun & Moon/SM Black Star Promos/SM233.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM233.ts
@@ -14,6 +14,7 @@ const card: Card = {
 		de: "Evoli GX"
 	},
 
+	illustrator: "Q-rais",
 	rarity: "Promo",
 	category: "Pokemon",
 	hp: 160,

--- a/data/Sun & Moon/SM Black Star Promos/SM234.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM234.ts
@@ -14,6 +14,7 @@ const card: Card = {
 		de: "Pikachu"
 	},
 
+	illustrator: "Naoki Saito",
 	rarity: "Promo",
 	category: "Pokemon",
 	hp: 60,

--- a/data/Sun & Moon/SM Black Star Promos/SM235.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM235.ts
@@ -14,6 +14,7 @@ const card: Card = {
 		de: "Evoli"
 	},
 
+	illustrator: "kirisAki",
 	rarity: "Promo",
 	category: "Pokemon",
 	hp: 60,

--- a/data/Sun & Moon/SM Black Star Promos/SM236.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM236.ts
@@ -14,6 +14,7 @@ const card: Card = {
 		de: "Alola-Sandamer GX"
 	},
 
+	illustrator: "5ban Graphics",
 	rarity: "Promo",
 	category: "Pokemon",
 	hp: 200,

--- a/data/Sun & Moon/SM Black Star Promos/SM237.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM237.ts
@@ -14,6 +14,7 @@ const card: Card = {
 		de: "Folipurba"
 	},
 
+	illustrator: "chibi",
 	rarity: "Promo",
 	category: "Pokemon",
 	hp: 110,

--- a/data/Sun & Moon/SM Black Star Promos/SM238.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM238.ts
@@ -14,6 +14,7 @@ const card: Card = {
 		de: "Glaziola"
 	},
 
+	illustrator: "Mizue",
 	rarity: "Promo",
 	category: "Pokemon",
 	hp: 110,

--- a/data/Sun & Moon/SM Black Star Promos/SM239.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM239.ts
@@ -14,6 +14,7 @@ const card: Card = {
 		de: "Karippas GX"
 	},
 
+	illustrator: "PLANETA Tsuji",
 	rarity: "Promo",
 	category: "Pokemon",
 	hp: 250,

--- a/data/Sun & Moon/SM Black Star Promos/SM240.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM240.ts
@@ -14,6 +14,7 @@ const card: Card = {
 		de: "Psiana & Deoxys GX"
 	},
 
+	illustrator: "Hasuno",
 	rarity: "Promo",
 	category: "Pokemon",
 	hp: 260,

--- a/data/Sun & Moon/SM Black Star Promos/SM241.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM241.ts
@@ -14,6 +14,7 @@ const card: Card = {
 		de: "Nachtara & Darkrai GX"
 	},
 
+	illustrator: "so-taro",
 	rarity: "Promo",
 	category: "Pokemon",
 	hp: 270,

--- a/data/Sun & Moon/SM Black Star Promos/SM242.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM242.ts
@@ -14,6 +14,7 @@ const card: Card = {
 		de: "Evoli GX"
 	},
 
+	illustrator: "aky CG Works",
 	rarity: "Promo",
 	category: "Pokemon",
 	hp: 160,

--- a/data/Sun & Moon/SM Black Star Promos/SM243.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM243.ts
@@ -14,6 +14,7 @@ const card: Card = {
 		de: "Regigigas"
 	},
 
+	illustrator: "Ryuta Fuse",
 	rarity: "Promo",
 	category: "Pokemon",
 	hp: 150,

--- a/data/Sun & Moon/SM Black Star Promos/SM244.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM244.ts
@@ -14,6 +14,7 @@ const card: Card = {
 		de: "Griffel"
 	},
 
+	illustrator: "Shibuzoh.",
 	rarity: "Promo",
 	category: "Pokemon",
 	hp: 60,


### PR DESCRIPTION
This is a bit more of a complex one. I wanted to just add missing illustrators, but I also had to replace some `undefined` values.

However, while checking some of the changes I noticed that quite a few of the original values were wrong. I am not sure where the original issues first started, but there must be some bad data going around.

For example, this [Suicune SM149](https://assets.tcgdex.net/en/sm/smp/SM149/high.webp), is illustrated by `Kouki Saitou` but it was currently set as `Anesaki Dynamic`

[limitlesstcg](https://limitlesstcg.com/cards/SMP/149) also has this bad data