### PR TITLE
fix(data): Fix misspelled and unify illustrators name

### DIFF
--- a/data/Black & White/BW Black Star Promos/BW87.ts
+++ b/data/Black & White/BW Black Star Promos/BW87.ts
@@ -6,7 +6,7 @@ const card: Card = {
 		en: "Leafeon",
 		fr: "Phyllali",
 	},
-	illustrator: "Illus.＆Direc.The Pokémon Company Art Team",
+	illustrator: "Illus. & Direc. The Pokémon Company Art Team",
 	rarity: "Common",
 	category: "Pokemon",
 

--- a/data/Black & White/BW Black Star Promos/BW88.ts
+++ b/data/Black & White/BW Black Star Promos/BW88.ts
@@ -6,7 +6,7 @@ const card: Card = {
 		en: "Flareon",
 		fr: "Pyroli",
 	},
-	illustrator: "Illus.＆Direc.The Pokémon Company Art Team",
+	illustrator: "Illus. & Direc. The Pokémon Company Art Team",
 	rarity: "Common",
 	category: "Pokemon",
 

--- a/data/Black & White/BW Black Star Promos/BW89.ts
+++ b/data/Black & White/BW Black Star Promos/BW89.ts
@@ -6,7 +6,7 @@ const card: Card = {
 		en: "Vaporeon",
 		fr: "Aquali",
 	},
-	illustrator: "Illus.＆Direc.The Pokémon Company Art Team",
+	illustrator: "Illus. & Direc. The Pokémon Company Art Team",
 	rarity: "Common",
 	category: "Pokemon",
 

--- a/data/Black & White/BW Black Star Promos/BW90.ts
+++ b/data/Black & White/BW Black Star Promos/BW90.ts
@@ -6,7 +6,7 @@ const card: Card = {
 		en: "Glaceon",
 		fr: "Givrali",
 	},
-	illustrator: "Illus.＆Direc.The Pokémon Company Art Team",
+	illustrator: "Illus. & Direc. The Pokémon Company Art Team",
 	rarity: "Common",
 	category: "Pokemon",
 

--- a/data/Black & White/BW Black Star Promos/BW91.ts
+++ b/data/Black & White/BW Black Star Promos/BW91.ts
@@ -6,7 +6,7 @@ const card: Card = {
 		en: "Jolteon",
 		fr: "Voltali",
 	},
-	illustrator: "Illus.＆Direc.The Pokémon Company Art Team",
+	illustrator: "Illus. & Direc. The Pokémon Company Art Team",
 	rarity: "Common",
 	category: "Pokemon",
 

--- a/data/Black & White/BW Black Star Promos/BW92.ts
+++ b/data/Black & White/BW Black Star Promos/BW92.ts
@@ -6,7 +6,7 @@ const card: Card = {
 		en: "Espeon",
 		fr: "Mentali",
 	},
-	illustrator: "Illus.＆Direc.The Pokémon Company Art Team",
+	illustrator: "Illus. & Direc. The Pokémon Company Art Team",
 	rarity: "Common",
 	category: "Pokemon",
 

--- a/data/Black & White/BW Black Star Promos/BW93.ts
+++ b/data/Black & White/BW Black Star Promos/BW93.ts
@@ -6,7 +6,7 @@ const card: Card = {
 		en: "Umbreon",
 		fr: "Noctali",
 	},
-	illustrator: "Illus.＆Direc.The Pokémon Company Art Team",
+	illustrator: "Illus. & Direc. The Pokémon Company Art Team",
 	rarity: "Common",
 	category: "Pokemon",
 

--- a/data/Black & White/BW Black Star Promos/BW94.ts
+++ b/data/Black & White/BW Black Star Promos/BW94.ts
@@ -6,7 +6,7 @@ const card: Card = {
 		en: "Eevee",
 		fr: "Évoli",
 	},
-	illustrator: "Illus.＆Direc.The Pokémon Company Art Team",
+	illustrator: "Illus. & Direc. The Pokémon Company Art Team",
 	rarity: "Common",
 	category: "Pokemon",
 

--- a/data/Diamond & Pearl/Great Encounters/62.ts
+++ b/data/Diamond & Pearl/Great Encounters/62.ts
@@ -8,7 +8,7 @@ const card: Card = {
 		de: "Tuska"
 	},
 
-	illustrator: "Saya　Tsuruta",
+	illustrator: "Saya Tsuruta",
 	rarity: "Common",
 	category: "Pokemon",
 	set: Set,

--- a/data/Diamond & Pearl/Great Encounters/82.ts
+++ b/data/Diamond & Pearl/Great Encounters/82.ts
@@ -8,7 +8,7 @@ const card: Card = {
 		de: "Flegmon"
 	},
 
-	illustrator: "Saya　Tsuruta",
+	illustrator: "Saya Tsuruta",
 	rarity: "Common",
 	category: "Pokemon",
 	set: Set,

--- a/data/E-Card/Expedition Base Set/28.ts
+++ b/data/E-Card/Expedition Base Set/28.ts
@@ -8,7 +8,7 @@ const card: Card = {
 		de: "Tornupto"
 	},
 
-	illustrator: "K.  Hoshiba",
+	illustrator: "K. Hoshiba",
 	rarity: "Rare",
 	category: "Pokemon",
 	set: Set,

--- a/data/E-Card/Expedition Base Set/65.ts
+++ b/data/E-Card/Expedition Base Set/65.ts
@@ -8,7 +8,7 @@ const card: Card = {
 		de: "Tornupto"
 	},
 
-	illustrator: "K.  Hoshiba",
+	illustrator: "K. Hoshiba",
 	rarity: "Rare",
 	category: "Pokemon",
 	set: Set,

--- a/data/EX/Dragon/48.ts
+++ b/data/EX/Dragon/48.ts
@@ -8,7 +8,7 @@ const card: Card = {
 		de: "Welsar"
 	},
 
-	illustrator: "Tomokazu",
+	illustrator: "Tomokazu Komiya",
 	rarity: "Uncommon",
 	category: "Pokemon",
 	set: Set,

--- a/data/EX/FireRed & LeafGreen/95.ts
+++ b/data/EX/FireRed & LeafGreen/95.ts
@@ -8,7 +8,7 @@ const card: Card = {
 		de: "Pokéball"
 	},
 
-	illustrator: "K Hoshiba",
+	illustrator: "K. Hoshiba",
 	rarity: "Uncommon",
 	category: "Trainer",
 	set: Set,

--- a/data/EX/Team Magma vs Team Aqua/72.ts
+++ b/data/EX/Team Magma vs Team Aqua/72.ts
@@ -8,7 +8,7 @@ const card: Card = {
 		de: "Doppelter Ball"
 	},
 
-	illustrator: "Big Mama\" Tagawa\"",
+	illustrator: "\"Big Mama\" Tagawa",
 	rarity: "Uncommon",
 	category: "Trainer",
 	set: Set,

--- a/data/EX/Team Rocket Returns/63.ts
+++ b/data/EX/Team Rocket Returns/63.ts
@@ -7,7 +7,7 @@ const card: Card = {
 		de: "Larvitar"
 	},
 
-	illustrator: "Midroi Harada",
+	illustrator: "Midori Harada",
 	rarity: "Common",
 	category: "Pokemon",
 	set: Set,
@@ -62,7 +62,7 @@ const card: Card = {
 		},
 	],
 
-	
+
 	retreat: 1,
 
 	thirdParty: {

--- a/data/McDonald's Collection/McDonald's Collection 2015/4.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2015/4.ts
@@ -34,7 +34,7 @@ const card: Card = {
 		},
 	],
 
-	illustrator: "Tomokazu Kamiya",
+	illustrator: "Tomokazu Komiya",
 
 	variants: [
 		{

--- a/data/McDonald's Collection/McDonald's Collection 2018/11.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2018/11.ts
@@ -49,7 +49,7 @@ const card: Card = {
 
 	retreat: 2,
 
-	illustrator: "Shibuzoh",
+	illustrator: "Shibuzoh.",
 
 	variants: [
 		{

--- a/data/McDonald's Collection/McDonald's Collection 2018/2.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2018/2.ts
@@ -37,7 +37,7 @@ const card: Card = {
 
 	retreat: 2,
 
-	illustrator: "Shibuzoh",
+	illustrator: "Shibuzoh.",
 
 	variants: [
 		{

--- a/data/McDonald's Collection/McDonald's Collection 2018/4.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2018/4.ts
@@ -55,7 +55,7 @@ const card: Card = {
 
 	retreat: 1,
 
-	illustrator: "Shibuzoh",
+	illustrator: "Shibuzoh.",
 
 	variants: [
 		{

--- a/data/McDonald's Collection/McDonald's Collection 2018/9.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2018/9.ts
@@ -46,7 +46,7 @@ const card: Card = {
 
 	retreat: 2,
 
-	illustrator: "Naoya Kimura",
+	illustrator: "Naoyo Kimura",
 
 	variants: [
 		{

--- a/data/Mega Evolution/Phantasmal Flames/101.ts
+++ b/data/Mega Evolution/Phantasmal Flames/101.ts
@@ -75,7 +75,7 @@ const card: Card = {
 		en: "Known as the Desert Spirit, this Pokémon hides in the sandstorms it causes by beating its wings.",
 	},
 
-	illustrator: "Ryoto Muriyama",
+	illustrator: "Ryota Murayama",
 	variants: [
 		{
 			type: 'holo',

--- a/data/Scarlet & Violet/Black Bolt/135.ts
+++ b/data/Scarlet & Violet/Black Bolt/135.ts
@@ -15,7 +15,7 @@ const card: Card = {
 		'es-mx': "Sandile"
 	},
 
-	illustrator: "Fujmoto Gold",
+	illustrator: "Fujimoto Gold",
 	rarity: "Illustration rare",
 	category: "Pokemon",
 	hp: 70,

--- a/data/Scarlet & Violet/My First Battle/19.ts
+++ b/data/Scarlet & Violet/My First Battle/19.ts
@@ -37,7 +37,7 @@ const card: Card = {
 		},
 	],
 
-	illustrator: "Shibuzoh",
+	illustrator: "Shibuzoh.",
 }
 
 export default card

--- a/data/Sword & Shield/Pokémon Futsal 2020/1.ts
+++ b/data/Sword & Shield/Pokémon Futsal 2020/1.ts
@@ -9,14 +9,14 @@ const card: Card = {
 		en: "Pikachu on the Ball"
 	},
 
-	illustrator: "The Pokémon Company Art Team",
+	illustrator: "Illus. & Direc. The Pokémon Company Art Team",
 	rarity: "None",
 	category: "Pokemon",
 
 	description: {
 		en: "Pikachu that can generate powerful electricity have cheek sacs that are extra soft and super stretchy."
 	},
-	
+
 	hp: 60,
 
 	stage: "Basic",

--- a/data/Sword & Shield/Pokémon Futsal 2020/2.ts
+++ b/data/Sword & Shield/Pokémon Futsal 2020/2.ts
@@ -9,14 +9,14 @@ const card: Card = {
 		en: "Eevee on the Ball"
 	},
 
-	illustrator: "The Pokémon Company Art Team",
+	illustrator: "Illus. & Direc. The Pokémon Company Art Team",
 	rarity: "None",
 	category: "Pokemon",
 
 	description: {
 		en: "It has the ability to alter the composition of its body to suit its surrounding environment."
 	},
-	
+
 	hp: 60,
 
 	stage: "Basic",

--- a/data/Sword & Shield/Pokémon Futsal 2020/3.ts
+++ b/data/Sword & Shield/Pokémon Futsal 2020/3.ts
@@ -9,14 +9,14 @@ const card: Card = {
 		en: "Grookey on the Ball"
 	},
 
-	illustrator: "The Pokémon Company Art Team",
+	illustrator: "Illus. & Direc. The Pokémon Company Art Team",
 	rarity: "None",
 	category: "Pokemon",
 
 	description: {
 		en: "When it uses its special stick to strike up a beat, the sound waves produced carry revitalizing energy to the plants and flowers in the area."
 	},
-	
+
 	hp: 60,
 
 	stage: "Basic",

--- a/data/Sword & Shield/Pokémon Futsal 2020/4.ts
+++ b/data/Sword & Shield/Pokémon Futsal 2020/4.ts
@@ -9,14 +9,14 @@ const card: Card = {
 		en: "Scorbunny on the Ball"
 	},
 
-	illustrator: "The Pokémon Company Art Team",
+	illustrator: "Illus. & Direc. The Pokémon Company Art Team",
 	rarity: "None",
 	category: "Pokemon",
 
 	description: {
 		en: "A warm-up of running around gets fire energy coursing through this Pokémon's body. Once that happens, it's ready to fight at full power."
 	},
-	
+
 	hp: 60,
 
 	stage: "Basic",

--- a/data/Sword & Shield/Pokémon Futsal 2020/5.ts
+++ b/data/Sword & Shield/Pokémon Futsal 2020/5.ts
@@ -9,14 +9,14 @@ const card: Card = {
 		en: "Sobble on the Ball"
 	},
 
-	illustrator: "The Pokémon Company Art Team",
+	illustrator: "Illus. & Direc. The Pokémon Company Art Team",
 	rarity: "None",
 	category: "Pokemon",
 
 	description: {
 		en: "When scared, this Pokémon cries. Its tears pack the chemical punch of 100 onions, and attackers won't be able to resist weeping."
 	},
-	
+
 	hp: 60,
 
 	stage: "Basic",

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH075.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH075.ts
@@ -4,7 +4,7 @@ import Set from "../SWSH Black Star Promos"
 const card: Card = {
 	dexId: [6],
 	set: Set,
-	illustrator: "The Pokémon Company Art Team",
+	illustrator: "Illus. & Direc. The Pokémon Company Art Team",
 
 	name: {
 		en: "Special Delivery Charizard"

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH177.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH177.ts
@@ -4,7 +4,7 @@ import Set from '../SWSH Black Star Promos'
 const card: Card = {
 	dexId: [399],
 	set: Set,
-	illustrator: "The Pokémon Company Art Team",
+	illustrator: "Illus. & Direc. The Pokémon Company Art Team",
 	category: "Pokemon",
 	weaknesses: [
 		{

--- a/data/Trainer kits/BW trainer Kit (Excadrill)/1.ts
+++ b/data/Trainer kits/BW trainer Kit (Excadrill)/1.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		de: "Yorkleff"
 	},
 
-	illustrator: "Mosakazu Fukuda",
+	illustrator: "Masakazu Fukuda",
 	rarity: "None",
 	category: "Pokemon",
 	stage: "Basic",

--- a/data/Trainer kits/BW trainer Kit (Excadrill)/27.ts
+++ b/data/Trainer kits/BW trainer Kit (Excadrill)/27.ts
@@ -14,7 +14,7 @@ const card: Card = {
 		de: "Yorkleff"
 	},
 
-	illustrator: "Mosakazu Fukuda",
+	illustrator: "Masakazu Fukuda",
 	rarity: "None",
 	category: "Pokemon",
 	stage: "Basic",


### PR DESCRIPTION
<!--
Contribution guide: https://github.com/tcgdex/cards-database/blob/master/CONTRIBUTING.md
please submit changes up to 1 set at most.
-->

closes #N/A <!-- Indicate the issue number here -->

## Changes

<!-- Quickly explain your changes -->
Update misspelled and unify illustrator's name accross cards

## Details

I found some inconsistencies for some illustrator's names :
- Misspelled in Illustrators Name, ex : `Midroi Harada` -> `Midori Harada`
- Some illustrators accross the database are being named differently in some cards, ex: `Tomokazu` -> `Tomokazu Komiya`
- Also sometimes there's name having multiple spaces between 2 words.
<!-- You can also give more details about your changes -->

