### PR TITLE
fix: relax brittle CI test assertions for new set splits

### DIFF
--- a/.bruno/endpoints/v2/lang/cards/get card -exu---.bru
+++ b/.bruno/endpoints/v2/lang/cards/get card -exu---.bru
@@ -13,5 +13,5 @@ get {
 assert {
   res.status: eq 200
   res.body.id: eq swsh3-136
-  res.responseTime: lte 10
+  res.responseTime: lte 50
 }

--- a/.bruno/endpoints/v2/lang/cards/get card -exu---.bru
+++ b/.bruno/endpoints/v2/lang/cards/get card -exu---.bru
@@ -13,5 +13,5 @@ get {
 assert {
   res.status: eq 200
   res.body.id: eq swsh3-136
-  res.responseTime: lte 50
+  res.responseTime: lte 15
 }

--- a/.bruno/endpoints/v2/lang/sets/Advanced Query.bru
+++ b/.bruno/endpoints/v2/lang/sets/Advanced Query.bru
@@ -17,5 +17,5 @@ params:query {
 
 assert {
   res.status: eq 200
-  res.body: length 17
+  res.body: length gte 17
 }

--- a/.bruno/endpoints/v2/lang/sets/Advanced Query.bru
+++ b/.bruno/endpoints/v2/lang/sets/Advanced Query.bru
@@ -17,5 +17,5 @@ params:query {
 
 assert {
   res.status: eq 200
-  res.body: length gte 17
+  res.body.length: gte 17
 }

--- a/.bruno/sets/Advanced Query.bru
+++ b/.bruno/sets/Advanced Query.bru
@@ -17,5 +17,5 @@ params:query {
 
 assert {
   res.status: eq 200
-  res.body: length 17
+  res.body: length gte 17
 }

--- a/.bruno/sets/Advanced Query.bru
+++ b/.bruno/sets/Advanced Query.bru
@@ -17,5 +17,5 @@ params:query {
 
 assert {
   res.status: eq 200
-  res.body: length gte 17
+  res.body.length: gte 17
 }


### PR DESCRIPTION
Update the sets Advanced Query assertion from an exact count to a minimum (gte 17) so it doesn't break each time a new set is split out. Also bump the card response-time limit from 10ms to 15ms to reduce timeouts.

