### PR TITLE
(data): Split BRS:TG into own set and update variants & Pricing for all Cards

### DIFF
--- a/data/Sword & Shield/Brilliant Stars Trainer Gallery.ts
+++ b/data/Sword & Shield/Brilliant Stars Trainer Gallery.ts
@@ -1,0 +1,31 @@
+import { Set } from '../../interfaces'
+import serie from '../Sword & Shield'
+
+const swsh95tg: Set = {
+	id: "swsh9.5tg",
+
+	name: {
+		en: "Brilliant Stars Trainer Gallery",
+		fr: "Stars Étincelantes Galerie de Dresseurs",
+		es: "Astros Brillantes Galería de Entrenador",
+		it: "Astri Lucenti Galleria Allenatori",
+		de: "Strahlende Sterne Trainer-Galerie",
+		pt: "Astros Cintilantes Galeria de Treinador"
+	},
+
+	tcgOnline: 'BRS',
+	serie: serie,
+
+	cardCount: {
+		official: 30
+	},
+
+	releaseDate: "2022-02-25",
+
+	abbreviations: {
+		official: "BRS:TG",
+		fr: "STA:TG"
+	}
+}
+
+export default swsh95tg

--- a/data/Sword & Shield/Brilliant Stars Trainer Gallery/TG01.ts
+++ b/data/Sword & Shield/Brilliant Stars Trainer Gallery/TG01.ts
@@ -77,20 +77,20 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "D",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
 	description: {
 		en: "Once it has stored up enough heat, this Pokémon's body temperature can reach up to 1,700 degrees Fahrenheit.",
 	},
 
-	thirdParty: {
-		cardmarket: 608733
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 608733,
+				tcgplayer: 264210
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Brilliant Stars Trainer Gallery/TG02.ts
+++ b/data/Sword & Shield/Brilliant Stars Trainer Gallery/TG02.ts
@@ -77,20 +77,20 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "D",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
 	description: {
 		en: "When Vaporeon's fins begin to vibrate, it is a sign that rain will come within a few hours.",
 	},
 
-	thirdParty: {
-		cardmarket: 608734
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 608734,
+				tcgplayer: 264211
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Brilliant Stars Trainer Gallery/TG03.ts
+++ b/data/Sword & Shield/Brilliant Stars Trainer Gallery/TG03.ts
@@ -77,20 +77,20 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "E",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
 	description: {
 		en: "It traps enemies with its suction-cupped tentacles, then smashes them with its rock-hard head.",
 	},
 
-	thirdParty: {
-		cardmarket: 608735
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 608735,
+				tcgplayer: 264212
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Brilliant Stars Trainer Gallery/TG04.ts
+++ b/data/Sword & Shield/Brilliant Stars Trainer Gallery/TG04.ts
@@ -77,20 +77,20 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "D",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
 	description: {
 		en: "If it is angered or startled, the fur all over its body bristles like sharp needles that pierce foes.",
 	},
 
-	thirdParty: {
-		cardmarket: 608736
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 608736,
+				tcgplayer: 264213
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Brilliant Stars Trainer Gallery/TG05.ts
+++ b/data/Sword & Shield/Brilliant Stars Trainer Gallery/TG05.ts
@@ -67,20 +67,20 @@ const card: Card = {
 	retreat: 3,
 	regulationMark: "D",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
 	description: {
 		en: "When the interior part of its tail spins like a motor, Zekrom can generate many bolts of lightning to blast its surroundings.",
 	},
 
-	thirdParty: {
-		cardmarket: 608737
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 608737,
+				tcgplayer: 264205
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Brilliant Stars Trainer Gallery/TG06.ts
+++ b/data/Sword & Shield/Brilliant Stars Trainer Gallery/TG06.ts
@@ -83,20 +83,20 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "D",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
 	description: {
 		en: "At the bidding of transmissions from the spirit world, it steals people and Pokémon away. No one knows whether it has a will of its own.",
 	},
 
-	thirdParty: {
-		cardmarket: 608512
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 608738,
+				tcgplayer: 263778
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Brilliant Stars Trainer Gallery/TG07.ts
+++ b/data/Sword & Shield/Brilliant Stars Trainer Gallery/TG07.ts
@@ -54,20 +54,20 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "E",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
 	description: {
 		en: "Since Dedenne can't generate as much electricity on its own, it steals electricity from outlets or other electric Pokémon.",
 	},
 
-	thirdParty: {
-		cardmarket: 608517
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 608739,
+				tcgplayer: 263783
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Brilliant Stars Trainer Gallery/TG08.ts
+++ b/data/Sword & Shield/Brilliant Stars Trainer Gallery/TG08.ts
@@ -86,20 +86,20 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "E",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
 	description: {
 		en: "When Alcremie is content, the cream it secretes from its hands becomes sweeter and richer.",
 	},
 
-	thirdParty: {
-		cardmarket: 608521
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 608740,
+				tcgplayer: 263787
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Brilliant Stars Trainer Gallery/TG09.ts
+++ b/data/Sword & Shield/Brilliant Stars Trainer Gallery/TG09.ts
@@ -86,20 +86,20 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "D",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
 	description: {
 		en: "It spews threads from its mouth to catch its prey. When night falls, it leaves its web to go hunt aggressively.",
 	},
 
-	thirdParty: {
-		cardmarket: 608741
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 608741,
+				tcgplayer: 264204
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Brilliant Stars Trainer Gallery/TG10.ts
+++ b/data/Sword & Shield/Brilliant Stars Trainer Gallery/TG10.ts
@@ -77,20 +77,20 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "E",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
 	description: {
 		en: "Identifiable by its eerie howls, people a long time ago thought it was the grim reaper and feared it.",
 	},
 
-	thirdParty: {
-		cardmarket: 608742
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 608742,
+				tcgplayer: 264217
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Brilliant Stars Trainer Gallery/TG11.ts
+++ b/data/Sword & Shield/Brilliant Stars Trainer Gallery/TG11.ts
@@ -65,20 +65,20 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "E",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
 	description: {
 		en: "Thanks to its unstable genetic makeup, this special Pokémon conceals many different possible evolutions.",
 	},
 
-	thirdParty: {
-		cardmarket: 608743
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 608743,
+				tcgplayer: 264218
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Brilliant Stars Trainer Gallery/TG12.ts
+++ b/data/Sword & Shield/Brilliant Stars Trainer Gallery/TG12.ts
@@ -67,20 +67,20 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "D",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
 	description: {
 		en: "It knows the forest inside and out. If it comes across a wounded Pokémon, Oranguru will gather medicinal herbs to treat it.",
 	},
 
-	thirdParty: {
-		cardmarket: 608744
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 608744,
+				tcgplayer: 264219
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Brilliant Stars Trainer Gallery/TG13.ts
+++ b/data/Sword & Shield/Brilliant Stars Trainer Gallery/TG13.ts
@@ -75,16 +75,16 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "D",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 608745
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 608745,
+				tcgplayer: 264202
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Brilliant Stars Trainer Gallery/TG14.ts
+++ b/data/Sword & Shield/Brilliant Stars Trainer Gallery/TG14.ts
@@ -68,16 +68,16 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "E",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 608746
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 608746,
+				tcgplayer: 264209
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Brilliant Stars Trainer Gallery/TG15.ts
+++ b/data/Sword & Shield/Brilliant Stars Trainer Gallery/TG15.ts
@@ -84,16 +84,16 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "E",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 608747
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 608747,
+				tcgplayer: 264208
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Brilliant Stars Trainer Gallery/TG16.ts
+++ b/data/Sword & Shield/Brilliant Stars Trainer Gallery/TG16.ts
@@ -81,16 +81,16 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "E",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 608518
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 608748,
+				tcgplayer: 263784
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Brilliant Stars Trainer Gallery/TG17.ts
+++ b/data/Sword & Shield/Brilliant Stars Trainer Gallery/TG17.ts
@@ -90,16 +90,16 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "E",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 608519
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 608749,
+				tcgplayer: 263785
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Brilliant Stars Trainer Gallery/TG18.ts
+++ b/data/Sword & Shield/Brilliant Stars Trainer Gallery/TG18.ts
@@ -75,16 +75,16 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "E",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 608750
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 608750,
+				tcgplayer: 264224
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Brilliant Stars Trainer Gallery/TG19.ts
+++ b/data/Sword & Shield/Brilliant Stars Trainer Gallery/TG19.ts
@@ -77,16 +77,16 @@ const card: Card = {
 	retreat: 3,
 	regulationMark: "E",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 608751
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 608751,
+				tcgplayer: 264225
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Brilliant Stars Trainer Gallery/TG20.ts
+++ b/data/Sword & Shield/Brilliant Stars Trainer Gallery/TG20.ts
@@ -68,16 +68,16 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "E",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 608752
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 608752,
+				tcgplayer: 264226
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Brilliant Stars Trainer Gallery/TG21.ts
+++ b/data/Sword & Shield/Brilliant Stars Trainer Gallery/TG21.ts
@@ -84,16 +84,16 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "E",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 608753
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 608753,
+				tcgplayer: 264227
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Brilliant Stars Trainer Gallery/TG22.ts
+++ b/data/Sword & Shield/Brilliant Stars Trainer Gallery/TG22.ts
@@ -77,16 +77,16 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "E",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 608754
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 608754,
+				tcgplayer: 264207
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Brilliant Stars Trainer Gallery/TG23.ts
+++ b/data/Sword & Shield/Brilliant Stars Trainer Gallery/TG23.ts
@@ -77,16 +77,16 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "E",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 608755
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 608755,
+				tcgplayer: 264206
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Brilliant Stars Trainer Gallery/TG24.ts
+++ b/data/Sword & Shield/Brilliant Stars Trainer Gallery/TG24.ts
@@ -29,16 +29,23 @@ const card: Card = {
 	trainerType: "Supporter",
 	regulationMark: "E",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 608675
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 608756,
+				tcgplayer: 263852
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 608756,
+				tcgplayer: 263852
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Brilliant Stars Trainer Gallery/TG25.ts
+++ b/data/Sword & Shield/Brilliant Stars Trainer Gallery/TG25.ts
@@ -29,16 +29,16 @@ const card: Card = {
 	trainerType: "Supporter",
 	regulationMark: "E",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 608679
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 608757,
+				tcgplayer: 264203
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Brilliant Stars Trainer Gallery/TG26.ts
+++ b/data/Sword & Shield/Brilliant Stars Trainer Gallery/TG26.ts
@@ -29,16 +29,23 @@ const card: Card = {
 	trainerType: "Supporter",
 	regulationMark: "E",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 608687
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 608758,
+				tcgplayer: 263863
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 608758,
+				tcgplayer: 263863
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Brilliant Stars Trainer Gallery/TG27.ts
+++ b/data/Sword & Shield/Brilliant Stars Trainer Gallery/TG27.ts
@@ -29,16 +29,16 @@ const card: Card = {
 	trainerType: "Supporter",
 	regulationMark: "E",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 608759
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 608759,
+				tcgplayer: 264230
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Brilliant Stars Trainer Gallery/TG28.ts
+++ b/data/Sword & Shield/Brilliant Stars Trainer Gallery/TG28.ts
@@ -29,16 +29,16 @@ const card: Card = {
 	trainerType: "Supporter",
 	regulationMark: "E",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 608760
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 608760,
+				tcgplayer: 264231
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Brilliant Stars Trainer Gallery/TG29.ts
+++ b/data/Sword & Shield/Brilliant Stars Trainer Gallery/TG29.ts
@@ -77,16 +77,16 @@ const card: Card = {
 	retreat: 3,
 	regulationMark: "E",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 608751
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 608761,
+				tcgplayer: 264232
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Brilliant Stars Trainer Gallery/TG30.ts
+++ b/data/Sword & Shield/Brilliant Stars Trainer Gallery/TG30.ts
@@ -84,16 +84,16 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "E",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 608753
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 608762,
+				tcgplayer: 264234
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Brilliant Stars/001.ts
+++ b/data/Sword & Shield/Brilliant Stars/001.ts
@@ -58,21 +58,27 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "F",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	description: {
 		en: "Though it may look like it's just a bunch of eggs, it's a proper Pokémon. Exeggcute communicates with others of its kind via telepathy, apparently.",
 	},
 
-	thirdParty: {
-		cardmarket: 608425,
-		tcgplayer: 263578
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 608425,
+				tcgplayer: 263578
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 608425,
+				tcgplayer: 263578
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Brilliant Stars/002.ts
+++ b/data/Sword & Shield/Brilliant Stars/002.ts
@@ -77,21 +77,27 @@ const card: Card = {
 	retreat: 3,
 	regulationMark: "F",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	description: {
 		en: "Each of Exeggutor's three heads is thinking different thoughts. The three don't seem to be very interested in one another.",
 	},
 
-	thirdParty: {
-		cardmarket: 608426,
-		tcgplayer: 263579
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 608426,
+				tcgplayer: 263579
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 608426,
+				tcgplayer: 263579
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Brilliant Stars/003.ts
+++ b/data/Sword & Shield/Brilliant Stars/003.ts
@@ -45,21 +45,27 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "F",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	description: {
 		en: "It spouts poison spores from the top of its head. These spores cause pain all over if inhaled.",
 	},
 
-	thirdParty: {
-		cardmarket: 608427,
-		tcgplayer: 263580
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 608427,
+				tcgplayer: 263580
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 608427,
+				tcgplayer: 263580
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Brilliant Stars/004.ts
+++ b/data/Sword & Shield/Brilliant Stars/004.ts
@@ -86,21 +86,27 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "F",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	description: {
 		en: "It scatters poisonous spores and throws powerful punches while its foe is hampered by inhaled spores.",
 	},
 
-	thirdParty: {
-		cardmarket: 608428,
-		tcgplayer: 263583
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 608428,
+				tcgplayer: 263583
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 608428,
+				tcgplayer: 263583
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Brilliant Stars/005.ts
+++ b/data/Sword & Shield/Brilliant Stars/005.ts
@@ -67,21 +67,27 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "F",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	description: {
 		en: "Bunches of delicious fruit grow around its neck. In warm areas, many ranches raise Tropius.",
 	},
 
-	thirdParty: {
-		cardmarket: 608429,
-		tcgplayer: 263585
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 608429,
+				tcgplayer: 263585
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 608429,
+				tcgplayer: 263585
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Brilliant Stars/006.ts
+++ b/data/Sword & Shield/Brilliant Stars/006.ts
@@ -58,21 +58,27 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "F",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	description: {
 		en: "It undertakes photosynthesis with its body, making oxygen. The leaf on its head wilts if it is thirsty.",
 	},
 
-	thirdParty: {
-		cardmarket: 608430,
-		tcgplayer: 263589
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 608430,
+				tcgplayer: 263589
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 608430,
+				tcgplayer: 263589
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Brilliant Stars/007.ts
+++ b/data/Sword & Shield/Brilliant Stars/007.ts
@@ -77,21 +77,27 @@ const card: Card = {
 	retreat: 3,
 	regulationMark: "F",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	description: {
 		en: "It knows where pure water wells up. It carries fellow Pokémon there on its back.",
 	},
 
-	thirdParty: {
-		cardmarket: 608431,
-		tcgplayer: 263592
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 608431,
+				tcgplayer: 263592
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 608431,
+				tcgplayer: 263592
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Brilliant Stars/008.ts
+++ b/data/Sword & Shield/Brilliant Stars/008.ts
@@ -77,21 +77,27 @@ const card: Card = {
 	retreat: 4,
 	regulationMark: "F",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: true,
-		firstEdition: false
-	},
 
 	description: {
 		en: "Small Pokémon occasionally gather on its unmoving back to begin building their nests.",
 	},
 
-	thirdParty: {
-		cardmarket: 608432,
-		tcgplayer: 263597
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 608432,
+				tcgplayer: 263597
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 608432,
+				tcgplayer: 263597
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Brilliant Stars/009.ts
+++ b/data/Sword & Shield/Brilliant Stars/009.ts
@@ -45,21 +45,27 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "F",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	description: {
 		en: "If its cloak is broken in battle, it quickly remakes the cloak with materials nearby.",
 	},
 
-	thirdParty: {
-		cardmarket: 608433,
-		tcgplayer: 263595
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 608433,
+				tcgplayer: 263595
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 608433,
+				tcgplayer: 263595
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Brilliant Stars/010.ts
+++ b/data/Sword & Shield/Brilliant Stars/010.ts
@@ -86,21 +86,27 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "F",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	description: {
 		en: "When Burmy evolved, its cloak became a part of this Pokémon's body. The cloak is never shed.",
 	},
 
-	thirdParty: {
-		cardmarket: 608434,
-		tcgplayer: 263598
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 608434,
+				tcgplayer: 263598
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 608434,
+				tcgplayer: 263598
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Brilliant Stars/011.ts
+++ b/data/Sword & Shield/Brilliant Stars/011.ts
@@ -83,21 +83,27 @@ const card: Card = {
 	retreat: 0,
 	regulationMark: "F",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	description: {
 		en: "It flutters around at night and steals honey from the Combee hive.",
 	},
 
-	thirdParty: {
-		cardmarket: 608435,
-		tcgplayer: 263605
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 608435,
+				tcgplayer: 263605
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 608435,
+				tcgplayer: 263605
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Brilliant Stars/012.ts
+++ b/data/Sword & Shield/Brilliant Stars/012.ts
@@ -67,21 +67,27 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "E",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	description: {
 		en: "The deeper a Cherubi's red, the more nutrients it has stockpiled in its body. And the sweeter and tastier its small ball!",
 	},
 
-	thirdParty: {
-		cardmarket: 608436,
-		tcgplayer: 263606
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 608436,
+				tcgplayer: 263606
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 608436,
+				tcgplayer: 263606
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Brilliant Stars/013.ts
+++ b/data/Sword & Shield/Brilliant Stars/013.ts
@@ -68,17 +68,16 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "F",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 608437,
-		tcgplayer: 263608
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 608437,
+				tcgplayer: 263608
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Brilliant Stars/014.ts
+++ b/data/Sword & Shield/Brilliant Stars/014.ts
@@ -65,17 +65,23 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "F",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 608448,
-		tcgplayer: 263611
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 608448,
+				tcgplayer: 263611
+			}
+		},
+		{
+			type: 'holo',
+			size: 'jumbo',
+			thirdParty: {
+				cardmarket: 675937
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Brilliant Stars/015.ts
+++ b/data/Sword & Shield/Brilliant Stars/015.ts
@@ -45,21 +45,27 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "F",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	description: {
 		en: "Its strange physiology reacts to electrical energy in interesting ways. The presence of a Shelmet will cause this Pokémon to evolve.",
 	},
 
-	thirdParty: {
-		cardmarket: 608452,
-		tcgplayer: 263703
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 608452,
+				tcgplayer: 263703
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 608452,
+				tcgplayer: 263703
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Brilliant Stars/016.ts
+++ b/data/Sword & Shield/Brilliant Stars/016.ts
@@ -77,17 +77,16 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "F",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 608455,
-		tcgplayer: 263704
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 608455,
+				tcgplayer: 263704
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Brilliant Stars/017.ts
+++ b/data/Sword & Shield/Brilliant Stars/017.ts
@@ -69,17 +69,16 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "F",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 608460,
-		tcgplayer: 257299
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 608460,
+				tcgplayer: 257299
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Brilliant Stars/018.ts
+++ b/data/Sword & Shield/Brilliant Stars/018.ts
@@ -88,17 +88,23 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "F",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 608462,
-		tcgplayer: 257293
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 608462,
+				tcgplayer: 257293
+			}
+		},
+		{
+			type: 'holo',
+			size: 'jumbo',
+			thirdParty: {
+				cardmarket: 610907
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Brilliant Stars/019.ts
+++ b/data/Sword & Shield/Brilliant Stars/019.ts
@@ -58,21 +58,27 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "F",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	description: {
 		en: "Magmar dispatches its prey with fire. But it regrets this habit once it realizes that it has burned its intended prey to a charred crisp.",
 	},
 
-	thirdParty: {
-		cardmarket: 608469,
-		tcgplayer: 263705
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 608469,
+				tcgplayer: 263705
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 608469,
+				tcgplayer: 263705
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Brilliant Stars/020.ts
+++ b/data/Sword & Shield/Brilliant Stars/020.ts
@@ -77,21 +77,27 @@ const card: Card = {
 	retreat: 3,
 	regulationMark: "F",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	description: {
 		en: "When Magmortar inhales deeply, the fire burning in its belly intensifies, rising in temperature to over 3,600 degrees Fahrenheit.",
 	},
 
-	thirdParty: {
-		cardmarket: 608470,
-		tcgplayer: 263708
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 608470,
+				tcgplayer: 263708
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 608470,
+				tcgplayer: 263708
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Brilliant Stars/021.ts
+++ b/data/Sword & Shield/Brilliant Stars/021.ts
@@ -54,21 +54,34 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "F",
 
-	variants: {
-		normal: false,
-		reverse: true,
-		holo: true,
-		firstEdition: false
-	},
 
 	description: {
 		en: "It's one of the legendary bird Pokémon. When Moltres flaps its flaming wings, they glimmer with a dazzling red glow.",
 	},
 
-	thirdParty: {
-		cardmarket: 608471,
-		tcgplayer: 263711
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 608471,
+				tcgplayer: 263711
+			}
+		},
+		{
+			type: 'holo',
+			foil: 'cosmos',
+			thirdParty: {
+				cardmarket: 778297
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 608471,
+				tcgplayer: 263711
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Brilliant Stars/022.ts
+++ b/data/Sword & Shield/Brilliant Stars/022.ts
@@ -77,17 +77,16 @@ const card: Card = {
 	retreat: 3,
 	regulationMark: "F",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 608472,
-		tcgplayer: 263715
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 608472,
+				tcgplayer: 263715
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Brilliant Stars/023.ts
+++ b/data/Sword & Shield/Brilliant Stars/023.ts
@@ -76,21 +76,27 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "F",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	description: {
 		en: "It burns coal inside its shell for energy. It blows out black soot if it is endangered.",
 	},
 
-	thirdParty: {
-		cardmarket: 608473,
-		tcgplayer: 263716
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 608473,
+				tcgplayer: 263716
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 608473,
+				tcgplayer: 263716
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Brilliant Stars/024.ts
+++ b/data/Sword & Shield/Brilliant Stars/024.ts
@@ -54,21 +54,27 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "F",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	description: {
 		en: "The gas made in its belly burns from its rear end. The fire burns weakly when it feels sick.",
 	},
 
-	thirdParty: {
-		cardmarket: 608474,
-		tcgplayer: 263723
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 608474,
+				tcgplayer: 263723
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 608474,
+				tcgplayer: 263723
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Brilliant Stars/025.ts
+++ b/data/Sword & Shield/Brilliant Stars/025.ts
@@ -77,21 +77,27 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "F",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	description: {
 		en: "It uses ceilings and walls to launch aerial attacks. Its fiery tail is but one weapon.",
 	},
 
-	thirdParty: {
-		cardmarket: 608475,
-		tcgplayer: 263724
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 608475,
+				tcgplayer: 263724
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 608475,
+				tcgplayer: 263724
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Brilliant Stars/026.ts
+++ b/data/Sword & Shield/Brilliant Stars/026.ts
@@ -86,21 +86,27 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "F",
 
-	variants: {
-		normal: false,
-		reverse: true,
-		holo: true,
-		firstEdition: false
-	},
 
 	description: {
 		en: "It tosses its enemies around with agility. It uses all its limbs to fight in its own unique style.",
 	},
 
-	thirdParty: {
-		cardmarket: 608476,
-		tcgplayer: 263725
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 608476,
+				tcgplayer: 263725
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 608476,
+				tcgplayer: 263725
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Brilliant Stars/027.ts
+++ b/data/Sword & Shield/Brilliant Stars/027.ts
@@ -77,17 +77,16 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "F",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 608477,
-		tcgplayer: 263726
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 608477,
+				tcgplayer: 263726
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Brilliant Stars/028.ts
+++ b/data/Sword & Shield/Brilliant Stars/028.ts
@@ -75,17 +75,16 @@ const card: Card = {
 	retreat: 3,
 	regulationMark: "F",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 608478,
-		tcgplayer: 263727
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 608478,
+				tcgplayer: 263727
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Brilliant Stars/029.ts
+++ b/data/Sword & Shield/Brilliant Stars/029.ts
@@ -84,17 +84,16 @@ const card: Card = {
 	retreat: 3,
 	regulationMark: "F",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 608479,
-		tcgplayer: 263728
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 608479,
+				tcgplayer: 263728
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Brilliant Stars/030.ts
+++ b/data/Sword & Shield/Brilliant Stars/030.ts
@@ -54,21 +54,27 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "F",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	description: {
 		en: "If you visit a beach at the end of summer, you'll be able to see groups of Staryu lighting up in a steady rhythm.",
 	},
 
-	thirdParty: {
-		cardmarket: 608480,
-		tcgplayer: 263729
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 608480,
+				tcgplayer: 263729
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 608480,
+				tcgplayer: 263729
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Brilliant Stars/031.ts
+++ b/data/Sword & Shield/Brilliant Stars/031.ts
@@ -54,21 +54,27 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "F",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	description: {
 		en: "A smart and kindhearted Pokémon, it glides across the surface of the sea while its beautiful song echoes around it.",
 	},
 
-	thirdParty: {
-		cardmarket: 608481,
-		tcgplayer: 263730
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 608481,
+				tcgplayer: 263730
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 608481,
+				tcgplayer: 263730
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Brilliant Stars/032.ts
+++ b/data/Sword & Shield/Brilliant Stars/032.ts
@@ -58,21 +58,27 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "F",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	description: {
 		en: "No matter how dirty the water in the river, it will adapt and thrive. It has a strong will to survive.",
 	},
 
-	thirdParty: {
-		cardmarket: 608482,
-		tcgplayer: 263731
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 608482,
+				tcgplayer: 263731
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 608482,
+				tcgplayer: 263731
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Brilliant Stars/033.ts
+++ b/data/Sword & Shield/Brilliant Stars/033.ts
@@ -77,21 +77,27 @@ const card: Card = {
 	retreat: 3,
 	regulationMark: "F",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	description: {
 		en: "A rough customer that wildly flails its giant claws. It is said to be extremely hard to raise.",
 	},
 
-	thirdParty: {
-		cardmarket: 608483,
-		tcgplayer: 263732
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 608483,
+				tcgplayer: 263732
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 608483,
+				tcgplayer: 263732
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Brilliant Stars/034.ts
+++ b/data/Sword & Shield/Brilliant Stars/034.ts
@@ -65,21 +65,27 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "E",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	description: {
 		en: "It can only survive in cold areas. It bounces happily around, even in environments as cold as -150 degrees Fahrenheit.",
 	},
 
-	thirdParty: {
-		cardmarket: 608484,
-		tcgplayer: 263733
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 608484,
+				tcgplayer: 263733
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 608484,
+				tcgplayer: 263733
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Brilliant Stars/035.ts
+++ b/data/Sword & Shield/Brilliant Stars/035.ts
@@ -54,21 +54,27 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "F",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	description: {
 		en: "Because it is very proud, it hates accepting food from people. Its thick down guards it from cold.",
 	},
 
-	thirdParty: {
-		cardmarket: 608485,
-		tcgplayer: 263734
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 608485,
+				tcgplayer: 263734
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 608485,
+				tcgplayer: 263734
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Brilliant Stars/036.ts
+++ b/data/Sword & Shield/Brilliant Stars/036.ts
@@ -55,21 +55,27 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "F",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	description: {
 		en: "It lives a solitary life. Its wings deliver wicked blows that can snap even the thickest of trees.",
 	},
 
-	thirdParty: {
-		cardmarket: 608486,
-		tcgplayer: 263735
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 608486,
+				tcgplayer: 263735
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 608486,
+				tcgplayer: 263735
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Brilliant Stars/037.ts
+++ b/data/Sword & Shield/Brilliant Stars/037.ts
@@ -84,21 +84,34 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "F",
 
-	variants: {
-		normal: false,
-		reverse: true,
-		holo: true,
-		firstEdition: false
-	},
 
 	description: {
 		en: "The three horns that extend from its beak attest to its power. The leader has the biggest horns.",
 	},
 
-	thirdParty: {
-		cardmarket: 608487,
-		tcgplayer: 263736
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 608487,
+				tcgplayer: 263736
+			}
+		},
+		{
+			type: 'holo',
+			foil: 'cosmos',
+			thirdParty: {
+				cardmarket: 730039
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 608487,
+				tcgplayer: 263736
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Brilliant Stars/038.ts
+++ b/data/Sword & Shield/Brilliant Stars/038.ts
@@ -54,21 +54,27 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "F",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	description: {
 		en: "It inflates the flotation sac around its neck and pokes its head out of the water to see what is going on.",
 	},
 
-	thirdParty: {
-		cardmarket: 608488,
-		tcgplayer: 263737
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 608488,
+				tcgplayer: 263737
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 608488,
+				tcgplayer: 263737
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Brilliant Stars/039.ts
+++ b/data/Sword & Shield/Brilliant Stars/039.ts
@@ -75,21 +75,27 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "F",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	description: {
 		en: "Its flotation sac developed as a result of pursuing aquatic prey. It can double as a rubber raft.",
 	},
 
-	thirdParty: {
-		cardmarket: 608489,
-		tcgplayer: 263738
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 608489,
+				tcgplayer: 263738
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 608489,
+				tcgplayer: 263738
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Brilliant Stars/040.ts
+++ b/data/Sword & Shield/Brilliant Stars/040.ts
@@ -77,17 +77,16 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "F",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 608490,
-		tcgplayer: 263740
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 608490,
+				tcgplayer: 263740
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Brilliant Stars/041.ts
+++ b/data/Sword & Shield/Brilliant Stars/041.ts
@@ -67,21 +67,27 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "F",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	description: {
 		en: "It starts its life with a wondrous power that permits it to bond with any kind of Pokémon.",
 	},
 
-	thirdParty: {
-		cardmarket: 608491,
-		tcgplayer: 263741
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 608491,
+				tcgplayer: 263741
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 608491,
+				tcgplayer: 263741
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Brilliant Stars/042.ts
+++ b/data/Sword & Shield/Brilliant Stars/042.ts
@@ -45,21 +45,27 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "F",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	description: {
 		en: "When this Pokémon is in good health, its snot becomes thicker and stickier. It will smear its snot on anyone it doesn't like.",
 	},
 
-	thirdParty: {
-		cardmarket: 608492,
-		tcgplayer: 263742
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 608492,
+				tcgplayer: 263742
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 608492,
+				tcgplayer: 263742
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Brilliant Stars/043.ts
+++ b/data/Sword & Shield/Brilliant Stars/043.ts
@@ -77,21 +77,27 @@ const card: Card = {
 	retreat: 3,
 	regulationMark: "F",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	description: {
 		en: "It swims through frigid seas, searching for prey. From its frozen breath, it forms icy fangs that are harder than steel.",
 	},
 
-	thirdParty: {
-		cardmarket: 608493,
-		tcgplayer: 263743
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 608493,
+				tcgplayer: 263743
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 608493,
+				tcgplayer: 263743
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Brilliant Stars/044.ts
+++ b/data/Sword & Shield/Brilliant Stars/044.ts
@@ -65,21 +65,27 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "E",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	description: {
 		en: "The hair on its head connects to the surface of its brain. When this Pokémon has something on its mind, its hair chills the air around it.",
 	},
 
-	thirdParty: {
-		cardmarket: 608494,
-		tcgplayer: 263745
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 608494,
+				tcgplayer: 263745
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 608494,
+				tcgplayer: 263745
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Brilliant Stars/045.ts
+++ b/data/Sword & Shield/Brilliant Stars/045.ts
@@ -75,17 +75,16 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "F",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 608495,
-		tcgplayer: 263747
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 608495,
+				tcgplayer: 263747
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Brilliant Stars/046.ts
+++ b/data/Sword & Shield/Brilliant Stars/046.ts
@@ -65,21 +65,27 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "F",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	description: {
 		en: "Many power plants keep Ground-type Pokémon around as a defense against Electabuzz that come seeking electricity.",
 	},
 
-	thirdParty: {
-		cardmarket: 608496,
-		tcgplayer: 263750
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 608496,
+				tcgplayer: 263750
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 608496,
+				tcgplayer: 263750
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Brilliant Stars/047.ts
+++ b/data/Sword & Shield/Brilliant Stars/047.ts
@@ -84,21 +84,27 @@ const card: Card = {
 	retreat: 3,
 	regulationMark: "F",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	description: {
 		en: "The amount of electrical energy this Pokémon produces is proportional to the rate of its pulse. The voltage jumps while Electivire is battling.",
 	},
 
-	thirdParty: {
-		cardmarket: 608497,
-		tcgplayer: 263751
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 608497,
+				tcgplayer: 263751
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 608497,
+				tcgplayer: 263751
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Brilliant Stars/048.ts
+++ b/data/Sword & Shield/Brilliant Stars/048.ts
@@ -77,17 +77,16 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "F",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 608498,
-		tcgplayer: 263754
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 608498,
+				tcgplayer: 263754
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Brilliant Stars/049.ts
+++ b/data/Sword & Shield/Brilliant Stars/049.ts
@@ -45,21 +45,27 @@ const card: Card = {
 	retreat: 0,
 	regulationMark: "F",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	description: {
 		en: "This Pokémon generates electricity by contracting its muscles. Excited trembling is a sign that Shinx is generating a tremendous amount of electricity.",
 	},
 
-	thirdParty: {
-		cardmarket: 608499,
-		tcgplayer: 263755
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 608499,
+				tcgplayer: 263755
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 608499,
+				tcgplayer: 263755
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Brilliant Stars/050.ts
+++ b/data/Sword & Shield/Brilliant Stars/050.ts
@@ -64,21 +64,27 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "F",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	description: {
 		en: "By joining its tail with that of another Luxio, this Pokémon can receive some of the other Luxio's electricity and power up its own electric blasts.",
 	},
 
-	thirdParty: {
-		cardmarket: 608500,
-		tcgplayer: 263756
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 608500,
+				tcgplayer: 263756
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 608500,
+				tcgplayer: 263756
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Brilliant Stars/051.ts
+++ b/data/Sword & Shield/Brilliant Stars/051.ts
@@ -86,21 +86,27 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "F",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	description: {
 		en: "Luxray can see through solid objects. It will instantly spot prey trying to hide behind walls, even if the walls are thick.",
 	},
 
-	thirdParty: {
-		cardmarket: 608501,
-		tcgplayer: 263757
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 608501,
+				tcgplayer: 263757
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 608501,
+				tcgplayer: 263757
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Brilliant Stars/052.ts
+++ b/data/Sword & Shield/Brilliant Stars/052.ts
@@ -54,21 +54,27 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "F",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	description: {
 		en: "A pair may be seen rubbing their cheek pouches together in an effort to share stored electricity.",
 	},
 
-	thirdParty: {
-		cardmarket: 608502,
-		tcgplayer: 263758
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 608502,
+				tcgplayer: 263758
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 608502,
+				tcgplayer: 263758
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Brilliant Stars/053.ts
+++ b/data/Sword & Shield/Brilliant Stars/053.ts
@@ -58,21 +58,27 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "F",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	description: {
 		en: "It is said that happiness will come to those who see a gathering of Clefairy dancing under a full moon.",
 	},
 
-	thirdParty: {
-		cardmarket: 608503,
-		tcgplayer: 263769
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 608503,
+				tcgplayer: 263769
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 608503,
+				tcgplayer: 263769
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Brilliant Stars/054.ts
+++ b/data/Sword & Shield/Brilliant Stars/054.ts
@@ -75,21 +75,27 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "F",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	description: {
 		en: "A timid fairy Pokémon that is rarely seen, it will run and hide the moment it senses people.",
 	},
 
-	thirdParty: {
-		cardmarket: 608504,
-		tcgplayer: 263770
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 608504,
+				tcgplayer: 263770
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 608504,
+				tcgplayer: 263770
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Brilliant Stars/055.ts
+++ b/data/Sword & Shield/Brilliant Stars/055.ts
@@ -83,21 +83,27 @@ const card: Card = {
 	retreat: 0,
 	regulationMark: "F",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	description: {
 		en: "This Pokémon has an organ known as its core. The organ glows in seven colors when Starmie is unleashing its potent psychic powers.",
 	},
 
-	thirdParty: {
-		cardmarket: 608505,
-		tcgplayer: 263771
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 608505,
+				tcgplayer: 263771
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 608505,
+				tcgplayer: 263771
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Brilliant Stars/056.ts
+++ b/data/Sword & Shield/Brilliant Stars/056.ts
@@ -73,21 +73,34 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "F",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	description: {
 		en: "A Pokémon created by recombining Mew's genes. It's said to have the most savage heart among Pokémon.",
 	},
 
-	thirdParty: {
-		cardmarket: 608506,
-		tcgplayer: 263772
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 608506,
+				tcgplayer: 263772
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 608506,
+				tcgplayer: 263772
+			}
+		},
+		{
+			type: 'reverse',
+			stamp: ['set-logo'],
+			thirdParty: {
+				cardmarket: 610906
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Brilliant Stars/057.ts
+++ b/data/Sword & Shield/Brilliant Stars/057.ts
@@ -77,17 +77,16 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "F",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 608507,
-		tcgplayer: 263773
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 608507,
+				tcgplayer: 263773
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Brilliant Stars/058.ts
+++ b/data/Sword & Shield/Brilliant Stars/058.ts
@@ -60,21 +60,27 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "F",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	description: {
 		en: "It moves while spinning around on its single foot. Some Baltoy have been seen spinning on their heads.",
 	},
 
-	thirdParty: {
-		cardmarket: 608508,
-		tcgplayer: 263774
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 608508,
+				tcgplayer: 263774
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 608508,
+				tcgplayer: 263774
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Brilliant Stars/059.ts
+++ b/data/Sword & Shield/Brilliant Stars/059.ts
@@ -83,21 +83,27 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "F",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	description: {
 		en: "This mysterious Pokémon started life as an ancient clay figurine made over 20,000 years ago.",
 	},
 
-	thirdParty: {
-		cardmarket: 608509,
-		tcgplayer: 263775
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 608509,
+				tcgplayer: 263775
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 608509,
+				tcgplayer: 263775
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Brilliant Stars/060.ts
+++ b/data/Sword & Shield/Brilliant Stars/060.ts
@@ -60,21 +60,27 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "F",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	description: {
 		en: "If it finds bad children who won't listen to their parents, it will spirit them away—or so it's said.",
 	},
 
-	thirdParty: {
-		cardmarket: 608510,
-		tcgplayer: 263776
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 608510,
+				tcgplayer: 263776
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 608510,
+				tcgplayer: 263776
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Brilliant Stars/061.ts
+++ b/data/Sword & Shield/Brilliant Stars/061.ts
@@ -70,21 +70,27 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "F",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	description: {
 		en: "Its body is entirely hollow. When it opens its mouth, it sucks everything in as if it were a black hole.",
 	},
 
-	thirdParty: {
-		cardmarket: 608511,
-		tcgplayer: 263777
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 608511,
+				tcgplayer: 263777
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 608511,
+				tcgplayer: 263777
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Brilliant Stars/062.ts
+++ b/data/Sword & Shield/Brilliant Stars/062.ts
@@ -83,21 +83,27 @@ const card: Card = {
 	retreat: 3,
 	regulationMark: "F",
 
-	variants: {
-		normal: false,
-		reverse: true,
-		holo: true,
-		firstEdition: false
-	},
 
 	description: {
 		en: "At the bidding of transmissions from the spirit world, it steals people and Pokémon away. No one knows whether it has a will of its own.",
 	},
 
-	thirdParty: {
-		cardmarket: 608512,
-		tcgplayer: 263778
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 608512,
+				tcgplayer: 263778
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 608512,
+				tcgplayer: 263778
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Brilliant Stars/063.ts
+++ b/data/Sword & Shield/Brilliant Stars/063.ts
@@ -71,21 +71,27 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "F",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	description: {
 		en: "Emitting ultrasonic cries, it floats on winds to travel great distances.",
 	},
 
-	thirdParty: {
-		cardmarket: 608513,
-		tcgplayer: 263779
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 608513,
+				tcgplayer: 263779
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 608513,
+				tcgplayer: 263779
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Brilliant Stars/064.ts
+++ b/data/Sword & Shield/Brilliant Stars/064.ts
@@ -77,17 +77,16 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "F",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 608514,
-		tcgplayer: 263780
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 608514,
+				tcgplayer: 263780
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Brilliant Stars/065.ts
+++ b/data/Sword & Shield/Brilliant Stars/065.ts
@@ -85,17 +85,16 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "F",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 608515,
-		tcgplayer: 263781
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 608515,
+				tcgplayer: 263781
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Brilliant Stars/066.ts
+++ b/data/Sword & Shield/Brilliant Stars/066.ts
@@ -80,21 +80,27 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "F",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	description: {
 		en: "Psychic power allows these Pokémon to fly. Some say they were the guardians of an ancient city. Others say they were the guardians' emissaries.",
 	},
 
-	thirdParty: {
-		cardmarket: 608516,
-		tcgplayer: 263782
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 608516,
+				tcgplayer: 263782
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 608516,
+				tcgplayer: 263782
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Brilliant Stars/067.ts
+++ b/data/Sword & Shield/Brilliant Stars/067.ts
@@ -54,21 +54,27 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "E",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	description: {
 		en: "Since Dedenne can't generate as much electricity on its own, it steals electricity from outlets or other electric Pokémon.",
 	},
 
-	thirdParty: {
-		cardmarket: 608517,
-		tcgplayer: 263783
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 608517,
+				tcgplayer: 263783
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 608517,
+				tcgplayer: 263783
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Brilliant Stars/068.ts
+++ b/data/Sword & Shield/Brilliant Stars/068.ts
@@ -81,17 +81,16 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "E",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 608518,
-		tcgplayer: 263784
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 608518,
+				tcgplayer: 263784
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Brilliant Stars/069.ts
+++ b/data/Sword & Shield/Brilliant Stars/069.ts
@@ -90,17 +90,16 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "E",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 608519,
-		tcgplayer: 263785
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 608519,
+				tcgplayer: 263785
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Brilliant Stars/070.ts
+++ b/data/Sword & Shield/Brilliant Stars/070.ts
@@ -65,21 +65,27 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "E",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	description: {
 		en: "They say that any patisserie visited by Milcery is guaranteed success and good fortune.",
 	},
 
-	thirdParty: {
-		cardmarket: 608520,
-		tcgplayer: 263786
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 608520,
+				tcgplayer: 263786
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 608520,
+				tcgplayer: 263786
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Brilliant Stars/071.ts
+++ b/data/Sword & Shield/Brilliant Stars/071.ts
@@ -86,21 +86,27 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "E",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	description: {
 		en: "When Alcremie is content, the cream it secretes from its hands becomes sweeter and richer.",
 	},
 
-	thirdParty: {
-		cardmarket: 608521,
-		tcgplayer: 263787
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 608521,
+				tcgplayer: 263787
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 608521,
+				tcgplayer: 263787
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Brilliant Stars/072.ts
+++ b/data/Sword & Shield/Brilliant Stars/072.ts
@@ -67,21 +67,27 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "F",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	description: {
 		en: "It launches kicks while spinning. If it spins at high speed, it may bore its way into the ground.",
 	},
 
-	thirdParty: {
-		cardmarket: 608522,
-		tcgplayer: 263788
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 608522,
+				tcgplayer: 263788
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 608522,
+				tcgplayer: 263788
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Brilliant Stars/073.ts
+++ b/data/Sword & Shield/Brilliant Stars/073.ts
@@ -45,21 +45,27 @@ const card: Card = {
 	retreat: 4,
 	regulationMark: "F",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	description: {
 		en: "It hunts without twitching a muscle by pulling in its prey with powerful magnetism. But sometimes it pulls natural enemies in close.",
 	},
 
-	thirdParty: {
-		cardmarket: 608523,
-		tcgplayer: 263789
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 608523,
+				tcgplayer: 263789
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 608523,
+				tcgplayer: 263789
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Brilliant Stars/074.ts
+++ b/data/Sword & Shield/Brilliant Stars/074.ts
@@ -54,21 +54,27 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "F",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	description: {
 		en: "Its nest is a sloped, bowl-like pit in the desert. Once something has fallen in, there is no escape.",
 	},
 
-	thirdParty: {
-		cardmarket: 608524,
-		tcgplayer: 263790
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 608524,
+				tcgplayer: 263790
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 608524,
+				tcgplayer: 263790
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Brilliant Stars/075.ts
+++ b/data/Sword & Shield/Brilliant Stars/075.ts
@@ -55,21 +55,27 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "F",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	description: {
 		en: "The ultrasonic waves it generates by rubbing its two wings together cause severe headaches.",
 	},
 
-	thirdParty: {
-		cardmarket: 608525,
-		tcgplayer: 263791
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 608525,
+				tcgplayer: 263791
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 608525,
+				tcgplayer: 263791
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Brilliant Stars/076.ts
+++ b/data/Sword & Shield/Brilliant Stars/076.ts
@@ -77,21 +77,27 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "F",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	description: {
 		en: "This Pokémon hides in the heart of sandstorms it creates and seldom appears where people can see it.",
 	},
 
-	thirdParty: {
-		cardmarket: 608526,
-		tcgplayer: 263792
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 608526,
+				tcgplayer: 263792
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 608526,
+				tcgplayer: 263792
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Brilliant Stars/077.ts
+++ b/data/Sword & Shield/Brilliant Stars/077.ts
@@ -86,21 +86,27 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "F",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	description: {
 		en: "When Burmy evolved, its cloak became a part of this Pokémon's body. The cloak is never shed.",
 	},
 
-	thirdParty: {
-		cardmarket: 608434,
-		tcgplayer: 263793
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 608527,
+				tcgplayer: 263793
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 608527,
+				tcgplayer: 263793
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Brilliant Stars/078.ts
+++ b/data/Sword & Shield/Brilliant Stars/078.ts
@@ -45,21 +45,27 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "F",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	description: {
 		en: "It's exceedingly energetic, with enough stamina to keep running all through the night. Taking it for walks can be a challenging experience.",
 	},
 
-	thirdParty: {
-		cardmarket: 608528,
-		tcgplayer: 263794
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 608528,
+				tcgplayer: 263794
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 608528,
+				tcgplayer: 263794
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Brilliant Stars/079.ts
+++ b/data/Sword & Shield/Brilliant Stars/079.ts
@@ -86,21 +86,27 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "F",
 
-	variants: {
-		normal: false,
-		reverse: true,
-		holo: true,
-		firstEdition: false
-	},
 
 	description: {
 		en: "It controls waves known as auras, which are powerful enough to pulverize huge rocks. It uses these waves to take down its prey.",
 	},
 
-	thirdParty: {
-		cardmarket: 608529,
-		tcgplayer: 263795
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 608529,
+				tcgplayer: 263795
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 608529,
+				tcgplayer: 263795
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Brilliant Stars/080.ts
+++ b/data/Sword & Shield/Brilliant Stars/080.ts
@@ -58,21 +58,27 @@ const card: Card = {
 	retreat: 3,
 	regulationMark: "F",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	description: {
 		en: "It performs throwing moves with first-rate skill. Over the course of many battles, Throh's belt grows darker as it absorbs its wearer's sweat.",
 	},
 
-	thirdParty: {
-		cardmarket: 608530,
-		tcgplayer: 263796
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 608530,
+				tcgplayer: 263796
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 608530,
+				tcgplayer: 263796
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Brilliant Stars/081.ts
+++ b/data/Sword & Shield/Brilliant Stars/081.ts
@@ -54,21 +54,27 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "F",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	description: {
 		en: "If you see a Sawk training in the mountains in its single-minded pursuit of strength, it's best to quietly pass by.",
 	},
 
-	thirdParty: {
-		cardmarket: 608531,
-		tcgplayer: 263797
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 608531,
+				tcgplayer: 263797
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 608531,
+				tcgplayer: 263797
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Brilliant Stars/082.ts
+++ b/data/Sword & Shield/Brilliant Stars/082.ts
@@ -58,21 +58,27 @@ const card: Card = {
 	retreat: 4,
 	regulationMark: "F",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	description: {
 		en: "They were sculpted from clay in ancient times. No one knows why, but some of them are driven to continually line up boulders.",
 	},
 
-	thirdParty: {
-		cardmarket: 608532,
-		tcgplayer: 263798
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 608532,
+				tcgplayer: 263798
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 608532,
+				tcgplayer: 263798
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Brilliant Stars/083.ts
+++ b/data/Sword & Shield/Brilliant Stars/083.ts
@@ -77,21 +77,27 @@ const card: Card = {
 	retreat: 4,
 	regulationMark: "F",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	description: {
 		en: "Artillery platforms built into the walls of ancient castles served as perches from which Golurk could fire energy beams.",
 	},
 
-	thirdParty: {
-		cardmarket: 608533,
-		tcgplayer: 263799
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 608533,
+				tcgplayer: 263799
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 608533,
+				tcgplayer: 263799
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Brilliant Stars/084.ts
+++ b/data/Sword & Shield/Brilliant Stars/084.ts
@@ -52,21 +52,27 @@ const card: Card = {
 	retreat: 3,
 	regulationMark: "F",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	description: {
 		en: "The wastewater coming from factories is clean these days, so Grimer have nothing to eat. They're said to be on the verge of extinction.",
 	},
 
-	thirdParty: {
-		cardmarket: 608534,
-		tcgplayer: 263800
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 608534,
+				tcgplayer: 263800
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 608534,
+				tcgplayer: 263800
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Brilliant Stars/085.ts
+++ b/data/Sword & Shield/Brilliant Stars/085.ts
@@ -86,21 +86,27 @@ const card: Card = {
 	retreat: 3,
 	regulationMark: "F",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	description: {
 		en: "Because they scatter germs everywhere, they've long been targeted for extermination, leading to a steep decline in their population.",
 	},
 
-	thirdParty: {
-		cardmarket: 608535,
-		tcgplayer: 263801
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 608535,
+				tcgplayer: 263801
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 608535,
+				tcgplayer: 263801
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Brilliant Stars/086.ts
+++ b/data/Sword & Shield/Brilliant Stars/086.ts
@@ -58,21 +58,27 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "F",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	description: {
 		en: "Its paws conceal sharp claws. If attacked, it suddenly extends the claws and startles its enemy.",
 	},
 
-	thirdParty: {
-		cardmarket: 608536,
-		tcgplayer: 263802
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 608536,
+				tcgplayer: 263802
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 608536,
+				tcgplayer: 263802
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Brilliant Stars/087.ts
+++ b/data/Sword & Shield/Brilliant Stars/087.ts
@@ -75,21 +75,27 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "F",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	description: {
 		en: "They attack their quarry in packs. Prey as large as Mamoswine easily fall to the teamwork of a group of Weavile.",
 	},
 
-	thirdParty: {
-		cardmarket: 608537,
-		tcgplayer: 263803
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 608537,
+				tcgplayer: 263803
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 608537,
+				tcgplayer: 263803
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Brilliant Stars/088.ts
+++ b/data/Sword & Shield/Brilliant Stars/088.ts
@@ -83,17 +83,16 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "F",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 608538,
-		tcgplayer: 263804
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 608538,
+				tcgplayer: 263804
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Brilliant Stars/089.ts
+++ b/data/Sword & Shield/Brilliant Stars/089.ts
@@ -72,21 +72,27 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "F",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	description: {
 		en: "Exactly 108 spirits gathered to become this Pokémon. Apparently there are some ill-natured spirits in the mix.",
 	},
 
-	thirdParty: {
-		cardmarket: 608539,
-		tcgplayer: 263806
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 608539,
+				tcgplayer: 263806
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 608539,
+				tcgplayer: 263806
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Brilliant Stars/090.ts
+++ b/data/Sword & Shield/Brilliant Stars/090.ts
@@ -54,21 +54,27 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "F",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	description: {
 		en: "It steals things from people just to amuse itself with their frustration. A rivalry exists between this Pokémon and Nickit.",
 	},
 
-	thirdParty: {
-		cardmarket: 608540,
-		tcgplayer: 263807
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 608540,
+				tcgplayer: 263807
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 608540,
+				tcgplayer: 263807
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Brilliant Stars/091.ts
+++ b/data/Sword & Shield/Brilliant Stars/091.ts
@@ -77,21 +77,27 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "F",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	description: {
 		en: "Don't be fooled by its gorgeous fur and elegant figure. This is a moody and vicious Pokémon.",
 	},
 
-	thirdParty: {
-		cardmarket: 608637,
-		tcgplayer: 263809
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 608637,
+				tcgplayer: 263809
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 608637,
+				tcgplayer: 263809
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Brilliant Stars/092.ts
+++ b/data/Sword & Shield/Brilliant Stars/092.ts
@@ -65,21 +65,27 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "F",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	description: {
 		en: "Through its nose, it sucks in the emanations produced by people and Pokémon when they feel annoyed. It thrives off this negative energy.",
 	},
 
-	thirdParty: {
-		cardmarket: 608638,
-		tcgplayer: 263810
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 608638,
+				tcgplayer: 263810
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 608638,
+				tcgplayer: 263810
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Brilliant Stars/093.ts
+++ b/data/Sword & Shield/Brilliant Stars/093.ts
@@ -68,21 +68,27 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "F",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	description: {
 		en: "When it gets down on all fours as if to beg for forgiveness, it's trying to lure opponents in so that it can stab them with its spear-like hair.",
 	},
 
-	thirdParty: {
-		cardmarket: 608639,
-		tcgplayer: 263811
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 608639,
+				tcgplayer: 263811
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 608639,
+				tcgplayer: 263811
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Brilliant Stars/094.ts
+++ b/data/Sword & Shield/Brilliant Stars/094.ts
@@ -75,21 +75,27 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "F",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	description: {
 		en: "With the hair wrapped around its body helping to enhance its muscles, this Pokémon can overwhelm even Machamp.",
 	},
 
-	thirdParty: {
-		cardmarket: 608640,
-		tcgplayer: 263812
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 608640,
+				tcgplayer: 263812
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 608640,
+				tcgplayer: 263812
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Brilliant Stars/095.ts
+++ b/data/Sword & Shield/Brilliant Stars/095.ts
@@ -77,17 +77,16 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "F",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 608641,
-		tcgplayer: 263813
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 608641,
+				tcgplayer: 263813
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Brilliant Stars/096.ts
+++ b/data/Sword & Shield/Brilliant Stars/096.ts
@@ -83,17 +83,16 @@ const card: Card = {
 	retreat: 4,
 	regulationMark: "F",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 608642,
-		tcgplayer: 263814
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 608642,
+				tcgplayer: 263814
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Brilliant Stars/097.ts
+++ b/data/Sword & Shield/Brilliant Stars/097.ts
@@ -92,17 +92,16 @@ const card: Card = {
 	retreat: 4,
 	regulationMark: "F",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 608643,
-		tcgplayer: 263815
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 608643,
+				tcgplayer: 263815
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Brilliant Stars/098.ts
+++ b/data/Sword & Shield/Brilliant Stars/098.ts
@@ -83,21 +83,27 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "F",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	description: {
 		en: "When Burmy evolved, its cloak became a part of this Pokémon's body. The cloak is never shed.",
 	},
 
-	thirdParty: {
-		cardmarket: 608434,
-		tcgplayer: 263817
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 608644,
+				tcgplayer: 263817
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 608644,
+				tcgplayer: 263817
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Brilliant Stars/099.ts
+++ b/data/Sword & Shield/Brilliant Stars/099.ts
@@ -90,21 +90,27 @@ const card: Card = {
 	retreat: 4,
 	regulationMark: "F",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	description: {
 		en: "It uses three small units to catch prey and battle enemies. The main body mostly just gives orders.",
 	},
 
-	thirdParty: {
-		cardmarket: 608645,
-		tcgplayer: 263818
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 608645,
+				tcgplayer: 263818
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 608645,
+				tcgplayer: 263818
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Brilliant Stars/100.ts
+++ b/data/Sword & Shield/Brilliant Stars/100.ts
@@ -82,21 +82,27 @@ const card: Card = {
 	retreat: 4,
 	regulationMark: "F",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	description: {
 		en: "Boiling blood, like magma, circulates through its body. It makes its dwelling place in volcanic caves.",
 	},
 
-	thirdParty: {
-		cardmarket: 608646,
-		tcgplayer: 263819
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 608646,
+				tcgplayer: 263819
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 608646,
+				tcgplayer: 263819
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Brilliant Stars/101.ts
+++ b/data/Sword & Shield/Brilliant Stars/101.ts
@@ -92,21 +92,27 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "F",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	description: {
 		en: "They use shells they've stolen from Shelmet to arm and protect themselves. They're very popular Pokémon in the Galar region.",
 	},
 
-	thirdParty: {
-		cardmarket: 608647,
-		tcgplayer: 263820
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 608647,
+				tcgplayer: 263820
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 608647,
+				tcgplayer: 263820
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Brilliant Stars/102.ts
+++ b/data/Sword & Shield/Brilliant Stars/102.ts
@@ -64,21 +64,27 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "F",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	description: {
 		en: "The two minigears that compose this Pokémon are closer than twins. They mesh well only with each other.",
 	},
 
-	thirdParty: {
-		cardmarket: 608648,
-		tcgplayer: 263822
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 608648,
+				tcgplayer: 263822
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 608648,
+				tcgplayer: 263822
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Brilliant Stars/103.ts
+++ b/data/Sword & Shield/Brilliant Stars/103.ts
@@ -83,21 +83,27 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "F",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	description: {
 		en: "When Klang goes all out, the minigear links up perfectly with the outer part of the big gear, and this Pokémon's rotation speed increases sharply.",
 	},
 
-	thirdParty: {
-		cardmarket: 608649,
-		tcgplayer: 263823
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 608649,
+				tcgplayer: 263823
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 608649,
+				tcgplayer: 263823
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Brilliant Stars/104.ts
+++ b/data/Sword & Shield/Brilliant Stars/104.ts
@@ -92,21 +92,27 @@ const card: Card = {
 	retreat: 3,
 	regulationMark: "F",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	description: {
 		en: "From its spikes, it launches powerful blasts of electricity. Its red core contains an enormous amount of energy.",
 	},
 
-	thirdParty: {
-		cardmarket: 608650,
-		tcgplayer: 263824
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 608650,
+				tcgplayer: 263824
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 608650,
+				tcgplayer: 263824
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Brilliant Stars/105.ts
+++ b/data/Sword & Shield/Brilliant Stars/105.ts
@@ -83,17 +83,16 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "F",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 608651,
-		tcgplayer: 263825
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 608651,
+				tcgplayer: 263825
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Brilliant Stars/106.ts
+++ b/data/Sword & Shield/Brilliant Stars/106.ts
@@ -62,17 +62,16 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "F",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 608652,
-		tcgplayer: 263826
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 608652,
+				tcgplayer: 263826
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Brilliant Stars/107.ts
+++ b/data/Sword & Shield/Brilliant Stars/107.ts
@@ -39,21 +39,27 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "F",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	description: {
 		en: "Gible prefers to stay in narrow holes in the sides of caves heated by geothermal energy. This way, Gible can stay warm even during a blizzard.",
 	},
 
-	thirdParty: {
-		cardmarket: 608653,
-		tcgplayer: 263827
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 608653,
+				tcgplayer: 263827
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 608653,
+				tcgplayer: 263827
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Brilliant Stars/108.ts
+++ b/data/Sword & Shield/Brilliant Stars/108.ts
@@ -49,21 +49,27 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "F",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	description: {
 		en: "This Pokémon emits ultrasonic waves from a protrusion on either side of its head to probe pitch-dark caves.",
 	},
 
-	thirdParty: {
-		cardmarket: 608654,
-		tcgplayer: 263828
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 608654,
+				tcgplayer: 263828
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 608654,
+				tcgplayer: 263828
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Brilliant Stars/109.ts
+++ b/data/Sword & Shield/Brilliant Stars/109.ts
@@ -80,21 +80,27 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "F",
 
-	variants: {
-		normal: false,
-		reverse: true,
-		holo: true,
-		firstEdition: false
-	},
 
 	description: {
 		en: "Garchomp makes its home in volcanic mountains. It flies through the sky as fast as a jet airplane, hunting down as much prey as it can.",
 	},
 
-	thirdParty: {
-		cardmarket: 608655,
-		tcgplayer: 263829
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 608655,
+				tcgplayer: 263829
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 608655,
+				tcgplayer: 263829
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Brilliant Stars/110.ts
+++ b/data/Sword & Shield/Brilliant Stars/110.ts
@@ -46,21 +46,27 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "F",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	description: {
 		en: "These Pokémon nest in the ground and use their tusks to crush hard berries. Crushing berries is also how they test each other's strength.",
 	},
 
-	thirdParty: {
-		cardmarket: 608656,
-		tcgplayer: 263830
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 608656,
+				tcgplayer: 263830
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 608656,
+				tcgplayer: 263830
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Brilliant Stars/111.ts
+++ b/data/Sword & Shield/Brilliant Stars/111.ts
@@ -62,21 +62,27 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "F",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	description: {
 		en: "After battle, this Pokémon carefully sharpens its tusks on river rocks. It needs to take care of its tusks—if one breaks, it will never grow back.",
 	},
 
-	thirdParty: {
-		cardmarket: 608657,
-		tcgplayer: 263832
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 608657,
+				tcgplayer: 263832
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 608657,
+				tcgplayer: 263832
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Brilliant Stars/112.ts
+++ b/data/Sword & Shield/Brilliant Stars/112.ts
@@ -71,21 +71,27 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "F",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	description: {
 		en: "Its resilient tusks are its pride and joy. It licks up dirt to take in the minerals it needs to keep its tusks in top condition.",
 	},
 
-	thirdParty: {
-		cardmarket: 608658,
-		tcgplayer: 263833
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 608658,
+				tcgplayer: 263833
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 608658,
+				tcgplayer: 263833
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Brilliant Stars/113.ts
+++ b/data/Sword & Shield/Brilliant Stars/113.ts
@@ -61,21 +61,27 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "E",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	description: {
 		en: "Druddigon are vicious and cunning. They take up residence in nests dug out by other Pokémon, treating the stolen nests as their own lairs.",
 	},
 
-	thirdParty: {
-		cardmarket: 608659,
-		tcgplayer: 263834
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 608659,
+				tcgplayer: 263834
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 608659,
+				tcgplayer: 263834
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Brilliant Stars/114.ts
+++ b/data/Sword & Shield/Brilliant Stars/114.ts
@@ -71,17 +71,16 @@ const card: Card = {
 	retreat: 3,
 	regulationMark: "E",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 608660,
-		tcgplayer: 263836
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 608660,
+				tcgplayer: 263836
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Brilliant Stars/115.ts
+++ b/data/Sword & Shield/Brilliant Stars/115.ts
@@ -60,21 +60,27 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "F",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	description: {
 		en: "The stalk this Pokémon carries in its wings serves as a sword to cut down opponents. In a dire situation, the stalk can also serve as food.",
 	},
 
-	thirdParty: {
-		cardmarket: 608661,
-		tcgplayer: 263838
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 608661,
+				tcgplayer: 263838
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 608661,
+				tcgplayer: 263838
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Brilliant Stars/116.ts
+++ b/data/Sword & Shield/Brilliant Stars/116.ts
@@ -74,21 +74,27 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "F",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	description: {
 		en: "Its form changes depending on the weather. The rougher conditions get, the rougher Castform's disposition!",
 	},
 
-	thirdParty: {
-		cardmarket: 608662,
-		tcgplayer: 263839
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 608662,
+				tcgplayer: 263839
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 608662,
+				tcgplayer: 263839
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Brilliant Stars/117.ts
+++ b/data/Sword & Shield/Brilliant Stars/117.ts
@@ -60,21 +60,27 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "F",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	description: {
 		en: "They flock around mountains and fields, chasing after bug Pokémon. Their singing is noisy and annoying.",
 	},
 
-	thirdParty: {
-		cardmarket: 608663,
-		tcgplayer: 263842
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 608663,
+				tcgplayer: 263842
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 608663,
+				tcgplayer: 263842
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Brilliant Stars/118.ts
+++ b/data/Sword & Shield/Brilliant Stars/118.ts
@@ -61,21 +61,27 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "F",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	description: {
 		en: "It lives in forests and fields. Squabbles over territory occur when flocks collide.",
 	},
 
-	thirdParty: {
-		cardmarket: 608664,
-		tcgplayer: 263843
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 608664,
+				tcgplayer: 263843
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 608664,
+				tcgplayer: 263843
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Brilliant Stars/119.ts
+++ b/data/Sword & Shield/Brilliant Stars/119.ts
@@ -90,21 +90,27 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "F",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	description: {
 		en: "When Staravia evolve into Staraptor, they leave the flock to live alone. They have sturdy wings.",
 	},
 
-	thirdParty: {
-		cardmarket: 608665,
-		tcgplayer: 263844
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 608665,
+				tcgplayer: 263844
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 608665,
+				tcgplayer: 263844
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Brilliant Stars/120.ts
+++ b/data/Sword & Shield/Brilliant Stars/120.ts
@@ -45,21 +45,27 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "F",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	description: {
 		en: "It constantly gnaws on logs and rocks to whittle down its front teeth. It nests alongside water.",
 	},
 
-	thirdParty: {
-		cardmarket: 608666,
-		tcgplayer: 263845
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 608666,
+				tcgplayer: 263845
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 608666,
+				tcgplayer: 263845
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Brilliant Stars/121.ts
+++ b/data/Sword & Shield/Brilliant Stars/121.ts
@@ -86,21 +86,27 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "F",
 
-	variants: {
-		normal: false,
-		reverse: true,
-		holo: true,
-		firstEdition: false
-	},
 
 	description: {
 		en: "It makes its nest by damming streams with bark and mud. It is known as an industrious worker.",
 	},
 
-	thirdParty: {
-		cardmarket: 608667,
-		tcgplayer: 263846
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 608667,
+				tcgplayer: 263846
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 608667,
+				tcgplayer: 263846
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Brilliant Stars/122.ts
+++ b/data/Sword & Shield/Brilliant Stars/122.ts
@@ -66,17 +66,16 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "F",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 608668,
-		tcgplayer: 257275
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 608668,
+				tcgplayer: 257275
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Brilliant Stars/123.ts
+++ b/data/Sword & Shield/Brilliant Stars/123.ts
@@ -65,17 +65,23 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "F",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 608669,
-		tcgplayer: 257279
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 608669,
+				tcgplayer: 257279
+			}
+		},
+		{
+			type: 'holo',
+			size: 'jumbo',
+			thirdParty: {
+				cardmarket: 671808
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Brilliant Stars/124.ts
+++ b/data/Sword & Shield/Brilliant Stars/124.ts
@@ -65,21 +65,27 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "F",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	description: {
 		en: "The way it brushes away grime with its tail can be helpful when cleaning. But its focus on spotlessness can make cleaning more of a hassle.",
 	},
 
-	thirdParty: {
-		cardmarket: 608670,
-		tcgplayer: 263847
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 608670,
+				tcgplayer: 263847
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 608670,
+				tcgplayer: 263847
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Brilliant Stars/125.ts
+++ b/data/Sword & Shield/Brilliant Stars/125.ts
@@ -77,21 +77,27 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "F",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	description: {
 		en: "Its body secretes oil that this Pokémon spreads over its nest as a coating to protect it from dust. Cinccino won't tolerate even a speck of the stuff.",
 	},
 
-	thirdParty: {
-		cardmarket: 608671,
-		tcgplayer: 263848
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 608671,
+				tcgplayer: 263848
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 608671,
+				tcgplayer: 263848
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Brilliant Stars/126.ts
+++ b/data/Sword & Shield/Brilliant Stars/126.ts
@@ -73,21 +73,27 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "F",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	description: {
 		en: "Tornadus expels massive energy from its tail, causing severe storms. Its power is great enough to blow houses away.",
 	},
 
-	thirdParty: {
-		cardmarket: 608672,
-		tcgplayer: 263849
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 608672,
+				tcgplayer: 263849
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 608672,
+				tcgplayer: 263849
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Brilliant Stars/127.ts
+++ b/data/Sword & Shield/Brilliant Stars/127.ts
@@ -80,21 +80,27 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "F",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	description: {
 		en: "It drives its opponents to exhaustion with its agile maneuvers, then ends the fight with a flashy finishing move.",
 	},
 
-	thirdParty: {
-		cardmarket: 608673,
-		tcgplayer: 263850
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 608673,
+				tcgplayer: 263850
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 608673,
+				tcgplayer: 263850
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Brilliant Stars/128.ts
+++ b/data/Sword & Shield/Brilliant Stars/128.ts
@@ -77,17 +77,16 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "F",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 608674,
-		tcgplayer: 263851
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 608674,
+				tcgplayer: 263851
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Brilliant Stars/129.ts
+++ b/data/Sword & Shield/Brilliant Stars/129.ts
@@ -29,17 +29,23 @@ const card: Card = {
 	trainerType: "Supporter",
 	regulationMark: "E",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 608675,
-		tcgplayer: 263852
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 608675,
+				tcgplayer: 263852
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 608675,
+				tcgplayer: 263852
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Brilliant Stars/130.ts
+++ b/data/Sword & Shield/Brilliant Stars/130.ts
@@ -29,17 +29,23 @@ const card: Card = {
 	trainerType: "Supporter",
 	regulationMark: "F",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 608676,
-		tcgplayer: 263853
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 608676,
+				tcgplayer: 263853
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 608676,
+				tcgplayer: 263853
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Brilliant Stars/131.ts
+++ b/data/Sword & Shield/Brilliant Stars/131.ts
@@ -29,17 +29,23 @@ const card: Card = {
 	trainerType: "Tool",
 	regulationMark: "E",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 608677,
-		tcgplayer: 263854
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 608677,
+				tcgplayer: 263854
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 608677,
+				tcgplayer: 263854
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Brilliant Stars/132.ts
+++ b/data/Sword & Shield/Brilliant Stars/132.ts
@@ -29,17 +29,37 @@ const card: Card = {
 	trainerType: "Supporter",
 	regulationMark: "D",
 
-	variants: {
-		normal: false,
-		reverse: true,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 608678,
-		tcgplayer: 263855
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 608678,
+				tcgplayer: 263855
+			}
+		},
+		{
+			type: 'holo',
+			stamp: ['regional-championships'],
+			thirdParty: {
+				cardmarket: 660946
+			}
+		},
+		{
+			type: 'holo',
+			foil: 'cosmos',
+			thirdParty: {
+				cardmarket: 716227
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 608678,
+				tcgplayer: 263855
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Brilliant Stars/133.ts
+++ b/data/Sword & Shield/Brilliant Stars/133.ts
@@ -29,16 +29,23 @@ const card: Card = {
 	trainerType: "Supporter",
 	regulationMark: "E",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 608679
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 608679,
+				tcgplayer: 263856
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 608679,
+				tcgplayer: 263856
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Brilliant Stars/134.ts
+++ b/data/Sword & Shield/Brilliant Stars/134.ts
@@ -29,17 +29,23 @@ const card: Card = {
 	trainerType: "Supporter",
 	regulationMark: "F",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 608680,
-		tcgplayer: 257306
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 608680,
+				tcgplayer: 257306
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 608680,
+				tcgplayer: 257306
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Brilliant Stars/135.ts
+++ b/data/Sword & Shield/Brilliant Stars/135.ts
@@ -29,17 +29,23 @@ const card: Card = {
 	trainerType: "Tool",
 	regulationMark: "F",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 608681,
-		tcgplayer: 263857
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 608681,
+				tcgplayer: 263857
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 608681,
+				tcgplayer: 263857
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Brilliant Stars/136.ts
+++ b/data/Sword & Shield/Brilliant Stars/136.ts
@@ -29,17 +29,23 @@ const card: Card = {
 	trainerType: "Tool",
 	regulationMark: "E",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 608682,
-		tcgplayer: 263858
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 608682,
+				tcgplayer: 263858
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 608682,
+				tcgplayer: 263858
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Brilliant Stars/137.ts
+++ b/data/Sword & Shield/Brilliant Stars/137.ts
@@ -29,17 +29,23 @@ const card: Card = {
 	trainerType: "Stadium",
 	regulationMark: "F",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 608683,
-		tcgplayer: 263859
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 608683,
+				tcgplayer: 263859
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 608683,
+				tcgplayer: 263859
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Brilliant Stars/138.ts
+++ b/data/Sword & Shield/Brilliant Stars/138.ts
@@ -29,17 +29,23 @@ const card: Card = {
 	trainerType: "Supporter",
 	regulationMark: "F",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 608684,
-		tcgplayer: 263860
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 608684,
+				tcgplayer: 263860
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 608684,
+				tcgplayer: 263860
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Brilliant Stars/139.ts
+++ b/data/Sword & Shield/Brilliant Stars/139.ts
@@ -28,17 +28,23 @@ const card: Card = {
 
 	trainerType: "Item",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 608685,
-		tcgplayer: 263861
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 608685,
+				tcgplayer: 263861
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 608685,
+				tcgplayer: 263861
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Brilliant Stars/140.ts
+++ b/data/Sword & Shield/Brilliant Stars/140.ts
@@ -29,17 +29,23 @@ const card: Card = {
 	trainerType: "Supporter",
 	regulationMark: "E",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 608686,
-		tcgplayer: 263862
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 608686,
+				tcgplayer: 263862
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 608686,
+				tcgplayer: 263862
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Brilliant Stars/141.ts
+++ b/data/Sword & Shield/Brilliant Stars/141.ts
@@ -29,17 +29,23 @@ const card: Card = {
 	trainerType: "Supporter",
 	regulationMark: "E",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 608687,
-		tcgplayer: 263863
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 608687,
+				tcgplayer: 263863
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 608687,
+				tcgplayer: 263863
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Brilliant Stars/142.ts
+++ b/data/Sword & Shield/Brilliant Stars/142.ts
@@ -29,17 +29,23 @@ const card: Card = {
 	trainerType: "Tool",
 	regulationMark: "E",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 608688,
-		tcgplayer: 263864
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 608688,
+				tcgplayer: 263864
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 608688,
+				tcgplayer: 263864
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Brilliant Stars/143.ts
+++ b/data/Sword & Shield/Brilliant Stars/143.ts
@@ -29,17 +29,23 @@ const card: Card = {
 	trainerType: "Supporter",
 	regulationMark: "F",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 608689,
-		tcgplayer: 257309
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 608689,
+				tcgplayer: 257309
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 608689,
+				tcgplayer: 257309
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Brilliant Stars/144.ts
+++ b/data/Sword & Shield/Brilliant Stars/144.ts
@@ -29,17 +29,23 @@ const card: Card = {
 	trainerType: "Stadium",
 	regulationMark: "F",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 608690,
-		tcgplayer: 257310
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 608690,
+				tcgplayer: 257310
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 608690,
+				tcgplayer: 257310
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Brilliant Stars/145.ts
+++ b/data/Sword & Shield/Brilliant Stars/145.ts
@@ -29,17 +29,23 @@ const card: Card = {
 	trainerType: "Supporter",
 	regulationMark: "F",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 608691,
-		tcgplayer: 263865
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 608691,
+				tcgplayer: 263865
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 608691,
+				tcgplayer: 263865
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Brilliant Stars/146.ts
+++ b/data/Sword & Shield/Brilliant Stars/146.ts
@@ -29,17 +29,23 @@ const card: Card = {
 	trainerType: "Tool",
 	regulationMark: "F",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 608692,
-		tcgplayer: 263866
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 608692,
+				tcgplayer: 263866
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 608692,
+				tcgplayer: 263866
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Brilliant Stars/147.ts
+++ b/data/Sword & Shield/Brilliant Stars/147.ts
@@ -29,17 +29,23 @@ const card: Card = {
 	trainerType: "Supporter",
 	regulationMark: "D",
 
-	variants: {
-		normal: false,
-		reverse: true,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 608693,
-		tcgplayer: 263867
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 608693,
+				tcgplayer: 263867
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 608693,
+				tcgplayer: 263867
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Brilliant Stars/148.ts
+++ b/data/Sword & Shield/Brilliant Stars/148.ts
@@ -29,17 +29,23 @@ const card: Card = {
 	trainerType: "Supporter",
 	regulationMark: "F",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 608694,
-		tcgplayer: 263868
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 608694,
+				tcgplayer: 263868
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 608694,
+				tcgplayer: 263868
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Brilliant Stars/149.ts
+++ b/data/Sword & Shield/Brilliant Stars/149.ts
@@ -29,17 +29,23 @@ const card: Card = {
 	trainerType: "Supporter",
 	regulationMark: "F",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 608695,
-		tcgplayer: 263869
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 608695,
+				tcgplayer: 263869
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 608695,
+				tcgplayer: 263869
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Brilliant Stars/150.ts
+++ b/data/Sword & Shield/Brilliant Stars/150.ts
@@ -28,17 +28,23 @@ const card: Card = {
 
 	trainerType: "Item",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 608696,
-		tcgplayer: 263870
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 608696,
+				tcgplayer: 263870
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 608696,
+				tcgplayer: 263870
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Brilliant Stars/151.ts
+++ b/data/Sword & Shield/Brilliant Stars/151.ts
@@ -28,17 +28,23 @@ const card: Card = {
 	energyType: "Special",
 	regulationMark: "F",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 608697,
-		tcgplayer: 257307
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 608697,
+				tcgplayer: 257307
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 608697,
+				tcgplayer: 257307
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Brilliant Stars/152.ts
+++ b/data/Sword & Shield/Brilliant Stars/152.ts
@@ -68,17 +68,16 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "F",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 608698,
-		tcgplayer: 263871
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 608698,
+				tcgplayer: 263871
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Brilliant Stars/153.ts
+++ b/data/Sword & Shield/Brilliant Stars/153.ts
@@ -68,17 +68,16 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "F",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 608699,
-		tcgplayer: 263872
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 608699,
+				tcgplayer: 263872
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Brilliant Stars/154.ts
+++ b/data/Sword & Shield/Brilliant Stars/154.ts
@@ -68,17 +68,16 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "F",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 608700,
-		tcgplayer: 263873
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 608700,
+				tcgplayer: 263873
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Brilliant Stars/155.ts
+++ b/data/Sword & Shield/Brilliant Stars/155.ts
@@ -77,17 +77,16 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "F",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 608701,
-		tcgplayer: 263874
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 608701,
+				tcgplayer: 263874
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Brilliant Stars/156.ts
+++ b/data/Sword & Shield/Brilliant Stars/156.ts
@@ -77,17 +77,16 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "F",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 608702,
-		tcgplayer: 263875
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 608702,
+				tcgplayer: 263875
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Brilliant Stars/157.ts
+++ b/data/Sword & Shield/Brilliant Stars/157.ts
@@ -55,17 +55,16 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "F",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 608703,
-		tcgplayer: 263876
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 608703,
+				tcgplayer: 263876
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Brilliant Stars/158.ts
+++ b/data/Sword & Shield/Brilliant Stars/158.ts
@@ -75,17 +75,16 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "F",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 608704,
-		tcgplayer: 263877
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 608704,
+				tcgplayer: 263877
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Brilliant Stars/159.ts
+++ b/data/Sword & Shield/Brilliant Stars/159.ts
@@ -77,17 +77,16 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "F",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 608705,
-		tcgplayer: 263878
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 608705,
+				tcgplayer: 263878
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Brilliant Stars/160.ts
+++ b/data/Sword & Shield/Brilliant Stars/160.ts
@@ -77,17 +77,16 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "F",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 608706,
-		tcgplayer: 263879
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 608706,
+				tcgplayer: 263879
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Brilliant Stars/161.ts
+++ b/data/Sword & Shield/Brilliant Stars/161.ts
@@ -83,17 +83,16 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "F",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 608707,
-		tcgplayer: 263880
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 608707,
+				tcgplayer: 263880
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Brilliant Stars/162.ts
+++ b/data/Sword & Shield/Brilliant Stars/162.ts
@@ -83,17 +83,16 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "F",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 608708,
-		tcgplayer: 263881
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 608708,
+				tcgplayer: 263881
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Brilliant Stars/163.ts
+++ b/data/Sword & Shield/Brilliant Stars/163.ts
@@ -83,17 +83,16 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "F",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 608709,
-		tcgplayer: 263882
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 608709,
+				tcgplayer: 263882
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Brilliant Stars/164.ts
+++ b/data/Sword & Shield/Brilliant Stars/164.ts
@@ -62,17 +62,16 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "F",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 608710,
-		tcgplayer: 263883
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 608710,
+				tcgplayer: 263883
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Brilliant Stars/165.ts
+++ b/data/Sword & Shield/Brilliant Stars/165.ts
@@ -66,17 +66,16 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "F",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 608711,
-		tcgplayer: 263884
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 608711,
+				tcgplayer: 263884
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Brilliant Stars/166.ts
+++ b/data/Sword & Shield/Brilliant Stars/166.ts
@@ -66,17 +66,16 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "F",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 608712,
-		tcgplayer: 263885
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 608712,
+				tcgplayer: 263885
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Brilliant Stars/167.ts
+++ b/data/Sword & Shield/Brilliant Stars/167.ts
@@ -29,17 +29,16 @@ const card: Card = {
 	trainerType: "Supporter",
 	regulationMark: "F",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 608713,
-		tcgplayer: 263886
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 608713,
+				tcgplayer: 263886
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Brilliant Stars/168.ts
+++ b/data/Sword & Shield/Brilliant Stars/168.ts
@@ -29,17 +29,16 @@ const card: Card = {
 	trainerType: "Supporter",
 	regulationMark: "F",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 608714,
-		tcgplayer: 263887
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 608714,
+				tcgplayer: 263887
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Brilliant Stars/169.ts
+++ b/data/Sword & Shield/Brilliant Stars/169.ts
@@ -29,17 +29,16 @@ const card: Card = {
 	trainerType: "Supporter",
 	regulationMark: "F",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 608715,
-		tcgplayer: 263888
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 608715,
+				tcgplayer: 263888
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Brilliant Stars/170.ts
+++ b/data/Sword & Shield/Brilliant Stars/170.ts
@@ -29,17 +29,16 @@ const card: Card = {
 	trainerType: "Supporter",
 	regulationMark: "F",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 608716,
-		tcgplayer: 263889
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 608716,
+				tcgplayer: 263889
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Brilliant Stars/171.ts
+++ b/data/Sword & Shield/Brilliant Stars/171.ts
@@ -29,17 +29,16 @@ const card: Card = {
 	trainerType: "Supporter",
 	regulationMark: "F",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 608717,
-		tcgplayer: 263890
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 608717,
+				tcgplayer: 263890
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Brilliant Stars/172.ts
+++ b/data/Sword & Shield/Brilliant Stars/172.ts
@@ -29,17 +29,16 @@ const card: Card = {
 	trainerType: "Supporter",
 	regulationMark: "F",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 608718,
-		tcgplayer: 263891
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 608718,
+				tcgplayer: 263891
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Brilliant Stars/173.ts
+++ b/data/Sword & Shield/Brilliant Stars/173.ts
@@ -65,17 +65,17 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "F",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 608719,
-		tcgplayer: 263892
-	}
+	variants: [
+		{
+			type: 'holo',
+			foil: 'rainbow',
+			thirdParty: {
+				cardmarket: 608719,
+				tcgplayer: 263892
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Brilliant Stars/174.ts
+++ b/data/Sword & Shield/Brilliant Stars/174.ts
@@ -87,17 +87,17 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "F",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 608720,
-		tcgplayer: 263893
-	}
+	variants: [
+		{
+			type: 'holo',
+			foil: 'rainbow',
+			thirdParty: {
+				cardmarket: 608720,
+				tcgplayer: 263893
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Brilliant Stars/175.ts
+++ b/data/Sword & Shield/Brilliant Stars/175.ts
@@ -85,17 +85,17 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "F",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 608721,
-		tcgplayer: 263895
-	}
+	variants: [
+		{
+			type: 'holo',
+			foil: 'rainbow',
+			thirdParty: {
+				cardmarket: 608721,
+				tcgplayer: 263895
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Brilliant Stars/176.ts
+++ b/data/Sword & Shield/Brilliant Stars/176.ts
@@ -65,17 +65,17 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "F",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 608668,
-		tcgplayer: 263896
-	}
+	variants: [
+		{
+			type: 'holo',
+			foil: 'rainbow',
+			thirdParty: {
+				cardmarket: 608722,
+				tcgplayer: 263896
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Brilliant Stars/177.ts
+++ b/data/Sword & Shield/Brilliant Stars/177.ts
@@ -29,17 +29,17 @@ const card: Card = {
 	trainerType: "Supporter",
 	regulationMark: "F",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 608723,
-		tcgplayer: 263897
-	}
+	variants: [
+		{
+			type: 'holo',
+			foil: 'rainbow',
+			thirdParty: {
+				cardmarket: 608723,
+				tcgplayer: 263897
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Brilliant Stars/178.ts
+++ b/data/Sword & Shield/Brilliant Stars/178.ts
@@ -29,17 +29,17 @@ const card: Card = {
 	trainerType: "Supporter",
 	regulationMark: "F",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 608724,
-		tcgplayer: 263898
-	}
+	variants: [
+		{
+			type: 'holo',
+			foil: 'rainbow',
+			thirdParty: {
+				cardmarket: 608724,
+				tcgplayer: 263898
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Brilliant Stars/179.ts
+++ b/data/Sword & Shield/Brilliant Stars/179.ts
@@ -29,17 +29,17 @@ const card: Card = {
 	trainerType: "Supporter",
 	regulationMark: "F",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 608725,
-		tcgplayer: 263899
-	}
+	variants: [
+		{
+			type: 'holo',
+			foil: 'rainbow',
+			thirdParty: {
+				cardmarket: 608725,
+				tcgplayer: 263899
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Brilliant Stars/180.ts
+++ b/data/Sword & Shield/Brilliant Stars/180.ts
@@ -29,17 +29,17 @@ const card: Card = {
 	trainerType: "Supporter",
 	regulationMark: "F",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 608726,
-		tcgplayer: 263900
-	}
+	variants: [
+		{
+			type: 'holo',
+			foil: 'rainbow',
+			thirdParty: {
+				cardmarket: 608726,
+				tcgplayer: 263900
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Brilliant Stars/181.ts
+++ b/data/Sword & Shield/Brilliant Stars/181.ts
@@ -83,17 +83,17 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "E",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 608727,
-		tcgplayer: 263901
-	}
+	variants: [
+		{
+			type: 'holo',
+			foil: 'gold',
+			thirdParty: {
+				cardmarket: 608727,
+				tcgplayer: 263901
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Brilliant Stars/182.ts
+++ b/data/Sword & Shield/Brilliant Stars/182.ts
@@ -77,17 +77,17 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "E",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 608728,
-		tcgplayer: 263902
-	}
+	variants: [
+		{
+			type: 'holo',
+			foil: 'gold',
+			thirdParty: {
+				cardmarket: 608728,
+				tcgplayer: 263902
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Brilliant Stars/183.ts
+++ b/data/Sword & Shield/Brilliant Stars/183.ts
@@ -77,17 +77,17 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "E",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 608729,
-		tcgplayer: 263903
-	}
+	variants: [
+		{
+			type: 'holo',
+			foil: 'gold',
+			thirdParty: {
+				cardmarket: 608729,
+				tcgplayer: 263903
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Brilliant Stars/184.ts
+++ b/data/Sword & Shield/Brilliant Stars/184.ts
@@ -65,17 +65,17 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "F",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 608668,
-		tcgplayer: 263904
-	}
+	variants: [
+		{
+			type: 'holo',
+			foil: 'gold',
+			thirdParty: {
+				cardmarket: 608730,
+				tcgplayer: 263904
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Brilliant Stars/185.ts
+++ b/data/Sword & Shield/Brilliant Stars/185.ts
@@ -29,17 +29,17 @@ const card: Card = {
 	trainerType: "Stadium",
 	regulationMark: "F",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 608731,
-		tcgplayer: 263906
-	}
+	variants: [
+		{
+			type: 'holo',
+			foil: 'gold',
+			thirdParty: {
+				cardmarket: 608731,
+				tcgplayer: 263906
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Brilliant Stars/186.ts
+++ b/data/Sword & Shield/Brilliant Stars/186.ts
@@ -28,17 +28,17 @@ const card: Card = {
 
 	trainerType: "Item",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 608732,
-		tcgplayer: 263907
-	}
+	variants: [
+		{
+			type: 'holo',
+			foil: 'gold',
+			thirdParty: {
+				cardmarket: 608732,
+				tcgplayer: 263907
+			}
+		},
+	],
 }
 
 export default card


### PR DESCRIPTION
## Changes
- Moved TG cards into it's own dedicated set.
- Updated all pricing ids for all cards (standard and TG)
- Added several variants
- Added set parent file for Brilliant Stars Trainer Gallery


