### PR TITLE
fix: change dark raichu and clefable variants

### DIFF
--- a/data/Base/Jungle/17.ts
+++ b/data/Base/Jungle/17.ts
@@ -94,10 +94,10 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "holo",
+			type: "normal",
 		},
 		{
-			type: "holo",
+			type: "normal",
 			stamp: ["1st-edition"]
 		}
 	],

--- a/data/Base/Team Rocket/83.ts
+++ b/data/Base/Team Rocket/83.ts
@@ -73,10 +73,10 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "normal",
+			type: "holo",
 		},
 		{
-			type: "normal",
+			type: "holo",
 			stamp: ["1st-edition"]
 		}
 	]


### PR DESCRIPTION
<!--
Contribution guide: https://github.com/tcgdex/cards-database/blob/master/CONTRIBUTING.md
please submit changes up to 1 set at most.
-->

closes # <!-- Indicate the issue number here -->

## Changes

<!-- Quickly explain your changes -->

## Details

Clefable base2-17 -> remove holo and holo with stamp "1st-edition"; add normal and normal with stamp "1st-edition";

Dark Raichu base5-83 -> remove normal and normal with stamp "1st-edition"; add holo and holo with stamp "1st-edition";

