### PR TITLE
(data): basep Missing TCGPlayer IDs for wotc promo base 

### DIFF
--- a/data/Base/Wizards Black Star Promos/1.ts
+++ b/data/Base/Wizards Black Star Promos/1.ts
@@ -77,7 +77,10 @@ const card: Card = {
 		},
 		{
 			type: "normal",
-			stamp: ["pikachu-tail"]
+			stamp: ["pikachu-tail"],
+			thirdParty: {
+				tcgplayer: 161750
+			},
 		},
 		{
 			type: "normal",

--- a/data/Base/Wizards Black Star Promos/1.ts
+++ b/data/Base/Wizards Black Star Promos/1.ts
@@ -60,6 +60,11 @@ const card: Card = {
 	description: {
 		en: "When several of these Pokémon gather, their electricity could build and cause lightning storms.",
 	},
+
+	thirdParty: {
+		tcgplayer: 121772
+	},
+	
 	variants: [
 		{
 			type: "normal",

--- a/data/Base/Wizards Black Star Promos/1.ts
+++ b/data/Base/Wizards Black Star Promos/1.ts
@@ -61,22 +61,31 @@ const card: Card = {
 		en: "When several of these Pokémon gather, their electricity could build and cause lightning storms.",
 	},
 
-	thirdParty: {
-		tcgplayer: 121772
-	},
-	
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 121772
+			},
 		},
 		{
 			type: "normal",
-			stamp: ["1st-edition-error"]
+			stamp: ["1st-edition-error"],
+			thirdParty: {
+				tcgplayer: 88065
+			},
 		},
 		{
 			type: "normal",
 			stamp: ["pikachu-tail"]
-		}
+		},
+		{
+			type: "normal",
+			stamp: ["grey-star"],
+			thirdParty: {
+				tcgplayer: 696103
+			},
+		},
 	]
 }
 

--- a/data/Base/Wizards Black Star Promos/10.ts
+++ b/data/Base/Wizards Black Star Promos/10.ts
@@ -56,13 +56,12 @@ const card: Card = {
 		en: "Adores circular objects. Wanders the streets on a nightly basis to look for dropped loose change.",
 	},
 
-	thirdParty: {
-		tcgplayer: 87309
-	},
-
 	variants: [
 		{
 			type: "holo",
+			thirdParty: {
+				tcgplayer: 87309
+			},
 		},
 	]
 }

--- a/data/Base/Wizards Black Star Promos/10.ts
+++ b/data/Base/Wizards Black Star Promos/10.ts
@@ -55,6 +55,11 @@ const card: Card = {
 	description: {
 		en: "Adores circular objects. Wanders the streets on a nightly basis to look for dropped loose change.",
 	},
+
+	thirdParty: {
+		tcgplayer: 87309
+	},
+
 	variants: [
 		{
 			type: "holo",

--- a/data/Base/Wizards Black Star Promos/11.ts
+++ b/data/Base/Wizards Black Star Promos/11.ts
@@ -61,17 +61,20 @@ const card: Card = {
 		en: "Its genetic code is irregular. It may mutate if it is exposed to radiation from elemental stones.",
 	},
 
-	thirdParty: {
-		tcgplayer: 85074
-	},
-
 	variants: [
 		{
 			type: "holo",
-			foil: "cosmos"
+			foil: "cosmos",
+			thirdParty: {
+				tcgplayer: 85074
+			},
 		},
 		{
 			type: "normal",
+			stamp: ["jr-stamp-rally"],
+			thirdParty: {
+				tcgplayer: 618732
+			},
 		}
 	]
 }

--- a/data/Base/Wizards Black Star Promos/11.ts
+++ b/data/Base/Wizards Black Star Promos/11.ts
@@ -60,13 +60,18 @@ const card: Card = {
 	description: {
 		en: "Its genetic code is irregular. It may mutate if it is exposed to radiation from elemental stones.",
 	},
+
+	thirdParty: {
+		tcgplayer: 85074
+	},
+
 	variants: [
 		{
 			type: "holo",
 			foil: "cosmos"
 		},
 		{
-			type: "normal"
+			type: "normal",
 		}
 	]
 }

--- a/data/Base/Wizards Black Star Promos/12.ts
+++ b/data/Base/Wizards Black Star Promos/12.ts
@@ -63,13 +63,12 @@ const card: Card = {
 		en: "A scientist created this Pokémon after years of horrific gene-splicing and DNA engineering experiments.",
 	},
 
-	thirdParty: {
-		tcgplayer: 87416
-	},
-  
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 87416
+			},
 		}
 	]
 }

--- a/data/Base/Wizards Black Star Promos/12.ts
+++ b/data/Base/Wizards Black Star Promos/12.ts
@@ -62,6 +62,11 @@ const card: Card = {
 	description: {
 		en: "A scientist created this Pokémon after years of horrific gene-splicing and DNA engineering experiments.",
 	},
+
+	thirdParty: {
+		tcgplayer: 87416
+	},
+  
 	variants: [
 		{
 			type: "normal"

--- a/data/Base/Wizards Black Star Promos/13.ts
+++ b/data/Base/Wizards Black Star Promos/13.ts
@@ -63,6 +63,11 @@ const card: Card = {
 	description: {
 		en: "This plant blooms when it is absorbing solar energy. It stays on the move to seek sunlight.",
 	},
+
+	thirdParty: {
+		tcgplayer: 90311
+	},
+
 	variants: [
 		{
 			type: "normal"

--- a/data/Base/Wizards Black Star Promos/13.ts
+++ b/data/Base/Wizards Black Star Promos/13.ts
@@ -64,13 +64,12 @@ const card: Card = {
 		en: "This plant blooms when it is absorbing solar energy. It stays on the move to seek sunlight.",
 	},
 
-	thirdParty: {
-		tcgplayer: 90311
-	},
-
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 90311
+			},
 		}
 	]
 }

--- a/data/Base/Wizards Black Star Promos/14.ts
+++ b/data/Base/Wizards Black Star Promos/14.ts
@@ -68,7 +68,9 @@ const card: Card = {
 		en: "Years of genetic experiments resulted in the creation of this never-before-seen violent Pokémon.",
 		fr: "Ce Pokémon violent, jamais vu auparavant, est le fruit de nombreuses années d'expériences génétiques."
 	},
-
+	thirdParty: {
+		tcgplayer: 87417
+	},
 	variants: [
 		{
 			type: "normal"

--- a/data/Base/Wizards Black Star Promos/14.ts
+++ b/data/Base/Wizards Black Star Promos/14.ts
@@ -68,12 +68,13 @@ const card: Card = {
 		en: "Years of genetic experiments resulted in the creation of this never-before-seen violent Pokémon.",
 		fr: "Ce Pokémon violent, jamais vu auparavant, est le fruit de nombreuses années d'expériences génétiques."
 	},
-	thirdParty: {
-		tcgplayer: 87417
-	},
+
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 87417
+			},
 		}
 	]
 }

--- a/data/Base/Wizards Black Star Promos/15.ts
+++ b/data/Base/Wizards Black Star Promos/15.ts
@@ -70,14 +70,12 @@ const card: Card = {
 	description: {
 		en: "A Pokémon that consists entirely of programming code. Capable of moving freely in cyberspace.",
 	},
-
-	thirdParty: {
-		tcgplayer: 84422
-	},
-
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 84422
+			},
 		}
 	]
 }

--- a/data/Base/Wizards Black Star Promos/15.ts
+++ b/data/Base/Wizards Black Star Promos/15.ts
@@ -70,6 +70,11 @@ const card: Card = {
 	description: {
 		en: "A Pokémon that consists entirely of programming code. Capable of moving freely in cyberspace.",
 	},
+
+	thirdParty: {
+		tcgplayer: 84422
+	},
+
 	variants: [
 		{
 			type: "normal"

--- a/data/Base/Wizards Black Star Promos/16.ts
+++ b/data/Base/Wizards Black Star Promos/16.ts
@@ -15,13 +15,12 @@ const card: Card = {
 		en: "You may draw up to 5 cards, then your opponent may draw up to 5 cards. Your turn is over now (you don't get to attack).",
 	},
 
-	thirdParty: {
-		tcgplayer: 84414
-	},
-
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 84414
+			},
 		}
 	]
 }

--- a/data/Base/Wizards Black Star Promos/16.ts
+++ b/data/Base/Wizards Black Star Promos/16.ts
@@ -14,6 +14,11 @@ const card: Card = {
 	effect: {
 		en: "You may draw up to 5 cards, then your opponent may draw up to 5 cards. Your turn is over now (you don't get to attack).",
 	},
+
+	thirdParty: {
+		tcgplayer: 84414
+	},
+
 	variants: [
 		{
 			type: "normal"

--- a/data/Base/Wizards Black Star Promos/17.ts
+++ b/data/Base/Wizards Black Star Promos/17.ts
@@ -66,6 +66,11 @@ const card: Card = {
 	description: {
 		en: "Popular with women because of its beautiful fur. The leader of the Rockets keeps one as a pet.",
 	},
+
+	thirdParty: {
+		tcgplayer: 84638
+	},
+
 	variants: [
 		{
 			type: "holo",

--- a/data/Base/Wizards Black Star Promos/17.ts
+++ b/data/Base/Wizards Black Star Promos/17.ts
@@ -67,14 +67,13 @@ const card: Card = {
 		en: "Popular with women because of its beautiful fur. The leader of the Rockets keeps one as a pet.",
 	},
 
-	thirdParty: {
-		tcgplayer: 84638
-	},
-
 	variants: [
 		{
 			type: "holo",
-			foil: "cosmos"
+			foil: "cosmos",
+			thirdParty: {
+				tcgplayer: 84638
+			},
 		},
 		{
 			type: "holo",

--- a/data/Base/Wizards Black Star Promos/18.ts
+++ b/data/Base/Wizards Black Star Promos/18.ts
@@ -55,13 +55,12 @@ const card: Card = {
 		en: "This Pokémon is more active at night. It likes bright, shiny things and cannot resist taking them and adding them to its collection.",
 	},
 
-	thirdParty: {
-		tcgplayer: 89851
-	},
-	
 	variants: [
 		{
-			type: "holo"
+			type: "holo",
+			thirdParty: {
+				tcgplayer: 89851
+			},
 		}
 	]
 }

--- a/data/Base/Wizards Black Star Promos/18.ts
+++ b/data/Base/Wizards Black Star Promos/18.ts
@@ -54,6 +54,11 @@ const card: Card = {
 	description: {
 		en: "This Pokémon is more active at night. It likes bright, shiny things and cannot resist taking them and adding them to its collection.",
 	},
+
+	thirdParty: {
+		tcgplayer: 89851
+	},
+	
 	variants: [
 		{
 			type: "holo"

--- a/data/Base/Wizards Black Star Promos/19.ts
+++ b/data/Base/Wizards Black Star Promos/19.ts
@@ -55,13 +55,12 @@ const card: Card = {
 		},
 	],
 
-	thirdParty: {
-		tcgplayer: 88862
-	},
-
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 88862
+			},
 		}
 	]
 }

--- a/data/Base/Wizards Black Star Promos/19.ts
+++ b/data/Base/Wizards Black Star Promos/19.ts
@@ -55,6 +55,10 @@ const card: Card = {
 		},
 	],
 
+	thirdParty: {
+		tcgplayer: 88862
+	},
+
 	variants: [
 		{
 			type: "normal"

--- a/data/Base/Wizards Black Star Promos/2.ts
+++ b/data/Base/Wizards Black Star Promos/2.ts
@@ -71,21 +71,17 @@ const card: Card = {
 		fr: "Un Pokémon sauvage au mauvais caractère. Capable de reconnaître les couleurs et apprécie la couleur rouge."
 	},
 
-	thirdParty: {
-		tcgplayer: 85107
-	},
-	
 	variants: [
-		{
-			type: "normal",
-		},
 		{
 			type: "normal",
 			stamp: ["1st-movie-inverted"]
 		},
 		{
 			type: "normal",
-			stamp: ["1st-movie"]
+			stamp: ["1st-movie"],
+			thirdParty: {
+				tcgplayer: 85107
+			},
 		}
 	]
 }

--- a/data/Base/Wizards Black Star Promos/2.ts
+++ b/data/Base/Wizards Black Star Promos/2.ts
@@ -71,6 +71,10 @@ const card: Card = {
 		fr: "Un Pokémon sauvage au mauvais caractère. Capable de reconnaître les couleurs et apprécie la couleur rouge."
 	},
 
+	thirdParty: {
+		tcgplayer: 85107
+	},
+	
 	variants: [
 		{
 			type: "normal",

--- a/data/Base/Wizards Black Star Promos/20.ts
+++ b/data/Base/Wizards Black Star Promos/20.ts
@@ -70,6 +70,10 @@ const card: Card = {
 		fr: "Alors qu'il trompe ses ennemis avec son air niais, ce Pokémon rusé utilise des pouvoirs psychokinésiques."
 	},
 
+	thirdParty: {
+		tcgplayer: 88429
+	},
+
 	variants: [
 		{
 			type: "normal"

--- a/data/Base/Wizards Black Star Promos/20.ts
+++ b/data/Base/Wizards Black Star Promos/20.ts
@@ -70,13 +70,12 @@ const card: Card = {
 		fr: "Alors qu'il trompe ses ennemis avec son air niais, ce Pokémon rusé utilise des pouvoirs psychokinésiques."
 	},
 
-	thirdParty: {
-		tcgplayer: 88429
-	},
-
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 88429
+			},
 		}
 	]
 }

--- a/data/Base/Wizards Black Star Promos/21.ts
+++ b/data/Base/Wizards Black Star Promos/21.ts
@@ -58,13 +58,12 @@ const card: Card = {
 		fr: "Les flammes des ailes de ce Pokémon légendaire brûlent d'un feu si ardent qu'elles permettent de voir la nuit comme en plein jour."
 	},
 
-	thirdParty: {
-		tcgplayer: 87557
-	},
-
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 87557
+			},
 		},
 		{
 			type: "normal",

--- a/data/Base/Wizards Black Star Promos/21.ts
+++ b/data/Base/Wizards Black Star Promos/21.ts
@@ -58,6 +58,10 @@ const card: Card = {
 		fr: "Les flammes des ailes de ce Pokémon légendaire brûlent d'un feu si ardent qu'elles permettent de voir la nuit comme en plein jour."
 	},
 
+	thirdParty: {
+		tcgplayer: 87557
+	},
+
 	variants: [
 		{
 			type: "normal"

--- a/data/Base/Wizards Black Star Promos/22.ts
+++ b/data/Base/Wizards Black Star Promos/22.ts
@@ -58,13 +58,12 @@ const card: Card = {
 		fr: "On prétend que ce Pokémon légendaire refroidit l'eau contenue dans l'air en hiver, au point de provoquer des chutes de neige."
 	},
 
-	thirdParty: {
-		tcgplayer: 83647
-	},
-
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 83647
+			},
 		},
 		{
 			type: "normal",

--- a/data/Base/Wizards Black Star Promos/22.ts
+++ b/data/Base/Wizards Black Star Promos/22.ts
@@ -58,6 +58,10 @@ const card: Card = {
 		fr: "On prétend que ce Pokémon légendaire refroidit l'eau contenue dans l'air en hiver, au point de provoquer des chutes de neige."
 	},
 
+	thirdParty: {
+		tcgplayer: 83647
+	},
+
 	variants: [
 		{
 			type: "normal"

--- a/data/Base/Wizards Black Star Promos/23.ts
+++ b/data/Base/Wizards Black Star Promos/23.ts
@@ -58,6 +58,10 @@ const card: Card = {
 		fr: "Ce Pokémon légendaire est connu pour se montrer partout où il y a un orage."
 	},
 
+	thirdParty: {
+		tcgplayer: 90713
+	},
+
 	variants: [
 		{
 			type: "normal"

--- a/data/Base/Wizards Black Star Promos/23.ts
+++ b/data/Base/Wizards Black Star Promos/23.ts
@@ -58,13 +58,12 @@ const card: Card = {
 		fr: "Ce Pokémon légendaire est connu pour se montrer partout où il y a un orage."
 	},
 
-	thirdParty: {
-		tcgplayer: 90713
-	},
-
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 90713
+			},
 		},
 		{
 			type: "normal",

--- a/data/Base/Wizards Black Star Promos/24.ts
+++ b/data/Base/Wizards Black Star Promos/24.ts
@@ -56,10 +56,6 @@ const card: Card = {
 		fr: "Votre anniversaire : _________________________________________"
 	},
 
-	thirdParty: {
-		tcgplayer: 90784
-	},
-
 	variants: [
 		{
 			type: "holo",
@@ -67,7 +63,10 @@ const card: Card = {
 		},
 		{
 			type: "holo",
-			foil: "cosmos"
+			foil: "cosmos",
+			thirdParty: {
+				tcgplayer: 90784
+			},
 		}
 	]
 }

--- a/data/Base/Wizards Black Star Promos/24.ts
+++ b/data/Base/Wizards Black Star Promos/24.ts
@@ -59,7 +59,10 @@ const card: Card = {
 	variants: [
 		{
 			type: "holo",
-			stamp: ["pikachu-tail"]
+			stamp: ["pikachu-tail"],
+			thirdParty: {
+				tcgplayer: 159115
+			},
 		},
 		{
 			type: "holo",

--- a/data/Base/Wizards Black Star Promos/24.ts
+++ b/data/Base/Wizards Black Star Promos/24.ts
@@ -56,6 +56,10 @@ const card: Card = {
 		fr: "Votre anniversaire : _________________________________________"
 	},
 
+	thirdParty: {
+		tcgplayer: 90784
+	},
+
 	variants: [
 		{
 			type: "holo",

--- a/data/Base/Wizards Black Star Promos/25.ts
+++ b/data/Base/Wizards Black Star Promos/25.ts
@@ -73,6 +73,10 @@ const card: Card = {
 		fr: "En apprenant à voler, Pikachu a surpassé sa faiblesse contre le Pokémon Combat."
 	},
 
+	thirdParty: {
+		tcgplayer: 85534
+	},
+
 	variants: [
 		{
 			type: "normal",

--- a/data/Base/Wizards Black Star Promos/25.ts
+++ b/data/Base/Wizards Black Star Promos/25.ts
@@ -73,10 +73,6 @@ const card: Card = {
 		fr: "En apprenant à voler, Pikachu a surpassé sa faiblesse contre le Pokémon Combat."
 	},
 
-	thirdParty: {
-		tcgplayer: 85534
-	},
-
 	variants: [
 		{
 			type: "normal",
@@ -84,6 +80,9 @@ const card: Card = {
 		},
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 85534
+			},
 		}
 	]
 }

--- a/data/Base/Wizards Black Star Promos/25.ts
+++ b/data/Base/Wizards Black Star Promos/25.ts
@@ -76,7 +76,10 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
-			stamp: ["pikachu-tail"]
+			stamp: ["pikachu-tail"],
+			thirdParty: {
+				tcgplayer: 161749
+			},
 		},
 		{
 			type: "normal",

--- a/data/Base/Wizards Black Star Promos/26.ts
+++ b/data/Base/Wizards Black Star Promos/26.ts
@@ -72,7 +72,10 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
-			stamp: ["pikachu-tail"]
+			stamp: ["pikachu-tail"],
+			thirdParty: {
+				tcgplayer: 161753
+			},
 		},
 		{
 			type: "normal",

--- a/data/Base/Wizards Black Star Promos/26.ts
+++ b/data/Base/Wizards Black Star Promos/26.ts
@@ -69,10 +69,6 @@ const card: Card = {
 		fr: "Il utilise sa queue sensible pour explorer son environnement et réagit violemment si on l'attrape par la queue."
 	},
 
-	thirdParty: {
-		tcgplayer: 88068
-	},
-
 	variants: [
 		{
 			type: "normal",
@@ -80,6 +76,9 @@ const card: Card = {
 		},
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 88068
+			},
 		}
 	]
 }

--- a/data/Base/Wizards Black Star Promos/26.ts
+++ b/data/Base/Wizards Black Star Promos/26.ts
@@ -69,6 +69,10 @@ const card: Card = {
 		fr: "Il utilise sa queue sensible pour explorer son environnement et réagit violemment si on l'attrape par la queue."
 	},
 
+	thirdParty: {
+		tcgplayer: 88068
+	},
+
 	variants: [
 		{
 			type: "normal",

--- a/data/Base/Wizards Black Star Promos/27.ts
+++ b/data/Base/Wizards Black Star Promos/27.ts
@@ -61,10 +61,6 @@ const card: Card = {
 		en: "When several of these Pokémon gather, their electricity can cause lightning storms.",
 	},
 
-	thirdParty: {
-		tcgplayer: 88069
-	},
-
 	variants: [
 		{
 			type: "normal",
@@ -72,6 +68,9 @@ const card: Card = {
 		},
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 88069
+			},
 		}
 	]
 }

--- a/data/Base/Wizards Black Star Promos/27.ts
+++ b/data/Base/Wizards Black Star Promos/27.ts
@@ -64,7 +64,10 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
-			stamp: ["pikachu-tail"]
+			stamp: ["pikachu-tail"],
+			thirdParty: {
+				tcgplayer: 161747
+			},
 		},
 		{
 			type: "normal",

--- a/data/Base/Wizards Black Star Promos/27.ts
+++ b/data/Base/Wizards Black Star Promos/27.ts
@@ -60,6 +60,11 @@ const card: Card = {
 	description: {
 		en: "When several of these Pokémon gather, their electricity can cause lightning storms.",
 	},
+
+	thirdParty: {
+		tcgplayer: 88069
+	},
+
 	variants: [
 		{
 			type: "normal",

--- a/data/Base/Wizards Black Star Promos/28.ts
+++ b/data/Base/Wizards Black Star Promos/28.ts
@@ -54,10 +54,6 @@ const card: Card = {
 		fr: "L'été, on aperçoit souvent des bandes de Pikachu surfant sur les vagues."
 	},
 
-	thirdParty: {
-		tcgplayer: 89643
-	},
-
 	variants: [
 		{
 			type: "normal",
@@ -65,6 +61,9 @@ const card: Card = {
 		},
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 89643
+			},
 		}
 	]
 }

--- a/data/Base/Wizards Black Star Promos/28.ts
+++ b/data/Base/Wizards Black Star Promos/28.ts
@@ -57,7 +57,10 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
-			stamp: ["pikachu-tail"]
+			stamp: ["pikachu-tail"],
+			thirdParty: {
+				tcgplayer: 161754
+			},
 		},
 		{
 			type: "normal",

--- a/data/Base/Wizards Black Star Promos/28.ts
+++ b/data/Base/Wizards Black Star Promos/28.ts
@@ -54,6 +54,10 @@ const card: Card = {
 		fr: "L'été, on aperçoit souvent des bandes de Pikachu surfant sur les vagues."
 	},
 
+	thirdParty: {
+		tcgplayer: 89643
+	},
+
 	variants: [
 		{
 			type: "normal",

--- a/data/Base/Wizards Black Star Promos/29.ts
+++ b/data/Base/Wizards Black Star Promos/29.ts
@@ -57,13 +57,12 @@ const card: Card = {
 		fr: "L'extrémité de sa queue, qui contient une huile plus légère que l'eau, lui permet de nager sans couler."
 	},
 
-	thirdParty: {
-		tcgplayer: 87211
-	},
-
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 87211
+			},
 		}
 	]
 }

--- a/data/Base/Wizards Black Star Promos/29.ts
+++ b/data/Base/Wizards Black Star Promos/29.ts
@@ -57,6 +57,10 @@ const card: Card = {
 		fr: "L'extrémité de sa queue, qui contient une huile plus légère que l'eau, lui permet de nager sans couler."
 	},
 
+	thirdParty: {
+		tcgplayer: 87211
+	},
+
 	variants: [
 		{
 			type: "normal",

--- a/data/Base/Wizards Black Star Promos/3.ts
+++ b/data/Base/Wizards Black Star Promos/3.ts
@@ -69,6 +69,10 @@ const card: Card = {
 		fr: "Ce Pokémon violent, jamais vu auparavant, est le fruit de nombreuses années d'expériences génétiques."
 	},
 
+	thirdParty: {
+		tcgplayer: 87414
+	},
+	
 	variants: [
 		{
 			type: "normal",

--- a/data/Base/Wizards Black Star Promos/3.ts
+++ b/data/Base/Wizards Black Star Promos/3.ts
@@ -69,21 +69,17 @@ const card: Card = {
 		fr: "Ce Pokémon violent, jamais vu auparavant, est le fruit de nombreuses années d'expériences génétiques."
 	},
 
-	thirdParty: {
-		tcgplayer: 87414
-	},
-	
 	variants: [
-		{
-			type: "normal",
-		},
 		{
 			type: "normal",
 			stamp: ["1st-movie-inverted"]
 		},
 		{
 			type: "normal",
-			stamp: ["1st-movie"]
+			stamp: ["1st-movie"],
+			thirdParty: {
+				tcgplayer: 87414
+			},
 		}
 	]
 }

--- a/data/Base/Wizards Black Star Promos/30.ts
+++ b/data/Base/Wizards Black Star Promos/30.ts
@@ -70,13 +70,12 @@ const card: Card = {
 		fr: "Même si ce n'est qu'un poussin, il utilise un poison pour repousser ses ennemis quand il se sent menacé."
 	},
 
-	thirdParty: {
-		tcgplayer: 89928
-	},
-
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 89928
+			},
 		}
 	]
 }

--- a/data/Base/Wizards Black Star Promos/30.ts
+++ b/data/Base/Wizards Black Star Promos/30.ts
@@ -70,6 +70,10 @@ const card: Card = {
 		fr: "Même si ce n'est qu'un poussin, il utilise un poison pour repousser ses ennemis quand il se sent menacé."
 	},
 
+	thirdParty: {
+		tcgplayer: 89928
+	},
+
 	variants: [
 		{
 			type: "normal",

--- a/data/Base/Wizards Black Star Promos/31.ts
+++ b/data/Base/Wizards Black Star Promos/31.ts
@@ -46,6 +46,10 @@ const card: Card = {
 		fr: "À cause de son étrange forme en étoile, les gens pensent qu'il est arrivé ici sur un météore."
 	},
 
+	thirdParty: {
+		tcgplayer: 84363
+	},
+
 	variants: [
 		{
 			type: "normal",

--- a/data/Base/Wizards Black Star Promos/31.ts
+++ b/data/Base/Wizards Black Star Promos/31.ts
@@ -46,13 +46,12 @@ const card: Card = {
 		fr: "À cause de son étrange forme en étoile, les gens pensent qu'il est arrivé ici sur un météore."
 	},
 
-	thirdParty: {
-		tcgplayer: 84363
-	},
-
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 84363
+			},
 		}
 	]
 }

--- a/data/Base/Wizards Black Star Promos/32.ts
+++ b/data/Base/Wizards Black Star Promos/32.ts
@@ -62,13 +62,12 @@ const card: Card = {
 		fr: "À l'âge adulte, il a tendance à laisser ses camarades imprimer leurs empreintes sur son dos."
 	},
 
-	thirdParty: {
-		tcgplayer: 89353
-	},
-
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 89353
+			},
 		}
 	]
 }

--- a/data/Base/Wizards Black Star Promos/32.ts
+++ b/data/Base/Wizards Black Star Promos/32.ts
@@ -62,6 +62,10 @@ const card: Card = {
 		fr: "À l'âge adulte, il a tendance à laisser ses camarades imprimer leurs empreintes sur son dos."
 	},
 
+	thirdParty: {
+		tcgplayer: 89353
+	},
+
 	variants: [
 		{
 			type: "normal",

--- a/data/Base/Wizards Black Star Promos/33.ts
+++ b/data/Base/Wizards Black Star Promos/33.ts
@@ -84,13 +84,12 @@ const card: Card = {
 		fr: "Il n'utilise pas ses ailes pour voler. Elles lui servent à ajuster la température de son corps en les faisant battre rapidement."
 	},
 
-	thirdParty: {
-		tcgplayer: 88960
-	},
-
 	variants: [
 		{
 			type: "reverse",
+			thirdParty: {
+				tcgplayer: 88960
+			},
 		}
 	]
 }

--- a/data/Base/Wizards Black Star Promos/33.ts
+++ b/data/Base/Wizards Black Star Promos/33.ts
@@ -84,6 +84,10 @@ const card: Card = {
 		fr: "Il n'utilise pas ses ailes pour voler. Elles lui servent à ajuster la température de son corps en les faisant battre rapidement."
 	},
 
+	thirdParty: {
+		tcgplayer: 88960
+	},
+
 	variants: [
 		{
 			type: "reverse",

--- a/data/Base/Wizards Black Star Promos/34.ts
+++ b/data/Base/Wizards Black Star Promos/34.ts
@@ -61,13 +61,12 @@ const card: Card = {
 		en: "Volcanoes erupt when it barks. Unable to restrain its extreme power, it races headlong around the land.",
 	},
 
-	thirdParty: {
-		tcgplayer: 85270
-	},
-
 	variants: [
 		{
 			type: "reverse",
+			thirdParty: {
+				tcgplayer: 85270
+			},
 		}
 	]
 }

--- a/data/Base/Wizards Black Star Promos/34.ts
+++ b/data/Base/Wizards Black Star Promos/34.ts
@@ -60,6 +60,11 @@ const card: Card = {
 	description: {
 		en: "Volcanoes erupt when it barks. Unable to restrain its extreme power, it races headlong around the land.",
 	},
+
+	thirdParty: {
+		tcgplayer: 85270
+	},
+
 	variants: [
 		{
 			type: "reverse",

--- a/data/Base/Wizards Black Star Promos/35.ts
+++ b/data/Base/Wizards Black Star Promos/35.ts
@@ -46,13 +46,12 @@ const card: Card = {
 		fr: "Bien qu'il ne soit pas encore très doué pour stocker l'électricité, il peut tout de même envoyer de petites secousses s'il est amusé ou surpris."
 	},
 
-	thirdParty: {
-		tcgplayer: 88014
-	},
-
 	variants: [
 		{
 			type: "reverse",
+			thirdParty: {
+				tcgplayer: 88014
+			},
 		}
 	]
 }

--- a/data/Base/Wizards Black Star Promos/35.ts
+++ b/data/Base/Wizards Black Star Promos/35.ts
@@ -46,6 +46,10 @@ const card: Card = {
 		fr: "Bien qu'il ne soit pas encore très doué pour stocker l'électricité, il peut tout de même envoyer de petites secousses s'il est amusé ou surpris."
 	},
 
+	thirdParty: {
+		tcgplayer: 88014
+	},
+
 	variants: [
 		{
 			type: "reverse",

--- a/data/Base/Wizards Black Star Promos/36.ts
+++ b/data/Base/Wizards Black Star Promos/36.ts
@@ -46,13 +46,12 @@ const card: Card = {
 		fr: "Son corps extrêmement flexible et élastique le fait rebondir continuellement ─ tout le temps, et dans toutes les directions."
 	},
 
-	thirdParty: {
-		tcgplayer: 86259
-	},
-
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 86259
+			},
 		}
 	]
 }

--- a/data/Base/Wizards Black Star Promos/36.ts
+++ b/data/Base/Wizards Black Star Promos/36.ts
@@ -46,6 +46,10 @@ const card: Card = {
 		fr: "Son corps extrêmement flexible et élastique le fait rebondir continuellement ─ tout le temps, et dans toutes les directions."
 	},
 
+	thirdParty: {
+		tcgplayer: 86259
+	},
+
 	variants: [
 		{
 			type: "normal",

--- a/data/Base/Wizards Black Star Promos/37.ts
+++ b/data/Base/Wizards Black Star Promos/37.ts
@@ -74,6 +74,10 @@ const card: Card = {
 		fr: "Il lance des coups de pieds tournant. S'il tournoie assez vite, il peut s'enfoncer dans le sol."
 	},
 
+	thirdParty: {
+		tcgplayer: 86112
+	},
+
 	variants: [
 		{
 			type: "normal",

--- a/data/Base/Wizards Black Star Promos/37.ts
+++ b/data/Base/Wizards Black Star Promos/37.ts
@@ -74,13 +74,12 @@ const card: Card = {
 		fr: "Il lance des coups de pieds tournant. S'il tournoie assez vite, il peut s'enfoncer dans le sol."
 	},
 
-	thirdParty: {
-		tcgplayer: 86112
-	},
-
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 86112
+			},
 		}
 	]
 }

--- a/data/Base/Wizards Black Star Promos/38.ts
+++ b/data/Base/Wizards Black Star Promos/38.ts
@@ -67,13 +67,12 @@ const card: Card = {
 		fr: "Ils ressemblent à des hiéroglyphes inscrits sur d'antiques tablettes. Certains croient qu'il existe un lien entre les hiéroglyphes et eux."
 	},
 
-	thirdParty: {
-		tcgplayer: 90215
-	},
-
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 90215
+			},
 		}
 	]
 }

--- a/data/Base/Wizards Black Star Promos/38.ts
+++ b/data/Base/Wizards Black Star Promos/38.ts
@@ -67,6 +67,10 @@ const card: Card = {
 		fr: "Ils ressemblent à des hiéroglyphes inscrits sur d'antiques tablettes. Certains croient qu'il existe un lien entre les hiéroglyphes et eux."
 	},
 
+	thirdParty: {
+		tcgplayer: 90215
+	},
+
 	variants: [
 		{
 			type: "normal",

--- a/data/Base/Wizards Black Star Promos/39.ts
+++ b/data/Base/Wizards Black Star Promos/39.ts
@@ -71,13 +71,12 @@ const card: Card = {
 		fr: "Il adore mordre et tirer les cheveux des gens par surprise, rien que pour voir leur expression horrifiée."
 	},
 
-	thirdParty: {
-		tcgplayer: 87503
-	},
-
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 87503
+			},
 		}
 	]
 }

--- a/data/Base/Wizards Black Star Promos/39.ts
+++ b/data/Base/Wizards Black Star Promos/39.ts
@@ -71,6 +71,10 @@ const card: Card = {
 		fr: "Il adore mordre et tirer les cheveux des gens par surprise, rien que pour voir leur expression horrifiée."
 	},
 
+	thirdParty: {
+		tcgplayer: 87503
+	},
+
 	variants: [
 		{
 			type: "normal",

--- a/data/Base/Wizards Black Star Promos/4.ts
+++ b/data/Base/Wizards Black Star Promos/4.ts
@@ -71,6 +71,10 @@ const card: Card = {
 		fr: "Quand plusieurs de ces Pokémon se réunissent, ils attirent tellement d'électricité qu'ils peuvent provoquer des coups de foudre."
 	},
 
+	thirdParty: {
+		tcgplayer: 88066
+	},
+
 	variants: [
 		{
 			type: "normal",

--- a/data/Base/Wizards Black Star Promos/4.ts
+++ b/data/Base/Wizards Black Star Promos/4.ts
@@ -71,21 +71,17 @@ const card: Card = {
 		fr: "Quand plusieurs de ces Pokémon se réunissent, ils attirent tellement d'électricité qu'ils peuvent provoquer des coups de foudre."
 	},
 
-	thirdParty: {
-		tcgplayer: 88066
-	},
-
 	variants: [
-		{
-			type: "normal",
-		},
 		{
 			type: "normal",
 			stamp: ["1st-movie-inverted"]
 		},
 		{
 			type: "normal",
-			stamp: ["1st-movie"]
+			stamp: ["1st-movie"],
+			thirdParty: {
+				tcgplayer: 88066
+			},
 		},
 		{
 			type: "normal",

--- a/data/Base/Wizards Black Star Promos/4.ts
+++ b/data/Base/Wizards Black Star Promos/4.ts
@@ -85,7 +85,10 @@ const card: Card = {
 		},
 		{
 			type: "normal",
-			stamp: ["pikachu-tail"]
+			stamp: ["pikachu-tail"],
+			thirdParty: {
+				tcgplayer: 161752
+			},
 		}
 	]
 }

--- a/data/Base/Wizards Black Star Promos/40.ts
+++ b/data/Base/Wizards Black Star Promos/40.ts
@@ -14,6 +14,11 @@ const card: Card = {
 	effect: {
 		en: "Remove all damage counters from all of your own Pokémon with damage counters on them, then discard all Energy cards attached to those Pokémon.",
 	},
+
+	thirdParty: {
+		tcgplayer: 88213
+	},
+
 	variants: [
 		{
 			type: "normal",

--- a/data/Base/Wizards Black Star Promos/40.ts
+++ b/data/Base/Wizards Black Star Promos/40.ts
@@ -15,13 +15,12 @@ const card: Card = {
 		en: "Remove all damage counters from all of your own Pokémon with damage counters on them, then discard all Energy cards attached to those Pokémon.",
 	},
 
-	thirdParty: {
-		tcgplayer: 88213
-	},
-
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 88213
+			},
 		}
 	]
 }

--- a/data/Base/Wizards Black Star Promos/41.ts
+++ b/data/Base/Wizards Black Star Promos/41.ts
@@ -15,13 +15,12 @@ const card: Card = {
 		en: "This card stays in play when you play it. Discard this card if another Stadium card comes into play. Once during each player's turn (before attacking), that player may flip a coin. If heads, that player draws a card.",
 	},
 
-	thirdParty: {
-		tcgplayer: 86894
-	},
-
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 86894
+			},
 		}
 	]
 }

--- a/data/Base/Wizards Black Star Promos/41.ts
+++ b/data/Base/Wizards Black Star Promos/41.ts
@@ -14,6 +14,11 @@ const card: Card = {
 	effect: {
 		en: "This card stays in play when you play it. Discard this card if another Stadium card comes into play. Once during each player's turn (before attacking), that player may flip a coin. If heads, that player draws a card.",
 	},
+
+	thirdParty: {
+		tcgplayer: 86894
+	},
+
 	variants: [
 		{
 			type: "normal",

--- a/data/Base/Wizards Black Star Promos/42.ts
+++ b/data/Base/Wizards Black Star Promos/42.ts
@@ -15,13 +15,12 @@ const card: Card = {
 		en: "This card stays in play when you play it. Discard this card if another Stadium card comes into play. If the effect of a Pokémon Power, attack, Energy card, or Trainer card would put a card in a discard pile into its owner's hand, that card stays in that discard pile instead.",
 	},
 
-	thirdParty: {
-		tcgplayer: 88240
-	},
-
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 88240
+			},
 		}
 	]
 }

--- a/data/Base/Wizards Black Star Promos/42.ts
+++ b/data/Base/Wizards Black Star Promos/42.ts
@@ -14,6 +14,11 @@ const card: Card = {
 	effect: {
 		en: "This card stays in play when you play it. Discard this card if another Stadium card comes into play. If the effect of a Pokémon Power, attack, Energy card, or Trainer card would put a card in a discard pile into its owner's hand, that card stays in that discard pile instead.",
 	},
+
+	thirdParty: {
+		tcgplayer: 88240
+	},
+
 	variants: [
 		{
 			type: "normal",

--- a/data/Base/Wizards Black Star Promos/43.ts
+++ b/data/Base/Wizards Black Star Promos/43.ts
@@ -68,13 +68,12 @@ const card: Card = {
 		en: "Using its amazing muscles, it throws powerful punches that can knock its victim clear over the horizon.",
 	},
 
-	thirdParty: {
-		tcgplayer: 86961
-	},
-
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 86961
+			},
 		}
 	]
 }

--- a/data/Base/Wizards Black Star Promos/43.ts
+++ b/data/Base/Wizards Black Star Promos/43.ts
@@ -67,6 +67,11 @@ const card: Card = {
 	description: {
 		en: "Using its amazing muscles, it throws powerful punches that can knock its victim clear over the horizon.",
 	},
+
+	thirdParty: {
+		tcgplayer: 86961
+	},
+
 	variants: [
 		{
 			type: "normal",

--- a/data/Base/Wizards Black Star Promos/44.ts
+++ b/data/Base/Wizards Black Star Promos/44.ts
@@ -67,8 +67,10 @@ const card: Card = {
 	description: {
 		en: "Its body always burns with an orange glow that enables it to hide perfectly among flames.",
 	},
+
 	thirdParty: {
 		cardmarket: 275463,
+		tcgplayer: 87043
 	}
 }
 

--- a/data/Base/Wizards Black Star Promos/44.ts
+++ b/data/Base/Wizards Black Star Promos/44.ts
@@ -61,17 +61,16 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				cardmarket: 275463,
+				tcgplayer: 87043
+			}
 		}
 	],
 
 	description: {
 		en: "Its body always burns with an orange glow that enables it to hide perfectly among flames.",
 	},
-
-	thirdParty: {
-		cardmarket: 275463,
-		tcgplayer: 87043
-	}
 }
 
 export default card

--- a/data/Base/Wizards Black Star Promos/45.ts
+++ b/data/Base/Wizards Black Star Promos/45.ts
@@ -56,13 +56,12 @@ const card: Card = {
 		en: "With ninja-like agility and speed, it can create the illusion that there is more than one.",
 	},
 
-	thirdParty: {
-		tcgplayer: 88993
-	},
-
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 88993
+			},
 		}
 	]
 }

--- a/data/Base/Wizards Black Star Promos/45.ts
+++ b/data/Base/Wizards Black Star Promos/45.ts
@@ -55,6 +55,11 @@ const card: Card = {
 	description: {
 		en: "With ninja-like agility and speed, it can create the illusion that there is more than one.",
 	},
+
+	thirdParty: {
+		tcgplayer: 88993
+	},
+
 	variants: [
 		{
 			type: "normal",

--- a/data/Base/Wizards Black Star Promos/46.ts
+++ b/data/Base/Wizards Black Star Promos/46.ts
@@ -61,6 +61,11 @@ const card: Card = {
 	description: {
 		en: "Normally found near power plants, it can wander away and cause major blackouts in cities.",
 	},
+
+	thirdParty: {
+		tcgplayer: 85111
+	},
+
 	variants: [
 		{
 			type: "normal",

--- a/data/Base/Wizards Black Star Promos/46.ts
+++ b/data/Base/Wizards Black Star Promos/46.ts
@@ -62,13 +62,12 @@ const card: Card = {
 		en: "Normally found near power plants, it can wander away and cause major blackouts in cities.",
 	},
 
-	thirdParty: {
-		tcgplayer: 85111
-	},
-
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 85111
+			},
 		}
 	]
 }

--- a/data/Base/Wizards Black Star Promos/47.ts
+++ b/data/Base/Wizards Black Star Promos/47.ts
@@ -59,13 +59,12 @@ const card: Card = {
 		en: "So rare that it is still said to be a mirage by many experts. Only a few people have seen it worldwide.",
 	},
 
-	thirdParty: {
-		tcgplayer: 87397
-	},
-
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 87397
+			},
 		}
 	]
 }

--- a/data/Base/Wizards Black Star Promos/47.ts
+++ b/data/Base/Wizards Black Star Promos/47.ts
@@ -58,6 +58,11 @@ const card: Card = {
 	description: {
 		en: "So rare that it is still said to be a mirage by many experts. Only a few people have seen it worldwide.",
 	},
+
+	thirdParty: {
+		tcgplayer: 87397
+	},
+
 	variants: [
 		{
 			type: "normal",

--- a/data/Base/Wizards Black Star Promos/48.ts
+++ b/data/Base/Wizards Black Star Promos/48.ts
@@ -63,13 +63,12 @@ const card: Card = {
 		en: "A legendary bird Pokémon that is said to appear to doomed people who are lost in icy mountains.",
 	},
 
-	thirdParty: {
-		tcgplayer: 83648
-	},
-
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 83648
+			},
 		}
 	]
 }

--- a/data/Base/Wizards Black Star Promos/48.ts
+++ b/data/Base/Wizards Black Star Promos/48.ts
@@ -62,6 +62,11 @@ const card: Card = {
 	description: {
 		en: "A legendary bird Pokémon that is said to appear to doomed people who are lost in icy mountains.",
 	},
+
+	thirdParty: {
+		tcgplayer: 83648
+	},
+
 	variants: [
 		{
 			type: "normal",

--- a/data/Base/Wizards Black Star Promos/49.ts
+++ b/data/Base/Wizards Black Star Promos/49.ts
@@ -68,13 +68,12 @@ const card: Card = {
 		en: "Very lazy. Just eats and sleeps. As its rotund bulk builds, it becomes steadily more slothful.",
 	},
 
-	thirdParty: {
-		tcgplayer: 89385
-	},
-
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 89385
+			},
 		}
 	]
 }

--- a/data/Base/Wizards Black Star Promos/49.ts
+++ b/data/Base/Wizards Black Star Promos/49.ts
@@ -67,6 +67,11 @@ const card: Card = {
 	description: {
 		en: "Very lazy. Just eats and sleeps. As its rotund bulk builds, it becomes steadily more slothful.",
 	},
+
+	thirdParty: {
+		tcgplayer: 89385
+	},
+
 	variants: [
 		{
 			type: "normal",

--- a/data/Base/Wizards Black Star Promos/5.ts
+++ b/data/Base/Wizards Black Star Promos/5.ts
@@ -79,6 +79,10 @@ const card: Card = {
 		fr: "Ce Pokémon peut voler malgré sa taille imposante. On le dit capable de faire le tour de la Terre en 16 heures à peine."
 	},
 
+	thirdParty: {
+		tcgplayer: 84909
+	},
+
 	variants: [
 		{
 			type: "normal",

--- a/data/Base/Wizards Black Star Promos/5.ts
+++ b/data/Base/Wizards Black Star Promos/5.ts
@@ -79,21 +79,17 @@ const card: Card = {
 		fr: "Ce Pokémon peut voler malgré sa taille imposante. On le dit capable de faire le tour de la Terre en 16 heures à peine."
 	},
 
-	thirdParty: {
-		tcgplayer: 84909
-	},
-
 	variants: [
-		{
-			type: "normal",
-		},
 		{
 			type: "normal",
 			stamp: ["1st-movie-inverted"]
 		},
 		{
 			type: "normal",
-			stamp: ["1st-movie"]
+			stamp: ["1st-movie"],
+			thirdParty: {
+				tcgplayer: 84909
+			},
 		}
 	]
 }

--- a/data/Base/Wizards Black Star Promos/50.ts
+++ b/data/Base/Wizards Black Star Promos/50.ts
@@ -45,14 +45,13 @@ const card: Card = {
 	],
 	retreat: 1,
 
-	thirdParty: {
-		tcgplayer: 84143
-	},
-
 	variants: [
 		{
 			type: "normal",
-			stamp: ["pokemon-4-ever"]
+			stamp: ["pokemon-4-ever"],
+			thirdParty: {
+				tcgplayer: 84143
+			},
 		}
 	]
 }

--- a/data/Base/Wizards Black Star Promos/50.ts
+++ b/data/Base/Wizards Black Star Promos/50.ts
@@ -45,6 +45,9 @@ const card: Card = {
 	],
 	retreat: 1,
 
+	thirdParty: {
+		tcgplayer: 84143
+	},
 
 	variants: [
 		{

--- a/data/Base/Wizards Black Star Promos/51.ts
+++ b/data/Base/Wizards Black Star Promos/51.ts
@@ -60,17 +60,19 @@ const card: Card = {
 		},
 	],
 
-	thirdParty: {
-		tcgplayer: 88575
-	},
-
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 88575
+			},
 		},
 		{
 			type: "normal",
-			stamp: ["pokemon-center-ny"]
+			stamp: ["pokemon-center-ny"],
+			thirdParty: {
+				tcgplayer: 244347
+			},
 		}
 	]
 }

--- a/data/Base/Wizards Black Star Promos/51.ts
+++ b/data/Base/Wizards Black Star Promos/51.ts
@@ -60,6 +60,10 @@ const card: Card = {
 		},
 	],
 
+	thirdParty: {
+		tcgplayer: 88575
+	},
+
 	variants: [
 		{
 			type: "normal",

--- a/data/Base/Wizards Black Star Promos/52.ts
+++ b/data/Base/Wizards Black Star Promos/52.ts
@@ -52,6 +52,9 @@ const card: Card = {
 	],
 	retreat: 2,
 
+	thirdParty: {
+		tcgplayer: 86120
+	},
 
 	variants: [
 		{
@@ -59,7 +62,7 @@ const card: Card = {
 		},
 		{
 			type: "normal",
-			stamp: ["pokemon-center-ny"]
+			stamp: ["pokemon-center-ny"],
 		}
 	]
 }

--- a/data/Base/Wizards Black Star Promos/52.ts
+++ b/data/Base/Wizards Black Star Promos/52.ts
@@ -52,17 +52,19 @@ const card: Card = {
 	],
 	retreat: 2,
 
-	thirdParty: {
-		tcgplayer: 86120
-	},
-
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 86120
+			},
 		},
 		{
 			type: "normal",
 			stamp: ["pokemon-center-ny"],
+			thirdParty: {
+				tcgplayer: 244348
+			},
 		}
 	]
 }

--- a/data/Base/Wizards Black Star Promos/53.ts
+++ b/data/Base/Wizards Black Star Promos/53.ts
@@ -56,14 +56,13 @@ const card: Card = {
 	],
 	retreat: 1,
 
-	thirdParty: {
-		tcgplayer: 89601
-	},
-
 	variants: [
 		{
 			type: "normal",
-			stamp: ["pokemon-4-ever"]
+			stamp: ["pokemon-4-ever"],
+			thirdParty: {
+				tcgplayer: 89601
+			},
 		}
 	]
 }

--- a/data/Base/Wizards Black Star Promos/53.ts
+++ b/data/Base/Wizards Black Star Promos/53.ts
@@ -56,6 +56,9 @@ const card: Card = {
 	],
 	retreat: 1,
 
+	thirdParty: {
+		tcgplayer: 89601
+	},
 
 	variants: [
 		{

--- a/data/Base/Wizards Black Star Promos/6.ts
+++ b/data/Base/Wizards Black Star Promos/6.ts
@@ -78,13 +78,12 @@ const card: Card = {
 		fr: "Un Pokémon légendaire réputé pour sa beauté. Il galope si vite qu'il semble voler."
 	},
 
-	thirdParty: {
-		tcgplayer: 83578
-	},
-
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 83578
+			},
 		},
 	]
 }

--- a/data/Base/Wizards Black Star Promos/6.ts
+++ b/data/Base/Wizards Black Star Promos/6.ts
@@ -78,6 +78,10 @@ const card: Card = {
 		fr: "Un Pokémon légendaire réputé pour sa beauté. Il galope si vite qu'il semble voler."
 	},
 
+	thirdParty: {
+		tcgplayer: 83578
+	},
+
 	variants: [
 		{
 			type: "normal",

--- a/data/Base/Wizards Black Star Promos/7.ts
+++ b/data/Base/Wizards Black Star Promos/7.ts
@@ -69,13 +69,12 @@ const card: Card = {
 		en: "When its huge eyes light up, it sings a mysteriously soothing melody that lulls its enemies to sleep.",
 	},
 
-	thirdParty: {
-		tcgplayer: 86309
-	},
-
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 86309
+			},
 		},
 	]
 

--- a/data/Base/Wizards Black Star Promos/7.ts
+++ b/data/Base/Wizards Black Star Promos/7.ts
@@ -68,6 +68,11 @@ const card: Card = {
 	description: {
 		en: "When its huge eyes light up, it sings a mysteriously soothing melody that lulls its enemies to sleep.",
 	},
+
+	thirdParty: {
+		tcgplayer: 86309
+	},
+
 	variants: [
 		{
 			type: "normal",

--- a/data/Base/Wizards Black Star Promos/8.ts
+++ b/data/Base/Wizards Black Star Promos/8.ts
@@ -71,13 +71,19 @@ const card: Card = {
 		fr: "Unique et rare, son existence est remise en cause par les experts. Peu nombreux sont ceux qui l'ont vu."
 	},
 
-	thirdParty: {
-		tcgplayer: 87394
-	},
-
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 87394
+			},
+		}, 
+		{
+			type: "normal",
+			subtype: "glossy",
+			thirdParty: {
+				tcgplayer: 607818
+			},
 		},
 	]
 }

--- a/data/Base/Wizards Black Star Promos/8.ts
+++ b/data/Base/Wizards Black Star Promos/8.ts
@@ -71,6 +71,10 @@ const card: Card = {
 		fr: "Unique et rare, son existence est remise en cause par les experts. Peu nombreux sont ceux qui l'ont vu."
 	},
 
+	thirdParty: {
+		tcgplayer: 87394
+	},
+
 	variants: [
 		{
 			type: "normal",

--- a/data/Base/Wizards Black Star Promos/9.ts
+++ b/data/Base/Wizards Black Star Promos/9.ts
@@ -71,13 +71,12 @@ const card: Card = {
 		fr: "Unique et rare, son existence est remise en cause par les experts. Peu nombreux sont ceux qui l'ont vu."
 	},
 
-	thirdParty: {
-		tcgplayer: 87395
-	},
-
 	variants: [
 		{
 			type: "holo",
+			thirdParty: {
+				tcgplayer: 87395
+			},
 		},
 	]
 }

--- a/data/Base/Wizards Black Star Promos/9.ts
+++ b/data/Base/Wizards Black Star Promos/9.ts
@@ -71,6 +71,10 @@ const card: Card = {
 		fr: "Unique et rare, son existence est remise en cause par les experts. Peu nombreux sont ceux qui l'ont vu."
 	},
 
+	thirdParty: {
+		tcgplayer: 87395
+	},
+
 	variants: [
 		{
 			type: "holo",

--- a/interfaces.d.ts
+++ b/interfaces.d.ts
@@ -35,7 +35,7 @@ export type VariantStamps = '1st-edition' | 'w-promo' | 'pre-release' | 'pokemon
 	| 'illustration-contest-2024' | 'worlds-2025' | 'top-eight' | "champion" | "poke-ball-league" | "master-ball-league" | "ultra-ball-league" | "judge" | "asia-promo"
 	| "international-championship-europe" | "international-championship-latin-america" | "international-championship-north-america" | 'ace-trainer'
 	| 'pikachu' | 'bulbasaur' | 'squirtle' | 'charmander' | 'pokeball' | '30th-pokeday' | 'mcdonalds' | 'pokemon-together' | 'rain-city' | 'tournament-collection'
-	| 'worlds-2024' | 'worlds-2023' | 'asia-2023-24' | 'thank-you'
+	| 'worlds-2024' | 'worlds-2023' | 'asia-2023-24' | 'thank-you' | 'jr-stamp-rally' | 'grey-star'
 
 export interface variant_detailed {
 	/**
@@ -54,7 +54,7 @@ export interface variant_detailed {
 	subtype?: 'shadowless' | 'unlimited' | '1999-2000-copyright' | 'missing-expansion-symbol' | 'gold-border'
 		| 'missing-hp' | 'aoki-error' | '1999-copyright' | 'evolution-box-error' | 'no-holo-error' | 'd-ink-dot-error'
 		| 'energy-symbol-error' | 'text-error' | 'shifted-energy-cost' | 'japanese-back' | 'no-e-reader' | 'rarity-error'
-		| 'cosmos' | 'blue-border'
+		| 'cosmos' | 'blue-border' | 'glossy'
 
 	/**
 	 * define the size of the card

--- a/meta/translations/de.json
+++ b/meta/translations/de.json
@@ -255,7 +255,8 @@
 		"worlds-2024": "worlds-2024",
 		"worlds-2023": "worlds-2023",
 		"asia-2023-24": "asia-2023-24",
-		"thank-you" : "thank-you"
+		"thank-you" : "thank-you",
+		"jr-stamp-rally": "jr-stamp-rally"
 	},
 	"variantSubtype": {
 		"shadowless": "schattenlos",
@@ -275,6 +276,7 @@
 		"japanese-back": "Japanische Rückseite",
 		"no-e-reader": "Kein e-Reader",
 		"rarity-error": "Seltenheitsfehler",
-		"cosmos": "cosmos"
+		"cosmos": "cosmos",
+		"glossy": "Hochglanz"
 	}
 }

--- a/meta/translations/de.json
+++ b/meta/translations/de.json
@@ -256,7 +256,8 @@
 		"worlds-2023": "worlds-2023",
 		"asia-2023-24": "asia-2023-24",
 		"thank-you" : "thank-you",
-		"jr-stamp-rally": "jr-stamp-rally"
+		"jr-stamp-rally": "jr-stamp-rally",
+		"grey-star": "grey-star"
 	},
 	"variantSubtype": {
 		"shadowless": "schattenlos",

--- a/meta/translations/de.json
+++ b/meta/translations/de.json
@@ -257,7 +257,7 @@
 		"asia-2023-24": "asia-2023-24",
 		"thank-you" : "thank-you",
 		"jr-stamp-rally": "jr-stamp-rally",
-		"grey-star": "grey-star"
+		"grey-star": "grauer stern"
 	},
 	"variantSubtype": {
 		"shadowless": "schattenlos",

--- a/meta/translations/es.json
+++ b/meta/translations/es.json
@@ -256,7 +256,8 @@
 		"worlds-2023": "worlds-2023",
 		"asia-2023-24": "asia-2023-24",
 		"thank-you" : "thank-you",
-		"jr-stamp-rally": "jr-stamp-rally"
+		"jr-stamp-rally": "jr-stamp-rally",
+		"grey-star": "grey-star"
 	},
 	"variantSubtype": {
 		"shadowless": "sin sombra",

--- a/meta/translations/es.json
+++ b/meta/translations/es.json
@@ -255,7 +255,8 @@
 		"worlds-2024": "worlds-2024",
 		"worlds-2023": "worlds-2023",
 		"asia-2023-24": "asia-2023-24",
-		"thank-you" : "thank-you"
+		"thank-you" : "thank-you",
+		"jr-stamp-rally": "jr-stamp-rally"
 	},
 	"variantSubtype": {
 		"shadowless": "sin sombra",
@@ -275,6 +276,7 @@
 		"japanese-back": "Reverso japonés",
 		"no-e-reader": "Sin e-Reader",
 		"rarity-error": "Error de rareza",
-		"cosmos": "cosmos"
+		"cosmos": "cosmos",
+		"glossy": "con brillo"
 	}
 }

--- a/meta/translations/es.json
+++ b/meta/translations/es.json
@@ -257,7 +257,7 @@
 		"asia-2023-24": "asia-2023-24",
 		"thank-you" : "thank-you",
 		"jr-stamp-rally": "jr-stamp-rally",
-		"grey-star": "grey-star"
+		"grey-star": "estrella gris"
 	},
 	"variantSubtype": {
 		"shadowless": "sin sombra",

--- a/meta/translations/fr.json
+++ b/meta/translations/fr.json
@@ -254,7 +254,8 @@
 		"worlds-2024": "worlds-2024",
 		"worlds-2023": "worlds-2023",
 		"asia-2023-24": "asia-2023-24",
-		"thank-you" : "thank-you"
+		"thank-you" : "thank-you",
+		"jr-stamp-rally": "jr-stamp-rally"
 	},
 	"variantSubtype": {
 		"shadowless": "sans ombre",
@@ -275,6 +276,7 @@
 		"no-e-reader": "Sans e-Reader",
 		"rarity-error": "Erreur de rareté",
 		"cosmos": "cosmos",
-		"blue border": "bordure bleue"
+		"blue border": "bordure bleue",
+		"glossy": "brillante"
 	}
 }

--- a/meta/translations/fr.json
+++ b/meta/translations/fr.json
@@ -256,7 +256,7 @@
 		"asia-2023-24": "asia-2023-24",
 		"thank-you" : "thank-you",
 		"jr-stamp-rally": "jr-stamp-rally",
-		"grey-star": "grey-star"
+		"grey-star": "étoile grise"
 	},
 	"variantSubtype": {
 		"shadowless": "sans ombre",

--- a/meta/translations/fr.json
+++ b/meta/translations/fr.json
@@ -255,7 +255,8 @@
 		"worlds-2023": "worlds-2023",
 		"asia-2023-24": "asia-2023-24",
 		"thank-you" : "thank-you",
-		"jr-stamp-rally": "jr-stamp-rally"
+		"jr-stamp-rally": "jr-stamp-rally",
+		"grey-star": "grey-star"
 	},
 	"variantSubtype": {
 		"shadowless": "sans ombre",

--- a/meta/translations/it.json
+++ b/meta/translations/it.json
@@ -256,7 +256,8 @@
 		"worlds-2023": "worlds-2023",
 		"asia-2023-24": "asia-2023-24",
 		"thank-you" : "thank-you",
-		"jr-stamp-rally": "jr-stamp-rally"
+		"jr-stamp-rally": "jr-stamp-rally",
+		"grey-star": "grey-star"
 	},
 	"variantSubtype": {
 		"shadowless": "senza ombra",

--- a/meta/translations/it.json
+++ b/meta/translations/it.json
@@ -255,7 +255,8 @@
 		"worlds-2024": "worlds-2024",
 		"worlds-2023": "worlds-2023",
 		"asia-2023-24": "asia-2023-24",
-		"thank-you" : "thank-you"
+		"thank-you" : "thank-you",
+		"jr-stamp-rally": "jr-stamp-rally"
 	},
 	"variantSubtype": {
 		"shadowless": "senza ombra",
@@ -275,6 +276,7 @@
 		"japanese-back": "Retro giapponese",
 		"no-e-reader": "Senza e-Reader",
 		"rarity-error": "Errore rarità",
-		"cosmos": "cosmos"
+		"cosmos": "cosmos",
+		"glossy": "patinato"
 	}
 }

--- a/meta/translations/pt.json
+++ b/meta/translations/pt.json
@@ -254,7 +254,8 @@
 		"worlds-2024": "worlds-2024",
 		"worlds-2023": "worlds-2023",
 		"asia-2023-24": "asia-2023-24",
-		"thank-you" : "thank-you"
+		"thank-you" : "thank-you",
+		"jr-stamp-rally": "jr-stamp-rally"
 	},
 	"variantSubtype": {
 		"shadowless": "sem sombra",
@@ -274,6 +275,7 @@
 		"japanese-back": "Verso japonês",
 		"no-e-reader": "Sem e-Reader",
 		"rarity-error": "Erro de raridade",
-		"cosmos": "cosmos"
+		"cosmos": "cosmos",
+		"glossy": "lustrosa"
 	}
 }

--- a/meta/translations/pt.json
+++ b/meta/translations/pt.json
@@ -255,7 +255,8 @@
 		"worlds-2023": "worlds-2023",
 		"asia-2023-24": "asia-2023-24",
 		"thank-you" : "thank-you",
-		"jr-stamp-rally": "jr-stamp-rally"
+		"jr-stamp-rally": "jr-stamp-rally",
+		"grey-star": "grey-star"
 	},
 	"variantSubtype": {
 		"shadowless": "sem sombra",

--- a/meta/translations/pt.json
+++ b/meta/translations/pt.json
@@ -256,7 +256,7 @@
 		"asia-2023-24": "asia-2023-24",
 		"thank-you" : "thank-you",
 		"jr-stamp-rally": "jr-stamp-rally",
-		"grey-star": "grey-star"
+		"grey-star": "estrela cinza"
 	},
 	"variantSubtype": {
 		"shadowless": "sem sombra",


### PR DESCRIPTION
closes # N/A

## Changes

- add tcgplayerids to all cards in basep set

## Details

- add the thirdParty pricing model for all cards in the basep set

