### PR TITLE
fix: point Brilliant Stars Trainer Gallery cards at their own set

### DIFF
--- a/data/Sword & Shield/Brilliant Stars Trainer Gallery/TG01.ts
+++ b/data/Sword & Shield/Brilliant Stars Trainer Gallery/TG01.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Brilliant Stars"
+import Set from "../Brilliant Stars Trainer Gallery"
 
 const card: Card = {
 	dexId: [136],

--- a/data/Sword & Shield/Brilliant Stars Trainer Gallery/TG02.ts
+++ b/data/Sword & Shield/Brilliant Stars Trainer Gallery/TG02.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Brilliant Stars"
+import Set from "../Brilliant Stars Trainer Gallery"
 
 const card: Card = {
 	dexId: [134],

--- a/data/Sword & Shield/Brilliant Stars Trainer Gallery/TG03.ts
+++ b/data/Sword & Shield/Brilliant Stars Trainer Gallery/TG03.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Brilliant Stars"
+import Set from "../Brilliant Stars Trainer Gallery"
 
 const card: Card = {
 	dexId: [224],

--- a/data/Sword & Shield/Brilliant Stars Trainer Gallery/TG04.ts
+++ b/data/Sword & Shield/Brilliant Stars Trainer Gallery/TG04.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Brilliant Stars"
+import Set from "../Brilliant Stars Trainer Gallery"
 
 const card: Card = {
 	dexId: [135],

--- a/data/Sword & Shield/Brilliant Stars Trainer Gallery/TG05.ts
+++ b/data/Sword & Shield/Brilliant Stars Trainer Gallery/TG05.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Brilliant Stars"
+import Set from "../Brilliant Stars Trainer Gallery"
 
 const card: Card = {
 	dexId: [644],

--- a/data/Sword & Shield/Brilliant Stars Trainer Gallery/TG06.ts
+++ b/data/Sword & Shield/Brilliant Stars Trainer Gallery/TG06.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Brilliant Stars"
+import Set from "../Brilliant Stars Trainer Gallery"
 
 const card: Card = {
 	dexId: [477],

--- a/data/Sword & Shield/Brilliant Stars Trainer Gallery/TG07.ts
+++ b/data/Sword & Shield/Brilliant Stars Trainer Gallery/TG07.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Brilliant Stars"
+import Set from "../Brilliant Stars Trainer Gallery"
 
 const card: Card = {
 	dexId: [702],

--- a/data/Sword & Shield/Brilliant Stars Trainer Gallery/TG08.ts
+++ b/data/Sword & Shield/Brilliant Stars Trainer Gallery/TG08.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Brilliant Stars"
+import Set from "../Brilliant Stars Trainer Gallery"
 
 const card: Card = {
 	dexId: [869],

--- a/data/Sword & Shield/Brilliant Stars Trainer Gallery/TG09.ts
+++ b/data/Sword & Shield/Brilliant Stars Trainer Gallery/TG09.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Brilliant Stars"
+import Set from "../Brilliant Stars Trainer Gallery"
 
 const card: Card = {
 	dexId: [168],

--- a/data/Sword & Shield/Brilliant Stars Trainer Gallery/TG10.ts
+++ b/data/Sword & Shield/Brilliant Stars Trainer Gallery/TG10.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Brilliant Stars"
+import Set from "../Brilliant Stars Trainer Gallery"
 
 const card: Card = {
 	dexId: [229],

--- a/data/Sword & Shield/Brilliant Stars Trainer Gallery/TG11.ts
+++ b/data/Sword & Shield/Brilliant Stars Trainer Gallery/TG11.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Brilliant Stars"
+import Set from "../Brilliant Stars Trainer Gallery"
 
 const card: Card = {
 	dexId: [133],

--- a/data/Sword & Shield/Brilliant Stars Trainer Gallery/TG12.ts
+++ b/data/Sword & Shield/Brilliant Stars Trainer Gallery/TG12.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Brilliant Stars"
+import Set from "../Brilliant Stars Trainer Gallery"
 
 const card: Card = {
 	dexId: [765],

--- a/data/Sword & Shield/Brilliant Stars Trainer Gallery/TG13.ts
+++ b/data/Sword & Shield/Brilliant Stars Trainer Gallery/TG13.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Brilliant Stars"
+import Set from "../Brilliant Stars Trainer Gallery"
 
 const card: Card = {
 	dexId: [836],

--- a/data/Sword & Shield/Brilliant Stars Trainer Gallery/TG14.ts
+++ b/data/Sword & Shield/Brilliant Stars Trainer Gallery/TG14.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Brilliant Stars"
+import Set from "../Brilliant Stars Trainer Gallery"
 
 const card: Card = {
 	dexId: [700],

--- a/data/Sword & Shield/Brilliant Stars Trainer Gallery/TG15.ts
+++ b/data/Sword & Shield/Brilliant Stars Trainer Gallery/TG15.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Brilliant Stars"
+import Set from "../Brilliant Stars Trainer Gallery"
 
 const card: Card = {
 	dexId: [700],

--- a/data/Sword & Shield/Brilliant Stars Trainer Gallery/TG16.ts
+++ b/data/Sword & Shield/Brilliant Stars Trainer Gallery/TG16.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Brilliant Stars"
+import Set from "../Brilliant Stars Trainer Gallery"
 
 const card: Card = {
 	dexId: [778],

--- a/data/Sword & Shield/Brilliant Stars Trainer Gallery/TG17.ts
+++ b/data/Sword & Shield/Brilliant Stars Trainer Gallery/TG17.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Brilliant Stars"
+import Set from "../Brilliant Stars Trainer Gallery"
 
 const card: Card = {
 	dexId: [778],

--- a/data/Sword & Shield/Brilliant Stars Trainer Gallery/TG18.ts
+++ b/data/Sword & Shield/Brilliant Stars Trainer Gallery/TG18.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Brilliant Stars"
+import Set from "../Brilliant Stars Trainer Gallery"
 
 const card: Card = {
 	dexId: [892],

--- a/data/Sword & Shield/Brilliant Stars Trainer Gallery/TG19.ts
+++ b/data/Sword & Shield/Brilliant Stars Trainer Gallery/TG19.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Brilliant Stars"
+import Set from "../Brilliant Stars Trainer Gallery"
 
 const card: Card = {
 	dexId: [892],

--- a/data/Sword & Shield/Brilliant Stars Trainer Gallery/TG20.ts
+++ b/data/Sword & Shield/Brilliant Stars Trainer Gallery/TG20.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Brilliant Stars"
+import Set from "../Brilliant Stars Trainer Gallery"
 
 const card: Card = {
 	dexId: [892],

--- a/data/Sword & Shield/Brilliant Stars Trainer Gallery/TG21.ts
+++ b/data/Sword & Shield/Brilliant Stars Trainer Gallery/TG21.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Brilliant Stars"
+import Set from "../Brilliant Stars Trainer Gallery"
 
 const card: Card = {
 	dexId: [892],

--- a/data/Sword & Shield/Brilliant Stars Trainer Gallery/TG22.ts
+++ b/data/Sword & Shield/Brilliant Stars Trainer Gallery/TG22.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Brilliant Stars"
+import Set from "../Brilliant Stars Trainer Gallery"
 
 const card: Card = {
 	dexId: [197],

--- a/data/Sword & Shield/Brilliant Stars Trainer Gallery/TG23.ts
+++ b/data/Sword & Shield/Brilliant Stars Trainer Gallery/TG23.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Brilliant Stars"
+import Set from "../Brilliant Stars Trainer Gallery"
 
 const card: Card = {
 	dexId: [197],

--- a/data/Sword & Shield/Brilliant Stars Trainer Gallery/TG24.ts
+++ b/data/Sword & Shield/Brilliant Stars Trainer Gallery/TG24.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Brilliant Stars"
+import Set from "../Brilliant Stars Trainer Gallery"
 
 const card: Card = {
 	set: Set,

--- a/data/Sword & Shield/Brilliant Stars Trainer Gallery/TG25.ts
+++ b/data/Sword & Shield/Brilliant Stars Trainer Gallery/TG25.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Brilliant Stars"
+import Set from "../Brilliant Stars Trainer Gallery"
 
 const card: Card = {
 	set: Set,

--- a/data/Sword & Shield/Brilliant Stars Trainer Gallery/TG26.ts
+++ b/data/Sword & Shield/Brilliant Stars Trainer Gallery/TG26.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Brilliant Stars"
+import Set from "../Brilliant Stars Trainer Gallery"
 
 const card: Card = {
 	set: Set,

--- a/data/Sword & Shield/Brilliant Stars Trainer Gallery/TG27.ts
+++ b/data/Sword & Shield/Brilliant Stars Trainer Gallery/TG27.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Brilliant Stars"
+import Set from "../Brilliant Stars Trainer Gallery"
 
 const card: Card = {
 	set: Set,

--- a/data/Sword & Shield/Brilliant Stars Trainer Gallery/TG28.ts
+++ b/data/Sword & Shield/Brilliant Stars Trainer Gallery/TG28.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Brilliant Stars"
+import Set from "../Brilliant Stars Trainer Gallery"
 
 const card: Card = {
 	set: Set,

--- a/data/Sword & Shield/Brilliant Stars Trainer Gallery/TG29.ts
+++ b/data/Sword & Shield/Brilliant Stars Trainer Gallery/TG29.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Brilliant Stars"
+import Set from "../Brilliant Stars Trainer Gallery"
 
 const card: Card = {
 	dexId: [892],

--- a/data/Sword & Shield/Brilliant Stars Trainer Gallery/TG30.ts
+++ b/data/Sword & Shield/Brilliant Stars Trainer Gallery/TG30.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Brilliant Stars"
+import Set from "../Brilliant Stars Trainer Gallery"
 
 const card: Card = {
 	dexId: [892],


### PR DESCRIPTION
## Changes

Updates the `Set` import in the 30 Brilliant Stars Trainer Gallery card files from `../Brilliant Stars` to `../Brilliant Stars Trainer Gallery`.

## Details

#1693 moved the TG cards into their own set (`swsh9.5tg`) but kept the card files importing the parent set. The compiled output therefore lists the Trainer Gallery cards with their old `swsh9-TG*` IDs (visible on `/v2/en/sets/swsh9.5tg`), while `swsh9` no longer contains them.