### PR TITLE
(data): Astral Radiance variants & Pricing, TG Split to own set

### DIFF
--- a/data/Sword & Shield/Astral Radiance Trainer Gallery.ts
+++ b/data/Sword & Shield/Astral Radiance Trainer Gallery.ts
@@ -1,0 +1,30 @@
+import { Set } from '../../interfaces'
+import serie from '../Sword & Shield'
+
+const swsh105tg: Set = {
+	id: "swsh10.5tg",
+
+	name: {
+		en: "Astral Radiance Trainer Gallery",
+		fr: "Astres Radieux Galerie de Dresseurs",
+		es: "Resplandor Astral Galería de Entrenador",
+		it: "Lucentezza Siderale Galleria Allenatori",
+		de: "Astralglanz Trainer-Galerie",
+		pt: "Estrelas Radiantes Galeria de Treinador"
+	},
+
+	tcgOnline: 'ASR',
+	serie: serie,
+
+	cardCount: {
+		official: 30
+	},
+
+	releaseDate: "2022-05-27",
+
+	abbreviations: {
+		official: "ASR:TG"
+	}
+}
+
+export default swsh105tg

--- a/data/Sword & Shield/Astral Radiance Trainer Gallery/TG01.ts
+++ b/data/Sword & Shield/Astral Radiance Trainer Gallery/TG01.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Astral Radiance"
+import Set from "../Astral Radiance Trainer Gallery"
 
 const card: Card = {
 	dexId: [460],
@@ -77,20 +77,20 @@ const card: Card = {
 	retreat: 3,
 	regulationMark: "E",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
 	description: {
 		en: "The Pokémon is known to bring blizzards. A shake of its massive body is enough to cause whiteout conditions.",
 	},
 
-	thirdParty: {
-		cardmarket: 658878
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 658878,
+				tcgplayer: 272472
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance Trainer Gallery/TG02.ts
+++ b/data/Sword & Shield/Astral Radiance Trainer Gallery/TG02.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Astral Radiance"
+import Set from "../Astral Radiance Trainer Gallery"
 
 const card: Card = {
 	dexId: [841],
@@ -86,20 +86,20 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "D",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
 	description: {
 		en: "It ate a sour apple, and that induced its evolution. In its cheeks, it stores an acid capable of causing chemical burns.",
 	},
 
-	thirdParty: {
-		cardmarket: 658879
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 658879,
+				tcgplayer: 272473
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance Trainer Gallery/TG03.ts
+++ b/data/Sword & Shield/Astral Radiance Trainer Gallery/TG03.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Astral Radiance"
+import Set from "../Astral Radiance Trainer Gallery"
 
 const card: Card = {
 	dexId: [230],
@@ -86,20 +86,20 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "E",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
 	description: {
 		en: "It stores energy by sleeping at underwater depths at which no other life forms can survive.",
 	},
 
-	thirdParty: {
-		cardmarket: 658880
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 658880,
+				tcgplayer: 272474
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance Trainer Gallery/TG04.ts
+++ b/data/Sword & Shield/Astral Radiance Trainer Gallery/TG04.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Astral Radiance"
+import Set from "../Astral Radiance Trainer Gallery"
 
 const card: Card = {
 	dexId: [873],
@@ -77,20 +77,20 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "D",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
 	description: {
 		en: "It shows no mercy to any who desecrate fields and mountains. It will fly around on its icy wings, causing a blizzard to chase offenders away.",
 	},
 
-	thirdParty: {
-		cardmarket: 658881
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 658881,
+				tcgplayer: 272475
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance Trainer Gallery/TG05.ts
+++ b/data/Sword & Shield/Astral Radiance Trainer Gallery/TG05.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Astral Radiance"
+import Set from "../Astral Radiance Trainer Gallery"
 
 const card: Card = {
 	dexId: [282],
@@ -86,20 +86,20 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "E",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
 	description: {
 		en: "To protect its Trainer, it will expend all its psychic power to create a small black hole.",
 	},
 
-	thirdParty: {
-		cardmarket: 658882
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 658882,
+				tcgplayer: 272476
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance Trainer Gallery/TG06.ts
+++ b/data/Sword & Shield/Astral Radiance Trainer Gallery/TG06.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Astral Radiance"
+import Set from "../Astral Radiance Trainer Gallery"
 
 const card: Card = {
 	dexId: [899],
@@ -92,20 +92,20 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "F",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
 	description: {
 		en: "The black orbs shine with an uncanny light when the Pokémon is erecting invisible barriers. The fur shed from its beard retains heat well and is a highly useful material for winter clothing.",
 	},
 
-	thirdParty: {
-		cardmarket: 658651
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 658883,
+				tcgplayer: 272477
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance Trainer Gallery/TG07.ts
+++ b/data/Sword & Shield/Astral Radiance Trainer Gallery/TG07.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Astral Radiance"
+import Set from "../Astral Radiance Trainer Gallery"
 
 const card: Card = {
 	dexId: [870],
@@ -54,20 +54,20 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "E",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
 	description: {
 		en: "The six of them work together as one Pokémon. Teamwork is also their battle strategy, and they constantly change their formation as they fight.",
 	},
 
-	thirdParty: {
-		cardmarket: 658884
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 658884,
+				tcgplayer: 272478
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance Trainer Gallery/TG08.ts
+++ b/data/Sword & Shield/Astral Radiance Trainer Gallery/TG08.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Astral Radiance"
+import Set from "../Astral Radiance Trainer Gallery"
 
 const card: Card = {
 	dexId: [900],
@@ -84,20 +84,20 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "F",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
 	description: {
 		en: "A violent creature that fells towering trees with its crude axes and shields itself with hard stone. If one should chance upon this Pokémon in the wilds, one's only recourse is to flee.",
 	},
 
-	thirdParty: {
-		cardmarket: 658702
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 658885,
+				tcgplayer: 272479
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance Trainer Gallery/TG09.ts
+++ b/data/Sword & Shield/Astral Radiance Trainer Gallery/TG09.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Astral Radiance"
+import Set from "../Astral Radiance Trainer Gallery"
 
 const card: Card = {
 	dexId: [262],
@@ -86,20 +86,20 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "F",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
 	description: {
 		en: "It chases down prey in a pack of around ten. They defeat foes with perfectly coordinated teamwork.",
 	},
 
-	thirdParty: {
-		cardmarket: 658740
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 658886,
+				tcgplayer: 272480
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance Trainer Gallery/TG10.ts
+++ b/data/Sword & Shield/Astral Radiance Trainer Gallery/TG10.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Astral Radiance"
+import Set from "../Astral Radiance Trainer Gallery"
 
 const card: Card = {
 	dexId: [862],
@@ -86,20 +86,20 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "D",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
 	description: {
 		en: "It evolved after experiencing numerous fights. While crossing its arms, it lets out a shout that would make any opponent flinch.",
 	},
 
-	thirdParty: {
-		cardmarket: 658887
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 658887,
+				tcgplayer: 272481
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance Trainer Gallery/TG11.ts
+++ b/data/Sword & Shield/Astral Radiance Trainer Gallery/TG11.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Astral Radiance"
+import Set from "../Astral Radiance Trainer Gallery"
 
 const card: Card = {
 	dexId: [437],
@@ -83,20 +83,20 @@ const card: Card = {
 	retreat: 3,
 	regulationMark: "E",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
 	description: {
 		en: "Many scientists suspect that this Pokémon originated outside the Galar region, based on the patterns on its body.",
 	},
 
-	thirdParty: {
-		cardmarket: 658773
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 658888,
+				tcgplayer: 272482
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance Trainer Gallery/TG12.ts
+++ b/data/Sword & Shield/Astral Radiance Trainer Gallery/TG12.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Astral Radiance"
+import Set from "../Astral Radiance Trainer Gallery"
 
 const card: Card = {
 	dexId: [163],
@@ -73,20 +73,20 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "F",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
 	description: {
 		en: "It always stands on one foot. It changes feet so fast, the movement can rarely be seen.",
 	},
 
-	thirdParty: {
-		cardmarket: 658781
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 658889,
+				tcgplayer: 272483
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance Trainer Gallery/TG13.ts
+++ b/data/Sword & Shield/Astral Radiance Trainer Gallery/TG13.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Astral Radiance"
+import Set from "../Astral Radiance Trainer Gallery"
 
 const card: Card = {
 	dexId: [121],
@@ -77,16 +77,16 @@ const card: Card = {
 	retreat: 0,
 	regulationMark: "F",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 658536
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 658890,
+				tcgplayer: 272484
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance Trainer Gallery/TG14.ts
+++ b/data/Sword & Shield/Astral Radiance Trainer Gallery/TG14.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Astral Radiance"
+import Set from "../Astral Radiance Trainer Gallery"
 
 const card: Card = {
 	dexId: [898],
@@ -68,16 +68,16 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "E",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 658891
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 658891,
+				tcgplayer: 272485
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance Trainer Gallery/TG15.ts
+++ b/data/Sword & Shield/Astral Radiance Trainer Gallery/TG15.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Astral Radiance"
+import Set from "../Astral Radiance Trainer Gallery"
 
 const card: Card = {
 	dexId: [898],
@@ -14,8 +14,8 @@ const card: Card = {
 		de: "Schimmelreiter-Coronospa VMAX"
 	},
 
-	illustrator: "5ban Graphics",
-	rarity: "Secret Rare",
+	illustrator: "Hitoshi Ariga",
+	rarity: "Ultra Rare",
 	category: "Pokemon",
 	hp: 320,
 	types: ["Water"],
@@ -86,16 +86,16 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "E",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 658892
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 658892,
+				tcgplayer: 272486
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance Trainer Gallery/TG16.ts
+++ b/data/Sword & Shield/Astral Radiance Trainer Gallery/TG16.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Astral Radiance"
+import Set from "../Astral Radiance Trainer Gallery"
 
 const card: Card = {
 	dexId: [144],
@@ -83,16 +83,16 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "E",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 658893
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 658893,
+				tcgplayer: 272487
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance Trainer Gallery/TG17.ts
+++ b/data/Sword & Shield/Astral Radiance Trainer Gallery/TG17.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Astral Radiance"
+import Set from "../Astral Radiance Trainer Gallery"
 
 const card: Card = {
 	dexId: [898],
@@ -81,16 +81,16 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "E",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 658894
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 658894,
+				tcgplayer: 272488
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance Trainer Gallery/TG18.ts
+++ b/data/Sword & Shield/Astral Radiance Trainer Gallery/TG18.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Astral Radiance"
+import Set from "../Astral Radiance Trainer Gallery"
 
 const card: Card = {
 	dexId: [898],
@@ -92,16 +92,16 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "E",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 658895
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 658895,
+				tcgplayer: 272489
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance Trainer Gallery/TG19.ts
+++ b/data/Sword & Shield/Astral Radiance Trainer Gallery/TG19.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Astral Radiance"
+import Set from "../Astral Radiance Trainer Gallery"
 
 const card: Card = {
 	dexId: [145],
@@ -77,16 +77,16 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "E",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 658896
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 658896,
+				tcgplayer: 272491
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance Trainer Gallery/TG20.ts
+++ b/data/Sword & Shield/Astral Radiance Trainer Gallery/TG20.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Astral Radiance"
+import Set from "../Astral Radiance Trainer Gallery"
 
 const card: Card = {
 	dexId: [146],
@@ -77,16 +77,16 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "E",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 658897
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 658897,
+				tcgplayer: 272492
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance Trainer Gallery/TG21.ts
+++ b/data/Sword & Shield/Astral Radiance Trainer Gallery/TG21.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Astral Radiance"
+import Set from "../Astral Radiance Trainer Gallery"
 
 const card: Card = {
 	dexId: [888],
@@ -83,16 +83,16 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "D",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 658898
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 658898,
+				tcgplayer: 272493
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance Trainer Gallery/TG22.ts
+++ b/data/Sword & Shield/Astral Radiance Trainer Gallery/TG22.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Astral Radiance"
+import Set from "../Astral Radiance Trainer Gallery"
 
 const card: Card = {
 	dexId: [889],
@@ -83,16 +83,16 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "D",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 658899
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 658899,
+				tcgplayer: 272494
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance Trainer Gallery/TG23.ts
+++ b/data/Sword & Shield/Astral Radiance Trainer Gallery/TG23.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Astral Radiance"
+import Set from "../Astral Radiance Trainer Gallery"
 
 const card: Card = {
 	dexId: [445],
@@ -60,16 +60,16 @@ const card: Card = {
 	retreat: 0,
 	regulationMark: "F",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 658778
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 658900,
+				tcgplayer: 272495
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance Trainer Gallery/TG24.ts
+++ b/data/Sword & Shield/Astral Radiance Trainer Gallery/TG24.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Astral Radiance"
+import Set from "../Astral Radiance Trainer Gallery"
 
 const card: Card = {
 	set: Set,
@@ -29,16 +29,16 @@ const card: Card = {
 	trainerType: "Supporter",
 	regulationMark: "D",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 658901
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 658901,
+				tcgplayer: 272496
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance Trainer Gallery/TG25.ts
+++ b/data/Sword & Shield/Astral Radiance Trainer Gallery/TG25.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Astral Radiance"
+import Set from "../Astral Radiance Trainer Gallery"
 
 const card: Card = {
 	set: Set,
@@ -29,16 +29,16 @@ const card: Card = {
 	trainerType: "Supporter",
 	regulationMark: "D",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 658902
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 658902,
+				tcgplayer: 272497
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance Trainer Gallery/TG26.ts
+++ b/data/Sword & Shield/Astral Radiance Trainer Gallery/TG26.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Astral Radiance"
+import Set from "../Astral Radiance Trainer Gallery"
 
 const card: Card = {
 	set: Set,
@@ -29,16 +29,16 @@ const card: Card = {
 	trainerType: "Supporter",
 	regulationMark: "E",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 658903
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 658903,
+				tcgplayer: 272498
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance Trainer Gallery/TG27.ts
+++ b/data/Sword & Shield/Astral Radiance Trainer Gallery/TG27.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Astral Radiance"
+import Set from "../Astral Radiance Trainer Gallery"
 
 const card: Card = {
 	set: Set,
@@ -29,16 +29,16 @@ const card: Card = {
 	trainerType: "Supporter",
 	regulationMark: "D",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 658904
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 658904,
+				tcgplayer: 272499
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance Trainer Gallery/TG28.ts
+++ b/data/Sword & Shield/Astral Radiance Trainer Gallery/TG28.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Astral Radiance"
+import Set from "../Astral Radiance Trainer Gallery"
 
 const card: Card = {
 	set: Set,
@@ -29,16 +29,16 @@ const card: Card = {
 	trainerType: "Supporter",
 	regulationMark: "D",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 658905
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 658905,
+				tcgplayer: 272500
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance Trainer Gallery/TG29.ts
+++ b/data/Sword & Shield/Astral Radiance Trainer Gallery/TG29.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Astral Radiance"
+import Set from "../Astral Radiance Trainer Gallery"
 
 const card: Card = {
 	dexId: [898],
@@ -14,8 +14,8 @@ const card: Card = {
 		de: "Schimmelreiter-Coronospa VMAX"
 	},
 
-	illustrator: "Hitoshi Ariga",
-	rarity: "Ultra Rare",
+	illustrator: "5ban Graphics",
+	rarity: "Secret Rare",
 	category: "Pokemon",
 	hp: 320,
 	types: ["Water"],
@@ -86,16 +86,22 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "E",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 658892
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				tcgplayer: 272501
+			}
+		},
+		{
+			type: 'holo',
+			foil: 'gold',
+			thirdParty: {
+				cardmarket: 658906
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance Trainer Gallery/TG30.ts
+++ b/data/Sword & Shield/Astral Radiance Trainer Gallery/TG30.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Astral Radiance"
+import Set from "../Astral Radiance Trainer Gallery"
 
 const card: Card = {
 	dexId: [898],
@@ -92,16 +92,22 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "E",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 658895
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				tcgplayer: 272502
+			}
+		},
+		{
+			type: 'holo',
+			foil: 'gold',
+			thirdParty: {
+				cardmarket: 658907
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance/001.ts
+++ b/data/Sword & Shield/Astral Radiance/001.ts
@@ -75,17 +75,16 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "F",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 658485,
-		tcgplayer: 272201
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 658485,
+				tcgplayer: 272201
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance/002.ts
+++ b/data/Sword & Shield/Astral Radiance/002.ts
@@ -63,21 +63,27 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "F",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	description: {
 		en: "An enigmatic Pokémon that happens to bear a resemblance to a Poké Ball. When excited, it discharges the electric current it has stored in its belly, then lets out a great, uproarious laugh.",
 	},
 
-	thirdParty: {
-		cardmarket: 658487,
-		tcgplayer: 272202
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 658487,
+				tcgplayer: 272202
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 658487,
+				tcgplayer: 272202
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance/003.ts
+++ b/data/Sword & Shield/Astral Radiance/003.ts
@@ -71,21 +71,27 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "F",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	description: {
 		en: "The tissue on the surface of its body is curiously similar in composition to an Apricorn. When irritated, this Pokémon lets loose an electric current equal to 20 lightning bolts.",
 	},
 
-	thirdParty: {
-		cardmarket: 658489,
-		tcgplayer: 272203
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 658489,
+				tcgplayer: 272203
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 658489,
+				tcgplayer: 272203
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance/004.ts
+++ b/data/Sword & Shield/Astral Radiance/004.ts
@@ -45,21 +45,27 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "F",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	description: {
 		en: "The large, wickedly sharp scythes on its forearms are truly fearsome weapons. Prey's attempts to flee are unfailingly thwarted by this Pokémon's nimble motions.",
 	},
 
-	thirdParty: {
-		cardmarket: 658491,
-		tcgplayer: 272204
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 658491,
+				tcgplayer: 272204
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 658491,
+				tcgplayer: 272204
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance/005.ts
+++ b/data/Sword & Shield/Astral Radiance/005.ts
@@ -54,21 +54,27 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "F",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	description: {
 		en: "The large, wickedly sharp scythes on its forearms are truly fearsome weapons. Prey's attempts to flee are unfailingly thwarted by this Pokémon's nimble motions.",
 	},
 
-	thirdParty: {
-		cardmarket: 658491,
-		tcgplayer: 272205
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 658493,
+				tcgplayer: 272205
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 658493,
+				tcgplayer: 272205
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance/006.ts
+++ b/data/Sword & Shield/Astral Radiance/006.ts
@@ -45,21 +45,27 @@ const card: Card = {
 	retreat: 0,
 	regulationMark: "F",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	description: {
 		en: "Its frail wings are so thin that one can see clear through them. However, during flight these wings exhibit the power to churn air with force enough to launch a house skyward.",
 	},
 
-	thirdParty: {
-		cardmarket: 658494,
-		tcgplayer: 272206
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 658494,
+				tcgplayer: 272206
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 658494,
+				tcgplayer: 272206
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance/007.ts
+++ b/data/Sword & Shield/Astral Radiance/007.ts
@@ -77,21 +77,27 @@ const card: Card = {
 	retreat: 0,
 	regulationMark: "F",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	description: {
 		en: "This six-legged Pokémon is easily capable of transporting an adult in flight. The wings on its tail help it stay balanced.",
 	},
 
-	thirdParty: {
-		cardmarket: 658498,
-		tcgplayer: 272207
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 658498,
+				tcgplayer: 272207
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 658498,
+				tcgplayer: 272207
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance/008.ts
+++ b/data/Sword & Shield/Astral Radiance/008.ts
@@ -67,21 +67,27 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "F",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	description: {
 		en: "This Pokémon has an unparalleled horn. Heracross itself demonstrates tremendous power—it's capable of throwing several people trained in the traditional arts of war at once.",
 	},
 
-	thirdParty: {
-		cardmarket: 658499,
-		tcgplayer: 272208
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 658499,
+				tcgplayer: 272208
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 658499,
+				tcgplayer: 272208
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance/009.ts
+++ b/data/Sword & Shield/Astral Radiance/009.ts
@@ -54,21 +54,27 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "F",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	description: {
 		en: "When its antennae hit each other, it sounds like the music of a xylophone.",
 	},
 
-	thirdParty: {
-		cardmarket: 658500,
-		tcgplayer: 272209
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 658500,
+				tcgplayer: 272209
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 658500,
+				tcgplayer: 272209
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance/010.ts
+++ b/data/Sword & Shield/Astral Radiance/010.ts
@@ -77,21 +77,27 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "F",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	description: {
 		en: "It uses its cutlass-like arms to produce sound, the melody of which varies from individual to individual. It is a worthwhile endeavor to seek out one's favorite tunes.",
 	},
 
-	thirdParty: {
-		cardmarket: 658502,
-		tcgplayer: 272210
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 658502,
+				tcgplayer: 272210
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 658502,
+				tcgplayer: 272210
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance/011.ts
+++ b/data/Sword & Shield/Astral Radiance/011.ts
@@ -65,21 +65,27 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "F",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	description: {
 		en: "The members of the trio spend all their time together. Each one has a slightly different taste in nectar.",
 	},
 
-	thirdParty: {
-		cardmarket: 658503,
-		tcgplayer: 272211
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 658503,
+				tcgplayer: 272211
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 658503,
+				tcgplayer: 272211
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance/012.ts
+++ b/data/Sword & Shield/Astral Radiance/012.ts
@@ -77,21 +77,27 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "F",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	description: {
 		en: "It skillfully commands its grubs in battles with its enemies. The grubs are willing to risk their lives to defend Vespiquen.",
 	},
 
-	thirdParty: {
-		cardmarket: 658504,
-		tcgplayer: 272212
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 658504,
+				tcgplayer: 272212
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 658504,
+				tcgplayer: 272212
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance/013.ts
+++ b/data/Sword & Shield/Astral Radiance/013.ts
@@ -84,21 +84,27 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "F",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	description: {
 		en: "Cells similar to those of plants have been found in its fur. Its hard tail can fell a large tree with one stroke, and the tail's sharpness exceeds even that of a sword crafted by a master.",
 	},
 
-	thirdParty: {
-		cardmarket: 658506,
-		tcgplayer: 272213
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 658506,
+				tcgplayer: 272213
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 658506,
+				tcgplayer: 272213
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance/014.ts
+++ b/data/Sword & Shield/Astral Radiance/014.ts
@@ -65,21 +65,27 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "F",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	description: {
 		en: "When the turning of seasons brings the cruel winter to its end and the joyous people give thanks to the heavens, Shaymin appears and covers the withered land with flowers.",
 	},
 
-	thirdParty: {
-		cardmarket: 658507,
-		tcgplayer: 272214
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 658507,
+				tcgplayer: 272214
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 658507,
+				tcgplayer: 272214
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance/015.ts
+++ b/data/Sword & Shield/Astral Radiance/015.ts
@@ -54,21 +54,27 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "F",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	description: {
 		en: "The leaves on its head are highly valued for medicinal purposes. Dry the leaves in the sun, boil them, and then drink the bitter decoction for remarkably effective relief from fatigue.",
 	},
 
-	thirdParty: {
-		cardmarket: 658509,
-		tcgplayer: 272215
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 658509,
+				tcgplayer: 272215
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 658509,
+				tcgplayer: 272215
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance/016.ts
+++ b/data/Sword & Shield/Astral Radiance/016.ts
@@ -75,21 +75,27 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "F",
 
-	variants: {
-		normal: false,
-		reverse: true,
-		holo: true,
-		firstEdition: false
-	},
 
 	description: {
 		en: "I suspect that its well-developed legs are the result of a life spent on mountains covered in deep snow. The scent it exudes from its flower crown heartens those in proximity.",
 	},
 
-	thirdParty: {
-		cardmarket: 658510,
-		tcgplayer: 272216
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 658510,
+				tcgplayer: 272216
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 658510,
+				tcgplayer: 272216
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance/017.ts
+++ b/data/Sword & Shield/Astral Radiance/017.ts
@@ -64,17 +64,16 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "F",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 658511,
-		tcgplayer: 272217
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 658511,
+				tcgplayer: 272217
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance/018.ts
+++ b/data/Sword & Shield/Astral Radiance/018.ts
@@ -65,17 +65,16 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "F",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 658514,
-		tcgplayer: 272218
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 658514,
+				tcgplayer: 272218
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance/019.ts
+++ b/data/Sword & Shield/Astral Radiance/019.ts
@@ -54,21 +54,27 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "F",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	description: {
 		en: "Flies noiselessly on delicate wings. It has mastered the art of deftly launching dagger-sharp feathers from those same wings.",
 	},
 
-	thirdParty: {
-		cardmarket: 658516,
-		tcgplayer: 272219
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 658516,
+				tcgplayer: 272219
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 658516,
+				tcgplayer: 272219
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance/020.ts
+++ b/data/Sword & Shield/Astral Radiance/020.ts
@@ -68,21 +68,27 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "F",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	description: {
 		en: "Regularly basks in sunlight to gather power—presumably due to the frigid climate. Nonetheless, the edges of the blade quills set into its wings are keen as ever.",
 	},
 
-	thirdParty: {
-		cardmarket: 658517,
-		tcgplayer: 272220
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 658517,
+				tcgplayer: 272220
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 658517,
+				tcgplayer: 272220
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance/021.ts
+++ b/data/Sword & Shield/Astral Radiance/021.ts
@@ -45,21 +45,27 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "F",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	description: {
 		en: "These Pokémon live in herds out in the grassland. Newborn foals lack their fiery manes, which will develop about an hour after birth.",
 	},
 
-	thirdParty: {
-		cardmarket: 658519,
-		tcgplayer: 272221
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 658519,
+				tcgplayer: 272221
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 658519,
+				tcgplayer: 272221
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance/022.ts
+++ b/data/Sword & Shield/Astral Radiance/022.ts
@@ -77,21 +77,27 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "F",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	description: {
 		en: "This Pokémon can be seen galloping through fields at speeds of up to 150 mph, its fiery mane fluttering in the wind.",
 	},
 
-	thirdParty: {
-		cardmarket: 658521,
-		tcgplayer: 272222
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 658521,
+				tcgplayer: 272222
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 658521,
+				tcgplayer: 272222
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance/023.ts
+++ b/data/Sword & Shield/Astral Radiance/023.ts
@@ -65,21 +65,27 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "F",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	description: {
 		en: "Hails from the Johto region. Though usually curled into a ball due to its timid disposition, it harbors tremendous firepower.",
 	},
 
-	thirdParty: {
-		cardmarket: 658523,
-		tcgplayer: 272223
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 658523,
+				tcgplayer: 272223
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 658523,
+				tcgplayer: 272223
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance/024.ts
+++ b/data/Sword & Shield/Astral Radiance/024.ts
@@ -68,21 +68,27 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "F",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	description: {
 		en: "This creature's fur is most mysterious—it is wholly impervious to the burning touch of flame. Should Quilava turn its back to you, take heed! Such a posture indicates a forthcoming attack.",
 	},
 
-	thirdParty: {
-		cardmarket: 658526,
-		tcgplayer: 272224
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 658526,
+				tcgplayer: 272224
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 658526,
+				tcgplayer: 272224
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance/025.ts
+++ b/data/Sword & Shield/Astral Radiance/025.ts
@@ -77,17 +77,16 @@ const card: Card = {
 	retreat: 3,
 	regulationMark: "F",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 658528,
-		tcgplayer: 272225
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 658528,
+				tcgplayer: 272225
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance/026.ts
+++ b/data/Sword & Shield/Astral Radiance/026.ts
@@ -86,17 +86,16 @@ const card: Card = {
 	retreat: 4,
 	regulationMark: "F",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 658529,
-		tcgplayer: 272226
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 658529,
+				tcgplayer: 272226
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance/027.ts
+++ b/data/Sword & Shield/Astral Radiance/027.ts
@@ -54,21 +54,20 @@ const card: Card = {
 	retreat: 3,
 	regulationMark: "F",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
 	description: {
 		en: "Boiling blood, like magma, circulates through its body. It makes its dwelling place in volcanic caves.",
 	},
 
-	thirdParty: {
-		cardmarket: 658531,
-		tcgplayer: 272227
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 658531,
+				tcgplayer: 272227
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance/028.ts
+++ b/data/Sword & Shield/Astral Radiance/028.ts
@@ -65,21 +65,27 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "F",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	description: {
 		en: "Suffers perpetual headaches. If the agony grows too great, Psyduck's latent power erupts, contrary to Psyduck's intent. Ergo, I am exploring ways to ease the pain.",
 	},
 
-	thirdParty: {
-		cardmarket: 658533,
-		tcgplayer: 272228
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 658533,
+				tcgplayer: 272228
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 658533,
+				tcgplayer: 272228
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance/029.ts
+++ b/data/Sword & Shield/Astral Radiance/029.ts
@@ -75,21 +75,27 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "F",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	description: {
 		en: "This Pokémon lives in gently flowing rivers. It paddles through the water with its long limbs, putting its graceful swimming skills on display.",
 	},
 
-	thirdParty: {
-		cardmarket: 658534,
-		tcgplayer: 272229
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 658534,
+				tcgplayer: 272229
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 658534,
+				tcgplayer: 272229
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance/030.ts
+++ b/data/Sword & Shield/Astral Radiance/030.ts
@@ -77,17 +77,16 @@ const card: Card = {
 	retreat: 0,
 	regulationMark: "F",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 658536,
-		tcgplayer: 272230
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 658536,
+				tcgplayer: 272230
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance/031.ts
+++ b/data/Sword & Shield/Astral Radiance/031.ts
@@ -67,21 +67,27 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "F",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	description: {
 		en: "Swinub excels at sniffing out mushrooms buried beneath grass or snow. Since ancient times, the people of Hisui have often relied upon this skill.",
 	},
 
-	thirdParty: {
-		cardmarket: 658538,
-		tcgplayer: 272231
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 658538,
+				tcgplayer: 272231
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 658538,
+				tcgplayer: 272231
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance/032.ts
+++ b/data/Sword & Shield/Astral Radiance/032.ts
@@ -77,21 +77,27 @@ const card: Card = {
 	retreat: 3,
 	regulationMark: "F",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	description: {
 		en: "If it charges at an enemy, the hairs on its back stand up straight. It is very sensitive to sound.",
 	},
 
-	thirdParty: {
-		cardmarket: 658540,
-		tcgplayer: 272232
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 658540,
+				tcgplayer: 272232
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 658540,
+				tcgplayer: 272232
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance/033.ts
+++ b/data/Sword & Shield/Astral Radiance/033.ts
@@ -86,21 +86,27 @@ const card: Card = {
 	retreat: 4,
 	regulationMark: "F",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	description: {
 		en: "This Pokémon can be spotted in wall paintings from as far back as 10,000 years ago. For a while, it was thought to have gone extinct.",
 	},
 
-	thirdParty: {
-		cardmarket: 658541,
-		tcgplayer: 272233
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 658541,
+				tcgplayer: 272233
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 658541,
+				tcgplayer: 272233
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance/034.ts
+++ b/data/Sword & Shield/Astral Radiance/034.ts
@@ -65,21 +65,27 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "F",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	description: {
 		en: "This calm and gentle Pokémon swims gracefully through the sea. After building speed, it can leap out of the water. It is often misidentified as a bird Pokémon due to this behavior.",
 	},
 
-	thirdParty: {
-		cardmarket: 658542,
-		tcgplayer: 272234
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 658542,
+				tcgplayer: 272234
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 658542,
+				tcgplayer: 272234
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance/035.ts
+++ b/data/Sword & Shield/Astral Radiance/035.ts
@@ -45,21 +45,27 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "F",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	description: {
 		en: "Makes its home in swamps with murky water. The poor visibility hides this Pokémon from predators, and the slime on its body makes grasping it difficult.",
 	},
 
-	thirdParty: {
-		cardmarket: 658543,
-		tcgplayer: 272235
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 658543,
+				tcgplayer: 272235
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 658543,
+				tcgplayer: 272235
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance/036.ts
+++ b/data/Sword & Shield/Astral Radiance/036.ts
@@ -77,21 +77,27 @@ const card: Card = {
 	retreat: 3,
 	regulationMark: "F",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	description: {
 		en: "It makes its nest at the bottom of swamps. It will eat anything—if it is alive, Whiscash will eat it.",
 	},
 
-	thirdParty: {
-		cardmarket: 658544,
-		tcgplayer: 272236
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 658544,
+				tcgplayer: 272236
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 658544,
+				tcgplayer: 272236
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance/037.ts
+++ b/data/Sword & Shield/Astral Radiance/037.ts
@@ -74,21 +74,27 @@ const card: Card = {
 	retreat: 3,
 	regulationMark: "F",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	description: {
 		en: "With cold air that can reach temperatures as low as −328 degrees Fahrenheit, Regice instantly freezes any creature that approaches it.",
 	},
 
-	thirdParty: {
-		cardmarket: 658545,
-		tcgplayer: 272237
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 658545,
+				tcgplayer: 272237
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 658545,
+				tcgplayer: 272237
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance/038.ts
+++ b/data/Sword & Shield/Astral Radiance/038.ts
@@ -77,21 +77,27 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "F",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	description: {
 		en: "Glaceon is able to lower its body temperature very quickly. It freezes the atmosphere, creating diamond dust that glitters like gems while it flutters and dances around.",
 	},
 
-	thirdParty: {
-		cardmarket: 658546,
-		tcgplayer: 272238
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 658546,
+				tcgplayer: 272238
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 658546,
+				tcgplayer: 272238
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance/039.ts
+++ b/data/Sword & Shield/Astral Radiance/039.ts
@@ -75,17 +75,16 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "F",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 658551,
-		tcgplayer: 272239
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 658551,
+				tcgplayer: 272239
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance/040.ts
+++ b/data/Sword & Shield/Astral Radiance/040.ts
@@ -65,17 +65,16 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "F",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 658560,
-		tcgplayer: 272240
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 658560,
+				tcgplayer: 272240
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance/041.ts
+++ b/data/Sword & Shield/Astral Radiance/041.ts
@@ -45,21 +45,27 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "F",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	description: {
 		en: "This Pokémon from the Unova region uses the shell on its belly as a weapon to cut down its foes. Thus, I've conferred upon this shell the name \"scalchop.\".",
 	},
 
-	thirdParty: {
-		cardmarket: 658578,
-		tcgplayer: 272241
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 658578,
+				tcgplayer: 272241
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 658578,
+				tcgplayer: 272241
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance/042.ts
+++ b/data/Sword & Shield/Astral Radiance/042.ts
@@ -64,21 +64,27 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "F",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	description: {
 		en: "Its exquisite double-scalchop technique is likely the result of daily training, and it can send even masters of the blade fleeing in defeat.",
 	},
 
-	thirdParty: {
-		cardmarket: 658580,
-		tcgplayer: 272242
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 658580,
+				tcgplayer: 272242
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 658580,
+				tcgplayer: 272242
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance/043.ts
+++ b/data/Sword & Shield/Astral Radiance/043.ts
@@ -63,21 +63,27 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "F",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	description: {
 		en: "Though it differs from other Basculin in several respects, including demeanor—this one is gentle—I have categorized it as a regional form given the vast array of shared qualities.",
 	},
 
-	thirdParty: {
-		cardmarket: 658582,
-		tcgplayer: 272243
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 658582,
+				tcgplayer: 272243
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 658582,
+				tcgplayer: 272243
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance/044.ts
+++ b/data/Sword & Shield/Astral Radiance/044.ts
@@ -77,21 +77,27 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "F",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	description: {
 		en: "Clads itself in the souls of comrades that perished before fulfilling their goals of journeying upstream. No other species throughout all Hisui's rivers is Basculegion's equal.",
 	},
 
-	thirdParty: {
-		cardmarket: 658583,
-		tcgplayer: 272244
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 658583,
+				tcgplayer: 272244
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 658583,
+				tcgplayer: 272244
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance/045.ts
+++ b/data/Sword & Shield/Astral Radiance/045.ts
@@ -67,21 +67,27 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "F",
 
-	variants: {
-		normal: false,
-		reverse: true,
-		holo: true,
-		firstEdition: false
-	},
 
 	description: {
 		en: "When it is resolute, its body fills with power and it becomes swifter. Its jumps are then too fast to follow.",
 	},
 
-	thirdParty: {
-		cardmarket: 658584,
-		tcgplayer: 272245
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 658584,
+				tcgplayer: 272245
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 658584,
+				tcgplayer: 272245
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance/046.ts
+++ b/data/Sword & Shield/Astral Radiance/046.ts
@@ -74,21 +74,20 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "F",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
 	description: {
 		en: "It appears and vanishes with a ninja's grace. It toys with its enemies using swift movements, while slicing them with throwing stars of sharpest water.",
 	},
 
-	thirdParty: {
-		cardmarket: 658586,
-		tcgplayer: 272246
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 658586,
+				tcgplayer: 272246
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance/047.ts
+++ b/data/Sword & Shield/Astral Radiance/047.ts
@@ -45,21 +45,27 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "F",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	description: {
 		en: "Lives on mountains blanketed in perennial snow. It freezes water vapor in the air to make the ice helmet that it dons for defense.",
 	},
 
-	thirdParty: {
-		cardmarket: 658588,
-		tcgplayer: 272247
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 658588,
+				tcgplayer: 272247
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 658588,
+				tcgplayer: 272247
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance/048.ts
+++ b/data/Sword & Shield/Astral Radiance/048.ts
@@ -86,21 +86,27 @@ const card: Card = {
 	retreat: 3,
 	regulationMark: "F",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	description: {
 		en: "The armor of ice covering its lower jaw puts steel to shame and can shatter rocks with ease. This Pokémon barrels along steep mountain paths, cleaving through the deep snow.",
 	},
 
-	thirdParty: {
-		cardmarket: 658589,
-		tcgplayer: 272248
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 658589,
+				tcgplayer: 272248
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 658589,
+				tcgplayer: 272248
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance/049.ts
+++ b/data/Sword & Shield/Astral Radiance/049.ts
@@ -75,17 +75,16 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "E",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 658590,
-		tcgplayer: 272249
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 658590,
+				tcgplayer: 272249
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance/050.ts
+++ b/data/Sword & Shield/Astral Radiance/050.ts
@@ -77,17 +77,16 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "F",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 658597,
-		tcgplayer: 272250
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 658597,
+				tcgplayer: 272250
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance/051.ts
+++ b/data/Sword & Shield/Astral Radiance/051.ts
@@ -72,21 +72,27 @@ const card: Card = {
 	retreat: 3,
 	regulationMark: "F",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	description: {
 		en: "This Pokémon is a cluster of electrical energy. It's said that removing the rings on Regieleki's body will unleash the Pokémon's latent power.",
 	},
 
-	thirdParty: {
-		cardmarket: 658600,
-		tcgplayer: 272252
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 658600,
+				tcgplayer: 272252
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 658600,
+				tcgplayer: 272252
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance/052.ts
+++ b/data/Sword & Shield/Astral Radiance/052.ts
@@ -92,21 +92,34 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "F",
 
-	variants: {
-		normal: false,
-		reverse: true,
-		holo: true,
-		firstEdition: false
-	},
 
 	description: {
 		en: "Said to purify lost, forsaken souls with its flames and guide them to the afterlife. I believe its form has been influenced by the energy of the sacred mountain towering at Hisui's center.",
 	},
 
-	thirdParty: {
-		cardmarket: 658603,
-		tcgplayer: 272253
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 658603,
+				tcgplayer: 272253
+			}
+		},
+		{
+			type: 'holo',
+			stamp: ['set-logo'],
+			thirdParty: {
+				cardmarket: 660427
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 658603,
+				tcgplayer: 272253
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance/053.ts
+++ b/data/Sword & Shield/Astral Radiance/053.ts
@@ -79,17 +79,16 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "F",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 658612,
-		tcgplayer: 272254
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 658612,
+				tcgplayer: 272254
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance/054.ts
+++ b/data/Sword & Shield/Astral Radiance/054.ts
@@ -91,17 +91,16 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "F",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 658615,
-		tcgplayer: 272255
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 658615,
+				tcgplayer: 272255
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance/055.ts
+++ b/data/Sword & Shield/Astral Radiance/055.ts
@@ -67,21 +67,27 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "F",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	description: {
 		en: "This ovate creature is frequently mistaken for a moving egg when encountered out in the fields or in the mountains. Its guileless smile soothes the soul.",
 	},
 
-	thirdParty: {
-		cardmarket: 658617,
-		tcgplayer: 272256
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 658617,
+				tcgplayer: 272256
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 658617,
+				tcgplayer: 272256
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance/056.ts
+++ b/data/Sword & Shield/Astral Radiance/056.ts
@@ -77,21 +77,27 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "F",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	description: {
 		en: "They say that it will appear before kindhearted, caring people and shower them with happiness.",
 	},
 
-	thirdParty: {
-		cardmarket: 658621,
-		tcgplayer: 272257
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 658621,
+				tcgplayer: 272257
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 658621,
+				tcgplayer: 272257
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance/057.ts
+++ b/data/Sword & Shield/Astral Radiance/057.ts
@@ -77,21 +77,27 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "F",
 
-	variants: {
-		normal: false,
-		reverse: true,
-		holo: true,
-		firstEdition: false
-	},
 
 	description: {
 		en: "These Pokémon are never seen anywhere near conflict or turmoil. In recent times, they've hardly been seen at all.",
 	},
 
-	thirdParty: {
-		cardmarket: 658623,
-		tcgplayer: 272258
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 658623,
+				tcgplayer: 272258
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 658623,
+				tcgplayer: 272258
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance/058.ts
+++ b/data/Sword & Shield/Astral Radiance/058.ts
@@ -51,21 +51,27 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "F",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	description: {
 		en: "It conceals itself in darkness, sending chills up travelers' spines with its childlike weeping. As it observes the frightened travelers with glee, the red orbs upon its chest let off an eerie light.",
 	},
 
-	thirdParty: {
-		cardmarket: 658625,
-		tcgplayer: 272259
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 658625,
+				tcgplayer: 272259
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 658625,
+				tcgplayer: 272259
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance/059.ts
+++ b/data/Sword & Shield/Astral Radiance/059.ts
@@ -90,21 +90,27 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "F",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	description: {
 		en: "Its muttered curses can cause awful headaches or terrifying visions that torment others.",
 	},
 
-	thirdParty: {
-		cardmarket: 658627,
-		tcgplayer: 272260
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 658627,
+				tcgplayer: 272260
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 658627,
+				tcgplayer: 272260
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance/060.ts
+++ b/data/Sword & Shield/Astral Radiance/060.ts
@@ -60,21 +60,27 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "F",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	description: {
 		en: "Tends to prefer people with a chipper disposition to those who are gloomy, but it has shown no discrimination with regard to age or gender. Needs more research.",
 	},
 
-	thirdParty: {
-		cardmarket: 658630,
-		tcgplayer: 272261
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 658630,
+				tcgplayer: 272261
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 658630,
+				tcgplayer: 272261
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance/061.ts
+++ b/data/Sword & Shield/Astral Radiance/061.ts
@@ -70,21 +70,27 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "F",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	description: {
 		en: "If its Trainer becomes happy, it overflows with energy, dancing joyously while spinning about.",
 	},
 
-	thirdParty: {
-		cardmarket: 658634,
-		tcgplayer: 272262
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 658634,
+				tcgplayer: 272262
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 658634,
+				tcgplayer: 272262
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance/062.ts
+++ b/data/Sword & Shield/Astral Radiance/062.ts
@@ -92,21 +92,27 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "F",
 
-	variants: {
-		normal: false,
-		reverse: true,
-		holo: true,
-		firstEdition: false
-	},
 
 	description: {
 		en: "True to its honorable-warrior image, it uses the blades on its elbows only in defense of something or someone.",
 	},
 
-	thirdParty: {
-		cardmarket: 658636,
-		tcgplayer: 272263
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 658636,
+				tcgplayer: 272263
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 658636,
+				tcgplayer: 272263
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance/063.ts
+++ b/data/Sword & Shield/Astral Radiance/063.ts
@@ -60,21 +60,27 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "F",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	description: {
 		en: "Said to lure away young children and carry them off to the afterlife. Some whisper that Drifloon are formed of reincarnated human souls, but these rumors are as yet unconfirmed.",
 	},
 
-	thirdParty: {
-		cardmarket: 658637,
-		tcgplayer: 272264
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 658637,
+				tcgplayer: 272264
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 658637,
+				tcgplayer: 272264
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance/064.ts
+++ b/data/Sword & Shield/Astral Radiance/064.ts
@@ -70,21 +70,27 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "F",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	description: {
 		en: "Some say this Pokémon is a collection of souls burdened with regrets, silently drifting through the dusk.",
 	},
 
-	thirdParty: {
-		cardmarket: 658639,
-		tcgplayer: 272265
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 658639,
+				tcgplayer: 272265
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 658639,
+				tcgplayer: 272265
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance/065.ts
+++ b/data/Sword & Shield/Astral Radiance/065.ts
@@ -71,21 +71,27 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "F",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	description: {
 		en: "It is said that its emergence gave humans the intelligence to improve their quality of life.",
 	},
 
-	thirdParty: {
-		cardmarket: 658641,
-		tcgplayer: 272266
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 658641,
+				tcgplayer: 272266
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 658641,
+				tcgplayer: 272266
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance/066.ts
+++ b/data/Sword & Shield/Astral Radiance/066.ts
@@ -73,21 +73,27 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "F",
 
-	variants: {
-		normal: false,
-		reverse: true,
-		holo: true,
-		firstEdition: false
-	},
 
 	description: {
 		en: "It sleeps at the bottom of a lake. Its spirit is said to leave its body to fly on the lake's surface.",
 	},
 
-	thirdParty: {
-		cardmarket: 658643,
-		tcgplayer: 272267
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 658643,
+				tcgplayer: 272267
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 658643,
+				tcgplayer: 272267
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance/067.ts
+++ b/data/Sword & Shield/Astral Radiance/067.ts
@@ -60,21 +60,27 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "F",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	description: {
 		en: "It is thought that Uxie, Mesprit, and Azelf all came from the same egg.",
 	},
 
-	thirdParty: {
-		cardmarket: 658645,
-		tcgplayer: 272268
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 658645,
+				tcgplayer: 272268
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 658645,
+				tcgplayer: 272268
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance/068.ts
+++ b/data/Sword & Shield/Astral Radiance/068.ts
@@ -76,21 +76,27 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "F",
 
-	variants: {
-		normal: false,
-		reverse: true,
-		holo: true,
-		firstEdition: false
-	},
 
 	description: {
 		en: "It can instantly create many diamonds by compressing the carbon in the air between its hands.",
 	},
 
-	thirdParty: {
-		cardmarket: 658647,
-		tcgplayer: 272269
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 658647,
+				tcgplayer: 272269
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 658647,
+				tcgplayer: 272269
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance/069.ts
+++ b/data/Sword & Shield/Astral Radiance/069.ts
@@ -92,21 +92,27 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "F",
 
-	variants: {
-		normal: false,
-		reverse: true,
-		holo: true,
-		firstEdition: false
-	},
 
 	description: {
 		en: "The black orbs shine with an uncanny light when the Pokémon is erecting invisible barriers. The fur shed from its beard retains heat well and is a highly useful material for winter clothing.",
 	},
 
-	thirdParty: {
-		cardmarket: 658651,
-		tcgplayer: 272270
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 658651,
+				tcgplayer: 272270
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 658651,
+				tcgplayer: 272270
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance/070.ts
+++ b/data/Sword & Shield/Astral Radiance/070.ts
@@ -63,21 +63,27 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "F",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	description: {
 		en: "They patrol their territory in pairs. I believe the igneous rock components in the fur of this species are the result of volcanic activity in its habitat.",
 	},
 
-	thirdParty: {
-		cardmarket: 658659,
-		tcgplayer: 272271
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 658659,
+				tcgplayer: 272271
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 658659,
+				tcgplayer: 272271
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance/071.ts
+++ b/data/Sword & Shield/Astral Radiance/071.ts
@@ -77,21 +77,27 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "F",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	description: {
 		en: "Snaps at its foes with fangs cloaked in blazing flame. Despite its bulk, it deftly feints every which way, leading opponents on a deceptively merry chase as it all but dances around them.",
 	},
 
-	thirdParty: {
-		cardmarket: 658660,
-		tcgplayer: 272272
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 658660,
+				tcgplayer: 272272
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 658660,
+				tcgplayer: 272272
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance/072.ts
+++ b/data/Sword & Shield/Astral Radiance/072.ts
@@ -68,17 +68,16 @@ const card: Card = {
 	retreat: 3,
 	regulationMark: "F",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 658662,
-		tcgplayer: 272273
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 658662,
+				tcgplayer: 272273
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance/073.ts
+++ b/data/Sword & Shield/Astral Radiance/073.ts
@@ -86,17 +86,16 @@ const card: Card = {
 	retreat: 3,
 	regulationMark: "F",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 658665,
-		tcgplayer: 272274
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 658665,
+				tcgplayer: 272274
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance/074.ts
+++ b/data/Sword & Shield/Astral Radiance/074.ts
@@ -76,21 +76,27 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "F",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	description: {
 		en: "Though it pretends to be a tree, it fails to fool even children. To the touch, its body feels more like rock than tree bark. Sudowoodo's extreme aversion to water merits special note.",
 	},
 
-	thirdParty: {
-		cardmarket: 658669,
-		tcgplayer: 272275
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 658669,
+				tcgplayer: 272275
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 658669,
+				tcgplayer: 272275
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance/075.ts
+++ b/data/Sword & Shield/Astral Radiance/075.ts
@@ -74,21 +74,27 @@ const card: Card = {
 	retreat: 3,
 	regulationMark: "F",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	description: {
 		en: "Every bit of Regirock's body is made of stone. As parts of its body erode, this Pokémon sticks rocks to itself to repair what's been lost.",
 	},
 
-	thirdParty: {
-		cardmarket: 658671,
-		tcgplayer: 272276
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 658671,
+				tcgplayer: 272276
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 658671,
+				tcgplayer: 272276
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance/076.ts
+++ b/data/Sword & Shield/Astral Radiance/076.ts
@@ -77,21 +77,27 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "F",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	description: {
 		en: "Its hard skull is its distinguishing feature. It snapped trees by headbutting them, and then it fed on their ripe berries.",
 	},
 
-	thirdParty: {
-		cardmarket: 658674,
-		tcgplayer: 272277
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 658674,
+				tcgplayer: 272277
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 658674,
+				tcgplayer: 272277
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance/077.ts
+++ b/data/Sword & Shield/Astral Radiance/077.ts
@@ -77,21 +77,27 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "F",
 
-	variants: {
-		normal: false,
-		reverse: true,
-		holo: true,
-		firstEdition: false
-	},
 
 	description: {
 		en: "This ancient Pokémon used headbutts skillfully. Its brain was really small, so some theories suggest that its stupidity led to its extinction.",
 	},
 
-	thirdParty: {
-		cardmarket: 658675,
-		tcgplayer: 272278
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 658675,
+				tcgplayer: 272278
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 658675,
+				tcgplayer: 272278
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance/078.ts
+++ b/data/Sword & Shield/Astral Radiance/078.ts
@@ -68,17 +68,16 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "F",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 658683,
-		tcgplayer: 272279
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 658683,
+				tcgplayer: 272279
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance/079.ts
+++ b/data/Sword & Shield/Astral Radiance/079.ts
@@ -58,21 +58,27 @@ const card: Card = {
 	retreat: 4,
 	regulationMark: "F",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	description: {
 		en: "Though large and languid, Hippopotas is difficult to detect due to its tendency to burrow into and lurk beneath the soil. When agitated or excited, it expels sand from its nostrils.",
 	},
 
-	thirdParty: {
-		cardmarket: 658686,
-		tcgplayer: 272280
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 658686,
+				tcgplayer: 272280
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 658686,
+				tcgplayer: 272280
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance/080.ts
+++ b/data/Sword & Shield/Astral Radiance/080.ts
@@ -77,21 +77,27 @@ const card: Card = {
 	retreat: 4,
 	regulationMark: "F",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	description: {
 		en: "Stones can get stuck in the ports on their bodies. Dwebble help dislodge such stones, so Hippowdon look after these Pokémon.",
 	},
 
-	thirdParty: {
-		cardmarket: 658688,
-		tcgplayer: 272281
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 658688,
+				tcgplayer: 272281
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 658688,
+				tcgplayer: 272281
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance/081.ts
+++ b/data/Sword & Shield/Astral Radiance/081.ts
@@ -67,21 +67,20 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "F",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
 	description: {
 		en: "It drives its opponents to exhaustion with its agile maneuvers, then ends the fight with a flashy finishing move.",
 	},
 
-	thirdParty: {
-		cardmarket: 658690,
-		tcgplayer: 272282
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 658690,
+				tcgplayer: 272282
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance/082.ts
+++ b/data/Sword & Shield/Astral Radiance/082.ts
@@ -82,21 +82,27 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "F",
 
-	variants: {
-		normal: false,
-		reverse: true,
-		holo: true,
-		firstEdition: false
-	},
 
 	description: {
 		en: "The air stored inside the rachises of Decidueye's feathers insulates the Pokémon against Hisui's extreme cold. This is firm proof that evolution can be influenced by environment.",
 	},
 
-	thirdParty: {
-		cardmarket: 658692,
-		tcgplayer: 272283
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 658692,
+				tcgplayer: 272283
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 658692,
+				tcgplayer: 272283
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance/083.ts
+++ b/data/Sword & Shield/Astral Radiance/083.ts
@@ -75,17 +75,16 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "F",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 658694,
-		tcgplayer: 272284
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 658694,
+				tcgplayer: 272284
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance/084.ts
+++ b/data/Sword & Shield/Astral Radiance/084.ts
@@ -65,17 +65,23 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "F",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 658696,
-		tcgplayer: 272285
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 658696,
+				tcgplayer: 272285
+			}
+		},
+		{
+			type: 'holo',
+			stamp: ['set-logo'],
+			thirdParty: {
+				cardmarket: 664803
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance/085.ts
+++ b/data/Sword & Shield/Astral Radiance/085.ts
@@ -86,21 +86,27 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "F",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	description: {
 		en: "A violent creature that fells towering trees with its crude axes and shields itself with hard stone. If one should chance upon this Pokémon in the wilds, one's only recourse is to flee.",
 	},
 
-	thirdParty: {
-		cardmarket: 658702,
-		tcgplayer: 272286
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 658702,
+				tcgplayer: 272286
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 658702,
+				tcgplayer: 272286
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance/086.ts
+++ b/data/Sword & Shield/Astral Radiance/086.ts
@@ -84,21 +84,27 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "F",
 
-	variants: {
-		normal: false,
-		reverse: true,
-		holo: true,
-		firstEdition: false
-	},
 
 	description: {
 		en: "A violent creature that fells towering trees with its crude axes and shields itself with hard stone. If one should chance upon this Pokémon in the wilds, one's only recourse is to flee.",
 	},
 
-	thirdParty: {
-		cardmarket: 658702,
-		tcgplayer: 272287
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 658703,
+				tcgplayer: 272287
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 658703,
+				tcgplayer: 272287
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance/087.ts
+++ b/data/Sword & Shield/Astral Radiance/087.ts
@@ -68,17 +68,16 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "F",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 658707,
-		tcgplayer: 272288
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 658707,
+				tcgplayer: 272288
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance/088.ts
+++ b/data/Sword & Shield/Astral Radiance/088.ts
@@ -58,21 +58,27 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "F",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	description: {
 		en: "Fishers detest this troublesome Pokémon because it sprays poison from its spines, getting it everywhere. A different form of Qwilfish lives in other regions.",
 	},
 
-	thirdParty: {
-		cardmarket: 658709,
-		tcgplayer: 272289
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 658709,
+				tcgplayer: 272289
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 658709,
+				tcgplayer: 272289
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance/089.ts
+++ b/data/Sword & Shield/Astral Radiance/089.ts
@@ -52,21 +52,27 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "F",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	description: {
 		en: "Fishers detest this troublesome Pokémon because it sprays poison from its spines, getting it everywhere. A different form of Qwilfish lives in other regions.",
 	},
 
-	thirdParty: {
-		cardmarket: 658709,
-		tcgplayer: 272290
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 658710,
+				tcgplayer: 272290
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 658710,
+				tcgplayer: 272290
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance/090.ts
+++ b/data/Sword & Shield/Astral Radiance/090.ts
@@ -82,21 +82,27 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "F",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	description: {
 		en: "Its lancelike spikes and savage temperament have earned it the nickname \"sea fiend.\" It slurps up poison to nourish itself.",
 	},
 
-	thirdParty: {
-		cardmarket: 658714,
-		tcgplayer: 272291
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 658714,
+				tcgplayer: 272291
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 658714,
+				tcgplayer: 272291
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance/091.ts
+++ b/data/Sword & Shield/Astral Radiance/091.ts
@@ -77,21 +77,27 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "F",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	description: {
 		en: "Its lancelike spikes and savage temperament have earned it the nickname \"sea fiend.\" It slurps up poison to nourish itself.",
 	},
 
-	thirdParty: {
-		cardmarket: 658714,
-		tcgplayer: 272292
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 658718,
+				tcgplayer: 272292
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 658718,
+				tcgplayer: 272292
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance/092.ts
+++ b/data/Sword & Shield/Astral Radiance/092.ts
@@ -58,21 +58,27 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "F",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	description: {
 		en: "Its sturdy, curved claws are ideal for traversing precipitous cliffs. From the tips of these claws drips a venom that infiltrates the nerves of any prey caught in Sneasel's grasp.",
 	},
 
-	thirdParty: {
-		cardmarket: 658720,
-		tcgplayer: 272293
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 658720,
+				tcgplayer: 272293
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 658720,
+				tcgplayer: 272293
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance/093.ts
+++ b/data/Sword & Shield/Astral Radiance/093.ts
@@ -77,21 +77,27 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "F",
 
-	variants: {
-		normal: false,
-		reverse: true,
-		holo: true,
-		firstEdition: false
-	},
 
 	description: {
 		en: "Because of Sneasler's virulent poison and daunting physical prowess, no other species could hope to best it on the frozen highlands. Preferring solitude, this species does not form packs.",
 	},
 
-	thirdParty: {
-		cardmarket: 658725,
-		tcgplayer: 272294
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 658725,
+				tcgplayer: 272294
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 658725,
+				tcgplayer: 272294
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance/094.ts
+++ b/data/Sword & Shield/Astral Radiance/094.ts
@@ -73,17 +73,16 @@ const card: Card = {
 	retreat: 0,
 	regulationMark: "F",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 658732,
-		tcgplayer: 272295
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 658732,
+				tcgplayer: 272295
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance/095.ts
+++ b/data/Sword & Shield/Astral Radiance/095.ts
@@ -67,21 +67,27 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "F",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	description: {
 		en: "It has a very tenacious nature. Its acute sense of smell lets it chase a chosen prey without ever losing track.",
 	},
 
-	thirdParty: {
-		cardmarket: 658738,
-		tcgplayer: 272296
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 658738,
+				tcgplayer: 272296
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 658738,
+				tcgplayer: 272296
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance/096.ts
+++ b/data/Sword & Shield/Astral Radiance/096.ts
@@ -86,21 +86,27 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "F",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	description: {
 		en: "It chases down prey in a pack of around ten. They defeat foes with perfectly coordinated teamwork.",
 	},
 
-	thirdParty: {
-		cardmarket: 658740,
-		tcgplayer: 272297
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 658740,
+				tcgplayer: 272297
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 658740,
+				tcgplayer: 272297
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance/097.ts
+++ b/data/Sword & Shield/Astral Radiance/097.ts
@@ -74,21 +74,27 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "F",
 
-	variants: {
-		normal: false,
-		reverse: true,
-		holo: true,
-		firstEdition: false
-	},
 
 	description: {
 		en: "Swift as the wind, Absol races through fields and mountains. Its curved, bow-like horn is acutely sensitive to the warning signs of natural disasters.",
 	},
 
-	thirdParty: {
-		cardmarket: 658743,
-		tcgplayer: 272298
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 658743,
+				tcgplayer: 272298
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 658743,
+				tcgplayer: 272298
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance/098.ts
+++ b/data/Sword & Shield/Astral Radiance/098.ts
@@ -68,17 +68,16 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "F",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 658747,
-		tcgplayer: 272299
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 658747,
+				tcgplayer: 272299
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance/099.ts
+++ b/data/Sword & Shield/Astral Radiance/099.ts
@@ -65,17 +65,23 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "F",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 658751,
-		tcgplayer: 272300
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 658751,
+				tcgplayer: 272300
+			}
+		},
+		{
+			type: 'holo',
+			size: 'jumbo',
+			thirdParty: {
+				cardmarket: 675936
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance/100.ts
+++ b/data/Sword & Shield/Astral Radiance/100.ts
@@ -86,21 +86,27 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "F",
 
-	variants: {
-		normal: false,
-		reverse: true,
-		holo: true,
-		firstEdition: false
-	},
 
 	description: {
 		en: "Hard of heart and deft of blade, this rare form of Samurott is a product of the Pokémon's evolution in the region of Hisui. Its turbulent blows crash into foes like ceaseless pounding waves.",
 	},
 
-	thirdParty: {
-		cardmarket: 658755,
-		tcgplayer: 272301
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 658755,
+				tcgplayer: 272301
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 658755,
+				tcgplayer: 272301
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance/101.ts
+++ b/data/Sword & Shield/Astral Radiance/101.ts
@@ -75,17 +75,16 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "F",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 658758,
-		tcgplayer: 272302
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 658758,
+				tcgplayer: 272302
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance/102.ts
+++ b/data/Sword & Shield/Astral Radiance/102.ts
@@ -65,17 +65,16 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "F",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 658762,
-		tcgplayer: 272303
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 658762,
+				tcgplayer: 272303
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance/103.ts
+++ b/data/Sword & Shield/Astral Radiance/103.ts
@@ -45,21 +45,27 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "F",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	description: {
 		en: "Aided by the soft pads on its feet, it silently raids the food stores of other Pokémon. It survives off its ill-gotten gains.",
 	},
 
-	thirdParty: {
-		cardmarket: 658764,
-		tcgplayer: 272304
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 658764,
+				tcgplayer: 272304
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 658764,
+				tcgplayer: 272304
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance/104.ts
+++ b/data/Sword & Shield/Astral Radiance/104.ts
@@ -77,21 +77,27 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "F",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	description: {
 		en: "It secretly marks potential targets with a scent. By following the scent, it stalks its targets and steals from them when they least expect it.",
 	},
 
-	thirdParty: {
-		cardmarket: 658765,
-		tcgplayer: 272305
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 658765,
+				tcgplayer: 272305
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 658765,
+				tcgplayer: 272305
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance/105.ts
+++ b/data/Sword & Shield/Astral Radiance/105.ts
@@ -71,21 +71,27 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "F",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	description: {
 		en: "A bizarre Pokémon with but a single eye embedded in an iron sphere. I suspect this creature levitates due to the magnetism it emits from its arms, which resemble horseshoe-shaped magnets.",
 	},
 
-	thirdParty: {
-		cardmarket: 658766,
-		tcgplayer: 272306
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 658766,
+				tcgplayer: 272306
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 658766,
+				tcgplayer: 272306
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance/106.ts
+++ b/data/Sword & Shield/Astral Radiance/106.ts
@@ -70,21 +70,27 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "F",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	description: {
 		en: "This Pokémon is three Magnemite that have linked together. Magneton sends out powerful radio waves to study its surroundings.",
 	},
 
-	thirdParty: {
-		cardmarket: 658767,
-		tcgplayer: 272307
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 658767,
+				tcgplayer: 272307
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 658767,
+				tcgplayer: 272307
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance/107.ts
+++ b/data/Sword & Shield/Astral Radiance/107.ts
@@ -83,21 +83,27 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "F",
 
-	variants: {
-		normal: false,
-		reverse: true,
-		holo: true,
-		firstEdition: false
-	},
 
 	description: {
 		en: "Some say that Magnezone receives signals from space via the antenna on its head and that it's being controlled by some mysterious being.",
 	},
 
-	thirdParty: {
-		cardmarket: 658768,
-		tcgplayer: 272310
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 658768,
+				tcgplayer: 272310
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 658768,
+				tcgplayer: 272310
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance/108.ts
+++ b/data/Sword & Shield/Astral Radiance/108.ts
@@ -80,21 +80,27 @@ const card: Card = {
 	retreat: 3,
 	regulationMark: "F",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	description: {
 		en: "Registeel's body is made of a strange material that is flexible enough to stretch and shrink but also more durable than any metal.",
 	},
 
-	thirdParty: {
-		cardmarket: 658769,
-		tcgplayer: 272708
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 658769,
+				tcgplayer: 272708
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 658769,
+				tcgplayer: 272708
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance/109.ts
+++ b/data/Sword & Shield/Astral Radiance/109.ts
@@ -83,21 +83,27 @@ const card: Card = {
 	retreat: 3,
 	regulationMark: "F",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	description: {
 		en: "Although its fossils can be found in layers of primeval rock, nothing but its face has ever been discovered.",
 	},
 
-	thirdParty: {
-		cardmarket: 658770,
-		tcgplayer: 272324
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 658770,
+				tcgplayer: 272324
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 658770,
+				tcgplayer: 272324
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance/110.ts
+++ b/data/Sword & Shield/Astral Radiance/110.ts
@@ -92,21 +92,27 @@ const card: Card = {
 	retreat: 4,
 	regulationMark: "F",
 
-	variants: {
-		normal: false,
-		reverse: true,
-		holo: true,
-		firstEdition: false
-	},
 
 	description: {
 		en: "This Pokémon is from roughly 100 million years ago. Its terrifyingly tough face is harder than steel.",
 	},
 
-	thirdParty: {
-		cardmarket: 658771,
-		tcgplayer: 272325
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 658771,
+				tcgplayer: 272325
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 658771,
+				tcgplayer: 272325
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance/111.ts
+++ b/data/Sword & Shield/Astral Radiance/111.ts
@@ -60,21 +60,27 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "F",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	description: {
 		en: "Floats using a mysterious energy. The pattern engraved upon its back is held as sacred and can sometimes be found in imagery from ancient cemeteries and other such timeworn places.",
 	},
 
-	thirdParty: {
-		cardmarket: 658772,
-		tcgplayer: 272332
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 658772,
+				tcgplayer: 272332
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 658772,
+				tcgplayer: 272332
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance/112.ts
+++ b/data/Sword & Shield/Astral Radiance/112.ts
@@ -83,21 +83,27 @@ const card: Card = {
 	retreat: 3,
 	regulationMark: "F",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	description: {
 		en: "Some believe it to be a deity that summons rain clouds. When angered, it lets out a warning cry that rings out like the tolling of a bell.",
 	},
 
-	thirdParty: {
-		cardmarket: 658773,
-		tcgplayer: 272337
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 658773,
+				tcgplayer: 272337
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 658773,
+				tcgplayer: 272337
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance/113.ts
+++ b/data/Sword & Shield/Astral Radiance/113.ts
@@ -72,17 +72,16 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "F",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 658774,
-		tcgplayer: 272338
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 658774,
+				tcgplayer: 272338
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance/114.ts
+++ b/data/Sword & Shield/Astral Radiance/114.ts
@@ -93,17 +93,16 @@ const card: Card = {
 	retreat: 3,
 	regulationMark: "F",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 658775,
-		tcgplayer: 272339
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 658775,
+				tcgplayer: 272339
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance/115.ts
+++ b/data/Sword & Shield/Astral Radiance/115.ts
@@ -60,21 +60,27 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "F",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	description: {
 		en: "It uses river stones to maintain the cutting edges of the blades covering its body. These sharpened blades allow it to bring down opponents.",
 	},
 
-	thirdParty: {
-		cardmarket: 658776,
-		tcgplayer: 272343
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 658776,
+				tcgplayer: 272343
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 658776,
+				tcgplayer: 272343
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance/116.ts
+++ b/data/Sword & Shield/Astral Radiance/116.ts
@@ -83,21 +83,27 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "F",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	description: {
 		en: "It's accompanied by a large retinue of Pawniard. Bisharp keeps a keen eye on its minions, ensuring none of them even think of double-crossing it.",
 	},
 
-	thirdParty: {
-		cardmarket: 658777,
-		tcgplayer: 272345
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 658777,
+				tcgplayer: 272345
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 658777,
+				tcgplayer: 272345
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance/117.ts
+++ b/data/Sword & Shield/Astral Radiance/117.ts
@@ -60,17 +60,16 @@ const card: Card = {
 	retreat: 0,
 	regulationMark: "F",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 658778,
-		tcgplayer: 272346
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 658778,
+				tcgplayer: 272346
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance/118.ts
+++ b/data/Sword & Shield/Astral Radiance/118.ts
@@ -61,21 +61,27 @@ const card: Card = {
 	retreat: 3,
 	regulationMark: "F",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	description: {
 		en: "An academic theory proposes that Regidrago's arms were once the head of an ancient dragon Pokémon. The theory remains unproven.",
 	},
 
-	thirdParty: {
-		cardmarket: 658779,
-		tcgplayer: 272349
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 658779,
+				tcgplayer: 272349
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 658779,
+				tcgplayer: 272349
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance/119.ts
+++ b/data/Sword & Shield/Astral Radiance/119.ts
@@ -67,21 +67,27 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "F",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	description: {
 		en: "It has the ability to alter the composition of its body to suit its surrounding environment.",
 	},
 
-	thirdParty: {
-		cardmarket: 658780,
-		tcgplayer: 272353
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 658780,
+				tcgplayer: 272353
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 658780,
+				tcgplayer: 272353
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance/120.ts
+++ b/data/Sword & Shield/Astral Radiance/120.ts
@@ -73,21 +73,27 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "F",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	description: {
 		en: "It always stands on one foot. It changes feet so fast, the movement can rarely be seen.",
 	},
 
-	thirdParty: {
-		cardmarket: 658781,
-		tcgplayer: 272355
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 658781,
+				tcgplayer: 272355
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 658781,
+				tcgplayer: 272355
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance/121.ts
+++ b/data/Sword & Shield/Astral Radiance/121.ts
@@ -92,21 +92,27 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "F",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	description: {
 		en: "Its eyes are specially developed to enable it to see clearly even in murky darkness and minimal light.",
 	},
 
-	thirdParty: {
-		cardmarket: 658782,
-		tcgplayer: 272356
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 658782,
+				tcgplayer: 272356
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 658782,
+				tcgplayer: 272356
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance/122.ts
+++ b/data/Sword & Shield/Astral Radiance/122.ts
@@ -65,21 +65,27 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "F",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	description: {
 		en: "It licks its paws because of the sweet honey that has soaked into them. It is cunning, stealing into the nests of Combee and taking for itself the honey that the Combee have amassed.",
 	},
 
-	thirdParty: {
-		cardmarket: 658783,
-		tcgplayer: 272359
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 658783,
+				tcgplayer: 272359
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 658783,
+				tcgplayer: 272359
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance/123.ts
+++ b/data/Sword & Shield/Astral Radiance/123.ts
@@ -77,21 +77,27 @@ const card: Card = {
 	retreat: 3,
 	regulationMark: "F",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	description: {
 		en: "When the cold season arrives in Hisui, this Pokémon will wander fields and mountains alike in search of its favorite berries. Ursaring's hunger during this time makes it a ferocious danger.",
 	},
 
-	thirdParty: {
-		cardmarket: 658784,
-		tcgplayer: 272360
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 658784,
+				tcgplayer: 272360
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 658784,
+				tcgplayer: 272360
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance/124.ts
+++ b/data/Sword & Shield/Astral Radiance/124.ts
@@ -84,21 +84,27 @@ const card: Card = {
 	retreat: 4,
 	regulationMark: "F",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	description: {
 		en: "I believe it was Hisui's swampy terrain that gave Ursaluna its burly physique and newfound capacity to manipulate peat at will.",
 	},
 
-	thirdParty: {
-		cardmarket: 658785,
-		tcgplayer: 272361
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 658785,
+				tcgplayer: 272361
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 658785,
+				tcgplayer: 272361
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance/125.ts
+++ b/data/Sword & Shield/Astral Radiance/125.ts
@@ -54,21 +54,34 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "F",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	description: {
 		en: "Its strangely shaped antlers have the power to bewitch those who see them. Medicine made by grinding up the black orbs from fallen antlers is an effective treatment for insomnia.",
 	},
 
-	thirdParty: {
-		cardmarket: 658786,
-		tcgplayer: 272362
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 658786,
+				tcgplayer: 272362
+			}
+		},
+		{
+			type: 'holo',
+			stamp: ['snowflake'],
+			thirdParty: {
+				cardmarket: 740472
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 658786,
+				tcgplayer: 272362
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance/126.ts
+++ b/data/Sword & Shield/Astral Radiance/126.ts
@@ -76,21 +76,27 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "F",
 
-	variants: {
-		normal: false,
-		reverse: true,
-		holo: true,
-		firstEdition: false
-	},
 
 	description: {
 		en: "Miltank produces highly nutritious milk, so it's been supporting the lives of people and other Pokémon since ancient times.",
 	},
 
-	thirdParty: {
-		cardmarket: 658787,
-		tcgplayer: 272363
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 658787,
+				tcgplayer: 272363
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 658787,
+				tcgplayer: 272363
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance/127.ts
+++ b/data/Sword & Shield/Astral Radiance/127.ts
@@ -54,21 +54,27 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "F",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	description: {
 		en: "Bewitches humans with its helical tail and piercing gaze. Its hidden claws are quite sharp as well, making this Pokémon an exceedingly tricky opponent if antagonized.",
 	},
 
-	thirdParty: {
-		cardmarket: 658788,
-		tcgplayer: 272364
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 658788,
+				tcgplayer: 272364
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 658788,
+				tcgplayer: 272364
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance/128.ts
+++ b/data/Sword & Shield/Astral Radiance/128.ts
@@ -77,21 +77,27 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "F",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	description: {
 		en: "To make itself appear intimidatingly beefy, it tightly cinches its waist with its twin tails.",
 	},
 
-	thirdParty: {
-		cardmarket: 658789,
-		tcgplayer: 272367
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 658789,
+				tcgplayer: 272367
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 658789,
+				tcgplayer: 272367
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance/129.ts
+++ b/data/Sword & Shield/Astral Radiance/129.ts
@@ -80,21 +80,27 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "F",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	description: {
 		en: "A versatile performer skilled in the imitation of human speech. It is said that older, more experienced Chatot can even understand the meaning of the words they mimic.",
 	},
 
-	thirdParty: {
-		cardmarket: 658790,
-		tcgplayer: 272370
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 658790,
+				tcgplayer: 272370
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 658790,
+				tcgplayer: 272370
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance/130.ts
+++ b/data/Sword & Shield/Astral Radiance/130.ts
@@ -76,21 +76,27 @@ const card: Card = {
 	retreat: 4,
 	regulationMark: "F",
 
-	variants: {
-		normal: false,
-		reverse: true,
-		holo: true,
-		firstEdition: false
-	},
 
 	description: {
 		en: "There is an enduring legend that states this Pokémon towed continents with ropes.",
 	},
 
-	thirdParty: {
-		cardmarket: 658791,
-		tcgplayer: 272371
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 658791,
+				tcgplayer: 272371
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 658791,
+				tcgplayer: 272371
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance/131.ts
+++ b/data/Sword & Shield/Astral Radiance/131.ts
@@ -60,21 +60,27 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "F",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	description: {
 		en: "Its chick-like looks belie its hotheadedness. It challenges its parents at every opportunity, desperate to prove its strength.",
 	},
 
-	thirdParty: {
-		cardmarket: 658792,
-		tcgplayer: 272372
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 658792,
+				tcgplayer: 272372
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 658792,
+				tcgplayer: 272372
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance/132.ts
+++ b/data/Sword & Shield/Astral Radiance/132.ts
@@ -90,21 +90,27 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "F",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
 	description: {
 		en: "Screaming a bloodcurdling battle cry, this huge and ferocious bird Pokémon goes out on the hunt. It blasts lakes with shock waves, then scoops up any prey that float to the water's surface.",
 	},
 
-	thirdParty: {
-		cardmarket: 658793,
-		tcgplayer: 272373
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 658793,
+				tcgplayer: 272373
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 658793,
+				tcgplayer: 272373
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance/133.ts
+++ b/data/Sword & Shield/Astral Radiance/133.ts
@@ -77,17 +77,16 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "F",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 658794,
-		tcgplayer: 272375
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 658794,
+				tcgplayer: 272375
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance/134.ts
+++ b/data/Sword & Shield/Astral Radiance/134.ts
@@ -77,17 +77,16 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "F",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 658795,
-		tcgplayer: 272377
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 658795,
+				tcgplayer: 272377
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance/135.ts
+++ b/data/Sword & Shield/Astral Radiance/135.ts
@@ -29,17 +29,23 @@ const card: Card = {
 	trainerType: "Supporter",
 	regulationMark: "F",
 
-	variants: {
-		normal: false,
-		reverse: true,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 658796,
-		tcgplayer: 272387
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 658796,
+				tcgplayer: 272387
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 658796,
+				tcgplayer: 272387
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance/136.ts
+++ b/data/Sword & Shield/Astral Radiance/136.ts
@@ -29,17 +29,23 @@ const card: Card = {
 	trainerType: "Item",
 	regulationMark: "F",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 658797,
-		tcgplayer: 272388
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 658797,
+				tcgplayer: 272388
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 658797,
+				tcgplayer: 272388
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance/137.ts
+++ b/data/Sword & Shield/Astral Radiance/137.ts
@@ -29,17 +29,23 @@ const card: Card = {
 	trainerType: "Supporter",
 	regulationMark: "F",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 658798,
-		tcgplayer: 272389
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 658798,
+				tcgplayer: 272389
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 658798,
+				tcgplayer: 272389
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance/138.ts
+++ b/data/Sword & Shield/Astral Radiance/138.ts
@@ -29,17 +29,23 @@ const card: Card = {
 	trainerType: "Supporter",
 	regulationMark: "F",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 658799,
-		tcgplayer: 272390
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 658799,
+				tcgplayer: 272390
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 658799,
+				tcgplayer: 272390
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance/139.ts
+++ b/data/Sword & Shield/Astral Radiance/139.ts
@@ -28,17 +28,23 @@ const card: Card = {
 
 	trainerType: "Item",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 658800,
-		tcgplayer: 272391
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 658800,
+				tcgplayer: 272391
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 658800,
+				tcgplayer: 272391
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance/140.ts
+++ b/data/Sword & Shield/Astral Radiance/140.ts
@@ -28,17 +28,23 @@ const card: Card = {
 
 	trainerType: "Item",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 658801,
-		tcgplayer: 272392
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 658801,
+				tcgplayer: 272392
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 658801,
+				tcgplayer: 272392
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance/141.ts
+++ b/data/Sword & Shield/Astral Radiance/141.ts
@@ -29,17 +29,23 @@ const card: Card = {
 	trainerType: "Item",
 	regulationMark: "F",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 658802,
-		tcgplayer: 272393
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 658802,
+				tcgplayer: 272393
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 658802,
+				tcgplayer: 272393
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance/142.ts
+++ b/data/Sword & Shield/Astral Radiance/142.ts
@@ -29,17 +29,23 @@ const card: Card = {
 	trainerType: "Stadium",
 	regulationMark: "F",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 658803,
-		tcgplayer: 272394
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 658803,
+				tcgplayer: 272394
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 658803,
+				tcgplayer: 272394
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance/143.ts
+++ b/data/Sword & Shield/Astral Radiance/143.ts
@@ -29,17 +29,23 @@ const card: Card = {
 	trainerType: "Supporter",
 	regulationMark: "F",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 658804,
-		tcgplayer: 272395
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 658804,
+				tcgplayer: 272395
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 658804,
+				tcgplayer: 272395
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance/144.ts
+++ b/data/Sword & Shield/Astral Radiance/144.ts
@@ -29,17 +29,23 @@ const card: Card = {
 	trainerType: "Supporter",
 	regulationMark: "F",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 658805,
-		tcgplayer: 272396
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 658805,
+				tcgplayer: 272396
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 658805,
+				tcgplayer: 272396
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance/145.ts
+++ b/data/Sword & Shield/Astral Radiance/145.ts
@@ -29,17 +29,23 @@ const card: Card = {
 	trainerType: "Item",
 	regulationMark: "F",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 658806,
-		tcgplayer: 272397
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 658806,
+				tcgplayer: 272397
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 658806,
+				tcgplayer: 272397
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance/146.ts
+++ b/data/Sword & Shield/Astral Radiance/146.ts
@@ -29,17 +29,23 @@ const card: Card = {
 	trainerType: "Item",
 	regulationMark: "F",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 658807,
-		tcgplayer: 272398
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 658807,
+				tcgplayer: 272398
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 658807,
+				tcgplayer: 272398
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance/147.ts
+++ b/data/Sword & Shield/Astral Radiance/147.ts
@@ -29,17 +29,23 @@ const card: Card = {
 	trainerType: "Supporter",
 	regulationMark: "F",
 
-	variants: {
-		normal: false,
-		reverse: true,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 658808,
-		tcgplayer: 272399
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 658808,
+				tcgplayer: 272399
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 658808,
+				tcgplayer: 272399
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance/148.ts
+++ b/data/Sword & Shield/Astral Radiance/148.ts
@@ -29,17 +29,23 @@ const card: Card = {
 	trainerType: "Stadium",
 	regulationMark: "F",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 658809,
-		tcgplayer: 272400
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 658809,
+				tcgplayer: 272400
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 658809,
+				tcgplayer: 272400
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance/149.ts
+++ b/data/Sword & Shield/Astral Radiance/149.ts
@@ -29,17 +29,23 @@ const card: Card = {
 	trainerType: "Supporter",
 	regulationMark: "F",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 658810,
-		tcgplayer: 272401
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 658810,
+				tcgplayer: 272401
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 658810,
+				tcgplayer: 272401
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance/150.ts
+++ b/data/Sword & Shield/Astral Radiance/150.ts
@@ -29,17 +29,30 @@ const card: Card = {
 	trainerType: "Supporter",
 	regulationMark: "F",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 658811,
-		tcgplayer: 272402
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 658811,
+				tcgplayer: 272402
+			}
+		},
+		{
+			type: 'normal',
+			stamp: ['regional-championships'],
+			thirdParty: {
+				cardmarket: 670548
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 658811,
+				tcgplayer: 272402
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance/151.ts
+++ b/data/Sword & Shield/Astral Radiance/151.ts
@@ -29,17 +29,23 @@ const card: Card = {
 	trainerType: "Item",
 	regulationMark: "E",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 658812,
-		tcgplayer: 272403
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 658812,
+				tcgplayer: 272403
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 658812,
+				tcgplayer: 272403
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance/152.ts
+++ b/data/Sword & Shield/Astral Radiance/152.ts
@@ -29,17 +29,23 @@ const card: Card = {
 	trainerType: "Tool",
 	regulationMark: "F",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 658813,
-		tcgplayer: 272404
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 658813,
+				tcgplayer: 272404
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 658813,
+				tcgplayer: 272404
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance/153.ts
+++ b/data/Sword & Shield/Astral Radiance/153.ts
@@ -29,17 +29,23 @@ const card: Card = {
 	trainerType: "Item",
 	regulationMark: "F",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 658814,
-		tcgplayer: 272405
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 658814,
+				tcgplayer: 272405
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 658814,
+				tcgplayer: 272405
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance/154.ts
+++ b/data/Sword & Shield/Astral Radiance/154.ts
@@ -29,17 +29,23 @@ const card: Card = {
 	trainerType: "Item",
 	regulationMark: "F",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 658815,
-		tcgplayer: 272406
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 658815,
+				tcgplayer: 272406
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 658815,
+				tcgplayer: 272406
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance/155.ts
+++ b/data/Sword & Shield/Astral Radiance/155.ts
@@ -29,17 +29,23 @@ const card: Card = {
 	trainerType: "Stadium",
 	regulationMark: "F",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 658816,
-		tcgplayer: 272407
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 658816,
+				tcgplayer: 272407
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 658816,
+				tcgplayer: 272407
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance/156.ts
+++ b/data/Sword & Shield/Astral Radiance/156.ts
@@ -29,17 +29,23 @@ const card: Card = {
 	trainerType: "Item",
 	regulationMark: "F",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 658817,
-		tcgplayer: 272408
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 658817,
+				tcgplayer: 272408
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 658817,
+				tcgplayer: 272408
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance/157.ts
+++ b/data/Sword & Shield/Astral Radiance/157.ts
@@ -28,17 +28,23 @@ const card: Card = {
 
 	trainerType: "Item",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 658818,
-		tcgplayer: 272409
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 658818,
+				tcgplayer: 272409
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 658818,
+				tcgplayer: 272409
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance/158.ts
+++ b/data/Sword & Shield/Astral Radiance/158.ts
@@ -29,17 +29,23 @@ const card: Card = {
 	trainerType: "Item",
 	regulationMark: "F",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 658819,
-		tcgplayer: 272410
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 658819,
+				tcgplayer: 272410
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 658819,
+				tcgplayer: 272410
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance/159.ts
+++ b/data/Sword & Shield/Astral Radiance/159.ts
@@ -29,17 +29,23 @@ const card: Card = {
 	trainerType: "Supporter",
 	regulationMark: "F",
 
-	variants: {
-		normal: true,
-		reverse: true,
-		holo: false,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 658820,
-		tcgplayer: 272411
-	}
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 658820,
+				tcgplayer: 272411
+			}
+		},
+		{
+			type: 'reverse',
+			thirdParty: {
+				cardmarket: 658820,
+				tcgplayer: 272411
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance/160.ts
+++ b/data/Sword & Shield/Astral Radiance/160.ts
@@ -75,17 +75,16 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "F",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 658821,
-		tcgplayer: 272412
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 658821,
+				tcgplayer: 272412
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance/161.ts
+++ b/data/Sword & Shield/Astral Radiance/161.ts
@@ -75,17 +75,16 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "F",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 658822,
-		tcgplayer: 272413
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 658822,
+				tcgplayer: 272413
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance/162.ts
+++ b/data/Sword & Shield/Astral Radiance/162.ts
@@ -64,17 +64,16 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "F",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 658823,
-		tcgplayer: 272414
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 658823,
+				tcgplayer: 272414
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance/163.ts
+++ b/data/Sword & Shield/Astral Radiance/163.ts
@@ -64,17 +64,16 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "F",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 658824,
-		tcgplayer: 272415
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 658824,
+				tcgplayer: 272415
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance/164.ts
+++ b/data/Sword & Shield/Astral Radiance/164.ts
@@ -77,17 +77,16 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "F",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 658825,
-		tcgplayer: 272416
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 658825,
+				tcgplayer: 272416
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance/165.ts
+++ b/data/Sword & Shield/Astral Radiance/165.ts
@@ -77,17 +77,16 @@ const card: Card = {
 	retreat: 3,
 	regulationMark: "F",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 658826,
-		tcgplayer: 272417
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 658826,
+				tcgplayer: 272417
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance/166.ts
+++ b/data/Sword & Shield/Astral Radiance/166.ts
@@ -77,17 +77,16 @@ const card: Card = {
 	retreat: 0,
 	regulationMark: "F",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 658827,
-		tcgplayer: 272418
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 658827,
+				tcgplayer: 272418
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance/167.ts
+++ b/data/Sword & Shield/Astral Radiance/167.ts
@@ -75,17 +75,16 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "F",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 658828,
-		tcgplayer: 272419
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 658828,
+				tcgplayer: 272419
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance/168.ts
+++ b/data/Sword & Shield/Astral Radiance/168.ts
@@ -77,17 +77,16 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "F",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 658829,
-		tcgplayer: 272420
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 658829,
+				tcgplayer: 272420
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance/169.ts
+++ b/data/Sword & Shield/Astral Radiance/169.ts
@@ -79,17 +79,16 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "F",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 658830,
-		tcgplayer: 272709
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 658830,
+				tcgplayer: 272709
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance/170.ts
+++ b/data/Sword & Shield/Astral Radiance/170.ts
@@ -83,17 +83,16 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "F",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 658831,
-		tcgplayer: 272710
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 658831,
+				tcgplayer: 272710
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance/171.ts
+++ b/data/Sword & Shield/Astral Radiance/171.ts
@@ -68,17 +68,16 @@ const card: Card = {
 	retreat: 3,
 	regulationMark: "F",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 658832,
-		tcgplayer: 272421
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 658832,
+				tcgplayer: 272421
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance/172.ts
+++ b/data/Sword & Shield/Astral Radiance/172.ts
@@ -68,17 +68,16 @@ const card: Card = {
 	retreat: 3,
 	regulationMark: "F",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 658833,
-		tcgplayer: 272422
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 658833,
+				tcgplayer: 272422
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance/173.ts
+++ b/data/Sword & Shield/Astral Radiance/173.ts
@@ -75,17 +75,16 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "F",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 658834,
-		tcgplayer: 272423
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 658834,
+				tcgplayer: 272423
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance/174.ts
+++ b/data/Sword & Shield/Astral Radiance/174.ts
@@ -73,17 +73,16 @@ const card: Card = {
 	retreat: 0,
 	regulationMark: "F",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 658835,
-		tcgplayer: 272424
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 658835,
+				tcgplayer: 272424
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance/175.ts
+++ b/data/Sword & Shield/Astral Radiance/175.ts
@@ -73,17 +73,16 @@ const card: Card = {
 	retreat: 0,
 	regulationMark: "F",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 658836,
-		tcgplayer: 272425
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 658836,
+				tcgplayer: 272425
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance/176.ts
+++ b/data/Sword & Shield/Astral Radiance/176.ts
@@ -75,17 +75,16 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "F",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 658837,
-		tcgplayer: 272426
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 658837,
+				tcgplayer: 272426
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance/177.ts
+++ b/data/Sword & Shield/Astral Radiance/177.ts
@@ -72,17 +72,16 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "F",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 658838,
-		tcgplayer: 272427
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 658838,
+				tcgplayer: 272427
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance/178.ts
+++ b/data/Sword & Shield/Astral Radiance/178.ts
@@ -60,17 +60,16 @@ const card: Card = {
 	retreat: 0,
 	regulationMark: "F",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 658839,
-		tcgplayer: 272428
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 658839,
+				tcgplayer: 272428
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance/179.ts
+++ b/data/Sword & Shield/Astral Radiance/179.ts
@@ -77,17 +77,16 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "F",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 658840,
-		tcgplayer: 272429
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 658840,
+				tcgplayer: 272429
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance/180.ts
+++ b/data/Sword & Shield/Astral Radiance/180.ts
@@ -77,17 +77,16 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "F",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 658841,
-		tcgplayer: 272430
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 658841,
+				tcgplayer: 272430
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance/181.ts
+++ b/data/Sword & Shield/Astral Radiance/181.ts
@@ -29,17 +29,16 @@ const card: Card = {
 	trainerType: "Supporter",
 	regulationMark: "F",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 658842,
-		tcgplayer: 272431
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 658842,
+				tcgplayer: 272431
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance/182.ts
+++ b/data/Sword & Shield/Astral Radiance/182.ts
@@ -29,17 +29,16 @@ const card: Card = {
 	trainerType: "Supporter",
 	regulationMark: "F",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 658843,
-		tcgplayer: 272432
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 658843,
+				tcgplayer: 272432
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance/183.ts
+++ b/data/Sword & Shield/Astral Radiance/183.ts
@@ -29,17 +29,16 @@ const card: Card = {
 	trainerType: "Supporter",
 	regulationMark: "F",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 658844,
-		tcgplayer: 272433
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 658844,
+				tcgplayer: 272433
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance/184.ts
+++ b/data/Sword & Shield/Astral Radiance/184.ts
@@ -29,17 +29,16 @@ const card: Card = {
 	trainerType: "Supporter",
 	regulationMark: "F",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 658845,
-		tcgplayer: 272434
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 658845,
+				tcgplayer: 272434
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance/185.ts
+++ b/data/Sword & Shield/Astral Radiance/185.ts
@@ -29,17 +29,16 @@ const card: Card = {
 	trainerType: "Supporter",
 	regulationMark: "F",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 658846,
-		tcgplayer: 272435
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 658846,
+				tcgplayer: 272435
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance/186.ts
+++ b/data/Sword & Shield/Astral Radiance/186.ts
@@ -29,17 +29,16 @@ const card: Card = {
 	trainerType: "Supporter",
 	regulationMark: "F",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 658847,
-		tcgplayer: 272436
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 658847,
+				tcgplayer: 272436
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance/187.ts
+++ b/data/Sword & Shield/Astral Radiance/187.ts
@@ -29,17 +29,16 @@ const card: Card = {
 	trainerType: "Supporter",
 	regulationMark: "F",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 658848,
-		tcgplayer: 272437
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 658848,
+				tcgplayer: 272437
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance/188.ts
+++ b/data/Sword & Shield/Astral Radiance/188.ts
@@ -29,17 +29,16 @@ const card: Card = {
 	trainerType: "Supporter",
 	regulationMark: "F",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 658849,
-		tcgplayer: 272438
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 658849,
+				tcgplayer: 272438
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance/189.ts
+++ b/data/Sword & Shield/Astral Radiance/189.ts
@@ -29,17 +29,16 @@ const card: Card = {
 	trainerType: "Supporter",
 	regulationMark: "F",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 658850,
-		tcgplayer: 272439
-	}
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 658850,
+				tcgplayer: 272439
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance/190.ts
+++ b/data/Sword & Shield/Astral Radiance/190.ts
@@ -65,17 +65,17 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "F",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 658851,
-		tcgplayer: 272444
-	}
+	variants: [
+		{
+			type: 'holo',
+			foil: 'rainbow',
+			thirdParty: {
+				cardmarket: 658851,
+				tcgplayer: 272444
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance/191.ts
+++ b/data/Sword & Shield/Astral Radiance/191.ts
@@ -86,17 +86,17 @@ const card: Card = {
 	retreat: 4,
 	regulationMark: "F",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 658852,
-		tcgplayer: 272445
-	}
+	variants: [
+		{
+			type: 'holo',
+			foil: 'rainbow',
+			thirdParty: {
+				cardmarket: 658852,
+				tcgplayer: 272445
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance/192.ts
+++ b/data/Sword & Shield/Astral Radiance/192.ts
@@ -65,17 +65,17 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "F",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 658551,
-		tcgplayer: 272446
-	}
+	variants: [
+		{
+			type: 'holo',
+			foil: 'rainbow',
+			thirdParty: {
+				cardmarket: 658853,
+				tcgplayer: 272446
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance/193.ts
+++ b/data/Sword & Shield/Astral Radiance/193.ts
@@ -91,17 +91,17 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "F",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 658854,
-		tcgplayer: 272447
-	}
+	variants: [
+		{
+			type: 'holo',
+			foil: 'rainbow',
+			thirdParty: {
+				cardmarket: 658854,
+				tcgplayer: 272447
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance/194.ts
+++ b/data/Sword & Shield/Astral Radiance/194.ts
@@ -86,17 +86,17 @@ const card: Card = {
 	retreat: 3,
 	regulationMark: "F",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 658855,
-		tcgplayer: 272448
-	}
+	variants: [
+		{
+			type: 'holo',
+			foil: 'rainbow',
+			thirdParty: {
+				cardmarket: 658855,
+				tcgplayer: 272448
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance/195.ts
+++ b/data/Sword & Shield/Astral Radiance/195.ts
@@ -65,17 +65,17 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "F",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 658856,
-		tcgplayer: 272449
-	}
+	variants: [
+		{
+			type: 'holo',
+			foil: 'rainbow',
+			thirdParty: {
+				cardmarket: 658856,
+				tcgplayer: 272449
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance/196.ts
+++ b/data/Sword & Shield/Astral Radiance/196.ts
@@ -87,17 +87,17 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "F",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 658857,
-		tcgplayer: 272450
-	}
+	variants: [
+		{
+			type: 'holo',
+			foil: 'rainbow',
+			thirdParty: {
+				cardmarket: 658857,
+				tcgplayer: 272450
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance/197.ts
+++ b/data/Sword & Shield/Astral Radiance/197.ts
@@ -65,17 +65,17 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "F",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 658858,
-		tcgplayer: 272451
-	}
+	variants: [
+		{
+			type: 'holo',
+			foil: 'rainbow',
+			thirdParty: {
+				cardmarket: 658858,
+				tcgplayer: 272451
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance/198.ts
+++ b/data/Sword & Shield/Astral Radiance/198.ts
@@ -93,17 +93,17 @@ const card: Card = {
 	retreat: 3,
 	regulationMark: "F",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 658859,
-		tcgplayer: 272452
-	}
+	variants: [
+		{
+			type: 'holo',
+			foil: 'rainbow',
+			thirdParty: {
+				cardmarket: 658859,
+				tcgplayer: 272452
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance/199.ts
+++ b/data/Sword & Shield/Astral Radiance/199.ts
@@ -29,17 +29,17 @@ const card: Card = {
 	trainerType: "Supporter",
 	regulationMark: "F",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 658860,
-		tcgplayer: 272453
-	}
+	variants: [
+		{
+			type: 'holo',
+			foil: 'rainbow',
+			thirdParty: {
+				cardmarket: 658860,
+				tcgplayer: 272453
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance/200.ts
+++ b/data/Sword & Shield/Astral Radiance/200.ts
@@ -29,17 +29,17 @@ const card: Card = {
 	trainerType: "Supporter",
 	regulationMark: "F",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 658861,
-		tcgplayer: 272454
-	}
+	variants: [
+		{
+			type: 'holo',
+			foil: 'rainbow',
+			thirdParty: {
+				cardmarket: 658861,
+				tcgplayer: 272454
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance/201.ts
+++ b/data/Sword & Shield/Astral Radiance/201.ts
@@ -29,17 +29,17 @@ const card: Card = {
 	trainerType: "Supporter",
 	regulationMark: "F",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 658862,
-		tcgplayer: 272455
-	}
+	variants: [
+		{
+			type: 'holo',
+			foil: 'rainbow',
+			thirdParty: {
+				cardmarket: 658862,
+				tcgplayer: 272455
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance/202.ts
+++ b/data/Sword & Shield/Astral Radiance/202.ts
@@ -29,17 +29,17 @@ const card: Card = {
 	trainerType: "Supporter",
 	regulationMark: "F",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 658863,
-		tcgplayer: 272457
-	}
+	variants: [
+		{
+			type: 'holo',
+			foil: 'rainbow',
+			thirdParty: {
+				cardmarket: 658863,
+				tcgplayer: 272457
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance/203.ts
+++ b/data/Sword & Shield/Astral Radiance/203.ts
@@ -29,17 +29,17 @@ const card: Card = {
 	trainerType: "Supporter",
 	regulationMark: "F",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 658864,
-		tcgplayer: 272458
-	}
+	variants: [
+		{
+			type: 'holo',
+			foil: 'rainbow',
+			thirdParty: {
+				cardmarket: 658864,
+				tcgplayer: 272458
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance/204.ts
+++ b/data/Sword & Shield/Astral Radiance/204.ts
@@ -29,17 +29,17 @@ const card: Card = {
 	trainerType: "Supporter",
 	regulationMark: "F",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 658865,
-		tcgplayer: 272459
-	}
+	variants: [
+		{
+			type: 'holo',
+			foil: 'rainbow',
+			thirdParty: {
+				cardmarket: 658865,
+				tcgplayer: 272459
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance/205.ts
+++ b/data/Sword & Shield/Astral Radiance/205.ts
@@ -29,17 +29,17 @@ const card: Card = {
 	trainerType: "Supporter",
 	regulationMark: "F",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 658866,
-		tcgplayer: 272460
-	}
+	variants: [
+		{
+			type: 'holo',
+			foil: 'rainbow',
+			thirdParty: {
+				cardmarket: 658866,
+				tcgplayer: 272460
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance/206.ts
+++ b/data/Sword & Shield/Astral Radiance/206.ts
@@ -29,17 +29,17 @@ const card: Card = {
 	trainerType: "Supporter",
 	regulationMark: "F",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 658867,
-		tcgplayer: 272461
-	}
+	variants: [
+		{
+			type: 'holo',
+			foil: 'rainbow',
+			thirdParty: {
+				cardmarket: 658867,
+				tcgplayer: 272461
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance/207.ts
+++ b/data/Sword & Shield/Astral Radiance/207.ts
@@ -29,17 +29,17 @@ const card: Card = {
 	trainerType: "Supporter",
 	regulationMark: "F",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 658868,
-		tcgplayer: 272462
-	}
+	variants: [
+		{
+			type: 'holo',
+			foil: 'rainbow',
+			thirdParty: {
+				cardmarket: 658868,
+				tcgplayer: 272462
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance/208.ts
+++ b/data/Sword & Shield/Astral Radiance/208.ts
@@ -65,17 +65,17 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "F",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 658551,
-		tcgplayer: 272463
-	}
+	variants: [
+		{
+			type: 'holo',
+			foil: 'gold',
+			thirdParty: {
+				cardmarket: 658869,
+				tcgplayer: 272463
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance/209.ts
+++ b/data/Sword & Shield/Astral Radiance/209.ts
@@ -65,17 +65,17 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "F",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 658755,
-		tcgplayer: 272464
-	}
+	variants: [
+		{
+			type: 'holo',
+			foil: 'gold',
+			thirdParty: {
+				cardmarket: 658870,
+				tcgplayer: 272464
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance/210.ts
+++ b/data/Sword & Shield/Astral Radiance/210.ts
@@ -93,17 +93,17 @@ const card: Card = {
 	retreat: 3,
 	regulationMark: "F",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 658871,
-		tcgplayer: 272465
-	}
+	variants: [
+		{
+			type: 'holo',
+			foil: 'gold',
+			thirdParty: {
+				cardmarket: 658871,
+				tcgplayer: 272465
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance/211.ts
+++ b/data/Sword & Shield/Astral Radiance/211.ts
@@ -29,17 +29,17 @@ const card: Card = {
 	trainerType: "Tool",
 	regulationMark: "F",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 658872,
-		tcgplayer: 272466
-	}
+	variants: [
+		{
+			type: 'holo',
+			foil: 'gold',
+			thirdParty: {
+				cardmarket: 658872,
+				tcgplayer: 272466
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance/212.ts
+++ b/data/Sword & Shield/Astral Radiance/212.ts
@@ -29,17 +29,17 @@ const card: Card = {
 	trainerType: "Stadium",
 	regulationMark: "F",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 658873,
-		tcgplayer: 272467
-	}
+	variants: [
+		{
+			type: 'holo',
+			foil: 'gold',
+			thirdParty: {
+				cardmarket: 658873,
+				tcgplayer: 272467
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance/213.ts
+++ b/data/Sword & Shield/Astral Radiance/213.ts
@@ -29,17 +29,17 @@ const card: Card = {
 	trainerType: "Stadium",
 	regulationMark: "E",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 658874,
-		tcgplayer: 272468
-	}
+	variants: [
+		{
+			type: 'holo',
+			foil: 'gold',
+			thirdParty: {
+				cardmarket: 658874,
+				tcgplayer: 272468
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance/214.ts
+++ b/data/Sword & Shield/Astral Radiance/214.ts
@@ -29,17 +29,17 @@ const card: Card = {
 	trainerType: "Stadium",
 	regulationMark: "F",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 658875,
-		tcgplayer: 272469
-	}
+	variants: [
+		{
+			type: 'holo',
+			foil: 'gold',
+			thirdParty: {
+				cardmarket: 658875,
+				tcgplayer: 272469
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance/215.ts
+++ b/data/Sword & Shield/Astral Radiance/215.ts
@@ -29,17 +29,17 @@ const card: Card = {
 	trainerType: "Item",
 	regulationMark: "F",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 658876,
-		tcgplayer: 272470
-	}
+	variants: [
+		{
+			type: 'holo',
+			foil: 'gold',
+			thirdParty: {
+				cardmarket: 658876,
+				tcgplayer: 272470
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/Astral Radiance/216.ts
+++ b/data/Sword & Shield/Astral Radiance/216.ts
@@ -28,17 +28,17 @@ const card: Card = {
 	energyType: "Special",
 	regulationMark: "F",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
 
-	thirdParty: {
-		cardmarket: 658877,
-		tcgplayer: 272471
-	}
+	variants: [
+		{
+			type: 'holo',
+			foil: 'gold',
+			thirdParty: {
+				cardmarket: 658877,
+				tcgplayer: 272471
+			}
+		},
+	],
 }
 
 export default card


### PR DESCRIPTION
## Changes

- Split ASR Trainer gallery to own set to reflect official sourcing 
- Added several new variants 
- Updated all `thirdParty` IDs and moved into vairants block 

