### PR TITLE
(data): ex5.5 Creators Pack Pricing Variants and Added TCGPlayerIds

### DIFF
--- a/data/EX/Poké Card Creator Pack/1.ts
+++ b/data/EX/Poké Card Creator Pack/1.ts
@@ -65,13 +65,13 @@ const card: Card = {
 		},
 	],
 
-	thirdParty: {
-		cardmarket: 605992
-	},
-
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				cardmarket: 605992,
+				tcgplayer: 162268
+			},
 		}
 	]
 }

--- a/data/EX/Poké Card Creator Pack/2.ts
+++ b/data/EX/Poké Card Creator Pack/2.ts
@@ -60,13 +60,13 @@ const card: Card = {
 		},
 	],
 
-	thirdParty: {
-		cardmarket: 605993
-	},
-
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				cardmarket: 605993,
+				tcgplayer: 162269
+			},
 		}
 	]
 }

--- a/data/EX/Poké Card Creator Pack/3.ts
+++ b/data/EX/Poké Card Creator Pack/3.ts
@@ -61,13 +61,13 @@ const card: Card = {
 		},
 	],
 
-	thirdParty: {
-		cardmarket: 605994
-	},
-
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				cardmarket: 605994,
+				tcgplayer: 162270
+			},
 		}
 	]
 }

--- a/data/EX/Poké Card Creator Pack/4.ts
+++ b/data/EX/Poké Card Creator Pack/4.ts
@@ -61,13 +61,13 @@ const card: Card = {
 		},
 	],
 
-	thirdParty: {
-		cardmarket: 605995
-	},
-
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				cardmarket: 605995,
+				tcgplayer: 162271
+			},
 		}
 	]
 }

--- a/data/EX/Poké Card Creator Pack/5.ts
+++ b/data/EX/Poké Card Creator Pack/5.ts
@@ -61,13 +61,13 @@ const card: Card = {
 		},
 	],
 
-	thirdParty: {
-		cardmarket: 605996
-	},
-
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				cardmarket: 605996,
+				tcgplayer: 162272
+			},
 		}
 	]
 }


### PR DESCRIPTION
closes # N/A

## Changes

- add missing tcgplayer ids
- moved third party pricing into variants

## Details

The web pack had cardmarket ids for all cards but were missing tcgplayer ids. I added all the tcgplayerIds and moved thirdparty into the variant

