### PR TITLE
fix: add reverse and holo variants for sv01-015

### DIFF
--- a/data/Scarlet & Violet/Scarlet & Violet/015.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/015.ts
@@ -74,7 +74,8 @@ const card: Card = {
 
 	variants: {
 		normal: false,
-		reverse: false
+		reverse: true,
+		holo: true,
 	},
 
 	illustrator: "Ryota Murayama",


### PR DESCRIPTION
<!--
Contribution guide: https://github.com/tcgdex/cards-database/blob/master/CONTRIBUTING.md
please submit changes up to 1 set at most.
-->

## Changes

Added `holo` and `reverse` variants for sv01-015 Meowscarada as they were missing

