### PR TITLE
fix: add normal, reverse and holo variants for sv01-023

### DIFF
--- a/data/Scarlet & Violet/Scarlet & Violet/023.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/023.ts
@@ -73,8 +73,9 @@ const card: Card = {
 	regulationMark: "G",
 
 	variants: {
-		reverse: false,
-		normal: false
+		reverse: true,
+		normal: true,
+		holo: true,
 	},
 
 	illustrator: "Kouki Saitou",


### PR DESCRIPTION
<!--
Contribution guide: https://github.com/tcgdex/cards-database/blob/master/CONTRIBUTING.md
please submit changes up to 1 set at most.
-->

## Changes

Added `normal`, `reverse` and `holo` variants for sv01-023 Arboliva as they were missing

