### PR TITLE
(patch) Lycanroc Trainer kit (tk-sm-l) Correct Caterpie pokeid

### DIFF
--- a/data/Trainer kits/SM trainer Kit (Lycanroc)/1.ts
+++ b/data/Trainer kits/SM trainer Kit (Lycanroc)/1.ts
@@ -2,7 +2,7 @@ import { Card } from '../../../interfaces'
 import Set from '../SM trainer Kit (Lycanroc)'
 
 const card: Card = {
-	dexId: [251],
+	dexId: [10],
 	set: Set,
 
 	name: {


### PR DESCRIPTION
closes # N/A

## Changes

correct pokeid

## Details

#1 caterpie of the set had incorrect pokeid. corrected to 10

