### PR TITLE
RFC + POC: @tcgdex/schema — single-source-of-truth output types [V3 - Not for Merge] 

### DIFF
--- a/schema/.gitignore
+++ b/schema/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+dist/

--- a/schema/README.md
+++ b/schema/README.md
@@ -1,0 +1,71 @@
+# @tcgdex/schema — demo
+
+Runnable proof for the schema-driven-types RFC, modeled on the **current V2** output
+shape so it can be checked against live data and the existing `@tcgdex/sdk` types.
+The real package will define V3's output contract using the same pipeline.
+
+> **Not for merge as-is.** This POC mirrors V2 to prove the pipeline end-to-end.
+> See [`RFC.md`](./RFC.md) for the full proposal and staging plan.
+
+## Run
+
+    npm install
+    npm run demo      # emit:dts + emit:openapi + validate:live
+
+Expected output:
+
+    → dist/types.d.ts
+    ✓ wrote dist/openapi.json
+      33 paths, 9 schemas
+    ✓ live base1-4 validates against Card
+
+## What to look at
+
+1. **`dist/types.d.ts`** — clean TypeScript declarations generated from the schema.
+   Closed enums (`category`, `types`, `energyType`, `abilityType`) become real unions
+   like `"Pokemon" | "Trainer" | "Energy"`. Open enums (`rarity`, `stage`, `suffix`)
+   stay `string` — new values from future set releases won't break consumers.
+   Compare with the current `@tcgdex/sdk` `.d.ts` where every enum is bare `string`.
+
+2. **`dist/openapi.json`** — full OpenAPI 3.1 document: 33 paths, 9 component schemas,
+   RFC 9457 `application/problem+json` error responses, `x-extensible-enum` metadata
+   on every open enum. Feed this straight into `openapi-generator-cli` for non-JS SDKs.
+   Compare with the hand-maintained `server/public/v2/openapi.yaml` (1705 lines).
+
+3. **`npm run validate:live`** — fetches `base1-4` (Charizard, Base Set) from
+   `api.tcgdex.net` and validates it against the schema. On the current run, it
+   passes clean with no un-modeled fields — `variants_detailed`, `pricing`, and
+   `updated` (all ghost properties on the current SDK type) are now modeled.
+
+## Sample generated SDK output
+
+To prove the OpenAPI pipeline is real, not aspirational:
+
+```powershell
+npx @openapitools/openapi-generator-cli generate -i dist/openapi.json -g python -o dist/generated-python-sample --additional-properties=packageName=tcgdex
+```
+
+Requires Java (the generator is a JVM tool). Produces a full Python client with
+Pydantic models — see `dist/generated-python-sample/tcgdex/models/card.py`. The
+pipeline works end-to-end; the follow-up work described in the RFC is a Mustache
+template override to convert `x-extensible-enum` metadata into real Python enums
+with an `UNKNOWN` fallback for open-enum semantics.
+
+## Docs
+
+- [`RFC.md`](./RFC.md) — the full RFC (problem, solution, staging, FAQ)
+- [`docus/sdk-migration.md`](./docus/sdk-migration.md) — how the JS SDK adopts the schema (`implements` pattern)
+- [`docus/workflows/`](./docus/workflows/) — example GitHub Actions showing how schema releases would auto-regenerate downstream SDKs
+- [`docus/python-template-sketch.mustache`](./docus/python-template-sketch.mustache) — a sketch of the `x-extensible-enum` Mustache override (needs archaeology against the actual openapi-generator Python defaults before it will run)
+
+## Notes / production deltas
+
+- **Sub-schemas are inlined** in the generated OpenAPI (no `$ref`s between component
+  schemas). Reviewers will see auto-named inline schemas like `Card_variants_detailed_inner`
+  in the Python sample — cosmetic, not correctness. Production adds a `$ref`-lifting
+  pass so `Card.set` becomes `{$ref: '#/components/schemas/SetResume'}`. Stage 2b work.
+- **Path operations lack `operationId`** — the generator invents names like `cardsGet`
+  from the path. Production sets explicit `operationId` per op so the generated client
+  methods read cleanly (`client.list_cards()` vs `client.cards_get()`). Stage 2b work.
+- **Package is `private: true`** and versioned `0.0.0-demo` — the real package publishes
+  to npm as `@tcgdex/schema` starting at `1.0.0`.

--- a/schema/RFC.md
+++ b/schema/RFC.md
@@ -421,13 +421,14 @@ But the alternative is a legitimate reading of the same diagnosis, and the RFC d
 - Validates against live API
 - **No changes to server or SDK**
 
-### Stage 2: SDK Adoption
+### Stage 2: SDK + Docs Adoption
 
 - `@tcgdex/schema` published to npm
 - JS SDK adds `implements` constraints
 - Ghost properties (`pricing`, `updated`) declared on Card class
 - Closed enum unions flow through to SDK consumers
-- **Non-breaking** — tighter types are backwards-compatible
+- **Docs site** repoints its OpenAPI renderer at the generated `dist/openapi.json` instead of the hand-maintained `server/public/v2/openapi.yaml` (see [Documentation site](#documentation-site))
+- Tighter SDK types may be *source-breaking* for consumers narrowing on bare `string` — see [implementation follow-ups](./docus/implementation-followups.md)
 
 ### Stage 3: V3 Breaking Changes
 

--- a/schema/RFC.md
+++ b/schema/RFC.md
@@ -1,0 +1,338 @@
+# RFC: Schema-Driven Types for TCGdex
+
+**Author:** Ryan (FalconChipp)  
+**Status:** Draft  
+**Target:** `tcgdex/cards-database` (new `schema/` package, V3 PR)
+
+---
+
+## Problem
+
+The TCGdex card database has three distinct data shapes — input, compiled, and output — with no shared contract between them:
+
+| Shape | Where | Example |
+|-------|-------|---------|
+| **Input** | `interfaces.d.ts` (root) | Localized maps, rich enums (`VariantStamps` ~130 values), template-literal `ISODate` |
+| **Compiled** | `server/generated/*/cards.json` | Typed as `any` (`Card.ts:28`), loaded with `@ts-ignore` |
+| **Output** | `@tcgdex/sdk` type declarations | Flattened enums (all `string`), no `variants_detailed`, no `pricing`, no `updated` |
+
+The SDK defines the output types, and the server *imports them back* (`server/src/V2/Components/Card.ts:2`):
+
+```ts
+import type { CardResume, Card as SDKCard } from '@tcgdex/sdk'
+```
+
+This creates a **backwards dependency**: the server depends on its own consumer for types. When the server adds fields (like `pricing` in `loadCard()`), the SDK type doesn't know — the field exists at runtime but is invisible to TypeScript. Drift is silent and cumulative.
+
+### Evidence: Live Drift (Demonstrated by POC)
+
+Running the POC's `validate-live` script against `api.tcgdex.net/v2/en/cards/base1-4` (Charizard, Base Set) produces:
+
+```
+✓ live base1-4 validates against Card
+  note: response also has un-modeled fields: variants_detailed, updated, pricing
+```
+
+Three fields the API serves that the SDK type omits entirely:
+
+- **`variants_detailed`** — the rich variant array (`type`/`pricing` per variant). The server builds it in `loadCard()` (line 122), but the SDK's `Card` type only has `variants` (the four booleans). The SDK class *does* declare `variantsDetailed` and remaps via `fill()`, but the type contract (`@tcgdex/sdk` `.d.ts`) never included it.
+- **`pricing`** — added by `loadCard()` (line 151–154) from CardMarket/TCGPlayer providers. Ghost property: present at runtime, absent from the type.
+- **`updated`** — a timestamp the type omits.
+
+These aren't edge cases. They're on *every card response* for the most popular endpoint.
+
+### Enum Erosion
+
+The SDK types every enum as bare `string`:
+
+```ts
+// from @tcgdex/sdk .d.ts
+public rarity!: string
+public category!: string
+public stage?: string
+public suffix?: string
+public trainerType?: string
+public energyType?: string
+```
+
+The input types (`interfaces.d.ts`) have full union types for these (e.g., 40 rarity values, 11 stages, 8 suffixes). That precision is lost at the output boundary — SDK consumers get no autocomplete, no exhaustiveness checking, no compile-time safety.
+
+### The Generic That Isn't
+
+The SDK defines `Card<SetType extends SetResume = SetResume>`. The generic parameter is never instantiated with a non-default argument anywhere — not in the server, not in the SDK, not in any consumer. It's vestigial complexity.
+
+---
+
+## Solution: `@tcgdex/schema`
+
+A new package in the cards-database monorepo that defines the **output shape** (what the API serves) as the single source of truth, using [TypeBox](https://github.com/sinclairzx81/typebox) (pinned `0.32.34`).
+
+### Why TypeBox
+
+TypeBox schemas *are* JSON Schema. No compilation step, no `.generate()` — the schema object is already a valid JSON Schema document. This means:
+
+- **OpenAPI 3.1 emission is lossless** — JSON Schema is a proper subset of OpenAPI 3.1's schema object. Drop the schemas into `components/schemas` directly.
+- **Runtime validation** — `TypeCompiler.Compile()` produces a validator from the same schema that generates the types. One definition, two uses.
+- **`.d.ts` generation** — `json-schema-to-typescript` (or TypeBox's `Static<>`) produces clean TypeScript interfaces from the schema.
+
+Zod was considered but rejected: Zod schemas aren't JSON Schema, so OpenAPI emission requires a lossy `zod-to-json-schema` conversion. TypeBox avoids the impedance mismatch entirely.
+
+### What the Schema Defines
+
+The output contract — the shapes clients receive from the API:
+
+| Schema | Matches |
+|--------|---------|
+| `CardResume` | Brief card (id, localId, name, image) |
+| `Card` | Full card (extends CardResume, all fields including `variants_detailed`, `pricing`, `updated`) |
+| `SetResume` | Brief set (id, name, logo, symbol, cardCount) |
+| `Set` | Full set (extends SetResume, adds serie, variants, cards, richer cardCount) |
+| `SerieResume` | Brief serie (id, name, logo) |
+| `Serie` | Full serie (extends SerieResume, adds sets) |
+| `Variants` | The four boolean variant flags |
+
+### Open vs. Closed Enums
+
+Not all enums grow at the same rate. The schema distinguishes:
+
+| Enum | Treatment | Rationale |
+|------|-----------|-----------|
+| `rarity` | **Open** (`string` + `x-extensible-enum`) | 40+ values, new rarities every set release. Open means new values never break validators or generated clients. |
+| `stage` | **Open** | Has grown historically (VMAX, VSTAR, V-UNION added over time). |
+| `suffix` | **Open** | Same — EX, GX, V, ex are generation-specific, more will come. |
+| `category` | **Closed** (union) | Pokemon / Trainer / Energy — hasn't changed since the game launched. |
+| `types` (Pokemon) | **Closed** | 11 types, stable since Fairy was added in XY. |
+| `energyType` | **Closed** | Normal / Special — binary, stable. |
+| `trainerType` | **Closed** | Supporter / Item / Stadium / Tool + legacy. Rarely grows. |
+| `abilityType` | **Closed** | Pokemon Power / Poke-BODY / Poke-POWER / Ability / Ancient Trait. |
+
+Implementation:
+
+```ts
+// Closed: real union in .d.ts, strict validation
+function ClosedEnum(values) {
+  return Type.Union(values.map(v => Type.Literal(v)))
+}
+
+// Open: validates as string (new values never throw),
+// known values ride along as metadata for docs + codegen
+function OpenEnum(values) {
+  return Type.String({ 'x-extensible-enum': values })
+}
+```
+
+### Wire Format vs. SDK Convention
+
+The API returns `variants_detailed` (snake_case). The JS SDK presents `variantsDetailed` (camelCase), remapping in the Card class's `fill()` override:
+
+```ts
+protected override fill(obj: object): void {
+  objectLoop(obj, (value, key: string) => {
+    if (key === 'variants_detailed') {
+      key = 'variantsDetailed'
+    }
+    (this as any)[key] = value
+  })
+}
+```
+
+**The schema defines the wire format** — snake_case `variants_detailed` — because it's the API contract and what validators check against. Two options for the JS SDK: (A) match the wire format by renaming the class property `variantsDetailed` → `variants_detailed` and dropping the `fill()` remap; (B) keep camelCase on the class and add a `CamelCard` mapped type to the schema as a follow-up. Option A is a one-line breaking change on one field name; option B preserves JS convention at the cost of a utility type. See [`docus/sdk-migration.md`](./docus/sdk-migration.md#3-handle-the-wire-format-vs-camelcase-naming).
+
+---
+
+## JS SDK Integration
+
+The SDK uses runtime classes extending a `Model` base class, not plain interfaces. `Model.fill()` copies API response properties onto `this`. The migration preserves this architecture entirely.
+
+### Current SDK Architecture
+
+```
+Model (base: sdk ref, fill())
+  └─ CardResume (id, localId, name, image)
+       └─ Card (all fields, overrides fill() for variants_detailed remap)
+  └─ SetResume → Set
+  └─ SerieResume → Serie
+```
+
+### Migration: `implements` Pattern
+
+```ts
+import type { Card as CardShape } from '@tcgdex/schema'
+
+export default class Card extends CardResume implements CardShape {
+  // Existing properties stay
+  // Add: pricing, updated (were ghost properties — runtime-present, type-absent)
+  // Tighten: category from string → union (non-breaking for consumers)
+  // fill() remap stays as-is
+}
+```
+
+**Key properties:**
+- `@tcgdex/schema` is a **devDependency** — types only, zero runtime footprint in the SDK bundle
+- `implements CardShape` makes drift a **compile error** — if the schema adds a field and the class doesn't declare it, `tsc` fails
+- `fill()` and the `Model` base class don't change at all
+- Consumers of `@tcgdex/sdk` get tighter types automatically (closed enum unions instead of bare `string`)
+
+### Optional: Runtime Validation
+
+The SDK can optionally validate API responses at the fetch boundary:
+
+```ts
+import { CardSchema } from '@tcgdex/schema'
+import { TypeCompiler } from '@sinclair/typebox/compiler'
+
+const CardValidator = TypeCompiler.Compile(CardSchema)
+
+// in the fetch path:
+const data = await res.json()
+if (!CardValidator.Check(data)) {
+  throw new Error('API response does not match Card schema')
+}
+```
+
+This catches server-side regressions at runtime. It's a nice-to-have, not a requirement for the type contract to work.
+
+### Other SDKs (Java, Kotlin, Python, etc.)
+
+Non-JS SDKs consume the OpenAPI document generated from the schema:
+
+```
+@tcgdex/schema → emit-openapi → openapi.json → openapi-generator → SDK
+```
+
+The `x-extensible-enum` extension requires Mustache template overrides in `openapi-generator` to produce real enums (the default ignores vendor extensions). This is a known, documented customization.
+
+---
+
+## OpenAPI
+
+The server currently maintains a hand-written `server/public/v2/openapi.yaml` (1705 lines, OpenAPI 3.1.0), served via swagger-ui at `/v2/openapi`. The apis.guru listing is unofficial (2.0.0, stale).
+
+With the schema package, OpenAPI generation becomes:
+
+```ts
+const doc = {
+  openapi: '3.1.0',
+  info: { title: 'TCGdex API', version: '2.0.0' },
+  components: {
+    schemas: {
+      Card: CardSchema,
+      CardResume: CardResumeSchema,
+      Set: SetSchema,
+      // ...
+    }
+  }
+}
+```
+
+The schemas drop in directly because TypeBox schemas are JSON Schema — no conversion step. Path/operation definitions still need to be maintained separately (they describe routing, not data shapes), but the `components/schemas` section — the largest and most drift-prone part — is now generated.
+
+---
+
+## Staging
+
+### Stage 1: Schema Package (This PR)
+
+- New `schema/` directory in `cards-database` monorepo
+- Defines V2 output shapes in TypeBox
+- Emits `dist/types.d.ts` and `dist/openapi.json`
+- Validates against live API
+- **No changes to server or SDK**
+
+### Stage 2: SDK Adoption
+
+- `@tcgdex/schema` published to npm
+- JS SDK adds `implements` constraints
+- Ghost properties (`pricing`, `updated`) declared on Card class
+- Closed enum unions flow through to SDK consumers
+- **Non-breaking** — tighter types are backwards-compatible
+
+### Stage 3: V3 Breaking Changes
+
+- `variants` (boolean flags) deprecated, `variants_detailed` becomes primary
+- Root `pricing` removed — per-variant pricing on `variants_detailed[]` becomes the single source (as noted in `Card.ts:141`)
+- Any other breaking rename/removal decided by the maintainers rides here
+- Versioned in the schema (`version: '3.0.0'`), breaking changes ride the major version
+
+### Stage 4: Server Adoption
+
+- Server imports types from `@tcgdex/schema` instead of `@tcgdex/sdk`
+- Backwards dependency eliminated
+- Compiled card data gets typed (replaces `any` / `@ts-ignore`)
+
+---
+
+## POC
+
+A working proof-of-concept lives at `schema/` in this PR. It demonstrates the full pipeline:
+
+```bash
+cd schema && npm install && npm run demo
+```
+
+This runs three steps:
+
+1. **`emit:dts`** — generates `dist/types.d.ts` with clean interfaces. Closed enums become real unions (`"Pokemon" | "Trainer" | "Energy"`), open enums stay `string`.
+2. **`emit:openapi`** — generates `dist/openapi.json`: a full OpenAPI 3.1 document with **33 paths, 9 component schemas**, RFC 9457 `application/problem+json` error responses, and `x-extensible-enum` metadata on every open enum field.
+3. **`validate:live`** — fetches Charizard (base1-4) from the live API and validates against the Card schema. On the current run it passes clean with no un-modeled fields — `variants_detailed`, `pricing`, and `updated` (all ghost properties on the current SDK type) are now modeled.
+
+**End-to-end proof:** running `openapi-generator-cli` against `dist/openapi.json` produces a working Python SDK (Pydantic models). The generator processes all 33 paths, resolves inline schemas, and preserves `x-extensible-enum` metadata. See `dist/generated-python-sample/tcgdex/models/card.py` after running the command in the README. A Mustache template that converts `x-extensible-enum` into real Python enums with an `UNKNOWN` fallback is sketched at [`docus/python-template-sketch.mustache`](./docus/python-template-sketch.mustache) — Stage 2b work, non-blocking.
+
+### Package Structure
+
+```
+schema/
+  src/
+    enums.ts         # Open/Closed enum helpers + value lists
+    resume.ts        # CardResume, SetResume, SerieResume, Variants
+    card.ts          # Card (full shape with variants_detailed, pricing, updated)
+    set.ts           # Set, Serie
+    index.ts         # Barrel exports: types, schemas, enums
+  build/
+    emit-dts.ts      # json-schema-to-typescript → dist/types.d.ts
+    emit-openapi.ts  # Assembles full OpenAPI 3.1 doc (paths + schemas + errors)
+    validate-live.ts # Fetches live card, validates, reports drift
+  docus/
+    sdk-migration.md              # JS SDK adoption guide (implements pattern)
+    python-template-sketch.mustache  # x-extensible-enum override sketch (Stage 2b)
+    workflows/
+      README.md                   # Explains the release → regenerate loop
+      publish-and-notify.yml      # Publisher example (cards-database)
+      sdk-regenerate.yml          # Consumer example (per SDK repo)
+  dist/                           # Generated (gitignored)
+    types.d.ts
+    openapi.json
+  README.md                       # How to run the demo + what to look at
+  RFC.md                          # This document
+```
+
+### Dependencies
+
+| Package | Version | Why |
+|---------|---------|-----|
+| `@sinclair/typebox` | `0.32.34` (pinned) | JSON-Schema-native schema definitions |
+| `json-schema-to-typescript` | `^15.0.0` (dev) | Readable `.d.ts` output (avoids TypeBox `Static<>` gunk) |
+| `tsx` | `^4.19.0` (dev) | Run TypeScript build scripts |
+| `typescript` | `^5.5.0` (dev) | Type checking |
+
+---
+
+## FAQ
+
+**Why not Zod?**  
+Zod schemas aren't JSON Schema. Emitting OpenAPI requires `zod-to-json-schema`, which is lossy (vendor extensions, `$ref` handling, nullable semantics all have edge cases). TypeBox schemas *are* JSON Schema — the conversion is identity, not translation.
+
+**Why `json-schema-to-typescript` instead of `Static<>`?**  
+TypeBox's `Static<typeof Card>` produces correct types, but the `.d.ts` output from `tsc --emitDeclarationOnly` is unreadable — deeply nested `TObject<TString<...>>` wrappers instead of clean `interface Card { id: string }`. `json-schema-to-typescript` generates human-readable interfaces from the JSON Schema representation.
+
+**Why define the output shape, not the input shape?**  
+The input shape (`interfaces.d.ts`) describes what data contributors write. The output shape describes what the API serves and what SDKs consume. The drift problem is at the output boundary — contributors don't use the SDK types, but every API consumer does.
+
+**What about `x-extensible-enum` in codegen?**  
+`openapi-generator` ignores vendor extensions by default. Generating real enums from `x-extensible-enum` requires Mustache template overrides. This is a documented pattern and a one-time setup per target language.
+
+**Does the SDK need a runtime dependency on `@tcgdex/schema`?**  
+No. The JS SDK uses it as a devDependency for `implements` type checking. The schema types are erased at compile time — zero bytes added to the SDK bundle. Runtime validation (via `TypeCompiler`) is optional and would be the only reason for a runtime dependency.
+
+**What about the Card generic (`Card<SetType>`)?**  
+It's vestigial. `Card<SetType extends SetResume = SetResume>` is never instantiated with a non-default argument anywhere in the server or SDK. The schema models `set` as concrete `SetResume`. The generic can be preserved for backwards compatibility in the SDK class if needed, but the schema doesn't encode it.

--- a/schema/RFC.md
+++ b/schema/RFC.md
@@ -204,6 +204,38 @@ The `x-extensible-enum` extension requires Mustache template overrides in `opena
 
 ---
 
+## The schema as a public API contract
+
+Publishing `@tcgdex/schema` to npm as a standalone package is not just an internal codegen input — it becomes a first-class dependency for anyone building against the TCGdex API without a first-party SDK. This is a distinct benefit from the SDK integration, worth calling out separately.
+
+### Concrete third-party use cases
+
+- **Devs hand-rolling `fetch` calls** get typed responses without pulling the full `@tcgdex/sdk` runtime — `npm i @tcgdex/schema` gives them `Card`, `Set`, `Serie` interfaces plus optional runtime validators
+- **Alternative and community SDKs** (framework-specific wrappers, forks, non-JS ports in TS) build on the same contract instead of reinventing the type surface
+- **Backend services** proxying or caching TCGdex data can validate responses at their boundary before serving them onward
+- **UI teams** import enum lists as runtime constants for form-builders — rarity filters, language pickers, category dropdowns — instead of hardcoding lists that go stale on every new set release
+- **Documentation and tooling projects** use `dist/openapi.json` directly as a dependency (swagger-ui, redoc, Stoplight Elements — no scraping the server's YAML)
+
+Folded into `cards-database` (rather than published as a standalone package), none of this is really consumable — asking third parties to `npm i @tcgdex/cards-database` for a frontend is a non-starter. As its own package, `@tcgdex/schema` earns its keep independently of the SDK regeneration story.
+
+### Query authoring
+
+TCGdex has a rich query surface — 33 endpoints, filter/sort/pagination on every list, dozens of filterable fields. Currently, consumers writing queries have to read the docs and hope. With `@tcgdex/schema` as a dependency:
+
+- **Field discovery via autocomplete** — the query field list *is* the `Card` schema; IDEs surface it as the user types
+- **Enum values as runtime constants** — `import { Enums } from '@tcgdex/schema'`; `Enums.RARITIES` is the array. Rarity filter UIs stop hardcoding stale lists.
+- **Compile-time validation of filter values** — `filter('rarity', 'Rare')` type-checks; `filter('rarity', 'super-rare')` errors before the request fires
+- **Typed responses** — the result is `Card[]`, autocomplete flows through into consumer code, no `any` at the API boundary
+- **Interactive query playground** — anyone can point swagger-ui / redoc / Stoplight at `dist/openapi.json` and get a live query builder without touching the tcgdex codebase
+
+Basically: raises the API's ergonomics for query authors from "read the docs and hope" to "TS tells you what's valid as you type." For a filter/sort/paginate API with the surface TCGdex has, that DX gain is substantial.
+
+### Precedent
+
+Publishing a types/schema package separately from the full SDK is a well-established pattern — Stripe's `@stripe/stripe-js`, AWS's `@aws-sdk/types`, Anthropic's SDK-independent types packages, and many others. Consumers who want the contract without the runtime are a normal audience for any public API.
+
+---
+
 ## OpenAPI
 
 The server currently maintains a hand-written `server/public/v2/openapi.yaml` (1705 lines, OpenAPI 3.1.0), served via swagger-ui at `/v2/openapi`. The apis.guru listing is unofficial (2.0.0, stale).
@@ -226,6 +258,76 @@ const doc = {
 ```
 
 The schemas drop in directly because TypeBox schemas are JSON Schema — no conversion step. Path/operation definitions still need to be maintained separately (they describe routing, not data shapes), but the `components/schemas` section — the largest and most drift-prone part — is now generated.
+
+---
+
+## Considered alternatives
+
+Two alternatives came up in discussion. Both are compatible with the RFC's core diagnosis (the SDK shouldn't be the source of truth) — the disagreement is only about *where* the truth should live and *what tooling* expresses it.
+
+### Alternative A: `interfaces.d.ts` as SoT via `typescript-json-schema`
+
+Rather than authoring TypeBox schemas in a new `schema/` package, treat `interfaces.d.ts` (the file contributors already edit) as the source of truth, and derive JSON Schema from the existing TypeScript types using [`typescript-json-schema`](https://github.com/YousefED/typescript-json-schema) (or the sibling `ts-json-schema-generator`).
+
+Dependency direction flips from what this RFC proposes:
+
+```
+Current RFC:  schema (authored, owns enums + shapes)
+                 ├─→ cards-database/server
+                 └─→ SDKs
+
+Alternative A: cards-database/interfaces.d.ts (input SoT)
+                     ↓
+                schema/output.d.ts (plain TS, imports shared enums, adds output-only fields)
+                     ↓ typescript-json-schema
+                JSON Schema → OpenAPI → SDKs
+```
+
+**Compelling:**
+
+- Follows the actual data flow — contributors → compiler → server → clients — rather than layering schema alongside cards-database
+- Enum drift risk killed entirely: one file, one set of values, `Exclude<>` / `Extract<>` for narrowing
+- Already recognisable to contributors — no new DSL, plain TypeScript throughout
+- The SDK stops being a truth source and becomes what it should be: a wrapper
+
+**Tradeoffs:**
+
+- **Loses free runtime validation.** TypeBox schemas *are* validators (`TypeCompiler.Compile`). `typescript-json-schema` produces JSON Schema but no runtime `.Check()` — validation would require a separate step (e.g. ajv). Not a blocker if consumers trust the server's response shape.
+- **Vendor extensions get more awkward.** TypeBox lets `x-extensible-enum` be a schema option. `typescript-json-schema` carries it as a JSDoc `@` annotation, which is ordering-sensitive and depends on the tool honoring it. SDK codegen becomes "author schema + author JSDoc" instead of "author schema."
+- **Draft mismatch.** `typescript-json-schema` defaults to JSON Schema draft-7; OpenAPI 3.1 uses draft 2020-12. Fixable via config but one more thing to get right.
+- **Extra build step.** TypeBox schemas evaluate at import — no compile phase. `typescript-json-schema` runs a TS compiler pass, which adds cold-start time and a moving piece to CI.
+- **Type expressiveness ceiling.** Template literals (like `ISODate` in `interfaces.d.ts`), conditional types, and complex mapped types don't always survive the conversion cleanly. TypeBox has explicit primitives for these; `typescript-json-schema` sometimes forces simplification of the input TS.
+- **Output shape still requires separate authoring.** The server adds `pricing`, `updated`, and `variants_detailed` at request time in `loadCard()`. These fields don't exist in `interfaces.d.ts` and shouldn't (contributors don't write pricing data). So a separate `output.d.ts` is still authored either way; the alternative moves the authoring from TypeBox schemas to plain TS interfaces, but doesn't eliminate the work.
+
+**Verdict:** genuinely worth considering. The RFC's core claims — silent drift, output isn't a SoT today, OpenAPI can be generated — hold under either approach. The choice is really about authoring ergonomics (TypeBox DSL vs plain TS with JSDoc), tooling weight (one tool vs two), and whether runtime validation is worth free schema-language cost.
+
+### Alternative B: Shared enum lists only (a hybrid)
+
+Regardless of which side authors the shapes, the enum *value lists* can live in one file that both sides import. `interfaces.d.ts` (or a new `enums.ts`) becomes the canonical list of rarities, stages, suffixes, Pokemon types, etc.; `@tcgdex/schema` (whether TypeBox or plain TS) imports the same values.
+
+```ts
+// shared file
+export const RARITIES = ['Common', 'Uncommon', ...] as const
+
+// interfaces.d.ts uses RARITIES for input
+// @tcgdex/schema uses RARITIES for output
+```
+
+**What this captures:** the biggest drift risk in practice is enum values — new rarities get added to `interfaces.d.ts` when a set drops, and the SDK type stays as bare `string`. Sharing the enum arrays eliminates that risk regardless of which side owns the shapes.
+
+**What this preserves:** two distinct shape authorings, because input ≠ output (localization, augmentation). Contributors keep their input file; the schema keeps its output file; neither side has to know about the other beyond the shared enum imports.
+
+This hybrid is compatible with the RFC as proposed — it can be adopted as a follow-up regardless of whether the schema is TypeBox-authored or `typescript-json-schema`-derived. Low-cost, high-value.
+
+### Why the RFC still proposes TypeBox + peer package
+
+The current proposal preserves three things Alternative A gives up:
+
+1. **Free runtime validation** — TypeBox schemas double as validators. For downstream consumers who *do* want to validate (backend proxies, cached-response verifiers, defensive JS SDKs), this is a real benefit.
+2. **Vendor extensions as first-class schema options** — `x-extensible-enum` on `OpenEnum(RARITIES)` is more ergonomic and less tool-dependent than JSDoc annotations.
+3. **Independent versioning of the type contract** — a peer package can version separately from card data. A schema change ships without waiting for a set release; a set release ships without touching the schema.
+
+But the alternative is a legitimate reading of the same diagnosis, and the RFC does not consider it settled. If maintainers prefer the derivation-from-input approach, the POC can be rebuilt on `typescript-json-schema` — the RFC's structural claims all still hold.
 
 ---
 
@@ -336,3 +438,6 @@ No. The JS SDK uses it as a devDependency for `implements` type checking. The sc
 
 **What about the Card generic (`Card<SetType>`)?**  
 It's vestigial. `Card<SetType extends SetResume = SetResume>` is never instantiated with a non-default argument anywhere in the server or SDK. The schema models `set` as concrete `SetResume`. The generic can be preserved for backwards compatibility in the SDK class if needed, but the schema doesn't encode it.
+
+**Why publish `@tcgdex/schema` as its own npm package instead of folding it into cards-database or the SDK?**  
+Three reasons: (1) different concerns and release cadences — schema changes when the type contract changes; card data changes when a new set drops. Coupling them forces artificial version bumps. (2) Third-party consumability — anyone building against the TCGdex API without the first-party SDK can `npm i @tcgdex/schema` for types + validators + enum constants. Folded into cards-database, `npm i @tcgdex/cards-database` for a frontend is a non-starter. (3) The pattern is well-established (Stripe, AWS, Anthropic all ship types packages independently of full SDKs). See [The schema as a public API contract](#the-schema-as-a-public-api-contract) for the full case.

--- a/schema/RFC.md
+++ b/schema/RFC.md
@@ -91,6 +91,26 @@ The output contract — the shapes clients receive from the API:
 | `Serie` | Full serie (extends SerieResume, adds sets) |
 | `Variants` | The four boolean variant flags |
 
+### Language coverage
+
+Consumers in any language can build against the schema. Two distribution channels:
+
+- **JS/TS consumers** install `@tcgdex/schema` from npm — types, runtime validators, and enum constants ready to import
+- **All other languages** consume `openapi.json` from the GitHub Release — feed it to `openapi-generator`, `quicktype`, Microsoft `Kiota`, Apple `swift-openapi-generator`, `datamodel-code-generator` (Pydantic), or any of the ~50+ tools that target OpenAPI 3.1 as an IDL
+
+| Language | Toolchain examples |
+|---|---|
+| Python | `openapi-generator`, `datamodel-code-generator` (Pydantic) |
+| Java / Kotlin | `openapi-generator`, `Kiota` |
+| Go | `openapi-generator`, `oapi-codegen` |
+| Rust | `openapi-generator`, `progenitor` |
+| Swift | `openapi-generator`, `swift-openapi-generator` (Apple official) |
+| C# / .NET | `openapi-generator`, `NSwag`, `Kiota` |
+| Ruby, PHP, Dart, Elixir, Scala, Perl, Haskell, R, Julia … | `openapi-generator` |
+| Any language | `quicktype`, `Speakeasy`, `Fern` |
+
+The schema package is authored in TypeScript, but the contract it publishes (`openapi.json`) is language-agnostic. Adding a new SDK target means writing one CI workflow (see [`docus/workflows/sdk-regenerate.yml`](./docus/workflows/sdk-regenerate.yml)), not hand-authoring types.
+
 ### Open vs. Closed Enums
 
 Not all enums grow at the same rate. The schema distinguishes:
@@ -258,6 +278,66 @@ const doc = {
 ```
 
 The schemas drop in directly because TypeBox schemas are JSON Schema — no conversion step. Path/operation definitions still need to be maintained separately (they describe routing, not data shapes), but the `components/schemas` section — the largest and most drift-prone part — is now generated.
+
+---
+
+## Documentation site
+
+Docs drift is the same root cause as type drift: hand-maintained documentation of shapes that live somewhere else. Every reported "the docs say X but the API returns Y" bug is the same failure mode this RFC diagnoses for SDK types, just downstream of a different consumer.
+
+Once `dist/openapi.json` exists as a first-class artifact, it becomes the source of truth for reference documentation the same way it does for SDKs. Any mainstream OpenAPI renderer consumes it directly:
+
+- **Redoc** — single-page reference, embeddable as `<redoc spec-url="openapi.json">`
+- **Swagger UI** — already what `tcgdex.dev` serves at `/v2/openapi`; would consume the generated file instead of the hand-maintained YAML
+- **Stoplight Elements** — modern web components, embeddable in an existing site
+- **Mintlify, Fern, Bump.sh, Scalar** — hosted docs platforms with rich UX, all consume OpenAPI directly
+
+### What stops drifting
+
+Comparing the categories of "wrong docs" reports to what schema-driven reference eliminates:
+
+| Doc bug class | Currently possible? | After schema adoption? |
+|---|---|---|
+| "Docs list field X but API returns Y" | Yes | No — reference *is* the schema |
+| "Field typed `string` in docs but `number` in reality" | Yes | No |
+| "Rarity 'X' isn't in the docs list" | Yes | No — `x-extensible-enum` carries through |
+| "Endpoint returns 429 but docs don't mention it" | Yes | No — error responses are modelled |
+| "Filter param name typo" | Yes | No — params live in the schema |
+| "Example response is stale" | Yes | Partially — see below |
+
+### What still needs hand-authoring
+
+Prose material — getting-started tutorials, "how pagination works" explainers, filter syntax examples, migration guides between API versions — stays hand-written. But that's a **bounded surface** that changes rarely. The volatile, drift-prone parts are exactly the parts the schema owns.
+
+The docs site becomes a two-layer structure, matching the pattern used by Stripe, Anthropic, GitHub, and every modern API docs site:
+
+- **Reference (auto)** — endpoints, schemas, enums, error shapes, request/response examples → rendered from `openapi.json`
+- **Guides (hand)** — tutorials, concepts, migration guides → prose, with links into the auto-generated reference
+
+Prose can still be wrong, but it can't lie about field types — the reference is right there next to it.
+
+### Live example responses
+
+`build/validate-live.ts` currently validates a live card against the schema. A two-line extension makes it dump the validated card as an OpenAPI `example` on the response:
+
+```ts
+// after C.Check(data) passes:
+const responseExample = { summary: 'Live Charizard', value: data }
+// injected into openapi.json under paths['/cards/{cardId}'].get.responses['200'].content['application/json'].examples
+```
+
+Docs then show a **real API response** as the example, not a hand-typed placeholder that goes stale on the next set release. Runs in CI on every schema build; examples update automatically alongside the schema.
+
+### Migration path
+
+The docs site adoption is Stage 2 work — non-breaking, independent of SDK adoption:
+
+1. Point the existing swagger-ui at the generated `openapi.json` instead of the hand-maintained YAML
+2. Optionally add a richer renderer (Redoc / Stoplight / Mintlify) for the reference layer
+3. Deprecate `server/public/v2/openapi.yaml` once parity is confirmed
+4. Prose guides live wherever they live today — untouched
+
+No content is lost; the drift-prone reference layer just stops being hand-maintained.
 
 ---
 

--- a/schema/build/emit-dts.ts
+++ b/schema/build/emit-dts.ts
@@ -1,0 +1,24 @@
+import { writeFileSync, mkdirSync } from 'node:fs'
+import { compile } from 'json-schema-to-typescript'
+import { Card } from '../src/card.js'
+import { Set, Serie } from '../src/set.js'
+import { CardResume, SetResume, SerieResume, Variants } from '../src/resume.js'
+
+// TypeBox schemas ARE JSON Schema, so we hand them straight to json-schema-to-typescript.
+const schemas: Array<[string, object]> = [
+  ['Variants', Variants], ['CardResume', CardResume], ['SetResume', SetResume],
+  ['SerieResume', SerieResume], ['Card', Card], ['Set', Set], ['Serie', Serie],
+]
+
+const parts: string[] = []
+for (const [name, schema] of schemas) {
+  const ts = await compile(schema as never, name, {
+    additionalProperties: false, // keep the .d.ts clean; runtime stays permissive (see validate)
+    bannerComment: '',
+  })
+  parts.push(ts.trim())
+}
+
+mkdirSync('dist', { recursive: true })
+writeFileSync('dist/types.d.ts', parts.join('\n\n') + '\n')
+console.log('→ dist/types.d.ts')

--- a/schema/build/emit-openapi.ts
+++ b/schema/build/emit-openapi.ts
@@ -1,0 +1,233 @@
+import { writeFileSync, mkdirSync } from 'node:fs'
+import { dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { resolve } from 'node:path'
+import {
+  CardSchema,
+  SetSchema,
+  SerieSchema,
+  CardResumeSchema,
+  SetResumeSchema,
+  SerieResumeSchema,
+  VariantsSchema,
+} from '../src/index.js'
+import { LANGUAGES } from '../src/enums.js'
+
+// ── output path ─────────────────────────────────────────────
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const OUT = resolve(__dirname, '../dist/openapi.json')
+
+// ── RFC 9457 problem+json (the error contract) ─────────────
+const Problem = {
+  type: 'object',
+  properties: {
+    type: { type: 'string' },
+    title: { type: 'string' },
+    status: { type: 'integer' },
+    detail: { type: 'string' },
+    endpoint: { type: 'string' },
+    method: { type: 'string' },
+  },
+  required: ['type', 'title', 'status'],
+}
+
+// ── shared parameters (filtering/sorting/pagination) ────────
+const commonParams = {
+  Pagination: [
+    { name: 'pagination:page', in: 'query', schema: { type: 'integer', minimum: 1 } },
+    { name: 'pagination:itemsPerPage', in: 'query', schema: { type: 'integer', minimum: 1, maximum: 250 } },
+  ],
+  Sort: [
+    { name: 'sort:field', in: 'query', schema: { type: 'string' } },
+    { name: 'sort:order', in: 'query', schema: { type: 'string', enum: ['ASC', 'DESC'] } },
+  ],
+}
+
+const problemResponse = (status: number, title: string) => ({
+  description: title,
+  content: { 'application/problem+json': { schema: { $ref: '#/components/schemas/Problem' } } },
+})
+
+// ── path builders ────────────────────────────────────────────
+type Op = { tags: string[]; summary: string; description?: string; parameters?: any[]; responses: any }
+
+const jsonResponse = (ref: string) => ({
+  description: 'OK',
+  content: { 'application/json': { schema: { $ref: `#/components/schemas/${ref}` } } },
+})
+
+const jsonListResponse = (ref: string) => ({
+  description: 'OK',
+  content: { 'application/json': { schema: { type: 'array', items: { $ref: `#/components/schemas/${ref}` } } } },
+})
+
+const jsonStringListResponse = () => ({
+  description: 'OK',
+  content: { 'application/json': { schema: { type: 'array', items: { type: 'string' } } } },
+})
+
+const notFound = problemResponse(404, 'Not Found')
+const rateLimit = problemResponse(429, 'Rate Limited')
+
+// Filter-style endpoints: /rarities → string[], /rarities/{rarity} → StringEndpoint
+const filterEndpoint = (path: string, paramName: string, tag: string): Record<string, any> => ({
+  [`/${path}`]: {
+    get: {
+      tags: [tag],
+      summary: `List all ${path}`,
+      parameters: [...commonParams.Pagination, ...commonParams.Sort],
+      responses: { '200': jsonStringListResponse(), '429': rateLimit },
+    },
+  },
+  [`/${path}/{${paramName}}`]: {
+    get: {
+      tags: [tag],
+      summary: `Get cards by ${paramName}`,
+      parameters: [
+        { name: paramName, in: 'path', required: true, schema: { type: 'string' } },
+        ...commonParams.Pagination,
+      ],
+      responses: {
+        '200': jsonResponse('StringEndpoint'),
+        '404': notFound,
+        '429': rateLimit,
+      },
+    },
+  },
+})
+
+const filterEndpoints = [
+  ['categories', 'category', 'filters'],
+  ['hp', 'hp', 'filters'],
+  ['illustrators', 'illustrator', 'filters'],
+  ['rarities', 'rarity', 'filters'],
+  ['retreats', 'retreat', 'filters'],
+  ['types', 'type', 'filters'],
+  ['dex-ids', 'dexId', 'filters'],
+  ['energy-types', 'energy-type', 'filters'],
+  ['regulation-marks', 'regulation-mark', 'filters'],
+  ['stages', 'stage', 'filters'],
+  ['suffixes', 'suffix', 'filters'],
+  ['trainer-types', 'trainer-type', 'filters'],
+  ['variants', 'variant', 'filters'],
+] as const
+
+// ── assemble the document ───────────────────────────────────
+const doc = {
+  openapi: '3.1.0',
+  info: {
+    title: 'TCGdex API',
+    description:
+      'A Multilanguage Pokémon TCG Database. Error responses follow RFC 9457 (application/problem+json). ' +
+      'List endpoints support filtering, sorting, and pagination — see https://tcgdex.dev/rest/filtering-sorting-pagination.',
+    contact: { name: 'TCGdex', url: 'https://github.com/tcgdex/cards-database', email: 'contact@tcgdex.net' },
+    license: { name: 'MIT', url: 'https://github.com/tcgdex/cards-database/blob/master/LICENSE' },
+    version: '2',
+  },
+  externalDocs: { description: 'TCGdex docs', url: 'https://www.tcgdex.net/docs' },
+  servers: [
+    {
+      url: 'https://api.tcgdex.net/v2/{lang}',
+      variables: {
+        lang: { enum: [...LANGUAGES], default: 'en' },
+      },
+    },
+  ],
+  tags: [
+    { name: 'cards', description: 'Fetch cards globally' },
+    { name: 'sets', description: 'Fetch sets and cards within them' },
+    { name: 'series', description: 'Fetch card series' },
+    { name: 'filters', description: 'Filter cards by attribute' },
+  ],
+  paths: {
+    '/cards': {
+      get: {
+        tags: ['cards'],
+        summary: 'List cards',
+        parameters: [...commonParams.Pagination, ...commonParams.Sort],
+        responses: { '200': jsonListResponse('CardResume'), '429': rateLimit },
+      },
+    },
+    '/cards/{cardId}': {
+      get: {
+        tags: ['cards'],
+        summary: 'Get a card by id',
+        parameters: [{ name: 'cardId', in: 'path', required: true, schema: { type: 'string' } }],
+        responses: { '200': jsonResponse('Card'), '404': notFound, '429': rateLimit },
+      },
+    },
+    '/sets': {
+      get: {
+        tags: ['sets'],
+        summary: 'List sets',
+        parameters: [...commonParams.Pagination, ...commonParams.Sort],
+        responses: { '200': jsonListResponse('SetResume'), '429': rateLimit },
+      },
+    },
+    '/sets/{set}': {
+      get: {
+        tags: ['sets'],
+        summary: 'Get a set',
+        parameters: [{ name: 'set', in: 'path', required: true, schema: { type: 'string' } }],
+        responses: { '200': jsonResponse('Set'), '404': notFound, '429': rateLimit },
+      },
+    },
+    '/sets/{set}/{cardLocalId}': {
+      get: {
+        tags: ['cards'],
+        summary: 'Get a card by set + local id',
+        parameters: [
+          { name: 'set', in: 'path', required: true, schema: { type: 'string' } },
+          { name: 'cardLocalId', in: 'path', required: true, schema: { type: 'string' } },
+        ],
+        responses: { '200': jsonResponse('Card'), '404': notFound, '429': rateLimit },
+      },
+    },
+    '/series': {
+      get: {
+        tags: ['series'],
+        summary: 'List series',
+        parameters: [...commonParams.Pagination, ...commonParams.Sort],
+        responses: { '200': jsonListResponse('SerieResume'), '429': rateLimit },
+      },
+    },
+    '/series/{serie}': {
+      get: {
+        tags: ['series'],
+        summary: 'Get a serie',
+        parameters: [{ name: 'serie', in: 'path', required: true, schema: { type: 'string' } }],
+        responses: { '200': jsonResponse('Serie'), '404': notFound, '429': rateLimit },
+      },
+    },
+    // filter endpoints (13 pairs) generated declaratively
+    ...Object.assign({}, ...filterEndpoints.map(([p, n, t]) => filterEndpoint(p, n, t))),
+  },
+  components: {
+    schemas: {
+      Card: CardSchema,
+      CardResume: CardResumeSchema,
+      Set: SetSchema,
+      SetResume: SetResumeSchema,
+      Serie: SerieSchema,
+      SerieResume: SerieResumeSchema,
+      Variants: VariantsSchema,
+      StringEndpoint: {
+        type: 'object',
+        properties: {
+          name: { type: 'string' },
+          cards: { type: 'array', items: { $ref: '#/components/schemas/CardResume' } },
+        },
+        required: ['name', 'cards'],
+      },
+      Problem,
+    },
+  },
+}
+
+// ── write ────────────────────────────────────────────────────
+mkdirSync(dirname(OUT), { recursive: true })
+writeFileSync(OUT, JSON.stringify(doc, null, 2))
+const pathCount = Object.keys(doc.paths).length
+const schemaCount = Object.keys(doc.components.schemas).length
+console.log(`✓ wrote ${OUT}`)
+console.log(`  ${pathCount} paths, ${schemaCount} schemas`)

--- a/schema/build/validate-live.ts
+++ b/schema/build/validate-live.ts
@@ -1,0 +1,22 @@
+import { TypeCompiler } from '@sinclair/typebox/compiler'
+import { Card } from '../src/card.js'
+
+const C = TypeCompiler.Compile(Card)
+const [lang, id] = ['en', 'base1-4'] // Charizard, Base Set — stable
+const url = `https://api.tcgdex.net/v2/${lang}/cards/${id}`
+
+const res = await fetch(url)
+if (!res.ok) { console.error(`fetch failed: ${res.status} ${url}`); process.exit(1) }
+const data = await res.json() as Record<string, unknown>
+
+if (C.Check(data)) {
+  console.log(`✓ live ${id} validates against Card`)
+  // Show the drift: fields the server actually returns that the schema (and the SDK type) omit.
+  const known = new Set(Object.keys((Card as { properties: object }).properties))
+  const extra = Object.keys(data).filter((k) => !known.has(k))
+  if (extra.length) console.log(`  note: response also has un-modeled fields: ${extra.join(', ')}`)
+} else {
+  console.log(`✗ ${id} mismatches (each one is a real finding, not a demo bug):`)
+  for (const e of C.Errors(data)) console.log(`  ${e.path}: ${e.message}`)
+  process.exit(1)
+}

--- a/schema/docus/implementation-followups.md
+++ b/schema/docus/implementation-followups.md
@@ -1,0 +1,178 @@
+# Implementation follow-ups
+
+Known gaps in the current POC and RFC wording that need addressing before the
+schema package can honestly claim production readiness. Each item is a real
+critique of what's in the tree today — not future feature work.
+
+Grouped by kind:
+1. **POC code gaps** — the demo works but its coverage/rigour is thin
+2. **RFC wording corrections** — claims that overreach the current implementation
+3. **Design refinements** — decisions the RFC asserts without adequate treatment
+
+---
+
+## 1. POC code gaps
+
+### 1.1 Provider-specific pricing schemas, including null
+
+**Current state:** `src/card.ts` models pricing as a loose `Record<string, number>` per provider — a placeholder shape. The actual CardMarket and TCGPlayer responses have provider-specific price keys (`averageSellPrice`, `lowPrice`, `trendPrice` for CardMarket; `market`, `low`, `mid`, `high` for TCGPlayer), each with their own optionality and semantics. Pricing objects can also be `null` when the provider has no data for a card, and the current schema doesn't model that.
+
+**What to do:** define `CardmarketPricing` and `TCGPlayerPricing` as first-class schemas with their real fields typed. Make both root `pricing` and per-variant `pricing` nullable via `Type.Union([..., Type.Null()])`. Cross-reference against `server/src/libs/providers/cardmarket.ts` and `.../tcgplayer.ts` for the authoritative field lists.
+
+**Blocks:** Stage 2 SDK adoption — non-JS SDK consumers get a `Record<string, number>` type today, which is nearly useless.
+
+### 1.2 Strict nested validation that detects unmodelled fields
+
+**Current state:** `validate-live.ts` uses TypeBox's `TypeCompiler.Compile(Card).Check(data)`, which by default allows additional properties. Un-modelled fields aren't caught by `Check` — only by the manual `Object.keys(data).filter(k => !known.has(k))` diff at the top level. That diff doesn't recurse into `set`, `variants_detailed[]`, `attacks[]`, etc.
+
+**What to do:** either (a) mark every schema `Type.Object(..., { additionalProperties: false })` and re-run — will surface every extra field with a clean error path, or (b) write a recursive walker that compares response keys against the schema tree. Option (a) is cleaner but noisier during development; option (b) is more forgiving and gives per-node reports.
+
+**Blocks:** honest "no drift" claims. Currently the RFC says validate-live is "clean" — that's true at the top level only. Nested drift is invisible.
+
+### 1.3 Fixture coverage across categories, pricing states, sets, series
+
+**Current state:** `validate-live.ts` fetches exactly one card (`base1-4`, Charizard, Base Set, Pokemon category, English). One card is not evidence — it's a smoke test.
+
+**What to do:** build a fixture set covering:
+- Every `category`: Pokemon, Trainer, Energy
+- Pricing states: cards with both providers, cardmarket-only, tcgplayer-only, no pricing at all, `null` pricing
+- Diverse sets: modern (SV era), classic (Base/Jungle), promo, digital-only
+- Diverse series: at least one card from each `Serie`
+- Each `SupportedLanguage` (at least a sample)
+- Edge shapes: cards with `variants_detailed`, cards without; cards with `boosters`, cards without; Trainer subtypes
+
+Run all fixtures through validate + strict nested check in CI. This turns "the schema works" from an assertion into a claim backed by evidence.
+
+**Blocks:** RFC's "the demo proves the drift is closed" argument. Currently proves it for one card.
+
+---
+
+## 2. RFC wording corrections
+
+### 2.1 "Single source of truth" is aspirational until Stage 4
+
+**Current state:** the RFC repeatedly calls the schema the "single source of truth" for output types. Today, and throughout Stages 1–3, the server still imports its output types from `@tcgdex/sdk`. The schema is a *proposed* SoT — the actual SoT is still the SDK until Stage 4 lands.
+
+**What to do:** audit every use of "source of truth" / "SoT" in the RFC and qualify it. Suggested rewordings:
+- Before Stage 4: "**intended** source of truth", "SoT candidate", "future SoT"
+- The Solution section can say "will become the source of truth after Stage 4"
+- The staging plan can say Stage 4 is "SoT realised"
+
+The current wording is confusing because a reader assumes SoT status the moment they read "Solution: `@tcgdex/schema`", but it's not true yet at the code level.
+
+### 2.2 Claims around `implements` and optional fields
+
+**Current state:** the RFC says `implements CardShape` "makes drift a compile error — if the schema adds a field and the class doesn't declare it, `tsc` fails." That's overstated. TypeScript's `implements` check is structural on *required* members. Optional fields on the interface don't force the class to declare them. Extra fields on the class don't fail the check either.
+
+**What to do:** correct the claim to describe what `implements` actually catches:
+- Required fields on the interface must be declared with a compatible type on the class — **yes, drift-catching**
+- Optional fields on the interface can be missing on the class — **not caught, silent gap**
+- Fields on the class that aren't on the interface — **allowed, class can extend**
+- Type narrowing (e.g. `category: 'Pokemon' | ...` on interface, `category: string` on class) — **caught**
+
+Mitigation for the optional-field gap: pair `implements` with a linter rule or a codegen step that emits stub properties for every optional interface field. Or accept the gap and document that optional fields are best-effort.
+
+### 2.3 Tighter SDK types are *source-breaking*, not "backwards-compatible"
+
+**Current state:** Stage 2 of the staging plan claims "**Non-breaking** — tighter types are backwards-compatible." That's wrong.
+
+Narrowing `category: string` → `category: 'Pokemon' | 'Trainer' | 'Energy'` breaks consumer code like:
+
+```ts
+if (card.category === 'unknown') { ... }   // TS error after tightening
+const map: Record<string, SomeHandler> = { ... }
+map[card.category]?.(card)                  // still works but subtler shifts if map keys change
+```
+
+Runtime behaviour is unchanged, but consumer TS code that compiled before may not compile after. That's a **source-breaking change** — not runtime-breaking, but breaking nonetheless.
+
+**What to do:** reword Stage 2 to say:
+
+> Tightening open enums to closed unions is **source-breaking** for consumers who type-check against the wider `string` type (e.g. comparing to unknown literal values or using it as a `Record<string, T>` key). Runtime behaviour is unchanged. Ships behind a schema major-version bump so consumers can opt in.
+
+Options to soften the transition:
+- Ship type tightening in the schema's own major bump (`1.0.0` → `2.0.0`), not in a patch
+- Provide a `@tcgdex/schema/loose` export that keeps enums as `string` for consumers who need time to migrate
+- Document specific known-broken patterns in a migration guide
+
+### 2.4 OpenAPI/docs guarantees around manually maintained paths
+
+**Current state:** the RFC's Documentation site section implies the docs become drift-free. But path definitions in `emit-openapi.ts` are **still hand-authored** — routes, parameters, `operationId`s, response codes. If the server adds a route and the emit script isn't updated, docs and reality drift again. The claim covers `components/schemas` well; it overstates coverage for paths.
+
+**What to do:** rewrite the "What stops drifting" table to distinguish:
+- **Component schemas (auto):** field types, enum values, error shapes, request/response bodies — genuinely drift-free
+- **Path definitions (manual):** endpoint URLs, method, parameters, status codes — still hand-authored, can drift
+
+Add a follow-up bullet to Stage 2:
+> Path definitions in `emit-openapi.ts` are currently hand-authored. Automating them would require introspection of the server's Express router — deferred to Stage 2b or later. Until then, adding a route in the server means updating `emit-openapi.ts` too.
+
+Also tone down "auto-generated reference" to "auto-generated schema reference; path reference is still maintained alongside the router."
+
+---
+
+## 3. Design refinements
+
+### 3.1 Keep wire DTOs separate from idiomatic SDK model shapes
+
+**Current state:** the RFC proposes JS SDK classes `implements CardShape` directly from the schema. But the schema is authored in **wire format** — snake_case `variants_detailed`, optional-vs-nullable ambiguity, no computed properties. Idiomatic JS SDK shapes are camelCase (`variantsDetailed`), have computed accessors (`getImageURL()`, `getCard()`), and may narrow or reshape fields for ergonomics.
+
+Forcing `implements CardShape` on JS SDK classes either (a) drags wire-format naming into JS SDK consumer code, or (b) breaks the `implements` check when the class uses idiomatic naming.
+
+**What to do:** treat the schema as **wire DTOs** and let SDKs define their own idiomatic **model shapes** on top:
+
+```
+@tcgdex/schema (wire DTOs — snake_case, faithful to HTTP response)
+        ↓ importable, but not implemented
+@tcgdex/sdk (idiomatic model classes — camelCase, methods, accessors)
+        ↑ fill() translates wire → model at deserialization
+```
+
+The SDK's `fill()` already does the `variants_detailed` → `variantsDetailed` remap. Formalise that: wire and model are two shapes, connected by an explicit adapter. `implements CardShape` doesn't apply to model classes; instead the SDK's *DTO layer* imports `CardShape` for its fetch/validation boundary, and the *model layer* is a separate translation.
+
+Non-JS SDKs face the same choice per language convention.
+
+Update the RFC's JS SDK Integration section accordingly. The current "just add `implements`" pitch is too glib.
+
+### 3.2 Share enum arrays with the input definitions immediately
+
+**Current state:** `schema/src/enums.ts` copies the enum lists (`RARITIES`, `STAGES`, `SUFFIXES`, `POKEMON_TYPES`, etc.) verbatim from `interfaces.d.ts`. Two lists, one truth in name only. If someone adds a rarity to `interfaces.d.ts` and forgets the schema, drift starts on day one.
+
+**What to do:** don't wait for Alternative B / a later stage — extract the enum arrays into a shared location that both `interfaces.d.ts` and the schema import. Options:
+
+- New file `interfaces/enums.ts` at the cards-database root, exporting the arrays as `const`. Both `interfaces.d.ts` (for input types) and `schema/src/enums.ts` (for output schemas) import from it.
+- Or put the arrays in `schema/src/enums.ts` and have `interfaces.d.ts` import them (schema becomes the enum SoT).
+
+Either way, the duplication ends immediately, not "eventually." This is a one-hour fix and it moots the entire enum-drift risk that the RFC spends multiple paragraphs framing.
+
+Bump the "shared enum hybrid" mention in Considered Alternatives from "compatible follow-up" to "adopted in the POC."
+
+### 3.3 Query contract — implement or defer
+
+**Current state:** the RFC's "Query authoring" section promises typed filter DX:
+
+> `filter('rarity', 'Rare')` type-checks; `filter('rarity', 'super-rare')` errors before the request fires
+
+But there's **no query contract in the schema**. Filter/sort/pagination params are in the OpenAPI as query parameters (`pagination:page`, `sort:field`, etc.), but the *filter grammar* (which fields are filterable, what operators are supported, how nested paths encode) is not modelled. The DX claim can't be delivered by anything in this PR.
+
+**What to do:** pick one:
+- **(a) Implement a real query contract.** Add a `QuerySchema` that enumerates filterable fields per resource, valid operators per field type, and the wire encoding. Expose it as a runtime constant and a type. This is a real design task — probably a follow-up RFC.
+- **(b) Move the query-authoring promises to future work.** Rewrite the section to say "the OpenAPI document describes the query parameter surface at the parameter-name level; a richer typed query contract is a future addition." Remove the `filter('rarity', 'Rare')` example — it's aspirational, not shipped.
+
+Recommendation: (b) for this RFC, then (a) as a follow-up RFC once the schema lands. The query contract deserves its own design conversation and shouldn't be smuggled in as a downstream benefit of this PR.
+
+---
+
+## Handling in the RFC
+
+The corrections in sections 2 and 3 should land as edits to `RFC.md` before the PR is treated as final. The code gaps in section 1 are POC-level — either fix in this PR or link to this document from the RFC as "known limitations of the demo, tracked here."
+
+Suggested minimum for a "final" RFC:
+- Reword all "single source of truth" claims (2.1)
+- Correct the `implements` characterisation (2.2)
+- Reword Stage 2 as source-breaking (2.3)
+- Split component-drift vs path-drift in the docs section (2.4)
+- Add the wire DTO / model shape separation (3.1) — probably as a subsection under JS SDK Integration
+- Fix the enum duplication in the POC and cite it as done (3.2)
+- Move or implement the query contract (3.3)
+
+The remaining POC gaps (1.1–1.3) are honest to leave as "follow-ups tracked in `docus/implementation-followups.md`" — the demo doesn't have to be production-grade to make the case.

--- a/schema/docus/python-template-sketch.mustache
+++ b/schema/docus/python-template-sketch.mustache
@@ -1,0 +1,49 @@
+{{! ─────────────────────────────────────────────────────────────────────────
+    SKETCH — this template is illustrative, not working.
+
+    Intent: override openapi-generator's Python `model_generic.mustache` so
+    that any string field carrying an `x-extensible-enum` vendor extension
+    generates a real Python enum (with an `UNKNOWN` fallback via `_missing_`)
+    instead of a bare `str`.
+
+    Known bug: the `{{> model_field }}` fall-through partial does not exist
+    in the openapi-generator Python target — its default field rendering
+    isn't extracted into a named partial. To make this template actually
+    work, you need to:
+      1. Dump the target's default via
+         `openapi-generator-cli author template -g python`
+      2. Locate the field-rendering block inside `model_generic.mustache`
+      3. Wrap that block in the `x-extensible-enum` guard shown below,
+         leaving the default rendering intact for all other fields
+
+    Stage 2b of the RFC — non-blocking for the schema PR itself. Kept in
+    the tree as a design sketch so future work has a starting point.
+    ────────────────────────────────────────────────────────────────────── }}
+{{#vars}}
+    {{#vendorExtensions.x-extensible-enum}}
+    class {{nameInCamelCase}}Values(str, Enum):
+        """Known values for {{name}}. Unknown values are preserved as raw strings
+        via the UNKNOWN fallback — open enum semantics."""
+        {{#vendorExtensions.x-extensible-enum}}
+        {{{.}}} = "{{{.}}}"
+        {{/vendorExtensions.x-extensible-enum}}
+        UNKNOWN = "__unknown__"
+
+        @classmethod
+        def _missing_(cls, value):
+            """Called when a value isn't in the enum — open-enum behavior.
+            Returns UNKNOWN so unrecognized rarities (new set releases) don't crash."""
+            obj = object.__new__(cls)
+            obj._value_ = value
+            return obj
+
+    {{name}}: Union[{{nameInCamelCase}}Values, str] = Field(
+        default={{#defaultValue}}{{{defaultValue}}}{{/defaultValue}}{{^defaultValue}}None{{/defaultValue}},
+        description="{{{description}}}",
+    )
+    {{/vendorExtensions.x-extensible-enum}}
+    {{^vendorExtensions.x-extensible-enum}}
+    {{! fall through to default field rendering }}
+    {{> model_field }}
+    {{/vendorExtensions.x-extensible-enum}}
+{{/vars}}

--- a/schema/docus/sdk-migration.md
+++ b/schema/docus/sdk-migration.md
@@ -1,0 +1,156 @@
+# Migrating @tcgdex/sdk onto @tcgdex/schema
+
+The JS SDK is two layers: **data shapes** (interfaces describing what the API
+returns) and **runtime model classes** (behavior — `getImageURL()`, `getCard()`,
+`Endpoint`, `TCGdex`, `Model.fill()`). `@tcgdex/schema` replaces layer 1. Layer 2
+stays untouched, and its class properties become checked against the schema
+instead of hand-declared in isolation.
+
+The migration is **non-breaking for SDK consumers** — types get tighter (closed
+enums become real unions), never looser.
+
+---
+
+## 1. Add `@tcgdex/schema` as a devDependency
+
+```json
+{
+  "devDependencies": {
+    "@tcgdex/schema": "^1.0.0"
+  }
+}
+```
+
+Types-only — the schema types are erased at compile time. Zero bytes added to
+the SDK's published bundle. No runtime dependency unless you opt into runtime
+validation (see [§4](#4-optional-runtime-validation)).
+
+---
+
+## 2. Add `implements` to each model class
+
+The SDK's model classes (`Card`, `Set`, `Serie`, `CardResume`, `SetResume`,
+`SerieResume`) each declare their properties by hand and extend a `Model` base
+that copies API response properties onto `this` via `fill()`. Keep that
+architecture — just add `implements` so the class's properties are checked
+against the schema's contract.
+
+**Before** — `src/models/Card.ts` hand-defines the shape (which drifts from what
+the server actually returns):
+
+```ts
+import CardResume from './CardResume'
+import type { Variants, VariantsDetailed } from './Other'
+
+export default class Card extends CardResume {
+  public rarity!: string          // schema knows this is Rarity (open) with 40 known values
+  public category!: string        // schema knows this is "Pokemon" | "Trainer" | "Energy" (closed union)
+  public types?: Array<string>    // schema knows this is Array<PokemonType> (closed union)
+  public stage?: string
+  public suffix?: string
+  public variants?: Variants
+  public variantsDetailed?: Array<VariantsDetailed>
+  // …
+  // Missing entirely: `pricing` and `updated` — served by the API, never typed
+}
+```
+
+**After** — add `implements Card` from `@tcgdex/schema`:
+
+```ts
+import type { Card as CardShape } from '@tcgdex/schema'
+import CardResume from './CardResume'
+
+export default class Card extends CardResume implements CardShape {
+  public rarity!: string
+  public category!: 'Pokemon' | 'Trainer' | 'Energy'   // tightened by the implements check
+  public types?: Array<'Colorless' | 'Darkness' | 'Dragon' | 'Fairy' | 'Fighting' | 'Fire' | 'Grass' | 'Lightning' | 'Metal' | 'Psychic' | 'Water'>
+  public stage?: string
+  public suffix?: string
+  public variants?: CardShape['variants']
+  public variants_detailed?: CardShape['variants_detailed']   // schema's wire-format field (see §3)
+  public pricing?: CardShape['pricing']                       // NEW — previously a ghost property
+  public updated?: string                                     // NEW — previously a ghost property
+  // …
+}
+```
+
+Once `implements CardShape` is in place, any future schema change that isn't
+mirrored on the class causes `tsc` to fail. Drift becomes a compile error.
+
+The generated `dist/types.d.ts` in this POC package is your reference for what
+the closed-enum unions look like.
+
+---
+
+## 3. Handle the wire-format vs. camelCase naming
+
+The API returns `variants_detailed` (snake_case). The SDK's current `Card` class
+presents `variantsDetailed` (camelCase) and rewrites the key in a `fill()`
+override:
+
+```ts
+protected override fill(obj: object): void {
+  objectLoop(obj, (value, key: string) => {
+    if (key === 'variants_detailed') {
+      key = 'variantsDetailed'
+    }
+    (this as any)[key] = value
+  })
+}
+```
+
+The schema is authoritative for the **wire format** — it uses
+`variants_detailed` because that's what the API sends and what validators check
+against. Two options for the SDK:
+
+**Option A (recommended for this iteration): match the wire format.**
+Rename the class property `variantsDetailed` → `variants_detailed`, remove the
+`fill()` remap. Simpler; no divergence between the class shape and the schema.
+
+**Option B: keep the camelCase convention, defer a mapped type.**
+Keep `variantsDetailed` on the class, drop `implements CardShape` on this one
+field, and add a follow-up to `@tcgdex/schema` to export a
+`CamelCard` mapped type. Then `implements CamelCard` restores full checking.
+
+Option A is a one-line breaking change on one field name. Option B preserves
+JS-idiom naming at the cost of a schema utility type. Team call.
+
+---
+
+## 4. Optional: runtime validation
+
+If you want to catch server-side regressions where the API starts returning
+something the schema doesn't allow, validate at the fetch boundary:
+
+```ts
+import { CardSchema } from '@tcgdex/schema'
+import { TypeCompiler } from '@sinclair/typebox/compiler'
+
+const CardValidator = TypeCompiler.Compile(CardSchema)
+
+// in the fetch path (once per SDK init, then reused):
+const data = await res.json()
+if (!CardValidator.Check(data)) {
+  const errors = [...CardValidator.Errors(data)]
+  throw new Error(`API response does not match Card schema: ${errors[0].message}`)
+}
+```
+
+This is opt-in. Adding it introduces a small runtime dependency on
+`@sinclair/typebox` (~30KB minified). Skip if you want to keep the SDK bundle
+lean; add it later if drift becomes a support-load issue.
+
+---
+
+## 5. What doesn't change
+
+- The `Model` base class, `fill()`, `Endpoint`, `TCGdex`, `getImageURL()`, all
+  fetch logic — untouched
+- Every public method on the SDK models — untouched
+- The published SDK API surface — unchanged (types get tighter but no new
+  imports required)
+- The class hierarchy (`Card extends CardResume`, etc.) — unchanged
+
+Consumers of `@tcgdex/sdk` see one thing on upgrade: cleaner autocomplete on
+enum fields. Every existing use site keeps working.

--- a/schema/docus/workflows/README.md
+++ b/schema/docus/workflows/README.md
@@ -1,0 +1,39 @@
+# Example workflows
+
+These YAML files illustrate the **Stage 2b** rollout described in the RFC —
+they are not wired up in this PR and are not run by GitHub. Their location
+under `docus/` (rather than `.github/workflows/`) ensures GitHub ignores them.
+
+Two workflows form the full loop:
+
+| File | Repo | Trigger | Purpose |
+|------|------|---------|---------|
+| `publish-and-notify.yml` | `tcgdex/cards-database` | `push` on `schema-v*` tag | Publish `@tcgdex/schema` to npm, upload `openapi.json` as release asset, dispatch to all SDK repos |
+| `sdk-regenerate.yml` | Each SDK repo (`sdk-python`, `sdk-java`, …) | `repository_dispatch: schema-released` | Download `openapi.json`, run `openapi-generator-cli`, open a PR with regenerated models |
+
+## Data flow
+
+    schema-v1.2.0 pushed
+             │
+             ▼
+     publish-and-notify.yml (cards-database)
+        ├── npm publish @tcgdex/schema
+        ├── upload openapi.json to GH release
+        └── repository_dispatch → { sdk-python, sdk-java, sdk-kotlin, sdk-swift }
+                                          │
+                                          ▼
+                              sdk-regenerate.yml (per SDK repo)
+                                 ├── download openapi.json
+                                 ├── openapi-generator-cli generate
+                                 └── open PR (regen/schema-v1.2.0)
+
+## What's needed before wiring these up
+
+1. `@tcgdex/schema` published to npm (Stage 2a in the RFC).
+2. Per-SDK Mustache template overrides for `x-extensible-enum` handling
+   (see [`../python-template-sketch.mustache`](../python-template-sketch.mustache) —
+   a design sketch; currently not runnable, see the header note in the file).
+3. `SDK_DISPATCH_TOKEN` PAT provisioned in `tcgdex/cards-database` secrets.
+
+The JS SDK doesn't use this loop — it consumes `@tcgdex/schema` directly via
+`implements` (see `sdk-migration.md`).

--- a/schema/docus/workflows/publish-and-notify.yml
+++ b/schema/docus/workflows/publish-and-notify.yml
@@ -1,0 +1,67 @@
+# EXAMPLE — not wired up in this PR. Illustrates Stage 2b of the RFC.
+# Lives at .github/workflows/publish-and-notify.yml in tcgdex/cards-database.
+
+name: Publish @tcgdex/schema + notify SDK repos
+
+on:
+  push:
+    tags:
+      - 'schema-v*'   # e.g. schema-v1.0.0, schema-v1.1.0
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.extract.outputs.version }}
+      openapi_url: ${{ steps.upload.outputs.browser_download_url }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Extract version from tag
+        id: extract
+        run: echo "version=${GITHUB_REF_NAME#schema-v}" >> $GITHUB_OUTPUT
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          registry-url: https://registry.npmjs.org
+
+      - name: Install + build
+        working-directory: schema
+        run: |
+          npm ci
+          npm run emit:dts
+          npm run emit:openapi
+
+      - name: Publish to npm
+        working-directory: schema
+        run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Create GitHub release
+        id: release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            schema/dist/openapi.json
+            schema/dist/types.d.ts
+          body: |
+            `@tcgdex/schema@${{ steps.extract.outputs.version }}`
+
+            - `openapi.json` — full OpenAPI 3.1 document for downstream SDK codegen
+            - `types.d.ts` — reference TypeScript declarations
+
+      - name: Fan out to SDK repos
+        env:
+          GH_TOKEN: ${{ secrets.SDK_DISPATCH_TOKEN }}   # PAT with `repo` scope on the SDK repos
+          VERSION: ${{ steps.extract.outputs.version }}
+          OPENAPI_URL: https://github.com/${{ github.repository }}/releases/download/${{ github.ref_name }}/openapi.json
+        run: |
+          for repo in sdk-python sdk-java sdk-kotlin sdk-swift; do
+            echo "Dispatching to tcgdex/$repo…"
+            gh api "repos/tcgdex/$repo/dispatches" \
+              -f event_type=schema-released \
+              -f "client_payload[version]=$VERSION" \
+              -f "client_payload[openapi_url]=$OPENAPI_URL"
+          done

--- a/schema/docus/workflows/sdk-regenerate.yml
+++ b/schema/docus/workflows/sdk-regenerate.yml
@@ -1,0 +1,87 @@
+# EXAMPLE — not wired up in this PR. Illustrates Stage 2b of the RFC.
+# Lives at .github/workflows/regenerate.yml in tcgdex/sdk-python
+# (and analogously in sdk-java, sdk-kotlin, sdk-swift).
+
+name: Regenerate models from @tcgdex/schema
+
+on:
+  repository_dispatch:
+    types: [schema-released]
+
+  # Also runnable manually for testing:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Schema version (e.g. 1.2.0)'
+        required: true
+      openapi_url:
+        description: 'URL to openapi.json'
+        required: true
+
+jobs:
+  regenerate:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Resolve inputs
+        id: inputs
+        run: |
+          VERSION="${{ github.event.client_payload.version || inputs.version }}"
+          OPENAPI_URL="${{ github.event.client_payload.openapi_url || inputs.openapi_url }}"
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "openapi_url=$OPENAPI_URL" >> $GITHUB_OUTPUT
+
+      - name: Set up Java (for openapi-generator)
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 17
+
+      - name: Download OpenAPI doc
+        run: curl -fSL -o openapi.json "${{ steps.inputs.outputs.openapi_url }}"
+
+      - name: Regenerate models
+        run: |
+          npx --yes @openapitools/openapi-generator-cli generate \
+            -i openapi.json \
+            -g python \
+            -o generated \
+            -t templates/python \
+            --additional-properties=packageName=tcgdex \
+            --global-property=models,supportingFiles=false
+          # Copy just the models over — leave client + docs alone
+          rm -rf tcgdex/models
+          mv generated/tcgdex/models tcgdex/models
+
+      - name: Detect changes
+        id: diff
+        run: |
+          if git diff --quiet; then
+            echo "changed=false" >> $GITHUB_OUTPUT
+          else
+            echo "changed=true" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Open PR
+        if: steps.diff.outputs.changed == 'true'
+        uses: peter-evans/create-pull-request@v6
+        with:
+          branch: regen/schema-v${{ steps.inputs.outputs.version }}
+          title: 'Regenerate models for @tcgdex/schema v${{ steps.inputs.outputs.version }}'
+          commit-message: 'regen: models from @tcgdex/schema v${{ steps.inputs.outputs.version }}'
+          body: |
+            Automated regeneration triggered by a new `@tcgdex/schema` release.
+
+            **Source:** https://github.com/tcgdex/cards-database/releases/tag/schema-v${{ steps.inputs.outputs.version }}
+            **OpenAPI doc:** ${{ steps.inputs.outputs.openapi_url }}
+
+            Please review the diff for:
+            - New enum members (typically additive — safe)
+            - Field additions (typically additive — safe)
+            - Field removals or type changes (breaking — schema major bump)
+
+            CI will run the test suite against these regenerated models before merge.

--- a/schema/openapitools.json
+++ b/schema/openapitools.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "./node_modules/@openapitools/openapi-generator-cli/config.schema.json",
+  "spaces": 2,
+  "generator-cli": {
+    "version": "7.23.0"
+  }
+}

--- a/schema/package-lock.json
+++ b/schema/package-lock.json
@@ -1,0 +1,755 @@
+{
+  "name": "@tcgdex/schema",
+  "version": "0.0.0-demo",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@tcgdex/schema",
+      "version": "0.0.0-demo",
+      "dependencies": {
+        "@sinclair/typebox": "0.32.34"
+      },
+      "devDependencies": {
+        "json-schema-to-typescript": "^15.0.0",
+        "tsx": "^4.19.0",
+        "typescript": "^5.5.0"
+      }
+    },
+    "node_modules/@apidevtools/json-schema-ref-parser": {
+      "version": "11.9.3",
+      "resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-11.9.3.tgz",
+      "integrity": "sha512-60vepv88RwcJtSHrD6MjIL6Ta3SOYbgfnkHb+ppAVK+o9mXprRtulx7VlRl3lN3bbvysAfCS7WMVfhUYemB0IQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jsdevtools/ono": "^7.1.3",
+        "@types/json-schema": "^7.0.15",
+        "js-yaml": "^4.1.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/philsturgeon"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jsdevtools/ono": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/@jsdevtools/ono/-/ono-7.1.3.tgz",
+      "integrity": "sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@sinclair/typebox": {
+      "version": "0.32.34",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.32.34.tgz",
+      "integrity": "sha512-a3Z3ytYl6R/+7ldxx04PO1semkwWlX/8pTqxsPw4quIcIXDFPZhOc1Wx8azWmkU26ccK3mHwcWenn0avNgAKQg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/lodash": {
+      "version": "4.17.24",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.24.tgz",
+      "integrity": "sha512-gIW7lQLZbue7lRSWEFql49QJJWThrTFFeIMJdp3eH4tKoxm1OvEPg02rm4wCCSHS0cL3/Fizimb35b7k8atwsQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "license": "Python-2.0"
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/js-yaml": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/json-schema-to-typescript": {
+      "version": "15.0.4",
+      "resolved": "https://registry.npmjs.org/json-schema-to-typescript/-/json-schema-to-typescript-15.0.4.tgz",
+      "integrity": "sha512-Su9oK8DR4xCmDsLlyvadkXzX6+GGXJpbhwoLtOGArAG61dvbW4YQmSEno2y66ahpIdmLMg6YUf/QHLgiwvkrHQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@apidevtools/json-schema-ref-parser": "^11.5.5",
+        "@types/json-schema": "^7.0.15",
+        "@types/lodash": "^4.17.7",
+        "is-glob": "^4.0.3",
+        "js-yaml": "^4.1.0",
+        "lodash": "^4.17.21",
+        "minimist": "^1.2.8",
+        "prettier": "^3.2.5",
+        "tinyglobby": "^0.2.9"
+      },
+      "bin": {
+        "json2ts": "dist/src/cli.js"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/lodash": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.9.5",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.5.tgz",
+      "integrity": "sha512-/FVl766LpUfB5vXgCYOYa0MeV/441Ia99AeICQIQFTY/Nw0roZwULcXpku5i1/m5kt/baz+s4Zogspd839HSMg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.23.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.0.tgz",
+      "integrity": "sha512-eUdUIaCr963q2h5u3+QwvYp0+eqPvn+egeqZUm0hwERCqqx1E3kK5ehbGCvqSE5MQAULr67ww0cA3jKc3YkM1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    }
+  }
+}

--- a/schema/package.json
+++ b/schema/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@tcgdex/schema",
+  "version": "0.0.0-demo",
+  "private": true,
+  "type": "module",
+  "description": "DEMO: schema-driven output types for V3, modeled on the current V2 shape",
+  "scripts": {
+    "emit:dts": "tsx build/emit-dts.ts",
+    "emit:openapi": "tsx build/emit-openapi.ts",
+    "validate:live": "tsx build/validate-live.ts",
+    "demo": "npm run emit:dts && npm run emit:openapi && npm run validate:live"
+  },
+  "dependencies": {
+    "@sinclair/typebox": "0.32.34"
+  },
+  "devDependencies": {
+    "json-schema-to-typescript": "^15.0.0",
+    "tsx": "^4.19.0",
+    "typescript": "^5.5.0"
+  }
+}

--- a/schema/src/card.ts
+++ b/schema/src/card.ts
@@ -1,0 +1,66 @@
+import { Type, type Static } from '@sinclair/typebox'
+import { CardResume, SetResume, Variants } from './resume.js'
+import { Rarity, Category, PokemonType, Stage, Suffix, TrainerType, EnergyType, AbilityType, VariantType } from './enums.js'
+
+const Legal = Type.Object({ standard: Type.Boolean(), expanded: Type.Boolean() })
+
+const PricingSource = Type.Optional(Type.Object({
+  url: Type.Optional(Type.String()),
+  updatedAt: Type.Optional(Type.String()),
+  prices: Type.Optional(Type.Record(Type.String(), Type.Number())),
+}))
+
+const Pricing = Type.Optional(Type.Object({
+  cardmarket: PricingSource,
+  tcgplayer: PricingSource,
+}))
+
+const VariantDetailed = Type.Object({
+  type: VariantType,
+  pricing: Pricing,
+})
+
+// Card = CardResume + the full card fields — mirrors the SDK's `Card extends CardResume`.
+export const Card = Type.Composite([
+  CardResume,
+  Type.Object({
+    illustrator: Type.Optional(Type.String()),
+    rarity: Rarity,
+    category: Category,
+    variants: Type.Optional(Variants),
+    variants_detailed: Type.Optional(Type.Array(VariantDetailed)),
+    set: SetResume,
+    dexId: Type.Optional(Type.Array(Type.Number())),
+    hp: Type.Optional(Type.Number()),
+    types: Type.Optional(Type.Array(PokemonType)),
+    evolveFrom: Type.Optional(Type.String()),
+    weight: Type.Optional(Type.String()),
+    description: Type.Optional(Type.String()),
+    level: Type.Optional(Type.Union([Type.Number(), Type.String()])),
+    stage: Type.Optional(Stage),
+    suffix: Type.Optional(Suffix),
+    item: Type.Optional(Type.Object({ name: Type.String(), effect: Type.String() })),
+    abilities: Type.Optional(Type.Array(Type.Object({
+      type: AbilityType, name: Type.String(), effect: Type.String(),
+    }))),
+    attacks: Type.Optional(Type.Array(Type.Object({
+      cost: Type.Optional(Type.Array(PokemonType)),
+      name: Type.String(),
+      effect: Type.Optional(Type.String()),
+      damage: Type.Optional(Type.Union([Type.String(), Type.Number()])),
+    }))),
+    weaknesses: Type.Optional(Type.Array(Type.Object({ type: PokemonType, value: Type.Optional(Type.String()) }))),
+    resistances: Type.Optional(Type.Array(Type.Object({ type: PokemonType, value: Type.Optional(Type.String()) }))),
+    retreat: Type.Optional(Type.Number()),
+    effect: Type.Optional(Type.String()),
+    trainerType: Type.Optional(TrainerType),
+    energyType: Type.Optional(EnergyType),
+    regulationMark: Type.Optional(Type.String()),
+    legal: Legal,
+    pricing: Pricing,
+    updated: Type.Optional(Type.String()),
+  }),
+])
+
+type _Card = Static<typeof Card>
+export type Card<S extends SetResume = SetResume> = Omit<_Card, 'set'> & { set: S }

--- a/schema/src/enums.ts
+++ b/schema/src/enums.ts
@@ -1,0 +1,58 @@
+import { Type, type SchemaOptions } from '@sinclair/typebox'
+
+/** Closed: a fixed set. Emits a real union — the .d.ts gains precision the SDK lacks. */
+export function ClosedEnum<T extends readonly string[]>(values: T, options?: SchemaOptions) {
+  return Type.Union(values.map((v) => Type.Literal(v)) as never, options)
+}
+
+/** Open: grows over time. Validates as any string (new values never throw);
+ *  known values ride along as x-extensible-enum metadata for docs + codegen. */
+export function OpenEnum<T extends readonly string[]>(values: T, options?: SchemaOptions) {
+  return Type.String({ ...options, 'x-extensible-enum': values as unknown as string[] })
+}
+
+// --- value lists, lifted verbatim from cards-database/interfaces.d.ts ---
+
+export const LANGUAGES = [
+  'en', 'fr', 'es', 'es-mx', 'it', 'pt', 'pt-br', 'pt-pt', 'de', 'nl', 'pl', 'ru',
+  'ja', 'ko', 'zh-tw', 'id', 'th', 'zh-cn',
+] as const
+export type SupportedLanguages = (typeof LANGUAGES)[number]
+
+export const RARITIES = [
+  'ACE SPEC Rare', 'Amazing Rare', 'Classic Collection', 'Common', 'Double rare',
+  'Full Art Trainer', 'Holo Rare', 'Holo Rare V', 'Holo Rare VMAX', 'Holo Rare VSTAR',
+  'Hyper rare', 'Illustration rare', 'LEGEND', 'None', 'Radiant Rare', 'Rare', 'Rare Holo',
+  'Rare Holo LV.X', 'Rare PRIME', 'Secret Rare', 'Shiny Ultra Rare', 'Shiny rare',
+  'Shiny rare V', 'Shiny rare VMAX', 'Special illustration rare', 'Ultra Rare', 'Uncommon',
+  'Black White Rare', 'Mega Hyper Rare',
+  'One Diamond', 'Two Diamond', 'Three Diamond', 'Four Diamond',
+  'One Star', 'Two Star', 'Three Star', 'Crown', 'One Shiny', 'Two Shiny', 'Promo',
+] as const // 40 values
+
+export const POKEMON_TYPES = [
+  'Colorless', 'Darkness', 'Dragon', 'Fairy', 'Fighting', 'Fire',
+  'Grass', 'Lightning', 'Metal', 'Psychic', 'Water',
+] as const
+
+export const CATEGORIES = ['Pokemon', 'Trainer', 'Energy'] as const
+export const STAGES = ['Basic', 'BREAK', 'LEVEL-UP', 'MEGA', 'RESTORED', 'Stage1', 'Stage2', 'VMAX', 'V-UNION', 'Baby', 'VSTAR'] as const
+export const SUFFIXES = ['EX', 'GX', 'V', 'Legend', 'Prime', 'SP', 'TAG TEAM-GX', 'ex'] as const
+export const TRAINER_TYPES = ['Supporter', 'Item', 'Stadium', 'Tool', 'Ace Spec', 'Technical Machine', 'Goldenrod Game Corner', "Rocket's Secret Machine"] as const
+export const ENERGY_TYPES = ['Normal', 'Special'] as const
+export const ABILITY_TYPES = ['Pokemon Power', 'Poke-BODY', 'Poke-POWER', 'Ability', 'Ancient Trait'] as const
+
+// --- the schemas. open vs closed per the RFC's ruling table ---
+
+export const Rarity = OpenEnum(RARITIES)        // OPEN  → headline: SDK types this as bare `string`
+export const Category = ClosedEnum(CATEGORIES)  // CLOSED → becomes a union in the .d.ts
+export const PokemonType = ClosedEnum(POKEMON_TYPES)
+export const EnergyType = ClosedEnum(ENERGY_TYPES)
+export const AbilityType = ClosedEnum(ABILITY_TYPES)
+export const Stage = OpenEnum(STAGES)
+export const Suffix = OpenEnum(SUFFIXES)
+export const TrainerType = ClosedEnum(TRAINER_TYPES)
+
+// --- variant_detailed enums (served by live API, never typed by SDK) ---
+export const VARIANT_TYPES = ['normal', 'reverse', 'holo', 'firstEdition'] as const
+export const VariantType = ClosedEnum(VARIANT_TYPES)

--- a/schema/src/index.ts
+++ b/schema/src/index.ts
@@ -1,0 +1,31 @@
+/**
+ * @tcgdex/schema — public surface.
+ *
+ * DATA TYPES + SCHEMAS live here (the single source of truth for the output shape).
+ * The RUNTIME CLIENT — model classes, Endpoint, TCGdex, getImageURL(), fill() — stays
+ * in @tcgdex/sdk. This package provides shapes and runtime validators, not behavior.
+ */
+
+import type { CardResume, SetResume, SerieResume } from './resume.js'
+
+// ── Data types: what the JS SDK imports instead of hand-defining ──────────────
+export type { Card } from './card.js'                 // generic: Card<S extends SetResume>
+export type { Set, Serie } from './set.js'
+export type { CardResume, SetResume, SerieResume, Variants } from './resume.js'
+
+export type CardList = CardResume[]
+export type SetList = SetResume[]
+export type SerieList = SerieResume[]
+export interface StringEndpoint { name: string; cards: CardList }
+
+// ── Runtime schemas: validation + codegen input ──────────────────────────────
+export { Card as CardSchema } from './card.js'
+export { Set as SetSchema, Serie as SerieSchema } from './set.js'
+export {
+  CardResume as CardResumeSchema, SetResume as SetResumeSchema,
+  SerieResume as SerieResumeSchema, Variants as VariantsSchema,
+} from './resume.js'
+
+// ── Enum values as runtime constants + the request-language list ──────────────
+export * as Enums from './enums.js'
+export { LANGUAGES, type SupportedLanguages } from './enums.js'

--- a/schema/src/resume.ts
+++ b/schema/src/resume.ts
@@ -1,0 +1,33 @@
+import { Type, type Static } from '@sinclair/typebox'
+
+export const Variants = Type.Object({
+  normal: Type.Optional(Type.Boolean()),
+  reverse: Type.Optional(Type.Boolean()),
+  holo: Type.Optional(Type.Boolean()),
+  firstEdition: Type.Optional(Type.Boolean()),
+})
+export type Variants = Static<typeof Variants>
+
+export const CardResume = Type.Object({
+  id: Type.String(),
+  localId: Type.String(),
+  name: Type.String(),
+  image: Type.Optional(Type.String()),
+})
+export type CardResume = Static<typeof CardResume>
+
+export const SetResume = Type.Object({
+  id: Type.String(),
+  name: Type.String(),
+  logo: Type.Optional(Type.String()),
+  symbol: Type.Optional(Type.String()),
+  cardCount: Type.Object({ total: Type.Number(), official: Type.Number() }),
+})
+export type SetResume = Static<typeof SetResume>
+
+export const SerieResume = Type.Object({
+  id: Type.String(),
+  name: Type.String(),
+  logo: Type.Optional(Type.String()),
+})
+export type SerieResume = Static<typeof SerieResume>

--- a/schema/src/set.ts
+++ b/schema/src/set.ts
@@ -1,0 +1,33 @@
+import { Type, type Static } from '@sinclair/typebox'
+import { SetResume, SerieResume, CardResume, Variants } from './resume.js'
+
+const Legal = Type.Object({ standard: Type.Boolean(), expanded: Type.Boolean() })
+
+// Standalone (not Composite) because Set redefines cardCount richer than SetResume —
+// composing would collide the key. Explicit is clearer for a demo anyway.
+export const Set = Type.Object({
+  id: Type.String(),
+  name: Type.String(),
+  logo: Type.Optional(Type.String()),
+  symbol: Type.Optional(Type.String()),
+  serie: SerieResume,
+  tcgOnline: Type.Optional(Type.String()),
+  variants: Type.Optional(Variants),
+  releaseDate: Type.String(),
+  legal: Legal,
+  cardCount: Type.Object({
+    total: Type.Number(), official: Type.Number(),
+    normal: Type.Number(), reverse: Type.Number(), holo: Type.Number(),
+    firstEd: Type.Optional(Type.Number()),
+  }),
+  cards: Type.Array(CardResume),
+})
+export type Set = Static<typeof Set>
+
+export const Serie = Type.Object({
+  id: Type.String(),
+  name: Type.String(),
+  logo: Type.Optional(Type.String()),
+  sets: Type.Array(SetResume),
+})
+export type Serie = Static<typeof Serie>


### PR DESCRIPTION
> [!WARNING]
> **RFC + POC — not for merge as-is.** This PR models the V2 output shape end-to-end to prove the pipeline; the real package will model V3's output contract. See `RFC.md` for the full proposal.

> **Read the RFC as rendered markdown:** [`schema/RFC.md`](https://github.com/tcgdex/cards-database/blob/SDK-Compat/schema/RFC.md)
>
> The diff view mangles tables, code blocks, and the ASCII diagrams. This link renders it properly.

## Changes

Adds a new `schema/` package proposing TypeBox-defined output shapes as the single source of truth for SDK types and OpenAPI. 
Runnable POC that models the current V2 output shape end-to-end (types, OpenAPI, live validation) as the foundation for V3's output contract.

## Details

 everything lives under `schema/`.

- `RFC.md` — full proposal: problem (silent drift between input, compiled, and output shapes; SDK types every enum as `string`; `variants_detailed`/`pricing`/`updated` are served but never typed), solution (`@tcgdex/schema` with TypeBox as JSON-Schema-native source of truth), open-vs-closed enum policy, staging plan, FAQ
- `README.md` — how to run the demo, what to look at
- `src/` — the schema definitions (`Card`, `CardResume`, `Set`, `SetResume`, `Serie`, `SerieResume`, `Variants`)
- `build/emit-dts.ts` — generates `dist/types.d.ts` (closed enums become real unions; open enums stay `string` and carry known values as `x-extensible-enum` OpenAPI metadata)
- `build/emit-openapi.ts` — generates `dist/openapi.json` (full OpenAPI 3.1 doc: 33 paths, 9 component schemas, RFC 9457 `application/problem+json` errors)
- `build/validate-live.ts` — fetches `base1-4` from `api.tcgdex.net` and validates against the schema
- `docus/sdk-migration.md` — how the JS SDK adopts the schema via `implements` (types-only devDep, no runtime footprint)
- `docus/workflows/` — example GitHub Actions showing how schema releases would auto-regenerate downstream SDKs (illustrative, not  wired up)
- `docus/python-template-sketch.mustache` — sketch of the `x-extensible-enum` → real-enum Python override (Stage 2b work, non-blocking)

**Run it:**

```bash
cd schema && npm install && npm run demo
```

## Docs index

Quick navigation for reviewers — all rendered at the branch head:

**Core:**
- 📘 [`RFC.md`](https://github.com/tcgdex/cards-database/blob/SDK-Compat/schema/RFC.md) — the full proposal
- 📖 [`README.md`](https://github.com/tcgdex/cards-database/blob/SDK-Compat/schema/README.md) — how to run the demo, expected output

**Under `docus/`:**
- 🔧 [`sdk-migration.md`](https://github.com/tcgdex/cards-database/blob/SDK-Compat/schema/docus/sdk-migration.md) — JS SDK adoption via `implements`
- 📋 [`implementation-followups.md`](https://github.com/tcgdex/cards-database/blob/SDK-Compat/schema/docus/implementation-followups.md) — known POC gaps + RFC wording corrections to address
- ⚙️ [`workflows/README.md`](https://github.com/tcgdex/cards-database/blob/SDK-Compat/schema/docus/workflows/README.md) — example release → auto-regen loop
- 🐍 [`python-template-sketch.mustache`](https://github.com/tcgdex/cards-database/blob/SDK-Compat/schema/docus/python-template-sketch.mustache) — sketch of the `x-extensible-enum` Python override

**RFC section deep links (jump straight to a topic):**
- [Problem](https://github.com/tcgdex/cards-database/blob/SDK-Compat/schema/RFC.md#problem) — drift diagnosis + evidence
- [Language coverage](https://github.com/tcgdex/cards-database/blob/SDK-Compat/schema/RFC.md#language-coverage) — how any language consumes this
- [Public API contract](https://github.com/tcgdex/cards-database/blob/SDK-Compat/schema/RFC.md#the-schema-as-a-public-api-contract) — third-party use cases
- [Documentation site](https://github.com/tcgdex/cards-database/blob/SDK-Compat/schema/RFC.md#documentation-site) — how docs stop drifting
- [Considered alternatives](https://github.com/tcgdex/cards-database/blob/SDK-Compat/schema/RFC.md#considered-alternatives) — `typescript-json-schema` + shared enum hybrid
- [Staging](https://github.com/tcgdex/cards-database/blob/SDK-Compat/schema/RFC.md#staging) — 4-stage rollout
- [FAQ](https://github.com/tcgdex/cards-database/blob/SDK-Compat/schema/RFC.md#faq)

---