### PR TITLE
(data) Ja PMCG4 (Rocket Gang) Corrected Names/TcgplayerId Pricing

### DIFF
--- a/data-asia/PMCG/PMCG4.ts
+++ b/data-asia/PMCG/PMCG4.ts
@@ -4,7 +4,6 @@ import serie from '../PMCG'
 const set: Set = {
 	id: 'PMCG4',
 	name: {
-		// rocket gang
 		ja: 'ロケット団'
 	},
 

--- a/data-asia/PMCG/PMCG4.ts
+++ b/data-asia/PMCG/PMCG4.ts
@@ -4,6 +4,7 @@ import serie from '../PMCG'
 const set: Set = {
 	id: 'PMCG4',
 	name: {
+		// rocket gang
 		ja: 'ロケット団'
 	},
 

--- a/data-asia/PMCG/PMCG4/001.ts
+++ b/data-asia/PMCG/PMCG4/001.ts
@@ -4,7 +4,6 @@ import Set from "../PMCG4"
 const card: Card = {
 	set: Set,
 	name: {
-		// Ekans
 		ja: "アーボ",
 	},
 

--- a/data-asia/PMCG/PMCG4/001.ts
+++ b/data-asia/PMCG/PMCG4/001.ts
@@ -8,6 +8,7 @@ const card: Card = {
 		ja: "アーボ",
 	},
 
+	illustrator: "Ken Sugimori",
 	rarity: "Common",
 	category: "Pokemon",
 	dexId: [23],

--- a/data-asia/PMCG/PMCG4/001.ts
+++ b/data-asia/PMCG/PMCG4/001.ts
@@ -4,7 +4,8 @@ import Set from "../PMCG4"
 const card: Card = {
 	set: Set,
 	name: {
-		ja: "エカン",
+		// Ekans
+		ja: "アーボ",
 	},
 
 	rarity: "Common",
@@ -39,6 +40,9 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 575721
+			},
 		},
 	],
 };

--- a/data-asia/PMCG/PMCG4/002.ts
+++ b/data-asia/PMCG/PMCG4/002.ts
@@ -4,7 +4,6 @@ import Set from "../PMCG4"
 const card: Card = {
 	set: Set,
 	name: {
-		// Zubat
 		ja: "ズバット",
 	},
 

--- a/data-asia/PMCG/PMCG4/002.ts
+++ b/data-asia/PMCG/PMCG4/002.ts
@@ -4,7 +4,8 @@ import Set from "../PMCG4"
 const card: Card = {
 	set: Set,
 	name: {
-		ja: "Zubat",
+		// Zubat
+		ja: "ズバット",
 	},
 
 	rarity: "Common",
@@ -36,6 +37,9 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 575740
+			},
 		},
 	],
 };

--- a/data-asia/PMCG/PMCG4/002.ts
+++ b/data-asia/PMCG/PMCG4/002.ts
@@ -8,6 +8,7 @@ const card: Card = {
 		ja: "ズバット",
 	},
 
+	illustrator: "Mitsuhiro Arita",
 	rarity: "Common",
 	category: "Pokemon",
 	dexId: [41],

--- a/data-asia/PMCG/PMCG4/003.ts
+++ b/data-asia/PMCG/PMCG4/003.ts
@@ -8,6 +8,7 @@ const card: Card = {
 		ja: "ナゾノクサ",
 	},
 
+	illustrator: "Kagemaru Himeno",
 	rarity: "Common",
 	category: "Pokemon",
 	dexId: [43],

--- a/data-asia/PMCG/PMCG4/003.ts
+++ b/data-asia/PMCG/PMCG4/003.ts
@@ -4,7 +4,8 @@ import Set from "../PMCG4"
 const card: Card = {
 	set: Set,
 	name: {
-		ja: "奇妙な",
+		// Oddish
+		ja: "ナゾノクサ",
 	},
 
 	rarity: "Common",
@@ -40,6 +41,9 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 575731
+			},
 		},
 	],
 };

--- a/data-asia/PMCG/PMCG4/003.ts
+++ b/data-asia/PMCG/PMCG4/003.ts
@@ -4,7 +4,6 @@ import Set from "../PMCG4"
 const card: Card = {
 	set: Set,
 	name: {
-		// Oddish
 		ja: "ナゾノクサ",
 	},
 

--- a/data-asia/PMCG/PMCG4/004.ts
+++ b/data-asia/PMCG/PMCG4/004.ts
@@ -8,6 +8,7 @@ const card: Card = {
 		ja: "ベトベター",
 	},
 
+	illustrator: "Kagemaru Himeno",
 	rarity: "Common",
 	category: "Pokemon",
 	dexId: [88],

--- a/data-asia/PMCG/PMCG4/004.ts
+++ b/data-asia/PMCG/PMCG4/004.ts
@@ -4,7 +4,8 @@ import Set from "../PMCG4"
 const card: Card = {
 	set: Set,
 	name: {
-		ja: "グリマー",
+		// Grimer
+		ja: "ベトベター",
 	},
 
 	rarity: "Common",
@@ -40,6 +41,9 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 575724
+			},
 		},
 	],
 };

--- a/data-asia/PMCG/PMCG4/004.ts
+++ b/data-asia/PMCG/PMCG4/004.ts
@@ -4,7 +4,6 @@ import Set from "../PMCG4"
 const card: Card = {
 	set: Set,
 	name: {
-		// Grimer
 		ja: "ベトベター",
 	},
 

--- a/data-asia/PMCG/PMCG4/005.ts
+++ b/data-asia/PMCG/PMCG4/005.ts
@@ -4,7 +4,8 @@ import Set from "../PMCG4"
 const card: Card = {
 	set: Set,
 	name: {
-		ja: "Koffing",
+		// Koffing
+		ja: "ドガース",
 	},
 
 	rarity: "Common",
@@ -39,6 +40,9 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 575725
+			},
 		},
 	],
 };

--- a/data-asia/PMCG/PMCG4/005.ts
+++ b/data-asia/PMCG/PMCG4/005.ts
@@ -4,7 +4,6 @@ import Set from "../PMCG4"
 const card: Card = {
 	set: Set,
 	name: {
-		// Koffing
 		ja: "ドガース",
 	},
 

--- a/data-asia/PMCG/PMCG4/005.ts
+++ b/data-asia/PMCG/PMCG4/005.ts
@@ -8,6 +8,7 @@ const card: Card = {
 		ja: "ドガース",
 	},
 
+	illustrator: "Sumiyoshi Kizuki",
 	rarity: "Common",
 	category: "Pokemon",
 	dexId: [109],

--- a/data-asia/PMCG/PMCG4/006.ts
+++ b/data-asia/PMCG/PMCG4/006.ts
@@ -8,6 +8,7 @@ const card: Card = {
 		ja: "わるいクサイハナ",
 	},
 
+	illustrator: "Kagemaru Himeno",
 	rarity: "Uncommon",
 	category: "Pokemon",
 	dexId: [44],

--- a/data-asia/PMCG/PMCG4/006.ts
+++ b/data-asia/PMCG/PMCG4/006.ts
@@ -4,7 +4,8 @@ import Set from "../PMCG4"
 const card: Card = {
 	set: Set,
 	name: {
-		ja: "暗い暗闇",
+		// Dark Gloom
+		ja: "わるいクサイハナ",
 	},
 
 	rarity: "Uncommon",
@@ -43,6 +44,9 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 575763
+			},
 		},
 	],
 };

--- a/data-asia/PMCG/PMCG4/006.ts
+++ b/data-asia/PMCG/PMCG4/006.ts
@@ -4,7 +4,6 @@ import Set from "../PMCG4"
 const card: Card = {
 	set: Set,
 	name: {
-		// Dark Gloom
 		ja: "わるいクサイハナ",
 	},
 

--- a/data-asia/PMCG/PMCG4/007.ts
+++ b/data-asia/PMCG/PMCG4/007.ts
@@ -8,6 +8,7 @@ const card: Card = {
 		ja: "わるいベトベトン",
 	},
 
+	illustrator: "Kagemaru Himeno",
 	rarity: "Uncommon",
 	category: "Pokemon",
 	dexId: [89],

--- a/data-asia/PMCG/PMCG4/007.ts
+++ b/data-asia/PMCG/PMCG4/007.ts
@@ -4,7 +4,8 @@ import Set from "../PMCG4"
 const card: Card = {
 	set: Set,
 	name: {
-		ja: "暗いMuk",
+		// Dark Muk
+		ja: "わるいベトベトン",
 	},
 
 	rarity: "Uncommon",
@@ -43,6 +44,9 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 575768
+			},
 		},
 	],
 };

--- a/data-asia/PMCG/PMCG4/007.ts
+++ b/data-asia/PMCG/PMCG4/007.ts
@@ -4,7 +4,6 @@ import Set from "../PMCG4"
 const card: Card = {
 	set: Set,
 	name: {
-		// Dark Muk
 		ja: "わるいベトベトン",
 	},
 

--- a/data-asia/PMCG/PMCG4/008.ts
+++ b/data-asia/PMCG/PMCG4/008.ts
@@ -8,6 +8,7 @@ const card: Card = {
 		ja: "わるいアーボック",
 	},
 
+	illustrator: "Mitsuhiro Arita",
 	rarity: "Holo Rare",
 	category: "Pokemon",
 	dexId: [24],

--- a/data-asia/PMCG/PMCG4/008.ts
+++ b/data-asia/PMCG/PMCG4/008.ts
@@ -42,6 +42,9 @@ const card: Card = {
 	variants: [
 		{
 			type: "holo",
+			thirdParty: {
+				tcgplayer: 575742
+			},
 		},
 	],
 };

--- a/data-asia/PMCG/PMCG4/008.ts
+++ b/data-asia/PMCG/PMCG4/008.ts
@@ -4,7 +4,8 @@ import Set from "../PMCG4"
 const card: Card = {
 	set: Set,
 	name: {
-		ja: "ダークアーボック",
+		// Dark Arbok
+		ja: "わるいアーボック",
 	},
 
 	rarity: "Holo Rare",

--- a/data-asia/PMCG/PMCG4/008.ts
+++ b/data-asia/PMCG/PMCG4/008.ts
@@ -4,7 +4,6 @@ import Set from "../PMCG4"
 const card: Card = {
 	set: Set,
 	name: {
-		// Dark Arbok
 		ja: "わるいアーボック",
 	},
 

--- a/data-asia/PMCG/PMCG4/009.ts
+++ b/data-asia/PMCG/PMCG4/009.ts
@@ -8,6 +8,7 @@ const card: Card = {
 		ja: "わるいゴルバット",
 	},
 
+	illustrator: "Mitsuhiro Arita",
 	rarity: "Holo Rare",
 	category: "Pokemon",
 	dexId: [42],

--- a/data-asia/PMCG/PMCG4/009.ts
+++ b/data-asia/PMCG/PMCG4/009.ts
@@ -4,7 +4,8 @@ import Set from "../PMCG4"
 const card: Card = {
 	set: Set,
 	name: {
-		ja: "暗いゴルバット",
+		// Dark Golbat
+		ja: "わるいゴルバット",
 	},
 
 	rarity: "Holo Rare",

--- a/data-asia/PMCG/PMCG4/009.ts
+++ b/data-asia/PMCG/PMCG4/009.ts
@@ -42,6 +42,9 @@ const card: Card = {
 	variants: [
 		{
 			type: "holo",
+			thirdParty: {
+				tcgplayer: 575747
+			},
 		},
 	],
 };

--- a/data-asia/PMCG/PMCG4/009.ts
+++ b/data-asia/PMCG/PMCG4/009.ts
@@ -4,7 +4,6 @@ import Set from "../PMCG4"
 const card: Card = {
 	set: Set,
 	name: {
-		// Dark Golbat
 		ja: "わるいゴルバット",
 	},
 

--- a/data-asia/PMCG/PMCG4/010.ts
+++ b/data-asia/PMCG/PMCG4/010.ts
@@ -4,7 +4,6 @@ import Set from "../PMCG4"
 const card: Card = {
 	set: Set,
 	name: {
-		// Dark Vileplume
 		ja: "ラフレシア",
 	},
 

--- a/data-asia/PMCG/PMCG4/010.ts
+++ b/data-asia/PMCG/PMCG4/010.ts
@@ -4,7 +4,8 @@ import Set from "../PMCG4"
 const card: Card = {
 	set: Set,
 	name: {
-		ja: "暗いvileplume",
+		// Dark Vileplume
+		ja: "ラフレシア",
 	},
 
 	rarity: "Holo Rare",

--- a/data-asia/PMCG/PMCG4/010.ts
+++ b/data-asia/PMCG/PMCG4/010.ts
@@ -8,6 +8,7 @@ const card: Card = {
 		ja: "ラフレシア",
 	},
 
+	illustrator: "Kagemaru Himeno",
 	rarity: "Holo Rare",
 	category: "Pokemon",
 	dexId: [45],

--- a/data-asia/PMCG/PMCG4/010.ts
+++ b/data-asia/PMCG/PMCG4/010.ts
@@ -43,6 +43,9 @@ const card: Card = {
 	variants: [
 		{
 			type: "holo",
+			thirdParty: {
+				tcgplayer: 575753
+			},
 		},
 	],
 };

--- a/data-asia/PMCG/PMCG4/011.ts
+++ b/data-asia/PMCG/PMCG4/011.ts
@@ -8,6 +8,7 @@ const card: Card = {
 		ja: "わるいマタドガス",
 	},
 
+	illustrator: "Shin-ichi Yoshida",
 	rarity: "Holo Rare",
 	category: "Pokemon",
 	dexId: [110],

--- a/data-asia/PMCG/PMCG4/011.ts
+++ b/data-asia/PMCG/PMCG4/011.ts
@@ -4,7 +4,6 @@ import Set from "../PMCG4"
 const card: Card = {
 	set: Set,
 	name: {
-		// Dark Weezing
 		ja: "わるいマタドガス",
 	},
 

--- a/data-asia/PMCG/PMCG4/011.ts
+++ b/data-asia/PMCG/PMCG4/011.ts
@@ -42,6 +42,9 @@ const card: Card = {
 	variants: [
 		{
 			type: "holo",
+			thirdParty: {
+				tcgplayer: 575754
+			},
 		},
 	],
 };

--- a/data-asia/PMCG/PMCG4/011.ts
+++ b/data-asia/PMCG/PMCG4/011.ts
@@ -4,7 +4,8 @@ import Set from "../PMCG4"
 const card: Card = {
 	set: Set,
 	name: {
-		ja: "暗いweezing",
+		// Dark Weezing
+		ja: "わるいマタドガス",
 	},
 
 	rarity: "Holo Rare",

--- a/data-asia/PMCG/PMCG4/012.ts
+++ b/data-asia/PMCG/PMCG4/012.ts
@@ -8,6 +8,7 @@ const card: Card = {
 		ja: "ヒトカゲ",
 	},
 
+	illustrator: "Kagemaru Himeno",
 	rarity: "Common",
 	category: "Pokemon",
 	dexId: [4],

--- a/data-asia/PMCG/PMCG4/012.ts
+++ b/data-asia/PMCG/PMCG4/012.ts
@@ -4,7 +4,6 @@ import Set from "../PMCG4"
 const card: Card = {
 	set: Set,
 	name: {
-		// Charmander
 		ja: "ヒトカゲ",
 	},
 

--- a/data-asia/PMCG/PMCG4/012.ts
+++ b/data-asia/PMCG/PMCG4/012.ts
@@ -4,7 +4,8 @@ import Set from "../PMCG4"
 const card: Card = {
 	set: Set,
 	name: {
-		ja: "チャーマンダー",
+		// Charmander
+		ja: "ヒトカゲ",
 	},
 
 	rarity: "Common",
@@ -40,6 +41,9 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 575713
+			},
 		},
 	],
 };

--- a/data-asia/PMCG/PMCG4/013.ts
+++ b/data-asia/PMCG/PMCG4/013.ts
@@ -4,6 +4,7 @@ import Set from "../PMCG4"
 const card: Card = {
 	set: Set,
 	name: {
+		// Ponyta
 		ja: "ポニータ",
 	},
 
@@ -32,6 +33,9 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 575732
+			},
 		},
 	],
 };

--- a/data-asia/PMCG/PMCG4/013.ts
+++ b/data-asia/PMCG/PMCG4/013.ts
@@ -4,7 +4,6 @@ import Set from "../PMCG4"
 const card: Card = {
 	set: Set,
 	name: {
-		// Ponyta
 		ja: "ポニータ",
 	},
 

--- a/data-asia/PMCG/PMCG4/013.ts
+++ b/data-asia/PMCG/PMCG4/013.ts
@@ -8,6 +8,7 @@ const card: Card = {
 		ja: "ポニータ",
 	},
 
+	illustrator: "Atsuko Nishida",
 	rarity: "Common",
 	category: "Pokemon",
 	dexId: [77],

--- a/data-asia/PMCG/PMCG4/014.ts
+++ b/data-asia/PMCG/PMCG4/014.ts
@@ -8,6 +8,7 @@ const card: Card = {
 		ja: "わるいギャロップ",
 	},
 
+	illustrator: "Kagemaru Himeno",
 	rarity: "Common",
 	category: "Pokemon",
 	dexId: [78],

--- a/data-asia/PMCG/PMCG4/014.ts
+++ b/data-asia/PMCG/PMCG4/014.ts
@@ -4,7 +4,8 @@ import Set from "../PMCG4"
 const card: Card = {
 	set: Set,
 	name: {
-		ja: "Dark Rapidash",
+		// Dark Rapidash
+		ja: "わるいギャロップ",
 	},
 
 	rarity: "Common",
@@ -38,6 +39,9 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 575715
+			},
 		},
 	],
 };

--- a/data-asia/PMCG/PMCG4/014.ts
+++ b/data-asia/PMCG/PMCG4/014.ts
@@ -4,7 +4,6 @@ import Set from "../PMCG4"
 const card: Card = {
 	set: Set,
 	name: {
-		// Dark Rapidash
 		ja: "わるいギャロップ",
 	},
 

--- a/data-asia/PMCG/PMCG4/015.ts
+++ b/data-asia/PMCG/PMCG4/015.ts
@@ -8,6 +8,7 @@ const card: Card = {
 		ja: "わるいリザード",
 	},
 
+	illustrator: "Kagemaru Himeno",
 	rarity: "Uncommon",
 	category: "Pokemon",
 	dexId: [5],

--- a/data-asia/PMCG/PMCG4/015.ts
+++ b/data-asia/PMCG/PMCG4/015.ts
@@ -4,7 +4,6 @@ import Set from "../PMCG4"
 const card: Card = {
 	set: Set,
 	name: {
-		// Dark Charmeleon
 		ja: "わるいリザード",
 	},
 

--- a/data-asia/PMCG/PMCG4/015.ts
+++ b/data-asia/PMCG/PMCG4/015.ts
@@ -4,7 +4,8 @@ import Set from "../PMCG4"
 const card: Card = {
 	set: Set,
 	name: {
-		ja: "ダークチャームレオン",
+		// Dark Charmeleon
+		ja: "わるいリザード",
 	},
 
 	rarity: "Uncommon",
@@ -39,6 +40,9 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 575759
+			},
 		},
 	],
 };

--- a/data-asia/PMCG/PMCG4/016.ts
+++ b/data-asia/PMCG/PMCG4/016.ts
@@ -8,6 +8,7 @@ const card: Card = {
 		ja: "わるいブースター",
 	},
 
+	illustrator: "Mitsuhiro Arita",
 	rarity: "Uncommon",
 	category: "Pokemon",
 	dexId: [136],

--- a/data-asia/PMCG/PMCG4/016.ts
+++ b/data-asia/PMCG/PMCG4/016.ts
@@ -4,7 +4,6 @@ import Set from "../PMCG4"
 const card: Card = {
 	set: Set,
 	name: {
-		// Dark Flareon
 		ja: "わるいブースター",
 	},
 

--- a/data-asia/PMCG/PMCG4/016.ts
+++ b/data-asia/PMCG/PMCG4/016.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	set: Set,
 	name: {
 		// Dark Flareon
-		ja: "わるいブースタ",
+		ja: "わるいブースター",
 	},
 
 	rarity: "Uncommon",

--- a/data-asia/PMCG/PMCG4/016.ts
+++ b/data-asia/PMCG/PMCG4/016.ts
@@ -4,7 +4,8 @@ import Set from "../PMCG4"
 const card: Card = {
 	set: Set,
 	name: {
-		ja: "ダークフレアロン",
+		// Dark Flareon
+		ja: "わるいブースタ",
 	},
 
 	rarity: "Uncommon",
@@ -40,6 +41,9 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 575762
+			},
 		},
 	],
 };

--- a/data-asia/PMCG/PMCG4/017.ts
+++ b/data-asia/PMCG/PMCG4/017.ts
@@ -8,6 +8,7 @@ const card: Card = {
 		ja: "わるいリザードン",
 	},
 
+	illustrator: "Ken Sugimori",
 	rarity: "Holo Rare",
 	category: "Pokemon",
 	dexId: [6],

--- a/data-asia/PMCG/PMCG4/017.ts
+++ b/data-asia/PMCG/PMCG4/017.ts
@@ -39,6 +39,9 @@ const card: Card = {
 	variants: [
 		{
 			type: "holo",
+			thirdParty: {
+				tcgplayer: 575744
+			},
 		},
 	],
 };

--- a/data-asia/PMCG/PMCG4/017.ts
+++ b/data-asia/PMCG/PMCG4/017.ts
@@ -4,7 +4,8 @@ import Set from "../PMCG4"
 const card: Card = {
 	set: Set,
 	name: {
-		ja: "暗いカリザード",
+		// Dark Charizard
+		ja: "わるいリザードン",
 	},
 
 	rarity: "Holo Rare",

--- a/data-asia/PMCG/PMCG4/017.ts
+++ b/data-asia/PMCG/PMCG4/017.ts
@@ -4,7 +4,6 @@ import Set from "../PMCG4"
 const card: Card = {
 	set: Set,
 	name: {
-		// Dark Charizard
 		ja: "わるいリザードン",
 	},
 

--- a/data-asia/PMCG/PMCG4/018.ts
+++ b/data-asia/PMCG/PMCG4/018.ts
@@ -4,7 +4,6 @@ import Set from "../PMCG4"
 const card: Card = {
 	set: Set,
 	name: {
-		// Squirtle
 		ja: "ゼニガメ",
 	},
 

--- a/data-asia/PMCG/PMCG4/018.ts
+++ b/data-asia/PMCG/PMCG4/018.ts
@@ -4,7 +4,8 @@ import Set from "../PMCG4"
 const card: Card = {
 	set: Set,
 	name: {
-		ja: "squirtle",
+		// Squirtle
+		ja: "ゼニガメ",
 	},
 
 	rarity: "Common",
@@ -29,6 +30,9 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 575738
+			},
 		},
 	],
 };

--- a/data-asia/PMCG/PMCG4/018.ts
+++ b/data-asia/PMCG/PMCG4/018.ts
@@ -8,6 +8,7 @@ const card: Card = {
 		ja: "ゼニガメ",
 	},
 
+	illustrator: "Atsuko Nishida",
 	rarity: "Common",
 	category: "Pokemon",
 	dexId: [7],

--- a/data-asia/PMCG/PMCG4/019.ts
+++ b/data-asia/PMCG/PMCG4/019.ts
@@ -4,7 +4,8 @@ import Set from "../PMCG4"
 const card: Card = {
 	set: Set,
 	name: {
-		ja: "Psyduck",
+		// Psyduck
+		ja: "コダック",
 	},
 
 	rarity: "Common",
@@ -40,6 +41,9 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 575734
+			},
 		},
 	],
 };

--- a/data-asia/PMCG/PMCG4/019.ts
+++ b/data-asia/PMCG/PMCG4/019.ts
@@ -4,7 +4,6 @@ import Set from "../PMCG4"
 const card: Card = {
 	set: Set,
 	name: {
-		// Psyduck
 		ja: "コダック",
 	},
 

--- a/data-asia/PMCG/PMCG4/019.ts
+++ b/data-asia/PMCG/PMCG4/019.ts
@@ -8,6 +8,7 @@ const card: Card = {
 		ja: "コダック",
 	},
 
+	illustrator: "Mitsuhiro Arita",
 	rarity: "Common",
 	category: "Pokemon",
 	dexId: [54],

--- a/data-asia/PMCG/PMCG4/020.ts
+++ b/data-asia/PMCG/PMCG4/020.ts
@@ -4,7 +4,8 @@ import Set from "../PMCG4"
 const card: Card = {
 	set: Set,
 	name: {
-		ja: "Magikarp",
+		// Magikarp
+		ja: "コイキング",
 	},
 
 	rarity: "Common",
@@ -38,6 +39,9 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 575727
+			},
 		},
 	],
 };

--- a/data-asia/PMCG/PMCG4/020.ts
+++ b/data-asia/PMCG/PMCG4/020.ts
@@ -4,7 +4,6 @@ import Set from "../PMCG4"
 const card: Card = {
 	set: Set,
 	name: {
-		// Magikarp
 		ja: "コイキング",
 	},
 

--- a/data-asia/PMCG/PMCG4/020.ts
+++ b/data-asia/PMCG/PMCG4/020.ts
@@ -8,6 +8,7 @@ const card: Card = {
 		ja: "コイキング",
 	},
 
+	illustrator: "Kagemaru Himeno",
 	rarity: "Common",
 	category: "Pokemon",
 	dexId: [129],

--- a/data-asia/PMCG/PMCG4/021.ts
+++ b/data-asia/PMCG/PMCG4/021.ts
@@ -4,7 +4,8 @@ import Set from "../PMCG4"
 const card: Card = {
 	set: Set,
 	name: {
-		ja: "暗いwartortle",
+		// Dark Wartortle
+		ja: "わるいカメール",
 	},
 
 	rarity: "Uncommon",
@@ -40,6 +41,9 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 575771
+			},
 		},
 	],
 };

--- a/data-asia/PMCG/PMCG4/021.ts
+++ b/data-asia/PMCG/PMCG4/021.ts
@@ -8,6 +8,7 @@ const card: Card = {
 		ja: "わるいカメール",
 	},
 
+	illustrator: "Kagemaru Himeno",
 	rarity: "Uncommon",
 	category: "Pokemon",
 	dexId: [8],

--- a/data-asia/PMCG/PMCG4/021.ts
+++ b/data-asia/PMCG/PMCG4/021.ts
@@ -4,7 +4,6 @@ import Set from "../PMCG4"
 const card: Card = {
 	set: Set,
 	name: {
-		// Dark Wartortle
 		ja: "わるいカメール",
 	},
 

--- a/data-asia/PMCG/PMCG4/022.ts
+++ b/data-asia/PMCG/PMCG4/022.ts
@@ -8,6 +8,7 @@ const card: Card = {
 		ja: "わるいゴルダック",
 	},
 
+	illustrator: "Mitsuhiro Arita",
 	rarity: "Uncommon",
 	category: "Pokemon",
 	dexId: [55],

--- a/data-asia/PMCG/PMCG4/022.ts
+++ b/data-asia/PMCG/PMCG4/022.ts
@@ -4,7 +4,8 @@ import Set from "../PMCG4"
 const card: Card = {
 	set: Set,
 	name: {
-		ja: "ダークゴルダック",
+		// Dark Golduck
+		ja: "わるいゴルダック",
 	},
 
 	rarity: "Uncommon",
@@ -38,6 +39,9 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 575764
+			},
 		},
 	],
 };

--- a/data-asia/PMCG/PMCG4/022.ts
+++ b/data-asia/PMCG/PMCG4/022.ts
@@ -4,7 +4,6 @@ import Set from "../PMCG4"
 const card: Card = {
 	set: Set,
 	name: {
-		// Dark Golduck
 		ja: "わるいゴルダック",
 	},
 

--- a/data-asia/PMCG/PMCG4/023.ts
+++ b/data-asia/PMCG/PMCG4/023.ts
@@ -4,7 +4,6 @@ import Set from "../PMCG4"
 const card: Card = {
 	set: Set,
 	name: {
-		// Dark Vaporeon
 		ja: "わるいシャワーズ",
 	},
 

--- a/data-asia/PMCG/PMCG4/023.ts
+++ b/data-asia/PMCG/PMCG4/023.ts
@@ -4,7 +4,8 @@ import Set from "../PMCG4"
 const card: Card = {
 	set: Set,
 	name: {
-		ja: "ダークバポレオン",
+		// Dark Vaporeon
+		ja: "わるいシャワーズ ",
 	},
 
 	rarity: "Uncommon",
@@ -39,6 +40,9 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 575770
+			},
 		},
 	],
 };

--- a/data-asia/PMCG/PMCG4/023.ts
+++ b/data-asia/PMCG/PMCG4/023.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	set: Set,
 	name: {
 		// Dark Vaporeon
-		ja: "わるいシャワーズ ",
+		ja: "わるいシャワーズ",
 	},
 
 	rarity: "Uncommon",

--- a/data-asia/PMCG/PMCG4/023.ts
+++ b/data-asia/PMCG/PMCG4/023.ts
@@ -8,6 +8,7 @@ const card: Card = {
 		ja: "わるいシャワーズ",
 	},
 
+	illustrator: "Mitsuhiro Arita",
 	rarity: "Uncommon",
 	category: "Pokemon",
 	dexId: [134],

--- a/data-asia/PMCG/PMCG4/024.ts
+++ b/data-asia/PMCG/PMCG4/024.ts
@@ -4,7 +4,6 @@ import Set from "../PMCG4"
 const card: Card = {
 	set: Set,
 	name: {
-		// Dark Blastoise
 		ja: "わるいカメックス",
 	},
 

--- a/data-asia/PMCG/PMCG4/024.ts
+++ b/data-asia/PMCG/PMCG4/024.ts
@@ -4,7 +4,8 @@ import Set from "../PMCG4"
 const card: Card = {
 	set: Set,
 	name: {
-		ja: "ダークブラストワイズ",
+		// Dark Blastoise
+		ja: "わるいカメックス",
 	},
 
 	rarity: "Holo Rare",

--- a/data-asia/PMCG/PMCG4/024.ts
+++ b/data-asia/PMCG/PMCG4/024.ts
@@ -42,6 +42,9 @@ const card: Card = {
 	variants: [
 		{
 			type: "holo",
+			thirdParty: {
+				tcgplayer: 575743
+			},
 		},
 	],
 };

--- a/data-asia/PMCG/PMCG4/024.ts
+++ b/data-asia/PMCG/PMCG4/024.ts
@@ -8,6 +8,7 @@ const card: Card = {
 		ja: "わるいカメックス",
 	},
 
+	illustrator: "Mitsuhiro Arita",
 	rarity: "Holo Rare",
 	category: "Pokemon",
 	dexId: [9],

--- a/data-asia/PMCG/PMCG4/025.ts
+++ b/data-asia/PMCG/PMCG4/025.ts
@@ -4,7 +4,8 @@ import Set from "../PMCG4"
 const card: Card = {
 	set: Set,
 	name: {
-		ja: "暗いギャラドス",
+		// Dark Gyarados
+		ja: "わるいギャラドス",
 	},
 
 	rarity: "Holo Rare",

--- a/data-asia/PMCG/PMCG4/025.ts
+++ b/data-asia/PMCG/PMCG4/025.ts
@@ -44,6 +44,9 @@ const card: Card = {
 	variants: [
 		{
 			type: "holo",
+			thirdParty: {
+				tcgplayer: 575748
+			},
 		},
 	],
 };

--- a/data-asia/PMCG/PMCG4/025.ts
+++ b/data-asia/PMCG/PMCG4/025.ts
@@ -4,7 +4,6 @@ import Set from "../PMCG4"
 const card: Card = {
 	set: Set,
 	name: {
-		// Dark Gyarados
 		ja: "わるいギャラドス",
 	},
 

--- a/data-asia/PMCG/PMCG4/025.ts
+++ b/data-asia/PMCG/PMCG4/025.ts
@@ -8,6 +8,7 @@ const card: Card = {
 		ja: "わるいギャラドス",
 	},
 
+	illustrator: "Kagemaru Himeno",
 	rarity: "Holo Rare",
 	category: "Pokemon",
 	dexId: [130],

--- a/data-asia/PMCG/PMCG4/026.ts
+++ b/data-asia/PMCG/PMCG4/026.ts
@@ -4,7 +4,8 @@ import Set from "../PMCG4"
 const card: Card = {
 	set: Set,
 	name: {
-		ja: "マグナイト",
+		// Magnemite
+		ja: "コイル",
 	},
 
 	rarity: "Common",
@@ -38,6 +39,9 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 575728
+			},
 		},
 	],
 };

--- a/data-asia/PMCG/PMCG4/026.ts
+++ b/data-asia/PMCG/PMCG4/026.ts
@@ -4,7 +4,6 @@ import Set from "../PMCG4"
 const card: Card = {
 	set: Set,
 	name: {
-		// Magnemite
 		ja: "コイル",
 	},
 

--- a/data-asia/PMCG/PMCG4/026.ts
+++ b/data-asia/PMCG/PMCG4/026.ts
@@ -8,6 +8,7 @@ const card: Card = {
 		ja: "コイル",
 	},
 
+	illustrator: "Miki Tanaka",
 	rarity: "Common",
 	category: "Pokemon",
 	dexId: [81],

--- a/data-asia/PMCG/PMCG4/027.ts
+++ b/data-asia/PMCG/PMCG4/027.ts
@@ -4,7 +4,8 @@ import Set from "../PMCG4"
 const card: Card = {
 	set: Set,
 	name: {
-		ja: "Voltorb",
+		// Voltorb
+		ja: "ビリリダマ",
 	},
 
 	rarity: "Common",
@@ -29,6 +30,9 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 575739
+			},
 		},
 	],
 };

--- a/data-asia/PMCG/PMCG4/027.ts
+++ b/data-asia/PMCG/PMCG4/027.ts
@@ -4,7 +4,6 @@ import Set from "../PMCG4"
 const card: Card = {
 	set: Set,
 	name: {
-		// Voltorb
 		ja: "ビリリダマ",
 	},
 

--- a/data-asia/PMCG/PMCG4/027.ts
+++ b/data-asia/PMCG/PMCG4/027.ts
@@ -8,6 +8,7 @@ const card: Card = {
 		ja: "ビリリダマ",
 	},
 
+	illustrator: "Ken Sugimori",
 	rarity: "Common",
 	category: "Pokemon",
 	dexId: [100],

--- a/data-asia/PMCG/PMCG4/028.ts
+++ b/data-asia/PMCG/PMCG4/028.ts
@@ -4,7 +4,8 @@ import Set from "../PMCG4"
 const card: Card = {
 	set: Set,
 	name: {
-		ja: "暗い電極",
+		// Dark Electrode
+		ja: "わるいマルマイン",
 	},
 
 	rarity: "Uncommon",
@@ -39,6 +40,9 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 575761
+			},
 		},
 	],
 };

--- a/data-asia/PMCG/PMCG4/028.ts
+++ b/data-asia/PMCG/PMCG4/028.ts
@@ -8,6 +8,7 @@ const card: Card = {
 		ja: "わるいマルマイン",
 	},
 
+	illustrator: "Ken Sugimori",
 	rarity: "Uncommon",
 	category: "Pokemon",
 	dexId: [101],

--- a/data-asia/PMCG/PMCG4/028.ts
+++ b/data-asia/PMCG/PMCG4/028.ts
@@ -4,7 +4,6 @@ import Set from "../PMCG4"
 const card: Card = {
 	set: Set,
 	name: {
-		// Dark Electrode
 		ja: "わるいマルマイン",
 	},
 

--- a/data-asia/PMCG/PMCG4/029.ts
+++ b/data-asia/PMCG/PMCG4/029.ts
@@ -8,6 +8,7 @@ const card: Card = {
 		ja: "わるいサンダース",
 	},
 
+	illustrator: "Mitsuhiro Arita",
 	rarity: "Uncommon",
 	category: "Pokemon",
 	dexId: [135],

--- a/data-asia/PMCG/PMCG4/029.ts
+++ b/data-asia/PMCG/PMCG4/029.ts
@@ -4,7 +4,6 @@ import Set from "../PMCG4"
 const card: Card = {
 	set: Set,
 	name: {
-		// Dark Jolteon
 		ja: "わるいサンダース",
 	},
 

--- a/data-asia/PMCG/PMCG4/029.ts
+++ b/data-asia/PMCG/PMCG4/029.ts
@@ -4,7 +4,8 @@ import Set from "../PMCG4"
 const card: Card = {
 	set: Set,
 	name: {
-		ja: "ダークジョルテオン",
+		// Dark Jolteon
+		ja: "わるいサンダース",
 	},
 
 	rarity: "Uncommon",
@@ -42,6 +43,9 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 575765
+			},
 		},
 	],
 };

--- a/data-asia/PMCG/PMCG4/030.ts
+++ b/data-asia/PMCG/PMCG4/030.ts
@@ -43,6 +43,9 @@ const card: Card = {
 	variants: [
 		{
 			type: "holo",
+			thirdParty: {
+				tcgplayer: 575751
+			},
 		},
 	],
 };

--- a/data-asia/PMCG/PMCG4/030.ts
+++ b/data-asia/PMCG/PMCG4/030.ts
@@ -4,7 +4,6 @@ import Set from "../PMCG4"
 const card: Card = {
 	set: Set,
 	name: {
-		// Dark Magneton
 		ja: "わるいレアコイル",
 	},
 

--- a/data-asia/PMCG/PMCG4/030.ts
+++ b/data-asia/PMCG/PMCG4/030.ts
@@ -4,7 +4,8 @@ import Set from "../PMCG4"
 const card: Card = {
 	set: Set,
 	name: {
-		ja: "ダークマグネトン",
+		// Dark Magneton
+		ja: "わるいレアコイル",
 	},
 
 	rarity: "Holo Rare",

--- a/data-asia/PMCG/PMCG4/030.ts
+++ b/data-asia/PMCG/PMCG4/030.ts
@@ -8,6 +8,7 @@ const card: Card = {
 		ja: "わるいレアコイル",
 	},
 
+	illustrator: "Miki Tanaka",
 	rarity: "Holo Rare",
 	category: "Pokemon",
 	dexId: [82],

--- a/data-asia/PMCG/PMCG4/031.ts
+++ b/data-asia/PMCG/PMCG4/031.ts
@@ -8,6 +8,7 @@ const card: Card = {
 		ja: "ケーシィ",
 	},
 
+	illustrator: "Sumiyoshi Kizuki",
 	rarity: "Common",
 	category: "Pokemon",
 	dexId: [63],

--- a/data-asia/PMCG/PMCG4/031.ts
+++ b/data-asia/PMCG/PMCG4/031.ts
@@ -4,7 +4,8 @@ import Set from "../PMCG4"
 const card: Card = {
 	set: Set,
 	name: {
-		ja: "アブラ",
+		// Abra
+		ja: "ケーシィ",
 	},
 
 	rarity: "Common",
@@ -41,6 +42,9 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 575712
+			},
 		},
 	],
 };

--- a/data-asia/PMCG/PMCG4/031.ts
+++ b/data-asia/PMCG/PMCG4/031.ts
@@ -4,7 +4,6 @@ import Set from "../PMCG4"
 const card: Card = {
 	set: Set,
 	name: {
-		// Abra
 		ja: "ケーシィ",
 	},
 

--- a/data-asia/PMCG/PMCG4/032.ts
+++ b/data-asia/PMCG/PMCG4/032.ts
@@ -8,6 +8,7 @@ const card: Card = {
 		ja: "ヤドン",
 	},
 
+	illustrator: "Sumiyoshi Kizuki",
 	rarity: "Common",
 	category: "Pokemon",
 	dexId: [79],

--- a/data-asia/PMCG/PMCG4/032.ts
+++ b/data-asia/PMCG/PMCG4/032.ts
@@ -4,7 +4,6 @@ import Set from "../PMCG4"
 const card: Card = {
 	set: Set,
 	name: {
-		// Slowpoke
 		ja: "ヤドン",
 	},
 

--- a/data-asia/PMCG/PMCG4/032.ts
+++ b/data-asia/PMCG/PMCG4/032.ts
@@ -4,7 +4,8 @@ import Set from "../PMCG4"
 const card: Card = {
 	set: Set,
 	name: {
-		ja: "slowpoke",
+		// Slowpoke
+		ja: "ヤドン",
 	},
 
 	rarity: "Common",
@@ -38,6 +39,9 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 575737
+			},
 		},
 	],
 };

--- a/data-asia/PMCG/PMCG4/033.ts
+++ b/data-asia/PMCG/PMCG4/033.ts
@@ -4,7 +4,6 @@ import Set from "../PMCG4"
 const card: Card = {
 	set: Set,
 	name: {
-		// Drowzee
 		ja: "スリープ",
 	},
 

--- a/data-asia/PMCG/PMCG4/033.ts
+++ b/data-asia/PMCG/PMCG4/033.ts
@@ -4,7 +4,8 @@ import Set from "../PMCG4"
 const card: Card = {
 	set: Set,
 	name: {
-		ja: "ドロージー",
+		// Drowzee
+		ja: "スリープ",
 	},
 
 	rarity: "Common",
@@ -43,6 +44,9 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 575719
+			},
 		},
 	],
 };

--- a/data-asia/PMCG/PMCG4/033.ts
+++ b/data-asia/PMCG/PMCG4/033.ts
@@ -8,6 +8,7 @@ const card: Card = {
 		ja: "スリープ",
 	},
 
+	illustrator: "Kagemaru Himeno",
 	rarity: "Common",
 	category: "Pokemon",
 	dexId: [96],

--- a/data-asia/PMCG/PMCG4/034.ts
+++ b/data-asia/PMCG/PMCG4/034.ts
@@ -4,7 +4,8 @@ import Set from "../PMCG4"
 const card: Card = {
 	set: Set,
 	name: {
-		ja: "暗いカダブラ",
+		// Dark Kadabra
+		ja: "わるいユンゲラ",
 	},
 
 	rarity: "Uncommon",
@@ -42,6 +43,9 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 575766
+			},
 		},
 	],
 };

--- a/data-asia/PMCG/PMCG4/034.ts
+++ b/data-asia/PMCG/PMCG4/034.ts
@@ -1,11 +1,11 @@
-import {Card} from "../../../interfaces"
+import { Card } from "../../../interfaces"
 import Set from "../PMCG4"
 
 const card: Card = {
 	set: Set,
 	name: {
 		// Dark Kadabra
-		ja: "わるいユンゲラ",
+		ja: "わるいユンゲラー",
 	},
 
 	rarity: "Uncommon",
@@ -20,6 +20,7 @@ const card: Card = {
 			name: {
 				ja: "物質交換",
 			},
+			type: 'Pokemon Power',
 			effect: {
 				ja: "順番<em>（攻撃の前）</em>中に、手からカードを捨てることができます。もしそうなら、カードを描きます。このポケモンが特別な状態の影響を受ける場合、このパワーは使用できません。",
 			},

--- a/data-asia/PMCG/PMCG4/034.ts
+++ b/data-asia/PMCG/PMCG4/034.ts
@@ -4,7 +4,6 @@ import Set from "../PMCG4"
 const card: Card = {
 	set: Set,
 	name: {
-		// Dark Kadabra
 		ja: "わるいユンゲラー",
 	},
 

--- a/data-asia/PMCG/PMCG4/034.ts
+++ b/data-asia/PMCG/PMCG4/034.ts
@@ -8,6 +8,7 @@ const card: Card = {
 		ja: "わるいユンゲラー",
 	},
 
+	illustrator: "Kagemaru Himeno",
 	rarity: "Uncommon",
 	category: "Pokemon",
 	dexId: [64],

--- a/data-asia/PMCG/PMCG4/035.ts
+++ b/data-asia/PMCG/PMCG4/035.ts
@@ -4,7 +4,8 @@ import Set from "../PMCG4"
 const card: Card = {
 	set: Set,
 	name: {
-		ja: "ダークアラカザム",
+		// Dark Alakazam
+		ja: "わるいフーディン",
 	},
 
 	rarity: "Holo Rare",

--- a/data-asia/PMCG/PMCG4/035.ts
+++ b/data-asia/PMCG/PMCG4/035.ts
@@ -8,6 +8,7 @@ const card: Card = {
 		ja: "わるいフーディン",
 	},
 
+	illustrator: "Ken Sugimori",
 	rarity: "Holo Rare",
 	category: "Pokemon",
 	dexId: [65],

--- a/data-asia/PMCG/PMCG4/035.ts
+++ b/data-asia/PMCG/PMCG4/035.ts
@@ -4,7 +4,6 @@ import Set from "../PMCG4"
 const card: Card = {
 	set: Set,
 	name: {
-		// Dark Alakazam
 		ja: "わるいフーディン",
 	},
 

--- a/data-asia/PMCG/PMCG4/035.ts
+++ b/data-asia/PMCG/PMCG4/035.ts
@@ -43,6 +43,9 @@ const card: Card = {
 	variants: [
 		{
 			type: "holo",
+			thirdParty: {
+				tcgplayer: 575741
+			},
 		},
 	],
 };

--- a/data-asia/PMCG/PMCG4/036.ts
+++ b/data-asia/PMCG/PMCG4/036.ts
@@ -44,6 +44,9 @@ const card: Card = {
 	variants: [
 		{
 			type: "holo",
+			thirdParty: {
+				tcgplayer: 575752
+			},
 		},
 	],
 };

--- a/data-asia/PMCG/PMCG4/036.ts
+++ b/data-asia/PMCG/PMCG4/036.ts
@@ -4,7 +4,8 @@ import Set from "../PMCG4"
 const card: Card = {
 	set: Set,
 	name: {
-		ja: "暗いスローブロ",
+		// Dark Slowbro
+		ja: "わるいヤドラン",
 	},
 
 	rarity: "Holo Rare",

--- a/data-asia/PMCG/PMCG4/036.ts
+++ b/data-asia/PMCG/PMCG4/036.ts
@@ -4,7 +4,6 @@ import Set from "../PMCG4"
 const card: Card = {
 	set: Set,
 	name: {
-		// Dark Slowbro
 		ja: "わるいヤドラン",
 	},
 

--- a/data-asia/PMCG/PMCG4/036.ts
+++ b/data-asia/PMCG/PMCG4/036.ts
@@ -8,6 +8,7 @@ const card: Card = {
 		ja: "わるいヤドラン",
 	},
 
+	illustrator: "Mitsuhiro Arita",
 	rarity: "Holo Rare",
 	category: "Pokemon",
 	dexId: [80],

--- a/data-asia/PMCG/PMCG4/037.ts
+++ b/data-asia/PMCG/PMCG4/037.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	set: Set,
 	name: {
 		// Dark Hypno
-		ja: "わるいスリーパ",
+		ja: "わるいスリーパー",
 	},
 
 	rarity: "Holo Rare",
@@ -39,6 +39,9 @@ const card: Card = {
 	variants: [
 		{
 			type: "holo",
+			thirdParty: {
+				tcgplayer: 575749
+			},
 		},
 	],
 };

--- a/data-asia/PMCG/PMCG4/037.ts
+++ b/data-asia/PMCG/PMCG4/037.ts
@@ -4,7 +4,6 @@ import Set from "../PMCG4"
 const card: Card = {
 	set: Set,
 	name: {
-		// Dark Hypno
 		ja: "わるいスリーパー",
 	},
 

--- a/data-asia/PMCG/PMCG4/037.ts
+++ b/data-asia/PMCG/PMCG4/037.ts
@@ -8,6 +8,7 @@ const card: Card = {
 		ja: "わるいスリーパー",
 	},
 
+	illustrator: "Kagemaru Himeno",
 	rarity: "Holo Rare",
 	category: "Pokemon",
 	dexId: [97],

--- a/data-asia/PMCG/PMCG4/037.ts
+++ b/data-asia/PMCG/PMCG4/037.ts
@@ -4,7 +4,8 @@ import Set from "../PMCG4"
 const card: Card = {
 	set: Set,
 	name: {
-		ja: "暗い催眠",
+		// Dark Hypno
+		ja: "わるいスリーパ",
 	},
 
 	rarity: "Holo Rare",

--- a/data-asia/PMCG/PMCG4/038.ts
+++ b/data-asia/PMCG/PMCG4/038.ts
@@ -4,7 +4,8 @@ import Set from "../PMCG4"
 const card: Card = {
 	set: Set,
 	name: {
-		ja: "ディグレット",
+		// Diglett
+		ja: "ディグダ",
 	},
 
 	rarity: "Common",
@@ -37,6 +38,9 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 575717
+			},
 		},
 	],
 };

--- a/data-asia/PMCG/PMCG4/038.ts
+++ b/data-asia/PMCG/PMCG4/038.ts
@@ -4,7 +4,6 @@ import Set from "../PMCG4"
 const card: Card = {
 	set: Set,
 	name: {
-		// Diglett
 		ja: "ディグダ",
 	},
 

--- a/data-asia/PMCG/PMCG4/038.ts
+++ b/data-asia/PMCG/PMCG4/038.ts
@@ -8,6 +8,7 @@ const card: Card = {
 		ja: "ディグダ",
 	},
 
+	illustrator: "Sumiyoshi Kizuki",
 	rarity: "Common",
 	category: "Pokemon",
 	dexId: [50],

--- a/data-asia/PMCG/PMCG4/039.ts
+++ b/data-asia/PMCG/PMCG4/039.ts
@@ -8,6 +8,7 @@ const card: Card = {
 		ja: "マンキー",
 	},
 
+	illustrator: "Sumiyoshi Kizuki",
 	rarity: "Common",
 	category: "Pokemon",
 	dexId: [56],

--- a/data-asia/PMCG/PMCG4/039.ts
+++ b/data-asia/PMCG/PMCG4/039.ts
@@ -4,6 +4,7 @@ import Set from "../PMCG4"
 const card: Card = {
 	set: Set,
 	name: {
+		// Mankey
 		ja: "マンキー",
 	},
 
@@ -39,6 +40,9 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 575729
+			},
 		},
 	],
 };

--- a/data-asia/PMCG/PMCG4/039.ts
+++ b/data-asia/PMCG/PMCG4/039.ts
@@ -4,7 +4,6 @@ import Set from "../PMCG4"
 const card: Card = {
 	set: Set,
 	name: {
-		// Mankey
 		ja: "マンキー",
 	},
 

--- a/data-asia/PMCG/PMCG4/040.ts
+++ b/data-asia/PMCG/PMCG4/040.ts
@@ -8,6 +8,7 @@ const card: Card = {
 		ja: "ワンリキー",
 	},
 
+	illustrator: "Ken Sugimori",
 	rarity: "Common",
 	category: "Pokemon",
 	dexId: [66],

--- a/data-asia/PMCG/PMCG4/040.ts
+++ b/data-asia/PMCG/PMCG4/040.ts
@@ -4,7 +4,8 @@ import Set from "../PMCG4"
 const card: Card = {
 	set: Set,
 	name: {
-		ja: "マチョップ",
+		// Machop
+		ja: "ワンリキー",
 	},
 
 	rarity: "Common",
@@ -36,6 +37,9 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 575726
+			},
 		},
 	],
 };

--- a/data-asia/PMCG/PMCG4/040.ts
+++ b/data-asia/PMCG/PMCG4/040.ts
@@ -4,7 +4,6 @@ import Set from "../PMCG4"
 const card: Card = {
 	set: Set,
 	name: {
-		// Machop
 		ja: "ワンリキー",
 	},
 

--- a/data-asia/PMCG/PMCG4/041.ts
+++ b/data-asia/PMCG/PMCG4/041.ts
@@ -8,6 +8,7 @@ const card: Card = {
 		ja: "わるいオコリザル",
 	},
 
+	illustrator: "Mitsuhiro Arita",
 	rarity: "Uncommon",
 	category: "Pokemon",
 	dexId: [57],

--- a/data-asia/PMCG/PMCG4/041.ts
+++ b/data-asia/PMCG/PMCG4/041.ts
@@ -4,7 +4,8 @@ import Set from "../PMCG4"
 const card: Card = {
 	set: Set,
 	name: {
-		ja: "ダークプライムエーパー",
+		// Dark Primeape
+		ja: "わるいオコリザル",
 	},
 
 	rarity: "Uncommon",
@@ -43,6 +44,9 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 575769
+			},
 		},
 	],
 };

--- a/data-asia/PMCG/PMCG4/041.ts
+++ b/data-asia/PMCG/PMCG4/041.ts
@@ -4,7 +4,6 @@ import Set from "../PMCG4"
 const card: Card = {
 	set: Set,
 	name: {
-		// Dark Primeape
 		ja: "わるいオコリザル",
 	},
 

--- a/data-asia/PMCG/PMCG4/042.ts
+++ b/data-asia/PMCG/PMCG4/042.ts
@@ -4,7 +4,8 @@ import Set from "../PMCG4"
 const card: Card = {
 	set: Set,
 	name: {
-		ja: "暗いマチョーク",
+		// Dark Machoke
+		ja: "わるいゴーリキー",
 	},
 
 	rarity: "Uncommon",
@@ -42,6 +43,9 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 575767
+			},
 		},
 	],
 };

--- a/data-asia/PMCG/PMCG4/042.ts
+++ b/data-asia/PMCG/PMCG4/042.ts
@@ -8,6 +8,7 @@ const card: Card = {
 		ja: "わるいゴーリキー",
 	},
 
+	illustrator: "Mitsuhiro Arita",
 	rarity: "Uncommon",
 	category: "Pokemon",
 	dexId: [67],

--- a/data-asia/PMCG/PMCG4/042.ts
+++ b/data-asia/PMCG/PMCG4/042.ts
@@ -4,7 +4,6 @@ import Set from "../PMCG4"
 const card: Card = {
 	set: Set,
 	name: {
-		// Dark Machoke
 		ja: "わるいゴーリキー",
 	},
 

--- a/data-asia/PMCG/PMCG4/043.ts
+++ b/data-asia/PMCG/PMCG4/043.ts
@@ -4,7 +4,6 @@ import Set from "../PMCG4"
 const card: Card = {
 	set: Set,
 	name: {
-		// Dark Dugtrio
 		ja: "わるいダグトリオ",
 	},
 

--- a/data-asia/PMCG/PMCG4/043.ts
+++ b/data-asia/PMCG/PMCG4/043.ts
@@ -8,6 +8,7 @@ const card: Card = {
 		ja: "わるいダグトリオ",
 	},
 
+	illustrator: "Kagemaru Himeno",
 	rarity: "Holo Rare",
 	category: "Pokemon",
 	dexId: [51],

--- a/data-asia/PMCG/PMCG4/043.ts
+++ b/data-asia/PMCG/PMCG4/043.ts
@@ -43,6 +43,9 @@ const card: Card = {
 	variants: [
 		{
 			type: "holo",
+			thirdParty: {
+				tcgplayer: 575746
+			},
 		},
 	],
 };

--- a/data-asia/PMCG/PMCG4/043.ts
+++ b/data-asia/PMCG/PMCG4/043.ts
@@ -4,7 +4,8 @@ import Set from "../PMCG4"
 const card: Card = {
 	set: Set,
 	name: {
-		ja: "ダークディグトリオ",
+		// Dark Dugtrio
+		ja: "わるいダグトリオ",
 	},
 
 	rarity: "Holo Rare",

--- a/data-asia/PMCG/PMCG4/044.ts
+++ b/data-asia/PMCG/PMCG4/044.ts
@@ -39,6 +39,9 @@ const card: Card = {
 	variants: [
 		{
 			type: "holo",
+			thirdParty: {
+				tcgplayer: 575750
+			},
 		},
 	],
 };

--- a/data-asia/PMCG/PMCG4/044.ts
+++ b/data-asia/PMCG/PMCG4/044.ts
@@ -4,7 +4,6 @@ import Set from "../PMCG4"
 const card: Card = {
 	set: Set,
 	name: {
-		// Dark Machamp
 		ja: "わるいカイリキー",
 	},
 

--- a/data-asia/PMCG/PMCG4/044.ts
+++ b/data-asia/PMCG/PMCG4/044.ts
@@ -4,7 +4,8 @@ import Set from "../PMCG4"
 const card: Card = {
 	set: Set,
 	name: {
-		ja: "暗いマチャンプ",
+		// Dark Machamp
+		ja: "わるいカイリキー",
 	},
 
 	rarity: "Holo Rare",

--- a/data-asia/PMCG/PMCG4/044.ts
+++ b/data-asia/PMCG/PMCG4/044.ts
@@ -8,6 +8,7 @@ const card: Card = {
 		ja: "わるいカイリキー",
 	},
 
+	illustrator: "Mitsuhiro Arita",
 	rarity: "Holo Rare",
 	category: "Pokemon",
 	dexId: [68],

--- a/data-asia/PMCG/PMCG4/045.ts
+++ b/data-asia/PMCG/PMCG4/045.ts
@@ -4,7 +4,6 @@ import Set from "../PMCG4"
 const card: Card = {
 	set: Set,
 	name: {
-		// Rattata
 		ja: "コラッタ",
 	},
 

--- a/data-asia/PMCG/PMCG4/045.ts
+++ b/data-asia/PMCG/PMCG4/045.ts
@@ -4,7 +4,8 @@ import Set from "../PMCG4"
 const card: Card = {
 	set: Set,
 	name: {
-		ja: "ラッタタ",
+		// Rattata
+		ja: "コラッタ",
 	},
 
 	rarity: "Common",
@@ -41,6 +42,9 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 575735
+			},
 		},
 	],
 };

--- a/data-asia/PMCG/PMCG4/045.ts
+++ b/data-asia/PMCG/PMCG4/045.ts
@@ -8,6 +8,7 @@ const card: Card = {
 		ja: "コラッタ",
 	},
 
+	illustrator: "Atsuko Nishida",
 	rarity: "Common",
 	category: "Pokemon",
 	dexId: [19],

--- a/data-asia/PMCG/PMCG4/046.ts
+++ b/data-asia/PMCG/PMCG4/046.ts
@@ -8,6 +8,7 @@ const card: Card = {
 		ja: "わるいラッタ",
 	},
 
+	illustrator: "Shin-ichi Yoshida",
 	rarity: "Common",
 	category: "Pokemon",
 	dexId: [20],

--- a/data-asia/PMCG/PMCG4/046.ts
+++ b/data-asia/PMCG/PMCG4/046.ts
@@ -4,7 +4,6 @@ import Set from "../PMCG4"
 const card: Card = {
 	set: Set,
 	name: {
-		// Dark Raticate
 		ja: "わるいラッタ",
 	},
 

--- a/data-asia/PMCG/PMCG4/046.ts
+++ b/data-asia/PMCG/PMCG4/046.ts
@@ -4,7 +4,8 @@ import Set from "../PMCG4"
 const card: Card = {
 	set: Set,
 	name: {
-		ja: "暗いラティテート",
+		// Dark Raticate
+		ja: "わるいラッタ",
 	},
 
 	rarity: "Common",
@@ -39,6 +40,9 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 575716
+			},
 		},
 	],
 };

--- a/data-asia/PMCG/PMCG4/047.ts
+++ b/data-asia/PMCG/PMCG4/047.ts
@@ -8,6 +8,7 @@ const card: Card = {
 		ja: "ニャース",
 	},
 
+	illustrator: "Atsuko Nishida",
 	rarity: "Common",
 	category: "Pokemon",
 	dexId: [52],

--- a/data-asia/PMCG/PMCG4/047.ts
+++ b/data-asia/PMCG/PMCG4/047.ts
@@ -4,7 +4,8 @@ import Set from "../PMCG4"
 const card: Card = {
 	set: Set,
 	name: {
-		ja: "meowth",
+		// Meowth
+		ja: "ニャース",
 	},
 
 	rarity: "Common",
@@ -31,6 +32,9 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 575730
+			},
 		},
 	],
 };

--- a/data-asia/PMCG/PMCG4/047.ts
+++ b/data-asia/PMCG/PMCG4/047.ts
@@ -4,7 +4,6 @@ import Set from "../PMCG4"
 const card: Card = {
 	set: Set,
 	name: {
-		// Meowth
 		ja: "ニャース",
 	},
 

--- a/data-asia/PMCG/PMCG4/048.ts
+++ b/data-asia/PMCG/PMCG4/048.ts
@@ -8,6 +8,7 @@ const card: Card = {
 		ja: "わるいペルシアン",
 	},
 
+	illustrator: "Ken Sugimori",
 	rarity: "Common",
 	category: "Pokemon",
 	dexId: [53],

--- a/data-asia/PMCG/PMCG4/048.ts
+++ b/data-asia/PMCG/PMCG4/048.ts
@@ -4,7 +4,8 @@ import Set from "../PMCG4"
 const card: Card = {
 	set: Set,
 	name: {
-		ja: "暗いペルシャ語",
+		// Dark Persian
+		ja: "わるいペルシアン",
 	},
 
 	rarity: "Common",
@@ -40,6 +41,9 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 575714
+			},
 		},
 	],
 };

--- a/data-asia/PMCG/PMCG4/048.ts
+++ b/data-asia/PMCG/PMCG4/048.ts
@@ -4,7 +4,6 @@ import Set from "../PMCG4"
 const card: Card = {
 	set: Set,
 	name: {
-		// Dark Persian
 		ja: "わるいペルシアン",
 	},
 

--- a/data-asia/PMCG/PMCG4/049.ts
+++ b/data-asia/PMCG/PMCG4/049.ts
@@ -4,7 +4,6 @@ import Set from "../PMCG4"
 const card: Card = {
 	set: Set,
 	name: {
-		// Eevee
 		ja: "イーブイ",
 	},
 

--- a/data-asia/PMCG/PMCG4/049.ts
+++ b/data-asia/PMCG/PMCG4/049.ts
@@ -8,6 +8,7 @@ const card: Card = {
 		ja: "イーブイ",
 	},
 
+	illustrator: "Atsuko Nishida",
 	rarity: "Common",
 	category: "Pokemon",
 	dexId: [133],

--- a/data-asia/PMCG/PMCG4/049.ts
+++ b/data-asia/PMCG/PMCG4/049.ts
@@ -4,7 +4,8 @@ import Set from "../PMCG4"
 const card: Card = {
 	set: Set,
 	name: {
-		ja: "Eevee",
+		// Eevee
+		ja: "イーブイ",
 	},
 
 	rarity: "Common",
@@ -39,6 +40,9 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 575720
+			},
 		},
 	],
 };

--- a/data-asia/PMCG/PMCG4/050.ts
+++ b/data-asia/PMCG/PMCG4/050.ts
@@ -4,6 +4,7 @@ import Set from "../PMCG4"
 const card: Card = {
 	set: Set,
 	name: {
+		// Porygon
 		ja: "ポリゴン",
 	},
 
@@ -40,6 +41,9 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 575775
+			},
 		},
 	],
 };

--- a/data-asia/PMCG/PMCG4/050.ts
+++ b/data-asia/PMCG/PMCG4/050.ts
@@ -8,6 +8,7 @@ const card: Card = {
 		ja: "ポリゴン",
 	},
 
+	illustrator: "Keiji Kinebuchi",
 	rarity: "Common",
 	category: "Pokemon",
 	dexId: [137],

--- a/data-asia/PMCG/PMCG4/050.ts
+++ b/data-asia/PMCG/PMCG4/050.ts
@@ -4,7 +4,6 @@ import Set from "../PMCG4"
 const card: Card = {
 	set: Set,
 	name: {
-		// Porygon
 		ja: "ポリゴン",
 	},
 

--- a/data-asia/PMCG/PMCG4/051.ts
+++ b/data-asia/PMCG/PMCG4/051.ts
@@ -8,6 +8,7 @@ const card: Card = {
 		ja: "ミニリュウ",
 	},
 
+	illustrator: "Kagemaru Himeno",
 	rarity: "Common",
 	category: "Pokemon",
 	dexId: [147],

--- a/data-asia/PMCG/PMCG4/051.ts
+++ b/data-asia/PMCG/PMCG4/051.ts
@@ -4,7 +4,6 @@ import Set from "../PMCG4"
 const card: Card = {
 	set: Set,
 	name: {
-		// Dratini
 		ja: "ミニリュウ",
 	},
 

--- a/data-asia/PMCG/PMCG4/051.ts
+++ b/data-asia/PMCG/PMCG4/051.ts
@@ -4,7 +4,8 @@ import Set from "../PMCG4"
 const card: Card = {
 	set: Set,
 	name: {
-		ja: "ドラチーニ",
+		// Dratini
+		ja: "ミニリュウ",
 	},
 
 	rarity: "Common",
@@ -32,6 +33,9 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 575718
+			},
 		},
 	],
 };

--- a/data-asia/PMCG/PMCG4/052.ts
+++ b/data-asia/PMCG/PMCG4/052.ts
@@ -4,7 +4,6 @@ import Set from "../PMCG4"
 const card: Card = {
 	set: Set,
 	name: {
-		// Dark Dragonair
 		ja: "わるいハクリュー",
 	},
 

--- a/data-asia/PMCG/PMCG4/052.ts
+++ b/data-asia/PMCG/PMCG4/052.ts
@@ -4,7 +4,8 @@ import Set from "../PMCG4"
 const card: Card = {
 	set: Set,
 	name: {
-		ja: "ダークドラゴンエア",
+		// Dark Dragonair
+		ja: "わるいハクリュー",
 	},
 
 	rarity: "Uncommon",
@@ -42,6 +43,9 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 575760
+			},
 		},
 	],
 };

--- a/data-asia/PMCG/PMCG4/052.ts
+++ b/data-asia/PMCG/PMCG4/052.ts
@@ -8,6 +8,7 @@ const card: Card = {
 		ja: "わるいハクリュー",
 	},
 
+	illustrator: "Kagemaru Himeno",
 	rarity: "Uncommon",
 	category: "Pokemon",
 	dexId: [148],

--- a/data-asia/PMCG/PMCG4/053.ts
+++ b/data-asia/PMCG/PMCG4/053.ts
@@ -8,6 +8,7 @@ const card: Card = {
 		ja: "わるいカイリュー",
 	},
 
+	illustrator: "Mitsuhiro Arita",
 	rarity: "Holo Rare",
 	category: "Pokemon",
 	dexId: [149],

--- a/data-asia/PMCG/PMCG4/053.ts
+++ b/data-asia/PMCG/PMCG4/053.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	set: Set,
 	name: {
 		// Dark Dragonite
-		ja: "わるいカイリュ",
+		ja: "わるいカイリュー",
 	},
 
 	rarity: "Holo Rare",
@@ -44,6 +44,9 @@ const card: Card = {
 	variants: [
 		{
 			type: "holo",
+			thirdParty: {
+				tcgplayer: 575745
+			},
 		},
 	],
 };

--- a/data-asia/PMCG/PMCG4/053.ts
+++ b/data-asia/PMCG/PMCG4/053.ts
@@ -4,7 +4,8 @@ import Set from "../PMCG4"
 const card: Card = {
 	set: Set,
 	name: {
-		ja: "暗いドラゴナイト",
+		// Dark Dragonite
+		ja: "わるいカイリュ",
 	},
 
 	rarity: "Holo Rare",

--- a/data-asia/PMCG/PMCG4/053.ts
+++ b/data-asia/PMCG/PMCG4/053.ts
@@ -4,7 +4,6 @@ import Set from "../PMCG4"
 const card: Card = {
 	set: Set,
 	name: {
-		// Dark Dragonite
 		ja: "わるいカイリュー",
 	},
 

--- a/data-asia/PMCG/PMCG4/054.ts
+++ b/data-asia/PMCG/PMCG4/054.ts
@@ -4,7 +4,8 @@ import Set from "../PMCG4"
 const card: Card = {
 	set: Set,
 	name: {
-		ja: "寝る！",
+		// Sleep!
+		ja: "ねむれ!ねむれ!",
 	},
 
 	rarity: "Common",
@@ -13,6 +14,9 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 575736
+			},
 		},
 	],
 };

--- a/data-asia/PMCG/PMCG4/054.ts
+++ b/data-asia/PMCG/PMCG4/054.ts
@@ -8,6 +8,7 @@ const card: Card = {
 		ja: "ねむれ!ねむれ!",
 	},
 
+	illustrator: "Sumiyoshi Kizuki",
 	rarity: "Common",
 	category: "Trainer",
 

--- a/data-asia/PMCG/PMCG4/054.ts
+++ b/data-asia/PMCG/PMCG4/054.ts
@@ -4,7 +4,6 @@ import Set from "../PMCG4"
 const card: Card = {
 	set: Set,
 	name: {
-		// Sleep!
 		ja: "ねむれ!ねむれ!",
 	},
 

--- a/data-asia/PMCG/PMCG4/055.ts
+++ b/data-asia/PMCG/PMCG4/055.ts
@@ -8,6 +8,7 @@ const card: Card = {
 		ja: "バトル場は穴だらけ!",
 	},
 
+	illustrator: "Sumiyoshi Kizuki",
 	rarity: "Common",
 	category: "Trainer",
 

--- a/data-asia/PMCG/PMCG4/055.ts
+++ b/data-asia/PMCG/PMCG4/055.ts
@@ -4,7 +4,8 @@ import Set from "../PMCG4"
 const card: Card = {
 	set: Set,
 	name: {
-		ja: "掘り",
+		// Digger
+		ja: "バトル場は穴だらけ!",
 	},
 
 	rarity: "Uncommon",
@@ -13,6 +14,9 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 575772
+			},
 		},
 	],
 };

--- a/data-asia/PMCG/PMCG4/055.ts
+++ b/data-asia/PMCG/PMCG4/055.ts
@@ -4,7 +4,6 @@ import Set from "../PMCG4"
 const card: Card = {
 	set: Set,
 	name: {
-		// Digger
 		ja: "バトル場は穴だらけ!",
 	},
 

--- a/data-asia/PMCG/PMCG4/055.ts
+++ b/data-asia/PMCG/PMCG4/055.ts
@@ -8,7 +8,7 @@ const card: Card = {
 		ja: "バトル場は穴だらけ!",
 	},
 
-	rarity: "Uncommon",
+	rarity: "Common",
 	category: "Trainer",
 
 	variants: [

--- a/data-asia/PMCG/PMCG4/056.ts
+++ b/data-asia/PMCG/PMCG4/056.ts
@@ -8,6 +8,7 @@ const card: Card = {
 		ja: "まきちらせ!ベトベトガス",
 	},
 
+	illustrator: "Sumiyoshi Kizuki",
 	rarity: "Common",
 	category: "Trainer",
 

--- a/data-asia/PMCG/PMCG4/056.ts
+++ b/data-asia/PMCG/PMCG4/056.ts
@@ -4,7 +4,6 @@ import Set from "../PMCG4"
 const card: Card = {
 	set: Set,
 	name: {
-		// Goop Gas Attack
 		ja: "まきちらせ!ベトベトガス",
 	},
 

--- a/data-asia/PMCG/PMCG4/056.ts
+++ b/data-asia/PMCG/PMCG4/056.ts
@@ -4,7 +4,8 @@ import Set from "../PMCG4"
 const card: Card = {
 	set: Set,
 	name: {
-		ja: "GOOPガス攻撃",
+		// Goop Gas Attack
+		ja: "まきちらせ!ベトベトガス",
 	},
 
 	rarity: "Common",
@@ -13,6 +14,9 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 575723
+			},
 		},
 	],
 };

--- a/data-asia/PMCG/PMCG4/057.ts
+++ b/data-asia/PMCG/PMCG4/057.ts
@@ -8,7 +8,7 @@ const card: Card = {
 		ja: "夜の廃品回収",
 	},
 
-	rarity: "Uncommon",
+	rarity: "Common",
 	category: "Trainer",
 
 	variants: [

--- a/data-asia/PMCG/PMCG4/057.ts
+++ b/data-asia/PMCG/PMCG4/057.ts
@@ -8,6 +8,7 @@ const card: Card = {
 		ja: "夜の廃品回収",
 	},
 
+	illustrator: "Sumiyoshi Kizuki",
 	rarity: "Common",
 	category: "Trainer",
 

--- a/data-asia/PMCG/PMCG4/057.ts
+++ b/data-asia/PMCG/PMCG4/057.ts
@@ -4,7 +4,8 @@ import Set from "../PMCG4"
 const card: Card = {
 	set: Set,
 	name: {
-		ja: "毎晩のごみ走り",
+		// Nightly Garbage Run
+		ja: "夜の廃品回収",
 	},
 
 	rarity: "Uncommon",
@@ -13,6 +14,9 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 575774
+			},
 		},
 	],
 };

--- a/data-asia/PMCG/PMCG4/057.ts
+++ b/data-asia/PMCG/PMCG4/057.ts
@@ -4,7 +4,6 @@ import Set from "../PMCG4"
 const card: Card = {
 	set: Set,
 	name: {
-		// Nightly Garbage Run
 		ja: "夜の廃品回収",
 	},
 

--- a/data-asia/PMCG/PMCG4/058.ts
+++ b/data-asia/PMCG/PMCG4/058.ts
@@ -4,7 +4,8 @@ import Set from "../PMCG4"
 const card: Card = {
 	set: Set,
 	name: {
-		ja: "チャレンジ！",
+		// Challenge!
+		ja: "たたきつけろ!挑戦状",
 	},
 
 	rarity: "Uncommon",
@@ -13,6 +14,9 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 575758
+			},
 		},
 	],
 };

--- a/data-asia/PMCG/PMCG4/058.ts
+++ b/data-asia/PMCG/PMCG4/058.ts
@@ -8,6 +8,7 @@ const card: Card = {
 		ja: "たたきつけろ!挑戦状",
 	},
 
+	illustrator: "Kagemaru Himeno",
 	rarity: "Uncommon",
 	category: "Trainer",
 

--- a/data-asia/PMCG/PMCG4/058.ts
+++ b/data-asia/PMCG/PMCG4/058.ts
@@ -4,7 +4,6 @@ import Set from "../PMCG4"
 const card: Card = {
 	set: Set,
 	name: {
-		// Challenge!
 		ja: "たたきつけろ!挑戦状",
 	},
 

--- a/data-asia/PMCG/PMCG4/059.ts
+++ b/data-asia/PMCG/PMCG4/059.ts
@@ -4,7 +4,6 @@ import Set from "../PMCG4"
 const card: Card = {
 	set: Set,
 	name: {
-		// Imposter Oak's Revenge
 		ja: "にせオーキドの逆襲",
 	},
 

--- a/data-asia/PMCG/PMCG4/059.ts
+++ b/data-asia/PMCG/PMCG4/059.ts
@@ -4,7 +4,8 @@ import Set from "../PMCG4"
 const card: Card = {
 	set: Set,
 	name: {
-		ja: "詐欺師オークの復ven",
+		// Imposter Oak's Revenge
+		ja: "にせオーキドの逆襲",
 	},
 
 	rarity: "Uncommon",
@@ -13,6 +14,9 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 575773
+			},
 		},
 	],
 };

--- a/data-asia/PMCG/PMCG4/059.ts
+++ b/data-asia/PMCG/PMCG4/059.ts
@@ -8,6 +8,7 @@ const card: Card = {
 		ja: "にせオーキドの逆襲",
 	},
 
+	illustrator: "Ken Sugimori",
 	rarity: "Uncommon",
 	category: "Trainer",
 

--- a/data-asia/PMCG/PMCG4/060.ts
+++ b/data-asia/PMCG/PMCG4/060.ts
@@ -8,6 +8,7 @@ const card: Card = {
 		ja: "ボスのやりかた",
 	},
 
+	illustrator: "Ken Sugimori",
 	rarity: "Uncommon",
 	category: "Trainer",
 

--- a/data-asia/PMCG/PMCG4/060.ts
+++ b/data-asia/PMCG/PMCG4/060.ts
@@ -4,7 +4,8 @@ import Set from "../PMCG4"
 const card: Card = {
 	set: Set,
 	name: {
-		ja: "上司のやり方",
+		// The Boss's Way
+		ja: "ボスのやりかた",
 	},
 
 	rarity: "Uncommon",
@@ -13,6 +14,9 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 575776
+			},
 		},
 	],
 };

--- a/data-asia/PMCG/PMCG4/060.ts
+++ b/data-asia/PMCG/PMCG4/060.ts
@@ -4,7 +4,6 @@ import Set from "../PMCG4"
 const card: Card = {
 	set: Set,
 	name: {
-		// The Boss's Way
 		ja: "ボスのやりかた",
 	},
 

--- a/data-asia/PMCG/PMCG4/061.ts
+++ b/data-asia/PMCG/PMCG4/061.ts
@@ -8,6 +8,7 @@ const card: Card = {
 		ja: "ロケット団のおねーさん",
 	},
 
+	illustrator: "Ken Sugimori",
 	rarity: "Holo Rare",
 	category: "Trainer",
 

--- a/data-asia/PMCG/PMCG4/061.ts
+++ b/data-asia/PMCG/PMCG4/061.ts
@@ -14,6 +14,9 @@ const card: Card = {
 	variants: [
 		{
 			type: "holo",
+			thirdParty: {
+				tcgplayer: 575756
+			},
 		},
 	],
 };

--- a/data-asia/PMCG/PMCG4/061.ts
+++ b/data-asia/PMCG/PMCG4/061.ts
@@ -4,7 +4,8 @@ import Set from "../PMCG4"
 const card: Card = {
 	set: Set,
 	name: {
-		ja: "ロケットのスニーク攻撃",
+		// Rocket's Sneak Attack
+		ja: "ロケット団のおねーさん",
 	},
 
 	rarity: "Holo Rare",

--- a/data-asia/PMCG/PMCG4/061.ts
+++ b/data-asia/PMCG/PMCG4/061.ts
@@ -4,7 +4,6 @@ import Set from "../PMCG4"
 const card: Card = {
 	set: Set,
 	name: {
-		// Rocket's Sneak Attack
 		ja: "ロケット団のおねーさん",
 	},
 

--- a/data-asia/PMCG/PMCG4/062.ts
+++ b/data-asia/PMCG/PMCG4/062.ts
@@ -4,7 +4,6 @@ import Set from "../PMCG4"
 const card: Card = {
 	set: Set,
 	name: {
-		// Here Comes Team Rocket!
 		ja: "ロケット団参上!",
 	},
 

--- a/data-asia/PMCG/PMCG4/062.ts
+++ b/data-asia/PMCG/PMCG4/062.ts
@@ -4,7 +4,8 @@ import Set from "../PMCG4"
 const card: Card = {
 	set: Set,
 	name: {
-		ja: "これがチームロケットが来ます！",
+		// Here Comes Team Rocket!
+		ja: "ロケット団参上!",
 	},
 
 	rarity: "Secret Rare",
@@ -14,6 +15,12 @@ const card: Card = {
 		{
 			type: "holo",
 		},
+				{
+						type: "normal",
+						thirdParty: {
+								tcgplayer: 575757
+						},
+				}
 	],
 };
 

--- a/data-asia/PMCG/PMCG4/062.ts
+++ b/data-asia/PMCG/PMCG4/062.ts
@@ -8,6 +8,7 @@ const card: Card = {
 		ja: "ロケット団参上!",
 	},
 
+	illustrator: "Ken Sugimori",
 	rarity: "Secret Rare",
 	category: "Trainer",
 

--- a/data-asia/PMCG/PMCG4/063.ts
+++ b/data-asia/PMCG/PMCG4/063.ts
@@ -4,7 +4,6 @@ import Set from "../PMCG4"
 const card: Card = {
 	set: Set,
 	name: {
-		// Potion Energy
 		ja: "きずぐすり配合エネルギー",
 	},
 

--- a/data-asia/PMCG/PMCG4/063.ts
+++ b/data-asia/PMCG/PMCG4/063.ts
@@ -4,7 +4,8 @@ import Set from "../PMCG4"
 const card: Card = {
 	set: Set,
 	name: {
-		ja: "ポーションエネルギー",
+		// Potion Energy
+		ja: "きずぐすり配合エネルギー",
 	},
 
 	rarity: "Common",
@@ -13,6 +14,9 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 575733
+			},
 		},
 	],
 };

--- a/data-asia/PMCG/PMCG4/063.ts
+++ b/data-asia/PMCG/PMCG4/063.ts
@@ -8,6 +8,7 @@ const card: Card = {
 		ja: "きずぐすり配合エネルギー",
 	},
 
+	illustrator: "Keiji Kinebuchi",
 	rarity: "Common",
 	category: "Energy",
 

--- a/data-asia/PMCG/PMCG4/064.ts
+++ b/data-asia/PMCG/PMCG4/064.ts
@@ -4,7 +4,8 @@ import Set from "../PMCG4"
 const card: Card = {
 	set: Set,
 	name: {
-		ja: "フルヒールエネルギー",
+		// Full Heal Energy
+		ja: "なんでもなおし配合エネルギー",
 	},
 
 	rarity: "Common",
@@ -13,6 +14,9 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 575722
+			},
 		},
 	],
 };

--- a/data-asia/PMCG/PMCG4/064.ts
+++ b/data-asia/PMCG/PMCG4/064.ts
@@ -8,6 +8,7 @@ const card: Card = {
 		ja: "なんでもなおし配合エネルギー",
 	},
 
+	illustrator: "Keiji Kinebuchi",
 	rarity: "Common",
 	category: "Energy",
 

--- a/data-asia/PMCG/PMCG4/064.ts
+++ b/data-asia/PMCG/PMCG4/064.ts
@@ -4,7 +4,6 @@ import Set from "../PMCG4"
 const card: Card = {
 	set: Set,
 	name: {
-		// Full Heal Energy
 		ja: "なんでもなおし配合エネルギー",
 	},
 

--- a/data-asia/PMCG/PMCG4/065.ts
+++ b/data-asia/PMCG/PMCG4/065.ts
@@ -4,6 +4,7 @@ import Set from "../PMCG4"
 const card: Card = {
 	set: Set,
 	name: {
+		// Rainbow Energy
 		ja: "レインボーエネルギー",
 	},
 

--- a/data-asia/PMCG/PMCG4/065.ts
+++ b/data-asia/PMCG/PMCG4/065.ts
@@ -4,7 +4,6 @@ import Set from "../PMCG4"
 const card: Card = {
 	set: Set,
 	name: {
-		// Rainbow Energy
 		ja: "レインボーエネルギー",
 	},
 

--- a/data-asia/PMCG/PMCG4/065.ts
+++ b/data-asia/PMCG/PMCG4/065.ts
@@ -14,6 +14,9 @@ const card: Card = {
 	variants: [
 		{
 			type: "holo",
+			thirdParty: {
+				tcgplayer: 575755
+			},
 		},
 	],
 };

--- a/data-asia/PMCG/PMCG4/065.ts
+++ b/data-asia/PMCG/PMCG4/065.ts
@@ -8,6 +8,7 @@ const card: Card = {
 		ja: "レインボーエネルギー",
 	},
 
+	illustrator: "Kent Kanetsuna",
 	rarity: "Holo Rare",
 	category: "Energy",
 


### PR DESCRIPTION
closes #1719

## Changes

- corrected japanese names (as displayed on cards from bulbapedia https://bulbapedia.bulbagarden.net/wiki/Team_Rocket_(TCG))
- added tcgplayerid
- added illustrators

## Details

- fixed names and added translations
- added thirdparty tcgplayerid into variants

