### PR TITLE
(data) Ja PMCG5 (Leaders Stadium) Corrected Names/TcgplayerId Pricing

### DIFF
--- a/data-asia/PMCG/PMCG5.ts
+++ b/data-asia/PMCG/PMCG5.ts
@@ -4,7 +4,6 @@ import serie from '../PMCG'
 const set: Set = {
 	id: 'PMCG5',
 	name: {
-		// leaders stadium
 		ja: 'リーダーズスタジアム'
 	},
 

--- a/data-asia/PMCG/PMCG5.ts
+++ b/data-asia/PMCG/PMCG5.ts
@@ -4,6 +4,7 @@ import serie from '../PMCG'
 const set: Set = {
 	id: 'PMCG5',
 	name: {
+		// leaders stadium
 		ja: 'リーダーズスタジアム'
 	},
 

--- a/data-asia/PMCG/PMCG5/001.ts
+++ b/data-asia/PMCG/PMCG5/001.ts
@@ -4,7 +4,8 @@ import Set from "../PMCG5"
 const card: Card = {
 	set: Set,
 	name: {
-		ja: "ブロックのズバット",
+		// Brock's Zubat
+		ja: "タケシのズバット",
 	},
 
 	rarity: "Common",
@@ -38,6 +39,9 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 576770
+			},
 		},
 	],
 };

--- a/data-asia/PMCG/PMCG5/001.ts
+++ b/data-asia/PMCG/PMCG5/001.ts
@@ -4,7 +4,6 @@ import Set from "../PMCG5"
 const card: Card = {
 	set: Set,
 	name: {
-		// Brock's Zubat
 		ja: "タケシのズバット",
 	},
 	illustrator: "Atsuko Nishida",

--- a/data-asia/PMCG/PMCG5/001.ts
+++ b/data-asia/PMCG/PMCG5/001.ts
@@ -7,6 +7,7 @@ const card: Card = {
 		// Brock's Zubat
 		ja: "タケシのズバット",
 	},
+	illustrator: "Atsuko Nishida",
 
 	rarity: "Common",
 	category: "Pokemon",

--- a/data-asia/PMCG/PMCG5/002.ts
+++ b/data-asia/PMCG/PMCG5/002.ts
@@ -4,7 +4,8 @@ import Set from "../PMCG5"
 const card: Card = {
 	set: Set,
 	name: {
-		ja: "エリカの奇妙な（lv.15）",
+		// Erika's Oddish
+		ja: "エリカのナゾノクサ",
 	},
 
 	rarity: "Common",
@@ -42,6 +43,9 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 576791
+			},
 		},
 	],
 };

--- a/data-asia/PMCG/PMCG5/002.ts
+++ b/data-asia/PMCG/PMCG5/002.ts
@@ -7,6 +7,7 @@ const card: Card = {
 		// Erika's Oddish
 		ja: "エリカのナゾノクサ",
 	},
+	illustrator: "Ken Sugimori",
 
 	rarity: "Common",
 	category: "Pokemon",

--- a/data-asia/PMCG/PMCG5/002.ts
+++ b/data-asia/PMCG/PMCG5/002.ts
@@ -4,7 +4,6 @@ import Set from "../PMCG5"
 const card: Card = {
 	set: Set,
 	name: {
-		// Erika's Oddish
 		ja: "エリカのナゾノクサ",
 	},
 	illustrator: "Ken Sugimori",

--- a/data-asia/PMCG/PMCG5/003.ts
+++ b/data-asia/PMCG/PMCG5/003.ts
@@ -7,6 +7,7 @@ const card: Card = {
 		// Erika's Oddish
 		ja: "エリカのナゾノクサ",
 	},
+	illustrator: "Ken Sugimori",
 
 	rarity: "Common",
 	category: "Pokemon",

--- a/data-asia/PMCG/PMCG5/003.ts
+++ b/data-asia/PMCG/PMCG5/003.ts
@@ -4,7 +4,6 @@ import Set from "../PMCG5"
 const card: Card = {
 	set: Set,
 	name: {
-		// Erika's Oddish
 		ja: "エリカのナゾノクサ",
 	},
 	illustrator: "Ken Sugimori",

--- a/data-asia/PMCG/PMCG5/003.ts
+++ b/data-asia/PMCG/PMCG5/003.ts
@@ -4,7 +4,8 @@ import Set from "../PMCG5"
 const card: Card = {
 	set: Set,
 	name: {
-		ja: "エリカの奇妙な（LV.10）",
+		// Erika's Oddish
+		ja: "エリカのナゾノクサ",
 	},
 
 	rarity: "Common",
@@ -32,6 +33,9 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 576790
+			},
 		},
 	],
 };

--- a/data-asia/PMCG/PMCG5/004.ts
+++ b/data-asia/PMCG/PMCG5/004.ts
@@ -4,7 +4,6 @@ import Set from "../PMCG5"
 const card: Card = {
 	set: Set,
 	name: {
-		// Erika's Paras
 		ja: "エリカのパラス",
 	},
 	illustrator: "Ken Sugimori",

--- a/data-asia/PMCG/PMCG5/004.ts
+++ b/data-asia/PMCG/PMCG5/004.ts
@@ -7,6 +7,7 @@ const card: Card = {
 		// Erika's Paras
 		ja: "エリカのパラス",
 	},
+	illustrator: "Ken Sugimori",
 
 	rarity: "Common",
 	category: "Pokemon",

--- a/data-asia/PMCG/PMCG5/004.ts
+++ b/data-asia/PMCG/PMCG5/004.ts
@@ -4,7 +4,8 @@ import Set from "../PMCG5"
 const card: Card = {
 	set: Set,
 	name: {
-		ja: "エリカのパラ",
+		// Erika's Paras
+		ja: "エリカのパラス",
 	},
 
 	rarity: "Common",
@@ -38,6 +39,9 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 576792
+			},
 		},
 	],
 };

--- a/data-asia/PMCG/PMCG5/005.ts
+++ b/data-asia/PMCG/PMCG5/005.ts
@@ -4,7 +4,8 @@ import Set from "../PMCG5"
 const card: Card = {
 	set: Set,
 	name: {
-		ja: "エリカのベルスプラウト（lv.15）",
+		// Erika's Bellsprout
+		ja: "エリカのマダツボミ",
 	},
 
 	rarity: "Common",
@@ -32,6 +33,9 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 576777
+			},
 		},
 	],
 };

--- a/data-asia/PMCG/PMCG5/005.ts
+++ b/data-asia/PMCG/PMCG5/005.ts
@@ -4,7 +4,6 @@ import Set from "../PMCG5"
 const card: Card = {
 	set: Set,
 	name: {
-		// Erika's Bellsprout
 		ja: "エリカのマダツボミ",
 	},
 	illustrator: "Ken Sugimori",

--- a/data-asia/PMCG/PMCG5/005.ts
+++ b/data-asia/PMCG/PMCG5/005.ts
@@ -7,6 +7,7 @@ const card: Card = {
 		// Erika's Bellsprout
 		ja: "エリカのマダツボミ",
 	},
+	illustrator: "Ken Sugimori",
 
 	rarity: "Common",
 	category: "Pokemon",

--- a/data-asia/PMCG/PMCG5/006.ts
+++ b/data-asia/PMCG/PMCG5/006.ts
@@ -4,7 +4,8 @@ import Set from "../PMCG5"
 const card: Card = {
 	set: Set,
 	name: {
-		ja: "エリカのタンゲラ",
+		// Erika's Tangela
+		ja: "エリカのモンジャラ",
 	},
 
 	rarity: "Common",
@@ -38,6 +39,9 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 576794
+			},
 		},
 	],
 };

--- a/data-asia/PMCG/PMCG5/006.ts
+++ b/data-asia/PMCG/PMCG5/006.ts
@@ -4,7 +4,6 @@ import Set from "../PMCG5"
 const card: Card = {
 	set: Set,
 	name: {
-		// Erika's Tangela
 		ja: "エリカのモンジャラ",
 	},
 	illustrator: "Ken Sugimori",

--- a/data-asia/PMCG/PMCG5/006.ts
+++ b/data-asia/PMCG/PMCG5/006.ts
@@ -7,6 +7,7 @@ const card: Card = {
 		// Erika's Tangela
 		ja: "エリカのモンジャラ",
 	},
+	illustrator: "Ken Sugimori",
 
 	rarity: "Common",
 	category: "Pokemon",

--- a/data-asia/PMCG/PMCG5/007.ts
+++ b/data-asia/PMCG/PMCG5/007.ts
@@ -4,7 +4,8 @@ import Set from "../PMCG5"
 const card: Card = {
 	set: Set,
 	name: {
-		ja: "エリカのブルバサウルス",
+		// Erika's Bulbasaur
+		ja: "エリカのフシギダネ",
 	},
 
 	rarity: "Uncommon",
@@ -41,6 +42,9 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 576778
+			},
 		},
 	],
 };

--- a/data-asia/PMCG/PMCG5/007.ts
+++ b/data-asia/PMCG/PMCG5/007.ts
@@ -7,6 +7,7 @@ const card: Card = {
 		// Erika's Bulbasaur
 		ja: "エリカのフシギダネ",
 	},
+	illustrator: "Ken Sugimori",
 
 	rarity: "Uncommon",
 	category: "Pokemon",

--- a/data-asia/PMCG/PMCG5/007.ts
+++ b/data-asia/PMCG/PMCG5/007.ts
@@ -4,7 +4,6 @@ import Set from "../PMCG5"
 const card: Card = {
 	set: Set,
 	name: {
-		// Erika's Bulbasaur
 		ja: "エリカのフシギダネ",
 	},
 	illustrator: "Ken Sugimori",

--- a/data-asia/PMCG/PMCG5/008.ts
+++ b/data-asia/PMCG/PMCG5/008.ts
@@ -4,7 +4,8 @@ import Set from "../PMCG5"
 const card: Card = {
 	set: Set,
 	name: {
-		ja: "ブロックのゴルバット",
+		// Brock's Golbat
+		ja: "タケシのゴルバット",
 	},
 
 	rarity: "Uncommon",
@@ -38,6 +39,9 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 576754
+			},
 		},
 	],
 };

--- a/data-asia/PMCG/PMCG5/008.ts
+++ b/data-asia/PMCG/PMCG5/008.ts
@@ -7,6 +7,7 @@ const card: Card = {
 		// Brock's Golbat
 		ja: "タケシのゴルバット",
 	},
+	illustrator: "Ken Sugimori",
 
 	rarity: "Uncommon",
 	category: "Pokemon",

--- a/data-asia/PMCG/PMCG5/008.ts
+++ b/data-asia/PMCG/PMCG5/008.ts
@@ -4,7 +4,6 @@ import Set from "../PMCG5"
 const card: Card = {
 	set: Set,
 	name: {
-		// Brock's Golbat
 		ja: "タケシのゴルバット",
 	},
 	illustrator: "Ken Sugimori",

--- a/data-asia/PMCG/PMCG5/009.ts
+++ b/data-asia/PMCG/PMCG5/009.ts
@@ -4,7 +4,8 @@ import Set from "../PMCG5"
 const card: Card = {
 	set: Set,
 	name: {
-		ja: "エリカの暗闇",
+		// Erika's Gloom
+		ja: "エリカのクサイハナ",
 	},
 
 	rarity: "Uncommon",
@@ -41,6 +42,9 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 576786
+			},
 		},
 	],
 };

--- a/data-asia/PMCG/PMCG5/009.ts
+++ b/data-asia/PMCG/PMCG5/009.ts
@@ -7,6 +7,7 @@ const card: Card = {
 		// Erika's Gloom
 		ja: "エリカのクサイハナ",
 	},
+	illustrator: "Ken Sugimori",
 
 	rarity: "Uncommon",
 	category: "Pokemon",

--- a/data-asia/PMCG/PMCG5/009.ts
+++ b/data-asia/PMCG/PMCG5/009.ts
@@ -4,7 +4,6 @@ import Set from "../PMCG5"
 const card: Card = {
 	set: Set,
 	name: {
-		// Erika's Gloom
 		ja: "エリカのクサイハナ",
 	},
 	illustrator: "Ken Sugimori",

--- a/data-asia/PMCG/PMCG5/010.ts
+++ b/data-asia/PMCG/PMCG5/010.ts
@@ -7,6 +7,7 @@ const card: Card = {
 		// Erika's Bellsprout
 		ja: "エリカのマダツボミ",
 	},
+	illustrator: "Ken Sugimori",
 
 	rarity: "Uncommon",
 	category: "Pokemon",

--- a/data-asia/PMCG/PMCG5/010.ts
+++ b/data-asia/PMCG/PMCG5/010.ts
@@ -4,7 +4,6 @@ import Set from "../PMCG5"
 const card: Card = {
 	set: Set,
 	name: {
-		// Erika's Bellsprout
 		ja: "エリカのマダツボミ",
 	},
 	illustrator: "Ken Sugimori",

--- a/data-asia/PMCG/PMCG5/010.ts
+++ b/data-asia/PMCG/PMCG5/010.ts
@@ -4,7 +4,8 @@ import Set from "../PMCG5"
 const card: Card = {
 	set: Set,
 	name: {
-		ja: "エリカのベルスプラウト（lv.13）",
+		// Erika's Bellsprout
+		ja: "エリカのマダツボミ",
 	},
 
 	rarity: "Uncommon",
@@ -42,6 +43,9 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 576778
+			},
 		},
 	],
 };

--- a/data-asia/PMCG/PMCG5/011.ts
+++ b/data-asia/PMCG/PMCG5/011.ts
@@ -4,7 +4,8 @@ import Set from "../PMCG5"
 const card: Card = {
 	set: Set,
 	name: {
-		ja: "エリカのweepinbell",
+		// Erika's Weepinbell
+		ja: "エリカのウツドン",
 	},
 
 	rarity: "Uncommon",
@@ -39,6 +40,9 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 576797
+			},
 		},
 	],
 };

--- a/data-asia/PMCG/PMCG5/011.ts
+++ b/data-asia/PMCG/PMCG5/011.ts
@@ -7,6 +7,7 @@ const card: Card = {
 		// Erika's Weepinbell
 		ja: "エリカのウツドン",
 	},
+	illustrator: "Atsuko Nishida",
 
 	rarity: "Uncommon",
 	category: "Pokemon",

--- a/data-asia/PMCG/PMCG5/011.ts
+++ b/data-asia/PMCG/PMCG5/011.ts
@@ -4,7 +4,6 @@ import Set from "../PMCG5"
 const card: Card = {
 	set: Set,
 	name: {
-		// Erika's Weepinbell
 		ja: "エリカのウツドン",
 	},
 	illustrator: "Atsuko Nishida",

--- a/data-asia/PMCG/PMCG5/012.ts
+++ b/data-asia/PMCG/PMCG5/012.ts
@@ -4,7 +4,6 @@ import Set from "../PMCG5"
 const card: Card = {
 	set: Set,
 	name: {
-		// Erika's Exeggcute
 		ja: "エリカのタマタマ",
 	},
 	illustrator: "Atsuko Nishida",

--- a/data-asia/PMCG/PMCG5/012.ts
+++ b/data-asia/PMCG/PMCG5/012.ts
@@ -7,6 +7,7 @@ const card: Card = {
 		// Erika's Exeggcute
 		ja: "エリカのタマタマ",
 	},
+	illustrator: "Atsuko Nishida",
 
 	rarity: "Uncommon",
 	category: "Pokemon",

--- a/data-asia/PMCG/PMCG5/012.ts
+++ b/data-asia/PMCG/PMCG5/012.ts
@@ -4,7 +4,8 @@ import Set from "../PMCG5"
 const card: Card = {
 	set: Set,
 	name: {
-		ja: "エリカのexeggcute",
+		// Erika's Exeggcute
+		ja: "エリカのタマタマ",
 	},
 
 	rarity: "Uncommon",
@@ -41,6 +42,9 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 576784
+			},
 		},
 	],
 };

--- a/data-asia/PMCG/PMCG5/013.ts
+++ b/data-asia/PMCG/PMCG5/013.ts
@@ -4,7 +4,8 @@ import Set from "../PMCG5"
 const card: Card = {
 	set: Set,
 	name: {
-		ja: "エリカのexeggutor",
+		// Erika's Exeggutor
+		ja: "エリカのナッシー",
 	},
 
 	rarity: "Uncommon",
@@ -40,6 +41,9 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 576785
+			},
 		},
 	],
 };

--- a/data-asia/PMCG/PMCG5/013.ts
+++ b/data-asia/PMCG/PMCG5/013.ts
@@ -7,6 +7,7 @@ const card: Card = {
 		// Erika's Exeggutor
 		ja: "エリカのナッシー",
 	},
+	illustrator: "Ken Sugimori",
 
 	rarity: "Uncommon",
 	category: "Pokemon",

--- a/data-asia/PMCG/PMCG5/013.ts
+++ b/data-asia/PMCG/PMCG5/013.ts
@@ -4,7 +4,6 @@ import Set from "../PMCG5"
 const card: Card = {
 	set: Set,
 	name: {
-		// Erika's Exeggutor
 		ja: "エリカのナッシー",
 	},
 	illustrator: "Ken Sugimori",

--- a/data-asia/PMCG/PMCG5/014.ts
+++ b/data-asia/PMCG/PMCG5/014.ts
@@ -4,7 +4,6 @@ import Set from "../PMCG5"
 const card: Card = {
 	set: Set,
 	name: {
-		// Erika's Vileplume
 		ja: "エリカのラフレシア",
 	},
 	illustrator: "Ken Sugimori",

--- a/data-asia/PMCG/PMCG5/014.ts
+++ b/data-asia/PMCG/PMCG5/014.ts
@@ -4,7 +4,8 @@ import Set from "../PMCG5"
 const card: Card = {
 	set: Set,
 	name: {
-		ja: "エリカのvileplume",
+		// Erika's Vileplume
+		ja: "エリカのラフレシア",
 	},
 
 	rarity: "Holo Rare",

--- a/data-asia/PMCG/PMCG5/014.ts
+++ b/data-asia/PMCG/PMCG5/014.ts
@@ -7,6 +7,7 @@ const card: Card = {
 		// Erika's Vileplume
 		ja: "エリカのラフレシア",
 	},
+	illustrator: "Ken Sugimori",
 
 	rarity: "Holo Rare",
 	category: "Pokemon",
@@ -44,6 +45,9 @@ const card: Card = {
 	variants: [
 		{
 			type: "holo",
+			thirdParty: {
+				tcgplayer: 576796
+			},
 		},
 	],
 };

--- a/data-asia/PMCG/PMCG5/015.ts
+++ b/data-asia/PMCG/PMCG5/015.ts
@@ -7,6 +7,7 @@ const card: Card = {
 		// Erika's Victreebel
 		ja: "エリカのウツボット",
 	},
+	illustrator: "Ken Sugimori",
 
 	rarity: "Rare",
 	category: "Pokemon",

--- a/data-asia/PMCG/PMCG5/015.ts
+++ b/data-asia/PMCG/PMCG5/015.ts
@@ -4,7 +4,8 @@ import Set from "../PMCG5"
 const card: Card = {
 	set: Set,
 	name: {
-		ja: "エリカのヴィックツリーベル",
+		// Erika's Victreebel
+		ja: "エリカのウツボット",
 	},
 
 	rarity: "Rare",
@@ -40,6 +41,9 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 576795
+			},
 		},
 	],
 };

--- a/data-asia/PMCG/PMCG5/015.ts
+++ b/data-asia/PMCG/PMCG5/015.ts
@@ -4,7 +4,6 @@ import Set from "../PMCG5"
 const card: Card = {
 	set: Set,
 	name: {
-		// Erika's Victreebel
 		ja: "エリカのウツボット",
 	},
 	illustrator: "Ken Sugimori",

--- a/data-asia/PMCG/PMCG5/016.ts
+++ b/data-asia/PMCG/PMCG5/016.ts
@@ -4,7 +4,6 @@ import Set from "../PMCG5"
 const card: Card = {
 	set: Set,
 	name: {
-		// Rocket's Scyther
 		ja: "R団のストライク",
 	},
 	illustrator: "Ken Sugimori",

--- a/data-asia/PMCG/PMCG5/016.ts
+++ b/data-asia/PMCG/PMCG5/016.ts
@@ -4,7 +4,8 @@ import Set from "../PMCG5"
 const card: Card = {
 	set: Set,
 	name: {
-		ja: "ロケットのスキタイヤー",
+		// Rocket's Scyther
+		ja: "R団のストライク",
 	},
 
 	rarity: "Holo Rare",

--- a/data-asia/PMCG/PMCG5/016.ts
+++ b/data-asia/PMCG/PMCG5/016.ts
@@ -7,7 +7,7 @@ const card: Card = {
 		// Rocket's Scyther
 		ja: "R団のストライク",
 	},
-
+	illustrator: "Ken Sugimori",
 	rarity: "Holo Rare",
 	category: "Pokemon",
 	dexId: [123],

--- a/data-asia/PMCG/PMCG5/017.ts
+++ b/data-asia/PMCG/PMCG5/017.ts
@@ -4,7 +4,6 @@ import Set from "../PMCG5"
 const card: Card = {
 	set: Set,
 	name: {
-		// Brock's Vulpix
 		ja: "タケシのロコン",
 	},
 	illustrator: "Ken Sugimori",

--- a/data-asia/PMCG/PMCG5/017.ts
+++ b/data-asia/PMCG/PMCG5/017.ts
@@ -7,8 +7,9 @@ const card: Card = {
 		// Brock's Vulpix
 		ja: "タケシのロコン",
 	},
+	illustrator: "Ken Sugimori",
 
-	rarity: "Uncommon",
+	rarity: "Common",
 	category: "Pokemon",
 	dexId: [37],
 	hp: 50,

--- a/data-asia/PMCG/PMCG5/017.ts
+++ b/data-asia/PMCG/PMCG5/017.ts
@@ -4,7 +4,8 @@ import Set from "../PMCG5"
 const card: Card = {
 	set: Set,
 	name: {
-		ja: "Brock's Vulpix（LV.16）",
+		// Brock's Vulpix
+		ja: "タケシのロコン",
 	},
 
 	rarity: "Uncommon",
@@ -41,6 +42,9 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 576768
+			},
 		},
 	],
 };

--- a/data-asia/PMCG/PMCG5/018.ts
+++ b/data-asia/PMCG/PMCG5/018.ts
@@ -4,7 +4,8 @@ import Set from "../PMCG5"
 const card: Card = {
 	set: Set,
 	name: {
-		ja: "Brock's Vulpix（LV.10）",
+		// Brock's Vulpix
+		ja: "タケシのロコン",
 	},
 
 	rarity: "Common",
@@ -38,6 +39,9 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 576769
+			},
 		},
 	],
 };

--- a/data-asia/PMCG/PMCG5/018.ts
+++ b/data-asia/PMCG/PMCG5/018.ts
@@ -4,7 +4,6 @@ import Set from "../PMCG5"
 const card: Card = {
 	set: Set,
 	name: {
-		// Brock's Vulpix
 		ja: "タケシのロコン",
 	},
 	illustrator: "Ken Sugimori",

--- a/data-asia/PMCG/PMCG5/018.ts
+++ b/data-asia/PMCG/PMCG5/018.ts
@@ -7,8 +7,9 @@ const card: Card = {
 		// Brock's Vulpix
 		ja: "タケシのロコン",
 	},
+	illustrator: "Ken Sugimori",
 
-	rarity: "Common",
+	rarity: "Uncommon",
 	category: "Pokemon",
 	dexId: [37],
 	hp: 40,

--- a/data-asia/PMCG/PMCG5/019.ts
+++ b/data-asia/PMCG/PMCG5/019.ts
@@ -7,6 +7,7 @@ const card: Card = {
 		// Brock's Ninetales
 		ja: "タケシのキュウコン",
 	},
+	illustrator: "Ken Sugimori",
 
 	rarity: "Holo Rare",
 	category: "Pokemon",
@@ -41,6 +42,9 @@ const card: Card = {
 	variants: [
 		{
 			type: "holo",
+			thirdParty: {
+				tcgplayer: 576759
+			},
 		},
 	],
 };

--- a/data-asia/PMCG/PMCG5/019.ts
+++ b/data-asia/PMCG/PMCG5/019.ts
@@ -4,7 +4,8 @@ import Set from "../PMCG5"
 const card: Card = {
 	set: Set,
 	name: {
-		ja: "ブロックのニネタール",
+		// Brock's Ninetales
+		ja: "タケシのキュウコン",
 	},
 
 	rarity: "Holo Rare",

--- a/data-asia/PMCG/PMCG5/019.ts
+++ b/data-asia/PMCG/PMCG5/019.ts
@@ -4,7 +4,6 @@ import Set from "../PMCG5"
 const card: Card = {
 	set: Set,
 	name: {
-		// Brock's Ninetales
 		ja: "タケシのキュウコン",
 	},
 	illustrator: "Ken Sugimori",

--- a/data-asia/PMCG/PMCG5/020.ts
+++ b/data-asia/PMCG/PMCG5/020.ts
@@ -7,7 +7,7 @@ const card: Card = {
 		// Rocket's Moltres
 		ja: "R団のファイヤー",
 	},
-
+	illustrator: "Ken Sugimori",
 	rarity: "Holo Rare",
 	category: "Pokemon",
 	dexId: [146],

--- a/data-asia/PMCG/PMCG5/020.ts
+++ b/data-asia/PMCG/PMCG5/020.ts
@@ -4,7 +4,8 @@ import Set from "../PMCG5"
 const card: Card = {
 	set: Set,
 	name: {
-		ja: "ロケットのモルト",
+		// Rocket's Moltres
+		ja: "R団のファイヤー",
 	},
 
 	rarity: "Holo Rare",

--- a/data-asia/PMCG/PMCG5/020.ts
+++ b/data-asia/PMCG/PMCG5/020.ts
@@ -4,7 +4,6 @@ import Set from "../PMCG5"
 const card: Card = {
 	set: Set,
 	name: {
-		// Rocket's Moltres
 		ja: "R団のファイヤー",
 	},
 	illustrator: "Ken Sugimori",

--- a/data-asia/PMCG/PMCG5/021.ts
+++ b/data-asia/PMCG/PMCG5/021.ts
@@ -7,6 +7,7 @@ const card: Card = {
 		// Misty's Psyduck
 		ja: "カスミのコダック",
 	},
+	illustrator: "Ken Sugimori",
 
 	rarity: "Common",
 	category: "Pokemon",

--- a/data-asia/PMCG/PMCG5/021.ts
+++ b/data-asia/PMCG/PMCG5/021.ts
@@ -4,7 +4,6 @@ import Set from "../PMCG5"
 const card: Card = {
 	set: Set,
 	name: {
-		// Misty's Psyduck
 		ja: "カスミのコダック",
 	},
 	illustrator: "Ken Sugimori",

--- a/data-asia/PMCG/PMCG5/021.ts
+++ b/data-asia/PMCG/PMCG5/021.ts
@@ -4,7 +4,8 @@ import Set from "../PMCG5"
 const card: Card = {
 	set: Set,
 	name: {
-		ja: "MistyのPsyduck",
+		// Misty's Psyduck
+		ja: "カスミのコダック",
 	},
 
 	rarity: "Common",
@@ -31,6 +32,9 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 576825
+			},
 		},
 	],
 };

--- a/data-asia/PMCG/PMCG5/022.ts
+++ b/data-asia/PMCG/PMCG5/022.ts
@@ -4,7 +4,6 @@ import Set from "../PMCG5"
 const card: Card = {
 	set: Set,
 	name: {
-		// Misty's Poliwag
 		ja: "カスミのニョロモ",
 	},
 	illustrator: "Ken Sugimori",

--- a/data-asia/PMCG/PMCG5/022.ts
+++ b/data-asia/PMCG/PMCG5/022.ts
@@ -4,7 +4,8 @@ import Set from "../PMCG5"
 const card: Card = {
 	set: Set,
 	name: {
-		ja: "ミスティのポリワグ",
+		// Misty's Poliwag
+		ja: "カスミのニョロモ",
 	},
 
 	rarity: "Common",
@@ -41,6 +42,9 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 576823
+			},
 		},
 	],
 };

--- a/data-asia/PMCG/PMCG5/022.ts
+++ b/data-asia/PMCG/PMCG5/022.ts
@@ -7,6 +7,7 @@ const card: Card = {
 		// Misty's Poliwag
 		ja: "カスミのニョロモ",
 	},
+	illustrator: "Ken Sugimori",
 
 	rarity: "Common",
 	category: "Pokemon",

--- a/data-asia/PMCG/PMCG5/023.ts
+++ b/data-asia/PMCG/PMCG5/023.ts
@@ -4,7 +4,8 @@ import Set from "../PMCG5"
 const card: Card = {
 	set: Set,
 	name: {
-		ja: "ミスティのシール",
+		// Misty's Seel
+		ja: "カスミのパウワウ",
 	},
 
 	rarity: "Common",
@@ -42,6 +43,9 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 576827
+			},
 		},
 	],
 };

--- a/data-asia/PMCG/PMCG5/023.ts
+++ b/data-asia/PMCG/PMCG5/023.ts
@@ -7,6 +7,7 @@ const card: Card = {
 		// Misty's Seel
 		ja: "カスミのパウワウ",
 	},
+	illustrator: "Ken Sugimori",
 
 	rarity: "Common",
 	category: "Pokemon",

--- a/data-asia/PMCG/PMCG5/023.ts
+++ b/data-asia/PMCG/PMCG5/023.ts
@@ -4,7 +4,6 @@ import Set from "../PMCG5"
 const card: Card = {
 	set: Set,
 	name: {
-		// Misty's Seel
 		ja: "カスミのパウワウ",
 	},
 	illustrator: "Ken Sugimori",

--- a/data-asia/PMCG/PMCG5/024.ts
+++ b/data-asia/PMCG/PMCG5/024.ts
@@ -4,7 +4,6 @@ import Set from "../PMCG5"
 const card: Card = {
 	set: Set,
 	name: {
-		// Misty's Horsea
 		ja: "カスミのタッツー",
 	},
 	illustrator: "Ken Sugimori",

--- a/data-asia/PMCG/PMCG5/024.ts
+++ b/data-asia/PMCG/PMCG5/024.ts
@@ -4,7 +4,8 @@ import Set from "../PMCG5"
 const card: Card = {
 	set: Set,
 	name: {
-		ja: "Misty's Horsea（LV.16）",
+		// Misty's Horsea
+		ja: "カスミのタッツー",
 	},
 
 	rarity: "Common",
@@ -31,6 +32,9 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 576821
+			},
 		},
 	],
 };

--- a/data-asia/PMCG/PMCG5/024.ts
+++ b/data-asia/PMCG/PMCG5/024.ts
@@ -7,6 +7,7 @@ const card: Card = {
 		// Misty's Horsea
 		ja: "カスミのタッツー",
 	},
+	illustrator: "Ken Sugimori",
 
 	rarity: "Common",
 	category: "Pokemon",

--- a/data-asia/PMCG/PMCG5/025.ts
+++ b/data-asia/PMCG/PMCG5/025.ts
@@ -4,7 +4,8 @@ import Set from "../PMCG5"
 const card: Card = {
 	set: Set,
 	name: {
-		ja: "Misty's Horsea（LV.10）",
+		// Misty's Horsea
+		ja: "カスミのタッツー",
 	},
 
 	rarity: "Common",
@@ -38,6 +39,9 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 576820
+			},
 		},
 	],
 };

--- a/data-asia/PMCG/PMCG5/025.ts
+++ b/data-asia/PMCG/PMCG5/025.ts
@@ -4,7 +4,6 @@ import Set from "../PMCG5"
 const card: Card = {
 	set: Set,
 	name: {
-		// Misty's Horsea
 		ja: "カスミのタッツー",
 	},
 	illustrator: "Ken Sugimori",

--- a/data-asia/PMCG/PMCG5/025.ts
+++ b/data-asia/PMCG/PMCG5/025.ts
@@ -7,6 +7,7 @@ const card: Card = {
 		// Misty's Horsea
 		ja: "カスミのタッツー",
 	},
+	illustrator: "Ken Sugimori",
 
 	rarity: "Common",
 	category: "Pokemon",

--- a/data-asia/PMCG/PMCG5/026.ts
+++ b/data-asia/PMCG/PMCG5/026.ts
@@ -4,7 +4,6 @@ import Set from "../PMCG5"
 const card: Card = {
 	set: Set,
 	name: {
-		// Misty's Goldeen
 		ja: "カスミのトサキント",
 	},
 	illustrator: "Atsuko Nishida",

--- a/data-asia/PMCG/PMCG5/026.ts
+++ b/data-asia/PMCG/PMCG5/026.ts
@@ -4,7 +4,8 @@ import Set from "../PMCG5"
 const card: Card = {
 	set: Set,
 	name: {
-		ja: "ミスティのゴールデン",
+		// Misty's Goldeen
+		ja: "カスミのトサキント",
 	},
 
 	rarity: "Common",
@@ -40,6 +41,9 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 576817
+			},
 		},
 	],
 };

--- a/data-asia/PMCG/PMCG5/026.ts
+++ b/data-asia/PMCG/PMCG5/026.ts
@@ -7,6 +7,7 @@ const card: Card = {
 		// Misty's Goldeen
 		ja: "カスミのトサキント",
 	},
+	illustrator: "Atsuko Nishida",
 
 	rarity: "Common",
 	category: "Pokemon",

--- a/data-asia/PMCG/PMCG5/027.ts
+++ b/data-asia/PMCG/PMCG5/027.ts
@@ -7,6 +7,7 @@ const card: Card = {
 		// Misty's Staryu
 		ja: "カスミのヒトデマン",
 	},
+	illustrator: "Ken Sugimori",
 
 	rarity: "Common",
 	category: "Pokemon",

--- a/data-asia/PMCG/PMCG5/027.ts
+++ b/data-asia/PMCG/PMCG5/027.ts
@@ -4,7 +4,8 @@ import Set from "../PMCG5"
 const card: Card = {
 	set: Set,
 	name: {
-		ja: "ミスティのstaryu",
+		// Misty's Staryu
+		ja: "カスミのヒトデマン",
 	},
 
 	rarity: "Common",
@@ -32,6 +33,9 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 576828
+			},
 		},
 	],
 };

--- a/data-asia/PMCG/PMCG5/027.ts
+++ b/data-asia/PMCG/PMCG5/027.ts
@@ -4,7 +4,6 @@ import Set from "../PMCG5"
 const card: Card = {
 	set: Set,
 	name: {
-		// Misty's Staryu
 		ja: "カスミのヒトデマン",
 	},
 	illustrator: "Ken Sugimori",

--- a/data-asia/PMCG/PMCG5/028.ts
+++ b/data-asia/PMCG/PMCG5/028.ts
@@ -4,7 +4,8 @@ import Set from "../PMCG5"
 const card: Card = {
 	set: Set,
 	name: {
-		ja: "ミスティのマジカルプ",
+		// Misty's Magikarp
+		ja: "カスミのコイキング",
 	},
 
 	rarity: "Common",
@@ -38,6 +39,9 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 576822
+			},
 		},
 	],
 };

--- a/data-asia/PMCG/PMCG5/028.ts
+++ b/data-asia/PMCG/PMCG5/028.ts
@@ -4,7 +4,6 @@ import Set from "../PMCG5"
 const card: Card = {
 	set: Set,
 	name: {
-		// Misty's Magikarp
 		ja: "カスミのコイキング",
 	},
 	illustrator: "Ken Sugimori",

--- a/data-asia/PMCG/PMCG5/028.ts
+++ b/data-asia/PMCG/PMCG5/028.ts
@@ -7,6 +7,7 @@ const card: Card = {
 		// Misty's Magikarp
 		ja: "カスミのコイキング",
 	},
+	illustrator: "Ken Sugimori",
 
 	rarity: "Common",
 	category: "Pokemon",

--- a/data-asia/PMCG/PMCG5/029.ts
+++ b/data-asia/PMCG/PMCG5/029.ts
@@ -4,7 +4,6 @@ import Set from "../PMCG5"
 const card: Card = {
 	set: Set,
 	name: {
-		// Misty's Poliwhirl
 		ja: "カスミのニョロゾ",
 	},
 	illustrator: "Ken Sugimori",

--- a/data-asia/PMCG/PMCG5/029.ts
+++ b/data-asia/PMCG/PMCG5/029.ts
@@ -7,6 +7,7 @@ const card: Card = {
 		// Misty's Poliwhirl
 		ja: "カスミのニョロゾ",
 	},
+	illustrator: "Ken Sugimori",
 
 	rarity: "Uncommon",
 	category: "Pokemon",

--- a/data-asia/PMCG/PMCG5/029.ts
+++ b/data-asia/PMCG/PMCG5/029.ts
@@ -4,7 +4,8 @@ import Set from "../PMCG5"
 const card: Card = {
 	set: Set,
 	name: {
-		ja: "MistyのPoliWhirl",
+		// Misty's Poliwhirl
+		ja: "カスミのニョロゾ",
 	},
 
 	rarity: "Uncommon",
@@ -41,6 +42,9 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 576824
+			},
 		},
 	],
 };

--- a/data-asia/PMCG/PMCG5/030.ts
+++ b/data-asia/PMCG/PMCG5/030.ts
@@ -7,6 +7,7 @@ const card: Card = {
 		// Misty's Tentacool
 		ja: "カスミのメノクラゲ",
 	},
+	illustrator: "Ken Sugimori",
 
 	rarity: "Uncommon",
 	category: "Pokemon",

--- a/data-asia/PMCG/PMCG5/030.ts
+++ b/data-asia/PMCG/PMCG5/030.ts
@@ -4,7 +4,6 @@ import Set from "../PMCG5"
 const card: Card = {
 	set: Set,
 	name: {
-		// Misty's Tentacool
 		ja: "カスミのメノクラゲ",
 	},
 	illustrator: "Ken Sugimori",

--- a/data-asia/PMCG/PMCG5/030.ts
+++ b/data-asia/PMCG/PMCG5/030.ts
@@ -4,7 +4,8 @@ import Set from "../PMCG5"
 const card: Card = {
 	set: Set,
 	name: {
-		ja: "ミスティの触手",
+		// Misty's Tentacool
+		ja: "カスミのメノクラゲ",
 	},
 
 	rarity: "Uncommon",
@@ -32,6 +33,9 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 576830
+			},
 		},
 	],
 };

--- a/data-asia/PMCG/PMCG5/031.ts
+++ b/data-asia/PMCG/PMCG5/031.ts
@@ -4,7 +4,6 @@ import Set from "../PMCG5"
 const card: Card = {
 	set: Set,
 	name: {
-		// Misty's Dewgong
 		ja: "カスミのジュゴン",
 	},
 	illustrator: "Ken Sugimori",

--- a/data-asia/PMCG/PMCG5/031.ts
+++ b/data-asia/PMCG/PMCG5/031.ts
@@ -7,6 +7,7 @@ const card: Card = {
 		// Misty's Dewgong
 		ja: "カスミのジュゴン",
 	},
+	illustrator: "Ken Sugimori",
 
 	rarity: "Uncommon",
 	category: "Pokemon",

--- a/data-asia/PMCG/PMCG5/031.ts
+++ b/data-asia/PMCG/PMCG5/031.ts
@@ -4,7 +4,8 @@ import Set from "../PMCG5"
 const card: Card = {
 	set: Set,
 	name: {
-		ja: "ミスティのデューゴン",
+		// Misty's Dewgong
+		ja: "カスミのジュゴン",
 	},
 
 	rarity: "Uncommon",
@@ -42,6 +43,9 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 576815
+			},
 		},
 	],
 };

--- a/data-asia/PMCG/PMCG5/032.ts
+++ b/data-asia/PMCG/PMCG5/032.ts
@@ -7,6 +7,7 @@ const card: Card = {
 		// Misty's Golduck
 		ja: "カスミのゴルダック",
 	},
+	illustrator: "Ken Sugimori",
 
 	rarity: "Holo Rare",
 	category: "Pokemon",
@@ -42,6 +43,9 @@ const card: Card = {
 	variants: [
 		{
 			type: "holo",
+			thirdParty: {
+				tcgplayer: 576818
+			},
 		},
 	],
 };

--- a/data-asia/PMCG/PMCG5/032.ts
+++ b/data-asia/PMCG/PMCG5/032.ts
@@ -4,7 +4,6 @@ import Set from "../PMCG5"
 const card: Card = {
 	set: Set,
 	name: {
-		// Misty's Golduck
 		ja: "カスミのゴルダック",
 	},
 	illustrator: "Ken Sugimori",

--- a/data-asia/PMCG/PMCG5/032.ts
+++ b/data-asia/PMCG/PMCG5/032.ts
@@ -4,7 +4,8 @@ import Set from "../PMCG5"
 const card: Card = {
 	set: Set,
 	name: {
-		ja: "ミスティのゴルダック",
+		// Misty's Golduck
+		ja: "カスミのゴルダック",
 	},
 
 	rarity: "Holo Rare",

--- a/data-asia/PMCG/PMCG5/033.ts
+++ b/data-asia/PMCG/PMCG5/033.ts
@@ -7,6 +7,7 @@ const card: Card = {
 		// Misty's Tentacruel
 		ja: "カスミのドククラゲ",
 	},
+	illustrator: "Ken Sugimori",
 
 	rarity: "Holo Rare",
 	category: "Pokemon",
@@ -43,6 +44,9 @@ const card: Card = {
 	variants: [
 		{
 			type: "holo",
+			thirdParty: {
+				tcgplayer: 576831
+			},
 		},
 	],
 };

--- a/data-asia/PMCG/PMCG5/033.ts
+++ b/data-asia/PMCG/PMCG5/033.ts
@@ -4,7 +4,6 @@ import Set from "../PMCG5"
 const card: Card = {
 	set: Set,
 	name: {
-		// Misty's Tentacruel
 		ja: "カスミのドククラゲ",
 	},
 	illustrator: "Ken Sugimori",

--- a/data-asia/PMCG/PMCG5/033.ts
+++ b/data-asia/PMCG/PMCG5/033.ts
@@ -4,7 +4,8 @@ import Set from "../PMCG5"
 const card: Card = {
 	set: Set,
 	name: {
-		ja: "ミスティのテンタクルエル",
+		// Misty's Tentacruel
+		ja: "カスミのドククラゲ",
 	},
 
 	rarity: "Holo Rare",

--- a/data-asia/PMCG/PMCG5/034.ts
+++ b/data-asia/PMCG/PMCG5/034.ts
@@ -4,7 +4,8 @@ import Set from "../PMCG5"
 const card: Card = {
 	set: Set,
 	name: {
-		ja: "ミスティのシードラ",
+		// Misty's Seadra
+		ja: "カスミのシードラ",
 	},
 
 	rarity: "Holo Rare",

--- a/data-asia/PMCG/PMCG5/034.ts
+++ b/data-asia/PMCG/PMCG5/034.ts
@@ -7,6 +7,7 @@ const card: Card = {
 		// Misty's Seadra
 		ja: "カスミのシードラ",
 	},
+	illustrator: "Atsuko Nishida",
 
 	rarity: "Holo Rare",
 	category: "Pokemon",
@@ -39,6 +40,9 @@ const card: Card = {
 	variants: [
 		{
 			type: "holo",
+			thirdParty: {
+				tcgplayer: 576826
+			},
 		},
 	],
 };

--- a/data-asia/PMCG/PMCG5/034.ts
+++ b/data-asia/PMCG/PMCG5/034.ts
@@ -4,7 +4,6 @@ import Set from "../PMCG5"
 const card: Card = {
 	set: Set,
 	name: {
-		// Misty's Seadra
 		ja: "カスミのシードラ",
 	},
 	illustrator: "Atsuko Nishida",

--- a/data-asia/PMCG/PMCG5/035.ts
+++ b/data-asia/PMCG/PMCG5/035.ts
@@ -4,7 +4,8 @@ import Set from "../PMCG5"
 const card: Card = {
 	set: Set,
 	name: {
-		ja: "ミスティのギャラドス",
+		// Misty's Gyarados
+		ja: "カスミのギャラドス",
 	},
 
 	rarity: "Holo Rare",

--- a/data-asia/PMCG/PMCG5/035.ts
+++ b/data-asia/PMCG/PMCG5/035.ts
@@ -4,7 +4,6 @@ import Set from "../PMCG5"
 const card: Card = {
 	set: Set,
 	name: {
-		// Misty's Gyarados
 		ja: "カスミのギャラドス",
 	},
 	illustrator: "Ken Sugimori",

--- a/data-asia/PMCG/PMCG5/035.ts
+++ b/data-asia/PMCG/PMCG5/035.ts
@@ -7,6 +7,7 @@ const card: Card = {
 		// Misty's Gyarados
 		ja: "カスミのギャラドス",
 	},
+	illustrator: "Ken Sugimori",
 
 	rarity: "Holo Rare",
 	category: "Pokemon",
@@ -41,6 +42,9 @@ const card: Card = {
 	variants: [
 		{
 			type: "holo",
+			thirdParty: {
+				tcgplayer: 576819
+			},
 		},
 	],
 };

--- a/data-asia/PMCG/PMCG5/036.ts
+++ b/data-asia/PMCG/PMCG5/036.ts
@@ -4,7 +4,8 @@ import Set from "../PMCG5"
 const card: Card = {
 	set: Set,
 	name: {
-		ja: "Surge's Pikachu中t",
+		// Lt. Surge's Pikachu
+		ja: "マチスのピカチュウ",
 	},
 
 	rarity: "Common",
@@ -31,6 +32,9 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 576807
+			},
 		},
 	],
 };

--- a/data-asia/PMCG/PMCG5/036.ts
+++ b/data-asia/PMCG/PMCG5/036.ts
@@ -7,6 +7,7 @@ const card: Card = {
 		// Lt. Surge's Pikachu
 		ja: "マチスのピカチュウ",
 	},
+	illustrator: "Atsuko Nishida",
 
 	rarity: "Common",
 	category: "Pokemon",

--- a/data-asia/PMCG/PMCG5/036.ts
+++ b/data-asia/PMCG/PMCG5/036.ts
@@ -4,7 +4,6 @@ import Set from "../PMCG5"
 const card: Card = {
 	set: Set,
 	name: {
-		// Lt. Surge's Pikachu
 		ja: "マチスのピカチュウ",
 	},
 	illustrator: "Atsuko Nishida",

--- a/data-asia/PMCG/PMCG5/037.ts
+++ b/data-asia/PMCG/PMCG5/037.ts
@@ -7,6 +7,7 @@ const card: Card = {
 		// Lt. Surge's Magnemite
 		ja: "マチスのコイル",
 	},
+	illustrator: "Ken Sugimori",
 
 	rarity: "Common",
 	category: "Pokemon",

--- a/data-asia/PMCG/PMCG5/037.ts
+++ b/data-asia/PMCG/PMCG5/037.ts
@@ -4,7 +4,8 @@ import Set from "../PMCG5"
 const card: Card = {
 	set: Set,
 	name: {
-		ja: "Surgeのマグネミテ（LV.12）",
+		// Lt. Surge's Magnemite
+		ja: "マチスのコイル",
 	},
 
 	rarity: "Common",
@@ -39,6 +40,9 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 576805
+			},
 		},
 	],
 };

--- a/data-asia/PMCG/PMCG5/037.ts
+++ b/data-asia/PMCG/PMCG5/037.ts
@@ -4,7 +4,6 @@ import Set from "../PMCG5"
 const card: Card = {
 	set: Set,
 	name: {
-		// Lt. Surge's Magnemite
 		ja: "マチスのコイル",
 	},
 	illustrator: "Ken Sugimori",

--- a/data-asia/PMCG/PMCG5/038.ts
+++ b/data-asia/PMCG/PMCG5/038.ts
@@ -4,7 +4,8 @@ import Set from "../PMCG5"
 const card: Card = {
 	set: Set,
 	name: {
-		ja: "Surge's Voltorb中t",
+		// Lt. Surge's Voltorb
+		ja: "マチスのビリリダマ",
 	},
 
 	rarity: "Common",
@@ -40,6 +41,9 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 576813
+			},
 		},
 	],
 };

--- a/data-asia/PMCG/PMCG5/038.ts
+++ b/data-asia/PMCG/PMCG5/038.ts
@@ -7,6 +7,7 @@ const card: Card = {
 		// Lt. Surge's Voltorb
 		ja: "マチスのビリリダマ",
 	},
+	illustrator: "Ken Sugimori",
 
 	rarity: "Common",
 	category: "Pokemon",

--- a/data-asia/PMCG/PMCG5/038.ts
+++ b/data-asia/PMCG/PMCG5/038.ts
@@ -4,7 +4,6 @@ import Set from "../PMCG5"
 const card: Card = {
 	set: Set,
 	name: {
-		// Lt. Surge's Voltorb
 		ja: "マチスのビリリダマ",
 	},
 	illustrator: "Ken Sugimori",

--- a/data-asia/PMCG/PMCG5/039.ts
+++ b/data-asia/PMCG/PMCG5/039.ts
@@ -7,6 +7,7 @@ const card: Card = {
 		// Lt. Surge's Magnemite
 		ja: "マチスのコイル",
 	},
+	illustrator: "Atsuko Nishida",
 
 	rarity: "Uncommon",
 	category: "Pokemon",

--- a/data-asia/PMCG/PMCG5/039.ts
+++ b/data-asia/PMCG/PMCG5/039.ts
@@ -4,7 +4,6 @@ import Set from "../PMCG5"
 const card: Card = {
 	set: Set,
 	name: {
-		// Lt. Surge's Magnemite
 		ja: "マチスのコイル",
 	},
 	illustrator: "Atsuko Nishida",

--- a/data-asia/PMCG/PMCG5/039.ts
+++ b/data-asia/PMCG/PMCG5/039.ts
@@ -4,7 +4,8 @@ import Set from "../PMCG5"
 const card: Card = {
 	set: Set,
 	name: {
-		ja: "Surgeのマグネマイト中,、 Lv.10）",
+		// Lt. Surge's Magnemite
+		ja: "マチスのコイル",
 	},
 
 	rarity: "Uncommon",
@@ -41,6 +42,9 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 576804
+			},
 		},
 	],
 };

--- a/data-asia/PMCG/PMCG5/040.ts
+++ b/data-asia/PMCG/PMCG5/040.ts
@@ -4,7 +4,8 @@ import Set from "../PMCG5"
 const card: Card = {
 	set: Set,
 	name: {
-		ja: "Surge's Magneton中t",
+		// Lt. Surge's Magneton
+		ja: "マチスのレアコイル",
 	},
 
 	rarity: "Holo Rare",

--- a/data-asia/PMCG/PMCG5/040.ts
+++ b/data-asia/PMCG/PMCG5/040.ts
@@ -4,7 +4,6 @@ import Set from "../PMCG5"
 const card: Card = {
 	set: Set,
 	name: {
-		// Lt. Surge's Magneton
 		ja: "マチスのレアコイル",
 	},
 	illustrator: "Ken Sugimori",

--- a/data-asia/PMCG/PMCG5/040.ts
+++ b/data-asia/PMCG/PMCG5/040.ts
@@ -7,6 +7,7 @@ const card: Card = {
 		// Lt. Surge's Magneton
 		ja: "マチスのレアコイル",
 	},
+	illustrator: "Ken Sugimori",
 
 	rarity: "Holo Rare",
 	category: "Pokemon",
@@ -44,6 +45,9 @@ const card: Card = {
 	variants: [
 		{
 			type: "holo",
+			thirdParty: {
+				tcgplayer: 576806
+			},
 		},
 	],
 };

--- a/data-asia/PMCG/PMCG5/041.ts
+++ b/data-asia/PMCG/PMCG5/041.ts
@@ -4,7 +4,6 @@ import Set from "../PMCG5"
 const card: Card = {
 	set: Set,
 	name: {
-		// Lt. Surge's Electabuzz
 		ja: "マチスのエレブー",
 	},
 	illustrator: "Ken Sugimori",

--- a/data-asia/PMCG/PMCG5/041.ts
+++ b/data-asia/PMCG/PMCG5/041.ts
@@ -4,7 +4,8 @@ import Set from "../PMCG5"
 const card: Card = {
 	set: Set,
 	name: {
-		ja: "SurgeのElectabuzz",
+		// Lt. Surge's Electabuzz
+		ja: "マチスのエレブー",
 	},
 
 	rarity: "Holo Rare",

--- a/data-asia/PMCG/PMCG5/041.ts
+++ b/data-asia/PMCG/PMCG5/041.ts
@@ -7,6 +7,7 @@ const card: Card = {
 		// Lt. Surge's Electabuzz
 		ja: "マチスのエレブー",
 	},
+	illustrator: "Ken Sugimori",
 
 	rarity: "Holo Rare",
 	category: "Pokemon",
@@ -41,6 +42,9 @@ const card: Card = {
 	variants: [
 		{
 			type: "holo",
+			thirdParty: {
+				tcgplayer: 576801
+			},
 		},
 	],
 };

--- a/data-asia/PMCG/PMCG5/042.ts
+++ b/data-asia/PMCG/PMCG5/042.ts
@@ -4,7 +4,6 @@ import Set from "../PMCG5"
 const card: Card = {
 	set: Set,
 	name: {
-		// Lt. Surge's Jolteon
 		ja: "マチスのサンダース",
 	},
 	illustrator: "Ken Sugimori",

--- a/data-asia/PMCG/PMCG5/042.ts
+++ b/data-asia/PMCG/PMCG5/042.ts
@@ -7,6 +7,7 @@ const card: Card = {
 		// Lt. Surge's Jolteon
 		ja: "マチスのサンダース",
 	},
+	illustrator: "Ken Sugimori",
 
 	rarity: "Rare",
 	category: "Pokemon",

--- a/data-asia/PMCG/PMCG5/042.ts
+++ b/data-asia/PMCG/PMCG5/042.ts
@@ -4,7 +4,8 @@ import Set from "../PMCG5"
 const card: Card = {
 	set: Set,
 	name: {
-		ja: "Surge's Jolteon中t",
+		// Lt. Surge's Jolteon
+		ja: "マチスのサンダース",
 	},
 
 	rarity: "Rare",
@@ -41,6 +42,9 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 576803
+			},
 		},
 	],
 };

--- a/data-asia/PMCG/PMCG5/043.ts
+++ b/data-asia/PMCG/PMCG5/043.ts
@@ -4,7 +4,8 @@ import Set from "../PMCG5"
 const card: Card = {
 	set: Set,
 	name: {
-		ja: "ブロックのサンドリュー",
+		// Brock's Sandshrew
+		ja: "タケシサンド",
 	},
 
 	rarity: "Common",
@@ -32,6 +33,9 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 576765
+			},
 		},
 	],
 };

--- a/data-asia/PMCG/PMCG5/043.ts
+++ b/data-asia/PMCG/PMCG5/043.ts
@@ -7,6 +7,7 @@ const card: Card = {
 		// Brock's Sandshrew
 		ja: "タケシサンド",
 	},
+	illustrator: "Ken Sugimori",
 
 	rarity: "Common",
 	category: "Pokemon",

--- a/data-asia/PMCG/PMCG5/043.ts
+++ b/data-asia/PMCG/PMCG5/043.ts
@@ -4,7 +4,6 @@ import Set from "../PMCG5"
 const card: Card = {
 	set: Set,
 	name: {
-		// Brock's Sandshrew
 		ja: "タケシサンド",
 	},
 	illustrator: "Ken Sugimori",

--- a/data-asia/PMCG/PMCG5/044.ts
+++ b/data-asia/PMCG/PMCG5/044.ts
@@ -4,7 +4,8 @@ import Set from "../PMCG5"
 const card: Card = {
 	set: Set,
 	name: {
-		ja: "ブロックのディグレット",
+		// Brock's Diglett
+		ja: "タケシのディグダ",
 	},
 
 	rarity: "Common",
@@ -42,6 +43,9 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 576751
+			},
 		},
 	],
 };

--- a/data-asia/PMCG/PMCG5/044.ts
+++ b/data-asia/PMCG/PMCG5/044.ts
@@ -4,7 +4,6 @@ import Set from "../PMCG5"
 const card: Card = {
 	set: Set,
 	name: {
-		// Brock's Diglett
 		ja: "タケシのディグダ",
 	},
 	illustrator: "Ken Sugimori",

--- a/data-asia/PMCG/PMCG5/044.ts
+++ b/data-asia/PMCG/PMCG5/044.ts
@@ -7,6 +7,7 @@ const card: Card = {
 		// Brock's Diglett
 		ja: "タケシのディグダ",
 	},
+	illustrator: "Ken Sugimori",
 
 	rarity: "Common",
 	category: "Pokemon",

--- a/data-asia/PMCG/PMCG5/045.ts
+++ b/data-asia/PMCG/PMCG5/045.ts
@@ -4,7 +4,6 @@ import Set from "../PMCG5"
 const card: Card = {
 	set: Set,
 	name: {
-		// Brock's Mankey
 		ja: "タケシのマンキー",
 	},
 	illustrator: "Ken Sugimori",

--- a/data-asia/PMCG/PMCG5/045.ts
+++ b/data-asia/PMCG/PMCG5/045.ts
@@ -7,6 +7,7 @@ const card: Card = {
 		// Brock's Mankey
 		ja: "タケシのマンキー",
 	},
+	illustrator: "Ken Sugimori",
 
 	rarity: "Common",
 	category: "Pokemon",

--- a/data-asia/PMCG/PMCG5/045.ts
+++ b/data-asia/PMCG/PMCG5/045.ts
@@ -4,7 +4,8 @@ import Set from "../PMCG5"
 const card: Card = {
 	set: Set,
 	name: {
-		ja: "ブロックのマンキー",
+		// Brock's Mankey
+		ja: "タケシのマンキー",
 	},
 
 	rarity: "Common",
@@ -39,6 +40,9 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 576758
+			},
 		},
 	],
 };

--- a/data-asia/PMCG/PMCG5/046.ts
+++ b/data-asia/PMCG/PMCG5/046.ts
@@ -4,7 +4,6 @@ import Set from "../PMCG5"
 const card: Card = {
 	set: Set,
 	name: {
-		// Brock's Geodude
 		ja: "タケシのイシツブテ",
 	},
 	illustrator: "Ken Sugimori",

--- a/data-asia/PMCG/PMCG5/046.ts
+++ b/data-asia/PMCG/PMCG5/046.ts
@@ -7,6 +7,7 @@ const card: Card = {
 		// Brock's Geodude
 		ja: "タケシのイシツブテ",
 	},
+	illustrator: "Ken Sugimori",
 
 	rarity: "Common",
 	category: "Pokemon",

--- a/data-asia/PMCG/PMCG5/046.ts
+++ b/data-asia/PMCG/PMCG5/046.ts
@@ -4,7 +4,8 @@ import Set from "../PMCG5"
 const card: Card = {
 	set: Set,
 	name: {
-		ja: "ブロックのジオドード（LV.15）",
+		// Brock's Geodude
+		ja: "タケシのイシツブテ",
 	},
 
 	rarity: "Common",
@@ -31,6 +32,9 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 576753
+			},
 		},
 	],
 };

--- a/data-asia/PMCG/PMCG5/047.ts
+++ b/data-asia/PMCG/PMCG5/047.ts
@@ -4,7 +4,6 @@ import Set from "../PMCG5"
 const card: Card = {
 	set: Set,
 	name: {
-		// Brock's Geodude
 		ja: "タケシのイシツブテ",
 	},
 	illustrator: "Ken Sugimori",

--- a/data-asia/PMCG/PMCG5/047.ts
+++ b/data-asia/PMCG/PMCG5/047.ts
@@ -4,7 +4,8 @@ import Set from "../PMCG5"
 const card: Card = {
 	set: Set,
 	name: {
-		ja: "ブロックのジオドード（LV.13）",
+		// Brock's Geodude
+		ja: "タケシのイシツブテ",
 	},
 
 	rarity: "Common",
@@ -41,6 +42,9 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 576752
+			},
 		},
 	],
 };

--- a/data-asia/PMCG/PMCG5/047.ts
+++ b/data-asia/PMCG/PMCG5/047.ts
@@ -7,6 +7,7 @@ const card: Card = {
 		// Brock's Geodude
 		ja: "タケシのイシツブテ",
 	},
+	illustrator: "Ken Sugimori",
 
 	rarity: "Common",
 	category: "Pokemon",

--- a/data-asia/PMCG/PMCG5/048.ts
+++ b/data-asia/PMCG/PMCG5/048.ts
@@ -4,7 +4,8 @@ import Set from "../PMCG5"
 const card: Card = {
 	set: Set,
 	name: {
-		ja: "ブロックのオニックス",
+		// Brock's Onix
+		ja: "タケシのイワーク",
 	},
 
 	rarity: "Common",
@@ -38,6 +39,9 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 576760
+			},
 		},
 	],
 };

--- a/data-asia/PMCG/PMCG5/048.ts
+++ b/data-asia/PMCG/PMCG5/048.ts
@@ -4,7 +4,6 @@ import Set from "../PMCG5"
 const card: Card = {
 	set: Set,
 	name: {
-		// Brock's Onix
 		ja: "タケシのイワーク",
 	},
 	illustrator: "Ken Sugimori",

--- a/data-asia/PMCG/PMCG5/048.ts
+++ b/data-asia/PMCG/PMCG5/048.ts
@@ -7,6 +7,7 @@ const card: Card = {
 		// Brock's Onix
 		ja: "タケシのイワーク",
 	},
+	illustrator: "Ken Sugimori",
 
 	rarity: "Common",
 	category: "Pokemon",

--- a/data-asia/PMCG/PMCG5/049.ts
+++ b/data-asia/PMCG/PMCG5/049.ts
@@ -4,7 +4,6 @@ import Set from "../PMCG5"
 const card: Card = {
 	set: Set,
 	name: {
-		// Brock's Rhyhorn
 		ja: "タケシのサイホーン",
 	},
 	illustrator: "Ken Sugimori",

--- a/data-asia/PMCG/PMCG5/049.ts
+++ b/data-asia/PMCG/PMCG5/049.ts
@@ -7,6 +7,7 @@ const card: Card = {
 		// Brock's Rhyhorn
 		ja: "タケシのサイホーン",
 	},
+	illustrator: "Ken Sugimori",
 
 	rarity: "Common",
 	category: "Pokemon",

--- a/data-asia/PMCG/PMCG5/049.ts
+++ b/data-asia/PMCG/PMCG5/049.ts
@@ -4,7 +4,8 @@ import Set from "../PMCG5"
 const card: Card = {
 	set: Set,
 	name: {
-		ja: "ブロックの韻",
+		// Brock's Rhyhorn
+		ja: "タケシのサイホーン",
 	},
 
 	rarity: "Common",
@@ -32,6 +33,9 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 576764
+			},
 		},
 	],
 };

--- a/data-asia/PMCG/PMCG5/050.ts
+++ b/data-asia/PMCG/PMCG5/050.ts
@@ -4,7 +4,8 @@ import Set from "../PMCG5"
 const card: Card = {
 	set: Set,
 	name: {
-		ja: "ブロックのサンドスラッシュ",
+		// Brock's Sandslash
+		ja: "タケシのサンドパン",
 	},
 
 	rarity: "Uncommon",
@@ -42,6 +43,9 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 576766
+			},
 		},
 	],
 };

--- a/data-asia/PMCG/PMCG5/050.ts
+++ b/data-asia/PMCG/PMCG5/050.ts
@@ -4,7 +4,6 @@ import Set from "../PMCG5"
 const card: Card = {
 	set: Set,
 	name: {
-		// Brock's Sandslash
 		ja: "タケシのサンドパン",
 	},
 	illustrator: "Atsuko Nishida",

--- a/data-asia/PMCG/PMCG5/050.ts
+++ b/data-asia/PMCG/PMCG5/050.ts
@@ -7,6 +7,7 @@ const card: Card = {
 		// Brock's Sandslash
 		ja: "タケシのサンドパン",
 	},
+	illustrator: "Atsuko Nishida",
 
 	rarity: "Uncommon",
 	category: "Pokemon",

--- a/data-asia/PMCG/PMCG5/051.ts
+++ b/data-asia/PMCG/PMCG5/051.ts
@@ -7,6 +7,7 @@ const card: Card = {
 		// Brock's Primeape
 		ja: "タケシのオコリザル",
 	},
+	illustrator: "Ken Sugimori",
 
 	rarity: "Uncommon",
 	category: "Pokemon",

--- a/data-asia/PMCG/PMCG5/051.ts
+++ b/data-asia/PMCG/PMCG5/051.ts
@@ -4,7 +4,6 @@ import Set from "../PMCG5"
 const card: Card = {
 	set: Set,
 	name: {
-		// Brock's Primeape
 		ja: "タケシのオコリザル",
 	},
 	illustrator: "Ken Sugimori",

--- a/data-asia/PMCG/PMCG5/051.ts
+++ b/data-asia/PMCG/PMCG5/051.ts
@@ -4,7 +4,8 @@ import Set from "../PMCG5"
 const card: Card = {
 	set: Set,
 	name: {
-		ja: "ブロックの入門",
+		// Brock's Primeape
+		ja: "タケシのオコリザル",
 	},
 
 	rarity: "Uncommon",
@@ -43,6 +44,9 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 576761
+			},
 		},
 	],
 };

--- a/data-asia/PMCG/PMCG5/052.ts
+++ b/data-asia/PMCG/PMCG5/052.ts
@@ -7,6 +7,7 @@ const card: Card = {
 		// Brock's Graveler
 		ja: "タケシのゴローン",
 	},
+	illustrator: "Atsuko Nishida",
 
 	rarity: "Uncommon",
 	category: "Pokemon",

--- a/data-asia/PMCG/PMCG5/052.ts
+++ b/data-asia/PMCG/PMCG5/052.ts
@@ -4,7 +4,6 @@ import Set from "../PMCG5"
 const card: Card = {
 	set: Set,
 	name: {
-		// Brock's Graveler
 		ja: "タケシのゴローン",
 	},
 	illustrator: "Atsuko Nishida",

--- a/data-asia/PMCG/PMCG5/052.ts
+++ b/data-asia/PMCG/PMCG5/052.ts
@@ -4,7 +4,8 @@ import Set from "../PMCG5"
 const card: Card = {
 	set: Set,
 	name: {
-		ja: "ブロックの砂利",
+		// Brock's Graveler
+		ja: "タケシのゴローン",
 	},
 
 	rarity: "Uncommon",
@@ -39,6 +40,9 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 576756
+			},
 		},
 	],
 };

--- a/data-asia/PMCG/PMCG5/053.ts
+++ b/data-asia/PMCG/PMCG5/053.ts
@@ -7,6 +7,7 @@ const card: Card = {
 		// Brock's Golem
 		ja: "タケシのゴローニャ",
 	},
+	illustrator: "Ken Sugimori",
 
 	rarity: "Rare",
 	category: "Pokemon",

--- a/data-asia/PMCG/PMCG5/053.ts
+++ b/data-asia/PMCG/PMCG5/053.ts
@@ -4,7 +4,8 @@ import Set from "../PMCG5"
 const card: Card = {
 	set: Set,
 	name: {
-		ja: "ブロックのゴーレム",
+		// Brock's Golem
+		ja: "タケシのゴローニャ",
 	},
 
 	rarity: "Rare",
@@ -39,6 +40,9 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 576755
+			},
 		},
 	],
 };

--- a/data-asia/PMCG/PMCG5/053.ts
+++ b/data-asia/PMCG/PMCG5/053.ts
@@ -4,7 +4,6 @@ import Set from "../PMCG5"
 const card: Card = {
 	set: Set,
 	name: {
-		// Brock's Golem
 		ja: "タケシのゴローニャ",
 	},
 	illustrator: "Ken Sugimori",

--- a/data-asia/PMCG/PMCG5/054.ts
+++ b/data-asia/PMCG/PMCG5/054.ts
@@ -7,7 +7,7 @@ const card: Card = {
 		// Rocket's Hitmonchan
 		ja: "R団のエビワラー",
 	},
-
+	illustrator: "Ken Sugimori",
 	rarity: "Holo Rare",
 	category: "Pokemon",
 	dexId: [107],

--- a/data-asia/PMCG/PMCG5/054.ts
+++ b/data-asia/PMCG/PMCG5/054.ts
@@ -4,7 +4,6 @@ import Set from "../PMCG5"
 const card: Card = {
 	set: Set,
 	name: {
-		// Rocket's Hitmonchan
 		ja: "R団のエビワラー",
 	},
 	illustrator: "Ken Sugimori",

--- a/data-asia/PMCG/PMCG5/054.ts
+++ b/data-asia/PMCG/PMCG5/054.ts
@@ -4,7 +4,8 @@ import Set from "../PMCG5"
 const card: Card = {
 	set: Set,
 	name: {
-		ja: "ロケットのヒットモンチャン",
+		// Rocket's Hitmonchan
+		ja: "R団のエビワラー",
 	},
 
 	rarity: "Holo Rare",

--- a/data-asia/PMCG/PMCG5/055.ts
+++ b/data-asia/PMCG/PMCG5/055.ts
@@ -4,7 +4,6 @@ import Set from "../PMCG5"
 const card: Card = {
 	set: Set,
 	name: {
-		// Brock's Rhydon
 		ja: "タケシのサイドン",
 	},
 	illustrator: "Ken Sugimori",

--- a/data-asia/PMCG/PMCG5/055.ts
+++ b/data-asia/PMCG/PMCG5/055.ts
@@ -4,7 +4,8 @@ import Set from "../PMCG5"
 const card: Card = {
 	set: Set,
 	name: {
-		ja: "ブロックのライドン",
+		// Brock's Rhydon
+		ja: "タケシのサイドン",
 	},
 
 	rarity: "Holo Rare",

--- a/data-asia/PMCG/PMCG5/055.ts
+++ b/data-asia/PMCG/PMCG5/055.ts
@@ -7,6 +7,7 @@ const card: Card = {
 		// Brock's Rhydon
 		ja: "タケシのサイドン",
 	},
+	illustrator: "Ken Sugimori",
 
 	rarity: "Holo Rare",
 	category: "Pokemon",
@@ -44,6 +45,9 @@ const card: Card = {
 	variants: [
 		{
 			type: "holo",
+			thirdParty: {
+				tcgplayer: 576763
+			},
 		},
 	],
 };

--- a/data-asia/PMCG/PMCG5/056.ts
+++ b/data-asia/PMCG/PMCG5/056.ts
@@ -4,7 +4,6 @@ import Set from "../PMCG5"
 const card: Card = {
 	set: Set,
 	name: {
-		// Lt. Surge's Rattata
 		ja: "マチスのコラッタ",
 	},
 	illustrator: "Atsuko Nishida",

--- a/data-asia/PMCG/PMCG5/056.ts
+++ b/data-asia/PMCG/PMCG5/056.ts
@@ -4,7 +4,8 @@ import Set from "../PMCG5"
 const card: Card = {
 	set: Set,
 	name: {
-		ja: "Surge's Rattata中t",
+		// Lt. Surge's Rattata
+		ja: "マチスのコラッタ",
 	},
 
 	rarity: "Common",
@@ -39,6 +40,9 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 576809
+			},
 		},
 	],
 };

--- a/data-asia/PMCG/PMCG5/056.ts
+++ b/data-asia/PMCG/PMCG5/056.ts
@@ -7,6 +7,7 @@ const card: Card = {
 		// Lt. Surge's Rattata
 		ja: "マチスのコラッタ",
 	},
+	illustrator: "Atsuko Nishida",
 
 	rarity: "Common",
 	category: "Pokemon",

--- a/data-asia/PMCG/PMCG5/057.ts
+++ b/data-asia/PMCG/PMCG5/057.ts
@@ -4,7 +4,6 @@ import Set from "../PMCG5"
 const card: Card = {
 	set: Set,
 	name: {
-		// Lt. Surge's Spearow
 		ja: "マチスのオニスズメ",
 	},
 	illustrator: "Atsuko Nishida",

--- a/data-asia/PMCG/PMCG5/057.ts
+++ b/data-asia/PMCG/PMCG5/057.ts
@@ -7,6 +7,7 @@ const card: Card = {
 		// Lt. Surge's Spearow
 		ja: "マチスのオニスズメ",
 	},
+	illustrator: "Atsuko Nishida",
 
 	rarity: "Common",
 	category: "Pokemon",

--- a/data-asia/PMCG/PMCG5/057.ts
+++ b/data-asia/PMCG/PMCG5/057.ts
@@ -4,7 +4,8 @@ import Set from "../PMCG5"
 const card: Card = {
 	set: Set,
 	name: {
-		ja: "Surgeの槍中",
+		// Lt. Surge's Spearow
+		ja: "マチスのオニスズメ",
 	},
 
 	rarity: "Common",
@@ -41,6 +42,9 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 576811
+			},
 		},
 	],
 };

--- a/data-asia/PMCG/PMCG5/058.ts
+++ b/data-asia/PMCG/PMCG5/058.ts
@@ -4,7 +4,6 @@ import Set from "../PMCG5"
 const card: Card = {
 	set: Set,
 	name: {
-		// Erika's Jigglypuff
 		ja: "エリカのプリン",
 	},
 	illustrator: "Ken Sugimori",

--- a/data-asia/PMCG/PMCG5/058.ts
+++ b/data-asia/PMCG/PMCG5/058.ts
@@ -4,7 +4,8 @@ import Set from "../PMCG5"
 const card: Card = {
 	set: Set,
 	name: {
-		ja: "エリカのジグリプフ",
+		// Erika's Jigglypuff
+		ja: "エリカのプリン",
 	},
 
 	rarity: "Common",
@@ -40,6 +41,9 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 576787
+			},
 		},
 	],
 };

--- a/data-asia/PMCG/PMCG5/058.ts
+++ b/data-asia/PMCG/PMCG5/058.ts
@@ -7,6 +7,7 @@ const card: Card = {
 		// Erika's Jigglypuff
 		ja: "エリカのプリン",
 	},
+	illustrator: "Ken Sugimori",
 
 	rarity: "Common",
 	category: "Pokemon",

--- a/data-asia/PMCG/PMCG5/059.ts
+++ b/data-asia/PMCG/PMCG5/059.ts
@@ -7,6 +7,7 @@ const card: Card = {
 		// Lt. Surge's Raticate
 		ja: "マチスのラッタ",
 	},
+	illustrator: "Ken Sugimori",
 
 	rarity: "Uncommon",
 	category: "Pokemon",

--- a/data-asia/PMCG/PMCG5/059.ts
+++ b/data-asia/PMCG/PMCG5/059.ts
@@ -4,7 +4,6 @@ import Set from "../PMCG5"
 const card: Card = {
 	set: Set,
 	name: {
-		// Lt. Surge's Raticate
 		ja: "マチスのラッタ",
 	},
 	illustrator: "Ken Sugimori",

--- a/data-asia/PMCG/PMCG5/059.ts
+++ b/data-asia/PMCG/PMCG5/059.ts
@@ -4,7 +4,8 @@ import Set from "../PMCG5"
 const card: Card = {
 	set: Set,
 	name: {
-		ja: "サージ中t",
+		// Lt. Surge's Raticate
+		ja: "マチスのラッタ",
 	},
 
 	rarity: "Uncommon",
@@ -41,6 +42,9 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 576808
+			},
 		},
 	],
 };

--- a/data-asia/PMCG/PMCG5/060.ts
+++ b/data-asia/PMCG/PMCG5/060.ts
@@ -7,6 +7,7 @@ const card: Card = {
 		// Erika's Clefairy
 		ja: "エリカのピッピ",
 	},
+	illustrator: "Atsuko Nishida",
 
 	rarity: "Uncommon",
 	category: "Pokemon",

--- a/data-asia/PMCG/PMCG5/060.ts
+++ b/data-asia/PMCG/PMCG5/060.ts
@@ -4,7 +4,6 @@ import Set from "../PMCG5"
 const card: Card = {
 	set: Set,
 	name: {
-		// Erika's Clefairy
 		ja: "エリカのピッピ",
 	},
 	illustrator: "Atsuko Nishida",

--- a/data-asia/PMCG/PMCG5/060.ts
+++ b/data-asia/PMCG/PMCG5/060.ts
@@ -4,7 +4,8 @@ import Set from "../PMCG5"
 const card: Card = {
 	set: Set,
 	name: {
-		ja: "エリカのクリーフ",
+		// Erika's Clefairy
+		ja: "エリカのピッピ",
 	},
 
 	rarity: "Uncommon",
@@ -38,6 +39,9 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 576781
+			},
 		},
 	],
 };

--- a/data-asia/PMCG/PMCG5/061.ts
+++ b/data-asia/PMCG/PMCG5/061.ts
@@ -4,7 +4,6 @@ import Set from "../PMCG5"
 const card: Card = {
 	set: Set,
 	name: {
-		// Brock's Lickitung
 		ja: "タケシのベロリンガ",
 	},
 	illustrator: "Ken Sugimori",

--- a/data-asia/PMCG/PMCG5/061.ts
+++ b/data-asia/PMCG/PMCG5/061.ts
@@ -4,7 +4,8 @@ import Set from "../PMCG5"
 const card: Card = {
 	set: Set,
 	name: {
-		ja: "ブロックのリキトゥン",
+		// Brock's Lickitung
+		ja: "タケシのベロリンガ",
 	},
 
 	rarity: "Uncommon",
@@ -38,6 +39,9 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 576757
+			},
 		},
 	],
 };

--- a/data-asia/PMCG/PMCG5/061.ts
+++ b/data-asia/PMCG/PMCG5/061.ts
@@ -7,6 +7,7 @@ const card: Card = {
 		// Brock's Lickitung
 		ja: "タケシのベロリンガ",
 	},
+	illustrator: "Ken Sugimori",
 
 	rarity: "Uncommon",
 	category: "Pokemon",

--- a/data-asia/PMCG/PMCG5/062.ts
+++ b/data-asia/PMCG/PMCG5/062.ts
@@ -7,6 +7,7 @@ const card: Card = {
 		// Lt. Surge's Eevee
 		ja: "マチスのイーブイ",
 	},
+	illustrator: "Ken Sugimori",
 
 	rarity: "Uncommon",
 	category: "Pokemon",

--- a/data-asia/PMCG/PMCG5/062.ts
+++ b/data-asia/PMCG/PMCG5/062.ts
@@ -4,7 +4,6 @@ import Set from "../PMCG5"
 const card: Card = {
 	set: Set,
 	name: {
-		// Lt. Surge's Eevee
 		ja: "マチスのイーブイ",
 	},
 	illustrator: "Ken Sugimori",

--- a/data-asia/PMCG/PMCG5/062.ts
+++ b/data-asia/PMCG/PMCG5/062.ts
@@ -4,7 +4,8 @@ import Set from "../PMCG5"
 const card: Card = {
 	set: Set,
 	name: {
-		ja: "Surge's Eevee中t",
+		// Lt. Surge's Eevee
+		ja: "マチスのイーブイ",
 	},
 
 	rarity: "Uncommon",
@@ -38,6 +39,9 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 576800
+			},
 		},
 	],
 };

--- a/data-asia/PMCG/PMCG5/063.ts
+++ b/data-asia/PMCG/PMCG5/063.ts
@@ -4,7 +4,8 @@ import Set from "../PMCG5"
 const card: Card = {
 	set: Set,
 	name: {
-		ja: "エリカのドラチーニ",
+		// Erika's Dratini
+		ja: "エリカのミニリュウ",
 	},
 
 	rarity: "Uncommon",
@@ -42,6 +43,9 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 576783
+			},
 		},
 	],
 };

--- a/data-asia/PMCG/PMCG5/063.ts
+++ b/data-asia/PMCG/PMCG5/063.ts
@@ -4,7 +4,6 @@ import Set from "../PMCG5"
 const card: Card = {
 	set: Set,
 	name: {
-		// Erika's Dratini
 		ja: "エリカのミニリュウ",
 	},
 	illustrator: "Ken Sugimori",

--- a/data-asia/PMCG/PMCG5/063.ts
+++ b/data-asia/PMCG/PMCG5/063.ts
@@ -7,6 +7,7 @@ const card: Card = {
 		// Erika's Dratini
 		ja: "エリカのミニリュウ",
 	},
+	illustrator: "Ken Sugimori",
 
 	rarity: "Uncommon",
 	category: "Pokemon",

--- a/data-asia/PMCG/PMCG5/064.ts
+++ b/data-asia/PMCG/PMCG5/064.ts
@@ -7,6 +7,7 @@ const card: Card = {
 		// Lt. Surge's Fearow
 		ja: "マチスのオニドリル",
 	},
+	illustrator: "Ken Sugimori",
 
 	rarity: "Holo Rare",
 	category: "Pokemon",
@@ -41,6 +42,9 @@ const card: Card = {
 	variants: [
 		{
 			type: "holo",
+			thirdParty: {
+				tcgplayer: 576802
+			},
 		},
 	],
 };

--- a/data-asia/PMCG/PMCG5/064.ts
+++ b/data-asia/PMCG/PMCG5/064.ts
@@ -4,7 +4,6 @@ import Set from "../PMCG5"
 const card: Card = {
 	set: Set,
 	name: {
-		// Lt. Surge's Fearow
 		ja: "マチスのオニドリル",
 	},
 	illustrator: "Ken Sugimori",

--- a/data-asia/PMCG/PMCG5/064.ts
+++ b/data-asia/PMCG/PMCG5/064.ts
@@ -4,7 +4,8 @@ import Set from "../PMCG5"
 const card: Card = {
 	set: Set,
 	name: {
-		ja: "Surgeの恐怖中",
+		// Lt. Surge's Fearow
+		ja: "マチスのオニドリル",
 	},
 
 	rarity: "Holo Rare",

--- a/data-asia/PMCG/PMCG5/065.ts
+++ b/data-asia/PMCG/PMCG5/065.ts
@@ -4,7 +4,6 @@ import Set from "../PMCG5"
 const card: Card = {
 	set: Set,
 	name: {
-		// Erika's Clefable
 		ja: "エリカのピクシー",
 	},
 	illustrator: "Atsuko Nishida",

--- a/data-asia/PMCG/PMCG5/065.ts
+++ b/data-asia/PMCG/PMCG5/065.ts
@@ -4,7 +4,8 @@ import Set from "../PMCG5"
 const card: Card = {
 	set: Set,
 	name: {
-		ja: "エリカのクレファー",
+		// Erika's Clefable
+		ja: "エリカのピクシー",
 	},
 
 	rarity: "Holo Rare",

--- a/data-asia/PMCG/PMCG5/065.ts
+++ b/data-asia/PMCG/PMCG5/065.ts
@@ -7,6 +7,7 @@ const card: Card = {
 		// Erika's Clefable
 		ja: "エリカのピクシー",
 	},
+	illustrator: "Atsuko Nishida",
 
 	rarity: "Holo Rare",
 	category: "Pokemon",
@@ -39,6 +40,9 @@ const card: Card = {
 	variants: [
 		{
 			type: "holo",
+			thirdParty: {
+				tcgplayer: 576780
+			},
 		},
 	],
 };

--- a/data-asia/PMCG/PMCG5/066.ts
+++ b/data-asia/PMCG/PMCG5/066.ts
@@ -4,7 +4,6 @@ import Set from "../PMCG5"
 const card: Card = {
 	set: Set,
 	name: {
-		// Erika's Dragonair
 		ja: "エリカのハクリュー",
 	},
 	illustrator: "Atsuko Nishida",

--- a/data-asia/PMCG/PMCG5/066.ts
+++ b/data-asia/PMCG/PMCG5/066.ts
@@ -4,7 +4,8 @@ import Set from "../PMCG5"
 const card: Card = {
 	set: Set,
 	name: {
-		ja: "エリカのドラゴンエア",
+		// Erika's Dragonair
+		ja: "エリカのハクリュー",
 	},
 
 	rarity: "Holo Rare",

--- a/data-asia/PMCG/PMCG5/066.ts
+++ b/data-asia/PMCG/PMCG5/066.ts
@@ -7,6 +7,7 @@ const card: Card = {
 		// Erika's Dragonair
 		ja: "エリカのハクリュー",
 	},
+	illustrator: "Atsuko Nishida",
 
 	rarity: "Holo Rare",
 	category: "Pokemon",
@@ -42,6 +43,9 @@ const card: Card = {
 	variants: [
 		{
 			type: "holo",
+			thirdParty: {
+				tcgplayer: 576782
+			},
 		},
 	],
 };

--- a/data-asia/PMCG/PMCG5/067.ts
+++ b/data-asia/PMCG/PMCG5/067.ts
@@ -7,7 +7,7 @@ const card: Card = {
 		// Energy Flow
 		ja: "エネルギーサーキュレート",
 	},
-
+	illustrator: "Kenji Kinebuchi",
 	rarity: "Common",
 	category: "Trainer",
 

--- a/data-asia/PMCG/PMCG5/067.ts
+++ b/data-asia/PMCG/PMCG5/067.ts
@@ -4,7 +4,8 @@ import Set from "../PMCG5"
 const card: Card = {
 	set: Set,
 	name: {
-		ja: "エネルギーの流れ",
+		// Energy Flow
+		ja: "エネルギーサーキュレート",
 	},
 
 	rarity: "Common",
@@ -13,6 +14,9 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 576775
+			},
 		},
 	],
 };

--- a/data-asia/PMCG/PMCG5/067.ts
+++ b/data-asia/PMCG/PMCG5/067.ts
@@ -4,7 +4,6 @@ import Set from "../PMCG5"
 const card: Card = {
 	set: Set,
 	name: {
-		// Energy Flow
 		ja: "エネルギーサーキュレート",
 	},
 	illustrator: "Kenji Kinebuchi",

--- a/data-asia/PMCG/PMCG5/068.ts
+++ b/data-asia/PMCG/PMCG5/068.ts
@@ -4,7 +4,6 @@ import Set from "../PMCG5"
 const card: Card = {
 	set: Set,
 	name: {
-		// Misty's Duel
 		ja: "カスミの勝負",
 	},
 	illustrator: "Ken Sugimori",

--- a/data-asia/PMCG/PMCG5/068.ts
+++ b/data-asia/PMCG/PMCG5/068.ts
@@ -7,6 +7,7 @@ const card: Card = {
 		// Misty's Duel
 		ja: "カスミの勝負",
 	},
+	illustrator: "Ken Sugimori",
 
 	rarity: "Common",
 	category: "Trainer",

--- a/data-asia/PMCG/PMCG5/068.ts
+++ b/data-asia/PMCG/PMCG5/068.ts
@@ -4,7 +4,8 @@ import Set from "../PMCG5"
 const card: Card = {
 	set: Set,
 	name: {
-		ja: "ミスティの決闘",
+		// Misty's Duel
+		ja: "カスミの勝負",
 	},
 
 	rarity: "Common",
@@ -13,6 +14,9 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 576816
+			},
 		},
 	],
 };

--- a/data-asia/PMCG/PMCG5/069.ts
+++ b/data-asia/PMCG/PMCG5/069.ts
@@ -4,7 +4,8 @@ import Set from "../PMCG5"
 const card: Card = {
 	set: Set,
 	name: {
-		ja: "ミスティの涙",
+		// Misty's Tears
+		ja: "カスミのなみだ",
 	},
 
 	rarity: "Common",
@@ -13,6 +14,9 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 576829
+			},
 		},
 	],
 };

--- a/data-asia/PMCG/PMCG5/069.ts
+++ b/data-asia/PMCG/PMCG5/069.ts
@@ -4,7 +4,6 @@ import Set from "../PMCG5"
 const card: Card = {
 	set: Set,
 	name: {
-		// Misty's Tears
 		ja: "カスミのなみだ",
 	},
 	illustrator: "Ken Sugimori",

--- a/data-asia/PMCG/PMCG5/069.ts
+++ b/data-asia/PMCG/PMCG5/069.ts
@@ -7,6 +7,7 @@ const card: Card = {
 		// Misty's Tears
 		ja: "カスミのなみだ",
 	},
+	illustrator: "Ken Sugimori",
 
 	rarity: "Common",
 	category: "Trainer",

--- a/data-asia/PMCG/PMCG5/070.ts
+++ b/data-asia/PMCG/PMCG5/070.ts
@@ -7,7 +7,7 @@ const card: Card = {
 		// Narrow Gym
 		ja: "せまいジム",
 	},
-
+	illustrator: "Kenji Kinebuchi",
 	rarity: "Common",
 	category: "Trainer",
 

--- a/data-asia/PMCG/PMCG5/070.ts
+++ b/data-asia/PMCG/PMCG5/070.ts
@@ -4,7 +4,6 @@ import Set from "../PMCG5"
 const card: Card = {
 	set: Set,
 	name: {
-		// Narrow Gym
 		ja: "せまいジム",
 	},
 	illustrator: "Kenji Kinebuchi",

--- a/data-asia/PMCG/PMCG5/070.ts
+++ b/data-asia/PMCG/PMCG5/070.ts
@@ -4,7 +4,8 @@ import Set from "../PMCG5"
 const card: Card = {
 	set: Set,
 	name: {
-		ja: "狭いジム",
+		// Narrow Gym
+		ja: "せまいジム",
 	},
 
 	rarity: "Common",
@@ -13,6 +14,9 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 576834
+			},
 		},
 	],
 };

--- a/data-asia/PMCG/PMCG5/071.ts
+++ b/data-asia/PMCG/PMCG5/071.ts
@@ -7,7 +7,7 @@ const card: Card = {
 		// Recall
 		ja: "思い出させる",
 	},
-
+	illustrator: "Sumiyoshi Kizuki",
 	rarity: "Uncommon",
 	category: "Trainer",
 

--- a/data-asia/PMCG/PMCG5/071.ts
+++ b/data-asia/PMCG/PMCG5/071.ts
@@ -4,7 +4,6 @@ import Set from "../PMCG5"
 const card: Card = {
 	set: Set,
 	name: {
-		// Recall
 		ja: "思い出させる",
 	},
 	illustrator: "Sumiyoshi Kizuki",

--- a/data-asia/PMCG/PMCG5/071.ts
+++ b/data-asia/PMCG/PMCG5/071.ts
@@ -4,7 +4,8 @@ import Set from "../PMCG5"
 const card: Card = {
 	set: Set,
 	name: {
-		ja: "想起",
+		// Recall
+		ja: "思い出させる",
 	},
 
 	rarity: "Uncommon",
@@ -13,6 +14,9 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 576837
+			},
 		},
 	],
 };

--- a/data-asia/PMCG/PMCG5/072.ts
+++ b/data-asia/PMCG/PMCG5/072.ts
@@ -4,7 +4,6 @@ import Set from "../PMCG5"
 const card: Card = {
 	set: Set,
 	name: {
-		// Erika's Maids
 		ja: "エリカのお付き",
 	},
 	illustrator: "Ken Sugimori",

--- a/data-asia/PMCG/PMCG5/072.ts
+++ b/data-asia/PMCG/PMCG5/072.ts
@@ -4,7 +4,8 @@ import Set from "../PMCG5"
 const card: Card = {
 	set: Set,
 	name: {
-		ja: "エリカのメイド",
+		// Erika's Maids
+		ja: "エリカのお付き",
 	},
 
 	rarity: "Uncommon",
@@ -13,6 +14,9 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 576789
+			},
 		},
 	],
 };

--- a/data-asia/PMCG/PMCG5/072.ts
+++ b/data-asia/PMCG/PMCG5/072.ts
@@ -7,6 +7,7 @@ const card: Card = {
 		// Erika's Maids
 		ja: "エリカのお付き",
 	},
+	illustrator: "Ken Sugimori",
 
 	rarity: "Uncommon",
 	category: "Trainer",

--- a/data-asia/PMCG/PMCG5/073.ts
+++ b/data-asia/PMCG/PMCG5/073.ts
@@ -4,7 +4,6 @@ import Set from "../PMCG5"
 const card: Card = {
 	set: Set,
 	name: {
-		// Erika's Perfume
 		ja: "エリカの香水",
 	},
 	illustrator: "Ken Sugimori",

--- a/data-asia/PMCG/PMCG5/073.ts
+++ b/data-asia/PMCG/PMCG5/073.ts
@@ -7,6 +7,7 @@ const card: Card = {
 		// Erika's Perfume
 		ja: "エリカの香水",
 	},
+	illustrator: "Ken Sugimori",
 
 	rarity: "Uncommon",
 	category: "Trainer",

--- a/data-asia/PMCG/PMCG5/073.ts
+++ b/data-asia/PMCG/PMCG5/073.ts
@@ -4,6 +4,7 @@ import Set from "../PMCG5"
 const card: Card = {
 	set: Set,
 	name: {
+		// Erika's Perfume
 		ja: "エリカの香水",
 	},
 
@@ -13,6 +14,9 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 576793
+			},
 		},
 	],
 };

--- a/data-asia/PMCG/PMCG5/074.ts
+++ b/data-asia/PMCG/PMCG5/074.ts
@@ -7,7 +7,7 @@ const card: Card = {
 		// Charity
 		ja: "お上品攻撃",
 	},
-
+	illustrator: "Ken Sugimori",
 	rarity: "Rare",
 	category: "Trainer",
 

--- a/data-asia/PMCG/PMCG5/074.ts
+++ b/data-asia/PMCG/PMCG5/074.ts
@@ -4,7 +4,8 @@ import Set from "../PMCG5"
 const card: Card = {
 	set: Set,
 	name: {
-		ja: "慈善",
+		// Charity
+		ja: "お上品攻撃",
 	},
 
 	rarity: "Rare",
@@ -13,6 +14,9 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 576774
+			},
 		},
 	],
 };

--- a/data-asia/PMCG/PMCG5/074.ts
+++ b/data-asia/PMCG/PMCG5/074.ts
@@ -4,7 +4,6 @@ import Set from "../PMCG5"
 const card: Card = {
 	set: Set,
 	name: {
-		// Charity
 		ja: "お上品攻撃",
 	},
 	illustrator: "Ken Sugimori",

--- a/data-asia/PMCG/PMCG5/075.ts
+++ b/data-asia/PMCG/PMCG5/075.ts
@@ -7,7 +7,7 @@ const card: Card = {
 		// Misty's Wrath
 		ja: "カスミのいかり",
 	},
-
+	illustrator: "Ken Sugimori",
 	rarity: "Uncommon",
 	category: "Trainer",
 

--- a/data-asia/PMCG/PMCG5/075.ts
+++ b/data-asia/PMCG/PMCG5/075.ts
@@ -4,7 +4,6 @@ import Set from "../PMCG5"
 const card: Card = {
 	set: Set,
 	name: {
-		// Misty's Wrath
 		ja: "カスミのいかり",
 	},
 	illustrator: "Ken Sugimori",

--- a/data-asia/PMCG/PMCG5/075.ts
+++ b/data-asia/PMCG/PMCG5/075.ts
@@ -4,7 +4,8 @@ import Set from "../PMCG5"
 const card: Card = {
 	set: Set,
 	name: {
-		ja: "ミスティの怒り",
+		// Misty's Wrath
+		ja: "カスミのいかり",
 	},
 
 	rarity: "Uncommon",
@@ -13,6 +14,9 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 576833
+			},
 		},
 	],
 };

--- a/data-asia/PMCG/PMCG5/076.ts
+++ b/data-asia/PMCG/PMCG5/076.ts
@@ -7,7 +7,7 @@ const card: Card = {
 		// Vermilion City Gym
 		ja: "クチバシティジム",
 	},
-
+	illustrator: "Kenji Kinebuchi",
 	rarity: "Uncommon",
 	category: "Trainer",
 

--- a/data-asia/PMCG/PMCG5/076.ts
+++ b/data-asia/PMCG/PMCG5/076.ts
@@ -4,7 +4,6 @@ import Set from "../PMCG5"
 const card: Card = {
 	set: Set,
 	name: {
-		// Vermilion City Gym
 		ja: "クチバシティジム",
 	},
 	illustrator: "Kenji Kinebuchi",

--- a/data-asia/PMCG/PMCG5/076.ts
+++ b/data-asia/PMCG/PMCG5/076.ts
@@ -4,7 +4,8 @@ import Set from "../PMCG5"
 const card: Card = {
 	set: Set,
 	name: {
-		ja: "バーミリオンシティジム",
+		// Vermilion City Gym
+		ja: "クチバシティジム",
 	},
 
 	rarity: "Uncommon",
@@ -13,6 +14,9 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 576845
+			},
 		},
 	],
 };

--- a/data-asia/PMCG/PMCG5/077.ts
+++ b/data-asia/PMCG/PMCG5/077.ts
@@ -4,7 +4,6 @@ import Set from "../PMCG5"
 const card: Card = {
 	set: Set,
 	name: {
-		// Brock's Training Method
 		ja: "タケシの育て方",
 	},
 	illustrator: "Ken Sugimori",

--- a/data-asia/PMCG/PMCG5/077.ts
+++ b/data-asia/PMCG/PMCG5/077.ts
@@ -7,6 +7,7 @@ const card: Card = {
 		// Brock's Training Method
 		ja: "タケシの育て方",
 	},
+	illustrator: "Ken Sugimori",
 
 	rarity: "Uncommon",
 	category: "Trainer",

--- a/data-asia/PMCG/PMCG5/077.ts
+++ b/data-asia/PMCG/PMCG5/077.ts
@@ -4,7 +4,8 @@ import Set from "../PMCG5"
 const card: Card = {
 	set: Set,
 	name: {
-		ja: "ブロックのトレーニング方法",
+		// Brock's Training Method
+		ja: "タケシの育て方",
 	},
 
 	rarity: "Uncommon",
@@ -13,6 +14,9 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 576767
+			},
 		},
 	],
 };

--- a/data-asia/PMCG/PMCG5/078.ts
+++ b/data-asia/PMCG/PMCG5/078.ts
@@ -4,7 +4,6 @@ import Set from "../PMCG5"
 const card: Card = {
 	set: Set,
 	name: {
-		// Celadon City Gym
 		ja: "タマムシシティジム",
 	},
 	illustrator: "Kenji Kinebuchi",

--- a/data-asia/PMCG/PMCG5/078.ts
+++ b/data-asia/PMCG/PMCG5/078.ts
@@ -7,7 +7,7 @@ const card: Card = {
 		// Celadon City Gym
 		ja: "タマムシシティジム",
 	},
-
+	illustrator: "Kenji Kinebuchi",
 	rarity: "Uncommon",
 	category: "Trainer",
 

--- a/data-asia/PMCG/PMCG5/078.ts
+++ b/data-asia/PMCG/PMCG5/078.ts
@@ -4,7 +4,8 @@ import Set from "../PMCG5"
 const card: Card = {
 	set: Set,
 	name: {
-		ja: "セラドンシティジム",
+		// Celadon City Gym
+		ja: "タマムシシティジム",
 	},
 
 	rarity: "Uncommon",
@@ -13,6 +14,9 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 576771
+			},
 		},
 	],
 };

--- a/data-asia/PMCG/PMCG5/079.ts
+++ b/data-asia/PMCG/PMCG5/079.ts
@@ -7,7 +7,7 @@ const card: Card = {
 		// Pewter City Gym
 		ja: "ニビシティジム",
 	},
-
+	illustrator: "Kenji Kinebuchi",
 	rarity: "Uncommon",
 	category: "Trainer",
 

--- a/data-asia/PMCG/PMCG5/079.ts
+++ b/data-asia/PMCG/PMCG5/079.ts
@@ -4,7 +4,8 @@ import Set from "../PMCG5"
 const card: Card = {
 	set: Set,
 	name: {
-		ja: "ピューターシティジム",
+		// Pewter City Gym
+		ja: "ニビシティジム",
 	},
 
 	rarity: "Uncommon",
@@ -13,6 +14,9 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 576836
+			},
 		},
 	],
 };

--- a/data-asia/PMCG/PMCG5/079.ts
+++ b/data-asia/PMCG/PMCG5/079.ts
@@ -4,7 +4,6 @@ import Set from "../PMCG5"
 const card: Card = {
 	set: Set,
 	name: {
-		// Pewter City Gym
 		ja: "ニビシティジム",
 	},
 	illustrator: "Kenji Kinebuchi",

--- a/data-asia/PMCG/PMCG5/080.ts
+++ b/data-asia/PMCG/PMCG5/080.ts
@@ -7,7 +7,7 @@ const card: Card = {
 		// Cerulean City Gym
 		ja: "ハナダシティジム",
 	},
-
+	illustrator: "Kenji Kinebuchi",
 	rarity: "Uncommon",
 	category: "Trainer",
 

--- a/data-asia/PMCG/PMCG5/080.ts
+++ b/data-asia/PMCG/PMCG5/080.ts
@@ -4,7 +4,8 @@ import Set from "../PMCG5"
 const card: Card = {
 	set: Set,
 	name: {
-		ja: "セルリアンシティジム",
+		// Cerulean City Gym
+		ja: "ハナダシティジム",
 	},
 
 	rarity: "Uncommon",
@@ -13,6 +14,9 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 576772
+			},
 		},
 	],
 };

--- a/data-asia/PMCG/PMCG5/080.ts
+++ b/data-asia/PMCG/PMCG5/080.ts
@@ -4,7 +4,6 @@ import Set from "../PMCG5"
 const card: Card = {
 	set: Set,
 	name: {
-		// Cerulean City Gym
 		ja: "ハナダシティジム",
 	},
 	illustrator: "Kenji Kinebuchi",

--- a/data-asia/PMCG/PMCG5/081.ts
+++ b/data-asia/PMCG/PMCG5/081.ts
@@ -7,6 +7,7 @@ const card: Card = {
 		// Lt. Surge's Treaty
 		ja: "マチスの交渉",
 	},
+	illustrator: "Ken Sugimori",
 
 	rarity: "Uncommon",
 	category: "Trainer",

--- a/data-asia/PMCG/PMCG5/081.ts
+++ b/data-asia/PMCG/PMCG5/081.ts
@@ -4,7 +4,6 @@ import Set from "../PMCG5"
 const card: Card = {
 	set: Set,
 	name: {
-		// Lt. Surge's Treaty
 		ja: "マチスの交渉",
 	},
 	illustrator: "Ken Sugimori",

--- a/data-asia/PMCG/PMCG5/081.ts
+++ b/data-asia/PMCG/PMCG5/081.ts
@@ -4,7 +4,8 @@ import Set from "../PMCG5"
 const card: Card = {
 	set: Set,
 	name: {
-		ja: "Surgeの条約",
+		// Lt. Surge's Treaty
+		ja: "マチスの交渉",
 	},
 
 	rarity: "Uncommon",
@@ -13,6 +14,9 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 576812
+			},
 		},
 	],
 };

--- a/data-asia/PMCG/PMCG5/082.ts
+++ b/data-asia/PMCG/PMCG5/082.ts
@@ -7,7 +7,7 @@ const card: Card = {
 		// Good Manners
 		ja: "礼儀作法",
 	},
-
+	illustrator: "Ken Sugimori",
 	rarity: "Uncommon",
 	category: "Trainer",
 

--- a/data-asia/PMCG/PMCG5/082.ts
+++ b/data-asia/PMCG/PMCG5/082.ts
@@ -4,7 +4,8 @@ import Set from "../PMCG5"
 const card: Card = {
 	set: Set,
 	name: {
-		ja: "良いマナー",
+		// Good Manners
+		ja: "礼儀作法",
 	},
 
 	rarity: "Uncommon",
@@ -13,6 +14,9 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 576798
+			},
 		},
 	],
 };

--- a/data-asia/PMCG/PMCG5/082.ts
+++ b/data-asia/PMCG/PMCG5/082.ts
@@ -4,7 +4,6 @@ import Set from "../PMCG5"
 const card: Card = {
 	set: Set,
 	name: {
-		// Good Manners
 		ja: "礼儀作法",
 	},
 	illustrator: "Ken Sugimori",

--- a/data-asia/PMCG/PMCG5/083.ts
+++ b/data-asia/PMCG/PMCG5/083.ts
@@ -4,6 +4,7 @@ import Set from "../PMCG5"
 const card: Card = {
 	set: Set,
 	name: {
+		// Erika
 		ja: "エリカ",
 	},
 
@@ -13,6 +14,9 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 576776
+			},
 		},
 	],
 };

--- a/data-asia/PMCG/PMCG5/083.ts
+++ b/data-asia/PMCG/PMCG5/083.ts
@@ -4,7 +4,6 @@ import Set from "../PMCG5"
 const card: Card = {
 	set: Set,
 	name: {
-		// Erika
 		ja: "エリカ",
 	},
 	illustrator: "Ken Sugimori",

--- a/data-asia/PMCG/PMCG5/083.ts
+++ b/data-asia/PMCG/PMCG5/083.ts
@@ -7,7 +7,7 @@ const card: Card = {
 		// Erika
 		ja: "エリカ",
 	},
-
+	illustrator: "Ken Sugimori",
 	rarity: "Rare",
 	category: "Trainer",
 

--- a/data-asia/PMCG/PMCG5/084.ts
+++ b/data-asia/PMCG/PMCG5/084.ts
@@ -4,7 +4,8 @@ import Set from "../PMCG5"
 const card: Card = {
 	set: Set,
 	name: {
-		ja: "エリカの優しさ",
+		// Erika's Kindness
+		ja: "エリカの親切",
 	},
 
 	rarity: "Rare",
@@ -13,6 +14,9 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 576788
+			},
 		},
 	],
 };

--- a/data-asia/PMCG/PMCG5/084.ts
+++ b/data-asia/PMCG/PMCG5/084.ts
@@ -4,7 +4,6 @@ import Set from "../PMCG5"
 const card: Card = {
 	set: Set,
 	name: {
-		// Erika's Kindness
 		ja: "エリカの親切",
 	},
 	illustrator: "Ken Sugimori",

--- a/data-asia/PMCG/PMCG5/084.ts
+++ b/data-asia/PMCG/PMCG5/084.ts
@@ -7,6 +7,7 @@ const card: Card = {
 		// Erika's Kindness
 		ja: "エリカの親切",
 	},
+	illustrator: "Ken Sugimori",
 
 	rarity: "Rare",
 	category: "Trainer",

--- a/data-asia/PMCG/PMCG5/085.ts
+++ b/data-asia/PMCG/PMCG5/085.ts
@@ -4,7 +4,8 @@ import Set from "../PMCG5"
 const card: Card = {
 	set: Set,
 	name: {
-		ja: "霧",
+		// Misty
+		ja: "カスミ",
 	},
 
 	rarity: "Rare",
@@ -13,6 +14,9 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 576814
+			},
 		},
 	],
 };

--- a/data-asia/PMCG/PMCG5/085.ts
+++ b/data-asia/PMCG/PMCG5/085.ts
@@ -7,7 +7,7 @@ const card: Card = {
 		// Misty
 		ja: "カスミ",
 	},
-
+	illustrator: "Ken Sugimori",
 	rarity: "Rare",
 	category: "Trainer",
 

--- a/data-asia/PMCG/PMCG5/085.ts
+++ b/data-asia/PMCG/PMCG5/085.ts
@@ -4,7 +4,6 @@ import Set from "../PMCG5"
 const card: Card = {
 	set: Set,
 	name: {
-		// Misty
 		ja: "カスミ",
 	},
 	illustrator: "Ken Sugimori",

--- a/data-asia/PMCG/PMCG5/086.ts
+++ b/data-asia/PMCG/PMCG5/086.ts
@@ -4,7 +4,8 @@ import Set from "../PMCG5"
 const card: Card = {
 	set: Set,
 	name: {
-		ja: "ミスティの願い",
+		// Misty's Wish
+		ja: "カスミのわがまま",
 	},
 
 	rarity: "Rare",
@@ -13,6 +14,9 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 576832
+			},
 		},
 	],
 };

--- a/data-asia/PMCG/PMCG5/086.ts
+++ b/data-asia/PMCG/PMCG5/086.ts
@@ -4,7 +4,6 @@ import Set from "../PMCG5"
 const card: Card = {
 	set: Set,
 	name: {
-		// Misty's Wish
 		ja: "カスミのわがまま",
 	},
 	illustrator: "Ken Sugimori",

--- a/data-asia/PMCG/PMCG5/086.ts
+++ b/data-asia/PMCG/PMCG5/086.ts
@@ -7,7 +7,7 @@ const card: Card = {
 		// Misty's Wish
 		ja: "カスミのわがまま",
 	},
-
+	illustrator: "Ken Sugimori",
 	rarity: "Rare",
 	category: "Trainer",
 

--- a/data-asia/PMCG/PMCG5/087.ts
+++ b/data-asia/PMCG/PMCG5/087.ts
@@ -7,7 +7,7 @@ const card: Card = {
 		// Chaos Gym
 		ja: "錯乱ジム",
 	},
-
+	illustrator: "Kenji Kinebuchi",
 	rarity: "Rare",
 	category: "Trainer",
 

--- a/data-asia/PMCG/PMCG5/087.ts
+++ b/data-asia/PMCG/PMCG5/087.ts
@@ -4,7 +4,6 @@ import Set from "../PMCG5"
 const card: Card = {
 	set: Set,
 	name: {
-		// Chaos Gym
 		ja: "錯乱ジム",
 	},
 	illustrator: "Kenji Kinebuchi",

--- a/data-asia/PMCG/PMCG5/087.ts
+++ b/data-asia/PMCG/PMCG5/087.ts
@@ -4,7 +4,8 @@ import Set from "../PMCG5"
 const card: Card = {
 	set: Set,
 	name: {
-		ja: "カオスジム",
+		// Chaos Gym
+		ja: "錯乱ジム",
 	},
 
 	rarity: "Rare",
@@ -13,6 +14,9 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 576773
+			},
 		},
 	],
 };

--- a/data-asia/PMCG/PMCG5/088.ts
+++ b/data-asia/PMCG/PMCG5/088.ts
@@ -7,7 +7,7 @@ const card: Card = {
 		// Secret Mission
 		ja: "スパイ作戦",
 	},
-
+	illustrator: "Ken Sugimori",
 	rarity: "Uncommon",
 	category: "Trainer",
 

--- a/data-asia/PMCG/PMCG5/088.ts
+++ b/data-asia/PMCG/PMCG5/088.ts
@@ -4,7 +4,8 @@ import Set from "../PMCG5"
 const card: Card = {
 	set: Set,
 	name: {
-		ja: "秘密の使命",
+		// Secret Mission
+		ja: "スパイ作戦",
 	},
 
 	rarity: "Uncommon",
@@ -13,6 +14,9 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 576842
+			},
 		},
 	],
 };

--- a/data-asia/PMCG/PMCG5/088.ts
+++ b/data-asia/PMCG/PMCG5/088.ts
@@ -4,7 +4,6 @@ import Set from "../PMCG5"
 const card: Card = {
 	set: Set,
 	name: {
-		// Secret Mission
 		ja: "スパイ作戦",
 	},
 	illustrator: "Ken Sugimori",

--- a/data-asia/PMCG/PMCG5/089.ts
+++ b/data-asia/PMCG/PMCG5/089.ts
@@ -7,7 +7,7 @@ const card: Card = {
 		// Brock
 		ja: "タケシ",
 	},
-
+	illustrator: "Ken Sugimori",
 	rarity: "Rare",
 	category: "Trainer",
 

--- a/data-asia/PMCG/PMCG5/089.ts
+++ b/data-asia/PMCG/PMCG5/089.ts
@@ -4,7 +4,8 @@ import Set from "../PMCG5"
 const card: Card = {
 	set: Set,
 	name: {
-		ja: "ブロック",
+		// Brock
+		ja: "タケシ",
 	},
 
 	rarity: "Rare",
@@ -13,6 +14,9 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 576750
+			},
 		},
 	],
 };

--- a/data-asia/PMCG/PMCG5/089.ts
+++ b/data-asia/PMCG/PMCG5/089.ts
@@ -4,7 +4,6 @@ import Set from "../PMCG5"
 const card: Card = {
 	set: Set,
 	name: {
-		// Brock
 		ja: "タケシ",
 	},
 	illustrator: "Ken Sugimori",

--- a/data-asia/PMCG/PMCG5/090.ts
+++ b/data-asia/PMCG/PMCG5/090.ts
@@ -7,7 +7,7 @@ const card: Card = {
 		// Brock's Protection
 		ja: "タケシの保護",
 	},
-
+	illustrator: "Ken Sugimori",
 	rarity: "Rare",
 	category: "Trainer",
 

--- a/data-asia/PMCG/PMCG5/090.ts
+++ b/data-asia/PMCG/PMCG5/090.ts
@@ -4,7 +4,6 @@ import Set from "../PMCG5"
 const card: Card = {
 	set: Set,
 	name: {
-		// Brock's Protection
 		ja: "タケシの保護",
 	},
 	illustrator: "Ken Sugimori",

--- a/data-asia/PMCG/PMCG5/090.ts
+++ b/data-asia/PMCG/PMCG5/090.ts
@@ -4,7 +4,8 @@ import Set from "../PMCG5"
 const card: Card = {
 	set: Set,
 	name: {
-		ja: "ブロックの保護",
+		// Brock's Protection
+		ja: "タケシの保護",
 	},
 
 	rarity: "Rare",
@@ -13,6 +14,9 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 576762
+			},
 		},
 	],
 };

--- a/data-asia/PMCG/PMCG5/091.ts
+++ b/data-asia/PMCG/PMCG5/091.ts
@@ -7,7 +7,7 @@ const card: Card = {
 		// Resistance Gym
 		ja: "抵抗力低下ジム",
 	},
-
+	illustrator: "Kenji Kinebuchi",
 	rarity: "Rare",
 	category: "Trainer",
 

--- a/data-asia/PMCG/PMCG5/091.ts
+++ b/data-asia/PMCG/PMCG5/091.ts
@@ -4,7 +4,6 @@ import Set from "../PMCG5"
 const card: Card = {
 	set: Set,
 	name: {
-		// Resistance Gym
 		ja: "抵抗力低下ジム",
 	},
 	illustrator: "Kenji Kinebuchi",

--- a/data-asia/PMCG/PMCG5/091.ts
+++ b/data-asia/PMCG/PMCG5/091.ts
@@ -4,7 +4,8 @@ import Set from "../PMCG5"
 const card: Card = {
 	set: Set,
 	name: {
-		ja: "レジスタンスジム",
+		// Resistance Gym
+		ja: "抵抗力低下ジム",
 	},
 
 	rarity: "Rare",
@@ -13,6 +14,9 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 576838
+			},
 		},
 	],
 };

--- a/data-asia/PMCG/PMCG5/092.ts
+++ b/data-asia/PMCG/PMCG5/092.ts
@@ -4,7 +4,6 @@ import Set from "../PMCG5"
 const card: Card = {
 	set: Set,
 	name: {
-		// Lt. Surge
 		ja: "マチス",
 	},
 	illustrator: "Ken Sugimori",

--- a/data-asia/PMCG/PMCG5/092.ts
+++ b/data-asia/PMCG/PMCG5/092.ts
@@ -7,7 +7,7 @@ const card: Card = {
 		// Lt. Surge
 		ja: "マチス",
 	},
-
+	illustrator: "Ken Sugimori",
 	rarity: "Rare",
 	category: "Trainer",
 

--- a/data-asia/PMCG/PMCG5/092.ts
+++ b/data-asia/PMCG/PMCG5/092.ts
@@ -4,7 +4,8 @@ import Set from "../PMCG5"
 const card: Card = {
 	set: Set,
 	name: {
-		ja: "中佐",
+		// Lt. Surge
+		ja: "マチス",
 	},
 
 	rarity: "Rare",
@@ -13,6 +14,9 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 576799
+			},
 		},
 	],
 };

--- a/data-asia/PMCG/PMCG5/093.ts
+++ b/data-asia/PMCG/PMCG5/093.ts
@@ -4,7 +4,6 @@ import Set from "../PMCG5"
 const card: Card = {
 	set: Set,
 	name: {
-		// Lt. Surge's Secret Plan
 		ja: "マチスの秘策",
 	},
 	illustrator: "Ken Sugimori",

--- a/data-asia/PMCG/PMCG5/093.ts
+++ b/data-asia/PMCG/PMCG5/093.ts
@@ -7,7 +7,7 @@ const card: Card = {
 		// Lt. Surge's Secret Plan
 		ja: "マチスの秘策",
 	},
-
+	illustrator: "Ken Sugimori",
 	rarity: "Rare",
 	category: "Trainer",
 

--- a/data-asia/PMCG/PMCG5/093.ts
+++ b/data-asia/PMCG/PMCG5/093.ts
@@ -4,7 +4,8 @@ import Set from "../PMCG5"
 const card: Card = {
 	set: Set,
 	name: {
-		ja: "Surgeの秘密計画中",
+		// Lt. Surge's Secret Plan
+		ja: "マチスの秘策",
 	},
 
 	rarity: "Rare",
@@ -13,6 +14,9 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 576810
+			},
 		},
 	],
 };

--- a/data-asia/PMCG/PMCG5/094.ts
+++ b/data-asia/PMCG/PMCG5/094.ts
@@ -7,7 +7,7 @@ const card: Card = {
 		// No Removal Gym
 		ja: "リムーブ禁止ジム",
 	},
-
+	illustrator: "Kenji Kinebuchi",
 	rarity: "Rare",
 	category: "Trainer",
 

--- a/data-asia/PMCG/PMCG5/094.ts
+++ b/data-asia/PMCG/PMCG5/094.ts
@@ -4,7 +4,8 @@ import Set from "../PMCG5"
 const card: Card = {
 	set: Set,
 	name: {
-		ja: "除去ジムはありません",
+		// No Removal Gym
+		ja: "リムーブ禁止ジム",
 	},
 
 	rarity: "Rare",
@@ -13,6 +14,9 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 576835
+			},
 		},
 	],
 };

--- a/data-asia/PMCG/PMCG5/094.ts
+++ b/data-asia/PMCG/PMCG5/094.ts
@@ -4,7 +4,6 @@ import Set from "../PMCG5"
 const card: Card = {
 	set: Set,
 	name: {
-		// No Removal Gym
 		ja: "リムーブ禁止ジム",
 	},
 	illustrator: "Kenji Kinebuchi",

--- a/data-asia/PMCG/PMCG5/095.ts
+++ b/data-asia/PMCG/PMCG5/095.ts
@@ -7,7 +7,7 @@ const card: Card = {
 		// The Rocket's Training Gym
 		ja: "ロケット団の特訓ジム",
 	},
-
+	illustrator: "Kenji Kinebuchi",
 	rarity: "Rare",
 	category: "Trainer",
 

--- a/data-asia/PMCG/PMCG5/095.ts
+++ b/data-asia/PMCG/PMCG5/095.ts
@@ -4,7 +4,8 @@ import Set from "../PMCG5"
 const card: Card = {
 	set: Set,
 	name: {
-		ja: "ロケットのトレーニングジム",
+		// The Rocket's Training Gym
+		ja: "ロケット団の特訓ジム",
 	},
 
 	rarity: "Rare",

--- a/data-asia/PMCG/PMCG5/095.ts
+++ b/data-asia/PMCG/PMCG5/095.ts
@@ -4,7 +4,6 @@ import Set from "../PMCG5"
 const card: Card = {
 	set: Set,
 	name: {
-		// The Rocket's Training Gym
 		ja: "ロケット団の特訓ジム",
 	},
 	illustrator: "Kenji Kinebuchi",

--- a/data-asia/PMCG/PMCG5/096.ts
+++ b/data-asia/PMCG/PMCG5/096.ts
@@ -4,7 +4,6 @@ import Set from "../PMCG5"
 const card: Card = {
 	set: Set,
 	name: {
-		// The Rocket's Trap
 		ja: "ロケット団のワナ",
 	},
 	illustrator: "Ken Sugimori",

--- a/data-asia/PMCG/PMCG5/096.ts
+++ b/data-asia/PMCG/PMCG5/096.ts
@@ -7,7 +7,7 @@ const card: Card = {
 		// The Rocket's Trap
 		ja: "ロケット団のワナ",
 	},
-
+	illustrator: "Ken Sugimori",
 	rarity: "Holo Rare",
 	category: "Trainer",
 

--- a/data-asia/PMCG/PMCG5/096.ts
+++ b/data-asia/PMCG/PMCG5/096.ts
@@ -4,7 +4,8 @@ import Set from "../PMCG5"
 const card: Card = {
 	set: Set,
 	name: {
-		ja: "ロケットのtrap",
+		// The Rocket's Trap
+		ja: "ロケット団のワナ",
 	},
 
 	rarity: "Holo Rare",


### PR DESCRIPTION
closes #1719

## Changes

- corrected japanese names (changed to match exactly as displayed on card. card is truth source)
- added tcgplayer thirdparty object in variant 
- added illustrators

## Details

- corrections made to card set 
- todo upload images