### PR TITLE
(data) Add Japanese Mega set M4 Ninja Spinner

### DIFF
--- a/data-asia/M/M4.ts
+++ b/data-asia/M/M4.ts
@@ -1,0 +1,20 @@
+import { Set } from "../../interfaces";
+import serie from "../M";
+
+const set: Set = {
+	id: "M4",
+	name: {
+		ja: "ニンジャスピナー",
+	},
+
+	serie: serie,
+
+	cardCount: {
+		official: 83,
+	},
+	releaseDate: {
+		ja: "2026-03-13",
+	},
+};
+
+export default set;

--- a/data-asia/M/M4/001.ts
+++ b/data-asia/M/M4/001.ts
@@ -1,0 +1,50 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ビードル",
+	},
+
+	illustrator: "sowsow",
+	category: "Pokemon",
+	hp: 50,
+	types: ["Grass"],
+
+	description: {
+		ja: "森や 草地に 多く 生息。 頭の 先に ５センチぐらいの 小さく 鋭い 毒針を持つ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ふいをつく" },
+			damage: 30,
+			cost: ["Grass"],
+			effect: {
+				ja: "コインを1回投げウラなら、このワザは失敗。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 876898,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "J",
+	rarity: "Common",
+	dexId: [13],
+};
+
+export default card;

--- a/data-asia/M/M4/002.ts
+++ b/data-asia/M/M4/002.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "コクーン",
+	},
+
+	illustrator: "Mugi Hamada",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Grass"],
+
+	description: {
+		ja: "自分では ほとんど 動けないが 危ないときは 硬くなって 身を守っているようだ。",
+	},
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "かたいからだ" },
+			effect: {
+				ja: "このポケモンが受けるワザのダメージは「-20」される。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ぶらさがる" },
+			damage: 20,
+			cost: ["Grass"],
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 876900,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ビードル",
+	},
+
+	retreat: 3,
+	regulationMark: "J",
+	rarity: "Common",
+	dexId: [14],
+};
+
+export default card;

--- a/data-asia/M/M4/003.ts
+++ b/data-asia/M/M4/003.ts
@@ -1,0 +1,52 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "スピアーex",
+	},
+
+	illustrator: "toriyufu",
+	category: "Pokemon",
+	hp: 310,
+	types: ["Grass"],
+
+	stage: "Stage2",
+
+	attacks: [
+		{
+			name: { ja: "ビーランブル" },
+			damage: "110×",
+			cost: ["Grass"],
+			effect: {
+				ja: "自分の場の「スピアー（『ポケモンex』をふくむ）」の数×110ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 876901,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "コクーン",
+	},
+
+	retreat: 1,
+	regulationMark: "J",
+	rarity: "Double rare",
+	dexId: [15],
+
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/M/M4/004.ts
+++ b/data-asia/M/M4/004.ts
@@ -1,0 +1,50 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "マスキッパ",
+	},
+
+	illustrator: "Heisuke Kitazawa",
+	category: "Pokemon",
+	hp: 110,
+	types: ["Grass"],
+
+	description: {
+		ja: "甘い においの だえきで 獲物を おびき寄せ おおあごで がぶり。 １日 かけて 獲物を 食べる。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "まるかじり" },
+			damage: "80+",
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンのにげるためのエネルギーがないなら、80ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 876902,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "J",
+	rarity: "Common",
+	dexId: [455],
+};
+
+export default card;

--- a/data-asia/M/M4/005.ts
+++ b/data-asia/M/M4/005.ts
@@ -1,0 +1,52 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ハリマロン",
+	},
+
+	illustrator: "HACCAN",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Grass"],
+
+	description: {
+		ja: "普段 やわらかい 頭の トゲは 力を こめると 鋭く 尖り 岩をも つらぬくほど 硬くなる。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "たたく" },
+			damage: 10,
+			cost: ["Grass"],
+		},
+		{
+			name: { ja: "トゲでさす" },
+			damage: 30,
+			cost: ["Grass", "Grass"],
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 876903,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "J",
+	rarity: "Common",
+	dexId: [650],
+};
+
+export default card;

--- a/data-asia/M/M4/006.ts
+++ b/data-asia/M/M4/006.ts
@@ -1,0 +1,59 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ハリボーグ",
+	},
+
+	illustrator: "Hideki Ishikawa",
+	category: "Pokemon",
+	hp: 100,
+	types: ["Grass"],
+
+	description: {
+		ja: "仲間同士で 体を ぶつけ合い 足腰を 鍛える。 自分からは 戦わない 優しい 性格。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "リーフチャージ" },
+			damage: 20,
+			cost: ["Grass"],
+			effect: {
+				ja: "自分の山札から「基本[G]エネルギー」を1枚選び、このポケモンにつける。そして山札を切る。",
+			},
+		},
+		{
+			name: { ja: "つるのムチ" },
+			damage: 80,
+			cost: ["Grass", "Grass", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 876904,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ハリマロン",
+	},
+
+	retreat: 3,
+	regulationMark: "J",
+	rarity: "Common",
+	dexId: [651],
+};
+
+export default card;

--- a/data-asia/M/M4/007.ts
+++ b/data-asia/M/M4/007.ts
@@ -1,0 +1,64 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ブリガロン",
+	},
+
+	illustrator: "Uta",
+	category: "Pokemon",
+	hp: 180,
+	types: ["Grass"],
+
+	description: {
+		ja: "体当たりで ５０トンの 戦車を ひっくり返す パワー。 自分が 盾となって 仲間を 守る。",
+	},
+
+	stage: "Stage2",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ニードルアーマー" },
+			effect: {
+				ja: "このポケモンが、バトル場で相手のポケモンからワザのダメージを受けたとき、このポケモンについている[G]エネルギーの数×3個ぶんのダメカンを、ワザを使ったポケモンにのせる。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "かこいこむ" },
+			damage: 160,
+			cost: ["Grass", "Grass", "Colorless"],
+			effect: {
+				ja: "次の相手の番、このワザを受けたポケモンは、にげられない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 876905,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ハリボーグ",
+	},
+
+	retreat: 4,
+	regulationMark: "J",
+	rarity: "Rare",
+	dexId: [652],
+};
+
+export default card;

--- a/data-asia/M/M4/008.ts
+++ b/data-asia/M/M4/008.ts
@@ -1,0 +1,49 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ロコン",
+	},
+
+	illustrator: "Yoshimoto Yoshimon",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Fire"],
+
+	description: {
+		ja: "温かい ６本の 尻尾は 体が 育つごとに 毛並みが 良くなり 美しく なっていく。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "こがす" },
+			cost: ["Fire"],
+			effect: {
+				ja: "相手のバトルポケモンをやけどにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 876906,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "J",
+	rarity: "Common",
+	dexId: [37],
+};
+
+export default card;

--- a/data-asia/M/M4/009.ts
+++ b/data-asia/M/M4/009.ts
@@ -1,0 +1,58 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "キュウコン",
+	},
+
+	illustrator: "Ryuta Fuse",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Fire"],
+
+	description: {
+		ja: "黄金に 輝く 体毛と ９本の 長い 尻尾を 持つ。 １０００年は 生きると 言われる。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "きゅうびうつし" },
+			cost: ["Fire"],
+			effect: {
+				ja: "自分のベンチポケモンを1匹選び、選んだポケモンにのっているダメカンをすべて、相手のバトルポケモンにのせ替える。",
+			},
+		},
+		{
+			name: { ja: "おにび" },
+			damage: 70,
+			cost: ["Fire", "Fire"],
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 876907,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ロコン",
+	},
+
+	retreat: 1,
+	regulationMark: "J",
+	rarity: "Uncommon",
+	dexId: [38],
+};
+
+export default card;

--- a/data-asia/M/M4/010.ts
+++ b/data-asia/M/M4/010.ts
@@ -1,0 +1,57 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ホウオウ",
+	},
+
+	illustrator: "Takumi Wada",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Fire"],
+
+	description: {
+		ja: "体は 七色に 輝き 飛んだあとは 虹が できると 神話に 残されている ポケモン。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "さいきのほのお" },
+			cost: ["Fire"],
+			effect: {
+				ja: "自分のトラッシュからたねポケモンを3枚まで選び、ベンチに出す。",
+			},
+		},
+		{
+			name: { ja: "ぐれんのつばさ" },
+			damage: 130,
+			cost: ["Fire", "Fire", "Fire"],
+			effect: {
+				ja: "このポケモンについている[R]エネルギーを1個選び、トラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 876908,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "J",
+	rarity: "Uncommon",
+	dexId: [250],
+};
+
+export default card;

--- a/data-asia/M/M4/011.ts
+++ b/data-asia/M/M4/011.ts
@@ -1,0 +1,54 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "フォッコ",
+	},
+
+	illustrator: "saino misaki",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Fire"],
+
+	description: {
+		ja: "小枝を 食べると 元気になって 摂氏２００度を 超える 熱気を 大きな 耳から 噴き出す。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "なかまをよぶ" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札からたねポケモンを2枚まで選び、ベンチに出す。そして山札を切る。",
+			},
+		},
+		{
+			name: { ja: "ひをはく" },
+			damage: 10,
+			cost: ["Fire"],
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 876909,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "J",
+	rarity: "Common",
+	dexId: [653],
+};
+
+export default card;

--- a/data-asia/M/M4/012.ts
+++ b/data-asia/M/M4/012.ts
@@ -1,0 +1,54 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "テールナー",
+	},
+
+	illustrator: "Taiga Kasai",
+	category: "Pokemon",
+	hp: 100,
+	types: ["Fire"],
+
+	description: {
+		ja: "木の枝を 尻尾に 挿している。 尻尾の 毛の 摩擦熱で 枝に 火をつけて 戦う。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "かえんほうしゃ" },
+			damage: 80,
+			cost: ["Fire", "Fire"],
+			effect: {
+				ja: "このポケモンについているエネルギーを1個選び、トラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 876911,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "フォッコ",
+	},
+
+	retreat: 1,
+	regulationMark: "J",
+	rarity: "Common",
+	dexId: [654],
+};
+
+export default card;

--- a/data-asia/M/M4/013.ts
+++ b/data-asia/M/M4/013.ts
@@ -1,0 +1,64 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "マフォクシー",
+	},
+
+	illustrator: "Gemi",
+	category: "Pokemon",
+	hp: 160,
+	types: ["Fire"],
+
+	description: {
+		ja: "摂氏３０００度の 炎の 渦を 超能力で 操る。 敵を 渦で 包み 焼きつくす。",
+	},
+
+	stage: "Stage2",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "フレアマジック" },
+			effect: {
+				ja: "自分の番に、自分の手札から「基本[R]エネルギー」を1枚トラッシュするなら、1回使える。自分の手札が7枚になるように、山札を引く。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "エナジーストーム" },
+			damage: "30×",
+			cost: ["Fire", "Fire"],
+			effect: {
+				ja: "おたがいのポケモン全員についているエネルギーの数×30ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 876912,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "テールナー",
+	},
+
+	retreat: 2,
+	regulationMark: "J",
+	rarity: "Rare",
+	dexId: [655],
+};
+
+export default card;

--- a/data-asia/M/M4/014.ts
+++ b/data-asia/M/M4/014.ts
@@ -1,0 +1,47 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "シシコ",
+	},
+
+	illustrator: "Mina Nakai",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Fire"],
+
+	description: {
+		ja: "強くなるため 群れを 離れて １匹で 生活するようになる。 血気盛んで ケンカっ早い。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "たいあたり" },
+			damage: 10,
+			cost: ["Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 876913,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "J",
+	rarity: "Common",
+	dexId: [667],
+};
+
+export default card;

--- a/data-asia/M/M4/015.ts
+++ b/data-asia/M/M4/015.ts
@@ -1,0 +1,59 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "メガカエンジシex",
+	},
+
+	illustrator: "Keisuke Azuma",
+	category: "Pokemon",
+	hp: 340,
+	types: ["Fire"],
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "ほえたてる" },
+			damage: 80,
+			cost: ["Fire", "Colorless"],
+			effect: {
+				ja: "次の相手の番、このワザを受けたポケモンが使うワザのダメージは「-50」される。",
+			},
+		},
+		{
+			name: { ja: "ビッグバンファイヤー 290-" },
+			cost: ["Fire", "Fire", "Colorless"],
+			effect: {
+				ja: "このポケモンにのっているダメカンの数×10ダメージぶん、このワザのダメージは小さくなる。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 876914,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "シシコ",
+	},
+
+	retreat: 2,
+	regulationMark: "J",
+	rarity: "Double rare",
+	dexId: [668],
+
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/M/M4/016.ts
+++ b/data-asia/M/M4/016.ts
@@ -1,0 +1,47 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "テッポウオ",
+	},
+
+	illustrator: "Mori Yuu",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Water"],
+
+	description: {
+		ja: "口から 噴き出す 水流は １００メートル先で 動く 獲物に だって 命中する。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "するどいひれ" },
+			damage: 20,
+			cost: ["Water"],
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 876915,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "J",
+	rarity: "Common",
+	dexId: [223],
+};
+
+export default card;

--- a/data-asia/M/M4/017.ts
+++ b/data-asia/M/M4/017.ts
@@ -1,0 +1,62 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "オクタン",
+	},
+
+	illustrator: "matazo",
+	category: "Pokemon",
+	hp: 110,
+	types: ["Water"],
+
+	description: {
+		ja: "穴に 入りたがる 性質で ほかの ポケモンが 作った 巣穴を 横取りして 眠る。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "すみふんしゃ" },
+			damage: 30,
+			cost: ["Water"],
+			effect: {
+				ja: "次の相手の番、このワザを受けたポケモンがワザを使うとき、相手はコインを2回投げる。1回でもウラなら、そのワザは失敗。",
+			},
+		},
+		{
+			name: { ja: "あばれまわる" },
+			damage: 120,
+			cost: ["Water", "Colorless"],
+			effect: {
+				ja: "このポケモンをこんらんにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 876916,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "テッポウオ",
+	},
+
+	retreat: 2,
+	regulationMark: "J",
+	rarity: "Common",
+	dexId: [224],
+};
+
+export default card;

--- a/data-asia/M/M4/018.ts
+++ b/data-asia/M/M4/018.ts
@@ -1,0 +1,54 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "デリバード",
+	},
+
+	illustrator: "Saboteri",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Water"],
+
+	description: {
+		ja: "尻尾で エサを 包んで 運ぶ。 山で 遭難した 人に エサを 分け与える 習性。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ハッピープレゼント" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "おたがいのプレイヤーは、のぞむなら、それぞれ自分の手札から基本エネルギーを3枚まで選び、自分のポケモンに好きなようにつける。（相手から行う。）",
+			},
+		},
+		{
+			name: { ja: "はばたく" },
+			damage: 40,
+			cost: ["Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 876917,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "J",
+	rarity: "Uncommon",
+	dexId: [225],
+};
+
+export default card;

--- a/data-asia/M/M4/019.ts
+++ b/data-asia/M/M4/019.ts
@@ -1,0 +1,58 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ケルディオ",
+	},
+
+	illustrator: "Mitsuhiro Arita",
+	category: "Pokemon",
+	hp: 110,
+	types: ["Water"],
+
+	description: {
+		ja: "戦う 覚悟を 決めたことで 全身に 気力が みなぎり ケルディオの 姿を 変えた。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "つきぬける" },
+			damage: 20,
+			cost: ["Water"],
+			effect: {
+				ja: "相手のベンチポケモン1匹にも、20ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+			},
+		},
+		{
+			name: { ja: "エネリフレクト" },
+			damage: 70,
+			cost: ["Water", "Water"],
+			effect: {
+				ja: "このポケモンについているエネルギーを1個選び、ベンチポケモンにつけ替える。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 876918,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "J",
+	rarity: "Uncommon",
+	dexId: [647],
+};
+
+export default card;

--- a/data-asia/M/M4/020.ts
+++ b/data-asia/M/M4/020.ts
@@ -1,0 +1,54 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ケロマツ",
+	},
+
+	illustrator: "Kariya",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Water"],
+
+	description: {
+		ja: "繊細な 泡で 体を 包み 肌を 守る。 のんきに 見せかけ 抜け目なく 周囲を うかがう。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "もってくる" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札を1枚引く。",
+			},
+		},
+		{
+			name: { ja: "みずでっぽう" },
+			damage: 10,
+			cost: ["Water"],
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 876919,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "J",
+	rarity: "Common",
+	dexId: [656],
+};
+
+export default card;

--- a/data-asia/M/M4/021.ts
+++ b/data-asia/M/M4/021.ts
@@ -1,0 +1,58 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ゲコガシラ",
+	},
+
+	illustrator: "Nelnal",
+	category: "Pokemon",
+	hp: 100,
+	types: ["Water"],
+
+	description: {
+		ja: "身軽さは だれにも 負けない。 ６００メートルを 超える タワーの 天辺まで １分で 登りきる。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "よびよせのじゅつ" },
+			cost: ["Water"],
+			effect: {
+				ja: "自分の山札からポケモンを3枚まで選び、相手に見せて、手札に加える。そして山札を切る。",
+			},
+		},
+		{
+			name: { ja: "アクアエッジ" },
+			damage: 50,
+			cost: ["Water", "Water"],
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 876920,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ケロマツ",
+	},
+
+	retreat: 1,
+	regulationMark: "J",
+	rarity: "Common",
+	dexId: [657],
+};
+
+export default card;

--- a/data-asia/M/M4/022.ts
+++ b/data-asia/M/M4/022.ts
@@ -1,0 +1,62 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "メガゲッコウガex",
+	},
+
+	illustrator: "takuyoa",
+	category: "Pokemon",
+	hp: 350,
+	types: ["Water"],
+
+	stage: "Stage2",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ひっさつしゅりけん" },
+			effect: {
+				ja: "このポケモンがバトル場にいて、自分の番に、自分の手札から「基本[W]エネルギー」を1枚トラッシュするなら、1回使える。相手のポケモン1匹に、ダメカンを6個のせる。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ニンジャスピナー" },
+			damage: "120+",
+			cost: ["Water", "Water"],
+			effect: {
+				ja: "のぞむなら、このポケモンについている[W]エネルギーを1個手札にもどし、80ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 876921,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ゲコガシラ",
+	},
+
+	retreat: 1,
+	regulationMark: "J",
+	rarity: "Double rare",
+	dexId: [658],
+
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/M/M4/023.ts
+++ b/data-asia/M/M4/023.ts
@@ -1,0 +1,52 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "カチコール",
+	},
+
+	illustrator: "Anesaki Dynamic",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Water"],
+
+	description: {
+		ja: "体を 覆う 氷が 敵の 攻撃を 防ぐ。 割られても 冷気で すぐに 氷を 張る。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ひんやり" },
+			damage: 10,
+			cost: ["Water"],
+		},
+		{
+			name: { ja: "こおりのいぶき" },
+			damage: 50,
+			cost: ["Water", "Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 876922,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "J",
+	rarity: "Common",
+	dexId: [712],
+};
+
+export default card;

--- a/data-asia/M/M4/024.ts
+++ b/data-asia/M/M4/024.ts
@@ -1,0 +1,59 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "クレベース",
+	},
+
+	illustrator: "Tomoki Sone",
+	category: "Pokemon",
+	hp: 160,
+	types: ["Water"],
+
+	description: {
+		ja: "凍りついた 体は 鋼鉄のように 硬い。 邪魔する ものを 巨体で 押しつぶし 移動する。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "ひょうざんくずし" },
+			damage: "60×",
+			cost: ["Water"],
+			effect: {
+				ja: "自分の山札を上から6枚トラッシュし、その中にある「基本[W]エネルギー」の枚数×60ダメージ。",
+			},
+		},
+		{
+			name: { ja: "フロストスタンプ" },
+			damage: 160,
+			cost: ["Water", "Water", "Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 876923,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "カチコール",
+	},
+
+	retreat: 4,
+	regulationMark: "J",
+	rarity: "Uncommon",
+	dexId: [713],
+};
+
+export default card;

--- a/data-asia/M/M4/025.ts
+++ b/data-asia/M/M4/025.ts
@@ -1,0 +1,52 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "コソクムシ",
+	},
+
+	illustrator: "0313",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Water"],
+
+	description: {
+		ja: "腐ったものや ゴミでも なんでも 食べまわる 自然の 掃除屋。 巣の まわりは いつも きれい。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "かじる" },
+			damage: 10,
+			cost: ["Water"],
+		},
+		{
+			name: { ja: "どつく" },
+			damage: 20,
+			cost: ["Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 876924,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "J",
+	rarity: "Common",
+	dexId: [767],
+};
+
+export default card;

--- a/data-asia/M/M4/026.ts
+++ b/data-asia/M/M4/026.ts
@@ -1,0 +1,62 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "グソクムシャ",
+	},
+
+	illustrator: "Takeshi Nakamura",
+	category: "Pokemon",
+	hp: 140,
+	types: ["Water"],
+
+	description: {
+		ja: "勝つためには 手段を 問わない。 相手の 隙を ついて 前脚の 小さな ツメで とどめを 刺す。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "きゅうしょぎり" },
+			damage: 30,
+			cost: ["Water"],
+			effect: {
+				ja: "このワザのダメージで、相手のポケモンがきぜつしたなら、次の相手の番、このポケモンはワザのダメージや効果を受けない。",
+			},
+		},
+		{
+			name: { ja: "そこぢから" },
+			damage: 150,
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "次の自分の番、このポケモンはワザが使えない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 876925,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "コソクムシ",
+	},
+
+	retreat: 2,
+	regulationMark: "J",
+	rarity: "Uncommon",
+	dexId: [768],
+};
+
+export default card;

--- a/data-asia/M/M4/027.ts
+++ b/data-asia/M/M4/027.ts
@@ -1,0 +1,50 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "メリープ",
+	},
+
+	illustrator: "UKUMO uiti",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Lightning"],
+
+	description: {
+		ja: "ふわふわの 体毛は 静電気が 溜まると ２倍に ふくらむ。 触ると 感電してしまう。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "でんじは" },
+			damage: 20,
+			cost: ["Lightning", "Colorless"],
+			effect: {
+				ja: "コインを1回投げオモテなら、相手のバトルポケモンをマヒにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 876926,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "J",
+	rarity: "Common",
+	dexId: [179],
+};
+
+export default card;

--- a/data-asia/M/M4/028.ts
+++ b/data-asia/M/M4/028.ts
@@ -1,0 +1,54 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "モココ",
+	},
+
+	illustrator: "miki kudo",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Lightning"],
+
+	description: {
+		ja: "体毛に 溜めた 電気が 満タンになると 尻尾が 光る。 触れると しびれる 毛を 飛ばす。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "でんじしょうがい" },
+			damage: 40,
+			cost: ["Lightning", "Colorless"],
+			effect: {
+				ja: "次の相手の番、相手は手札からグッズを出して使えない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 876927,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "メリープ",
+	},
+
+	retreat: 2,
+	regulationMark: "J",
+	rarity: "Common",
+	dexId: [180],
+};
+
+export default card;

--- a/data-asia/M/M4/029.ts
+++ b/data-asia/M/M4/029.ts
@@ -1,0 +1,64 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "デンリュウ",
+	},
+
+	illustrator: "CHORISO",
+	category: "Pokemon",
+	hp: 160,
+	types: ["Lightning"],
+
+	description: {
+		ja: "尻尾の 先が 光り輝く。 光は はるか 遠くまで 届き 迷った者の 道標となる。",
+	},
+
+	stage: "Stage2",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "シンクロパルス" },
+			effect: {
+				ja: "自分の手札と相手の手札が同じ枚数なら、このポケモンが使うワザの、相手のバトルポケモンへのダメージは「+80」される。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "フラッシュボルト" },
+			damage: 140,
+			cost: ["Lightning", "Colorless"],
+			effect: {
+				ja: "次の自分の番、このポケモンは「フラッシュボルト」が使えない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 876928,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "モココ",
+	},
+
+	retreat: 2,
+	regulationMark: "J",
+	rarity: "Rare",
+	dexId: [181],
+};
+
+export default card;

--- a/data-asia/M/M4/030.ts
+++ b/data-asia/M/M4/030.ts
@@ -1,0 +1,57 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "エモンガ",
+	},
+
+	illustrator: "Kazumasa Yasukuni",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Lightning"],
+
+	description: {
+		ja: "頬の 電気袋で 作った 電気を 膜の 内側に 溜めて 滑空しながら 電気を 放つ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ちいさなおつかい" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札から基本エネルギーを2枚まで選び、相手に見せて、手札に加える。そして山札を切る。",
+			},
+		},
+		{
+			name: { ja: "スカイリターン" },
+			damage: 30,
+			cost: ["Lightning"],
+			effect: {
+				ja: "このポケモンと、ついているすべてのカードを、手札にもどす。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 876929,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "J",
+	rarity: "Common",
+	dexId: [587],
+};
+
+export default card;

--- a/data-asia/M/M4/031.ts
+++ b/data-asia/M/M4/031.ts
@@ -1,0 +1,57 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "デオキシス",
+	},
+
+	illustrator: "Shiburingaru",
+	category: "Pokemon",
+	hp: 110,
+	types: ["Psychic"],
+
+	description: {
+		ja: "隕石に 付着していた 宇宙ウイルスの ＤＮＡが 変異して 生まれた ポケモン。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ゲノムチャージ" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札から「基本[P]エネルギー」を2枚まで選び、このポケモンにつける。そして山札を切る。",
+			},
+		},
+		{
+			name: { ja: "サイコキネシス" },
+			damage: "80+",
+			cost: ["Psychic", "Psychic", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンについているエネルギーの数×20ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 876930,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "J",
+	rarity: "Uncommon",
+	dexId: [386],
+};
+
+export default card;

--- a/data-asia/M/M4/032.ts
+++ b/data-asia/M/M4/032.ts
@@ -1,0 +1,50 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "デオキシス",
+	},
+
+	illustrator: "nagimiso",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Psychic"],
+
+	description: {
+		ja: "隕石に 付着していた 宇宙ウイルスの ＤＮＡが 変異して 生まれた ポケモン。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "サイコスピア" },
+			damage: 120,
+			cost: ["Psychic", "Psychic", "Psychic"],
+			effect: {
+				ja: "このワザを使うためのエネルギーより、2個多くエネルギーがついているなら、相手のベンチポケモン1匹にも、120ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 876931,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "J",
+	rarity: "Uncommon",
+	dexId: [386],
+};
+
+export default card;

--- a/data-asia/M/M4/033.ts
+++ b/data-asia/M/M4/033.ts
@@ -1,0 +1,50 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "デオキシス",
+	},
+
+	illustrator: "GOSSAN",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Psychic"],
+
+	description: {
+		ja: "隕石に 付着していた 宇宙ウイルスの ＤＮＡが 変異して 生まれた ポケモン。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "サイコプロテクト" },
+			damage: 80,
+			cost: ["Psychic", "Psychic", "Colorless"],
+			effect: {
+				ja: "次の相手の番、このポケモンは特性を持つポケモンからワザのダメージを受けない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 876932,
+			},
+		},
+	],
+
+	retreat: 3,
+	regulationMark: "J",
+	rarity: "Uncommon",
+	dexId: [386],
+};
+
+export default card;

--- a/data-asia/M/M4/034.ts
+++ b/data-asia/M/M4/034.ts
@@ -1,0 +1,50 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "デオキシス",
+	},
+
+	illustrator: "hncl",
+	category: "Pokemon",
+	hp: 100,
+	types: ["Psychic"],
+
+	description: {
+		ja: "隕石に 付着していた 宇宙ウイルスの ＤＮＡが 変異して 生まれた ポケモン。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "サイコスピード" },
+			damage: 30,
+			cost: ["Psychic"],
+			effect: {
+				ja: "のぞむなら、自分の手札が5枚になるように、山札を引く。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 876933,
+			},
+		},
+	],
+
+	retreat: 0,
+	regulationMark: "J",
+	rarity: "Uncommon",
+	dexId: [386],
+};
+
+export default card;

--- a/data-asia/M/M4/035.ts
+++ b/data-asia/M/M4/035.ts
@@ -1,0 +1,55 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "メガフラエッテex",
+	},
+
+	illustrator: "aky CG Works",
+	category: "Pokemon",
+	hp: 250,
+	types: ["Psychic"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "やさしいひかり" },
+			cost: ["Psychic"],
+			effect: {
+				ja: "おたがいのポケモン全員のHPを、それぞれ「30」回復する。",
+			},
+		},
+		{
+			name: { ja: "エタニティブルーム" },
+			damage: 200,
+			cost: ["Psychic", "Psychic", "Psychic"],
+			effect: {
+				ja: "自分の山札から「基本[P]エネルギー」を4枚まで選び、ベンチポケモンに好きなようにつける。そして山札を切る。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 876934,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "J",
+	rarity: "Double rare",
+	dexId: [670],
+
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/M/M4/036.ts
+++ b/data-asia/M/M4/036.ts
@@ -1,0 +1,50 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ニャスパー",
+	},
+
+	illustrator: "sowsow",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Psychic"],
+
+	description: {
+		ja: "強力な サイコパワーが 漏れ出さないように 放出する 器官を 耳で ふさいでいるのだ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "バディアタック" },
+			damage: "10+",
+			cost: ["Psychic"],
+			effect: {
+				ja: "この番に、手札から「マチエール」を出して使っていたなら、60ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 876935,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "J",
+	rarity: "Common",
+	dexId: [677],
+};
+
+export default card;

--- a/data-asia/M/M4/037.ts
+++ b/data-asia/M/M4/037.ts
@@ -1,0 +1,54 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ニャオニクス",
+	},
+
+	illustrator: "mingo",
+	category: "Pokemon",
+	hp: 100,
+	types: ["Psychic"],
+
+	description: {
+		ja: "危険が 迫ると 耳を 持ち上げ １０トン トラックを ひねりつぶす サイコパワーを 解放する。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "トリックステップ" },
+			damage: 80,
+			cost: ["Psychic", "Colorless"],
+			effect: {
+				ja: "のぞむなら、相手のバトルポケモンについているエネルギーを1個選び、相手のベンチポケモンにつけ替える。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 876936,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ニャスパー",
+	},
+
+	retreat: 1,
+	regulationMark: "J",
+	rarity: "Uncommon",
+	dexId: [678],
+};
+
+export default card;

--- a/data-asia/M/M4/038.ts
+++ b/data-asia/M/M4/038.ts
@@ -1,0 +1,57 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ボクレー",
+	},
+
+	illustrator: "Taiga Kasai",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Psychic"],
+
+	description: {
+		ja: "森で さまよい 死んだ 子供の 魂が 切り株に 宿り ポケモンになったと いわれている。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "うらみしんか" },
+			effect: {
+				ja: "自分の番に1回使える。このポケモンから進化するカードを、自分の手札から1枚選び、このポケモンにのせて進化させる。その後、進化させたポケモンに、ダメカンを2個のせる。（最初の自分の番には使えない。）",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "つぶやく" },
+			damage: 10,
+			cost: ["Psychic"],
+		},
+	],
+
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 876937,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "J",
+	rarity: "Common",
+	dexId: [708],
+};
+
+export default card;

--- a/data-asia/M/M4/039.ts
+++ b/data-asia/M/M4/039.ts
@@ -1,0 +1,62 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "オーロット",
+	},
+
+	illustrator: "Uninori",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Psychic"],
+
+	description: {
+		ja: "根っこを 神経の かわりにして 森の 木を 操る。 体に 棲みついた ポケモンには 親切。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "のろいのねっこ" },
+			damage: 30,
+			cost: ["Psychic"],
+			effect: {
+				ja: "次の相手の番、このワザを受けたポケモンは、手札から出すエネルギーをつけられない。",
+			},
+		},
+		{
+			name: { ja: "オーバーペイン" },
+			damage: "60+",
+			cost: ["Psychic", "Psychic"],
+			effect: {
+				ja: "相手のポケモン全員にのっているダメカンの数×10ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 876938,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ボクレー",
+	},
+
+	retreat: 3,
+	regulationMark: "J",
+	rarity: "Rare",
+	dexId: [709],
+};
+
+export default card;

--- a/data-asia/M/M4/040.ts
+++ b/data-asia/M/M4/040.ts
@@ -1,0 +1,47 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "バケッチャ",
+	},
+
+	illustrator: "Jerky",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Psychic"],
+
+	description: {
+		ja: "体の 大きさだけでなく 連れ去る 魂の サイズも 違う 別の 品種と 最近 判明した。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ふむ" },
+			damage: 20,
+			cost: ["Psychic"],
+		},
+	],
+
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 876939,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "J",
+	rarity: "Common",
+	dexId: [710],
+};
+
+export default card;

--- a/data-asia/M/M4/041.ts
+++ b/data-asia/M/M4/041.ts
@@ -1,0 +1,60 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "パンプジンex",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 270,
+	types: ["Psychic"],
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "ホラーロンド" },
+			damage: "30+",
+			cost: ["Psychic"],
+			effect: {
+				ja: "ダメカンがのっている自分のベンチポケモンの数×50ダメージ追加。",
+			},
+		},
+		{
+			name: { ja: "ゴーストタッチ" },
+			damage: 140,
+			cost: ["Psychic", "Psychic"],
+			effect: {
+				ja: "相手の手札からオモテを見ないで1枚選び、トラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 876940,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "バケッチャ",
+	},
+
+	retreat: 2,
+	regulationMark: "J",
+	rarity: "Double rare",
+	dexId: [711],
+
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/M/M4/042.ts
+++ b/data-asia/M/M4/042.ts
@@ -1,0 +1,50 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ゼルネアス",
+	},
+
+	illustrator: "KEIICHIRO ITO",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Psychic"],
+
+	description: {
+		ja: "頭の ツノが 七色に 輝くとき 永遠の 命を 分け与えると いわれている。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ジオストーム" },
+			damage: "30×",
+			cost: ["Psychic", "Psychic", "Psychic"],
+			effect: {
+				ja: "自分のポケモン全員についている[P]エネルギーの数×30ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 876941,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "J",
+	rarity: "Rare",
+	dexId: [716],
+};
+
+export default card;

--- a/data-asia/M/M4/043.ts
+++ b/data-asia/M/M4/043.ts
@@ -1,0 +1,57 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ウソッキー",
+	},
+
+	illustrator: "GOTO minori",
+	category: "Pokemon",
+	hp: 110,
+	types: ["Fighting"],
+
+	description: {
+		ja: "攻撃 されないように ひたすら 木のマネをしているが 水は苦手で 雨になると どこかに 逃げ出す。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "しれんのたび" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札から「変化の書」を2枚まで選び、相手に見せて、手札に加える。そして山札を切る。",
+			},
+		},
+		{
+			name: { ja: "いわとばし" },
+			damage: 30,
+			cost: ["Fighting"],
+			effect: {
+				ja: "このワザのダメージは抵抗力を計算しない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 876942,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "J",
+	rarity: "Uncommon",
+	dexId: [185],
+};
+
+export default card;

--- a/data-asia/M/M4/044.ts
+++ b/data-asia/M/M4/044.ts
@@ -1,0 +1,52 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ゴマゾウ",
+	},
+
+	illustrator: "Akino Fukuji",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Fighting"],
+
+	description: {
+		ja: "見た目より ずっと 力持ち。 振りまわす 鼻に ぶつかると 腕の 骨が もっていかれる。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "どろかけ" },
+			damage: 10,
+			cost: ["Fighting"],
+		},
+		{
+			name: { ja: "ころがる" },
+			damage: 40,
+			cost: ["Colorless", "Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 876943,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "J",
+	rarity: "Common",
+	dexId: [231],
+};
+
+export default card;

--- a/data-asia/M/M4/045.ts
+++ b/data-asia/M/M4/045.ts
@@ -1,0 +1,62 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ドンファン",
+	},
+
+	illustrator: "Julie Hang",
+	category: "Pokemon",
+	hp: 150,
+	types: ["Fighting"],
+
+	description: {
+		ja: "普段は 落ち着いているが 一度 怒らせると 体を 丸めて 回転しながら 突っ込んでくる。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "たたみかける" },
+			damage: 20,
+			cost: ["Fighting"],
+			effect: {
+				ja: "次の自分の番、このポケモンが使うワザの、相手のバトルポケモンへのダメージは「+120」される。",
+			},
+		},
+		{
+			name: { ja: "スマッシュヘッド" },
+			damage: 180,
+			cost: ["Fighting", "Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンについているエネルギーを2個選び、トラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 876944,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ゴマゾウ",
+	},
+
+	retreat: 3,
+	regulationMark: "J",
+	rarity: "Common",
+	dexId: [232],
+};
+
+export default card;

--- a/data-asia/M/M4/046.ts
+++ b/data-asia/M/M4/046.ts
@@ -1,0 +1,50 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヤジロン",
+	},
+
+	illustrator: "Tomomi Ozaki",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Fighting"],
+
+	description: {
+		ja: "一本足で 回転しながら 移動する。 逆さまに なって 回転する ヤジロンも 見かける。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "れんぞくスピン" },
+			damage: "30×",
+			cost: ["Fighting"],
+			effect: {
+				ja: "ウラが出るまでコインを投げ、オモテの数×30ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 876945,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "J",
+	rarity: "Common",
+	dexId: [343],
+};
+
+export default card;

--- a/data-asia/M/M4/047.ts
+++ b/data-asia/M/M4/047.ts
@@ -1,0 +1,54 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ネンドール",
+	},
+
+	illustrator: "Oswaldo KATO",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Fighting"],
+
+	description: {
+		ja: "２万年前の 古代人が つくった 泥人形から 生まれたらしい 謎の ポケモン。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "たいかこうせん" },
+			damage: 50,
+			cost: ["Fighting"],
+			effect: {
+				ja: "相手の進化しているバトルポケモンから、「進化カード」を1枚はがして退化させる。はがしたカードは、相手の手札にもどす。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 876946,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ヤジロン",
+	},
+
+	retreat: 2,
+	regulationMark: "J",
+	rarity: "Uncommon",
+	dexId: [344],
+};
+
+export default card;

--- a/data-asia/M/M4/048.ts
+++ b/data-asia/M/M4/048.ts
@@ -1,0 +1,49 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ズバット",
+	},
+
+	illustrator: "Mékayu",
+	category: "Pokemon",
+	hp: 40,
+	types: ["Darkness"],
+
+	description: {
+		ja: "口から 出す 超音波で まわりの 様子を 探る。 狭い 洞窟も 器用に 飛びまわる。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ちょうおんぱ" },
+			cost: ["Darkness"],
+			effect: {
+				ja: "相手のバトルポケモンをこんらんにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 876947,
+			},
+		},
+	],
+
+	retreat: 0,
+	regulationMark: "J",
+	rarity: "Common",
+	dexId: [41],
+};
+
+export default card;

--- a/data-asia/M/M4/049.ts
+++ b/data-asia/M/M4/049.ts
@@ -1,0 +1,54 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ゴルバット",
+	},
+
+	illustrator: "Mousho",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Darkness"],
+
+	description: {
+		ja: "生き物の 血液が 好物。 腹ペコの 仲間に 吸った 血を 分け与えることも あるという。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "おんみつひこう" },
+			damage: 30,
+			cost: ["Darkness"],
+			effect: {
+				ja: "次の相手の番、このポケモンはたねポケモンからワザのダメージを受けない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 876948,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ズバット",
+	},
+
+	retreat: 1,
+	regulationMark: "J",
+	rarity: "Common",
+	dexId: [42],
+};
+
+export default card;

--- a/data-asia/M/M4/050.ts
+++ b/data-asia/M/M4/050.ts
@@ -1,0 +1,64 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "クロバット",
+	},
+
+	illustrator: "IKEDA Saki",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Darkness"],
+
+	description: {
+		ja: "両足が 羽に 変化。 音を たてずに 高速で 飛び 獲物の うなじに キバを たてる。",
+	},
+
+	stage: "Stage2",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "よるこうさく" },
+			effect: {
+				ja: "このポケモンがバトル場にいるなら、自分の番に1回使える。自分の山札から好きなカードを1枚選ぶ。残りの山札を切り、選んだカードを山札の上にもどす。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "どくおんぱ" },
+			damage: 80,
+			cost: ["Darkness"],
+			effect: {
+				ja: "相手のバトルポケモンをどくとこんらんにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 876949,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ゴルバット",
+	},
+
+	retreat: 1,
+	regulationMark: "J",
+	rarity: "Uncommon",
+	dexId: [169],
+};
+
+export default card;

--- a/data-asia/M/M4/051.ts
+++ b/data-asia/M/M4/051.ts
@@ -1,0 +1,60 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ハリーセン",
+	},
+
+	illustrator: "nisimono",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Darkness"],
+
+	description: {
+		ja: "毒針を 撃ち出した 直後の 無防備な 状態を 狙うと ベテランの 漁師は 語る。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "どくのトゲ" },
+			effect: {
+				ja: "このポケモンが、バトル場で相手のポケモンからワザのダメージを受けたとき、ワザを使ったポケモンをどくにする。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ベノムショック" },
+			damage: "30+",
+			cost: ["Darkness"],
+			effect: {
+				ja: "相手のバトルポケモンがどくなら、50ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 876950,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "J",
+	rarity: "Common",
+	dexId: [211],
+};
+
+export default card;

--- a/data-asia/M/M4/052.ts
+++ b/data-asia/M/M4/052.ts
@@ -1,0 +1,47 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "スカンプー",
+	},
+
+	illustrator: "Nobuhiro Imagawa",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Darkness"],
+
+	description: {
+		ja: "お尻から 飛ばす 液体の 臭いは ２キロも 離れた 人が 具合を 悪くするほど くさい。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ひっかく" },
+			damage: 20,
+			cost: ["Darkness"],
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 876951,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "J",
+	rarity: "Common",
+	dexId: [434],
+};
+
+export default card;

--- a/data-asia/M/M4/053.ts
+++ b/data-asia/M/M4/053.ts
@@ -1,0 +1,59 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "スカタンク",
+	},
+
+	illustrator: "Yuriko Akase",
+	category: "Pokemon",
+	hp: 110,
+	types: ["Darkness"],
+
+	description: {
+		ja: "尻尾の 先から くさい 臭いの 液体を 飛ばして 攻撃。 連射すると 臭いは 弱まる。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "うしろげり" },
+			damage: 40,
+			cost: ["Darkness"],
+		},
+		{
+			name: { ja: "スマッシュターン" },
+			damage: 100,
+			cost: ["Darkness", "Darkness", "Colorless"],
+			effect: {
+				ja: "このポケモンをベンチポケモンと入れ替える。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 876952,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "スカンプー",
+	},
+
+	retreat: 2,
+	regulationMark: "J",
+	rarity: "Uncommon",
+	dexId: [435],
+};
+
+export default card;

--- a/data-asia/M/M4/054.ts
+++ b/data-asia/M/M4/054.ts
@@ -1,0 +1,50 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヤブクロン",
+	},
+
+	illustrator: "Souichirou Gunjima",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Darkness"],
+
+	description: {
+		ja: "ゴミ袋が 産業廃棄物と 化学変化を 起こしたことで ポケモンとして 生まれ変わった。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "アシッドボム" },
+			damage: 10,
+			cost: ["Darkness"],
+			effect: {
+				ja: "コインを1回投げオモテなら、相手のバトルポケモンについているエネルギーを1個選び、トラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 876953,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "J",
+	rarity: "Common",
+	dexId: [568],
+};
+
+export default card;

--- a/data-asia/M/M4/055.ts
+++ b/data-asia/M/M4/055.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ダストダス",
+	},
+
+	illustrator: "HYOGONOSUKE",
+	category: "Pokemon",
+	hp: 140,
+	types: ["Darkness"],
+
+	description: {
+		ja: "ゴミを 吸いとっては 体内で 新しい 種類の 毒ガスや 毒の 液体を 生みだしている。",
+	},
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ゴミダウナー" },
+			effect: {
+				ja: "このポケモンがいるかぎり、「ポケモンのどうぐ」がついている相手のバトルポケモンが使うワザのダメージは「-20」される。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ヘドロばくだん" },
+			damage: 100,
+			cost: ["Darkness", "Darkness", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 876954,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ヤブクロン",
+	},
+
+	retreat: 3,
+	regulationMark: "J",
+	rarity: "Uncommon",
+	dexId: [569],
+};
+
+export default card;

--- a/data-asia/M/M4/056.ts
+++ b/data-asia/M/M4/056.ts
@@ -1,0 +1,47 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "クズモー",
+	},
+
+	illustrator: "Shimaris Yukichi",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Darkness"],
+
+	description: {
+		ja: "腐った 海藻に 擬態する。 気づかずに 近寄ってきた 獲物に 毒液を 浴びせて 仕留める。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ひっかける" },
+			damage: 10,
+			cost: ["Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 876955,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "J",
+	rarity: "Common",
+	dexId: [690],
+};
+
+export default card;

--- a/data-asia/M/M4/057.ts
+++ b/data-asia/M/M4/057.ts
@@ -1,0 +1,52 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ダンバル",
+	},
+
+	illustrator: "toi8",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Metal"],
+
+	description: {
+		ja: "磁力の 波長で 仲間と 交信。 群れになった ダンバルは 一糸乱れぬ 動きを する。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ずつき" },
+			damage: 10,
+			cost: ["Metal"],
+		},
+		{
+			name: { ja: "ビーム" },
+			damage: 20,
+			cost: ["Metal", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Grass", value: "-30" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 876956,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "J",
+	rarity: "Common",
+	dexId: [374],
+};
+
+export default card;

--- a/data-asia/M/M4/058.ts
+++ b/data-asia/M/M4/058.ts
@@ -1,0 +1,59 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "メタング",
+	},
+
+	illustrator: "Kazumasa Yasukuni",
+	category: "Pokemon",
+	hp: 100,
+	types: ["Metal"],
+
+	description: {
+		ja: "２匹の ダンバルが 合体した。 鋼の ボディは ジェット機と 衝突しても 傷つかない。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "メタルクロー" },
+			damage: 30,
+			cost: ["Metal"],
+		},
+		{
+			name: { ja: "ガードプレス" },
+			damage: 70,
+			cost: ["Metal", "Metal", "Colorless"],
+			effect: {
+				ja: "次の相手の番、このポケモンが受けるワザのダメージは「-30」される。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Grass", value: "-30" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 876957,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ダンバル",
+	},
+
+	retreat: 2,
+	regulationMark: "J",
+	rarity: "Common",
+	dexId: [375],
+};
+
+export default card;

--- a/data-asia/M/M4/059.ts
+++ b/data-asia/M/M4/059.ts
@@ -1,0 +1,62 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "メタグロス",
+	},
+
+	illustrator: "Bun Toujo",
+	category: "Pokemon",
+	hp: 180,
+	types: ["Metal"],
+
+	description: {
+		ja: "メタングが 合体して 生まれた。 ４つの 脳を 持つ メタグロスは スーパーコンピュータ並みの 知能。",
+	},
+
+	stage: "Stage2",
+
+	attacks: [
+		{
+			name: { ja: "はねかえす" },
+			damage: 60,
+			cost: ["Metal"],
+			effect: {
+				ja: "相手のバトルポケモンをベンチポケモンと入れ替える。［バトル場に出すポケモンは相手が選ぶ。］",
+			},
+		},
+		{
+			name: { ja: "メタリックハンマー" },
+			damage: "150+",
+			cost: ["Metal", "Metal", "Metal", "Colorless"],
+			effect: {
+				ja: "のぞむなら、このポケモンについている[M]エネルギーを3個トラッシュし、150ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Grass", value: "-30" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 876958,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "メタング",
+	},
+
+	retreat: 3,
+	regulationMark: "J",
+	rarity: "Uncommon",
+	dexId: [376],
+};
+
+export default card;

--- a/data-asia/M/M4/060.ts
+++ b/data-asia/M/M4/060.ts
@@ -1,0 +1,47 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "テッシード",
+	},
+
+	illustrator: "OKUBO",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Metal"],
+
+	description: {
+		ja: "棘を 飛ばして 身を 守る。 狙った 方向に 飛ばすには たくさんの 訓練が 必要。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ころがりタックル" },
+			damage: 40,
+			cost: ["Metal", "Metal"],
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Grass", value: "-30" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 876959,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "J",
+	rarity: "Common",
+	dexId: [597],
+};
+
+export default card;

--- a/data-asia/M/M4/061.ts
+++ b/data-asia/M/M4/061.ts
@@ -1,0 +1,64 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ナットレイ",
+	},
+
+	illustrator: "Haru Akasaka",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Metal"],
+
+	description: {
+		ja: "トゲで 岩盤に キズを つけると 触手の 先端を あてて 栄養を 吸収する。",
+	},
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "どっきりおとし" },
+			effect: {
+				ja: "相手の番に、このカードが相手のワザ・特性・グッズ・サポートの効果で山札からトラッシュされたとき、相手の山札を上から8枚トラッシュする。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "スペシャルウィップ" },
+			damage: "70+",
+			cost: ["Metal", "Metal"],
+			effect: {
+				ja: "このポケモンに特殊エネルギーがついているなら、70ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Grass", value: "-30" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 876960,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "テッシード",
+	},
+
+	retreat: 3,
+	regulationMark: "J",
+	rarity: "Uncommon",
+	dexId: [598],
+};
+
+export default card;

--- a/data-asia/M/M4/062.ts
+++ b/data-asia/M/M4/062.ts
@@ -1,0 +1,58 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "コバルオンex",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 210,
+	types: ["Metal"],
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "メタルロード" },
+			effect: {
+				ja: "自分の番に、このポケモンがベンチからバトル場に出たとき、1回使える。自分の場のポケモンについている[M]エネルギーを好きなだけ選び、このポケモンにつけ替える。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "パワータックル" },
+			damage: 200,
+			cost: ["Metal", "Metal", "Colorless"],
+			effect: {
+				ja: "次の自分の番、このポケモンはワザが使えない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Grass", value: "-30" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 876961,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "J",
+	rarity: "Double rare",
+	dexId: [638],
+
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/M/M4/063.ts
+++ b/data-asia/M/M4/063.ts
@@ -1,0 +1,58 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "メガドラミドロex",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 330,
+	types: ["Dragon"],
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "ふしょくえき" },
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "相手のポケモン全員についている「ポケモンのどうぐ」と「特殊エネルギー」を、すべてトラッシュする。",
+			},
+		},
+		{
+			name: { ja: "デッドリーポイズン" },
+			cost: ["Water", "Darkness"],
+			effect: {
+				ja: "相手のバトルポケモンをどくにする。このどくでのせるダメカンの数は16個になる。",
+			},
+		},
+	],
+
+	weaknesses: [],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 876962,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "クズモー",
+	},
+
+	retreat: 2,
+	regulationMark: "J",
+	rarity: "Double rare",
+	dexId: [691],
+
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/M/M4/064.ts
+++ b/data-asia/M/M4/064.ts
@@ -1,0 +1,50 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヌメラ",
+	},
+
+	illustrator: "Anesaki Dynamic",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Dragon"],
+
+	description: {
+		ja: "ヌメヌメの 粘膜で 覆われた 体は 敵の パンチや キックを ヌルリと 滑らせてしまうのだ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "すいとる" },
+			damage: 30,
+			cost: ["Water", "Psychic"],
+			effect: {
+				ja: "このポケモンのHPを「30」回復する。",
+			},
+		},
+	],
+
+	weaknesses: [],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 876963,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "J",
+	rarity: "Common",
+	dexId: [704],
+};
+
+export default card;

--- a/data-asia/M/M4/065.ts
+++ b/data-asia/M/M4/065.ts
@@ -1,0 +1,51 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヌメイル",
+	},
+
+	illustrator: "Yoriyuki Ikegami",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Dragon"],
+
+	description: {
+		ja: "４本の ツノは 高性能の レーダー。 耳や 鼻の かわりに 音や においを 感じ取る。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "ひっぱたく" },
+			damage: 70,
+			cost: ["Water", "Psychic"],
+		},
+	],
+
+	weaknesses: [],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 876964,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ヌメラ",
+	},
+
+	retreat: 3,
+	regulationMark: "J",
+	rarity: "Common",
+	dexId: [705],
+};
+
+export default card;

--- a/data-asia/M/M4/066.ts
+++ b/data-asia/M/M4/066.ts
@@ -1,0 +1,64 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヌメルゴン",
+	},
+
+	illustrator: "Tonji Matsuno",
+	category: "Pokemon",
+	hp: 160,
+	types: ["Dragon"],
+
+	description: {
+		ja: "人懐っこい ドラゴンポケモン。 大好きな トレーナーに 抱き着いて 粘液で ヌルヌルにしてしまう。",
+	},
+
+	stage: "Stage2",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ぬめぬめスリップ" },
+			effect: {
+				ja: "このポケモンがいるかぎり、相手のバトルポケモンがにげるとき、相手はコインを1回投げる。ウラなら、にげるためのエネルギーはトラッシュせず、入れ替えをしない。この特性の効果は重ならない。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "りゅうのはどう" },
+			damage: 160,
+			cost: ["Water", "Psychic"],
+			effect: {
+				ja: "自分の山札を上から1枚トラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 876965,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ヌメイル",
+	},
+
+	retreat: 3,
+	regulationMark: "J",
+	rarity: "Uncommon",
+	dexId: [706],
+};
+
+export default card;

--- a/data-asia/M/M4/067.ts
+++ b/data-asia/M/M4/067.ts
@@ -1,0 +1,49 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ケンタロス",
+	},
+
+	illustrator: "Satoshi Ito",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Colorless"],
+
+	description: {
+		ja: "ツノを つきあわせて 戦う。 群れを守る 強い ケンタロスは キズだらけの ツノを 自慢する。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "むれでねらう" },
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "相手のポケモンを1匹選び、自分の場の、名前に「ケンタロス」とつくポケモンの数ぶんコインを投げる。選んだポケモンに、オモテの数×50ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 876966,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "J",
+	rarity: "Uncommon",
+	dexId: [128],
+};
+
+export default card;

--- a/data-asia/M/M4/068.ts
+++ b/data-asia/M/M4/068.ts
@@ -1,0 +1,57 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ミネズミ",
+	},
+
+	illustrator: "Souichirou Gunjima",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Colorless"],
+
+	description: {
+		ja: "頬の 袋に エサを 溜めこみ 何日も 見張りを 続ける。 尻尾で 仲間に 合図する。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "かんしのめ" },
+			effect: {
+				ja: "このポケモンがいるかぎり、おたがいのポケモン全員にのっているダメカンは、別のポケモンにのせ替えられない。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "かみつく" },
+			damage: 10,
+			cost: ["Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 876967,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "J",
+	rarity: "Common",
+	dexId: [504],
+};
+
+export default card;

--- a/data-asia/M/M4/069.ts
+++ b/data-asia/M/M4/069.ts
@@ -1,0 +1,58 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ミルホッグ",
+	},
+
+	illustrator: "Kouki Saitou",
+	category: "Pokemon",
+	hp: 100,
+	types: ["Colorless"],
+
+	description: {
+		ja: "体内の 発光物質で 目玉や 体を 光らせ 襲ってきた 敵を ひるませる。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "ぬきうちチェック" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "コインを3回投げる。オモテが出たなら、相手の手札を見て、その中からカードをオモテの数ぶん選び、相手の山札にもどして切る。",
+			},
+		},
+		{
+			name: { ja: "けたぐり" },
+			damage: 50,
+			cost: ["Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 876968,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ミネズミ",
+	},
+
+	retreat: 1,
+	regulationMark: "J",
+	rarity: "Common",
+	dexId: [505],
+};
+
+export default card;

--- a/data-asia/M/M4/070.ts
+++ b/data-asia/M/M4/070.ts
@@ -1,0 +1,50 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "チラーミィ",
+	},
+
+	illustrator: "ryoma uratsuka",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Colorless"],
+
+	description: {
+		ja: "きれい好きな 性格の ポケモン。 尻尾を ほうきがわりに いつも 棲み処の ほこりを 払っている。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "とっしん" },
+			damage: 30,
+			cost: ["Colorless"],
+			effect: {
+				ja: "このポケモンにも10ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 876969,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "J",
+	rarity: "Common",
+	dexId: [572],
+};
+
+export default card;

--- a/data-asia/M/M4/071.ts
+++ b/data-asia/M/M4/071.ts
@@ -1,0 +1,62 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "チラチーノex",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 240,
+	types: ["Colorless"],
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "なめらかコート" },
+			effect: {
+				ja: "このポケモンがワザのダメージを受けるとき、自分はコインを1回投げる。オモテなら、このポケモンはそのダメージを受けない。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "エナジービンタ" },
+			damage: "40×",
+			cost: ["Colorless"],
+			effect: {
+				ja: "このポケモンについているエネルギーの数×40ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 876970,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "チラーミィ",
+	},
+
+	retreat: 1,
+	regulationMark: "J",
+	rarity: "Double rare",
+	dexId: [573],
+
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/M/M4/072.ts
+++ b/data-asia/M/M4/072.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "スペシャルレッドカード",
+	},
+
+	illustrator: "Studio Bora Inc.",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードは、相手のサイドの残り枚数が3枚以下のときにしか使えない。相手は相手自身の手札をすべてウラにして切り、山札の下にもどす。その後、相手は山札を3枚引く。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 876971,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	regulationMark: "J",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/M/M4/073.ts
+++ b/data-asia/M/M4/073.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "大漁ネット",
+	},
+
+	illustrator: "Toyste Beach",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分のトラッシュから[W]ポケモンと「基本[W]エネルギー」をそれぞれ3枚まで選び、相手に見せて、山札にもどして切る。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 876972,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	regulationMark: "J",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/M/M4/074.ts
+++ b/data-asia/M/M4/074.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "変化の書",
+	},
+
+	illustrator: "Toyste Beach",
+	category: "Trainer",
+
+	effect: {
+		ja: "「変化の書」は、2枚同時にしか使えない。（効果は、2枚で1回はたらく。）自分のトラッシュからたねポケモンを1枚選び、自分の場のたねポケモン1匹と入れ替える（ついているカード・ダメカン・特殊状態・効果などは、すべて引きつぐ）。入れ替えたポケモンはトラッシュする。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 876973,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	regulationMark: "J",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/M/M4/075.ts
+++ b/data-asia/M/M4/075.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "AZの安らぎ",
+	},
+
+	illustrator: "GIDORA",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分のバトルポケモンをベンチポケモンと入れ替える。「ポケモンex」をベンチに入れ替えた場合、そのポケモンのHPを「80」回復する。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 876974,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "J",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/M/M4/076.ts
+++ b/data-asia/M/M4/076.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ジプソ",
+	},
+
+	illustrator: "Souichirou Gunjima",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分のトラッシュから「基本[M]エネルギー」を2枚まで選び、自分の[M]ポケモン1匹につける。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 876975,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "J",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/M/M4/077.ts
+++ b/data-asia/M/M4/077.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ホミカの演奏",
+	},
+
+	illustrator: "Nobusawa/Mochipuyo",
+	category: "Trainer",
+
+	effect: {
+		ja: "次の相手の番、相手のどくのポケモンは、にげられない。（新しくどくにしたポケモンもふくむ。）",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 876976,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "J",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/M/M4/078.ts
+++ b/data-asia/M/M4/078.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "マチエール",
+	},
+
+	illustrator: "Akira Komayama",
+	category: "Trainer",
+
+	effect: {
+		ja: "相手の手札を見て、その中にあるポケモンの枚数ぶん、自分の山札を引く。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 876977,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "J",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/M/M4/079.ts
+++ b/data-asia/M/M4/079.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アンジュフラエッテ",
+	},
+
+	illustrator: "MARINA Chikazawa",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードは、場に出ている「プリズムタワー」をトラッシュしなければ場に出せず、「プリズムタワー」を出した番でも場に出せる。おたがいの場の「メガフラエッテex」全員は、それぞれ最大HPが「+150」される。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 876978,
+			},
+		},
+	],
+
+	trainerType: "Stadium",
+	regulationMark: "J",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/M/M4/080.ts
+++ b/data-asia/M/M4/080.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "プリズムタワー",
+	},
+
+	illustrator: "MARINA Chikazawa",
+	category: "Trainer",
+
+	effect: {
+		ja: "おたがいのプレイヤーは、自分の番ごとに1回、自分の手札を2枚トラッシュするなら、自分の山札を1枚引いてよい。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 876979,
+			},
+		},
+	],
+
+	trainerType: "Stadium",
+	regulationMark: "J",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/M/M4/081.ts
+++ b/data-asia/M/M4/081.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ニトロ炎エネルギー",
+	},
+
+	illustrator: "",
+	category: "Energy",
+	energyType: "Special",
+
+	effect: {
+		ja: "このカードは、ポケモンについているかぎり、[R]エネルギー1個ぶんとしてはたらく。このカードをつけている[R]ポケモンが使うワザの効果で、このカードがトラッシュされたなら、ワザのダメージや効果のあとに、手札にもどす。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 876980,
+			},
+		},
+	],
+
+	regulationMark: "J",
+	rarity: "Rare",
+};
+
+export default card;

--- a/data-asia/M/M4/082.ts
+++ b/data-asia/M/M4/082.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "バブル水エネルギー",
+	},
+
+	illustrator: "",
+	category: "Energy",
+	energyType: "Special",
+
+	effect: {
+		ja: "このカードは、ポケモンについているかぎり、[W]エネルギー1個ぶんとしてはたらく。このカードをつけている[W]ポケモンは、特殊状態にならず、受けている特殊状態は、すべて回復する。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 876981,
+			},
+		},
+	],
+
+	regulationMark: "J",
+	rarity: "Rare",
+};
+
+export default card;

--- a/data-asia/M/M4/083.ts
+++ b/data-asia/M/M4/083.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "マグネット鋼エネルギー",
+	},
+
+	illustrator: "",
+	category: "Energy",
+	energyType: "Special",
+
+	effect: {
+		ja: "このカードは、ポケモンについているかぎり、[M]エネルギー1個ぶんとしてはたらく。このカードをつけている[M]ポケモンは、にげるためのエネルギーが、すべてなくなる。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 876982,
+			},
+		},
+	],
+
+	regulationMark: "J",
+	rarity: "Rare",
+};
+
+export default card;

--- a/data-asia/M/M4/084.ts
+++ b/data-asia/M/M4/084.ts
@@ -1,0 +1,52 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ハリマロン",
+	},
+
+	illustrator: "Atsushi Furusawa",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Grass"],
+
+	description: {
+		ja: "普段 やわらかい 頭の トゲは 力を こめると 鋭く 尖り 岩をも つらぬくほど 硬くなる。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "たたく" },
+			damage: 10,
+			cost: ["Grass"],
+		},
+		{
+			name: { ja: "トゲでさす" },
+			damage: 30,
+			cost: ["Grass", "Grass"],
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 877308,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "J",
+	rarity: "Illustration rare",
+	dexId: [650],
+};
+
+export default card;

--- a/data-asia/M/M4/085.ts
+++ b/data-asia/M/M4/085.ts
@@ -1,0 +1,54 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "フォッコ",
+	},
+
+	illustrator: "satoma",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Fire"],
+
+	description: {
+		ja: "小枝を 食べると 元気になって 摂氏２００度を 超える 熱気を 大きな 耳から 噴き出す。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "なかまをよぶ" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札からたねポケモンを2枚まで選び、ベンチに出す。そして山札を切る。",
+			},
+		},
+		{
+			name: { ja: "ひをはく" },
+			damage: 10,
+			cost: ["Fire"],
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 877311,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "J",
+	rarity: "Illustration rare",
+	dexId: [653],
+};
+
+export default card;

--- a/data-asia/M/M4/086.ts
+++ b/data-asia/M/M4/086.ts
@@ -1,0 +1,54 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ケロマツ",
+	},
+
+	illustrator: "Susumu Maeya",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Water"],
+
+	description: {
+		ja: "繊細な 泡で 体を 包み 肌を 守る。 のんきに 見せかけ 抜け目なく 周囲を うかがう。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "もってくる" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札を1枚引く。",
+			},
+		},
+		{
+			name: { ja: "みずでっぽう" },
+			damage: 10,
+			cost: ["Water"],
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 877315,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "J",
+	rarity: "Illustration rare",
+	dexId: [656],
+};
+
+export default card;

--- a/data-asia/M/M4/087.ts
+++ b/data-asia/M/M4/087.ts
@@ -1,0 +1,58 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ゲコガシラ",
+	},
+
+	illustrator: "Susumu Maeya",
+	category: "Pokemon",
+	hp: 100,
+	types: ["Water"],
+
+	description: {
+		ja: "身軽さは だれにも 負けない。 ６００メートルを 超える タワーの 天辺まで １分で 登りきる。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "よびよせのじゅつ" },
+			cost: ["Water"],
+			effect: {
+				ja: "自分の山札からポケモンを3枚まで選び、相手に見せて、手札に加える。そして山札を切る。",
+			},
+		},
+		{
+			name: { ja: "アクアエッジ" },
+			damage: 50,
+			cost: ["Water", "Water"],
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 877316,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ケロマツ",
+	},
+
+	retreat: 1,
+	regulationMark: "J",
+	rarity: "Illustration rare",
+	dexId: [657],
+};
+
+export default card;

--- a/data-asia/M/M4/088.ts
+++ b/data-asia/M/M4/088.ts
@@ -1,0 +1,64 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "デンリュウ",
+	},
+
+	illustrator: "saino misaki",
+	category: "Pokemon",
+	hp: 160,
+	types: ["Lightning"],
+
+	description: {
+		ja: "尻尾の 先が 光り輝く。 光は はるか 遠くまで 届き 迷った者の 道標となる。",
+	},
+
+	stage: "Stage2",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "シンクロパルス" },
+			effect: {
+				ja: "自分の手札と相手の手札が同じ枚数なら、このポケモンが使うワザの、相手のバトルポケモンへのダメージは「+80」される。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "フラッシュボルト" },
+			damage: 140,
+			cost: ["Lightning", "Colorless"],
+			effect: {
+				ja: "次の自分の番、このポケモンは「フラッシュボルト」が使えない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 877317,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "モココ",
+	},
+
+	retreat: 2,
+	regulationMark: "J",
+	rarity: "Illustration rare",
+	dexId: [181],
+};
+
+export default card;

--- a/data-asia/M/M4/089.ts
+++ b/data-asia/M/M4/089.ts
@@ -1,0 +1,50 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ゼルネアス",
+	},
+
+	illustrator: "YASHIRO Nanaco",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Psychic"],
+
+	description: {
+		ja: "頭の ツノが 七色に 輝くとき 永遠の 命を 分け与えると いわれている。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ジオストーム" },
+			damage: "30×",
+			cost: ["Psychic", "Psychic", "Psychic"],
+			effect: {
+				ja: "自分のポケモン全員についている[P]エネルギーの数×30ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 877318,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "J",
+	rarity: "Illustration rare",
+	dexId: [716],
+};
+
+export default card;

--- a/data-asia/M/M4/090.ts
+++ b/data-asia/M/M4/090.ts
@@ -1,0 +1,54 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ネンドール",
+	},
+
+	illustrator: "matazo",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Fighting"],
+
+	description: {
+		ja: "２万年前の 古代人が つくった 泥人形から 生まれたらしい 謎の ポケモン。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "たいかこうせん" },
+			damage: 50,
+			cost: ["Fighting"],
+			effect: {
+				ja: "相手の進化しているバトルポケモンから、「進化カード」を1枚はがして退化させる。はがしたカードは、相手の手札にもどす。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 877319,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ヤジロン",
+	},
+
+	retreat: 2,
+	regulationMark: "J",
+	rarity: "Illustration rare",
+	dexId: [344],
+};
+
+export default card;

--- a/data-asia/M/M4/091.ts
+++ b/data-asia/M/M4/091.ts
@@ -1,0 +1,64 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "クロバット",
+	},
+
+	illustrator: "Kazuhisa Uragami",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Darkness"],
+
+	description: {
+		ja: "両足が 羽に 変化。 音を たてずに 高速で 飛び 獲物の うなじに キバを たてる。",
+	},
+
+	stage: "Stage2",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "よるこうさく" },
+			effect: {
+				ja: "このポケモンがバトル場にいるなら、自分の番に1回使える。自分の山札から好きなカードを1枚選ぶ。残りの山札を切り、選んだカードを山札の上にもどす。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "どくおんぱ" },
+			damage: 80,
+			cost: ["Darkness"],
+			effect: {
+				ja: "相手のバトルポケモンをどくとこんらんにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 877320,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ゴルバット",
+	},
+
+	retreat: 1,
+	regulationMark: "J",
+	rarity: "Illustration rare",
+	dexId: [169],
+};
+
+export default card;

--- a/data-asia/M/M4/092.ts
+++ b/data-asia/M/M4/092.ts
@@ -1,0 +1,59 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "メタング",
+	},
+
+	illustrator: "Kurata So",
+	category: "Pokemon",
+	hp: 100,
+	types: ["Metal"],
+
+	description: {
+		ja: "２匹の ダンバルが 合体した。 鋼の ボディは ジェット機と 衝突しても 傷つかない。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "メタルクロー" },
+			damage: 30,
+			cost: ["Metal"],
+		},
+		{
+			name: { ja: "ガードプレス" },
+			damage: 70,
+			cost: ["Metal", "Metal", "Colorless"],
+			effect: {
+				ja: "次の相手の番、このポケモンが受けるワザのダメージは「-30」される。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Grass", value: "-30" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 877321,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ダンバル",
+	},
+
+	retreat: 2,
+	regulationMark: "J",
+	rarity: "Illustration rare",
+	dexId: [375],
+};
+
+export default card;

--- a/data-asia/M/M4/093.ts
+++ b/data-asia/M/M4/093.ts
@@ -1,0 +1,51 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヌメイル",
+	},
+
+	illustrator: "aspara",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Dragon"],
+
+	description: {
+		ja: "４本の ツノは 高性能の レーダー。 耳や 鼻の かわりに 音や においを 感じ取る。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "ひっぱたく" },
+			damage: 70,
+			cost: ["Water", "Psychic"],
+		},
+	],
+
+	weaknesses: [],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 877322,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ヌメラ",
+	},
+
+	retreat: 3,
+	regulationMark: "J",
+	rarity: "Illustration rare",
+	dexId: [705],
+};
+
+export default card;

--- a/data-asia/M/M4/094.ts
+++ b/data-asia/M/M4/094.ts
@@ -1,0 +1,49 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ケンタロス",
+	},
+
+	illustrator: "Tsuyoshi Nagano",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Colorless"],
+
+	description: {
+		ja: "ツノを つきあわせて 戦う。 群れを守る 強い ケンタロスは キズだらけの ツノを 自慢する。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "むれでねらう" },
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "相手のポケモンを1匹選び、自分の場の、名前に「ケンタロス」とつくポケモンの数ぶんコインを投げる。選んだポケモンに、オモテの数×50ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 877323,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "J",
+	rarity: "Illustration rare",
+	dexId: [128],
+};
+
+export default card;

--- a/data-asia/M/M4/095.ts
+++ b/data-asia/M/M4/095.ts
@@ -1,0 +1,58 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ミルホッグ",
+	},
+
+	illustrator: "MARINA Chikazawa",
+	category: "Pokemon",
+	hp: 100,
+	types: ["Colorless"],
+
+	description: {
+		ja: "体内の 発光物質で 目玉や 体を 光らせ 襲ってきた 敵を ひるませる。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "ぬきうちチェック" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "コインを3回投げる。オモテが出たなら、相手の手札を見て、その中からカードをオモテの数ぶん選び、相手の山札にもどして切る。",
+			},
+		},
+		{
+			name: { ja: "けたぐり" },
+			damage: 50,
+			cost: ["Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 877324,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ミネズミ",
+	},
+
+	retreat: 1,
+	regulationMark: "J",
+	rarity: "Illustration rare",
+	dexId: [505],
+};
+
+export default card;

--- a/data-asia/M/M4/096.ts
+++ b/data-asia/M/M4/096.ts
@@ -1,0 +1,52 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "スピアーex",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 310,
+	types: ["Grass"],
+
+	stage: "Stage2",
+
+	attacks: [
+		{
+			name: { ja: "ビーランブル" },
+			damage: "110×",
+			cost: ["Grass"],
+			effect: {
+				ja: "自分の場の「スピアー（『ポケモンex』をふくむ）」の数×110ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 877326,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "コクーン",
+	},
+
+	retreat: 1,
+	regulationMark: "J",
+	rarity: "Ultra Rare",
+	dexId: [15],
+
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/M/M4/097.ts
+++ b/data-asia/M/M4/097.ts
@@ -1,0 +1,59 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "メガカエンジシex",
+	},
+
+	illustrator: "Keisuke Azuma",
+	category: "Pokemon",
+	hp: 340,
+	types: ["Fire"],
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "ほえたてる" },
+			damage: 80,
+			cost: ["Fire", "Colorless"],
+			effect: {
+				ja: "次の相手の番、このワザを受けたポケモンが使うワザのダメージは「-50」される。",
+			},
+		},
+		{
+			name: { ja: "ビッグバンファイヤー 290-" },
+			cost: ["Fire", "Fire", "Colorless"],
+			effect: {
+				ja: "このポケモンにのっているダメカンの数×10ダメージぶん、このワザのダメージは小さくなる。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 877330,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "シシコ",
+	},
+
+	retreat: 2,
+	regulationMark: "J",
+	rarity: "Ultra Rare",
+	dexId: [668],
+
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/M/M4/098.ts
+++ b/data-asia/M/M4/098.ts
@@ -1,0 +1,62 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "メガゲッコウガex",
+	},
+
+	illustrator: "takuyoa",
+	category: "Pokemon",
+	hp: 350,
+	types: ["Water"],
+
+	stage: "Stage2",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ひっさつしゅりけん" },
+			effect: {
+				ja: "このポケモンがバトル場にいて、自分の番に、自分の手札から「基本[W]エネルギー」を1枚トラッシュするなら、1回使える。相手のポケモン1匹に、ダメカンを6個のせる。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ニンジャスピナー" },
+			damage: "120+",
+			cost: ["Water", "Water"],
+			effect: {
+				ja: "のぞむなら、このポケモンについている[W]エネルギーを1個手札にもどし、80ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 877331,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ゲコガシラ",
+	},
+
+	retreat: 1,
+	regulationMark: "J",
+	rarity: "Ultra Rare",
+	dexId: [658],
+
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/M/M4/099.ts
+++ b/data-asia/M/M4/099.ts
@@ -1,0 +1,55 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "メガフラエッテex",
+	},
+
+	illustrator: "aky CG Works",
+	category: "Pokemon",
+	hp: 250,
+	types: ["Psychic"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "やさしいひかり" },
+			cost: ["Psychic"],
+			effect: {
+				ja: "おたがいのポケモン全員のHPを、それぞれ「30」回復する。",
+			},
+		},
+		{
+			name: { ja: "エタニティブルーム" },
+			damage: 200,
+			cost: ["Psychic", "Psychic", "Psychic"],
+			effect: {
+				ja: "自分の山札から「基本[P]エネルギー」を4枚まで選び、ベンチポケモンに好きなようにつける。そして山札を切る。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 877332,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "J",
+	rarity: "Ultra Rare",
+	dexId: [670],
+
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/M/M4/100.ts
+++ b/data-asia/M/M4/100.ts
@@ -1,0 +1,60 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "パンプジンex",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 270,
+	types: ["Psychic"],
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "ホラーロンド" },
+			damage: "30+",
+			cost: ["Psychic"],
+			effect: {
+				ja: "ダメカンがのっている自分のベンチポケモンの数×50ダメージ追加。",
+			},
+		},
+		{
+			name: { ja: "ゴーストタッチ" },
+			damage: 140,
+			cost: ["Psychic", "Psychic"],
+			effect: {
+				ja: "相手の手札からオモテを見ないで1枚選び、トラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 877338,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "バケッチャ",
+	},
+
+	retreat: 2,
+	regulationMark: "J",
+	rarity: "Ultra Rare",
+	dexId: [711],
+
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/M/M4/101.ts
+++ b/data-asia/M/M4/101.ts
@@ -1,0 +1,58 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "コバルオンex",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 210,
+	types: ["Metal"],
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "メタルロード" },
+			effect: {
+				ja: "自分の番に、このポケモンがベンチからバトル場に出たとき、1回使える。自分の場のポケモンについている[M]エネルギーを好きなだけ選び、このポケモンにつけ替える。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "パワータックル" },
+			damage: 200,
+			cost: ["Metal", "Metal", "Colorless"],
+			effect: {
+				ja: "次の自分の番、このポケモンはワザが使えない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Grass", value: "-30" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 877340,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "J",
+	rarity: "Ultra Rare",
+	dexId: [638],
+
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/M/M4/102.ts
+++ b/data-asia/M/M4/102.ts
@@ -1,0 +1,58 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "メガドラミドロex",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 330,
+	types: ["Dragon"],
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "ふしょくえき" },
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "相手のポケモン全員についている「ポケモンのどうぐ」と「特殊エネルギー」を、すべてトラッシュする。",
+			},
+		},
+		{
+			name: { ja: "デッドリーポイズン" },
+			cost: ["Water", "Darkness"],
+			effect: {
+				ja: "相手のバトルポケモンをどくにする。このどくでのせるダメカンの数は16個になる。",
+			},
+		},
+	],
+
+	weaknesses: [],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 877343,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "クズモー",
+	},
+
+	retreat: 2,
+	regulationMark: "J",
+	rarity: "Ultra Rare",
+	dexId: [691],
+
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/M/M4/103.ts
+++ b/data-asia/M/M4/103.ts
@@ -1,0 +1,62 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "チラチーノex",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 240,
+	types: ["Colorless"],
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "なめらかコート" },
+			effect: {
+				ja: "このポケモンがワザのダメージを受けるとき、自分はコインを1回投げる。オモテなら、このポケモンはそのダメージを受けない。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "エナジービンタ" },
+			damage: "40×",
+			cost: ["Colorless"],
+			effect: {
+				ja: "このポケモンについているエネルギーの数×40ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 877345,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "チラーミィ",
+	},
+
+	retreat: 1,
+	regulationMark: "J",
+	rarity: "Ultra Rare",
+	dexId: [573],
+
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/M/M4/104.ts
+++ b/data-asia/M/M4/104.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "エネルギー回収",
+	},
+
+	illustrator: "Studio Bora Inc.",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分のトラッシュから基本エネルギーを2枚選び、相手に見せてから、手札に加える。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 877348,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	regulationMark: "I",
+	rarity: "Ultra Rare",
+};
+
+export default card;

--- a/data-asia/M/M4/105.ts
+++ b/data-asia/M/M4/105.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ジャンボアイス",
+	},
+
+	illustrator: "AYUMI ODASHIMA",
+	category: "Trainer",
+
+	effect: {
+		ja: "エネルギーが3個以上ついている自分のバトルポケモンのHPを「80」回復する。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 877350,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	regulationMark: "I",
+	rarity: "Ultra Rare",
+};
+
+export default card;

--- a/data-asia/M/M4/106.ts
+++ b/data-asia/M/M4/106.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "スペシャルレッドカード",
+	},
+
+	illustrator: "Studio Bora Inc.",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードは、相手のサイドの残り枚数が3枚以下のときにしか使えない。相手は相手自身の手札をすべてウラにして切り、山札の下にもどす。その後、相手は山札を3枚引く。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 877351,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	regulationMark: "J",
+	rarity: "Ultra Rare",
+};
+
+export default card;

--- a/data-asia/M/M4/107.ts
+++ b/data-asia/M/M4/107.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ツールスクラッパー",
+	},
+
+	illustrator: "Studio Bora Inc.",
+	category: "Trainer",
+
+	effect: {
+		ja: "おたがいの場のポケモンについている「ポケモンのどうぐ」を2枚まで選び、トラッシュする。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 877354,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	regulationMark: "I",
+	rarity: "Ultra Rare",
+};
+
+export default card;

--- a/data-asia/M/M4/108.ts
+++ b/data-asia/M/M4/108.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "AZの安らぎ",
+	},
+
+	illustrator: "GIDORA",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分のバトルポケモンをベンチポケモンと入れ替える。「ポケモンex」をベンチに入れ替えた場合、そのポケモンのHPを「80」回復する。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 877361,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "J",
+	rarity: "Ultra Rare",
+};
+
+export default card;

--- a/data-asia/M/M4/109.ts
+++ b/data-asia/M/M4/109.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ジプソ",
+	},
+
+	illustrator: "Souichirou Gunjima",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分のトラッシュから「基本[M]エネルギー」を2枚まで選び、自分の[M]ポケモン1匹につける。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 877364,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "J",
+	rarity: "Ultra Rare",
+};
+
+export default card;

--- a/data-asia/M/M4/110.ts
+++ b/data-asia/M/M4/110.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ホミカの演奏",
+	},
+
+	illustrator: "Nobusawa/Mochipuyo",
+	category: "Trainer",
+
+	effect: {
+		ja: "次の相手の番、相手のどくのポケモンは、にげられない。（新しくどくにしたポケモンもふくむ。）",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 877365,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "J",
+	rarity: "Ultra Rare",
+};
+
+export default card;

--- a/data-asia/M/M4/111.ts
+++ b/data-asia/M/M4/111.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "マチエール",
+	},
+
+	illustrator: "Akira Komayama",
+	category: "Trainer",
+
+	effect: {
+		ja: "相手の手札を見て、その中にあるポケモンの枚数ぶん、自分の山札を引く。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 877366,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "J",
+	rarity: "Ultra Rare",
+};
+
+export default card;

--- a/data-asia/M/M4/112.ts
+++ b/data-asia/M/M4/112.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "なみのりビーチ",
+	},
+
+	illustrator: "AYUMI ODASHIMA",
+	category: "Trainer",
+
+	effect: {
+		ja: "おたがいのプレイヤーは、自分の番ごとに1回、自分のバトル場の[W]ポケモンを、ベンチの[W]ポケモンと入れ替えてよい。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 877369,
+			},
+		},
+	],
+
+	trainerType: "Stadium",
+	regulationMark: "I",
+	rarity: "Ultra Rare",
+};
+
+export default card;

--- a/data-asia/M/M4/113.ts
+++ b/data-asia/M/M4/113.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "プリズムタワー",
+	},
+
+	illustrator: "MARINA Chikazawa",
+	category: "Trainer",
+
+	effect: {
+		ja: "おたがいのプレイヤーは、自分の番ごとに1回、自分の手札を2枚トラッシュするなら、自分の山札を1枚引いてよい。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 877370,
+			},
+		},
+	],
+
+	trainerType: "Stadium",
+	regulationMark: "J",
+	rarity: "Ultra Rare",
+};
+
+export default card;

--- a/data-asia/M/M4/114.ts
+++ b/data-asia/M/M4/114.ts
@@ -1,0 +1,62 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "メガゲッコウガex",
+	},
+
+	illustrator: "Susumu Maeya",
+	category: "Pokemon",
+	hp: 350,
+	types: ["Water"],
+
+	stage: "Stage2",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ひっさつしゅりけん" },
+			effect: {
+				ja: "このポケモンがバトル場にいて、自分の番に、自分の手札から「基本[W]エネルギー」を1枚トラッシュするなら、1回使える。相手のポケモン1匹に、ダメカンを6個のせる。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ニンジャスピナー" },
+			damage: "120+",
+			cost: ["Water", "Water"],
+			effect: {
+				ja: "のぞむなら、このポケモンについている[W]エネルギーを1個手札にもどし、80ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 877373,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ゲコガシラ",
+	},
+
+	retreat: 1,
+	regulationMark: "J",
+	rarity: "Special illustration rare",
+	dexId: [658],
+
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/M/M4/115.ts
+++ b/data-asia/M/M4/115.ts
@@ -1,0 +1,55 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "メガフラエッテex",
+	},
+
+	illustrator: "Teeziro",
+	category: "Pokemon",
+	hp: 250,
+	types: ["Psychic"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "やさしいひかり" },
+			cost: ["Psychic"],
+			effect: {
+				ja: "おたがいのポケモン全員のHPを、それぞれ「30」回復する。",
+			},
+		},
+		{
+			name: { ja: "エタニティブルーム" },
+			damage: 200,
+			cost: ["Psychic", "Psychic", "Psychic"],
+			effect: {
+				ja: "自分の山札から「基本[P]エネルギー」を4枚まで選び、ベンチポケモンに好きなようにつける。そして山札を切る。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 877376,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "J",
+	rarity: "Special illustration rare",
+	dexId: [670],
+
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/M/M4/116.ts
+++ b/data-asia/M/M4/116.ts
@@ -1,0 +1,58 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "メガドラミドロex",
+	},
+
+	illustrator: "Kazumasa Yasukuni",
+	category: "Pokemon",
+	hp: 330,
+	types: ["Dragon"],
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "ふしょくえき" },
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "相手のポケモン全員についている「ポケモンのどうぐ」と「特殊エネルギー」を、すべてトラッシュする。",
+			},
+		},
+		{
+			name: { ja: "デッドリーポイズン" },
+			cost: ["Water", "Darkness"],
+			effect: {
+				ja: "相手のバトルポケモンをどくにする。このどくでのせるダメカンの数は16個になる。",
+			},
+		},
+	],
+
+	weaknesses: [],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 877377,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "クズモー",
+	},
+
+	retreat: 2,
+	regulationMark: "J",
+	rarity: "Special illustration rare",
+	dexId: [691],
+
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/M/M4/117.ts
+++ b/data-asia/M/M4/117.ts
@@ -1,0 +1,62 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "チラチーノex",
+	},
+
+	illustrator: "Keisin",
+	category: "Pokemon",
+	hp: 240,
+	types: ["Colorless"],
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "なめらかコート" },
+			effect: {
+				ja: "このポケモンがワザのダメージを受けるとき、自分はコインを1回投げる。オモテなら、このポケモンはそのダメージを受けない。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "エナジービンタ" },
+			damage: "40×",
+			cost: ["Colorless"],
+			effect: {
+				ja: "このポケモンについているエネルギーの数×40ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 877379,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "チラーミィ",
+	},
+
+	retreat: 1,
+	regulationMark: "J",
+	rarity: "Special illustration rare",
+	dexId: [573],
+
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/M/M4/118.ts
+++ b/data-asia/M/M4/118.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "AZの安らぎ",
+	},
+
+	illustrator: "OKACHEKE",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分のバトルポケモンをベンチポケモンと入れ替える。「ポケモンex」をベンチに入れ替えた場合、そのポケモンのHPを「80」回復する。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 877381,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "J",
+	rarity: "Special illustration rare",
+};
+
+export default card;

--- a/data-asia/M/M4/119.ts
+++ b/data-asia/M/M4/119.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ホミカの演奏",
+	},
+
+	illustrator: "Tomowaka",
+	category: "Trainer",
+
+	effect: {
+		ja: "次の相手の番、相手のどくのポケモンは、にげられない。（新しくどくにしたポケモンもふくむ。）",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 877382,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "J",
+	rarity: "Special illustration rare",
+};
+
+export default card;

--- a/data-asia/M/M4/120.ts
+++ b/data-asia/M/M4/120.ts
@@ -1,0 +1,62 @@
+import { Card } from "../../../interfaces";
+import Set from "../M4";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "メガゲッコウガex",
+	},
+
+	illustrator: "takuyoa",
+	category: "Pokemon",
+	hp: 350,
+	types: ["Water"],
+
+	stage: "Stage2",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ひっさつしゅりけん" },
+			effect: {
+				ja: "このポケモンがバトル場にいて、自分の番に、自分の手札から「基本[W]エネルギー」を1枚トラッシュするなら、1回使える。相手のポケモン1匹に、ダメカンを6個のせる。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ニンジャスピナー" },
+			damage: "120+",
+			cost: ["Water", "Water"],
+			effect: {
+				ja: "のぞむなら、このポケモンについている[W]エネルギーを1個手札にもどし、80ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 877384,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ゲコガシラ",
+	},
+
+	retreat: 1,
+	regulationMark: "J",
+	rarity: "Mega Hyper Rare",
+	dexId: [658],
+
+	suffix: "EX",
+};
+
+export default card;


### PR DESCRIPTION
## What

Adds the complete Japanese expansion **M4 ニンジャスピナー (Ninja Spinner)**, released 2026-03-13 — the next Mega-era set after M3 (#1154):

- `data-asia/M/M4.ts` — set definition (83 official cards)
- `data-asia/M/M4/001.ts` … `120.ts` — all 120 cards (83 regular + 37 secret rares: 12 AR, 18 SR, 6 SAR, 1 Mega Hyper Rare)

## Data sources

- **pokemon-card.com** (official database): Japanese names, HP, attacks/abilities with full Japanese effect text, flavor texts, National Dex numbers, illustrators, regulation mark (J), official card count
- **limitlesstcg.com**: stages, evolves-from, weaknesses/resistances/retreat, rarity (mapped to the same rarity names M1–M3 use)
- **Cardmarket**: product IDs included as `thirdParty.cardmarket` (tcgplayer IDs not available to me)

## Notes

- Follows the exact file format and conventions of M3 (tabs, double quotes, `suffix: "EX"`, `variants` normal for C/U and holo above, empty `description` omitted for ex cards that have no flavor text)
- All 121 files type-check against `interfaces.d.ts` (`tsc --noEmit`)
- Cardimages(by cardid): https://files.felix.lol/api/file/share.php?token=d68161ef0157e90cb1d2cc4db5b0b3c3
