### PR TITLE
(data) Add Japanese Mega set M5 Abyss Eye

### DIFF
--- a/data-asia/M/M5.ts
+++ b/data-asia/M/M5.ts
@@ -1,0 +1,20 @@
+import { Set } from "../../interfaces";
+import serie from "../M";
+
+const set: Set = {
+	id: "M5",
+	name: {
+		ja: "アビスアイ",
+	},
+
+	serie: serie,
+
+	cardCount: {
+		official: 81,
+	},
+	releaseDate: {
+		ja: "2026-05-22",
+	},
+};
+
+export default set;

--- a/data-asia/M/M5/001.ts
+++ b/data-asia/M/M5/001.ts
@@ -1,0 +1,51 @@
+import { Card } from "../../../interfaces";
+import Set from "../M5";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "トロピウス",
+	},
+
+	illustrator: "Akino Fukuji",
+	category: "Pokemon",
+	hp: 110,
+	types: ["Grass"],
+
+	description: {
+		ja: "いつも 同じ 果物ばかり 食べていたら のど元に とても 美味しい 果物が 生えてきた。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "かじつのかおり" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札を上から6枚見て、その中からポケモンを好きなだけ選び、相手に見せて、手札に加える。残りのカードは山札にもどして切る。",
+			},
+		},
+		{
+			name: { ja: "ソーラービーム" },
+			damage: 60,
+			cost: ["Grass", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [{ type: "normal" }],
+
+	retreat: 1,
+	regulationMark: "J",
+	rarity: "Common",
+	dexId: [357],
+
+	thirdParty: {
+		cardmarket: 888185,
+	},
+};
+
+export default card;

--- a/data-asia/M/M5/002.ts
+++ b/data-asia/M/M5/002.ts
@@ -1,0 +1,47 @@
+import { Card } from "../../../interfaces";
+import Set from "../M5";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アゴジムシ",
+	},
+
+	illustrator: "Mina Nakai",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Grass"],
+
+	description: {
+		ja: "ネバネバの 糸を 吐いて 枝に 巻きつけ 振り子の 動きで 木から 木へと 身軽に 飛び移る。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "いとをはく" },
+			damage: 10,
+			cost: ["Colorless"],
+			effect: {
+				ja: "コインを1回投げオモテなら、相手のバトルポケモンをマヒにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [{ type: "normal" }],
+
+	retreat: 2,
+	regulationMark: "J",
+	rarity: "Common",
+	dexId: [736],
+
+	thirdParty: {
+		cardmarket: 888186,
+	},
+};
+
+export default card;

--- a/data-asia/M/M5/003.ts
+++ b/data-asia/M/M5/003.ts
@@ -1,0 +1,47 @@
+import { Card } from "../../../interfaces";
+import Set from "../M5";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "カリキリ",
+	},
+
+	illustrator: "nisimono",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Grass"],
+
+	description: {
+		ja: "落ち着いて 日光浴 できるよう カリキリ専用の フラワーポットを 与える トレーナーも 多い。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "とつげき" },
+			damage: 30,
+			cost: ["Grass"],
+			effect: {
+				ja: "このポケモンにも10ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [{ type: "normal" }],
+
+	retreat: 1,
+	regulationMark: "J",
+	rarity: "Common",
+	dexId: [753],
+
+	thirdParty: {
+		cardmarket: 888227,
+	},
+};
+
+export default card;

--- a/data-asia/M/M5/004.ts
+++ b/data-asia/M/M5/004.ts
@@ -1,0 +1,57 @@
+import { Card } from "../../../interfaces";
+import Set from "../M5";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ラランテスex",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 260,
+	types: ["Grass"],
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "はつらつカッター" },
+			damage: "60+",
+			cost: ["Grass"],
+			effect: {
+				ja: "この番に、このポケモンのHPを回復していたなら、200ダメージ追加。",
+			},
+		},
+		{
+			name: { ja: "リーフガード" },
+			damage: 140,
+			cost: ["Grass", "Colorless"],
+			effect: {
+				ja: "次の相手の番、このポケモンが受けるワザのダメージは「-50」される。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [{ type: "holo" }],
+
+	evolveFrom: {
+		ja: "カリキリ",
+	},
+
+	retreat: 1,
+	regulationMark: "J",
+	rarity: "Double rare",
+	dexId: [754],
+
+	suffix: "EX",
+
+	thirdParty: {
+		cardmarket: 888240,
+	},
+};
+
+export default card;

--- a/data-asia/M/M5/005.ts
+++ b/data-asia/M/M5/005.ts
@@ -1,0 +1,56 @@
+import { Card } from "../../../interfaces";
+import Set from "../M5";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "チャデス",
+	},
+
+	illustrator: "Mousho",
+	category: "Pokemon",
+	hp: 30,
+	types: ["Grass"],
+
+	description: {
+		ja: "ヤバチャの リージョンフォームに 見えるが まったく 関係のない ポケモンと 最近 判明した。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ばけがくれ" },
+			effect: {
+				ja: "このポケモンは、相手のワザや特性の効果を受けない。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ひっそりのせる" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンに、ダメカンを1個のせる。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [{ type: "normal" }],
+
+	retreat: 0,
+	regulationMark: "J",
+	rarity: "Common",
+	dexId: [1012],
+
+	thirdParty: {
+		cardmarket: 888241,
+	},
+};
+
+export default card;

--- a/data-asia/M/M5/006.ts
+++ b/data-asia/M/M5/006.ts
@@ -1,0 +1,60 @@
+import { Card } from "../../../interfaces";
+import Set from "../M5";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヤバソチャ",
+	},
+
+	illustrator: "mingo",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Grass"],
+
+	description: {
+		ja: "民家の 床下や 棚の奥など 冷暗所を 好む。 日没後 獲物を 探して 徘徊する。",
+	},
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ばけがくれ" },
+			effect: {
+				ja: "このポケモンは、相手のワザや特性の効果を受けない。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "まっちゃスピン" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分のトラッシュに、特性「ばけがくれ」を持つポケモンが6枚以上あるなら、相手のポケモン全員に、それぞれダメカンを4個のせる。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [{ type: "normal" }],
+
+	evolveFrom: {
+		ja: "チャデス",
+	},
+
+	retreat: 1,
+	regulationMark: "J",
+	rarity: "Uncommon",
+	dexId: [1013],
+
+	thirdParty: {
+		cardmarket: 888243,
+	},
+};
+
+export default card;

--- a/data-asia/M/M5/007.ts
+++ b/data-asia/M/M5/007.ts
@@ -1,0 +1,54 @@
+import { Card } from "../../../interfaces";
+import Set from "../M5";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヒードラン",
+	},
+
+	illustrator: "Takeshi Nakamura",
+	category: "Pokemon",
+	hp: 140,
+	types: ["Fire"],
+
+	description: {
+		ja: "火山の 洞穴に 生息。 十字の ツメを 食いこませて 壁や 天井を はい回る。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "こがす" },
+			cost: ["Fire"],
+			effect: {
+				ja: "相手のバトルポケモンをやけどにする。",
+			},
+		},
+		{
+			name: { ja: "ようがんウォール" },
+			damage: 120,
+			cost: ["Fire", "Fire", "Colorless"],
+			effect: {
+				ja: "次の相手の番、このポケモンはやけどのポケモンからワザのダメージを受けない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [{ type: "normal" }],
+
+	retreat: 4,
+	regulationMark: "J",
+	rarity: "Uncommon",
+	dexId: [485],
+
+	thirdParty: {
+		cardmarket: 888244,
+	},
+};
+
+export default card;

--- a/data-asia/M/M5/008.ts
+++ b/data-asia/M/M5/008.ts
@@ -1,0 +1,54 @@
+import { Card } from "../../../interfaces";
+import Set from "../M5";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヤクデ",
+	},
+
+	illustrator: "Yuya Oka",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Fire"],
+
+	description: {
+		ja: "体に 溜めた 可燃ガスで 発熱。 とくに お腹の 黄色い 部分が 熱いのだ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "のやき" },
+			cost: ["Fire"],
+			effect: {
+				ja: "相手の山札を上から1枚トラッシュする。",
+			},
+		},
+		{
+			name: { ja: "バグパニック" },
+			damage: "50×",
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "自分の山札を下から7枚オモテにして、その中にある、ワザ「バグパニック」を持つポケモンの枚数×50ダメージ。オモテにしたポケモンは山札にもどして切る。残りのカードはトラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [{ type: "normal" }],
+
+	retreat: 2,
+	regulationMark: "J",
+	rarity: "Common",
+	dexId: [850],
+
+	thirdParty: {
+		cardmarket: 888245,
+	},
+};
+
+export default card;

--- a/data-asia/M/M5/009.ts
+++ b/data-asia/M/M5/009.ts
@@ -1,0 +1,58 @@
+import { Card } from "../../../interfaces";
+import Set from "../M5";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "マルヤクデ",
+	},
+
+	illustrator: "Kouki Saitou",
+	category: "Pokemon",
+	hp: 140,
+	types: ["Fire"],
+
+	description: {
+		ja: "発熱時の 体温は およそ ８００度。 体を 鞭のように しならせて 跳びかかってくるぞ。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "のやき" },
+			cost: ["Fire"],
+			effect: {
+				ja: "相手の山札を上から2枚トラッシュする。",
+			},
+		},
+		{
+			name: { ja: "ヒートタックル" },
+			damage: 160,
+			cost: ["Fire", "Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンにも30ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [{ type: "normal" }],
+
+	evolveFrom: {
+		ja: "ヤクデ",
+	},
+
+	retreat: 3,
+	regulationMark: "J",
+	rarity: "Common",
+	dexId: [851],
+
+	thirdParty: {
+		cardmarket: 888246,
+	},
+};
+
+export default card;

--- a/data-asia/M/M5/010.ts
+++ b/data-asia/M/M5/010.ts
@@ -1,0 +1,47 @@
+import { Card } from "../../../interfaces";
+import Set from "../M5";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "カルボウ",
+	},
+
+	illustrator: "Ryuta Fuse",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Fire"],
+
+	description: {
+		ja: "戦いになると 火力が 上がり 摂氏１０００度に 達する。 油分の多い 木の実を 好む。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ぜんりょくパンチ" },
+			damage: 40,
+			cost: ["Fire"],
+			effect: {
+				ja: "コインを1回投げウラなら、このワザは失敗。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [{ type: "normal" }],
+
+	retreat: 2,
+	regulationMark: "J",
+	rarity: "Common",
+	dexId: [935],
+
+	thirdParty: {
+		cardmarket: 888247,
+	},
+};
+
+export default card;

--- a/data-asia/M/M5/011.ts
+++ b/data-asia/M/M5/011.ts
@@ -1,0 +1,51 @@
+import { Card } from "../../../interfaces";
+import Set from "../M5";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "グレンアルマ",
+	},
+
+	illustrator: "Jiro Sasumo",
+	category: "Pokemon",
+	hp: 140,
+	types: ["Fire"],
+
+	description: {
+		ja: "エスパーと 炎の エネルギーで 強化された 鎧を まとう。 灼熱の 火の玉を 放つ。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "フレイムレギオン" },
+			damage: "40+",
+			cost: ["Fire"],
+			effect: {
+				ja: "[R]エネルギーがついている自分のベンチポケモンの数×40ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [{ type: "holo" }],
+
+	evolveFrom: {
+		ja: "カルボウ",
+	},
+
+	retreat: 2,
+	regulationMark: "J",
+	rarity: "Rare",
+	dexId: [936],
+
+	thirdParty: {
+		cardmarket: 888248,
+	},
+};
+
+export default card;

--- a/data-asia/M/M5/012.ts
+++ b/data-asia/M/M5/012.ts
@@ -1,0 +1,44 @@
+import { Card } from "../../../interfaces";
+import Set from "../M5";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "トサキント",
+	},
+
+	illustrator: "Shibuzoh.",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Water"],
+
+	description: {
+		ja: "背びれ 胸びれ 尾びれが 優雅に たなびくので 水の踊り子 と呼ばれる。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "つきさす" },
+			damage: 30,
+			cost: ["Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
+
+	variants: [{ type: "normal" }],
+
+	retreat: 1,
+	regulationMark: "J",
+	rarity: "Common",
+	dexId: [118],
+
+	thirdParty: {
+		cardmarket: 888249,
+	},
+};
+
+export default card;

--- a/data-asia/M/M5/013.ts
+++ b/data-asia/M/M5/013.ts
@@ -1,0 +1,50 @@
+import { Card } from "../../../interfaces";
+import Set from "../M5";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アズマオウ",
+	},
+
+	illustrator: "OKUBO",
+	category: "Pokemon",
+	hp: 110,
+	types: ["Water"],
+
+	description: {
+		ja: "秋になると プロポーズのため 体に 脂が のってきて とても きれいな色に 変化する。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "ハイドロショット" },
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のポケモン1匹に、このポケモンについている[W]エネルギーの数×30ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
+
+	variants: [{ type: "normal" }],
+
+	evolveFrom: {
+		ja: "トサキント",
+	},
+
+	retreat: 1,
+	regulationMark: "J",
+	rarity: "Uncommon",
+	dexId: [119],
+
+	thirdParty: {
+		cardmarket: 888250,
+	},
+};
+
+export default card;

--- a/data-asia/M/M5/014.ts
+++ b/data-asia/M/M5/014.ts
@@ -1,0 +1,49 @@
+import { Card } from "../../../interfaces";
+import Set from "../M5";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ホエルコ",
+	},
+
+	illustrator: "Asako Ito",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Water"],
+
+	description: {
+		ja: "飲みこんだ 海水を 目の 上の 鼻の 穴から 噴き出し アピール。 毎日 １トンの ヨワシを 食う。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "みずでっぽう" },
+			damage: 40,
+			cost: ["Water", "Water"],
+		},
+		{
+			name: { ja: "スプラッシュ" },
+			damage: 80,
+			cost: ["Water", "Water", "Water"],
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
+
+	variants: [{ type: "normal" }],
+
+	retreat: 4,
+	regulationMark: "J",
+	rarity: "Common",
+	dexId: [320],
+
+	thirdParty: {
+		cardmarket: 888251,
+	},
+};
+
+export default card;

--- a/data-asia/M/M5/015.ts
+++ b/data-asia/M/M5/015.ts
@@ -1,0 +1,54 @@
+import { Card } from "../../../interfaces";
+import Set from "../M5";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ホエルオーex",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 380,
+	types: ["Water"],
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "なみのり" },
+			damage: 120,
+			cost: ["Water", "Water", "Water"],
+		},
+		{
+			name: { ja: "フォーリングダウン" },
+			damage: 270,
+			cost: ["Water", "Water", "Water", "Water", "Water"],
+			effect: {
+				ja: "このポケモンをねむりにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
+
+	variants: [{ type: "holo" }],
+
+	evolveFrom: {
+		ja: "ホエルコ",
+	},
+
+	retreat: 4,
+	regulationMark: "J",
+	rarity: "Double rare",
+	dexId: [321],
+
+	suffix: "EX",
+
+	thirdParty: {
+		cardmarket: 888252,
+	},
+};
+
+export default card;

--- a/data-asia/M/M5/016.ts
+++ b/data-asia/M/M5/016.ts
@@ -1,0 +1,47 @@
+import { Card } from "../../../interfaces";
+import Set from "../M5";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ジーランス",
+	},
+
+	illustrator: "Naoyo Kimura",
+	category: "Pokemon",
+	hp: 100,
+	types: ["Water"],
+
+	description: {
+		ja: "岩のように 硬い ウロコと 脂の 詰まった 浮袋で 深海の 水圧に 耐える。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "フォッシルビート" },
+			damage: "10+",
+			cost: ["Colorless"],
+			effect: {
+				ja: "名前に「古びた」とつく自分のベンチポケモンの数×30ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
+
+	variants: [{ type: "normal" }],
+
+	retreat: 1,
+	regulationMark: "J",
+	rarity: "Uncommon",
+	dexId: [369],
+
+	thirdParty: {
+		cardmarket: 888253,
+	},
+};
+
+export default card;

--- a/data-asia/M/M5/017.ts
+++ b/data-asia/M/M5/017.ts
@@ -1,0 +1,44 @@
+import { Card } from "../../../interfaces";
+import Set from "../M5";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アシマリ",
+	},
+
+	illustrator: "Oswaldo KATO",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Water"],
+
+	description: {
+		ja: "鼻で ふくらませる バルーンは 日々 練習を 重ねることで 少しずつ 大きく なっていく。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "はたく" },
+			damage: 20,
+			cost: ["Water"],
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
+
+	variants: [{ type: "normal" }],
+
+	retreat: 1,
+	regulationMark: "J",
+	rarity: "Common",
+	dexId: [728],
+
+	thirdParty: {
+		cardmarket: 888255,
+	},
+};
+
+export default card;

--- a/data-asia/M/M5/018.ts
+++ b/data-asia/M/M5/018.ts
@@ -1,0 +1,48 @@
+import { Card } from "../../../interfaces";
+import Set from "../M5";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "オシャマリ",
+	},
+
+	illustrator: "MINAMINAMI Take",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Water"],
+
+	description: {
+		ja: "仲間を 思う 気持ちが 強い。 トレーナーが 落ち込んでいると ダンスを 踊って 励まそうとする。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "ハイパーボイス" },
+			damage: 40,
+			cost: ["Water"],
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
+
+	variants: [{ type: "normal" }],
+
+	evolveFrom: {
+		ja: "アシマリ",
+	},
+
+	retreat: 2,
+	regulationMark: "J",
+	rarity: "Common",
+	dexId: [729],
+
+	thirdParty: {
+		cardmarket: 888257,
+	},
+};
+
+export default card;

--- a/data-asia/M/M5/019.ts
+++ b/data-asia/M/M5/019.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../M5";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アシレーヌ",
+	},
+
+	illustrator: "Taira Akitsu",
+	category: "Pokemon",
+	hp: 150,
+	types: ["Water"],
+
+	description: {
+		ja: "歌姫の 異名を 持つ。 月夜の 晩に 群れを 率いて 歌う 姿は 幻想的。",
+	},
+
+	stage: "Stage2",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "まんたんメロディ" },
+			effect: {
+				ja: "自分の番に、このカードを手札から出して進化させたとき、1回使える。自分のポケモン1匹のHPを、すべて回復する。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "アクアリターン" },
+			damage: 120,
+			cost: ["Water", "Colorless"],
+			effect: {
+				ja: "このポケモンと、ついているすべてのカードを、山札にもどして切る。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
+
+	variants: [{ type: "holo" }],
+
+	evolveFrom: {
+		ja: "オシャマリ",
+	},
+
+	retreat: 2,
+	regulationMark: "J",
+	rarity: "Rare",
+	dexId: [730],
+
+	thirdParty: {
+		cardmarket: 888260,
+	},
+};
+
+export default card;

--- a/data-asia/M/M5/020.ts
+++ b/data-asia/M/M5/020.ts
@@ -1,0 +1,47 @@
+import { Card } from "../../../interfaces";
+import Set from "../M5";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ナミイルカ",
+	},
+
+	illustrator: "Yukiko Baba",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Water"],
+
+	description: {
+		ja: "水のリングは 頭の 穴から 出る 粘着液と 海の水を 混ぜて 作り出したものなのだ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ドレインフィン" },
+			damage: 20,
+			cost: ["Water", "Water"],
+			effect: {
+				ja: "このポケモンのHPを「20」回復する。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
+
+	variants: [{ type: "normal" }],
+
+	retreat: 2,
+	regulationMark: "J",
+	rarity: "Common",
+	dexId: [963],
+
+	thirdParty: {
+		cardmarket: 888262,
+	},
+};
+
+export default card;

--- a/data-asia/M/M5/021.ts
+++ b/data-asia/M/M5/021.ts
@@ -1,0 +1,51 @@
+import { Card } from "../../../interfaces";
+import Set from "../M5";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "イルカマン",
+	},
+
+	illustrator: "satoma",
+	category: "Pokemon",
+	hp: 150,
+	types: ["Water"],
+
+	description: {
+		ja: "５０ノットの 速さで 泳ぎ 溺れている 人や ポケモンを 助ける 海の ヒーロー。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "ジャスティスナックル" },
+			damage: "80+",
+			cost: ["Water", "Water"],
+			effect: {
+				ja: "相手のサイドの残り枚数が1枚なら、200ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
+
+	variants: [{ type: "normal" }],
+
+	evolveFrom: {
+		ja: "ナミイルカ",
+	},
+
+	retreat: 2,
+	regulationMark: "J",
+	rarity: "Uncommon",
+	dexId: [964],
+
+	thirdParty: {
+		cardmarket: 888263,
+	},
+};
+
+export default card;

--- a/data-asia/M/M5/022.ts
+++ b/data-asia/M/M5/022.ts
@@ -1,0 +1,51 @@
+import { Card } from "../../../interfaces";
+import Set from "../M5";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ラクライ",
+	},
+
+	illustrator: "Dsuke",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Lightning"],
+
+	description: {
+		ja: "静電気を 体毛に 蓄えて 放電する。 嵐が 近づくと 全身から 火花を 散らす。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "もってくる" },
+			cost: ["Lightning"],
+			effect: {
+				ja: "自分の山札を1枚引く。",
+			},
+		},
+		{
+			name: { ja: "たいあたり" },
+			damage: 30,
+			cost: ["Lightning", "Lightning"],
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [{ type: "normal" }],
+
+	retreat: 1,
+	regulationMark: "J",
+	rarity: "Common",
+	dexId: [309],
+
+	thirdParty: {
+		cardmarket: 888264,
+	},
+};
+
+export default card;

--- a/data-asia/M/M5/023.ts
+++ b/data-asia/M/M5/023.ts
@@ -1,0 +1,59 @@
+import { Card } from "../../../interfaces";
+import Set from "../M5";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ライボルト",
+	},
+
+	illustrator: "Uninori",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Lightning"],
+
+	description: {
+		ja: "たてがみから 放電している。 頭上に 雷雲を 作り 稲妻を 落として 攻撃する。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "フラッシュバリア" },
+			damage: 50,
+			cost: ["Lightning", "Lightning"],
+			effect: {
+				ja: "次の相手の番、このポケモンは進化ポケモンからワザのダメージを受けない。",
+			},
+		},
+		{
+			name: { ja: "ソニックエッジ" },
+			damage: 110,
+			cost: ["Lightning", "Lightning", "Lightning"],
+			effect: {
+				ja: "このワザのダメージは、相手のバトルポケモンにかかっている効果を計算しない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [{ type: "normal" }],
+
+	evolveFrom: {
+		ja: "ラクライ",
+	},
+
+	retreat: 1,
+	regulationMark: "J",
+	rarity: "Uncommon",
+	dexId: [310],
+
+	thirdParty: {
+		cardmarket: 888265,
+	},
+};
+
+export default card;

--- a/data-asia/M/M5/024.ts
+++ b/data-asia/M/M5/024.ts
@@ -1,0 +1,53 @@
+import { Card } from "../../../interfaces";
+import Set from "../M5";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "デンヂムシ",
+	},
+
+	illustrator: "Kazuhisa Uragami",
+	category: "Pokemon",
+	hp: 100,
+	types: ["Lightning"],
+
+	description: {
+		ja: "食べた 落ち葉を 消化するとき 発電して 電気を 溜めこむ。 あごの 先端から 放電する。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "はさむ" },
+			damage: 30,
+			cost: ["Lightning"],
+		},
+		{
+			name: { ja: "ぶつかる" },
+			damage: 50,
+			cost: ["Lightning", "Lightning"],
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [{ type: "normal" }],
+
+	evolveFrom: {
+		ja: "アゴジムシ",
+	},
+
+	retreat: 2,
+	regulationMark: "J",
+	rarity: "Common",
+	dexId: [737],
+
+	thirdParty: {
+		cardmarket: 888266,
+	},
+};
+
+export default card;

--- a/data-asia/M/M5/025.ts
+++ b/data-asia/M/M5/025.ts
@@ -1,0 +1,58 @@
+import { Card } from "../../../interfaces";
+import Set from "../M5";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "クワガノン",
+	},
+
+	illustrator: "KEIICHIRO ITO",
+	category: "Pokemon",
+	hp: 160,
+	types: ["Lightning"],
+
+	description: {
+		ja: "デンヂムシを 抱えて 電気を もらい 大あごから 強力な 電磁ビームを 連射する。",
+	},
+
+	stage: "Stage2",
+
+	attacks: [
+		{
+			name: { ja: "クイックダイブ" },
+			cost: ["Lightning"],
+			effect: {
+				ja: "相手のポケモン1匹に、50ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+			},
+		},
+		{
+			name: { ja: "ギガレールガン" },
+			damage: 260,
+			cost: ["Lightning", "Lightning"],
+			effect: {
+				ja: "このポケモンに「ボルト[L]エネルギー」がついていないなら、このワザは失敗。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [{ type: "normal" }],
+
+	evolveFrom: {
+		ja: "デンヂムシ",
+	},
+
+	retreat: 2,
+	regulationMark: "J",
+	rarity: "Uncommon",
+	dexId: [738],
+
+	thirdParty: {
+		cardmarket: 888267,
+	},
+};
+
+export default card;

--- a/data-asia/M/M5/026.ts
+++ b/data-asia/M/M5/026.ts
@@ -1,0 +1,53 @@
+import { Card } from "../../../interfaces";
+import Set from "../M5";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "メガゼラオラex",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 270,
+	types: ["Lightning"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "サンダーフィスト" },
+			damage: "60×",
+			cost: ["Lightning"],
+			effect: {
+				ja: "このポケモンについている[L]エネルギーの数×60ダメージ。",
+			},
+		},
+		{
+			name: { ja: "ゼプトターン" },
+			damage: 150,
+			cost: ["Lightning", "Lightning", "Lightning"],
+			effect: {
+				ja: "このポケモンをベンチポケモンと入れ替える。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [{ type: "holo" }],
+
+	retreat: 1,
+	regulationMark: "J",
+	rarity: "Double rare",
+	dexId: [807],
+
+	suffix: "EX",
+
+	thirdParty: {
+		cardmarket: 888269,
+	},
+};
+
+export default card;

--- a/data-asia/M/M5/027.ts
+++ b/data-asia/M/M5/027.ts
@@ -1,0 +1,57 @@
+import { Card } from "../../../interfaces";
+import Set from "../M5";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ミライドン",
+	},
+
+	illustrator: "mashu",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Lightning"],
+
+	description: {
+		ja: "古い 書物に 名が ある テツノオロチらしい。 雷で 大地を 灰に 変えたという。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "フォトンコード" },
+			effect: {
+				ja: "このポケモンが、バトル場で相手のポケモンからワザのダメージを受けてきぜつしたとき、このポケモンについている「基本[L]エネルギー」を2枚まで選び、ベンチポケモン1匹につけ替える。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "かみなり" },
+			damage: 90,
+			cost: ["Lightning", "Lightning"],
+			effect: {
+				ja: "このポケモンにも30ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [{ type: "normal" }],
+
+	retreat: 1,
+	regulationMark: "J",
+	rarity: "Uncommon",
+	dexId: [1008],
+
+	thirdParty: {
+		cardmarket: 888270,
+	},
+};
+
+export default card;

--- a/data-asia/M/M5/028.ts
+++ b/data-asia/M/M5/028.ts
@@ -1,0 +1,51 @@
+import { Card } from "../../../interfaces";
+import Set from "../M5";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヤドン",
+	},
+
+	illustrator: "Nelnal",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Psychic"],
+
+	description: {
+		ja: "水辺で ボーッとしている。 なにかが 尻尾に 噛みついても まる１日 気づかない。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "すてほうだい" },
+			cost: ["Psychic"],
+			effect: {
+				ja: "自分の手札を好きなだけ選び、トラッシュする。",
+			},
+		},
+		{
+			name: { ja: "ずつき" },
+			damage: 20,
+			cost: ["Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [{ type: "normal" }],
+
+	retreat: 2,
+	regulationMark: "J",
+	rarity: "Common",
+	dexId: [79],
+
+	thirdParty: {
+		cardmarket: 888271,
+	},
+};
+
+export default card;

--- a/data-asia/M/M5/029.ts
+++ b/data-asia/M/M5/029.ts
@@ -1,0 +1,56 @@
+import { Card } from "../../../interfaces";
+import Set from "../M5";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヤドラン",
+	},
+
+	illustrator: "CHORISO",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Psychic"],
+
+	description: {
+		ja: "くっついている シェルダーは 尻尾から にじみでる うま味が 欲しくて ずっと 離れない。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "スッカラカン" },
+			damage: "50+",
+			cost: ["Psychic"],
+			effect: {
+				ja: "自分の手札が1枚もないなら、160ダメージ追加。",
+			},
+		},
+		{
+			name: { ja: "しねんのずつき" },
+			damage: 110,
+			cost: ["Colorless", "Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [{ type: "normal" }],
+
+	evolveFrom: {
+		ja: "ヤドン",
+	},
+
+	retreat: 3,
+	regulationMark: "J",
+	rarity: "Uncommon",
+	dexId: [80],
+
+	thirdParty: {
+		cardmarket: 888272,
+	},
+};
+
+export default card;

--- a/data-asia/M/M5/030.ts
+++ b/data-asia/M/M5/030.ts
@@ -1,0 +1,54 @@
+import { Card } from "../../../interfaces";
+import Set from "../M5";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ルージュラ",
+	},
+
+	illustrator: "Yoshimoto Yoshimon",
+	category: "Pokemon",
+	hp: 100,
+	types: ["Psychic"],
+
+	description: {
+		ja: "人間の 言葉のような 不思議な 鳴き声。 ルージュラに 歌わせる 曲を 作る 音楽家もいる。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "きょうれつキッス" },
+			cost: ["Psychic"],
+			effect: {
+				ja: "次の相手の番の終わりに、このワザを受けたポケモンと、ついているすべてのカードを、トラッシュする。",
+			},
+		},
+		{
+			name: { ja: "ねんりき" },
+			damage: 50,
+			cost: ["Psychic", "Colorless"],
+			effect: {
+				ja: "コインを1回投げオモテなら、相手のバトルポケモンをマヒにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [{ type: "normal" }],
+
+	retreat: 1,
+	regulationMark: "J",
+	rarity: "Common",
+	dexId: [124],
+
+	thirdParty: {
+		cardmarket: 888273,
+	},
+};
+
+export default card;

--- a/data-asia/M/M5/031.ts
+++ b/data-asia/M/M5/031.ts
@@ -1,0 +1,54 @@
+import { Card } from "../../../interfaces";
+import Set from "../M5";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "カゲボウズ",
+	},
+
+	illustrator: "Bun Toujo",
+	category: "Pokemon",
+	hp: 50,
+	types: ["Psychic"],
+
+	description: {
+		ja: "頭の ツノで 恨みや ねたみの 感情を 食べると いわれる。 真夜中 活発に 活動する。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ばけがくれ" },
+			effect: {
+				ja: "このポケモンは、相手のワザや特性の効果を受けない。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ぶらさがる" },
+			damage: 10,
+			cost: ["Psychic"],
+		},
+	],
+
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [{ type: "normal" }],
+
+	retreat: 1,
+	regulationMark: "J",
+	rarity: "Common",
+	dexId: [353],
+
+	thirdParty: {
+		cardmarket: 888274,
+	},
+};
+
+export default card;

--- a/data-asia/M/M5/032.ts
+++ b/data-asia/M/M5/032.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../M5";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ジュペッタ",
+	},
+
+	illustrator: "Mugi Hamada",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Psychic"],
+
+	description: {
+		ja: "捨てられた ぬいぐるみに おんねんが 宿り ポケモンになった。 自分を 捨てた 子供を 捜している。",
+	},
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ばけがくれ" },
+			effect: {
+				ja: "このポケモンは、相手のワザや特性の効果を受けない。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "にんぎょうキャッチ" },
+			damage: 80,
+			cost: ["Psychic"],
+			effect: {
+				ja: "のぞむなら、自分の山札から好きなカードを1枚選び、手札に加える。そして山札を切る。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [{ type: "normal" }],
+
+	evolveFrom: {
+		ja: "カゲボウズ",
+	},
+
+	retreat: 1,
+	regulationMark: "J",
+	rarity: "Uncommon",
+	dexId: [354],
+
+	thirdParty: {
+		cardmarket: 888275,
+	},
+};
+
+export default card;

--- a/data-asia/M/M5/033.ts
+++ b/data-asia/M/M5/033.ts
@@ -1,0 +1,46 @@
+import { Card } from "../../../interfaces";
+import Set from "../M5";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ミカルゲ",
+	},
+
+	illustrator: "danciao",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Psychic"],
+
+	description: {
+		ja: "１０８個の 魂で できている。 二度と 悪さを しないように 要石に 縛りつけられている。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "たましいエンド" },
+			cost: ["Psychic"],
+			effect: {
+				ja: "自分のトラッシュに、特性「ばけがくれ」を持つポケモンが13枚以上あるなら、相手のポケモンを2匹選び、それぞれのっているダメカンの数が4倍になるように、ダメカンをのせる。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [{ type: "holo" }],
+
+	retreat: 1,
+	regulationMark: "J",
+	rarity: "Rare",
+	dexId: [442],
+
+	thirdParty: {
+		cardmarket: 888276,
+	},
+};
+
+export default card;

--- a/data-asia/M/M5/034.ts
+++ b/data-asia/M/M5/034.ts
@@ -1,0 +1,44 @@
+import { Card } from "../../../interfaces";
+import Set from "../M5";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヒトモシ",
+	},
+
+	illustrator: "HYOGONOSUKE",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Psychic"],
+
+	description: {
+		ja: "ヒトモシの 灯す 明かりは 人や ポケモンの 生命力を 吸い取って 燃えているのだ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "おにび" },
+			damage: 20,
+			cost: ["Psychic"],
+		},
+	],
+
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [{ type: "normal" }],
+
+	retreat: 1,
+	regulationMark: "J",
+	rarity: "Common",
+	dexId: [607],
+
+	thirdParty: {
+		cardmarket: 888277,
+	},
+};
+
+export default card;

--- a/data-asia/M/M5/035.ts
+++ b/data-asia/M/M5/035.ts
@@ -1,0 +1,50 @@
+import { Card } from "../../../interfaces";
+import Set from "../M5";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ランプラー",
+	},
+
+	illustrator: "sowsow",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Psychic"],
+
+	description: {
+		ja: "臨終の 際に 現れて 魂が 肉体を 離れると すかさず 吸い取ってしまうのだ。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "ふえるあかり" },
+			cost: ["Psychic"],
+			effect: {
+				ja: "自分の山札から「ランプラー」を3枚まで選び、ベンチに出す。そして山札を切る。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [{ type: "normal" }],
+
+	evolveFrom: {
+		ja: "ヒトモシ",
+	},
+
+	retreat: 1,
+	regulationMark: "J",
+	rarity: "Common",
+	dexId: [608],
+
+	thirdParty: {
+		cardmarket: 888278,
+	},
+};
+
+export default card;

--- a/data-asia/M/M5/036.ts
+++ b/data-asia/M/M5/036.ts
@@ -1,0 +1,59 @@
+import { Card } from "../../../interfaces";
+import Set from "../M5";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "メガシャンデラex",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 350,
+	types: ["Psychic"],
+
+	stage: "Stage2",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "じゅばくのほのお" },
+			effect: {
+				ja: "このポケモンがいるかぎり、相手のバトルポケモンは、にげるためのエネルギーが1個ぶん多くなる。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ファントムメイズ" },
+			damage: "130+",
+			cost: ["Psychic", "Psychic"],
+			effect: {
+				ja: "相手のバトルポケモンのにげるためのエネルギーの数×50ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [{ type: "holo" }],
+
+	evolveFrom: {
+		ja: "ランプラー",
+	},
+
+	retreat: 2,
+	regulationMark: "J",
+	rarity: "Double rare",
+	dexId: [609],
+
+	suffix: "EX",
+
+	thirdParty: {
+		cardmarket: 888279,
+	},
+};
+
+export default card;

--- a/data-asia/M/M5/037.ts
+++ b/data-asia/M/M5/037.ts
@@ -1,0 +1,47 @@
+import { Card } from "../../../interfaces";
+import Set from "../M5";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ダダリン",
+	},
+
+	illustrator: "Oku",
+	category: "Pokemon",
+	hp: 140,
+	types: ["Psychic"],
+
+	description: {
+		ja: "海底を 漂う 藻屑が 沈没船の 部品を 取りこんで ゴーストポケモンに 生まれ変わった。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "むねんのイカリ" },
+			damage: "30+",
+			cost: ["Psychic"],
+			effect: {
+				ja: "自分のトラッシュに、特性「ばけがくれ」を持つポケモンが4枚以上あるなら、140ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [{ type: "normal" }],
+
+	retreat: 3,
+	regulationMark: "J",
+	rarity: "Uncommon",
+	dexId: [781],
+
+	thirdParty: {
+		cardmarket: 888280,
+	},
+};
+
+export default card;

--- a/data-asia/M/M5/038.ts
+++ b/data-asia/M/M5/038.ts
@@ -1,0 +1,47 @@
+import { Card } from "../../../interfaces";
+import Set from "../M5";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "マーシャドー",
+	},
+
+	illustrator: "Nakamura Ippan",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Psychic"],
+
+	description: {
+		ja: "拳法の 達人の 影に 潜って 動きを コピーしたため 究極奥義を 身につけた。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "かげむすび" },
+			damage: "30×",
+			cost: ["Psychic"],
+			effect: {
+				ja: "相手のバトルポケモンのにげるためのエネルギーの数×30ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [{ type: "normal" }],
+
+	retreat: 1,
+	regulationMark: "J",
+	rarity: "Uncommon",
+	dexId: [802],
+
+	thirdParty: {
+		cardmarket: 888281,
+	},
+};
+
+export default card;

--- a/data-asia/M/M5/039.ts
+++ b/data-asia/M/M5/039.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../M5";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "コノヨザル",
+	},
+
+	illustrator: "Haru Akasaka",
+	category: "Pokemon",
+	hp: 150,
+	types: ["Psychic"],
+
+	description: {
+		ja: "心に 秘めた 怒りのパワーを こぶしに 込めて 叩きつけると 相手を 骨の髄から 砕く。",
+	},
+
+	stage: "Stage2",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "くちないからだ" },
+			effect: {
+				ja: "このポケモンが、ワザのダメージを受けてきぜつするとき、自分はコインを1回投げる。オモテなら、このポケモンはきぜつせず、残りHPが「10」の状態で場に残る。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ゴーストブロー" },
+			damage: 100,
+			cost: ["Psychic", "Psychic"],
+			effect: {
+				ja: "相手のベンチポケモン1匹に、ダメカンを5個のせる。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [{ type: "normal" }],
+
+	evolveFrom: {
+		ja: "オコリザル",
+	},
+
+	retreat: 2,
+	regulationMark: "J",
+	rarity: "Uncommon",
+	dexId: [979],
+
+	thirdParty: {
+		cardmarket: 888283,
+	},
+};
+
+export default card;

--- a/data-asia/M/M5/040.ts
+++ b/data-asia/M/M5/040.ts
@@ -1,0 +1,44 @@
+import { Card } from "../../../interfaces";
+import Set from "../M5";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "マンキー",
+	},
+
+	illustrator: "Yuka Morii",
+	category: "Pokemon",
+	hp: 50,
+	types: ["Fighting"],
+
+	description: {
+		ja: "普段は 機嫌が 良くても ちょっとしたことで いきなり 暴れだすから 怖いのだ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "けたぐり" },
+			damage: 20,
+			cost: ["Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [{ type: "normal" }],
+
+	retreat: 1,
+	regulationMark: "J",
+	rarity: "Common",
+	dexId: [56],
+
+	thirdParty: {
+		cardmarket: 888285,
+	},
+};
+
+export default card;

--- a/data-asia/M/M5/041.ts
+++ b/data-asia/M/M5/041.ts
@@ -1,0 +1,48 @@
+import { Card } from "../../../interfaces";
+import Set from "../M5";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "オコリザル",
+	},
+
+	illustrator: "GOSSAN",
+	category: "Pokemon",
+	hp: 110,
+	types: ["Fighting"],
+
+	description: {
+		ja: "ある研究者の 学説では モンスターボールの 中でも オコリザルは 怒っているらしい。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "どつく" },
+			damage: 50,
+			cost: ["Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [{ type: "normal" }],
+
+	evolveFrom: {
+		ja: "マンキー",
+	},
+
+	retreat: 2,
+	regulationMark: "J",
+	rarity: "Common",
+	dexId: [57],
+
+	thirdParty: {
+		cardmarket: 888286,
+	},
+};
+
+export default card;

--- a/data-asia/M/M5/042.ts
+++ b/data-asia/M/M5/042.ts
@@ -1,0 +1,47 @@
+import { Card } from "../../../interfaces";
+import Set from "../M5";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ズガイドス",
+	},
+
+	illustrator: "Hideki Ishikawa",
+	category: "Pokemon",
+	hp: 100,
+	types: ["Fighting"],
+
+	description: {
+		ja: "ズガイドス同士が 頭を ぶつけあうことで 頑丈な 頭が さらに 鍛えられる。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "つきとばす" },
+			damage: 70,
+			cost: ["Fighting", "Fighting"],
+			effect: {
+				ja: "相手のバトルポケモンをベンチポケモンと入れ替える。［バトル場に出すポケモンは相手が選ぶ。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [{ type: "normal" }],
+
+	retreat: 2,
+	regulationMark: "J",
+	rarity: "Common",
+	dexId: [408],
+
+	thirdParty: {
+		cardmarket: 888297,
+	},
+};
+
+export default card;

--- a/data-asia/M/M5/043.ts
+++ b/data-asia/M/M5/043.ts
@@ -1,0 +1,59 @@
+import { Card } from "../../../interfaces";
+import Set from "../M5";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ラムパルドex",
+	},
+
+	illustrator: "hncl",
+	category: "Pokemon",
+	hp: 330,
+	types: ["Fighting"],
+
+	stage: "Stage2",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "はかいのずつき" },
+			effect: {
+				ja: "このポケモンがバトル場にいるなら、自分の番に1回使える。コインを1回投げオモテなら、相手のバトルポケモンについているエネルギーを1個選び、トラッシュする。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ランページハンマー" },
+			damage: 150,
+			cost: ["Fighting", "Fighting"],
+			effect: {
+				ja: "次の自分の番、このポケモンが使うワザの、相手のバトルポケモンへのダメージは「+150」される。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [{ type: "holo" }],
+
+	evolveFrom: {
+		ja: "ズガイドス",
+	},
+
+	retreat: 2,
+	regulationMark: "J",
+	rarity: "Double rare",
+	dexId: [409],
+
+	suffix: "EX",
+
+	thirdParty: {
+		cardmarket: 888298,
+	},
+};
+
+export default card;

--- a/data-asia/M/M5/044.ts
+++ b/data-asia/M/M5/044.ts
@@ -1,0 +1,51 @@
+import { Card } from "../../../interfaces";
+import Set from "../M5";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "モグリュー",
+	},
+
+	illustrator: "Atsushi Furusawa",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Fighting"],
+
+	description: {
+		ja: "体を スピンさせることで 時速５０キロの スピードのまま まっすぐ 地面を 掘り進む。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "なかまをよぶ" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札からたねポケモンを2枚まで選び、ベンチに出す。そして山札を切る。",
+			},
+		},
+		{
+			name: { ja: "ツメをたてる" },
+			damage: 50,
+			cost: ["Colorless", "Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [{ type: "normal" }],
+
+	retreat: 2,
+	regulationMark: "J",
+	rarity: "Common",
+	dexId: [529],
+
+	thirdParty: {
+		cardmarket: 888299,
+	},
+};
+
+export default card;

--- a/data-asia/M/M5/045.ts
+++ b/data-asia/M/M5/045.ts
@@ -1,0 +1,55 @@
+import { Card } from "../../../interfaces";
+import Set from "../M5";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "コライドン",
+	},
+
+	illustrator: "kodama",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Fighting"],
+
+	description: {
+		ja: "拳で 大地を 引き裂いたと 古い 探検記に 記された ツバサノオウの 正体らしい。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "バトルクロー" },
+			damage: "30+",
+			cost: ["Fighting"],
+			effect: {
+				ja: "相手のバトルポケモンが進化ポケモンなら、30ダメージ追加。",
+			},
+		},
+		{
+			name: { ja: "ガイアインパクト" },
+			damage: 190,
+			cost: ["Fighting", "Fighting", "Colorless"],
+			effect: {
+				ja: "このポケモンについているエネルギーを、すべてトラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [{ type: "normal" }],
+
+	retreat: 2,
+	regulationMark: "J",
+	rarity: "Uncommon",
+	dexId: [1007],
+
+	thirdParty: {
+		cardmarket: 888300,
+	},
+};
+
+export default card;

--- a/data-asia/M/M5/046.ts
+++ b/data-asia/M/M5/046.ts
@@ -1,0 +1,52 @@
+import { Card } from "../../../interfaces";
+import Set from "../M5";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "メガダークライex",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 280,
+	types: ["Darkness"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ナイトレイド" },
+			damage: "110+",
+			cost: ["Darkness", "Darkness"],
+			effect: {
+				ja: "自分のベンチポケモンにダメカンがのっているなら、110ダメージ追加。",
+			},
+		},
+		{
+			name: { ja: "アビスアイ" },
+			cost: ["Darkness", "Darkness", "Darkness"],
+			effect: {
+				ja: "相手のバトルポケモンが特殊状態なら、そのポケモンをきぜつさせる。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [{ type: "holo" }],
+
+	retreat: 2,
+	regulationMark: "J",
+	rarity: "Double rare",
+	dexId: [491],
+
+	suffix: "EX",
+
+	thirdParty: {
+		cardmarket: 888301,
+	},
+};
+
+export default card;

--- a/data-asia/M/M5/047.ts
+++ b/data-asia/M/M5/047.ts
@@ -1,0 +1,49 @@
+import { Card } from "../../../interfaces";
+import Set from "../M5";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "バルチャイ",
+	},
+
+	illustrator: "Shiburingaru",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Darkness"],
+
+	description: {
+		ja: "食べ盛りの 育ち盛り。 体の 成長に あわせて ガイコツを 何度も 履き替えるよ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "はばたく" },
+			damage: 10,
+			cost: ["Darkness"],
+		},
+		{
+			name: { ja: "かぜおこし" },
+			damage: 20,
+			cost: ["Darkness", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [{ type: "normal" }],
+
+	retreat: 1,
+	regulationMark: "J",
+	rarity: "Common",
+	dexId: [629],
+
+	thirdParty: {
+		cardmarket: 888302,
+	},
+};
+
+export default card;

--- a/data-asia/M/M5/048.ts
+++ b/data-asia/M/M5/048.ts
@@ -1,0 +1,55 @@
+import { Card } from "../../../interfaces";
+import Set from "../M5";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "バルジーナ",
+	},
+
+	illustrator: "Nisota Niso",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Darkness"],
+
+	description: {
+		ja: "空から 地上を 観察して 弱った 獲物に 襲いかかる。 骨で 着飾る 習性。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "ボーンスナイプ" },
+			cost: ["Darkness"],
+			effect: {
+				ja: "特殊エネルギーがついている相手のポケモン1匹に、70ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+			},
+		},
+		{
+			name: { ja: "ブラストウインド" },
+			damage: 120,
+			cost: ["Darkness", "Darkness", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [{ type: "normal" }],
+
+	evolveFrom: {
+		ja: "バルチャイ",
+	},
+
+	retreat: 2,
+	regulationMark: "J",
+	rarity: "Common",
+	dexId: [630],
+
+	thirdParty: {
+		cardmarket: 888303,
+	},
+};
+
+export default card;

--- a/data-asia/M/M5/049.ts
+++ b/data-asia/M/M5/049.ts
@@ -1,0 +1,51 @@
+import { Card } from "../../../interfaces";
+import Set from "../M5";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "マーイーカ",
+	},
+
+	illustrator: "Yuriko Akase",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Darkness"],
+
+	description: {
+		ja: "光の 点滅で 襲ってきた 敵の 戦意を なくしてしまう。 その 隙に 姿を くらますのだ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ちょうたつ" },
+			cost: ["Darkness"],
+			effect: {
+				ja: "自分の山札からグッズを1枚選び、相手に見せて、手札に加える。そして山札を切る。",
+			},
+		},
+		{
+			name: { ja: "かいてんアタック" },
+			damage: 30,
+			cost: ["Darkness", "Darkness"],
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [{ type: "normal" }],
+
+	retreat: 1,
+	regulationMark: "J",
+	rarity: "Common",
+	dexId: [686],
+
+	thirdParty: {
+		cardmarket: 888304,
+	},
+};
+
+export default card;

--- a/data-asia/M/M5/050.ts
+++ b/data-asia/M/M5/050.ts
@@ -1,0 +1,58 @@
+import { Card } from "../../../interfaces";
+import Set from "../M5";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "カラマネロ",
+	},
+
+	illustrator: "Naoki Saito",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Darkness"],
+
+	description: {
+		ja: "ポケモンで 一番 強力な 催眠術を 使う。 相手を 意のままに 操ってしまうのだ。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "まどわす" },
+			cost: ["Darkness"],
+			effect: {
+				ja: "相手のバトルポケモンをこんらんにする。",
+			},
+		},
+		{
+			name: { ja: "ブレインクラッシュ" },
+			damage: 130,
+			cost: ["Darkness"],
+			effect: {
+				ja: "相手のバトルポケモンがこんらんでないなら、このワザは失敗。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [{ type: "normal" }],
+
+	evolveFrom: {
+		ja: "マーイーカ",
+	},
+
+	retreat: 2,
+	regulationMark: "J",
+	rarity: "Uncommon",
+	dexId: [687],
+
+	thirdParty: {
+		cardmarket: 888305,
+	},
+};
+
+export default card;

--- a/data-asia/M/M5/051.ts
+++ b/data-asia/M/M5/051.ts
@@ -1,0 +1,49 @@
+import { Card } from "../../../interfaces";
+import Set from "../M5";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "クスネ",
+	},
+
+	illustrator: "Krgc",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Darkness"],
+
+	description: {
+		ja: "ほかの ポケモンが みつけた 餌を 掠めて 暮らしている。 ふかふかの 肉球は 足音を たてない。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "かじる" },
+			damage: 10,
+			cost: ["Darkness"],
+		},
+		{
+			name: { ja: "うしろげり" },
+			damage: 30,
+			cost: ["Darkness", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [{ type: "normal" }],
+
+	retreat: 1,
+	regulationMark: "J",
+	rarity: "Common",
+	dexId: [827],
+
+	thirdParty: {
+		cardmarket: 888306,
+	},
+};
+
+export default card;

--- a/data-asia/M/M5/052.ts
+++ b/data-asia/M/M5/052.ts
@@ -1,0 +1,55 @@
+import { Card } from "../../../interfaces";
+import Set from "../M5";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "フォクスライ",
+	},
+
+	illustrator: "GOTO minori",
+	category: "Pokemon",
+	hp: 100,
+	types: ["Darkness"],
+
+	description: {
+		ja: "狙った 獲物は こっそり マーキング。 においを 辿って 油断 したころ 盗みに 来るぞ。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "スキルシーフ" },
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "自分の手札が1枚もないなら、相手の場のポケモンが持つワザを1つ選び、このワザとして使う。",
+			},
+		},
+		{
+			name: { ja: "するどいキバ" },
+			damage: 80,
+			cost: ["Darkness", "Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [{ type: "normal" }],
+
+	evolveFrom: {
+		ja: "クスネ",
+	},
+
+	retreat: 1,
+	regulationMark: "J",
+	rarity: "Uncommon",
+	dexId: [828],
+
+	thirdParty: {
+		cardmarket: 888307,
+	},
+};
+
+export default card;

--- a/data-asia/M/M5/053.ts
+++ b/data-asia/M/M5/053.ts
@@ -1,0 +1,52 @@
+import { Card } from "../../../interfaces";
+import Set from "../M5";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "モルペコex",
+	},
+
+	illustrator: "aky CG Works",
+	category: "Pokemon",
+	hp: 180,
+	types: ["Darkness"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ホイールドロー" },
+			cost: ["Darkness"],
+			effect: {
+				ja: "自分の手札をすべて山札にもどして切る。その後、山札を6枚引く。",
+			},
+		},
+		{
+			name: { ja: "はらぺこボンバー" },
+			damage: "40+",
+			cost: ["Darkness", "Darkness"],
+			effect: {
+				ja: "このポケモンにのっているダメカンの数×40ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [{ type: "holo" }],
+
+	retreat: 1,
+	regulationMark: "J",
+	rarity: "Double rare",
+	dexId: [877],
+
+	suffix: "EX",
+
+	thirdParty: {
+		cardmarket: 888308,
+	},
+};
+
+export default card;

--- a/data-asia/M/M5/054.ts
+++ b/data-asia/M/M5/054.ts
@@ -1,0 +1,55 @@
+import { Card } from "../../../interfaces";
+import Set from "../M5";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ザルード",
+	},
+
+	illustrator: "matazo",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Darkness"],
+
+	description: {
+		ja: "群れを つくり 密林で 暮らす。 とても 攻撃的で 森にすむ ポケモンたちから 恐れられている。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "うしろなげ" },
+			damage: 30,
+			cost: ["Darkness"],
+			effect: {
+				ja: "自分のベンチポケモン1匹にも、30ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+			},
+		},
+		{
+			name: { ja: "シャドーウィップ" },
+			damage: "100+",
+			cost: ["Darkness", "Darkness", "Darkness"],
+			effect: {
+				ja: "自分のベンチポケモンに「シャドー[D]エネルギー」がついているなら、70ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [{ type: "normal" }],
+
+	retreat: 2,
+	regulationMark: "J",
+	rarity: "Uncommon",
+	dexId: [893],
+
+	thirdParty: {
+		cardmarket: 888310,
+	},
+};
+
+export default card;

--- a/data-asia/M/M5/055.ts
+++ b/data-asia/M/M5/055.ts
@@ -1,0 +1,44 @@
+import { Card } from "../../../interfaces";
+import Set from "../M5";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "オラチフ",
+	},
+
+	illustrator: "ryoma uratsuka",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Darkness"],
+
+	description: {
+		ja: "発達した あごと キバは 岩を 噛み砕く 力強さ。 厚い 脂肪は 防御力 抜群。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "かみつく" },
+			damage: 40,
+			cost: ["Darkness", "Darkness"],
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [{ type: "normal" }],
+
+	retreat: 2,
+	regulationMark: "J",
+	rarity: "Common",
+	dexId: [942],
+
+	thirdParty: {
+		cardmarket: 888311,
+	},
+};
+
+export default card;

--- a/data-asia/M/M5/056.ts
+++ b/data-asia/M/M5/056.ts
@@ -1,0 +1,56 @@
+import { Card } from "../../../interfaces";
+import Set from "../M5";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "マフィティフ",
+	},
+
+	illustrator: "kawayoo",
+	category: "Pokemon",
+	hp: 140,
+	types: ["Darkness"],
+
+	description: {
+		ja: "子どもと 遊ぶことが 大好き。 普段は 温厚だが 家族を 守るとき 形相が 変わる。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "かみつく" },
+			damage: 60,
+			cost: ["Darkness", "Darkness"],
+		},
+		{
+			name: { ja: "とびこみヘッド" },
+			damage: 210,
+			cost: ["Darkness", "Darkness", "Darkness"],
+			effect: {
+				ja: "次の相手の番、このポケモンが受けるワザのダメージは「+100」される。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [{ type: "normal" }],
+
+	evolveFrom: {
+		ja: "オラチフ",
+	},
+
+	retreat: 3,
+	regulationMark: "J",
+	rarity: "Common",
+	dexId: [943],
+
+	thirdParty: {
+		cardmarket: 888313,
+	},
+};
+
+export default card;

--- a/data-asia/M/M5/057.ts
+++ b/data-asia/M/M5/057.ts
@@ -1,0 +1,47 @@
+import { Card } from "../../../interfaces";
+import Set from "../M5";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "イーユイ",
+	},
+
+	illustrator: "IKEDA Saki",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Darkness"],
+
+	description: {
+		ja: "多くの 争いの 火種となった 勾玉に 集まった 妬みが 炎を まとい ポケモンとなった。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "うずまくねたみ" },
+			damage: "20+",
+			cost: ["Darkness"],
+			effect: {
+				ja: "このポケモンにダメカンが2個以上のっているなら、90ダメージ追加。このワザのダメージは弱点を計算しない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [{ type: "holo" }],
+
+	retreat: 1,
+	regulationMark: "J",
+	rarity: "Rare",
+	dexId: [1004],
+
+	thirdParty: {
+		cardmarket: 888315,
+	},
+};
+
+export default card;

--- a/data-asia/M/M5/058.ts
+++ b/data-asia/M/M5/058.ts
@@ -1,0 +1,47 @@
+import { Card } from "../../../interfaces";
+import Set from "../M5";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "エアームド",
+	},
+
+	illustrator: "Anesaki Dynamic",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Metal"],
+
+	description: {
+		ja: "いばらの 中に 巣を作る。 トゲで 傷つきながら 育てられた ヒナの 羽は 硬くなる。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "スチールカッター" },
+			damage: "40×",
+			cost: ["Metal"],
+			effect: {
+				ja: "自分の手札から「基本[M]エネルギー」を2枚までトラッシュし、その枚数×40ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [{ type: "normal" }],
+
+	retreat: 1,
+	regulationMark: "J",
+	rarity: "Common",
+	dexId: [227],
+
+	thirdParty: {
+		cardmarket: 888318,
+	},
+};
+
+export default card;

--- a/data-asia/M/M5/059.ts
+++ b/data-asia/M/M5/059.ts
@@ -1,0 +1,47 @@
+import { Card } from "../../../interfaces";
+import Set from "../M5";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "タテトプス",
+	},
+
+	illustrator: "Kurata So",
+	category: "Pokemon",
+	hp: 100,
+	types: ["Metal"],
+
+	description: {
+		ja: "頑丈な 顔のおかげで 敵は 少なかったと 思われる。 太古の ジャングルに 棲んでいた。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "くだく" },
+			damage: 50,
+			cost: ["Metal", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンについているエネルギーを1個選び、トラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Grass", value: "-30" }],
+
+	variants: [{ type: "normal" }],
+
+	retreat: 3,
+	regulationMark: "J",
+	rarity: "Common",
+	dexId: [410],
+
+	thirdParty: {
+		cardmarket: 888321,
+	},
+};
+
+export default card;

--- a/data-asia/M/M5/060.ts
+++ b/data-asia/M/M5/060.ts
@@ -1,0 +1,58 @@
+import { Card } from "../../../interfaces";
+import Set from "../M5";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "トリデプス",
+	},
+
+	illustrator: "Kinu Nishimura",
+	category: "Pokemon",
+	hp: 160,
+	types: ["Metal"],
+
+	description: {
+		ja: "群れで 暮らす トリデプスたちは 敵に 襲われると 横に 並び 硬い 顔で 攻撃を 防ぐ。",
+	},
+
+	stage: "Stage2",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "たいこのぼうへき" },
+			effect: {
+				ja: "このポケモンがベンチにいるかぎり、自分のポケモン全員は、ついているエネルギーが2個以下の相手のポケモンからワザのダメージを受けない。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ぶちかます" },
+			damage: 160,
+			cost: ["Metal", "Metal", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Grass", value: "-30" }],
+
+	variants: [{ type: "holo" }],
+
+	evolveFrom: {
+		ja: "タテトプス",
+	},
+
+	retreat: 4,
+	regulationMark: "J",
+	rarity: "Rare",
+	dexId: [411],
+
+	thirdParty: {
+		cardmarket: 888323,
+	},
+};
+
+export default card;

--- a/data-asia/M/M5/061.ts
+++ b/data-asia/M/M5/061.ts
@@ -1,0 +1,47 @@
+import { Card } from "../../../interfaces";
+import Set from "../M5";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ドーミラー",
+	},
+
+	illustrator: "Saboteri",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Metal"],
+
+	description: {
+		ja: "古い お墓から みつかる。 背中の 模様には 神秘的な 力が 宿っていると いわれる。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ミラーアタック" },
+			damage: "10+",
+			cost: ["Metal"],
+			effect: {
+				ja: "相手のバトルポケモンが[M]ポケモンなら、30ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Grass", value: "-30" }],
+
+	variants: [{ type: "normal" }],
+
+	retreat: 3,
+	regulationMark: "J",
+	rarity: "Common",
+	dexId: [436],
+
+	thirdParty: {
+		cardmarket: 888324,
+	},
+};
+
+export default card;

--- a/data-asia/M/M5/062.ts
+++ b/data-asia/M/M5/062.ts
@@ -1,0 +1,56 @@
+import { Card } from "../../../interfaces";
+import Set from "../M5";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ドータクン",
+	},
+
+	illustrator: "Uta",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Metal"],
+
+	description: {
+		ja: "別世界への 穴を 開けて そこから 雨を 降らしていた。 そのため 豊作の神 とされる。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "ひっぱたく" },
+			damage: 40,
+			cost: ["Metal"],
+		},
+		{
+			name: { ja: "メタルブロック" },
+			damage: 120,
+			cost: ["Metal", "Metal", "Colorless"],
+			effect: {
+				ja: "次の相手の番、このポケモンが進化ポケモンから受けるワザのダメージは「-100」される。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Grass", value: "-30" }],
+
+	variants: [{ type: "normal" }],
+
+	evolveFrom: {
+		ja: "ドーミラー",
+	},
+
+	retreat: 3,
+	regulationMark: "J",
+	rarity: "Uncommon",
+	dexId: [437],
+
+	thirdParty: {
+		cardmarket: 888325,
+	},
+};
+
+export default card;

--- a/data-asia/M/M5/063.ts
+++ b/data-asia/M/M5/063.ts
@@ -1,0 +1,57 @@
+import { Card } from "../../../interfaces";
+import Set from "../M5";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "メガドリュウズex",
+	},
+
+	illustrator: "Keisuke Azuma",
+	category: "Pokemon",
+	hp: 340,
+	types: ["Metal"],
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "ほりくずす" },
+			damage: 90,
+			cost: ["Metal", "Metal"],
+			effect: {
+				ja: "相手の山札を上から2枚トラッシュする。",
+			},
+		},
+		{
+			name: { ja: "マキシマムドリル" },
+			damage: "200+",
+			cost: ["Metal", "Metal", "Metal"],
+			effect: {
+				ja: "このワザを使うためのエネルギーより、2個多くエネルギーがついているなら、130ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Grass", value: "-30" }],
+
+	variants: [{ type: "holo" }],
+
+	evolveFrom: {
+		ja: "モグリュー",
+	},
+
+	retreat: 4,
+	regulationMark: "J",
+	rarity: "Double rare",
+	dexId: [530],
+
+	suffix: "EX",
+
+	thirdParty: {
+		cardmarket: 888327,
+	},
+};
+
+export default card;

--- a/data-asia/M/M5/064.ts
+++ b/data-asia/M/M5/064.ts
@@ -1,0 +1,47 @@
+import { Card } from "../../../interfaces";
+import Set from "../M5";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ツツケラ",
+	},
+
+	illustrator: "Koji Nakata",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Colorless"],
+
+	description: {
+		ja: "頭を 激しく 揺さぶっても 首の 筋肉が 強いおかげで ダメージは まったく ない。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "にどづき" },
+			damage: "10×",
+			cost: ["Colorless"],
+			effect: {
+				ja: "コインを2回投げ、オモテの数×10ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [{ type: "normal" }],
+
+	retreat: 1,
+	regulationMark: "J",
+	rarity: "Common",
+	dexId: [731],
+
+	thirdParty: {
+		cardmarket: 888328,
+	},
+};
+
+export default card;

--- a/data-asia/M/M5/065.ts
+++ b/data-asia/M/M5/065.ts
@@ -1,0 +1,51 @@
+import { Card } from "../../../interfaces";
+import Set from "../M5";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ケララッパ",
+	},
+
+	illustrator: "miki kudo",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Colorless"],
+
+	description: {
+		ja: "敵に 出会うと クチバシに 溜めこんでいた 多くの 木の実の タネを 放射状に 撃ちだす。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "そらをとぶ" },
+			damage: 30,
+			cost: ["Colorless"],
+			effect: {
+				ja: "コインを1回投げウラなら、このワザは失敗。オモテなら、次の相手の番、このポケモンはワザのダメージや効果を受けない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [{ type: "normal" }],
+
+	evolveFrom: {
+		ja: "ツツケラ",
+	},
+
+	retreat: 1,
+	regulationMark: "J",
+	rarity: "Common",
+	dexId: [732],
+
+	thirdParty: {
+		cardmarket: 888329,
+	},
+};
+
+export default card;

--- a/data-asia/M/M5/066.ts
+++ b/data-asia/M/M5/066.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../M5";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ドデカバシ",
+	},
+
+	illustrator: "Masako Tomii",
+	category: "Pokemon",
+	hp: 150,
+	types: ["Colorless"],
+
+	description: {
+		ja: "番いの ドデカバシは クチバシの 温度を 上げて 温めあうので 仲良しの シンボルと されている。",
+	},
+
+	stage: "Stage2",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "スカイドロー" },
+			effect: {
+				ja: "自分の番に1回使える。自分の山札を1枚引く。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "フェザーロンド" },
+			damage: "60+",
+			cost: ["Colorless"],
+			effect: {
+				ja: "おたがいのベンチポケモンの数×20ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [{ type: "normal" }],
+
+	evolveFrom: {
+		ja: "ケララッパ",
+	},
+
+	retreat: 2,
+	regulationMark: "J",
+	rarity: "Uncommon",
+	dexId: [733],
+
+	thirdParty: {
+		cardmarket: 888330,
+	},
+};
+
+export default card;

--- a/data-asia/M/M5/067.ts
+++ b/data-asia/M/M5/067.ts
@@ -1,0 +1,44 @@
+import { Card } from "../../../interfaces";
+import Set from "../M5";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "タイプ：ヌル",
+	},
+
+	illustrator: "Ligton",
+	category: "Pokemon",
+	hp: 110,
+	types: ["Colorless"],
+
+	description: {
+		ja: "神話の ポケモンを モデルに つくられたが 力の 暴走を 抑える マスクを 着けられている。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "パワーエッジ" },
+			damage: 40,
+			cost: ["Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [{ type: "normal" }],
+
+	retreat: 2,
+	regulationMark: "J",
+	rarity: "Common",
+	dexId: [772],
+
+	thirdParty: {
+		cardmarket: 888334,
+	},
+};
+
+export default card;

--- a/data-asia/M/M5/068.ts
+++ b/data-asia/M/M5/068.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../M5";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "シルヴァディ",
+	},
+
+	illustrator: "Takumi Wada",
+	category: "Pokemon",
+	hp: 140,
+	types: ["Colorless"],
+
+	description: {
+		ja: "本来の 力を 解き放つ 最後の ファクターは 信頼する トレーナーとの 絆 だった。",
+	},
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "バディコール" },
+			effect: {
+				ja: "自分の手札が1枚もないなら、自分の番に1回使える。自分の山札からサポートを1枚選び、相手に見せて、手札に加える。そして山札を切る。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "エアスラッシュ" },
+			damage: 130,
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンについているエネルギーを1個選び、トラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [{ type: "holo" }],
+
+	evolveFrom: {
+		ja: "タイプ：ヌル",
+	},
+
+	retreat: 2,
+	regulationMark: "J",
+	rarity: "Rare",
+	dexId: [773],
+
+	thirdParty: {
+		cardmarket: 888336,
+	},
+};
+
+export default card;

--- a/data-asia/M/M5/069.ts
+++ b/data-asia/M/M5/069.ts
@@ -1,0 +1,51 @@
+import { Card } from "../../../interfaces";
+import Set from "../M5";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "オトシドリ",
+	},
+
+	illustrator: "Wintr Wandr",
+	category: "Pokemon",
+	hp: 100,
+	types: ["Colorless"],
+
+	description: {
+		ja: "胸元の 袋で エサを 包み 巣に 持ち帰る。 大きな 音の するものを 落として 喜ぶ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "おとどけチャレンジ" },
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "コインを2回投げ、すべてオモテなら、自分の山札からポケモンを1枚選び、ベンチに出す。そして山札を切る。",
+			},
+		},
+		{
+			name: { ja: "スピードウイング" },
+			damage: 100,
+			cost: ["Colorless", "Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [{ type: "normal" }],
+
+	retreat: 1,
+	regulationMark: "J",
+	rarity: "Common",
+	dexId: [962],
+
+	thirdParty: {
+		cardmarket: 888337,
+	},
+};
+
+export default card;

--- a/data-asia/M/M5/070.ts
+++ b/data-asia/M/M5/070.ts
@@ -1,0 +1,28 @@
+import { Card } from "../../../interfaces";
+import Set from "../M5";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ダークベル",
+	},
+
+	illustrator: "Toyste Beach",
+	category: "Trainer",
+
+	effect: {
+		ja: "おたがいのバトルポケモン（[D]ポケモンをのぞく）を、それぞれこんらんにする。",
+	},
+
+	variants: [{ type: "normal" }],
+
+	trainerType: "Item",
+	regulationMark: "J",
+	rarity: "Uncommon",
+
+	thirdParty: {
+		cardmarket: 888339,
+	},
+};
+
+export default card;

--- a/data-asia/M/M5/071.ts
+++ b/data-asia/M/M5/071.ts
@@ -1,0 +1,28 @@
+import { Card } from "../../../interfaces";
+import Set from "../M5";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "古びたずがいの化石",
+	},
+
+	illustrator: "AYUMI ODASHIMA",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードは、HP60の[C]タイプのたねポケモンとして、場に出せる。このカードは、特殊状態にならず、にげられない。自分の番の中でなら、場に出ているこのカードをトラッシュできる。 Ability: ずがいのトゲ このポケモンが、バトル場で相手のポケモンからワザのダメージを受けたとき、ワザを使ったポケモンにダメカンを3個のせる。グッズは、自分の番に何枚でも使える。",
+	},
+
+	variants: [{ type: "normal" }],
+
+	trainerType: "Item",
+	regulationMark: "J",
+	rarity: "Common",
+
+	thirdParty: {
+		cardmarket: 888343,
+	},
+};
+
+export default card;

--- a/data-asia/M/M5/072.ts
+++ b/data-asia/M/M5/072.ts
@@ -1,0 +1,28 @@
+import { Card } from "../../../interfaces";
+import Set from "../M5";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "古びたたての化石",
+	},
+
+	illustrator: "AYUMI ODASHIMA",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードは、HP60の[C]タイプのたねポケモンとして、場に出せる。このカードは、特殊状態にならず、にげられない。自分の番の中でなら、場に出ているこのカードをトラッシュできる。グッズは、自分の番に何枚でも使える。 Ability: たてのまもり このポケモンがバトル場にいるかぎり、自分のポケモン全員が、相手のポケモンから受けるワザのダメージは「-10」される。",
+	},
+
+	variants: [{ type: "normal" }],
+
+	trainerType: "Item",
+	regulationMark: "J",
+	rarity: "Common",
+
+	thirdParty: {
+		cardmarket: 888344,
+	},
+};
+
+export default card;

--- a/data-asia/M/M5/073.ts
+++ b/data-asia/M/M5/073.ts
@@ -1,0 +1,28 @@
+import { Card } from "../../../interfaces";
+import Set from "../M5";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ごうかいボム",
+	},
+
+	illustrator: "inose yukie",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードをつけているポケモン（「メガシンカex」をのぞく）が、バトル場で相手の「メガシンカex」から「240」以上のワザのダメージを受けたとき、ワザを使ったポケモンにダメカンを12個のせる。その後、このカードをトラッシュする。",
+	},
+
+	variants: [{ type: "normal" }],
+
+	trainerType: "Tool",
+	regulationMark: "J",
+	rarity: "Uncommon",
+
+	thirdParty: {
+		cardmarket: 888345,
+	},
+};
+
+export default card;

--- a/data-asia/M/M5/074.ts
+++ b/data-asia/M/M5/074.ts
@@ -1,0 +1,28 @@
+import { Card } from "../../../interfaces";
+import Set from "../M5";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "リトライバッジ",
+	},
+
+	illustrator: "Toyste Beach",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の番ごとに1回、このカードをつけている[C]ポケモンのワザで自分がコインを投げたとき、そのコインの結果をすべてなくし、はじめからコインを投げなおしてよい。",
+	},
+
+	variants: [{ type: "normal" }],
+
+	trainerType: "Tool",
+	regulationMark: "J",
+	rarity: "Uncommon",
+
+	thirdParty: {
+		cardmarket: 888346,
+	},
+};
+
+export default card;

--- a/data-asia/M/M5/075.ts
+++ b/data-asia/M/M5/075.ts
@@ -1,0 +1,28 @@
+import { Card } from "../../../interfaces";
+import Set from "../M5";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "カスミの元気",
+	},
+
+	illustrator: "En Morikura",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードを使ったなら、自分の番は終わる。自分の山札から「基本[W]エネルギー」を4枚まで選び、自分のポケモン1匹につける。そして山札を切る。",
+	},
+
+	variants: [{ type: "normal" }],
+
+	trainerType: "Supporter",
+	regulationMark: "J",
+	rarity: "Uncommon",
+
+	thirdParty: {
+		cardmarket: 888347,
+	},
+};
+
+export default card;

--- a/data-asia/M/M5/076.ts
+++ b/data-asia/M/M5/076.ts
@@ -1,0 +1,28 @@
+import { Card } from "../../../interfaces";
+import Set from "../M5";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "グラジオの決戦",
+	},
+
+	illustrator: "akagi",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードは、自分の手札がこのカード1枚だけのときにしか使えない。この番、自分のポケモン（「ルールを持つポケモン」をのぞく）が使うワザの、相手のバトルポケモンへのダメージは「+80」される。",
+	},
+
+	variants: [{ type: "normal" }],
+
+	trainerType: "Supporter",
+	regulationMark: "J",
+	rarity: "Uncommon",
+
+	thirdParty: {
+		cardmarket: 888348,
+	},
+};
+
+export default card;

--- a/data-asia/M/M5/077.ts
+++ b/data-asia/M/M5/077.ts
@@ -1,0 +1,28 @@
+import { Card } from "../../../interfaces";
+import Set from "../M5";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "サビ組のしたっぱ",
+	},
+
+	illustrator: "Teeziro",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードは、前の相手の番に、自分のポケモンがきぜつしていなければ使えない。相手の場のポケモンについているエネルギーを1個選び、トラッシュする。",
+	},
+
+	variants: [{ type: "normal" }],
+
+	trainerType: "Supporter",
+	regulationMark: "J",
+	rarity: "Uncommon",
+
+	thirdParty: {
+		cardmarket: 888349,
+	},
+};
+
+export default card;

--- a/data-asia/M/M5/078.ts
+++ b/data-asia/M/M5/078.ts
@@ -1,0 +1,28 @@
+import { Card } from "../../../interfaces";
+import Set from "../M5";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ムク",
+	},
+
+	illustrator: "nagimiso",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の手札からポケモン（「ルールを持つポケモン」をのぞく）を2枚までトラッシュし、その枚数×3枚ぶん、山札を引く。",
+	},
+
+	variants: [{ type: "normal" }],
+
+	trainerType: "Supporter",
+	regulationMark: "J",
+	rarity: "Uncommon",
+
+	thirdParty: {
+		cardmarket: 888350,
+	},
+};
+
+export default card;

--- a/data-asia/M/M5/079.ts
+++ b/data-asia/M/M5/079.ts
@@ -1,0 +1,28 @@
+import { Card } from "../../../interfaces";
+import Set from "../M5";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "化石採掘場",
+	},
+
+	illustrator: "Oswaldo KATO",
+	category: "Trainer",
+
+	effect: {
+		ja: "おたがいのプレイヤーは、自分の番ごとに1回、自分の山札から、名前に「古びた」とつくグッズを2枚まで選び、ベンチに出してよい。そして山札を切る。",
+	},
+
+	variants: [{ type: "normal" }],
+
+	trainerType: "Stadium",
+	regulationMark: "J",
+	rarity: "Uncommon",
+
+	thirdParty: {
+		cardmarket: 888351,
+	},
+};
+
+export default card;

--- a/data-asia/M/M5/080.ts
+++ b/data-asia/M/M5/080.ts
@@ -1,0 +1,28 @@
+import { Card } from "../../../interfaces";
+import Set from "../M5";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ボルト雷エネルギー",
+	},
+
+	illustrator: "",
+	category: "Energy",
+	energyType: "Special",
+
+	effect: {
+		ja: "このカードは、ポケモンについているかぎり、[L]エネルギー1個ぶんとしてはたらく。このカードをつけている[L]ポケモンが使うワザの、相手のバトルポケモンへのダメージは「+20」される。",
+	},
+
+	variants: [{ type: "holo" }],
+
+	regulationMark: "J",
+	rarity: "Rare",
+
+	thirdParty: {
+		cardmarket: 888352,
+	},
+};
+
+export default card;

--- a/data-asia/M/M5/081.ts
+++ b/data-asia/M/M5/081.ts
@@ -1,0 +1,28 @@
+import { Card } from "../../../interfaces";
+import Set from "../M5";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "シャドー悪エネルギー",
+	},
+
+	illustrator: "",
+	category: "Energy",
+	energyType: "Special",
+
+	effect: {
+		ja: "このカードは、ポケモンについているかぎり、[D]エネルギー1個ぶんとしてはたらく。このカードをつけている[D]ポケモンは、ベンチにいるかぎり、相手のワザのダメージを受けない。",
+	},
+
+	variants: [{ type: "holo" }],
+
+	regulationMark: "J",
+	rarity: "Rare",
+
+	thirdParty: {
+		cardmarket: 888353,
+	},
+};
+
+export default card;

--- a/data-asia/M/M5/082.ts
+++ b/data-asia/M/M5/082.ts
@@ -1,0 +1,43 @@
+import { Card } from "../../../interfaces";
+import Set from "../M5";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "カリキリ",
+	},
+
+	illustrator: "Jiro Sasuno",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Grass"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "とつげき" },
+			damage: 30,
+			cost: ["Grass"],
+			effect: {
+				ja: "このポケモンにも10ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [{ type: "holo" }],
+
+	retreat: 1,
+	regulationMark: "J",
+	rarity: "Illustration rare",
+	dexId: [753],
+
+	thirdParty: {
+		cardmarket: 888627,
+	},
+};
+
+export default card;

--- a/data-asia/M/M5/083.ts
+++ b/data-asia/M/M5/083.ts
@@ -1,0 +1,47 @@
+import { Card } from "../../../interfaces";
+import Set from "../M5";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "グレンアルマ",
+	},
+
+	illustrator: "Iwamoto05",
+	category: "Pokemon",
+	hp: 140,
+	types: ["Fire"],
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "フレイムレギオン" },
+			damage: "40+",
+			cost: ["Fire"],
+			effect: {
+				ja: "[R]エネルギーがついている自分のベンチポケモンの数×40ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [{ type: "holo" }],
+
+	evolveFrom: {
+		ja: "カルボウ",
+	},
+
+	retreat: 2,
+	regulationMark: "J",
+	rarity: "Illustration rare",
+	dexId: [936],
+
+	thirdParty: {
+		cardmarket: 888628,
+	},
+};
+
+export default card;

--- a/data-asia/M/M5/084.ts
+++ b/data-asia/M/M5/084.ts
@@ -1,0 +1,40 @@
+import { Card } from "../../../interfaces";
+import Set from "../M5";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "トサキント",
+	},
+
+	illustrator: "Gemi",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Water"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "つきさす" },
+			damage: 30,
+			cost: ["Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
+
+	variants: [{ type: "holo" }],
+
+	retreat: 1,
+	regulationMark: "J",
+	rarity: "Illustration rare",
+	dexId: [118],
+
+	thirdParty: {
+		cardmarket: 888629,
+	},
+};
+
+export default card;

--- a/data-asia/M/M5/085.ts
+++ b/data-asia/M/M5/085.ts
@@ -1,0 +1,57 @@
+import { Card } from "../../../interfaces";
+import Set from "../M5";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アシレーヌ",
+	},
+
+	illustrator: "satoma",
+	category: "Pokemon",
+	hp: 150,
+	types: ["Water"],
+
+	stage: "Stage2",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "まんたんメロディ" },
+			effect: {
+				ja: "自分の番に、このカードを手札から出して進化させたとき、1回使える。自分のポケモン1匹のHPを、すべて回復する。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "アクアリターン" },
+			damage: 120,
+			cost: ["Water", "Colorless"],
+			effect: {
+				ja: "このポケモンと、ついているすべてのカードを、山札にもどして切る。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
+
+	variants: [{ type: "holo" }],
+
+	evolveFrom: {
+		ja: "オシャマリ",
+	},
+
+	retreat: 2,
+	regulationMark: "J",
+	rarity: "Illustration rare",
+	dexId: [730],
+
+	thirdParty: {
+		cardmarket: 888630,
+	},
+};
+
+export default card;

--- a/data-asia/M/M5/086.ts
+++ b/data-asia/M/M5/086.ts
@@ -1,0 +1,55 @@
+import { Card } from "../../../interfaces";
+import Set from "../M5";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ライボルト",
+	},
+
+	illustrator: "HICO KIM",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Lightning"],
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "フラッシュバリア" },
+			damage: 50,
+			cost: ["Lightning", "Lightning"],
+			effect: {
+				ja: "次の相手の番、このポケモンは進化ポケモンからワザのダメージを受けない。",
+			},
+		},
+		{
+			name: { ja: "ソニックエッジ" },
+			damage: 110,
+			cost: ["Lightning", "Lightning", "Lightning"],
+			effect: {
+				ja: "このワザのダメージは、相手のバトルポケモンにかかっている効果を計算しない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [{ type: "holo" }],
+
+	evolveFrom: {
+		ja: "ラクライ",
+	},
+
+	retreat: 1,
+	regulationMark: "J",
+	rarity: "Illustration rare",
+	dexId: [310],
+
+	thirdParty: {
+		cardmarket: 888631,
+	},
+};
+
+export default card;

--- a/data-asia/M/M5/087.ts
+++ b/data-asia/M/M5/087.ts
@@ -1,0 +1,52 @@
+import { Card } from "../../../interfaces";
+import Set from "../M5";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヤドラン",
+	},
+
+	illustrator: "Mekayu",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Psychic"],
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "スッカラカン" },
+			damage: "50+",
+			cost: ["Psychic"],
+			effect: {
+				ja: "自分の手札が1枚もないなら、160ダメージ追加。",
+			},
+		},
+		{
+			name: { ja: "しねんのずつき" },
+			damage: 110,
+			cost: ["Colorless", "Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [{ type: "holo" }],
+
+	evolveFrom: {
+		ja: "ヤドン",
+	},
+
+	retreat: 3,
+	regulationMark: "J",
+	rarity: "Illustration rare",
+	dexId: [80],
+
+	thirdParty: {
+		cardmarket: 888632,
+	},
+};
+
+export default card;

--- a/data-asia/M/M5/088.ts
+++ b/data-asia/M/M5/088.ts
@@ -1,0 +1,43 @@
+import { Card } from "../../../interfaces";
+import Set from "../M5";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ダダリン",
+	},
+
+	illustrator: "Nakamura Ippan",
+	category: "Pokemon",
+	hp: 140,
+	types: ["Psychic"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "むねんのイカリ" },
+			damage: "30+",
+			cost: ["Psychic"],
+			effect: {
+				ja: "自分のトラッシュに、特性「ばけがくれ」を持つポケモンが4枚以上あるなら、140ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [{ type: "holo" }],
+
+	retreat: 3,
+	regulationMark: "J",
+	rarity: "Illustration rare",
+	dexId: [781],
+
+	thirdParty: {
+		cardmarket: 888633,
+	},
+};
+
+export default card;

--- a/data-asia/M/M5/089.ts
+++ b/data-asia/M/M5/089.ts
@@ -1,0 +1,51 @@
+import { Card } from "../../../interfaces";
+import Set from "../M5";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "フォクスライ",
+	},
+
+	illustrator: "Jerky",
+	category: "Pokemon",
+	hp: 100,
+	types: ["Darkness"],
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "スキルシーフ" },
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "自分の手札が1枚もないなら、相手の場のポケモンが持つワザを1つ選び、このワザとして使う。",
+			},
+		},
+		{
+			name: { ja: "するどいキバ" },
+			damage: 80,
+			cost: ["Darkness", "Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [{ type: "holo" }],
+
+	evolveFrom: {
+		ja: "クスネ",
+	},
+
+	retreat: 1,
+	regulationMark: "J",
+	rarity: "Illustration rare",
+	dexId: [828],
+
+	thirdParty: {
+		cardmarket: 888634,
+	},
+};
+
+export default card;

--- a/data-asia/M/M5/090.ts
+++ b/data-asia/M/M5/090.ts
@@ -1,0 +1,51 @@
+import { Card } from "../../../interfaces";
+import Set from "../M5";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ザルード",
+	},
+
+	illustrator: "IKEDA Saki",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Darkness"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "うしろなげ" },
+			damage: 30,
+			cost: ["Darkness"],
+			effect: {
+				ja: "自分のベンチポケモン1匹にも、30ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+			},
+		},
+		{
+			name: { ja: "シャドーウィップ" },
+			damage: "100+",
+			cost: ["Darkness", "Darkness", "Darkness"],
+			effect: {
+				ja: "自分のベンチポケモンに「シャドー[D]エネルギー」がついているなら、70ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [{ type: "holo" }],
+
+	retreat: 2,
+	regulationMark: "J",
+	rarity: "Illustration rare",
+	dexId: [893],
+
+	thirdParty: {
+		cardmarket: 888635,
+	},
+};
+
+export default card;

--- a/data-asia/M/M5/091.ts
+++ b/data-asia/M/M5/091.ts
@@ -1,0 +1,54 @@
+import { Card } from "../../../interfaces";
+import Set from "../M5";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "トリデプス",
+	},
+
+	illustrator: "Yoriyuki Ikegami",
+	category: "Pokemon",
+	hp: 160,
+	types: ["Metal"],
+
+	stage: "Stage2",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "たいこのぼうへき" },
+			effect: {
+				ja: "このポケモンがベンチにいるかぎり、自分のポケモン全員は、ついているエネルギーが2個以下の相手のポケモンからワザのダメージを受けない。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ぶちかます" },
+			damage: 160,
+			cost: ["Metal", "Metal", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Grass", value: "-30" }],
+
+	variants: [{ type: "holo" }],
+
+	evolveFrom: {
+		ja: "タテトプス",
+	},
+
+	retreat: 4,
+	regulationMark: "J",
+	rarity: "Illustration rare",
+	dexId: [411],
+
+	thirdParty: {
+		cardmarket: 888636,
+	},
+};
+
+export default card;

--- a/data-asia/M/M5/092.ts
+++ b/data-asia/M/M5/092.ts
@@ -1,0 +1,57 @@
+import { Card } from "../../../interfaces";
+import Set from "../M5";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ドデカバシ",
+	},
+
+	illustrator: "miki kudo",
+	category: "Pokemon",
+	hp: 150,
+	types: ["Colorless"],
+
+	stage: "Stage2",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "スカイドロー" },
+			effect: {
+				ja: "自分の番に1回使える。自分の山札を1枚引く。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "フェザーロンド" },
+			damage: "60+",
+			cost: ["Colorless"],
+			effect: {
+				ja: "おたがいのベンチポケモンの数×20ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [{ type: "holo" }],
+
+	evolveFrom: {
+		ja: "ケララッパ",
+	},
+
+	retreat: 2,
+	regulationMark: "J",
+	rarity: "Illustration rare",
+	dexId: [733],
+
+	thirdParty: {
+		cardmarket: 888637,
+	},
+};
+
+export default card;

--- a/data-asia/M/M5/093.ts
+++ b/data-asia/M/M5/093.ts
@@ -1,0 +1,57 @@
+import { Card } from "../../../interfaces";
+import Set from "../M5";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "シルヴァディ",
+	},
+
+	illustrator: "DOM",
+	category: "Pokemon",
+	hp: 140,
+	types: ["Colorless"],
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "バディコール" },
+			effect: {
+				ja: "自分の手札が1枚もないなら、自分の番に1回使える。自分の山札からサポートを1枚選び、相手に見せて、手札に加える。そして山札を切る。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "エアスラッシュ" },
+			damage: 130,
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンについているエネルギーを1個選び、トラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [{ type: "holo" }],
+
+	evolveFrom: {
+		ja: "タイプ：ヌル",
+	},
+
+	retreat: 2,
+	regulationMark: "J",
+	rarity: "Illustration rare",
+	dexId: [773],
+
+	thirdParty: {
+		cardmarket: 888638,
+	},
+};
+
+export default card;

--- a/data-asia/M/M5/094.ts
+++ b/data-asia/M/M5/094.ts
@@ -1,0 +1,57 @@
+import { Card } from "../../../interfaces";
+import Set from "../M5";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ラランテスex",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 260,
+	types: ["Grass"],
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "はつらつカッター" },
+			damage: "60+",
+			cost: ["Grass"],
+			effect: {
+				ja: "この番に、このポケモンのHPを回復していたなら、200ダメージ追加。",
+			},
+		},
+		{
+			name: { ja: "リーフガード" },
+			damage: 140,
+			cost: ["Grass", "Colorless"],
+			effect: {
+				ja: "次の相手の番、このポケモンが受けるワザのダメージは「-50」される。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [{ type: "holo" }],
+
+	evolveFrom: {
+		ja: "カリキリ",
+	},
+
+	retreat: 1,
+	regulationMark: "J",
+	rarity: "Ultra Rare",
+	dexId: [754],
+
+	suffix: "EX",
+
+	thirdParty: {
+		cardmarket: 888639,
+	},
+};
+
+export default card;

--- a/data-asia/M/M5/095.ts
+++ b/data-asia/M/M5/095.ts
@@ -1,0 +1,54 @@
+import { Card } from "../../../interfaces";
+import Set from "../M5";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ホエルオーex",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 380,
+	types: ["Water"],
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "なみのり" },
+			damage: 120,
+			cost: ["Water", "Water", "Water"],
+		},
+		{
+			name: { ja: "フォーリングダウン" },
+			damage: 270,
+			cost: ["Water", "Water", "Water", "Water", "Water"],
+			effect: {
+				ja: "このポケモンをねむりにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
+
+	variants: [{ type: "holo" }],
+
+	evolveFrom: {
+		ja: "ホエルコ",
+	},
+
+	retreat: 4,
+	regulationMark: "J",
+	rarity: "Ultra Rare",
+	dexId: [321],
+
+	suffix: "EX",
+
+	thirdParty: {
+		cardmarket: 888640,
+	},
+};
+
+export default card;

--- a/data-asia/M/M5/096.ts
+++ b/data-asia/M/M5/096.ts
@@ -1,0 +1,53 @@
+import { Card } from "../../../interfaces";
+import Set from "../M5";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "メガゼラオラex",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 270,
+	types: ["Lightning"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "サンダーフィスト" },
+			damage: "60×",
+			cost: ["Lightning"],
+			effect: {
+				ja: "このポケモンについている[L]エネルギーの数×60ダメージ。",
+			},
+		},
+		{
+			name: { ja: "ゼプトターン" },
+			damage: 150,
+			cost: ["Lightning", "Lightning", "Lightning"],
+			effect: {
+				ja: "このポケモンをベンチポケモンと入れ替える。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [{ type: "holo" }],
+
+	retreat: 1,
+	regulationMark: "J",
+	rarity: "Ultra Rare",
+	dexId: [807],
+
+	suffix: "EX",
+
+	thirdParty: {
+		cardmarket: 888641,
+	},
+};
+
+export default card;

--- a/data-asia/M/M5/097.ts
+++ b/data-asia/M/M5/097.ts
@@ -1,0 +1,59 @@
+import { Card } from "../../../interfaces";
+import Set from "../M5";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "メガシャンデラex",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 350,
+	types: ["Psychic"],
+
+	stage: "Stage2",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "じゅばくのほのお" },
+			effect: {
+				ja: "このポケモンがいるかぎり、相手のバトルポケモンは、にげるためのエネルギーが1個ぶん多くなる。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ファントムメイズ" },
+			damage: "130+",
+			cost: ["Psychic", "Psychic"],
+			effect: {
+				ja: "相手のバトルポケモンのにげるためのエネルギーの数×50ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [{ type: "holo" }],
+
+	evolveFrom: {
+		ja: "ランプラー",
+	},
+
+	retreat: 2,
+	regulationMark: "J",
+	rarity: "Ultra Rare",
+	dexId: [609],
+
+	suffix: "EX",
+
+	thirdParty: {
+		cardmarket: 888642,
+	},
+};
+
+export default card;

--- a/data-asia/M/M5/098.ts
+++ b/data-asia/M/M5/098.ts
@@ -1,0 +1,59 @@
+import { Card } from "../../../interfaces";
+import Set from "../M5";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ラムパルドex",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 330,
+	types: ["Fighting"],
+
+	stage: "Stage2",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "はかいのずつき" },
+			effect: {
+				ja: "このポケモンがバトル場にいるなら、自分の番に1回使える。コインを1回投げオモテなら、相手のバトルポケモンについているエネルギーを1個選び、トラッシュする。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ランページハンマー" },
+			damage: 150,
+			cost: ["Fighting", "Fighting"],
+			effect: {
+				ja: "次の自分の番、このポケモンが使うワザの、相手のバトルポケモンへのダメージは「+150」される。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [{ type: "holo" }],
+
+	evolveFrom: {
+		ja: "ズガイドス",
+	},
+
+	retreat: 2,
+	regulationMark: "J",
+	rarity: "Ultra Rare",
+	dexId: [409],
+
+	suffix: "EX",
+
+	thirdParty: {
+		cardmarket: 888643,
+	},
+};
+
+export default card;

--- a/data-asia/M/M5/099.ts
+++ b/data-asia/M/M5/099.ts
@@ -1,0 +1,52 @@
+import { Card } from "../../../interfaces";
+import Set from "../M5";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "メガダークライex",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 280,
+	types: ["Darkness"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ナイトレイド" },
+			damage: "110+",
+			cost: ["Darkness", "Darkness"],
+			effect: {
+				ja: "自分のベンチポケモンにダメカンがのっているなら、110ダメージ追加。",
+			},
+		},
+		{
+			name: { ja: "アビスアイ" },
+			cost: ["Darkness", "Darkness", "Darkness"],
+			effect: {
+				ja: "相手のバトルポケモンが特殊状態なら、そのポケモンをきぜつさせる。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [{ type: "holo" }],
+
+	retreat: 2,
+	regulationMark: "J",
+	rarity: "Ultra Rare",
+	dexId: [491],
+
+	suffix: "EX",
+
+	thirdParty: {
+		cardmarket: 888644,
+	},
+};
+
+export default card;

--- a/data-asia/M/M5/100.ts
+++ b/data-asia/M/M5/100.ts
@@ -1,0 +1,52 @@
+import { Card } from "../../../interfaces";
+import Set from "../M5";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "モルペコex",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 180,
+	types: ["Darkness"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ホイールドロー" },
+			cost: ["Darkness"],
+			effect: {
+				ja: "自分の手札をすべて山札にもどして切る。その後、山札を6枚引く。",
+			},
+		},
+		{
+			name: { ja: "はらぺこボンバー" },
+			damage: "40+",
+			cost: ["Darkness", "Darkness"],
+			effect: {
+				ja: "このポケモンにのっているダメカンの数×40ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [{ type: "holo" }],
+
+	retreat: 1,
+	regulationMark: "J",
+	rarity: "Ultra Rare",
+	dexId: [877],
+
+	suffix: "EX",
+
+	thirdParty: {
+		cardmarket: 888645,
+	},
+};
+
+export default card;

--- a/data-asia/M/M5/101.ts
+++ b/data-asia/M/M5/101.ts
@@ -1,0 +1,57 @@
+import { Card } from "../../../interfaces";
+import Set from "../M5";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "メガドリュウズex",
+	},
+
+	illustrator: "Keisuke Azuma",
+	category: "Pokemon",
+	hp: 340,
+	types: ["Metal"],
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "ほりくずす" },
+			damage: 90,
+			cost: ["Metal", "Metal"],
+			effect: {
+				ja: "相手の山札を上から2枚トラッシュする。",
+			},
+		},
+		{
+			name: { ja: "マキシマムドリル" },
+			damage: "200+",
+			cost: ["Metal", "Metal", "Metal"],
+			effect: {
+				ja: "このワザを使うためのエネルギーより、2個多くエネルギーがついているなら、130ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Grass", value: "-30" }],
+
+	variants: [{ type: "holo" }],
+
+	evolveFrom: {
+		ja: "モグリュー",
+	},
+
+	retreat: 4,
+	regulationMark: "J",
+	rarity: "Ultra Rare",
+	dexId: [530],
+
+	suffix: "EX",
+
+	thirdParty: {
+		cardmarket: 888646,
+	},
+};
+
+export default card;

--- a/data-asia/M/M5/102.ts
+++ b/data-asia/M/M5/102.ts
@@ -1,0 +1,28 @@
+import { Card } from "../../../interfaces";
+import Set from "../M5";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アイアンディフェンダー",
+	},
+
+	illustrator: "Studio Bora Inc.",
+	category: "Trainer",
+
+	effect: {
+		ja: "次の相手の番、自分のポケモン全員が、相手のポケモンから受けるワザのダメージは「-30」される。（新しく場に出したポケモンもふくむ。）",
+	},
+
+	variants: [{ type: "holo" }],
+
+	trainerType: "Item",
+	regulationMark: "J",
+	rarity: "Ultra Rare",
+
+	thirdParty: {
+		cardmarket: 888647,
+	},
+};
+
+export default card;

--- a/data-asia/M/M5/103.ts
+++ b/data-asia/M/M5/103.ts
@@ -1,0 +1,28 @@
+import { Card } from "../../../interfaces";
+import Set from "../M5";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "エネルギーつけかえ",
+	},
+
+	illustrator: "Studio Bora Inc.",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の場のポケモンについている基本エネルギーを1個選び、自分の別のポケモンにつけ替える。",
+	},
+
+	variants: [{ type: "holo" }],
+
+	trainerType: "Item",
+	regulationMark: "J",
+	rarity: "Ultra Rare",
+
+	thirdParty: {
+		cardmarket: 888648,
+	},
+};
+
+export default card;

--- a/data-asia/M/M5/104.ts
+++ b/data-asia/M/M5/104.ts
@@ -1,0 +1,28 @@
+import { Card } from "../../../interfaces";
+import Set from "../M5";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "クラッシュハンマー",
+	},
+
+	illustrator: "Ayako Yoshida",
+	category: "Trainer",
+
+	effect: {
+		ja: "コインを1回投げオモテなら、相手の場のポケモンについているエネルギーを1個選び、トラッシュする。",
+	},
+
+	variants: [{ type: "holo" }],
+
+	trainerType: "Item",
+	regulationMark: "J",
+	rarity: "Ultra Rare",
+
+	thirdParty: {
+		cardmarket: 888649,
+	},
+};
+
+export default card;

--- a/data-asia/M/M5/105.ts
+++ b/data-asia/M/M5/105.ts
@@ -1,0 +1,28 @@
+import { Card } from "../../../interfaces";
+import Set from "../M5";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ダークベル",
+	},
+
+	illustrator: "Toyste Beach",
+	category: "Trainer",
+
+	effect: {
+		ja: "おたがいのバトルポケモン（[D]ポケモンをのぞく）を、それぞれこんらんにする。",
+	},
+
+	variants: [{ type: "holo" }],
+
+	trainerType: "Item",
+	regulationMark: "J",
+	rarity: "Ultra Rare",
+
+	thirdParty: {
+		cardmarket: 888650,
+	},
+};
+
+export default card;

--- a/data-asia/M/M5/106.ts
+++ b/data-asia/M/M5/106.ts
@@ -1,0 +1,28 @@
+import { Card } from "../../../interfaces";
+import Set from "../M5";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ごうかいボム",
+	},
+
+	illustrator: "inose yukie",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードをつけているポケモン（「メガシンカex」をのぞく）が、バトル場で相手の「メガシンカex」から「240」以上のワザのダメージを受けたとき、ワザを使ったポケモンにダメカンを12個のせる。その後、このカードをトラッシュする。",
+	},
+
+	variants: [{ type: "holo" }],
+
+	trainerType: "Tool",
+	regulationMark: "J",
+	rarity: "Ultra Rare",
+
+	thirdParty: {
+		cardmarket: 888651,
+	},
+};
+
+export default card;

--- a/data-asia/M/M5/107.ts
+++ b/data-asia/M/M5/107.ts
@@ -1,0 +1,28 @@
+import { Card } from "../../../interfaces";
+import Set from "../M5";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ブレイブバングル",
+	},
+
+	illustrator: "Toyste Beach",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードをつけているポケモン（「ルールを持つポケモン」をのぞく）が使うワザの、相手のバトル場の「ポケモンex」へのダメージは「+30」される。",
+	},
+
+	variants: [{ type: "holo" }],
+
+	trainerType: "Tool",
+	regulationMark: "J",
+	rarity: "Ultra Rare",
+
+	thirdParty: {
+		cardmarket: 888652,
+	},
+};
+
+export default card;

--- a/data-asia/M/M5/108.ts
+++ b/data-asia/M/M5/108.ts
@@ -1,0 +1,28 @@
+import { Card } from "../../../interfaces";
+import Set from "../M5";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "カスミの元気",
+	},
+
+	illustrator: "En Morikura",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードを使ったなら、自分の番は終わる。自分の山札から「基本[W]エネルギー」を4枚まで選び、自分のポケモン1匹につける。そして山札を切る。",
+	},
+
+	variants: [{ type: "holo" }],
+
+	trainerType: "Supporter",
+	regulationMark: "J",
+	rarity: "Ultra Rare",
+
+	thirdParty: {
+		cardmarket: 888653,
+	},
+};
+
+export default card;

--- a/data-asia/M/M5/109.ts
+++ b/data-asia/M/M5/109.ts
@@ -1,0 +1,28 @@
+import { Card } from "../../../interfaces";
+import Set from "../M5";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "グラジオの決戦",
+	},
+
+	illustrator: "akagi",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードは、自分の手札がこのカード1枚だけのときにしか使えない。この番、自分のポケモン（「ルールを持つポケモン」をのぞく）が使うワザの、相手のバトルポケモンへのダメージは「+80」される。",
+	},
+
+	variants: [{ type: "holo" }],
+
+	trainerType: "Supporter",
+	regulationMark: "J",
+	rarity: "Ultra Rare",
+
+	thirdParty: {
+		cardmarket: 888654,
+	},
+};
+
+export default card;

--- a/data-asia/M/M5/110.ts
+++ b/data-asia/M/M5/110.ts
@@ -1,0 +1,28 @@
+import { Card } from "../../../interfaces";
+import Set from "../M5";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "サビ組のしたっぱ",
+	},
+
+	illustrator: "Teeziro",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードは、前の相手の番に、自分のポケモンがきぜつしていなければ使えない。相手の場のポケモンについているエネルギーを1個選び、トラッシュする。",
+	},
+
+	variants: [{ type: "holo" }],
+
+	trainerType: "Supporter",
+	regulationMark: "J",
+	rarity: "Ultra Rare",
+
+	thirdParty: {
+		cardmarket: 888655,
+	},
+};
+
+export default card;

--- a/data-asia/M/M5/111.ts
+++ b/data-asia/M/M5/111.ts
@@ -1,0 +1,28 @@
+import { Card } from "../../../interfaces";
+import Set from "../M5";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ムク",
+	},
+
+	illustrator: "nagimiso",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の手札からポケモン（「ルールを持つポケモン」をのぞく）を2枚までトラッシュし、その枚数×3枚ぶん、山札を引く。",
+	},
+
+	variants: [{ type: "holo" }],
+
+	trainerType: "Supporter",
+	regulationMark: "J",
+	rarity: "Ultra Rare",
+
+	thirdParty: {
+		cardmarket: 888656,
+	},
+};
+
+export default card;

--- a/data-asia/M/M5/112.ts
+++ b/data-asia/M/M5/112.ts
@@ -1,0 +1,53 @@
+import { Card } from "../../../interfaces";
+import Set from "../M5";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "メガゼラオラex",
+	},
+
+	illustrator: "GIDORA",
+	category: "Pokemon",
+	hp: 270,
+	types: ["Lightning"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "サンダーフィスト" },
+			damage: "60×",
+			cost: ["Lightning"],
+			effect: {
+				ja: "このポケモンについている[L]エネルギーの数×60ダメージ。",
+			},
+		},
+		{
+			name: { ja: "ゼプトターン" },
+			damage: 150,
+			cost: ["Lightning", "Lightning", "Lightning"],
+			effect: {
+				ja: "このポケモンをベンチポケモンと入れ替える。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [{ type: "holo" }],
+
+	retreat: 1,
+	regulationMark: "J",
+	rarity: "Special illustration rare",
+	dexId: [807],
+
+	suffix: "EX",
+
+	thirdParty: {
+		cardmarket: 888657,
+	},
+};
+
+export default card;

--- a/data-asia/M/M5/113.ts
+++ b/data-asia/M/M5/113.ts
@@ -1,0 +1,59 @@
+import { Card } from "../../../interfaces";
+import Set from "../M5";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "メガシャンデラex",
+	},
+
+	illustrator: "REND",
+	category: "Pokemon",
+	hp: 350,
+	types: ["Psychic"],
+
+	stage: "Stage2",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "じゅばくのほのお" },
+			effect: {
+				ja: "このポケモンがいるかぎり、相手のバトルポケモンは、にげるためのエネルギーが1個ぶん多くなる。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ファントムメイズ" },
+			damage: "130+",
+			cost: ["Psychic", "Psychic"],
+			effect: {
+				ja: "相手のバトルポケモンのにげるためのエネルギーの数×50ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [{ type: "holo" }],
+
+	evolveFrom: {
+		ja: "ランプラー",
+	},
+
+	retreat: 2,
+	regulationMark: "J",
+	rarity: "Special illustration rare",
+	dexId: [609],
+
+	suffix: "EX",
+
+	thirdParty: {
+		cardmarket: 888658,
+	},
+};
+
+export default card;

--- a/data-asia/M/M5/114.ts
+++ b/data-asia/M/M5/114.ts
@@ -1,0 +1,52 @@
+import { Card } from "../../../interfaces";
+import Set from "../M5";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "メガダークライex",
+	},
+
+	illustrator: "AKIRA EGAWA",
+	category: "Pokemon",
+	hp: 280,
+	types: ["Darkness"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ナイトレイド" },
+			damage: "110+",
+			cost: ["Darkness", "Darkness"],
+			effect: {
+				ja: "自分のベンチポケモンにダメカンがのっているなら、110ダメージ追加。",
+			},
+		},
+		{
+			name: { ja: "アビスアイ" },
+			cost: ["Darkness", "Darkness", "Darkness"],
+			effect: {
+				ja: "相手のバトルポケモンが特殊状態なら、そのポケモンをきぜつさせる。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [{ type: "holo" }],
+
+	retreat: 2,
+	regulationMark: "J",
+	rarity: "Special illustration rare",
+	dexId: [491],
+
+	suffix: "EX",
+
+	thirdParty: {
+		cardmarket: 888659,
+	},
+};
+
+export default card;

--- a/data-asia/M/M5/115.ts
+++ b/data-asia/M/M5/115.ts
@@ -1,0 +1,52 @@
+import { Card } from "../../../interfaces";
+import Set from "../M5";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "モルペコex",
+	},
+
+	illustrator: "NC Empire",
+	category: "Pokemon",
+	hp: 180,
+	types: ["Darkness"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ホイールドロー" },
+			cost: ["Darkness"],
+			effect: {
+				ja: "自分の手札をすべて山札にもどして切る。その後、山札を6枚引く。",
+			},
+		},
+		{
+			name: { ja: "はらぺこボンバー" },
+			damage: "40+",
+			cost: ["Darkness", "Darkness"],
+			effect: {
+				ja: "このポケモンにのっているダメカンの数×40ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [{ type: "holo" }],
+
+	retreat: 1,
+	regulationMark: "J",
+	rarity: "Special illustration rare",
+	dexId: [877],
+
+	suffix: "EX",
+
+	thirdParty: {
+		cardmarket: 888660,
+	},
+};
+
+export default card;

--- a/data-asia/M/M5/116.ts
+++ b/data-asia/M/M5/116.ts
@@ -1,0 +1,28 @@
+import { Card } from "../../../interfaces";
+import Set from "../M5";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "グラジオの決戦",
+	},
+
+	illustrator: "DOM",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードは、自分の手札がこのカード1枚だけのときにしか使えない。この番、自分のポケモン（「ルールを持つポケモン」をのぞく）が使うワザの、相手のバトルポケモンへのダメージは「+80」される。",
+	},
+
+	variants: [{ type: "holo" }],
+
+	trainerType: "Supporter",
+	regulationMark: "J",
+	rarity: "Special illustration rare",
+
+	thirdParty: {
+		cardmarket: 888661,
+	},
+};
+
+export default card;

--- a/data-asia/M/M5/117.ts
+++ b/data-asia/M/M5/117.ts
@@ -1,0 +1,28 @@
+import { Card } from "../../../interfaces";
+import Set from "../M5";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ムク",
+	},
+
+	illustrator: "Naoki Saito",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の手札からポケモン（「ルールを持つポケモン」をのぞく）を2枚までトラッシュし、その枚数×3枚ぶん、山札を引く。",
+	},
+
+	variants: [{ type: "holo" }],
+
+	trainerType: "Supporter",
+	regulationMark: "J",
+	rarity: "Special illustration rare",
+
+	thirdParty: {
+		cardmarket: 888662,
+	},
+};
+
+export default card;

--- a/data-asia/M/M5/118.ts
+++ b/data-asia/M/M5/118.ts
@@ -1,0 +1,52 @@
+import { Card } from "../../../interfaces";
+import Set from "../M5";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "メガダークライex",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 280,
+	types: ["Darkness"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ナイトレイド" },
+			damage: "110+",
+			cost: ["Darkness", "Darkness"],
+			effect: {
+				ja: "自分のベンチポケモンにダメカンがのっているなら、110ダメージ追加。",
+			},
+		},
+		{
+			name: { ja: "アビスアイ" },
+			cost: ["Darkness", "Darkness", "Darkness"],
+			effect: {
+				ja: "相手のバトルポケモンが特殊状態なら、そのポケモンをきぜつさせる。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [{ type: "holo" }],
+
+	retreat: 2,
+	regulationMark: "J",
+	rarity: "Mega Hyper Rare",
+	dexId: [491],
+
+	suffix: "EX",
+
+	thirdParty: {
+		cardmarket: 888663,
+	},
+};
+
+export default card;


### PR DESCRIPTION
## What

Adds the complete Japanese expansion **M5 アビスアイ (Abyss Eye)**, released 2026-05-22 — the next Mega-era set after M4 (#1728):

- `data-asia/M/M5.ts` — set definition (81 official cards)
- `data-asia/M/M5/001.ts` … `118.ts` — all 118 cards (81 regular + 37 secret rares: 12 AR, 18 SR, 6 SAR, 1 Mega Hyper Rare)

## Data sources

- **pokemon-card.com** (official database): Japanese names, HP, attacks/abilities with full Japanese effect text, flavor texts, National Dex numbers, illustrators, regulation mark (J), official card count
- **limitlesstcg.com**: stages, evolves-from, weaknesses/resistances/retreat, rarity (mapped to the same rarity names M1–M4 use)
- **serebii.net**: illustrators of the secret rares 082–118 (these cards are not yet listed on limitlesstcg.com or in the official database); rarities cross-checked against Bulbapedia and Cardmarket
- **Cardmarket**: product IDs included as `thirdParty.cardmarket` (tcgplayer IDs not available to me)

## Notes

- Secret-rare reprints (082–101, 105–106, 108–118) carry the identical Japanese text of their main-set base card; the four gold trainers without a base in this set (102 アイアンディフェンダー, 103 エネルギーつけかえ, 104 クラッシュハンマー, 107 ブレイブバングル) use the official Japanese text of their most recent print from pokemon-card.com
- Follows the exact file format and conventions of M3/M4 (tabs, double quotes, `suffix: "EX"`, `variants` normal for C/U and holo above, `description` omitted where no flavor text exists)
- All 119 files type-check against `interfaces.d.ts` (`tsc --noEmit`)
- Cardimages(by cardid): https://files.felix.lol/api/file/share.php?token=4affa713df06407244d17006e8cb005b