### PR TITLE
(data) Add Japanese XY set CP1 Magma Gang VS Aqua Gang: Double Crisis

### DIFF
--- a/data-asia/XY/CP1/001.ts
+++ b/data-asia/XY/CP1/001.ts
@@ -1,0 +1,49 @@
+import { Card } from "../../../interfaces";
+import Set from "../CP1";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "マグマ団のドンメル",
+	},
+
+	illustrator: "Akira Komayama",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Fire"],
+
+	description: {
+		ja: "どんなに 重い 荷物でも ドンメルの おかげで 楽に 目的地まで 運べるわ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ひのこ" },
+			damage: 30,
+			cost: ["Fire", "Colorless"],
+			effect: {
+				ja: "このポケモンについているエネルギーを1個選び、トラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 563721,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Common",
+	dexId: [322],
+};
+
+export default card;

--- a/data-asia/XY/CP1/002.ts
+++ b/data-asia/XY/CP1/002.ts
@@ -1,0 +1,63 @@
+import { Card } from "../../../interfaces";
+import Set from "../CP1";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "マグマ団のバクーダ",
+	},
+
+	illustrator: "Shin Nagasawa",
+	category: "Pokemon",
+	hp: 110,
+	types: ["Fire"],
+
+	description: {
+		ja: "炎に 強い バクーダは 団員を 救出するときにも 大活躍 だったぞ。",
+	},
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "バーンドラフト" },
+			effect: {
+				ja: "自分のトラッシュから[炎]または[闘]エネルギーを1枚選び、このポケモンにつける。この特性は、自分の番に1回使える。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "かえんだま" },
+			damage: 60,
+			cost: ["Fire", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンについている基本エネルギーを1個選び、ベンチポケモンにつけ替える。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 563722,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "マグマ団のドンメル",
+	},
+
+	retreat: 3,
+	rarity: "Rare",
+	dexId: [323],
+};
+
+export default card;

--- a/data-asia/XY/CP1/003.ts
+++ b/data-asia/XY/CP1/003.ts
@@ -1,0 +1,46 @@
+import { Card } from "../../../interfaces";
+import Set from "../CP1";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アクア団のタマザラシ",
+	},
+
+	illustrator: "Sanosuke Sakuma",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Water"],
+
+	description: {
+		ja: "タマザラシの 水鉄砲は どんな 火だろうと 消せるの。 敵の 使う 炎なんて 効かないわ！",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "みずでっぽう" },
+			damage: 10,
+			cost: ["Water"],
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 563723,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Common",
+	dexId: [363],
+};
+
+export default card;

--- a/data-asia/XY/CP1/004.ts
+++ b/data-asia/XY/CP1/004.ts
@@ -1,0 +1,60 @@
+import { Card } from "../../../interfaces";
+import Set from "../CP1";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アクア団のトドグラー",
+	},
+
+	illustrator: "Naoki Saito",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Water"],
+
+	description: {
+		ja: "氷の道を 作って サポートして くれるんだ。 氷の上なら どんな バトルでも 勝てるぜ。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "みずとばし" },
+			cost: ["Water", "Colorless"],
+			effect: {
+				ja: "相手のポケモンを1匹選び、20ダメージ。［ベンチは弱点・抵抗力の計算をしない。］",
+			},
+		},
+		{
+			name: { ja: "ひょうのかぜ" },
+			damage: "60+",
+			cost: ["Water", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンが「マグマ団」のポケモンなら、60ダメージを追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 563724,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "アクア団のタマザラシ",
+	},
+
+	retreat: 3,
+	rarity: "Common",
+	dexId: [364],
+};
+
+export default card;

--- a/data-asia/XY/CP1/005.ts
+++ b/data-asia/XY/CP1/005.ts
@@ -1,0 +1,60 @@
+import { Card } from "../../../interfaces";
+import Set from "../CP1";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アクア団のトドゼルガ",
+	},
+
+	illustrator: "Hitoshi Ariga",
+	category: "Pokemon",
+	hp: 140,
+	types: ["Water"],
+
+	description: {
+		ja: "強力な 冷気で 凍らせる ワザが 得意よ。 凍らせたら 鋭い キバで 粉々に するの！",
+	},
+
+	stage: "Stage2",
+
+	attacks: [
+		{
+			name: { ja: "パワーブロー" },
+			damage: "30×",
+			cost: ["Colorless"],
+			effect: {
+				ja: "このポケモンについているエネルギーの数x30ダメージ。",
+			},
+		},
+		{
+			name: { ja: "デュアルブリザード" },
+			cost: ["Water", "Water", "Water", "Colorless"],
+			effect: {
+				ja: "このポケモンについている[水]エネルギーを2個トラッシュし、相手のポケモンを2匹選び、それぞれに80ダメージ。［ベンチは弱点・抵抗力の計算をしない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 563725,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "アクア団のトドグラー",
+	},
+
+	retreat: 4,
+	rarity: "Rare",
+	dexId: [365],
+};
+
+export default card;

--- a/data-asia/XY/CP1/006.ts
+++ b/data-asia/XY/CP1/006.ts
@@ -1,0 +1,57 @@
+import { Card } from "../../../interfaces";
+import Set from "../CP1";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アクア団のカイオーガEX",
+	},
+
+	illustrator: "nagimiso",
+	category: "Pokemon",
+	hp: 190,
+	types: ["Water"],
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "パワーセーバー" },
+			effect: {
+				ja: "おたがいの場にいる「アクア団」のポケモンの合計が4匹以下なら、このポケモンはワザが使えない。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "アクアインパクト" },
+			damage: "80+",
+			cost: ["Water", "Water", "Water", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンのにげるために必要なエネルギーの数x20ダメージを追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 563726,
+			},
+		},
+	],
+
+	retreat: 4,
+	rarity: "Double rare",
+	dexId: [382],
+
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/XY/CP1/007.ts
+++ b/data-asia/XY/CP1/007.ts
@@ -1,0 +1,51 @@
+import { Card } from "../../../interfaces";
+import Set from "../CP1";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アクア団のベトベター",
+	},
+
+	illustrator: "kawayoo",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Psychic"],
+
+	description: {
+		ja: "どんな 隙間でも 入り込める 柔軟な 体は 敵の アジトに 侵入するときに 役立つぜ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "はたく" },
+			damage: 10,
+			cost: ["Psychic"],
+		},
+		{
+			name: { ja: "どろかけ" },
+			damage: 30,
+			cost: ["Psychic", "Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 563727,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Common",
+	dexId: [88],
+};
+
+export default card;

--- a/data-asia/XY/CP1/008.ts
+++ b/data-asia/XY/CP1/008.ts
@@ -1,0 +1,63 @@
+import { Card } from "../../../interfaces";
+import Set from "../CP1";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アクア団のベトベトン",
+	},
+
+	illustrator: "Kouki Saitou",
+	category: "Pokemon",
+	hp: 110,
+	types: ["Psychic"],
+
+	description: {
+		ja: "毒を まとった 巨体で 敵を 包み込んで 動けなくするの。 あなたも 押しつぶして あげる！",
+	},
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ヘドロまつり" },
+			effect: {
+				ja: "このポケモンがいるかぎり、おたがいのポケモン全員（「アクア団」をのぞく）のにげるために必要なエネルギーは、それぞれ1個ぶん多くなる。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ついげき" },
+			damage: "60+",
+			cost: ["Psychic", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンが特殊状態なら、60ダメージを追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 563728,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "アクア団のベトベター",
+	},
+
+	retreat: 3,
+	rarity: "Rare",
+	dexId: [89],
+};
+
+export default card;

--- a/data-asia/XY/CP1/009.ts
+++ b/data-asia/XY/CP1/009.ts
@@ -1,0 +1,57 @@
+import { Card } from "../../../interfaces";
+import Set from "../CP1";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アクア団のハブネーク",
+	},
+
+	illustrator: "Naoki Saito",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Psychic"],
+
+	description: {
+		ja: "ハブネークの しっぽは するどい 剣に なっているぞ。 毒を 出すことだって できるのさ！",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "どくのキバ" },
+			damage: 10,
+			cost: ["Psychic"],
+			effect: {
+				ja: "コインを1回投げオモテなら、相手のバトルポケモンをどくにする。",
+			},
+		},
+		{
+			name: { ja: "ベノムテール" },
+			damage: 30,
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンが特殊状態なら、そのバトルポケモンについているエネルギーを1個選び、トラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 563729,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [336],
+};
+
+export default card;

--- a/data-asia/XY/CP1/010.ts
+++ b/data-asia/XY/CP1/010.ts
@@ -1,0 +1,48 @@
+import { Card } from "../../../interfaces";
+import Set from "../CP1";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "マグマ団のヤジロン",
+	},
+
+	illustrator: "Mitsuhiro Arita",
+	category: "Pokemon",
+	hp: 50,
+	types: ["Psychic"],
+
+	description: {
+		ja: "敵を 見つけたら 一斉に 鳴き声を あげて 知らせて くれるんだ。 助かるぜ！",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "テレキネシス" },
+			cost: ["Psychic", "Colorless"],
+			effect: {
+				ja: "相手のポケモンを1匹選び、20ダメージ。このワザのダメージは弱点・抵抗力の計算をしない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 563730,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [343],
+};
+
+export default card;

--- a/data-asia/XY/CP1/011.ts
+++ b/data-asia/XY/CP1/011.ts
@@ -1,0 +1,60 @@
+import { Card } from "../../../interfaces";
+import Set from "../CP1";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "マグマ団のネンドール",
+	},
+
+	illustrator: "Masakazu Fukuda",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Psychic"],
+
+	description: {
+		ja: "ネンドールが 放つ ビームは 確実に 敵を 捉えるの。 遠くからの 攻撃は 任せなさい！",
+	},
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "マグマスイッチ" },
+			effect: {
+				ja: "自分の場のポケモンについている基本エネルギーを1個選び、自分の別の「マグマ団」のポケモンにつけ替える。この特性は、自分の番に1回使える。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "パワービーム" },
+			damage: 70,
+			cost: ["Psychic", "Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 563731,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "マグマ団のヤジロン",
+	},
+
+	retreat: 2,
+	rarity: "Rare",
+	dexId: [344],
+};
+
+export default card;

--- a/data-asia/XY/CP1/012.ts
+++ b/data-asia/XY/CP1/012.ts
@@ -1,0 +1,46 @@
+import { Card } from "../../../interfaces";
+import Set from "../CP1";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "マグマ団のココドラ",
+	},
+
+	illustrator: "Akira Komayama",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Fighting"],
+
+	description: {
+		ja: "鉄も 食べてしまう ココドラは 敵の 船だって あっと いう間に 食べて 壊して しまうんだ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "かじる" },
+			damage: 10,
+			cost: ["Fighting"],
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 563732,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Common",
+	dexId: [304],
+};
+
+export default card;

--- a/data-asia/XY/CP1/013.ts
+++ b/data-asia/XY/CP1/013.ts
@@ -1,0 +1,58 @@
+import { Card } from "../../../interfaces";
+import Set from "../CP1";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "マグマ団のコドラ",
+	},
+
+	illustrator: "Masakazu Fukuda",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Fighting"],
+
+	description: {
+		ja: "コドラの 堅い体で 与える 突進の 衝撃は コンクリートも 破壊するぜ！",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "かじる" },
+			damage: 30,
+			cost: ["Fighting", "Colorless"],
+		},
+		{
+			name: { ja: "とっしん" },
+			damage: 60,
+			cost: ["Fighting", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンにも10ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 563733,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "マグマ団のココドラ",
+	},
+
+	retreat: 3,
+	rarity: "Common",
+	dexId: [305],
+};
+
+export default card;

--- a/data-asia/XY/CP1/014.ts
+++ b/data-asia/XY/CP1/014.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../CP1";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "マグマ団のボスゴドラ",
+	},
+
+	illustrator: "TOKIYA",
+	category: "Pokemon",
+	hp: 140,
+	types: ["Fighting"],
+
+	description: {
+		ja: "ボスゴドラの 鋼のツノは どんなに 固い 防壁でも 突き破ることが できるのよ！",
+	},
+
+	stage: "Stage2",
+
+	attacks: [
+		{
+			name: { ja: "ロックスタンプ" },
+			damage: "40×",
+			cost: ["Fighting", "Colorless"],
+			effect: {
+				ja: "自分の場のポケモンについている[闘]エネルギーを好きなだけトラッシュし、トラッシュした[闘]エネルギーの数x40ダメージ。",
+			},
+		},
+		{
+			name: { ja: "がんせきあらし" },
+			damage: 120,
+			cost: ["Fighting", "Fighting", "Fighting", "Colorless"],
+			effect: {
+				ja: "ダメカンがのっている相手のベンチポケモン全員にも、それぞれ20ダメージ。［ベンチは弱点・抵抗力の計算をしない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 563734,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "マグマ団のコドラ",
+	},
+
+	retreat: 4,
+	rarity: "Rare",
+	dexId: [306],
+};
+
+export default card;

--- a/data-asia/XY/CP1/015.ts
+++ b/data-asia/XY/CP1/015.ts
@@ -1,0 +1,57 @@
+import { Card } from "../../../interfaces";
+import Set from "../CP1";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "マグマ団のグラードンEX",
+	},
+
+	illustrator: "nagimiso",
+	category: "Pokemon",
+	hp: 190,
+	types: ["Fighting"],
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "パワーセーバー" },
+			effect: {
+				ja: "おたがいの場にいる「マグマ団」のポケモンの合計が4匹以下なら、このポケモンはワザが使えない。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "マグマクエイク" },
+			damage: "80+",
+			cost: ["Fighting", "Fighting", "Fighting", "Colorless"],
+			effect: {
+				ja: "ダメージを与えるとき、すでに相手のバトルポケモンにダメカンがのっているなら、80ダメージを追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 563735,
+			},
+		},
+	],
+
+	retreat: 4,
+	rarity: "Double rare",
+	dexId: [383],
+
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/XY/CP1/016.ts
+++ b/data-asia/XY/CP1/016.ts
@@ -1,0 +1,53 @@
+import { Card } from "../../../interfaces";
+import Set from "../CP1";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アクア団のポチエナ",
+	},
+
+	illustrator: "Kouki Saitou",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Darkness"],
+
+	description: {
+		ja: "ポチエナの するどい 嗅覚は 敵の 侵入を すぐに 察知するぞ。 とても 優秀な 見張り番だ！",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ほえる" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをベンチポケモンと入れ替える。［バトル場に出すポケモンは相手が選ぶ。］",
+			},
+		},
+		{
+			name: { ja: "かみつく" },
+			damage: 20,
+			cost: ["Water", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 563736,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [261],
+};
+
+export default card;

--- a/data-asia/XY/CP1/017.ts
+++ b/data-asia/XY/CP1/017.ts
@@ -1,0 +1,53 @@
+import { Card } from "../../../interfaces";
+import Set from "../CP1";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "マグマ団のポチエナ",
+	},
+
+	illustrator: "TOKIYA",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Darkness"],
+
+	description: {
+		ja: "ポチエナの 鼻は どんな 匂いも 嗅ぎ分けられるから 偵察のときに とても 役立つんだ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "せんにゅう" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "相手の手札を見る。",
+			},
+		},
+		{
+			name: { ja: "かみつく" },
+			damage: 20,
+			cost: ["Fighting", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 563737,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [261],
+};
+
+export default card;

--- a/data-asia/XY/CP1/018.ts
+++ b/data-asia/XY/CP1/018.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../CP1";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アクア団のグラエナ",
+	},
+
+	illustrator: "Mitsuhiro Arita",
+	category: "Pokemon",
+	hp: 100,
+	types: ["Darkness"],
+
+	description: {
+		ja: "統率力 バツグンの コンビネーション 攻撃が 得意！ 襲われたら 手も足も 出ないぞ。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "チームインパクト" },
+			damage: "30×",
+			cost: ["Water", "Colorless"],
+			effect: {
+				ja: "自分の場の「アクア団」のポケモンの数ぶんコインを投げ、オモテの数x30ダメージ。",
+			},
+		},
+		{
+			name: { ja: "かみくだく" },
+			damage: 80,
+			cost: ["Water", "Water", "Colorless"],
+			effect: {
+				ja: "コインを1回投げオモテなら、相手のバトルポケモンについているエネルギーを1個選び、トラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 563738,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "アクア団のポチエナ",
+	},
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [262],
+};
+
+export default card;

--- a/data-asia/XY/CP1/019.ts
+++ b/data-asia/XY/CP1/019.ts
@@ -1,0 +1,58 @@
+import { Card } from "../../../interfaces";
+import Set from "../CP1";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "マグマ団のグラエナ",
+	},
+
+	illustrator: "Hitoshi Ariga",
+	category: "Pokemon",
+	hp: 100,
+	types: ["Darkness"],
+
+	description: {
+		ja: "主人に 忠実な ポケモンだ。 どんなに 傷ついたと しても トレーナーを 守りぬくぞ。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "かみつく" },
+			damage: 30,
+			cost: ["Fighting", "Colorless"],
+		},
+		{
+			name: { ja: "てきいのキバ" },
+			damage: "80+",
+			cost: ["Fighting", "Fighting", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンが「アクア団」のポケモンなら、40ダメージを追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 563739,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "マグマ団のポチエナ",
+	},
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [262],
+};
+
+export default card;

--- a/data-asia/XY/CP1/020.ts
+++ b/data-asia/XY/CP1/020.ts
@@ -1,0 +1,49 @@
+import { Card } from "../../../interfaces";
+import Set from "../CP1";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アクア団のキバニア",
+	},
+
+	illustrator: "Sanosuke Sakuma",
+	category: "Pokemon",
+	hp: 50,
+	types: ["Darkness"],
+
+	description: {
+		ja: "水の中なら こいつの 動きに ついて これないだろ？ この渦に 巻き込まれたら 脱出できないぜ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ひれビンタ" },
+			damage: "10×",
+			cost: ["Darkness"],
+			effect: {
+				ja: "コインを2回投げ、オモテの数x10ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 563740,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [318],
+};
+
+export default card;

--- a/data-asia/XY/CP1/021.ts
+++ b/data-asia/XY/CP1/021.ts
@@ -1,0 +1,60 @@
+import { Card } from "../../../interfaces";
+import Set from "../CP1";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アクア団のサメハダー",
+	},
+
+	illustrator: "kawayoo",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Darkness"],
+
+	description: {
+		ja: "自慢の キバは 一撃必殺の 威力！ 油断している 敵を 確実に 仕留めるわ！",
+	},
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "アクアサーチ" },
+			effect: {
+				ja: "自分の山札から「アクア団」のポケモンを1枚選び、相手に見せてから、手札に加える。そして山札を切る。この特性は、自分の番に1回使える。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "するどいキバ" },
+			damage: 70,
+			cost: ["Darkness", "Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 563741,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "アクア団のキバニア",
+	},
+
+	retreat: 0,
+	rarity: "Rare",
+	dexId: [319],
+};
+
+export default card;

--- a/data-asia/XY/CP1/022.ts
+++ b/data-asia/XY/CP1/022.ts
@@ -1,0 +1,56 @@
+import { Card } from "../../../interfaces";
+import Set from "../CP1";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "マグマ団のザングース",
+	},
+
+	illustrator: "Shin Nagasawa",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Colorless"],
+
+	description: {
+		ja: "恐れ知らずの ザングース達の フォーメーション 攻撃を 見切ることが できるかしら？",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "なかまをよぶ" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札から「マグマ団」のたねポケモンを2枚まで選び、ベンチに出す。そして山札を切る。",
+			},
+		},
+		{
+			name: { ja: "チームプレイ" },
+			damage: "20×",
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "自分のベンチの「マグマ団」のポケモンの数x20ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 563742,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [335],
+};
+
+export default card;

--- a/data-asia/XY/CP1/023.ts
+++ b/data-asia/XY/CP1/023.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../CP1";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アクア団のスーパーボール",
+	},
+
+	illustrator: "Toyste Beach",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の山札から「アクア団」のたねポケモンと基本[水]エネルギーをそれぞれ1枚ずつ選び、相手に見せてから、手札に加える。そして山札を切る。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 563743,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/XY/CP1/024.ts
+++ b/data-asia/XY/CP1/024.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../CP1";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "マグマ団のスーパーボール",
+	},
+
+	illustrator: "Toyste Beach",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の山札から「マグマ団」のたねポケモンと基本[闘]エネルギーをそれぞれ1枚ずつ選び、相手に見せてから、手札に加える。そして山札を切る。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 563744,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/XY/CP1/025.ts
+++ b/data-asia/XY/CP1/025.ts
@@ -1,0 +1,40 @@
+import { Card } from "../../../interfaces";
+import Set from "../CP1";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アクアディフューザー",
+	},
+
+	illustrator: "Toyste Beach",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードをつけている「アクア団」のポケモンは、このカードに書かれているワザを使える。［ワザを使うためのエネルギーは必要。］",
+	},
+
+	attacks: [
+		{
+			name: { ja: "アクアディフューザー" },
+			cost: ["Water"],
+			effect: {
+				ja: "相手のバトルポケモンをどくとこんらんにする。",
+			},
+		},
+	],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 563745,
+			},
+		},
+	],
+
+	trainerType: "Tool",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/XY/CP1/026.ts
+++ b/data-asia/XY/CP1/026.ts
@@ -1,0 +1,40 @@
+import { Card } from "../../../interfaces";
+import Set from "../CP1";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "マグマポインター",
+	},
+
+	illustrator: "Toyste Beach",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードをつけている「マグマ団」のポケモンは、このカードに書かれているワザを使える。［ワザを使うためのエネルギーは必要。］",
+	},
+
+	attacks: [
+		{
+			name: { ja: "マグマポインター" },
+			cost: ["Fighting"],
+			effect: {
+				ja: "相手のポケモンを1匹選び、20ダメージ。［ベンチは弱点・抵抗力の計算をしない。］",
+			},
+		},
+	],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 563746,
+			},
+		},
+	],
+
+	trainerType: "Tool",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/XY/CP1/027.ts
+++ b/data-asia/XY/CP1/027.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../CP1";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アクア団の幹部",
+	},
+
+	illustrator: "GAME FREAK inc.",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分のトラッシュから基本エネルギーを1枚選び、自分のバトル場にいる「アクア団」のポケモンにつける。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 563747,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/XY/CP1/028.ts
+++ b/data-asia/XY/CP1/028.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../CP1";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アクア団のしたっぱ",
+	},
+
+	illustrator: "GAME FREAK inc.",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の手札を1枚選び、トラッシュする。その後、自分の山札を3枚引く。トラッシュしたカードが「アクア団」のポケモンなら、さらに1枚引く。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 563748,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/XY/CP1/029.ts
+++ b/data-asia/XY/CP1/029.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../CP1";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "マグマ団の幹部",
+	},
+
+	illustrator: "GAME FREAK inc.",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分のトラッシュから「マグマ団」のポケモンを3枚選び、相手に見せてから、手札に加える。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 563749,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/XY/CP1/030.ts
+++ b/data-asia/XY/CP1/030.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../CP1";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "マグマ団のしたっぱ",
+	},
+
+	illustrator: "GAME FREAK inc.",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の手札を1枚選び、トラッシュする。その後、自分の山札を3枚引く。トラッシュしたカードが「マグマ団」のポケモンなら、さらに1枚引く。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 563750,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/XY/CP1/031.ts
+++ b/data-asia/XY/CP1/031.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../CP1";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アクア団の秘密基地",
+	},
+
+	illustrator: "Ryo Ueda",
+	category: "Trainer",
+
+	effect: {
+		ja: "おたがいのポケモン全員（「アクア団」をのぞく）のにげるために必要なエネルギーは、それぞれ1個ぶん多くなる。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 563751,
+			},
+		},
+	],
+
+	trainerType: "Stadium",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/XY/CP1/032.ts
+++ b/data-asia/XY/CP1/032.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../CP1";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "マグマ団の秘密基地",
+	},
+
+	illustrator: "Ryo Ueda",
+	category: "Trainer",
+
+	effect: {
+		ja: "おたがいのプレイヤーは、それぞれ、手札からたねポケモン（「マグマ団」をのぞく）をベンチに出すたび、そのポケモンにダメカンを2個のせる。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 563752,
+			},
+		},
+	],
+
+	trainerType: "Stadium",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/XY/CP1/033.ts
+++ b/data-asia/XY/CP1/033.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../CP1";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ダブルアクアエネルギー",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Energy",
+	energyType: "Special",
+
+	effect: {
+		ja: "このカードは「アクア団」のポケモンにしかつけられず、つけた番の終わりにトラッシュする。このカードはポケモンについているかぎり、[水]エネルギー2個ぶんとしてはたらく。（このカードが「アクア団」のポケモン以外についているなら、トラッシュする。）",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 563753,
+			},
+		},
+	],
+
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/XY/CP1/034.ts
+++ b/data-asia/XY/CP1/034.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../CP1";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ダブルマグマエネルギー",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Energy",
+	energyType: "Special",
+
+	effect: {
+		ja: "このカードは「マグマ団」のポケモンにしかつけられず、つけた番の終わりにトラッシュする。このカードはポケモンについているかぎり、[闘]エネルギー2個ぶんとしてはたらく。（このカードが「マグマ団」のポケモン以外についているなら、トラッシュする。）",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 563754,
+			},
+		},
+	],
+
+	rarity: "Uncommon",
+};
+
+export default card;


### PR DESCRIPTION
## What

Adds all cards of the Japanese XY concept pack **CP1 マグマ団VSアクア団 ダブルクライシス (Double Crisis)**, released 2015-01-30:

- `data-asia/XY/CP1/001.ts` … `034.ts` — all 34 cards (22 Pokémon incl. Team Aqua's Kyogre-EX / Team Magma's Groudon-EX, 10 Trainers, 2 Special Energy)
- the set definition `data-asia/XY/CP1.ts` already existed and is untouched

## Data sources

- **pokemon-card.com** (official database): Japanese names, flavor texts, National Dex numbers, Pokémon Tool text of 025/026
- **limitlesstcg.com**: full Japanese card text, stages, weaknesses/resistances/retreat, rarities, illustrators, attack costs
- **Cardmarket**: product IDs as `thirdParty.cardmarket` on the variant objects (563721–563754; tcgplayer IDs not available to me)

## Notes

- Same file format as the M-era sets (M4 #1728); no `regulationMark` (the XY era predates regulation marks), resistances are `-20` per the era
- Rarities follow the Japanese print: C/U/R plus the two EX as `Double rare`; variants `normal` for C/U, `holo` for R/RR
- 025/026 (Aqua Diffuser / Magma Pointer) are Pokémon Tools that grant an attack — modeled as `effect` (Tool clause) + `attacks`, like their English prints
- All 34 files type-check against `interfaces.d.ts` (`tsc --noEmit`)
- No card images included yet