### PR TITLE
(data) Add Japanese M set M2a Mega Dream ex

### DIFF
--- a/data-asia/M/M2a.ts
+++ b/data-asia/M/M2a.ts
@@ -1,0 +1,20 @@
+import { Set } from "../../interfaces";
+import serie from "../M";
+
+const set: Set = {
+	id: "M2a",
+	name: {
+		ja: "MEGAドリームex",
+	},
+
+	serie: serie,
+
+	cardCount: {
+		official: 193,
+	},
+	releaseDate: {
+		ja: "2025-11-28",
+	},
+};
+
+export default set;

--- a/data-asia/M/M2a/001.ts
+++ b/data-asia/M/M2a/001.ts
@@ -1,0 +1,68 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヒビキのカイロス",
+	},
+
+	illustrator: "GIDORA",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Grass"],
+
+	description: {
+		ja: "ツノで 獲物を 挟みこみ そのまま まっぷたつに するか 強引に 投げ飛ばしてしまう。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "はさむ" },
+			damage: 20,
+			cost: ["Grass"],
+		},
+		{
+			name: { ja: "いっぽんがえし" },
+			damage: "70+",
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "前の相手の番に、ワザのダメージで、自分の「ヒビキのポケモン」がきぜつしていたなら、100ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 861245,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "energy",
+			thirdParty: {
+				cardmarket: 861526,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 861527,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "I",
+	rarity: "None",
+	dexId: [127],
+};
+
+export default card;

--- a/data-asia/M/M2a/002.ts
+++ b/data-asia/M/M2a/002.ts
@@ -1,0 +1,67 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヤンヤンマ",
+	},
+
+	illustrator: "svlt",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Grass"],
+
+	description: {
+		ja: "翅を 高速で はためかせて 空中で 停止 しながら 自分の 縄張りを 見張っている。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ふきとばし" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをベンチポケモンと入れ替える。［バトル場に出すポケモンは相手が選ぶ。］",
+			},
+		},
+		{
+			name: { ja: "するどいはね" },
+			damage: 30,
+			cost: ["Grass", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 861246,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "energy",
+			thirdParty: {
+				cardmarket: 861528,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 861529,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "None",
+	dexId: [193],
+};
+
+export default card;

--- a/data-asia/M/M2a/003.ts
+++ b/data-asia/M/M2a/003.ts
@@ -1,0 +1,62 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "メガヤンマex",
+	},
+
+	illustrator: "takuyoa",
+	category: "Pokemon",
+	hp: 280,
+	types: ["Grass"],
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "バズブースト" },
+			effect: {
+				ja: "自分の番に、このポケモンがベンチからバトル場に出たとき、1回使える。自分の山札から「基本[G]エネルギー」を3枚まで選び、このポケモンにつける。そして山札を切る。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ジェットサイクロン" },
+			damage: 210,
+			cost: ["Grass", "Grass", "Grass", "Colorless"],
+			effect: {
+				ja: "このポケモンについているエネルギーを3個選び、ベンチポケモン1匹につけ替える。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 861247,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ヤンヤンマ",
+	},
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "Double rare",
+	dexId: [469],
+
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/M/M2a/004.ts
+++ b/data-asia/M/M2a/004.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ケムッソ",
+	},
+
+	illustrator: "USGMEN",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Grass"],
+
+	description: {
+		ja: "葉っぱが 大好物。 ムックルに 襲われたときは お尻の トゲで 撃退する。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "むしくい" },
+			damage: 20,
+			cost: ["Grass"],
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 861248,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "energy",
+			thirdParty: {
+				cardmarket: 861530,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "loveball",
+			thirdParty: {
+				cardmarket: 861531,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "None",
+	dexId: [265],
+};
+
+export default card;

--- a/data-asia/M/M2a/005.ts
+++ b/data-asia/M/M2a/005.ts
@@ -1,0 +1,75 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "カラサリス",
+	},
+
+	illustrator: "Eri Yamaki",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Grass"],
+
+	description: {
+		ja: "糸を 木の枝に 巻きつけている。 糸についた 雨水を 飲みながら 進化の ときを 待っている。",
+	},
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ふえるまゆ" },
+			effect: {
+				ja: "自分の番に、このカードを手札から出して進化させたとき、1回使える。自分の山札から「カラサリス」または「マユルド」を1枚選び、ベンチに出す。そして山札を切る。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "たいあたり" },
+			damage: 30,
+			cost: ["Grass"],
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 861249,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "energy",
+			thirdParty: {
+				cardmarket: 861532,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "loveball",
+			thirdParty: {
+				cardmarket: 861533,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ケムッソ",
+	},
+
+	retreat: 3,
+	regulationMark: "I",
+	rarity: "None",
+	dexId: [266],
+};
+
+export default card;

--- a/data-asia/M/M2a/006.ts
+++ b/data-asia/M/M2a/006.ts
@@ -1,0 +1,76 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アゲハント",
+	},
+
+	illustrator: "Narumi Sato",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Grass"],
+
+	description: {
+		ja: "色 鮮やかな 羽の 模様が 特徴。 細い 口を 伸ばして 花の 甘い ミツを 吸い取る。",
+	},
+
+	stage: "Stage2",
+
+	attacks: [
+		{
+			name: { ja: "しびれごな" },
+			damage: 40,
+			cost: ["Grass"],
+			effect: {
+				ja: "コインを1回投げオモテなら、相手のバトルポケモンをマヒにする。",
+			},
+		},
+		{
+			name: { ja: "エナジーストロー" },
+			damage: "80×",
+			cost: ["Grass"],
+			effect: {
+				ja: "相手の手札を見て、その中にあるエネルギーの枚数×80ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 861250,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "energy",
+			thirdParty: {
+				cardmarket: 861534,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "loveball",
+			thirdParty: {
+				cardmarket: 861535,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "カラサリス",
+	},
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "None",
+	dexId: [267],
+};
+
+export default card;

--- a/data-asia/M/M2a/007.ts
+++ b/data-asia/M/M2a/007.ts
@@ -1,0 +1,67 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "マユルド",
+	},
+
+	illustrator: "June",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Grass"],
+
+	description: {
+		ja: "やわらかい 糸で できた 体は 時間と ともに 硬くなっていく。 ひび割れると 進化は 間近だ。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "いれかわる" },
+			cost: ["Grass"],
+			effect: {
+				ja: "このポケモンをベンチポケモンと入れ替える。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 861251,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "energy",
+			thirdParty: {
+				cardmarket: 861536,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "loveball",
+			thirdParty: {
+				cardmarket: 861537,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ケムッソ",
+	},
+
+	retreat: 3,
+	regulationMark: "I",
+	rarity: "None",
+	dexId: [268],
+};
+
+export default card;

--- a/data-asia/M/M2a/008.ts
+++ b/data-asia/M/M2a/008.ts
@@ -1,0 +1,78 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ドクケイル",
+	},
+
+	illustrator: "kamonabe",
+	category: "Pokemon",
+	hp: 140,
+	types: ["Grass"],
+
+	description: {
+		ja: "夜行性の ポケモン。 明かりに 誘われた ドクケイルが 街路樹の 葉を 食い散らかす。",
+	},
+
+	stage: "Stage2",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "さざめくかぜ" },
+			effect: {
+				ja: "自分の番に1回使える。コインを1回投げオモテなら、相手のバトルポケモンについているエネルギーを1個選び、相手の手札にもどす。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ゆうやみどく" },
+			damage: 100,
+			cost: ["Grass", "Grass"],
+			effect: {
+				ja: "相手のバトルポケモンをどくとねむりにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 861252,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "energy",
+			thirdParty: {
+				cardmarket: 861538,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "loveball",
+			thirdParty: {
+				cardmarket: 861539,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "マユルド",
+	},
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "None",
+	dexId: [269],
+};
+
+export default card;

--- a/data-asia/M/M2a/009.ts
+++ b/data-asia/M/M2a/009.ts
@@ -1,0 +1,60 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "シロナのロゼリア",
+	},
+
+	illustrator: "nisimono",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Grass"],
+
+	description: {
+		ja: "右手と 左手で ２種類の 毒を 使いわけて 攻撃する。 香りが 強いほど 元気だ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "トゲでさす" },
+			damage: 20,
+			cost: ["Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 861253,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "energy",
+			thirdParty: {
+				cardmarket: 861540,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 861541,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "None",
+	dexId: [315],
+};
+
+export default card;

--- a/data-asia/M/M2a/010.ts
+++ b/data-asia/M/M2a/010.ts
@@ -1,0 +1,74 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "シロナのロズレイド",
+	},
+
+	illustrator: "En Morikura",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Grass"],
+
+	description: {
+		ja: "右手の 毒は 即効性。 左手の 毒は 遅効性。 どちらも 命に かかわるぞ。",
+	},
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "グローリーエール" },
+			effect: {
+				ja: "このポケモンがいるかぎり、自分の「シロナのポケモン」が使うワザの、相手のバトルポケモンへのダメージは「+30」される。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "リーフステップ" },
+			damage: 80,
+			cost: ["Grass", "Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 861254,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "energy",
+			thirdParty: {
+				cardmarket: 861542,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 861543,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "シロナのロゼリア",
+	},
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "None",
+	dexId: [407],
+};
+
+export default card;

--- a/data-asia/M/M2a/011.ts
+++ b/data-asia/M/M2a/011.ts
@@ -1,0 +1,64 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "スボミー",
+	},
+
+	illustrator: "Yoriyuki Ikegami",
+	category: "Pokemon",
+	hp: 30,
+	types: ["Grass"],
+
+	description: {
+		ja: "毒を 含んだ 花粉を まく。 きれいな 水で 育てるほど 毒の 成分は 高まる。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "むずむずかふん" },
+			damage: 10,
+			cost: [],
+			effect: {
+				ja: "次の相手の番、相手は手札からグッズを出して使えない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 861255,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "energy",
+			thirdParty: {
+				cardmarket: 861544,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "friendball",
+			thirdParty: {
+				cardmarket: 861545,
+			},
+		},
+	],
+
+	retreat: 0,
+	regulationMark: "H",
+	rarity: "None",
+	dexId: [406],
+};
+
+export default card;

--- a/data-asia/M/M2a/012.ts
+++ b/data-asia/M/M2a/012.ts
@@ -1,0 +1,70 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "シェイミ",
+	},
+
+	illustrator: "tono",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Grass"],
+
+	description: {
+		ja: "グラシデアの花が 咲く 季節 感謝の 心を 届けるために 飛び立つと 言われている。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "はなのカーテン" },
+			effect: {
+				ja: "このポケモンがいるかぎり、自分のベンチポケモン（「ルールを持つポケモン」をのぞく）全員は、相手のワザのダメージを受けない。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "けとばす" },
+			damage: 30,
+			cost: ["Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 861256,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "energy",
+			thirdParty: {
+				cardmarket: 861546,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 861547,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "None",
+	dexId: [492],
+};
+
+export default card;

--- a/data-asia/M/M2a/013.ts
+++ b/data-asia/M/M2a/013.ts
@@ -1,0 +1,62 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "イシズマイ",
+	},
+
+	illustrator: "Kanami Ogata",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Grass"],
+
+	description: {
+		ja: "家に ちょうどいい 小石が 見つからないと カバルドンの 穴に 棲んでしまうことも。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "かくせい" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "このポケモンから進化するカードを、自分の山札から1枚選び、このポケモンにのせて進化させる。そして山札を切る。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 861257,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "energy",
+			thirdParty: {
+				cardmarket: 861548,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 861549,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "I",
+	rarity: "None",
+	dexId: [557],
+};
+
+export default card;

--- a/data-asia/M/M2a/014.ts
+++ b/data-asia/M/M2a/014.ts
@@ -1,0 +1,77 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "イワパレス",
+	},
+
+	illustrator: "Po-Suzuki",
+	category: "Pokemon",
+	hp: 150,
+	types: ["Grass"],
+
+	description: {
+		ja: "太い ツメが 最大の 武器。 ドサイドンの プロテクターにさえ ひびを 入れるほど 硬いぞ。",
+	},
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "しんぴのいしやど" },
+			effect: {
+				ja: "このポケモンは、相手の「ポケモンex」からワザのダメージを受けない。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "グレートシザー" },
+			damage: 120,
+			cost: ["Grass", "Colorless", "Colorless"],
+			effect: {
+				ja: "このワザのダメージは、相手のバトルポケモンにかかっている効果を計算しない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 861258,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "energy",
+			thirdParty: {
+				cardmarket: 861550,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 861551,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "イシズマイ",
+	},
+
+	retreat: 3,
+	regulationMark: "I",
+	rarity: "None",
+	dexId: [558],
+};
+
+export default card;

--- a/data-asia/M/M2a/015.ts
+++ b/data-asia/M/M2a/015.ts
@@ -1,0 +1,64 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ロケット団のタマンチュラ",
+	},
+
+	illustrator: "Saboteri",
+	category: "Pokemon",
+	hp: 50,
+	types: ["Grass"],
+
+	description: {
+		ja: "体を 包みこむ 糸玉は 天敵の ストライクの カマを はね返す 弾力性を 持つ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "とっしん" },
+			damage: 30,
+			cost: ["Grass"],
+			effect: {
+				ja: "このポケモンにも10ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 861259,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "energy",
+			thirdParty: {
+				cardmarket: 861552,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "team-rocket",
+			thirdParty: {
+				cardmarket: 861553,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "None",
+	dexId: [917],
+};
+
+export default card;

--- a/data-asia/M/M2a/016.ts
+++ b/data-asia/M/M2a/016.ts
@@ -1,0 +1,78 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ロケット団のワナイダー",
+	},
+
+	illustrator: "Taiga Kasai",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Grass"],
+
+	description: {
+		ja: "木の枝や 天井に 糸で 張りつき 音もなく 行動する。 獲物に 気づかれる前に 倒す。",
+	},
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "チャージアップ" },
+			effect: {
+				ja: "自分の番に1回使える。自分のトラッシュから基本エネルギーを1枚選び、このポケモンにつける。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ロケットラッシュ" },
+			damage: "30×",
+			cost: ["Grass", "Colorless"],
+			effect: {
+				ja: "自分の場の「ロケット団のポケモン」の数×30ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 861494,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "energy",
+			thirdParty: {
+				cardmarket: 861554,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "team-rocket",
+			thirdParty: {
+				cardmarket: 861555,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ロケット団のタマンチュラ",
+	},
+
+	retreat: 2,
+	regulationMark: "I",
+	rarity: "None",
+	dexId: [918],
+};
+
+export default card;

--- a/data-asia/M/M2a/017.ts
+++ b/data-asia/M/M2a/017.ts
@@ -1,0 +1,58 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "オーガポン みどりのめんex",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 210,
+	types: ["Grass"],
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "みどりのまい" },
+			effect: {
+				ja: "自分の番に1回使える。自分の手札から「基本[G]エネルギー」を1枚選び、このポケモンにつける。その後、自分の山札を1枚引く。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "まんようしぐれ" },
+			damage: "30+",
+			cost: ["Grass", "Grass", "Grass"],
+			effect: {
+				ja: "おたがいのバトルポケモンについているエネルギーの数×30ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 861260,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "H",
+	rarity: "Double rare",
+	dexId: [1017],
+
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/M/M2a/018.ts
+++ b/data-asia/M/M2a/018.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヒビキのマグマッグ",
+	},
+
+	illustrator: "Sanosuke Sakuma",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Fire"],
+
+	description: {
+		ja: "溶岩で できた 体は 冷えて 欠けてしまうこともあるが マグマに 浸かると 治るのだ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ひをはく" },
+			damage: 20,
+			cost: ["Fire"],
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 861261,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "energy",
+			thirdParty: {
+				cardmarket: 861556,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				cardmarket: 861557,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "I",
+	rarity: "None",
+	dexId: [218],
+};
+
+export default card;

--- a/data-asia/M/M2a/019.ts
+++ b/data-asia/M/M2a/019.ts
@@ -1,0 +1,78 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヒビキのマグカルゴ",
+	},
+
+	illustrator: "kodama",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Fire"],
+
+	description: {
+		ja: "火山の 火口付近で 暮らす。 マグマが 冷えて 固まった 殻に 炎エネルギーを 蓄えている。",
+	},
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "とけてながれる" },
+			effect: {
+				ja: "このポケモンにエネルギーがついていないなら、このポケモンのにげるためのエネルギーは、すべてなくなる。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ようがんバースト" },
+			damage: "70×",
+			cost: ["Fire", "Fire", "Fire"],
+			effect: {
+				ja: "このポケモンについている[R]エネルギーを5枚までトラッシュし、その枚数×70ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 861262,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "energy",
+			thirdParty: {
+				cardmarket: 861558,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				cardmarket: 861559,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ヒビキのマグマッグ",
+	},
+
+	retreat: 3,
+	regulationMark: "I",
+	rarity: "None",
+	dexId: [219],
+};
+
+export default card;

--- a/data-asia/M/M2a/020.ts
+++ b/data-asia/M/M2a/020.ts
@@ -1,0 +1,64 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "エンテイ",
+	},
+
+	illustrator: "Kazumasa Yasukuni",
+	category: "Pokemon",
+	hp: 140,
+	types: ["Fire"],
+
+	description: {
+		ja: "新しい 火山が できるたび 生まれてくると 伝えられる 大地を 駆け巡る ポケモン。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "フレアフォール" },
+			damage: "30+",
+			cost: ["Fire", "Fire"],
+			effect: {
+				ja: "自分の場に[R]エネルギーが4個以上あるなら、90ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 861263,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "energy",
+			thirdParty: {
+				cardmarket: 861560,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "quickball",
+			thirdParty: {
+				cardmarket: 861561,
+			},
+		},
+	],
+
+	retreat: 3,
+	regulationMark: "I",
+	rarity: "None",
+	dexId: [244],
+};
+
+export default card;

--- a/data-asia/M/M2a/021.ts
+++ b/data-asia/M/M2a/021.ts
@@ -1,0 +1,58 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヒビキのホウオウex",
+	},
+
+	illustrator: "aky CG Works",
+	category: "Pokemon",
+	hp: 230,
+	types: ["Fire"],
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "こんじきのほのお" },
+			effect: {
+				ja: "自分の番に1回使える。自分の手札から「基本[R]エネルギー」を2枚まで選び、ベンチの「ヒビキのポケモン」1匹につける。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "シャイニングフェザー" },
+			damage: 160,
+			cost: ["Fire", "Fire", "Fire", "Fire"],
+			effect: {
+				ja: "自分のポケモン全員のHPを、それぞれ「50」回復する。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 861264,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "I",
+	rarity: "Double rare",
+	dexId: [250],
+
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/M/M2a/022.ts
+++ b/data-asia/M/M2a/022.ts
@@ -1,0 +1,71 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ドンメル",
+	},
+
+	illustrator: "Ounishi",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Fire"],
+
+	description: {
+		ja: "１２００度の マグマを 体内に 溜めこんでいる。 炎の 技を 使うと コブは 小さく しぼむ。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "しゃくねつボディ" },
+			effect: {
+				ja: "このポケモンが、バトル場で相手のポケモンからワザのダメージを受けたとき、ワザを使ったポケモンをやけどにする。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "かえん" },
+			damage: 20,
+			cost: ["Fire", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 861265,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "energy",
+			thirdParty: {
+				cardmarket: 861562,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "quickball",
+			thirdParty: {
+				cardmarket: 861563,
+			},
+		},
+	],
+
+	retreat: 3,
+	regulationMark: "I",
+	rarity: "None",
+	dexId: [322],
+};
+
+export default card;

--- a/data-asia/M/M2a/023.ts
+++ b/data-asia/M/M2a/023.ts
@@ -1,0 +1,76 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "バクーダ",
+	},
+
+	illustrator: "Minahamu",
+	category: "Pokemon",
+	hp: 140,
+	types: ["Fire"],
+
+	description: {
+		ja: "背中の コブの 火山は １０年ごとに 大噴火 するが 激しく 怒っても 噴火する。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "やけどあぶり" },
+			damage: 110,
+			cost: ["Fire"],
+			effect: {
+				ja: "相手のバトルポケモンがやけどでないなら、このワザは失敗。",
+			},
+		},
+		{
+			name: { ja: "パワースタンプ" },
+			damage: 170,
+			cost: ["Fire", "Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンについているエネルギーを2個選び、トラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 861266,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "energy",
+			thirdParty: {
+				cardmarket: 861564,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "quickball",
+			thirdParty: {
+				cardmarket: 861565,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ドンメル",
+	},
+
+	retreat: 3,
+	regulationMark: "I",
+	rarity: "None",
+	dexId: [323],
+};
+
+export default card;

--- a/data-asia/M/M2a/024.ts
+++ b/data-asia/M/M2a/024.ts
@@ -1,0 +1,66 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ポカブ",
+	},
+
+	illustrator: "Teeziro",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Fire"],
+
+	description: {
+		ja: "敵の 攻撃を 身軽に 避けて 鼻から 火の玉を 撃ち出す。 炎で 木の実を 焼いて 食べる。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "たいあたり" },
+			damage: 10,
+			cost: ["Fire"],
+		},
+		{
+			name: { ja: "ころがる" },
+			damage: 30,
+			cost: ["Fire", "Fire"],
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 861267,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "energy",
+			thirdParty: {
+				cardmarket: 861566,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "friendball",
+			thirdParty: {
+				cardmarket: 861567,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "None",
+	dexId: [498],
+};
+
+export default card;

--- a/data-asia/M/M2a/025.ts
+++ b/data-asia/M/M2a/025.ts
@@ -1,0 +1,70 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "チャオブー",
+	},
+
+	illustrator: "Teeziro",
+	category: "Pokemon",
+	hp: 110,
+	types: ["Fire"],
+
+	description: {
+		ja: "体内の 炎が 燃え上がると 動きの キレと スピードが 増す。 ピンチになると 煙を 吹き出す。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "かえん" },
+			damage: 30,
+			cost: ["Fire"],
+		},
+		{
+			name: { ja: "ヒートスタンプ" },
+			damage: 80,
+			cost: ["Fire", "Fire", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 861268,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "energy",
+			thirdParty: {
+				cardmarket: 861568,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "friendball",
+			thirdParty: {
+				cardmarket: 861569,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ポカブ",
+	},
+
+	retreat: 3,
+	regulationMark: "I",
+	rarity: "None",
+	dexId: [499],
+};
+
+export default card;

--- a/data-asia/M/M2a/026.ts
+++ b/data-asia/M/M2a/026.ts
@@ -1,0 +1,74 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "エンブオー",
+	},
+
+	illustrator: "Teeziro",
+	category: "Pokemon",
+	hp: 180,
+	types: ["Fire"],
+
+	description: {
+		ja: "アゴの 炎で こぶしを 燃やして 炎の パンチを 繰り出す。 とても 仲間思いの ポケモン。",
+	},
+
+	stage: "Stage2",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "れっからんぶ" },
+			effect: {
+				ja: "自分の番に何回でも使える。自分の手札から「基本[R]エネルギー」を1枚選び、自分のポケモンにつける。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ヒートスタンプ" },
+			damage: 120,
+			cost: ["Fire", "Fire", "Fire", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 861269,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "energy",
+			thirdParty: {
+				cardmarket: 861570,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 861571,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "チャオブー",
+	},
+
+	retreat: 4,
+	regulationMark: "I",
+	rarity: "None",
+	dexId: [500],
+};
+
+export default card;

--- a/data-asia/M/M2a/027.ts
+++ b/data-asia/M/M2a/027.ts
@@ -1,0 +1,66 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "Nのダルマッカ",
+	},
+
+	illustrator: "Gemi",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Fire"],
+
+	description: {
+		ja: "寝ているときは 押しても 引いても けっして 倒れない。 縁起ものの モチーフとして 人気が 高い。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ころがりタックル" },
+			damage: 20,
+			cost: ["Colorless", "Colorless"],
+		},
+		{
+			name: { ja: "ほのお" },
+			damage: 50,
+			cost: ["Fire", "Fire", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 861270,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "energy",
+			thirdParty: {
+				cardmarket: 861572,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				cardmarket: 861573,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "I",
+	rarity: "None",
+	dexId: [554],
+};
+
+export default card;

--- a/data-asia/M/M2a/028.ts
+++ b/data-asia/M/M2a/028.ts
@@ -1,0 +1,76 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "Nのヒヒダルマ",
+	},
+
+	illustrator: "Takeshi Nakamura",
+	category: "Pokemon",
+	hp: 140,
+	types: ["Fire"],
+
+	description: {
+		ja: "体内の 炎が 燃え盛るほど パワーが 高まる。 その 温度は １４００度を 超える ことも。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "バックドラフト" },
+			damage: "30×",
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "相手のトラッシュにある基本エネルギーの枚数×30ダメージ。",
+			},
+		},
+		{
+			name: { ja: "ひだるまキャノン" },
+			damage: 90,
+			cost: ["Fire", "Fire", "Colorless"],
+			effect: {
+				ja: "このポケモンについているエネルギーをすべてトラッシュし、相手のベンチポケモン1匹にも、90ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 861271,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "energy",
+			thirdParty: {
+				cardmarket: 861574,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				cardmarket: 861575,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "Nのダルマッカ",
+	},
+
+	retreat: 3,
+	regulationMark: "I",
+	rarity: "None",
+	dexId: [555],
+};
+
+export default card;

--- a/data-asia/M/M2a/029.ts
+++ b/data-asia/M/M2a/029.ts
@@ -1,0 +1,53 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "レシラムex",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 230,
+	types: ["Fire"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "きりさく" },
+			damage: 50,
+			cost: ["Colorless", "Colorless"],
+		},
+		{
+			name: { ja: "ブレイズバースト" },
+			damage: "130+",
+			cost: ["Fire", "Fire", "Colorless"],
+			effect: {
+				ja: "相手がすでにとったサイドの枚数×50ダメージ追加。このポケモンについているエネルギーを1個選び、トラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 861272,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "I",
+	rarity: "Double rare",
+	dexId: [643],
+
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/M/M2a/030.ts
+++ b/data-asia/M/M2a/030.ts
@@ -1,0 +1,60 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "カルボウ",
+	},
+
+	illustrator: "Kariya",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Fire"],
+
+	description: {
+		ja: "戦いになると 火力が 上がり 摂氏１０００度に 達する。 油分の多い 木の実を 好む。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "おにび" },
+			damage: 20,
+			cost: ["Fire"],
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 861273,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "energy",
+			thirdParty: {
+				cardmarket: 861576,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 861577,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "H",
+	rarity: "None",
+	dexId: [935],
+};
+
+export default card;

--- a/data-asia/M/M2a/031.ts
+++ b/data-asia/M/M2a/031.ts
@@ -1,0 +1,60 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ソウブレイズex",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 270,
+	types: ["Fire"],
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "しんえんほむら" },
+			damage: "30+",
+			cost: ["Fire"],
+			effect: {
+				ja: "自分のトラッシュにあるエネルギーの枚数×20ダメージ追加。",
+			},
+		},
+		{
+			name: { ja: "アメジストレイジ" },
+			damage: 280,
+			cost: ["Fire", "Psychic", "Metal"],
+			effect: {
+				ja: "このポケモンについているエネルギーを、すべてトラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 861274,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "カルボウ",
+	},
+
+	retreat: 2,
+	regulationMark: "H",
+	rarity: "Double rare",
+	dexId: [937],
+
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/M/M2a/032.ts
+++ b/data-asia/M/M2a/032.ts
@@ -1,0 +1,71 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "コダック",
+	},
+
+	illustrator: "Jiro Sasumo",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Water"],
+
+	description: {
+		ja: "いつも 頭痛に 悩まされている。 この 頭痛が 激しくなると 不思議な 力を 使いはじめる。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "しめりけ" },
+			effect: {
+				ja: "このポケモンがいるかぎり、おたがいのポケモン全員は、そのポケモン自身をきぜつさせる効果の特性が、すべてなくなる。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ぶつかる" },
+			damage: 20,
+			cost: ["Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 861275,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "energy",
+			thirdParty: {
+				cardmarket: 861578,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "loveball",
+			thirdParty: {
+				cardmarket: 861579,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "None",
+	dexId: [54],
+};
+
+export default card;

--- a/data-asia/M/M2a/033.ts
+++ b/data-asia/M/M2a/033.ts
@@ -1,0 +1,78 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ゴルダック",
+	},
+
+	illustrator: "Jiro Sasumo",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Water"],
+
+	description: {
+		ja: "水かきのついた 長い 手足を 使い 全力で 泳ぎだすと なぜか 額が 光り輝く。",
+	},
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "しめりけ" },
+			effect: {
+				ja: "このポケモンがいるかぎり、おたがいのポケモン全員は、そのポケモン自身をきぜつさせる効果の特性が、すべてなくなる。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ハイドロポンプ" },
+			damage: "60+",
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンについている[W]エネルギーの数×20ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 861276,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "energy",
+			thirdParty: {
+				cardmarket: 861580,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "loveball",
+			thirdParty: {
+				cardmarket: 861581,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "コダック",
+	},
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "None",
+	dexId: [55],
+};
+
+export default card;

--- a/data-asia/M/M2a/034.ts
+++ b/data-asia/M/M2a/034.ts
@@ -1,0 +1,73 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ロケット団のフリーザー",
+	},
+
+	illustrator: "Mitsuhiro Arita",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Water"],
+
+	description: {
+		ja: "氷を 自在に 操る 力を もつ。 永久凍土の 雪山に 棲んでいるという。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "レジストヴェール" },
+			effect: {
+				ja: "このポケモンがいるかぎり、自分の場のたねポケモンの「ロケット団のポケモン」全員は、相手のポケモンが使うワザの効果を受けない。（すでに受けている効果は、なくならない。）",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ダークフロスト" },
+			damage: "60+",
+			cost: ["Water", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンに「ロケット団エネルギー」がついているなら、60ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 861277,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "energy",
+			thirdParty: {
+				cardmarket: 861582,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 861583,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "None",
+	dexId: [144],
+};
+
+export default card;

--- a/data-asia/M/M2a/035.ts
+++ b/data-asia/M/M2a/035.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ユキワラシ",
+	},
+
+	illustrator: "Wintr Wandr",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Water"],
+
+	description: {
+		ja: "ユキワラシの 棲みついた 家は お金持ちになるという 言い伝えが 雪国には 残っている。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ひんやり" },
+			damage: 10,
+			cost: ["Water"],
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 861278,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "energy",
+			thirdParty: {
+				cardmarket: 861584,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "loveball",
+			thirdParty: {
+				cardmarket: 861585,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "None",
+	dexId: [361],
+};
+
+export default card;

--- a/data-asia/M/M2a/036.ts
+++ b/data-asia/M/M2a/036.ts
@@ -1,0 +1,60 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "メガユキメノコex",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 310,
+	types: ["Water"],
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "うらみぶし" },
+			damage: "50×",
+			cost: ["Water"],
+			effect: {
+				ja: "相手の手札の枚数×50ダメージ。",
+			},
+		},
+		{
+			name: { ja: "アブソリュートスノー" },
+			damage: 150,
+			cost: ["Water", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをねむりにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 861279,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ユキワラシ",
+	},
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "Double rare",
+	dexId: [478],
+
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/M/M2a/037.ts
+++ b/data-asia/M/M2a/037.ts
@@ -1,0 +1,68 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "Nのバニプッチ",
+	},
+
+	illustrator: "yuu",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Water"],
+
+	description: {
+		ja: "マイナス５０度の 息を 吐く。 雪の 結晶を 作って あたりに 雪を 降らせる。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "なかまをよぶ" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札からたねポケモンを2枚まで選び、ベンチに出す。そして山札を切る。",
+			},
+		},
+		{
+			name: { ja: "スノーアイス" },
+			damage: 20,
+			cost: ["Water", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 861280,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "energy",
+			thirdParty: {
+				cardmarket: 861586,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				cardmarket: 861587,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "None",
+	dexId: [582],
+};
+
+export default card;

--- a/data-asia/M/M2a/038.ts
+++ b/data-asia/M/M2a/038.ts
@@ -1,0 +1,73 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "Nのバニリッチ",
+	},
+
+	illustrator: "kirisAki",
+	category: "Pokemon",
+	hp: 100,
+	types: ["Water"],
+
+	description: {
+		ja: "あたりの 空気を 冷やして 氷の 粒を 発生させて 敵の 体を 凍りつかせる。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "はねまわる" },
+			damage: 20,
+			cost: ["Colorless"],
+		},
+		{
+			name: { ja: "ぜったいれいど" },
+			damage: 60,
+			cost: ["Water", "Colorless", "Colorless"],
+			effect: {
+				ja: "次の相手の番、このワザを受けたポケモンは、ワザが使えない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 861281,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "energy",
+			thirdParty: {
+				cardmarket: 861588,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				cardmarket: 861589,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "Nのバニプッチ",
+	},
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "None",
+	dexId: [583],
+};
+
+export default card;

--- a/data-asia/M/M2a/039.ts
+++ b/data-asia/M/M2a/039.ts
@@ -1,0 +1,75 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "Nのバイバニラ",
+	},
+
+	illustrator: "imoniii",
+	category: "Pokemon",
+	hp: 150,
+	types: ["Water"],
+
+	description: {
+		ja: "２つの 頭が 同時に 怒ると ツノから 猛吹雪を 噴き出す。 あたりを 大雪で 埋めてしまう。",
+	},
+
+	stage: "Stage2",
+
+	attacks: [
+		{
+			name: { ja: "かさねゆき" },
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "相手のポケモン全員に、それぞれのっているダメカンの数が2倍になるように、ダメカンをのせる。",
+			},
+		},
+		{
+			name: { ja: "ふぶき" },
+			damage: 120,
+			cost: ["Water", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のベンチポケモン全員にも、それぞれ10ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 861282,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "energy",
+			thirdParty: {
+				cardmarket: 861590,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				cardmarket: 861591,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "Nのバニリッチ",
+	},
+
+	retreat: 2,
+	regulationMark: "I",
+	rarity: "None",
+	dexId: [584],
+};
+
+export default card;

--- a/data-asia/M/M2a/040.ts
+++ b/data-asia/M/M2a/040.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ユキハミ",
+	},
+
+	illustrator: "Izucch",
+	category: "Pokemon",
+	hp: 50,
+	types: ["Water"],
+
+	description: {
+		ja: "食べた 雪から 得た 冷気を 体内の 器官で 増幅して 氷柱のような トゲを 作る。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "つらら" },
+			damage: 20,
+			cost: ["Water"],
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 861283,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "energy",
+			thirdParty: {
+				cardmarket: 861592,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "friendball",
+			thirdParty: {
+				cardmarket: 861593,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "None",
+	dexId: [872],
+};
+
+export default card;

--- a/data-asia/M/M2a/041.ts
+++ b/data-asia/M/M2a/041.ts
@@ -1,0 +1,78 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "モスノウ",
+	},
+
+	illustrator: "cochi8i",
+	category: "Pokemon",
+	hp: 110,
+	types: ["Water"],
+
+	description: {
+		ja: "冷気を 発する 大きな 翅で 飛びまわり 猛吹雪を 起こす。 綺麗な 雪解け水が 好物。",
+	},
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "いざなうはね" },
+			effect: {
+				ja: "このポケモンがバトル場にいるなら、自分の番に1回使える。おたがいのプレイヤーは、それぞれ山札を1枚引く。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "コールドサイクロン" },
+			damage: 90,
+			cost: ["Water", "Water"],
+			effect: {
+				ja: "このポケモンについている[W]エネルギーを1個選び、ベンチポケモンにつけ替える。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 861284,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "energy",
+			thirdParty: {
+				cardmarket: 861594,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "friendball",
+			thirdParty: {
+				cardmarket: 861595,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ユキハミ",
+	},
+
+	retreat: 2,
+	regulationMark: "I",
+	rarity: "None",
+	dexId: [873],
+};
+
+export default card;

--- a/data-asia/M/M2a/042.ts
+++ b/data-asia/M/M2a/042.ts
@@ -1,0 +1,72 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ブリザポス",
+	},
+
+	illustrator: "mashu",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Water"],
+
+	description: {
+		ja: "蹄から 強力な 冷気を 放つ。 欲しいものは なんでも 力尽くで 奪う 暴れん坊。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "アイスショット" },
+			damage: 20,
+			cost: ["Water"],
+			effect: {
+				ja: "相手のベンチポケモン1匹にも、20ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+			},
+		},
+		{
+			name: { ja: "フロストタイフーン" },
+			damage: 130,
+			cost: ["Water", "Water", "Water"],
+			effect: {
+				ja: "次の自分の番、このポケモンは「フロストタイフーン」が使えない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 861285,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "energy",
+			thirdParty: {
+				cardmarket: 861596,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "friendball",
+			thirdParty: {
+				cardmarket: 861597,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "I",
+	rarity: "None",
+	dexId: [896],
+};
+
+export default card;

--- a/data-asia/M/M2a/043.ts
+++ b/data-asia/M/M2a/043.ts
@@ -1,0 +1,73 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "パオジアン",
+	},
+
+	illustrator: "toi8",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Water"],
+
+	description: {
+		ja: "大昔に 剣によって 露と消えた 者たちの 憎しみが 雪を まとい ポケモンになった。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ゆきにしずめる" },
+			effect: {
+				ja: "自分の番に、このカードを手札からベンチに出したとき、1回使える。場に出ているスタジアムをトラッシュする。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "アイシクルループ" },
+			damage: 120,
+			cost: ["Water", "Water", "Colorless"],
+			effect: {
+				ja: "このポケモンについているエネルギーを1個選び、手札にもどす。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 861286,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "energy",
+			thirdParty: {
+				cardmarket: 861598,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 861599,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "H",
+	rarity: "None",
+	dexId: [1002],
+};
+
+export default card;

--- a/data-asia/M/M2a/044.ts
+++ b/data-asia/M/M2a/044.ts
@@ -1,0 +1,58 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ピカチュウex",
+	},
+
+	illustrator: "aky CG Works",
+	category: "Pokemon",
+	hp: 200,
+	types: ["Lightning"],
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "がんばりハート" },
+			effect: {
+				ja: "このポケモンのHPがまんたんの状態で、このポケモンがワザのダメージを受けてきぜつするとき、きぜつせず、残りHPが「10」の状態で場に残る。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "トパーズボルト" },
+			damage: 300,
+			cost: ["Grass", "Lightning", "Metal"],
+			effect: {
+				ja: "このポケモンについているエネルギーを3個選び、トラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 861287,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "H",
+	rarity: "Double rare",
+	dexId: [25],
+
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/M/M2a/045.ts
+++ b/data-asia/M/M2a/045.ts
@@ -1,0 +1,60 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "コイル",
+	},
+
+	illustrator: "Hoshino KURO",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Lightning"],
+
+	description: {
+		ja: "空中に 浮いたまま 移動して 左右の ユニットから 電磁波などを 放射する。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ピッカリだま" },
+			damage: 20,
+			cost: ["Lightning"],
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 861288,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "energy",
+			thirdParty: {
+				cardmarket: 861600,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 861601,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "H",
+	rarity: "None",
+	dexId: [81],
+};
+
+export default card;

--- a/data-asia/M/M2a/046.ts
+++ b/data-asia/M/M2a/046.ts
@@ -1,0 +1,74 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "レアコイル",
+	},
+
+	illustrator: "Shinya Mizuno",
+	category: "Pokemon",
+	hp: 100,
+	types: ["Lightning"],
+
+	description: {
+		ja: "連結した タイプの コイルは 太陽の 黒点が 多いとき たくさん 現れると 言われる。",
+	},
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "かじょうほうでん" },
+			effect: {
+				ja: "自分の番に1回使えて、使ったなら、このポケモンをきぜつさせる。自分のトラッシュから基本エネルギーを3枚まで選び、自分の[L]ポケモンに好きなようにつける。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ライトニングボール" },
+			damage: 40,
+			cost: ["Lightning", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 861289,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "energy",
+			thirdParty: {
+				cardmarket: 861602,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 861603,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "コイル",
+	},
+
+	retreat: 1,
+	regulationMark: "H",
+	rarity: "None",
+	dexId: [82],
+};
+
+export default card;

--- a/data-asia/M/M2a/047.ts
+++ b/data-asia/M/M2a/047.ts
@@ -1,0 +1,63 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "シビシラス",
+	},
+
+	illustrator: "Jerky",
+	category: "Pokemon",
+	hp: 40,
+	types: ["Lightning"],
+
+	description: {
+		ja: "１匹の 電力は 小さいが たくさんの シビシラスが つながると 雷と 同じ 威力になる。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "じっとする" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "このポケモンのHPを「10」回復する。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 861290,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "energy",
+			thirdParty: {
+				cardmarket: 861604,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "quickball",
+			thirdParty: {
+				cardmarket: 861605,
+			},
+		},
+	],
+
+	retreat: 0,
+	regulationMark: "I",
+	rarity: "None",
+	dexId: [602],
+};
+
+export default card;

--- a/data-asia/M/M2a/048.ts
+++ b/data-asia/M/M2a/048.ts
@@ -1,0 +1,75 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "シビビール",
+	},
+
+	illustrator: "Jerky",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Lightning"],
+
+	description: {
+		ja: "丸い 模様が 発電 器官。 相手に 巻きついてから 模様を 押しつけて 電気を 流すのだ。",
+	},
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "エレキダイナモ" },
+			effect: {
+				ja: "自分のトラッシュから[雷]エネルギーを1枚選び、自分のベンチポケモンにつける。この特性は、自分の番に1回使える。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ライトニングボール" },
+			damage: 50,
+			cost: ["Lightning", "Lightning", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 861291,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "energy",
+			thirdParty: {
+				cardmarket: 861606,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "quickball",
+			thirdParty: {
+				cardmarket: 861607,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "シビシラス",
+	},
+
+	retreat: 2,
+	regulationMark: "I",
+	rarity: "None",
+	dexId: [603],
+};
+
+export default card;

--- a/data-asia/M/M2a/049.ts
+++ b/data-asia/M/M2a/049.ts
@@ -1,0 +1,59 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "メガシビルドンex",
+	},
+
+	illustrator: "takuyoa",
+	category: "Pokemon",
+	hp: 350,
+	types: ["Lightning"],
+
+	stage: "Stage2",
+
+	attacks: [
+		{
+			name: { ja: "ばくれつだん" },
+			cost: ["Lightning", "Lightning"],
+			effect: {
+				ja: "相手のポケモン2匹に、それぞれ60ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+			},
+		},
+		{
+			name: { ja: "ディザスターショック" },
+			damage: 190,
+			cost: ["Lightning", "Lightning", "Lightning"],
+			effect: {
+				ja: "のぞむなら、このポケモンについている[L]エネルギーを2個トラッシュし、相手のバトルポケモンをマヒにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 861292,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "シビビール",
+	},
+
+	retreat: 2,
+	regulationMark: "I",
+	rarity: "Double rare",
+	dexId: [604],
+
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/M/M2a/050.ts
+++ b/data-asia/M/M2a/050.ts
@@ -1,0 +1,64 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "マッギョ",
+	},
+
+	illustrator: "Tetsu Kayama",
+	category: "Pokemon",
+	hp: 110,
+	types: ["Lightning"],
+
+	description: {
+		ja: "海辺の 泥に 埋まって 獲物を 待ち構える。 獲物が 触れたとき 電気を 出して しびれさせるのだ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "とびつくわな" },
+			damage: 30,
+			cost: ["Lightning"],
+			effect: {
+				ja: "次の相手の番、このワザを受けたポケモンは、にげられない。次の自分の番、このワザを受けたポケモンが受けるワザのダメージは「+100」される。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 861293,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "energy",
+			thirdParty: {
+				cardmarket: 861608,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "quickball",
+			thirdParty: {
+				cardmarket: 861609,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "I",
+	rarity: "None",
+	dexId: [618],
+};
+
+export default card;

--- a/data-asia/M/M2a/051.ts
+++ b/data-asia/M/M2a/051.ts
@@ -1,0 +1,53 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ゼクロムex",
+	},
+
+	illustrator: "takuyoa",
+	category: "Pokemon",
+	hp: 230,
+	types: ["Lightning"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "きりさく" },
+			damage: 50,
+			cost: ["Colorless", "Colorless"],
+		},
+		{
+			name: { ja: "ボルテージバースト" },
+			damage: "130+",
+			cost: ["Lightning", "Lightning", "Colorless"],
+			effect: {
+				ja: "相手がすでにとったサイドの枚数×50ダメージ追加。このポケモンにも30ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 861294,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "I",
+	rarity: "Double rare",
+	dexId: [644],
+
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/M/M2a/052.ts
+++ b/data-asia/M/M2a/052.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "エリキテル",
+	},
+
+	illustrator: "Tika Matsuno",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Lightning"],
+
+	description: {
+		ja: "頭の 両わきの ひだには 太陽の 光を 浴びると 発電する 細胞が あるのだ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "エレキック" },
+			damage: 30,
+			cost: ["Lightning", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 861295,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "energy",
+			thirdParty: {
+				cardmarket: 861610,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "quickball",
+			thirdParty: {
+				cardmarket: 861611,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "None",
+	dexId: [694],
+};
+
+export default card;

--- a/data-asia/M/M2a/053.ts
+++ b/data-asia/M/M2a/053.ts
@@ -1,0 +1,78 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "エレザード",
+	},
+
+	illustrator: "svlt",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Lightning"],
+
+	description: {
+		ja: "エリマキを 広げて 発電する。 エレザード １匹で 高層ビルで 必要な 電気を 作れるのだ。",
+	},
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "エリマキはつでん" },
+			effect: {
+				ja: "この番に、手札から「カナリィ」を出して使っていたなら、自分の番に1回使える。自分の山札から「基本[L]エネルギー」を2枚まで選び、このポケモンにつける。そして山札を切る。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "パワフルボルト" },
+			damage: "70×",
+			cost: ["Lightning", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンについているエネルギーの数ぶんコインを投げ、オモテの数×70ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 861296,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "energy",
+			thirdParty: {
+				cardmarket: 861612,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "quickball",
+			thirdParty: {
+				cardmarket: 861613,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "エリキテル",
+	},
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "None",
+	dexId: [695],
+};
+
+export default card;

--- a/data-asia/M/M2a/054.ts
+++ b/data-asia/M/M2a/054.ts
@@ -1,0 +1,71 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "カプ・コケコ",
+	},
+
+	illustrator: "Anesaki Dynamic",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Lightning"],
+
+	description: {
+		ja: "守り神と 呼ばれるが 気分を 害する 人間や ポケモンには 襲い掛かる 荒ぶる神 でもある。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ファストフライト" },
+			cost: ["Lightning"],
+			effect: {
+				ja: "このワザは、先攻プレイヤーの最初の番でも使える。自分の手札をすべてトラッシュし、山札を5枚引く。",
+			},
+		},
+		{
+			name: { ja: "サンダーブラスト" },
+			damage: 130,
+			cost: ["Lightning", "Lightning", "Colorless"],
+			effect: {
+				ja: "このポケモンについているエネルギーを2個選び、トラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 861297,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "energy",
+			thirdParty: {
+				cardmarket: 861614,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "quickball",
+			thirdParty: {
+				cardmarket: 861615,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "None",
+	dexId: [785],
+};
+
+export default card;

--- a/data-asia/M/M2a/055.ts
+++ b/data-asia/M/M2a/055.ts
@@ -1,0 +1,67 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ゼラオラ",
+	},
+
+	illustrator: "Ryuta Fuse",
+	category: "Pokemon",
+	hp: 100,
+	types: ["Lightning"],
+
+	description: {
+		ja: "手足の 肉球から 放電。 ゼラオラが 駆け抜けると 稲妻が 光り 雷鳴が 轟く。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ひっかく" },
+			damage: 20,
+			cost: ["Colorless"],
+		},
+		{
+			name: { ja: "サンダーブリッツ" },
+			cost: ["Lightning", "Lightning", "Lightning"],
+			effect: {
+				ja: "このポケモンについているエネルギーをすべてトラッシュし、相手のベンチの「ポケモンex」1匹に、210ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 861298,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "energy",
+			thirdParty: {
+				cardmarket: 861616,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 861617,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "None",
+	dexId: [807],
+};
+
+export default card;

--- a/data-asia/M/M2a/056.ts
+++ b/data-asia/M/M2a/056.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ナンジャモのズピカ",
+	},
+
+	illustrator: "kurumitsu",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Lightning"],
+
+	description: {
+		ja: "尻尾を 振って 発電する。 危険を 感じると 頭を 点滅させて 仲間に 伝える。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "プチでんき" },
+			damage: 30,
+			cost: ["Lightning", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 861299,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "energy",
+			thirdParty: {
+				cardmarket: 861618,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				cardmarket: 861619,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "I",
+	rarity: "None",
+	dexId: [938],
+};
+
+export default card;

--- a/data-asia/M/M2a/057.ts
+++ b/data-asia/M/M2a/057.ts
@@ -1,0 +1,62 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ナンジャモのハラバリーex",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 280,
+	types: ["Lightning"],
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "エレキストリーマー" },
+			effect: {
+				ja: "自分の番に何回でも使える。自分の手札から「基本[L]エネルギー」を1枚選び、自分の「ナンジャモのポケモン」につける。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "サンダーボルト" },
+			damage: 230,
+			cost: ["Lightning", "Lightning", "Lightning", "Colorless"],
+			effect: {
+				ja: "次の自分の番、このポケモンはワザが使えない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 861300,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ナンジャモのズピカ",
+	},
+
+	retreat: 2,
+	regulationMark: "I",
+	rarity: "Double rare",
+	dexId: [939],
+
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/M/M2a/058.ts
+++ b/data-asia/M/M2a/058.ts
@@ -1,0 +1,64 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ナンジャモのカイデン",
+	},
+
+	illustrator: "Akira Komayama",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Lightning"],
+
+	description: {
+		ja: "翼の 骨は 風を 受けると 電気を 作る。 海に 飛び込み 獲物を 感電させて 捕らえる。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "でんこうせっか" },
+			damage: "10+",
+			cost: ["Lightning"],
+			effect: {
+				ja: "コインを1回投げオモテなら、20ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 861301,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "energy",
+			thirdParty: {
+				cardmarket: 861620,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				cardmarket: 861621,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "None",
+	dexId: [940],
+};
+
+export default card;

--- a/data-asia/M/M2a/059.ts
+++ b/data-asia/M/M2a/059.ts
@@ -1,0 +1,75 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ナンジャモのタイカイデン",
+	},
+
+	illustrator: "DOM",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Lightning"],
+
+	description: {
+		ja: "のど袋を ふくらませて 電気を 増幅させる。 風に 乗って １日で ７００キロを 飛行する。",
+	},
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "フラッシュドロー" },
+			effect: {
+				ja: "自分の番に、このポケモンについている「基本[L]エネルギー」を1個トラッシュするなら、1回使える。自分の手札が6枚になるように、山札を引く。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "マッハボルト" },
+			damage: 70,
+			cost: ["Lightning", "Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 861302,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "energy",
+			thirdParty: {
+				cardmarket: 861622,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				cardmarket: 861623,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ナンジャモのカイデン",
+	},
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "None",
+	dexId: [941],
+};
+
+export default card;

--- a/data-asia/M/M2a/060.ts
+++ b/data-asia/M/M2a/060.ts
@@ -1,0 +1,58 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "リーリエのピッピex",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 190,
+	types: ["Psychic"],
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "フェアリーゾーン" },
+			effect: {
+				ja: "このポケモンがいるかぎり、相手の場の[N]ポケモン全員の弱点は、すべて[P]タイプになる。［弱点は「×2」で計算する。］",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "フルムーンロンド" },
+			damage: "20+",
+			cost: ["Psychic", "Colorless"],
+			effect: {
+				ja: "おたがいのベンチポケモンの数×20ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 861303,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "Double rare",
+	dexId: [35],
+
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/M/M2a/061.ts
+++ b/data-asia/M/M2a/061.ts
@@ -1,0 +1,64 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ロケット団のタマタマ",
+	},
+
+	illustrator: "Gapao",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Psychic"],
+
+	description: {
+		ja: "タマタマだけに 伝わる テレパシーを 出し合っているので どんなときでも ６匹 集まれる。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ねんじる" },
+			damage: "10+",
+			cost: ["Psychic"],
+			effect: {
+				ja: "コインを1回投げオモテなら、20ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 861304,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "energy",
+			thirdParty: {
+				cardmarket: 861624,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "team-rocket",
+			thirdParty: {
+				cardmarket: 861625,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "None",
+	dexId: [102],
+};
+
+export default card;

--- a/data-asia/M/M2a/062.ts
+++ b/data-asia/M/M2a/062.ts
@@ -1,0 +1,75 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ロケット団のナッシー",
+	},
+
+	illustrator: "Ryuta Fuse",
+	category: "Pokemon",
+	hp: 140,
+	types: ["Psychic"],
+
+	description: {
+		ja: "ごくまれに 頭の どれか ひとつが 地面に 落ちると タマタマになって 動きだすという。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "トライキネシス" },
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "コインを3回投げ、すべてオモテなら、相手のポケモンを1匹選び、きぜつさせる。",
+			},
+		},
+		{
+			name: { ja: "すてみタックル" },
+			damage: 150,
+			cost: ["Psychic", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンにも30ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 861305,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "energy",
+			thirdParty: {
+				cardmarket: 861626,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "team-rocket",
+			thirdParty: {
+				cardmarket: 861627,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ロケット団のタマタマ",
+	},
+
+	retreat: 3,
+	regulationMark: "I",
+	rarity: "None",
+	dexId: [103],
+};
+
+export default card;

--- a/data-asia/M/M2a/063.ts
+++ b/data-asia/M/M2a/063.ts
@@ -1,0 +1,58 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ロケット団のミュウツーex",
+	},
+
+	illustrator: "aky CG Works",
+	category: "Pokemon",
+	hp: 280,
+	types: ["Psychic"],
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "パワーセーバー" },
+			effect: {
+				ja: "自分の場の「ロケット団のポケモン」が4匹以上のときにしか、このポケモンはワザが使えない。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "イレイザーボール" },
+			damage: "160+",
+			cost: ["Psychic", "Psychic", "Colorless"],
+			effect: {
+				ja: "のぞむなら、自分のベンチポケモンについているエネルギーを2枚までトラッシュし、その枚数×60ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 861306,
+			},
+		},
+	],
+
+	retreat: 3,
+	regulationMark: "I",
+	rarity: "Double rare",
+	dexId: [150],
+
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/M/M2a/064.ts
+++ b/data-asia/M/M2a/064.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "トゲピー",
+	},
+
+	illustrator: "Yoko Hishida",
+	category: "Pokemon",
+	hp: 50,
+	types: ["Psychic"],
+
+	description: {
+		ja: "殻の中に 幸せが たくさん つまっているらしく 優しくされると 幸運を 分け与える という。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "はたく" },
+			damage: 30,
+			cost: ["Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 861307,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "energy",
+			thirdParty: {
+				cardmarket: 861628,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "loveball",
+			thirdParty: {
+				cardmarket: 861629,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "H",
+	rarity: "None",
+	dexId: [175],
+};
+
+export default card;

--- a/data-asia/M/M2a/065.ts
+++ b/data-asia/M/M2a/065.ts
@@ -1,0 +1,68 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "トゲチック",
+	},
+
+	illustrator: "Teeziro",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Psychic"],
+
+	description: {
+		ja: "心優しい 人の 前に 幸せを もたらすため 姿を 現すと 言われている。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "ドレインキッス" },
+			damage: 30,
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンのHPを「30」回復する。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 861308,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "energy",
+			thirdParty: {
+				cardmarket: 861630,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "loveball",
+			thirdParty: {
+				cardmarket: 861631,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "トゲピー",
+	},
+
+	retreat: 1,
+	regulationMark: "H",
+	rarity: "None",
+	dexId: [176],
+};
+
+export default card;

--- a/data-asia/M/M2a/066.ts
+++ b/data-asia/M/M2a/066.ts
@@ -1,0 +1,75 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "トゲキッス",
+	},
+
+	illustrator: "Narano",
+	category: "Pokemon",
+	hp: 140,
+	types: ["Psychic"],
+
+	description: {
+		ja: "争い事や もめ事が 起こる 場所には 姿を 見せない。 近ごろは ほとんど 見かけない。",
+	},
+
+	stage: "Stage2",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ワンダーキッス" },
+			effect: {
+				ja: "このポケモンがいるかぎり、相手のバトルポケモンがきぜつするたび、自分はコインを1回投げる。オモテなら、サイドを1枚多くとる。この効果は、この特性を持つポケモンが何匹いても、重ならない。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "スピードウイング" },
+			damage: 140,
+			cost: ["Colorless", "Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 861309,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "energy",
+			thirdParty: {
+				cardmarket: 861632,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "loveball",
+			thirdParty: {
+				cardmarket: 861633,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "トゲチック",
+	},
+
+	retreat: 1,
+	regulationMark: "H",
+	rarity: "None",
+	dexId: [468],
+};
+
+export default card;

--- a/data-asia/M/M2a/067.ts
+++ b/data-asia/M/M2a/067.ts
@@ -1,0 +1,63 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ムウマ",
+	},
+
+	illustrator: "Kazuhisa Uragami",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Psychic"],
+
+	description: {
+		ja: "いきなり 後ろ髪に 噛みつき 引っぱっては 人の 驚く 姿を見て 喜んでいる。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "かくせい" },
+			cost: ["Psychic"],
+			effect: {
+				ja: "このポケモンから進化するカードを、自分の山札から1枚選び、このポケモンにのせて進化させる。そして山札を切る。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 861310,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "energy",
+			thirdParty: {
+				cardmarket: 861634,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "duskball",
+			thirdParty: {
+				cardmarket: 861635,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "None",
+	dexId: [200],
+};
+
+export default card;

--- a/data-asia/M/M2a/068.ts
+++ b/data-asia/M/M2a/068.ts
@@ -1,0 +1,68 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ムウマージ",
+	},
+
+	illustrator: "nisimono",
+	category: "Pokemon",
+	hp: 110,
+	types: ["Psychic"],
+
+	description: {
+		ja: "呪文のような 怪しい 鳴き声で 相手を 苦しめる。 神出鬼没の ポケモン。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "アサシンマジック" },
+			damage: 60,
+			cost: ["Psychic", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンが特殊状態なら、相手のベンチポケモン1匹に、ダメカンを6個のせる。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 861311,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "energy",
+			thirdParty: {
+				cardmarket: 861636,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "duskball",
+			thirdParty: {
+				cardmarket: 861637,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ムウマ",
+	},
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "None",
+	dexId: [429],
+};
+
+export default card;

--- a/data-asia/M/M2a/069.ts
+++ b/data-asia/M/M2a/069.ts
@@ -1,0 +1,68 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ラルトス",
+	},
+
+	illustrator: "Terada Tera",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Psychic"],
+
+	description: {
+		ja: "人の 感情を 頭の 赤い ツノで 敏感に キャッチする 力を 持つ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "もってくる" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札を1枚引く。",
+			},
+		},
+		{
+			name: { ja: "ずつき" },
+			damage: 10,
+			cost: ["Psychic"],
+		},
+	],
+
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 861312,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "energy",
+			thirdParty: {
+				cardmarket: 861638,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "loveball",
+			thirdParty: {
+				cardmarket: 861639,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "None",
+	dexId: [280],
+};
+
+export default card;

--- a/data-asia/M/M2a/070.ts
+++ b/data-asia/M/M2a/070.ts
@@ -1,0 +1,72 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "キルリア",
+	},
+
+	illustrator: "satoma",
+	category: "Pokemon",
+	hp: 100,
+	types: ["Psychic"],
+
+	description: {
+		ja: "サイコパワーを 操り まわりの 空間を ねじ曲げることで 未来を 見通すことができる。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "コールサイン" },
+			cost: ["Psychic"],
+			effect: {
+				ja: "自分の山札からポケモンを3枚まで選び、相手に見せて、手札に加える。そして山札を切る。",
+			},
+		},
+		{
+			name: { ja: "サイコショット" },
+			damage: 30,
+			cost: ["Psychic"],
+		},
+	],
+
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 861313,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "energy",
+			thirdParty: {
+				cardmarket: 861640,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "loveball",
+			thirdParty: {
+				cardmarket: 861641,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ラルトス",
+	},
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "None",
+	dexId: [281],
+};
+
+export default card;

--- a/data-asia/M/M2a/071.ts
+++ b/data-asia/M/M2a/071.ts
@@ -1,0 +1,59 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "メガサーナイトex",
+	},
+
+	illustrator: "takuyoa",
+	category: "Pokemon",
+	hp: 360,
+	types: ["Psychic"],
+
+	stage: "Stage2",
+
+	attacks: [
+		{
+			name: { ja: "あふれるねがい" },
+			cost: ["Psychic"],
+			effect: {
+				ja: "自分のベンチポケモン全員に、山札から「基本[P]エネルギー」を1枚ずつつける。そして山札を切る。",
+			},
+		},
+		{
+			name: { ja: "メガシンフォニア" },
+			damage: "50×",
+			cost: ["Psychic"],
+			effect: {
+				ja: "自分のポケモン全員についている[P]エネルギーの数×50ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 861314,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "キルリア",
+	},
+
+	retreat: 2,
+	regulationMark: "I",
+	rarity: "Double rare",
+	dexId: [282],
+
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/M/M2a/072.ts
+++ b/data-asia/M/M2a/072.ts
@@ -1,0 +1,67 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヨマワル",
+	},
+
+	illustrator: "IKEDA Saki",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Psychic"],
+
+	description: {
+		ja: "真っ赤な ひとつ目で 睨みつけられ 生体エネルギーを 吸われるとき ひどい 寒気に 襲われる。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "むかえにいく" },
+			cost: ["Psychic"],
+			effect: {
+				ja: "自分のトラッシュから「ヨマワル」を3枚まで選び、ベンチに出す。",
+			},
+		},
+		{
+			name: { ja: "つぶやく" },
+			damage: 30,
+			cost: ["Psychic", "Psychic"],
+		},
+	],
+
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 861315,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "energy",
+			thirdParty: {
+				cardmarket: 861642,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 861643,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "H",
+	rarity: "None",
+	dexId: [355],
+};
+
+export default card;

--- a/data-asia/M/M2a/073.ts
+++ b/data-asia/M/M2a/073.ts
@@ -1,0 +1,74 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "サマヨール",
+	},
+
+	illustrator: "Aya Kusube",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Psychic"],
+
+	description: {
+		ja: "体の中で 燃えている 真っ赤な ひとつ目が サマヨールの 本体と いわれるが 誰も 見ていない。",
+	},
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "カースドボム" },
+			effect: {
+				ja: "自分の番に1回使えて、使ったなら、このポケモンをきぜつさせる。相手のポケモン1匹に、ダメカンを5個のせる。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "おにび" },
+			damage: 50,
+			cost: ["Psychic", "Psychic"],
+		},
+	],
+
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 861316,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "energy",
+			thirdParty: {
+				cardmarket: 861644,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 861645,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ヨマワル",
+	},
+
+	retreat: 2,
+	regulationMark: "H",
+	rarity: "None",
+	dexId: [356],
+};
+
+export default card;

--- a/data-asia/M/M2a/074.ts
+++ b/data-asia/M/M2a/074.ts
@@ -1,0 +1,77 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヨノワール",
+	},
+
+	illustrator: "danciao",
+	category: "Pokemon",
+	hp: 160,
+	types: ["Psychic"],
+
+	description: {
+		ja: "この世と あの世を 行ったり来たり。 さまよう 魂を 吸い込んで 運ぶと いわれ 恐れられている。",
+	},
+
+	stage: "Stage2",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "カースドボム" },
+			effect: {
+				ja: "自分の番に1回使えて、使ったなら、このポケモンをきぜつさせる。相手のポケモン1匹に、ダメカンを13個のせる。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "かげしばり" },
+			damage: 150,
+			cost: ["Psychic", "Psychic", "Colorless"],
+			effect: {
+				ja: "次の相手の番、このワザを受けたポケモンは、にげられない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 861317,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "energy",
+			thirdParty: {
+				cardmarket: 861646,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 861647,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "サマヨール",
+	},
+
+	retreat: 3,
+	regulationMark: "H",
+	rarity: "None",
+	dexId: [477],
+};
+
+export default card;

--- a/data-asia/M/M2a/075.ts
+++ b/data-asia/M/M2a/075.ts
@@ -1,0 +1,58 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ラティアスex",
+	},
+
+	illustrator: "takuyoa",
+	category: "Pokemon",
+	hp: 210,
+	types: ["Psychic"],
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "スカイライン" },
+			effect: {
+				ja: "このポケモンがいるかぎり、自分のたねポケモン全員のにげるためのエネルギーは、すべてなくなる。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "むげんのやいば" },
+			damage: 200,
+			cost: ["Psychic", "Psychic", "Colorless"],
+			effect: {
+				ja: "次の自分の番、このポケモンはワザが使えない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 861318,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "H",
+	rarity: "Double rare",
+	dexId: [380],
+
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/M/M2a/076.ts
+++ b/data-asia/M/M2a/076.ts
@@ -1,0 +1,71 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ロトム",
+	},
+
+	illustrator: "mingo",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Psychic"],
+
+	description: {
+		ja: "特殊な モーターを 動かす 動力源として 長い あいだ 研究されていた ポケモン。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ロトコール" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札から、名前に「ロトム」とつくポケモンを好きなだけ選び、ベンチに出す。そして山札を切る。",
+			},
+		},
+		{
+			name: { ja: "ガジェットショー" },
+			damage: "30×",
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "自分のポケモン全員についている「ポケモンのどうぐ」の数×30ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 861319,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "energy",
+			thirdParty: {
+				cardmarket: 861648,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "duskball",
+			thirdParty: {
+				cardmarket: 861649,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "None",
+	dexId: [479],
+};
+
+export default card;

--- a/data-asia/M/M2a/077.ts
+++ b/data-asia/M/M2a/077.ts
@@ -1,0 +1,64 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ホップのボクレー",
+	},
+
+	illustrator: "tono",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Psychic"],
+
+	description: {
+		ja: "森で さまよい 死んだ 子供の 魂が 切り株に 宿り ポケモンになったと いわれている。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "はねてかわす" },
+			damage: 10,
+			cost: ["Colorless"],
+			effect: {
+				ja: "コインを1回投げオモテなら、次の相手の番、このポケモンはワザのダメージや効果を受けない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 861320,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "energy",
+			thirdParty: {
+				cardmarket: 861650,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				cardmarket: 861651,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "I",
+	rarity: "None",
+	dexId: [708],
+};
+
+export default card;

--- a/data-asia/M/M2a/078.ts
+++ b/data-asia/M/M2a/078.ts
@@ -1,0 +1,76 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ホップのオーロット",
+	},
+
+	illustrator: "matazo",
+	category: "Pokemon",
+	hp: 140,
+	types: ["Psychic"],
+
+	description: {
+		ja: "根っこを 神経の かわりにして 森の 木を 操る。 体に 棲みついた ポケモンには 親切。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "ホラーリベンジ" },
+			damage: "30+",
+			cost: ["Colorless"],
+			effect: {
+				ja: "前の相手の番に、ワザのダメージで、自分の「ホップのポケモン」がきぜつしていたなら、100ダメージ追加。",
+			},
+		},
+		{
+			name: { ja: "おいつめる" },
+			damage: 90,
+			cost: ["Psychic", "Colorless", "Colorless"],
+			effect: {
+				ja: "次の相手の番、このワザを受けたポケモンは、にげられない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 861321,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "energy",
+			thirdParty: {
+				cardmarket: 861652,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				cardmarket: 861653,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ホップのボクレー",
+	},
+
+	retreat: 2,
+	regulationMark: "I",
+	rarity: "None",
+	dexId: [709],
+};
+
+export default card;

--- a/data-asia/M/M2a/079.ts
+++ b/data-asia/M/M2a/079.ts
@@ -1,0 +1,63 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ロケット団のミミッキュ",
+	},
+
+	illustrator: "DOM",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Psychic"],
+
+	description: {
+		ja: "陽の 当たらない 暗がりに 棲む。 人前に 出るときは ピカチュウに 似せた 布で 全身を 隠す。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ほうせきごっこ" },
+			cost: ["Psychic", "Colorless"],
+			effect: {
+				ja: "相手のバトル場の「テラスタル」のポケモンが持つワザを1つ選び、このワザとして使う。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 861322,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "energy",
+			thirdParty: {
+				cardmarket: 861654,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "team-rocket",
+			thirdParty: {
+				cardmarket: 861655,
+			},
+		},
+	],
+
+	retreat: 0,
+	regulationMark: "I",
+	rarity: "None",
+	dexId: [778],
+};
+
+export default card;

--- a/data-asia/M/M2a/080.ts
+++ b/data-asia/M/M2a/080.ts
@@ -1,0 +1,68 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "レイスポス",
+	},
+
+	illustrator: "Taiga Kasai",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Psychic"],
+
+	description: {
+		ja: "視覚 以外の 五感を 使い 様子を 探る。 蹴られたものは 魂を 抜かれてしまうという。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ホロウショット" },
+			damage: 30,
+			cost: ["Psychic"],
+		},
+		{
+			name: { ja: "ファントムビット" },
+			cost: ["Psychic", "Psychic", "Colorless"],
+			effect: {
+				ja: "このポケモンについているエネルギーをすべてトラッシュし、相手のポケモン1匹に、ダメカンを12個のせる。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 861323,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "energy",
+			thirdParty: {
+				cardmarket: 861656,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "duskball",
+			thirdParty: {
+				cardmarket: 861657,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "None",
+	dexId: [897],
+};
+
+export default card;

--- a/data-asia/M/M2a/081.ts
+++ b/data-asia/M/M2a/081.ts
@@ -1,0 +1,74 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "マシマシラ",
+	},
+
+	illustrator: "kodama",
+	category: "Pokemon",
+	hp: 110,
+	types: ["Psychic"],
+
+	description: {
+		ja: "安全な 場所から 強烈な めまいを 引き起こす 念力を 放って 敵を 翻弄する。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "アドレナブレイン" },
+			effect: {
+				ja: "このポケモンに[D]エネルギーがついているなら、自分の番に1回使える。自分の場のポケモン1匹にのっているダメカンを3個まで選び、相手の場のポケモン1匹にのせ替える。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "サイコトリップ" },
+			damage: 60,
+			cost: ["Psychic", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをこんらんにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 861324,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "energy",
+			thirdParty: {
+				cardmarket: 861658,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "duskball",
+			thirdParty: {
+				cardmarket: 861659,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "H",
+	rarity: "None",
+	dexId: [1015],
+};
+
+export default card;

--- a/data-asia/M/M2a/082.ts
+++ b/data-asia/M/M2a/082.ts
@@ -1,0 +1,63 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ロケット団のディグダ",
+	},
+
+	illustrator: "Yuriko Akase",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Fighting"],
+
+	description: {
+		ja: "皮膚が とても 薄いので 光に 照らされると 血液が 温められて 弱ってしまう。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "もぐりまくる" },
+			cost: ["Fighting"],
+			effect: {
+				ja: "ウラが出るまでコインを投げ、オモテの数ぶん、相手の山札を上からトラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 861325,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "energy",
+			thirdParty: {
+				cardmarket: 861660,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "team-rocket",
+			thirdParty: {
+				cardmarket: 861661,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "None",
+	dexId: [50],
+};
+
+export default card;

--- a/data-asia/M/M2a/083.ts
+++ b/data-asia/M/M2a/083.ts
@@ -1,0 +1,75 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ロケット団のダグトリオ",
+	},
+
+	illustrator: "KEIICHIRO ITO",
+	category: "Pokemon",
+	hp: 100,
+	types: ["Fighting"],
+
+	description: {
+		ja: "地中を 掘りすすんで 相手が 油断しているところを 別の 場所から 攻撃する。",
+	},
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "あなぼこ" },
+			effect: {
+				ja: "このポケモンがいるかぎり、相手の番に、相手のバトルポケモンがベンチにもどるたび、そのポケモンにダメカンを2個のせる。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "マッドショット" },
+			damage: 50,
+			cost: ["Fighting", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 861326,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "energy",
+			thirdParty: {
+				cardmarket: 861662,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "team-rocket",
+			thirdParty: {
+				cardmarket: 861663,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ロケット団のディグダ",
+	},
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "None",
+	dexId: [51],
+};
+
+export default card;

--- a/data-asia/M/M2a/084.ts
+++ b/data-asia/M/M2a/084.ts
@@ -1,0 +1,68 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アサナン",
+	},
+
+	illustrator: "Lee HyunJung",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Fighting"],
+
+	description: {
+		ja: "１日 １個だけ 木の実を 食べる。 空腹に 耐えることで 心が 研ぎ澄まされていく。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "もってくる" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札を1枚引く。",
+			},
+		},
+		{
+			name: { ja: "ひっぱたく" },
+			damage: 10,
+			cost: ["Fighting"],
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 861327,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "energy",
+			thirdParty: {
+				cardmarket: 861664,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "quickball",
+			thirdParty: {
+				cardmarket: 861665,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "None",
+	dexId: [307],
+};
+
+export default card;

--- a/data-asia/M/M2a/085.ts
+++ b/data-asia/M/M2a/085.ts
@@ -1,0 +1,68 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "チャーレム",
+	},
+
+	illustrator: "GIDORA",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Fighting"],
+
+	description: {
+		ja: "ヨガの 修行で 鍛えられた サイコパワーで 相手の 動きを 予測することが できるのだ。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "セブンスキック" },
+			damage: 150,
+			cost: ["Fighting"],
+			effect: {
+				ja: "自分の手札が7枚でないなら、このワザは失敗。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 861328,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "energy",
+			thirdParty: {
+				cardmarket: 861666,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "quickball",
+			thirdParty: {
+				cardmarket: 861667,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "アサナン",
+	},
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "None",
+	dexId: [308],
+};
+
+export default card;

--- a/data-asia/M/M2a/086.ts
+++ b/data-asia/M/M2a/086.ts
@@ -1,0 +1,71 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ルナトーン",
+	},
+
+	illustrator: "Ounishi",
+	category: "Pokemon",
+	hp: 110,
+	types: ["Fighting"],
+
+	description: {
+		ja: "４０年前に 隕石の 落ちた 場所で 初めて 見つかった。 にらむ だけで 敵を 眠らせる。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ルナサイクル" },
+			effect: {
+				ja: "自分の場に「ソルロック」がいて、自分の番に、自分の手札から「基本[F]エネルギー」を1枚トラッシュするなら、1回使える。自分の山札を3枚引く。この特性は別の「ルナサイクル」を使った番は使えない。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "パワージェム" },
+			damage: 50,
+			cost: ["Fighting", "Fighting"],
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 861329,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "energy",
+			thirdParty: {
+				cardmarket: 861668,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "duskball",
+			thirdParty: {
+				cardmarket: 861669,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "None",
+	dexId: [337],
+};
+
+export default card;

--- a/data-asia/M/M2a/087.ts
+++ b/data-asia/M/M2a/087.ts
@@ -1,0 +1,64 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ソルロック",
+	},
+
+	illustrator: "Whisker",
+	category: "Pokemon",
+	hp: 110,
+	types: ["Fighting"],
+
+	description: {
+		ja: "太陽エネルギーが パワーの 源 なので 昼間は 強い。 回転すると 体が 光る。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "コスモビーム" },
+			damage: 70,
+			cost: ["Fighting"],
+			effect: {
+				ja: "自分のベンチに「ルナトーン」がいないなら、このワザは失敗。このワザのダメージは弱点・抵抗力を計算しない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 861330,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "energy",
+			thirdParty: {
+				cardmarket: 861670,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "duskball",
+			thirdParty: {
+				cardmarket: 861671,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "None",
+	dexId: [338],
+};
+
+export default card;

--- a/data-asia/M/M2a/088.ts
+++ b/data-asia/M/M2a/088.ts
@@ -1,0 +1,64 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "シロナのフカマル",
+	},
+
+	illustrator: "Tomomi Ozaki",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Fighting"],
+
+	description: {
+		ja: "穴倉に 潜み 獲物や 敵が 横切ると 飛びだして 噛みつく。 勢い余り 歯が 欠けることも。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "いわとばし" },
+			damage: 20,
+			cost: ["Fighting"],
+			effect: {
+				ja: "このワザのダメージは抵抗力を計算しない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 861331,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "energy",
+			thirdParty: {
+				cardmarket: 861672,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				cardmarket: 861673,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "None",
+	dexId: [443],
+};
+
+export default card;

--- a/data-asia/M/M2a/089.ts
+++ b/data-asia/M/M2a/089.ts
@@ -1,0 +1,75 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "シロナのガバイト",
+	},
+
+	illustrator: "Taira Akitsu",
+	category: "Pokemon",
+	hp: 100,
+	types: ["Fighting"],
+
+	description: {
+		ja: "まれに 脱皮し ウロコが 剥げる。 その成分が 含まれる 薬は 疲れた 体を ギンギンにする。",
+	},
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "おうじゃのよびごえ" },
+			effect: {
+				ja: "自分の番に1回使える。自分の山札から「シロナのポケモン」を1枚選び、相手に見せて、手札に加える。そして山札を切る。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "リューノスライス" },
+			damage: 40,
+			cost: ["Fighting"],
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 861332,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "energy",
+			thirdParty: {
+				cardmarket: 861674,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				cardmarket: 861675,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "シロナのフカマル",
+	},
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "None",
+	dexId: [444],
+};
+
+export default card;

--- a/data-asia/M/M2a/090.ts
+++ b/data-asia/M/M2a/090.ts
@@ -1,0 +1,60 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "シロナのガブリアスex",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 330,
+	types: ["Fighting"],
+
+	stage: "Stage2",
+
+	attacks: [
+		{
+			name: { ja: "スクリューダイブ" },
+			damage: 100,
+			cost: ["Fighting"],
+			effect: {
+				ja: "のぞむなら、自分の手札が6枚になるように、山札を引く。",
+			},
+		},
+		{
+			name: { ja: "リューノバスター" },
+			damage: 260,
+			cost: ["Fighting", "Fighting"],
+			effect: {
+				ja: "このポケモンについているエネルギーを、すべてトラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 861333,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "シロナのガバイト",
+	},
+
+	retreat: 0,
+	regulationMark: "I",
+	rarity: "Double rare",
+	dexId: [445],
+
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/M/M2a/091.ts
+++ b/data-asia/M/M2a/091.ts
@@ -1,0 +1,64 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "リオル",
+	},
+
+	illustrator: "hncl",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Fighting"],
+
+	description: {
+		ja: "仲間同士で 波動を 出して コミュニケーションを とっている。 一晩中 走り続けられる。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "かそくづき" },
+			damage: 30,
+			cost: ["Fighting"],
+			effect: {
+				ja: "次の自分の番、このポケモンは「かそくづき」が使えない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 861334,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "energy",
+			thirdParty: {
+				cardmarket: 861676,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "friendball",
+			thirdParty: {
+				cardmarket: 861677,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "I",
+	rarity: "None",
+	dexId: [447],
+};
+
+export default card;

--- a/data-asia/M/M2a/092.ts
+++ b/data-asia/M/M2a/092.ts
@@ -1,0 +1,60 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "メガルカリオex",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 340,
+	types: ["Fighting"],
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "はどうづき" },
+			damage: 130,
+			cost: ["Fighting"],
+			effect: {
+				ja: "自分のトラッシュから「基本[F]エネルギー」を3枚まで選び、ベンチポケモンに好きなようにつける。",
+			},
+		},
+		{
+			name: { ja: "メガブレイブ" },
+			damage: 270,
+			cost: ["Fighting", "Fighting"],
+			effect: {
+				ja: "次の自分の番、このポケモンは「メガブレイブ」が使えない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 861335,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "リオル",
+	},
+
+	retreat: 2,
+	regulationMark: "I",
+	rarity: "Double rare",
+	dexId: [448],
+
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/M/M2a/093.ts
+++ b/data-asia/M/M2a/093.ts
@@ -1,0 +1,64 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヤンチャム",
+	},
+
+	illustrator: "Minato",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Fighting"],
+
+	description: {
+		ja: "一生懸命 怖い 顔で 相手を にらみつけるが 頭を なでられると つい にやけてしまう。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "とつげき" },
+			damage: 20,
+			cost: ["Colorless"],
+			effect: {
+				ja: "このポケモンにも10ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 861336,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "energy",
+			thirdParty: {
+				cardmarket: 861678,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "loveball",
+			thirdParty: {
+				cardmarket: 861679,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "I",
+	rarity: "None",
+	dexId: [674],
+};
+
+export default card;

--- a/data-asia/M/M2a/094.ts
+++ b/data-asia/M/M2a/094.ts
@@ -1,0 +1,58 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "メガルチャブルex",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 250,
+	types: ["Fighting"],
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ふんばりボディ" },
+			effect: {
+				ja: "このポケモンが、ワザのダメージを受けてきぜつするとき、自分はコインを1回投げる。オモテなら、このポケモンはきぜつせず、残りHPが「10」の状態で場に残る。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "サマーソルトダイブ" },
+			damage: "120+",
+			cost: ["Fighting", "Fighting", "Colorless"],
+			effect: {
+				ja: "場にスタジアムが出ているなら、140ダメージ追加。その後、そのスタジアムをトラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 861337,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "Double rare",
+	dexId: [701],
+
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/M/M2a/095.ts
+++ b/data-asia/M/M2a/095.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "タンドン",
+	},
+
+	illustrator: "Kurata So",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Fighting"],
+
+	description: {
+		ja: "古くなり 剥がれ落ちた 体の 表面は 石炭の 代わりに 燃料として 使われてきた。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "どろかけ" },
+			damage: 20,
+			cost: ["Fighting"],
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 861338,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "energy",
+			thirdParty: {
+				cardmarket: 861680,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "duskball",
+			thirdParty: {
+				cardmarket: 861681,
+			},
+		},
+	],
+
+	retreat: 3,
+	regulationMark: "I",
+	rarity: "None",
+	dexId: [837],
+};
+
+export default card;

--- a/data-asia/M/M2a/096.ts
+++ b/data-asia/M/M2a/096.ts
@@ -1,0 +1,73 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "トロッゴン",
+	},
+
+	illustrator: "Apios",
+	category: "Pokemon",
+	hp: 110,
+	types: ["Fighting"],
+
+	description: {
+		ja: "背中の 石炭の 山は 中で コールタールが 作られているため 高速で 走っても 崩れない。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "ガードプレス" },
+			damage: 20,
+			cost: ["Fighting"],
+			effect: {
+				ja: "次の相手の番、このポケモンが受けるワザのダメージは「-20」される。",
+			},
+		},
+		{
+			name: { ja: "パワージェム" },
+			damage: 60,
+			cost: ["Fighting", "Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 861339,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "energy",
+			thirdParty: {
+				cardmarket: 861682,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "duskball",
+			thirdParty: {
+				cardmarket: 861683,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "タンドン",
+	},
+
+	retreat: 3,
+	regulationMark: "I",
+	rarity: "None",
+	dexId: [838],
+};
+
+export default card;

--- a/data-asia/M/M2a/097.ts
+++ b/data-asia/M/M2a/097.ts
@@ -1,0 +1,75 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "セキタンザン",
+	},
+
+	illustrator: "Nisota Niso",
+	category: "Pokemon",
+	hp: 180,
+	types: ["Fighting"],
+
+	description: {
+		ja: "温厚な 気質だが 怒ると 怖い。 １５００度の 燃えあがる 体で のしかかり 焼きつくす。",
+	},
+
+	stage: "Stage2",
+
+	attacks: [
+		{
+			name: { ja: "タールキャノン" },
+			cost: ["Fighting"],
+			effect: {
+				ja: "相手のポケモン1匹に、140ダメージ。自分のトラッシュに「基本[F]エネルギー」が10枚以上ないなら、このワザは失敗。［ベンチは弱点・抵抗力を計算しない。］",
+			},
+		},
+		{
+			name: { ja: "きょたいでつっこむ" },
+			damage: 220,
+			cost: ["Fighting", "Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンについているエネルギーを3個選び、トラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 861340,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "energy",
+			thirdParty: {
+				cardmarket: 861684,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "duskball",
+			thirdParty: {
+				cardmarket: 861685,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "トロッゴン",
+	},
+
+	retreat: 4,
+	regulationMark: "I",
+	rarity: "None",
+	dexId: [839],
+};
+
+export default card;

--- a/data-asia/M/M2a/098.ts
+++ b/data-asia/M/M2a/098.ts
@@ -1,0 +1,69 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "イイネイヌ",
+	},
+
+	illustrator: "Mitsuhiro Arita",
+	category: "Pokemon",
+	hp: 140,
+	types: ["Fighting"],
+
+	description: {
+		ja: "すぐ 頭に 血が 上ってしまう 荒くれもの。 首の 鎖を 振り回し なんでも 叩き潰す。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "なぐる" },
+			damage: 20,
+			cost: ["Fighting"],
+		},
+		{
+			name: { ja: "おれいまいり" },
+			damage: "80+",
+			cost: ["Fighting", "Fighting", "Colorless"],
+			effect: {
+				ja: "前の相手の番に、相手がとったサイドの枚数×60ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 861341,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "energy",
+			thirdParty: {
+				cardmarket: 861686,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "friendball",
+			thirdParty: {
+				cardmarket: 861687,
+			},
+		},
+	],
+
+	retreat: 3,
+	regulationMark: "I",
+	rarity: "None",
+	dexId: [1014],
+};
+
+export default card;

--- a/data-asia/M/M2a/099.ts
+++ b/data-asia/M/M2a/099.ts
@@ -1,0 +1,62 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ロケット団のズバット",
+	},
+
+	illustrator: "toi8",
+	category: "Pokemon",
+	hp: 50,
+	types: ["Darkness"],
+
+	description: {
+		ja: "陽の 当たらない 洞窟に 棲む。 朝になると 仲間で 集まり 体を 温めあいながら 寝る。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "どくをとばす" },
+			cost: ["Darkness"],
+			effect: {
+				ja: "相手のバトルポケモンをどくにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 861342,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "energy",
+			thirdParty: {
+				cardmarket: 861688,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 861689,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "None",
+	dexId: [41],
+};
+
+export default card;

--- a/data-asia/M/M2a/100.ts
+++ b/data-asia/M/M2a/100.ts
@@ -1,0 +1,77 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ロケット団のゴルバット",
+	},
+
+	illustrator: "AKIRA EGAWA",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Darkness"],
+
+	description: {
+		ja: "小さな 脚で 器用に 歩く。 寝ている 獲物に 忍びより キバを 突きたて 血を すするのだ。",
+	},
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "こっそりかみつく" },
+			effect: {
+				ja: "自分の番に、このカードを手札から出して進化させたとき、1回使える。相手のポケモン1匹に、ダメカンを2個のせる。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "あやしいひかり" },
+			damage: 30,
+			cost: ["Darkness"],
+			effect: {
+				ja: "相手のバトルポケモンをこんらんにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 861343,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "energy",
+			thirdParty: {
+				cardmarket: 861690,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 861691,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ロケット団のズバット",
+	},
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "None",
+	dexId: [42],
+};
+
+export default card;

--- a/data-asia/M/M2a/101.ts
+++ b/data-asia/M/M2a/101.ts
@@ -1,0 +1,62 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ロケット団のクロバットex",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 310,
+	types: ["Darkness"],
+
+	stage: "Stage2",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "かみつきまわる" },
+			effect: {
+				ja: "自分の番に、このカードを手札から出して進化させたとき、1回使える。相手のポケモン2匹に、それぞれダメカンを2個のせる。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "アサシンリターン" },
+			damage: 120,
+			cost: ["Darkness", "Darkness"],
+			effect: {
+				ja: "のぞむなら、このポケモンを手札にもどす。（ポケモン以外のカードは、すべてトラッシュする。）",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 861344,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ロケット団のゴルバット",
+	},
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "Double rare",
+	dexId: [169],
+
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/M/M2a/102.ts
+++ b/data-asia/M/M2a/102.ts
@@ -1,0 +1,71 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ロケット団のヤミカラス",
+	},
+
+	illustrator: "Mugi Hamada",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Darkness"],
+
+	description: {
+		ja: "夜 姿を 見かけると 不吉なことが 起きると 信じられ 忌み嫌われている ポケモン。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "たぶらかす" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札からサポートを1枚選び、相手に見せて、手札に加える。そして山札を切る。",
+			},
+		},
+		{
+			name: { ja: "いちゃもん" },
+			damage: 30,
+			cost: ["Darkness", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンが持つワザを1つ選ぶ。次の相手の番、このワザを受けたポケモンは、選ばれたワザが使えない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 861345,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "energy",
+			thirdParty: {
+				cardmarket: 861692,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "team-rocket",
+			thirdParty: {
+				cardmarket: 861693,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "None",
+	dexId: [198],
+};
+
+export default card;

--- a/data-asia/M/M2a/103.ts
+++ b/data-asia/M/M2a/103.ts
@@ -1,0 +1,73 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ロケット団のドンカラス",
+	},
+
+	illustrator: "hncl",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Darkness"],
+
+	description: {
+		ja: "夜行性。 一声 鳴けば １００匹を 超える 子分の ヤミカラスが 集結する。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "ロケットフェザー" },
+			damage: "60×",
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "自分の手札から、名前に「ロケット団」とつくサポートを好きなだけトラッシュし、その枚数×60ダメージ。",
+			},
+		},
+		{
+			name: { ja: "ぶちかます" },
+			damage: 100,
+			cost: ["Darkness", "Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 861346,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "energy",
+			thirdParty: {
+				cardmarket: 861694,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "team-rocket",
+			thirdParty: {
+				cardmarket: 861695,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ロケット団のヤミカラス",
+	},
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "None",
+	dexId: [430],
+};
+
+export default card;

--- a/data-asia/M/M2a/104.ts
+++ b/data-asia/M/M2a/104.ts
@@ -1,0 +1,68 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ロケット団のニューラ",
+	},
+
+	illustrator: "GIDORA",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Darkness"],
+
+	description: {
+		ja: "自分が 目立たないよう 暗闇に まぎれて 獲物に 襲いかかる とても ずる賢い ポケモン。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ひっかく" },
+			damage: 20,
+			cost: ["Darkness"],
+		},
+		{
+			name: { ja: "ねくびをかく" },
+			cost: ["Darkness", "Darkness"],
+			effect: {
+				ja: "相手のベンチポケモン1匹に、そのポケモンにのっているダメカンの数×20ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 861347,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "energy",
+			thirdParty: {
+				cardmarket: 861696,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "duskball",
+			thirdParty: {
+				cardmarket: 861697,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "None",
+	dexId: [215],
+};
+
+export default card;

--- a/data-asia/M/M2a/105.ts
+++ b/data-asia/M/M2a/105.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ガラル ジグザグマ",
+	},
+
+	illustrator: "osare",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Darkness"],
+
+	description: {
+		ja: "落ち着きなく 走りまわっている。 ほかの ポケモンを 見つけると わざと ぶつかって ケンカを 売る。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "かじる" },
+			damage: 10,
+			cost: ["Darkness"],
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 861348,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "energy",
+			thirdParty: {
+				cardmarket: 861698,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "duskball",
+			thirdParty: {
+				cardmarket: 861699,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "None",
+	dexId: [263],
+};
+
+export default card;

--- a/data-asia/M/M2a/106.ts
+++ b/data-asia/M/M2a/106.ts
@@ -1,0 +1,70 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ガラル マッスグマ",
+	},
+
+	illustrator: "Tomowaka",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Darkness"],
+
+	description: {
+		ja: "長い舌で 獲物を 挑発。 怒った 相手に 強烈な タックルを おみまい するぞ。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "かじる" },
+			damage: 20,
+			cost: ["Darkness"],
+		},
+		{
+			name: { ja: "ツメできりさく" },
+			damage: 50,
+			cost: ["Darkness", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 861349,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "energy",
+			thirdParty: {
+				cardmarket: 861700,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "duskball",
+			thirdParty: {
+				cardmarket: 861701,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ガラル ジグザグマ",
+	},
+
+	retreat: 2,
+	regulationMark: "I",
+	rarity: "None",
+	dexId: [264],
+};
+
+export default card;

--- a/data-asia/M/M2a/107.ts
+++ b/data-asia/M/M2a/107.ts
@@ -1,0 +1,76 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ガラル タチフサグマ",
+	},
+
+	illustrator: "Dsuke",
+	category: "Pokemon",
+	hp: 170,
+	types: ["Darkness"],
+
+	description: {
+		ja: "凄まじい 声量を もつ。 シャウトとともに 威嚇するさまは ブロッキングと 呼ばれている。",
+	},
+
+	stage: "Stage2",
+
+	attacks: [
+		{
+			name: { ja: "スカーシャウト" },
+			damage: "70×",
+			cost: ["Darkness", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンにのっているダメカンの数×70ダメージ。",
+			},
+		},
+		{
+			name: { ja: "パンクスマッシュ" },
+			damage: 160,
+			cost: ["Darkness", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンについているエネルギーを1個選び、トラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 861350,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "energy",
+			thirdParty: {
+				cardmarket: 861702,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "duskball",
+			thirdParty: {
+				cardmarket: 861703,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ガラル マッスグマ",
+	},
+
+	retreat: 2,
+	regulationMark: "I",
+	rarity: "None",
+	dexId: [862],
+};
+
+export default card;

--- a/data-asia/M/M2a/108.ts
+++ b/data-asia/M/M2a/108.ts
@@ -1,0 +1,64 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "シロナのミカルゲ",
+	},
+
+	illustrator: "satoma",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Darkness"],
+
+	description: {
+		ja: "いつも 悪さばかり していたら 不思議な 術で 本体を 要石に 縛りつけられた。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "レイジングカース" },
+			damage: "10×",
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分のベンチの「シロナのポケモン」全員にのっているダメカンの数×10ダメージ。このワザのダメージは弱点を計算しない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 861351,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "energy",
+			thirdParty: {
+				cardmarket: 861704,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				cardmarket: 861705,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "None",
+	dexId: [442],
+};
+
+export default card;

--- a/data-asia/M/M2a/109.ts
+++ b/data-asia/M/M2a/109.ts
@@ -1,0 +1,64 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ズルッグ",
+	},
+
+	illustrator: "Shimaris Yukichi",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Darkness"],
+
+	description: {
+		ja: "皮を 首まで 引き上げて 防御の 姿勢。 ゴムのような 弾力で ダメージを 減らす。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "はたきおとす" },
+			damage: 20,
+			cost: ["Darkness", "Colorless"],
+			effect: {
+				ja: "相手の手札からオモテを見ないで1枚選び、トラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 861352,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "energy",
+			thirdParty: {
+				cardmarket: 861706,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "quickball",
+			thirdParty: {
+				cardmarket: 861707,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "I",
+	rarity: "None",
+	dexId: [559],
+};
+
+export default card;

--- a/data-asia/M/M2a/110.ts
+++ b/data-asia/M/M2a/110.ts
@@ -1,0 +1,62 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "メガズルズキンex",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 330,
+	types: ["Darkness"],
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "はんげきトサカ" },
+			effect: {
+				ja: "このポケモンが、バトル場で相手のポケモンからワザのダメージを受けたとき、ワザを使ったポケモンにダメカンを5個のせる。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "アウトローレッグ" },
+			damage: 160,
+			cost: ["Darkness", "Darkness", "Colorless"],
+			effect: {
+				ja: "相手の手札からオモテを見ないで1枚選び、トラッシュする。相手の山札を上から1枚トラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 861353,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ズルッグ",
+	},
+
+	retreat: 2,
+	regulationMark: "I",
+	rarity: "Double rare",
+	dexId: [560],
+
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/M/M2a/111.ts
+++ b/data-asia/M/M2a/111.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "Nのゾロア",
+	},
+
+	illustrator: "Jiro Sasumo",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Darkness"],
+
+	description: {
+		ja: "相手の 姿に 化けてみせて 驚かせる。 無口な 子どもに 化けていることが 多いらしい。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ひっかく" },
+			damage: 20,
+			cost: ["Darkness"],
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 861354,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "energy",
+			thirdParty: {
+				cardmarket: 861708,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				cardmarket: 861709,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "None",
+	dexId: [570],
+};
+
+export default card;

--- a/data-asia/M/M2a/112.ts
+++ b/data-asia/M/M2a/112.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "Nのゾロアークex",
+	},
+
+	illustrator: "takuyoa",
+	category: "Pokemon",
+	hp: 280,
+	types: ["Darkness"],
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "とりひき" },
+			effect: {
+				ja: "自分の番に、自分の手札を1枚トラッシュするなら、1回使える。自分の山札を2枚引く。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ナイトジョーカー" },
+			cost: ["Darkness", "Darkness"],
+			effect: {
+				ja: "自分のベンチの「Nのポケモン」が持つワザを1つ選び、このワザとして使う。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 861355,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "Nのゾロア",
+	},
+
+	retreat: 2,
+	regulationMark: "I",
+	rarity: "Double rare",
+	dexId: [571],
+
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/M/M2a/113.ts
+++ b/data-asia/M/M2a/113.ts
@@ -1,0 +1,73 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ゴロンダ",
+	},
+
+	illustrator: "takashi shiraishi",
+	category: "Pokemon",
+	hp: 140,
+	types: ["Darkness"],
+
+	description: {
+		ja: "気性が 荒く ケンカっ早いが 弱いものいじめは 許さない。 葉っぱで 敵の 動きを 読む。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "どつく" },
+			damage: 40,
+			cost: ["Darkness"],
+		},
+		{
+			name: { ja: "おやぶんパンチ" },
+			damage: "80+",
+			cost: ["Darkness", "Darkness", "Colorless"],
+			effect: {
+				ja: "自分のベンチの「ヤンチャム」にダメカンがのっているなら、120ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 861356,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "energy",
+			thirdParty: {
+				cardmarket: 861710,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "loveball",
+			thirdParty: {
+				cardmarket: 861711,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ヤンチャム",
+	},
+
+	retreat: 3,
+	regulationMark: "I",
+	rarity: "None",
+	dexId: [675],
+};
+
+export default card;

--- a/data-asia/M/M2a/114.ts
+++ b/data-asia/M/M2a/114.ts
@@ -1,0 +1,57 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "キチキギスex",
+	},
+
+	illustrator: "takuyoa",
+	category: "Pokemon",
+	hp: 210,
+	types: ["Darkness"],
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "さかてにとる" },
+			effect: {
+				ja: "前の相手の番に、自分のポケモンがきぜつしていたなら、自分の番に1回使える。自分の山札を3枚引く。この番、すでに別の「さかてにとる」を使っていたなら、この特性は使えない。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "クルーエルアロー" },
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のポケモン1匹に、100ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 861357,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "H",
+	rarity: "Double rare",
+	dexId: [1016],
+
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/M/M2a/115.ts
+++ b/data-asia/M/M2a/115.ts
@@ -1,0 +1,74 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "モモワロウ",
+	},
+
+	illustrator: "IKEDA Saki",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Darkness"],
+
+	description: {
+		ja: "モモ型の 殻は 猛毒の 貯蔵庫。 毒の 餅を 作り 人や ポケモンに ふるまう。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "さいごのくさり" },
+			effect: {
+				ja: "このポケモンが、相手のポケモンからワザのダメージを受けてきぜつしたとき、自分の山札から好きなカードを1枚選び、手札に加える。そして山札を切る。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "もちラッシュ" },
+			damage: 20,
+			cost: ["Darkness"],
+			effect: {
+				ja: "次の自分の番、このポケモンの「もちラッシュ」のダメージは「+50」される。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 861358,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "energy",
+			thirdParty: {
+				cardmarket: 861712,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				cardmarket: 861713,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "None",
+	dexId: [1025],
+};
+
+export default card;

--- a/data-asia/M/M2a/116.ts
+++ b/data-asia/M/M2a/116.ts
@@ -1,0 +1,64 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "コマタナ",
+	},
+
+	illustrator: "Yuya Oka",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Metal"],
+
+	description: {
+		ja: "刃の 刃こぼれは 命取り。 戦いが 終わると お気に入りの 砥石で 念入りに 手入れする。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "つきとばす" },
+			damage: 10,
+			cost: ["Metal"],
+			effect: {
+				ja: "相手のバトルポケモンをベンチポケモンと入れ替える。［バトル場に出すポケモンは相手が選ぶ。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Grass", value: "-30" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 861359,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "energy",
+			thirdParty: {
+				cardmarket: 861714,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "quickball",
+			thirdParty: {
+				cardmarket: 861715,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "None",
+	dexId: [624],
+};
+
+export default card;

--- a/data-asia/M/M2a/117.ts
+++ b/data-asia/M/M2a/117.ts
@@ -1,0 +1,68 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "キリキザン",
+	},
+
+	illustrator: "Scav",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Metal"],
+
+	description: {
+		ja: "体中の 鋭利な 刃で 容赦なく 相手を 切り刻む。 勝つために 手段は 選ばない。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "クイックドロー" },
+			damage: 50,
+			cost: ["Metal"],
+			effect: {
+				ja: "自分の山札を2枚引く。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Grass", value: "-30" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 861360,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "energy",
+			thirdParty: {
+				cardmarket: 861716,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "quickball",
+			thirdParty: {
+				cardmarket: 861717,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "コマタナ",
+	},
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "None",
+	dexId: [625],
+};
+
+export default card;

--- a/data-asia/M/M2a/118.ts
+++ b/data-asia/M/M2a/118.ts
@@ -1,0 +1,78 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ドドゲザン",
+	},
+
+	illustrator: "Teeziro",
+	category: "Pokemon",
+	hp: 170,
+	types: ["Metal"],
+
+	description: {
+		ja: "大軍勢を 率いて 戦うが 難しい 作戦は 苦手なので 力で 押して 押しまくるだけ。",
+	},
+
+	stage: "Stage2",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "そうだいしょう" },
+			effect: {
+				ja: "このポケモンが使うワザの、相手のバトルポケモンへのダメージは、相手がすでにとったサイド1枚につき「+30」される。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "もろはぎり" },
+			damage: 180,
+			cost: ["Metal", "Metal"],
+			effect: {
+				ja: "このポケモンにも50ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Grass", value: "-30" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 861361,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "energy",
+			thirdParty: {
+				cardmarket: 861718,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "quickball",
+			thirdParty: {
+				cardmarket: 861719,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "キリキザン",
+	},
+
+	retreat: 3,
+	regulationMark: "I",
+	rarity: "None",
+	dexId: [983],
+};
+
+export default card;

--- a/data-asia/M/M2a/119.ts
+++ b/data-asia/M/M2a/119.ts
@@ -1,0 +1,58 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ゲノセクトex",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 220,
+	types: ["Metal"],
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "メタルシグナル" },
+			effect: {
+				ja: "自分の番に1回使える。自分の山札から[M]タイプの進化ポケモンを2枚まで選び、相手に見せて、手札に加える。そして山札を切る。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "プロテクトチャージ" },
+			damage: 150,
+			cost: ["Metal", "Metal", "Colorless"],
+			effect: {
+				ja: "次の相手の番、このポケモンが受けるワザのダメージは「-30」される。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Grass", value: "-30" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 861362,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "I",
+	rarity: "Double rare",
+	dexId: [649],
+
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/M/M2a/120.ts
+++ b/data-asia/M/M2a/120.ts
@@ -1,0 +1,73 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "マギアナ",
+	},
+
+	illustrator: "rika",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Metal"],
+
+	description: {
+		ja: "およそ ５００年前 科学者に よって 作られた。 ソウルハートと 呼ばれる パーツが 本体なのだ。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "オートヒール" },
+			effect: {
+				ja: "このポケモンがバトル場にいるかぎり、自分の手札からエネルギーをポケモンにつけるたび、そのポケモンのHPを「90」回復する。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "スパイクドロー" },
+			damage: 20,
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札を2枚引く。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Grass", value: "-30" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 861363,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "energy",
+			thirdParty: {
+				cardmarket: 861720,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 861721,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "None",
+	dexId: [801],
+};
+
+export default card;

--- a/data-asia/M/M2a/121.ts
+++ b/data-asia/M/M2a/121.ts
@@ -1,0 +1,68 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ジュラルドン",
+	},
+
+	illustrator: "Takeshi Nakamura",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Metal"],
+
+	description: {
+		ja: "金属の ボディは 頑丈だが 熱が こもってしまうので 尻尾の スリットから 放熱している。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ぶちかます" },
+			damage: 30,
+			cost: ["Metal"],
+		},
+		{
+			name: { ja: "レイジングハンマー" },
+			damage: "80+",
+			cost: ["Metal", "Metal", "Colorless"],
+			effect: {
+				ja: "このポケモンにのっているダメカンの数×10ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Grass", value: "-30" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 861364,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "energy",
+			thirdParty: {
+				cardmarket: 861722,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 861723,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "H",
+	rarity: "None",
+	dexId: [884],
+};
+
+export default card;

--- a/data-asia/M/M2a/122.ts
+++ b/data-asia/M/M2a/122.ts
@@ -1,0 +1,62 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ブリジュラスex",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 300,
+	types: ["Metal"],
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ごうきんビルド" },
+			effect: {
+				ja: "自分の番に、このカードを手札から出して進化させたとき、1回使える。自分のトラッシュから「基本[M]エネルギー」を2枚まで選び、自分の[M]ポケモンに好きなようにつける。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "メタルディフェンダー" },
+			damage: 220,
+			cost: ["Metal", "Metal", "Metal"],
+			effect: {
+				ja: "次の相手の番、このポケモンの弱点は、すべてなくなる。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Grass", value: "-30" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 861365,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ジュラルドン",
+	},
+
+	retreat: 2,
+	regulationMark: "H",
+	rarity: "Double rare",
+	dexId: [1018],
+
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/M/M2a/123.ts
+++ b/data-asia/M/M2a/123.ts
@@ -1,0 +1,56 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ホップのザシアンex",
+	},
+
+	illustrator: "PLANETA Mochizuki",
+	category: "Pokemon",
+	hp: 230,
+	types: ["Metal"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "せつなぎり" },
+			damage: 30,
+			cost: ["Colorless"],
+			effect: {
+				ja: "相手のベンチポケモン1匹にも、30ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+			},
+		},
+		{
+			name: { ja: "ブレイブスラッシュ" },
+			damage: 240,
+			cost: ["Metal", "Metal", "Metal", "Colorless"],
+			effect: {
+				ja: "次の自分の番、このポケモンは「ブレイブスラッシュ」が使えない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Grass", value: "-30" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 861366,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "I",
+	rarity: "Double rare",
+	dexId: [888],
+
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/M/M2a/124.ts
+++ b/data-asia/M/M2a/124.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ミニリュウ",
+	},
+
+	illustrator: "HYOGONOSUKE",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Dragon"],
+
+	description: {
+		ja: "脱皮を 繰り返しては どんどん 大きくなる 生命力 あふれる ポケモン。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ずつき" },
+			damage: 30,
+			cost: ["Water", "Lightning"],
+		},
+	],
+
+	weaknesses: [],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 861367,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "energy",
+			thirdParty: {
+				cardmarket: 861724,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "loveball",
+			thirdParty: {
+				cardmarket: 861725,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "I",
+	rarity: "None",
+	dexId: [147],
+};
+
+export default card;

--- a/data-asia/M/M2a/125.ts
+++ b/data-asia/M/M2a/125.ts
@@ -1,0 +1,75 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ハクリュー",
+	},
+
+	illustrator: "Gemi",
+	category: "Pokemon",
+	hp: 100,
+	types: ["Dragon"],
+
+	description: {
+		ja: "水晶のような 玉には 天候を 自由に 操る 能力が 秘められているらしい。",
+	},
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "しんかのみちびき" },
+			effect: {
+				ja: "このポケモンにエネルギーがついているなら、自分の番に1回使える。自分の山札から進化ポケモンを1枚選び、相手に見せて、手札に加える。そして山札を切る。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "しっぽのムチ" },
+			damage: 60,
+			cost: ["Water", "Lightning"],
+		},
+	],
+
+	weaknesses: [],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 861368,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "energy",
+			thirdParty: {
+				cardmarket: 861726,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "loveball",
+			thirdParty: {
+				cardmarket: 861727,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ミニリュウ",
+	},
+
+	retreat: 2,
+	regulationMark: "I",
+	rarity: "None",
+	dexId: [148],
+};
+
+export default card;

--- a/data-asia/M/M2a/126.ts
+++ b/data-asia/M/M2a/126.ts
@@ -1,0 +1,62 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "メガカイリューex",
+	},
+
+	illustrator: "aky CG Works",
+	category: "Pokemon",
+	hp: 370,
+	types: ["Dragon"],
+
+	stage: "Stage2",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "スカイキャリー" },
+			effect: {
+				ja: "自分の番に1回使える。自分のバトルポケモンをベンチポケモンと入れ替える。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "リューノグライド" },
+			damage: 330,
+			cost: ["Water", "Lightning", "Lightning"],
+			effect: {
+				ja: "このポケモンについているエネルギーを2個選び、トラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 861369,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ハクリュー",
+	},
+
+	retreat: 2,
+	regulationMark: "I",
+	rarity: "Double rare",
+	dexId: [149],
+
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/M/M2a/127.ts
+++ b/data-asia/M/M2a/127.ts
@@ -1,0 +1,69 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "レックウザ",
+	},
+
+	illustrator: "nagimiso",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Dragon"],
+
+	description: {
+		ja: "雲より はるか上の オゾン層に 生息しているため 地上から 姿を 見ることは できない。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "アサルトブレイク" },
+			damage: "20+",
+			cost: ["Lightning", "Colorless"],
+			effect: {
+				ja: "この番に、このポケモンがベンチからバトル場に出ていたなら、90ダメージ追加。",
+			},
+		},
+		{
+			name: { ja: "ドラゴンクロー" },
+			damage: 130,
+			cost: ["Fire", "Lightning", "Colorless"],
+		},
+	],
+
+	weaknesses: [],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 861370,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "energy",
+			thirdParty: {
+				cardmarket: 861728,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "friendball",
+			thirdParty: {
+				cardmarket: 861729,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "None",
+	dexId: [384],
+};
+
+export default card;

--- a/data-asia/M/M2a/128.ts
+++ b/data-asia/M/M2a/128.ts
@@ -1,0 +1,69 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "Nのレシラム",
+	},
+
+	illustrator: "rika",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Dragon"],
+
+	description: {
+		ja: "人が 真実を 蔑ろにして 欲に まみれると 炎で 国を 焼きつくすと 神話に 描かれた。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "パワーレイジ" },
+			damage: "20×",
+			cost: ["Fire", "Lightning"],
+			effect: {
+				ja: "このポケモンにのっているダメカンの数×20ダメージ。",
+			},
+		},
+		{
+			name: { ja: "イノセントフレイム" },
+			damage: 170,
+			cost: ["Fire", "Fire", "Lightning", "Colorless"],
+		},
+	],
+
+	weaknesses: [],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 861371,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "energy",
+			thirdParty: {
+				cardmarket: 861730,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				cardmarket: 861731,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "I",
+	rarity: "None",
+	dexId: [643],
+};
+
+export default card;

--- a/data-asia/M/M2a/129.ts
+++ b/data-asia/M/M2a/129.ts
@@ -1,0 +1,72 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "Nのゼクロム",
+	},
+
+	illustrator: "AKIRA EGAWA",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Dragon"],
+
+	description: {
+		ja: "しっぽの 内部が モーターのように 回ると 何本もの 稲妻が 発生して 周囲を つらぬく。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ひきさく" },
+			damage: 70,
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "このワザのダメージは、相手のバトルポケモンにかかっている効果を計算しない。",
+			},
+		},
+		{
+			name: { ja: "ランページサンダー" },
+			damage: 250,
+			cost: ["Fire", "Lightning", "Lightning", "Colorless"],
+			effect: {
+				ja: "次の自分の番、このポケモンはワザが使えない。",
+			},
+		},
+	],
+
+	weaknesses: [],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 861372,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "energy",
+			thirdParty: {
+				cardmarket: 861732,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				cardmarket: 861733,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "I",
+	rarity: "None",
+	dexId: [644],
+};
+
+export default card;

--- a/data-asia/M/M2a/130.ts
+++ b/data-asia/M/M2a/130.ts
@@ -1,0 +1,68 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "オンバット",
+	},
+
+	illustrator: "Eri Kamei",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Dragon"],
+
+	description: {
+		ja: "２０万ヘルツの 超音波を 浴びると 屈強な レスラーも 目が 回り 立っていられないのだ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ガラクタはこび" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札から「ポケモンのどうぐ」を1枚選び、相手に見せて、手札に加える。そして山札を切る。",
+			},
+		},
+		{
+			name: { ja: "かみつく" },
+			damage: 30,
+			cost: ["Psychic", "Darkness"],
+		},
+	],
+
+	weaknesses: [],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 861373,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "energy",
+			thirdParty: {
+				cardmarket: 861734,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "friendball",
+			thirdParty: {
+				cardmarket: 861735,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "None",
+	dexId: [714],
+};
+
+export default card;

--- a/data-asia/M/M2a/131.ts
+++ b/data-asia/M/M2a/131.ts
@@ -1,0 +1,76 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "オンバーン",
+	},
+
+	illustrator: "Natsumi Miyanose",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Dragon"],
+
+	description: {
+		ja: "月明かりすら ない 闇夜を 飛び 油断している 獲物を 襲う。 暗闇の 戦いでは 無敵だ。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "こうそくいどう" },
+			damage: 40,
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "コインを1回投げオモテなら、次の相手の番、このポケモンはワザのダメージや効果を受けない。",
+			},
+		},
+		{
+			name: { ja: "きょうかスラッシュ" },
+			damage: "70+",
+			cost: ["Psychic", "Darkness"],
+			effect: {
+				ja: "このポケモンに「ポケモンのどうぐ」がついているなら、70ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 861374,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "energy",
+			thirdParty: {
+				cardmarket: 861736,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "friendball",
+			thirdParty: {
+				cardmarket: 861737,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "オンバット",
+	},
+
+	retreat: 0,
+	regulationMark: "I",
+	rarity: "None",
+	dexId: [715],
+};
+
+export default card;

--- a/data-asia/M/M2a/132.ts
+++ b/data-asia/M/M2a/132.ts
@@ -1,0 +1,66 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ドラメシヤ",
+	},
+
+	illustrator: "Scav",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Dragon"],
+
+	description: {
+		ja: "食べもしないのに ウデッポウに 食らいつくのは 生きていたころの 行動の 名残りと 言われている。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ちょっとうらむ" },
+			damage: 10,
+			cost: ["Psychic"],
+		},
+		{
+			name: { ja: "かみつく" },
+			damage: 40,
+			cost: ["Fire", "Psychic"],
+		},
+	],
+
+	weaknesses: [],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 861375,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "energy",
+			thirdParty: {
+				cardmarket: 861738,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "quickball",
+			thirdParty: {
+				cardmarket: 861739,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "H",
+	rarity: "None",
+	dexId: [885],
+};
+
+export default card;

--- a/data-asia/M/M2a/133.ts
+++ b/data-asia/M/M2a/133.ts
@@ -1,0 +1,75 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ドロンチ",
+	},
+
+	illustrator: "cochi8i",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Dragon"],
+
+	description: {
+		ja: "肺に エネルギーを溜め 撃ち出す。 ドラメシヤが 立派に 育つまで 一緒に 戦い 世話もする。",
+	},
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ていさつしれい" },
+			effect: {
+				ja: "自分の番に1回使える。自分の山札を上から2枚見て、どちらか1枚を選び、手札に加える。残りのカードは、山札の下にもどす。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "リューズヘッド" },
+			damage: 70,
+			cost: ["Fire", "Psychic"],
+		},
+	],
+
+	weaknesses: [],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 861376,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "energy",
+			thirdParty: {
+				cardmarket: 861740,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "quickball",
+			thirdParty: {
+				cardmarket: 861741,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ドラメシヤ",
+	},
+
+	retreat: 1,
+	regulationMark: "H",
+	rarity: "None",
+	dexId: [886],
+};
+
+export default card;

--- a/data-asia/M/M2a/134.ts
+++ b/data-asia/M/M2a/134.ts
@@ -1,0 +1,57 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ドラパルトex",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 320,
+	types: ["Dragon"],
+
+	stage: "Stage2",
+
+	attacks: [
+		{
+			name: { ja: "ジェットヘッド" },
+			damage: 70,
+			cost: ["Colorless"],
+		},
+		{
+			name: { ja: "ファントムダイブ" },
+			damage: 200,
+			cost: ["Fire", "Psychic"],
+			effect: {
+				ja: "ダメカン6個を、相手のベンチポケモンに好きなようにのせる。",
+			},
+		},
+	],
+
+	weaknesses: [],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 861377,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ドロンチ",
+	},
+
+	retreat: 1,
+	regulationMark: "H",
+	rarity: "Double rare",
+	dexId: [887],
+
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/M/M2a/135.ts
+++ b/data-asia/M/M2a/135.ts
@@ -1,0 +1,70 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "シャリタツ",
+	},
+
+	illustrator: "Jerky",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Dragon"],
+
+	description: {
+		ja: "非常に 悪賢い ポケモン。 弱ったふりで 獲物を おびき寄せ 仲間の ポケモンに 襲わせる。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "きゃくよせ" },
+			effect: {
+				ja: "このポケモンがバトル場にいるなら、自分の番に1回使える。自分の山札を上から6枚見て、その中からサポートを1枚選び、相手に見せて、手札に加える。残りのカードは山札にもどして切る。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "なみのり" },
+			damage: 50,
+			cost: ["Fire", "Water"],
+		},
+	],
+
+	weaknesses: [],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 861378,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "energy",
+			thirdParty: {
+				cardmarket: 861742,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 861743,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "H",
+	rarity: "None",
+	dexId: [978],
+};
+
+export default card;

--- a/data-asia/M/M2a/136.ts
+++ b/data-asia/M/M2a/136.ts
@@ -1,0 +1,73 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ホップのカビゴン",
+	},
+
+	illustrator: "OKACHEKE",
+	category: "Pokemon",
+	hp: 150,
+	types: ["Colorless"],
+
+	description: {
+		ja: "眠っているとき以外は つねに エサを 食べている 大食らい。 １日に ４００キロも たいらげる。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ふとっぱら" },
+			effect: {
+				ja: "このポケモンがいるかぎり、自分の「ホップのポケモン」が使うワザの、相手のバトルポケモンへのダメージは「+30」される。この効果は、この特性を持つポケモンが何匹いても、重ならない。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ダイナミックプレス" },
+			damage: 140,
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンにも80ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 861379,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "energy",
+			thirdParty: {
+				cardmarket: 861744,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 861745,
+			},
+		},
+	],
+
+	retreat: 4,
+	regulationMark: "I",
+	rarity: "None",
+	dexId: [143],
+};
+
+export default card;

--- a/data-asia/M/M2a/137.ts
+++ b/data-asia/M/M2a/137.ts
@@ -1,0 +1,63 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ホーホー",
+	},
+
+	illustrator: "Yukihiro Tada",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Colorless"],
+
+	description: {
+		ja: "正確に 時を 告げることから 世界の ことわりを わきまえた 知恵の神様 とする 国もある。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "さんどづき" },
+			damage: "10×",
+			cost: ["Colorless"],
+			effect: {
+				ja: "コインを3回投げ、オモテの数×10ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 861380,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "energy",
+			thirdParty: {
+				cardmarket: 861746,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 861747,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "H",
+	rarity: "None",
+	dexId: [163],
+};
+
+export default card;

--- a/data-asia/M/M2a/138.ts
+++ b/data-asia/M/M2a/138.ts
@@ -1,0 +1,74 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヨルノズク",
+	},
+
+	illustrator: "matazo",
+	category: "Pokemon",
+	hp: 100,
+	types: ["Colorless"],
+
+	description: {
+		ja: "非常に 柔らかい 羽は 飛ぶとき 音を 出さないので こっそり 獲物に 近づける。",
+	},
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ほうせきさがし" },
+			effect: {
+				ja: "自分の番に、このカードを手札から出して進化させたとき、自分の場に「テラスタル」のポケモンがいるなら、1回使える。自分の山札からトレーナーズを2枚まで選び、相手に見せて、手札に加える。そして山札を切る。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "スピードウイング" },
+			damage: 60,
+			cost: ["Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 861381,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "energy",
+			thirdParty: {
+				cardmarket: 861748,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 861749,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ホーホー",
+	},
+
+	retreat: 1,
+	regulationMark: "H",
+	rarity: "None",
+	dexId: [164],
+};
+
+export default card;

--- a/data-asia/M/M2a/139.ts
+++ b/data-asia/M/M2a/139.ts
@@ -1,0 +1,74 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "スピンロトム",
+	},
+
+	illustrator: "Toshinao Aoki",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Colorless"],
+
+	description: {
+		ja: "ロトムが 入れる 家電製品は いくつか あるが いちばん 初めに 開発されたのは 扇風機だ。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ファンコール" },
+			effect: {
+				ja: "最初の自分の番にだけ1回使える。自分の山札から、HPが「100」以下の[C]ポケモンを3枚まで選び、相手に見せて、手札に加える。そして山札を切る。この番、すでに別の「ファンコール」を使っていたなら、この特性は使えない。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "とつげきランディング" },
+			damage: 70,
+			cost: ["Colorless"],
+			effect: {
+				ja: "場にスタジアムが出ていないなら、このワザは失敗。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 861382,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "energy",
+			thirdParty: {
+				cardmarket: 861750,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "duskball",
+			thirdParty: {
+				cardmarket: 861751,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "H",
+	rarity: "None",
+	dexId: [479],
+};
+
+export default card;

--- a/data-asia/M/M2a/140.ts
+++ b/data-asia/M/M2a/140.ts
@@ -1,0 +1,73 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "バッフロン",
+	},
+
+	illustrator: "GOSSAN",
+	category: "Pokemon",
+	hp: 100,
+	types: ["Colorless"],
+
+	description: {
+		ja: "頭突きだけで 車を 潰す。 頭の 毛が 大きいほど 群れでの 地位が 上がるのだ。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "カーリーウォール" },
+			effect: {
+				ja: "このポケモンと、自分の別の「バッフロン」がいるかぎり、自分の[C]タイプのたねポケモン全員が、相手のポケモンから受けるワザのダメージは「-60」される。この効果は、この特性を持つポケモンが何匹いても、重ならない。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "そこぢから" },
+			damage: 130,
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "次の自分の番、このポケモンはワザが使えない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 861383,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "energy",
+			thirdParty: {
+				cardmarket: 861752,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 861753,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "H",
+	rarity: "None",
+	dexId: [626],
+};
+
+export default card;

--- a/data-asia/M/M2a/141.ts
+++ b/data-asia/M/M2a/141.ts
@@ -1,0 +1,60 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ホップのウールー",
+	},
+
+	illustrator: "Tomomi Ozaki",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Colorless"],
+
+	description: {
+		ja: "毛が 伸びすぎると 動けない。 ウールーの 体毛で 織られた 布は 驚くほど 丈夫。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "けとばす" },
+			damage: 50,
+			cost: ["Colorless", "Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 861384,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "energy",
+			thirdParty: {
+				cardmarket: 861754,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 861755,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "None",
+	dexId: [831],
+};
+
+export default card;

--- a/data-asia/M/M2a/142.ts
+++ b/data-asia/M/M2a/142.ts
@@ -1,0 +1,74 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ホップのバイウールー",
+	},
+
+	illustrator: "Ryota Murayama",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Colorless"],
+
+	description: {
+		ja: "立派に 伸びた ツノは 異性に アピールするために 生えている。 武器として 使うことはない。",
+	},
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "チャレンジホーン" },
+			effect: {
+				ja: "自分の番に、このカードを手札から出して進化させたとき、1回使える。相手のベンチポケモンを1匹選び、バトルポケモンと入れ替える。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ずつき" },
+			damage: 80,
+			cost: ["Colorless", "Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 861385,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "energy",
+			thirdParty: {
+				cardmarket: 861756,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 861757,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ホップのウールー",
+	},
+
+	retreat: 2,
+	regulationMark: "I",
+	rarity: "None",
+	dexId: [832],
+};
+
+export default card;

--- a/data-asia/M/M2a/143.ts
+++ b/data-asia/M/M2a/143.ts
@@ -1,0 +1,64 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ホップのウッウ",
+	},
+
+	illustrator: "Saboteri",
+	category: "Pokemon",
+	hp: 110,
+	types: ["Colorless"],
+
+	description: {
+		ja: "なんでも 丸飲みする 習性。 大きすぎる 獲物を 詰まらせて 困っている ウッウほど 手強い。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "きまぐれスピット" },
+			damage: 120,
+			cost: ["Colorless"],
+			effect: {
+				ja: "相手のサイドの残り枚数が4枚・3枚でないなら、このワザは失敗。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 861386,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "energy",
+			thirdParty: {
+				cardmarket: 861758,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				cardmarket: 861759,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "None",
+	dexId: [845],
+};
+
+export default card;

--- a/data-asia/M/M2a/144.ts
+++ b/data-asia/M/M2a/144.ts
@@ -1,0 +1,68 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "テラパゴス",
+	},
+
+	illustrator: "GIDORA",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Colorless"],
+
+	description: {
+		ja: "テラスタルの 甲羅は 相手の 技を 受けると そのエネルギーを 吸い取って 自分のものにする。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "プリズムチャージ" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札から、それぞれちがうタイプの基本エネルギーを3枚まで選び、自分の「テラスタル」のポケモンに好きなようにつける。そして山札を切る。",
+			},
+		},
+		{
+			name: { ja: "ハードタックル" },
+			damage: 100,
+			cost: ["Colorless", "Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 861387,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "energy",
+			thirdParty: {
+				cardmarket: 861760,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "loveball",
+			thirdParty: {
+				cardmarket: 861761,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "H",
+	rarity: "None",
+	dexId: [1024],
+};
+
+export default card;

--- a/data-asia/M/M2a/145.ts
+++ b/data-asia/M/M2a/145.ts
@@ -1,0 +1,56 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "テラパゴスex",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 230,
+	types: ["Colorless"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ユニオンビート" },
+			damage: "30×",
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "このワザは、後攻プレイヤーの最初の番には使えない。自分のベンチポケモンの数×30ダメージ。",
+			},
+		},
+		{
+			name: { ja: "クラウンオパール" },
+			damage: 180,
+			cost: ["Grass", "Water", "Lightning"],
+			effect: {
+				ja: "次の相手の番、このポケモンはたねポケモン（[C]ポケモンをのぞく）からワザのダメージを受けない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 861388,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "H",
+	rarity: "Double rare",
+	dexId: [1024],
+
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/M/M2a/146.ts
+++ b/data-asia/M/M2a/146.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "Nのポイントアップ",
+	},
+
+	illustrator: "Toyste Beach",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分のトラッシュから基本エネルギーを1枚選び、ベンチの「Nのポケモン」につける。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 861389,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	regulationMark: "I",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/M/M2a/147.ts
+++ b/data-asia/M/M2a/147.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "エネルギーリサイクル",
+	},
+
+	illustrator: "Toyste Beach",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分のトラッシュから基本エネルギーを5枚選び、相手に見せてから、山札にもどす。そして山札を切る。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 861390,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	regulationMark: "I",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/M/M2a/148.ts
+++ b/data-asia/M/M2a/148.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "改造ハンマー",
+	},
+
+	illustrator: "Eske Yoshinob",
+	category: "Trainer",
+
+	effect: {
+		ja: "相手のポケモンについている特殊エネルギーを1個選び、トラッシュする。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 861391,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	regulationMark: "H",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/M/M2a/149.ts
+++ b/data-asia/M/M2a/149.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ガラスのラッパ",
+	},
+
+	illustrator: "Toyste Beach",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードは、自分の場に「テラスタル」のポケモンがいるときにしか使えない。自分のベンチの[C]ポケモンを2匹まで選び、トラッシュから基本エネルギーを1枚ずつつける。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 861392,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	regulationMark: "H",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/M/M2a/150.ts
+++ b/data-asia/M/M2a/150.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "せいなるはい",
+	},
+
+	illustrator: "Eske Yoshinob",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分のトラッシュからポケモンを5枚選び、相手に見せてから、山札にもどす。そして山札を切る。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 861393,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	regulationMark: "I",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/M/M2a/151.ts
+++ b/data-asia/M/M2a/151.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ツールスクラッパー",
+	},
+
+	illustrator: "Studio Bora Inc.",
+	category: "Trainer",
+
+	effect: {
+		ja: "おたがいの場のポケモンについている「ポケモンのどうぐ」を2枚まで選び、トラッシュする。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 861394,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	regulationMark: "I",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/M/M2a/152.ts
+++ b/data-asia/M/M2a/152.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "テラスタルオーブ",
+	},
+
+	illustrator: "Ayaka Yoshida",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の山札から「テラスタル」のポケモンを1枚選び、相手に見せて、手札に加える。そして山札を切る。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 861395,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	regulationMark: "H",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/M/M2a/153.ts
+++ b/data-asia/M/M2a/153.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "なかよしポフィン",
+	},
+
+	illustrator: "AYUMI ODASHIMA",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の山札から、HPが「70」以下のたねポケモンを2枚まで選び、ベンチに出す。そして山札を切る。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 861396,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	regulationMark: "H",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/M/M2a/154.ts
+++ b/data-asia/M/M2a/154.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "パワープロテイン",
+	},
+
+	illustrator: "Toyste Beach",
+	category: "Trainer",
+
+	effect: {
+		ja: "この番、自分の[F]ポケモンが使うワザの、相手のバトルポケモンへのダメージは「+30」される。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 861397,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	regulationMark: "I",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/M/M2a/155.ts
+++ b/data-asia/M/M2a/155.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ファイトゴング",
+	},
+
+	illustrator: "Toyste Beach",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の山札から[F]タイプのたねポケモンまたは「基本[F]エネルギー」を1枚選び、相手に見せて、手札に加える。そして山札を切る。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 861398,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	regulationMark: "I",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/M/M2a/156.ts
+++ b/data-asia/M/M2a/156.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ホップのバッグ",
+	},
+
+	illustrator: "AYUMI ODASHIMA",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の山札からたねポケモンの「ホップのポケモン」を2枚まで選び、ベンチに出す。そして山札を切る。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 861399,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	regulationMark: "I",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/M/M2a/157.ts
+++ b/data-asia/M/M2a/157.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "むしとりセット",
+	},
+
+	illustrator: "AYUMI ODASHIMA",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の山札を上から7枚見て、その中から[G]ポケモンと「基本[G]エネルギー」を合計2枚まで選び、相手に見せて、手札に加える。残りのカードは山札にもどして切る。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 861400,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	regulationMark: "H",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/M/M2a/158.ts
+++ b/data-asia/M/M2a/158.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "メガシグナル",
+	},
+
+	illustrator: "inose yukie",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の山札から「メガシンカex」を1枚選び、相手に見せて、手札に加える。そして山札を切る。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 861401,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	regulationMark: "I",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/M/M2a/159.ts
+++ b/data-asia/M/M2a/159.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "夜のタンカ",
+	},
+
+	illustrator: "Toyste Beach",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分のトラッシュからポケモンまたは基本エネルギーを1枚選び、相手に見せて、手札に加える。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 861402,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	regulationMark: "H",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/M/M2a/160.ts
+++ b/data-asia/M/M2a/160.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ロケット団のレシーバー",
+	},
+
+	illustrator: "inose yukie",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の山札から、名前に「ロケット団」とつくサポートを1枚選び、相手に見せて、手札に加える。そして山札を切る。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 861403,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	regulationMark: "I",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/M/M2a/161.ts
+++ b/data-asia/M/M2a/161.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "カウンターゲイン",
+	},
+
+	illustrator: "Toyste Beach",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分のサイドの残り枚数が、相手のサイドの残り枚数より多いなら、このカードをつけているポケモンがワザを使うためのエネルギーは、エネルギー1個ぶん少なくなる。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 861404,
+			},
+		},
+	],
+
+	trainerType: "Tool",
+	regulationMark: "H",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/M/M2a/162.ts
+++ b/data-asia/M/M2a/162.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "シロナのパワーウエイト",
+	},
+
+	illustrator: "Studio Bora Inc.",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードをつけている「シロナのポケモン」の最大HPは「＋70」される。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 861405,
+			},
+		},
+	],
+
+	trainerType: "Tool",
+	regulationMark: "I",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/M/M2a/163.ts
+++ b/data-asia/M/M2a/163.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "でんきだま",
+	},
+
+	illustrator: "Studio Bora Inc.",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードをつけている「ピカチュウex」が使うワザの、相手のバトル場の「ポケモンex」へのダメージは「+50」される。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 861406,
+			},
+		},
+	],
+
+	trainerType: "Tool",
+	regulationMark: "I",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/M/M2a/164.ts
+++ b/data-asia/M/M2a/164.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ぶあついうろこ",
+	},
+
+	illustrator: "Toyste Beach",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードをつけている[N]ポケモンが、相手の[G][R][W][L]ポケモンから受けるワザのダメージは「-50」される。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 861407,
+			},
+		},
+	],
+
+	trainerType: "Tool",
+	regulationMark: "I",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/M/M2a/165.ts
+++ b/data-asia/M/M2a/165.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ふうせん",
+	},
+
+	illustrator: "Studio Bora Inc.",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードをつけているポケモンは、にげるためのエネルギーが2個ぶん少なくなる。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 861408,
+			},
+		},
+	],
+
+	trainerType: "Tool",
+	regulationMark: "I",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/M/M2a/166.ts
+++ b/data-asia/M/M2a/166.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ブレイブバングル",
+	},
+
+	illustrator: "Toyste Beach",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードをつけているポケモン（「ルールを持つポケモン」をのぞく）が使うワザの、相手のバトル場の「ポケモンex」へのダメージは「+30」される。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 861409,
+			},
+		},
+	],
+
+	trainerType: "Tool",
+	regulationMark: "I",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/M/M2a/167.ts
+++ b/data-asia/M/M2a/167.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ホップのこだわりハチマキ",
+	},
+
+	illustrator: "Toyste Beach",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードをつけている「ホップのポケモン」は、ワザを使うためのエネルギーが[C]エネルギー1個ぶん少なくなり、そのポケモンが使うワザの、相手のバトルポケモンへのダメージは「+30」される。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 861410,
+			},
+		},
+	],
+
+	trainerType: "Tool",
+	regulationMark: "I",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/M/M2a/168.ts
+++ b/data-asia/M/M2a/168.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アイリスの闘志",
+	},
+
+	illustrator: "yuu",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードは、自分の手札を1枚トラッシュしなければ使えない。自分の手札が6枚になるように、山札を引く。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 861411,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "I",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/M/M2a/169.ts
+++ b/data-asia/M/M2a/169.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アセロラのいたずら",
+	},
+
+	illustrator: "Yuu Nishida",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードは、相手のサイドの残り枚数が2枚以下のときにしか使えない。 自分の場のポケモンを1匹選ぶ。次の相手の番、そのポケモンは相手の「ポケモンex」からワザのダメージや効果を受けない。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 861412,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "I",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/M/M2a/170.ts
+++ b/data-asia/M/M2a/170.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "カナリィ",
+	},
+
+	illustrator: "Naoki Saito",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードは、自分の手札を1枚トラッシュしなければ使えない。自分の山札から[L]ポケモンを4枚まで選び、相手に見せて、手札に加える。そして山札を切る。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 861413,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "I",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/M/M2a/171.ts
+++ b/data-asia/M/M2a/171.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "サーファー",
+	},
+
+	illustrator: "Hideki Ishikawa",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分のバトルポケモンをベンチポケモンと入れ替える。その後、自分の手札が5枚になるように、山札を引く。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 861414,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "H",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/M/M2a/172.ts
+++ b/data-asia/M/M2a/172.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "トウコ",
+	},
+
+	illustrator: "yuu",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の山札から進化ポケモンとエネルギーを1枚ずつ選び、相手に見せて、手札に加える。そして山札を切る。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 861415,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "I",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/M/M2a/173.ts
+++ b/data-asia/M/M2a/173.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "バーベナとヘレナ",
+	},
+
+	illustrator: "Sanosuke Sakuma",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードは、自分の場に「Nのヒヒダルマ」「Nのゾロアークex」「Nのバイバニラ」「Nのギギギアル」「Nのレシラム」「Nのゼクロム」がいなければ使えない。この番、自分の「Nのポケモン」が使うワザのダメージで、相手のバトルポケモンがきぜつしたなら、サイドを3枚多くとる。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 861416,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "I",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/M/M2a/174.ts
+++ b/data-asia/M/M2a/174.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヒビキの冒険",
+	},
+
+	illustrator: "Iori Suzuki",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の山札から「ヒビキのポケモン」と「基本[R]エネルギー」を合計3枚まで選び、相手に見せて、手札に加える。そして山札を切る。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 861417,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "I",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/M/M2a/175.ts
+++ b/data-asia/M/M2a/175.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "リーリエの決心",
+	},
+
+	illustrator: "Atsushi Furusawa",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の手札をすべて山札にもどして切る。その後、山札を6枚引く。自分のサイドの残り枚数が6枚なら、引く枚数は8枚になる。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 861418,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "I",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/M/M2a/176.ts
+++ b/data-asia/M/M2a/176.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ロケット団のアテナ",
+	},
+
+	illustrator: "hncl",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の手札が5枚になるように、山札を引く。自分の場のポケモン全員が「ロケット団のポケモン」なら、8枚になるように引く。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 861419,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "I",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/M/M2a/177.ts
+++ b/data-asia/M/M2a/177.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ロケット団のアポロ",
+	},
+
+	illustrator: "Hideki Ishikawa",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードは、前の相手の番に、自分の「ロケット団のポケモン」がきぜつしていなければ使えない。おたがいのプレイヤーは、それぞれ手札をすべて山札にもどして切る。その後、自分は5枚、相手は3枚、山札を引く。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 861420,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "I",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/M/M2a/178.ts
+++ b/data-asia/M/M2a/178.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ロケット団のサカキ",
+	},
+
+	illustrator: "akagi",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分のバトル場の「ロケット団のポケモン」を、ベンチの「ロケット団のポケモン」と入れ替える。その後、相手のベンチポケモンを1匹選び、バトルポケモンと入れ替える。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 861421,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "I",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/M/M2a/179.ts
+++ b/data-asia/M/M2a/179.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ロケット団のラムダ",
+	},
+
+	illustrator: "GOSSAN",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の山札からトレーナーズを1枚選び、相手に見せて、手札に加える。そして山札を切る。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 861422,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "I",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/M/M2a/180.ts
+++ b/data-asia/M/M2a/180.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ロケット団のランス",
+	},
+
+	illustrator: "Naoki Saito",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードは、先攻プレイヤーの最初の番でも使える。自分の山札からたねポケモンの「ロケット団のポケモン」を3枚まで選び、相手に見せて、手札に加える。そして山札を切る。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 861423,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "I",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/M/M2a/181.ts
+++ b/data-asia/M/M2a/181.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "Nの城",
+	},
+
+	illustrator: "AYUMI ODASHIMA",
+	category: "Trainer",
+
+	effect: {
+		ja: "おたがいの場の「Nのポケモン」全員のにげるためのエネルギーは、すべてなくなる。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 861424,
+			},
+		},
+	],
+
+	trainerType: "Stadium",
+	regulationMark: "I",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/M/M2a/182.ts
+++ b/data-asia/M/M2a/182.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "活力の森",
+	},
+
+	illustrator: "AYUMI ODASHIMA",
+	category: "Trainer",
+
+	effect: {
+		ja: "おたがいの[G]ポケモン全員は、出したばかりの番（最初の自分の番をのぞく）でも[G]ポケモンに進化できる。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 861425,
+			},
+		},
+	],
+
+	trainerType: "Stadium",
+	regulationMark: "I",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/M/M2a/183.ts
+++ b/data-asia/M/M2a/183.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "グラビティーマウンテン",
+	},
+
+	illustrator: "AYUMI ODASHIMA",
+	category: "Trainer",
+
+	effect: {
+		ja: "おたがいの場の2進化ポケモン全員の最大HPは、それぞれ「-30」される。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 861426,
+			},
+		},
+	],
+
+	trainerType: "Stadium",
+	regulationMark: "H",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/M/M2a/184.ts
+++ b/data-asia/M/M2a/184.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ゼロの大空洞",
+	},
+
+	illustrator: "MARINA Chikazawa",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の場に「テラスタル」のポケモンがいるプレイヤーが、ベンチに出せるポケモンの数は8匹になる。（このカードがトラッシュされたときか、自分の場に「テラスタル」のポケモンがいなくなったとき、ベンチが5匹になるまでトラッシュする。おたがいにトラッシュするなら、このカードの持ち主から行う。）",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 861427,
+			},
+		},
+	],
+
+	trainerType: "Stadium",
+	regulationMark: "H",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/M/M2a/185.ts
+++ b/data-asia/M/M2a/185.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ハッコウシティ",
+	},
+
+	illustrator: "MARINA Chikazawa",
+	category: "Trainer",
+
+	effect: {
+		ja: "おたがいのプレイヤーは、自分の番ごとに1回、自分のトラッシュから「基本[L]エネルギー」を2枚まで選び、相手に見せて、手札に加えてよい。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 861428,
+			},
+		},
+	],
+
+	trainerType: "Stadium",
+	regulationMark: "I",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/M/M2a/186.ts
+++ b/data-asia/M/M2a/186.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ハロンタウン",
+	},
+
+	illustrator: "AYUMI ODASHIMA",
+	category: "Trainer",
+
+	effect: {
+		ja: "おたがいの「ホップのポケモン」が使うワザの、相手のバトルポケモンへのダメージは「+30」される。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 861429,
+			},
+		},
+	],
+
+	trainerType: "Stadium",
+	regulationMark: "I",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/M/M2a/187.ts
+++ b/data-asia/M/M2a/187.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ミステリーガーデン",
+	},
+
+	illustrator: "AYUMI ODASHIMA",
+	category: "Trainer",
+
+	effect: {
+		ja: "おたがいのプレイヤーは、自分の番ごとに1回、手札からエネルギーを1枚トラッシュするなら、自分の手札の枚数が、自分の場の[P]ポケモンの数と同じ枚数になるように、山札を引いてよい。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 861430,
+			},
+		},
+	],
+
+	trainerType: "Stadium",
+	regulationMark: "I",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/M/M2a/188.ts
+++ b/data-asia/M/M2a/188.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "夜の鉱山",
+	},
+
+	illustrator: "Kenichi Yamaguchi",
+	category: "Trainer",
+
+	effect: {
+		ja: "おたがいの場の「テラスタル」のポケモン全員は、ワザを使うためのエネルギーが、それぞれ[C]エネルギー1個ぶん多くなる。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 861431,
+			},
+		},
+	],
+
+	trainerType: "Stadium",
+	regulationMark: "I",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/M/M2a/189.ts
+++ b/data-asia/M/M2a/189.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ロケット団の監視塔",
+	},
+
+	illustrator: "AYUMI ODASHIMA",
+	category: "Trainer",
+
+	effect: {
+		ja: "おたがいの場の[C]ポケモン全員の特性は、すべてなくなる。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 861432,
+			},
+		},
+	],
+
+	trainerType: "Stadium",
+	regulationMark: "I",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/M/M2a/190.ts
+++ b/data-asia/M/M2a/190.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ロケット団のファクトリー",
+	},
+
+	illustrator: "imoniii",
+	category: "Trainer",
+
+	effect: {
+		ja: "この番に、手札から、名前に「ロケット団」とつくサポートを出して使っていたプレイヤーは、自分の番ごとに1回、自分の山札を2枚引いてよい。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 861433,
+			},
+		},
+	],
+
+	trainerType: "Stadium",
+	regulationMark: "I",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/M/M2a/191.ts
+++ b/data-asia/M/M2a/191.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "イグニッションエネルギー",
+	},
+
+	illustrator: "",
+	category: "Energy",
+	energyType: "Special",
+
+	effect: {
+		ja: "ポケモンについているこのカードは、自分の番の終わりにトラッシュする。このカードは、ポケモンについているかぎり、[C]エネルギー1個ぶんとしてはたらく。進化ポケモンについているなら、[C]エネルギー3個ぶんとしてはたらく。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 861434,
+			},
+		},
+	],
+
+	regulationMark: "I",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/M/M2a/192.ts
+++ b/data-asia/M/M2a/192.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "プリズムエネルギー",
+	},
+
+	illustrator: "",
+	category: "Energy",
+	energyType: "Special",
+
+	effect: {
+		ja: "このカードは、[無]エネルギー1個ぶんとしてはたらく。たねポケモンについているかぎり、すべてのタイプのエネルギー1個ぶんとしてはたらく。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 861435,
+			},
+		},
+	],
+
+	regulationMark: "I",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/M/M2a/193.ts
+++ b/data-asia/M/M2a/193.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ロケット団エネルギー",
+	},
+
+	illustrator: "",
+	category: "Energy",
+	energyType: "Special",
+
+	effect: {
+		ja: "このカードは「ロケット団のポケモン」にしかつけられず、「ロケット団のポケモン」以外についているなら、トラッシュする。このカードは、ポケモンについているかぎり、[P][D]の2つのタイプのエネルギー2個ぶんとしてはたらく。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 861436,
+			},
+		},
+	],
+
+	regulationMark: "I",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/M/M2a/194.ts
+++ b/data-asia/M/M2a/194.ts
@@ -1,0 +1,62 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アゲハント",
+	},
+
+	illustrator: "Mori Yuu",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Grass"],
+
+	description: {
+		ja: "色 鮮やかな 羽の 模様が 特徴。 細い 口を 伸ばして 花の 甘い ミツを 吸い取る。",
+	},
+
+	stage: "Stage2",
+
+	attacks: [
+		{
+			name: { ja: "しびれごな" },
+			damage: 40,
+			cost: ["Grass"],
+			effect: {
+				ja: "コインを1回投げオモテなら、相手のバトルポケモンをマヒにする。",
+			},
+		},
+		{
+			name: { ja: "エナジーストロー" },
+			damage: "80×",
+			cost: ["Grass"],
+			effect: {
+				ja: "相手の手札を見て、その中にあるエネルギーの枚数×80ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 861437,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "カラサリス",
+	},
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "Illustration rare",
+	dexId: [267],
+};
+
+export default card;

--- a/data-asia/M/M2a/195.ts
+++ b/data-asia/M/M2a/195.ts
@@ -1,0 +1,64 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ドクケイル",
+	},
+
+	illustrator: "IKEDA Saki",
+	category: "Pokemon",
+	hp: 140,
+	types: ["Grass"],
+
+	description: {
+		ja: "夜行性の ポケモン。 明かりに 誘われた ドクケイルが 街路樹の 葉を 食い散らかす。",
+	},
+
+	stage: "Stage2",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "さざめくかぜ" },
+			effect: {
+				ja: "自分の番に1回使える。コインを1回投げオモテなら、相手のバトルポケモンについているエネルギーを1個選び、相手の手札にもどす。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ゆうやみどく" },
+			damage: 100,
+			cost: ["Grass", "Grass"],
+			effect: {
+				ja: "相手のバトルポケモンをどくとねむりにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 861438,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "マユルド",
+	},
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "Illustration rare",
+	dexId: [269],
+};
+
+export default card;

--- a/data-asia/M/M2a/196.ts
+++ b/data-asia/M/M2a/196.ts
@@ -1,0 +1,50 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "スボミー",
+	},
+
+	illustrator: "Yoko Hishida",
+	category: "Pokemon",
+	hp: 30,
+	types: ["Grass"],
+
+	description: {
+		ja: "毒を 含んだ 花粉を まく。 きれいな 水で 育てるほど 毒の 成分は 高まる。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "むずむずかふん" },
+			damage: 10,
+			cost: [],
+			effect: {
+				ja: "次の相手の番、相手は手札からグッズを出して使えない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 861439,
+			},
+		},
+	],
+
+	retreat: 0,
+	regulationMark: "H",
+	rarity: "Illustration rare",
+	dexId: [406],
+};
+
+export default card;

--- a/data-asia/M/M2a/197.ts
+++ b/data-asia/M/M2a/197.ts
@@ -1,0 +1,64 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヒビキのマグカルゴ",
+	},
+
+	illustrator: "Hideki Ishikawa",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Fire"],
+
+	description: {
+		ja: "火山の 火口付近で 暮らす。 マグマが 冷えて 固まった 殻に 炎エネルギーを 蓄えている。",
+	},
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "とけてながれる" },
+			effect: {
+				ja: "このポケモンにエネルギーがついていないなら、このポケモンのにげるためのエネルギーは、すべてなくなる。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ようがんバースト" },
+			damage: "70×",
+			cost: ["Fire", "Fire", "Fire"],
+			effect: {
+				ja: "このポケモンについている[R]エネルギーを5枚までトラッシュし、その枚数×70ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 861440,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ヒビキのマグマッグ",
+	},
+
+	retreat: 3,
+	regulationMark: "I",
+	rarity: "Illustration rare",
+	dexId: [219],
+};
+
+export default card;

--- a/data-asia/M/M2a/198.ts
+++ b/data-asia/M/M2a/198.ts
@@ -1,0 +1,57 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ドンメル",
+	},
+
+	illustrator: "Yoshimi Miyoshi",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Fire"],
+
+	description: {
+		ja: "１２００度の マグマを 体内に 溜めこんでいる。 炎の 技を 使うと コブは 小さく しぼむ。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "しゃくねつボディ" },
+			effect: {
+				ja: "このポケモンが、バトル場で相手のポケモンからワザのダメージを受けたとき、ワザを使ったポケモンをやけどにする。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "かえん" },
+			damage: 20,
+			cost: ["Fire", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 861441,
+			},
+		},
+	],
+
+	retreat: 3,
+	regulationMark: "I",
+	rarity: "Illustration rare",
+	dexId: [322],
+};
+
+export default card;

--- a/data-asia/M/M2a/199.ts
+++ b/data-asia/M/M2a/199.ts
@@ -1,0 +1,57 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "コダック",
+	},
+
+	illustrator: "REND",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Water"],
+
+	description: {
+		ja: "いつも 頭痛に 悩まされている。 この 頭痛が 激しくなると 不思議な 力を 使いはじめる。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "しめりけ" },
+			effect: {
+				ja: "このポケモンがいるかぎり、おたがいのポケモン全員は、そのポケモン自身をきぜつさせる効果の特性が、すべてなくなる。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ぶつかる" },
+			damage: 20,
+			cost: ["Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 861442,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "Illustration rare",
+	dexId: [54],
+};
+
+export default card;

--- a/data-asia/M/M2a/200.ts
+++ b/data-asia/M/M2a/200.ts
@@ -1,0 +1,47 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ユキワラシ",
+	},
+
+	illustrator: "June",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Water"],
+
+	description: {
+		ja: "ユキワラシの 棲みついた 家は お金持ちになるという 言い伝えが 雪国には 残っている。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ひんやり" },
+			damage: 10,
+			cost: ["Water"],
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 861443,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "Illustration rare",
+	dexId: [361],
+};
+
+export default card;

--- a/data-asia/M/M2a/201.ts
+++ b/data-asia/M/M2a/201.ts
@@ -1,0 +1,64 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "エレザード",
+	},
+
+	illustrator: "Takeshi Nakamura",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Lightning"],
+
+	description: {
+		ja: "エリマキを 広げて 発電する。 エレザード １匹で 高層ビルで 必要な 電気を 作れるのだ。",
+	},
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "エリマキはつでん" },
+			effect: {
+				ja: "この番に、手札から「カナリィ」を出して使っていたなら、自分の番に1回使える。自分の山札から「基本[L]エネルギー」を2枚まで選び、このポケモンにつける。そして山札を切る。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "パワフルボルト" },
+			damage: "70×",
+			cost: ["Lightning", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンについているエネルギーの数ぶんコインを投げ、オモテの数×70ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 861444,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "エリキテル",
+	},
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "Illustration rare",
+	dexId: [695],
+};
+
+export default card;

--- a/data-asia/M/M2a/202.ts
+++ b/data-asia/M/M2a/202.ts
@@ -1,0 +1,49 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ムウマ",
+	},
+
+	illustrator: "mashu",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Psychic"],
+
+	description: {
+		ja: "いきなり 後ろ髪に 噛みつき 引っぱっては 人の 驚く 姿を見て 喜んでいる。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "かくせい" },
+			cost: ["Psychic"],
+			effect: {
+				ja: "このポケモンから進化するカードを、自分の山札から1枚選び、このポケモンにのせて進化させる。そして山札を切る。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 861445,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "Illustration rare",
+	dexId: [200],
+};
+
+export default card;

--- a/data-asia/M/M2a/203.ts
+++ b/data-asia/M/M2a/203.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "トゲキッス",
+	},
+
+	illustrator: "satoma",
+	category: "Pokemon",
+	hp: 140,
+	types: ["Psychic"],
+
+	description: {
+		ja: "争い事や もめ事が 起こる 場所には 姿を 見せない。 近ごろは ほとんど 見かけない。",
+	},
+
+	stage: "Stage2",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ワンダーキッス" },
+			effect: {
+				ja: "このポケモンがいるかぎり、相手のバトルポケモンがきぜつするたび、自分はコインを1回投げる。オモテなら、サイドを1枚多くとる。この効果は、この特性を持つポケモンが何匹いても、重ならない。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "スピードウイング" },
+			damage: 140,
+			cost: ["Colorless", "Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 861446,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "トゲチック",
+	},
+
+	retreat: 1,
+	regulationMark: "H",
+	rarity: "Illustration rare",
+	dexId: [468],
+};
+
+export default card;

--- a/data-asia/M/M2a/204.ts
+++ b/data-asia/M/M2a/204.ts
@@ -1,0 +1,62 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ホップのオーロット",
+	},
+
+	illustrator: "Tomowaka",
+	category: "Pokemon",
+	hp: 140,
+	types: ["Psychic"],
+
+	description: {
+		ja: "根っこを 神経の かわりにして 森の 木を 操る。 体に 棲みついた ポケモンには 親切。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "ホラーリベンジ" },
+			damage: "30+",
+			cost: ["Colorless"],
+			effect: {
+				ja: "前の相手の番に、ワザのダメージで、自分の「ホップのポケモン」がきぜつしていたなら、100ダメージ追加。",
+			},
+		},
+		{
+			name: { ja: "おいつめる" },
+			damage: 90,
+			cost: ["Psychic", "Colorless", "Colorless"],
+			effect: {
+				ja: "次の相手の番、このワザを受けたポケモンは、にげられない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 861447,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ホップのボクレー",
+	},
+
+	retreat: 2,
+	regulationMark: "I",
+	rarity: "Illustration rare",
+	dexId: [709],
+};
+
+export default card;

--- a/data-asia/M/M2a/205.ts
+++ b/data-asia/M/M2a/205.ts
@@ -1,0 +1,49 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ロケット団のミミッキュ",
+	},
+
+	illustrator: "GOSSAN",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Psychic"],
+
+	description: {
+		ja: "陽の 当たらない 暗がりに 棲む。 人前に 出るときは ピカチュウに 似せた 布で 全身を 隠す。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ほうせきごっこ" },
+			cost: ["Psychic", "Colorless"],
+			effect: {
+				ja: "相手のバトル場の「テラスタル」のポケモンが持つワザを1つ選び、このワザとして使う。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 861448,
+			},
+		},
+	],
+
+	retreat: 0,
+	regulationMark: "I",
+	rarity: "Illustration rare",
+	dexId: [778],
+};
+
+export default card;

--- a/data-asia/M/M2a/206.ts
+++ b/data-asia/M/M2a/206.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ロケット団のダグトリオ",
+	},
+
+	illustrator: "Whisker",
+	category: "Pokemon",
+	hp: 100,
+	types: ["Fighting"],
+
+	description: {
+		ja: "地中を 掘りすすんで 相手が 油断しているところを 別の 場所から 攻撃する。",
+	},
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "あなぼこ" },
+			effect: {
+				ja: "このポケモンがいるかぎり、相手の番に、相手のバトルポケモンがベンチにもどるたび、そのポケモンにダメカンを2個のせる。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "マッドショット" },
+			damage: 50,
+			cost: ["Fighting", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 861449,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ロケット団のディグダ",
+	},
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "Illustration rare",
+	dexId: [51],
+};
+
+export default card;

--- a/data-asia/M/M2a/207.ts
+++ b/data-asia/M/M2a/207.ts
@@ -1,0 +1,54 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "チャーレム",
+	},
+
+	illustrator: "KEIICHIRO ITO",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Fighting"],
+
+	description: {
+		ja: "ヨガの 修行で 鍛えられた サイコパワーで 相手の 動きを 予測することが できるのだ。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "セブンスキック" },
+			damage: 150,
+			cost: ["Fighting"],
+			effect: {
+				ja: "自分の手札が7枚でないなら、このワザは失敗。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 861450,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "アサナン",
+	},
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "Illustration rare",
+	dexId: [308],
+};
+
+export default card;

--- a/data-asia/M/M2a/208.ts
+++ b/data-asia/M/M2a/208.ts
@@ -1,0 +1,50 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "シロナのミカルゲ",
+	},
+
+	illustrator: "hncl",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Darkness"],
+
+	description: {
+		ja: "いつも 悪さばかり していたら 不思議な 術で 本体を 要石に 縛りつけられた。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "レイジングカース" },
+			damage: "10×",
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分のベンチの「シロナのポケモン」全員にのっているダメカンの数×10ダメージ。このワザのダメージは弱点を計算しない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 861451,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "Illustration rare",
+	dexId: [442],
+};
+
+export default card;

--- a/data-asia/M/M2a/209.ts
+++ b/data-asia/M/M2a/209.ts
@@ -1,0 +1,62 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ガラル タチフサグマ",
+	},
+
+	illustrator: "Krgc",
+	category: "Pokemon",
+	hp: 170,
+	types: ["Darkness"],
+
+	description: {
+		ja: "凄まじい 声量を もつ。 シャウトとともに 威嚇するさまは ブロッキングと 呼ばれている。",
+	},
+
+	stage: "Stage2",
+
+	attacks: [
+		{
+			name: { ja: "スカーシャウト" },
+			damage: "70×",
+			cost: ["Darkness", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンにのっているダメカンの数×70ダメージ。",
+			},
+		},
+		{
+			name: { ja: "パンクスマッシュ" },
+			damage: 160,
+			cost: ["Darkness", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンについているエネルギーを1個選び、トラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 861452,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ガラル マッスグマ",
+	},
+
+	retreat: 2,
+	regulationMark: "I",
+	rarity: "Illustration rare",
+	dexId: [862],
+};
+
+export default card;

--- a/data-asia/M/M2a/210.ts
+++ b/data-asia/M/M2a/210.ts
@@ -1,0 +1,58 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "Nのゼクロム",
+	},
+
+	illustrator: "Bun Toujo",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Dragon"],
+
+	description: {
+		ja: "しっぽの 内部が モーターのように 回ると 何本もの 稲妻が 発生して 周囲を つらぬく。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ひきさく" },
+			damage: 70,
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "このワザのダメージは、相手のバトルポケモンにかかっている効果を計算しない。",
+			},
+		},
+		{
+			name: { ja: "ランページサンダー" },
+			damage: 250,
+			cost: ["Fire", "Lightning", "Lightning", "Colorless"],
+			effect: {
+				ja: "次の自分の番、このポケモンはワザが使えない。",
+			},
+		},
+	],
+
+	weaknesses: [],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 861453,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "I",
+	rarity: "Illustration rare",
+	dexId: [644],
+};
+
+export default card;

--- a/data-asia/M/M2a/211.ts
+++ b/data-asia/M/M2a/211.ts
@@ -1,0 +1,52 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ドラメシヤ",
+	},
+
+	illustrator: "Jerky",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Dragon"],
+
+	description: {
+		ja: "食べもしないのに ウデッポウに 食らいつくのは 生きていたころの 行動の 名残りと 言われている。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ちょっとうらむ" },
+			damage: 10,
+			cost: ["Psychic"],
+		},
+		{
+			name: { ja: "かみつく" },
+			damage: 40,
+			cost: ["Fire", "Psychic"],
+		},
+	],
+
+	weaknesses: [],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 861454,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "H",
+	rarity: "Illustration rare",
+	dexId: [885],
+};
+
+export default card;

--- a/data-asia/M/M2a/212.ts
+++ b/data-asia/M/M2a/212.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ドロンチ",
+	},
+
+	illustrator: "Jerky",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Dragon"],
+
+	description: {
+		ja: "肺に エネルギーを溜め 撃ち出す。 ドラメシヤが 立派に 育つまで 一緒に 戦い 世話もする。",
+	},
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ていさつしれい" },
+			effect: {
+				ja: "自分の番に1回使える。自分の山札を上から2枚見て、どちらか1枚を選び、手札に加える。残りのカードは、山札の下にもどす。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "リューズヘッド" },
+			damage: 70,
+			cost: ["Fire", "Psychic"],
+		},
+	],
+
+	weaknesses: [],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 861455,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ドラメシヤ",
+	},
+
+	retreat: 1,
+	regulationMark: "H",
+	rarity: "Illustration rare",
+	dexId: [886],
+};
+
+export default card;

--- a/data-asia/M/M2a/213.ts
+++ b/data-asia/M/M2a/213.ts
@@ -1,0 +1,60 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "スピンロトム",
+	},
+
+	illustrator: "Yukihiro Tada",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Colorless"],
+
+	description: {
+		ja: "ロトムが 入れる 家電製品は いくつか あるが いちばん 初めに 開発されたのは 扇風機だ。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ファンコール" },
+			effect: {
+				ja: "最初の自分の番にだけ1回使える。自分の山札から、HPが「100」以下の[C]ポケモンを3枚まで選び、相手に見せて、手札に加える。そして山札を切る。この番、すでに別の「ファンコール」を使っていたなら、この特性は使えない。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "とつげきランディング" },
+			damage: 70,
+			cost: ["Colorless"],
+			effect: {
+				ja: "場にスタジアムが出ていないなら、このワザは失敗。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 861456,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "H",
+	rarity: "Illustration rare",
+	dexId: [479],
+};
+
+export default card;

--- a/data-asia/M/M2a/214.ts
+++ b/data-asia/M/M2a/214.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "Nのポイントアップ",
+	},
+
+	illustrator: "Toyste Beach",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分のトラッシュから基本エネルギーを1枚選び、ベンチの「Nのポケモン」につける。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 861457,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	regulationMark: "I",
+	rarity: "Ultra Rare",
+};
+
+export default card;

--- a/data-asia/M/M2a/215.ts
+++ b/data-asia/M/M2a/215.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ガラスのラッパ",
+	},
+
+	illustrator: "Toyste Beach",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードは、自分の場に「テラスタル」のポケモンがいるときにしか使えない。自分のベンチの[C]ポケモンを2匹まで選び、トラッシュから基本エネルギーを1枚ずつつける。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 861458,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	regulationMark: "H",
+	rarity: "Ultra Rare",
+};
+
+export default card;

--- a/data-asia/M/M2a/216.ts
+++ b/data-asia/M/M2a/216.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ハイパーボール",
+	},
+
+	illustrator: "Studio Bora Inc.",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードは、自分の手札を2枚トラッシュしなければ使えない。自分の山札からポケモンを1枚選び、相手に見せてから、手札に加える。そして山札を切る。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 861459,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	regulationMark: "I",
+	rarity: "Ultra Rare",
+};
+
+export default card;

--- a/data-asia/M/M2a/217.ts
+++ b/data-asia/M/M2a/217.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ロケット団のレシーバー",
+	},
+
+	illustrator: "inose yukie",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の山札から、名前に「ロケット団」とつくサポートを1枚選び、相手に見せて、手札に加える。そして山札を切る。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 861460,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	regulationMark: "I",
+	rarity: "Ultra Rare",
+};
+
+export default card;

--- a/data-asia/M/M2a/218.ts
+++ b/data-asia/M/M2a/218.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "カウンターゲイン",
+	},
+
+	illustrator: "Toyste Beach",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分のサイドの残り枚数が、相手のサイドの残り枚数より多いなら、このカードをつけているポケモンがワザを使うためのエネルギーは、エネルギー1個ぶん少なくなる。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 861461,
+			},
+		},
+	],
+
+	trainerType: "Tool",
+	regulationMark: "H",
+	rarity: "Ultra Rare",
+};
+
+export default card;

--- a/data-asia/M/M2a/219.ts
+++ b/data-asia/M/M2a/219.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "カナリィ",
+	},
+
+	illustrator: "Naoki Saito",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードは、自分の手札を1枚トラッシュしなければ使えない。自分の山札から[L]ポケモンを4枚まで選び、相手に見せて、手札に加える。そして山札を切る。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 861462,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "I",
+	rarity: "Ultra Rare",
+};
+
+export default card;

--- a/data-asia/M/M2a/220.ts
+++ b/data-asia/M/M2a/220.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "からておうの稽古",
+	},
+
+	illustrator: "GOSSAN",
+	category: "Trainer",
+
+	effect: {
+		ja: "この番、自分のポケモンが使うワザの、相手のバトル場の「ポケモンex」へのダメージは「+40」される。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 861463,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "H",
+	rarity: "Ultra Rare",
+};
+
+export default card;

--- a/data-asia/M/M2a/221.ts
+++ b/data-asia/M/M2a/221.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "バーベナとヘレナ",
+	},
+
+	illustrator: "Sanosuke Sakuma",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードは、自分の場に「Nのヒヒダルマ」「Nのゾロアークex」「Nのバイバニラ」「Nのギギギアル」「Nのレシラム」「Nのゼクロム」がいなければ使えない。この番、自分の「Nのポケモン」が使うワザのダメージで、相手のバトルポケモンがきぜつしたなら、サイドを3枚多くとる。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 861464,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "I",
+	rarity: "Ultra Rare",
+};
+
+export default card;

--- a/data-asia/M/M2a/222.ts
+++ b/data-asia/M/M2a/222.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ジャミングタワー",
+	},
+
+	illustrator: "AYUMI ODASHIMA",
+	category: "Trainer",
+
+	effect: {
+		ja: "おたがいのポケモン全員についている「ポケモンのどうぐ」の効果は、すべてなくなる。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 861465,
+			},
+		},
+	],
+
+	trainerType: "Stadium",
+	regulationMark: "H",
+	rarity: "Ultra Rare",
+};
+
+export default card;

--- a/data-asia/M/M2a/223.ts
+++ b/data-asia/M/M2a/223.ts
@@ -1,0 +1,52 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "メガリザードンXex",
+	},
+
+	illustrator: "Saboteri",
+	category: "Pokemon",
+	hp: 360,
+	types: ["Fire"],
+
+	stage: "Stage2",
+
+	attacks: [
+		{
+			name: { ja: "インフェルノX" },
+			damage: "90×",
+			cost: ["Fire", "Fire"],
+			effect: {
+				ja: "自分の場のポケモンについている[R]エネルギーを好きなだけトラッシュし、その枚数×90ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 861466,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "リザード",
+	},
+
+	retreat: 2,
+	regulationMark: "I",
+	rarity: "Ultra Rare",
+	dexId: [6],
+
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/M/M2a/224.ts
+++ b/data-asia/M/M2a/224.ts
@@ -1,0 +1,60 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "メガユキメノコex",
+	},
+
+	illustrator: "Saboteri",
+	category: "Pokemon",
+	hp: 310,
+	types: ["Water"],
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "うらみぶし" },
+			damage: "50×",
+			cost: ["Water"],
+			effect: {
+				ja: "相手の手札の枚数×50ダメージ。",
+			},
+		},
+		{
+			name: { ja: "アブソリュートスノー" },
+			damage: 150,
+			cost: ["Water", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをねむりにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 861467,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ユキワラシ",
+	},
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "Ultra Rare",
+	dexId: [478],
+
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/M/M2a/225.ts
+++ b/data-asia/M/M2a/225.ts
@@ -1,0 +1,59 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "メガシビルドンex",
+	},
+
+	illustrator: "DOM",
+	category: "Pokemon",
+	hp: 350,
+	types: ["Lightning"],
+
+	stage: "Stage2",
+
+	attacks: [
+		{
+			name: { ja: "ばくれつだん" },
+			cost: ["Lightning", "Lightning"],
+			effect: {
+				ja: "相手のポケモン2匹に、それぞれ60ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+			},
+		},
+		{
+			name: { ja: "ディザスターショック" },
+			damage: 190,
+			cost: ["Lightning", "Lightning", "Lightning"],
+			effect: {
+				ja: "のぞむなら、このポケモンについている[L]エネルギーを2個トラッシュし、相手のバトルポケモンをマヒにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 861468,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "シビビール",
+	},
+
+	retreat: 2,
+	regulationMark: "I",
+	rarity: "Ultra Rare",
+	dexId: [604],
+
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/M/M2a/226.ts
+++ b/data-asia/M/M2a/226.ts
@@ -1,0 +1,59 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "メガサーナイトex",
+	},
+
+	illustrator: "Saboteri",
+	category: "Pokemon",
+	hp: 360,
+	types: ["Psychic"],
+
+	stage: "Stage2",
+
+	attacks: [
+		{
+			name: { ja: "あふれるねがい" },
+			cost: ["Psychic"],
+			effect: {
+				ja: "自分のベンチポケモン全員に、山札から「基本[P]エネルギー」を1枚ずつつける。そして山札を切る。",
+			},
+		},
+		{
+			name: { ja: "メガシンフォニア" },
+			damage: "50×",
+			cost: ["Psychic"],
+			effect: {
+				ja: "自分のポケモン全員についている[P]エネルギーの数×50ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 861469,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "キルリア",
+	},
+
+	retreat: 2,
+	regulationMark: "I",
+	rarity: "Ultra Rare",
+	dexId: [282],
+
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/M/M2a/227.ts
+++ b/data-asia/M/M2a/227.ts
@@ -1,0 +1,58 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "メガディアンシーex",
+	},
+
+	illustrator: "DOM",
+	category: "Pokemon",
+	hp: 270,
+	types: ["Psychic"],
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ダイヤコート" },
+			effect: {
+				ja: "このポケモンが受けるワザのダメージは「-30」される。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ガーランドレイ" },
+			damage: "120×",
+			cost: ["Psychic", "Psychic"],
+			effect: {
+				ja: "このポケモンについているエネルギーを2枚までトラッシュし、その枚数×120ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 861470,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "Ultra Rare",
+	dexId: [719],
+
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/M/M2a/228.ts
+++ b/data-asia/M/M2a/228.ts
@@ -1,0 +1,60 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "メガルカリオex",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 340,
+	types: ["Fighting"],
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "はどうづき" },
+			damage: 130,
+			cost: ["Fighting"],
+			effect: {
+				ja: "自分のトラッシュから「基本[F]エネルギー」を3枚まで選び、ベンチポケモンに好きなようにつける。",
+			},
+		},
+		{
+			name: { ja: "メガブレイブ" },
+			damage: 270,
+			cost: ["Fighting", "Fighting"],
+			effect: {
+				ja: "次の自分の番、このポケモンは「メガブレイブ」が使えない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 861471,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "リオル",
+	},
+
+	retreat: 2,
+	regulationMark: "I",
+	rarity: "Ultra Rare",
+	dexId: [448],
+
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/M/M2a/229.ts
+++ b/data-asia/M/M2a/229.ts
@@ -1,0 +1,58 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "メガルチャブルex",
+	},
+
+	illustrator: "Taiga Kasai",
+	category: "Pokemon",
+	hp: 250,
+	types: ["Fighting"],
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ふんばりボディ" },
+			effect: {
+				ja: "このポケモンが、ワザのダメージを受けてきぜつするとき、自分はコインを1回投げる。オモテなら、このポケモンはきぜつせず、残りHPが「10」の状態で場に残る。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "サマーソルトダイブ" },
+			damage: "120+",
+			cost: ["Fighting", "Fighting", "Colorless"],
+			effect: {
+				ja: "場にスタジアムが出ているなら、140ダメージ追加。その後、そのスタジアムをトラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 861472,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "Ultra Rare",
+	dexId: [701],
+
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/M/M2a/230.ts
+++ b/data-asia/M/M2a/230.ts
@@ -1,0 +1,62 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "メガゲンガーex",
+	},
+
+	illustrator: "Taiga Kasai",
+	category: "Pokemon",
+	hp: 350,
+	types: ["Darkness"],
+
+	stage: "Stage2",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "かげかくし" },
+			effect: {
+				ja: "このポケモンがいるかぎり、自分の[D]ポケモンが、相手の「ポケモンex」からワザのダメージを受けてきぜつしたとき、とられるサイドは1枚少なくなる。この特性の効果は重ならない。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ヴォイドゲイル" },
+			damage: 230,
+			cost: ["Darkness", "Darkness"],
+			effect: {
+				ja: "このポケモンについているエネルギーを1個選び、ベンチポケモンにつけ替える。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 861473,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ゴースト",
+	},
+
+	retreat: 2,
+	regulationMark: "I",
+	rarity: "Ultra Rare",
+	dexId: [94],
+
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/M/M2a/231.ts
+++ b/data-asia/M/M2a/231.ts
@@ -1,0 +1,62 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "メガズルズキンex",
+	},
+
+	illustrator: "Taiga Kasai",
+	category: "Pokemon",
+	hp: 330,
+	types: ["Darkness"],
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "はんげきトサカ" },
+			effect: {
+				ja: "このポケモンが、バトル場で相手のポケモンからワザのダメージを受けたとき、ワザを使ったポケモンにダメカンを5個のせる。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "アウトローレッグ" },
+			damage: 160,
+			cost: ["Darkness", "Darkness", "Colorless"],
+			effect: {
+				ja: "相手の手札からオモテを見ないで1枚選び、トラッシュする。相手の山札を上から1枚トラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 861474,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ズルッグ",
+	},
+
+	retreat: 2,
+	regulationMark: "I",
+	rarity: "Ultra Rare",
+	dexId: [560],
+
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/M/M2a/232.ts
+++ b/data-asia/M/M2a/232.ts
@@ -1,0 +1,62 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "メガカイリューex",
+	},
+
+	illustrator: "DOM",
+	category: "Pokemon",
+	hp: 370,
+	types: ["Dragon"],
+
+	stage: "Stage2",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "スカイキャリー" },
+			effect: {
+				ja: "自分の番に1回使える。自分のバトルポケモンをベンチポケモンと入れ替える。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "リューノグライド" },
+			damage: 330,
+			cost: ["Water", "Lightning", "Lightning"],
+			effect: {
+				ja: "このポケモンについているエネルギーを2個選び、トラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 861475,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ハクリュー",
+	},
+
+	retreat: 2,
+	regulationMark: "I",
+	rarity: "Ultra Rare",
+	dexId: [149],
+
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/M/M2a/233.ts
+++ b/data-asia/M/M2a/233.ts
@@ -1,0 +1,60 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "メガユキメノコex",
+	},
+
+	illustrator: "Teeziro",
+	category: "Pokemon",
+	hp: 310,
+	types: ["Water"],
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "うらみぶし" },
+			damage: "50×",
+			cost: ["Water"],
+			effect: {
+				ja: "相手の手札の枚数×50ダメージ。",
+			},
+		},
+		{
+			name: { ja: "アブソリュートスノー" },
+			damage: 150,
+			cost: ["Water", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをねむりにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 861476,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ユキワラシ",
+	},
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "Special illustration rare",
+	dexId: [478],
+
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/M/M2a/234.ts
+++ b/data-asia/M/M2a/234.ts
@@ -1,0 +1,58 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ピカチュウex",
+	},
+
+	illustrator: "James Turner",
+	category: "Pokemon",
+	hp: 200,
+	types: ["Lightning"],
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "がんばりハート" },
+			effect: {
+				ja: "このポケモンのHPがまんたんの状態で、このポケモンがワザのダメージを受けてきぜつするとき、きぜつせず、残りHPが「10」の状態で場に残る。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "トパーズボルト" },
+			damage: 300,
+			cost: ["Grass", "Lightning", "Metal"],
+			effect: {
+				ja: "このポケモンについているエネルギーを3個選び、トラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 861477,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "H",
+	rarity: "Special illustration rare",
+	dexId: [25],
+
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/M/M2a/235.ts
+++ b/data-asia/M/M2a/235.ts
@@ -1,0 +1,59 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "メガシビルドンex",
+	},
+
+	illustrator: "akagi",
+	category: "Pokemon",
+	hp: 350,
+	types: ["Lightning"],
+
+	stage: "Stage2",
+
+	attacks: [
+		{
+			name: { ja: "ばくれつだん" },
+			cost: ["Lightning", "Lightning"],
+			effect: {
+				ja: "相手のポケモン2匹に、それぞれ60ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+			},
+		},
+		{
+			name: { ja: "ディザスターショック" },
+			damage: 190,
+			cost: ["Lightning", "Lightning", "Lightning"],
+			effect: {
+				ja: "のぞむなら、このポケモンについている[L]エネルギーを2個トラッシュし、相手のバトルポケモンをマヒにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 861478,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "シビビール",
+	},
+
+	retreat: 2,
+	regulationMark: "I",
+	rarity: "Special illustration rare",
+	dexId: [604],
+
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/M/M2a/236.ts
+++ b/data-asia/M/M2a/236.ts
@@ -1,0 +1,62 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ナンジャモのハラバリーex",
+	},
+
+	illustrator: "Akira Komayama",
+	category: "Pokemon",
+	hp: 280,
+	types: ["Lightning"],
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "エレキストリーマー" },
+			effect: {
+				ja: "自分の番に何回でも使える。自分の手札から「基本[L]エネルギー」を1枚選び、自分の「ナンジャモのポケモン」につける。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "サンダーボルト" },
+			damage: 230,
+			cost: ["Lightning", "Lightning", "Lightning", "Colorless"],
+			effect: {
+				ja: "次の自分の番、このポケモンはワザが使えない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 861479,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ナンジャモのズピカ",
+	},
+
+	retreat: 2,
+	regulationMark: "I",
+	rarity: "Special illustration rare",
+	dexId: [939],
+
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/M/M2a/237.ts
+++ b/data-asia/M/M2a/237.ts
@@ -1,0 +1,58 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ロケット団のミュウツーex",
+	},
+
+	illustrator: "Mitsuhiro Arita",
+	category: "Pokemon",
+	hp: 280,
+	types: ["Psychic"],
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "パワーセーバー" },
+			effect: {
+				ja: "自分の場の「ロケット団のポケモン」が4匹以上のときにしか、このポケモンはワザが使えない。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "イレイザーボール" },
+			damage: "160+",
+			cost: ["Psychic", "Psychic", "Colorless"],
+			effect: {
+				ja: "のぞむなら、自分のベンチポケモンについているエネルギーを2枚までトラッシュし、その枚数×60ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 861480,
+			},
+		},
+	],
+
+	retreat: 3,
+	regulationMark: "I",
+	rarity: "Special illustration rare",
+	dexId: [150],
+
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/M/M2a/238.ts
+++ b/data-asia/M/M2a/238.ts
@@ -1,0 +1,58 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "メガディアンシーex",
+	},
+
+	illustrator: "Narano",
+	category: "Pokemon",
+	hp: 270,
+	types: ["Psychic"],
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ダイヤコート" },
+			effect: {
+				ja: "このポケモンが受けるワザのダメージは「-30」される。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ガーランドレイ" },
+			damage: "120×",
+			cost: ["Psychic", "Psychic"],
+			effect: {
+				ja: "このポケモンについているエネルギーを2枚までトラッシュし、その枚数×120ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 861481,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "Special illustration rare",
+	dexId: [719],
+
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/M/M2a/239.ts
+++ b/data-asia/M/M2a/239.ts
@@ -1,0 +1,58 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "メガルチャブルex",
+	},
+
+	illustrator: "AKIRA EGAWA",
+	category: "Pokemon",
+	hp: 250,
+	types: ["Fighting"],
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ふんばりボディ" },
+			effect: {
+				ja: "このポケモンが、ワザのダメージを受けてきぜつするとき、自分はコインを1回投げる。オモテなら、このポケモンはきぜつせず、残りHPが「10」の状態で場に残る。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "サマーソルトダイブ" },
+			damage: "120+",
+			cost: ["Fighting", "Fighting", "Colorless"],
+			effect: {
+				ja: "場にスタジアムが出ているなら、140ダメージ追加。その後、そのスタジアムをトラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 861482,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "Special illustration rare",
+	dexId: [701],
+
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/M/M2a/240.ts
+++ b/data-asia/M/M2a/240.ts
@@ -1,0 +1,62 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "メガゲンガーex",
+	},
+
+	illustrator: "danciao",
+	category: "Pokemon",
+	hp: 350,
+	types: ["Darkness"],
+
+	stage: "Stage2",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "かげかくし" },
+			effect: {
+				ja: "このポケモンがいるかぎり、自分の[D]ポケモンが、相手の「ポケモンex」からワザのダメージを受けてきぜつしたとき、とられるサイドは1枚少なくなる。この特性の効果は重ならない。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ヴォイドゲイル" },
+			damage: 230,
+			cost: ["Darkness", "Darkness"],
+			effect: {
+				ja: "このポケモンについているエネルギーを1個選び、ベンチポケモンにつけ替える。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 861483,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ゴースト",
+	},
+
+	retreat: 2,
+	regulationMark: "I",
+	rarity: "Special illustration rare",
+	dexId: [94],
+
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/M/M2a/241.ts
+++ b/data-asia/M/M2a/241.ts
@@ -1,0 +1,62 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "メガズルズキンex",
+	},
+
+	illustrator: "nagimiso",
+	category: "Pokemon",
+	hp: 330,
+	types: ["Darkness"],
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "はんげきトサカ" },
+			effect: {
+				ja: "このポケモンが、バトル場で相手のポケモンからワザのダメージを受けたとき、ワザを使ったポケモンにダメカンを5個のせる。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "アウトローレッグ" },
+			damage: 160,
+			cost: ["Darkness", "Darkness", "Colorless"],
+			effect: {
+				ja: "相手の手札からオモテを見ないで1枚選び、トラッシュする。相手の山札を上から1枚トラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 861484,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ズルッグ",
+	},
+
+	retreat: 2,
+	regulationMark: "I",
+	rarity: "Special illustration rare",
+	dexId: [560],
+
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/M/M2a/242.ts
+++ b/data-asia/M/M2a/242.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "Nのゾロアークex",
+	},
+
+	illustrator: "Raita Kazama",
+	category: "Pokemon",
+	hp: 280,
+	types: ["Darkness"],
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "とりひき" },
+			effect: {
+				ja: "自分の番に、自分の手札を1枚トラッシュするなら、1回使える。自分の山札を2枚引く。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ナイトジョーカー" },
+			cost: ["Darkness", "Darkness"],
+			effect: {
+				ja: "自分のベンチの「Nのポケモン」が持つワザを1つ選び、このワザとして使う。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 861485,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "Nのゾロア",
+	},
+
+	retreat: 2,
+	regulationMark: "I",
+	rarity: "Special illustration rare",
+	dexId: [571],
+
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/M/M2a/243.ts
+++ b/data-asia/M/M2a/243.ts
@@ -1,0 +1,62 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "マリィのオーロンゲex",
+	},
+
+	illustrator: "Ligton",
+	category: "Pokemon",
+	hp: 320,
+	types: ["Darkness"],
+
+	stage: "Stage2",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "パンクアップ" },
+			effect: {
+				ja: "自分の番に、このカードを手札から出して進化させたとき、1回使える。自分の山札から「基本[D]エネルギー」を5枚まで選び、自分の「マリィのポケモン」に好きなようにつける。そして山札を切る。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "シャドーバレット" },
+			damage: 180,
+			cost: ["Darkness", "Darkness"],
+			effect: {
+				ja: "相手のベンチポケモン1匹にも、30ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 861486,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "マリィのギモー",
+	},
+
+	retreat: 2,
+	regulationMark: "I",
+	rarity: "Special illustration rare",
+	dexId: [861],
+
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/M/M2a/244.ts
+++ b/data-asia/M/M2a/244.ts
@@ -1,0 +1,57 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "キチキギスex",
+	},
+
+	illustrator: "SIE NANAHARA",
+	category: "Pokemon",
+	hp: 210,
+	types: ["Darkness"],
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "さかてにとる" },
+			effect: {
+				ja: "前の相手の番に、自分のポケモンがきぜつしていたなら、自分の番に1回使える。自分の山札を3枚引く。この番、すでに別の「さかてにとる」を使っていたなら、この特性は使えない。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "クルーエルアロー" },
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のポケモン1匹に、100ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 861487,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "H",
+	rarity: "Special illustration rare",
+	dexId: [1016],
+
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/M/M2a/245.ts
+++ b/data-asia/M/M2a/245.ts
@@ -1,0 +1,59 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ダイゴのメタグロスex",
+	},
+
+	illustrator: "chibi",
+	category: "Pokemon",
+	hp: 340,
+	types: ["Metal"],
+
+	stage: "Stage2",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "エクスブート" },
+			effect: {
+				ja: "自分の番に1回使える。自分の山札から「基本[P]エネルギー」と「基本[M]エネルギー」をそれぞれ1枚まで選び、自分の[P]または[M]ポケモンに好きなようにつける。そして山札を切る。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "メタルスタンプ" },
+			damage: 200,
+			cost: ["Metal", "Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Grass", value: "-30" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 861488,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ダイゴのメタング",
+	},
+
+	retreat: 3,
+	regulationMark: "I",
+	rarity: "Special illustration rare",
+	dexId: [376],
+
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/M/M2a/246.ts
+++ b/data-asia/M/M2a/246.ts
@@ -1,0 +1,62 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "メガカイリューex",
+	},
+
+	illustrator: "DOM",
+	category: "Pokemon",
+	hp: 370,
+	types: ["Dragon"],
+
+	stage: "Stage2",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "スカイキャリー" },
+			effect: {
+				ja: "自分の番に1回使える。自分のバトルポケモンをベンチポケモンと入れ替える。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "リューノグライド" },
+			damage: 330,
+			cost: ["Water", "Lightning", "Lightning"],
+			effect: {
+				ja: "このポケモンについているエネルギーを2個選び、トラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 861489,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ハクリュー",
+	},
+
+	retreat: 2,
+	regulationMark: "I",
+	rarity: "Special illustration rare",
+	dexId: [149],
+
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/M/M2a/247.ts
+++ b/data-asia/M/M2a/247.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アイリスの闘志",
+	},
+
+	illustrator: "Kuroimori",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードは、自分の手札を1枚トラッシュしなければ使えない。自分の手札が6枚になるように、山札を引く。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 861490,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "I",
+	rarity: "Special illustration rare",
+};
+
+export default card;

--- a/data-asia/M/M2a/248.ts
+++ b/data-asia/M/M2a/248.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "カナリィ",
+	},
+
+	illustrator: "kantaro",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードは、自分の手札を1枚トラッシュしなければ使えない。自分の山札から[L]ポケモンを4枚まで選び、相手に見せて、手札に加える。そして山札を切る。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 861491,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "I",
+	rarity: "Special illustration rare",
+};
+
+export default card;

--- a/data-asia/M/M2a/249.ts
+++ b/data-asia/M/M2a/249.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "サーファー",
+	},
+
+	illustrator: "OKUBO",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分のバトルポケモンをベンチポケモンと入れ替える。その後、自分の手札が5枚になるように、山札を引く。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 861492,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "H",
+	rarity: "Special illustration rare",
+};
+
+export default card;

--- a/data-asia/M/M2a/250.ts
+++ b/data-asia/M/M2a/250.ts
@@ -1,0 +1,62 @@
+import { Card } from "../../../interfaces";
+import Set from "../M2a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "メガカイリューex",
+	},
+
+	illustrator: "aky CG Works",
+	category: "Pokemon",
+	hp: 370,
+	types: ["Dragon"],
+
+	stage: "Stage2",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "スカイキャリー" },
+			effect: {
+				ja: "自分の番に1回使える。自分のバトルポケモンをベンチポケモンと入れ替える。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "リューノグライド" },
+			damage: 330,
+			cost: ["Water", "Lightning", "Lightning"],
+			effect: {
+				ja: "このポケモンについているエネルギーを2個選び、トラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 861493,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ハクリュー",
+	},
+
+	retreat: 2,
+	regulationMark: "I",
+	rarity: "Mega Hyper Rare",
+	dexId: [149],
+
+	suffix: "EX",
+};
+
+export default card;


### PR DESCRIPTION
## What

Adds the complete Japanese set **M2a MEGAドリームex (Mega Dream ex)**, released 2025-11-28:

- `data-asia/M/M2a.ts` — set definition (193 official cards)
- `data-asia/M/M2a/001.ts` … `250.ts` — all 250 cards (193 regular + 57 secret rares: 20 AR, 19 SR, 17 SAR, 1 Mega Hyper Rare)

## Data sources

- **pokemon-card.com** (official database): Japanese names, flavor texts, National Dex numbers, official card count
- **limitlesstcg.com**: full Japanese card text, stages, weaknesses/resistances/retreat, rarities, illustrators, attack costs
- **Cardmarket**: product IDs as `thirdParty.cardmarket` on the variant objects (861245–861494; tcgplayer IDs not available to me)

## Notes

- Follows the file format and conventions of the M-era sets (#1728)
- 118 regular cards additionally exist as two mirror prints, modeled as `reverse` variants with their own cardmarket ids — `foil: "energy"` plus a ball foil per card (taken from the English print, `data/Mega Evolution/Ascended Heroes`)
- All 250 files type-check against `interfaces.d.ts` (`tsc --noEmit`)
