### PR TITLE
(data) Add Japanese SM set SM12a Tag All Stars

### DIFF
--- a/data-asia/SM/SM12a/001.ts
+++ b/data-asia/SM/SM12a/001.ts
@@ -1,0 +1,64 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "フェローチェ&マッシブーンGX",
+	},
+
+	illustrator: "Mitsuhiro Arita",
+	category: "Pokemon",
+	hp: 260,
+	types: ["Grass"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ジェットパンチ" },
+			damage: 30,
+			cost: ["Grass"],
+			effect: {
+				ja: "相手のベンチポケモン1匹にも、30ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+			},
+		},
+		{
+			name: { ja: "エレガントソール" },
+			damage: 190,
+			cost: ["Grass", "Grass", "Colorless"],
+			effect: {
+				ja: "次の自分の番、このポケモンの「エレガントソール」のダメージは「60」になる。",
+			},
+		},
+		{
+			name: { ja: "ビーストゲームGX" },
+			damage: 50,
+			cost: ["Grass"],
+			effect: {
+				ja: "このワザのダメージで、相手のポケモンがきぜつしたなら、サイドを1枚多くとる。追加でエネルギーが7個ついているなら、多くとる枚数は3枚になる。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 543366,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "C",
+	rarity: "Double rare",
+	dexId: [795, 794],
+
+	suffix: "TAG TEAM-GX",
+};
+
+export default card;

--- a/data-asia/SM/SM12a/002.ts
+++ b/data-asia/SM/SM12a/002.ts
@@ -1,0 +1,52 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "パラス",
+	},
+
+	illustrator: "Naoyo Kimura",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Grass"],
+
+	description: {
+		ja: "湿気が 足りないのか 栄養が 足りないのか アローラの パラスの キノコは 育ちが いまいち。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ひっかく" },
+			damage: 10,
+			cost: ["Colorless"],
+		},
+		{
+			name: { ja: "きりさく" },
+			damage: 20,
+			cost: ["Grass", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 543376,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "None",
+	dexId: [46],
+};
+
+export default card;

--- a/data-asia/SM/SM12a/003.ts
+++ b/data-asia/SM/SM12a/003.ts
@@ -1,0 +1,64 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "パラセクト",
+	},
+
+	illustrator: "Satoshi Shirai",
+	category: "Pokemon",
+	hp: 100,
+	types: ["Grass"],
+
+	description: {
+		ja: "ムシの 方は ほぼ 死んでいて 本体は 背中の キノコだ。 もげると もう 動かなくなる。",
+	},
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "パニックほうし" },
+			effect: {
+				ja: "このポケモンがいるかぎり、ポケモンチェックのたび、相手のこんらんのポケモンにダメカンを2個のせる。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ふしぎなこな" },
+			damage: 30,
+			cost: ["Grass", "Colorless"],
+			effect: {
+				ja: "コインを1回投げオモテなら、相手のバトルポケモンをこんらんにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 543381,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "パラス",
+	},
+
+	retreat: 2,
+	regulationMark: "C",
+	rarity: "None",
+	dexId: [47],
+};
+
+export default card;

--- a/data-asia/SM/SM12a/004.ts
+++ b/data-asia/SM/SM12a/004.ts
@@ -1,0 +1,47 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ハネッコ",
+	},
+
+	illustrator: "kawayoo",
+	category: "Pokemon",
+	hp: 40,
+	types: ["Grass"],
+
+	description: {
+		ja: "風に 流されて 漂う。 野山に ハネッコが 集まり出すと 春が 訪れると 言われている。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "たいあたり" },
+			damage: 20,
+			cost: ["Grass"],
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 543386,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "B",
+	rarity: "None",
+	dexId: [187],
+};
+
+export default card;

--- a/data-asia/SM/SM12a/005.ts
+++ b/data-asia/SM/SM12a/005.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ポポッコ",
+	},
+
+	illustrator: "Hitoshi Ariga",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Grass"],
+
+	description: {
+		ja: "太陽の 光を 浴びるため 花びらを 広げるだけでなく 近づこうと 空に 浮かんでしまう。",
+	},
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "そらのはなみち" },
+			effect: {
+				ja: "自分の番に1回使える。自分の山札から「ワタッコ」を1枚選ぶ。その後、このポケモンと、ついているすべてのカードを、ロストゾーンに置き、このポケモンがいた場所に、選んだ「ワタッコ」を出す。そして山札を切る。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "たいあたり" },
+			damage: 30,
+			cost: ["Grass"],
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 543391,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ハネッコ",
+	},
+
+	retreat: 0,
+	regulationMark: "B",
+	rarity: "None",
+	dexId: [188],
+};
+
+export default card;

--- a/data-asia/SM/SM12a/006.ts
+++ b/data-asia/SM/SM12a/006.ts
@@ -1,0 +1,54 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ワタッコ",
+	},
+
+	illustrator: "Masakazu Fukuda",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Grass"],
+
+	description: {
+		ja: "どんな 風に あおられても 綿毛を 自在に 操って 世界の 好きなところへ 行ける。",
+	},
+
+	stage: "Stage2",
+
+	attacks: [
+		{
+			name: { ja: "ロストマーチ" },
+			damage: "20×",
+			cost: ["Grass"],
+			effect: {
+				ja: "自分のロストゾーンにあるポケモン（♢（プリズムスター）をのぞく）の枚数x20ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 543396,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ポポッコ",
+	},
+
+	retreat: 0,
+	regulationMark: "B",
+	rarity: "None",
+	dexId: [189],
+};
+
+export default card;

--- a/data-asia/SM/SM12a/007.ts
+++ b/data-asia/SM/SM12a/007.ts
@@ -1,0 +1,59 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ツボツボ",
+	},
+
+	illustrator: "Masakazu Fukuda",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Grass"],
+
+	description: {
+		ja: "甲羅に 木の実を たくわえている。 襲われないように 岩の 下に こもって じっとしている。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "なましぼり" },
+			effect: {
+				ja: "自分の番に、このカードを手札からベンチに出したとき、1回使える。自分の山札にある基本エネルギーを3枚まで、トラッシュする。そして山札を切る。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "エナジードリンク" },
+			cost: ["Grass"],
+			effect: {
+				ja: "自分のトラッシュにある基本エネルギーを2枚、自分のポケモンに好きなようにつける。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 543416,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "B",
+	rarity: "None",
+	dexId: [213],
+};
+
+export default card;

--- a/data-asia/SM/SM12a/008.ts
+++ b/data-asia/SM/SM12a/008.ts
@@ -1,0 +1,49 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "キモリ",
+	},
+
+	illustrator: "Tomokazu Komiya",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Grass"],
+
+	description: {
+		ja: "足の 裏の 小さな トゲが 壁や 天井に 引っかかるので 逆さまに なっても 落ちないのだ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ともだちをさがす" },
+			cost: ["Grass"],
+			effect: {
+				ja: "自分の山札にある[草]ポケモンを1枚、相手に見せてから、手札に加える。そして山札を切る。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 543421,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "B",
+	rarity: "None",
+	dexId: [252],
+};
+
+export default card;

--- a/data-asia/SM/SM12a/009.ts
+++ b/data-asia/SM/SM12a/009.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ジュプトル",
+	},
+
+	illustrator: "Ayaka Yoshida",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Grass"],
+
+	description: {
+		ja: "密林に 生息する。 枝から 枝へ 飛び移りながら 移動して 獲物に 接近する。",
+	},
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "たいようのめぐみ" },
+			effect: {
+				ja: "自分の番に1回使える。自分の山札にある[草]ポケモンを1枚、相手に見せてから、手札に加える。そして山札を切る。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "スライスブレード" },
+			damage: 40,
+			cost: ["Grass", "Grass"],
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 543426,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "キモリ",
+	},
+
+	retreat: 2,
+	regulationMark: "B",
+	rarity: "None",
+	dexId: [253],
+};
+
+export default card;

--- a/data-asia/SM/SM12a/010.ts
+++ b/data-asia/SM/SM12a/010.ts
@@ -1,0 +1,67 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ジュカインGX",
+	},
+
+	illustrator: "Yoshinobu Saito",
+	category: "Pokemon",
+	hp: 230,
+	types: ["Grass"],
+
+	stage: "Stage2",
+
+	attacks: [
+		{
+			name: { ja: "おんそくぎり" },
+			damage: 60,
+			cost: ["Grass"],
+			effect: {
+				ja: "相手のバトルポケモンについている特殊エネルギーを、1個トラッシュする。",
+			},
+		},
+		{
+			name: { ja: "リーフサイクロン" },
+			damage: 130,
+			cost: ["Grass", "Grass"],
+			effect: {
+				ja: "このポケモンについている[草]エネルギーを1個、ベンチポケモンにつけ替える。",
+			},
+		},
+		{
+			name: { ja: "ジャングルヒールGX" },
+			cost: ["Grass"],
+			effect: {
+				ja: "[草]エネルギーがついている自分のポケモン全員のHPを、すべて回復する。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 543431,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ジュプトル",
+	},
+
+	retreat: 1,
+	regulationMark: "B",
+	rarity: "Double rare",
+	dexId: [254],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM12a/011.ts
+++ b/data-asia/SM/SM12a/011.ts
@@ -1,0 +1,50 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "シェイミ",
+	},
+
+	illustrator: "kawayoo",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Grass"],
+
+	description: {
+		ja: "グラシデアの花が 咲く 季節 感謝の 心を 届けるために 飛び立つと 言われている。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "フラワーストーム" },
+			damage: "30×",
+			cost: ["Grass", "Grass"],
+			effect: {
+				ja: "自分の場のポケモンについている基本エネルギーの数x30ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 543446,
+			},
+		},
+	],
+
+	retreat: 0,
+	regulationMark: "B",
+	rarity: "None",
+	dexId: [492],
+};
+
+export default card;

--- a/data-asia/SM/SM12a/012.ts
+++ b/data-asia/SM/SM12a/012.ts
@@ -1,0 +1,52 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アマカジ",
+	},
+
+	illustrator: "Mizue",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Grass"],
+
+	description: {
+		ja: "甘く 美味しそうな 匂いのせいで とりポケモンに 狙われるが あまり 賢くないので 気に していない。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "はねる" },
+			damage: 10,
+			cost: ["Grass"],
+		},
+		{
+			name: { ja: "かいてんアタック" },
+			damage: 20,
+			cost: ["Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 543451,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Rare Holo",
+	dexId: [761],
+};
+
+export default card;

--- a/data-asia/SM/SM12a/013.ts
+++ b/data-asia/SM/SM12a/013.ts
@@ -1,0 +1,59 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アママイコ",
+	},
+
+	illustrator: "Kagemaru Himeno",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Grass"],
+
+	description: {
+		ja: "硬いヘタで 守られているので とりポケモンとも 平気で 遊ぶ。 突かれまくるが 気に していない。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "おうふくビンタ" },
+			damage: "30×",
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "コインを2回投げ、オモテの数×30ダメージ。",
+			},
+		},
+		{
+			name: { ja: "リーフステップ" },
+			damage: 60,
+			cost: ["Grass", "Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 543456,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "アマカジ",
+	},
+
+	retreat: 2,
+	regulationMark: "C",
+	rarity: "None",
+	dexId: [762],
+};
+
+export default card;

--- a/data-asia/SM/SM12a/014.ts
+++ b/data-asia/SM/SM12a/014.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アマージョ",
+	},
+
+	illustrator: "kirisAki",
+	category: "Pokemon",
+	hp: 140,
+	types: ["Grass"],
+
+	description: {
+		ja: "美しい 蹴り技の 使い手。 キックボクシングの チャンピオンも 一撃で ノックアウトするぞ。",
+	},
+
+	stage: "Stage2",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "じょおうのほうび" },
+			effect: {
+				ja: "自分の番に1回使える。自分のトラッシュにある[草]エネルギーを1枚、バトルポケモンにつける。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "とびひざげり" },
+			damage: 90,
+			cost: ["Grass", "Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 543461,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "アママイコ",
+	},
+
+	retreat: 2,
+	regulationMark: "C",
+	rarity: "None",
+	dexId: [763],
+};
+
+export default card;

--- a/data-asia/SM/SM12a/015.ts
+++ b/data-asia/SM/SM12a/015.ts
@@ -1,0 +1,57 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "カミツルギ",
+	},
+
+	illustrator: "Shin Nagasawa",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Grass"],
+
+	description: {
+		ja: "紙の ように 薄い 身体から 研がれた 刀に 似た 鋭さを 感じる ウルトラビーストだ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ダイキリ" },
+			damage: "10+",
+			cost: ["Grass"],
+			effect: {
+				ja: "自分のサイドの残り枚数が4枚なら、120ダメージ追加。",
+			},
+		},
+		{
+			name: { ja: "みねうち" },
+			cost: ["Grass", "Colorless", "Colorless"],
+			effect: {
+				ja: "コインを1回投げオモテなら、相手のバトルポケモンの残りHPが「10」になるように、ダメカンをのせる。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 543466,
+			},
+		},
+	],
+
+	retreat: 0,
+	regulationMark: "C",
+	rarity: "None",
+	dexId: [798],
+};
+
+export default card;

--- a/data-asia/SM/SM12a/016.ts
+++ b/data-asia/SM/SM12a/016.ts
@@ -1,0 +1,64 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "レシラム&リザードンGX",
+	},
+
+	illustrator: "Mitsuhiro Arita",
+	category: "Pokemon",
+	hp: 270,
+	types: ["Fire"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "げきりん" },
+			damage: "30+",
+			cost: ["Fire", "Colorless"],
+			effect: {
+				ja: "このポケモンにのっているダメカンの数x10ダメージ追加。",
+			},
+		},
+		{
+			name: { ja: "フレアストライク" },
+			damage: 230,
+			cost: ["Fire", "Fire", "Fire", "Colorless"],
+			effect: {
+				ja: "次の自分の番、このポケモンは「フレアストライク」が使えない。",
+			},
+		},
+		{
+			name: { ja: "ダブルブレイズGX" },
+			damage: "200+",
+			cost: ["Fire", "Fire", "Fire"],
+			effect: {
+				ja: "追加で[炎]エネルギーが3個ついているなら、100ダメージ追加。その場合、このワザのダメージは、相手のバトルポケモンにかかっている効果を計算しない。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 543471,
+			},
+		},
+	],
+
+	retreat: 3,
+	regulationMark: "C",
+	rarity: "Double rare",
+	dexId: [643, 6],
+
+	suffix: "TAG TEAM-GX",
+};
+
+export default card;

--- a/data-asia/SM/SM12a/017.ts
+++ b/data-asia/SM/SM12a/017.ts
@@ -1,0 +1,49 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ロコン",
+	},
+
+	illustrator: "Ken Sugimori",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Fire"],
+
+	description: {
+		ja: "美しい シッポで 大人気。 ただし まめに ブラッシングしないと あっという間に 毛玉だらけになる。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "しっぽをふる" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "コインを1回投げオモテなら、次の相手の番、このワザを受けたポケモンは、ワザが使えない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 543476,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "None",
+	dexId: [37],
+};
+
+export default card;

--- a/data-asia/SM/SM12a/018.ts
+++ b/data-asia/SM/SM12a/018.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "キュウコン",
+	},
+
+	illustrator: "You Iribi",
+	category: "Pokemon",
+	hp: 100,
+	types: ["Fire"],
+
+	description: {
+		ja: "しつこく 執念深い 性質。 １度 恨むと 子孫を 含め １０００年間 祟り続ける。",
+	},
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "きゅうびのいざない" },
+			effect: {
+				ja: "自分の番に1回使える。自分の手札にある[炎]エネルギーを、2枚トラッシュする。その後、相手のベンチポケモンを1匹選び、バトルポケモンと入れ替える。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ほのおのしっぽ" },
+			damage: 90,
+			cost: ["Fire", "Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 543481,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ロコン",
+	},
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "None",
+	dexId: [38],
+};
+
+export default card;

--- a/data-asia/SM/SM12a/019.ts
+++ b/data-asia/SM/SM12a/019.ts
@@ -1,0 +1,64 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ブースター",
+	},
+
+	illustrator: "AKIRA EGAWA",
+	category: "Pokemon",
+	hp: 110,
+	types: ["Fire"],
+
+	description: {
+		ja: "大きく 空気を 吸い込むのは 攻撃の サイン。 １７００度の 炎が 襲ってくるぞ。",
+	},
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "パワーエール" },
+			effect: {
+				ja: "このポケモンがいるかぎり、自分の場の「イーブイ」から進化する「ポケモンGX」が使うワザの、相手のバトルポケモンへのダメージは「+30」される。この効果は、この特性を持つポケモンが何匹いても、重ならない",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "かえんほうしゃ" },
+			damage: 90,
+			cost: ["Fire", "Colorless", "Colorless"],
+			effect: {
+				ja: "のポケモンについているエネルギーを、1個トラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 543486,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "イーブイ",
+	},
+
+	retreat: 2,
+	regulationMark: "C",
+	rarity: "None",
+	dexId: [136],
+};
+
+export default card;

--- a/data-asia/SM/SM12a/020.ts
+++ b/data-asia/SM/SM12a/020.ts
@@ -1,0 +1,54 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ビクティニ",
+	},
+
+	illustrator: "Mizue",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Fire"],
+
+	description: {
+		ja: "勝利を もたらす ポケモン。 ビクティニを 連れた トレーナーは どんな 勝負にも 勝てるという。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ビクトリーサイン" },
+			cost: ["Fire"],
+			effect: {
+				ja: "自分の山札にある、それぞれちがうタイプの基本エネルギーを2枚まで、自分のポケモンに好きなようにつける。そして山札を切る。",
+			},
+		},
+		{
+			name: { ja: "ほのお" },
+			damage: 20,
+			cost: ["Fire"],
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 543491,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "None",
+	dexId: [494],
+};
+
+export default card;

--- a/data-asia/SM/SM12a/021.ts
+++ b/data-asia/SM/SM12a/021.ts
@@ -1,0 +1,50 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ビクティニ",
+	},
+
+	illustrator: "Shin Nagasawa",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Fire"],
+
+	description: {
+		ja: "ビクティニが 無限に 生み出す エネルギーを 分け与えてもらうと 全身に パワーが あふれ出す。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "インフィニティ" },
+			damage: "20×",
+			cost: ["Fire", "Fire"],
+			effect: {
+				ja: "自分のトラッシュにある基本エネルギーをすべて相手に見せ、その枚数x20ダメージ。その後、見せたエネルギーを山札にもどして切る。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 543496,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "B",
+	rarity: "Rare Holo",
+	dexId: [494],
+};
+
+export default card;

--- a/data-asia/SM/SM12a/022.ts
+++ b/data-asia/SM/SM12a/022.ts
@@ -1,0 +1,57 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ボルケニオン",
+	},
+
+	illustrator: "Hasuno",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Fire"],
+
+	description: {
+		ja: "水蒸気を 噴き出して 自分の 姿を 濃霧で 隠す。 人の 立ち入らない 山に 住むという。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "フレアスターター" },
+			cost: ["Fire"],
+			effect: {
+				ja: "自分の山札にある[炎]エネルギーを1枚、自分のポケモンにつける。そして山札を切る。後攻プレイヤーの最初の番に使ったなら、つけられる枚数は3枚までになり、自分のポケモンに好きなようにつけられる。",
+			},
+		},
+		{
+			name: { ja: "こうねつばくは" },
+			damage: "50+",
+			cost: ["Fire", "Fire"],
+			effect: {
+				ja: "自分の場に[炎]エネルギーが4個以上あるなら、60ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 543501,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "C",
+	rarity: "None",
+	dexId: [721],
+};
+
+export default card;

--- a/data-asia/SM/SM12a/023.ts
+++ b/data-asia/SM/SM12a/023.ts
@@ -1,0 +1,57 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ニャビー",
+	},
+
+	illustrator: "Atsuko Nishida",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Fire"],
+
+	description: {
+		ja: "しつこく 付きまとわれると 心を 開かなくなる。 懐いてきても 過剰な スキンシップは 禁物。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ねこびより" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札を1枚引く。その後、このポケモンをねむりにする。",
+			},
+		},
+		{
+			name: { ja: "かじりつく" },
+			damage: 60,
+			cost: ["Fire", "Colorless", "Colorless"],
+			effect: {
+				ja: "次の相手の番、このワザを受けたポケモンは、にげられない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 543506,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "None",
+	dexId: [725],
+};
+
+export default card;

--- a/data-asia/SM/SM12a/024.ts
+++ b/data-asia/SM/SM12a/024.ts
@@ -1,0 +1,54 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ニャヒート",
+	},
+
+	illustrator: "tetsuya koizumi",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Fire"],
+
+	description: {
+		ja: "なつくと トレーナーにも 甘えるが 力は 強く ツメも 鋭い。 全身 傷だらけに されるぞ。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "ほのおのキバ" },
+			damage: 20,
+			cost: ["Fire"],
+			effect: {
+				ja: "相手のバトルポケモンをやけどにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 543511,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ニャビー",
+	},
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "None",
+	dexId: [726],
+};
+
+export default card;

--- a/data-asia/SM/SM12a/025.ts
+++ b/data-asia/SM/SM12a/025.ts
@@ -1,0 +1,64 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ガオガエン",
+	},
+
+	illustrator: "Misa Tsutsui",
+	category: "Pokemon",
+	hp: 160,
+	types: ["Fire"],
+
+	description: {
+		ja: "荒っぽく わがままだが 格下を なぶることは つまらないので キライ。 格上の 相手に やる気を 出す。",
+	},
+
+	stage: "Stage2",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ストロングエール" },
+			effect: {
+				ja: "このポケモンがいるかぎり、自分のポケモンが使うワザの、相手のバトルポケモンへのダメージは「+30」される。この効果は、この特性を持つポケモンが何匹いても、重ならない。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "かえんほうしゃ" },
+			damage: 90,
+			cost: ["Fire", "Colorless"],
+			effect: {
+				ja: "このポケモンについているエネルギーを、1個トラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 543516,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ニャヒート",
+	},
+
+	retreat: 2,
+	regulationMark: "C",
+	rarity: "None",
+	dexId: [727],
+};
+
+export default card;

--- a/data-asia/SM/SM12a/026.ts
+++ b/data-asia/SM/SM12a/026.ts
@@ -1,0 +1,50 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヤトウモリ",
+	},
+
+	illustrator: "Yusuke Ohmura",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Fire"],
+
+	description: {
+		ja: "オスは メスの ほぼ いいなり。 獲った エサも ほとんど 貢ぐので 栄養不足で 進化 できない。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "くさをもやす" },
+			damage: 10,
+			cost: ["Fire"],
+			effect: {
+				ja: "相手のバトルポケモンについている[草]エネルギーを、1個トラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 543521,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "None",
+	dexId: [757],
+};
+
+export default card;

--- a/data-asia/SM/SM12a/027.ts
+++ b/data-asia/SM/SM12a/027.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "エンニュート",
+	},
+
+	illustrator: "hatachu",
+	category: "Pokemon",
+	hp: 100,
+	types: ["Fire"],
+
+	description: {
+		ja: "洞窟の 奥深くに 棲み フェロモンで メロメロに した ヤトウモリたちを 侍らせている。",
+	},
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "あぶりだす" },
+			effect: {
+				ja: "自分の番に1回使える。自分の手札にある[炎]エネルギーを1枚トラッシュする。その後、山札を3枚引く。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "かえん" },
+			damage: 60,
+			cost: ["Fire", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 543526,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ヤトウモリ",
+	},
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "None",
+	dexId: [758],
+};
+
+export default card;

--- a/data-asia/SM/SM12a/028.ts
+++ b/data-asia/SM/SM12a/028.ts
@@ -1,0 +1,62 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ズガドーンGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 180,
+	types: ["Fire"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "さくれつバーナー" },
+			cost: ["Fire"],
+			effect: {
+				ja: "相手のバトルポケモンをやけどとこんらんにする。",
+			},
+		},
+		{
+			name: { ja: "ビックリヘッド" },
+			damage: "50×",
+			cost: ["Fire", "Fire"],
+			effect: {
+				ja: "自分の場のポケモンについている[炎]エネルギーを好きなだけロストゾーンに置き、その枚数x50ダメージ。",
+			},
+		},
+		{
+			name: { ja: "バーストGX" },
+			cost: ["Fire"],
+			effect: {
+				ja: "自分のサイドを1枚トラッシュし、そのカードがエネルギーなら、自分のポケモンにつける。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 543531,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "B",
+	rarity: "Double rare",
+	dexId: [806],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM12a/029.ts
+++ b/data-asia/SM/SM12a/029.ts
@@ -1,0 +1,50 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ゼニガメ",
+	},
+
+	illustrator: "tetsuya koizumi",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Water"],
+
+	description: {
+		ja: "甲羅に 閉じこもり 身を 守る。 相手の すきを 見逃さず 水を 噴き出して 反撃する。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "あわ" },
+			damage: 10,
+			cost: ["Water"],
+			effect: {
+				ja: "コインを1回投げオモテなら、相手のバトルポケモンをマヒにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 543536,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "None",
+	dexId: [7],
+};
+
+export default card;

--- a/data-asia/SM/SM12a/030.ts
+++ b/data-asia/SM/SM12a/030.ts
@@ -1,0 +1,64 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "カメール",
+	},
+
+	illustrator: "Hiroki Asanuma",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Water"],
+
+	description: {
+		ja: "ポカンと 頭を たたかれるとき 甲羅に 引っこんで 避ける。でも ちょっとだけ 尻尾が 出ているよ。",
+	},
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "かたいこうら" },
+			effect: {
+				ja: "このポケモンが受けるワザのダメージは「-20」される。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "アクアスラッシュ" },
+			damage: 60,
+			cost: ["Water", "Water"],
+			effect: {
+				ja: "次の自分の番、このポケモンはワザが使えない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 543541,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ゼニガメ",
+	},
+
+	retreat: 2,
+	regulationMark: "C",
+	rarity: "None",
+	dexId: [8],
+};
+
+export default card;

--- a/data-asia/SM/SM12a/031.ts
+++ b/data-asia/SM/SM12a/031.ts
@@ -1,0 +1,64 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "カメックス",
+	},
+
+	illustrator: "Hitoshi Ariga",
+	category: "Pokemon",
+	hp: 160,
+	types: ["Water"],
+
+	description: {
+		ja: "体が 重たく のしかかって 相手を 気絶させる。 ピンチのときは 殻に 隠れる。",
+	},
+
+	stage: "Stage2",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "パワースコール" },
+			effect: {
+				ja: "自分の番に1回使える。自分の山札を上から6枚見て、その中にある[水]エネルギーを好きなだけ、自分のポケモンに好きなようにつける。残りのカードは山札にもどして切る。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ハイドロタックル" },
+			damage: 150,
+			cost: ["Water", "Water", "Water"],
+			effect: {
+				ja: "このポケモンにも30ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 543546,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "カメール",
+	},
+
+	retreat: 3,
+	regulationMark: "C",
+	rarity: "None",
+	dexId: [9],
+};
+
+export default card;

--- a/data-asia/SM/SM12a/032.ts
+++ b/data-asia/SM/SM12a/032.ts
@@ -1,0 +1,57 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アローラロコン",
+	},
+
+	illustrator: "Naoyo Kimura",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Water"],
+
+	description: {
+		ja: "暑いときには ６本の 尻尾で 氷の礫を 作り あたりに ばらまいて 身体を 冷やす。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ひみつのうらみち" },
+			effect: {
+				ja: "自分の場に[妖]ポケモンがいるなら、このポケモンのにげるためのエネルギーは、すべてなくなる。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "かじる" },
+			damage: 20,
+			cost: ["Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 543551,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "B",
+	rarity: "None",
+	dexId: [37],
+};
+
+export default card;

--- a/data-asia/SM/SM12a/033.ts
+++ b/data-asia/SM/SM12a/033.ts
@@ -1,0 +1,64 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "シャワーズ",
+	},
+
+	illustrator: "sui",
+	category: "Pokemon",
+	hp: 110,
+	types: ["Water"],
+
+	description: {
+		ja: "綺麗な 水辺が 主な 棲み処。 外敵に 襲われそうに なると 水に 飛び込み 姿を 隠す。",
+	},
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "バイタルエール" },
+			effect: {
+				ja: "このポケモンがいるかぎり、自分の場の「イーブイ」から進化する「ポケモンGX」全員の最大HPは、それぞれ「60」大きくなる。この効果は、この特性を持つポケモンが何匹いても、重ならない",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "キュアレイン" },
+			damage: 60,
+			cost: ["Water", "Colorless", "Colorless"],
+			effect: {
+				ja: "分のポケモン全員のHPを、それぞれ「30」回復する。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 543556,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "イーブイ",
+	},
+
+	retreat: 2,
+	regulationMark: "C",
+	rarity: "None",
+	dexId: [134],
+};
+
+export default card;

--- a/data-asia/SM/SM12a/034.ts
+++ b/data-asia/SM/SM12a/034.ts
@@ -1,0 +1,60 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "フリーザー",
+	},
+
+	illustrator: "Yusuke Ohmura",
+	category: "Pokemon",
+	hp: 110,
+	types: ["Water"],
+
+	description: {
+		ja: "伝説の とりポケモン。 空気中の 水分を 凍らせ 吹雪を 作り出すことが できる。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ブリザードヴェール" },
+			effect: {
+				ja: "このポケモンがバトル場にいるかぎり、自分のベンチの[水]ポケモン全員は、相手が手札からサポートを出して使ったとき、その効果を受けない。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "コールドサイクロン" },
+			damage: 70,
+			cost: ["Water", "Water"],
+			effect: {
+				ja: "このポケモンについている[水]エネルギーを2個、ベンチポケモン1匹につけ替える。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 543561,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "C",
+	rarity: "None",
+	dexId: [144],
+};
+
+export default card;

--- a/data-asia/SM/SM12a/035.ts
+++ b/data-asia/SM/SM12a/035.ts
@@ -1,0 +1,58 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ホワイトキュレム",
+	},
+
+	illustrator: "Hitoshi Ariga",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Water"],
+
+	description: {
+		ja: "強力な 冷凍エネルギーを 体内で 作り出すが 漏れ出した 冷気で 体が 凍っている。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "フィールドクラッシュ" },
+			damage: 30,
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "場に出ている相手のスタジアムをトラッシュする。",
+			},
+		},
+		{
+			name: { ja: "いてつくほのお" },
+			damage: "80+",
+			cost: ["Water", "Water", "Colorless"],
+			effect: {
+				ja: "このポケモンに[炎]エネルギーがついているなら、80ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 543566,
+			},
+		},
+	],
+
+	retreat: 3,
+	regulationMark: "B",
+	rarity: "None",
+	dexId: [646],
+};
+
+export default card;

--- a/data-asia/SM/SM12a/036.ts
+++ b/data-asia/SM/SM12a/036.ts
@@ -1,0 +1,66 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ケルディオGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 170,
+	types: ["Water"],
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ホーリーハート" },
+			effect: {
+				ja: "このポケモンは、相手の「ポケモンGX・EX」からワザのダメージや効果を受けない。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ソニックエッジ" },
+			damage: 110,
+			cost: ["Water", "Water", "Colorless"],
+			effect: {
+				ja: "このワザのダメージは、相手のバトルポケモンにかかっている効果を計算しない。",
+			},
+		},
+		{
+			name: { ja: "かくごのつるぎGX" },
+			damage: "50×",
+			cost: ["Water", "Water", "Colorless"],
+			effect: {
+				ja: "相手のベンチポケモンの数×50ダメージ。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 543571,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "C",
+	rarity: "Double rare",
+	dexId: [647],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM12a/037.ts
+++ b/data-asia/SM/SM12a/037.ts
@@ -1,0 +1,60 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ボルケニオン",
+	},
+
+	illustrator: "Naoki Saito",
+	category: "Pokemon",
+	hp: 160,
+	types: ["Water"],
+
+	description: {
+		ja: "背中の アームから 体内の 水蒸気を 噴射する。 山 ひとつ 吹き飛ばす 威力。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ジェットほうすい" },
+			effect: {
+				ja: "自分の番に1回使える。自分の手札にある[水]エネルギーを、1枚トラッシュする。その後、相手のバトルポケモンをベンチポケモンと入れ替える。［バトル場に出すポケモンは相手が選ぶ。］",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "サウナボム" },
+			damage: 100,
+			cost: ["Water", "Water", "Water"],
+			effect: {
+				ja: "相手のベンチポケモン全員にも、それぞれ20ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 543576,
+			},
+		},
+	],
+
+	retreat: 3,
+	regulationMark: "B",
+	rarity: "Rare Holo",
+	dexId: [721],
+};
+
+export default card;

--- a/data-asia/SM/SM12a/038.ts
+++ b/data-asia/SM/SM12a/038.ts
@@ -1,0 +1,57 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヨワシ",
+	},
+
+	illustrator: "Kouki Saitou",
+	category: "Pokemon",
+	hp: 30,
+	types: ["Water"],
+
+	description: {
+		ja: "とても 弱く とても 美味しいので 常に 誰からも 狙われているが いじめていると ひどい目に あうぞ。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "げんちしゅうごう" },
+			effect: {
+				ja: "このポケモンがいるかぎり、自分の「ヨワシGX」全員は、最大HPが「20」大きくなり、使うワザの、相手のバトルポケモンへのダメージは「+20」される。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "みずでっぽう" },
+			damage: 20,
+			cost: ["Water"],
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 543586,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "B",
+	rarity: "None",
+	dexId: [746],
+};
+
+export default card;

--- a/data-asia/SM/SM12a/039.ts
+++ b/data-asia/SM/SM12a/039.ts
@@ -1,0 +1,55 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヨワシGX",
+	},
+
+	illustrator: "sadaji",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Water"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ぎょぐんストーム" },
+			damage: "20×",
+			cost: ["Water", "Colorless"],
+			effect: {
+				ja: "分の場の「ヨワシ（GXをふくむ）」の数×20ダメージ。",
+			},
+		},
+		{
+			name: { ja: "たいりょうGX" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "分の山札を上から12枚見て、その中にあるたねポケモンを好きなだけ、ベンチに出す。残りのカードは山札にもどして切る。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 543616,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Double rare",
+	dexId: [746],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM12a/040.ts
+++ b/data-asia/SM/SM12a/040.ts
@@ -1,0 +1,55 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "カプ・レヒレ",
+	},
+
+	illustrator: "Hasuno",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Water"],
+
+	description: {
+		ja: "深い 霧の 奥に 棲んでいると 恐れ 敬われてきた。 水を 操る ポニの 守り神だ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ひれカッター" },
+			damage: 20,
+			cost: ["Water"],
+		},
+		{
+			name: { ja: "ネイチャーウェーブ" },
+			damage: 100,
+			cost: ["Water", "Water", "Colorless"],
+			effect: {
+				ja: "このワザは、相手の場に「ウルトラビースト」がいるなら、【無】エネルギー1個で使える。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 543636,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "None",
+	dexId: [788],
+};
+
+export default card;

--- a/data-asia/SM/SM12a/041.ts
+++ b/data-asia/SM/SM12a/041.ts
@@ -1,0 +1,56 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ピカチュウ&ゼクロムGX",
+	},
+
+	illustrator: "Mitsuhiro Arita",
+	category: "Pokemon",
+	hp: 240,
+	types: ["Lightning"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "フルドライブ" },
+			damage: 150,
+			cost: ["Lightning", "Lightning", "Lightning"],
+			effect: {
+				ja: "自分の山札にある[雷]エネルギーを3枚まで、自分のポケモン1匹につける。そして山札を切る。",
+			},
+		},
+		{
+			name: { ja: "タッグボルトGX" },
+			damage: 200,
+			cost: ["Lightning", "Lightning", "Lightning"],
+			effect: {
+				ja: "追加で[雷]エネルギーが3個ついているなら、相手のベンチポケモン1匹にも、170ダメージ。［ベンチは弱点・抵抗力を計算しない。］［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Metal", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 543676,
+			},
+		},
+	],
+
+	retreat: 3,
+	regulationMark: "C",
+	rarity: "Double rare",
+	dexId: [25, 644],
+
+	suffix: "TAG TEAM-GX",
+};
+
+export default card;

--- a/data-asia/SM/SM12a/042.ts
+++ b/data-asia/SM/SM12a/042.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "サンダース",
+	},
+
+	illustrator: "Uta",
+	category: "Pokemon",
+	hp: 100,
+	types: ["Lightning"],
+
+	description: {
+		ja: "肺の 中に 電気を 生み出す 器官が ある。 吐息に 混ざって 電気の 音が バチバチ聞こえる。",
+	},
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "スピードエール" },
+			effect: {
+				ja: "このポケモンがいるかぎり、自分の場の「イーブイ」から進化する「ポケモンGX」が使うワザに必要なエネルギーは、それぞれ【無】エネルギー1個ぶん少なくなる。この効果は、この特性を持つポケモンが何匹いても、重ならない",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ヘッドボルト" },
+			damage: 70,
+			cost: ["Lightning", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Metal", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 543681,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "イーブイ",
+	},
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "None",
+	dexId: [135],
+};
+
+export default card;

--- a/data-asia/SM/SM12a/043.ts
+++ b/data-asia/SM/SM12a/043.ts
@@ -1,0 +1,50 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "サンダー",
+	},
+
+	illustrator: "Misa Tsutsui",
+	category: "Pokemon",
+	hp: 110,
+	types: ["Lightning"],
+
+	description: {
+		ja: "雷雲の 中に いると 言われる 伝説の ポケモン。 雷を 自在に 操る。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "アサルトサンダー" },
+			damage: "10+",
+			cost: ["Lightning"],
+			effect: {
+				ja: "この番、このポケモンがベンチからバトル場に出ていたなら、70ダメージ追加。このワザのダメージは弱点を計算しない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 543686,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "B",
+	rarity: "None",
+	dexId: [145],
+};
+
+export default card;

--- a/data-asia/SM/SM12a/044.ts
+++ b/data-asia/SM/SM12a/044.ts
@@ -1,0 +1,50 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ライコウ",
+	},
+
+	illustrator: "nagimiso",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Lightning"],
+
+	description: {
+		ja: "体内で 渦巻く 力を 電撃として 出しながら 大地を 駆け巡る 荒々しい ポケモン。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ロストボルテージ" },
+			damage: "30+",
+			cost: ["Lightning", "Colorless"],
+			effect: {
+				ja: "自分のロストゾーンに[雷]エネルギーがあるなら、90ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Metal", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 543691,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "B",
+	rarity: "None",
+	dexId: [243],
+};
+
+export default card;

--- a/data-asia/SM/SM12a/045.ts
+++ b/data-asia/SM/SM12a/045.ts
@@ -1,0 +1,52 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "シママ",
+	},
+
+	illustrator: "Miki Tanaka",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Lightning"],
+
+	description: {
+		ja: "放電すると たてがみが 光る。 たてがみが 輝く 回数や リズムで 仲間と 会話している。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "はねまわる" },
+			damage: 10,
+			cost: ["Lightning"],
+		},
+		{
+			name: { ja: "エレキック" },
+			damage: 20,
+			cost: ["Lightning", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Metal", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 543696,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "B",
+	rarity: "None",
+	dexId: [522],
+};
+
+export default card;

--- a/data-asia/SM/SM12a/046.ts
+++ b/data-asia/SM/SM12a/046.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ゼブライカ",
+	},
+
+	illustrator: "Misa Tsutsui",
+	category: "Pokemon",
+	hp: 110,
+	types: ["Lightning"],
+
+	description: {
+		ja: "稲妻のような 瞬発力。 ゼブライカが 全速力で 走ると 雷鳴が 響きわたる。",
+	},
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "はやがけ" },
+			effect: {
+				ja: "自分の番に1回使える。自分の手札をすべてトラッシュし、山札を4枚引く。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ヘッドボルト" },
+			damage: 60,
+			cost: ["Lightning", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Metal", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 543701,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "シママ",
+	},
+
+	retreat: 1,
+	regulationMark: "B",
+	rarity: "None",
+	dexId: [523],
+};
+
+export default card;

--- a/data-asia/SM/SM12a/047.ts
+++ b/data-asia/SM/SM12a/047.ts
@@ -1,0 +1,58 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "マッギョ",
+	},
+
+	illustrator: "sowsow",
+	category: "Pokemon",
+	hp: 110,
+	types: ["Lightning"],
+
+	description: {
+		ja: "皮膚が 硬いので 相撲取りに 踏まれても 平気。 電気を 流すとき 笑い顔に なる。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "らくらい" },
+			damage: 30,
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分のベンチポケモン1匹にも、10ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+			},
+		},
+		{
+			name: { ja: "ビリビリトラップ" },
+			damage: "30×",
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "自分の場のダメカンがのっているポケモンの数x30ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Metal", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 543706,
+			},
+		},
+	],
+
+	retreat: 3,
+	regulationMark: "C",
+	rarity: "None",
+	dexId: [618],
+};
+
+export default card;

--- a/data-asia/SM/SM12a/048.ts
+++ b/data-asia/SM/SM12a/048.ts
@@ -1,0 +1,63 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "デデンネGX",
+	},
+
+	illustrator: "PLANETA Igarashi",
+	category: "Pokemon",
+	hp: 160,
+	types: ["Lightning"],
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "デデチェンジ" },
+			effect: {
+				ja: "自分の番に、このカードを手札からベンチに出したとき、1回使える。自分の手札をすべてトラッシュし、山札を6枚引く。この番、すでに別の「デデチェンジ」を使っていたなら、この特性は使えない。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "バチバチ" },
+			damage: 50,
+			cost: ["Lightning", "Colorless"],
+		},
+		{
+			name: { ja: "ビリリターンGX" },
+			damage: 50,
+			cost: ["Lightning", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをマヒにする。このポケモンと、ついているすべてのカードを、手札にもどす。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Metal", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 543716,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Double rare",
+	dexId: [702],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM12a/049.ts
+++ b/data-asia/SM/SM12a/049.ts
@@ -1,0 +1,57 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "カプ・コケコ",
+	},
+
+	illustrator: "Kouki Saitou",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Lightning"],
+
+	description: {
+		ja: "目にも 止まらぬ スピードで 敵を かく乱する。 ひどく 怒りっぽいが なんで 怒ったかは すぐ 忘れる。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "せんじんのまい" },
+			effect: {
+				ja: "このポケモンがベンチにいるなら、自分の番に1回使える。自分のベンチポケモン2匹に、トラッシュにある[雷]エネルギーを1枚ずつつける。その後、このカードをロストゾーンに置く。（ついているカードは、すべてトラッシュする。）",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "マッハボルト" },
+			damage: 120,
+			cost: ["Lightning", "Lightning", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Metal", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 543731,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "B",
+	rarity: "Rare Holo",
+	dexId: [785],
+};
+
+export default card;

--- a/data-asia/SM/SM12a/050.ts
+++ b/data-asia/SM/SM12a/050.ts
@@ -1,0 +1,58 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ゼラオラ",
+	},
+
+	illustrator: "kawayoo",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Lightning"],
+
+	description: {
+		ja: "両手足の ツメを 帯電させ 相手を 八つ裂き。 かわされても 飛び散る 電撃で 感電させる。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "クラッシュクロー" },
+			damage: 20,
+			cost: ["Lightning"],
+			effect: {
+				ja: "相手のバトルポケモンについている特殊エネルギーを、1個トラッシュする。",
+			},
+		},
+		{
+			name: { ja: "ほうでん" },
+			damage: "50×",
+			cost: ["Lightning", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンについている[雷]エネルギーをすべてトラッシュし、その枚数x50ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Metal", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 543736,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "None",
+	dexId: [807],
+};
+
+export default card;

--- a/data-asia/SM/SM12a/051.ts
+++ b/data-asia/SM/SM12a/051.ts
@@ -1,0 +1,65 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ゼラオラGX",
+	},
+
+	illustrator: "PLANETA Otani",
+	category: "Pokemon",
+	hp: 190,
+	types: ["Lightning"],
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "じんらいゾーン" },
+			effect: {
+				ja: "このポケモンがいるかぎり、[雷]エネルギーがついている自分のポケモン全員のにげるためのエネルギーは、すべてなくなる。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "プラズマフィスト" },
+			damage: 160,
+			cost: ["Lightning", "Lightning", "Colorless"],
+			effect: {
+				ja: "次の自分の番、このポケモンはワザが使えない。",
+			},
+		},
+		{
+			name: { ja: "フルボルテージGX" },
+			cost: ["Lightning"],
+			effect: {
+				ja: "自分のトラッシュにある基本エネルギーを5枚、自分のポケモンに好きなようにつける。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Metal", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 543741,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "B",
+	rarity: "Double rare",
+	dexId: [807],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM12a/052.ts
+++ b/data-asia/SM/SM12a/052.ts
@@ -1,0 +1,58 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ミュウツー&ミュウGX",
+	},
+
+	illustrator: "Mitsuhiro Arita",
+	category: "Pokemon",
+	hp: 270,
+	types: ["Psychic"],
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "パーフェクション" },
+			effect: {
+				ja: "このポケモンは、自分のベンチまたはトラッシュにある「ポケモンGX・EX」が持っているワザを、すべて使える。［ワザを使うためのエネルギーは必要。］",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "Attack 1" },
+			damage: 200,
+			cost: ["Psychic", "Psychic", "Colorless"],
+			effect: {
+				ja: "追加でエネルギーが1個ついているなら、自分のポケモン全員のHPを、すべて回復する。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 543796,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "C",
+	rarity: "Double rare",
+	dexId: [150, 151],
+
+	suffix: "TAG TEAM-GX",
+};
+
+export default card;

--- a/data-asia/SM/SM12a/053.ts
+++ b/data-asia/SM/SM12a/053.ts
@@ -1,0 +1,55 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "オーロット&ヨノワールGX",
+	},
+
+	illustrator: "Mitsuhiro Arita",
+	category: "Pokemon",
+	hp: 270,
+	types: ["Psychic"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ナイトウォッチャー" },
+			damage: 150,
+			cost: ["Psychic", "Psychic", "Psychic"],
+			effect: {
+				ja: "手の手札からオモテを見ないで2枚選び、そのカードのオモテを見てから、相手の山札にもどして切る。",
+			},
+		},
+		{
+			name: { ja: "ペイルムーンGX" },
+			cost: ["Psychic", "Colorless"],
+			effect: {
+				ja: "の相手の番の終わりに、このワザを受けたポケモンはきぜつする。追加で[超]エネルギーが1個ついているなら、相手のバトルポケモンについているエネルギーを、すべてトラッシュする。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 543806,
+			},
+		},
+	],
+
+	retreat: 3,
+	regulationMark: "C",
+	rarity: "Double rare",
+	dexId: [709, 477],
+
+	suffix: "TAG TEAM-GX",
+};
+
+export default card;

--- a/data-asia/SM/SM12a/054.ts
+++ b/data-asia/SM/SM12a/054.ts
@@ -1,0 +1,60 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ミュウツー",
+	},
+
+	illustrator: "Shin Nagasawa",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Psychic"],
+
+	description: {
+		ja: "１人の 科学者が 何年も 恐ろしい 遺伝子 研究を 続けた 結果 誕生した。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "マインドリポート" },
+			effect: {
+				ja: "自分の番に、このカードを手札からベンチに出したとき、1回使える。自分のトラッシュにあるサポートを1枚、相手に見せてから、山札の上にもどす。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "サイコショック" },
+			damage: 70,
+			cost: ["Psychic", "Colorless", "Colorless"],
+			effect: {
+				ja: "このワザのダメージは、相手のバトルポケモンにかかっている効果を計算しない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 543811,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "C",
+	rarity: "None",
+	dexId: [150],
+};
+
+export default card;

--- a/data-asia/SM/SM12a/055.ts
+++ b/data-asia/SM/SM12a/055.ts
@@ -1,0 +1,59 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ミュウ",
+	},
+
+	illustrator: "sui",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Psychic"],
+
+	description: {
+		ja: "あらゆる 技を 使うため ポケモンの 先祖と 考える 学者が たくさん いる。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ベンチバリア" },
+			effect: {
+				ja: "このポケモンがいるかぎり、自分のベンチポケモン全員は、相手のワザのダメージを受けない。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "サイコパワー" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "ダメカン3個を、相手のポケモンに好きなようにのせる。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 543816,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "None",
+	dexId: [151],
+};
+
+export default card;

--- a/data-asia/SM/SM12a/056.ts
+++ b/data-asia/SM/SM12a/056.ts
@@ -1,0 +1,50 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ネイティ",
+	},
+
+	illustrator: "Anesaki Dynamic",
+	category: "Pokemon",
+	hp: 40,
+	types: ["Psychic"],
+
+	description: {
+		ja: "普段は 地上で エサを 探すが ごくたまに 木の枝に 飛び乗って 木の芽を ついばんだりする。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ロストマーチ" },
+			damage: "20×",
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "自分のロストゾーンにあるポケモン（♢（プリズムスター）をのぞく）の枚数x20ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 543821,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "B",
+	rarity: "None",
+	dexId: [177],
+};
+
+export default card;

--- a/data-asia/SM/SM12a/057.ts
+++ b/data-asia/SM/SM12a/057.ts
@@ -1,0 +1,60 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ギラティナ",
+	},
+
+	illustrator: "Shin Nagasawa",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Psychic"],
+
+	description: {
+		ja: "暴れ者 ゆえ 追い出されたが 破れた世界と 言われる 場所で 静かに 元の世界を 見ていた。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "やぶれたとびら" },
+			effect: {
+				ja: "このカードがトラッシュにあるなら、自分の番に1回使える。このカードをベンチに出す。その後、相手のベンチポケモン2匹に、それぞれダメカンを1個のせる。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "シャドーインパクト" },
+			damage: 130,
+			cost: ["Psychic", "Psychic", "Colorless"],
+			effect: {
+				ja: "自分のポケモン1匹に、ダメカンを4個のせる。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 543826,
+			},
+		},
+	],
+
+	retreat: 3,
+	regulationMark: "B",
+	rarity: "None",
+	dexId: [487],
+};
+
+export default card;

--- a/data-asia/SM/SM12a/058.ts
+++ b/data-asia/SM/SM12a/058.ts
@@ -1,0 +1,60 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ギラティナ",
+	},
+
+	illustrator: "Masakazu Fukuda",
+	category: "Pokemon",
+	hp: 160,
+	types: ["Psychic"],
+
+	description: {
+		ja: "暴れ者 ゆえ 追い出されたが 破れた世界と 言われる 場所で 静かに 元の世界を 見ていた。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "カオティックスター" },
+			effect: {
+				ja: "自分の番に、このカードを手札からベンチに出したとき、1回使える。自分の手札にある[超]エネルギーを2枚、このポケモンにつける。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "クライシスダイブ" },
+			damage: 160,
+			cost: ["Psychic", "Psychic", "Psychic", "Psychic"],
+			effect: {
+				ja: "このポケモンについているエネルギーを、2個トラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 543831,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "B",
+	rarity: "Rare Holo",
+	dexId: [487],
+};
+
+export default card;

--- a/data-asia/SM/SM12a/059.ts
+++ b/data-asia/SM/SM12a/059.ts
@@ -1,0 +1,56 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ニャスパー",
+	},
+
+	illustrator: "HYOGONOSUKE",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Psychic"],
+
+	description: {
+		ja: "強力な サイコパワーが 漏れ出さないように 放出する 器官を 耳で ふさいでいるのだ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ねこびより" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札を1枚引く。その後、このポケモンをねむりにする。",
+			},
+		},
+		{
+			name: { ja: "イヤーキネシス" },
+			cost: ["Psychic", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のベンチポケモン1匹に、そのポケモンにのっているダメカンの数x20ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 543836,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "None",
+	dexId: [677],
+};
+
+export default card;

--- a/data-asia/SM/SM12a/060.ts
+++ b/data-asia/SM/SM12a/060.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ニャオニクス",
+	},
+
+	illustrator: "Saya Tsuruta",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Psychic"],
+
+	description: {
+		ja: "危険が 迫ると 耳を 持ち上げ １０トン トラックを ひねりつぶす サイコパワーを 解放する。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "ねこびより" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札を3枚引く。その後、このポケモンをねむりにする。",
+			},
+		},
+		{
+			name: { ja: "まどわすひとみ" },
+			damage: 70,
+			cost: ["Psychic", "Colorless", "Colorless"],
+			effect: {
+				ja: "次の自分の番の終わりまで、このワザを受けたポケモンの弱点は[超]タイプになる。［弱点は「x2」でダメージ計算をする。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 543841,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ニャスパー",
+	},
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "None",
+	dexId: [678],
+};
+
+export default card;

--- a/data-asia/SM/SM12a/061.ts
+++ b/data-asia/SM/SM12a/061.ts
@@ -1,0 +1,49 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "マーイーカ",
+	},
+
+	illustrator: "sowsow",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Psychic"],
+
+	description: {
+		ja: "光の 点滅で 襲ってきた 敵の 戦意を なくしてしまう。 その すきに 姿を くらますのだ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "さいみんじゅつ" },
+			cost: ["Psychic"],
+			effect: {
+				ja: "相手のバトルポケモンをねむりにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 543846,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "B",
+	rarity: "None",
+	dexId: [686],
+};
+
+export default card;

--- a/data-asia/SM/SM12a/062.ts
+++ b/data-asia/SM/SM12a/062.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "カラマネロ",
+	},
+
+	illustrator: "You Iribi",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Psychic"],
+
+	description: {
+		ja: "催眠術で おびき寄せて 頭の 触手で 絡め取り 消化液を 浴びせて しとめる。",
+	},
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "サイコリチャージ" },
+			effect: {
+				ja: "自分の番に1回使える。自分のトラッシュにある[超]エネルギーを1枚、ベンチポケモンにつける。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ねんどうだん" },
+			damage: 60,
+			cost: ["Psychic", "Psychic", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 543851,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "マーイーカ",
+	},
+
+	retreat: 2,
+	regulationMark: "B",
+	rarity: "None",
+	dexId: [687],
+};
+
+export default card;

--- a/data-asia/SM/SM12a/063.ts
+++ b/data-asia/SM/SM12a/063.ts
@@ -1,0 +1,60 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ミミッキュ",
+	},
+
+	illustrator: "Yuka Morii",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Psychic"],
+
+	description: {
+		ja: "大人しい 寂しがり屋 だけど ボロ切れの 中身を 見ようとすると 激しく 嫌がり 抵抗する。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "シャドーボックス" },
+			effect: {
+				ja: "このポケモンがいるかぎり、おたがいの場のダメカンがのっている「ポケモンGX」の特性は、すべてなくなる",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "しっぽでまどわす" },
+			damage: 20,
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "インを1回投げオモテなら、相手のバトルポケモンをこんらんにする。",
+			},
+		},
+	],
+
+	weaknesses: [],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 543856,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "None",
+	dexId: [778],
+};
+
+export default card;

--- a/data-asia/SM/SM12a/064.ts
+++ b/data-asia/SM/SM12a/064.ts
@@ -1,0 +1,60 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "マーシャドー",
+	},
+
+	illustrator: "chibi",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Psychic"],
+
+	description: {
+		ja: "相手の 影に 潜って 動きや 力を 真似る。 真似ているうちに 本物 よりも 強くなるぞ。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "リセットホール" },
+			effect: {
+				ja: "このポケモンがベンチにいるなら、自分の番に1回使える。場に出ているスタジアムをトラッシュする。その後、このポケモンと、ついているすべてのカードを、トラッシュする。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "レッドナックル" },
+			damage: "10+",
+			cost: ["Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンが「ウルトラビースト」なら、60ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 543861,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "None",
+	dexId: [802],
+};
+
+export default card;

--- a/data-asia/SM/SM12a/065.ts
+++ b/data-asia/SM/SM12a/065.ts
@@ -1,0 +1,54 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ベベノム",
+	},
+
+	illustrator: "Hitoshi Ariga",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Psychic"],
+
+	description: {
+		ja: "異世界に おいては 旅立ちの パートナーに 選ばれるほど 親しまれている ウルトラビースト。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "アイオープナー" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "ウラになっている自分のサイドのオモテをすべて見てから、もとにもどす。",
+			},
+		},
+		{
+			name: { ja: "つつく" },
+			damage: 20,
+			cost: ["Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 543866,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "B",
+	rarity: "None",
+	dexId: [803],
+};
+
+export default card;

--- a/data-asia/SM/SM12a/066.ts
+++ b/data-asia/SM/SM12a/066.ts
@@ -1,0 +1,64 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アーゴヨン",
+	},
+
+	illustrator: "Shin Nagasawa",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Psychic"],
+
+	description: {
+		ja: "体内に 数百リットルの 毒液を ためている。 ＵＢと 呼ばれる 生物の 一種。",
+	},
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "チャージアップ" },
+			effect: {
+				ja: "自分の番に1回使える。自分のトラッシュにある基本エネルギーを1枚、このポケモンにつける。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ターニングポイント" },
+			damage: "80+",
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "自分のサイドの残り枚数が3枚なら、80ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 543876,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ベベノム",
+	},
+
+	retreat: 1,
+	regulationMark: "B",
+	rarity: "None",
+	dexId: [804],
+};
+
+export default card;

--- a/data-asia/SM/SM12a/067.ts
+++ b/data-asia/SM/SM12a/067.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "マーシャドー&カイリキーGX",
+	},
+
+	illustrator: "Mitsuhiro Arita",
+	category: "Pokemon",
+	hp: 270,
+	types: ["Fighting"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "リベンジ" },
+			damage: "30+",
+			cost: ["Fighting", "Colorless"],
+			effect: {
+				ja: "前の相手の番に、ワザのダメージで、自分のポケモンがきぜつしていたなら、90ダメージ追加。",
+			},
+		},
+		{
+			name: { ja: "ひゃくれつインパクト" },
+			damage: 160,
+			cost: ["Fighting", "Fighting", "Colorless"],
+		},
+		{
+			name: { ja: "ごうけつのきわみGX" },
+			damage: 200,
+			cost: ["Fighting", "Fighting", "Colorless"],
+			effect: {
+				ja: "追加でエネルギーが1個ついているなら、次の相手の番、このポケモンがワザのダメージを受けてきぜつするとき、このポケモンはきぜつせず、残りHPが「10」の状態で場に残る。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 543891,
+			},
+		},
+	],
+
+	retreat: 3,
+	regulationMark: "C",
+	rarity: "Double rare",
+	dexId: [802, 68],
+
+	suffix: "TAG TEAM-GX",
+};
+
+export default card;

--- a/data-asia/SM/SM12a/068.ts
+++ b/data-asia/SM/SM12a/068.ts
@@ -1,0 +1,49 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "バルキー",
+	},
+
+	illustrator: "Mina Nakai",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Fighting"],
+
+	description: {
+		ja: "いつでも 元気いっぱい。 強くなるため 負けても 負けても 相手に 立ち向かっていく。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "わんぱくキック" },
+			effect: {
+				ja: "自分の番に1回使えて、使ったなら、自分の番は終わる。コインを1回投げオモテなら、相手のポケモン1匹に、ダメカンを3個のせる。",
+			},
+		},
+	],
+
+	weaknesses: [],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 543901,
+			},
+		},
+	],
+
+	retreat: 0,
+	regulationMark: "C",
+	rarity: "None",
+	dexId: [236],
+};
+
+export default card;

--- a/data-asia/SM/SM12a/069.ts
+++ b/data-asia/SM/SM12a/069.ts
@@ -1,0 +1,57 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ランドロス",
+	},
+
+	illustrator: "Hasuno",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Fighting"],
+
+	description: {
+		ja: "ランドロスが 訪れる 土地は 作物が たくさん 実るため 畑の神様 と 言われている。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ちょくげきだん" },
+			cost: ["Fighting"],
+			effect: {
+				ja: "相手のポケモン1匹に、30ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+			},
+		},
+		{
+			name: { ja: "パワーサイクロン" },
+			damage: 60,
+			cost: ["Fighting", "Colorless"],
+			effect: {
+				ja: "このポケモンについているエネルギーを1個、ベンチポケモンにつけ替える。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 543911,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "None",
+	dexId: [645],
+};
+
+export default card;

--- a/data-asia/SM/SM12a/070.ts
+++ b/data-asia/SM/SM12a/070.ts
@@ -1,0 +1,60 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ディアンシー",
+	},
+
+	illustrator: "kawayoo",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Fighting"],
+
+	description: {
+		ja: "両手の すきまで 空気中の 炭素を 圧縮して たくさんの ダイヤを 一瞬で 生み出す。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "プリンセスエール" },
+			effect: {
+				ja: "このポケモンがベンチにいるかぎり、自分の[闘]ポケモンが使うワザの、相手のバトルポケモンへのダメージは「+20」される。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ダイヤレイン" },
+			damage: 90,
+			cost: ["Fighting", "Fighting", "Fighting"],
+			effect: {
+				ja: "自分のベンチポケモン全員のHPを、それぞれ「30」回復する。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 543921,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "B",
+	rarity: "Rare Holo",
+	dexId: [719],
+};
+
+export default card;

--- a/data-asia/SM/SM12a/071.ts
+++ b/data-asia/SM/SM12a/071.ts
@@ -1,0 +1,60 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ツンデツンデ",
+	},
+
+	illustrator: "Hiroki Asanuma",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Fighting"],
+
+	description: {
+		ja: "ウルトラホールから 出現した。 複数の 生命が 積み上がり １匹を 形成している ようだ。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ストーンフェンス" },
+			effect: {
+				ja: "相手のサイドの残り枚数が3枚以下なら、このポケモンの最大HPは「200」になる。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "やまおとし" },
+			damage: 110,
+			cost: ["Fighting", "Fighting", "Colorless"],
+			effect: {
+				ja: "ウラが出るまでコインを投げ、オモテの数ぶん、相手の山札を上からトラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 543931,
+			},
+		},
+	],
+
+	retreat: 4,
+	regulationMark: "C",
+	rarity: "None",
+	dexId: [805],
+};
+
+export default card;

--- a/data-asia/SM/SM12a/072.ts
+++ b/data-asia/SM/SM12a/072.ts
@@ -1,0 +1,55 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ゲッコウガ&ゾロアークGX",
+	},
+
+	illustrator: "Mitsuhiro Arita",
+	category: "Pokemon",
+	hp: 250,
+	types: ["Darkness"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "あくのはどう" },
+			damage: "30+",
+			cost: ["Darkness", "Colorless"],
+			effect: {
+				ja: "自分の場のポケモンについている[悪]エネルギーの数x30ダメージ追加。",
+			},
+		},
+		{
+			name: { ja: "ナイトユニゾンGX" },
+			cost: ["Darkness", "Colorless"],
+			effect: {
+				ja: "自分のトラッシュにある[悪]タイプの「ポケモンGX・EX」を2枚、ベンチに出す。 追加でエネルギーが1個ついているなら、新しく出したポケモンに、トラッシュにあるエネルギーを2枚ずつつける。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 543941,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "C",
+	rarity: "Double rare",
+	dexId: [658, 571],
+
+	suffix: "TAG TEAM-GX",
+};
+
+export default card;

--- a/data-asia/SM/SM12a/073.ts
+++ b/data-asia/SM/SM12a/073.ts
@@ -1,0 +1,47 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ニューラ",
+	},
+
+	illustrator: "sui",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Darkness"],
+
+	description: {
+		ja: "チームプレイで とりポケモンの 巣穴から タマゴを 盗み出すが 誰が 食うかで ケンカになるのだ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "きりさく" },
+			damage: 30,
+			cost: ["Darkness", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 543971,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "None",
+	dexId: [215],
+};
+
+export default card;

--- a/data-asia/SM/SM12a/074.ts
+++ b/data-asia/SM/SM12a/074.ts
@@ -1,0 +1,62 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "マニューラ",
+	},
+
+	illustrator: "Misa Tsutsui",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Darkness"],
+
+	description: {
+		ja: "寒い 場所に 棲み アローラでは ロコンや サンドが 主な 餌。 獲物は 仲間で きちんと 分ける。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "こごえるかぜ" },
+			damage: 10,
+			cost: ["Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをねむりにする。",
+			},
+		},
+		{
+			name: { ja: "あくのいましめ" },
+			damage: "50×",
+			cost: ["Darkness"],
+			effect: {
+				ja: "相手の場の特性を持つポケモンの数x50ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 543996,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ニューラ",
+	},
+
+	retreat: 1,
+	regulationMark: "B",
+	rarity: "None",
+	dexId: [461],
+};
+
+export default card;

--- a/data-asia/SM/SM12a/075.ts
+++ b/data-asia/SM/SM12a/075.ts
@@ -1,0 +1,60 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アブソル",
+	},
+
+	illustrator: "nagimiso",
+	category: "Pokemon",
+	hp: 100,
+	types: ["Darkness"],
+
+	description: {
+		ja: "災いを もたらすと いわれるが 実際には おだやかな 性質。 災害の 危機を 人に 伝える。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "あくのはき" },
+			effect: {
+				ja: "このポケモンがいるかぎり、相手のバトル場のたねポケモンのにげるためのエネルギーは、1個ぶん多くなる。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "シャドーシーカー" },
+			damage: "30+",
+			cost: ["Darkness", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンのにげるためのエネルギーの数x30ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 544001,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "B",
+	rarity: "None",
+	dexId: [359],
+};
+
+export default card;

--- a/data-asia/SM/SM12a/076.ts
+++ b/data-asia/SM/SM12a/076.ts
@@ -1,0 +1,60 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ミカルゲ",
+	},
+
+	illustrator: "Kagemaru Himeno",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Darkness"],
+
+	description: {
+		ja: "１０８個の 魂が 集まって 生まれた ポケモン。 要石の ひび割れに つながれている。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "うらみだめ" },
+			effect: {
+				ja: "自分の番に1回使える。このポケモンにダメカンを1個のせる。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "くもんのさけび" },
+			damage: "10+",
+			cost: ["Darkness"],
+			effect: {
+				ja: "このポケモンにのっているダメカンの数x30ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 544006,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "None",
+	dexId: [442],
+};
+
+export default card;

--- a/data-asia/SM/SM12a/077.ts
+++ b/data-asia/SM/SM12a/077.ts
@@ -1,0 +1,60 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ダークライ",
+	},
+
+	illustrator: "Naoki Saito",
+	category: "Pokemon",
+	hp: 160,
+	types: ["Darkness"],
+
+	description: {
+		ja: "人々を 深い 眠りに 誘い 夢を 見せる 能力を 持つ。 新月の 夜に 活動する。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ナイトメアスター" },
+			effect: {
+				ja: "自分の番に、このカードを手札からベンチに出したとき、1回使える。自分の手札にある[悪]エネルギーを2枚、このポケモンにつける。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "アビススリープ" },
+			damage: 120,
+			cost: ["Darkness", "Darkness", "Darkness", "Darkness"],
+			effect: {
+				ja: "相手のバトルポケモンをねむりにする。このねむりで投げるコインは2回になり、すべてオモテが出ないと回復しない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 544011,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "B",
+	rarity: "Rare Holo",
+	dexId: [491],
+};
+
+export default card;

--- a/data-asia/SM/SM12a/078.ts
+++ b/data-asia/SM/SM12a/078.ts
@@ -1,0 +1,49 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ゾロア",
+	},
+
+	illustrator: "Naoyo Kimura",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Darkness"],
+
+	description: {
+		ja: "人や ほかの ポケモンに 化ける。 自分の 正体を 隠すことで 危険から 身を 守っているのだ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "やみにかくれる" },
+			cost: ["Darkness"],
+			effect: {
+				ja: "このポケモンをベンチポケモンと入れ替える。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 544016,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "B",
+	rarity: "None",
+	dexId: [570],
+};
+
+export default card;

--- a/data-asia/SM/SM12a/079.ts
+++ b/data-asia/SM/SM12a/079.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ゾロアーク",
+	},
+
+	illustrator: "Masakazu Fukuda",
+	category: "Pokemon",
+	hp: 110,
+	types: ["Darkness"],
+
+	description: {
+		ja: "相手を 化かす ことで 群れの 安全を 守ってきた ポケモン。 仲間同士の 結束が 固い。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "ちょうはつ" },
+			cost: ["Darkness"],
+			effect: {
+				ja: "相手のベンチポケモンを1匹選び、バトルポケモンと入れ替える。",
+			},
+		},
+		{
+			name: { ja: "ナイトパニッシュ" },
+			damage: "20×",
+			cost: ["Darkness", "Colorless", "Colorless"],
+			effect: {
+				ja: "自分のトラッシュにあるポケモンの枚数x20ダメージ。与えられるダメージはポケモン10枚ぶんまで。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 544021,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ゾロア",
+	},
+
+	retreat: 2,
+	regulationMark: "B",
+	rarity: "None",
+	dexId: [571],
+};
+
+export default card;

--- a/data-asia/SM/SM12a/080.ts
+++ b/data-asia/SM/SM12a/080.ts
@@ -1,0 +1,58 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "イベルタル",
+	},
+
+	illustrator: "Misa Tsutsui",
+	category: "Pokemon",
+	hp: 110,
+	types: ["Darkness"],
+
+	description: {
+		ja: "寿命が つきるとき あらゆる 生き物の 命を 吸いつくし 繭の 姿に 戻るという。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "くつがえす" },
+			damage: 30,
+			cost: ["Darkness"],
+			effect: {
+				ja: "相手のバトルポケモンについている特殊エネルギーを、1個トラッシュする。",
+			},
+		},
+		{
+			name: { ja: "わしづかみ" },
+			damage: 60,
+			cost: ["Darkness", "Darkness"],
+			effect: {
+				ja: "次の相手の番、このワザを受けたポケモンは、にげられない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 544026,
+			},
+		},
+	],
+
+	retreat: 0,
+	regulationMark: "B",
+	rarity: "None",
+	dexId: [717],
+};
+
+export default card;

--- a/data-asia/SM/SM12a/081.ts
+++ b/data-asia/SM/SM12a/081.ts
@@ -1,0 +1,58 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "フーパ",
+	},
+
+	illustrator: "Ayaka Yoshida",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Darkness"],
+
+	description: {
+		ja: "空間を ゆがめる リングで あらゆる ものを 離れた 場所へ 飛ばしてしまう トラブルメーカー。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "あくのいましめ" },
+			damage: "10+",
+			cost: ["Colorless"],
+			effect: {
+				ja: "相手の場の特性を持つポケモンの数×20ダメージ追加。",
+			},
+		},
+		{
+			name: { ja: "マインドショック" },
+			damage: 80,
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "このワザのダメージは弱点・抵抗力を計算しない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 544031,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "C",
+	rarity: "None",
+	dexId: [720],
+};
+
+export default card;

--- a/data-asia/SM/SM12a/082.ts
+++ b/data-asia/SM/SM12a/082.ts
@@ -1,0 +1,70 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ガオガエンGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 250,
+	types: ["Darkness"],
+
+	stage: "Stage2",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "スカーチャージ" },
+			effect: {
+				ja: "自分の番に1回使える。このポケモンにダメカンを3個のせる。その後、自分の山札にある[悪]エネルギーを3枚まで、このポケモンにつける。そして山札を切る。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "クラッシュパンチ" },
+			damage: 130,
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンについている特殊エネルギーを、1個トラッシュする。",
+			},
+		},
+		{
+			name: { ja: "DDトルネードGX" },
+			damage: "10+",
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンにのっているダメカンの数x50ダメージ追加。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 544036,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ニャヒート",
+	},
+
+	retreat: 3,
+	regulationMark: "B",
+	rarity: "Double rare",
+	dexId: [727],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM12a/083.ts
+++ b/data-asia/SM/SM12a/083.ts
@@ -1,0 +1,60 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ルカリオ&メルメタルGX",
+	},
+
+	illustrator: "Mitsuhiro Arita",
+	category: "Pokemon",
+	hp: 260,
+	types: ["Metal"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "こうてつのこぶし" },
+			damage: 50,
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "自分の山札にある[鋼]エネルギーを1枚、このポケモンにつける。そして山札を切る。",
+			},
+		},
+		{
+			name: { ja: "ヘビーインパクト" },
+			damage: 150,
+			cost: ["Metal", "Metal", "Colorless", "Colorless"],
+		},
+		{
+			name: { ja: "フルメタルウォールGX" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "この対戦が終わるまで、自分の[鋼]ポケモン全員が、相手のポケモンから受けるワザのダメージは、すべて「-30」される。追加でエネルギーが1個ついているなら、相手のバトルポケモンについているエネルギーを、すべてトラッシュする。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 544041,
+			},
+		},
+	],
+
+	retreat: 3,
+	regulationMark: "C",
+	rarity: "Double rare",
+	dexId: [448, 809],
+
+	suffix: "TAG TEAM-GX",
+};
+
+export default card;

--- a/data-asia/SM/SM12a/084.ts
+++ b/data-asia/SM/SM12a/084.ts
@@ -1,0 +1,47 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アローラディグダ",
+	},
+
+	illustrator: "Atsuko Nishida",
+	category: "Pokemon",
+	hp: 50,
+	types: ["Metal"],
+
+	description: {
+		ja: "溶岩質の 地面も グングン 掘り進むほど パワフルだが なかなか 姿を 見せないぞ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ぶつかる" },
+			damage: 10,
+			cost: [],
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 544046,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "None",
+	dexId: [50],
+};
+
+export default card;

--- a/data-asia/SM/SM12a/085.ts
+++ b/data-asia/SM/SM12a/085.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アローラダグトリオ",
+	},
+
+	illustrator: "SATOSHI NAKAI",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Metal"],
+
+	description: {
+		ja: "金属質の 髭は 重いので 素早さは いまいちだが 硬い 岩盤も 掘りぬくパワーを 持つ。",
+	},
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ヘアーウォール" },
+			effect: {
+				ja: "このポケモンがいるかぎり、自分の[鋼]ポケモン全員が、相手のポケモンから受けるワザのダメージは「-10」される。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ぶちかます" },
+			damage: 40,
+			cost: ["Metal", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 544051,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "アローラディグダ",
+	},
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "None",
+	dexId: [51],
+};
+
+export default card;

--- a/data-asia/SM/SM12a/086.ts
+++ b/data-asia/SM/SM12a/086.ts
@@ -1,0 +1,54 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "コイル",
+	},
+
+	illustrator: "MAHOU",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Metal"],
+
+	description: {
+		ja: "電磁波を 放ち 空を 漂う。 電気を 喰っているときに 触ると 全身が ビリッと 痺れるぞ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "マグネサーチ" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札にある[鋼]エネルギーを3枚まで、相手に見せてから、手札に加える。そして山札を切る。",
+			},
+		},
+		{
+			name: { ja: "たいあたり" },
+			damage: 10,
+			cost: ["Metal"],
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 544056,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "B",
+	rarity: "None",
+	dexId: [81],
+};
+
+export default card;

--- a/data-asia/SM/SM12a/087.ts
+++ b/data-asia/SM/SM12a/087.ts
@@ -1,0 +1,59 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "レアコイル",
+	},
+
+	illustrator: "kirisAki",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Metal"],
+
+	description: {
+		ja: "ほぼ コイル ３倍の 電力。 太陽の黒点が 多いとき なぜか 大量発生。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "ぶつかる" },
+			damage: 20,
+			cost: ["Metal"],
+		},
+		{
+			name: { ja: "でんじほう" },
+			damage: 80,
+			cost: ["Metal", "Metal", "Colorless"],
+			effect: {
+				ja: "次の自分の番、このポケモンは「でんじほう」が使えない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 544061,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "コイル",
+	},
+
+	retreat: 2,
+	regulationMark: "B",
+	rarity: "None",
+	dexId: [82],
+};
+
+export default card;

--- a/data-asia/SM/SM12a/088.ts
+++ b/data-asia/SM/SM12a/088.ts
@@ -1,0 +1,64 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ジバコイル",
+	},
+
+	illustrator: "Yoshinobu Saito",
+	category: "Pokemon",
+	hp: 150,
+	types: ["Metal"],
+
+	description: {
+		ja: "怪電波を 発信 しながら 空を 飛び回り 未知の 電波を 受信 していると いう。",
+	},
+
+	stage: "Stage2",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "マグネサーキット" },
+			effect: {
+				ja: "自分の番に何回でも使える。自分の手札にある[鋼]エネルギーを1枚、自分のポケモンにつける。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "でんじほう" },
+			damage: 130,
+			cost: ["Metal", "Metal", "Metal", "Colorless"],
+			effect: {
+				ja: "次の自分の番、このポケモンは「でんじほう」が使えない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 544066,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "レアコイル",
+	},
+
+	retreat: 2,
+	regulationMark: "B",
+	rarity: "None",
+	dexId: [462],
+};
+
+export default card;

--- a/data-asia/SM/SM12a/089.ts
+++ b/data-asia/SM/SM12a/089.ts
@@ -1,0 +1,65 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "クチートGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 170,
+	types: ["Metal"],
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "みわくのウインク" },
+			effect: {
+				ja: "自分の番に、このカードを手札からベンチに出したとき、1回使える。相手の手札を見て、その中にあるたねポケモンを、好きなだけ相手のベンチに出す。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ハッスルバイト" },
+			damage: "10+",
+			cost: ["Metal", "Colorless"],
+			effect: {
+				ja: "相手のベンチポケモンの数×30ダメージ追加。",
+			},
+		},
+		{
+			name: { ja: "ビッグイーターGX" },
+			cost: ["Metal", "Colorless"],
+			effect: {
+				ja: "相手の手札を見て、その中にあるサポートを、すべてトラッシュする。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 544071,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Double rare",
+	dexId: [303],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM12a/090.ts
+++ b/data-asia/SM/SM12a/090.ts
@@ -1,0 +1,57 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ジラーチ",
+	},
+
+	illustrator: "HYOGONOSUKE",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Metal"],
+
+	description: {
+		ja: "１０００年間で ７日だけ 目を 覚まし どんな 願い事でも かなえる 力を 使うという。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ねがいぼし" },
+			effect: {
+				ja: "このポケモンがバトル場にいるなら、自分の番に1回使える。自分の山札を上から5枚見る。その中にあるトレーナーズを1枚、相手に見せてから、手札に加える。残りのカードは山札にもどして切る。その後、このポケモンをねむりにする。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ビンタ" },
+			damage: 30,
+			cost: ["Metal", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 544076,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "B",
+	rarity: "None",
+	dexId: [385],
+};
+
+export default card;

--- a/data-asia/SM/SM12a/091.ts
+++ b/data-asia/SM/SM12a/091.ts
@@ -1,0 +1,60 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ジラーチ",
+	},
+
+	illustrator: "Kouki Saitou",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Metal"],
+
+	description: {
+		ja: "１０００年間で ７日だけ 目を 覚まし どんな 願い事でも かなえる 力を 使うという。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ほしにねがいを" },
+			effect: {
+				ja: "自分の番に、ウラになっている自分のサイドからこのカードをとったとき、自分のベンチに空きがあるなら、手札に加える前に使える。このポケモンを自分のベンチに出し、さらにサイドを1枚とる。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ほろびのゆめ" },
+			damage: 10,
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンをねむりにする。次の相手の番の終わりに、このワザを受けた相手のポケモンはきぜつする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 544081,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "B",
+	rarity: "Rare Holo",
+	dexId: [385],
+};
+
+export default card;

--- a/data-asia/SM/SM12a/092.ts
+++ b/data-asia/SM/SM12a/092.ts
@@ -1,0 +1,50 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "メルタン",
+	},
+
+	illustrator: "Kouki Saitou",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Metal"],
+
+	description: {
+		ja: "とろりと 溶けた 鋼の 体。 地中の 鉄分や 金属を 溶かして 吸収する。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "はがねとかし" },
+			damage: "10+",
+			cost: ["Metal"],
+			effect: {
+				ja: "相手のバトルポケモンが[鋼]ポケモンなら、40ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 544086,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "None",
+	dexId: [808],
+};
+
+export default card;

--- a/data-asia/SM/SM12a/093.ts
+++ b/data-asia/SM/SM12a/093.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "メルメタル",
+	},
+
+	illustrator: "TOKIYA",
+	category: "Pokemon",
+	hp: 150,
+	types: ["Metal"],
+
+	description: {
+		ja: "鉄を 産み出す 力を 持つと 崇められていた。 ３０００年の 時を 経て なぜか 蘇った。",
+	},
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "メタルイーター" },
+			effect: {
+				ja: "自分の番に1回使える。自分の手札にある[鋼]ポケモンを1枚トラッシュする。その後、このポケモンのHPを「100」回復する。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ヘビーインパクト" },
+			damage: 130,
+			cost: ["Metal", "Colorless", "Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 544091,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "メルタン",
+	},
+
+	retreat: 4,
+	regulationMark: "C",
+	rarity: "None",
+	dexId: [809],
+};
+
+export default card;

--- a/data-asia/SM/SM12a/094.ts
+++ b/data-asia/SM/SM12a/094.ts
@@ -1,0 +1,55 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "トゲピー&ピィ&ププリンGX",
+	},
+
+	illustrator: "Mitsuhiro Arita",
+	category: "Pokemon",
+	hp: 240,
+	types: ["Fairy"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ころがりパニック" },
+			damage: "120+",
+			cost: ["Fairy", "Fairy", "Colorless"],
+			effect: {
+				ja: "ラが出るまでコインを投げ、オモテの数×30ダメージ追加。",
+			},
+		},
+		{
+			name: { ja: "シュープリームGX" },
+			cost: ["Fairy", "Fairy"],
+			effect: {
+				ja: "の番が終わったら、もう1回自分の番を始める。追加で[妖]エネルギーが14個ついているなら、相手のベンチポケモン全員と、そのポケモンについているすべてのカードを、相手の山札にもどして切る。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [{ type: "Darkness", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 544096,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "C",
+	rarity: "Double rare",
+	dexId: [175, 173, 174],
+
+	suffix: "TAG TEAM-GX",
+};
+
+export default card;

--- a/data-asia/SM/SM12a/095.ts
+++ b/data-asia/SM/SM12a/095.ts
@@ -1,0 +1,69 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アローラキュウコンGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 200,
+	types: ["Fairy"],
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ふしぎなみちびき" },
+			effect: {
+				ja: "自分の番に、このカードを手札から出して進化させたとき、1回使える。自分の山札にあるグッズを2枚まで、相手に見せてから、手札に加える。そして山札を切る。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "はくぎんのかぜ" },
+			damage: 70,
+			cost: ["Fairy", "Colorless"],
+			effect: {
+				ja: "相手のベンチポケモン1匹にも、30ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+			},
+		},
+		{
+			name: { ja: "サブリメイションGX" },
+			cost: ["Fairy", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンが「ウルトラビースト」なら、そのポケモンをきぜつさせる。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [{ type: "Darkness", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 544101,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "アローラロコン",
+	},
+
+	retreat: 2,
+	regulationMark: "B",
+	rarity: "Double rare",
+	dexId: [38],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM12a/096.ts
+++ b/data-asia/SM/SM12a/096.ts
@@ -1,0 +1,49 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ピィ",
+	},
+
+	illustrator: "Shibuzoh.",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Fairy"],
+
+	description: {
+		ja: "流れ星の 多い 夜に 群れ 輪になって ダンス。 その 姿を 見ると ちょっと いいことが あるよ。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "はりきりドロー" },
+			effect: {
+				ja: "自分の番に1回使えて、使ったなら、自分の番は終わる。コインを1回投げオモテなら、自分の手札をすべて山札にもどして切る。その後、山札を6枚引く。",
+			},
+		},
+	],
+
+	weaknesses: [],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 544116,
+			},
+		},
+	],
+
+	retreat: 0,
+	regulationMark: "C",
+	rarity: "None",
+	dexId: [173],
+};
+
+export default card;

--- a/data-asia/SM/SM12a/097.ts
+++ b/data-asia/SM/SM12a/097.ts
@@ -1,0 +1,50 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "モンメン",
+	},
+
+	illustrator: "Pani Kobayashi",
+	category: "Pokemon",
+	hp: 40,
+	types: ["Fairy"],
+
+	description: {
+		ja: "綿を 飛ばして 身を 守る。 雨に 濡れると 綿が 湿って 重くなり 身動きが とれなくなる。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ロストマーチ" },
+			damage: "20×",
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "分のロストゾーンにあるポケモン（♢（プリズムスター）をのぞく）の枚数×20ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [{ type: "Darkness", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 544121,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "None",
+	dexId: [546],
+};
+
+export default card;

--- a/data-asia/SM/SM12a/098.ts
+++ b/data-asia/SM/SM12a/098.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "エルフーン",
+	},
+
+	illustrator: "Yumi",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Fairy"],
+
+	description: {
+		ja: "民家に 忍び込み 大切な ものを 隠したり 部屋中に 綿を まき散らす 厄介者だ。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "すきまのポケット" },
+			cost: ["Fairy"],
+			effect: {
+				ja: "分の手札を1枚、ロストゾーンに置く。その後、自分の山札を3枚引く。",
+			},
+		},
+		{
+			name: { ja: "ロストマーチ" },
+			damage: "20×",
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "分のロストゾーンにあるポケモン（♢（プリズムスター）をのぞく）の枚数×20ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [{ type: "Darkness", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 544126,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "モンメン",
+	},
+
+	retreat: 0,
+	regulationMark: "C",
+	rarity: "None",
+	dexId: [547],
+};
+
+export default card;

--- a/data-asia/SM/SM12a/099.ts
+++ b/data-asia/SM/SM12a/099.ts
@@ -1,0 +1,62 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ガブリアス&ギラティナGX",
+	},
+
+	illustrator: "Mitsuhiro Arita",
+	category: "Pokemon",
+	hp: 270,
+	types: ["Dragon"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ちょくげきだん" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "相手のポケモン1匹に、40ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+			},
+		},
+		{
+			name: { ja: "カラミティエッジ" },
+			damage: "160+",
+			cost: ["Psychic", "Fighting", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンにダメカンがのっているなら、80ダメージ追加。",
+			},
+		},
+		{
+			name: { ja: "ジージーエンドGX" },
+			cost: ["Psychic", "Psychic", "Fighting"],
+			effect: {
+				ja: "相手のポケモン1匹と、ついているすべてのカードを、トラッシュする。追加で[闘]エネルギーが3個ついているなら、トラッシュするポケモンの数は2匹になる。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fairy", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 544131,
+			},
+		},
+	],
+
+	retreat: 3,
+	regulationMark: "C",
+	rarity: "Double rare",
+	dexId: [445, 487],
+
+	suffix: "TAG TEAM-GX",
+};
+
+export default card;

--- a/data-asia/SM/SM12a/100.ts
+++ b/data-asia/SM/SM12a/100.ts
@@ -1,0 +1,65 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "レックウザGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 180,
+	types: ["Dragon"],
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "しっぷうどとう" },
+			effect: {
+				ja: "自分の番に、このカードを手札からベンチに出したとき、1回使える。自分の山札を上から3枚トラッシュする。その後、トラッシュにある基本エネルギーを1枚、このポケモンにつける。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ドラゴンブレイク" },
+			damage: "30×",
+			cost: ["Grass", "Lightning", "Colorless"],
+			effect: {
+				ja: "自分の場のポケモンについている[草]と[雷]タイプの基本エネルギーの数x30ダメージ。",
+			},
+		},
+		{
+			name: { ja: "テンペストGX" },
+			cost: ["Grass"],
+			effect: {
+				ja: "自分の手札をすべてトラッシュし、山札を10枚引く。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fairy", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 544136,
+			},
+		},
+	],
+
+	retreat: 3,
+	regulationMark: "B",
+	rarity: "Double rare",
+	dexId: [384],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM12a/101.ts
+++ b/data-asia/SM/SM12a/101.ts
@@ -1,0 +1,55 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ウルトラネクロズマGX",
+	},
+
+	illustrator: "PLANETA Otani",
+	category: "Pokemon",
+	hp: 190,
+	types: ["Dragon"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "フォトンゲイザー" },
+			damage: "20+",
+			cost: ["Psychic", "Metal"],
+			effect: {
+				ja: "このポケモンについている基本[超]エネルギーをすべてトラッシュし、その枚数x80ダメージ追加。",
+			},
+		},
+		{
+			name: { ja: "めつぼうのひかりGX" },
+			cost: ["Psychic", "Metal"],
+			effect: {
+				ja: "このワザは、おたがいのサイドの残り枚数の合計が、6枚以下のときにしか使えない。相手のポケモン全員に、それぞれダメカンを6個のせる。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fairy", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 544141,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "B",
+	rarity: "Double rare",
+	dexId: [800],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM12a/102.ts
+++ b/data-asia/SM/SM12a/102.ts
@@ -1,0 +1,52 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ファイヤー&サンダー&フリーザーGX",
+	},
+
+	illustrator: "Mitsuhiro Arita",
+	category: "Pokemon",
+	hp: 300,
+	types: ["Colorless"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "トリニティバーン" },
+			damage: 210,
+			cost: ["Fire", "Water", "Lightning", "Colorless"],
+		},
+		{
+			name: { ja: "スカイレジェンドGX" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "このポケモンと、ついているすべてのカードを、自分の山札にもどして切る。追加で[炎][水][雷]エネルギーが1個ずつついているなら、相手のポケモン3匹に、それぞれ110ダメージ。［ベンチは弱点・抵抗力を計算しない。］［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 544146,
+			},
+		},
+	],
+
+	retreat: 3,
+	regulationMark: "C",
+	rarity: "Double rare",
+	dexId: [146, 145, 144],
+
+	suffix: "TAG TEAM-GX",
+};
+
+export default card;

--- a/data-asia/SM/SM12a/103.ts
+++ b/data-asia/SM/SM12a/103.ts
@@ -1,0 +1,54 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ポッポ",
+	},
+
+	illustrator: "Shigenori Negishi",
+	category: "Pokemon",
+	hp: 50,
+	types: ["Colorless"],
+
+	description: {
+		ja: "森や 林に 多く 分布。 地上でも 激しく はばたいて 砂を かけたりする。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "もってくる" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札を1枚引く。",
+			},
+		},
+		{
+			name: { ja: "かぜおこし" },
+			damage: 20,
+			cost: ["Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 544151,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "None",
+	dexId: [16],
+};
+
+export default card;

--- a/data-asia/SM/SM12a/104.ts
+++ b/data-asia/SM/SM12a/104.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ピジョン",
+	},
+
+	illustrator: "Mizue",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Colorless"],
+
+	description: {
+		ja: "足の ツメが 発達している。 エサの タマタマを つかんで １００キロ先の 巣まで 運ぶ。",
+	},
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "エアメール" },
+			effect: {
+				ja: "自分の番に1回使える。自分の山札を上から2枚見て、どちらか1枚を手札に加える。残りのカードは、山札の下にもどす。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "かぜおこし" },
+			damage: 30,
+			cost: ["Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 544156,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ポッポ",
+	},
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "None",
+	dexId: [17],
+};
+
+export default card;

--- a/data-asia/SM/SM12a/105.ts
+++ b/data-asia/SM/SM12a/105.ts
@@ -1,0 +1,54 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ニャース",
+	},
+
+	illustrator: "Shibuzoh.",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Colorless"],
+
+	description: {
+		ja: "ゴミ捨て場に いくと ひかりものを 巡って ヤミカラスと 激しく ケンカする 光景が 見られる。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ねこびより" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札を2枚引く。その後、このポケモンをねむりにする。",
+			},
+		},
+		{
+			name: { ja: "しっぽではたく" },
+			damage: 30,
+			cost: ["Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 544161,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "None",
+	dexId: [52],
+};
+
+export default card;

--- a/data-asia/SM/SM12a/106.ts
+++ b/data-asia/SM/SM12a/106.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ペルシアン",
+	},
+
+	illustrator: "tetsuya koizumi",
+	category: "Pokemon",
+	hp: 100,
+	types: ["Colorless"],
+
+	description: {
+		ja: "アローラの ペルシアンとは 額の 宝石の色が 違って 見えるが 成分は あまり 変わらないのだ。",
+	},
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ねこのしゅうかい" },
+			effect: {
+				ja: "このポケモンがいるかぎり、自分の場にいるワザ「ねこびより」を持つポケモンが使うワザに必要なエネルギーは、すべてなくなる。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ツメできりさく" },
+			damage: 90,
+			cost: ["Colorless", "Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 544166,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ニャース",
+	},
+
+	retreat: 0,
+	regulationMark: "C",
+	rarity: "None",
+	dexId: [53],
+};
+
+export default card;

--- a/data-asia/SM/SM12a/107.ts
+++ b/data-asia/SM/SM12a/107.ts
@@ -1,0 +1,54 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ガルーラ",
+	},
+
+	illustrator: "Mizue",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Colorless"],
+
+	description: {
+		ja: "お腹の 袋に 我が子を 入れて 守る。 子どもを 傷つけた者は 絶対に 許さず 叩きのめす。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "しんかそくせい" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札にある進化ポケモンを2枚まで、相手に見せてから、手札に加える。そして山札を切る。",
+			},
+		},
+		{
+			name: { ja: "メガトンパンチ" },
+			damage: 80,
+			cost: ["Colorless", "Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 544171,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "C",
+	rarity: "None",
+	dexId: [115],
+};
+
+export default card;

--- a/data-asia/SM/SM12a/108.ts
+++ b/data-asia/SM/SM12a/108.ts
@@ -1,0 +1,49 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "メタモン",
+	},
+
+	illustrator: "kirisAki",
+	category: "Pokemon",
+	hp: 40,
+	types: ["Colorless"],
+
+	description: {
+		ja: "驚きの 変身能力で どんな者とも 仲間に なれる。 メタモン同士は 仲が 悪い。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "なんでもしんか" },
+			effect: {
+				ja: "このポケモンは、自分の番に、1進化ポケモンを手札から出して、このポケモンに重ねて進化できる。（最初の自分の番と、このポケモンを場に出した番はのぞく。）",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 544176,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "B",
+	rarity: "Rare Holo",
+	dexId: [132],
+};
+
+export default card;

--- a/data-asia/SM/SM12a/109.ts
+++ b/data-asia/SM/SM12a/109.ts
@@ -1,0 +1,54 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "イーブイ",
+	},
+
+	illustrator: "Hasuno",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Colorless"],
+
+	description: {
+		ja: "イーブイだけが とても 不安定な 遺伝子を 持っている 理由は 未だ 解明 されて いない。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "しっぽにとまれ" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "分の山札にある「イーブイ（GXをふくむ）」を好きなだけ、ベンチに出す。そして山札を切る。",
+			},
+		},
+		{
+			name: { ja: "たいあたり" },
+			damage: 10,
+			cost: ["Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 544181,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "None",
+	dexId: [133],
+};
+
+export default card;

--- a/data-asia/SM/SM12a/110.ts
+++ b/data-asia/SM/SM12a/110.ts
@@ -1,0 +1,54 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ポリゴン",
+	},
+
+	illustrator: "Ayaka Yoshida",
+	category: "Pokemon",
+	hp: 50,
+	types: ["Colorless"],
+
+	description: {
+		ja: "約２０年前の 科学力で 生み出された ポケモンなので 今や 時代遅れな 部分も 多い。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "デジチャージ" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "コインを3回投げ、オモテの数ぶんまで、自分の山札にあるエネルギーを、相手に見せてから、手札に加える。そして山札を切る。",
+			},
+		},
+		{
+			name: { ja: "とがる" },
+			damage: 10,
+			cost: ["Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 544186,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "None",
+	dexId: [137],
+};
+
+export default card;

--- a/data-asia/SM/SM12a/111.ts
+++ b/data-asia/SM/SM12a/111.ts
@@ -1,0 +1,58 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ポリゴン2",
+	},
+
+	illustrator: "sowsow",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Colorless"],
+
+	description: {
+		ja: "ＡＩを 搭載。 自力で 様々なことを 学んでいくが 余計なことまで 覚えだす。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "ダブルドロー" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札を2枚引く。",
+			},
+		},
+		{
+			name: { ja: "かいてんアタック" },
+			damage: 30,
+			cost: ["Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 544191,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ポリゴン",
+	},
+
+	retreat: 2,
+	regulationMark: "C",
+	rarity: "None",
+	dexId: [233],
+};
+
+export default card;

--- a/data-asia/SM/SM12a/112.ts
+++ b/data-asia/SM/SM12a/112.ts
@@ -1,0 +1,64 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ポリゴンZ",
+	},
+
+	illustrator: "Misa Tsutsui",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Colorless"],
+
+	description: {
+		ja: "不安定な 挙動が 目立つ。 プログラムを アップデートした 技術者の 腕の せいらしい。",
+	},
+
+	stage: "Stage2",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "クレイジーコード" },
+			effect: {
+				ja: "自分の番に何回でも使える。自分の手札にある特殊エネルギーを1枚、自分のポケモンにつける。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "あばれまわる" },
+			damage: 120,
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンをこんらんにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 544196,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ポリゴン２",
+	},
+
+	retreat: 2,
+	regulationMark: "C",
+	rarity: "None",
+	dexId: [474],
+};
+
+export default card;

--- a/data-asia/SM/SM12a/113.ts
+++ b/data-asia/SM/SM12a/113.ts
@@ -1,0 +1,56 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ニャルマー",
+	},
+
+	illustrator: "sowsow",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Colorless"],
+
+	description: {
+		ja: "気に入らないと ツメを 立てるが たまに のどを 鳴らして 甘える 性格が 一部に 大人気だ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ねこびより" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札を1枚引く。その後、このポケモンをねむりにする。",
+			},
+		},
+		{
+			name: { ja: "びょんびょんテール" },
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手の「ポケモンGX・EX」1匹に、60ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 544201,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "None",
+	dexId: [431],
+};
+
+export default card;

--- a/data-asia/SM/SM12a/114.ts
+++ b/data-asia/SM/SM12a/114.ts
@@ -1,0 +1,49 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ゴンベ",
+	},
+
+	illustrator: "sowsow",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Colorless"],
+
+	description: {
+		ja: "長い 毛の 下に 食べ物を 隠すが 隠したことを 忘れて 異臭 騒ぎに なることも。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ごちそうサーチ" },
+			effect: {
+				ja: "自分の番に1回使えて、使ったなら、自分の番は終わる。コインを1回投げオモテなら、自分のトラッシュにある好きなカードを1枚、相手に見せてから、山札の上にもどす。",
+			},
+		},
+	],
+
+	weaknesses: [],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 544206,
+			},
+		},
+	],
+
+	retreat: 0,
+	regulationMark: "C",
+	rarity: "None",
+	dexId: [446],
+};
+
+export default card;

--- a/data-asia/SM/SM12a/115.ts
+++ b/data-asia/SM/SM12a/115.ts
@@ -1,0 +1,60 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "タブンネ",
+	},
+
+	illustrator: "sui",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Colorless"],
+
+	description: {
+		ja: "耳の 触角で 相手の 体調や タマゴから ポケモンが いつ でてくるのかも わかるのだ。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ヒヤリング" },
+			effect: {
+				ja: "このポケモンがバトル場にいるなら、自分の番に1回使える。自分の山札を1枚引く。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ドレインビンタ" },
+			damage: 30,
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンのHPを「30」回復する。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 544211,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "None",
+	dexId: [531],
+};
+
+export default card;

--- a/data-asia/SM/SM12a/116.ts
+++ b/data-asia/SM/SM12a/116.ts
@@ -1,0 +1,54 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ツツケラ",
+	},
+
+	illustrator: "Suwama Chiaki",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Colorless"],
+
+	description: {
+		ja: "きのみが 餌。 喰らった後の タネを 弾として 口から 発射し 攻撃に 利用。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "つきかえす" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをベンチポケモンと入れ替える。［バトル場に出すポケモンは相手が選ぶ。］",
+			},
+		},
+		{
+			name: { ja: "つつく" },
+			damage: 20,
+			cost: ["Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 544216,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "B",
+	rarity: "None",
+	dexId: [731],
+};
+
+export default card;

--- a/data-asia/SM/SM12a/117.ts
+++ b/data-asia/SM/SM12a/117.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ケララッパ",
+	},
+
+	illustrator: "Shin Nagasawa",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Colorless"],
+
+	description: {
+		ja: "クチバシを 反り返らせ 色んな 音で 鳴く。 かなり うるさいので 周りの 御宅には 嫌われるぞ。",
+	},
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "やまわたり" },
+			effect: {
+				ja: "このカードが手札にあるなら、自分の番に1回使えて、使ったなら、このカードをロストゾーンに置く。相手の山札を上から1枚見て、もとにもどす。そのカードがサポートの場合、のぞむなら、ロストゾーンに置く。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "つつく" },
+			damage: 30,
+			cost: ["Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 544221,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ツツケラ",
+	},
+
+	retreat: 1,
+	regulationMark: "B",
+	rarity: "None",
+	dexId: [732],
+};
+
+export default card;

--- a/data-asia/SM/SM12a/118.ts
+++ b/data-asia/SM/SM12a/118.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "エレキパワー",
+	},
+
+	illustrator: "Eske Yoshinob",
+	category: "Trainer",
+
+	effect: {
+		ja: "この番、自分の[雷]ポケモンが使うワザの、相手のバトルポケモンへのダメージは「+30」される。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 544226,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	regulationMark: "B",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/SM/SM12a/119.ts
+++ b/data-asia/SM/SM12a/119.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "エレキパワー",
+	},
+
+	illustrator: "OOYAMA",
+	category: "Trainer",
+
+	effect: {
+		ja: "この番、自分の[雷]ポケモンが使うワザの、相手のバトルポケモンへのダメージは「+30」される。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 544231,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	regulationMark: "B",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/SM/SM12a/120.ts
+++ b/data-asia/SM/SM12a/120.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "カスタムキャッチャー",
+	},
+
+	illustrator: "Toyste Beach",
+	category: "Trainer",
+
+	effect: {
+		ja: "「カスタムキャッチャー」は、1枚または2枚同時に使え、使った枚数によって効果が変わる。◆1枚使ったなら、自分の手札が3枚になるように、山札を引く。◆2枚同時に使ったなら、相手のベンチポケモンを1匹選び、バトルポケモンと入れ替える。（この効果は、2枚で1回はたらく。）",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 544236,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	regulationMark: "B",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/SM/SM12a/121.ts
+++ b/data-asia/SM/SM12a/121.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ダートじてんしゃ",
+	},
+
+	illustrator: "Toyste Beach",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の山札を上から2枚見て、どちらか1枚を選び、手札に加える。残りのカードはトラッシュする。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 544241,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	regulationMark: "B",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/SM/SM12a/122.ts
+++ b/data-asia/SM/SM12a/122.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ダートじてんしゃ",
+	},
+
+	illustrator: "OOYAMA",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の山札を上から2枚見て、どちらか1枚を選び、手札に加える。残りのカードはトラッシュする。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 544246,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	regulationMark: "B",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/SM/SM12a/123.ts
+++ b/data-asia/SM/SM12a/123.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "電磁レーダー",
+	},
+
+	illustrator: "Yoshinobu Saito",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードは、自分の手札を2枚トラッシュしなければ使えない。自分の山札にある[雷]タイプの「ポケモンGX・EX」を2枚まで、相手に見せてから、手札に加える。そして山札を切る。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 544251,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	regulationMark: "C",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/SM/SM12a/124.ts
+++ b/data-asia/SM/SM12a/124.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "電磁レーダー",
+	},
+
+	illustrator: "OOYAMA",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードは、自分の手札を2枚トラッシュしなければ使えない。自分の山札にある[雷]タイプの「ポケモンGX・EX」を2枚まで、相手に見せてから、手札に加える。そして山札を切る。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 544256,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	regulationMark: "C",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/SM/SM12a/125.ts
+++ b/data-asia/SM/SM12a/125.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ネットボール",
+	},
+
+	illustrator: "Ryo Ueda",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の山札にある[草]タイプのたねポケモンまたは[草]エネルギーを1枚、相手に見せてから、手札に加える。そして山札を切る。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 544261,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	regulationMark: "B",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/SM/SM12a/126.ts
+++ b/data-asia/SM/SM12a/126.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ビーストリング",
+	},
+
+	illustrator: "Toyste Beach",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードは、相手のサイドの残り枚数が、4枚または3枚でなければ使えない。自分の山札にある基本エネルギーを2枚まで、自分の「ウルトラビースト」1匹につける。そして山札を切る。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 544266,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	regulationMark: "B",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/SM/SM12a/127.ts
+++ b/data-asia/SM/SM12a/127.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "プレシャスボール",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の山札にある「ポケモンGX」を1枚、相手に見せてから、手札に加える。そして山札を切る。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 544271,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	regulationMark: "C",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/SM/SM12a/128.ts
+++ b/data-asia/SM/SM12a/128.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ぼうけんのカバン",
+	},
+
+	illustrator: "Yoshinobu Saito",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の山札にある「ポケモンのどうぐ」を2枚まで、相手に見せてから、手札に加える。そして山札を切る。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 544276,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	regulationMark: "B",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/SM/SM12a/129.ts
+++ b/data-asia/SM/SM12a/129.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ポケギア3.0",
+	},
+
+	illustrator: "Studio Bora Inc.",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の山札を上から7枚見る。その中にあるサポートを1枚、相手に見せてから、手札に加えてよい。残りのカードは山札にもどして切る。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 544281,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	regulationMark: "C",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/SM/SM12a/130.ts
+++ b/data-asia/SM/SM12a/130.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ポケギア3.0",
+	},
+
+	illustrator: "OOYAMA",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の山札を上から7枚見る。その中にあるサポートを1枚、相手に見せてから、手札に加えてよい。残りのカードは山札にもどして切る。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 544286,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	regulationMark: "C",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/SM/SM12a/131.ts
+++ b/data-asia/SM/SM12a/131.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ポケモン通信",
+	},
+
+	illustrator: "Ayaka Yoshida",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の手札からポケモンを1枚選び、相手に見せてから、山札にもどす。もどした場合、自分の山札からポケモンを1枚選び、相手に見せてから、手札に加える。そして山札を切る。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 544291,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	regulationMark: "C",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/SM/SM12a/132.ts
+++ b/data-asia/SM/SM12a/132.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ポケモン通信",
+	},
+
+	illustrator: "OOYAMA",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の手札からポケモンを1枚選び、相手に見せてから、山札にもどす。もどした場合、自分の山札からポケモンを1枚選び、相手に見せてから、手札に加える。そして山札を切る。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 544296,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	regulationMark: "C",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/SM/SM12a/133.ts
+++ b/data-asia/SM/SM12a/133.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "炎の結晶",
+	},
+
+	illustrator: "Yoshinobu Saito",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分のトラッシュにある[炎]エネルギーを3枚、相手に見せてから、手札に加える。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 544301,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	regulationMark: "C",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/SM/SM12a/134.ts
+++ b/data-asia/SM/SM12a/134.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ミステリートレジャー",
+	},
+
+	illustrator: "Eske Yoshinob",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードは、自分の手札を1枚トラッシュしなければ使えない。自分の山札にある[超]または[竜]ポケモンを1枚、相手に見せてから、手札に加える。そして山札を切る。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 544306,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	regulationMark: "B",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/SM/SM12a/135.ts
+++ b/data-asia/SM/SM12a/135.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ミステリートレジャー",
+	},
+
+	illustrator: "OOYAMA",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードは、自分の手札を1枚トラッシュしなければ使えない。自分の山札にある[超]または[竜]ポケモンを1枚、相手に見せてから、手札に加える。そして山札を切る。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 544311,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	regulationMark: "B",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/SM/SM12a/136.ts
+++ b/data-asia/SM/SM12a/136.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "リセットスタンプ",
+	},
+
+	illustrator: "sadaji",
+	category: "Trainer",
+
+	effect: {
+		ja: "相手は相手自身の手札をすべて山札にもどして切る。その後、相手は相手自身のサイドの残り枚数ぶん、山札を引く。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 544316,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	regulationMark: "C",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/SM/SM12a/137.ts
+++ b/data-asia/SM/SM12a/137.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "リセットスタンプ",
+	},
+
+	illustrator: "OOYAMA",
+	category: "Trainer",
+
+	effect: {
+		ja: "相手は相手自身の手札をすべて山札にもどして切る。その後、相手は相手自身のサイドの残り枚数ぶん、山札を引く。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 544321,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	regulationMark: "C",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/SM/SM12a/138.ts
+++ b/data-asia/SM/SM12a/138.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ロストミキサー",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の手札を2枚、ロストゾーンに置く。その後、自分の山札を1枚引く。（自分の手札を2枚、ロストゾーンに置けないなら、このカードは使えない。）",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 544326,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	regulationMark: "B",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/SM/SM12a/139.ts
+++ b/data-asia/SM/SM12a/139.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "カウンターゲイン",
+	},
+
+	illustrator: "Toyste Beach",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分のサイドの残り枚数が、相手より多いなら、このカードをつけているポケモンが使うワザに必要なエネルギーは、エネルギー1個ぶん少なくなる。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 544331,
+			},
+		},
+	],
+
+	trainerType: "Tool",
+	regulationMark: "B",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/SM/SM12a/140.ts
+++ b/data-asia/SM/SM12a/140.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "くろおび",
+	},
+
+	illustrator: "Yoshinobu Saito",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分のサイドの残り枚数が、相手より多いなら、このカードをつけているポケモンが使うワザに必要なエネルギーは、エネルギー1個ぶん少なくなる。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 544336,
+			},
+		},
+	],
+
+	trainerType: "Tool",
+	regulationMark: "C",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/SM/SM12a/141.ts
+++ b/data-asia/SM/SM12a/141.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "のろいのおふだ",
+	},
+
+	illustrator: "Ayaka Yoshida",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードをつけているポケモンが、相手のワザのダメージを受けてきぜつしたとき、ダメカン4個を、相手のポケモンに好きなようにのせる。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 544341,
+			},
+		},
+	],
+
+	trainerType: "Tool",
+	regulationMark: "B",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/SM/SM12a/142.ts
+++ b/data-asia/SM/SM12a/142.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "メタルコアバリア",
+	},
+
+	illustrator: "Studio Bora Inc.",
+	category: "Trainer",
+
+	effect: {
+		ja: "ポケモンについているこのカードは、相手の番の終わりにトラッシュする。 このカードをつけているポケモンが、相手のポケモンから受けるワザのダメージは「-70」される。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 544346,
+			},
+		},
+	],
+
+	trainerType: "Tool",
+	regulationMark: "C",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/SM/SM12a/143.ts
+++ b/data-asia/SM/SM12a/143.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "Uターンボード",
+	},
+
+	illustrator: "sadaji",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードをつけているポケモンは、にげるためのエネルギーが1個ぶん少なくなる。 このカードは、場からトラッシュされるとき、トラッシュせず、手札にもどす。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 544351,
+			},
+		},
+	],
+
+	trainerType: "Tool",
+	regulationMark: "C",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/SM/SM12a/144.ts
+++ b/data-asia/SM/SM12a/144.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アカギ",
+	},
+
+	illustrator: "Masakazu Fukuda",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードは、自分のバトル場に[水]または[鋼]ポケモンがいなければ使えない。相手は相手自身のベンチポケモンが2匹になるまで、ポケモンとついているすべてのカードを、山札にもどして切る。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 544356,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "B",
+	rarity: "Rare Holo",
+};
+
+export default card;

--- a/data-asia/SM/SM12a/145.ts
+++ b/data-asia/SM/SM12a/145.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ウツギ博士のレクチャー",
+	},
+
+	illustrator: "Hideki Ishikawa",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の山札にある、HPが「60」以下のポケモンを3枚まで、相手に見せてから、手札に加える。そして山札を切る。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 544361,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "B",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/SM/SM12a/146.ts
+++ b/data-asia/SM/SM12a/146.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "エリカのおもてなし",
+	},
+
+	illustrator: "Sanosuke Sakuma",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードは、自分の手札がこのカードをふくめて6枚以上なら使えない。相手の場のポケモンの数ぶん、自分の山札を引く。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 544366,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "C",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/SM/SM12a/147.ts
+++ b/data-asia/SM/SM12a/147.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "カスミ&カンナ",
+	},
+
+	illustrator: "Megumi Mizutani",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の山札にある[水]エネルギーを3枚まで、相手に見せてから、手札に加える。そして山札を切る。追加で、このカードを使うときに、自分の手札を5枚トラッシュしてよい。その場合、この番、自分の[水]ポケモンは、自分がすでにGXワザを使っていても、GXワザが使える。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 544371,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "C",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/SM/SM12a/148.ts
+++ b/data-asia/SM/SM12a/148.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "カルネ",
+	},
+
+	illustrator: "Ken Sugimori",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードは、前の相手の番に、自分の[妖]ポケモンがきぜつしていなければ使えない。自分のトラッシュにある好きなカードを2枚、相手に見せてから、手札に加える。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 544376,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "B",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/SM/SM12a/149.ts
+++ b/data-asia/SM/SM12a/149.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "かんこうきゃく",
+	},
+
+	illustrator: "Naoki Saito",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の手札が5枚になるように、山札を引く。のぞむなら、山札を引く前に、自分の手札を好きなだけトラッシュする。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 544381,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "B",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/SM/SM12a/150.ts
+++ b/data-asia/SM/SM12a/150.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ザオボー",
+	},
+
+	illustrator: "take",
+	category: "Trainer",
+
+	effect: {
+		ja: "相手の場のポケモンについている「ポケモンのどうぐ」「特殊エネルギー」と場に出ている「スタジアム」の中から1枚、ロストゾーンに置く。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 544386,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "B",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/SM/SM12a/151.ts
+++ b/data-asia/SM/SM12a/151.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "サカキの追放",
+	},
+
+	illustrator: "Megumi Mizutani",
+	category: "Trainer",
+
+	effect: {
+		ja: "ダメカンがのっていない自分のベンチポケモンを2匹まで選び、選んだポケモンと、ついているすべてのカードを、トラッシュする。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 544391,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "C",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/SM/SM12a/152.ts
+++ b/data-asia/SM/SM12a/152.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ジュジュベ&ハチクマン",
+	},
+
+	illustrator: "Hideki Ishikawa",
+	category: "Trainer",
+
+	effect: {
+		ja: "おたがいの山札を上から3枚ずつトラッシュする。追加で、このカードを使うときに、自分の手札を3枚トラッシュしてよい。その場合、おたがいのプレイヤーは、それぞれ自分のベンチポケモンが3匹になるまでポケモンをトラッシュする。（トラッシュは相手から行う。）",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 544396,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "C",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/SM/SM12a/153.ts
+++ b/data-asia/SM/SM12a/153.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "デンジ",
+	},
+
+	illustrator: "Ken Sugimori",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の山札にあるグッズと[雷]エネルギーを1枚ずつ、相手に見せてから、手札に加える。そして山札を切る。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 544401,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "B",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/SM/SM12a/154.ts
+++ b/data-asia/SM/SM12a/154.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ブルーの探索",
+	},
+
+	illustrator: "Naoki Saito",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードは、自分の場に特性を持つポケモンがいるなら、使えない。自分の山札にあるトレーナ−ズを2枚まで、相手に見せてから、手札に加える。そして山札を切る。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 544406,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "C",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/SM/SM12a/155.ts
+++ b/data-asia/SM/SM12a/155.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "マツバ",
+	},
+
+	illustrator: "Ken Sugimori",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードは、前の相手の番に、自分の[超]ポケモンがきぜつしていなければ使えない。相手の手札を見て、その中にあるカードを2枚、相手の山札にもどして切る。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 544411,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "B",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/SM/SM12a/156.ts
+++ b/data-asia/SM/SM12a/156.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "マツリカ",
+	},
+
+	illustrator: "Ken Sugimori",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の山札にある[妖]エネルギーを1枚、自分のポケモンにつける。そして山札を切る。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 544416,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "B",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/SM/SM12a/157.ts
+++ b/data-asia/SM/SM12a/157.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "溶接工",
+	},
+
+	illustrator: "Hitoshi Ariga",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の手札にある[炎]エネルギーを2枚まで、自分のポケモン1匹につける。その後、自分の山札を3枚引く。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 544421,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "C",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/SM/SM12a/158.ts
+++ b/data-asia/SM/SM12a/158.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ルチア",
+	},
+
+	illustrator: "Megumi Mizutani",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の山札にある♢（プリズムスター）のカードを2枚まで、相手に見せてから、手札に加える。そして山札を切る。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 544426,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "B",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/SM/SM12a/159.ts
+++ b/data-asia/SM/SM12a/159.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "レッドの挑戦",
+	},
+
+	illustrator: "Megumi Mizutani",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードは、自分の手札を2枚トラッシュしなければ使えない。自分の山札にある好きなカードを1枚、手札に加える。そして山札を切る。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 544431,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "C",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/SM/SM12a/160.ts
+++ b/data-asia/SM/SM12a/160.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "戒めの祠",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Trainer",
+
+	effect: {
+		ja: "ポケモンチェックのたび、おたがいの「ポケモンGX・EX」全員に、それぞれダメカンを1個のせる。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 544436,
+			},
+		},
+	],
+
+	trainerType: "Stadium",
+	regulationMark: "B",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/SM/SM12a/161.ts
+++ b/data-asia/SM/SM12a/161.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "格闘道場",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Trainer",
+
+	effect: {
+		ja: "おたがいの基本[闘]エネルギーがついているポケモン（「ウルトラビースト」をのぞく）が使うワザの、相手のバトルポケモンへのダメージは「+10」され、自分のサイドの残り枚数が、相手より多いなら「+40」になる。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 544441,
+			},
+		},
+	],
+
+	trainerType: "Stadium",
+	regulationMark: "C",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/SM/SM12a/162.ts
+++ b/data-asia/SM/SM12a/162.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "巨大なカマド",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Trainer",
+
+	effect: {
+		ja: "おたがいのプレイヤーは、自分の番ごとに1回、自分の手札を1枚トラッシュしてよい。その場合、自分の山札にある[炎]エネルギーを2枚まで、相手に見せてから、手札に加える。そして山札を切る。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 544446,
+			},
+		},
+	],
+
+	trainerType: "Stadium",
+	regulationMark: "C",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/SM/SM12a/163.ts
+++ b/data-asia/SM/SM12a/163.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "サンダーマウンテン",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Trainer",
+
+	effect: {
+		ja: "おたがいの場の[雷]ポケモンが使うワザに必要なエネルギーは、それぞれ[雷]エネルギー1個ぶん少なくなる。このスタジアムは、場に出ているかぎり、おたがいのプレイヤーが手札からグッズまたはサポートを出して使ったとき、その効果を受けない。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 544451,
+			},
+		},
+	],
+
+	trainerType: "Stadium",
+	regulationMark: "B",
+	rarity: "Rare Holo",
+};
+
+export default card;

--- a/data-asia/SM/SM12a/164.ts
+++ b/data-asia/SM/SM12a/164.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "テンガン山",
+	},
+
+	illustrator: "Ryo Ueda",
+	category: "Trainer",
+
+	effect: {
+		ja: "おたがいのプレイヤーは、自分の番に1回、自分のトラッシュにある[鋼]エネルギーを2枚、相手に見せてから、手札に加えてよい。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 544456,
+			},
+		},
+	],
+
+	trainerType: "Stadium",
+	regulationMark: "B",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/SM/SM12a/165.ts
+++ b/data-asia/SM/SM12a/165.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "トキワの森",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Trainer",
+
+	effect: {
+		ja: "おたがいのプレイヤーは、自分の番ごとに1回、自分の手札を1枚トラッシュしてよい。その場合、自分の山札にある基本エネルギーを1枚、相手に見せてから、手札に加える。そして山札を切る。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 544461,
+			},
+		},
+	],
+
+	trainerType: "Stadium",
+	regulationMark: "C",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/SM/SM12a/166.ts
+++ b/data-asia/SM/SM12a/166.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヒートファクトリー",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Trainer",
+
+	effect: {
+		ja: "おたがいのプレイヤーは、自分の番ごとに1回、自分の手札にある[炎]エネルギーを、1枚トラッシュしてよい。トラッシュした場合、自分の山札を3枚引く。このスタジアムは、場に出ているかぎり、おたがいのプレイヤーが手札からグッズまたはサポートを出して使ったとき、その効果を受けない。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 544466,
+			},
+		},
+	],
+
+	trainerType: "Stadium",
+	regulationMark: "B",
+	rarity: "Rare Holo",
+};
+
+export default card;

--- a/data-asia/SM/SM12a/167.ts
+++ b/data-asia/SM/SM12a/167.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ブラックマーケット",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Trainer",
+
+	effect: {
+		ja: "おたがいの[悪]エネルギーがついている[悪]ポケモンが、相手のポケモンからワザのダメージを受けてきぜつしたとき、とられるサイドは1枚少なくなる。このスタジアムは、場に出ているかぎり、おたがいのプレイヤーが手札からグッズまたはサポートを出して使ったとき、その効果を受けない。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 544471,
+			},
+		},
+	],
+
+	trainerType: "Stadium",
+	regulationMark: "B",
+	rarity: "Rare Holo",
+};
+
+export default card;

--- a/data-asia/SM/SM12a/168.ts
+++ b/data-asia/SM/SM12a/168.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ライフフォレスト",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Trainer",
+
+	effect: {
+		ja: "おたがいのプレイヤーは、自分の番ごとに1回、自分の[草]ポケモン1匹のHPを「60」回復し、特殊状態もすべて回復してよい。このスタジアムは、場に出ているかぎり、おたがいのプレイヤーが手札からグッズまたはサポートを出して使ったとき、その効果を受けない。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 544476,
+			},
+		},
+	],
+
+	trainerType: "Stadium",
+	regulationMark: "B",
+	rarity: "Rare Holo",
+};
+
+export default card;

--- a/data-asia/SM/SM12a/169.ts
+++ b/data-asia/SM/SM12a/169.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ワンダーラビリンス",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Trainer",
+
+	effect: {
+		ja: "おたがいの場のポケモン（[妖]ポケモンをのぞく）が使うワザに必要なエネルギーは、それぞれ[無]エネルギー1個ぶん多くなる。このスタジアムは、場に出ているかぎり、おたがいのプレイヤーが手札からグッズまたはサポートを出して使ったとき、その効果を受けない。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 544481,
+			},
+		},
+	],
+
+	trainerType: "Stadium",
+	regulationMark: "B",
+	rarity: "Rare Holo",
+};
+
+export default card;

--- a/data-asia/SM/SM12a/170.ts
+++ b/data-asia/SM/SM12a/170.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "超ブーストエネルギー",
+	},
+
+	illustrator: "",
+	category: "Energy",
+	energyType: "Special",
+
+	effect: {
+		ja: "このカードは[無]エネルギー1個ぶんとしてはたらく。このカードは、2進化ポケモンについているかぎり、すべてのタイプのエネルギー1個ぶんとしてはたらき、自分の場に2進化ポケモンが3匹以上いるなら、すべてのタイプのエネルギー4個ぶんとしてはたらく。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 544551,
+			},
+		},
+	],
+
+	regulationMark: "B",
+	rarity: "Rare Holo",
+};
+
+export default card;

--- a/data-asia/SM/SM12a/171.ts
+++ b/data-asia/SM/SM12a/171.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "トリプル加速エネルギー",
+	},
+
+	illustrator: "",
+	category: "Energy",
+	energyType: "Special",
+
+	effect: {
+		ja: "このカードは、進化ポケモンにしかつけられず、つけた番の終わりにトラッシュする。このカードはポケモンについているかぎり[無]エネルギー3個ぶんとしてはたらく。（このカードが進化ポケモン以外についているなら、トラッシュする。）",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 544556,
+			},
+		},
+	],
+
+	regulationMark: "C",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/SM/SM12a/172.ts
+++ b/data-asia/SM/SM12a/172.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ビーストエネルギー",
+	},
+
+	illustrator: "",
+	category: "Energy",
+	energyType: "Special",
+
+	effect: {
+		ja: "このカードは[無]エネルギー1個ぶんとしてはたらく。このカードは、自分の「ウルトラビースト」についているとき、すべてのタイプのエネルギー1個ぶんとしてはたらき、このカードをつけている「ウルトラビースト」が使うワザの、相手のバトルポケモンへのダメージは「+30」される。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 544561,
+			},
+		},
+	],
+
+	regulationMark: "B",
+	rarity: "Rare Holo",
+};
+
+export default card;

--- a/data-asia/SM/SM12a/173.ts
+++ b/data-asia/SM/SM12a/173.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "リサイクルエネルギー",
+	},
+
+	illustrator: "",
+	category: "Energy",
+	energyType: "Special",
+
+	effect: {
+		ja: "このカードは[無]エネルギー1個ぶんとしてはたらく。このカードは、場からトラッシュされるとき、トラッシュせず、手札にもどす。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 544566,
+			},
+		},
+	],
+
+	regulationMark: "C",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/SM/SM12a/174.ts
+++ b/data-asia/SM/SM12a/174.ts
@@ -1,0 +1,55 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヨワシGX",
+	},
+
+	illustrator: "sadaji",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Water"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ぎょぐんストーム" },
+			damage: "20×",
+			cost: ["Water", "Colorless"],
+			effect: {
+				ja: "分の場の「ヨワシ（GXをふくむ）」の数×20ダメージ。",
+			},
+		},
+		{
+			name: { ja: "たいりょうGX" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "分の山札を上から12枚見て、その中にあるたねポケモンを好きなだけ、ベンチに出す。残りのカードは山札にもどして切る。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 544616,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Ultra Rare",
+	dexId: [746],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM12a/175.ts
+++ b/data-asia/SM/SM12a/175.ts
@@ -1,0 +1,63 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "デデンネGX",
+	},
+
+	illustrator: "kanahei",
+	category: "Pokemon",
+	hp: 160,
+	types: ["Lightning"],
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "デデチェンジ" },
+			effect: {
+				ja: "自分の番に、このカードを手札からベンチに出したとき、1回使える。自分の手札をすべてトラッシュし、山札を6枚引く。この番、すでに別の「デデチェンジ」を使っていたなら、この特性は使えない。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "バチバチ" },
+			damage: 50,
+			cost: ["Lightning", "Colorless"],
+		},
+		{
+			name: { ja: "ビリリターンGX" },
+			damage: 50,
+			cost: ["Lightning", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをマヒにする。このポケモンと、ついているすべてのカードを、手札にもどす。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Metal", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 544621,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Ultra Rare",
+	dexId: [702],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM12a/176.ts
+++ b/data-asia/SM/SM12a/176.ts
@@ -1,0 +1,55 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "エーフィ&デオキシスGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 260,
+	types: ["Psychic"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "サイコサークル" },
+			damage: "10+",
+			cost: ["Psychic", "Colorless", "Colorless"],
+			effect: {
+				ja: "自分のベンチの[超]ポケモンの数×30ダメージ追加。",
+			},
+		},
+		{
+			name: { ja: "クロスディヴィジョンGX" },
+			cost: ["Psychic", "Colorless", "Colorless"],
+			effect: {
+				ja: "ダメカン10個を、相手のポケモンに好きなようにのせる。追加でエネルギーが3個ついているなら、のせるダメカンの数は20個になる。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 544626,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "C",
+	rarity: "Ultra Rare",
+	dexId: [196, 386],
+
+	suffix: "TAG TEAM-GX",
+};
+
+export default card;

--- a/data-asia/SM/SM12a/177.ts
+++ b/data-asia/SM/SM12a/177.ts
@@ -1,0 +1,55 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "エーフィ&デオキシスGX",
+	},
+
+	illustrator: "Hasuno",
+	category: "Pokemon",
+	hp: 260,
+	types: ["Psychic"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "サイコサークル" },
+			damage: "10+",
+			cost: ["Psychic", "Colorless", "Colorless"],
+			effect: {
+				ja: "自分のベンチの[超]ポケモンの数×30ダメージ追加。",
+			},
+		},
+		{
+			name: { ja: "クロスディヴィジョンGX" },
+			cost: ["Psychic", "Colorless", "Colorless"],
+			effect: {
+				ja: "ダメカン10個を、相手のポケモンに好きなようにのせる。追加でエネルギーが3個ついているなら、のせるダメカンの数は20個になる。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 544631,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "C",
+	rarity: "Ultra Rare",
+	dexId: [196, 386],
+
+	suffix: "TAG TEAM-GX",
+};
+
+export default card;

--- a/data-asia/SM/SM12a/178.ts
+++ b/data-asia/SM/SM12a/178.ts
@@ -1,0 +1,55 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "オーロット&ヨノワールGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 270,
+	types: ["Psychic"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ナイトウォッチャー" },
+			damage: 150,
+			cost: ["Psychic", "Psychic", "Psychic"],
+			effect: {
+				ja: "手の手札からオモテを見ないで2枚選び、そのカードのオモテを見てから、相手の山札にもどして切る。",
+			},
+		},
+		{
+			name: { ja: "ペイルムーンGX" },
+			cost: ["Psychic", "Colorless"],
+			effect: {
+				ja: "の相手の番の終わりに、このワザを受けたポケモンはきぜつする。追加で[超]エネルギーが1個ついているなら、相手のバトルポケモンについているエネルギーを、すべてトラッシュする。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 544636,
+			},
+		},
+	],
+
+	retreat: 3,
+	regulationMark: "C",
+	rarity: "Ultra Rare",
+	dexId: [709, 477],
+
+	suffix: "TAG TEAM-GX",
+};
+
+export default card;

--- a/data-asia/SM/SM12a/179.ts
+++ b/data-asia/SM/SM12a/179.ts
@@ -1,0 +1,55 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "オーロット&ヨノワールGX",
+	},
+
+	illustrator: "PLANETA Tsuji",
+	category: "Pokemon",
+	hp: 270,
+	types: ["Psychic"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ナイトウォッチャー" },
+			damage: 150,
+			cost: ["Psychic", "Psychic", "Psychic"],
+			effect: {
+				ja: "手の手札からオモテを見ないで2枚選び、そのカードのオモテを見てから、相手の山札にもどして切る。",
+			},
+		},
+		{
+			name: { ja: "ペイルムーンGX" },
+			cost: ["Psychic", "Colorless"],
+			effect: {
+				ja: "の相手の番の終わりに、このワザを受けたポケモンはきぜつする。追加で[超]エネルギーが1個ついているなら、相手のバトルポケモンについているエネルギーを、すべてトラッシュする。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 544641,
+			},
+		},
+	],
+
+	retreat: 3,
+	regulationMark: "C",
+	rarity: "Ultra Rare",
+	dexId: [709, 477],
+
+	suffix: "TAG TEAM-GX",
+};
+
+export default card;

--- a/data-asia/SM/SM12a/180.ts
+++ b/data-asia/SM/SM12a/180.ts
@@ -1,0 +1,65 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ジラーチGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 160,
+	types: ["Psychic"],
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "サイキックゾーン" },
+			effect: {
+				ja: "このポケモンがいるかぎり、おたがいの場の[超]タイプの弱点を持つポケモンが、ワザのダメージを受けるとき、弱点を計算しない。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ほしさがし" },
+			cost: ["Psychic"],
+			effect: {
+				ja: "自分の山札にあるエネルギーを1枚、自分の[超]ポケモンにつける。そして山札を切る。",
+			},
+		},
+		{
+			name: { ja: "スターシールドGX" },
+			damage: 100,
+			cost: ["Psychic", "Psychic", "Psychic"],
+			effect: {
+				ja: "次の相手の番、このポケモンはワザのダメージや効果を受けない。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 544646,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Ultra Rare",
+	dexId: [385],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM12a/181.ts
+++ b/data-asia/SM/SM12a/181.ts
@@ -1,0 +1,55 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ブラッキー&ダークライGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 270,
+	types: ["Darkness"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ブラックランス" },
+			damage: 150,
+			cost: ["Darkness", "Darkness", "Colorless"],
+			effect: {
+				ja: "相手のベンチにいる「ポケモンGX・EX」1匹にも、60ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+			},
+		},
+		{
+			name: { ja: "デッドムーンGX" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "次の相手の番、相手は手札からトレーナーズを出して使えない。追加で[悪]エネルギーが5個ついているなら、相手のバトルポケモンをきぜつさせる。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 544651,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "C",
+	rarity: "Ultra Rare",
+	dexId: [197, 491],
+
+	suffix: "TAG TEAM-GX",
+};
+
+export default card;

--- a/data-asia/SM/SM12a/182.ts
+++ b/data-asia/SM/SM12a/182.ts
@@ -1,0 +1,55 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ブラッキー&ダークライGX",
+	},
+
+	illustrator: "so-taro",
+	category: "Pokemon",
+	hp: 270,
+	types: ["Darkness"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ブラックランス" },
+			damage: 150,
+			cost: ["Darkness", "Darkness", "Colorless"],
+			effect: {
+				ja: "相手のベンチにいる「ポケモンGX・EX」1匹にも、60ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+			},
+		},
+		{
+			name: { ja: "デッドムーンGX" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "次の相手の番、相手は手札からトレーナーズを出して使えない。追加で[悪]エネルギーが5個ついているなら、相手のバトルポケモンをきぜつさせる。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 544656,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "C",
+	rarity: "Ultra Rare",
+	dexId: [197, 491],
+
+	suffix: "TAG TEAM-GX",
+};
+
+export default card;

--- a/data-asia/SM/SM12a/183.ts
+++ b/data-asia/SM/SM12a/183.ts
@@ -1,0 +1,66 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "マニューラGX",
+	},
+
+	illustrator: "aky CG Works",
+	category: "Pokemon",
+	hp: 200,
+	types: ["Darkness"],
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "シャドーコネクション" },
+			effect: {
+				ja: "自分の番に何回でも使える。自分の場のポケモンについている基本[悪]エネルギーを1個、自分の別のポケモンにつけ替える。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ツメできりさく" },
+			damage: 130,
+			cost: ["Darkness", "Darkness", "Colorless"],
+		},
+		{
+			name: { ja: "よるのごうれいGX" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札にあるたねポケモンを好きなだけ、ベンチに出す。そして山札を切る。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 544661,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ニューラ",
+	},
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Ultra Rare",
+	dexId: [461],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM12a/184.ts
+++ b/data-asia/SM/SM12a/184.ts
@@ -1,0 +1,60 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ルカリオ&メルメタルGX",
+	},
+
+	illustrator: "sadaji",
+	category: "Pokemon",
+	hp: 260,
+	types: ["Metal"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "こうてつのこぶし" },
+			damage: 50,
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "自分の山札にある[鋼]エネルギーを1枚、このポケモンにつける。そして山札を切る。",
+			},
+		},
+		{
+			name: { ja: "ヘビーインパクト" },
+			damage: 150,
+			cost: ["Metal", "Metal", "Colorless", "Colorless"],
+		},
+		{
+			name: { ja: "フルメタルウォールGX" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "この対戦が終わるまで、自分の[鋼]ポケモン全員が、相手のポケモンから受けるワザのダメージは、すべて「-30」される。追加でエネルギーが1個ついているなら、相手のバトルポケモンについているエネルギーを、すべてトラッシュする。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 544666,
+			},
+		},
+	],
+
+	retreat: 3,
+	regulationMark: "C",
+	rarity: "Ultra Rare",
+	dexId: [448, 809],
+
+	suffix: "TAG TEAM-GX",
+};
+
+export default card;

--- a/data-asia/SM/SM12a/185.ts
+++ b/data-asia/SM/SM12a/185.ts
@@ -1,0 +1,55 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "トゲピー&ピィ&ププリンGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 240,
+	types: ["Fairy"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ころがりパニック" },
+			damage: "120+",
+			cost: ["Fairy", "Fairy", "Colorless"],
+			effect: {
+				ja: "ラが出るまでコインを投げ、オモテの数×30ダメージ追加。",
+			},
+		},
+		{
+			name: { ja: "シュープリームGX" },
+			cost: ["Fairy", "Fairy"],
+			effect: {
+				ja: "の番が終わったら、もう1回自分の番を始める。追加で[妖]エネルギーが14個ついているなら、相手のベンチポケモン全員と、そのポケモンについているすべてのカードを、相手の山札にもどして切る。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [{ type: "Darkness", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 544671,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "C",
+	rarity: "Ultra Rare",
+	dexId: [175, 173, 174],
+
+	suffix: "TAG TEAM-GX",
+};
+
+export default card;

--- a/data-asia/SM/SM12a/186.ts
+++ b/data-asia/SM/SM12a/186.ts
@@ -1,0 +1,55 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "トゲピー&ピィ&ププリンGX",
+	},
+
+	illustrator: "0313",
+	category: "Pokemon",
+	hp: 240,
+	types: ["Fairy"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ころがりパニック" },
+			damage: "120+",
+			cost: ["Fairy", "Fairy", "Colorless"],
+			effect: {
+				ja: "ラが出るまでコインを投げ、オモテの数×30ダメージ追加。",
+			},
+		},
+		{
+			name: { ja: "シュープリームGX" },
+			cost: ["Fairy", "Fairy"],
+			effect: {
+				ja: "の番が終わったら、もう1回自分の番を始める。追加で[妖]エネルギーが14個ついているなら、相手のベンチポケモン全員と、そのポケモンについているすべてのカードを、相手の山札にもどして切る。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [{ type: "Darkness", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 544676,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "C",
+	rarity: "Ultra Rare",
+	dexId: [175, 173, 174],
+
+	suffix: "TAG TEAM-GX",
+};
+
+export default card;

--- a/data-asia/SM/SM12a/187.ts
+++ b/data-asia/SM/SM12a/187.ts
@@ -1,0 +1,62 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "イーブイGX",
+	},
+
+	illustrator: "aky CG Works",
+	category: "Pokemon",
+	hp: 160,
+	types: ["Colorless"],
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "かくせいDNA" },
+			effect: {
+				ja: "このポケモンは、自分の番に、「イーブイ」から進化するカードを手札から出して、このポケモンに重ねて進化できる（最初の自分の番と、このポケモンを場に出した番はのぞく）。進化する前に、このポケモンのHPを、すべて回復する。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ブーストダッシュ" },
+			damage: 100,
+			cost: ["Colorless", "Colorless", "Colorless"],
+		},
+		{
+			name: { ja: "ハッピーメーカーGX" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分のトラッシュにある好きなカードを3枚、相手に見せてから、手札に加える。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 544681,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Ultra Rare",
+	dexId: [133],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM12a/188.ts
+++ b/data-asia/SM/SM12a/188.ts
@@ -1,0 +1,62 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "イーブイGX",
+	},
+
+	illustrator: "Q-rais",
+	category: "Pokemon",
+	hp: 160,
+	types: ["Colorless"],
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "かくせいDNA" },
+			effect: {
+				ja: "このポケモンは、自分の番に、「イーブイ」から進化するカードを手札から出して、このポケモンに重ねて進化できる（最初の自分の番と、このポケモンを場に出した番はのぞく）。進化する前に、このポケモンのHPを、すべて回復する。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ブーストダッシュ" },
+			damage: 100,
+			cost: ["Colorless", "Colorless", "Colorless"],
+		},
+		{
+			name: { ja: "ハッピーメーカーGX" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分のトラッシュにある好きなカードを3枚、相手に見せてから、手札に加える。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 544686,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Ultra Rare",
+	dexId: [133],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM12a/189.ts
+++ b/data-asia/SM/SM12a/189.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "イツキ",
+	},
+
+	illustrator: "Kazuma Koda",
+	category: "Trainer",
+
+	effect: {
+		ja: "この番、このカードを使ったあとに、ワザ・特性・トレーナーズの効果で自分が次に投げるコインは、最初の1回だけ、オモテかウラか選べる。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 544486,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "C",
+	rarity: "Ultra Rare",
+};
+
+export default card;

--- a/data-asia/SM/SM12a/190.ts
+++ b/data-asia/SM/SM12a/190.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "エリカのおもてなし",
+	},
+
+	illustrator: "kodama",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードは、自分の手札がこのカードをふくめて6枚以上なら使えない。相手の場のポケモンの数ぶん、自分の山札を引く。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 544491,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "C",
+	rarity: "Ultra Rare",
+};
+
+export default card;

--- a/data-asia/SM/SM12a/191.ts
+++ b/data-asia/SM/SM12a/191.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "カスミ&カンナ",
+	},
+
+	illustrator: "Ryuta Fuse",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の山札にある[水]エネルギーを3枚まで、相手に見せてから、手札に加える。そして山札を切る。追加で、このカードを使うときに、自分の手札を5枚トラッシュしてよい。その場合、この番、自分の[水]ポケモンは、自分がすでにGXワザを使っていても、GXワザが使える。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 544496,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "C",
+	rarity: "Ultra Rare",
+};
+
+export default card;

--- a/data-asia/SM/SM12a/192.ts
+++ b/data-asia/SM/SM12a/192.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "かんこうきゃく",
+	},
+
+	illustrator: "Naoki Saito",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の手札が5枚になるように、山札を引く。のぞむなら、山札を引く前に、自分の手札を好きなだけトラッシュする。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 544501,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "B",
+	rarity: "Ultra Rare",
+};
+
+export default card;

--- a/data-asia/SM/SM12a/193.ts
+++ b/data-asia/SM/SM12a/193.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "グリーンの戦略",
+	},
+
+	illustrator: "TOKIYA",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードを使った番の終わりに、自分の手札が8枚になるように、山札を引く。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 544506,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "C",
+	rarity: "Ultra Rare",
+};
+
+export default card;

--- a/data-asia/SM/SM12a/194.ts
+++ b/data-asia/SM/SM12a/194.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ジュジュベ&ハチクマン",
+	},
+
+	illustrator: "Sanosuke Sakuma",
+	category: "Trainer",
+
+	effect: {
+		ja: "おたがいの山札を上から3枚ずつトラッシュする。追加で、このカードを使うときに、自分の手札を3枚トラッシュしてよい。その場合、おたがいのプレイヤーは、それぞれ自分のベンチポケモンが3匹になるまでポケモンをトラッシュする。（トラッシュは相手から行う。）",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 544511,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "C",
+	rarity: "Ultra Rare",
+};
+
+export default card;

--- a/data-asia/SM/SM12a/195.ts
+++ b/data-asia/SM/SM12a/195.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ハプウ",
+	},
+
+	illustrator: "Ryota Murayama",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の山札を上から6枚見て、その中にあるカードを2枚、手札に加える。残りのカードはトラッシュする。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 544516,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "C",
+	rarity: "Ultra Rare",
+};
+
+export default card;

--- a/data-asia/SM/SM12a/196.ts
+++ b/data-asia/SM/SM12a/196.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ブルーの探索",
+	},
+
+	illustrator: "TOKIYA",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードは、自分の場に特性を持つポケモンがいるなら、使えない。自分の山札にあるトレーナ−ズを2枚まで、相手に見せてから、手札に加える。そして山札を切る。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 544521,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "C",
+	rarity: "Ultra Rare",
+};
+
+export default card;

--- a/data-asia/SM/SM12a/197.ts
+++ b/data-asia/SM/SM12a/197.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ホミカの演奏",
+	},
+
+	illustrator: "Jumpei Akasaka",
+	category: "Trainer",
+
+	effect: {
+		ja: "次の相手の番、相手のどくのポケモンは、にげられない。（新しくどくにしたポケモンもふくむ。）",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 544526,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "J",
+	rarity: "Ultra Rare",
+};
+
+export default card;

--- a/data-asia/SM/SM12a/198.ts
+++ b/data-asia/SM/SM12a/198.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "マツリカ",
+	},
+
+	illustrator: "Sanosuke Sakuma",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の山札にある[妖]エネルギーを1枚、自分のポケモンにつける。そして山札を切る。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 544531,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "B",
+	rarity: "Ultra Rare",
+};
+
+export default card;

--- a/data-asia/SM/SM12a/199.ts
+++ b/data-asia/SM/SM12a/199.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヤーコン",
+	},
+
+	illustrator: "Hideki Ishikawa",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の山札を上から7枚トラッシュし、その中にあるグッズをすべて、相手に見せてから、手札に加える。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 544536,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "C",
+	rarity: "Ultra Rare",
+};
+
+export default card;

--- a/data-asia/SM/SM12a/200.ts
+++ b/data-asia/SM/SM12a/200.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "溶接工",
+	},
+
+	illustrator: "Hitoshi Ariga",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の手札にある[炎]エネルギーを2枚まで、自分のポケモン1匹につける。その後、自分の山札を3枚引く。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 544541,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "C",
+	rarity: "Ultra Rare",
+};
+
+export default card;

--- a/data-asia/SM/SM12a/201.ts
+++ b/data-asia/SM/SM12a/201.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "レッドの挑戦",
+	},
+
+	illustrator: "TOKIYA",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードは、自分の手札を2枚トラッシュしなければ使えない。自分の山札にある好きなカードを1枚、手札に加える。そして山札を切る。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 544546,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "C",
+	rarity: "Ultra Rare",
+};
+
+export default card;

--- a/data-asia/SM/SM12a/202.ts
+++ b/data-asia/SM/SM12a/202.ts
@@ -1,0 +1,26 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "基本草エネルギー",
+	},
+
+	illustrator: "",
+	category: "Energy",
+	energyType: "Normal",
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 544571,
+			},
+		},
+	],
+
+	rarity: "Ultra Rare",
+};
+
+export default card;

--- a/data-asia/SM/SM12a/203.ts
+++ b/data-asia/SM/SM12a/203.ts
@@ -1,0 +1,26 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "基本炎エネルギー",
+	},
+
+	illustrator: "",
+	category: "Energy",
+	energyType: "Normal",
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 544576,
+			},
+		},
+	],
+
+	rarity: "Ultra Rare",
+};
+
+export default card;

--- a/data-asia/SM/SM12a/204.ts
+++ b/data-asia/SM/SM12a/204.ts
@@ -1,0 +1,26 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "基本水エネルギー",
+	},
+
+	illustrator: "",
+	category: "Energy",
+	energyType: "Normal",
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 544581,
+			},
+		},
+	],
+
+	rarity: "Ultra Rare",
+};
+
+export default card;

--- a/data-asia/SM/SM12a/205.ts
+++ b/data-asia/SM/SM12a/205.ts
@@ -1,0 +1,26 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "基本雷エネルギー",
+	},
+
+	illustrator: "",
+	category: "Energy",
+	energyType: "Normal",
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 544586,
+			},
+		},
+	],
+
+	rarity: "Ultra Rare",
+};
+
+export default card;

--- a/data-asia/SM/SM12a/206.ts
+++ b/data-asia/SM/SM12a/206.ts
@@ -1,0 +1,26 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "基本超エネルギー",
+	},
+
+	illustrator: "",
+	category: "Energy",
+	energyType: "Normal",
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 544591,
+			},
+		},
+	],
+
+	rarity: "Ultra Rare",
+};
+
+export default card;

--- a/data-asia/SM/SM12a/207.ts
+++ b/data-asia/SM/SM12a/207.ts
@@ -1,0 +1,26 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "基本闘エネルギー",
+	},
+
+	illustrator: "",
+	category: "Energy",
+	energyType: "Normal",
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 544596,
+			},
+		},
+	],
+
+	rarity: "Ultra Rare",
+};
+
+export default card;

--- a/data-asia/SM/SM12a/208.ts
+++ b/data-asia/SM/SM12a/208.ts
@@ -1,0 +1,26 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "基本悪エネルギー",
+	},
+
+	illustrator: "",
+	category: "Energy",
+	energyType: "Normal",
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 544601,
+			},
+		},
+	],
+
+	rarity: "Ultra Rare",
+};
+
+export default card;

--- a/data-asia/SM/SM12a/209.ts
+++ b/data-asia/SM/SM12a/209.ts
@@ -1,0 +1,26 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "基本鋼エネルギー",
+	},
+
+	illustrator: "",
+	category: "Energy",
+	energyType: "Normal",
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 544606,
+			},
+		},
+	],
+
+	rarity: "Ultra Rare",
+};
+
+export default card;

--- a/data-asia/SM/SM12a/210.ts
+++ b/data-asia/SM/SM12a/210.ts
@@ -1,0 +1,26 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "基本フェアリーエネルギー",
+	},
+
+	illustrator: "",
+	category: "Energy",
+	energyType: "Normal",
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 544611,
+			},
+		},
+	],
+
+	rarity: "Ultra Rare",
+};
+
+export default card;

--- a/data-asia/SM/SM12a/211.ts
+++ b/data-asia/SM/SM12a/211.ts
@@ -1,0 +1,55 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヨワシGX",
+	},
+
+	illustrator: "",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Water"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ぎょぐんストーム" },
+			damage: "20×",
+			cost: ["Water", "Colorless"],
+			effect: {
+				ja: "分の場の「ヨワシ（GXをふくむ）」の数×20ダメージ。",
+			},
+		},
+		{
+			name: { ja: "たいりょうGX" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "分の山札を上から12枚見て、その中にあるたねポケモンを好きなだけ、ベンチに出す。残りのカードは山札にもどして切る。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 547071,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Hyper rare",
+	dexId: [746],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM12a/211.ts
+++ b/data-asia/SM/SM12a/211.ts
@@ -7,7 +7,7 @@ const card: Card = {
 		ja: "ヨワシGX",
 	},
 
-	illustrator: "",
+	illustrator: "sadaji",
 	category: "Pokemon",
 	hp: 130,
 	types: ["Water"],

--- a/data-asia/SM/SM12a/212.ts
+++ b/data-asia/SM/SM12a/212.ts
@@ -7,7 +7,7 @@ const card: Card = {
 		ja: "エーフィ&デオキシスGX",
 	},
 
-	illustrator: "",
+	illustrator: "5ban Graphics",
 	category: "Pokemon",
 	hp: 260,
 	types: ["Psychic"],

--- a/data-asia/SM/SM12a/212.ts
+++ b/data-asia/SM/SM12a/212.ts
@@ -1,0 +1,55 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "エーフィ&デオキシスGX",
+	},
+
+	illustrator: "",
+	category: "Pokemon",
+	hp: 260,
+	types: ["Psychic"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "サイコサークル" },
+			damage: "10+",
+			cost: ["Psychic", "Colorless", "Colorless"],
+			effect: {
+				ja: "自分のベンチの[超]ポケモンの数×30ダメージ追加。",
+			},
+		},
+		{
+			name: { ja: "クロスディヴィジョンGX" },
+			cost: ["Psychic", "Colorless", "Colorless"],
+			effect: {
+				ja: "ダメカン10個を、相手のポケモンに好きなようにのせる。追加でエネルギーが3個ついているなら、のせるダメカンの数は20個になる。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 547076,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "C",
+	rarity: "Hyper rare",
+	dexId: [196, 386],
+
+	suffix: "TAG TEAM-GX",
+};
+
+export default card;

--- a/data-asia/SM/SM12a/213.ts
+++ b/data-asia/SM/SM12a/213.ts
@@ -7,7 +7,7 @@ const card: Card = {
 		ja: "オーロット&ヨノワールGX",
 	},
 
-	illustrator: "",
+	illustrator: "5ban Graphics",
 	category: "Pokemon",
 	hp: 270,
 	types: ["Psychic"],

--- a/data-asia/SM/SM12a/213.ts
+++ b/data-asia/SM/SM12a/213.ts
@@ -1,0 +1,55 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "オーロット&ヨノワールGX",
+	},
+
+	illustrator: "",
+	category: "Pokemon",
+	hp: 270,
+	types: ["Psychic"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ナイトウォッチャー" },
+			damage: 150,
+			cost: ["Psychic", "Psychic", "Psychic"],
+			effect: {
+				ja: "手の手札からオモテを見ないで2枚選び、そのカードのオモテを見てから、相手の山札にもどして切る。",
+			},
+		},
+		{
+			name: { ja: "ペイルムーンGX" },
+			cost: ["Psychic", "Colorless"],
+			effect: {
+				ja: "の相手の番の終わりに、このワザを受けたポケモンはきぜつする。追加で[超]エネルギーが1個ついているなら、相手のバトルポケモンについているエネルギーを、すべてトラッシュする。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 547081,
+			},
+		},
+	],
+
+	retreat: 3,
+	regulationMark: "C",
+	rarity: "Hyper rare",
+	dexId: [709, 477],
+
+	suffix: "TAG TEAM-GX",
+};
+
+export default card;

--- a/data-asia/SM/SM12a/214.ts
+++ b/data-asia/SM/SM12a/214.ts
@@ -1,0 +1,65 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ジラーチGX",
+	},
+
+	illustrator: "",
+	category: "Pokemon",
+	hp: 160,
+	types: ["Psychic"],
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "サイキックゾーン" },
+			effect: {
+				ja: "このポケモンがいるかぎり、おたがいの場の[超]タイプの弱点を持つポケモンが、ワザのダメージを受けるとき、弱点を計算しない。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ほしさがし" },
+			cost: ["Psychic"],
+			effect: {
+				ja: "自分の山札にあるエネルギーを1枚、自分の[超]ポケモンにつける。そして山札を切る。",
+			},
+		},
+		{
+			name: { ja: "スターシールドGX" },
+			damage: 100,
+			cost: ["Psychic", "Psychic", "Psychic"],
+			effect: {
+				ja: "次の相手の番、このポケモンはワザのダメージや効果を受けない。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 547086,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Hyper rare",
+	dexId: [385],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM12a/214.ts
+++ b/data-asia/SM/SM12a/214.ts
@@ -7,7 +7,7 @@ const card: Card = {
 		ja: "ジラーチGX",
 	},
 
-	illustrator: "",
+	illustrator: "5ban Graphics",
 	category: "Pokemon",
 	hp: 160,
 	types: ["Psychic"],

--- a/data-asia/SM/SM12a/215.ts
+++ b/data-asia/SM/SM12a/215.ts
@@ -7,7 +7,7 @@ const card: Card = {
 		ja: "ブラッキー&ダークライGX",
 	},
 
-	illustrator: "",
+	illustrator: "5ban Graphics",
 	category: "Pokemon",
 	hp: 270,
 	types: ["Darkness"],

--- a/data-asia/SM/SM12a/215.ts
+++ b/data-asia/SM/SM12a/215.ts
@@ -1,0 +1,55 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ブラッキー&ダークライGX",
+	},
+
+	illustrator: "",
+	category: "Pokemon",
+	hp: 270,
+	types: ["Darkness"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ブラックランス" },
+			damage: 150,
+			cost: ["Darkness", "Darkness", "Colorless"],
+			effect: {
+				ja: "相手のベンチにいる「ポケモンGX・EX」1匹にも、60ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+			},
+		},
+		{
+			name: { ja: "デッドムーンGX" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "次の相手の番、相手は手札からトレーナーズを出して使えない。追加で[悪]エネルギーが5個ついているなら、相手のバトルポケモンをきぜつさせる。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 547091,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "C",
+	rarity: "Hyper rare",
+	dexId: [197, 491],
+
+	suffix: "TAG TEAM-GX",
+};
+
+export default card;

--- a/data-asia/SM/SM12a/216.ts
+++ b/data-asia/SM/SM12a/216.ts
@@ -7,7 +7,7 @@ const card: Card = {
 		ja: "マニューラGX",
 	},
 
-	illustrator: "",
+	illustrator: "aky CG Works",
 	category: "Pokemon",
 	hp: 200,
 	types: ["Darkness"],

--- a/data-asia/SM/SM12a/216.ts
+++ b/data-asia/SM/SM12a/216.ts
@@ -1,0 +1,66 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "マニューラGX",
+	},
+
+	illustrator: "",
+	category: "Pokemon",
+	hp: 200,
+	types: ["Darkness"],
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "シャドーコネクション" },
+			effect: {
+				ja: "自分の番に何回でも使える。自分の場のポケモンについている基本[悪]エネルギーを1個、自分の別のポケモンにつけ替える。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ツメできりさく" },
+			damage: 130,
+			cost: ["Darkness", "Darkness", "Colorless"],
+		},
+		{
+			name: { ja: "よるのごうれいGX" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札にあるたねポケモンを好きなだけ、ベンチに出す。そして山札を切る。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 547096,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ニューラ",
+	},
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Hyper rare",
+	dexId: [461],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM12a/217.ts
+++ b/data-asia/SM/SM12a/217.ts
@@ -1,0 +1,60 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ルカリオ&メルメタルGX",
+	},
+
+	illustrator: "",
+	category: "Pokemon",
+	hp: 260,
+	types: ["Metal"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "こうてつのこぶし" },
+			damage: 50,
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "自分の山札にある[鋼]エネルギーを1枚、このポケモンにつける。そして山札を切る。",
+			},
+		},
+		{
+			name: { ja: "ヘビーインパクト" },
+			damage: 150,
+			cost: ["Metal", "Metal", "Colorless", "Colorless"],
+		},
+		{
+			name: { ja: "フルメタルウォールGX" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "この対戦が終わるまで、自分の[鋼]ポケモン全員が、相手のポケモンから受けるワザのダメージは、すべて「-30」される。追加でエネルギーが1個ついているなら、相手のバトルポケモンについているエネルギーを、すべてトラッシュする。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 547101,
+			},
+		},
+	],
+
+	retreat: 3,
+	regulationMark: "C",
+	rarity: "Hyper rare",
+	dexId: [448, 809],
+
+	suffix: "TAG TEAM-GX",
+};
+
+export default card;

--- a/data-asia/SM/SM12a/217.ts
+++ b/data-asia/SM/SM12a/217.ts
@@ -7,7 +7,7 @@ const card: Card = {
 		ja: "ルカリオ&メルメタルGX",
 	},
 
-	illustrator: "",
+	illustrator: "sadaji",
 	category: "Pokemon",
 	hp: 260,
 	types: ["Metal"],

--- a/data-asia/SM/SM12a/218.ts
+++ b/data-asia/SM/SM12a/218.ts
@@ -1,0 +1,55 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "トゲピー&ピィ&ププリンGX",
+	},
+
+	illustrator: "",
+	category: "Pokemon",
+	hp: 240,
+	types: ["Fairy"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ころがりパニック" },
+			damage: "120+",
+			cost: ["Fairy", "Fairy", "Colorless"],
+			effect: {
+				ja: "ラが出るまでコインを投げ、オモテの数×30ダメージ追加。",
+			},
+		},
+		{
+			name: { ja: "シュープリームGX" },
+			cost: ["Fairy", "Fairy"],
+			effect: {
+				ja: "の番が終わったら、もう1回自分の番を始める。追加で[妖]エネルギーが14個ついているなら、相手のベンチポケモン全員と、そのポケモンについているすべてのカードを、相手の山札にもどして切る。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [{ type: "Darkness", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 547106,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "C",
+	rarity: "Hyper rare",
+	dexId: [175, 173, 174],
+
+	suffix: "TAG TEAM-GX",
+};
+
+export default card;

--- a/data-asia/SM/SM12a/218.ts
+++ b/data-asia/SM/SM12a/218.ts
@@ -7,7 +7,7 @@ const card: Card = {
 		ja: "トゲピー&ピィ&ププリンGX",
 	},
 
-	illustrator: "",
+	illustrator: "5ban Graphics",
 	category: "Pokemon",
 	hp: 240,
 	types: ["Fairy"],

--- a/data-asia/SM/SM12a/219.ts
+++ b/data-asia/SM/SM12a/219.ts
@@ -7,7 +7,7 @@ const card: Card = {
 		ja: "イーブイGX",
 	},
 
-	illustrator: "",
+	illustrator: "aky CG Works",
 	category: "Pokemon",
 	hp: 160,
 	types: ["Colorless"],

--- a/data-asia/SM/SM12a/219.ts
+++ b/data-asia/SM/SM12a/219.ts
@@ -1,0 +1,62 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "イーブイGX",
+	},
+
+	illustrator: "",
+	category: "Pokemon",
+	hp: 160,
+	types: ["Colorless"],
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "かくせいDNA" },
+			effect: {
+				ja: "このポケモンは、自分の番に、「イーブイ」から進化するカードを手札から出して、このポケモンに重ねて進化できる（最初の自分の番と、このポケモンを場に出した番はのぞく）。進化する前に、このポケモンのHPを、すべて回復する。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ブーストダッシュ" },
+			damage: 100,
+			cost: ["Colorless", "Colorless", "Colorless"],
+		},
+		{
+			name: { ja: "ハッピーメーカーGX" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分のトラッシュにある好きなカードを3枚、相手に見せてから、手札に加える。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 547111,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Hyper rare",
+	dexId: [133],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM12a/220.ts
+++ b/data-asia/SM/SM12a/220.ts
@@ -7,7 +7,7 @@ const card: Card = {
 		ja: "レシラム&リザードンGX",
 	},
 
-	illustrator: "",
+	illustrator: "aky CG Works",
 	category: "Pokemon",
 	hp: 270,
 	types: ["Fire"],

--- a/data-asia/SM/SM12a/220.ts
+++ b/data-asia/SM/SM12a/220.ts
@@ -1,0 +1,64 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "レシラム&リザードンGX",
+	},
+
+	illustrator: "",
+	category: "Pokemon",
+	hp: 270,
+	types: ["Fire"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "げきりん" },
+			damage: "30+",
+			cost: ["Fire", "Colorless"],
+			effect: {
+				ja: "このポケモンにのっているダメカンの数x10ダメージ追加。",
+			},
+		},
+		{
+			name: { ja: "フレアストライク" },
+			damage: 230,
+			cost: ["Fire", "Fire", "Fire", "Colorless"],
+			effect: {
+				ja: "次の自分の番、このポケモンは「フレアストライク」が使えない。",
+			},
+		},
+		{
+			name: { ja: "ダブルブレイズGX" },
+			damage: "200+",
+			cost: ["Fire", "Fire", "Fire"],
+			effect: {
+				ja: "追加で[炎]エネルギーが3個ついているなら、100ダメージ追加。その場合、このワザのダメージは、相手のバトルポケモンにかかっている効果を計算しない。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 547116,
+			},
+		},
+	],
+
+	retreat: 3,
+	regulationMark: "C",
+	rarity: "Secret Rare",
+	dexId: [643, 6],
+
+	suffix: "TAG TEAM-GX",
+};
+
+export default card;

--- a/data-asia/SM/SM12a/221.ts
+++ b/data-asia/SM/SM12a/221.ts
@@ -7,7 +7,7 @@ const card: Card = {
 		ja: "ピカチュウ&ゼクロムGX",
 	},
 
-	illustrator: "",
+	illustrator: "5ban Graphics",
 	category: "Pokemon",
 	hp: 240,
 	types: ["Lightning"],

--- a/data-asia/SM/SM12a/221.ts
+++ b/data-asia/SM/SM12a/221.ts
@@ -1,0 +1,56 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ピカチュウ&ゼクロムGX",
+	},
+
+	illustrator: "",
+	category: "Pokemon",
+	hp: 240,
+	types: ["Lightning"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "フルドライブ" },
+			damage: 150,
+			cost: ["Lightning", "Lightning", "Lightning"],
+			effect: {
+				ja: "自分の山札にある[雷]エネルギーを3枚まで、自分のポケモン1匹につける。そして山札を切る。",
+			},
+		},
+		{
+			name: { ja: "タッグボルトGX" },
+			damage: 200,
+			cost: ["Lightning", "Lightning", "Lightning"],
+			effect: {
+				ja: "追加で[雷]エネルギーが3個ついているなら、相手のベンチポケモン1匹にも、170ダメージ。［ベンチは弱点・抵抗力を計算しない。］［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Metal", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 547136,
+			},
+		},
+	],
+
+	retreat: 3,
+	regulationMark: "C",
+	rarity: "Secret Rare",
+	dexId: [25, 644],
+
+	suffix: "TAG TEAM-GX",
+};
+
+export default card;

--- a/data-asia/SM/SM12a/222.ts
+++ b/data-asia/SM/SM12a/222.ts
@@ -1,0 +1,58 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ミュウツー&ミュウGX",
+	},
+
+	illustrator: "",
+	category: "Pokemon",
+	hp: 270,
+	types: ["Psychic"],
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "パーフェクション" },
+			effect: {
+				ja: "このポケモンは、自分のベンチまたはトラッシュにある「ポケモンGX・EX」が持っているワザを、すべて使える。［ワザを使うためのエネルギーは必要。］",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "Attack 1" },
+			damage: 200,
+			cost: ["Psychic", "Psychic", "Colorless"],
+			effect: {
+				ja: "追加でエネルギーが1個ついているなら、自分のポケモン全員のHPを、すべて回復する。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 547166,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "C",
+	rarity: "Secret Rare",
+	dexId: [150, 151],
+
+	suffix: "TAG TEAM-GX",
+};
+
+export default card;

--- a/data-asia/SM/SM12a/222.ts
+++ b/data-asia/SM/SM12a/222.ts
@@ -7,7 +7,7 @@ const card: Card = {
 		ja: "ミュウツー&ミュウGX",
 	},
 
-	illustrator: "",
+	illustrator: "5ban Graphics",
 	category: "Pokemon",
 	hp: 270,
 	types: ["Psychic"],

--- a/data-asia/SM/SM12a/223.ts
+++ b/data-asia/SM/SM12a/223.ts
@@ -1,0 +1,55 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ゲッコウガ&ゾロアークGX",
+	},
+
+	illustrator: "",
+	category: "Pokemon",
+	hp: 250,
+	types: ["Darkness"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "あくのはどう" },
+			damage: "30+",
+			cost: ["Darkness", "Colorless"],
+			effect: {
+				ja: "自分の場のポケモンについている[悪]エネルギーの数x30ダメージ追加。",
+			},
+		},
+		{
+			name: { ja: "ナイトユニゾンGX" },
+			cost: ["Darkness", "Colorless"],
+			effect: {
+				ja: "自分のトラッシュにある[悪]タイプの「ポケモンGX・EX」を2枚、ベンチに出す。 追加でエネルギーが1個ついているなら、新しく出したポケモンに、トラッシュにあるエネルギーを2枚ずつつける。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 547196,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "C",
+	rarity: "Secret Rare",
+	dexId: [658, 571],
+
+	suffix: "TAG TEAM-GX",
+};
+
+export default card;

--- a/data-asia/SM/SM12a/223.ts
+++ b/data-asia/SM/SM12a/223.ts
@@ -7,7 +7,7 @@ const card: Card = {
 		ja: "ゲッコウガ&ゾロアークGX",
 	},
 
-	illustrator: "",
+	illustrator: "5ban Graphics",
 	category: "Pokemon",
 	hp: 250,
 	types: ["Darkness"],

--- a/data-asia/SM/SM12a/224.ts
+++ b/data-asia/SM/SM12a/224.ts
@@ -7,7 +7,7 @@ const card: Card = {
 		ja: "ルカリオ&メルメタルGX",
 	},
 
-	illustrator: "",
+	illustrator: "5ban Graphics",
 	category: "Pokemon",
 	hp: 260,
 	types: ["Metal"],

--- a/data-asia/SM/SM12a/224.ts
+++ b/data-asia/SM/SM12a/224.ts
@@ -1,0 +1,60 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ルカリオ&メルメタルGX",
+	},
+
+	illustrator: "",
+	category: "Pokemon",
+	hp: 260,
+	types: ["Metal"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "こうてつのこぶし" },
+			damage: 50,
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "自分の山札にある[鋼]エネルギーを1枚、このポケモンにつける。そして山札を切る。",
+			},
+		},
+		{
+			name: { ja: "ヘビーインパクト" },
+			damage: 150,
+			cost: ["Metal", "Metal", "Colorless", "Colorless"],
+		},
+		{
+			name: { ja: "フルメタルウォールGX" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "この対戦が終わるまで、自分の[鋼]ポケモン全員が、相手のポケモンから受けるワザのダメージは、すべて「-30」される。追加でエネルギーが1個ついているなら、相手のバトルポケモンについているエネルギーを、すべてトラッシュする。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 547211,
+			},
+		},
+	],
+
+	retreat: 3,
+	regulationMark: "C",
+	rarity: "Secret Rare",
+	dexId: [448, 809],
+
+	suffix: "TAG TEAM-GX",
+};
+
+export default card;

--- a/data-asia/SM/SM12a/225.ts
+++ b/data-asia/SM/SM12a/225.ts
@@ -1,0 +1,62 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ガブリアス&ギラティナGX",
+	},
+
+	illustrator: "",
+	category: "Pokemon",
+	hp: 270,
+	types: ["Dragon"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ちょくげきだん" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "相手のポケモン1匹に、40ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+			},
+		},
+		{
+			name: { ja: "カラミティエッジ" },
+			damage: "160+",
+			cost: ["Psychic", "Fighting", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンにダメカンがのっているなら、80ダメージ追加。",
+			},
+		},
+		{
+			name: { ja: "ジージーエンドGX" },
+			cost: ["Psychic", "Psychic", "Fighting"],
+			effect: {
+				ja: "相手のポケモン1匹と、ついているすべてのカードを、トラッシュする。追加で[闘]エネルギーが3個ついているなら、トラッシュするポケモンの数は2匹になる。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fairy", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 547216,
+			},
+		},
+	],
+
+	retreat: 3,
+	regulationMark: "C",
+	rarity: "Secret Rare",
+	dexId: [445, 487],
+
+	suffix: "TAG TEAM-GX",
+};
+
+export default card;

--- a/data-asia/SM/SM12a/225.ts
+++ b/data-asia/SM/SM12a/225.ts
@@ -7,7 +7,7 @@ const card: Card = {
 		ja: "ガブリアス&ギラティナGX",
 	},
 
-	illustrator: "",
+	illustrator: "aky CG Works",
 	category: "Pokemon",
 	hp: 270,
 	types: ["Dragon"],

--- a/data-asia/SM/SM12a/226.ts
+++ b/data-asia/SM/SM12a/226.ts
@@ -7,7 +7,7 @@ const card: Card = {
 		ja: "ファイヤー&サンダー&フリーザーGX",
 	},
 
-	illustrator: "",
+	illustrator: "5ban Graphics",
 	category: "Pokemon",
 	hp: 300,
 	types: ["Colorless"],

--- a/data-asia/SM/SM12a/226.ts
+++ b/data-asia/SM/SM12a/226.ts
@@ -1,0 +1,52 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ファイヤー&サンダー&フリーザーGX",
+	},
+
+	illustrator: "",
+	category: "Pokemon",
+	hp: 300,
+	types: ["Colorless"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "トリニティバーン" },
+			damage: 210,
+			cost: ["Fire", "Water", "Lightning", "Colorless"],
+		},
+		{
+			name: { ja: "スカイレジェンドGX" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "このポケモンと、ついているすべてのカードを、自分の山札にもどして切る。追加で[炎][水][雷]エネルギーが1個ずつついているなら、相手のポケモン3匹に、それぞれ110ダメージ。［ベンチは弱点・抵抗力を計算しない。］［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 547221,
+			},
+		},
+	],
+
+	retreat: 3,
+	regulationMark: "C",
+	rarity: "Secret Rare",
+	dexId: [146, 145, 144],
+
+	suffix: "TAG TEAM-GX",
+};
+
+export default card;


### PR DESCRIPTION
## What

Adds the complete Japanese set **SM12a TAG TEAM GXタッグオールスターズ (Tag All Stars)**, released 2019-10-04:

- `data-asia/SM/SM12a/001.ts` … `226.ts` — all 226 cards (173 regular + 53 secret rares: 37 SR, 9 UR, 7 Secret Rare)
- the set definition `data-asia/SM/SM12a.ts` already existed and is untouched

## Data sources

- **pokemon-card.com** (official database): Japanese names, flavor texts, National Dex numbers, official card count
- **limitlesstcg.com**: full Japanese card text, stages, weaknesses/resistances/retreat, rarities, illustrators, attack costs
- **Cardmarket**: product IDs as `thirdParty.cardmarket` on the variant objects (543366–547221; tcgplayer IDs not available to me)

## Notes

- Follows the file format and conventions of the M-era sets (#1728)
- All 226 files type-check against `interfaces.d.ts` (`tsc --noEmit`)
