### PR TITLE
(data) Add Japanese SM set SM12 Alter Genesis

### DIFF
--- a/data-asia/SM/SM12/001.ts
+++ b/data-asia/SM/SM12/001.ts
@@ -1,0 +1,50 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヒマナッツ",
+	},
+
+	illustrator: "0313",
+	category: "Pokemon",
+	hp: 50,
+	types: ["Grass"],
+
+	description: {
+		ja: "ある朝 突然 降ってくる。 オニスズメに 襲われると 葉っぱを 激しく 振って 追い払う。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "やどりぎのタネ" },
+			damage: 10,
+			cost: ["Grass"],
+			effect: {
+				ja: "このポケモンのHPを「10」回復する。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 554751,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [191],
+};
+
+export default card;

--- a/data-asia/SM/SM12/002.ts
+++ b/data-asia/SM/SM12/002.ts
@@ -1,0 +1,58 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "キマワリ",
+	},
+
+	illustrator: "Yumi",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Grass"],
+
+	description: {
+		ja: "暑い 季節が 近づくと 顔の 花びらは 鮮やかになり 活発に 動くようになる。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "サンパワー" },
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "次の自分の番、[草]または[炎]ポケモンが使うワザに必要なエネルギーは、すべてなくなる。（新しく出したポケモンも含む。）",
+			},
+		},
+		{
+			name: { ja: "ソーラービーム" },
+			damage: 80,
+			cost: ["Grass", "Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 554752,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ヒマナッツ",
+	},
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Uncommon",
+	dexId: [192],
+};
+
+export default card;

--- a/data-asia/SM/SM12/003.ts
+++ b/data-asia/SM/SM12/003.ts
@@ -1,0 +1,54 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "リリーラ",
+	},
+
+	illustrator: "Misa Tsutsui",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Grass"],
+
+	description: {
+		ja: "古代の 暖かい 海に いた。 海草に 化け 獲物を 待ち伏せ 近寄ったところを 丸呑みにする。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "あやしいひかり" },
+			cost: ["Grass"],
+			effect: {
+				ja: "相手のバトルポケモンをこんらんにする。",
+			},
+		},
+		{
+			name: { ja: "タネばくだん" },
+			damage: 60,
+			cost: ["Grass", "Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 554753,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [345],
+};
+
+export default card;

--- a/data-asia/SM/SM12/004.ts
+++ b/data-asia/SM/SM12/004.ts
@@ -1,0 +1,64 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ユレイドル",
+	},
+
+	illustrator: "otumami",
+	category: "Pokemon",
+	hp: 150,
+	types: ["Grass"],
+
+	description: {
+		ja: "普段は 浅瀬の 海底に 棲み 潮が 引くと そのまま 陸に あがって 獲物を 探していた。",
+	},
+
+	stage: "Stage2",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ゆらゆらしばり" },
+			effect: {
+				ja: "このポケモンがいるかぎり、相手の特殊状態のポケモンは、にげられない。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "どくのしょくしゅ" },
+			damage: 110,
+			cost: ["Grass", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをどくにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 554754,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "リリーラ",
+	},
+
+	retreat: 3,
+	regulationMark: "C",
+	rarity: "Uncommon",
+	dexId: [346],
+};
+
+export default card;

--- a/data-asia/SM/SM12/005.ts
+++ b/data-asia/SM/SM12/005.ts
@@ -1,0 +1,54 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "コロボーシ",
+	},
+
+	illustrator: "Ken Sugimori",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Grass"],
+
+	description: {
+		ja: "触角を ぶつけ合って 鳴らす 音で 仲間と 会話をする。 音色は 秋の 夜の 風物詩。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "もってくる" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札を1枚引く。",
+			},
+		},
+		{
+			name: { ja: "むしくい" },
+			damage: 10,
+			cost: ["Grass"],
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 554756,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [401],
+};
+
+export default card;

--- a/data-asia/SM/SM12/006.ts
+++ b/data-asia/SM/SM12/006.ts
@@ -1,0 +1,54 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "コロトック",
+	},
+
+	illustrator: "Anesaki Dynamic",
+	category: "Pokemon",
+	hp: 100,
+	types: ["Grass"],
+
+	description: {
+		ja: "鳴くときは ナイフのような 腕を 胸の 前で 交差させる。 即興で メロディを 作る。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "きままなえんそう" },
+			damage: "30+",
+			cost: ["Grass"],
+			effect: {
+				ja: "自分の手札が1枚なら、100ダメージ追加。3枚なら、相手のバトルポケモンをこんらんにする。6枚なら、相手のベンチポケモン全員にも、それぞれ30ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 554757,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "コロボーシ",
+	},
+
+	retreat: 2,
+	regulationMark: "C",
+	rarity: "Uncommon",
+	dexId: [402],
+};
+
+export default card;

--- a/data-asia/SM/SM12/007.ts
+++ b/data-asia/SM/SM12/007.ts
@@ -1,0 +1,54 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "モクロー",
+	},
+
+	illustrator: "Yuka Morii",
+	category: "Pokemon",
+	hp: 50,
+	types: ["Grass"],
+
+	description: {
+		ja: "刃物の ように 鋭い 羽を 飛ばして 攻撃。 足の力も 強く キックも 侮れないのだ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "かくれんぼ" },
+			cost: ["Grass"],
+			effect: {
+				ja: "コインを1回投げオモテなら、次の相手の番、このポケモンはワザのダメージや効果を受けない。",
+			},
+		},
+		{
+			name: { ja: "たいあたり" },
+			damage: 30,
+			cost: ["Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 554759,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [722],
+};
+
+export default card;

--- a/data-asia/SM/SM12/008.ts
+++ b/data-asia/SM/SM12/008.ts
@@ -1,0 +1,49 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "モクロー",
+	},
+
+	illustrator: "Saya Tsuruta",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Grass"],
+
+	description: {
+		ja: "刃物の ように 鋭い 羽を 飛ばして 攻撃。 足の力も 強く キックも 侮れないのだ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ちょくげきひこう" },
+			cost: ["Grass"],
+			effect: {
+				ja: "相手のポケモン1匹に、10ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 554762,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [722],
+};
+
+export default card;

--- a/data-asia/SM/SM12/009.ts
+++ b/data-asia/SM/SM12/009.ts
@@ -1,0 +1,59 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "フクスロー",
+	},
+
+	illustrator: "Akira Komayama",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Grass"],
+
+	description: {
+		ja: "ナルシストで 綺麗好き。 マメに お手入れ してあげないと いうことを 聞かなく なることも。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "このは" },
+			damage: 20,
+			cost: ["Grass"],
+		},
+		{
+			name: { ja: "つばさではじく" },
+			damage: 30,
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをベンチポケモンと入れ替える。［バトル場に出すポケモンは相手が選ぶ。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 554766,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "モクロー",
+	},
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [723],
+};
+
+export default card;

--- a/data-asia/SM/SM12/010.ts
+++ b/data-asia/SM/SM12/010.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ジュナイパー",
+	},
+
+	illustrator: "kawayoo",
+	category: "Pokemon",
+	hp: 140,
+	types: ["Grass"],
+
+	description: {
+		ja: "矢羽を つがえ 相手に 放つ。 絶対 外せない時は 頭の ツルを引き 集中 するのだ。",
+	},
+
+	stage: "Stage2",
+
+	attacks: [
+		{
+			name: { ja: "ちょくげきひこう" },
+			cost: ["Grass"],
+			effect: {
+				ja: "相手のポケモン1匹に、40ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+			},
+		},
+		{
+			name: { ja: "トラッキングシュート" },
+			damage: 80,
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "ダメカンがのっている相手のベンチポケモン1匹にも、80ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 554768,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "フクスロー",
+	},
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Rare",
+	dexId: [724],
+};
+
+export default card;

--- a/data-asia/SM/SM12/011.ts
+++ b/data-asia/SM/SM12/011.ts
@@ -1,0 +1,60 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "マッシブーン",
+	},
+
+	illustrator: "Anesaki Dynamic",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Grass"],
+
+	description: {
+		ja: "この世界では 異質で 危険だが 本来 棲んでいる 世界では 普通に 見かける 生物らしい。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ビーストブースト" },
+			effect: {
+				ja: "このポケモンが使うワザの、相手のバトルポケモンへのダメージは、自分がすでにとったサイド1枚につき「+20」される。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "タッチダウン" },
+			damage: 60,
+			cost: ["Grass", "Colorless"],
+			effect: {
+				ja: "このポケモンのHPを「30」回復する。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 554773,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "C",
+	rarity: "Rare",
+	dexId: [794],
+};
+
+export default card;

--- a/data-asia/SM/SM12/012.ts
+++ b/data-asia/SM/SM12/012.ts
@@ -1,0 +1,52 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "メラルバ",
+	},
+
+	illustrator: "Midori Harada",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Fire"],
+
+	description: {
+		ja: "５本のツノから 炎を 吹きだし 相手と 戦う。 その温度は 最大で ３０００度に 達する。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ぶつかる" },
+			damage: 10,
+			cost: ["Colorless"],
+		},
+		{
+			name: { ja: "かえん" },
+			damage: 50,
+			cost: ["Fire", "Fire", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 554778,
+			},
+		},
+	],
+
+	retreat: 3,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [636],
+};
+
+export default card;

--- a/data-asia/SM/SM12/013.ts
+++ b/data-asia/SM/SM12/013.ts
@@ -1,0 +1,69 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ウルガモスGX",
+	},
+
+	illustrator: "Hiroyuki Yamamoto",
+	category: "Pokemon",
+	hp: 210,
+	types: ["Fire"],
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "れっかだん" },
+			effect: {
+				ja: "自分の番に1回使える。自分の手札にある[炎]エネルギーを、1枚トラッシュする。その後、相手のポケモン1匹に、ダメカンを2個のせる。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "バックファイヤー" },
+			damage: 160,
+			cost: ["Fire", "Fire", "Colorless"],
+			effect: {
+				ja: "このポケモンについている[炎]エネルギーを、2個手札にもどす。",
+			},
+		},
+		{
+			name: { ja: "だいねっぱGX" },
+			cost: ["Fire"],
+			effect: {
+				ja: "相手の場のポケモン全員についているエネルギーを、1個ずつトラッシュする。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 554782,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "メラルバ",
+	},
+
+	retreat: 3,
+	regulationMark: "C",
+	rarity: "Double rare",
+	dexId: [637],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM12/014.ts
+++ b/data-asia/SM/SM12/014.ts
@@ -1,0 +1,52 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "シシコ",
+	},
+
+	illustrator: "HYOGONOSUKE",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Fire"],
+
+	description: {
+		ja: "幼い頃は 仲間と 群れている。 自分で 獲物を 狩るようになると 群れから 追い出され 独り立ちする。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "たいあたり" },
+			damage: 10,
+			cost: ["Fire"],
+		},
+		{
+			name: { ja: "ほのおのしっぽ" },
+			damage: 20,
+			cost: ["Fire", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 554783,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [667],
+};
+
+export default card;

--- a/data-asia/SM/SM12/015.ts
+++ b/data-asia/SM/SM12/015.ts
@@ -1,0 +1,59 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "カエンジシ",
+	},
+
+	illustrator: "KEIICHIRO ITO",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Fire"],
+
+	description: {
+		ja: "オスは 普段 だらだら しているが 強敵が 襲ってくると わが身を かえりみず 仲間を 守るぞ。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "うずまくごうか" },
+			damage: 70,
+			cost: ["Fire", "Fire", "Colorless"],
+			effect: {
+				ja: "相手の場のポケモンについている「ポケモンのどうぐ」と「特殊エネルギー」を、すべてトラッシュする。",
+			},
+		},
+		{
+			name: { ja: "ヒートブラスト" },
+			damage: 140,
+			cost: ["Fire", "Fire", "Fire", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 554788,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "シシコ",
+	},
+
+	retreat: 2,
+	regulationMark: "C",
+	rarity: "Uncommon",
+	dexId: [668],
+};
+
+export default card;

--- a/data-asia/SM/SM12/016.ts
+++ b/data-asia/SM/SM12/016.ts
@@ -1,0 +1,57 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アローラロコン",
+	},
+
+	illustrator: "nagimiso",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Water"],
+
+	description: {
+		ja: "かわいいからと 無闇に 近付くと 群れの ボスで ある キュウコンが 現れて 氷漬けに される。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ゆきごもり" },
+			effect: {
+				ja: "このポケモンは、ベンチにいるかぎり、ワザのダメージを受けない。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "かじる" },
+			damage: 10,
+			cost: [],
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 554789,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [37],
+};
+
+export default card;

--- a/data-asia/SM/SM12/017.ts
+++ b/data-asia/SM/SM12/017.ts
@@ -1,0 +1,50 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ユキワラシ",
+	},
+
+	illustrator: "sowsow",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Water"],
+
+	description: {
+		ja: "雪や 氷が 主な エサ。 暖かな アローラでは 限られた 場所 でしか 生きていけない。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "れんぞくずつき" },
+			damage: "20×",
+			cost: ["Water"],
+			effect: {
+				ja: "ウラが出るまでコインを投げ、オモテの数×20ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 554792,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [361],
+};
+
+export default card;

--- a/data-asia/SM/SM12/018.ts
+++ b/data-asia/SM/SM12/018.ts
@@ -1,0 +1,62 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "オニゴーリ",
+	},
+
+	illustrator: "Uta",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Water"],
+
+	description: {
+		ja: "獲物を 凍らせ 丸かじり。 だけど 好物は バニプッチなどの もともと 凍っている ポケモンだ。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "こおりのキバ" },
+			damage: 30,
+			cost: ["Water"],
+			effect: {
+				ja: "コインを1回投げオモテなら、相手のバトルポケモンをマヒにする。さらに、相手のバトルポケモンについているエネルギーを、1個トラッシュする。",
+			},
+		},
+		{
+			name: { ja: "フロストタイフーン" },
+			damage: 120,
+			cost: ["Water", "Colorless", "Colorless"],
+			effect: {
+				ja: "次の自分の番、このポケモンは「フロストタイフーン」が使えない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 554796,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ユキワラシ",
+	},
+
+	retreat: 3,
+	regulationMark: "C",
+	rarity: "Uncommon",
+	dexId: [362],
+};
+
+export default card;

--- a/data-asia/SM/SM12/019.ts
+++ b/data-asia/SM/SM12/019.ts
@@ -1,0 +1,52 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "タマザラシ",
+	},
+
+	illustrator: "sui",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Water"],
+
+	description: {
+		ja: "まだ 上手に 泳げず 転がったほうが 速く 動ける。 うれしいと みんなで 手をたたく。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ころがる" },
+			damage: 10,
+			cost: ["Water"],
+		},
+		{
+			name: { ja: "スノーアイス" },
+			damage: 20,
+			cost: ["Water", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 554799,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [363],
+};
+
+export default card;

--- a/data-asia/SM/SM12/020.ts
+++ b/data-asia/SM/SM12/020.ts
@@ -1,0 +1,50 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "タマザラシ",
+	},
+
+	illustrator: "SATOSHI NAKAI",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Water"],
+
+	description: {
+		ja: "まだ 上手に 泳げず 転がったほうが 速く 動ける。 うれしいと みんなで 手をたたく。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "のしかかり" },
+			damage: 30,
+			cost: ["Water", "Colorless", "Colorless"],
+			effect: {
+				ja: "コインを1回投げオモテなら、相手のバトルポケモンをマヒにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 554803,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [363],
+};
+
+export default card;

--- a/data-asia/SM/SM12/021.ts
+++ b/data-asia/SM/SM12/021.ts
@@ -1,0 +1,56 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "トドグラー",
+	},
+
+	illustrator: "miki kudo",
+	category: "Pokemon",
+	hp: 100,
+	types: ["Water"],
+
+	description: {
+		ja: "鼻の 神経が 敏感。 はじめて 目に する 物は 鼻で 触って 覚えるのだ。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "ころがる" },
+			damage: 20,
+			cost: ["Water"],
+		},
+		{
+			name: { ja: "アイスボール" },
+			damage: 90,
+			cost: ["Water", "Colorless", "Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 554804,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "タマザラシ",
+	},
+
+	retreat: 3,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [364],
+};
+
+export default card;

--- a/data-asia/SM/SM12/022.ts
+++ b/data-asia/SM/SM12/022.ts
@@ -1,0 +1,62 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "トドゼルガ",
+	},
+
+	illustrator: "Ayaka Yoshida",
+	category: "Pokemon",
+	hp: 160,
+	types: ["Water"],
+
+	description: {
+		ja: "大きな 氷を キバで 砕く。 厚い 脂肪は 寒さだけでなく 敵の 攻撃も はね返す。",
+	},
+
+	stage: "Stage2",
+
+	attacks: [
+		{
+			name: { ja: "コールドウェーブ" },
+			damage: 60,
+			cost: ["Water"],
+			effect: {
+				ja: "次の相手の番、相手は手札からトレーナーズを出して使えない。前の自分の番に、自分のポケモンが「コールドウェーブ」を使っていたなら、このワザは使えない。",
+			},
+		},
+		{
+			name: { ja: "ふぶき" },
+			damage: 120,
+			cost: ["Water", "Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のベンチポケモン全員にも、それぞれ10ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 554807,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "トドグラー",
+	},
+
+	retreat: 4,
+	regulationMark: "C",
+	rarity: "Uncommon",
+	dexId: [365],
+};
+
+export default card;

--- a/data-asia/SM/SM12/023.ts
+++ b/data-asia/SM/SM12/023.ts
@@ -1,0 +1,50 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "コアルヒー",
+	},
+
+	illustrator: "Yumi",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Water"],
+
+	description: {
+		ja: "敵に 襲われると 全身の 羽毛から 水しぶきを 出す。 水煙に 紛れて 逃げるのだ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "つばめがえし" },
+			damage: "10+",
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "コインを1回投げオモテなら、30ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 554808,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [580],
+};
+
+export default card;

--- a/data-asia/SM/SM12/024.ts
+++ b/data-asia/SM/SM12/024.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "スワンナ",
+	},
+
+	illustrator: "Yukiko Baba",
+	category: "Pokemon",
+	hp: 110,
+	types: ["Water"],
+
+	description: {
+		ja: "優雅な みかけに よらず 翼で 力強く 羽ばたき 数千キロ 飛び続けられる。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "おいかぜ" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の手札にあるエネルギーを1枚、自分のポケモンにつける。",
+			},
+		},
+		{
+			name: { ja: "エアスラッシュ" },
+			damage: 70,
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンについているエネルギーを、1個トラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 554813,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "コアルヒー",
+	},
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Uncommon",
+	dexId: [581],
+};
+
+export default card;

--- a/data-asia/SM/SM12/025.ts
+++ b/data-asia/SM/SM12/025.ts
@@ -1,0 +1,58 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ブラックキュレム",
+	},
+
+	illustrator: "Kouki Saitou",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Water"],
+
+	description: {
+		ja: "失った 体を 真実と 理想で 埋めてくれる 英雄を 待つ 氷の 伝説ポケモン。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "いてつくつばさ" },
+			damage: 30,
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンについている特殊エネルギーを、1個トラッシュする。",
+			},
+		},
+		{
+			name: { ja: "ブリザードダスト" },
+			damage: "100+",
+			cost: ["Water", "Water", "Colorless", "Colorless"],
+			effect: {
+				ja: "場に自分のスタジアムが出ているなら、100ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 554818,
+			},
+		},
+	],
+
+	retreat: 3,
+	regulationMark: "C",
+	rarity: "Rare",
+	dexId: [646],
+};
+
+export default card;

--- a/data-asia/SM/SM12/026.ts
+++ b/data-asia/SM/SM12/026.ts
@@ -1,0 +1,54 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "チョンチー",
+	},
+
+	illustrator: "Sekio",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Lightning"],
+
+	description: {
+		ja: "２本の 触手が ほのかに 光って 獲物を 呼び寄せる。 夜釣りに 便利な ポケモンだ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "さぐる" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "相手の手札を見る。",
+			},
+		},
+		{
+			name: { ja: "ひれカッター" },
+			damage: 10,
+			cost: ["Lightning"],
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Metal", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 554819,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [170],
+};
+
+export default card;

--- a/data-asia/SM/SM12/027.ts
+++ b/data-asia/SM/SM12/027.ts
@@ -1,0 +1,64 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ランターン",
+	},
+
+	illustrator: "otumami",
+	category: "Pokemon",
+	hp: 110,
+	types: ["Lightning"],
+
+	description: {
+		ja: "触手に 棲む バクテリアが ランターンの 体液を 吸うとき 強い 発光現象が 起こる。",
+	},
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ちらちらライト" },
+			effect: {
+				ja: "自分の番に何回でも使える。相手の山札を上から1枚見て、もとにもどす。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "かくはんりゅう" },
+			damage: 50,
+			cost: ["Lightning", "Colorless"],
+			effect: {
+				ja: "のぞむなら、相手に相手自身の山札を切らせる。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Metal", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 554824,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "チョンチー",
+	},
+
+	retreat: 2,
+	regulationMark: "C",
+	rarity: "Uncommon",
+	dexId: [171],
+};
+
+export default card;

--- a/data-asia/SM/SM12/028.ts
+++ b/data-asia/SM/SM12/028.ts
@@ -1,0 +1,56 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "トゲデマル",
+	},
+
+	illustrator: "sowsow",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Lightning"],
+
+	description: {
+		ja: "１４本の 背中の ハリの 毛は びっくりしたり 興奮することが あると 勝手に 逆立ってしまう。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "なかまをよぶ" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札にあるたねポケモンを2枚まで、ベンチに出す。そして山札を切る。",
+			},
+		},
+		{
+			name: { ja: "でんじスパーク" },
+			cost: ["Lightning"],
+			effect: {
+				ja: "相手のポケモン1匹に、20ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Metal", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 554828,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [777],
+};
+
+export default card;

--- a/data-asia/SM/SM12/029.ts
+++ b/data-asia/SM/SM12/029.ts
@@ -1,0 +1,57 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "コロモリ",
+	},
+
+	illustrator: "Shibuzoh.",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Psychic"],
+
+	description: {
+		ja: "暗い 森や 洞穴で 暮らす。 鼻の 穴から 超音波を 出して あたりの 様子を 探る。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "はなですいつく" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "次の相手の番、このワザを受けたポケモンは、にげられない。",
+			},
+		},
+		{
+			name: { ja: "エアカッター" },
+			damage: 30,
+			cost: ["Psychic"],
+			effect: {
+				ja: "コインを1回投げウラなら、このワザは失敗。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 554833,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [527],
+};
+
+export default card;

--- a/data-asia/SM/SM12/030.ts
+++ b/data-asia/SM/SM12/030.ts
@@ -1,0 +1,60 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ココロモリ",
+	},
+
+	illustrator: "Tomokazu Komiya",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Psychic"],
+
+	description: {
+		ja: "コンクリートも 壊せるほどの 強い 超音波を 出すとき 尻尾が 激しく 震える。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "ちょうおんぱ" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをこんらんにする。",
+			},
+		},
+		{
+			name: { ja: "チャームスタンプ" },
+			cost: ["Psychic"],
+			effect: {
+				ja: "相手は相手自身のポケモンを1匹選ぶ。そのポケモンに、90ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 554838,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "コロモリ",
+	},
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Uncommon",
+	dexId: [528],
+};
+
+export default card;

--- a/data-asia/SM/SM12/031.ts
+++ b/data-asia/SM/SM12/031.ts
@@ -1,0 +1,50 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ゴビット",
+	},
+
+	illustrator: "Shigenori Negishi",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Psychic"],
+
+	description: {
+		ja: "謎の エネルギーに よって 活動。 古代から 動き続けているので そろそろ パワーが 尽きるとも。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "おんがえし" },
+			damage: 10,
+			cost: ["Psychic"],
+			effect: {
+				ja: "のぞむなら、自分の手札が5枚になるように、山札を引く。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 554839,
+			},
+		},
+	],
+
+	retreat: 3,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [622],
+};
+
+export default card;

--- a/data-asia/SM/SM12/032.ts
+++ b/data-asia/SM/SM12/032.ts
@@ -1,0 +1,62 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ゴルーグ",
+	},
+
+	illustrator: "Ayaka Yoshida",
+	category: "Pokemon",
+	hp: 140,
+	types: ["Psychic"],
+
+	description: {
+		ja: "古代人が 労働力 として ゴルーグを 発明したといわれる。 主の 命令に 忠実だ。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "がんせきおとし" },
+			damage: 40,
+			cost: ["Psychic"],
+			effect: {
+				ja: "このワザのダメージは抵抗力を計算しない。",
+			},
+		},
+		{
+			name: { ja: "いにしえのこぶし" },
+			damage: 160,
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "自分のトラッシュにサポートがあるなら、このワザは失敗。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 554844,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ゴビット",
+	},
+
+	retreat: 4,
+	regulationMark: "C",
+	rarity: "Uncommon",
+	dexId: [623],
+};
+
+export default card;

--- a/data-asia/SM/SM12/033.ts
+++ b/data-asia/SM/SM12/033.ts
@@ -1,0 +1,49 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "クズモー",
+	},
+
+	illustrator: "sui",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Psychic"],
+
+	description: {
+		ja: "藻屑に 紛れ 大きなポケモンに 襲われないよう じっと している。 腐った 海草が 主な エサ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "どくをはく" },
+			cost: ["Psychic"],
+			effect: {
+				ja: "相手のバトルポケモンをどくにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 554847,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [690],
+};
+
+export default card;

--- a/data-asia/SM/SM12/034.ts
+++ b/data-asia/SM/SM12/034.ts
@@ -1,0 +1,58 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ドラミドロ",
+	},
+
+	illustrator: "Midori Harada",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Psychic"],
+
+	description: {
+		ja: "凶暴で 寄ってきた 相手に 毒液を 吹きかける。 なぜだか ダダリンとだけは とっても 仲良し。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "どくばいよう" },
+			cost: ["Psychic"],
+			effect: {
+				ja: "相手のバトルポケモンがどくなら、そのどくでのせるダメカンの数は10個になる。",
+			},
+		},
+		{
+			name: { ja: "するどいひれ" },
+			damage: 40,
+			cost: ["Psychic"],
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 554848,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "クズモー",
+	},
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Uncommon",
+	dexId: [691],
+};
+
+export default card;

--- a/data-asia/SM/SM12/035.ts
+++ b/data-asia/SM/SM12/035.ts
@@ -1,0 +1,63 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "オドリドリGX",
+	},
+
+	illustrator: "aky CG Works",
+	category: "Pokemon",
+	hp: 170,
+	types: ["Psychic"],
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "たむけのまい" },
+			effect: {
+				ja: "前の相手の番に、自分のポケモンがきぜつしていたなら、自分の番に1回使える。自分の山札を3枚引く。この番、すでに別の「たむけのまい」を使っていたなら、この特性は使えない。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "するどいはね" },
+			damage: 80,
+			cost: ["Psychic", "Colorless", "Colorless"],
+		},
+		{
+			name: { ja: "ひるがえすGX" },
+			damage: 100,
+			cost: ["Psychic", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンをベンチポケモンと入れ替える。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 554852,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Double rare",
+	dexId: [741],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM12/036.ts
+++ b/data-asia/SM/SM12/036.ts
@@ -1,0 +1,49 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "コスモッグ",
+	},
+
+	illustrator: "Mizue",
+	category: "Pokemon",
+	hp: 50,
+	types: ["Psychic"],
+
+	description: {
+		ja: "頼りない ガス状の 身体は ちょっとの 風にも 流されるが 全然 気にして いない 様子。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "かくせい" },
+			cost: ["Psychic"],
+			effect: {
+				ja: "このポケモンから進化するカードを、自分の山札から1枚選び、このポケモンにのせて進化させる。そして山札を切る。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 554853,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [789],
+};
+
+export default card;

--- a/data-asia/SM/SM12/037.ts
+++ b/data-asia/SM/SM12/037.ts
@@ -1,0 +1,60 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "コスモッグ",
+	},
+
+	illustrator: "Masakazu Fukuda",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Psychic"],
+
+	description: {
+		ja: "頼りない ガス状の 身体は ちょっとの 風にも 流されるが 全然 気にして いない 様子。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "てんねん" },
+			effect: {
+				ja: "このポケモンは、相手のポケモンが使うワザの効果を受けない。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ふいをつく" },
+			damage: 10,
+			cost: ["Colorless"],
+			effect: {
+				ja: "コインを1回投げウラなら、このワザは失敗。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 554858,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [789],
+};
+
+export default card;

--- a/data-asia/SM/SM12/038.ts
+++ b/data-asia/SM/SM12/038.ts
@@ -1,0 +1,53 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "コスモウム",
+	},
+
+	illustrator: "Aya Kusube",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Psychic"],
+
+	description: {
+		ja: "太古 アローラを 支配 していた 王様は 星の繭と 呼んで 崇めるための 祭壇を 作った。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "かたまる" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "次の相手の番、このポケモンが受けるワザのダメージは「-40」される。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 554859,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "コスモッグ",
+	},
+
+	retreat: 3,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [790],
+};
+
+export default card;

--- a/data-asia/SM/SM12/039.ts
+++ b/data-asia/SM/SM12/039.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ルナアーラ",
+	},
+
+	illustrator: "Shin Nagasawa",
+	category: "Pokemon",
+	hp: 160,
+	types: ["Psychic"],
+
+	description: {
+		ja: "遥か 大昔の 文献に 月を 誘いし 獣と いう 名前で 記録が 残っている。",
+	},
+
+	stage: "Stage2",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "がちりんのめぐみ" },
+			effect: {
+				ja: "自分の場に「ソルガレオ」がいるなら、自分の番に1回使える。自分の山札にあるエネルギーを2枚まで、自分の場の「ソルガレオ」または「ルナアーラ」に好きなようにつける。そして山札を切る。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ルナブラスト" },
+			damage: 130,
+			cost: ["Psychic", "Psychic", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 554861,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "コスモウム",
+	},
+
+	retreat: 2,
+	regulationMark: "C",
+	rarity: "Rare",
+	dexId: [792],
+};
+
+export default card;

--- a/data-asia/SM/SM12/040.ts
+++ b/data-asia/SM/SM12/040.ts
@@ -1,0 +1,57 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ノズパス",
+	},
+
+	illustrator: "Anesaki Dynamic",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Fighting"],
+
+	description: {
+		ja: "１年に １センチしか 動かないが ピンチに 陥ると 回転し 一瞬で 地中に 潜る。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ひきよせる" },
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "相手のベンチポケモンを1匹選び、バトルポケモンと入れ替える。",
+			},
+		},
+		{
+			name: { ja: "でんじほう" },
+			damage: 50,
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "次の自分の番、このポケモンは「でんじほう」が使えない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 554864,
+			},
+		},
+	],
+
+	retreat: 3,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [299],
+};
+
+export default card;

--- a/data-asia/SM/SM12/041.ts
+++ b/data-asia/SM/SM12/041.ts
@@ -1,0 +1,54 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ナックラー",
+	},
+
+	illustrator: "sowsow",
+	category: "Pokemon",
+	hp: 50,
+	types: ["Fighting"],
+
+	description: {
+		ja: "アゴは 岩も 砕くが 重くて ひっくり 返ると 起きられない。 メグロコは その隙を 狙うのだ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "すづくり" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札にあるスタジアムを1枚、相手に見せてから、手札に加える。そして山札を切る。",
+			},
+		},
+		{
+			name: { ja: "すなしぶき" },
+			damage: 10,
+			cost: ["Fighting"],
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 554869,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [328],
+};
+
+export default card;

--- a/data-asia/SM/SM12/042.ts
+++ b/data-asia/SM/SM12/042.ts
@@ -1,0 +1,50 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ナックラー",
+	},
+
+	illustrator: "Midori Harada",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Fighting"],
+
+	description: {
+		ja: "アゴは 岩も 砕くが 重くて ひっくり 返ると 起きられない。 メグロコは その隙を 狙うのだ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "あなをほる" },
+			damage: 30,
+			cost: ["Fighting", "Colorless"],
+			effect: {
+				ja: "コインを1回投げオモテなら、次の相手の番、このポケモンはワザのダメージや効果を受けない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 554873,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [328],
+};
+
+export default card;

--- a/data-asia/SM/SM12/043.ts
+++ b/data-asia/SM/SM12/043.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ビブラーバ",
+	},
+
+	illustrator: "SATOSHI NAKAI",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Fighting"],
+
+	description: {
+		ja: "ハネを 振動させ 超音波を 放つ。 気絶した 獲物を 砂の 中に 生き埋めにして 保存する。",
+	},
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "うるさいはおと" },
+			effect: {
+				ja: "このポケモンは、相手が手札からサポートを出して使ったとき、その効果を受けない。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "はばたく" },
+			damage: 40,
+			cost: ["Fighting", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 554876,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ナックラー",
+	},
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Uncommon",
+	dexId: [329],
+};
+
+export default card;

--- a/data-asia/SM/SM12/044.ts
+++ b/data-asia/SM/SM12/044.ts
@@ -1,0 +1,70 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "フライゴンGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 240,
+	types: ["Fighting"],
+
+	stage: "Stage2",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "さじんのまもり" },
+			effect: {
+				ja: "このポケモンがバトル場にいるかぎり、自分のポケモン全員が、相手のポケモンから受けるワザのダメージは「-30」される。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "デザートハリケーン" },
+			damage: "120+",
+			cost: ["Fighting", "Fighting", "Fighting"],
+			effect: {
+				ja: "場にスタジアムが出ているなら、120ダメージ追加。その後、そのスタジアムをトラッシュする。",
+			},
+		},
+		{
+			name: { ja: "ソニックエッジGX" },
+			damage: 220,
+			cost: ["Fighting", "Fighting", "Fighting"],
+			effect: {
+				ja: "このワザのダメージは、相手のバトルポケモンにかかっている効果を計算しない。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 554881,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ビブラーバ",
+	},
+
+	retreat: 2,
+	regulationMark: "C",
+	rarity: "Double rare",
+	dexId: [330],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM12/045.ts
+++ b/data-asia/SM/SM12/045.ts
@@ -1,0 +1,52 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アノプス",
+	},
+
+	illustrator: "Sumiyoshi Kizuki",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Fighting"],
+
+	description: {
+		ja: "化石から 復元した アノプスを 海に 放っても 元気が ない。 当時と 水質が 違うからだ。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "むしくい" },
+			damage: 40,
+			cost: ["Colorless", "Colorless"],
+		},
+		{
+			name: { ja: "ツメできりさく" },
+			damage: 80,
+			cost: ["Fighting", "Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 554883,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [347],
+};
+
+export default card;

--- a/data-asia/SM/SM12/046.ts
+++ b/data-asia/SM/SM12/046.ts
@@ -1,0 +1,62 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アーマルド",
+	},
+
+	illustrator: "Ayaka Yoshida",
+	category: "Pokemon",
+	hp: 150,
+	types: ["Fighting"],
+
+	description: {
+		ja: "陸に 暮らし 獲物を 求めて 海へ 狩りへと でかけていた。 鋭い ツメが 最大の 武器。",
+	},
+
+	stage: "Stage2",
+
+	attacks: [
+		{
+			name: { ja: "エンシャントブラスト" },
+			damage: "20+",
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "自分のトラッシュにある「なぞの化石」の枚数×50ダメージ追加。",
+			},
+		},
+		{
+			name: { ja: "マッハクロー" },
+			damage: 100,
+			cost: ["Fighting", "Colorless", "Colorless"],
+			effect: {
+				ja: "このワザのダメージは抵抗力を計算しない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 554884,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "アノプス",
+	},
+
+	retreat: 2,
+	regulationMark: "C",
+	rarity: "Uncommon",
+	dexId: [348],
+};
+
+export default card;

--- a/data-asia/SM/SM12/047.ts
+++ b/data-asia/SM/SM12/047.ts
@@ -1,0 +1,54 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "イワンコ",
+	},
+
+	illustrator: "Saya Tsuruta",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Fighting"],
+
+	description: {
+		ja: "育つに つれて 気性は 荒く 攻撃的に なる。 持て余して 捨てる トレーナーも 少なくない。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ほえる" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをベンチポケモンと入れ替える。［バトル場に出すポケモンは相手が選ぶ。］",
+			},
+		},
+		{
+			name: { ja: "いわおとし" },
+			damage: 40,
+			cost: ["Fighting", "Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 554888,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [744],
+};
+
+export default card;

--- a/data-asia/SM/SM12/048.ts
+++ b/data-asia/SM/SM12/048.ts
@@ -1,0 +1,64 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ルガルガン",
+	},
+
+	illustrator: "so-taro",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Fighting"],
+
+	description: {
+		ja: "気に入らない 命令は 平気で 無視。 相手を 仕留めるためなら 傷つくことも まるで 気にしない。",
+	},
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ちがたぎる" },
+			effect: {
+				ja: "相手の場に「ポケモンGX・EX」がいるなら、このポケモンが使うワザに必要なエネルギーは、【無】エネルギー3個ぶん少なくなる。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ボルテージクロー" },
+			damage: "60+",
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンに特殊エネルギーがついているなら、70ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 554893,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "イワンコ",
+	},
+
+	retreat: 2,
+	regulationMark: "C",
+	rarity: "Rare",
+	dexId: [745],
+};
+
+export default card;

--- a/data-asia/SM/SM12/049.ts
+++ b/data-asia/SM/SM12/049.ts
@@ -1,0 +1,55 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "スナバァ",
+	},
+
+	illustrator: "Yukiko Baba",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Fighting"],
+
+	description: {
+		ja: "頭の スコップは お気に入り。 取り返しに 来た 子どもと ケンカ。 ムキに なって 殴り合いに なる。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "おどろかす" },
+			damage: 10,
+			cost: ["Fighting"],
+			effect: {
+				ja: "相手の手札からオモテを見ないで1枚選び、そのカードのオモテを見てから、相手の山札にもどして切る。",
+			},
+		},
+		{
+			name: { ja: "ひっかける" },
+			damage: 20,
+			cost: ["Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 554897,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [769],
+};
+
+export default card;

--- a/data-asia/SM/SM12/050.ts
+++ b/data-asia/SM/SM12/050.ts
@@ -1,0 +1,62 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "シロデスナ",
+	},
+
+	illustrator: "OOYAMA",
+	category: "Pokemon",
+	hp: 140,
+	types: ["Fighting"],
+
+	description: {
+		ja: "一粒の 砂にも 意思が ある。 小さな ポケモンを 呑み込み 生きたまま 生気を 奪う。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "ガードプレス" },
+			damage: 80,
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "次の相手の番、このポケモンが受けるワザのダメージは「-20」される。",
+			},
+		},
+		{
+			name: { ja: "じしん" },
+			damage: 150,
+			cost: ["Fighting", "Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "自分のベンチポケモン全員にも、それぞれ20ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 554901,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "スナバァ",
+	},
+
+	retreat: 4,
+	regulationMark: "C",
+	rarity: "Uncommon",
+	dexId: [770],
+};
+
+export default card;

--- a/data-asia/SM/SM12/051.ts
+++ b/data-asia/SM/SM12/051.ts
@@ -1,0 +1,54 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アローラサンド",
+	},
+
+	illustrator: "ryoma uratsuka",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Metal"],
+
+	description: {
+		ja: "火山の 噴火から 逃げるうちに 雪山に 移り棲んだ。 氷の 甲羅は 鋼並みの 硬さ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "はしゃぐ" },
+			cost: [],
+			effect: {
+				ja: "このポケモンをベンチポケモンと入れ替える。",
+			},
+		},
+		{
+			name: { ja: "メタルクロー" },
+			damage: 20,
+			cost: ["Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 554902,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [27],
+};
+
+export default card;

--- a/data-asia/SM/SM12/052.ts
+++ b/data-asia/SM/SM12/052.ts
@@ -1,0 +1,62 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アローラサンドパン",
+	},
+
+	illustrator: "Hasuno",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Metal"],
+
+	description: {
+		ja: "雪原を 高速で 駆ける。 雪を 掻きわけるために ツメが ぶっとく 鋭く 発達した。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "まるまるアタック" },
+			damage: 30,
+			cost: [],
+			effect: {
+				ja: "コインを1回投げオモテなら、次の相手の番、このポケモンはワザのダメージを受けない。",
+			},
+		},
+		{
+			name: { ja: "きょうかニードル" },
+			damage: "60+",
+			cost: ["Metal", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンに「ポケモンのどうぐ」がついているなら、60ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 554906,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "アローラサンド",
+	},
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Uncommon",
+	dexId: [28],
+};
+
+export default card;

--- a/data-asia/SM/SM12/053.ts
+++ b/data-asia/SM/SM12/053.ts
@@ -1,0 +1,57 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "クチート",
+	},
+
+	illustrator: "kodama",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Metal"],
+
+	description: {
+		ja: "ずる賢く 恐ろしい ポケモン。 キュートな 仕草で 油断させ いきなり おおアゴで 丸呑みにする。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ふたつのよびごえ" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札にある「TAG TEAM」のカードを2枚まで、相手に見せてから、手札に加える。そして山札を切る。",
+			},
+		},
+		{
+			name: { ja: "くらいつく" },
+			damage: 20,
+			cost: ["Colorless"],
+			effect: {
+				ja: "次の相手の番、このワザを受けたポケモンは、にげられない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 554907,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Uncommon",
+	dexId: [303],
+};
+
+export default card;

--- a/data-asia/SM/SM12/054.ts
+++ b/data-asia/SM/SM12/054.ts
@@ -1,0 +1,62 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ダイノーズ",
+	},
+
+	illustrator: "Masakazu Fukuda",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Metal"],
+
+	description: {
+		ja: "チビノーズと 呼ばれる ユニットを 操るが たまに 迷子に なって 帰ってこないことも あるらしい。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "ハードプレス" },
+			damage: 60,
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "コインを1回投げオモテなら、相手のバトルポケモンをマヒにする。",
+			},
+		},
+		{
+			name: { ja: "トリプルノーズ" },
+			damage: "80+",
+			cost: ["Metal", "Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "コインを3回投げ、オモテの数×40ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 554908,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ノズパス",
+	},
+
+	retreat: 3,
+	regulationMark: "C",
+	rarity: "Uncommon",
+	dexId: [476],
+};
+
+export default card;

--- a/data-asia/SM/SM12/055.ts
+++ b/data-asia/SM/SM12/055.ts
@@ -1,0 +1,64 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ソルガレオ",
+	},
+
+	illustrator: "Misa Tsutsui",
+	category: "Pokemon",
+	hp: 170,
+	types: ["Metal"],
+
+	description: {
+		ja: "ウルトラホールを 開いた 結果 異世界の エネルギーや 生命を この世界に 呼ぶことも あるのだ。",
+	},
+
+	stage: "Stage2",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "にちりんのそうこう" },
+			effect: {
+				ja: "自分の場に「ルナアーラ」がいるなら、自分の場の「ソルガレオ」と「ルナアーラ」が、相手のポケモンから受けるワザのダメージは「-50」される。この効果は、この特性を持つポケモンが何匹いても、重ならない。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ソルファング" },
+			damage: 180,
+			cost: ["Metal", "Metal", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンについているエネルギーを、2個トラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 554909,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "コスモウム",
+	},
+
+	retreat: 3,
+	regulationMark: "C",
+	rarity: "Rare",
+	dexId: [791],
+};
+
+export default card;

--- a/data-asia/SM/SM12/056.ts
+++ b/data-asia/SM/SM12/056.ts
@@ -1,0 +1,54 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アローラキュウコン",
+	},
+
+	illustrator: "Eri Yamaki",
+	category: "Pokemon",
+	hp: 110,
+	types: ["Fairy"],
+
+	description: {
+		ja: "雪山で 迷った 人間を 麓まで 案内 してくれるのは さっさと 追い払いたいからだ。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "ちりふぶき" },
+			damage: "10×",
+			cost: [],
+			effect: {
+				ja: "自分のトラッシュにある「ポケモンのどうぐ」の枚数×10ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [{ type: "Darkness", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 554911,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "アローラロコン",
+	},
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Rare",
+	dexId: [38],
+};
+
+export default card;

--- a/data-asia/SM/SM12/057.ts
+++ b/data-asia/SM/SM12/057.ts
@@ -1,0 +1,49 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ルリリ",
+	},
+
+	illustrator: "Asako Ito",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Fairy"],
+
+	description: {
+		ja: "大きな 尻尾に 乗って 弾むと 地上では 速く 移動できる。 水辺で 暮らす ポケモン。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ぐんぐんチャージ" },
+			effect: {
+				ja: "自分の番に1回使えて、使ったなら、自分の番は終わる。コインを1回投げオモテなら、自分のトラッシュにある基本エネルギーを1枚、バトルポケモンにつける。",
+			},
+		},
+	],
+
+	weaknesses: [],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 554916,
+			},
+		},
+	],
+
+	retreat: 0,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [298],
+};
+
+export default card;

--- a/data-asia/SM/SM12/058.ts
+++ b/data-asia/SM/SM12/058.ts
@@ -1,0 +1,49 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "フラベベ",
+	},
+
+	illustrator: "tetsuya koizumi",
+	category: "Pokemon",
+	hp: 30,
+	types: ["Fairy"],
+
+	description: {
+		ja: "花の 力が ないと 危険。 でも 好きな 色と 形が 見つかるまで 旅を 続けるぞ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "はなのさそい" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札にある[妖]ポケモンを2枚まで、相手に見せてから、手札に加える。そして山札を切る。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [{ type: "Darkness", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 554918,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [669],
+};
+
+export default card;

--- a/data-asia/SM/SM12/059.ts
+++ b/data-asia/SM/SM12/059.ts
@@ -1,0 +1,49 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "フラベベ",
+	},
+
+	illustrator: "Atsuko Nishida",
+	category: "Pokemon",
+	hp: 40,
+	types: ["Fairy"],
+
+	description: {
+		ja: "花の 力が ないと 危険。 でも 好きな 色と 形が 見つかるまで 旅を 続けるぞ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "はなふぶき" },
+			cost: ["Fairy"],
+			effect: {
+				ja: "相手のポケモン全員に、それぞれ10ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [{ type: "Darkness", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 554921,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [669],
+};
+
+export default card;

--- a/data-asia/SM/SM12/060.ts
+++ b/data-asia/SM/SM12/060.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "フラエッテ",
+	},
+
+	illustrator: "miki kudo",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Fairy"],
+
+	description: {
+		ja: "花を 育て 自分の 武器として 利用。 美しく咲いた 花ほど 強力なパワーを 秘めている。",
+	},
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "はなつみ" },
+			effect: {
+				ja: "自分の番に、このカードを手札から出して進化させたとき、1回使える。相手の手札からオモテを見ないで1枚選び、そのカードのオモテを見てから、相手の山札にもどして切る。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "マジカルショット" },
+			damage: 30,
+			cost: ["Fairy", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [{ type: "Darkness", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 554923,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "フラベベ",
+	},
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [670],
+};
+
+export default card;

--- a/data-asia/SM/SM12/061.ts
+++ b/data-asia/SM/SM12/061.ts
@@ -1,0 +1,64 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "フラージェス",
+	},
+
+	illustrator: "Akira Komayama",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Fairy"],
+
+	description: {
+		ja: "育てた 花々を 操る。 フラージェスの 放つ 花吹雪は 美しさも パワーも 圧倒的。",
+	},
+
+	stage: "Stage2",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "はなつみ" },
+			effect: {
+				ja: "自分の番に、このカードを手札から出して進化させたとき、1回使える。相手の手札からオモテを見ないで2枚選び、そのカードのオモテを見てから、相手の山札にもどして切る。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "はなびらのまい" },
+			damage: "60×",
+			cost: ["Fairy", "Colorless"],
+			effect: {
+				ja: "コインを3回投げ、オモテの数×60ダメージ。このポケモンをこんらんにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [{ type: "Darkness", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 554928,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "フラエッテ",
+	},
+
+	retreat: 2,
+	regulationMark: "C",
+	rarity: "Rare",
+	dexId: [671],
+};
+
+export default card;

--- a/data-asia/SM/SM12/062.ts
+++ b/data-asia/SM/SM12/062.ts
@@ -1,0 +1,50 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ペロッパフ",
+	},
+
+	illustrator: "MAHOU",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Fairy"],
+
+	description: {
+		ja: "わたあめのような 甘くて ベタつく 白い 糸を 出して 相手を 絡め取り 動きを 封じる。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "コットンガード" },
+			damage: 10,
+			cost: ["Fairy"],
+			effect: {
+				ja: "次の相手の番、このポケモンが受けるワザのダメージは「-10」される。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [{ type: "Darkness", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 554929,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [684],
+};
+
+export default card;

--- a/data-asia/SM/SM12/063.ts
+++ b/data-asia/SM/SM12/063.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ペロリーム",
+	},
+
+	illustrator: "Kyoko Umemoto",
+	category: "Pokemon",
+	hp: 110,
+	types: ["Fairy"],
+
+	description: {
+		ja: "わずかな においでも かぎわける 敏感な きゅうかくを 活かして パティシエの 手伝いを している。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "とろけるにおい" },
+			cost: ["Fairy"],
+			effect: {
+				ja: "相手のバトルポケモンをこんらんにする。",
+			},
+		},
+		{
+			name: { ja: "スイートパニック" },
+			damage: 110,
+			cost: ["Fairy"],
+			effect: {
+				ja: "相手のバトルポケモンがこんらんでないなら、このワザは失敗。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [{ type: "Darkness", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 554931,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ペロッパフ",
+	},
+
+	retreat: 2,
+	regulationMark: "C",
+	rarity: "Uncommon",
+	dexId: [685],
+};
+
+export default card;

--- a/data-asia/SM/SM12/064.ts
+++ b/data-asia/SM/SM12/064.ts
@@ -1,0 +1,62 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ニンフィア",
+	},
+
+	illustrator: "Naoyo Kimura",
+	category: "Pokemon",
+	hp: 110,
+	types: ["Fairy"],
+
+	description: {
+		ja: "ひとたび 戦いとなれば 自分の 何倍もある ドラゴンポケモンにも いっさい怯まず 飛びかかっていく。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "ムーンフォース" },
+			damage: 30,
+			cost: ["Fairy"],
+			effect: {
+				ja: "次の相手の番、このワザを受けたポケモンが使うワザのダメージは「-30」される。",
+			},
+		},
+		{
+			name: { ja: "しんあいのはどう" },
+			damage: "80+",
+			cost: ["Fairy", "Colorless", "Colorless"],
+			effect: {
+				ja: "この番、手札から「TAG TEAM」のサポートを出して使っていたなら、80ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [{ type: "Darkness", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 554936,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "イーブイ",
+	},
+
+	retreat: 2,
+	regulationMark: "C",
+	rarity: "Uncommon",
+	dexId: [700],
+};
+
+export default card;

--- a/data-asia/SM/SM12/065.ts
+++ b/data-asia/SM/SM12/065.ts
@@ -1,0 +1,55 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アルセウス&ディアルガ&パルキアGX",
+	},
+
+	illustrator: "Mitsuhiro Arita",
+	category: "Pokemon",
+	hp: 280,
+	types: ["Dragon"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "アルティメットレイ" },
+			damage: 150,
+			cost: ["Water", "Metal", "Colorless"],
+			effect: {
+				ja: "自分の山札にある基本エネルギーを3枚まで、自分のポケモンに好きなようにつける。そして山札を切る。",
+			},
+		},
+		{
+			name: { ja: "オルタージェネシスGX" },
+			cost: ["Metal"],
+			effect: {
+				ja: "この対戦が終わるまで、自分のポケモン全員が使うワザの、相手のバトルポケモンへのダメージはすべて「+30」される。追加で[水]エネルギーが1個ついているなら、そのワザのダメージで相手のバトルポケモンをきぜつさせた場合、サイドを1枚多くとる。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fairy", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 554939,
+			},
+		},
+	],
+
+	retreat: 3,
+	regulationMark: "C",
+	rarity: "Double rare",
+	dexId: [493, 483, 484],
+
+	suffix: "TAG TEAM-GX",
+};
+
+export default card;

--- a/data-asia/SM/SM12/066.ts
+++ b/data-asia/SM/SM12/066.ts
@@ -1,0 +1,62 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アーゴヨン&アクジキングGX",
+	},
+
+	illustrator: "Mitsuhiro Arita",
+	category: "Pokemon",
+	hp: 280,
+	types: ["Dragon"],
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ぼうしょく" },
+			effect: {
+				ja: "自分の番に1回使える。自分の手札にあるポケモンを1枚トラッシュする。その後、このポケモンのHPを「60」回復する。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ジェットピアス" },
+			damage: 180,
+			cost: ["Psychic", "Darkness", "Colorless"],
+		},
+		{
+			name: { ja: "カオスオーダーGX" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分のサイドをすべてオモテにする（対戦が終わるまで、そのサイドはオモテのまま）。追加で[超]エネルギーと[悪]エネルギーが1個ずつついているなら、自分のサイドを2枚とる。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fairy", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 554944,
+			},
+		},
+	],
+
+	retreat: 3,
+	regulationMark: "C",
+	rarity: "Double rare",
+	dexId: [804, 799],
+
+	suffix: "TAG TEAM-GX",
+};
+
+export default card;

--- a/data-asia/SM/SM12/067.ts
+++ b/data-asia/SM/SM12/067.ts
@@ -1,0 +1,55 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ジジーロン",
+	},
+
+	illustrator: "Naoki Saito",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Dragon"],
+
+	description: {
+		ja: "お友達に なった 子どもが いじめられると いじめた 子どもの 家を 探して 焼き尽くしてしまう。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ドラゴンクロー" },
+			damage: 20,
+			cost: ["Colorless"],
+		},
+		{
+			name: { ja: "りゅうのおうぎ" },
+			damage: "70+",
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンに2種類以上のタイプの基本エネルギーがついているなら、70ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fairy", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 554946,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Uncommon",
+	dexId: [780],
+};
+
+export default card;

--- a/data-asia/SM/SM12/068.ts
+++ b/data-asia/SM/SM12/068.ts
@@ -1,0 +1,50 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ジャラコ",
+	},
+
+	illustrator: "AKIRA EGAWA",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Dragon"],
+
+	description: {
+		ja: "頭の ウロコで 岩や 地面を バシバシ 叩き 相手を 威嚇。 音で 仲間と 連絡も とる。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "いかりのツメ" },
+			damage: "20+",
+			cost: ["Lightning", "Fighting"],
+			effect: {
+				ja: "このポケモンにのっているダメカンの数×10ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fairy", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 554949,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [782],
+};
+
+export default card;

--- a/data-asia/SM/SM12/069.ts
+++ b/data-asia/SM/SM12/069.ts
@@ -1,0 +1,52 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ジャラコ",
+	},
+
+	illustrator: "Tomokazu Komiya",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Dragon"],
+
+	description: {
+		ja: "頭の ウロコで 岩や 地面を バシバシ 叩き 相手を 威嚇。 音で 仲間と 連絡も とる。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "かじる" },
+			damage: 10,
+			cost: ["Fighting"],
+		},
+		{
+			name: { ja: "リューズヘッド" },
+			damage: 50,
+			cost: ["Lightning", "Fighting", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fairy", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 554953,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [782],
+};
+
+export default card;

--- a/data-asia/SM/SM12/070.ts
+++ b/data-asia/SM/SM12/070.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ジャランゴ",
+	},
+
+	illustrator: "Ryuta Fuse",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Dragon"],
+
+	description: {
+		ja: "ウロコを 叩き合わせて 音を 鳴らす。 リズムが 最高潮に 達したところで 襲いかかる。",
+	},
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "せんしのほうこう" },
+			effect: {
+				ja: "このポケモンは、相手のバトル場に「ポケモンGX・EX」がいるなら、出したばかりでも進化できる。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "リューノスライス" },
+			damage: 30,
+			cost: ["Lightning", "Fighting"],
+		},
+	],
+
+	weaknesses: [{ type: "Fairy", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 554956,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ジャラコ",
+	},
+
+	retreat: 2,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [783],
+};
+
+export default card;

--- a/data-asia/SM/SM12/071.ts
+++ b/data-asia/SM/SM12/071.ts
@@ -1,0 +1,62 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ジャラランガ",
+	},
+
+	illustrator: "hatachu",
+	category: "Pokemon",
+	hp: 160,
+	types: ["Dragon"],
+
+	description: {
+		ja: "獲物を 仕留めて 遠吠えすると あちこちから 仲間が 祝福する 金属音が こだまする。",
+	},
+
+	stage: "Stage2",
+
+	attacks: [
+		{
+			name: { ja: "ちからのさけび" },
+			damage: 60,
+			cost: ["Fighting"],
+			effect: {
+				ja: "自分のトラッシュにある基本エネルギーを1枚、ベンチポケモンにつける。",
+			},
+		},
+		{
+			name: { ja: "スケイルアッパー" },
+			damage: "90+",
+			cost: ["Lightning", "Fighting"],
+			effect: {
+				ja: "のぞむなら、このポケモンについている「ポケモンのどうぐ」を、トラッシュする。その場合、90ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fairy", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 554957,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ジャランゴ",
+	},
+
+	retreat: 2,
+	regulationMark: "C",
+	rarity: "Rare",
+	dexId: [784],
+};
+
+export default card;

--- a/data-asia/SM/SM12/072.ts
+++ b/data-asia/SM/SM12/072.ts
@@ -1,0 +1,60 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ウルトラネクロズマ",
+	},
+
+	illustrator: "Hasuno",
+	category: "Pokemon",
+	hp: 110,
+	types: ["Dragon"],
+
+	description: {
+		ja: "圧倒的な 光エネルギーを 吸収し 変化した 姿。 全身から レーザー光を 放つ。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ウルトラバースト" },
+			effect: {
+				ja: "このポケモンは、相手のサイドの残り枚数が2枚以下でなければ、ワザが使えない。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ほろびのかがやき" },
+			damage: 170,
+			cost: ["Psychic", "Metal"],
+			effect: {
+				ja: "相手のバトルポケモンについているエネルギーを、1個トラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fairy", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 554961,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "C",
+	rarity: "Rare",
+	dexId: [800],
+};
+
+export default card;

--- a/data-asia/SM/SM12/073.ts
+++ b/data-asia/SM/SM12/073.ts
@@ -1,0 +1,55 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "メガミミロップ&プリンGX",
+	},
+
+	illustrator: "Mitsuhiro Arita",
+	category: "Pokemon",
+	hp: 240,
+	types: ["Colorless"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ジャンピングバルーン" },
+			damage: "60+",
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手の場の「ポケモンGX・EX」の数×60ダメージ追加。",
+			},
+		},
+		{
+			name: { ja: "パフスマッシャーGX" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをねむりにする。追加でエネルギーが4個ついているなら、相手のベンチポケモン1匹に、200ダメージ。［ベンチは弱点・抵抗力を計算しない。］［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 554964,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Double rare",
+	dexId: [428, 39],
+
+	suffix: "TAG TEAM-GX",
+};
+
+export default card;

--- a/data-asia/SM/SM12/074.ts
+++ b/data-asia/SM/SM12/074.ts
@@ -1,0 +1,54 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "イーブイ",
+	},
+
+	illustrator: "Motofumi Fujiwara",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Colorless"],
+
+	description: {
+		ja: "イーブイだけが とても 不安定な 遺伝子を 持っている 理由は 未だ 解明 されて いない。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "みちびく" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札にあるサポートを1枚、相手に見せてから、手札に加える。そして山札を切る。",
+			},
+		},
+		{
+			name: { ja: "かみつく" },
+			damage: 20,
+			cost: ["Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 554968,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [133],
+};
+
+export default card;

--- a/data-asia/SM/SM12/075.ts
+++ b/data-asia/SM/SM12/075.ts
@@ -1,0 +1,57 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "エイパム",
+	},
+
+	illustrator: "Miki Tanaka",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Colorless"],
+
+	description: {
+		ja: "シッポで いろんなことを していたら 手先は 不器用に なってしまった。 高い 木の上に 巣を 作る。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ちょろちょろテール" },
+			effect: {
+				ja: "自分の番に1回使える。相手の山札を上から1枚、オモテを見ないで、相手の山札の下にもどす。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "しっぽでたたく" },
+			damage: 20,
+			cost: ["Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 554973,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [190],
+};
+
+export default card;

--- a/data-asia/SM/SM12/076.ts
+++ b/data-asia/SM/SM12/076.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "エテボース",
+	},
+
+	illustrator: "Sumiyoshi Kizuki",
+	category: "Pokemon",
+	hp: 100,
+	types: ["Colorless"],
+
+	description: {
+		ja: "居心地の良い 木を 巡って ナゲツケサルのグループと 縄張りを 争っている。 結果は ５分だ。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "カムカムキャッチ" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札を2枚引く。",
+			},
+		},
+		{
+			name: { ja: "バイバイスロー" },
+			damage: "60×",
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "自分の手札を2枚までトラッシュし、その枚数×60ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 554977,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "エイパム",
+	},
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Uncommon",
+	dexId: [424],
+};
+
+export default card;

--- a/data-asia/SM/SM12/077.ts
+++ b/data-asia/SM/SM12/077.ts
@@ -1,0 +1,52 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヒメグマ",
+	},
+
+	illustrator: "kodama",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Colorless"],
+
+	description: {
+		ja: "ミツを見つけると 三日月模様が 輝く。甘いミツが 染みこんだ 手のひらを いつも なめている。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ひっかく" },
+			damage: 10,
+			cost: ["Colorless"],
+		},
+		{
+			name: { ja: "きりさく" },
+			damage: 20,
+			cost: ["Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 554982,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [216],
+};
+
+export default card;

--- a/data-asia/SM/SM12/078.ts
+++ b/data-asia/SM/SM12/078.ts
@@ -1,0 +1,59 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "リングマ",
+	},
+
+	illustrator: "Hiroki Asanuma",
+	category: "Pokemon",
+	hp: 140,
+	types: ["Colorless"],
+
+	description: {
+		ja: "どんな においも かぎわける。 地面深くに 埋まっている 食べ物も 残らず 見つけ出す。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "ぶちかます" },
+			damage: 50,
+			cost: ["Colorless", "Colorless"],
+		},
+		{
+			name: { ja: "ヘビーホールド" },
+			damage: 120,
+			cost: ["Colorless", "Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "次の相手の番、このワザを受けたポケモンは、ワザが使えない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 554984,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ヒメグマ",
+	},
+
+	retreat: 3,
+	regulationMark: "C",
+	rarity: "Uncommon",
+	dexId: [217],
+};
+
+export default card;

--- a/data-asia/SM/SM12/079.ts
+++ b/data-asia/SM/SM12/079.ts
@@ -1,0 +1,50 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ワシボン",
+	},
+
+	illustrator: "Ken Sugimori",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Colorless"],
+
+	description: {
+		ja: "強い 脚力と 丈夫な ツメで 硬い シェルダーの カラも 砕いて 中身を ついばむ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "みだれづき" },
+			damage: "10×",
+			cost: ["Colorless"],
+			effect: {
+				ja: "コインを3回投げ、オモテの数×10ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 554986,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [627],
+};
+
+export default card;

--- a/data-asia/SM/SM12/080.ts
+++ b/data-asia/SM/SM12/080.ts
@@ -1,0 +1,62 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ウォーグル",
+	},
+
+	illustrator: "chibi",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Colorless"],
+
+	description: {
+		ja: "向こう傷の 多い ものほど 勇敢とされ 後ろ傷の 多い ものは 群れで バカに される。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "わしづかみ" },
+			damage: 30,
+			cost: ["Colorless"],
+			effect: {
+				ja: "次の相手の番、このワザを受けたポケモンは、にげられない。",
+			},
+		},
+		{
+			name: { ja: "エアロフォール" },
+			damage: 140,
+			cost: ["Colorless", "Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンについているエネルギーを、2個トラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 554988,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ワシボン",
+	},
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Uncommon",
+	dexId: [628],
+};
+
+export default card;

--- a/data-asia/SM/SM12/081.ts
+++ b/data-asia/SM/SM12/081.ts
@@ -1,0 +1,54 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "エリキテル",
+	},
+
+	illustrator: "Sekio",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Colorless"],
+
+	description: {
+		ja: "砂漠で 生活する。 太陽の 光を 浴びて 発電すれば エサを 食べなくても 平気なのだ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "しっぽをふる" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "コインを1回投げオモテなら、次の相手の番、このワザを受けたポケモンは、ワザが使えない。",
+			},
+		},
+		{
+			name: { ja: "うしろげり" },
+			damage: 30,
+			cost: ["Colorless", "Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 554991,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [694],
+};
+
+export default card;

--- a/data-asia/SM/SM12/082.ts
+++ b/data-asia/SM/SM12/082.ts
@@ -1,0 +1,59 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "エレザード",
+	},
+
+	illustrator: "Kyoko Umemoto",
+	category: "Pokemon",
+	hp: 100,
+	types: ["Colorless"],
+
+	description: {
+		ja: "エリマキを 広げて 発電する。 エレザード １匹で 高層ビルで 必要な 電気を 作れるのだ。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "パラボラカウンター" },
+			damage: "30+",
+			cost: ["Colorless"],
+			effect: {
+				ja: "相手の場に[雷]ポケモンがいるなら、90ダメージ追加。",
+			},
+		},
+		{
+			name: { ja: "エレキック" },
+			damage: 80,
+			cost: ["Colorless", "Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 554994,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "エリキテル",
+	},
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Uncommon",
+	dexId: [695],
+};
+
+export default card;

--- a/data-asia/SM/SM12/083.ts
+++ b/data-asia/SM/SM12/083.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "タッグコール",
+	},
+
+	illustrator: "Toyste Beach",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の山札にある「TAG TEAM」のカードを2枚まで、相手に見せてから、手札に加える。そして山札を切る。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 554996,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	regulationMark: "C",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM12/084.ts
+++ b/data-asia/SM/SM12/084.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "なぞの化石",
+	},
+
+	illustrator: "Toyste Beach",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードは、HP60の[無]タイプのたねポケモンとして、場に出すことができる。自分の番の中でなら、場に出ているこのカードをトラッシュしてよい。このカードは、にげられない。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 555001,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	regulationMark: "B",
+	rarity: "Common",
+};
+
+export default card;

--- a/data-asia/SM/SM12/085.ts
+++ b/data-asia/SM/SM12/085.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "しまめぐりのあかし",
+	},
+
+	illustrator: "sadaji",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードをつけている「ポケモンGX・EX」の最大HPは「100」小さくなり、そのポケモンが相手のワザのダメージできぜつしたとき、とられるサイドは1枚少なくなる。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 555002,
+			},
+		},
+	],
+
+	trainerType: "Tool",
+	regulationMark: "C",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM12/086.ts
+++ b/data-asia/SM/SM12/086.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ビーストナイト",
+	},
+
+	illustrator: "inose yukie",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードをつけている「ウルトラビースト」が使うワザの、相手のバトルポケモンへのダメージは、自分がすでにとったサイド1枚につき「+10」される。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 555006,
+			},
+		},
+	],
+
+	trainerType: "Tool",
+	regulationMark: "C",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM12/087.ts
+++ b/data-asia/SM/SM12/087.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "グズマ&ハラ",
+	},
+
+	illustrator: "Ken Sugimori",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の山札にある「スタジアム」を1枚、相手に見せてから、手札に加える。そして山札を切る。追加で、このカードを使うときに、自分の手札を2枚トラッシュしてよい。その場合、「ポケモンのどうぐ」と「特殊エネルギー」も1枚ずつ手札に加えられる。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 555009,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "C",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM12/088.ts
+++ b/data-asia/SM/SM12/088.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "シロナ&カトレア",
+	},
+
+	illustrator: "Ken Sugimori",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分のトラッシュにあるサポート（「シロナ&カトレア」とこのカードの効果でトラッシュされたカードをのぞく）を1枚、相手に見せてから、手札に加える。追加で、このカードを使うときに、自分の手札を1枚トラッシュしてよい。その場合、自分の山札を3枚引く。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 555011,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "C",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM12/089.ts
+++ b/data-asia/SM/SM12/089.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "マオ&スイレン",
+	},
+
+	illustrator: "Ken Sugimori",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分のバトルポケモンをベンチポケモンと入れ替える。追加で、このカードを使うときに、自分の手札を2枚トラッシュしてよい。その場合、ベンチに入れ替えたポケモンのHPを「120」回復する。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 555013,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "C",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM12/090.ts
+++ b/data-asia/SM/SM12/090.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "レッド&グリーン",
+	},
+
+	illustrator: "Megumi Mizutani",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の場のポケモン1匹から進化する「ポケモンGX」を、自分の山札から1枚選び、そのポケモンにのせて進化させる。そして山札を切る。（最初の自分の番や、出したばかりのポケモンには使えない。）追加で、このカードを使うときに、自分の手札を2枚トラッシュしてよい。その場合、進化させたポケモンに、自分の山札にある基本エネルギーを2枚までつける。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 555016,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "C",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM12/091.ts
+++ b/data-asia/SM/SM12/091.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "混沌のうねり",
+	},
+
+	illustrator: "Ryo Ueda",
+	category: "Trainer",
+
+	effect: {
+		ja: "おたがいのプレイヤーが、手札から別の名前のスタジアムを場に出したとき、このスタジアムをトラッシュしたあと、そのスタジアムもトラッシュする。（新しく出たスタジアムの効果ははたらかない。）",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 555018,
+			},
+		},
+	],
+
+	trainerType: "Stadium",
+	regulationMark: "C",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM12/092.ts
+++ b/data-asia/SM/SM12/092.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "プレシャスボール",
+	},
+
+	illustrator: "Ryo Ueda",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の山札にある「ポケモンGX」を1枚、相手に見せてから、手札に加える。そして山札を切る。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 555023,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	regulationMark: "C",
+	rarity: "Rare Holo",
+};
+
+export default card;

--- a/data-asia/SM/SM12/093.ts
+++ b/data-asia/SM/SM12/093.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ぼうけんのカバン",
+	},
+
+	illustrator: "Yoshinobu Saito",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の山札にある「ポケモンのどうぐ」を2枚まで、相手に見せてから、手札に加える。そして山札を切る。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 555026,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	regulationMark: "B",
+	rarity: "Rare Holo",
+};
+
+export default card;

--- a/data-asia/SM/SM12/094.ts
+++ b/data-asia/SM/SM12/094.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ポケモン通信",
+	},
+
+	illustrator: "Studio Bora Inc.",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の手札からポケモンを1枚選び、相手に見せてから、山札にもどす。もどした場合、自分の山札からポケモンを1枚選び、相手に見せてから、手札に加える。そして山札を切る。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 555031,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	regulationMark: "C",
+	rarity: "Rare Holo",
+};
+
+export default card;

--- a/data-asia/SM/SM12/095.ts
+++ b/data-asia/SM/SM12/095.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ウツギ博士のレクチャー",
+	},
+
+	illustrator: "nagimiso",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の山札にある、HPが「60」以下のポケモンを3枚まで、相手に見せてから、手札に加える。そして山札を切る。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 555034,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "B",
+	rarity: "Rare Holo",
+};
+
+export default card;

--- a/data-asia/SM/SM12/096.ts
+++ b/data-asia/SM/SM12/096.ts
@@ -1,0 +1,69 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ウルガモスGX",
+	},
+
+	illustrator: "PLANETA Tsuji",
+	category: "Pokemon",
+	hp: 210,
+	types: ["Fire"],
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "れっかだん" },
+			effect: {
+				ja: "自分の番に1回使える。自分の手札にある[炎]エネルギーを、1枚トラッシュする。その後、相手のポケモン1匹に、ダメカンを2個のせる。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "バックファイヤー" },
+			damage: 160,
+			cost: ["Fire", "Fire", "Colorless"],
+			effect: {
+				ja: "このポケモンについている[炎]エネルギーを、2個手札にもどす。",
+			},
+		},
+		{
+			name: { ja: "だいねっぱGX" },
+			cost: ["Fire"],
+			effect: {
+				ja: "相手の場のポケモン全員についているエネルギーを、1個ずつトラッシュする。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 555039,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "メラルバ",
+	},
+
+	retreat: 3,
+	regulationMark: "C",
+	rarity: "Ultra Rare",
+	dexId: [637],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM12/097.ts
+++ b/data-asia/SM/SM12/097.ts
@@ -1,0 +1,63 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "オドリドリGX",
+	},
+
+	illustrator: "PLANETA Tsuji",
+	category: "Pokemon",
+	hp: 170,
+	types: ["Psychic"],
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "たむけのまい" },
+			effect: {
+				ja: "前の相手の番に、自分のポケモンがきぜつしていたなら、自分の番に1回使える。自分の山札を3枚引く。この番、すでに別の「たむけのまい」を使っていたなら、この特性は使えない。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "するどいはね" },
+			damage: 80,
+			cost: ["Psychic", "Colorless", "Colorless"],
+		},
+		{
+			name: { ja: "ひるがえすGX" },
+			damage: 100,
+			cost: ["Psychic", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンをベンチポケモンと入れ替える。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 555044,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Ultra Rare",
+	dexId: [741],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM12/098.ts
+++ b/data-asia/SM/SM12/098.ts
@@ -1,0 +1,70 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "フライゴンGX",
+	},
+
+	illustrator: "PLANETA Tsuji",
+	category: "Pokemon",
+	hp: 240,
+	types: ["Fighting"],
+
+	stage: "Stage2",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "さじんのまもり" },
+			effect: {
+				ja: "このポケモンがバトル場にいるかぎり、自分のポケモン全員が、相手のポケモンから受けるワザのダメージは「-30」される。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "デザートハリケーン" },
+			damage: "120+",
+			cost: ["Fighting", "Fighting", "Fighting"],
+			effect: {
+				ja: "場にスタジアムが出ているなら、120ダメージ追加。その後、そのスタジアムをトラッシュする。",
+			},
+		},
+		{
+			name: { ja: "ソニックエッジGX" },
+			damage: 220,
+			cost: ["Fighting", "Fighting", "Fighting"],
+			effect: {
+				ja: "このワザのダメージは、相手のバトルポケモンにかかっている効果を計算しない。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 555047,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ビブラーバ",
+	},
+
+	retreat: 2,
+	regulationMark: "C",
+	rarity: "Ultra Rare",
+	dexId: [330],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM12/099.ts
+++ b/data-asia/SM/SM12/099.ts
@@ -1,0 +1,55 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アルセウス&ディアルガ&パルキアGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 280,
+	types: ["Dragon"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "アルティメットレイ" },
+			damage: 150,
+			cost: ["Water", "Metal", "Colorless"],
+			effect: {
+				ja: "自分の山札にある基本エネルギーを3枚まで、自分のポケモンに好きなようにつける。そして山札を切る。",
+			},
+		},
+		{
+			name: { ja: "オルタージェネシスGX" },
+			cost: ["Metal"],
+			effect: {
+				ja: "この対戦が終わるまで、自分のポケモン全員が使うワザの、相手のバトルポケモンへのダメージはすべて「+30」される。追加で[水]エネルギーが1個ついているなら、そのワザのダメージで相手のバトルポケモンをきぜつさせた場合、サイドを1枚多くとる。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fairy", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 555051,
+			},
+		},
+	],
+
+	retreat: 3,
+	regulationMark: "C",
+	rarity: "Ultra Rare",
+	dexId: [493, 483, 484],
+
+	suffix: "TAG TEAM-GX",
+};
+
+export default card;

--- a/data-asia/SM/SM12/100.ts
+++ b/data-asia/SM/SM12/100.ts
@@ -1,0 +1,55 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アルセウス&ディアルガ&パルキアGX",
+	},
+
+	illustrator: "Kouki Saitou",
+	category: "Pokemon",
+	hp: 280,
+	types: ["Dragon"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "アルティメットレイ" },
+			damage: 150,
+			cost: ["Water", "Metal", "Colorless"],
+			effect: {
+				ja: "自分の山札にある基本エネルギーを3枚まで、自分のポケモンに好きなようにつける。そして山札を切る。",
+			},
+		},
+		{
+			name: { ja: "オルタージェネシスGX" },
+			cost: ["Metal"],
+			effect: {
+				ja: "この対戦が終わるまで、自分のポケモン全員が使うワザの、相手のバトルポケモンへのダメージはすべて「+30」される。追加で[水]エネルギーが1個ついているなら、そのワザのダメージで相手のバトルポケモンをきぜつさせた場合、サイドを1枚多くとる。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fairy", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 555053,
+			},
+		},
+	],
+
+	retreat: 3,
+	regulationMark: "C",
+	rarity: "Ultra Rare",
+	dexId: [493, 483, 484],
+
+	suffix: "TAG TEAM-GX",
+};
+
+export default card;

--- a/data-asia/SM/SM12/101.ts
+++ b/data-asia/SM/SM12/101.ts
@@ -1,0 +1,62 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アーゴヨン&アクジキングGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 280,
+	types: ["Dragon"],
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ぼうしょく" },
+			effect: {
+				ja: "自分の番に1回使える。自分の手札にあるポケモンを1枚トラッシュする。その後、このポケモンのHPを「60」回復する。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ジェットピアス" },
+			damage: 180,
+			cost: ["Psychic", "Darkness", "Colorless"],
+		},
+		{
+			name: { ja: "カオスオーダーGX" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分のサイドをすべてオモテにする（対戦が終わるまで、そのサイドはオモテのまま）。追加で[超]エネルギーと[悪]エネルギーが1個ずつついているなら、自分のサイドを2枚とる。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fairy", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 555056,
+			},
+		},
+	],
+
+	retreat: 3,
+	regulationMark: "C",
+	rarity: "Ultra Rare",
+	dexId: [804, 799],
+
+	suffix: "TAG TEAM-GX",
+};
+
+export default card;

--- a/data-asia/SM/SM12/102.ts
+++ b/data-asia/SM/SM12/102.ts
@@ -1,0 +1,62 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アーゴヨン&アクジキングGX",
+	},
+
+	illustrator: "Aya Kusube",
+	category: "Pokemon",
+	hp: 280,
+	types: ["Dragon"],
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ぼうしょく" },
+			effect: {
+				ja: "自分の番に1回使える。自分の手札にあるポケモンを1枚トラッシュする。その後、このポケモンのHPを「60」回復する。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ジェットピアス" },
+			damage: 180,
+			cost: ["Psychic", "Darkness", "Colorless"],
+		},
+		{
+			name: { ja: "カオスオーダーGX" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分のサイドをすべてオモテにする（対戦が終わるまで、そのサイドはオモテのまま）。追加で[超]エネルギーと[悪]エネルギーが1個ずつついているなら、自分のサイドを2枚とる。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fairy", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 555061,
+			},
+		},
+	],
+
+	retreat: 3,
+	regulationMark: "C",
+	rarity: "Ultra Rare",
+	dexId: [804, 799],
+
+	suffix: "TAG TEAM-GX",
+};
+
+export default card;

--- a/data-asia/SM/SM12/103.ts
+++ b/data-asia/SM/SM12/103.ts
@@ -1,0 +1,55 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "メガミミロップ&プリンGX",
+	},
+
+	illustrator: "aky CG Works",
+	category: "Pokemon",
+	hp: 240,
+	types: ["Colorless"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ジャンピングバルーン" },
+			damage: "60+",
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手の場の「ポケモンGX・EX」の数×60ダメージ追加。",
+			},
+		},
+		{
+			name: { ja: "パフスマッシャーGX" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをねむりにする。追加でエネルギーが4個ついているなら、相手のベンチポケモン1匹に、200ダメージ。［ベンチは弱点・抵抗力を計算しない。］［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 555063,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Ultra Rare",
+	dexId: [428, 39],
+
+	suffix: "TAG TEAM-GX",
+};
+
+export default card;

--- a/data-asia/SM/SM12/104.ts
+++ b/data-asia/SM/SM12/104.ts
@@ -1,0 +1,55 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "メガミミロップ&プリンGX",
+	},
+
+	illustrator: "Shibuzoh.",
+	category: "Pokemon",
+	hp: 240,
+	types: ["Colorless"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ジャンピングバルーン" },
+			damage: "60+",
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手の場の「ポケモンGX・EX」の数×60ダメージ追加。",
+			},
+		},
+		{
+			name: { ja: "パフスマッシャーGX" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをねむりにする。追加でエネルギーが4個ついているなら、相手のベンチポケモン1匹に、200ダメージ。［ベンチは弱点・抵抗力を計算しない。］［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 555066,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Ultra Rare",
+	dexId: [428, 39],
+
+	suffix: "TAG TEAM-GX",
+};
+
+export default card;

--- a/data-asia/SM/SM12/105.ts
+++ b/data-asia/SM/SM12/105.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "グズマ&ハラ",
+	},
+
+	illustrator: "Junsei Kuninobu",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の山札にある「スタジアム」を1枚、相手に見せてから、手札に加える。そして山札を切る。追加で、このカードを使うときに、自分の手札を2枚トラッシュしてよい。その場合、「ポケモンのどうぐ」と「特殊エネルギー」も1枚ずつ手札に加えられる。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 555071,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "C",
+	rarity: "Ultra Rare",
+};
+
+export default card;

--- a/data-asia/SM/SM12/106.ts
+++ b/data-asia/SM/SM12/106.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "シロナ&カトレア",
+	},
+
+	illustrator: "Sakiko Maeda",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分のトラッシュにあるサポート（「シロナ&カトレア」とこのカードの効果でトラッシュされたカードをのぞく）を1枚、相手に見せてから、手札に加える。追加で、このカードを使うときに、自分の手札を1枚トラッシュしてよい。その場合、自分の山札を3枚引く。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 555076,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "C",
+	rarity: "Ultra Rare",
+};
+
+export default card;

--- a/data-asia/SM/SM12/107.ts
+++ b/data-asia/SM/SM12/107.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "マオ&スイレン",
+	},
+
+	illustrator: "kirisAki",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分のバトルポケモンをベンチポケモンと入れ替える。追加で、このカードを使うときに、自分の手札を2枚トラッシュしてよい。その場合、ベンチに入れ替えたポケモンのHPを「120」回復する。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 555081,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "C",
+	rarity: "Ultra Rare",
+};
+
+export default card;

--- a/data-asia/SM/SM12/108.ts
+++ b/data-asia/SM/SM12/108.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "レッド&グリーン",
+	},
+
+	illustrator: "Hitoshi Ariga",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の場のポケモン1匹から進化する「ポケモンGX」を、自分の山札から1枚選び、そのポケモンにのせて進化させる。そして山札を切る。（最初の自分の番や、出したばかりのポケモンには使えない。）追加で、このカードを使うときに、自分の手札を2枚トラッシュしてよい。その場合、進化させたポケモンに、自分の山札にある基本エネルギーを2枚までつける。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 555086,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "C",
+	rarity: "Ultra Rare",
+};
+
+export default card;

--- a/data-asia/SM/SM12/109.ts
+++ b/data-asia/SM/SM12/109.ts
@@ -1,0 +1,69 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ウルガモスGX",
+	},
+
+	illustrator: "",
+	category: "Pokemon",
+	hp: 210,
+	types: ["Fire"],
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "れっかだん" },
+			effect: {
+				ja: "自分の番に1回使える。自分の手札にある[炎]エネルギーを、1枚トラッシュする。その後、相手のポケモン1匹に、ダメカンを2個のせる。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "バックファイヤー" },
+			damage: 160,
+			cost: ["Fire", "Fire", "Colorless"],
+			effect: {
+				ja: "このポケモンについている[炎]エネルギーを、2個手札にもどす。",
+			},
+		},
+		{
+			name: { ja: "だいねっぱGX" },
+			cost: ["Fire"],
+			effect: {
+				ja: "相手の場のポケモン全員についているエネルギーを、1個ずつトラッシュする。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 555087,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "メラルバ",
+	},
+
+	retreat: 3,
+	regulationMark: "C",
+	rarity: "Hyper rare",
+	dexId: [637],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM12/110.ts
+++ b/data-asia/SM/SM12/110.ts
@@ -1,0 +1,63 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "オドリドリGX",
+	},
+
+	illustrator: "",
+	category: "Pokemon",
+	hp: 170,
+	types: ["Psychic"],
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "たむけのまい" },
+			effect: {
+				ja: "前の相手の番に、自分のポケモンがきぜつしていたなら、自分の番に1回使える。自分の山札を3枚引く。この番、すでに別の「たむけのまい」を使っていたなら、この特性は使えない。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "するどいはね" },
+			damage: 80,
+			cost: ["Psychic", "Colorless", "Colorless"],
+		},
+		{
+			name: { ja: "ひるがえすGX" },
+			damage: 100,
+			cost: ["Psychic", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンをベンチポケモンと入れ替える。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 555088,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Hyper rare",
+	dexId: [741],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM12/111.ts
+++ b/data-asia/SM/SM12/111.ts
@@ -1,0 +1,70 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "フライゴンGX",
+	},
+
+	illustrator: "",
+	category: "Pokemon",
+	hp: 240,
+	types: ["Fighting"],
+
+	stage: "Stage2",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "さじんのまもり" },
+			effect: {
+				ja: "このポケモンがバトル場にいるかぎり、自分のポケモン全員が、相手のポケモンから受けるワザのダメージは「-30」される。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "デザートハリケーン" },
+			damage: "120+",
+			cost: ["Fighting", "Fighting", "Fighting"],
+			effect: {
+				ja: "場にスタジアムが出ているなら、120ダメージ追加。その後、そのスタジアムをトラッシュする。",
+			},
+		},
+		{
+			name: { ja: "ソニックエッジGX" },
+			damage: 220,
+			cost: ["Fighting", "Fighting", "Fighting"],
+			effect: {
+				ja: "このワザのダメージは、相手のバトルポケモンにかかっている効果を計算しない。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 555092,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ビブラーバ",
+	},
+
+	retreat: 2,
+	regulationMark: "C",
+	rarity: "Hyper rare",
+	dexId: [330],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM12/112.ts
+++ b/data-asia/SM/SM12/112.ts
@@ -1,0 +1,55 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アルセウス&ディアルガ&パルキアGX",
+	},
+
+	illustrator: "",
+	category: "Pokemon",
+	hp: 280,
+	types: ["Dragon"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "アルティメットレイ" },
+			damage: 150,
+			cost: ["Water", "Metal", "Colorless"],
+			effect: {
+				ja: "自分の山札にある基本エネルギーを3枚まで、自分のポケモンに好きなようにつける。そして山札を切る。",
+			},
+		},
+		{
+			name: { ja: "オルタージェネシスGX" },
+			cost: ["Metal"],
+			effect: {
+				ja: "この対戦が終わるまで、自分のポケモン全員が使うワザの、相手のバトルポケモンへのダメージはすべて「+30」される。追加で[水]エネルギーが1個ついているなら、そのワザのダメージで相手のバトルポケモンをきぜつさせた場合、サイドを1枚多くとる。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fairy", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 555097,
+			},
+		},
+	],
+
+	retreat: 3,
+	regulationMark: "C",
+	rarity: "Hyper rare",
+	dexId: [493, 483, 484],
+
+	suffix: "TAG TEAM-GX",
+};
+
+export default card;

--- a/data-asia/SM/SM12/113.ts
+++ b/data-asia/SM/SM12/113.ts
@@ -1,0 +1,62 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アーゴヨン&アクジキングGX",
+	},
+
+	illustrator: "",
+	category: "Pokemon",
+	hp: 280,
+	types: ["Dragon"],
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ぼうしょく" },
+			effect: {
+				ja: "自分の番に1回使える。自分の手札にあるポケモンを1枚トラッシュする。その後、このポケモンのHPを「60」回復する。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ジェットピアス" },
+			damage: 180,
+			cost: ["Psychic", "Darkness", "Colorless"],
+		},
+		{
+			name: { ja: "カオスオーダーGX" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分のサイドをすべてオモテにする（対戦が終わるまで、そのサイドはオモテのまま）。追加で[超]エネルギーと[悪]エネルギーが1個ずつついているなら、自分のサイドを2枚とる。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fairy", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 555098,
+			},
+		},
+	],
+
+	retreat: 3,
+	regulationMark: "C",
+	rarity: "Hyper rare",
+	dexId: [804, 799],
+
+	suffix: "TAG TEAM-GX",
+};
+
+export default card;

--- a/data-asia/SM/SM12/114.ts
+++ b/data-asia/SM/SM12/114.ts
@@ -1,0 +1,55 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "メガミミロップ&プリンGX",
+	},
+
+	illustrator: "",
+	category: "Pokemon",
+	hp: 240,
+	types: ["Colorless"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ジャンピングバルーン" },
+			damage: "60+",
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手の場の「ポケモンGX・EX」の数×60ダメージ追加。",
+			},
+		},
+		{
+			name: { ja: "パフスマッシャーGX" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをねむりにする。追加でエネルギーが4個ついているなら、相手のベンチポケモン1匹に、200ダメージ。［ベンチは弱点・抵抗力を計算しない。］［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 555102,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Hyper rare",
+	dexId: [428, 39],
+
+	suffix: "TAG TEAM-GX",
+};
+
+export default card;

--- a/data-asia/SM/SM12/115.ts
+++ b/data-asia/SM/SM12/115.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "タッグコール",
+	},
+
+	illustrator: "",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の山札にある「TAG TEAM」のカードを2枚まで、相手に見せてから、手札に加える。そして山札を切る。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 555106,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	regulationMark: "C",
+	rarity: "Secret Rare",
+};
+
+export default card;

--- a/data-asia/SM/SM12/116.ts
+++ b/data-asia/SM/SM12/116.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "しまめぐりのあかし",
+	},
+
+	illustrator: "",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードをつけている「ポケモンGX・EX」の最大HPは「100」小さくなり、そのポケモンが相手のワザのダメージできぜつしたとき、とられるサイドは1枚少なくなる。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 555107,
+			},
+		},
+	],
+
+	trainerType: "Tool",
+	regulationMark: "C",
+	rarity: "Secret Rare",
+};
+
+export default card;

--- a/data-asia/SM/SM12/117.ts
+++ b/data-asia/SM/SM12/117.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM12";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "巨大なカマド",
+	},
+
+	illustrator: "",
+	category: "Trainer",
+
+	effect: {
+		ja: "おたがいのプレイヤーは、自分の番ごとに1回、自分の手札を1枚トラッシュしてよい。その場合、自分の山札にある[炎]エネルギーを2枚まで、相手に見せてから、手札に加える。そして山札を切る。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 555112,
+			},
+		},
+	],
+
+	trainerType: "Stadium",
+	regulationMark: "C",
+	rarity: "Secret Rare",
+};
+
+export default card;


### PR DESCRIPTION
## What

Adds the complete Japanese set **SM12 オルタージェネシス (Alter Genesis)**, released 2019-09-06:

- `data-asia/SM/SM12/001.ts` … `117.ts` — all 117 cards (95 regular + 22 secret rares: 13 SR, 6 UR, 3 Secret Rare)
- the set definition `data-asia/SM/SM12.ts` already existed and is untouched

## Data sources

- **pokemon-card.com** (official database): Japanese names, flavor texts, National Dex numbers, official card count
- **limitlesstcg.com**: full Japanese card text, stages, weaknesses/resistances/retreat, rarities, illustrators, attack costs
- **Cardmarket**: product IDs as `thirdParty.cardmarket` on the variant objects (554751–555112; tcgplayer IDs not available to me)

## Notes

- Follows the file format and conventions of the M-era sets (#1728)
- All 117 files type-check against `interfaces.d.ts` (`tsc --noEmit`)
