### PR TITLE
(data) Add Japanese SM set SM11b Dream League (& adjusted interface to cater for CHR CSR)

### DIFF
--- a/data-asia/SM/SM11b/001.ts
+++ b/data-asia/SM/SM11b/001.ts
@@ -1,0 +1,49 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM11b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ナゾノクサ",
+	},
+
+	illustrator: "Yumi",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Grass"],
+
+	description: {
+		ja: "昼間は 太陽を 避けるため 冷たい 地面に 潜っている。 月の 光を 浴びて 育つ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "あまいかおり" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分のポケモン1匹のHPを「30」回復する。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 555117,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [43],
+};
+
+export default card;

--- a/data-asia/SM/SM11b/002.ts
+++ b/data-asia/SM/SM11b/002.ts
@@ -1,0 +1,54 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM11b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "クサイハナ",
+	},
+
+	illustrator: "sui",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Grass"],
+
+	description: {
+		ja: "猛烈な クサさ！ それなのに １０００人に １人ぐらい これを 好んで かぐ 人がいる。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "ねむりごな" },
+			damage: 20,
+			cost: ["Grass"],
+			effect: {
+				ja: "相手のバトルポケモンをねむりにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 555118,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ナゾノクサ",
+	},
+
+	retreat: 2,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [44],
+};
+
+export default card;

--- a/data-asia/SM/SM11b/003.ts
+++ b/data-asia/SM/SM11b/003.ts
@@ -1,0 +1,69 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM11b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ラフレシアGX",
+	},
+
+	illustrator: "Kagemaru Himeno",
+	category: "Pokemon",
+	hp: 240,
+	types: ["Grass"],
+
+	stage: "Stage2",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "かおるはなぞの" },
+			effect: {
+				ja: "自分の番に1回使える。自分のポケモン全員のHPを、それぞれ「30」回復する。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "だいかいか 180-" },
+			cost: ["Grass", "Colorless"],
+			effect: {
+				ja: "このポケモンにのっているダメカンの数×10ダメージぶん、このワザのダメージは小さくなる。",
+			},
+		},
+		{
+			name: { ja: "アレルギーボムGX" },
+			damage: 50,
+			cost: ["Grass"],
+			effect: {
+				ja: "相手のバトルポケモンをどくとやけどとマヒにする。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 555122,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "クサイハナ",
+	},
+
+	retreat: 2,
+	regulationMark: "C",
+	rarity: "Double rare",
+	dexId: [45],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM11b/004.ts
+++ b/data-asia/SM/SM11b/004.ts
@@ -1,0 +1,49 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM11b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "マグマッグ",
+	},
+
+	illustrator: "Ken Sugimori",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Fire"],
+
+	description: {
+		ja: "火山地帯に 多く 発生。 暖かい ところを 探して のろのろ はいずり回っている。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "こがす" },
+			cost: ["Fire"],
+			effect: {
+				ja: "相手のバトルポケモンをやけどにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 555126,
+			},
+		},
+	],
+
+	retreat: 3,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [218],
+};
+
+export default card;

--- a/data-asia/SM/SM11b/005.ts
+++ b/data-asia/SM/SM11b/005.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM11b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "マグカルゴ",
+	},
+
+	illustrator: "Miki Tanaka",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Fire"],
+
+	description: {
+		ja: "背中の 殻は 崩れやすいが ときどき 体内を 巡っている 高熱の 炎が 噴き出す。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "ふみならす" },
+			cost: ["Fire"],
+			effect: {
+				ja: "相手の山札を上から2枚トラッシュする。",
+			},
+		},
+		{
+			name: { ja: "かえんほうしゃ" },
+			damage: 80,
+			cost: ["Fire", "Colorless"],
+			effect: {
+				ja: "このポケモンについているエネルギーを、1個トラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 555129,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "マグマッグ",
+	},
+
+	retreat: 3,
+	regulationMark: "C",
+	rarity: "Uncommon",
+	dexId: [219],
+};
+
+export default card;

--- a/data-asia/SM/SM11b/006.ts
+++ b/data-asia/SM/SM11b/006.ts
@@ -1,0 +1,57 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM11b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "コータス",
+	},
+
+	illustrator: "0313",
+	category: "Pokemon",
+	hp: 110,
+	types: ["Fire"],
+
+	description: {
+		ja: "甲羅から 噴きだす 煙で 体調が わかる。 勢いが 激しいときは 元気な 証拠。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ファイヤートス" },
+			cost: ["Fire"],
+			effect: {
+				ja: "自分のトラッシュにある[炎]エネルギーを4枚、相手に見せてから、手札に加える。",
+			},
+		},
+		{
+			name: { ja: "メラメラ" },
+			damage: 100,
+			cost: ["Fire", "Fire", "Fire"],
+			effect: {
+				ja: "このポケモンについているエネルギーを、1個トラッシュする。その後、相手のバトルポケモンについているエネルギーを、1個トラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 555131,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "C",
+	rarity: "Uncommon",
+	dexId: [324],
+};
+
+export default card;

--- a/data-asia/SM/SM11b/007.ts
+++ b/data-asia/SM/SM11b/007.ts
@@ -1,0 +1,50 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM11b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ニューラ",
+	},
+
+	illustrator: "ryoma uratsuka",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Water"],
+
+	description: {
+		ja: "チームプレイで とりポケモンの 巣穴から タマゴを 盗み出すが 誰が 食うかで ケンカになるのだ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "こうそくいどう" },
+			damage: 10,
+			cost: ["Darkness"],
+			effect: {
+				ja: "コインを1回投げオモテなら、次の相手の番、このポケモンはワザのダメージや効果を受けない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 555134,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [215],
+};
+
+export default card;

--- a/data-asia/SM/SM11b/008.ts
+++ b/data-asia/SM/SM11b/008.ts
@@ -1,0 +1,58 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM11b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "マニューラ",
+	},
+
+	illustrator: "MAHOU",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Water"],
+
+	description: {
+		ja: "１匹が サンドの 足を すくい ひっくり返すと もう １匹が 鋭いツメで 止めを 刺す。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "わるだくみ" },
+			cost: ["Darkness"],
+			effect: {
+				ja: "自分の山札にある好きなカードを2枚まで、手札に加える。そして山札を切る。",
+			},
+		},
+		{
+			name: { ja: "スラッシュクロー" },
+			damage: 110,
+			cost: ["Darkness", "Darkness", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 555139,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ニューラ",
+	},
+
+	retreat: 0,
+	regulationMark: "C",
+	rarity: "Uncommon",
+	dexId: [461],
+};
+
+export default card;

--- a/data-asia/SM/SM11b/009.ts
+++ b/data-asia/SM/SM11b/009.ts
@@ -1,0 +1,50 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM11b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ポッチャマ",
+	},
+
+	illustrator: "Suwama Chiaki",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Water"],
+
+	description: {
+		ja: "世話を 焼かれる ことが 大嫌い。 トレーナーの 指示を 聞かないので 仲良く なるのが 難しい。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "バブルホールド" },
+			damage: 80,
+			cost: ["Water", "Water", "Water"],
+			effect: {
+				ja: "次の相手の番、このワザを受けたたねポケモンは、ワザが使えない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 555141,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [393],
+};
+
+export default card;

--- a/data-asia/SM/SM11b/010.ts
+++ b/data-asia/SM/SM11b/010.ts
@@ -1,0 +1,58 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM11b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ポッタイシ",
+	},
+
+	illustrator: "Hasuno",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Water"],
+
+	description: {
+		ja: "群れを 作らずに １匹で いる。 自分が 一番 偉いと どの ポッタイシも 考えているようだ。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "みずきり" },
+			damage: 20,
+			cost: ["Water"],
+		},
+		{
+			name: { ja: "ダイレクトダイブ" },
+			cost: ["Water", "Water", "Water"],
+			effect: {
+				ja: "このポケモンについているエネルギーをすべてトラッシュし、相手のベンチポケモン1匹に、100ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 555142,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ポッチャマ",
+	},
+
+	retreat: 2,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [394],
+};
+
+export default card;

--- a/data-asia/SM/SM11b/011.ts
+++ b/data-asia/SM/SM11b/011.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM11b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "エンペルト",
+	},
+
+	illustrator: "Masakazu Fukuda",
+	category: "Pokemon",
+	hp: 160,
+	types: ["Water"],
+
+	description: {
+		ja: "ジェットスキーに 負けない 速度で 泳ぐ。翼の 縁は 鋭く 流氷を 切断する。",
+	},
+
+	stage: "Stage2",
+
+	attacks: [
+		{
+			name: { ja: "おもいだす" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "このポケモンが進化前に持っていたワザを1つ選び、このワザとして使う。",
+			},
+		},
+		{
+			name: { ja: "アクアフォール" },
+			damage: 130,
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンについているエネルギーを、すべてトラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 555143,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ポッタイシ",
+	},
+
+	retreat: 2,
+	regulationMark: "C",
+	rarity: "Uncommon",
+	dexId: [395],
+};
+
+export default card;

--- a/data-asia/SM/SM11b/012.ts
+++ b/data-asia/SM/SM11b/012.ts
@@ -1,0 +1,50 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM11b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "オタマロ",
+	},
+
+	illustrator: "Asako Ito",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Water"],
+
+	description: {
+		ja: "ほほの 振動膜を 震わせ 人には きこえない 音波を だし 仲間たちに 危険を 伝える。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "はねまくる" },
+			damage: "10×",
+			cost: ["Colorless"],
+			effect: {
+				ja: "コインを3回投げ、オモテの数×10ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 555146,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [535],
+};
+
+export default card;

--- a/data-asia/SM/SM11b/013.ts
+++ b/data-asia/SM/SM11b/013.ts
@@ -1,0 +1,57 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM11b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヨワシ",
+	},
+
+	illustrator: "kawayoo",
+	category: "Pokemon",
+	hp: 180,
+	types: ["Water"],
+
+	description: {
+		ja: "ヨワシたちが 敵に 立ち向かうため 陣形を 組んだ。 海の魔物と 呼ばれるほどの 力を 誇る。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ちりぢり" },
+			effect: {
+				ja: "このポケモンにダメカンがのっているなら、相手の番の終わりに、コインを1回投げる。ウラなら、このポケモンと、ついているすべてのカードを、自分の山札にもどして切る。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ハイドロスプラッシュ" },
+			damage: 130,
+			cost: ["Water", "Water", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 555147,
+			},
+		},
+	],
+
+	retreat: 3,
+	regulationMark: "C",
+	rarity: "Rare",
+	dexId: [746],
+};
+
+export default card;

--- a/data-asia/SM/SM11b/014.ts
+++ b/data-asia/SM/SM11b/014.ts
@@ -1,0 +1,52 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM11b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "シズクモ",
+	},
+
+	illustrator: "Shibuzoh.",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Water"],
+
+	description: {
+		ja: "シズクモ同士が 出会うと 頭の 水泡を 自慢し アピールする。 小さな 方が 道を 譲る。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ぶつかる" },
+			damage: 20,
+			cost: ["Colorless", "Colorless"],
+		},
+		{
+			name: { ja: "スプラッシュ" },
+			damage: 40,
+			cost: ["Water", "Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 555148,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [751],
+};
+
+export default card;

--- a/data-asia/SM/SM11b/015.ts
+++ b/data-asia/SM/SM11b/015.ts
@@ -1,0 +1,59 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM11b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "オニシズクモ",
+	},
+
+	illustrator: "Tomokazu Komiya",
+	category: "Pokemon",
+	hp: 100,
+	types: ["Water"],
+
+	description: {
+		ja: "普段は 水の中で 過ごす。 満腹の とき 仕留めた 獲物は 頭の 水泡に 仕舞っておく。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "ヘッドバット" },
+			damage: 40,
+			cost: ["Colorless", "Colorless"],
+		},
+		{
+			name: { ja: "アクアブレイク" },
+			damage: 80,
+			cost: ["Water", "Colorless", "Colorless"],
+			effect: {
+				ja: "次の自分の番、このワザを受けたポケモンが受けるワザのダメージは「+60」される。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 555151,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "シズクモ",
+	},
+
+	retreat: 2,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [752],
+};
+
+export default card;

--- a/data-asia/SM/SM11b/016.ts
+++ b/data-asia/SM/SM11b/016.ts
@@ -1,0 +1,57 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM11b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ピカチュウ",
+	},
+
+	illustrator: "Naoyo Kimura",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Lightning"],
+
+	description: {
+		ja: "電気を ため込む 性質。 ピカチュウが 群れて 暮らす 森は 落雷が 絶えず 危険だ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ほっぺすりすり" },
+			cost: ["Lightning"],
+			effect: {
+				ja: "コインを1回投げオモテなら、相手のバトルポケモンをマヒにする。",
+			},
+		},
+		{
+			name: { ja: "ボルテッカー" },
+			damage: 70,
+			cost: ["Lightning", "Lightning", "Colorless"],
+			effect: {
+				ja: "このポケモンにも10ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Metal", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 555154,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [25],
+};
+
+export default card;

--- a/data-asia/SM/SM11b/017.ts
+++ b/data-asia/SM/SM11b/017.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM11b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ライチュウ",
+	},
+
+	illustrator: "AKIRA EGAWA",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Lightning"],
+
+	description: {
+		ja: "身体に 電気が たまるに つれ 攻撃的に。 実は 電気が ストレスなのでは という 説もある。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "ほっぺすりすり" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "コインを1回投げオモテなら、相手のバトルポケモンをマヒにする。",
+			},
+		},
+		{
+			name: { ja: "パワフルスパーク" },
+			damage: "20×",
+			cost: ["Lightning"],
+			effect: {
+				ja: "自分の場のポケモンについている[雷]エネルギーの数×20ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Metal", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 555156,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ピカチュウ",
+	},
+
+	retreat: 2,
+	regulationMark: "C",
+	rarity: "Uncommon",
+	dexId: [26],
+};
+
+export default card;

--- a/data-asia/SM/SM11b/018.ts
+++ b/data-asia/SM/SM11b/018.ts
@@ -1,0 +1,50 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM11b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "コイル",
+	},
+
+	illustrator: "Suwama Chiaki",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Lightning"],
+
+	description: {
+		ja: "たびたび 停電の 原因と なる ため コイルが 嫌がる 電波を 流す 発電所も あるほど。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ミラーショット" },
+			damage: 10,
+			cost: ["Lightning"],
+			effect: {
+				ja: "次の相手の番、このワザを受けたポケモンがワザを使うとき、相手はコインを1回投げる。ウラならそのワザは失敗。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Metal", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 555158,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [81],
+};
+
+export default card;

--- a/data-asia/SM/SM11b/019.ts
+++ b/data-asia/SM/SM11b/019.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM11b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "レアコイル",
+	},
+
+	illustrator: "Eske Yoshinob",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Lightning"],
+
+	description: {
+		ja: "謎の 電波を 発信 しており レアコイルが 棲んでいる 場所では 精密機器が 故障してしまう。",
+	},
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "しょうしゅうしんごう" },
+			effect: {
+				ja: "自分の番に1回使えて、使ったなら、このポケモンをきぜつさせる。自分の山札にあるサポートを3枚まで、相手に見せてから、手札に加える。そして山札を切る。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "マグネブラスト" },
+			damage: 50,
+			cost: ["Lightning", "Lightning", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Metal", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 555163,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "コイル",
+	},
+
+	retreat: 2,
+	regulationMark: "C",
+	rarity: "Rare",
+	dexId: [82],
+};
+
+export default card;

--- a/data-asia/SM/SM11b/020.ts
+++ b/data-asia/SM/SM11b/020.ts
@@ -1,0 +1,56 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM11b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ソルガレオ&ルナアーラGX",
+	},
+
+	illustrator: "Hideki Ishikawa",
+	category: "Pokemon",
+	hp: 270,
+	types: ["Psychic"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "コズミックバーン" },
+			damage: 230,
+			cost: ["Psychic", "Psychic", "Psychic", "Colorless"],
+			effect: {
+				ja: "次の自分の番、このポケモンは「コズミックバーン」が使えない。",
+			},
+		},
+		{
+			name: { ja: "めがみのひかりGX" },
+			damage: 200,
+			cost: ["Psychic", "Psychic", "Colorless"],
+			effect: {
+				ja: "追加でこの番、手札から「リーリエの全力」を出して使っていたなら、次の相手の番、自分のポケモン全員は、ワザのダメージや効果を受けない。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 555167,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "C",
+	rarity: "Double rare",
+	dexId: [791, 792],
+
+	suffix: "TAG TEAM-GX",
+};
+
+export default card;

--- a/data-asia/SM/SM11b/021.ts
+++ b/data-asia/SM/SM11b/021.ts
@@ -1,0 +1,60 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM11b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ドガース",
+	},
+
+	illustrator: "Naoyo Kimura",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Psychic"],
+
+	description: {
+		ja: "薄い バルーン状の 体に 猛毒の ガスが つまっている。 近くに 来ると くさい。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ぶっとびボム" },
+			effect: {
+				ja: "自分の番に、このカードが「ホミカ」の効果でトラッシュされたとき、1回使える。相手のポケモン全員に、それぞれダメカンを1個のせる。（ダメカンをのせるのは「ホミカ」の効果のあと。）",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "どくガス" },
+			damage: 10,
+			cost: ["Psychic", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをどくにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 555171,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [109],
+};
+
+export default card;

--- a/data-asia/SM/SM11b/022.ts
+++ b/data-asia/SM/SM11b/022.ts
@@ -1,0 +1,64 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM11b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "マタドガス",
+	},
+
+	illustrator: "Motofumi Fujiwara",
+	category: "Pokemon",
+	hp: 100,
+	types: ["Psychic"],
+
+	description: {
+		ja: "どちらかが ふくらむと 片方は しぼむ 双子の ドガース。いつも 体内の 毒ガスを 混ぜている。",
+	},
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ぶっとびボム" },
+			effect: {
+				ja: "自分の番に、このカードが「ホミカ」の効果でトラッシュされたとき、1回使える。相手のポケモン全員に、それぞれダメカンを1個のせる。（ダメカンをのせるのは「ホミカ」の効果のあと。）",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "バルーンバースト" },
+			damage: 90,
+			cost: ["Psychic", "Colorless"],
+			effect: {
+				ja: "このポケモンと、ついているすべてのカードを、トラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 555173,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ドガース",
+	},
+
+	retreat: 2,
+	regulationMark: "C",
+	rarity: "Uncommon",
+	dexId: [110],
+};
+
+export default card;

--- a/data-asia/SM/SM11b/023.ts
+++ b/data-asia/SM/SM11b/023.ts
@@ -1,0 +1,49 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM11b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ネイティ",
+	},
+
+	illustrator: "tetsuya koizumi",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Psychic"],
+
+	description: {
+		ja: "まだ 飛べないが ジャンプ力は 抜群。 高い 木の 枝に 飛び上がり 木の芽を ついばむ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "みらいよち" },
+			cost: ["Psychic"],
+			effect: {
+				ja: "自分または相手の山札を上から4枚見て、好きな順番に入れ替えて、山札の上にもどす。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 555174,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [177],
+};
+
+export default card;

--- a/data-asia/SM/SM11b/024.ts
+++ b/data-asia/SM/SM11b/024.ts
@@ -1,0 +1,60 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM11b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ネイティオ",
+	},
+
+	illustrator: "Anesaki Dynamic",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Psychic"],
+
+	description: {
+		ja: "未来を 予知する 力が あるが 未来を 変えるほどの 力は 持っていないと いわれる ポケモン。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "ぶきみなかぜ" },
+			cost: ["Psychic"],
+			effect: {
+				ja: "相手のバトルポケモンをこんらんにする。",
+			},
+		},
+		{
+			name: { ja: "ライフダウン" },
+			cost: ["Psychic", "Colorless"],
+			effect: {
+				ja: "コインを1回投げオモテなら、相手のバトルポケモンの残りHPが「10」になるように、ダメカンをのせる。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 555179,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ネイティ",
+	},
+
+	retreat: 2,
+	regulationMark: "C",
+	rarity: "Uncommon",
+	dexId: [178],
+};
+
+export default card;

--- a/data-asia/SM/SM11b/025.ts
+++ b/data-asia/SM/SM11b/025.ts
@@ -1,0 +1,54 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM11b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ラルトス",
+	},
+
+	illustrator: "Atsuko Nishida",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Psychic"],
+
+	description: {
+		ja: "赤いツノで 人や ポケモンの 温かな 気持ちを キャッチすると 全身が ほのかに 熱くなる。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "テレポート" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "このポケモンをベンチポケモンと入れ替える。",
+			},
+		},
+		{
+			name: { ja: "ぶつかる" },
+			damage: 10,
+			cost: ["Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 555182,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [280],
+};
+
+export default card;

--- a/data-asia/SM/SM11b/026.ts
+++ b/data-asia/SM/SM11b/026.ts
@@ -1,0 +1,58 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM11b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "キルリア",
+	},
+
+	illustrator: "sowsow",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Psychic"],
+
+	description: {
+		ja: "トレーナーの 明るい 気持ちが サイコパワーの 源。楽しい 気分に なると クルクル 踊る。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "さいみんじゅつ" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをねむりにする。",
+			},
+		},
+		{
+			name: { ja: "かいてんげり" },
+			damage: 20,
+			cost: ["Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 555186,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ラルトス",
+	},
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [281],
+};
+
+export default card;

--- a/data-asia/SM/SM11b/027.ts
+++ b/data-asia/SM/SM11b/027.ts
@@ -1,0 +1,64 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM11b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "エルレイド",
+	},
+
+	illustrator: "Misa Tsutsui",
+	category: "Pokemon",
+	hp: 160,
+	types: ["Psychic"],
+
+	description: {
+		ja: "相手の 考えを 敏感に キャッチする 能力を 持つため 先に 攻撃が できるのだ。",
+	},
+
+	stage: "Stage2",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ダブルタイプ" },
+			effect: {
+				ja: "このポケモンは、場にいるかぎり[超]と[闘]の2つのタイプになる。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "パワーサイクロン" },
+			damage: 120,
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンについているエネルギーを1個、ベンチポケモンにつけ替える。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 555187,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "キルリア",
+	},
+
+	retreat: 2,
+	regulationMark: "C",
+	rarity: "Rare",
+	dexId: [475],
+};
+
+export default card;

--- a/data-asia/SM/SM11b/028.ts
+++ b/data-asia/SM/SM11b/028.ts
@@ -1,0 +1,56 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM11b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ミミッキュ",
+	},
+
+	illustrator: "HYOGONOSUKE",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Psychic"],
+
+	description: {
+		ja: "大人しい 寂しがり屋 だけど ボロ切れの 中身を 見ようとすると 激しく 嫌がり 抵抗する。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "なりすます" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の手札にあるサポートを1枚トラッシュする。その後、そのサポートの効果を、このワザの効果として使う。",
+			},
+		},
+		{
+			name: { ja: "いたずらなて" },
+			cost: ["Psychic"],
+			effect: {
+				ja: "相手のポケモン2匹に、それぞれダメカンを2個のせる。",
+			},
+		},
+	],
+
+	weaknesses: [],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 555192,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [778],
+};
+
+export default card;

--- a/data-asia/SM/SM11b/029.ts
+++ b/data-asia/SM/SM11b/029.ts
@@ -1,0 +1,57 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM11b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "イワーク",
+	},
+
+	illustrator: "otumami",
+	category: "Pokemon",
+	hp: 110,
+	types: ["Fighting"],
+
+	description: {
+		ja: "地中を ものすごい 勢いで 掘りすすみ エサを 探す。通った 跡は ディグダの 住処になる。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ほりあてる" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分のトラッシュにあるエネルギーを1枚、相手に見せてから、手札に加える。",
+			},
+		},
+		{
+			name: { ja: "テールスマッシュ" },
+			damage: 100,
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "コインを1回投げウラなら、このワザは失敗。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 555194,
+			},
+		},
+	],
+
+	retreat: 4,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [95],
+};
+
+export default card;

--- a/data-asia/SM/SM11b/030.ts
+++ b/data-asia/SM/SM11b/030.ts
@@ -1,0 +1,54 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM11b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "モグリュー",
+	},
+
+	illustrator: "Suwama Chiaki",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Fighting"],
+
+	description: {
+		ja: "両手の ツメを 重ね合わせて 体を 高速 回転させると 猛スピードで 地中を 進む。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "たがやす" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分のトラッシュにある好きなカードを1枚、相手に見せてから、山札にもどして切る。",
+			},
+		},
+		{
+			name: { ja: "どろかけ" },
+			damage: 10,
+			cost: ["Fighting"],
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 555198,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [529],
+};
+
+export default card;

--- a/data-asia/SM/SM11b/031.ts
+++ b/data-asia/SM/SM11b/031.ts
@@ -1,0 +1,62 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM11b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ドリュウズ",
+	},
+
+	illustrator: "SATOSHI NAKAI",
+	category: "Pokemon",
+	hp: 140,
+	types: ["Fighting"],
+
+	description: {
+		ja: "鋼に 進化した ドリルは 鉄板を つらぬく 破壊力。 トンネル工事で 大活躍する。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "どたんばタックル" },
+			damage: "30+",
+			cost: ["Fighting"],
+			effect: {
+				ja: "自分の山札の残り枚数が3枚以下なら、150ダメージ追加。",
+			},
+		},
+		{
+			name: { ja: "ドリルバズーカ" },
+			damage: 120,
+			cost: ["Fighting"],
+			effect: {
+				ja: "自分の山札を上から4枚トラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 555199,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "モグリュー",
+	},
+
+	retreat: 4,
+	regulationMark: "C",
+	rarity: "Rare",
+	dexId: [530],
+};
+
+export default card;

--- a/data-asia/SM/SM11b/032.ts
+++ b/data-asia/SM/SM11b/032.ts
@@ -1,0 +1,54 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM11b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ガマガル",
+	},
+
+	illustrator: "Ken Sugimori",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Fighting"],
+
+	description: {
+		ja: "頭の コブを 振動させると 水中が 波立つ だけでなく 地面も 地震のように 揺れる。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "ミニじしん" },
+			damage: 60,
+			cost: ["Fighting"],
+			effect: {
+				ja: "自分のベンチポケモン全員にも、それぞれ10ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 555201,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "オタマロ",
+	},
+
+	retreat: 2,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [536],
+};
+
+export default card;

--- a/data-asia/SM/SM11b/033.ts
+++ b/data-asia/SM/SM11b/033.ts
@@ -1,0 +1,64 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM11b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ガマゲロゲ",
+	},
+
+	illustrator: "Shigenori Negishi",
+	category: "Pokemon",
+	hp: 160,
+	types: ["Fighting"],
+
+	description: {
+		ja: "こぶしの コブを 振動させると パンチの 威力が 倍増する。 一撃で 大岩を 粉砕。",
+	},
+
+	stage: "Stage2",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "じならし" },
+			effect: {
+				ja: "自分の番に1回使える。自分の山札から好きなカードを1枚選ぶ。残りの山札を切り、選んだカードを山札の上にもどす。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "わななくこぶし" },
+			damage: "80+",
+			cost: ["Fighting", "Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "自分のベンチのダメカンがのっているポケモンの数×30ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 555202,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ガマガル",
+	},
+
+	retreat: 3,
+	regulationMark: "C",
+	rarity: "Uncommon",
+	dexId: [537],
+};
+
+export default card;

--- a/data-asia/SM/SM11b/034.ts
+++ b/data-asia/SM/SM11b/034.ts
@@ -1,0 +1,62 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM11b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ハガネール",
+	},
+
+	illustrator: "KEIICHIRO ITO",
+	category: "Pokemon",
+	hp: 170,
+	types: ["Metal"],
+
+	description: {
+		ja: "地中の 高い 圧力と 熱で 鍛えられた 体は あらゆる 金属よりも 硬い。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "どっすんフォール" },
+			damage: "50×",
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "自分の手札にあるにげるためのエネルギーが4個のポケモンを好きなだけトラッシュし、その枚数×50ダメージ。",
+			},
+		},
+		{
+			name: { ja: "アイアンテール" },
+			damage: "100×",
+			cost: ["Metal", "Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "ウラが出るまでコインを投げ、オモテの数×100ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 555207,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "イワーク",
+	},
+
+	retreat: 4,
+	regulationMark: "C",
+	rarity: "Rare",
+	dexId: [208],
+};
+
+export default card;

--- a/data-asia/SM/SM11b/035.ts
+++ b/data-asia/SM/SM11b/035.ts
@@ -1,0 +1,50 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM11b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ピッピ",
+	},
+
+	illustrator: "Mina Nakai",
+	category: "Pokemon",
+	hp: 50,
+	types: ["Fairy"],
+
+	description: {
+		ja: "人気だが 数が 少ないので 貴重。 むやみに 見せびらかすと 泥棒に 狙われるぞ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "にんぎょうへんげ" },
+			damage: 60,
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンと、ついているすべてのカードを、手札にもどす。その後、のぞむなら、自分の手札にある「リーリエのピッピ人形」を直接バトル場に出す。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [{ type: "Darkness", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 555208,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Uncommon",
+	dexId: [35],
+};
+
+export default card;

--- a/data-asia/SM/SM11b/036.ts
+++ b/data-asia/SM/SM11b/036.ts
@@ -1,0 +1,55 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM11b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "レシラム&ゼクロムGX",
+	},
+
+	illustrator: "Naoki Saito",
+	category: "Pokemon",
+	hp: 270,
+	types: ["Dragon"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "らいえんむそう" },
+			damage: "90×",
+			cost: ["Fire", "Lightning"],
+			effect: {
+				ja: "自分のベンチポケモンについている[炎]と[雷]タイプの基本エネルギーを3枚までトラッシュし、その枚数×90ダメージ。",
+			},
+		},
+		{
+			name: { ja: "クロスブレイクGX" },
+			cost: ["Fire", "Fire", "Lightning", "Lightning"],
+			effect: {
+				ja: "相手のベンチポケモン1匹に、170ダメージ。追加でこの番、手札から「Nの覚悟」を出して使っていたなら、相手の別のベンチポケモン1匹にも、170ダメージ。［ベンチは弱点・抵抗力を計算しない。］［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fairy", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 555213,
+			},
+		},
+	],
+
+	retreat: 3,
+	regulationMark: "C",
+	rarity: "Double rare",
+	dexId: [643, 644],
+
+	suffix: "TAG TEAM-GX",
+};
+
+export default card;

--- a/data-asia/SM/SM11b/037.ts
+++ b/data-asia/SM/SM11b/037.ts
@@ -1,0 +1,54 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM11b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヨーテリー",
+	},
+
+	illustrator: "Sekio",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Colorless"],
+
+	description: {
+		ja: "判断力に 優れた ポケモン。 勝てない 相手と 判断したら さっさと シッポを 巻いて 逃げる。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "つぶらなひとみ" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "次の相手の番、このワザを受けたポケモンは、にげられない。",
+			},
+		},
+		{
+			name: { ja: "たいあたり" },
+			damage: 40,
+			cost: ["Colorless", "Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 555216,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [506],
+};
+
+export default card;

--- a/data-asia/SM/SM11b/038.ts
+++ b/data-asia/SM/SM11b/038.ts
@@ -1,0 +1,58 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM11b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ハーデリア",
+	},
+
+	illustrator: "Shigenori Negishi",
+	category: "Pokemon",
+	hp: 100,
+	types: ["Colorless"],
+
+	description: {
+		ja: "黒い 体毛は 育つほど 硬く 丈夫に なって ツメや キバも 簡単には 通さないぞ。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "ふるいたてる" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "次の自分の番、このポケモンが使うワザの、相手のバトルポケモンへのダメージは「+60」される。",
+			},
+		},
+		{
+			name: { ja: "とびだしヘッド" },
+			damage: 60,
+			cost: ["Colorless", "Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 555221,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ヨーテリー",
+	},
+
+	retreat: 2,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [507],
+};
+
+export default card;

--- a/data-asia/SM/SM11b/039.ts
+++ b/data-asia/SM/SM11b/039.ts
@@ -1,0 +1,64 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM11b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ムーランド",
+	},
+
+	illustrator: "Masakazu Fukuda",
+	category: "Pokemon",
+	hp: 150,
+	types: ["Colorless"],
+
+	description: {
+		ja: "長く 暖かい 毛の おかげで 寒さは へっちゃら。 アローラの ムーランドは 少し 苦しそうだ。",
+	},
+
+	stage: "Stage2",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ガウガウバーク" },
+			effect: {
+				ja: "自分の番に、このカードを手札から出して進化させたときと、このポケモンがバトル場で相手のワザのダメージを受けてきぜつしたとき、それぞれ1回使える。相手のバトルポケモンについているエネルギーを、1個トラッシュする。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "かけぬける" },
+			damage: 110,
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のベンチポケモン1匹にも、30ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 555222,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ハーデリア",
+	},
+
+	retreat: 3,
+	regulationMark: "C",
+	rarity: "Rare",
+	dexId: [508],
+};
+
+export default card;

--- a/data-asia/SM/SM11b/040.ts
+++ b/data-asia/SM/SM11b/040.ts
@@ -1,0 +1,50 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM11b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "タイプ：ヌル",
+	},
+
+	illustrator: "KEIICHIRO ITO",
+	category: "Pokemon",
+	hp: 110,
+	types: ["Colorless"],
+
+	description: {
+		ja: "ある任務の ために 開発された ポケモン兵器。 実験中に 暴走した ため 凍結された。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "エアスラッシュ" },
+			damage: 50,
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンについているエネルギーを、1個トラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 555227,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [772],
+};
+
+export default card;

--- a/data-asia/SM/SM11b/041.ts
+++ b/data-asia/SM/SM11b/041.ts
@@ -1,0 +1,69 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM11b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "シルヴァディGX",
+	},
+
+	illustrator: "Megumi Mizutani",
+	category: "Pokemon",
+	hp: 210,
+	types: ["Colorless"],
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ディスクリロード" },
+			effect: {
+				ja: "自分の番に1回使える。自分の手札が5枚になるように、山札を引く。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "バディブレイブ" },
+			damage: "50+",
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "この番、手札からサポートを出して使っていたなら、70ダメージ追加。",
+			},
+		},
+		{
+			name: { ja: "ホワイトナイトGX" },
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンが「ウルトラビースト」なら、そのポケモンをきぜつさせる。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 555228,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "タイプ：ヌル",
+	},
+
+	retreat: 2,
+	regulationMark: "C",
+	rarity: "Double rare",
+	dexId: [773],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM11b/042.ts
+++ b/data-asia/SM/SM11b/042.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM11b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "スイレンのつりざお",
+	},
+
+	illustrator: "Eske Yoshinob",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分のトラッシュにあるポケモンと「ポケモンのどうぐ」を1枚ずつ、相手に見せてから、山札にもどして切る。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 555229,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	regulationMark: "C",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM11b/043.ts
+++ b/data-asia/SM/SM11b/043.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM11b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "リーリエのピッピ人形",
+	},
+
+	illustrator: "Studio Bora Inc.",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードは、HP30の無色タイプのたねポケモンとして、場に出すことができる。自分の番の中でなら、バトル場に出ているこのカードを山札の下にもどしてよい。（ついているカードは、すべてトラッシュする。）このカードは、にげられない。このカードがきぜつしても、相手はサイドをとれない。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 555232,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	regulationMark: "C",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM11b/044.ts
+++ b/data-asia/SM/SM11b/044.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM11b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "イツキ",
+	},
+
+	illustrator: "Ken Sugimori",
+	category: "Trainer",
+
+	effect: {
+		ja: "この番、このカードを使ったあとに、ワザ・特性・トレーナーズの効果で自分が次に投げるコインは、最初の1回だけ、オモテかウラか選べる。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 555234,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "C",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM11b/045.ts
+++ b/data-asia/SM/SM11b/045.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM11b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "Nの覚悟",
+	},
+
+	illustrator: "Ryuta Fuse",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の山札を上から6枚トラッシュし、その中にある基本エネルギーをすべて、自分のベンチの[竜]ポケモン1匹につける。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 555236,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "C",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM11b/046.ts
+++ b/data-asia/SM/SM11b/046.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM11b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ホミカ",
+	},
+
+	illustrator: "Yusuke Ohmura",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の手札にあるポケモン（「ポケモンGX・EX」をのぞく）を2枚までトラッシュし、その枚数×3枚、自分の山札を引く。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 555237,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "C",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM11b/047.ts
+++ b/data-asia/SM/SM11b/047.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM11b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "メイ",
+	},
+
+	illustrator: "Yusuke Ohmura",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードは、前の相手の番に、自分のポケモンがきぜつしていなければ使えない。自分の山札にあるポケモン・トレーナーズ・基本エネルギーを1枚ずつ、相手に見せてから、手札に加える。そして山札を切る。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 555241,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "C",
+	rarity: "Rare",
+};
+
+export default card;

--- a/data-asia/SM/SM11b/048.ts
+++ b/data-asia/SM/SM11b/048.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM11b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヤーコン",
+	},
+
+	illustrator: "Yusuke Ohmura",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の山札を上から7枚トラッシュし、その中にあるグッズをすべて、相手に見せてから、手札に加える。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 555246,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "C",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM11b/049.ts
+++ b/data-asia/SM/SM11b/049.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM11b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "リーリエの全力",
+	},
+
+	illustrator: "kodama",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の山札を4枚引く。このカードを使った番の終わりに、自分の手札が3枚以上あるなら、その手札が2枚になるように、山札にもどして切る。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 555249,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "C",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM11b/050.ts
+++ b/data-asia/SM/SM11b/050.ts
@@ -1,0 +1,57 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM11b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "コータス",
+	},
+
+	illustrator: "Ryota Murayama",
+	category: "Pokemon",
+	hp: 110,
+	types: ["Fire"],
+
+	description: {
+		ja: "甲羅から 噴きだす 煙で 体調が わかる。 勢いが 激しいときは 元気な 証拠。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ファイヤートス" },
+			cost: ["Fire"],
+			effect: {
+				ja: "自分のトラッシュにある[炎]エネルギーを4枚、相手に見せてから、手札に加える。",
+			},
+		},
+		{
+			name: { ja: "メラメラ" },
+			damage: 100,
+			cost: ["Fire", "Fire", "Fire"],
+			effect: {
+				ja: "このポケモンについているエネルギーを、1個トラッシュする。その後、相手のバトルポケモンについているエネルギーを、1個トラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 555254,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "C",
+	rarity: "Character Rare",
+	dexId: [324],
+};
+
+export default card;

--- a/data-asia/SM/SM11b/051.ts
+++ b/data-asia/SM/SM11b/051.ts
@@ -1,0 +1,58 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM11b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "マニューラ",
+	},
+
+	illustrator: "nagimiso",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Water"],
+
+	description: {
+		ja: "１匹が サンドの 足を すくい ひっくり返すと もう １匹が 鋭いツメで 止めを 刺す。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "わるだくみ" },
+			cost: ["Darkness"],
+			effect: {
+				ja: "自分の山札にある好きなカードを2枚まで、手札に加える。そして山札を切る。",
+			},
+		},
+		{
+			name: { ja: "スラッシュクロー" },
+			damage: 110,
+			cost: ["Darkness", "Darkness", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 555258,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ニューラ",
+	},
+
+	retreat: 0,
+	regulationMark: "C",
+	rarity: "Character Rare",
+	dexId: [461],
+};
+
+export default card;

--- a/data-asia/SM/SM11b/052.ts
+++ b/data-asia/SM/SM11b/052.ts
@@ -1,0 +1,50 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM11b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ポッチャマ",
+	},
+
+	illustrator: "Tomomi Kaneko",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Water"],
+
+	description: {
+		ja: "世話を 焼かれる ことが 大嫌い。 トレーナーの 指示を 聞かないので 仲良く なるのが 難しい。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "バブルホールド" },
+			damage: 80,
+			cost: ["Water", "Water", "Water"],
+			effect: {
+				ja: "次の相手の番、このワザを受けたたねポケモンは、ワザが使えない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 555259,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Character Rare",
+	dexId: [393],
+};
+
+export default card;

--- a/data-asia/SM/SM11b/053.ts
+++ b/data-asia/SM/SM11b/053.ts
@@ -1,0 +1,57 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM11b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヨワシ",
+	},
+
+	illustrator: "Misaki Hashimoto",
+	category: "Pokemon",
+	hp: 180,
+	types: ["Water"],
+
+	description: {
+		ja: "ヨワシたちが 敵に 立ち向かうため 陣形を 組んだ。 海の魔物と 呼ばれるほどの 力を 誇る。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ちりぢり" },
+			effect: {
+				ja: "このポケモンにダメカンがのっているなら、相手の番の終わりに、コインを1回投げる。ウラなら、このポケモンと、ついているすべてのカードを、自分の山札にもどして切る。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ハイドロスプラッシュ" },
+			damage: 130,
+			cost: ["Water", "Water", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 555263,
+			},
+		},
+	],
+
+	retreat: 3,
+	regulationMark: "C",
+	rarity: "Character Rare",
+	dexId: [746],
+};
+
+export default card;

--- a/data-asia/SM/SM11b/054.ts
+++ b/data-asia/SM/SM11b/054.ts
@@ -1,0 +1,57 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM11b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ピカチュウ",
+	},
+
+	illustrator: "Hitoshi Ariga",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Lightning"],
+
+	description: {
+		ja: "電気を ため込む 性質。 ピカチュウが 群れて 暮らす 森は 落雷が 絶えず 危険だ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ほっぺすりすり" },
+			cost: ["Lightning"],
+			effect: {
+				ja: "コインを1回投げオモテなら、相手のバトルポケモンをマヒにする。",
+			},
+		},
+		{
+			name: { ja: "ボルテッカー" },
+			damage: 70,
+			cost: ["Lightning", "Lightning", "Colorless"],
+			effect: {
+				ja: "このポケモンにも10ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Metal", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 555267,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Character Rare",
+	dexId: [25],
+};
+
+export default card;

--- a/data-asia/SM/SM11b/055.ts
+++ b/data-asia/SM/SM11b/055.ts
@@ -1,0 +1,50 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM11b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "コイル",
+	},
+
+	illustrator: "Fumie Kittaka",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Lightning"],
+
+	description: {
+		ja: "たびたび 停電の 原因と なる ため コイルが 嫌がる 電波を 流す 発電所も あるほど。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ミラーショット" },
+			damage: 10,
+			cost: ["Lightning"],
+			effect: {
+				ja: "次の相手の番、このワザを受けたポケモンがワザを使うとき、相手はコインを1回投げる。ウラならそのワザは失敗。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Metal", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 555269,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Character Rare",
+	dexId: [81],
+};
+
+export default card;

--- a/data-asia/SM/SM11b/056.ts
+++ b/data-asia/SM/SM11b/056.ts
@@ -1,0 +1,60 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM11b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ドガース",
+	},
+
+	illustrator: "HYOGONOSUKE",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Psychic"],
+
+	description: {
+		ja: "薄い バルーン状の 体に 猛毒の ガスが つまっている。 近くに 来ると くさい。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ぶっとびボム" },
+			effect: {
+				ja: "自分の番に、このカードが「ホミカ」の効果でトラッシュされたとき、1回使える。相手のポケモン全員に、それぞれダメカンを1個のせる。（ダメカンをのせるのは「ホミカ」の効果のあと。）",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "どくガス" },
+			damage: 10,
+			cost: ["Psychic", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをどくにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 555274,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Character Rare",
+	dexId: [109],
+};
+
+export default card;

--- a/data-asia/SM/SM11b/057.ts
+++ b/data-asia/SM/SM11b/057.ts
@@ -1,0 +1,64 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM11b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "エルレイド",
+	},
+
+	illustrator: "Huang Tzu En",
+	category: "Pokemon",
+	hp: 160,
+	types: ["Psychic"],
+
+	description: {
+		ja: "相手の 考えを 敏感に キャッチする 能力を 持つため 先に 攻撃が できるのだ。",
+	},
+
+	stage: "Stage2",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ダブルタイプ" },
+			effect: {
+				ja: "このポケモンは、場にいるかぎり[超]と[闘]の2つのタイプになる。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "パワーサイクロン" },
+			damage: 120,
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンについているエネルギーを1個、ベンチポケモンにつけ替える。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 555276,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "キルリア",
+	},
+
+	retreat: 2,
+	regulationMark: "C",
+	rarity: "Character Rare",
+	dexId: [475],
+};
+
+export default card;

--- a/data-asia/SM/SM11b/058.ts
+++ b/data-asia/SM/SM11b/058.ts
@@ -1,0 +1,56 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM11b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ミミッキュ",
+	},
+
+	illustrator: "You Iribi",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Psychic"],
+
+	description: {
+		ja: "大人しい 寂しがり屋 だけど ボロ切れの 中身を 見ようとすると 激しく 嫌がり 抵抗する。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "なりすます" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の手札にあるサポートを1枚トラッシュする。その後、そのサポートの効果を、このワザの効果として使う。",
+			},
+		},
+		{
+			name: { ja: "いたずらなて" },
+			cost: ["Psychic"],
+			effect: {
+				ja: "相手のポケモン2匹に、それぞれダメカンを2個のせる。",
+			},
+		},
+	],
+
+	weaknesses: [],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 555281,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Character Rare",
+	dexId: [778],
+};
+
+export default card;

--- a/data-asia/SM/SM11b/059.ts
+++ b/data-asia/SM/SM11b/059.ts
@@ -1,0 +1,62 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM11b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ドリュウズ",
+	},
+
+	illustrator: "Mitsuhiro Arita",
+	category: "Pokemon",
+	hp: 140,
+	types: ["Fighting"],
+
+	description: {
+		ja: "鋼に 進化した ドリルは 鉄板を つらぬく 破壊力。 トンネル工事で 大活躍する。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "どたんばタックル" },
+			damage: "30+",
+			cost: ["Fighting"],
+			effect: {
+				ja: "自分の山札の残り枚数が3枚以下なら、150ダメージ追加。",
+			},
+		},
+		{
+			name: { ja: "ドリルバズーカ" },
+			damage: 120,
+			cost: ["Fighting"],
+			effect: {
+				ja: "自分の山札を上から4枚トラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 555286,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "モグリュー",
+	},
+
+	retreat: 4,
+	regulationMark: "C",
+	rarity: "Character Rare",
+	dexId: [530],
+};
+
+export default card;

--- a/data-asia/SM/SM11b/060.ts
+++ b/data-asia/SM/SM11b/060.ts
@@ -1,0 +1,62 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM11b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ハガネール",
+	},
+
+	illustrator: "Avec Yoko",
+	category: "Pokemon",
+	hp: 170,
+	types: ["Metal"],
+
+	description: {
+		ja: "地中の 高い 圧力と 熱で 鍛えられた 体は あらゆる 金属よりも 硬い。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "どっすんフォール" },
+			damage: "50×",
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "自分の手札にあるにげるためのエネルギーが4個のポケモンを好きなだけトラッシュし、その枚数×50ダメージ。",
+			},
+		},
+		{
+			name: { ja: "アイアンテール" },
+			damage: "100×",
+			cost: ["Metal", "Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "ウラが出るまでコインを投げ、オモテの数×100ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 555288,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "イワーク",
+	},
+
+	retreat: 4,
+	regulationMark: "C",
+	rarity: "Character Rare",
+	dexId: [208],
+};
+
+export default card;

--- a/data-asia/SM/SM11b/061.ts
+++ b/data-asia/SM/SM11b/061.ts
@@ -1,0 +1,64 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM11b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ムーランド",
+	},
+
+	illustrator: "Mizue",
+	category: "Pokemon",
+	hp: 150,
+	types: ["Colorless"],
+
+	description: {
+		ja: "長く 暖かい 毛の おかげで 寒さは へっちゃら。 アローラの ムーランドは 少し 苦しそうだ。",
+	},
+
+	stage: "Stage2",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ガウガウバーク" },
+			effect: {
+				ja: "自分の番に、このカードを手札から出して進化させたときと、このポケモンがバトル場で相手のワザのダメージを受けてきぜつしたとき、それぞれ1回使える。相手のバトルポケモンについているエネルギーを、1個トラッシュする。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "かけぬける" },
+			damage: 110,
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のベンチポケモン1匹にも、30ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 555289,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ハーデリア",
+	},
+
+	retreat: 3,
+	regulationMark: "C",
+	rarity: "Character Rare",
+	dexId: [508],
+};
+
+export default card;

--- a/data-asia/SM/SM11b/062.ts
+++ b/data-asia/SM/SM11b/062.ts
@@ -1,0 +1,69 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM11b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ラフレシアGX",
+	},
+
+	illustrator: "Kagemaru Himeno",
+	category: "Pokemon",
+	hp: 240,
+	types: ["Grass"],
+
+	stage: "Stage2",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "かおるはなぞの" },
+			effect: {
+				ja: "自分の番に1回使える。自分のポケモン全員のHPを、それぞれ「30」回復する。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "だいかいか 180-" },
+			cost: ["Grass", "Colorless"],
+			effect: {
+				ja: "このポケモンにのっているダメカンの数×10ダメージぶん、このワザのダメージは小さくなる。",
+			},
+		},
+		{
+			name: { ja: "アレルギーボムGX" },
+			damage: 50,
+			cost: ["Grass"],
+			effect: {
+				ja: "相手のバトルポケモンをどくとやけどとマヒにする。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 555294,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "クサイハナ",
+	},
+
+	retreat: 2,
+	regulationMark: "C",
+	rarity: "Ultra Rare",
+	dexId: [45],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM11b/063.ts
+++ b/data-asia/SM/SM11b/063.ts
@@ -1,0 +1,56 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM11b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ソルガレオ&ルナアーラGX",
+	},
+
+	illustrator: "Hideki Ishikawa",
+	category: "Pokemon",
+	hp: 270,
+	types: ["Psychic"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "コズミックバーン" },
+			damage: 230,
+			cost: ["Psychic", "Psychic", "Psychic", "Colorless"],
+			effect: {
+				ja: "次の自分の番、このポケモンは「コズミックバーン」が使えない。",
+			},
+		},
+		{
+			name: { ja: "めがみのひかりGX" },
+			damage: 200,
+			cost: ["Psychic", "Psychic", "Colorless"],
+			effect: {
+				ja: "追加でこの番、手札から「リーリエの全力」を出して使っていたなら、次の相手の番、自分のポケモン全員は、ワザのダメージや効果を受けない。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 555297,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "C",
+	rarity: "Ultra Rare",
+	dexId: [791, 792],
+
+	suffix: "TAG TEAM-GX",
+};
+
+export default card;

--- a/data-asia/SM/SM11b/064.ts
+++ b/data-asia/SM/SM11b/064.ts
@@ -1,0 +1,55 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM11b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "レシラム&ゼクロムGX",
+	},
+
+	illustrator: "Naoki Saito",
+	category: "Pokemon",
+	hp: 270,
+	types: ["Dragon"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "らいえんむそう" },
+			damage: "90×",
+			cost: ["Fire", "Lightning"],
+			effect: {
+				ja: "自分のベンチポケモンについている[炎]と[雷]タイプの基本エネルギーを3枚までトラッシュし、その枚数×90ダメージ。",
+			},
+		},
+		{
+			name: { ja: "クロスブレイクGX" },
+			cost: ["Fire", "Fire", "Lightning", "Lightning"],
+			effect: {
+				ja: "相手のベンチポケモン1匹に、170ダメージ。追加でこの番、手札から「Nの覚悟」を出して使っていたなら、相手の別のベンチポケモン1匹にも、170ダメージ。［ベンチは弱点・抵抗力を計算しない。］［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fairy", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 555299,
+			},
+		},
+	],
+
+	retreat: 3,
+	regulationMark: "C",
+	rarity: "Ultra Rare",
+	dexId: [643, 644],
+
+	suffix: "TAG TEAM-GX",
+};
+
+export default card;

--- a/data-asia/SM/SM11b/065.ts
+++ b/data-asia/SM/SM11b/065.ts
@@ -1,0 +1,69 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM11b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "シルヴァディGX",
+	},
+
+	illustrator: "Megumi Mizutani",
+	category: "Pokemon",
+	hp: 210,
+	types: ["Colorless"],
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ディスクリロード" },
+			effect: {
+				ja: "自分の番に1回使える。自分の手札が5枚になるように、山札を引く。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "バディブレイブ" },
+			damage: "50+",
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "この番、手札からサポートを出して使っていたなら、70ダメージ追加。",
+			},
+		},
+		{
+			name: { ja: "ホワイトナイトGX" },
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンが「ウルトラビースト」なら、そのポケモンをきぜつさせる。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 555304,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "タイプ：ヌル",
+	},
+
+	retreat: 2,
+	regulationMark: "C",
+	rarity: "Ultra Rare",
+	dexId: [773],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM11b/066.ts
+++ b/data-asia/SM/SM11b/066.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM11b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "Nの覚悟",
+	},
+
+	illustrator: "Mana Ibe",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の山札を上から6枚トラッシュし、その中にある基本エネルギーをすべて、自分のベンチの[竜]ポケモン1匹につける。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 555308,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "C",
+	rarity: "Ultra Rare",
+};
+
+export default card;

--- a/data-asia/SM/SM11b/067.ts
+++ b/data-asia/SM/SM11b/067.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM11b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "メイ",
+	},
+
+	illustrator: "kirisAki",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードは、前の相手の番に、自分のポケモンがきぜつしていなければ使えない。自分の山札にあるポケモン・トレーナーズ・基本エネルギーを1枚ずつ、相手に見せてから、手札に加える。そして山札を切る。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 555313,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "C",
+	rarity: "Ultra Rare",
+};
+
+export default card;

--- a/data-asia/SM/SM11b/068.ts
+++ b/data-asia/SM/SM11b/068.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM11b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "リーリエの全力",
+	},
+
+	illustrator: "Noriko Uono",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の山札を4枚引く。このカードを使った番の終わりに、自分の手札が3枚以上あるなら、その手札が2枚になるように、山札にもどして切る。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 555318,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "C",
+	rarity: "Ultra Rare",
+};
+
+export default card;

--- a/data-asia/SM/SM11b/069.ts
+++ b/data-asia/SM/SM11b/069.ts
@@ -1,0 +1,69 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM11b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ラフレシアGX",
+	},
+
+	illustrator: "",
+	category: "Pokemon",
+	hp: 240,
+	types: ["Grass"],
+
+	stage: "Stage2",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "かおるはなぞの" },
+			effect: {
+				ja: "自分の番に1回使える。自分のポケモン全員のHPを、それぞれ「30」回復する。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "だいかいか 180-" },
+			cost: ["Grass", "Colorless"],
+			effect: {
+				ja: "このポケモンにのっているダメカンの数×10ダメージぶん、このワザのダメージは小さくなる。",
+			},
+		},
+		{
+			name: { ja: "アレルギーボムGX" },
+			damage: 50,
+			cost: ["Grass"],
+			effect: {
+				ja: "相手のバトルポケモンをどくとやけどとマヒにする。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 555319,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "クサイハナ",
+	},
+
+	retreat: 2,
+	regulationMark: "C",
+	rarity: "Hyper rare",
+	dexId: [45],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM11b/070.ts
+++ b/data-asia/SM/SM11b/070.ts
@@ -1,0 +1,56 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM11b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ソルガレオ&ルナアーラGX",
+	},
+
+	illustrator: "",
+	category: "Pokemon",
+	hp: 270,
+	types: ["Psychic"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "コズミックバーン" },
+			damage: 230,
+			cost: ["Psychic", "Psychic", "Psychic", "Colorless"],
+			effect: {
+				ja: "次の自分の番、このポケモンは「コズミックバーン」が使えない。",
+			},
+		},
+		{
+			name: { ja: "めがみのひかりGX" },
+			damage: 200,
+			cost: ["Psychic", "Psychic", "Colorless"],
+			effect: {
+				ja: "追加でこの番、手札から「リーリエの全力」を出して使っていたなら、次の相手の番、自分のポケモン全員は、ワザのダメージや効果を受けない。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 555322,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "C",
+	rarity: "Hyper rare",
+	dexId: [791, 792],
+
+	suffix: "TAG TEAM-GX",
+};
+
+export default card;

--- a/data-asia/SM/SM11b/071.ts
+++ b/data-asia/SM/SM11b/071.ts
@@ -1,0 +1,55 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM11b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "レシラム&ゼクロムGX",
+	},
+
+	illustrator: "",
+	category: "Pokemon",
+	hp: 270,
+	types: ["Dragon"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "らいえんむそう" },
+			damage: "90×",
+			cost: ["Fire", "Lightning"],
+			effect: {
+				ja: "自分のベンチポケモンについている[炎]と[雷]タイプの基本エネルギーを3枚までトラッシュし、その枚数×90ダメージ。",
+			},
+		},
+		{
+			name: { ja: "クロスブレイクGX" },
+			cost: ["Fire", "Fire", "Lightning", "Lightning"],
+			effect: {
+				ja: "相手のベンチポケモン1匹に、170ダメージ。追加でこの番、手札から「Nの覚悟」を出して使っていたなら、相手の別のベンチポケモン1匹にも、170ダメージ。［ベンチは弱点・抵抗力を計算しない。］［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fairy", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 555323,
+			},
+		},
+	],
+
+	retreat: 3,
+	regulationMark: "C",
+	rarity: "Hyper rare",
+	dexId: [643, 644],
+
+	suffix: "TAG TEAM-GX",
+};
+
+export default card;

--- a/data-asia/SM/SM11b/072.ts
+++ b/data-asia/SM/SM11b/072.ts
@@ -1,0 +1,69 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM11b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "シルヴァディGX",
+	},
+
+	illustrator: "",
+	category: "Pokemon",
+	hp: 210,
+	types: ["Colorless"],
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ディスクリロード" },
+			effect: {
+				ja: "自分の番に1回使える。自分の手札が5枚になるように、山札を引く。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "バディブレイブ" },
+			damage: "50+",
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "この番、手札からサポートを出して使っていたなら、70ダメージ追加。",
+			},
+		},
+		{
+			name: { ja: "ホワイトナイトGX" },
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンが「ウルトラビースト」なら、そのポケモンをきぜつさせる。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 555327,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "タイプ：ヌル",
+	},
+
+	retreat: 2,
+	regulationMark: "C",
+	rarity: "Hyper rare",
+	dexId: [773],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM11b/073.ts
+++ b/data-asia/SM/SM11b/073.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM11b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "スイレンのつりざお",
+	},
+
+	illustrator: "",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分のトラッシュにあるポケモンと「ポケモンのどうぐ」を1枚ずつ、相手に見せてから、山札にもどして切る。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 555331,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	regulationMark: "C",
+	rarity: "Secret Rare",
+};
+
+export default card;

--- a/data-asia/SM/SM11b/074.ts
+++ b/data-asia/SM/SM11b/074.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM11b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "リーリエのピッピ人形",
+	},
+
+	illustrator: "",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードは、HP30の無色タイプのたねポケモンとして、場に出すことができる。自分の番の中でなら、バトル場に出ているこのカードを山札の下にもどしてよい。（ついているカードは、すべてトラッシュする。）このカードは、にげられない。このカードがきぜつしても、相手はサイドをとれない。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 555336,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	regulationMark: "C",
+	rarity: "Secret Rare",
+};
+
+export default card;

--- a/data-asia/SM/SM11b/075.ts
+++ b/data-asia/SM/SM11b/075.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM11b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "無人発電所",
+	},
+
+	illustrator: "",
+	category: "Trainer",
+
+	effect: {
+		ja: "おたがいの場の「ポケモンGX・EX」の特性は、すべてなくなる。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 555337,
+			},
+		},
+	],
+
+	trainerType: "Stadium",
+	regulationMark: "C",
+	rarity: "Secret Rare",
+};
+
+export default card;

--- a/interfaces.d.ts
+++ b/interfaces.d.ts
@@ -236,6 +236,8 @@ export interface Card {
 			// Black White rare
 			| 'Black White Rare'
 			| 'Mega Hyper Rare'
+			// Japanese Character Rares (since SM11b Dream League)
+			| 'Character Rare' | 'Character Super Rare'
 			// Pokémon TCG Pocket Rarities
 			| 'One Diamond' | 'Two Diamond' | 'Three Diamond' | 'Four Diamond' | 'One Star' | 'Two Star' | 'Three Star' | 'Crown' | 'One Shiny' | 'Two Shiny'
 			| 'Promo'


### PR DESCRIPTION
## What

Adds the complete Japanese set **SM11b ドリームリーグ (Dream League)**, released 2019-08-02:

- `data-asia/SM/SM11b/001.ts` … `075.ts` — all 75 cards (49 regular + 26 secret rares: 12 CHR, 7 SR, 3 Secret Rare, 4 UR)
- the set definition `data-asia/SM/SM11b.ts` already existed and is untouched

## Data sources

- **pokemon-card.com** (official database): Japanese names, flavor texts, National Dex numbers, official card count
- **limitlesstcg.com**: full Japanese card text, stages, weaknesses/resistances/retreat, rarities, illustrators, attack costs
- **Cardmarket**: product IDs as `thirdParty.cardmarket` on the variant objects (555117–555337; tcgplayer IDs not available to me)

## Notes

- Follows the file format and conventions of the M-era sets (#1728)
- All 75 files type-check against `interfaces.d.ts` (`tsc --noEmit`)
- Also added CHR / CSR to interface