### PR TITLE
(data) - en/ja illustrator contest 2022 (greninja, arcanine, bulbasaur) 

### DIFF
--- a/data-asia/S/S-P/337.ts
+++ b/data-asia/S/S-P/337.ts
@@ -1,0 +1,56 @@
+import { Card } from "../../../interfaces"
+import Set from "../S-P"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		ja: "フシギダネ",
+	},
+
+	illustrator: "Julie Hang",
+	rarity: "Promo",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Grass"],
+	stage: "Basic",
+	dexId: [1],
+
+	attacks: [{
+		cost: ["Grass"],
+
+		name: {
+			ja: "ゆすってあつめる",
+		},
+
+		effect: {
+			en: "ウラが出るまでコインを投げ、オモテの数ぶん、自分の山札を引く。",
+		},
+
+	}],
+
+	weaknesses: [{
+		type: "Fire",
+		value: "×2"
+	}],
+
+	retreat: 2,
+
+	description: {
+		ja: "生まれたときから背中に植物のタネがあって少しずつ大きく育つ。.",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			stamp: ["illustration-contest-2022"],
+			thirdParty: {
+				tcgplayer: 485843
+			},
+		},
+	],
+
+	regulationMark: "F"
+}
+
+export default card

--- a/data-asia/S/S-P/338.ts
+++ b/data-asia/S/S-P/338.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces"
+import Set from "../S-P"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		ja: "ウインディ",
+	},
+
+	illustrator: "REND",
+	rarity: "Promo",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Fire"],
+	stage: "Stage1",
+	dexId: [59],
+
+	attacks: [{
+		cost: ["Fire", "Fire", "Colorless"],
+
+		name: {
+			ja: "ひだまりタックル",
+		},
+
+		effect: {
+			ja: "次の自分の番、このポケモンはワザが使えない。",
+		},
+
+		damage: 160
+	}],
+
+	evolveFrom: {
+		ja: "ガーディ",
+	},
+
+	weaknesses: [{
+		type: "Water",
+		value: "×2"
+	}],
+
+	retreat: 3,
+
+	description: {
+		ja: "一昼夜で10000キロもの距離を走りひろる。炎を吹くと岩も粉々になる。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			stamp: ["illustration-contest-2022"],
+			thirdParty: {
+				tcgplayer: 597503
+			},
+		},
+	],
+
+	regulationMark: "F"
+}
+
+export default card

--- a/data-asia/S/S-P/339.ts
+++ b/data-asia/S/S-P/339.ts
@@ -2,19 +2,19 @@ import { Card } from "../../../interfaces"
 import Set from "../S-P"
 
 const card: Card = {
-	dexId: [658],
 	set: Set,
-	illustrator: "Taiga Kasai",
 
 	name: {
 		ja: "ゲッコウガ",
 	},
 
+	illustrator: "Taiga Kasai",
 	rarity: "Promo",
 	category: "Pokemon",
 	hp: 140,
 	types: ["Water"],
 	stage: "Stage2",
+	dexId: [658],
 
 	attacks: [{
 		cost: ["Water", "Colorless", "Colorless"],

--- a/data-asia/S/S-P/339.ts
+++ b/data-asia/S/S-P/339.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces"
+import Set from "../S-P"
+
+const card: Card = {
+	dexId: [658],
+	set: Set,
+	illustrator: "Taiga Kasai",
+
+	name: {
+		ja: "ゲッコウガ",
+	},
+
+	rarity: "Promo",
+	category: "Pokemon",
+	hp: 140,
+	types: ["Water"],
+	stage: "Stage2",
+
+	attacks: [{
+		cost: ["Water", "Colorless", "Colorless"],
+
+		name: {
+			ja: "れんけいしゅりけん",
+		},
+
+		effect: {
+			ja: "相手のベンチポケモン3匹にも、それぞれ10ダメージ。「ベンチは弱点・抵抗力を計算しない。」",
+		},
+
+		damage: 120
+	}],
+
+	evolveFrom: {
+		ja: "ゲコガシ",
+	},
+
+	weaknesses: [{
+		type: "Lightning",
+		value: "×2"
+	}],
+
+	retreat: 1,
+
+	description: {
+		en: "It creates throwing stars out of compressed water. When it spins them and throws them at high speed, these stars can split metal into two.",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			stamp: ["illustration-contest-2022"],
+			thirdParty: {
+				tcgplayer: 597504
+			},
+		},
+	],
+
+	regulationMark: "F"
+}
+
+export default card

--- a/data-asia/S/S-P/339.ts
+++ b/data-asia/S/S-P/339.ts
@@ -42,7 +42,7 @@ const card: Card = {
 	retreat: 1,
 
 	description: {
-		en: "It creates throwing stars out of compressed water. When it spins them and throws them at high speed, these stars can split metal into two.",
+		ja: "水を圧縮して手裏剣を作り出す。高速回転させて飛ばすと金属も真っ二つ。"
 	},
 
 	variants: [

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH303.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH303.ts
@@ -1,0 +1,56 @@
+import { Card } from "../../../interfaces"
+import Set from "../SWSH Black Star Promos"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Bulbasaur",
+	},
+
+	illustrator: "Julie Hang",
+	rarity: "Promo",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Grass"],
+	stage: "Basic",
+	dexId: [1],
+
+	attacks: [{
+		cost: ["Grass"],
+
+		name: {
+			en: "Shake and Gather",
+		},
+
+		effect: {
+			en: "Flip a coin until you get tails. For each head, draw a card.",
+		},
+
+	}],
+
+	weaknesses: [{
+		type: "Fire",
+		value: "×2"
+	}],
+
+	retreat: 2,
+
+	description: {
+		en: "There is a aplant seed on its back right from the day this Pokémon is born. THe seed slowly grows larger.",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			stamp: ["illustration-contest-2022"],
+			thirdParty: {
+				tcgplayer: 485843
+			},
+		},
+	],
+
+	regulationMark: "F"
+}
+
+export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH304.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH304.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces"
+import Set from "../SWSH Black Star Promos"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Arcanine",
+	},
+
+	illustrator: "REND",
+	rarity: "Promo",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Fire"],
+	stage: "Stage1",
+	dexId: [59],
+
+	attacks: [{
+		cost: ["Fire", "Fire", "Colorless"],
+
+		name: {
+			en: "Sun-Drenched Tackle",
+		},
+
+		effect: {
+			en: "During your next turn, this Pokémon can't attack",
+		},
+
+		damage: 160
+	}],
+
+	evolveFrom: {
+		en: "Growlithe",
+	},
+
+	weaknesses: [{
+		type: "Water",
+		value: "×2"
+	}],
+
+	retreat: 3,
+
+	description: {
+		en: "The sight of it running over 6,200 miles in a single day and night has captivated many people.",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			stamp: ["illustration-contest-2022"],
+			thirdParty: {
+				tcgplayer: 485844
+			},
+		},
+	],
+
+	regulationMark: "F"
+}
+
+export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH305.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH305.ts
@@ -2,19 +2,19 @@ import { Card } from "../../../interfaces"
 import Set from "../SWSH Black Star Promos"
 
 const card: Card = {
-	dexId: [658],
 	set: Set,
-	illustrator: "Taiga Kasai",
 
 	name: {
 		en: "Greninja",
 	},
 
+	illustrator: "Taiga Kasai",
 	rarity: "Promo",
 	category: "Pokemon",
 	hp: 140,
 	types: ["Water"],
 	stage: "Stage2",
+	dexId: [658],
 
 	attacks: [{
 		cost: ["Water", "Colorless", "Colorless"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH305.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH305.ts
@@ -42,7 +42,7 @@ const card: Card = {
 	retreat: 1,
 
 	description: {
-		ja: "水を圧縮して手裏剣を作り出す。高速回転させて飛ばすと金属も真っ二つ。"
+		en: "It creates throwing stars out of compressed water. When it spins them and throws them at high speed, these stars can split metal into two.",
 	},
 
 	variants: [

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH305.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH305.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces"
+import Set from "../SWSH Black Star Promos"
+
+const card: Card = {
+	dexId: [658],
+	set: Set,
+	illustrator: "Taiga Kasai",
+
+	name: {
+		en: "Greninja",
+	},
+
+	rarity: "Promo",
+	category: "Pokemon",
+	hp: 140,
+	types: ["Water"],
+	stage: "Stage2",
+
+	attacks: [{
+		cost: ["Water", "Colorless", "Colorless"],
+
+		name: {
+			en: "Coordinated Shuriken",
+		},
+
+		effect: {
+			en: "This attack also does 10 damage to 3 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon",
+		},
+
+		damage: 120
+	}],
+
+	evolveFrom: {
+		en: "Frogadier",
+	},
+
+	weaknesses: [{
+		type: "Lightning",
+		value: "×2"
+	}],
+
+	retreat: 1,
+
+	description: {
+		ja: "水を圧縮して手裏剣を作り出す。高速回転させて飛ばすと金属も真っ二つ。"
+	},
+
+	variants: [
+		{
+			type: "normal",
+			stamp: ["illustration-contest-2022"],
+			thirdParty: {
+				tcgplayer: 485845
+			},
+		},
+	],
+
+	regulationMark: "F"
+}
+
+export default card

--- a/interfaces.d.ts
+++ b/interfaces.d.ts
@@ -32,7 +32,7 @@ export type VariantStamps = '1st-edition' | 'w-promo' | 'pre-release' | 'pokemon
 	| 'yuka-furusawa' | 'jason-martinez' | 'yuta-komatsuda' | 'origins-2008' | 'platinum' | 'worlds-2010'
 	| 'ross-cawthorn' | 'gustavo-wada' | 'christopher-kan' | 'player-rewards-program' | 'igor-costa'
 	| 'zachary-bokhari' | 'shuto-itagaki' | 'snowflake' | 'trick-or-trade' | 'horizons' | 'gamestop' | 'eb-games'
-	| 'illustration-contest-2024' | 'worlds-2025' | 'top-eight' | "champion" | "poke-ball-league" | "master-ball-league" | "ultra-ball-league" | "judge" | "asia-promo"
+	| 'illustration-contest-2022' | 'illustration-contest-2024' | 'worlds-2025' | 'top-eight' | "champion" | "poke-ball-league" | "master-ball-league" | "ultra-ball-league" | "judge" | "asia-promo"
 	| "international-championship-europe" | "international-championship-latin-america" | "international-championship-north-america" | 'ace-trainer'
 	| 'pikachu' | 'bulbasaur' | 'squirtle' | 'charmander' | 'pokeball' | '30th-pokeday' | 'mcdonalds' | 'pokemon-together' | 'rain-city' | 'tournament-collection'
 	| 'worlds-2024' | 'worlds-2023' | 'asia-2023-24' | 'thank-you' | 'jr-stamp-rally' | 'grey-star'

--- a/meta/translations/de.json
+++ b/meta/translations/de.json
@@ -229,6 +229,7 @@
 		"eb-games": "EB Games",
 		"snowflake": "Schneeflocke",
 		"horizons": "horizons",
+		"illustration-contest-2022": "illustration-contest-2022",
 		"illustration-contest-2024": "illustration-contest-2024",
 		"worlds-2025": "worlds-2025",
 		"top-eight": "top-eight",

--- a/meta/translations/es.json
+++ b/meta/translations/es.json
@@ -229,6 +229,7 @@
 		"gamestop": "GameStop",
 		"eb-games": "EB Games",
 		"horizons": "horizons",
+		"illustration-contest-2022": "illustration-contest-2022",
 		"illustration-contest-2024": "illustration-contest-2024",
 		"worlds-2025": "worlds-2025",
 		"top-eight": "top-eight",

--- a/meta/translations/fr.json
+++ b/meta/translations/fr.json
@@ -228,6 +228,7 @@
 		"gamestop": "GameStop",
 		"eb-games": "EB Games",
 		"horizons": "horizons",
+		"illustration-contest-2022": "illustration-contest-2022",
 		"illustration-contest-2024": "illustration-contest-2024",
 		"worlds-2025": "worlds-2025",
 		"top-eight": "top-eight",

--- a/meta/translations/it.json
+++ b/meta/translations/it.json
@@ -229,6 +229,7 @@
 		"gamestop": "GameStop",
 		"eb-games": "EB Games",
 		"horizons": "horizons",
+		"illustration-contest-2022": "illustration-contest-2022",
 		"illustration-contest-2024": "illustration-contest-2024",
 		"worlds-2025": "worlds-2025",
 		"top-eight": "top-eight",

--- a/meta/translations/pt.json
+++ b/meta/translations/pt.json
@@ -228,6 +228,7 @@
 		"gamestop": "GameStop",
 		"eb-games": "EB Games",
 		"horizons": "horizons",
+		"illustration-contest-2022": "illustration-contest-2022",
 		"illustration-contest-2024": "illustration-contest-2024",
 		"worlds-2025": "worlds-2025",
 		"top-eight": "top-eight",


### PR DESCRIPTION
closes #1611 

## Changes

Adds the missing Illustrator contest 2022 of the following:
- [x] add greninja en/ja
- [x] add arcanine en/ja
- [x] add bulbasaur en/ja
- [x] uploaded english images (via intake -> swshp)
- [x] uploaded japanese images (via intake -> S-P)


## Details
- added greninja illustrator contest 2022 for japanese and english
- define new `illustrator-contest-2022` stamp type 

Images:
[illustrator-contest-2022.zip](https://github.com/user-attachments/files/30095789/illustrator-contest-2022.zip)