### PR TITLE
(data) Add Japanese M set M-P Mega Promotional Cards

### DIFF
--- a/data-asia/M/M-P.ts
+++ b/data-asia/M/M-P.ts
@@ -1,0 +1,20 @@
+import { Set } from "../../interfaces";
+import serie from "../M";
+
+const set: Set = {
+	id: "M-P",
+	name: {
+		ja: "メガ プロモカード",
+	},
+
+	serie: serie,
+
+	cardCount: {
+		official: 0,
+	},
+	releaseDate: {
+		ja: "2025-07-28",
+	},
+};
+
+export default set;

--- a/data-asia/M/M-P/001.ts
+++ b/data-asia/M/M-P/001.ts
@@ -1,0 +1,47 @@
+import { Card } from "../../../interfaces";
+import Set from "../M-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "チコリータ",
+	},
+
+	illustrator: "Makura Tami",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Grass"],
+
+	description: {
+		ja: "日差しを 浴びるのが 大好き。 頭の 葉っぱを 使って 暖かい 場所を 探す。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "はっぱカッター" },
+			damage: 20,
+			cost: ["Grass"],
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 839193,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "Promo",
+	dexId: [152],
+};
+
+export default card;

--- a/data-asia/M/M-P/002.ts
+++ b/data-asia/M/M-P/002.ts
@@ -1,0 +1,53 @@
+import { Card } from "../../../interfaces";
+import Set from "../M-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ラプラスex",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 210,
+	types: ["Water"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ハイドロターン" },
+			damage: "30×",
+			cost: ["Water"],
+			effect: {
+				ja: "このポケモンについている[W]エネルギーの数×30ダメージ。このポケモンをベンチポケモンと入れ替える。",
+			},
+		},
+		{
+			name: { ja: "なみのり" },
+			damage: 140,
+			cost: ["Water", "Water", "Water"],
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 839209,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "I",
+	rarity: "Promo",
+	dexId: [131],
+
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/M/M-P/003.ts
+++ b/data-asia/M/M-P/003.ts
@@ -1,0 +1,60 @@
+import { Card } from "../../../interfaces";
+import Set from "../M-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "マシマシラ",
+	},
+
+	illustrator: "kodama",
+	category: "Pokemon",
+	hp: 110,
+	types: ["Psychic"],
+
+	description: {
+		ja: "安全な 場所から 強烈な めまいを 引き起こす 念力を 放って 敵を 翻弄する。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "アドレナブレイン" },
+			effect: {
+				ja: "このポケモンに[D]エネルギーがついているなら、自分の番に1回使える。自分の場のポケモン1匹にのっているダメカンを3個まで選び、相手の場のポケモン1匹にのせ替える。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "サイコトリップ" },
+			damage: 60,
+			cost: ["Psychic", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをこんらんにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 839215,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "H",
+	rarity: "Promo",
+	dexId: [1015],
+};
+
+export default card;

--- a/data-asia/M/M-P/004.ts
+++ b/data-asia/M/M-P/004.ts
@@ -1,0 +1,52 @@
+import { Card } from "../../../interfaces";
+import Set from "../M-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "マクノシタ",
+	},
+
+	illustrator: "Takeshi Nakamura",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Fighting"],
+
+	description: {
+		ja: "厳しい 稽古を 繰り返して 強くなる。 どんな 攻撃にも 耐える 根性の ポケモン。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "どつく" },
+			damage: 10,
+			cost: ["Fighting"],
+		},
+		{
+			name: { ja: "がちんこ" },
+			damage: 30,
+			cost: ["Fighting", "Fighting"],
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 839224,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "I",
+	rarity: "Promo",
+	dexId: [296],
+};
+
+export default card;

--- a/data-asia/M/M-P/005.ts
+++ b/data-asia/M/M-P/005.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../M-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "あなあけスコップ",
+	},
+
+	illustrator: "Toyste Beach",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の山札を上から2枚トラッシュする。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 839225,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	regulationMark: "I",
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/M/M-P/006.ts
+++ b/data-asia/M/M-P/006.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../M-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "カウンターゲイン",
+	},
+
+	illustrator: "Toyste Beach",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分のサイドの残り枚数が、相手のサイドの残り枚数より多いなら、このカードをつけているポケモンがワザを使うためのエネルギーは、エネルギー1個ぶん少なくなる。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 839228,
+			},
+		},
+	],
+
+	trainerType: "Tool",
+	regulationMark: "H",
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/M/M-P/007.ts
+++ b/data-asia/M/M-P/007.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../M-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "リーリエの決心",
+	},
+
+	illustrator: "Atsushi Furusawa",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の手札をすべて山札にもどして切る。その後、山札を6枚引く。自分のサイドの残り枚数が6枚なら、引く枚数は8枚になる。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 839229,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "I",
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/M/M-P/008.ts
+++ b/data-asia/M/M-P/008.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../M-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "メガシグナル",
+	},
+
+	illustrator: "inose yukie",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の山札から「メガシンカex」を1枚選び、相手に見せて、手札に加える。そして山札を切る。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 839232,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	regulationMark: "I",
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/M/M-P/009.ts
+++ b/data-asia/M/M-P/009.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../M-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "基本草エネルギー",
+	},
+
+	illustrator: "",
+	category: "Energy",
+	energyType: "Normal",
+
+	effect: {
+		ja: "&copy;Pokémon/Nintendo/Creatures/GAME FREAK ポケットモンスター・ポケモン・Pokémonは任天堂・クリーチャーズ・ゲームフリークの商標です。 このホームページに掲載された画像その他の内容の無断転載はお断りします。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 839235,
+			},
+		},
+	],
+
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/M/M-P/010.ts
+++ b/data-asia/M/M-P/010.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../M-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "基本炎エネルギー",
+	},
+
+	illustrator: "",
+	category: "Energy",
+	energyType: "Normal",
+
+	effect: {
+		ja: "&copy;Pokémon/Nintendo/Creatures/GAME FREAK ポケットモンスター・ポケモン・Pokémonは任天堂・クリーチャーズ・ゲームフリークの商標です。 このホームページに掲載された画像その他の内容の無断転載はお断りします。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 839246,
+			},
+		},
+	],
+
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/M/M-P/011.ts
+++ b/data-asia/M/M-P/011.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../M-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "基本水エネルギー",
+	},
+
+	illustrator: "",
+	category: "Energy",
+	energyType: "Normal",
+
+	effect: {
+		ja: "&copy;Pokémon/Nintendo/Creatures/GAME FREAK ポケットモンスター・ポケモン・Pokémonは任天堂・クリーチャーズ・ゲームフリークの商標です。 このホームページに掲載された画像その他の内容の無断転載はお断りします。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 839247,
+			},
+		},
+	],
+
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/M/M-P/012.ts
+++ b/data-asia/M/M-P/012.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../M-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "基本雷エネルギー",
+	},
+
+	illustrator: "",
+	category: "Energy",
+	energyType: "Normal",
+
+	effect: {
+		ja: "&copy;Pokémon/Nintendo/Creatures/GAME FREAK ポケットモンスター・ポケモン・Pokémonは任天堂・クリーチャーズ・ゲームフリークの商標です。 このホームページに掲載された画像その他の内容の無断転載はお断りします。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 839249,
+			},
+		},
+	],
+
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/M/M-P/013.ts
+++ b/data-asia/M/M-P/013.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../M-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "基本超エネルギー",
+	},
+
+	illustrator: "",
+	category: "Energy",
+	energyType: "Normal",
+
+	effect: {
+		ja: "&copy;Pokémon/Nintendo/Creatures/GAME FREAK ポケットモンスター・ポケモン・Pokémonは任天堂・クリーチャーズ・ゲームフリークの商標です。 このホームページに掲載された画像その他の内容の無断転載はお断りします。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 839250,
+			},
+		},
+	],
+
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/M/M-P/014.ts
+++ b/data-asia/M/M-P/014.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../M-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "基本闘エネルギー",
+	},
+
+	illustrator: "",
+	category: "Energy",
+	energyType: "Normal",
+
+	effect: {
+		ja: "&copy;Pokémon/Nintendo/Creatures/GAME FREAK ポケットモンスター・ポケモン・Pokémonは任天堂・クリーチャーズ・ゲームフリークの商標です。 このホームページに掲載された画像その他の内容の無断転載はお断りします。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 839252,
+			},
+		},
+	],
+
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/M/M-P/015.ts
+++ b/data-asia/M/M-P/015.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../M-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "基本悪エネルギー",
+	},
+
+	illustrator: "",
+	category: "Energy",
+	energyType: "Normal",
+
+	effect: {
+		ja: "&copy;Pokémon/Nintendo/Creatures/GAME FREAK ポケットモンスター・ポケモン・Pokémonは任天堂・クリーチャーズ・ゲームフリークの商標です。 このホームページに掲載された画像その他の内容の無断転載はお断りします。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 839253,
+			},
+		},
+	],
+
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/M/M-P/016.ts
+++ b/data-asia/M/M-P/016.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../M-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "基本鋼エネルギー",
+	},
+
+	illustrator: "",
+	category: "Energy",
+	energyType: "Normal",
+
+	effect: {
+		ja: "&copy;Pokémon/Nintendo/Creatures/GAME FREAK ポケットモンスター・ポケモン・Pokémonは任天堂・クリーチャーズ・ゲームフリークの商標です。 このホームページに掲載された画像その他の内容の無断転載はお断りします。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 839254,
+			},
+		},
+	],
+
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/M/M-P/017.ts
+++ b/data-asia/M/M-P/017.ts
@@ -1,0 +1,50 @@
+import { Card } from "../../../interfaces";
+import Set from "../M-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ニャオハ",
+	},
+
+	illustrator: "Mina Nakai",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Grass"],
+
+	description: {
+		ja: "フワフワの 体毛は 植物に 近い 成分。 こまめに 顔を 洗って 乾燥を 防ぐ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ふみまくる" },
+			damage: "10×",
+			cost: ["Colorless"],
+			effect: {
+				ja: "コインを3回投げ、オモテの数×10ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 839255,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "Promo",
+	dexId: [906],
+};
+
+export default card;

--- a/data-asia/M/M-P/018.ts
+++ b/data-asia/M/M-P/018.ts
@@ -1,0 +1,50 @@
+import { Card } from "../../../interfaces";
+import Set from "../M-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ホゲータ",
+	},
+
+	illustrator: "Tomomi Ozaki",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Fire"],
+
+	description: {
+		ja: "炎袋が 小さく あふれ出た エネルギーが 頭の くぼみから 放出され ゆらゆら 揺れる。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ねつでこがす" },
+			damage: 20,
+			cost: ["Fire", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをやけどにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 839256,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "H",
+	rarity: "Promo",
+	dexId: [909],
+};
+
+export default card;

--- a/data-asia/M/M-P/019.ts
+++ b/data-asia/M/M-P/019.ts
@@ -1,0 +1,50 @@
+import { Card } from "../../../interfaces";
+import Set from "../M-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "クワッス",
+	},
+
+	illustrator: "Saboteri",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Water"],
+
+	description: {
+		ja: "流れが 急な 川も 自由に 泳ぎまわる 脚力を 持つ。 きれい好きで 思い込みが 強い。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "つばめがえし" },
+			damage: "10+",
+			cost: ["Water"],
+			effect: {
+				ja: "コインを1回投げオモテなら、20ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 839257,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "H",
+	rarity: "Promo",
+	dexId: [912],
+};
+
+export default card;

--- a/data-asia/M/M-P/020.ts
+++ b/data-asia/M/M-P/020.ts
@@ -1,0 +1,49 @@
+import { Card } from "../../../interfaces";
+import Set from "../M-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ピカチュウ",
+	},
+
+	illustrator: "Yuu Nishida",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Lightning"],
+
+	description: {
+		ja: "何匹かが 集まっていると そこに 猛烈な 電気が 溜まり 稲妻が 落ちることがあるという。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "でんじスパーク" },
+			cost: ["Lightning"],
+			effect: {
+				ja: "相手のポケモン1匹に、10ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 839259,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "H",
+	rarity: "Promo",
+	dexId: [25],
+};
+
+export default card;

--- a/data-asia/M/M-P/021.ts
+++ b/data-asia/M/M-P/021.ts
@@ -1,0 +1,54 @@
+import { Card } from "../../../interfaces";
+import Set from "../M-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ラルトス",
+	},
+
+	illustrator: "Terada Tera",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Psychic"],
+
+	description: {
+		ja: "人の 感情を 頭の 赤い ツノで 敏感に キャッチする 力を 持つ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "もってくる" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札を1枚引く。",
+			},
+		},
+		{
+			name: { ja: "ずつき" },
+			damage: 10,
+			cost: ["Psychic"],
+		},
+	],
+
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 839263,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "Promo",
+	dexId: [280],
+};
+
+export default card;

--- a/data-asia/M/M-P/022.ts
+++ b/data-asia/M/M-P/022.ts
@@ -1,0 +1,50 @@
+import { Card } from "../../../interfaces";
+import Set from "../M-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "リオル",
+	},
+
+	illustrator: "hncl",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Fighting"],
+
+	description: {
+		ja: "仲間同士で 波動を 出して コミュニケーションを とっている。 一晩中 走り続けられる。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "かそくづき" },
+			damage: 30,
+			cost: ["Fighting"],
+			effect: {
+				ja: "次の自分の番、このポケモンは「かそくづき」が使えない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 839267,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "I",
+	rarity: "Promo",
+	dexId: [447],
+};
+
+export default card;

--- a/data-asia/M/M-P/023.ts
+++ b/data-asia/M/M-P/023.ts
@@ -1,0 +1,23 @@
+import { Card } from "../../../interfaces";
+import Set from "../M-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "基本草エネルギー",
+	},
+
+	illustrator: "",
+	category: "Energy",
+	energyType: "Normal",
+
+	effect: {
+		ja: "&copy;Pokémon/Nintendo/Creatures/GAME FREAK ポケットモンスター・ポケモン・Pokémonは任天堂・クリーチャーズ・ゲームフリークの商標です。 このホームページに掲載された画像その他の内容の無断転載はお断りします。",
+	},
+
+	variants: [{ type: "normal" }],
+
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/M/M-P/024.ts
+++ b/data-asia/M/M-P/024.ts
@@ -1,0 +1,23 @@
+import { Card } from "../../../interfaces";
+import Set from "../M-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "基本炎エネルギー",
+	},
+
+	illustrator: "",
+	category: "Energy",
+	energyType: "Normal",
+
+	effect: {
+		ja: "&copy;Pokémon/Nintendo/Creatures/GAME FREAK ポケットモンスター・ポケモン・Pokémonは任天堂・クリーチャーズ・ゲームフリークの商標です。 このホームページに掲載された画像その他の内容の無断転載はお断りします。",
+	},
+
+	variants: [{ type: "normal" }],
+
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/M/M-P/025.ts
+++ b/data-asia/M/M-P/025.ts
@@ -1,0 +1,23 @@
+import { Card } from "../../../interfaces";
+import Set from "../M-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "基本水エネルギー",
+	},
+
+	illustrator: "",
+	category: "Energy",
+	energyType: "Normal",
+
+	effect: {
+		ja: "&copy;Pokémon/Nintendo/Creatures/GAME FREAK ポケットモンスター・ポケモン・Pokémonは任天堂・クリーチャーズ・ゲームフリークの商標です。 このホームページに掲載された画像その他の内容の無断転載はお断りします。",
+	},
+
+	variants: [{ type: "normal" }],
+
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/M/M-P/026.ts
+++ b/data-asia/M/M-P/026.ts
@@ -1,0 +1,23 @@
+import { Card } from "../../../interfaces";
+import Set from "../M-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "基本雷エネルギー",
+	},
+
+	illustrator: "",
+	category: "Energy",
+	energyType: "Normal",
+
+	effect: {
+		ja: "&copy;Pokémon/Nintendo/Creatures/GAME FREAK ポケットモンスター・ポケモン・Pokémonは任天堂・クリーチャーズ・ゲームフリークの商標です。 このホームページに掲載された画像その他の内容の無断転載はお断りします。",
+	},
+
+	variants: [{ type: "normal" }],
+
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/M/M-P/027.ts
+++ b/data-asia/M/M-P/027.ts
@@ -1,0 +1,23 @@
+import { Card } from "../../../interfaces";
+import Set from "../M-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "基本超エネルギー",
+	},
+
+	illustrator: "",
+	category: "Energy",
+	energyType: "Normal",
+
+	effect: {
+		ja: "&copy;Pokémon/Nintendo/Creatures/GAME FREAK ポケットモンスター・ポケモン・Pokémonは任天堂・クリーチャーズ・ゲームフリークの商標です。 このホームページに掲載された画像その他の内容の無断転載はお断りします。",
+	},
+
+	variants: [{ type: "normal" }],
+
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/M/M-P/028.ts
+++ b/data-asia/M/M-P/028.ts
@@ -1,0 +1,23 @@
+import { Card } from "../../../interfaces";
+import Set from "../M-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "基本闘エネルギー",
+	},
+
+	illustrator: "",
+	category: "Energy",
+	energyType: "Normal",
+
+	effect: {
+		ja: "&copy;Pokémon/Nintendo/Creatures/GAME FREAK ポケットモンスター・ポケモン・Pokémonは任天堂・クリーチャーズ・ゲームフリークの商標です。 このホームページに掲載された画像その他の内容の無断転載はお断りします。",
+	},
+
+	variants: [{ type: "normal" }],
+
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/M/M-P/029.ts
+++ b/data-asia/M/M-P/029.ts
@@ -1,0 +1,23 @@
+import { Card } from "../../../interfaces";
+import Set from "../M-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "基本悪エネルギー",
+	},
+
+	illustrator: "",
+	category: "Energy",
+	energyType: "Normal",
+
+	effect: {
+		ja: "&copy;Pokémon/Nintendo/Creatures/GAME FREAK ポケットモンスター・ポケモン・Pokémonは任天堂・クリーチャーズ・ゲームフリークの商標です。 このホームページに掲載された画像その他の内容の無断転載はお断りします。",
+	},
+
+	variants: [{ type: "normal" }],
+
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/M/M-P/030.ts
+++ b/data-asia/M/M-P/030.ts
@@ -1,0 +1,23 @@
+import { Card } from "../../../interfaces";
+import Set from "../M-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "基本鋼エネルギー",
+	},
+
+	illustrator: "",
+	category: "Energy",
+	energyType: "Normal",
+
+	effect: {
+		ja: "&copy;Pokémon/Nintendo/Creatures/GAME FREAK ポケットモンスター・ポケモン・Pokémonは任天堂・クリーチャーズ・ゲームフリークの商標です。 このホームページに掲載された画像その他の内容の無断転載はお断りします。",
+	},
+
+	variants: [{ type: "normal" }],
+
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/M/M-P/031.ts
+++ b/data-asia/M/M-P/031.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../M-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "夜のタンカ",
+	},
+
+	illustrator: "Toyste Beach",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分のトラッシュからポケモンまたは基本エネルギーを1枚選び、相手に見せて、手札に加える。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 845901,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	regulationMark: "H",
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/M/M-P/032.ts
+++ b/data-asia/M/M-P/032.ts
@@ -1,0 +1,58 @@
+import { Card } from "../../../interfaces";
+import Set from "../M-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ラティアスex",
+	},
+
+	illustrator: "takuyoa",
+	category: "Pokemon",
+	hp: 210,
+	types: ["Psychic"],
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "スカイライン" },
+			effect: {
+				ja: "このポケモンがいるかぎり、自分のたねポケモン全員のにげるためのエネルギーは、すべてなくなる。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "むげんのやいば" },
+			damage: 200,
+			cost: ["Psychic", "Psychic", "Colorless"],
+			effect: {
+				ja: "次の自分の番、このポケモンはワザが使えない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 845902,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "H",
+	rarity: "Promo",
+	dexId: [380],
+
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/M/M-P/033.ts
+++ b/data-asia/M/M-P/033.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../M-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "おいわいファンファーレ",
+	},
+
+	illustrator: "Yuu Nishida",
+	category: "Trainer",
+
+	effect: {
+		ja: "おたがいのプレイヤーは、自分の番ごとに1回、自分のポケモン全員のHPを、それぞれ「10」回復してよい。その場合、自分の番は終わる。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 841214,
+			},
+		},
+	],
+
+	trainerType: "Stadium",
+	regulationMark: "I",
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/M/M-P/034.ts
+++ b/data-asia/M/M-P/034.ts
@@ -1,0 +1,53 @@
+import { Card } from "../../../interfaces";
+import Set from "../M-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "シェイミ",
+	},
+
+	illustrator: "tono",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Grass"],
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "はなのカーテン" },
+			effect: {
+				ja: "このポケモンがいるかぎり、自分のベンチポケモン（「ルールを持つポケモン」をのぞく）全員は、相手のワザのダメージを受けない。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "けとばす" },
+			damage: 30,
+			cost: ["Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 843813,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "Promo",
+	dexId: [492],
+};
+
+export default card;

--- a/data-asia/M/M-P/035.ts
+++ b/data-asia/M/M-P/035.ts
@@ -1,0 +1,23 @@
+import { Card } from "../../../interfaces";
+import Set from "../M-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "基本草エネルギー",
+	},
+
+	illustrator: "",
+	category: "Energy",
+	energyType: "Normal",
+
+	effect: {
+		ja: "&copy;Pokémon/Nintendo/Creatures/GAME FREAK ポケットモンスター・ポケモン・Pokémonは任天堂・クリーチャーズ・ゲームフリークの商標です。 このホームページに掲載された画像その他の内容の無断転載はお断りします。",
+	},
+
+	variants: [{ type: "normal" }],
+
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/M/M-P/036.ts
+++ b/data-asia/M/M-P/036.ts
@@ -1,0 +1,23 @@
+import { Card } from "../../../interfaces";
+import Set from "../M-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "基本炎エネルギー",
+	},
+
+	illustrator: "",
+	category: "Energy",
+	energyType: "Normal",
+
+	effect: {
+		ja: "&copy;Pokémon/Nintendo/Creatures/GAME FREAK ポケットモンスター・ポケモン・Pokémonは任天堂・クリーチャーズ・ゲームフリークの商標です。 このホームページに掲載された画像その他の内容の無断転載はお断りします。",
+	},
+
+	variants: [{ type: "normal" }],
+
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/M/M-P/037.ts
+++ b/data-asia/M/M-P/037.ts
@@ -1,0 +1,23 @@
+import { Card } from "../../../interfaces";
+import Set from "../M-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "基本水エネルギー",
+	},
+
+	illustrator: "",
+	category: "Energy",
+	energyType: "Normal",
+
+	effect: {
+		ja: "&copy;Pokémon/Nintendo/Creatures/GAME FREAK ポケットモンスター・ポケモン・Pokémonは任天堂・クリーチャーズ・ゲームフリークの商標です。 このホームページに掲載された画像その他の内容の無断転載はお断りします。",
+	},
+
+	variants: [{ type: "normal" }],
+
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/M/M-P/038.ts
+++ b/data-asia/M/M-P/038.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../M-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "基本雷エネルギー",
+	},
+
+	illustrator: "",
+	category: "Energy",
+	energyType: "Normal",
+
+	effect: {
+		ja: "&copy;Pokémon/Nintendo/Creatures/GAME FREAK ポケットモンスター・ポケモン・Pokémonは任天堂・クリーチャーズ・ゲームフリークの商標です。 このホームページに掲載された画像その他の内容の無断転載はお断りします。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 850503,
+			},
+		},
+	],
+
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/M/M-P/039.ts
+++ b/data-asia/M/M-P/039.ts
@@ -1,0 +1,23 @@
+import { Card } from "../../../interfaces";
+import Set from "../M-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "基本超エネルギー",
+	},
+
+	illustrator: "",
+	category: "Energy",
+	energyType: "Normal",
+
+	effect: {
+		ja: "&copy;Pokémon/Nintendo/Creatures/GAME FREAK ポケットモンスター・ポケモン・Pokémonは任天堂・クリーチャーズ・ゲームフリークの商標です。 このホームページに掲載された画像その他の内容の無断転載はお断りします。",
+	},
+
+	variants: [{ type: "normal" }],
+
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/M/M-P/040.ts
+++ b/data-asia/M/M-P/040.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../M-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "基本闘エネルギー",
+	},
+
+	illustrator: "",
+	category: "Energy",
+	energyType: "Normal",
+
+	effect: {
+		ja: "&copy;Pokémon/Nintendo/Creatures/GAME FREAK ポケットモンスター・ポケモン・Pokémonは任天堂・クリーチャーズ・ゲームフリークの商標です。 このホームページに掲載された画像その他の内容の無断転載はお断りします。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 885573,
+			},
+		},
+	],
+
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/M/M-P/041.ts
+++ b/data-asia/M/M-P/041.ts
@@ -1,0 +1,23 @@
+import { Card } from "../../../interfaces";
+import Set from "../M-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "基本悪エネルギー",
+	},
+
+	illustrator: "",
+	category: "Energy",
+	energyType: "Normal",
+
+	effect: {
+		ja: "&copy;Pokémon/Nintendo/Creatures/GAME FREAK ポケットモンスター・ポケモン・Pokémonは任天堂・クリーチャーズ・ゲームフリークの商標です。 このホームページに掲載された画像その他の内容の無断転載はお断りします。",
+	},
+
+	variants: [{ type: "normal" }],
+
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/M/M-P/042.ts
+++ b/data-asia/M/M-P/042.ts
@@ -1,0 +1,23 @@
+import { Card } from "../../../interfaces";
+import Set from "../M-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "基本鋼エネルギー",
+	},
+
+	illustrator: "",
+	category: "Energy",
+	energyType: "Normal",
+
+	effect: {
+		ja: "&copy;Pokémon/Nintendo/Creatures/GAME FREAK ポケットモンスター・ポケモン・Pokémonは任天堂・クリーチャーズ・ゲームフリークの商標です。 このホームページに掲載された画像その他の内容の無断転載はお断りします。",
+	},
+
+	variants: [{ type: "normal" }],
+
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/M/M-P/043.ts
+++ b/data-asia/M/M-P/043.ts
@@ -1,0 +1,58 @@
+import { Card } from "../../../interfaces";
+import Set from "../M-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ロケット団のミュウツーex",
+	},
+
+	illustrator: "aky CG Works",
+	category: "Pokemon",
+	hp: 280,
+	types: ["Psychic"],
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "パワーセーバー" },
+			effect: {
+				ja: "自分の場の「ロケット団のポケモン」が4匹以上のときにしか、このポケモンはワザが使えない。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "イレイザーボール" },
+			damage: "160+",
+			cost: ["Psychic", "Psychic", "Colorless"],
+			effect: {
+				ja: "のぞむなら、自分のベンチポケモンについているエネルギーを2枚までトラッシュし、その枚数×60ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 843814,
+			},
+		},
+	],
+
+	retreat: 3,
+	regulationMark: "I",
+	rarity: "Promo",
+	dexId: [150],
+
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/M/M-P/044.ts
+++ b/data-asia/M/M-P/044.ts
@@ -1,0 +1,24 @@
+import { Card } from "../../../interfaces";
+import Set from "../M-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ブレイブバングル",
+	},
+
+	illustrator: "Toyste Beach",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードをつけているポケモン（「ルールを持つポケモン」をのぞく）が使うワザの、相手のバトル場の「ポケモンex」へのダメージは「+30」される。",
+	},
+
+	variants: [{ type: "normal" }],
+
+	trainerType: "Tool",
+	regulationMark: "I",
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/M/M-P/045.ts
+++ b/data-asia/M/M-P/045.ts
@@ -1,0 +1,51 @@
+import { Card } from "../../../interfaces";
+import Set from "../M-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "リザード",
+	},
+
+	illustrator: "Teeziro",
+	category: "Pokemon",
+	hp: 110,
+	types: ["Fire"],
+
+	description: {
+		ja: "燃える 尻尾を 振りまわすと まわりの 温度が どんどん 上がって 相手を 苦しめる。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "ひをはく" },
+			damage: 40,
+			cost: ["Fire"],
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 858263,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ヒトカゲ",
+	},
+
+	retreat: 2,
+	regulationMark: "I",
+	rarity: "Promo",
+	dexId: [5],
+};
+
+export default card;

--- a/data-asia/M/M-P/046.ts
+++ b/data-asia/M/M-P/046.ts
@@ -1,0 +1,60 @@
+import { Card } from "../../../interfaces";
+import Set from "../M-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ワルビアルex",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 320,
+	types: ["Darkness"],
+
+	stage: "Stage2",
+
+	attacks: [
+		{
+			name: { ja: "おいつめる" },
+			damage: 80,
+			cost: ["Darkness", "Colorless"],
+			effect: {
+				ja: "次の相手の番、このワザを受けたポケモンは、にげられない。",
+			},
+		},
+		{
+			name: { ja: "ストロングバイト" },
+			damage: "140+",
+			cost: ["Darkness", "Darkness", "Colorless"],
+			effect: {
+				ja: "このポケモンに「ポケモンのどうぐ」がついているなら、140ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 858264,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ワルビル",
+	},
+
+	retreat: 3,
+	regulationMark: "I",
+	rarity: "Promo",
+	dexId: [553],
+
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/M/M-P/047.ts
+++ b/data-asia/M/M-P/047.ts
@@ -1,0 +1,54 @@
+import { Card } from "../../../interfaces";
+import Set from "../M-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "エレズン",
+	},
+
+	illustrator: "Mina Nakai",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Darkness"],
+
+	description: {
+		ja: "汚れた 水を 飲んでも 平気。 体内の 器官で 自分には 無害の 毒液に ろ過するぞ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "なかまをよぶ" },
+			cost: ["Darkness"],
+			effect: {
+				ja: "自分の山札からたねポケモンを2枚まで選び、ベンチに出す。そして山札を切る。",
+			},
+		},
+		{
+			name: { ja: "やんちゃげり" },
+			damage: 20,
+			cost: ["Darkness", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 858265,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "Promo",
+	dexId: [848],
+};
+
+export default card;

--- a/data-asia/M/M-P/048.ts
+++ b/data-asia/M/M-P/048.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../M-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ノココッチ",
+	},
+
+	illustrator: "Teeziro",
+	category: "Pokemon",
+	hp: 140,
+	types: ["Colorless"],
+
+	description: {
+		ja: "硬い 尻尾で 地中 深くの 岩盤を くり抜き 巣を 作る。 巣穴は 長さ１０キロに およぶ。",
+	},
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "にげあしドロー" },
+			effect: {
+				ja: "自分の番に1回使える。自分の山札を3枚引く。その後、このポケモンと、ついているすべてのカードを、山札にもどして切る。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ランドクラッシュ" },
+			damage: 90,
+			cost: ["Colorless", "Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 858266,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ノコッチ",
+	},
+
+	retreat: 3,
+	regulationMark: "H",
+	rarity: "Promo",
+	dexId: [982],
+};
+
+export default card;

--- a/data-asia/M/M-P/049.ts
+++ b/data-asia/M/M-P/049.ts
@@ -1,0 +1,24 @@
+import { Card } from "../../../interfaces";
+import Set from "../M-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "逆境ほけん",
+	},
+
+	illustrator: "Ayaka Yoshida",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードをつけているポケモンの弱点のタイプと、相手のバトルポケモンのタイプが同じなら、このカードをつけているポケモンが、バトル場で相手のポケモンからワザのダメージを受けたとき、自分の山札を3枚引く。",
+	},
+
+	variants: [{ type: "normal" }],
+
+	trainerType: "Tool",
+	regulationMark: "I",
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/M/M-P/050.ts
+++ b/data-asia/M/M-P/050.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../M-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ふうせん",
+	},
+
+	illustrator: "Studio Bora Inc.",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードをつけているポケモンは、にげるためのエネルギーが2個ぶん少なくなる。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 858268,
+			},
+		},
+	],
+
+	trainerType: "Tool",
+	regulationMark: "I",
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/M/M-P/051.ts
+++ b/data-asia/M/M-P/051.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../M-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "トウコ",
+	},
+
+	illustrator: "yuu",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の山札から進化ポケモンとエネルギーを1枚ずつ選び、相手に見せて、手札に加える。そして山札を切る。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 858269,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "I",
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/M/M-P/053.ts
+++ b/data-asia/M/M-P/053.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../M-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ペパー",
+	},
+
+	illustrator: "GIDORA",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の山札から「グッズ」と「ポケモンのどうぐ」を1枚ずつ選び、相手に見せて、手札に加える。そして山札を切る。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 864265,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "G",
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/M/M-P/054.ts
+++ b/data-asia/M/M-P/054.ts
@@ -1,0 +1,63 @@
+import { Card } from "../../../interfaces";
+import Set from "../M-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "デデンネGX",
+	},
+
+	illustrator: "PLANETA Igarashi",
+	category: "Pokemon",
+	hp: 160,
+	types: ["Lightning"],
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "デデチェンジ" },
+			effect: {
+				ja: "自分の番に、このカードを手札からベンチに出したとき、1回使える。自分の手札をすべてトラッシュし、山札を6枚引く。この番、すでに別の「デデチェンジ」を使っていたなら、この特性は使えない。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "バチバチ" },
+			damage: 50,
+			cost: ["Lightning", "Colorless"],
+		},
+		{
+			name: { ja: "ビリリターンGX" },
+			damage: 50,
+			cost: ["Lightning", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをマヒにする。このポケモンと、ついているすべてのカードを、手札にもどす。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Metal", value: "-30" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 864266,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Promo",
+	dexId: [702],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/M/M-P/055.ts
+++ b/data-asia/M/M-P/055.ts
@@ -1,0 +1,58 @@
+import { Card } from "../../../interfaces";
+import Set from "../M-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ミカルゲ",
+	},
+
+	illustrator: "Mitsuhiro Arita",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Darkness"],
+
+	description: {
+		ja: "いつも 悪さばかり していたら 不思議な 術で 本体を 要石に 縛りつけられた。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ふういんのさけび" },
+			effect: {
+				ja: "このポケモンがいるかぎり、おたがいのプレイヤーは、手札から「ACE SPEC」のカードを出して使えない。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "オカルトミラー" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の手札をすべて山札にもどし、山札を切る。その後、相手の手札の枚数ぶん、自分の山札を引く。",
+			},
+		},
+	],
+
+	weaknesses: [],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 864267,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Promo",
+	dexId: [442],
+};
+
+export default card;

--- a/data-asia/M/M-P/056.ts
+++ b/data-asia/M/M-P/056.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../M-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ホルビー",
+	},
+
+	illustrator: "Hitoshi Ariga",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Colorless"],
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "Ω（オメガ）連打" },
+			effect: {
+				ja: "このポケモンは、ワザを2回連続で使える。（1回目で相手のバトルポケモンがきぜつしたなら、次のポケモンが出た後、2回目を使う。）",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ほるほる" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "相手の山札を上から1枚トラッシュする。",
+			},
+		},
+		{
+			name: { ja: "たがやす" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分のトラッシュから好きなカードを1枚選び、相手に見せてから、山札にもどす。そして山札を切る。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 864268,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Promo",
+	dexId: [659],
+};
+
+export default card;

--- a/data-asia/M/M-P/057.ts
+++ b/data-asia/M/M-P/057.ts
@@ -1,0 +1,23 @@
+import { Card } from "../../../interfaces";
+import Set from "../M-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "スペシャルチャージ",
+	},
+
+	illustrator: "Toyste Beach",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分のトラッシュから特殊エネルギーを2枚選び、相手に見せてから、山札にもどす。そして山札を切る。",
+	},
+
+	variants: [{ type: "normal" }],
+
+	trainerType: "Item",
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/M/M-P/058.ts
+++ b/data-asia/M/M-P/058.ts
@@ -1,0 +1,23 @@
+import { Card } from "../../../interfaces";
+import Set from "../M-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "トレーナーズポスト",
+	},
+
+	illustrator: "Toyste Beach",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の山札を上から4枚見る。その中からトレーナーズ（「トレーナーズポスト」をのぞく）を1枚選び、相手に見せてから、手札に加える。残りのカードは山札にもどし、山札を切る。",
+	},
+
+	variants: [{ type: "normal" }],
+
+	trainerType: "Item",
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/M/M-P/059.ts
+++ b/data-asia/M/M-P/059.ts
@@ -1,0 +1,23 @@
+import { Card } from "../../../interfaces";
+import Set from "../M-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "バトルコンプレッサー",
+	},
+
+	illustrator: "Toyste Beach",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の山札から好きなカードを3枚まで選び、トラッシュする。そして山札を切る。",
+	},
+
+	variants: [{ type: "normal" }],
+
+	trainerType: "Item",
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/M/M-P/060.ts
+++ b/data-asia/M/M-P/060.ts
@@ -1,0 +1,23 @@
+import { Card } from "../../../interfaces";
+import Set from "../M-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "バトルサーチャー",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分のトラッシュからサポートを1枚選び、相手に見せてから、手札に加える。",
+	},
+
+	variants: [{ type: "normal" }],
+
+	trainerType: "Item",
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/M/M-P/061.ts
+++ b/data-asia/M/M-P/061.ts
@@ -1,0 +1,24 @@
+import { Card } from "../../../interfaces";
+import Set from "../M-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "フィールドブロアー",
+	},
+
+	illustrator: "Toyste Beach",
+	category: "Trainer",
+
+	effect: {
+		ja: "場にある「ポケモンのどうぐ」または「スタジアム」を、2枚までトラッシュする。",
+	},
+
+	variants: [{ type: "normal" }],
+
+	trainerType: "Item",
+	regulationMark: "A",
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/M/M-P/062.ts
+++ b/data-asia/M/M-P/062.ts
@@ -1,0 +1,23 @@
+import { Card } from "../../../interfaces";
+import Set from "../M-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "かるいし",
+	},
+
+	illustrator: "Toyste Beach",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードをつけているポケモンのにげるために必要なエネルギーは、すべてなくなる。",
+	},
+
+	variants: [{ type: "normal" }],
+
+	trainerType: "Tool",
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/M/M-P/063.ts
+++ b/data-asia/M/M-P/063.ts
@@ -1,0 +1,24 @@
+import { Card } from "../../../interfaces";
+import Set from "../M-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "プルメリ",
+	},
+
+	illustrator: "Ken Sugimori",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードは、自分の手札を2枚トラッシュしなければ使えない。相手の場のポケモンについているエネルギーを、1個トラッシュする。",
+	},
+
+	variants: [{ type: "normal" }],
+
+	trainerType: "Supporter",
+	regulationMark: "A",
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/M/M-P/064.ts
+++ b/data-asia/M/M-P/064.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../M-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "パラレルシティ",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードは、上下の向きを選んでから場に出す。こちら側のプレイヤーがベンチに出せるポケモンの数は、3匹になる。（このカードが場に出たとき、ベンチに4匹以上いる場合は、こちら側のプレイヤーが、ベンチが3匹になるまでポケモンをトラッシュする。）",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 864276,
+			},
+		},
+	],
+
+	trainerType: "Stadium",
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/M/M-P/065.ts
+++ b/data-asia/M/M-P/065.ts
@@ -1,0 +1,23 @@
+import { Card } from "../../../interfaces";
+import Set from "../M-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ダブルドラゴンエネルギー",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Energy",
+	energyType: "Special",
+
+	effect: {
+		ja: "このカードは[竜]ポケモンにしかつけられず、ついているかぎりすべてのタイプのエネルギー2個ぶんとしてはたらく。（このカードが[竜]ポケモン以外についているなら、トラッシュする。）",
+	},
+
+	variants: [{ type: "normal" }],
+
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/M/M-P/066.ts
+++ b/data-asia/M/M-P/066.ts
@@ -1,0 +1,54 @@
+import { Card } from "../../../interfaces";
+import Set from "../M-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ラルトス",
+	},
+
+	illustrator: "Terada Tera",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Psychic"],
+
+	description: {
+		ja: "人の 感情を 頭の 赤い ツノで 敏感に キャッチする 力を 持つ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "もってくる" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札を1枚引く。",
+			},
+		},
+		{
+			name: { ja: "ずつき" },
+			damage: 10,
+			cost: ["Psychic"],
+		},
+	],
+
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 864278,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "Promo",
+	dexId: [280],
+};
+
+export default card;

--- a/data-asia/M/M-P/067.ts
+++ b/data-asia/M/M-P/067.ts
@@ -1,0 +1,58 @@
+import { Card } from "../../../interfaces";
+import Set from "../M-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "キルリア",
+	},
+
+	illustrator: "satoma",
+	category: "Pokemon",
+	hp: 100,
+	types: ["Psychic"],
+
+	description: {
+		ja: "サイコパワーを 操り まわりの 空間を ねじ曲げることで 未来を 見通すことができる。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "コールサイン" },
+			cost: ["Psychic"],
+			effect: {
+				ja: "自分の山札からポケモンを3枚まで選び、相手に見せて、手札に加える。そして山札を切る。",
+			},
+		},
+		{
+			name: { ja: "サイコショット" },
+			damage: 30,
+			cost: ["Psychic"],
+		},
+	],
+
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 864279,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ラルトス",
+	},
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "Promo",
+	dexId: [281],
+};
+
+export default card;

--- a/data-asia/M/M-P/068.ts
+++ b/data-asia/M/M-P/068.ts
@@ -1,0 +1,57 @@
+import { Card } from "../../../interfaces";
+import Set from "../M-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "メガエルレイドex",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 350,
+	types: ["Fighting"],
+
+	stage: "Stage2",
+
+	attacks: [
+		{
+			name: { ja: "はやてぎり" },
+			damage: "50+",
+			cost: ["Fighting"],
+			effect: {
+				ja: "このポケモンにダメカンがのっていないなら、150ダメージ追加。",
+			},
+		},
+		{
+			name: { ja: "マーベラスエッジ" },
+			damage: 240,
+			cost: ["Fighting", "Fighting", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 864280,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "キルリア",
+	},
+
+	retreat: 2,
+	regulationMark: "J",
+	rarity: "Promo",
+	dexId: [475],
+
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/M/M-P/069.ts
+++ b/data-asia/M/M-P/069.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../M-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "パワープロテイン",
+	},
+
+	illustrator: "Toyste Beach",
+	category: "Trainer",
+
+	effect: {
+		ja: "この番、自分の[F]ポケモンが使うワザの、相手のバトルポケモンへのダメージは「+30」される。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 867912,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	regulationMark: "I",
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/M/M-P/070.ts
+++ b/data-asia/M/M-P/070.ts
@@ -1,0 +1,57 @@
+import { Card } from "../../../interfaces";
+import Set from "../M-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヤドン",
+	},
+
+	illustrator: "miki kudo",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Psychic"],
+
+	description: {
+		ja: "いつも ボーッとしていて なにを 考えているか わからない。 尻尾で エサを 釣るのが 得意。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "まぬけがお" },
+			effect: {
+				ja: "このポケモンはこんらんにならない。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ちょうねんりき" },
+			damage: 50,
+			cost: ["Psychic", "Psychic", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 871025,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "J",
+	rarity: "Promo",
+	dexId: [79],
+};
+
+export default card;

--- a/data-asia/M/M-P/071.ts
+++ b/data-asia/M/M-P/071.ts
@@ -1,0 +1,52 @@
+import { Card } from "../../../interfaces";
+import Set from "../M-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "メガヤドランex",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 330,
+	types: ["Psychic"],
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "シェルネードスピン" },
+			damage: 180,
+			cost: ["Psychic", "Psychic", "Psychic"],
+			effect: {
+				ja: "次の相手の番、このポケモンがワザのダメージを受けたとき、ワザを使ったポケモンにダメカンを12個のせる。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 871028,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ヤドン",
+	},
+
+	retreat: 3,
+	regulationMark: "J",
+	rarity: "Promo",
+	dexId: [80],
+
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/M/M-P/072.ts
+++ b/data-asia/M/M-P/072.ts
@@ -1,0 +1,57 @@
+import { Card } from "../../../interfaces";
+import Set from "../M-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ジーランス",
+	},
+
+	illustrator: "Mina Nakai",
+	category: "Pokemon",
+	hp: 100,
+	types: ["Fighting"],
+
+	description: {
+		ja: "岩のように 硬い ウロコと 脂の 詰まった 浮袋で 深海の 水圧に 耐える。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "きおくにもぐる" },
+			effect: {
+				ja: "このポケモンがいるかぎり、自分の進化しているポケモン全員は、進化前に持っていたワザを、すべて使える。［ワザを使うためのエネルギーは必要。］",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ひれカッター" },
+			damage: 30,
+			cost: ["Fighting", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 871033,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "H",
+	rarity: "Promo",
+	dexId: [369],
+};
+
+export default card;

--- a/data-asia/M/M-P/073.ts
+++ b/data-asia/M/M-P/073.ts
@@ -1,0 +1,54 @@
+import { Card } from "../../../interfaces";
+import Set from "../M-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "カメテテ",
+	},
+
+	illustrator: "Shimaris Yukichi",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Fighting"],
+
+	description: {
+		ja: "２匹の カメテテが ひとつの 岩で 暮らす。 ケンカすると どちらかが ほかの 岩に 移る。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ダブルドロー" },
+			cost: ["Fighting"],
+			effect: {
+				ja: "自分の山札を2枚引く。",
+			},
+		},
+		{
+			name: { ja: "ひっかく" },
+			damage: 30,
+			cost: ["Fighting", "Fighting"],
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 871035,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "J",
+	rarity: "Promo",
+	dexId: [688],
+};
+
+export default card;

--- a/data-asia/M/M-P/074.ts
+++ b/data-asia/M/M-P/074.ts
@@ -1,0 +1,24 @@
+import { Card } from "../../../interfaces";
+import Set from "../M-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ブレイブバングル",
+	},
+
+	illustrator: "Toyste Beach",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードをつけているポケモン（「ルールを持つポケモン」をのぞく）が使うワザの、相手のバトル場の「ポケモンex」へのダメージは「+30」される。",
+	},
+
+	variants: [{ type: "normal" }],
+
+	trainerType: "Tool",
+	regulationMark: "I",
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/M/M-P/075.ts
+++ b/data-asia/M/M-P/075.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../M-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ジェット",
+	},
+
+	illustrator: "GIDORA",
+	category: "Trainer",
+
+	effect: {
+		ja: "相手の場の「メガシンカex」の数ぶん、自分の山札を引く。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 871040,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "J",
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/M/M-P/076.ts
+++ b/data-asia/M/M-P/076.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../M-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ミツルの思いやり",
+	},
+
+	illustrator: "Iori Suzuki",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の「メガシンカex」1匹のHPを、すべて回復する。その後、回復したポケモンについているエネルギーを、すべて手札にもどす。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 871042,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "I",
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/M/M-P/085.ts
+++ b/data-asia/M/M-P/085.ts
@@ -1,0 +1,24 @@
+import { Card } from "../../../interfaces";
+import Set from "../M-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ポケパッド",
+	},
+
+	illustrator: "Studio Bora Inc.",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の山札からポケモン（「ルールを持つポケモン」をのぞく）を1枚選び、相手に見せて、手札に加える。そして山札を切る。",
+	},
+
+	variants: [{ type: "normal" }],
+
+	trainerType: "Item",
+	regulationMark: "J",
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/M/M-P/086.ts
+++ b/data-asia/M/M-P/086.ts
@@ -1,0 +1,51 @@
+import { Card } from "../../../interfaces";
+import Set from "../M-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "メガガルーラex",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 300,
+	types: ["Colorless"],
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "おつかいダッシュ" },
+			effect: {
+				ja: "このポケモンがバトル場にいるなら、自分の番に1回使える。自分の山札を2枚引く。この特性は別の「おつかいダッシュ」を使った番は使えない。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "マシンガンコンボ" },
+			damage: "200+",
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "ウラが出るまでコインを投げ、オモテの数×50ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [{ type: "normal" }],
+
+	retreat: 3,
+	regulationMark: "I",
+	rarity: "Promo",
+	dexId: [115],
+
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/M/M-P/095.ts
+++ b/data-asia/M/M-P/095.ts
@@ -1,0 +1,50 @@
+import { Card } from "../../../interfaces";
+import Set from "../M-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "シェイミ",
+	},
+
+	illustrator: "tono",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Grass"],
+
+	description: {
+		ja: "グラシデアの花が 咲く 季節 感謝の 心を 届けるために 飛び立つと 言われている。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "はなのカーテン" },
+			effect: {
+				ja: "このポケモンがいるかぎり、自分のベンチポケモン（「ルールを持つポケモン」をのぞく）全員は、相手のワザのダメージを受けない。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "けとばす" },
+			damage: 30,
+			cost: ["Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [{ type: "normal" }],
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "Promo",
+	dexId: [492],
+};
+
+export default card;

--- a/data-asia/M/M-P/096.ts
+++ b/data-asia/M/M-P/096.ts
@@ -1,0 +1,59 @@
+import { Card } from "../../../interfaces";
+import Set from "../M-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "メガマフォクシーex",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 350,
+	types: ["Fire"],
+
+	stage: "Stage2",
+
+	attacks: [
+		{
+			name: { ja: "トリックポータル" },
+			cost: ["Fire"],
+			effect: {
+				ja: "自分の山札を上から9枚見て、その中からポケモンを好きなだけ選び、ベンチに出す。残りのカードは山札にもどして切る。",
+			},
+		},
+		{
+			name: { ja: "あやしいともしび" },
+			damage: 200,
+			cost: ["Fire", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをやけどとこんらんにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 888188,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "テールナー",
+	},
+
+	retreat: 2,
+	regulationMark: "J",
+	rarity: "Promo",
+	dexId: [655],
+
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/M/M-P/097.ts
+++ b/data-asia/M/M-P/097.ts
@@ -1,0 +1,52 @@
+import { Card } from "../../../interfaces";
+import Set from "../M-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "パウワウ",
+	},
+
+	illustrator: "cochi8i",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Water"],
+
+	description: {
+		ja: "寒くなるほど 元気になって 氷の 浮かぶ 冷たい 海を うれしそうに 泳ぎまわる。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "みずかけ" },
+			damage: 10,
+			cost: ["Water"],
+		},
+		{
+			name: { ja: "スプラッシュ" },
+			damage: 30,
+			cost: ["Water", "Water"],
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 888189,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "J",
+	rarity: "Promo",
+	dexId: [86],
+};
+
+export default card;

--- a/data-asia/M/M-P/098.ts
+++ b/data-asia/M/M-P/098.ts
@@ -1,0 +1,54 @@
+import { Card } from "../../../interfaces";
+import Set from "../M-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "シュシュプ",
+	},
+
+	illustrator: "Terada Tera",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Psychic"],
+
+	description: {
+		ja: "昔の 貴婦人たちは 香水の かわりに 好みの 香りを 出す シュシュプを 連れていたという。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "あまいかおり" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分のポケモン1匹のHPを「30」回復する。",
+			},
+		},
+		{
+			name: { ja: "ぶつかる" },
+			damage: 10,
+			cost: ["Psychic"],
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 888190,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "J",
+	rarity: "Promo",
+	dexId: [682],
+};
+
+export default card;

--- a/data-asia/M/M-P/099.ts
+++ b/data-asia/M/M-P/099.ts
@@ -1,0 +1,24 @@
+import { Card } from "../../../interfaces";
+import Set from "../M-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "グリ",
+	},
+
+	illustrator: "Souichirou Gunjima",
+	category: "Trainer",
+
+	effect: {
+		ja: "おたがいのポケモン全員のHPを、それぞれ「50」回復する。",
+	},
+
+	variants: [{ type: "normal" }],
+
+	trainerType: "Supporter",
+	regulationMark: "J",
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/M/M-P/100.ts
+++ b/data-asia/M/M-P/100.ts
@@ -1,0 +1,24 @@
+import { Card } from "../../../interfaces";
+import Set from "../M-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヒカリ",
+	},
+
+	illustrator: "Yuu Nishida",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の山札から「たねポケモン」「1進化ポケモン」「2進化ポケモン」を1枚ずつ選び、相手に見せて、手札に加える。そして山札を切る。",
+	},
+
+	variants: [{ type: "normal" }],
+
+	trainerType: "Supporter",
+	regulationMark: "I",
+	rarity: "Promo",
+};
+
+export default card;


### PR DESCRIPTION
## What

Adds the complete Japanese set **M-P メガ プロモカード (Mega Promotional Cards)**, released 2025-07-28:

- `data-asia/M/M-P.ts` — set definition (0 official cards)
- `data-asia/M/M-P/001.ts` … `133.ts` — the 83 promos published so far (numbering has gaps)

## Data sources

- **pokemon-card.com** (official database): Japanese names, flavor texts, National Dex numbers, official card count
- **limitlesstcg.com**: full Japanese card text, stages, weaknesses/resistances/retreat, rarities, illustrators, attack costs
- **Cardmarket**: product IDs as `thirdParty.cardmarket` on the variant objects (839193–894858; tcgplayer IDs not available to me)

## Notes

- Follows the file format and conventions of the M-era sets (#1728)
- All 83 files type-check against `interfaces.d.ts` (`tsc --noEmit`)
