### PR TITLE
(data) Add Japanese SM set SM10 Double Blaze

### DIFF
--- a/data-asia/SM/SM10/001.ts
+++ b/data-asia/SM/SM10/001.ts
@@ -1,0 +1,54 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM10";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ナゾノクサ",
+	},
+
+	illustrator: "0313",
+	category: "Pokemon",
+	hp: 50,
+	types: ["Grass"],
+
+	description: {
+		ja: "昼間は 太陽を 避けるため 冷たい 地面に 潜っている。 月の 光を 浴びて 育つ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "しびれごな" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "コインを1回投げオモテなら、相手のバトルポケモンをマヒにする。",
+			},
+		},
+		{
+			name: { ja: "タネばくだん" },
+			damage: 20,
+			cost: ["Grass", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 557356,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [43],
+};
+
+export default card;

--- a/data-asia/SM/SM10/002.ts
+++ b/data-asia/SM/SM10/002.ts
@@ -1,0 +1,47 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM10";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ナゾノクサ",
+	},
+
+	illustrator: "Asako Ito",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Grass"],
+
+	description: {
+		ja: "昼間は 太陽を 避けるため 冷たい 地面に 潜っている。 月の 光を 浴びて 育つ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ひっかける" },
+			damage: 10,
+			cost: ["Grass"],
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 557357,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [43],
+};
+
+export default card;

--- a/data-asia/SM/SM10/003.ts
+++ b/data-asia/SM/SM10/003.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM10";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "クサイハナ",
+	},
+
+	illustrator: "Anesaki Dynamic",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Grass"],
+
+	description: {
+		ja: "猛烈な クサさ！ それなのに １０００人に １人ぐらい これを 好んで かぐ 人がいる。",
+	},
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "たまらんかおり" },
+			effect: {
+				ja: "自分の番に1回使える。コインを1回投げオモテなら、相手の手札を見て、その中にあるたねポケモンを1枚、相手のベンチに出す。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "よだれ" },
+			damage: 30,
+			cost: ["Grass", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 557358,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ナゾノクサ",
+	},
+
+	retreat: 2,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [44],
+};
+
+export default card;

--- a/data-asia/SM/SM10/004.ts
+++ b/data-asia/SM/SM10/004.ts
@@ -1,0 +1,64 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM10";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ラフレシア",
+	},
+
+	illustrator: "Suwama Chiaki",
+	category: "Pokemon",
+	hp: 140,
+	types: ["Grass"],
+
+	description: {
+		ja: "花びらが 大きいほど たくさん 花粉を 出すが 頭が 重たくて 疲れてしまうという。",
+	},
+
+	stage: "Stage2",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "バラエティかふん" },
+			effect: {
+				ja: "自分の番に1回使える。コインを1回投げオモテなら、どく・やけど・ねむり・こんらんの中から1つを選び、相手のバトルポケモンをその特殊状態にする。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ジャイアントブルーム" },
+			damage: 90,
+			cost: ["Grass", "Grass", "Colorless"],
+			effect: {
+				ja: "このポケモンのHPを「30」回復する。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 557359,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "クサイハナ",
+	},
+
+	retreat: 3,
+	regulationMark: "C",
+	rarity: "Rare",
+	dexId: [45],
+};
+
+export default card;

--- a/data-asia/SM/SM10/005.ts
+++ b/data-asia/SM/SM10/005.ts
@@ -1,0 +1,50 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM10";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "コンパン",
+	},
+
+	illustrator: "Yuka Morii",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Grass"],
+
+	description: {
+		ja: "小さな 目が たくさん 集まって 大きな 目に なっている。 夜になると 明かりに 集まる。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "サイケこうせん" },
+			damage: 10,
+			cost: ["Grass"],
+			effect: {
+				ja: "相手のバトルポケモンをこんらんにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 557360,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [48],
+};
+
+export default card;

--- a/data-asia/SM/SM10/006.ts
+++ b/data-asia/SM/SM10/006.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM10";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "モルフォン",
+	},
+
+	illustrator: "Mina Nakai",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Grass"],
+
+	description: {
+		ja: "ばらまかれた りんぷんに 触れると 体の 感覚が おかしくなって まっすぐ 立っていられなくなる。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "アサシンフライト" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "このワザは、相手のバトルポケモンが特殊状態なら、使える。相手のベンチポケモン1匹に、90ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+			},
+		},
+		{
+			name: { ja: "どくのこな" },
+			damage: 30,
+			cost: ["Grass"],
+			effect: {
+				ja: "相手のバトルポケモンをどくにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 557361,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "コンパン",
+	},
+
+	retreat: 0,
+	regulationMark: "C",
+	rarity: "Uncommon",
+	dexId: [49],
+};
+
+export default card;

--- a/data-asia/SM/SM10/007.ts
+++ b/data-asia/SM/SM10/007.ts
@@ -1,0 +1,64 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM10";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "レシラム&リザードンGX",
+	},
+
+	illustrator: "Mitsuhiro Arita",
+	category: "Pokemon",
+	hp: 270,
+	types: ["Fire"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "げきりん" },
+			damage: "30+",
+			cost: ["Fire", "Colorless"],
+			effect: {
+				ja: "このポケモンにのっているダメカンの数x10ダメージ追加。",
+			},
+		},
+		{
+			name: { ja: "フレアストライク" },
+			damage: 230,
+			cost: ["Fire", "Fire", "Fire", "Colorless"],
+			effect: {
+				ja: "次の自分の番、このポケモンは「フレアストライク」が使えない。",
+			},
+		},
+		{
+			name: { ja: "ダブルブレイズGX" },
+			damage: "200+",
+			cost: ["Fire", "Fire", "Fire"],
+			effect: {
+				ja: "追加で[炎]エネルギーが3個ついているなら、100ダメージ追加。その場合、このワザのダメージは、相手のバトルポケモンにかかっている効果を計算しない。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 557362,
+			},
+		},
+	],
+
+	retreat: 3,
+	regulationMark: "C",
+	rarity: "Double rare",
+	dexId: [643, 6],
+
+	suffix: "TAG TEAM-GX",
+};
+
+export default card;

--- a/data-asia/SM/SM10/008.ts
+++ b/data-asia/SM/SM10/008.ts
@@ -1,0 +1,52 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM10";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ガーディ",
+	},
+
+	illustrator: "tetsuya koizumi",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Fire"],
+
+	description: {
+		ja: "慣れれば 人懐っこいのだが 野生では イワンコと 縄張りを 巡って 激しく 争っている。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ひだね" },
+			damage: 10,
+			cost: ["Fire"],
+		},
+		{
+			name: { ja: "かえん" },
+			damage: 30,
+			cost: ["Fire", "Fire"],
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 557363,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [58],
+};
+
+export default card;

--- a/data-asia/SM/SM10/009.ts
+++ b/data-asia/SM/SM10/009.ts
@@ -1,0 +1,62 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM10";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ウインディ",
+	},
+
+	illustrator: "Shin Nagasawa",
+	category: "Pokemon",
+	hp: 140,
+	types: ["Fire"],
+
+	description: {
+		ja: "大昔に とある 武将と ともに 戦い 国を 治めた という 伝説が 残されている。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "グランドフレイム" },
+			damage: 120,
+			cost: ["Fire", "Fire", "Fire"],
+			effect: {
+				ja: "自分のトラッシュにある[炎]エネルギーを2枚、ベンチポケモン1匹につける。",
+			},
+		},
+		{
+			name: { ja: "ヒートタックル" },
+			damage: 190,
+			cost: ["Fire", "Fire", "Fire", "Fire"],
+			effect: {
+				ja: "このポケモンにも50ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 557364,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ガーディ",
+	},
+
+	retreat: 4,
+	regulationMark: "C",
+	rarity: "Rare",
+	dexId: [59],
+};
+
+export default card;

--- a/data-asia/SM/SM10/010.ts
+++ b/data-asia/SM/SM10/010.ts
@@ -1,0 +1,55 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM10";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ダルマッカ",
+	},
+
+	illustrator: "Yuka Morii",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Fire"],
+
+	description: {
+		ja: "ダルマッカの フンは 熱いので 昔の 人は 懐に 入れて 体を 温めていたのだ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ニトロチャージ" },
+			damage: 10,
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札にある[炎]エネルギーを1枚、このポケモンにつける。そして山札を切る。",
+			},
+		},
+		{
+			name: { ja: "はねまわる" },
+			damage: 20,
+			cost: ["Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 557365,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [554],
+};
+
+export default card;

--- a/data-asia/SM/SM10/011.ts
+++ b/data-asia/SM/SM10/011.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM10";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヒヒダルマ",
+	},
+
+	illustrator: "Midori Harada",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Fire"],
+
+	description: {
+		ja: "激しい 戦いで 傷つくと 岩のように 固まり 黙考して 心を 研ぎ澄ませるのだ。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "おにびさがし" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札にある[炎]エネルギーを3枚まで、相手に見せてから、手札に加える。そして山札を切る。",
+			},
+		},
+		{
+			name: { ja: "フレアドライブ" },
+			damage: 110,
+			cost: ["Fire", "Fire"],
+			effect: {
+				ja: "このポケモンについている[炎]エネルギーを、すべてトラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 557366,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ダルマッカ",
+	},
+
+	retreat: 3,
+	regulationMark: "C",
+	rarity: "Uncommon",
+	dexId: [555],
+};
+
+export default card;

--- a/data-asia/SM/SM10/012.ts
+++ b/data-asia/SM/SM10/012.ts
@@ -1,0 +1,57 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM10";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ボルケニオン",
+	},
+
+	illustrator: "Satoshi Shirai",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Fire"],
+
+	description: {
+		ja: "水蒸気を 噴き出して 自分の 姿を 濃霧で 隠す。 人の 立ち入らない 山に 住むという。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "フレアスターター" },
+			cost: ["Fire"],
+			effect: {
+				ja: "自分の山札にある[炎]エネルギーを1枚、自分のポケモンにつける。そして山札を切る。後攻プレイヤーの最初の番に使ったなら、つけられる枚数は3枚までになり、自分のポケモンに好きなようにつけられる。",
+			},
+		},
+		{
+			name: { ja: "こうねつばくは" },
+			damage: "50+",
+			cost: ["Fire", "Fire"],
+			effect: {
+				ja: "自分の場に[炎]エネルギーが4個以上あるなら、60ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 557367,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "C",
+	rarity: "Rare",
+	dexId: [721],
+};
+
+export default card;

--- a/data-asia/SM/SM10/013.ts
+++ b/data-asia/SM/SM10/013.ts
@@ -1,0 +1,49 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM10";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ニャビー",
+	},
+
+	illustrator: "0313",
+	category: "Pokemon",
+	hp: 50,
+	types: ["Fire"],
+
+	description: {
+		ja: "しつこく 付きまとわれると 心を 開かなくなる。 懐いてきても 過剰な スキンシップは 禁物。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "こがす" },
+			cost: ["Fire"],
+			effect: {
+				ja: "相手のバトルポケモンをやけどにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 557368,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [725],
+};
+
+export default card;

--- a/data-asia/SM/SM10/014.ts
+++ b/data-asia/SM/SM10/014.ts
@@ -1,0 +1,57 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM10";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ニャビー",
+	},
+
+	illustrator: "Atsuko Nishida",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Fire"],
+
+	description: {
+		ja: "しつこく 付きまとわれると 心を 開かなくなる。 懐いてきても 過剰な スキンシップは 禁物。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ねこびより" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札を1枚引く。その後、このポケモンをねむりにする。",
+			},
+		},
+		{
+			name: { ja: "かじりつく" },
+			damage: 60,
+			cost: ["Fire", "Colorless", "Colorless"],
+			effect: {
+				ja: "次の相手の番、このワザを受けたポケモンは、にげられない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 557369,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [725],
+};
+
+export default card;

--- a/data-asia/SM/SM10/015.ts
+++ b/data-asia/SM/SM10/015.ts
@@ -1,0 +1,54 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM10";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ニャヒート",
+	},
+
+	illustrator: "tetsuya koizumi",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Fire"],
+
+	description: {
+		ja: "なつくと トレーナーにも 甘えるが 力は 強く ツメも 鋭い。 全身 傷だらけに されるぞ。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "ほのおのキバ" },
+			damage: 20,
+			cost: ["Fire"],
+			effect: {
+				ja: "相手のバトルポケモンをやけどにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 557370,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ニャビー",
+	},
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [726],
+};
+
+export default card;

--- a/data-asia/SM/SM10/016.ts
+++ b/data-asia/SM/SM10/016.ts
@@ -1,0 +1,64 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM10";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ガオガエン",
+	},
+
+	illustrator: "Misa Tsutsui",
+	category: "Pokemon",
+	hp: 160,
+	types: ["Fire"],
+
+	description: {
+		ja: "荒っぽく わがままだが 格下を なぶることは つまらないので キライ。 格上の 相手に やる気を 出す。",
+	},
+
+	stage: "Stage2",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ストロングエール" },
+			effect: {
+				ja: "このポケモンがいるかぎり、自分のポケモンが使うワザの、相手のバトルポケモンへのダメージは「+30」される。この効果は、この特性を持つポケモンが何匹いても、重ならない。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "かえんほうしゃ" },
+			damage: 90,
+			cost: ["Fire", "Colorless"],
+			effect: {
+				ja: "このポケモンについているエネルギーを、1個トラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 557371,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ニャヒート",
+	},
+
+	retreat: 2,
+	regulationMark: "C",
+	rarity: "Uncommon",
+	dexId: [727],
+};
+
+export default card;

--- a/data-asia/SM/SM10/017.ts
+++ b/data-asia/SM/SM10/017.ts
@@ -1,0 +1,50 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM10";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヤトウモリ",
+	},
+
+	illustrator: "Yusuke Ohmura",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Fire"],
+
+	description: {
+		ja: "オスは メスの ほぼ いいなり。 獲った エサも ほとんど 貢ぐので 栄養不足で 進化 できない。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "くさをもやす" },
+			damage: 10,
+			cost: ["Fire"],
+			effect: {
+				ja: "相手のバトルポケモンについている[草]エネルギーを、1個トラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 557372,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [757],
+};
+
+export default card;

--- a/data-asia/SM/SM10/018.ts
+++ b/data-asia/SM/SM10/018.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM10";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "エンニュート",
+	},
+
+	illustrator: "hatachu",
+	category: "Pokemon",
+	hp: 100,
+	types: ["Fire"],
+
+	description: {
+		ja: "洞窟の 奥深くに 棲み フェロモンで メロメロに した ヤトウモリたちを 侍らせている。",
+	},
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "あぶりだす" },
+			effect: {
+				ja: "自分の番に1回使える。自分の手札にある[炎]エネルギーを1枚トラッシュする。その後、山札を3枚引く。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "かえん" },
+			damage: 60,
+			cost: ["Fire", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 557373,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ヤトウモリ",
+	},
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Uncommon",
+	dexId: [758],
+};
+
+export default card;

--- a/data-asia/SM/SM10/019.ts
+++ b/data-asia/SM/SM10/019.ts
@@ -1,0 +1,58 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM10";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ズガドーン",
+	},
+
+	illustrator: "kawayoo",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Fire"],
+
+	description: {
+		ja: "クネクネ動いて 人に 近付くと 突然 頭を 爆発させた。 ウルトラビーストの 一種らしい。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ブレイザー" },
+			damage: "10+",
+			cost: ["Fire"],
+			effect: {
+				ja: "ウラになっている自分のサイドを1枚、オモテにする。そのカードが[炎]エネルギーなら、50ダメージ追加。（対戦が終わるまで、そのサイドはオモテのまま。）",
+			},
+		},
+		{
+			name: { ja: "ひのたまサーカス" },
+			damage: "50×",
+			cost: ["Fire", "Fire", "Fire"],
+			effect: {
+				ja: "自分の手札にある[炎]エネルギーを好きなだけトラッシュし、その枚数x50ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 557374,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "C",
+	rarity: "Uncommon",
+	dexId: [806],
+};
+
+export default card;

--- a/data-asia/SM/SM10/020.ts
+++ b/data-asia/SM/SM10/020.ts
@@ -1,0 +1,57 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM10";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ニョロモ",
+	},
+
+	illustrator: "Midori Harada",
+	category: "Pokemon",
+	hp: 50,
+	types: ["Water"],
+
+	description: {
+		ja: "危険なのに 陸に 上がりたがる。 まだ よちよち歩き なので 敵に 見つかると 慌てて 水の中へ。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ぐるりんぱ" },
+			effect: {
+				ja: "後攻プレイヤーの最初の自分の番にだけ1回使える。相手のバトルポケモンをこんらんにする。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "みずまき" },
+			damage: 10,
+			cost: ["Water"],
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 557375,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [60],
+};
+
+export default card;

--- a/data-asia/SM/SM10/021.ts
+++ b/data-asia/SM/SM10/021.ts
@@ -1,0 +1,49 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM10";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ニョロモ",
+	},
+
+	illustrator: "Shibuzoh.",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Water"],
+
+	description: {
+		ja: "危険なのに 陸に 上がりたがる。 まだ よちよち歩き なので 敵に 見つかると 慌てて 水の中へ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "なかまをよぶ" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札にあるたねポケモンを1枚、ベンチに出す。そして山札を切る。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 557376,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [60],
+};
+
+export default card;

--- a/data-asia/SM/SM10/022.ts
+++ b/data-asia/SM/SM10/022.ts
@@ -1,0 +1,59 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM10";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ニョロゾ",
+	},
+
+	illustrator: "Yukiko Baba",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Water"],
+
+	description: {
+		ja: "陸でも 暮らせるように なったのに 獲物の さかなポケモンが 多い 水の 中で 過ごしている。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "あわ" },
+			damage: 20,
+			cost: ["Water"],
+			effect: {
+				ja: "コインを1回投げオモテなら、相手のバトルポケモンをマヒにする。",
+			},
+		},
+		{
+			name: { ja: "げんこつ" },
+			damage: 40,
+			cost: ["Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 557377,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ニョロモ",
+	},
+
+	retreat: 2,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [61],
+};
+
+export default card;

--- a/data-asia/SM/SM10/023.ts
+++ b/data-asia/SM/SM10/023.ts
@@ -1,0 +1,59 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM10";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ニョロボン",
+	},
+
+	illustrator: "Akira Komayama",
+	category: "Pokemon",
+	hp: 150,
+	types: ["Water"],
+
+	description: {
+		ja: "みずポケモンの 中でも かなり 泳ぎは 達者な 部類 なのに 普段は 陸で 過ごしている。",
+	},
+
+	stage: "Stage2",
+
+	attacks: [
+		{
+			name: { ja: "げんこつ" },
+			damage: 50,
+			cost: ["Colorless", "Colorless"],
+		},
+		{
+			name: { ja: "うずまきラッシュ" },
+			damage: "90+",
+			cost: ["Water", "Colorless", "Colorless"],
+			effect: {
+				ja: "自分のベンチに「ニョロモ」「ニョロゾ」がいるなら、90ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 557378,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ニョロゾ",
+	},
+
+	retreat: 3,
+	regulationMark: "C",
+	rarity: "Uncommon",
+	dexId: [62],
+};
+
+export default card;

--- a/data-asia/SM/SM10/024.ts
+++ b/data-asia/SM/SM10/024.ts
@@ -1,0 +1,47 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM10";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "パウワウ",
+	},
+
+	illustrator: "Sumiyoshi Kizuki",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Water"],
+
+	description: {
+		ja: "冷たい 海にしか 棲まないと 考えられてきた。 アローラに 現れる 理由は ナゾ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "つのでつく" },
+			damage: 30,
+			cost: ["Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 557379,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [86],
+};
+
+export default card;

--- a/data-asia/SM/SM10/025.ts
+++ b/data-asia/SM/SM10/025.ts
@@ -1,0 +1,58 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM10";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ジュゴン",
+	},
+
+	illustrator: "Kagemaru Himeno",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Water"],
+
+	description: {
+		ja: "８ノットの 速度で 海を 泳ぎ 獲物である ポケモンを 探す。 特に ヨワシが 大好物。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "しっぽではたく" },
+			damage: 60,
+			cost: ["Colorless", "Colorless"],
+		},
+		{
+			name: { ja: "デュアルブリザード" },
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンについているエネルギーを2個トラッシュし、相手のポケモン2匹に、それぞれ60ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 557380,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "パウワウ",
+	},
+
+	retreat: 2,
+	regulationMark: "C",
+	rarity: "Uncommon",
+	dexId: [87],
+};
+
+export default card;

--- a/data-asia/SM/SM10/026.ts
+++ b/data-asia/SM/SM10/026.ts
@@ -1,0 +1,52 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM10";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "クラブ",
+	},
+
+	illustrator: "Sekio",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Water"],
+
+	description: {
+		ja: "危険が 迫ると 口から 吐き出す 泡で 全身を 包んで 体を 大きく みせようとする。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ふむ" },
+			damage: 10,
+			cost: ["Colorless"],
+		},
+		{
+			name: { ja: "はさむ" },
+			damage: 20,
+			cost: ["Water", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 557381,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [98],
+};
+
+export default card;

--- a/data-asia/SM/SM10/027.ts
+++ b/data-asia/SM/SM10/027.ts
@@ -1,0 +1,59 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM10";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "キングラー",
+	},
+
+	illustrator: "Shigenori Negishi",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Water"],
+
+	description: {
+		ja: "硬い ハサミは １万馬力の パワーを 持っているが 大きすぎて 動きが 鈍い。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "バブルこうせん" },
+			damage: 80,
+			cost: ["Water", "Colorless", "Colorless"],
+			effect: {
+				ja: "コインを1回投げオモテなら、相手のバトルポケモンをマヒにする。",
+			},
+		},
+		{
+			name: { ja: "だいせつだん" },
+			damage: 130,
+			cost: ["Water", "Colorless", "Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 557382,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "クラブ",
+	},
+
+	retreat: 4,
+	regulationMark: "C",
+	rarity: "Uncommon",
+	dexId: [99],
+};
+
+export default card;

--- a/data-asia/SM/SM10/028.ts
+++ b/data-asia/SM/SM10/028.ts
@@ -1,0 +1,58 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM10";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "マッギョ",
+	},
+
+	illustrator: "sowsow",
+	category: "Pokemon",
+	hp: 110,
+	types: ["Lightning"],
+
+	description: {
+		ja: "皮膚が 硬いので 相撲取りに 踏まれても 平気。 電気を 流すとき 笑い顔に なる。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "らくらい" },
+			damage: 30,
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分のベンチポケモン1匹にも、10ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+			},
+		},
+		{
+			name: { ja: "ビリビリトラップ" },
+			damage: "30×",
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "自分の場のダメカンがのっているポケモンの数x30ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Metal", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 557383,
+			},
+		},
+	],
+
+	retreat: 3,
+	regulationMark: "C",
+	rarity: "Uncommon",
+	dexId: [618],
+};
+
+export default card;

--- a/data-asia/SM/SM10/029.ts
+++ b/data-asia/SM/SM10/029.ts
@@ -1,0 +1,62 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM10";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ベトベトン&アローラベトベトンGX",
+	},
+
+	illustrator: "Mitsuhiro Arita",
+	category: "Pokemon",
+	hp: 270,
+	types: ["Psychic"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "バッドポイズン" },
+			cost: ["Psychic", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをどくにする。このどくでのせるダメカンの数は8個になる。",
+			},
+		},
+		{
+			name: { ja: "どくしゃぶり" },
+			damage: 120,
+			cost: ["Psychic", "Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンがどくなら、このポケモンのHPを「100」回復する。",
+			},
+		},
+		{
+			name: { ja: "ベトベトミックスGX" },
+			cost: [],
+			effect: {
+				ja: "相手のバトルポケモンをどくとマヒにする。追加でエネルギーが4個ついているなら、このどくでのせるダメカンの数は15個になる。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 557384,
+			},
+		},
+	],
+
+	retreat: 4,
+	regulationMark: "C",
+	rarity: "Double rare",
+	dexId: [89, 89],
+
+	suffix: "TAG TEAM-GX",
+};
+
+export default card;

--- a/data-asia/SM/SM10/030.ts
+++ b/data-asia/SM/SM10/030.ts
@@ -1,0 +1,57 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM10";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ゴース",
+	},
+
+	illustrator: "chibi",
+	category: "Pokemon",
+	hp: 40,
+	types: ["Psychic"],
+
+	description: {
+		ja: "墓場で 発生する ガスに 怨念が 宿るうち やがて ポケモンに なったと いわれている。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ふえるうらみ" },
+			effect: {
+				ja: "このポケモンがきぜつしたとき、自分の山札にある「ゴースト」を2枚まで、ベンチに出す。そして山札を切る。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "おにび" },
+			damage: 20,
+			cost: ["Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 557385,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [92],
+};
+
+export default card;

--- a/data-asia/SM/SM10/031.ts
+++ b/data-asia/SM/SM10/031.ts
@@ -1,0 +1,49 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM10";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ゴース",
+	},
+
+	illustrator: "MAHOU",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Psychic"],
+
+	description: {
+		ja: "墓場で 発生する ガスに 怨念が 宿るうち やがて ポケモンに なったと いわれている。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "スモッグ" },
+			cost: ["Psychic"],
+			effect: {
+				ja: "相手のバトルポケモンをどくにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 557386,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [92],
+};
+
+export default card;

--- a/data-asia/SM/SM10/032.ts
+++ b/data-asia/SM/SM10/032.ts
@@ -1,0 +1,53 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM10";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ゴースト",
+	},
+
+	illustrator: "Miki Tanaka",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Psychic"],
+
+	description: {
+		ja: "月のない 夜。 ゴーストは 呪う 相手を 探しているので 出歩かない 方が いいぞ。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "ふきつなきり" },
+			cost: ["Psychic"],
+			effect: {
+				ja: "相手のバトルポケモンをどくにする。相手のベンチポケモン全員に、それぞれダメカンを1個のせる。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 557387,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ゴース",
+	},
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [93],
+};
+
+export default card;

--- a/data-asia/SM/SM10/033.ts
+++ b/data-asia/SM/SM10/033.ts
@@ -1,0 +1,64 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM10";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ゲンガー",
+	},
+
+	illustrator: "so-taro",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Psychic"],
+
+	description: {
+		ja: "悪い子の ところには ゲンガーが やってくる という 言い伝えは 世界中で 聞くことが できる。",
+	},
+
+	stage: "Stage2",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "シャドーペイン" },
+			effect: {
+				ja: "自分の番に、このカードを手札から出して進化させたとき、1回使える。ダメカン6個を、相手の「ポケモンGX・EX」に好きなようにのせる。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ゆうやみどく" },
+			damage: 70,
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをどくとねむりにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 557388,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ゴースト",
+	},
+
+	retreat: 0,
+	regulationMark: "C",
+	rarity: "Uncommon",
+	dexId: [94],
+};
+
+export default card;

--- a/data-asia/SM/SM10/034.ts
+++ b/data-asia/SM/SM10/034.ts
@@ -1,0 +1,49 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM10";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ドガース",
+	},
+
+	illustrator: "Mizue",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Psychic"],
+
+	description: {
+		ja: "薄い バルーン状の 体に 猛毒の ガスが つまっている。 近くに 来ると くさい。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "くさいにおい" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "おたがいのバトルポケモンをそれぞれこんらんにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 557389,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [109],
+};
+
+export default card;

--- a/data-asia/SM/SM10/035.ts
+++ b/data-asia/SM/SM10/035.ts
@@ -1,0 +1,64 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM10";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "マタドガス",
+	},
+
+	illustrator: "OOYAMA",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Psychic"],
+
+	description: {
+		ja: "どちらかが ふくらむと 片方は しぼむ 双子の ドガース。 いつも 体内の 毒ガスを 混ぜている。",
+	},
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "いのこりガス" },
+			effect: {
+				ja: "このポケモンがバトル場にいるかぎり、ポケモンチェックのたび、相手のたねポケモン全員に、それぞれダメカンを1個のせる。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "とびちるヘドロ" },
+			damage: 40,
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "ダメカンがのっている相手のベンチポケモン全員にも、それぞれ20ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 557390,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ドガース",
+	},
+
+	retreat: 3,
+	regulationMark: "C",
+	rarity: "Uncommon",
+	dexId: [110],
+};
+
+export default card;

--- a/data-asia/SM/SM10/036.ts
+++ b/data-asia/SM/SM10/036.ts
@@ -1,0 +1,60 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM10";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ミュウツー",
+	},
+
+	illustrator: "Shin Nagasawa",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Psychic"],
+
+	description: {
+		ja: "１人の 科学者が 何年も 恐ろしい 遺伝子 研究を 続けた 結果 誕生した。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "マインドリポート" },
+			effect: {
+				ja: "自分の番に、このカードを手札からベンチに出したとき、1回使える。自分のトラッシュにあるサポートを1枚、相手に見せてから、山札の上にもどす。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "サイコショック" },
+			damage: 70,
+			cost: ["Psychic", "Colorless", "Colorless"],
+			effect: {
+				ja: "このワザのダメージは、相手のバトルポケモンにかかっている効果を計算しない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 557391,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "C",
+	rarity: "Rare",
+	dexId: [150],
+};
+
+export default card;

--- a/data-asia/SM/SM10/037.ts
+++ b/data-asia/SM/SM10/037.ts
@@ -1,0 +1,59 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM10";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ミュウ",
+	},
+
+	illustrator: "sui",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Psychic"],
+
+	description: {
+		ja: "あらゆる 技を 使うため ポケモンの 先祖と 考える 学者が たくさん いる。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ベンチバリア" },
+			effect: {
+				ja: "このポケモンがいるかぎり、自分のベンチポケモン全員は、相手のワザのダメージを受けない。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "サイコパワー" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "ダメカン3個を、相手のポケモンに好きなようにのせる。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 557392,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Rare",
+	dexId: [151],
+};
+
+export default card;

--- a/data-asia/SM/SM10/038.ts
+++ b/data-asia/SM/SM10/038.ts
@@ -1,0 +1,49 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM10";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ムウマ",
+	},
+
+	illustrator: "Miki Tanaka",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Psychic"],
+
+	description: {
+		ja: "驚かせることが 生きがい。 首の 赤い玉に 耳を あてると 中から 悲鳴が 聞こえてくるぞ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ふきつなめ" },
+			cost: ["Psychic"],
+			effect: {
+				ja: "相手のポケモン1匹に、ダメカンを1個のせる。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 557393,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [200],
+};
+
+export default card;

--- a/data-asia/SM/SM10/039.ts
+++ b/data-asia/SM/SM10/039.ts
@@ -1,0 +1,64 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM10";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ムウマージ",
+	},
+
+	illustrator: "sui",
+	category: "Pokemon",
+	hp: 110,
+	types: ["Psychic"],
+
+	description: {
+		ja: "祟りや 呪いを 振りまくとして 恐れられて きた。 気まぐれに 人を助ける 呪文も 使う。",
+	},
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ふしぎなことづけ" },
+			effect: {
+				ja: "自分の番に1回使えて、使ったなら、このポケモンをきぜつさせる。自分の手札が7枚になるように、山札を引く。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "さいみんはどう" },
+			damage: 70,
+			cost: ["Psychic", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをねむりにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 557394,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ムウマ",
+	},
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Uncommon",
+	dexId: [429],
+};
+
+export default card;

--- a/data-asia/SM/SM10/040.ts
+++ b/data-asia/SM/SM10/040.ts
@@ -1,0 +1,56 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM10";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ニャスパー",
+	},
+
+	illustrator: "HYOGONOSUKE",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Psychic"],
+
+	description: {
+		ja: "強力な サイコパワーが 漏れ出さないように 放出する 器官を 耳で ふさいでいるのだ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ねこびより" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札を1枚引く。その後、このポケモンをねむりにする。",
+			},
+		},
+		{
+			name: { ja: "イヤーキネシス" },
+			cost: ["Psychic", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のベンチポケモン1匹に、そのポケモンにのっているダメカンの数x20ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 557395,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [677],
+};
+
+export default card;

--- a/data-asia/SM/SM10/041.ts
+++ b/data-asia/SM/SM10/041.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM10";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ニャオニクス",
+	},
+
+	illustrator: "Saya Tsuruta",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Psychic"],
+
+	description: {
+		ja: "危険が 迫ると 耳を 持ち上げ １０トン トラックを ひねりつぶす サイコパワーを 解放する。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "ねこびより" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札を3枚引く。その後、このポケモンをねむりにする。",
+			},
+		},
+		{
+			name: { ja: "まどわすひとみ" },
+			damage: 70,
+			cost: ["Psychic", "Colorless", "Colorless"],
+			effect: {
+				ja: "次の自分の番の終わりまで、このワザを受けたポケモンの弱点は[超]タイプになる。［弱点は「x2」でダメージ計算をする。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 557396,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ニャスパー",
+	},
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Uncommon",
+	dexId: [678],
+};
+
+export default card;

--- a/data-asia/SM/SM10/042.ts
+++ b/data-asia/SM/SM10/042.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM10";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "マーシャドー&カイリキーGX",
+	},
+
+	illustrator: "Mitsuhiro Arita",
+	category: "Pokemon",
+	hp: 270,
+	types: ["Fighting"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "リベンジ" },
+			damage: "30+",
+			cost: ["Fighting", "Colorless"],
+			effect: {
+				ja: "前の相手の番に、ワザのダメージで、自分のポケモンがきぜつしていたなら、90ダメージ追加。",
+			},
+		},
+		{
+			name: { ja: "ひゃくれつインパクト" },
+			damage: 160,
+			cost: ["Fighting", "Fighting", "Colorless"],
+		},
+		{
+			name: { ja: "ごうけつのきわみGX" },
+			damage: 200,
+			cost: ["Fighting", "Fighting", "Colorless"],
+			effect: {
+				ja: "追加でエネルギーが1個ついているなら、次の相手の番、このポケモンがワザのダメージを受けてきぜつするとき、このポケモンはきぜつせず、残りHPが「10」の状態で場に残る。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 557397,
+			},
+		},
+	],
+
+	retreat: 3,
+	regulationMark: "C",
+	rarity: "Double rare",
+	dexId: [802, 68],
+
+	suffix: "TAG TEAM-GX",
+};
+
+export default card;

--- a/data-asia/SM/SM10/043.ts
+++ b/data-asia/SM/SM10/043.ts
@@ -1,0 +1,57 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM10";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ディグダ",
+	},
+
+	illustrator: "Kouki Saitou",
+	category: "Pokemon",
+	hp: 50,
+	types: ["Fighting"],
+
+	description: {
+		ja: "地下に トンネルを 掘って 移動。 光が 嫌いなので 地上に 出てくるのは 日が 沈んでから。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ちかこうさく" },
+			effect: {
+				ja: "このポケモンが、「サカキの追放」の効果でトラッシュされたとき、相手の山札を上から1枚トラッシュする。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ひっかける" },
+			damage: 10,
+			cost: ["Fighting"],
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 557398,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [50],
+};
+
+export default card;

--- a/data-asia/SM/SM10/044.ts
+++ b/data-asia/SM/SM10/044.ts
@@ -1,0 +1,54 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM10";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ダグトリオ",
+	},
+
+	illustrator: "Akira Komayama",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Fighting"],
+
+	description: {
+		ja: "いつも 仲良しの ３つ子だが ごく まれに どの頭が 初めに エサを 食うかで 大ゲンカになる。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "ホームグランド" },
+			damage: "30+",
+			cost: ["Fighting"],
+			effect: {
+				ja: "場に自分のスタジアムが出ているなら、60ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 557399,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ディグダ",
+	},
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Uncommon",
+	dexId: [51],
+};
+
+export default card;

--- a/data-asia/SM/SM10/045.ts
+++ b/data-asia/SM/SM10/045.ts
@@ -1,0 +1,54 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM10";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "カラカラ",
+	},
+
+	illustrator: "Mizue",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Fighting"],
+
+	description: {
+		ja: "亡くした 母親を 思い 夜に 泣き叫ぶが そのせいで 天敵の バルジーナに 見つかってしまう。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "きあいだめ" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "次の自分の番、このポケモンの「たたく」のダメージは「80」になる。",
+			},
+		},
+		{
+			name: { ja: "たたく" },
+			damage: 10,
+			cost: ["Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 557400,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [104],
+};
+
+export default card;

--- a/data-asia/SM/SM10/046.ts
+++ b/data-asia/SM/SM10/046.ts
@@ -1,0 +1,62 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM10";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ガラガラ",
+	},
+
+	illustrator: "kirisAki",
+	category: "Pokemon",
+	hp: 110,
+	types: ["Fighting"],
+
+	description: {
+		ja: "ホネを 投げつけ バルジーナを 撃ち落す。 親の かたきを 討っていると 考えられている。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "ボーンラッシュ" },
+			damage: "50×",
+			cost: ["Fighting"],
+			effect: {
+				ja: "ウラが出るまでコインを投げ、オモテの数x50ダメージ。",
+			},
+		},
+		{
+			name: { ja: "アサルトブーム" },
+			damage: "70+",
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンに「ポケモンのどうぐ」がついているなら、70ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 557401,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "カラカラ",
+	},
+
+	retreat: 2,
+	regulationMark: "C",
+	rarity: "Uncommon",
+	dexId: [105],
+};
+
+export default card;

--- a/data-asia/SM/SM10/047.ts
+++ b/data-asia/SM/SM10/047.ts
@@ -1,0 +1,50 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM10";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "サイホーン",
+	},
+
+	illustrator: "sowsow",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Fighting"],
+
+	description: {
+		ja: "頭は 悪いが 力が 強く 高層ビルも 体当たりで コナゴナに 粉砕する。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "つきとばす" },
+			damage: 20,
+			cost: ["Fighting"],
+			effect: {
+				ja: "相手のバトルポケモンをベンチポケモンと入れ替える。［バトル場に出すポケモンは相手が選ぶ。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 557405,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [111],
+};
+
+export default card;

--- a/data-asia/SM/SM10/048.ts
+++ b/data-asia/SM/SM10/048.ts
@@ -1,0 +1,52 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM10";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "サイホーン",
+	},
+
+	illustrator: "otumami",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Fighting"],
+
+	description: {
+		ja: "頭は 悪いが 力が 強く 高層ビルも 体当たりで コナゴナに 粉砕する。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "つのでつく" },
+			damage: 30,
+			cost: ["Colorless", "Colorless"],
+		},
+		{
+			name: { ja: "ロックスマッシュ" },
+			damage: 80,
+			cost: ["Fighting", "Colorless", "Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 557406,
+			},
+		},
+	],
+
+	retreat: 4,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [111],
+};
+
+export default card;

--- a/data-asia/SM/SM10/049.ts
+++ b/data-asia/SM/SM10/049.ts
@@ -1,0 +1,58 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM10";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "サイドン",
+	},
+
+	illustrator: "kirisAki",
+	category: "Pokemon",
+	hp: 110,
+	types: ["Fighting"],
+
+	description: {
+		ja: "全身を よろいのような 皮膚で 守っている。 ２０００度の マグマの 中でも 生きられる。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "ダーティワーク" },
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "相手の山札を上から1枚トラッシュする。この番、手札から「サカキの追放」を出して使っていたなら、さらに4枚トラッシュする。",
+			},
+		},
+		{
+			name: { ja: "つのでつく" },
+			damage: 90,
+			cost: ["Fighting", "Colorless", "Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 557407,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "サイホーン",
+	},
+
+	retreat: 4,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [112],
+};
+
+export default card;

--- a/data-asia/SM/SM10/050.ts
+++ b/data-asia/SM/SM10/050.ts
@@ -1,0 +1,62 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM10";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ドサイドン",
+	},
+
+	illustrator: "kawayoo",
+	category: "Pokemon",
+	hp: 170,
+	types: ["Fighting"],
+
+	description: {
+		ja: "手のひらの 穴から イシツブテを 発射。 全身の プロテクターは 火山の 噴火にも 耐えられる。",
+	},
+
+	stage: "Stage2",
+
+	attacks: [
+		{
+			name: { ja: "どっしんキャノン" },
+			damage: 90,
+			cost: ["Fighting", "Colorless", "Colorless"],
+			effect: {
+				ja: "次の相手の番、このワザを受けたたねポケモンは、ワザが使えない。",
+			},
+		},
+		{
+			name: { ja: "グラウンドブレイク" },
+			damage: 160,
+			cost: ["Fighting", "Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "自分のベンチポケモン全員にも、それぞれ20ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 557408,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "サイドン",
+	},
+
+	retreat: 4,
+	regulationMark: "C",
+	rarity: "Uncommon",
+	dexId: [464],
+};
+
+export default card;

--- a/data-asia/SM/SM10/051.ts
+++ b/data-asia/SM/SM10/051.ts
@@ -1,0 +1,49 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM10";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "バルキー",
+	},
+
+	illustrator: "Mina Nakai",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Fighting"],
+
+	description: {
+		ja: "いつでも 元気いっぱい。 強くなるため 負けても 負けても 相手に 立ち向かっていく。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "わんぱくキック" },
+			effect: {
+				ja: "自分の番に1回使えて、使ったなら、自分の番は終わる。コインを1回投げオモテなら、相手のポケモン1匹に、ダメカンを3個のせる。",
+			},
+		},
+	],
+
+	weaknesses: [],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 557409,
+			},
+		},
+	],
+
+	retreat: 0,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [236],
+};
+
+export default card;

--- a/data-asia/SM/SM10/052.ts
+++ b/data-asia/SM/SM10/052.ts
@@ -1,0 +1,57 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM10";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ランドロス",
+	},
+
+	illustrator: "Hasuno",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Fighting"],
+
+	description: {
+		ja: "ランドロスが 訪れる 土地は 作物が たくさん 実るため 畑の神様 と 言われている。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ちょくげきだん" },
+			cost: ["Fighting"],
+			effect: {
+				ja: "相手のポケモン1匹に、30ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+			},
+		},
+		{
+			name: { ja: "パワーサイクロン" },
+			damage: 60,
+			cost: ["Fighting", "Colorless"],
+			effect: {
+				ja: "このポケモンについているエネルギーを1個、ベンチポケモンにつけ替える。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 557410,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Rare",
+	dexId: [645],
+};
+
+export default card;

--- a/data-asia/SM/SM10/053.ts
+++ b/data-asia/SM/SM10/053.ts
@@ -1,0 +1,55 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM10";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "マケンカニ",
+	},
+
+	illustrator: "Akira Komayama",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Fighting"],
+
+	description: {
+		ja: "硬い ハサミは 攻めも 守りも 得意。 マケンカニ 同士の 戦いは ボクシングの ようだ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "どつく" },
+			damage: 20,
+			cost: ["Colorless", "Colorless"],
+		},
+		{
+			name: { ja: "ナックルボンバー" },
+			damage: "30+",
+			cost: ["Fighting", "Colorless", "Colorless"],
+			effect: {
+				ja: "自分のサイドの残り枚数が、相手より多いなら、60ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 557411,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [739],
+};
+
+export default card;

--- a/data-asia/SM/SM10/054.ts
+++ b/data-asia/SM/SM10/054.ts
@@ -1,0 +1,59 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM10";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ケケンカニ",
+	},
+
+	illustrator: "Tomokazu Komiya",
+	category: "Pokemon",
+	hp: 140,
+	types: ["Fighting"],
+
+	description: {
+		ja: "ハサミの 中に 冷気を 溜めて ぶん殴る。 分厚い 氷の 壁も 粉々に してしまうぞ。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "ファイトアローン" },
+			damage: "30+",
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "自分の場のポケモンの数が、相手より少ないなら、その少ない数x50ダメージ追加。",
+			},
+		},
+		{
+			name: { ja: "マグナムパンチ" },
+			damage: 80,
+			cost: ["Fighting", "Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 557412,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "マケンカニ",
+	},
+
+	retreat: 4,
+	regulationMark: "C",
+	rarity: "Uncommon",
+	dexId: [740],
+};
+
+export default card;

--- a/data-asia/SM/SM10/055.ts
+++ b/data-asia/SM/SM10/055.ts
@@ -1,0 +1,49 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM10";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヤミカラス",
+	},
+
+	illustrator: "0313",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Darkness"],
+
+	description: {
+		ja: "光るものに 目が ない。 お宝を 求めて 宝石を ため込む ガバイトの 巣に 忍び込むことも。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "おどろかす" },
+			cost: ["Darkness"],
+			effect: {
+				ja: "相手の手札からオモテを見ないで1枚選び、そのカードのオモテを見てから、相手の山札にもどして切る。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 557413,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [198],
+};
+
+export default card;

--- a/data-asia/SM/SM10/056.ts
+++ b/data-asia/SM/SM10/056.ts
@@ -1,0 +1,69 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM10";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ドンカラスGX",
+	},
+
+	illustrator: "sadaji",
+	category: "Pokemon",
+	hp: 210,
+	types: ["Darkness"],
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "よるのしはいしゃ" },
+			effect: {
+				ja: "このポケモンがバトル場にいるかぎり、相手は手札から、「ポケモンのどうぐ」「特殊エネルギー」を出してつけられず「スタジアム」も出せない。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "フェザーストーム" },
+			damage: 90,
+			cost: ["Darkness", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のベンチにいる「ポケモンGX・EX」2匹にも、それぞれ30ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+			},
+		},
+		{
+			name: { ja: "アンフェアGX" },
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "相手の手札を見て、その中にあるカードを、2枚トラッシュする。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 557414,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ヤミカラス",
+	},
+
+	retreat: 2,
+	regulationMark: "C",
+	rarity: "Double rare",
+	dexId: [430],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM10/057.ts
+++ b/data-asia/SM/SM10/057.ts
@@ -1,0 +1,60 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM10";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ミカルゲ",
+	},
+
+	illustrator: "Kagemaru Himeno",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Darkness"],
+
+	description: {
+		ja: "１０８個の 魂が 集まって 生まれた ポケモン。 要石の ひび割れに つながれている。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "うらみだめ" },
+			effect: {
+				ja: "自分の番に1回使える。このポケモンにダメカンを1個のせる。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "くもんのさけび" },
+			damage: "10+",
+			cost: ["Darkness"],
+			effect: {
+				ja: "このポケモンにのっているダメカンの数x30ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 557415,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Rare",
+	dexId: [442],
+};
+
+export default card;

--- a/data-asia/SM/SM10/058.ts
+++ b/data-asia/SM/SM10/058.ts
@@ -1,0 +1,57 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM10";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "メグロコ",
+	},
+
+	illustrator: "Yuka Morii",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Darkness"],
+
+	description: {
+		ja: "年中 暖かい アローラは 過ごしやすい 環境。 砂漠 以外でも 時々 見かける。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "いかくのキバ" },
+			effect: {
+				ja: "このポケモンがバトル場にいるかぎり、相手のバトルポケモンが使うワザのダメージは、すべて「-20」される。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "かじる" },
+			damage: 10,
+			cost: ["Darkness"],
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 557416,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [551],
+};
+
+export default card;

--- a/data-asia/SM/SM10/059.ts
+++ b/data-asia/SM/SM10/059.ts
@@ -1,0 +1,50 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM10";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "メグロコ",
+	},
+
+	illustrator: "Akira Komayama",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Darkness"],
+
+	description: {
+		ja: "年中 暖かい アローラは 過ごしやすい 環境。 砂漠 以外でも 時々 見かける。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "いきがるキバ" },
+			damage: 30,
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "このワザのダメージで、相手のポケモンがきぜつしたなら、次の自分の番、このポケモンが使うワザの、相手のバトルポケモンへのダメージは「+120」される。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 557417,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [551],
+};
+
+export default card;

--- a/data-asia/SM/SM10/060.ts
+++ b/data-asia/SM/SM10/060.ts
@@ -1,0 +1,59 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM10";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ワルビル",
+	},
+
+	illustrator: "SATOSHI NAKAI",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Darkness"],
+
+	description: {
+		ja: "体が 冷えるのが とても 苦手。 気温が 下がる 晩には 砂漠の 砂の 奥深くに 潜っている。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "かみつく" },
+			damage: 20,
+			cost: ["Darkness"],
+		},
+		{
+			name: { ja: "おいつめる" },
+			damage: 50,
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "次の相手の番、このワザを受けたポケモンは、にげられない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 557418,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "メグロコ",
+	},
+
+	retreat: 2,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [552],
+};
+
+export default card;

--- a/data-asia/SM/SM10/061.ts
+++ b/data-asia/SM/SM10/061.ts
@@ -1,0 +1,62 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM10";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ワルビアル",
+	},
+
+	illustrator: "Anesaki Dynamic",
+	category: "Pokemon",
+	hp: 150,
+	types: ["Darkness"],
+
+	description: {
+		ja: "５０キロ 先に いる 獲物を 見つけると 砂漠を 泳ぐように 移動して 飛びかかり 噛みつく。",
+	},
+
+	stage: "Stage2",
+
+	attacks: [
+		{
+			name: { ja: "ガブガブパニック" },
+			damage: "50×",
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンのにげるためのエネルギーの数x50ダメージ。",
+			},
+		},
+		{
+			name: { ja: "かみくだく" },
+			damage: 100,
+			cost: ["Darkness", "Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンについているエネルギーを、1個トラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 557419,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ワルビル",
+	},
+
+	retreat: 3,
+	regulationMark: "C",
+	rarity: "Uncommon",
+	dexId: [553],
+};
+
+export default card;

--- a/data-asia/SM/SM10/062.ts
+++ b/data-asia/SM/SM10/062.ts
@@ -1,0 +1,50 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM10";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "プリン",
+	},
+
+	illustrator: "Yumi",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Fairy"],
+
+	description: {
+		ja: "デパートの 寝具コーナーには プリンの 不思議な 子守唄を 収録した ＣＤが 売られている。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "たまころがり" },
+			damage: "20×",
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "ウラが出るまでコインを投げ、オモテの数x20ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [{ type: "Darkness", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 557420,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [39],
+};
+
+export default card;

--- a/data-asia/SM/SM10/063.ts
+++ b/data-asia/SM/SM10/063.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM10";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "プクリン",
+	},
+
+	illustrator: "miki kudo",
+	category: "Pokemon",
+	hp: 110,
+	types: ["Fairy"],
+
+	description: {
+		ja: "弾力の ある ボディーと キメ細やかな 毛皮が 人気。 抱きしめて 寝ると 気持ちいい。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "たまをみがく" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分のトラッシュにあるエネルギーを3枚、相手に見せてから、手札に加える。",
+			},
+		},
+		{
+			name: { ja: "スリーピーボール" },
+			damage: 80,
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをねむりにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [{ type: "Darkness", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 557421,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "プリン",
+	},
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Uncommon",
+	dexId: [40],
+};
+
+export default card;

--- a/data-asia/SM/SM10/064.ts
+++ b/data-asia/SM/SM10/064.ts
@@ -1,0 +1,49 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM10";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ピィ",
+	},
+
+	illustrator: "Shibuzoh.",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Fairy"],
+
+	description: {
+		ja: "流れ星の 多い 夜に 群れ 輪になって ダンス。 その 姿を 見ると ちょっと いいことが あるよ。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "はりきりドロー" },
+			effect: {
+				ja: "自分の番に1回使えて、使ったなら、自分の番は終わる。コインを1回投げオモテなら、自分の手札をすべて山札にもどして切る。その後、山札を6枚引く。",
+			},
+		},
+	],
+
+	weaknesses: [],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 557422,
+			},
+		},
+	],
+
+	retreat: 0,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [173],
+};
+
+export default card;

--- a/data-asia/SM/SM10/065.ts
+++ b/data-asia/SM/SM10/065.ts
@@ -1,0 +1,50 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM10";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "モンメン",
+	},
+
+	illustrator: "Ken Sugimori",
+	category: "Pokemon",
+	hp: 50,
+	types: ["Fairy"],
+
+	description: {
+		ja: "綿を 飛ばして 身を 守る。 雨に 濡れると 綿が 湿って 重くなり 身動きが とれなくなる。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ふくらむ" },
+			damage: 10,
+			cost: ["Fairy"],
+			effect: {
+				ja: "次の相手の番、このポケモンが受けるワザのダメージは「-10」される。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [{ type: "Darkness", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 557423,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [546],
+};
+
+export default card;

--- a/data-asia/SM/SM10/066.ts
+++ b/data-asia/SM/SM10/066.ts
@@ -1,0 +1,69 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM10";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "エルフーンGX",
+	},
+
+	illustrator: "PLANETA Igarashi",
+	category: "Pokemon",
+	hp: 190,
+	types: ["Fairy"],
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ふわふわコットン" },
+			effect: {
+				ja: "このポケモンがワザのダメージを受けるとき、自分はコインを1回投げる。オモテなら、このポケモンはそのダメージを受けない。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "エナジーブロー" },
+			damage: "10+",
+			cost: ["Fairy"],
+			effect: {
+				ja: "このポケモンについているエネルギーの数x30ダメージ追加。",
+			},
+		},
+		{
+			name: { ja: "トイボックスGX" },
+			cost: ["Fairy"],
+			effect: {
+				ja: "自分の山札にある好きなカードを5枚まで、手札に加える。そして山札を切る。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [{ type: "Darkness", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 557424,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "モンメン",
+	},
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Double rare",
+	dexId: [547],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM10/067.ts
+++ b/data-asia/SM/SM10/067.ts
@@ -1,0 +1,54 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM10";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ニャース",
+	},
+
+	illustrator: "Shibuzoh.",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Colorless"],
+
+	description: {
+		ja: "ゴミ捨て場に いくと ひかりものを 巡って ヤミカラスと 激しく ケンカする 光景が 見られる。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ねこびより" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札を2枚引く。その後、このポケモンをねむりにする。",
+			},
+		},
+		{
+			name: { ja: "しっぽではたく" },
+			damage: 30,
+			cost: ["Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 557425,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [52],
+};
+
+export default card;

--- a/data-asia/SM/SM10/068.ts
+++ b/data-asia/SM/SM10/068.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM10";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ペルシアン",
+	},
+
+	illustrator: "nagimiso",
+	category: "Pokemon",
+	hp: 100,
+	types: ["Colorless"],
+
+	description: {
+		ja: "アローラの ペルシアンとは 額の 宝石の色が 違って 見えるが 成分は あまり 変わらないのだ。",
+	},
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ねこのしゅうかい" },
+			effect: {
+				ja: "このポケモンがいるかぎり、自分の場にいるワザ「ねこびより」を持つポケモンが使うワザに必要なエネルギーは、すべてなくなる。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ツメできりさく" },
+			damage: 90,
+			cost: ["Colorless", "Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 557426,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ニャース",
+	},
+
+	retreat: 0,
+	regulationMark: "C",
+	rarity: "Uncommon",
+	dexId: [53],
+};
+
+export default card;

--- a/data-asia/SM/SM10/069.ts
+++ b/data-asia/SM/SM10/069.ts
@@ -1,0 +1,70 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM10";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ペルシアンGX",
+	},
+
+	illustrator: "PLANETA Igarashi",
+	category: "Pokemon",
+	hp: 200,
+	types: ["Colorless"],
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "キャットウォーク" },
+			effect: {
+				ja: "前の相手の番に、自分の「ポケモンGX・EX」がきぜつしていたなら、自分の番に1回使える。自分の山札にある好きなカードを2枚まで、手札に加える。そして山札を切る。この番、すでに別の「キャットウォーク」を使っていたなら、この特性は使えない。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ふくしゅう" },
+			damage: "10+",
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "自分のトラッシュにあるポケモンの枚数x20ダメージ追加。追加できるダメージはポケモン9枚ぶんまで。",
+			},
+		},
+		{
+			name: { ja: "スラッシュバックGX" },
+			damage: 150,
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンをベンチポケモンと入れ替える。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 557427,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ニャース",
+	},
+
+	retreat: 2,
+	regulationMark: "C",
+	rarity: "Double rare",
+	dexId: [53],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM10/070.ts
+++ b/data-asia/SM/SM10/070.ts
@@ -1,0 +1,55 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM10";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ドードー",
+	},
+
+	illustrator: "kodama",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Colorless"],
+
+	description: {
+		ja: "突然変異で 見つかった ２つの 頭を 持つ ポケモン。 時速１００キロで 走る。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "つつく" },
+			damage: 10,
+			cost: ["Colorless"],
+		},
+		{
+			name: { ja: "にどつつき" },
+			damage: "20×",
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "コインを2回投げ、オモテの数x20ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 557428,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [84],
+};
+
+export default card;

--- a/data-asia/SM/SM10/071.ts
+++ b/data-asia/SM/SM10/071.ts
@@ -1,0 +1,62 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM10";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ドードリオ",
+	},
+
+	illustrator: "Misa Tsutsui",
+	category: "Pokemon",
+	hp: 100,
+	types: ["Colorless"],
+
+	description: {
+		ja: "３つの 頭が 見ている前で わずかでも すきを 見せると クチバシで 激しく つつかれる。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "トライアタック" },
+			damage: "60×",
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "コインを3回投げ、オモテの数x60ダメージ。",
+			},
+		},
+		{
+			name: { ja: "かそくづき" },
+			damage: 90,
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "次の自分の番、このポケモンは「かそくづき」が使えない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 557429,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ドードー",
+	},
+
+	retreat: 0,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [85],
+};
+
+export default card;

--- a/data-asia/SM/SM10/072.ts
+++ b/data-asia/SM/SM10/072.ts
@@ -1,0 +1,54 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM10";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ポリゴン",
+	},
+
+	illustrator: "Ayaka Yoshida",
+	category: "Pokemon",
+	hp: 50,
+	types: ["Colorless"],
+
+	description: {
+		ja: "約２０年前の 科学力で 生み出された ポケモンなので 今や 時代遅れな 部分も 多い。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "デジチャージ" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "コインを3回投げ、オモテの数ぶんまで、自分の山札にあるエネルギーを、相手に見せてから、手札に加える。そして山札を切る。",
+			},
+		},
+		{
+			name: { ja: "とがる" },
+			damage: 10,
+			cost: ["Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 557430,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [137],
+};
+
+export default card;

--- a/data-asia/SM/SM10/073.ts
+++ b/data-asia/SM/SM10/073.ts
@@ -1,0 +1,54 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM10";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ポリゴン",
+	},
+
+	illustrator: "Suwama Chiaki",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Colorless"],
+
+	description: {
+		ja: "約２０年前の 科学力で 生み出された ポケモンなので 今や 時代遅れな 部分も 多い。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "クイックドロー" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札を1枚引く。",
+			},
+		},
+		{
+			name: { ja: "ぶつかる" },
+			damage: 20,
+			cost: ["Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 557431,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [137],
+};
+
+export default card;

--- a/data-asia/SM/SM10/074.ts
+++ b/data-asia/SM/SM10/074.ts
@@ -1,0 +1,58 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM10";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ポリゴン2",
+	},
+
+	illustrator: "sowsow",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Colorless"],
+
+	description: {
+		ja: "ＡＩを 搭載。 自力で 様々なことを 学んでいくが 余計なことまで 覚えだす。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "ダブルドロー" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札を2枚引く。",
+			},
+		},
+		{
+			name: { ja: "かいてんアタック" },
+			damage: 30,
+			cost: ["Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 557432,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ポリゴン",
+	},
+
+	retreat: 2,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [233],
+};
+
+export default card;

--- a/data-asia/SM/SM10/075.ts
+++ b/data-asia/SM/SM10/075.ts
@@ -1,0 +1,64 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM10";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ポリゴンZ",
+	},
+
+	illustrator: "Misa Tsutsui",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Colorless"],
+
+	description: {
+		ja: "不安定な 挙動が 目立つ。 プログラムを アップデートした 技術者の 腕の せいらしい。",
+	},
+
+	stage: "Stage2",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "クレイジーコード" },
+			effect: {
+				ja: "自分の番に何回でも使える。自分の手札にある特殊エネルギーを1枚、自分のポケモンにつける。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "あばれまわる" },
+			damage: 120,
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンをこんらんにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 557433,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ポリゴン２",
+	},
+
+	retreat: 2,
+	regulationMark: "C",
+	rarity: "Rare",
+	dexId: [474],
+};
+
+export default card;

--- a/data-asia/SM/SM10/076.ts
+++ b/data-asia/SM/SM10/076.ts
@@ -1,0 +1,60 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM10";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "カビゴン",
+	},
+
+	illustrator: "kanahei",
+	category: "Pokemon",
+	hp: 150,
+	types: ["Colorless"],
+
+	description: {
+		ja: "食うか 寝るかしか していないが なにかの きっかけで 本気を出すと 凄い パワーを 発揮するらしい。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ながらぐい" },
+			effect: {
+				ja: "ポケモンチェックのたび、このポケモンのHPを「10」回復する。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ビッグカウンター" },
+			damage: "60+",
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンが「TAG TEAM」なら、120ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 557434,
+			},
+		},
+	],
+
+	retreat: 4,
+	regulationMark: "C",
+	rarity: "Rare",
+	dexId: [143],
+};
+
+export default card;

--- a/data-asia/SM/SM10/077.ts
+++ b/data-asia/SM/SM10/077.ts
@@ -1,0 +1,49 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM10";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ピンプク",
+	},
+
+	illustrator: "Eri Yamaki",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Colorless"],
+
+	description: {
+		ja: "大人しい ポケモンだが お腹の 丸い 石を 取り上げると 泣いて 騒いで 大暴れ。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ままごとヒール" },
+			effect: {
+				ja: "自分の番に1回使えて、使ったなら、自分の番は終わる。コインを1回投げオモテなら、自分のポケモン1匹のHPを「60」回復する。",
+			},
+		},
+	],
+
+	weaknesses: [],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 557435,
+			},
+		},
+	],
+
+	retreat: 0,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [440],
+};
+
+export default card;

--- a/data-asia/SM/SM10/078.ts
+++ b/data-asia/SM/SM10/078.ts
@@ -1,0 +1,57 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM10";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ペラップ",
+	},
+
+	illustrator: "HYOGONOSUKE",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Colorless"],
+
+	description: {
+		ja: "相手と 同じ 鳴き声を 出す ことで 仲間と 思いこませて 襲われないように しているのだ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ものまね" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の手札をすべて山札にもどして切る。その後、相手の手札の枚数ぶん、自分の山札を引く。",
+			},
+		},
+		{
+			name: { ja: "おんち" },
+			damage: 10,
+			cost: ["Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをこんらんにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 557436,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [441],
+};
+
+export default card;

--- a/data-asia/SM/SM10/079.ts
+++ b/data-asia/SM/SM10/079.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM10";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "あなぬけのヒモ",
+	},
+
+	illustrator: "Toyste Beach",
+	category: "Trainer",
+
+	effect: {
+		ja: "おたがいのプレイヤーは、それぞれ、自分のバトルポケモンをベンチポケモンと入れ替える。（入れ替えは相手からおこない、ベンチがいないプレイヤーは、入れ替えをしない。）",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 557437,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	regulationMark: "A",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM10/080.ts
+++ b/data-asia/SM/SM10/080.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM10";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ザクザクピッケル",
+	},
+
+	illustrator: "Yoshinobu Saito",
+	category: "Trainer",
+
+	effect: {
+		ja: "相手の山札を上から3枚見て、その中から好きなカードを1枚選ぶ。残りのカードを山札にもどして切り、選んだカードを山札の上にもどす。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 557438,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	regulationMark: "C",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM10/081.ts
+++ b/data-asia/SM/SM10/081.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM10";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ハイパーボール",
+	},
+
+	illustrator: "Ryo Ueda",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードは、自分の手札を2枚トラッシュしなければ使えない。自分の山札からポケモンを1枚選び、相手に見せてから、手札に加える。そして山札を切る。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 557439,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	regulationMark: "A",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM10/082.ts
+++ b/data-asia/SM/SM10/082.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM10";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ふしぎなアメ",
+	},
+
+	illustrator: "Toyste Beach",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分のたねポケモン1匹から進化する1進化の上の2進化ポケモンを、手札から1枚選び、そのたねポケモンにのせて進化させる。[最初の自分の番と、この番出したばかりのたねポケモンには使えない。]",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 557440,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	regulationMark: "A",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM10/083.ts
+++ b/data-asia/SM/SM10/083.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM10";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "炎の結晶",
+	},
+
+	illustrator: "Yoshinobu Saito",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分のトラッシュにある[炎]エネルギーを3枚、相手に見せてから、手札に加える。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 557441,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	regulationMark: "C",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM10/084.ts
+++ b/data-asia/SM/SM10/084.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM10";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "やみのいし",
+	},
+
+	illustrator: "Ryo Ueda",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の場に「ムウマージ」「ドンカラス」「シャンデラ」「ギルガルド」（GXをふくむ）に進化できるポケモンがいるなら、その進化カードを、自分の山札から1枚選び、そのポケモンにのせて進化させる。そして山札を切る。（最初の自分の番や、出したばかりのポケモンにも使える。）",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 557442,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	regulationMark: "C",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM10/085.ts
+++ b/data-asia/SM/SM10/085.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM10";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "サカキの追放",
+	},
+
+	illustrator: "Megumi Mizutani",
+	category: "Trainer",
+
+	effect: {
+		ja: "ダメカンがのっていない自分のベンチポケモンを2匹まで選び、選んだポケモンと、ついているすべてのカードを、トラッシュする。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 557443,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "C",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM10/086.ts
+++ b/data-asia/SM/SM10/086.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM10";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ポケモンだいすきクラブ",
+	},
+
+	illustrator: "Sanosuke Sakuma",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の山札からたねポケモンを2枚まで選び、相手に見せてから、手札に加える。そして山札を切る。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 557444,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "B",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM10/087.ts
+++ b/data-asia/SM/SM10/087.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM10";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "溶接工",
+	},
+
+	illustrator: "Hitoshi Ariga",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の手札にある[炎]エネルギーを2枚まで、自分のポケモン1匹につける。その後、自分の山札を3枚引く。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 557445,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "C",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM10/088.ts
+++ b/data-asia/SM/SM10/088.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM10";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "レッドの挑戦",
+	},
+
+	illustrator: "Megumi Mizutani",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードは、自分の手札を2枚トラッシュしなければ使えない。自分の山札にある好きなカードを1枚、手札に加える。そして山札を切る。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 557446,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "C",
+	rarity: "Rare",
+};
+
+export default card;

--- a/data-asia/SM/SM10/089.ts
+++ b/data-asia/SM/SM10/089.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM10";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "格闘道場",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Trainer",
+
+	effect: {
+		ja: "おたがいの基本[闘]エネルギーがついているポケモン（「ウルトラビースト」をのぞく）が使うワザの、相手のバトルポケモンへのダメージは「+10」され、自分のサイドの残り枚数が、相手より多いなら「+40」になる。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 557447,
+			},
+		},
+	],
+
+	trainerType: "Stadium",
+	regulationMark: "C",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM10/090.ts
+++ b/data-asia/SM/SM10/090.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM10";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ダストアイランド",
+	},
+
+	illustrator: "Ryo Ueda",
+	category: "Trainer",
+
+	effect: {
+		ja: "おたがいのプレイヤーが、自分のどくのバトルポケモンをトレーナーズの効果でベンチポケモンと入れ替えたとき、新しく出てきたポケモンが、そのどくを引きつぐ。（どくでのせるダメカンの数が増えているなら、その数も引きつぐ。）",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 557448,
+			},
+		},
+	],
+
+	trainerType: "Stadium",
+	regulationMark: "C",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM10/091.ts
+++ b/data-asia/SM/SM10/091.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM10";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "トリプル加速エネルギー",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Energy",
+	energyType: "Special",
+
+	effect: {
+		ja: "このカードは、進化ポケモンにしかつけられず、つけた番の終わりにトラッシュする。このカードはポケモンについているかぎり[無]エネルギー3個ぶんとしてはたらく。（このカードが進化ポケモン以外についているなら、トラッシュする。）",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 557449,
+			},
+		},
+	],
+
+	regulationMark: "C",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM10/092.ts
+++ b/data-asia/SM/SM10/092.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM10";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "火打石",
+	},
+
+	illustrator: "Yoshinobu Saito",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードは、自分の手札を2枚トラッシュしなければ使えない。自分の山札にある[炎]エネルギーを4枚まで、相手に見せてから、手札に加える。そして山札を切る。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 557450,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	regulationMark: "B",
+	rarity: "Rare Holo",
+};
+
+export default card;

--- a/data-asia/SM/SM10/093.ts
+++ b/data-asia/SM/SM10/093.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM10";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "レスキュータンカ",
+	},
+
+	illustrator: "Yoshinobu Saito",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分のトラッシュにあるポケモンを1枚、相手に見せてから、手札に加える。または、自分のトラッシュにあるポケモンを3枚、相手に見せてから、山札にもどして切る。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 557451,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	regulationMark: "A",
+	rarity: "Rare Holo",
+};
+
+export default card;

--- a/data-asia/SM/SM10/094.ts
+++ b/data-asia/SM/SM10/094.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM10";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "カキ",
+	},
+
+	illustrator: "Masakazu Fukuda",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードを使ったら、自分の番は終わる。自分の山札にある[炎]エネルギーを4枚まで、自分のポケモン1匹につける。そして山札を切る。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 557452,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "A",
+	rarity: "Rare Holo",
+};
+
+export default card;

--- a/data-asia/SM/SM10/095.ts
+++ b/data-asia/SM/SM10/095.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM10";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "シロナ",
+	},
+
+	illustrator: "Hideki Ishikawa",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の手札をすべて山札にもどして切る。その後、山札を6枚引く。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 557453,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "B",
+	rarity: "Rare Holo",
+};
+
+export default card;

--- a/data-asia/SM/SM10/096.ts
+++ b/data-asia/SM/SM10/096.ts
@@ -1,0 +1,64 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM10";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "レシラム&リザードンGX",
+	},
+
+	illustrator: "aky CG Works",
+	category: "Pokemon",
+	hp: 270,
+	types: ["Fire"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "げきりん" },
+			damage: "30+",
+			cost: ["Fire", "Colorless"],
+			effect: {
+				ja: "このポケモンにのっているダメカンの数x10ダメージ追加。",
+			},
+		},
+		{
+			name: { ja: "フレアストライク" },
+			damage: 230,
+			cost: ["Fire", "Fire", "Fire", "Colorless"],
+			effect: {
+				ja: "次の自分の番、このポケモンは「フレアストライク」が使えない。",
+			},
+		},
+		{
+			name: { ja: "ダブルブレイズGX" },
+			damage: "200+",
+			cost: ["Fire", "Fire", "Fire"],
+			effect: {
+				ja: "追加で[炎]エネルギーが3個ついているなら、100ダメージ追加。その場合、このワザのダメージは、相手のバトルポケモンにかかっている効果を計算しない。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 557454,
+			},
+		},
+	],
+
+	retreat: 3,
+	regulationMark: "C",
+	rarity: "Ultra Rare",
+	dexId: [643, 6],
+
+	suffix: "TAG TEAM-GX",
+};
+
+export default card;

--- a/data-asia/SM/SM10/097.ts
+++ b/data-asia/SM/SM10/097.ts
@@ -1,0 +1,64 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM10";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "レシラム&リザードンGX",
+	},
+
+	illustrator: "Ryota Murayama",
+	category: "Pokemon",
+	hp: 270,
+	types: ["Fire"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "げきりん" },
+			damage: "30+",
+			cost: ["Fire", "Colorless"],
+			effect: {
+				ja: "このポケモンにのっているダメカンの数x10ダメージ追加。",
+			},
+		},
+		{
+			name: { ja: "フレアストライク" },
+			damage: 230,
+			cost: ["Fire", "Fire", "Fire", "Colorless"],
+			effect: {
+				ja: "次の自分の番、このポケモンは「フレアストライク」が使えない。",
+			},
+		},
+		{
+			name: { ja: "ダブルブレイズGX" },
+			damage: "200+",
+			cost: ["Fire", "Fire", "Fire"],
+			effect: {
+				ja: "追加で[炎]エネルギーが3個ついているなら、100ダメージ追加。その場合、このワザのダメージは、相手のバトルポケモンにかかっている効果を計算しない。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 557455,
+			},
+		},
+	],
+
+	retreat: 3,
+	regulationMark: "C",
+	rarity: "Ultra Rare",
+	dexId: [643, 6],
+
+	suffix: "TAG TEAM-GX",
+};
+
+export default card;

--- a/data-asia/SM/SM10/098.ts
+++ b/data-asia/SM/SM10/098.ts
@@ -1,0 +1,62 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM10";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ベトベトン&アローラベトベトンGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 270,
+	types: ["Psychic"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "バッドポイズン" },
+			cost: ["Psychic", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをどくにする。このどくでのせるダメカンの数は8個になる。",
+			},
+		},
+		{
+			name: { ja: "どくしゃぶり" },
+			damage: 120,
+			cost: ["Psychic", "Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンがどくなら、このポケモンのHPを「100」回復する。",
+			},
+		},
+		{
+			name: { ja: "ベトベトミックスGX" },
+			cost: [],
+			effect: {
+				ja: "相手のバトルポケモンをどくとマヒにする。追加でエネルギーが4個ついているなら、このどくでのせるダメカンの数は15個になる。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 557456,
+			},
+		},
+	],
+
+	retreat: 4,
+	regulationMark: "C",
+	rarity: "Ultra Rare",
+	dexId: [89, 89],
+
+	suffix: "TAG TEAM-GX",
+};
+
+export default card;

--- a/data-asia/SM/SM10/099.ts
+++ b/data-asia/SM/SM10/099.ts
@@ -1,0 +1,62 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM10";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ベトベトン&アローラベトベトンGX",
+	},
+
+	illustrator: "Masakazu Fukuda",
+	category: "Pokemon",
+	hp: 270,
+	types: ["Psychic"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "バッドポイズン" },
+			cost: ["Psychic", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをどくにする。このどくでのせるダメカンの数は8個になる。",
+			},
+		},
+		{
+			name: { ja: "どくしゃぶり" },
+			damage: 120,
+			cost: ["Psychic", "Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンがどくなら、このポケモンのHPを「100」回復する。",
+			},
+		},
+		{
+			name: { ja: "ベトベトミックスGX" },
+			cost: [],
+			effect: {
+				ja: "相手のバトルポケモンをどくとマヒにする。追加でエネルギーが4個ついているなら、このどくでのせるダメカンの数は15個になる。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 557457,
+			},
+		},
+	],
+
+	retreat: 4,
+	regulationMark: "C",
+	rarity: "Ultra Rare",
+	dexId: [89, 89],
+
+	suffix: "TAG TEAM-GX",
+};
+
+export default card;

--- a/data-asia/SM/SM10/100.ts
+++ b/data-asia/SM/SM10/100.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM10";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "マーシャドー&カイリキーGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 270,
+	types: ["Fighting"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "リベンジ" },
+			damage: "30+",
+			cost: ["Fighting", "Colorless"],
+			effect: {
+				ja: "前の相手の番に、ワザのダメージで、自分のポケモンがきぜつしていたなら、90ダメージ追加。",
+			},
+		},
+		{
+			name: { ja: "ひゃくれつインパクト" },
+			damage: 160,
+			cost: ["Fighting", "Fighting", "Colorless"],
+		},
+		{
+			name: { ja: "ごうけつのきわみGX" },
+			damage: 200,
+			cost: ["Fighting", "Fighting", "Colorless"],
+			effect: {
+				ja: "追加でエネルギーが1個ついているなら、次の相手の番、このポケモンがワザのダメージを受けてきぜつするとき、このポケモンはきぜつせず、残りHPが「10」の状態で場に残る。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 557458,
+			},
+		},
+	],
+
+	retreat: 3,
+	regulationMark: "C",
+	rarity: "Ultra Rare",
+	dexId: [802, 68],
+
+	suffix: "TAG TEAM-GX",
+};
+
+export default card;

--- a/data-asia/SM/SM10/101.ts
+++ b/data-asia/SM/SM10/101.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM10";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "マーシャドー&カイリキーGX",
+	},
+
+	illustrator: "You Iribi",
+	category: "Pokemon",
+	hp: 270,
+	types: ["Fighting"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "リベンジ" },
+			damage: "30+",
+			cost: ["Fighting", "Colorless"],
+			effect: {
+				ja: "前の相手の番に、ワザのダメージで、自分のポケモンがきぜつしていたなら、90ダメージ追加。",
+			},
+		},
+		{
+			name: { ja: "ひゃくれつインパクト" },
+			damage: 160,
+			cost: ["Fighting", "Fighting", "Colorless"],
+		},
+		{
+			name: { ja: "ごうけつのきわみGX" },
+			damage: 200,
+			cost: ["Fighting", "Fighting", "Colorless"],
+			effect: {
+				ja: "追加でエネルギーが1個ついているなら、次の相手の番、このポケモンがワザのダメージを受けてきぜつするとき、このポケモンはきぜつせず、残りHPが「10」の状態で場に残る。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 557459,
+			},
+		},
+	],
+
+	retreat: 3,
+	regulationMark: "C",
+	rarity: "Ultra Rare",
+	dexId: [802, 68],
+
+	suffix: "TAG TEAM-GX",
+};
+
+export default card;

--- a/data-asia/SM/SM10/102.ts
+++ b/data-asia/SM/SM10/102.ts
@@ -1,0 +1,69 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM10";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ドンカラスGX",
+	},
+
+	illustrator: "sadaji",
+	category: "Pokemon",
+	hp: 210,
+	types: ["Darkness"],
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "よるのしはいしゃ" },
+			effect: {
+				ja: "このポケモンがバトル場にいるかぎり、相手は手札から、「ポケモンのどうぐ」「特殊エネルギー」を出してつけられず「スタジアム」も出せない。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "フェザーストーム" },
+			damage: 90,
+			cost: ["Darkness", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のベンチにいる「ポケモンGX・EX」2匹にも、それぞれ30ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+			},
+		},
+		{
+			name: { ja: "アンフェアGX" },
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "相手の手札を見て、その中にあるカードを、2枚トラッシュする。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 557460,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ヤミカラス",
+	},
+
+	retreat: 2,
+	regulationMark: "C",
+	rarity: "Ultra Rare",
+	dexId: [430],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM10/103.ts
+++ b/data-asia/SM/SM10/103.ts
@@ -1,0 +1,69 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM10";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "エルフーンGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 190,
+	types: ["Fairy"],
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ふわふわコットン" },
+			effect: {
+				ja: "このポケモンがワザのダメージを受けるとき、自分はコインを1回投げる。オモテなら、このポケモンはそのダメージを受けない。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "エナジーブロー" },
+			damage: "10+",
+			cost: ["Fairy"],
+			effect: {
+				ja: "このポケモンについているエネルギーの数x30ダメージ追加。",
+			},
+		},
+		{
+			name: { ja: "トイボックスGX" },
+			cost: ["Fairy"],
+			effect: {
+				ja: "自分の山札にある好きなカードを5枚まで、手札に加える。そして山札を切る。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [{ type: "Darkness", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 557461,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "モンメン",
+	},
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Ultra Rare",
+	dexId: [547],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM10/104.ts
+++ b/data-asia/SM/SM10/104.ts
@@ -1,0 +1,70 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM10";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ペルシアンGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 200,
+	types: ["Colorless"],
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "キャットウォーク" },
+			effect: {
+				ja: "前の相手の番に、自分の「ポケモンGX・EX」がきぜつしていたなら、自分の番に1回使える。自分の山札にある好きなカードを2枚まで、手札に加える。そして山札を切る。この番、すでに別の「キャットウォーク」を使っていたなら、この特性は使えない。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ふくしゅう" },
+			damage: "10+",
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "自分のトラッシュにあるポケモンの枚数x20ダメージ追加。追加できるダメージはポケモン9枚ぶんまで。",
+			},
+		},
+		{
+			name: { ja: "スラッシュバックGX" },
+			damage: 150,
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンをベンチポケモンと入れ替える。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 557462,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ニャース",
+	},
+
+	retreat: 2,
+	regulationMark: "C",
+	rarity: "Ultra Rare",
+	dexId: [53],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM10/105.ts
+++ b/data-asia/SM/SM10/105.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM10";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "サカキの追放",
+	},
+
+	illustrator: "TOKIYA",
+	category: "Trainer",
+
+	effect: {
+		ja: "ダメカンがのっていない自分のベンチポケモンを2匹まで選び、選んだポケモンと、ついているすべてのカードを、トラッシュする。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 557463,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "C",
+	rarity: "Ultra Rare",
+};
+
+export default card;

--- a/data-asia/SM/SM10/106.ts
+++ b/data-asia/SM/SM10/106.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM10";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "溶接工",
+	},
+
+	illustrator: "Hitoshi Ariga",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の手札にある[炎]エネルギーを2枚まで、自分のポケモン1匹につける。その後、自分の山札を3枚引く。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 557464,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "C",
+	rarity: "Ultra Rare",
+};
+
+export default card;

--- a/data-asia/SM/SM10/107.ts
+++ b/data-asia/SM/SM10/107.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM10";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "レッドの挑戦",
+	},
+
+	illustrator: "Naoki Saito",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードは、自分の手札を2枚トラッシュしなければ使えない。自分の山札にある好きなカードを1枚、手札に加える。そして山札を切る。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 557465,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "C",
+	rarity: "Ultra Rare",
+};
+
+export default card;

--- a/data-asia/SM/SM10/108.ts
+++ b/data-asia/SM/SM10/108.ts
@@ -1,0 +1,64 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM10";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "レシラム&リザードンGX",
+	},
+
+	illustrator: "",
+	category: "Pokemon",
+	hp: 270,
+	types: ["Fire"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "げきりん" },
+			damage: "30+",
+			cost: ["Fire", "Colorless"],
+			effect: {
+				ja: "このポケモンにのっているダメカンの数x10ダメージ追加。",
+			},
+		},
+		{
+			name: { ja: "フレアストライク" },
+			damage: 230,
+			cost: ["Fire", "Fire", "Fire", "Colorless"],
+			effect: {
+				ja: "次の自分の番、このポケモンは「フレアストライク」が使えない。",
+			},
+		},
+		{
+			name: { ja: "ダブルブレイズGX" },
+			damage: "200+",
+			cost: ["Fire", "Fire", "Fire"],
+			effect: {
+				ja: "追加で[炎]エネルギーが3個ついているなら、100ダメージ追加。その場合、このワザのダメージは、相手のバトルポケモンにかかっている効果を計算しない。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 557466,
+			},
+		},
+	],
+
+	retreat: 3,
+	regulationMark: "C",
+	rarity: "Hyper rare",
+	dexId: [643, 6],
+
+	suffix: "TAG TEAM-GX",
+};
+
+export default card;

--- a/data-asia/SM/SM10/109.ts
+++ b/data-asia/SM/SM10/109.ts
@@ -1,0 +1,62 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM10";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ベトベトン&アローラベトベトンGX",
+	},
+
+	illustrator: "",
+	category: "Pokemon",
+	hp: 270,
+	types: ["Psychic"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "バッドポイズン" },
+			cost: ["Psychic", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをどくにする。このどくでのせるダメカンの数は8個になる。",
+			},
+		},
+		{
+			name: { ja: "どくしゃぶり" },
+			damage: 120,
+			cost: ["Psychic", "Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンがどくなら、このポケモンのHPを「100」回復する。",
+			},
+		},
+		{
+			name: { ja: "ベトベトミックスGX" },
+			cost: [],
+			effect: {
+				ja: "相手のバトルポケモンをどくとマヒにする。追加でエネルギーが4個ついているなら、このどくでのせるダメカンの数は15個になる。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 557467,
+			},
+		},
+	],
+
+	retreat: 4,
+	regulationMark: "C",
+	rarity: "Hyper rare",
+	dexId: [89, 89],
+
+	suffix: "TAG TEAM-GX",
+};
+
+export default card;

--- a/data-asia/SM/SM10/110.ts
+++ b/data-asia/SM/SM10/110.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM10";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "マーシャドー&カイリキーGX",
+	},
+
+	illustrator: "",
+	category: "Pokemon",
+	hp: 270,
+	types: ["Fighting"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "リベンジ" },
+			damage: "30+",
+			cost: ["Fighting", "Colorless"],
+			effect: {
+				ja: "前の相手の番に、ワザのダメージで、自分のポケモンがきぜつしていたなら、90ダメージ追加。",
+			},
+		},
+		{
+			name: { ja: "ひゃくれつインパクト" },
+			damage: 160,
+			cost: ["Fighting", "Fighting", "Colorless"],
+		},
+		{
+			name: { ja: "ごうけつのきわみGX" },
+			damage: 200,
+			cost: ["Fighting", "Fighting", "Colorless"],
+			effect: {
+				ja: "追加でエネルギーが1個ついているなら、次の相手の番、このポケモンがワザのダメージを受けてきぜつするとき、このポケモンはきぜつせず、残りHPが「10」の状態で場に残る。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 557468,
+			},
+		},
+	],
+
+	retreat: 3,
+	regulationMark: "C",
+	rarity: "Hyper rare",
+	dexId: [802, 68],
+
+	suffix: "TAG TEAM-GX",
+};
+
+export default card;

--- a/data-asia/SM/SM10/111.ts
+++ b/data-asia/SM/SM10/111.ts
@@ -1,0 +1,69 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM10";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ドンカラスGX",
+	},
+
+	illustrator: "",
+	category: "Pokemon",
+	hp: 210,
+	types: ["Darkness"],
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "よるのしはいしゃ" },
+			effect: {
+				ja: "このポケモンがバトル場にいるかぎり、相手は手札から、「ポケモンのどうぐ」「特殊エネルギー」を出してつけられず「スタジアム」も出せない。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "フェザーストーム" },
+			damage: 90,
+			cost: ["Darkness", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のベンチにいる「ポケモンGX・EX」2匹にも、それぞれ30ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+			},
+		},
+		{
+			name: { ja: "アンフェアGX" },
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "相手の手札を見て、その中にあるカードを、2枚トラッシュする。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 557469,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ヤミカラス",
+	},
+
+	retreat: 2,
+	regulationMark: "C",
+	rarity: "Hyper rare",
+	dexId: [430],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM10/112.ts
+++ b/data-asia/SM/SM10/112.ts
@@ -1,0 +1,69 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM10";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "エルフーンGX",
+	},
+
+	illustrator: "",
+	category: "Pokemon",
+	hp: 190,
+	types: ["Fairy"],
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ふわふわコットン" },
+			effect: {
+				ja: "このポケモンがワザのダメージを受けるとき、自分はコインを1回投げる。オモテなら、このポケモンはそのダメージを受けない。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "エナジーブロー" },
+			damage: "10+",
+			cost: ["Fairy"],
+			effect: {
+				ja: "このポケモンについているエネルギーの数x30ダメージ追加。",
+			},
+		},
+		{
+			name: { ja: "トイボックスGX" },
+			cost: ["Fairy"],
+			effect: {
+				ja: "自分の山札にある好きなカードを5枚まで、手札に加える。そして山札を切る。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [{ type: "Darkness", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 557470,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "モンメン",
+	},
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Hyper rare",
+	dexId: [547],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM10/113.ts
+++ b/data-asia/SM/SM10/113.ts
@@ -1,0 +1,70 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM10";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ペルシアンGX",
+	},
+
+	illustrator: "",
+	category: "Pokemon",
+	hp: 200,
+	types: ["Colorless"],
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "キャットウォーク" },
+			effect: {
+				ja: "前の相手の番に、自分の「ポケモンGX・EX」がきぜつしていたなら、自分の番に1回使える。自分の山札にある好きなカードを2枚まで、手札に加える。そして山札を切る。この番、すでに別の「キャットウォーク」を使っていたなら、この特性は使えない。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ふくしゅう" },
+			damage: "10+",
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "自分のトラッシュにあるポケモンの枚数x20ダメージ追加。追加できるダメージはポケモン9枚ぶんまで。",
+			},
+		},
+		{
+			name: { ja: "スラッシュバックGX" },
+			damage: 150,
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンをベンチポケモンと入れ替える。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 557471,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ニャース",
+	},
+
+	retreat: 2,
+	regulationMark: "C",
+	rarity: "Hyper rare",
+	dexId: [53],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM10/114.ts
+++ b/data-asia/SM/SM10/114.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM10";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "炎の結晶",
+	},
+
+	illustrator: "",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分のトラッシュにある[炎]エネルギーを3枚、相手に見せてから、手札に加える。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 557472,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	regulationMark: "C",
+	rarity: "Secret Rare",
+};
+
+export default card;

--- a/data-asia/SM/SM10/115.ts
+++ b/data-asia/SM/SM10/115.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM10";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "戒めの祠",
+	},
+
+	illustrator: "",
+	category: "Trainer",
+
+	effect: {
+		ja: "ポケモンチェックのたび、おたがいの「ポケモンGX・EX」全員に、それぞれダメカンを1個のせる。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 557473,
+			},
+		},
+	],
+
+	trainerType: "Stadium",
+	regulationMark: "B",
+	rarity: "Secret Rare",
+};
+
+export default card;

--- a/data-asia/SM/SM10/116.ts
+++ b/data-asia/SM/SM10/116.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM10";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "トリプル加速エネルギー",
+	},
+
+	illustrator: "",
+	category: "Energy",
+	energyType: "Special",
+
+	effect: {
+		ja: "このカードは、進化ポケモンにしかつけられず、つけた番の終わりにトラッシュする。このカードはポケモンについているかぎり[無]エネルギー3個ぶんとしてはたらく。（このカードが進化ポケモン以外についているなら、トラッシュする。）",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 557474,
+			},
+		},
+	],
+
+	regulationMark: "C",
+	rarity: "Secret Rare",
+};
+
+export default card;


### PR DESCRIPTION
## What

Adds the complete Japanese set **SM10 ダブルブレイズ (Double Blaze)**, released 2019-03-01:

- `data-asia/SM/SM10/001.ts` … `116.ts` — all 116 cards (95 regular + 21 secret rares: 12 SR, 3 Secret Rare, 6 UR)
- the set definition `data-asia/SM/SM10.ts` already existed and is untouched

## Data sources

- **pokemon-card.com** (official database): Japanese names, flavor texts, National Dex numbers, official card count
- **limitlesstcg.com**: full Japanese card text, stages, weaknesses/resistances/retreat, rarities, illustrators, attack costs
- **Cardmarket**: product IDs as `thirdParty.cardmarket` on the variant objects (557356–557474; tcgplayer IDs not available to me)

## Notes

- Follows the file format and conventions of the M-era sets (#1728)
- All 116 files type-check against `interfaces.d.ts` (`tsc --noEmit`)
