### PR TITLE
(data) Add Japanese SM set SM10b Sky Legend

### DIFF
--- a/data-asia/SM/SM10b/001.ts
+++ b/data-asia/SM/SM10b/001.ts
@@ -1,0 +1,63 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM10b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "モクロー&アローラナッシーGX",
+	},
+
+	illustrator: "Mitsuhiro Arita",
+	category: "Pokemon",
+	hp: 270,
+	types: ["Grass"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "スーパーグロウ" },
+			cost: [],
+			effect: {
+				ja: "自分の場の[草]ポケモン1匹から進化するカードを、自分の山札から1枚選び、そのポケモンにのせて進化させる。進化後が1進化なら、続けて2進化を1枚選び進化させる。そして山札を切る。",
+			},
+		},
+		{
+			name: { ja: "やすらぎハリケーン" },
+			damage: 150,
+			cost: ["Grass", "Grass", "Colorless"],
+			effect: {
+				ja: "このポケモンのHPを「30」回復する。",
+			},
+		},
+		{
+			name: { ja: "トロピカルアワーGX" },
+			damage: 200,
+			cost: ["Grass", "Grass", "Grass"],
+			effect: {
+				ja: "追加でエネルギーが3個ついているなら、相手の場のポケモンについているエネルギーを、すべて山札にもどして切る。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 557192,
+			},
+		},
+	],
+
+	retreat: 3,
+	regulationMark: "C",
+	rarity: "Double rare",
+	dexId: [722, 103],
+
+	suffix: "TAG TEAM-GX",
+};
+
+export default card;

--- a/data-asia/SM/SM10b/002.ts
+++ b/data-asia/SM/SM10b/002.ts
@@ -1,0 +1,47 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM10b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "イシズマイ",
+	},
+
+	illustrator: "kawayoo",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Grass"],
+
+	description: {
+		ja: "手ごろな 石に 穴を 開けて 住処にする。 壊されると かわりの 石が 見つかるまで 落ち着かない。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ツメをたてる" },
+			damage: 10,
+			cost: ["Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 557193,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [557],
+};
+
+export default card;

--- a/data-asia/SM/SM10b/003.ts
+++ b/data-asia/SM/SM10b/003.ts
@@ -1,0 +1,64 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM10b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "イワパレス",
+	},
+
+	illustrator: "Tomokazu Komiya",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Grass"],
+
+	description: {
+		ja: "重たい 岩を 背負って 乾燥した 土地を 何日でも 移動できる 脚力を 持つ。",
+	},
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "シェルアーマー" },
+			effect: {
+				ja: "このポケモンが受けるワザのダメージは「-30」される。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "れんぞくぎり" },
+			damage: "50+",
+			cost: ["Grass", "Colorless", "Colorless"],
+			effect: {
+				ja: "コインを3回投げる。オモテが1回なら、40ダメージ追加。オモテが2回なら、80ダメージ追加。すべてオモテなら、150ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 557194,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "イシズマイ",
+	},
+
+	retreat: 3,
+	regulationMark: "C",
+	rarity: "Uncommon",
+	dexId: [558],
+};
+
+export default card;

--- a/data-asia/SM/SM10b/004.ts
+++ b/data-asia/SM/SM10b/004.ts
@@ -1,0 +1,54 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM10b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "カリキリ",
+	},
+
+	illustrator: "Yuka Morii",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Grass"],
+
+	description: {
+		ja: "日が 昇ると ４枚の 葉っぱを 広げ 日光浴。 頭の 先から いい 匂いが するよ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "あまいかおり" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分のポケモン1匹のHPを「30」回復する。",
+			},
+		},
+		{
+			name: { ja: "このは" },
+			damage: 10,
+			cost: ["Grass"],
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 557195,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [753],
+};
+
+export default card;

--- a/data-asia/SM/SM10b/005.ts
+++ b/data-asia/SM/SM10b/005.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM10b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ラランテス",
+	},
+
+	illustrator: "AKIRA EGAWA",
+	category: "Pokemon",
+	hp: 110,
+	types: ["Grass"],
+
+	description: {
+		ja: "むしポケモンの ふりを するのは 身を 守るため。 両腕の 花びらは 鋭い 切れ味。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "はなふぶき" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "相手のポケモン全員に、それぞれ10ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+			},
+		},
+		{
+			name: { ja: "ソルスラッシュ" },
+			damage: "50+",
+			cost: ["Grass"],
+			effect: {
+				ja: "このポケモンに[炎]エネルギーがついているなら、50ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 557196,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "カリキリ",
+	},
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [754],
+};
+
+export default card;

--- a/data-asia/SM/SM10b/006.ts
+++ b/data-asia/SM/SM10b/006.ts
@@ -1,0 +1,52 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM10b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アマカジ",
+	},
+
+	illustrator: "Mizue",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Grass"],
+
+	description: {
+		ja: "甘く 美味しそうな 匂いのせいで とりポケモンに 狙われるが あまり 賢くないので 気に していない。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "はねる" },
+			damage: 10,
+			cost: ["Grass"],
+		},
+		{
+			name: { ja: "かいてんアタック" },
+			damage: 20,
+			cost: ["Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 557197,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [761],
+};
+
+export default card;

--- a/data-asia/SM/SM10b/007.ts
+++ b/data-asia/SM/SM10b/007.ts
@@ -1,0 +1,59 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM10b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アママイコ",
+	},
+
+	illustrator: "Kagemaru Himeno",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Grass"],
+
+	description: {
+		ja: "硬いヘタで 守られているので とりポケモンとも 平気で 遊ぶ。 突かれまくるが 気に していない。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "おうふくビンタ" },
+			damage: "30×",
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "コインを2回投げ、オモテの数×30ダメージ。",
+			},
+		},
+		{
+			name: { ja: "リーフステップ" },
+			damage: 60,
+			cost: ["Grass", "Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 557198,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "アマカジ",
+	},
+
+	retreat: 2,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [762],
+};
+
+export default card;

--- a/data-asia/SM/SM10b/008.ts
+++ b/data-asia/SM/SM10b/008.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM10b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アマージョ",
+	},
+
+	illustrator: "kirisAki",
+	category: "Pokemon",
+	hp: 140,
+	types: ["Grass"],
+
+	description: {
+		ja: "美しい 蹴り技の 使い手。 キックボクシングの チャンピオンも 一撃で ノックアウトするぞ。",
+	},
+
+	stage: "Stage2",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "じょおうのほうび" },
+			effect: {
+				ja: "自分の番に1回使える。自分のトラッシュにある[草]エネルギーを1枚、バトルポケモンにつける。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "とびひざげり" },
+			damage: 90,
+			cost: ["Grass", "Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 557199,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "アママイコ",
+	},
+
+	retreat: 2,
+	regulationMark: "C",
+	rarity: "Rare",
+	dexId: [763],
+};
+
+export default card;

--- a/data-asia/SM/SM10b/009.ts
+++ b/data-asia/SM/SM10b/009.ts
@@ -1,0 +1,55 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM10b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ドンメル",
+	},
+
+	illustrator: "Motofumi Fujiwara",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Fire"],
+
+	description: {
+		ja: "灼熱の マグマを 背中の コブに ためている。 雨に 当たると マグマが 冷えて 動きが 鈍る。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "たいあたり" },
+			damage: 10,
+			cost: ["Colorless"],
+		},
+		{
+			name: { ja: "かえんほうしゃ" },
+			damage: 80,
+			cost: ["Fire", "Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンについているエネルギーを、1個トラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 557200,
+			},
+		},
+	],
+
+	retreat: 4,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [322],
+};
+
+export default card;

--- a/data-asia/SM/SM10b/010.ts
+++ b/data-asia/SM/SM10b/010.ts
@@ -1,0 +1,59 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM10b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "バクーダ",
+	},
+
+	illustrator: "Masakazu Fukuda",
+	category: "Pokemon",
+	hp: 140,
+	types: ["Fire"],
+
+	description: {
+		ja: "背中の コブの 火山は １０年ごとに 大噴火 するが 激しく 怒っても 噴火する。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "たいあたり" },
+			damage: 50,
+			cost: ["Colorless", "Colorless"],
+		},
+		{
+			name: { ja: "ストロングフレア" },
+			damage: 150,
+			cost: ["Fire", "Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンについているエネルギーを、2個トラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 557201,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ドンメル",
+	},
+
+	retreat: 4,
+	regulationMark: "C",
+	rarity: "Uncommon",
+	dexId: [323],
+};
+
+export default card;

--- a/data-asia/SM/SM10b/011.ts
+++ b/data-asia/SM/SM10b/011.ts
@@ -1,0 +1,54 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM10b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ビクティニ",
+	},
+
+	illustrator: "Mizue",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Fire"],
+
+	description: {
+		ja: "勝利を もたらす ポケモン。 ビクティニを 連れた トレーナーは どんな 勝負にも 勝てるという。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ビクトリーサイン" },
+			cost: ["Fire"],
+			effect: {
+				ja: "自分の山札にある、それぞれちがうタイプの基本エネルギーを2枚まで、自分のポケモンに好きなようにつける。そして山札を切る。",
+			},
+		},
+		{
+			name: { ja: "ほのお" },
+			damage: 20,
+			cost: ["Fire"],
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 557202,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Rare",
+	dexId: [494],
+};
+
+export default card;

--- a/data-asia/SM/SM10b/012.ts
+++ b/data-asia/SM/SM10b/012.ts
@@ -1,0 +1,54 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM10b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヒノヤコマ",
+	},
+
+	illustrator: "Mina Nakai",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Fire"],
+
+	description: {
+		ja: "草むらに ひのこを まき散らす。 炎に 驚いて 飛び出してきた むしポケモンを ぱくりと いただく。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "ニトロチャージ" },
+			damage: 20,
+			cost: ["Fire"],
+			effect: {
+				ja: "自分の山札にある[炎]エネルギーを1枚、このポケモンにつける。そして山札を切る。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 557203,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ヤヤコマ",
+	},
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [662],
+};
+
+export default card;

--- a/data-asia/SM/SM10b/013.ts
+++ b/data-asia/SM/SM10b/013.ts
@@ -1,0 +1,62 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM10b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ファイアロー",
+	},
+
+	illustrator: "SATOSHI NAKAI",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Fire"],
+
+	description: {
+		ja: "羽は 火を 通さず 丈夫。 昔の 消防士の 服は ファイアローの 羽で できていた。",
+	},
+
+	stage: "Stage2",
+
+	attacks: [
+		{
+			name: { ja: "ねっぷう" },
+			damage: 40,
+			cost: ["Fire"],
+			effect: {
+				ja: "相手のバトルポケモンをやけどにする。",
+			},
+		},
+		{
+			name: { ja: "フレアブリッツ" },
+			damage: 100,
+			cost: ["Fire", "Colorless"],
+			effect: {
+				ja: "このポケモンについているエネルギーを1個トラッシュし、相手のベンチポケモン1匹にも、50ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 557204,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ヒノヤコマ",
+	},
+
+	retreat: 0,
+	regulationMark: "C",
+	rarity: "Uncommon",
+	dexId: [663],
+};
+
+export default card;

--- a/data-asia/SM/SM10b/014.ts
+++ b/data-asia/SM/SM10b/014.ts
@@ -1,0 +1,47 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM10b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ユキワラシ",
+	},
+
+	illustrator: "Naoyo Kimura",
+	category: "Pokemon",
+	hp: 50,
+	types: ["Water"],
+
+	description: {
+		ja: "雪や 氷が 主な エサ。 暖かな アローラでは 限られた 場所 でしか 生きていけない。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "つらら" },
+			damage: 20,
+			cost: ["Water"],
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 557205,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [361],
+};
+
+export default card;

--- a/data-asia/SM/SM10b/015.ts
+++ b/data-asia/SM/SM10b/015.ts
@@ -1,0 +1,62 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM10b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ユキメノコ",
+	},
+
+	illustrator: "Mizue",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Water"],
+
+	description: {
+		ja: "雪山登山に 来た 山男を 氷漬けにし 棲家に 持ち帰る。 美男子 しか 狙われない。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "うらみのといき" },
+			damage: "20×",
+			cost: ["Water"],
+			effect: {
+				ja: "このポケモンにダメカンを7個までのせ、のせた数×20ダメージ。",
+			},
+		},
+		{
+			name: { ja: "こごえるかぜ" },
+			damage: 40,
+			cost: ["Water"],
+			effect: {
+				ja: "相手のバトルポケモンをねむりにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 557206,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ユキワラシ",
+	},
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Rare",
+	dexId: [478],
+};
+
+export default card;

--- a/data-asia/SM/SM10b/016.ts
+++ b/data-asia/SM/SM10b/016.ts
@@ -1,0 +1,50 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM10b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ユキカブリ",
+	},
+
+	illustrator: "otumami",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Water"],
+
+	description: {
+		ja: "寒い 季節は 山の ふもとまで 降りてくるが 春に なると 雪が 残る 山頂に 戻っていく。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "こなゆき" },
+			damage: 10,
+			cost: ["Water"],
+			effect: {
+				ja: "相手のバトルポケモンをねむりにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 557207,
+			},
+		},
+	],
+
+	retreat: 4,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [459],
+};
+
+export default card;

--- a/data-asia/SM/SM10b/017.ts
+++ b/data-asia/SM/SM10b/017.ts
@@ -1,0 +1,62 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM10b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ユキノオー",
+	},
+
+	illustrator: "Shin Nagasawa",
+	category: "Pokemon",
+	hp: 140,
+	types: ["Water"],
+
+	description: {
+		ja: "ブリザードを 発生させて あたり 一面を 真っ白に してしまう。 別名 アイスモンスター。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "きゅうそくれいとう" },
+			damage: 70,
+			cost: ["Water", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンに[水]エネルギーがついているなら、相手のバトルポケモンをマヒにする。",
+			},
+		},
+		{
+			name: { ja: "ワイルドタックル" },
+			damage: 140,
+			cost: ["Water", "Water", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンにも20ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 557208,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ユキカブリ",
+	},
+
+	retreat: 4,
+	regulationMark: "C",
+	rarity: "Uncommon",
+	dexId: [460],
+};
+
+export default card;

--- a/data-asia/SM/SM10b/018.ts
+++ b/data-asia/SM/SM10b/018.ts
@@ -1,0 +1,50 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM10b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "フリージオ",
+	},
+
+	illustrator: "Ken Sugimori",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Water"],
+
+	description: {
+		ja: "雪雲の 中で 生まれた。 氷の 結晶で できた 鎖で 獲物を 捕まえる。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "カチカチロック" },
+			damage: 10,
+			cost: ["Water"],
+			effect: {
+				ja: "次の相手の番、相手は手札からグッズを出して使えない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 557209,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [615],
+};
+
+export default card;

--- a/data-asia/SM/SM10b/019.ts
+++ b/data-asia/SM/SM10b/019.ts
@@ -1,0 +1,66 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM10b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ケルディオGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 170,
+	types: ["Water"],
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ホーリーハート" },
+			effect: {
+				ja: "このポケモンは、相手の「ポケモンGX・EX」からワザのダメージや効果を受けない。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ソニックエッジ" },
+			damage: 110,
+			cost: ["Water", "Water", "Colorless"],
+			effect: {
+				ja: "このワザのダメージは、相手のバトルポケモンにかかっている効果を計算しない。",
+			},
+		},
+		{
+			name: { ja: "かくごのつるぎGX" },
+			damage: "50×",
+			cost: ["Water", "Water", "Colorless"],
+			effect: {
+				ja: "相手のベンチポケモンの数×50ダメージ。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 557210,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "C",
+	rarity: "Double rare",
+	dexId: [647],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM10b/020.ts
+++ b/data-asia/SM/SM10b/020.ts
@@ -1,0 +1,55 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM10b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "カプ・レヒレ",
+	},
+
+	illustrator: "Hasuno",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Water"],
+
+	description: {
+		ja: "深い 霧の 奥に 棲んでいると 恐れ 敬われてきた。 水を 操る ポニの 守り神だ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ひれカッター" },
+			damage: 20,
+			cost: ["Water"],
+		},
+		{
+			name: { ja: "ネイチャーウェーブ" },
+			damage: 100,
+			cost: ["Water", "Water", "Colorless"],
+			effect: {
+				ja: "このワザは、相手の場に「ウルトラビースト」がいるなら、【無】エネルギー1個で使える。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 557211,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Uncommon",
+	dexId: [788],
+};
+
+export default card;

--- a/data-asia/SM/SM10b/021.ts
+++ b/data-asia/SM/SM10b/021.ts
@@ -1,0 +1,49 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM10b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "コイル",
+	},
+
+	illustrator: "sowsow",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Lightning"],
+
+	description: {
+		ja: "たびたび 停電の 原因と なる ため コイルが 嫌がる 電波を 流す 発電所も あるほど。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ちょうおんぱ" },
+			cost: ["Lightning"],
+			effect: {
+				ja: "相手のバトルポケモンをこんらんにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Metal", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 557221,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [81],
+};
+
+export default card;

--- a/data-asia/SM/SM10b/022.ts
+++ b/data-asia/SM/SM10b/022.ts
@@ -1,0 +1,59 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM10b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "レアコイル",
+	},
+
+	illustrator: "Yumi",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Lightning"],
+
+	description: {
+		ja: "謎の 電波を 発信 しており レアコイルが 棲んでいる 場所では 精密機器が 故障してしまう。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "ピッカリだま" },
+			damage: 20,
+			cost: ["Lightning"],
+		},
+		{
+			name: { ja: "トライアタック" },
+			damage: "40×",
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "コインを3回投げ、オモテの数×40ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Metal", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 557222,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "コイル",
+	},
+
+	retreat: 2,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [82],
+};
+
+export default card;

--- a/data-asia/SM/SM10b/023.ts
+++ b/data-asia/SM/SM10b/023.ts
@@ -1,0 +1,64 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM10b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ジバコイル",
+	},
+
+	illustrator: "Shin Nagasawa",
+	category: "Pokemon",
+	hp: 160,
+	types: ["Lightning"],
+
+	description: {
+		ja: "自分の テリトリーを レーダーで 監視 している。 侵入者は 破壊光線で ただちに 処分。",
+	},
+
+	stage: "Stage2",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ダブルタイプ" },
+			effect: {
+				ja: "このポケモンは、場にいるかぎり[雷]と[鋼]の2つのタイプになる。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "マグネットボルト" },
+			damage: 120,
+			cost: ["Lightning", "Colorless", "Colorless"],
+			effect: {
+				ja: "自分のトラッシュにあるトレーナーズを1枚、相手に見せてから、手札に加える。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Metal", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 557223,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "レアコイル",
+	},
+
+	retreat: 3,
+	regulationMark: "C",
+	rarity: "Rare",
+	dexId: [462],
+};
+
+export default card;

--- a/data-asia/SM/SM10b/024.ts
+++ b/data-asia/SM/SM10b/024.ts
@@ -1,0 +1,58 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM10b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "デンジュモク",
+	},
+
+	illustrator: "Satoshi Shirai",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Lightning"],
+
+	description: {
+		ja: "この世界では 異質で 危険だが 本来 棲んでいる 世界では 普通に 見かける 生物らしい。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "スリーミラーズ" },
+			damage: "30+",
+			cost: ["Lightning"],
+			effect: {
+				ja: "相手のサイドの残り枚数が3枚なら、90ダメージ追加。",
+			},
+		},
+		{
+			name: { ja: "シグナルビーム" },
+			damage: 50,
+			cost: ["Lightning", "Lightning"],
+			effect: {
+				ja: "相手のバトルポケモンをこんらんにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Metal", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 557225,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "C",
+	rarity: "Uncommon",
+	dexId: [796],
+};
+
+export default card;

--- a/data-asia/SM/SM10b/025.ts
+++ b/data-asia/SM/SM10b/025.ts
@@ -1,0 +1,47 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM10b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アーボ",
+	},
+
+	illustrator: "Masakazu Fukuda",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Psychic"],
+
+	description: {
+		ja: "顎を 外すことで 自分より 大きな 獲物も 丸呑みに する。 食後は 身体を 丸め 休む。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "しっぽではたく" },
+			damage: 30,
+			cost: ["Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 557226,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [23],
+};
+
+export default card;

--- a/data-asia/SM/SM10b/026.ts
+++ b/data-asia/SM/SM10b/026.ts
@@ -1,0 +1,64 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM10b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アーボック",
+	},
+
+	illustrator: "kirisAki",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Psychic"],
+
+	description: {
+		ja: "最新の 研究で お腹の 模様は ２０種類 以上の パターンが あることが 判明。",
+	},
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "いまわのもよう" },
+			effect: {
+				ja: "このポケモンが、相手のポケモンからワザのダメージを受けてきぜつしたとき、相手の手札からオモテを見ないで、2枚トラッシュする。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ロケットテール" },
+			damage: "50+",
+			cost: ["Psychic", "Colorless", "Colorless"],
+			effect: {
+				ja: "自分のトラッシュに「ムサシとコジロウ」があるなら、80ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 557227,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "アーボ",
+	},
+
+	retreat: 2,
+	regulationMark: "C",
+	rarity: "Uncommon",
+	dexId: [24],
+};
+
+export default card;

--- a/data-asia/SM/SM10b/027.ts
+++ b/data-asia/SM/SM10b/027.ts
@@ -1,0 +1,47 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM10b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ドガース",
+	},
+
+	illustrator: "Saya Tsuruta",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Psychic"],
+
+	description: {
+		ja: "薄い バルーン状の 体に 猛毒の ガスが つまっている。 近くに 来ると くさい。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "たいあたり" },
+			damage: 20,
+			cost: ["Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 557228,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [109],
+};
+
+export default card;

--- a/data-asia/SM/SM10b/028.ts
+++ b/data-asia/SM/SM10b/028.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM10b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "マタドガス",
+	},
+
+	illustrator: "Hideki Ishikawa",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Psychic"],
+
+	description: {
+		ja: "どちらかが ふくらむと 片方は しぼむ 双子の ドガース。 いつも 体内の 毒ガスを 混ぜている。",
+	},
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ホワイトホール" },
+			effect: {
+				ja: "自分の番に、このカードが「ムサシとコジロウ」の効果でトラッシュされたとき、1回使える。相手は相手自身の手札を、1枚トラッシュする。（トラッシュするのは「ムサシとコジロウ」の効果のあと。）",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "たいあたり" },
+			damage: 40,
+			cost: ["Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 557229,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ドガース",
+	},
+
+	retreat: 3,
+	regulationMark: "C",
+	rarity: "Uncommon",
+	dexId: [110],
+};
+
+export default card;

--- a/data-asia/SM/SM10b/029.ts
+++ b/data-asia/SM/SM10b/029.ts
@@ -1,0 +1,57 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM10b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ユクシー",
+	},
+
+	illustrator: "kodama",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Psychic"],
+
+	description: {
+		ja: "知識の神と 呼ばれている。 目を 合わせた 者の 記憶を 消してしまう 力を 持つという。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ひみつのテリトリー" },
+			effect: {
+				ja: "自分の場に「エムリット」「アグノム」がいるなら、おたがいのポケモン全員の弱点は、すべて「×4」としてダメージ計算をする。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "サイコショット" },
+			damage: 30,
+			cost: ["Colorless", "Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 557230,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Rare",
+	dexId: [480],
+};
+
+export default card;

--- a/data-asia/SM/SM10b/030.ts
+++ b/data-asia/SM/SM10b/030.ts
@@ -1,0 +1,54 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM10b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "エムリット",
+	},
+
+	illustrator: "Sekio",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Psychic"],
+
+	description: {
+		ja: "悲しみの 苦しさと 喜びの 尊さを 人々に 教えた。 感情の神と 呼ばれている。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "コンタクト" },
+			cost: ["Psychic"],
+			effect: {
+				ja: "自分の山札にあるたねポケモンを3枚まで、ベンチに出す。そして山札を切る。",
+			},
+		},
+		{
+			name: { ja: "つぶやく" },
+			damage: 20,
+			cost: ["Psychic"],
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 557231,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [481],
+};
+
+export default card;

--- a/data-asia/SM/SM10b/031.ts
+++ b/data-asia/SM/SM10b/031.ts
@@ -1,0 +1,49 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM10b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アグノム",
+	},
+
+	illustrator: "Mizue",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Psychic"],
+
+	description: {
+		ja: "意思の神と 呼ばれている。 湖の 底で 眠り続け 世界の バランスを とっている。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "サイコパワー" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "ダメカン3個を、相手のポケモンに好きなようにのせる。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 557232,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [482],
+};
+
+export default card;

--- a/data-asia/SM/SM10b/032.ts
+++ b/data-asia/SM/SM10b/032.ts
@@ -1,0 +1,55 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM10b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ベベノム",
+	},
+
+	illustrator: "Shin Nagasawa",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Psychic"],
+
+	description: {
+		ja: "異世界に おいては 旅立ちの パートナーに 選ばれるほど 親しまれている ウルトラビースト。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "とばす" },
+			damage: 10,
+			cost: ["Colorless"],
+		},
+		{
+			name: { ja: "ラストシーン" },
+			damage: "50+",
+			cost: ["Psychic", "Colorless", "Colorless"],
+			effect: {
+				ja: "おたがいのサイドの残り枚数が、それぞれ1枚なら、130ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 557233,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [803],
+};
+
+export default card;

--- a/data-asia/SM/SM10b/033.ts
+++ b/data-asia/SM/SM10b/033.ts
@@ -1,0 +1,57 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM10b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "クリムガン",
+	},
+
+	illustrator: "hatachu",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Dragon"],
+
+	description: {
+		ja: "赤い 顔の 皮膚は 岩よりも 硬い。 狭い 洞窟の 中で 敵に 向かって 顔から 突撃。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ひきずりだす" },
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "相手のベンチポケモンを1匹選び、バトルポケモンと入れ替える。その後、新しく出てきたポケモンに30ダメージ。",
+			},
+		},
+		{
+			name: { ja: "ドラゴンテール" },
+			damage: "100×",
+			cost: ["Fire", "Water", "Colorless"],
+			effect: {
+				ja: "コインを2回投げ、オモテの数×100ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fairy", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 557234,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [621],
+};
+
+export default card;

--- a/data-asia/SM/SM10b/034.ts
+++ b/data-asia/SM/SM10b/034.ts
@@ -1,0 +1,68 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM10b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アーゴヨンGX",
+	},
+
+	illustrator: "PLANETA Tsuji",
+	category: "Pokemon",
+	hp: 210,
+	types: ["Dragon"],
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ウルトラへんかん" },
+			effect: {
+				ja: "自分の番に1回使える。自分の手札にある「ウルトラビースト」を1枚トラッシュする。その後、山札を3枚引く。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ベノムシュート" },
+			cost: ["Psychic", "Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンについているエネルギーを2個トラッシュし、相手のポケモン1匹に、170ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+			},
+		},
+		{
+			name: { ja: "インジェクションGX" },
+			cost: ["Lightning"],
+			effect: {
+				ja: "相手のトラッシュにある好きなカードを1枚、相手に見せてから、ウラにして相手のサイドとして置く。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fairy", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 557235,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ベベノム",
+	},
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Double rare",
+	dexId: [804],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM10b/035.ts
+++ b/data-asia/SM/SM10b/035.ts
@@ -1,0 +1,52 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM10b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ファイヤー&サンダー&フリーザーGX",
+	},
+
+	illustrator: "Mitsuhiro Arita",
+	category: "Pokemon",
+	hp: 300,
+	types: ["Colorless"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "トリニティバーン" },
+			damage: 210,
+			cost: ["Fire", "Water", "Lightning", "Colorless"],
+		},
+		{
+			name: { ja: "スカイレジェンドGX" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "このポケモンと、ついているすべてのカードを、自分の山札にもどして切る。追加で[炎][水][雷]エネルギーが1個ずつついているなら、相手のポケモン3匹に、それぞれ110ダメージ。［ベンチは弱点・抵抗力を計算しない。］［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 557236,
+			},
+		},
+	],
+
+	retreat: 3,
+	regulationMark: "C",
+	rarity: "Double rare",
+	dexId: [146, 145, 144],
+
+	suffix: "TAG TEAM-GX",
+};
+
+export default card;

--- a/data-asia/SM/SM10b/036.ts
+++ b/data-asia/SM/SM10b/036.ts
@@ -1,0 +1,54 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM10b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ベロリンガ",
+	},
+
+	illustrator: "tetsuya koizumi",
+	category: "Pokemon",
+	hp: 100,
+	types: ["Colorless"],
+
+	description: {
+		ja: "長い ベロで なんでも ベロリと 舐めて 確かめている。 舐められた 部分を 放っておくと かぶれるぞ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "どすこいドロー" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の場のにげるためのエネルギーが4個のポケモンの数ぶん、山札を引く。",
+			},
+		},
+		{
+			name: { ja: "ベロではたく" },
+			damage: 40,
+			cost: ["Colorless", "Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 557237,
+			},
+		},
+	],
+
+	retreat: 4,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [108],
+};
+
+export default card;

--- a/data-asia/SM/SM10b/037.ts
+++ b/data-asia/SM/SM10b/037.ts
@@ -1,0 +1,59 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM10b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ベロベルト",
+	},
+
+	illustrator: "Suwama Chiaki",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Colorless"],
+
+	description: {
+		ja: "舌が どこまで 伸びるのかの コンテストが 開催 されている。 現在の 最高記録は２５ｍ。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "ころがる" },
+			damage: 40,
+			cost: ["Colorless"],
+		},
+		{
+			name: { ja: "ベロベロらんぶ" },
+			damage: 90,
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手の手札からオモテを見ないで1枚トラッシュし、相手の山札を上から1枚トラッシュし、相手のバトルポケモンについているエネルギーを、1個トラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 557238,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ベロリンガ",
+	},
+
+	retreat: 4,
+	regulationMark: "C",
+	rarity: "Uncommon",
+	dexId: [463],
+};
+
+export default card;

--- a/data-asia/SM/SM10b/038.ts
+++ b/data-asia/SM/SM10b/038.ts
@@ -1,0 +1,50 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM10b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ホーホー",
+	},
+
+	illustrator: "Misa Tsutsui",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Colorless"],
+
+	description: {
+		ja: "毎日 必ず 決まったリズムで 首を かしげる。 昔の人は 時計の 代わりに 飼っていた。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "エアスラッシュ" },
+			damage: 30,
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンについているエネルギーを、1個トラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 557239,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [163],
+};
+
+export default card;

--- a/data-asia/SM/SM10b/039.ts
+++ b/data-asia/SM/SM10b/039.ts
@@ -1,0 +1,58 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM10b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヨルノズク",
+	},
+
+	illustrator: "Tomokazu Komiya",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Colorless"],
+
+	description: {
+		ja: "暗闇でも はっきり 見える 目を 持っており 獲物を 逃がさない。 闇夜の 帝王とも 呼ばれる。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "やみうち" },
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "ダメカンがのっている相手のポケモン1匹に、60ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+			},
+		},
+		{
+			name: { ja: "スラッシュクロー" },
+			damage: 60,
+			cost: ["Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 557240,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ホーホー",
+	},
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [164],
+};
+
+export default card;

--- a/data-asia/SM/SM10b/040.ts
+++ b/data-asia/SM/SM10b/040.ts
@@ -1,0 +1,60 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM10b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "タブンネ",
+	},
+
+	illustrator: "sui",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Colorless"],
+
+	description: {
+		ja: "耳の 触角で 相手の 体調や タマゴから ポケモンが いつ でてくるのかも わかるのだ。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ヒヤリング" },
+			effect: {
+				ja: "このポケモンがバトル場にいるなら、自分の番に1回使える。自分の山札を1枚引く。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ドレインビンタ" },
+			damage: 30,
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンのHPを「30」回復する。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 557241,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Uncommon",
+	dexId: [531],
+};
+
+export default card;

--- a/data-asia/SM/SM10b/041.ts
+++ b/data-asia/SM/SM10b/041.ts
@@ -1,0 +1,47 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM10b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヤヤコマ",
+	},
+
+	illustrator: "Saya Tsuruta",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Colorless"],
+
+	description: {
+		ja: "人懐っこい ポケモンだけど 無理やり 触ると 身体を 一気に 発熱させるので 火傷 するぞ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "はばたく" },
+			damage: 10,
+			cost: ["Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 557242,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [661],
+};
+
+export default card;

--- a/data-asia/SM/SM10b/042.ts
+++ b/data-asia/SM/SM10b/042.ts
@@ -1,0 +1,55 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM10b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "タイプ：ヌル",
+	},
+
+	illustrator: "tetsuya koizumi",
+	category: "Pokemon",
+	hp: 100,
+	types: ["Colorless"],
+
+	description: {
+		ja: "ある任務の ために 開発された ポケモン兵器。 実験中に 暴走した ため 凍結された。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "けとばす" },
+			damage: 20,
+			cost: ["Colorless"],
+		},
+		{
+			name: { ja: "クイックアタック" },
+			damage: "30+",
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "コインを1回投げオモテなら、30ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 557243,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [772],
+};
+
+export default card;

--- a/data-asia/SM/SM10b/043.ts
+++ b/data-asia/SM/SM10b/043.ts
@@ -1,0 +1,62 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM10b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "シルヴァディ",
+	},
+
+	illustrator: "Eske Yoshinob",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Colorless"],
+
+	description: {
+		ja: "覚醒し 進化した 姿。 重い マスクから 解き放たれ スピードが 大幅に アップ。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "アベンジハート" },
+			damage: "30+",
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "前の相手の番に、相手がとったサイドの枚数×50ダメージ追加。",
+			},
+		},
+		{
+			name: { ja: "エアスラッシュ" },
+			damage: 120,
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンについているエネルギーを、1個トラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 557244,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "タイプ：ヌル",
+	},
+
+	retreat: 2,
+	regulationMark: "C",
+	rarity: "Rare",
+	dexId: [773],
+};
+
+export default card;

--- a/data-asia/SM/SM10b/044.ts
+++ b/data-asia/SM/SM10b/044.ts
@@ -1,0 +1,42 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM10b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ノーマルZたいあたり",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードをつけている、ワザ「たいあたり」を持つポケモンは、このカードに書かれているGXワザを使える。［ワザを使うためのエネルギーは必要。］",
+	},
+
+	attacks: [
+		{
+			name: { ja: "ダッシュアタックGX" },
+			damage: "200+",
+			cost: ["Colorless", "Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "ウラが出るまでコインを投げ、オモテの数×40ダメージ追加。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 557245,
+			},
+		},
+	],
+
+	trainerType: "Tool",
+	regulationMark: "C",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM10b/045.ts
+++ b/data-asia/SM/SM10b/045.ts
@@ -1,0 +1,42 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM10b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヒコウZエアスラッシュ",
+	},
+
+	illustrator: "aky CG Works",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードをつけている、ワザ「エアスラッシュ」を持つポケモンは、このカードに書かれているGXワザを使える。［ワザを使うためのエネルギーは必要。］",
+	},
+
+	attacks: [
+		{
+			name: { ja: "ダイブクラッシュGX" },
+			damage: 180,
+			cost: ["Colorless", "Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "次の相手の番、このポケモンはワザのダメージや効果を受けない。",
+			},
+		},
+	],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 557246,
+			},
+		},
+	],
+
+	trainerType: "Tool",
+	regulationMark: "C",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM10b/046.ts
+++ b/data-asia/SM/SM10b/046.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM10b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "Uターンボード",
+	},
+
+	illustrator: "sadaji",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードをつけているポケモンは、にげるためのエネルギーが1個ぶん少なくなる。 このカードは、場からトラッシュされるとき、トラッシュせず、手札にもどす。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 557247,
+			},
+		},
+	],
+
+	trainerType: "Tool",
+	regulationMark: "C",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM10b/047.ts
+++ b/data-asia/SM/SM10b/047.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM10b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "かいじゅうマニア",
+	},
+
+	illustrator: "Hitoshi Ariga",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の山札にあるにげるためのエネルギーが4個のポケモンを3枚まで、相手に見せてから、手札に加える。そして山札を切る。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 557249,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "C",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM10b/048.ts
+++ b/data-asia/SM/SM10b/048.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM10b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ムサシとコジロウ",
+	},
+
+	illustrator: "Megumi Mizutani",
+	category: "Trainer",
+
+	effect: {
+		ja: "おたがいのプレイヤーは、それぞれ自分の手札を、2枚トラッシュする。（トラッシュは相手から行う。手札がないプレイヤーはトラッシュしない。）",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 557250,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "C",
+	rarity: "Rare",
+};
+
+export default card;

--- a/data-asia/SM/SM10b/049.ts
+++ b/data-asia/SM/SM10b/049.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM10b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ブリザードタウン",
+	},
+
+	illustrator: "Ryo Ueda",
+	category: "Trainer",
+
+	effect: {
+		ja: "おたがいの場の残りHPが「40」以下のポケモンは、ワザが使えない。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 557251,
+			},
+		},
+	],
+
+	trainerType: "Stadium",
+	regulationMark: "C",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM10b/050.ts
+++ b/data-asia/SM/SM10b/050.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM10b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "リサイクルエネルギー",
+	},
+
+	illustrator: "",
+	category: "Energy",
+	energyType: "Special",
+
+	effect: {
+		ja: "このカードは[無]エネルギー1個ぶんとしてはたらく。このカードは、場からトラッシュされるとき、トラッシュせず、手札にもどす。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 557252,
+			},
+		},
+	],
+
+	regulationMark: "C",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM10b/051.ts
+++ b/data-asia/SM/SM10b/051.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM10b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ネットボール",
+	},
+
+	illustrator: "Ryo Ueda",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の山札にある[草]タイプのたねポケモンまたは[草]エネルギーを1枚、相手に見せてから、手札に加える。そして山札を切る。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 557253,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	regulationMark: "B",
+	rarity: "Rare Holo",
+};
+
+export default card;

--- a/data-asia/SM/SM10b/052.ts
+++ b/data-asia/SM/SM10b/052.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM10b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "グラジオ",
+	},
+
+	illustrator: "Mana Ibe",
+	category: "Trainer",
+
+	effect: {
+		ja: "ウラになっている自分のサイドのオモテをすべて見て、その中にあるカードを1枚、この「グラジオ」と入れ替えて、手札に加える。その後、この「グラジオ」と残りのサイドをすべてウラにして切り、サイドとして置く。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 557254,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "A",
+	rarity: "Rare Holo",
+};
+
+export default card;

--- a/data-asia/SM/SM10b/053.ts
+++ b/data-asia/SM/SM10b/053.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM10b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "リーリエ",
+	},
+
+	illustrator: "Mana Ibe",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の手札が6枚になるように、山札を引く。最初の自分の番に使ったなら、8枚になるように引く。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 557255,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "A",
+	rarity: "Rare Holo",
+};
+
+export default card;

--- a/data-asia/SM/SM10b/054.ts
+++ b/data-asia/SM/SM10b/054.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM10b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ルザミーネ",
+	},
+
+	illustrator: "Mana Ibe",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分のトラッシュにあるサポートとスタジアムを合計2枚、相手に見せてから、手札に加える。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 557256,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "A",
+	rarity: "Rare Holo",
+};
+
+export default card;

--- a/data-asia/SM/SM10b/055.ts
+++ b/data-asia/SM/SM10b/055.ts
@@ -1,0 +1,63 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM10b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "モクロー&アローラナッシーGX",
+	},
+
+	illustrator: "ConceptLab",
+	category: "Pokemon",
+	hp: 270,
+	types: ["Grass"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "スーパーグロウ" },
+			cost: [],
+			effect: {
+				ja: "自分の場の[草]ポケモン1匹から進化するカードを、自分の山札から1枚選び、そのポケモンにのせて進化させる。進化後が1進化なら、続けて2進化を1枚選び進化させる。そして山札を切る。",
+			},
+		},
+		{
+			name: { ja: "やすらぎハリケーン" },
+			damage: 150,
+			cost: ["Grass", "Grass", "Colorless"],
+			effect: {
+				ja: "このポケモンのHPを「30」回復する。",
+			},
+		},
+		{
+			name: { ja: "トロピカルアワーGX" },
+			damage: 200,
+			cost: ["Grass", "Grass", "Grass"],
+			effect: {
+				ja: "追加でエネルギーが3個ついているなら、相手の場のポケモンについているエネルギーを、すべて山札にもどして切る。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 557257,
+			},
+		},
+	],
+
+	retreat: 3,
+	regulationMark: "C",
+	rarity: "Ultra Rare",
+	dexId: [722, 103],
+
+	suffix: "TAG TEAM-GX",
+};
+
+export default card;

--- a/data-asia/SM/SM10b/056.ts
+++ b/data-asia/SM/SM10b/056.ts
@@ -1,0 +1,63 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM10b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "モクロー&アローラナッシーGX",
+	},
+
+	illustrator: "Naoyo Kimura",
+	category: "Pokemon",
+	hp: 270,
+	types: ["Grass"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "スーパーグロウ" },
+			cost: [],
+			effect: {
+				ja: "自分の場の[草]ポケモン1匹から進化するカードを、自分の山札から1枚選び、そのポケモンにのせて進化させる。進化後が1進化なら、続けて2進化を1枚選び進化させる。そして山札を切る。",
+			},
+		},
+		{
+			name: { ja: "やすらぎハリケーン" },
+			damage: 150,
+			cost: ["Grass", "Grass", "Colorless"],
+			effect: {
+				ja: "このポケモンのHPを「30」回復する。",
+			},
+		},
+		{
+			name: { ja: "トロピカルアワーGX" },
+			damage: 200,
+			cost: ["Grass", "Grass", "Grass"],
+			effect: {
+				ja: "追加でエネルギーが3個ついているなら、相手の場のポケモンについているエネルギーを、すべて山札にもどして切る。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 557258,
+			},
+		},
+	],
+
+	retreat: 3,
+	regulationMark: "C",
+	rarity: "Ultra Rare",
+	dexId: [722, 103],
+
+	suffix: "TAG TEAM-GX",
+};
+
+export default card;

--- a/data-asia/SM/SM10b/057.ts
+++ b/data-asia/SM/SM10b/057.ts
@@ -1,0 +1,66 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM10b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ケルディオGX",
+	},
+
+	illustrator: "ConceptLab",
+	category: "Pokemon",
+	hp: 170,
+	types: ["Water"],
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ホーリーハート" },
+			effect: {
+				ja: "このポケモンは、相手の「ポケモンGX・EX」からワザのダメージや効果を受けない。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ソニックエッジ" },
+			damage: 110,
+			cost: ["Water", "Water", "Colorless"],
+			effect: {
+				ja: "このワザのダメージは、相手のバトルポケモンにかかっている効果を計算しない。",
+			},
+		},
+		{
+			name: { ja: "かくごのつるぎGX" },
+			damage: "50×",
+			cost: ["Water", "Water", "Colorless"],
+			effect: {
+				ja: "相手のベンチポケモンの数×50ダメージ。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 557259,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "C",
+	rarity: "Ultra Rare",
+	dexId: [647],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM10b/058.ts
+++ b/data-asia/SM/SM10b/058.ts
@@ -1,0 +1,68 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM10b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アーゴヨンGX",
+	},
+
+	illustrator: "ConceptLab",
+	category: "Pokemon",
+	hp: 210,
+	types: ["Dragon"],
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ウルトラへんかん" },
+			effect: {
+				ja: "自分の番に1回使える。自分の手札にある「ウルトラビースト」を1枚トラッシュする。その後、山札を3枚引く。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ベノムシュート" },
+			cost: ["Psychic", "Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンについているエネルギーを2個トラッシュし、相手のポケモン1匹に、170ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+			},
+		},
+		{
+			name: { ja: "インジェクションGX" },
+			cost: ["Lightning"],
+			effect: {
+				ja: "相手のトラッシュにある好きなカードを1枚、相手に見せてから、ウラにして相手のサイドとして置く。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fairy", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 557260,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ベベノム",
+	},
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Ultra Rare",
+	dexId: [804],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM10b/059.ts
+++ b/data-asia/SM/SM10b/059.ts
@@ -1,0 +1,52 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM10b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ファイヤー&サンダー&フリーザーGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 300,
+	types: ["Colorless"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "トリニティバーン" },
+			damage: 210,
+			cost: ["Fire", "Water", "Lightning", "Colorless"],
+		},
+		{
+			name: { ja: "スカイレジェンドGX" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "このポケモンと、ついているすべてのカードを、自分の山札にもどして切る。追加で[炎][水][雷]エネルギーが1個ずつついているなら、相手のポケモン3匹に、それぞれ110ダメージ。［ベンチは弱点・抵抗力を計算しない。］［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 557261,
+			},
+		},
+	],
+
+	retreat: 3,
+	regulationMark: "C",
+	rarity: "Ultra Rare",
+	dexId: [146, 145, 144],
+
+	suffix: "TAG TEAM-GX",
+};
+
+export default card;

--- a/data-asia/SM/SM10b/060.ts
+++ b/data-asia/SM/SM10b/060.ts
@@ -1,0 +1,52 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM10b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ファイヤー&サンダー&フリーザーGX",
+	},
+
+	illustrator: "HYOGONOSUKE",
+	category: "Pokemon",
+	hp: 300,
+	types: ["Colorless"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "トリニティバーン" },
+			damage: 210,
+			cost: ["Fire", "Water", "Lightning", "Colorless"],
+		},
+		{
+			name: { ja: "スカイレジェンドGX" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "このポケモンと、ついているすべてのカードを、自分の山札にもどして切る。追加で[炎][水][雷]エネルギーが1個ずつついているなら、相手のポケモン3匹に、それぞれ110ダメージ。［ベンチは弱点・抵抗力を計算しない。］［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 557262,
+			},
+		},
+	],
+
+	retreat: 3,
+	regulationMark: "C",
+	rarity: "Ultra Rare",
+	dexId: [146, 145, 144],
+
+	suffix: "TAG TEAM-GX",
+};
+
+export default card;

--- a/data-asia/SM/SM10b/061.ts
+++ b/data-asia/SM/SM10b/061.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM10b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "かいじゅうマニア",
+	},
+
+	illustrator: "Hitoshi Ariga",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の山札にあるにげるためのエネルギーが4個のポケモンを3枚まで、相手に見せてから、手札に加える。そして山札を切る。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 557263,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "C",
+	rarity: "Ultra Rare",
+};
+
+export default card;

--- a/data-asia/SM/SM10b/062.ts
+++ b/data-asia/SM/SM10b/062.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM10b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ムサシとコジロウ",
+	},
+
+	illustrator: "Megumi Mizutani",
+	category: "Trainer",
+
+	effect: {
+		ja: "おたがいのプレイヤーは、それぞれ自分の手札を、2枚トラッシュする。（トラッシュは相手から行う。手札がないプレイヤーはトラッシュしない。）",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 557264,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "C",
+	rarity: "Ultra Rare",
+};
+
+export default card;

--- a/data-asia/SM/SM10b/063.ts
+++ b/data-asia/SM/SM10b/063.ts
@@ -1,0 +1,63 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM10b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "モクロー&アローラナッシーGX",
+	},
+
+	illustrator: "",
+	category: "Pokemon",
+	hp: 270,
+	types: ["Grass"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "スーパーグロウ" },
+			cost: [],
+			effect: {
+				ja: "自分の場の[草]ポケモン1匹から進化するカードを、自分の山札から1枚選び、そのポケモンにのせて進化させる。進化後が1進化なら、続けて2進化を1枚選び進化させる。そして山札を切る。",
+			},
+		},
+		{
+			name: { ja: "やすらぎハリケーン" },
+			damage: 150,
+			cost: ["Grass", "Grass", "Colorless"],
+			effect: {
+				ja: "このポケモンのHPを「30」回復する。",
+			},
+		},
+		{
+			name: { ja: "トロピカルアワーGX" },
+			damage: 200,
+			cost: ["Grass", "Grass", "Grass"],
+			effect: {
+				ja: "追加でエネルギーが3個ついているなら、相手の場のポケモンについているエネルギーを、すべて山札にもどして切る。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 557265,
+			},
+		},
+	],
+
+	retreat: 3,
+	regulationMark: "C",
+	rarity: "Hyper rare",
+	dexId: [722, 103],
+
+	suffix: "TAG TEAM-GX",
+};
+
+export default card;

--- a/data-asia/SM/SM10b/064.ts
+++ b/data-asia/SM/SM10b/064.ts
@@ -1,0 +1,66 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM10b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ケルディオGX",
+	},
+
+	illustrator: "",
+	category: "Pokemon",
+	hp: 170,
+	types: ["Water"],
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ホーリーハート" },
+			effect: {
+				ja: "このポケモンは、相手の「ポケモンGX・EX」からワザのダメージや効果を受けない。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ソニックエッジ" },
+			damage: 110,
+			cost: ["Water", "Water", "Colorless"],
+			effect: {
+				ja: "このワザのダメージは、相手のバトルポケモンにかかっている効果を計算しない。",
+			},
+		},
+		{
+			name: { ja: "かくごのつるぎGX" },
+			damage: "50×",
+			cost: ["Water", "Water", "Colorless"],
+			effect: {
+				ja: "相手のベンチポケモンの数×50ダメージ。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 557266,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "C",
+	rarity: "Hyper rare",
+	dexId: [647],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM10b/065.ts
+++ b/data-asia/SM/SM10b/065.ts
@@ -1,0 +1,68 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM10b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アーゴヨンGX",
+	},
+
+	illustrator: "",
+	category: "Pokemon",
+	hp: 210,
+	types: ["Dragon"],
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ウルトラへんかん" },
+			effect: {
+				ja: "自分の番に1回使える。自分の手札にある「ウルトラビースト」を1枚トラッシュする。その後、山札を3枚引く。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ベノムシュート" },
+			cost: ["Psychic", "Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンについているエネルギーを2個トラッシュし、相手のポケモン1匹に、170ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+			},
+		},
+		{
+			name: { ja: "インジェクションGX" },
+			cost: ["Lightning"],
+			effect: {
+				ja: "相手のトラッシュにある好きなカードを1枚、相手に見せてから、ウラにして相手のサイドとして置く。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fairy", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 557267,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ベベノム",
+	},
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Hyper rare",
+	dexId: [804],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM10b/066.ts
+++ b/data-asia/SM/SM10b/066.ts
@@ -1,0 +1,52 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM10b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ファイヤー&サンダー&フリーザーGX",
+	},
+
+	illustrator: "",
+	category: "Pokemon",
+	hp: 300,
+	types: ["Colorless"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "トリニティバーン" },
+			damage: 210,
+			cost: ["Fire", "Water", "Lightning", "Colorless"],
+		},
+		{
+			name: { ja: "スカイレジェンドGX" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "このポケモンと、ついているすべてのカードを、自分の山札にもどして切る。追加で[炎][水][雷]エネルギーが1個ずつついているなら、相手のポケモン3匹に、それぞれ110ダメージ。［ベンチは弱点・抵抗力を計算しない。］［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 557268,
+			},
+		},
+	],
+
+	retreat: 3,
+	regulationMark: "C",
+	rarity: "Hyper rare",
+	dexId: [146, 145, 144],
+
+	suffix: "TAG TEAM-GX",
+};
+
+export default card;

--- a/data-asia/SM/SM10b/067.ts
+++ b/data-asia/SM/SM10b/067.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM10b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "Uターンボード",
+	},
+
+	illustrator: "",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードをつけているポケモンは、にげるためのエネルギーが1個ぶん少なくなる。 このカードは、場からトラッシュされるとき、トラッシュせず、手札にもどす。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 557269,
+			},
+		},
+	],
+
+	trainerType: "Tool",
+	regulationMark: "C",
+	rarity: "Secret Rare",
+};
+
+export default card;

--- a/data-asia/SM/SM10b/068.ts
+++ b/data-asia/SM/SM10b/068.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM10b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "トキワの森",
+	},
+
+	illustrator: "",
+	category: "Trainer",
+
+	effect: {
+		ja: "おたがいのプレイヤーは、自分の番ごとに1回、自分の手札を1枚トラッシュしてよい。その場合、自分の山札にある基本エネルギーを1枚、相手に見せてから、手札に加える。そして山札を切る。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 557270,
+			},
+		},
+	],
+
+	trainerType: "Stadium",
+	regulationMark: "C",
+	rarity: "Secret Rare",
+};
+
+export default card;

--- a/data-asia/SM/SM10b/069.ts
+++ b/data-asia/SM/SM10b/069.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM10b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "リサイクルエネルギー",
+	},
+
+	illustrator: "",
+	category: "Energy",
+	energyType: "Special",
+
+	effect: {
+		ja: "このカードは[無]エネルギー1個ぶんとしてはたらく。このカードは、場からトラッシュされるとき、トラッシュせず、手札にもどす。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 557271,
+			},
+		},
+	],
+
+	regulationMark: "C",
+	rarity: "Secret Rare",
+};
+
+export default card;


### PR DESCRIPTION
## What

Adds the complete Japanese set **SM10b スカイレジェンド (Sky Legend)**, released 2019-04-26:

- `data-asia/SM/SM10b/001.ts` … `069.ts` — all 69 cards (54 regular + 15 secret rares: 8 SR, 3 Secret Rare, 4 UR)
- the set definition `data-asia/SM/SM10b.ts` already existed and is untouched

## Data sources

- **pokemon-card.com** (official database): Japanese names, flavor texts, National Dex numbers, official card count
- **limitlesstcg.com**: full Japanese card text, stages, weaknesses/resistances/retreat, rarities, illustrators, attack costs
- **Cardmarket**: product IDs as `thirdParty.cardmarket` on the variant objects (557192–557271; tcgplayer IDs not available to me)

## Notes

- Follows the file format and conventions of the M-era sets (#1728)
- 044/045 are Pokémon Tools that grant an attack — modeled as `effect` + `attacks`, like their English prints
- All 69 files type-check against `interfaces.d.ts` (`tsc --noEmit`)
