### PR TITLE
(data) Add Japanese SM set SM11a Remix Bout

### DIFF
--- a/data-asia/SM/SM11a/001.ts
+++ b/data-asia/SM/SM11a/001.ts
@@ -1,0 +1,62 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM11a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "フシギバナ&ツタージャGX",
+	},
+
+	illustrator: "Mitsuhiro Arita",
+	category: "Pokemon",
+	hp: 270,
+	types: ["Grass"],
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "かがやくつる" },
+			effect: {
+				ja: "自分の番に、このポケモンがバトル場にいるなら、自分の手札から[草]エネルギーをこのポケモンにつけるたび、1回使える。相手のベンチポケモンを1匹選び、バトルポケモンと入れ替える。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "フォレストダンプ" },
+			damage: 160,
+			cost: ["Grass", "Colorless", "Colorless", "Colorless"],
+		},
+		{
+			name: { ja: "ソーラープラントGX" },
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のポケモン全員に、それぞれ50ダメージ。追加でエネルギーが2個ついているなら、自分のポケモン全員のHPを、すべて回復する。［ベンチは弱点・抵抗力を計算しない。］［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 556557,
+			},
+		},
+	],
+
+	retreat: 3,
+	regulationMark: "C",
+	rarity: "Double rare",
+	dexId: [3, 495],
+
+	suffix: "TAG TEAM-GX",
+};
+
+export default card;

--- a/data-asia/SM/SM11a/002.ts
+++ b/data-asia/SM/SM11a/002.ts
@@ -1,0 +1,49 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM11a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "モンジャラ",
+	},
+
+	illustrator: "otumami",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Grass"],
+
+	description: {
+		ja: "たくさんの うごめく ツルに 覆われて 正体不明。 青いツルは 一生 伸びる。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "どくどく" },
+			cost: ["Grass"],
+			effect: {
+				ja: "相手のバトルポケモンをどくにする。このどくでのせるダメカンの数は2個になる。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 556560,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [114],
+};
+
+export default card;

--- a/data-asia/SM/SM11a/003.ts
+++ b/data-asia/SM/SM11a/003.ts
@@ -1,0 +1,62 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM11a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "モジャンボ",
+	},
+
+	illustrator: "nagimiso",
+	category: "Pokemon",
+	hp: 140,
+	types: ["Grass"],
+
+	description: {
+		ja: "植物の ツルで できた 腕を 伸ばして 獲物を 絡め取る。 腕を 食べられても へっちゃら。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "くさむすび" },
+			damage: "10+",
+			cost: ["Grass"],
+			effect: {
+				ja: "相手のバトルポケモンのにげるためのエネルギーの数×30ダメージ追加。",
+			},
+		},
+		{
+			name: { ja: "たたきつける" },
+			damage: "80×",
+			cost: ["Grass", "Colorless", "Colorless"],
+			effect: {
+				ja: "コインを2回投げ、オモテの数×80ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 556562,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "モンジャラ",
+	},
+
+	retreat: 3,
+	regulationMark: "C",
+	rarity: "Uncommon",
+	dexId: [465],
+};
+
+export default card;

--- a/data-asia/SM/SM11a/004.ts
+++ b/data-asia/SM/SM11a/004.ts
@@ -1,0 +1,55 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM11a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヘラクロス",
+	},
+
+	illustrator: "Satoshi Shirai",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Grass"],
+
+	description: {
+		ja: "太いツノが 自慢。 アローラでは クワガノンが 最大の ライバルで しょっちゅう ケンカを している。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "つきたおし" },
+			damage: 20,
+			cost: ["Grass"],
+		},
+		{
+			name: { ja: "なにくそホーン" },
+			damage: "50+",
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手の場に「TAG TEAM」のポケモンがいるなら、70ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 556564,
+			},
+		},
+	],
+
+	retreat: 3,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [214],
+};
+
+export default card;

--- a/data-asia/SM/SM11a/005.ts
+++ b/data-asia/SM/SM11a/005.ts
@@ -1,0 +1,57 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM11a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "トロピウス",
+	},
+
+	illustrator: "sowsow",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Grass"],
+
+	description: {
+		ja: "アローラに棲む トロピウスの 首に 実る フサは 他の 地方より 格別に 甘くて もう最高。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "こうごうせい" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札にある[草]エネルギーを1枚、自分のポケモンにつける。そして山札を切る。",
+			},
+		},
+		{
+			name: { ja: "リーフドレイン" },
+			damage: 50,
+			cost: ["Grass", "Colorless"],
+			effect: {
+				ja: "このポケモンのHPを「30」回復する。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 556565,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [357],
+};
+
+export default card;

--- a/data-asia/SM/SM11a/006.ts
+++ b/data-asia/SM/SM11a/006.ts
@@ -1,0 +1,47 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM11a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "シキジカ",
+	},
+
+	illustrator: "Shibuzoh.",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Grass"],
+
+	description: {
+		ja: "季節が 変わったとき だけでなく 気温や 湿度に よっても 体の色は 少し 変化する。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "たいあたり" },
+			damage: 20,
+			cost: ["Grass"],
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 556570,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [585],
+};
+
+export default card;

--- a/data-asia/SM/SM11a/007.ts
+++ b/data-asia/SM/SM11a/007.ts
@@ -1,0 +1,64 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM11a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "メブキジカ",
+	},
+
+	illustrator: "sui",
+	category: "Pokemon",
+	hp: 100,
+	types: ["Grass"],
+
+	description: {
+		ja: "季節によって 住処を 変える。 人々は メブキジカの ツノで 季節の 移り変わりを 感じる。",
+	},
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "きせつのめぐみ" },
+			effect: {
+				ja: "自分の番に1回使える。自分の山札を1枚引く。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "とびはねる" },
+			damage: 60,
+			cost: ["Grass", "Colorless"],
+			effect: {
+				ja: "のぞむなら、このポケモンをベンチポケモンと入れ替える。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 556572,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "シキジカ",
+	},
+
+	retreat: 2,
+	regulationMark: "C",
+	rarity: "Rare",
+	dexId: [586],
+};
+
+export default card;

--- a/data-asia/SM/SM11a/008.ts
+++ b/data-asia/SM/SM11a/008.ts
@@ -1,0 +1,55 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM11a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "リザードン&テールナーGX",
+	},
+
+	illustrator: "Mitsuhiro Arita",
+	category: "Pokemon",
+	hp: 270,
+	types: ["Fire"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "シャイニーフレア" },
+			damage: 180,
+			cost: ["Fire", "Fire", "Fire", "Colorless"],
+			effect: {
+				ja: "のぞむなら、自分の山札にある好きなカードを3枚まで、手札に加える。そして山札を切る。",
+			},
+		},
+		{
+			name: { ja: "ぐれんのひばしらGX" },
+			cost: ["Fire"],
+			effect: {
+				ja: "自分のトラッシュにある基本エネルギーを5枚、自分のポケモンに好きなようにつける。追加でエネルギーが1個ついているなら、相手のバトルポケモンをやけどとこんらんにする。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 556573,
+			},
+		},
+	],
+
+	retreat: 3,
+	regulationMark: "C",
+	rarity: "Double rare",
+	dexId: [6, 654],
+
+	suffix: "TAG TEAM-GX",
+};
+
+export default card;

--- a/data-asia/SM/SM11a/009.ts
+++ b/data-asia/SM/SM11a/009.ts
@@ -1,0 +1,54 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM11a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ポニータ",
+	},
+
+	illustrator: "Uta",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Fire"],
+
+	description: {
+		ja: "生まれたばかりでは 立つのがやっと。 だが 走るほどに 足腰は 鍛えられて 速度が 増していく。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ちいさなおつかい" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札にある基本エネルギーを2枚まで、相手に見せてから、手札に加える。そして山札を切る。",
+			},
+		},
+		{
+			name: { ja: "ほのお" },
+			damage: 10,
+			cost: ["Fire"],
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 556577,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [77],
+};
+
+export default card;

--- a/data-asia/SM/SM11a/010.ts
+++ b/data-asia/SM/SM11a/010.ts
@@ -1,0 +1,59 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM11a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ギャロップ",
+	},
+
+	illustrator: "Misa Tsutsui",
+	category: "Pokemon",
+	hp: 100,
+	types: ["Fire"],
+
+	description: {
+		ja: "速く 動く 物体を 見ると 競争したくなり 猛烈な スピードで 追いかけはじめる。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "かけぬける" },
+			damage: 30,
+			cost: ["Fire"],
+			effect: {
+				ja: "相手のベンチポケモン1匹にも、30ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+			},
+		},
+		{
+			name: { ja: "ほのおのしっぽ" },
+			damage: 60,
+			cost: ["Fire", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 556578,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ポニータ",
+	},
+
+	retreat: 0,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [78],
+};
+
+export default card;

--- a/data-asia/SM/SM11a/011.ts
+++ b/data-asia/SM/SM11a/011.ts
@@ -1,0 +1,55 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM11a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "エンテイ",
+	},
+
+	illustrator: "Shin Nagasawa",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Fire"],
+
+	description: {
+		ja: "新しい 火山が できるたび 生まれてくると 伝えられる 大地を 駆け巡る ポケモン。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "まきかえす" },
+			damage: "30+",
+			cost: ["Fire", "Colorless"],
+			effect: {
+				ja: "前の相手の番に、ワザのダメージで、自分のポケモンがきぜつしていたなら、90ダメージ追加。",
+			},
+		},
+		{
+			name: { ja: "ほのおのたてがみ" },
+			damage: 100,
+			cost: ["Fire", "Fire", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 556583,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "C",
+	rarity: "Uncommon",
+	dexId: [244],
+};
+
+export default card;

--- a/data-asia/SM/SM11a/012.ts
+++ b/data-asia/SM/SM11a/012.ts
@@ -1,0 +1,57 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM11a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ビクティニ",
+	},
+
+	illustrator: "Saya Tsuruta",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Fire"],
+
+	description: {
+		ja: "勝利を もたらす ポケモン。 ビクティニを 連れた トレーナーは どんな 勝負にも 勝てるという。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ビクトリーヒール" },
+			effect: {
+				ja: "自分の番に1回使える。自分のベンチポケモン1匹のHPを「20」回復する。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "かえん" },
+			damage: 30,
+			cost: ["Fire", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 556588,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Rare",
+	dexId: [494],
+};
+
+export default card;

--- a/data-asia/SM/SM11a/013.ts
+++ b/data-asia/SM/SM11a/013.ts
@@ -1,0 +1,52 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM11a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ポカブ",
+	},
+
+	illustrator: "Mina Nakai",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Fire"],
+
+	description: {
+		ja: "敵の 攻撃を 身軽に 避けて 鼻から 火の玉を 撃ち出す。 炎で 木の実を 焼いて 食べる。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ひだね" },
+			damage: 10,
+			cost: ["Fire"],
+		},
+		{
+			name: { ja: "ころがる" },
+			damage: 40,
+			cost: ["Fire", "Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 556589,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [498],
+};
+
+export default card;

--- a/data-asia/SM/SM11a/014.ts
+++ b/data-asia/SM/SM11a/014.ts
@@ -1,0 +1,56 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM11a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "チャオブー",
+	},
+
+	illustrator: "Naoyo Kimura",
+	category: "Pokemon",
+	hp: 110,
+	types: ["Fire"],
+
+	description: {
+		ja: "食べるほどに 燃やすものが 増えて 胃袋内の 炎が 強まり パワーも どんどん あふれ出すのだ。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "たいあたり" },
+			damage: 30,
+			cost: ["Fire", "Colorless"],
+		},
+		{
+			name: { ja: "ヒートスタンプ" },
+			damage: 60,
+			cost: ["Fire", "Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 556590,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ポカブ",
+	},
+
+	retreat: 4,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [499],
+};
+
+export default card;

--- a/data-asia/SM/SM11a/015.ts
+++ b/data-asia/SM/SM11a/015.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM11a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "エンブオー",
+	},
+
+	illustrator: "kawayoo",
+	category: "Pokemon",
+	hp: 170,
+	types: ["Fire"],
+
+	description: {
+		ja: "アゴの 炎で こぶしを 燃やして 炎の パンチを 繰り出す。 とても 仲間思いの ポケモン。",
+	},
+
+	stage: "Stage2",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ばくねつえんぶ" },
+			effect: {
+				ja: "自分の番に、このカードを手札から出して進化させたとき、1回使える。自分の山札を上から8枚見て、その中にある基本エネルギーを好きなだけ、自分のポケモンに好きなようにつける。残りのカードは山札にもどして切る。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ヒートブラスト" },
+			damage: 160,
+			cost: ["Fire", "Colorless", "Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 556593,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "チャオブー",
+	},
+
+	retreat: 4,
+	regulationMark: "C",
+	rarity: "Uncommon",
+	dexId: [500],
+};
+
+export default card;

--- a/data-asia/SM/SM11a/016.ts
+++ b/data-asia/SM/SM11a/016.ts
@@ -1,0 +1,56 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM11a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "カメックス&ポッチャマGX",
+	},
+
+	illustrator: "Mitsuhiro Arita",
+	category: "Pokemon",
+	hp: 270,
+	types: ["Water"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "スプラッシュメーカー" },
+			damage: 150,
+			cost: ["Water", "Water", "Colorless"],
+			effect: {
+				ja: "のぞむなら、自分の手札にある[水]エネルギーを3枚まで、自分のポケモンに好きなようにつける。その後、つけたポケモンのHPを、それぞれつけた枚数×50ダメージぶん回復する。",
+			},
+		},
+		{
+			name: { ja: "バブルランチャーGX" },
+			damage: "100+",
+			cost: ["Water", "Water", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをマヒにする。追加で[水]エネルギーが3個ついているなら、150ダメージ追加。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 556595,
+			},
+		},
+	],
+
+	retreat: 3,
+	regulationMark: "C",
+	rarity: "Double rare",
+	dexId: [9, 393],
+
+	suffix: "TAG TEAM-GX",
+};
+
+export default card;

--- a/data-asia/SM/SM11a/017.ts
+++ b/data-asia/SM/SM11a/017.ts
@@ -1,0 +1,55 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM11a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "コダック",
+	},
+
+	illustrator: "sui",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Water"],
+
+	description: {
+		ja: "念力を 使うと 頭痛が するので 普段は なるべく 何も しないで ボーっと 過ごしているよ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ひっかく" },
+			damage: 10,
+			cost: ["Colorless"],
+		},
+		{
+			name: { ja: "へんなねんぱ" },
+			damage: 20,
+			cost: ["Water", "Colorless"],
+			effect: {
+				ja: "おたがいのバトルポケモンを、それぞれこんらんにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 556597,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [54],
+};
+
+export default card;

--- a/data-asia/SM/SM11a/018.ts
+++ b/data-asia/SM/SM11a/018.ts
@@ -1,0 +1,59 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM11a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ゴルダック",
+	},
+
+	illustrator: "Shigenori Negishi",
+	category: "Pokemon",
+	hp: 110,
+	types: ["Water"],
+
+	description: {
+		ja: "泳ぎが 速い さかなポケモンでも 金縛りで 動きを 止めて 簡単に 捕まえることが できる。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "ひっかく" },
+			damage: 30,
+			cost: ["Colorless"],
+		},
+		{
+			name: { ja: "エネループ" },
+			damage: 80,
+			cost: ["Water", "Colorless"],
+			effect: {
+				ja: "このポケモンについているエネルギーを、1個手札にもどす。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 556599,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "コダック",
+	},
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [55],
+};
+
+export default card;

--- a/data-asia/SM/SM11a/019.ts
+++ b/data-asia/SM/SM11a/019.ts
@@ -1,0 +1,47 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM11a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ホエルコ",
+	},
+
+	illustrator: "Tomokazu Komiya",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Water"],
+
+	description: {
+		ja: "口を 開いたまま 泳いで 海水ごと エサを 食う。 いらない 水は 鼻から 噴き出し 捨てる。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "スプラッシュ" },
+			damage: 30,
+			cost: ["Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 556604,
+			},
+		},
+	],
+
+	retreat: 3,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [320],
+};
+
+export default card;

--- a/data-asia/SM/SM11a/020.ts
+++ b/data-asia/SM/SM11a/020.ts
@@ -1,0 +1,56 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM11a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ホエルオー",
+	},
+
+	illustrator: "Kyoko Umemoto",
+	category: "Pokemon",
+	hp: 200,
+	types: ["Water"],
+
+	description: {
+		ja: "あまりに たくさん さかなポケモンを 食らうので 数が 増えすぎると 漁師たちに 追い払われている。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "ヘビーインパクト" },
+			damage: 90,
+			cost: ["Water", "Colorless", "Colorless"],
+		},
+		{
+			name: { ja: "ハイドロスプラッシュ" },
+			damage: 140,
+			cost: ["Water", "Water", "Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 556607,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ホエルコ",
+	},
+
+	retreat: 4,
+	regulationMark: "C",
+	rarity: "Uncommon",
+	dexId: [321],
+};
+
+export default card;

--- a/data-asia/SM/SM11a/021.ts
+++ b/data-asia/SM/SM11a/021.ts
@@ -1,0 +1,57 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM11a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "カイオーガ",
+	},
+
+	illustrator: "kawayoo",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Water"],
+
+	description: {
+		ja: "大雨と 大津波で 海を 広げた 神話の ポケモン。 グラードンと 激しく 戦った。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "みちしお" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分のトラッシュにある[水]エネルギーを2枚、自分のポケモン1匹につける。",
+			},
+		},
+		{
+			name: { ja: "うずまくなみ" },
+			damage: 130,
+			cost: ["Water", "Water", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンについているエネルギーを、1個トラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 556612,
+			},
+		},
+	],
+
+	retreat: 3,
+	regulationMark: "C",
+	rarity: "Rare",
+	dexId: [382],
+};
+
+export default card;

--- a/data-asia/SM/SM11a/022.ts
+++ b/data-asia/SM/SM11a/022.ts
@@ -1,0 +1,57 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM11a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "フィオネ",
+	},
+
+	illustrator: "AKIRA EGAWA",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Water"],
+
+	description: {
+		ja: "海の 温度が 高くなると 頭の 浮き袋を ふくらませて 海面を 集団で 漂う。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ひきよせのうず" },
+			effect: {
+				ja: "このポケモンがベンチにいるなら、自分の番に1回使える。相手のバトルポケモンをベンチポケモンと入れ替える（バトル場に出すポケモンは相手が選ぶ）。その後、このポケモンについているカードをすべてトラッシュし、このポケモンを山札の下にもどす。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "みずかけ" },
+			damage: 10,
+			cost: ["Water"],
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 556613,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Uncommon",
+	dexId: [489],
+};
+
+export default card;

--- a/data-asia/SM/SM11a/023.ts
+++ b/data-asia/SM/SM11a/023.ts
@@ -1,0 +1,59 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM11a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヨマワル",
+	},
+
+	illustrator: "ryoma uratsuka",
+	category: "Pokemon",
+	hp: 40,
+	types: ["Psychic"],
+
+	description: {
+		ja: "どこまでも 獲物を 追い続ける。 執念深い 性格だが 朝日が 昇ると あきらめる。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ひとだましんか" },
+			effect: {
+				ja: "自分の番に1回使える。自分の手札を3枚トラッシュする。その後、このポケモンから進化するカードを、自分の山札から1枚選び、このポケモンにのせて進化させる。そして山札を切る。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ふきつなめ" },
+			cost: ["Psychic"],
+			effect: {
+				ja: "相手のポケモン1匹に、ダメカンを2個のせる。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 556618,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [355],
+};
+
+export default card;

--- a/data-asia/SM/SM11a/024.ts
+++ b/data-asia/SM/SM11a/024.ts
@@ -1,0 +1,54 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM11a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "サマヨール",
+	},
+
+	illustrator: "Suwama Chiaki",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Psychic"],
+
+	description: {
+		ja: "体の 中で 燃えている 人魂を のぞきこむと 魂を 吸い取られてしまう。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "かなしばり" },
+			damage: 20,
+			cost: ["Psychic"],
+			effect: {
+				ja: "相手のバトルポケモンが持っているワザを1つ選ぶ。次の相手の番、このワザを受けたポケモンは、選ばれたワザを使えない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 556620,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ヨマワル",
+	},
+
+	retreat: 3,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [356],
+};
+
+export default card;

--- a/data-asia/SM/SM11a/025.ts
+++ b/data-asia/SM/SM11a/025.ts
@@ -1,0 +1,64 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM11a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヨノワール",
+	},
+
+	illustrator: "Eske Yoshinob",
+	category: "Pokemon",
+	hp: 160,
+	types: ["Psychic"],
+
+	description: {
+		ja: "弾力のある 体の 中に 行き場のない 魂を 取りこんで あの世に 連れていくと 言われる。",
+	},
+
+	stage: "Stage2",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "しのこくいん" },
+			effect: {
+				ja: "このポケモンが、バトル場で相手のポケモンからワザのダメージを受けてきぜつしたとき、ダメカン4個を、相手のポケモンに好きなようにのせる。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "じこあんじ" },
+			damage: 60,
+			cost: ["Psychic"],
+			effect: {
+				ja: "次の自分の番、このポケモンの「じこあんじ」のダメージは「+60」される。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 556625,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "サマヨール",
+	},
+
+	retreat: 3,
+	regulationMark: "C",
+	rarity: "Rare",
+	dexId: [477],
+};
+
+export default card;

--- a/data-asia/SM/SM11a/026.ts
+++ b/data-asia/SM/SM11a/026.ts
@@ -1,0 +1,56 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM11a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ロトム",
+	},
+
+	illustrator: "Mina Nakai",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Psychic"],
+
+	description: {
+		ja: "特殊な モーターを 動かす 動力源として 長い あいだ 研究されていた ポケモン。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "サイクルドロー" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の手札を1枚トラッシュする。その後、山札を2枚引く。",
+			},
+		},
+		{
+			name: { ja: "エネアシスト" },
+			cost: ["Psychic"],
+			effect: {
+				ja: "自分のトラッシュにある基本エネルギーを2枚、自分のベンチポケモンに好きなようにつける。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 556630,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [479],
+};
+
+export default card;

--- a/data-asia/SM/SM11a/027.ts
+++ b/data-asia/SM/SM11a/027.ts
@@ -1,0 +1,52 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM11a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ボクレー",
+	},
+
+	illustrator: "miki kudo",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Psychic"],
+
+	description: {
+		ja: "子どもの声を 真似 人を 森の 奥深くへ 迷いこませる。 自分の仲間に する つもりなのだ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "つぶやく" },
+			damage: 10,
+			cost: ["Colorless"],
+		},
+		{
+			name: { ja: "ホロウショット" },
+			damage: 20,
+			cost: ["Psychic", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 556633,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [708],
+};
+
+export default card;

--- a/data-asia/SM/SM11a/028.ts
+++ b/data-asia/SM/SM11a/028.ts
@@ -1,0 +1,62 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM11a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "オーロット",
+	},
+
+	illustrator: "Shin Nagasawa",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Psychic"],
+
+	description: {
+		ja: "森の 化け物と 恐れられる。 木こりたちは オーロットが 嫌う ほのおタイプを連れ 森に 入る。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "まどわすもり" },
+			damage: 20,
+			cost: ["Colorless"],
+			effect: {
+				ja: "のぞむなら、相手のバトルポケモンをベンチポケモンと入れ替える。［バトル場に出すポケモンは相手が選ぶ。］",
+			},
+		},
+		{
+			name: { ja: "シャドーインパクト" },
+			damage: 120,
+			cost: ["Psychic", "Colorless", "Colorless"],
+			effect: {
+				ja: "自分のポケモン1匹に、ダメカンを4個のせる。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 556637,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ボクレー",
+	},
+
+	retreat: 2,
+	regulationMark: "C",
+	rarity: "Uncommon",
+	dexId: [709],
+};
+
+export default card;

--- a/data-asia/SM/SM11a/029.ts
+++ b/data-asia/SM/SM11a/029.ts
@@ -1,0 +1,57 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM11a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ダダリン",
+	},
+
+	illustrator: "Midori Harada",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Psychic"],
+
+	description: {
+		ja: "緑のモズクを 絡ませ 生気を 奪い すする。 ホエルオーみたいな 大物ばかりを 好んで 狙う。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "モズクでひろう" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分のトラッシュにあるトレーナーズを1枚、相手に見せてから、手札に加える。",
+			},
+		},
+		{
+			name: { ja: "バスタースイング" },
+			damage: 100,
+			cost: ["Psychic", "Psychic", "Colorless"],
+			effect: {
+				ja: "このワザのダメージは抵抗力を計算しない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 556640,
+			},
+		},
+	],
+
+	retreat: 3,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [781],
+};
+
+export default card;

--- a/data-asia/SM/SM11a/030.ts
+++ b/data-asia/SM/SM11a/030.ts
@@ -1,0 +1,49 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM11a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "マーシャドー",
+	},
+
+	illustrator: "0313",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Psychic"],
+
+	description: {
+		ja: "相手の 影に 潜って 動きや 力を 真似る。 真似ているうちに 本物 よりも 強くなるぞ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "かげまね" },
+			cost: ["Psychic", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンが持っているワザ（GXワザをのぞく）を1つ選び、このワザとして使う。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 556643,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Uncommon",
+	dexId: [802],
+};
+
+export default card;

--- a/data-asia/SM/SM11a/031.ts
+++ b/data-asia/SM/SM11a/031.ts
@@ -1,0 +1,49 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM11a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ズガドーン",
+	},
+
+	illustrator: "Hasuno",
+	category: "Pokemon",
+	hp: 110,
+	types: ["Psychic"],
+
+	description: {
+		ja: "クネクネ動いて 人に 近付くと 突然 頭を 爆発させた。 ウルトラビーストの 一種らしい。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "デプスボム" },
+			cost: ["Psychic", "Colorless"],
+			effect: {
+				ja: "ダメカン4個を、相手のポケモンに好きなようにのせる。相手のサイドの残り枚数が3枚なら、のせるダメカンの数は12個になる。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 556647,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "C",
+	rarity: "Rare",
+	dexId: [806],
+};
+
+export default card;

--- a/data-asia/SM/SM11a/032.ts
+++ b/data-asia/SM/SM11a/032.ts
@@ -1,0 +1,57 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM11a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "グラードン",
+	},
+
+	illustrator: "Shin Nagasawa",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Fighting"],
+
+	description: {
+		ja: "高熱で 水を 蒸発させて 大地を 広げたと 言われている。 カイオーガと 激しく 戦った。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ひでり" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の手札にある[闘]エネルギーを2枚まで、自分のポケモン1匹につける。",
+			},
+		},
+		{
+			name: { ja: "ふるえるだいち" },
+			damage: 130,
+			cost: ["Fighting", "Fighting", "Colorless"],
+			effect: {
+				ja: "次の自分の番、このポケモンは「ふるえるだいち」が使えない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 556649,
+			},
+		},
+	],
+
+	retreat: 3,
+	regulationMark: "C",
+	rarity: "Rare",
+	dexId: [383],
+};
+
+export default card;

--- a/data-asia/SM/SM11a/033.ts
+++ b/data-asia/SM/SM11a/033.ts
@@ -1,0 +1,50 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM11a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ナゲキ",
+	},
+
+	illustrator: "Ken Sugimori",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Fighting"],
+
+	description: {
+		ja: "帯を 締めると パワーアップする。 野生の ナゲキは つる草を 編んで 自分の 帯を 作る。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ぎゃくぜおい" },
+			damage: "30+",
+			cost: ["Fighting", "Colorless"],
+			effect: {
+				ja: "自分のベンチポケモンにダメカンがのっているなら、90ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 556654,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "C",
+	rarity: "Uncommon",
+	dexId: [538],
+};
+
+export default card;

--- a/data-asia/SM/SM11a/034.ts
+++ b/data-asia/SM/SM11a/034.ts
@@ -1,0 +1,47 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM11a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヤンチャム",
+	},
+
+	illustrator: "Motofumi Fujiwara",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Fighting"],
+
+	description: {
+		ja: "ゴロンダの あとを 子分の ように ついていく。 大きな 失敗を すると 葉っぱを 取られてしまう。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "パンチ" },
+			damage: 10,
+			cost: ["Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 556657,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [674],
+};
+
+export default card;

--- a/data-asia/SM/SM11a/035.ts
+++ b/data-asia/SM/SM11a/035.ts
@@ -1,0 +1,56 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM11a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ゴロンダ",
+	},
+
+	illustrator: "Shin Nagasawa",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Fighting"],
+
+	description: {
+		ja: "腕っ節が 自慢の ワイルドな ポケモン。 豪快な 性質に 惚れこむ トレーナーも 多い。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "なぐる" },
+			damage: 40,
+			cost: ["Colorless"],
+		},
+		{
+			name: { ja: "マグナムパンチ" },
+			damage: 90,
+			cost: ["Colorless", "Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 556660,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ヤンチャム",
+	},
+
+	retreat: 2,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [675],
+};
+
+export default card;

--- a/data-asia/SM/SM11a/036.ts
+++ b/data-asia/SM/SM11a/036.ts
@@ -1,0 +1,52 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM11a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "マケンカニ",
+	},
+
+	illustrator: "Miki Tanaka",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Fighting"],
+
+	description: {
+		ja: "硬い ハサミは 攻めも 守りも 得意。 マケンカニ 同士の 戦いは ボクシングの ようだ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ジャブ" },
+			damage: 10,
+			cost: ["Colorless"],
+		},
+		{
+			name: { ja: "がちんこ" },
+			damage: 30,
+			cost: ["Fighting", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 556663,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [739],
+};
+
+export default card;

--- a/data-asia/SM/SM11a/037.ts
+++ b/data-asia/SM/SM11a/037.ts
@@ -1,0 +1,64 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM11a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ケケンカニ",
+	},
+
+	illustrator: "tetsuya koizumi",
+	category: "Pokemon",
+	hp: 140,
+	types: ["Fighting"],
+
+	description: {
+		ja: "ハサミの 中に 冷気を 溜めて ぶん殴る。 分厚い 氷の 壁も 粉々に してしまうぞ。",
+	},
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "かたいこうら" },
+			effect: {
+				ja: "このポケモンが受けるワザのダメージは「-30」される。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ひょうけつパンチ" },
+			damage: "80+",
+			cost: ["Fighting", "Fighting", "Colorless"],
+			effect: {
+				ja: "このポケモンに[水]エネルギーがついているなら、80ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 556668,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "マケンカニ",
+	},
+
+	retreat: 4,
+	regulationMark: "C",
+	rarity: "Uncommon",
+	dexId: [740],
+};
+
+export default card;

--- a/data-asia/SM/SM11a/038.ts
+++ b/data-asia/SM/SM11a/038.ts
@@ -1,0 +1,55 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM11a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ナゲツケサル",
+	},
+
+	illustrator: "Masakazu Fukuda",
+	category: "Pokemon",
+	hp: 110,
+	types: ["Fighting"],
+
+	description: {
+		ja: "唾液を 使って 葉っぱを 肩に 貼り付けて マーキング。 葉っぱの 配置で どの 群れか わかるよ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "スパイクドロー" },
+			damage: 20,
+			cost: ["Fighting"],
+			effect: {
+				ja: "自分の山札を2枚引く。",
+			},
+		},
+		{
+			name: { ja: "ちきゅうなげ" },
+			damage: 70,
+			cost: ["Fighting", "Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 556670,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [766],
+};
+
+export default card;

--- a/data-asia/SM/SM11a/039.ts
+++ b/data-asia/SM/SM11a/039.ts
@@ -1,0 +1,54 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM11a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アローラニャース",
+	},
+
+	illustrator: "Sekio",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Darkness"],
+
+	description: {
+		ja: "気まぐれで わがままで 飽きっぽい。 尽くされるより 尽くすのが 好きな 一部の トレーナーに 大人気。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "いばる" },
+			cost: ["Darkness"],
+			effect: {
+				ja: "コインを1回投げオモテなら、相手のバトルポケモンについているエネルギーを、1個トラッシュする。",
+			},
+		},
+		{
+			name: { ja: "ひっかける" },
+			damage: 20,
+			cost: ["Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 556672,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [52],
+};
+
+export default card;

--- a/data-asia/SM/SM11a/040.ts
+++ b/data-asia/SM/SM11a/040.ts
@@ -1,0 +1,66 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM11a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アローラペルシアンGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 200,
+	types: ["Darkness"],
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ドヤがお" },
+			effect: {
+				ja: "このポケモンは、相手の「TAG TEAM」「ウルトラビースト」と、特殊エネルギーがついている相手のポケモンから、ワザのダメージや効果を受けない。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ツメできりさく" },
+			damage: 120,
+			cost: ["Darkness", "Colorless", "Colorless"],
+		},
+		{
+			name: { ja: "ストーククローGX" },
+			cost: ["Darkness", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のポケモン1匹に、120ダメージ。このワザのダメージは、弱点・抵抗力と、ダメージを受けるポケモンにかかっている効果を計算しない。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 556677,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "アローラニャース",
+	},
+
+	retreat: 2,
+	regulationMark: "C",
+	rarity: "Double rare",
+	dexId: [53],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM11a/041.ts
+++ b/data-asia/SM/SM11a/041.ts
@@ -1,0 +1,55 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM11a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アローラベトベター",
+	},
+
+	illustrator: "Sekio",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Darkness"],
+
+	description: {
+		ja: "アローラの ゴミ処分場 には １００匹前後が 棲んでいる。 みな たくさん ゴミを 食う 働きもの。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "とかす" },
+			damage: 10,
+			cost: ["Colorless"],
+		},
+		{
+			name: { ja: "ベトベト" },
+			damage: 20,
+			cost: ["Darkness", "Colorless"],
+			effect: {
+				ja: "コインを1回投げオモテなら、相手のバトルポケモンをマヒにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 556680,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [88],
+};
+
+export default card;

--- a/data-asia/SM/SM11a/042.ts
+++ b/data-asia/SM/SM11a/042.ts
@@ -1,0 +1,59 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM11a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アローラベトベトン",
+	},
+
+	illustrator: "MAHOU",
+	category: "Pokemon",
+	hp: 140,
+	types: ["Darkness"],
+
+	description: {
+		ja: "体内にある 毒の 種類は １００ 以上。 毒と 毒の 化学反応が 命の 源。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "パニックどく" },
+			damage: 20,
+			cost: ["Darkness", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをどくとやけどとこんらんにする。",
+			},
+		},
+		{
+			name: { ja: "ヘドロばくだん" },
+			damage: 110,
+			cost: ["Darkness", "Darkness", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 556684,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "アローラベトベター",
+	},
+
+	retreat: 4,
+	regulationMark: "C",
+	rarity: "Uncommon",
+	dexId: [89],
+};
+
+export default card;

--- a/data-asia/SM/SM11a/043.ts
+++ b/data-asia/SM/SM11a/043.ts
@@ -1,0 +1,57 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM11a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アブソル",
+	},
+
+	illustrator: "Mizue",
+	category: "Pokemon",
+	hp: 100,
+	types: ["Darkness"],
+
+	description: {
+		ja: "不吉なのは 見た目だけ。 田畑を 守ってくれたり 異変を 人に 告げてくれる ありがたい 存在。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ふきつなしらせ" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "相手の場のポケモンについている特殊エネルギーを、1個トラッシュする。",
+			},
+		},
+		{
+			name: { ja: "ダーティスロー" },
+			damage: 70,
+			cost: ["Darkness", "Colorless"],
+			effect: {
+				ja: "自分の手札を1枚トラッシュする。トラッシュできないなら、このワザは失敗。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 556687,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [359],
+};
+
+export default card;

--- a/data-asia/SM/SM11a/044.ts
+++ b/data-asia/SM/SM11a/044.ts
@@ -1,0 +1,54 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM11a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "コマタナ",
+	},
+
+	illustrator: "Ken Sugimori",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Darkness"],
+
+	description: {
+		ja: "獲物を 切り裂いたあとは 河原の 石で 刃を 研ぐ。 それぞれの コマタナに お気に入りの 石がある。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ふくろぎり" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "相手の手札を見て、その中にあるグッズを、1枚トラッシュする。",
+			},
+		},
+		{
+			name: { ja: "チクチクさす" },
+			damage: 20,
+			cost: ["Darkness", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 556692,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [624],
+};
+
+export default card;

--- a/data-asia/SM/SM11a/045.ts
+++ b/data-asia/SM/SM11a/045.ts
@@ -1,0 +1,62 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM11a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "キリキザン",
+	},
+
+	illustrator: "SATOSHI NAKAI",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Darkness"],
+
+	description: {
+		ja: "どんなに 強い キリキザンでも 頭の 刃が 刃こぼれすると ボスの 座を 引退すると いう。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "おいつめる" },
+			damage: 30,
+			cost: ["Colorless"],
+			effect: {
+				ja: "次の相手の番、このワザを受けたポケモンは、にげられない。",
+			},
+		},
+		{
+			name: { ja: "スラッシュダウン" },
+			damage: 80,
+			cost: ["Darkness", "Colorless"],
+			effect: {
+				ja: "次の自分の番、このポケモンは「スラッシュダウン」が使えない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 556694,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "コマタナ",
+	},
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [625],
+};
+
+export default card;

--- a/data-asia/SM/SM11a/046.ts
+++ b/data-asia/SM/SM11a/046.ts
@@ -1,0 +1,57 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM11a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アクジキング",
+	},
+
+	illustrator: "Kouki Saitou",
+	category: "Pokemon",
+	hp: 150,
+	types: ["Darkness"],
+
+	description: {
+		ja: "この世界では 異質で 危険だが 本来 棲んでいる 世界では 普通に 見かける 生物らしい。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "やまかじり" },
+			cost: ["Darkness"],
+			effect: {
+				ja: "相手の山札を上から1枚トラッシュする。",
+			},
+		},
+		{
+			name: { ja: "レッドバイキング" },
+			damage: 120,
+			cost: ["Darkness", "Darkness", "Colorless", "Colorless"],
+			effect: {
+				ja: "このワザのダメージで、相手のポケモンがきぜつしたなら、サイドを1枚多くとる。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 556699,
+			},
+		},
+	],
+
+	retreat: 4,
+	regulationMark: "C",
+	rarity: "Rare",
+	dexId: [799],
+};
+
+export default card;

--- a/data-asia/SM/SM11a/047.ts
+++ b/data-asia/SM/SM11a/047.ts
@@ -1,0 +1,55 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM11a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ザングース",
+	},
+
+	illustrator: "tetsuya koizumi",
+	category: "Pokemon",
+	hp: 100,
+	types: ["Colorless"],
+
+	description: {
+		ja: "何世代にも 渡って ハブネークと 戦ってきた。 鋭い ツメが 最大の 武器。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "どつく" },
+			damage: 10,
+			cost: ["Colorless"],
+		},
+		{
+			name: { ja: "ざんこくなやいば" },
+			damage: "20+",
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンにのっているダメカンの数×10ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 556703,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Uncommon",
+	dexId: [335],
+};
+
+export default card;

--- a/data-asia/SM/SM11a/048.ts
+++ b/data-asia/SM/SM11a/048.ts
@@ -1,0 +1,50 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM11a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヌイコグマ",
+	},
+
+	illustrator: "Shigenori Negishi",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Colorless"],
+
+	description: {
+		ja: "大木も へし折る 力自慢。 おしりの 器官から 匂いを 出し 仲間と コミュニケーションをとる。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "れんぞくころがり" },
+			damage: "10+",
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "ウラが出るまでコインを投げ、オモテの数×30ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 556707,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [759],
+};
+
+export default card;

--- a/data-asia/SM/SM11a/049.ts
+++ b/data-asia/SM/SM11a/049.ts
@@ -1,0 +1,64 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM11a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "キテルグマ",
+	},
+
+	illustrator: "Akira Komayama",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Colorless"],
+
+	description: {
+		ja: "大きく 手を 振るのは 威嚇と 警戒の サイン。 一刻も 早く 逃げないと 命は ない。",
+	},
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "キャリーラン" },
+			effect: {
+				ja: "このポケモンがベンチにいるかぎり、自分のバトルポケモンのにげるためのエネルギーは、2個ぶん少なくなる。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ラリアット" },
+			damage: 120,
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "コインを1回投げウラなら、このワザは失敗。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 556709,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ヌイコグマ",
+	},
+
+	retreat: 2,
+	regulationMark: "C",
+	rarity: "Uncommon",
+	dexId: [760],
+};
+
+export default card;

--- a/data-asia/SM/SM11a/050.ts
+++ b/data-asia/SM/SM11a/050.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM11a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "エネルギー回収",
+	},
+
+	illustrator: "Toyste Beach",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分のトラッシュから基本エネルギーを2枚選び、相手に見せてから、手札に加える。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 556713,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	regulationMark: "A",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM11a/051.ts
+++ b/data-asia/SM/SM11a/051.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM11a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "エネルギーつけかえ",
+	},
+
+	illustrator: "Ryo Ueda",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分のポケモンについている基本エネルギーを1個、自分の別のポケモンにつけ替える。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 556717,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	regulationMark: "A",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM11a/052.ts
+++ b/data-asia/SM/SM11a/052.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM11a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "グレートキャッチャー",
+	},
+
+	illustrator: "Studio Bora Inc.",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードは、自分の手札を2枚トラッシュしなければ使えない。相手のベンチの「ポケモンGX・EX」を1匹選び、バトルポケモンと入れ替える。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 556718,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	regulationMark: "C",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM11a/053.ts
+++ b/data-asia/SM/SM11a/053.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM11a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ポケモンいれかえ",
+	},
+
+	illustrator: "Ryo Ueda",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分のバトルポケモンをベンチポケモンと入れ替える。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 556720,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	regulationMark: "A",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM11a/054.ts
+++ b/data-asia/SM/SM11a/054.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM11a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ポケモン通信",
+	},
+
+	illustrator: "Ayaka Yoshida",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の手札からポケモンを1枚選び、相手に見せてから、山札にもどす。もどした場合、自分の山札からポケモンを1枚選び、相手に見せてから、手札に加える。そして山札を切る。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 556722,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	regulationMark: "C",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM11a/055.ts
+++ b/data-asia/SM/SM11a/055.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM11a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アンズ",
+	},
+
+	illustrator: "Ken Sugimori",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の山札を上から4枚見て、その中にあるカードを2枚、手札に加える。残りのカードは山札にもどして切る。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 556724,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "C",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM11a/056.ts
+++ b/data-asia/SM/SM11a/056.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM11a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "オーキド博士のセッティング",
+	},
+
+	illustrator: "Megumi Mizutani",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の山札にある、それぞれちがうタイプのたねポケモンを3枚まで、ベンチに出す。そして山札を切る。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 556727,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "C",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM11a/057.ts
+++ b/data-asia/SM/SM11a/057.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM11a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ジャッジマン",
+	},
+
+	illustrator: "Sanosuke Sakuma",
+	category: "Trainer",
+
+	effect: {
+		ja: "おたがいのプレイヤーは、それぞれ、手札をすべて山札にもどし、山札を切る。その後、それぞれの山札を4枚引く。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 556729,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "B",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM11a/058.ts
+++ b/data-asia/SM/SM11a/058.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM11a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ローラースケーター",
+	},
+
+	illustrator: "Yusuke Ohmura",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の手札を1枚トラッシュする。その後、山札を2枚引く。トラッシュしたカードがエネルギーなら、さらに2枚引く。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 556732,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "C",
+	rarity: "Common",
+};
+
+export default card;

--- a/data-asia/SM/SM11a/059.ts
+++ b/data-asia/SM/SM11a/059.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM11a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ウィークガードエネルギー",
+	},
+
+	illustrator: "",
+	category: "Energy",
+	energyType: "Special",
+
+	effect: {
+		ja: "このカードは[無]エネルギー1個ぶんとしてはたらく。このカードをつけているポケモンの弱点は、すべてなくなる。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 556734,
+			},
+		},
+	],
+
+	regulationMark: "C",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM11a/060.ts
+++ b/data-asia/SM/SM11a/060.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM11a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ドローエネルギー",
+	},
+
+	illustrator: "",
+	category: "Energy",
+	energyType: "Special",
+
+	effect: {
+		ja: "このカードは[無]エネルギー1個ぶんとしてはたらく。このカードを手札からポケモンにつけたとき、自分の山札を1枚引く。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 556738,
+			},
+		},
+	],
+
+	regulationMark: "C",
+	rarity: "Common",
+};
+
+export default card;

--- a/data-asia/SM/SM11a/061.ts
+++ b/data-asia/SM/SM11a/061.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM11a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ダートじてんしゃ",
+	},
+
+	illustrator: "Toyste Beach",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の山札を上から2枚見て、どちらか1枚を選び、手札に加える。残りのカードはトラッシュする。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 556742,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	regulationMark: "B",
+	rarity: "Rare Holo",
+};
+
+export default card;

--- a/data-asia/SM/SM11a/062.ts
+++ b/data-asia/SM/SM11a/062.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM11a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "エスケープボード",
+	},
+
+	illustrator: "Toyste Beach",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードをつけているポケモンは、にげるためのエネルギーが1個ぶん少なくなり、ねむりまたはマヒでも、にげられる。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 556744,
+			},
+		},
+	],
+
+	trainerType: "Tool",
+	regulationMark: "B",
+	rarity: "Rare Holo",
+};
+
+export default card;

--- a/data-asia/SM/SM11a/063.ts
+++ b/data-asia/SM/SM11a/063.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM11a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "おじょうさま",
+	},
+
+	illustrator: "kirisAki",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の山札にある基本エネルギーを4枚まで、相手に見せてから、手札に加える。そして山札を切る。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 556745,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "B",
+	rarity: "Rare Holo",
+};
+
+export default card;

--- a/data-asia/SM/SM11a/064.ts
+++ b/data-asia/SM/SM11a/064.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM11a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "溶接工",
+	},
+
+	illustrator: "Hitoshi Ariga",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の手札にある[炎]エネルギーを2枚まで、自分のポケモン1匹につける。その後、自分の山札を3枚引く。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 556748,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "C",
+	rarity: "Rare Holo",
+};
+
+export default card;

--- a/data-asia/SM/SM11a/065.ts
+++ b/data-asia/SM/SM11a/065.ts
@@ -1,0 +1,62 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM11a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "フシギバナ&ツタージャGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 270,
+	types: ["Grass"],
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "かがやくつる" },
+			effect: {
+				ja: "自分の番に、このポケモンがバトル場にいるなら、自分の手札から[草]エネルギーをこのポケモンにつけるたび、1回使える。相手のベンチポケモンを1匹選び、バトルポケモンと入れ替える。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "フォレストダンプ" },
+			damage: 160,
+			cost: ["Grass", "Colorless", "Colorless", "Colorless"],
+		},
+		{
+			name: { ja: "ソーラープラントGX" },
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のポケモン全員に、それぞれ50ダメージ。追加でエネルギーが2個ついているなら、自分のポケモン全員のHPを、すべて回復する。［ベンチは弱点・抵抗力を計算しない。］［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 556753,
+			},
+		},
+	],
+
+	retreat: 3,
+	regulationMark: "C",
+	rarity: "Ultra Rare",
+	dexId: [3, 495],
+
+	suffix: "TAG TEAM-GX",
+};
+
+export default card;

--- a/data-asia/SM/SM11a/066.ts
+++ b/data-asia/SM/SM11a/066.ts
@@ -1,0 +1,62 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM11a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "フシギバナ&ツタージャGX",
+	},
+
+	illustrator: "Yuka Morii",
+	category: "Pokemon",
+	hp: 270,
+	types: ["Grass"],
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "かがやくつる" },
+			effect: {
+				ja: "自分の番に、このポケモンがバトル場にいるなら、自分の手札から[草]エネルギーをこのポケモンにつけるたび、1回使える。相手のベンチポケモンを1匹選び、バトルポケモンと入れ替える。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "フォレストダンプ" },
+			damage: 160,
+			cost: ["Grass", "Colorless", "Colorless", "Colorless"],
+		},
+		{
+			name: { ja: "ソーラープラントGX" },
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のポケモン全員に、それぞれ50ダメージ。追加でエネルギーが2個ついているなら、自分のポケモン全員のHPを、すべて回復する。［ベンチは弱点・抵抗力を計算しない。］［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 556755,
+			},
+		},
+	],
+
+	retreat: 3,
+	regulationMark: "C",
+	rarity: "Ultra Rare",
+	dexId: [3, 495],
+
+	suffix: "TAG TEAM-GX",
+};
+
+export default card;

--- a/data-asia/SM/SM11a/067.ts
+++ b/data-asia/SM/SM11a/067.ts
@@ -1,0 +1,55 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM11a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "リザードン&テールナーGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 270,
+	types: ["Fire"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "シャイニーフレア" },
+			damage: 180,
+			cost: ["Fire", "Fire", "Fire", "Colorless"],
+			effect: {
+				ja: "のぞむなら、自分の山札にある好きなカードを3枚まで、手札に加える。そして山札を切る。",
+			},
+		},
+		{
+			name: { ja: "ぐれんのひばしらGX" },
+			cost: ["Fire"],
+			effect: {
+				ja: "自分のトラッシュにある基本エネルギーを5枚、自分のポケモンに好きなようにつける。追加でエネルギーが1個ついているなら、相手のバトルポケモンをやけどとこんらんにする。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 556758,
+			},
+		},
+	],
+
+	retreat: 3,
+	regulationMark: "C",
+	rarity: "Ultra Rare",
+	dexId: [6, 654],
+
+	suffix: "TAG TEAM-GX",
+};
+
+export default card;

--- a/data-asia/SM/SM11a/068.ts
+++ b/data-asia/SM/SM11a/068.ts
@@ -1,0 +1,55 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM11a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "リザードン&テールナーGX",
+	},
+
+	illustrator: "Kagemaru Himeno",
+	category: "Pokemon",
+	hp: 270,
+	types: ["Fire"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "シャイニーフレア" },
+			damage: 180,
+			cost: ["Fire", "Fire", "Fire", "Colorless"],
+			effect: {
+				ja: "のぞむなら、自分の山札にある好きなカードを3枚まで、手札に加える。そして山札を切る。",
+			},
+		},
+		{
+			name: { ja: "ぐれんのひばしらGX" },
+			cost: ["Fire"],
+			effect: {
+				ja: "自分のトラッシュにある基本エネルギーを5枚、自分のポケモンに好きなようにつける。追加でエネルギーが1個ついているなら、相手のバトルポケモンをやけどとこんらんにする。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 556762,
+			},
+		},
+	],
+
+	retreat: 3,
+	regulationMark: "C",
+	rarity: "Ultra Rare",
+	dexId: [6, 654],
+
+	suffix: "TAG TEAM-GX",
+};
+
+export default card;

--- a/data-asia/SM/SM11a/069.ts
+++ b/data-asia/SM/SM11a/069.ts
@@ -1,0 +1,56 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM11a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "カメックス&ポッチャマGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 270,
+	types: ["Water"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "スプラッシュメーカー" },
+			damage: 150,
+			cost: ["Water", "Water", "Colorless"],
+			effect: {
+				ja: "のぞむなら、自分の手札にある[水]エネルギーを3枚まで、自分のポケモンに好きなようにつける。その後、つけたポケモンのHPを、それぞれつけた枚数×50ダメージぶん回復する。",
+			},
+		},
+		{
+			name: { ja: "バブルランチャーGX" },
+			damage: "100+",
+			cost: ["Water", "Water", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをマヒにする。追加で[水]エネルギーが3個ついているなら、150ダメージ追加。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 556763,
+			},
+		},
+	],
+
+	retreat: 3,
+	regulationMark: "C",
+	rarity: "Ultra Rare",
+	dexId: [9, 393],
+
+	suffix: "TAG TEAM-GX",
+};
+
+export default card;

--- a/data-asia/SM/SM11a/070.ts
+++ b/data-asia/SM/SM11a/070.ts
@@ -1,0 +1,56 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM11a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "カメックス&ポッチャマGX",
+	},
+
+	illustrator: "Akira Komayama",
+	category: "Pokemon",
+	hp: 270,
+	types: ["Water"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "スプラッシュメーカー" },
+			damage: 150,
+			cost: ["Water", "Water", "Colorless"],
+			effect: {
+				ja: "のぞむなら、自分の手札にある[水]エネルギーを3枚まで、自分のポケモンに好きなようにつける。その後、つけたポケモンのHPを、それぞれつけた枚数×50ダメージぶん回復する。",
+			},
+		},
+		{
+			name: { ja: "バブルランチャーGX" },
+			damage: "100+",
+			cost: ["Water", "Water", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをマヒにする。追加で[水]エネルギーが3個ついているなら、150ダメージ追加。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 556768,
+			},
+		},
+	],
+
+	retreat: 3,
+	regulationMark: "C",
+	rarity: "Ultra Rare",
+	dexId: [9, 393],
+
+	suffix: "TAG TEAM-GX",
+};
+
+export default card;

--- a/data-asia/SM/SM11a/071.ts
+++ b/data-asia/SM/SM11a/071.ts
@@ -1,0 +1,66 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM11a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アローラペルシアンGX",
+	},
+
+	illustrator: "PLANETA Tsuji",
+	category: "Pokemon",
+	hp: 200,
+	types: ["Darkness"],
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ドヤがお" },
+			effect: {
+				ja: "このポケモンは、相手の「TAG TEAM」「ウルトラビースト」と、特殊エネルギーがついている相手のポケモンから、ワザのダメージや効果を受けない。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ツメできりさく" },
+			damage: 120,
+			cost: ["Darkness", "Colorless", "Colorless"],
+		},
+		{
+			name: { ja: "ストーククローGX" },
+			cost: ["Darkness", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のポケモン1匹に、120ダメージ。このワザのダメージは、弱点・抵抗力と、ダメージを受けるポケモンにかかっている効果を計算しない。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 556772,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "アローラニャース",
+	},
+
+	retreat: 2,
+	regulationMark: "C",
+	rarity: "Ultra Rare",
+	dexId: [53],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM11a/072.ts
+++ b/data-asia/SM/SM11a/072.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM11a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "オーキド博士のセッティング",
+	},
+
+	illustrator: "Nabana Kensaku",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の山札にある、それぞれちがうタイプのたねポケモンを3枚まで、ベンチに出す。そして山札を切る。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 556774,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "C",
+	rarity: "Ultra Rare",
+};
+
+export default card;

--- a/data-asia/SM/SM11a/073.ts
+++ b/data-asia/SM/SM11a/073.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM11a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ローラースケーター",
+	},
+
+	illustrator: "nagimiso",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の手札を1枚トラッシュする。その後、山札を2枚引く。トラッシュしたカードがエネルギーなら、さらに2枚引く。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 556778,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "C",
+	rarity: "Ultra Rare",
+};
+
+export default card;

--- a/data-asia/SM/SM11a/074.ts
+++ b/data-asia/SM/SM11a/074.ts
@@ -1,0 +1,62 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM11a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "フシギバナ&ツタージャGX",
+	},
+
+	illustrator: "",
+	category: "Pokemon",
+	hp: 270,
+	types: ["Grass"],
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "かがやくつる" },
+			effect: {
+				ja: "自分の番に、このポケモンがバトル場にいるなら、自分の手札から[草]エネルギーをこのポケモンにつけるたび、1回使える。相手のベンチポケモンを1匹選び、バトルポケモンと入れ替える。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "フォレストダンプ" },
+			damage: 160,
+			cost: ["Grass", "Colorless", "Colorless", "Colorless"],
+		},
+		{
+			name: { ja: "ソーラープラントGX" },
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のポケモン全員に、それぞれ50ダメージ。追加でエネルギーが2個ついているなら、自分のポケモン全員のHPを、すべて回復する。［ベンチは弱点・抵抗力を計算しない。］［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 556780,
+			},
+		},
+	],
+
+	retreat: 3,
+	regulationMark: "C",
+	rarity: "Hyper rare",
+	dexId: [3, 495],
+
+	suffix: "TAG TEAM-GX",
+};
+
+export default card;

--- a/data-asia/SM/SM11a/075.ts
+++ b/data-asia/SM/SM11a/075.ts
@@ -1,0 +1,55 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM11a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "リザードン&テールナーGX",
+	},
+
+	illustrator: "",
+	category: "Pokemon",
+	hp: 270,
+	types: ["Fire"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "シャイニーフレア" },
+			damage: 180,
+			cost: ["Fire", "Fire", "Fire", "Colorless"],
+			effect: {
+				ja: "のぞむなら、自分の山札にある好きなカードを3枚まで、手札に加える。そして山札を切る。",
+			},
+		},
+		{
+			name: { ja: "ぐれんのひばしらGX" },
+			cost: ["Fire"],
+			effect: {
+				ja: "自分のトラッシュにある基本エネルギーを5枚、自分のポケモンに好きなようにつける。追加でエネルギーが1個ついているなら、相手のバトルポケモンをやけどとこんらんにする。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 556784,
+			},
+		},
+	],
+
+	retreat: 3,
+	regulationMark: "C",
+	rarity: "Hyper rare",
+	dexId: [6, 654],
+
+	suffix: "TAG TEAM-GX",
+};
+
+export default card;

--- a/data-asia/SM/SM11a/076.ts
+++ b/data-asia/SM/SM11a/076.ts
@@ -1,0 +1,56 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM11a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "カメックス&ポッチャマGX",
+	},
+
+	illustrator: "",
+	category: "Pokemon",
+	hp: 270,
+	types: ["Water"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "スプラッシュメーカー" },
+			damage: 150,
+			cost: ["Water", "Water", "Colorless"],
+			effect: {
+				ja: "のぞむなら、自分の手札にある[水]エネルギーを3枚まで、自分のポケモンに好きなようにつける。その後、つけたポケモンのHPを、それぞれつけた枚数×50ダメージぶん回復する。",
+			},
+		},
+		{
+			name: { ja: "バブルランチャーGX" },
+			damage: "100+",
+			cost: ["Water", "Water", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをマヒにする。追加で[水]エネルギーが3個ついているなら、150ダメージ追加。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 556785,
+			},
+		},
+	],
+
+	retreat: 3,
+	regulationMark: "C",
+	rarity: "Hyper rare",
+	dexId: [9, 393],
+
+	suffix: "TAG TEAM-GX",
+};
+
+export default card;

--- a/data-asia/SM/SM11a/077.ts
+++ b/data-asia/SM/SM11a/077.ts
@@ -1,0 +1,66 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM11a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アローラペルシアンGX",
+	},
+
+	illustrator: "",
+	category: "Pokemon",
+	hp: 200,
+	types: ["Darkness"],
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ドヤがお" },
+			effect: {
+				ja: "このポケモンは、相手の「TAG TEAM」「ウルトラビースト」と、特殊エネルギーがついている相手のポケモンから、ワザのダメージや効果を受けない。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ツメできりさく" },
+			damage: 120,
+			cost: ["Darkness", "Colorless", "Colorless"],
+		},
+		{
+			name: { ja: "ストーククローGX" },
+			cost: ["Darkness", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のポケモン1匹に、120ダメージ。このワザのダメージは、弱点・抵抗力と、ダメージを受けるポケモンにかかっている効果を計算しない。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 556788,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "アローラニャース",
+	},
+
+	retreat: 2,
+	regulationMark: "C",
+	rarity: "Hyper rare",
+	dexId: [53],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM11a/078.ts
+++ b/data-asia/SM/SM11a/078.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM11a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "グレートキャッチャー",
+	},
+
+	illustrator: "",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードは、自分の手札を2枚トラッシュしなければ使えない。相手のベンチの「ポケモンGX・EX」を1匹選び、バトルポケモンと入れ替える。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 556792,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	regulationMark: "C",
+	rarity: "Secret Rare",
+};
+
+export default card;

--- a/data-asia/SM/SM11a/079.ts
+++ b/data-asia/SM/SM11a/079.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM11a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "格闘道場",
+	},
+
+	illustrator: "",
+	category: "Trainer",
+
+	effect: {
+		ja: "おたがいの基本[闘]エネルギーがついているポケモン（「ウルトラビースト」をのぞく）が使うワザの、相手のバトルポケモンへのダメージは「+10」され、自分のサイドの残り枚数が、相手より多いなら「+40」になる。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 556795,
+			},
+		},
+	],
+
+	trainerType: "Stadium",
+	regulationMark: "C",
+	rarity: "Secret Rare",
+};
+
+export default card;

--- a/data-asia/SM/SM11a/080.ts
+++ b/data-asia/SM/SM11a/080.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM11a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ドローエネルギー",
+	},
+
+	illustrator: "",
+	category: "Energy",
+	energyType: "Special",
+
+	effect: {
+		ja: "このカードは[無]エネルギー1個ぶんとしてはたらく。このカードを手札からポケモンにつけたとき、自分の山札を1枚引く。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 556797,
+			},
+		},
+	],
+
+	regulationMark: "C",
+	rarity: "Secret Rare",
+};
+
+export default card;


### PR DESCRIPTION
## What

Adds the complete Japanese set **SM11a リミックスバウト (Remix Bout)**, released 2019-07-05:

- `data-asia/SM/SM11a/001.ts` … `080.ts` — all 80 cards (64 regular + 16 secret rares: 9 SR, 3 Secret Rare, 4 UR)
- the set definition `data-asia/SM/SM11a.ts` already existed and is untouched

## Data sources

- **pokemon-card.com** (official database): Japanese names, flavor texts, National Dex numbers, official card count
- **limitlesstcg.com**: full Japanese card text, stages, weaknesses/resistances/retreat, rarities, illustrators, attack costs
- **Cardmarket**: product IDs as `thirdParty.cardmarket` on the variant objects (556557–556797; tcgplayer IDs not available to me)

## Notes

- Follows the file format and conventions of the M-era sets (#1728)
- All 80 files type-check against `interfaces.d.ts` (`tsc --noEmit`)
