### PR TITLE
(data) Add Japanese SM set SM1S Collection Sun

### DIFF
--- a/data-asia/SM/SM1S/001.ts
+++ b/data-asia/SM/SM1S/001.ts
@@ -1,0 +1,53 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM1S";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "キャタピー",
+	},
+
+	illustrator: "Kanako Eo",
+	category: "Pokemon",
+	hp: 50,
+	types: ["Grass"],
+
+	description: {
+		ja: "とりポケモンに 襲われると ツノから 臭いを だして 抵抗 するが 餌食に なることも 多い。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ひとやすみ" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "このポケモンのHPを「20」回復する。",
+			},
+		},
+		{
+			name: { ja: "かじる" },
+			damage: 20,
+			cost: ["Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561675,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [10],
+};
+
+export default card;

--- a/data-asia/SM/SM1S/002.ts
+++ b/data-asia/SM/SM1S/002.ts
@@ -1,0 +1,57 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM1S";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "トランセル",
+	},
+
+	illustrator: "Yuka Morii",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Grass"],
+
+	description: {
+		ja: "カラの中には トロトロの 中身が 詰まっている。 ほぼ動かないのは ウッカリ 中身が こぼれないため。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "てっぺき" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "コインを1回投げオモテなら、次の相手の番、このポケモンはワザのダメージを受けない。",
+			},
+		},
+		{
+			name: { ja: "むしくい" },
+			damage: 40,
+			cost: ["Colorless", "Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561676,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "キャタピー",
+	},
+
+	retreat: 3,
+	rarity: "Common",
+	dexId: [11],
+};
+
+export default card;

--- a/data-asia/SM/SM1S/003.ts
+++ b/data-asia/SM/SM1S/003.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM1S";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "バタフリー",
+	},
+
+	illustrator: "chibi",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Grass"],
+
+	description: {
+		ja: "大きな 眼を よく 観察すると 実は 小さな 眼が 無数に 集まって できているのが わかる。",
+	},
+
+	stage: "Stage2",
+
+	attacks: [
+		{
+			name: { ja: "ねんりき" },
+			damage: 30,
+			cost: ["Colorless"],
+			effect: {
+				ja: "コインを1回投げオモテなら、相手のバトルポケモンをマヒにする。",
+			},
+		},
+		{
+			name: { ja: "ふきとばし" },
+			damage: 80,
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをベンチポケモンと入れ替える。［バトル場に出すポケモンは相手が選ぶ。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561677,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "トランセル",
+	},
+
+	retreat: 1,
+	rarity: "Uncommon",
+	dexId: [12],
+};
+
+export default card;

--- a/data-asia/SM/SM1S/004.ts
+++ b/data-asia/SM/SM1S/004.ts
@@ -1,0 +1,46 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM1S";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "パラス",
+	},
+
+	illustrator: "Ayaka Yoshida",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Grass"],
+
+	description: {
+		ja: "喰っても 喰っても 背中に 生えている キノコが ほとんど 栄養を 奪っていくのだ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ひっかく" },
+			damage: 30,
+			cost: ["Grass", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561678,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [46],
+};
+
+export default card;

--- a/data-asia/SM/SM1S/005.ts
+++ b/data-asia/SM/SM1S/005.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM1S";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "パラセクト",
+	},
+
+	illustrator: "Eri Yamaki",
+	category: "Pokemon",
+	hp: 110,
+	types: ["Grass"],
+
+	description: {
+		ja: "大きな キノコが パラセクトを 操っている。 よく マシェードと 縄張り争いを している。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "れんぞくぎり" },
+			damage: "10+",
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "コインを3回投げる。オモテが1回なら、20ダメージ追加。オモテが2回なら、60ダメージ追加。すべてオモテなら、120ダメージ追加。",
+			},
+		},
+		{
+			name: { ja: "きのこドレイン" },
+			damage: 70,
+			cost: ["Grass", "Grass", "Colorless"],
+			effect: {
+				ja: "このポケモンのHPを「30」回復する。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561679,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "パラス",
+	},
+
+	retreat: 3,
+	rarity: "Common",
+	dexId: [47],
+};
+
+export default card;

--- a/data-asia/SM/SM1S/006.ts
+++ b/data-asia/SM/SM1S/006.ts
@@ -1,0 +1,53 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM1S";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アマカジ",
+	},
+
+	illustrator: "Akira Komayama",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Grass"],
+
+	description: {
+		ja: "美味しそうな 香りが 体から 漏れ出している。 匂いに 誘われた ドデカバシに 丸呑みに される。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "あまいかおり" },
+			cost: ["Grass"],
+			effect: {
+				ja: "自分のポケモン1匹のHPを「30」回復する。",
+			},
+		},
+		{
+			name: { ja: "はねる" },
+			damage: 10,
+			cost: ["Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561680,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [761],
+};
+
+export default card;

--- a/data-asia/SM/SM1S/007.ts
+++ b/data-asia/SM/SM1S/007.ts
@@ -1,0 +1,60 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM1S";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アママイコ",
+	},
+
+	illustrator: "Mizue",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Grass"],
+
+	description: {
+		ja: "身を 守るため ヘタが 発達。 かなりの 硬さで とりポケモンに 突かれても 全然 平気だ。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "あまいかおり" },
+			cost: ["Grass"],
+			effect: {
+				ja: "自分のポケモン1匹のHPを「30」回復する。",
+			},
+		},
+		{
+			name: { ja: "ふみつけ" },
+			damage: "20+",
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "コインを1回投げオモテなら、20ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561681,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "アマカジ",
+	},
+
+	retreat: 2,
+	rarity: "Uncommon",
+	dexId: [762],
+};
+
+export default card;

--- a/data-asia/SM/SM1S/008.ts
+++ b/data-asia/SM/SM1S/008.ts
@@ -1,0 +1,63 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM1S";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アマージョ",
+	},
+
+	illustrator: "Shin Nagasawa",
+	category: "Pokemon",
+	hp: 140,
+	types: ["Grass"],
+
+	description: {
+		ja: "脚を 活かした 蹴りが 得意。 倒した 相手を 足蹴に して 高笑いで 勝利を アピール。",
+	},
+
+	stage: "Stage2",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "じょおうのいげん" },
+			effect: {
+				ja: "自分の番に、このカードを手札から出して進化させたとき、1回使える。相手の手札を見て、その中にあるカードを、1枚トラッシュする。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "トロピカルキック" },
+			damage: 80,
+			cost: ["Grass", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンのHPを「20」回復し、特殊状態もすべて回復する。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 561682,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "アママイコ",
+	},
+
+	retreat: 2,
+	rarity: "Rare",
+	dexId: [763],
+};
+
+export default card;

--- a/data-asia/SM/SM1S/009.ts
+++ b/data-asia/SM/SM1S/009.ts
@@ -1,0 +1,49 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM1S";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ガーディ",
+	},
+
+	illustrator: "MAHOU",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Fire"],
+
+	description: {
+		ja: "利口で 忠実。 ただし 見知らぬ者や 縄張りを 侵す 者には 吠えたてて いかく するぞ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "とっしん" },
+			damage: 60,
+			cost: ["Fire", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンにも20ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561683,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Common",
+	dexId: [58],
+};
+
+export default card;

--- a/data-asia/SM/SM1S/010.ts
+++ b/data-asia/SM/SM1S/010.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM1S";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ウインディ",
+	},
+
+	illustrator: "kodama",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Fire"],
+
+	description: {
+		ja: "東洋の 古い 言い伝え にも 登場する。 威厳に あふれ たくましくも 美しい ポケモン。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "やきこがす" },
+			damage: 60,
+			cost: ["Fire", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをやけどにする。",
+			},
+		},
+		{
+			name: { ja: "ほのおのあらし" },
+			damage: 190,
+			cost: ["Fire", "Fire", "Fire", "Colorless"],
+			effect: {
+				ja: "このポケモンについている[炎]エネルギーを、3個トラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 561684,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ガーディ",
+	},
+
+	retreat: 2,
+	rarity: "Rare",
+	dexId: [59],
+};
+
+export default card;

--- a/data-asia/SM/SM1S/011.ts
+++ b/data-asia/SM/SM1S/011.ts
@@ -1,0 +1,56 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM1S";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "コータス",
+	},
+
+	illustrator: "sui",
+	category: "Pokemon",
+	hp: 110,
+	types: ["Fire"],
+
+	description: {
+		ja: "石炭が エネルギーの 源。 コータスの 棲んでいる 山には 多くの 石炭が 眠っている。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "こがす" },
+			cost: ["Fire"],
+			effect: {
+				ja: "相手のバトルポケモンをやけどにする。",
+			},
+		},
+		{
+			name: { ja: "のしかかり" },
+			damage: 50,
+			cost: ["Fire", "Colorless"],
+			effect: {
+				ja: "コインを1回投げオモテなら、相手のバトルポケモンをマヒにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561685,
+			},
+		},
+	],
+
+	retreat: 3,
+	rarity: "Common",
+	dexId: [324],
+};
+
+export default card;

--- a/data-asia/SM/SM1S/012.ts
+++ b/data-asia/SM/SM1S/012.ts
@@ -1,0 +1,48 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM1S";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "コダック",
+	},
+
+	illustrator: "Shibuzoh.",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Water"],
+
+	description: {
+		ja: "自分の 意思とは 関係なく 時折 念力が でてきて 頭が 痛くて 鳴いている。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "へんなねんぱ" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "おたがいのバトルポケモンを、それぞれこんらんにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561688,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Common",
+	dexId: [54],
+};
+
+export default card;

--- a/data-asia/SM/SM1S/013.ts
+++ b/data-asia/SM/SM1S/013.ts
@@ -1,0 +1,58 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM1S";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ゴルダック",
+	},
+
+	illustrator: "Hasuno",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Water"],
+
+	description: {
+		ja: "額の 赤い 部分を 持つと 神通力を 授かると いわれ 乱獲 された 過去も ある。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "ひっかく" },
+			damage: 20,
+			cost: ["Colorless"],
+		},
+		{
+			name: { ja: "ダブルジェット" },
+			damage: "60×",
+			cost: ["Water"],
+			effect: {
+				ja: "自分の手札から[水]エネルギーを2枚までトラッシュし、その枚数x60ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561689,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "コダック",
+	},
+
+	retreat: 0,
+	rarity: "Uncommon",
+	dexId: [55],
+};
+
+export default card;

--- a/data-asia/SM/SM1S/014.ts
+++ b/data-asia/SM/SM1S/014.ts
@@ -1,0 +1,46 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM1S";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "シェルダー",
+	},
+
+	illustrator: "Midori Harada",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Water"],
+
+	description: {
+		ja: "殻の 硬度は ダイヤモンドを 超える。 昔の人は カラを 集めて 盾を 造っていた。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "たいあたり" },
+			damage: 10,
+			cost: ["Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561690,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Common",
+	dexId: [90],
+};
+
+export default card;

--- a/data-asia/SM/SM1S/015.ts
+++ b/data-asia/SM/SM1S/015.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM1S";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "パルシェン",
+	},
+
+	illustrator: "Yoshinobu Saito",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Water"],
+
+	description: {
+		ja: "硬い殻は ナパーム弾 でも 砕けない。 カラの 中味の 正体は 未だ 不明。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "じごくがため" },
+			damage: "30+",
+			cost: ["Water", "Colorless"],
+			effect: {
+				ja: "コインを1回投げオモテなら、30ダメージ追加。ウラなら、相手のバトルポケモンをマヒにする。",
+			},
+		},
+		{
+			name: { ja: "ガードプレス" },
+			damage: 80,
+			cost: ["Water", "Water", "Colorless"],
+			effect: {
+				ja: "次の相手の番、このポケモンが受けるワザのダメージは「-20」される。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561691,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "シェルダー",
+	},
+
+	retreat: 3,
+	rarity: "Common",
+	dexId: [91],
+};
+
+export default card;

--- a/data-asia/SM/SM1S/016.ts
+++ b/data-asia/SM/SM1S/016.ts
@@ -1,0 +1,62 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM1S";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ラプラスGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 190,
+	types: ["Water"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "もってくる" },
+			cost: ["Water"],
+			effect: {
+				ja: "自分の山札を3枚引く。",
+			},
+		},
+		{
+			name: { ja: "ブリザードバーン" },
+			damage: 160,
+			cost: ["Water", "Water", "Water"],
+			effect: {
+				ja: "次の自分の番、このポケモンはワザが使えない。",
+			},
+		},
+		{
+			name: { ja: "れいとうビームGX" },
+			damage: 100,
+			cost: ["Water", "Water", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをマヒにする。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 561693,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Double rare",
+	dexId: [131],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM1S/017.ts
+++ b/data-asia/SM/SM1S/017.ts
@@ -1,0 +1,56 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM1S";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヨワシ",
+	},
+
+	illustrator: "Mitsuhiro Arita",
+	category: "Pokemon",
+	hp: 30,
+	types: ["Water"],
+
+	description: {
+		ja: "ピンチになると 目が 潤みだし 輝く。 その光に 群れる 仲間と 敵に 立ち向かうのだ。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "おくびょう" },
+			effect: {
+				ja: "自分の番に1回使える（最初の自分の番と、このポケモンを場に出した番はのぞく）。このポケモンについているカードをすべてトラッシュし、このポケモンを手札にもどす。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "みずでっぽう" },
+			damage: 10,
+			cost: ["Water"],
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561694,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [746],
+};
+
+export default card;

--- a/data-asia/SM/SM1S/018.ts
+++ b/data-asia/SM/SM1S/018.ts
@@ -1,0 +1,49 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM1S";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "シズクモ",
+	},
+
+	illustrator: "Kagemaru Himeno",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Water"],
+
+	description: {
+		ja: "餌を 求め 地上に あがる。 水泡を 被るのは 呼吸と 柔らかい 頭を 守るため。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "あわ" },
+			damage: 10,
+			cost: ["Water"],
+			effect: {
+				ja: "コインを1回投げオモテなら、相手のバトルポケモンをマヒにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561695,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [751],
+};
+
+export default card;

--- a/data-asia/SM/SM1S/019.ts
+++ b/data-asia/SM/SM1S/019.ts
@@ -1,0 +1,60 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM1S";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "オニシズクモ",
+	},
+
+	illustrator: "match",
+	category: "Pokemon",
+	hp: 100,
+	types: ["Water"],
+
+	description: {
+		ja: "頭部の 水泡で ヘッドバット。 小さなポケモンで あれば そのまま 水泡に 取り込まれ 溺れ死ぬ。",
+	},
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "すいほう" },
+			effect: {
+				ja: "このポケモンは、相手の[炎]ポケモンからワザのダメージを受けない。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "アクアエッジ" },
+			damage: 70,
+			cost: ["Water", "Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561696,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "シズクモ",
+	},
+
+	retreat: 2,
+	rarity: "Uncommon",
+	dexId: [752],
+};
+
+export default card;

--- a/data-asia/SM/SM1S/020.ts
+++ b/data-asia/SM/SM1S/020.ts
@@ -1,0 +1,59 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM1S";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ナマコブシ",
+	},
+
+	illustrator: "You Iribi",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Water"],
+
+	description: {
+		ja: "ビーチなど 浅い 海に 棲む。 身体から 体内器官を だして 餌を 捕ったり 敵と 戦う。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "とびだすなかみ" },
+			effect: {
+				ja: "このポケモンが、バトル場で相手のポケモンからワザのダメージを受けてきぜつしたとき、ワザを使ったポケモンにダメカンを6個のせる。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "れんぞくころがり" },
+			damage: "30×",
+			cost: ["Water"],
+			effect: {
+				ja: "ウラが出るまでコインを投げ、オモテの数x30ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561697,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [771],
+};
+
+export default card;

--- a/data-asia/SM/SM1S/021.ts
+++ b/data-asia/SM/SM1S/021.ts
@@ -1,0 +1,48 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM1S";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ズバット",
+	},
+
+	illustrator: "Satoshi Shirai",
+	category: "Pokemon",
+	hp: 50,
+	types: ["Psychic"],
+
+	description: {
+		ja: "昼間は 洞穴で 寝ている。 目が ないので 超音波で 周りを 確認しながら 飛ぶ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "おどろかす" },
+			cost: ["Psychic"],
+			effect: {
+				ja: "相手の手札からオモテを見ないで1枚選び、そのカードのオモテを見てから、相手の山札にもどして切る。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561698,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [41],
+};
+
+export default card;

--- a/data-asia/SM/SM1S/022.ts
+++ b/data-asia/SM/SM1S/022.ts
@@ -1,0 +1,60 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM1S";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ゴルバット",
+	},
+
+	illustrator: "Masakazu Fukuda",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Psychic"],
+
+	description: {
+		ja: "太い キバは ストローのように 中が 空洞で 意外に もろい。 血を 吸うのに 特化 したのだ。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "どくのいき" },
+			cost: ["Psychic"],
+			effect: {
+				ja: "相手のバトルポケモンをどくにする。",
+			},
+		},
+		{
+			name: { ja: "アクロバット" },
+			damage: "10+",
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "コインを2回投げ、オモテの数x20ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561699,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ズバット",
+	},
+
+	retreat: 0,
+	rarity: "Uncommon",
+	dexId: [42],
+};
+
+export default card;

--- a/data-asia/SM/SM1S/023.ts
+++ b/data-asia/SM/SM1S/023.ts
@@ -1,0 +1,60 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM1S";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "クロバット",
+	},
+
+	illustrator: "DemizuPosuka",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Psychic"],
+
+	description: {
+		ja: "両足も 羽になった 結果 地上での 動きは 苦手。 はいずりまわることしか できない。",
+	},
+
+	stage: "Stage2",
+
+	attacks: [
+		{
+			name: { ja: "さんばいどく" },
+			cost: ["Psychic"],
+			effect: {
+				ja: "相手のバトルポケモンをどくにする。このどくでのせるダメカンの数は3個になる。",
+			},
+		},
+		{
+			name: { ja: "きしゅうこうげき" },
+			damage: "60+",
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "この番、このポケモンがベンチからバトル場に出ていたなら、60ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 561700,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ゴルバット",
+	},
+
+	retreat: 0,
+	rarity: "Rare",
+	dexId: [169],
+};
+
+export default card;

--- a/data-asia/SM/SM1S/024.ts
+++ b/data-asia/SM/SM1S/024.ts
@@ -1,0 +1,66 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM1S";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "エーフィGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 200,
+	types: ["Psychic"],
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "サイケこうせん" },
+			damage: 30,
+			cost: ["Psychic"],
+			effect: {
+				ja: "相手のバトルポケモンをこんらんにする。",
+			},
+		},
+		{
+			name: { ja: "サイコキネシス" },
+			damage: "60+",
+			cost: ["Psychic", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンについているエネルギーの数x30ダメージ追加。",
+			},
+		},
+		{
+			name: { ja: "ディビジョンGX" },
+			cost: ["Psychic", "Colorless", "Colorless"],
+			effect: {
+				ja: "ダメカン10個を、相手のポケモンに好きなようにのせる。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 561701,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "イーブイ",
+	},
+
+	retreat: 1,
+	rarity: "Double rare",
+	dexId: [196],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM1S/025.ts
+++ b/data-asia/SM/SM1S/025.ts
@@ -1,0 +1,48 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM1S";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヒドイデ",
+	},
+
+	illustrator: "match",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Psychic"],
+
+	description: {
+		ja: "頭に ある 毒トゲで 獲物を ズブリ。 弱ったところを １０本の 触手で 捕らえ 止めを 刺す。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "どくばり" },
+			cost: ["Psychic"],
+			effect: {
+				ja: "相手のバトルポケモンをどくにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561702,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [747],
+};
+
+export default card;

--- a/data-asia/SM/SM1S/026.ts
+++ b/data-asia/SM/SM1S/026.ts
@@ -1,0 +1,63 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM1S";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ドヒドイデ",
+	},
+
+	illustrator: "Mitsuhiro Arita",
+	category: "Pokemon",
+	hp: 110,
+	types: ["Psychic"],
+
+	description: {
+		ja: "１２本の足で 海底を はう。 ドヒドイデの はったあとには サニーゴのカスが 散らばっている。",
+	},
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "どくびし" },
+			effect: {
+				ja: "このポケモンがいるかぎり、相手のバトルポケモンがにげるたび、新しく出てきたポケモンをどくにする。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ベノムショック" },
+			damage: "50+",
+			cost: ["Psychic", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンがどくなら、50ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 561703,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ヒドイデ",
+	},
+
+	retreat: 3,
+	rarity: "Rare",
+	dexId: [748],
+};
+
+export default card;

--- a/data-asia/SM/SM1S/027.ts
+++ b/data-asia/SM/SM1S/027.ts
@@ -1,0 +1,48 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM1S";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "コスモッグ",
+	},
+
+	illustrator: "Megumi Mizutani",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Psychic"],
+
+	description: {
+		ja: "はかない ガス状の 身体。 大気の チリを 集めながら ゆっくりと 成長していく。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ちりあつめ" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札を1枚引く。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561704,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [789],
+};
+
+export default card;

--- a/data-asia/SM/SM1S/028.ts
+++ b/data-asia/SM/SM1S/028.ts
@@ -1,0 +1,52 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM1S";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "コスモウム",
+	},
+
+	illustrator: "Sanosuke Sakuma",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Psychic"],
+
+	description: {
+		ja: "死んだように まったく 動かないが 触れると ほのかに 温かい。 大昔は 星の繭と 呼ばれた。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "テレポート" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "このポケモンをベンチポケモンと入れ替える。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561705,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "コスモッグ",
+	},
+
+	retreat: 3,
+	rarity: "Uncommon",
+	dexId: [790],
+};
+
+export default card;

--- a/data-asia/SM/SM1S/029.ts
+++ b/data-asia/SM/SM1S/029.ts
@@ -1,0 +1,54 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM1S";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "マクノシタ",
+	},
+
+	illustrator: "Mina Nakai",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Fighting"],
+
+	description: {
+		ja: "元々は 他の 地方から 連れてこられたが 今は アローラの マクノシタの ほうが 有名。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ふいをつく" },
+			damage: 20,
+			cost: ["Fighting"],
+			effect: {
+				ja: "コインを1回投げウラなら、このワザは失敗。",
+			},
+		},
+		{
+			name: { ja: "かいりき" },
+			damage: 40,
+			cost: ["Fighting", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561706,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Common",
+	dexId: [296],
+};
+
+export default card;

--- a/data-asia/SM/SM1S/030.ts
+++ b/data-asia/SM/SM1S/030.ts
@@ -1,0 +1,58 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM1S";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ハリテヤマ",
+	},
+
+	illustrator: "Miki Tanaka",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Fighting"],
+
+	description: {
+		ja: "怪力で 知られるが 年老いると 戦うことを やめ マクノシタに 稽古を つけるように なるのだ。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "おしだし" },
+			damage: 60,
+			cost: ["Fighting", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをベンチポケモンと入れ替える。［バトル場に出すポケモンは相手が選ぶ。］",
+			},
+		},
+		{
+			name: { ja: "メガトンはりて" },
+			damage: 130,
+			cost: ["Fighting", "Colorless", "Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561707,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "マクノシタ",
+	},
+
+	retreat: 4,
+	rarity: "Uncommon",
+	dexId: [297],
+};
+
+export default card;

--- a/data-asia/SM/SM1S/031.ts
+++ b/data-asia/SM/SM1S/031.ts
@@ -1,0 +1,56 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM1S";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ナゲツケサル",
+	},
+
+	illustrator: "Naoki Saito",
+	category: "Pokemon",
+	hp: 110,
+	types: ["Fighting"],
+
+	description: {
+		ja: "２０匹前後の グループを つくる。 その結束は 非常に 固く 絶対 仲間を 見捨てない。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "なげつける" },
+			cost: ["Fighting"],
+			effect: {
+				ja: "相手のベンチポケモン1匹に、30ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+			},
+		},
+		{
+			name: { ja: "チームプレイ" },
+			damage: "10+",
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "自分のベンチの「ナゲツケサル」の数x30ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561708,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [766],
+};
+
+export default card;

--- a/data-asia/SM/SM1S/032.ts
+++ b/data-asia/SM/SM1S/032.ts
@@ -1,0 +1,49 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM1S";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アローラニャース",
+	},
+
+	illustrator: "Kagemaru Himeno",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Darkness"],
+
+	description: {
+		ja: "元々 アローラには いなかったが 人の 手で 増えたのち 野生化。 ズル賢くて プライドが 高い。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "みだれひっかき" },
+			damage: "10×",
+			cost: [],
+			effect: {
+				ja: "コインを3回投げ、オモテの数x10ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561709,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [52],
+};
+
+export default card;

--- a/data-asia/SM/SM1S/033.ts
+++ b/data-asia/SM/SM1S/033.ts
@@ -1,0 +1,60 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM1S";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アローラペルシアン",
+	},
+
+	illustrator: "kirisAki",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Darkness"],
+
+	description: {
+		ja: "丸い 顔と 最高級の ベルベットより 滑らかな 毛並みが アローラで 大人気の ポケモン。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "ちょうはつ" },
+			cost: [],
+			effect: {
+				ja: "相手のベンチポケモンを1匹選び、バトルポケモンと入れ替える。",
+			},
+		},
+		{
+			name: { ja: "ツメでえぐる" },
+			damage: "30+",
+			cost: ["Darkness"],
+			effect: {
+				ja: "相手のバトルポケモンにダメカンがのっているなら、30ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561710,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "アローラニャース",
+	},
+
+	retreat: 1,
+	rarity: "Uncommon",
+	dexId: [53],
+};
+
+export default card;

--- a/data-asia/SM/SM1S/034.ts
+++ b/data-asia/SM/SM1S/034.ts
@@ -1,0 +1,54 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM1S";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "メグロコ",
+	},
+
+	illustrator: "Atsuko Nishida",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Darkness"],
+
+	description: {
+		ja: "砂の中に 潜り 泳ぐように 移動。 敵に みつからないためと 体温を 下げない 知恵 なのだ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "かじる" },
+			damage: 20,
+			cost: ["Colorless", "Colorless"],
+		},
+		{
+			name: { ja: "かみくだく" },
+			damage: 30,
+			cost: ["Darkness", "Darkness", "Colorless"],
+			effect: {
+				ja: "コインを1回投げオモテなら、相手のバトルポケモンについているエネルギーを、1個トラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561711,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Common",
+	dexId: [551],
+};
+
+export default card;

--- a/data-asia/SM/SM1S/035.ts
+++ b/data-asia/SM/SM1S/035.ts
@@ -1,0 +1,58 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM1S";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ワルビル",
+	},
+
+	illustrator: "kawayoo",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Darkness"],
+
+	description: {
+		ja: "数匹の 群れを 成して 行動。 群れの 中心は ♀の 場合が 多く ♂たちが 餌を 集める。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "はたきおとす" },
+			damage: 20,
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "相手の手札からオモテを見ないで、1枚トラッシュする。",
+			},
+		},
+		{
+			name: { ja: "やみのキバ" },
+			damage: 60,
+			cost: ["Darkness", "Darkness", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561712,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "メグロコ",
+	},
+
+	retreat: 2,
+	rarity: "Uncommon",
+	dexId: [552],
+};
+
+export default card;

--- a/data-asia/SM/SM1S/036.ts
+++ b/data-asia/SM/SM1S/036.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM1S";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ワルビアル",
+	},
+
+	illustrator: "Hajime Kusajima",
+	category: "Pokemon",
+	hp: 150,
+	types: ["Darkness"],
+
+	description: {
+		ja: "砂嵐でも ５０キロ先に いる 小さな 獲物も 発見する 特殊な 両目を 持つ。",
+	},
+
+	stage: "Stage2",
+
+	attacks: [
+		{
+			name: { ja: "いいがかり" },
+			damage: "20+",
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "相手の手札の枚数x20ダメージ追加。",
+			},
+		},
+		{
+			name: { ja: "ダークファング" },
+			damage: 120,
+			cost: ["Darkness", "Darkness", "Colorless"],
+			effect: {
+				ja: "ダメージを与える前に、相手のバトルポケモンについている「ポケモンのどうぐ」をトラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 561713,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ワルビル",
+	},
+
+	retreat: 3,
+	rarity: "Rare",
+	dexId: [553],
+};
+
+export default card;

--- a/data-asia/SM/SM1S/037.ts
+++ b/data-asia/SM/SM1S/037.ts
@@ -1,0 +1,53 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM1S";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アローラディグダ",
+	},
+
+	illustrator: "Megumi Mizutani",
+	category: "Pokemon",
+	hp: 50,
+	types: ["Metal"],
+
+	description: {
+		ja: "頭から 生えているのは 髭が 変化 したもので 金属質。 ゆらゆら 動き 仲間と 交信。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "あなさぐり" },
+			cost: [],
+			effect: {
+				ja: "自分の山札を上から3枚見て、好きな順番に入れ替えて、山札の上にもどす。",
+			},
+		},
+		{
+			name: { ja: "どろかけ" },
+			damage: 10,
+			cost: ["Metal"],
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561714,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [50],
+};
+
+export default card;

--- a/data-asia/SM/SM1S/038.ts
+++ b/data-asia/SM/SM1S/038.ts
@@ -1,0 +1,62 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM1S";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アローラダグトリオ",
+	},
+
+	illustrator: "match",
+	category: "Pokemon",
+	hp: 100,
+	types: ["Metal"],
+
+	description: {
+		ja: "金色に 輝く 髭で 身を 守っている。 抜け落ちた 髭を 持ち帰ると 不幸に なると いう。",
+	},
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "カーリーヘアー" },
+			effect: {
+				ja: "このポケモンがいるかぎり、相手のバトルポケモンのにげるためのエネルギーは、1個ぶん多くなる。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "じめんにもぐる" },
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のポケモン1匹に、50ダメージ。このワザのダメージは弱点・抵抗力を計算しない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 561715,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "アローラディグダ",
+	},
+
+	retreat: 2,
+	rarity: "Rare",
+	dexId: [51],
+};
+
+export default card;

--- a/data-asia/SM/SM1S/039.ts
+++ b/data-asia/SM/SM1S/039.ts
@@ -1,0 +1,56 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM1S";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "エアームド",
+	},
+
+	illustrator: "Anesaki Dynamic",
+	category: "Pokemon",
+	hp: 110,
+	types: ["Metal"],
+
+	description: {
+		ja: "成長の度 抜け落ちる 羽は 薄く 鋭い。 昔の 戦士は 刀 として 利用した。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "メタルサウンド" },
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "おたがいの場のポケモンについている特殊エネルギーを、すべてトラッシュする。",
+			},
+		},
+		{
+			name: { ja: "つばめがえし" },
+			damage: "60+",
+			cost: ["Metal", "Colorless", "Colorless"],
+			effect: {
+				ja: "コインを1回投げオモテなら、30ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561716,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [227],
+};
+
+export default card;

--- a/data-asia/SM/SM1S/040.ts
+++ b/data-asia/SM/SM1S/040.ts
@@ -1,0 +1,68 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM1S";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ソルガレオGX",
+	},
+
+	illustrator: "PLANETA",
+	category: "Pokemon",
+	hp: 250,
+	types: ["Metal"],
+
+	stage: "Stage2",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ウルトラロード" },
+			effect: {
+				ja: "自分の番に1回使える。自分のバトルポケモンをベンチポケモンと入れ替える。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "メテオドライブ" },
+			damage: 230,
+			cost: ["Metal", "Metal", "Colorless"],
+			effect: {
+				ja: "このポケモンについているエネルギーを、すべてトラッシュする。",
+			},
+		},
+		{
+			name: { ja: "ソルバーストGX" },
+			cost: ["Metal"],
+			effect: {
+				ja: "自分の山札にあるエネルギーを5枚まで、自分のポケモンに好きなようにつける。そして山札を切る。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 561717,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "コスモウム",
+	},
+
+	retreat: 3,
+	rarity: "Double rare",
+	dexId: [791],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM1S/041.ts
+++ b/data-asia/SM/SM1S/041.ts
@@ -1,0 +1,49 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM1S";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アブリー",
+	},
+
+	illustrator: "Hitoshi Ariga",
+	category: "Pokemon",
+	hp: 30,
+	types: ["Fairy"],
+
+	description: {
+		ja: "花のミツや 花粉が 餌。 オーラを 感じる 力を 持ち 咲きそうな 花を 見分けている。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "とびまわる" },
+			damage: 10,
+			cost: ["Fairy"],
+			effect: {
+				ja: "次の相手の番、このポケモンがワザのダメージを受けるとき、自分はコインを1回投げる。オモテなら、このポケモンはそのダメージを受けない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [{ type: "Darkness", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561718,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [742],
+};
+
+export default card;

--- a/data-asia/SM/SM1S/042.ts
+++ b/data-asia/SM/SM1S/042.ts
@@ -1,0 +1,60 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM1S";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アブリボン",
+	},
+
+	illustrator: "Shin Nagasawa",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Fairy"],
+
+	description: {
+		ja: "花粉を 丸め 団子を つくる。 食用 から 戦闘用 まで たくさんの 種類が あるよ。",
+	},
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "いやしのかふん" },
+			effect: {
+				ja: "自分の番に1回使える。自分のポケモン1匹のHPを「20」回復する。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ようせいのかぜ" },
+			damage: 30,
+			cost: ["Fairy"],
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [{ type: "Darkness", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 561719,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "アブリー",
+	},
+
+	retreat: 1,
+	rarity: "Rare",
+	dexId: [743],
+};
+
+export default card;

--- a/data-asia/SM/SM1S/043.ts
+++ b/data-asia/SM/SM1S/043.ts
@@ -1,0 +1,57 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM1S";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ガルーラ",
+	},
+
+	illustrator: "TOKIYA",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Colorless"],
+
+	description: {
+		ja: "ガルーラの 母親の 愛情は 深い。 我が子を 守るためならば 死さえ 恐れないと いわれている。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ふりおろす" },
+			damage: "30+",
+			cost: ["Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンが進化ポケモンなら、30ダメージ追加。",
+			},
+		},
+		{
+			name: { ja: "ハリケーンパンチ" },
+			damage: "50×",
+			cost: ["Colorless", "Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "コインを4回投げ、オモテの数x50ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 561720,
+			},
+		},
+	],
+
+	retreat: 3,
+	rarity: "Rare",
+	dexId: [115],
+};
+
+export default card;

--- a/data-asia/SM/SM1S/044.ts
+++ b/data-asia/SM/SM1S/044.ts
@@ -1,0 +1,58 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM1S";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "イーブイ",
+	},
+
+	illustrator: "Shibuzoh.",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Colorless"],
+
+	description: {
+		ja: "アンバランス かつ 不安定な 遺伝子を 持っており 様々な 進化の 可能性を 秘めている。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "エナジーしんか" },
+			effect: {
+				ja: "自分の番に、自分の手札から基本エネルギーをこのポケモンにつけたとき、1回使える。つけたエネルギーと同じタイプの、このポケモンから進化するカードを、自分の山札から1枚選び、このポケモンにのせて進化させる。そして山札を切る。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "クイックドロー" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "コインを1回投げオモテなら、自分の山札を1枚引く。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561721,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Common",
+	dexId: [133],
+};
+
+export default card;

--- a/data-asia/SM/SM1S/045.ts
+++ b/data-asia/SM/SM1S/045.ts
@@ -1,0 +1,49 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM1S";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "パッチール",
+	},
+
+	illustrator: "Shigenori Negishi",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Colorless"],
+
+	description: {
+		ja: "フラフラ おぼつかない 足取りだが パッチール自体は 真っ直ぐに 歩いている つもりだよ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "フラフラパンチ" },
+			damage: 30,
+			cost: ["Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをこんらんにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561722,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [327],
+};
+
+export default card;

--- a/data-asia/SM/SM1S/046.ts
+++ b/data-asia/SM/SM1S/046.ts
@@ -1,0 +1,53 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM1S";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヨーテリー",
+	},
+
+	illustrator: "MAHOU",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Colorless"],
+
+	description: {
+		ja: "キャンキャン 吠えたり しないので マンション暮らしの トレーナーに 人気の 高い ポケモン。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ふるいたてる" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "次の自分の番、このポケモンが使うワザの、相手のバトルポケモンへのダメージは「+20」される。",
+			},
+		},
+		{
+			name: { ja: "かみつく" },
+			damage: 20,
+			cost: ["Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561723,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [506],
+};
+
+export default card;

--- a/data-asia/SM/SM1S/047.ts
+++ b/data-asia/SM/SM1S/047.ts
@@ -1,0 +1,60 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM1S";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ハーデリア",
+	},
+
+	illustrator: "sui",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Colorless"],
+
+	description: {
+		ja: "黒い 体毛は とても 硬くて どんどん 伸びる。 トリミング代が かかって 大変な ポケモン。",
+	},
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "おたからサーチ" },
+			effect: {
+				ja: "自分の番に、このカードを手札から出して進化させたとき、1回使える。自分のトラッシュにあるグッズを1枚、相手に見せてから、手札に加える。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "かみつく" },
+			damage: 50,
+			cost: ["Colorless", "Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561724,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ヨーテリー",
+	},
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [507],
+};
+
+export default card;

--- a/data-asia/SM/SM1S/048.ts
+++ b/data-asia/SM/SM1S/048.ts
@@ -1,0 +1,58 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM1S";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ムーランド",
+	},
+
+	illustrator: "Kagemaru Himeno",
+	category: "Pokemon",
+	hp: 150,
+	types: ["Colorless"],
+
+	description: {
+		ja: "賢く 温厚で 勇敢。 レスキュー隊の 隊員たちの 頼れる 相棒だぞ。",
+	},
+
+	stage: "Stage2",
+
+	attacks: [
+		{
+			name: { ja: "ほえたてる" },
+			damage: 50,
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "次の相手の番、このワザを受けたポケモンが使うワザのダメージは「-50」される。",
+			},
+		},
+		{
+			name: { ja: "ぶちかます" },
+			damage: 120,
+			cost: ["Colorless", "Colorless", "Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561725,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ハーデリア",
+	},
+
+	retreat: 3,
+	rarity: "Uncommon",
+	dexId: [508],
+};
+
+export default card;

--- a/data-asia/SM/SM1S/049.ts
+++ b/data-asia/SM/SM1S/049.ts
@@ -1,0 +1,51 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM1S";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヤングース",
+	},
+
+	illustrator: "match",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Colorless"],
+
+	description: {
+		ja: "鋭いキバで なんにでも かみつく。 元々 アローラには 棲んでおらず 他の地方から 連れてこられた。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "たいあたり" },
+			damage: 10,
+			cost: ["Colorless"],
+		},
+		{
+			name: { ja: "かみつく" },
+			damage: 20,
+			cost: ["Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561726,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [734],
+};
+
+export default card;

--- a/data-asia/SM/SM1S/050.ts
+++ b/data-asia/SM/SM1S/050.ts
@@ -1,0 +1,66 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM1S";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "デカグースGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 210,
+	types: ["Colorless"],
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ガサいれ" },
+			effect: {
+				ja: "自分の番に1回使える。相手の手札を見る。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "とびだしヘッド" },
+			damage: 100,
+			cost: ["Colorless", "Colorless", "Colorless"],
+		},
+		{
+			name: { ja: "デカチャンスGX" },
+			damage: "10+",
+			cost: ["Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンについているエネルギーの数x50ダメージ追加。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 561727,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ヤングース",
+	},
+
+	retreat: 2,
+	rarity: "Double rare",
+	dexId: [735],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM1S/051.ts
+++ b/data-asia/SM/SM1S/051.ts
@@ -1,0 +1,46 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM1S";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヌイコグマ",
+	},
+
+	illustrator: "Sanosuke Sakuma",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Colorless"],
+
+	description: {
+		ja: "愛くるしい 見た目だが 怒って ジタバタする 手足に ぶつかると プロレスラーでも 吹っ飛ばされる。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "たいあたり" },
+			damage: 30,
+			cost: ["Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561728,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Common",
+	dexId: [759],
+};
+
+export default card;

--- a/data-asia/SM/SM1S/052.ts
+++ b/data-asia/SM/SM1S/052.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM1S";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "キテルグマ",
+	},
+
+	illustrator: "kirisAki",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Colorless"],
+
+	description: {
+		ja: "圧倒的な 筋力を 持つ 非常に 危険な ポケモン。 生息地は 基本 立ち入り禁止。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "ベアハッグ" },
+			damage: 40,
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "次の相手の番、このワザを受けたポケモンは、にげられない。",
+			},
+		},
+		{
+			name: { ja: "ばかぢから" },
+			damage: "80+",
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "のぞむなら、40ダメージ追加。その場合、このポケモンにも20ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561729,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ヌイコグマ",
+	},
+
+	retreat: 3,
+	rarity: "Uncommon",
+	dexId: [760],
+};
+
+export default card;

--- a/data-asia/SM/SM1S/053.ts
+++ b/data-asia/SM/SM1S/053.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM1S";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "クラッシュハンマー",
+	},
+
+	illustrator: "Yoshinobu Saito",
+	category: "Trainer",
+
+	effect: {
+		ja: "コインを1回投げオモテなら、相手のポケモンについているエネルギーを1個選び、トラッシュする。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561730,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM1S/054.ts
+++ b/data-asia/SM/SM1S/054.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM1S";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "タイマーボール",
+	},
+
+	illustrator: "Toyste Beach",
+	category: "Trainer",
+
+	effect: {
+		ja: "コインを2回投げ、オモテの数ぶん、自分の山札にある進化ポケモンを、相手に見せてから、手札に加える。そして山札を切る。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561731,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM1S/055.ts
+++ b/data-asia/SM/SM1S/055.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM1S";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "むしよけスプレー",
+	},
+
+	illustrator: "Yoshinobu Saito",
+	category: "Trainer",
+
+	effect: {
+		ja: "相手のバトルポケモンをベンチポケモンと入れ替える。［バトル場に出すポケモンは相手が選ぶ。］",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561732,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM1S/056.ts
+++ b/data-asia/SM/SM1S/056.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM1S";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ロトム図鑑",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分のサイドを数えたあと、すべて山札にもどして切る。その後、山札の上から、もどした枚数ぶんのカードを、サイドとして置く。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561733,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM1S/057.ts
+++ b/data-asia/SM/SM1S/057.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM1S";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "学習装置",
+	},
+
+	illustrator: "Toyste Beach",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分のバトルポケモンが、相手のワザのダメージを受けてきぜつするたび、そのポケモンについていた基本エネルギーを1枚、このカードをつけているポケモンにつけ替えてよい。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561734,
+			},
+		},
+	],
+
+	trainerType: "Tool",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM1S/058.ts
+++ b/data-asia/SM/SM1S/058.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM1S";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "イリマ",
+	},
+
+	illustrator: "Ken Sugimori",
+	category: "Trainer",
+
+	effect: {
+		ja: "おたがいのプレイヤーは、それぞれ手札をすべて山札にもどして切る。その後、おたがいのプレイヤーは、それぞれコインを1回投げ、オモテなら6枚、ウラなら3枚、山札を引く。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561735,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM1S/059.ts
+++ b/data-asia/SM/SM1S/059.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM1S";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ククイ博士",
+	},
+
+	illustrator: "Ken Sugimori",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の山札を2枚引く。この番、自分のポケモンが使うワザの、相手のバトルポケモンへのダメージは「+20」される。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561736,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM1S/060.ts
+++ b/data-asia/SM/SM1S/060.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM1S";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ダブル無色エネルギー",
+	},
+
+	illustrator: "",
+	category: "Energy",
+	energyType: "Special",
+
+	effect: {
+		ja: "このカードは、[無]エネルギー2個ぶんとしてはたらく。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561737,
+			},
+		},
+	],
+
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM1S/061.ts
+++ b/data-asia/SM/SM1S/061.ts
@@ -1,0 +1,62 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM1S";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ラプラスGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 190,
+	types: ["Water"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "もってくる" },
+			cost: ["Water"],
+			effect: {
+				ja: "自分の山札を3枚引く。",
+			},
+		},
+		{
+			name: { ja: "ブリザードバーン" },
+			damage: 160,
+			cost: ["Water", "Water", "Water"],
+			effect: {
+				ja: "次の自分の番、このポケモンはワザが使えない。",
+			},
+		},
+		{
+			name: { ja: "れいとうビームGX" },
+			damage: 100,
+			cost: ["Water", "Water", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをマヒにする。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 561738,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Ultra Rare",
+	dexId: [131],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM1S/062.ts
+++ b/data-asia/SM/SM1S/062.ts
@@ -1,0 +1,66 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM1S";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "エーフィGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 200,
+	types: ["Psychic"],
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "サイケこうせん" },
+			damage: 30,
+			cost: ["Psychic"],
+			effect: {
+				ja: "相手のバトルポケモンをこんらんにする。",
+			},
+		},
+		{
+			name: { ja: "サイコキネシス" },
+			damage: "60+",
+			cost: ["Psychic", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンについているエネルギーの数x30ダメージ追加。",
+			},
+		},
+		{
+			name: { ja: "ディビジョンGX" },
+			cost: ["Psychic", "Colorless", "Colorless"],
+			effect: {
+				ja: "ダメカン10個を、相手のポケモンに好きなようにのせる。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 561739,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "イーブイ",
+	},
+
+	retreat: 1,
+	rarity: "Ultra Rare",
+	dexId: [196],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM1S/063.ts
+++ b/data-asia/SM/SM1S/063.ts
@@ -1,0 +1,68 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM1S";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ソルガレオGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 250,
+	types: ["Metal"],
+
+	stage: "Stage2",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ウルトラロード" },
+			effect: {
+				ja: "自分の番に1回使える。自分のバトルポケモンをベンチポケモンと入れ替える。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "メテオドライブ" },
+			damage: 230,
+			cost: ["Metal", "Metal", "Colorless"],
+			effect: {
+				ja: "このポケモンについているエネルギーを、すべてトラッシュする。",
+			},
+		},
+		{
+			name: { ja: "ソルバーストGX" },
+			cost: ["Metal"],
+			effect: {
+				ja: "自分の山札にあるエネルギーを5枚まで、自分のポケモンに好きなようにつける。そして山札を切る。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 561740,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "コスモウム",
+	},
+
+	retreat: 3,
+	rarity: "Ultra Rare",
+	dexId: [791],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM1S/064.ts
+++ b/data-asia/SM/SM1S/064.ts
@@ -1,0 +1,66 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM1S";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "デカグースGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 210,
+	types: ["Colorless"],
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ガサいれ" },
+			effect: {
+				ja: "自分の番に1回使える。相手の手札を見る。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "とびだしヘッド" },
+			damage: 100,
+			cost: ["Colorless", "Colorless", "Colorless"],
+		},
+		{
+			name: { ja: "デカチャンスGX" },
+			damage: "10+",
+			cost: ["Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンについているエネルギーの数x50ダメージ追加。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 561741,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ヤングース",
+	},
+
+	retreat: 2,
+	rarity: "Ultra Rare",
+	dexId: [735],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM1S/065.ts
+++ b/data-asia/SM/SM1S/065.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM1S";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "イリマ",
+	},
+
+	illustrator: "Sanosuke Sakuma",
+	category: "Trainer",
+
+	effect: {
+		ja: "おたがいのプレイヤーは、それぞれ手札をすべて山札にもどして切る。その後、おたがいのプレイヤーは、それぞれコインを1回投げ、オモテなら6枚、ウラなら3枚、山札を引く。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 561742,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	rarity: "Ultra Rare",
+};
+
+export default card;

--- a/data-asia/SM/SM1S/066.ts
+++ b/data-asia/SM/SM1S/066.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM1S";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ククイ博士",
+	},
+
+	illustrator: "Megumi Mizutani",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の山札を2枚引く。この番、自分のポケモンが使うワザの、相手のバトルポケモンへのダメージは「+20」される。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 561743,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	rarity: "Ultra Rare",
+};
+
+export default card;

--- a/data-asia/SM/SM1S/067.ts
+++ b/data-asia/SM/SM1S/067.ts
@@ -1,0 +1,62 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM1S";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ラプラスGX",
+	},
+
+	illustrator: "",
+	category: "Pokemon",
+	hp: 190,
+	types: ["Water"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "もってくる" },
+			cost: ["Water"],
+			effect: {
+				ja: "自分の山札を3枚引く。",
+			},
+		},
+		{
+			name: { ja: "ブリザードバーン" },
+			damage: 160,
+			cost: ["Water", "Water", "Water"],
+			effect: {
+				ja: "次の自分の番、このポケモンはワザが使えない。",
+			},
+		},
+		{
+			name: { ja: "れいとうビームGX" },
+			damage: 100,
+			cost: ["Water", "Water", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをマヒにする。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 561744,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Hyper rare",
+	dexId: [131],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM1S/068.ts
+++ b/data-asia/SM/SM1S/068.ts
@@ -1,0 +1,66 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM1S";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "エーフィGX",
+	},
+
+	illustrator: "",
+	category: "Pokemon",
+	hp: 200,
+	types: ["Psychic"],
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "サイケこうせん" },
+			damage: 30,
+			cost: ["Psychic"],
+			effect: {
+				ja: "相手のバトルポケモンをこんらんにする。",
+			},
+		},
+		{
+			name: { ja: "サイコキネシス" },
+			damage: "60+",
+			cost: ["Psychic", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンについているエネルギーの数x30ダメージ追加。",
+			},
+		},
+		{
+			name: { ja: "ディビジョンGX" },
+			cost: ["Psychic", "Colorless", "Colorless"],
+			effect: {
+				ja: "ダメカン10個を、相手のポケモンに好きなようにのせる。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 561745,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "イーブイ",
+	},
+
+	retreat: 1,
+	rarity: "Hyper rare",
+	dexId: [196],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM1S/069.ts
+++ b/data-asia/SM/SM1S/069.ts
@@ -1,0 +1,68 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM1S";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ソルガレオGX",
+	},
+
+	illustrator: "",
+	category: "Pokemon",
+	hp: 250,
+	types: ["Metal"],
+
+	stage: "Stage2",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ウルトラロード" },
+			effect: {
+				ja: "自分の番に1回使える。自分のバトルポケモンをベンチポケモンと入れ替える。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "メテオドライブ" },
+			damage: 230,
+			cost: ["Metal", "Metal", "Colorless"],
+			effect: {
+				ja: "このポケモンについているエネルギーを、すべてトラッシュする。",
+			},
+		},
+		{
+			name: { ja: "ソルバーストGX" },
+			cost: ["Metal"],
+			effect: {
+				ja: "自分の山札にあるエネルギーを5枚まで、自分のポケモンに好きなようにつける。そして山札を切る。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 561746,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "コスモウム",
+	},
+
+	retreat: 3,
+	rarity: "Hyper rare",
+	dexId: [791],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM1S/070.ts
+++ b/data-asia/SM/SM1S/070.ts
@@ -1,0 +1,66 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM1S";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "デカグースGX",
+	},
+
+	illustrator: "",
+	category: "Pokemon",
+	hp: 210,
+	types: ["Colorless"],
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ガサいれ" },
+			effect: {
+				ja: "自分の番に1回使える。相手の手札を見る。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "とびだしヘッド" },
+			damage: 100,
+			cost: ["Colorless", "Colorless", "Colorless"],
+		},
+		{
+			name: { ja: "デカチャンスGX" },
+			damage: "10+",
+			cost: ["Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンについているエネルギーの数x50ダメージ追加。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 561747,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ヤングース",
+	},
+
+	retreat: 2,
+	rarity: "Hyper rare",
+	dexId: [735],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM1S/071.ts
+++ b/data-asia/SM/SM1S/071.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM1S";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ハイパーボール",
+	},
+
+	illustrator: "",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードは、自分の手札を2枚トラッシュしなければ使えない。自分の山札からポケモンを1枚選び、相手に見せてから、手札に加える。そして山札を切る。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 561748,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	rarity: "Secret Rare",
+};
+
+export default card;

--- a/data-asia/SM/SM1S/072.ts
+++ b/data-asia/SM/SM1S/072.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM1S";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ロトム図鑑",
+	},
+
+	illustrator: "",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分のサイドを数えたあと、すべて山札にもどして切る。その後、山札の上から、もどした枚数ぶんのカードを、サイドとして置く。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 561749,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	rarity: "Secret Rare",
+};
+
+export default card;

--- a/data-asia/SM/SM1S/073.ts
+++ b/data-asia/SM/SM1S/073.ts
@@ -1,0 +1,26 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM1S";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "基本鋼エネルギー",
+	},
+
+	illustrator: "",
+	category: "Energy",
+	energyType: "Normal",
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 561750,
+			},
+		},
+	],
+
+	rarity: "Secret Rare",
+};
+
+export default card;


### PR DESCRIPTION
## What

Adds the complete Japanese set **SM1S コレクション サン (Collection Sun)**, released 2016-12-09:

- `data-asia/SM/SM1S/001.ts` … `073.ts` — all 73 cards (60 regular + 13 secret rares: 6 SR, 3 Secret Rare, 4 UR)
- the set definition `data-asia/SM/SM1S.ts` already existed and is untouched

## Data sources

- **pokemon-card.com** (official database): Japanese names, flavor texts, National Dex numbers, official card count
- **limitlesstcg.com**: full Japanese card text, stages, weaknesses/resistances/retreat, rarities, illustrators, attack costs
- **Cardmarket**: product IDs as `thirdParty.cardmarket` on the variant objects (561675–561750; tcgplayer IDs not available to me)

## Notes

- Follows the file format and conventions of the M-era sets (#1728)
- No `regulationMark` (the set predates regulation marks); resistances are `-20` per the era
- All 73 files type-check against `interfaces.d.ts` (`tsc --noEmit`)
