### PR TITLE
(data) Add Japanese SM set SM1p Sun and Moon plus

### DIFF
--- a/data-asia/SM/SM1p.ts
+++ b/data-asia/SM/SM1p.ts
@@ -1,0 +1,20 @@
+import { Set } from "../../interfaces";
+import serie from "../SM";
+
+const set: Set = {
+	id: "SM1p",
+	name: {
+		ja: "サン＆ムーン",
+	},
+
+	serie: serie,
+
+	cardCount: {
+		official: 51,
+	},
+	releaseDate: {
+		ja: "2017-01-27",
+	},
+};
+
+export default set;

--- a/data-asia/SM/SM1p/001.ts
+++ b/data-asia/SM/SM1p/001.ts
@@ -1,0 +1,51 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM1p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "モクロー",
+	},
+
+	illustrator: "Megumi Mizutani",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Grass"],
+
+	description: {
+		ja: "警戒心が 強い。 昼は 光合成で 力を 溜めて 夜になったら 活動開始。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "たいあたり" },
+			damage: 10,
+			cost: ["Colorless"],
+		},
+		{
+			name: { ja: "このは" },
+			damage: 20,
+			cost: ["Grass", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561529,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "None",
+	dexId: [722],
+};
+
+export default card;

--- a/data-asia/SM/SM1p/002.ts
+++ b/data-asia/SM/SM1p/002.ts
@@ -1,0 +1,60 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM1p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "フクスロー",
+	},
+
+	illustrator: "Mizue",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Grass"],
+
+	description: {
+		ja: "気取り屋で 暇が あれば 翼の 手入れ。 羽毛の 汚れが 気に なりすぎて 戦えないことも。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "するどいはばね" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "相手のポケモン1匹に、20ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+			},
+		},
+		{
+			name: { ja: "リーフブレード" },
+			damage: "50+",
+			cost: ["Grass", "Colorless", "Colorless"],
+			effect: {
+				ja: "コインを1回投げオモテなら、20ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561530,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "モクロー",
+	},
+
+	retreat: 1,
+	rarity: "None",
+	dexId: [723],
+};
+
+export default card;

--- a/data-asia/SM/SM1p/003.ts
+++ b/data-asia/SM/SM1p/003.ts
@@ -1,0 +1,65 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM1p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ジュナイパーGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 240,
+	types: ["Grass"],
+
+	stage: "Stage2",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "フェザーアロー" },
+			effect: {
+				ja: "自分の番に1回使える。相手のポケモン1匹に、ダメカンを2個のせる。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "はっぱカッター" },
+			damage: 90,
+			cost: ["Grass", "Colorless", "Colorless"],
+		},
+		{
+			name: { ja: "ホロウハントGX" },
+			cost: ["Grass"],
+			effect: {
+				ja: "自分のトラッシュにある好きなカードを3枚、相手に見せてから、手札に加える。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 561531,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "フクスロー",
+	},
+
+	retreat: 2,
+	rarity: "Double rare",
+	dexId: [724],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM1p/004.ts
+++ b/data-asia/SM/SM1p/004.ts
@@ -1,0 +1,46 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM1p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アゴジムシ",
+	},
+
+	illustrator: "Akira Komayama",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Grass"],
+
+	description: {
+		ja: "とりポケモンに 襲われないよう でんきポケモンが 棲む 場所に 集まっていることが 多い。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "はさむ" },
+			damage: 20,
+			cost: ["Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561532,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "None",
+	dexId: [736],
+};
+
+export default card;

--- a/data-asia/SM/SM1p/005.ts
+++ b/data-asia/SM/SM1p/005.ts
@@ -1,0 +1,53 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM1p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "カリキリ",
+	},
+
+	illustrator: "Kagemaru Himeno",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Grass"],
+
+	description: {
+		ja: "爽やかで 甘い香りが する。 カリキリが 隠れている 草むらには よく アブリーが 群れている。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "こうごうせい" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札にある[草]エネルギーを1枚、自分のポケモンにつける。そして山札を切る。",
+			},
+		},
+		{
+			name: { ja: "このは" },
+			damage: 20,
+			cost: ["Grass", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561533,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "None",
+	dexId: [753],
+};
+
+export default card;

--- a/data-asia/SM/SM1p/006.ts
+++ b/data-asia/SM/SM1p/006.ts
@@ -1,0 +1,60 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM1p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ラランテス",
+	},
+
+	illustrator: "Mitsuhiro Arita",
+	category: "Pokemon",
+	hp: 100,
+	types: ["Grass"],
+
+	description: {
+		ja: "鮮やかな 体色を 保つには 非常に 手間が かかるが それを 趣味にする 好事家も いるのだ。",
+	},
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "にほんばれ" },
+			effect: {
+				ja: "このポケモンがいるかぎり、自分の[草]または[炎]ポケモンが使うワザの、相手のバトルポケモンへのダメージは「+20」される。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ソーラービーム" },
+			damage: 80,
+			cost: ["Grass", "Grass", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561534,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "カリキリ",
+	},
+
+	retreat: 2,
+	rarity: "None",
+	dexId: [754],
+};
+
+export default card;

--- a/data-asia/SM/SM1p/007.ts
+++ b/data-asia/SM/SM1p/007.ts
@@ -1,0 +1,51 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM1p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ニャビー",
+	},
+
+	illustrator: "Akira Komayama",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Fire"],
+
+	description: {
+		ja: "毛づくろいで お腹に 溜まった 抜け毛を 燃やして 火を 吹く。 毛の 吐きかたで 炎も 変化。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "かみつく" },
+			damage: 10,
+			cost: ["Fire"],
+		},
+		{
+			name: { ja: "ほのお" },
+			damage: 20,
+			cost: ["Fire", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561535,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "None",
+	dexId: [725],
+};
+
+export default card;

--- a/data-asia/SM/SM1p/008.ts
+++ b/data-asia/SM/SM1p/008.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM1p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ニャヒート",
+	},
+
+	illustrator: "TOKIYA",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Fire"],
+
+	description: {
+		ja: "首の 付け根に 炎の 鈴が ある。 炎が 噴きだすとき リンリンと 高い音が 鳴る。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "みだれひっかき" },
+			damage: "20×",
+			cost: ["Fire"],
+			effect: {
+				ja: "コインを3回投げ、オモテの数x20ダメージ。",
+			},
+		},
+		{
+			name: { ja: "かえんほうしゃ" },
+			damage: 90,
+			cost: ["Fire", "Fire", "Colorless"],
+			effect: {
+				ja: "このポケモンについているエネルギーを、1個トラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561536,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ニャビー",
+	},
+
+	retreat: 2,
+	rarity: "None",
+	dexId: [726],
+};
+
+export default card;

--- a/data-asia/SM/SM1p/009.ts
+++ b/data-asia/SM/SM1p/009.ts
@@ -1,0 +1,67 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM1p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ガオガエンGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 250,
+	types: ["Fire"],
+
+	stage: "Stage2",
+
+	attacks: [
+		{
+			name: { ja: "ハッスルブロー" },
+			damage: "10+",
+			cost: ["Fire"],
+			effect: {
+				ja: "自分のベンチの[炎]ポケモンの数x20ダメージ追加。",
+			},
+		},
+		{
+			name: { ja: "タイガースイング" },
+			damage: "80+",
+			cost: ["Fire", "Fire", "Colorless"],
+			effect: {
+				ja: "コインを2回投げ、オモテの数x50ダメージ追加。",
+			},
+		},
+		{
+			name: { ja: "バーンスラムGX" },
+			damage: 200,
+			cost: ["Fire", "Fire", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをやけどにする。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 561537,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ニャヒート",
+	},
+
+	retreat: 3,
+	rarity: "Double rare",
+	dexId: [727],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM1p/010.ts
+++ b/data-asia/SM/SM1p/010.ts
@@ -1,0 +1,56 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM1p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "オドリドリ",
+	},
+
+	illustrator: "Shin Nagasawa",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Fire"],
+
+	description: {
+		ja: "羽を 打ち合わせて 発火。 華麗な ステップを 踏みながら 激しい 炎を 浴びせかけるぞ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "じょうねつのダンス" },
+			cost: ["Fire"],
+			effect: {
+				ja: "自分の山札にある[炎]タイプのたねポケモンを3枚まで、ベンチに出す。そして山札を切る。",
+			},
+		},
+		{
+			name: { ja: "メラメラ" },
+			damage: 30,
+			cost: ["Fire", "Fire"],
+			effect: {
+				ja: "このポケモンについているエネルギーを、1個トラッシュする。その後、相手のバトルポケモンについているエネルギーを、1個トラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561538,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "None",
+	dexId: [741],
+};
+
+export default card;

--- a/data-asia/SM/SM1p/011.ts
+++ b/data-asia/SM/SM1p/011.ts
@@ -1,0 +1,54 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM1p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ニョロモ",
+	},
+
+	illustrator: "Asako Ito",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Water"],
+
+	description: {
+		ja: "まだまだ 歩くのが 下手。 トレーナーに なったら 毎日 歩く 訓練を してあげよう。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "みずでっぽう" },
+			damage: 10,
+			cost: ["Water"],
+		},
+		{
+			name: { ja: "ハイドロポンプ" },
+			damage: "30+",
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンについている[水]エネルギーの数x10ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561539,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "None",
+	dexId: [60],
+};
+
+export default card;

--- a/data-asia/SM/SM1p/012.ts
+++ b/data-asia/SM/SM1p/012.ts
@@ -1,0 +1,58 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM1p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ニョロゾ",
+	},
+
+	illustrator: "Atsuko Nishida",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Water"],
+
+	description: {
+		ja: "陸上を 練り歩いて 餌の むしポケモンを 探す。 食べるのは 安全な 水の中。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "おうふくビンタ" },
+			damage: "30×",
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "コインを2回投げ、オモテの数x30ダメージ。",
+			},
+		},
+		{
+			name: { ja: "スプラッシュ" },
+			damage: 60,
+			cost: ["Water", "Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561540,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ニョロモ",
+	},
+
+	retreat: 2,
+	rarity: "None",
+	dexId: [61],
+};
+
+export default card;

--- a/data-asia/SM/SM1p/013.ts
+++ b/data-asia/SM/SM1p/013.ts
@@ -1,0 +1,60 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM1p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ニョロトノ",
+	},
+
+	illustrator: "Saya Tsuruta",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Water"],
+
+	description: {
+		ja: "月夜に 集まり 大合唱。 その鳴き声は 怒鳴り声のようで 美しくはないが 味が あるぞ。",
+	},
+
+	stage: "Stage2",
+
+	attacks: [
+		{
+			name: { ja: "てんこをとる" },
+			cost: ["Water"],
+			effect: {
+				ja: "自分の山札にある「ニョロモ」「ニョロゾ」「ニョロボン」を1枚ずつ、ベンチに出す。そして山札を切る。",
+			},
+		},
+		{
+			name: { ja: "ハイパージャンプ" },
+			damage: 100,
+			cost: ["Water", "Colorless", "Colorless"],
+			effect: {
+				ja: "のぞむなら、このポケモンと、ついているすべてのカードを、自分の山札にもどして切る。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561541,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ニョロゾ",
+	},
+
+	retreat: 1,
+	rarity: "None",
+	dexId: [186],
+};
+
+export default card;

--- a/data-asia/SM/SM1p/014.ts
+++ b/data-asia/SM/SM1p/014.ts
@@ -1,0 +1,51 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM1p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アシマリ",
+	},
+
+	illustrator: "Kouki Saitou",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Water"],
+
+	description: {
+		ja: "頑張り屋な 性質で 有名。 体液を 鼻で 膨らませた バルーンを 敵に ぶつける。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "はたく" },
+			damage: 10,
+			cost: ["Water"],
+		},
+		{
+			name: { ja: "みずでっぽう" },
+			damage: 20,
+			cost: ["Water", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561542,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "None",
+	dexId: [728],
+};
+
+export default card;

--- a/data-asia/SM/SM1p/015.ts
+++ b/data-asia/SM/SM1p/015.ts
@@ -1,0 +1,58 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM1p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "オシャマリ",
+	},
+
+	illustrator: "Saya Tsuruta",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Water"],
+
+	description: {
+		ja: "ダンスが 得意で 踊りながら 次々に 水の バルーンを 作りだし 敵に ぶつけるぞ。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "スプラッシュ" },
+			damage: 30,
+			cost: ["Water", "Colorless"],
+		},
+		{
+			name: { ja: "チャームボイス" },
+			damage: 50,
+			cost: ["Water", "Water", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをこんらんにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561543,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "アシマリ",
+	},
+
+	retreat: 2,
+	rarity: "None",
+	dexId: [729],
+};
+
+export default card;

--- a/data-asia/SM/SM1p/016.ts
+++ b/data-asia/SM/SM1p/016.ts
@@ -1,0 +1,66 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM1p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アシレーヌGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 250,
+	types: ["Water"],
+
+	stage: "Stage2",
+
+	attacks: [
+		{
+			name: { ja: "バブルビート" },
+			damage: "10+",
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "自分の場のポケモンについている[水]エネルギーの数x20ダメージ追加。",
+			},
+		},
+		{
+			name: { ja: "うみなり" },
+			damage: 120,
+			cost: ["Water", "Water", "Water", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンについているエネルギーを、1個トラッシュする。",
+			},
+		},
+		{
+			name: { ja: "グランエコーGX" },
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "自分のポケモン全員のHPを、すべて回復する。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 561544,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "オシャマリ",
+	},
+
+	retreat: 2,
+	rarity: "Double rare",
+	dexId: [730],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM1p/017.ts
+++ b/data-asia/SM/SM1p/017.ts
@@ -1,0 +1,49 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM1p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "シズクモ",
+	},
+
+	illustrator: "Kagemaru Himeno",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Water"],
+
+	description: {
+		ja: "餌を 求め 地上に あがる。 水泡を 被るのは 呼吸と 柔らかい 頭を 守るため。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "あわ" },
+			damage: 10,
+			cost: ["Water"],
+			effect: {
+				ja: "コインを1回投げオモテなら、相手のバトルポケモンをマヒにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561545,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "None",
+	dexId: [751],
+};
+
+export default card;

--- a/data-asia/SM/SM1p/018.ts
+++ b/data-asia/SM/SM1p/018.ts
@@ -1,0 +1,60 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM1p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "オニシズクモ",
+	},
+
+	illustrator: "match",
+	category: "Pokemon",
+	hp: 100,
+	types: ["Water"],
+
+	description: {
+		ja: "頭部の 水泡で ヘッドバット。 小さなポケモンで あれば そのまま 水泡に 取り込まれ 溺れ死ぬ。",
+	},
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "すいほう" },
+			effect: {
+				ja: "このポケモンは、相手の[炎]ポケモンからワザのダメージを受けない。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "アクアエッジ" },
+			damage: 70,
+			cost: ["Water", "Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561546,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "シズクモ",
+	},
+
+	retreat: 2,
+	rarity: "None",
+	dexId: [752],
+};
+
+export default card;

--- a/data-asia/SM/SM1p/019.ts
+++ b/data-asia/SM/SM1p/019.ts
@@ -1,0 +1,59 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM1p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ナマコブシ",
+	},
+
+	illustrator: "You Iribi",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Water"],
+
+	description: {
+		ja: "ビーチなど 浅い 海に 棲む。 身体から 体内器官を だして 餌を 捕ったり 敵と 戦う。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "とびだすなかみ" },
+			effect: {
+				ja: "このポケモンが、バトル場で相手のポケモンからワザのダメージを受けてきぜつしたとき、ワザを使ったポケモンにダメカンを6個のせる。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "れんぞくころがり" },
+			damage: "30×",
+			cost: ["Water"],
+			effect: {
+				ja: "ウラが出るまでコインを投げ、オモテの数x30ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561547,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "None",
+	dexId: [771],
+};
+
+export default card;

--- a/data-asia/SM/SM1p/020.ts
+++ b/data-asia/SM/SM1p/020.ts
@@ -1,0 +1,58 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM1p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "デンヂムシ",
+	},
+
+	illustrator: "Naoki Saito",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Lightning"],
+
+	description: {
+		ja: "喰らった 餌を 消化 するとき 発生した 電気エネルギーを 電気袋に 溜め込んでいる。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "しびれアゴ" },
+			damage: 20,
+			cost: ["Lightning", "Colorless"],
+			effect: {
+				ja: "コインを1回投げオモテなら、相手のバトルポケモンをマヒにする。",
+			},
+		},
+		{
+			name: { ja: "ライトニングボール" },
+			damage: 50,
+			cost: ["Lightning", "Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Metal", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561548,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "アゴジムシ",
+	},
+
+	retreat: 3,
+	rarity: "None",
+	dexId: [737],
+};
+
+export default card;

--- a/data-asia/SM/SM1p/021.ts
+++ b/data-asia/SM/SM1p/021.ts
@@ -1,0 +1,66 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM1p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "クワガノンGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 240,
+	types: ["Lightning"],
+
+	stage: "Stage2",
+
+	attacks: [
+		{
+			name: { ja: "チャージビーム" },
+			damage: 50,
+			cost: ["Lightning"],
+			effect: {
+				ja: "自分のトラッシュにあるエネルギーを1枚、このポケモンにつける。",
+			},
+		},
+		{
+			name: { ja: "ちょうでんじほう" },
+			damage: 180,
+			cost: ["Lightning", "Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンについているエネルギーを、2個トラッシュする。",
+			},
+		},
+		{
+			name: { ja: "ギガトロンGX" },
+			cost: ["Lightning", "Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のベンチポケモン全員に、それぞれ60ダメージ。［ベンチは弱点・抵抗力を計算しない。］［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Metal", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 561549,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "デンヂムシ",
+	},
+
+	retreat: 1,
+	rarity: "Double rare",
+	dexId: [738],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM1p/022.ts
+++ b/data-asia/SM/SM1p/022.ts
@@ -1,0 +1,53 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM1p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "オドリドリ",
+	},
+
+	illustrator: "Naoki Saito",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Lightning"],
+
+	description: {
+		ja: "やまぶきのミツを 吸った オドリドリ。 明るく 陽気な ダンスで 敵の 身も 心も 弾けさせる。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "フェザーダンス" },
+			cost: ["Lightning"],
+			effect: {
+				ja: "次の自分の番、このポケモンの「ぱちぱちパンチ」のダメージは「100」になる。",
+			},
+		},
+		{
+			name: { ja: "ぱちぱちパンチ" },
+			damage: 20,
+			cost: ["Lightning"],
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Metal", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561550,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "None",
+	dexId: [741],
+};
+
+export default card;

--- a/data-asia/SM/SM1p/023.ts
+++ b/data-asia/SM/SM1p/023.ts
@@ -1,0 +1,56 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM1p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "オドリドリ",
+	},
+
+	illustrator: "Kouki Saitou",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Psychic"],
+
+	description: {
+		ja: "ゆらゆら 揺れて リラックス。 こうして 高まった サイコパワーを 敵に 目掛けて 放射するぞ。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "バイタルダンス" },
+			effect: {
+				ja: "自分の番に、このカードを手札からベンチに出したとき、1回使える。自分の山札にある基本エネルギーを2枚まで、相手に見せてから、手札に加える。そして山札を切る。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ふらっとビンタ" },
+			damage: 30,
+			cost: ["Psychic", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561551,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "None",
+	dexId: [741],
+};
+
+export default card;

--- a/data-asia/SM/SM1p/024.ts
+++ b/data-asia/SM/SM1p/024.ts
@@ -1,0 +1,56 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM1p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "オドリドリ",
+	},
+
+	illustrator: "TOKIYA",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Psychic"],
+
+	description: {
+		ja: "むらさきのミツを 吸った オドリドリ。 雅で あでやかな 舞は 敵の 身も 心も 異界へ 誘う。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "あやかしのまい" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "相手のトラッシュにあるポケモンの枚数ぶんのダメカンを、相手のポケモンに好きなようにのせる。",
+			},
+		},
+		{
+			name: { ja: "めざめるダンス" },
+			damage: 30,
+			cost: ["Colorless"],
+			effect: {
+				ja: "場にスタジアムが出ていないなら、このワザは失敗。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561552,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "None",
+	dexId: [741],
+};
+
+export default card;

--- a/data-asia/SM/SM1p/025.ts
+++ b/data-asia/SM/SM1p/025.ts
@@ -1,0 +1,48 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM1p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヒドイデ",
+	},
+
+	illustrator: "match",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Psychic"],
+
+	description: {
+		ja: "頭に ある 毒トゲで 獲物を ズブリ。 弱ったところを １０本の 触手で 捕らえ 止めを 刺す。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "どくばり" },
+			cost: ["Psychic"],
+			effect: {
+				ja: "相手のバトルポケモンをどくにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561553,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "None",
+	dexId: [747],
+};
+
+export default card;

--- a/data-asia/SM/SM1p/026.ts
+++ b/data-asia/SM/SM1p/026.ts
@@ -1,0 +1,66 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM1p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ドヒドイデGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 210,
+	types: ["Psychic"],
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "とげキャノン" },
+			damage: "30×",
+			cost: ["Psychic"],
+			effect: {
+				ja: "コインを4回投げ、オモテの数x30ダメージ。",
+			},
+		},
+		{
+			name: { ja: "げきヤバポイズン" },
+			cost: ["Psychic", "Psychic", "Psychic"],
+			effect: {
+				ja: "相手のバトルポケモンをどくにする。このどくでのせるダメカンの数は10個になる。",
+			},
+		},
+		{
+			name: { ja: "ドシェルターGX" },
+			damage: 150,
+			cost: ["Psychic", "Psychic", "Psychic"],
+			effect: {
+				ja: "次の相手の番、このポケモンはワザのダメージや効果を受けない。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 561554,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ヒドイデ",
+	},
+
+	retreat: 3,
+	rarity: "Double rare",
+	dexId: [748],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM1p/027.ts
+++ b/data-asia/SM/SM1p/027.ts
@@ -1,0 +1,48 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM1p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "コスモッグ",
+	},
+
+	illustrator: "Megumi Mizutani",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Psychic"],
+
+	description: {
+		ja: "はかない ガス状の 身体。 大気の チリを 集めながら ゆっくりと 成長していく。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ちりあつめ" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札を1枚引く。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561555,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "None",
+	dexId: [789],
+};
+
+export default card;

--- a/data-asia/SM/SM1p/028.ts
+++ b/data-asia/SM/SM1p/028.ts
@@ -1,0 +1,52 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM1p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "コスモウム",
+	},
+
+	illustrator: "Sanosuke Sakuma",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Psychic"],
+
+	description: {
+		ja: "死んだように まったく 動かないが 触れると ほのかに 温かい。 大昔は 星の繭と 呼ばれた。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "テレポート" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "このポケモンをベンチポケモンと入れ替える。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561556,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "コスモッグ",
+	},
+
+	retreat: 3,
+	rarity: "None",
+	dexId: [790],
+};
+
+export default card;

--- a/data-asia/SM/SM1p/029.ts
+++ b/data-asia/SM/SM1p/029.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM1p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ルナアーラ",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 160,
+	types: ["Psychic"],
+
+	description: {
+		ja: "コスモッグが 進化した ♀だと いわれる。 第３の 眼が 浮かぶとき 別世界へと 飛び去っていく。",
+	},
+
+	stage: "Stage2",
+
+	attacks: [
+		{
+			name: { ja: "バーストボール" },
+			damage: "40×",
+			cost: ["Psychic"],
+			effect: {
+				ja: "このポケモンについている[超]エネルギーの数x40ダメージ。",
+			},
+		},
+		{
+			name: { ja: "がちりんのつばさ" },
+			damage: 130,
+			cost: ["Psychic", "Psychic", "Psychic"],
+			effect: {
+				ja: "このポケモンについているエネルギーをすべて、ベンチポケモンに好きなようにつけ替える。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561557,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "コスモウム",
+	},
+
+	retreat: 2,
+	rarity: "None",
+	dexId: [792],
+};
+
+export default card;

--- a/data-asia/SM/SM1p/030.ts
+++ b/data-asia/SM/SM1p/030.ts
@@ -1,0 +1,56 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM1p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ウソッキー",
+	},
+
+	illustrator: "Hajime Kusajima",
+	category: "Pokemon",
+	hp: 100,
+	types: ["Fighting"],
+
+	description: {
+		ja: "襲われないため 樹木の 真似を するが 嫌いな 水を かけられて あわてて 逃げだしていく。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "みちをふさぐ" },
+			effect: {
+				ja: "このポケモンがいるかぎり、相手がベンチに出せるポケモンの数は、4匹になる。相手のベンチに5匹以上いる場合は、相手はベンチが4匹になるまでポケモンをトラッシュする。［ベンチの数を変更する効果は、少ない数が優先される。］",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "いわおとし" },
+			damage: 40,
+			cost: ["Fighting", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561558,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "None",
+	dexId: [185],
+};
+
+export default card;

--- a/data-asia/SM/SM1p/031.ts
+++ b/data-asia/SM/SM1p/031.ts
@@ -1,0 +1,49 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM1p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ドロバンコ",
+	},
+
+	illustrator: "Kouki Saitou",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Fighting"],
+
+	description: {
+		ja: "足に まとわりついた 泥が グリップに なり 力強い 走りを 実現しているのだ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "にどげり" },
+			damage: "30×",
+			cost: ["Fighting", "Fighting"],
+			effect: {
+				ja: "コインを2回投げ、オモテの数x30ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561559,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "None",
+	dexId: [749],
+};
+
+export default card;

--- a/data-asia/SM/SM1p/032.ts
+++ b/data-asia/SM/SM1p/032.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM1p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "バンバドロ",
+	},
+
+	illustrator: "Mitsuhiro Arita",
+	category: "Pokemon",
+	hp: 140,
+	types: ["Fighting"],
+
+	description: {
+		ja: "口から 吐く 泥は 固まると 雨風にも 強いので 昔の 家の 壁には よく塗られている。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "きょうかスタンプ" },
+			damage: "60+",
+			cost: ["Fighting", "Fighting", "Colorless"],
+			effect: {
+				ja: "このポケモンに「ポケモンのどうぐ」がついているなら、60ダメージ追加。",
+			},
+		},
+		{
+			name: { ja: "10まんばりき" },
+			damage: 180,
+			cost: ["Fighting", "Fighting", "Fighting", "Colorless"],
+			effect: {
+				ja: "このポケモンにも40ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561560,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ドロバンコ",
+	},
+
+	retreat: 4,
+	rarity: "None",
+	dexId: [750],
+};
+
+export default card;

--- a/data-asia/SM/SM1p/033.ts
+++ b/data-asia/SM/SM1p/033.ts
@@ -1,0 +1,56 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM1p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ナゲツケサル",
+	},
+
+	illustrator: "Naoki Saito",
+	category: "Pokemon",
+	hp: 110,
+	types: ["Fighting"],
+
+	description: {
+		ja: "２０匹前後の グループを つくる。 その結束は 非常に 固く 絶対 仲間を 見捨てない。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "なげつける" },
+			cost: ["Fighting"],
+			effect: {
+				ja: "相手のベンチポケモン1匹に、30ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+			},
+		},
+		{
+			name: { ja: "チームプレイ" },
+			damage: "10+",
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "自分のベンチの「ナゲツケサル」の数x30ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561561,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "None",
+	dexId: [766],
+};
+
+export default card;

--- a/data-asia/SM/SM1p/034.ts
+++ b/data-asia/SM/SM1p/034.ts
@@ -1,0 +1,56 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM1p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "スナバァ",
+	},
+
+	illustrator: "Akira Komayama",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Fighting"],
+
+	description: {
+		ja: "口の中に 手を 入れた者を 操ってしまう。 砂山の 身体を 大きく させるためだ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "すなあつめ" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分のトラッシュにある[闘]エネルギーを1枚、このポケモンにつける。",
+			},
+		},
+		{
+			name: { ja: "すなじごく" },
+			damage: 30,
+			cost: ["Fighting", "Colorless", "Colorless"],
+			effect: {
+				ja: "次の相手の番、このワザを受けたポケモンは、にげられない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561562,
+			},
+		},
+	],
+
+	retreat: 3,
+	rarity: "None",
+	dexId: [769],
+};
+
+export default card;

--- a/data-asia/SM/SM1p/035.ts
+++ b/data-asia/SM/SM1p/035.ts
@@ -1,0 +1,63 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM1p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "シロデスナ",
+	},
+
+	illustrator: "Kouki Saitou",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Fighting"],
+
+	description: {
+		ja: "城の 下には 精気を 吸われ 干からびた 者たちの 骨が 大量に 埋まっている。",
+	},
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "すなのぼうへき" },
+			effect: {
+				ja: "このポケモンが受けるワザのダメージは「-20」される。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "せいきをすいとる" },
+			damage: 50,
+			cost: ["Fighting", "Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンに与えたダメージぶん、このポケモンのHPを回復する。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561563,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "スナバァ",
+	},
+
+	retreat: 4,
+	rarity: "None",
+	dexId: [770],
+};
+
+export default card;

--- a/data-asia/SM/SM1p/036.ts
+++ b/data-asia/SM/SM1p/036.ts
@@ -1,0 +1,46 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM1p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アローラコラッタ",
+	},
+
+	illustrator: "Kouki Saitou",
+	category: "Pokemon",
+	hp: 40,
+	types: ["Darkness"],
+
+	description: {
+		ja: "日が 暮れると 活動。 群れの ボスである ラッタのため いい餌を 求めて 街中を 駆け廻る。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "かじる" },
+			damage: 20,
+			cost: [],
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561564,
+			},
+		},
+	],
+
+	retreat: 0,
+	rarity: "None",
+	dexId: [19],
+};
+
+export default card;

--- a/data-asia/SM/SM1p/037.ts
+++ b/data-asia/SM/SM1p/037.ts
@@ -1,0 +1,60 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM1p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アローララッタ",
+	},
+
+	illustrator: "match",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Darkness"],
+
+	description: {
+		ja: "餌の 味と 鮮度に こだわる グルメな ポケモン。 ラッタが 棲む レストランは アタリと いわれる。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "わるいさしず" },
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "自分の山札にある好きなカードを、自分のベンチポケモンの数ぶんまで、手札に加える。そして山札を切る。",
+			},
+		},
+		{
+			name: { ja: "がむしゃら" },
+			damage: "60+",
+			cost: ["Darkness", "Colorless", "Colorless"],
+			effect: {
+				ja: "コインを2回投げ、オモテの数x30ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561565,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "アローラコラッタ",
+	},
+
+	retreat: 3,
+	rarity: "None",
+	dexId: [20],
+};
+
+export default card;

--- a/data-asia/SM/SM1p/038.ts
+++ b/data-asia/SM/SM1p/038.ts
@@ -1,0 +1,55 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM1p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アブソル",
+	},
+
+	illustrator: "Anesaki Dynamic",
+	category: "Pokemon",
+	hp: 100,
+	types: ["Darkness"],
+
+	description: {
+		ja: "迷信が はびこる 昔 災いを もたらすと 忌み嫌われ 山の 奥へと 追いやられた。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "みらいよち" },
+			cost: ["Darkness"],
+			effect: {
+				ja: "自分または相手の山札を上から4枚見て、好きな順番に入れ替えて、山札の上にもどす。",
+			},
+		},
+		{
+			name: { ja: "はめつのしらせ" },
+			cost: ["Darkness", "Colorless"],
+			effect: {
+				ja: "このポケモンについているエネルギーを、すべて手札にもどす。次の相手の番の終わりに、このワザを受けたポケモンはきぜつする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561566,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "None",
+	dexId: [359],
+};
+
+export default card;

--- a/data-asia/SM/SM1p/039.ts
+++ b/data-asia/SM/SM1p/039.ts
@@ -1,0 +1,60 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM1p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ソルガレオ",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 160,
+	types: ["Metal"],
+
+	description: {
+		ja: "別世界に 棲むと いわれる。 全身から 激しい光を 放ち 闇夜も 真昼のように 照らすのだ。",
+	},
+
+	stage: "Stage2",
+
+	attacks: [
+		{
+			name: { ja: "シャイニングアロー" },
+			cost: ["Metal", "Colorless"],
+			effect: {
+				ja: "相手のポケモン1匹に、50ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+			},
+		},
+		{
+			name: { ja: "にちりんのキバ" },
+			damage: 170,
+			cost: ["Metal", "Metal", "Colorless"],
+			effect: {
+				ja: "次の自分の番、このポケモンは「にちりんのキバ」が使えない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561567,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "コスモウム",
+	},
+
+	retreat: 3,
+	rarity: "None",
+	dexId: [791],
+};
+
+export default card;

--- a/data-asia/SM/SM1p/040.ts
+++ b/data-asia/SM/SM1p/040.ts
@@ -1,0 +1,62 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM1p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ニンフィアGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 200,
+	types: ["Fairy"],
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "マジカルリボン" },
+			cost: ["Fairy"],
+			effect: {
+				ja: "自分の山札にある好きなカードを3枚まで、手札に加える。そして山札を切る。",
+			},
+		},
+		{
+			name: { ja: "ようせいのかぜ" },
+			damage: 110,
+			cost: ["Fairy", "Colorless", "Colorless"],
+		},
+		{
+			name: { ja: "プリエールGX" },
+			cost: ["Fairy", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のベンチポケモン2匹と、そのポケモンについているすべてのカードを、相手の手札にもどす。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [{ type: "Darkness", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 561568,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "イーブイ",
+	},
+
+	retreat: 2,
+	rarity: "Double rare",
+	dexId: [700],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM1p/041.ts
+++ b/data-asia/SM/SM1p/041.ts
@@ -1,0 +1,58 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM1p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "イーブイ",
+	},
+
+	illustrator: "Shibuzoh.",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Colorless"],
+
+	description: {
+		ja: "今 現在の 調査では なんと ８種類もの ポケモンへ 進化する 可能性を 持つ。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "エナジーしんか" },
+			effect: {
+				ja: "自分の番に、自分の手札から基本エネルギーをこのポケモンにつけたとき、1回使える。つけたエネルギーと同じタイプの、このポケモンから進化するカードを、自分の山札から1枚選び、このポケモンにのせて進化させる。そして山札を切る。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "クイックドロー" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "コインを1回投げオモテなら、自分の山札を1枚引く。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561569,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "None",
+	dexId: [133],
+};
+
+export default card;

--- a/data-asia/SM/SM1p/042.ts
+++ b/data-asia/SM/SM1p/042.ts
@@ -1,0 +1,62 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM1p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ジジーロンGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 180,
+	types: ["Colorless"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ホーリーエッジ" },
+			damage: 20,
+			cost: ["Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンについている特殊エネルギーを、1個トラッシュする。",
+			},
+		},
+		{
+			name: { ja: "ぎゃくじょう" },
+			damage: "80+",
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "自分のベンチポケモンにダメカンがのっているなら、70ダメージ追加。",
+			},
+		},
+		{
+			name: { ja: "だいしゃりんGX" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の手札をすべて山札にもどして切る。その後、山札を10枚引く。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 561570,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Double rare",
+	dexId: [780],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM1p/043.ts
+++ b/data-asia/SM/SM1p/043.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM1p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "エネルギーリサイクル",
+	},
+
+	illustrator: "Toyste Beach",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分のトラッシュから基本エネルギーを5枚選び、相手に見せてから、山札にもどす。そして山札を切る。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561571,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/SM/SM1p/044.ts
+++ b/data-asia/SM/SM1p/044.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM1p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "改造ハンマー",
+	},
+
+	illustrator: "Yoshinobu Saito",
+	category: "Trainer",
+
+	effect: {
+		ja: "相手のポケモンについている特殊エネルギーを1個選び、トラッシュする。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561572,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/SM/SM1p/045.ts
+++ b/data-asia/SM/SM1p/045.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM1p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ハイパーボール",
+	},
+
+	illustrator: "Ryo Ueda",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードは、自分の手札を2枚トラッシュしなければ使えない。自分の山札からポケモンを1枚選び、相手に見せてから、手札に加える。そして山札を切る。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561573,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/SM/SM1p/046.ts
+++ b/data-asia/SM/SM1p/046.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM1p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ふしぎなアメ",
+	},
+
+	illustrator: "Toyste Beach",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分のたねポケモン1匹から進化する1進化の上の2進化ポケモンを、手札から1枚選び、そのたねポケモンにのせて進化させる。[最初の自分の番と、この番出したばかりのたねポケモンには使えない。]",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561574,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/SM/SM1p/047.ts
+++ b/data-asia/SM/SM1p/047.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM1p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "マルチつけかえ",
+	},
+
+	illustrator: "Toyste Beach",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分のベンチポケモンについているエネルギーを1個、自分のバトルポケモンにつけ替える。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561575,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/SM/SM1p/048.ts
+++ b/data-asia/SM/SM1p/048.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM1p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "まんたんのくすり",
+	},
+
+	illustrator: "Toyste Beach",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分のポケモンを1匹選び、HPをすべて回復する。その後、そのポケモンについているエネルギーをすべてトラッシュする。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561576,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/SM/SM1p/049.ts
+++ b/data-asia/SM/SM1p/049.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM1p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "こだわりハチマキ",
+	},
+
+	illustrator: "Eske Yoshinob",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードをつけているポケモンが使うワザの、相手のバトル場の「ポケモンGX・EX」へのダメージは「+30」される。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561577,
+			},
+		},
+	],
+
+	trainerType: "Tool",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/SM/SM1p/050.ts
+++ b/data-asia/SM/SM1p/050.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM1p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "月輪の祭壇",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Trainer",
+
+	effect: {
+		ja: "[超]または[悪]エネルギーがついているおたがいのポケモン全員のにげるためのエネルギーは、それぞれ2個ぶん少なくなる。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561578,
+			},
+		},
+	],
+
+	trainerType: "Stadium",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/SM/SM1p/051.ts
+++ b/data-asia/SM/SM1p/051.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM1p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "日輪の祭壇",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Trainer",
+
+	effect: {
+		ja: "おたがいの場の[炎]ポケモンと[鋼]ポケモン全員の弱点は、すべてなくなる。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561579,
+			},
+		},
+	],
+
+	trainerType: "Stadium",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/SM/SM1p/052.ts
+++ b/data-asia/SM/SM1p/052.ts
@@ -1,0 +1,65 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM1p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ジュナイパーGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 240,
+	types: ["Grass"],
+
+	stage: "Stage2",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "フェザーアロー" },
+			effect: {
+				ja: "自分の番に1回使える。相手のポケモン1匹に、ダメカンを2個のせる。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "はっぱカッター" },
+			damage: 90,
+			cost: ["Grass", "Colorless", "Colorless"],
+		},
+		{
+			name: { ja: "ホロウハントGX" },
+			cost: ["Grass"],
+			effect: {
+				ja: "自分のトラッシュにある好きなカードを3枚、相手に見せてから、手札に加える。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 561580,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "フクスロー",
+	},
+
+	retreat: 2,
+	rarity: "Ultra Rare",
+	dexId: [724],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM1p/053.ts
+++ b/data-asia/SM/SM1p/053.ts
@@ -1,0 +1,67 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM1p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ガオガエンGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 250,
+	types: ["Fire"],
+
+	stage: "Stage2",
+
+	attacks: [
+		{
+			name: { ja: "ハッスルブロー" },
+			damage: "10+",
+			cost: ["Fire"],
+			effect: {
+				ja: "自分のベンチの[炎]ポケモンの数x20ダメージ追加。",
+			},
+		},
+		{
+			name: { ja: "タイガースイング" },
+			damage: "80+",
+			cost: ["Fire", "Fire", "Colorless"],
+			effect: {
+				ja: "コインを2回投げ、オモテの数x50ダメージ追加。",
+			},
+		},
+		{
+			name: { ja: "バーンスラムGX" },
+			damage: 200,
+			cost: ["Fire", "Fire", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをやけどにする。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 561581,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ニャヒート",
+	},
+
+	retreat: 3,
+	rarity: "Ultra Rare",
+	dexId: [727],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM1p/054.ts
+++ b/data-asia/SM/SM1p/054.ts
@@ -1,0 +1,66 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM1p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アシレーヌGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 250,
+	types: ["Water"],
+
+	stage: "Stage2",
+
+	attacks: [
+		{
+			name: { ja: "バブルビート" },
+			damage: "10+",
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "自分の場のポケモンについている[水]エネルギーの数x20ダメージ追加。",
+			},
+		},
+		{
+			name: { ja: "うみなり" },
+			damage: 120,
+			cost: ["Water", "Water", "Water", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンについているエネルギーを、1個トラッシュする。",
+			},
+		},
+		{
+			name: { ja: "グランエコーGX" },
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "自分のポケモン全員のHPを、すべて回復する。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 561582,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "オシャマリ",
+	},
+
+	retreat: 2,
+	rarity: "Ultra Rare",
+	dexId: [730],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM1p/055.ts
+++ b/data-asia/SM/SM1p/055.ts
@@ -1,0 +1,66 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM1p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "クワガノンGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 240,
+	types: ["Lightning"],
+
+	stage: "Stage2",
+
+	attacks: [
+		{
+			name: { ja: "チャージビーム" },
+			damage: 50,
+			cost: ["Lightning"],
+			effect: {
+				ja: "自分のトラッシュにあるエネルギーを1枚、このポケモンにつける。",
+			},
+		},
+		{
+			name: { ja: "ちょうでんじほう" },
+			damage: 180,
+			cost: ["Lightning", "Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンについているエネルギーを、2個トラッシュする。",
+			},
+		},
+		{
+			name: { ja: "ギガトロンGX" },
+			cost: ["Lightning", "Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のベンチポケモン全員に、それぞれ60ダメージ。［ベンチは弱点・抵抗力を計算しない。］［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Metal", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 561583,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "デンヂムシ",
+	},
+
+	retreat: 1,
+	rarity: "Ultra Rare",
+	dexId: [738],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM1p/056.ts
+++ b/data-asia/SM/SM1p/056.ts
@@ -1,0 +1,66 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM1p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ドヒドイデGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 210,
+	types: ["Psychic"],
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "とげキャノン" },
+			damage: "30×",
+			cost: ["Psychic"],
+			effect: {
+				ja: "コインを4回投げ、オモテの数x30ダメージ。",
+			},
+		},
+		{
+			name: { ja: "げきヤバポイズン" },
+			cost: ["Psychic", "Psychic", "Psychic"],
+			effect: {
+				ja: "相手のバトルポケモンをどくにする。このどくでのせるダメカンの数は10個になる。",
+			},
+		},
+		{
+			name: { ja: "ドシェルターGX" },
+			damage: 150,
+			cost: ["Psychic", "Psychic", "Psychic"],
+			effect: {
+				ja: "次の相手の番、このポケモンはワザのダメージや効果を受けない。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 561584,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ヒドイデ",
+	},
+
+	retreat: 3,
+	rarity: "Ultra Rare",
+	dexId: [748],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM1p/057.ts
+++ b/data-asia/SM/SM1p/057.ts
@@ -1,0 +1,62 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM1p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ニンフィアGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 200,
+	types: ["Fairy"],
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "マジカルリボン" },
+			cost: ["Fairy"],
+			effect: {
+				ja: "自分の山札にある好きなカードを3枚まで、手札に加える。そして山札を切る。",
+			},
+		},
+		{
+			name: { ja: "ようせいのかぜ" },
+			damage: 110,
+			cost: ["Fairy", "Colorless", "Colorless"],
+		},
+		{
+			name: { ja: "プリエールGX" },
+			cost: ["Fairy", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のベンチポケモン2匹と、そのポケモンについているすべてのカードを、相手の手札にもどす。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [{ type: "Darkness", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 561585,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "イーブイ",
+	},
+
+	retreat: 2,
+	rarity: "Ultra Rare",
+	dexId: [700],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM1p/058.ts
+++ b/data-asia/SM/SM1p/058.ts
@@ -1,0 +1,62 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM1p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ジジーロンGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 180,
+	types: ["Colorless"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ホーリーエッジ" },
+			damage: 20,
+			cost: ["Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンについている特殊エネルギーを、1個トラッシュする。",
+			},
+		},
+		{
+			name: { ja: "ぎゃくじょう" },
+			damage: "80+",
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "自分のベンチポケモンにダメカンがのっているなら、70ダメージ追加。",
+			},
+		},
+		{
+			name: { ja: "だいしゃりんGX" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の手札をすべて山札にもどして切る。その後、山札を10枚引く。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 561586,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Ultra Rare",
+	dexId: [780],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM1p/059.ts
+++ b/data-asia/SM/SM1p/059.ts
@@ -1,0 +1,65 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM1p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ジュナイパーGX",
+	},
+
+	illustrator: "",
+	category: "Pokemon",
+	hp: 240,
+	types: ["Grass"],
+
+	stage: "Stage2",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "フェザーアロー" },
+			effect: {
+				ja: "自分の番に1回使える。相手のポケモン1匹に、ダメカンを2個のせる。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "はっぱカッター" },
+			damage: 90,
+			cost: ["Grass", "Colorless", "Colorless"],
+		},
+		{
+			name: { ja: "ホロウハントGX" },
+			cost: ["Grass"],
+			effect: {
+				ja: "自分のトラッシュにある好きなカードを3枚、相手に見せてから、手札に加える。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 561587,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "フクスロー",
+	},
+
+	retreat: 2,
+	rarity: "Hyper rare",
+	dexId: [724],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM1p/060.ts
+++ b/data-asia/SM/SM1p/060.ts
@@ -1,0 +1,67 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM1p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ガオガエンGX",
+	},
+
+	illustrator: "",
+	category: "Pokemon",
+	hp: 250,
+	types: ["Fire"],
+
+	stage: "Stage2",
+
+	attacks: [
+		{
+			name: { ja: "ハッスルブロー" },
+			damage: "10+",
+			cost: ["Fire"],
+			effect: {
+				ja: "自分のベンチの[炎]ポケモンの数x20ダメージ追加。",
+			},
+		},
+		{
+			name: { ja: "タイガースイング" },
+			damage: "80+",
+			cost: ["Fire", "Fire", "Colorless"],
+			effect: {
+				ja: "コインを2回投げ、オモテの数x50ダメージ追加。",
+			},
+		},
+		{
+			name: { ja: "バーンスラムGX" },
+			damage: 200,
+			cost: ["Fire", "Fire", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをやけどにする。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 561588,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ニャヒート",
+	},
+
+	retreat: 3,
+	rarity: "Hyper rare",
+	dexId: [727],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM1p/061.ts
+++ b/data-asia/SM/SM1p/061.ts
@@ -1,0 +1,66 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM1p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アシレーヌGX",
+	},
+
+	illustrator: "",
+	category: "Pokemon",
+	hp: 250,
+	types: ["Water"],
+
+	stage: "Stage2",
+
+	attacks: [
+		{
+			name: { ja: "バブルビート" },
+			damage: "10+",
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "自分の場のポケモンについている[水]エネルギーの数x20ダメージ追加。",
+			},
+		},
+		{
+			name: { ja: "うみなり" },
+			damage: 120,
+			cost: ["Water", "Water", "Water", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンについているエネルギーを、1個トラッシュする。",
+			},
+		},
+		{
+			name: { ja: "グランエコーGX" },
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "自分のポケモン全員のHPを、すべて回復する。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 561589,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "オシャマリ",
+	},
+
+	retreat: 2,
+	rarity: "Hyper rare",
+	dexId: [730],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM1p/062.ts
+++ b/data-asia/SM/SM1p/062.ts
@@ -1,0 +1,66 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM1p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "クワガノンGX",
+	},
+
+	illustrator: "",
+	category: "Pokemon",
+	hp: 240,
+	types: ["Lightning"],
+
+	stage: "Stage2",
+
+	attacks: [
+		{
+			name: { ja: "チャージビーム" },
+			damage: 50,
+			cost: ["Lightning"],
+			effect: {
+				ja: "自分のトラッシュにあるエネルギーを1枚、このポケモンにつける。",
+			},
+		},
+		{
+			name: { ja: "ちょうでんじほう" },
+			damage: 180,
+			cost: ["Lightning", "Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンについているエネルギーを、2個トラッシュする。",
+			},
+		},
+		{
+			name: { ja: "ギガトロンGX" },
+			cost: ["Lightning", "Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のベンチポケモン全員に、それぞれ60ダメージ。［ベンチは弱点・抵抗力を計算しない。］［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Metal", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 561590,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "デンヂムシ",
+	},
+
+	retreat: 1,
+	rarity: "Hyper rare",
+	dexId: [738],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM1p/063.ts
+++ b/data-asia/SM/SM1p/063.ts
@@ -1,0 +1,66 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM1p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ドヒドイデGX",
+	},
+
+	illustrator: "",
+	category: "Pokemon",
+	hp: 210,
+	types: ["Psychic"],
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "とげキャノン" },
+			damage: "30×",
+			cost: ["Psychic"],
+			effect: {
+				ja: "コインを4回投げ、オモテの数x30ダメージ。",
+			},
+		},
+		{
+			name: { ja: "げきヤバポイズン" },
+			cost: ["Psychic", "Psychic", "Psychic"],
+			effect: {
+				ja: "相手のバトルポケモンをどくにする。このどくでのせるダメカンの数は10個になる。",
+			},
+		},
+		{
+			name: { ja: "ドシェルターGX" },
+			damage: 150,
+			cost: ["Psychic", "Psychic", "Psychic"],
+			effect: {
+				ja: "次の相手の番、このポケモンはワザのダメージや効果を受けない。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 561591,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ヒドイデ",
+	},
+
+	retreat: 3,
+	rarity: "Secret Rare",
+	dexId: [748],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM1p/064.ts
+++ b/data-asia/SM/SM1p/064.ts
@@ -1,0 +1,62 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM1p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ニンフィアGX",
+	},
+
+	illustrator: "",
+	category: "Pokemon",
+	hp: 200,
+	types: ["Fairy"],
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "マジカルリボン" },
+			cost: ["Fairy"],
+			effect: {
+				ja: "自分の山札にある好きなカードを3枚まで、手札に加える。そして山札を切る。",
+			},
+		},
+		{
+			name: { ja: "ようせいのかぜ" },
+			damage: 110,
+			cost: ["Fairy", "Colorless", "Colorless"],
+		},
+		{
+			name: { ja: "プリエールGX" },
+			cost: ["Fairy", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のベンチポケモン2匹と、そのポケモンについているすべてのカードを、相手の手札にもどす。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [{ type: "Darkness", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 561592,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "イーブイ",
+	},
+
+	retreat: 2,
+	rarity: "Hyper rare",
+	dexId: [700],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM1p/065.ts
+++ b/data-asia/SM/SM1p/065.ts
@@ -1,0 +1,62 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM1p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ジジーロンGX",
+	},
+
+	illustrator: "",
+	category: "Pokemon",
+	hp: 180,
+	types: ["Colorless"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ホーリーエッジ" },
+			damage: 20,
+			cost: ["Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンについている特殊エネルギーを、1個トラッシュする。",
+			},
+		},
+		{
+			name: { ja: "ぎゃくじょう" },
+			damage: "80+",
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "自分のベンチポケモンにダメカンがのっているなら、70ダメージ追加。",
+			},
+		},
+		{
+			name: { ja: "だいしゃりんGX" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の手札をすべて山札にもどして切る。その後、山札を10枚引く。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 561593,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Hyper rare",
+	dexId: [780],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM1p/066.ts
+++ b/data-asia/SM/SM1p/066.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM1p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ふしぎなアメ",
+	},
+
+	illustrator: "",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分のたねポケモン1匹から進化する1進化の上の2進化ポケモンを、手札から1枚選び、そのたねポケモンにのせて進化させる。[最初の自分の番と、この番出したばかりのたねポケモンには使えない。]",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 561594,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	rarity: "Secret Rare",
+};
+
+export default card;

--- a/data-asia/SM/SM1p/067.ts
+++ b/data-asia/SM/SM1p/067.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM1p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ダブル無色エネルギー",
+	},
+
+	illustrator: "",
+	category: "Energy",
+	energyType: "Special",
+
+	effect: {
+		ja: "このカードは、[無]エネルギー2個ぶんとしてはたらく。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 561595,
+			},
+		},
+	],
+
+	rarity: "Secret Rare",
+};
+
+export default card;

--- a/data-asia/SM/SM1p/068.ts
+++ b/data-asia/SM/SM1p/068.ts
@@ -1,0 +1,26 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM1p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "基本草エネルギー",
+	},
+
+	illustrator: "",
+	category: "Energy",
+	energyType: "Normal",
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 561596,
+			},
+		},
+	],
+
+	rarity: "Secret Rare",
+};
+
+export default card;


### PR DESCRIPTION
## What

Adds the complete Japanese set **SM1p サン＆ムーン (Sun and Moon plus)**, released 2017-01-27:

- `data-asia/SM/SM1p.ts` — set definition (51 official cards)
- `data-asia/SM/SM1p/001.ts` … `068.ts` — all 68 cards (51 regular + 17 secret rares: 7 SR, 4 Secret Rare, 6 UR)

## Data sources

- **pokemon-card.com** (official database): Japanese names, flavor texts, National Dex numbers, official card count
- **limitlesstcg.com**: full Japanese card text, stages, weaknesses/resistances/retreat, rarities, illustrators, attack costs
- **Cardmarket**: product IDs as `thirdParty.cardmarket` on the variant objects (561529–561596; tcgplayer IDs not available to me)

## Notes

- Follows the file format and conventions of the M-era sets (#1728)
- No `regulationMark` (the set predates regulation marks); resistances are `-20` per the era
- All 68 files type-check against `interfaces.d.ts` (`tsc --noEmit`)
