### PR TITLE
(data) Add Japanese SM set SM2K Islands Await You

### DIFF
--- a/data-asia/SM/SM2K/001.ts
+++ b/data-asia/SM/SM2K/001.ts
@@ -1,0 +1,46 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM2K";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "マダツボミ",
+	},
+
+	illustrator: "Aya Kusube",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Grass"],
+
+	description: {
+		ja: "ひょろっとした 体つきだが 獲物を 捕らえるときの 動きは 目にも とまらないほど 素早い。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "つるのムチ" },
+			damage: 30,
+			cost: ["Grass", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561467,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [69],
+};
+
+export default card;

--- a/data-asia/SM/SM2K/002.ts
+++ b/data-asia/SM/SM2K/002.ts
@@ -1,0 +1,53 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM2K";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ウツドン",
+	},
+
+	illustrator: "Mina Nakai",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Grass"],
+
+	description: {
+		ja: "葉っぱの 部分は カッターになって 相手を 切り裂く。 口からは なんでも 溶かす 液体を 吐く。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "どろろえき" },
+			damage: 40,
+			cost: ["Grass", "Colorless"],
+			effect: {
+				ja: "コインを1回投げオモテなら、相手のバトルポケモンについているエネルギーを、1個トラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561468,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "マダツボミ",
+	},
+
+	retreat: 2,
+	rarity: "Common",
+	dexId: [70],
+};
+
+export default card;

--- a/data-asia/SM/SM2K/003.ts
+++ b/data-asia/SM/SM2K/003.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM2K";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ウツボット",
+	},
+
+	illustrator: "TOKIYA",
+	category: "Pokemon",
+	hp: 140,
+	types: ["Grass"],
+
+	description: {
+		ja: "ジャングルの 奥地に ウツボット ばかり いる 地帯が あって 行ったら ２度と 帰ってこれない。",
+	},
+
+	stage: "Stage2",
+
+	attacks: [
+		{
+			name: { ja: "きけんなかふん" },
+			damage: 20,
+			cost: ["Grass"],
+			effect: {
+				ja: "相手のバトルポケモンをどくとやけどとこんらんにする。",
+			},
+		},
+		{
+			name: { ja: "からめてすいとる" },
+			damage: 80,
+			cost: ["Grass", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンのHPを「20」回復する。次の相手の番、このワザを受けたポケモンは、にげられない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561469,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ウツドン",
+	},
+
+	retreat: 2,
+	rarity: "Uncommon",
+	dexId: [71],
+};
+
+export default card;

--- a/data-asia/SM/SM2K/004.ts
+++ b/data-asia/SM/SM2K/004.ts
@@ -1,0 +1,49 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM2K";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "チュリネ",
+	},
+
+	illustrator: "Naoki Saito",
+	category: "Pokemon",
+	hp: 50,
+	types: ["Grass"],
+
+	description: {
+		ja: "頭の葉っぱは めまいが するほど 苦いが 疲れた 身体に 効く。 煎じて 飲めば もっと 効く。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ちょっとすいとる" },
+			damage: 10,
+			cost: ["Colorless"],
+			effect: {
+				ja: "このポケモンのHPを「10」回復する。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561470,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [548],
+};
+
+export default card;

--- a/data-asia/SM/SM2K/005.ts
+++ b/data-asia/SM/SM2K/005.ts
@@ -1,0 +1,60 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM2K";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ドレディア",
+	},
+
+	illustrator: "You Iribi",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Grass"],
+
+	description: {
+		ja: "どんなに 手間と お金を かけても 人の 手で 咲かせるよりも 野生で 咲く 花の ほうが 美しい。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "はなふぶき" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "相手のポケモン全員に、それぞれ10ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+			},
+		},
+		{
+			name: { ja: "はなびらのまい" },
+			damage: "40×",
+			cost: ["Grass", "Colorless"],
+			effect: {
+				ja: "コインを3回投げ、オモテの数x40ダメージ。このポケモンをこんらんにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561471,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "チュリネ",
+	},
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [549],
+};
+
+export default card;

--- a/data-asia/SM/SM2K/006.ts
+++ b/data-asia/SM/SM2K/006.ts
@@ -1,0 +1,53 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM2K";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "コソクムシ",
+	},
+
+	illustrator: "match",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Grass"],
+
+	description: {
+		ja: "臆病で たくさんの 足を ばたつかせ 必死に 逃げまわる。 逃げたあとは ピカピカ 綺麗。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "チョロにげ" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "このポケモンと、ついているすべてのカードを、自分の山札にもどして切る。",
+			},
+		},
+		{
+			name: { ja: "ぶつかる" },
+			damage: 10,
+			cost: ["Grass"],
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561472,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Common",
+	dexId: [767],
+};
+
+export default card;

--- a/data-asia/SM/SM2K/007.ts
+++ b/data-asia/SM/SM2K/007.ts
@@ -1,0 +1,63 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM2K";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "グソクムシャ",
+	},
+
+	illustrator: "Kouki Saitou",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Grass"],
+
+	description: {
+		ja: "鋭く 巨大な ツメで 一閃。 空気や 海水さえ 一刀両断の 腕前。",
+	},
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "そうこう" },
+			effect: {
+				ja: "このポケモンが受けるワザのダメージは「-30」される。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "かくごのツメ" },
+			damage: "80+",
+			cost: ["Grass", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンが「ポケモンGX・EX」なら、70ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 561473,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "コソクムシ",
+	},
+
+	retreat: 2,
+	rarity: "Rare",
+	dexId: [768],
+};
+
+export default card;

--- a/data-asia/SM/SM2K/008.ts
+++ b/data-asia/SM/SM2K/008.ts
@@ -1,0 +1,56 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM2K";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ビクティニ",
+	},
+
+	illustrator: "kodama",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Fire"],
+
+	description: {
+		ja: "勝利を もたらす ポケモン。 ビクティニを 連れた トレーナーは どんな 勝負にも 勝てるという。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "しょうりのほし" },
+			effect: {
+				ja: "自分の番に、自分のポケモンのワザでコインを投げたとき、1回使える。そのコインの結果をすべてなくし、はじめからコインを投げなおす。「ビクティニ」が何匹いても、「しょうりのほし」は自分の番に1回しか使えない。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "Vフレイム" },
+			damage: 50,
+			cost: ["Fire", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 561474,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Rare",
+	dexId: [494],
+};
+
+export default card;

--- a/data-asia/SM/SM2K/009.ts
+++ b/data-asia/SM/SM2K/009.ts
@@ -1,0 +1,62 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM2K";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "バクガメスGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 190,
+	types: ["Fire"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "トラップシェル" },
+			damage: 20,
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "次の相手の番、このポケモンがワザのダメージを受けたとき、ワザを使ったポケモンにダメカンを8個のせる。",
+			},
+		},
+		{
+			name: { ja: "ぐれんのほのお" },
+			damage: 160,
+			cost: ["Fire", "Fire", "Colorless"],
+			effect: {
+				ja: "このポケモンについている[炎]エネルギーを、2個トラッシュする。",
+			},
+		},
+		{
+			name: { ja: "ニトロタンクGX" },
+			cost: ["Fire"],
+			effect: {
+				ja: "自分のトラッシュにある[炎]エネルギーを5枚、自分のポケモンに好きなようにつける。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 561475,
+			},
+		},
+	],
+
+	retreat: 3,
+	rarity: "Double rare",
+	dexId: [776],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM2K/010.ts
+++ b/data-asia/SM/SM2K/010.ts
@@ -1,0 +1,53 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM2K";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アローラサンド",
+	},
+
+	illustrator: "Mizue",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Water"],
+
+	description: {
+		ja: "雪山に 棲む。 鋼の甲羅は とても 頑丈だが 硬すぎて 身体を 丸めることが できない。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "まるくなる" },
+			cost: [],
+			effect: {
+				ja: "コインを1回投げオモテなら、次の相手の番、このポケモンはワザのダメージを受けない。",
+			},
+		},
+		{
+			name: { ja: "アイスボール" },
+			damage: 30,
+			cost: ["Water", "Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561476,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [27],
+};
+
+export default card;

--- a/data-asia/SM/SM2K/011.ts
+++ b/data-asia/SM/SM2K/011.ts
@@ -1,0 +1,63 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM2K";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アローラサンドパン",
+	},
+
+	illustrator: "TOKIYA",
+	category: "Pokemon",
+	hp: 110,
+	types: ["Water"],
+
+	description: {
+		ja: "火山噴火 から 逃れるうちに 雪山に 棲みつくように なった。 雪しぶきをあげ 雪原を 駆ける。",
+	},
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ゆきかき" },
+			effect: {
+				ja: "自分の番に1回使える。自分の山札を1枚引く。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "スマッシュターン" },
+			damage: 50,
+			cost: ["Water", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンをベンチポケモンと入れ替える。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561477,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "アローラサンド",
+	},
+
+	retreat: 2,
+	rarity: "Uncommon",
+	dexId: [28],
+};
+
+export default card;

--- a/data-asia/SM/SM2K/012.ts
+++ b/data-asia/SM/SM2K/012.ts
@@ -1,0 +1,53 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM2K";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アローラロコン",
+	},
+
+	illustrator: "You Iribi",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Water"],
+
+	description: {
+		ja: "マイナス５０度の 冷気を 吐く。 アローラの老人は ケオケオという 昔の 名前で 呼ぶことも。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "みちしるべ" },
+			cost: [],
+			effect: {
+				ja: "自分の山札にあるポケモンを2枚まで、相手に見せてから、手札に加える。そして山札を切る。",
+			},
+		},
+		{
+			name: { ja: "スノーアイス" },
+			damage: 20,
+			cost: ["Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561478,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [37],
+};
+
+export default card;

--- a/data-asia/SM/SM2K/013.ts
+++ b/data-asia/SM/SM2K/013.ts
@@ -1,0 +1,65 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM2K";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アローラキュウコンGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 210,
+	types: ["Water"],
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "こおりのやいば" },
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "相手のポケモン1匹に、50ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+			},
+		},
+		{
+			name: { ja: "ブリザードエッジ" },
+			damage: 160,
+			cost: ["Water", "Water", "Colorless"],
+			effect: {
+				ja: "このポケモンについているエネルギーを、2個トラッシュする。",
+			},
+		},
+		{
+			name: { ja: "クリアゲートGX" },
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンにのっているダメカンをすべて、相手のバトルポケモンにのせ替える。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 561479,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "アローラロコン",
+	},
+
+	retreat: 1,
+	rarity: "Double rare",
+	dexId: [38],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM2K/014.ts
+++ b/data-asia/SM/SM2K/014.ts
@@ -1,0 +1,56 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM2K";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "デリバード",
+	},
+
+	illustrator: "sui",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Water"],
+
+	description: {
+		ja: "本来 寒い 土地を 好むが アローラの デリバードは ある程度の 暑さでも 耐えられる ようだ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ガンガンプレゼント" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "ウラが出るまでコインを投げ、オモテの数ぶんまで、自分の山札にある好きなカードを、手札に加える。そして山札を切る。",
+			},
+		},
+		{
+			name: { ja: "ふいをつく" },
+			damage: 40,
+			cost: ["Water"],
+			effect: {
+				ja: "コインを1回投げウラなら、このワザは失敗。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561480,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [225],
+};
+
+export default card;

--- a/data-asia/SM/SM2K/015.ts
+++ b/data-asia/SM/SM2K/015.ts
@@ -1,0 +1,51 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM2K";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ユキワラシ",
+	},
+
+	illustrator: "Tomokazu Komiya",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Water"],
+
+	description: {
+		ja: "気づくと アローラで 増えていた。 ユキワラシが 棲みついた 家は 子々孫々に 栄えると いう。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ひんやり" },
+			damage: 10,
+			cost: ["Water"],
+		},
+		{
+			name: { ja: "こおりのいぶき" },
+			damage: 20,
+			cost: ["Water", "Water"],
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561481,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Common",
+	dexId: [361],
+};
+
+export default card;

--- a/data-asia/SM/SM2K/016.ts
+++ b/data-asia/SM/SM2K/016.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM2K";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "オニゴーリ",
+	},
+
+	illustrator: "so-taro",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Water"],
+
+	description: {
+		ja: "登頂 間近に 雪山で 遭難した 登山家の 無念が 岩に 取りつき 生まれたと いう。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "かみくだく" },
+			damage: 40,
+			cost: ["Water", "Water"],
+			effect: {
+				ja: "コインを1回投げオモテなら、相手のバトルポケモンについているエネルギーを、1個トラッシュする。",
+			},
+		},
+		{
+			name: { ja: "いかりのひょうかい" },
+			damage: "70+",
+			cost: ["Water", "Water", "Water"],
+			effect: {
+				ja: "このポケモンにダメカンがのっているなら、80ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561482,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ユキワラシ",
+	},
+
+	retreat: 3,
+	rarity: "Uncommon",
+	dexId: [362],
+};
+
+export default card;

--- a/data-asia/SM/SM2K/017.ts
+++ b/data-asia/SM/SM2K/017.ts
@@ -1,0 +1,49 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM2K";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "バニプッチ",
+	},
+
+	illustrator: "OOYAMA",
+	category: "Pokemon",
+	hp: 50,
+	types: ["Water"],
+
+	description: {
+		ja: "氷柱から 生まれたポケモン。 冷たい 息で 雪の 結晶を つくって 雪を 降らせる。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "トリプルスピン" },
+			damage: "10×",
+			cost: ["Water"],
+			effect: {
+				ja: "コインを3回投げ、オモテの数x10ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561483,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [582],
+};
+
+export default card;

--- a/data-asia/SM/SM2K/018.ts
+++ b/data-asia/SM/SM2K/018.ts
@@ -1,0 +1,53 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM2K";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "バニリッチ",
+	},
+
+	illustrator: "Naoki Saito",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Water"],
+
+	description: {
+		ja: "暑い 日には 身体が 溶ける。 凍らせれば 元に 戻るけど 身体の 形は 少し 歪む。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "こおりのつぶて" },
+			damage: "30+",
+			cost: ["Water"],
+			effect: {
+				ja: "相手のバトルポケモンが[闘]ポケモンなら、30ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561484,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "バニプッチ",
+	},
+
+	retreat: 2,
+	rarity: "Common",
+	dexId: [583],
+};
+
+export default card;

--- a/data-asia/SM/SM2K/019.ts
+++ b/data-asia/SM/SM2K/019.ts
@@ -1,0 +1,60 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM2K";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "バイバニラ",
+	},
+
+	illustrator: "kawayoo",
+	category: "Pokemon",
+	hp: 140,
+	types: ["Water"],
+
+	description: {
+		ja: "２つの頭 それぞれに 脳があり 両者の 意見が 一致すると 猛吹雪を 吐いて 敵を 襲う。",
+	},
+
+	stage: "Stage2",
+
+	attacks: [
+		{
+			name: { ja: "あられ" },
+			cost: ["Water"],
+			effect: {
+				ja: "相手のポケモン全員に、それぞれ20ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+			},
+		},
+		{
+			name: { ja: "フローズンブレス" },
+			damage: 80,
+			cost: ["Water", "Water", "Water"],
+			effect: {
+				ja: "のぞむなら、このポケモンについている[水]エネルギーを、2個トラッシュする。その場合、相手のバトルポケモンをマヒにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561485,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "バニリッチ",
+	},
+
+	retreat: 2,
+	rarity: "Uncommon",
+	dexId: [584],
+};
+
+export default card;

--- a/data-asia/SM/SM2K/020.ts
+++ b/data-asia/SM/SM2K/020.ts
@@ -1,0 +1,49 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM2K";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "エリキテル",
+	},
+
+	illustrator: "Masakazu Fukuda",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Lightning"],
+
+	description: {
+		ja: "砂漠で 生活する。 太陽の 光を 浴びて 発電すれば エサを 食べなくても 平気なのだ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "でんきショック" },
+			damage: 10,
+			cost: ["Lightning"],
+			effect: {
+				ja: "コインを1回投げオモテなら、相手のバトルポケモンをマヒにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Metal", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561486,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [694],
+};
+
+export default card;

--- a/data-asia/SM/SM2K/021.ts
+++ b/data-asia/SM/SM2K/021.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM2K";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "エレザード",
+	},
+
+	illustrator: "Shin Nagasawa",
+	category: "Pokemon",
+	hp: 100,
+	types: ["Lightning"],
+
+	description: {
+		ja: "エリマキを 広げて 発電する。 エレザード １匹で 高層ビルで 必要な 電気を 作れるのだ。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "でんこうせっか" },
+			damage: "20+",
+			cost: ["Colorless"],
+			effect: {
+				ja: "コインを1回投げオモテなら、20ダメージ追加。",
+			},
+		},
+		{
+			name: { ja: "らくらい" },
+			damage: 120,
+			cost: ["Lightning", "Colorless", "Colorless"],
+			effect: {
+				ja: "自分のベンチポケモン1匹にも、30ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Metal", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561487,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "エリキテル",
+	},
+
+	retreat: 1,
+	rarity: "Uncommon",
+	dexId: [695],
+};
+
+export default card;

--- a/data-asia/SM/SM2K/022.ts
+++ b/data-asia/SM/SM2K/022.ts
@@ -1,0 +1,62 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM2K";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "カプ・コケコGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 170,
+	types: ["Lightning"],
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "エアロトレイル" },
+			effect: {
+				ja: "自分の番に、このカードを手札からベンチに出したとき、1回使える。自分の場のポケモンについている[雷]エネルギーを好きなだけ、このポケモンにつけ替える。つけ替えた場合、このポケモンをバトルポケモンと入れ替える。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "てんくうのツメ" },
+			damage: 130,
+			cost: ["Lightning", "Lightning", "Colorless"],
+		},
+		{
+			name: { ja: "カプサンダーGX" },
+			damage: "50×",
+			cost: ["Lightning", "Lightning", "Colorless"],
+			effect: {
+				ja: "相手の場のポケモンについているエネルギーの数x50ダメージ。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 561488,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Double rare",
+	dexId: [785],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM2K/023.ts
+++ b/data-asia/SM/SM2K/023.ts
@@ -1,0 +1,54 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM2K";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヤドン",
+	},
+
+	illustrator: "Mina Nakai",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Psychic"],
+
+	description: {
+		ja: "長い 尻尾は よく千切れる。 特に 痛みも 感じないし すぐに 生えるので 気にしない。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ずつき" },
+			damage: 10,
+			cost: ["Colorless"],
+		},
+		{
+			name: { ja: "きまぐれタックル" },
+			damage: 60,
+			cost: ["Psychic", "Colorless", "Colorless"],
+			effect: {
+				ja: "コインを1回投げウラなら、このワザは失敗。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561489,
+			},
+		},
+	],
+
+	retreat: 3,
+	rarity: "Common",
+	dexId: [79],
+};
+
+export default card;

--- a/data-asia/SM/SM2K/024.ts
+++ b/data-asia/SM/SM2K/024.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM2K";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヤドラン",
+	},
+
+	illustrator: "Shibuzoh.",
+	category: "Pokemon",
+	hp: 110,
+	types: ["Psychic"],
+
+	description: {
+		ja: "海を 眺め ぼーっと している。 シェルダーの毒が 身体に 回り より ぼんやりするように なった。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "ドわすれ" },
+			damage: 20,
+			cost: ["Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンが持っているワザを1つ選ぶ。次の相手の番、このワザを受けたポケモンは、選ばれたワザを使えない。",
+			},
+		},
+		{
+			name: { ja: "からげんき" },
+			damage: "50+",
+			cost: ["Psychic", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンがどくまたはやけどなら、80ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561490,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ヤドン",
+	},
+
+	retreat: 3,
+	rarity: "Uncommon",
+	dexId: [80],
+};
+
+export default card;

--- a/data-asia/SM/SM2K/025.ts
+++ b/data-asia/SM/SM2K/025.ts
@@ -1,0 +1,48 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM2K";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ゴチム",
+	},
+
+	illustrator: "Yuka Morii",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Psychic"],
+
+	description: {
+		ja: "リボンのような 触角で サイコパワーを 増幅させる。 なにかを じっと 見つめている。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "なげキッス" },
+			cost: ["Psychic"],
+			effect: {
+				ja: "相手のポケモン1匹に、ダメカンを1個のせる。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561491,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [574],
+};
+
+export default card;

--- a/data-asia/SM/SM2K/026.ts
+++ b/data-asia/SM/SM2K/026.ts
@@ -1,0 +1,58 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM2K";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ゴチミル",
+	},
+
+	illustrator: "kawayoo",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Psychic"],
+
+	description: {
+		ja: "星明りが パワーの 源。 夜になると サイコパワーで 石を 浮かべて 星の 配置を 印す。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "ビンタ" },
+			damage: 20,
+			cost: ["Psychic"],
+		},
+		{
+			name: { ja: "サイケこうせん" },
+			damage: 30,
+			cost: ["Psychic", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをこんらんにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561492,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ゴチム",
+	},
+
+	retreat: 2,
+	rarity: "Common",
+	dexId: [575],
+};
+
+export default card;

--- a/data-asia/SM/SM2K/027.ts
+++ b/data-asia/SM/SM2K/027.ts
@@ -1,0 +1,60 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM2K";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ゴチルゼル",
+	},
+
+	illustrator: "Mitsuhiro Arita",
+	category: "Pokemon",
+	hp: 140,
+	types: ["Psychic"],
+
+	description: {
+		ja: "強力な サイコパワーの 影響で ゴチルゼルの 周囲の 空間が ねじれ 何万光年も 遠くの 星空が 映る。",
+	},
+
+	stage: "Stage2",
+
+	attacks: [
+		{
+			name: { ja: "トラクタービーム" },
+			cost: ["Psychic"],
+			effect: {
+				ja: "相手のベンチポケモンを1匹選び、バトルポケモンと入れ替える。その後、新しく出てきたポケモンに30ダメージ。",
+			},
+		},
+		{
+			name: { ja: "リンクブラスト" },
+			damage: "50+",
+			cost: ["Psychic", "Colorless"],
+			effect: {
+				ja: "このポケモンと相手のバトルポケモンについているエネルギーの数が同じなら、80ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561493,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ゴチミル",
+	},
+
+	retreat: 2,
+	rarity: "Uncommon",
+	dexId: [576],
+};
+
+export default card;

--- a/data-asia/SM/SM2K/028.ts
+++ b/data-asia/SM/SM2K/028.ts
@@ -1,0 +1,49 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM2K";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ワンリキー",
+	},
+
+	illustrator: "Kyoko Umemoto",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Fighting"],
+
+	description: {
+		ja: "きたえるのが 大好き。 日に日に 膨れていく 筋肉を ながめて ますます トレーニングに 励むぞ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ダブルチョップ" },
+			damage: "30×",
+			cost: ["Fighting", "Fighting"],
+			effect: {
+				ja: "コインを2回投げ、オモテの数x30ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561494,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Common",
+	dexId: [66],
+};
+
+export default card;

--- a/data-asia/SM/SM2K/029.ts
+++ b/data-asia/SM/SM2K/029.ts
@@ -1,0 +1,63 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM2K";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ゴーリキー",
+	},
+
+	illustrator: "Kouki Saitou",
+	category: "Pokemon",
+	hp: 100,
+	types: ["Fighting"],
+
+	description: {
+		ja: "きたえにきたえた 結果 凄まじい パワーを 手にいれた。 その力を 活かし 人の仕事を 手伝う。",
+	},
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "におうだち" },
+			effect: {
+				ja: "このポケモンがいるかぎり、自分のベンチポケモン全員は、相手のワザのダメージを受けず、相手のワザや特性の効果によるダメカンものらない。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "クロスチョップ" },
+			damage: "30+",
+			cost: ["Fighting", "Fighting"],
+			effect: {
+				ja: "コインを1回投げオモテなら、30ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561495,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ワンリキー",
+	},
+
+	retreat: 3,
+	rarity: "Uncommon",
+	dexId: [67],
+};
+
+export default card;

--- a/data-asia/SM/SM2K/030.ts
+++ b/data-asia/SM/SM2K/030.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM2K";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "カイリキー",
+	},
+
+	illustrator: "Hitoshi Ariga",
+	category: "Pokemon",
+	hp: 160,
+	types: ["Fighting"],
+
+	description: {
+		ja: "メガトン級の パンチを 放ち 立ちふさがる 敵を 地平線の 彼方まで ぶっ飛ばすのだ。",
+	},
+
+	stage: "Stage2",
+
+	attacks: [
+		{
+			name: { ja: "おれいまいり" },
+			damage: "20+",
+			cost: ["Fighting", "Fighting"],
+			effect: {
+				ja: "前の相手の番に、相手がとったサイドの枚数x80ダメージ追加。",
+			},
+		},
+		{
+			name: { ja: "じごくぐるま" },
+			damage: 150,
+			cost: ["Fighting", "Fighting", "Fighting"],
+			effect: {
+				ja: "このポケモンにも30ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 561496,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ゴーリキー",
+	},
+
+	retreat: 3,
+	rarity: "Rare",
+	dexId: [68],
+};
+
+export default card;

--- a/data-asia/SM/SM2K/031.ts
+++ b/data-asia/SM/SM2K/031.ts
@@ -1,0 +1,54 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM2K";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ノズパス",
+	},
+
+	illustrator: "Tomokazu Komiya",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Fighting"],
+
+	description: {
+		ja: "ノズパスの 鼻の 磁石は 絶対 狂わないので 旅する トレーナーの 良き パートナーだ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ぶつかる" },
+			damage: 20,
+			cost: ["Colorless", "Colorless"],
+		},
+		{
+			name: { ja: "つきあげる" },
+			damage: "30+",
+			cost: ["Fighting", "Colorless", "Colorless"],
+			effect: {
+				ja: "コインを1回投げオモテなら、30ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561497,
+			},
+		},
+	],
+
+	retreat: 3,
+	rarity: "Common",
+	dexId: [299],
+};
+
+export default card;

--- a/data-asia/SM/SM2K/032.ts
+++ b/data-asia/SM/SM2K/032.ts
@@ -1,0 +1,51 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM2K";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ドジョッチ",
+	},
+
+	illustrator: "sui",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Fighting"],
+
+	description: {
+		ja: "２本のヒゲは 敏感なレーダー。 泥で 濁った 水の 中でも 獲物の 位置を 察知するぞ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ひっかける" },
+			damage: 10,
+			cost: ["Colorless"],
+		},
+		{
+			name: { ja: "どろかけ" },
+			damage: 20,
+			cost: ["Fighting", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561498,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Common",
+	dexId: [339],
+};
+
+export default card;

--- a/data-asia/SM/SM2K/033.ts
+++ b/data-asia/SM/SM2K/033.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM2K";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ナマズン",
+	},
+
+	illustrator: "Masakazu Fukuda",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Fighting"],
+
+	description: {
+		ja: "動くものなら なんでも 喰いつく 大食らい。 普段は 沼底で じっと 獲物を 待ち構えている。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "みずのはどう" },
+			damage: 60,
+			cost: ["Fighting", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをねむりにする。",
+			},
+		},
+		{
+			name: { ja: "じすべり" },
+			damage: "100×",
+			cost: ["Fighting", "Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "自分の山札を上から3枚トラッシュし、その中のエネルギーの枚数x100ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561499,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ドジョッチ",
+	},
+
+	retreat: 3,
+	rarity: "Uncommon",
+	dexId: [340],
+};
+
+export default card;

--- a/data-asia/SM/SM2K/034.ts
+++ b/data-asia/SM/SM2K/034.ts
@@ -1,0 +1,58 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM2K";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ダイノーズ",
+	},
+
+	illustrator: "Yoshinobu Saito",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Metal"],
+
+	description: {
+		ja: "強い 磁力を 放っているので 近くにある 電化製品は 使いものに ならなくなってしまう。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "エナジーコネクター" },
+			damage: 30,
+			cost: ["Metal"],
+			effect: {
+				ja: "自分のトラッシュにあるエネルギーを1枚、このポケモンにつける。",
+			},
+		},
+		{
+			name: { ja: "パワージェム" },
+			damage: 120,
+			cost: ["Colorless", "Colorless", "Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561500,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ノズパス",
+	},
+
+	retreat: 4,
+	rarity: "Uncommon",
+	dexId: [476],
+};
+
+export default card;

--- a/data-asia/SM/SM2K/035.ts
+++ b/data-asia/SM/SM2K/035.ts
@@ -1,0 +1,53 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM2K";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ピッピ",
+	},
+
+	illustrator: "Kagemaru Himeno",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Fairy"],
+
+	description: {
+		ja: "愛くるしい 仕草と 姿で 老若男女 問わずに 人気だが その数は 少ない。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ビンタ" },
+			damage: 10,
+			cost: ["Fairy"],
+		},
+		{
+			name: { ja: "このゆびとまれ" },
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "相手のベンチポケモンを1匹選び、バトルポケモンと入れ替える。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [{ type: "Darkness", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561501,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [35],
+};
+
+export default card;

--- a/data-asia/SM/SM2K/036.ts
+++ b/data-asia/SM/SM2K/036.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM2K";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ピクシー",
+	},
+
+	illustrator: "Miki Tanaka",
+	category: "Pokemon",
+	hp: 100,
+	types: ["Fairy"],
+
+	description: {
+		ja: "人前に 姿を みせることを 好まない。 深い 山の 奥で 群れに なって ひっそり 暮らす。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "こもりうた" },
+			damage: 20,
+			cost: ["Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをねむりにする。",
+			},
+		},
+		{
+			name: { ja: "コメットパンチ" },
+			damage: 60,
+			cost: ["Fairy", "Colorless", "Colorless"],
+			effect: {
+				ja: "次の自分の番、このポケモンの「コメットパンチ」のダメージは「+60」される。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [{ type: "Darkness", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561502,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ピッピ",
+	},
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [36],
+};
+
+export default card;

--- a/data-asia/SM/SM2K/037.ts
+++ b/data-asia/SM/SM2K/037.ts
@@ -1,0 +1,59 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM2K";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "キュワワー",
+	},
+
+	illustrator: "Sanosuke Sakuma",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Fairy"],
+
+	description: {
+		ja: "栄養満点の ツルに 花を くっつける。 花は 活性化し 香しい アロマが 漂いだす。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "フラワーガード" },
+			effect: {
+				ja: "このポケモンがいるかぎり、[妖]エネルギーがついている自分のポケモン全員は、特殊状態にならず、受けている特殊状態は、すべて回復する。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "てんしのキッス" },
+			damage: 30,
+			cost: ["Fairy", "Colorless"],
+			effect: {
+				ja: "相手は山札を1枚引く。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [{ type: "Darkness", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 561503,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Rare",
+	dexId: [764],
+};
+
+export default card;

--- a/data-asia/SM/SM2K/038.ts
+++ b/data-asia/SM/SM2K/038.ts
@@ -1,0 +1,56 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM2K";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ジジーロン",
+	},
+
+	illustrator: "match",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Dragon"],
+
+	description: {
+		ja: "心優しい 性質。 だが 一度 怒りに かられると 激しい 息吹で あたりを 破壊 し尽くす。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ためる" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札にある基本エネルギーを1枚、このポケモンにつける。そして山札を切る。",
+			},
+		},
+		{
+			name: { ja: "パワーサイクロン" },
+			damage: 80,
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンについているエネルギーを1個、ベンチポケモンにつけ替える。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fairy", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 561504,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Rare",
+	dexId: [780],
+};
+
+export default card;

--- a/data-asia/SM/SM2K/039.ts
+++ b/data-asia/SM/SM2K/039.ts
@@ -1,0 +1,56 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM2K";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ジャラコ",
+	},
+
+	illustrator: "match",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Dragon"],
+
+	description: {
+		ja: "ウロコを 叩き 気持ちを 伝える。 ジャラコの 棲む 高山では 金属音が 木霊する。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ぼうだん" },
+			effect: {
+				ja: "このポケモンが受けるワザのダメージは「-10」される。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ドラゴンクロー" },
+			damage: 30,
+			cost: ["Lightning", "Fighting"],
+		},
+	],
+
+	weaknesses: [{ type: "Fairy", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561505,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Common",
+	dexId: [782],
+};
+
+export default card;

--- a/data-asia/SM/SM2K/040.ts
+++ b/data-asia/SM/SM2K/040.ts
@@ -1,0 +1,55 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM2K";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ジャランゴ",
+	},
+
+	illustrator: "Shin Nagasawa",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Dragon"],
+
+	description: {
+		ja: "雄叫びと ともに 獲物に 飛びかかる。 ウロコの パンチは 相手を ズタズタに 引き裂くぞ。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "ずつき" },
+			damage: 30,
+			cost: ["Colorless"],
+		},
+		{
+			name: { ja: "ドラゴンクロー" },
+			damage: 80,
+			cost: ["Lightning", "Fighting", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fairy", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561506,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ジャラコ",
+	},
+
+	retreat: 2,
+	rarity: "Common",
+	dexId: [783],
+};
+
+export default card;

--- a/data-asia/SM/SM2K/041.ts
+++ b/data-asia/SM/SM2K/041.ts
@@ -1,0 +1,67 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM2K";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ジャラランガGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 240,
+	types: ["Dragon"],
+
+	stage: "Stage2",
+
+	attacks: [
+		{
+			name: { ja: "こんごうプレス" },
+			damage: 30,
+			cost: ["Colorless"],
+			effect: {
+				ja: "次の相手の番、このポケモンが受けるワザのダメージは「-30」される。",
+			},
+		},
+		{
+			name: { ja: "ひきさく" },
+			damage: 130,
+			cost: ["Lightning", "Fighting", "Colorless", "Colorless"],
+			effect: {
+				ja: "このワザのダメージは、相手のバトルポケモンにかかっている効果を計算しない。",
+			},
+		},
+		{
+			name: { ja: "ゲキアッパーGX" },
+			damage: 240,
+			cost: ["Lightning", "Fighting", "Colorless", "Colorless"],
+			effect: {
+				ja: "［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fairy", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 561507,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ジャランゴ",
+	},
+
+	retreat: 2,
+	rarity: "Double rare",
+	dexId: [784],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM2K/042.ts
+++ b/data-asia/SM/SM2K/042.ts
@@ -1,0 +1,53 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM2K";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ラッキー",
+	},
+
+	illustrator: "Megumi Mizutani",
+	category: "Pokemon",
+	hp: 110,
+	types: ["Colorless"],
+
+	description: {
+		ja: "ラッキーの 産む タマゴは 栄養が たっぷり つまっている。 多くの ポケモンが 大好物だ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "きずをなおす" },
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "コインを1回投げオモテなら、自分のポケモン1匹のHPを「30」回復する。",
+			},
+		},
+		{
+			name: { ja: "ぶちかます" },
+			damage: 80,
+			cost: ["Colorless", "Colorless", "Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561508,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Common",
+	dexId: [113],
+};
+
+export default card;

--- a/data-asia/SM/SM2K/043.ts
+++ b/data-asia/SM/SM2K/043.ts
@@ -1,0 +1,63 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM2K";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ハピナス",
+	},
+
+	illustrator: "Hideki Ishikawa",
+	category: "Pokemon",
+	hp: 160,
+	types: ["Colorless"],
+
+	description: {
+		ja: "幸せが つまっていると いわれる ハピナスの タマゴを 食べれば どんな 凶暴な ポケモンも 穏やかに。",
+	},
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "うみたてタマゴ" },
+			effect: {
+				ja: "自分の番に、このカードを手札から出して進化させたとき、1回使える。自分のバトルポケモンのHPを「80」回復する。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "すてみタックル" },
+			damage: 160,
+			cost: ["Colorless", "Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンにも80ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 561509,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ラッキー",
+	},
+
+	retreat: 4,
+	rarity: "Rare",
+	dexId: [242],
+};
+
+export default card;

--- a/data-asia/SM/SM2K/044.ts
+++ b/data-asia/SM/SM2K/044.ts
@@ -1,0 +1,49 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM2K";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "スバメ",
+	},
+
+	illustrator: "Ayaka Yoshida",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Colorless"],
+
+	description: {
+		ja: "強い 相手にも 勇敢に 立ち向かう 根性の 持ち主。 暖かい 土地を 目指して 飛ぶ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "とつげき" },
+			damage: 20,
+			cost: ["Colorless"],
+			effect: {
+				ja: "このポケモンにも10ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561510,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [276],
+};
+
+export default card;

--- a/data-asia/SM/SM2K/045.ts
+++ b/data-asia/SM/SM2K/045.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM2K";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "オオスバメ",
+	},
+
+	illustrator: "Kagemaru Himeno",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Colorless"],
+
+	description: {
+		ja: "２本の 尾羽が ピンと 立って いれば 健康な 証拠。 優雅に 大空を 飛び回る。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "こうそくいどう" },
+			damage: 20,
+			cost: ["Colorless"],
+			effect: {
+				ja: "コインを1回投げオモテなら、次の相手の番、このポケモンはワザのダメージや効果を受けない。",
+			},
+		},
+		{
+			name: { ja: "スワローダイブ" },
+			damage: "40+",
+			cost: ["Colorless"],
+			effect: {
+				ja: "前の自分の番、このポケモンが「こうそくいどう」を使っていたなら、80ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561511,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "スバメ",
+	},
+
+	retreat: 1,
+	rarity: "Uncommon",
+	dexId: [277],
+};
+
+export default card;

--- a/data-asia/SM/SM2K/046.ts
+++ b/data-asia/SM/SM2K/046.ts
@@ -1,0 +1,59 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM2K";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ネッコアラ",
+	},
+
+	illustrator: "Kouki Saitou",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Colorless"],
+
+	description: {
+		ja: "寝たまま 生まれ 寝たまま 死ぬ。 すべての 行動は みている 夢に よる 寝相 らしい。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ぜったいねむり" },
+			effect: {
+				ja: "このポケモンがバトル場にいるかぎり、手札からこのポケモンにエネルギーをつけるたび、このポケモンをねむりにする。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ヒプノロール" },
+			damage: 100,
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "このワザは、このポケモンがねむりなら、使える。このポケモンがねむりでないなら、このワザは失敗。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561512,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Uncommon",
+	dexId: [775],
+};
+
+export default card;

--- a/data-asia/SM/SM2K/047.ts
+++ b/data-asia/SM/SM2K/047.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM2K";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "エネくじ",
+	},
+
+	illustrator: "Yoshinobu Saito",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の山札を上から7枚見る。その中にあるエネルギーを1枚、相手に見せてから、手札に加えてよい。残りのカードは山札にもどして切る。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561513,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM2K/048.ts
+++ b/data-asia/SM/SM2K/048.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM2K";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "フィールドブロアー",
+	},
+
+	illustrator: "Toyste Beach",
+	category: "Trainer",
+
+	effect: {
+		ja: "場にある「ポケモンのどうぐ」または「スタジアム」を、2枚までトラッシュする。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561514,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM2K/049.ts
+++ b/data-asia/SM/SM2K/049.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM2K";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ハラ",
+	},
+
+	illustrator: "Ken Sugimori",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の手札をすべて山札にもどして切る。その後、山札を4枚引く。自分がすでにGXワザを使っていたなら、引く枚数は7枚になる。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561515,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM2K/050.ts
+++ b/data-asia/SM/SM2K/050.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM2K";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "エーテルパラダイス保護区",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Trainer",
+
+	effect: {
+		ja: "おたがいの[草]または[雷]タイプのたねポケモンが、相手のポケモンから受けるワザのダメージは「-30」される。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561516,
+			},
+		},
+	],
+
+	trainerType: "Stadium",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM2K/051.ts
+++ b/data-asia/SM/SM2K/051.ts
@@ -1,0 +1,62 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM2K";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "バクガメスGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 190,
+	types: ["Fire"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "トラップシェル" },
+			damage: 20,
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "次の相手の番、このポケモンがワザのダメージを受けたとき、ワザを使ったポケモンにダメカンを8個のせる。",
+			},
+		},
+		{
+			name: { ja: "ぐれんのほのお" },
+			damage: 160,
+			cost: ["Fire", "Fire", "Colorless"],
+			effect: {
+				ja: "このポケモンについている[炎]エネルギーを、2個トラッシュする。",
+			},
+		},
+		{
+			name: { ja: "ニトロタンクGX" },
+			cost: ["Fire"],
+			effect: {
+				ja: "自分のトラッシュにある[炎]エネルギーを5枚、自分のポケモンに好きなようにつける。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 561517,
+			},
+		},
+	],
+
+	retreat: 3,
+	rarity: "Ultra Rare",
+	dexId: [776],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM2K/052.ts
+++ b/data-asia/SM/SM2K/052.ts
@@ -1,0 +1,65 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM2K";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アローラキュウコンGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 210,
+	types: ["Water"],
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "こおりのやいば" },
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "相手のポケモン1匹に、50ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+			},
+		},
+		{
+			name: { ja: "ブリザードエッジ" },
+			damage: 160,
+			cost: ["Water", "Water", "Colorless"],
+			effect: {
+				ja: "このポケモンについているエネルギーを、2個トラッシュする。",
+			},
+		},
+		{
+			name: { ja: "クリアゲートGX" },
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンにのっているダメカンをすべて、相手のバトルポケモンにのせ替える。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 561518,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "アローラロコン",
+	},
+
+	retreat: 1,
+	rarity: "Ultra Rare",
+	dexId: [38],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM2K/053.ts
+++ b/data-asia/SM/SM2K/053.ts
@@ -1,0 +1,62 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM2K";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "カプ・コケコGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 170,
+	types: ["Lightning"],
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "エアロトレイル" },
+			effect: {
+				ja: "自分の番に、このカードを手札からベンチに出したとき、1回使える。自分の場のポケモンについている[雷]エネルギーを好きなだけ、このポケモンにつけ替える。つけ替えた場合、このポケモンをバトルポケモンと入れ替える。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "てんくうのツメ" },
+			damage: 130,
+			cost: ["Lightning", "Lightning", "Colorless"],
+		},
+		{
+			name: { ja: "カプサンダーGX" },
+			damage: "50×",
+			cost: ["Lightning", "Lightning", "Colorless"],
+			effect: {
+				ja: "相手の場のポケモンについているエネルギーの数x50ダメージ。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 561519,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Ultra Rare",
+	dexId: [785],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM2K/054.ts
+++ b/data-asia/SM/SM2K/054.ts
@@ -1,0 +1,67 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM2K";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ジャラランガGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 240,
+	types: ["Dragon"],
+
+	stage: "Stage2",
+
+	attacks: [
+		{
+			name: { ja: "こんごうプレス" },
+			damage: 30,
+			cost: ["Colorless"],
+			effect: {
+				ja: "次の相手の番、このポケモンが受けるワザのダメージは「-30」される。",
+			},
+		},
+		{
+			name: { ja: "ひきさく" },
+			damage: 130,
+			cost: ["Lightning", "Fighting", "Colorless", "Colorless"],
+			effect: {
+				ja: "このワザのダメージは、相手のバトルポケモンにかかっている効果を計算しない。",
+			},
+		},
+		{
+			name: { ja: "ゲキアッパーGX" },
+			damage: 240,
+			cost: ["Lightning", "Fighting", "Colorless", "Colorless"],
+			effect: {
+				ja: "［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fairy", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 561520,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ジャランゴ",
+	},
+
+	retreat: 2,
+	rarity: "Ultra Rare",
+	dexId: [784],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM2K/055.ts
+++ b/data-asia/SM/SM2K/055.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM2K";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ハラ",
+	},
+
+	illustrator: "Naoki Saito",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の手札をすべて山札にもどして切る。その後、山札を4枚引く。自分がすでにGXワザを使っていたなら、引く枚数は7枚になる。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 561521,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	rarity: "Ultra Rare",
+};
+
+export default card;

--- a/data-asia/SM/SM2K/056.ts
+++ b/data-asia/SM/SM2K/056.ts
@@ -1,0 +1,62 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM2K";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "バクガメスGX",
+	},
+
+	illustrator: "",
+	category: "Pokemon",
+	hp: 190,
+	types: ["Fire"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "トラップシェル" },
+			damage: 20,
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "次の相手の番、このポケモンがワザのダメージを受けたとき、ワザを使ったポケモンにダメカンを8個のせる。",
+			},
+		},
+		{
+			name: { ja: "ぐれんのほのお" },
+			damage: 160,
+			cost: ["Fire", "Fire", "Colorless"],
+			effect: {
+				ja: "このポケモンについている[炎]エネルギーを、2個トラッシュする。",
+			},
+		},
+		{
+			name: { ja: "ニトロタンクGX" },
+			cost: ["Fire"],
+			effect: {
+				ja: "自分のトラッシュにある[炎]エネルギーを5枚、自分のポケモンに好きなようにつける。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 561522,
+			},
+		},
+	],
+
+	retreat: 3,
+	rarity: "Hyper rare",
+	dexId: [776],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM2K/057.ts
+++ b/data-asia/SM/SM2K/057.ts
@@ -1,0 +1,65 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM2K";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アローラキュウコンGX",
+	},
+
+	illustrator: "",
+	category: "Pokemon",
+	hp: 210,
+	types: ["Water"],
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "こおりのやいば" },
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "相手のポケモン1匹に、50ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+			},
+		},
+		{
+			name: { ja: "ブリザードエッジ" },
+			damage: 160,
+			cost: ["Water", "Water", "Colorless"],
+			effect: {
+				ja: "このポケモンについているエネルギーを、2個トラッシュする。",
+			},
+		},
+		{
+			name: { ja: "クリアゲートGX" },
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンにのっているダメカンをすべて、相手のバトルポケモンにのせ替える。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 561523,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "アローラロコン",
+	},
+
+	retreat: 1,
+	rarity: "Hyper rare",
+	dexId: [38],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM2K/058.ts
+++ b/data-asia/SM/SM2K/058.ts
@@ -1,0 +1,62 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM2K";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "カプ・コケコGX",
+	},
+
+	illustrator: "",
+	category: "Pokemon",
+	hp: 170,
+	types: ["Lightning"],
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "エアロトレイル" },
+			effect: {
+				ja: "自分の番に、このカードを手札からベンチに出したとき、1回使える。自分の場のポケモンについている[雷]エネルギーを好きなだけ、このポケモンにつけ替える。つけ替えた場合、このポケモンをバトルポケモンと入れ替える。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "てんくうのツメ" },
+			damage: 130,
+			cost: ["Lightning", "Lightning", "Colorless"],
+		},
+		{
+			name: { ja: "カプサンダーGX" },
+			damage: "50×",
+			cost: ["Lightning", "Lightning", "Colorless"],
+			effect: {
+				ja: "相手の場のポケモンについているエネルギーの数x50ダメージ。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 561524,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Hyper rare",
+	dexId: [785],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM2K/059.ts
+++ b/data-asia/SM/SM2K/059.ts
@@ -1,0 +1,67 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM2K";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ジャラランガGX",
+	},
+
+	illustrator: "",
+	category: "Pokemon",
+	hp: 240,
+	types: ["Dragon"],
+
+	stage: "Stage2",
+
+	attacks: [
+		{
+			name: { ja: "こんごうプレス" },
+			damage: 30,
+			cost: ["Colorless"],
+			effect: {
+				ja: "次の相手の番、このポケモンが受けるワザのダメージは「-30」される。",
+			},
+		},
+		{
+			name: { ja: "ひきさく" },
+			damage: 130,
+			cost: ["Lightning", "Fighting", "Colorless", "Colorless"],
+			effect: {
+				ja: "このワザのダメージは、相手のバトルポケモンにかかっている効果を計算しない。",
+			},
+		},
+		{
+			name: { ja: "ゲキアッパーGX" },
+			damage: 240,
+			cost: ["Lightning", "Fighting", "Colorless", "Colorless"],
+			effect: {
+				ja: "［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fairy", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 561525,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ジャランゴ",
+	},
+
+	retreat: 2,
+	rarity: "Hyper rare",
+	dexId: [784],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM2K/060.ts
+++ b/data-asia/SM/SM2K/060.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM2K";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "フィールドブロアー",
+	},
+
+	illustrator: "",
+	category: "Trainer",
+
+	effect: {
+		ja: "場にある「ポケモンのどうぐ」または「スタジアム」を、2枚までトラッシュする。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 561526,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	rarity: "Secret Rare",
+};
+
+export default card;

--- a/data-asia/SM/SM2K/061.ts
+++ b/data-asia/SM/SM2K/061.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM2K";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "まんたんのくすり",
+	},
+
+	illustrator: "",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分のポケモンを1匹選び、HPをすべて回復する。その後、そのポケモンについているエネルギーをすべてトラッシュする。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 561527,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	rarity: "Secret Rare",
+};
+
+export default card;


### PR DESCRIPTION
## What

Adds the complete Japanese set **SM2K キミを待つ島々 (Islands Await You)**, released 2017-03-17:

- `data-asia/SM/SM2K/001.ts` … `061.ts` — all 61 cards (50 regular + 11 secret rares: 5 SR, 2 Secret Rare, 4 UR)
- the set definition `data-asia/SM/SM2K.ts` already existed and is untouched

## Data sources

- **pokemon-card.com** (official database): Japanese names, flavor texts, National Dex numbers, official card count
- **limitlesstcg.com**: full Japanese card text, stages, weaknesses/resistances/retreat, rarities, illustrators, attack costs
- **Cardmarket**: product IDs as `thirdParty.cardmarket` on the variant objects (561467–561527; tcgplayer IDs not available to me)

## Notes

- Follows the file format and conventions of the M-era sets (#1728)
- No `regulationMark` (the set predates regulation marks); resistances are `-20` per the era
- All 61 files type-check against `interfaces.d.ts` (`tsc --noEmit`)
