### PR TITLE
(data) Add Japanese SM set SM2L Alolan Moonlight

### DIFF
--- a/data-asia/SM/SM2L/001.ts
+++ b/data-asia/SM/SM2L/001.ts
@@ -1,0 +1,53 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM2L";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ボクレー",
+	},
+
+	illustrator: "Sanosuke Sakuma",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Grass"],
+
+	description: {
+		ja: "森で 死んだ 子どもの 魂が 切り株に 宿った。 悲鳴の ような 不気味な 声で 鳴く。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "たいあたり" },
+			damage: 10,
+			cost: ["Grass"],
+		},
+		{
+			name: { ja: "あやしいひかり" },
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをこんらんにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561405,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Common",
+	dexId: [708],
+};
+
+export default card;

--- a/data-asia/SM/SM2L/002.ts
+++ b/data-asia/SM/SM2L/002.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM2L";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "オーロット",
+	},
+
+	illustrator: "Hiroyuki Yamamoto",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Grass"],
+
+	description: {
+		ja: "森を 荒らす者を 喰ってしまうと いわれる ポケモン。 森に 暮らす 生き物たちには とても 優しい。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "ポルターガイスト" },
+			damage: "30×",
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "相手の手札を見て、その中にあるトレーナーズの枚数x30ダメージ。",
+			},
+		},
+		{
+			name: { ja: "ウッドホーン" },
+			damage: 90,
+			cost: ["Grass", "Grass", "Colorless"],
+			effect: {
+				ja: "このポケモンのHPを「30」回復する。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561406,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ボクレー",
+	},
+
+	retreat: 2,
+	rarity: "Uncommon",
+	dexId: [709],
+};
+
+export default card;

--- a/data-asia/SM/SM2L/003.ts
+++ b/data-asia/SM/SM2L/003.ts
@@ -1,0 +1,49 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM2L";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヒトモシ",
+	},
+
+	illustrator: "Mitsuhiro Arita",
+	category: "Pokemon",
+	hp: 50,
+	types: ["Fire"],
+
+	description: {
+		ja: "明かりを 灯して 道案内を するように 見せかけながら 生命力を 吸い取っている。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ゆれるほのお" },
+			damage: 10,
+			cost: ["Fire"],
+			effect: {
+				ja: "相手のバトルポケモンをねむりにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561407,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [607],
+};
+
+export default card;

--- a/data-asia/SM/SM2L/004.ts
+++ b/data-asia/SM/SM2L/004.ts
@@ -1,0 +1,50 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM2L";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ランプラー",
+	},
+
+	illustrator: "0313",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Fire"],
+
+	description: {
+		ja: "魂を 吸いとり 火を灯す。 人が 死ぬのを 待つため 病院を うろつくようになった。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "おにび" },
+			damage: 30,
+			cost: ["Fire"],
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561408,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ヒトモシ",
+	},
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [608],
+};
+
+export default card;

--- a/data-asia/SM/SM2L/005.ts
+++ b/data-asia/SM/SM2L/005.ts
@@ -1,0 +1,63 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM2L";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "シャンデラ",
+	},
+
+	illustrator: "Kouki Saitou",
+	category: "Pokemon",
+	hp: 140,
+	types: ["Fire"],
+
+	description: {
+		ja: "シャンデラの 炎に 包まれると 魂が 吸い取られ 燃やされる。 抜け殻の 体 だけが 残る。",
+	},
+
+	stage: "Stage2",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "シャドームーブ" },
+			effect: {
+				ja: "自分の番に1回使える。おたがいの場のポケモンにのっているダメカンを1個、おたがいの場の別のポケモンにのせ替える。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ほのおでこがす" },
+			damage: 50,
+			cost: ["Fire"],
+			effect: {
+				ja: "相手のバトルポケモンをやけどにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 561409,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ランプラー",
+	},
+
+	retreat: 1,
+	rarity: "Rare",
+	dexId: [609],
+};
+
+export default card;

--- a/data-asia/SM/SM2L/006.ts
+++ b/data-asia/SM/SM2L/006.ts
@@ -1,0 +1,54 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM2L";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヤトウモリ",
+	},
+
+	illustrator: "TOKIYA",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Fire"],
+
+	description: {
+		ja: "体液を 燃やし 毒ガスを たく。 ガスを 吸った 敵が フラフラに なったあと 襲いかかるのだ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ひっかく" },
+			damage: 10,
+			cost: ["Fire"],
+		},
+		{
+			name: { ja: "ベノムショック" },
+			damage: "20+",
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンがどくなら、40ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561410,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [757],
+};
+
+export default card;

--- a/data-asia/SM/SM2L/007.ts
+++ b/data-asia/SM/SM2L/007.ts
@@ -1,0 +1,63 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM2L";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "エンニュート",
+	},
+
+	illustrator: "Mitsuhiro Arita",
+	category: "Pokemon",
+	hp: 110,
+	types: ["Fire"],
+
+	description: {
+		ja: "なぜか ♀しか 見つかっていない。 ヤトウモリの♂を 引き連れて 逆ハーレムを 作って 暮らす。",
+	},
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ホットポイズン" },
+			effect: {
+				ja: "自分の番に、このカードを手札から出して進化させたとき、1回使える。相手のバトルポケモンをどくとやけどにする。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "かえんほうしゃ" },
+			damage: 90,
+			cost: ["Fire", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンについているエネルギーを、1個トラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561411,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ヤトウモリ",
+	},
+
+	retreat: 1,
+	rarity: "Uncommon",
+	dexId: [758],
+};
+
+export default card;

--- a/data-asia/SM/SM2L/008.ts
+++ b/data-asia/SM/SM2L/008.ts
@@ -1,0 +1,49 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM2L";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "メノクラゲ",
+	},
+
+	illustrator: "Shibuzoh.",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Water"],
+
+	description: {
+		ja: "ビーチなどで 干からびているが まだ 生きていることも 多い。 水に 浸せば ふやけて 復活。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ヘドロショック" },
+			damage: 10,
+			cost: ["Colorless"],
+			effect: {
+				ja: "次の相手の番、このワザを受けたポケモンのHPは、回復しない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561412,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [72],
+};
+
+export default card;

--- a/data-asia/SM/SM2L/009.ts
+++ b/data-asia/SM/SM2L/009.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM2L";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ドククラゲ",
+	},
+
+	illustrator: "Masakazu Fukuda",
+	category: "Pokemon",
+	hp: 110,
+	types: ["Water"],
+
+	description: {
+		ja: "毒の触手は 普通 ８０本。 長く 生きているもの ほど その 本数は 減っていく。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "どくばり" },
+			damage: 30,
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをどくにする。",
+			},
+		},
+		{
+			name: { ja: "あばれしょくしゅ" },
+			damage: "40+",
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "コインを1回投げオモテなら、40ダメージ追加。ウラなら、相手のバトルポケモンをマヒにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561413,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "メノクラゲ",
+	},
+
+	retreat: 2,
+	rarity: "Uncommon",
+	dexId: [73],
+};
+
+export default card;

--- a/data-asia/SM/SM2L/010.ts
+++ b/data-asia/SM/SM2L/010.ts
@@ -1,0 +1,51 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM2L";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ホエルコ",
+	},
+
+	illustrator: "Miki Tanaka",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Water"],
+
+	description: {
+		ja: "人を 驚かせるのが 好き。 海水を 飲み込んで ボールの ように ふくらみ 弾んで 遊ぶ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "はねる" },
+			damage: 20,
+			cost: ["Water", "Colorless"],
+		},
+		{
+			name: { ja: "なみのり" },
+			damage: 70,
+			cost: ["Water", "Water", "Water", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561414,
+			},
+		},
+	],
+
+	retreat: 3,
+	rarity: "Common",
+	dexId: [320],
+};
+
+export default card;

--- a/data-asia/SM/SM2L/011.ts
+++ b/data-asia/SM/SM2L/011.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM2L";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ホエルオー",
+	},
+
+	illustrator: "OOYAMA",
+	category: "Pokemon",
+	hp: 200,
+	types: ["Water"],
+
+	description: {
+		ja: "群れで 獲物を 追う 習性。 大きな 口で ヨワシの 群れごと 一気に 呑み込んでしまうぞ。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "ダイビング" },
+			damage: 40,
+			cost: ["Water", "Water", "Colorless"],
+			effect: {
+				ja: "コインを1回投げオモテなら、次の相手の番、このポケモンはワザのダメージや効果を受けない。",
+			},
+		},
+		{
+			name: { ja: "おおうなばら" },
+			damage: 80,
+			cost: ["Water", "Water", "Water", "Colorless"],
+			effect: {
+				ja: "自分の[水]ポケモン全員のHPを、それぞれ「30」回復する。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561415,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ホエルコ",
+	},
+
+	retreat: 4,
+	rarity: "Uncommon",
+	dexId: [321],
+};
+
+export default card;

--- a/data-asia/SM/SM2L/012.ts
+++ b/data-asia/SM/SM2L/012.ts
@@ -1,0 +1,53 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM2L";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ママンボウ",
+	},
+
+	illustrator: "Aya Kusube",
+	category: "Pokemon",
+	hp: 110,
+	types: ["Water"],
+
+	description: {
+		ja: "傷ついた ポケモンを 抱きしめ 特殊な 粘液で 傷を ふさぐ。 その理由は 不明。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "きしにはこぶ" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分または相手のトラッシュにあるたねポケモンを1枚、持ち主のベンチに出す。",
+			},
+		},
+		{
+			name: { ja: "ハイドロスプラッシュ" },
+			damage: 60,
+			cost: ["Water", "Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561416,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Uncommon",
+	dexId: [594],
+};
+
+export default card;

--- a/data-asia/SM/SM2L/013.ts
+++ b/data-asia/SM/SM2L/013.ts
@@ -1,0 +1,58 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM2L";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヨワシ",
+	},
+
+	illustrator: "Sanosuke Sakuma",
+	category: "Pokemon",
+	hp: 30,
+	types: ["Water"],
+
+	description: {
+		ja: "ピンチになると 目が 潤みだし 輝く。 その光に 群れる 仲間と 敵に 立ち向かうのだ。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ぎょぐん" },
+			effect: {
+				ja: "自分の番に1回使える。自分の手札にある「ヨワシGX」を1枚、このカードと入れ替える（ついているカード・ダメカン・特殊状態・効果などは、すべて引きつぐ）。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ねらいうち" },
+			cost: ["Water"],
+			effect: {
+				ja: "相手のポケモン1匹に、10ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561417,
+			},
+		},
+	],
+
+	retreat: 0,
+	rarity: "Common",
+	dexId: [746],
+};
+
+export default card;

--- a/data-asia/SM/SM2L/014.ts
+++ b/data-asia/SM/SM2L/014.ts
@@ -1,0 +1,60 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM2L";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヨワシGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 210,
+	types: ["Water"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "みずでっぽう" },
+			damage: 20,
+			cost: ["Water"],
+		},
+		{
+			name: { ja: "ばくりゅうのうず" },
+			damage: 120,
+			cost: ["Water", "Water", "Water", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンについている特殊エネルギーを、1個トラッシュする。",
+			},
+		},
+		{
+			name: { ja: "ブルーサージGX" },
+			damage: 220,
+			cost: ["Water", "Water", "Water", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンについているエネルギーをすべて、ベンチポケモンに好きなようにつけ替える。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 561418,
+			},
+		},
+	],
+
+	retreat: 3,
+	rarity: "Double rare",
+	dexId: [746],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM2L/015.ts
+++ b/data-asia/SM/SM2L/015.ts
@@ -1,0 +1,53 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM2L";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アローライシツブテ",
+	},
+
+	illustrator: "Hitoshi Ariga",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Lightning"],
+
+	description: {
+		ja: "磁力を 帯びた 石の身体。 特に 磁力が 強い 部分には 砂鉄が ビッシリ ついてるよ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ロックカット" },
+			cost: [],
+			effect: {
+				ja: "次の自分の番、このポケモンのにげるためのエネルギーは、すべてなくなる。",
+			},
+		},
+		{
+			name: { ja: "ころがる" },
+			damage: 40,
+			cost: ["Lightning", "Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Metal", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561419,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Common",
+	dexId: [74],
+};
+
+export default card;

--- a/data-asia/SM/SM2L/016.ts
+++ b/data-asia/SM/SM2L/016.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM2L";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アローラゴローン",
+	},
+
+	illustrator: "match",
+	category: "Pokemon",
+	hp: 110,
+	types: ["Lightning"],
+
+	description: {
+		ja: "ドラバイトを 好んで 喰らう。 喰った 成分が 結晶になり 身体の一部に 浮きだしているぞ。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "かみなりパンチ" },
+			damage: "50+",
+			cost: ["Lightning", "Colorless", "Colorless"],
+			effect: {
+				ja: "コインを1回投げオモテなら、20ダメージ追加。ウラなら、このポケモンにも20ダメージ。",
+			},
+		},
+		{
+			name: { ja: "エレキバレット" },
+			damage: 80,
+			cost: ["Lightning", "Lightning", "Lightning", "Colorless"],
+			effect: {
+				ja: "相手のベンチポケモン1匹にも、20ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Metal", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561420,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "アローライシツブテ",
+	},
+
+	retreat: 4,
+	rarity: "Common",
+	dexId: [75],
+};
+
+export default card;

--- a/data-asia/SM/SM2L/017.ts
+++ b/data-asia/SM/SM2L/017.ts
@@ -1,0 +1,60 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM2L";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アローラゴローニャ",
+	},
+
+	illustrator: "Shin Nagasawa",
+	category: "Pokemon",
+	hp: 160,
+	types: ["Lightning"],
+
+	description: {
+		ja: "電気を帯びた 岩石を 発射。 命中 せずとも かするだけで 相手は 痺れ 失神する。",
+	},
+
+	stage: "Stage2",
+
+	attacks: [
+		{
+			name: { ja: "でんじがんせきほう" },
+			damage: "80×",
+			cost: ["Lightning", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンについている[雷]エネルギーの数ぶんコインを投げ、オモテの数x80ダメージ。",
+			},
+		},
+		{
+			name: { ja: "ヘビーボンバー 200-" },
+			cost: ["Lightning", "Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンのにげるためのエネルギーの数x30ダメージぶん、このワザのダメージは小さくなる。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Metal", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 561421,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "アローラゴローン",
+	},
+
+	retreat: 4,
+	rarity: "Rare",
+	dexId: [76],
+};
+
+export default card;

--- a/data-asia/SM/SM2L/018.ts
+++ b/data-asia/SM/SM2L/018.ts
@@ -1,0 +1,53 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM2L";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヤブクロン",
+	},
+
+	illustrator: "Yuka Morii",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Psychic"],
+
+	description: {
+		ja: "不衛生な 場所が 好き。 アローラでは よく ベトベターに 追いまわされる 姿を みかける。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ふみならす" },
+			cost: ["Psychic"],
+			effect: {
+				ja: "相手の山札を上から1枚トラッシュする。",
+			},
+		},
+		{
+			name: { ja: "よだれ" },
+			damage: 30,
+			cost: ["Psychic", "Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561422,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Common",
+	dexId: [568],
+};
+
+export default card;

--- a/data-asia/SM/SM2L/019.ts
+++ b/data-asia/SM/SM2L/019.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM2L";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ダストダス",
+	},
+
+	illustrator: "Mitsuhiro Arita",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Psychic"],
+
+	description: {
+		ja: "右腕から 飛びだす 毒液に 注意。 ちょっと かかるだけで 未知の 毒素に 冒される。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "ゴミなだれ" },
+			damage: "20×",
+			cost: ["Psychic"],
+			effect: {
+				ja: "相手のトラッシュにあるグッズの枚数x20ダメージ。",
+			},
+		},
+		{
+			name: { ja: "アシッドボム" },
+			damage: 70,
+			cost: ["Psychic", "Colorless", "Colorless"],
+			effect: {
+				ja: "コインを1回投げオモテなら、相手のバトルポケモンについているエネルギーを、1個トラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561423,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ヤブクロン",
+	},
+
+	retreat: 3,
+	rarity: "Uncommon",
+	dexId: [569],
+};
+
+export default card;

--- a/data-asia/SM/SM2L/020.ts
+++ b/data-asia/SM/SM2L/020.ts
@@ -1,0 +1,55 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM2L";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ミミッキュ",
+	},
+
+	illustrator: "Megumi Mizutani",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Psychic"],
+
+	description: {
+		ja: "正体不明。 ボロ布の 中身を みた とある 学者は 恐怖の あまり ショック死した。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "くすねる" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札を2枚引く。",
+			},
+		},
+		{
+			name: { ja: "まねっこ" },
+			cost: ["Psychic", "Colorless"],
+			effect: {
+				ja: "前の相手の番に、相手のポケモンがワザ(GXワザをのぞく)を使っていたなら、そのワザをこのワザとして使う。",
+			},
+		},
+	],
+
+	weaknesses: [],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 561424,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Rare",
+	dexId: [778],
+};
+
+export default card;

--- a/data-asia/SM/SM2L/021.ts
+++ b/data-asia/SM/SM2L/021.ts
@@ -1,0 +1,59 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM2L";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ダダリン",
+	},
+
+	illustrator: "Hasuno",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Psychic"],
+
+	description: {
+		ja: "でかい 錨を ブンブン 振り回し ホエルオーさえ 一撃で ＫＯ。 緑の モズクが 本体だ。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "はがねつかい" },
+			effect: {
+				ja: "このポケモンがいるかぎり、自分の[鋼]ポケモンが使うワザの、相手のバトルポケモンへのダメージは「+10」される。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "アンカーショット" },
+			damage: 70,
+			cost: ["Psychic", "Colorless", "Colorless"],
+			effect: {
+				ja: "次の相手の番、このワザを受けたポケモンは、にげられない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 561425,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Rare",
+	dexId: [781],
+};
+
+export default card;

--- a/data-asia/SM/SM2L/022.ts
+++ b/data-asia/SM/SM2L/022.ts
@@ -1,0 +1,64 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM2L";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "カプ・テテフGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 170,
+	types: ["Psychic"],
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ワンダータッチ" },
+			effect: {
+				ja: "自分の番に、このカードを手札からベンチに出したとき、1回使える。自分の山札にあるサポートを1枚、相手に見せてから、手札に加える。そして山札を切る。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "エナジードライブ" },
+			damage: "20×",
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "おたがいのバトルポケモンについているエネルギーの数x20ダメージ。このワザのダメージは弱点・抵抗力を計算しない。",
+			},
+		},
+		{
+			name: { ja: "カプキュアーGX" },
+			cost: ["Psychic"],
+			effect: {
+				ja: "自分のベンチポケモン2匹のHPを、すべて回復する。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 561426,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Double rare",
+	dexId: [786],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM2L/023.ts
+++ b/data-asia/SM/SM2L/023.ts
@@ -1,0 +1,48 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM2L";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "グライガー",
+	},
+
+	illustrator: "Mina Nakai",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Fighting"],
+
+	description: {
+		ja: "いつもは 崖に 張りついている。 獲物を見つけると 羽を広げ 風に乗り 襲いかかってくる。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ダブルショット" },
+			cost: ["Fighting"],
+			effect: {
+				ja: "相手のベンチポケモン2匹に、それぞれ10ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561427,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [207],
+};
+
+export default card;

--- a/data-asia/SM/SM2L/024.ts
+++ b/data-asia/SM/SM2L/024.ts
@@ -1,0 +1,58 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM2L";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "グライオン",
+	},
+
+	illustrator: "Yoshinobu Saito",
+	category: "Pokemon",
+	hp: 110,
+	types: ["Fighting"],
+
+	description: {
+		ja: "尻尾で 木の枝に ぶら下がり 獲物を 観察する。 すきを 見て 上空から 襲いかかる。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "とどめのはり" },
+			damage: 70,
+			cost: ["Fighting"],
+			effect: {
+				ja: "相手のバトルポケモンにダメカンがのっていないなら、このワザは失敗。",
+			},
+		},
+		{
+			name: { ja: "ハサミギロチン" },
+			damage: 90,
+			cost: ["Fighting", "Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561428,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "グライガー",
+	},
+
+	retreat: 1,
+	rarity: "Uncommon",
+	dexId: [472],
+};
+
+export default card;

--- a/data-asia/SM/SM2L/025.ts
+++ b/data-asia/SM/SM2L/025.ts
@@ -1,0 +1,48 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM2L";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヤンチャム",
+	},
+
+	illustrator: "TOKIYA",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Fighting"],
+
+	description: {
+		ja: "親分の ように 慕っている ゴロンダの 仕草を 真似ながら 一人前に なっていくぞ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "からてチョップ 60-" },
+			cost: ["Fighting", "Fighting"],
+			effect: {
+				ja: "このポケモンにのっているダメカンの数x10ダメージぶん、このワザのダメージは小さくなる。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561429,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Common",
+	dexId: [674],
+};
+
+export default card;

--- a/data-asia/SM/SM2L/026.ts
+++ b/data-asia/SM/SM2L/026.ts
@@ -1,0 +1,56 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM2L";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "イワンコ",
+	},
+
+	illustrator: "Naoki Saito",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Fighting"],
+
+	description: {
+		ja: "よく なつくので 初心者に お勧めのポケモンと いわれるが 育つと 気性は 荒くなる。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "おいつめる" },
+			cost: ["Fighting"],
+			effect: {
+				ja: "次の相手の番、このワザを受けたポケモンは、にげられない。",
+			},
+		},
+		{
+			name: { ja: "けりつける" },
+			damage: 30,
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "コインを1回投げウラなら、このワザは失敗。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561430,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [744],
+};
+
+export default card;

--- a/data-asia/SM/SM2L/027.ts
+++ b/data-asia/SM/SM2L/027.ts
@@ -1,0 +1,66 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM2L";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ルガルガンGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 200,
+	types: ["Fighting"],
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ブラッディアイ" },
+			effect: {
+				ja: "自分の番に、このカードを手札から出して進化させたとき、1回使える。相手のベンチポケモンを1匹選び、バトルポケモンと入れ替える。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ツメできりさく" },
+			damage: 110,
+			cost: ["Fighting", "Colorless", "Colorless"],
+		},
+		{
+			name: { ja: "デスローグGX" },
+			damage: "50×",
+			cost: ["Fighting", "Colorless"],
+			effect: {
+				ja: "相手のベンチポケモンの数x50ダメージ。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 561431,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "イワンコ",
+	},
+
+	retreat: 2,
+	rarity: "Double rare",
+	dexId: [745],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM2L/028.ts
+++ b/data-asia/SM/SM2L/028.ts
@@ -1,0 +1,57 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM2L";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "メテノ",
+	},
+
+	illustrator: "Naoki Saito",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Fighting"],
+
+	description: {
+		ja: "大気中の チリを 喰っている。 喰った チリの 成分に よって コアの 色合いが 決まる。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "スピードスター" },
+			damage: 20,
+			cost: ["Colorless"],
+			effect: {
+				ja: "このワザのダメージは、弱点・抵抗力と、相手のバトルポケモンにかかっている効果を計算しない。",
+			},
+		},
+		{
+			name: { ja: "コスモプロージョン" },
+			damage: 190,
+			cost: ["Fighting", "Fighting", "Fighting"],
+			effect: {
+				ja: "このポケモンをきぜつさせる。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 561432,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Rare",
+	dexId: [774],
+};
+
+export default card;

--- a/data-asia/SM/SM2L/029.ts
+++ b/data-asia/SM/SM2L/029.ts
@@ -1,0 +1,49 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM2L";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヤミカラス",
+	},
+
+	illustrator: "Sekio",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Darkness"],
+
+	description: {
+		ja: "日暮れに 目覚め 夕闇を 飛ぶ。 ヤミカラスが 飛ぶまでに 家に 帰れ という ことわざも あるぞ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ふきとばし" },
+			damage: 10,
+			cost: ["Darkness"],
+			effect: {
+				ja: "相手のバトルポケモンをベンチポケモンと入れ替える。［バトル場に出すポケモンは相手が選ぶ。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561433,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [198],
+};
+
+export default card;

--- a/data-asia/SM/SM2L/030.ts
+++ b/data-asia/SM/SM2L/030.ts
@@ -1,0 +1,60 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM2L";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ドンカラス",
+	},
+
+	illustrator: "Hideki Ishikawa",
+	category: "Pokemon",
+	hp: 110,
+	types: ["Darkness"],
+
+	description: {
+		ja: "夜行性。 一声 鳴けば １００匹を 超える 子分の ヤミカラスが 集結する。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "だましうち" },
+			cost: ["Darkness"],
+			effect: {
+				ja: "相手のポケモン1匹に、30ダメージ。このワザのダメージは、弱点・抵抗力と、ダメージを受けるポケモンにかかっている効果を計算しない。",
+			},
+		},
+		{
+			name: { ja: "レイブンクロー" },
+			damage: "10+",
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "相手の場のポケモンにのっているダメカンの数x10ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561434,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ヤミカラス",
+	},
+
+	retreat: 1,
+	rarity: "Uncommon",
+	dexId: [430],
+};
+
+export default card;

--- a/data-asia/SM/SM2L/031.ts
+++ b/data-asia/SM/SM2L/031.ts
@@ -1,0 +1,53 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM2L";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヤミラミ",
+	},
+
+	illustrator: "Aya Kusube",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Darkness"],
+
+	description: {
+		ja: "宝石が 好物で メレシーを 狙って 付け回しているが ガバイトに 横取り されてしまう。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "そくばく" },
+			cost: ["Darkness"],
+			effect: {
+				ja: "次の相手の番、相手は手札からサポートを出して使えない。",
+			},
+		},
+		{
+			name: { ja: "ひっかく" },
+			damage: 20,
+			cost: ["Colorless"],
+		},
+	],
+
+	weaknesses: [],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561435,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Uncommon",
+	dexId: [302],
+};
+
+export default card;

--- a/data-asia/SM/SM2L/032.ts
+++ b/data-asia/SM/SM2L/032.ts
@@ -1,0 +1,58 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM2L";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ゴロンダ",
+	},
+
+	illustrator: "kodama",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Darkness"],
+
+	description: {
+		ja: "腕っぷしが 自慢で 豪快。 ゴロンダの トレーナーに なりたいなら 拳で 語り合う しかない。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "スカイアッパー" },
+			damage: 70,
+			cost: ["Darkness", "Colorless", "Colorless"],
+			effect: {
+				ja: "このワザのダメージは抵抗力を計算しない。",
+			},
+		},
+		{
+			name: { ja: "マグナムパンチ" },
+			damage: 130,
+			cost: ["Darkness", "Colorless", "Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561436,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ヤンチャム",
+	},
+
+	retreat: 3,
+	rarity: "Uncommon",
+	dexId: [675],
+};
+
+export default card;

--- a/data-asia/SM/SM2L/033.ts
+++ b/data-asia/SM/SM2L/033.ts
@@ -1,0 +1,49 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM2L";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ダンバル",
+	},
+
+	illustrator: "Kyoko Umemoto",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Metal"],
+
+	description: {
+		ja: "細胞 すべてが 磁石。 磁力を 使って 仲間と コミュニケーションを 取る。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "コアビーム" },
+			damage: 20,
+			cost: ["Metal"],
+			effect: {
+				ja: "このポケモンについている[鋼]エネルギーを、1個トラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561437,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [374],
+};
+
+export default card;

--- a/data-asia/SM/SM2L/034.ts
+++ b/data-asia/SM/SM2L/034.ts
@@ -1,0 +1,58 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM2L";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "メタング",
+	},
+
+	illustrator: "Kagemaru Himeno",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Metal"],
+
+	description: {
+		ja: "２匹の ダンバルが 連結し サイコパワーは ２倍に。 ただし 賢さ自体は 変わっていない。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "ぶつかる" },
+			damage: 20,
+			cost: ["Colorless"],
+		},
+		{
+			name: { ja: "コアビーム" },
+			damage: 80,
+			cost: ["Metal", "Metal", "Colorless"],
+			effect: {
+				ja: "このポケモンについている[鋼]エネルギーを、1個トラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561438,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ダンバル",
+	},
+
+	retreat: 3,
+	rarity: "Common",
+	dexId: [375],
+};
+
+export default card;

--- a/data-asia/SM/SM2L/035.ts
+++ b/data-asia/SM/SM2L/035.ts
@@ -1,0 +1,68 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM2L";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "メタグロスGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 250,
+	types: ["Metal"],
+
+	stage: "Stage2",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ジオテックシステム" },
+			effect: {
+				ja: "自分の番に1回使える。自分のトラッシュにある[超]または[鋼]エネルギーを1枚、バトルポケモンにつける。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ギガハンマー" },
+			damage: 150,
+			cost: ["Metal", "Metal", "Colorless"],
+			effect: {
+				ja: "次の自分の番、このポケモンは「ギガハンマー」が使えない。",
+			},
+		},
+		{
+			name: { ja: "アルゴリズムGX" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札にある好きなカードを5枚まで、手札に加える。そして山札を切る。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 561439,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "メタング",
+	},
+
+	retreat: 3,
+	rarity: "Double rare",
+	dexId: [376],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM2L/036.ts
+++ b/data-asia/SM/SM2L/036.ts
@@ -1,0 +1,49 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM2L";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "モンメン",
+	},
+
+	illustrator: "Megumi Mizutani",
+	category: "Pokemon",
+	hp: 50,
+	types: ["Fairy"],
+
+	description: {
+		ja: "仲間を みつけると くっつく。 あまりに たくさん くっつきすぎて 入道雲 みたいになることも。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "れんぞくころがり" },
+			damage: "10×",
+			cost: ["Colorless"],
+			effect: {
+				ja: "ウラが出るまでコインを投げ、オモテの数x10ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [{ type: "Darkness", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561440,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [546],
+};
+
+export default card;

--- a/data-asia/SM/SM2L/037.ts
+++ b/data-asia/SM/SM2L/037.ts
@@ -1,0 +1,57 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM2L";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "エルフーン",
+	},
+
+	illustrator: "Kouki Saitou",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Fairy"],
+
+	description: {
+		ja: "風に 乗り 民家に 侵入。 部屋中を 綿まみれに すると ニコニコ 笑って 去っていく。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "よけいなわたげ" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "次の自分の番、このワザを受けたポケモンがきぜつしたとき、サイドを2枚多くとる。",
+			},
+		},
+		{
+			name: { ja: "ようせいのかぜ" },
+			damage: 30,
+			cost: ["Fairy"],
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [{ type: "Darkness", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561441,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "モンメン",
+	},
+
+	retreat: 0,
+	rarity: "Uncommon",
+	dexId: [547],
+};
+
+export default card;

--- a/data-asia/SM/SM2L/038.ts
+++ b/data-asia/SM/SM2L/038.ts
@@ -1,0 +1,53 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM2L";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヌメラ",
+	},
+
+	illustrator: "Asako Ito",
+	category: "Pokemon",
+	hp: 50,
+	types: ["Dragon"],
+
+	description: {
+		ja: "最も 弱い ドラゴンポケモン。 皮膚が 乾くと 息が できないので 日陰で じーっと しているよ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "あわ" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "コインを1回投げオモテなら、相手のバトルポケモンをマヒにする。",
+			},
+		},
+		{
+			name: { ja: "たいあたり" },
+			damage: 20,
+			cost: ["Water", "Fairy"],
+		},
+	],
+
+	weaknesses: [{ type: "Fairy", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561442,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [704],
+};
+
+export default card;

--- a/data-asia/SM/SM2L/039.ts
+++ b/data-asia/SM/SM2L/039.ts
@@ -1,0 +1,57 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM2L";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヌメイル",
+	},
+
+	illustrator: "Tomokazu Komiya",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Dragon"],
+
+	description: {
+		ja: "餌と 仲間の 区別が 曖昧。 仲良くなっても 平気で 溶かして 喰らおうと してくることが ある。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "ぶんれつ" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札にある「ヌメイル」を2枚まで、ベンチに出す。そして山札を切る。",
+			},
+		},
+		{
+			name: { ja: "たいあたり" },
+			damage: 20,
+			cost: ["Water", "Fairy"],
+		},
+	],
+
+	weaknesses: [{ type: "Fairy", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561443,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ヌメラ",
+	},
+
+	retreat: 3,
+	rarity: "Common",
+	dexId: [705],
+};
+
+export default card;

--- a/data-asia/SM/SM2L/040.ts
+++ b/data-asia/SM/SM2L/040.ts
@@ -1,0 +1,60 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM2L";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヌメルゴン",
+	},
+
+	illustrator: "Naoki Saito",
+	category: "Pokemon",
+	hp: 160,
+	types: ["Dragon"],
+
+	description: {
+		ja: "すごく 人懐っこい ポケモン。 構わないでいると 寂しくて ヌルヌルの 涙を 流し 鳴く。",
+	},
+
+	stage: "Stage2",
+
+	attacks: [
+		{
+			name: { ja: "パワーウィップ" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "相手のポケモン1匹に、このポケモンについているエネルギーの数x20ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+			},
+		},
+		{
+			name: { ja: "ビートスライダー" },
+			damage: 130,
+			cost: ["Water", "Fairy", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをベンチポケモンと入れ替える。［バトル場に出すポケモンは相手が選ぶ。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fairy", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 561444,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ヌメイル",
+	},
+
+	retreat: 3,
+	rarity: "Rare",
+	dexId: [706],
+};
+
+export default card;

--- a/data-asia/SM/SM2L/041.ts
+++ b/data-asia/SM/SM2L/041.ts
@@ -1,0 +1,56 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM2L";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ポワルン",
+	},
+
+	illustrator: "sui",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Colorless"],
+
+	description: {
+		ja: "天気に よって 姿を 変える。 気温や 湿度の 変化が 細胞に 影響 するらしい。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "おてんきうらない" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札にあるスタジアムを2枚まで、相手に見せてから、手札に加える。そして山札を切る。",
+			},
+		},
+		{
+			name: { ja: "みずのはどう" },
+			damage: 30,
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをねむりにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561445,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [351],
+};
+
+export default card;

--- a/data-asia/SM/SM2L/042.ts
+++ b/data-asia/SM/SM2L/042.ts
@@ -1,0 +1,53 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM2L";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ミネズミ",
+	},
+
+	illustrator: "Ayaka Yoshida",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Colorless"],
+
+	description: {
+		ja: "ほほの 袋に エサを ためこみ 何日も 見張りを 続ける。 尻尾で 仲間に 合図する。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ちらみ" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "相手の山札を上から1枚見て、もとにもどす。",
+			},
+		},
+		{
+			name: { ja: "たいあたり" },
+			damage: 20,
+			cost: ["Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561446,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [504],
+};
+
+export default card;

--- a/data-asia/SM/SM2L/043.ts
+++ b/data-asia/SM/SM2L/043.ts
@@ -1,0 +1,60 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM2L";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ミルホッグ",
+	},
+
+	illustrator: "Kagemaru Himeno",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Colorless"],
+
+	description: {
+		ja: "体内の 発光物質で 目玉や 体を 光らせ 襲ってきた 敵を ひるませる。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "しなさだめ" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "相手の山札を上から2枚見て、どちらか1枚をトラッシュし、残りのカードは山札の上にもどす。",
+			},
+		},
+		{
+			name: { ja: "たたきつける" },
+			damage: "60×",
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "コインを2回投げ、オモテの数x60ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561447,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ミネズミ",
+	},
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [505],
+};
+
+export default card;

--- a/data-asia/SM/SM2L/044.ts
+++ b/data-asia/SM/SM2L/044.ts
@@ -1,0 +1,53 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM2L";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヤヤコマ",
+	},
+
+	illustrator: "You Iribi",
+	category: "Pokemon",
+	hp: 50,
+	types: ["Colorless"],
+
+	description: {
+		ja: "人懐っこいので 扱いやすい ポケモンだが 一度 戦いに なると とても 荒々しいぞ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "なきごえ" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "次の相手の番、このワザを受けたポケモンが使うワザのダメージは「-20」される。",
+			},
+		},
+		{
+			name: { ja: "はばたく" },
+			damage: 20,
+			cost: ["Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561448,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [661],
+};
+
+export default card;

--- a/data-asia/SM/SM2L/045.ts
+++ b/data-asia/SM/SM2L/045.ts
@@ -1,0 +1,58 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM2L";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヒノヤコマ",
+	},
+
+	illustrator: "kawayoo",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Colorless"],
+
+	description: {
+		ja: "クチバシから 火の粉を 飛ばして 獲物に ぶつける。 捕まえた 獲物は 焼いてから いただくぞ。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "はばたく" },
+			damage: 20,
+			cost: ["Colorless"],
+		},
+		{
+			name: { ja: "かまいたち" },
+			damage: 40,
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "コインを1回投げウラなら、このワザは失敗。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561449,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ヤヤコマ",
+	},
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [662],
+};
+
+export default card;

--- a/data-asia/SM/SM2L/046.ts
+++ b/data-asia/SM/SM2L/046.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM2L";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ファイアロー",
+	},
+
+	illustrator: "Shin Nagasawa",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Colorless"],
+
+	description: {
+		ja: "好物は キャモメや ツツケラ。 強烈な キックを お見舞いし 鋭いツメで がっちり キャッチ。",
+	},
+
+	stage: "Stage2",
+
+	attacks: [
+		{
+			name: { ja: "ニトロチャージ" },
+			damage: 30,
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札にある[炎]エネルギーを1枚、このポケモンにつける。そして山札を切る。",
+			},
+		},
+		{
+			name: { ja: "エアロループ" },
+			damage: 90,
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンについているエネルギーを、すべて手札にもどす。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561450,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ヒノヤコマ",
+	},
+
+	retreat: 0,
+	rarity: "Uncommon",
+	dexId: [663],
+};
+
+export default card;

--- a/data-asia/SM/SM2L/047.ts
+++ b/data-asia/SM/SM2L/047.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM2L";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アクアパッチ",
+	},
+
+	illustrator: "Toyste Beach",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分のトラッシュにある[水]エネルギーを1枚、ベンチの[水]ポケモンにつける。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561451,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM2L/048.ts
+++ b/data-asia/SM/SM2L/048.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM2L";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "レスキュータンカ",
+	},
+
+	illustrator: "Yoshinobu Saito",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分のトラッシュにあるポケモンを1枚、相手に見せてから、手札に加える。または、自分のトラッシュにあるポケモンを3枚、相手に見せてから、山札にもどして切る。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561452,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM2L/049.ts
+++ b/data-asia/SM/SM2L/049.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM2L";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "マオ",
+	},
+
+	illustrator: "Ken Sugimori",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の山札から好きなカードを2枚選ぶ。残りの山札を切り、選んだカードを好きな順番にして、山札の上にもどす。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561453,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM2L/050.ts
+++ b/data-asia/SM/SM2L/050.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM2L";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "せせらぎの丘",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Trainer",
+
+	effect: {
+		ja: "おたがいのプレイヤーは、自分の番ごとに1回、自分の山札にある[水]または[闘]タイプのたねポケモンを1枚、ベンチに出してよい。その場合、山札を切る。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561454,
+			},
+		},
+	],
+
+	trainerType: "Stadium",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM2L/051.ts
+++ b/data-asia/SM/SM2L/051.ts
@@ -1,0 +1,60 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM2L";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヨワシGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 210,
+	types: ["Water"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "みずでっぽう" },
+			damage: 20,
+			cost: ["Water"],
+		},
+		{
+			name: { ja: "ばくりゅうのうず" },
+			damage: 120,
+			cost: ["Water", "Water", "Water", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンについている特殊エネルギーを、1個トラッシュする。",
+			},
+		},
+		{
+			name: { ja: "ブルーサージGX" },
+			damage: 220,
+			cost: ["Water", "Water", "Water", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンについているエネルギーをすべて、ベンチポケモンに好きなようにつけ替える。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 561455,
+			},
+		},
+	],
+
+	retreat: 3,
+	rarity: "Ultra Rare",
+	dexId: [746],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM2L/052.ts
+++ b/data-asia/SM/SM2L/052.ts
@@ -1,0 +1,64 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM2L";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "カプ・テテフGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 170,
+	types: ["Psychic"],
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ワンダータッチ" },
+			effect: {
+				ja: "自分の番に、このカードを手札からベンチに出したとき、1回使える。自分の山札にあるサポートを1枚、相手に見せてから、手札に加える。そして山札を切る。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "エナジードライブ" },
+			damage: "20×",
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "おたがいのバトルポケモンについているエネルギーの数x20ダメージ。このワザのダメージは弱点・抵抗力を計算しない。",
+			},
+		},
+		{
+			name: { ja: "カプキュアーGX" },
+			cost: ["Psychic"],
+			effect: {
+				ja: "自分のベンチポケモン2匹のHPを、すべて回復する。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 561456,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Ultra Rare",
+	dexId: [786],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM2L/053.ts
+++ b/data-asia/SM/SM2L/053.ts
@@ -1,0 +1,66 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM2L";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ルガルガンGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 200,
+	types: ["Fighting"],
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ブラッディアイ" },
+			effect: {
+				ja: "自分の番に、このカードを手札から出して進化させたとき、1回使える。相手のベンチポケモンを1匹選び、バトルポケモンと入れ替える。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ツメできりさく" },
+			damage: 110,
+			cost: ["Fighting", "Colorless", "Colorless"],
+		},
+		{
+			name: { ja: "デスローグGX" },
+			damage: "50×",
+			cost: ["Fighting", "Colorless"],
+			effect: {
+				ja: "相手のベンチポケモンの数x50ダメージ。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 561457,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "イワンコ",
+	},
+
+	retreat: 2,
+	rarity: "Ultra Rare",
+	dexId: [745],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM2L/054.ts
+++ b/data-asia/SM/SM2L/054.ts
@@ -1,0 +1,68 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM2L";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "メタグロスGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 250,
+	types: ["Metal"],
+
+	stage: "Stage2",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ジオテックシステム" },
+			effect: {
+				ja: "自分の番に1回使える。自分のトラッシュにある[超]または[鋼]エネルギーを1枚、バトルポケモンにつける。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ギガハンマー" },
+			damage: 150,
+			cost: ["Metal", "Metal", "Colorless"],
+			effect: {
+				ja: "次の自分の番、このポケモンは「ギガハンマー」が使えない。",
+			},
+		},
+		{
+			name: { ja: "アルゴリズムGX" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札にある好きなカードを5枚まで、手札に加える。そして山札を切る。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 561458,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "メタング",
+	},
+
+	retreat: 3,
+	rarity: "Ultra Rare",
+	dexId: [376],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM2L/055.ts
+++ b/data-asia/SM/SM2L/055.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM2L";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "マオ",
+	},
+
+	illustrator: "Megumi Mizutani",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の山札から好きなカードを2枚選ぶ。残りの山札を切り、選んだカードを好きな順番にして、山札の上にもどす。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 561459,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	rarity: "Ultra Rare",
+};
+
+export default card;

--- a/data-asia/SM/SM2L/056.ts
+++ b/data-asia/SM/SM2L/056.ts
@@ -1,0 +1,60 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM2L";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヨワシGX",
+	},
+
+	illustrator: "",
+	category: "Pokemon",
+	hp: 210,
+	types: ["Water"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "みずでっぽう" },
+			damage: 20,
+			cost: ["Water"],
+		},
+		{
+			name: { ja: "ばくりゅうのうず" },
+			damage: 120,
+			cost: ["Water", "Water", "Water", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンについている特殊エネルギーを、1個トラッシュする。",
+			},
+		},
+		{
+			name: { ja: "ブルーサージGX" },
+			damage: 220,
+			cost: ["Water", "Water", "Water", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンについているエネルギーをすべて、ベンチポケモンに好きなようにつけ替える。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 561460,
+			},
+		},
+	],
+
+	retreat: 3,
+	rarity: "Hyper rare",
+	dexId: [746],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM2L/057.ts
+++ b/data-asia/SM/SM2L/057.ts
@@ -1,0 +1,64 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM2L";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "カプ・テテフGX",
+	},
+
+	illustrator: "",
+	category: "Pokemon",
+	hp: 170,
+	types: ["Psychic"],
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ワンダータッチ" },
+			effect: {
+				ja: "自分の番に、このカードを手札からベンチに出したとき、1回使える。自分の山札にあるサポートを1枚、相手に見せてから、手札に加える。そして山札を切る。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "エナジードライブ" },
+			damage: "20×",
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "おたがいのバトルポケモンについているエネルギーの数x20ダメージ。このワザのダメージは弱点・抵抗力を計算しない。",
+			},
+		},
+		{
+			name: { ja: "カプキュアーGX" },
+			cost: ["Psychic"],
+			effect: {
+				ja: "自分のベンチポケモン2匹のHPを、すべて回復する。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 561461,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Hyper rare",
+	dexId: [786],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM2L/058.ts
+++ b/data-asia/SM/SM2L/058.ts
@@ -1,0 +1,66 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM2L";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ルガルガンGX",
+	},
+
+	illustrator: "",
+	category: "Pokemon",
+	hp: 200,
+	types: ["Fighting"],
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ブラッディアイ" },
+			effect: {
+				ja: "自分の番に、このカードを手札から出して進化させたとき、1回使える。相手のベンチポケモンを1匹選び、バトルポケモンと入れ替える。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ツメできりさく" },
+			damage: 110,
+			cost: ["Fighting", "Colorless", "Colorless"],
+		},
+		{
+			name: { ja: "デスローグGX" },
+			damage: "50×",
+			cost: ["Fighting", "Colorless"],
+			effect: {
+				ja: "相手のベンチポケモンの数x50ダメージ。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 561462,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "イワンコ",
+	},
+
+	retreat: 2,
+	rarity: "Hyper rare",
+	dexId: [745],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM2L/059.ts
+++ b/data-asia/SM/SM2L/059.ts
@@ -1,0 +1,68 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM2L";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "メタグロスGX",
+	},
+
+	illustrator: "",
+	category: "Pokemon",
+	hp: 250,
+	types: ["Metal"],
+
+	stage: "Stage2",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ジオテックシステム" },
+			effect: {
+				ja: "自分の番に1回使える。自分のトラッシュにある[超]または[鋼]エネルギーを1枚、バトルポケモンにつける。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ギガハンマー" },
+			damage: 150,
+			cost: ["Metal", "Metal", "Colorless"],
+			effect: {
+				ja: "次の自分の番、このポケモンは「ギガハンマー」が使えない。",
+			},
+		},
+		{
+			name: { ja: "アルゴリズムGX" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札にある好きなカードを5枚まで、手札に加える。そして山札を切る。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 561463,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "メタング",
+	},
+
+	retreat: 3,
+	rarity: "Hyper rare",
+	dexId: [376],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM2L/060.ts
+++ b/data-asia/SM/SM2L/060.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM2L";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アクアパッチ",
+	},
+
+	illustrator: "",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分のトラッシュにある[水]エネルギーを1枚、ベンチの[水]ポケモンにつける。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 561464,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	rarity: "Secret Rare",
+};
+
+export default card;

--- a/data-asia/SM/SM2L/061.ts
+++ b/data-asia/SM/SM2L/061.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM2L";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "改造ハンマー",
+	},
+
+	illustrator: "",
+	category: "Trainer",
+
+	effect: {
+		ja: "相手のポケモンについている特殊エネルギーを1個選び、トラッシュする。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 561465,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	rarity: "Secret Rare",
+};
+
+export default card;

--- a/data-asia/SM/SM2L/062.ts
+++ b/data-asia/SM/SM2L/062.ts
@@ -1,0 +1,26 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM2L";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "基本闘エネルギー",
+	},
+
+	illustrator: "",
+	category: "Energy",
+	energyType: "Normal",
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 561466,
+			},
+		},
+	],
+
+	rarity: "Secret Rare",
+};
+
+export default card;


### PR DESCRIPTION
## What

Adds the complete Japanese set **SM2L アローラの月光 (Alolan Moonlight)**, released 2017-03-17:

- `data-asia/SM/SM2L/001.ts` … `062.ts` — all 62 cards (50 regular + 12 secret rares: 5 SR, 3 Secret Rare, 4 UR)
- the set definition `data-asia/SM/SM2L.ts` already existed and is untouched

## Data sources

- **pokemon-card.com** (official database): Japanese names, flavor texts, National Dex numbers, official card count
- **limitlesstcg.com**: full Japanese card text, stages, weaknesses/resistances/retreat, rarities, illustrators, attack costs
- **Cardmarket**: product IDs as `thirdParty.cardmarket` on the variant objects (561405–561466; tcgplayer IDs not available to me)

## Notes

- Follows the file format and conventions of the M-era sets (#1728)
- No `regulationMark` (the set predates regulation marks); resistances are `-20` per the era
- All 62 files type-check against `interfaces.d.ts` (`tsc --noEmit`)
