### PR TITLE
(data) Add Japanese SM set SM2p Let's Face New Trials

### DIFF
--- a/data-asia/SM/SM2p.ts
+++ b/data-asia/SM/SM2p.ts
@@ -1,0 +1,20 @@
+import { Set } from "../../interfaces";
+import serie from "../SM";
+
+const set: Set = {
+	id: "SM2p",
+	name: {
+		ja: "新たなる試練の向こう",
+	},
+
+	serie: serie,
+
+	cardCount: {
+		official: 49,
+	},
+	releaseDate: {
+		ja: "2017-04-21",
+	},
+};
+
+export default set;

--- a/data-asia/SM/SM2p/001.ts
+++ b/data-asia/SM/SM2p/001.ts
@@ -1,0 +1,46 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM2p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "マダツボミ",
+	},
+
+	illustrator: "Aya Kusube",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Grass"],
+
+	description: {
+		ja: "ひょろっとした 体つきだが 獲物を 捕らえるときの 動きは 目にも とまらないほど 素早い。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "つるのムチ" },
+			damage: 30,
+			cost: ["Grass", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561204,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "None",
+	dexId: [69],
+};
+
+export default card;

--- a/data-asia/SM/SM2p/002.ts
+++ b/data-asia/SM/SM2p/002.ts
@@ -1,0 +1,53 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM2p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ウツドン",
+	},
+
+	illustrator: "Mina Nakai",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Grass"],
+
+	description: {
+		ja: "葉っぱの 部分は カッターになって 相手を 切り裂く。 口からは なんでも 溶かす 液体を 吐く。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "どろろえき" },
+			damage: 40,
+			cost: ["Grass", "Colorless"],
+			effect: {
+				ja: "コインを1回投げオモテなら、相手のバトルポケモンについているエネルギーを、1個トラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561205,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "マダツボミ",
+	},
+
+	retreat: 2,
+	rarity: "None",
+	dexId: [70],
+};
+
+export default card;

--- a/data-asia/SM/SM2p/003.ts
+++ b/data-asia/SM/SM2p/003.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM2p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ウツボット",
+	},
+
+	illustrator: "TOKIYA",
+	category: "Pokemon",
+	hp: 140,
+	types: ["Grass"],
+
+	description: {
+		ja: "ジャングルの 奥地に ウツボット ばかり いる 地帯が あって 行ったら ２度と 帰ってこれない。",
+	},
+
+	stage: "Stage2",
+
+	attacks: [
+		{
+			name: { ja: "きけんなかふん" },
+			damage: 20,
+			cost: ["Grass"],
+			effect: {
+				ja: "相手のバトルポケモンをどくとやけどとこんらんにする。",
+			},
+		},
+		{
+			name: { ja: "からめてすいとる" },
+			damage: 80,
+			cost: ["Grass", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンのHPを「20」回復する。次の相手の番、このワザを受けたポケモンは、にげられない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561206,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ウツドン",
+	},
+
+	retreat: 2,
+	rarity: "None",
+	dexId: [71],
+};
+
+export default card;

--- a/data-asia/SM/SM2p/004.ts
+++ b/data-asia/SM/SM2p/004.ts
@@ -1,0 +1,49 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM2p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "レディバ",
+	},
+
+	illustrator: "Ayaka Yoshida",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Grass"],
+
+	description: {
+		ja: "臆病で 常に 群れていないと 不安。 背中の模様は １匹 １匹 微妙に 違う 形。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "こうそくいどう" },
+			damage: 10,
+			cost: ["Grass"],
+			effect: {
+				ja: "コインを1回投げオモテなら、次の相手の番、このポケモンはワザのダメージや効果を受けない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561207,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "None",
+	dexId: [165],
+};
+
+export default card;

--- a/data-asia/SM/SM2p/005.ts
+++ b/data-asia/SM/SM2p/005.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM2p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "レディアン",
+	},
+
+	illustrator: "Atsuko Nishida",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Grass"],
+
+	description: {
+		ja: "星明りが エネルギーと いわれるが 普通に 木の実も 大好物。 昼間は 草に 包まって 寝てる。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "スピードスター" },
+			damage: 30,
+			cost: ["Grass"],
+			effect: {
+				ja: "このワザのダメージは、弱点・抵抗力と、相手のバトルポケモンにかかっている効果を計算しない。",
+			},
+		},
+		{
+			name: { ja: "れんぞくパンチ" },
+			damage: "40×",
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "コインを4回投げ、オモテの数x40ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561208,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "レディバ",
+	},
+
+	retreat: 1,
+	rarity: "None",
+	dexId: [166],
+};
+
+export default card;

--- a/data-asia/SM/SM2p/006.ts
+++ b/data-asia/SM/SM2p/006.ts
@@ -1,0 +1,57 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM2p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "カプ・ブルル",
+	},
+
+	illustrator: "Megumi Mizutani",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Grass"],
+
+	description: {
+		ja: "大木を 引き抜き ブンブン 振り回す。 草木を 茂らせて そのエネルギーを 吸収する。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ウッドホーン" },
+			damage: 30,
+			cost: ["Grass", "Colorless"],
+			effect: {
+				ja: "このポケモンのHPを「30」回復する。",
+			},
+		},
+		{
+			name: { ja: "カームストライク" },
+			damage: "60+",
+			cost: ["Grass", "Colorless", "Colorless"],
+			effect: {
+				ja: "自分がすでにGXワザを使っていたなら、60ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561209,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "None",
+	dexId: [787],
+};
+
+export default card;

--- a/data-asia/SM/SM2p/007.ts
+++ b/data-asia/SM/SM2p/007.ts
@@ -1,0 +1,60 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM2p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "カプ・ブルルGX",
+	},
+
+	illustrator: "PLANETA",
+	category: "Pokemon",
+	hp: 180,
+	types: ["Grass"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "つのでつく" },
+			damage: 30,
+			cost: ["Grass"],
+		},
+		{
+			name: { ja: "しぜんのさばき" },
+			damage: "120+",
+			cost: ["Grass", "Grass", "Colorless"],
+			effect: {
+				ja: "のぞむなら、このポケモンについているエネルギーを、すべてトラッシュする。その場合、60ダメージ追加。",
+			},
+		},
+		{
+			name: { ja: "カプワイルドGX" },
+			damage: 150,
+			cost: ["Grass", "Grass", "Colorless"],
+			effect: {
+				ja: "このポケモンのHPを、すべて回復する。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 561210,
+			},
+		},
+	],
+
+	retreat: 3,
+	rarity: "Double rare",
+	dexId: [787],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM2p/008.ts
+++ b/data-asia/SM/SM2p/008.ts
@@ -1,0 +1,54 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM2p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヤトウモリ",
+	},
+
+	illustrator: "TOKIYA",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Fire"],
+
+	description: {
+		ja: "体液を 燃やし 毒ガスを たく。 ガスを 吸った 敵が フラフラに なったあと 襲いかかるのだ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ひっかく" },
+			damage: 10,
+			cost: ["Fire"],
+		},
+		{
+			name: { ja: "ベノムショック" },
+			damage: "20+",
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンがどくなら、40ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561211,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "None",
+	dexId: [757],
+};
+
+export default card;

--- a/data-asia/SM/SM2p/009.ts
+++ b/data-asia/SM/SM2p/009.ts
@@ -1,0 +1,63 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM2p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "エンニュート",
+	},
+
+	illustrator: "Mitsuhiro Arita",
+	category: "Pokemon",
+	hp: 110,
+	types: ["Fire"],
+
+	description: {
+		ja: "なぜか ♀しか 見つかっていない。 ヤトウモリの♂を 引き連れて 逆ハーレムを 作って 暮らす。",
+	},
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ホットポイズン" },
+			effect: {
+				ja: "自分の番に、このカードを手札から出して進化させたとき、1回使える。相手のバトルポケモンをどくとやけどにする。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "かえんほうしゃ" },
+			damage: 90,
+			cost: ["Fire", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンについているエネルギーを、1個トラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561212,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ヤトウモリ",
+	},
+
+	retreat: 1,
+	rarity: "None",
+	dexId: [758],
+};
+
+export default card;

--- a/data-asia/SM/SM2p/010.ts
+++ b/data-asia/SM/SM2p/010.ts
@@ -1,0 +1,63 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM2p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "エンニュートGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 200,
+	types: ["Fire"],
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "ましょうのツメ" },
+			damage: "50×",
+			cost: ["Fire", "Fire"],
+			effect: {
+				ja: "自分がすでにとったサイドの枚数x50ダメージ。",
+			},
+		},
+		{
+			name: { ja: "ヒートブラスト" },
+			damage: 110,
+			cost: ["Fire", "Fire"],
+		},
+		{
+			name: { ja: "クインヘイズGX" },
+			cost: ["Fire", "Fire"],
+			effect: {
+				ja: "相手のバトルポケモンについているエネルギーを、すべてトラッシュする。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 561213,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ヤトウモリ",
+	},
+
+	retreat: 2,
+	rarity: "Double rare",
+	dexId: [758],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM2p/011.ts
+++ b/data-asia/SM/SM2p/011.ts
@@ -1,0 +1,53 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM2p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アローラサンド",
+	},
+
+	illustrator: "Mizue",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Water"],
+
+	description: {
+		ja: "雪山に 棲む。 鋼の甲羅は とても 頑丈だが 硬すぎて 身体を 丸めることが できない。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "まるくなる" },
+			cost: [],
+			effect: {
+				ja: "コインを1回投げオモテなら、次の相手の番、このポケモンはワザのダメージを受けない。",
+			},
+		},
+		{
+			name: { ja: "アイスボール" },
+			damage: 30,
+			cost: ["Water", "Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561214,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "None",
+	dexId: [27],
+};
+
+export default card;

--- a/data-asia/SM/SM2p/012.ts
+++ b/data-asia/SM/SM2p/012.ts
@@ -1,0 +1,63 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM2p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アローラサンドパン",
+	},
+
+	illustrator: "TOKIYA",
+	category: "Pokemon",
+	hp: 110,
+	types: ["Water"],
+
+	description: {
+		ja: "火山噴火 から 逃れるうちに 雪山に 棲みつくように なった。 雪しぶきをあげ 雪原を 駆ける。",
+	},
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ゆきかき" },
+			effect: {
+				ja: "自分の番に1回使える。自分の山札を1枚引く。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "スマッシュターン" },
+			damage: 50,
+			cost: ["Water", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンをベンチポケモンと入れ替える。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561215,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "アローラサンド",
+	},
+
+	retreat: 2,
+	rarity: "None",
+	dexId: [28],
+};
+
+export default card;

--- a/data-asia/SM/SM2p/013.ts
+++ b/data-asia/SM/SM2p/013.ts
@@ -1,0 +1,53 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM2p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アローラロコン",
+	},
+
+	illustrator: "You Iribi",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Water"],
+
+	description: {
+		ja: "マイナス５０度の 冷気を 吐く。 アローラの老人は ケオケオという 昔の 名前で 呼ぶことも。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "みちしるべ" },
+			cost: [],
+			effect: {
+				ja: "自分の山札にあるポケモンを2枚まで、相手に見せてから、手札に加える。そして山札を切る。",
+			},
+		},
+		{
+			name: { ja: "スノーアイス" },
+			damage: 20,
+			cost: ["Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561216,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "None",
+	dexId: [37],
+};
+
+export default card;

--- a/data-asia/SM/SM2p/014.ts
+++ b/data-asia/SM/SM2p/014.ts
@@ -1,0 +1,60 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM2p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アローラキュウコン",
+	},
+
+	illustrator: "Mitsuhiro Arita",
+	category: "Pokemon",
+	hp: 110,
+	types: ["Water"],
+
+	description: {
+		ja: "体毛から 氷の粒を 生み 敵に 浴びせかける。 怒らせると 一瞬で 氷漬けに される。",
+	},
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ひかりのけっかい" },
+			effect: {
+				ja: "このポケモンは、相手の「ポケモンGX・EX」からワザのダメージや効果を受けない。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "オーロラビーム" },
+			damage: 80,
+			cost: ["Water", "Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561217,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "アローラロコン",
+	},
+
+	retreat: 1,
+	rarity: "None",
+	dexId: [38],
+};
+
+export default card;

--- a/data-asia/SM/SM2p/015.ts
+++ b/data-asia/SM/SM2p/015.ts
@@ -1,0 +1,51 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM2p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ホエルコ",
+	},
+
+	illustrator: "Miki Tanaka",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Water"],
+
+	description: {
+		ja: "人を 驚かせるのが 好き。 海水を 飲み込んで ボールの ように ふくらみ 弾んで 遊ぶ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "はねる" },
+			damage: 20,
+			cost: ["Water", "Colorless"],
+		},
+		{
+			name: { ja: "なみのり" },
+			damage: 70,
+			cost: ["Water", "Water", "Water", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561218,
+			},
+		},
+	],
+
+	retreat: 3,
+	rarity: "None",
+	dexId: [320],
+};
+
+export default card;

--- a/data-asia/SM/SM2p/016.ts
+++ b/data-asia/SM/SM2p/016.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM2p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ホエルオー",
+	},
+
+	illustrator: "OOYAMA",
+	category: "Pokemon",
+	hp: 200,
+	types: ["Water"],
+
+	description: {
+		ja: "群れで 獲物を 追う 習性。 大きな 口で ヨワシの 群れごと 一気に 呑み込んでしまうぞ。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "ダイビング" },
+			damage: 40,
+			cost: ["Water", "Water", "Colorless"],
+			effect: {
+				ja: "コインを1回投げオモテなら、次の相手の番、このポケモンはワザのダメージや効果を受けない。",
+			},
+		},
+		{
+			name: { ja: "おおうなばら" },
+			damage: 80,
+			cost: ["Water", "Water", "Water", "Colorless"],
+			effect: {
+				ja: "自分の[水]ポケモン全員のHPを、それぞれ「30」回復する。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561219,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ホエルコ",
+	},
+
+	retreat: 4,
+	rarity: "None",
+	dexId: [321],
+};
+
+export default card;

--- a/data-asia/SM/SM2p/017.ts
+++ b/data-asia/SM/SM2p/017.ts
@@ -1,0 +1,58 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM2p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヨワシ",
+	},
+
+	illustrator: "Sanosuke Sakuma",
+	category: "Pokemon",
+	hp: 30,
+	types: ["Water"],
+
+	description: {
+		ja: "ピンチになると 目が 潤みだし 輝く。 その光に 群れる 仲間と 敵に 立ち向かうのだ。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ぎょぐん" },
+			effect: {
+				ja: "自分の番に1回使える。自分の手札にある「ヨワシGX」を1枚、このカードと入れ替える（ついているカード・ダメカン・特殊状態・効果などは、すべて引きつぐ）。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ねらいうち" },
+			cost: ["Water"],
+			effect: {
+				ja: "相手のポケモン1匹に、10ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561220,
+			},
+		},
+	],
+
+	retreat: 0,
+	rarity: "None",
+	dexId: [746],
+};
+
+export default card;

--- a/data-asia/SM/SM2p/018.ts
+++ b/data-asia/SM/SM2p/018.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM2p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "カプ・レヒレGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 170,
+	types: ["Water"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "アクアリング" },
+			damage: 20,
+			cost: ["Colorless"],
+			effect: {
+				ja: "のぞむなら、このポケモンをベンチポケモンと入れ替える。",
+			},
+		},
+		{
+			name: { ja: "ハイドロシュート" },
+			cost: ["Water", "Water", "Colorless"],
+			effect: {
+				ja: "このポケモンについている[水]エネルギーを2個トラッシュし、相手のポケモン1匹に、120ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+			},
+		},
+		{
+			name: { ja: "カプストームGX" },
+			cost: ["Water"],
+			effect: {
+				ja: "相手のバトルポケモンと、ついているすべてのカードを、相手の山札にもどして切る。相手のベンチポケモンがいないなら、このワザは失敗。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 561221,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Double rare",
+	dexId: [788],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM2p/019.ts
+++ b/data-asia/SM/SM2p/019.ts
@@ -1,0 +1,54 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM2p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "エレブー",
+	},
+
+	illustrator: "match",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Lightning"],
+
+	description: {
+		ja: "突然起こる 停電の 半分は エレブーが 発電所に 集まり 電気を 喰い散らかした からだ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "パンチ" },
+			damage: 20,
+			cost: ["Colorless", "Colorless"],
+		},
+		{
+			name: { ja: "でんきショック" },
+			damage: 40,
+			cost: ["Lightning", "Colorless", "Colorless"],
+			effect: {
+				ja: "コインを1回投げオモテなら、相手のバトルポケモンをマヒにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Metal", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561222,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "None",
+	dexId: [125],
+};
+
+export default card;

--- a/data-asia/SM/SM2p/020.ts
+++ b/data-asia/SM/SM2p/020.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM2p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "エレキブル",
+	},
+
+	illustrator: "kawayoo",
+	category: "Pokemon",
+	hp: 140,
+	types: ["Lightning"],
+
+	description: {
+		ja: "尻尾の 先を 敵に 押しつけ 高圧電流を 流し込む。 一瞬で 敵は 黒コゲ。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "かみなりパンチ" },
+			damage: "60+",
+			cost: ["Lightning", "Colorless", "Colorless"],
+			effect: {
+				ja: "コインを1回投げオモテなら、60ダメージ追加。ウラなら、このポケモンにも20ダメージ。",
+			},
+		},
+		{
+			name: { ja: "ギガインパクト" },
+			damage: 170,
+			cost: ["Lightning", "Lightning", "Colorless", "Colorless"],
+			effect: {
+				ja: "次の自分の番、このポケモンはワザが使えない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Metal", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561223,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "エレブー",
+	},
+
+	retreat: 4,
+	rarity: "None",
+	dexId: [466],
+};
+
+export default card;

--- a/data-asia/SM/SM2p/021.ts
+++ b/data-asia/SM/SM2p/021.ts
@@ -1,0 +1,53 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM2p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "カプ・コケコ",
+	},
+
+	illustrator: "kirisAki",
+	category: "Pokemon",
+	hp: 110,
+	types: ["Lightning"],
+
+	description: {
+		ja: "好奇心旺盛な メレメレの 守り神。 雷雲を 呼び 雷を 身体に 溜め込む。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "かいてんひこう" },
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "相手のポケモン全員に、それぞれ20ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+			},
+		},
+		{
+			name: { ja: "ライトニングボール" },
+			damage: 100,
+			cost: ["Lightning", "Lightning", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Metal", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561226,
+			},
+		},
+	],
+
+	retreat: 0,
+	rarity: "None",
+	dexId: [785],
+};
+
+export default card;

--- a/data-asia/SM/SM2p/022.ts
+++ b/data-asia/SM/SM2p/022.ts
@@ -1,0 +1,54 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM2p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヤドン",
+	},
+
+	illustrator: "Mina Nakai",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Psychic"],
+
+	description: {
+		ja: "長い 尻尾は よく千切れる。 特に 痛みも 感じないし すぐに 生えるので 気にしない。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ずつき" },
+			damage: 10,
+			cost: ["Colorless"],
+		},
+		{
+			name: { ja: "きまぐれタックル" },
+			damage: 60,
+			cost: ["Psychic", "Colorless", "Colorless"],
+			effect: {
+				ja: "コインを1回投げウラなら、このワザは失敗。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561235,
+			},
+		},
+	],
+
+	retreat: 3,
+	rarity: "None",
+	dexId: [79],
+};
+
+export default card;

--- a/data-asia/SM/SM2p/023.ts
+++ b/data-asia/SM/SM2p/023.ts
@@ -1,0 +1,60 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM2p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヤドキング",
+	},
+
+	illustrator: "Eri Yamaki",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Psychic"],
+
+	description: {
+		ja: "噛まれた 毒素の 影響で 天才的 頭脳の 持ち主に。 サイコパワーを 自在に 操る。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "ながれつく" },
+			cost: ["Psychic"],
+			effect: {
+				ja: "自分の山札にある好きなカードを1枚、手札に加える。そして山札を切る。",
+			},
+		},
+		{
+			name: { ja: "まるごし" },
+			damage: 110,
+			cost: ["Psychic", "Psychic", "Psychic"],
+			effect: {
+				ja: "このワザは、自分の手札が1枚もないなら、このワザに必要なエネルギーがこのポケモンについていなくても、使える。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561238,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ヤドン",
+	},
+
+	retreat: 2,
+	rarity: "None",
+	dexId: [199],
+};
+
+export default card;

--- a/data-asia/SM/SM2p/024.ts
+++ b/data-asia/SM/SM2p/024.ts
@@ -1,0 +1,53 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM2p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヤブクロン",
+	},
+
+	illustrator: "Yuka Morii",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Psychic"],
+
+	description: {
+		ja: "不衛生な 場所が 好き。 アローラでは よく ベトベターに 追いまわされる 姿を みかける。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ふみならす" },
+			cost: ["Psychic"],
+			effect: {
+				ja: "相手の山札を上から1枚トラッシュする。",
+			},
+		},
+		{
+			name: { ja: "よだれ" },
+			damage: 30,
+			cost: ["Psychic", "Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561240,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "None",
+	dexId: [568],
+};
+
+export default card;

--- a/data-asia/SM/SM2p/025.ts
+++ b/data-asia/SM/SM2p/025.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM2p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ダストダス",
+	},
+
+	illustrator: "Mitsuhiro Arita",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Psychic"],
+
+	description: {
+		ja: "右腕から 飛びだす 毒液に 注意。 ちょっと かかるだけで 未知の 毒素に 冒される。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "ゴミなだれ" },
+			damage: "20×",
+			cost: ["Psychic"],
+			effect: {
+				ja: "相手のトラッシュにあるグッズの枚数x20ダメージ。",
+			},
+		},
+		{
+			name: { ja: "アシッドボム" },
+			damage: 70,
+			cost: ["Psychic", "Colorless", "Colorless"],
+			effect: {
+				ja: "コインを1回投げオモテなら、相手のバトルポケモンについているエネルギーを、1個トラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561242,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ヤブクロン",
+	},
+
+	retreat: 3,
+	rarity: "None",
+	dexId: [569],
+};
+
+export default card;

--- a/data-asia/SM/SM2p/026.ts
+++ b/data-asia/SM/SM2p/026.ts
@@ -1,0 +1,56 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM2p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "カプ・テテフ",
+	},
+
+	illustrator: "You Iribi",
+	category: "Pokemon",
+	hp: 110,
+	types: ["Psychic"],
+
+	description: {
+		ja: "無邪気で 残酷な アーカラの 守り神。 花の 芳しい 香りが エネルギーの 源。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "サイコウェーブ" },
+			damage: "20×",
+			cost: ["Psychic"],
+			effect: {
+				ja: "相手のバトルポケモンについているエネルギーの数x20ダメージ。",
+			},
+		},
+		{
+			name: { ja: "マジカルスワップ" },
+			cost: ["Psychic", "Colorless"],
+			effect: {
+				ja: "相手の場のポケモンにのっているダメカンを好きなだけ選び、相手の場のポケモンに好きなようにのせ替える。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561245,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "None",
+	dexId: [786],
+};
+
+export default card;

--- a/data-asia/SM/SM2p/027.ts
+++ b/data-asia/SM/SM2p/027.ts
@@ -1,0 +1,49 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM2p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ワンリキー",
+	},
+
+	illustrator: "Kyoko Umemoto",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Fighting"],
+
+	description: {
+		ja: "きたえるのが 大好き。 日に日に 膨れていく 筋肉を ながめて ますます トレーニングに 励むぞ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ダブルチョップ" },
+			damage: "30×",
+			cost: ["Fighting", "Fighting"],
+			effect: {
+				ja: "コインを2回投げ、オモテの数x30ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561253,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "None",
+	dexId: [66],
+};
+
+export default card;

--- a/data-asia/SM/SM2p/028.ts
+++ b/data-asia/SM/SM2p/028.ts
@@ -1,0 +1,63 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM2p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ゴーリキー",
+	},
+
+	illustrator: "Kouki Saitou",
+	category: "Pokemon",
+	hp: 100,
+	types: ["Fighting"],
+
+	description: {
+		ja: "きたえにきたえた 結果 凄まじい パワーを 手にいれた。 その力を 活かし 人の仕事を 手伝う。",
+	},
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "におうだち" },
+			effect: {
+				ja: "このポケモンがいるかぎり、自分のベンチポケモン全員は、相手のワザのダメージを受けず、相手のワザや特性の効果によるダメカンものらない。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "クロスチョップ" },
+			damage: "30+",
+			cost: ["Fighting", "Fighting"],
+			effect: {
+				ja: "コインを1回投げオモテなら、30ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561255,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ワンリキー",
+	},
+
+	retreat: 3,
+	rarity: "None",
+	dexId: [67],
+};
+
+export default card;

--- a/data-asia/SM/SM2p/029.ts
+++ b/data-asia/SM/SM2p/029.ts
@@ -1,0 +1,67 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM2p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "カイリキーGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 250,
+	types: ["Fighting"],
+
+	stage: "Stage2",
+
+	attacks: [
+		{
+			name: { ja: "ふりおろす" },
+			damage: "60+",
+			cost: ["Fighting", "Fighting"],
+			effect: {
+				ja: "相手のバトルポケモンが進化ポケモンなら、60ダメージ追加。",
+			},
+		},
+		{
+			name: { ja: "がんばんくずし" },
+			damage: 130,
+			cost: ["Fighting", "Fighting", "Fighting"],
+			effect: {
+				ja: "場に出ているスタジアムをトラッシュする。",
+			},
+		},
+		{
+			name: { ja: "マッスルパンチGX" },
+			damage: 180,
+			cost: ["Fighting", "Fighting", "Fighting"],
+			effect: {
+				ja: "このワザのダメージは抵抗力を計算しない。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 561257,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ゴーリキー",
+	},
+
+	retreat: 3,
+	rarity: "Double rare",
+	dexId: [68],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM2p/030.ts
+++ b/data-asia/SM/SM2p/030.ts
@@ -1,0 +1,56 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM2p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ルナトーン",
+	},
+
+	illustrator: "Shin Nagasawa",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Fighting"],
+
+	description: {
+		ja: "満月の 夜になると 活発に 活動するため 月の 満ち欠けと 関係していると 言われている。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "かいふくふうじ" },
+			effect: {
+				ja: "自分の場に「ソルロック」がいるなら、おたがいのポケモン全員のHPは、回復しない。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ルナブラスト" },
+			damage: 30,
+			cost: ["Fighting", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561259,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "None",
+	dexId: [337],
+};
+
+export default card;

--- a/data-asia/SM/SM2p/031.ts
+++ b/data-asia/SM/SM2p/031.ts
@@ -1,0 +1,56 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM2p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ソルロック",
+	},
+
+	illustrator: "Masakazu Fukuda",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Fighting"],
+
+	description: {
+		ja: "太陽エネルギーが パワーの 源 なので 昼間は 強い。 回転すると 体が 光る。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ダブルドロー" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札を2枚引く。",
+			},
+		},
+		{
+			name: { ja: "ソーラーヒート" },
+			damage: "20+",
+			cost: ["Fighting"],
+			effect: {
+				ja: "場にスタジアムが出ているなら、20ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561261,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "None",
+	dexId: [338],
+};
+
+export default card;

--- a/data-asia/SM/SM2p/032.ts
+++ b/data-asia/SM/SM2p/032.ts
@@ -1,0 +1,51 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM2p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "イワンコ",
+	},
+
+	illustrator: "match",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Fighting"],
+
+	description: {
+		ja: "よく なつくので 初心者に お勧めのポケモンと いわれるが 育つと 気性は 荒くなる。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "たいあたり" },
+			damage: 10,
+			cost: ["Colorless"],
+		},
+		{
+			name: { ja: "いわおとし" },
+			damage: 20,
+			cost: ["Fighting", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561263,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "None",
+	dexId: [744],
+};
+
+export default card;

--- a/data-asia/SM/SM2p/033.ts
+++ b/data-asia/SM/SM2p/033.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM2p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ルガルガン",
+	},
+
+	illustrator: "Shin Nagasawa",
+	category: "Pokemon",
+	hp: 110,
+	types: ["Fighting"],
+
+	description: {
+		ja: "手強い 相手を 前に するほど 血が 高ぶる。 勝つためなら 我が身を かえりみず 襲いかかる。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "デンジャラスクロー" },
+			damage: "30+",
+			cost: ["Fighting"],
+			effect: {
+				ja: "相手のバトルポケモンがたねポケモンなら、30ダメージ追加。",
+			},
+		},
+		{
+			name: { ja: "おいつめる" },
+			damage: 90,
+			cost: ["Fighting", "Colorless", "Colorless"],
+			effect: {
+				ja: "次の相手の番、このワザを受けたポケモンは、にげられない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561266,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "イワンコ",
+	},
+
+	retreat: 2,
+	rarity: "None",
+	dexId: [745],
+};
+
+export default card;

--- a/data-asia/SM/SM2p/034.ts
+++ b/data-asia/SM/SM2p/034.ts
@@ -1,0 +1,64 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM2p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ルガルガンGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 200,
+	types: ["Fighting"],
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "かみくだく" },
+			damage: 30,
+			cost: ["Fighting", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンについているエネルギーを、1個トラッシュする。",
+			},
+		},
+		{
+			name: { ja: "アクセルロック" },
+			damage: 120,
+			cost: ["Fighting", "Fighting", "Colorless"],
+		},
+		{
+			name: { ja: "ガルファングGX" },
+			damage: 200,
+			cost: ["Fighting", "Fighting", "Colorless"],
+			effect: {
+				ja: "このポケモンについているエネルギーを、2個トラッシュする。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 561268,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "イワンコ",
+	},
+
+	retreat: 1,
+	rarity: "Double rare",
+	dexId: [745],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM2p/035.ts
+++ b/data-asia/SM/SM2p/035.ts
@@ -1,0 +1,49 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM2p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヤミカラス",
+	},
+
+	illustrator: "Sekio",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Darkness"],
+
+	description: {
+		ja: "日暮れに 目覚め 夕闇を 飛ぶ。 ヤミカラスが 飛ぶまでに 家に 帰れ という ことわざも あるぞ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ふきとばし" },
+			damage: 10,
+			cost: ["Darkness"],
+			effect: {
+				ja: "相手のバトルポケモンをベンチポケモンと入れ替える。［バトル場に出すポケモンは相手が選ぶ。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561274,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "None",
+	dexId: [198],
+};
+
+export default card;

--- a/data-asia/SM/SM2p/036.ts
+++ b/data-asia/SM/SM2p/036.ts
@@ -1,0 +1,60 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM2p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ドンカラス",
+	},
+
+	illustrator: "Hideki Ishikawa",
+	category: "Pokemon",
+	hp: 110,
+	types: ["Darkness"],
+
+	description: {
+		ja: "夜行性。 一声 鳴けば １００匹を 超える 子分の ヤミカラスが 集結する。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "だましうち" },
+			cost: ["Darkness"],
+			effect: {
+				ja: "相手のポケモン1匹に、30ダメージ。このワザのダメージは、弱点・抵抗力と、ダメージを受けるポケモンにかかっている効果を計算しない。",
+			},
+		},
+		{
+			name: { ja: "レイブンクロー" },
+			damage: "10+",
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "相手の場のポケモンにのっているダメカンの数x10ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561277,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ヤミカラス",
+	},
+
+	retreat: 1,
+	rarity: "None",
+	dexId: [430],
+};
+
+export default card;

--- a/data-asia/SM/SM2p/037.ts
+++ b/data-asia/SM/SM2p/037.ts
@@ -1,0 +1,53 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM2p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ニューラ",
+	},
+
+	illustrator: "Hasuno",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Darkness"],
+
+	description: {
+		ja: "ずる賢く 獰猛な 性質。 親が いない スキに 巣穴に 侵入。 タマゴを 盗みだす。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "つめとぎ" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "次の自分の番、このポケモンの「きりさく」のダメージは「80」になる。",
+			},
+		},
+		{
+			name: { ja: "きりさく" },
+			damage: 20,
+			cost: ["Darkness", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561279,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "None",
+	dexId: [215],
+};
+
+export default card;

--- a/data-asia/SM/SM2p/038.ts
+++ b/data-asia/SM/SM2p/038.ts
@@ -1,0 +1,57 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM2p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "マニューラ",
+	},
+
+	illustrator: "Satoshi Shirai",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Darkness"],
+
+	description: {
+		ja: "４〜５匹の グループで 行動。 岩や 樹木に サインを 残し 連係プレイで 獲物を 仕留める。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "あくのおきて" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "おたがいの場の特性を持つポケモン全員に、それぞれ60ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+			},
+		},
+		{
+			name: { ja: "きりさく" },
+			damage: 70,
+			cost: ["Darkness", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561281,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ニューラ",
+	},
+
+	retreat: 0,
+	rarity: "None",
+	dexId: [461],
+};
+
+export default card;

--- a/data-asia/SM/SM2p/039.ts
+++ b/data-asia/SM/SM2p/039.ts
@@ -1,0 +1,53 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM2p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヤミラミ",
+	},
+
+	illustrator: "Aya Kusube",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Darkness"],
+
+	description: {
+		ja: "宝石が 好物で メレシーを 狙って 付け回しているが ガバイトに 横取り されてしまう。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "そくばく" },
+			cost: ["Darkness"],
+			effect: {
+				ja: "次の相手の番、相手は手札からサポートを出して使えない。",
+			},
+		},
+		{
+			name: { ja: "ひっかく" },
+			damage: 20,
+			cost: ["Colorless"],
+		},
+	],
+
+	weaknesses: [],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561283,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "None",
+	dexId: [302],
+};
+
+export default card;

--- a/data-asia/SM/SM2p/040.ts
+++ b/data-asia/SM/SM2p/040.ts
@@ -1,0 +1,64 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM2p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ダークライGX",
+	},
+
+	illustrator: "PLANETA",
+	category: "Pokemon",
+	hp: 180,
+	types: ["Darkness"],
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "リザレクション" },
+			effect: {
+				ja: "このカードがトラッシュにあるなら、自分の番に1回使える。このカードをベンチに出す。その後、自分のトラッシュにある[悪]エネルギーを1枚、このカードにつける。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "やみのさけめ" },
+			damage: 130,
+			cost: ["Darkness", "Darkness", "Colorless"],
+			effect: {
+				ja: "このワザのダメージは抵抗力を計算しない。",
+			},
+		},
+		{
+			name: { ja: "デッドエンドGX" },
+			cost: ["Darkness", "Darkness", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンが特殊状態なら、そのポケモンをきぜつさせる。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 561286,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Double rare",
+	dexId: [491],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM2p/041.ts
+++ b/data-asia/SM/SM2p/041.ts
@@ -1,0 +1,49 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM2p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "モンメン",
+	},
+
+	illustrator: "Megumi Mizutani",
+	category: "Pokemon",
+	hp: 50,
+	types: ["Fairy"],
+
+	description: {
+		ja: "仲間を みつけると くっつく。 あまりに たくさん くっつきすぎて 入道雲 みたいになることも。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "れんぞくころがり" },
+			damage: "10×",
+			cost: ["Colorless"],
+			effect: {
+				ja: "ウラが出るまでコインを投げ、オモテの数x10ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [{ type: "Darkness", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561290,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "None",
+	dexId: [546],
+};
+
+export default card;

--- a/data-asia/SM/SM2p/042.ts
+++ b/data-asia/SM/SM2p/042.ts
@@ -1,0 +1,57 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM2p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "エルフーン",
+	},
+
+	illustrator: "Kouki Saitou",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Fairy"],
+
+	description: {
+		ja: "風に 乗り 民家に 侵入。 部屋中を 綿まみれに すると ニコニコ 笑って 去っていく。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "よけいなわたげ" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "次の自分の番、このワザを受けたポケモンがきぜつしたとき、サイドを2枚多くとる。",
+			},
+		},
+		{
+			name: { ja: "ようせいのかぜ" },
+			damage: 30,
+			cost: ["Fairy"],
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [{ type: "Darkness", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561292,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "モンメン",
+	},
+
+	retreat: 0,
+	rarity: "None",
+	dexId: [547],
+};
+
+export default card;

--- a/data-asia/SM/SM2p/043.ts
+++ b/data-asia/SM/SM2p/043.ts
@@ -1,0 +1,59 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM2p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ネッコアラ",
+	},
+
+	illustrator: "Kouki Saitou",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Colorless"],
+
+	description: {
+		ja: "寝たまま 生まれ 寝たまま 死ぬ。 すべての 行動は みている 夢に よる 寝相 らしい。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ぜったいねむり" },
+			effect: {
+				ja: "このポケモンがバトル場にいるかぎり、手札からこのポケモンにエネルギーをつけるたび、このポケモンをねむりにする。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ヒプノロール" },
+			damage: 100,
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "このワザは、このポケモンがねむりなら、使える。このポケモンがねむりでないなら、このワザは失敗。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561294,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "None",
+	dexId: [775],
+};
+
+export default card;

--- a/data-asia/SM/SM2p/044.ts
+++ b/data-asia/SM/SM2p/044.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM2p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "あなぬけのヒモ",
+	},
+
+	illustrator: "Toyste Beach",
+	category: "Trainer",
+
+	effect: {
+		ja: "おたがいのプレイヤーは、それぞれ、自分のバトルポケモンをベンチポケモンと入れ替える。（入れ替えは相手からおこない、ベンチがいないプレイヤーは、入れ替えをしない。）",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561298,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/SM/SM2p/045.ts
+++ b/data-asia/SM/SM2p/045.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM2p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "じゃくてんほけん",
+	},
+
+	illustrator: "Ayaka Yoshida",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードをつけているポケモンの弱点は、すべてなくなる。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561300,
+			},
+		},
+	],
+
+	trainerType: "Tool",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/SM/SM2p/046.ts
+++ b/data-asia/SM/SM2p/046.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM2p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ねがいのバトン",
+	},
+
+	illustrator: "Toyste Beach",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードをつけているポケモンが、バトル場で相手のワザのダメージを受けてきぜつしたとき、そのポケモンについている基本エネルギーを3枚まで、自分のベンチポケモン1匹につけ替える。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561302,
+			},
+		},
+	],
+
+	trainerType: "Tool",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/SM/SM2p/047.ts
+++ b/data-asia/SM/SM2p/047.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM2p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アセロラ",
+	},
+
+	illustrator: "Ken Sugimori",
+	category: "Trainer",
+
+	effect: {
+		ja: "ダメカンがのっている自分のポケモン1匹と、ついているすべてのカードを、手札にもどす。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561306,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/SM/SM2p/048.ts
+++ b/data-asia/SM/SM2p/048.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM2p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "マーマネ",
+	},
+
+	illustrator: "Ken Sugimori",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードは、自分の手札を2枚トラッシュしなければ使えない。自分の山札を4枚引く。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561308,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/SM/SM2p/049.ts
+++ b/data-asia/SM/SM2p/049.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM2p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ライチ",
+	},
+
+	illustrator: "Ken Sugimori",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の山札にある「ポケモンGX」を2枚まで、相手に見せてから、手札に加える。そして山札を切る。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561310,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/SM/SM2p/050.ts
+++ b/data-asia/SM/SM2p/050.ts
@@ -1,0 +1,60 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM2p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "カプ・ブルルGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 180,
+	types: ["Grass"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "つのでつく" },
+			damage: 30,
+			cost: ["Grass"],
+		},
+		{
+			name: { ja: "しぜんのさばき" },
+			damage: "120+",
+			cost: ["Grass", "Grass", "Colorless"],
+			effect: {
+				ja: "のぞむなら、このポケモンについているエネルギーを、すべてトラッシュする。その場合、60ダメージ追加。",
+			},
+		},
+		{
+			name: { ja: "カプワイルドGX" },
+			damage: 150,
+			cost: ["Grass", "Grass", "Colorless"],
+			effect: {
+				ja: "このポケモンのHPを、すべて回復する。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 561313,
+			},
+		},
+	],
+
+	retreat: 3,
+	rarity: "Ultra Rare",
+	dexId: [787],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM2p/051.ts
+++ b/data-asia/SM/SM2p/051.ts
@@ -1,0 +1,63 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM2p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "エンニュートGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 200,
+	types: ["Fire"],
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "ましょうのツメ" },
+			damage: "50×",
+			cost: ["Fire", "Fire"],
+			effect: {
+				ja: "自分がすでにとったサイドの枚数x50ダメージ。",
+			},
+		},
+		{
+			name: { ja: "ヒートブラスト" },
+			damage: 110,
+			cost: ["Fire", "Fire"],
+		},
+		{
+			name: { ja: "クインヘイズGX" },
+			cost: ["Fire", "Fire"],
+			effect: {
+				ja: "相手のバトルポケモンについているエネルギーを、すべてトラッシュする。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 561315,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ヤトウモリ",
+	},
+
+	retreat: 2,
+	rarity: "Ultra Rare",
+	dexId: [758],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM2p/052.ts
+++ b/data-asia/SM/SM2p/052.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM2p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "カプ・レヒレGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 170,
+	types: ["Water"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "アクアリング" },
+			damage: 20,
+			cost: ["Colorless"],
+			effect: {
+				ja: "のぞむなら、このポケモンをベンチポケモンと入れ替える。",
+			},
+		},
+		{
+			name: { ja: "ハイドロシュート" },
+			cost: ["Water", "Water", "Colorless"],
+			effect: {
+				ja: "このポケモンについている[水]エネルギーを2個トラッシュし、相手のポケモン1匹に、120ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+			},
+		},
+		{
+			name: { ja: "カプストームGX" },
+			cost: ["Water"],
+			effect: {
+				ja: "相手のバトルポケモンと、ついているすべてのカードを、相手の山札にもどして切る。相手のベンチポケモンがいないなら、このワザは失敗。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 561317,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Ultra Rare",
+	dexId: [788],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM2p/053.ts
+++ b/data-asia/SM/SM2p/053.ts
@@ -1,0 +1,67 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM2p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "カイリキーGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 250,
+	types: ["Fighting"],
+
+	stage: "Stage2",
+
+	attacks: [
+		{
+			name: { ja: "ふりおろす" },
+			damage: "60+",
+			cost: ["Fighting", "Fighting"],
+			effect: {
+				ja: "相手のバトルポケモンが進化ポケモンなら、60ダメージ追加。",
+			},
+		},
+		{
+			name: { ja: "がんばんくずし" },
+			damage: 130,
+			cost: ["Fighting", "Fighting", "Fighting"],
+			effect: {
+				ja: "場に出ているスタジアムをトラッシュする。",
+			},
+		},
+		{
+			name: { ja: "マッスルパンチGX" },
+			damage: 180,
+			cost: ["Fighting", "Fighting", "Fighting"],
+			effect: {
+				ja: "このワザのダメージは抵抗力を計算しない。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 561319,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ゴーリキー",
+	},
+
+	retreat: 3,
+	rarity: "Ultra Rare",
+	dexId: [68],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM2p/054.ts
+++ b/data-asia/SM/SM2p/054.ts
@@ -1,0 +1,64 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM2p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ルガルガンGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 200,
+	types: ["Fighting"],
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "かみくだく" },
+			damage: 30,
+			cost: ["Fighting", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンについているエネルギーを、1個トラッシュする。",
+			},
+		},
+		{
+			name: { ja: "アクセルロック" },
+			damage: 120,
+			cost: ["Fighting", "Fighting", "Colorless"],
+		},
+		{
+			name: { ja: "ガルファングGX" },
+			damage: 200,
+			cost: ["Fighting", "Fighting", "Colorless"],
+			effect: {
+				ja: "このポケモンについているエネルギーを、2個トラッシュする。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 561321,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "イワンコ",
+	},
+
+	retreat: 1,
+	rarity: "Ultra Rare",
+	dexId: [745],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM2p/055.ts
+++ b/data-asia/SM/SM2p/055.ts
@@ -1,0 +1,64 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM2p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ダークライGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 180,
+	types: ["Darkness"],
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "リザレクション" },
+			effect: {
+				ja: "このカードがトラッシュにあるなら、自分の番に1回使える。このカードをベンチに出す。その後、自分のトラッシュにある[悪]エネルギーを1枚、このカードにつける。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "やみのさけめ" },
+			damage: 130,
+			cost: ["Darkness", "Darkness", "Colorless"],
+			effect: {
+				ja: "このワザのダメージは抵抗力を計算しない。",
+			},
+		},
+		{
+			name: { ja: "デッドエンドGX" },
+			cost: ["Darkness", "Darkness", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンが特殊状態なら、そのポケモンをきぜつさせる。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 561323,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Ultra Rare",
+	dexId: [491],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM2p/056.ts
+++ b/data-asia/SM/SM2p/056.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM2p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アセロラ",
+	},
+
+	illustrator: "Megumi Mizutani",
+	category: "Trainer",
+
+	effect: {
+		ja: "ダメカンがのっている自分のポケモン1匹と、ついているすべてのカードを、手札にもどす。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 561325,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	rarity: "Ultra Rare",
+};
+
+export default card;

--- a/data-asia/SM/SM2p/057.ts
+++ b/data-asia/SM/SM2p/057.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM2p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "マーマネ",
+	},
+
+	illustrator: "Sanosuke Sakuma",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードは、自分の手札を2枚トラッシュしなければ使えない。自分の山札を4枚引く。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 561327,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	rarity: "Ultra Rare",
+};
+
+export default card;

--- a/data-asia/SM/SM2p/058.ts
+++ b/data-asia/SM/SM2p/058.ts
@@ -1,0 +1,60 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM2p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "カプ・ブルルGX",
+	},
+
+	illustrator: "",
+	category: "Pokemon",
+	hp: 180,
+	types: ["Grass"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "つのでつく" },
+			damage: 30,
+			cost: ["Grass"],
+		},
+		{
+			name: { ja: "しぜんのさばき" },
+			damage: "120+",
+			cost: ["Grass", "Grass", "Colorless"],
+			effect: {
+				ja: "のぞむなら、このポケモンについているエネルギーを、すべてトラッシュする。その場合、60ダメージ追加。",
+			},
+		},
+		{
+			name: { ja: "カプワイルドGX" },
+			damage: 150,
+			cost: ["Grass", "Grass", "Colorless"],
+			effect: {
+				ja: "このポケモンのHPを、すべて回復する。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 561328,
+			},
+		},
+	],
+
+	retreat: 3,
+	rarity: "Hyper rare",
+	dexId: [787],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM2p/059.ts
+++ b/data-asia/SM/SM2p/059.ts
@@ -1,0 +1,63 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM2p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "エンニュートGX",
+	},
+
+	illustrator: "",
+	category: "Pokemon",
+	hp: 200,
+	types: ["Fire"],
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "ましょうのツメ" },
+			damage: "50×",
+			cost: ["Fire", "Fire"],
+			effect: {
+				ja: "自分がすでにとったサイドの枚数x50ダメージ。",
+			},
+		},
+		{
+			name: { ja: "ヒートブラスト" },
+			damage: 110,
+			cost: ["Fire", "Fire"],
+		},
+		{
+			name: { ja: "クインヘイズGX" },
+			cost: ["Fire", "Fire"],
+			effect: {
+				ja: "相手のバトルポケモンについているエネルギーを、すべてトラッシュする。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 561329,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ヤトウモリ",
+	},
+
+	retreat: 2,
+	rarity: "Hyper rare",
+	dexId: [758],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM2p/060.ts
+++ b/data-asia/SM/SM2p/060.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM2p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "カプ・レヒレGX",
+	},
+
+	illustrator: "",
+	category: "Pokemon",
+	hp: 170,
+	types: ["Water"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "アクアリング" },
+			damage: 20,
+			cost: ["Colorless"],
+			effect: {
+				ja: "のぞむなら、このポケモンをベンチポケモンと入れ替える。",
+			},
+		},
+		{
+			name: { ja: "ハイドロシュート" },
+			cost: ["Water", "Water", "Colorless"],
+			effect: {
+				ja: "このポケモンについている[水]エネルギーを2個トラッシュし、相手のポケモン1匹に、120ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+			},
+		},
+		{
+			name: { ja: "カプストームGX" },
+			cost: ["Water"],
+			effect: {
+				ja: "相手のバトルポケモンと、ついているすべてのカードを、相手の山札にもどして切る。相手のベンチポケモンがいないなら、このワザは失敗。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 561330,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Hyper rare",
+	dexId: [788],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM2p/061.ts
+++ b/data-asia/SM/SM2p/061.ts
@@ -1,0 +1,67 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM2p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "カイリキーGX",
+	},
+
+	illustrator: "",
+	category: "Pokemon",
+	hp: 250,
+	types: ["Fighting"],
+
+	stage: "Stage2",
+
+	attacks: [
+		{
+			name: { ja: "ふりおろす" },
+			damage: "60+",
+			cost: ["Fighting", "Fighting"],
+			effect: {
+				ja: "相手のバトルポケモンが進化ポケモンなら、60ダメージ追加。",
+			},
+		},
+		{
+			name: { ja: "がんばんくずし" },
+			damage: 130,
+			cost: ["Fighting", "Fighting", "Fighting"],
+			effect: {
+				ja: "場に出ているスタジアムをトラッシュする。",
+			},
+		},
+		{
+			name: { ja: "マッスルパンチGX" },
+			damage: 180,
+			cost: ["Fighting", "Fighting", "Fighting"],
+			effect: {
+				ja: "このワザのダメージは抵抗力を計算しない。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 561331,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ゴーリキー",
+	},
+
+	retreat: 3,
+	rarity: "Hyper rare",
+	dexId: [68],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM2p/062.ts
+++ b/data-asia/SM/SM2p/062.ts
@@ -1,0 +1,64 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM2p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ルガルガンGX",
+	},
+
+	illustrator: "",
+	category: "Pokemon",
+	hp: 200,
+	types: ["Fighting"],
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "かみくだく" },
+			damage: 30,
+			cost: ["Fighting", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンについているエネルギーを、1個トラッシュする。",
+			},
+		},
+		{
+			name: { ja: "アクセルロック" },
+			damage: 120,
+			cost: ["Fighting", "Fighting", "Colorless"],
+		},
+		{
+			name: { ja: "ガルファングGX" },
+			damage: 200,
+			cost: ["Fighting", "Fighting", "Colorless"],
+			effect: {
+				ja: "このポケモンについているエネルギーを、2個トラッシュする。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 561332,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "イワンコ",
+	},
+
+	retreat: 1,
+	rarity: "Hyper rare",
+	dexId: [745],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM2p/063.ts
+++ b/data-asia/SM/SM2p/063.ts
@@ -1,0 +1,64 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM2p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ダークライGX",
+	},
+
+	illustrator: "",
+	category: "Pokemon",
+	hp: 180,
+	types: ["Darkness"],
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "リザレクション" },
+			effect: {
+				ja: "このカードがトラッシュにあるなら、自分の番に1回使える。このカードをベンチに出す。その後、自分のトラッシュにある[悪]エネルギーを1枚、このカードにつける。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "やみのさけめ" },
+			damage: 130,
+			cost: ["Darkness", "Darkness", "Colorless"],
+			effect: {
+				ja: "このワザのダメージは抵抗力を計算しない。",
+			},
+		},
+		{
+			name: { ja: "デッドエンドGX" },
+			cost: ["Darkness", "Darkness", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンが特殊状態なら、そのポケモンをきぜつさせる。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 561333,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Hyper rare",
+	dexId: [491],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM2p/064.ts
+++ b/data-asia/SM/SM2p/064.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM2p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "こだわりハチマキ",
+	},
+
+	illustrator: "",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードをつけているポケモンが使うワザの、相手のバトル場の「ポケモンGX・EX」へのダメージは「+30」される。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 561334,
+			},
+		},
+	],
+
+	trainerType: "Tool",
+	rarity: "Secret Rare",
+};
+
+export default card;

--- a/data-asia/SM/SM2p/065.ts
+++ b/data-asia/SM/SM2p/065.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM2p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "マルチつけかえ",
+	},
+
+	illustrator: "",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分のベンチポケモンについているエネルギーを1個、自分のバトルポケモンにつけ替える。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 561335,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	rarity: "Secret Rare",
+};
+
+export default card;


### PR DESCRIPTION
## What

Adds the complete Japanese set **SM2p 新たなる試練の向こう (Let's Face New Trials)**, released 2017-04-21:

- `data-asia/SM/SM2p.ts` — set definition (49 official cards)
- `data-asia/SM/SM2p/001.ts` … `065.ts` — all 65 cards (49 regular + 16 secret rares: 8 SR, 2 Secret Rare, 6 UR)

## Data sources

- **pokemon-card.com** (official database): Japanese names, flavor texts, National Dex numbers, official card count
- **limitlesstcg.com**: full Japanese card text, stages, weaknesses/resistances/retreat, rarities, illustrators, attack costs
- **Cardmarket**: product IDs as `thirdParty.cardmarket` on the variant objects (561204–561335; tcgplayer IDs not available to me)

## Notes

- Follows the file format and conventions of the M-era sets (#1728)
- No `regulationMark` (the set predates regulation marks); resistances are `-20` per the era
- All 65 files type-check against `interfaces.d.ts` (`tsc --noEmit`)
