### PR TITLE
(data) Add Japanese SM set SM3H Did You See The Fighting Rainbow

### DIFF
--- a/data-asia/SM/SM3H/001.ts
+++ b/data-asia/SM/SM3H/001.ts
@@ -1,0 +1,48 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM3H";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ナゾノクサ",
+	},
+
+	illustrator: "Sumiyoshi Kizuki",
+	category: "Pokemon",
+	hp: 50,
+	types: ["Grass"],
+
+	description: {
+		ja: "昼間は 太陽を 避けるため 冷たい 地面に 潜っている。 月の 光を 浴びて 育つ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "どくのこな" },
+			cost: ["Grass"],
+			effect: {
+				ja: "相手のバトルポケモンをどくにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561065,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [43],
+};
+
+export default card;

--- a/data-asia/SM/SM3H/002.ts
+++ b/data-asia/SM/SM3H/002.ts
@@ -1,0 +1,57 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM3H";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "クサイハナ",
+	},
+
+	illustrator: "Shibuzoh.",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Grass"],
+
+	description: {
+		ja: "猛烈な クサさ！ それなのに １０００人に １人ぐらい これを 好んで かぐ 人がいる。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "くさいかおり" },
+			cost: ["Grass"],
+			effect: {
+				ja: "相手のバトルポケモンをこんらんにする。",
+			},
+		},
+		{
+			name: { ja: "はっぱカッター" },
+			damage: 30,
+			cost: ["Grass", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561066,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ナゾノクサ",
+	},
+
+	retreat: 2,
+	rarity: "Common",
+	dexId: [44],
+};
+
+export default card;

--- a/data-asia/SM/SM3H/003.ts
+++ b/data-asia/SM/SM3H/003.ts
@@ -1,0 +1,63 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM3H";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ラフレシア",
+	},
+
+	illustrator: "chibi",
+	category: "Pokemon",
+	hp: 140,
+	types: ["Grass"],
+
+	description: {
+		ja: "花びらが 大きいほど たくさん 花粉を 出すが 頭が 重たくて 疲れてしまうという。",
+	},
+
+	stage: "Stage2",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "にがにがかふん" },
+			effect: {
+				ja: "このポケモンがバトル場にいるかぎり、相手のたねポケモンはワザが使えない。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ダウナーショック" },
+			damage: 60,
+			cost: ["Grass", "Grass", "Colorless"],
+			effect: {
+				ja: "コインを1回投げオモテなら、相手のバトルポケモンをねむりにする。ウラなら、相手のバトルポケモンをこんらんにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 561067,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "クサイハナ",
+	},
+
+	retreat: 3,
+	rarity: "Rare",
+	dexId: [45],
+};
+
+export default card;

--- a/data-asia/SM/SM3H/004.ts
+++ b/data-asia/SM/SM3H/004.ts
@@ -1,0 +1,59 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM3H";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヘラクロス",
+	},
+
+	illustrator: "Shin Nagasawa",
+	category: "Pokemon",
+	hp: 110,
+	types: ["Grass"],
+
+	description: {
+		ja: "自慢のツノを 相手の お腹の 下に ねじこみ 一気に 持ち上げ ぶん投げてしまう 力持ち。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "こんじょう" },
+			effect: {
+				ja: "このポケモンが、ワザのダメージを受けてきぜつするとき、コインを1回投げる。オモテなら、このポケモンはきぜつせず、残りHPが「10」の状態で場に残る。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "なげとばす" },
+			damage: 50,
+			cost: ["Grass", "Grass"],
+			effect: {
+				ja: "相手のバトルポケモンをベンチポケモンと入れ替える。［バトル場に出すポケモンは相手が選ぶ。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561068,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Uncommon",
+	dexId: [214],
+};
+
+export default card;

--- a/data-asia/SM/SM3H/005.ts
+++ b/data-asia/SM/SM3H/005.ts
@@ -1,0 +1,46 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM3H";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヤナップ",
+	},
+
+	illustrator: "Shigenori Negishi",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Grass"],
+
+	description: {
+		ja: "元気の ない ポケモンに 頭の 葉っぱを 分け与える。 疲れを 取る 効果が あるのだ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "つるのムチ" },
+			damage: 10,
+			cost: ["Grass"],
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561069,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [511],
+};
+
+export default card;

--- a/data-asia/SM/SM3H/006.ts
+++ b/data-asia/SM/SM3H/006.ts
@@ -1,0 +1,58 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM3H";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヤナッキー",
+	},
+
+	illustrator: "tetsuya koizumi",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Grass"],
+
+	description: {
+		ja: "トゲの たくさん ついた 尻尾を 相手に たたきつけて 攻撃。 気性の 激しい ポケモン。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "ひっかく" },
+			damage: 30,
+			cost: ["Colorless"],
+		},
+		{
+			name: { ja: "リーフサプライ" },
+			damage: 50,
+			cost: ["Grass", "Colorless"],
+			effect: {
+				ja: "のぞむなら、自分の手札にある[草]エネルギーを1枚、自分のポケモンにつける。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561070,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ヤナップ",
+	},
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [512],
+};
+
+export default card;

--- a/data-asia/SM/SM3H/007.ts
+++ b/data-asia/SM/SM3H/007.ts
@@ -1,0 +1,49 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM3H";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "シズクモ",
+	},
+
+	illustrator: "Kouki Saitou",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Grass"],
+
+	description: {
+		ja: "餌を 求め 地上に あがる。 水泡を 被るのは 呼吸と 柔らかい 頭を 守るため。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "おそいかかる" },
+			damage: "10+",
+			cost: ["Grass"],
+			effect: {
+				ja: "コインを1回投げオモテなら、10ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561071,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [751],
+};
+
+export default card;

--- a/data-asia/SM/SM3H/008.ts
+++ b/data-asia/SM/SM3H/008.ts
@@ -1,0 +1,58 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM3H";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "オニシズクモ",
+	},
+
+	illustrator: "Naoki Saito",
+	category: "Pokemon",
+	hp: 100,
+	types: ["Grass"],
+
+	description: {
+		ja: "頭部の 水泡で ヘッドバット。 小さなポケモンで あれば そのまま 水泡に 取り込まれ 溺れ死ぬ。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "バブルネット" },
+			damage: 30,
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "次の相手の番、このワザを受けたポケモンは、手札からエネルギーを出してつけられない。",
+			},
+		},
+		{
+			name: { ja: "するどいキバ" },
+			damage: 80,
+			cost: ["Grass", "Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561072,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "シズクモ",
+	},
+
+	retreat: 1,
+	rarity: "Uncommon",
+	dexId: [752],
+};
+
+export default card;

--- a/data-asia/SM/SM3H/009.ts
+++ b/data-asia/SM/SM3H/009.ts
@@ -1,0 +1,51 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM3H";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヒトカゲ",
+	},
+
+	illustrator: "Kagemaru Himeno",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Fire"],
+
+	description: {
+		ja: "尻尾の 炎は ヒトカゲの 生命力の 証。 元気だと さかんに 燃えさかる。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ひっかく" },
+			damage: 10,
+			cost: ["Colorless"],
+		},
+		{
+			name: { ja: "ほのおのしっぽ" },
+			damage: 20,
+			cost: ["Fire", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561073,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [4],
+};
+
+export default card;

--- a/data-asia/SM/SM3H/010.ts
+++ b/data-asia/SM/SM3H/010.ts
@@ -1,0 +1,55 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM3H";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "リザード",
+	},
+
+	illustrator: "kawayoo",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Fire"],
+
+	description: {
+		ja: "尻尾を 振り回して 相手を なぎ倒し 鋭い ツメで ズタズタに ひきさいてしまう。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "ツメできりさく" },
+			damage: 30,
+			cost: ["Colorless", "Colorless"],
+		},
+		{
+			name: { ja: "ヒートブラスト" },
+			damage: 70,
+			cost: ["Fire", "Fire", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561074,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ヒトカゲ",
+	},
+
+	retreat: 2,
+	rarity: "Common",
+	dexId: [5],
+};
+
+export default card;

--- a/data-asia/SM/SM3H/011.ts
+++ b/data-asia/SM/SM3H/011.ts
@@ -1,0 +1,63 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM3H";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "リザードンGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 250,
+	types: ["Fire"],
+
+	stage: "Stage2",
+
+	attacks: [
+		{
+			name: { ja: "つばさでうつ" },
+			damage: 70,
+			cost: ["Colorless", "Colorless", "Colorless"],
+		},
+		{
+			name: { ja: "ぐれんのあらし" },
+			damage: 300,
+			cost: ["Fire", "Fire", "Fire", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンについている[炎]エネルギーを、3個トラッシュする。",
+			},
+		},
+		{
+			name: { ja: "レイジングアウトGX" },
+			cost: ["Fire", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手の山札を上から10枚トラッシュする。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 561075,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "リザード",
+	},
+
+	retreat: 2,
+	rarity: "Double rare",
+	dexId: [6],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM3H/012.ts
+++ b/data-asia/SM/SM3H/012.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM3H";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ホウオウGX",
+	},
+
+	illustrator: "PLANETA",
+	category: "Pokemon",
+	hp: 190,
+	types: ["Fire"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "せいなるほのお" },
+			cost: ["Fire", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のポケモン1匹に、50ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+			},
+		},
+		{
+			name: { ja: "フェニックスバーン" },
+			damage: 180,
+			cost: ["Fire", "Fire", "Fire", "Colorless"],
+			effect: {
+				ja: "次の自分の番、このポケモンは「フェニックスバーン」が使えない。",
+			},
+		},
+		{
+			name: { ja: "エターナルライトGX" },
+			cost: ["Fire", "Colorless", "Colorless"],
+			effect: {
+				ja: "自分のトラッシュにある[炎]タイプの「ポケモンGX・EX」を3枚、ベンチに出す。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 561076,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Double rare",
+	dexId: [250],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM3H/013.ts
+++ b/data-asia/SM/SM3H/013.ts
@@ -1,0 +1,46 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM3H";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "バオップ",
+	},
+
+	illustrator: "Miki Tanaka",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Fire"],
+
+	description: {
+		ja: "知能が 高く 木の実は 焼いてから 食べる 習性。 人の 手伝いを 好んでいる。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ほのお" },
+			damage: 10,
+			cost: ["Fire"],
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561077,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [513],
+};
+
+export default card;

--- a/data-asia/SM/SM3H/014.ts
+++ b/data-asia/SM/SM3H/014.ts
@@ -1,0 +1,58 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM3H";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "バオッキー",
+	},
+
+	illustrator: "kirisAki",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Fire"],
+
+	description: {
+		ja: "体の 中の 炎を 燃やして 頭や 尻尾から 火の粉を まき散らせて 敵を 焦がす。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "ひっかく" },
+			damage: 30,
+			cost: ["Colorless"],
+		},
+		{
+			name: { ja: "フレアリチャージ" },
+			damage: 50,
+			cost: ["Fire", "Colorless"],
+			effect: {
+				ja: "自分のトラッシュにある[炎]エネルギーを1枚、ベンチポケモンにつける。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561078,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "バオップ",
+	},
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [514],
+};
+
+export default card;

--- a/data-asia/SM/SM3H/015.ts
+++ b/data-asia/SM/SM3H/015.ts
@@ -1,0 +1,56 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM3H";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "クイタラン",
+	},
+
+	illustrator: "Anesaki Dynamic",
+	category: "Pokemon",
+	hp: 110,
+	types: ["Fire"],
+
+	description: {
+		ja: "高温で 燃える 炎の 舌で アイアントの 鋼の 体を 溶かして 中身を いただくのだ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "かぎわける" },
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "コインを2回投げ、オモテの数ぶん、自分のトラッシュにある好きなカードを、相手に見せてから、手札に加える。",
+			},
+		},
+		{
+			name: { ja: "やきこがす" },
+			damage: 60,
+			cost: ["Fire", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをやけどにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561079,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Common",
+	dexId: [631],
+};
+
+export default card;

--- a/data-asia/SM/SM3H/016.ts
+++ b/data-asia/SM/SM3H/016.ts
@@ -1,0 +1,48 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM3H";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "タッツー",
+	},
+
+	illustrator: "Saya Tsuruta",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Water"],
+
+	description: {
+		ja: "水面から 勢いよく 墨を 発射して 飛んでいる 虫を 撃ち落とすことがあるという。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ウォーターアロー" },
+			cost: ["Water"],
+			effect: {
+				ja: "相手のポケモン1匹に、10ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561080,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [116],
+};
+
+export default card;

--- a/data-asia/SM/SM3H/017.ts
+++ b/data-asia/SM/SM3H/017.ts
@@ -1,0 +1,52 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM3H";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "シードラ",
+	},
+
+	illustrator: "Suwama Chiaki",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Water"],
+
+	description: {
+		ja: "うかつに 触ろうとすると 体中に 生える トゲに 刺されて 気絶することもある。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "ウォーターアロー" },
+			cost: ["Water"],
+			effect: {
+				ja: "相手のポケモン1匹に、30ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561081,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "タッツー",
+	},
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [117],
+};
+
+export default card;

--- a/data-asia/SM/SM3H/018.ts
+++ b/data-asia/SM/SM3H/018.ts
@@ -1,0 +1,60 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM3H";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "キングドラ",
+	},
+
+	illustrator: "Mitsuhiro Arita",
+	category: "Pokemon",
+	hp: 140,
+	types: ["Water"],
+
+	description: {
+		ja: "普段は 海底洞窟に 身を 潜めているらしい。 あくびで 渦潮を 発生させる。",
+	},
+
+	stage: "Stage2",
+
+	attacks: [
+		{
+			name: { ja: "しおみず" },
+			cost: ["Water"],
+			effect: {
+				ja: "ダメカンがのっている相手のポケモン1匹に、90ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+			},
+		},
+		{
+			name: { ja: "トルネードショット" },
+			damage: 90,
+			cost: ["Water"],
+			effect: {
+				ja: "このポケモンについている[水]エネルギーを1個トラッシュし、相手のベンチポケモン1匹にも、30ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 561082,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "シードラ",
+	},
+
+	retreat: 1,
+	rarity: "Rare",
+	dexId: [230],
+};
+
+export default card;

--- a/data-asia/SM/SM3H/019.ts
+++ b/data-asia/SM/SM3H/019.ts
@@ -1,0 +1,53 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM3H";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "マリル",
+	},
+
+	illustrator: "Asako Ito",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Water"],
+
+	description: {
+		ja: "全身の 体毛は 水を 弾く 性質を 持ち 水浴び しても 乾いている。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "あわ" },
+			cost: ["Water"],
+			effect: {
+				ja: "コインを1回投げオモテなら、相手のバトルポケモンをマヒにする。",
+			},
+		},
+		{
+			name: { ja: "ころがる" },
+			damage: 20,
+			cost: ["Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561083,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [183],
+};
+
+export default card;

--- a/data-asia/SM/SM3H/020.ts
+++ b/data-asia/SM/SM3H/020.ts
@@ -1,0 +1,60 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM3H";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "マリルリ",
+	},
+
+	illustrator: "miki kudo",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Water"],
+
+	description: {
+		ja: "長い 耳は 優れた センサー。 川底で 動く 生き物の 音を 聞き分ける ことが できる。",
+	},
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "あついしぼう" },
+			effect: {
+				ja: "このポケモンが、相手の[炎]または[水]ポケモンから受けるワザのダメージは、「-30」される。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "たきのぼり" },
+			damage: 80,
+			cost: ["Water", "Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561084,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "マリル",
+	},
+
+	retreat: 3,
+	rarity: "Uncommon",
+	dexId: [184],
+};
+
+export default card;

--- a/data-asia/SM/SM3H/021.ts
+++ b/data-asia/SM/SM3H/021.ts
@@ -1,0 +1,49 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM3H";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ソーナンス",
+	},
+
+	illustrator: "nagimiso",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Psychic"],
+
+	description: {
+		ja: "光や ショックを 嫌う。 攻撃されると 体が ふくらみ 反撃が 強力に なる。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "かげむすび" },
+			damage: "50×",
+			cost: ["Psychic", "Psychic", "Psychic"],
+			effect: {
+				ja: "相手のバトルポケモンのにげるためのエネルギーの数x50ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561085,
+			},
+		},
+	],
+
+	retreat: 3,
+	rarity: "Uncommon",
+	dexId: [202],
+};
+
+export default card;

--- a/data-asia/SM/SM3H/022.ts
+++ b/data-asia/SM/SM3H/022.ts
@@ -1,0 +1,54 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM3H";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "フシデ",
+	},
+
+	illustrator: "Yukiko Baba",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Psychic"],
+
+	description: {
+		ja: "頭と 尻尾の 触角で まわりの 様子を 探る。 非常に 凶暴な 性格。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "むしくい" },
+			damage: 10,
+			cost: ["Psychic"],
+		},
+		{
+			name: { ja: "ベノムショック" },
+			damage: "20+",
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンがどくなら、40ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561086,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Common",
+	dexId: [543],
+};
+
+export default card;

--- a/data-asia/SM/SM3H/023.ts
+++ b/data-asia/SM/SM3H/023.ts
@@ -1,0 +1,58 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM3H";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ホイーガ",
+	},
+
+	illustrator: "SATOSHI NAKAI",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Psychic"],
+
+	description: {
+		ja: "硬い 殻に 守られている。 タイヤのように 回転して 敵に 激しく 体当たりする。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "スピンターン" },
+			damage: 30,
+			cost: ["Psychic", "Colorless"],
+			effect: {
+				ja: "このポケモンをベンチポケモンと入れ替える。",
+			},
+		},
+		{
+			name: { ja: "ころがる" },
+			damage: 60,
+			cost: ["Psychic", "Psychic", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561087,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "フシデ",
+	},
+
+	retreat: 3,
+	rarity: "Common",
+	dexId: [544],
+};
+
+export default card;

--- a/data-asia/SM/SM3H/024.ts
+++ b/data-asia/SM/SM3H/024.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM3H";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ペンドラー",
+	},
+
+	illustrator: "Ayaka Yoshida",
+	category: "Pokemon",
+	hp: 160,
+	types: ["Psychic"],
+
+	description: {
+		ja: "獲物を 首のツメで 挟みこみ 身動きを とれなくしてから 猛毒を 与え とどめを 刺す。",
+	},
+
+	stage: "Stage2",
+
+	attacks: [
+		{
+			name: { ja: "どくのつの" },
+			damage: 80,
+			cost: ["Psychic", "Psychic", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをどくにする。",
+			},
+		},
+		{
+			name: { ja: "ハードローラー" },
+			damage: 140,
+			cost: ["Psychic", "Psychic", "Psychic", "Colorless"],
+			effect: {
+				ja: "このワザのダメージは抵抗力を計算しない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561088,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ホイーガ",
+	},
+
+	retreat: 4,
+	rarity: "Uncommon",
+	dexId: [545],
+};
+
+export default card;

--- a/data-asia/SM/SM3H/025.ts
+++ b/data-asia/SM/SM3H/025.ts
@@ -1,0 +1,49 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM3H";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "スナバァ",
+	},
+
+	illustrator: "Masakazu Fukuda",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Psychic"],
+
+	description: {
+		ja: "行き倒れた者の 怨念が 子どもが つくった 砂山に 取りつき 誕生 したのだ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "いのちをすいとる" },
+			damage: 10,
+			cost: ["Psychic"],
+			effect: {
+				ja: "このポケモンのHPを「10」回復する。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561089,
+			},
+		},
+	],
+
+	retreat: 3,
+	rarity: "Common",
+	dexId: [769],
+};
+
+export default card;

--- a/data-asia/SM/SM3H/026.ts
+++ b/data-asia/SM/SM3H/026.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM3H";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "シロデスナ",
+	},
+
+	illustrator: "kawayoo",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Psychic"],
+
+	description: {
+		ja: "人を 操り 砂の山を 砂の城まで 進化 させた。 呪いの 力も あがっている。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "すなじごく" },
+			damage: 80,
+			cost: ["Psychic", "Colorless", "Colorless"],
+			effect: {
+				ja: "次の相手の番、このワザを受けたポケモンは、にげられない。",
+			},
+		},
+		{
+			name: { ja: "さじんのあらし" },
+			damage: 100,
+			cost: ["Colorless", "Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "おたがいのバトルポケモンについているカードを、すべてトラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 561090,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "スナバァ",
+	},
+
+	retreat: 4,
+	rarity: "Rare",
+	dexId: [770],
+};
+
+export default card;

--- a/data-asia/SM/SM3H/027.ts
+++ b/data-asia/SM/SM3H/027.ts
@@ -1,0 +1,51 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM3H";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "リオル",
+	},
+
+	illustrator: "Saya Tsuruta",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Fighting"],
+
+	description: {
+		ja: "人や ポケモンの 感情や 自然の 様子を 波動 という 波の 形で みているのだ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "パンチ" },
+			damage: 10,
+			cost: ["Fighting"],
+		},
+		{
+			name: { ja: "けたぐり" },
+			damage: 30,
+			cost: ["Fighting", "Fighting"],
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561091,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [447],
+};
+
+export default card;

--- a/data-asia/SM/SM3H/028.ts
+++ b/data-asia/SM/SM3H/028.ts
@@ -1,0 +1,60 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM3H";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ルカリオ",
+	},
+
+	illustrator: "nagimiso",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Fighting"],
+
+	description: {
+		ja: "読み取るだけ ではなく 波動を 操る 力を 手に 入れた。 戦いにも 利用 するぞ。",
+	},
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "みきわめ" },
+			effect: {
+				ja: "自分の番に、このカードを手札から出して進化させたとき、1回使える。次の相手の番の終わりまで、このポケモンは、相手のポケモンからワザのダメージや効果を受けない。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "サブマリンブロー" },
+			damage: 120,
+			cost: ["Fighting", "Fighting", "Fighting"],
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 561092,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "リオル",
+	},
+
+	retreat: 1,
+	rarity: "Rare",
+	dexId: [448],
+};
+
+export default card;

--- a/data-asia/SM/SM3H/029.ts
+++ b/data-asia/SM/SM3H/029.ts
@@ -1,0 +1,46 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM3H";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "マケンカニ",
+	},
+
+	illustrator: "kirisAki",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Fighting"],
+
+	description: {
+		ja: "ハサミで 弱点を ガードしつつ 隙を うかがい パンチを 放つ。 負けたほうは 泡を ふいて ダウン。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "なぐる" },
+			damage: 40,
+			cost: ["Fighting", "Fighting"],
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561093,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Common",
+	dexId: [739],
+};
+
+export default card;

--- a/data-asia/SM/SM3H/030.ts
+++ b/data-asia/SM/SM3H/030.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM3H";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ケケンカニ",
+	},
+
+	illustrator: "Mitsuhiro Arita",
+	category: "Pokemon",
+	hp: 140,
+	types: ["Fighting"],
+
+	description: {
+		ja: "トップを 目指すはずが 雪山に 迷い登り 寒さに 耐えるうちに 毛が 生えてきて 進化していた。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "ガッツハンマー" },
+			damage: 80,
+			cost: ["Fighting"],
+			effect: {
+				ja: "このポケモンにも、このポケモンにのっているダメカンの数x10ダメージ。",
+			},
+		},
+		{
+			name: { ja: "ダブルスタンプ" },
+			damage: "80+",
+			cost: ["Fighting", "Fighting", "Fighting"],
+			effect: {
+				ja: "コインを2回投げ、オモテの数x40ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561094,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "マケンカニ",
+	},
+
+	retreat: 4,
+	rarity: "Uncommon",
+	dexId: [740],
+};
+
+export default card;

--- a/data-asia/SM/SM3H/031.ts
+++ b/data-asia/SM/SM3H/031.ts
@@ -1,0 +1,54 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM3H";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ナゲツケサル",
+	},
+
+	illustrator: "Kouki Saitou",
+	category: "Pokemon",
+	hp: 110,
+	types: ["Fighting"],
+
+	description: {
+		ja: "２０匹前後の グループを つくる。 その結束は 非常に 固く 絶対 仲間を 見捨てない。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "パンチ" },
+			damage: 30,
+			cost: ["Colorless", "Colorless"],
+		},
+		{
+			name: { ja: "ワイルドピッチ" },
+			damage: 90,
+			cost: ["Fighting", "Fighting"],
+			effect: {
+				ja: "自分の手札にある「ポケモンのどうぐ」を、1枚トラッシュする。トラッシュできないなら、このワザは失敗。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561095,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Uncommon",
+	dexId: [766],
+};
+
+export default card;

--- a/data-asia/SM/SM3H/032.ts
+++ b/data-asia/SM/SM3H/032.ts
@@ -1,0 +1,55 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM3H";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アローラベトベター",
+	},
+
+	illustrator: "Kouki Saitou",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Darkness"],
+
+	description: {
+		ja: "ゴミ問題を 解決 するため よそから 持ちこんだ ベトベターが いつのまにか この姿に なった。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ぶんれつ" },
+			cost: [],
+			effect: {
+				ja: "自分の山札にある「アローラベトベター」を1枚、ベンチに出す。そして山札を切る。",
+			},
+		},
+		{
+			name: { ja: "トリップヘドロ" },
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをこんらんにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561096,
+			},
+		},
+	],
+
+	retreat: 3,
+	rarity: "Common",
+	dexId: [88],
+};
+
+export default card;

--- a/data-asia/SM/SM3H/033.ts
+++ b/data-asia/SM/SM3H/033.ts
@@ -1,0 +1,66 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM3H";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アローラベトベトンGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 220,
+	types: ["Darkness"],
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "ケミカルブレス" },
+			damage: "10+",
+			cost: ["Darkness", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンが受けている特殊状態の数x70ダメージ追加。",
+			},
+		},
+		{
+			name: { ja: "かみくだく" },
+			damage: 120,
+			cost: ["Darkness", "Darkness", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンについているエネルギーを、1個トラッシュする。",
+			},
+		},
+		{
+			name: { ja: "トライハザードGX" },
+			cost: [],
+			effect: {
+				ja: "相手のベンチポケモンを1匹選び、バトルポケモンと入れ替える。その後、新しく出てきたポケモンをどくとやけどとマヒにする。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 561097,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "アローラベトベター",
+	},
+
+	retreat: 4,
+	rarity: "Double rare",
+	dexId: [89],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM3H/034.ts
+++ b/data-asia/SM/SM3H/034.ts
@@ -1,0 +1,57 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM3H";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ダークライ",
+	},
+
+	illustrator: "Hitoshi Ariga",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Darkness"],
+
+	description: {
+		ja: "深い 眠りに 誘う 力で 人や ポケモンに 悪夢を 見せて 自分の 縄張りから 追い出す。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "さいみんはどう" },
+			damage: 30,
+			cost: ["Darkness", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをねむりにする。",
+			},
+		},
+		{
+			name: { ja: "ダークレイド" },
+			damage: "80+",
+			cost: ["Darkness", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手がすでにGXワザを使っていたなら、80ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 561098,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Rare",
+	dexId: [491],
+};
+
+export default card;

--- a/data-asia/SM/SM3H/035.ts
+++ b/data-asia/SM/SM3H/035.ts
@@ -1,0 +1,53 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM3H";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "マーイーカ",
+	},
+
+	illustrator: "OOYAMA",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Darkness"],
+
+	description: {
+		ja: "発光体の 点滅を 見つめた 相手は 目が くらみ 戦う 気持ちが なくなってしまうのだ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "からみつく" },
+			cost: ["Darkness"],
+			effect: {
+				ja: "コインを1回投げオモテなら、相手のバトルポケモンをマヒにする。",
+			},
+		},
+		{
+			name: { ja: "たいあたり" },
+			damage: 20,
+			cost: ["Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561099,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [686],
+};
+
+export default card;

--- a/data-asia/SM/SM3H/036.ts
+++ b/data-asia/SM/SM3H/036.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM3H";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "カラマネロ",
+	},
+
+	illustrator: "Mitsuhiro Arita",
+	category: "Pokemon",
+	hp: 100,
+	types: ["Darkness"],
+
+	description: {
+		ja: "ポケモンで 一番 強力な 催眠術を 使う。 相手を 意のままに 操ってしまうのだ。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "サイケこうせん" },
+			damage: 20,
+			cost: ["Darkness"],
+			effect: {
+				ja: "相手のバトルポケモンをこんらんにする。",
+			},
+		},
+		{
+			name: { ja: "エナジースロッシュ" },
+			damage: 70,
+			cost: ["Darkness", "Colorless", "Colorless"],
+			effect: {
+				ja: "のぞむなら、このポケモンについているエネルギーをすべて、ベンチポケモン1匹につけ替える。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561100,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "マーイーカ",
+	},
+
+	retreat: 1,
+	rarity: "Uncommon",
+	dexId: [687],
+};
+
+export default card;

--- a/data-asia/SM/SM3H/037.ts
+++ b/data-asia/SM/SM3H/037.ts
@@ -1,0 +1,56 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM3H";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ディアンシー",
+	},
+
+	illustrator: "TOKIYA",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Fairy"],
+
+	description: {
+		ja: "メレシーの 突然変異。 ピンク色に 輝く 体は 世界一 美しいと 言われる。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "きらめくいのり" },
+			cost: ["Fairy"],
+			effect: {
+				ja: "自分の場のポケモン1匹から進化するカードを、自分の山札から1枚選び、そのポケモンにのせて進化させる。そして山札を切る。",
+			},
+		},
+		{
+			name: { ja: "ダイヤストーム" },
+			damage: 30,
+			cost: ["Fairy", "Colorless"],
+			effect: {
+				ja: "自分の[妖]ポケモン全員のHPを、それぞれ「30」回復する。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [{ type: "Darkness", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 561101,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Rare",
+	dexId: [719],
+};
+
+export default card;

--- a/data-asia/SM/SM3H/038.ts
+++ b/data-asia/SM/SM3H/038.ts
@@ -1,0 +1,46 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM3H";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アブリー",
+	},
+
+	illustrator: "Atsuko Nishida",
+	category: "Pokemon",
+	hp: 30,
+	types: ["Fairy"],
+
+	description: {
+		ja: "花のミツや 花粉が 餌。 オーラを 感じる 力を 持ち 咲きそうな 花を 見分けている。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ようせいのかぜ" },
+			damage: 10,
+			cost: ["Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [{ type: "Darkness", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561102,
+			},
+		},
+	],
+
+	retreat: 0,
+	rarity: "Common",
+	dexId: [742],
+};
+
+export default card;

--- a/data-asia/SM/SM3H/039.ts
+++ b/data-asia/SM/SM3H/039.ts
@@ -1,0 +1,60 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM3H";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アブリボン",
+	},
+
+	illustrator: "Megumi Mizutani",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Fairy"],
+
+	description: {
+		ja: "花粉を 丸め 団子を つくる。 食用 から 戦闘用 まで たくさんの 種類が あるよ。",
+	},
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "みつあつめ" },
+			effect: {
+				ja: "自分の番に1回使える。自分の山札にある基本エネルギーを2枚まで、相手に見せてから、手札に加える。そして山札を切る。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "かふんだま" },
+			damage: 20,
+			cost: ["Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [{ type: "Darkness", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561103,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "アブリー",
+	},
+
+	retreat: 1,
+	rarity: "Uncommon",
+	dexId: [743],
+};
+
+export default card;

--- a/data-asia/SM/SM3H/040.ts
+++ b/data-asia/SM/SM3H/040.ts
@@ -1,0 +1,66 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM3H";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "オンバーンGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 200,
+	types: ["Dragon"],
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "ディストーション" },
+			damage: 50,
+			cost: ["Darkness", "Colorless"],
+			effect: {
+				ja: "次の相手の番、相手は手札からグッズを出して使えない。",
+			},
+		},
+		{
+			name: { ja: "ラウドソニック" },
+			damage: 120,
+			cost: ["Psychic", "Darkness", "Colorless"],
+			effect: {
+				ja: "次の相手の番、相手は手札から特殊エネルギーを出してつけられない。",
+			},
+		},
+		{
+			name: { ja: "ばくおんぱGX" },
+			cost: ["Psychic", "Darkness", "Colorless"],
+			effect: {
+				ja: "相手のポケモン全員に、それぞれ50ダメージ。［ベンチは弱点・抵抗力を計算しない。］［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fairy", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 561104,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "オンバット",
+	},
+
+	retreat: 0,
+	rarity: "Double rare",
+	dexId: [715],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM3H/041.ts
+++ b/data-asia/SM/SM3H/041.ts
@@ -1,0 +1,49 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM3H";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ニャース",
+	},
+
+	illustrator: "Kagemaru Himeno",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Colorless"],
+
+	description: {
+		ja: "昼間は だらだら 寝て過ごし 日が 暮れるころに 活動開始。 夜の街で コインを 探す。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ねこだまし" },
+			damage: 10,
+			cost: ["Colorless"],
+			effect: {
+				ja: "コインを1回投げオモテなら、相手のバトルポケモンをマヒにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561105,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [52],
+};
+
+export default card;

--- a/data-asia/SM/SM3H/042.ts
+++ b/data-asia/SM/SM3H/042.ts
@@ -1,0 +1,57 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM3H";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ペルシアン",
+	},
+
+	illustrator: "Sekio",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Colorless"],
+
+	description: {
+		ja: "気性が 荒く 目が 合うだけで 飛び掛ってくる。 鋭いツメに やられると 深い 傷を 負う。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "いやなおと" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "次の自分の番、このワザを受けたポケモンが受けるワザのダメージは「+60」される。",
+			},
+		},
+		{
+			name: { ja: "きりさく" },
+			damage: 40,
+			cost: ["Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561106,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ニャース",
+	},
+
+	retreat: 1,
+	rarity: "Uncommon",
+	dexId: [53],
+};
+
+export default card;

--- a/data-asia/SM/SM3H/043.ts
+++ b/data-asia/SM/SM3H/043.ts
@@ -1,0 +1,53 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM3H";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ホーホー",
+	},
+
+	illustrator: "MAHOU",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Colorless"],
+
+	description: {
+		ja: "体内の 時間の 間隔は どんなときでも 正確で 決まった リズムで 首をかしげる。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "みすかす" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "相手の手札を見る。",
+			},
+		},
+		{
+			name: { ja: "つつく" },
+			damage: 20,
+			cost: ["Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561107,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [163],
+};
+
+export default card;

--- a/data-asia/SM/SM3H/044.ts
+++ b/data-asia/SM/SM3H/044.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM3H";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヨルノズク",
+	},
+
+	illustrator: "Sekio",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Colorless"],
+
+	description: {
+		ja: "両目は 特殊な つくり。 わずかな 光を 集めては 暗闇でも まわりを 見分ける。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "さいみんはどう" },
+			damage: 30,
+			cost: ["Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをねむりにする。",
+			},
+		},
+		{
+			name: { ja: "やしゅう" },
+			damage: 70,
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手の手札を見て、その中にあるポケモンを、1枚トラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561108,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ホーホー",
+	},
+
+	retreat: 1,
+	rarity: "Uncommon",
+	dexId: [164],
+};
+
+export default card;

--- a/data-asia/SM/SM3H/045.ts
+++ b/data-asia/SM/SM3H/045.ts
@@ -1,0 +1,57 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM3H";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "バッフロン",
+	},
+
+	illustrator: "TOKIYA",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Colorless"],
+
+	description: {
+		ja: "見境なく 突進して 頭突きを 食らわせる。 走っている 列車を 脱線させる 破壊力。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "アフロヘッド" },
+			damage: 30,
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "次の相手の番、このポケモンが受けるワザのダメージは「-30」される。",
+			},
+		},
+		{
+			name: { ja: "つきくずす" },
+			damage: 80,
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "のぞむなら、場に出ているスタジアムをトラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561109,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Common",
+	dexId: [626],
+};
+
+export default card;

--- a/data-asia/SM/SM3H/046.ts
+++ b/data-asia/SM/SM3H/046.ts
@@ -1,0 +1,49 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM3H";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "オンバット",
+	},
+
+	illustrator: "Yumi",
+	category: "Pokemon",
+	hp: 50,
+	types: ["Colorless"],
+
+	description: {
+		ja: "真っ暗な 洞窟で 暮らす。 ２０万ヘルツの 超音波を 大きな 耳から 発射する。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "こうそくいどう" },
+			damage: 10,
+			cost: ["Colorless"],
+			effect: {
+				ja: "コインを1回投げオモテなら、次の相手の番、このポケモンはワザのダメージや効果を受けない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561110,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [714],
+};
+
+export default card;

--- a/data-asia/SM/SM3H/047.ts
+++ b/data-asia/SM/SM3H/047.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM3H";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ロトム図鑑 ポケファインダーモード",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の山札を上から4枚見る。そのカードを好きな順番に入れ替えて、山札の上にもどす。または、そのカードを山札にもどして切る。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561111,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM3H/048.ts
+++ b/data-asia/SM/SM3H/048.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM3H";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ムキムキダンベル",
+	},
+
+	illustrator: "Eske Yoshinob",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードをつけている1進化ポケモンの最大HPは「40」大きくなる。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561112,
+			},
+		},
+	],
+
+	trainerType: "Tool",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM3H/049.ts
+++ b/data-asia/SM/SM3H/049.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM3H";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "カキ",
+	},
+
+	illustrator: "Ken Sugimori",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードを使ったら、自分の番は終わる。自分の山札にある[炎]エネルギーを4枚まで、自分のポケモン1匹につける。そして山札を切る。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561113,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM3H/050.ts
+++ b/data-asia/SM/SM3H/050.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM3H";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "プルメリ",
+	},
+
+	illustrator: "Ken Sugimori",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードは、自分の手札を2枚トラッシュしなければ使えない。相手の場のポケモンについているエネルギーを、1個トラッシュする。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561114,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM3H/051.ts
+++ b/data-asia/SM/SM3H/051.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM3H";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ラナキラマウンテン",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Trainer",
+
+	effect: {
+		ja: "おたがいのたねポケモン全員のにげるためのエネルギーは、それぞれ1個ぶん多くなる。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561115,
+			},
+		},
+	],
+
+	trainerType: "Stadium",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM3H/052.ts
+++ b/data-asia/SM/SM3H/052.ts
@@ -1,0 +1,63 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM3H";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "リザードンGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 250,
+	types: ["Fire"],
+
+	stage: "Stage2",
+
+	attacks: [
+		{
+			name: { ja: "つばさでうつ" },
+			damage: 70,
+			cost: ["Colorless", "Colorless", "Colorless"],
+		},
+		{
+			name: { ja: "ぐれんのあらし" },
+			damage: 300,
+			cost: ["Fire", "Fire", "Fire", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンについている[炎]エネルギーを、3個トラッシュする。",
+			},
+		},
+		{
+			name: { ja: "レイジングアウトGX" },
+			cost: ["Fire", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手の山札を上から10枚トラッシュする。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 561116,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "リザード",
+	},
+
+	retreat: 2,
+	rarity: "Ultra Rare",
+	dexId: [6],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM3H/053.ts
+++ b/data-asia/SM/SM3H/053.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM3H";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ホウオウGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 190,
+	types: ["Fire"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "せいなるほのお" },
+			cost: ["Fire", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のポケモン1匹に、50ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+			},
+		},
+		{
+			name: { ja: "フェニックスバーン" },
+			damage: 180,
+			cost: ["Fire", "Fire", "Fire", "Colorless"],
+			effect: {
+				ja: "次の自分の番、このポケモンは「フェニックスバーン」が使えない。",
+			},
+		},
+		{
+			name: { ja: "エターナルライトGX" },
+			cost: ["Fire", "Colorless", "Colorless"],
+			effect: {
+				ja: "自分のトラッシュにある[炎]タイプの「ポケモンGX・EX」を3枚、ベンチに出す。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 561117,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Ultra Rare",
+	dexId: [250],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM3H/054.ts
+++ b/data-asia/SM/SM3H/054.ts
@@ -1,0 +1,66 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM3H";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アローラベトベトンGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 220,
+	types: ["Darkness"],
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "ケミカルブレス" },
+			damage: "10+",
+			cost: ["Darkness", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンが受けている特殊状態の数x70ダメージ追加。",
+			},
+		},
+		{
+			name: { ja: "かみくだく" },
+			damage: 120,
+			cost: ["Darkness", "Darkness", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンについているエネルギーを、1個トラッシュする。",
+			},
+		},
+		{
+			name: { ja: "トライハザードGX" },
+			cost: [],
+			effect: {
+				ja: "相手のベンチポケモンを1匹選び、バトルポケモンと入れ替える。その後、新しく出てきたポケモンをどくとやけどとマヒにする。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 561118,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "アローラベトベター",
+	},
+
+	retreat: 4,
+	rarity: "Ultra Rare",
+	dexId: [89],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM3H/055.ts
+++ b/data-asia/SM/SM3H/055.ts
@@ -1,0 +1,66 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM3H";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "オンバーンGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 200,
+	types: ["Dragon"],
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "ディストーション" },
+			damage: 50,
+			cost: ["Darkness", "Colorless"],
+			effect: {
+				ja: "次の相手の番、相手は手札からグッズを出して使えない。",
+			},
+		},
+		{
+			name: { ja: "ラウドソニック" },
+			damage: 120,
+			cost: ["Psychic", "Darkness", "Colorless"],
+			effect: {
+				ja: "次の相手の番、相手は手札から特殊エネルギーを出してつけられない。",
+			},
+		},
+		{
+			name: { ja: "ばくおんぱGX" },
+			cost: ["Psychic", "Darkness", "Colorless"],
+			effect: {
+				ja: "相手のポケモン全員に、それぞれ50ダメージ。［ベンチは弱点・抵抗力を計算しない。］［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fairy", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 561119,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "オンバット",
+	},
+
+	retreat: 0,
+	rarity: "Ultra Rare",
+	dexId: [715],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM3H/056.ts
+++ b/data-asia/SM/SM3H/056.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM3H";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "カキ",
+	},
+
+	illustrator: "Naoki Saito",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードを使ったら、自分の番は終わる。自分の山札にある[炎]エネルギーを4枚まで、自分のポケモン1匹につける。そして山札を切る。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 561120,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	rarity: "Ultra Rare",
+};
+
+export default card;

--- a/data-asia/SM/SM3H/057.ts
+++ b/data-asia/SM/SM3H/057.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM3H";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "プルメリ",
+	},
+
+	illustrator: "Sanosuke Sakuma",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードは、自分の手札を2枚トラッシュしなければ使えない。相手の場のポケモンについているエネルギーを、1個トラッシュする。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 561121,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	rarity: "Ultra Rare",
+};
+
+export default card;

--- a/data-asia/SM/SM3H/058.ts
+++ b/data-asia/SM/SM3H/058.ts
@@ -1,0 +1,63 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM3H";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "リザードンGX",
+	},
+
+	illustrator: "",
+	category: "Pokemon",
+	hp: 250,
+	types: ["Fire"],
+
+	stage: "Stage2",
+
+	attacks: [
+		{
+			name: { ja: "つばさでうつ" },
+			damage: 70,
+			cost: ["Colorless", "Colorless", "Colorless"],
+		},
+		{
+			name: { ja: "ぐれんのあらし" },
+			damage: 300,
+			cost: ["Fire", "Fire", "Fire", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンについている[炎]エネルギーを、3個トラッシュする。",
+			},
+		},
+		{
+			name: { ja: "レイジングアウトGX" },
+			cost: ["Fire", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手の山札を上から10枚トラッシュする。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 561122,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "リザード",
+	},
+
+	retreat: 2,
+	rarity: "Hyper rare",
+	dexId: [6],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM3H/059.ts
+++ b/data-asia/SM/SM3H/059.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM3H";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ホウオウGX",
+	},
+
+	illustrator: "",
+	category: "Pokemon",
+	hp: 190,
+	types: ["Fire"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "せいなるほのお" },
+			cost: ["Fire", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のポケモン1匹に、50ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+			},
+		},
+		{
+			name: { ja: "フェニックスバーン" },
+			damage: 180,
+			cost: ["Fire", "Fire", "Fire", "Colorless"],
+			effect: {
+				ja: "次の自分の番、このポケモンは「フェニックスバーン」が使えない。",
+			},
+		},
+		{
+			name: { ja: "エターナルライトGX" },
+			cost: ["Fire", "Colorless", "Colorless"],
+			effect: {
+				ja: "自分のトラッシュにある[炎]タイプの「ポケモンGX・EX」を3枚、ベンチに出す。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 561123,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Hyper rare",
+	dexId: [250],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM3H/060.ts
+++ b/data-asia/SM/SM3H/060.ts
@@ -1,0 +1,66 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM3H";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アローラベトベトンGX",
+	},
+
+	illustrator: "",
+	category: "Pokemon",
+	hp: 220,
+	types: ["Darkness"],
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "ケミカルブレス" },
+			damage: "10+",
+			cost: ["Darkness", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンが受けている特殊状態の数x70ダメージ追加。",
+			},
+		},
+		{
+			name: { ja: "かみくだく" },
+			damage: 120,
+			cost: ["Darkness", "Darkness", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンについているエネルギーを、1個トラッシュする。",
+			},
+		},
+		{
+			name: { ja: "トライハザードGX" },
+			cost: [],
+			effect: {
+				ja: "相手のベンチポケモンを1匹選び、バトルポケモンと入れ替える。その後、新しく出てきたポケモンをどくとやけどとマヒにする。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 561124,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "アローラベトベター",
+	},
+
+	retreat: 4,
+	rarity: "Hyper rare",
+	dexId: [89],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM3H/061.ts
+++ b/data-asia/SM/SM3H/061.ts
@@ -1,0 +1,66 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM3H";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "オンバーンGX",
+	},
+
+	illustrator: "",
+	category: "Pokemon",
+	hp: 200,
+	types: ["Dragon"],
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "ディストーション" },
+			damage: 50,
+			cost: ["Darkness", "Colorless"],
+			effect: {
+				ja: "次の相手の番、相手は手札からグッズを出して使えない。",
+			},
+		},
+		{
+			name: { ja: "ラウドソニック" },
+			damage: 120,
+			cost: ["Psychic", "Darkness", "Colorless"],
+			effect: {
+				ja: "次の相手の番、相手は手札から特殊エネルギーを出してつけられない。",
+			},
+		},
+		{
+			name: { ja: "ばくおんぱGX" },
+			cost: ["Psychic", "Darkness", "Colorless"],
+			effect: {
+				ja: "相手のポケモン全員に、それぞれ50ダメージ。［ベンチは弱点・抵抗力を計算しない。］［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fairy", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 561125,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "オンバット",
+	},
+
+	retreat: 0,
+	rarity: "Secret Rare",
+	dexId: [715],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM3H/062.ts
+++ b/data-asia/SM/SM3H/062.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM3H";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "あなぬけのヒモ",
+	},
+
+	illustrator: "",
+	category: "Trainer",
+
+	effect: {
+		ja: "おたがいのプレイヤーは、それぞれ、自分のバトルポケモンをベンチポケモンと入れ替える。（入れ替えは相手からおこない、ベンチがいないプレイヤーは、入れ替えをしない。）",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 561126,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	rarity: "Secret Rare",
+};
+
+export default card;

--- a/data-asia/SM/SM3H/063.ts
+++ b/data-asia/SM/SM3H/063.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM3H";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ムキムキダンベル",
+	},
+
+	illustrator: "",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードをつけている1進化ポケモンの最大HPは「40」大きくなる。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 561127,
+			},
+		},
+	],
+
+	trainerType: "Tool",
+	rarity: "Secret Rare",
+};
+
+export default card;

--- a/data-asia/SM/SM3H/064.ts
+++ b/data-asia/SM/SM3H/064.ts
@@ -1,0 +1,26 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM3H";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "基本炎エネルギー",
+	},
+
+	illustrator: "",
+	category: "Energy",
+	energyType: "Normal",
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 561128,
+			},
+		},
+	],
+
+	rarity: "Secret Rare",
+};
+
+export default card;


### PR DESCRIPTION
## What

Adds the complete Japanese set **SM3H 闘う虹を見たか (Did You See The Fighting Rainbow)**, released 2017-06-16:

- `data-asia/SM/SM3H/001.ts` … `064.ts` — all 64 cards (51 regular + 13 secret rares: 6 SR, 4 Secret Rare, 3 UR)
- the set definition `data-asia/SM/SM3H.ts` already existed and is untouched

## Data sources

- **pokemon-card.com** (official database): Japanese names, flavor texts, National Dex numbers, official card count
- **limitlesstcg.com**: full Japanese card text, stages, weaknesses/resistances/retreat, rarities, illustrators, attack costs
- **Cardmarket**: product IDs as `thirdParty.cardmarket` on the variant objects (561065–561128; tcgplayer IDs not available to me)

## Notes

- Follows the file format and conventions of the M-era sets (#1728)
- No `regulationMark` (the set predates regulation marks); resistances are `-20` per the era
- All 64 files type-check against `interfaces.d.ts` (`tsc --noEmit`)
