### PR TITLE
(data) Add Japanese SM set SM3N Light Consuming Darkness

### DIFF
--- a/data-asia/SM/SM3N/001.ts
+++ b/data-asia/SM/SM3N/001.ts
@@ -1,0 +1,49 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM3N";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "キャタピー",
+	},
+
+	illustrator: "Sekio",
+	category: "Pokemon",
+	hp: 50,
+	types: ["Grass"],
+
+	description: {
+		ja: "とりポケモンに 襲われると ツノから 臭いを だして 抵抗 するが 餌食に なることも 多い。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ふいをつく" },
+			damage: 20,
+			cost: ["Grass"],
+			effect: {
+				ja: "コインを1回投げウラなら、このワザは失敗。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561001,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [10],
+};
+
+export default card;

--- a/data-asia/SM/SM3N/002.ts
+++ b/data-asia/SM/SM3N/002.ts
@@ -1,0 +1,57 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM3N";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "トランセル",
+	},
+
+	illustrator: "Suwama Chiaki",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Grass"],
+
+	description: {
+		ja: "カラの中には トロトロの 中身が 詰まっている。 ほぼ動かないのは ウッカリ 中身が こぼれないため。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "ぶつかる" },
+			damage: 20,
+			cost: ["Grass"],
+		},
+		{
+			name: { ja: "だっぴ" },
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンのHPを「40」回復する。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561002,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "キャタピー",
+	},
+
+	retreat: 2,
+	rarity: "Common",
+	dexId: [11],
+};
+
+export default card;

--- a/data-asia/SM/SM3N/003.ts
+++ b/data-asia/SM/SM3N/003.ts
@@ -1,0 +1,60 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM3N";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "バタフリー",
+	},
+
+	illustrator: "Shin Nagasawa",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Grass"],
+
+	description: {
+		ja: "大きな 眼を よく 観察すると 実は 小さな 眼が 無数に 集まって できているのが わかる。",
+	},
+
+	stage: "Stage2",
+
+	attacks: [
+		{
+			name: { ja: "バイバイヒーリング" },
+			cost: ["Grass"],
+			effect: {
+				ja: "自分のポケモン全員のHPを、すべて回復する。このポケモンと、ついているすべてのカードを、自分の山札にもどして切る。",
+			},
+		},
+		{
+			name: { ja: "しびれごな" },
+			damage: 60,
+			cost: ["Grass", "Colorless", "Colorless"],
+			effect: {
+				ja: "コインを1回投げオモテなら、相手のバトルポケモンをマヒにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561003,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "トランセル",
+	},
+
+	retreat: 1,
+	rarity: "Uncommon",
+	dexId: [12],
+};
+
+export default card;

--- a/data-asia/SM/SM3N/004.ts
+++ b/data-asia/SM/SM3N/004.ts
@@ -1,0 +1,49 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM3N";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "モンジャラ",
+	},
+
+	illustrator: "Shibuzoh.",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Grass"],
+
+	description: {
+		ja: "たくさんの うごめく ツルに 覆われて 正体不明。 青いツルは 一生 伸びる。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "しばりつける" },
+			damage: 10,
+			cost: ["Grass"],
+			effect: {
+				ja: "次の相手の番、このワザを受けたポケモンは、にげられない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561004,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Common",
+	dexId: [114],
+};
+
+export default card;

--- a/data-asia/SM/SM3N/005.ts
+++ b/data-asia/SM/SM3N/005.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM3N";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "モジャンボ",
+	},
+
+	illustrator: "tetsuya koizumi",
+	category: "Pokemon",
+	hp: 140,
+	types: ["Grass"],
+
+	description: {
+		ja: "植物の ツルで できた 腕を 伸ばして 獲物を 絡め取る。 腕を 食べられても へっちゃら。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "ギガドレイン" },
+			damage: 30,
+			cost: ["Grass"],
+			effect: {
+				ja: "相手のバトルポケモンに与えたダメージぶん、このポケモンのHPを回復する。",
+			},
+		},
+		{
+			name: { ja: "クロスウィップ" },
+			damage: "50×",
+			cost: ["Colorless", "Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "コインを4回投げ、オモテの数x50ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561005,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "モンジャラ",
+	},
+
+	retreat: 4,
+	rarity: "Uncommon",
+	dexId: [465],
+};
+
+export default card;

--- a/data-asia/SM/SM3N/006.ts
+++ b/data-asia/SM/SM3N/006.ts
@@ -1,0 +1,56 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM3N";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "コソクムシ",
+	},
+
+	illustrator: "Kagemaru Himeno",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Grass"],
+
+	description: {
+		ja: "臆病で たくさんの 足を ばたつかせ 必死に 逃げまわる。 逃げたあとは ピカピカ 綺麗。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "にげごし" },
+			effect: {
+				ja: "最初の自分の番、このポケモンのにげるためのエネルギーは、すべてなくなる。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "かじる" },
+			damage: 30,
+			cost: ["Grass", "Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561006,
+			},
+		},
+	],
+
+	retreat: 3,
+	rarity: "Common",
+	dexId: [767],
+};
+
+export default card;

--- a/data-asia/SM/SM3N/007.ts
+++ b/data-asia/SM/SM3N/007.ts
@@ -1,0 +1,67 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM3N";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "グソクムシャGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 210,
+	types: ["Grass"],
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "であいがしら" },
+			damage: "30+",
+			cost: ["Grass"],
+			effect: {
+				ja: "この番、このポケモンがベンチからバトル場に出ていたなら、90ダメージ追加。",
+			},
+		},
+		{
+			name: { ja: "アーマープレス" },
+			damage: 100,
+			cost: ["Grass", "Colorless", "Colorless"],
+			effect: {
+				ja: "次の相手の番、このポケモンが受けるワザのダメージは「-20」される。",
+			},
+		},
+		{
+			name: { ja: "ザンクロスGX" },
+			damage: 150,
+			cost: ["Grass", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンをベンチポケモンと入れ替える。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 561007,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "コソクムシ",
+	},
+
+	retreat: 3,
+	rarity: "Double rare",
+	dexId: [768],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM3N/008.ts
+++ b/data-asia/SM/SM3N/008.ts
@@ -1,0 +1,49 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM3N";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "コイキング",
+	},
+
+	illustrator: "Yukiko Baba",
+	category: "Pokemon",
+	hp: 30,
+	types: ["Water"],
+
+	description: {
+		ja: "力は 弱く 頼りないのに 繁殖力だけ 物凄い。 飽きるほど みかけるぞ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "はねてかわす" },
+			damage: 10,
+			cost: ["Water"],
+			effect: {
+				ja: "コインを1回投げオモテなら、次の相手の番、このポケモンはワザのダメージや効果を受けない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561008,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [129],
+};
+
+export default card;

--- a/data-asia/SM/SM3N/009.ts
+++ b/data-asia/SM/SM3N/009.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM3N";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ギャラドス",
+	},
+
+	illustrator: "so-taro",
+	category: "Pokemon",
+	hp: 150,
+	types: ["Water"],
+
+	description: {
+		ja: "ギャラドスを 怒らせた ある街は 一晩の うちに 焼き尽くされ 跡形も なくなったと いわれる。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "あたりちらす" },
+			damage: "50×",
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "自分のトラッシュにある「コイキング」の枚数x50ダメージ。",
+			},
+		},
+		{
+			name: { ja: "スプラッシュバーン" },
+			damage: 160,
+			cost: ["Water", "Water", "Colorless", "Colorless"],
+			effect: {
+				ja: "自分のベンチポケモン全員にも、それぞれ30ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 561009,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "コイキング",
+	},
+
+	retreat: 4,
+	rarity: "Rare",
+	dexId: [130],
+};
+
+export default card;

--- a/data-asia/SM/SM3N/010.ts
+++ b/data-asia/SM/SM3N/010.ts
@@ -1,0 +1,46 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM3N";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヒヤップ",
+	},
+
+	illustrator: "Suwama Chiaki",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Water"],
+
+	description: {
+		ja: "頭の房に ためこんだ 水は 栄養 たっぷり。 尻尾を使って その 水を 草木に かけている。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "みずでっぽう" },
+			damage: 10,
+			cost: ["Water"],
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561010,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [515],
+};
+
+export default card;

--- a/data-asia/SM/SM3N/011.ts
+++ b/data-asia/SM/SM3N/011.ts
@@ -1,0 +1,58 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM3N";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヒヤッキー",
+	},
+
+	illustrator: "Sanosuke Sakuma",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Water"],
+
+	description: {
+		ja: "尻尾から 高圧の 水を 発射すると コンクリートの 壁も 破壊する 威力。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "ひっかく" },
+			damage: 30,
+			cost: ["Colorless"],
+		},
+		{
+			name: { ja: "アクアリフレクト" },
+			damage: 50,
+			cost: ["Water", "Colorless"],
+			effect: {
+				ja: "このポケモンについている[水]エネルギーを1個、ベンチポケモンにつけ替える。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561011,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ヒヤップ",
+	},
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [516],
+};
+
+export default card;

--- a/data-asia/SM/SM3N/012.ts
+++ b/data-asia/SM/SM3N/012.ts
@@ -1,0 +1,56 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM3N";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ハギギシリ",
+	},
+
+	illustrator: "Masakazu Fukuda",
+	category: "Pokemon",
+	hp: 100,
+	types: ["Water"],
+
+	description: {
+		ja: "頭の 突起から サイコパワーを 放つとき とても 耳障りな 歯ぎしりの 音が あたりに 響く。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "はぎしり" },
+			cost: ["Water"],
+			effect: {
+				ja: "相手のバトルポケモンをこんらんにする。",
+			},
+		},
+		{
+			name: { ja: "シンクロノイズ" },
+			damage: 60,
+			cost: ["Water", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンと同じタイプの、相手のベンチポケモン全員にも、それぞれ20ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561012,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Uncommon",
+	dexId: [779],
+};
+
+export default card;

--- a/data-asia/SM/SM3N/013.ts
+++ b/data-asia/SM/SM3N/013.ts
@@ -1,0 +1,54 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM3N";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ピカチュウ",
+	},
+
+	illustrator: "Saya Tsuruta",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Lightning"],
+
+	description: {
+		ja: "たくさんの ピカチュウを 集め 発電所を 造る 計画が 最近 発表 された。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "しっぽではたく" },
+			damage: 10,
+			cost: ["Colorless"],
+		},
+		{
+			name: { ja: "でんきショック" },
+			damage: 20,
+			cost: ["Lightning", "Colorless"],
+			effect: {
+				ja: "コインを1回投げオモテなら、相手のバトルポケモンをマヒにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Metal", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561013,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [25],
+};
+
+export default card;

--- a/data-asia/SM/SM3N/014.ts
+++ b/data-asia/SM/SM3N/014.ts
@@ -1,0 +1,63 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM3N";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ライチュウ",
+	},
+
+	illustrator: "Kagemaru Himeno",
+	category: "Pokemon",
+	hp: 110,
+	types: ["Lightning"],
+
+	description: {
+		ja: "電撃は １０万ボルトに 達することもあり ヘタに触ると インド象でも 気絶する。",
+	},
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "エボルショック" },
+			effect: {
+				ja: "自分の番に、このカードを手札から出して進化させたとき、1回使える。相手のバトルポケモンをマヒにする。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ボルテッカー" },
+			damage: 130,
+			cost: ["Lightning", "Lightning", "Colorless"],
+			effect: {
+				ja: "このポケモンにも30ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Metal", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 561014,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ピカチュウ",
+	},
+
+	retreat: 1,
+	rarity: "Rare",
+	dexId: [26],
+};
+
+export default card;

--- a/data-asia/SM/SM3N/015.ts
+++ b/data-asia/SM/SM3N/015.ts
@@ -1,0 +1,49 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM3N";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "シビシラス",
+	},
+
+	illustrator: "Asako Ito",
+	category: "Pokemon",
+	hp: 40,
+	types: ["Lightning"],
+
+	description: {
+		ja: "１匹の 電力は 小さいが たくさんの シビシラスが つながると 雷と 同じ 威力になる。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "アクアショック" },
+			damage: "10+",
+			cost: ["Lightning"],
+			effect: {
+				ja: "相手のバトルポケモンに[水]エネルギーがついているなら、30ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Metal", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561015,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [602],
+};
+
+export default card;

--- a/data-asia/SM/SM3N/016.ts
+++ b/data-asia/SM/SM3N/016.ts
@@ -1,0 +1,53 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM3N";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "シビビール",
+	},
+
+	illustrator: "OOYAMA",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Lightning"],
+
+	description: {
+		ja: "相手に 巻きつき まるい はん点から 電気を 流して しびれたところを まるかじりする。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "こものぐい" },
+			damage: 50,
+			cost: ["Lightning", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンの最大HPが「100」以上なら、このワザは失敗。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Metal", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561016,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "シビシラス",
+	},
+
+	retreat: 2,
+	rarity: "Common",
+	dexId: [603],
+};
+
+export default card;

--- a/data-asia/SM/SM3N/017.ts
+++ b/data-asia/SM/SM3N/017.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM3N";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "シビルドン",
+	},
+
+	illustrator: "hatachu",
+	category: "Pokemon",
+	hp: 140,
+	types: ["Lightning"],
+
+	description: {
+		ja: "吸盤の 口で 獲物に 吸いつき 食いこませた キバから 電気を 流して 感電させる。",
+	},
+
+	stage: "Stage2",
+
+	attacks: [
+		{
+			name: { ja: "くらいつく" },
+			damage: 50,
+			cost: ["Lightning", "Colorless"],
+			effect: {
+				ja: "次の相手の番、このワザを受けたポケモンは、にげられない。",
+			},
+		},
+		{
+			name: { ja: "バキュームボルト" },
+			damage: "80+",
+			cost: ["Lightning", "Lightning", "Colorless"],
+			effect: {
+				ja: "のぞむなら、80ダメージ追加。その場合、自分のポケモン1匹にも、80ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Metal", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561017,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "シビビール",
+	},
+
+	retreat: 3,
+	rarity: "Uncommon",
+	dexId: [604],
+};
+
+export default card;

--- a/data-asia/SM/SM3N/018.ts
+++ b/data-asia/SM/SM3N/018.ts
@@ -1,0 +1,59 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM3N";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ハブネーク",
+	},
+
+	illustrator: "Eri Yamaki",
+	category: "Pokemon",
+	hp: 100,
+	types: ["Psychic"],
+
+	description: {
+		ja: "猛毒が 染み出している 鋭い 切れ味の 尻尾で 素早い ザングースに 立ち向かう。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ポイズンアップ" },
+			effect: {
+				ja: "このポケモンがいるかぎり、相手のバトルポケモンは、どくでのせるダメカンの数が1個多くなる。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "どくのキバ" },
+			damage: 30,
+			cost: ["Psychic", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをどくにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561018,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Uncommon",
+	dexId: [336],
+};
+
+export default card;

--- a/data-asia/SM/SM3N/019.ts
+++ b/data-asia/SM/SM3N/019.ts
@@ -1,0 +1,53 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM3N";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヨマワル",
+	},
+
+	illustrator: "Midori Harada",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Psychic"],
+
+	description: {
+		ja: "どこまでも 獲物を 追い続ける。 執念深い 性格だが 朝日が 昇ると あきらめる。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "やみあんない" },
+			cost: ["Psychic"],
+			effect: {
+				ja: "自分のトラッシュにあるたねポケモンを1枚、ベンチに出す。",
+			},
+		},
+		{
+			name: { ja: "Attack 2" },
+			damage: 20,
+			cost: ["Psychic", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561019,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [355],
+};
+
+export default card;

--- a/data-asia/SM/SM3N/020.ts
+++ b/data-asia/SM/SM3N/020.ts
@@ -1,0 +1,60 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM3N";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "サマヨール",
+	},
+
+	illustrator: "SATOSHI NAKAI",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Psychic"],
+
+	description: {
+		ja: "体の 中で 燃えている 人魂を のぞきこむと 魂を 吸い取られてしまう。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "よるにさまよう" },
+			cost: ["Psychic"],
+			effect: {
+				ja: "おたがいのポケモン全員に、それぞれダメカンを1個のせる。",
+			},
+		},
+		{
+			name: { ja: "おそいかかる" },
+			damage: "30+",
+			cost: ["Psychic", "Colorless", "Colorless"],
+			effect: {
+				ja: "コインを1回投げオモテなら、30ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561020,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ヨマワル",
+	},
+
+	retreat: 3,
+	rarity: "Common",
+	dexId: [356],
+};
+
+export default card;

--- a/data-asia/SM/SM3N/021.ts
+++ b/data-asia/SM/SM3N/021.ts
@@ -1,0 +1,63 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM3N";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヨノワール",
+	},
+
+	illustrator: "nagimiso",
+	category: "Pokemon",
+	hp: 150,
+	types: ["Psychic"],
+
+	description: {
+		ja: "弾力のある 体の 中に 行き場のない 魂を 取りこんで あの世に 連れていくと 言われる。",
+	},
+
+	stage: "Stage2",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "やみのしょうたいじょう" },
+			effect: {
+				ja: "自分の番に1回使える。相手の手札を見て、その中にあるたねポケモンを1枚、相手のベンチに出す。その後、そのポケモンにダメカンを3個のせる。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "マインドジャック" },
+			damage: "30+",
+			cost: ["Psychic", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のベンチポケモンの数x30ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 561021,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "サマヨール",
+	},
+
+	retreat: 3,
+	rarity: "Rare",
+	dexId: [477],
+};
+
+export default card;

--- a/data-asia/SM/SM3N/022.ts
+++ b/data-asia/SM/SM3N/022.ts
@@ -1,0 +1,54 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM3N";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "グレッグル",
+	},
+
+	illustrator: "Naoki Saito",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Psychic"],
+
+	description: {
+		ja: "ほっぺたに 毒袋を 持つ。 相手の すきを ついて 猛毒を にじませている 指を 突き刺す。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "どつく" },
+			damage: 10,
+			cost: ["Colorless"],
+		},
+		{
+			name: { ja: "かえるとび" },
+			damage: "20+",
+			cost: ["Psychic", "Colorless"],
+			effect: {
+				ja: "コインを1回投げオモテなら、20ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561022,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [453],
+};
+
+export default card;

--- a/data-asia/SM/SM3N/023.ts
+++ b/data-asia/SM/SM3N/023.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM3N";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ドクロッグ",
+	},
+
+	illustrator: "kawayoo",
+	category: "Pokemon",
+	hp: 110,
+	types: ["Psychic"],
+
+	description: {
+		ja: "のど元に 毒袋を 持つ。 のどを 鳴らすと たまった 毒は 練りこまれ 強力になる。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "どくづき" },
+			damage: 30,
+			cost: ["Psychic", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをどくにする。",
+			},
+		},
+		{
+			name: { ja: "ポイズンハイ" },
+			damage: "80+",
+			cost: ["Psychic", "Psychic", "Colorless"],
+			effect: {
+				ja: "このポケモンがどくなら、80ダメージ追加。その後、このポケモンのどくを回復する。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561023,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "グレッグル",
+	},
+
+	retreat: 2,
+	rarity: "Uncommon",
+	dexId: [454],
+};
+
+export default card;

--- a/data-asia/SM/SM3N/024.ts
+++ b/data-asia/SM/SM3N/024.ts
@@ -1,0 +1,48 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM3N";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ニャスパー",
+	},
+
+	illustrator: "Miki Tanaka",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Psychic"],
+
+	description: {
+		ja: "強力な サイコパワーが 漏れ出さないように 放出する 器官を 耳で ふさいでいるのだ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "まどわすひとみ" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "次の自分の番の終わりまで、このワザを受けたポケモンの弱点は[超]タイプになる。［弱点は「x2」でダメージ計算をする。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561024,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [677],
+};
+
+export default card;

--- a/data-asia/SM/SM3N/025.ts
+++ b/data-asia/SM/SM3N/025.ts
@@ -1,0 +1,60 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM3N";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ニャオニクス",
+	},
+
+	illustrator: "Anesaki Dynamic",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Psychic"],
+
+	description: {
+		ja: "危険が 迫ると 耳を 持ち上げ １０トン トラックを ひねりつぶす サイコパワーを 解放する。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "ひきつける" },
+			cost: ["Psychic"],
+			effect: {
+				ja: "自分の山札を3枚引く。",
+			},
+		},
+		{
+			name: { ja: "ハンドキネシス" },
+			damage: "10×",
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "自分の手札の枚数x10ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561025,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ニャスパー",
+	},
+
+	retreat: 1,
+	rarity: "Uncommon",
+	dexId: [678],
+};
+
+export default card;

--- a/data-asia/SM/SM3N/026.ts
+++ b/data-asia/SM/SM3N/026.ts
@@ -1,0 +1,64 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM3N";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ネクロズマGX",
+	},
+
+	illustrator: "PLANETA",
+	category: "Pokemon",
+	hp: 180,
+	types: ["Psychic"],
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ひかりのおわり" },
+			effect: {
+				ja: "このポケモンは[無]ポケモンから、ワザのダメージを受けない。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "プリズムバースト" },
+			damage: "10+",
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンについている[超]エネルギーをすべてトラッシュし、その枚数x60ダメージ追加。",
+			},
+		},
+		{
+			name: { ja: "ブラックレイGX" },
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手の「ポケモンGX・EX」全員に、それぞれ100ダメージ。このワザのダメージは弱点・抵抗力を計算しない。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 561026,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Double rare",
+	dexId: [800],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM3N/027.ts
+++ b/data-asia/SM/SM3N/027.ts
@@ -1,0 +1,51 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM3N";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "サイホーン",
+	},
+
+	illustrator: "miki kudo",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Fighting"],
+
+	description: {
+		ja: "頭は 悪いが 力が 強く 高層ビルも 体当たりで コナゴナに 粉砕する。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "つきたおし" },
+			damage: 20,
+			cost: ["Colorless", "Colorless"],
+		},
+		{
+			name: { ja: "つのドリル" },
+			damage: 60,
+			cost: ["Fighting", "Fighting", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561027,
+			},
+		},
+	],
+
+	retreat: 3,
+	rarity: "Common",
+	dexId: [111],
+};
+
+export default card;

--- a/data-asia/SM/SM3N/028.ts
+++ b/data-asia/SM/SM3N/028.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM3N";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "サイドン",
+	},
+
+	illustrator: "Sanosuke Sakuma",
+	category: "Pokemon",
+	hp: 110,
+	types: ["Fighting"],
+
+	description: {
+		ja: "全身を よろいのような 皮膚で 守っている。 ２０００度の マグマの 中でも 生きられる。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "がんせきおとし" },
+			damage: 80,
+			cost: ["Fighting", "Fighting", "Colorless"],
+			effect: {
+				ja: "このワザのダメージは抵抗力を計算しない。",
+			},
+		},
+		{
+			name: { ja: "メガホーン" },
+			damage: 120,
+			cost: ["Fighting", "Fighting", "Fighting", "Colorless"],
+			effect: {
+				ja: "コインを1回投げウラなら、このワザは失敗。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561028,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "サイホーン",
+	},
+
+	retreat: 4,
+	rarity: "Common",
+	dexId: [112],
+};
+
+export default card;

--- a/data-asia/SM/SM3N/029.ts
+++ b/data-asia/SM/SM3N/029.ts
@@ -1,0 +1,63 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM3N";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ドサイドン",
+	},
+
+	illustrator: "Mitsuhiro Arita",
+	category: "Pokemon",
+	hp: 160,
+	types: ["Fighting"],
+
+	description: {
+		ja: "手のひらの 穴から イシツブテを 発射。 全身の プロテクターは 火山の 噴火にも 耐えられる。",
+	},
+
+	stage: "Stage2",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "やまおろし" },
+			effect: {
+				ja: "自分の番に、このカードを手札から出して進化させたとき、1回使える。相手の山札を上から3枚トラッシュする。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "がんせきほう" },
+			damage: 170,
+			cost: ["Fighting", "Fighting", "Colorless", "Colorless"],
+			effect: {
+				ja: "このワザのダメージは弱点・抵抗力を計算しない。次の自分の番、このポケモンはワザが使えない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 561029,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "サイドン",
+	},
+
+	retreat: 4,
+	rarity: "Rare",
+	dexId: [464],
+};
+
+export default card;

--- a/data-asia/SM/SM3N/030.ts
+++ b/data-asia/SM/SM3N/030.ts
@@ -1,0 +1,56 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM3N";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ダゲキ",
+	},
+
+	illustrator: "Shigenori Negishi",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Fighting"],
+
+	description: {
+		ja: "最強の からてチョップを 求めて 山奥に こもって 眠ることなく 修行する。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ファストガード" },
+			cost: ["Fighting"],
+			effect: {
+				ja: "次の相手の番、このポケモンはたねポケモンからワザのダメージを受けない。次の自分の番、このポケモンは「ファストガード」が使えない。",
+			},
+		},
+		{
+			name: { ja: "かわらわり" },
+			damage: 40,
+			cost: ["Fighting", "Colorless"],
+			effect: {
+				ja: "このワザのダメージは、抵抗力と相手のバトルポケモンにかかっている効果を計算しない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561030,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Common",
+	dexId: [539],
+};
+
+export default card;

--- a/data-asia/SM/SM3N/031.ts
+++ b/data-asia/SM/SM3N/031.ts
@@ -1,0 +1,49 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM3N";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ドロバンコ",
+	},
+
+	illustrator: "Saya Tsuruta",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Fighting"],
+
+	description: {
+		ja: "足に まとわりついた 泥が グリップに なり 力強い 走りを 実現しているのだ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ふみつけ" },
+			damage: "20+",
+			cost: ["Fighting", "Colorless"],
+			effect: {
+				ja: "コインを1回投げオモテなら、20ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561031,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Common",
+	dexId: [749],
+};
+
+export default card;

--- a/data-asia/SM/SM3N/032.ts
+++ b/data-asia/SM/SM3N/032.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM3N";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "バンバドロ",
+	},
+
+	illustrator: "TOKIYA",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Fighting"],
+
+	description: {
+		ja: "口から 吐く 泥は 固まると 雨風にも 強いので 昔の 家の 壁には よく塗られている。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "けりとばす" },
+			damage: 60,
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをベンチポケモンと入れ替える。［バトル場に出すポケモンは相手が選ぶ。］",
+			},
+		},
+		{
+			name: { ja: "ばくしん" },
+			damage: 130,
+			cost: ["Fighting", "Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンにも30ダメージ。相手のベンチポケモン1匹にも、30ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561032,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ドロバンコ",
+	},
+
+	retreat: 3,
+	rarity: "Uncommon",
+	dexId: [750],
+};
+
+export default card;

--- a/data-asia/SM/SM3N/033.ts
+++ b/data-asia/SM/SM3N/033.ts
@@ -1,0 +1,62 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM3N";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "マーシャドーGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 150,
+	types: ["Fighting"],
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "シャドーハント" },
+			effect: {
+				ja: "このポケモンは、自分のトラッシュにあるたねポケモンが持っているワザを、すべて使える。［ワザを使うためのエネルギーは必要。］",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "せいけんづき" },
+			damage: 120,
+			cost: ["Fighting", "Fighting", "Colorless"],
+		},
+		{
+			name: { ja: "ひゃくれつむそうGX" },
+			damage: "50×",
+			cost: ["Fighting"],
+			effect: {
+				ja: "このポケモンについている基本エネルギーの数x50ダメージ。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 561033,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Double rare",
+	dexId: [802],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM3N/034.ts
+++ b/data-asia/SM/SM3N/034.ts
@@ -1,0 +1,53 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM3N";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アローラコラッタ",
+	},
+
+	illustrator: "nagimiso",
+	category: "Pokemon",
+	hp: 40,
+	types: ["Darkness"],
+
+	description: {
+		ja: "前歯で ドアを かじり 民家に 侵入。 ヒゲを ひくつかせ 餌を 探しだし 盗んでいくぞ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "きあいだめ" },
+			cost: [],
+			effect: {
+				ja: "次の自分の番、このポケモンの「かみつく」のダメージは「60」になる。",
+			},
+		},
+		{
+			name: { ja: "かみつく" },
+			damage: 10,
+			cost: ["Darkness"],
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561034,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [19],
+};
+
+export default card;

--- a/data-asia/SM/SM3N/035.ts
+++ b/data-asia/SM/SM3N/035.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM3N";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アローララッタ",
+	},
+
+	illustrator: "Kouki Saitou",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Darkness"],
+
+	description: {
+		ja: "コラッタを 率い グループをつくる。 グループには テリトリーが あり 餌を 巡り 抗争に なる。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "きょうかまえば" },
+			damage: "10+",
+			cost: [],
+			effect: {
+				ja: "このポケモンに「ポケモンのどうぐ」がついているなら、50ダメージ追加。",
+			},
+		},
+		{
+			name: { ja: "ひっさつまえば" },
+			damage: 60,
+			cost: ["Darkness"],
+			effect: {
+				ja: "コインを1回投げウラなら、このワザは失敗。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561035,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "アローラコラッタ",
+	},
+
+	retreat: 3,
+	rarity: "Uncommon",
+	dexId: [20],
+};
+
+export default card;

--- a/data-asia/SM/SM3N/036.ts
+++ b/data-asia/SM/SM3N/036.ts
@@ -1,0 +1,49 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM3N";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ラルトス",
+	},
+
+	illustrator: "Yumi",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Fairy"],
+
+	description: {
+		ja: "赤いツノで 人や ポケモンの 温かな 気持ちを キャッチすると 全身が ほのかに 熱くなる。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ドレインキッス" },
+			damage: 10,
+			cost: ["Fairy"],
+			effect: {
+				ja: "このポケモンのHPを「10」回復する。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [{ type: "Darkness", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561036,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [280],
+};
+
+export default card;

--- a/data-asia/SM/SM3N/037.ts
+++ b/data-asia/SM/SM3N/037.ts
@@ -1,0 +1,55 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM3N";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "キルリア",
+	},
+
+	illustrator: "Anesaki Dynamic",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Fairy"],
+
+	description: {
+		ja: "トレーナーの 明るい 気持ちが サイコパワーの 源。 楽しい 気分に なると クルクル 踊る。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "ひらてうち" },
+			damage: 20,
+			cost: ["Colorless"],
+		},
+		{
+			name: { ja: "マジカルショット" },
+			damage: 30,
+			cost: ["Fairy", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [{ type: "Darkness", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561037,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ラルトス",
+	},
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [281],
+};
+
+export default card;

--- a/data-asia/SM/SM3N/038.ts
+++ b/data-asia/SM/SM3N/038.ts
@@ -1,0 +1,68 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM3N";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "サーナイトGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 230,
+	types: ["Fairy"],
+
+	stage: "Stage2",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ひみつのいずみ" },
+			effect: {
+				ja: "自分の番に1回使える。自分の手札にある[妖]エネルギーを1枚、自分のポケモンにつける。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "インフィニットフォース" },
+			damage: "30×",
+			cost: ["Fairy"],
+			effect: {
+				ja: "おたがいのバトルポケモンについているエネルギーの数x30ダメージ。",
+			},
+		},
+		{
+			name: { ja: "トワイライトGX" },
+			cost: ["Fairy"],
+			effect: {
+				ja: "自分のトラッシュにある好きなカードを10枚、相手に見せてから、山札にもどして切る。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [{ type: "Darkness", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 561038,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "キルリア",
+	},
+
+	retreat: 2,
+	rarity: "Double rare",
+	dexId: [282],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM3N/039.ts
+++ b/data-asia/SM/SM3N/039.ts
@@ -1,0 +1,46 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM3N";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ネマシュ",
+	},
+
+	illustrator: "Hitoshi Ariga",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Fairy"],
+
+	description: {
+		ja: "点滅しながら 発光する 胞子を あたりに ばら撒く。 その光を 見た者は 深い眠りに おちる。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ぶつかる" },
+			damage: 10,
+			cost: ["Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [{ type: "Darkness", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561039,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [755],
+};
+
+export default card;

--- a/data-asia/SM/SM3N/040.ts
+++ b/data-asia/SM/SM3N/040.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM3N";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "マシェード",
+	},
+
+	illustrator: "Naoki Saito",
+	category: "Pokemon",
+	hp: 100,
+	types: ["Fairy"],
+
+	description: {
+		ja: "夜中に マシェードの棲む 森に いくのは 危険。 怪しい光に 惑わされ 二度と 帰れなくなる。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "ちからをすいとる" },
+			damage: 30,
+			cost: ["Fairy", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンについているエネルギーの数x30ダメージぶん、このポケモンのHPを回復する。",
+			},
+		},
+		{
+			name: { ja: "ねむりのはどう" },
+			damage: 60,
+			cost: ["Fairy", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをねむりにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [{ type: "Darkness", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561040,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ネマシュ",
+	},
+
+	retreat: 2,
+	rarity: "Uncommon",
+	dexId: [756],
+};
+
+export default card;

--- a/data-asia/SM/SM3N/041.ts
+++ b/data-asia/SM/SM3N/041.ts
@@ -1,0 +1,54 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM3N";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ジガルデ",
+	},
+
+	illustrator: "Masakazu Fukuda",
+	category: "Pokemon",
+	hp: 150,
+	types: ["Dragon"],
+
+	description: {
+		ja: "生態系を 脅かす者を 圧倒的な 力を 以て 制圧する ジガルデの 姿。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ランドクラッシュ" },
+			damage: 80,
+			cost: ["Colorless", "Colorless", "Colorless"],
+		},
+		{
+			name: { ja: "コアパニッシャー" },
+			damage: 150,
+			cost: ["Darkness", "Fairy", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンについている[悪]エネルギーと[妖]エネルギーを、1個ずつトラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fairy", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 561041,
+			},
+		},
+	],
+
+	retreat: 4,
+	rarity: "Rare",
+	dexId: [718],
+};
+
+export default card;

--- a/data-asia/SM/SM3N/042.ts
+++ b/data-asia/SM/SM3N/042.ts
@@ -1,0 +1,53 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM3N";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ポリゴン",
+	},
+
+	illustrator: "Shin Nagasawa",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Colorless"],
+
+	description: {
+		ja: "およそ ２０年前に 当時の 科学力を 結集し 生みだされた 人工の ポケモン。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "コードチェック" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "ウラになっている相手のサイドを1枚選び、そのカードのオモテを見てから、もとにもどす。",
+			},
+		},
+		{
+			name: { ja: "ビーム" },
+			damage: 10,
+			cost: ["Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561042,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [137],
+};
+
+export default card;

--- a/data-asia/SM/SM3N/043.ts
+++ b/data-asia/SM/SM3N/043.ts
@@ -1,0 +1,57 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM3N";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ポリゴン2",
+	},
+
+	illustrator: "Midori Harada",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Colorless"],
+
+	description: {
+		ja: "惑星 開発を 視野に 入れ 当時の 最新技術で ポリゴンを アップデートしたのだ。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "けいさん" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札を上から6枚見て、好きな順番に入れ替えて、山札の上にもどす。",
+			},
+		},
+		{
+			name: { ja: "ビーム" },
+			damage: 40,
+			cost: ["Colorless", "Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561043,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ポリゴン",
+	},
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [233],
+};
+
+export default card;

--- a/data-asia/SM/SM3N/044.ts
+++ b/data-asia/SM/SM3N/044.ts
@@ -1,0 +1,63 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM3N";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ポリゴンZ",
+	},
+
+	illustrator: "MAHOU",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Colorless"],
+
+	description: {
+		ja: "さらに 優れた ポケモンを 目指し 追加した プログラムに 不具合が あったらしく 動きが おかしい。",
+	},
+
+	stage: "Stage2",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "しょきか" },
+			effect: {
+				ja: "自分の番に、このカードを手札から出して進化させたとき、1回使える。相手の進化しているポケモン全員の上から、それぞれ「進化カード」を1枚はがして退化させる。はがしたカードは、相手の手札にもどす。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "でんじほう" },
+			damage: 80,
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "次の自分の番、このポケモンは「でんじほう」が使えない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 561044,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ポリゴン２",
+	},
+
+	retreat: 2,
+	rarity: "Rare",
+	dexId: [474],
+};
+
+export default card;

--- a/data-asia/SM/SM3N/045.ts
+++ b/data-asia/SM/SM3N/045.ts
@@ -1,0 +1,53 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM3N";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヌイコグマ",
+	},
+
+	illustrator: "Sekio",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Colorless"],
+
+	description: {
+		ja: "愛くるしい 見た目だが 怒って ジタバタする 手足に ぶつかると プロレスラーでも 吹っ飛ばされる。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "つぶらなひとみ" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "次の相手の番、このワザを受けたポケモンは、にげられない。",
+			},
+		},
+		{
+			name: { ja: "たいあたり" },
+			damage: 20,
+			cost: ["Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561045,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Common",
+	dexId: [759],
+};
+
+export default card;

--- a/data-asia/SM/SM3N/046.ts
+++ b/data-asia/SM/SM3N/046.ts
@@ -1,0 +1,60 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM3N";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "キテルグマ",
+	},
+
+	illustrator: "Mitsuhiro Arita",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Colorless"],
+
+	description: {
+		ja: "圧倒的な 筋力を 持つ 非常に 危険な ポケモン。 生息地は 基本 立ち入り禁止。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "かきみだす" },
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "コインを1回投げオモテなら、相手の山札を上から3枚トラッシュする。",
+			},
+		},
+		{
+			name: { ja: "あばれまわる" },
+			damage: 120,
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンをこんらんにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561046,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ヌイコグマ",
+	},
+
+	retreat: 2,
+	rarity: "Uncommon",
+	dexId: [760],
+};
+
+export default card;

--- a/data-asia/SM/SM3N/047.ts
+++ b/data-asia/SM/SM3N/047.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM3N";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "いちゃもんスプレー",
+	},
+
+	illustrator: "Toyste Beach",
+	category: "Trainer",
+
+	effect: {
+		ja: "相手の手札からオモテを見ないで1枚選び、オモテを見る。そのカードがサポートなら、トラッシュする。サポートでないなら、もとの手札にもどす。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561047,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM3N/048.ts
+++ b/data-asia/SM/SM3N/048.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM3N";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "スーパーポケモン回収",
+	},
+
+	illustrator: "Toyste Beach",
+	category: "Trainer",
+
+	effect: {
+		ja: "コインを1回投げオモテなら、自分のポケモン1匹と、ついているすべてのカードを、手札にもどす。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561048,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM3N/049.ts
+++ b/data-asia/SM/SM3N/049.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM3N";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "グズマ",
+	},
+
+	illustrator: "Ken Sugimori",
+	category: "Trainer",
+
+	effect: {
+		ja: "相手のベンチポケモンを1匹選び、バトルポケモンと入れ替える。その後、自分のバトルポケモンをベンチポケモンと入れ替える。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561049,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM3N/050.ts
+++ b/data-asia/SM/SM3N/050.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM3N";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ビッケ",
+	},
+
+	illustrator: "take",
+	category: "Trainer",
+
+	effect: {
+		ja: "おたがいのプレイヤーは、それぞれ自分の手札を数えたあと、すべて山札にもどして切る。その後、おたがいのプレイヤーは、それぞれもどした枚数ぶん山札を引く。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561050,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM3N/051.ts
+++ b/data-asia/SM/SM3N/051.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM3N";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ポータウン",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Trainer",
+
+	effect: {
+		ja: "おたがいのプレイヤーが、それぞれ手札からポケモンを出して進化させるたび、そのポケモンにダメカンを3個のせる。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561051,
+			},
+		},
+	],
+
+	trainerType: "Stadium",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM3N/052.ts
+++ b/data-asia/SM/SM3N/052.ts
@@ -1,0 +1,67 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM3N";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "グソクムシャGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 210,
+	types: ["Grass"],
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "であいがしら" },
+			damage: "30+",
+			cost: ["Grass"],
+			effect: {
+				ja: "この番、このポケモンがベンチからバトル場に出ていたなら、90ダメージ追加。",
+			},
+		},
+		{
+			name: { ja: "アーマープレス" },
+			damage: 100,
+			cost: ["Grass", "Colorless", "Colorless"],
+			effect: {
+				ja: "次の相手の番、このポケモンが受けるワザのダメージは「-20」される。",
+			},
+		},
+		{
+			name: { ja: "ザンクロスGX" },
+			damage: 150,
+			cost: ["Grass", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンをベンチポケモンと入れ替える。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 561052,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "コソクムシ",
+	},
+
+	retreat: 3,
+	rarity: "Ultra Rare",
+	dexId: [768],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM3N/053.ts
+++ b/data-asia/SM/SM3N/053.ts
@@ -1,0 +1,64 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM3N";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ネクロズマGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 180,
+	types: ["Psychic"],
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ひかりのおわり" },
+			effect: {
+				ja: "このポケモンは[無]ポケモンから、ワザのダメージを受けない。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "プリズムバースト" },
+			damage: "10+",
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンについている[超]エネルギーをすべてトラッシュし、その枚数x60ダメージ追加。",
+			},
+		},
+		{
+			name: { ja: "ブラックレイGX" },
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手の「ポケモンGX・EX」全員に、それぞれ100ダメージ。このワザのダメージは弱点・抵抗力を計算しない。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 561053,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Ultra Rare",
+	dexId: [800],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM3N/054.ts
+++ b/data-asia/SM/SM3N/054.ts
@@ -1,0 +1,62 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM3N";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "マーシャドーGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 150,
+	types: ["Fighting"],
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "シャドーハント" },
+			effect: {
+				ja: "このポケモンは、自分のトラッシュにあるたねポケモンが持っているワザを、すべて使える。［ワザを使うためのエネルギーは必要。］",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "せいけんづき" },
+			damage: 120,
+			cost: ["Fighting", "Fighting", "Colorless"],
+		},
+		{
+			name: { ja: "ひゃくれつむそうGX" },
+			damage: "50×",
+			cost: ["Fighting"],
+			effect: {
+				ja: "このポケモンについている基本エネルギーの数x50ダメージ。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 561054,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Ultra Rare",
+	dexId: [802],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM3N/055.ts
+++ b/data-asia/SM/SM3N/055.ts
@@ -1,0 +1,68 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM3N";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "サーナイトGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 230,
+	types: ["Fairy"],
+
+	stage: "Stage2",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ひみつのいずみ" },
+			effect: {
+				ja: "自分の番に1回使える。自分の手札にある[妖]エネルギーを1枚、自分のポケモンにつける。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "インフィニットフォース" },
+			damage: "30×",
+			cost: ["Fairy"],
+			effect: {
+				ja: "おたがいのバトルポケモンについているエネルギーの数x30ダメージ。",
+			},
+		},
+		{
+			name: { ja: "トワイライトGX" },
+			cost: ["Fairy"],
+			effect: {
+				ja: "自分のトラッシュにある好きなカードを10枚、相手に見せてから、山札にもどして切る。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [{ type: "Darkness", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 561055,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "キルリア",
+	},
+
+	retreat: 2,
+	rarity: "Ultra Rare",
+	dexId: [282],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM3N/056.ts
+++ b/data-asia/SM/SM3N/056.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM3N";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "グズマ",
+	},
+
+	illustrator: "Masakazu Fukuda",
+	category: "Trainer",
+
+	effect: {
+		ja: "相手のベンチポケモンを1匹選び、バトルポケモンと入れ替える。その後、自分のバトルポケモンをベンチポケモンと入れ替える。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 561056,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	rarity: "Ultra Rare",
+};
+
+export default card;

--- a/data-asia/SM/SM3N/057.ts
+++ b/data-asia/SM/SM3N/057.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM3N";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ビッケ",
+	},
+
+	illustrator: "Naoki Saito",
+	category: "Trainer",
+
+	effect: {
+		ja: "おたがいのプレイヤーは、それぞれ自分の手札を数えたあと、すべて山札にもどして切る。その後、おたがいのプレイヤーは、それぞれもどした枚数ぶん山札を引く。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 561057,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	rarity: "Ultra Rare",
+};
+
+export default card;

--- a/data-asia/SM/SM3N/058.ts
+++ b/data-asia/SM/SM3N/058.ts
@@ -1,0 +1,67 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM3N";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "グソクムシャGX",
+	},
+
+	illustrator: "",
+	category: "Pokemon",
+	hp: 210,
+	types: ["Grass"],
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "であいがしら" },
+			damage: "30+",
+			cost: ["Grass"],
+			effect: {
+				ja: "この番、このポケモンがベンチからバトル場に出ていたなら、90ダメージ追加。",
+			},
+		},
+		{
+			name: { ja: "アーマープレス" },
+			damage: 100,
+			cost: ["Grass", "Colorless", "Colorless"],
+			effect: {
+				ja: "次の相手の番、このポケモンが受けるワザのダメージは「-20」される。",
+			},
+		},
+		{
+			name: { ja: "ザンクロスGX" },
+			damage: 150,
+			cost: ["Grass", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンをベンチポケモンと入れ替える。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 561058,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "コソクムシ",
+	},
+
+	retreat: 3,
+	rarity: "Hyper rare",
+	dexId: [768],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM3N/059.ts
+++ b/data-asia/SM/SM3N/059.ts
@@ -1,0 +1,64 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM3N";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ネクロズマGX",
+	},
+
+	illustrator: "",
+	category: "Pokemon",
+	hp: 180,
+	types: ["Psychic"],
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ひかりのおわり" },
+			effect: {
+				ja: "このポケモンは[無]ポケモンから、ワザのダメージを受けない。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "プリズムバースト" },
+			damage: "10+",
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンについている[超]エネルギーをすべてトラッシュし、その枚数x60ダメージ追加。",
+			},
+		},
+		{
+			name: { ja: "ブラックレイGX" },
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手の「ポケモンGX・EX」全員に、それぞれ100ダメージ。このワザのダメージは弱点・抵抗力を計算しない。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 561059,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Hyper rare",
+	dexId: [800],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM3N/060.ts
+++ b/data-asia/SM/SM3N/060.ts
@@ -1,0 +1,62 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM3N";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "マーシャドーGX",
+	},
+
+	illustrator: "",
+	category: "Pokemon",
+	hp: 150,
+	types: ["Fighting"],
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "シャドーハント" },
+			effect: {
+				ja: "このポケモンは、自分のトラッシュにあるたねポケモンが持っているワザを、すべて使える。［ワザを使うためのエネルギーは必要。］",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "せいけんづき" },
+			damage: 120,
+			cost: ["Fighting", "Fighting", "Colorless"],
+		},
+		{
+			name: { ja: "ひゃくれつむそうGX" },
+			damage: "50×",
+			cost: ["Fighting"],
+			effect: {
+				ja: "このポケモンについている基本エネルギーの数x50ダメージ。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 561060,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Hyper rare",
+	dexId: [802],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM3N/061.ts
+++ b/data-asia/SM/SM3N/061.ts
@@ -1,0 +1,68 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM3N";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "サーナイトGX",
+	},
+
+	illustrator: "",
+	category: "Pokemon",
+	hp: 230,
+	types: ["Fairy"],
+
+	stage: "Stage2",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ひみつのいずみ" },
+			effect: {
+				ja: "自分の番に1回使える。自分の手札にある[妖]エネルギーを1枚、自分のポケモンにつける。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "インフィニットフォース" },
+			damage: "30×",
+			cost: ["Fairy"],
+			effect: {
+				ja: "おたがいのバトルポケモンについているエネルギーの数x30ダメージ。",
+			},
+		},
+		{
+			name: { ja: "トワイライトGX" },
+			cost: ["Fairy"],
+			effect: {
+				ja: "自分のトラッシュにある好きなカードを10枚、相手に見せてから、山札にもどして切る。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [{ type: "Darkness", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 561061,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "キルリア",
+	},
+
+	retreat: 2,
+	rarity: "Hyper rare",
+	dexId: [282],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM3N/062.ts
+++ b/data-asia/SM/SM3N/062.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM3N";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "スーパーポケモン回収",
+	},
+
+	illustrator: "",
+	category: "Trainer",
+
+	effect: {
+		ja: "コインを1回投げオモテなら、自分のポケモン1匹と、ついているすべてのカードを、手札にもどす。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 561062,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	rarity: "Secret Rare",
+};
+
+export default card;

--- a/data-asia/SM/SM3N/063.ts
+++ b/data-asia/SM/SM3N/063.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM3N";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "レスキュータンカ",
+	},
+
+	illustrator: "",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分のトラッシュにあるポケモンを1枚、相手に見せてから、手札に加える。または、自分のトラッシュにあるポケモンを3枚、相手に見せてから、山札にもどして切る。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 561063,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	rarity: "Secret Rare",
+};
+
+export default card;

--- a/data-asia/SM/SM3N/064.ts
+++ b/data-asia/SM/SM3N/064.ts
@@ -1,0 +1,26 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM3N";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "基本フェアリーエネルギー",
+	},
+
+	illustrator: "",
+	category: "Energy",
+	energyType: "Normal",
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 561064,
+			},
+		},
+	],
+
+	rarity: "Secret Rare",
+};
+
+export default card;


### PR DESCRIPTION
## What

Adds the complete Japanese set **SM3N 光を喰らう闇 (Light Consuming Darkness)**, released 2017-06-16:

- `data-asia/SM/SM3N/001.ts` … `064.ts` — all 64 cards (51 regular + 13 secret rares: 6 SR, 3 Secret Rare, 4 UR)
- the set definition `data-asia/SM/SM3N.ts` already existed and is untouched

## Data sources

- **pokemon-card.com** (official database): Japanese names, flavor texts, National Dex numbers, official card count
- **limitlesstcg.com**: full Japanese card text, stages, weaknesses/resistances/retreat, rarities, illustrators, attack costs
- **Cardmarket**: product IDs as `thirdParty.cardmarket` on the variant objects (561001–561064; tcgplayer IDs not available to me)

## Notes

- Follows the file format and conventions of the M-era sets (#1728)
- No `regulationMark` (the set predates regulation marks); resistances are `-20` per the era
- All 64 files type-check against `interfaces.d.ts` (`tsc --noEmit`)
