### PR TITLE
(data) Add Japanese SM set SM3p Shining Legends

### DIFF
--- a/data-asia/SM/SM3p.ts
+++ b/data-asia/SM/SM3p.ts
@@ -1,0 +1,20 @@
+import { Set } from "../../interfaces";
+import serie from "../SM";
+
+const set: Set = {
+	id: "SM3p",
+	name: {
+		ja: "ひかる伝説",
+	},
+
+	serie: serie,
+
+	cardCount: {
+		official: 72,
+	},
+	releaseDate: {
+		ja: "2017-07-15",
+	},
+};
+
+export default set;

--- a/data-asia/SM/SM3p/001.ts
+++ b/data-asia/SM/SM3p/001.ts
@@ -1,0 +1,46 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM3p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "フシギダネ",
+	},
+
+	illustrator: "Mizue",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Grass"],
+
+	description: {
+		ja: "生まれたときから 背中に 不思議な タネが 植えてあって 体と ともに 育つという。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "はっぱカッター" },
+			damage: 30,
+			cost: ["Grass", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560159,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Common",
+	dexId: [1],
+};
+
+export default card;

--- a/data-asia/SM/SM3p/002.ts
+++ b/data-asia/SM/SM3p/002.ts
@@ -1,0 +1,58 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM3p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "フシギソウ",
+	},
+
+	illustrator: "Kouki Saitou",
+	category: "Pokemon",
+	hp: 100,
+	types: ["Grass"],
+
+	description: {
+		ja: "つぼみが 背中に ついていて 養分を 吸収していくと 大きな 花が 咲くという。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "はっぱカッター" },
+			damage: 30,
+			cost: ["Grass", "Colorless"],
+		},
+		{
+			name: { ja: "もうどくのムチ" },
+			damage: 50,
+			cost: ["Grass", "Grass", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをどくとこんらんにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560160,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "フシギダネ",
+	},
+
+	retreat: 4,
+	rarity: "Common",
+	dexId: [2],
+};
+
+export default card;

--- a/data-asia/SM/SM3p/003.ts
+++ b/data-asia/SM/SM3p/003.ts
@@ -1,0 +1,60 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM3p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "フシギバナ",
+	},
+
+	illustrator: "Eske Yoshinob",
+	category: "Pokemon",
+	hp: 160,
+	types: ["Grass"],
+
+	description: {
+		ja: "大きな 花びらを 広げ 太陽の 光を 浴びていると 体に 元気が みなぎっていく。",
+	},
+
+	stage: "Stage2",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "みつりんのぬし" },
+			effect: {
+				ja: "このポケモンがいるかぎり、自分の場のポケモンについているすべての基本[草]エネルギーは、それぞれ[草]エネルギー2個ぶんとしてはたらく。この効果は、この特性を持つポケモンが何匹いても、重ならない。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ソーラービーム" },
+			damage: 90,
+			cost: ["Grass", "Grass", "Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560161,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "フシギソウ",
+	},
+
+	retreat: 4,
+	rarity: "Uncommon",
+	dexId: [3],
+};
+
+export default card;

--- a/data-asia/SM/SM3p/004.ts
+++ b/data-asia/SM/SM3p/004.ts
@@ -1,0 +1,56 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM3p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ひかるセレビィ",
+	},
+
+	illustrator: "Sanosuke Sakuma",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Grass"],
+
+	description: {
+		ja: "時間を超えて あちこち さまよう。 セレビィが 姿を 現した 森は 草木が 生い茂るという。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "タイムリコール" },
+			effect: {
+				ja: "このポケモンがいるかぎり、自分の進化しているポケモン全員は、進化前に持っていたワザを、すべて使える。［ワザを使うためのエネルギーは必要。］",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "リーフステップ" },
+			damage: 30,
+			cost: ["Grass", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 560162,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Shiny Ultra Rare",
+	dexId: [251],
+};
+
+export default card;

--- a/data-asia/SM/SM3p/005.ts
+++ b/data-asia/SM/SM3p/005.ts
@@ -1,0 +1,49 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM3p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "キノココ",
+	},
+
+	illustrator: "kawayoo",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Grass"],
+
+	description: {
+		ja: "湿った 場所を 好み 昼間は 森の 木陰で じっと している。 頭から 毒の 粉を 出す。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "すいとる" },
+			damage: 20,
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンのHPを「20」回復する。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560163,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [285],
+};
+
+export default card;

--- a/data-asia/SM/SM3p/006.ts
+++ b/data-asia/SM/SM3p/006.ts
@@ -1,0 +1,57 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM3p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "キノガッサ",
+	},
+
+	illustrator: "Mizue",
+	category: "Pokemon",
+	hp: 110,
+	types: ["Grass"],
+
+	description: {
+		ja: "短い 腕は パンチを 出すとき グーンと 伸びる。 プロボクサー 顔負けの テクニックを 持つ。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "じゅくすいほうし" },
+			cost: ["Grass"],
+			effect: {
+				ja: "相手のバトルポケモンをねむりにする。このねむりで投げるコインは2回になり、すべてオモテが出ないと回復しない。",
+			},
+		},
+		{
+			name: { ja: "マグナムパンチ" },
+			damage: 80,
+			cost: ["Colorless", "Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560164,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "キノココ",
+	},
+
+	retreat: 2,
+	rarity: "Uncommon",
+	dexId: [286],
+};
+
+export default card;

--- a/data-asia/SM/SM3p/007.ts
+++ b/data-asia/SM/SM3p/007.ts
@@ -1,0 +1,56 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM3p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "マスキッパ",
+	},
+
+	illustrator: "Tomokazu Komiya",
+	category: "Pokemon",
+	hp: 100,
+	types: ["Grass"],
+
+	description: {
+		ja: "甘い においの だえきで 獲物を おびき寄せ おおあごで がぶり。 １日 かけて 獲物を 食べる。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "さそいどく" },
+			cost: ["Grass"],
+			effect: {
+				ja: "相手のベンチポケモンを1匹選び、バトルポケモンと入れ替える。その後、新しく出てきたポケモンをどくにする。",
+			},
+		},
+		{
+			name: { ja: "かみくだく" },
+			damage: 30,
+			cost: ["Grass", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンについているエネルギーを、1個トラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560165,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Uncommon",
+	dexId: [455],
+};
+
+export default card;

--- a/data-asia/SM/SM3p/008.ts
+++ b/data-asia/SM/SM3p/008.ts
@@ -1,0 +1,56 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM3p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "シェイミ",
+	},
+
+	illustrator: "Mizue",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Grass"],
+
+	description: {
+		ja: "大気の 毒素を 分解して 荒れた 大地を 一瞬のうちに 花畑にする 力を 持つ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ぱたぱた" },
+			cost: ["Grass"],
+			effect: {
+				ja: "自分の手札をすべて山札にもどして切る。その後、山札を6枚引く。",
+			},
+		},
+		{
+			name: { ja: "まきかえす" },
+			damage: "30+",
+			cost: ["Grass", "Colorless"],
+			effect: {
+				ja: "前の相手の番に、ワザのダメージで、自分のポケモンがきぜつしていたなら、90ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 560166,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Rare",
+	dexId: [492],
+};
+
+export default card;

--- a/data-asia/SM/SM3p/009.ts
+++ b/data-asia/SM/SM3p/009.ts
@@ -1,0 +1,57 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM3p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ビリジオン",
+	},
+
+	illustrator: "kawayoo",
+	category: "Pokemon",
+	hp: 110,
+	types: ["Grass"],
+
+	description: {
+		ja: "頭の ツノは 鋭い 刃。 旋風のような 動きで 敵を 翻弄して 素早く 切りつける。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "かぜをまとう" },
+			damage: 30,
+			cost: ["Grass"],
+			effect: {
+				ja: "のぞむなら、自分の手札にある基本エネルギーを1枚、このポケモンにつける。",
+			},
+		},
+		{
+			name: { ja: "ロングスピア" },
+			damage: 90,
+			cost: ["Grass", "Grass", "Colorless"],
+			effect: {
+				ja: "相手のベンチポケモン1匹にも、30ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 560167,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Rare",
+	dexId: [640],
+};
+
+export default card;

--- a/data-asia/SM/SM3p/010.ts
+++ b/data-asia/SM/SM3p/010.ts
@@ -1,0 +1,59 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM3p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ひかるゲノセクト",
+	},
+
+	illustrator: "Hitoshi Ariga",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Grass"],
+
+	description: {
+		ja: "プラズマ団によって 改造された 古代の むしポケモン。 背中の 大砲が パワーアップした。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "エナジーリロード" },
+			effect: {
+				ja: "自分の番に1回使える。自分の場のポケモンについている[草]エネルギーを1個、このポケモンにつけ替える。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ガイブラスター" },
+			damage: "50+",
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンについている[草]エネルギーの数x20ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 560168,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Shiny Ultra Rare",
+	dexId: [649],
+};
+
+export default card;

--- a/data-asia/SM/SM3p/011.ts
+++ b/data-asia/SM/SM3p/011.ts
@@ -1,0 +1,59 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM3p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "エンテイGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 180,
+	types: ["Fire"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "かえん" },
+			damage: 50,
+			cost: ["Fire", "Colorless"],
+		},
+		{
+			name: { ja: "ほのおのキバ" },
+			damage: 100,
+			cost: ["Fire", "Fire", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをやけどにする。",
+			},
+		},
+		{
+			name: { ja: "ブレイブバーンGX" },
+			cost: ["Fire", "Fire", "Colorless"],
+			effect: {
+				ja: "相手のベンチポケモン1匹に、150ダメージ。［ベンチは弱点・抵抗力を計算しない。］［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 560169,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Double rare",
+	dexId: [244],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM3p/012.ts
+++ b/data-asia/SM/SM3p/012.ts
@@ -1,0 +1,57 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM3p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "コータス",
+	},
+
+	illustrator: "Suwama Chiaki",
+	category: "Pokemon",
+	hp: 110,
+	types: ["Fire"],
+
+	description: {
+		ja: "石炭が エネルギーの 源。 コータスの 棲んでいる 山には 多くの 石炭が 眠っている。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "こうあつねつ" },
+			damage: 30,
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "次の自分の番、このポケモンの「こうあつねつ」のダメージは「+50」される。",
+			},
+		},
+		{
+			name: { ja: "かえんほうしゃ" },
+			damage: 90,
+			cost: ["Fire", "Fire", "Colorless"],
+			effect: {
+				ja: "このポケモンについているエネルギーを、1個トラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560170,
+			},
+		},
+	],
+
+	retreat: 3,
+	rarity: "Uncommon",
+	dexId: [324],
+};
+
+export default card;

--- a/data-asia/SM/SM3p/013.ts
+++ b/data-asia/SM/SM3p/013.ts
@@ -1,0 +1,46 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM3p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "メラルバ",
+	},
+
+	illustrator: "kawayoo",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Fire"],
+
+	description: {
+		ja: "太陽から 生まれたと いわれる。 進化するとき ツノから 噴き出した 炎で 全身を 包みこむ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ほのお" },
+			damage: 30,
+			cost: ["Fire", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560171,
+			},
+		},
+	],
+
+	retreat: 3,
+	rarity: "Common",
+	dexId: [636],
+};
+
+export default card;

--- a/data-asia/SM/SM3p/014.ts
+++ b/data-asia/SM/SM3p/014.ts
@@ -1,0 +1,60 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM3p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ウルガモス",
+	},
+
+	illustrator: "nagimiso",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Fire"],
+
+	description: {
+		ja: "戦いになると ６枚の 羽から 火の粉の りんぷんを まき散らして あたり 一面を 火の海にする。",
+	},
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "あついせんぷう" },
+			effect: {
+				ja: "自分の番に1回使える。相手のバトルポケモンをベンチポケモンと入れ替える。［バトル場に出すポケモンは相手が選ぶ。］",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ヒートブラスト" },
+			damage: 60,
+			cost: ["Fire", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560172,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "メラルバ",
+	},
+
+	retreat: 1,
+	rarity: "Uncommon",
+	dexId: [637],
+};
+
+export default card;

--- a/data-asia/SM/SM3p/015.ts
+++ b/data-asia/SM/SM3p/015.ts
@@ -1,0 +1,57 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM3p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "レシラム",
+	},
+
+	illustrator: "TOKIYA",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Fire"],
+
+	description: {
+		ja: "炎で 世界を 燃やしつくせる 伝説の ポケモン。 真実の 世界を 築く 人を 助ける。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "げきりん" },
+			damage: "20+",
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンにのっているダメカンの数x10ダメージ追加。",
+			},
+		},
+		{
+			name: { ja: "しゃくねつのいぶき" },
+			damage: 130,
+			cost: ["Fire", "Fire", "Colorless"],
+			effect: {
+				ja: "次の自分の番、このポケモンはワザが使えない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 560173,
+			},
+		},
+	],
+
+	retreat: 3,
+	rarity: "Rare",
+	dexId: [643],
+};
+
+export default card;

--- a/data-asia/SM/SM3p/016.ts
+++ b/data-asia/SM/SM3p/016.ts
@@ -1,0 +1,46 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM3p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ニャビー",
+	},
+
+	illustrator: "Mitsuhiro Arita",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Fire"],
+
+	description: {
+		ja: "毛づくろいで お腹に 溜まった 抜け毛を 燃やして 火を 吹く。 毛の 吐きかたで 炎も 変化。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ひだね" },
+			damage: 20,
+			cost: ["Fire"],
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560174,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [725],
+};
+
+export default card;

--- a/data-asia/SM/SM3p/017.ts
+++ b/data-asia/SM/SM3p/017.ts
@@ -1,0 +1,57 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM3p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ニャヒート",
+	},
+
+	illustrator: "Shin Nagasawa",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Fire"],
+
+	description: {
+		ja: "首の 付け根に 炎の 鈴が ある。 炎が 噴きだすとき リンリンと 高い音が 鳴る。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "いばる" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "コインを1回投げオモテなら、相手のバトルポケモンについているエネルギーを、1個トラッシュする。",
+			},
+		},
+		{
+			name: { ja: "ほのおのツメ" },
+			damage: 30,
+			cost: ["Fire", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560175,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ニャビー",
+	},
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [726],
+};
+
+export default card;

--- a/data-asia/SM/SM3p/018.ts
+++ b/data-asia/SM/SM3p/018.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM3p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ガオガエン",
+	},
+
+	illustrator: "Emi Ando",
+	category: "Pokemon",
+	hp: 170,
+	types: ["Fire"],
+
+	description: {
+		ja: "粗暴で 身勝手な 性格。 気分が 乗らなければ トレーナーの 命令も 平気で 無視するぞ。",
+	},
+
+	stage: "Stage2",
+
+	attacks: [
+		{
+			name: { ja: "ガッデムパンチ" },
+			damage: "50+",
+			cost: ["Fire", "Colorless"],
+			effect: {
+				ja: "自分のベンチポケモンにダメカンがのっているなら、80ダメージ追加。",
+			},
+		},
+		{
+			name: { ja: "フレアドライブ" },
+			damage: 180,
+			cost: ["Fire", "Fire", "Colorless"],
+			effect: {
+				ja: "このポケモンについている[炎]エネルギーを、すべてトラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560176,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ニャヒート",
+	},
+
+	retreat: 2,
+	rarity: "Uncommon",
+	dexId: [727],
+};
+
+export default card;

--- a/data-asia/SM/SM3p/019.ts
+++ b/data-asia/SM/SM3p/019.ts
@@ -1,0 +1,51 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM3p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ワニノコ",
+	},
+
+	illustrator: "TOKIYA",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Water"],
+
+	description: {
+		ja: "小さいながらも 暴れん坊。 目の前で 動くものが あれば とにかく かみついてくる。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "みずでっぽう" },
+			damage: 10,
+			cost: ["Water"],
+		},
+		{
+			name: { ja: "かみつく" },
+			damage: 20,
+			cost: ["Water", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560177,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [158],
+};
+
+export default card;

--- a/data-asia/SM/SM3p/020.ts
+++ b/data-asia/SM/SM3p/020.ts
@@ -1,0 +1,60 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM3p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アリゲイツ",
+	},
+
+	illustrator: "Naoki Saito",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Water"],
+
+	description: {
+		ja: "キバは 抜けても 次から 次に 生えてくる。 いつも 口の中には ４８本の キバが そろっている。",
+	},
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "とびこむ" },
+			effect: {
+				ja: "このポケモンがベンチにいるなら、自分の番に1回使える。自分のバトルポケモンについているエネルギーをすべて、このポケモンにつけ替える。つけ替えた場合、このポケモンをバトルポケモンと入れ替える。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "かみつく" },
+			damage: 60,
+			cost: ["Water", "Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560178,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ワニノコ",
+	},
+
+	retreat: 3,
+	rarity: "Common",
+	dexId: [159],
+};
+
+export default card;

--- a/data-asia/SM/SM3p/021.ts
+++ b/data-asia/SM/SM3p/021.ts
@@ -1,0 +1,58 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM3p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "オーダイル",
+	},
+
+	illustrator: "nagimiso",
+	category: "Pokemon",
+	hp: 160,
+	types: ["Water"],
+
+	description: {
+		ja: "普段は ゆっくりとした 動きだが 獲物に かみつくときは 目にも 止まらない スピードだ。",
+	},
+
+	stage: "Stage2",
+
+	attacks: [
+		{
+			name: { ja: "かみくだく" },
+			damage: 80,
+			cost: ["Water", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンについているエネルギーを、1個トラッシュする。",
+			},
+		},
+		{
+			name: { ja: "ハイドロスプラッシュ" },
+			damage: 130,
+			cost: ["Water", "Colorless", "Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560179,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "アリゲイツ",
+	},
+
+	retreat: 3,
+	rarity: "Uncommon",
+	dexId: [160],
+};
+
+export default card;

--- a/data-asia/SM/SM3p/022.ts
+++ b/data-asia/SM/SM3p/022.ts
@@ -1,0 +1,56 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM3p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ハリーセン",
+	},
+
+	illustrator: "Shin Nagasawa",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Water"],
+
+	description: {
+		ja: "全身の 毒針を 飛ばすため １０リットルの 水を 一気に 飲みこみ 体を ふくらませる。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "どくばり" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをどくにする。",
+			},
+		},
+		{
+			name: { ja: "ショックばり" },
+			damage: "20+",
+			cost: ["Water", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンが特殊状態なら、50ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560180,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [211],
+};
+
+export default card;

--- a/data-asia/SM/SM3p/023.ts
+++ b/data-asia/SM/SM3p/023.ts
@@ -1,0 +1,51 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM3p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ブイゼル",
+	},
+
+	illustrator: "Sekio",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Water"],
+
+	description: {
+		ja: "２本の 尻尾を スクリューの ように 回して 泳ぐ。 潜る ときは 浮き袋が しぼむ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ひれカッター" },
+			damage: 10,
+			cost: ["Colorless"],
+		},
+		{
+			name: { ja: "みずでっぽう" },
+			damage: 40,
+			cost: ["Water", "Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560181,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [418],
+};
+
+export default card;

--- a/data-asia/SM/SM3p/024.ts
+++ b/data-asia/SM/SM3p/024.ts
@@ -1,0 +1,58 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM3p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "フローゼル",
+	},
+
+	illustrator: "Suwama Chiaki",
+	category: "Pokemon",
+	hp: 100,
+	types: ["Water"],
+
+	description: {
+		ja: "発達した 浮き袋で 浮かぶ。 おぼれた 人を 救助する 手伝いを している ポケモンだ。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "ひれカッター" },
+			damage: 20,
+			cost: ["Colorless"],
+		},
+		{
+			name: { ja: "アクアボム" },
+			damage: 120,
+			cost: ["Water", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンにも30ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560182,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ブイゼル",
+	},
+
+	retreat: 1,
+	rarity: "Uncommon",
+	dexId: [419],
+};
+
+export default card;

--- a/data-asia/SM/SM3p/025.ts
+++ b/data-asia/SM/SM3p/025.ts
@@ -1,0 +1,54 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM3p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "パルキア",
+	},
+
+	illustrator: "Eske Yoshinob",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Water"],
+
+	description: {
+		ja: "並行して 並ぶ 空間の 狭間に 住むと 言われている。 神話に 登場する ポケモン。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "スパイラルドレイン" },
+			damage: 30,
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンのHPを「30」回復する。",
+			},
+		},
+		{
+			name: { ja: "アクアブレード" },
+			damage: 100,
+			cost: ["Water", "Water", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 560183,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Rare",
+	dexId: [484],
+};
+
+export default card;

--- a/data-asia/SM/SM3p/026.ts
+++ b/data-asia/SM/SM3p/026.ts
@@ -1,0 +1,56 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM3p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "マナフィ",
+	},
+
+	illustrator: "Kagemaru Himeno",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Water"],
+
+	description: {
+		ja: "生まれたときから 備わっている 不思議な 力を 使うと どんな ポケモンとも 心が 通い合う。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "しんかいのめぐみ" },
+			effect: {
+				ja: "自分の番に1回使える。[水]エネルギーがついている自分のポケモン1匹のHPを「20」回復する。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "スプラッシュ" },
+			damage: 30,
+			cost: ["Water", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 560184,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Rare",
+	dexId: [490],
+};
+
+export default card;

--- a/data-asia/SM/SM3p/027.ts
+++ b/data-asia/SM/SM3p/027.ts
@@ -1,0 +1,56 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM3p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ケルディオ",
+	},
+
+	illustrator: "kodama",
+	category: "Pokemon",
+	hp: 110,
+	types: ["Water"],
+
+	description: {
+		ja: "海や 川など 水面を 走り 世界中を 駆け巡る。 美しい 水辺に 現れる。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "すくいだす" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分のトラッシュにある[水]ポケモンを1枚、相手に見せてから、手札に加える。",
+			},
+		},
+		{
+			name: { ja: "かくごのつるぎ" },
+			damage: "20+",
+			cost: ["Water", "Water"],
+			effect: {
+				ja: "相手のベンチポケモンの数x20ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 560185,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Rare",
+	dexId: [647],
+};
+
+export default card;

--- a/data-asia/SM/SM3p/028.ts
+++ b/data-asia/SM/SM3p/028.ts
@@ -1,0 +1,56 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM3p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ひかるボルケニオン",
+	},
+
+	illustrator: "Hitoshi Ariga",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Water"],
+
+	description: {
+		ja: "水蒸気を 噴き出して 自分の 姿を 濃霧で 隠す。 人の 立ち入らない 山に 住むという。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "デュアルポンプ" },
+			cost: ["Water", "Water", "Water"],
+			effect: {
+				ja: "相手のポケモン2匹に、それぞれ50ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+			},
+		},
+		{
+			name: { ja: "グランドスマッシュ" },
+			damage: "50×",
+			cost: ["Colorless", "Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "コインを4回投げ、オモテの数x50ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 560186,
+			},
+		},
+	],
+
+	retreat: 3,
+	rarity: "Shiny Ultra Rare",
+	dexId: [721],
+};
+
+export default card;

--- a/data-asia/SM/SM3p/029.ts
+++ b/data-asia/SM/SM3p/029.ts
@@ -1,0 +1,49 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM3p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ピカチュウ",
+	},
+
+	illustrator: "Kagemaru Himeno",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Lightning"],
+
+	description: {
+		ja: "たくさんの ピカチュウを 集め 発電所を 造る 計画が 最近 発表 された。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "アイアンテール" },
+			damage: "20×",
+			cost: ["Lightning"],
+			effect: {
+				ja: "ウラが出るまでコインを投げ、オモテの数x20ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Metal", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560187,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [25],
+};
+
+export default card;

--- a/data-asia/SM/SM3p/030.ts
+++ b/data-asia/SM/SM3p/030.ts
@@ -1,0 +1,67 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM3p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ライチュウGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 210,
+	types: ["Lightning"],
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "パワフルスパーク" },
+			damage: "20+",
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "自分の場のポケモンについている[雷]エネルギーの数x20ダメージ追加。",
+			},
+		},
+		{
+			name: { ja: "かみなり" },
+			damage: 160,
+			cost: ["Lightning", "Lightning", "Colorless"],
+			effect: {
+				ja: "このポケモンにも30ダメージ。",
+			},
+		},
+		{
+			name: { ja: "ボルテールGX" },
+			damage: 120,
+			cost: ["Lightning", "Lightning", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをマヒにする。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Metal", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 560188,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ピカチュウ",
+	},
+
+	retreat: 1,
+	rarity: "Double rare",
+	dexId: [26],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM3p/031.ts
+++ b/data-asia/SM/SM3p/031.ts
@@ -1,0 +1,46 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM3p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ビリリダマ",
+	},
+
+	illustrator: "match",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Lightning"],
+
+	description: {
+		ja: "モンスターボールが 売り出されたのと 同じ 時期に 発見された。 なにか 関係があると いわれる。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "エレキボール" },
+			damage: 10,
+			cost: ["Lightning"],
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Metal", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560189,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [100],
+};
+
+export default card;

--- a/data-asia/SM/SM3p/032.ts
+++ b/data-asia/SM/SM3p/032.ts
@@ -1,0 +1,53 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM3p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "マルマイン",
+	},
+
+	illustrator: "Kyoko Umemoto",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Lightning"],
+
+	description: {
+		ja: "少しの 刺激に 反応して 爆発する。 バクダンボールという あだ名で 怖がられている。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "スピードスター" },
+			damage: 60,
+			cost: ["Lightning"],
+			effect: {
+				ja: "このワザのダメージは、弱点・抵抗力と、相手のバトルポケモンにかかっている効果を計算しない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Metal", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560190,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ビリリダマ",
+	},
+
+	retreat: 0,
+	rarity: "Uncommon",
+	dexId: [101],
+};
+
+export default card;

--- a/data-asia/SM/SM3p/033.ts
+++ b/data-asia/SM/SM3p/033.ts
@@ -1,0 +1,54 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM3p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ライコウ",
+	},
+
+	illustrator: "Mitsuhiro Arita",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Lightning"],
+
+	description: {
+		ja: "雨雲を 背負っているので どんなときでも 雷を 出せる。 雷とともに 落ちてきたという。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "とどろくらいめい" },
+			damage: 30,
+			cost: ["Lightning"],
+			effect: {
+				ja: "自分のトラッシュにある[雷]エネルギーを1枚、ベンチポケモンにつける。",
+			},
+		},
+		{
+			name: { ja: "ライトニングボール" },
+			damage: 90,
+			cost: ["Lightning", "Lightning", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Metal", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 560191,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Rare",
+	dexId: [243],
+};
+
+export default card;

--- a/data-asia/SM/SM3p/034.ts
+++ b/data-asia/SM/SM3p/034.ts
@@ -1,0 +1,49 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM3p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "プラスル",
+	},
+
+	illustrator: "Tomokazu Komiya",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Lightning"],
+
+	description: {
+		ja: "火花の ボンボンを 作って 仲間を 応援する。 電柱から 電気を 吸い取る。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "タッグブースト" },
+			damage: "10+",
+			cost: ["Lightning"],
+			effect: {
+				ja: "自分のベンチに「マイナン」がいるなら、50ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Metal", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560192,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [311],
+};
+
+export default card;

--- a/data-asia/SM/SM3p/035.ts
+++ b/data-asia/SM/SM3p/035.ts
@@ -1,0 +1,56 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM3p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "マイナン",
+	},
+
+	illustrator: "nagimiso",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Lightning"],
+
+	description: {
+		ja: "マイナンと プラスルの 電気は 血液の 流れを 良くして こりを ほぐす 効果が ある。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "もってくる" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札を1枚引く。",
+			},
+		},
+		{
+			name: { ja: "スパーク" },
+			damage: 20,
+			cost: ["Lightning"],
+			effect: {
+				ja: "相手のベンチポケモン1匹にも、20ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Metal", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560193,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [312],
+};
+
+export default card;

--- a/data-asia/SM/SM3p/036.ts
+++ b/data-asia/SM/SM3p/036.ts
@@ -1,0 +1,57 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM3p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ゼクロム",
+	},
+
+	illustrator: "nagimiso",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Lightning"],
+
+	description: {
+		ja: "稲妻で 世界を 焼きつくせる 伝説の ポケモン。 理想の 世界を つくる 人を 補佐する。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "げきりん" },
+			damage: "20+",
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンにのっているダメカンの数x10ダメージ追加。",
+			},
+		},
+		{
+			name: { ja: "いかずちのやいば" },
+			damage: 130,
+			cost: ["Lightning", "Lightning", "Colorless"],
+			effect: {
+				ja: "このポケモンについているエネルギーを、2個トラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Metal", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 560194,
+			},
+		},
+	],
+
+	retreat: 3,
+	rarity: "Rare",
+	dexId: [644],
+};
+
+export default card;

--- a/data-asia/SM/SM3p/037.ts
+++ b/data-asia/SM/SM3p/037.ts
@@ -1,0 +1,49 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM3p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アーボ",
+	},
+
+	illustrator: "DemizuPosuka",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Psychic"],
+
+	description: {
+		ja: "育つほどに どんどん 長くなる。 そして 夜中は 木の枝に グルグルと 絡まって 休む。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "どくばり" },
+			damage: 10,
+			cost: ["Colorless"],
+			effect: {
+				ja: "コインを1回投げオモテなら、相手のバトルポケモンをどくにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560195,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Common",
+	dexId: [23],
+};
+
+export default card;

--- a/data-asia/SM/SM3p/038.ts
+++ b/data-asia/SM/SM3p/038.ts
@@ -1,0 +1,63 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM3p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アーボック",
+	},
+
+	illustrator: "kodama",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Psychic"],
+
+	description: {
+		ja: "お腹の 模様が 怖い 顔に 見える。 弱い 敵は その模様を 見ただけで 逃げ出してしまう。",
+	},
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "いかくのもよう" },
+			effect: {
+				ja: "このポケモンがバトル場にいるかぎり、相手のバトルポケモンが使うワザのダメージは、すべて「-30」される。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "どくのキバ" },
+			damage: 70,
+			cost: ["Psychic", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをどくにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560196,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "アーボ",
+	},
+
+	retreat: 3,
+	rarity: "Uncommon",
+	dexId: [24],
+};
+
+export default card;

--- a/data-asia/SM/SM3p/039.ts
+++ b/data-asia/SM/SM3p/039.ts
@@ -1,0 +1,56 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM3p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ルージュラ",
+	},
+
+	illustrator: "Tomokazu Komiya",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Psychic"],
+
+	description: {
+		ja: "腰を 振るように 歩いている。 油断をすると 思わず 釣られて 踊ってしまうという。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "あまえごえ" },
+			cost: ["Psychic"],
+			effect: {
+				ja: "相手の手札からオモテを見ないで1枚選び、そのカードのオモテを見てから、相手の山札にもどして切る。",
+			},
+		},
+		{
+			name: { ja: "モーレツキッス" },
+			damage: 30,
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをこんらんにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560197,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Uncommon",
+	dexId: [124],
+};
+
+export default card;

--- a/data-asia/SM/SM3p/040.ts
+++ b/data-asia/SM/SM3p/040.ts
@@ -1,0 +1,63 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM3p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ミュウツーGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 190,
+	types: ["Psychic"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "フルバースト" },
+			damage: "30×",
+			cost: ["Psychic"],
+			effect: {
+				ja: "このポケモンについているエネルギーの数x30ダメージ。",
+			},
+		},
+		{
+			name: { ja: "ちょうきゅうしゅう" },
+			damage: 60,
+			cost: ["Psychic", "Colorless"],
+			effect: {
+				ja: "このポケモンのHPを「30」回復する。",
+			},
+		},
+		{
+			name: { ja: "サイコブレイクGX" },
+			damage: 200,
+			cost: ["Psychic", "Psychic", "Psychic"],
+			effect: {
+				ja: "このワザのダメージは、相手のバトルポケモンにかかっている効果を計算しない。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 560198,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Double rare",
+	dexId: [150],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM3p/041.ts
+++ b/data-asia/SM/SM3p/041.ts
@@ -1,0 +1,53 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM3p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ひかるミュウ",
+	},
+
+	illustrator: "Sanosuke Sakuma",
+	category: "Pokemon",
+	hp: 30,
+	types: ["Psychic"],
+
+	description: {
+		ja: "あらゆる 技を 使うため ポケモンの 先祖と 考える 学者が たくさん いる。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "でんせつのみちびき" },
+			cost: ["Psychic"],
+			effect: {
+				ja: "自分の山札にあるエネルギーを2枚まで、自分のポケモンに好きなようにつける。そして山札を切る。",
+			},
+		},
+		{
+			name: { ja: "ビーム" },
+			damage: 10,
+			cost: ["Psychic"],
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 560199,
+			},
+		},
+	],
+
+	retreat: 0,
+	rarity: "Shiny Ultra Rare",
+	dexId: [151],
+};
+
+export default card;

--- a/data-asia/SM/SM3p/042.ts
+++ b/data-asia/SM/SM3p/042.ts
@@ -1,0 +1,54 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM3p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ラティオス",
+	},
+
+	illustrator: "Mitsuhiro Arita",
+	category: "Pokemon",
+	hp: 110,
+	types: ["Psychic"],
+
+	description: {
+		ja: "高い 知能を 持つ ポケモン。 腕を 折りたたんで 飛べば ジェット機を 追い越す スピードだ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ブレイクスルー" },
+			damage: 30,
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "相手のベンチポケモン1匹にも、30ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+			},
+		},
+		{
+			name: { ja: "ラグーンフライト" },
+			damage: 70,
+			cost: ["Psychic", "Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 560200,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Rare",
+	dexId: [381],
+};
+
+export default card;

--- a/data-asia/SM/SM3p/043.ts
+++ b/data-asia/SM/SM3p/043.ts
@@ -1,0 +1,49 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM3p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ひかるジラーチ",
+	},
+
+	illustrator: "Shigenori Negishi",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Psychic"],
+
+	description: {
+		ja: "目覚めた とき 頭の 短冊に 書かれた 願い事を かなえると 大昔から 語り継がれてきた。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ほしのさだめ" },
+			damage: 10,
+			cost: ["Psychic"],
+			effect: {
+				ja: "相手の進化しているバトルポケモンから、「進化カード」をすべてはがして退化させる。はがしたカードは、相手の手札にもどす。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 560201,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Shiny Ultra Rare",
+	dexId: [385],
+};
+
+export default card;

--- a/data-asia/SM/SM3p/044.ts
+++ b/data-asia/SM/SM3p/044.ts
@@ -1,0 +1,46 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM3p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ゴビット",
+	},
+
+	illustrator: "Kyoko Umemoto",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Psychic"],
+
+	description: {
+		ja: "体内で 燃える エネルギーに よって 活動しているが どんな エネルギーなのかは 不明である。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "メガトンパンチ" },
+			damage: 60,
+			cost: ["Psychic", "Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560202,
+			},
+		},
+	],
+
+	retreat: 3,
+	rarity: "Common",
+	dexId: [622],
+};
+
+export default card;

--- a/data-asia/SM/SM3p/045.ts
+++ b/data-asia/SM/SM3p/045.ts
@@ -1,0 +1,58 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM3p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ゴルーグ",
+	},
+
+	illustrator: "Kagemaru Himeno",
+	category: "Pokemon",
+	hp: 140,
+	types: ["Psychic"],
+
+	description: {
+		ja: "ゴルーグを 作った 古代人から 人や ポケモンを 守るように 命令されていると 言われている。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "トリプルスマッシュ" },
+			damage: "10+",
+			cost: ["Psychic", "Colorless", "Colorless"],
+			effect: {
+				ja: "コインを3回投げ、オモテの数x60ダメージ追加。",
+			},
+		},
+		{
+			name: { ja: "ゴルーグハンマー" },
+			damage: 120,
+			cost: ["Psychic", "Colorless", "Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560203,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ゴビット",
+	},
+
+	retreat: 4,
+	rarity: "Uncommon",
+	dexId: [623],
+};
+
+export default card;

--- a/data-asia/SM/SM3p/046.ts
+++ b/data-asia/SM/SM3p/046.ts
@@ -1,0 +1,59 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM3p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "マーシャドー",
+	},
+
+	illustrator: "Emi Ando",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Psychic"],
+
+	description: {
+		ja: "影の中に 潜むことが でき 人前に 姿を みせないので その存在は 幻 だった。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "やぶれかぶれ" },
+			effect: {
+				ja: "自分の番に、このカードを手札からベンチに出したとき、1回使える。おたがいのプレイヤーは、それぞれ手札をすべて山札にもどして切る。その後、それぞれ山札を4枚引く。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "シャドーパンチ" },
+			damage: 30,
+			cost: ["Psychic", "Colorless"],
+			effect: {
+				ja: "このワザのダメージは抵抗力を計算しない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 560204,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Rare",
+	dexId: [802],
+};
+
+export default card;

--- a/data-asia/SM/SM3p/047.ts
+++ b/data-asia/SM/SM3p/047.ts
@@ -1,0 +1,54 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM3p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "マッギョ",
+	},
+
+	illustrator: "Naoyo Kimura",
+	category: "Pokemon",
+	hp: 110,
+	types: ["Fighting"],
+
+	description: {
+		ja: "皮膚が 硬いので 相撲取りに 踏まれても 平気。 電気を 流すとき 笑い顔に なる。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "でんきショック" },
+			damage: 30,
+			cost: ["Lightning", "Colorless"],
+			effect: {
+				ja: "コインを1回投げオモテなら、相手のバトルポケモンをマヒにする。",
+			},
+		},
+		{
+			name: { ja: "ヘッドボルト" },
+			damage: 70,
+			cost: ["Lightning", "Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560205,
+			},
+		},
+	],
+
+	retreat: 3,
+	rarity: "Uncommon",
+	dexId: [618],
+};
+
+export default card;

--- a/data-asia/SM/SM3p/048.ts
+++ b/data-asia/SM/SM3p/048.ts
@@ -1,0 +1,58 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM3p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ミカルゲ",
+	},
+
+	illustrator: "Kouki Saitou",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Darkness"],
+
+	description: {
+		ja: "１０８個の 魂が 集まって 生まれた ポケモン。 要石の ひび割れに つながれている。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "じゅばくのうず" },
+			effect: {
+				ja: "このポケモンがバトル場にいるかぎり、相手のバトルポケモンは、にげられない。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "のろいのしずく" },
+			cost: ["Darkness", "Colorless"],
+			effect: {
+				ja: "ダメカン3個を、相手のポケモンに好きなようにのせる。",
+			},
+		},
+	],
+
+	weaknesses: [],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560206,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Uncommon",
+	dexId: [442],
+};
+
+export default card;

--- a/data-asia/SM/SM3p/049.ts
+++ b/data-asia/SM/SM3p/049.ts
@@ -1,0 +1,54 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM3p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "チョロネコ",
+	},
+
+	illustrator: "Naoyo Kimura",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Darkness"],
+
+	description: {
+		ja: "かわいらしい 仕草で 油断させて その すきに 持ち物を 奪う。 怒ると ツメを 立てて 反撃。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ひっかく" },
+			damage: 10,
+			cost: ["Colorless"],
+		},
+		{
+			name: { ja: "しっぽビンタ" },
+			damage: "20×",
+			cost: ["Darkness", "Colorless"],
+			effect: {
+				ja: "コインを2回投げ、オモテの数x20ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560207,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [509],
+};
+
+export default card;

--- a/data-asia/SM/SM3p/050.ts
+++ b/data-asia/SM/SM3p/050.ts
@@ -1,0 +1,58 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM3p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "レパルダス",
+	},
+
+	illustrator: "kawayoo",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Darkness"],
+
+	description: {
+		ja: "美しい スタイルは 全身の 発達した 筋肉の おかげ。 音もたてずに 夜を 駆けぬける。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "いちゃもん" },
+			damage: 30,
+			cost: ["Darkness"],
+			effect: {
+				ja: "相手のバトルポケモンが持っているワザを1つ選ぶ。次の相手の番、このワザを受けたポケモンは、選ばれたワザを使えない。",
+			},
+		},
+		{
+			name: { ja: "きりさく" },
+			damage: 60,
+			cost: ["Darkness", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560208,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "チョロネコ",
+	},
+
+	retreat: 1,
+	rarity: "Uncommon",
+	dexId: [510],
+};
+
+export default card;

--- a/data-asia/SM/SM3p/051.ts
+++ b/data-asia/SM/SM3p/051.ts
@@ -1,0 +1,53 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM3p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ズルッグ",
+	},
+
+	illustrator: "Sekio",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Darkness"],
+
+	description: {
+		ja: "皮を 首まで 引き上げて 防御の 姿勢。 ゴムのような 弾力で ダメージを 減らす。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "なかまをよぶ" },
+			cost: ["Darkness"],
+			effect: {
+				ja: "自分の山札にあるたねポケモンを1枚、ベンチに出す。そして山札を切る。",
+			},
+		},
+		{
+			name: { ja: "ずつき" },
+			damage: 20,
+			cost: ["Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560209,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [559],
+};
+
+export default card;

--- a/data-asia/SM/SM3p/052.ts
+++ b/data-asia/SM/SM3p/052.ts
@@ -1,0 +1,58 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM3p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ズルズキン",
+	},
+
+	illustrator: "Mitsuhiro Arita",
+	category: "Pokemon",
+	hp: 110,
+	types: ["Darkness"],
+
+	description: {
+		ja: "脱皮した 皮を ずりあげて ダメージを 減らしつつ キック！ とさかが 大きいほど 偉そうだ。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "デンジャラスヘッド" },
+			damage: "20+",
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンがたねポケモンなら、50ダメージ追加。",
+			},
+		},
+		{
+			name: { ja: "ぶちかます" },
+			damage: 90,
+			cost: ["Darkness", "Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560210,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ズルッグ",
+	},
+
+	retreat: 2,
+	rarity: "Uncommon",
+	dexId: [560],
+};
+
+export default card;

--- a/data-asia/SM/SM3p/053.ts
+++ b/data-asia/SM/SM3p/053.ts
@@ -1,0 +1,51 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM3p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ゾロア",
+	},
+
+	illustrator: "kodama",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Darkness"],
+
+	description: {
+		ja: "相手そっくりに 化けているように みせかけ だましたり 驚かして そのすきに 逃げ出すことが 多い。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ふむ" },
+			damage: 10,
+			cost: ["Darkness"],
+		},
+		{
+			name: { ja: "ぶつかる" },
+			damage: 20,
+			cost: ["Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560211,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [570],
+};
+
+export default card;

--- a/data-asia/SM/SM3p/054.ts
+++ b/data-asia/SM/SM3p/054.ts
@@ -1,0 +1,68 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM3p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ゾロアークGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 210,
+	types: ["Darkness"],
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "とりひき" },
+			effect: {
+				ja: "自分の番に1回使える。自分の手札を1枚トラッシュする。その後、山札を2枚引く。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ライオットビート" },
+			damage: "20×",
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "自分の場のポケモンの数x20ダメージ。",
+			},
+		},
+		{
+			name: { ja: "トリックスターGX" },
+			cost: ["Darkness", "Darkness"],
+			effect: {
+				ja: "相手の場のポケモンが持っているワザを1つ選び、このワザとして使う。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 560212,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ゾロア",
+	},
+
+	retreat: 2,
+	rarity: "Double rare",
+	dexId: [571],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM3p/055.ts
+++ b/data-asia/SM/SM3p/055.ts
@@ -1,0 +1,57 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM3p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "イベルタル",
+	},
+
+	illustrator: "Shin Nagasawa",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Darkness"],
+
+	description: {
+		ja: "翼と 尾羽を 広げて 赤く 輝くとき 生き物の 命を 吸い取る 伝説の ポケモン。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ひるがえす" },
+			damage: 30,
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "のぞむなら、このポケモンをベンチポケモンと入れ替える。",
+			},
+		},
+		{
+			name: { ja: "デスウイング" },
+			damage: 90,
+			cost: ["Darkness", "Colorless", "Colorless"],
+			effect: {
+				ja: "自分のトラッシュにある[悪]エネルギーを1枚、ベンチポケモンにつける。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 560213,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Rare",
+	dexId: [717],
+};
+
+export default card;

--- a/data-asia/SM/SM3p/056.ts
+++ b/data-asia/SM/SM3p/056.ts
@@ -1,0 +1,56 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM3p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "フーパ",
+	},
+
+	illustrator: "TOKIYA",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Darkness"],
+
+	description: {
+		ja: "真の姿は 巨大な 力を 持っている。 財宝 欲しさに それが 隠された 城ごと 引き抜き 奪い去った という 伝説が ある。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "バンデットガード" },
+			effect: {
+				ja: "このポケモンは、相手の「ポケモンGX・EX」からワザのダメージや効果を受けない。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ちょうねんりき" },
+			damage: 80,
+			cost: ["Darkness", "Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 560214,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Rare",
+	dexId: [720],
+};
+
+export default card;

--- a/data-asia/SM/SM3p/057.ts
+++ b/data-asia/SM/SM3p/057.ts
@@ -1,0 +1,57 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM3p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ひかるレックウザ",
+	},
+
+	illustrator: "Naoki Saito",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Dragon"],
+
+	description: {
+		ja: "雲より はるか上の オゾン層に 生息しているため 地上から 姿を 見ることは できない。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "りゅうのはどう" },
+			damage: 40,
+			cost: ["Lightning"],
+			effect: {
+				ja: "自分の山札を上から2枚トラッシュする。",
+			},
+		},
+		{
+			name: { ja: "てんくうのさばき" },
+			damage: 190,
+			cost: ["Fire", "Lightning", "Lightning", "Colorless"],
+			effect: {
+				ja: "このポケモンについているエネルギーを、3個トラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fairy", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 560215,
+			},
+		},
+	],
+
+	retreat: 3,
+	rarity: "Shiny Ultra Rare",
+	dexId: [384],
+};
+
+export default card;

--- a/data-asia/SM/SM3p/058.ts
+++ b/data-asia/SM/SM3p/058.ts
@@ -1,0 +1,57 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM3p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ひかるルギア",
+	},
+
+	illustrator: "Hitoshi Ariga",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Colorless"],
+
+	description: {
+		ja: "深い 海溝の 底で 眠る。 ルギアが 羽ばたくと ４０日 嵐が 続くと 言われている。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ぎんのつばさ" },
+			damage: "60+",
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンが特性を持っているなら、60ダメージ追加。",
+			},
+		},
+		{
+			name: { ja: "エアロフォース" },
+			damage: 130,
+			cost: ["Colorless", "Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンについているエネルギーを、1個トラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 560216,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Shiny Ultra Rare",
+	dexId: [249],
+};
+
+export default card;

--- a/data-asia/SM/SM3p/059.ts
+++ b/data-asia/SM/SM3p/059.ts
@@ -1,0 +1,58 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM3p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ひかるアルセウス",
+	},
+
+	illustrator: "Kouki Saitou",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Colorless"],
+
+	description: {
+		ja: "タマゴから 姿を 現して 世界の すべてを 生み出したと シンオウ神話に 語られている。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "しんわのまもり" },
+			effect: {
+				ja: "このポケモンがバトル場にいるかぎり、自分のベンチポケモン全員は、相手のワザのダメージを受けない。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "アルティメットアロー" },
+			cost: ["Colorless", "Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のポケモン全員に、それぞれ30ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 560217,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Shiny Ultra Rare",
+	dexId: [493],
+};
+
+export default card;

--- a/data-asia/SM/SM3p/060.ts
+++ b/data-asia/SM/SM3p/060.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM3p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "エネルギー回収",
+	},
+
+	illustrator: "Toyste Beach",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分のトラッシュから基本エネルギーを2枚選び、相手に見せてから、手札に加える。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560218,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM3p/061.ts
+++ b/data-asia/SM/SM3p/061.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM3p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "スーパーボール",
+	},
+
+	illustrator: "Ryo Ueda",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の山札を上から7枚見る。その中からポケモンを1枚選び、相手に見せてから、手札に加えてよい。残りのカードは山札にもどし、山札を切る。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560219,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM3p/062.ts
+++ b/data-asia/SM/SM3p/062.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM3p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "スーパーポケモン回収",
+	},
+
+	illustrator: "Toyste Beach",
+	category: "Trainer",
+
+	effect: {
+		ja: "コインを1回投げオモテなら、自分のポケモン1匹と、ついているすべてのカードを、手札にもどす。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560220,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM3p/063.ts
+++ b/data-asia/SM/SM3p/063.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM3p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ダメージムーバー",
+	},
+
+	illustrator: "Toyste Beach",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の場のポケモン1匹にのっているダメカンを3個、自分の別のポケモン1匹にのせ替える。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560221,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM3p/064.ts
+++ b/data-asia/SM/SM3p/064.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM3p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ハイパーボール",
+	},
+
+	illustrator: "Ryo Ueda",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードは、自分の手札を2枚トラッシュしなければ使えない。自分の山札からポケモンを1枚選び、相手に見せてから、手札に加える。そして山札を切る。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560222,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM3p/065.ts
+++ b/data-asia/SM/SM3p/065.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM3p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ポケモンいれかえ",
+	},
+
+	illustrator: "Ryo Ueda",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分のバトルポケモンをベンチポケモンと入れ替える。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560223,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM3p/066.ts
+++ b/data-asia/SM/SM3p/066.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM3p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ポケモンキャッチャー",
+	},
+
+	illustrator: "Toyste Beach",
+	category: "Trainer",
+
+	effect: {
+		ja: "相手のベンチポケモンを1匹選び、バトルポケモンと入れ替える。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560224,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM3p/067.ts
+++ b/data-asia/SM/SM3p/067.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM3p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ハウ",
+	},
+
+	illustrator: "Ken Sugimori",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の山札を3枚引く。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560225,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM3p/068.ts
+++ b/data-asia/SM/SM3p/068.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM3p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ポケモンブリーダー",
+	},
+
+	illustrator: "Kanako Eo",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の山札を2枚引く。その後、自分のバトルポケモンのHPを「20」回復する。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560226,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM3p/069.ts
+++ b/data-asia/SM/SM3p/069.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM3p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "マーマネ",
+	},
+
+	illustrator: "Ken Sugimori",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードは、自分の手札を2枚トラッシュしなければ使えない。自分の山札を4枚引く。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560227,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM3p/070.ts
+++ b/data-asia/SM/SM3p/070.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM3p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "リーリエ",
+	},
+
+	illustrator: "Ken Sugimori",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の手札が6枚になるように、山札を引く。最初の自分の番に使ったなら、8枚になるように引く。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560228,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM3p/071.ts
+++ b/data-asia/SM/SM3p/071.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM3p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ダブル無色エネルギー",
+	},
+
+	illustrator: "",
+	category: "Energy",
+	energyType: "Special",
+
+	effect: {
+		ja: "このカードは、[無]エネルギー2個ぶんとしてはたらく。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560229,
+			},
+		},
+	],
+
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM3p/072.ts
+++ b/data-asia/SM/SM3p/072.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM3p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ワープエネルギー",
+	},
+
+	illustrator: "",
+	category: "Energy",
+	energyType: "Special",
+
+	effect: {
+		ja: "このカードは、[無]エネルギー1個ぶんとしてはたらく。このカードを手札からバトルポケモンにつけたとき、このカードをつけたポケモンをベンチポケモンと入れ替える。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560230,
+			},
+		},
+	],
+
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM3p/073.ts
+++ b/data-asia/SM/SM3p/073.ts
@@ -1,0 +1,59 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM3p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "エンテイGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 180,
+	types: ["Fire"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "かえん" },
+			damage: 50,
+			cost: ["Fire", "Colorless"],
+		},
+		{
+			name: { ja: "ほのおのキバ" },
+			damage: 100,
+			cost: ["Fire", "Fire", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをやけどにする。",
+			},
+		},
+		{
+			name: { ja: "ブレイブバーンGX" },
+			cost: ["Fire", "Fire", "Colorless"],
+			effect: {
+				ja: "相手のベンチポケモン1匹に、150ダメージ。［ベンチは弱点・抵抗力を計算しない。］［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 560231,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Ultra Rare",
+	dexId: [244],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM3p/074.ts
+++ b/data-asia/SM/SM3p/074.ts
@@ -1,0 +1,67 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM3p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ライチュウGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 210,
+	types: ["Lightning"],
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "パワフルスパーク" },
+			damage: "20+",
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "自分の場のポケモンについている[雷]エネルギーの数x20ダメージ追加。",
+			},
+		},
+		{
+			name: { ja: "かみなり" },
+			damage: 160,
+			cost: ["Lightning", "Lightning", "Colorless"],
+			effect: {
+				ja: "このポケモンにも30ダメージ。",
+			},
+		},
+		{
+			name: { ja: "ボルテールGX" },
+			damage: 120,
+			cost: ["Lightning", "Lightning", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをマヒにする。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Metal", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 560232,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ピカチュウ",
+	},
+
+	retreat: 1,
+	rarity: "Ultra Rare",
+	dexId: [26],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM3p/075.ts
+++ b/data-asia/SM/SM3p/075.ts
@@ -1,0 +1,63 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM3p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ミュウツーGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 190,
+	types: ["Psychic"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "フルバースト" },
+			damage: "30×",
+			cost: ["Psychic"],
+			effect: {
+				ja: "このポケモンについているエネルギーの数x30ダメージ。",
+			},
+		},
+		{
+			name: { ja: "ちょうきゅうしゅう" },
+			damage: 60,
+			cost: ["Psychic", "Colorless"],
+			effect: {
+				ja: "このポケモンのHPを「30」回復する。",
+			},
+		},
+		{
+			name: { ja: "サイコブレイクGX" },
+			damage: 200,
+			cost: ["Psychic", "Psychic", "Psychic"],
+			effect: {
+				ja: "このワザのダメージは、相手のバトルポケモンにかかっている効果を計算しない。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 560233,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Ultra Rare",
+	dexId: [150],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM3p/076.ts
+++ b/data-asia/SM/SM3p/076.ts
@@ -1,0 +1,68 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM3p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ゾロアークGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 210,
+	types: ["Darkness"],
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "とりひき" },
+			effect: {
+				ja: "自分の番に1回使える。自分の手札を1枚トラッシュする。その後、山札を2枚引く。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ライオットビート" },
+			damage: "20×",
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "自分の場のポケモンの数x20ダメージ。",
+			},
+		},
+		{
+			name: { ja: "トリックスターGX" },
+			cost: ["Darkness", "Darkness"],
+			effect: {
+				ja: "相手の場のポケモンが持っているワザを1つ選び、このワザとして使う。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 560234,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ゾロア",
+	},
+
+	retreat: 2,
+	rarity: "Ultra Rare",
+	dexId: [571],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM3p/077.ts
+++ b/data-asia/SM/SM3p/077.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM3p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ポケモンブリーダー",
+	},
+
+	illustrator: "Sanosuke Sakuma",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の山札を2枚引く。その後、自分のバトルポケモンのHPを「20」回復する。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 560235,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	rarity: "Ultra Rare",
+};
+
+export default card;

--- a/data-asia/SM/SM3p/078.ts
+++ b/data-asia/SM/SM3p/078.ts
@@ -1,0 +1,59 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM3p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "エンテイGX",
+	},
+
+	illustrator: "Mitsuhiro Arita",
+	category: "Pokemon",
+	hp: 180,
+	types: ["Fire"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "かえん" },
+			damage: 50,
+			cost: ["Fire", "Colorless"],
+		},
+		{
+			name: { ja: "ほのおのキバ" },
+			damage: 100,
+			cost: ["Fire", "Fire", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをやけどにする。",
+			},
+		},
+		{
+			name: { ja: "ブレイブバーンGX" },
+			cost: ["Fire", "Fire", "Colorless"],
+			effect: {
+				ja: "相手のベンチポケモン1匹に、150ダメージ。［ベンチは弱点・抵抗力を計算しない。］［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 560236,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Hyper rare",
+	dexId: [244],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM3p/079.ts
+++ b/data-asia/SM/SM3p/079.ts
@@ -1,0 +1,67 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM3p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ライチュウGX",
+	},
+
+	illustrator: "",
+	category: "Pokemon",
+	hp: 210,
+	types: ["Lightning"],
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "パワフルスパーク" },
+			damage: "20+",
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "自分の場のポケモンについている[雷]エネルギーの数x20ダメージ追加。",
+			},
+		},
+		{
+			name: { ja: "かみなり" },
+			damage: 160,
+			cost: ["Lightning", "Lightning", "Colorless"],
+			effect: {
+				ja: "このポケモンにも30ダメージ。",
+			},
+		},
+		{
+			name: { ja: "ボルテールGX" },
+			damage: 120,
+			cost: ["Lightning", "Lightning", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをマヒにする。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Metal", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 560237,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ピカチュウ",
+	},
+
+	retreat: 1,
+	rarity: "Hyper rare",
+	dexId: [26],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM3p/080.ts
+++ b/data-asia/SM/SM3p/080.ts
@@ -1,0 +1,63 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM3p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ミュウツーGX",
+	},
+
+	illustrator: "",
+	category: "Pokemon",
+	hp: 190,
+	types: ["Psychic"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "フルバースト" },
+			damage: "30×",
+			cost: ["Psychic"],
+			effect: {
+				ja: "このポケモンについているエネルギーの数x30ダメージ。",
+			},
+		},
+		{
+			name: { ja: "ちょうきゅうしゅう" },
+			damage: 60,
+			cost: ["Psychic", "Colorless"],
+			effect: {
+				ja: "このポケモンのHPを「30」回復する。",
+			},
+		},
+		{
+			name: { ja: "サイコブレイクGX" },
+			damage: 200,
+			cost: ["Psychic", "Psychic", "Psychic"],
+			effect: {
+				ja: "このワザのダメージは、相手のバトルポケモンにかかっている効果を計算しない。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 560238,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Hyper rare",
+	dexId: [150],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM3p/081.ts
+++ b/data-asia/SM/SM3p/081.ts
@@ -1,0 +1,68 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM3p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ゾロアークGX",
+	},
+
+	illustrator: "",
+	category: "Pokemon",
+	hp: 210,
+	types: ["Darkness"],
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "とりひき" },
+			effect: {
+				ja: "自分の番に1回使える。自分の手札を1枚トラッシュする。その後、山札を2枚引く。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ライオットビート" },
+			damage: "20×",
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "自分の場のポケモンの数x20ダメージ。",
+			},
+		},
+		{
+			name: { ja: "トリックスターGX" },
+			cost: ["Darkness", "Darkness"],
+			effect: {
+				ja: "相手の場のポケモンが持っているワザを1つ選び、このワザとして使う。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 560239,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ゾロア",
+	},
+
+	retreat: 2,
+	rarity: "Hyper rare",
+	dexId: [571],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM3p/082.ts
+++ b/data-asia/SM/SM3p/082.ts
@@ -1,0 +1,63 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM3p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ミュウツーGX",
+	},
+
+	illustrator: "",
+	category: "Pokemon",
+	hp: 190,
+	types: ["Psychic"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "フルバースト" },
+			damage: "30×",
+			cost: ["Psychic"],
+			effect: {
+				ja: "このポケモンについているエネルギーの数x30ダメージ。",
+			},
+		},
+		{
+			name: { ja: "ちょうきゅうしゅう" },
+			damage: 60,
+			cost: ["Psychic", "Colorless"],
+			effect: {
+				ja: "このポケモンのHPを「30」回復する。",
+			},
+		},
+		{
+			name: { ja: "サイコブレイクGX" },
+			damage: 200,
+			cost: ["Psychic", "Psychic", "Psychic"],
+			effect: {
+				ja: "このワザのダメージは、相手のバトルポケモンにかかっている効果を計算しない。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 560240,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Secret Rare",
+	dexId: [150],
+
+	suffix: "GX",
+};
+
+export default card;


### PR DESCRIPTION
## What

Adds the complete Japanese set **SM3p ひかる伝説 (Shining Legends)**, released 2017-07-15:

- `data-asia/SM/SM3p.ts` — set definition (72 official cards)
- `data-asia/SM/SM3p/001.ts` … `082.ts` — all 82 cards (72 regular + 10 secret rares: 5 SR, 4 UR, 1 Secret Rare)

## Data sources

- **pokemon-card.com** (official database): Japanese names, flavor texts, National Dex numbers, official card count
- **limitlesstcg.com**: full Japanese card text, stages, weaknesses/resistances/retreat, rarities, illustrators, attack costs
- **Cardmarket**: product IDs as `thirdParty.cardmarket` on the variant objects (560159–560240; tcgplayer IDs not available to me)

## Notes

- Follows the file format and conventions of the M-era sets (#1728)
- No `regulationMark` (the set predates regulation marks); resistances are `-20` per the era
- All 82 files type-check against `interfaces.d.ts` (`tsc --noEmit`)
