### PR TITLE
(data) Add Japanese SM set SM4A Beasts from the Ultradimension

### DIFF
--- a/data-asia/SM/SM4A/001.ts
+++ b/data-asia/SM/SM4A/001.ts
@@ -1,0 +1,48 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4A";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ビードル",
+	},
+
+	illustrator: "Yukiko Baba",
+	category: "Pokemon",
+	hp: 50,
+	types: ["Grass"],
+
+	description: {
+		ja: "森や 草地に 多く 生息。 頭の 先に ５センチぐらいの 小さく 鋭い 毒針を持つ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "どくばり" },
+			cost: ["Grass"],
+			effect: {
+				ja: "相手のバトルポケモンをどくにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560241,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [13],
+};
+
+export default card;

--- a/data-asia/SM/SM4A/002.ts
+++ b/data-asia/SM/SM4A/002.ts
@@ -1,0 +1,52 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4A";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "コクーン",
+	},
+
+	illustrator: "miki kudo",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Grass"],
+
+	description: {
+		ja: "自分では ほとんど 動けないが 危ないときは 硬くなって 身を守っているようだ。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "ふえる" },
+			cost: ["Grass"],
+			effect: {
+				ja: "自分の山札にある「コクーン」を3枚まで、ベンチに出す。そして山札を切る。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560247,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ビードル",
+	},
+
+	retreat: 2,
+	rarity: "Common",
+	dexId: [14],
+};
+
+export default card;

--- a/data-asia/SM/SM4A/003.ts
+++ b/data-asia/SM/SM4A/003.ts
@@ -1,0 +1,58 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4A";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "スピアー",
+	},
+
+	illustrator: "kirisAki",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Grass"],
+
+	description: {
+		ja: "両手と お尻にある ３本の 毒針で 相手を 刺して 刺して 刺しまくって 攻撃する。",
+	},
+
+	stage: "Stage2",
+
+	attacks: [
+		{
+			name: { ja: "いきなりさす" },
+			damage: 10,
+			cost: ["Grass"],
+			effect: {
+				ja: "この番、このポケモンが「コクーン」から進化していたなら、相手のバトルポケモンをどくとマヒにする。",
+			},
+		},
+		{
+			name: { ja: "するどいはり" },
+			damage: 60,
+			cost: ["Grass"],
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560248,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "コクーン",
+	},
+
+	retreat: 0,
+	rarity: "Uncommon",
+	dexId: [15],
+};
+
+export default card;

--- a/data-asia/SM/SM4A/004.ts
+++ b/data-asia/SM/SM4A/004.ts
@@ -1,0 +1,53 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4A";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "タマタマ",
+	},
+
+	illustrator: "Kouki Saitou",
+	category: "Pokemon",
+	hp: 50,
+	types: ["Grass"],
+
+	description: {
+		ja: "テレパシーで 仲間と 交信する。 植物と ある種の タイプの 遺伝子を 併せ持つと いう。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "さいみんじゅつ" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをねむりにする。",
+			},
+		},
+		{
+			name: { ja: "ぶつかる" },
+			damage: 10,
+			cost: ["Grass"],
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560249,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [102],
+};
+
+export default card;

--- a/data-asia/SM/SM4A/005.ts
+++ b/data-asia/SM/SM4A/005.ts
@@ -1,0 +1,49 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4A";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "チョボマキ",
+	},
+
+	illustrator: "OOYAMA",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Grass"],
+
+	description: {
+		ja: "カブルモと 一緒に いるときに 電気的な 刺激を 受けると お互いの 体が 進化する。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "すいとる" },
+			damage: 10,
+			cost: ["Grass"],
+			effect: {
+				ja: "このポケモンのHPを「10」回復する。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560250,
+			},
+		},
+	],
+
+	retreat: 3,
+	rarity: "Common",
+	dexId: [616],
+};
+
+export default card;

--- a/data-asia/SM/SM4A/006.ts
+++ b/data-asia/SM/SM4A/006.ts
@@ -1,0 +1,57 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4A";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アギルダー",
+	},
+
+	illustrator: "tetsuya koizumi",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Grass"],
+
+	description: {
+		ja: "重い 殻を 脱いだために 身軽になった。 まるで 忍者のような 身のこなしで 戦う。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "じこさいせい" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "このポケモンについているエネルギーを、1個トラッシュする。このポケモンのHPをすべて回復する。",
+			},
+		},
+		{
+			name: { ja: "スピードアタック" },
+			damage: 70,
+			cost: ["Grass", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560251,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "チョボマキ",
+	},
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [617],
+};
+
+export default card;

--- a/data-asia/SM/SM4A/007.ts
+++ b/data-asia/SM/SM4A/007.ts
@@ -1,0 +1,58 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4A";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "コイキング",
+	},
+
+	illustrator: "TOKIYA",
+	category: "Pokemon",
+	hp: 30,
+	types: ["Water"],
+
+	description: {
+		ja: "力は 弱く 頼りないのに 繁殖力だけ 物凄い。 飽きるほど みかけるぞ。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "もぐる" },
+			effect: {
+				ja: "このポケモンは、ベンチにいるかぎり、ワザのダメージを受けない。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "たきのぼりしんか" },
+			cost: ["Water", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンから進化するカードを、自分の山札から1枚選び、このポケモンにのせて進化させる。そして山札を切る。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560252,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [129],
+};
+
+export default card;

--- a/data-asia/SM/SM4A/008.ts
+++ b/data-asia/SM/SM4A/008.ts
@@ -1,0 +1,63 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4A";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ギャラドスGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 240,
+	types: ["Water"],
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "たきのぼり" },
+			damage: 70,
+			cost: ["Water", "Colorless", "Colorless"],
+		},
+		{
+			name: { ja: "りゅうのわざわい" },
+			damage: "100+",
+			cost: ["Water", "Colorless", "Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "場にスタジアムが出ているなら、100ダメージ追加。その後、そのスタジアムをトラッシュする。",
+			},
+		},
+		{
+			name: { ja: "ドレッドストームGX" },
+			cost: ["Water"],
+			effect: {
+				ja: "相手の場のポケモン全員についているエネルギーを、1個ずつトラッシュする。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 560253,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "コイキング",
+	},
+
+	retreat: 4,
+	rarity: "Double rare",
+	dexId: [130],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM4A/009.ts
+++ b/data-asia/SM/SM4A/009.ts
@@ -1,0 +1,46 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4A";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ウリムー",
+	},
+
+	illustrator: "Eri Yamaki",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Water"],
+
+	description: {
+		ja: "エサを 探すため 鼻を こすり合わせ 地面を 掘っている。 たまに 温泉を 掘り当てる。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "かじる" },
+			damage: 30,
+			cost: ["Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560254,
+			},
+		},
+	],
+
+	retreat: 3,
+	rarity: "Common",
+	dexId: [220],
+};
+
+export default card;

--- a/data-asia/SM/SM4A/010.ts
+++ b/data-asia/SM/SM4A/010.ts
@@ -1,0 +1,57 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4A";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "イノムー",
+	},
+
+	illustrator: "Kouki Saitou",
+	category: "Pokemon",
+	hp: 100,
+	types: ["Water"],
+
+	description: {
+		ja: "４本の 脚は 短いが ひづめは 広く ギザギザ なので 雪の上でも 滑らず 歩ける。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "ふむ" },
+			damage: 20,
+			cost: ["Water"],
+		},
+		{
+			name: { ja: "ねむる" },
+			cost: ["Colorless", "Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンをねむりにする。このポケモンのHPを「90」回復する。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560255,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ウリムー",
+	},
+
+	retreat: 4,
+	rarity: "Common",
+	dexId: [221],
+};
+
+export default card;

--- a/data-asia/SM/SM4A/011.ts
+++ b/data-asia/SM/SM4A/011.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4A";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "マンムー",
+	},
+
+	illustrator: "Mitsuhiro Arita",
+	category: "Pokemon",
+	hp: 180,
+	types: ["Water"],
+
+	description: {
+		ja: "１万年前の 氷の 下から 発見された ことも あるほど 大昔から いた ポケモン。",
+	},
+
+	stage: "Stage2",
+
+	attacks: [
+		{
+			name: { ja: "ダブルスタンプ" },
+			damage: "60+",
+			cost: ["Water", "Colorless", "Colorless"],
+			effect: {
+				ja: "コインを2回投げ、オモテの数x30ダメージ追加。",
+			},
+		},
+		{
+			name: { ja: "ごういんタックル" },
+			damage: "90+",
+			cost: ["Water", "Water", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンにダメカンを9個までのせ、のせた数x10ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560256,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "イノムー",
+	},
+
+	retreat: 4,
+	rarity: "Uncommon",
+	dexId: [473],
+};
+
+export default card;

--- a/data-asia/SM/SM4A/012.ts
+++ b/data-asia/SM/SM4A/012.ts
@@ -1,0 +1,49 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4A";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヒンバス",
+	},
+
+	illustrator: "Hitoshi Ariga",
+	category: "Pokemon",
+	hp: 30,
+	types: ["Water"],
+
+	description: {
+		ja: "汚い 水でも ぜんぜん 平気な タフな ポケモン。 でも ボロボロで みすぼらしいので 人気は ない。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "はねてかわす" },
+			damage: 10,
+			cost: ["Water"],
+			effect: {
+				ja: "コインを1回投げオモテなら、次の相手の番、このポケモンはワザのダメージや効果を受けない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560257,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [349],
+};
+
+export default card;

--- a/data-asia/SM/SM4A/013.ts
+++ b/data-asia/SM/SM4A/013.ts
@@ -1,0 +1,60 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4A";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ミロカロス",
+	},
+
+	illustrator: "Kagemaru Himeno",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Water"],
+
+	description: {
+		ja: "最も 美しい ポケモンとも 呼ばれ 多くの 芸術家に インスピレーションを 与えてきた。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "いつくしむ" },
+			cost: ["Water"],
+			effect: {
+				ja: "ダメカンがのっている相手のベンチポケモン1匹と、ついているすべてのカードを、山札にもどして切る。",
+			},
+		},
+		{
+			name: { ja: "オーシャンサイクロン" },
+			damage: 80,
+			cost: ["Water", "Water", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のベンチポケモン全員にも、それぞれ10ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 560258,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ヒンバス",
+	},
+
+	retreat: 2,
+	rarity: "Rare",
+	dexId: [350],
+};
+
+export default card;

--- a/data-asia/SM/SM4A/014.ts
+++ b/data-asia/SM/SM4A/014.ts
@@ -1,0 +1,56 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4A";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "レジアイス",
+	},
+
+	illustrator: "Masakazu Fukuda",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Water"],
+
+	description: {
+		ja: "氷河の 中で 数千年 眠っていたと 言われている。 マグマでも 体は 溶けない。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ひょうざんのたて" },
+			effect: {
+				ja: "自分の場に「レジロック」がいるなら、このポケモンは、相手の2進化ポケモンからワザのダメージや効果を受けない。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "フロストスマッシュ" },
+			damage: 70,
+			cost: ["Water", "Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 560259,
+			},
+		},
+	],
+
+	retreat: 3,
+	rarity: "Rare",
+	dexId: [378],
+};
+
+export default card;

--- a/data-asia/SM/SM4A/015.ts
+++ b/data-asia/SM/SM4A/015.ts
@@ -1,0 +1,56 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4A";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ピカチュウ",
+	},
+
+	illustrator: "Shibuzoh.",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Lightning"],
+
+	description: {
+		ja: "たくさんの ピカチュウを 集め 発電所を 造る 計画が 最近 発表 された。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ピカドロー" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札を1枚引く。",
+			},
+		},
+		{
+			name: { ja: "でんこうせっか" },
+			damage: "20+",
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "コインを1回投げオモテなら、20ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Metal", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560260,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [25],
+};
+
+export default card;

--- a/data-asia/SM/SM4A/016.ts
+++ b/data-asia/SM/SM4A/016.ts
@@ -1,0 +1,63 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4A";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アローラライチュウ",
+	},
+
+	illustrator: "Akira Komayama",
+	category: "Pokemon",
+	hp: 110,
+	types: ["Lightning"],
+
+	description: {
+		ja: "アローラ地方 でのみ この姿に 進化する。 その要因の ひとつが 餌であると 研究家は 語る。",
+	},
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "サーフテール" },
+			effect: {
+				ja: "場にスタジアムが出ているなら、このポケモンのにげるためのエネルギーは、すべてなくなる。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "サイコキネシス" },
+			damage: "70+",
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンについているエネルギーの数x20ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Metal", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 560261,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ピカチュウ",
+	},
+
+	retreat: 2,
+	rarity: "Rare",
+	dexId: [26],
+};
+
+export default card;

--- a/data-asia/SM/SM4A/017.ts
+++ b/data-asia/SM/SM4A/017.ts
@@ -1,0 +1,48 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4A";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ムウマ",
+	},
+
+	illustrator: "so-taro",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Psychic"],
+
+	description: {
+		ja: "あの手 この手で 人を 驚かし 生命エネルギーを 吸い取る。 驚かす 練習は 欠かさない。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "あやしいひかり" },
+			cost: ["Psychic"],
+			effect: {
+				ja: "相手のバトルポケモンをこんらんにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560262,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [200],
+};
+
+export default card;

--- a/data-asia/SM/SM4A/018.ts
+++ b/data-asia/SM/SM4A/018.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4A";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ムウマージ",
+	},
+
+	illustrator: "chibi",
+	category: "Pokemon",
+	hp: 110,
+	types: ["Psychic"],
+
+	description: {
+		ja: "どこからともなく 現れ 呪文を つぶやき 呪いを かけたり 恐ろしい 幻を みせる。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "カオスウィール" },
+			damage: 30,
+			cost: ["Psychic"],
+			effect: {
+				ja: "次の相手の番、相手は手札から、「ポケモンのどうぐ」「特殊エネルギー」を出してつけられず「スタジアム」も出せない。",
+			},
+		},
+		{
+			name: { ja: "くろまじゅつ" },
+			damage: "20×",
+			cost: ["Psychic", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手の手札の枚数x20ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560263,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ムウマ",
+	},
+
+	retreat: 1,
+	rarity: "Uncommon",
+	dexId: [429],
+};
+
+export default card;

--- a/data-asia/SM/SM4A/019.ts
+++ b/data-asia/SM/SM4A/019.ts
@@ -1,0 +1,46 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4A";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "バネブー",
+	},
+
+	illustrator: "Sekio",
+	category: "Pokemon",
+	hp: 50,
+	types: ["Psychic"],
+
+	description: {
+		ja: "尻尾を バネのかわりに いつも 飛び跳ねている。 跳ねる 振動で 心臓を 鼓動 させているのだ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "はねる" },
+			damage: 10,
+			cost: ["Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560265,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [325],
+};
+
+export default card;

--- a/data-asia/SM/SM4A/020.ts
+++ b/data-asia/SM/SM4A/020.ts
@@ -1,0 +1,63 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4A";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ブーピッグ",
+	},
+
+	illustrator: "Saya Tsuruta",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Psychic"],
+
+	description: {
+		ja: "黒真珠で サイコパワーを 強め 奇妙な ステップで 相手の 心を 操るぞ。",
+	},
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "マイペース" },
+			effect: {
+				ja: "このポケモンはこんらんにならない。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "じこあんじ" },
+			damage: 60,
+			cost: ["Psychic", "Colorless", "Colorless"],
+			effect: {
+				ja: "次の自分の番、このポケモンの「じこあんじ」のダメージは「+60」される。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560266,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "バネブー",
+	},
+
+	retreat: 2,
+	rarity: "Common",
+	dexId: [326],
+};
+
+export default card;

--- a/data-asia/SM/SM4A/021.ts
+++ b/data-asia/SM/SM4A/021.ts
@@ -1,0 +1,53 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4A";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヤレユータン",
+	},
+
+	illustrator: "Yoshinobu Saito",
+	category: "Pokemon",
+	hp: 110,
+	types: ["Psychic"],
+
+	description: {
+		ja: "非常に 賢いことで 知られる。 未熟な トレーナーは 見下す ベテラン向けの ポケモンだぞ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "もりのしゅうりや" },
+			cost: ["Psychic"],
+			effect: {
+				ja: "自分のトラッシュにある「ポケモンのどうぐ」を3枚、相手に見せてから、手札に加える。",
+			},
+		},
+		{
+			name: { ja: "しねんのずつき" },
+			damage: 70,
+			cost: ["Psychic", "Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560267,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Uncommon",
+	dexId: [765],
+};
+
+export default card;

--- a/data-asia/SM/SM4A/022.ts
+++ b/data-asia/SM/SM4A/022.ts
@@ -1,0 +1,64 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4A";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ウツロイドGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 180,
+	types: ["Psychic"],
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "うつろなひかり" },
+			effect: {
+				ja: "自分の番に、このカードを手札からベンチに出したとき、1回使える。おたがいのバトルポケモンを、それぞれどくとこんらんにする。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "とじこめる" },
+			damage: 120,
+			cost: ["Psychic", "Psychic", "Psychic"],
+			effect: {
+				ja: "次の相手の番、このワザを受けたポケモンは、にげられない。",
+			},
+		},
+		{
+			name: { ja: "パラサイトGX" },
+			cost: ["Psychic", "Psychic", "Psychic"],
+			effect: {
+				ja: "相手の山札を上から2枚、相手のサイドとして置く。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 560268,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Double rare",
+	dexId: [793],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM4A/023.ts
+++ b/data-asia/SM/SM4A/023.ts
@@ -1,0 +1,49 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4A";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "マンキー",
+	},
+
+	illustrator: "Miki Tanaka",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Fighting"],
+
+	description: {
+		ja: "前触れもなく 突然 怒る。 暴れまくって 誰も いなくなると 孤独に 耐えられなくて また怒る。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "さんだんづき" },
+			damage: "10×",
+			cost: ["Fighting"],
+			effect: {
+				ja: "コインを3回投げ、オモテの数x10ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560269,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [56],
+};
+
+export default card;

--- a/data-asia/SM/SM4A/024.ts
+++ b/data-asia/SM/SM4A/024.ts
@@ -1,0 +1,58 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4A";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "オコリザル",
+	},
+
+	illustrator: "Yuka Morii",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Fighting"],
+
+	description: {
+		ja: "あまりに 怒りすぎて そのまま 死んでしまうことが あるほどだが その死に顔は とても 安らか。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "けたぐり" },
+			damage: 30,
+			cost: ["Colorless", "Colorless"],
+		},
+		{
+			name: { ja: "ケンカファイト" },
+			damage: 90,
+			cost: ["Fighting", "Fighting"],
+			effect: {
+				ja: "次の相手の番、このワザを受けたポケモンが使うワザのダメージは「+30」される。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560270,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "マンキー",
+	},
+
+	retreat: 1,
+	rarity: "Uncommon",
+	dexId: [57],
+};
+
+export default card;

--- a/data-asia/SM/SM4A/025.ts
+++ b/data-asia/SM/SM4A/025.ts
@@ -1,0 +1,59 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4A";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "レジロック",
+	},
+
+	illustrator: "kawayoo",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Fighting"],
+
+	description: {
+		ja: "全身が 岩で できている。 戦いで 体が 欠けても 岩を くっつけて 治してしまう。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "いわやまのうなり" },
+			effect: {
+				ja: "このポケモンがいるかぎり、自分の「レジスチル」が使うワザの、相手のバトルポケモンへのダメージは「+10」される。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ハードスイング" },
+			damage: 110,
+			cost: ["Fighting", "Fighting", "Colorless"],
+			effect: {
+				ja: "このワザのダメージは抵抗力を計算しない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560271,
+			},
+		},
+	],
+
+	retreat: 3,
+	rarity: "Uncommon",
+	dexId: [377],
+};
+
+export default card;

--- a/data-asia/SM/SM4A/026.ts
+++ b/data-asia/SM/SM4A/026.ts
@@ -1,0 +1,46 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4A";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヌイコグマ",
+	},
+
+	illustrator: "Kanako Eo",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Fighting"],
+
+	description: {
+		ja: "愛くるしい 見た目だが 怒って ジタバタする 手足に ぶつかると プロレスラーでも 吹っ飛ばされる。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "はねまわる" },
+			damage: 30,
+			cost: ["Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560272,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Common",
+	dexId: [759],
+};
+
+export default card;

--- a/data-asia/SM/SM4A/027.ts
+++ b/data-asia/SM/SM4A/027.ts
@@ -1,0 +1,63 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4A";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "キテルグマ",
+	},
+
+	illustrator: "Saya Tsuruta",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Fighting"],
+
+	description: {
+		ja: "圧倒的な 筋力を 持つ 非常に 危険な ポケモン。 生息地は 基本 立ち入り禁止。",
+	},
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "もふもふ" },
+			effect: {
+				ja: "このポケモンが、相手のポケモン（[炎]ポケモンをのぞく）から受けるワザのダメージは「-30」される。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ふりおろす" },
+			damage: "60+",
+			cost: ["Fighting", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンが進化ポケモンなら、60ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 560273,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ヌイコグマ",
+	},
+
+	retreat: 3,
+	rarity: "Rare",
+	dexId: [760],
+};
+
+export default card;

--- a/data-asia/SM/SM4A/028.ts
+++ b/data-asia/SM/SM4A/028.ts
@@ -1,0 +1,51 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4A";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "デルビル",
+	},
+
+	illustrator: "Kouki Saitou",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Darkness"],
+
+	description: {
+		ja: "夜明けごろ あたり一帯に 響きわたる 不気味な 遠ぼえで 自分たちの 縄張りを アピール。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "うしろげり" },
+			damage: 10,
+			cost: ["Darkness"],
+		},
+		{
+			name: { ja: "やみのキバ" },
+			damage: 20,
+			cost: ["Darkness", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560274,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [228],
+};
+
+export default card;

--- a/data-asia/SM/SM4A/029.ts
+++ b/data-asia/SM/SM4A/029.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4A";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヘルガー",
+	},
+
+	illustrator: "Shin Nagasawa",
+	category: "Pokemon",
+	hp: 110,
+	types: ["Darkness"],
+
+	description: {
+		ja: "ヘルガーの 不気味な 遠ぼえは 地獄から 死神が 呼ぶ 声と 昔の 人は 想像していた。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "ほのおのキバ" },
+			damage: 30,
+			cost: ["Darkness", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをやけどにする。",
+			},
+		},
+		{
+			name: { ja: "つらぬくキバ" },
+			damage: 90,
+			cost: ["Darkness", "Colorless", "Colorless"],
+			effect: {
+				ja: "このワザのダメージは抵抗力を計算しない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560275,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "デルビル",
+	},
+
+	retreat: 1,
+	rarity: "Uncommon",
+	dexId: [229],
+};
+
+export default card;

--- a/data-asia/SM/SM4A/030.ts
+++ b/data-asia/SM/SM4A/030.ts
@@ -1,0 +1,54 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4A";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "モノズ",
+	},
+
+	illustrator: "miki kudo",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Darkness"],
+
+	description: {
+		ja: "目が 見えないため 体当たりしたり かみついて まわりを 探る。 体中 生傷が 絶えない。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ずつき" },
+			damage: 20,
+			cost: ["Darkness", "Colorless"],
+		},
+		{
+			name: { ja: "ふいをつく" },
+			damage: 60,
+			cost: ["Darkness", "Darkness", "Colorless"],
+			effect: {
+				ja: "コインを1回投げウラなら、このワザは失敗。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560276,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Common",
+	dexId: [633],
+};
+
+export default card;

--- a/data-asia/SM/SM4A/031.ts
+++ b/data-asia/SM/SM4A/031.ts
@@ -1,0 +1,58 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4A";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ジヘッド",
+	},
+
+	illustrator: "kodama",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Darkness"],
+
+	description: {
+		ja: "２つの 頭は 仲が 悪く 相手より 多く 食べることで 主導権を 握ろうと する。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "ずつき" },
+			damage: 30,
+			cost: ["Darkness", "Colorless"],
+		},
+		{
+			name: { ja: "ダブルアタック" },
+			damage: "60×",
+			cost: ["Darkness", "Darkness", "Colorless"],
+			effect: {
+				ja: "コインを2回投げ、オモテの数x60ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560277,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "モノズ",
+	},
+
+	retreat: 2,
+	rarity: "Uncommon",
+	dexId: [634],
+};
+
+export default card;

--- a/data-asia/SM/SM4A/032.ts
+++ b/data-asia/SM/SM4A/032.ts
@@ -1,0 +1,63 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4A";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "サザンドラ",
+	},
+
+	illustrator: "Anesaki Dynamic",
+	category: "Pokemon",
+	hp: 160,
+	types: ["Darkness"],
+
+	description: {
+		ja: "両腕の 頭は 脳みそを 持たない。 ３つの 頭で すべてを 食べつくし 破壊してしまう。",
+	},
+
+	stage: "Stage2",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ふるいおとす" },
+			effect: {
+				ja: "自分の番に1回使える。自分のベンチポケモンを3匹選ぶ。その後、選んでいない自分のベンチポケモン全員と、ついているすべてのカードを、トラッシュする。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ダークデストロイ" },
+			damage: 120,
+			cost: ["Darkness", "Darkness", "Colorless"],
+			effect: {
+				ja: "のぞむなら、このポケモンについているエネルギーを、1個トラッシュする。その場合、相手のバトルポケモンについているエネルギーを、1個トラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 560278,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ジヘッド",
+	},
+
+	retreat: 2,
+	rarity: "Rare",
+	dexId: [635],
+};
+
+export default card;

--- a/data-asia/SM/SM4A/033.ts
+++ b/data-asia/SM/SM4A/033.ts
@@ -1,0 +1,59 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4A";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アクジキングGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 210,
+	types: ["Darkness"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "くいちらかす" },
+			cost: ["Darkness"],
+			effect: {
+				ja: "自分の山札を上から5枚トラッシュし、その中にあるエネルギーをすべて、このポケモンにつける。",
+			},
+		},
+		{
+			name: { ja: "タイラントホール" },
+			damage: 180,
+			cost: ["Darkness", "Darkness", "Darkness", "Colorless", "Colorless"],
+		},
+		{
+			name: { ja: "グラトニーGX" },
+			damage: 100,
+			cost: ["Darkness", "Darkness", "Darkness", "Darkness", "Darkness"],
+			effect: {
+				ja: "このワザのダメージで、相手のポケモンがきぜつしたなら、サイドを2枚多くとる。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 560279,
+			},
+		},
+	],
+
+	retreat: 4,
+	rarity: "Double rare",
+	dexId: [799],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM4A/034.ts
+++ b/data-asia/SM/SM4A/034.ts
@@ -1,0 +1,54 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4A";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "プリン",
+	},
+
+	illustrator: "You Iribi",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Fairy"],
+
+	description: {
+		ja: "大きく お腹を 膨らませて 不思議な メロディーを 歌う。 聞くと すぐに 眠くなるぞ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ころがる" },
+			damage: 10,
+			cost: ["Colorless"],
+		},
+		{
+			name: { ja: "おうふくビンタ" },
+			damage: "20×",
+			cost: ["Fairy", "Colorless"],
+			effect: {
+				ja: "コインを2回投げ、オモテの数x20ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [{ type: "Darkness", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560280,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [39],
+};
+
+export default card;

--- a/data-asia/SM/SM4A/035.ts
+++ b/data-asia/SM/SM4A/035.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4A";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "プクリン",
+	},
+
+	illustrator: "0313",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Fairy"],
+
+	description: {
+		ja: "ふわふわの 毛は 季節の 変わり目に 抜け落ちる。 それを 拾い集めて 紡いだ 毛糸は 高級品。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "さいみんはどう" },
+			damage: 30,
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをねむりにする。",
+			},
+		},
+		{
+			name: { ja: "おしおきビンタ" },
+			damage: "60+",
+			cost: ["Fairy", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手の場のポケモンに[悪]エネルギーがついているなら、60ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [{ type: "Darkness", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560281,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "プリン",
+	},
+
+	retreat: 2,
+	rarity: "Uncommon",
+	dexId: [40],
+};
+
+export default card;

--- a/data-asia/SM/SM4A/036.ts
+++ b/data-asia/SM/SM4A/036.ts
@@ -1,0 +1,56 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4A";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ゼルネアス",
+	},
+
+	illustrator: "sui",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Fairy"],
+
+	description: {
+		ja: "永遠の 命を 分け与えると 言われている。 樹木の 姿で １０００年 眠り 復活する。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "みちびく" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札にあるサポートを1枚、相手に見せてから、手札に加える。そして山札を切る。",
+			},
+		},
+		{
+			name: { ja: "ブライトホーン" },
+			damage: 130,
+			cost: ["Fairy", "Fairy", "Fairy"],
+			effect: {
+				ja: "次の自分の番、このポケモンは「ブライトホーン」が使えない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [{ type: "Darkness", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 560282,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Rare",
+	dexId: [716],
+};
+
+export default card;

--- a/data-asia/SM/SM4A/037.ts
+++ b/data-asia/SM/SM4A/037.ts
@@ -1,0 +1,66 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4A";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アローラナッシーGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 220,
+	types: ["Dragon"],
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "トロピカルヘッド" },
+			cost: ["Grass"],
+			effect: {
+				ja: "相手のポケモン1匹に、このポケモンについているエネルギーの数x20ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+			},
+		},
+		{
+			name: { ja: "ドラゴンハンマー" },
+			damage: 120,
+			cost: ["Grass", "Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをこんらんにする。",
+			},
+		},
+		{
+			name: { ja: "タワーゴーランドGX" },
+			damage: 180,
+			cost: ["Grass", "Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "自分の場のポケモンについているエネルギーを好きなだけ選び、自分のポケモンに好きなようにつけ替える。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fairy", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 560283,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "タマタマ",
+	},
+
+	retreat: 3,
+	rarity: "Double rare",
+	dexId: [103],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM4A/038.ts
+++ b/data-asia/SM/SM4A/038.ts
@@ -1,0 +1,51 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4A";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ジャラコ",
+	},
+
+	illustrator: "Atsuko Nishida",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Dragon"],
+
+	description: {
+		ja: "ウロコを 叩き 気持ちを 伝える。 ジャラコの 棲む 高山では 金属音が 木霊する。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ずつき" },
+			damage: 10,
+			cost: ["Colorless"],
+		},
+		{
+			name: { ja: "ひっぱたく" },
+			damage: 20,
+			cost: ["Lightning", "Fighting"],
+		},
+	],
+
+	weaknesses: [{ type: "Fairy", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560284,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [782],
+};
+
+export default card;

--- a/data-asia/SM/SM4A/039.ts
+++ b/data-asia/SM/SM4A/039.ts
@@ -1,0 +1,57 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4A";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ジャランゴ",
+	},
+
+	illustrator: "Masakazu Fukuda",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Dragon"],
+
+	description: {
+		ja: "雄叫びと ともに 獲物に 飛びかかる。 ウロコの パンチは 相手を ズタズタに 引き裂くぞ。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "おたけび" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをベンチポケモンと入れ替える。［バトル場に出すポケモンは相手が選ぶ。］",
+			},
+		},
+		{
+			name: { ja: "ドラゴンクロー" },
+			damage: 40,
+			cost: ["Lightning", "Fighting"],
+		},
+	],
+
+	weaknesses: [{ type: "Fairy", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560285,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ジャラコ",
+	},
+
+	retreat: 1,
+	rarity: "Uncommon",
+	dexId: [783],
+};
+
+export default card;

--- a/data-asia/SM/SM4A/040.ts
+++ b/data-asia/SM/SM4A/040.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4A";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ジャラランガ",
+	},
+
+	illustrator: "kawayoo",
+	category: "Pokemon",
+	hp: 160,
+	types: ["Dragon"],
+
+	description: {
+		ja: "敵を 見ると 尻尾の ウロコを ジャラジャラ 鳴らして いかく。 弱い者は あわてて 逃げ出す。",
+	},
+
+	stage: "Stage2",
+
+	attacks: [
+		{
+			name: { ja: "ウォークライ" },
+			damage: "30+",
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "自分の場のポケモンの数が、相手の場のポケモンの数より少ないなら、90ダメージ追加。",
+			},
+		},
+		{
+			name: { ja: "スケイルノイズ" },
+			damage: 130,
+			cost: ["Lightning", "Fighting", "Colorless"],
+			effect: {
+				ja: "次の相手の番、このポケモンが受けるワザのダメージは「+30」される。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fairy", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 560286,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ジャランゴ",
+	},
+
+	retreat: 2,
+	rarity: "Rare",
+	dexId: [784],
+};
+
+export default card;

--- a/data-asia/SM/SM4A/041.ts
+++ b/data-asia/SM/SM4A/041.ts
@@ -1,0 +1,59 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4A";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ミルタンク",
+	},
+
+	illustrator: "Mina Nakai",
+	category: "Pokemon",
+	hp: 100,
+	types: ["Colorless"],
+
+	description: {
+		ja: "そのミルクは 栄養満点で 高カロリー。 ゆえに 飲みすぎると ミルタンクみたいな 体型に なる。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "モーモーエール" },
+			effect: {
+				ja: "このポケモンがバトル場にいるかぎり、手札から自分のポケモンにエネルギーをつけるたび、そのポケモンのHPを「90」回復する。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ヒップドロップ" },
+			damage: "60+",
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "コインを1回投げオモテなら、30ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560287,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Common",
+	dexId: [241],
+};
+
+export default card;

--- a/data-asia/SM/SM4A/042.ts
+++ b/data-asia/SM/SM4A/042.ts
@@ -1,0 +1,46 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4A";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "チルット",
+	},
+
+	illustrator: "Mitsuhiro Arita",
+	category: "Pokemon",
+	hp: 50,
+	types: ["Colorless"],
+
+	description: {
+		ja: "人の 頭の 上に ちょこんと 乗って 帽子のように ふるまうのが なぜか 大好き。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "つつく" },
+			damage: 10,
+			cost: ["Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560288,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [333],
+};
+
+export default card;

--- a/data-asia/SM/SM4A/043.ts
+++ b/data-asia/SM/SM4A/043.ts
@@ -1,0 +1,60 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4A";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "チルタリス",
+	},
+
+	illustrator: "sui",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Colorless"],
+
+	description: {
+		ja: "大空を ゆったりと 飛ぶ。 チルタリスの 美しい ハミングを 聴くと うっとり 夢心地だ。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "りゅうのメロディ" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "コインを1回投げオモテなら、自分の山札にある[竜]ポケモンを1枚、ベンチに出す。そして山札を切る。",
+			},
+		},
+		{
+			name: { ja: "コットンガード" },
+			damage: 30,
+			cost: ["Colorless"],
+			effect: {
+				ja: "次の相手の番、このポケモンが受けるワザのダメージは「-30」される。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560289,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "チルット",
+	},
+
+	retreat: 1,
+	rarity: "Uncommon",
+	dexId: [334],
+};
+
+export default card;

--- a/data-asia/SM/SM4A/044.ts
+++ b/data-asia/SM/SM4A/044.ts
@@ -1,0 +1,46 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4A";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ホルビー",
+	},
+
+	illustrator: "kirisAki",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Colorless"],
+
+	description: {
+		ja: "大きな 耳で 地面を 掘って 巣穴を 作る。 一晩中 休まずに 掘り続けられる。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "マッドショット" },
+			damage: 30,
+			cost: ["Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560291,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Common",
+	dexId: [659],
+};
+
+export default card;

--- a/data-asia/SM/SM4A/045.ts
+++ b/data-asia/SM/SM4A/045.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4A";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ホルード",
+	},
+
+	illustrator: "Anesaki Dynamic",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Colorless"],
+
+	description: {
+		ja: "大きな 耳は １トンを 超える 岩を 楽に 持ち上げる パワー。 工事現場で 大活躍する。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "あなをほる" },
+			damage: 60,
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "コインを1回投げオモテなら、次の相手の番、このポケモンはワザのダメージや効果を受けない。",
+			},
+		},
+		{
+			name: { ja: "アームハンマー" },
+			damage: 90,
+			cost: ["Colorless", "Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手の山札を上から1枚トラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560292,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ホルビー",
+	},
+
+	retreat: 3,
+	rarity: "Common",
+	dexId: [660],
+};
+
+export default card;

--- a/data-asia/SM/SM4A/046.ts
+++ b/data-asia/SM/SM4A/046.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4A";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ダッシュポーチ",
+	},
+
+	illustrator: "Eske Yoshinob",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードをつけているポケモンがにげるとき、にげるためのエネルギーはトラッシュせず、自分の手札にもどす。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560293,
+			},
+		},
+	],
+
+	trainerType: "Tool",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM4A/047.ts
+++ b/data-asia/SM/SM4A/047.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4A";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ルザミーネ",
+	},
+
+	illustrator: "take",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分のトラッシュにあるサポートとスタジアムを合計2枚、相手に見せてから、手札に加える。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560294,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM4A/048.ts
+++ b/data-asia/SM/SM4A/048.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4A";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "虚ろの海",
+	},
+
+	illustrator: "Ryo Ueda",
+	category: "Trainer",
+
+	effect: {
+		ja: "おたがいの特殊状態のポケモンは、進化・退化しても特殊状態が回復しない。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560295,
+			},
+		},
+	],
+
+	trainerType: "Stadium",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM4A/049.ts
+++ b/data-asia/SM/SM4A/049.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4A";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "喰いつくされた原野",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Trainer",
+
+	effect: {
+		ja: "おたがいの[悪]または[竜]ポケモンが使うワザの、相手のバトルポケモンへのダメージは「+10」される。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560296,
+			},
+		},
+	],
+
+	trainerType: "Stadium",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM4A/050.ts
+++ b/data-asia/SM/SM4A/050.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4A";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "カウンターエネルギー",
+	},
+
+	illustrator: "",
+	category: "Energy",
+	energyType: "Special",
+
+	effect: {
+		ja: "このカードは[無]エネルギー1個ぶんとしてはたらく。このカードは、自分のポケモン（「ポケモンGX・EX」をのぞく）についているとき、自分のサイドの残り枚数が相手のサイドの残り枚数より多いなら、すべてのタイプのエネルギー2個ぶんとしてはたらく。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560297,
+			},
+		},
+	],
+
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM4A/051.ts
+++ b/data-asia/SM/SM4A/051.ts
@@ -1,0 +1,63 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4A";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ギャラドスGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 240,
+	types: ["Water"],
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "たきのぼり" },
+			damage: 70,
+			cost: ["Water", "Colorless", "Colorless"],
+		},
+		{
+			name: { ja: "りゅうのわざわい" },
+			damage: "100+",
+			cost: ["Water", "Colorless", "Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "場にスタジアムが出ているなら、100ダメージ追加。その後、そのスタジアムをトラッシュする。",
+			},
+		},
+		{
+			name: { ja: "ドレッドストームGX" },
+			cost: ["Water"],
+			effect: {
+				ja: "相手の場のポケモン全員についているエネルギーを、1個ずつトラッシュする。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 560299,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "コイキング",
+	},
+
+	retreat: 4,
+	rarity: "Ultra Rare",
+	dexId: [130],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM4A/052.ts
+++ b/data-asia/SM/SM4A/052.ts
@@ -1,0 +1,64 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4A";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ウツロイドGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 180,
+	types: ["Psychic"],
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "うつろなひかり" },
+			effect: {
+				ja: "自分の番に、このカードを手札からベンチに出したとき、1回使える。おたがいのバトルポケモンを、それぞれどくとこんらんにする。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "とじこめる" },
+			damage: 120,
+			cost: ["Psychic", "Psychic", "Psychic"],
+			effect: {
+				ja: "次の相手の番、このワザを受けたポケモンは、にげられない。",
+			},
+		},
+		{
+			name: { ja: "パラサイトGX" },
+			cost: ["Psychic", "Psychic", "Psychic"],
+			effect: {
+				ja: "相手の山札を上から2枚、相手のサイドとして置く。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 560300,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Ultra Rare",
+	dexId: [793],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM4A/053.ts
+++ b/data-asia/SM/SM4A/053.ts
@@ -1,0 +1,59 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4A";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アクジキングGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 210,
+	types: ["Darkness"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "くいちらかす" },
+			cost: ["Darkness"],
+			effect: {
+				ja: "自分の山札を上から5枚トラッシュし、その中にあるエネルギーをすべて、このポケモンにつける。",
+			},
+		},
+		{
+			name: { ja: "タイラントホール" },
+			damage: 180,
+			cost: ["Darkness", "Darkness", "Darkness", "Colorless", "Colorless"],
+		},
+		{
+			name: { ja: "グラトニーGX" },
+			damage: 100,
+			cost: ["Darkness", "Darkness", "Darkness", "Darkness", "Darkness"],
+			effect: {
+				ja: "このワザのダメージで、相手のポケモンがきぜつしたなら、サイドを2枚多くとる。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 560301,
+			},
+		},
+	],
+
+	retreat: 4,
+	rarity: "Ultra Rare",
+	dexId: [799],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM4A/054.ts
+++ b/data-asia/SM/SM4A/054.ts
@@ -1,0 +1,66 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4A";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アローラナッシーGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 220,
+	types: ["Dragon"],
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "トロピカルヘッド" },
+			cost: ["Grass"],
+			effect: {
+				ja: "相手のポケモン1匹に、このポケモンについているエネルギーの数x20ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+			},
+		},
+		{
+			name: { ja: "ドラゴンハンマー" },
+			damage: 120,
+			cost: ["Grass", "Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをこんらんにする。",
+			},
+		},
+		{
+			name: { ja: "タワーゴーランドGX" },
+			damage: 180,
+			cost: ["Grass", "Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "自分の場のポケモンについているエネルギーを好きなだけ選び、自分のポケモンに好きなようにつけ替える。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fairy", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 560302,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "タマタマ",
+	},
+
+	retreat: 3,
+	rarity: "Ultra Rare",
+	dexId: [103],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM4A/055.ts
+++ b/data-asia/SM/SM4A/055.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4A";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ルザミーネ",
+	},
+
+	illustrator: "Megumi Mizutani",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分のトラッシュにあるサポートとスタジアムを合計2枚、相手に見せてから、手札に加える。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 560303,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	rarity: "Ultra Rare",
+};
+
+export default card;

--- a/data-asia/SM/SM4A/056.ts
+++ b/data-asia/SM/SM4A/056.ts
@@ -1,0 +1,63 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4A";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ギャラドスGX",
+	},
+
+	illustrator: "",
+	category: "Pokemon",
+	hp: 240,
+	types: ["Water"],
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "たきのぼり" },
+			damage: 70,
+			cost: ["Water", "Colorless", "Colorless"],
+		},
+		{
+			name: { ja: "りゅうのわざわい" },
+			damage: "100+",
+			cost: ["Water", "Colorless", "Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "場にスタジアムが出ているなら、100ダメージ追加。その後、そのスタジアムをトラッシュする。",
+			},
+		},
+		{
+			name: { ja: "ドレッドストームGX" },
+			cost: ["Water"],
+			effect: {
+				ja: "相手の場のポケモン全員についているエネルギーを、1個ずつトラッシュする。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 560304,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "コイキング",
+	},
+
+	retreat: 4,
+	rarity: "Hyper rare",
+	dexId: [130],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM4A/057.ts
+++ b/data-asia/SM/SM4A/057.ts
@@ -1,0 +1,64 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4A";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ウツロイドGX",
+	},
+
+	illustrator: "",
+	category: "Pokemon",
+	hp: 180,
+	types: ["Psychic"],
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "うつろなひかり" },
+			effect: {
+				ja: "自分の番に、このカードを手札からベンチに出したとき、1回使える。おたがいのバトルポケモンを、それぞれどくとこんらんにする。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "とじこめる" },
+			damage: 120,
+			cost: ["Psychic", "Psychic", "Psychic"],
+			effect: {
+				ja: "次の相手の番、このワザを受けたポケモンは、にげられない。",
+			},
+		},
+		{
+			name: { ja: "パラサイトGX" },
+			cost: ["Psychic", "Psychic", "Psychic"],
+			effect: {
+				ja: "相手の山札を上から2枚、相手のサイドとして置く。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 560305,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Hyper rare",
+	dexId: [793],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM4A/058.ts
+++ b/data-asia/SM/SM4A/058.ts
@@ -1,0 +1,59 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4A";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アクジキングGX",
+	},
+
+	illustrator: "",
+	category: "Pokemon",
+	hp: 210,
+	types: ["Darkness"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "くいちらかす" },
+			cost: ["Darkness"],
+			effect: {
+				ja: "自分の山札を上から5枚トラッシュし、その中にあるエネルギーをすべて、このポケモンにつける。",
+			},
+		},
+		{
+			name: { ja: "タイラントホール" },
+			damage: 180,
+			cost: ["Darkness", "Darkness", "Darkness", "Colorless", "Colorless"],
+		},
+		{
+			name: { ja: "グラトニーGX" },
+			damage: 100,
+			cost: ["Darkness", "Darkness", "Darkness", "Darkness", "Darkness"],
+			effect: {
+				ja: "このワザのダメージで、相手のポケモンがきぜつしたなら、サイドを2枚多くとる。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 560306,
+			},
+		},
+	],
+
+	retreat: 4,
+	rarity: "Hyper rare",
+	dexId: [799],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM4A/059.ts
+++ b/data-asia/SM/SM4A/059.ts
@@ -1,0 +1,66 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4A";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アローラナッシーGX",
+	},
+
+	illustrator: "",
+	category: "Pokemon",
+	hp: 220,
+	types: ["Dragon"],
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "トロピカルヘッド" },
+			cost: ["Grass"],
+			effect: {
+				ja: "相手のポケモン1匹に、このポケモンについているエネルギーの数x20ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+			},
+		},
+		{
+			name: { ja: "ドラゴンハンマー" },
+			damage: 120,
+			cost: ["Grass", "Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをこんらんにする。",
+			},
+		},
+		{
+			name: { ja: "タワーゴーランドGX" },
+			damage: 180,
+			cost: ["Grass", "Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "自分の場のポケモンについているエネルギーを好きなだけ選び、自分のポケモンに好きなようにつけ替える。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fairy", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 560307,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "タマタマ",
+	},
+
+	retreat: 3,
+	rarity: "Hyper rare",
+	dexId: [103],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM4A/060.ts
+++ b/data-asia/SM/SM4A/060.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4A";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ねがいのバトン",
+	},
+
+	illustrator: "",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードをつけているポケモンが、バトル場で相手のワザのダメージを受けてきぜつしたとき、そのポケモンについている基本エネルギーを3枚まで、自分のベンチポケモン1匹につけ替える。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 560308,
+			},
+		},
+	],
+
+	trainerType: "Tool",
+	rarity: "Secret Rare",
+};
+
+export default card;

--- a/data-asia/SM/SM4A/061.ts
+++ b/data-asia/SM/SM4A/061.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4A";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "カウンターエネルギー",
+	},
+
+	illustrator: "",
+	category: "Energy",
+	energyType: "Special",
+
+	effect: {
+		ja: "このカードは[無]エネルギー1個ぶんとしてはたらく。このカードは、自分のポケモン（「ポケモンGX・EX」をのぞく）についているとき、自分のサイドの残り枚数が相手のサイドの残り枚数より多いなら、すべてのタイプのエネルギー2個ぶんとしてはたらく。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 560309,
+			},
+		},
+	],
+
+	rarity: "Secret Rare",
+};
+
+export default card;


### PR DESCRIPTION
## What

Adds the complete Japanese set **SM4A 超次元の暴獣 (Beasts from the Ultradimension)**, released 2017-09-15:

- `data-asia/SM/SM4A/001.ts` … `061.ts` — all 61 cards (50 regular + 11 secret rares: 5 SR, 2 Secret Rare, 4 UR)
- the set definition `data-asia/SM/SM4A.ts` already existed and is untouched

## Data sources

- **pokemon-card.com** (official database): Japanese names, flavor texts, National Dex numbers, official card count
- **limitlesstcg.com**: full Japanese card text, stages, weaknesses/resistances/retreat, rarities, illustrators, attack costs
- **Cardmarket**: product IDs as `thirdParty.cardmarket` on the variant objects (560241–560309; tcgplayer IDs not available to me)

## Notes

- Follows the file format and conventions of the M-era sets (#1728)
- No `regulationMark` (the set predates regulation marks); resistances are `-20` per the era
- All 61 files type-check against `interfaces.d.ts` (`tsc --noEmit`)
