### PR TITLE
(data) Add Japanese SM set SM4S Awakened Heroes

### DIFF
--- a/data-asia/SM/SM4S/001.ts
+++ b/data-asia/SM/SM4S/001.ts
@@ -1,0 +1,49 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4S";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "サボネア",
+	},
+
+	illustrator: "Anesaki Dynamic",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Grass"],
+
+	description: {
+		ja: "雨が 少ない 乾燥した 地域に 生息。 １年に １回 黄色の 花を 咲かせる。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ふいうち" },
+			damage: "10+",
+			cost: ["Grass"],
+			effect: {
+				ja: "このポケモンに[悪]エネルギーがついているなら、30ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560313,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [331],
+};
+
+export default card;

--- a/data-asia/SM/SM4S/002.ts
+++ b/data-asia/SM/SM4S/002.ts
@@ -1,0 +1,60 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4S";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ノクタス",
+	},
+
+	illustrator: "Mina Nakai",
+	category: "Pokemon",
+	hp: 110,
+	types: ["Grass"],
+
+	description: {
+		ja: "夜になると 活動を はじめる。 砂漠の 暑さに 疲れ果てた 獲物を 見つけ出し 捕らえるのだ。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "トゲでえぐる" },
+			damage: "30+",
+			cost: ["Grass"],
+			effect: {
+				ja: "相手のバトルポケモンにダメカンがのっているなら、60ダメージ追加。",
+			},
+		},
+		{
+			name: { ja: "つけねらう" },
+			cost: ["Grass", "Colorless"],
+			effect: {
+				ja: "相手のベンチポケモンを1匹選び、バトルポケモンと入れ替える。その後、新しく出てきたポケモンに40ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560314,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "サボネア",
+	},
+
+	retreat: 2,
+	rarity: "Uncommon",
+	dexId: [332],
+};
+
+export default card;

--- a/data-asia/SM/SM4S/003.ts
+++ b/data-asia/SM/SM4S/003.ts
@@ -1,0 +1,56 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4S";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "カブルモ",
+	},
+
+	illustrator: "OOYAMA",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Grass"],
+
+	description: {
+		ja: "チョボマキと 一緒に いるときに 電気的な 刺激を 受けると 進化する 不思議な ポケモンだ。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "カラかぶり" },
+			effect: {
+				ja: "自分の番に1回使える。自分の手札にある「チョボマキ」を、1枚トラッシュする。その後、このポケモンから進化するカードを、自分の山札から1枚選び、このポケモンにのせて進化させる。そして山札を切る。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "つつく" },
+			damage: 30,
+			cost: ["Colorless", "Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560315,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Common",
+	dexId: [588],
+};
+
+export default card;

--- a/data-asia/SM/SM4S/004.ts
+++ b/data-asia/SM/SM4S/004.ts
@@ -1,0 +1,46 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4S";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "メェークル",
+	},
+
+	illustrator: "Naoki Saito",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Grass"],
+
+	description: {
+		ja: "人と 暮らすようになった 最初の ポケモンと 言われる。 穏やかな 性格の ポケモン。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "タネばくだん" },
+			damage: 20,
+			cost: ["Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560316,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [672],
+};
+
+export default card;

--- a/data-asia/SM/SM4S/005.ts
+++ b/data-asia/SM/SM4S/005.ts
@@ -1,0 +1,63 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4S";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ゴーゴート",
+	},
+
+	illustrator: "You Iribi",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Grass"],
+
+	description: {
+		ja: "ツノを 握る わずかな 違いから トレーナーの 気持ちを 読み取るので 一体となって 走れるのだ。",
+	},
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "そうしょく" },
+			effect: {
+				ja: "このポケモンが使うワザの、相手の[草]ポケモンへのダメージは「+80」される。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ウッドホーン" },
+			damage: 80,
+			cost: ["Grass", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンのHPを「20」回復する。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 560317,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "メェークル",
+	},
+
+	retreat: 2,
+	rarity: "Rare",
+	dexId: [673],
+};
+
+export default card;

--- a/data-asia/SM/SM4S/006.ts
+++ b/data-asia/SM/SM4S/006.ts
@@ -1,0 +1,60 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4S";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アローラガラガラ",
+	},
+
+	illustrator: "Mitsuhiro Arita",
+	category: "Pokemon",
+	hp: 100,
+	types: ["Fire"],
+
+	description: {
+		ja: "手にした ホネは 母のホネ。 死してなお 子を想う 母の無念は 炎となって ガラガラを 守る。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "ファイヤーダンス" },
+			cost: [],
+			effect: {
+				ja: "自分のトラッシュにある[炎]エネルギーを、相手の場のポケモンについているエネルギーの数ぶん、自分のポケモンに好きなようにつける。",
+			},
+		},
+		{
+			name: { ja: "もえるホネブーメラン" },
+			damage: "70×",
+			cost: ["Fire", "Fire", "Colorless"],
+			effect: {
+				ja: "コインを2回投げ、オモテの数x70ダメージ。1回でもオモテなら、相手のバトルポケモンをやけどにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 560318,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "カラカラ",
+	},
+
+	retreat: 2,
+	rarity: "Rare",
+	dexId: [105],
+};
+
+export default card;

--- a/data-asia/SM/SM4S/007.ts
+++ b/data-asia/SM/SM4S/007.ts
@@ -1,0 +1,49 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4S";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ドンメル",
+	},
+
+	illustrator: "sui",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Fire"],
+
+	description: {
+		ja: "灼熱の マグマを 背中の コブに ためている。 雨に 当たると マグマが 冷えて 動きが 鈍る。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "れんぞくずつき" },
+			damage: "30×",
+			cost: ["Fire", "Colorless"],
+			effect: {
+				ja: "ウラが出るまでコインを投げ、オモテの数x30ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560319,
+			},
+		},
+	],
+
+	retreat: 3,
+	rarity: "Common",
+	dexId: [322],
+};
+
+export default card;

--- a/data-asia/SM/SM4S/008.ts
+++ b/data-asia/SM/SM4S/008.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4S";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "バクーダ",
+	},
+
+	illustrator: "Anesaki Dynamic",
+	category: "Pokemon",
+	hp: 140,
+	types: ["Fire"],
+
+	description: {
+		ja: "背中の コブの 火山は １０年ごとに 大噴火 するが 激しく 怒っても 噴火する。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "れんぞくずつき" },
+			damage: "80×",
+			cost: ["Fire", "Colorless", "Colorless"],
+			effect: {
+				ja: "ウラが出るまでコインを投げ、オモテの数x80ダメージ。",
+			},
+		},
+		{
+			name: { ja: "やきこがす" },
+			damage: 120,
+			cost: ["Fire", "Fire", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをやけどにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560320,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ドンメル",
+	},
+
+	retreat: 4,
+	rarity: "Uncommon",
+	dexId: [323],
+};
+
+export default card;

--- a/data-asia/SM/SM4S/009.ts
+++ b/data-asia/SM/SM4S/009.ts
@@ -1,0 +1,46 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4S";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヒトデマン",
+	},
+
+	illustrator: "Yukiko Baba",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Water"],
+
+	description: {
+		ja: "海辺に 多く 生息。 夜に なると 身体の 中心が 怪しく 赤く 輝きだす。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "かいてんアタック" },
+			damage: 10,
+			cost: ["Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560321,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [120],
+};
+
+export default card;

--- a/data-asia/SM/SM4S/010.ts
+++ b/data-asia/SM/SM4S/010.ts
@@ -1,0 +1,60 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4S";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "スターミー",
+	},
+
+	illustrator: "Yuka Morii",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Water"],
+
+	description: {
+		ja: "輝く コアから 謎の 電波を 送受信 していると いう。 近づくと 頭痛が することも。",
+	},
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "エスケープ" },
+			effect: {
+				ja: "自分の番に1回使える。このポケモンと、ついているすべてのカードを、自分の山札にもどして切る。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "かいてんアタック" },
+			damage: 40,
+			cost: ["Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560322,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ヒトデマン",
+	},
+
+	retreat: 1,
+	rarity: "Uncommon",
+	dexId: [121],
+};
+
+export default card;

--- a/data-asia/SM/SM4S/011.ts
+++ b/data-asia/SM/SM4S/011.ts
@@ -1,0 +1,46 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4S";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "テッポウオ",
+	},
+
+	illustrator: "Aya Kusube",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Water"],
+
+	description: {
+		ja: "ねらいは 正確。 噴き出す 水は １００メートル先で 動く 獲物に かならず 命中する。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "みずでっぽう" },
+			damage: 30,
+			cost: ["Water", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560323,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [223],
+};
+
+export default card;

--- a/data-asia/SM/SM4S/012.ts
+++ b/data-asia/SM/SM4S/012.ts
@@ -1,0 +1,60 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4S";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "オクタン",
+	},
+
+	illustrator: "tetsuya koizumi",
+	category: "Pokemon",
+	hp: 100,
+	types: ["Water"],
+
+	description: {
+		ja: "穴に 入りたがる 性質で 岩穴や ツボを 好み そこから 墨を 噴き出して 攻撃する。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "すみをはく" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "次の相手の番、このワザを受けたポケモンがワザを使うとき、相手はコインを1回投げる。ウラならそのワザは失敗。",
+			},
+		},
+		{
+			name: { ja: "スペシャルほう" },
+			damage: "40+",
+			cost: ["Water", "Colorless"],
+			effect: {
+				ja: "のぞむなら、このポケモンについている特殊エネルギーを、1個トラッシュする。その場合、80ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560324,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "テッポウオ",
+	},
+
+	retreat: 2,
+	rarity: "Uncommon",
+	dexId: [224],
+};
+
+export default card;

--- a/data-asia/SM/SM4S/013.ts
+++ b/data-asia/SM/SM4S/013.ts
@@ -1,0 +1,46 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4S";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヘイガニ",
+	},
+
+	illustrator: "Masakazu Fukuda",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Water"],
+
+	description: {
+		ja: "どんなに 水が 汚れた 川でも 適応して 増えていく タフな 生命力の 持ち主。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "クラブハンマー" },
+			damage: 30,
+			cost: ["Water", "Water"],
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560325,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Common",
+	dexId: [341],
+};
+
+export default card;

--- a/data-asia/SM/SM4S/014.ts
+++ b/data-asia/SM/SM4S/014.ts
@@ -1,0 +1,53 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4S";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "シザリガー",
+	},
+
+	illustrator: "Saya Tsuruta",
+	category: "Pokemon",
+	hp: 110,
+	types: ["Water"],
+
+	description: {
+		ja: "池に 住む ほかの ポケモンを ハサミで つまみ上げ 池の 外へ 放り出してしまう 暴れん坊。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "ダブルニッパー" },
+			damage: 80,
+			cost: ["Water", "Water", "Water", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンについているエネルギーを、2個トラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560326,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ヘイガニ",
+	},
+
+	retreat: 2,
+	rarity: "Uncommon",
+	dexId: [342],
+};
+
+export default card;

--- a/data-asia/SM/SM4S/015.ts
+++ b/data-asia/SM/SM4S/015.ts
@@ -1,0 +1,53 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4S";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "カラナクシ",
+	},
+
+	illustrator: "Kouki Saitou",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Water"],
+
+	description: {
+		ja: "磯が 主な 棲みか。 生息地の 環境や 餌の 質で 色や 姿が 異なる。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "さいせい" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "このポケモンのHPを「30」回復する。",
+			},
+		},
+		{
+			name: { ja: "どろかけ" },
+			damage: 10,
+			cost: ["Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560327,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [422],
+};
+
+export default card;

--- a/data-asia/SM/SM4S/016.ts
+++ b/data-asia/SM/SM4S/016.ts
@@ -1,0 +1,53 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4S";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アローライシツブテ",
+	},
+
+	illustrator: "Mitsuhiro Arita",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Lightning"],
+
+	description: {
+		ja: "磁力を 帯びた 石の身体。 特に 磁力が 強い 部分には 砂鉄が ビッシリ ついてるよ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "まるくなる" },
+			cost: [],
+			effect: {
+				ja: "コインを1回投げオモテなら、次の相手の番、このポケモンはワザのダメージを受けない。",
+			},
+		},
+		{
+			name: { ja: "たいあたり" },
+			damage: 20,
+			cost: ["Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Metal", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560328,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Common",
+	dexId: [74],
+};
+
+export default card;

--- a/data-asia/SM/SM4S/017.ts
+++ b/data-asia/SM/SM4S/017.ts
@@ -1,0 +1,58 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4S";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アローラゴローン",
+	},
+
+	illustrator: "kirisAki",
+	category: "Pokemon",
+	hp: 100,
+	types: ["Lightning"],
+
+	description: {
+		ja: "ドラバイトを 好んで 喰らう。 喰った 成分が 結晶になり 身体の一部に 浮きだしているぞ。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "どつく" },
+			damage: 30,
+			cost: ["Colorless", "Colorless"],
+		},
+		{
+			name: { ja: "じばく" },
+			damage: 100,
+			cost: ["Lightning", "Lightning", "Colorless"],
+			effect: {
+				ja: "このポケモンにも100ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Metal", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560329,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "アローライシツブテ",
+	},
+
+	retreat: 3,
+	rarity: "Uncommon",
+	dexId: [75],
+};
+
+export default card;

--- a/data-asia/SM/SM4S/018.ts
+++ b/data-asia/SM/SM4S/018.ts
@@ -1,0 +1,64 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4S";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アローラゴローニャGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 250,
+	types: ["Lightning"],
+
+	stage: "Stage2",
+
+	attacks: [
+		{
+			name: { ja: "ぶちかます" },
+			damage: 80,
+			cost: ["Lightning", "Colorless", "Colorless"],
+		},
+		{
+			name: { ja: "ちょうでんじタックル" },
+			damage: 200,
+			cost: ["Lightning", "Lightning", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンにも50ダメージ。",
+			},
+		},
+		{
+			name: { ja: "ヘビーロックGX" },
+			damage: 100,
+			cost: ["Lightning", "Lightning", "Colorless", "Colorless"],
+			effect: {
+				ja: "次の相手の番、相手は手札からカードを出して使えない。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Metal", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 560330,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "アローラゴローン",
+	},
+
+	retreat: 4,
+	rarity: "Double rare",
+	dexId: [76],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM4S/019.ts
+++ b/data-asia/SM/SM4S/019.ts
@@ -1,0 +1,56 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4S";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "エモンガ",
+	},
+
+	illustrator: "Kagemaru Himeno",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Lightning"],
+
+	description: {
+		ja: "マントのような 膜で 滑空。 電気を まき散らして 敵も 味方も 感電 させまくる。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "エネキャッチ" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分のトラッシュにある基本エネルギーを3枚、相手に見せてから、手札に加える。",
+			},
+		},
+		{
+			name: { ja: "ボルトチェンジ" },
+			damage: 30,
+			cost: ["Lightning"],
+			effect: {
+				ja: "このポケモンをベンチの[雷]ポケモンと入れ替える。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560331,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [587],
+};
+
+export default card;

--- a/data-asia/SM/SM4S/020.ts
+++ b/data-asia/SM/SM4S/020.ts
@@ -1,0 +1,48 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4S";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ゴース",
+	},
+
+	illustrator: "Shibuzoh.",
+	category: "Pokemon",
+	hp: 50,
+	types: ["Psychic"],
+
+	description: {
+		ja: "廃墟に なった 建物に 怪しい光が 灯っていたら そこに ゴースが 潜んでいる。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ふきつなめ" },
+			cost: ["Psychic"],
+			effect: {
+				ja: "相手のポケモン1匹に、ダメカンを1個のせる。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560332,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [92],
+};
+
+export default card;

--- a/data-asia/SM/SM4S/021.ts
+++ b/data-asia/SM/SM4S/021.ts
@@ -1,0 +1,52 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4S";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ゴースト",
+	},
+
+	illustrator: "Eri Yamaki",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Psychic"],
+
+	description: {
+		ja: "暗闇から 人間を 狙う。 冷たい 舌に 舐められると 日に日に 弱り 死に 至る。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "ダメージぞうふく" },
+			cost: ["Psychic"],
+			effect: {
+				ja: "ダメカンがのっている相手のポケモン全員に、それぞれダメカンを2個のせる。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560333,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ゴース",
+	},
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [93],
+};
+
+export default card;

--- a/data-asia/SM/SM4S/022.ts
+++ b/data-asia/SM/SM4S/022.ts
@@ -1,0 +1,63 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4S";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ゲンガー",
+	},
+
+	illustrator: "Shin Nagasawa",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Psychic"],
+
+	description: {
+		ja: "突然 寒気に 襲われたら ゲンガーに 狙われた 証拠。 逃げる術は ないので 諦めろ。",
+	},
+
+	stage: "Stage2",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "むしばむのろい" },
+			effect: {
+				ja: "このポケモンがいるかぎり、相手は手札からエネルギーをポケモンにつけるたび、そのポケモンにダメカンを2個のせる。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "あんこく" },
+			damage: 70,
+			cost: ["Psychic", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをこんらんにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 560334,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ゴースト",
+	},
+
+	retreat: 0,
+	rarity: "Rare",
+	dexId: [94],
+};
+
+export default card;

--- a/data-asia/SM/SM4S/023.ts
+++ b/data-asia/SM/SM4S/023.ts
@@ -1,0 +1,49 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4S";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "チリーン",
+	},
+
+	illustrator: "Kanako Eo",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Psychic"],
+
+	description: {
+		ja: "頭の 吸盤で 木の 枝や 家の 軒下に ぶら下がる。 ７種類 音色を 使い分ける。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ちんもくのすず" },
+			damage: 10,
+			cost: ["Psychic"],
+			effect: {
+				ja: "次の相手の番、相手は手札から特性を持つポケモンを場に出せない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560335,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [358],
+};
+
+export default card;

--- a/data-asia/SM/SM4S/024.ts
+++ b/data-asia/SM/SM4S/024.ts
@@ -1,0 +1,48 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4S";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "バケッチャ",
+	},
+
+	illustrator: "Miki Tanaka",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Psychic"],
+
+	description: {
+		ja: "成仏できない 魂を カボチャの 体に 入れている。 日暮れと ともに 動きはじめる。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "おどろかす" },
+			cost: ["Psychic"],
+			effect: {
+				ja: "相手の手札からオモテを見ないで1枚選び、そのカードのオモテを見てから、相手の山札にもどして切る。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560336,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Common",
+	dexId: [710],
+};
+
+export default card;

--- a/data-asia/SM/SM4S/025.ts
+++ b/data-asia/SM/SM4S/025.ts
@@ -1,0 +1,60 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4S";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "パンプジン",
+	},
+
+	illustrator: "kirisAki",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Psychic"],
+
+	description: {
+		ja: "新月の 夜に 不気味な 声で 歌いながら 街中を さまよう。 その歌を 聞くと のろわれる。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "あやしいひかり" },
+			cost: ["Psychic"],
+			effect: {
+				ja: "相手のバトルポケモンをこんらんにする。",
+			},
+		},
+		{
+			name: { ja: "パンプキンボム" },
+			damage: "10+",
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "ダメージを与える前に、自分の場にある「ポケモンのどうぐ」を好きなだけトラッシュし、その枚数x40ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560337,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "バケッチャ",
+	},
+
+	retreat: 3,
+	rarity: "Uncommon",
+	dexId: [711],
+};
+
+export default card;

--- a/data-asia/SM/SM4S/026.ts
+++ b/data-asia/SM/SM4S/026.ts
@@ -1,0 +1,48 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4S";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヤトウモリ",
+	},
+
+	illustrator: "tetsuya koizumi",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Psychic"],
+
+	description: {
+		ja: "体液を 燃やし 毒ガスを たく。 ガスを 吸った 敵が フラフラに なったあと 襲いかかるのだ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "こがす" },
+			cost: ["Psychic"],
+			effect: {
+				ja: "相手のバトルポケモンをやけどにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560338,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [757],
+};
+
+export default card;

--- a/data-asia/SM/SM4S/027.ts
+++ b/data-asia/SM/SM4S/027.ts
@@ -1,0 +1,59 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4S";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "エンニュート",
+	},
+
+	illustrator: "Shin Nagasawa",
+	category: "Pokemon",
+	hp: 110,
+	types: ["Psychic"],
+
+	description: {
+		ja: "なぜか ♀しか 見つかっていない。 ヤトウモリの♂を 引き連れて 逆ハーレムを 作って 暮らす。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "わるだくみ" },
+			cost: ["Psychic"],
+			effect: {
+				ja: "自分の山札にある好きなカードを2枚まで、手札に加える。そして山札を切る。",
+			},
+		},
+		{
+			name: { ja: "バッドポイズン" },
+			cost: ["Psychic"],
+			effect: {
+				ja: "相手のバトルポケモンをどくにする。このどくでのせるダメカンの数は4個になる。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 560339,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ヤトウモリ",
+	},
+
+	retreat: 1,
+	rarity: "Rare",
+	dexId: [758],
+};
+
+export default card;

--- a/data-asia/SM/SM4S/028.ts
+++ b/data-asia/SM/SM4S/028.ts
@@ -1,0 +1,53 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4S";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "カラカラ",
+	},
+
+	illustrator: "sui",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Fighting"],
+
+	description: {
+		ja: "死に別れた 母を 思いだして 大声で 泣く。 声を聞きつけた バルジーナに 空から 狙われる。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "にらみつける" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "コインを1回投げオモテなら、相手のバトルポケモンをマヒにする。",
+			},
+		},
+		{
+			name: { ja: "ずつき" },
+			damage: 20,
+			cost: ["Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560340,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Common",
+	dexId: [104],
+};
+
+export default card;

--- a/data-asia/SM/SM4S/029.ts
+++ b/data-asia/SM/SM4S/029.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4S";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "トリトドン",
+	},
+
+	illustrator: "TOKIYA",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Fighting"],
+
+	description: {
+		ja: "再生能力が 高い。 さかなポケモンに 喰い千切られても 数時間で 元通りに なるよ。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "ぶきみなしる" },
+			damage: 30,
+			cost: ["Fighting", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをこんらんにする。",
+			},
+		},
+		{
+			name: { ja: "じしん" },
+			damage: 120,
+			cost: ["Fighting", "Fighting", "Colorless"],
+			effect: {
+				ja: "自分のベンチポケモン全員にも、それぞれ10ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560341,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "カラナクシ",
+	},
+
+	retreat: 3,
+	rarity: "Common",
+	dexId: [423],
+};
+
+export default card;

--- a/data-asia/SM/SM4S/030.ts
+++ b/data-asia/SM/SM4S/030.ts
@@ -1,0 +1,63 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4S";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "マッシブーンGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 190,
+	types: ["Fighting"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ジェットパンチ" },
+			damage: 30,
+			cost: ["Fighting"],
+			effect: {
+				ja: "相手のベンチポケモン1匹にも、30ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+			},
+		},
+		{
+			name: { ja: "ナックルインパクト" },
+			damage: 160,
+			cost: ["Fighting", "Fighting", "Fighting"],
+			effect: {
+				ja: "次の自分の番、このポケモンはワザが使えない。",
+			},
+		},
+		{
+			name: { ja: "イクスパンションGX" },
+			damage: "40×",
+			cost: ["Fighting", "Fighting", "Fighting"],
+			effect: {
+				ja: "自分のサイドの枚数x40ダメージ。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 560342,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Double rare",
+	dexId: [794],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM4S/031.ts
+++ b/data-asia/SM/SM4S/031.ts
@@ -1,0 +1,56 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4S";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "クチート",
+	},
+
+	illustrator: "tetsuya koizumi",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Metal"],
+
+	description: {
+		ja: "おとなしい 顔で 相手を 油断 させてから おおあごで がぶり。 かみつくと 絶対に 放さない。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "なかまをよぶ" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札にあるたねポケモンを2枚まで、ベンチに出す。そして山札を切る。",
+			},
+		},
+		{
+			name: { ja: "かみくだく" },
+			damage: 30,
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "コインを1回投げオモテなら、相手のバトルポケモンについているエネルギーを、1個トラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560343,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [303],
+};
+
+export default card;

--- a/data-asia/SM/SM4S/032.ts
+++ b/data-asia/SM/SM4S/032.ts
@@ -1,0 +1,51 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4S";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ココドラ",
+	},
+
+	illustrator: "TOKIYA",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Metal"],
+
+	description: {
+		ja: "普段は 山奥で 暮らしているが お腹が すくと ふもとに 現われ 線路や 車を 食べてしまう。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "たいあたり" },
+			damage: 10,
+			cost: ["Metal"],
+		},
+		{
+			name: { ja: "メタルクロー" },
+			damage: 30,
+			cost: ["Metal", "Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560344,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [304],
+};
+
+export default card;

--- a/data-asia/SM/SM4S/033.ts
+++ b/data-asia/SM/SM4S/033.ts
@@ -1,0 +1,55 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4S";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "コドラ",
+	},
+
+	illustrator: "Atsuko Nishida",
+	category: "Pokemon",
+	hp: 100,
+	types: ["Metal"],
+
+	description: {
+		ja: "鉄鉱石が 大好物。 鋼の 体を ぶつけ合って 縄張り 争いを する。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "メタルクロー" },
+			damage: 20,
+			cost: ["Metal"],
+		},
+		{
+			name: { ja: "ぶちかます" },
+			damage: 80,
+			cost: ["Metal", "Metal", "Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560345,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ココドラ",
+	},
+
+	retreat: 3,
+	rarity: "Uncommon",
+	dexId: [305],
+};
+
+export default card;

--- a/data-asia/SM/SM4S/034.ts
+++ b/data-asia/SM/SM4S/034.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4S";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ボスゴドラ",
+	},
+
+	illustrator: "Yoshinobu Saito",
+	category: "Pokemon",
+	hp: 170,
+	types: ["Metal"],
+
+	description: {
+		ja: "山を まるごと 縄張りに する。 傷が 多い ボスゴドラほど 戦っているので 侮れない。",
+	},
+
+	stage: "Stage2",
+
+	attacks: [
+		{
+			name: { ja: "リベンジほう" },
+			damage: "10+",
+			cost: ["Metal", "Colorless", "Colorless"],
+			effect: {
+				ja: "自分のベンチポケモンにのっているダメカンの数x10ダメージ追加。",
+			},
+		},
+		{
+			name: { ja: "バスタースイング" },
+			damage: 120,
+			cost: ["Metal", "Metal", "Colorless", "Colorless"],
+			effect: {
+				ja: "このワザのダメージは抵抗力を計算しない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 560346,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "コドラ",
+	},
+
+	retreat: 4,
+	rarity: "Rare",
+	dexId: [306],
+};
+
+export default card;

--- a/data-asia/SM/SM4S/035.ts
+++ b/data-asia/SM/SM4S/035.ts
@@ -1,0 +1,57 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4S";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "レジスチル",
+	},
+
+	illustrator: "Mitsuhiro Arita",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Metal"],
+
+	description: {
+		ja: "何万年も 地下の 圧力で 鍛えられた 金属の ボディは 傷ひとつ つかない。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ターボアーム" },
+			damage: 30,
+			cost: ["Metal"],
+			effect: {
+				ja: "自分のトラッシュにある基本エネルギーを1枚、ベンチポケモンにつける。",
+			},
+		},
+		{
+			name: { ja: "くろがねのこぶし" },
+			damage: 90,
+			cost: ["Metal", "Metal", "Colorless"],
+			effect: {
+				ja: "自分のベンチに「レジアイス」がいるなら、このポケモンのHPを「30」回復する。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560347,
+			},
+		},
+	],
+
+	retreat: 3,
+	rarity: "Uncommon",
+	dexId: [379],
+};
+
+export default card;

--- a/data-asia/SM/SM4S/036.ts
+++ b/data-asia/SM/SM4S/036.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4S";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "シュバルゴ",
+	},
+
+	illustrator: "Kagemaru Himeno",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Metal"],
+
+	description: {
+		ja: "チョボマキから 奪った 殻で 体を 覆い ガードしながら ２本の ヤリで 突いてくる。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "みだれづき" },
+			damage: "30×",
+			cost: ["Metal"],
+			effect: {
+				ja: "コインを3回投げ、オモテの数x30ダメージ。",
+			},
+		},
+		{
+			name: { ja: "アイアンタックル" },
+			damage: 130,
+			cost: ["Metal", "Metal", "Colorless"],
+			effect: {
+				ja: "このポケモンにも30ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560348,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "カブルモ",
+	},
+
+	retreat: 2,
+	rarity: "Uncommon",
+	dexId: [589],
+};
+
+export default card;

--- a/data-asia/SM/SM4S/037.ts
+++ b/data-asia/SM/SM4S/037.ts
@@ -1,0 +1,64 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4S";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "カミツルギGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 170,
+	types: ["Metal"],
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "きりすてる" },
+			effect: {
+				ja: "自分の番に、このカードを手札からベンチに出したとき、1回使える。相手の場のポケモンについている特殊エネルギーを、1個トラッシュする。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "はやてのたち" },
+			damage: 70,
+			cost: ["Metal", "Colorless", "Colorless"],
+			effect: {
+				ja: "のぞむなら、このポケモンと、ついているすべてのカードを、自分の山札にもどして切る。",
+			},
+		},
+		{
+			name: { ja: "スラッシュGX" },
+			cost: ["Metal"],
+			effect: {
+				ja: "自分のサイドを1枚とる。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 560349,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Double rare",
+	dexId: [798],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM4S/038.ts
+++ b/data-asia/SM/SM4S/038.ts
@@ -1,0 +1,53 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4S";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ムックル",
+	},
+
+	illustrator: "miki kudo",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Colorless"],
+
+	description: {
+		ja: "たくさんの 群れで 行動する。 体は 小さいが 羽ばたく 力は 非常に 強い。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "むしさがし" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "相手の手札を見る。",
+			},
+		},
+		{
+			name: { ja: "はばたく" },
+			damage: 20,
+			cost: ["Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560350,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [396],
+};
+
+export default card;

--- a/data-asia/SM/SM4S/039.ts
+++ b/data-asia/SM/SM4S/039.ts
@@ -1,0 +1,55 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4S";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ムクバード",
+	},
+
+	illustrator: "kawayoo",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Colorless"],
+
+	description: {
+		ja: "大きな グループを 作って 行動する 習性。 グループ同士の 争いは 激しい。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "はばたく" },
+			damage: 20,
+			cost: ["Colorless"],
+		},
+		{
+			name: { ja: "つばさでうつ" },
+			damage: 60,
+			cost: ["Colorless", "Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560351,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ムックル",
+	},
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [397],
+};
+
+export default card;

--- a/data-asia/SM/SM4S/040.ts
+++ b/data-asia/SM/SM4S/040.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4S";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ムクホーク",
+	},
+
+	illustrator: "Sekio",
+	category: "Pokemon",
+	hp: 140,
+	types: ["Colorless"],
+
+	description: {
+		ja: "翼と 脚の 筋肉が 強く 小さな ポケモンを つかんだまま らくらくと 飛ぶことが できる。",
+	},
+
+	stage: "Stage2",
+
+	attacks: [
+		{
+			name: { ja: "わしづかみ" },
+			damage: 50,
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "次の相手の番、このワザを受けたポケモンは、にげられない。",
+			},
+		},
+		{
+			name: { ja: "スカイハンティング" },
+			damage: 120,
+			cost: ["Colorless", "Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "このワザのダメージで、相手のポケモンがきぜつしたなら、このポケモンとベンチポケモンを入れ替える。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560352,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ムクバード",
+	},
+
+	retreat: 1,
+	rarity: "Uncommon",
+	dexId: [398],
+};
+
+export default card;

--- a/data-asia/SM/SM4S/041.ts
+++ b/data-asia/SM/SM4S/041.ts
@@ -1,0 +1,59 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4S";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "レジギガス",
+	},
+
+	illustrator: "Kouki Saitou",
+	category: "Pokemon",
+	hp: 180,
+	types: ["Colorless"],
+
+	description: {
+		ja: "特殊な 氷山や 岩石 マグマから 自分の 姿に 似た ポケモンを つくったと 言われる。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "いにしえのふういん" },
+			effect: {
+				ja: "自分のベンチに「レジロック」「レジアイス」「レジスチル」がいないなら、このポケモンはワザが使えない。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ジャイアントスタンプ" },
+			damage: 160,
+			cost: ["Colorless", "Colorless", "Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "場に出ているスタジアムをトラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 560353,
+			},
+		},
+	],
+
+	retreat: 4,
+	rarity: "Rare",
+	dexId: [486],
+};
+
+export default card;

--- a/data-asia/SM/SM4S/042.ts
+++ b/data-asia/SM/SM4S/042.ts
@@ -1,0 +1,49 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4S";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "チラーミィ",
+	},
+
+	illustrator: "kodama",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Colorless"],
+
+	description: {
+		ja: "お互いの 尻尾で 相手を とことん きれいに してあげるのが チラーミィ同士の あいさつ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "くすぐる" },
+			damage: 10,
+			cost: ["Colorless"],
+			effect: {
+				ja: "コインを1回投げオモテなら、相手のバトルポケモンをマヒにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560354,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [572],
+};
+
+export default card;

--- a/data-asia/SM/SM4S/043.ts
+++ b/data-asia/SM/SM4S/043.ts
@@ -1,0 +1,52 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4S";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "チラチーノ",
+	},
+
+	illustrator: "0313",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Colorless"],
+
+	description: {
+		ja: "白い 体毛は 肌触りが 抜群。 ほこりや 静電気を まったく 寄せつけないのだ。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "すごいおねだり" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分のトラッシュにある好きなカードを2枚選び、相手に見せてから、手札に加えて良いかを相手にたずねる。相手が良いなら、選んだカードを手札に加える。良くないなら、選んだカードをトラッシュにもどし、相手のバトルポケモンに80ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560355,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "チラーミィ",
+	},
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [573],
+};
+
+export default card;

--- a/data-asia/SM/SM4S/044.ts
+++ b/data-asia/SM/SM4S/044.ts
@@ -1,0 +1,54 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4S";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "タイプ：ヌル",
+	},
+
+	illustrator: "Hitoshi Ariga",
+	category: "Pokemon",
+	hp: 110,
+	types: ["Colorless"],
+
+	description: {
+		ja: "重い 制御マスクを つけており 本来の 能力を だせない。 特別な 力を 秘めている。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "アーマープレス" },
+			damage: 30,
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "次の相手の番、このポケモンが受けるワザのダメージは「-30」される。",
+			},
+		},
+		{
+			name: { ja: "スラッシュクロー" },
+			damage: 70,
+			cost: ["Colorless", "Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 560356,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Rare",
+	dexId: [772],
+};
+
+export default card;

--- a/data-asia/SM/SM4S/045.ts
+++ b/data-asia/SM/SM4S/045.ts
@@ -1,0 +1,69 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4S";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "シルヴァディGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 210,
+	types: ["Colorless"],
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ジャイロユニット" },
+			effect: {
+				ja: "このポケモンがいるかぎり、自分のたねポケモン全員のにげるためのエネルギーは、すべてなくなる。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ターボドライブ" },
+			damage: 120,
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "自分のトラッシュにある基本エネルギーを1枚、ベンチポケモンにつける。",
+			},
+		},
+		{
+			name: { ja: "リベリオンGX" },
+			damage: "50×",
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のベンチポケモンの数x50ダメージ。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 560357,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "タイプ：ヌル",
+	},
+
+	retreat: 2,
+	rarity: "Double rare",
+	dexId: [773],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM4S/046.ts
+++ b/data-asia/SM/SM4S/046.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4S";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "カウンターキャッチャー",
+	},
+
+	illustrator: "Toyste Beach",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードは、自分のサイドの残り枚数が、相手のサイドの残り枚数より多いときにしか使えない。相手のベンチポケモンを1匹選び、バトルポケモンと入れ替える。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560358,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM4S/047.ts
+++ b/data-asia/SM/SM4S/047.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4S";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "のぞきみレッドカード",
+	},
+
+	illustrator: "Toyste Beach",
+	category: "Trainer",
+
+	effect: {
+		ja: "相手の手札を見る。のぞむなら、相手に相手自身の手札を数えさせたあと、すべて山札にもどして切らせる。その場合、相手はもどした枚数ぶん山札を引く。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560359,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM4S/048.ts
+++ b/data-asia/SM/SM4S/048.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4S";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "サイキックメモリ",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードをつけている「シルヴァディGX」は、ポケモンになる。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560360,
+			},
+		},
+	],
+
+	trainerType: "Tool",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM4S/049.ts
+++ b/data-asia/SM/SM4S/049.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4S";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ファイトメモリ",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードをつけている「シルヴァディGX」は、ポケモンになる。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560361,
+			},
+		},
+	],
+
+	trainerType: "Tool",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM4S/050.ts
+++ b/data-asia/SM/SM4S/050.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4S";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "グラジオ",
+	},
+
+	illustrator: "Ken Sugimori",
+	category: "Trainer",
+
+	effect: {
+		ja: "ウラになっている自分のサイドのオモテをすべて見て、その中にあるカードを1枚、この「グラジオ」と入れ替えて、手札に加える。その後、この「グラジオ」と残りのサイドをすべてウラにして切り、サイドとして置く。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560362,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM4S/051.ts
+++ b/data-asia/SM/SM4S/051.ts
@@ -1,0 +1,64 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4S";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アローラゴローニャGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 250,
+	types: ["Lightning"],
+
+	stage: "Stage2",
+
+	attacks: [
+		{
+			name: { ja: "ぶちかます" },
+			damage: 80,
+			cost: ["Lightning", "Colorless", "Colorless"],
+		},
+		{
+			name: { ja: "ちょうでんじタックル" },
+			damage: 200,
+			cost: ["Lightning", "Lightning", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンにも50ダメージ。",
+			},
+		},
+		{
+			name: { ja: "ヘビーロックGX" },
+			damage: 100,
+			cost: ["Lightning", "Lightning", "Colorless", "Colorless"],
+			effect: {
+				ja: "次の相手の番、相手は手札からカードを出して使えない。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Metal", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 560363,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "アローラゴローン",
+	},
+
+	retreat: 4,
+	rarity: "Ultra Rare",
+	dexId: [76],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM4S/052.ts
+++ b/data-asia/SM/SM4S/052.ts
@@ -1,0 +1,63 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4S";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "マッシブーンGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 190,
+	types: ["Fighting"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ジェットパンチ" },
+			damage: 30,
+			cost: ["Fighting"],
+			effect: {
+				ja: "相手のベンチポケモン1匹にも、30ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+			},
+		},
+		{
+			name: { ja: "ナックルインパクト" },
+			damage: 160,
+			cost: ["Fighting", "Fighting", "Fighting"],
+			effect: {
+				ja: "次の自分の番、このポケモンはワザが使えない。",
+			},
+		},
+		{
+			name: { ja: "イクスパンションGX" },
+			damage: "40×",
+			cost: ["Fighting", "Fighting", "Fighting"],
+			effect: {
+				ja: "自分のサイドの枚数x40ダメージ。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 560364,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Ultra Rare",
+	dexId: [794],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM4S/053.ts
+++ b/data-asia/SM/SM4S/053.ts
@@ -1,0 +1,64 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4S";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "カミツルギGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 170,
+	types: ["Metal"],
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "きりすてる" },
+			effect: {
+				ja: "自分の番に、このカードを手札からベンチに出したとき、1回使える。相手の場のポケモンについている特殊エネルギーを、1個トラッシュする。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "はやてのたち" },
+			damage: 70,
+			cost: ["Metal", "Colorless", "Colorless"],
+			effect: {
+				ja: "のぞむなら、このポケモンと、ついているすべてのカードを、自分の山札にもどして切る。",
+			},
+		},
+		{
+			name: { ja: "スラッシュGX" },
+			cost: ["Metal"],
+			effect: {
+				ja: "自分のサイドを1枚とる。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 560365,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Ultra Rare",
+	dexId: [798],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM4S/054.ts
+++ b/data-asia/SM/SM4S/054.ts
@@ -1,0 +1,69 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4S";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "シルヴァディGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 210,
+	types: ["Colorless"],
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ジャイロユニット" },
+			effect: {
+				ja: "このポケモンがいるかぎり、自分のたねポケモン全員のにげるためのエネルギーは、すべてなくなる。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ターボドライブ" },
+			damage: 120,
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "自分のトラッシュにある基本エネルギーを1枚、ベンチポケモンにつける。",
+			},
+		},
+		{
+			name: { ja: "リベリオンGX" },
+			damage: "50×",
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のベンチポケモンの数x50ダメージ。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 560366,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "タイプ：ヌル",
+	},
+
+	retreat: 2,
+	rarity: "Ultra Rare",
+	dexId: [773],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM4S/055.ts
+++ b/data-asia/SM/SM4S/055.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4S";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "グラジオ",
+	},
+
+	illustrator: "TOKIYA",
+	category: "Trainer",
+
+	effect: {
+		ja: "ウラになっている自分のサイドのオモテをすべて見て、その中にあるカードを1枚、この「グラジオ」と入れ替えて、手札に加える。その後、この「グラジオ」と残りのサイドをすべてウラにして切り、サイドとして置く。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 560367,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	rarity: "Ultra Rare",
+};
+
+export default card;

--- a/data-asia/SM/SM4S/056.ts
+++ b/data-asia/SM/SM4S/056.ts
@@ -1,0 +1,64 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4S";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アローラゴローニャGX",
+	},
+
+	illustrator: "",
+	category: "Pokemon",
+	hp: 250,
+	types: ["Lightning"],
+
+	stage: "Stage2",
+
+	attacks: [
+		{
+			name: { ja: "ぶちかます" },
+			damage: 80,
+			cost: ["Lightning", "Colorless", "Colorless"],
+		},
+		{
+			name: { ja: "ちょうでんじタックル" },
+			damage: 200,
+			cost: ["Lightning", "Lightning", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンにも50ダメージ。",
+			},
+		},
+		{
+			name: { ja: "ヘビーロックGX" },
+			damage: 100,
+			cost: ["Lightning", "Lightning", "Colorless", "Colorless"],
+			effect: {
+				ja: "次の相手の番、相手は手札からカードを出して使えない。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Metal", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 560368,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "アローラゴローン",
+	},
+
+	retreat: 4,
+	rarity: "Hyper rare",
+	dexId: [76],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM4S/057.ts
+++ b/data-asia/SM/SM4S/057.ts
@@ -1,0 +1,63 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4S";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "マッシブーンGX",
+	},
+
+	illustrator: "",
+	category: "Pokemon",
+	hp: 190,
+	types: ["Fighting"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ジェットパンチ" },
+			damage: 30,
+			cost: ["Fighting"],
+			effect: {
+				ja: "相手のベンチポケモン1匹にも、30ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+			},
+		},
+		{
+			name: { ja: "ナックルインパクト" },
+			damage: 160,
+			cost: ["Fighting", "Fighting", "Fighting"],
+			effect: {
+				ja: "次の自分の番、このポケモンはワザが使えない。",
+			},
+		},
+		{
+			name: { ja: "イクスパンションGX" },
+			damage: "40×",
+			cost: ["Fighting", "Fighting", "Fighting"],
+			effect: {
+				ja: "自分のサイドの枚数x40ダメージ。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 560369,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Hyper rare",
+	dexId: [794],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM4S/058.ts
+++ b/data-asia/SM/SM4S/058.ts
@@ -1,0 +1,64 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4S";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "カミツルギGX",
+	},
+
+	illustrator: "",
+	category: "Pokemon",
+	hp: 170,
+	types: ["Metal"],
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "きりすてる" },
+			effect: {
+				ja: "自分の番に、このカードを手札からベンチに出したとき、1回使える。相手の場のポケモンについている特殊エネルギーを、1個トラッシュする。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "はやてのたち" },
+			damage: 70,
+			cost: ["Metal", "Colorless", "Colorless"],
+			effect: {
+				ja: "のぞむなら、このポケモンと、ついているすべてのカードを、自分の山札にもどして切る。",
+			},
+		},
+		{
+			name: { ja: "スラッシュGX" },
+			cost: ["Metal"],
+			effect: {
+				ja: "自分のサイドを1枚とる。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 560370,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Hyper rare",
+	dexId: [798],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM4S/059.ts
+++ b/data-asia/SM/SM4S/059.ts
@@ -1,0 +1,69 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4S";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "シルヴァディGX",
+	},
+
+	illustrator: "",
+	category: "Pokemon",
+	hp: 210,
+	types: ["Colorless"],
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ジャイロユニット" },
+			effect: {
+				ja: "このポケモンがいるかぎり、自分のたねポケモン全員のにげるためのエネルギーは、すべてなくなる。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ターボドライブ" },
+			damage: 120,
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "自分のトラッシュにある基本エネルギーを1枚、ベンチポケモンにつける。",
+			},
+		},
+		{
+			name: { ja: "リベリオンGX" },
+			damage: "50×",
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のベンチポケモンの数x50ダメージ。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 560371,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "タイプ：ヌル",
+	},
+
+	retreat: 2,
+	rarity: "Hyper rare",
+	dexId: [773],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM4S/060.ts
+++ b/data-asia/SM/SM4S/060.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4S";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "カウンターキャッチャー",
+	},
+
+	illustrator: "",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードは、自分のサイドの残り枚数が、相手のサイドの残り枚数より多いときにしか使えない。相手のベンチポケモンを1匹選び、バトルポケモンと入れ替える。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 560372,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	rarity: "Secret Rare",
+};
+
+export default card;

--- a/data-asia/SM/SM4S/061.ts
+++ b/data-asia/SM/SM4S/061.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4S";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ワープエネルギー",
+	},
+
+	illustrator: "",
+	category: "Energy",
+	energyType: "Special",
+
+	effect: {
+		ja: "このカードは、[無]エネルギー1個ぶんとしてはたらく。このカードを手札からバトルポケモンにつけたとき、このカードをつけたポケモンをベンチポケモンと入れ替える。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 560373,
+			},
+		},
+	],
+
+	rarity: "Secret Rare",
+};
+
+export default card;

--- a/data-asia/SM/SM4S/062.ts
+++ b/data-asia/SM/SM4S/062.ts
@@ -1,0 +1,26 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4S";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "基本鋼エネルギー",
+	},
+
+	illustrator: "",
+	category: "Energy",
+	energyType: "Normal",
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 560374,
+			},
+		},
+	],
+
+	rarity: "Secret Rare",
+};
+
+export default card;


### PR DESCRIPTION
## What

Adds the complete Japanese set **SM4S 覚醒の勇者 (Awakened Heroes)**, released 2017-09-15:

- `data-asia/SM/SM4S/001.ts` … `062.ts` — all 62 cards (50 regular + 12 secret rares: 5 SR, 3 Secret Rare, 4 UR)
- the set definition `data-asia/SM/SM4S.ts` already existed and is untouched

## Data sources

- **pokemon-card.com** (official database): Japanese names, flavor texts, National Dex numbers, official card count
- **limitlesstcg.com**: full Japanese card text, stages, weaknesses/resistances/retreat, rarities, illustrators, attack costs
- **Cardmarket**: product IDs as `thirdParty.cardmarket` on the variant objects (560313–560374; tcgplayer IDs not available to me)

## Notes

- Follows the file format and conventions of the M-era sets (#1728)
- No `regulationMark` (the set predates regulation marks); resistances are `-20` per the era
- All 62 files type-check against `interfaces.d.ts` (`tsc --noEmit`)
