### PR TITLE
(data) Add Japanese SM set SM4p GX Battle Boost

### DIFF
--- a/data-asia/SM/SM4p.ts
+++ b/data-asia/SM/SM4p.ts
@@ -1,0 +1,20 @@
+import { Set } from "../../interfaces";
+import serie from "../SM";
+
+const set: Set = {
+	id: "SM4p",
+	name: {
+		ja: "GXバトルブースト",
+	},
+
+	serie: serie,
+
+	cardCount: {
+		official: 114,
+	},
+	releaseDate: {
+		ja: "2017-10-20",
+	},
+};
+
+export default set;

--- a/data-asia/SM/SM4p/001.ts
+++ b/data-asia/SM/SM4p/001.ts
@@ -1,0 +1,49 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "タマタマ",
+	},
+
+	illustrator: "kawayoo",
+	category: "Pokemon",
+	hp: 50,
+	types: ["Grass"],
+
+	description: {
+		ja: "テレパシーで 仲間と 交信する。 植物と ある種の タイプの 遺伝子を 併せ持つと いう。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "れんぞくたまなげ" },
+			damage: "20×",
+			cost: ["Grass"],
+			effect: {
+				ja: "ウラが出るまでコインを投げ、オモテの数x20ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560034,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "None",
+	dexId: [102],
+};
+
+export default card;

--- a/data-asia/SM/SM4p/002.ts
+++ b/data-asia/SM/SM4p/002.ts
@@ -1,0 +1,53 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "カイロス",
+	},
+
+	illustrator: "DemizuPosuka",
+	category: "Pokemon",
+	hp: 110,
+	types: ["Grass"],
+
+	description: {
+		ja: "角の 一撃は 大木 さえ へし折るほど。 アローラでは クワガノンが 最大の ライバル。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "てんじょうなげ" },
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "コインを1回投げオモテなら、相手のバトルポケモンと、ついているすべてのカードを、相手の手札にもどす。",
+			},
+		},
+		{
+			name: { ja: "ハサミギロチン" },
+			damage: 50,
+			cost: ["Grass", "Grass"],
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560035,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "None",
+	dexId: [127],
+};
+
+export default card;

--- a/data-asia/SM/SM4p/003.ts
+++ b/data-asia/SM/SM4p/003.ts
@@ -1,0 +1,46 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アゴジムシ",
+	},
+
+	illustrator: "Akira Komayama",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Grass"],
+
+	description: {
+		ja: "とりポケモンに 襲われないよう でんきポケモンが 棲む 場所に 集まっていることが 多い。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "はさむ" },
+			damage: 20,
+			cost: ["Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560036,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "None",
+	dexId: [736],
+};
+
+export default card;

--- a/data-asia/SM/SM4p/004.ts
+++ b/data-asia/SM/SM4p/004.ts
@@ -1,0 +1,49 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "シズクモ",
+	},
+
+	illustrator: "Midori Harada",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Grass"],
+
+	description: {
+		ja: "餌を 求め 地上に あがる。 水泡を 被るのは 呼吸と 柔らかい 頭を 守るため。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "あわ" },
+			damage: 10,
+			cost: ["Grass"],
+			effect: {
+				ja: "コインを1回投げオモテなら、相手のバトルポケモンをマヒにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560037,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "None",
+	dexId: [751],
+};
+
+export default card;

--- a/data-asia/SM/SM4p/005.ts
+++ b/data-asia/SM/SM4p/005.ts
@@ -1,0 +1,60 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "オニシズクモ",
+	},
+
+	illustrator: "Shin Nagasawa",
+	category: "Pokemon",
+	hp: 100,
+	types: ["Grass"],
+
+	description: {
+		ja: "頭部の 水泡で ヘッドバット。 小さなポケモンで あれば そのまま 水泡に 取り込まれ 溺れ死ぬ。",
+	},
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "すいほう" },
+			effect: {
+				ja: "このポケモンは、相手の[炎]ポケモンからワザのダメージを受けない。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "アクアエッジ" },
+			damage: 70,
+			cost: ["Grass", "Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560038,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "シズクモ",
+	},
+
+	retreat: 2,
+	rarity: "None",
+	dexId: [752],
+};
+
+export default card;

--- a/data-asia/SM/SM4p/006.ts
+++ b/data-asia/SM/SM4p/006.ts
@@ -1,0 +1,53 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "カリキリ",
+	},
+
+	illustrator: "Kagemaru Himeno",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Grass"],
+
+	description: {
+		ja: "爽やかで 甘い香りが する。 カリキリが 隠れている 草むらには よく アブリーが 群れている。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "こうごうせい" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札にある[草]エネルギーを1枚、自分のポケモンにつける。そして山札を切る。",
+			},
+		},
+		{
+			name: { ja: "このは" },
+			damage: 20,
+			cost: ["Grass", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560039,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "None",
+	dexId: [753],
+};
+
+export default card;

--- a/data-asia/SM/SM4p/007.ts
+++ b/data-asia/SM/SM4p/007.ts
@@ -1,0 +1,60 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ラランテス",
+	},
+
+	illustrator: "Mitsuhiro Arita",
+	category: "Pokemon",
+	hp: 100,
+	types: ["Grass"],
+
+	description: {
+		ja: "鮮やかな 体色を 保つには 非常に 手間が かかるが それを 趣味にする 好事家も いるのだ。",
+	},
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "にほんばれ" },
+			effect: {
+				ja: "このポケモンがいるかぎり、自分の[草]または[炎]ポケモンが使うワザの、相手のバトルポケモンへのダメージは「+20」される。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ソーラービーム" },
+			damage: 80,
+			cost: ["Grass", "Grass", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560040,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "カリキリ",
+	},
+
+	retreat: 2,
+	rarity: "None",
+	dexId: [754],
+};
+
+export default card;

--- a/data-asia/SM/SM4p/008.ts
+++ b/data-asia/SM/SM4p/008.ts
@@ -1,0 +1,53 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アマカジ",
+	},
+
+	illustrator: "Akira Komayama",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Grass"],
+
+	description: {
+		ja: "美味しそうな 香りが 体から 漏れ出している。 匂いに 誘われた ドデカバシに 丸呑みに される。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "あまいかおり" },
+			cost: ["Grass"],
+			effect: {
+				ja: "自分のポケモン1匹のHPを「30」回復する。",
+			},
+		},
+		{
+			name: { ja: "はねる" },
+			damage: 10,
+			cost: ["Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560041,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "None",
+	dexId: [761],
+};
+
+export default card;

--- a/data-asia/SM/SM4p/009.ts
+++ b/data-asia/SM/SM4p/009.ts
@@ -1,0 +1,60 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アママイコ",
+	},
+
+	illustrator: "Mizue",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Grass"],
+
+	description: {
+		ja: "身を 守るため ヘタが 発達。 かなりの 硬さで とりポケモンに 突かれても 全然 平気だ。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "あまいかおり" },
+			cost: ["Grass"],
+			effect: {
+				ja: "自分のポケモン1匹のHPを「30」回復する。",
+			},
+		},
+		{
+			name: { ja: "ふみつけ" },
+			damage: "20+",
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "コインを1回投げオモテなら、20ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560042,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "アマカジ",
+	},
+
+	retreat: 2,
+	rarity: "None",
+	dexId: [762],
+};
+
+export default card;

--- a/data-asia/SM/SM4p/010.ts
+++ b/data-asia/SM/SM4p/010.ts
@@ -1,0 +1,63 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アマージョ",
+	},
+
+	illustrator: "Shin Nagasawa",
+	category: "Pokemon",
+	hp: 140,
+	types: ["Grass"],
+
+	description: {
+		ja: "脚を 活かした 蹴りが 得意。 倒した 相手を 足蹴に して 高笑いで 勝利を アピール。",
+	},
+
+	stage: "Stage2",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "じょおうのいげん" },
+			effect: {
+				ja: "自分の番に、このカードを手札から出して進化させたとき、1回使える。相手の手札を見て、その中にあるカードを、1枚トラッシュする。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "トロピカルキック" },
+			damage: 80,
+			cost: ["Grass", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンのHPを「20」回復し、特殊状態もすべて回復する。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560043,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "アママイコ",
+	},
+
+	retreat: 2,
+	rarity: "None",
+	dexId: [763],
+};
+
+export default card;

--- a/data-asia/SM/SM4p/011.ts
+++ b/data-asia/SM/SM4p/011.ts
@@ -1,0 +1,57 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "カプ・ブルル",
+	},
+
+	illustrator: "Megumi Mizutani",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Grass"],
+
+	description: {
+		ja: "大木を 引き抜き ブンブン 振り回す。 草木を 茂らせて そのエネルギーを 吸収する。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ウッドホーン" },
+			damage: 30,
+			cost: ["Grass", "Colorless"],
+			effect: {
+				ja: "このポケモンのHPを「30」回復する。",
+			},
+		},
+		{
+			name: { ja: "カームストライク" },
+			damage: "60+",
+			cost: ["Grass", "Colorless", "Colorless"],
+			effect: {
+				ja: "自分がすでにGXワザを使っていたなら、60ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560044,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "None",
+	dexId: [787],
+};
+
+export default card;

--- a/data-asia/SM/SM4p/012.ts
+++ b/data-asia/SM/SM4p/012.ts
@@ -1,0 +1,63 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "フェローチェGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 170,
+	types: ["Grass"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ファストレイド" },
+			damage: 30,
+			cost: ["Grass"],
+			effect: {
+				ja: "このワザは、先攻プレイヤーの最初の番でも使える。",
+			},
+		},
+		{
+			name: { ja: "クルーエルスパイク" },
+			damage: 60,
+			cost: ["Grass", "Grass"],
+			effect: {
+				ja: "相手のバトルポケモンをこんらんにする。",
+			},
+		},
+		{
+			name: { ja: "ビューティーGX" },
+			damage: "50×",
+			cost: ["Grass", "Grass"],
+			effect: {
+				ja: "相手がすでにとったサイドの枚数x50ダメージ。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 560045,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Double rare",
+	dexId: [795],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM4p/013.ts
+++ b/data-asia/SM/SM4p/013.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ホウオウGX",
+	},
+
+	illustrator: "PLANETA",
+	category: "Pokemon",
+	hp: 190,
+	types: ["Fire"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "せいなるほのお" },
+			cost: ["Fire", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のポケモン1匹に、50ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+			},
+		},
+		{
+			name: { ja: "フェニックスバーン" },
+			damage: 180,
+			cost: ["Fire", "Fire", "Fire", "Colorless"],
+			effect: {
+				ja: "次の自分の番、このポケモンは「フェニックスバーン」が使えない。",
+			},
+		},
+		{
+			name: { ja: "エターナルライトGX" },
+			cost: ["Fire", "Colorless", "Colorless"],
+			effect: {
+				ja: "自分のトラッシュにある[炎]タイプの「ポケモンGX・EX」を3枚、ベンチに出す。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 560046,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Double rare",
+	dexId: [250],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM4p/014.ts
+++ b/data-asia/SM/SM4p/014.ts
@@ -1,0 +1,56 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ビクティニ",
+	},
+
+	illustrator: "kodama",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Fire"],
+
+	description: {
+		ja: "勝利を もたらす ポケモン。 ビクティニを 連れた トレーナーは どんな 勝負にも 勝てるという。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "しょうりのほし" },
+			effect: {
+				ja: "自分の番に、自分のポケモンのワザでコインを投げたとき、1回使える。そのコインの結果をすべてなくし、はじめからコインを投げなおす。「ビクティニ」が何匹いても、「しょうりのほし」は自分の番に1回しか使えない。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "Vフレイム" },
+			damage: 50,
+			cost: ["Fire", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560047,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "None",
+	dexId: [494],
+};
+
+export default card;

--- a/data-asia/SM/SM4p/015.ts
+++ b/data-asia/SM/SM4p/015.ts
@@ -1,0 +1,49 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヒトモシ",
+	},
+
+	illustrator: "Mitsuhiro Arita",
+	category: "Pokemon",
+	hp: 50,
+	types: ["Fire"],
+
+	description: {
+		ja: "明かりを 灯して 道案内を するように 見せかけながら 生命力を 吸い取っている。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ゆれるほのお" },
+			damage: 10,
+			cost: ["Fire"],
+			effect: {
+				ja: "相手のバトルポケモンをねむりにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560048,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "None",
+	dexId: [607],
+};
+
+export default card;

--- a/data-asia/SM/SM4p/016.ts
+++ b/data-asia/SM/SM4p/016.ts
@@ -1,0 +1,50 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ランプラー",
+	},
+
+	illustrator: "0313",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Fire"],
+
+	description: {
+		ja: "魂を 吸いとり 火を灯す。 人が 死ぬのを 待つため 病院を うろつくようになった。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "おにび" },
+			damage: 30,
+			cost: ["Fire"],
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560049,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ヒトモシ",
+	},
+
+	retreat: 1,
+	rarity: "None",
+	dexId: [608],
+};
+
+export default card;

--- a/data-asia/SM/SM4p/017.ts
+++ b/data-asia/SM/SM4p/017.ts
@@ -1,0 +1,63 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "シャンデラ",
+	},
+
+	illustrator: "Kouki Saitou",
+	category: "Pokemon",
+	hp: 140,
+	types: ["Fire"],
+
+	description: {
+		ja: "シャンデラの 炎に 包まれると 魂が 吸い取られ 燃やされる。 抜け殻の 体 だけが 残る。",
+	},
+
+	stage: "Stage2",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "シャドームーブ" },
+			effect: {
+				ja: "自分の番に1回使える。おたがいの場のポケモンにのっているダメカンを1個、おたがいの場の別のポケモンにのせ替える。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ほのおでこがす" },
+			damage: 50,
+			cost: ["Fire"],
+			effect: {
+				ja: "相手のバトルポケモンをやけどにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560050,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ランプラー",
+	},
+
+	retreat: 1,
+	rarity: "None",
+	dexId: [609],
+};
+
+export default card;

--- a/data-asia/SM/SM4p/018.ts
+++ b/data-asia/SM/SM4p/018.ts
@@ -1,0 +1,54 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヤトウモリ",
+	},
+
+	illustrator: "TOKIYA",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Fire"],
+
+	description: {
+		ja: "体液を 燃やし 毒ガスを たく。 ガスを 吸った 敵が フラフラに なったあと 襲いかかるのだ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ひっかく" },
+			damage: 10,
+			cost: ["Fire"],
+		},
+		{
+			name: { ja: "ベノムショック" },
+			damage: "20+",
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンがどくなら、40ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560051,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "None",
+	dexId: [757],
+};
+
+export default card;

--- a/data-asia/SM/SM4p/019.ts
+++ b/data-asia/SM/SM4p/019.ts
@@ -1,0 +1,63 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "エンニュート",
+	},
+
+	illustrator: "Mitsuhiro Arita",
+	category: "Pokemon",
+	hp: 110,
+	types: ["Fire"],
+
+	description: {
+		ja: "なぜか ♀しか 見つかっていない。 ヤトウモリの♂を 引き連れて 逆ハーレムを 作って 暮らす。",
+	},
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ホットポイズン" },
+			effect: {
+				ja: "自分の番に、このカードを手札から出して進化させたとき、1回使える。相手のバトルポケモンをどくとやけどにする。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "かえんほうしゃ" },
+			damage: 90,
+			cost: ["Fire", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンについているエネルギーを、1個トラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560052,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ヤトウモリ",
+	},
+
+	retreat: 1,
+	rarity: "None",
+	dexId: [758],
+};
+
+export default card;

--- a/data-asia/SM/SM4p/020.ts
+++ b/data-asia/SM/SM4p/020.ts
@@ -1,0 +1,53 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アローラサンド",
+	},
+
+	illustrator: "Mizue",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Water"],
+
+	description: {
+		ja: "雪山に 棲む。 鋼の甲羅は とても 頑丈だが 硬すぎて 身体を 丸めることが できない。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "まるくなる" },
+			cost: [],
+			effect: {
+				ja: "コインを1回投げオモテなら、次の相手の番、このポケモンはワザのダメージを受けない。",
+			},
+		},
+		{
+			name: { ja: "アイスボール" },
+			damage: 30,
+			cost: ["Water", "Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560053,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "None",
+	dexId: [27],
+};
+
+export default card;

--- a/data-asia/SM/SM4p/021.ts
+++ b/data-asia/SM/SM4p/021.ts
@@ -1,0 +1,63 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アローラサンドパン",
+	},
+
+	illustrator: "TOKIYA",
+	category: "Pokemon",
+	hp: 110,
+	types: ["Water"],
+
+	description: {
+		ja: "火山噴火 から 逃れるうちに 雪山に 棲みつくように なった。 雪しぶきをあげ 雪原を 駆ける。",
+	},
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ゆきかき" },
+			effect: {
+				ja: "自分の番に1回使える。自分の山札を1枚引く。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "スマッシュターン" },
+			damage: 50,
+			cost: ["Water", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンをベンチポケモンと入れ替える。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560054,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "アローラサンド",
+	},
+
+	retreat: 2,
+	rarity: "None",
+	dexId: [28],
+};
+
+export default card;

--- a/data-asia/SM/SM4p/022.ts
+++ b/data-asia/SM/SM4p/022.ts
@@ -1,0 +1,53 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アローラロコン",
+	},
+
+	illustrator: "Tomokazu Komiya",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Water"],
+
+	description: {
+		ja: "マイナス５０度の 冷気を 吐く。 アローラの老人は ケオケオという 昔の 名前で 呼ぶことも。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ほえる" },
+			cost: [],
+			effect: {
+				ja: "相手のバトルポケモンをベンチポケモンと入れ替える。［バトル場に出すポケモンは相手が選ぶ。］",
+			},
+		},
+		{
+			name: { ja: "スノーアイス" },
+			damage: 10,
+			cost: ["Water"],
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560055,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "None",
+	dexId: [37],
+};
+
+export default card;

--- a/data-asia/SM/SM4p/023.ts
+++ b/data-asia/SM/SM4p/023.ts
@@ -1,0 +1,60 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アローラキュウコン",
+	},
+
+	illustrator: "Mitsuhiro Arita",
+	category: "Pokemon",
+	hp: 110,
+	types: ["Water"],
+
+	description: {
+		ja: "体毛から 氷の粒を 生み 敵に 浴びせかける。 怒らせると 一瞬で 氷漬けに される。",
+	},
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ひかりのけっかい" },
+			effect: {
+				ja: "このポケモンは、相手の「ポケモンGX・EX」からワザのダメージや効果を受けない。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "オーロラビーム" },
+			damage: 80,
+			cost: ["Water", "Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560056,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "アローラロコン",
+	},
+
+	retreat: 1,
+	rarity: "None",
+	dexId: [38],
+};
+
+export default card;

--- a/data-asia/SM/SM4p/024.ts
+++ b/data-asia/SM/SM4p/024.ts
@@ -1,0 +1,56 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "レジアイス",
+	},
+
+	illustrator: "Masakazu Fukuda",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Water"],
+
+	description: {
+		ja: "氷河の 中で 数千年 眠っていたと 言われている。 マグマでも 体は 溶けない。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ひょうざんのたて" },
+			effect: {
+				ja: "自分の場に「レジロック」がいるなら、このポケモンは、相手の2進化ポケモンからワザのダメージや効果を受けない。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "フロストスマッシュ" },
+			damage: 70,
+			cost: ["Water", "Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560057,
+			},
+		},
+	],
+
+	retreat: 3,
+	rarity: "None",
+	dexId: [378],
+};
+
+export default card;

--- a/data-asia/SM/SM4p/025.ts
+++ b/data-asia/SM/SM4p/025.ts
@@ -1,0 +1,59 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ナマコブシ",
+	},
+
+	illustrator: "You Iribi",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Water"],
+
+	description: {
+		ja: "ビーチなど 浅い 海に 棲む。 身体から 体内器官を だして 餌を 捕ったり 敵と 戦う。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "とびだすなかみ" },
+			effect: {
+				ja: "このポケモンが、バトル場で相手のポケモンからワザのダメージを受けてきぜつしたとき、ワザを使ったポケモンにダメカンを6個のせる。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "れんぞくころがり" },
+			damage: "30×",
+			cost: ["Water"],
+			effect: {
+				ja: "ウラが出るまでコインを投げ、オモテの数x30ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560058,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "None",
+	dexId: [771],
+};
+
+export default card;

--- a/data-asia/SM/SM4p/026.ts
+++ b/data-asia/SM/SM4p/026.ts
@@ -1,0 +1,57 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "カプ・レヒレ",
+	},
+
+	illustrator: "Sanosuke Sakuma",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Water"],
+
+	description: {
+		ja: "深い霧で 敵を 惑わせ 自滅させる 恐ろしさを 持つ。 海流が エネルギーの 源。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "みずのはどう" },
+			damage: 30,
+			cost: ["Water", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをねむりにする。",
+			},
+		},
+		{
+			name: { ja: "かがやくかいりゅう" },
+			damage: "60+",
+			cost: ["Water", "Colorless", "Colorless"],
+			effect: {
+				ja: "この番、自分の[水]ポケモンのHPを回復していたなら、60ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560059,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "None",
+	dexId: [788],
+};
+
+export default card;

--- a/data-asia/SM/SM4p/027.ts
+++ b/data-asia/SM/SM4p/027.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "カプ・レヒレGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 170,
+	types: ["Water"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "アクアリング" },
+			damage: 20,
+			cost: ["Colorless"],
+			effect: {
+				ja: "のぞむなら、このポケモンをベンチポケモンと入れ替える。",
+			},
+		},
+		{
+			name: { ja: "ハイドロシュート" },
+			cost: ["Water", "Water", "Colorless"],
+			effect: {
+				ja: "このポケモンについている[水]エネルギーを2個トラッシュし、相手のポケモン1匹に、120ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+			},
+		},
+		{
+			name: { ja: "カプストームGX" },
+			cost: ["Water"],
+			effect: {
+				ja: "相手のバトルポケモンと、ついているすべてのカードを、相手の山札にもどして切る。相手のベンチポケモンがいないなら、このワザは失敗。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 560060,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Double rare",
+	dexId: [788],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM4p/028.ts
+++ b/data-asia/SM/SM4p/028.ts
@@ -1,0 +1,54 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ピカチュウ",
+	},
+
+	illustrator: "Saya Tsuruta",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Lightning"],
+
+	description: {
+		ja: "たくさんの ピカチュウを 集め 発電所を 造る 計画が 最近 発表 された。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "しっぽではたく" },
+			damage: 10,
+			cost: ["Colorless"],
+		},
+		{
+			name: { ja: "でんきショック" },
+			damage: 20,
+			cost: ["Lightning", "Colorless"],
+			effect: {
+				ja: "コインを1回投げオモテなら、相手のバトルポケモンをマヒにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Metal", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560061,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "None",
+	dexId: [25],
+};
+
+export default card;

--- a/data-asia/SM/SM4p/029.ts
+++ b/data-asia/SM/SM4p/029.ts
@@ -1,0 +1,63 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ライチュウ",
+	},
+
+	illustrator: "Kagemaru Himeno",
+	category: "Pokemon",
+	hp: 110,
+	types: ["Lightning"],
+
+	description: {
+		ja: "電撃は １０万ボルトに 達することもあり ヘタに触ると インド象でも 気絶する。",
+	},
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "エボルショック" },
+			effect: {
+				ja: "自分の番に、このカードを手札から出して進化させたとき、1回使える。相手のバトルポケモンをマヒにする。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ボルテッカー" },
+			damage: 130,
+			cost: ["Lightning", "Lightning", "Colorless"],
+			effect: {
+				ja: "このポケモンにも30ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Metal", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560062,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ピカチュウ",
+	},
+
+	retreat: 1,
+	rarity: "None",
+	dexId: [26],
+};
+
+export default card;

--- a/data-asia/SM/SM4p/030.ts
+++ b/data-asia/SM/SM4p/030.ts
@@ -1,0 +1,58 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "デンヂムシ",
+	},
+
+	illustrator: "Naoki Saito",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Lightning"],
+
+	description: {
+		ja: "喰らった 餌を 消化 するとき 発生した 電気エネルギーを 電気袋に 溜め込んでいる。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "しびれアゴ" },
+			damage: 20,
+			cost: ["Lightning", "Colorless"],
+			effect: {
+				ja: "コインを1回投げオモテなら、相手のバトルポケモンをマヒにする。",
+			},
+		},
+		{
+			name: { ja: "ライトニングボール" },
+			damage: 50,
+			cost: ["Lightning", "Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Metal", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560063,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "アゴジムシ",
+	},
+
+	retreat: 3,
+	rarity: "None",
+	dexId: [737],
+};
+
+export default card;

--- a/data-asia/SM/SM4p/031.ts
+++ b/data-asia/SM/SM4p/031.ts
@@ -1,0 +1,63 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "クワガノン",
+	},
+
+	illustrator: "Hitoshi Ariga",
+	category: "Pokemon",
+	hp: 150,
+	types: ["Lightning"],
+
+	description: {
+		ja: "お腹に ある 発電器官で 電気を 起こす。 電撃ビームで とりポケモンも 圧倒する。",
+	},
+
+	stage: "Stage2",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ストロングチャージ" },
+			effect: {
+				ja: "自分の番に1回使える。自分の山札にある[草]エネルギーと[雷]エネルギーを1枚ずつ、自分のポケモンに好きなようにつける。そして山札を切る。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "エレクトロキャノン" },
+			damage: 150,
+			cost: ["Lightning", "Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンについているエネルギーを、3個トラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Metal", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560064,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "デンヂムシ",
+	},
+
+	retreat: 3,
+	rarity: "None",
+	dexId: [738],
+};
+
+export default card;

--- a/data-asia/SM/SM4p/032.ts
+++ b/data-asia/SM/SM4p/032.ts
@@ -1,0 +1,62 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "カプ・コケコGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 170,
+	types: ["Lightning"],
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "エアロトレイル" },
+			effect: {
+				ja: "自分の番に、このカードを手札からベンチに出したとき、1回使える。自分の場のポケモンについている[雷]エネルギーを好きなだけ、このポケモンにつけ替える。つけ替えた場合、このポケモンをバトルポケモンと入れ替える。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "てんくうのツメ" },
+			damage: 130,
+			cost: ["Lightning", "Lightning", "Colorless"],
+		},
+		{
+			name: { ja: "カプサンダーGX" },
+			damage: "50×",
+			cost: ["Lightning", "Lightning", "Colorless"],
+			effect: {
+				ja: "相手の場のポケモンについているエネルギーの数x50ダメージ。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 560065,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Double rare",
+	dexId: [785],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM4p/033.ts
+++ b/data-asia/SM/SM4p/033.ts
@@ -1,0 +1,64 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "デンジュモクGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 180,
+	types: ["Lightning"],
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "フラッシュヘッド" },
+			effect: {
+				ja: "このポケモンは、特殊エネルギーがついている相手のポケモンから、ワザのダメージを受けない。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ランブルワイヤー" },
+			damage: 100,
+			cost: ["Lightning", "Lightning", "Colorless"],
+			effect: {
+				ja: "相手の山札を上から1枚トラッシュする。",
+			},
+		},
+		{
+			name: { ja: "ライトニングGX" },
+			cost: ["Lightning"],
+			effect: {
+				ja: "相手の手札を見て、その中にあるカードを1枚、ウラにして相手のサイドとして置く。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Metal", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 560066,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Double rare",
+	dexId: [796],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM4p/034.ts
+++ b/data-asia/SM/SM4p/034.ts
@@ -1,0 +1,53 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アローラベトベター",
+	},
+
+	illustrator: "Naoki Saito",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Psychic"],
+
+	description: {
+		ja: "結晶は 毒素の 塊。 ベトベターの 身体から 落ちると 死に至る 毒素が 漏れだすぞ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "どくのいき" },
+			cost: [],
+			effect: {
+				ja: "コインを1回投げオモテなら、相手のバトルポケモンをどくにする。",
+			},
+		},
+		{
+			name: { ja: "はたく" },
+			damage: 40,
+			cost: ["Psychic", "Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560067,
+			},
+		},
+	],
+
+	retreat: 3,
+	rarity: "None",
+	dexId: [88],
+};
+
+export default card;

--- a/data-asia/SM/SM4p/035.ts
+++ b/data-asia/SM/SM4p/035.ts
@@ -1,0 +1,63 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アローラベトベトン",
+	},
+
+	illustrator: "Hitoshi Ariga",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Psychic"],
+
+	description: {
+		ja: "意外に 大人しく なつくが 餌の ゴミを ずっと あげていないと 家の 家具を 壊して 喰らいだす。",
+	},
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "かがくのちから" },
+			effect: {
+				ja: "このポケモンがいるかぎり、おたがいの場・手札・トラッシュにあるたねポケモンの特性は、すべてなくなる。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "かみくだく" },
+			damage: 90,
+			cost: ["Psychic", "Psychic", "Colorless", "Colorless"],
+			effect: {
+				ja: "コインを1回投げオモテなら、相手のバトルポケモンについているエネルギーを、1個トラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560068,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "アローラベトベター",
+	},
+
+	retreat: 4,
+	rarity: "None",
+	dexId: [89],
+};
+
+export default card;

--- a/data-asia/SM/SM4p/036.ts
+++ b/data-asia/SM/SM4p/036.ts
@@ -1,0 +1,63 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ミュウツーGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 190,
+	types: ["Psychic"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "フルバースト" },
+			damage: "30×",
+			cost: ["Psychic"],
+			effect: {
+				ja: "このポケモンについているエネルギーの数x30ダメージ。",
+			},
+		},
+		{
+			name: { ja: "ちょうきゅうしゅう" },
+			damage: 60,
+			cost: ["Psychic", "Colorless"],
+			effect: {
+				ja: "このポケモンのHPを「30」回復する。",
+			},
+		},
+		{
+			name: { ja: "サイコブレイクGX" },
+			damage: 200,
+			cost: ["Psychic", "Psychic", "Psychic"],
+			effect: {
+				ja: "このワザのダメージは、相手のバトルポケモンにかかっている効果を計算しない。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 560069,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Double rare",
+	dexId: [150],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM4p/037.ts
+++ b/data-asia/SM/SM4p/037.ts
@@ -1,0 +1,49 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ソーナンス",
+	},
+
+	illustrator: "nagimiso",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Psychic"],
+
+	description: {
+		ja: "光や ショックを 嫌う。 攻撃されると 体が ふくらみ 反撃が 強力に なる。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "かげむすび" },
+			damage: "50×",
+			cost: ["Psychic", "Psychic", "Psychic"],
+			effect: {
+				ja: "相手のバトルポケモンのにげるためのエネルギーの数x50ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560070,
+			},
+		},
+	],
+
+	retreat: 3,
+	rarity: "None",
+	dexId: [202],
+};
+
+export default card;

--- a/data-asia/SM/SM4p/038.ts
+++ b/data-asia/SM/SM4p/038.ts
@@ -1,0 +1,59 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ハブネーク",
+	},
+
+	illustrator: "Eri Yamaki",
+	category: "Pokemon",
+	hp: 100,
+	types: ["Psychic"],
+
+	description: {
+		ja: "猛毒が 染み出している 鋭い 切れ味の 尻尾で 素早い ザングースに 立ち向かう。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ポイズンアップ" },
+			effect: {
+				ja: "このポケモンがいるかぎり、相手のバトルポケモンは、どくでのせるダメカンの数が1個多くなる。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "どくのキバ" },
+			damage: 30,
+			cost: ["Psychic", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをどくにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560071,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "None",
+	dexId: [336],
+};
+
+export default card;

--- a/data-asia/SM/SM4p/039.ts
+++ b/data-asia/SM/SM4p/039.ts
@@ -1,0 +1,53 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヤブクロン",
+	},
+
+	illustrator: "Yuka Morii",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Psychic"],
+
+	description: {
+		ja: "不衛生な 場所が 好き。 アローラでは よく ベトベターに 追いまわされる 姿を みかける。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ふみならす" },
+			cost: ["Psychic"],
+			effect: {
+				ja: "相手の山札を上から1枚トラッシュする。",
+			},
+		},
+		{
+			name: { ja: "よだれ" },
+			damage: 30,
+			cost: ["Psychic", "Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560072,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "None",
+	dexId: [568],
+};
+
+export default card;

--- a/data-asia/SM/SM4p/040.ts
+++ b/data-asia/SM/SM4p/040.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ダストダス",
+	},
+
+	illustrator: "Mitsuhiro Arita",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Psychic"],
+
+	description: {
+		ja: "右腕から 飛びだす 毒液に 注意。 ちょっと かかるだけで 未知の 毒素に 冒される。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "ゴミなだれ" },
+			damage: "20×",
+			cost: ["Psychic"],
+			effect: {
+				ja: "相手のトラッシュにあるグッズの枚数x20ダメージ。",
+			},
+		},
+		{
+			name: { ja: "アシッドボム" },
+			damage: 70,
+			cost: ["Psychic", "Colorless", "Colorless"],
+			effect: {
+				ja: "コインを1回投げオモテなら、相手のバトルポケモンについているエネルギーを、1個トラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560073,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ヤブクロン",
+	},
+
+	retreat: 3,
+	rarity: "None",
+	dexId: [569],
+};
+
+export default card;

--- a/data-asia/SM/SM4p/041.ts
+++ b/data-asia/SM/SM4p/041.ts
@@ -1,0 +1,56 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "オドリドリ",
+	},
+
+	illustrator: "Kouki Saitou",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Psychic"],
+
+	description: {
+		ja: "ゆらゆら 揺れて リラックス。 こうして 高まった サイコパワーを 敵に 目掛けて 放射するぞ。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "バイタルダンス" },
+			effect: {
+				ja: "自分の番に、このカードを手札からベンチに出したとき、1回使える。自分の山札にある基本エネルギーを2枚まで、相手に見せてから、手札に加える。そして山札を切る。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ふらっとビンタ" },
+			damage: 30,
+			cost: ["Psychic", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560074,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "None",
+	dexId: [741],
+};
+
+export default card;

--- a/data-asia/SM/SM4p/042.ts
+++ b/data-asia/SM/SM4p/042.ts
@@ -1,0 +1,56 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "オドリドリ",
+	},
+
+	illustrator: "TOKIYA",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Psychic"],
+
+	description: {
+		ja: "むらさきのミツを 吸った オドリドリ。 雅で あでやかな 舞は 敵の 身も 心も 異界へ 誘う。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "あやかしのまい" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "相手のトラッシュにあるポケモンの枚数ぶんのダメカンを、相手のポケモンに好きなようにのせる。",
+			},
+		},
+		{
+			name: { ja: "めざめるダンス" },
+			damage: 30,
+			cost: ["Colorless"],
+			effect: {
+				ja: "場にスタジアムが出ていないなら、このワザは失敗。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560075,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "None",
+	dexId: [741],
+};
+
+export default card;

--- a/data-asia/SM/SM4p/043.ts
+++ b/data-asia/SM/SM4p/043.ts
@@ -1,0 +1,55 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ミミッキュ",
+	},
+
+	illustrator: "Megumi Mizutani",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Psychic"],
+
+	description: {
+		ja: "正体不明。 ボロ布の 中身を みた とある 学者は 恐怖の あまり ショック死した。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "くすねる" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札を2枚引く。",
+			},
+		},
+		{
+			name: { ja: "まねっこ" },
+			cost: ["Psychic", "Colorless"],
+			effect: {
+				ja: "前の相手の番に、相手のポケモンがワザ(GXワザをのぞく)を使っていたなら、そのワザをこのワザとして使う。",
+			},
+		},
+	],
+
+	weaknesses: [],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560076,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "None",
+	dexId: [778],
+};
+
+export default card;

--- a/data-asia/SM/SM4p/044.ts
+++ b/data-asia/SM/SM4p/044.ts
@@ -1,0 +1,59 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ダダリン",
+	},
+
+	illustrator: "Hasuno",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Psychic"],
+
+	description: {
+		ja: "でかい 錨を ブンブン 振り回し ホエルオーさえ 一撃で ＫＯ。 緑の モズクが 本体だ。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "はがねつかい" },
+			effect: {
+				ja: "このポケモンがいるかぎり、自分の[鋼]ポケモンが使うワザの、相手のバトルポケモンへのダメージは「+10」される。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "アンカーショット" },
+			damage: 70,
+			cost: ["Psychic", "Colorless", "Colorless"],
+			effect: {
+				ja: "次の相手の番、このワザを受けたポケモンは、にげられない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560077,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "None",
+	dexId: [781],
+};
+
+export default card;

--- a/data-asia/SM/SM4p/045.ts
+++ b/data-asia/SM/SM4p/045.ts
@@ -1,0 +1,64 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "カプ・テテフGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 170,
+	types: ["Psychic"],
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ワンダータッチ" },
+			effect: {
+				ja: "自分の番に、このカードを手札からベンチに出したとき、1回使える。自分の山札にあるサポートを1枚、相手に見せてから、手札に加える。そして山札を切る。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "エナジードライブ" },
+			damage: "20×",
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "おたがいのバトルポケモンについているエネルギーの数x20ダメージ。このワザのダメージは弱点・抵抗力を計算しない。",
+			},
+		},
+		{
+			name: { ja: "カプキュアーGX" },
+			cost: ["Psychic"],
+			effect: {
+				ja: "自分のベンチポケモン2匹のHPを、すべて回復する。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 560078,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Double rare",
+	dexId: [786],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM4p/046.ts
+++ b/data-asia/SM/SM4p/046.ts
@@ -1,0 +1,48 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "コスモッグ",
+	},
+
+	illustrator: "Shin Nagasawa",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Psychic"],
+
+	description: {
+		ja: "はかない ガス状の 身体。 大気の チリを 集めながら ゆっくりと 成長していく。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "テレポート" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "このポケモンをベンチポケモンと入れ替える。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560079,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "None",
+	dexId: [789],
+};
+
+export default card;

--- a/data-asia/SM/SM4p/047.ts
+++ b/data-asia/SM/SM4p/047.ts
@@ -1,0 +1,52 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "コスモウム",
+	},
+
+	illustrator: "Sanosuke Sakuma",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Psychic"],
+
+	description: {
+		ja: "硬いカラの 中で 黒いコアに なにかが 集まり 続けている。 別世界の ポケモンと いわれる。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "テレポート" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "このポケモンをベンチポケモンと入れ替える。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560080,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "コスモッグ",
+	},
+
+	retreat: 3,
+	rarity: "None",
+	dexId: [790],
+};
+
+export default card;

--- a/data-asia/SM/SM4p/048.ts
+++ b/data-asia/SM/SM4p/048.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ルナアーラ",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 160,
+	types: ["Psychic"],
+
+	description: {
+		ja: "コスモッグが 進化した ♀だと いわれる。 第３の 眼が 浮かぶとき 別世界へと 飛び去っていく。",
+	},
+
+	stage: "Stage2",
+
+	attacks: [
+		{
+			name: { ja: "バーストボール" },
+			damage: "40×",
+			cost: ["Psychic"],
+			effect: {
+				ja: "このポケモンについている[超]エネルギーの数x40ダメージ。",
+			},
+		},
+		{
+			name: { ja: "がちりんのつばさ" },
+			damage: 130,
+			cost: ["Psychic", "Psychic", "Psychic"],
+			effect: {
+				ja: "このポケモンについているエネルギーをすべて、ベンチポケモンに好きなようにつけ替える。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560081,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "コスモウム",
+	},
+
+	retreat: 2,
+	rarity: "None",
+	dexId: [792],
+};
+
+export default card;

--- a/data-asia/SM/SM4p/049.ts
+++ b/data-asia/SM/SM4p/049.ts
@@ -1,0 +1,68 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ルナアーラGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 250,
+	types: ["Psychic"],
+
+	stage: "Stage2",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "サイコトランス" },
+			effect: {
+				ja: "自分の番に何回でも使える。自分の場のポケモンについている[超]エネルギーを1個、自分の別のポケモンにつけ替える。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "シャドーレイ" },
+			damage: 120,
+			cost: ["Psychic", "Psychic", "Psychic", "Psychic"],
+			effect: {
+				ja: "次の相手の番、このワザを受けたポケモンのHPは、回復しない。",
+			},
+		},
+		{
+			name: { ja: "ルナフォールGX" },
+			cost: ["Psychic", "Psychic", "Psychic"],
+			effect: {
+				ja: "相手のたねポケモン（「ポケモンGX」をのぞく）を1匹、きぜつさせる。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 560082,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "コスモウム",
+	},
+
+	retreat: 2,
+	rarity: "Double rare",
+	dexId: [792],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM4p/050.ts
+++ b/data-asia/SM/SM4p/050.ts
@@ -1,0 +1,64 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ネクロズマGX",
+	},
+
+	illustrator: "PLANETA",
+	category: "Pokemon",
+	hp: 180,
+	types: ["Psychic"],
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ひかりのおわり" },
+			effect: {
+				ja: "このポケモンは[無]ポケモンから、ワザのダメージを受けない。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "プリズムバースト" },
+			damage: "10+",
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンについている[超]エネルギーをすべてトラッシュし、その枚数x60ダメージ追加。",
+			},
+		},
+		{
+			name: { ja: "ブラックレイGX" },
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手の「ポケモンGX・EX」全員に、それぞれ100ダメージ。このワザのダメージは弱点・抵抗力を計算しない。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 560083,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Double rare",
+	dexId: [800],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM4p/051.ts
+++ b/data-asia/SM/SM4p/051.ts
@@ -1,0 +1,56 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ウソッキー",
+	},
+
+	illustrator: "Hajime Kusajima",
+	category: "Pokemon",
+	hp: 100,
+	types: ["Fighting"],
+
+	description: {
+		ja: "襲われないため 樹木の 真似を するが 嫌いな 水を かけられて あわてて 逃げだしていく。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "みちをふさぐ" },
+			effect: {
+				ja: "このポケモンがいるかぎり、相手がベンチに出せるポケモンの数は、4匹になる。相手のベンチに5匹以上いる場合は、相手はベンチが4匹になるまでポケモンをトラッシュする。［ベンチの数を変更する効果は、少ない数が優先される。］",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "いわおとし" },
+			damage: 40,
+			cost: ["Fighting", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560084,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "None",
+	dexId: [185],
+};
+
+export default card;

--- a/data-asia/SM/SM4p/052.ts
+++ b/data-asia/SM/SM4p/052.ts
@@ -1,0 +1,56 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ルナトーン",
+	},
+
+	illustrator: "Shin Nagasawa",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Fighting"],
+
+	description: {
+		ja: "満月の 夜になると 活発に 活動するため 月の 満ち欠けと 関係していると 言われている。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "かいふくふうじ" },
+			effect: {
+				ja: "自分の場に「ソルロック」がいるなら、おたがいのポケモン全員のHPは、回復しない。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ルナブラスト" },
+			damage: 30,
+			cost: ["Fighting", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560085,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "None",
+	dexId: [337],
+};
+
+export default card;

--- a/data-asia/SM/SM4p/053.ts
+++ b/data-asia/SM/SM4p/053.ts
@@ -1,0 +1,56 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ソルロック",
+	},
+
+	illustrator: "Masakazu Fukuda",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Fighting"],
+
+	description: {
+		ja: "太陽エネルギーが パワーの 源 なので 昼間は 強い。 回転すると 体が 光る。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ダブルドロー" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札を2枚引く。",
+			},
+		},
+		{
+			name: { ja: "ソーラーヒート" },
+			damage: "20+",
+			cost: ["Fighting"],
+			effect: {
+				ja: "場にスタジアムが出ているなら、20ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560086,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "None",
+	dexId: [338],
+};
+
+export default card;

--- a/data-asia/SM/SM4p/054.ts
+++ b/data-asia/SM/SM4p/054.ts
@@ -1,0 +1,59 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "レジロック",
+	},
+
+	illustrator: "kawayoo",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Fighting"],
+
+	description: {
+		ja: "全身が 岩で できている。 戦いで 体が 欠けても 岩を くっつけて 治してしまう。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "いわやまのうなり" },
+			effect: {
+				ja: "このポケモンがいるかぎり、自分の「レジスチル」が使うワザの、相手のバトルポケモンへのダメージは「+10」される。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ハードスイング" },
+			damage: 110,
+			cost: ["Fighting", "Fighting", "Colorless"],
+			effect: {
+				ja: "このワザのダメージは抵抗力を計算しない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560087,
+			},
+		},
+	],
+
+	retreat: 3,
+	rarity: "None",
+	dexId: [377],
+};
+
+export default card;

--- a/data-asia/SM/SM4p/055.ts
+++ b/data-asia/SM/SM4p/055.ts
@@ -1,0 +1,56 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "イワンコ",
+	},
+
+	illustrator: "Naoki Saito",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Fighting"],
+
+	description: {
+		ja: "よく なつくので 初心者に お勧めのポケモンと いわれるが 育つと 気性は 荒くなる。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "おいつめる" },
+			cost: ["Fighting"],
+			effect: {
+				ja: "次の相手の番、このワザを受けたポケモンは、にげられない。",
+			},
+		},
+		{
+			name: { ja: "けりつける" },
+			damage: 30,
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "コインを1回投げウラなら、このワザは失敗。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560088,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "None",
+	dexId: [744],
+};
+
+export default card;

--- a/data-asia/SM/SM4p/056.ts
+++ b/data-asia/SM/SM4p/056.ts
@@ -1,0 +1,64 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ルガルガンGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 200,
+	types: ["Fighting"],
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "かみくだく" },
+			damage: 30,
+			cost: ["Fighting", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンについているエネルギーを、1個トラッシュする。",
+			},
+		},
+		{
+			name: { ja: "アクセルロック" },
+			damage: 120,
+			cost: ["Fighting", "Fighting", "Colorless"],
+		},
+		{
+			name: { ja: "ガルファングGX" },
+			damage: 200,
+			cost: ["Fighting", "Fighting", "Colorless"],
+			effect: {
+				ja: "このポケモンについているエネルギーを、2個トラッシュする。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 560089,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "イワンコ",
+	},
+
+	retreat: 1,
+	rarity: "Double rare",
+	dexId: [745],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM4p/057.ts
+++ b/data-asia/SM/SM4p/057.ts
@@ -1,0 +1,66 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ルガルガンGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 200,
+	types: ["Fighting"],
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ブラッディアイ" },
+			effect: {
+				ja: "自分の番に、このカードを手札から出して進化させたとき、1回使える。相手のベンチポケモンを1匹選び、バトルポケモンと入れ替える。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ツメできりさく" },
+			damage: 110,
+			cost: ["Fighting", "Colorless", "Colorless"],
+		},
+		{
+			name: { ja: "デスローグGX" },
+			damage: "50×",
+			cost: ["Fighting", "Colorless"],
+			effect: {
+				ja: "相手のベンチポケモンの数x50ダメージ。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 560090,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "イワンコ",
+	},
+
+	retreat: 2,
+	rarity: "Double rare",
+	dexId: [745],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM4p/058.ts
+++ b/data-asia/SM/SM4p/058.ts
@@ -1,0 +1,56 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ナゲツケサル",
+	},
+
+	illustrator: "Naoki Saito",
+	category: "Pokemon",
+	hp: 110,
+	types: ["Fighting"],
+
+	description: {
+		ja: "２０匹前後の グループを つくる。 その結束は 非常に 固く 絶対 仲間を 見捨てない。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "なげつける" },
+			cost: ["Fighting"],
+			effect: {
+				ja: "相手のベンチポケモン1匹に、30ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+			},
+		},
+		{
+			name: { ja: "チームプレイ" },
+			damage: "10+",
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "自分のベンチの「ナゲツケサル」の数x30ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560091,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "None",
+	dexId: [766],
+};
+
+export default card;

--- a/data-asia/SM/SM4p/059.ts
+++ b/data-asia/SM/SM4p/059.ts
@@ -1,0 +1,56 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "スナバァ",
+	},
+
+	illustrator: "Akira Komayama",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Fighting"],
+
+	description: {
+		ja: "口の中に 手を 入れた者を 操ってしまう。 砂山の 身体を 大きく させるためだ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "すなあつめ" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分のトラッシュにある[闘]エネルギーを1枚、このポケモンにつける。",
+			},
+		},
+		{
+			name: { ja: "すなじごく" },
+			damage: 30,
+			cost: ["Fighting", "Colorless", "Colorless"],
+			effect: {
+				ja: "次の相手の番、このワザを受けたポケモンは、にげられない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560092,
+			},
+		},
+	],
+
+	retreat: 3,
+	rarity: "None",
+	dexId: [769],
+};
+
+export default card;

--- a/data-asia/SM/SM4p/060.ts
+++ b/data-asia/SM/SM4p/060.ts
@@ -1,0 +1,63 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "シロデスナ",
+	},
+
+	illustrator: "Kouki Saitou",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Fighting"],
+
+	description: {
+		ja: "城の 下には 精気を 吸われ 干からびた 者たちの 骨が 大量に 埋まっている。",
+	},
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "すなのぼうへき" },
+			effect: {
+				ja: "このポケモンが受けるワザのダメージは「-20」される。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "せいきをすいとる" },
+			damage: 50,
+			cost: ["Fighting", "Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンに与えたダメージぶん、このポケモンのHPを回復する。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560093,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "スナバァ",
+	},
+
+	retreat: 4,
+	rarity: "None",
+	dexId: [770],
+};
+
+export default card;

--- a/data-asia/SM/SM4p/061.ts
+++ b/data-asia/SM/SM4p/061.ts
@@ -1,0 +1,49 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヤミカラス",
+	},
+
+	illustrator: "Sekio",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Darkness"],
+
+	description: {
+		ja: "日暮れに 目覚め 夕闇を 飛ぶ。 ヤミカラスが 飛ぶまでに 家に 帰れ という ことわざも あるぞ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ふきとばし" },
+			damage: 10,
+			cost: ["Darkness"],
+			effect: {
+				ja: "相手のバトルポケモンをベンチポケモンと入れ替える。［バトル場に出すポケモンは相手が選ぶ。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560094,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "None",
+	dexId: [198],
+};
+
+export default card;

--- a/data-asia/SM/SM4p/062.ts
+++ b/data-asia/SM/SM4p/062.ts
@@ -1,0 +1,60 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ドンカラス",
+	},
+
+	illustrator: "Hideki Ishikawa",
+	category: "Pokemon",
+	hp: 110,
+	types: ["Darkness"],
+
+	description: {
+		ja: "夜行性。 一声 鳴けば １００匹を 超える 子分の ヤミカラスが 集結する。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "だましうち" },
+			cost: ["Darkness"],
+			effect: {
+				ja: "相手のポケモン1匹に、30ダメージ。このワザのダメージは、弱点・抵抗力と、ダメージを受けるポケモンにかかっている効果を計算しない。",
+			},
+		},
+		{
+			name: { ja: "レイブンクロー" },
+			damage: "10+",
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "相手の場のポケモンにのっているダメカンの数x10ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560095,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ヤミカラス",
+	},
+
+	retreat: 1,
+	rarity: "None",
+	dexId: [430],
+};
+
+export default card;

--- a/data-asia/SM/SM4p/063.ts
+++ b/data-asia/SM/SM4p/063.ts
@@ -1,0 +1,53 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヤミラミ",
+	},
+
+	illustrator: "Aya Kusube",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Darkness"],
+
+	description: {
+		ja: "宝石が 好物で メレシーを 狙って 付け回しているが ガバイトに 横取り されてしまう。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "そくばく" },
+			cost: ["Darkness"],
+			effect: {
+				ja: "次の相手の番、相手は手札からサポートを出して使えない。",
+			},
+		},
+		{
+			name: { ja: "ひっかく" },
+			damage: 20,
+			cost: ["Colorless"],
+		},
+	],
+
+	weaknesses: [],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560096,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "None",
+	dexId: [302],
+};
+
+export default card;

--- a/data-asia/SM/SM4p/064.ts
+++ b/data-asia/SM/SM4p/064.ts
@@ -1,0 +1,64 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ダークライGX",
+	},
+
+	illustrator: "PLANETA",
+	category: "Pokemon",
+	hp: 180,
+	types: ["Darkness"],
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "リザレクション" },
+			effect: {
+				ja: "このカードがトラッシュにあるなら、自分の番に1回使える。このカードをベンチに出す。その後、自分のトラッシュにある[悪]エネルギーを1枚、このカードにつける。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "やみのさけめ" },
+			damage: 130,
+			cost: ["Darkness", "Darkness", "Colorless"],
+			effect: {
+				ja: "このワザのダメージは抵抗力を計算しない。",
+			},
+		},
+		{
+			name: { ja: "デッドエンドGX" },
+			cost: ["Darkness", "Darkness", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンが特殊状態なら、そのポケモンをきぜつさせる。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 560097,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Double rare",
+	dexId: [491],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM4p/065.ts
+++ b/data-asia/SM/SM4p/065.ts
@@ -1,0 +1,59 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アクジキングGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 210,
+	types: ["Darkness"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "くいちらかす" },
+			cost: ["Darkness"],
+			effect: {
+				ja: "自分の山札を上から5枚トラッシュし、その中にあるエネルギーをすべて、このポケモンにつける。",
+			},
+		},
+		{
+			name: { ja: "タイラントホール" },
+			damage: 180,
+			cost: ["Darkness", "Darkness", "Darkness", "Colorless", "Colorless"],
+		},
+		{
+			name: { ja: "グラトニーGX" },
+			damage: 100,
+			cost: ["Darkness", "Darkness", "Darkness", "Darkness", "Darkness"],
+			effect: {
+				ja: "このワザのダメージで、相手のポケモンがきぜつしたなら、サイドを2枚多くとる。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 560098,
+			},
+		},
+	],
+
+	retreat: 4,
+	rarity: "Double rare",
+	dexId: [799],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM4p/066.ts
+++ b/data-asia/SM/SM4p/066.ts
@@ -1,0 +1,53 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アローラディグダ",
+	},
+
+	illustrator: "Megumi Mizutani",
+	category: "Pokemon",
+	hp: 50,
+	types: ["Metal"],
+
+	description: {
+		ja: "頭から 生えているのは 髭が 変化 したもので 金属質。 ゆらゆら 動き 仲間と 交信。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "あなさぐり" },
+			cost: [],
+			effect: {
+				ja: "自分の山札を上から3枚見て、好きな順番に入れ替えて、山札の上にもどす。",
+			},
+		},
+		{
+			name: { ja: "どろかけ" },
+			damage: 10,
+			cost: ["Metal"],
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560099,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "None",
+	dexId: [50],
+};
+
+export default card;

--- a/data-asia/SM/SM4p/067.ts
+++ b/data-asia/SM/SM4p/067.ts
@@ -1,0 +1,62 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アローラダグトリオ",
+	},
+
+	illustrator: "match",
+	category: "Pokemon",
+	hp: 100,
+	types: ["Metal"],
+
+	description: {
+		ja: "金色に 輝く 髭で 身を 守っている。 抜け落ちた 髭を 持ち帰ると 不幸に なると いう。",
+	},
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "カーリーヘアー" },
+			effect: {
+				ja: "このポケモンがいるかぎり、相手のバトルポケモンのにげるためのエネルギーは、1個ぶん多くなる。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "じめんにもぐる" },
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のポケモン1匹に、50ダメージ。このワザのダメージは弱点・抵抗力を計算しない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560100,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "アローラディグダ",
+	},
+
+	retreat: 2,
+	rarity: "None",
+	dexId: [51],
+};
+
+export default card;

--- a/data-asia/SM/SM4p/068.ts
+++ b/data-asia/SM/SM4p/068.ts
@@ -1,0 +1,57 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "レジスチル",
+	},
+
+	illustrator: "Mitsuhiro Arita",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Metal"],
+
+	description: {
+		ja: "何万年も 地下の 圧力で 鍛えられた 金属の ボディは 傷ひとつ つかない。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ターボアーム" },
+			damage: 30,
+			cost: ["Metal"],
+			effect: {
+				ja: "自分のトラッシュにある基本エネルギーを1枚、ベンチポケモンにつける。",
+			},
+		},
+		{
+			name: { ja: "くろがねのこぶし" },
+			damage: 90,
+			cost: ["Metal", "Metal", "Colorless"],
+			effect: {
+				ja: "自分のベンチに「レジアイス」がいるなら、このポケモンのHPを「30」回復する。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560101,
+			},
+		},
+	],
+
+	retreat: 3,
+	rarity: "None",
+	dexId: [379],
+};
+
+export default card;

--- a/data-asia/SM/SM4p/069.ts
+++ b/data-asia/SM/SM4p/069.ts
@@ -1,0 +1,60 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ソルガレオ",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 160,
+	types: ["Metal"],
+
+	description: {
+		ja: "別世界に 棲むと いわれる。 全身から 激しい光を 放ち 闇夜も 真昼のように 照らすのだ。",
+	},
+
+	stage: "Stage2",
+
+	attacks: [
+		{
+			name: { ja: "シャイニングアロー" },
+			cost: ["Metal", "Colorless"],
+			effect: {
+				ja: "相手のポケモン1匹に、50ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+			},
+		},
+		{
+			name: { ja: "にちりんのキバ" },
+			damage: 170,
+			cost: ["Metal", "Metal", "Colorless"],
+			effect: {
+				ja: "次の自分の番、このポケモンは「にちりんのキバ」が使えない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560102,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "コスモウム",
+	},
+
+	retreat: 3,
+	rarity: "None",
+	dexId: [791],
+};
+
+export default card;

--- a/data-asia/SM/SM4p/070.ts
+++ b/data-asia/SM/SM4p/070.ts
@@ -1,0 +1,68 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ソルガレオGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 250,
+	types: ["Metal"],
+
+	stage: "Stage2",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ウルトラロード" },
+			effect: {
+				ja: "自分の番に1回使える。自分のバトルポケモンをベンチポケモンと入れ替える。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "メテオドライブ" },
+			damage: 230,
+			cost: ["Metal", "Metal", "Colorless"],
+			effect: {
+				ja: "このポケモンについているエネルギーを、すべてトラッシュする。",
+			},
+		},
+		{
+			name: { ja: "ソルバーストGX" },
+			cost: ["Metal"],
+			effect: {
+				ja: "自分の山札にあるエネルギーを5枚まで、自分のポケモンに好きなようにつける。そして山札を切る。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 560103,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "コスモウム",
+	},
+
+	retreat: 3,
+	rarity: "Double rare",
+	dexId: [791],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM4p/071.ts
+++ b/data-asia/SM/SM4p/071.ts
@@ -1,0 +1,60 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "テッカグヤGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 200,
+	types: ["Metal"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ロケットフォール" },
+			damage: "30+",
+			cost: ["Metal", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンのにげるためのエネルギーの数x30ダメージ追加。",
+			},
+		},
+		{
+			name: { ja: "ムーンプレス" },
+			damage: 130,
+			cost: ["Metal", "Colorless", "Colorless", "Colorless"],
+		},
+		{
+			name: { ja: "ブラスターGX" },
+			damage: 180,
+			cost: ["Metal", "Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "自分のサイドをすべてオモテにする。（対戦が終わるまで、そのサイドはオモテのまま。）［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 560104,
+			},
+		},
+	],
+
+	retreat: 4,
+	rarity: "Double rare",
+	dexId: [797],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM4p/072.ts
+++ b/data-asia/SM/SM4p/072.ts
@@ -1,0 +1,56 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "マギアナ",
+	},
+
+	illustrator: "kawayoo",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Metal"],
+
+	description: {
+		ja: "５００年以上前に 造られた 人造ポケモン。 人の 言葉を 理解するが しゃべれない。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "きせかえ" },
+			effect: {
+				ja: "自分の番に1回使える。自分の場のポケモンについている「ポケモンのどうぐ」を1枚、手札にもどす。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ボールアタック" },
+			damage: 60,
+			cost: ["Metal", "Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560105,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "None",
+	dexId: [801],
+};
+
+export default card;

--- a/data-asia/SM/SM4p/073.ts
+++ b/data-asia/SM/SM4p/073.ts
@@ -1,0 +1,62 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ニンフィアGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 200,
+	types: ["Fairy"],
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "マジカルリボン" },
+			cost: ["Fairy"],
+			effect: {
+				ja: "自分の山札にある好きなカードを3枚まで、手札に加える。そして山札を切る。",
+			},
+		},
+		{
+			name: { ja: "ようせいのかぜ" },
+			damage: 110,
+			cost: ["Fairy", "Colorless", "Colorless"],
+		},
+		{
+			name: { ja: "プリエールGX" },
+			cost: ["Fairy", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のベンチポケモン2匹と、そのポケモンについているすべてのカードを、相手の手札にもどす。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [{ type: "Darkness", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 560106,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "イーブイ",
+	},
+
+	retreat: 2,
+	rarity: "Double rare",
+	dexId: [700],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM4p/074.ts
+++ b/data-asia/SM/SM4p/074.ts
@@ -1,0 +1,56 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ディアンシー",
+	},
+
+	illustrator: "TOKIYA",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Fairy"],
+
+	description: {
+		ja: "メレシーの 突然変異。 ピンク色に 輝く 体は 世界一 美しいと 言われる。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "きらめくいのり" },
+			cost: ["Fairy"],
+			effect: {
+				ja: "自分の場のポケモン1匹から進化するカードを、自分の山札から1枚選び、そのポケモンにのせて進化させる。そして山札を切る。",
+			},
+		},
+		{
+			name: { ja: "ダイヤストーム" },
+			damage: 30,
+			cost: ["Fairy", "Colorless"],
+			effect: {
+				ja: "自分の[妖]ポケモン全員のHPを、それぞれ「30」回復する。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [{ type: "Darkness", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560107,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "None",
+	dexId: [719],
+};
+
+export default card;

--- a/data-asia/SM/SM4p/075.ts
+++ b/data-asia/SM/SM4p/075.ts
@@ -1,0 +1,53 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ネマシュ",
+	},
+
+	illustrator: "Midori Harada",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Fairy"],
+
+	description: {
+		ja: "点滅しながら 発光する 胞子を あたりに ばら撒く。 その光を 見た者は 深い眠りに おちる。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ゆれるほうし" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをねむりにする。",
+			},
+		},
+		{
+			name: { ja: "ぶつかる" },
+			damage: 10,
+			cost: ["Fairy"],
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [{ type: "Darkness", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560108,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "None",
+	dexId: [755],
+};
+
+export default card;

--- a/data-asia/SM/SM4p/076.ts
+++ b/data-asia/SM/SM4p/076.ts
@@ -1,0 +1,63 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "マシェード",
+	},
+
+	illustrator: "kawayoo",
+	category: "Pokemon",
+	hp: 100,
+	types: ["Fairy"],
+
+	description: {
+		ja: "夜中に マシェードの棲む 森に いくのは 危険。 怪しい光に 惑わされ 二度と 帰れなくなる。",
+	},
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "はっこう" },
+			effect: {
+				ja: "自分の番に1回使える。自分の山札にある[妖]ポケモンを1枚、相手に見せてから、手札に加える。そして山札を切る。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ゆれるほうし" },
+			damage: 30,
+			cost: ["Fairy", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをねむりにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [{ type: "Darkness", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560109,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ネマシュ",
+	},
+
+	retreat: 2,
+	rarity: "None",
+	dexId: [756],
+};
+
+export default card;

--- a/data-asia/SM/SM4p/077.ts
+++ b/data-asia/SM/SM4p/077.ts
@@ -1,0 +1,56 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "カプ・テテフ",
+	},
+
+	illustrator: "Shin Nagasawa",
+	category: "Pokemon",
+	hp: 110,
+	types: ["Fairy"],
+
+	description: {
+		ja: "無邪気で 残酷な アーカラの 守り神。 花の 芳しい 香りが エネルギーの 源。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "サイコウェーブ" },
+			damage: "20×",
+			cost: ["Fairy"],
+			effect: {
+				ja: "相手のバトルポケモンについているエネルギーの数x20ダメージ。",
+			},
+		},
+		{
+			name: { ja: "マジカルスワップ" },
+			cost: ["Fairy", "Colorless"],
+			effect: {
+				ja: "相手の場のポケモンにのっているダメカンを好きなだけ選び、相手の場のポケモンに好きなようにのせ替える。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [{ type: "Darkness", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560110,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "None",
+	dexId: [786],
+};
+
+export default card;

--- a/data-asia/SM/SM4p/078.ts
+++ b/data-asia/SM/SM4p/078.ts
@@ -1,0 +1,60 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アローラナッシー",
+	},
+
+	illustrator: "Hasuno",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Dragon"],
+
+	description: {
+		ja: "アローラは 最高の 環境。 この姿が 本来の ナッシーだと 地元の 人々は 誇らしげだ。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "ナッシーパラダイス" },
+			cost: [],
+			effect: {
+				ja: "自分のベンチの「タマタマ」の数ぶん、自分の山札にある「アローラナッシー」または「アローラナッシーGX」を選び、ベンチの「タマタマ」それぞれにのせて進化させる。そして山札を切る。",
+			},
+		},
+		{
+			name: { ja: "たまなげりゅうせいぐん" },
+			damage: "80×",
+			cost: ["Grass", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンについている[草]エネルギーの数ぶんコインを投げ、オモテの数x80ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fairy", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560111,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "タマタマ",
+	},
+
+	retreat: 3,
+	rarity: "None",
+	dexId: [103],
+};
+
+export default card;

--- a/data-asia/SM/SM4p/079.ts
+++ b/data-asia/SM/SM4p/079.ts
@@ -1,0 +1,56 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ジジーロン",
+	},
+
+	illustrator: "match",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Dragon"],
+
+	description: {
+		ja: "心優しい 性質。 だが 一度 怒りに かられると 激しい 息吹で あたりを 破壊 し尽くす。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ためる" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札にある基本エネルギーを1枚、このポケモンにつける。そして山札を切る。",
+			},
+		},
+		{
+			name: { ja: "パワーサイクロン" },
+			damage: 80,
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンについているエネルギーを1個、ベンチポケモンにつけ替える。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fairy", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560112,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "None",
+	dexId: [780],
+};
+
+export default card;

--- a/data-asia/SM/SM4p/080.ts
+++ b/data-asia/SM/SM4p/080.ts
@@ -1,0 +1,53 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ラッキー",
+	},
+
+	illustrator: "Megumi Mizutani",
+	category: "Pokemon",
+	hp: 110,
+	types: ["Colorless"],
+
+	description: {
+		ja: "ラッキーの 産む タマゴは 栄養が たっぷり つまっている。 多くの ポケモンが 大好物だ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "きずをなおす" },
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "コインを1回投げオモテなら、自分のポケモン1匹のHPを「30」回復する。",
+			},
+		},
+		{
+			name: { ja: "ぶちかます" },
+			damage: 80,
+			cost: ["Colorless", "Colorless", "Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560113,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "None",
+	dexId: [113],
+};
+
+export default card;

--- a/data-asia/SM/SM4p/081.ts
+++ b/data-asia/SM/SM4p/081.ts
@@ -1,0 +1,63 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ハピナス",
+	},
+
+	illustrator: "Hideki Ishikawa",
+	category: "Pokemon",
+	hp: 160,
+	types: ["Colorless"],
+
+	description: {
+		ja: "幸せが つまっていると いわれる ハピナスの タマゴを 食べれば どんな 凶暴な ポケモンも 穏やかに。",
+	},
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "うみたてタマゴ" },
+			effect: {
+				ja: "自分の番に、このカードを手札から出して進化させたとき、1回使える。自分のバトルポケモンのHPを「80」回復する。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "すてみタックル" },
+			damage: 160,
+			cost: ["Colorless", "Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンにも80ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560114,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ラッキー",
+	},
+
+	retreat: 4,
+	rarity: "None",
+	dexId: [242],
+};
+
+export default card;

--- a/data-asia/SM/SM4p/082.ts
+++ b/data-asia/SM/SM4p/082.ts
@@ -1,0 +1,57 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ガルーラ",
+	},
+
+	illustrator: "TOKIYA",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Colorless"],
+
+	description: {
+		ja: "ガルーラの 母親の 愛情は 深い。 我が子を 守るためならば 死さえ 恐れないと いわれている。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ふりおろす" },
+			damage: "30+",
+			cost: ["Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンが進化ポケモンなら、30ダメージ追加。",
+			},
+		},
+		{
+			name: { ja: "ハリケーンパンチ" },
+			damage: "50×",
+			cost: ["Colorless", "Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "コインを4回投げ、オモテの数x50ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560115,
+			},
+		},
+	],
+
+	retreat: 3,
+	rarity: "None",
+	dexId: [115],
+};
+
+export default card;

--- a/data-asia/SM/SM4p/083.ts
+++ b/data-asia/SM/SM4p/083.ts
@@ -1,0 +1,49 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "イーブイ",
+	},
+
+	illustrator: "Hideki Ishikawa",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Colorless"],
+
+	description: {
+		ja: "アンバランス かつ 不安定な 遺伝子を 持っており 様々な 進化の 可能性を 秘めている。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "フレンズパレット" },
+			damage: "10×",
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "自分のベンチポケモンのタイプの数x10ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560116,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "None",
+	dexId: [133],
+};
+
+export default card;

--- a/data-asia/SM/SM4p/084.ts
+++ b/data-asia/SM/SM4p/084.ts
@@ -1,0 +1,54 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "レックウザ",
+	},
+
+	illustrator: "Yoshinobu Saito",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Colorless"],
+
+	description: {
+		ja: "雲より はるか上の オゾン層に 生息しているため 地上から 姿を 見ることは できない。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ターボストーム" },
+			damage: 30,
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "自分のトラッシュにある基本エネルギーを2枚、自分のベンチポケモン1匹につける。",
+			},
+		},
+		{
+			name: { ja: "ドラゴンクロー" },
+			damage: 80,
+			cost: ["Colorless", "Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560117,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "None",
+	dexId: [384],
+};
+
+export default card;

--- a/data-asia/SM/SM4p/085.ts
+++ b/data-asia/SM/SM4p/085.ts
@@ -1,0 +1,54 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "タイプ：ヌル",
+	},
+
+	illustrator: "match",
+	category: "Pokemon",
+	hp: 110,
+	types: ["Colorless"],
+
+	description: {
+		ja: "重い 制御マスクを つけており 本来の 能力を だせない。 特別な 力を 秘めている。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "むじひないちげき" },
+			damage: "30+",
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンにダメカンがのっているなら、30ダメージ追加。",
+			},
+		},
+		{
+			name: { ja: "ヘッドバング" },
+			damage: 70,
+			cost: ["Colorless", "Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560118,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "None",
+	dexId: [772],
+};
+
+export default card;

--- a/data-asia/SM/SM4p/086.ts
+++ b/data-asia/SM/SM4p/086.ts
@@ -1,0 +1,69 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "シルヴァディGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 210,
+	types: ["Colorless"],
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ジャイロユニット" },
+			effect: {
+				ja: "このポケモンがいるかぎり、自分のたねポケモン全員のにげるためのエネルギーは、すべてなくなる。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ターボドライブ" },
+			damage: 120,
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "自分のトラッシュにある基本エネルギーを1枚、ベンチポケモンにつける。",
+			},
+		},
+		{
+			name: { ja: "リベリオンGX" },
+			damage: "50×",
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のベンチポケモンの数x50ダメージ。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 560119,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "タイプ：ヌル",
+	},
+
+	retreat: 2,
+	rarity: "Double rare",
+	dexId: [773],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM4p/087.ts
+++ b/data-asia/SM/SM4p/087.ts
@@ -1,0 +1,62 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ジジーロンGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 180,
+	types: ["Colorless"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ホーリーエッジ" },
+			damage: 20,
+			cost: ["Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンについている特殊エネルギーを、1個トラッシュする。",
+			},
+		},
+		{
+			name: { ja: "ぎゃくじょう" },
+			damage: "80+",
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "自分のベンチポケモンにダメカンがのっているなら、70ダメージ追加。",
+			},
+		},
+		{
+			name: { ja: "だいしゃりんGX" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の手札をすべて山札にもどして切る。その後、山札を10枚引く。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 560120,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Double rare",
+	dexId: [780],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM4p/088.ts
+++ b/data-asia/SM/SM4p/088.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アクアパッチ",
+	},
+
+	illustrator: "Toyste Beach",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分のトラッシュにある[水]エネルギーを1枚、ベンチの[水]ポケモンにつける。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560121,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/SM/SM4p/089.ts
+++ b/data-asia/SM/SM4p/089.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "あなぬけのヒモ",
+	},
+
+	illustrator: "Toyste Beach",
+	category: "Trainer",
+
+	effect: {
+		ja: "おたがいのプレイヤーは、それぞれ、自分のバトルポケモンをベンチポケモンと入れ替える。（入れ替えは相手からおこない、ベンチがいないプレイヤーは、入れ替えをしない。）",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560122,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/SM/SM4p/090.ts
+++ b/data-asia/SM/SM4p/090.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "改造ハンマー",
+	},
+
+	illustrator: "Yoshinobu Saito",
+	category: "Trainer",
+
+	effect: {
+		ja: "相手のポケモンについている特殊エネルギーを1個選び、トラッシュする。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560123,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/SM/SM4p/091.ts
+++ b/data-asia/SM/SM4p/091.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "タイマーボール",
+	},
+
+	illustrator: "Toyste Beach",
+	category: "Trainer",
+
+	effect: {
+		ja: "コインを2回投げ、オモテの数ぶん、自分の山札にある進化ポケモンを、相手に見せてから、手札に加える。そして山札を切る。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560124,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/SM/SM4p/092.ts
+++ b/data-asia/SM/SM4p/092.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ネストボール",
+	},
+
+	illustrator: "Toyste Beach",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の山札にあるたねポケモンを1枚、ベンチに出す。そして山札を切る。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560125,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/SM/SM4p/093.ts
+++ b/data-asia/SM/SM4p/093.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "フィールドブロアー",
+	},
+
+	illustrator: "Toyste Beach",
+	category: "Trainer",
+
+	effect: {
+		ja: "場にある「ポケモンのどうぐ」または「スタジアム」を、2枚までトラッシュする。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560126,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/SM/SM4p/094.ts
+++ b/data-asia/SM/SM4p/094.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ふしぎなアメ",
+	},
+
+	illustrator: "Toyste Beach",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分のたねポケモン1匹から進化する1進化の上の2進化ポケモンを、手札から1枚選び、そのたねポケモンにのせて進化させる。[最初の自分の番と、この番出したばかりのたねポケモンには使えない。]",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560127,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/SM/SM4p/095.ts
+++ b/data-asia/SM/SM4p/095.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "マルチつけかえ",
+	},
+
+	illustrator: "Toyste Beach",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分のベンチポケモンについているエネルギーを1個、自分のバトルポケモンにつけ替える。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560128,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/SM/SM4p/096.ts
+++ b/data-asia/SM/SM4p/096.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "まんたんのくすり",
+	},
+
+	illustrator: "Toyste Beach",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分のポケモンを1匹選び、HPをすべて回復する。その後、そのポケモンについているエネルギーをすべてトラッシュする。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560129,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/SM/SM4p/097.ts
+++ b/data-asia/SM/SM4p/097.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "レスキュータンカ",
+	},
+
+	illustrator: "Yoshinobu Saito",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分のトラッシュにあるポケモンを1枚、相手に見せてから、手札に加える。または、自分のトラッシュにあるポケモンを3枚、相手に見せてから、山札にもどして切る。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560130,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/SM/SM4p/098.ts
+++ b/data-asia/SM/SM4p/098.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ロトム図鑑",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分のサイドを数えたあと、すべて山札にもどして切る。その後、山札の上から、もどした枚数ぶんのカードを、サイドとして置く。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560131,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/SM/SM4p/099.ts
+++ b/data-asia/SM/SM4p/099.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "エレクトロメモリ",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードをつけている「シルヴァディGX」は、ポケモンになる。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560132,
+			},
+		},
+	],
+
+	trainerType: "Tool",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/SM/SM4p/100.ts
+++ b/data-asia/SM/SM4p/100.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "古代のクリスタル",
+	},
+
+	illustrator: "Toyste Beach",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードをつけている「レジロック」「レジアイス」「レジスチル」「レジギガス」が、相手のポケモンから受けるワザのダメージは「-30」される。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560133,
+			},
+		},
+	],
+
+	trainerType: "Tool",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/SM/SM4p/101.ts
+++ b/data-asia/SM/SM4p/101.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "こだわりハチマキ",
+	},
+
+	illustrator: "Eske Yoshinob",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードをつけているポケモンが使うワザの、相手のバトル場の「ポケモンGX・EX」へのダメージは「+30」される。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560134,
+			},
+		},
+	],
+
+	trainerType: "Tool",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/SM/SM4p/102.ts
+++ b/data-asia/SM/SM4p/102.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ファイヤーメモリ",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードをつけている「シルヴァディGX」は、ポケモンになる。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560135,
+			},
+		},
+	],
+
+	trainerType: "Tool",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/SM/SM4p/103.ts
+++ b/data-asia/SM/SM4p/103.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アセロラ",
+	},
+
+	illustrator: "Ken Sugimori",
+	category: "Trainer",
+
+	effect: {
+		ja: "ダメカンがのっている自分のポケモン1匹と、ついているすべてのカードを、手札にもどす。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560136,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/SM/SM4p/104.ts
+++ b/data-asia/SM/SM4p/104.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "カキ",
+	},
+
+	illustrator: "Ken Sugimori",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードを使ったら、自分の番は終わる。自分の山札にある[炎]エネルギーを4枚まで、自分のポケモン1匹につける。そして山札を切る。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560137,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/SM/SM4p/105.ts
+++ b/data-asia/SM/SM4p/105.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "グズマ",
+	},
+
+	illustrator: "Ken Sugimori",
+	category: "Trainer",
+
+	effect: {
+		ja: "相手のベンチポケモンを1匹選び、バトルポケモンと入れ替える。その後、自分のバトルポケモンをベンチポケモンと入れ替える。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560138,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/SM/SM4p/106.ts
+++ b/data-asia/SM/SM4p/106.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "スイレン",
+	},
+
+	illustrator: "Ken Sugimori",
+	category: "Trainer",
+
+	effect: {
+		ja: "[水]エネルギーがついている自分のポケモン全員のHPを、それぞれ「50」回復する。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560139,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/SM/SM4p/107.ts
+++ b/data-asia/SM/SM4p/107.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "マオ",
+	},
+
+	illustrator: "Ken Sugimori",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の山札から好きなカードを2枚選ぶ。残りの山札を切り、選んだカードを好きな順番にして、山札の上にもどす。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560140,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/SM/SM4p/108.ts
+++ b/data-asia/SM/SM4p/108.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "リーリエ",
+	},
+
+	illustrator: "Sanosuke Sakuma",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の手札が6枚になるように、山札を引く。最初の自分の番に使ったなら、8枚になるように引く。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560141,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/SM/SM4p/109.ts
+++ b/data-asia/SM/SM4p/109.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ルザミーネ",
+	},
+
+	illustrator: "take",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分のトラッシュにあるサポートとスタジアムを合計2枚、相手に見せてから、手札に加える。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560142,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/SM/SM4p/110.ts
+++ b/data-asia/SM/SM4p/110.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "エーテルパラダイス保護区",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Trainer",
+
+	effect: {
+		ja: "おたがいの[草]または[雷]タイプのたねポケモンが、相手のポケモンから受けるワザのダメージは「-30」される。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560143,
+			},
+		},
+	],
+
+	trainerType: "Stadium",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/SM/SM4p/111.ts
+++ b/data-asia/SM/SM4p/111.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "月輪の祭壇",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Trainer",
+
+	effect: {
+		ja: "[超]または[悪]エネルギーがついているおたがいのポケモン全員のにげるためのエネルギーは、それぞれ2個ぶん少なくなる。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560144,
+			},
+		},
+	],
+
+	trainerType: "Stadium",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/SM/SM4p/112.ts
+++ b/data-asia/SM/SM4p/112.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "せせらぎの丘",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Trainer",
+
+	effect: {
+		ja: "おたがいのプレイヤーは、自分の番ごとに1回、自分の山札にある[水]または[闘]タイプのたねポケモンを1枚、ベンチに出してよい。その場合、山札を切る。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560145,
+			},
+		},
+	],
+
+	trainerType: "Stadium",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/SM/SM4p/113.ts
+++ b/data-asia/SM/SM4p/113.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "日輪の祭壇",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Trainer",
+
+	effect: {
+		ja: "おたがいの場の[炎]ポケモンと[鋼]ポケモン全員の弱点は、すべてなくなる。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560146,
+			},
+		},
+	],
+
+	trainerType: "Stadium",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/SM/SM4p/114.ts
+++ b/data-asia/SM/SM4p/114.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ダブル無色エネルギー",
+	},
+
+	illustrator: "",
+	category: "Energy",
+	energyType: "Special",
+
+	effect: {
+		ja: "このカードは、[無]エネルギー2個ぶんとしてはたらく。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560147,
+			},
+		},
+	],
+
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/SM/SM4p/115.ts
+++ b/data-asia/SM/SM4p/115.ts
@@ -1,0 +1,63 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "フェローチェGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 170,
+	types: ["Grass"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ファストレイド" },
+			damage: 30,
+			cost: ["Grass"],
+			effect: {
+				ja: "このワザは、先攻プレイヤーの最初の番でも使える。",
+			},
+		},
+		{
+			name: { ja: "クルーエルスパイク" },
+			damage: 60,
+			cost: ["Grass", "Grass"],
+			effect: {
+				ja: "相手のバトルポケモンをこんらんにする。",
+			},
+		},
+		{
+			name: { ja: "ビューティーGX" },
+			damage: "50×",
+			cost: ["Grass", "Grass"],
+			effect: {
+				ja: "相手がすでにとったサイドの枚数x50ダメージ。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 560148,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Ultra Rare",
+	dexId: [795],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM4p/116.ts
+++ b/data-asia/SM/SM4p/116.ts
@@ -1,0 +1,64 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "デンジュモクGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 180,
+	types: ["Lightning"],
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "フラッシュヘッド" },
+			effect: {
+				ja: "このポケモンは、特殊エネルギーがついている相手のポケモンから、ワザのダメージを受けない。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ランブルワイヤー" },
+			damage: 100,
+			cost: ["Lightning", "Lightning", "Colorless"],
+			effect: {
+				ja: "相手の山札を上から1枚トラッシュする。",
+			},
+		},
+		{
+			name: { ja: "ライトニングGX" },
+			cost: ["Lightning"],
+			effect: {
+				ja: "相手の手札を見て、その中にあるカードを1枚、ウラにして相手のサイドとして置く。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Metal", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 560149,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Ultra Rare",
+	dexId: [796],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM4p/117.ts
+++ b/data-asia/SM/SM4p/117.ts
@@ -1,0 +1,60 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "テッカグヤGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 200,
+	types: ["Metal"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ロケットフォール" },
+			damage: "30+",
+			cost: ["Metal", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンのにげるためのエネルギーの数x30ダメージ追加。",
+			},
+		},
+		{
+			name: { ja: "ムーンプレス" },
+			damage: 130,
+			cost: ["Metal", "Colorless", "Colorless", "Colorless"],
+		},
+		{
+			name: { ja: "ブラスターGX" },
+			damage: 180,
+			cost: ["Metal", "Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "自分のサイドをすべてオモテにする。（対戦が終わるまで、そのサイドはオモテのまま。）［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 560150,
+			},
+		},
+	],
+
+	retreat: 4,
+	rarity: "Ultra Rare",
+	dexId: [797],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM4p/118.ts
+++ b/data-asia/SM/SM4p/118.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "スイレン",
+	},
+
+	illustrator: "Kanako Eo",
+	category: "Trainer",
+
+	effect: {
+		ja: "[水]エネルギーがついている自分のポケモン全員のHPを、それぞれ「50」回復する。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 560151,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	rarity: "Ultra Rare",
+};
+
+export default card;

--- a/data-asia/SM/SM4p/119.ts
+++ b/data-asia/SM/SM4p/119.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "リーリエ",
+	},
+
+	illustrator: "Naoki Saito",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の手札が6枚になるように、山札を引く。最初の自分の番に使ったなら、8枚になるように引く。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 560152,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	rarity: "Ultra Rare",
+};
+
+export default card;

--- a/data-asia/SM/SM4p/120.ts
+++ b/data-asia/SM/SM4p/120.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ルザミーネ",
+	},
+
+	illustrator: "You Iribi",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分のトラッシュにあるサポートとスタジアムを合計2枚、相手に見せてから、手札に加える。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 560153,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	rarity: "Ultra Rare",
+};
+
+export default card;

--- a/data-asia/SM/SM4p/121.ts
+++ b/data-asia/SM/SM4p/121.ts
@@ -1,0 +1,63 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "フェローチェGX",
+	},
+
+	illustrator: "",
+	category: "Pokemon",
+	hp: 170,
+	types: ["Grass"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ファストレイド" },
+			damage: 30,
+			cost: ["Grass"],
+			effect: {
+				ja: "このワザは、先攻プレイヤーの最初の番でも使える。",
+			},
+		},
+		{
+			name: { ja: "クルーエルスパイク" },
+			damage: 60,
+			cost: ["Grass", "Grass"],
+			effect: {
+				ja: "相手のバトルポケモンをこんらんにする。",
+			},
+		},
+		{
+			name: { ja: "ビューティーGX" },
+			damage: "50×",
+			cost: ["Grass", "Grass"],
+			effect: {
+				ja: "相手がすでにとったサイドの枚数x50ダメージ。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 560154,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Hyper rare",
+	dexId: [795],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM4p/122.ts
+++ b/data-asia/SM/SM4p/122.ts
@@ -1,0 +1,64 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "デンジュモクGX",
+	},
+
+	illustrator: "",
+	category: "Pokemon",
+	hp: 180,
+	types: ["Lightning"],
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "フラッシュヘッド" },
+			effect: {
+				ja: "このポケモンは、特殊エネルギーがついている相手のポケモンから、ワザのダメージを受けない。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ランブルワイヤー" },
+			damage: 100,
+			cost: ["Lightning", "Lightning", "Colorless"],
+			effect: {
+				ja: "相手の山札を上から1枚トラッシュする。",
+			},
+		},
+		{
+			name: { ja: "ライトニングGX" },
+			cost: ["Lightning"],
+			effect: {
+				ja: "相手の手札を見て、その中にあるカードを1枚、ウラにして相手のサイドとして置く。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Metal", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 560155,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Hyper rare",
+	dexId: [796],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM4p/123.ts
+++ b/data-asia/SM/SM4p/123.ts
@@ -1,0 +1,60 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "テッカグヤGX",
+	},
+
+	illustrator: "",
+	category: "Pokemon",
+	hp: 200,
+	types: ["Metal"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ロケットフォール" },
+			damage: "30+",
+			cost: ["Metal", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンのにげるためのエネルギーの数x30ダメージ追加。",
+			},
+		},
+		{
+			name: { ja: "ムーンプレス" },
+			damage: 130,
+			cost: ["Metal", "Colorless", "Colorless", "Colorless"],
+		},
+		{
+			name: { ja: "ブラスターGX" },
+			damage: 180,
+			cost: ["Metal", "Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "自分のサイドをすべてオモテにする。（対戦が終わるまで、そのサイドはオモテのまま。）［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 560156,
+			},
+		},
+	],
+
+	retreat: 4,
+	rarity: "Hyper rare",
+	dexId: [797],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM4p/124.ts
+++ b/data-asia/SM/SM4p/124.ts
@@ -1,0 +1,68 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ルナアーラGX",
+	},
+
+	illustrator: "",
+	category: "Pokemon",
+	hp: 250,
+	types: ["Psychic"],
+
+	stage: "Stage2",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "サイコトランス" },
+			effect: {
+				ja: "自分の番に何回でも使える。自分の場のポケモンについている[超]エネルギーを1個、自分の別のポケモンにつけ替える。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "シャドーレイ" },
+			damage: 120,
+			cost: ["Psychic", "Psychic", "Psychic", "Psychic"],
+			effect: {
+				ja: "次の相手の番、このワザを受けたポケモンのHPは、回復しない。",
+			},
+		},
+		{
+			name: { ja: "ルナフォールGX" },
+			cost: ["Psychic", "Psychic", "Psychic"],
+			effect: {
+				ja: "相手のたねポケモン（「ポケモンGX」をのぞく）を1匹、きぜつさせる。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 560157,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "コスモウム",
+	},
+
+	retreat: 2,
+	rarity: "Secret Rare",
+	dexId: [792],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM4p/125.ts
+++ b/data-asia/SM/SM4p/125.ts
@@ -1,0 +1,68 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM4p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ソルガレオGX",
+	},
+
+	illustrator: "",
+	category: "Pokemon",
+	hp: 250,
+	types: ["Metal"],
+
+	stage: "Stage2",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ウルトラロード" },
+			effect: {
+				ja: "自分の番に1回使える。自分のバトルポケモンをベンチポケモンと入れ替える。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "メテオドライブ" },
+			damage: 230,
+			cost: ["Metal", "Metal", "Colorless"],
+			effect: {
+				ja: "このポケモンについているエネルギーを、すべてトラッシュする。",
+			},
+		},
+		{
+			name: { ja: "ソルバーストGX" },
+			cost: ["Metal"],
+			effect: {
+				ja: "自分の山札にあるエネルギーを5枚まで、自分のポケモンに好きなようにつける。そして山札を切る。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 560158,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "コスモウム",
+	},
+
+	retreat: 3,
+	rarity: "Secret Rare",
+	dexId: [791],
+
+	suffix: "GX",
+};
+
+export default card;


### PR DESCRIPTION
## What

Adds the complete Japanese set **SM4p GXバトルブースト (GX Battle Boost)**, released 2017-10-20:

- `data-asia/SM/SM4p.ts` — set definition (114 official cards)
- `data-asia/SM/SM4p/001.ts` … `125.ts` — all 125 cards (114 regular + 11 secret rares: 6 SR, 3 UR, 2 Secret Rare)

## Data sources

- **pokemon-card.com** (official database): Japanese names, flavor texts, National Dex numbers, official card count
- **limitlesstcg.com**: full Japanese card text, stages, weaknesses/resistances/retreat, rarities, illustrators, attack costs
- **Cardmarket**: product IDs as `thirdParty.cardmarket` on the variant objects (560034–560158; tcgplayer IDs not available to me)

## Notes

- Follows the file format and conventions of the M-era sets (#1728)
- No `regulationMark` (the set predates regulation marks); resistances are `-20` per the era
- All 125 files type-check against `interfaces.d.ts` (`tsc --noEmit`)
