### PR TITLE
(data) Add Japanese SM set SM5M Ultra Moon

### DIFF
--- a/data-asia/SM/SM5M/001.ts
+++ b/data-asia/SM/SM5M/001.ts
@@ -1,0 +1,49 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM5M";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アローラサンド",
+	},
+
+	illustrator: "Shin Nagasawa",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Water"],
+
+	description: {
+		ja: "氷の 上で サンドを 滑らせ その距離を 競う。 古来から 続く アローラの祭りの ひとつ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "みだれひっかき" },
+			damage: "10×",
+			cost: [],
+			effect: {
+				ja: "コインを3回投げ、オモテの数x10ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559814,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [27],
+};
+
+export default card;

--- a/data-asia/SM/SM5M/002.ts
+++ b/data-asia/SM/SM5M/002.ts
@@ -1,0 +1,58 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM5M";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アローラサンドパン",
+	},
+
+	illustrator: "Anesaki Dynamic",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Water"],
+
+	description: {
+		ja: "鋼の針を 氷が おおう。 刺さると 深い 傷と 一緒に 凍傷にも なってしまうぞ。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "トゲのよろい" },
+			damage: 30,
+			cost: [],
+			effect: {
+				ja: "次の相手の番、このポケモンがワザのダメージを受けたとき、ワザを使ったポケモンにダメカンを6個のせる。",
+			},
+		},
+		{
+			name: { ja: "こおりのいぶき" },
+			damage: 90,
+			cost: ["Water", "Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559815,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "アローラサンド",
+	},
+
+	retreat: 1,
+	rarity: "Uncommon",
+	dexId: [28],
+};
+
+export default card;

--- a/data-asia/SM/SM5M/003.ts
+++ b/data-asia/SM/SM5M/003.ts
@@ -1,0 +1,48 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM5M";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ポッチャマ",
+	},
+
+	illustrator: "Ken Sugimori",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Water"],
+
+	description: {
+		ja: "プライドが 高く 人から 食べ物を もらう ことを 嫌う。 長い 産毛が 寒さを 防ぐ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "みずとばし" },
+			cost: ["Water"],
+			effect: {
+				ja: "相手のポケモン1匹に、20ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559816,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [393],
+};
+
+export default card;

--- a/data-asia/SM/SM5M/004.ts
+++ b/data-asia/SM/SM5M/004.ts
@@ -1,0 +1,51 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM5M";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ポッチャマ",
+	},
+
+	illustrator: "Shibuzoh.",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Water"],
+
+	description: {
+		ja: "プライドが 高く 人から 食べ物を もらう ことを 嫌う。 長い 産毛が 寒さを 防ぐ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "つつく" },
+			damage: 10,
+			cost: ["Colorless"],
+		},
+		{
+			name: { ja: "スプラッシュ" },
+			damage: 20,
+			cost: ["Water", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559817,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [393],
+};
+
+export default card;

--- a/data-asia/SM/SM5M/005.ts
+++ b/data-asia/SM/SM5M/005.ts
@@ -1,0 +1,58 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM5M";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ポッタイシ",
+	},
+
+	illustrator: "Mizue",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Water"],
+
+	description: {
+		ja: "仲間を 作らずに 暮らす。 翼の 強烈な 一撃は 大木を 真っ二つに へし折る。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "バブルこうせん" },
+			damage: 20,
+			cost: ["Water"],
+			effect: {
+				ja: "コインを1回投げオモテなら、相手のバトルポケモンをマヒにする。",
+			},
+		},
+		{
+			name: { ja: "スプラッシュ" },
+			damage: 40,
+			cost: ["Water", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559818,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ポッチャマ",
+	},
+
+	retreat: 2,
+	rarity: "Common",
+	dexId: [394],
+};
+
+export default card;

--- a/data-asia/SM/SM5M/006.ts
+++ b/data-asia/SM/SM5M/006.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM5M";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "エンペルト",
+	},
+
+	illustrator: "nagimiso",
+	category: "Pokemon",
+	hp: 160,
+	types: ["Water"],
+
+	description: {
+		ja: "クチバシから 伸びている ３本の ツノは 強さの 象徴。 リーダーが 一番 大きい。",
+	},
+
+	stage: "Stage2",
+
+	attacks: [
+		{
+			name: { ja: "トータルコマンド" },
+			damage: "20×",
+			cost: ["Water", "Colorless"],
+			effect: {
+				ja: "おたがいのベンチポケモンの数x20ダメージ。",
+			},
+		},
+		{
+			name: { ja: "うずしお" },
+			damage: 90,
+			cost: ["Water", "Water", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンについているエネルギーを、1個トラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 559819,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ポッタイシ",
+	},
+
+	retreat: 2,
+	rarity: "Rare",
+	dexId: [395],
+};
+
+export default card;

--- a/data-asia/SM/SM5M/007.ts
+++ b/data-asia/SM/SM5M/007.ts
@@ -1,0 +1,46 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM5M";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ブイゼル",
+	},
+
+	illustrator: "so-taro",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Water"],
+
+	description: {
+		ja: "首の 浮き袋を ふくらませ 水面から 顔を だして 辺りの 様子を うかがっている。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "みずでっぽう" },
+			damage: 30,
+			cost: ["Water", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559820,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [418],
+};
+
+export default card;

--- a/data-asia/SM/SM5M/008.ts
+++ b/data-asia/SM/SM5M/008.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM5M";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "フローゼル",
+	},
+
+	illustrator: "Naoyo Kimura",
+	category: "Pokemon",
+	hp: 100,
+	types: ["Water"],
+
+	description: {
+		ja: "水中の 獲物を 追いかける うちに 浮き袋が 発達した。 ゴムボートのように 人を 乗せる。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "こうそくいどう" },
+			damage: 30,
+			cost: ["Water"],
+			effect: {
+				ja: "コインを1回投げオモテなら、次の相手の番、このポケモンはワザのダメージや効果を受けない。",
+			},
+		},
+		{
+			name: { ja: "アクアブラスト" },
+			damage: 80,
+			cost: ["Water", "Colorless"],
+			effect: {
+				ja: "このポケモンについている[水]エネルギーを、1個トラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559821,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ブイゼル",
+	},
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [419],
+};
+
+export default card;

--- a/data-asia/SM/SM5M/009.ts
+++ b/data-asia/SM/SM5M/009.ts
@@ -1,0 +1,49 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM5M";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ユキカブリ",
+	},
+
+	illustrator: "match",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Water"],
+
+	description: {
+		ja: "春になると アイスキャンディーの ような 食感の 木の実が お腹の まわりに 生る。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "こおりのつぶて" },
+			damage: "20+",
+			cost: ["Water", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンが[闘]ポケモンなら、40ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559822,
+			},
+		},
+	],
+
+	retreat: 3,
+	rarity: "Common",
+	dexId: [459],
+};
+
+export default card;

--- a/data-asia/SM/SM5M/010.ts
+++ b/data-asia/SM/SM5M/010.ts
@@ -1,0 +1,63 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM5M";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ユキノオー",
+	},
+
+	illustrator: "Masakazu Fukuda",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Water"],
+
+	description: {
+		ja: "万年雪が 積もる 山脈で 静かに 暮らす。 ブリザードを 発生させて 姿を 隠す。",
+	},
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "じゅひょうのめぐみ" },
+			effect: {
+				ja: "自分の番に、このカードを手札から出して進化させたとき、1回使える。自分のトラッシュにある[水]エネルギーを1枚、自分のポケモンにつける。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ヒプノハンマー" },
+			damage: 80,
+			cost: ["Water", "Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをねむりにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559823,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ユキカブリ",
+	},
+
+	retreat: 3,
+	rarity: "Uncommon",
+	dexId: [460],
+};
+
+export default card;

--- a/data-asia/SM/SM5M/011.ts
+++ b/data-asia/SM/SM5M/011.ts
@@ -1,0 +1,69 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM5M";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "グレイシアGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 200,
+	types: ["Water"],
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "いてつくひとみ" },
+			effect: {
+				ja: "このポケモンがバトル場にいるかぎり、相手の場・手札・トラッシュにある「ポケモンGX・EX」の特性（「いてつくひとみ」をのぞく）は、すべてなくなる。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "フロストバレット" },
+			damage: 90,
+			cost: ["Water", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のベンチポケモン1匹にも、30ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+			},
+		},
+		{
+			name: { ja: "ポーラースピアGX" },
+			damage: "50×",
+			cost: ["Water", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンにのっているダメカンの数x50ダメージ。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 559824,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "イーブイ",
+	},
+
+	retreat: 2,
+	rarity: "Double rare",
+	dexId: [471],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM5M/012.ts
+++ b/data-asia/SM/SM5M/012.ts
@@ -1,0 +1,58 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM5M";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ウォッシュロトム",
+	},
+
+	illustrator: "Shigenori Negishi",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Water"],
+
+	description: {
+		ja: "プラズマで できた 体を 持つ。 電化製品に 潜りこみ 悪さを することで 知られている。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ロトモーター" },
+			effect: {
+				ja: "自分のトラッシュに「ポケモンのどうぐ」が9枚以上あるなら、このポケモンが使うワザに必要なエネルギーは、すべてなくなる。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ウォッシュアロー" },
+			cost: ["Water", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のベンチポケモン1匹に、50ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559825,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Uncommon",
+	dexId: [479],
+};
+
+export default card;

--- a/data-asia/SM/SM5M/013.ts
+++ b/data-asia/SM/SM5M/013.ts
@@ -1,0 +1,59 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM5M";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "フロストロトム",
+	},
+
+	illustrator: "MAHOU",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Water"],
+
+	description: {
+		ja: "プラズマで できた 体を 持つ。 電化製品に 潜りこみ 悪さを することで 知られている。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ロトモーター" },
+			effect: {
+				ja: "自分のトラッシュに「ポケモンのどうぐ」が9枚以上あるなら、このポケモンが使うワザに必要なエネルギーは、すべてなくなる。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "フロストクラッシュ" },
+			damage: "10+",
+			cost: ["Water", "Colorless"],
+			effect: {
+				ja: "相手の場のポケモンについているエネルギーの数x20ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559826,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Uncommon",
+	dexId: [479],
+};
+
+export default card;

--- a/data-asia/SM/SM5M/014.ts
+++ b/data-asia/SM/SM5M/014.ts
@@ -1,0 +1,56 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM5M";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "マナフィ",
+	},
+
+	illustrator: "kawayoo",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Water"],
+
+	description: {
+		ja: "どんな ポケモンとでも 心を 通い合わせる ことが できる 不思議な 能力を 持っている。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "しんそうかいりゅう" },
+			cost: ["Water"],
+			effect: {
+				ja: "自分のトラッシュにある[水]エネルギーを5枚、相手に見せてから、山札にもどして切る。",
+			},
+		},
+		{
+			name: { ja: "みずのはどう" },
+			damage: 20,
+			cost: ["Water"],
+			effect: {
+				ja: "相手のバトルポケモンをねむりにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559827,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [490],
+};
+
+export default card;

--- a/data-asia/SM/SM5M/015.ts
+++ b/data-asia/SM/SM5M/015.ts
@@ -1,0 +1,54 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM5M";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "エレブー",
+	},
+
+	illustrator: "Kouki Saitou",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Lightning"],
+
+	description: {
+		ja: "餌で 喰う 電気量 よりも 身体から 漏れる 電気量の ほうが 圧倒的に 多い。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "けたぐり" },
+			damage: 30,
+			cost: ["Lightning", "Colorless"],
+		},
+		{
+			name: { ja: "かみなり" },
+			damage: 90,
+			cost: ["Lightning", "Lightning", "Colorless"],
+			effect: {
+				ja: "このポケモンにも30ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Metal", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559828,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Common",
+	dexId: [125],
+};
+
+export default card;

--- a/data-asia/SM/SM5M/016.ts
+++ b/data-asia/SM/SM5M/016.ts
@@ -1,0 +1,58 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM5M";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "エレキブル",
+	},
+
+	illustrator: "Anesaki Dynamic",
+	category: "Pokemon",
+	hp: 140,
+	types: ["Lightning"],
+
+	description: {
+		ja: "興奮すると 胸を 打ち鳴らす。 そのたびに 電気火花が 散り 雷鳴が あたりに 響き渡る。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "スチールショート" },
+			damage: 60,
+			cost: ["Lightning", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンが[鋼]ポケモンなら、相手のバトルポケモンをマヒにする。",
+			},
+		},
+		{
+			name: { ja: "ボルトナックル" },
+			damage: 130,
+			cost: ["Lightning", "Lightning", "Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Metal", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559829,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "エレブー",
+	},
+
+	retreat: 4,
+	rarity: "Uncommon",
+	dexId: [466],
+};
+
+export default card;

--- a/data-asia/SM/SM5M/017.ts
+++ b/data-asia/SM/SM5M/017.ts
@@ -1,0 +1,56 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM5M";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "コリンク",
+	},
+
+	illustrator: "Shibuzoh.",
+	category: "Pokemon",
+	hp: 50,
+	types: ["Lightning"],
+
+	description: {
+		ja: "危険を 感じると 全身の 体毛が 光る。 相手が 目を くらませている あいだに 逃げる。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ぬけがけしんか" },
+			effect: {
+				ja: "このポケモンは、後攻プレイヤーの最初の番なら、出したばかりでも進化できる。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "バチバチ" },
+			damage: 10,
+			cost: ["Lightning"],
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Metal", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559830,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [403],
+};
+
+export default card;

--- a/data-asia/SM/SM5M/018.ts
+++ b/data-asia/SM/SM5M/018.ts
@@ -1,0 +1,48 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM5M";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "コリンク",
+	},
+
+	illustrator: "Ken Sugimori",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Lightning"],
+
+	description: {
+		ja: "危険を 感じると 全身の 体毛が 光る。 相手が 目を くらませている あいだに 逃げる。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "じゅうでん" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札にある[雷]エネルギーを1枚、このポケモンにつける。そして山札を切る。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Metal", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559831,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [403],
+};
+
+export default card;

--- a/data-asia/SM/SM5M/019.ts
+++ b/data-asia/SM/SM5M/019.ts
@@ -1,0 +1,53 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM5M";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ルクシオ",
+	},
+
+	illustrator: "tetsuya koizumi",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Lightning"],
+
+	description: {
+		ja: "鋭い ツメの 先には 強い 電気が 流れており ほんの少し かするだけで 相手を気絶させる。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "でんじしょうがい" },
+			damage: 30,
+			cost: ["Colorless"],
+			effect: {
+				ja: "次の相手の番、相手は手札からグッズを出して使えない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Metal", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559832,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "コリンク",
+	},
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [404],
+};
+
+export default card;

--- a/data-asia/SM/SM5M/020.ts
+++ b/data-asia/SM/SM5M/020.ts
@@ -1,0 +1,62 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM5M";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "レントラー",
+	},
+
+	illustrator: "Akira Komayama",
+	category: "Pokemon",
+	hp: 150,
+	types: ["Lightning"],
+
+	description: {
+		ja: "レントラーの 透視能力は 危険な ものを 発見するとき とても 役に立つのだ。",
+	},
+
+	stage: "Stage2",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "いかくのキバ" },
+			effect: {
+				ja: "このポケモンがバトル場にいるかぎり、相手のバトルポケモンが使うワザのダメージは、すべて「-30」される。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ボルテージアロー" },
+			cost: ["Lightning", "Lightning", "Colorless"],
+			effect: {
+				ja: "このポケモンについている[雷]エネルギーをすべてトラッシュし、相手のポケモン1匹に、150ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Metal", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 559833,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ルクシオ",
+	},
+
+	retreat: 0,
+	rarity: "Rare",
+	dexId: [405],
+};
+
+export default card;

--- a/data-asia/SM/SM5M/021.ts
+++ b/data-asia/SM/SM5M/021.ts
@@ -1,0 +1,55 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM5M";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "パチリス",
+	},
+
+	illustrator: "OOYAMA",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Lightning"],
+
+	description: {
+		ja: "たまった 電気を 分け与えようと ほほ袋を こすり合わせる パチリスを 見かけることも ある。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "すりすりはつでん" },
+			cost: ["Lightning"],
+			effect: {
+				ja: "自分のベンチにいるワザ「ほっぺすりすり」を持つポケモン全員に、山札にある[雷]エネルギーを1枚ずつつける。そして山札を切る。",
+			},
+		},
+		{
+			name: { ja: "ほっぺすりすり" },
+			cost: ["Lightning"],
+			effect: {
+				ja: "コインを1回投げオモテなら、相手のバトルポケモンをマヒにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Metal", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559834,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [417],
+};
+
+export default card;

--- a/data-asia/SM/SM5M/022.ts
+++ b/data-asia/SM/SM5M/022.ts
@@ -1,0 +1,59 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM5M";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ロトム",
+	},
+
+	illustrator: "Naoyo Kimura",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Lightning"],
+
+	description: {
+		ja: "プラズマで できた 体を 持つ。 電化製品に 潜りこみ 悪さを することで 知られている。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ロトモーター" },
+			effect: {
+				ja: "自分のトラッシュに「ポケモンのどうぐ」が9枚以上あるなら、このポケモンが使うワザに必要なエネルギーは、すべてなくなる。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "プラズマスラッシュ" },
+			damage: 120,
+			cost: ["Lightning", "Lightning", "Lightning"],
+			effect: {
+				ja: "次の自分の番、このポケモンはワザが使えない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Metal", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559835,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Uncommon",
+	dexId: [479],
+};
+
+export default card;

--- a/data-asia/SM/SM5M/023.ts
+++ b/data-asia/SM/SM5M/023.ts
@@ -1,0 +1,53 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM5M";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "フワンテ",
+	},
+
+	illustrator: "Asako Ito",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Psychic"],
+
+	description: {
+		ja: "なにかの 拍子で 身体が 割れると 叫びのような 音と ともに 魂が あふれだす。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ぶきみなかぜ" },
+			cost: ["Psychic"],
+			effect: {
+				ja: "相手のバトルポケモンをこんらんにする。",
+			},
+		},
+		{
+			name: { ja: "ぶらさがる" },
+			damage: 10,
+			cost: ["Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559836,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [425],
+};
+
+export default card;

--- a/data-asia/SM/SM5M/024.ts
+++ b/data-asia/SM/SM5M/024.ts
@@ -1,0 +1,60 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM5M";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "フワライド",
+	},
+
+	illustrator: "Yumi",
+	category: "Pokemon",
+	hp: 110,
+	types: ["Psychic"],
+
+	description: {
+		ja: "夕暮れに 飛ぶ フワライドの 大群は じっと 観察して いても いつのまにか 消えている。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "ダメージはこび" },
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "自分の場のポケモン全員にのっているダメカンをそれぞれ4個、相手のバトルポケモンにのせ替える。",
+			},
+		},
+		{
+			name: { ja: "ウィールウインド" },
+			damage: 80,
+			cost: ["Psychic", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをベンチポケモンと入れ替える。［バトル場に出すポケモンは相手が選ぶ。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559837,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "フワンテ",
+	},
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [426],
+};
+
+export default card;

--- a/data-asia/SM/SM5M/025.ts
+++ b/data-asia/SM/SM5M/025.ts
@@ -1,0 +1,56 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM5M";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ミカルゲ",
+	},
+
+	illustrator: "Shin Nagasawa",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Psychic"],
+
+	description: {
+		ja: "５００年前に 悪さをしたため 要石の ひび割れに 体を つなぎとめられてしまった。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "しろなきせかい" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分のトラッシュにあるサポートを2枚、相手に見せてから、手札に加える。",
+			},
+		},
+		{
+			name: { ja: "せんりつ" },
+			damage: 10,
+			cost: ["Colorless"],
+			effect: {
+				ja: "次の相手の番、このワザを受けたたねポケモンは、ワザが使えない。",
+			},
+		},
+	],
+
+	weaknesses: [],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559838,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [442],
+};
+
+export default card;

--- a/data-asia/SM/SM5M/026.ts
+++ b/data-asia/SM/SM5M/026.ts
@@ -1,0 +1,53 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM5M";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "スコルピ",
+	},
+
+	illustrator: "Misa Tsutsui",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Psychic"],
+
+	description: {
+		ja: "砂の 中に 隠れて 獲物を 待ち伏せする。 尻尾の ツメから 毒を 出して 獲物を しとめる。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "つめとぎ" },
+			cost: ["Psychic"],
+			effect: {
+				ja: "次の自分の番、このポケモンの「つきさす」のダメージは「90」になる。",
+			},
+		},
+		{
+			name: { ja: "つきさす" },
+			damage: 30,
+			cost: ["Psychic", "Psychic"],
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559839,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Common",
+	dexId: [451],
+};
+
+export default card;

--- a/data-asia/SM/SM5M/027.ts
+++ b/data-asia/SM/SM5M/027.ts
@@ -1,0 +1,53 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM5M";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ドラピオン",
+	},
+
+	illustrator: "Studio Bora Inc.",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Psychic"],
+
+	description: {
+		ja: "両腕の ツメは 自動車を スクラップにする 破壊力。 ツメの 先から 毒を 出す。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "キラースティンガー" },
+			damage: 100,
+			cost: ["Psychic", "Psychic", "Psychic", "Psychic"],
+			effect: {
+				ja: "相手のバトルポケモンをどくとマヒにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559840,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "スコルピ",
+	},
+
+	retreat: 3,
+	rarity: "Uncommon",
+	dexId: [452],
+};
+
+export default card;

--- a/data-asia/SM/SM5M/028.ts
+++ b/data-asia/SM/SM5M/028.ts
@@ -1,0 +1,49 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM5M";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "グレッグル",
+	},
+
+	illustrator: "SATOSHI NAKAI",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Psychic"],
+
+	description: {
+		ja: "毒袋を ふくらませて 鳴らし 辺りに 不気味な 音を 響かせ 相手が ひるむと どくづきをする。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "いばる" },
+			damage: 10,
+			cost: ["Psychic"],
+			effect: {
+				ja: "コインを1回投げオモテなら、相手のバトルポケモンについているエネルギーを、1個トラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559841,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [453],
+};
+
+export default card;

--- a/data-asia/SM/SM5M/029.ts
+++ b/data-asia/SM/SM5M/029.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM5M";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ドクロッグ",
+	},
+
+	illustrator: "Hasuno",
+	category: "Pokemon",
+	hp: 100,
+	types: ["Psychic"],
+
+	description: {
+		ja: "こぶしの トゲからは かすり傷でも 命を 落とすほどの 猛毒を 分泌する。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "どくづき" },
+			damage: 30,
+			cost: ["Psychic"],
+			effect: {
+				ja: "相手のバトルポケモンをどくにする。",
+			},
+		},
+		{
+			name: { ja: "むねんをはらす" },
+			damage: "50+",
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "前の相手の番に、ワザのダメージで、自分の[闘]ポケモンがきぜつしていたなら、70ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559842,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "グレッグル",
+	},
+
+	retreat: 2,
+	rarity: "Uncommon",
+	dexId: [454],
+};
+
+export default card;

--- a/data-asia/SM/SM5M/030.ts
+++ b/data-asia/SM/SM5M/030.ts
@@ -1,0 +1,59 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM5M";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ギラティナ",
+	},
+
+	illustrator: "Masakazu Fukuda",
+	category: "Pokemon",
+	hp: 160,
+	types: ["Psychic"],
+
+	description: {
+		ja: "暴れ者 ゆえ 追い出されたが 破れた世界と 言われる 場所で 静かに 元の世界を 見ていた。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "カオティックスター" },
+			effect: {
+				ja: "自分の番に、このカードを手札からベンチに出したとき、1回使える。自分の手札にある[超]エネルギーを2枚、このポケモンにつける。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "クライシスダイブ" },
+			damage: 160,
+			cost: ["Psychic", "Psychic", "Psychic", "Psychic"],
+			effect: {
+				ja: "このポケモンについているエネルギーを、2個トラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 559843,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Rare Holo",
+	dexId: [487],
+};
+
+export default card;

--- a/data-asia/SM/SM5M/031.ts
+++ b/data-asia/SM/SM5M/031.ts
@@ -1,0 +1,56 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM5M";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "クレセリア",
+	},
+
+	illustrator: "chibi",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Psychic"],
+
+	description: {
+		ja: "クレセリアの 羽を 持って 寝ると 楽しい 夢が 見られると いう。 三日月の化身と 呼ばれている。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "みかづきがえし" },
+			cost: ["Psychic"],
+			effect: {
+				ja: "このポケモンについているエネルギーを、1個トラッシュする。その後、おたがいのバトルポケモンにのっているダメカンを、すべてのせ替える。",
+			},
+		},
+		{
+			name: { ja: "サイコキネシス" },
+			damage: "60+",
+			cost: ["Psychic", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンについているエネルギーの数x20ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 559844,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Rare",
+	dexId: [488],
+};
+
+export default card;

--- a/data-asia/SM/SM5M/032.ts
+++ b/data-asia/SM/SM5M/032.ts
@@ -1,0 +1,56 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM5M";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ルナアーラ",
+	},
+
+	illustrator: "Hitoshi Ariga",
+	category: "Pokemon",
+	hp: 160,
+	types: ["Psychic"],
+
+	description: {
+		ja: "別世界に 棲むと いわれる。 光を 喰らい続け 真昼も 闇夜の ように 翳らせる。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "フルムーンスター" },
+			cost: ["Psychic"],
+			effect: {
+				ja: "自分のトラッシュにある[超]エネルギーを、相手の場のポケモンの数ぶん、自分のポケモンに好きなようにつける。",
+			},
+		},
+		{
+			name: { ja: "サイコストーム" },
+			damage: "20×",
+			cost: ["Psychic", "Psychic", "Psychic", "Psychic"],
+			effect: {
+				ja: "おたがいの場のポケモンについているエネルギーの数x20ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 559845,
+			},
+		},
+	],
+
+	retreat: 3,
+	rarity: "Rare Holo",
+	dexId: [792],
+};
+
+export default card;

--- a/data-asia/SM/SM5M/033.ts
+++ b/data-asia/SM/SM5M/033.ts
@@ -1,0 +1,65 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM5M";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ネクロズマ あかつきのつばさGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 180,
+	types: ["Psychic"],
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "インベイジョン" },
+			effect: {
+				ja: "このポケモンがベンチにいるなら、自分の番に1回使える。このポケモンを自分のバトルポケモンと入れ替える。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "やみのせんこう" },
+			damage: 120,
+			cost: ["Psychic", "Psychic", "Psychic"],
+			effect: {
+				ja: "このワザのダメージは抵抗力を計算しない。",
+			},
+		},
+		{
+			name: { ja: "イクリプスムーンGX" },
+			damage: 180,
+			cost: ["Psychic", "Psychic", "Psychic"],
+			effect: {
+				ja: "このワザは、自分のサイドの残り枚数が、相手より多いときにしか使えない。次の相手の番、このポケモンはワザのダメージや効果を受けない。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 559846,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Double rare",
+	dexId: [800],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM5M/034.ts
+++ b/data-asia/SM/SM5M/034.ts
@@ -1,0 +1,51 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM5M";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ズガイドス",
+	},
+
+	illustrator: "Kouki Saitou",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Fighting"],
+
+	description: {
+		ja: "ズガイドスの 化石が 見つかる 地層では へし折れた 樹木の 化石も 一緒に 出てくるぞ。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "どつく" },
+			damage: 30,
+			cost: ["Fighting"],
+		},
+		{
+			name: { ja: "ヘッドバット" },
+			damage: 50,
+			cost: ["Fighting", "Fighting"],
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559847,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Uncommon",
+	dexId: [408],
+};
+
+export default card;

--- a/data-asia/SM/SM5M/035.ts
+++ b/data-asia/SM/SM5M/035.ts
@@ -1,0 +1,60 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM5M";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ラムパルド",
+	},
+
+	illustrator: "Yoshinobu Saito",
+	category: "Pokemon",
+	hp: 150,
+	types: ["Fighting"],
+
+	description: {
+		ja: "復元され 進化した ラムパルドが 逃げだして 頭突きで 高層ビルを 破壊したという 記録が ある。",
+	},
+
+	stage: "Stage2",
+
+	attacks: [
+		{
+			name: { ja: "クリーンヒット" },
+			damage: "60+",
+			cost: ["Fighting"],
+			effect: {
+				ja: "相手のバトルポケモンが進化ポケモンなら、60ダメージ追加。",
+			},
+		},
+		{
+			name: { ja: "ワイルドボンバー" },
+			cost: ["Fighting", "Fighting", "Fighting"],
+			effect: {
+				ja: "相手のバトルポケモンがたねポケモンなら、そのポケモンをきぜつさせる。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 559848,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ズガイドス",
+	},
+
+	retreat: 2,
+	rarity: "Rare",
+	dexId: [409],
+};
+
+export default card;

--- a/data-asia/SM/SM5M/036.ts
+++ b/data-asia/SM/SM5M/036.ts
@@ -1,0 +1,53 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM5M";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "リオル",
+	},
+
+	illustrator: "Kyoko Umemoto",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Fighting"],
+
+	description: {
+		ja: "一晩中 走っていられる タフさが あり 頑張り屋 だが まだまだ ひよっ子 なのだ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "みきり" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "コインを1回投げオモテなら、次の相手の番、このポケモンはワザのダメージや効果を受けない。",
+			},
+		},
+		{
+			name: { ja: "ジャブ" },
+			damage: 10,
+			cost: ["Fighting"],
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559849,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [447],
+};
+
+export default card;

--- a/data-asia/SM/SM5M/037.ts
+++ b/data-asia/SM/SM5M/037.ts
@@ -1,0 +1,63 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM5M";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ルカリオ",
+	},
+
+	illustrator: "Mitsuhiro Arita",
+	category: "Pokemon",
+	hp: 110,
+	types: ["Fighting"],
+
+	description: {
+		ja: "１キロ先の 生き物の 種類や 気持ちを キャッチする。 波動を 操り 群れで 獲物を 狩る。",
+	},
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "はどうよち" },
+			effect: {
+				ja: "自分の場に「ガブリアス」がいるなら、自分の番に1回使える。自分の山札にある好きなカードを1枚、手札に加える。そして山札を切る。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "スカッドジャブ" },
+			damage: 70,
+			cost: ["Fighting", "Colorless"],
+			effect: {
+				ja: "このワザのダメージは抵抗力を計算しない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 559850,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "リオル",
+	},
+
+	retreat: 1,
+	rarity: "Rare",
+	dexId: [448],
+};
+
+export default card;

--- a/data-asia/SM/SM5M/038.ts
+++ b/data-asia/SM/SM5M/038.ts
@@ -1,0 +1,49 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM5M";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヒポポタス",
+	},
+
+	illustrator: "Yumi",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Fighting"],
+
+	description: {
+		ja: "全身に 砂を まとうことで ばい菌から 体を 守る。 水に ぬれることが 苦手。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "どたんばタックル" },
+			damage: "50+",
+			cost: ["Fighting", "Colorless", "Colorless"],
+			effect: {
+				ja: "自分の山札の残り枚数が3枚以下なら、130ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559851,
+			},
+		},
+	],
+
+	retreat: 3,
+	rarity: "Common",
+	dexId: [449],
+};
+
+export default card;

--- a/data-asia/SM/SM5M/039.ts
+++ b/data-asia/SM/SM5M/039.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM5M";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "カバルドン",
+	},
+
+	illustrator: "Shigenori Negishi",
+	category: "Pokemon",
+	hp: 140,
+	types: ["Fighting"],
+
+	description: {
+		ja: "体内に ためた 砂を 体の 穴から 噴き上げて 巨大な 竜巻を 作り 攻撃する。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "すなじごく" },
+			damage: 50,
+			cost: ["Fighting", "Colorless", "Colorless"],
+			effect: {
+				ja: "次の相手の番、このワザを受けたポケモンは、にげられない。",
+			},
+		},
+		{
+			name: { ja: "さじんほう" },
+			damage: "100+",
+			cost: ["Fighting", "Fighting", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンのにげるためのエネルギーの数x10ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559852,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ヒポポタス",
+	},
+
+	retreat: 4,
+	rarity: "Uncommon",
+	dexId: [450],
+};
+
+export default card;

--- a/data-asia/SM/SM5M/040.ts
+++ b/data-asia/SM/SM5M/040.ts
@@ -1,0 +1,59 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM5M";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ナゲツケサル",
+	},
+
+	illustrator: "kawayoo",
+	category: "Pokemon",
+	hp: 110,
+	types: ["Fighting"],
+
+	description: {
+		ja: "硬い 木の実を 使い 戦う。 そのテクニックは 代々の ボスから グループの 仲間に 受け継がれる。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "パワースクラム" },
+			effect: {
+				ja: "このポケモンがベンチにいるかぎり、自分の「ナゲツケサル」が使うワザの、相手のバトル場の進化ポケモンへのダメージは「+30」される。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "いわとばし" },
+			damage: 40,
+			cost: ["Fighting", "Colorless"],
+			effect: {
+				ja: "このワザのダメージは抵抗力を計算しない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559853,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [766],
+};
+
+export default card;

--- a/data-asia/SM/SM5M/041.ts
+++ b/data-asia/SM/SM5M/041.ts
@@ -1,0 +1,48 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM5M";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "フカマル",
+	},
+
+	illustrator: "Kyoko Umemoto",
+	category: "Pokemon",
+	hp: 50,
+	types: ["Dragon"],
+
+	description: {
+		ja: "穴倉に 潜み 獲物や 敵が 横切ると 飛びだして 噛みつく。 勢い余り 歯が 欠けることも。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "かくせい" },
+			cost: ["Fighting"],
+			effect: {
+				ja: "このポケモンから進化するカードを、自分の山札から1枚選び、このポケモンにのせて進化させる。そして山札を切る。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fairy", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559854,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [443],
+};
+
+export default card;

--- a/data-asia/SM/SM5M/042.ts
+++ b/data-asia/SM/SM5M/042.ts
@@ -1,0 +1,56 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM5M";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "フカマル",
+	},
+
+	illustrator: "Ken Sugimori",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Dragon"],
+
+	description: {
+		ja: "穴倉に 潜み 獲物や 敵が 横切ると 飛びだして 噛みつく。 勢い余り 歯が 欠けることも。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "いわがくれ" },
+			effect: {
+				ja: "このポケモンに[闘]エネルギーがついているなら、このポケモンのにげるためのエネルギーは、すべてなくなる。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "かじる" },
+			damage: 20,
+			cost: ["Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fairy", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559855,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [443],
+};
+
+export default card;

--- a/data-asia/SM/SM5M/043.ts
+++ b/data-asia/SM/SM5M/043.ts
@@ -1,0 +1,57 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM5M";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ガバイト",
+	},
+
+	illustrator: "Sumiyoshi Kizuki",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Dragon"],
+
+	description: {
+		ja: "光り 輝くものが 大好き。 宝石や 捕まえた メレシーを 巣穴で じーっと 眺めている。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "かくせい" },
+			cost: ["Fighting"],
+			effect: {
+				ja: "このポケモンから進化するカードを、自分の山札から1枚選び、このポケモンにのせて進化させる。そして山札を切る。",
+			},
+		},
+		{
+			name: { ja: "きりさく" },
+			damage: 40,
+			cost: ["Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fairy", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559856,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "フカマル",
+	},
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [444],
+};
+
+export default card;

--- a/data-asia/SM/SM5M/044.ts
+++ b/data-asia/SM/SM5M/044.ts
@@ -1,0 +1,60 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM5M";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ガブリアス",
+	},
+
+	illustrator: "Megumi Mizutani",
+	category: "Pokemon",
+	hp: 150,
+	types: ["Dragon"],
+
+	description: {
+		ja: "頭に ついた ２つの 突起は センサーの 役目。 遥か 先の 獲物の 様子も わかる。",
+	},
+
+	stage: "Stage2",
+
+	attacks: [
+		{
+			name: { ja: "クイックダイブ" },
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "相手のポケモン1匹に、50ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+			},
+		},
+		{
+			name: { ja: "おうじゃのやいば" },
+			damage: "100+",
+			cost: ["Fighting", "Colorless", "Colorless"],
+			effect: {
+				ja: "この番、手札から「シロナ」を出して使っていたなら、100ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fairy", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 559857,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ガバイト",
+	},
+
+	retreat: 0,
+	rarity: "Rare",
+	dexId: [445],
+};
+
+export default card;

--- a/data-asia/SM/SM5M/045.ts
+++ b/data-asia/SM/SM5M/045.ts
@@ -1,0 +1,62 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM5M";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "パルキアGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 180,
+	types: ["Dragon"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "くうかんせいぎょ" },
+			cost: ["Water"],
+			effect: {
+				ja: "自分のベンチポケモンについているエネルギーを好きなだけ、このポケモンにつけ替える。",
+			},
+		},
+		{
+			name: { ja: "ハイドロプレッシャー" },
+			damage: "60+",
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンについている[水]エネルギーの数x20ダメージ追加。",
+			},
+		},
+		{
+			name: { ja: "ゼロバニッシュGX" },
+			damage: 150,
+			cost: ["Water", "Water", "Water", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手の場のポケモンについているエネルギーを、すべて山札にもどして切る。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fairy", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 559858,
+			},
+		},
+	],
+
+	retreat: 3,
+	rarity: "Double rare",
+	dexId: [484],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM5M/046.ts
+++ b/data-asia/SM/SM5M/046.ts
@@ -1,0 +1,46 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM5M";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "イーブイ",
+	},
+
+	illustrator: "Atsuko Nishida",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Colorless"],
+
+	description: {
+		ja: "今 現在の 調査では なんと ８種類もの ポケモンへ 進化する 可能性を 持つ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "かじる" },
+			damage: 20,
+			cost: ["Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559859,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [133],
+};
+
+export default card;

--- a/data-asia/SM/SM5M/047.ts
+++ b/data-asia/SM/SM5M/047.ts
@@ -1,0 +1,53 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM5M";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ミミロル",
+	},
+
+	illustrator: "Kagemaru Himeno",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Colorless"],
+
+	description: {
+		ja: "危険を 感じ取ると 両耳を 立てて 警戒する。 寒い 夜は 毛皮に 顔を 埋めて 眠る。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ホネぬき" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "次の相手の番、このワザを受けたポケモンがワザを使うとき、相手はコインを1回投げる。ウラならそのワザは失敗。",
+			},
+		},
+		{
+			name: { ja: "スキップ" },
+			damage: 10,
+			cost: ["Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559860,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [427],
+};
+
+export default card;

--- a/data-asia/SM/SM5M/048.ts
+++ b/data-asia/SM/SM5M/048.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM5M";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ミミロップ",
+	},
+
+	illustrator: "Kagemaru Himeno",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Colorless"],
+
+	description: {
+		ja: "耳は とても デリケートらしく 優しく 丁寧に 触らないと しなやかな 脚で けられてしまう。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "ふみふみ" },
+			damage: "40×",
+			cost: ["Colorless"],
+			effect: {
+				ja: "コインを2回投げ、オモテの数x40ダメージ。",
+			},
+		},
+		{
+			name: { ja: "ハッピーターン" },
+			damage: 60,
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "のぞむなら、このポケモンと、ついているすべてのカードを、自分の山札にもどして切る。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559861,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ミミロル",
+	},
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [428],
+};
+
+export default card;

--- a/data-asia/SM/SM5M/049.ts
+++ b/data-asia/SM/SM5M/049.ts
@@ -1,0 +1,53 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM5M";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "シェイミ",
+	},
+
+	illustrator: "kirisAki",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Colorless"],
+
+	description: {
+		ja: "グラシデアの花が 咲く 季節 感謝の 心を 届けるために 飛び立つと 言われている。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "なかまをよぶ" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札にあるたねポケモンを2枚まで、ベンチに出す。そして山札を切る。",
+			},
+		},
+		{
+			name: { ja: "かっくう" },
+			damage: 20,
+			cost: ["Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559862,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Uncommon",
+	dexId: [492],
+};
+
+export default card;

--- a/data-asia/SM/SM5M/050.ts
+++ b/data-asia/SM/SM5M/050.ts
@@ -1,0 +1,56 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM5M";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヤングース",
+	},
+
+	illustrator: "Misa Tsutsui",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Colorless"],
+
+	description: {
+		ja: "餌を 探し うろつき続ける。 日が 暮れるころには 疲れ果て 倒れ込むように その場で 眠る。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "さぐる" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "相手の手札を見る。",
+			},
+		},
+		{
+			name: { ja: "とっしん" },
+			damage: 30,
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンにも10ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559863,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [734],
+};
+
+export default card;

--- a/data-asia/SM/SM5M/051.ts
+++ b/data-asia/SM/SM5M/051.ts
@@ -1,0 +1,58 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM5M";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "デカグース",
+	},
+
+	illustrator: "nagimiso",
+	category: "Pokemon",
+	hp: 110,
+	types: ["Colorless"],
+
+	description: {
+		ja: "コラッタや ラッタが 好物なのに 昼行性のため 出会えない。 忍耐強さが 自慢の ポケモン。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "つきとめる" },
+			damage: "20+",
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "相手の手札を見て、その中にポケモンがあるなら、80ダメージ追加。",
+			},
+		},
+		{
+			name: { ja: "はりたおす" },
+			damage: 70,
+			cost: ["Colorless", "Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559864,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ヤングース",
+	},
+
+	retreat: 2,
+	rarity: "Common",
+	dexId: [735],
+};
+
+export default card;

--- a/data-asia/SM/SM5M/052.ts
+++ b/data-asia/SM/SM5M/052.ts
@@ -1,0 +1,57 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM5M";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ジジーロン",
+	},
+
+	illustrator: "Hasuno",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Colorless"],
+
+	description: {
+		ja: "人懐っこく 子どもが 大好き。 仲良しの 子どもと 遊ぶために 山奥から 町に 降りてくる。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "げきりん" },
+			damage: "20+",
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンにのっているダメカンの数x10ダメージ追加。",
+			},
+		},
+		{
+			name: { ja: "りゅうのはどう" },
+			damage: 100,
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "自分の山札を上から2枚トラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 559865,
+			},
+		},
+	],
+
+	retreat: 3,
+	rarity: "Rare",
+	dexId: [780],
+};
+
+export default card;

--- a/data-asia/SM/SM5M/053.ts
+++ b/data-asia/SM/SM5M/053.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM5M";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "おとりよせパッド",
+	},
+
+	illustrator: "Eske Yoshinob",
+	category: "Trainer",
+
+	effect: {
+		ja: "コインを1回投げオモテなら、自分の山札にあるグッズを1枚、相手に見せてから、手札に加える。そして山札を切る。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559866,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	rarity: "Common",
+};
+
+export default card;

--- a/data-asia/SM/SM5M/054.ts
+++ b/data-asia/SM/SM5M/054.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM5M";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "クラッシュハンマー",
+	},
+
+	illustrator: "Yoshinobu Saito",
+	category: "Trainer",
+
+	effect: {
+		ja: "コインを1回投げオモテなら、相手のポケモンについているエネルギーを1個選び、トラッシュする。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559868,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM5M/055.ts
+++ b/data-asia/SM/SM5M/055.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM5M";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "なぞの化石",
+	},
+
+	illustrator: "Toyste Beach",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードは、HP60の[無]タイプのたねポケモンとして、場に出すことができる。自分の番の中でなら、場に出ているこのカードをトラッシュしてよい。このカードは、にげられない。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559867,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	rarity: "Common",
+};
+
+export default card;

--- a/data-asia/SM/SM5M/056.ts
+++ b/data-asia/SM/SM5M/056.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM5M";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ハイパーボール",
+	},
+
+	illustrator: "Ryo Ueda",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードは、自分の手札を2枚トラッシュしなければ使えない。自分の山札からポケモンを1枚選び、相手に見せてから、手札に加える。そして山札を切る。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559869,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM5M/057.ts
+++ b/data-asia/SM/SM5M/057.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM5M";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ハンサムホイッスル",
+	},
+
+	illustrator: "Toyste Beach",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の山札にある「ハンサム」を2枚まで、相手に見せてから、手札に加える。そして山札を切る。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559870,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM5M/058.ts
+++ b/data-asia/SM/SM5M/058.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM5M";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ふしぎなアメ",
+	},
+
+	illustrator: "Toyste Beach",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分のたねポケモン1匹から進化する1進化の上の2進化ポケモンを、手札から1枚選び、そのたねポケモンにのせて進化させる。[最初の自分の番と、この番出したばかりのたねポケモンには使えない。]",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559871,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM5M/059.ts
+++ b/data-asia/SM/SM5M/059.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM5M";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "レスキュータンカ",
+	},
+
+	illustrator: "Yoshinobu Saito",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分のトラッシュにあるポケモンを1枚、相手に見せてから、手札に加える。または、自分のトラッシュにあるポケモンを3枚、相手に見せてから、山札にもどして切る。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559872,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM5M/060.ts
+++ b/data-asia/SM/SM5M/060.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM5M";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "エスケープボード",
+	},
+
+	illustrator: "Toyste Beach",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードをつけているポケモンは、にげるためのエネルギーが1個ぶん少なくなり、ねむりまたはマヒでも、にげられる。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559873,
+			},
+		},
+	],
+
+	trainerType: "Tool",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM5M/061.ts
+++ b/data-asia/SM/SM5M/061.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM5M";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "シロナ",
+	},
+
+	illustrator: "Ken Sugimori",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の手札をすべて山札にもどして切る。その後、山札を6枚引く。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 559874,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	rarity: "Rare",
+};
+
+export default card;

--- a/data-asia/SM/SM5M/062.ts
+++ b/data-asia/SM/SM5M/062.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM5M";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "デンジ",
+	},
+
+	illustrator: "Ken Sugimori",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の山札にあるグッズと[雷]エネルギーを1枚ずつ、相手に見せてから、手札に加える。そして山札を切る。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559875,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM5M/063.ts
+++ b/data-asia/SM/SM5M/063.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM5M";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ハンサム",
+	},
+
+	illustrator: "Ken Sugimori",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の山札を下から3枚引く。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559876,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	rarity: "Common",
+};
+
+export default card;

--- a/data-asia/SM/SM5M/064.ts
+++ b/data-asia/SM/SM5M/064.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM5M";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "マーマネ",
+	},
+
+	illustrator: "Ken Sugimori",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードは、自分の手札を2枚トラッシュしなければ使えない。自分の山札を4枚引く。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559877,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM5M/065.ts
+++ b/data-asia/SM/SM5M/065.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM5M";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "超ブーストエネルギー",
+	},
+
+	illustrator: "",
+	category: "Energy",
+	energyType: "Special",
+
+	effect: {
+		ja: "このカードは[無]エネルギー1個ぶんとしてはたらく。このカードは、2進化ポケモンについているかぎり、すべてのタイプのエネルギー1個ぶんとしてはたらき、自分の場に2進化ポケモンが3匹以上いるなら、すべてのタイプのエネルギー4個ぶんとしてはたらく。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 559878,
+			},
+		},
+	],
+
+	rarity: "Rare Holo",
+};
+
+export default card;

--- a/data-asia/SM/SM5M/066.ts
+++ b/data-asia/SM/SM5M/066.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM5M";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ユニットエネルギー雷超鋼",
+	},
+
+	illustrator: "",
+	category: "Energy",
+	energyType: "Special",
+
+	effect: {
+		ja: "このカードは、ポケモンについているかぎり、[雷][超][鋼]の3つのタイプのエネルギー1個ぶんとしてはたらく。ポケモンについていないなら、[無]エネルギー1個ぶんとしてはたらく。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559879,
+			},
+		},
+	],
+
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM5M/067.ts
+++ b/data-asia/SM/SM5M/067.ts
@@ -1,0 +1,69 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM5M";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "グレイシアGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 200,
+	types: ["Water"],
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "いてつくひとみ" },
+			effect: {
+				ja: "このポケモンがバトル場にいるかぎり、相手の場・手札・トラッシュにある「ポケモンGX・EX」の特性（「いてつくひとみ」をのぞく）は、すべてなくなる。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "フロストバレット" },
+			damage: 90,
+			cost: ["Water", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のベンチポケモン1匹にも、30ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+			},
+		},
+		{
+			name: { ja: "ポーラースピアGX" },
+			damage: "50×",
+			cost: ["Water", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンにのっているダメカンの数x50ダメージ。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 559880,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "イーブイ",
+	},
+
+	retreat: 2,
+	rarity: "Ultra Rare",
+	dexId: [471],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM5M/068.ts
+++ b/data-asia/SM/SM5M/068.ts
@@ -1,0 +1,65 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM5M";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ネクロズマ あかつきのつばさGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 180,
+	types: ["Psychic"],
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "インベイジョン" },
+			effect: {
+				ja: "このポケモンがベンチにいるなら、自分の番に1回使える。このポケモンを自分のバトルポケモンと入れ替える。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "やみのせんこう" },
+			damage: 120,
+			cost: ["Psychic", "Psychic", "Psychic"],
+			effect: {
+				ja: "このワザのダメージは抵抗力を計算しない。",
+			},
+		},
+		{
+			name: { ja: "イクリプスムーンGX" },
+			damage: 180,
+			cost: ["Psychic", "Psychic", "Psychic"],
+			effect: {
+				ja: "このワザは、自分のサイドの残り枚数が、相手より多いときにしか使えない。次の相手の番、このポケモンはワザのダメージや効果を受けない。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 559881,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Ultra Rare",
+	dexId: [800],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM5M/069.ts
+++ b/data-asia/SM/SM5M/069.ts
@@ -1,0 +1,62 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM5M";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "パルキアGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 180,
+	types: ["Dragon"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "くうかんせいぎょ" },
+			cost: ["Water"],
+			effect: {
+				ja: "自分のベンチポケモンについているエネルギーを好きなだけ、このポケモンにつけ替える。",
+			},
+		},
+		{
+			name: { ja: "ハイドロプレッシャー" },
+			damage: "60+",
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンについている[水]エネルギーの数x20ダメージ追加。",
+			},
+		},
+		{
+			name: { ja: "ゼロバニッシュGX" },
+			damage: 150,
+			cost: ["Water", "Water", "Water", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手の場のポケモンについているエネルギーを、すべて山札にもどして切る。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fairy", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 559882,
+			},
+		},
+	],
+
+	retreat: 3,
+	rarity: "Ultra Rare",
+	dexId: [484],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM5M/070.ts
+++ b/data-asia/SM/SM5M/070.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM5M";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "シロナ",
+	},
+
+	illustrator: "nagimiso",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の手札をすべて山札にもどして切る。その後、山札を6枚引く。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 559883,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	rarity: "Ultra Rare",
+};
+
+export default card;

--- a/data-asia/SM/SM5M/071.ts
+++ b/data-asia/SM/SM5M/071.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM5M";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "デンジ",
+	},
+
+	illustrator: "TOKIYA",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の山札にあるグッズと[雷]エネルギーを1枚ずつ、相手に見せてから、手札に加える。そして山札を切る。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 559884,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	rarity: "Ultra Rare",
+};
+
+export default card;

--- a/data-asia/SM/SM5M/072.ts
+++ b/data-asia/SM/SM5M/072.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM5M";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ハンサム",
+	},
+
+	illustrator: "Hitoshi Ariga",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の山札を下から3枚引く。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 559885,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	rarity: "Ultra Rare",
+};
+
+export default card;

--- a/data-asia/SM/SM5M/073.ts
+++ b/data-asia/SM/SM5M/073.ts
@@ -1,0 +1,69 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM5M";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "グレイシアGX",
+	},
+
+	illustrator: "",
+	category: "Pokemon",
+	hp: 200,
+	types: ["Water"],
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "いてつくひとみ" },
+			effect: {
+				ja: "このポケモンがバトル場にいるかぎり、相手の場・手札・トラッシュにある「ポケモンGX・EX」の特性（「いてつくひとみ」をのぞく）は、すべてなくなる。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "フロストバレット" },
+			damage: 90,
+			cost: ["Water", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のベンチポケモン1匹にも、30ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+			},
+		},
+		{
+			name: { ja: "ポーラースピアGX" },
+			damage: "50×",
+			cost: ["Water", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンにのっているダメカンの数x50ダメージ。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 559886,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "イーブイ",
+	},
+
+	retreat: 2,
+	rarity: "Hyper rare",
+	dexId: [471],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM5M/074.ts
+++ b/data-asia/SM/SM5M/074.ts
@@ -1,0 +1,65 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM5M";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ネクロズマ あかつきのつばさGX",
+	},
+
+	illustrator: "",
+	category: "Pokemon",
+	hp: 180,
+	types: ["Psychic"],
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "インベイジョン" },
+			effect: {
+				ja: "このポケモンがベンチにいるなら、自分の番に1回使える。このポケモンを自分のバトルポケモンと入れ替える。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "やみのせんこう" },
+			damage: 120,
+			cost: ["Psychic", "Psychic", "Psychic"],
+			effect: {
+				ja: "このワザのダメージは抵抗力を計算しない。",
+			},
+		},
+		{
+			name: { ja: "イクリプスムーンGX" },
+			damage: 180,
+			cost: ["Psychic", "Psychic", "Psychic"],
+			effect: {
+				ja: "このワザは、自分のサイドの残り枚数が、相手より多いときにしか使えない。次の相手の番、このポケモンはワザのダメージや効果を受けない。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 559887,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Hyper rare",
+	dexId: [800],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM5M/075.ts
+++ b/data-asia/SM/SM5M/075.ts
@@ -1,0 +1,62 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM5M";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "パルキアGX",
+	},
+
+	illustrator: "",
+	category: "Pokemon",
+	hp: 180,
+	types: ["Dragon"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "くうかんせいぎょ" },
+			cost: ["Water"],
+			effect: {
+				ja: "自分のベンチポケモンについているエネルギーを好きなだけ、このポケモンにつけ替える。",
+			},
+		},
+		{
+			name: { ja: "ハイドロプレッシャー" },
+			damage: "60+",
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンについている[水]エネルギーの数x20ダメージ追加。",
+			},
+		},
+		{
+			name: { ja: "ゼロバニッシュGX" },
+			damage: 150,
+			cost: ["Water", "Water", "Water", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手の場のポケモンについているエネルギーを、すべて山札にもどして切る。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fairy", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 559888,
+			},
+		},
+	],
+
+	retreat: 3,
+	rarity: "Hyper rare",
+	dexId: [484],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM5M/076.ts
+++ b/data-asia/SM/SM5M/076.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM5M";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "クラッシュハンマー",
+	},
+
+	illustrator: "",
+	category: "Trainer",
+
+	effect: {
+		ja: "コインを1回投げオモテなら、相手のポケモンについているエネルギーを1個選び、トラッシュする。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 559889,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	rarity: "Secret Rare",
+};
+
+export default card;

--- a/data-asia/SM/SM5M/077.ts
+++ b/data-asia/SM/SM5M/077.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM5M";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "エスケープボード",
+	},
+
+	illustrator: "",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードをつけているポケモンは、にげるためのエネルギーが1個ぶん少なくなり、ねむりまたはマヒでも、にげられる。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 559890,
+			},
+		},
+	],
+
+	trainerType: "Tool",
+	rarity: "Secret Rare",
+};
+
+export default card;

--- a/data-asia/SM/SM5M/078.ts
+++ b/data-asia/SM/SM5M/078.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM5M";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ユニットエネルギー雷超鋼",
+	},
+
+	illustrator: "",
+	category: "Energy",
+	energyType: "Special",
+
+	effect: {
+		ja: "このカードは、ポケモンについているかぎり、[雷][超][鋼]の3つのタイプのエネルギー1個ぶんとしてはたらく。ポケモンについていないなら、[無]エネルギー1個ぶんとしてはたらく。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 559891,
+			},
+		},
+	],
+
+	rarity: "Secret Rare",
+};
+
+export default card;


### PR DESCRIPTION
## What

Adds the complete Japanese set **SM5M ウルトラムーン (Ultra Moon)**, released 2017-12-08:

- `data-asia/SM/SM5M/001.ts` … `078.ts` — all 78 cards (66 regular + 12 secret rares: 6 SR, 3 UR, 3 Secret Rare)
- the set definition `data-asia/SM/SM5M.ts` already existed and is untouched

## Data sources

- **pokemon-card.com** (official database): Japanese names, flavor texts, National Dex numbers, official card count
- **limitlesstcg.com**: full Japanese card text, stages, weaknesses/resistances/retreat, rarities, illustrators, attack costs
- **Cardmarket**: product IDs as `thirdParty.cardmarket` on the variant objects (559814–559891; tcgplayer IDs not available to me)

## Notes

- Follows the file format and conventions of the M-era sets (#1728)
- No `regulationMark` (the set predates regulation marks); resistances are `-20` per the era
- All 78 files type-check against `interfaces.d.ts` (`tsc --noEmit`)
