### PR TITLE
(data) Add Japanese SM set SM5S Ultra Sun

### DIFF
--- a/data-asia/SM/SM5S/001.ts
+++ b/data-asia/SM/SM5S/001.ts
@@ -1,0 +1,49 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM5S";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヤンヤンマ",
+	},
+
+	illustrator: "Akira Komayama",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Grass"],
+
+	description: {
+		ja: "高速で 羽を 羽ばたかせると 衝撃波が 発生して まわりの 窓ガラスが 割れていく。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ばいそくいどう" },
+			damage: 20,
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "コインを1回投げオモテなら、次の相手の番、このポケモンはワザのダメージや効果を受けない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559955,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [193],
+};
+
+export default card;

--- a/data-asia/SM/SM5S/002.ts
+++ b/data-asia/SM/SM5S/002.ts
@@ -1,0 +1,58 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM5S";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "メガヤンマ",
+	},
+
+	illustrator: "SATOSHI NAKAI",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Grass"],
+
+	description: {
+		ja: "６本の 脚で 大人を 抱えて 楽々と 飛ぶ ことが できる。 尻尾の 羽で バランスを とる。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "ちょうおんぱ" },
+			damage: 30,
+			cost: ["Grass"],
+			effect: {
+				ja: "相手のバトルポケモンをこんらんにする。",
+			},
+		},
+		{
+			name: { ja: "カッターウインド" },
+			damage: 120,
+			cost: ["Colorless", "Colorless", "Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559956,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ヤンヤンマ",
+	},
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [469],
+};
+
+export default card;

--- a/data-asia/SM/SM5S/003.ts
+++ b/data-asia/SM/SM5S/003.ts
@@ -1,0 +1,49 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM5S";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ロゼリア",
+	},
+
+	illustrator: "Kyoko Umemoto",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Grass"],
+
+	description: {
+		ja: "栄養満点の わき水を 飲んだ ロゼリアは 珍しい 色の 花を 咲かせる らしい。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "はなびらのまい" },
+			damage: "30×",
+			cost: ["Grass", "Colorless"],
+			effect: {
+				ja: "コインを3回投げ、オモテの数x30ダメージ。このポケモンをこんらんにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559957,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [315],
+};
+
+export default card;

--- a/data-asia/SM/SM5S/004.ts
+++ b/data-asia/SM/SM5S/004.ts
@@ -1,0 +1,60 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM5S";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ロズレイド",
+	},
+
+	illustrator: "Mitsuhiro Arita",
+	category: "Pokemon",
+	hp: 100,
+	types: ["Grass"],
+
+	description: {
+		ja: "ダンサーのような 身のこなしで 毒の トゲが びっしりと 並んだ ムチを 操り 攻撃する。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "ごしめいどく" },
+			cost: ["Grass"],
+			effect: {
+				ja: "相手のベンチポケモンを1匹選び、バトルポケモンと入れ替える。その後、新しく出てきたポケモンをどくにする。",
+			},
+		},
+		{
+			name: { ja: "フラワーミキサー" },
+			damage: 100,
+			cost: ["Grass", "Grass", "Colorless"],
+			effect: {
+				ja: "自分の場のポケモンについている[草]エネルギーを好きなだけ選び、自分のポケモンに好きなようにつけ替える。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559958,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ロゼリア",
+	},
+
+	retreat: 1,
+	rarity: "Uncommon",
+	dexId: [407],
+};
+
+export default card;

--- a/data-asia/SM/SM5S/005.ts
+++ b/data-asia/SM/SM5S/005.ts
@@ -1,0 +1,53 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM5S";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ナエトル",
+	},
+
+	illustrator: "Ken Sugimori",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Grass"],
+
+	description: {
+		ja: "全身で 光合成を して 酸素を 作る。 のどが 渇くと 頭の 葉っぱが しおれてしまう。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "こうごうせい" },
+			cost: ["Grass"],
+			effect: {
+				ja: "自分の山札にある[草]エネルギーを1枚、自分のポケモンにつける。そして山札を切る。",
+			},
+		},
+		{
+			name: { ja: "とびだしヘッド" },
+			damage: 30,
+			cost: ["Grass", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559959,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Common",
+	dexId: [387],
+};
+
+export default card;

--- a/data-asia/SM/SM5S/006.ts
+++ b/data-asia/SM/SM5S/006.ts
@@ -1,0 +1,51 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM5S";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ナエトル",
+	},
+
+	illustrator: "OOYAMA",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Grass"],
+
+	description: {
+		ja: "全身で 光合成を して 酸素を 作る。 のどが 渇くと 頭の 葉っぱが しおれてしまう。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "たいあたり" },
+			damage: 20,
+			cost: ["Colorless", "Colorless"],
+		},
+		{
+			name: { ja: "はっぱカッター" },
+			damage: 50,
+			cost: ["Grass", "Grass", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559960,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Common",
+	dexId: [387],
+};
+
+export default card;

--- a/data-asia/SM/SM5S/007.ts
+++ b/data-asia/SM/SM5S/007.ts
@@ -1,0 +1,58 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM5S";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ハヤシガメ",
+	},
+
+	illustrator: "Shigenori Negishi",
+	category: "Pokemon",
+	hp: 110,
+	types: ["Grass"],
+
+	description: {
+		ja: "きれいな 水が わき出る 場所を 知っていて 仲間の ポケモンを 背中に 乗せて そこまで 運ぶ。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "メガドレイン" },
+			damage: 30,
+			cost: ["Grass", "Colorless"],
+			effect: {
+				ja: "このポケモンのHPを「30」回復する。",
+			},
+		},
+		{
+			name: { ja: "はっぱカッター" },
+			damage: 80,
+			cost: ["Grass", "Grass", "Grass", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559961,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ナエトル",
+	},
+
+	retreat: 4,
+	rarity: "Common",
+	dexId: [388],
+};
+
+export default card;

--- a/data-asia/SM/SM5S/008.ts
+++ b/data-asia/SM/SM5S/008.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM5S";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ドダイトス",
+	},
+
+	illustrator: "kawayoo",
+	category: "Pokemon",
+	hp: 180,
+	types: ["Grass"],
+
+	description: {
+		ja: "小さな ポケモンたちが 集まり 動かない ドダイトスの 背中で 巣作りを はじめることがある。",
+	},
+
+	stage: "Stage2",
+
+	attacks: [
+		{
+			name: { ja: "ギガドレイン" },
+			damage: 50,
+			cost: ["Grass", "Grass", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンに与えたダメージぶん、このポケモンのHPを回復する。",
+			},
+		},
+		{
+			name: { ja: "じしん" },
+			damage: 180,
+			cost: ["Grass", "Grass", "Grass", "Colorless"],
+			effect: {
+				ja: "自分のベンチポケモン全員にも、それぞれ20ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 559962,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ハヤシガメ",
+	},
+
+	retreat: 4,
+	rarity: "Rare",
+	dexId: [389],
+};
+
+export default card;

--- a/data-asia/SM/SM5S/009.ts
+++ b/data-asia/SM/SM5S/009.ts
@@ -1,0 +1,49 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM5S";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "チェリンボ",
+	},
+
+	illustrator: "Asako Ito",
+	category: "Pokemon",
+	hp: 50,
+	types: ["Grass"],
+
+	description: {
+		ja: "小さな 玉に つまった 栄養分を 吸い取って 進化の エネルギーに するのだ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ふいをつく" },
+			damage: 30,
+			cost: ["Grass"],
+			effect: {
+				ja: "コインを1回投げウラなら、このワザは失敗。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559963,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [420],
+};
+
+export default card;

--- a/data-asia/SM/SM5S/010.ts
+++ b/data-asia/SM/SM5S/010.ts
@@ -1,0 +1,60 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM5S";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "チェリム",
+	},
+
+	illustrator: "MAHOU",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Grass"],
+
+	description: {
+		ja: "強い 日差しを 感じとると 閉ざしていた 花びらを 広げ 全身で 日光を 浴びる。",
+	},
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "おてんきガード" },
+			effect: {
+				ja: "このポケモンがいるかぎり、自分の[草]ポケモン全員の弱点は、すべてなくなる。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "タネばくだん" },
+			damage: 30,
+			cost: ["Grass"],
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559964,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "チェリンボ",
+	},
+
+	retreat: 1,
+	rarity: "Uncommon",
+	dexId: [421],
+};
+
+export default card;

--- a/data-asia/SM/SM5S/011.ts
+++ b/data-asia/SM/SM5S/011.ts
@@ -1,0 +1,56 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM5S";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "マスキッパ",
+	},
+
+	illustrator: "Anesaki Dynamic",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Grass"],
+
+	description: {
+		ja: "湿地帯に 生える 木に巻きつき 甘い香りの だえきで 獲物を 誘き寄せては ひとくちで 食べる。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ガブガブ" },
+			damage: 20,
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンのHPを「20」回復する。",
+			},
+		},
+		{
+			name: { ja: "おおいかぶさる 90-" },
+			cost: ["Grass", "Grass"],
+			effect: {
+				ja: "このポケモンにのっているダメカンの数x10ダメージぶん、このワザのダメージは小さくなる。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559965,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [455],
+};
+
+export default card;

--- a/data-asia/SM/SM5S/012.ts
+++ b/data-asia/SM/SM5S/012.ts
@@ -1,0 +1,65 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM5S";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "リーフィアGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 200,
+	types: ["Grass"],
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "あおばのいぶき" },
+			effect: {
+				ja: "このポケモンがバトル場にいるなら、自分の番に1回使える。エネルギーがついている自分のポケモン1匹のHPを「50」回復する。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ソーラービーム" },
+			damage: 110,
+			cost: ["Grass", "Colorless", "Colorless"],
+		},
+		{
+			name: { ja: "グランブルームGX" },
+			cost: ["Grass"],
+			effect: {
+				ja: "自分のベンチのたねポケモン全員からそれぞれ進化するカードを、自分の山札から1枚ずつ選び、それぞれにのせて進化させる。そして山札を切る。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 559966,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "イーブイ",
+	},
+
+	retreat: 2,
+	rarity: "Double rare",
+	dexId: [470],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM5S/013.ts
+++ b/data-asia/SM/SM5S/013.ts
@@ -1,0 +1,59 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM5S";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "カットロトム",
+	},
+
+	illustrator: "kawayoo",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Grass"],
+
+	description: {
+		ja: "プラズマで できた 体を 持つ。 電化製品に 潜りこみ 悪さを することで 知られている。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ロトモーター" },
+			effect: {
+				ja: "自分のトラッシュに「ポケモンのどうぐ」が9枚以上あるなら、このポケモンが使うワザに必要なエネルギーは、すべてなくなる。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "スペシャルカット" },
+			damage: 60,
+			cost: ["Grass", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンについている特殊エネルギーを、1個トラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559967,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Uncommon",
+	dexId: [479],
+};
+
+export default card;

--- a/data-asia/SM/SM5S/014.ts
+++ b/data-asia/SM/SM5S/014.ts
@@ -1,0 +1,56 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM5S";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "シェイミ",
+	},
+
+	illustrator: "Mizue",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Grass"],
+
+	description: {
+		ja: "グラシデアの花が 咲く 季節 感謝の 心を 届けるために 飛び立つと 言われている。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "てまねき" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札にある、それぞれちがうタイプのたねポケモンを3枚まで、ベンチに出す。そして山札を切る。",
+			},
+		},
+		{
+			name: { ja: "アロマスリープ" },
+			damage: 30,
+			cost: ["Grass", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをねむりにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 559968,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Rare",
+	dexId: [492],
+};
+
+export default card;

--- a/data-asia/SM/SM5S/015.ts
+++ b/data-asia/SM/SM5S/015.ts
@@ -1,0 +1,56 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM5S";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ブーバー",
+	},
+
+	illustrator: "Yumi",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Fire"],
+
+	description: {
+		ja: "怒ると 全身から 灼熱の 炎を 噴き上げる。 相手を 炭に するまで 収まらない。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "のやき" },
+			cost: ["Fire"],
+			effect: {
+				ja: "相手の山札を上から1枚トラッシュする。",
+			},
+		},
+		{
+			name: { ja: "かえんほうしゃ" },
+			damage: 80,
+			cost: ["Fire", "Fire", "Colorless"],
+			effect: {
+				ja: "このポケモンについているエネルギーを、1個トラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559969,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Common",
+	dexId: [126],
+};
+
+export default card;

--- a/data-asia/SM/SM5S/016.ts
+++ b/data-asia/SM/SM5S/016.ts
@@ -1,0 +1,63 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM5S";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ブーバーン",
+	},
+
+	illustrator: "nagimiso",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Fire"],
+
+	description: {
+		ja: "腕先から 摂氏２０００度の 火の玉を 発射。 連射を すると 腕先が 少し 溶ける。",
+	},
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "しゃくねつボディ" },
+			effect: {
+				ja: "このポケモンが、バトル場で相手のポケモンからワザのダメージを受けたとき、ワザを使ったポケモンをやけどにする。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ファイヤーガン" },
+			damage: "80+",
+			cost: ["Fire", "Fire", "Colorless"],
+			effect: {
+				ja: "のぞむなら、このポケモンについているエネルギーを、2個トラッシュする。その場合、80ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 559970,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ブーバー",
+	},
+
+	retreat: 3,
+	rarity: "Rare",
+	dexId: [467],
+};
+
+export default card;

--- a/data-asia/SM/SM5S/017.ts
+++ b/data-asia/SM/SM5S/017.ts
@@ -1,0 +1,46 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM5S";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヒコザル",
+	},
+
+	illustrator: "Ken Sugimori",
+	category: "Pokemon",
+	hp: 40,
+	types: ["Fire"],
+
+	description: {
+		ja: "お腹で 作られた ガスが お尻で 燃えている。 体調が 悪いと 炎が 弱くなる。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ほのお" },
+			damage: 20,
+			cost: ["Fire"],
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559971,
+			},
+		},
+	],
+
+	retreat: 0,
+	rarity: "Common",
+	dexId: [390],
+};
+
+export default card;

--- a/data-asia/SM/SM5S/018.ts
+++ b/data-asia/SM/SM5S/018.ts
@@ -1,0 +1,49 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM5S";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヒコザル",
+	},
+
+	illustrator: "Kouki Saitou",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Fire"],
+
+	description: {
+		ja: "お腹で 作られた ガスが お尻で 燃えている。 体調が 悪いと 炎が 弱くなる。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "みだれひっかき" },
+			damage: "10×",
+			cost: ["Colorless"],
+			effect: {
+				ja: "コインを3回投げ、オモテの数x10ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559972,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [390],
+};
+
+export default card;

--- a/data-asia/SM/SM5S/019.ts
+++ b/data-asia/SM/SM5S/019.ts
@@ -1,0 +1,53 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM5S";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "モウカザル",
+	},
+
+	illustrator: "Shigenori Negishi",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Fire"],
+
+	description: {
+		ja: "天井や 壁を 利用して 空中殺法を 繰り出す。 尻尾の 炎も 武器の ひとつ。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "ほのおでこがす" },
+			damage: 20,
+			cost: ["Fire"],
+			effect: {
+				ja: "相手のバトルポケモンをやけどにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559973,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ヒコザル",
+	},
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [391],
+};
+
+export default card;

--- a/data-asia/SM/SM5S/020.ts
+++ b/data-asia/SM/SM5S/020.ts
@@ -1,0 +1,63 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM5S";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ゴウカザル",
+	},
+
+	illustrator: "nagimiso",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Fire"],
+
+	description: {
+		ja: "素早さで 相手を 翻弄する。 両手 両足を 使った 独特の 戦い方を する。",
+	},
+
+	stage: "Stage2",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "あつきとうし" },
+			effect: {
+				ja: "このポケモンがいるかぎり、相手のバトルポケモンは、やけどでのせるダメカンの数が6個になる。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "バーストパンチ" },
+			damage: 50,
+			cost: ["Fire", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをやけどにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 559974,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "モウカザル",
+	},
+
+	retreat: 1,
+	rarity: "Rare",
+	dexId: [392],
+};
+
+export default card;

--- a/data-asia/SM/SM5S/021.ts
+++ b/data-asia/SM/SM5S/021.ts
@@ -1,0 +1,56 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM5S";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヒートロトム",
+	},
+
+	illustrator: "Shin Nagasawa",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Fire"],
+
+	description: {
+		ja: "プラズマで できた 体を 持つ。 電化製品に 潜りこみ 悪さを することで 知られている。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ロトモーター" },
+			effect: {
+				ja: "自分のトラッシュに「ポケモンのどうぐ」が9枚以上あるなら、このポケモンが使うワザに必要なエネルギーは、すべてなくなる。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ヒートブラスト" },
+			damage: 80,
+			cost: ["Fire", "Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559975,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Uncommon",
+	dexId: [479],
+};
+
+export default card;

--- a/data-asia/SM/SM5S/022.ts
+++ b/data-asia/SM/SM5S/022.ts
@@ -1,0 +1,51 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM5S";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヤトウモリ",
+	},
+
+	illustrator: "Misa Tsutsui",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Fire"],
+
+	description: {
+		ja: "火山や 乾いた 岩場に 棲む。 甘い 香りの 毒ガスを 放ち むしポケモンを おびき寄せ 襲う。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ひだね" },
+			damage: 10,
+			cost: ["Fire"],
+		},
+		{
+			name: { ja: "かえん" },
+			damage: 30,
+			cost: ["Fire", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559976,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [757],
+};
+
+export default card;

--- a/data-asia/SM/SM5S/023.ts
+++ b/data-asia/SM/SM5S/023.ts
@@ -1,0 +1,60 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM5S";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "エンニュート",
+	},
+
+	illustrator: "Kagemaru Himeno",
+	category: "Pokemon",
+	hp: 110,
+	types: ["Fire"],
+
+	description: {
+		ja: "毒ガスには 多くの フェロモンが 含まれている。 薄めることで 官能的な 香水が できる。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "パニックどく" },
+			cost: ["Fire"],
+			effect: {
+				ja: "相手のバトルポケモンをどくとやけどとこんらんにする。",
+			},
+		},
+		{
+			name: { ja: "アサシンネイル" },
+			damage: "60+",
+			cost: ["Fire", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンが特殊状態なら、60ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559977,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ヤトウモリ",
+	},
+
+	retreat: 1,
+	rarity: "Uncommon",
+	dexId: [758],
+};
+
+export default card;

--- a/data-asia/SM/SM5S/024.ts
+++ b/data-asia/SM/SM5S/024.ts
@@ -1,0 +1,54 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM5S";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "バクガメス",
+	},
+
+	illustrator: "Anesaki Dynamic",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Fire"],
+
+	description: {
+		ja: "鼻の 孔から 炎や 毒ガスを 吹く。 フンは 爆発物で 色んな 使い道が ある。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "やきこがす" },
+			damage: 10,
+			cost: ["Fire"],
+			effect: {
+				ja: "相手のバトルポケモンをやけどにする。",
+			},
+		},
+		{
+			name: { ja: "ばくねつほう" },
+			damage: 100,
+			cost: ["Fire", "Colorless", "Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559978,
+			},
+		},
+	],
+
+	retreat: 4,
+	rarity: "Common",
+	dexId: [776],
+};
+
+export default card;

--- a/data-asia/SM/SM5S/025.ts
+++ b/data-asia/SM/SM5S/025.ts
@@ -1,0 +1,49 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM5S";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヤミカラス",
+	},
+
+	illustrator: "match",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Darkness"],
+
+	description: {
+		ja: "不吉の 証と 嫌われるが 仲良しの トレーナーには キラキラ 光るものを プレゼントするよ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "くろいまなざし" },
+			damage: 10,
+			cost: ["Darkness"],
+			effect: {
+				ja: "次の相手の番、このワザを受けたポケモンは、にげられない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559979,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [198],
+};
+
+export default card;

--- a/data-asia/SM/SM5S/026.ts
+++ b/data-asia/SM/SM5S/026.ts
@@ -1,0 +1,57 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM5S";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ドンカラス",
+	},
+
+	illustrator: "Hitoshi Ariga",
+	category: "Pokemon",
+	hp: 110,
+	types: ["Darkness"],
+
+	description: {
+		ja: "獲物を 捕るのを 失敗したり 裏切った 子分の ヤミカラスを どこまでも 追い詰め 処分する。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "スナッチターン" },
+			cost: ["Darkness"],
+			effect: {
+				ja: "相手の手札からオモテを見ないで、1枚トラッシュする。このポケモンをベンチポケモンと入れ替える。",
+			},
+		},
+		{
+			name: { ja: "スピードひこう" },
+			damage: 90,
+			cost: ["Darkness", "Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559980,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ヤミカラス",
+	},
+
+	retreat: 1,
+	rarity: "Uncommon",
+	dexId: [430],
+};
+
+export default card;

--- a/data-asia/SM/SM5S/027.ts
+++ b/data-asia/SM/SM5S/027.ts
@@ -1,0 +1,56 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM5S";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ニューラ",
+	},
+
+	illustrator: "Masakazu Fukuda",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Darkness"],
+
+	description: {
+		ja: "ツメで タマゴに 穴を 開けて 中味を すする。 ブリーダーに 憎まれ 駆除 されることもある。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "こっそりこわす" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "このワザは、後攻プレイヤーの最初の番にだけ使える。相手の場のポケモンについているエネルギーを、1個トラッシュする。",
+			},
+		},
+		{
+			name: { ja: "おそいかかる" },
+			damage: "10+",
+			cost: ["Darkness"],
+			effect: {
+				ja: "コインを1回投げオモテなら、20ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559981,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [215],
+};
+
+export default card;

--- a/data-asia/SM/SM5S/028.ts
+++ b/data-asia/SM/SM5S/028.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM5S";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "マニューラ",
+	},
+
+	illustrator: "Misa Tsutsui",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Darkness"],
+
+	description: {
+		ja: "寒い 場所に 棲み アローラでは ロコンや サンドが 主な 餌。 獲物は 仲間で きちんと 分ける。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "こごえるかぜ" },
+			damage: 10,
+			cost: ["Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをねむりにする。",
+			},
+		},
+		{
+			name: { ja: "あくのいましめ" },
+			damage: "50×",
+			cost: ["Darkness"],
+			effect: {
+				ja: "相手の場の特性を持つポケモンの数x50ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 559982,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ニューラ",
+	},
+
+	retreat: 1,
+	rarity: "Rare",
+	dexId: [461],
+};
+
+export default card;

--- a/data-asia/SM/SM5S/029.ts
+++ b/data-asia/SM/SM5S/029.ts
@@ -1,0 +1,49 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM5S";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "スカンプー",
+	},
+
+	illustrator: "Naoyo Kimura",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Darkness"],
+
+	description: {
+		ja: "お尻から 強烈に くさい 液体を 飛ばして 身を 守る。 においは ２４時間 消えない。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "みちづれガス" },
+			damage: 10,
+			cost: ["Darkness"],
+			effect: {
+				ja: "おたがいのバトルポケモンを、それぞれこんらんにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559983,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Common",
+	dexId: [434],
+};
+
+export default card;

--- a/data-asia/SM/SM5S/030.ts
+++ b/data-asia/SM/SM5S/030.ts
@@ -1,0 +1,58 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM5S";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "スカタンク",
+	},
+
+	illustrator: "Studio Bora Inc.",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Darkness"],
+
+	description: {
+		ja: "尻尾から くさい 汁を 飛ばす。 お腹で 熟成させる 時間が 長いほど においが ひどくなる。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "ベタつくえんまく" },
+			damage: 50,
+			cost: ["Darkness", "Colorless"],
+			effect: {
+				ja: "次の相手の番、このワザを受けたポケモンがワザを使うとき、相手はコインを2回投げる。1回でもウラなら、そのワザは失敗。",
+			},
+		},
+		{
+			name: { ja: "ぶちかます" },
+			damage: 100,
+			cost: ["Darkness", "Darkness", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559984,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "スカンプー",
+	},
+
+	retreat: 3,
+	rarity: "Common",
+	dexId: [435],
+};
+
+export default card;

--- a/data-asia/SM/SM5S/031.ts
+++ b/data-asia/SM/SM5S/031.ts
@@ -1,0 +1,59 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM5S";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ダークライ",
+	},
+
+	illustrator: "Naoki Saito",
+	category: "Pokemon",
+	hp: 160,
+	types: ["Darkness"],
+
+	description: {
+		ja: "人々を 深い 眠りに 誘い 夢を 見せる 能力を 持つ。 新月の 夜に 活動する。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ナイトメアスター" },
+			effect: {
+				ja: "自分の番に、このカードを手札からベンチに出したとき、1回使える。自分の手札にある[悪]エネルギーを2枚、このポケモンにつける。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "アビススリープ" },
+			damage: 120,
+			cost: ["Darkness", "Darkness", "Darkness", "Darkness"],
+			effect: {
+				ja: "相手のバトルポケモンをねむりにする。このねむりで投げるコインは2回になり、すべてオモテが出ないと回復しない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 559985,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Rare Holo",
+	dexId: [491],
+};
+
+export default card;

--- a/data-asia/SM/SM5S/032.ts
+++ b/data-asia/SM/SM5S/032.ts
@@ -1,0 +1,49 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM5S";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アローラディグダ",
+	},
+
+	illustrator: "Naoyo Kimura",
+	category: "Pokemon",
+	hp: 50,
+	types: ["Metal"],
+
+	description: {
+		ja: "金色の 髭は センサー機能を 持っている。 穴から だして 周りの 様子を うかがっている。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "アイアンヘッド" },
+			damage: "10×",
+			cost: [],
+			effect: {
+				ja: "ウラが出るまでコインを投げ、オモテの数x10ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559986,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [50],
+};
+
+export default card;

--- a/data-asia/SM/SM5S/033.ts
+++ b/data-asia/SM/SM5S/033.ts
@@ -1,0 +1,53 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM5S";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アローラダグトリオ",
+	},
+
+	illustrator: "Megumi Mizutani",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Metal"],
+
+	description: {
+		ja: "大地の 女神たちの 化身と 考えられ アローラ地方では とても 大切に されている。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "ゴールドラッシュ" },
+			damage: "30×",
+			cost: [],
+			effect: {
+				ja: "自分の手札にある[鋼]エネルギーを好きなだけトラッシュし、その枚数x30ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559987,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "アローラディグダ",
+	},
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [51],
+};
+
+export default card;

--- a/data-asia/SM/SM5S/034.ts
+++ b/data-asia/SM/SM5S/034.ts
@@ -1,0 +1,53 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM5S";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "コイル",
+	},
+
+	illustrator: "MAHOU",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Metal"],
+
+	description: {
+		ja: "電磁波を 放ち 空を 漂う。 電気を 喰っているときに 触ると 全身が ビリッと 痺れるぞ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "マグネサーチ" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札にある[鋼]エネルギーを3枚まで、相手に見せてから、手札に加える。そして山札を切る。",
+			},
+		},
+		{
+			name: { ja: "たいあたり" },
+			damage: 10,
+			cost: ["Metal"],
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559988,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [81],
+};
+
+export default card;

--- a/data-asia/SM/SM5S/035.ts
+++ b/data-asia/SM/SM5S/035.ts
@@ -1,0 +1,56 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM5S";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "コイル",
+	},
+
+	illustrator: "Ken Sugimori",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Metal"],
+
+	description: {
+		ja: "電磁波を 放ち 空を 漂う。 電気を 喰っているときに 触ると 全身が ビリッと 痺れるぞ。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ハードユニット" },
+			effect: {
+				ja: "このポケモンは、ベンチにいるかぎり、ワザのダメージを受けない。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ぶつかる" },
+			damage: 20,
+			cost: ["Metal", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559989,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [81],
+};
+
+export default card;

--- a/data-asia/SM/SM5S/036.ts
+++ b/data-asia/SM/SM5S/036.ts
@@ -1,0 +1,58 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM5S";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "レアコイル",
+	},
+
+	illustrator: "kirisAki",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Metal"],
+
+	description: {
+		ja: "ほぼ コイル ３倍の 電力。 太陽の黒点が 多いとき なぜか 大量発生。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "ぶつかる" },
+			damage: 20,
+			cost: ["Metal"],
+		},
+		{
+			name: { ja: "でんじほう" },
+			damage: 80,
+			cost: ["Metal", "Metal", "Colorless"],
+			effect: {
+				ja: "次の自分の番、このポケモンは「でんじほう」が使えない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559990,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "コイル",
+	},
+
+	retreat: 2,
+	rarity: "Common",
+	dexId: [82],
+};
+
+export default card;

--- a/data-asia/SM/SM5S/037.ts
+++ b/data-asia/SM/SM5S/037.ts
@@ -1,0 +1,63 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM5S";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ジバコイル",
+	},
+
+	illustrator: "Yoshinobu Saito",
+	category: "Pokemon",
+	hp: 150,
+	types: ["Metal"],
+
+	description: {
+		ja: "怪電波を 発信 しながら 空を 飛び回り 未知の 電波を 受信 していると いう。",
+	},
+
+	stage: "Stage2",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "マグネサーキット" },
+			effect: {
+				ja: "自分の番に何回でも使える。自分の手札にある[鋼]エネルギーを1枚、自分のポケモンにつける。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "でんじほう" },
+			damage: 130,
+			cost: ["Metal", "Metal", "Metal", "Colorless"],
+			effect: {
+				ja: "次の自分の番、このポケモンは「でんじほう」が使えない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 559991,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "レアコイル",
+	},
+
+	retreat: 2,
+	rarity: "Rare",
+	dexId: [462],
+};
+
+export default card;

--- a/data-asia/SM/SM5S/038.ts
+++ b/data-asia/SM/SM5S/038.ts
@@ -1,0 +1,54 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM5S";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "タテトプス",
+	},
+
+	illustrator: "so-taro",
+	category: "Pokemon",
+	hp: 100,
+	types: ["Metal"],
+
+	description: {
+		ja: "頑丈な 顔の おかげで 敵は 少なかったと 思われる。 太古の ジャングルに 棲んでいた。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "とっしん" },
+			damage: 50,
+			cost: ["Metal", "Colorless"],
+			effect: {
+				ja: "このポケモンにも10ダメージ。",
+			},
+		},
+		{
+			name: { ja: "がちんこ" },
+			damage: 80,
+			cost: ["Metal", "Metal", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559992,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Uncommon",
+	dexId: [410],
+};
+
+export default card;

--- a/data-asia/SM/SM5S/039.ts
+++ b/data-asia/SM/SM5S/039.ts
@@ -1,0 +1,63 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM5S";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "トリデプス",
+	},
+
+	illustrator: "Hasuno",
+	category: "Pokemon",
+	hp: 160,
+	types: ["Metal"],
+
+	description: {
+		ja: "ラムパルドと 似た 場所に いた。 ２匹が 争い 共倒れに なった 化石が 見つかることも。",
+	},
+
+	stage: "Stage2",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "だいちのたて" },
+			effect: {
+				ja: "このポケモンがいるかぎり、自分の[鋼]ポケモン全員は、特殊エネルギーがついている相手のポケモンから、ワザのダメージを受けない。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "つきとばす" },
+			damage: 110,
+			cost: ["Metal", "Metal", "Colorless"],
+			effect: {
+				ja: "のぞむなら、相手のバトルポケモンをベンチポケモンと入れ替える。［バトル場に出すポケモンは相手が選ぶ。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 559993,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "タテトプス",
+	},
+
+	retreat: 3,
+	rarity: "Rare",
+	dexId: [411],
+};
+
+export default card;

--- a/data-asia/SM/SM5S/040.ts
+++ b/data-asia/SM/SM5S/040.ts
@@ -1,0 +1,53 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM5S";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ドーミラー",
+	},
+
+	illustrator: "Sumiyoshi Kizuki",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Metal"],
+
+	description: {
+		ja: "古い お墓から ドーミラーに そっくりな 道具が 掘り出されたが 関係は わかっていない。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "さいみんじゅつ" },
+			cost: ["Metal"],
+			effect: {
+				ja: "相手のバトルポケモンをねむりにする。",
+			},
+		},
+		{
+			name: { ja: "かいてんアタック" },
+			damage: 20,
+			cost: ["Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559994,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Common",
+	dexId: [436],
+};
+
+export default card;

--- a/data-asia/SM/SM5S/041.ts
+++ b/data-asia/SM/SM5S/041.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM5S";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ドータクン",
+	},
+
+	illustrator: "Kagemaru Himeno",
+	category: "Pokemon",
+	hp: 110,
+	types: ["Metal"],
+
+	description: {
+		ja: "ドータクンに 祈りを ささげると 雨が 降り 作物を 育てると 古代の 人々は 信じていた。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "ねんりき" },
+			damage: 20,
+			cost: ["Metal"],
+			effect: {
+				ja: "コインを1回投げオモテなら、相手のバトルポケモンをマヒにする。",
+			},
+		},
+		{
+			name: { ja: "サイコレゾナンス" },
+			damage: "60+",
+			cost: ["Metal", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手の場に[超]ポケモンがいるなら、60ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559995,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ドーミラー",
+	},
+
+	retreat: 3,
+	rarity: "Uncommon",
+	dexId: [437],
+};
+
+export default card;

--- a/data-asia/SM/SM5S/042.ts
+++ b/data-asia/SM/SM5S/042.ts
@@ -1,0 +1,57 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM5S";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヒードラン",
+	},
+
+	illustrator: "tetsuya koizumi",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Metal"],
+
+	description: {
+		ja: "マグマのように 燃えたぎる 血液が 体を 流れている。 火山の 洞穴に 生息する。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ガードプレス" },
+			damage: 30,
+			cost: ["Metal", "Colorless"],
+			effect: {
+				ja: "次の相手の番、このポケモンが受けるワザのダメージは「-30」される。",
+			},
+		},
+		{
+			name: { ja: "ボイラーインパクト" },
+			damage: 130,
+			cost: ["Metal", "Metal", "Colorless"],
+			effect: {
+				ja: "このポケモンについているエネルギーを、2個トラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 559996,
+			},
+		},
+	],
+
+	retreat: 3,
+	rarity: "Rare",
+	dexId: [485],
+};
+
+export default card;

--- a/data-asia/SM/SM5S/043.ts
+++ b/data-asia/SM/SM5S/043.ts
@@ -1,0 +1,56 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM5S";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ソルガレオ",
+	},
+
+	illustrator: "Shin Nagasawa",
+	category: "Pokemon",
+	hp: 160,
+	types: ["Metal"],
+
+	description: {
+		ja: "コスモッグが 進化した ♂だと いわれる。 第３の 眼が 浮かぶとき 別世界へと 駆け抜けていく。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ライジングスター" },
+			cost: ["Metal"],
+			effect: {
+				ja: "自分のトラッシュにある[鋼]エネルギーを、相手の場のポケモンの数ぶん、自分のポケモンに好きなようにつける。",
+			},
+		},
+		{
+			name: { ja: "コロナインパクト" },
+			damage: 160,
+			cost: ["Metal", "Metal", "Metal", "Metal"],
+			effect: {
+				ja: "次の自分の番、このポケモンはワザが使えない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 559997,
+			},
+		},
+	],
+
+	retreat: 3,
+	rarity: "Rare Holo",
+	dexId: [791],
+};
+
+export default card;

--- a/data-asia/SM/SM5S/044.ts
+++ b/data-asia/SM/SM5S/044.ts
@@ -1,0 +1,60 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM5S";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ネクロズマ たそがれのたてがみGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 190,
+	types: ["Metal"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ツメできりさく" },
+			damage: 60,
+			cost: ["Colorless", "Colorless", "Colorless"],
+		},
+		{
+			name: { ja: "メテオテンペスト" },
+			damage: 220,
+			cost: ["Metal", "Metal", "Metal", "Colorless"],
+			effect: {
+				ja: "このポケモンについているエネルギーを、3個トラッシュする。",
+			},
+		},
+		{
+			name: { ja: "イクリプスサンGX" },
+			damage: 250,
+			cost: ["Metal", "Metal", "Metal"],
+			effect: {
+				ja: "このワザは、自分のサイドの残り枚数が、相手より多いときにしか使えない。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 559998,
+			},
+		},
+	],
+
+	retreat: 3,
+	rarity: "Double rare",
+	dexId: [800],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM5S/045.ts
+++ b/data-asia/SM/SM5S/045.ts
@@ -1,0 +1,62 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM5S";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ディアルガGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 180,
+	types: ["Dragon"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "クロックアップ" },
+			cost: ["Metal"],
+			effect: {
+				ja: "自分の手札が6枚になるように、山札を引く。",
+			},
+		},
+		{
+			name: { ja: "ひきさく" },
+			damage: 80,
+			cost: ["Metal", "Colorless", "Colorless"],
+			effect: {
+				ja: "このワザのダメージは、相手のバトルポケモンにかかっている効果を計算しない。",
+			},
+		},
+		{
+			name: { ja: "タイムレスGX" },
+			damage: 150,
+			cost: ["Metal", "Metal", "Metal", "Colorless", "Colorless"],
+			effect: {
+				ja: "この番が終わったら、もう1回自分の番を始める。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fairy", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 559999,
+			},
+		},
+	],
+
+	retreat: 3,
+	rarity: "Double rare",
+	dexId: [483],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM5S/046.ts
+++ b/data-asia/SM/SM5S/046.ts
@@ -1,0 +1,56 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM5S";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ベロリンガ",
+	},
+
+	illustrator: "Mizue",
+	category: "Pokemon",
+	hp: 100,
+	types: ["Colorless"],
+
+	description: {
+		ja: "舌が 身長の ２倍もある。 エサを 取ったり 攻撃を したりと まるで 手のように 動かせる。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "したでとる" },
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "自分の山札を3枚引く。",
+			},
+		},
+		{
+			name: { ja: "たたきつける" },
+			damage: "50×",
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "コインを2回投げ、オモテの数x50ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560000,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Common",
+	dexId: [108],
+};
+
+export default card;

--- a/data-asia/SM/SM5S/047.ts
+++ b/data-asia/SM/SM5S/047.ts
@@ -1,0 +1,58 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM5S";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ベロベルト",
+	},
+
+	illustrator: "Yumi",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Colorless"],
+
+	description: {
+		ja: "だえきには どんな 物も 溶かす 成分が たっぷり 含まれており なめられると いつまでも しびれる。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "なめごろし" },
+			damage: "50+",
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "ウラが出るまでコインを投げ、オモテの数x50ダメージ追加。最初のコインがウラなら、相手のバトルポケモンをマヒにする。",
+			},
+		},
+		{
+			name: { ja: "ころがりタックル" },
+			damage: 110,
+			cost: ["Colorless", "Colorless", "Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560001,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ベロリンガ",
+	},
+
+	retreat: 3,
+	rarity: "Uncommon",
+	dexId: [463],
+};
+
+export default card;

--- a/data-asia/SM/SM5S/048.ts
+++ b/data-asia/SM/SM5S/048.ts
@@ -1,0 +1,46 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM5S";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "イーブイ",
+	},
+
+	illustrator: "Atsuko Nishida",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Colorless"],
+
+	description: {
+		ja: "今 現在の 調査では なんと ８種類もの ポケモンへ 進化する 可能性を 持つ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "かじる" },
+			damage: 20,
+			cost: ["Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560002,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [133],
+};
+
+export default card;

--- a/data-asia/SM/SM5S/049.ts
+++ b/data-asia/SM/SM5S/049.ts
@@ -1,0 +1,49 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM5S";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ニャルマー",
+	},
+
+	illustrator: "Shibuzoh.",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Colorless"],
+
+	description: {
+		ja: "ご機嫌な ニャルマーは 尻尾で 新体操の リボンのような 美しい 動きを 見せる。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "あまがみ" },
+			damage: 10,
+			cost: ["Colorless"],
+			effect: {
+				ja: "次の相手の番、このワザを受けたポケモンが使うワザのダメージは「-40」される。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560003,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [431],
+};
+
+export default card;

--- a/data-asia/SM/SM5S/050.ts
+++ b/data-asia/SM/SM5S/050.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM5S";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ブニャット",
+	},
+
+	illustrator: "Shibuzoh.",
+	category: "Pokemon",
+	hp: 110,
+	types: ["Colorless"],
+
+	description: {
+		ja: "体を 大きく 見せて 相手を 威圧するため ふたまたの 尻尾で ウエストを ぎゅっと 絞っている。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "わがものがお" },
+			damage: 20,
+			cost: ["Colorless"],
+			effect: {
+				ja: "場に出ている相手のスタジアムをトラッシュする。トラッシュした場合、次の相手の番、このポケモンはワザのダメージや効果を受けない。",
+			},
+		},
+		{
+			name: { ja: "うっちゃらかす" },
+			damage: 60,
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手の手札を、オモテを見ないで3枚になるまで、トラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560004,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ニャルマー",
+	},
+
+	retreat: 2,
+	rarity: "Common",
+	dexId: [432],
+};
+
+export default card;

--- a/data-asia/SM/SM5S/051.ts
+++ b/data-asia/SM/SM5S/051.ts
@@ -1,0 +1,58 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM5S";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "スピンロトム",
+	},
+
+	illustrator: "Masakazu Fukuda",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Colorless"],
+
+	description: {
+		ja: "プラズマで できた 体を 持つ。 電化製品に 潜りこみ 悪さを することで 知られている。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ロトモーター" },
+			effect: {
+				ja: "自分のトラッシュに「ポケモンのどうぐ」が9枚以上あるなら、このポケモンが使うワザに必要なエネルギーは、すべてなくなる。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "くるくるスピン" },
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のポケモン全員に、それぞれ20ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560005,
+			},
+		},
+	],
+
+	retreat: 0,
+	rarity: "Uncommon",
+	dexId: [479],
+};
+
+export default card;

--- a/data-asia/SM/SM5S/052.ts
+++ b/data-asia/SM/SM5S/052.ts
@@ -1,0 +1,56 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM5S";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヤレユータン",
+	},
+
+	illustrator: "Kouki Saitou",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Colorless"],
+
+	description: {
+		ja: "ジャングル奥地の 木の上に 棲む。 まれに 海辺に 現れて ヤドキングと 知恵比べを する。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "リソースマネージメント" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分のトラッシュにある好きなカードを3枚、相手に見せてから、好きな順番に入れ替えて、山札の下にもどす。",
+			},
+		},
+		{
+			name: { ja: "うんちく" },
+			damage: 60,
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをこんらんにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560006,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Common",
+	dexId: [765],
+};
+
+export default card;

--- a/data-asia/SM/SM5S/053.ts
+++ b/data-asia/SM/SM5S/053.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM5S";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "きずぐすり",
+	},
+
+	illustrator: "Toyste Beach",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分のポケモン1匹のHPを「30」回復する。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560007,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM5S/054.ts
+++ b/data-asia/SM/SM5S/054.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM5S";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ともだちてちょう",
+	},
+
+	illustrator: "Toyste Beach",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分のトラッシュからサポートを2枚選び、相手に見せてから、山札にもどす。そして山札を切る。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560008,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	rarity: "Common",
+};
+
+export default card;

--- a/data-asia/SM/SM5S/055.ts
+++ b/data-asia/SM/SM5S/055.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM5S";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "なぞの化石",
+	},
+
+	illustrator: "Toyste Beach",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードは、HP60の[無]タイプのたねポケモンとして、場に出すことができる。自分の番の中でなら、場に出ているこのカードをトラッシュしてよい。このカードは、にげられない。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560009,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	rarity: "Common",
+};
+
+export default card;

--- a/data-asia/SM/SM5S/056.ts
+++ b/data-asia/SM/SM5S/056.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM5S";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ネストボール",
+	},
+
+	illustrator: "Toyste Beach",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の山札にあるたねポケモンを1枚、ベンチに出す。そして山札を切る。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560010,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM5S/057.ts
+++ b/data-asia/SM/SM5S/057.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM5S";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ポケモンキャッチャー",
+	},
+
+	illustrator: "Toyste Beach",
+	category: "Trainer",
+
+	effect: {
+		ja: "相手のベンチポケモンを1匹選び、バトルポケモンと入れ替える。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560011,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM5S/058.ts
+++ b/data-asia/SM/SM5S/058.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM5S";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ミッシングクローバー",
+	},
+
+	illustrator: "Toyste Beach",
+	category: "Trainer",
+
+	effect: {
+		ja: "「ミッシングクローバー」は、1枚または4枚同時に使え、使った枚数によって効果が変わる。◆1枚使ったなら、自分の山札を上から1枚見て、もとにもどす。◆4枚同時に使ったなら、自分のサイドを1枚とる。（この効果は、4枚で1回はたらく。）",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560012,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	rarity: "Common",
+};
+
+export default card;

--- a/data-asia/SM/SM5S/059.ts
+++ b/data-asia/SM/SM5S/059.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM5S";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アカギ",
+	},
+
+	illustrator: "Masakazu Fukuda",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードは、自分のバトル場に[水]または[鋼]ポケモンがいなければ使えない。相手は相手自身のベンチポケモンが2匹になるまで、ポケモンとついているすべてのカードを、山札にもどして切る。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 560013,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	rarity: "Rare Holo",
+};
+
+export default card;

--- a/data-asia/SM/SM5S/060.ts
+++ b/data-asia/SM/SM5S/060.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM5S";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ナタネ",
+	},
+
+	illustrator: "Ken Sugimori",
+	category: "Trainer",
+
+	effect: {
+		ja: "[草]エネルギーがついている自分のポケモン1匹のHPを「80」回復する。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560014,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM5S/061.ts
+++ b/data-asia/SM/SM5S/061.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM5S";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ポケモンだいすきクラブ",
+	},
+
+	illustrator: "Sanosuke Sakuma",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の山札からたねポケモンを2枚まで選び、相手に見せてから、手札に加える。そして山札を切る。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560015,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM5S/062.ts
+++ b/data-asia/SM/SM5S/062.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM5S";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "マーズ",
+	},
+
+	illustrator: "Ken Sugimori",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の山札を2枚引く。その後、相手の手札からオモテを見ないで、1枚トラッシュする。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560016,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM5S/063.ts
+++ b/data-asia/SM/SM5S/063.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM5S";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "リーリエ",
+	},
+
+	illustrator: "Ken Sugimori",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の手札が6枚になるように、山札を引く。最初の自分の番に使ったなら、8枚になるように引く。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560017,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM5S/064.ts
+++ b/data-asia/SM/SM5S/064.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM5S";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "テンガン山",
+	},
+
+	illustrator: "Ryo Ueda",
+	category: "Trainer",
+
+	effect: {
+		ja: "おたがいのプレイヤーは、自分の番に1回、自分のトラッシュにある[鋼]エネルギーを2枚、相手に見せてから、手札に加えてよい。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560018,
+			},
+		},
+	],
+
+	trainerType: "Stadium",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM5S/065.ts
+++ b/data-asia/SM/SM5S/065.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM5S";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ダブル無色エネルギー",
+	},
+
+	illustrator: "",
+	category: "Energy",
+	energyType: "Special",
+
+	effect: {
+		ja: "このカードは、[無]エネルギー2個ぶんとしてはたらく。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560019,
+			},
+		},
+	],
+
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM5S/066.ts
+++ b/data-asia/SM/SM5S/066.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM5S";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ユニットエネルギー草炎水",
+	},
+
+	illustrator: "",
+	category: "Energy",
+	energyType: "Special",
+
+	effect: {
+		ja: "このカードは、ポケモンについているかぎり、[草][炎][水]の3つのタイプのエネルギー1個ぶんとしてはたらく。ポケモンについていないなら、[無]エネルギー1個ぶんとしてはたらく。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560020,
+			},
+		},
+	],
+
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM5S/067.ts
+++ b/data-asia/SM/SM5S/067.ts
@@ -1,0 +1,65 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM5S";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "リーフィアGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 200,
+	types: ["Grass"],
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "あおばのいぶき" },
+			effect: {
+				ja: "このポケモンがバトル場にいるなら、自分の番に1回使える。エネルギーがついている自分のポケモン1匹のHPを「50」回復する。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ソーラービーム" },
+			damage: 110,
+			cost: ["Grass", "Colorless", "Colorless"],
+		},
+		{
+			name: { ja: "グランブルームGX" },
+			cost: ["Grass"],
+			effect: {
+				ja: "自分のベンチのたねポケモン全員からそれぞれ進化するカードを、自分の山札から1枚ずつ選び、それぞれにのせて進化させる。そして山札を切る。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 560021,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "イーブイ",
+	},
+
+	retreat: 2,
+	rarity: "Ultra Rare",
+	dexId: [470],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM5S/068.ts
+++ b/data-asia/SM/SM5S/068.ts
@@ -1,0 +1,60 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM5S";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ネクロズマ たそがれのたてがみGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 190,
+	types: ["Metal"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ツメできりさく" },
+			damage: 60,
+			cost: ["Colorless", "Colorless", "Colorless"],
+		},
+		{
+			name: { ja: "メテオテンペスト" },
+			damage: 220,
+			cost: ["Metal", "Metal", "Metal", "Colorless"],
+			effect: {
+				ja: "このポケモンについているエネルギーを、3個トラッシュする。",
+			},
+		},
+		{
+			name: { ja: "イクリプスサンGX" },
+			damage: 250,
+			cost: ["Metal", "Metal", "Metal"],
+			effect: {
+				ja: "このワザは、自分のサイドの残り枚数が、相手より多いときにしか使えない。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 560022,
+			},
+		},
+	],
+
+	retreat: 3,
+	rarity: "Ultra Rare",
+	dexId: [800],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM5S/069.ts
+++ b/data-asia/SM/SM5S/069.ts
@@ -1,0 +1,62 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM5S";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ディアルガGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 180,
+	types: ["Dragon"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "クロックアップ" },
+			cost: ["Metal"],
+			effect: {
+				ja: "自分の手札が6枚になるように、山札を引く。",
+			},
+		},
+		{
+			name: { ja: "ひきさく" },
+			damage: 80,
+			cost: ["Metal", "Colorless", "Colorless"],
+			effect: {
+				ja: "このワザのダメージは、相手のバトルポケモンにかかっている効果を計算しない。",
+			},
+		},
+		{
+			name: { ja: "タイムレスGX" },
+			damage: 150,
+			cost: ["Metal", "Metal", "Metal", "Colorless", "Colorless"],
+			effect: {
+				ja: "この番が終わったら、もう1回自分の番を始める。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fairy", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 560023,
+			},
+		},
+	],
+
+	retreat: 3,
+	rarity: "Ultra Rare",
+	dexId: [483],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM5S/070.ts
+++ b/data-asia/SM/SM5S/070.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM5S";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ナタネ",
+	},
+
+	illustrator: "You Iribi",
+	category: "Trainer",
+
+	effect: {
+		ja: "[草]エネルギーがついている自分のポケモン1匹のHPを「80」回復する。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 560024,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	rarity: "Ultra Rare",
+};
+
+export default card;

--- a/data-asia/SM/SM5S/071.ts
+++ b/data-asia/SM/SM5S/071.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM5S";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ポケモンだいすきクラブ",
+	},
+
+	illustrator: "Sanosuke Sakuma",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の山札からたねポケモンを2枚まで選び、相手に見せてから、手札に加える。そして山札を切る。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 560025,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	rarity: "Ultra Rare",
+};
+
+export default card;

--- a/data-asia/SM/SM5S/072.ts
+++ b/data-asia/SM/SM5S/072.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM5S";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "マーズ",
+	},
+
+	illustrator: "kodama",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の山札を2枚引く。その後、相手の手札からオモテを見ないで、1枚トラッシュする。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 560026,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	rarity: "Ultra Rare",
+};
+
+export default card;

--- a/data-asia/SM/SM5S/073.ts
+++ b/data-asia/SM/SM5S/073.ts
@@ -1,0 +1,65 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM5S";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "リーフィアGX",
+	},
+
+	illustrator: "",
+	category: "Pokemon",
+	hp: 200,
+	types: ["Grass"],
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "あおばのいぶき" },
+			effect: {
+				ja: "このポケモンがバトル場にいるなら、自分の番に1回使える。エネルギーがついている自分のポケモン1匹のHPを「50」回復する。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ソーラービーム" },
+			damage: 110,
+			cost: ["Grass", "Colorless", "Colorless"],
+		},
+		{
+			name: { ja: "グランブルームGX" },
+			cost: ["Grass"],
+			effect: {
+				ja: "自分のベンチのたねポケモン全員からそれぞれ進化するカードを、自分の山札から1枚ずつ選び、それぞれにのせて進化させる。そして山札を切る。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 560027,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "イーブイ",
+	},
+
+	retreat: 2,
+	rarity: "Hyper rare",
+	dexId: [470],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM5S/074.ts
+++ b/data-asia/SM/SM5S/074.ts
@@ -1,0 +1,60 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM5S";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ネクロズマ たそがれのたてがみGX",
+	},
+
+	illustrator: "",
+	category: "Pokemon",
+	hp: 190,
+	types: ["Metal"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ツメできりさく" },
+			damage: 60,
+			cost: ["Colorless", "Colorless", "Colorless"],
+		},
+		{
+			name: { ja: "メテオテンペスト" },
+			damage: 220,
+			cost: ["Metal", "Metal", "Metal", "Colorless"],
+			effect: {
+				ja: "このポケモンについているエネルギーを、3個トラッシュする。",
+			},
+		},
+		{
+			name: { ja: "イクリプスサンGX" },
+			damage: 250,
+			cost: ["Metal", "Metal", "Metal"],
+			effect: {
+				ja: "このワザは、自分のサイドの残り枚数が、相手より多いときにしか使えない。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 560028,
+			},
+		},
+	],
+
+	retreat: 3,
+	rarity: "Hyper rare",
+	dexId: [800],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM5S/075.ts
+++ b/data-asia/SM/SM5S/075.ts
@@ -1,0 +1,62 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM5S";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ディアルガGX",
+	},
+
+	illustrator: "",
+	category: "Pokemon",
+	hp: 180,
+	types: ["Dragon"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "クロックアップ" },
+			cost: ["Metal"],
+			effect: {
+				ja: "自分の手札が6枚になるように、山札を引く。",
+			},
+		},
+		{
+			name: { ja: "ひきさく" },
+			damage: 80,
+			cost: ["Metal", "Colorless", "Colorless"],
+			effect: {
+				ja: "このワザのダメージは、相手のバトルポケモンにかかっている効果を計算しない。",
+			},
+		},
+		{
+			name: { ja: "タイムレスGX" },
+			damage: 150,
+			cost: ["Metal", "Metal", "Metal", "Colorless", "Colorless"],
+			effect: {
+				ja: "この番が終わったら、もう1回自分の番を始める。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fairy", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 560029,
+			},
+		},
+	],
+
+	retreat: 3,
+	rarity: "Hyper rare",
+	dexId: [483],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM5S/076.ts
+++ b/data-asia/SM/SM5S/076.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM5S";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "のぞきみレッドカード",
+	},
+
+	illustrator: "",
+	category: "Trainer",
+
+	effect: {
+		ja: "相手の手札を見る。のぞむなら、相手に相手自身の手札を数えさせたあと、すべて山札にもどして切らせる。その場合、相手はもどした枚数ぶん山札を引く。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 560030,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	rarity: "Secret Rare",
+};
+
+export default card;

--- a/data-asia/SM/SM5S/077.ts
+++ b/data-asia/SM/SM5S/077.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM5S";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ミッシングクローバー",
+	},
+
+	illustrator: "",
+	category: "Trainer",
+
+	effect: {
+		ja: "「ミッシングクローバー」は、1枚または4枚同時に使え、使った枚数によって効果が変わる。◆1枚使ったなら、自分の山札を上から1枚見て、もとにもどす。◆4枚同時に使ったなら、自分のサイドを1枚とる。（この効果は、4枚で1回はたらく。）",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 560031,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	rarity: "Secret Rare",
+};
+
+export default card;

--- a/data-asia/SM/SM5S/078.ts
+++ b/data-asia/SM/SM5S/078.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM5S";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ユニットエネルギー草炎水",
+	},
+
+	illustrator: "",
+	category: "Energy",
+	energyType: "Special",
+
+	effect: {
+		ja: "このカードは、ポケモンについているかぎり、[草][炎][水]の3つのタイプのエネルギー1個ぶんとしてはたらく。ポケモンについていないなら、[無]エネルギー1個ぶんとしてはたらく。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 560032,
+			},
+		},
+	],
+
+	rarity: "Secret Rare",
+};
+
+export default card;


### PR DESCRIPTION
## What

Adds the complete Japanese set **SM5S ウルトラサン (Ultra Sun)**, released 2017-12-08:

- `data-asia/SM/SM5S/001.ts` … `078.ts` — all 78 cards (66 regular + 12 secret rares: 6 SR, 3 Secret Rare, 3 UR)
- the set definition `data-asia/SM/SM5S.ts` already existed and is untouched

## Data sources

- **pokemon-card.com** (official database): Japanese names, flavor texts, National Dex numbers, official card count
- **limitlesstcg.com**: full Japanese card text, stages, weaknesses/resistances/retreat, rarities, illustrators, attack costs
- **Cardmarket**: product IDs as `thirdParty.cardmarket` on the variant objects (559955–560032; tcgplayer IDs not available to me)

## Notes

- Follows the file format and conventions of the M-era sets (#1728)
- No `regulationMark` (the set predates regulation marks); resistances are `-20` per the era
- All 78 files type-check against `interfaces.d.ts` (`tsc --noEmit`)
