### PR TITLE
(data) Add Japanese SM set SM5p Ultra Force

### DIFF
--- a/data-asia/SM/SM5p.ts
+++ b/data-asia/SM/SM5p.ts
@@ -1,0 +1,20 @@
+import { Set } from "../../interfaces";
+import serie from "../SM";
+
+const set: Set = {
+	id: "SM5p",
+	name: {
+		ja: "ウルトラフォース",
+	},
+
+	serie: serie,
+
+	cardCount: {
+		official: 50,
+	},
+	releaseDate: {
+		ja: "2018-01-19",
+	},
+};
+
+export default set;

--- a/data-asia/SM/SM5p/001.ts
+++ b/data-asia/SM/SM5p/001.ts
@@ -1,0 +1,51 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM5p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ナエトル",
+	},
+
+	illustrator: "OOYAMA",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Grass"],
+
+	description: {
+		ja: "全身で 光合成を して 酸素を 作る。 のどが 渇くと 頭の 葉っぱが しおれてしまう。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "たいあたり" },
+			damage: 20,
+			cost: ["Colorless", "Colorless"],
+		},
+		{
+			name: { ja: "はっぱカッター" },
+			damage: 50,
+			cost: ["Grass", "Grass", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559751,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "None",
+	dexId: [387],
+};
+
+export default card;

--- a/data-asia/SM/SM5p/002.ts
+++ b/data-asia/SM/SM5p/002.ts
@@ -1,0 +1,58 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM5p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ハヤシガメ",
+	},
+
+	illustrator: "Shigenori Negishi",
+	category: "Pokemon",
+	hp: 110,
+	types: ["Grass"],
+
+	description: {
+		ja: "きれいな 水が わき出る 場所を 知っていて 仲間の ポケモンを 背中に 乗せて そこまで 運ぶ。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "メガドレイン" },
+			damage: 30,
+			cost: ["Grass", "Colorless"],
+			effect: {
+				ja: "このポケモンのHPを「30」回復する。",
+			},
+		},
+		{
+			name: { ja: "はっぱカッター" },
+			damage: 80,
+			cost: ["Grass", "Grass", "Grass", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559752,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ナエトル",
+	},
+
+	retreat: 4,
+	rarity: "None",
+	dexId: [388],
+};
+
+export default card;

--- a/data-asia/SM/SM5p/003.ts
+++ b/data-asia/SM/SM5p/003.ts
@@ -1,0 +1,49 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM5p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ユキカブリ",
+	},
+
+	illustrator: "match",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Grass"],
+
+	description: {
+		ja: "春になると アイスキャンディーの ような 食感の 木の実が お腹の まわりに 生る。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "こおりのつぶて" },
+			damage: "20+",
+			cost: ["Grass", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンが[闘]ポケモンなら、40ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559753,
+			},
+		},
+	],
+
+	retreat: 3,
+	rarity: "None",
+	dexId: [459],
+};
+
+export default card;

--- a/data-asia/SM/SM5p/004.ts
+++ b/data-asia/SM/SM5p/004.ts
@@ -1,0 +1,63 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM5p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ユキノオー",
+	},
+
+	illustrator: "Masakazu Fukuda",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Grass"],
+
+	description: {
+		ja: "万年雪が 積もる 山脈で 静かに 暮らす。 ブリザードを 発生させて 姿を 隠す。",
+	},
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "じゅひょうのめぐみ" },
+			effect: {
+				ja: "自分の番に、このカードを手札から出して進化させたとき、1回使える。自分のトラッシュにある[草]エネルギーを1枚、自分のポケモンにつける。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ヒプノハンマー" },
+			damage: 80,
+			cost: ["Grass", "Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをねむりにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559754,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ユキカブリ",
+	},
+
+	retreat: 3,
+	rarity: "None",
+	dexId: [460],
+};
+
+export default card;

--- a/data-asia/SM/SM5p/005.ts
+++ b/data-asia/SM/SM5p/005.ts
@@ -1,0 +1,49 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM5p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヒコザル",
+	},
+
+	illustrator: "Kouki Saitou",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Fire"],
+
+	description: {
+		ja: "お腹で 作られた ガスが お尻で 燃えている。 体調が 悪いと 炎が 弱くなる。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "みだれひっかき" },
+			damage: "10×",
+			cost: ["Colorless"],
+			effect: {
+				ja: "コインを3回投げ、オモテの数x10ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559755,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "None",
+	dexId: [390],
+};
+
+export default card;

--- a/data-asia/SM/SM5p/006.ts
+++ b/data-asia/SM/SM5p/006.ts
@@ -1,0 +1,53 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM5p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "モウカザル",
+	},
+
+	illustrator: "Shigenori Negishi",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Fire"],
+
+	description: {
+		ja: "天井や 壁を 利用して 空中殺法を 繰り出す。 尻尾の 炎も 武器の ひとつ。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "ほのおでこがす" },
+			damage: 20,
+			cost: ["Fire"],
+			effect: {
+				ja: "相手のバトルポケモンをやけどにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559756,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ヒコザル",
+	},
+
+	retreat: 1,
+	rarity: "None",
+	dexId: [391],
+};
+
+export default card;

--- a/data-asia/SM/SM5p/007.ts
+++ b/data-asia/SM/SM5p/007.ts
@@ -1,0 +1,57 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM5p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヒードラン",
+	},
+
+	illustrator: "tetsuya koizumi",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Fire"],
+
+	description: {
+		ja: "マグマのように 燃えたぎる 血液が 体を 流れている。 火山の 洞穴に 生息する。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ガードプレス" },
+			damage: 30,
+			cost: ["Fire", "Colorless"],
+			effect: {
+				ja: "次の相手の番、このポケモンが受けるワザのダメージは「-30」される。",
+			},
+		},
+		{
+			name: { ja: "ボイラーインパクト" },
+			damage: 130,
+			cost: ["Fire", "Fire", "Colorless"],
+			effect: {
+				ja: "このポケモンについているエネルギーを、2個トラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559757,
+			},
+		},
+	],
+
+	retreat: 3,
+	rarity: "None",
+	dexId: [485],
+};
+
+export default card;

--- a/data-asia/SM/SM5p/008.ts
+++ b/data-asia/SM/SM5p/008.ts
@@ -1,0 +1,51 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM5p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ポッチャマ",
+	},
+
+	illustrator: "Shibuzoh.",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Water"],
+
+	description: {
+		ja: "プライドが 高く 人から 食べ物を もらう ことを 嫌う。 長い 産毛が 寒さを 防ぐ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "つつく" },
+			damage: 10,
+			cost: ["Colorless"],
+		},
+		{
+			name: { ja: "スプラッシュ" },
+			damage: 20,
+			cost: ["Water", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559758,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "None",
+	dexId: [393],
+};
+
+export default card;

--- a/data-asia/SM/SM5p/009.ts
+++ b/data-asia/SM/SM5p/009.ts
@@ -1,0 +1,58 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM5p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ポッタイシ",
+	},
+
+	illustrator: "Mizue",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Water"],
+
+	description: {
+		ja: "仲間を 作らずに 暮らす。 翼の 強烈な 一撃は 大木を 真っ二つに へし折る。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "バブルこうせん" },
+			damage: 20,
+			cost: ["Water"],
+			effect: {
+				ja: "コインを1回投げオモテなら、相手のバトルポケモンをマヒにする。",
+			},
+		},
+		{
+			name: { ja: "スプラッシュ" },
+			damage: 40,
+			cost: ["Water", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559759,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ポッチャマ",
+	},
+
+	retreat: 2,
+	rarity: "None",
+	dexId: [394],
+};
+
+export default card;

--- a/data-asia/SM/SM5p/010.ts
+++ b/data-asia/SM/SM5p/010.ts
@@ -1,0 +1,62 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM5p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "パルキアGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 180,
+	types: ["Water"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "くうかんせいぎょ" },
+			cost: ["Water"],
+			effect: {
+				ja: "自分のベンチポケモンについているエネルギーを好きなだけ、このポケモンにつけ替える。",
+			},
+		},
+		{
+			name: { ja: "ハイドロプレッシャー" },
+			damage: "60+",
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンについている[水]エネルギーの数x20ダメージ追加。",
+			},
+		},
+		{
+			name: { ja: "ゼロバニッシュGX" },
+			damage: 150,
+			cost: ["Water", "Water", "Water", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手の場のポケモンについているエネルギーを、すべて山札にもどして切る。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 559760,
+			},
+		},
+	],
+
+	retreat: 3,
+	rarity: "Double rare",
+	dexId: [484],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM5p/011.ts
+++ b/data-asia/SM/SM5p/011.ts
@@ -1,0 +1,53 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM5p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "シズクモ",
+	},
+
+	illustrator: "sui",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Water"],
+
+	description: {
+		ja: "獲物や 敵を 見つけると 頭に 被った 水泡を 弾いて 水を ぶつけるぞ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "かじる" },
+			damage: 10,
+			cost: ["Colorless"],
+		},
+		{
+			name: { ja: "クモのす" },
+			cost: ["Water"],
+			effect: {
+				ja: "次の相手の番、このワザを受けたポケモンは、にげられない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559761,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "None",
+	dexId: [751],
+};
+
+export default card;

--- a/data-asia/SM/SM5p/012.ts
+++ b/data-asia/SM/SM5p/012.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM5p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "オニシズクモ",
+	},
+
+	illustrator: "kodama",
+	category: "Pokemon",
+	hp: 100,
+	types: ["Water"],
+
+	description: {
+		ja: "見かけに よらず 面倒見が いい。 弱く 小さな 仲間を 見つけると 水泡の 中に 入れて 守る。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "あわ" },
+			damage: 30,
+			cost: ["Water"],
+			effect: {
+				ja: "コインを1回投げオモテなら、相手のバトルポケモンをマヒにする。",
+			},
+		},
+		{
+			name: { ja: "バブルトラップ" },
+			damage: "40+",
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "前の自分の番、自分のポケモンが「あわ」を使っていたなら、80ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559762,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "シズクモ",
+	},
+
+	retreat: 1,
+	rarity: "None",
+	dexId: [752],
+};
+
+export default card;

--- a/data-asia/SM/SM5p/013.ts
+++ b/data-asia/SM/SM5p/013.ts
@@ -1,0 +1,53 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM5p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "コイル",
+	},
+
+	illustrator: "MAHOU",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Lightning"],
+
+	description: {
+		ja: "電磁波を 放ち 空を 漂う。 電気を 喰っているときに 触ると 全身が ビリッと 痺れるぞ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "マグネサーチ" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札にある[雷]エネルギーを3枚まで、相手に見せてから、手札に加える。そして山札を切る。",
+			},
+		},
+		{
+			name: { ja: "たいあたり" },
+			damage: 10,
+			cost: ["Lightning"],
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Metal", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559763,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "None",
+	dexId: [81],
+};
+
+export default card;

--- a/data-asia/SM/SM5p/014.ts
+++ b/data-asia/SM/SM5p/014.ts
@@ -1,0 +1,58 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM5p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "レアコイル",
+	},
+
+	illustrator: "kirisAki",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Lightning"],
+
+	description: {
+		ja: "ほぼ コイル ３倍の 電力。 太陽の黒点が 多いとき なぜか 大量発生。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "ぶつかる" },
+			damage: 20,
+			cost: ["Lightning"],
+		},
+		{
+			name: { ja: "でんじほう" },
+			damage: 80,
+			cost: ["Lightning", "Lightning", "Colorless"],
+			effect: {
+				ja: "次の自分の番、このポケモンは「でんじほう」が使えない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Metal", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559764,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "コイル",
+	},
+
+	retreat: 2,
+	rarity: "None",
+	dexId: [82],
+};
+
+export default card;

--- a/data-asia/SM/SM5p/015.ts
+++ b/data-asia/SM/SM5p/015.ts
@@ -1,0 +1,63 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM5p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ジバコイル",
+	},
+
+	illustrator: "Yoshinobu Saito",
+	category: "Pokemon",
+	hp: 150,
+	types: ["Lightning"],
+
+	description: {
+		ja: "怪電波を 発信 しながら 空を 飛び回り 未知の 電波を 受信 していると いう。",
+	},
+
+	stage: "Stage2",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "マグネサーキット" },
+			effect: {
+				ja: "自分の番に何回でも使える。自分の手札にある[雷]エネルギーを1枚、自分のポケモンにつける。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "でんじほう" },
+			damage: 130,
+			cost: ["Lightning", "Lightning", "Lightning", "Colorless"],
+			effect: {
+				ja: "次の自分の番、このポケモンは「でんじほう」が使えない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Metal", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559765,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "レアコイル",
+	},
+
+	retreat: 2,
+	rarity: "None",
+	dexId: [462],
+};
+
+export default card;

--- a/data-asia/SM/SM5p/016.ts
+++ b/data-asia/SM/SM5p/016.ts
@@ -1,0 +1,57 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM5p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "デンジュモク",
+	},
+
+	illustrator: "Shin Nagasawa",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Lightning"],
+
+	description: {
+		ja: "ウルトラホールから 出現した。 発電所を 襲撃 したため 電気が エネルギーと おもわれる。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "せんこうだん" },
+			damage: 20,
+			cost: ["Lightning"],
+			effect: {
+				ja: "相手のバトルポケモンをこんらんにする。",
+			},
+		},
+		{
+			name: { ja: "ケーブルグラム" },
+			damage: 100,
+			cost: ["Lightning", "Lightning", "Colorless"],
+			effect: {
+				ja: "自分のサイドの残り枚数が3枚なら、相手のバトルポケモンをマヒにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Metal", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559766,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "None",
+	dexId: [796],
+};
+
+export default card;

--- a/data-asia/SM/SM5p/017.ts
+++ b/data-asia/SM/SM5p/017.ts
@@ -1,0 +1,59 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM5p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ロトム",
+	},
+
+	illustrator: "Naoyo Kimura",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Psychic"],
+
+	description: {
+		ja: "プラズマで できた 体を 持つ。 電化製品に 潜りこみ 悪さを することで 知られている。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ロトモーター" },
+			effect: {
+				ja: "自分のトラッシュに「ポケモンのどうぐ」が9枚以上あるなら、このポケモンが使うワザに必要なエネルギーは、すべてなくなる。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "プラズマスラッシュ" },
+			damage: 120,
+			cost: ["Psychic", "Psychic", "Psychic"],
+			effect: {
+				ja: "次の自分の番、このポケモンはワザが使えない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559767,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "None",
+	dexId: [479],
+};
+
+export default card;

--- a/data-asia/SM/SM5p/018.ts
+++ b/data-asia/SM/SM5p/018.ts
@@ -1,0 +1,49 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM5p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ユクシー",
+	},
+
+	illustrator: "Shin Nagasawa",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Psychic"],
+
+	description: {
+		ja: "ユクシーの 誕生により 人々の 生活を 豊かにする 知恵が 生まれたと 言われている。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "メモリースキップ" },
+			damage: 30,
+			cost: ["Psychic"],
+			effect: {
+				ja: "相手のバトルポケモンが持っているワザを1つ選ぶ。次の相手の番、このワザを受けたポケモンは、選ばれたワザを使えない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559768,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "None",
+	dexId: [480],
+};
+
+export default card;

--- a/data-asia/SM/SM5p/019.ts
+++ b/data-asia/SM/SM5p/019.ts
@@ -1,0 +1,59 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM5p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "エムリット",
+	},
+
+	illustrator: "kodama",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Psychic"],
+
+	description: {
+		ja: "湖の 底で 眠っているが 魂が 抜け出して 水面を 飛び回ると 言われている。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "せいじゃくのなみ" },
+			effect: {
+				ja: "自分の場に「アグノム」がいるなら、相手のポケモン全員の抵抗力は、すべてなくなる。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "マインドスプラッシュ" },
+			damage: "20+",
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "自分のベンチに「ユクシー」がいるなら、50ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559769,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "None",
+	dexId: [481],
+};
+
+export default card;

--- a/data-asia/SM/SM5p/020.ts
+++ b/data-asia/SM/SM5p/020.ts
@@ -1,0 +1,56 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM5p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アグノム",
+	},
+
+	illustrator: "sui",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Psychic"],
+
+	description: {
+		ja: "ユクシー エムリット アグノムは 同じ タマゴから 生まれた ポケモンと 考えられている。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "サイコアブダクション" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "このワザは、後攻プレイヤーの最初の番にだけ使える。相手のベンチポケモン1匹と、そのポケモンについているすべてのカードを、相手の山札にもどして切る。",
+			},
+		},
+		{
+			name: { ja: "さいみんはどう" },
+			damage: 10,
+			cost: ["Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをねむりにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559770,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "None",
+	dexId: [482],
+};
+
+export default card;

--- a/data-asia/SM/SM5p/021.ts
+++ b/data-asia/SM/SM5p/021.ts
@@ -1,0 +1,57 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM5p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ネクロズマ あかつきのつばさ",
+	},
+
+	illustrator: "Shin Nagasawa",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Psychic"],
+
+	description: {
+		ja: "ルナアーラに 最早 意思は ない。 ネクロズマに 支配され すべての エネルギーを 放出 し続ける。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ガルフストリーム" },
+			damage: "20+",
+			cost: ["Psychic"],
+			effect: {
+				ja: "自分のサイドの残り枚数が6枚なら、このポケモンにのっているダメカンの数x20ダメージ追加。",
+			},
+		},
+		{
+			name: { ja: "あかつきのやいば" },
+			damage: 130,
+			cost: ["Psychic", "Psychic", "Psychic"],
+			effect: {
+				ja: "このポケモンについているエネルギーを、2個トラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559771,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "None",
+	dexId: [800],
+};
+
+export default card;

--- a/data-asia/SM/SM5p/022.ts
+++ b/data-asia/SM/SM5p/022.ts
@@ -1,0 +1,55 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM5p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ベベノム",
+	},
+
+	illustrator: "Megumi Mizutani",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Psychic"],
+
+	description: {
+		ja: "異世界に おいては 旅立ちの パートナーに 選ばれるほど 親しまれている ウルトラビースト。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "どくえき" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをどくにする。",
+			},
+		},
+		{
+			name: { ja: "コープスリバイバー" },
+			cost: ["Psychic", "Colorless"],
+			effect: {
+				ja: "次の相手の番、このポケモンがきぜつしても、相手はサイドをとれない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559772,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "None",
+	dexId: [803],
+};
+
+export default card;

--- a/data-asia/SM/SM5p/023.ts
+++ b/data-asia/SM/SM5p/023.ts
@@ -1,0 +1,66 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM5p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アーゴヨンGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 210,
+	types: ["Psychic"],
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "ビーストレイド" },
+			damage: "20×",
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の場の「ウルトラビースト」の数x20ダメージ。",
+			},
+		},
+		{
+			name: { ja: "ジェットタッカー" },
+			damage: 110,
+			cost: ["Psychic", "Colorless", "Colorless"],
+			effect: {
+				ja: "このワザのダメージは弱点・抵抗力を計算しない。",
+			},
+		},
+		{
+			name: { ja: "スティンガーGX" },
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "おたがいのプレイヤーは、それぞれサイドをすべて山札にもどして切る。その後、それぞれ山札を上から3枚、サイドとして置く。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 559773,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ベベノム",
+	},
+
+	retreat: 1,
+	rarity: "Double rare",
+	dexId: [804],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM5p/024.ts
+++ b/data-asia/SM/SM5p/024.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM5p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ドダイトス",
+	},
+
+	illustrator: "kawayoo",
+	category: "Pokemon",
+	hp: 180,
+	types: ["Fighting"],
+
+	description: {
+		ja: "小さな ポケモンたちが 集まり 動かない ドダイトスの 背中で 巣作りを はじめることがある。",
+	},
+
+	stage: "Stage2",
+
+	attacks: [
+		{
+			name: { ja: "ギガドレイン" },
+			damage: 50,
+			cost: ["Fighting", "Fighting", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンに与えたダメージぶん、このポケモンのHPを回復する。",
+			},
+		},
+		{
+			name: { ja: "じしん" },
+			damage: 180,
+			cost: ["Fighting", "Fighting", "Fighting", "Colorless"],
+			effect: {
+				ja: "自分のベンチポケモン全員にも、それぞれ20ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559774,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ハヤシガメ",
+	},
+
+	retreat: 4,
+	rarity: "None",
+	dexId: [389],
+};
+
+export default card;

--- a/data-asia/SM/SM5p/025.ts
+++ b/data-asia/SM/SM5p/025.ts
@@ -1,0 +1,63 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM5p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ゴウカザル",
+	},
+
+	illustrator: "nagimiso",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Fighting"],
+
+	description: {
+		ja: "素早さで 相手を 翻弄する。 両手 両足を 使った 独特の 戦い方を する。",
+	},
+
+	stage: "Stage2",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "あつきとうし" },
+			effect: {
+				ja: "このポケモンがいるかぎり、相手のバトルポケモンは、やけどでのせるダメカンの数が6個になる。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "バーストパンチ" },
+			damage: 50,
+			cost: ["Fighting", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをやけどにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559775,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "モウカザル",
+	},
+
+	retreat: 1,
+	rarity: "None",
+	dexId: [392],
+};
+
+export default card;

--- a/data-asia/SM/SM5p/026.ts
+++ b/data-asia/SM/SM5p/026.ts
@@ -1,0 +1,48 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM5p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "フカマル",
+	},
+
+	illustrator: "Kyoko Umemoto",
+	category: "Pokemon",
+	hp: 50,
+	types: ["Fighting"],
+
+	description: {
+		ja: "穴倉に 潜み 獲物や 敵が 横切ると 飛びだして 噛みつく。 勢い余り 歯が 欠けることも。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "かくせい" },
+			cost: ["Fighting"],
+			effect: {
+				ja: "このポケモンから進化するカードを、自分の山札から1枚選び、このポケモンにのせて進化させる。そして山札を切る。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559776,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "None",
+	dexId: [443],
+};
+
+export default card;

--- a/data-asia/SM/SM5p/027.ts
+++ b/data-asia/SM/SM5p/027.ts
@@ -1,0 +1,57 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM5p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ガバイト",
+	},
+
+	illustrator: "Sumiyoshi Kizuki",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Fighting"],
+
+	description: {
+		ja: "光り 輝くものが 大好き。 宝石や 捕まえた メレシーを 巣穴で じーっと 眺めている。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "かくせい" },
+			cost: ["Fighting"],
+			effect: {
+				ja: "このポケモンから進化するカードを、自分の山札から1枚選び、このポケモンにのせて進化させる。そして山札を切る。",
+			},
+		},
+		{
+			name: { ja: "きりさく" },
+			damage: 40,
+			cost: ["Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559777,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "フカマル",
+	},
+
+	retreat: 1,
+	rarity: "None",
+	dexId: [444],
+};
+
+export default card;

--- a/data-asia/SM/SM5p/028.ts
+++ b/data-asia/SM/SM5p/028.ts
@@ -1,0 +1,60 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM5p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ガブリアス",
+	},
+
+	illustrator: "Megumi Mizutani",
+	category: "Pokemon",
+	hp: 150,
+	types: ["Fighting"],
+
+	description: {
+		ja: "頭に ついた ２つの 突起は センサーの 役目。 遥か 先の 獲物の 様子も わかる。",
+	},
+
+	stage: "Stage2",
+
+	attacks: [
+		{
+			name: { ja: "クイックダイブ" },
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "相手のポケモン1匹に、50ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+			},
+		},
+		{
+			name: { ja: "おうじゃのやいば" },
+			damage: "100+",
+			cost: ["Fighting", "Colorless", "Colorless"],
+			effect: {
+				ja: "この番、手札から「シロナ」を出して使っていたなら、100ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559778,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ガバイト",
+	},
+
+	retreat: 0,
+	rarity: "None",
+	dexId: [445],
+};
+
+export default card;

--- a/data-asia/SM/SM5p/029.ts
+++ b/data-asia/SM/SM5p/029.ts
@@ -1,0 +1,53 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM5p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "リオル",
+	},
+
+	illustrator: "Kyoko Umemoto",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Fighting"],
+
+	description: {
+		ja: "一晩中 走っていられる タフさが あり 頑張り屋 だが まだまだ ひよっ子 なのだ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "みきり" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "コインを1回投げオモテなら、次の相手の番、このポケモンはワザのダメージや効果を受けない。",
+			},
+		},
+		{
+			name: { ja: "ジャブ" },
+			damage: 10,
+			cost: ["Fighting"],
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559779,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "None",
+	dexId: [447],
+};
+
+export default card;

--- a/data-asia/SM/SM5p/030.ts
+++ b/data-asia/SM/SM5p/030.ts
@@ -1,0 +1,64 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM5p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ルカリオGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 210,
+	types: ["Fighting"],
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "はどうげき" },
+			damage: "30+",
+			cost: ["Fighting"],
+			effect: {
+				ja: "この番、このポケモンが「リオル」から進化していたなら、90ダメージ追加。",
+			},
+		},
+		{
+			name: { ja: "せんぷうきゃく" },
+			damage: 130,
+			cost: ["Fighting", "Fighting", "Colorless"],
+		},
+		{
+			name: { ja: "クロスビートGX" },
+			damage: "30×",
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンにのっているダメカンの数x30ダメージ。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 559780,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "リオル",
+	},
+
+	retreat: 2,
+	rarity: "Double rare",
+	dexId: [448],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM5p/031.ts
+++ b/data-asia/SM/SM5p/031.ts
@@ -1,0 +1,49 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM5p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "グレッグル",
+	},
+
+	illustrator: "SATOSHI NAKAI",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Fighting"],
+
+	description: {
+		ja: "毒袋を ふくらませて 鳴らし 辺りに 不気味な 音を 響かせ 相手が ひるむと どくづきをする。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "いばる" },
+			damage: 10,
+			cost: ["Fighting"],
+			effect: {
+				ja: "コインを1回投げオモテなら、相手のバトルポケモンについているエネルギーを、1個トラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559781,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "None",
+	dexId: [453],
+};
+
+export default card;

--- a/data-asia/SM/SM5p/032.ts
+++ b/data-asia/SM/SM5p/032.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM5p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ドクロッグ",
+	},
+
+	illustrator: "Hasuno",
+	category: "Pokemon",
+	hp: 100,
+	types: ["Fighting"],
+
+	description: {
+		ja: "こぶしの トゲからは かすり傷でも 命を 落とすほどの 猛毒を 分泌する。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "どくづき" },
+			damage: 30,
+			cost: ["Fighting"],
+			effect: {
+				ja: "相手のバトルポケモンをどくにする。",
+			},
+		},
+		{
+			name: { ja: "むねんをはらす" },
+			damage: "50+",
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "前の相手の番に、ワザのダメージで、自分の[超]ポケモンがきぜつしていたなら、70ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559782,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "グレッグル",
+	},
+
+	retreat: 2,
+	rarity: "None",
+	dexId: [454],
+};
+
+export default card;

--- a/data-asia/SM/SM5p/033.ts
+++ b/data-asia/SM/SM5p/033.ts
@@ -1,0 +1,57 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM5p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "マッシブーン",
+	},
+
+	illustrator: "Masakazu Fukuda",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Fighting"],
+
+	description: {
+		ja: "謎の 生物 ＵＢ。 一発の パンチで ダンプカーを 粉砕する 光景が 目撃 された。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "スレッジハンマー" },
+			damage: "30+",
+			cost: ["Fighting"],
+			effect: {
+				ja: "相手のサイドの残り枚数が4枚なら、90ダメージ追加。",
+			},
+		},
+		{
+			name: { ja: "ふりまわす" },
+			damage: "80+",
+			cost: ["Fighting", "Fighting", "Colorless"],
+			effect: {
+				ja: "コインを2回投げ、オモテの数x20ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559783,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "None",
+	dexId: [794],
+};
+
+export default card;

--- a/data-asia/SM/SM5p/034.ts
+++ b/data-asia/SM/SM5p/034.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM5p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "エンペルト",
+	},
+
+	illustrator: "nagimiso",
+	category: "Pokemon",
+	hp: 160,
+	types: ["Metal"],
+
+	description: {
+		ja: "クチバシから 伸びている ３本の ツノは 強さの 象徴。 リーダーが 一番 大きい。",
+	},
+
+	stage: "Stage2",
+
+	attacks: [
+		{
+			name: { ja: "トータルコマンド" },
+			damage: "20×",
+			cost: ["Metal", "Colorless"],
+			effect: {
+				ja: "おたがいのベンチポケモンの数x20ダメージ。",
+			},
+		},
+		{
+			name: { ja: "うずしお" },
+			damage: 90,
+			cost: ["Metal", "Metal", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンについているエネルギーを、1個トラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559784,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ポッタイシ",
+	},
+
+	retreat: 2,
+	rarity: "None",
+	dexId: [395],
+};
+
+export default card;

--- a/data-asia/SM/SM5p/035.ts
+++ b/data-asia/SM/SM5p/035.ts
@@ -1,0 +1,62 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM5p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ディアルガGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 180,
+	types: ["Metal"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "クロックアップ" },
+			cost: ["Metal"],
+			effect: {
+				ja: "自分の手札が6枚になるように、山札を引く。",
+			},
+		},
+		{
+			name: { ja: "ひきさく" },
+			damage: 80,
+			cost: ["Metal", "Colorless", "Colorless"],
+			effect: {
+				ja: "このワザのダメージは、相手のバトルポケモンにかかっている効果を計算しない。",
+			},
+		},
+		{
+			name: { ja: "タイムレスGX" },
+			damage: 150,
+			cost: ["Metal", "Metal", "Metal", "Colorless", "Colorless"],
+			effect: {
+				ja: "この番が終わったら、もう1回自分の番を始める。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 559785,
+			},
+		},
+	],
+
+	retreat: 3,
+	rarity: "Double rare",
+	dexId: [483],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM5p/036.ts
+++ b/data-asia/SM/SM5p/036.ts
@@ -1,0 +1,56 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM5p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ネクロズマ たそがれのたてがみ",
+	},
+
+	illustrator: "Shin Nagasawa",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Metal"],
+
+	description: {
+		ja: "ソルガレオの光を 喰らい続ける 姿。 敵に とびかかり 背中と 四肢のツメで 相手を 切り裂く。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "たそがれのだんがん" },
+			cost: ["Metal"],
+			effect: {
+				ja: "相手の「ポケモンGX・EX」1匹に、60ダメージ。このワザのダメージは、弱点・抵抗力を計算しない。",
+			},
+		},
+		{
+			name: { ja: "ラスティネイル" },
+			damage: "100+",
+			cost: ["Metal", "Metal", "Colorless"],
+			effect: {
+				ja: "相手のサイドの残り枚数が1枚なら、100ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559786,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "None",
+	dexId: [800],
+};
+
+export default card;

--- a/data-asia/SM/SM5p/037.ts
+++ b/data-asia/SM/SM5p/037.ts
@@ -1,0 +1,59 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM5p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アルセウス",
+	},
+
+	illustrator: "Masakazu Fukuda",
+	category: "Pokemon",
+	hp: 160,
+	types: ["Colorless"],
+
+	description: {
+		ja: "宇宙が まだ ない ころに 最初に 生まれた ポケモンと 神話の 中で 語られている。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "はじまりのおきて" },
+			effect: {
+				ja: "このポケモンは、相手のポケモンが使うワザの効果を受けない。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "トリニティスター" },
+			damage: 30,
+			cost: ["Colorless"],
+			effect: {
+				ja: "このワザは、自分のベンチに[草]と[水]と[雷]ポケモンがいるときにしか使えない。自分の山札にある基本エネルギーを3枚まで、自分のポケモンに好きなようにつける。そして山札を切る。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 559787,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Rare Holo",
+	dexId: [493],
+};
+
+export default card;

--- a/data-asia/SM/SM5p/038.ts
+++ b/data-asia/SM/SM5p/038.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM5p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アクアパッチ",
+	},
+
+	illustrator: "Toyste Beach",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分のトラッシュにある[水]エネルギーを1枚、ベンチの[水]ポケモンにつける。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559788,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/SM/SM5p/039.ts
+++ b/data-asia/SM/SM5p/039.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM5p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "改造ハンマー",
+	},
+
+	illustrator: "Yoshinobu Saito",
+	category: "Trainer",
+
+	effect: {
+		ja: "相手のポケモンについている特殊エネルギーを1個選び、トラッシュする。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559789,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/SM/SM5p/040.ts
+++ b/data-asia/SM/SM5p/040.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM5p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "スーパーポケモン回収",
+	},
+
+	illustrator: "Toyste Beach",
+	category: "Trainer",
+
+	effect: {
+		ja: "コインを1回投げオモテなら、自分のポケモン1匹と、ついているすべてのカードを、手札にもどす。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559790,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/SM/SM5p/041.ts
+++ b/data-asia/SM/SM5p/041.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM5p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ビーストリング",
+	},
+
+	illustrator: "Toyste Beach",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードは、相手のサイドの残り枚数が、4枚または3枚でなければ使えない。自分の山札にある基本エネルギーを2枚まで、自分の「ウルトラビースト」1匹につける。そして山札を切る。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559791,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/SM/SM5p/042.ts
+++ b/data-asia/SM/SM5p/042.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM5p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "鋼鉄のフライパン",
+	},
+
+	illustrator: "Toyste Beach",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードをつけているポケモンは、相手のポケモンから受けるワザのダメージが「-30」され、弱点もなくなる。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559792,
+			},
+		},
+	],
+
+	trainerType: "Tool",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/SM/SM5p/043.ts
+++ b/data-asia/SM/SM5p/043.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM5p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "こだわりハチマキ",
+	},
+
+	illustrator: "Eske Yoshinob",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードをつけているポケモンが使うワザの、相手のバトル場の「ポケモンGX・EX」へのダメージは「+30」される。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559793,
+			},
+		},
+	],
+
+	trainerType: "Tool",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/SM/SM5p/044.ts
+++ b/data-asia/SM/SM5p/044.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM5p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ウルトラ調査隊",
+	},
+
+	illustrator: "Megumi Mizutani",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の手札にある「ウルトラビースト」を2枚までトラッシュし、その枚数x3枚、自分の山札を引く。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559794,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/SM/SM5p/045.ts
+++ b/data-asia/SM/SM5p/045.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM5p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ハンサム",
+	},
+
+	illustrator: "Ken Sugimori",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の山札を下から3枚引く。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559795,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/SM/SM5p/046.ts
+++ b/data-asia/SM/SM5p/046.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM5p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "マキシ",
+	},
+
+	illustrator: "Ken Sugimori",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードは、自分の手札にある[水]エネルギーを2枚トラッシュしなければ使えない。自分の山札にある好きなカードを2枚まで、手札に加える。そして山札を切る。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559796,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/SM/SM5p/047.ts
+++ b/data-asia/SM/SM5p/047.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM5p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ウルトラスペース",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Trainer",
+
+	effect: {
+		ja: "おたがいのプレイヤーは、自分の番ごとに1回、自分の山札にある「ウルトラビースト」を1枚、相手に見せてから、手札に加えてよい。その場合、山札を切る。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559797,
+			},
+		},
+	],
+
+	trainerType: "Stadium",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/SM/SM5p/048.ts
+++ b/data-asia/SM/SM5p/048.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM5p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ビーストエネルギー",
+	},
+
+	illustrator: "",
+	category: "Energy",
+	energyType: "Special",
+
+	effect: {
+		ja: "このカードは[無]エネルギー1個ぶんとしてはたらく。このカードは、自分の「ウルトラビースト」についているとき、すべてのタイプのエネルギー1個ぶんとしてはたらき、このカードをつけている「ウルトラビースト」が使うワザの、相手のバトルポケモンへのダメージは「+30」される。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 559798,
+			},
+		},
+	],
+
+	rarity: "Rare Holo",
+};
+
+export default card;

--- a/data-asia/SM/SM5p/049.ts
+++ b/data-asia/SM/SM5p/049.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM5p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ユニットエネルギー草炎水",
+	},
+
+	illustrator: "",
+	category: "Energy",
+	energyType: "Special",
+
+	effect: {
+		ja: "このカードは、ポケモンについているかぎり、[草][炎][水]の3つのタイプのエネルギー1個ぶんとしてはたらく。ポケモンについていないなら、[無]エネルギー1個ぶんとしてはたらく。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559799,
+			},
+		},
+	],
+
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/SM/SM5p/050.ts
+++ b/data-asia/SM/SM5p/050.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM5p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ユニットエネルギー雷超鋼",
+	},
+
+	illustrator: "",
+	category: "Energy",
+	energyType: "Special",
+
+	effect: {
+		ja: "このカードは、ポケモンについているかぎり、[雷][超][鋼]の3つのタイプのエネルギー1個ぶんとしてはたらく。ポケモンについていないなら、[無]エネルギー1個ぶんとしてはたらく。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559800,
+			},
+		},
+	],
+
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/SM/SM5p/051.ts
+++ b/data-asia/SM/SM5p/051.ts
@@ -1,0 +1,62 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM5p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "パルキアGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 180,
+	types: ["Water"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "くうかんせいぎょ" },
+			cost: ["Water"],
+			effect: {
+				ja: "自分のベンチポケモンについているエネルギーを好きなだけ、このポケモンにつけ替える。",
+			},
+		},
+		{
+			name: { ja: "ハイドロプレッシャー" },
+			damage: "60+",
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンについている[水]エネルギーの数x20ダメージ追加。",
+			},
+		},
+		{
+			name: { ja: "ゼロバニッシュGX" },
+			damage: 150,
+			cost: ["Water", "Water", "Water", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手の場のポケモンについているエネルギーを、すべて山札にもどして切る。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 559801,
+			},
+		},
+	],
+
+	retreat: 3,
+	rarity: "Ultra Rare",
+	dexId: [484],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM5p/052.ts
+++ b/data-asia/SM/SM5p/052.ts
@@ -1,0 +1,66 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM5p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アーゴヨンGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 210,
+	types: ["Psychic"],
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "ビーストレイド" },
+			damage: "20×",
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の場の「ウルトラビースト」の数x20ダメージ。",
+			},
+		},
+		{
+			name: { ja: "ジェットタッカー" },
+			damage: 110,
+			cost: ["Psychic", "Colorless", "Colorless"],
+			effect: {
+				ja: "このワザのダメージは弱点・抵抗力を計算しない。",
+			},
+		},
+		{
+			name: { ja: "スティンガーGX" },
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "おたがいのプレイヤーは、それぞれサイドをすべて山札にもどして切る。その後、それぞれ山札を上から3枚、サイドとして置く。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 559802,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ベベノム",
+	},
+
+	retreat: 1,
+	rarity: "Ultra Rare",
+	dexId: [804],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM5p/053.ts
+++ b/data-asia/SM/SM5p/053.ts
@@ -1,0 +1,64 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM5p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ルカリオGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 210,
+	types: ["Fighting"],
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "はどうげき" },
+			damage: "30+",
+			cost: ["Fighting"],
+			effect: {
+				ja: "この番、このポケモンが「リオル」から進化していたなら、90ダメージ追加。",
+			},
+		},
+		{
+			name: { ja: "せんぷうきゃく" },
+			damage: 130,
+			cost: ["Fighting", "Fighting", "Colorless"],
+		},
+		{
+			name: { ja: "クロスビートGX" },
+			damage: "30×",
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンにのっているダメカンの数x30ダメージ。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 559803,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "リオル",
+	},
+
+	retreat: 2,
+	rarity: "Ultra Rare",
+	dexId: [448],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM5p/054.ts
+++ b/data-asia/SM/SM5p/054.ts
@@ -1,0 +1,62 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM5p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ディアルガGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 180,
+	types: ["Metal"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "クロックアップ" },
+			cost: ["Metal"],
+			effect: {
+				ja: "自分の手札が6枚になるように、山札を引く。",
+			},
+		},
+		{
+			name: { ja: "ひきさく" },
+			damage: 80,
+			cost: ["Metal", "Colorless", "Colorless"],
+			effect: {
+				ja: "このワザのダメージは、相手のバトルポケモンにかかっている効果を計算しない。",
+			},
+		},
+		{
+			name: { ja: "タイムレスGX" },
+			damage: 150,
+			cost: ["Metal", "Metal", "Metal", "Colorless", "Colorless"],
+			effect: {
+				ja: "この番が終わったら、もう1回自分の番を始める。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 559804,
+			},
+		},
+	],
+
+	retreat: 3,
+	rarity: "Ultra Rare",
+	dexId: [483],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM5p/055.ts
+++ b/data-asia/SM/SM5p/055.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM5p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ウルトラ調査隊",
+	},
+
+	illustrator: "Megumi Mizutani",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の手札にある「ウルトラビースト」を2枚までトラッシュし、その枚数x3枚、自分の山札を引く。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 559805,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	rarity: "Ultra Rare",
+};
+
+export default card;

--- a/data-asia/SM/SM5p/056.ts
+++ b/data-asia/SM/SM5p/056.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM5p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "マキシ",
+	},
+
+	illustrator: "Naoki Saito",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードは、自分の手札にある[水]エネルギーを2枚トラッシュしなければ使えない。自分の山札にある好きなカードを2枚まで、手札に加える。そして山札を切る。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 559806,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	rarity: "Ultra Rare",
+};
+
+export default card;

--- a/data-asia/SM/SM5p/057.ts
+++ b/data-asia/SM/SM5p/057.ts
@@ -1,0 +1,62 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM5p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "パルキアGX",
+	},
+
+	illustrator: "",
+	category: "Pokemon",
+	hp: 180,
+	types: ["Water"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "くうかんせいぎょ" },
+			cost: ["Water"],
+			effect: {
+				ja: "自分のベンチポケモンについているエネルギーを好きなだけ、このポケモンにつけ替える。",
+			},
+		},
+		{
+			name: { ja: "ハイドロプレッシャー" },
+			damage: "60+",
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンについている[水]エネルギーの数x20ダメージ追加。",
+			},
+		},
+		{
+			name: { ja: "ゼロバニッシュGX" },
+			damage: 150,
+			cost: ["Water", "Water", "Water", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手の場のポケモンについているエネルギーを、すべて山札にもどして切る。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 559807,
+			},
+		},
+	],
+
+	retreat: 3,
+	rarity: "Hyper rare",
+	dexId: [484],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM5p/058.ts
+++ b/data-asia/SM/SM5p/058.ts
@@ -1,0 +1,66 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM5p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アーゴヨンGX",
+	},
+
+	illustrator: "",
+	category: "Pokemon",
+	hp: 210,
+	types: ["Psychic"],
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "ビーストレイド" },
+			damage: "20×",
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の場の「ウルトラビースト」の数x20ダメージ。",
+			},
+		},
+		{
+			name: { ja: "ジェットタッカー" },
+			damage: 110,
+			cost: ["Psychic", "Colorless", "Colorless"],
+			effect: {
+				ja: "このワザのダメージは弱点・抵抗力を計算しない。",
+			},
+		},
+		{
+			name: { ja: "スティンガーGX" },
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "おたがいのプレイヤーは、それぞれサイドをすべて山札にもどして切る。その後、それぞれ山札を上から3枚、サイドとして置く。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 559808,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ベベノム",
+	},
+
+	retreat: 1,
+	rarity: "Hyper rare",
+	dexId: [804],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM5p/059.ts
+++ b/data-asia/SM/SM5p/059.ts
@@ -1,0 +1,64 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM5p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ルカリオGX",
+	},
+
+	illustrator: "",
+	category: "Pokemon",
+	hp: 210,
+	types: ["Fighting"],
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "はどうげき" },
+			damage: "30+",
+			cost: ["Fighting"],
+			effect: {
+				ja: "この番、このポケモンが「リオル」から進化していたなら、90ダメージ追加。",
+			},
+		},
+		{
+			name: { ja: "せんぷうきゃく" },
+			damage: 130,
+			cost: ["Fighting", "Fighting", "Colorless"],
+		},
+		{
+			name: { ja: "クロスビートGX" },
+			damage: "30×",
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンにのっているダメカンの数x30ダメージ。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 559809,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "リオル",
+	},
+
+	retreat: 2,
+	rarity: "Hyper rare",
+	dexId: [448],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM5p/060.ts
+++ b/data-asia/SM/SM5p/060.ts
@@ -1,0 +1,62 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM5p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ディアルガGX",
+	},
+
+	illustrator: "",
+	category: "Pokemon",
+	hp: 180,
+	types: ["Metal"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "クロックアップ" },
+			cost: ["Metal"],
+			effect: {
+				ja: "自分の手札が6枚になるように、山札を引く。",
+			},
+		},
+		{
+			name: { ja: "ひきさく" },
+			damage: 80,
+			cost: ["Metal", "Colorless", "Colorless"],
+			effect: {
+				ja: "このワザのダメージは、相手のバトルポケモンにかかっている効果を計算しない。",
+			},
+		},
+		{
+			name: { ja: "タイムレスGX" },
+			damage: 150,
+			cost: ["Metal", "Metal", "Metal", "Colorless", "Colorless"],
+			effect: {
+				ja: "この番が終わったら、もう1回自分の番を始める。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 559810,
+			},
+		},
+	],
+
+	retreat: 3,
+	rarity: "Hyper rare",
+	dexId: [483],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM5p/061.ts
+++ b/data-asia/SM/SM5p/061.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM5p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "エネルギーリサイクル",
+	},
+
+	illustrator: "",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分のトラッシュから基本エネルギーを5枚選び、相手に見せてから、山札にもどす。そして山札を切る。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 559811,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	rarity: "Secret Rare",
+};
+
+export default card;

--- a/data-asia/SM/SM5p/062.ts
+++ b/data-asia/SM/SM5p/062.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM5p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ビーストリング",
+	},
+
+	illustrator: "",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードは、相手のサイドの残り枚数が、4枚または3枚でなければ使えない。自分の山札にある基本エネルギーを2枚まで、自分の「ウルトラビースト」1匹につける。そして山札を切る。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 559812,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	rarity: "Secret Rare",
+};
+
+export default card;

--- a/data-asia/SM/SM5p/063.ts
+++ b/data-asia/SM/SM5p/063.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM5p";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "鋼鉄のフライパン",
+	},
+
+	illustrator: "",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードをつけているポケモンは、相手のポケモンから受けるワザのダメージが「-30」され、弱点もなくなる。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 559813,
+			},
+		},
+	],
+
+	trainerType: "Tool",
+	rarity: "Secret Rare",
+};
+
+export default card;


### PR DESCRIPTION
## What

Adds the complete Japanese set **SM5p ウルトラフォース (Ultra Force)**, released 2018-01-19:

- `data-asia/SM/SM5p.ts` — set definition (50 official cards)
- `data-asia/SM/SM5p/001.ts` … `063.ts` — all 63 cards (50 regular + 13 secret rares: 6 SR, 3 Secret Rare, 4 UR)

## Data sources

- **pokemon-card.com** (official database): Japanese names, flavor texts, National Dex numbers, official card count
- **limitlesstcg.com**: full Japanese card text, stages, weaknesses/resistances/retreat, rarities, illustrators, attack costs
- **Cardmarket**: product IDs as `thirdParty.cardmarket` on the variant objects (559751–559813; tcgplayer IDs not available to me)

## Notes

- Follows the file format and conventions of the M-era sets (#1728)
- No `regulationMark` (the set predates regulation marks); resistances are `-20` per the era
- All 63 files type-check against `interfaces.d.ts` (`tsc --noEmit`)
