### PR TITLE
(data) Add Japanese SM set SM6 Forbidden Light

### DIFF
--- a/data-asia/SM/SM6/001.ts
+++ b/data-asia/SM/SM6/001.ts
@@ -1,0 +1,48 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "タマタマ",
+	},
+
+	illustrator: "Yuka Morii",
+	category: "Pokemon",
+	hp: 40,
+	types: ["Grass"],
+
+	description: {
+		ja: "６匹で １人前の ポケモン。 マケンカニに よく 狙われるが 念力を 使って 撃退する。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ふえる" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札にある「タマタマ」を1枚、ベンチに出す。そして山札を切る。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559546,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [102],
+};
+
+export default card;

--- a/data-asia/SM/SM6/002.ts
+++ b/data-asia/SM/SM6/002.ts
@@ -1,0 +1,53 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アローラナッシー",
+	},
+
+	illustrator: "Satoshi Shirai",
+	category: "Pokemon",
+	hp: 160,
+	types: ["Grass"],
+
+	description: {
+		ja: "伸び伸び 育って サイコパワーは いらなくなり 眠れる ドラゴンの 力が 覚醒 したのだ。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "トロピカルシェイク" },
+			damage: "20+",
+			cost: ["Grass"],
+			effect: {
+				ja: "自分のトラッシュにある基本エネルギーのタイプの数x20ダメージ追加。追加できるダメージはタイプ5種類ぶんまで。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 559547,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "タマタマ",
+	},
+
+	retreat: 3,
+	rarity: "Rare",
+	dexId: [103],
+};
+
+export default card;

--- a/data-asia/SM/SM6/003.ts
+++ b/data-asia/SM/SM6/003.ts
@@ -1,0 +1,56 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "コフキムシ",
+	},
+
+	illustrator: "kirisAki",
+	category: "Pokemon",
+	hp: 30,
+	types: ["Grass"],
+
+	description: {
+		ja: "体を 覆う 粉が 体温を 調節するので どんな 気候や 風土の 地域でも 暮らせる。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "いじょうはっせい" },
+			effect: {
+				ja: "後攻プレイヤーの最初の自分の番にだけ1回使える。自分の山札にある「コフーライ」「ビビヨン」を1枚ずつ、相手に見せてから、手札に加える。そして山札を切る。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "たいあたり" },
+			damage: 10,
+			cost: ["Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559548,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [664],
+};
+
+export default card;

--- a/data-asia/SM/SM6/004.ts
+++ b/data-asia/SM/SM6/004.ts
@@ -1,0 +1,48 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "コフキムシ",
+	},
+
+	illustrator: "Ken Sugimori",
+	category: "Pokemon",
+	hp: 40,
+	types: ["Grass"],
+
+	description: {
+		ja: "体を 覆う 粉が 体温を 調節するので どんな 気候や 風土の 地域でも 暮らせる。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ちょうしんか" },
+			cost: ["Grass"],
+			effect: {
+				ja: "コインを1回投げオモテなら、自分の山札にある「ビビヨン」を1枚、この「コフキムシ」にのせて進化させる。そして山札を切る。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559549,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [664],
+};
+
+export default card;

--- a/data-asia/SM/SM6/005.ts
+++ b/data-asia/SM/SM6/005.ts
@@ -1,0 +1,53 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "コフーライ",
+	},
+
+	illustrator: "Miki Tanaka",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Grass"],
+
+	description: {
+		ja: "硬い 体は とりポケモンの クチバシでも 傷ひとつ つかない。 粉を まき散らして 防戦する。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "いとをはく" },
+			damage: 20,
+			cost: ["Grass"],
+			effect: {
+				ja: "コインを1回投げオモテなら、相手のバトルポケモンをマヒにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559550,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "コフキムシ",
+	},
+
+	retreat: 2,
+	rarity: "Common",
+	dexId: [665],
+};
+
+export default card;

--- a/data-asia/SM/SM6/006.ts
+++ b/data-asia/SM/SM6/006.ts
@@ -1,0 +1,53 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ビビヨン",
+	},
+
+	illustrator: "Akira Komayama",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Grass"],
+
+	description: {
+		ja: "住んでいる 気候や 風土によって 羽の 模様が 違う ポケモン。 色鮮やかな りんぷんを まく。",
+	},
+
+	stage: "Stage2",
+
+	attacks: [
+		{
+			name: { ja: "ビビッドパウダー" },
+			damage: 50,
+			cost: ["Grass"],
+			effect: {
+				ja: "相手のバトルポケモンをどくとねむりにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559551,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "コフーライ",
+	},
+
+	retreat: 1,
+	rarity: "Uncommon",
+	dexId: [666],
+};
+
+export default card;

--- a/data-asia/SM/SM6/007.ts
+++ b/data-asia/SM/SM6/007.ts
@@ -1,0 +1,53 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "メェークル",
+	},
+
+	illustrator: "Suwama Chiaki",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Grass"],
+
+	description: {
+		ja: "水と 太陽が あれば 背中の 葉っぱで エネルギーが 作れるので エサを 食べなくても 平気なのだ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "せいちょう" },
+			cost: ["Grass"],
+			effect: {
+				ja: "自分の手札にある[草]エネルギーを1枚、このポケモンにつける。",
+			},
+		},
+		{
+			name: { ja: "はっぱカッター" },
+			damage: 40,
+			cost: ["Grass", "Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559552,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Common",
+	dexId: [672],
+};
+
+export default card;

--- a/data-asia/SM/SM6/008.ts
+++ b/data-asia/SM/SM6/008.ts
@@ -1,0 +1,60 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ゴーゴート",
+	},
+
+	illustrator: "Anesaki Dynamic",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Grass"],
+
+	description: {
+		ja: "山岳地帯で 生活する。 ツノを ぶつけ合う 力比べの 勝者が 群れの リーダーだ。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "ミルクのみ" },
+			cost: ["Grass"],
+			effect: {
+				ja: "コインを2回投げ、オモテの数x40ダメージぶん、このポケモンのHPを回復する。",
+			},
+		},
+		{
+			name: { ja: "すてみタックル" },
+			damage: 120,
+			cost: ["Grass", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンにも30ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559553,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "メェークル",
+	},
+
+	retreat: 2,
+	rarity: "Common",
+	dexId: [673],
+};
+
+export default card;

--- a/data-asia/SM/SM6/009.ts
+++ b/data-asia/SM/SM6/009.ts
@@ -1,0 +1,54 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "フェローチェ",
+	},
+
+	illustrator: "Hitoshi Ariga",
+	category: "Pokemon",
+	hp: 110,
+	types: ["Grass"],
+
+	description: {
+		ja: "ＵＢの 一種。 この世界の ものに けがれを 感じるのか 一切 手を 触れようと しない。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "とびひざげり" },
+			damage: 20,
+			cost: ["Colorless"],
+		},
+		{
+			name: { ja: "ホワイトレイ" },
+			damage: "90+",
+			cost: ["Grass", "Grass", "Colorless"],
+			effect: {
+				ja: "自分のサイドの残り枚数が1枚なら、90ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 559554,
+			},
+		},
+	],
+
+	retreat: 0,
+	rarity: "Rare",
+	dexId: [795],
+};
+
+export default card;

--- a/data-asia/SM/SM6/010.ts
+++ b/data-asia/SM/SM6/010.ts
@@ -1,0 +1,60 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アローラガラガラ",
+	},
+
+	illustrator: "Suwama Chiaki",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Fire"],
+
+	description: {
+		ja: "仲間を 弔う 習性。 道の すみに 盛り上がった 土が あったら それは ガラガラの 墓。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "リンボーリンボー" },
+			cost: [],
+			effect: {
+				ja: "自分の山札にある基本エネルギーを2枚まで、自分のポケモンに好きなようにつける。そして山札を切る。",
+			},
+		},
+		{
+			name: { ja: "アローラサークル" },
+			damage: "20×",
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "自分の場の、名前に「アローラ」とつくポケモンの数x20ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559555,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "カラカラ",
+	},
+
+	retreat: 2,
+	rarity: "Uncommon",
+	dexId: [105],
+};
+
+export default card;

--- a/data-asia/SM/SM6/011.ts
+++ b/data-asia/SM/SM6/011.ts
@@ -1,0 +1,49 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "フォッコ",
+	},
+
+	illustrator: "Ken Sugimori",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Fire"],
+
+	description: {
+		ja: "小枝を 持ち歩き おやつがわりに ポリポリ 食べる。 耳から 熱気を 噴き出して 相手を 威嚇する。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ひのこ" },
+			damage: 30,
+			cost: ["Fire"],
+			effect: {
+				ja: "このポケモンについているエネルギーを、1個トラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559556,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [653],
+};
+
+export default card;

--- a/data-asia/SM/SM6/012.ts
+++ b/data-asia/SM/SM6/012.ts
@@ -1,0 +1,51 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "フォッコ",
+	},
+
+	illustrator: "Atsuko Nishida",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Fire"],
+
+	description: {
+		ja: "小枝を 持ち歩き おやつがわりに ポリポリ 食べる。 耳から 熱気を 噴き出して 相手を 威嚇する。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ひだね" },
+			damage: 10,
+			cost: ["Fire"],
+		},
+		{
+			name: { ja: "うしろげり" },
+			damage: 20,
+			cost: ["Fire", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559557,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [653],
+};
+
+export default card;

--- a/data-asia/SM/SM6/013.ts
+++ b/data-asia/SM/SM6/013.ts
@@ -1,0 +1,58 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "テールナー",
+	},
+
+	illustrator: "Kagemaru Himeno",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Fire"],
+
+	description: {
+		ja: "木の枝を 尻尾から 引き抜くとき 摩擦で 着火。 枝の 炎を 振って 仲間に 合図を 送る。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "ほのお" },
+			damage: 20,
+			cost: ["Fire"],
+		},
+		{
+			name: { ja: "かえんほうしゃ" },
+			damage: 80,
+			cost: ["Fire", "Fire", "Colorless"],
+			effect: {
+				ja: "このポケモンについているエネルギーを、1個トラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559558,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "フォッコ",
+	},
+
+	retreat: 2,
+	rarity: "Common",
+	dexId: [654],
+};
+
+export default card;

--- a/data-asia/SM/SM6/014.ts
+++ b/data-asia/SM/SM6/014.ts
@@ -1,0 +1,63 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "マフォクシー",
+	},
+
+	illustrator: "kawayoo",
+	category: "Pokemon",
+	hp: 150,
+	types: ["Fire"],
+
+	description: {
+		ja: "摂氏３０００度の 炎の 渦を 超能力で 操る。 敵を 渦で 包み 焼きつくす。",
+	},
+
+	stage: "Stage2",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "マジカルトーチ" },
+			effect: {
+				ja: "自分の番に1回使える。相手のバトルポケモンをやけどにする。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ほのおのうず" },
+			damage: 150,
+			cost: ["Fire", "Fire", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンについているエネルギーを、2個トラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 559559,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "テールナー",
+	},
+
+	retreat: 2,
+	rarity: "Rare",
+	dexId: [655],
+};
+
+export default card;

--- a/data-asia/SM/SM6/015.ts
+++ b/data-asia/SM/SM6/015.ts
@@ -1,0 +1,46 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "シシコ",
+	},
+
+	illustrator: "Yuka Morii",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Fire"],
+
+	description: {
+		ja: "強くなるため 群れを 離れて １匹で 生活するようになる。 血気盛んで ケンカっ早い。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ずつき" },
+			damage: 20,
+			cost: ["Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559560,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Common",
+	dexId: [667],
+};
+
+export default card;

--- a/data-asia/SM/SM6/016.ts
+++ b/data-asia/SM/SM6/016.ts
@@ -1,0 +1,63 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "カエンジシ",
+	},
+
+	illustrator: "Mitsuhiro Arita",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Fire"],
+
+	description: {
+		ja: "摂氏６０００度の 息を 吐き出し 激しく 相手を 威嚇する。 メスが 群れの 子供を 守る。",
+	},
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "きんちょうかん" },
+			effect: {
+				ja: "このポケモンは、相手が手札からグッズまたはサポートを出して使ったとき、その効果を受けない。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ドミネートファング" },
+			damage: "80+",
+			cost: ["Fire", "Colorless", "Colorless"],
+			effect: {
+				ja: "場に「フラダリラボ」が出ているなら、60ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 559561,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "シシコ",
+	},
+
+	retreat: 2,
+	rarity: "Rare",
+	dexId: [668],
+};
+
+export default card;

--- a/data-asia/SM/SM6/017.ts
+++ b/data-asia/SM/SM6/017.ts
@@ -1,0 +1,56 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ケロマツ",
+	},
+
+	illustrator: "Ken Sugimori",
+	category: "Pokemon",
+	hp: 50,
+	types: ["Water"],
+
+	description: {
+		ja: "繊細な 泡で 体を 包み 肌を 守る。 のんきに 見せかけて 抜け目なく 周囲を うかがう。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ケロムース" },
+			effect: {
+				ja: "このポケモンに[水]エネルギーがついているなら、このポケモンのにげるためのエネルギーは、すべてなくなる。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "はねまわる" },
+			damage: 20,
+			cost: ["Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559562,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [656],
+};
+
+export default card;

--- a/data-asia/SM/SM6/018.ts
+++ b/data-asia/SM/SM6/018.ts
@@ -1,0 +1,51 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ケロマツ",
+	},
+
+	illustrator: "Aya Kusube",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Water"],
+
+	description: {
+		ja: "繊細な 泡で 体を 包み 肌を 守る。 のんきに 見せかけて 抜け目なく 周囲を うかがう。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "みずかけ" },
+			damage: 10,
+			cost: ["Water"],
+		},
+		{
+			name: { ja: "スプラッシュ" },
+			damage: 20,
+			cost: ["Water", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559563,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [656],
+};
+
+export default card;

--- a/data-asia/SM/SM6/019.ts
+++ b/data-asia/SM/SM6/019.ts
@@ -1,0 +1,60 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ゲコガシラ",
+	},
+
+	illustrator: "Akira Komayama",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Water"],
+
+	description: {
+		ja: "身軽さは だれにも 負けない。 ６００メートルを 超える タワーの 天辺まで １分で 登りきる。",
+	},
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "はやてしゅりけん" },
+			effect: {
+				ja: "自分の番に、このカードを手札から出して進化させたとき、1回使える。相手のポケモン1匹に、ダメカンを2個のせる。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "みずきり" },
+			damage: 20,
+			cost: ["Water"],
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559564,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ケロマツ",
+	},
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [657],
+};
+
+export default card;

--- a/data-asia/SM/SM6/020.ts
+++ b/data-asia/SM/SM6/020.ts
@@ -1,0 +1,68 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ゲッコウガGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 230,
+	types: ["Water"],
+
+	stage: "Stage2",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ふうましゅりけん" },
+			effect: {
+				ja: "自分の番に、このカードを手札から出して進化させたとき、1回使える。相手のポケモン1匹に、ダメカンを3個のせる。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "おぼろぎり" },
+			damage: 110,
+			cost: ["Water", "Colorless", "Colorless"],
+			effect: {
+				ja: "のぞむなら、このポケモンと、ついているすべてのカードを、自分の山札にもどして切る。",
+			},
+		},
+		{
+			name: { ja: "シャドーアサシンGX" },
+			cost: ["Water", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のベンチポケモン1匹に、130ダメージ。［ベンチは弱点・抵抗力を計算しない。］［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 559565,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ゲコガシラ",
+	},
+
+	retreat: 2,
+	rarity: "Double rare",
+	dexId: [658],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM6/021.ts
+++ b/data-asia/SM/SM6/021.ts
@@ -1,0 +1,46 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ウデッポウ",
+	},
+
+	illustrator: "Midori Harada",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Water"],
+
+	description: {
+		ja: "体内ガスの 爆発で 水を ピストルのように 発射する。 至近距離なら 岩を 砕く。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "みずでっぽう" },
+			damage: 10,
+			cost: ["Water"],
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559566,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [692],
+};
+
+export default card;

--- a/data-asia/SM/SM6/022.ts
+++ b/data-asia/SM/SM6/022.ts
@@ -1,0 +1,59 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ブロスター",
+	},
+
+	illustrator: "otumami",
+	category: "Pokemon",
+	hp: 100,
+	types: ["Water"],
+
+	description: {
+		ja: "ハサミの 後ろの ノズルから 水を 噴き出す 推進力で ６０ノットの スピードで 進む。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "スタンバイ" },
+			cost: ["Water"],
+			effect: {
+				ja: "次の自分の番、このポケモンの「ねらいうち」のダメージは「120」になる。",
+			},
+		},
+		{
+			name: { ja: "ねらいうち" },
+			cost: ["Water"],
+			effect: {
+				ja: "相手のポケモン1匹に、40ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559567,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ウデッポウ",
+	},
+
+	retreat: 2,
+	rarity: "Uncommon",
+	dexId: [693],
+};
+
+export default card;

--- a/data-asia/SM/SM6/023.ts
+++ b/data-asia/SM/SM6/023.ts
@@ -1,0 +1,54 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アマルス",
+	},
+
+	illustrator: "Atsuko Nishida",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Water"],
+
+	description: {
+		ja: "おっとりした 性格の ポケモン。 ガチゴラスなど 凶暴な 敵の いない 寒い 土地に 住んでいた。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "こなゆき" },
+			damage: 30,
+			cost: ["Water", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをねむりにする。",
+			},
+		},
+		{
+			name: { ja: "オーロラビーム" },
+			damage: 60,
+			cost: ["Water", "Water", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559568,
+			},
+		},
+	],
+
+	retreat: 3,
+	rarity: "Uncommon",
+	dexId: [698],
+};
+
+export default card;

--- a/data-asia/SM/SM6/024.ts
+++ b/data-asia/SM/SM6/024.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アマルルガ",
+	},
+
+	illustrator: "Suwama Chiaki",
+	category: "Pokemon",
+	hp: 160,
+	types: ["Water"],
+
+	description: {
+		ja: "ひし形の 結晶で 氷の 壁を 瞬間的に 作り 敵の 攻撃を 防ぐのだ。",
+	},
+
+	stage: "Stage2",
+
+	attacks: [
+		{
+			name: { ja: "フロストウォール" },
+			damage: 50,
+			cost: ["Water", "Colorless", "Colorless"],
+			effect: {
+				ja: "次の相手の番、このポケモンは進化ポケモンからワザのダメージを受けない。",
+			},
+		},
+		{
+			name: { ja: "ブリザードバーン" },
+			damage: 150,
+			cost: ["Water", "Water", "Colorless", "Colorless"],
+			effect: {
+				ja: "次の自分の番、このポケモンはワザが使えない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 559569,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "アマルス",
+	},
+
+	retreat: 4,
+	rarity: "Rare",
+	dexId: [699],
+};
+
+export default card;

--- a/data-asia/SM/SM6/025.ts
+++ b/data-asia/SM/SM6/025.ts
@@ -1,0 +1,49 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "カチコール",
+	},
+
+	illustrator: "Miki Tanaka",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Water"],
+
+	description: {
+		ja: "マイナス１００度の 冷気で 敵を 氷漬けにする。 万年雪に 覆われた 山で 群れを 作る。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "かちわる" },
+			damage: 10,
+			cost: ["Water"],
+			effect: {
+				ja: "場に出ている相手のスタジアムをトラッシュする。トラッシュした場合、相手のバトルポケモンをマヒにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559570,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Common",
+	dexId: [712],
+};
+
+export default card;

--- a/data-asia/SM/SM6/026.ts
+++ b/data-asia/SM/SM6/026.ts
@@ -1,0 +1,58 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "クレベース",
+	},
+
+	illustrator: "sowsow",
+	category: "Pokemon",
+	hp: 140,
+	types: ["Water"],
+
+	description: {
+		ja: "背中に 数匹の カチコールを 乗せて 暮らす 様子は まるで 氷の 航空母艦のようだ。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "じばんとうけつ" },
+			damage: 80,
+			cost: ["Water", "Colorless", "Colorless"],
+			effect: {
+				ja: "次の相手の番、相手は手札からスタジアムを出せない。",
+			},
+		},
+		{
+			name: { ja: "ロケットずつき" },
+			damage: 100,
+			cost: ["Water", "Colorless", "Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559571,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "カチコール",
+	},
+
+	retreat: 4,
+	rarity: "Uncommon",
+	dexId: [713],
+};
+
+export default card;

--- a/data-asia/SM/SM6/027.ts
+++ b/data-asia/SM/SM6/027.ts
@@ -1,0 +1,59 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ボルケニオン",
+	},
+
+	illustrator: "Naoki Saito",
+	category: "Pokemon",
+	hp: 160,
+	types: ["Water"],
+
+	description: {
+		ja: "背中の アームから 体内の 水蒸気を 噴射する。 山 ひとつ 吹き飛ばす 威力。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ジェットほうすい" },
+			effect: {
+				ja: "自分の番に1回使える。自分の手札にある[水]エネルギーを、1枚トラッシュする。その後、相手のバトルポケモンをベンチポケモンと入れ替える。［バトル場に出すポケモンは相手が選ぶ。］",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "サウナボム" },
+			damage: 100,
+			cost: ["Water", "Water", "Water"],
+			effect: {
+				ja: "相手のベンチポケモン全員にも、それぞれ20ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 559572,
+			},
+		},
+	],
+
+	retreat: 3,
+	rarity: "Rare Holo",
+	dexId: [721],
+};
+
+export default card;

--- a/data-asia/SM/SM6/028.ts
+++ b/data-asia/SM/SM6/028.ts
@@ -1,0 +1,51 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "エリキテル",
+	},
+
+	illustrator: "Miki Tanaka",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Lightning"],
+
+	description: {
+		ja: "頭の 両わきの ひだには 太陽の 光を 浴びると 発電する 細胞が あるのだ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "かじる" },
+			damage: 10,
+			cost: ["Colorless"],
+		},
+		{
+			name: { ja: "しっぽではたく" },
+			damage: 20,
+			cost: ["Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Metal", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559573,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [694],
+};
+
+export default card;

--- a/data-asia/SM/SM6/029.ts
+++ b/data-asia/SM/SM6/029.ts
@@ -1,0 +1,58 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "エレザード",
+	},
+
+	illustrator: "otumami",
+	category: "Pokemon",
+	hp: 100,
+	types: ["Lightning"],
+
+	description: {
+		ja: "電気で 筋肉を 刺激すると １００メートルを ５秒で 走る 脚力に パワーアップする。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "かじる" },
+			damage: 20,
+			cost: ["Colorless"],
+		},
+		{
+			name: { ja: "ショックウェーブ" },
+			damage: 80,
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "コインを1回投げオモテなら、相手のバトルポケモンをマヒにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Metal", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559574,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "エリキテル",
+	},
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [695],
+};
+
+export default card;

--- a/data-asia/SM/SM6/030.ts
+++ b/data-asia/SM/SM6/030.ts
@@ -1,0 +1,48 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ニャスパー",
+	},
+
+	illustrator: "0313",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Psychic"],
+
+	description: {
+		ja: "１００メートル以内の ものを 吹き飛ばす ほどの サイコパワーを うまく コントロール できないのだ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "エネじゃらし" },
+			cost: ["Psychic"],
+			effect: {
+				ja: "相手のベンチポケモンについているエネルギーを1個、相手の別のポケモンにつけ替える。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559575,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [677],
+};
+
+export default card;

--- a/data-asia/SM/SM6/031.ts
+++ b/data-asia/SM/SM6/031.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ニャオニクス",
+	},
+
+	illustrator: "0313",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Psychic"],
+
+	description: {
+		ja: "耳の 内側の 目玉模様から サイコパワーを 出すが あまりにも 強力なので ふさいでいる。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "テレポートブレイク" },
+			damage: 20,
+			cost: ["Psychic"],
+			effect: {
+				ja: "このポケモンをベンチポケモンと入れ替える。",
+			},
+		},
+		{
+			name: { ja: "サイコキネシス" },
+			damage: "30+",
+			cost: ["Psychic", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンについているエネルギーの数x30ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559576,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ニャスパー",
+	},
+
+	retreat: 1,
+	rarity: "Uncommon",
+	dexId: [678],
+};
+
+export default card;

--- a/data-asia/SM/SM6/032.ts
+++ b/data-asia/SM/SM6/032.ts
@@ -1,0 +1,56 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヒトツキ",
+	},
+
+	illustrator: "Ken Sugimori",
+	category: "Pokemon",
+	hp: 50,
+	types: ["Psychic"],
+
+	description: {
+		ja: "剣の 柄を 握った 人の 腕に 青い 布を 巻きつけて 倒れるまで 命を 吸い取る。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "だんまつま" },
+			effect: {
+				ja: "このポケモンが、バトル場で相手のポケモンからワザのダメージを受けてきぜつしたとき、相手のポケモン1匹に、ダメカン3個をのせる。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "きりさく" },
+			damage: 50,
+			cost: ["Psychic", "Psychic", "Psychic"],
+		},
+	],
+
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559577,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Common",
+	dexId: [679],
+};
+
+export default card;

--- a/data-asia/SM/SM6/033.ts
+++ b/data-asia/SM/SM6/033.ts
@@ -1,0 +1,48 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヒトツキ",
+	},
+
+	illustrator: "Midori Harada",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Psychic"],
+
+	description: {
+		ja: "剣の 柄を 握った 人の 腕に 青い 布を 巻きつけて 倒れるまで 命を 吸い取る。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "きんぞくおん" },
+			cost: ["Psychic"],
+			effect: {
+				ja: "相手のバトルポケモンをこんらんにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559578,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Common",
+	dexId: [679],
+};
+
+export default card;

--- a/data-asia/SM/SM6/034.ts
+++ b/data-asia/SM/SM6/034.ts
@@ -1,0 +1,52 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ニダンギル",
+	},
+
+	illustrator: "kirisAki",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Psychic"],
+
+	description: {
+		ja: "２本の 剣による 複雑な 連続攻撃を 防ぐことは 剣の 達人でも 不可能だ。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "やいばののろい" },
+			cost: ["Psychic"],
+			effect: {
+				ja: "「ポケモンのどうぐ」がついている相手のポケモン全員に、それぞれダメカンを3個のせる。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559579,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ヒトツキ",
+	},
+
+	retreat: 2,
+	rarity: "Common",
+	dexId: [680],
+};
+
+export default card;

--- a/data-asia/SM/SM6/035.ts
+++ b/data-asia/SM/SM6/035.ts
@@ -1,0 +1,60 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ギルガルド",
+	},
+
+	illustrator: "Anesaki Dynamic",
+	category: "Pokemon",
+	hp: 150,
+	types: ["Psychic"],
+
+	description: {
+		ja: "王の 素質を 持つ 人間を 見抜くらしい。 認められた 人は やがて 王になると 言われている。",
+	},
+
+	stage: "Stage2",
+
+	attacks: [
+		{
+			name: { ja: "しをきざむ" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "次の自分の番、このワザを受けたポケモンは、ワザのダメージを受けたらきぜつする。",
+			},
+		},
+		{
+			name: { ja: "ドレインスラッシュ" },
+			damage: 90,
+			cost: ["Psychic", "Psychic", "Psychic"],
+			effect: {
+				ja: "このポケモンのHPを「30」回復する。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559580,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ニダンギル",
+	},
+
+	retreat: 2,
+	rarity: "Uncommon",
+	dexId: [681],
+};
+
+export default card;

--- a/data-asia/SM/SM6/036.ts
+++ b/data-asia/SM/SM6/036.ts
@@ -1,0 +1,48 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "マーイーカ",
+	},
+
+	illustrator: "sowsow",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Psychic"],
+
+	description: {
+		ja: "光の 点滅で 襲ってきた 敵の 戦意を なくしてしまう。 その すきに 姿を くらますのだ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "さいみんじゅつ" },
+			cost: ["Psychic"],
+			effect: {
+				ja: "相手のバトルポケモンをねむりにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559581,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [686],
+};
+
+export default card;

--- a/data-asia/SM/SM6/037.ts
+++ b/data-asia/SM/SM6/037.ts
@@ -1,0 +1,60 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "カラマネロ",
+	},
+
+	illustrator: "You Iribi",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Psychic"],
+
+	description: {
+		ja: "催眠術で おびき寄せて 頭の 触手で 絡め取り 消化液を 浴びせて しとめる。",
+	},
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "サイコリチャージ" },
+			effect: {
+				ja: "自分の番に1回使える。自分のトラッシュにある[超]エネルギーを1枚、ベンチポケモンにつける。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ねんどうだん" },
+			damage: 60,
+			cost: ["Psychic", "Psychic", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559582,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "マーイーカ",
+	},
+
+	retreat: 2,
+	rarity: "Uncommon",
+	dexId: [687],
+};
+
+export default card;

--- a/data-asia/SM/SM6/038.ts
+++ b/data-asia/SM/SM6/038.ts
@@ -1,0 +1,46 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "クズモー",
+	},
+
+	illustrator: "Mina Nakai",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Psychic"],
+
+	description: {
+		ja: "腐った 海藻に そっくり。 敵の 目を ごまかしながら 進化する 力を 蓄える。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ひっかける" },
+			damage: 10,
+			cost: ["Psychic"],
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559583,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [690],
+};
+
+export default card;

--- a/data-asia/SM/SM6/039.ts
+++ b/data-asia/SM/SM6/039.ts
@@ -1,0 +1,63 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ドラミドロ",
+	},
+
+	illustrator: "SATOSHI NAKAI",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Psychic"],
+
+	description: {
+		ja: "ドラミドロが 住む 海域に 迷いこんだ 船は ２度と 生きて 戻れないと 言われている。",
+	},
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "どくのトゲ" },
+			effect: {
+				ja: "このポケモンが、バトル場で相手のポケモンからワザのダメージを受けたとき、ワザを使ったポケモンをどくにする。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "たつまき" },
+			damage: 60,
+			cost: ["Psychic", "Colorless"],
+			effect: {
+				ja: "コインを2回投げ、オモテの数ぶん、相手のバトルポケモンについているエネルギーをトラッシュする。すべてウラなら、このワザは失敗。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559584,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "クズモー",
+	},
+
+	retreat: 1,
+	rarity: "Uncommon",
+	dexId: [691],
+};
+
+export default card;

--- a/data-asia/SM/SM6/040.ts
+++ b/data-asia/SM/SM6/040.ts
@@ -1,0 +1,56 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "フーパ",
+	},
+
+	illustrator: "Aya Kusube",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Psychic"],
+
+	description: {
+		ja: "気に入った ものを リングを 使い 秘密の 住処へ 集めている。 リングを 潜って テレポートする。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "いじげんリング" },
+			cost: ["Psychic"],
+			effect: {
+				ja: "自分の山札にあるグッズを2枚まで、相手に見せてから、手札に加える。そして山札を切る。",
+			},
+		},
+		{
+			name: { ja: "ねんりき" },
+			damage: 10,
+			cost: ["Psychic"],
+			effect: {
+				ja: "コインを1回投げオモテなら、相手のバトルポケモンをマヒにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559585,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [720],
+};
+
+export default card;

--- a/data-asia/SM/SM6/041.ts
+++ b/data-asia/SM/SM6/041.ts
@@ -1,0 +1,49 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "カラカラ",
+	},
+
+	illustrator: "sowsow",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Fighting"],
+
+	description: {
+		ja: "頭に 被った 頭がい骨は 死んだ 母親。 死の 悲しみを 乗り越えたとき 進化する という。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "おもいホネ" },
+			damage: 40,
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "次の自分の番、このポケモンはワザが使えない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559586,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Common",
+	dexId: [104],
+};
+
+export default card;

--- a/data-asia/SM/SM6/042.ts
+++ b/data-asia/SM/SM6/042.ts
@@ -1,0 +1,49 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヤンチャム",
+	},
+
+	illustrator: "Midori Harada",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Fighting"],
+
+	description: {
+		ja: "咥えている 葉っぱに 意味は なく ただの かっこつけ。 やんちゃなので 素人トレーナーには 向かない。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ワルぶる" },
+			damage: "10+",
+			cost: ["Fighting"],
+			effect: {
+				ja: "このポケモンに[悪]エネルギーがついているなら、30ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559587,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Common",
+	dexId: [674],
+};
+
+export default card;

--- a/data-asia/SM/SM6/043.ts
+++ b/data-asia/SM/SM6/043.ts
@@ -1,0 +1,49 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "カメテテ",
+	},
+
+	illustrator: "Yuka Morii",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Fighting"],
+
+	description: {
+		ja: "体を 伸ばす 反動で 岩を 持ち上げて 歩く。 波打ち際で 流されてきた 海藻を 食べる。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ぶんたん" },
+			damage: 10,
+			cost: ["Fighting"],
+			effect: {
+				ja: "自分の山札を1枚引く。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559588,
+			},
+		},
+	],
+
+	retreat: 3,
+	rarity: "Common",
+	dexId: [688],
+};
+
+export default card;

--- a/data-asia/SM/SM6/044.ts
+++ b/data-asia/SM/SM6/044.ts
@@ -1,0 +1,58 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ガメノデス",
+	},
+
+	illustrator: "kirisAki",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Fighting"],
+
+	description: {
+		ja: "手足にも 脳が あり 勝手に 動けるが 普段は 頭の ガメノデスの 命令に 従う。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "セブンショック" },
+			damage: 30,
+			cost: ["Fighting", "Colorless"],
+			effect: {
+				ja: "自分の手札が7枚なら、相手のバトルポケモンをマヒにする。",
+			},
+		},
+		{
+			name: { ja: "ツメできりさく" },
+			damage: 90,
+			cost: ["Fighting", "Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559589,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "カメテテ",
+	},
+
+	retreat: 3,
+	rarity: "Uncommon",
+	dexId: [689],
+};
+
+export default card;

--- a/data-asia/SM/SM6/045.ts
+++ b/data-asia/SM/SM6/045.ts
@@ -1,0 +1,54 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "チゴラス",
+	},
+
+	illustrator: "SATOSHI NAKAI",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Fighting"],
+
+	description: {
+		ja: "自動車を バリバリと かじって 壊す おおあごの 破壊力。 １億年前に 生息していた。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "かみくだく" },
+			damage: 20,
+			cost: ["Fighting"],
+			effect: {
+				ja: "コインを1回投げオモテなら、相手のバトルポケモンについているエネルギーを、1個トラッシュする。",
+			},
+		},
+		{
+			name: { ja: "ぶちかます" },
+			damage: 40,
+			cost: ["Fighting", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559590,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Uncommon",
+	dexId: [696],
+};
+
+export default card;

--- a/data-asia/SM/SM6/046.ts
+++ b/data-asia/SM/SM6/046.ts
@@ -1,0 +1,63 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ガチゴラス",
+	},
+
+	illustrator: "hatachu",
+	category: "Pokemon",
+	hp: 160,
+	types: ["Fighting"],
+
+	description: {
+		ja: "１億年前の 世界では 無敵を ほこり 王様のように ふるまっていた ポケモン。",
+	},
+
+	stage: "Stage2",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ティラノハート" },
+			effect: {
+				ja: "自分の場のポケモンの数が、相手と同じか少ないなら、このポケモンが使うワザのダメージは「+60」され、このポケモンが受けるワザのダメージは「-30」される。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "かみくだく" },
+			damage: 100,
+			cost: ["Fighting", "Fighting", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンについているエネルギーを、1個トラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 559591,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "チゴラス",
+	},
+
+	retreat: 3,
+	rarity: "Rare",
+	dexId: [697],
+};
+
+export default card;

--- a/data-asia/SM/SM6/047.ts
+++ b/data-asia/SM/SM6/047.ts
@@ -1,0 +1,53 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ルチャブル",
+	},
+
+	illustrator: "Naoki Saito",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Fighting"],
+
+	description: {
+		ja: "翼を 使い 空中で 姿勢を コントロール。 防ぎにくい 頭上から 攻撃を 仕掛ける。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "とびひざげり" },
+			damage: 20,
+			cost: ["Fighting"],
+		},
+		{
+			name: { ja: "フリーフォール 80-" },
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンのにげるためのエネルギーの数x20ダメージぶん、このワザのダメージは小さくなる。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559592,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [701],
+};
+
+export default card;

--- a/data-asia/SM/SM6/048.ts
+++ b/data-asia/SM/SM6/048.ts
@@ -1,0 +1,59 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ジガルデ",
+	},
+
+	illustrator: "Akira Komayama",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Fighting"],
+
+	description: {
+		ja: "セルと 呼ばれる ジガルデの 一部が １０％ほど 集まった 姿。 時速１００キロで 地を 駆ける。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "だいちのオーラ" },
+			effect: {
+				ja: "このポケモンが使うワザのダメージは、弱点・抵抗力を計算しない。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ピースメーカー" },
+			damage: "30+",
+			cost: ["Fighting"],
+			effect: {
+				ja: "相手の場に「ウルトラビースト」がいるなら、30ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559593,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [718],
+};
+
+export default card;

--- a/data-asia/SM/SM6/049.ts
+++ b/data-asia/SM/SM6/049.ts
@@ -1,0 +1,57 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ジガルデ",
+	},
+
+	illustrator: "Mitsuhiro Arita",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Fighting"],
+
+	description: {
+		ja: "生態系を 監視 していると 考えられている。 さらなる 力を 秘めているとの ウワサ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "へびにらみ" },
+			damage: 20,
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "コインを1回投げオモテなら、相手のバトルポケモンをマヒにする。",
+			},
+		},
+		{
+			name: { ja: "カームストライク" },
+			damage: "60+",
+			cost: ["Fighting", "Colorless", "Colorless"],
+			effect: {
+				ja: "自分がすでにGXワザを使っていたなら、60ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559594,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Uncommon",
+	dexId: [718],
+};
+
+export default card;

--- a/data-asia/SM/SM6/050.ts
+++ b/data-asia/SM/SM6/050.ts
@@ -1,0 +1,60 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ジガルデGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 200,
+	types: ["Fighting"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "セルコネクター" },
+			damage: 50,
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "自分のトラッシュにある[闘]エネルギーを2枚、このポケモンにつける。",
+			},
+		},
+		{
+			name: { ja: "グランドフォース" },
+			damage: 130,
+			cost: ["Fighting", "Fighting", "Colorless", "Colorless"],
+		},
+		{
+			name: { ja: "ジャッジメントGX" },
+			damage: 150,
+			cost: ["Fighting", "Fighting", "Colorless", "Colorless"],
+			effect: {
+				ja: "次の相手の番、このポケモンは「ポケモンGX・EX」からワザのダメージを受けない。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 559595,
+			},
+		},
+	],
+
+	retreat: 3,
+	rarity: "Double rare",
+	dexId: [718],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM6/051.ts
+++ b/data-asia/SM/SM6/051.ts
@@ -1,0 +1,59 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ディアンシー",
+	},
+
+	illustrator: "kawayoo",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Fighting"],
+
+	description: {
+		ja: "両手の すきまで 空気中の 炭素を 圧縮して たくさんの ダイヤを 一瞬で 生み出す。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "プリンセスエール" },
+			effect: {
+				ja: "このポケモンがベンチにいるかぎり、自分の[闘]ポケモンが使うワザの、相手のバトルポケモンへのダメージは「+20」される。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ダイヤレイン" },
+			damage: 90,
+			cost: ["Fighting", "Fighting", "Fighting"],
+			effect: {
+				ja: "自分のベンチポケモン全員のHPを、それぞれ「30」回復する。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 559596,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Rare Holo",
+	dexId: [719],
+};
+
+export default card;

--- a/data-asia/SM/SM6/052.ts
+++ b/data-asia/SM/SM6/052.ts
@@ -1,0 +1,49 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "イワンコ",
+	},
+
+	illustrator: "Tomokazu Komiya",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Fighting"],
+
+	description: {
+		ja: "昔から 人と 暮らしてきた。 トレーナーが 悲しんでいると それを 察して 側を 離れない。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ふいをつく" },
+			damage: 50,
+			cost: ["Fighting", "Colorless"],
+			effect: {
+				ja: "コインを1回投げウラなら、このワザは失敗。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559597,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [744],
+};
+
+export default card;

--- a/data-asia/SM/SM6/053.ts
+++ b/data-asia/SM/SM6/053.ts
@@ -1,0 +1,58 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ルガルガン",
+	},
+
+	illustrator: "Megumi Mizutani",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Fighting"],
+
+	description: {
+		ja: "夕日を 浴び 特別な 進化を した ルガルガン。 もの静かだが 激しい 闘志を 秘めている。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "デスローグ" },
+			damage: "20+",
+			cost: ["Fighting", "Colorless"],
+			effect: {
+				ja: "相手のベンチポケモンの数x20ダメージ追加。",
+			},
+		},
+		{
+			name: { ja: "アクセルロック" },
+			damage: 100,
+			cost: ["Fighting", "Fighting", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 559598,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "イワンコ",
+	},
+
+	retreat: 2,
+	rarity: "Rare",
+	dexId: [745],
+};
+
+export default card;

--- a/data-asia/SM/SM6/054.ts
+++ b/data-asia/SM/SM6/054.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ゴロンダ",
+	},
+
+	illustrator: "SATOSHI NAKAI",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Darkness"],
+
+	description: {
+		ja: "竹の 葉っぱの 揺れで 敵の 動きを 読む。 ケンカっ早いが 仲間への 情は 厚い。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "あらくれパンチ" },
+			damage: "50+",
+			cost: ["Darkness", "Colorless"],
+			effect: {
+				ja: "このポケモンにダメカンがのっているなら、50ダメージ追加し、おたがいのバトルポケモンをこんらんにする。",
+			},
+		},
+		{
+			name: { ja: "ダブルスタンプ" },
+			damage: "80+",
+			cost: ["Darkness", "Darkness", "Colorless"],
+			effect: {
+				ja: "コインを2回投げ、オモテの数x40ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559599,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ヤンチャム",
+	},
+
+	retreat: 3,
+	rarity: "Uncommon",
+	dexId: [675],
+};
+
+export default card;

--- a/data-asia/SM/SM6/055.ts
+++ b/data-asia/SM/SM6/055.ts
@@ -1,0 +1,62 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "イベルタルGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 180,
+	types: ["Darkness"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "せいきをすいとる" },
+			damage: 20,
+			cost: ["Darkness"],
+			effect: {
+				ja: "相手のバトルポケモンに与えたダメージぶん、このポケモンのHPを回復する。",
+			},
+		},
+		{
+			name: { ja: "イビルソニック" },
+			damage: 100,
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "このワザのダメージは弱点・抵抗力を計算しない。",
+			},
+		},
+		{
+			name: { ja: "デスカウントGX" },
+			cost: ["Darkness"],
+			effect: {
+				ja: "相手のバトルポケモンにダメカンが4個のっているなら、そのポケモンをきぜつさせる。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 559600,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Double rare",
+	dexId: [717],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM6/056.ts
+++ b/data-asia/SM/SM6/056.ts
@@ -1,0 +1,49 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アクジキング",
+	},
+
+	illustrator: "Anesaki Dynamic",
+	category: "Pokemon",
+	hp: 160,
+	types: ["Darkness"],
+
+	description: {
+		ja: "危険生物 ビーストの 一種。 つねに なにかを 喰らっているようだが なぜか フンは 未発見。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "キングスバレイ" },
+			damage: 160,
+			cost: ["Darkness", "Darkness", "Darkness", "Darkness"],
+			effect: {
+				ja: "自分のサイドの残り枚数が6枚・4枚・2枚なら、自分の山札を上から10枚トラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 559601,
+			},
+		},
+	],
+
+	retreat: 4,
+	rarity: "Rare",
+	dexId: [799],
+};
+
+export default card;

--- a/data-asia/SM/SM6/057.ts
+++ b/data-asia/SM/SM6/057.ts
@@ -1,0 +1,56 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "フラベベ",
+	},
+
+	illustrator: "kirisAki",
+	category: "Pokemon",
+	hp: 30,
+	types: ["Fairy"],
+
+	description: {
+		ja: "気に入った 花を 見つけると 一生 その花と 暮らす。 風に 乗って 気ままに 漂う。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ぬけがけしんか" },
+			effect: {
+				ja: "このポケモンは、後攻プレイヤーの最初の番なら、出したばかりでも進化できる。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "たいあたり" },
+			damage: 10,
+			cost: ["Fairy"],
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [{ type: "Darkness", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559602,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [669],
+};
+
+export default card;

--- a/data-asia/SM/SM6/058.ts
+++ b/data-asia/SM/SM6/058.ts
@@ -1,0 +1,48 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "フラベベ",
+	},
+
+	illustrator: "Ken Sugimori",
+	category: "Pokemon",
+	hp: 40,
+	types: ["Fairy"],
+
+	description: {
+		ja: "気に入った 花を 見つけると 一生 その花と 暮らす。 風に 乗って 気ままに 漂う。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ひみつのめぐみ" },
+			cost: ["Fairy"],
+			effect: {
+				ja: "自分のトラッシュにあるポケモンと基本エネルギーを合計3枚、相手に見せてから、山札にもどして切る。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [{ type: "Darkness", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559603,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [669],
+};
+
+export default card;

--- a/data-asia/SM/SM6/059.ts
+++ b/data-asia/SM/SM6/059.ts
@@ -1,0 +1,52 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "フラエッテ",
+	},
+
+	illustrator: "Mina Nakai",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Fairy"],
+
+	description: {
+		ja: "手入れの 行き届いた 花壇の 花が 咲くと 姿を 現して かれんな ダンスで 祝福する。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "はなびらくるくる" },
+			cost: ["Fairy"],
+			effect: {
+				ja: "相手のベンチポケモンを1匹選び、バトルポケモンと入れ替える。その後、このポケモンをベンチポケモンと入れ替える。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [{ type: "Darkness", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559604,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "フラベベ",
+	},
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [670],
+};
+
+export default card;

--- a/data-asia/SM/SM6/060.ts
+++ b/data-asia/SM/SM6/060.ts
@@ -1,0 +1,63 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "フラージェス",
+	},
+
+	illustrator: "Satoshi Shirai",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Fairy"],
+
+	description: {
+		ja: "昔の 城の 主たちは 庭を 飾るため フラージェスを 招き入れ 花園を 作らせた。",
+	},
+
+	stage: "Stage2",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ワンダーギフト" },
+			effect: {
+				ja: "自分の番に1回使える。コインを1回投げオモテなら、自分のトラッシュにあるグッズを1枚、相手に見せてから、山札の上にもどす。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ミストガード" },
+			damage: 70,
+			cost: ["Fairy", "Fairy", "Colorless"],
+			effect: {
+				ja: "次の相手の番、このポケモンは[竜]ポケモンからワザのダメージを受けない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [{ type: "Darkness", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559605,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "フラエッテ",
+	},
+
+	retreat: 2,
+	rarity: "Uncommon",
+	dexId: [671],
+};
+
+export default card;

--- a/data-asia/SM/SM6/061.ts
+++ b/data-asia/SM/SM6/061.ts
@@ -1,0 +1,57 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ニンフィア",
+	},
+
+	illustrator: "0313",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Fairy"],
+
+	description: {
+		ja: "獲物を 見つけると リボン状の 触角を 揺らし 油断 させ スキが できると 飛びかかる。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "めくばせ" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "相手の手札を見る。のぞむなら、その中にあるサポートを、1枚トラッシュする。その場合、そのサポートの効果を、このワザの効果として使う。",
+			},
+		},
+		{
+			name: { ja: "マジカルショット" },
+			damage: 40,
+			cost: ["Fairy", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [{ type: "Darkness", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559606,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "イーブイ",
+	},
+
+	retreat: 1,
+	rarity: "Uncommon",
+	dexId: [700],
+};
+
+export default card;

--- a/data-asia/SM/SM6/062.ts
+++ b/data-asia/SM/SM6/062.ts
@@ -1,0 +1,56 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "デデンネ",
+	},
+
+	illustrator: "Tomokazu Komiya",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Fairy"],
+
+	description: {
+		ja: "尻尾で 発電所や 民家の コンセントから 電気を 吸い取り ヒゲから 電撃を 撃ち出す。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ともだちをさがす" },
+			cost: ["Fairy"],
+			effect: {
+				ja: "自分の山札にあるポケモンを1枚、相手に見せてから、手札に加える。そして山札を切る。",
+			},
+		},
+		{
+			name: { ja: "エレキチェイン" },
+			damage: "30+",
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "自分のベンチに[雷]ポケモンがいるなら、30ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [{ type: "Darkness", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559607,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [702],
+};
+
+export default card;

--- a/data-asia/SM/SM6/063.ts
+++ b/data-asia/SM/SM6/063.ts
@@ -1,0 +1,56 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "クレッフィ",
+	},
+
+	illustrator: "otumami",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Fairy"],
+
+	description: {
+		ja: "頭の角を 金属の すき間に 突っ込んで 金属イオンを 吸う。 なぜか カギを 集めている。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "きんぞくおん" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをこんらんにする。",
+			},
+		},
+		{
+			name: { ja: "フェアリーロック" },
+			damage: 20,
+			cost: ["Colorless"],
+			effect: {
+				ja: "次の相手の番、このワザを受けたポケモンは、にげられない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [{ type: "Darkness", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559608,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [707],
+};
+
+export default card;

--- a/data-asia/SM/SM6/064.ts
+++ b/data-asia/SM/SM6/064.ts
@@ -1,0 +1,59 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ゼルネアスGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 180,
+	types: ["Fairy"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "かけぬける" },
+			damage: 20,
+			cost: ["Colorless"],
+			effect: {
+				ja: "相手のベンチポケモン1匹にも、20ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+			},
+		},
+		{
+			name: { ja: "オーロラホーン" },
+			damage: 120,
+			cost: ["Fairy", "Fairy", "Colorless"],
+		},
+		{
+			name: { ja: "サンクチュアリGX" },
+			cost: ["Fairy", "Fairy", "Colorless"],
+			effect: {
+				ja: "自分のポケモン全員にのっているダメカンをすべて、相手のバトルポケモンにのせ替える。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [{ type: "Darkness", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 559609,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Double rare",
+	dexId: [716],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM6/065.ts
+++ b/data-asia/SM/SM6/065.ts
@@ -1,0 +1,56 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヌメラ",
+	},
+
+	illustrator: "Midori Harada",
+	category: "Pokemon",
+	hp: 40,
+	types: ["Dragon"],
+
+	description: {
+		ja: "ヌメヌメの 粘膜で 身を 守る。 粘膜は 雑菌まみれ なので 触ったら しっかり 手を 洗おう。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ねばるねんまく" },
+			effect: {
+				ja: "このポケモンがバトル場にいるかぎり、相手のポケモンが使うワザに必要なエネルギーは、[無]エネルギー1個ぶん多くなる。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ぶつかる" },
+			damage: 10,
+			cost: ["Fairy"],
+		},
+	],
+
+	weaknesses: [{ type: "Fairy", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559610,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [704],
+};
+
+export default card;

--- a/data-asia/SM/SM6/066.ts
+++ b/data-asia/SM/SM6/066.ts
@@ -1,0 +1,54 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヌメラ",
+	},
+
+	illustrator: "Ken Sugimori",
+	category: "Pokemon",
+	hp: 50,
+	types: ["Dragon"],
+
+	description: {
+		ja: "ヌメヌメの 粘膜で 身を 守る。 粘膜は 雑菌まみれ なので 触ったら しっかり 手を 洗おう。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "みずかけ" },
+			damage: 10,
+			cost: ["Water"],
+		},
+		{
+			name: { ja: "じたばた" },
+			damage: "10×",
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンにのっているダメカンの数x10ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fairy", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559611,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Common",
+	dexId: [704],
+};
+
+export default card;

--- a/data-asia/SM/SM6/067.ts
+++ b/data-asia/SM/SM6/067.ts
@@ -1,0 +1,58 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヌメイル",
+	},
+
+	illustrator: "Atsuko Nishida",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Dragon"],
+
+	description: {
+		ja: "歯が ないので なんでも 溶かす 粘液を 獲物に かけて 溶かしてから すすって 喰らう。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "すいとる" },
+			damage: 30,
+			cost: ["Water", "Colorless"],
+			effect: {
+				ja: "このポケモンのHPを「30」回復する。",
+			},
+		},
+		{
+			name: { ja: "ぶちかます" },
+			damage: 50,
+			cost: ["Water", "Fairy", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fairy", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559612,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ヌメラ",
+	},
+
+	retreat: 2,
+	rarity: "Common",
+	dexId: [705],
+};
+
+export default card;

--- a/data-asia/SM/SM6/068.ts
+++ b/data-asia/SM/SM6/068.ts
@@ -1,0 +1,63 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヌメルゴン",
+	},
+
+	illustrator: "hatachu",
+	category: "Pokemon",
+	hp: 160,
+	types: ["Dragon"],
+
+	description: {
+		ja: "大人しいからと からかうと 角で 思い切り 突かれ 太い 尻尾で 薙ぎ払われる。",
+	},
+
+	stage: "Stage2",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "うるおいボディ" },
+			effect: {
+				ja: "手札からこのポケモンに[水]エネルギーをつけるたび、このポケモンのHPを「20」回復する。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ぬれたつの" },
+			damage: "80+",
+			cost: ["Water", "Fairy", "Colorless"],
+			effect: {
+				ja: "この番、このポケモンのHPを回復していたなら、80ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fairy", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 559613,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ヌメイル",
+	},
+
+	retreat: 3,
+	rarity: "Rare",
+	dexId: [706],
+};
+
+export default card;

--- a/data-asia/SM/SM6/069.ts
+++ b/data-asia/SM/SM6/069.ts
@@ -1,0 +1,54 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ウルトラネクロズマGX",
+	},
+
+	illustrator: "PLANETA Otani",
+	category: "Pokemon",
+	hp: 190,
+	types: ["Dragon"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "フォトンゲイザー" },
+			damage: "20+",
+			cost: ["Psychic", "Metal"],
+			effect: {
+				ja: "このポケモンについている基本[超]エネルギーをすべてトラッシュし、その枚数x80ダメージ追加。",
+			},
+		},
+		{
+			name: { ja: "めつぼうのひかりGX" },
+			cost: ["Psychic", "Metal"],
+			effect: {
+				ja: "このワザは、おたがいのサイドの残り枚数の合計が、6枚以下のときにしか使えない。相手のポケモン全員に、それぞれダメカンを6個のせる。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fairy", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 559614,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Double rare",
+	dexId: [800],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM6/070.ts
+++ b/data-asia/SM/SM6/070.ts
@@ -1,0 +1,46 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "イーブイ",
+	},
+
+	illustrator: "Aya Kusube",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Colorless"],
+
+	description: {
+		ja: "今 現在の 調査では なんと ８種類もの ポケモンへ 進化する 可能性を 持つ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "かじる" },
+			damage: 20,
+			cost: ["Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559615,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [133],
+};
+
+export default card;

--- a/data-asia/SM/SM6/071.ts
+++ b/data-asia/SM/SM6/071.ts
@@ -1,0 +1,53 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ホルビー",
+	},
+
+	illustrator: "Akira Komayama",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Colorless"],
+
+	description: {
+		ja: "シャベルのような 耳を 持つ。 穴掘りで 鍛えた 耳は 太い 根っこを 断ち切る 威力だ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "もってくる" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札を1枚引く。",
+			},
+		},
+		{
+			name: { ja: "かじる" },
+			damage: 20,
+			cost: ["Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559616,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Common",
+	dexId: [659],
+};
+
+export default card;

--- a/data-asia/SM/SM6/072.ts
+++ b/data-asia/SM/SM6/072.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ホルード",
+	},
+
+	illustrator: "Mina Nakai",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Colorless"],
+
+	description: {
+		ja: "ショベルカー並みの パワーの 耳で 硬い 岩盤も コナゴナ。 穴を 掘り終えると ダラダラと 過ごす。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "やまおこし" },
+			damage: "60+",
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "のぞむなら、40ダメージ追加。その場合、自分の山札を上から2枚トラッシュする。",
+			},
+		},
+		{
+			name: { ja: "れんぞくいわなげ" },
+			damage: "80×",
+			cost: ["Colorless", "Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "ウラが出るまでコインを投げ、オモテの数x80ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559617,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ホルビー",
+	},
+
+	retreat: 3,
+	rarity: "Common",
+	dexId: [660],
+};
+
+export default card;

--- a/data-asia/SM/SM6/073.ts
+++ b/data-asia/SM/SM6/073.ts
@@ -1,0 +1,49 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "トリミアン",
+	},
+
+	illustrator: "Kagemaru Himeno",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Colorless"],
+
+	description: {
+		ja: "大昔の カロス地方では 王様を 護衛する 役目を 与えられた ポケモン。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "おんがえし" },
+			damage: 20,
+			cost: ["Colorless"],
+			effect: {
+				ja: "のぞむなら、自分の手札が5枚になるように、山札を引く。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559618,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [676],
+};
+
+export default card;

--- a/data-asia/SM/SM6/074.ts
+++ b/data-asia/SM/SM6/074.ts
@@ -1,0 +1,53 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "オンバット",
+	},
+
+	illustrator: "Anesaki Dynamic",
+	category: "Pokemon",
+	hp: 50,
+	types: ["Colorless"],
+
+	description: {
+		ja: "２０万ヘルツの 超音波を 浴びると 屈強な レスラーも 目が 回り 立っていられないのだ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ぶつかる" },
+			damage: 10,
+			cost: ["Colorless"],
+		},
+		{
+			name: { ja: "はかいおん" },
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "相手の手札を見て、その中にあるグッズを、すべてトラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559619,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [714],
+};
+
+export default card;

--- a/data-asia/SM/SM6/075.ts
+++ b/data-asia/SM/SM6/075.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "オンバーン",
+	},
+
+	illustrator: "You Iribi",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Colorless"],
+
+	description: {
+		ja: "耳から 発する 超音波で 巨大な 岩も 粉砕する。 暗闇に 紛れて 襲いかかる。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "ちょうおんぱ" },
+			damage: 20,
+			cost: ["Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをこんらんにする。",
+			},
+		},
+		{
+			name: { ja: "きょうしん" },
+			damage: "70+",
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンがこんらんなら、70ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559620,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "オンバット",
+	},
+
+	retreat: 1,
+	rarity: "Uncommon",
+	dexId: [715],
+};
+
+export default card;

--- a/data-asia/SM/SM6/076.ts
+++ b/data-asia/SM/SM6/076.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "エネポーター",
+	},
+
+	illustrator: "Toyste Beach",
+	category: "Trainer",
+
+	effect: {
+		ja: "相手の場のポケモンについている特殊エネルギーを1個、相手の別のポケモンにつけ替える。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559621,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM6/077.ts
+++ b/data-asia/SM/SM6/077.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "化石発掘マップ",
+	},
+
+	illustrator: "Yoshinobu Saito",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の山札またはトラッシュのどちらかを選ぶ。その中にある「なぞの化石」を1枚、相手に見せてから、手札に加える。山札を見たなら、山札を切る。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559622,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM6/078.ts
+++ b/data-asia/SM/SM6/078.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "なぞの化石",
+	},
+
+	illustrator: "Toyste Beach",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードは、HP60の[無]タイプのたねポケモンとして、場に出すことができる。自分の番の中でなら、場に出ているこのカードをトラッシュしてよい。このカードは、にげられない。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559623,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	rarity: "Common",
+};
+
+export default card;

--- a/data-asia/SM/SM6/079.ts
+++ b/data-asia/SM/SM6/079.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ハイパーボール",
+	},
+
+	illustrator: "Ryo Ueda",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードは、自分の手札を2枚トラッシュしなければ使えない。自分の山札からポケモンを1枚選び、相手に見せてから、手札に加える。そして山札を切る。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559624,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM6/080.ts
+++ b/data-asia/SM/SM6/080.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ふしぎなアメ",
+	},
+
+	illustrator: "Toyste Beach",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分のたねポケモン1匹から進化する1進化の上の2進化ポケモンを、手札から1枚選び、そのたねポケモンにのせて進化させる。[最初の自分の番と、この番出したばかりのたねポケモンには使えない。]",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559625,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM6/081.ts
+++ b/data-asia/SM/SM6/081.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ポケモンいれかえ",
+	},
+
+	illustrator: "Ryo Ueda",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分のバトルポケモンをベンチポケモンと入れ替える。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559626,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM6/082.ts
+++ b/data-asia/SM/SM6/082.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ポケモンキャッチャー",
+	},
+
+	illustrator: "Toyste Beach",
+	category: "Trainer",
+
+	effect: {
+		ja: "相手のベンチポケモンを1匹選び、バトルポケモンと入れ替える。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559627,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM6/083.ts
+++ b/data-asia/SM/SM6/083.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ミステリートレジャー",
+	},
+
+	illustrator: "Eske Yoshinob",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードは、自分の手札を1枚トラッシュしなければ使えない。自分の山札にある[超]または[竜]ポケモンを1枚、相手に見せてから、手札に加える。そして山札を切る。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559628,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM6/084.ts
+++ b/data-asia/SM/SM6/084.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "こだわりハチマキ",
+	},
+
+	illustrator: "Eske Yoshinob",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードをつけているポケモンが使うワザの、相手のバトル場の「ポケモンGX・EX」へのダメージは「+30」される。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559629,
+			},
+		},
+	],
+
+	trainerType: "Tool",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM6/085.ts
+++ b/data-asia/SM/SM6/085.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "おじょうさま",
+	},
+
+	illustrator: "Yusuke Ohmura",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の山札にある基本エネルギーを4枚まで、相手に見せてから、手札に加える。そして山札を切る。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559630,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM6/086.ts
+++ b/data-asia/SM/SM6/086.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "カルネ",
+	},
+
+	illustrator: "Ken Sugimori",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードは、前の相手の番に、自分の[妖]ポケモンがきぜつしていなければ使えない。自分のトラッシュにある好きなカードを2枚、相手に見せてから、手札に加える。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 559631,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	rarity: "Rare",
+};
+
+export default card;

--- a/data-asia/SM/SM6/087.ts
+++ b/data-asia/SM/SM6/087.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ジャッジマン",
+	},
+
+	illustrator: "Sanosuke Sakuma",
+	category: "Trainer",
+
+	effect: {
+		ja: "おたがいのプレイヤーは、それぞれ、手札をすべて山札にもどし、山札を切る。その後、それぞれの山札を4枚引く。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559632,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM6/088.ts
+++ b/data-asia/SM/SM6/088.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ハウ",
+	},
+
+	illustrator: "Ken Sugimori",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の山札を3枚引く。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559633,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM6/089.ts
+++ b/data-asia/SM/SM6/089.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "フラダリ",
+	},
+
+	illustrator: "Hitoshi Ariga",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の場の[炎]ポケモンの数ぶん、相手のトラッシュにある好きなカードを、ロストゾーンに置く。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 559634,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	rarity: "Rare Holo",
+};
+
+export default card;

--- a/data-asia/SM/SM6/090.ts
+++ b/data-asia/SM/SM6/090.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ユリーカ",
+	},
+
+	illustrator: "Hideki Ishikawa",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードは、場にスタジアムが出ていなければ使えない。場に出ているスタジアムをトラッシュする。この番、自分の「ジガルデGX」は、自分がすでにGXワザを使っていても、GXワザが使える。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559635,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM6/091.ts
+++ b/data-asia/SM/SM6/091.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "リーリエ",
+	},
+
+	illustrator: "Ken Sugimori",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の手札が6枚になるように、山札を引く。最初の自分の番に使ったなら、8枚になるように引く。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559636,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM6/092.ts
+++ b/data-asia/SM/SM6/092.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "フラダリラボ",
+	},
+
+	illustrator: "Ryo Ueda",
+	category: "Trainer",
+
+	effect: {
+		ja: "おたがいの場にある「ポケモンのどうぐ」の効果は、すべてなくなる。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559637,
+			},
+		},
+	],
+
+	trainerType: "Stadium",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM6/093.ts
+++ b/data-asia/SM/SM6/093.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ダブル無色エネルギー",
+	},
+
+	illustrator: "",
+	category: "Energy",
+	energyType: "Special",
+
+	effect: {
+		ja: "このカードは、[無]エネルギー2個ぶんとしてはたらく。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559638,
+			},
+		},
+	],
+
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM6/094.ts
+++ b/data-asia/SM/SM6/094.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ユニットエネルギー闘悪妖",
+	},
+
+	illustrator: "",
+	category: "Energy",
+	energyType: "Special",
+
+	effect: {
+		ja: "このカードは、ポケモンについているかぎり、[闘][悪][妖]の3つのタイプのエネルギー1個ぶんとしてはたらく。ポケモンについていないなら、[無]エネルギー1個ぶんとしてはたらく。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559639,
+			},
+		},
+	],
+
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM6/095.ts
+++ b/data-asia/SM/SM6/095.ts
@@ -1,0 +1,68 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ゲッコウガGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 230,
+	types: ["Water"],
+
+	stage: "Stage2",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ふうましゅりけん" },
+			effect: {
+				ja: "自分の番に、このカードを手札から出して進化させたとき、1回使える。相手のポケモン1匹に、ダメカンを3個のせる。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "おぼろぎり" },
+			damage: 110,
+			cost: ["Water", "Colorless", "Colorless"],
+			effect: {
+				ja: "のぞむなら、このポケモンと、ついているすべてのカードを、自分の山札にもどして切る。",
+			},
+		},
+		{
+			name: { ja: "シャドーアサシンGX" },
+			cost: ["Water", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のベンチポケモン1匹に、130ダメージ。［ベンチは弱点・抵抗力を計算しない。］［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 559640,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ゲコガシラ",
+	},
+
+	retreat: 2,
+	rarity: "Ultra Rare",
+	dexId: [658],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM6/096.ts
+++ b/data-asia/SM/SM6/096.ts
@@ -1,0 +1,60 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ジガルデGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 200,
+	types: ["Fighting"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "セルコネクター" },
+			damage: 50,
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "自分のトラッシュにある[闘]エネルギーを2枚、このポケモンにつける。",
+			},
+		},
+		{
+			name: { ja: "グランドフォース" },
+			damage: 130,
+			cost: ["Fighting", "Fighting", "Colorless", "Colorless"],
+		},
+		{
+			name: { ja: "ジャッジメントGX" },
+			damage: 150,
+			cost: ["Fighting", "Fighting", "Colorless", "Colorless"],
+			effect: {
+				ja: "次の相手の番、このポケモンは「ポケモンGX・EX」からワザのダメージを受けない。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 559641,
+			},
+		},
+	],
+
+	retreat: 3,
+	rarity: "Ultra Rare",
+	dexId: [718],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM6/097.ts
+++ b/data-asia/SM/SM6/097.ts
@@ -1,0 +1,62 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "イベルタルGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 180,
+	types: ["Darkness"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "せいきをすいとる" },
+			damage: 20,
+			cost: ["Darkness"],
+			effect: {
+				ja: "相手のバトルポケモンに与えたダメージぶん、このポケモンのHPを回復する。",
+			},
+		},
+		{
+			name: { ja: "イビルソニック" },
+			damage: 100,
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "このワザのダメージは弱点・抵抗力を計算しない。",
+			},
+		},
+		{
+			name: { ja: "デスカウントGX" },
+			cost: ["Darkness"],
+			effect: {
+				ja: "相手のバトルポケモンにダメカンが4個のっているなら、そのポケモンをきぜつさせる。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 559642,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Ultra Rare",
+	dexId: [717],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM6/098.ts
+++ b/data-asia/SM/SM6/098.ts
@@ -1,0 +1,59 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ゼルネアスGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 180,
+	types: ["Fairy"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "かけぬける" },
+			damage: 20,
+			cost: ["Colorless"],
+			effect: {
+				ja: "相手のベンチポケモン1匹にも、20ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+			},
+		},
+		{
+			name: { ja: "オーロラホーン" },
+			damage: 120,
+			cost: ["Fairy", "Fairy", "Colorless"],
+		},
+		{
+			name: { ja: "サンクチュアリGX" },
+			cost: ["Fairy", "Fairy", "Colorless"],
+			effect: {
+				ja: "自分のポケモン全員にのっているダメカンをすべて、相手のバトルポケモンにのせ替える。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [{ type: "Darkness", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 559643,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Ultra Rare",
+	dexId: [716],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM6/099.ts
+++ b/data-asia/SM/SM6/099.ts
@@ -1,0 +1,54 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ウルトラネクロズマGX",
+	},
+
+	illustrator: "PLANETA",
+	category: "Pokemon",
+	hp: 190,
+	types: ["Dragon"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "フォトンゲイザー" },
+			damage: "20+",
+			cost: ["Psychic", "Metal"],
+			effect: {
+				ja: "このポケモンについている基本[超]エネルギーをすべてトラッシュし、その枚数x80ダメージ追加。",
+			},
+		},
+		{
+			name: { ja: "めつぼうのひかりGX" },
+			cost: ["Psychic", "Metal"],
+			effect: {
+				ja: "このワザは、おたがいのサイドの残り枚数の合計が、6枚以下のときにしか使えない。相手のポケモン全員に、それぞれダメカンを6個のせる。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fairy", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 559644,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Ultra Rare",
+	dexId: [800],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM6/100.ts
+++ b/data-asia/SM/SM6/100.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "おじょうさま",
+	},
+
+	illustrator: "Kanako Eo",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の山札にある基本エネルギーを4枚まで、相手に見せてから、手札に加える。そして山札を切る。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 559645,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	rarity: "Ultra Rare",
+};
+
+export default card;

--- a/data-asia/SM/SM6/101.ts
+++ b/data-asia/SM/SM6/101.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "カルネ",
+	},
+
+	illustrator: "nagimiso",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードは、前の相手の番に、自分の[妖]ポケモンがきぜつしていなければ使えない。自分のトラッシュにある好きなカードを2枚、相手に見せてから、手札に加える。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 559646,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	rarity: "Ultra Rare",
+};
+
+export default card;

--- a/data-asia/SM/SM6/102.ts
+++ b/data-asia/SM/SM6/102.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ユリーカ",
+	},
+
+	illustrator: "Hideki Ishikawa",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードは、場にスタジアムが出ていなければ使えない。場に出ているスタジアムをトラッシュする。この番、自分の「ジガルデGX」は、自分がすでにGXワザを使っていても、GXワザが使える。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 559647,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	rarity: "Ultra Rare",
+};
+
+export default card;

--- a/data-asia/SM/SM6/103.ts
+++ b/data-asia/SM/SM6/103.ts
@@ -1,0 +1,68 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ゲッコウガGX",
+	},
+
+	illustrator: "Hideki Ishikawa",
+	category: "Pokemon",
+	hp: 230,
+	types: ["Water"],
+
+	stage: "Stage2",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ふうましゅりけん" },
+			effect: {
+				ja: "自分の番に、このカードを手札から出して進化させたとき、1回使える。相手のポケモン1匹に、ダメカンを3個のせる。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "おぼろぎり" },
+			damage: 110,
+			cost: ["Water", "Colorless", "Colorless"],
+			effect: {
+				ja: "のぞむなら、このポケモンと、ついているすべてのカードを、自分の山札にもどして切る。",
+			},
+		},
+		{
+			name: { ja: "シャドーアサシンGX" },
+			cost: ["Water", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のベンチポケモン1匹に、130ダメージ。［ベンチは弱点・抵抗力を計算しない。］［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 559648,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ゲコガシラ",
+	},
+
+	retreat: 2,
+	rarity: "Hyper rare",
+	dexId: [658],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM6/104.ts
+++ b/data-asia/SM/SM6/104.ts
@@ -1,0 +1,60 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ジガルデGX",
+	},
+
+	illustrator: "Ken Sugimori",
+	category: "Pokemon",
+	hp: 200,
+	types: ["Fighting"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "セルコネクター" },
+			damage: 50,
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "自分のトラッシュにある[闘]エネルギーを2枚、このポケモンにつける。",
+			},
+		},
+		{
+			name: { ja: "グランドフォース" },
+			damage: 130,
+			cost: ["Fighting", "Fighting", "Colorless", "Colorless"],
+		},
+		{
+			name: { ja: "ジャッジメントGX" },
+			damage: 150,
+			cost: ["Fighting", "Fighting", "Colorless", "Colorless"],
+			effect: {
+				ja: "次の相手の番、このポケモンは「ポケモンGX・EX」からワザのダメージを受けない。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 559649,
+			},
+		},
+	],
+
+	retreat: 3,
+	rarity: "Hyper rare",
+	dexId: [718],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM6/105.ts
+++ b/data-asia/SM/SM6/105.ts
@@ -1,0 +1,62 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "イベルタルGX",
+	},
+
+	illustrator: "Ken Sugimori",
+	category: "Pokemon",
+	hp: 180,
+	types: ["Darkness"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "せいきをすいとる" },
+			damage: 20,
+			cost: ["Darkness"],
+			effect: {
+				ja: "相手のバトルポケモンに与えたダメージぶん、このポケモンのHPを回復する。",
+			},
+		},
+		{
+			name: { ja: "イビルソニック" },
+			damage: 100,
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "このワザのダメージは弱点・抵抗力を計算しない。",
+			},
+		},
+		{
+			name: { ja: "デスカウントGX" },
+			cost: ["Darkness"],
+			effect: {
+				ja: "相手のバトルポケモンにダメカンが4個のっているなら、そのポケモンをきぜつさせる。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 559650,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Hyper rare",
+	dexId: [717],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM6/106.ts
+++ b/data-asia/SM/SM6/106.ts
@@ -1,0 +1,59 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ゼルネアスGX",
+	},
+
+	illustrator: "Toyste Beach",
+	category: "Pokemon",
+	hp: 180,
+	types: ["Fairy"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "かけぬける" },
+			damage: 20,
+			cost: ["Colorless"],
+			effect: {
+				ja: "相手のベンチポケモン1匹にも、20ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+			},
+		},
+		{
+			name: { ja: "オーロラホーン" },
+			damage: 120,
+			cost: ["Fairy", "Fairy", "Colorless"],
+		},
+		{
+			name: { ja: "サンクチュアリGX" },
+			cost: ["Fairy", "Fairy", "Colorless"],
+			effect: {
+				ja: "自分のポケモン全員にのっているダメカンをすべて、相手のバトルポケモンにのせ替える。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [{ type: "Darkness", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 559651,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Hyper rare",
+	dexId: [716],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM6/107.ts
+++ b/data-asia/SM/SM6/107.ts
@@ -1,0 +1,54 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ウルトラネクロズマGX",
+	},
+
+	illustrator: "Yoshinobu Saito",
+	category: "Pokemon",
+	hp: 190,
+	types: ["Dragon"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "フォトンゲイザー" },
+			damage: "20+",
+			cost: ["Psychic", "Metal"],
+			effect: {
+				ja: "このポケモンについている基本[超]エネルギーをすべてトラッシュし、その枚数x80ダメージ追加。",
+			},
+		},
+		{
+			name: { ja: "めつぼうのひかりGX" },
+			cost: ["Psychic", "Metal"],
+			effect: {
+				ja: "このワザは、おたがいのサイドの残り枚数の合計が、6枚以下のときにしか使えない。相手のポケモン全員に、それぞれダメカンを6個のせる。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fairy", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 559652,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Hyper rare",
+	dexId: [800],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM6/108.ts
+++ b/data-asia/SM/SM6/108.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "エネポーター",
+	},
+
+	illustrator: "Sanosuke Sakuma",
+	category: "Trainer",
+
+	effect: {
+		ja: "相手の場のポケモンについている特殊エネルギーを1個、相手の別のポケモンにつけ替える。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 559653,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	rarity: "Secret Rare",
+};
+
+export default card;

--- a/data-asia/SM/SM6/109.ts
+++ b/data-asia/SM/SM6/109.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ミステリートレジャー",
+	},
+
+	illustrator: "Yusuke Ohmura",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードは、自分の手札を1枚トラッシュしなければ使えない。自分の山札にある[超]または[竜]ポケモンを1枚、相手に見せてから、手札に加える。そして山札を切る。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 559654,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	rarity: "Secret Rare",
+};
+
+export default card;

--- a/data-asia/SM/SM6/110.ts
+++ b/data-asia/SM/SM6/110.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ユニットエネルギー闘悪妖",
+	},
+
+	illustrator: "Hitoshi Ariga",
+	category: "Energy",
+	energyType: "Special",
+
+	effect: {
+		ja: "このカードは、ポケモンについているかぎり、[闘][悪][妖]の3つのタイプのエネルギー1個ぶんとしてはたらく。ポケモンについていないなら、[無]エネルギー1個ぶんとしてはたらく。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 559655,
+			},
+		},
+	],
+
+	rarity: "Secret Rare",
+};
+
+export default card;


### PR DESCRIPTION
## What

Adds the complete Japanese set **SM6 禁断の光 (Forbidden Light)**, released 2018-03-02:

- `data-asia/SM/SM6/001.ts` … `110.ts` — all 110 cards (94 regular + 16 secret rares: 8 SR, 5 UR, 3 Secret Rare)
- the set definition `data-asia/SM/SM6.ts` already existed and is untouched

## Data sources

- **pokemon-card.com** (official database): Japanese names, flavor texts, National Dex numbers, official card count
- **limitlesstcg.com**: full Japanese card text, stages, weaknesses/resistances/retreat, rarities, illustrators, attack costs
- **Cardmarket**: product IDs as `thirdParty.cardmarket` on the variant objects (559546–559655; tcgplayer IDs not available to me)

## Notes

- Follows the file format and conventions of the M-era sets (#1728)
- No `regulationMark` (the set predates regulation marks); resistances are `-20` per the era
- All 110 files type-check against `interfaces.d.ts` (`tsc --noEmit`)
