### PR TITLE
(data) Add Japanese SM set SM6a Dragon Storm

### DIFF
--- a/data-asia/SM/SM6a/001.ts
+++ b/data-asia/SM/SM6a/001.ts
@@ -1,0 +1,49 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヒトカゲ",
+	},
+
+	illustrator: "tetsuya koizumi",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Fire"],
+
+	description: {
+		ja: "生まれたときから 尻尾に 炎が 点っている。 炎が 消えたとき その 命は 終わってしまう。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ほのおのキバ" },
+			damage: 20,
+			cost: ["Fire", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをやけどにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559237,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Common",
+	dexId: [4],
+};
+
+export default card;

--- a/data-asia/SM/SM6a/002.ts
+++ b/data-asia/SM/SM6a/002.ts
@@ -1,0 +1,63 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "リザード",
+	},
+
+	illustrator: "kodama",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Fire"],
+
+	description: {
+		ja: "燃える 尻尾を 振り回すと まわりの 温度が どんどん 上がって 相手を 苦しめる。",
+	},
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "もえるとうし" },
+			effect: {
+				ja: "自分の番に、このカードを手札から出して進化させたとき、1回使える。自分の山札を上から5枚トラッシュし、その中にある[炎]エネルギーをすべて、このポケモンにつける。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "かえんほうしゃ" },
+			damage: 80,
+			cost: ["Fire", "Fire", "Colorless"],
+			effect: {
+				ja: "このポケモンについているエネルギーを、1個トラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559238,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ヒトカゲ",
+	},
+
+	retreat: 2,
+	rarity: "Uncommon",
+	dexId: [5],
+};
+
+export default card;

--- a/data-asia/SM/SM6a/003.ts
+++ b/data-asia/SM/SM6a/003.ts
@@ -1,0 +1,63 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "リザードン",
+	},
+
+	illustrator: "Ryota Murayama",
+	category: "Pokemon",
+	hp: 160,
+	types: ["Fire"],
+
+	description: {
+		ja: "地上 １４００メートルまで 羽を 使って 飛ぶことができる。 高熱の 炎を 吐く。",
+	},
+
+	stage: "Stage2",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "かくごのほのお" },
+			effect: {
+				ja: "このポケモンが使うワザの、相手のバトルポケモンへのダメージは、相手の場の「ポケモンGX・EX」1匹につき「+30」される。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ファイヤーブラスト" },
+			damage: 130,
+			cost: ["Fire", "Fire", "Colorless"],
+			effect: {
+				ja: "このポケモンについているエネルギーを、1個トラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 559239,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "リザード",
+	},
+
+	retreat: 2,
+	rarity: "Rare",
+	dexId: [6],
+};
+
+export default card;

--- a/data-asia/SM/SM6a/004.ts
+++ b/data-asia/SM/SM6a/004.ts
@@ -1,0 +1,49 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ビクティニ",
+	},
+
+	illustrator: "Shin Nagasawa",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Fire"],
+
+	description: {
+		ja: "ビクティニが 無限に 生み出す エネルギーを 分け与えてもらうと 全身に パワーが あふれ出す。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "インフィニティ" },
+			damage: "20×",
+			cost: ["Fire", "Fire"],
+			effect: {
+				ja: "自分のトラッシュにある基本エネルギーをすべて相手に見せ、その枚数x20ダメージ。その後、見せたエネルギーを山札にもどして切る。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 559240,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Rare Holo",
+	dexId: [494],
+};
+
+export default card;

--- a/data-asia/SM/SM6a/005.ts
+++ b/data-asia/SM/SM6a/005.ts
@@ -1,0 +1,49 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ダルマッカ",
+	},
+
+	illustrator: "Mitsuhiro Arita",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Fire"],
+
+	description: {
+		ja: "寝るときは 手足を ひっこめ 体内で 燃えている ６００度の 炎も 小さくなり 落ち着くよ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ダメージラッシュ" },
+			damage: "10+",
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "ウラが出るまでコインを投げ、オモテの数x30ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559241,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Common",
+	dexId: [554],
+};
+
+export default card;

--- a/data-asia/SM/SM6a/006.ts
+++ b/data-asia/SM/SM6a/006.ts
@@ -1,0 +1,60 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヒヒダルマ",
+	},
+
+	illustrator: "Masakazu Fukuda",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Fire"],
+
+	description: {
+		ja: "体内で １４００度の 炎を 燃やすことで ダンプカーを パンチで 破壊するほどの パワーを 作る。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "ヒートアシスト" },
+			cost: ["Fire"],
+			effect: {
+				ja: "自分の手札にある[炎]エネルギーを3枚まで、自分のポケモンに好きなようにつける。",
+			},
+		},
+		{
+			name: { ja: "だるまれんだん" },
+			damage: "30+",
+			cost: ["Fire", "Fire", "Colorless"],
+			effect: {
+				ja: "コインを4回投げ、オモテの数x50ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559242,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ダルマッカ",
+	},
+
+	retreat: 2,
+	rarity: "Common",
+	dexId: [555],
+};
+
+export default card;

--- a/data-asia/SM/SM6a/007.ts
+++ b/data-asia/SM/SM6a/007.ts
@@ -1,0 +1,56 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "クイタラン",
+	},
+
+	illustrator: "Ken Sugimori",
+	category: "Pokemon",
+	hp: 110,
+	types: ["Fire"],
+
+	description: {
+		ja: "尻尾から 取りこんだ 空気を 炎に変えて ベロのように 使い アイアントを 溶かして 食べるぞ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "こがす" },
+			cost: ["Fire"],
+			effect: {
+				ja: "相手のバトルポケモンをやけどにする。",
+			},
+		},
+		{
+			name: { ja: "くろこげブレス" },
+			damage: 120,
+			cost: ["Fire", "Fire"],
+			effect: {
+				ja: "相手のバトルポケモンがやけどでないなら、このワザは失敗。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559243,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Common",
+	dexId: [631],
+};
+
+export default card;

--- a/data-asia/SM/SM6a/008.ts
+++ b/data-asia/SM/SM6a/008.ts
@@ -1,0 +1,62 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "レシラムGX",
+	},
+
+	illustrator: "PLANETA Otani",
+	category: "Pokemon",
+	hp: 180,
+	types: ["Fire"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ニトロチャージ" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札にある[炎]エネルギーを2枚まで、このポケモンにつける。そして山札を切る。",
+			},
+		},
+		{
+			name: { ja: "しゃくねつのはしら" },
+			damage: 110,
+			cost: ["Fire", "Fire", "Fire", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをやけどにする。",
+			},
+		},
+		{
+			name: { ja: "ヴァーミリオンGX" },
+			damage: 180,
+			cost: ["Fire", "Fire", "Fire", "Colorless"],
+			effect: {
+				ja: "のぞむなら、自分の手札にある[炎]エネルギーを5枚まで、自分のポケモンに好きなようにつける。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 559244,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Double rare",
+	dexId: [643],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM6a/009.ts
+++ b/data-asia/SM/SM6a/009.ts
@@ -1,0 +1,53 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヤトウモリ",
+	},
+
+	illustrator: "MAHOU",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Fire"],
+
+	description: {
+		ja: "火山や 乾いた 岩場に 棲む。 甘い 香りの 毒ガスを 放ち むしポケモンを おびき寄せ 襲う。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "なかまをよぶ" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札にあるたねポケモンを1枚、ベンチに出す。そして山札を切る。",
+			},
+		},
+		{
+			name: { ja: "ツメをたてる" },
+			damage: 20,
+			cost: ["Fire", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559245,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [757],
+};
+
+export default card;

--- a/data-asia/SM/SM6a/010.ts
+++ b/data-asia/SM/SM6a/010.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "エンニュート",
+	},
+
+	illustrator: "Naoki Saito",
+	category: "Pokemon",
+	hp: 110,
+	types: ["Fire"],
+
+	description: {
+		ja: "毒ガスには 多くの フェロモンが 含まれている。 薄めることで 官能的な 香水が できる。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "フレイムサークル" },
+			damage: 20,
+			cost: ["Fire"],
+			effect: {
+				ja: "相手のバトルポケモンをやけどにする。次の相手の番、このワザを受けたポケモンは、にげられない。",
+			},
+		},
+		{
+			name: { ja: "かえんほうしゃ" },
+			damage: 80,
+			cost: ["Fire", "Colorless"],
+			effect: {
+				ja: "このポケモンについているエネルギーを、1個トラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559246,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ヤトウモリ",
+	},
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [758],
+};
+
+export default card;

--- a/data-asia/SM/SM6a/011.ts
+++ b/data-asia/SM/SM6a/011.ts
@@ -1,0 +1,48 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "タッツー",
+	},
+
+	illustrator: "Yukiko Baba",
+	category: "Pokemon",
+	hp: 40,
+	types: ["Water"],
+
+	description: {
+		ja: "サンゴの 陰に 住処を 作る。 危険を 感じると 口から 真っ黒い 墨を 吐いて 逃げる。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "みずとばし" },
+			cost: ["Water"],
+			effect: {
+				ja: "相手のポケモン1匹に、20ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559248,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [116],
+};
+
+export default card;

--- a/data-asia/SM/SM6a/012.ts
+++ b/data-asia/SM/SM6a/012.ts
@@ -1,0 +1,49 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "タッツー",
+	},
+
+	illustrator: "Mizue",
+	category: "Pokemon",
+	hp: 50,
+	types: ["Water"],
+
+	description: {
+		ja: "サンゴの 陰に 住処を 作る。 危険を 感じると 口から 真っ黒い 墨を 吐いて 逃げる。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ハイドロポンプ" },
+			damage: "10+",
+			cost: ["Colorless"],
+			effect: {
+				ja: "このポケモンについている[水]エネルギーの数x10ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559249,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [116],
+};
+
+export default card;

--- a/data-asia/SM/SM6a/013.ts
+++ b/data-asia/SM/SM6a/013.ts
@@ -1,0 +1,53 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "シードラ",
+	},
+
+	illustrator: "Yumi",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Water"],
+
+	description: {
+		ja: "羽と 尻尾を 素早く 動かし 前を 向いたまま 後ろへ 泳ぐこともできる ポケモン。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "ハイドロポンプ" },
+			damage: "10+",
+			cost: ["Colorless"],
+			effect: {
+				ja: "このポケモンについている[水]エネルギーの数x20ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559250,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "タッツー",
+	},
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [117],
+};
+
+export default card;

--- a/data-asia/SM/SM6a/014.ts
+++ b/data-asia/SM/SM6a/014.ts
@@ -1,0 +1,66 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "キングドラGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 230,
+	types: ["Water"],
+
+	stage: "Stage2",
+
+	attacks: [
+		{
+			name: { ja: "ハイドロポンプ" },
+			damage: "10+",
+			cost: ["Colorless"],
+			effect: {
+				ja: "このポケモンについている[水]エネルギーの数x50ダメージ追加。",
+			},
+		},
+		{
+			name: { ja: "ぎゃくふんしゃ" },
+			damage: 30,
+			cost: ["Water"],
+			effect: {
+				ja: "このポケモンをベンチポケモンと入れ替える。",
+			},
+		},
+		{
+			name: { ja: "メイルストロムGX" },
+			cost: ["Water"],
+			effect: {
+				ja: "相手のポケモン全員に、それぞれ40ダメージ。［ベンチは弱点・抵抗力を計算しない。］［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 559253,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "シードラ",
+	},
+
+	retreat: 2,
+	rarity: "Double rare",
+	dexId: [230],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM6a/015.ts
+++ b/data-asia/SM/SM6a/015.ts
@@ -1,0 +1,49 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "コイキング",
+	},
+
+	illustrator: "Sekio",
+	category: "Pokemon",
+	hp: 30,
+	types: ["Water"],
+
+	description: {
+		ja: "無闇に 跳ねて すぐ 襲われるが コイキングの おかげで 多くの ポケモンが 生き延びられると いう。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "みずしぶき" },
+			damage: "10+",
+			cost: ["Water"],
+			effect: {
+				ja: "コインを1回投げオモテなら、10ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559255,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [129],
+};
+
+export default card;

--- a/data-asia/SM/SM6a/016.ts
+++ b/data-asia/SM/SM6a/016.ts
@@ -1,0 +1,63 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ギャラドス",
+	},
+
+	illustrator: "kawayoo",
+	category: "Pokemon",
+	hp: 160,
+	types: ["Water"],
+
+	description: {
+		ja: "ギャラドスが 現れる 場所は 破壊される 定めに あると 信じている 人も いる。",
+	},
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "おおあれ" },
+			effect: {
+				ja: "このポケモンが、バトル場で相手のポケモンからワザのダメージを受けたとき、自分のベンチポケモン全員に、それぞれダメカンを2個のせる。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ワイルドテール" },
+			damage: 160,
+			cost: ["Water", "Water", "Colorless"],
+			effect: {
+				ja: "のぞむなら、場に出ているスタジアムをトラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 559257,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "コイキング",
+	},
+
+	retreat: 4,
+	rarity: "Rare",
+	dexId: [130],
+};
+
+export default card;

--- a/data-asia/SM/SM6a/017.ts
+++ b/data-asia/SM/SM6a/017.ts
@@ -1,0 +1,57 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ラプラス",
+	},
+
+	illustrator: "Saya Tsuruta",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Water"],
+
+	description: {
+		ja: "密漁で 絶滅寸前に。 大切に 保護 された 結果 逆に 増え過ぎてきたという。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "アクアバレット" },
+			damage: 20,
+			cost: ["Water"],
+			effect: {
+				ja: "相手のベンチポケモン1匹にも、20ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+			},
+		},
+		{
+			name: { ja: "ハイドロポンプ" },
+			damage: "70+",
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンについている[水]エネルギーの数x10ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559262,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Common",
+	dexId: [131],
+};
+
+export default card;

--- a/data-asia/SM/SM6a/018.ts
+++ b/data-asia/SM/SM6a/018.ts
@@ -1,0 +1,51 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ウパー",
+	},
+
+	illustrator: "Shibuzoh.",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Water"],
+
+	description: {
+		ja: "夕暮れどき 涼しくなると 水から 上がってきた ウパーたちは エサを 探して 水辺を 歩く。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ぶつかる" },
+			damage: 10,
+			cost: ["Colorless"],
+		},
+		{
+			name: { ja: "みずかけ" },
+			damage: 20,
+			cost: ["Water", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559265,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [194],
+};
+
+export default card;

--- a/data-asia/SM/SM6a/019.ts
+++ b/data-asia/SM/SM6a/019.ts
@@ -1,0 +1,63 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヌオー",
+	},
+
+	illustrator: "Ken Sugimori",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Water"],
+
+	description: {
+		ja: "のんびりとした 性格で 気ままに 泳いでは いつも 船底に 頭を ぶつけている。",
+	},
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "おしながす" },
+			effect: {
+				ja: "自分の番に何回でも使える。自分のベンチポケモンについている[水]エネルギーを1個、バトルポケモンにつけ替える。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ハイドロポンプ" },
+			damage: "60+",
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンについている[水]エネルギーの数x20ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559268,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ウパー",
+	},
+
+	retreat: 2,
+	rarity: "Uncommon",
+	dexId: [195],
+};
+
+export default card;

--- a/data-asia/SM/SM6a/020.ts
+++ b/data-asia/SM/SM6a/020.ts
@@ -1,0 +1,48 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "サニーゴ",
+	},
+
+	illustrator: "Kagemaru Himeno",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Water"],
+
+	description: {
+		ja: "頭の 枝を 狙い ヒドイデが 追いかけてくると 自分で 枝を ポキリと 折って 逃げだすよ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "バブルシュート" },
+			cost: ["Water"],
+			effect: {
+				ja: "相手のポケモン1匹に、このポケモンについている[水]エネルギーの数x20ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559271,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [222],
+};
+
+export default card;

--- a/data-asia/SM/SM6a/021.ts
+++ b/data-asia/SM/SM6a/021.ts
@@ -1,0 +1,56 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヒンバス",
+	},
+
+	illustrator: "Shin Nagasawa",
+	category: "Pokemon",
+	hp: 30,
+	types: ["Water"],
+
+	description: {
+		ja: "見た目が 悪いので 人気はないが 脅威の 生命力が あり 研究対象には なっている。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "もぐる" },
+			effect: {
+				ja: "このポケモンは、ベンチにいるかぎり、ワザのダメージを受けない。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "みずかけ" },
+			damage: 10,
+			cost: ["Water"],
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559273,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [349],
+};
+
+export default card;

--- a/data-asia/SM/SM6a/022.ts
+++ b/data-asia/SM/SM6a/022.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ミロカロス",
+	},
+
+	illustrator: "hatachu",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Water"],
+
+	description: {
+		ja: "澄んだ 湖の 底に 棲む。 戦争が 起こるとき 現れ 人々の 心を いやす。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "オーロラウェーブ" },
+			damage: 30,
+			cost: ["Water"],
+			effect: {
+				ja: "相手のバトルポケモンをこんらんにする。",
+			},
+		},
+		{
+			name: { ja: "アクアスプリット" },
+			damage: 40,
+			cost: ["Water", "Water", "Water"],
+			effect: {
+				ja: "相手のベンチポケモン2匹にも、それぞれ40ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559275,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ヒンバス",
+	},
+
+	retreat: 1,
+	rarity: "Uncommon",
+	dexId: [350],
+};
+
+export default card;

--- a/data-asia/SM/SM6a/023.ts
+++ b/data-asia/SM/SM6a/023.ts
@@ -1,0 +1,56 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヨワシ",
+	},
+
+	illustrator: "Kouki Saitou",
+	category: "Pokemon",
+	hp: 30,
+	types: ["Water"],
+
+	description: {
+		ja: "とても 弱く とても 美味しいので 常に 誰からも 狙われているが いじめていると ひどい目に あうぞ。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "げんちしゅうごう" },
+			effect: {
+				ja: "このポケモンがいるかぎり、自分の「ヨワシGX」全員は、最大HPが「20」大きくなり、使うワザの、相手のバトルポケモンへのダメージは「+20」される。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "みずでっぽう" },
+			damage: 20,
+			cost: ["Water"],
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559278,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [746],
+};
+
+export default card;

--- a/data-asia/SM/SM6a/024.ts
+++ b/data-asia/SM/SM6a/024.ts
@@ -1,0 +1,49 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ナックラー",
+	},
+
+	illustrator: "Naoyo Kimura",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Fighting"],
+
+	description: {
+		ja: "大きな 顎で 邪魔な 岩を 砕きながら 砂を 掘る。 巣穴の 形は スリ鉢状。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ミニじしん" },
+			damage: 20,
+			cost: ["Fighting"],
+			effect: {
+				ja: "自分のベンチポケモン全員にも、それぞれ10ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559290,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [328],
+};
+
+export default card;

--- a/data-asia/SM/SM6a/025.ts
+++ b/data-asia/SM/SM6a/025.ts
@@ -1,0 +1,49 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ミニリュウ",
+	},
+
+	illustrator: "Ayaka Yoshida",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Dragon"],
+
+	description: {
+		ja: "とある 釣り師が １０時間の ファイトの 末に 釣り上げて 存在が 確認 された。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "まきつく" },
+			damage: 10,
+			cost: ["Lightning"],
+			effect: {
+				ja: "コインを1回投げオモテなら、相手のバトルポケモンをマヒにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fairy", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559291,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Common",
+	dexId: [147],
+};
+
+export default card;

--- a/data-asia/SM/SM6a/026.ts
+++ b/data-asia/SM/SM6a/026.ts
@@ -1,0 +1,46 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ミニリュウ",
+	},
+
+	illustrator: "Anesaki Dynamic",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Dragon"],
+
+	description: {
+		ja: "とある 釣り師が １０時間の ファイトの 末に 釣り上げて 存在が 確認 された。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "しっぽではたく" },
+			damage: 30,
+			cost: ["Water", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fairy", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559292,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Common",
+	dexId: [147],
+};
+
+export default card;

--- a/data-asia/SM/SM6a/027.ts
+++ b/data-asia/SM/SM6a/027.ts
@@ -1,0 +1,58 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ハクリュー",
+	},
+
+	illustrator: "sui",
+	category: "Pokemon",
+	hp: 100,
+	types: ["Dragon"],
+
+	description: {
+		ja: "天候を 司る 者として 太古から 農業を 営む 人々に 崇められてきた。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "ドラゴンテール" },
+			damage: "60×",
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "コインを2回投げ、オモテの数x60ダメージ。",
+			},
+		},
+		{
+			name: { ja: "たきのぼり" },
+			damage: 80,
+			cost: ["Water", "Lightning", "Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fairy", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559293,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ミニリュウ",
+	},
+
+	retreat: 2,
+	rarity: "Common",
+	dexId: [148],
+};
+
+export default card;

--- a/data-asia/SM/SM6a/028.ts
+++ b/data-asia/SM/SM6a/028.ts
@@ -1,0 +1,63 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "カイリューGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 250,
+	types: ["Dragon"],
+
+	stage: "Stage2",
+
+	attacks: [
+		{
+			name: { ja: "ドラゴンクロー" },
+			damage: 70,
+			cost: ["Lightning"],
+		},
+		{
+			name: { ja: "ギガインパクト" },
+			damage: 200,
+			cost: ["Water", "Lightning", "Colorless", "Colorless"],
+			effect: {
+				ja: "次の自分の番、このポケモンはワザが使えない。",
+			},
+		},
+		{
+			name: { ja: "ドラゴンポーターGX" },
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "自分のトラッシュにある[竜]ポケモンを3枚、ベンチに出す。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fairy", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 559294,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ハクリュー",
+	},
+
+	retreat: 3,
+	rarity: "Double rare",
+	dexId: [149],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM6a/029.ts
+++ b/data-asia/SM/SM6a/029.ts
@@ -1,0 +1,53 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ビブラーバ",
+	},
+
+	illustrator: "Ken Sugimori",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Dragon"],
+
+	description: {
+		ja: "ハネを 成長 させるために 毎日 大量の 獲物を 消化液で 溶かして すする。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "ソニックエッジ" },
+			damage: 50,
+			cost: ["Fighting", "Colorless"],
+			effect: {
+				ja: "このワザのダメージは、相手のバトルポケモンにかかっている効果を計算しない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fairy", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559295,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ナックラー",
+	},
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [329],
+};
+
+export default card;

--- a/data-asia/SM/SM6a/030.ts
+++ b/data-asia/SM/SM6a/030.ts
@@ -1,0 +1,63 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "フライゴン",
+	},
+
+	illustrator: "Shigenori Negishi",
+	category: "Pokemon",
+	hp: 140,
+	types: ["Dragon"],
+
+	description: {
+		ja: "自らが 巻き起こす 砂嵐の 中心に いるので 滅多に 人前に 現れない ポケモン。",
+	},
+
+	stage: "Stage2",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "りゅうのまもり" },
+			effect: {
+				ja: "このポケモンがいるかぎり、自分の[竜]ポケモン全員は、相手のポケモンが使うワザの効果を受けない。（すでに受けている効果は、なくならない。）",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "すなじごく" },
+			damage: 110,
+			cost: ["Fighting", "Fighting", "Colorless"],
+			effect: {
+				ja: "次の相手の番、このワザを受けたポケモンは、にげられない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fairy", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559296,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ビブラーバ",
+	},
+
+	retreat: 1,
+	rarity: "Uncommon",
+	dexId: [330],
+};
+
+export default card;

--- a/data-asia/SM/SM6a/031.ts
+++ b/data-asia/SM/SM6a/031.ts
@@ -1,0 +1,60 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "チルタリス",
+	},
+
+	illustrator: "Kyoko Umemoto",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Dragon"],
+
+	description: {
+		ja: "晴れた日 綿雲に まぎれながら 大空を 自由に 飛び回り 美しい ソプラノで 歌う。",
+	},
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "たたかいのうた" },
+			effect: {
+				ja: "このポケモンがいるかぎり、自分の[竜]ポケモンが使うワザの、相手のバトルポケモンへのダメージは「+20」される。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "つきさす" },
+			damage: 20,
+			cost: ["Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fairy", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 559297,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "チルット",
+	},
+
+	retreat: 1,
+	rarity: "Rare",
+	dexId: [334],
+};
+
+export default card;

--- a/data-asia/SM/SM6a/032.ts
+++ b/data-asia/SM/SM6a/032.ts
@@ -1,0 +1,56 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "クリムガン",
+	},
+
+	illustrator: "Mitsuhiro Arita",
+	category: "Pokemon",
+	hp: 110,
+	types: ["Dragon"],
+
+	description: {
+		ja: "日光を 翼で 受けて 体を 温める。 体温が 下がると 動けなくなってしまう。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "さめはだ" },
+			effect: {
+				ja: "このポケモンが、バトル場で相手のポケモンからワザのダメージを受けたとき、ワザを使ったポケモンにダメカンを3個のせる。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ドラゴンクロー" },
+			damage: 100,
+			cost: ["Fire", "Water", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fairy", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559300,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Uncommon",
+	dexId: [621],
+};
+
+export default card;

--- a/data-asia/SM/SM6a/033.ts
+++ b/data-asia/SM/SM6a/033.ts
@@ -1,0 +1,57 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ゼクロム",
+	},
+
+	illustrator: "Hasuno",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Dragon"],
+
+	description: {
+		ja: "尻尾で 電気を 作り出す。 全身を 雷雲に 隠して イッシュ地方の 空を 飛ぶ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ひきさく" },
+			damage: 70,
+			cost: ["Lightning", "Colorless", "Colorless"],
+			effect: {
+				ja: "このワザのダメージは、相手のバトルポケモンにかかっている効果を計算しない。",
+			},
+		},
+		{
+			name: { ja: "らいげき" },
+			damage: 150,
+			cost: ["Lightning", "Lightning", "Colorless", "Colorless"],
+			effect: {
+				ja: "コインを1回投げウラなら、このポケモンにも50ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fairy", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 559303,
+			},
+		},
+	],
+
+	retreat: 3,
+	rarity: "Rare",
+	dexId: [644],
+};
+
+export default card;

--- a/data-asia/SM/SM6a/034.ts
+++ b/data-asia/SM/SM6a/034.ts
@@ -1,0 +1,57 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "キュレム",
+	},
+
+	illustrator: "TOKIYA",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Dragon"],
+
+	description: {
+		ja: "強力な 冷凍エネルギーを 体内で 作り出すが 漏れ出した 冷気で 体が 凍っている。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "げきりん" },
+			damage: "20+",
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンにのっているダメカンの数x10ダメージ追加。",
+			},
+		},
+		{
+			name: { ja: "フロストスピア" },
+			damage: 100,
+			cost: ["Water", "Water", "Colorless"],
+			effect: {
+				ja: "相手のベンチポケモン1匹にも、20ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fairy", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 559305,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Rare",
+	dexId: [646],
+};
+
+export default card;

--- a/data-asia/SM/SM6a/035.ts
+++ b/data-asia/SM/SM6a/035.ts
@@ -1,0 +1,63 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ホワイトキュレムGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 190,
+	types: ["Dragon"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ひきさく" },
+			damage: 40,
+			cost: ["Fire"],
+			effect: {
+				ja: "このワザのダメージは、相手のバトルポケモンにかかっている効果を計算しない。",
+			},
+		},
+		{
+			name: { ja: "いかりのやいば" },
+			damage: "80+",
+			cost: ["Fire", "Water", "Colorless"],
+			effect: {
+				ja: "このポケモンにダメカンがのっているなら、80ダメージ追加。",
+			},
+		},
+		{
+			name: { ja: "ドラゴンノヴァGX" },
+			damage: 200,
+			cost: ["Fire", "Fire", "Water", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをやけどとマヒにする。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fairy", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 559308,
+			},
+		},
+	],
+
+	retreat: 3,
+	rarity: "Double rare",
+	dexId: [646],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM6a/036.ts
+++ b/data-asia/SM/SM6a/036.ts
@@ -1,0 +1,57 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ジガルデ",
+	},
+
+	illustrator: "Misa Tsutsui",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Dragon"],
+
+	description: {
+		ja: "生態系を 監視 していると 考えられている。 さらなる 力を 秘めているとの ウワサ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "じひびき" },
+			damage: 20,
+			cost: ["Fighting"],
+			effect: {
+				ja: "次の相手の番、このワザを受けたポケモンは、にげられない。",
+			},
+		},
+		{
+			name: { ja: "いかりのやいば" },
+			damage: "60+",
+			cost: ["Fighting", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンにダメカンがのっているなら、60ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fairy", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559322,
+			},
+		},
+	],
+
+	retreat: 3,
+	rarity: "Uncommon",
+	dexId: [718],
+};
+
+export default card;

--- a/data-asia/SM/SM6a/037.ts
+++ b/data-asia/SM/SM6a/037.ts
@@ -1,0 +1,49 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "バクガメス",
+	},
+
+	illustrator: "Sumiyoshi Kizuki",
+	category: "Pokemon",
+	hp: 110,
+	types: ["Dragon"],
+
+	description: {
+		ja: "鼻の 孔から 炎や 毒ガスを 吹く。 フンは 爆発物で 色んな 使い道が ある。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ばくふんしゃ" },
+			damage: "50×",
+			cost: ["Fire", "Fire", "Fire"],
+			effect: {
+				ja: "自分の場のポケモンについている[炎]エネルギーを好きなだけトラッシュし、その枚数x50ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fairy", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559324,
+			},
+		},
+	],
+
+	retreat: 3,
+	rarity: "Uncommon",
+	dexId: [776],
+};
+
+export default card;

--- a/data-asia/SM/SM6a/038.ts
+++ b/data-asia/SM/SM6a/038.ts
@@ -1,0 +1,54 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ジジーロン",
+	},
+
+	illustrator: "Sanosuke Sakuma",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Dragon"],
+
+	description: {
+		ja: "人懐っこく 子どもが 大好き。 仲良しの 子どもと 遊ぶために 山奥から 町に 降りてくる。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "りゅうのちえ" },
+			damage: 20,
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分のトラッシュにある基本エネルギーを1枚、自分の[竜]ポケモンにつける。",
+			},
+		},
+		{
+			name: { ja: "ハイパーボイス" },
+			damage: 80,
+			cost: ["Colorless", "Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fairy", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559326,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Uncommon",
+	dexId: [780],
+};
+
+export default card;

--- a/data-asia/SM/SM6a/039.ts
+++ b/data-asia/SM/SM6a/039.ts
@@ -1,0 +1,53 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ジャラコ",
+	},
+
+	illustrator: "Yusuke Ohmura",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Dragon"],
+
+	description: {
+		ja: "人気の ない 山に 暮らす。 ジャラコ同士 戦いながら 少しずつ 成長 していく。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "こうちょく" },
+			cost: ["Lightning"],
+			effect: {
+				ja: "次の相手の番、このポケモンが受けるワザのダメージは「-20」される。",
+			},
+		},
+		{
+			name: { ja: "ドラゴンクロー" },
+			damage: 20,
+			cost: ["Fighting", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fairy", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559330,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [782],
+};
+
+export default card;

--- a/data-asia/SM/SM6a/040.ts
+++ b/data-asia/SM/SM6a/040.ts
@@ -1,0 +1,58 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ジャランゴ",
+	},
+
+	illustrator: "hatachu",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Dragon"],
+
+	description: {
+		ja: "鱗は どんどん 生え変わる。 新しくなるたび 鱗は 硬く 鋭く なっていく。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "ガードプレス" },
+			damage: 30,
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "次の相手の番、このポケモンが受けるワザのダメージは「-30」される。",
+			},
+		},
+		{
+			name: { ja: "ドラゴンクロー" },
+			damage: 70,
+			cost: ["Lightning", "Fighting", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fairy", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559332,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ジャラコ",
+	},
+
+	retreat: 2,
+	rarity: "Common",
+	dexId: [783],
+};
+
+export default card;

--- a/data-asia/SM/SM6a/041.ts
+++ b/data-asia/SM/SM6a/041.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ジャラランガ",
+	},
+
+	illustrator: "so-taro",
+	category: "Pokemon",
+	hp: 160,
+	types: ["Dragon"],
+
+	description: {
+		ja: "硬い 鱗は 攻防一体。 かつては 武器や 日用品に 加工 されて 使われた。",
+	},
+
+	stage: "Stage2",
+
+	attacks: [
+		{
+			name: { ja: "ガードプレス" },
+			damage: 60,
+			cost: ["Lightning", "Colorless"],
+			effect: {
+				ja: "次の相手の番、このポケモンが受けるワザのダメージは「-30」される。",
+			},
+		},
+		{
+			name: { ja: "いかりのアッパーカット" },
+			damage: "90+",
+			cost: ["Fighting", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンにダメカンが8個以上のっているなら、120ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fairy", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 559335,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ジャランゴ",
+	},
+
+	retreat: 2,
+	rarity: "Rare",
+	dexId: [784],
+};
+
+export default card;

--- a/data-asia/SM/SM6a/042.ts
+++ b/data-asia/SM/SM6a/042.ts
@@ -1,0 +1,53 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "チルット",
+	},
+
+	illustrator: "Yukiko Baba",
+	category: "Pokemon",
+	hp: 50,
+	types: ["Colorless"],
+
+	description: {
+		ja: "真綿の ような 翼の 手入れは 絶対に 欠かさない。 汚れると 水浴びをして きれいに 洗う。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "もってくる" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札を1枚引く。",
+			},
+		},
+		{
+			name: { ja: "つつく" },
+			damage: 20,
+			cost: ["Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559337,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [333],
+};
+
+export default card;

--- a/data-asia/SM/SM6a/043.ts
+++ b/data-asia/SM/SM6a/043.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アクアパッチ",
+	},
+
+	illustrator: "Toyste Beach",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分のトラッシュにある[水]エネルギーを1枚、ベンチの[水]ポケモンにつける。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559353,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM6a/044.ts
+++ b/data-asia/SM/SM6a/044.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "いれかえフロート",
+	},
+
+	illustrator: "Yoshinobu Saito",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分のバトル場の[水]ポケモンをベンチポケモンと入れ替える。その後、ベンチに入れ替えたポケモンのHPを「30」回復する。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559355,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM6a/045.ts
+++ b/data-asia/SM/SM6a/045.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "火打石",
+	},
+
+	illustrator: "Eske Yoshinob",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードは、自分の手札を2枚トラッシュしなければ使えない。自分の山札にある[炎]エネルギーを4枚まで、相手に見せてから、手札に加える。そして山札を切る。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559357,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM6a/046.ts
+++ b/data-asia/SM/SM6a/046.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "竜の鉤爪",
+	},
+
+	illustrator: "Toyste Beach",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードをつけているポケモンが、バトル場で相手のポケモンからワザのダメージを受けたとき、ワザを使ったポケモンにダメカンを3個のせる。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559360,
+			},
+		},
+	],
+
+	trainerType: "Tool",
+	rarity: "Common",
+};
+
+export default card;

--- a/data-asia/SM/SM6a/047.ts
+++ b/data-asia/SM/SM6a/047.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "カキ",
+	},
+
+	illustrator: "Ken Sugimori",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードを使ったら、自分の番は終わる。自分の山札にある[炎]エネルギーを4枚まで、自分のポケモン1匹につける。そして山札を切る。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559362,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM6a/048.ts
+++ b/data-asia/SM/SM6a/048.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "カツラの一発勝負",
+	},
+
+	illustrator: "Ken Sugimori",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードは、自分の手札がこのカード1枚だけのときにしか使えない。自分の場の[炎]ポケモンの数x2枚ぶん、山札を引く。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 559364,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	rarity: "Rare",
+};
+
+export default card;

--- a/data-asia/SM/SM6a/049.ts
+++ b/data-asia/SM/SM6a/049.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヒガナ",
+	},
+
+	illustrator: "Megumi Mizutani",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードは、前の相手の番に、自分のポケモンがきぜつしていなければ使えない。自分の手札にある基本エネルギーを2枚まで、自分の[竜]ポケモン1匹につける。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559366,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM6a/050.ts
+++ b/data-asia/SM/SM6a/050.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ワタル♢",
+	},
+
+	illustrator: "kodama",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードは、前の相手の番に、自分のポケモンがきぜつしていなければ使えない。自分の山札にある[竜]ポケモンを2枚まで、ベンチに出す。そして山札を切る。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 559367,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	rarity: "Rare Holo",
+};
+
+export default card;

--- a/data-asia/SM/SM6a/051.ts
+++ b/data-asia/SM/SM6a/051.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヴェラ火山公園",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Trainer",
+
+	effect: {
+		ja: "おたがいのやけどのポケモンは、ポケモンチェックのときに投げるコインがオモテでも、やけどは回復しない。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559370,
+			},
+		},
+	],
+
+	trainerType: "Stadium",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM6a/052.ts
+++ b/data-asia/SM/SM6a/052.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "喰いつくされた原野",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Trainer",
+
+	effect: {
+		ja: "おたがいの[悪]または[竜]ポケモンが使うワザの、相手のバトルポケモンへのダメージは「+10」される。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559371,
+			},
+		},
+	],
+
+	trainerType: "Stadium",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM6a/053.ts
+++ b/data-asia/SM/SM6a/053.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "せせらぎの丘",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Trainer",
+
+	effect: {
+		ja: "おたがいのプレイヤーは、自分の番ごとに1回、自分の山札にある[水]または[闘]タイプのたねポケモンを1枚、ベンチに出してよい。その場合、山札を切る。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559373,
+			},
+		},
+	],
+
+	trainerType: "Stadium",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM6a/054.ts
+++ b/data-asia/SM/SM6a/054.ts
@@ -1,0 +1,62 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "レシラムGX",
+	},
+
+	illustrator: "PLANETA Igarashi",
+	category: "Pokemon",
+	hp: 180,
+	types: ["Fire"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ニトロチャージ" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札にある[炎]エネルギーを2枚まで、このポケモンにつける。そして山札を切る。",
+			},
+		},
+		{
+			name: { ja: "しゃくねつのはしら" },
+			damage: 110,
+			cost: ["Fire", "Fire", "Fire", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをやけどにする。",
+			},
+		},
+		{
+			name: { ja: "ヴァーミリオンGX" },
+			damage: 180,
+			cost: ["Fire", "Fire", "Fire", "Colorless"],
+			effect: {
+				ja: "のぞむなら、自分の手札にある[炎]エネルギーを5枚まで、自分のポケモンに好きなようにつける。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 559375,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Ultra Rare",
+	dexId: [643],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM6a/055.ts
+++ b/data-asia/SM/SM6a/055.ts
@@ -1,0 +1,66 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "キングドラGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 230,
+	types: ["Water"],
+
+	stage: "Stage2",
+
+	attacks: [
+		{
+			name: { ja: "ハイドロポンプ" },
+			damage: "10+",
+			cost: ["Colorless"],
+			effect: {
+				ja: "このポケモンについている[水]エネルギーの数x50ダメージ追加。",
+			},
+		},
+		{
+			name: { ja: "ぎゃくふんしゃ" },
+			damage: 30,
+			cost: ["Water"],
+			effect: {
+				ja: "このポケモンをベンチポケモンと入れ替える。",
+			},
+		},
+		{
+			name: { ja: "メイルストロムGX" },
+			cost: ["Water"],
+			effect: {
+				ja: "相手のポケモン全員に、それぞれ40ダメージ。［ベンチは弱点・抵抗力を計算しない。］［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 559378,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "シードラ",
+	},
+
+	retreat: 2,
+	rarity: "Ultra Rare",
+	dexId: [230],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM6a/056.ts
+++ b/data-asia/SM/SM6a/056.ts
@@ -1,0 +1,63 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "カイリューGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 250,
+	types: ["Dragon"],
+
+	stage: "Stage2",
+
+	attacks: [
+		{
+			name: { ja: "ドラゴンクロー" },
+			damage: 70,
+			cost: ["Lightning"],
+		},
+		{
+			name: { ja: "ギガインパクト" },
+			damage: 200,
+			cost: ["Water", "Lightning", "Colorless", "Colorless"],
+			effect: {
+				ja: "次の自分の番、このポケモンはワザが使えない。",
+			},
+		},
+		{
+			name: { ja: "ドラゴンポーターGX" },
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "自分のトラッシュにある[竜]ポケモンを3枚、ベンチに出す。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fairy", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 559381,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ハクリュー",
+	},
+
+	retreat: 3,
+	rarity: "Ultra Rare",
+	dexId: [149],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM6a/057.ts
+++ b/data-asia/SM/SM6a/057.ts
@@ -1,0 +1,63 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ホワイトキュレムGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 190,
+	types: ["Dragon"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ひきさく" },
+			damage: 40,
+			cost: ["Fire"],
+			effect: {
+				ja: "このワザのダメージは、相手のバトルポケモンにかかっている効果を計算しない。",
+			},
+		},
+		{
+			name: { ja: "いかりのやいば" },
+			damage: "80+",
+			cost: ["Fire", "Water", "Colorless"],
+			effect: {
+				ja: "このポケモンにダメカンがのっているなら、80ダメージ追加。",
+			},
+		},
+		{
+			name: { ja: "ドラゴンノヴァGX" },
+			damage: 200,
+			cost: ["Fire", "Fire", "Water", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをやけどとマヒにする。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fairy", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 559383,
+			},
+		},
+	],
+
+	retreat: 3,
+	rarity: "Ultra Rare",
+	dexId: [646],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM6a/058.ts
+++ b/data-asia/SM/SM6a/058.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "カツラの一発勝負",
+	},
+
+	illustrator: "Mitsuhiro Arita",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードは、自分の手札がこのカード1枚だけのときにしか使えない。自分の場の[炎]ポケモンの数x2枚ぶん、山札を引く。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 559385,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	rarity: "Ultra Rare",
+};
+
+export default card;

--- a/data-asia/SM/SM6a/059.ts
+++ b/data-asia/SM/SM6a/059.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヒガナ",
+	},
+
+	illustrator: "Hideki Ishikawa",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードは、前の相手の番に、自分のポケモンがきぜつしていなければ使えない。自分の手札にある基本エネルギーを2枚まで、自分の[竜]ポケモン1匹につける。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 559387,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	rarity: "Ultra Rare",
+};
+
+export default card;

--- a/data-asia/SM/SM6a/060.ts
+++ b/data-asia/SM/SM6a/060.ts
@@ -1,0 +1,62 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "レシラムGX",
+	},
+
+	illustrator: "",
+	category: "Pokemon",
+	hp: 180,
+	types: ["Fire"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ニトロチャージ" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札にある[炎]エネルギーを2枚まで、このポケモンにつける。そして山札を切る。",
+			},
+		},
+		{
+			name: { ja: "しゃくねつのはしら" },
+			damage: 110,
+			cost: ["Fire", "Fire", "Fire", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをやけどにする。",
+			},
+		},
+		{
+			name: { ja: "ヴァーミリオンGX" },
+			damage: 180,
+			cost: ["Fire", "Fire", "Fire", "Colorless"],
+			effect: {
+				ja: "のぞむなら、自分の手札にある[炎]エネルギーを5枚まで、自分のポケモンに好きなようにつける。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 559390,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Hyper rare",
+	dexId: [643],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM6a/061.ts
+++ b/data-asia/SM/SM6a/061.ts
@@ -1,0 +1,66 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "キングドラGX",
+	},
+
+	illustrator: "",
+	category: "Pokemon",
+	hp: 230,
+	types: ["Water"],
+
+	stage: "Stage2",
+
+	attacks: [
+		{
+			name: { ja: "ハイドロポンプ" },
+			damage: "10+",
+			cost: ["Colorless"],
+			effect: {
+				ja: "このポケモンについている[水]エネルギーの数x50ダメージ追加。",
+			},
+		},
+		{
+			name: { ja: "ぎゃくふんしゃ" },
+			damage: 30,
+			cost: ["Water"],
+			effect: {
+				ja: "このポケモンをベンチポケモンと入れ替える。",
+			},
+		},
+		{
+			name: { ja: "メイルストロムGX" },
+			cost: ["Water"],
+			effect: {
+				ja: "相手のポケモン全員に、それぞれ40ダメージ。［ベンチは弱点・抵抗力を計算しない。］［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 559393,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "シードラ",
+	},
+
+	retreat: 2,
+	rarity: "Hyper rare",
+	dexId: [230],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM6a/062.ts
+++ b/data-asia/SM/SM6a/062.ts
@@ -1,0 +1,63 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "カイリューGX",
+	},
+
+	illustrator: "",
+	category: "Pokemon",
+	hp: 250,
+	types: ["Dragon"],
+
+	stage: "Stage2",
+
+	attacks: [
+		{
+			name: { ja: "ドラゴンクロー" },
+			damage: 70,
+			cost: ["Lightning"],
+		},
+		{
+			name: { ja: "ギガインパクト" },
+			damage: 200,
+			cost: ["Water", "Lightning", "Colorless", "Colorless"],
+			effect: {
+				ja: "次の自分の番、このポケモンはワザが使えない。",
+			},
+		},
+		{
+			name: { ja: "ドラゴンポーターGX" },
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "自分のトラッシュにある[竜]ポケモンを3枚、ベンチに出す。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fairy", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 559395,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ハクリュー",
+	},
+
+	retreat: 3,
+	rarity: "Hyper rare",
+	dexId: [149],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM6a/063.ts
+++ b/data-asia/SM/SM6a/063.ts
@@ -1,0 +1,63 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ホワイトキュレムGX",
+	},
+
+	illustrator: "",
+	category: "Pokemon",
+	hp: 190,
+	types: ["Dragon"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ひきさく" },
+			damage: 40,
+			cost: ["Fire"],
+			effect: {
+				ja: "このワザのダメージは、相手のバトルポケモンにかかっている効果を計算しない。",
+			},
+		},
+		{
+			name: { ja: "いかりのやいば" },
+			damage: "80+",
+			cost: ["Fire", "Water", "Colorless"],
+			effect: {
+				ja: "このポケモンにダメカンがのっているなら、80ダメージ追加。",
+			},
+		},
+		{
+			name: { ja: "ドラゴンノヴァGX" },
+			damage: 200,
+			cost: ["Fire", "Fire", "Water", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをやけどとマヒにする。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fairy", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 559397,
+			},
+		},
+	],
+
+	retreat: 3,
+	rarity: "Hyper rare",
+	dexId: [646],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM6a/064.ts
+++ b/data-asia/SM/SM6a/064.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "いれかえフロート",
+	},
+
+	illustrator: "",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分のバトル場の[水]ポケモンをベンチポケモンと入れ替える。その後、ベンチに入れ替えたポケモンのHPを「30」回復する。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 559399,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	rarity: "Secret Rare",
+};
+
+export default card;

--- a/data-asia/SM/SM6a/065.ts
+++ b/data-asia/SM/SM6a/065.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "火打石",
+	},
+
+	illustrator: "",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードは、自分の手札を2枚トラッシュしなければ使えない。自分の山札にある[炎]エネルギーを4枚まで、相手に見せてから、手札に加える。そして山札を切る。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 559401,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	rarity: "Secret Rare",
+};
+
+export default card;

--- a/data-asia/SM/SM6a/066.ts
+++ b/data-asia/SM/SM6a/066.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "竜の鉤爪",
+	},
+
+	illustrator: "",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードをつけているポケモンが、バトル場で相手のポケモンからワザのダメージを受けたとき、ワザを使ったポケモンにダメカンを3個のせる。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 559402,
+			},
+		},
+	],
+
+	trainerType: "Tool",
+	rarity: "Secret Rare",
+};
+
+export default card;


### PR DESCRIPTION
## What

Adds the complete Japanese set **SM6a ドラゴンストーム (Dragon Storm)**, released 2018-04-06:

- `data-asia/SM/SM6a/001.ts` … `066.ts` — all 66 cards (53 regular + 13 secret rares: 6 SR, 4 UR, 3 Secret Rare)
- the set definition `data-asia/SM/SM6a.ts` already existed and is untouched

## Data sources

- **pokemon-card.com** (official database): Japanese names, flavor texts, National Dex numbers, official card count
- **limitlesstcg.com**: full Japanese card text, stages, weaknesses/resistances/retreat, rarities, illustrators, attack costs
- **Cardmarket**: product IDs as `thirdParty.cardmarket` on the variant objects (559237–559402; tcgplayer IDs not available to me)

## Notes

- Follows the file format and conventions of the M-era sets (#1728)
- No `regulationMark` (the set predates regulation marks)
- All 66 files type-check against `interfaces.d.ts` (`tsc --noEmit`)
