### PR TITLE
(data) Add Japanese SM set SM6b Champion's Road

### DIFF
--- a/data-asia/SM/SM6b/001.ts
+++ b/data-asia/SM/SM6b/001.ts
@@ -1,0 +1,49 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "マダツボミ",
+	},
+
+	illustrator: "Masako Yamashita",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Grass"],
+
+	description: {
+		ja: "人の 顔のような つぼみから 伝説の マンドラゴラの 一種ではないかと ささやかれている。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ちょっとすいとる" },
+			damage: 20,
+			cost: ["Grass", "Colorless"],
+			effect: {
+				ja: "このポケモンのHPを「10」回復する。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559151,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [69],
+};
+
+export default card;

--- a/data-asia/SM/SM6b/002.ts
+++ b/data-asia/SM/SM6b/002.ts
@@ -1,0 +1,60 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ウツドン",
+	},
+
+	illustrator: "Miki Tanaka",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Grass"],
+
+	description: {
+		ja: "まず 毒の粉を 吐き 相手の 動きを 止めてしまってから 溶解液で とどめを 刺す。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "せいちょう" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の手札にある[草]エネルギーを2枚まで、このポケモンにつける。",
+			},
+		},
+		{
+			name: { ja: "ダブルはっぱカッター" },
+			damage: "30×",
+			cost: ["Grass", "Colorless"],
+			effect: {
+				ja: "コインを2回投げ、オモテの数x30ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559152,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "マダツボミ",
+	},
+
+	retreat: 1,
+	rarity: "Uncommon",
+	dexId: [70],
+};
+
+export default card;

--- a/data-asia/SM/SM6b/003.ts
+++ b/data-asia/SM/SM6b/003.ts
@@ -1,0 +1,63 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ウツボット",
+	},
+
+	illustrator: "Miki Tanaka",
+	category: "Pokemon",
+	hp: 140,
+	types: ["Grass"],
+
+	description: {
+		ja: "体内に 取りこまれた ものは どんなに 硬くても 溶解液で 跡形なく 溶かされてしまう。",
+	},
+
+	stage: "Stage2",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "かおりのわな" },
+			effect: {
+				ja: "自分の番に1回使える。コインを1回投げオモテなら、相手のベンチポケモンを1匹選び、バトルポケモンと入れ替える。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "さんでとかす" },
+			damage: 80,
+			cost: ["Grass", "Grass", "Colorless"],
+			effect: {
+				ja: "コインを1回投げオモテなら、相手のバトルポケモンをやけどにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 559153,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ウツドン",
+	},
+
+	retreat: 2,
+	rarity: "Rare",
+	dexId: [71],
+};
+
+export default card;

--- a/data-asia/SM/SM6b/004.ts
+++ b/data-asia/SM/SM6b/004.ts
@@ -1,0 +1,56 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ストライク",
+	},
+
+	illustrator: "Hajime Kusajima",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Grass"],
+
+	description: {
+		ja: "若いうちは 山奥で 群れて 暮らし 鎌での 戦いかたや 高速移動を 修行する。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ぶんしん" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札にある「ストライク」を2枚まで、ベンチに出す。そして山札を切る。",
+			},
+		},
+		{
+			name: { ja: "こうそくいどう" },
+			damage: 20,
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "コインを1回投げオモテなら、次の相手の番、このポケモンはワザのダメージや効果を受けない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559154,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [123],
+};
+
+export default card;

--- a/data-asia/SM/SM6b/005.ts
+++ b/data-asia/SM/SM6b/005.ts
@@ -1,0 +1,53 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "イトマル",
+	},
+
+	illustrator: "Sachiko Adachi",
+	category: "Pokemon",
+	hp: 50,
+	types: ["Grass"],
+
+	description: {
+		ja: "丈夫な 糸を より合わせ さかなポケモンを 捕らえる 網を こしらえる 漁師も いるぞ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "しんけいどく" },
+			cost: ["Grass"],
+			effect: {
+				ja: "コインを1回投げオモテなら、相手のバトルポケモンをどくとマヒにする。",
+			},
+		},
+		{
+			name: { ja: "つきさす" },
+			damage: 20,
+			cost: ["Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559155,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [167],
+};
+
+export default card;

--- a/data-asia/SM/SM6b/006.ts
+++ b/data-asia/SM/SM6b/006.ts
@@ -1,0 +1,60 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アリアドス",
+	},
+
+	illustrator: "Mitsuhiro Arita",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Grass"],
+
+	description: {
+		ja: "尻からも 口からも 糸をだす。 糸で 獲物を 絡め取り ゆっくりと 体液を すする。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "どくへんげ" },
+			damage: "20+",
+			cost: ["Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンが受けている特殊状態の数x50ダメージ追加。",
+			},
+		},
+		{
+			name: { ja: "スパイダートラップ" },
+			cost: ["Grass"],
+			effect: {
+				ja: "相手のバトルポケモンをどくとねむりにする。のぞむなら、相手のベンチポケモンを1匹選び、バトルポケモンと入れ替える。その後、新しく出てきたポケモンをどくとねむりにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 559156,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "イトマル",
+	},
+
+	retreat: 1,
+	rarity: "Rare",
+	dexId: [168],
+};
+
+export default card;

--- a/data-asia/SM/SM6b/007.ts
+++ b/data-asia/SM/SM6b/007.ts
@@ -1,0 +1,56 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "サボネア",
+	},
+
+	illustrator: "Atsuko Nishida",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Grass"],
+
+	description: {
+		ja: "砂漠などの 過酷な 環境を 好む。 体の 中に たくわえた 水で ３０日間 生きられる。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "トゲトゲどく" },
+			effect: {
+				ja: "このポケモンが、バトル場で相手のポケモンからワザのダメージを受けたとき、ワザを使ったポケモンをどくにする。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "なぐる" },
+			damage: 10,
+			cost: ["Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559157,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [331],
+};
+
+export default card;

--- a/data-asia/SM/SM6b/008.ts
+++ b/data-asia/SM/SM6b/008.ts
@@ -1,0 +1,62 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ノクタス",
+	},
+
+	illustrator: "Atsuko Nishida",
+	category: "Pokemon",
+	hp: 110,
+	types: ["Grass"],
+
+	description: {
+		ja: "砂漠の 旅人の 後ろを 集団で つきまとい 疲れて 動けなく なるのを 待つのだ。",
+	},
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "トゲトゲどく" },
+			effect: {
+				ja: "このポケモンが、バトル場で相手のポケモンからワザのダメージを受けたとき、ワザを使ったポケモンをどくにする。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "だましうち" },
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のポケモン1匹に、50ダメージ。このワザのダメージは、弱点・抵抗力と、ダメージを受けるポケモンにかかっている効果を計算しない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559158,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "サボネア",
+	},
+
+	retreat: 1,
+	rarity: "Uncommon",
+	dexId: [332],
+};
+
+export default card;

--- a/data-asia/SM/SM6b/009.ts
+++ b/data-asia/SM/SM6b/009.ts
@@ -1,0 +1,54 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "マグマッグ",
+	},
+
+	illustrator: "Midori Harada",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Fire"],
+
+	description: {
+		ja: "溶岩で できた 体を 持つ。 絶えず 動いていないと 体が 冷えて 固まってしまうのだ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "マグマでかこむ" },
+			damage: 10,
+			cost: ["Colorless"],
+			effect: {
+				ja: "次の相手の番、このワザを受けたポケモンは、にげられない。",
+			},
+		},
+		{
+			name: { ja: "ほのお" },
+			damage: 20,
+			cost: ["Fire", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559159,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Common",
+	dexId: [218],
+};
+
+export default card;

--- a/data-asia/SM/SM6b/010.ts
+++ b/data-asia/SM/SM6b/010.ts
@@ -1,0 +1,60 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "マグカルゴ",
+	},
+
+	illustrator: "Midori Harada",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Fire"],
+
+	description: {
+		ja: "体は いつも 波打っていて 溶岩のように 熱い。 ときどき 殻から 火の粉が漏れる。",
+	},
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "じならし" },
+			effect: {
+				ja: "自分の番に1回使える。自分の山札から好きなカードを1枚選ぶ。残りの山札を切り、選んだカードを山札の上にもどす。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "かえん" },
+			damage: 50,
+			cost: ["Fire", "Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559160,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "マグマッグ",
+	},
+
+	retreat: 3,
+	rarity: "Uncommon",
+	dexId: [219],
+};
+
+export default card;

--- a/data-asia/SM/SM6b/011.ts
+++ b/data-asia/SM/SM6b/011.ts
@@ -1,0 +1,48 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アチャモ",
+	},
+
+	illustrator: "Kouki Saitou",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Fire"],
+
+	description: {
+		ja: "体内で 炎が 燃えているので 抱きしめると とても 温かい。 １０００度の 火の玉を 飛ばす。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "こがす" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "コインを1回投げオモテなら、相手のバトルポケモンをやけどにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559161,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [255],
+};
+
+export default card;

--- a/data-asia/SM/SM6b/012.ts
+++ b/data-asia/SM/SM6b/012.ts
@@ -1,0 +1,63 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ワカシャモ",
+	},
+
+	illustrator: "Ken Sugimori",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Fire"],
+
+	description: {
+		ja: "戦いに なると 体内の 炎が 激しく 燃え上がる。 キックは 破壊力 抜群だ。",
+	},
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "しぜんかいふく" },
+			effect: {
+				ja: "手札からこのポケモンにエネルギーをつけるたび、このポケモンの特殊状態をすべて回復する。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "とびかかる" },
+			damage: 60,
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "コインを1回投げウラなら、このワザは失敗。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559162,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "アチャモ",
+	},
+
+	retreat: 1,
+	rarity: "Uncommon",
+	dexId: [256],
+};
+
+export default card;

--- a/data-asia/SM/SM6b/013.ts
+++ b/data-asia/SM/SM6b/013.ts
@@ -1,0 +1,63 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "バシャーモ",
+	},
+
+	illustrator: "Kouki Saitou",
+	category: "Pokemon",
+	hp: 150,
+	types: ["Fire"],
+
+	description: {
+		ja: "強敵に 出会うと 手首から 炎を 噴き出す。 ジャンプで ビルを 跳び越す 脚力。",
+	},
+
+	stage: "Stage2",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "たきつける" },
+			effect: {
+				ja: "自分の番に1回使える。自分のトラッシュにある[炎]エネルギーを1枚、ベンチポケモンにつける。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ファイヤーストリーム" },
+			damage: 90,
+			cost: ["Fire", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンについている[炎]エネルギーを1個トラッシュし、相手のベンチポケモン全員にも、それぞれ20ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 559163,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ワカシャモ",
+	},
+
+	retreat: 2,
+	rarity: "Rare",
+	dexId: [257],
+};
+
+export default card;

--- a/data-asia/SM/SM6b/014.ts
+++ b/data-asia/SM/SM6b/014.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "フリーザーGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 170,
+	types: ["Water"],
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "でんせつのひしょう" },
+			effect: {
+				ja: "自分の番に、このカードを手札からベンチに出したとき、1回使える。このポケモンをバトルポケモンと入れ替える。入れ替えた場合、自分の場のポケモンについている[水]エネルギーを好きなだけ、このポケモンにつけ替える。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "アイスウイング" },
+			damage: 130,
+			cost: ["Water", "Water", "Colorless"],
+		},
+		{
+			name: { ja: "コールドクラッシュGX" },
+			cost: ["Water"],
+			effect: {
+				ja: "おたがいのバトルポケモンについているエネルギーを、すべてトラッシュする。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 559164,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Double rare",
+	dexId: [144],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM6b/015.ts
+++ b/data-asia/SM/SM6b/015.ts
@@ -1,0 +1,56 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ワニノコ",
+	},
+
+	illustrator: "Hironobu Yoshida",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Water"],
+
+	description: {
+		ja: "発達した アゴは パワフルで なんでも かみくだいて しまうので 親のトレーナーでも 要注意。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "にらみつける" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "コインを1回投げオモテなら、相手のバトルポケモンをマヒにする。",
+			},
+		},
+		{
+			name: { ja: "みだれひっかき" },
+			damage: "10×",
+			cost: ["Water"],
+			effect: {
+				ja: "コインを3回投げ、オモテの数x10ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559165,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [158],
+};
+
+export default card;

--- a/data-asia/SM/SM6b/016.ts
+++ b/data-asia/SM/SM6b/016.ts
@@ -1,0 +1,58 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アリゲイツ",
+	},
+
+	illustrator: "Ken Sugimori",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Water"],
+
+	description: {
+		ja: "一度 かみつくと キバが 抜けるまで 絶対に 離さない。 抜けた キバは すぐに 生えてくる。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "たいあたり" },
+			damage: 30,
+			cost: ["Colorless", "Colorless"],
+		},
+		{
+			name: { ja: "まきこむ" },
+			damage: 90,
+			cost: ["Water", "Water", "Colorless"],
+			effect: {
+				ja: "自分の山札を上から3枚トラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559166,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ワニノコ",
+	},
+
+	retreat: 2,
+	rarity: "Uncommon",
+	dexId: [159],
+};
+
+export default card;

--- a/data-asia/SM/SM6b/017.ts
+++ b/data-asia/SM/SM6b/017.ts
@@ -1,0 +1,63 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "オーダイル",
+	},
+
+	illustrator: "Ken Sugimori",
+	category: "Pokemon",
+	hp: 160,
+	types: ["Water"],
+
+	description: {
+		ja: "大きく 力強い アゴで かみつくと そのまま 首を振って 相手を ずたずたに 引きちぎる。",
+	},
+
+	stage: "Stage2",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "どしゃぶり" },
+			effect: {
+				ja: "自分の番に何回でも使える。自分の手札にある[水]エネルギーを、1枚トラッシュする。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ぎゃくりゅう" },
+			damage: "10+",
+			cost: ["Water", "Water"],
+			effect: {
+				ja: "自分のトラッシュにある[水]エネルギーをすべて相手に見せ、その枚数x20ダメージ追加。その後、見せたエネルギーを山札にもどして切る。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 559167,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "アリゲイツ",
+	},
+
+	retreat: 3,
+	rarity: "Rare",
+	dexId: [160],
+};
+
+export default card;

--- a/data-asia/SM/SM6b/018.ts
+++ b/data-asia/SM/SM6b/018.ts
@@ -1,0 +1,49 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ハスボー",
+	},
+
+	illustrator: "Atsuko Nishida",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Water"],
+
+	description: {
+		ja: "きれいな 水を 探して 歩く。 長い 時間 水を 飲まないと 頭の 葉っぱが 枯れてしまう。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "おどろかす" },
+			damage: 10,
+			cost: ["Water"],
+			effect: {
+				ja: "相手の手札からオモテを見ないで1枚選び、そのカードのオモテを見てから、相手の山札にもどして切る。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559168,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [270],
+};
+
+export default card;

--- a/data-asia/SM/SM6b/019.ts
+++ b/data-asia/SM/SM6b/019.ts
@@ -1,0 +1,63 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ハスブレロ",
+	},
+
+	illustrator: "Atsuko Nishida",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Water"],
+
+	description: {
+		ja: "釣り人を 見つけると 水中から 釣り糸を 引っ張り ジャマして 喜ぶ いたずらもの。",
+	},
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "アクアフロート" },
+			effect: {
+				ja: "このポケモンに[水]エネルギーがついているなら、このポケモンのにげるためのエネルギーは、すべてなくなる。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "おそいかかる" },
+			damage: "20+",
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "コインを1回投げオモテなら、20ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559169,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ハスボー",
+	},
+
+	retreat: 1,
+	rarity: "Uncommon",
+	dexId: [271],
+};
+
+export default card;

--- a/data-asia/SM/SM6b/020.ts
+++ b/data-asia/SM/SM6b/020.ts
@@ -1,0 +1,63 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ルンパッパ",
+	},
+
+	illustrator: "Atsuko Nishida",
+	category: "Pokemon",
+	hp: 140,
+	types: ["Water"],
+
+	description: {
+		ja: "楽しい 音楽の リズムが ルンパッパの 細胞を 活性化させて パワーを 発揮するのだ。",
+	},
+
+	stage: "Stage2",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "すいすいダンス" },
+			effect: {
+				ja: "自分の番に1回使える。自分の山札を1枚引く。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "みんなでステップ" },
+			damage: "70+",
+			cost: ["Water", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモン以外の、おたがいの場のポケモンの数x10ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 559170,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ハスブレロ",
+	},
+
+	retreat: 2,
+	rarity: "Rare",
+	dexId: [272],
+};
+
+export default card;

--- a/data-asia/SM/SM6b/021.ts
+++ b/data-asia/SM/SM6b/021.ts
@@ -1,0 +1,59 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ビリリダマ",
+	},
+
+	illustrator: "Ken Sugimori",
+	category: "Pokemon",
+	hp: 50,
+	types: ["Lightning"],
+
+	description: {
+		ja: "発電所などに 現れる。 モンスターボールと 間違えて 触って しびれる 人が 多い。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "エレキフロート" },
+			effect: {
+				ja: "このポケモンにエネルギーがついているなら、このポケモンのにげるためのエネルギーは、すべてなくなる。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "でんきショック" },
+			damage: 20,
+			cost: ["Lightning", "Colorless"],
+			effect: {
+				ja: "コインを1回投げオモテなら、相手のバトルポケモンをマヒにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Metal", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559171,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [100],
+};
+
+export default card;

--- a/data-asia/SM/SM6b/022.ts
+++ b/data-asia/SM/SM6b/022.ts
@@ -1,0 +1,66 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "マルマインGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 190,
+	types: ["Lightning"],
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "エネエネボンバー" },
+			effect: {
+				ja: "自分の番に1回使えて、使ったなら、このポケモンをきぜつさせる。自分のトラッシュにあるエネルギーを5枚、自分のポケモン（「ポケモンGX・EX」をのぞく）に好きなようにつける。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "エレキボール" },
+			damage: 50,
+			cost: ["Lightning", "Colorless"],
+		},
+		{
+			name: { ja: "クラッシュバーンGX" },
+			damage: "30+",
+			cost: ["Lightning", "Colorless"],
+			effect: {
+				ja: "自分の場のポケモンについているエネルギーを好きなだけトラッシュし、その枚数x50ダメージ追加。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Metal", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 559172,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ビリリダマ",
+	},
+
+	retreat: 1,
+	rarity: "Double rare",
+	dexId: [101],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM6b/023.ts
+++ b/data-asia/SM/SM6b/023.ts
@@ -1,0 +1,54 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "チョンチー",
+	},
+
+	illustrator: "Aya Kusube",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Lightning"],
+
+	description: {
+		ja: "光の 届かない 海底に 暮らす。 触手を 光らせ 仲間と コミュニケーション。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "はたく" },
+			damage: 10,
+			cost: ["Colorless"],
+		},
+		{
+			name: { ja: "スパーク" },
+			damage: 10,
+			cost: ["Lightning", "Colorless"],
+			effect: {
+				ja: "相手のベンチポケモン2匹にも、それぞれ10ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Metal", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559173,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [170],
+};
+
+export default card;

--- a/data-asia/SM/SM6b/024.ts
+++ b/data-asia/SM/SM6b/024.ts
@@ -1,0 +1,63 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ランターン",
+	},
+
+	illustrator: "Aya Kusube",
+	category: "Pokemon",
+	hp: 110,
+	types: ["Lightning"],
+
+	description: {
+		ja: "強い 光を 放ち 獲物の 目を くらませる。 隙が できたら 電撃を お見舞いする。",
+	},
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "エネアース" },
+			effect: {
+				ja: "自分のポケモンが、相手のワザのダメージを受けてきぜつするたび、1回使える。きぜつしたポケモンについていた基本エネルギーを1枚、このポケモンにつけ替える。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "エレキほう" },
+			damage: "70+",
+			cost: ["Lightning", "Lightning", "Colorless"],
+			effect: {
+				ja: "のぞむなら、このポケモンについている[雷]エネルギーをすべてトラッシュする。その場合、70ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Metal", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559174,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "チョンチー",
+	},
+
+	retreat: 2,
+	rarity: "Common",
+	dexId: [171],
+};
+
+export default card;

--- a/data-asia/SM/SM6b/025.ts
+++ b/data-asia/SM/SM6b/025.ts
@@ -1,0 +1,63 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "バリヤードGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 150,
+	types: ["Psychic"],
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "パールバリア" },
+			effect: {
+				ja: "このポケモンは、相手のポケモンから「20・40・60・80・100・120・140・160・180・200・220・240・260」のワザのダメージを受けない。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ブレイクダウン" },
+			cost: ["Psychic", "Colorless"],
+			effect: {
+				ja: "相手の手札の枚数ぶんのダメカンを、相手のバトルポケモンにのせる。",
+			},
+		},
+		{
+			name: { ja: "ライフトリックGX" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "このポケモンのHPを、すべて回復する。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 559175,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Double rare",
+	dexId: [122],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM6b/026.ts
+++ b/data-asia/SM/SM6b/026.ts
@@ -1,0 +1,55 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ゴクリン",
+	},
+
+	illustrator: "Yuka Morii",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Psychic"],
+
+	description: {
+		ja: "なんでも 消化する 胃袋。 消化する ときに 発生する ガスは 強烈な 悪臭だ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "あくび" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをねむりにする。",
+			},
+		},
+		{
+			name: { ja: "どくえき" },
+			cost: ["Psychic"],
+			effect: {
+				ja: "相手のバトルポケモンをどくにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559176,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [316],
+};
+
+export default card;

--- a/data-asia/SM/SM6b/027.ts
+++ b/data-asia/SM/SM6b/027.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "マルノーム",
+	},
+
+	illustrator: "Yuka Morii",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Psychic"],
+
+	description: {
+		ja: "口に 入る 大きさの ものなら なんでも まる飲み。 特殊な 胃液で なんでも 消化する。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "ドわすれ" },
+			damage: 30,
+			cost: ["Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンが持っているワザを1つ選ぶ。次の相手の番、このワザを受けたポケモンは、選ばれたワザを使えない。",
+			},
+		},
+		{
+			name: { ja: "まるのみ" },
+			damage: "40+",
+			cost: ["Psychic", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンの残りHPが、このポケモンの残りHPより少ないなら、80ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559177,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ゴクリン",
+	},
+
+	retreat: 2,
+	rarity: "Common",
+	dexId: [317],
+};
+
+export default card;

--- a/data-asia/SM/SM6b/028.ts
+++ b/data-asia/SM/SM6b/028.ts
@@ -1,0 +1,59 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ルナトーン",
+	},
+
+	illustrator: "Hisao Nakamura",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Psychic"],
+
+	description: {
+		ja: "４０年前に 隕石の 落ちた 場所で 初めて 見つかった。 にらむ だけで 敵を 眠らせる。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ソルシェイダー" },
+			effect: {
+				ja: "自分の場に「ソルロック」がいるなら、おたがいの場の[炎]ポケモン（「ポケモンGX・EX」をのぞく）の特性は、すべてなくなる。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ねんりき" },
+			damage: 10,
+			cost: ["Psychic"],
+			effect: {
+				ja: "コインを1回投げオモテなら、相手のバトルポケモンをマヒにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 559178,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Rare",
+	dexId: [337],
+};
+
+export default card;

--- a/data-asia/SM/SM6b/029.ts
+++ b/data-asia/SM/SM6b/029.ts
@@ -1,0 +1,58 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ソルロック",
+	},
+
+	illustrator: "Kyoko Umemoto",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Psychic"],
+
+	description: {
+		ja: "昼間に 太陽エネルギーを たくわえる。 いつも 無表情。 相手の 考えを 読み取る。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "サンライト" },
+			effect: {
+				ja: "このポケモンがいるかぎり、自分の場の「ルナトーン」の最大HPは「130」になる。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "やけつくひかり" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "コインを1回投げオモテなら、相手のバトルポケモンをマヒにする。ウラなら、相手のバトルポケモンをやけどにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559179,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [338],
+};
+
+export default card;

--- a/data-asia/SM/SM6b/030.ts
+++ b/data-asia/SM/SM6b/030.ts
@@ -1,0 +1,51 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "カゲボウズ",
+	},
+
+	illustrator: "Mitsuhiro Arita",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Psychic"],
+
+	description: {
+		ja: "恨みの 感情が 大好き。 恨みを 持つ 人が 住む 家の 軒下に ずらりと ぶらさがる。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ずつき" },
+			damage: 10,
+			cost: ["Colorless"],
+		},
+		{
+			name: { ja: "おにび" },
+			damage: 20,
+			cost: ["Psychic", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559180,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [353],
+};
+
+export default card;

--- a/data-asia/SM/SM6b/031.ts
+++ b/data-asia/SM/SM6b/031.ts
@@ -1,0 +1,68 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ジュペッタGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 190,
+	types: ["Psychic"],
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "シャドームーブ" },
+			effect: {
+				ja: "このポケモンがバトル場にいるなら、自分の番に1回使える。おたがいの場のポケモンにのっているダメカンを1個、おたがいの場の別のポケモンにのせ替える。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "かげのじゅもん" },
+			damage: "30+",
+			cost: ["Psychic"],
+			effect: {
+				ja: "自分のトラッシュのサポートの枚数x10ダメージ追加。追加できるダメージはサポート10枚ぶんまで。",
+			},
+		},
+		{
+			name: { ja: "トゥームハントGX" },
+			cost: ["Psychic"],
+			effect: {
+				ja: "自分のトラッシュにある好きなカードを3枚、相手に見せてから、手札に加える。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 559181,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "カゲボウズ",
+	},
+
+	retreat: 1,
+	rarity: "Double rare",
+	dexId: [354],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM6b/032.ts
+++ b/data-asia/SM/SM6b/032.ts
@@ -1,0 +1,56 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "イワーク",
+	},
+
+	illustrator: "Mitsuhiro Arita",
+	category: "Pokemon",
+	hp: 100,
+	types: ["Fighting"],
+
+	description: {
+		ja: "普段は 土の中に 住んでいる。 地中を 時速８０キロで 掘りながら エサを 探す。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "いやなおと" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "次の自分の番、このワザを受けたポケモンが受けるワザのダメージは「+20」される。",
+			},
+		},
+		{
+			name: { ja: "いかり" },
+			damage: "10+",
+			cost: ["Fighting", "Fighting"],
+			effect: {
+				ja: "このポケモンにのっているダメカンの数x10ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559182,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Common",
+	dexId: [95],
+};
+
+export default card;

--- a/data-asia/SM/SM6b/033.ts
+++ b/data-asia/SM/SM6b/033.ts
@@ -1,0 +1,53 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ゴマゾウ",
+	},
+
+	illustrator: "Ken Sugimori",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Fighting"],
+
+	description: {
+		ja: "体は 小さいが 力持ち。 大人の 人を 軽々と 背中に 乗せて 歩いてしまう。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "たいあたり" },
+			damage: 10,
+			cost: ["Colorless"],
+		},
+		{
+			name: { ja: "こらえる" },
+			cost: ["Fighting"],
+			effect: {
+				ja: "コインを1回投げオモテなら、次の相手の番、このポケモンがワザのダメージを受けてきぜつするとき、このポケモンはきぜつせず、残りHPが「10」の状態で場に残る。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559183,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [231],
+};
+
+export default card;

--- a/data-asia/SM/SM6b/034.ts
+++ b/data-asia/SM/SM6b/034.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ドンファン",
+	},
+
+	illustrator: "Ken Sugimori",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Fighting"],
+
+	description: {
+		ja: "キバが 長くて 大きいほど 群れの中での ランクが 高い。 キバが 伸びるには 時間が かかる。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "じたばた" },
+			damage: "10×",
+			cost: ["Fighting"],
+			effect: {
+				ja: "このポケモンにのっているダメカンの数x10ダメージ。",
+			},
+		},
+		{
+			name: { ja: "こうそくスピン" },
+			damage: 50,
+			cost: ["Fighting", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンをベンチポケモンと入れ替える。その後、相手は相手自身のバトルポケモンをベンチポケモンと入れ替える。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559184,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ゴマゾウ",
+	},
+
+	retreat: 3,
+	rarity: "Common",
+	dexId: [232],
+};
+
+export default card;

--- a/data-asia/SM/SM6b/035.ts
+++ b/data-asia/SM/SM6b/035.ts
@@ -1,0 +1,53 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヨーギラス",
+	},
+
+	illustrator: "Ken Sugimori",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Fighting"],
+
+	description: {
+		ja: "地底 奥深くで 生まれる。 まわりの 土を たいらげると 地上に 現われ サナギになる。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "にらみつける" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "コインを1回投げオモテなら、相手のバトルポケモンをマヒにする。",
+			},
+		},
+		{
+			name: { ja: "いわおとし" },
+			damage: 20,
+			cost: ["Fighting", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559185,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [246],
+};
+
+export default card;

--- a/data-asia/SM/SM6b/036.ts
+++ b/data-asia/SM/SM6b/036.ts
@@ -1,0 +1,57 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "サナギラス",
+	},
+
+	illustrator: "Hironobu Yoshida",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Fighting"],
+
+	description: {
+		ja: "岩盤のような 硬い 殻に 覆われているが 力は 強く 暴れると 山も 崩れてしまう。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "ロケットずつき" },
+			damage: 20,
+			cost: ["Colorless", "Colorless"],
+		},
+		{
+			name: { ja: "すなあらし" },
+			cost: ["Fighting", "Fighting"],
+			effect: {
+				ja: "おたがいのポケモン（[闘]ポケモンをのぞく）全員に、それぞれ20ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559186,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ヨーギラス",
+	},
+
+	retreat: 1,
+	rarity: "Uncommon",
+	dexId: [247],
+};
+
+export default card;

--- a/data-asia/SM/SM6b/037.ts
+++ b/data-asia/SM/SM6b/037.ts
@@ -1,0 +1,57 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ニューラ",
+	},
+
+	illustrator: "Ken Sugimori",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Darkness"],
+
+	description: {
+		ja: "ツメで タマゴに 穴を 開けて 中味を すする。 ブリーダーに 憎まれ 駆除 されることもある。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "みだれひっかき" },
+			damage: "10×",
+			cost: ["Colorless"],
+			effect: {
+				ja: "コインを3回投げ、オモテの数x10ダメージ。",
+			},
+		},
+		{
+			name: { ja: "ふくろだたき" },
+			damage: "30×",
+			cost: ["Darkness", "Darkness"],
+			effect: {
+				ja: "自分の場のポケモンの数ぶんコインを投げ、オモテの数x30ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559187,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [215],
+};
+
+export default card;

--- a/data-asia/SM/SM6b/038.ts
+++ b/data-asia/SM/SM6b/038.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "バンギラス",
+	},
+
+	illustrator: "Hironobu Yoshida",
+	category: "Pokemon",
+	hp: 170,
+	types: ["Darkness"],
+
+	description: {
+		ja: "バンギラスが 暴れると 山が 崩れ 川が 埋まるため 地図を 書き換える ことになる。",
+	},
+
+	stage: "Stage2",
+
+	attacks: [
+		{
+			name: { ja: "たたきつける" },
+			damage: "60×",
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "コインを2回投げ、オモテの数x60ダメージ。",
+			},
+		},
+		{
+			name: { ja: "なぎたおす" },
+			damage: 120,
+			cost: ["Darkness", "Darkness", "Colorless", "Colorless"],
+			effect: {
+				ja: "おたがいのベンチポケモン全員に、コインを1回ずつ投げ、オモテが出たポケモンに、それぞれ60ダメージ。このワザのダメージは、弱点・抵抗力を計算しない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 559188,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "サナギラス",
+	},
+
+	retreat: 3,
+	rarity: "Rare",
+	dexId: [248],
+};
+
+export default card;

--- a/data-asia/SM/SM6b/039.ts
+++ b/data-asia/SM/SM6b/039.ts
@@ -1,0 +1,59 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヤミラミ",
+	},
+
+	illustrator: "Yukiko Baba",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Darkness"],
+
+	description: {
+		ja: "宝石の 瞳が 怪しく 輝くとき 人の 魂を 奪うと 恐れられる ポケモン。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ほりさげる" },
+			effect: {
+				ja: "自分の番に1回使える。自分の山札を上から1枚見て、もとにもどす。のぞむなら、そのカードをトラッシュする。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "かなしばり" },
+			damage: 10,
+			cost: ["Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンが持っているワザを1つ選ぶ。次の相手の番、このワザを受けたポケモンは、選ばれたワザを使えない。",
+			},
+		},
+	],
+
+	weaknesses: [],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559189,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Uncommon",
+	dexId: [302],
+};
+
+export default card;

--- a/data-asia/SM/SM6b/040.ts
+++ b/data-asia/SM/SM6b/040.ts
@@ -1,0 +1,58 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ハガネール",
+	},
+
+	illustrator: "Ken Sugimori",
+	category: "Pokemon",
+	hp: 190,
+	types: ["Metal"],
+
+	description: {
+		ja: "丈夫な アゴで 岩石を かみくだき 進む。 真っ暗な 地中でも 見える 目を 持つ。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "たいあたり" },
+			damage: 30,
+			cost: ["Colorless", "Colorless"],
+		},
+		{
+			name: { ja: "テールクラッシュ" },
+			damage: "80+",
+			cost: ["Metal", "Colorless", "Colorless"],
+			effect: {
+				ja: "コインを1回投げオモテなら、40ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 559190,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "イワーク",
+	},
+
+	retreat: 4,
+	rarity: "Rare",
+	dexId: [208],
+};
+
+export default card;

--- a/data-asia/SM/SM6b/041.ts
+++ b/data-asia/SM/SM6b/041.ts
@@ -1,0 +1,69 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ハッサムGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 210,
+	types: ["Metal"],
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "きけんしょく" },
+			effect: {
+				ja: "このポケモンの残りHPが「100」以下なら、このポケモンが使うワザの、相手のバトルポケモンへのダメージは「+80」される。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "はがねのつばさ" },
+			damage: 80,
+			cost: ["Metal", "Colorless"],
+			effect: {
+				ja: "次の相手の番、このポケモンが受けるワザのダメージは「-30」される。",
+			},
+		},
+		{
+			name: { ja: "ふりおろすGX" },
+			damage: "100+",
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンが進化ポケモンなら、100ダメージ追加。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 559191,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ストライク",
+	},
+
+	retreat: 1,
+	rarity: "Double rare",
+	dexId: [212],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM6b/042.ts
+++ b/data-asia/SM/SM6b/042.ts
@@ -1,0 +1,56 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "クチート",
+	},
+
+	illustrator: "Kagemaru Himeno",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Metal"],
+
+	description: {
+		ja: "ツノが 変形して できた おおあごが 頭に ついている。 鉄骨を かみきってしまう。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "さいくつ" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札にあるグッズを1枚、相手に見せてから、手札に加える。そして山札を切る。そのカードが「ポケモンのどうぐ」の場合、のぞむなら、手札に加える前に、自分の場の「ポケモンのどうぐ」がついていないポケモンに、そのカードをつける。",
+			},
+		},
+		{
+			name: { ja: "かみちぎる" },
+			damage: "20+",
+			cost: ["Metal", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンが「ポケモンGX・EX」なら、30ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559192,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [303],
+};
+
+export default card;

--- a/data-asia/SM/SM6b/043.ts
+++ b/data-asia/SM/SM6b/043.ts
@@ -1,0 +1,57 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "タツベイ",
+	},
+
+	illustrator: "Kouki Saitou",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Dragon"],
+
+	description: {
+		ja: "鋼鉄並みの 石頭で やたら めったら 頭突きする。 空を 飛べない ストレスの せいだ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ける" },
+			damage: 10,
+			cost: ["Colorless"],
+			effect: {
+				ja: "コインを1回投げウラなら、このワザは失敗。",
+			},
+		},
+		{
+			name: { ja: "りゅうのめ" },
+			damage: 20,
+			cost: ["Fire", "Water"],
+			effect: {
+				ja: "相手のバトルポケモンをねむりにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fairy", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559193,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [371],
+};
+
+export default card;

--- a/data-asia/SM/SM6b/044.ts
+++ b/data-asia/SM/SM6b/044.ts
@@ -1,0 +1,60 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "コモルー",
+	},
+
+	illustrator: "Yuka Morii",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Dragon"],
+
+	description: {
+		ja: "洞穴の 奥に じっと 潜み 何も 喰わず 何も 飲まない。 なぜ 死なないのかは 不明だ。",
+	},
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "エナジーガード" },
+			effect: {
+				ja: "このポケモンに基本エネルギーがついているなら、このポケモンが受けるワザのダメージは「-20」される。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ころがる" },
+			damage: 30,
+			cost: ["Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fairy", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559194,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "タツベイ",
+	},
+
+	retreat: 2,
+	rarity: "Uncommon",
+	dexId: [372],
+};
+
+export default card;

--- a/data-asia/SM/SM6b/045.ts
+++ b/data-asia/SM/SM6b/045.ts
@@ -1,0 +1,68 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ボーマンダGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 250,
+	types: ["Dragon"],
+
+	stage: "Stage2",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ドラゴンフロート" },
+			effect: {
+				ja: "このポケモンがいるかぎり、自分のポケモン全員（「ポケモンGX・EX」をのぞく）のにげるためのエネルギーは、すべてなくなる。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ぐれんのほのお" },
+			damage: 200,
+			cost: ["Fire", "Water", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンについているエネルギーを、2個トラッシュする。",
+			},
+		},
+		{
+			name: { ja: "かえんひこうGX" },
+			cost: ["Fire", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のポケモン1匹に、120ダメージ。［ベンチは弱点・抵抗力を計算しない。］［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fairy", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 559195,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "コモルー",
+	},
+
+	retreat: 2,
+	rarity: "Double rare",
+	dexId: [373],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM6b/046.ts
+++ b/data-asia/SM/SM6b/046.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ガルーラ",
+	},
+
+	illustrator: "Naoyo Kimura",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Colorless"],
+
+	description: {
+		ja: "お腹の 子どもは およそ ３年で 親離れする。 母親が 大声で 鳴くのは その時だけ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "こどものおつかい" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札を1枚引く。",
+			},
+		},
+		{
+			name: { ja: "ずつき" },
+			damage: 30,
+			cost: ["Colorless", "Colorless"],
+		},
+		{
+			name: { ja: "おやこパンチ" },
+			damage: "60+",
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "コインを1回投げオモテなら、30ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559196,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Common",
+	dexId: [115],
+};
+
+export default card;

--- a/data-asia/SM/SM6b/047.ts
+++ b/data-asia/SM/SM6b/047.ts
@@ -1,0 +1,56 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ノコッチ",
+	},
+
+	illustrator: "Mitsuhiro Arita",
+	category: "Pokemon",
+	hp: 50,
+	types: ["Colorless"],
+
+	description: {
+		ja: "尻尾で 地面を 掘って 迷路のような 巣穴を 作る。 羽で 少しだけ 飛べる。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "よんでにげる" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札にあるたねポケモンを3枚まで、ベンチに出す。そして山札を切る。ベンチに出した場合、のぞむなら、このポケモンをベンチポケモンと入れ替える。",
+			},
+		},
+		{
+			name: { ja: "スネークフラッシュ" },
+			damage: 10,
+			cost: ["Colorless"],
+			effect: {
+				ja: "コインを1回投げオモテなら、相手のバトルポケモンをマヒにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559197,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [206],
+};
+
+export default card;

--- a/data-asia/SM/SM6b/048.ts
+++ b/data-asia/SM/SM6b/048.ts
@@ -1,0 +1,49 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ホウオウ",
+	},
+
+	illustrator: "Aya Kusube",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Colorless"],
+
+	description: {
+		ja: "心正しき トレーナーの 前に 七色の 翼を 光らせながら 姿を 現すと 伝えられる。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "レインボーバーン" },
+			damage: "30+",
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンについている基本エネルギーのタイプの数x30ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559198,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Uncommon",
+	dexId: [250],
+};
+
+export default card;

--- a/data-asia/SM/SM6b/049.ts
+++ b/data-asia/SM/SM6b/049.ts
@@ -1,0 +1,56 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ナマケロ",
+	},
+
+	illustrator: "Kagemaru Himeno",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Colorless"],
+
+	description: {
+		ja: "１日に 葉っぱを ３枚も 食べれば 満足で それ以外は ２０時間も 眠っている。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "かぎづめ" },
+			damage: 20,
+			cost: ["Colorless"],
+			effect: {
+				ja: "コインを1回投げウラなら、このワザは失敗。",
+			},
+		},
+		{
+			name: { ja: "なまける" },
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンのHPを、すべて回復する。次の自分の番、このポケモンはワザが使えない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559199,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [287],
+};
+
+export default card;

--- a/data-asia/SM/SM6b/050.ts
+++ b/data-asia/SM/SM6b/050.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヤルキモノ",
+	},
+
+	illustrator: "Kagemaru Himeno",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Colorless"],
+
+	description: {
+		ja: "体を 動かしていないと ストレスが たまりすぎて 具合が 悪くなって しまうのだ。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "みだれひっかき" },
+			damage: "20×",
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "コインを3回投げ、オモテの数x20ダメージ。",
+			},
+		},
+		{
+			name: { ja: "いかり" },
+			damage: "20+",
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンにのっているダメカンの数x10ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559200,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ナマケロ",
+	},
+
+	retreat: 1,
+	rarity: "Uncommon",
+	dexId: [288],
+};
+
+export default card;

--- a/data-asia/SM/SM6b/051.ts
+++ b/data-asia/SM/SM6b/051.ts
@@ -1,0 +1,63 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ケッキング",
+	},
+
+	illustrator: "Ken Sugimori",
+	category: "Pokemon",
+	hp: 160,
+	types: ["Colorless"],
+
+	description: {
+		ja: "世界一の ぐうたらだが たまった エネルギーを 一気に 出す ことで 恐ろしい パワーを 発揮する。",
+	},
+
+	stage: "Stage2",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "なまけがお" },
+			effect: {
+				ja: "このポケモンがバトル場にいるかぎり、相手の場のポケモンの特性（「なまけがお」をのぞく）は、すべてなくなる。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "はめつのいちげき" },
+			damage: 160,
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンについているエネルギーを、1個トラッシュする。次の自分の番、このポケモンはワザが使えない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 559201,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ヤルキモノ",
+	},
+
+	retreat: 3,
+	rarity: "Rare",
+	dexId: [289],
+};
+
+export default card;

--- a/data-asia/SM/SM6b/052.ts
+++ b/data-asia/SM/SM6b/052.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "エネルギー循環装置",
+	},
+
+	illustrator: "Zu-Ka",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分のトラッシュにある基本エネルギーを1枚、相手に見せてから、手札に加える。または、自分のトラッシュにある基本エネルギーを3枚、相手に見せてから、山札にもどして切る。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559202,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	rarity: "Common",
+};
+
+export default card;

--- a/data-asia/SM/SM6b/053.ts
+++ b/data-asia/SM/SM6b/053.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "エネルギーつけかえ",
+	},
+
+	illustrator: "Ken Ikuji",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分のポケモンについている基本エネルギーを1個、自分の別のポケモンにつけ替える。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559203,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM6b/054.ts
+++ b/data-asia/SM/SM6b/054.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "スーパーポケモン回収",
+	},
+
+	illustrator: "Keiji Kinebuchi",
+	category: "Trainer",
+
+	effect: {
+		ja: "コインを1回投げオモテなら、自分のポケモン1匹と、ついているすべてのカードを、手札にもどす。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559204,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM6b/055.ts
+++ b/data-asia/SM/SM6b/055.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ふしぎなアメ",
+	},
+
+	illustrator: "Ryo Ueda",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分のたねポケモン1匹から進化する1進化の上の2進化ポケモンを、手札から1枚選び、そのたねポケモンにのせて進化させる。[最初の自分の番と、この番出したばかりのたねポケモンには使えない。]",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559205,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM6b/056.ts
+++ b/data-asia/SM/SM6b/056.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ふっかつそう",
+	},
+
+	illustrator: "Ryo Ueda",
+	category: "Trainer",
+
+	effect: {
+		ja: "コインを1回投げオモテなら、自分のポケモン1匹のHPを「60」回復し、特殊状態もすべて回復する。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559206,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM6b/057.ts
+++ b/data-asia/SM/SM6b/057.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "フレンドボール",
+	},
+
+	illustrator: "Katsura Tabata",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の山札にある、相手の場のポケモンと同じタイプのポケモンを1枚、相手に見せてから、手札に加える。そして山札を切る。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559207,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	rarity: "Common",
+};
+
+export default card;

--- a/data-asia/SM/SM6b/058.ts
+++ b/data-asia/SM/SM6b/058.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ポケナビ",
+	},
+
+	illustrator: "Katsura Tabata",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の山札を上から3枚見る。その中にあるポケモンまたはエネルギーを1枚、相手に見せてから、手札に加えてよい。残りのカードは、好きな順番に入れ替えて、山札の上にもどす。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559208,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM6b/059.ts
+++ b/data-asia/SM/SM6b/059.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ポケモンいれかえ",
+	},
+
+	illustrator: "Hiromichi Sugiyama",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分のバトルポケモンをベンチポケモンと入れ替える。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559209,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM6b/060.ts
+++ b/data-asia/SM/SM6b/060.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ルアーボール",
+	},
+
+	illustrator: "Katsura Tabata",
+	category: "Trainer",
+
+	effect: {
+		ja: "コインを3回投げ、オモテの数ぶん、自分のトラッシュにある進化ポケモンを、相手に見せてから、手札に加える。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559210,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM6b/061.ts
+++ b/data-asia/SM/SM6b/061.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "地底探険隊",
+	},
+
+	illustrator: "Kagemaru Himeno",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の山札を下から4枚見る。その中にある好きなカードを2枚、手札に加える。残りのカードは好きな順番に入れ替えて、山札の下にもどす。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559211,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM6b/062.ts
+++ b/data-asia/SM/SM6b/062.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "TVレポーター",
+	},
+
+	illustrator: "Ken Sugimori",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の山札を3枚引く。その後、自分の手札を1枚トラッシュする。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559212,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	rarity: "Common",
+};
+
+export default card;

--- a/data-asia/SM/SM6b/063.ts
+++ b/data-asia/SM/SM6b/063.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ぼんぐり職人",
+	},
+
+	illustrator: "Kagemaru Himeno",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の山札にある、名前に「ボール」とつくグッズを2枚まで、相手に見せてから、手札に加える。そして山札を切る。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559213,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM6b/064.ts
+++ b/data-asia/SM/SM6b/064.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "マサキのメンテナンス",
+	},
+
+	illustrator: "Ken Sugimori",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の手札を1枚、山札にもどして切る。その後、自分の山札を3枚引く。（自分の手札をもどせないなら、このカードは使えない。）",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559214,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	rarity: "Common",
+};
+
+export default card;

--- a/data-asia/SM/SM6b/065.ts
+++ b/data-asia/SM/SM6b/065.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "モノマネむすめ",
+	},
+
+	illustrator: "Ken Sugimori",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の手札をすべて山札にもどして切る。その後、相手の手札の枚数ぶん、自分の山札を引く。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559215,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM6b/066.ts
+++ b/data-asia/SM/SM6b/066.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "レインボーエネルギー",
+	},
+
+	illustrator: "",
+	category: "Energy",
+	energyType: "Special",
+
+	effect: {
+		ja: "このカードを手札からポケモンにつけたとき、そのポケモンにダメカンを1個のせる。このカードは、ポケモンについているかぎり、すべてのタイプのエネルギー1個ぶんとしてはたらく。ポケモンについていないなら、[無]エネルギー1個ぶんとしてはたらく。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559216,
+			},
+		},
+	],
+
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM6b/067.ts
+++ b/data-asia/SM/SM6b/067.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "フリーザーGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 170,
+	types: ["Water"],
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "でんせつのひしょう" },
+			effect: {
+				ja: "自分の番に、このカードを手札からベンチに出したとき、1回使える。このポケモンをバトルポケモンと入れ替える。入れ替えた場合、自分の場のポケモンについている[水]エネルギーを好きなだけ、このポケモンにつけ替える。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "アイスウイング" },
+			damage: 130,
+			cost: ["Water", "Water", "Colorless"],
+		},
+		{
+			name: { ja: "コールドクラッシュGX" },
+			cost: ["Water"],
+			effect: {
+				ja: "おたがいのバトルポケモンについているエネルギーを、すべてトラッシュする。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 559217,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Ultra Rare",
+	dexId: [144],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM6b/068.ts
+++ b/data-asia/SM/SM6b/068.ts
@@ -1,0 +1,66 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "マルマインGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 190,
+	types: ["Lightning"],
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "エネエネボンバー" },
+			effect: {
+				ja: "自分の番に1回使えて、使ったなら、このポケモンをきぜつさせる。自分のトラッシュにあるエネルギーを5枚、自分のポケモン（「ポケモンGX・EX」をのぞく）に好きなようにつける。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "エレキボール" },
+			damage: 50,
+			cost: ["Lightning", "Colorless"],
+		},
+		{
+			name: { ja: "クラッシュバーンGX" },
+			damage: "30+",
+			cost: ["Lightning", "Colorless"],
+			effect: {
+				ja: "自分の場のポケモンについているエネルギーを好きなだけトラッシュし、その枚数x50ダメージ追加。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Metal", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 559218,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ビリリダマ",
+	},
+
+	retreat: 1,
+	rarity: "Ultra Rare",
+	dexId: [101],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM6b/069.ts
+++ b/data-asia/SM/SM6b/069.ts
@@ -1,0 +1,63 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "バリヤードGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 150,
+	types: ["Psychic"],
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "パールバリア" },
+			effect: {
+				ja: "このポケモンは、相手のポケモンから「20・40・60・80・100・120・140・160・180・200・220・240・260」のワザのダメージを受けない。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ブレイクダウン" },
+			cost: ["Psychic", "Colorless"],
+			effect: {
+				ja: "相手の手札の枚数ぶんのダメカンを、相手のバトルポケモンにのせる。",
+			},
+		},
+		{
+			name: { ja: "ライフトリックGX" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "このポケモンのHPを、すべて回復する。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 559219,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Ultra Rare",
+	dexId: [122],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM6b/070.ts
+++ b/data-asia/SM/SM6b/070.ts
@@ -1,0 +1,68 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ジュペッタGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 190,
+	types: ["Psychic"],
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "シャドームーブ" },
+			effect: {
+				ja: "このポケモンがバトル場にいるなら、自分の番に1回使える。おたがいの場のポケモンにのっているダメカンを1個、おたがいの場の別のポケモンにのせ替える。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "かげのじゅもん" },
+			damage: "30+",
+			cost: ["Psychic"],
+			effect: {
+				ja: "自分のトラッシュのサポートの枚数x10ダメージ追加。追加できるダメージはサポート10枚ぶんまで。",
+			},
+		},
+		{
+			name: { ja: "トゥームハントGX" },
+			cost: ["Psychic"],
+			effect: {
+				ja: "自分のトラッシュにある好きなカードを3枚、相手に見せてから、手札に加える。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 559220,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "カゲボウズ",
+	},
+
+	retreat: 1,
+	rarity: "Ultra Rare",
+	dexId: [354],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM6b/071.ts
+++ b/data-asia/SM/SM6b/071.ts
@@ -1,0 +1,69 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ハッサムGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 210,
+	types: ["Metal"],
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "きけんしょく" },
+			effect: {
+				ja: "このポケモンの残りHPが「100」以下なら、このポケモンが使うワザの、相手のバトルポケモンへのダメージは「+80」される。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "はがねのつばさ" },
+			damage: 80,
+			cost: ["Metal", "Colorless"],
+			effect: {
+				ja: "次の相手の番、このポケモンが受けるワザのダメージは「-30」される。",
+			},
+		},
+		{
+			name: { ja: "ふりおろすGX" },
+			damage: "100+",
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンが進化ポケモンなら、100ダメージ追加。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 559221,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ストライク",
+	},
+
+	retreat: 1,
+	rarity: "Ultra Rare",
+	dexId: [212],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM6b/072.ts
+++ b/data-asia/SM/SM6b/072.ts
@@ -1,0 +1,68 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ボーマンダGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 250,
+	types: ["Dragon"],
+
+	stage: "Stage2",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ドラゴンフロート" },
+			effect: {
+				ja: "このポケモンがいるかぎり、自分のポケモン全員（「ポケモンGX・EX」をのぞく）のにげるためのエネルギーは、すべてなくなる。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ぐれんのほのお" },
+			damage: 200,
+			cost: ["Fire", "Water", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンについているエネルギーを、2個トラッシュする。",
+			},
+		},
+		{
+			name: { ja: "かえんひこうGX" },
+			cost: ["Fire", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のポケモン1匹に、120ダメージ。［ベンチは弱点・抵抗力を計算しない。］［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fairy", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 559222,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "コモルー",
+	},
+
+	retreat: 2,
+	rarity: "Ultra Rare",
+	dexId: [373],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM6b/073.ts
+++ b/data-asia/SM/SM6b/073.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "地底探険隊",
+	},
+
+	illustrator: "Kagemaru Himeno",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の山札を下から4枚見る。その中にある好きなカードを2枚、手札に加える。残りのカードは好きな順番に入れ替えて、山札の下にもどす。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 559223,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	rarity: "Ultra Rare",
+};
+
+export default card;

--- a/data-asia/SM/SM6b/074.ts
+++ b/data-asia/SM/SM6b/074.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "TVレポーター",
+	},
+
+	illustrator: "nagimiso",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の山札を3枚引く。その後、自分の手札を1枚トラッシュする。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 559224,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	rarity: "Ultra Rare",
+};
+
+export default card;

--- a/data-asia/SM/SM6b/075.ts
+++ b/data-asia/SM/SM6b/075.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ぼんぐり職人",
+	},
+
+	illustrator: "Kagemaru Himeno",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の山札にある、名前に「ボール」とつくグッズを2枚まで、相手に見せてから、手札に加える。そして山札を切る。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 559225,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	rarity: "Ultra Rare",
+};
+
+export default card;

--- a/data-asia/SM/SM6b/076.ts
+++ b/data-asia/SM/SM6b/076.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "マサキのメンテナンス",
+	},
+
+	illustrator: "Sanosuke Sakuma",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の手札を1枚、山札にもどして切る。その後、自分の山札を3枚引く。（自分の手札をもどせないなら、このカードは使えない。）",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 559226,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	rarity: "Ultra Rare",
+};
+
+export default card;

--- a/data-asia/SM/SM6b/077.ts
+++ b/data-asia/SM/SM6b/077.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "モノマネむすめ",
+	},
+
+	illustrator: "Megumi Mizutani",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の手札をすべて山札にもどして切る。その後、相手の手札の枚数ぶん、自分の山札を引く。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 559227,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	rarity: "Ultra Rare",
+};
+
+export default card;

--- a/data-asia/SM/SM6b/078.ts
+++ b/data-asia/SM/SM6b/078.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "フリーザーGX",
+	},
+
+	illustrator: "",
+	category: "Pokemon",
+	hp: 170,
+	types: ["Water"],
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "でんせつのひしょう" },
+			effect: {
+				ja: "自分の番に、このカードを手札からベンチに出したとき、1回使える。このポケモンをバトルポケモンと入れ替える。入れ替えた場合、自分の場のポケモンについている[水]エネルギーを好きなだけ、このポケモンにつけ替える。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "アイスウイング" },
+			damage: 130,
+			cost: ["Water", "Water", "Colorless"],
+		},
+		{
+			name: { ja: "コールドクラッシュGX" },
+			cost: ["Water"],
+			effect: {
+				ja: "おたがいのバトルポケモンについているエネルギーを、すべてトラッシュする。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 559228,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Hyper rare",
+	dexId: [144],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM6b/079.ts
+++ b/data-asia/SM/SM6b/079.ts
@@ -1,0 +1,66 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "マルマインGX",
+	},
+
+	illustrator: "",
+	category: "Pokemon",
+	hp: 190,
+	types: ["Lightning"],
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "エネエネボンバー" },
+			effect: {
+				ja: "自分の番に1回使えて、使ったなら、このポケモンをきぜつさせる。自分のトラッシュにあるエネルギーを5枚、自分のポケモン（「ポケモンGX・EX」をのぞく）に好きなようにつける。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "エレキボール" },
+			damage: 50,
+			cost: ["Lightning", "Colorless"],
+		},
+		{
+			name: { ja: "クラッシュバーンGX" },
+			damage: "30+",
+			cost: ["Lightning", "Colorless"],
+			effect: {
+				ja: "自分の場のポケモンについているエネルギーを好きなだけトラッシュし、その枚数x50ダメージ追加。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Metal", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 559229,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ビリリダマ",
+	},
+
+	retreat: 1,
+	rarity: "Hyper rare",
+	dexId: [101],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM6b/080.ts
+++ b/data-asia/SM/SM6b/080.ts
@@ -1,0 +1,63 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "バリヤードGX",
+	},
+
+	illustrator: "",
+	category: "Pokemon",
+	hp: 150,
+	types: ["Psychic"],
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "パールバリア" },
+			effect: {
+				ja: "このポケモンは、相手のポケモンから「20・40・60・80・100・120・140・160・180・200・220・240・260」のワザのダメージを受けない。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ブレイクダウン" },
+			cost: ["Psychic", "Colorless"],
+			effect: {
+				ja: "相手の手札の枚数ぶんのダメカンを、相手のバトルポケモンにのせる。",
+			},
+		},
+		{
+			name: { ja: "ライフトリックGX" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "このポケモンのHPを、すべて回復する。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 559230,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Hyper rare",
+	dexId: [122],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM6b/081.ts
+++ b/data-asia/SM/SM6b/081.ts
@@ -1,0 +1,68 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ジュペッタGX",
+	},
+
+	illustrator: "",
+	category: "Pokemon",
+	hp: 190,
+	types: ["Psychic"],
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "シャドームーブ" },
+			effect: {
+				ja: "このポケモンがバトル場にいるなら、自分の番に1回使える。おたがいの場のポケモンにのっているダメカンを1個、おたがいの場の別のポケモンにのせ替える。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "かげのじゅもん" },
+			damage: "30+",
+			cost: ["Psychic"],
+			effect: {
+				ja: "自分のトラッシュのサポートの枚数x10ダメージ追加。追加できるダメージはサポート10枚ぶんまで。",
+			},
+		},
+		{
+			name: { ja: "トゥームハントGX" },
+			cost: ["Psychic"],
+			effect: {
+				ja: "自分のトラッシュにある好きなカードを3枚、相手に見せてから、手札に加える。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 559231,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "カゲボウズ",
+	},
+
+	retreat: 1,
+	rarity: "Hyper rare",
+	dexId: [354],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM6b/082.ts
+++ b/data-asia/SM/SM6b/082.ts
@@ -1,0 +1,69 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ハッサムGX",
+	},
+
+	illustrator: "",
+	category: "Pokemon",
+	hp: 210,
+	types: ["Metal"],
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "きけんしょく" },
+			effect: {
+				ja: "このポケモンの残りHPが「100」以下なら、このポケモンが使うワザの、相手のバトルポケモンへのダメージは「+80」される。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "はがねのつばさ" },
+			damage: 80,
+			cost: ["Metal", "Colorless"],
+			effect: {
+				ja: "次の相手の番、このポケモンが受けるワザのダメージは「-30」される。",
+			},
+		},
+		{
+			name: { ja: "ふりおろすGX" },
+			damage: "100+",
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンが進化ポケモンなら、100ダメージ追加。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 559232,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ストライク",
+	},
+
+	retreat: 1,
+	rarity: "Hyper rare",
+	dexId: [212],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM6b/083.ts
+++ b/data-asia/SM/SM6b/083.ts
@@ -1,0 +1,68 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ボーマンダGX",
+	},
+
+	illustrator: "",
+	category: "Pokemon",
+	hp: 250,
+	types: ["Dragon"],
+
+	stage: "Stage2",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ドラゴンフロート" },
+			effect: {
+				ja: "このポケモンがいるかぎり、自分のポケモン全員（「ポケモンGX・EX」をのぞく）のにげるためのエネルギーは、すべてなくなる。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ぐれんのほのお" },
+			damage: 200,
+			cost: ["Fire", "Water", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンについているエネルギーを、2個トラッシュする。",
+			},
+		},
+		{
+			name: { ja: "かえんひこうGX" },
+			cost: ["Fire", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のポケモン1匹に、120ダメージ。［ベンチは弱点・抵抗力を計算しない。］［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fairy", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 559233,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "コモルー",
+	},
+
+	retreat: 2,
+	rarity: "Hyper rare",
+	dexId: [373],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM6b/084.ts
+++ b/data-asia/SM/SM6b/084.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ふっかつそう",
+	},
+
+	illustrator: "",
+	category: "Trainer",
+
+	effect: {
+		ja: "コインを1回投げオモテなら、自分のポケモン1匹のHPを「60」回復し、特殊状態もすべて回復する。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 559234,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	rarity: "Secret Rare",
+};
+
+export default card;

--- a/data-asia/SM/SM6b/085.ts
+++ b/data-asia/SM/SM6b/085.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ポケナビ",
+	},
+
+	illustrator: "",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の山札を上から3枚見る。その中にあるポケモンまたはエネルギーを1枚、相手に見せてから、手札に加えてよい。残りのカードは、好きな順番に入れ替えて、山札の上にもどす。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 559235,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	rarity: "Secret Rare",
+};
+
+export default card;

--- a/data-asia/SM/SM6b/086.ts
+++ b/data-asia/SM/SM6b/086.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM6b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "レインボーエネルギー",
+	},
+
+	illustrator: "",
+	category: "Energy",
+	energyType: "Special",
+
+	effect: {
+		ja: "このカードを手札からポケモンにつけたとき、そのポケモンにダメカンを1個のせる。このカードは、ポケモンについているかぎり、すべてのタイプのエネルギー1個ぶんとしてはたらく。ポケモンについていないなら、[無]エネルギー1個ぶんとしてはたらく。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 559236,
+			},
+		},
+	],
+
+	rarity: "Secret Rare",
+};
+
+export default card;


### PR DESCRIPTION
## What

Adds the complete Japanese set **SM6b チャンピオンロード (Champion's Road)**, released 2018-05-03:

- `data-asia/SM/SM6b/001.ts` … `086.ts` — all 86 cards (66 regular + 20 secret rares: 11 SR, 6 UR, 3 Secret Rare)
- the set definition `data-asia/SM/SM6b.ts` already existed and is untouched

## Data sources

- **pokemon-card.com** (official database): Japanese names, flavor texts, National Dex numbers, official card count
- **limitlesstcg.com**: full Japanese card text, stages, weaknesses/resistances/retreat, rarities, illustrators, attack costs
- **Cardmarket**: product IDs as `thirdParty.cardmarket` on the variant objects (559151–559236; tcgplayer IDs not available to me)

## Notes

- Follows the file format and conventions of the M-era sets (#1728)
- No `regulationMark` (the set predates regulation marks); resistances are `-20` per the era
- All 86 files type-check against `interfaces.d.ts` (`tsc --noEmit`)
