### PR TITLE
(data) Add Japanese SM set SM7 Charisma of the Ripped Sky

### DIFF
--- a/data-asia/SM/SM7/001.ts
+++ b/data-asia/SM/SM7/001.ts
@@ -1,0 +1,48 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "キモリ",
+	},
+
+	illustrator: "Sekio",
+	category: "Pokemon",
+	hp: 50,
+	types: ["Grass"],
+
+	description: {
+		ja: "足の 裏の 小さな トゲが 壁や 天井に 引っかかるので 逆さまに なっても 落ちないのだ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ねむけどく" },
+			cost: ["Grass"],
+			effect: {
+				ja: "相手のバトルポケモンをどくとねむりにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558962,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [252],
+};
+
+export default card;

--- a/data-asia/SM/SM7/002.ts
+++ b/data-asia/SM/SM7/002.ts
@@ -1,0 +1,51 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "キモリ",
+	},
+
+	illustrator: "tetsuya koizumi",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Grass"],
+
+	description: {
+		ja: "足の 裏の 小さな トゲが 壁や 天井に 引っかかるので 逆さまに なっても 落ちないのだ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ひらてうち" },
+			damage: 10,
+			cost: ["Grass"],
+		},
+		{
+			name: { ja: "しっぽではたく" },
+			damage: 20,
+			cost: ["Grass", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558963,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [252],
+};
+
+export default card;

--- a/data-asia/SM/SM7/003.ts
+++ b/data-asia/SM/SM7/003.ts
@@ -1,0 +1,53 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ジュプトル",
+	},
+
+	illustrator: "Shin Nagasawa",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Grass"],
+
+	description: {
+		ja: "密林に 生息する。 枝から 枝へ 飛び移りながら 移動して 獲物に 接近する。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "リーフブレード" },
+			damage: "20+",
+			cost: ["Grass"],
+			effect: {
+				ja: "コインを1回投げオモテなら、40ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558964,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "キモリ",
+	},
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [253],
+};
+
+export default card;

--- a/data-asia/SM/SM7/004.ts
+++ b/data-asia/SM/SM7/004.ts
@@ -1,0 +1,63 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ジュカイン",
+	},
+
+	illustrator: "Mitsuhiro Arita",
+	category: "Pokemon",
+	hp: 140,
+	types: ["Grass"],
+
+	description: {
+		ja: "ジャングルを 身軽に 走り回り 腕に 生えた 切れ味 鋭い 葉っぱで 獲物を しとめるのだ。",
+	},
+
+	stage: "Stage2",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ネイチャーパワー" },
+			effect: {
+				ja: "このポケモンがいるかぎり、[草]エネルギーがついている自分のポケモン全員は、相手の「ウルトラビースト」からワザのダメージを受けない。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "パワフルストーム" },
+			damage: "20×",
+			cost: ["Grass"],
+			effect: {
+				ja: "自分の場のポケモンについているエネルギーの数x20ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 558965,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ジュプトル",
+	},
+
+	retreat: 1,
+	rarity: "Rare",
+	dexId: [254],
+};
+
+export default card;

--- a/data-asia/SM/SM7/005.ts
+++ b/data-asia/SM/SM7/005.ts
@@ -1,0 +1,53 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "タネボー",
+	},
+
+	illustrator: "miki kudo",
+	category: "Pokemon",
+	hp: 40,
+	types: ["Grass"],
+
+	description: {
+		ja: "枝に ぶらさがっていると 木の実に そっくり。 ついばもうとした ポケモンを 驚かせて 喜ぶ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ぶらさがる" },
+			damage: 10,
+			cost: ["Colorless"],
+		},
+		{
+			name: { ja: "かたくなる" },
+			cost: ["Grass"],
+			effect: {
+				ja: "次の相手の番、このポケモンは「40」以下のワザのダメージを受けない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558966,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [273],
+};
+
+export default card;

--- a/data-asia/SM/SM7/006.ts
+++ b/data-asia/SM/SM7/006.ts
@@ -1,0 +1,46 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "タネボー",
+	},
+
+	illustrator: "Misa Tsutsui",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Grass"],
+
+	description: {
+		ja: "枝に ぶらさがっていると 木の実に そっくり。 ついばもうとした ポケモンを 驚かせて 喜ぶ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ふむ" },
+			damage: 30,
+			cost: ["Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558967,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Common",
+	dexId: [273],
+};
+
+export default card;

--- a/data-asia/SM/SM7/007.ts
+++ b/data-asia/SM/SM7/007.ts
@@ -1,0 +1,57 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "コノハナ",
+	},
+
+	illustrator: "Ken Sugimori",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Grass"],
+
+	description: {
+		ja: "森の 奥深くに 生息。 頭の 葉っぱで 笛を 作り 不安に させる 音色を 出す。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "はたく" },
+			damage: 20,
+			cost: ["Grass"],
+		},
+		{
+			name: { ja: "ひとばらい" },
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "相手の手札を見て、その中にあるサポートを1枚、相手の山札にもどして切る。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558968,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "タネボー",
+	},
+
+	retreat: 2,
+	rarity: "Common",
+	dexId: [274],
+};
+
+export default card;

--- a/data-asia/SM/SM7/008.ts
+++ b/data-asia/SM/SM7/008.ts
@@ -1,0 +1,66 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ダーテングGX",
+	},
+
+	illustrator: "PLANETA Igarashi",
+	category: "Pokemon",
+	hp: 240,
+	types: ["Grass"],
+
+	stage: "Stage2",
+
+	attacks: [
+		{
+			name: { ja: "まどわす" },
+			damage: 40,
+			cost: ["Grass"],
+			effect: {
+				ja: "相手のバトルポケモンをこんらんにする。",
+			},
+		},
+		{
+			name: { ja: "じんつうりき" },
+			damage: "90+",
+			cost: ["Grass", "Colorless", "Colorless"],
+			effect: {
+				ja: "自分の手札と相手の手札が同じ枚数なら、90ダメージ追加。",
+			},
+		},
+		{
+			name: { ja: "ふくまでんGX" },
+			cost: ["Grass", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のポケモン1匹と、ついているすべてのカードを、相手の山札にもどして切る。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 558969,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "コノハナ",
+	},
+
+	retreat: 2,
+	rarity: "Double rare",
+	dexId: [275],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM7/009.ts
+++ b/data-asia/SM/SM7/009.ts
@@ -1,0 +1,48 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アメタマ",
+	},
+
+	illustrator: "Ken Sugimori",
+	category: "Pokemon",
+	hp: 50,
+	types: ["Grass"],
+
+	description: {
+		ja: "危険が 及ぶと 頭の 先から 甘い味の 液体が にじみだす。 とりポケモンが 嫌いな味だ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "あわ" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "コインを1回投げオモテなら、相手のバトルポケモンをマヒにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558970,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [283],
+};
+
+export default card;

--- a/data-asia/SM/SM7/010.ts
+++ b/data-asia/SM/SM7/010.ts
@@ -1,0 +1,60 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アメモース",
+	},
+
+	illustrator: "Yukiko Baba",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Grass"],
+
+	description: {
+		ja: "羽や 触角は 湿気が 苦手。 雨上がりには 太陽の ほうを 向いて 身体を 乾かす。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "びっくりもよう" },
+			cost: ["Grass"],
+			effect: {
+				ja: "相手の場のポケモンについている特殊エネルギーを、すべてトラッシュする。",
+			},
+		},
+		{
+			name: { ja: "ハリケーンウイング" },
+			damage: "40×",
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "コインを4回投げ、オモテの数x40ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558971,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "アメタマ",
+	},
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [284],
+};
+
+export default card;

--- a/data-asia/SM/SM7/011.ts
+++ b/data-asia/SM/SM7/011.ts
@@ -1,0 +1,49 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "バルビート",
+	},
+
+	illustrator: "Saya Tsuruta",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Grass"],
+
+	description: {
+		ja: "水の きれいな 池に 生息。 夜に なると お尻が 光り 点滅させて 仲間と 会話。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "フェロモンキャッチ" },
+			damage: "20+",
+			cost: ["Grass"],
+			effect: {
+				ja: "前の自分の番、自分の「イルミーゼ」が「フェロモンサイン」を使っていたなら、100ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558972,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [313],
+};
+
+export default card;

--- a/data-asia/SM/SM7/012.ts
+++ b/data-asia/SM/SM7/012.ts
@@ -1,0 +1,49 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "イルミーゼ",
+	},
+
+	illustrator: "Saya Tsuruta",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Grass"],
+
+	description: {
+		ja: "甘い 香りで バルビートを 誘導して 夜空に 光の サインを 描く。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "フェロモンサイン" },
+			damage: 20,
+			cost: ["Grass"],
+			effect: {
+				ja: "相手のバトルポケモンをこんらんにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558973,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [314],
+};
+
+export default card;

--- a/data-asia/SM/SM7/013.ts
+++ b/data-asia/SM/SM7/013.ts
@@ -1,0 +1,53 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "トロピウス",
+	},
+
+	illustrator: "Kagemaru Himeno",
+	category: "Pokemon",
+	hp: 110,
+	types: ["Grass"],
+
+	description: {
+		ja: "首の 房は １年に ２回 実を つける。 甘くて おいしい。 南国の 子供の おやつだ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ともだちをさがす" },
+			cost: ["Grass"],
+			effect: {
+				ja: "自分の山札にあるポケモンを2枚まで、相手に見せてから、手札に加える。そして山札を切る。",
+			},
+		},
+		{
+			name: { ja: "ソーラービーム" },
+			damage: 70,
+			cost: ["Grass", "Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558974,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [357],
+};
+
+export default card;

--- a/data-asia/SM/SM7/014.ts
+++ b/data-asia/SM/SM7/014.ts
@@ -1,0 +1,57 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ダダリン",
+	},
+
+	illustrator: "Kyoko Umemoto",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Grass"],
+
+	description: {
+		ja: "海に 漂う モズクの 魂が 生まれ変わった。 海の ゴミを モズクに 絡めて 身体を 保つ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ギガドレイン" },
+			damage: 30,
+			cost: ["Grass", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンに与えたダメージぶん、このポケモンのHPを回復する。",
+			},
+		},
+		{
+			name: { ja: "だいかいてん" },
+			damage: 130,
+			cost: ["Grass", "Grass", "Colorless"],
+			effect: {
+				ja: "次の自分の番、このポケモンはワザが使えない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558975,
+			},
+		},
+	],
+
+	retreat: 3,
+	rarity: "Uncommon",
+	dexId: [781],
+};
+
+export default card;

--- a/data-asia/SM/SM7/015.ts
+++ b/data-asia/SM/SM7/015.ts
@@ -1,0 +1,49 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アチャモ",
+	},
+
+	illustrator: "Kagemaru Himeno",
+	category: "Pokemon",
+	hp: 50,
+	types: ["Fire"],
+
+	description: {
+		ja: "体内で 炎が 燃えているので 抱きしめると とても 温かい。 １０００度の 火の玉を 飛ばす。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ひのこ" },
+			damage: 30,
+			cost: ["Fire"],
+			effect: {
+				ja: "このポケモンについているエネルギーを、1個トラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558976,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [255],
+};
+
+export default card;

--- a/data-asia/SM/SM7/016.ts
+++ b/data-asia/SM/SM7/016.ts
@@ -1,0 +1,51 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アチャモ",
+	},
+
+	illustrator: "MAHOU",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Fire"],
+
+	description: {
+		ja: "体内で 炎が 燃えているので 抱きしめると とても 温かい。 １０００度の 火の玉を 飛ばす。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "つつく" },
+			damage: 10,
+			cost: ["Fire"],
+		},
+		{
+			name: { ja: "ひだね" },
+			damage: 20,
+			cost: ["Fire", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558977,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [255],
+};
+
+export default card;

--- a/data-asia/SM/SM7/017.ts
+++ b/data-asia/SM/SM7/017.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ワカシャモ",
+	},
+
+	illustrator: "Mizue",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Fire"],
+
+	description: {
+		ja: "戦いに なると 体内の 炎が 激しく 燃え上がる。 キックは 破壊力 抜群だ。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "にどげり" },
+			damage: "30×",
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "コインを2回投げ、オモテの数x30ダメージ。",
+			},
+		},
+		{
+			name: { ja: "かえんほうしゃ" },
+			damage: 80,
+			cost: ["Fire", "Fire", "Colorless"],
+			effect: {
+				ja: "このポケモンについているエネルギーを、1個トラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558978,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "アチャモ",
+	},
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [256],
+};
+
+export default card;

--- a/data-asia/SM/SM7/018.ts
+++ b/data-asia/SM/SM7/018.ts
@@ -1,0 +1,63 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "バシャーモGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 240,
+	types: ["Fire"],
+
+	stage: "Stage2",
+
+	attacks: [
+		{
+			name: { ja: "きりさく" },
+			damage: 60,
+			cost: ["Colorless", "Colorless"],
+		},
+		{
+			name: { ja: "ばくえんきゃく" },
+			damage: 210,
+			cost: ["Fire", "Fire", "Colorless"],
+			effect: {
+				ja: "このポケモンについている[炎]エネルギーを、2個トラッシュする。",
+			},
+		},
+		{
+			name: { ja: "ブレイズアウトGX" },
+			cost: ["Fire"],
+			effect: {
+				ja: "相手の場のポケモンについているエネルギーを、2個トラッシュする。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 558979,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ワカシャモ",
+	},
+
+	retreat: 1,
+	rarity: "Double rare",
+	dexId: [257],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM7/019.ts
+++ b/data-asia/SM/SM7/019.ts
@@ -1,0 +1,57 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "コータス",
+	},
+
+	illustrator: "Ken Sugimori",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Fire"],
+
+	description: {
+		ja: "甲羅の中の 炎が 消えると 死んでしまう。 家で 育てるには 常に 燃やすものが いるぞ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "もえるけいてき" },
+			damage: 30,
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "自分の山札を上から4枚トラッシュし、その中にある[炎]エネルギーをすべて、自分のポケモンに好きなようにつける。",
+			},
+		},
+		{
+			name: { ja: "やきこがす" },
+			damage: 80,
+			cost: ["Fire", "Fire", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをやけどにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558980,
+			},
+		},
+	],
+
+	retreat: 3,
+	rarity: "Common",
+	dexId: [324],
+};
+
+export default card;

--- a/data-asia/SM/SM7/020.ts
+++ b/data-asia/SM/SM7/020.ts
@@ -1,0 +1,53 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "オドリドリ",
+	},
+
+	illustrator: "Naoyo Kimura",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Fire"],
+
+	description: {
+		ja: "くれないのミツを 吸った オドリドリ。 情熱的な ステップで 敵の 身も 心も 焼き尽くす。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "みわくのサルサ" },
+			cost: ["Fire"],
+			effect: {
+				ja: "相手のベンチポケモンを1匹選び、バトルポケモンと入れ替える。その後、新しく出てきたポケモンをやけどとこんらんにする。",
+			},
+		},
+		{
+			name: { ja: "ヒートブラスト" },
+			damage: 70,
+			cost: ["Fire", "Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558981,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [741],
+};
+
+export default card;

--- a/data-asia/SM/SM7/021.ts
+++ b/data-asia/SM/SM7/021.ts
@@ -1,0 +1,48 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ミズゴロウ",
+	},
+
+	illustrator: "Shigenori Negishi",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Water"],
+
+	description: {
+		ja: "頭の ヒレで 水の 流れを 感じて まわりの 様子を 知る。 岩を 持ち上げる 力持ち。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "みずため" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札にある[水]エネルギーを3枚まで、相手に見せてから、手札に加える。そして山札を切る。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558982,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [258],
+};
+
+export default card;

--- a/data-asia/SM/SM7/022.ts
+++ b/data-asia/SM/SM7/022.ts
@@ -1,0 +1,51 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ミズゴロウ",
+	},
+
+	illustrator: "Misa Tsutsui",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Water"],
+
+	description: {
+		ja: "頭の ヒレで 水の 流れを 感じて まわりの 様子を 知る。 岩を 持ち上げる 力持ち。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "たいあたり" },
+			damage: 10,
+			cost: ["Water"],
+		},
+		{
+			name: { ja: "スプラッシュ" },
+			damage: 20,
+			cost: ["Water", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558983,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [258],
+};
+
+export default card;

--- a/data-asia/SM/SM7/023.ts
+++ b/data-asia/SM/SM7/023.ts
@@ -1,0 +1,58 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヌマクロー",
+	},
+
+	illustrator: "Ken Sugimori",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Water"],
+
+	description: {
+		ja: "ドロドロに ぬかるんだ 足場で 生活する うちに 鍛えられ 強靭な 足腰に なった。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "だくりゅう" },
+			damage: 20,
+			cost: ["Water", "Colorless"],
+			effect: {
+				ja: "相手のベンチポケモン1匹にも、20ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+			},
+		},
+		{
+			name: { ja: "なみのり" },
+			damage: 70,
+			cost: ["Water", "Water", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558984,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ミズゴロウ",
+	},
+
+	retreat: 3,
+	rarity: "Common",
+	dexId: [259],
+};
+
+export default card;

--- a/data-asia/SM/SM7/024.ts
+++ b/data-asia/SM/SM7/024.ts
@@ -1,0 +1,63 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ラグラージ",
+	},
+
+	illustrator: "SATOSHI NAKAI",
+	category: "Pokemon",
+	hp: 160,
+	types: ["Water"],
+
+	description: {
+		ja: "大型船を 引っ張って 泳ぐ パワーの 持ち主。 太い 腕の 一振りで 相手を たたきのめす。",
+	},
+
+	stage: "Stage2",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "パワードロー" },
+			effect: {
+				ja: "自分の番に1回使える。自分の手札を1枚トラッシュする。その後、山札を3枚引く。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ハイドロポンプ" },
+			damage: "80+",
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンについている[水]エネルギーの数x20ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 558985,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ヌマクロー",
+	},
+
+	retreat: 3,
+	rarity: "Rare",
+	dexId: [260],
+};
+
+export default card;

--- a/data-asia/SM/SM7/025.ts
+++ b/data-asia/SM/SM7/025.ts
@@ -1,0 +1,45 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ホエルコ",
+	},
+
+	illustrator: "Kagemaru Himeno",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Water"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "なみをのみこむ" },
+			damage: 50,
+			cost: ["Water", "Water", "Water"],
+			effect: {
+				ja: "ウラが出るまでコインを投げ、オモテの数x50ダメージぶん、このポケモンのHPを回復する。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558986,
+			},
+		},
+	],
+
+	retreat: 3,
+	rarity: "Common",
+	dexId: [320],
+};
+
+export default card;

--- a/data-asia/SM/SM7/026.ts
+++ b/data-asia/SM/SM7/026.ts
@@ -1,0 +1,52 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ホエルオー",
+	},
+
+	illustrator: "Anesaki Dynamic",
+	category: "Pokemon",
+	hp: 220,
+	types: ["Water"],
+
+	description: {
+		ja: "とにかく どでかいので 人気。 ホエルオーウォッチングは 各地で 人気の 観光プラン なのだ。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "ひきしお 200-" },
+			cost: ["Water", "Water", "Water", "Water"],
+			effect: {
+				ja: "このポケモンにのっているダメカンの数x40ダメージぶん、このワザのダメージは小さくなる。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558987,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ホエルコ",
+	},
+
+	retreat: 4,
+	rarity: "Uncommon",
+	dexId: [321],
+};
+
+export default card;

--- a/data-asia/SM/SM7/027.ts
+++ b/data-asia/SM/SM7/027.ts
@@ -1,0 +1,56 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "パールル",
+	},
+
+	illustrator: "sui",
+	category: "Pokemon",
+	hp: 50,
+	types: ["Water"],
+
+	description: {
+		ja: "頑丈な 殻に 守られて 一生の うちに １個だけ 見事な 真珠を 作る。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ぬけがけしんか" },
+			effect: {
+				ja: "このポケモンは、後攻プレイヤーの最初の番なら、出したばかりでも進化できる。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "たまのかがやき" },
+			damage: 10,
+			cost: ["Water"],
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558988,
+			},
+		},
+	],
+
+	retreat: 3,
+	rarity: "Common",
+	dexId: [366],
+};
+
+export default card;

--- a/data-asia/SM/SM7/028.ts
+++ b/data-asia/SM/SM7/028.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ハンテール",
+	},
+
+	illustrator: "Shigenori Negishi",
+	category: "Pokemon",
+	hp: 110,
+	types: ["Water"],
+
+	description: {
+		ja: "深海に 生息する ポケモン。 小魚の 形をした 尻尾で 獲物を 誘き寄せ 捕まえる。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "かじりつく" },
+			damage: 30,
+			cost: ["Water"],
+			effect: {
+				ja: "次の相手の番、このワザを受けたポケモンは、にげられない。",
+			},
+		},
+		{
+			name: { ja: "デンジャラスバイト" },
+			damage: "40+",
+			cost: ["Water", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンがたねポケモンなら、80ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558989,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "パールル",
+	},
+
+	retreat: 1,
+	rarity: "Uncommon",
+	dexId: [367],
+};
+
+export default card;

--- a/data-asia/SM/SM7/029.ts
+++ b/data-asia/SM/SM7/029.ts
@@ -1,0 +1,53 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "サクラビス",
+	},
+
+	illustrator: "Mizue",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Water"],
+
+	description: {
+		ja: "泳ぐ 姿は とても 優雅。 細い 口で 岩場の すき間に 生えた 海藻を 食べる。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "さくらしぶき" },
+			damage: 30,
+			cost: ["Water"],
+			effect: {
+				ja: "次の相手の番、このポケモンは進化ポケモンからワザのダメージを受けない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558990,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "パールル",
+	},
+
+	retreat: 0,
+	rarity: "Uncommon",
+	dexId: [368],
+};
+
+export default card;

--- a/data-asia/SM/SM7/030.ts
+++ b/data-asia/SM/SM7/030.ts
@@ -1,0 +1,56 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ラブカス",
+	},
+
+	illustrator: "Asako Ito",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Water"],
+
+	description: {
+		ja: "カップルに 人気が 高いので ハネムーン客が 泊まる ホテルの プールに 放流 される。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "おあいこ" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札にあるたねポケモンを、相手のベンチポケモンの数ぶんまで、ベンチに出す。そして山札を切る。",
+			},
+		},
+		{
+			name: { ja: "みずのはどう" },
+			damage: 20,
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをねむりにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558991,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [370],
+};
+
+export default card;

--- a/data-asia/SM/SM7/031.ts
+++ b/data-asia/SM/SM7/031.ts
@@ -1,0 +1,59 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "レジアイス",
+	},
+
+	illustrator: "kodama",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Water"],
+
+	description: {
+		ja: "氷河期に できた 氷で 体が 作られている。 マイナス２００度の 冷気を 操る。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "こおりのけっかい" },
+			effect: {
+				ja: "このポケモンがバトル場にいるかぎり、相手は手札からスタジアムを出せない。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "こごえるかぜ" },
+			damage: 60,
+			cost: ["Water", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをねむりにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558992,
+			},
+		},
+	],
+
+	retreat: 3,
+	rarity: "Uncommon",
+	dexId: [378],
+};
+
+export default card;

--- a/data-asia/SM/SM7/032.ts
+++ b/data-asia/SM/SM7/032.ts
@@ -1,0 +1,56 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "カイオーガ",
+	},
+
+	illustrator: "Shin Nagasawa",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Water"],
+
+	description: {
+		ja: "大雨を 降らせる 能力で 海を 広げたと 言われている。 海溝の 底で 眠っていた。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "デュアルスプラッシュ" },
+			cost: ["Water", "Colorless"],
+			effect: {
+				ja: "相手のポケモン2匹に、それぞれ30ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+			},
+		},
+		{
+			name: { ja: "グランドウェーブ" },
+			damage: 120,
+			cost: ["Water", "Water", "Colorless"],
+			effect: {
+				ja: "次の自分の番、このポケモンは「グランドウェーブ」が使えない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 558993,
+			},
+		},
+	],
+
+	retreat: 4,
+	rarity: "Rare",
+	dexId: [382],
+};
+
+export default card;

--- a/data-asia/SM/SM7/033.ts
+++ b/data-asia/SM/SM7/033.ts
@@ -1,0 +1,46 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ラクライ",
+	},
+
+	illustrator: "Kouki Saitou",
+	category: "Pokemon",
+	hp: 50,
+	types: ["Lightning"],
+
+	description: {
+		ja: "静電気を 体毛に たくわえて 放電する。 嵐が 近づくと 全身から 火花を 散らす。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "エレキック" },
+			damage: 20,
+			cost: ["Lightning"],
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Metal", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558994,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [309],
+};
+
+export default card;

--- a/data-asia/SM/SM7/034.ts
+++ b/data-asia/SM/SM7/034.ts
@@ -1,0 +1,63 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ライボルト",
+	},
+
+	illustrator: "Sanosuke Sakuma",
+	category: "Pokemon",
+	hp: 110,
+	types: ["Lightning"],
+
+	description: {
+		ja: "たてがみから 放電している。 頭上に 雷雲を 作り 稲妻を 落として 攻撃する。",
+	},
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ボルトスタート" },
+			effect: {
+				ja: "自分が後攻プレイヤーなら、対戦準備でポケモンを場に出すとき、このカードを手札からウラにして出してよい。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ダブルチャージ" },
+			damage: 40,
+			cost: ["Lightning"],
+			effect: {
+				ja: "のぞむなら、自分の手札にある基本エネルギーを2枚まで、ベンチポケモン1匹につける。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Metal", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558995,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ラクライ",
+	},
+
+	retreat: 0,
+	rarity: "Uncommon",
+	dexId: [310],
+};
+
+export default card;

--- a/data-asia/SM/SM7/035.ts
+++ b/data-asia/SM/SM7/035.ts
@@ -1,0 +1,53 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "プラスル",
+	},
+
+	illustrator: "Kanako Eo",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Lightning"],
+
+	description: {
+		ja: "電柱から 電気を 吸い取る。 体に ためた 電気を ショートさせて 音を 出す。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "みんなでドロー" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の手札をすべて山札にもどして切る。その後、おたがいのベンチポケモンの数ぶん、山札を引く。",
+			},
+		},
+		{
+			name: { ja: "エレキボール" },
+			damage: 30,
+			cost: ["Lightning", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Metal", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558996,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [311],
+};
+
+export default card;

--- a/data-asia/SM/SM7/036.ts
+++ b/data-asia/SM/SM7/036.ts
@@ -1,0 +1,53 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "マイナン",
+	},
+
+	illustrator: "Sumiyoshi Kizuki",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Lightning"],
+
+	description: {
+		ja: "仲間を 応援する 習性。 負けそうになると 体から 出す 火花の 数が どんどん 増える。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ぽいぽいドロー" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の手札が5枚になるように、山札を引く。のぞむなら、山札を引く前に、自分の手札を好きなだけトラッシュする。",
+			},
+		},
+		{
+			name: { ja: "エレキボール" },
+			damage: 30,
+			cost: ["Lightning", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Metal", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558997,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [312],
+};
+
+export default card;

--- a/data-asia/SM/SM7/037.ts
+++ b/data-asia/SM/SM7/037.ts
@@ -1,0 +1,53 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "オドリドリ",
+	},
+
+	illustrator: "Sekio",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Lightning"],
+
+	description: {
+		ja: "羽毛を こすり合わせ 帯電。 踊るように 敵に 近づき 電撃パンチを お見舞いするぞ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "びりびりポンポン" },
+			cost: ["Lightning"],
+			effect: {
+				ja: "おたがいの場の「ポケモンGX・EX」全員に、それぞれ30ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+			},
+		},
+		{
+			name: { ja: "ライトニングボール" },
+			damage: 70,
+			cost: ["Lightning", "Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558998,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [741],
+};
+
+export default card;

--- a/data-asia/SM/SM7/038.ts
+++ b/data-asia/SM/SM7/038.ts
@@ -1,0 +1,48 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "バネブー",
+	},
+
+	illustrator: "MAHOU",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Psychic"],
+
+	description: {
+		ja: "尻尾で 飛び跳ねて 心臓を 動かしている。 パールルの 作った 真珠を 頭に 乗せている。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "とびはねる" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "このポケモンをベンチポケモンと入れ替える。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558999,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [325],
+};
+
+export default card;

--- a/data-asia/SM/SM7/039.ts
+++ b/data-asia/SM/SM7/039.ts
@@ -1,0 +1,53 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ブーピッグ",
+	},
+
+	illustrator: "Ken Sugimori",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Psychic"],
+
+	description: {
+		ja: "黒真珠で サイコパワーを 増幅させる。 不思議な ステップで 相手の 心を 操る。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "ミラーステップ" },
+			damage: "10+",
+			cost: ["Colorless"],
+			effect: {
+				ja: "相手の場に、自分の場のポケモンと同じ名前のポケモンがいるなら、70ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559000,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "バネブー",
+	},
+
+	retreat: 2,
+	rarity: "Uncommon",
+	dexId: [326],
+};
+
+export default card;

--- a/data-asia/SM/SM7/040.ts
+++ b/data-asia/SM/SM7/040.ts
@@ -1,0 +1,48 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "カゲボウズ",
+	},
+
+	illustrator: "Eri Yamaki",
+	category: "Pokemon",
+	hp: 50,
+	types: ["Psychic"],
+
+	description: {
+		ja: "恨みの 感情が 大好き。 恨みを 持つ 人が 住む 家の 軒下に ずらりと ぶらさがる。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "まどわす" },
+			cost: ["Psychic"],
+			effect: {
+				ja: "相手のバトルポケモンをこんらんにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559001,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [353],
+};
+
+export default card;

--- a/data-asia/SM/SM7/041.ts
+++ b/data-asia/SM/SM7/041.ts
@@ -1,0 +1,62 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ジュペッタ",
+	},
+
+	illustrator: "Eri Yamaki",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Psychic"],
+
+	description: {
+		ja: "強い おん念が ぬいぐるみを ポケモンに 変えた。 口を 開けると のろいの エネルギーが 逃げていく。",
+	},
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "あかいまなこ" },
+			effect: {
+				ja: "自分の番に、このカードを手札から出して進化させたとき、1回使える。相手のトラッシュにあるたねポケモンを1枚、相手のベンチに出す。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "エネミーショー" },
+			cost: ["Psychic", "Colorless"],
+			effect: {
+				ja: "相手の場のポケモンの数ぶんのダメカンを、相手のポケモンに好きなようにのせる。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559002,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "カゲボウズ",
+	},
+
+	retreat: 1,
+	rarity: "Uncommon",
+	dexId: [354],
+};
+
+export default card;

--- a/data-asia/SM/SM7/042.ts
+++ b/data-asia/SM/SM7/042.ts
@@ -1,0 +1,57 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "デオキシス",
+	},
+
+	illustrator: "Masakazu Fukuda",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Psychic"],
+
+	description: {
+		ja: "宇宙ウイルスが 突然変異を 起こして ポケモンに なった。 オーロラの 近くに 現れる。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "サイコキネシス" },
+			damage: "20+",
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンについているエネルギーの数x20ダメージ追加。",
+			},
+		},
+		{
+			name: { ja: "パワーブラスト" },
+			damage: 120,
+			cost: ["Psychic", "Psychic", "Colorless"],
+			effect: {
+				ja: "このポケモンについているエネルギーを、1個トラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 559003,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Rare",
+	dexId: [386],
+};
+
+export default card;

--- a/data-asia/SM/SM7/043.ts
+++ b/data-asia/SM/SM7/043.ts
@@ -1,0 +1,56 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "デオキシス",
+	},
+
+	illustrator: "Ayaka Yoshida",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Psychic"],
+
+	description: {
+		ja: "宇宙ウイルスが 突然変異を 起こして ポケモンに なった。 オーロラの 近くに 現れる。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "リフレクター" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "次の相手の番、このポケモンが受けるワザのダメージは「-40」される。",
+			},
+		},
+		{
+			name: { ja: "サイコスクリュー" },
+			damage: 80,
+			cost: ["Psychic", "Colorless", "Colorless"],
+			effect: {
+				ja: "このワザのダメージは抵抗力を計算しない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559004,
+			},
+		},
+	],
+
+	retreat: 3,
+	rarity: "Uncommon",
+	dexId: [386],
+};
+
+export default card;

--- a/data-asia/SM/SM7/044.ts
+++ b/data-asia/SM/SM7/044.ts
@@ -1,0 +1,56 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "デオキシス",
+	},
+
+	illustrator: "Kouki Saitou",
+	category: "Pokemon",
+	hp: 100,
+	types: ["Psychic"],
+
+	description: {
+		ja: "宇宙ウイルスが 突然変異を 起こして ポケモンに なった。 オーロラの 近くに 現れる。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "テレポートブレイク" },
+			damage: 20,
+			cost: ["Psychic"],
+			effect: {
+				ja: "のぞむなら、このポケモンをベンチポケモンと入れ替える。",
+			},
+		},
+		{
+			name: { ja: "スピアダイブ" },
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のポケモン1匹に、50ダメージ。このワザのダメージは弱点・抵抗力を計算しない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559005,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Uncommon",
+	dexId: [386],
+};
+
+export default card;

--- a/data-asia/SM/SM7/045.ts
+++ b/data-asia/SM/SM7/045.ts
@@ -1,0 +1,53 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アサナン",
+	},
+
+	illustrator: "Shibuzoh.",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Fighting"],
+
+	description: {
+		ja: "１日 １個だけ 木の実を 食べる。 空腹に 耐えることで 心が 研ぎ澄まされていく。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "がまん" },
+			cost: ["Fighting"],
+			effect: {
+				ja: "コインを1回投げオモテなら、次の相手の番、このポケモンがワザのダメージを受けてきぜつするとき、このポケモンはきぜつせず、残りHPが「10」の状態で場に残る。",
+			},
+		},
+		{
+			name: { ja: "キック" },
+			damage: 30,
+			cost: ["Fighting", "Fighting"],
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559006,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [307],
+};
+
+export default card;

--- a/data-asia/SM/SM7/046.ts
+++ b/data-asia/SM/SM7/046.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "チャーレム",
+	},
+
+	illustrator: "Misa Tsutsui",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Fighting"],
+
+	description: {
+		ja: "ヨガの 修行で 鍛えられた サイコパワーで 相手の 動きを 予測する ことが できるのだ。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "さとりのいちげき" },
+			damage: "10+",
+			cost: ["Fighting", "Fighting"],
+			effect: {
+				ja: "このポケモンの残りHPが「30」以下なら、160ダメージ追加。",
+			},
+		},
+		{
+			name: { ja: "スピニングキック" },
+			damage: 90,
+			cost: ["Fighting", "Fighting"],
+			effect: {
+				ja: "このポケモンにも30ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559007,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "アサナン",
+	},
+
+	retreat: 1,
+	rarity: "Uncommon",
+	dexId: [308],
+};
+
+export default card;

--- a/data-asia/SM/SM7/047.ts
+++ b/data-asia/SM/SM7/047.ts
@@ -1,0 +1,49 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヤジロン",
+	},
+
+	illustrator: "Ken Sugimori",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Fighting"],
+
+	description: {
+		ja: "一本足で 回転しながら 移動する。 古代の 遺跡から 見つかった 珍しい ポケモン。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ねんりき" },
+			damage: 20,
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "コインを1回投げオモテなら、相手のバトルポケモンをマヒにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559008,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [343],
+};
+
+export default card;

--- a/data-asia/SM/SM7/048.ts
+++ b/data-asia/SM/SM7/048.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ネンドール",
+	},
+
+	illustrator: "Yumi",
+	category: "Pokemon",
+	hp: 110,
+	types: ["Fighting"],
+
+	description: {
+		ja: "２万年前の 古代人が 泥で 作った 人形に 命が 宿ったと 言われている。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "ねんりき" },
+			damage: 20,
+			cost: ["Colorless"],
+			effect: {
+				ja: "コインを1回投げオモテなら、相手のバトルポケモンをマヒにする。",
+			},
+		},
+		{
+			name: { ja: "ミラクルスピン" },
+			damage: "40×",
+			cost: ["Fighting", "Colorless", "Colorless"],
+			effect: {
+				ja: "自分のトラッシュにある「ダイゴの決断」の枚数x40ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559009,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ヤジロン",
+	},
+
+	retreat: 2,
+	rarity: "Uncommon",
+	dexId: [344],
+};
+
+export default card;

--- a/data-asia/SM/SM7/049.ts
+++ b/data-asia/SM/SM7/049.ts
@@ -1,0 +1,57 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "レジロック",
+	},
+
+	illustrator: "Ayaka Yoshida",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Fighting"],
+
+	description: {
+		ja: "体を 作っている 岩石と 同じ 物が 世界中の あらゆる 地層で 見つかっている。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "きょうかスタンプ" },
+			damage: "20+",
+			cost: ["Fighting"],
+			effect: {
+				ja: "このポケモンに「ポケモンのどうぐ」がついているなら、20ダメージ追加。",
+			},
+		},
+		{
+			name: { ja: "アームハンマー" },
+			damage: 100,
+			cost: ["Fighting", "Fighting", "Colorless"],
+			effect: {
+				ja: "相手の山札を上から1枚トラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559010,
+			},
+		},
+	],
+
+	retreat: 3,
+	rarity: "Uncommon",
+	dexId: [377],
+};
+
+export default card;

--- a/data-asia/SM/SM7/050.ts
+++ b/data-asia/SM/SM7/050.ts
@@ -1,0 +1,57 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "グラードン",
+	},
+
+	illustrator: "Masakazu Fukuda",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Fighting"],
+
+	description: {
+		ja: "カイオーガと 死闘の末 長い 眠りに ついた。 大地の 化身と 言われる 伝説の ポケモン。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ぶちこわす" },
+			damage: "50+",
+			cost: ["Fighting", "Colorless", "Colorless"],
+			effect: {
+				ja: "場にスタジアムが出ているなら、50ダメージ追加。その後、そのスタジアムをトラッシュする。",
+			},
+		},
+		{
+			name: { ja: "グラウンドスラッシュ" },
+			damage: 130,
+			cost: ["Fighting", "Fighting", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンについているエネルギーを、1個トラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 559011,
+			},
+		},
+	],
+
+	retreat: 4,
+	rarity: "Rare",
+	dexId: [383],
+};
+
+export default card;

--- a/data-asia/SM/SM7/051.ts
+++ b/data-asia/SM/SM7/051.ts
@@ -1,0 +1,59 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "メテノ",
+	},
+
+	illustrator: "sui",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Fighting"],
+
+	description: {
+		ja: "強い 衝撃を うけると 殻は はがれ 落ちる。 ナノ粒子が 突然変異し 生まれたポケモン。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ほしふり" },
+			effect: {
+				ja: "自分の番に、このカードが手札にあり、自分のベンチに空きがあるなら、1回使える。このカードを手札から直接バトル場に出す。その場合、バトルポケモンはベンチへもどす。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "スピードスター" },
+			damage: 30,
+			cost: ["Fighting"],
+			effect: {
+				ja: "このワザのダメージは、弱点・抵抗力と、相手のバトルポケモンにかかっている効果を計算しない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559012,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Common",
+	dexId: [774],
+};
+
+export default card;

--- a/data-asia/SM/SM7/052.ts
+++ b/data-asia/SM/SM7/052.ts
@@ -1,0 +1,56 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ダンバル",
+	},
+
+	illustrator: "Naoyo Kimura",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Metal"],
+
+	description: {
+		ja: "磁力を 放って 相手を ひき寄せた ところで お尻の ツメで 切り裂くのだ。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ひきあうからだ" },
+			effect: {
+				ja: "このポケモンがバトル場にいるかぎり、このポケモンのにげるためのエネルギーは、自分のベンチの「ダンバル」の数ぶん少なくなる。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ぶつかる" },
+			damage: 10,
+			cost: ["Metal"],
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559013,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Common",
+	dexId: [374],
+};
+
+export default card;

--- a/data-asia/SM/SM7/053.ts
+++ b/data-asia/SM/SM7/053.ts
@@ -1,0 +1,49 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ダンバル",
+	},
+
+	illustrator: "Hasuno",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Metal"],
+
+	description: {
+		ja: "磁力を 放って 相手を ひき寄せた ところで お尻の ツメで 切り裂くのだ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "シングルスマッシュ" },
+			damage: 50,
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "コインを1回投げウラなら、このワザは失敗。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559014,
+			},
+		},
+	],
+
+	retreat: 3,
+	rarity: "Common",
+	dexId: [374],
+};
+
+export default card;

--- a/data-asia/SM/SM7/054.ts
+++ b/data-asia/SM/SM7/054.ts
@@ -1,0 +1,53 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "メタング",
+	},
+
+	illustrator: "SATOSHI NAKAI",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Metal"],
+
+	description: {
+		ja: "磁力を 放つ 鉱物が 好物。 時速 １００キロで ノズパスを 追いつめるぞ。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "バレットパンチ" },
+			damage: "20+",
+			cost: ["Metal"],
+			effect: {
+				ja: "コインを2回投げ、オモテの数x20ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559015,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ダンバル",
+	},
+
+	retreat: 3,
+	rarity: "Common",
+	dexId: [375],
+};
+
+export default card;

--- a/data-asia/SM/SM7/055.ts
+++ b/data-asia/SM/SM7/055.ts
@@ -1,0 +1,63 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "メタグロス",
+	},
+
+	illustrator: "TOKIYA",
+	category: "Pokemon",
+	hp: 170,
+	types: ["Metal"],
+
+	description: {
+		ja: "２匹の メタングが 連結。 ４つの 脳の 並列処理で どんな 計算も あっという間。",
+	},
+
+	stage: "Stage2",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "エクステンド" },
+			effect: {
+				ja: "このポケモンがバトル場にいるかぎり、自分の「ダイゴの決断」を使っても、自分の番は終わらない。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "コメットパンチ" },
+			damage: 60,
+			cost: ["Metal"],
+			effect: {
+				ja: "次の自分の番、このポケモンの「コメットパンチ」のダメージは「+60」される。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 559016,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "メタング",
+	},
+
+	retreat: 4,
+	rarity: "Rare",
+	dexId: [376],
+};
+
+export default card;

--- a/data-asia/SM/SM7/056.ts
+++ b/data-asia/SM/SM7/056.ts
@@ -1,0 +1,59 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "レジスチル",
+	},
+
+	illustrator: "Shin Nagasawa",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Metal"],
+
+	description: {
+		ja: "どんな 金属よりも 硬いと 言われる 体。 調査の 結果 体の 中は 空洞だった。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "かたいからだ" },
+			effect: {
+				ja: "このポケモンが受けるワザのダメージは「-20」される。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "シルバーフィスト" },
+			damage: "60+",
+			cost: ["Metal", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンが特性を持っているなら、60ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559017,
+			},
+		},
+	],
+
+	retreat: 3,
+	rarity: "Uncommon",
+	dexId: [379],
+};
+
+export default card;

--- a/data-asia/SM/SM7/057.ts
+++ b/data-asia/SM/SM7/057.ts
@@ -1,0 +1,59 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ジラーチ",
+	},
+
+	illustrator: "Kouki Saitou",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Metal"],
+
+	description: {
+		ja: "１０００年間で ７日だけ 目を 覚まし どんな 願い事でも かなえる 力を 使うという。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ほしにねがいを" },
+			effect: {
+				ja: "自分の番に、ウラになっている自分のサイドからこのカードをとったとき、自分のベンチに空きがあるなら、手札に加える前に使える。このポケモンを自分のベンチに出し、さらにサイドを1枚とる。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ほろびのゆめ" },
+			damage: 10,
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンをねむりにする。次の相手の番の終わりに、このワザを受けた相手のポケモンはきぜつする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 559018,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Rare Holo",
+	dexId: [385],
+};
+
+export default card;

--- a/data-asia/SM/SM7/058.ts
+++ b/data-asia/SM/SM7/058.ts
@@ -1,0 +1,49 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "テッカグヤ",
+	},
+
+	illustrator: "kawayoo",
+	category: "Pokemon",
+	hp: 140,
+	types: ["Metal"],
+
+	description: {
+		ja: "ＵＢの 一種。 ２本の 腕から ガスを 噴きだし 森を 焼き払う 姿が 確認 されている。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ムーンレイカー" },
+			damage: 160,
+			cost: ["Metal", "Colorless", "Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "このワザは、おたがいのサイドの残り枚数の合計が6枚なら、[鋼]エネルギー1個で使える。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 559019,
+			},
+		},
+	],
+
+	retreat: 4,
+	rarity: "Rare",
+	dexId: [797],
+};
+
+export default card;

--- a/data-asia/SM/SM7/059.ts
+++ b/data-asia/SM/SM7/059.ts
@@ -1,0 +1,49 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "カミツルギ",
+	},
+
+	illustrator: "Hasuno",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Metal"],
+
+	description: {
+		ja: "巨大な 鉄塔を 一刀の もとに 切り捨てる 姿が 目撃された ビーストの 一種。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "カミカゼ" },
+			damage: "40+",
+			cost: ["Metal", "Metal"],
+			effect: {
+				ja: "相手のサイドの残り枚数が6枚なら、90ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559020,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Uncommon",
+	dexId: [798],
+};
+
+export default card;

--- a/data-asia/SM/SM7/060.ts
+++ b/data-asia/SM/SM7/060.ts
@@ -1,0 +1,62 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ツンデツンデGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 180,
+	types: ["Metal"],
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ウルトラウォール" },
+			effect: {
+				ja: "このポケモンがいるかぎり、自分の「ウルトラビースト」全員が、相手のポケモンから受けるワザのダメージは「-10」される。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ギガトンスタンプ" },
+			damage: 120,
+			cost: ["Metal", "Metal", "Colorless"],
+		},
+		{
+			name: { ja: "レイGX" },
+			damage: "50+",
+			cost: ["Metal", "Metal", "Colorless"],
+			effect: {
+				ja: "自分がすでにとったサイドの枚数x50ダメージ追加。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 559021,
+			},
+		},
+	],
+
+	retreat: 3,
+	rarity: "Double rare",
+	dexId: [805],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM7/061.ts
+++ b/data-asia/SM/SM7/061.ts
@@ -1,0 +1,66 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "チルタリスGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 200,
+	types: ["Dragon"],
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "ブライトトーン" },
+			damage: 50,
+			cost: ["Fairy", "Colorless"],
+			effect: {
+				ja: "次の相手の番、このポケモンは「ポケモンGX・EX」からワザのダメージを受けない。",
+			},
+		},
+		{
+			name: { ja: "ソニックエッジ" },
+			damage: 110,
+			cost: ["Water", "Fairy", "Colorless"],
+			effect: {
+				ja: "このワザのダメージは、相手のバトルポケモンにかかっている効果を計算しない。",
+			},
+		},
+		{
+			name: { ja: "ユーフォリアGX" },
+			cost: ["Fairy", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをねむりにする。自分のポケモン全員のHPを、すべて回復する。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fairy", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 559022,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "チルット",
+	},
+
+	retreat: 1,
+	rarity: "Double rare",
+	dexId: [334],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM7/062.ts
+++ b/data-asia/SM/SM7/062.ts
@@ -1,0 +1,49 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "タツベイ",
+	},
+
+	illustrator: "Yumi",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Dragon"],
+
+	description: {
+		ja: "鋼鉄並みの 石頭で やたら めったら 頭突きする。 空を 飛べない ストレスの せいだ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "いしあたま" },
+			damage: 10,
+			cost: ["Water"],
+			effect: {
+				ja: "次の相手の番、このポケモンが受けるワザのダメージは「-10」される。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fairy", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559023,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [371],
+};
+
+export default card;

--- a/data-asia/SM/SM7/063.ts
+++ b/data-asia/SM/SM7/063.ts
@@ -1,0 +1,49 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "タツベイ",
+	},
+
+	illustrator: "sui",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Dragon"],
+
+	description: {
+		ja: "鋼鉄並みの 石頭で やたら めったら 頭突きする。 空を 飛べない ストレスの せいだ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "とつげき" },
+			damage: 40,
+			cost: ["Fire", "Colorless"],
+			effect: {
+				ja: "このポケモンにも10ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fairy", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559024,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Common",
+	dexId: [371],
+};
+
+export default card;

--- a/data-asia/SM/SM7/064.ts
+++ b/data-asia/SM/SM7/064.ts
@@ -1,0 +1,53 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "コモルー",
+	},
+
+	illustrator: "Asako Ito",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Dragon"],
+
+	description: {
+		ja: "洞穴の 奥に じっと 潜み 何も 喰わず 何も 飲まない。 なぜ 死なないのかは 不明だ。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "いかりのやいば" },
+			damage: "30+",
+			cost: ["Fire", "Water"],
+			effect: {
+				ja: "このポケモンにダメカンがのっているなら、50ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fairy", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559025,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "タツベイ",
+	},
+
+	retreat: 3,
+	rarity: "Common",
+	dexId: [372],
+};
+
+export default card;

--- a/data-asia/SM/SM7/065.ts
+++ b/data-asia/SM/SM7/065.ts
@@ -1,0 +1,60 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ボーマンダ",
+	},
+
+	illustrator: "Mitsuhiro Arita",
+	category: "Pokemon",
+	hp: 150,
+	types: ["Dragon"],
+
+	description: {
+		ja: "ついに 生えた 翼で 大空を 駆け廻る。 うれしくて 火炎を 吐いて 一面を 焼け野原にする。",
+	},
+
+	stage: "Stage2",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "りゅうのかぜ" },
+			effect: {
+				ja: "このポケモンがバトル場にいるなら、自分の番に1回使える。相手のベンチポケモンを1匹選び、バトルポケモンと入れ替える。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ドラゴンクロー" },
+			damage: 100,
+			cost: ["Fire", "Water", "Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fairy", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 559026,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "コモルー",
+	},
+
+	retreat: 3,
+	rarity: "Rare",
+	dexId: [373],
+};
+
+export default card;

--- a/data-asia/SM/SM7/066.ts
+++ b/data-asia/SM/SM7/066.ts
@@ -1,0 +1,49 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ラティアス",
+	},
+
+	illustrator: "Anesaki Dynamic",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Dragon"],
+
+	description: {
+		ja: "テレパシーで 人間と 気持ちを 通わせる。 光を 屈折させる 羽毛で 別の 姿に 変わる。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ドリームミスト" },
+			damage: 30,
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分のベンチの[竜]タイプのたねポケモン全員に、トラッシュにある基本エネルギーを1枚ずつつける。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fairy", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 559027,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Rare Holo",
+	dexId: [380],
+};
+
+export default card;

--- a/data-asia/SM/SM7/067.ts
+++ b/data-asia/SM/SM7/067.ts
@@ -1,0 +1,49 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ラティオス",
+	},
+
+	illustrator: "Anesaki Dynamic",
+	category: "Pokemon",
+	hp: 140,
+	types: ["Dragon"],
+
+	description: {
+		ja: "高い 知能を 持ち 人間の 言葉を 理解する。 争いを 嫌う 優しい ポケモンだ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ドラゴンフリート" },
+			damage: "50×",
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "自分の場の[竜]タイプの進化ポケモンの数x50ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fairy", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 559028,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Rare Holo",
+	dexId: [381],
+};
+
+export default card;

--- a/data-asia/SM/SM7/068.ts
+++ b/data-asia/SM/SM7/068.ts
@@ -1,0 +1,64 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "レックウザGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 180,
+	types: ["Dragon"],
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "しっぷうどとう" },
+			effect: {
+				ja: "自分の番に、このカードを手札からベンチに出したとき、1回使える。自分の山札を上から3枚トラッシュする。その後、トラッシュにある基本エネルギーを1枚、このポケモンにつける。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ドラゴンブレイク" },
+			damage: "30×",
+			cost: ["Grass", "Lightning", "Colorless"],
+			effect: {
+				ja: "自分の場のポケモンについている[草]と[雷]タイプの基本エネルギーの数x30ダメージ。",
+			},
+		},
+		{
+			name: { ja: "テンペストGX" },
+			cost: ["Grass"],
+			effect: {
+				ja: "自分の手札をすべてトラッシュし、山札を10枚引く。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fairy", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 559029,
+			},
+		},
+	],
+
+	retreat: 3,
+	rarity: "Double rare",
+	dexId: [384],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM7/069.ts
+++ b/data-asia/SM/SM7/069.ts
@@ -1,0 +1,46 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "キャモメ",
+	},
+
+	illustrator: "Ken Sugimori",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Colorless"],
+
+	description: {
+		ja: "キャモメが 飛び交う 海の 下は さかなポケモンが 群れているので 漁師は まずキャモメを 探す。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "かっくう" },
+			damage: 10,
+			cost: ["Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559030,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [278],
+};
+
+export default card;

--- a/data-asia/SM/SM7/070.ts
+++ b/data-asia/SM/SM7/070.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ペリッパー",
+	},
+
+	illustrator: "Shigenori Negishi",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Colorless"],
+
+	description: {
+		ja: "餌集めは 若い ♂の 仕事。 大きなクチバシに 餌を 溜めて 仲間が 待つ 巣まで 運ぶ。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "しょうか" },
+			damage: 30,
+			cost: ["Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンについている[炎]エネルギーを、1個トラッシュする。",
+			},
+		},
+		{
+			name: { ja: "みずのはどう" },
+			damage: 80,
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをねむりにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559031,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "キャモメ",
+	},
+
+	retreat: 2,
+	rarity: "Common",
+	dexId: [279],
+};
+
+export default card;

--- a/data-asia/SM/SM7/071.ts
+++ b/data-asia/SM/SM7/071.ts
@@ -1,0 +1,53 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ゴニョニョ",
+	},
+
+	illustrator: "Shibuzoh.",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Colorless"],
+
+	description: {
+		ja: "危険を 察知すると ジェット機と 同じ 音量の 鳴き声を 上げて 敵を ひるませるのだ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ごうきゅう" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "このワザは、後攻プレイヤーの最初の番にだけ使える。次の相手の番、相手は手札からトレーナーズを出して使えない。",
+			},
+		},
+		{
+			name: { ja: "はたく" },
+			damage: 20,
+			cost: ["Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559032,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Common",
+	dexId: [293],
+};
+
+export default card;

--- a/data-asia/SM/SM7/072.ts
+++ b/data-asia/SM/SM7/072.ts
@@ -1,0 +1,49 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ゴニョニョ",
+	},
+
+	illustrator: "Asako Ito",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Colorless"],
+
+	description: {
+		ja: "危険を 察知すると ジェット機と 同じ 音量の 鳴き声を 上げて 敵を ひるませるのだ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "なきわめく" },
+			damage: 40,
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをベンチポケモンと入れ替える。［バトル場に出すポケモンは相手が選ぶ。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559033,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Common",
+	dexId: [293],
+};
+
+export default card;

--- a/data-asia/SM/SM7/073.ts
+++ b/data-asia/SM/SM7/073.ts
@@ -1,0 +1,53 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ドゴーム",
+	},
+
+	illustrator: "Masakazu Fukuda",
+	category: "Pokemon",
+	hp: 100,
+	types: ["Colorless"],
+
+	description: {
+		ja: "大声の 衝撃波で トラックを ひっくりかえしてしまう。 足を 踏みならして パワーアップ。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "だみごえ" },
+			damage: 60,
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをこんらんにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559034,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ゴニョニョ",
+	},
+
+	retreat: 3,
+	rarity: "Common",
+	dexId: [294],
+};
+
+export default card;

--- a/data-asia/SM/SM7/074.ts
+++ b/data-asia/SM/SM7/074.ts
@@ -1,0 +1,58 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "バクオング",
+	},
+
+	illustrator: "kawayoo",
+	category: "Pokemon",
+	hp: 150,
+	types: ["Colorless"],
+
+	description: {
+		ja: "戦いのときに 出す うなり声は まるで 地震の ように 地面を グラグラと 揺らす。",
+	},
+
+	stage: "Stage2",
+
+	attacks: [
+		{
+			name: { ja: "デスライブ" },
+			damage: 80,
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "ダメカンがのっている相手のベンチポケモン全員にも、それぞれ30ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+			},
+		},
+		{
+			name: { ja: "ヘビーインパクト" },
+			damage: 100,
+			cost: ["Colorless", "Colorless", "Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559035,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ドゴーム",
+	},
+
+	retreat: 4,
+	rarity: "Uncommon",
+	dexId: [295],
+};
+
+export default card;

--- a/data-asia/SM/SM7/075.ts
+++ b/data-asia/SM/SM7/075.ts
@@ -1,0 +1,49 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "エネコ",
+	},
+
+	illustrator: "Ken Sugimori",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Colorless"],
+
+	description: {
+		ja: "自分の 尻尾を 追いかけて 遊んでいると 目を 回すといった 可愛らしい 一面を みせる。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ねこだまし" },
+			damage: 10,
+			cost: ["Colorless"],
+			effect: {
+				ja: "コインを1回投げオモテなら、相手のバトルポケモンをマヒにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559036,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [300],
+};
+
+export default card;

--- a/data-asia/SM/SM7/076.ts
+++ b/data-asia/SM/SM7/076.ts
@@ -1,0 +1,60 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "エネコロロ",
+	},
+
+	illustrator: "Sekio",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Colorless"],
+
+	description: {
+		ja: "美しい 毛並みを 持ち 女性トレーナーに 大人気。 決まった 住処を 持たない。",
+	},
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "フレンドサーチ" },
+			effect: {
+				ja: "自分の番に、このカードを手札から出して進化させたとき、1回使える。自分のトラッシュにあるサポートを2枚、相手に見せてから、手札に加える。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ねこキック" },
+			damage: 40,
+			cost: ["Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 559037,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "エネコ",
+	},
+
+	retreat: 1,
+	rarity: "Rare",
+	dexId: [301],
+};
+
+export default card;

--- a/data-asia/SM/SM7/077.ts
+++ b/data-asia/SM/SM7/077.ts
@@ -1,0 +1,48 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "チルット",
+	},
+
+	illustrator: "Shibuzoh.",
+	category: "Pokemon",
+	hp: 50,
+	types: ["Colorless"],
+
+	description: {
+		ja: "真綿の ような 翼の 手入れは 絶対に 欠かさない。 汚れると 水浴びをして きれいに 洗う。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "うたう" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをねむりにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559038,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [333],
+};
+
+export default card;

--- a/data-asia/SM/SM7/078.ts
+++ b/data-asia/SM/SM7/078.ts
@@ -1,0 +1,56 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "カクレオン",
+	},
+
+	illustrator: "OOYAMA",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Colorless"],
+
+	description: {
+		ja: "体の 色を 変えて 景色に 溶けこみ 獲物に 忍び寄る。 お腹の 模様は 消せないのだ。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ユニットカラー２" },
+			effect: {
+				ja: "このポケモンに「ユニットエネルギー雷超鋼」がついているかぎり、このポケモンは[雷][超][鋼]の3つのタイプになる。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "きりさく" },
+			damage: 80,
+			cost: ["Colorless", "Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559039,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Uncommon",
+	dexId: [352],
+};
+
+export default card;

--- a/data-asia/SM/SM7/079.ts
+++ b/data-asia/SM/SM7/079.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ギリギリポーション",
+	},
+
+	illustrator: "Ayaka Yoshida",
+	category: "Trainer",
+
+	effect: {
+		ja: "残りHPが「30」以下の自分のポケモン1匹のHPを「120」回復する。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559040,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM7/080.ts
+++ b/data-asia/SM/SM7/080.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ダートじてんしゃ",
+	},
+
+	illustrator: "Toyste Beach",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の山札を上から2枚見て、どちらか1枚を選び、手札に加える。残りのカードはトラッシュする。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559041,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM7/081.ts
+++ b/data-asia/SM/SM7/081.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ハイパーボール",
+	},
+
+	illustrator: "Ryo Ueda",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードは、自分の手札を2枚トラッシュしなければ使えない。自分の山札からポケモンを1枚選び、相手に見せてから、手札に加える。そして山札を切る。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559042,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM7/082.ts
+++ b/data-asia/SM/SM7/082.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ふしぎなアメ",
+	},
+
+	illustrator: "Toyste Beach",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分のたねポケモン1匹から進化する1進化の上の2進化ポケモンを、手札から1枚選び、そのたねポケモンにのせて進化させる。[最初の自分の番と、この番出したばかりのたねポケモンには使えない。]",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559043,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM7/083.ts
+++ b/data-asia/SM/SM7/083.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ポケモンいれかえ",
+	},
+
+	illustrator: "Ryo Ueda",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分のバトルポケモンをベンチポケモンと入れ替える。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559044,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM7/084.ts
+++ b/data-asia/SM/SM7/084.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ポケモンキャッチャー",
+	},
+
+	illustrator: "Toyste Beach",
+	category: "Trainer",
+
+	effect: {
+		ja: "相手のベンチポケモンを1匹選び、バトルポケモンと入れ替える。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559045,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM7/085.ts
+++ b/data-asia/SM/SM7/085.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "レインボーブラシ",
+	},
+
+	illustrator: "Eske Yoshinob",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の山札にある基本エネルギーを1枚、自分の場のポケモンについているエネルギー1枚とつけ替え、ついていたエネルギーを山札にもどして切る。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559046,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM7/086.ts
+++ b/data-asia/SM/SM7/086.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "こだわりハチマキ",
+	},
+
+	illustrator: "Eske Yoshinob",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードをつけているポケモンが使うワザの、相手のバトル場の「ポケモンGX・EX」へのダメージは「+30」される。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559047,
+			},
+		},
+	],
+
+	trainerType: "Tool",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM7/087.ts
+++ b/data-asia/SM/SM7/087.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ハッスルベルト",
+	},
+
+	illustrator: "Yoshinobu Saito",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードをつけているポケモンの残りHPが「30」以下でダメカンがのっているなら、このカードをつけているポケモンが使うワザの、相手のバトルポケモンへのダメージは「+60」される。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559048,
+			},
+		},
+	],
+
+	trainerType: "Tool",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM7/088.ts
+++ b/data-asia/SM/SM7/088.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ダイゴの決断",
+	},
+
+	illustrator: "Hitoshi Ariga",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードを使ったら、自分の番は終わる。自分の山札にある好きなカードを3枚まで、手札に加える。そして山札を切る。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 559049,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	rarity: "Rare",
+};
+
+export default card;

--- a/data-asia/SM/SM7/089.ts
+++ b/data-asia/SM/SM7/089.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "釣り人",
+	},
+
+	illustrator: "Masakazu Fukuda",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分のトラッシュから基本エネルギーを4枚選び、相手に見せてから、手札に加える。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559050,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM7/090.ts
+++ b/data-asia/SM/SM7/090.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ハウ",
+	},
+
+	illustrator: "TOKIYA",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の山札を3枚引く。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559051,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM7/091.ts
+++ b/data-asia/SM/SM7/091.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "フウとラン",
+	},
+
+	illustrator: "Megumi Mizutani",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードは、2つの効果から1つを選んで使う。◆自分の手札をすべて山札にもどして切る。その後、山札を5枚引く。◆自分のバトルポケモンをベンチポケモンと入れ替える。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559052,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM7/092.ts
+++ b/data-asia/SM/SM7/092.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "リーリエ",
+	},
+
+	illustrator: "Sanosuke Sakuma",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の手札が6枚になるように、山札を引く。最初の自分の番に使ったなら、8枚になるように引く。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559053,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM7/093.ts
+++ b/data-asia/SM/SM7/093.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ルチア",
+	},
+
+	illustrator: "Megumi Mizutani",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の山札にある♢（プリズムスター）のカードを2枚まで、相手に見せてから、手札に加える。そして山札を切る。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559054,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM7/094.ts
+++ b/data-asia/SM/SM7/094.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "戒めの祠",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Trainer",
+
+	effect: {
+		ja: "ポケモンチェックのたび、おたがいの「ポケモンGX・EX」全員に、それぞれダメカンを1個のせる。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559055,
+			},
+		},
+	],
+
+	trainerType: "Stadium",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM7/095.ts
+++ b/data-asia/SM/SM7/095.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "そらのはしら",
+	},
+
+	illustrator: "Ryo Ueda",
+	category: "Trainer",
+
+	effect: {
+		ja: "おたがいのベンチポケモン全員は、相手のワザのダメージや効果を受けない。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559056,
+			},
+		},
+	],
+
+	trainerType: "Stadium",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM7/096.ts
+++ b/data-asia/SM/SM7/096.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ダブル無色エネルギー",
+	},
+
+	illustrator: "",
+	category: "Energy",
+	energyType: "Special",
+
+	effect: {
+		ja: "このカードは、[無]エネルギー2個ぶんとしてはたらく。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 559057,
+			},
+		},
+	],
+
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM7/097.ts
+++ b/data-asia/SM/SM7/097.ts
@@ -1,0 +1,66 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ダーテングGX",
+	},
+
+	illustrator: "PLANETA Igarashi",
+	category: "Pokemon",
+	hp: 240,
+	types: ["Grass"],
+
+	stage: "Stage2",
+
+	attacks: [
+		{
+			name: { ja: "まどわす" },
+			damage: 40,
+			cost: ["Grass"],
+			effect: {
+				ja: "相手のバトルポケモンをこんらんにする。",
+			},
+		},
+		{
+			name: { ja: "じんつうりき" },
+			damage: "90+",
+			cost: ["Grass", "Colorless", "Colorless"],
+			effect: {
+				ja: "自分の手札と相手の手札が同じ枚数なら、90ダメージ追加。",
+			},
+		},
+		{
+			name: { ja: "ふくまでんGX" },
+			cost: ["Grass", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のポケモン1匹と、ついているすべてのカードを、相手の山札にもどして切る。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 559058,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "コノハナ",
+	},
+
+	retreat: 2,
+	rarity: "Ultra Rare",
+	dexId: [275],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM7/098.ts
+++ b/data-asia/SM/SM7/098.ts
@@ -1,0 +1,63 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "バシャーモGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 240,
+	types: ["Fire"],
+
+	stage: "Stage2",
+
+	attacks: [
+		{
+			name: { ja: "きりさく" },
+			damage: 60,
+			cost: ["Colorless", "Colorless"],
+		},
+		{
+			name: { ja: "ばくえんきゃく" },
+			damage: 210,
+			cost: ["Fire", "Fire", "Colorless"],
+			effect: {
+				ja: "このポケモンについている[炎]エネルギーを、2個トラッシュする。",
+			},
+		},
+		{
+			name: { ja: "ブレイズアウトGX" },
+			cost: ["Fire"],
+			effect: {
+				ja: "相手の場のポケモンについているエネルギーを、2個トラッシュする。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 559059,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ワカシャモ",
+	},
+
+	retreat: 1,
+	rarity: "Ultra Rare",
+	dexId: [257],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM7/099.ts
+++ b/data-asia/SM/SM7/099.ts
@@ -1,0 +1,62 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ツンデツンデGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 180,
+	types: ["Metal"],
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ウルトラウォール" },
+			effect: {
+				ja: "このポケモンがいるかぎり、自分の「ウルトラビースト」全員が、相手のポケモンから受けるワザのダメージは「-10」される。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ギガトンスタンプ" },
+			damage: 120,
+			cost: ["Metal", "Metal", "Colorless"],
+		},
+		{
+			name: { ja: "レイGX" },
+			damage: "50+",
+			cost: ["Metal", "Metal", "Colorless"],
+			effect: {
+				ja: "自分がすでにとったサイドの枚数x50ダメージ追加。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 559060,
+			},
+		},
+	],
+
+	retreat: 3,
+	rarity: "Ultra Rare",
+	dexId: [805],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM7/100.ts
+++ b/data-asia/SM/SM7/100.ts
@@ -1,0 +1,66 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "チルタリスGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 200,
+	types: ["Dragon"],
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "ブライトトーン" },
+			damage: 50,
+			cost: ["Fairy", "Colorless"],
+			effect: {
+				ja: "次の相手の番、このポケモンは「ポケモンGX・EX」からワザのダメージを受けない。",
+			},
+		},
+		{
+			name: { ja: "ソニックエッジ" },
+			damage: 110,
+			cost: ["Water", "Fairy", "Colorless"],
+			effect: {
+				ja: "このワザのダメージは、相手のバトルポケモンにかかっている効果を計算しない。",
+			},
+		},
+		{
+			name: { ja: "ユーフォリアGX" },
+			cost: ["Fairy", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをねむりにする。自分のポケモン全員のHPを、すべて回復する。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fairy", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 559061,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "チルット",
+	},
+
+	retreat: 1,
+	rarity: "Ultra Rare",
+	dexId: [334],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM7/101.ts
+++ b/data-asia/SM/SM7/101.ts
@@ -1,0 +1,64 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "レックウザGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 180,
+	types: ["Dragon"],
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "しっぷうどとう" },
+			effect: {
+				ja: "自分の番に、このカードを手札からベンチに出したとき、1回使える。自分の山札を上から3枚トラッシュする。その後、トラッシュにある基本エネルギーを1枚、このポケモンにつける。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ドラゴンブレイク" },
+			damage: "30×",
+			cost: ["Grass", "Lightning", "Colorless"],
+			effect: {
+				ja: "自分の場のポケモンについている[草]と[雷]タイプの基本エネルギーの数x30ダメージ。",
+			},
+		},
+		{
+			name: { ja: "テンペストGX" },
+			cost: ["Grass"],
+			effect: {
+				ja: "自分の手札をすべてトラッシュし、山札を10枚引く。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fairy", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 559062,
+			},
+		},
+	],
+
+	retreat: 3,
+	rarity: "Ultra Rare",
+	dexId: [384],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM7/102.ts
+++ b/data-asia/SM/SM7/102.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ダイゴの決断",
+	},
+
+	illustrator: "Hitoshi Ariga",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードを使ったら、自分の番は終わる。自分の山札にある好きなカードを3枚まで、手札に加える。そして山札を切る。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 559063,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	rarity: "Ultra Rare",
+};
+
+export default card;

--- a/data-asia/SM/SM7/103.ts
+++ b/data-asia/SM/SM7/103.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "フウとラン",
+	},
+
+	illustrator: "Hideki Ishikawa",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードは、2つの効果から1つを選んで使う。◆自分の手札をすべて山札にもどして切る。その後、山札を5枚引く。◆自分のバトルポケモンをベンチポケモンと入れ替える。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 559064,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	rarity: "Ultra Rare",
+};
+
+export default card;

--- a/data-asia/SM/SM7/104.ts
+++ b/data-asia/SM/SM7/104.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ルチア",
+	},
+
+	illustrator: "Naoki Saito",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の山札にある♢（プリズムスター）のカードを2枚まで、相手に見せてから、手札に加える。そして山札を切る。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 559065,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	rarity: "Ultra Rare",
+};
+
+export default card;

--- a/data-asia/SM/SM7/105.ts
+++ b/data-asia/SM/SM7/105.ts
@@ -1,0 +1,66 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ダーテングGX",
+	},
+
+	illustrator: "",
+	category: "Pokemon",
+	hp: 240,
+	types: ["Grass"],
+
+	stage: "Stage2",
+
+	attacks: [
+		{
+			name: { ja: "まどわす" },
+			damage: 40,
+			cost: ["Grass"],
+			effect: {
+				ja: "相手のバトルポケモンをこんらんにする。",
+			},
+		},
+		{
+			name: { ja: "じんつうりき" },
+			damage: "90+",
+			cost: ["Grass", "Colorless", "Colorless"],
+			effect: {
+				ja: "自分の手札と相手の手札が同じ枚数なら、90ダメージ追加。",
+			},
+		},
+		{
+			name: { ja: "ふくまでんGX" },
+			cost: ["Grass", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のポケモン1匹と、ついているすべてのカードを、相手の山札にもどして切る。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 559066,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "コノハナ",
+	},
+
+	retreat: 2,
+	rarity: "Hyper rare",
+	dexId: [275],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM7/106.ts
+++ b/data-asia/SM/SM7/106.ts
@@ -1,0 +1,63 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "バシャーモGX",
+	},
+
+	illustrator: "",
+	category: "Pokemon",
+	hp: 240,
+	types: ["Fire"],
+
+	stage: "Stage2",
+
+	attacks: [
+		{
+			name: { ja: "きりさく" },
+			damage: 60,
+			cost: ["Colorless", "Colorless"],
+		},
+		{
+			name: { ja: "ばくえんきゃく" },
+			damage: 210,
+			cost: ["Fire", "Fire", "Colorless"],
+			effect: {
+				ja: "このポケモンについている[炎]エネルギーを、2個トラッシュする。",
+			},
+		},
+		{
+			name: { ja: "ブレイズアウトGX" },
+			cost: ["Fire"],
+			effect: {
+				ja: "相手の場のポケモンについているエネルギーを、2個トラッシュする。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 559067,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ワカシャモ",
+	},
+
+	retreat: 1,
+	rarity: "Hyper rare",
+	dexId: [257],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM7/107.ts
+++ b/data-asia/SM/SM7/107.ts
@@ -1,0 +1,62 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ツンデツンデGX",
+	},
+
+	illustrator: "",
+	category: "Pokemon",
+	hp: 180,
+	types: ["Metal"],
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ウルトラウォール" },
+			effect: {
+				ja: "このポケモンがいるかぎり、自分の「ウルトラビースト」全員が、相手のポケモンから受けるワザのダメージは「-10」される。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ギガトンスタンプ" },
+			damage: 120,
+			cost: ["Metal", "Metal", "Colorless"],
+		},
+		{
+			name: { ja: "レイGX" },
+			damage: "50+",
+			cost: ["Metal", "Metal", "Colorless"],
+			effect: {
+				ja: "自分がすでにとったサイドの枚数x50ダメージ追加。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 559068,
+			},
+		},
+	],
+
+	retreat: 3,
+	rarity: "Hyper rare",
+	dexId: [805],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM7/108.ts
+++ b/data-asia/SM/SM7/108.ts
@@ -1,0 +1,66 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "チルタリスGX",
+	},
+
+	illustrator: "",
+	category: "Pokemon",
+	hp: 200,
+	types: ["Dragon"],
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "ブライトトーン" },
+			damage: 50,
+			cost: ["Fairy", "Colorless"],
+			effect: {
+				ja: "次の相手の番、このポケモンは「ポケモンGX・EX」からワザのダメージを受けない。",
+			},
+		},
+		{
+			name: { ja: "ソニックエッジ" },
+			damage: 110,
+			cost: ["Water", "Fairy", "Colorless"],
+			effect: {
+				ja: "このワザのダメージは、相手のバトルポケモンにかかっている効果を計算しない。",
+			},
+		},
+		{
+			name: { ja: "ユーフォリアGX" },
+			cost: ["Fairy", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをねむりにする。自分のポケモン全員のHPを、すべて回復する。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fairy", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 559069,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "チルット",
+	},
+
+	retreat: 1,
+	rarity: "Hyper rare",
+	dexId: [334],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM7/109.ts
+++ b/data-asia/SM/SM7/109.ts
@@ -1,0 +1,64 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "レックウザGX",
+	},
+
+	illustrator: "",
+	category: "Pokemon",
+	hp: 180,
+	types: ["Dragon"],
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "しっぷうどとう" },
+			effect: {
+				ja: "自分の番に、このカードを手札からベンチに出したとき、1回使える。自分の山札を上から3枚トラッシュする。その後、トラッシュにある基本エネルギーを1枚、このポケモンにつける。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ドラゴンブレイク" },
+			damage: "30×",
+			cost: ["Grass", "Lightning", "Colorless"],
+			effect: {
+				ja: "自分の場のポケモンについている[草]と[雷]タイプの基本エネルギーの数x30ダメージ。",
+			},
+		},
+		{
+			name: { ja: "テンペストGX" },
+			cost: ["Grass"],
+			effect: {
+				ja: "自分の手札をすべてトラッシュし、山札を10枚引く。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fairy", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 559070,
+			},
+		},
+	],
+
+	retreat: 3,
+	rarity: "Hyper rare",
+	dexId: [384],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM7/110.ts
+++ b/data-asia/SM/SM7/110.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ダートじてんしゃ",
+	},
+
+	illustrator: "",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の山札を上から2枚見て、どちらか1枚を選び、手札に加える。残りのカードはトラッシュする。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 559071,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	rarity: "Secret Rare",
+};
+
+export default card;

--- a/data-asia/SM/SM7/111.ts
+++ b/data-asia/SM/SM7/111.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "レインボーブラシ",
+	},
+
+	illustrator: "",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の山札にある基本エネルギーを1枚、自分の場のポケモンについているエネルギー1枚とつけ替え、ついていたエネルギーを山札にもどして切る。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 559072,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	rarity: "Secret Rare",
+};
+
+export default card;

--- a/data-asia/SM/SM7/112.ts
+++ b/data-asia/SM/SM7/112.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ハッスルベルト",
+	},
+
+	illustrator: "",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードをつけているポケモンの残りHPが「30」以下でダメカンがのっているなら、このカードをつけているポケモンが使うワザの、相手のバトルポケモンへのダメージは「+60」される。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 559073,
+			},
+		},
+	],
+
+	trainerType: "Tool",
+	rarity: "Secret Rare",
+};
+
+export default card;


### PR DESCRIPTION
## What

Adds the complete Japanese set **SM7 裂空のカリスマ (Charisma of the Ripped Sky)**, released 2018-06-01:

- `data-asia/SM/SM7/001.ts` … `112.ts` — all 112 cards (96 regular + 16 secret rares: 8 SR, 5 UR, 3 Secret Rare)
- the set definition `data-asia/SM/SM7.ts` already existed and is untouched

## Data sources

- **pokemon-card.com** (official database): Japanese names, flavor texts, National Dex numbers, official card count
- **limitlesstcg.com**: full Japanese card text, stages, weaknesses/resistances/retreat, rarities, illustrators, attack costs
- **Cardmarket**: product IDs as `thirdParty.cardmarket` on the variant objects (558962–559073; tcgplayer IDs not available to me)

## Notes

- Follows the file format and conventions of the M-era sets (#1728)
- No `regulationMark` (the set predates regulation marks); resistances are `-20` per the era
- All 112 files type-check against `interfaces.d.ts` (`tsc --noEmit`)
