### PR TITLE
(data) Add Japanese SM set SM7a Thunderclap Spark

### DIFF
--- a/data-asia/SM/SM7a/001.ts
+++ b/data-asia/SM/SM7a/001.ts
@@ -1,0 +1,54 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "カイロス",
+	},
+
+	illustrator: "Suwama Chiaki",
+	category: "Pokemon",
+	hp: 110,
+	types: ["Grass"],
+
+	description: {
+		ja: "角の 一撃は 大木 さえ へし折るほど。 アローラでは クワガノンが 最大の ライバル。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "はさんでしめる" },
+			damage: 20,
+			cost: ["Grass"],
+			effect: {
+				ja: "次の相手の番、このワザを受けたポケモンは、にげられない。",
+			},
+		},
+		{
+			name: { ja: "ぶちかます" },
+			damage: 70,
+			cost: ["Colorless", "Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558889,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Common",
+	dexId: [127],
+};
+
+export default card;

--- a/data-asia/SM/SM7a/002.ts
+++ b/data-asia/SM/SM7a/002.ts
@@ -1,0 +1,58 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ツボツボ",
+	},
+
+	illustrator: "Masakazu Fukuda",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Grass"],
+
+	description: {
+		ja: "甲羅に 木の実を たくわえている。 襲われないように 岩の 下に こもって じっとしている。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "なましぼり" },
+			effect: {
+				ja: "自分の番に、このカードを手札からベンチに出したとき、1回使える。自分の山札にある基本エネルギーを3枚まで、トラッシュする。そして山札を切る。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "エナジードリンク" },
+			cost: ["Grass"],
+			effect: {
+				ja: "自分のトラッシュにある基本エネルギーを2枚、自分のポケモンに好きなようにつける。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558890,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Uncommon",
+	dexId: [213],
+};
+
+export default card;

--- a/data-asia/SM/SM7a/003.ts
+++ b/data-asia/SM/SM7a/003.ts
@@ -1,0 +1,46 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ケムッソ",
+	},
+
+	illustrator: "kirisAki",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Grass"],
+
+	description: {
+		ja: "森や 草むらに 生息。 敵に 襲われた ときは お尻の 毒の トゲで 対抗する。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ぶつかる" },
+			damage: 10,
+			cost: ["Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558891,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [265],
+};
+
+export default card;

--- a/data-asia/SM/SM7a/004.ts
+++ b/data-asia/SM/SM7a/004.ts
@@ -1,0 +1,57 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "マユルド",
+	},
+
+	illustrator: "Aya Kusube",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Grass"],
+
+	description: {
+		ja: "マユに こもっている あいだに 受けた 攻撃は 進化しても 忘れずに かならず 仕返しする。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "まゆがあつまる" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札にある「カラサリス」または「マユルド」を合計4枚まで、ベンチに出す。そして山札を切る。",
+			},
+		},
+		{
+			name: { ja: "ぶつかる" },
+			damage: 30,
+			cost: ["Grass", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558892,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ケムッソ",
+	},
+
+	retreat: 2,
+	rarity: "Common",
+	dexId: [268],
+};
+
+export default card;

--- a/data-asia/SM/SM7a/005.ts
+++ b/data-asia/SM/SM7a/005.ts
@@ -1,0 +1,60 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ドクケイル",
+	},
+
+	illustrator: "Midori Harada",
+	category: "Pokemon",
+	hp: 140,
+	types: ["Grass"],
+
+	description: {
+		ja: "襲われると 激しく 羽ばたいて 猛毒の 粉を まき散らす。 日が暮れると 行動を はじめる。",
+	},
+
+	stage: "Stage2",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ハザードしんか" },
+			effect: {
+				ja: "自分の番に、このカードを手札から出して進化させたとき、1回使える。相手のバトルポケモンをどくとマヒにする。このどくでのせるダメカンの数は3個になる。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "かぜおこし" },
+			damage: 70,
+			cost: ["Grass", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558893,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "マユルド",
+	},
+
+	retreat: 2,
+	rarity: "Uncommon",
+	dexId: [269],
+};
+
+export default card;

--- a/data-asia/SM/SM7a/006.ts
+++ b/data-asia/SM/SM7a/006.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ビリジオンGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 170,
+	types: ["Grass"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ダブルドロー" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札を2枚引く。",
+			},
+		},
+		{
+			name: { ja: "センシングブレード" },
+			damage: "50+",
+			cost: ["Grass", "Grass"],
+			effect: {
+				ja: "この番、手札からサポートを出して使っていたなら、80ダメージ追加。",
+			},
+		},
+		{
+			name: { ja: "ブリーズアウェイGX" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の場のポケモンを好きなだけ選び、選んだポケモンと、ついているすべてのカードを、手札にもどす。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 558894,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Double rare",
+	dexId: [640],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM7a/007.ts
+++ b/data-asia/SM/SM7a/007.ts
@@ -1,0 +1,53 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "メェークル",
+	},
+
+	illustrator: "Ken Sugimori",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Grass"],
+
+	description: {
+		ja: "水と 太陽が あれば 背中の 葉っぱで エネルギーが 作れるので エサを 食べなくても 平気なのだ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "もってくる" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札を1枚引く。",
+			},
+		},
+		{
+			name: { ja: "つるのムチ" },
+			damage: 20,
+			cost: ["Grass", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558895,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [672],
+};
+
+export default card;

--- a/data-asia/SM/SM7a/008.ts
+++ b/data-asia/SM/SM7a/008.ts
@@ -1,0 +1,58 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ゴーゴート",
+	},
+
+	illustrator: "sowsow",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Grass"],
+
+	description: {
+		ja: "山岳地帯で 生活する。 ツノを ぶつけ合う 力比べの 勝者が 群れの リーダーだ。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "リーフスラッガー" },
+			damage: 40,
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "次の自分の番、このポケモンの「リーフスラッガー」のダメージは「+50」される。",
+			},
+		},
+		{
+			name: { ja: "ソーラービーム" },
+			damage: 100,
+			cost: ["Grass", "Grass", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558896,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "メェークル",
+	},
+
+	retreat: 2,
+	rarity: "Common",
+	dexId: [673],
+};
+
+export default card;

--- a/data-asia/SM/SM7a/009.ts
+++ b/data-asia/SM/SM7a/009.ts
@@ -1,0 +1,57 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "カプ・ブルル",
+	},
+
+	illustrator: "Satoshi Shirai",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Grass"],
+
+	description: {
+		ja: "ウラウラの 守り神で 物臭。 草木を 操り 敵を 縛りつけ 動きを 止めて 角で 一突き。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ハッスルパンチ" },
+			damage: "20×",
+			cost: ["Grass", "Colorless"],
+			effect: {
+				ja: "相手のベンチポケモンの数x20ダメージ。",
+			},
+		},
+		{
+			name: { ja: "ワイルドタックル" },
+			damage: 120,
+			cost: ["Grass", "Grass", "Colorless"],
+			effect: {
+				ja: "コインを1回投げウラなら、このポケモンにも30ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 558897,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Rare",
+	dexId: [787],
+};
+
+export default card;

--- a/data-asia/SM/SM7a/010.ts
+++ b/data-asia/SM/SM7a/010.ts
@@ -1,0 +1,54 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ファイヤー",
+	},
+
+	illustrator: "Misa Tsutsui",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Fire"],
+
+	description: {
+		ja: "伝説の とりポケモンの １匹。 ファイヤーが 姿を 見せると 春が 訪れると 言われている。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "アシストヒーター" },
+			damage: 30,
+			cost: ["Fire"],
+			effect: {
+				ja: "のぞむなら、自分の手札にある[炎]エネルギーを1枚、ベンチポケモンにつける。",
+			},
+		},
+		{
+			name: { ja: "ほのおのつばさ" },
+			damage: 90,
+			cost: ["Fire", "Fire", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558898,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Uncommon",
+	dexId: [146],
+};
+
+export default card;

--- a/data-asia/SM/SM7a/011.ts
+++ b/data-asia/SM/SM7a/011.ts
@@ -1,0 +1,54 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "マグマッグ",
+	},
+
+	illustrator: "SATOSHI NAKAI",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Fire"],
+
+	description: {
+		ja: "溶岩で できた 体を 持つ。 絶えず 動いていないと 体が 冷えて 固まってしまうのだ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ふむ" },
+			damage: 20,
+			cost: ["Colorless", "Colorless"],
+		},
+		{
+			name: { ja: "かえんほうしゃ" },
+			damage: 60,
+			cost: ["Fire", "Fire", "Colorless"],
+			effect: {
+				ja: "このポケモンについているエネルギーを、1個トラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558899,
+			},
+		},
+	],
+
+	retreat: 3,
+	rarity: "Common",
+	dexId: [218],
+};
+
+export default card;

--- a/data-asia/SM/SM7a/012.ts
+++ b/data-asia/SM/SM7a/012.ts
@@ -1,0 +1,68 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "マグカルゴGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 210,
+	types: ["Fire"],
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "クラッシュチャージ" },
+			effect: {
+				ja: "自分の番に1回使える。自分の山札を上から1枚トラッシュし、そのカードが基本エネルギーなら、自分のポケモンにつける。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ようがんりゅう" },
+			damage: "50+",
+			cost: ["Fire", "Fire", "Colorless"],
+			effect: {
+				ja: "このポケモンについている基本エネルギーを好きなだけトラッシュし、その枚数x50ダメージ追加。",
+			},
+		},
+		{
+			name: { ja: "マッグバンGX" },
+			cost: ["Fire"],
+			effect: {
+				ja: "相手の山札を上から5枚トラッシュする。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 558900,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "マグマッグ",
+	},
+
+	retreat: 3,
+	rarity: "Double rare",
+	dexId: [219],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM7a/013.ts
+++ b/data-asia/SM/SM7a/013.ts
@@ -1,0 +1,57 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヒードラン",
+	},
+
+	illustrator: "Kagemaru Himeno",
+	category: "Pokemon",
+	hp: 140,
+	types: ["Fire"],
+
+	description: {
+		ja: "マグマのように 燃えたぎる 血液が 体を 流れている。 火山の 洞穴に 生息する。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ひのたま" },
+			damage: 60,
+			cost: ["Fire", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のベンチポケモン1匹にも、30ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+			},
+		},
+		{
+			name: { ja: "ヒートバズーカ" },
+			damage: 150,
+			cost: ["Fire", "Fire", "Colorless", "Colorless"],
+			effect: {
+				ja: "自分の山札を上から5枚トラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 558901,
+			},
+		},
+	],
+
+	retreat: 4,
+	rarity: "Rare",
+	dexId: [485],
+};
+
+export default card;

--- a/data-asia/SM/SM7a/014.ts
+++ b/data-asia/SM/SM7a/014.ts
@@ -1,0 +1,49 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ビクティニ",
+	},
+
+	illustrator: "sowsow",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Fire"],
+
+	description: {
+		ja: "ビクティニが 無限に 生み出す エネルギーを 分け与えてもらうと 全身に パワーが あふれ出す。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "Vビート" },
+			damage: "20×",
+			cost: ["Fire", "Colorless"],
+			effect: {
+				ja: "自分の場のたねポケモンの数x20ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558902,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Uncommon",
+	dexId: [494],
+};
+
+export default card;

--- a/data-asia/SM/SM7a/015.ts
+++ b/data-asia/SM/SM7a/015.ts
@@ -1,0 +1,59 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "シシコ",
+	},
+
+	illustrator: "Akira Komayama",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Fire"],
+
+	description: {
+		ja: "強くなるため 群れを 離れて １匹で 生活するようになる。 血気盛んで ケンカっ早い。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ワイルドダッシュ" },
+			effect: {
+				ja: "相手の場に「ポケモンGX・EX」がいるなら、このポケモンのにげるためのエネルギーは、すべてなくなる。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "とっしん" },
+			damage: 30,
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンにも10ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558903,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Common",
+	dexId: [667],
+};
+
+export default card;

--- a/data-asia/SM/SM7a/016.ts
+++ b/data-asia/SM/SM7a/016.ts
@@ -1,0 +1,58 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "カエンジシ",
+	},
+
+	illustrator: "Hasuno",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Fire"],
+
+	description: {
+		ja: "摂氏６０００度の 息を 吐き出し 激しく 相手を 威嚇する。 メスが 群れの 子供を 守る。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "かみくだく" },
+			damage: 30,
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンについているエネルギーを、1個トラッシュする。",
+			},
+		},
+		{
+			name: { ja: "ヒートブラスト" },
+			damage: 90,
+			cost: ["Fire", "Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558904,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "シシコ",
+	},
+
+	retreat: 2,
+	rarity: "Common",
+	dexId: [668],
+};
+
+export default card;

--- a/data-asia/SM/SM7a/017.ts
+++ b/data-asia/SM/SM7a/017.ts
@@ -1,0 +1,59 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ラプラス",
+	},
+
+	illustrator: "Sekio",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Water"],
+
+	description: {
+		ja: "密漁で 絶滅寸前に。 大切に 保護 された 結果 逆に 増え過ぎてきたという。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ゆうえい" },
+			effect: {
+				ja: "自分の番に1回使える。自分の山札を上から2枚見て、好きな順番に入れ替えて、山札の上にもどす。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "れいとうビーム" },
+			damage: 50,
+			cost: ["Water", "Colorless"],
+			effect: {
+				ja: "コインを1回投げオモテなら、相手のバトルポケモンをマヒにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558905,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Uncommon",
+	dexId: [131],
+};
+
+export default card;

--- a/data-asia/SM/SM7a/018.ts
+++ b/data-asia/SM/SM7a/018.ts
@@ -1,0 +1,59 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "スイクン",
+	},
+
+	illustrator: "Anesaki Dynamic",
+	category: "Pokemon",
+	hp: 110,
+	types: ["Water"],
+
+	description: {
+		ja: "一瞬で 汚く 濁った 水も 清める 力を 持つ。 北風の 生まれ変わり という。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "いてつくすいりゅう" },
+			effect: {
+				ja: "このポケモンがバトル場にいるなら、自分の番に1回使える。相手のバトルポケモンをベンチポケモンと入れ替える。［バトル場に出すポケモンは相手が選ぶ。］",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "オーロラゲイン" },
+			damage: 70,
+			cost: ["Water", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンのHPを「30」回復する。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 558906,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Rare",
+	dexId: [245],
+};
+
+export default card;

--- a/data-asia/SM/SM7a/019.ts
+++ b/data-asia/SM/SM7a/019.ts
@@ -1,0 +1,53 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "クマシュン",
+	},
+
+	illustrator: "0313",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Water"],
+
+	description: {
+		ja: "鼻水は 健康の バロメータ。 調子が いいと 粘り強くなり 氷の 技の 威力も 増す。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "あとびえ" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "このワザは、後攻プレイヤーの最初の番にだけ使える。相手のバトルポケモンをマヒにする。",
+			},
+		},
+		{
+			name: { ja: "たたく" },
+			damage: 20,
+			cost: ["Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558907,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Common",
+	dexId: [613],
+};
+
+export default card;

--- a/data-asia/SM/SM7a/020.ts
+++ b/data-asia/SM/SM7a/020.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ツンベアー",
+	},
+
+	illustrator: "Mina Nakai",
+	category: "Pokemon",
+	hp: 140,
+	types: ["Water"],
+
+	description: {
+		ja: "吐く 息を 凍らせて 氷の キバや ツメを 作り 戦う。 北の 寒い 土地で 暮らす。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "かくごのツメ" },
+			damage: "60+",
+			cost: ["Water", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンが「ポケモンGX・EX」なら、60ダメージ追加。",
+			},
+		},
+		{
+			name: { ja: "ブリザードバーン" },
+			damage: 150,
+			cost: ["Water", "Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "次の自分の番、このポケモンはワザが使えない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558908,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "クマシュン",
+	},
+
+	retreat: 3,
+	rarity: "Uncommon",
+	dexId: [614],
+};
+
+export default card;

--- a/data-asia/SM/SM7a/021.ts
+++ b/data-asia/SM/SM7a/021.ts
@@ -1,0 +1,57 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ホワイトキュレム",
+	},
+
+	illustrator: "Hitoshi Ariga",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Water"],
+
+	description: {
+		ja: "強力な 冷凍エネルギーを 体内で 作り出すが 漏れ出した 冷気で 体が 凍っている。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "フィールドクラッシュ" },
+			damage: 30,
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "場に出ている相手のスタジアムをトラッシュする。",
+			},
+		},
+		{
+			name: { ja: "いてつくほのお" },
+			damage: "80+",
+			cost: ["Water", "Water", "Colorless"],
+			effect: {
+				ja: "このポケモンに[炎]エネルギーがついているなら、80ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 558909,
+			},
+		},
+	],
+
+	retreat: 3,
+	rarity: "Rare",
+	dexId: [646],
+};
+
+export default card;

--- a/data-asia/SM/SM7a/022.ts
+++ b/data-asia/SM/SM7a/022.ts
@@ -1,0 +1,49 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アシマリ",
+	},
+
+	illustrator: "Yusuke Ohmura",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Water"],
+
+	description: {
+		ja: "水の バルーンを 操る。 大きな バルーンを 作るため コツコツ 練習を 繰り返す。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ちょっとすいとる" },
+			damage: 10,
+			cost: ["Water"],
+			effect: {
+				ja: "このポケモンのHPを「10」回復する。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558910,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [728],
+};
+
+export default card;

--- a/data-asia/SM/SM7a/023.ts
+++ b/data-asia/SM/SM7a/023.ts
@@ -1,0 +1,57 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "オシャマリ",
+	},
+
+	illustrator: "Atsuko Nishida",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Water"],
+
+	description: {
+		ja: "仲間を 思う 気持ちが 強い。 トレーナーが 落ち込んでいると ダンスを 踊って 励まそうとする。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "ゆうわく" },
+			cost: ["Water"],
+			effect: {
+				ja: "相手のベンチポケモンを1匹選び、バトルポケモンと入れ替える。",
+			},
+		},
+		{
+			name: { ja: "みずでっぽう" },
+			damage: 20,
+			cost: ["Water"],
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558911,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "アシマリ",
+	},
+
+	retreat: 2,
+	rarity: "Common",
+	dexId: [729],
+};
+
+export default card;

--- a/data-asia/SM/SM7a/024.ts
+++ b/data-asia/SM/SM7a/024.ts
@@ -1,0 +1,63 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アシレーヌ",
+	},
+
+	illustrator: "Shin Nagasawa",
+	category: "Pokemon",
+	hp: 150,
+	types: ["Water"],
+
+	description: {
+		ja: "歌声を 活かし 戦う。 毎日の のどの メンテナンスは トレーナーの 大切な 役目。",
+	},
+
+	stage: "Stage2",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ハーモニクス" },
+			effect: {
+				ja: "このポケモンがいるかぎり、手札から自分のポケモンにエネルギーをつけるとき、同時に2枚までつけられる。（ワザ・「ハーモニクス」以外の特性・トレーナーズでつける場合はのぞく。）",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ヒプノスプラッシュ" },
+			damage: 80,
+			cost: ["Water", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをねむりにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558912,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "オシャマリ",
+	},
+
+	retreat: 2,
+	rarity: "Uncommon",
+	dexId: [730],
+};
+
+export default card;

--- a/data-asia/SM/SM7a/025.ts
+++ b/data-asia/SM/SM7a/025.ts
@@ -1,0 +1,56 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ハギギシリ",
+	},
+
+	illustrator: "tetsuya koizumi",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Water"],
+
+	description: {
+		ja: "念力で 獲物を しびれさせ 丈夫な 歯で 噛み砕く。 シェルダーの 殻でも よゆうだ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "サイコトリップ" },
+			damage: 20,
+			cost: ["Water"],
+			effect: {
+				ja: "相手のバトルポケモンをこんらんにする。",
+			},
+		},
+		{
+			name: { ja: "きずをたどる" },
+			cost: ["Water", "Colorless"],
+			effect: {
+				ja: "ダメカンがのっている相手のベンチポケモン1匹に、60ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558913,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [779],
+};
+
+export default card;

--- a/data-asia/SM/SM7a/026.ts
+++ b/data-asia/SM/SM7a/026.ts
@@ -1,0 +1,49 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "エレブー",
+	},
+
+	illustrator: "Naoyo Kimura",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Lightning"],
+
+	description: {
+		ja: "餌で 喰う 電気量 よりも 身体から 漏れる 電気量の ほうが 圧倒的に 多い。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "でんきショック" },
+			damage: 30,
+			cost: ["Lightning", "Colorless"],
+			effect: {
+				ja: "コインを1回投げオモテなら、相手のバトルポケモンをマヒにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Metal", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558914,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Common",
+	dexId: [125],
+};
+
+export default card;

--- a/data-asia/SM/SM7a/027.ts
+++ b/data-asia/SM/SM7a/027.ts
@@ -1,0 +1,60 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "エレキブル",
+	},
+
+	illustrator: "Akira Komayama",
+	category: "Pokemon",
+	hp: 140,
+	types: ["Lightning"],
+
+	description: {
+		ja: "興奮すると 胸を 打ち鳴らす。 そのたびに 電気火花が 散り 雷鳴が あたりに 響き渡る。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "エレキチャージ" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札にある[雷]エネルギーを2枚まで、このポケモンにつける。そして山札を切る。",
+			},
+		},
+		{
+			name: { ja: "こうでんあつナックル" },
+			damage: 190,
+			cost: ["Lightning", "Lightning", "Lightning", "Colorless"],
+			effect: {
+				ja: "このポケモンについているエネルギーを、3個トラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Metal", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558915,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "エレブー",
+	},
+
+	retreat: 4,
+	rarity: "Uncommon",
+	dexId: [466],
+};
+
+export default card;

--- a/data-asia/SM/SM7a/028.ts
+++ b/data-asia/SM/SM7a/028.ts
@@ -1,0 +1,49 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "パチリス",
+	},
+
+	illustrator: "Yuka Morii",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Lightning"],
+
+	description: {
+		ja: "たまった 電気を 分け与えようと ほほ袋を こすり合わせる パチリスを 見かけることも ある。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "オーバーショート" },
+			damage: "20+",
+			cost: ["Lightning"],
+			effect: {
+				ja: "ダメージを与える前に、相手のバトルポケモンについている「ポケモンのどうぐ」をトラッシュする。トラッシュした場合、40ダメージ追加し、相手のバトルポケモンをマヒにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Metal", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558916,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [417],
+};
+
+export default card;

--- a/data-asia/SM/SM7a/029.ts
+++ b/data-asia/SM/SM7a/029.ts
@@ -1,0 +1,51 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "シママ",
+	},
+
+	illustrator: "Miki Tanaka",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Lightning"],
+
+	description: {
+		ja: "放電すると たてがみが 光る。 たてがみが 輝く 回数や リズムで 仲間と 会話している。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "はねまわる" },
+			damage: 10,
+			cost: ["Lightning"],
+		},
+		{
+			name: { ja: "エレキック" },
+			damage: 20,
+			cost: ["Lightning", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Metal", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558917,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [522],
+};
+
+export default card;

--- a/data-asia/SM/SM7a/030.ts
+++ b/data-asia/SM/SM7a/030.ts
@@ -1,0 +1,60 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ゼブライカ",
+	},
+
+	illustrator: "Misa Tsutsui",
+	category: "Pokemon",
+	hp: 110,
+	types: ["Lightning"],
+
+	description: {
+		ja: "稲妻のような 瞬発力。 ゼブライカが 全速力で 走ると 雷鳴が 響きわたる。",
+	},
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "はやがけ" },
+			effect: {
+				ja: "自分の番に1回使える。自分の手札をすべてトラッシュし、山札を4枚引く。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ヘッドボルト" },
+			damage: 60,
+			cost: ["Lightning", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Metal", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558918,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "シママ",
+	},
+
+	retreat: 1,
+	rarity: "Uncommon",
+	dexId: [523],
+};
+
+export default card;

--- a/data-asia/SM/SM7a/031.ts
+++ b/data-asia/SM/SM7a/031.ts
@@ -1,0 +1,57 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "マッギョ",
+	},
+
+	illustrator: "Ken Sugimori",
+	category: "Pokemon",
+	hp: 110,
+	types: ["Lightning"],
+
+	description: {
+		ja: "海辺の 泥に 埋まって 獲物を 待ち構える。 獲物が 触ったとき 電気を 出して しびれさせるのだ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "じたばた" },
+			damage: "10×",
+			cost: ["Colorless"],
+			effect: {
+				ja: "このポケモンにのっているダメカンの数x10ダメージ。",
+			},
+		},
+		{
+			name: { ja: "サンダーブラスト" },
+			damage: 50,
+			cost: ["Lightning"],
+			effect: {
+				ja: "このポケモンについている[雷]エネルギーを、1個トラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Metal", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558919,
+			},
+		},
+	],
+
+	retreat: 3,
+	rarity: "Common",
+	dexId: [618],
+};
+
+export default card;

--- a/data-asia/SM/SM7a/032.ts
+++ b/data-asia/SM/SM7a/032.ts
@@ -1,0 +1,57 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "カプ・コケコ",
+	},
+
+	illustrator: "kawayoo",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Lightning"],
+
+	description: {
+		ja: "目にも 止まらぬ スピードで 敵を かく乱する。 ひどく 怒りっぽいが なんで 怒ったかは すぐ 忘れる。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ひるがえす" },
+			damage: 30,
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "のぞむなら、このポケモンをベンチポケモンと入れ替える。",
+			},
+		},
+		{
+			name: { ja: "フラッシュボルト" },
+			damage: 120,
+			cost: ["Lightning", "Lightning", "Colorless"],
+			effect: {
+				ja: "次の自分の番、このポケモンは「フラッシュボルト」が使えない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Metal", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 558920,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Rare",
+	dexId: [785],
+};
+
+export default card;

--- a/data-asia/SM/SM7a/033.ts
+++ b/data-asia/SM/SM7a/033.ts
@@ -1,0 +1,64 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ゼラオラGX",
+	},
+
+	illustrator: "PLANETA Otani",
+	category: "Pokemon",
+	hp: 190,
+	types: ["Lightning"],
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "じんらいゾーン" },
+			effect: {
+				ja: "このポケモンがいるかぎり、[雷]エネルギーがついている自分のポケモン全員のにげるためのエネルギーは、すべてなくなる。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "プラズマフィスト" },
+			damage: 160,
+			cost: ["Lightning", "Lightning", "Colorless"],
+			effect: {
+				ja: "次の自分の番、このポケモンはワザが使えない。",
+			},
+		},
+		{
+			name: { ja: "フルボルテージGX" },
+			cost: ["Lightning"],
+			effect: {
+				ja: "自分のトラッシュにある基本エネルギーを5枚、自分のポケモンに好きなようにつける。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Metal", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 558921,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Double rare",
+	dexId: [807],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM7a/034.ts
+++ b/data-asia/SM/SM7a/034.ts
@@ -1,0 +1,46 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "イワーク",
+	},
+
+	illustrator: "Tomokazu Komiya",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Fighting"],
+
+	description: {
+		ja: "普段は 土の中に 住んでいる。 地中を 時速８０キロで 掘りながら エサを 探す。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ランドクラッシュ" },
+			damage: 120,
+			cost: ["Colorless", "Colorless", "Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558922,
+			},
+		},
+	],
+
+	retreat: 4,
+	rarity: "Common",
+	dexId: [95],
+};
+
+export default card;

--- a/data-asia/SM/SM7a/035.ts
+++ b/data-asia/SM/SM7a/035.ts
@@ -1,0 +1,48 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アローラディグダ",
+	},
+
+	illustrator: "Midori Harada",
+	category: "Pokemon",
+	hp: 50,
+	types: ["Metal"],
+
+	description: {
+		ja: "金色の 髭は センサー機能を 持っている。 穴から だして 周りの 様子を うかがっている。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "なかまをよぶ" },
+			cost: [],
+			effect: {
+				ja: "自分の山札にあるたねポケモンを1枚、ベンチに出す。そして山札を切る。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558923,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [50],
+};
+
+export default card;

--- a/data-asia/SM/SM7a/036.ts
+++ b/data-asia/SM/SM7a/036.ts
@@ -1,0 +1,53 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アローラダグトリオ",
+	},
+
+	illustrator: "Yuka Morii",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Metal"],
+
+	description: {
+		ja: "大地の 女神たちの 化身と 考えられ アローラ地方では とても 大切に されている。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "モグラッシュ" },
+			damage: 60,
+			cost: [],
+			effect: {
+				ja: "このワザのダメージは弱点・抵抗力を計算しない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558924,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "アローラディグダ",
+	},
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [51],
+};
+
+export default card;

--- a/data-asia/SM/SM7a/037.ts
+++ b/data-asia/SM/SM7a/037.ts
@@ -1,0 +1,58 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ハガネール",
+	},
+
+	illustrator: "Shin Nagasawa",
+	category: "Pokemon",
+	hp: 180,
+	types: ["Metal"],
+
+	description: {
+		ja: "丈夫な アゴで 岩石を かみくだき 進む。 真っ暗な 地中でも 見える 目を 持つ。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "ぶちかます" },
+			damage: 90,
+			cost: ["Metal", "Colorless", "Colorless"],
+		},
+		{
+			name: { ja: "アイアンタックル" },
+			damage: 170,
+			cost: ["Metal", "Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンにも50ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558925,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "イワーク",
+	},
+
+	retreat: 4,
+	rarity: "Uncommon",
+	dexId: [208],
+};
+
+export default card;

--- a/data-asia/SM/SM7a/038.ts
+++ b/data-asia/SM/SM7a/038.ts
@@ -1,0 +1,57 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ディアルガ",
+	},
+
+	illustrator: "nagimiso",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Metal"],
+
+	description: {
+		ja: "時間を 操る 力を 持つ。 シンオウ地方では 神様と 呼ばれ 神話に 登場する。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ときをけずる" },
+			damage: 60,
+			cost: ["Metal", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手の進化しているバトルポケモンから、「進化カード」を1枚はがして退化させる。はがしたカードは、相手の手札にもどす。",
+			},
+		},
+		{
+			name: { ja: "パワーブラスト" },
+			damage: 130,
+			cost: ["Metal", "Metal", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンについているエネルギーを、1個トラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 558926,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Rare",
+	dexId: [483],
+};
+
+export default card;

--- a/data-asia/SM/SM7a/039.ts
+++ b/data-asia/SM/SM7a/039.ts
@@ -1,0 +1,56 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アイアント",
+	},
+
+	illustrator: "Ken Sugimori",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Metal"],
+
+	description: {
+		ja: "鋼の よろいを 身にまとう。 天敵の クイタランの 攻撃を 集団で 防ぎ 反撃する。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "つきくずす" },
+			damage: 20,
+			cost: ["Colorless"],
+			effect: {
+				ja: "のぞむなら、場に出ているスタジアムをトラッシュする。",
+			},
+		},
+		{
+			name: { ja: "やまかじり" },
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "相手の山札を上から2枚トラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558927,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [632],
+};
+
+export default card;

--- a/data-asia/SM/SM7a/040.ts
+++ b/data-asia/SM/SM7a/040.ts
@@ -1,0 +1,57 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "コバルオン",
+	},
+
+	illustrator: "Kouki Saitou",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Metal"],
+
+	description: {
+		ja: "鋼の 心と 体を 持つ。 人が ポケモンを 傷つけたとき 仲間とともに 人を こらしめた。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ガードプレス" },
+			damage: 30,
+			cost: ["Metal", "Colorless"],
+			effect: {
+				ja: "次の相手の番、このポケモンが受けるワザのダメージは「-30」される。",
+			},
+		},
+		{
+			name: { ja: "メタルアームズ" },
+			damage: "80+",
+			cost: ["Metal", "Metal", "Colorless"],
+			effect: {
+				ja: "このポケモンに「ポケモンのどうぐ」がついているなら、40ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 558928,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Rare",
+	dexId: [638],
+};
+
+export default card;

--- a/data-asia/SM/SM7a/041.ts
+++ b/data-asia/SM/SM7a/041.ts
@@ -1,0 +1,62 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ゲノセクトGX",
+	},
+
+	illustrator: "Yoshinobu Saito",
+	category: "Pokemon",
+	hp: 180,
+	types: ["Metal"],
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ダブルカセット" },
+			effect: {
+				ja: "このポケモンは、「ポケモンのどうぐ」を2枚までつけられる。（この特性がなくなったとき、自分は「ポケモンのどうぐ」を1枚になるようにトラッシュする。）",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "さくれつだん" },
+			damage: 130,
+			cost: ["Metal", "Metal", "Colorless"],
+		},
+		{
+			name: { ja: "ブレイクバスターGX" },
+			damage: 190,
+			cost: ["Metal", "Metal", "Colorless"],
+			effect: {
+				ja: "このワザのダメージは抵抗力を計算しない。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 558929,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Double rare",
+	dexId: [649],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM7a/042.ts
+++ b/data-asia/SM/SM7a/042.ts
@@ -1,0 +1,56 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "マギアナ",
+	},
+
+	illustrator: "Masakazu Fukuda",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Metal"],
+
+	description: {
+		ja: "機械仕掛けの 身体は ただの 器。 ソウルハートと 呼ばれる 人造の 魂が 本体。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ちいさなおつかい" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札にある基本エネルギーを2枚まで、相手に見せてから、手札に加える。そして山札を切る。",
+			},
+		},
+		{
+			name: { ja: "エナジープレス" },
+			damage: "30+",
+			cost: ["Metal", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンについているエネルギーの数x20ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558930,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [801],
+};
+
+export default card;

--- a/data-asia/SM/SM7a/043.ts
+++ b/data-asia/SM/SM7a/043.ts
@@ -1,0 +1,48 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "メタモン",
+	},
+
+	illustrator: "kirisAki",
+	category: "Pokemon",
+	hp: 40,
+	types: ["Colorless"],
+
+	description: {
+		ja: "驚きの 変身能力で どんな者とも 仲間に なれる。 メタモン同士は 仲が 悪い。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "なんでもしんか" },
+			effect: {
+				ja: "このポケモンは、自分の番に、1進化ポケモンを手札から出して、このポケモンに重ねて進化できる。（最初の自分の番と、このポケモンを場に出した番はのぞく。）",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 558931,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Rare Holo",
+	dexId: [132],
+};
+
+export default card;

--- a/data-asia/SM/SM7a/044.ts
+++ b/data-asia/SM/SM7a/044.ts
@@ -1,0 +1,59 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "カクレオン",
+	},
+
+	illustrator: "OOYAMA",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Colorless"],
+
+	description: {
+		ja: "体の 色を 変えて 景色に 溶けこみ 獲物に 忍び寄る。 お腹の 模様は 消せないのだ。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ユニットカラー1" },
+			effect: {
+				ja: "このポケモンに「ユニットエネルギー草炎水」がついているかぎり、このポケモンは[草][炎][水]の3つのタイプになる。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ベロビンタ" },
+			damage: "10+",
+			cost: ["Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンが進化ポケモンなら、50ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558932,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [352],
+};
+
+export default card;

--- a/data-asia/SM/SM7a/045.ts
+++ b/data-asia/SM/SM7a/045.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "エネルギーつけかえ",
+	},
+
+	illustrator: "Ryo Ueda",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分のポケモンについている基本エネルギーを1個、自分の別のポケモンにつけ替える。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558933,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM7a/046.ts
+++ b/data-asia/SM/SM7a/046.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "エレキパワー",
+	},
+
+	illustrator: "Eske Yoshinob",
+	category: "Trainer",
+
+	effect: {
+		ja: "この番、自分の[雷]ポケモンが使うワザの、相手のバトルポケモンへのダメージは「+30」される。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558934,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM7a/047.ts
+++ b/data-asia/SM/SM7a/047.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "カスタムキャッチャー",
+	},
+
+	illustrator: "Toyste Beach",
+	category: "Trainer",
+
+	effect: {
+		ja: "「カスタムキャッチャー」は、1枚または2枚同時に使え、使った枚数によって効果が変わる。◆1枚使ったなら、自分の手札が3枚になるように、山札を引く。◆2枚同時に使ったなら、相手のベンチポケモンを1匹選び、バトルポケモンと入れ替える。（この効果は、2枚で1回はたらく。）",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558935,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	rarity: "Common",
+};
+
+export default card;

--- a/data-asia/SM/SM7a/048.ts
+++ b/data-asia/SM/SM7a/048.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "スーパーポケモン回収",
+	},
+
+	illustrator: "Toyste Beach",
+	category: "Trainer",
+
+	effect: {
+		ja: "コインを1回投げオモテなら、自分のポケモン1匹と、ついているすべてのカードを、手札にもどす。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558936,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM7a/049.ts
+++ b/data-asia/SM/SM7a/049.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ハイパーボール",
+	},
+
+	illustrator: "Ryo Ueda",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードは、自分の手札を2枚トラッシュしなければ使えない。自分の山札からポケモンを1枚選び、相手に見せてから、手札に加える。そして山札を切る。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558937,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM7a/050.ts
+++ b/data-asia/SM/SM7a/050.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ポケモンいれかえ",
+	},
+
+	illustrator: "Ryo Ueda",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分のバトルポケモンをベンチポケモンと入れ替える。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558938,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM7a/051.ts
+++ b/data-asia/SM/SM7a/051.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ポケモンキャッチャー",
+	},
+
+	illustrator: "Toyste Beach",
+	category: "Trainer",
+
+	effect: {
+		ja: "相手のベンチポケモンを1匹選び、バトルポケモンと入れ替える。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558939,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM7a/052.ts
+++ b/data-asia/SM/SM7a/052.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ミックスハーブ",
+	},
+
+	illustrator: "Toyste Beach",
+	category: "Trainer",
+
+	effect: {
+		ja: "「ミックスハーブ」は、1枚または2枚同時に使え、使った枚数によって効果が変わる。◆1枚使ったなら、自分のバトルポケモンの特殊状態を1つ回復する。◆2枚同時に使ったなら、自分のバトルポケモンのHPを「90」回復し、特殊状態もすべて回復する。（この効果は、2枚で1回はたらく。）",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558940,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	rarity: "Common",
+};
+
+export default card;

--- a/data-asia/SM/SM7a/053.ts
+++ b/data-asia/SM/SM7a/053.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "カウンターゲイン",
+	},
+
+	illustrator: "Toyste Beach",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分のサイドの残り枚数が、相手より多いなら、このカードをつけているポケモンが使うワザに必要なエネルギーは、エネルギー1個ぶん少なくなる。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558941,
+			},
+		},
+	],
+
+	trainerType: "Tool",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM7a/054.ts
+++ b/data-asia/SM/SM7a/054.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "こだわりハチマキ",
+	},
+
+	illustrator: "Eske Yoshinob",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードをつけているポケモンが使うワザの、相手のバトル場の「ポケモンGX・EX」へのダメージは「+30」される。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558942,
+			},
+		},
+	],
+
+	trainerType: "Tool",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM7a/055.ts
+++ b/data-asia/SM/SM7a/055.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "カヒリ",
+	},
+
+	illustrator: "Ken Sugimori",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の山札を2枚引く。その後、コインを1回投げオモテなら、この「カヒリ」はトラッシュせずに、手札にもどす。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558943,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	rarity: "Common",
+};
+
+export default card;

--- a/data-asia/SM/SM7a/056.ts
+++ b/data-asia/SM/SM7a/056.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "かんこうきゃく",
+	},
+
+	illustrator: "Naoki Saito",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の手札が5枚になるように、山札を引く。のぞむなら、山札を引く前に、自分の手札を好きなだけトラッシュする。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558944,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	rarity: "Common",
+};
+
+export default card;

--- a/data-asia/SM/SM7a/057.ts
+++ b/data-asia/SM/SM7a/057.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ジャッジマン",
+	},
+
+	illustrator: "Sanosuke Sakuma",
+	category: "Trainer",
+
+	effect: {
+		ja: "おたがいのプレイヤーは、それぞれ、手札をすべて山札にもどし、山札を切る。その後、それぞれの山札を4枚引く。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558945,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM7a/058.ts
+++ b/data-asia/SM/SM7a/058.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "サンダーマウンテン",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Trainer",
+
+	effect: {
+		ja: "おたがいの場の[雷]ポケモンが使うワザに必要なエネルギーは、それぞれ[雷]エネルギー1個ぶん少なくなる。このスタジアムは、場に出ているかぎり、おたがいのプレイヤーが手札からグッズまたはサポートを出して使ったとき、その効果を受けない。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 558946,
+			},
+		},
+	],
+
+	trainerType: "Stadium",
+	rarity: "Rare Holo",
+};
+
+export default card;

--- a/data-asia/SM/SM7a/059.ts
+++ b/data-asia/SM/SM7a/059.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ダブル無色エネルギー",
+	},
+
+	illustrator: "",
+	category: "Energy",
+	energyType: "Special",
+
+	effect: {
+		ja: "このカードは、[無]エネルギー2個ぶんとしてはたらく。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558947,
+			},
+		},
+	],
+
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM7a/060.ts
+++ b/data-asia/SM/SM7a/060.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ユニットエネルギー草炎水",
+	},
+
+	illustrator: "",
+	category: "Energy",
+	energyType: "Special",
+
+	effect: {
+		ja: "このカードは、ポケモンについているかぎり、[草][炎][水]の3つのタイプのエネルギー1個ぶんとしてはたらく。ポケモンについていないなら、[無]エネルギー1個ぶんとしてはたらく。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558948,
+			},
+		},
+	],
+
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM7a/061.ts
+++ b/data-asia/SM/SM7a/061.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ビリジオンGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 170,
+	types: ["Grass"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ダブルドロー" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札を2枚引く。",
+			},
+		},
+		{
+			name: { ja: "センシングブレード" },
+			damage: "50+",
+			cost: ["Grass", "Grass"],
+			effect: {
+				ja: "この番、手札からサポートを出して使っていたなら、80ダメージ追加。",
+			},
+		},
+		{
+			name: { ja: "ブリーズアウェイGX" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の場のポケモンを好きなだけ選び、選んだポケモンと、ついているすべてのカードを、手札にもどす。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 558949,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Ultra Rare",
+	dexId: [640],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM7a/062.ts
+++ b/data-asia/SM/SM7a/062.ts
@@ -1,0 +1,68 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "マグカルゴGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 210,
+	types: ["Fire"],
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "クラッシュチャージ" },
+			effect: {
+				ja: "自分の番に1回使える。自分の山札を上から1枚トラッシュし、そのカードが基本エネルギーなら、自分のポケモンにつける。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ようがんりゅう" },
+			damage: "50+",
+			cost: ["Fire", "Fire", "Colorless"],
+			effect: {
+				ja: "このポケモンについている基本エネルギーを好きなだけトラッシュし、その枚数x50ダメージ追加。",
+			},
+		},
+		{
+			name: { ja: "マッグバンGX" },
+			cost: ["Fire"],
+			effect: {
+				ja: "相手の山札を上から5枚トラッシュする。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 558950,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "マグマッグ",
+	},
+
+	retreat: 3,
+	rarity: "Ultra Rare",
+	dexId: [219],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM7a/063.ts
+++ b/data-asia/SM/SM7a/063.ts
@@ -1,0 +1,64 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ゼラオラGX",
+	},
+
+	illustrator: "PLANETA Otani",
+	category: "Pokemon",
+	hp: 190,
+	types: ["Lightning"],
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "じんらいゾーン" },
+			effect: {
+				ja: "このポケモンがいるかぎり、[雷]エネルギーがついている自分のポケモン全員のにげるためのエネルギーは、すべてなくなる。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "プラズマフィスト" },
+			damage: 160,
+			cost: ["Lightning", "Lightning", "Colorless"],
+			effect: {
+				ja: "次の自分の番、このポケモンはワザが使えない。",
+			},
+		},
+		{
+			name: { ja: "フルボルテージGX" },
+			cost: ["Lightning"],
+			effect: {
+				ja: "自分のトラッシュにある基本エネルギーを5枚、自分のポケモンに好きなようにつける。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Metal", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 558951,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Ultra Rare",
+	dexId: [807],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM7a/064.ts
+++ b/data-asia/SM/SM7a/064.ts
@@ -1,0 +1,62 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ゲノセクトGX",
+	},
+
+	illustrator: "Yoshinobu Saito",
+	category: "Pokemon",
+	hp: 180,
+	types: ["Metal"],
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ダブルカセット" },
+			effect: {
+				ja: "このポケモンは、「ポケモンのどうぐ」を2枚までつけられる。（この特性がなくなったとき、自分は「ポケモンのどうぐ」を1枚になるようにトラッシュする。）",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "さくれつだん" },
+			damage: 130,
+			cost: ["Metal", "Metal", "Colorless"],
+		},
+		{
+			name: { ja: "ブレイクバスターGX" },
+			damage: 190,
+			cost: ["Metal", "Metal", "Colorless"],
+			effect: {
+				ja: "このワザのダメージは抵抗力を計算しない。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 558952,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Ultra Rare",
+	dexId: [649],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM7a/065.ts
+++ b/data-asia/SM/SM7a/065.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "カヒリ",
+	},
+
+	illustrator: "Megumi Mizutani",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の山札を2枚引く。その後、コインを1回投げオモテなら、この「カヒリ」はトラッシュせずに、手札にもどす。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 558953,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	rarity: "Ultra Rare",
+};
+
+export default card;

--- a/data-asia/SM/SM7a/066.ts
+++ b/data-asia/SM/SM7a/066.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ジャッジマン",
+	},
+
+	illustrator: "Sanosuke Sakuma",
+	category: "Trainer",
+
+	effect: {
+		ja: "おたがいのプレイヤーは、それぞれ、手札をすべて山札にもどし、山札を切る。その後、それぞれの山札を4枚引く。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 558954,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	rarity: "Ultra Rare",
+};
+
+export default card;

--- a/data-asia/SM/SM7a/067.ts
+++ b/data-asia/SM/SM7a/067.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ビリジオンGX",
+	},
+
+	illustrator: "",
+	category: "Pokemon",
+	hp: 170,
+	types: ["Grass"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ダブルドロー" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札を2枚引く。",
+			},
+		},
+		{
+			name: { ja: "センシングブレード" },
+			damage: "50+",
+			cost: ["Grass", "Grass"],
+			effect: {
+				ja: "この番、手札からサポートを出して使っていたなら、80ダメージ追加。",
+			},
+		},
+		{
+			name: { ja: "ブリーズアウェイGX" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の場のポケモンを好きなだけ選び、選んだポケモンと、ついているすべてのカードを、手札にもどす。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 558955,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Hyper rare",
+	dexId: [640],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM7a/068.ts
+++ b/data-asia/SM/SM7a/068.ts
@@ -1,0 +1,68 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "マグカルゴGX",
+	},
+
+	illustrator: "",
+	category: "Pokemon",
+	hp: 210,
+	types: ["Fire"],
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "クラッシュチャージ" },
+			effect: {
+				ja: "自分の番に1回使える。自分の山札を上から1枚トラッシュし、そのカードが基本エネルギーなら、自分のポケモンにつける。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ようがんりゅう" },
+			damage: "50+",
+			cost: ["Fire", "Fire", "Colorless"],
+			effect: {
+				ja: "このポケモンについている基本エネルギーを好きなだけトラッシュし、その枚数x50ダメージ追加。",
+			},
+		},
+		{
+			name: { ja: "マッグバンGX" },
+			cost: ["Fire"],
+			effect: {
+				ja: "相手の山札を上から5枚トラッシュする。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 558956,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "マグマッグ",
+	},
+
+	retreat: 3,
+	rarity: "Hyper rare",
+	dexId: [219],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM7a/069.ts
+++ b/data-asia/SM/SM7a/069.ts
@@ -1,0 +1,64 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ゼラオラGX",
+	},
+
+	illustrator: "",
+	category: "Pokemon",
+	hp: 190,
+	types: ["Lightning"],
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "じんらいゾーン" },
+			effect: {
+				ja: "このポケモンがいるかぎり、[雷]エネルギーがついている自分のポケモン全員のにげるためのエネルギーは、すべてなくなる。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "プラズマフィスト" },
+			damage: 160,
+			cost: ["Lightning", "Lightning", "Colorless"],
+			effect: {
+				ja: "次の自分の番、このポケモンはワザが使えない。",
+			},
+		},
+		{
+			name: { ja: "フルボルテージGX" },
+			cost: ["Lightning"],
+			effect: {
+				ja: "自分のトラッシュにある基本エネルギーを5枚、自分のポケモンに好きなようにつける。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Metal", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 558957,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Hyper rare",
+	dexId: [807],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM7a/070.ts
+++ b/data-asia/SM/SM7a/070.ts
@@ -1,0 +1,62 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ゲノセクトGX",
+	},
+
+	illustrator: "",
+	category: "Pokemon",
+	hp: 180,
+	types: ["Metal"],
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ダブルカセット" },
+			effect: {
+				ja: "このポケモンは、「ポケモンのどうぐ」を2枚までつけられる。（この特性がなくなったとき、自分は「ポケモンのどうぐ」を1枚になるようにトラッシュする。）",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "さくれつだん" },
+			damage: 130,
+			cost: ["Metal", "Metal", "Colorless"],
+		},
+		{
+			name: { ja: "ブレイクバスターGX" },
+			damage: 190,
+			cost: ["Metal", "Metal", "Colorless"],
+			effect: {
+				ja: "このワザのダメージは抵抗力を計算しない。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 558958,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Hyper rare",
+	dexId: [649],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM7a/071.ts
+++ b/data-asia/SM/SM7a/071.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "エレキパワー",
+	},
+
+	illustrator: "",
+	category: "Trainer",
+
+	effect: {
+		ja: "この番、自分の[雷]ポケモンが使うワザの、相手のバトルポケモンへのダメージは「+30」される。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 558959,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	rarity: "Secret Rare",
+};
+
+export default card;

--- a/data-asia/SM/SM7a/072.ts
+++ b/data-asia/SM/SM7a/072.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "カスタムキャッチャー",
+	},
+
+	illustrator: "",
+	category: "Trainer",
+
+	effect: {
+		ja: "「カスタムキャッチャー」は、1枚または2枚同時に使え、使った枚数によって効果が変わる。◆1枚使ったなら、自分の手札が3枚になるように、山札を引く。◆2枚同時に使ったなら、相手のベンチポケモンを1匹選び、バトルポケモンと入れ替える。（この効果は、2枚で1回はたらく。）",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 558960,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	rarity: "Secret Rare",
+};
+
+export default card;

--- a/data-asia/SM/SM7a/073.ts
+++ b/data-asia/SM/SM7a/073.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "カウンターゲイン",
+	},
+
+	illustrator: "",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分のサイドの残り枚数が、相手より多いなら、このカードをつけているポケモンが使うワザに必要なエネルギーは、エネルギー1個ぶん少なくなる。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 558961,
+			},
+		},
+	],
+
+	trainerType: "Tool",
+	rarity: "Secret Rare",
+};
+
+export default card;


### PR DESCRIPTION
## What

Adds the complete Japanese set **SM7a 迅雷スパーク (Thunderclap Spark)**, released 2018-07-06:

- `data-asia/SM/SM7a/001.ts` … `073.ts` — all 73 cards (60 regular + 13 secret rares: 6 SR, 4 UR, 3 Secret Rare)
- the set definition `data-asia/SM/SM7a.ts` already existed and is untouched

## Data sources

- **pokemon-card.com** (official database): Japanese names, flavor texts, National Dex numbers, official card count
- **limitlesstcg.com**: full Japanese card text, stages, weaknesses/resistances/retreat, rarities, illustrators, attack costs
- **Cardmarket**: product IDs as `thirdParty.cardmarket` on the variant objects (558889–558961; tcgplayer IDs not available to me)

## Notes

- Follows the file format and conventions of the M-era sets (#1728)
- No `regulationMark` (the set predates regulation marks); resistances are `-20` per the era
- All 73 files type-check against `interfaces.d.ts` (`tsc --noEmit`)
