### PR TITLE
(data) Add Japanese SM set SM7b Fairy Rise

### DIFF
--- a/data-asia/SM/SM7b/001.ts
+++ b/data-asia/SM/SM7b/001.ts
@@ -1,0 +1,54 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "モンジャラ",
+	},
+
+	illustrator: "Ken Sugimori",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Grass"],
+
+	description: {
+		ja: "動くものに ツルを 絡める。 ツルは 微妙に 揺れているので 絡みつかれると くすぐったい。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ひっぱたく" },
+			damage: 20,
+			cost: ["Colorless", "Colorless"],
+		},
+		{
+			name: { ja: "しめつける" },
+			damage: 40,
+			cost: ["Grass", "Colorless", "Colorless"],
+			effect: {
+				ja: "コインを1回投げオモテなら、相手のバトルポケモンをマヒにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558826,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Common",
+	dexId: [114],
+};
+
+export default card;

--- a/data-asia/SM/SM7b/002.ts
+++ b/data-asia/SM/SM7b/002.ts
@@ -1,0 +1,58 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "モジャンボ",
+	},
+
+	illustrator: "Atsuko Nishida",
+	category: "Pokemon",
+	hp: 140,
+	types: ["Grass"],
+
+	description: {
+		ja: "暖かい 季節に なると 目玉も 隠れてしまうほど 植物の ツルが 伸び続ける。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "ごんぶとウィップ" },
+			damage: "30+",
+			cost: ["Grass", "Colorless", "Colorless"],
+			effect: {
+				ja: "この番、このポケモンのHPを回復していたなら、130ダメージ追加。",
+			},
+		},
+		{
+			name: { ja: "ウィップスマッシュ" },
+			damage: 110,
+			cost: ["Grass", "Grass", "Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558827,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "モンジャラ",
+	},
+
+	retreat: 3,
+	rarity: "Uncommon",
+	dexId: [465],
+};
+
+export default card;

--- a/data-asia/SM/SM7b/003.ts
+++ b/data-asia/SM/SM7b/003.ts
@@ -1,0 +1,48 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "キモリ",
+	},
+
+	illustrator: "Tomokazu Komiya",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Grass"],
+
+	description: {
+		ja: "足の 裏の 小さな トゲが 壁や 天井に 引っかかるので 逆さまに なっても 落ちないのだ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ともだちをさがす" },
+			cost: ["Grass"],
+			effect: {
+				ja: "自分の山札にある[草]ポケモンを1枚、相手に見せてから、手札に加える。そして山札を切る。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558828,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [252],
+};
+
+export default card;

--- a/data-asia/SM/SM7b/004.ts
+++ b/data-asia/SM/SM7b/004.ts
@@ -1,0 +1,60 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ジュプトル",
+	},
+
+	illustrator: "Ayaka Yoshida",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Grass"],
+
+	description: {
+		ja: "密林に 生息する。 枝から 枝へ 飛び移りながら 移動して 獲物に 接近する。",
+	},
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "たいようのめぐみ" },
+			effect: {
+				ja: "自分の番に1回使える。自分の山札にある[草]ポケモンを1枚、相手に見せてから、手札に加える。そして山札を切る。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "スライスブレード" },
+			damage: 40,
+			cost: ["Grass", "Grass"],
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558829,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "キモリ",
+	},
+
+	retreat: 2,
+	rarity: "Uncommon",
+	dexId: [253],
+};
+
+export default card;

--- a/data-asia/SM/SM7b/005.ts
+++ b/data-asia/SM/SM7b/005.ts
@@ -1,0 +1,66 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ジュカインGX",
+	},
+
+	illustrator: "Yoshinobu Saito",
+	category: "Pokemon",
+	hp: 230,
+	types: ["Grass"],
+
+	stage: "Stage2",
+
+	attacks: [
+		{
+			name: { ja: "おんそくぎり" },
+			damage: 60,
+			cost: ["Grass"],
+			effect: {
+				ja: "相手のバトルポケモンについている特殊エネルギーを、1個トラッシュする。",
+			},
+		},
+		{
+			name: { ja: "リーフサイクロン" },
+			damage: 130,
+			cost: ["Grass", "Grass"],
+			effect: {
+				ja: "このポケモンについている[草]エネルギーを1個、ベンチポケモンにつけ替える。",
+			},
+		},
+		{
+			name: { ja: "ジャングルヒールGX" },
+			cost: ["Grass"],
+			effect: {
+				ja: "[草]エネルギーがついている自分のポケモン全員のHPを、すべて回復する。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 558830,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ジュプトル",
+	},
+
+	retreat: 1,
+	rarity: "Double rare",
+	dexId: [254],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM7b/006.ts
+++ b/data-asia/SM/SM7b/006.ts
@@ -1,0 +1,48 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ケムッソ",
+	},
+
+	illustrator: "Mina Nakai",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Grass"],
+
+	description: {
+		ja: "森や 草むらに 生息。 敵に 襲われた ときは お尻の 毒の トゲで 対抗する。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "どくばり" },
+			cost: ["Grass"],
+			effect: {
+				ja: "相手のバトルポケモンをどくにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558831,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [265],
+};
+
+export default card;

--- a/data-asia/SM/SM7b/007.ts
+++ b/data-asia/SM/SM7b/007.ts
@@ -1,0 +1,57 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "カラサリス",
+	},
+
+	illustrator: "Satoshi Shirai",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Grass"],
+
+	description: {
+		ja: "糸に ついた 朝露を 飲んで 進化の ときを 待ち続ける。 硬い 繭が 攻撃を 防ぐ。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "まゆがあつまる" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札にある「カラサリス」または「マユルド」を合計4枚まで、ベンチに出す。そして山札を切る。",
+			},
+		},
+		{
+			name: { ja: "ころがりタックル" },
+			damage: 20,
+			cost: ["Grass"],
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558832,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ケムッソ",
+	},
+
+	retreat: 3,
+	rarity: "Common",
+	dexId: [266],
+};
+
+export default card;

--- a/data-asia/SM/SM7b/008.ts
+++ b/data-asia/SM/SM7b/008.ts
@@ -1,0 +1,60 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アゲハント",
+	},
+
+	illustrator: "0313",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Grass"],
+
+	description: {
+		ja: "長細い 口を 突き刺して 相手の 体液を 吸い取る。 攻撃的な 性格。",
+	},
+
+	stage: "Stage2",
+
+	attacks: [
+		{
+			name: { ja: "ちょくげきひこう" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "相手のポケモン1匹に、50ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+			},
+		},
+		{
+			name: { ja: "バタフライエッジ" },
+			damage: 30,
+			cost: ["Grass"],
+			effect: {
+				ja: "このワザのダメージで、相手のポケモンがきぜつしたなら、次の相手の番、このポケモンはワザのダメージや効果を受けない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558833,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "カラサリス",
+	},
+
+	retreat: 1,
+	rarity: "Uncommon",
+	dexId: [267],
+};
+
+export default card;

--- a/data-asia/SM/SM7b/009.ts
+++ b/data-asia/SM/SM7b/009.ts
@@ -1,0 +1,49 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ツチニン",
+	},
+
+	illustrator: "SATOSHI NAKAI",
+	category: "Pokemon",
+	hp: 40,
+	types: ["Grass"],
+
+	description: {
+		ja: "１０年以上 土の 中で 暮らす ことも ある。 樹木の 根っこから 栄養を 吸い取る。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "みだれひっかき" },
+			damage: "10×",
+			cost: ["Colorless"],
+			effect: {
+				ja: "コインを3回投げ、オモテの数x10ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558834,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [290],
+};
+
+export default card;

--- a/data-asia/SM/SM7b/010.ts
+++ b/data-asia/SM/SM7b/010.ts
@@ -1,0 +1,63 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "テッカニン",
+	},
+
+	illustrator: "kirisAki",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Grass"],
+
+	description: {
+		ja: "あまりに 高速で 動くため 姿が 見えなくなる ことがある。 樹液に 集まってくる。",
+	},
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ぬぎのこし" },
+			effect: {
+				ja: "自分の番に、このカードを手札から出して進化させたとき、1回使える。自分のトラッシュにある「ヌケニン」を1枚、ベンチに出す。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "シザークロス" },
+			damage: "40+",
+			cost: ["Grass"],
+			effect: {
+				ja: "コインを1回投げオモテなら、40ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558835,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ツチニン",
+	},
+
+	retreat: 0,
+	rarity: "Common",
+	dexId: [291],
+};
+
+export default card;

--- a/data-asia/SM/SM7b/011.ts
+++ b/data-asia/SM/SM7b/011.ts
@@ -1,0 +1,48 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ミツハニー",
+	},
+
+	illustrator: "Akira Komayama",
+	category: "Pokemon",
+	hp: 40,
+	types: ["Grass"],
+
+	description: {
+		ja: "集めた ミツを 住処に 運ぶ。 夜には たくさんの ミツハニーが 重なって ハチの巣になり 眠る。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ビーマーチ" },
+			cost: ["Grass"],
+			effect: {
+				ja: "自分の山札にある「ミツハニー」を3枚まで、ベンチに出す。そして山札を切る。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558836,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [415],
+};
+
+export default card;

--- a/data-asia/SM/SM7b/012.ts
+++ b/data-asia/SM/SM7b/012.ts
@@ -1,0 +1,53 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ビークイン",
+	},
+
+	illustrator: "chibi",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Grass"],
+
+	description: {
+		ja: "胴体が 子供たちの 巣穴に なっている。 ミツハニーの 集めた ミツで 子供たちを 育てる。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "クイーンコマンド" },
+			damage: 120,
+			cost: ["Grass"],
+			effect: {
+				ja: "自分のベンチに[草]ポケモンが5匹いないなら、このワザは失敗。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558837,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ミツハニー",
+	},
+
+	retreat: 2,
+	rarity: "Common",
+	dexId: [416],
+};
+
+export default card;

--- a/data-asia/SM/SM7b/013.ts
+++ b/data-asia/SM/SM7b/013.ts
@@ -1,0 +1,56 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "シェイミ",
+	},
+
+	illustrator: "Sekio",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Grass"],
+
+	description: {
+		ja: "グラシデアの花が 咲く 季節 感謝の 心を 届けるために 飛び立つと 言われている。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "フローラルヒール" },
+			effect: {
+				ja: "自分の番に1回使える。自分のバトル場の[草]ポケモンのHPを「20」回復する。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ぶつかる" },
+			damage: 30,
+			cost: ["Grass", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 558838,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Rare",
+	dexId: [492],
+};
+
+export default card;

--- a/data-asia/SM/SM7b/014.ts
+++ b/data-asia/SM/SM7b/014.ts
@@ -1,0 +1,56 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アローラロコン",
+	},
+
+	illustrator: "Naoyo Kimura",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Water"],
+
+	description: {
+		ja: "暑いときには ６本の 尻尾で 氷の礫を 作り あたりに ばらまいて 身体を 冷やす。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ひみつのうらみち" },
+			effect: {
+				ja: "自分の場に[妖]ポケモンがいるなら、このポケモンのにげるためのエネルギーは、すべてなくなる。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "かじる" },
+			damage: 20,
+			cost: ["Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558839,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [37],
+};
+
+export default card;

--- a/data-asia/SM/SM7b/015.ts
+++ b/data-asia/SM/SM7b/015.ts
@@ -1,0 +1,62 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヌケニン",
+	},
+
+	illustrator: "kawayoo",
+	category: "Pokemon",
+	hp: 40,
+	types: ["Psychic"],
+
+	description: {
+		ja: "ツチニンが 進化する ときに いつの間にか モンスターボールに 入っている 不思議な ポケモンだ。",
+	},
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "いのちのうつわ" },
+			effect: {
+				ja: "自分の番に1回使える。このポケモンについているカードをすべてトラッシュし、このポケモンを「ポケモンのどうぐ」として、自分のポケモンにつける。このカードをつけているポケモンがきぜつしたとき、相手がとるサイドは1枚少なくなる。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "のろう" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンに、ダメカンを3個のせる。",
+			},
+		},
+	],
+
+	weaknesses: [],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558840,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ツチニン",
+	},
+
+	retreat: 1,
+	rarity: "Uncommon",
+	dexId: [292],
+};
+
+export default card;

--- a/data-asia/SM/SM7b/016.ts
+++ b/data-asia/SM/SM7b/016.ts
@@ -1,0 +1,55 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヤミラミ",
+	},
+
+	illustrator: "Miki Tanaka",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Psychic"],
+
+	description: {
+		ja: "宝石の 瞳が 怪しく 輝くとき 人の 魂を 奪うと 恐れられる ポケモン。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ファストハント" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "このワザは、先攻プレイヤーの最初の番でも使える。自分の山札にある好きなカードを１枚、手札に加える。そして山札を切る。",
+			},
+		},
+		{
+			name: { ja: "のろいのしずく" },
+			cost: ["Psychic"],
+			effect: {
+				ja: "ダメカン3個を、相手のポケモンに好きなようにのせる。",
+			},
+		},
+	],
+
+	weaknesses: [],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558841,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [302],
+};
+
+export default card;

--- a/data-asia/SM/SM7b/017.ts
+++ b/data-asia/SM/SM7b/017.ts
@@ -1,0 +1,59 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ギラティナ",
+	},
+
+	illustrator: "Hasuno",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Psychic"],
+
+	description: {
+		ja: "暴れ者 ゆえ 追い出されたが 破れた世界と 言われる 場所で 静かに 元の世界を 見ていた。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "やぶれたとびら" },
+			effect: {
+				ja: "このカードがトラッシュにあるなら、自分の番に1回使える。このカードをベンチに出す。その後、相手のベンチポケモン2匹に、それぞれダメカンを1個のせる。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "シャドーインパクト" },
+			damage: 130,
+			cost: ["Psychic", "Psychic", "Colorless"],
+			effect: {
+				ja: "自分のポケモン1匹に、ダメカンを4個のせる。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 558842,
+			},
+		},
+	],
+
+	retreat: 3,
+	rarity: "Rare",
+	dexId: [487],
+};
+
+export default card;

--- a/data-asia/SM/SM7b/018.ts
+++ b/data-asia/SM/SM7b/018.ts
@@ -1,0 +1,65 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "シンボラーGX",
+	},
+
+	illustrator: "PLANETA Otani",
+	category: "Pokemon",
+	hp: 170,
+	types: ["Psychic"],
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ミラーカウンター" },
+			effect: {
+				ja: "このポケモンが、バトル場で相手の「ポケモンGX・EX」からワザのダメージを受けたとき、受けたダメージぶんのダメカンを、ワザを使ったポケモンにのせる。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ソニックウイング" },
+			damage: 80,
+			cost: ["Psychic", "Colorless", "Colorless"],
+			effect: {
+				ja: "このワザのダメージは抵抗力を計算しない。",
+			},
+		},
+		{
+			name: { ja: "インターセプトGX" },
+			damage: "60×",
+			cost: ["Psychic", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンについているエネルギーの数x60ダメージ。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 558843,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Double rare",
+	dexId: [561],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM7b/019.ts
+++ b/data-asia/SM/SM7b/019.ts
@@ -1,0 +1,48 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "デスマス",
+	},
+
+	illustrator: "Ken Sugimori",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Psychic"],
+
+	description: {
+		ja: "持っている マスクは デスマスが 人間だった ときの 顔。 たまに 見つめては 泣いている。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "のろう" },
+			cost: ["Psychic"],
+			effect: {
+				ja: "相手のバトルポケモンに、ダメカンを1個のせる。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558844,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [562],
+};
+
+export default card;

--- a/data-asia/SM/SM7b/020.ts
+++ b/data-asia/SM/SM7b/020.ts
@@ -1,0 +1,53 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "デスカーン",
+	},
+
+	illustrator: "tetsuya koizumi",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Psychic"],
+
+	description: {
+		ja: "本物の かんおけと 間違え 近寄ってきた 墓ドロボウを 体の 中に 閉じこめてしまう。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "ソウルジャグリング" },
+			damage: "10+",
+			cost: ["Psychic", "Colorless"],
+			effect: {
+				ja: "自分のベンチポケモンを好きなだけトラッシュし、トラッシュしたベンチポケモンの数x30ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558845,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "デスマス",
+	},
+
+	retreat: 3,
+	rarity: "Uncommon",
+	dexId: [563],
+};
+
+export default card;

--- a/data-asia/SM/SM7b/021.ts
+++ b/data-asia/SM/SM7b/021.ts
@@ -1,0 +1,48 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヒトモシ",
+	},
+
+	illustrator: "Asako Ito",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Psychic"],
+
+	description: {
+		ja: "ヒトモシの 灯す 明かりは 人や ポケモンの 生命力を 吸い取って 燃えているのだ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "のろう" },
+			cost: ["Psychic"],
+			effect: {
+				ja: "相手のバトルポケモンに、ダメカンを1個のせる。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558846,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [607],
+};
+
+export default card;

--- a/data-asia/SM/SM7b/022.ts
+++ b/data-asia/SM/SM7b/022.ts
@@ -1,0 +1,52 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ランプラー",
+	},
+
+	illustrator: "Anesaki Dynamic",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Psychic"],
+
+	description: {
+		ja: "臨終の 際に 現れて 魂が 肉体を 離れると すかさず 吸い取ってしまうのだ。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "のろう" },
+			cost: ["Psychic"],
+			effect: {
+				ja: "相手のバトルポケモンに、ダメカンを3個のせる。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558847,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ヒトモシ",
+	},
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [608],
+};
+
+export default card;

--- a/data-asia/SM/SM7b/023.ts
+++ b/data-asia/SM/SM7b/023.ts
@@ -1,0 +1,60 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "シャンデラ",
+	},
+
+	illustrator: "so-taro",
+	category: "Pokemon",
+	hp: 140,
+	types: ["Psychic"],
+
+	description: {
+		ja: "怪しげな 炎で 燃やされた 魂は 行き場を なくし この 世を 永遠に さまよう。",
+	},
+
+	stage: "Stage2",
+
+	attacks: [
+		{
+			name: { ja: "のろいのしずく" },
+			cost: ["Psychic"],
+			effect: {
+				ja: "ダメカン4個を、相手のポケモンに好きなようにのせる。",
+			},
+		},
+		{
+			name: { ja: "いたみのらせん" },
+			damage: "20×",
+			cost: ["Psychic", "Psychic"],
+			effect: {
+				ja: "相手の場のポケモンにのっているダメカンの数x20ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 558848,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ランプラー",
+	},
+
+	retreat: 2,
+	rarity: "Rare",
+	dexId: [609],
+};
+
+export default card;

--- a/data-asia/SM/SM7b/024.ts
+++ b/data-asia/SM/SM7b/024.ts
@@ -1,0 +1,55 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "メロエッタ",
+	},
+
+	illustrator: "nagimiso",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Psychic"],
+
+	description: {
+		ja: "特殊な 発声法で 歌う メロディは 聞いた者の 感情を 自在に 操る。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "うたう" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをねむりにする。",
+			},
+		},
+		{
+			name: { ja: "ミラクルハーモニー" },
+			cost: ["Psychic", "Colorless", "Colorless"],
+			effect: {
+				ja: "自分の場にいるワザ「うたう」を持つポケモンの数ぶんコインを投げ、オモテの数x10ダメージを、相手のポケモン全員にそれぞれ与える。［ベンチは弱点・抵抗力を計算しない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558849,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Uncommon",
+	dexId: [648],
+};
+
+export default card;

--- a/data-asia/SM/SM7b/025.ts
+++ b/data-asia/SM/SM7b/025.ts
@@ -1,0 +1,68 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アローラキュウコンGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 200,
+	types: ["Fairy"],
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ふしぎなみちびき" },
+			effect: {
+				ja: "自分の番に、このカードを手札から出して進化させたとき、1回使える。自分の山札にあるグッズを2枚まで、相手に見せてから、手札に加える。そして山札を切る。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "はくぎんのかぜ" },
+			damage: 70,
+			cost: ["Fairy", "Colorless"],
+			effect: {
+				ja: "相手のベンチポケモン1匹にも、30ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+			},
+		},
+		{
+			name: { ja: "サブリメイションGX" },
+			cost: ["Fairy", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンが「ウルトラビースト」なら、そのポケモンをきぜつさせる。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [{ type: "Darkness", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 558850,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "アローラロコン",
+	},
+
+	retreat: 2,
+	rarity: "Double rare",
+	dexId: [38],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM7b/026.ts
+++ b/data-asia/SM/SM7b/026.ts
@@ -1,0 +1,53 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "プリン",
+	},
+
+	illustrator: "Ken Sugimori",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Fairy"],
+
+	description: {
+		ja: "１２オクターブを 超える 声域を 持つが 歌が 上手いか どうかは それぞれの プリンの 努力次第。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "はたく" },
+			damage: 10,
+			cost: ["Fairy"],
+		},
+		{
+			name: { ja: "うたう" },
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをねむりにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [{ type: "Darkness", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558851,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Common",
+	dexId: [39],
+};
+
+export default card;

--- a/data-asia/SM/SM7b/027.ts
+++ b/data-asia/SM/SM7b/027.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "プクリン",
+	},
+
+	illustrator: "nagimiso",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Fairy"],
+
+	description: {
+		ja: "息を 吸って どんどん 膨らむ。 プクリン同士は どっちが 大きく 膨らめるか 勝負 するよ。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "ふくらむ" },
+			damage: 30,
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "次の相手の番、このポケモンが受けるワザのダメージは「-30」される。",
+			},
+		},
+		{
+			name: { ja: "デコレートビンタ" },
+			damage: "70+",
+			cost: ["Fairy", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンに、名前に「フェアリーチャーム」とつく「ポケモンのどうぐ」がついているなら、70ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [{ type: "Darkness", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558852,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "プリン",
+	},
+
+	retreat: 2,
+	rarity: "Uncommon",
+	dexId: [40],
+};
+
+export default card;

--- a/data-asia/SM/SM7b/028.ts
+++ b/data-asia/SM/SM7b/028.ts
@@ -1,0 +1,53 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ラルトス",
+	},
+
+	illustrator: "Yuka Morii",
+	category: "Pokemon",
+	hp: 50,
+	types: ["Fairy"],
+
+	description: {
+		ja: "人や ポケモンの 感情を 敏感に キャッチ。 敵意を 感じると 物陰に 隠れる。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "まねきよせる" },
+			cost: ["Fairy"],
+			effect: {
+				ja: "自分のトラッシュにあるサポートを1枚、相手に見せてから、手札に加える。",
+			},
+		},
+		{
+			name: { ja: "たたく" },
+			damage: 20,
+			cost: ["Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [{ type: "Darkness", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558853,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [280],
+};
+
+export default card;

--- a/data-asia/SM/SM7b/029.ts
+++ b/data-asia/SM/SM7b/029.ts
@@ -1,0 +1,58 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "キルリア",
+	},
+
+	illustrator: "Kouki Saitou",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Fairy"],
+
+	description: {
+		ja: "サイコパワーを 操り まわりの 空間を ねじ曲げる ことで 未来を 見通す ことが できる。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "たたく" },
+			damage: 20,
+			cost: ["Colorless", "Colorless"],
+		},
+		{
+			name: { ja: "チャームボイス" },
+			damage: 50,
+			cost: ["Fairy", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをこんらんにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [{ type: "Darkness", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558854,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ラルトス",
+	},
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [281],
+};
+
+export default card;

--- a/data-asia/SM/SM7b/030.ts
+++ b/data-asia/SM/SM7b/030.ts
@@ -1,0 +1,60 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "サーナイト",
+	},
+
+	illustrator: "Ryota Murayama",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Fairy"],
+
+	description: {
+		ja: "未来を 予知する 力を 持つ。 トレーナーを 守る ときに 最大 パワーを 発揮する。",
+	},
+
+	stage: "Stage2",
+
+	attacks: [
+		{
+			name: { ja: "ブリリアントサーチ" },
+			cost: ["Fairy"],
+			effect: {
+				ja: "自分の山札にある好きなカードを3枚まで、手札に加える。そして山札を切る。",
+			},
+		},
+		{
+			name: { ja: "センシングレイ" },
+			damage: "70+",
+			cost: ["Fairy", "Colorless", "Colorless"],
+			effect: {
+				ja: "この番、手札からサポートを出して使っていたなら、90ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [{ type: "Darkness", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 558855,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "キルリア",
+	},
+
+	retreat: 2,
+	rarity: "Rare",
+	dexId: [282],
+};
+
+export default card;

--- a/data-asia/SM/SM7b/031.ts
+++ b/data-asia/SM/SM7b/031.ts
@@ -1,0 +1,49 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "デデンネ",
+	},
+
+	illustrator: "Megumi Mizutani",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Fairy"],
+
+	description: {
+		ja: "尻尾で 発電所や 民家の コンセントから 電気を 吸い取り ヒゲから 電撃を 撃ち出す。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "パチパチタッチ" },
+			damage: 10,
+			cost: ["Fairy"],
+			effect: {
+				ja: "コインを1回投げオモテなら、相手のバトルポケモンをこんらんにする。ウラなら、相手のバトルポケモンをマヒにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [{ type: "Darkness", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558856,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [702],
+};
+
+export default card;

--- a/data-asia/SM/SM7b/032.ts
+++ b/data-asia/SM/SM7b/032.ts
@@ -1,0 +1,54 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "メレシー",
+	},
+
+	illustrator: "Ken Sugimori",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Fairy"],
+
+	description: {
+		ja: "さほど 珍しいわけではないが キラキラと 輝く 宝石の 身体が 女性に 人気だ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ワンダーレイ" },
+			damage: 30,
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "次の相手の番、このポケモンは特性を持つポケモンからワザのダメージや効果を受けない。",
+			},
+		},
+		{
+			name: { ja: "パワージェム" },
+			damage: 60,
+			cost: ["Fairy", "Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [{ type: "Darkness", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558857,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [703],
+};
+
+export default card;

--- a/data-asia/SM/SM7b/033.ts
+++ b/data-asia/SM/SM7b/033.ts
@@ -1,0 +1,55 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ゼルネアス",
+	},
+
+	illustrator: "Shin Nagasawa",
+	category: "Pokemon",
+	hp: 160,
+	types: ["Fairy"],
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "せいめいのみち" },
+			effect: {
+				ja: "自分の番に、このポケモンがベンチからバトル場に出たとき、1回使える。自分の場のポケモンについているエネルギーを好きなだけ、このポケモンにつけ替える。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ブライトホーン" },
+			damage: 160,
+			cost: ["Fairy", "Fairy", "Fairy"],
+			effect: {
+				ja: "次の自分の番、このポケモンは「ブライトホーン」が使えない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [{ type: "Darkness", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 558858,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Rare Holo",
+	dexId: [716],
+};
+
+export default card;

--- a/data-asia/SM/SM7b/034.ts
+++ b/data-asia/SM/SM7b/034.ts
@@ -1,0 +1,48 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アブリー",
+	},
+
+	illustrator: "Midori Harada",
+	category: "Pokemon",
+	hp: 30,
+	types: ["Fairy"],
+
+	description: {
+		ja: "花に 似た オーラを 持つ 人の 頭の 上には たくさんの アブリーが 集まってくるよ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "あまいかおり" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分のポケモン1匹のHPを「30」回復する。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [{ type: "Darkness", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558859,
+			},
+		},
+	],
+
+	retreat: 0,
+	rarity: "Common",
+	dexId: [742],
+};
+
+export default card;

--- a/data-asia/SM/SM7b/035.ts
+++ b/data-asia/SM/SM7b/035.ts
@@ -1,0 +1,60 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アブリボン",
+	},
+
+	illustrator: "Hasuno",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Fairy"],
+
+	description: {
+		ja: "アブリボンの 花粉団子は 栄養満点の ものも ある。 サプリメントとして 売られることも。",
+	},
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ふしぎなはおと" },
+			effect: {
+				ja: "このポケモンがベンチにいるかぎり、自分の場の[妖]ポケモン全員は、相手が手札からサポートを出して使ったとき、その効果を受けない。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ふむ" },
+			damage: 20,
+			cost: ["Fairy"],
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [{ type: "Darkness", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558860,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "アブリー",
+	},
+
+	retreat: 0,
+	rarity: "Uncommon",
+	dexId: [743],
+};
+
+export default card;

--- a/data-asia/SM/SM7b/036.ts
+++ b/data-asia/SM/SM7b/036.ts
@@ -1,0 +1,48 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ネマシュ",
+	},
+
+	illustrator: "You Iribi",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Fairy"],
+
+	description: {
+		ja: "昼は 寝ながら 樹木の 根から 養分を 吸う。 夜に 目覚め 新たな 樹木を 探し歩く。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "まどわす" },
+			cost: ["Fairy"],
+			effect: {
+				ja: "相手のバトルポケモンをこんらんにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [{ type: "Darkness", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558861,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [755],
+};
+
+export default card;

--- a/data-asia/SM/SM7b/037.ts
+++ b/data-asia/SM/SM7b/037.ts
@@ -1,0 +1,63 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "マシェード",
+	},
+
+	illustrator: "Suwama Chiaki",
+	category: "Pokemon",
+	hp: 100,
+	types: ["Fairy"],
+
+	description: {
+		ja: "点滅する 胞子を 吹き出し 眠りに 誘う。 眠った 獲物の 精気を 吸い取る。",
+	},
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ほうし" },
+			effect: {
+				ja: "このポケモンが、バトル場で相手のポケモンからワザのダメージを受けたとき、ワザを使ったポケモンをねむりにする。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ゆめみにふれる" },
+			damage: 50,
+			cost: ["Fairy", "Fairy"],
+			effect: {
+				ja: "相手のバトルポケモンがねむりなら、相手のバトルポケモンについているエネルギーを、すべて山札にもどして切る。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [{ type: "Darkness", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558862,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ネマシュ",
+	},
+
+	retreat: 2,
+	rarity: "Common",
+	dexId: [756],
+};
+
+export default card;

--- a/data-asia/SM/SM7b/038.ts
+++ b/data-asia/SM/SM7b/038.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ミミッキュGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 170,
+	types: ["Fairy"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "まどわす" },
+			cost: ["Fairy"],
+			effect: {
+				ja: "相手のバトルポケモンをこんらんにする。",
+			},
+		},
+		{
+			name: { ja: "ぽかぼかフォール" },
+			damage: "10+",
+			cost: ["Fairy", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンにのっているダメカンの数x30ダメージ追加。",
+			},
+		},
+		{
+			name: { ja: "ドリームフィアーGX" },
+			cost: ["Fairy"],
+			effect: {
+				ja: "相手のベンチポケモン1匹と、そのポケモンについているすべてのカードを、相手の山札にもどして切る。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 558863,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Double rare",
+	dexId: [778],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM7b/039.ts
+++ b/data-asia/SM/SM7b/039.ts
@@ -1,0 +1,56 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "カプ・テテフ",
+	},
+
+	illustrator: "Mizue",
+	category: "Pokemon",
+	hp: 110,
+	types: ["Fairy"],
+
+	description: {
+		ja: "ヒラヒラ 飛びまわり 不思議に 光る 鱗粉を 振りまく。 触れた者は たちまち 元気を 取り戻すという。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "チャームチャーム" },
+			effect: {
+				ja: "自分の番に、自分の手札から名前に「フェアリーチャーム」とつく「ポケモンのどうぐ」を、このポケモンにつけるたび、1回使える。相手のバトルポケモンをこんらんにする。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "マジカルショット" },
+			damage: 70,
+			cost: ["Fairy", "Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [{ type: "Darkness", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 558864,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Rare",
+	dexId: [786],
+};
+
+export default card;

--- a/data-asia/SM/SM7b/040.ts
+++ b/data-asia/SM/SM7b/040.ts
@@ -1,0 +1,56 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "カプ・レヒレ",
+	},
+
+	illustrator: "Kagemaru Himeno",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Fairy"],
+
+	description: {
+		ja: "水を 操る ポニの 守り神。 けがれを 払う 清らかな 水を 生みだすと 伝えられている。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ドリームアウェイ" },
+			cost: ["Fairy", "Colorless"],
+			effect: {
+				ja: "コインを1回投げオモテなら、相手のバトルポケモンと、ついているすべてのカードを、相手の山札にもどして切る。",
+			},
+		},
+		{
+			name: { ja: "ワンダーシャイン" },
+			damage: 100,
+			cost: ["Fairy", "Fairy", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをこんらんにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [{ type: "Darkness", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 558865,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Rare",
+	dexId: [788],
+};
+
+export default card;

--- a/data-asia/SM/SM7b/041.ts
+++ b/data-asia/SM/SM7b/041.ts
@@ -1,0 +1,56 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "カクレオン",
+	},
+
+	illustrator: "OOYAMA",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Colorless"],
+
+	description: {
+		ja: "体の 色を 変えて 景色に 溶けこみ 獲物に 忍び寄る。 お腹の 模様は 消せないのだ。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ユニットカラー3" },
+			effect: {
+				ja: "このポケモンに「ユニットエネルギー闘悪妖」がついているかぎり、このポケモンは[闘][悪][妖]の3つのタイプになる。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ひっぱたく" },
+			damage: 60,
+			cost: ["Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558866,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [352],
+};
+
+export default card;

--- a/data-asia/SM/SM7b/042.ts
+++ b/data-asia/SM/SM7b/042.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ネットボール",
+	},
+
+	illustrator: "Ryo Ueda",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の山札にある[草]タイプのたねポケモンまたは[草]エネルギーを1枚、相手に見せてから、手札に加える。そして山札を切る。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558867,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM7b/043.ts
+++ b/data-asia/SM/SM7b/043.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ぼうけんのカバン",
+	},
+
+	illustrator: "Yoshinobu Saito",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の山札にある「ポケモンのどうぐ」を2枚まで、相手に見せてから、手札に加える。そして山札を切る。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558868,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	rarity: "Common",
+};
+
+export default card;

--- a/data-asia/SM/SM7b/044.ts
+++ b/data-asia/SM/SM7b/044.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "のろいのおふだ",
+	},
+
+	illustrator: "Ayaka Yoshida",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードをつけているポケモンが、相手のワザのダメージを受けてきぜつしたとき、ダメカン4個を、相手のポケモンに好きなようにのせる。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558869,
+			},
+		},
+	],
+
+	trainerType: "Tool",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM7b/045.ts
+++ b/data-asia/SM/SM7b/045.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "フェアリーチャーム超",
+	},
+
+	illustrator: "Toyste Beach",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードをつけているポケモンは、相手のタイプの「ポケモンGX・EX」からワザのダメージを受けない。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558870,
+			},
+		},
+	],
+
+	trainerType: "Tool",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM7b/046.ts
+++ b/data-asia/SM/SM7b/046.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "フェアリーチャーム闘",
+	},
+
+	illustrator: "Toyste Beach",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードをつけているポケモンは、相手のタイプの「ポケモンGX・EX」からワザのダメージを受けない。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558871,
+			},
+		},
+	],
+
+	trainerType: "Tool",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM7b/047.ts
+++ b/data-asia/SM/SM7b/047.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "フェアリーチャームドラゴン",
+	},
+
+	illustrator: "Toyste Beach",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードをつけているポケモンは、相手のタイプの「ポケモンGX・EX」からワザのダメージを受けない。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558872,
+			},
+		},
+	],
+
+	trainerType: "Tool",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM7b/048.ts
+++ b/data-asia/SM/SM7b/048.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "マツバ",
+	},
+
+	illustrator: "Ken Sugimori",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードは、前の相手の番に、自分の[超]ポケモンがきぜつしていなければ使えない。相手の手札を見て、その中にあるカードを2枚、相手の山札にもどして切る。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558873,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM7b/049.ts
+++ b/data-asia/SM/SM7b/049.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "マツリカ",
+	},
+
+	illustrator: "Ken Sugimori",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の山札にある[妖]エネルギーを1枚、自分のポケモンにつける。そして山札を切る。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558874,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM7b/050.ts
+++ b/data-asia/SM/SM7b/050.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ライフフォレスト",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Trainer",
+
+	effect: {
+		ja: "おたがいのプレイヤーは、自分の番ごとに1回、自分の[草]ポケモン1匹のHPを「60」回復し、特殊状態もすべて回復してよい。このスタジアムは、場に出ているかぎり、おたがいのプレイヤーが手札からグッズまたはサポートを出して使ったとき、その効果を受けない。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 558875,
+			},
+		},
+	],
+
+	trainerType: "Stadium",
+	rarity: "Rare Holo",
+};
+
+export default card;

--- a/data-asia/SM/SM7b/051.ts
+++ b/data-asia/SM/SM7b/051.ts
@@ -1,0 +1,66 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ジュカインGX",
+	},
+
+	illustrator: "Yoshinobu Saito",
+	category: "Pokemon",
+	hp: 230,
+	types: ["Grass"],
+
+	stage: "Stage2",
+
+	attacks: [
+		{
+			name: { ja: "おんそくぎり" },
+			damage: 60,
+			cost: ["Grass"],
+			effect: {
+				ja: "相手のバトルポケモンについている特殊エネルギーを、1個トラッシュする。",
+			},
+		},
+		{
+			name: { ja: "リーフサイクロン" },
+			damage: 130,
+			cost: ["Grass", "Grass"],
+			effect: {
+				ja: "このポケモンについている[草]エネルギーを1個、ベンチポケモンにつけ替える。",
+			},
+		},
+		{
+			name: { ja: "ジャングルヒールGX" },
+			cost: ["Grass"],
+			effect: {
+				ja: "[草]エネルギーがついている自分のポケモン全員のHPを、すべて回復する。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 558876,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ジュプトル",
+	},
+
+	retreat: 1,
+	rarity: "Ultra Rare",
+	dexId: [254],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM7b/052.ts
+++ b/data-asia/SM/SM7b/052.ts
@@ -1,0 +1,65 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "シンボラーGX",
+	},
+
+	illustrator: "PLANETA Igarashi",
+	category: "Pokemon",
+	hp: 170,
+	types: ["Psychic"],
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ミラーカウンター" },
+			effect: {
+				ja: "このポケモンが、バトル場で相手の「ポケモンGX・EX」からワザのダメージを受けたとき、受けたダメージぶんのダメカンを、ワザを使ったポケモンにのせる。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ソニックウイング" },
+			damage: 80,
+			cost: ["Psychic", "Colorless", "Colorless"],
+			effect: {
+				ja: "このワザのダメージは抵抗力を計算しない。",
+			},
+		},
+		{
+			name: { ja: "インターセプトGX" },
+			damage: "60×",
+			cost: ["Psychic", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンについているエネルギーの数x60ダメージ。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 558877,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Ultra Rare",
+	dexId: [561],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM7b/053.ts
+++ b/data-asia/SM/SM7b/053.ts
@@ -1,0 +1,68 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アローラキュウコンGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 200,
+	types: ["Fairy"],
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ふしぎなみちびき" },
+			effect: {
+				ja: "自分の番に、このカードを手札から出して進化させたとき、1回使える。自分の山札にあるグッズを2枚まで、相手に見せてから、手札に加える。そして山札を切る。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "はくぎんのかぜ" },
+			damage: 70,
+			cost: ["Fairy", "Colorless"],
+			effect: {
+				ja: "相手のベンチポケモン1匹にも、30ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+			},
+		},
+		{
+			name: { ja: "サブリメイションGX" },
+			cost: ["Fairy", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンが「ウルトラビースト」なら、そのポケモンをきぜつさせる。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [{ type: "Darkness", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 558878,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "アローラロコン",
+	},
+
+	retreat: 2,
+	rarity: "Ultra Rare",
+	dexId: [38],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM7b/054.ts
+++ b/data-asia/SM/SM7b/054.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ミミッキュGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 170,
+	types: ["Fairy"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "まどわす" },
+			cost: ["Fairy"],
+			effect: {
+				ja: "相手のバトルポケモンをこんらんにする。",
+			},
+		},
+		{
+			name: { ja: "ぽかぼかフォール" },
+			damage: "10+",
+			cost: ["Fairy", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンにのっているダメカンの数x30ダメージ追加。",
+			},
+		},
+		{
+			name: { ja: "ドリームフィアーGX" },
+			cost: ["Fairy"],
+			effect: {
+				ja: "相手のベンチポケモン1匹と、そのポケモンについているすべてのカードを、相手の山札にもどして切る。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 558879,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Ultra Rare",
+	dexId: [778],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM7b/055.ts
+++ b/data-asia/SM/SM7b/055.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "マツバ",
+	},
+
+	illustrator: "Sanosuke Sakuma",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードは、前の相手の番に、自分の[超]ポケモンがきぜつしていなければ使えない。相手の手札を見て、その中にあるカードを2枚、相手の山札にもどして切る。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 558880,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	rarity: "Ultra Rare",
+};
+
+export default card;

--- a/data-asia/SM/SM7b/056.ts
+++ b/data-asia/SM/SM7b/056.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "マツリカ",
+	},
+
+	illustrator: "You Iribi",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の山札にある[妖]エネルギーを1枚、自分のポケモンにつける。そして山札を切る。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 558881,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	rarity: "Ultra Rare",
+};
+
+export default card;

--- a/data-asia/SM/SM7b/057.ts
+++ b/data-asia/SM/SM7b/057.ts
@@ -1,0 +1,66 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ジュカインGX",
+	},
+
+	illustrator: "",
+	category: "Pokemon",
+	hp: 230,
+	types: ["Grass"],
+
+	stage: "Stage2",
+
+	attacks: [
+		{
+			name: { ja: "おんそくぎり" },
+			damage: 60,
+			cost: ["Grass"],
+			effect: {
+				ja: "相手のバトルポケモンについている特殊エネルギーを、1個トラッシュする。",
+			},
+		},
+		{
+			name: { ja: "リーフサイクロン" },
+			damage: 130,
+			cost: ["Grass", "Grass"],
+			effect: {
+				ja: "このポケモンについている[草]エネルギーを1個、ベンチポケモンにつけ替える。",
+			},
+		},
+		{
+			name: { ja: "ジャングルヒールGX" },
+			cost: ["Grass"],
+			effect: {
+				ja: "[草]エネルギーがついている自分のポケモン全員のHPを、すべて回復する。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 558882,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ジュプトル",
+	},
+
+	retreat: 1,
+	rarity: "Hyper rare",
+	dexId: [254],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM7b/058.ts
+++ b/data-asia/SM/SM7b/058.ts
@@ -1,0 +1,65 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "シンボラーGX",
+	},
+
+	illustrator: "",
+	category: "Pokemon",
+	hp: 170,
+	types: ["Psychic"],
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ミラーカウンター" },
+			effect: {
+				ja: "このポケモンが、バトル場で相手の「ポケモンGX・EX」からワザのダメージを受けたとき、受けたダメージぶんのダメカンを、ワザを使ったポケモンにのせる。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ソニックウイング" },
+			damage: 80,
+			cost: ["Psychic", "Colorless", "Colorless"],
+			effect: {
+				ja: "このワザのダメージは抵抗力を計算しない。",
+			},
+		},
+		{
+			name: { ja: "インターセプトGX" },
+			damage: "60×",
+			cost: ["Psychic", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンについているエネルギーの数x60ダメージ。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 558883,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Hyper rare",
+	dexId: [561],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM7b/059.ts
+++ b/data-asia/SM/SM7b/059.ts
@@ -1,0 +1,68 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アローラキュウコンGX",
+	},
+
+	illustrator: "",
+	category: "Pokemon",
+	hp: 200,
+	types: ["Fairy"],
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ふしぎなみちびき" },
+			effect: {
+				ja: "自分の番に、このカードを手札から出して進化させたとき、1回使える。自分の山札にあるグッズを2枚まで、相手に見せてから、手札に加える。そして山札を切る。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "はくぎんのかぜ" },
+			damage: 70,
+			cost: ["Fairy", "Colorless"],
+			effect: {
+				ja: "相手のベンチポケモン1匹にも、30ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+			},
+		},
+		{
+			name: { ja: "サブリメイションGX" },
+			cost: ["Fairy", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンが「ウルトラビースト」なら、そのポケモンをきぜつさせる。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [{ type: "Darkness", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 558884,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "アローラロコン",
+	},
+
+	retreat: 2,
+	rarity: "Hyper rare",
+	dexId: [38],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM7b/060.ts
+++ b/data-asia/SM/SM7b/060.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ミミッキュGX",
+	},
+
+	illustrator: "",
+	category: "Pokemon",
+	hp: 170,
+	types: ["Fairy"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "まどわす" },
+			cost: ["Fairy"],
+			effect: {
+				ja: "相手のバトルポケモンをこんらんにする。",
+			},
+		},
+		{
+			name: { ja: "ぽかぼかフォール" },
+			damage: "10+",
+			cost: ["Fairy", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンにのっているダメカンの数x30ダメージ追加。",
+			},
+		},
+		{
+			name: { ja: "ドリームフィアーGX" },
+			cost: ["Fairy"],
+			effect: {
+				ja: "相手のベンチポケモン1匹と、そのポケモンについているすべてのカードを、相手の山札にもどして切る。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 558885,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Hyper rare",
+	dexId: [778],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM7b/061.ts
+++ b/data-asia/SM/SM7b/061.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ネットボール",
+	},
+
+	illustrator: "",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の山札にある[草]タイプのたねポケモンまたは[草]エネルギーを1枚、相手に見せてから、手札に加える。そして山札を切る。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 558886,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	rarity: "Secret Rare",
+};
+
+export default card;

--- a/data-asia/SM/SM7b/062.ts
+++ b/data-asia/SM/SM7b/062.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ぼうけんのカバン",
+	},
+
+	illustrator: "",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の山札にある「ポケモンのどうぐ」を2枚まで、相手に見せてから、手札に加える。そして山札を切る。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 558887,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	rarity: "Secret Rare",
+};
+
+export default card;

--- a/data-asia/SM/SM7b/063.ts
+++ b/data-asia/SM/SM7b/063.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM7b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "のろいのおふだ",
+	},
+
+	illustrator: "",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードをつけているポケモンが、相手のワザのダメージを受けてきぜつしたとき、ダメカン4個を、相手のポケモンに好きなようにのせる。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 558888,
+			},
+		},
+	],
+
+	trainerType: "Tool",
+	rarity: "Secret Rare",
+};
+
+export default card;


### PR DESCRIPTION
## What

Adds the complete Japanese set **SM7b フェアリーライズ (Fairy Rise)**, released 2018-08-03:

- `data-asia/SM/SM7b/001.ts` … `063.ts` — all 63 cards (50 regular + 13 secret rares: 6 SR, 4 UR, 3 Secret Rare)
- the set definition `data-asia/SM/SM7b.ts` already existed and is untouched

## Data sources

- **pokemon-card.com** (official database): Japanese names, flavor texts, National Dex numbers, official card count
- **limitlesstcg.com**: full Japanese card text, stages, weaknesses/resistances/retreat, rarities, illustrators, attack costs
- **Cardmarket**: product IDs as `thirdParty.cardmarket` on the variant objects (558826–558888; tcgplayer IDs not available to me)

## Notes

- Follows the file format and conventions of the M-era sets (#1728)
- No `regulationMark` (the set predates regulation marks); resistances are `-20` per the era
- All 63 files type-check against `interfaces.d.ts` (`tsc --noEmit`)
