### PR TITLE
(data) Add Japanese SM set SM8 Super Burst Impact

### DIFF
--- a/data-asia/SM/SM8/001.ts
+++ b/data-asia/SM/SM8/001.ts
@@ -1,0 +1,49 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ストライク",
+	},
+
+	illustrator: "Kouki Saitou",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Grass"],
+
+	description: {
+		ja: "若いうちは 山奥で 群れて 暮らし 鎌での 戦いかたや 高速移動を 修行する。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "れんぞくぎり" },
+			damage: "10+",
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "コインを3回投げる。オモテが1回なら、20ダメージ追加。オモテが2回なら、50ダメージ追加。すべてオモテなら、70ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558640,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [123],
+};
+
+export default card;

--- a/data-asia/SM/SM8/002.ts
+++ b/data-asia/SM/SM8/002.ts
@@ -1,0 +1,53 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "チコリータ",
+	},
+
+	illustrator: "Aya Kusube",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Grass"],
+
+	description: {
+		ja: "頭の 葉っぱで まわりの 温度や 湿度を 探る。 日差しを 浴びることが 大好き。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "こうごうせい" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札にある[草]エネルギーを1枚、自分のポケモンにつける。そして山札を切る。",
+			},
+		},
+		{
+			name: { ja: "はっぱカッター" },
+			damage: 20,
+			cost: ["Grass", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558641,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [152],
+};
+
+export default card;

--- a/data-asia/SM/SM8/003.ts
+++ b/data-asia/SM/SM8/003.ts
@@ -1,0 +1,49 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "チコリータ",
+	},
+
+	illustrator: "sowsow",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Grass"],
+
+	description: {
+		ja: "頭の 葉っぱで まわりの 温度や 湿度を 探る。 日差しを 浴びることが 大好き。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "プチドレイン" },
+			damage: 10,
+			cost: ["Grass"],
+			effect: {
+				ja: "このポケモンのHPを「10」回復する。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558642,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [152],
+};
+
+export default card;

--- a/data-asia/SM/SM8/004.ts
+++ b/data-asia/SM/SM8/004.ts
@@ -1,0 +1,58 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ベイリーフ",
+	},
+
+	illustrator: "Kagemaru Himeno",
+	category: "Pokemon",
+	hp: 100,
+	types: ["Grass"],
+
+	description: {
+		ja: "首回りの つぼみから におう スパイシーな 香りは かいだ 人を 元気に させる。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "アロマスリープ" },
+			damage: 20,
+			cost: ["Grass"],
+			effect: {
+				ja: "相手のバトルポケモンをねむりにする。",
+			},
+		},
+		{
+			name: { ja: "はっぱカッター" },
+			damage: 50,
+			cost: ["Grass", "Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558643,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "チコリータ",
+	},
+
+	retreat: 2,
+	rarity: "Common",
+	dexId: [153],
+};
+
+export default card;

--- a/data-asia/SM/SM8/005.ts
+++ b/data-asia/SM/SM8/005.ts
@@ -1,0 +1,60 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "メガニウム",
+	},
+
+	illustrator: "nagimiso",
+	category: "Pokemon",
+	hp: 150,
+	types: ["Grass"],
+
+	description: {
+		ja: "メガニウムが 吐き出す 息には 枯れた 草木を よみがえらせる 力が 秘められている。",
+	},
+
+	stage: "Stage2",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "そうじゅくハーブ" },
+			effect: {
+				ja: "自分の番に1回使える。自分の手札にある2進化ポケモンを1枚、そのポケモンへと進化する自分の場のたねポケモンにのせて進化させる。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ソーラービーム" },
+			damage: 110,
+			cost: ["Grass", "Colorless", "Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 558644,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ベイリーフ",
+	},
+
+	retreat: 2,
+	rarity: "Rare",
+	dexId: [154],
+};
+
+export default card;

--- a/data-asia/SM/SM8/006.ts
+++ b/data-asia/SM/SM8/006.ts
@@ -1,0 +1,53 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "イトマル",
+	},
+
+	illustrator: "Misa Tsutsui",
+	category: "Pokemon",
+	hp: 50,
+	types: ["Grass"],
+
+	description: {
+		ja: "丈夫な 糸を より合わせ さかなポケモンを 捕らえる 網を こしらえる 漁師も いるぞ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "クモがくれ" },
+			cost: ["Grass"],
+			effect: {
+				ja: "相手のバトルポケモンをどくとマヒにする。このポケモンと、ついているすべてのカードを、ロストゾーンに置く。",
+			},
+		},
+		{
+			name: { ja: "チクチクさす" },
+			damage: 10,
+			cost: ["Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558645,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [167],
+};
+
+export default card;

--- a/data-asia/SM/SM8/007.ts
+++ b/data-asia/SM/SM8/007.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アリアドス",
+	},
+
+	illustrator: "Suwama Chiaki",
+	category: "Pokemon",
+	hp: 110,
+	types: ["Grass"],
+
+	description: {
+		ja: "尻からも 口からも 糸をだす。 糸で 獲物を 絡め取り ゆっくりと 体液を すする。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "トラップスレッド" },
+			damage: 30,
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "次の相手の番、このワザを受けたポケモンは、相手が手札からグッズまたはサポートを出して使ったとき、その効果を受けない。",
+			},
+		},
+		{
+			name: { ja: "どくづき" },
+			damage: 70,
+			cost: ["Grass", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをどくにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558646,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "イトマル",
+	},
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [168],
+};
+
+export default card;

--- a/data-asia/SM/SM8/008.ts
+++ b/data-asia/SM/SM8/008.ts
@@ -1,0 +1,48 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ハネッコ",
+	},
+
+	illustrator: "Mizue",
+	category: "Pokemon",
+	hp: 30,
+	types: ["Grass"],
+
+	description: {
+		ja: "風に 流されて 漂う。 野山に ハネッコが 集まり出すと 春が 訪れると 言われている。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ふえる" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札にある「ハネッコ」を1枚、ベンチに出す。そして山札を切る。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558647,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [187],
+};
+
+export default card;

--- a/data-asia/SM/SM8/009.ts
+++ b/data-asia/SM/SM8/009.ts
@@ -1,0 +1,46 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ハネッコ",
+	},
+
+	illustrator: "kawayoo",
+	category: "Pokemon",
+	hp: 40,
+	types: ["Grass"],
+
+	description: {
+		ja: "風に 流されて 漂う。 野山に ハネッコが 集まり出すと 春が 訪れると 言われている。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "たいあたり" },
+			damage: 20,
+			cost: ["Grass"],
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558648,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [187],
+};
+
+export default card;

--- a/data-asia/SM/SM8/010.ts
+++ b/data-asia/SM/SM8/010.ts
@@ -1,0 +1,60 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ポポッコ",
+	},
+
+	illustrator: "Hitoshi Ariga",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Grass"],
+
+	description: {
+		ja: "太陽の 光を 浴びるため 花びらを 広げるだけでなく 近づこうと 空に 浮かんでしまう。",
+	},
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "そらのはなみち" },
+			effect: {
+				ja: "自分の番に1回使える。自分の山札から「ワタッコ」を1枚選ぶ。その後、このポケモンと、ついているすべてのカードを、ロストゾーンに置き、このポケモンがいた場所に、選んだ「ワタッコ」を出す。そして山札を切る。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "たいあたり" },
+			damage: 30,
+			cost: ["Grass"],
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558649,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ハネッコ",
+	},
+
+	retreat: 0,
+	rarity: "Common",
+	dexId: [188],
+};
+
+export default card;

--- a/data-asia/SM/SM8/011.ts
+++ b/data-asia/SM/SM8/011.ts
@@ -1,0 +1,53 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ワタッコ",
+	},
+
+	illustrator: "Masakazu Fukuda",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Grass"],
+
+	description: {
+		ja: "どんな 風に あおられても 綿毛を 自在に 操って 世界の 好きなところへ 行ける。",
+	},
+
+	stage: "Stage2",
+
+	attacks: [
+		{
+			name: { ja: "ロストマーチ" },
+			damage: "20×",
+			cost: ["Grass"],
+			effect: {
+				ja: "自分のロストゾーンにあるポケモン（♢（プリズムスター）をのぞく）の枚数x20ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 558650,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ポポッコ",
+	},
+
+	retreat: 0,
+	rarity: "Rare",
+	dexId: [189],
+};
+
+export default card;

--- a/data-asia/SM/SM8/012.ts
+++ b/data-asia/SM/SM8/012.ts
@@ -1,0 +1,49 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "クヌギダマ",
+	},
+
+	illustrator: "Misa Tsutsui",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Grass"],
+
+	description: {
+		ja: "木の実に そっくり。 間違われて とりポケモンに つつかれてしまうが 硬い 殻で 守られている。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "れんぞくずつき" },
+			damage: "20×",
+			cost: ["Colorless"],
+			effect: {
+				ja: "ウラが出るまでコインを投げ、オモテの数x20ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558651,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Common",
+	dexId: [204],
+};
+
+export default card;

--- a/data-asia/SM/SM8/013.ts
+++ b/data-asia/SM/SM8/013.ts
@@ -1,0 +1,64 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ツボツボGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 170,
+	types: ["Grass"],
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "まもりのツボ" },
+			effect: {
+				ja: "このポケモンは、ついているエネルギーが2個以下の相手のポケモンから、ワザのダメージを受けない。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "さんばいどく" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをどくにする。このどくでのせるダメカンの数は3個になる。",
+			},
+		},
+		{
+			name: { ja: "まきつくGX" },
+			damage: 40,
+			cost: ["Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをマヒにする。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 558652,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Double rare",
+	dexId: [213],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM8/014.ts
+++ b/data-asia/SM/SM8/014.ts
@@ -1,0 +1,54 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヘラクロス",
+	},
+
+	illustrator: "Ken Sugimori",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Grass"],
+
+	description: {
+		ja: "ものすごい 怪力の 持ち主。 自分の 体重の １００倍の 重さでも 楽に ぶん投げる。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "たいあたり" },
+			damage: 20,
+			cost: ["Colorless"],
+		},
+		{
+			name: { ja: "ひゃくにんりき" },
+			damage: "30+",
+			cost: ["Grass", "Colorless"],
+			effect: {
+				ja: "自分のベンチに2進化ポケモンがいるなら、90ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558653,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Common",
+	dexId: [214],
+};
+
+export default card;

--- a/data-asia/SM/SM8/015.ts
+++ b/data-asia/SM/SM8/015.ts
@@ -1,0 +1,52 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "セレビィ",
+	},
+
+	illustrator: "Masakazu Fukuda",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Grass"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ときのひずみ" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分のベンチの進化しているポケモンを好きなだけ選ぶ。その後、選んだポケモン全員の上から、それぞれ「進化カード」を好きなだけはがして退化させる。はがしたカードは、手札にもどす。",
+			},
+		},
+		{
+			name: { ja: "やどりぎのタネ" },
+			damage: 20,
+			cost: ["Grass"],
+			effect: {
+				ja: "このポケモンのHPを「20」回復する。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 558654,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Rare Holo",
+	dexId: [251],
+};
+
+export default card;

--- a/data-asia/SM/SM8/016.ts
+++ b/data-asia/SM/SM8/016.ts
@@ -1,0 +1,49 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヒノアラシ",
+	},
+
+	illustrator: "Mina Nakai",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Fire"],
+
+	description: {
+		ja: "臆病な 性格。 驚くと 背中の 炎が 一段と 強く 燃え上がる。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "えんまく" },
+			damage: 10,
+			cost: ["Fire"],
+			effect: {
+				ja: "次の相手の番、このワザを受けたポケモンがワザを使うとき、相手はコインを1回投げる。ウラならそのワザは失敗。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558655,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [155],
+};
+
+export default card;

--- a/data-asia/SM/SM8/017.ts
+++ b/data-asia/SM/SM8/017.ts
@@ -1,0 +1,46 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヒノアラシ",
+	},
+
+	illustrator: "kirisAki",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Fire"],
+
+	description: {
+		ja: "臆病な 性格。 驚くと 背中の 炎が 一段と 強く 燃え上がる。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ぶちかます" },
+			damage: 30,
+			cost: ["Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558656,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [155],
+};
+
+export default card;

--- a/data-asia/SM/SM8/018.ts
+++ b/data-asia/SM/SM8/018.ts
@@ -1,0 +1,58 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "マグマラシ",
+	},
+
+	illustrator: "Miki Tanaka",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Fire"],
+
+	description: {
+		ja: "戦闘中 背中を 向けたら 要注意。 背中の 炎で 攻撃してくる 前触れだ。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "ぶちかます" },
+			damage: 30,
+			cost: ["Colorless", "Colorless"],
+		},
+		{
+			name: { ja: "ほのおでこがす" },
+			damage: 60,
+			cost: ["Fire", "Fire", "Fire"],
+			effect: {
+				ja: "相手のバトルポケモンをやけどにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558657,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ヒノアラシ",
+	},
+
+	retreat: 2,
+	rarity: "Common",
+	dexId: [156],
+};
+
+export default card;

--- a/data-asia/SM/SM8/019.ts
+++ b/data-asia/SM/SM8/019.ts
@@ -1,0 +1,63 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "バクフーン",
+	},
+
+	illustrator: "Kouki Saitou",
+	category: "Pokemon",
+	hp: 160,
+	types: ["Fire"],
+
+	description: {
+		ja: "燃えさかる 体毛を こすり合わせ 爆風を 起こして 攻撃する。 大技を 隠し持っている。",
+	},
+
+	stage: "Stage2",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "バーニングエナジー" },
+			effect: {
+				ja: "自分の番に1回使える。この番の終わりまで、自分の場のポケモンについているエネルギーは、すべて[炎]エネルギーとしてあつかう。（新しく場に出したカードもふくむ。）",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ロストフレイム" },
+			damage: 120,
+			cost: ["Fire", "Fire", "Fire", "Fire"],
+			effect: {
+				ja: "相手のバトルポケモンについているエネルギーを2個、ロストゾーンに置く。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 558658,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "マグマラシ",
+	},
+
+	retreat: 2,
+	rarity: "Rare",
+	dexId: [157],
+};
+
+export default card;

--- a/data-asia/SM/SM8/020.ts
+++ b/data-asia/SM/SM8/020.ts
@@ -1,0 +1,53 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "デルビル",
+	},
+
+	illustrator: "Ken Sugimori",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Fire"],
+
+	description: {
+		ja: "仲間だけで わかりあえる 鳴き声で お互いの 位置を 確かめながら 獲物を 追いつめる。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "チームハント" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の場の「デルビル」の数ぶん、自分の山札を引く。",
+			},
+		},
+		{
+			name: { ja: "ほのお" },
+			damage: 10,
+			cost: ["Fire"],
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558659,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [228],
+};
+
+export default card;

--- a/data-asia/SM/SM8/021.ts
+++ b/data-asia/SM/SM8/021.ts
@@ -1,0 +1,60 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヘルガー",
+	},
+
+	illustrator: "Sekio",
+	category: "Pokemon",
+	hp: 110,
+	types: ["Fire"],
+
+	description: {
+		ja: "怒ったときに 口から 噴き出す 炎には 毒素も 混じっていて やけどになると いつまでも うずく。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "わるだくみ" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札にある好きなカードを1枚、手札に加える。そして山札を切る。",
+			},
+		},
+		{
+			name: { ja: "オペレーションアタック" },
+			damage: "50+",
+			cost: ["Fire", "Fire"],
+			effect: {
+				ja: "自分の手札の枚数が、相手より多いなら、80ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558660,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "デルビル",
+	},
+
+	retreat: 1,
+	rarity: "Uncommon",
+	dexId: [229],
+};
+
+export default card;

--- a/data-asia/SM/SM8/022.ts
+++ b/data-asia/SM/SM8/022.ts
@@ -1,0 +1,57 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "エンテイ",
+	},
+
+	illustrator: "kawayoo",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Fire"],
+
+	description: {
+		ja: "エンテイが ほえると 世界の どこかの 火山が 噴火すると 言われている。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ほのおのキバ" },
+			damage: 20,
+			cost: ["Fire", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをやけどにする。",
+			},
+		},
+		{
+			name: { ja: "ふんか" },
+			damage: "80+",
+			cost: ["Fire", "Fire", "Colorless"],
+			effect: {
+				ja: "おたがいの山札を上から1枚ずつトラッシュし、その中のエネルギーの枚数x60ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 558661,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Rare",
+	dexId: [244],
+};
+
+export default card;

--- a/data-asia/SM/SM8/023.ts
+++ b/data-asia/SM/SM8/023.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ズガドーンGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 180,
+	types: ["Fire"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "さくれつバーナー" },
+			cost: ["Fire"],
+			effect: {
+				ja: "相手のバトルポケモンをやけどとこんらんにする。",
+			},
+		},
+		{
+			name: { ja: "ビックリヘッド" },
+			damage: "50×",
+			cost: ["Fire", "Fire"],
+			effect: {
+				ja: "自分の場のポケモンについている[炎]エネルギーを好きなだけロストゾーンに置き、その枚数x50ダメージ。",
+			},
+		},
+		{
+			name: { ja: "バーストGX" },
+			cost: ["Fire"],
+			effect: {
+				ja: "自分のサイドを1枚トラッシュし、そのカードがエネルギーなら、自分のポケモンにつける。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 558662,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Double rare",
+	dexId: [806],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM8/024.ts
+++ b/data-asia/SM/SM8/024.ts
@@ -1,0 +1,48 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヤドン",
+	},
+
+	illustrator: "Tomokazu Komiya",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Water"],
+
+	description: {
+		ja: "ヤドンの尻尾を 干したあと 塩水で 煮込んだ 料理は アローラの 家庭の 味。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "あくび" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをねむりにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558663,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Common",
+	dexId: [79],
+};
+
+export default card;

--- a/data-asia/SM/SM8/025.ts
+++ b/data-asia/SM/SM8/025.ts
@@ -1,0 +1,60 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヤドキング",
+	},
+
+	illustrator: "sowsow",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Water"],
+
+	description: {
+		ja: "迷ったら ヤドキングに聞け という ことわざが 残る 地域も あるほど 賢いことで 有名 なのだ。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "きおくをとろかす" },
+			cost: ["Water"],
+			effect: {
+				ja: "相手の手札を見て、その中にあるカードを1枚、ロストゾーンに置く。",
+			},
+		},
+		{
+			name: { ja: "サイコキネシス" },
+			damage: "60+",
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンについているエネルギーの数x20ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558664,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ヤドン",
+	},
+
+	retreat: 2,
+	rarity: "Uncommon",
+	dexId: [199],
+};
+
+export default card;

--- a/data-asia/SM/SM8/026.ts
+++ b/data-asia/SM/SM8/026.ts
@@ -1,0 +1,53 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "デリバード",
+	},
+
+	illustrator: "Ken Sugimori",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Water"],
+
+	description: {
+		ja: "自分の 餌を 人や ポケモンに 分け与える 習性が あるため いつも 餌を 探しまわっている。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ハッピーデリバリー" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "「ポケモンのどうぐ」がついていない自分のベンチポケモンを好きなだけ選ぶ。その後、選んだ数ぶんまでの「ポケモンのどうぐ」を自分の山札から選び、選んだポケモンにそれぞれつける。そして山札を切る。",
+			},
+		},
+		{
+			name: { ja: "はばたく" },
+			damage: 30,
+			cost: ["Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558665,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [225],
+};
+
+export default card;

--- a/data-asia/SM/SM8/027.ts
+++ b/data-asia/SM/SM8/027.ts
@@ -1,0 +1,56 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "マンタイン",
+	},
+
+	illustrator: "Sanosuke Sakuma",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Water"],
+
+	description: {
+		ja: "悠然と 海を 泳ぐうちに 食べ残しを ねらった テッポウオが ヒレに くっつくが 気にしていない。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "マンタインサーフ" },
+			effect: {
+				ja: "このポケモンにエネルギーがついているなら、このポケモンのにげるためのエネルギーは、すべてなくなる。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "なみのり" },
+			damage: 100,
+			cost: ["Water", "Water", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558666,
+			},
+		},
+	],
+
+	retreat: 3,
+	rarity: "Common",
+	dexId: [226],
+};
+
+export default card;

--- a/data-asia/SM/SM8/028.ts
+++ b/data-asia/SM/SM8/028.ts
@@ -1,0 +1,65 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "スイクンGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 180,
+	types: ["Water"],
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "げんえいのかぜ" },
+			effect: {
+				ja: "このポケモンがベンチにいるなら、自分の番に1回使える。このポケモンと、ついているすべてのカードを、自分の山札にもどして切る。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "キュアストリーム" },
+			damage: 120,
+			cost: ["Water", "Water", "Colorless"],
+			effect: {
+				ja: "次の相手の番、このワザを受けたポケモンが使うワザのダメージは「-30」される。",
+			},
+		},
+		{
+			name: { ja: "ブライニクルGX" },
+			damage: 150,
+			cost: ["Water", "Water", "Colorless"],
+			effect: {
+				ja: "このポケモンをベンチポケモンと入れ替える。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 558667,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Double rare",
+	dexId: [245],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM8/029.ts
+++ b/data-asia/SM/SM8/029.ts
@@ -1,0 +1,49 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヒドイデ",
+	},
+
+	illustrator: "Aya Kusube",
+	category: "Pokemon",
+	hp: 50,
+	types: ["Water"],
+
+	description: {
+		ja: "海底や 海岸を はいまわる。 サニーゴの 頭に 生える サンゴが 大好物だぞ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "とげキャノン" },
+			damage: "30×",
+			cost: ["Water"],
+			effect: {
+				ja: "コインを2回投げ、オモテの数x30ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558668,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [747],
+};
+
+export default card;

--- a/data-asia/SM/SM8/030.ts
+++ b/data-asia/SM/SM8/030.ts
@@ -1,0 +1,60 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ドヒドイデ",
+	},
+
+	illustrator: "kirisAki",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Water"],
+
+	description: {
+		ja: "ドヒドイデの 毒に やられると ３日３晩 激痛に 苦しみ 助かっても 後遺症が 残る。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "どくばり" },
+			cost: ["Water"],
+			effect: {
+				ja: "相手のバトルポケモンをどくにする。",
+			},
+		},
+		{
+			name: { ja: "ベノムフィーバー" },
+			damage: "50×",
+			cost: ["Water", "Water"],
+			effect: {
+				ja: "相手のバトルポケモンがどくなら、相手のバトルポケモンにのっているダメカンの数x50ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558669,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ヒドイデ",
+	},
+
+	retreat: 3,
+	rarity: "Uncommon",
+	dexId: [748],
+};
+
+export default card;

--- a/data-asia/SM/SM8/031.ts
+++ b/data-asia/SM/SM8/031.ts
@@ -1,0 +1,53 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "チョンチー",
+	},
+
+	illustrator: "Akira Komayama",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Lightning"],
+
+	description: {
+		ja: "光の 届かない 海底に 暮らす。 触手を 光らせ 仲間と コミュニケーション。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "でんじは" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "コインを1回投げオモテなら、相手のバトルポケモンをマヒにする。",
+			},
+		},
+		{
+			name: { ja: "ピッカリだま" },
+			damage: 20,
+			cost: ["Lightning", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Metal", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558670,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [170],
+};
+
+export default card;

--- a/data-asia/SM/SM8/032.ts
+++ b/data-asia/SM/SM8/032.ts
@@ -1,0 +1,60 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ランターン",
+	},
+
+	illustrator: "Ken Sugimori",
+	category: "Pokemon",
+	hp: 110,
+	types: ["Lightning"],
+
+	description: {
+		ja: "強い 光を 放ち 獲物の 目を くらませる。 隙が できたら 電撃を お見舞いする。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "サルベージ" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分のトラッシュにあるグッズを4枚、相手に見せてから、山札にもどして切る。",
+			},
+		},
+		{
+			name: { ja: "シグナルビーム" },
+			damage: 50,
+			cost: ["Lightning", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをこんらんにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Metal", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558671,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "チョンチー",
+	},
+
+	retreat: 2,
+	rarity: "Uncommon",
+	dexId: [171],
+};
+
+export default card;

--- a/data-asia/SM/SM8/033.ts
+++ b/data-asia/SM/SM8/033.ts
@@ -1,0 +1,56 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "メリープ",
+	},
+
+	illustrator: "Midori Harada",
+	category: "Pokemon",
+	hp: 50,
+	types: ["Lightning"],
+
+	description: {
+		ja: "ふかふかの 体毛は 空気を たくさん 含んで 夏は 涼しく 冬は 温かいのが 特徴。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ふわふわまくら" },
+			effect: {
+				ja: "このポケモンがバトル場にいるなら、自分の番に1回使える。相手のバトルポケモンをねむりにする。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "たいあたり" },
+			damage: 20,
+			cost: ["Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Metal", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558672,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [179],
+};
+
+export default card;

--- a/data-asia/SM/SM8/034.ts
+++ b/data-asia/SM/SM8/034.ts
@@ -1,0 +1,49 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "メリープ",
+	},
+
+	illustrator: "0313",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Lightning"],
+
+	description: {
+		ja: "ふかふかの 体毛は 空気を たくさん 含んで 夏は 涼しく 冬は 温かいのが 特徴。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "でんきショック" },
+			damage: 10,
+			cost: ["Lightning"],
+			effect: {
+				ja: "コインを1回投げオモテなら、相手のバトルポケモンをマヒにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Metal", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558673,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [179],
+};
+
+export default card;

--- a/data-asia/SM/SM8/035.ts
+++ b/data-asia/SM/SM8/035.ts
@@ -1,0 +1,53 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "モココ",
+	},
+
+	illustrator: "Mizue",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Lightning"],
+
+	description: {
+		ja: "体毛に ためた 電気が 満タンになると 尻尾が 光る。 触れると しびれる 毛を 飛ばす。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "シグナルビーム" },
+			damage: 40,
+			cost: ["Lightning", "Lightning"],
+			effect: {
+				ja: "相手のバトルポケモンをこんらんにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Metal", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558674,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "メリープ",
+	},
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [180],
+};
+
+export default card;

--- a/data-asia/SM/SM8/036.ts
+++ b/data-asia/SM/SM8/036.ts
@@ -1,0 +1,62 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "デンリュウ",
+	},
+
+	illustrator: "Satoshi Shirai",
+	category: "Pokemon",
+	hp: 150,
+	types: ["Lightning"],
+
+	description: {
+		ja: "尻尾の 先が 光り輝く。 光は はるか 遠くまで 届き 迷った者の 道標となる。",
+	},
+
+	stage: "Stage2",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "みえざるせんこう" },
+			effect: {
+				ja: "自分の番に1回使える。自分の手札にある[雷]エネルギーを2枚、ロストゾーンに置く。その後、相手のバトルポケモンをマヒにする。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ばくれつだん" },
+			cost: ["Lightning", "Lightning"],
+			effect: {
+				ja: "相手のポケモン2匹に、それぞれ50ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Metal", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 558675,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "モココ",
+	},
+
+	retreat: 2,
+	rarity: "Rare",
+	dexId: [181],
+};
+
+export default card;

--- a/data-asia/SM/SM8/037.ts
+++ b/data-asia/SM/SM8/037.ts
@@ -1,0 +1,49 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ライコウ",
+	},
+
+	illustrator: "Kagemaru Himeno",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Lightning"],
+
+	description: {
+		ja: "体内で 渦巻く 力を 電撃として 出しながら 大地を 駆け巡る 荒々しい ポケモン。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ロストボルテージ" },
+			damage: "30+",
+			cost: ["Lightning", "Colorless"],
+			effect: {
+				ja: "自分のロストゾーンに[雷]エネルギーがあるなら、90ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Metal", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 558676,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Rare",
+	dexId: [243],
+};
+
+export default card;

--- a/data-asia/SM/SM8/038.ts
+++ b/data-asia/SM/SM8/038.ts
@@ -1,0 +1,49 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ネイティ",
+	},
+
+	illustrator: "Anesaki Dynamic",
+	category: "Pokemon",
+	hp: 40,
+	types: ["Psychic"],
+
+	description: {
+		ja: "普段は 地上で エサを 探すが ごくたまに 木の枝に 飛び乗って 木の芽を ついばんだりする。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ロストマーチ" },
+			damage: "20×",
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "自分のロストゾーンにあるポケモン（♢（プリズムスター）をのぞく）の枚数x20ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558677,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [177],
+};
+
+export default card;

--- a/data-asia/SM/SM8/039.ts
+++ b/data-asia/SM/SM8/039.ts
@@ -1,0 +1,58 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ネイティオ",
+	},
+
+	illustrator: "Ken Sugimori",
+	category: "Pokemon",
+	hp: 100,
+	types: ["Psychic"],
+
+	description: {
+		ja: "ほとんど 動かず 鳴きもせず じっとするのは 過去と 未来を 見ているからだと 信じられている。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "エナジーゲイズ" },
+			damage: "30+",
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "相手の手札を見て、その中にエネルギーがあるなら、60ダメージ追加。",
+			},
+		},
+		{
+			name: { ja: "ねんどうだん" },
+			damage: 80,
+			cost: ["Psychic", "Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558678,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ネイティ",
+	},
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [178],
+};
+
+export default card;

--- a/data-asia/SM/SM8/040.ts
+++ b/data-asia/SM/SM8/040.ts
@@ -1,0 +1,60 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "エーフィ",
+	},
+
+	illustrator: "Ryota Murayama",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Psychic"],
+
+	description: {
+		ja: "額の 玉から サイコパワーを 放射して 戦う。 パワーが 尽きると 玉の 色が くすむ。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "ひきつける" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札を3枚引く。",
+			},
+		},
+		{
+			name: { ja: "エナジークラッシュ" },
+			damage: "20+",
+			cost: ["Psychic"],
+			effect: {
+				ja: "相手の場のポケモンについているエネルギーの数x20ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558679,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "イーブイ",
+	},
+
+	retreat: 1,
+	rarity: "Uncommon",
+	dexId: [196],
+};
+
+export default card;

--- a/data-asia/SM/SM8/041.ts
+++ b/data-asia/SM/SM8/041.ts
@@ -1,0 +1,56 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アンノーン",
+	},
+
+	illustrator: "Masakazu Fukuda",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Psychic"],
+
+	description: {
+		ja: "古代文明の 文字に 似ている。 文字が 先か アンノーンが 先か 世界の 七不思議の ひとつ。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "DAMAGE[ダメージ]" },
+			effect: {
+				ja: "このポケモンがバトル場にいるなら、自分の番に1回使える。自分のベンチポケモン全員にのっているダメカンの数が66個以上なら、この対戦は自分の勝ちになる。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "めざめるパワー" },
+			damage: 10,
+			cost: ["Psychic"],
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558680,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Uncommon",
+	dexId: [201],
+};
+
+export default card;

--- a/data-asia/SM/SM8/042.ts
+++ b/data-asia/SM/SM8/042.ts
@@ -1,0 +1,56 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アンノーン",
+	},
+
+	illustrator: "Hasuno",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Psychic"],
+
+	description: {
+		ja: "古代文明の 文字に 似ている。 文字が 先か アンノーンが 先か 世界の 七不思議の ひとつ。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "HAND[ハンド]" },
+			effect: {
+				ja: "このポケモンがバトル場にいるなら、自分の番に1回使える。自分の手札の枚数が35枚以上なら、この対戦は自分の勝ちになる。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "めざめるパワー" },
+			damage: 10,
+			cost: ["Psychic"],
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558681,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Uncommon",
+	dexId: [201],
+};
+
+export default card;

--- a/data-asia/SM/SM8/043.ts
+++ b/data-asia/SM/SM8/043.ts
@@ -1,0 +1,56 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アンノーン",
+	},
+
+	illustrator: "Naoki Saito",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Psychic"],
+
+	description: {
+		ja: "古代文明の 文字に 似ている。 文字が 先か アンノーンが 先か 世界の 七不思議の ひとつ。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "MISSING[ミッシング]" },
+			effect: {
+				ja: "このポケモンがバトル場にいるなら、自分の番に1回使える。相手のロストゾーンにあるサポートの枚数が12枚以上なら、この対戦は自分の勝ちになる。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "めざめるパワー" },
+			damage: 10,
+			cost: ["Psychic"],
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558682,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Uncommon",
+	dexId: [201],
+};
+
+export default card;

--- a/data-asia/SM/SM8/044.ts
+++ b/data-asia/SM/SM8/044.ts
@@ -1,0 +1,59 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ソーナンス",
+	},
+
+	illustrator: "Megumi Mizutani",
+	category: "Pokemon",
+	hp: 110,
+	types: ["Psychic"],
+
+	description: {
+		ja: "真っ黒な 尻尾を 隠すため 暗闇で ひっそりと 生きている。 自分からは 攻撃しない。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "シェードテール" },
+			effect: {
+				ja: "このポケモンがベンチにいるかぎり、おたがいの場の♢（プリズムスター）のポケモンは、ワザが使えず、特性もすべてなくなる。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "はねとばす" },
+			damage: "30+",
+			cost: ["Psychic", "Colorless"],
+			effect: {
+				ja: "コインを1回投げオモテなら、30ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558683,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Uncommon",
+	dexId: [202],
+};
+
+export default card;

--- a/data-asia/SM/SM8/045.ts
+++ b/data-asia/SM/SM8/045.ts
@@ -1,0 +1,56 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "キリンリキ",
+	},
+
+	illustrator: "Ayaka Yoshida",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Psychic"],
+
+	description: {
+		ja: "尻尾にも 小さな 脳がある。 近寄ると においに 反応して かみついて くるので 注意。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ロストおくり" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "相手のトラッシュにある好きなカードを2枚、ロストゾーンに置く。",
+			},
+		},
+		{
+			name: { ja: "マインドショック" },
+			damage: 70,
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "このワザのダメージは弱点・抵抗力を計算しない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558684,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [203],
+};
+
+export default card;

--- a/data-asia/SM/SM8/046.ts
+++ b/data-asia/SM/SM8/046.ts
@@ -1,0 +1,55 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ウツロイド",
+	},
+
+	illustrator: "Megumi Mizutani",
+	category: "Pokemon",
+	hp: 110,
+	types: ["Psychic"],
+
+	description: {
+		ja: "ＵＢの 一種。 意思が あるかは 不明だが 時折 少女の ような 仕草を みせる。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ナイトキャップ" },
+			cost: ["Psychic"],
+			effect: {
+				ja: "このワザは、相手のサイドの残り枚数が2枚のときにだけ使える。相手の場のポケモンが持っているワザを1つ選び、このワザとして使う。",
+			},
+		},
+		{
+			name: { ja: "うつろなしょくしゅ" },
+			cost: ["Psychic"],
+			effect: {
+				ja: "相手のバトルポケモンをどくとこんらんにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 558685,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Rare",
+	dexId: [793],
+};
+
+export default card;

--- a/data-asia/SM/SM8/047.ts
+++ b/data-asia/SM/SM8/047.ts
@@ -1,0 +1,53 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ベベノム",
+	},
+
+	illustrator: "Hitoshi Ariga",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Psychic"],
+
+	description: {
+		ja: "異世界に おいては 旅立ちの パートナーに 選ばれるほど 親しまれている ウルトラビースト。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "アイオープナー" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "ウラになっている自分のサイドのオモテをすべて見てから、もとにもどす。",
+			},
+		},
+		{
+			name: { ja: "つつく" },
+			damage: 20,
+			cost: ["Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558686,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [803],
+};
+
+export default card;

--- a/data-asia/SM/SM8/048.ts
+++ b/data-asia/SM/SM8/048.ts
@@ -1,0 +1,63 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アーゴヨン",
+	},
+
+	illustrator: "Shin Nagasawa",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Psychic"],
+
+	description: {
+		ja: "体内に 数百リットルの 毒液を ためている。 ＵＢと 呼ばれる 生物の 一種。",
+	},
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "チャージアップ" },
+			effect: {
+				ja: "自分の番に1回使える。自分のトラッシュにある基本エネルギーを1枚、このポケモンにつける。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ターニングポイント" },
+			damage: "80+",
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "自分のサイドの残り枚数が3枚なら、80ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 558687,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ベベノム",
+	},
+
+	retreat: 1,
+	rarity: "Rare",
+	dexId: [804],
+};
+
+export default card;

--- a/data-asia/SM/SM8/049.ts
+++ b/data-asia/SM/SM8/049.ts
@@ -1,0 +1,49 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ウソッキー",
+	},
+
+	illustrator: "Ken Sugimori",
+	category: "Pokemon",
+	hp: 110,
+	types: ["Fighting"],
+
+	description: {
+		ja: "お年寄りを 中心に 人気。 緑の 部分が 大きいほど マニアの 評価は あがるらしい。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "つよめにかえす" },
+			damage: "20+",
+			cost: ["Fighting"],
+			effect: {
+				ja: "前の相手の番に、このポケモンがバトル場でワザのダメージを受けていたなら、80ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558688,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Common",
+	dexId: [185],
+};
+
+export default card;

--- a/data-asia/SM/SM8/050.ts
+++ b/data-asia/SM/SM8/050.ts
@@ -1,0 +1,49 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ゴマゾウ",
+	},
+
+	illustrator: "Asako Ito",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Fighting"],
+
+	description: {
+		ja: "体は 小さいが 力持ち。 大人の 人を 軽々と 背中に 乗せて 歩いてしまう。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "とっておき" },
+			damage: 50,
+			cost: ["Fighting", "Colorless"],
+			effect: {
+				ja: "コインを1回投げウラなら、このワザは失敗。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558689,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Common",
+	dexId: [231],
+};
+
+export default card;

--- a/data-asia/SM/SM8/051.ts
+++ b/data-asia/SM/SM8/051.ts
@@ -1,0 +1,63 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ドンファン",
+	},
+
+	illustrator: "Naoyo Kimura",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Fighting"],
+
+	description: {
+		ja: "キバが 長くて 大きいほど 群れの中での ランクが 高い。 キバが 伸びるには 時間が かかる。",
+	},
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "がんじょう" },
+			effect: {
+				ja: "このポケモンのHPがまんたんの状態で、このポケモンがワザのダメージを受けてきぜつするとき、このポケモンはきぜつせず、残りHPが「10」の状態で場に残る。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ローリングスピン" },
+			damage: 70,
+			cost: ["Fighting", "Colorless", "Colorless"],
+			effect: {
+				ja: "次の自分の番、このポケモンの「ローリングスピン」のダメージは「+70」される。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558690,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ゴマゾウ",
+	},
+
+	retreat: 3,
+	rarity: "Uncommon",
+	dexId: [232],
+};
+
+export default card;

--- a/data-asia/SM/SM8/052.ts
+++ b/data-asia/SM/SM8/052.ts
@@ -1,0 +1,57 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "カポエラー",
+	},
+
+	illustrator: "sowsow",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Fighting"],
+
+	description: {
+		ja: "踊るように 華麗で 滑らかな キック技に 見とれていると きつい 一撃を お見舞いされる。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "こうそくスピン" },
+			damage: 30,
+			cost: ["Fighting"],
+			effect: {
+				ja: "このポケモンをベンチポケモンと入れ替える。その後、相手は相手自身のバトルポケモンをベンチポケモンと入れ替える。",
+			},
+		},
+		{
+			name: { ja: "トリプルキック" },
+			damage: "40×",
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "コインを3回投げ、オモテの数x40ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558691,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [237],
+};
+
+export default card;

--- a/data-asia/SM/SM8/053.ts
+++ b/data-asia/SM/SM8/053.ts
@@ -1,0 +1,56 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヨーギラス",
+	},
+
+	illustrator: "Misa Tsutsui",
+	category: "Pokemon",
+	hp: 50,
+	types: ["Fighting"],
+
+	description: {
+		ja: "地底 奥深くで 生まれる。 まわりの 土を たいらげると 地上に 現われ サナギになる。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "もぐる" },
+			effect: {
+				ja: "このポケモンは、ベンチにいるかぎり、ワザのダメージを受けない。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "かみつく" },
+			damage: 10,
+			cost: ["Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558692,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [246],
+};
+
+export default card;

--- a/data-asia/SM/SM8/054.ts
+++ b/data-asia/SM/SM8/054.ts
@@ -1,0 +1,49 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヨーギラス",
+	},
+
+	illustrator: "SATOSHI NAKAI",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Fighting"],
+
+	description: {
+		ja: "地底 奥深くで 生まれる。 まわりの 土を たいらげると 地上に 現われ サナギになる。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "きずをえぐる" },
+			damage: "10+",
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンにダメカンが3個以上のっているなら、70ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558693,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [246],
+};
+
+export default card;

--- a/data-asia/SM/SM8/055.ts
+++ b/data-asia/SM/SM8/055.ts
@@ -1,0 +1,60 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "サナギラス",
+	},
+
+	illustrator: "Yuka Morii",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Fighting"],
+
+	description: {
+		ja: "岩盤のような 硬い 殻に 覆われているが 力は 強く 暴れると 山も 崩れてしまう。",
+	},
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "だんがんしんか" },
+			effect: {
+				ja: "自分の番に、このカードを手札から出して進化させたとき、1回使える。次の相手の番の終わりまで、このポケモンは、相手のポケモンからワザのダメージを受けない。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ぶちかます" },
+			damage: 30,
+			cost: ["Colorless", "Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558694,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ヨーギラス",
+	},
+
+	retreat: 3,
+	rarity: "Common",
+	dexId: [247],
+};
+
+export default card;

--- a/data-asia/SM/SM8/056.ts
+++ b/data-asia/SM/SM8/056.ts
@@ -1,0 +1,49 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アローラニャース",
+	},
+
+	illustrator: "Akira Komayama",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Darkness"],
+
+	description: {
+		ja: "高いプライドを 傷つけられたり 額の 小判を 汚されると 狂ったような ヒステリーを 起こす。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "でばなをくじく" },
+			damage: "10+",
+			cost: [],
+			effect: {
+				ja: "後攻プレイヤーの最初の番なら、60ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558695,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [52],
+};
+
+export default card;

--- a/data-asia/SM/SM8/057.ts
+++ b/data-asia/SM/SM8/057.ts
@@ -1,0 +1,52 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アローラペルシアン",
+	},
+
+	illustrator: "Tomokazu Komiya",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Darkness"],
+
+	description: {
+		ja: "自分以外の すべてを 見下す。 不意打ちや 闇討ちなど ひれつで ひきょうな 戦法を 好む。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "コケおどし 90-" },
+			cost: [],
+			effect: {
+				ja: "相手のバトルポケモンについているエネルギーの数x30ダメージぶん、このワザのダメージは小さくなる。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558696,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "アローラニャース",
+	},
+
+	retreat: 1,
+	rarity: "Uncommon",
+	dexId: [53],
+};
+
+export default card;

--- a/data-asia/SM/SM8/058.ts
+++ b/data-asia/SM/SM8/058.ts
@@ -1,0 +1,58 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ブラッキー",
+	},
+
+	illustrator: "Ryota Murayama",
+	category: "Pokemon",
+	hp: 110,
+	types: ["Darkness"],
+
+	description: {
+		ja: "闇に 溶け込む 黒い 体毛。 じっと 獲物の 隙を うかがい 喉笛 目掛けて 喰いかかる。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "かたきうち" },
+			damage: "30+",
+			cost: ["Darkness"],
+			effect: {
+				ja: "前の相手の番に、ワザのダメージで、自分のポケモンがきぜつしていたなら、90ダメージ追加。",
+			},
+		},
+		{
+			name: { ja: "ダークカッター" },
+			damage: 60,
+			cost: ["Darkness", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558697,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "イーブイ",
+	},
+
+	retreat: 1,
+	rarity: "Uncommon",
+	dexId: [197],
+};
+
+export default card;

--- a/data-asia/SM/SM8/059.ts
+++ b/data-asia/SM/SM8/059.ts
@@ -1,0 +1,69 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "バンギラスGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 250,
+	types: ["Darkness"],
+
+	stage: "Stage2",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ロストアウト" },
+			effect: {
+				ja: "このポケモンのワザのダメージで、相手のポケモンがきぜつしたなら、そのポケモンと、ついているすべてのカードはトラッシュせず、ロストゾーンに置く。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "あばれさじん" },
+			damage: 130,
+			cost: ["Darkness", "Darkness", "Colorless"],
+			effect: {
+				ja: "相手のベンチのたねポケモン全員にも、それぞれ30ダメージ。[ベンチは弱点・抵抗力を計算しない。]",
+			},
+		},
+		{
+			name: { ja: "スマックダウンGX" },
+			damage: 220,
+			cost: ["Darkness", "Darkness", "Colorless"],
+			effect: {
+				ja: "このワザのダメージは、相手のバトルポケモンにかかっている効果を計算しない。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 558698,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "サナギラス",
+	},
+
+	retreat: 3,
+	rarity: "Double rare",
+	dexId: [248],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM8/060.ts
+++ b/data-asia/SM/SM8/060.ts
@@ -1,0 +1,60 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "フォレトス",
+	},
+
+	illustrator: "tetsuya koizumi",
+	category: "Pokemon",
+	hp: 110,
+	types: ["Metal"],
+
+	description: {
+		ja: "木に くっついたまま 動かない。 硬い殻の 破片を ばらまいて 近づくものを 追い払う。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "トゲトゲふんしゃ" },
+			cost: ["Metal"],
+			effect: {
+				ja: "コインを3回投げ、オモテの数x10ダメージを、相手のポケモン全員にそれぞれ与える。［ベンチは弱点・抵抗力を計算しない。］",
+			},
+		},
+		{
+			name: { ja: "ロストボンバー" },
+			damage: 190,
+			cost: ["Metal", "Metal", "Colorless"],
+			effect: {
+				ja: "このポケモンと、ついているすべてのカードを、ロストゾーンに置く。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558699,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "クヌギダマ",
+	},
+
+	retreat: 2,
+	rarity: "Uncommon",
+	dexId: [205],
+};
+
+export default card;

--- a/data-asia/SM/SM8/061.ts
+++ b/data-asia/SM/SM8/061.ts
@@ -1,0 +1,63 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ハッサム",
+	},
+
+	illustrator: "Anesaki Dynamic",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Metal"],
+
+	description: {
+		ja: "ひとたび 敵と 認識すると 鋼鉄の 硬度を 持つ ハサミで 容赦なく 叩き潰す。",
+	},
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "かたいからだ" },
+			effect: {
+				ja: "このポケモンが受けるワザのダメージは「-30」される。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "スペシャルブロー" },
+			damage: "60+",
+			cost: ["Metal", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンに特殊エネルギーがついているなら、70ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 558700,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ストライク",
+	},
+
+	retreat: 1,
+	rarity: "Rare",
+	dexId: [212],
+};
+
+export default card;

--- a/data-asia/SM/SM8/062.ts
+++ b/data-asia/SM/SM8/062.ts
@@ -1,0 +1,46 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "マリル",
+	},
+
+	illustrator: "Ken Sugimori",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Fairy"],
+
+	description: {
+		ja: "尻尾の 先には 水より 軽い 油が つまっているので 浮き袋の かわりに なるのだ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "マジカルショット" },
+			damage: 30,
+			cost: ["Fairy", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [{ type: "Darkness", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558701,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Common",
+	dexId: [183],
+};
+
+export default card;

--- a/data-asia/SM/SM8/063.ts
+++ b/data-asia/SM/SM8/063.ts
@@ -1,0 +1,60 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "マリルリ",
+	},
+
+	illustrator: "Naoyo Kimura",
+	category: "Pokemon",
+	hp: 100,
+	types: ["Fairy"],
+
+	description: {
+		ja: "お腹の 泡のような 模様は 水の 中で 自分の 姿を カモフラージュ してくれる。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "みずたまさがし" },
+			cost: ["Fairy"],
+			effect: {
+				ja: "自分の山札を上から8枚見て、その中にあるエネルギーを好きなだけ、自分のポケモンに好きなようにつける。残りのカードは山札にもどして切る。",
+			},
+		},
+		{
+			name: { ja: "じゃれつく" },
+			damage: "60+",
+			cost: ["Fairy", "Colorless", "Colorless"],
+			effect: {
+				ja: "コインを1回投げオモテなら、30ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [{ type: "Darkness", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558702,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "マリル",
+	},
+
+	retreat: 2,
+	rarity: "Common",
+	dexId: [184],
+};
+
+export default card;

--- a/data-asia/SM/SM8/064.ts
+++ b/data-asia/SM/SM8/064.ts
@@ -1,0 +1,49 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ブルー",
+	},
+
+	illustrator: "Akira Komayama",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Fairy"],
+
+	description: {
+		ja: "唸り声は 相手を 不安に させる。 普段は のんびり屋で １日の 半分は 寝ているよ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ちらかす" },
+			damage: "20×",
+			cost: ["Fairy"],
+			effect: {
+				ja: "自分の手札にあるトレーナーズを2枚までトラッシュし、その枚数x20ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [{ type: "Darkness", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558703,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Common",
+	dexId: [209],
+};
+
+export default card;

--- a/data-asia/SM/SM8/065.ts
+++ b/data-asia/SM/SM8/065.ts
@@ -1,0 +1,58 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "グランブル",
+	},
+
+	illustrator: "Shin Nagasawa",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Fairy"],
+
+	description: {
+		ja: "ブルー 以上に 臆病。 見た目との ギャップが うけて 若い 女性に 大人気。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "スッカラカン" },
+			damage: "30+",
+			cost: ["Fairy"],
+			effect: {
+				ja: "自分の手札が1枚もないなら、130ダメージ追加。",
+			},
+		},
+		{
+			name: { ja: "きょだいなキバ" },
+			damage: 110,
+			cost: ["Fairy", "Fairy", "Fairy"],
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [{ type: "Darkness", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558704,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ブルー",
+	},
+
+	retreat: 3,
+	rarity: "Uncommon",
+	dexId: [210],
+};
+
+export default card;

--- a/data-asia/SM/SM8/066.ts
+++ b/data-asia/SM/SM8/066.ts
@@ -1,0 +1,56 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ラッキー",
+	},
+
+	illustrator: "MAHOU",
+	category: "Pokemon",
+	hp: 100,
+	types: ["Colorless"],
+
+	description: {
+		ja: "数が 少ないうえに 逃げ足の 速い ポケモンなので 見つけた 人は 運が いいぞ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "いやしのまい" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分のポケモン全員のHPを、それぞれ「20」回復する。",
+			},
+		},
+		{
+			name: { ja: "いたわりビンタ" },
+			damage: 100,
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンにダメカンがのっているなら、このワザは失敗。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558705,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Common",
+	dexId: [113],
+};
+
+export default card;

--- a/data-asia/SM/SM8/067.ts
+++ b/data-asia/SM/SM8/067.ts
@@ -1,0 +1,63 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ハピナス",
+	},
+
+	illustrator: "MAHOU",
+	category: "Pokemon",
+	hp: 160,
+	types: ["Colorless"],
+
+	description: {
+		ja: "ふわふわの 体毛は センサー。 ポケモンや 人の 気持ちを キャッチすることが できるのだ。",
+	},
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ハッピーサプリ" },
+			effect: {
+				ja: "自分の番に1回使える。自分のバトルポケモンの特殊状態を1つ回復する。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "パワフルビンタ" },
+			damage: "80×",
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンについているエネルギーの数ぶんコインを投げ、オモテの数x80ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 558706,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ラッキー",
+	},
+
+	retreat: 3,
+	rarity: "Rare",
+	dexId: [242],
+};
+
+export default card;

--- a/data-asia/SM/SM8/068.ts
+++ b/data-asia/SM/SM8/068.ts
@@ -1,0 +1,46 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "イーブイ",
+	},
+
+	illustrator: "Sekio",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Colorless"],
+
+	description: {
+		ja: "今 現在の 調査では なんと ８種類もの ポケモンへ 進化する 可能性を 持つ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "かじる" },
+			damage: 20,
+			cost: ["Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558707,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [133],
+};
+
+export default card;

--- a/data-asia/SM/SM8/069.ts
+++ b/data-asia/SM/SM8/069.ts
@@ -1,0 +1,56 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "オドシシ",
+	},
+
+	illustrator: "Midori Harada",
+	category: "Pokemon",
+	hp: 110,
+	types: ["Colorless"],
+
+	description: {
+		ja: "ツノの 曲がり具合が まわりの 空気の 流れを 微妙に 変え 不思議な 空間を 作り出す。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "つのでまどわす" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをこんらんにする。",
+			},
+		},
+		{
+			name: { ja: "きょうかホーン" },
+			damage: "20+",
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンに「ポケモンのどうぐ」がついているなら、60ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558708,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Common",
+	dexId: [234],
+};
+
+export default card;

--- a/data-asia/SM/SM8/070.ts
+++ b/data-asia/SM/SM8/070.ts
@@ -1,0 +1,56 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ドーブル",
+	},
+
+	illustrator: "Ken Sugimori",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Colorless"],
+
+	description: {
+		ja: "自分の 縄張りを 示す マークを 描き散らすので ドーブルの 多い 街の 壁は 落書き だらけ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "そっくりなぞる" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "相手の手札を見る。のぞむなら、その中にあるサポートを1枚選び、その効果を、このワザの効果として使う。",
+			},
+		},
+		{
+			name: { ja: "テールスマッシュ" },
+			damage: 30,
+			cost: ["Colorless"],
+			effect: {
+				ja: "コインを1回投げウラなら、このワザは失敗。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558709,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Uncommon",
+	dexId: [235],
+};
+
+export default card;

--- a/data-asia/SM/SM8/071.ts
+++ b/data-asia/SM/SM8/071.ts
@@ -1,0 +1,49 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ミルタンク",
+	},
+
+	illustrator: "Naoki Saito",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Colorless"],
+
+	description: {
+		ja: "ミルクを 採るため 育てる 人が ほとんどだが かなり たくましくて タフなので 戦いにも 向いている。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ミルクほう" },
+			damage: "60×",
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "自分の手札にある「モーモーミルク」を好きなだけ相手に見せて、その枚数x60ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558710,
+			},
+		},
+	],
+
+	retreat: 3,
+	rarity: "Uncommon",
+	dexId: [241],
+};
+
+export default card;

--- a/data-asia/SM/SM8/072.ts
+++ b/data-asia/SM/SM8/072.ts
@@ -1,0 +1,62 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ルギアGX",
+	},
+
+	illustrator: "PLANETA Igarashi",
+	category: "Pokemon",
+	hp: 190,
+	types: ["Colorless"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "サイコキネシス" },
+			damage: "30+",
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンについているエネルギーの数x30ダメージ追加。",
+			},
+		},
+		{
+			name: { ja: "わだつみのやいば" },
+			damage: 170,
+			cost: ["Colorless", "Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "次の自分の番、このポケモンは「わだつみのやいば」が使えない。",
+			},
+		},
+		{
+			name: { ja: "ロストパージGX" },
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンと、ついているすべてのカードを、ロストゾーンに置く。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 558711,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Double rare",
+	dexId: [249],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM8/073.ts
+++ b/data-asia/SM/SM8/073.ts
@@ -1,0 +1,49 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ツツケラ",
+	},
+
+	illustrator: "Miki Tanaka",
+	category: "Pokemon",
+	hp: 50,
+	types: ["Colorless"],
+
+	description: {
+		ja: "きのみが 餌。 喰らった後の タネを 弾として 口から 発射し 攻撃に 利用。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "つつきおとす" },
+			damage: 10,
+			cost: ["Colorless"],
+			effect: {
+				ja: "ダメージを与える前に、相手のバトルポケモンについている「ポケモンのどうぐ」をトラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558712,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [731],
+};
+
+export default card;

--- a/data-asia/SM/SM8/074.ts
+++ b/data-asia/SM/SM8/074.ts
@@ -1,0 +1,53 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ツツケラ",
+	},
+
+	illustrator: "Suwama Chiaki",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Colorless"],
+
+	description: {
+		ja: "きのみが 餌。 喰らった後の タネを 弾として 口から 発射し 攻撃に 利用。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "つきかえす" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをベンチポケモンと入れ替える。［バトル場に出すポケモンは相手が選ぶ。］",
+			},
+		},
+		{
+			name: { ja: "つつく" },
+			damage: 20,
+			cost: ["Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558713,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [731],
+};
+
+export default card;

--- a/data-asia/SM/SM8/075.ts
+++ b/data-asia/SM/SM8/075.ts
@@ -1,0 +1,60 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ケララッパ",
+	},
+
+	illustrator: "Shin Nagasawa",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Colorless"],
+
+	description: {
+		ja: "クチバシを 反り返らせ 色んな 音で 鳴く。 かなり うるさいので 周りの 御宅には 嫌われるぞ。",
+	},
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "やまわたり" },
+			effect: {
+				ja: "このカードが手札にあるなら、自分の番に1回使えて、使ったなら、このカードをロストゾーンに置く。相手の山札を上から1枚見て、もとにもどす。そのカードがサポートの場合、のぞむなら、ロストゾーンに置く。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "つつく" },
+			damage: 30,
+			cost: ["Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558714,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ツツケラ",
+	},
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [732],
+};
+
+export default card;

--- a/data-asia/SM/SM8/076.ts
+++ b/data-asia/SM/SM8/076.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ドデカバシ",
+	},
+
+	illustrator: "Kouki Saitou",
+	category: "Pokemon",
+	hp: 140,
+	types: ["Colorless"],
+
+	description: {
+		ja: "体内の ガスを クチバシの 中で 爆発させ 木のタネを 発射。 大岩も 粉々にする パワー。",
+	},
+
+	stage: "Stage2",
+
+	attacks: [
+		{
+			name: { ja: "ヒートビーク" },
+			damage: 40,
+			cost: ["Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをやけどにする。",
+			},
+		},
+		{
+			name: { ja: "ドデカほう" },
+			damage: 160,
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "この番、このポケモンに進化していたなら、このワザは失敗。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558715,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ケララッパ",
+	},
+
+	retreat: 2,
+	rarity: "Uncommon",
+	dexId: [733],
+};
+
+export default card;

--- a/data-asia/SM/SM8/077.ts
+++ b/data-asia/SM/SM8/077.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "あとだしハンマー",
+	},
+
+	illustrator: "Yoshinobu Saito",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードは、後攻プレイヤーの最初の番しか使えない。相手の場のポケモンについているエネルギーを、1個トラッシュする。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558716,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM8/078.ts
+++ b/data-asia/SM/SM8/078.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ハイパーボール",
+	},
+
+	illustrator: "Ryo Ueda",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードは、自分の手札を2枚トラッシュしなければ使えない。自分の山札からポケモンを1枚選び、相手に見せてから、手札に加える。そして山札を切る。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558717,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM8/079.ts
+++ b/data-asia/SM/SM8/079.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ふしぎなアメ",
+	},
+
+	illustrator: "Toyste Beach",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分のたねポケモン1匹から進化する1進化の上の2進化ポケモンを、手札から1枚選び、そのたねポケモンにのせて進化させる。[最初の自分の番と、この番出したばかりのたねポケモンには使えない。]",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558718,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM8/080.ts
+++ b/data-asia/SM/SM8/080.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ポケモンいれかえ",
+	},
+
+	illustrator: "Ryo Ueda",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分のバトルポケモンをベンチポケモンと入れ替える。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558719,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM8/081.ts
+++ b/data-asia/SM/SM8/081.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ポケモンキャッチャー",
+	},
+
+	illustrator: "Toyste Beach",
+	category: "Trainer",
+
+	effect: {
+		ja: "相手のベンチポケモンを1匹選び、バトルポケモンと入れ替える。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558720,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM8/082.ts
+++ b/data-asia/SM/SM8/082.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "モーモーミルク",
+	},
+
+	illustrator: "Ayaka Yoshida",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分のポケモンを1匹選ぶ。コインを2回投げ、オモテの数x30ダメージぶん、そのポケモンのHPを回復する。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558721,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM8/083.ts
+++ b/data-asia/SM/SM8/083.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ロストミキサー",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の手札を2枚、ロストゾーンに置く。その後、自分の山札を1枚引く。（自分の手札を2枚、ロストゾーンに置けないなら、このカードは使えない。）",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558722,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM8/084.ts
+++ b/data-asia/SM/SM8/084.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "こだわりハチマキ",
+	},
+
+	illustrator: "Eske Yoshinob",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードをつけているポケモンが使うワザの、相手のバトル場の「ポケモンGX・EX」へのダメージは「+30」される。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558723,
+			},
+		},
+	],
+
+	trainerType: "Tool",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM8/085.ts
+++ b/data-asia/SM/SM8/085.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "こだわりメット",
+	},
+
+	illustrator: "Eske Yoshinob",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードをつけているポケモンが、相手の「ポケモンGX・EX」から受けるワザのダメージは「-30」される。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558724,
+			},
+		},
+	],
+
+	trainerType: "Tool",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM8/086.ts
+++ b/data-asia/SM/SM8/086.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "フェアリーチャーム草",
+	},
+
+	illustrator: "Toyste Beach",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードがついているポケモンは、相手のタイプの「ポケモンGX・EX」からワザのダメージを受けない。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558725,
+			},
+		},
+	],
+
+	trainerType: "Tool",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM8/087.ts
+++ b/data-asia/SM/SM8/087.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アカネ",
+	},
+
+	illustrator: "Ken Sugimori",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の山札を1枚引く。自分のトラッシュに「アカネ」（このカードをのぞく）があるなら、その枚数x2枚ぶん、さらに山札を引く。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558726,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM8/088.ts
+++ b/data-asia/SM/SM8/088.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ウツギ博士のレクチャー",
+	},
+
+	illustrator: "Hideki Ishikawa",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の山札にある、HPが「60」以下のポケモンを3枚まで、相手に見せてから、手札に加える。そして山札を切る。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558727,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM8/089.ts
+++ b/data-asia/SM/SM8/089.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ザオボー",
+	},
+
+	illustrator: "take",
+	category: "Trainer",
+
+	effect: {
+		ja: "相手の場のポケモンについている「ポケモンのどうぐ」「特殊エネルギー」と場に出ている「スタジアム」の中から1枚、ロストゾーンに置く。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558728,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM8/090.ts
+++ b/data-asia/SM/SM8/090.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ハウ",
+	},
+
+	illustrator: "TOKIYA",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の山札を3枚引く。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558729,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM8/091.ts
+++ b/data-asia/SM/SM8/091.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "リーリエ",
+	},
+
+	illustrator: "Sanosuke Sakuma",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の手札が6枚になるように、山札を引く。最初の自分の番に使ったなら、8枚になるように引く。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558730,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM8/092.ts
+++ b/data-asia/SM/SM8/092.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ルザミーネ",
+	},
+
+	illustrator: "nagimiso",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードは、相手のサイドの残り枚数が3枚でなければ使えない。次の相手の番、自分の「ウルトラビースト」全員は、相手のポケモンからワザのダメージを受けない。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 558731,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	rarity: "Rare Holo",
+};
+
+export default card;

--- a/data-asia/SM/SM8/093.ts
+++ b/data-asia/SM/SM8/093.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヒートファクトリー",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Trainer",
+
+	effect: {
+		ja: "おたがいのプレイヤーは、自分の番ごとに1回、自分の手札にある[炎]エネルギーを、1枚トラッシュしてよい。トラッシュした場合、自分の山札を3枚引く。このスタジアムは、場に出ているかぎり、おたがいのプレイヤーが手札からグッズまたはサポートを出して使ったとき、その効果を受けない。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 558732,
+			},
+		},
+	],
+
+	trainerType: "Stadium",
+	rarity: "Rare Holo",
+};
+
+export default card;

--- a/data-asia/SM/SM8/094.ts
+++ b/data-asia/SM/SM8/094.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ダブル無色エネルギー",
+	},
+
+	illustrator: "",
+	category: "Energy",
+	energyType: "Special",
+
+	effect: {
+		ja: "このカードは、[無]エネルギー2個ぶんとしてはたらく。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558733,
+			},
+		},
+	],
+
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM8/095.ts
+++ b/data-asia/SM/SM8/095.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "メモリーエネルギー",
+	},
+
+	illustrator: "",
+	category: "Energy",
+	energyType: "Special",
+
+	effect: {
+		ja: "このカードは、[無]エネルギー1個ぶんとしてはたらく。このカードをつけているポケモンは、進化前に持っていたワザを、すべて使える。［ワザを使うためのエネルギーは必要。］",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558734,
+			},
+		},
+	],
+
+	rarity: "Common",
+};
+
+export default card;

--- a/data-asia/SM/SM8/096.ts
+++ b/data-asia/SM/SM8/096.ts
@@ -1,0 +1,64 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ツボツボGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 170,
+	types: ["Grass"],
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "まもりのツボ" },
+			effect: {
+				ja: "このポケモンは、ついているエネルギーが2個以下の相手のポケモンから、ワザのダメージを受けない。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "さんばいどく" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをどくにする。このどくでのせるダメカンの数は3個になる。",
+			},
+		},
+		{
+			name: { ja: "まきつくGX" },
+			damage: 40,
+			cost: ["Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをマヒにする。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 558735,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Ultra Rare",
+	dexId: [213],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM8/097.ts
+++ b/data-asia/SM/SM8/097.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ズガドーンGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 180,
+	types: ["Fire"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "さくれつバーナー" },
+			cost: ["Fire"],
+			effect: {
+				ja: "相手のバトルポケモンをやけどとこんらんにする。",
+			},
+		},
+		{
+			name: { ja: "ビックリヘッド" },
+			damage: "50×",
+			cost: ["Fire", "Fire"],
+			effect: {
+				ja: "自分の場のポケモンについている[炎]エネルギーを好きなだけロストゾーンに置き、その枚数x50ダメージ。",
+			},
+		},
+		{
+			name: { ja: "バーストGX" },
+			cost: ["Fire"],
+			effect: {
+				ja: "自分のサイドを1枚トラッシュし、そのカードがエネルギーなら、自分のポケモンにつける。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 558736,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Ultra Rare",
+	dexId: [806],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM8/098.ts
+++ b/data-asia/SM/SM8/098.ts
@@ -1,0 +1,65 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "スイクンGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 180,
+	types: ["Water"],
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "げんえいのかぜ" },
+			effect: {
+				ja: "このポケモンがベンチにいるなら、自分の番に1回使える。このポケモンと、ついているすべてのカードを、自分の山札にもどして切る。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "キュアストリーム" },
+			damage: 120,
+			cost: ["Water", "Water", "Colorless"],
+			effect: {
+				ja: "次の相手の番、このワザを受けたポケモンが使うワザのダメージは「-30」される。",
+			},
+		},
+		{
+			name: { ja: "ブライニクルGX" },
+			damage: 150,
+			cost: ["Water", "Water", "Colorless"],
+			effect: {
+				ja: "このポケモンをベンチポケモンと入れ替える。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 558737,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Ultra Rare",
+	dexId: [245],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM8/099.ts
+++ b/data-asia/SM/SM8/099.ts
@@ -1,0 +1,69 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "バンギラスGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 250,
+	types: ["Darkness"],
+
+	stage: "Stage2",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ロストアウト" },
+			effect: {
+				ja: "このポケモンのワザのダメージで、相手のポケモンがきぜつしたなら、そのポケモンと、ついているすべてのカードはトラッシュせず、ロストゾーンに置く。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "あばれさじん" },
+			damage: 130,
+			cost: ["Darkness", "Darkness", "Colorless"],
+			effect: {
+				ja: "相手のベンチのたねポケモン全員にも、それぞれ30ダメージ。[ベンチは弱点・抵抗力を計算しない。]",
+			},
+		},
+		{
+			name: { ja: "スマックダウンGX" },
+			damage: 220,
+			cost: ["Darkness", "Darkness", "Colorless"],
+			effect: {
+				ja: "このワザのダメージは、相手のバトルポケモンにかかっている効果を計算しない。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 558738,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "サナギラス",
+	},
+
+	retreat: 3,
+	rarity: "Ultra Rare",
+	dexId: [248],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM8/100.ts
+++ b/data-asia/SM/SM8/100.ts
@@ -1,0 +1,62 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ルギアGX",
+	},
+
+	illustrator: "PLANETA Igarashi",
+	category: "Pokemon",
+	hp: 190,
+	types: ["Colorless"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "サイコキネシス" },
+			damage: "30+",
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンについているエネルギーの数x30ダメージ追加。",
+			},
+		},
+		{
+			name: { ja: "わだつみのやいば" },
+			damage: 170,
+			cost: ["Colorless", "Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "次の自分の番、このポケモンは「わだつみのやいば」が使えない。",
+			},
+		},
+		{
+			name: { ja: "ロストパージGX" },
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンと、ついているすべてのカードを、ロストゾーンに置く。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 558739,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Ultra Rare",
+	dexId: [249],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM8/101.ts
+++ b/data-asia/SM/SM8/101.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アカネ",
+	},
+
+	illustrator: "Sanosuke Sakuma",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の山札を1枚引く。自分のトラッシュに「アカネ」（このカードをのぞく）があるなら、その枚数x2枚ぶん、さらに山札を引く。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 558740,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	rarity: "Ultra Rare",
+};
+
+export default card;

--- a/data-asia/SM/SM8/102.ts
+++ b/data-asia/SM/SM8/102.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ウツギ博士のレクチャー",
+	},
+
+	illustrator: "Hideki Ishikawa",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の山札にある、HPが「60」以下のポケモンを3枚まで、相手に見せてから、手札に加える。そして山札を切る。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 558741,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	rarity: "Ultra Rare",
+};
+
+export default card;

--- a/data-asia/SM/SM8/103.ts
+++ b/data-asia/SM/SM8/103.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ザオボー",
+	},
+
+	illustrator: "take",
+	category: "Trainer",
+
+	effect: {
+		ja: "相手の場のポケモンについている「ポケモンのどうぐ」「特殊エネルギー」と場に出ている「スタジアム」の中から1枚、ロストゾーンに置く。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 558742,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	rarity: "Ultra Rare",
+};
+
+export default card;

--- a/data-asia/SM/SM8/104.ts
+++ b/data-asia/SM/SM8/104.ts
@@ -1,0 +1,64 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ツボツボGX",
+	},
+
+	illustrator: "",
+	category: "Pokemon",
+	hp: 170,
+	types: ["Grass"],
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "まもりのツボ" },
+			effect: {
+				ja: "このポケモンは、ついているエネルギーが2個以下の相手のポケモンから、ワザのダメージを受けない。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "さんばいどく" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをどくにする。このどくでのせるダメカンの数は3個になる。",
+			},
+		},
+		{
+			name: { ja: "まきつくGX" },
+			damage: 40,
+			cost: ["Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをマヒにする。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 558743,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Hyper rare",
+	dexId: [213],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM8/105.ts
+++ b/data-asia/SM/SM8/105.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ズガドーンGX",
+	},
+
+	illustrator: "",
+	category: "Pokemon",
+	hp: 180,
+	types: ["Fire"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "さくれつバーナー" },
+			cost: ["Fire"],
+			effect: {
+				ja: "相手のバトルポケモンをやけどとこんらんにする。",
+			},
+		},
+		{
+			name: { ja: "ビックリヘッド" },
+			damage: "50×",
+			cost: ["Fire", "Fire"],
+			effect: {
+				ja: "自分の場のポケモンについている[炎]エネルギーを好きなだけロストゾーンに置き、その枚数x50ダメージ。",
+			},
+		},
+		{
+			name: { ja: "バーストGX" },
+			cost: ["Fire"],
+			effect: {
+				ja: "自分のサイドを1枚トラッシュし、そのカードがエネルギーなら、自分のポケモンにつける。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 558744,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Hyper rare",
+	dexId: [806],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM8/106.ts
+++ b/data-asia/SM/SM8/106.ts
@@ -1,0 +1,65 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "スイクンGX",
+	},
+
+	illustrator: "",
+	category: "Pokemon",
+	hp: 180,
+	types: ["Water"],
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "げんえいのかぜ" },
+			effect: {
+				ja: "このポケモンがベンチにいるなら、自分の番に1回使える。このポケモンと、ついているすべてのカードを、自分の山札にもどして切る。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "キュアストリーム" },
+			damage: 120,
+			cost: ["Water", "Water", "Colorless"],
+			effect: {
+				ja: "次の相手の番、このワザを受けたポケモンが使うワザのダメージは「-30」される。",
+			},
+		},
+		{
+			name: { ja: "ブライニクルGX" },
+			damage: 150,
+			cost: ["Water", "Water", "Colorless"],
+			effect: {
+				ja: "このポケモンをベンチポケモンと入れ替える。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 558745,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Hyper rare",
+	dexId: [245],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM8/107.ts
+++ b/data-asia/SM/SM8/107.ts
@@ -1,0 +1,69 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "バンギラスGX",
+	},
+
+	illustrator: "",
+	category: "Pokemon",
+	hp: 250,
+	types: ["Darkness"],
+
+	stage: "Stage2",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ロストアウト" },
+			effect: {
+				ja: "このポケモンのワザのダメージで、相手のポケモンがきぜつしたなら、そのポケモンと、ついているすべてのカードはトラッシュせず、ロストゾーンに置く。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "あばれさじん" },
+			damage: 130,
+			cost: ["Darkness", "Darkness", "Colorless"],
+			effect: {
+				ja: "相手のベンチのたねポケモン全員にも、それぞれ30ダメージ。[ベンチは弱点・抵抗力を計算しない。]",
+			},
+		},
+		{
+			name: { ja: "スマックダウンGX" },
+			damage: 220,
+			cost: ["Darkness", "Darkness", "Colorless"],
+			effect: {
+				ja: "このワザのダメージは、相手のバトルポケモンにかかっている効果を計算しない。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 558746,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "サナギラス",
+	},
+
+	retreat: 3,
+	rarity: "Hyper rare",
+	dexId: [248],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM8/108.ts
+++ b/data-asia/SM/SM8/108.ts
@@ -1,0 +1,62 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ルギアGX",
+	},
+
+	illustrator: "",
+	category: "Pokemon",
+	hp: 190,
+	types: ["Colorless"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "サイコキネシス" },
+			damage: "30+",
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンについているエネルギーの数x30ダメージ追加。",
+			},
+		},
+		{
+			name: { ja: "わだつみのやいば" },
+			damage: 170,
+			cost: ["Colorless", "Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "次の自分の番、このポケモンは「わだつみのやいば」が使えない。",
+			},
+		},
+		{
+			name: { ja: "ロストパージGX" },
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンと、ついているすべてのカードを、ロストゾーンに置く。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 558747,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Hyper rare",
+	dexId: [249],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM8/109.ts
+++ b/data-asia/SM/SM8/109.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "あとだしハンマー",
+	},
+
+	illustrator: "",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードは、後攻プレイヤーの最初の番しか使えない。相手の場のポケモンについているエネルギーを、1個トラッシュする。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 558748,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	rarity: "Secret Rare",
+};
+
+export default card;

--- a/data-asia/SM/SM8/110.ts
+++ b/data-asia/SM/SM8/110.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ロストミキサー",
+	},
+
+	illustrator: "",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の手札を2枚、ロストゾーンに置く。その後、自分の山札を1枚引く。（自分の手札を2枚、ロストゾーンに置けないなら、このカードは使えない。）",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 558749,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	rarity: "Secret Rare",
+};
+
+export default card;

--- a/data-asia/SM/SM8/111.ts
+++ b/data-asia/SM/SM8/111.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "こだわりメット",
+	},
+
+	illustrator: "",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードをつけているポケモンが、相手の「ポケモンGX・EX」から受けるワザのダメージは「-30」される。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 558750,
+			},
+		},
+	],
+
+	trainerType: "Tool",
+	rarity: "Secret Rare",
+};
+
+export default card;


### PR DESCRIPTION
## What

Adds the complete Japanese set **SM8 超爆インパクト (Super Burst Impact)**, released 2018-09-07:

- `data-asia/SM/SM8/001.ts` … `111.ts` — all 111 cards (95 regular + 16 secret rares: 8 SR, 5 UR, 3 Secret Rare)
- the set definition `data-asia/SM/SM8.ts` already existed and is untouched

## Data sources

- **pokemon-card.com** (official database): Japanese names, flavor texts, National Dex numbers, official card count
- **limitlesstcg.com**: full Japanese card text, stages, weaknesses/resistances/retreat, rarities, illustrators, attack costs
- **Cardmarket**: product IDs as `thirdParty.cardmarket` on the variant objects (558640–558750; tcgplayer IDs not available to me)

## Notes

- Follows the file format and conventions of the M-era sets (#1728)
- No `regulationMark` (the set predates regulation marks); resistances are `-20` per the era
- All 111 files type-check against `interfaces.d.ts` (`tsc --noEmit`)
