### PR TITLE
(data) Add Japanese SM set SM8a Dark Order

### DIFF
--- a/data-asia/SM/SM8a/001.ts
+++ b/data-asia/SM/SM8a/001.ts
@@ -1,0 +1,49 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ニャビー",
+	},
+
+	illustrator: "sui",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Fire"],
+
+	description: {
+		ja: "感情を ださず 独りで いることを 好む。 信頼を 得るまでには 時間が かかるぞ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ツメをだす" },
+			damage: "10+",
+			cost: ["Colorless"],
+			effect: {
+				ja: "コインを1回投げオモテなら、10ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558575,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [725],
+};
+
+export default card;

--- a/data-asia/SM/SM8a/002.ts
+++ b/data-asia/SM/SM8a/002.ts
@@ -1,0 +1,57 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ニャヒート",
+	},
+
+	illustrator: "Sanosuke Sakuma",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Fire"],
+
+	description: {
+		ja: "前足の 力が 自慢。 パンチの 一撃で 鉄の棒も へし曲げて しまうのだ。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "ほえる" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをベンチポケモンと入れ替える。［バトル場に出すポケモンは相手が選ぶ。］",
+			},
+		},
+		{
+			name: { ja: "ツメできりさく" },
+			damage: 60,
+			cost: ["Colorless", "Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558576,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ニャビー",
+	},
+
+	retreat: 2,
+	rarity: "Common",
+	dexId: [726],
+};
+
+export default card;

--- a/data-asia/SM/SM8a/003.ts
+++ b/data-asia/SM/SM8a/003.ts
@@ -1,0 +1,49 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "サンダー",
+	},
+
+	illustrator: "kawayoo",
+	category: "Pokemon",
+	hp: 110,
+	types: ["Lightning"],
+
+	description: {
+		ja: "雷雲の 中に いると 言われる 伝説の ポケモン。 雷を 自在に 操る。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "アサルトサンダー" },
+			damage: "10+",
+			cost: ["Lightning"],
+			effect: {
+				ja: "この番、このポケモンがベンチからバトル場に出ていたなら、70ダメージ追加。このワザのダメージは弱点を計算しない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 558577,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Rare",
+	dexId: [145],
+};
+
+export default card;

--- a/data-asia/SM/SM8a/004.ts
+++ b/data-asia/SM/SM8a/004.ts
@@ -1,0 +1,49 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "メリープ",
+	},
+
+	illustrator: "Akira Komayama",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Lightning"],
+
+	description: {
+		ja: "ふかふかの 体毛は 空気を たくさん 含んで 夏は 涼しく 冬は 温かいのが 特徴。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ショックボルト" },
+			damage: 30,
+			cost: ["Lightning"],
+			effect: {
+				ja: "このポケモンについている[雷]エネルギーを、すべてトラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Metal", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558578,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [179],
+};
+
+export default card;

--- a/data-asia/SM/SM8a/005.ts
+++ b/data-asia/SM/SM8a/005.ts
@@ -1,0 +1,58 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "モココ",
+	},
+
+	illustrator: "Shibuzoh.",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Lightning"],
+
+	description: {
+		ja: "体毛に ためた 電気が 満タンになると 尻尾が 光る。 触れると しびれる 毛を 飛ばす。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "ビリリパンチ" },
+			damage: 30,
+			cost: ["Lightning"],
+		},
+		{
+			name: { ja: "ショックボルト" },
+			damage: 60,
+			cost: ["Lightning", "Lightning"],
+			effect: {
+				ja: "このポケモンについている[雷]エネルギーを、すべてトラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Metal", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558579,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "メリープ",
+	},
+
+	retreat: 2,
+	rarity: "Common",
+	dexId: [180],
+};
+
+export default card;

--- a/data-asia/SM/SM8a/006.ts
+++ b/data-asia/SM/SM8a/006.ts
@@ -1,0 +1,66 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "デンリュウGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 240,
+	types: ["Lightning"],
+
+	stage: "Stage2",
+
+	attacks: [
+		{
+			name: { ja: "パワーリチャージ" },
+			damage: 30,
+			cost: ["Lightning"],
+			effect: {
+				ja: "自分のトラッシュにある「エレキパワー」をすべて、相手に見せてから、手札に加える。",
+			},
+		},
+		{
+			name: { ja: "インパクトボルト" },
+			damage: 150,
+			cost: ["Lightning", "Lightning"],
+			effect: {
+				ja: "このポケモンについている[雷]エネルギーを、すべてトラッシュする。",
+			},
+		},
+		{
+			name: { ja: "エレクトリカルGX" },
+			cost: ["Lightning"],
+			effect: {
+				ja: "自分の山札にあるポケモンを7枚まで、相手に見せてから、手札に加える。そして山札を切る。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Metal", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 558580,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "モココ",
+	},
+
+	retreat: 3,
+	rarity: "Double rare",
+	dexId: [181],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM8a/007.ts
+++ b/data-asia/SM/SM8a/007.ts
@@ -1,0 +1,53 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "シママ",
+	},
+
+	illustrator: "Akira Komayama",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Lightning"],
+
+	description: {
+		ja: "放電すると たてがみが 光る。 たてがみが 輝く 回数や リズムで 仲間と 会話している。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "おとどけダッシュ" },
+			cost: ["Lightning"],
+			effect: {
+				ja: "自分の山札にある「エレキパワー」を2枚まで、相手に見せてから、手札に加える。そして山札を切る。",
+			},
+		},
+		{
+			name: { ja: "エレキック" },
+			damage: 20,
+			cost: ["Lightning", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Metal", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558581,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [522],
+};
+
+export default card;

--- a/data-asia/SM/SM8a/008.ts
+++ b/data-asia/SM/SM8a/008.ts
@@ -1,0 +1,58 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ゼブライカ",
+	},
+
+	illustrator: "Shin Nagasawa",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Lightning"],
+
+	description: {
+		ja: "稲妻のような 瞬発力。 ゼブライカが 全速力で 走ると 雷鳴が 響きわたる。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "しゅうげき" },
+			damage: "30+",
+			cost: ["Lightning", "Colorless"],
+			effect: {
+				ja: "この番、このポケモンが「シママ」から進化していたなら、90ダメージ追加。",
+			},
+		},
+		{
+			name: { ja: "マッハボルト" },
+			damage: 100,
+			cost: ["Lightning", "Lightning", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Metal", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558582,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "シママ",
+	},
+
+	retreat: 1,
+	rarity: "Uncommon",
+	dexId: [523],
+};
+
+export default card;

--- a/data-asia/SM/SM8a/009.ts
+++ b/data-asia/SM/SM8a/009.ts
@@ -1,0 +1,58 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "エモンガ",
+	},
+
+	illustrator: "Megumi Mizutani",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Lightning"],
+
+	description: {
+		ja: "電撃で 木の実や むしポケモンを こんがり 焼いて 喰う。 ツツケラが 空けた 木の穴が 主な 巣だ。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ほっぺのつどい" },
+			effect: {
+				ja: "自分の番に1回使える。自分の山札にあるワザ「ほっぺすりすり」を持つポケモンを1枚、相手に見せてから、手札に加える。そして山札を切る。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ほっぺすりすり" },
+			cost: ["Lightning"],
+			effect: {
+				ja: "コインを1回投げオモテなら、相手のバトルポケモンをマヒにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558583,
+			},
+		},
+	],
+
+	retreat: 0,
+	rarity: "Common",
+	dexId: [587],
+};
+
+export default card;

--- a/data-asia/SM/SM8a/010.ts
+++ b/data-asia/SM/SM8a/010.ts
@@ -1,0 +1,49 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "バチュル",
+	},
+
+	illustrator: "Yuka Morii",
+	category: "Pokemon",
+	hp: 40,
+	types: ["Lightning"],
+
+	description: {
+		ja: "体の 大きな ポケモンに とりついて 静電気を 吸い取り 蓄電袋に 電気を ためる。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "きゅうけつ" },
+			damage: 10,
+			cost: ["Lightning"],
+			effect: {
+				ja: "相手のバトルポケモンに与えたダメージぶん、このポケモンのHPを回復する。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Metal", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558584,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [595],
+};
+
+export default card;

--- a/data-asia/SM/SM8a/011.ts
+++ b/data-asia/SM/SM8a/011.ts
@@ -1,0 +1,63 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "デンチュラ",
+	},
+
+	illustrator: "SATOSHI NAKAI",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Lightning"],
+
+	description: {
+		ja: "敵に 襲われると 電気を 帯びた 糸を たくさん 吐き出して 電気の バリアを 作る。",
+	},
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "きんちょうかん" },
+			effect: {
+				ja: "このポケモンは、相手が手札からグッズまたはサポートを出して使ったとき、その効果を受けない。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "スパイダースレッド" },
+			damage: 40,
+			cost: ["Lightning"],
+			effect: {
+				ja: "自分のトラッシュにある好きなカードを1枚、相手に見せてから、手札に加える。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Metal", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558585,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "バチュル",
+	},
+
+	retreat: 1,
+	rarity: "Uncommon",
+	dexId: [596],
+};
+
+export default card;

--- a/data-asia/SM/SM8a/012.ts
+++ b/data-asia/SM/SM8a/012.ts
@@ -1,0 +1,51 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "エリキテル",
+	},
+
+	illustrator: "Ken Sugimori",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Lightning"],
+
+	description: {
+		ja: "頭の 両わきの ひだには 太陽の 光を 浴びると 発電する 細胞が あるのだ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "はたく" },
+			damage: 10,
+			cost: ["Colorless"],
+		},
+		{
+			name: { ja: "バチバチ" },
+			damage: 40,
+			cost: ["Lightning", "Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Metal", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558586,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [694],
+};
+
+export default card;

--- a/data-asia/SM/SM8a/013.ts
+++ b/data-asia/SM/SM8a/013.ts
@@ -1,0 +1,60 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "エレザード",
+	},
+
+	illustrator: "Sumiyoshi Kizuki",
+	category: "Pokemon",
+	hp: 100,
+	types: ["Lightning"],
+
+	description: {
+		ja: "電気で 筋肉を 刺激すると １００メートルを ５秒で 走る 脚力に パワーアップする。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "でんじスパーク" },
+			cost: ["Lightning"],
+			effect: {
+				ja: "相手のポケモン1匹に、30ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+			},
+		},
+		{
+			name: { ja: "ボルトチェンジ" },
+			damage: 90,
+			cost: ["Lightning", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンをベンチの[雷]ポケモンと入れ替える。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Metal", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558587,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "エリキテル",
+	},
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [695],
+};
+
+export default card;

--- a/data-asia/SM/SM8a/014.ts
+++ b/data-asia/SM/SM8a/014.ts
@@ -1,0 +1,52 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "カプ・コケコ",
+	},
+
+	illustrator: "Kouki Saitou",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Lightning"],
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "せんじんのまい" },
+			effect: {
+				ja: "このポケモンがベンチにいるなら、自分の番に1回使える。自分のベンチポケモン2匹に、トラッシュにある[雷]エネルギーを1枚ずつつける。その後、このカードをロストゾーンに置く。（ついているカードは、すべてトラッシュする。）",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "マッハボルト" },
+			damage: 120,
+			cost: ["Lightning", "Lightning", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Metal", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 558588,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Rare Holo",
+	dexId: [785],
+};
+
+export default card;

--- a/data-asia/SM/SM8a/015.ts
+++ b/data-asia/SM/SM8a/015.ts
@@ -1,0 +1,49 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヨーギラス",
+	},
+
+	illustrator: "Ken Sugimori",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Fighting"],
+
+	description: {
+		ja: "地底 奥深くで 生まれる。 まわりの 土を たいらげると 地上に 現われ サナギになる。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "なしくずし" },
+			damage: 30,
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "このワザのダメージは、相手のバトルポケモンにかかっている効果を計算しない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558589,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Common",
+	dexId: [246],
+};
+
+export default card;

--- a/data-asia/SM/SM8a/016.ts
+++ b/data-asia/SM/SM8a/016.ts
@@ -1,0 +1,53 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "サナギラス",
+	},
+
+	illustrator: "Anesaki Dynamic",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Fighting"],
+
+	description: {
+		ja: "岩盤のような 硬い 殻に 覆われているが 力は 強く 暴れると 山も 崩れてしまう。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "しっぺがえし" },
+			damage: "30+",
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "相手のサイドの残り枚数が1枚なら、90ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558590,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ヨーギラス",
+	},
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [247],
+};
+
+export default card;

--- a/data-asia/SM/SM8a/017.ts
+++ b/data-asia/SM/SM8a/017.ts
@@ -1,0 +1,49 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヤンチャム",
+	},
+
+	illustrator: "Yuka Morii",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Fighting"],
+
+	description: {
+		ja: "咥えている 葉っぱに 意味は なく ただの かっこつけ。 やんちゃなので 素人トレーナーには 向かない。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "つっぱり" },
+			damage: 40,
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "コインを1回投げウラなら、このワザは失敗。オモテなら、相手のバトルポケモンについているエネルギーを、1個トラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558591,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Common",
+	dexId: [674],
+};
+
+export default card;

--- a/data-asia/SM/SM8a/018.ts
+++ b/data-asia/SM/SM8a/018.ts
@@ -1,0 +1,49 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アローラベトベター",
+	},
+
+	illustrator: "SATOSHI NAKAI",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Darkness"],
+
+	description: {
+		ja: "結晶は 毒素の 塊。 ベトベターの 身体から 落ちると 死に至る 毒素が 漏れだすぞ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ケミカルブレス" },
+			damage: "20+",
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンが受けている特殊状態の数x50ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558592,
+			},
+		},
+	],
+
+	retreat: 3,
+	rarity: "Common",
+	dexId: [88],
+};
+
+export default card;

--- a/data-asia/SM/SM8a/019.ts
+++ b/data-asia/SM/SM8a/019.ts
@@ -1,0 +1,63 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アローラベトベトン",
+	},
+
+	illustrator: "Midori Harada",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Darkness"],
+
+	description: {
+		ja: "意外に 大人しく なつくが 餌の ゴミを ずっと あげていないと 家の 家具を 壊して 喰らいだす。",
+	},
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "いかものぐい" },
+			effect: {
+				ja: "自分の番に、このカードを手札から出して進化させたとき、1回使える。相手の山札を上から6枚見て、その中にあるグッズを、好きなだけトラッシュする。残りのカードは山札にもどして切る。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ダストシュート" },
+			damage: 80,
+			cost: ["Darkness", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをどくにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558593,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "アローラベトベター",
+	},
+
+	retreat: 3,
+	rarity: "Uncommon",
+	dexId: [89],
+};
+
+export default card;

--- a/data-asia/SM/SM8a/020.ts
+++ b/data-asia/SM/SM8a/020.ts
@@ -1,0 +1,60 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "バンギラス",
+	},
+
+	illustrator: "Hasuno",
+	category: "Pokemon",
+	hp: 170,
+	types: ["Darkness"],
+
+	description: {
+		ja: "バンギラスが 暴れると 山が 崩れ 川が 埋まるため 地図を 書き換える ことになる。",
+	},
+
+	stage: "Stage2",
+
+	attacks: [
+		{
+			name: { ja: "スピンテール" },
+			cost: ["Darkness", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のポケモン全員に、それぞれ30ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+			},
+		},
+		{
+			name: { ja: "かみちぎる" },
+			damage: "130+",
+			cost: ["Darkness", "Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンが「ポケモンGX・EX」なら、100ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 558594,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "サナギラス",
+	},
+
+	retreat: 4,
+	rarity: "Rare",
+	dexId: [248],
+};
+
+export default card;

--- a/data-asia/SM/SM8a/021.ts
+++ b/data-asia/SM/SM8a/021.ts
@@ -1,0 +1,53 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ポチエナ",
+	},
+
+	illustrator: "Ken Sugimori",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Darkness"],
+
+	description: {
+		ja: "鋭い きゅうかくで ねらった 獲物は 絶対に 逃がさない。 とっても しつこい 性格だ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "やみのとおぼえ" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札にある[悪]ポケモンを2枚まで、相手に見せてから、手札に加える。そして山札を切る。",
+			},
+		},
+		{
+			name: { ja: "かみつく" },
+			damage: 10,
+			cost: ["Darkness"],
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558595,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [261],
+};
+
+export default card;

--- a/data-asia/SM/SM8a/022.ts
+++ b/data-asia/SM/SM8a/022.ts
@@ -1,0 +1,58 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "グラエナ",
+	},
+
+	illustrator: "kirisAki",
+	category: "Pokemon",
+	hp: 100,
+	types: ["Darkness"],
+
+	description: {
+		ja: "１０匹 程度の 群れを 作って 一糸乱れぬ チームワークで 獲物を 追いつめて しとめるのだ。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "かみつく" },
+			damage: 30,
+			cost: ["Darkness"],
+		},
+		{
+			name: { ja: "あんこくのキバ" },
+			damage: 50,
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "相手の手札からオモテを見ないで、1枚トラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558596,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ポチエナ",
+	},
+
+	retreat: 1,
+	rarity: "Uncommon",
+	dexId: [262],
+};
+
+export default card;

--- a/data-asia/SM/SM8a/023.ts
+++ b/data-asia/SM/SM8a/023.ts
@@ -1,0 +1,59 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アブソル",
+	},
+
+	illustrator: "nagimiso",
+	category: "Pokemon",
+	hp: 100,
+	types: ["Darkness"],
+
+	description: {
+		ja: "災いを もたらすと いわれるが 実際には おだやかな 性質。 災害の 危機を 人に 伝える。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "あくのはき" },
+			effect: {
+				ja: "このポケモンがいるかぎり、相手のバトル場のたねポケモンのにげるためのエネルギーは、1個ぶん多くなる。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "シャドーシーカー" },
+			damage: "30+",
+			cost: ["Darkness", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンのにげるためのエネルギーの数x30ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 558597,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Rare",
+	dexId: [359],
+};
+
+export default card;

--- a/data-asia/SM/SM8a/024.ts
+++ b/data-asia/SM/SM8a/024.ts
@@ -1,0 +1,53 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ミカルゲ",
+	},
+
+	illustrator: "HYOGONOSUKE",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Darkness"],
+
+	description: {
+		ja: "５００年前に 悪さをしたため 要石の ひび割れに 体を つなぎとめられてしまった。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ソウルコンプレッサー" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札にあるポケモンを4枚まで、トラッシュする。そして山札を切る。",
+			},
+		},
+		{
+			name: { ja: "ホロウショット" },
+			damage: 20,
+			cost: ["Colorless"],
+		},
+	],
+
+	weaknesses: [],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558598,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [442],
+};
+
+export default card;

--- a/data-asia/SM/SM8a/025.ts
+++ b/data-asia/SM/SM8a/025.ts
@@ -1,0 +1,48 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ゾロア",
+	},
+
+	illustrator: "Naoyo Kimura",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Darkness"],
+
+	description: {
+		ja: "人や ほかの ポケモンに 化ける。 自分の 正体を 隠すことで 危険から 身を 守っているのだ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "やみにかくれる" },
+			cost: ["Darkness"],
+			effect: {
+				ja: "このポケモンをベンチポケモンと入れ替える。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558599,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [570],
+};
+
+export default card;

--- a/data-asia/SM/SM8a/026.ts
+++ b/data-asia/SM/SM8a/026.ts
@@ -1,0 +1,60 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ゾロアーク",
+	},
+
+	illustrator: "Masakazu Fukuda",
+	category: "Pokemon",
+	hp: 110,
+	types: ["Darkness"],
+
+	description: {
+		ja: "相手を 化かす ことで 群れの 安全を 守ってきた ポケモン。 仲間同士の 結束が 固い。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "ちょうはつ" },
+			cost: ["Darkness"],
+			effect: {
+				ja: "相手のベンチポケモンを1匹選び、バトルポケモンと入れ替える。",
+			},
+		},
+		{
+			name: { ja: "ナイトパニッシュ" },
+			damage: "20×",
+			cost: ["Darkness", "Colorless", "Colorless"],
+			effect: {
+				ja: "自分のトラッシュにあるポケモンの枚数x20ダメージ。与えられるダメージはポケモン10枚ぶんまで。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 558600,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ゾロア",
+	},
+
+	retreat: 2,
+	rarity: "Rare",
+	dexId: [571],
+};
+
+export default card;

--- a/data-asia/SM/SM8a/027.ts
+++ b/data-asia/SM/SM8a/027.ts
@@ -1,0 +1,53 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "バルチャイ",
+	},
+
+	illustrator: "Eri Yamaki",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Darkness"],
+
+	description: {
+		ja: "まだまだ 遊び盛り。 羽が 未熟で 飛べないので ぴょんぴょん 跳ね回っているよ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "もってくる" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札を1枚引く。",
+			},
+		},
+		{
+			name: { ja: "どつく" },
+			damage: 10,
+			cost: ["Darkness"],
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558601,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [629],
+};
+
+export default card;

--- a/data-asia/SM/SM8a/028.ts
+++ b/data-asia/SM/SM8a/028.ts
@@ -1,0 +1,60 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "バルジーナ",
+	},
+
+	illustrator: "Ayaka Yoshida",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Darkness"],
+
+	description: {
+		ja: "大空を 旋回 しながら 弱った ポケモンを 狙っている。 大好物は カラカラ。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "ゴミおとし" },
+			cost: ["Darkness"],
+			effect: {
+				ja: "自分の手札にあるグッズを1枚トラッシュし、相手のポケモン1匹に、弱点・抵抗力を計算せず、60ダメージ。トラッシュできないなら、このワザは失敗。",
+			},
+		},
+		{
+			name: { ja: "ブレイブバード" },
+			damage: 120,
+			cost: ["Darkness", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンにも30ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558602,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "バルチャイ",
+	},
+
+	retreat: 2,
+	rarity: "Uncommon",
+	dexId: [630],
+};
+
+export default card;

--- a/data-asia/SM/SM8a/029.ts
+++ b/data-asia/SM/SM8a/029.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ゴロンダ",
+	},
+
+	illustrator: "Satoshi Shirai",
+	category: "Pokemon",
+	hp: 140,
+	types: ["Darkness"],
+
+	description: {
+		ja: "竹の 葉っぱの 揺れで 敵の 動きを 読む。 ケンカっ早いが 仲間への 情は 厚い。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "シメる" },
+			damage: 60,
+			cost: ["Darkness", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手は相手自身の手札を、2枚トラッシュする。",
+			},
+		},
+		{
+			name: { ja: "あばれまわる" },
+			damage: 170,
+			cost: ["Darkness", "Darkness", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンをこんらんにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558603,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ヤンチャム",
+	},
+
+	retreat: 4,
+	rarity: "Uncommon",
+	dexId: [675],
+};
+
+export default card;

--- a/data-asia/SM/SM8a/030.ts
+++ b/data-asia/SM/SM8a/030.ts
@@ -1,0 +1,57 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "イベルタル",
+	},
+
+	illustrator: "Misa Tsutsui",
+	category: "Pokemon",
+	hp: 110,
+	types: ["Darkness"],
+
+	description: {
+		ja: "寿命が つきるとき あらゆる 生き物の 命を 吸いつくし 繭の 姿に 戻るという。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "くつがえす" },
+			damage: 30,
+			cost: ["Darkness"],
+			effect: {
+				ja: "相手のバトルポケモンについている特殊エネルギーを、1個トラッシュする。",
+			},
+		},
+		{
+			name: { ja: "わしづかみ" },
+			damage: 60,
+			cost: ["Darkness", "Darkness"],
+			effect: {
+				ja: "次の相手の番、このワザを受けたポケモンは、にげられない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 558604,
+			},
+		},
+	],
+
+	retreat: 0,
+	rarity: "Rare",
+	dexId: [717],
+};
+
+export default card;

--- a/data-asia/SM/SM8a/031.ts
+++ b/data-asia/SM/SM8a/031.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "フーパGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 190,
+	types: ["Darkness"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ローグリング" },
+			cost: ["Darkness"],
+			effect: {
+				ja: "自分の山札にある好きなカードを2枚まで、手札に加える。そして山札を切る。",
+			},
+		},
+		{
+			name: { ja: "ダークストライク" },
+			damage: 160,
+			cost: ["Darkness", "Darkness", "Darkness"],
+			effect: {
+				ja: "次の自分の番、このポケモンは「ダークストライク」が使えない。",
+			},
+		},
+		{
+			name: { ja: "デビルハンドGX" },
+			cost: ["Darkness", "Darkness", "Darkness"],
+			effect: {
+				ja: "相手の「ポケモンGX・EX」を6回選び、選んだポケモン全員に、弱点・抵抗力を計算せず、選んだ回数x30ダメージ。（1匹を2回以上選べる。）［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 558605,
+			},
+		},
+	],
+
+	retreat: 3,
+	rarity: "Double rare",
+	dexId: [720],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM8a/032.ts
+++ b/data-asia/SM/SM8a/032.ts
@@ -1,0 +1,69 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ガオガエンGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 250,
+	types: ["Darkness"],
+
+	stage: "Stage2",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "スカーチャージ" },
+			effect: {
+				ja: "自分の番に1回使える。このポケモンにダメカンを3個のせる。その後、自分の山札にある[悪]エネルギーを3枚まで、このポケモンにつける。そして山札を切る。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "クラッシュパンチ" },
+			damage: 130,
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンについている特殊エネルギーを、1個トラッシュする。",
+			},
+		},
+		{
+			name: { ja: "DDトルネードGX" },
+			damage: "10+",
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンにのっているダメカンの数x50ダメージ追加。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 558606,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ニャヒート",
+	},
+
+	retreat: 3,
+	rarity: "Double rare",
+	dexId: [727],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM8a/033.ts
+++ b/data-asia/SM/SM8a/033.ts
@@ -1,0 +1,57 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "エアームド",
+	},
+
+	illustrator: "kirisAki",
+	category: "Pokemon",
+	hp: 110,
+	types: ["Metal"],
+
+	description: {
+		ja: "鉄の 身体は 頑丈だが さびやすいので 雨の 日は 巣穴で じっと しているよ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "カームストライク" },
+			damage: "20+",
+			cost: ["Metal", "Colorless"],
+			effect: {
+				ja: "自分がすでにGXワザを使っていたなら、70ダメージ追加。",
+			},
+		},
+		{
+			name: { ja: "はがねのつばさ" },
+			damage: 90,
+			cost: ["Metal", "Metal", "Colorless"],
+			effect: {
+				ja: "次の相手の番、このポケモンが受けるワザのダメージは「-30」される。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558607,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Uncommon",
+	dexId: [227],
+};
+
+export default card;

--- a/data-asia/SM/SM8a/034.ts
+++ b/data-asia/SM/SM8a/034.ts
@@ -1,0 +1,56 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ジラーチ",
+	},
+
+	illustrator: "HYOGONOSUKE",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Metal"],
+
+	description: {
+		ja: "１０００年間で ７日だけ 目を 覚まし どんな 願い事でも かなえる 力を 使うという。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ねがいぼし" },
+			effect: {
+				ja: "このポケモンがバトル場にいるなら、自分の番に1回使える。自分の山札を上から5枚見る。その中にあるトレーナーズを1枚、相手に見せてから、手札に加える。残りのカードは山札にもどして切る。その後、このポケモンをねむりにする。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ビンタ" },
+			damage: 30,
+			cost: ["Metal", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 558608,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Rare",
+	dexId: [385],
+};
+
+export default card;

--- a/data-asia/SM/SM8a/035.ts
+++ b/data-asia/SM/SM8a/035.ts
@@ -1,0 +1,56 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ドーミラー",
+	},
+
+	illustrator: "Ken Sugimori",
+	category: "Pokemon",
+	hp: 50,
+	types: ["Metal"],
+
+	description: {
+		ja: "古い お墓から ドーミラーに そっくりな 道具が 掘り出されたが 関係は わかっていない。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ぬけがけしんか" },
+			effect: {
+				ja: "このポケモンは、後攻プレイヤーの最初の番なら、出したばかりでも進化できる。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "たいあたり" },
+			damage: 20,
+			cost: ["Metal", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558609,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [436],
+};
+
+export default card;

--- a/data-asia/SM/SM8a/036.ts
+++ b/data-asia/SM/SM8a/036.ts
@@ -1,0 +1,63 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ドータクン",
+	},
+
+	illustrator: "Misa Tsutsui",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Metal"],
+
+	description: {
+		ja: "ドータクンに 祈りを ささげると 雨が 降り 作物を 育てると 古代の 人々は 信じていた。",
+	},
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "たいねつ" },
+			effect: {
+				ja: "このポケモンは、相手の[炎]ポケモンからワザのダメージを受けない。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "あやしいこくいん" },
+			damage: 70,
+			cost: ["Metal", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをこんらんにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558610,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ドーミラー",
+	},
+
+	retreat: 3,
+	rarity: "Uncommon",
+	dexId: [437],
+};
+
+export default card;

--- a/data-asia/SM/SM8a/037.ts
+++ b/data-asia/SM/SM8a/037.ts
@@ -1,0 +1,49 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "テッシード",
+	},
+
+	illustrator: "Shigenori Negishi",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Metal"],
+
+	description: {
+		ja: "洞穴の 天井に 突きささり 岩の 鉄分を 吸いとる。 危険がせまると トゲを 撃ち出す。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "れんぞくころがり" },
+			damage: "20×",
+			cost: ["Metal"],
+			effect: {
+				ja: "ウラが出るまでコインを投げ、オモテの数x20ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558611,
+			},
+		},
+	],
+
+	retreat: 3,
+	rarity: "Common",
+	dexId: [597],
+};
+
+export default card;

--- a/data-asia/SM/SM8a/038.ts
+++ b/data-asia/SM/SM8a/038.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ナットレイ",
+	},
+
+	illustrator: "Hasuno",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Metal"],
+
+	description: {
+		ja: "洞穴の 天井に はりつき 下を 通る 獲物に 向かって 鉄の トゲを 打ちこみ 襲う。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "ガードプレス" },
+			damage: 20,
+			cost: ["Metal"],
+			effect: {
+				ja: "次の相手の番、このポケモンが受けるワザのダメージは「-20」される。",
+			},
+		},
+		{
+			name: { ja: "スローンポッドスロー" },
+			damage: 80,
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のベンチポケモン1匹にも、このポケモンについている[鋼]エネルギーの数x20ダメージ。ベンチへのダメージは[鋼]エネルギー5個ぶんまで。［ベンチは弱点・抵抗力を計算しない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558612,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "テッシード",
+	},
+
+	retreat: 3,
+	rarity: "Uncommon",
+	dexId: [598],
+};
+
+export default card;

--- a/data-asia/SM/SM8a/039.ts
+++ b/data-asia/SM/SM8a/039.ts
@@ -1,0 +1,53 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "コマタナ",
+	},
+
+	illustrator: "Masakazu Fukuda",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Metal"],
+
+	description: {
+		ja: "自分が 傷ついても 気にせず 集団で 全身の 刃物を 食いこませ 相手を 攻撃する。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "こうちょく" },
+			cost: ["Metal"],
+			effect: {
+				ja: "次の相手の番、このポケモンが受けるワザのダメージは「-30」される。",
+			},
+		},
+		{
+			name: { ja: "ひっかく" },
+			damage: 20,
+			cost: ["Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558613,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [624],
+};
+
+export default card;

--- a/data-asia/SM/SM8a/040.ts
+++ b/data-asia/SM/SM8a/040.ts
@@ -1,0 +1,58 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "キリキザン",
+	},
+
+	illustrator: "Anesaki Dynamic",
+	category: "Pokemon",
+	hp: 110,
+	types: ["Metal"],
+
+	description: {
+		ja: "大勢の コマタナを 従えて 獲物を 群れで 追いつめる。 とどめは キリキザンが 刺す。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "いってんづき" },
+			damage: "30+",
+			cost: ["Metal"],
+			effect: {
+				ja: "このポケモンにダメカンがのっていないなら、90ダメージ追加。",
+			},
+		},
+		{
+			name: { ja: "パワーエッジ" },
+			damage: 90,
+			cost: ["Metal", "Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558614,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "コマタナ",
+	},
+
+	retreat: 2,
+	rarity: "Uncommon",
+	dexId: [625],
+};
+
+export default card;

--- a/data-asia/SM/SM8a/041.ts
+++ b/data-asia/SM/SM8a/041.ts
@@ -1,0 +1,64 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "コバルオンGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 170,
+	types: ["Metal"],
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "メタルシンボル" },
+			effect: {
+				ja: "このポケモンがいるかぎり、[鋼]エネルギーがついている自分のポケモン全員は、特殊状態にならず、受けている特殊状態は、すべて回復する。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "デュエルセーバー" },
+			damage: "50+",
+			cost: ["Metal", "Metal"],
+			effect: {
+				ja: "場にスタジアムが出ているなら、60ダメージ追加。",
+			},
+		},
+		{
+			name: { ja: "てつのおきてGX" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "次の相手の番、相手のポケモン全員はワザが使えない。（新しく出したポケモンも含む。）［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 558615,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Double rare",
+	dexId: [638],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM8a/042.ts
+++ b/data-asia/SM/SM8a/042.ts
@@ -1,0 +1,48 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヒトツキ",
+	},
+
+	illustrator: "sui",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Metal"],
+
+	description: {
+		ja: "剣の 柄を 握った 人の 腕に 青い 布を 巻きつけて 倒れるまで 命を 吸い取る。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "きりおとす" },
+			cost: ["Metal"],
+			effect: {
+				ja: "コインを1回投げオモテなら、相手のバトルポケモンについているエネルギーを、1個トラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558616,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Common",
+	dexId: [679],
+};
+
+export default card;

--- a/data-asia/SM/SM8a/043.ts
+++ b/data-asia/SM/SM8a/043.ts
@@ -1,0 +1,53 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ニダンギル",
+	},
+
+	illustrator: "Shin Nagasawa",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Metal"],
+
+	description: {
+		ja: "２本の 剣による 複雑な 連続攻撃を 防ぐことは 剣の 達人でも 不可能だ。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "どうぐおとし" },
+			damage: "30×",
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "おたがいの場のポケモンについている「ポケモンのどうぐ」の数x30ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558617,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ヒトツキ",
+	},
+
+	retreat: 2,
+	rarity: "Common",
+	dexId: [680],
+};
+
+export default card;

--- a/data-asia/SM/SM8a/044.ts
+++ b/data-asia/SM/SM8a/044.ts
@@ -1,0 +1,63 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ギルガルド",
+	},
+
+	illustrator: "Kagemaru Himeno",
+	category: "Pokemon",
+	hp: 140,
+	types: ["Metal"],
+
+	description: {
+		ja: "王の 素質を 持つ 人間を 見抜くらしい。 認められた 人は やがて 王になると 言われている。",
+	},
+
+	stage: "Stage2",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ロイヤルガード" },
+			effect: {
+				ja: "このポケモンが受けるワザのダメージは「-40」される。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "シールドバッシュ" },
+			damage: 100,
+			cost: ["Metal", "Colorless", "Colorless"],
+			effect: {
+				ja: "このワザのダメージは、相手のバトルポケモンにかかっている効果を計算しない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 558618,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ニダンギル",
+	},
+
+	retreat: 3,
+	rarity: "Rare",
+	dexId: [681],
+};
+
+export default card;

--- a/data-asia/SM/SM8a/045.ts
+++ b/data-asia/SM/SM8a/045.ts
@@ -1,0 +1,56 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "クレッフィ",
+	},
+
+	illustrator: "Shigenori Negishi",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Metal"],
+
+	description: {
+		ja: "頭の角を 金属の すき間に 突っ込んで 金属イオンを 吸う。 なぜか カギを 集めている。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ないしょのカギ" },
+			effect: {
+				ja: "このポケモンがいるかぎり、自分の[鋼]ポケモン全員の抵抗力は、すべて「-40」になる。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ぶつかる" },
+			damage: 30,
+			cost: ["Metal", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558619,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [707],
+};
+
+export default card;

--- a/data-asia/SM/SM8a/046.ts
+++ b/data-asia/SM/SM8a/046.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "エレキチャージャー",
+	},
+
+	illustrator: "Eske Yoshinob",
+	category: "Trainer",
+
+	effect: {
+		ja: "コインを2回投げ、オモテの数ぶん、自分のトラッシュにある「エレキパワー」を、相手に見せてから、山札にもどして切る。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558620,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM8a/047.ts
+++ b/data-asia/SM/SM8a/047.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "エレキパワー",
+	},
+
+	illustrator: "Eske Yoshinob",
+	category: "Trainer",
+
+	effect: {
+		ja: "この番、自分の[雷]ポケモンが使うワザの、相手のバトルポケモンへのダメージは「+30」される。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558621,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM8a/048.ts
+++ b/data-asia/SM/SM8a/048.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "デンジャラスドリル",
+	},
+
+	illustrator: "Toyste Beach",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードは、自分の手札にある[悪]ポケモンを1枚トラッシュしなければ使えない。相手の場のポケモンについている「ポケモンのどうぐ」「特殊エネルギー」と場に出ている「スタジアム」の中から、1枚トラッシュする。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558622,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM8a/049.ts
+++ b/data-asia/SM/SM8a/049.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "メタルゴーグル",
+	},
+
+	illustrator: "Yoshinobu Saito",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードをつけているポケモンは、相手のポケモンから受けるワザのダメージが「-30」され、相手のワザや特性の効果によるダメカンものらない。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558623,
+			},
+		},
+	],
+
+	trainerType: "Tool",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM8a/050.ts
+++ b/data-asia/SM/SM8a/050.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "クチナシ",
+	},
+
+	illustrator: "Ken Sugimori",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分のトラッシュにある[悪]タイプのたねポケモン1枚を、自分の場のポケモン1匹と入れ替える（ついているカード・ダメカン・特殊状態・かかっている効果などは、すべて引きつぐ）。入れ替えたポケモンはトラッシュする。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558624,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM8a/051.ts
+++ b/data-asia/SM/SM8a/051.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ミカン",
+	},
+
+	illustrator: "Ken Sugimori",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の山札にある[鋼]ポケモンを1枚、相手に見せてから、手札に加える。そして山札を切る。後攻プレイヤーの最初の番に使ったなら、手札に加えられる[鋼]ポケモンの枚数は5枚までになる。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558625,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM8a/052.ts
+++ b/data-asia/SM/SM8a/052.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ブラックマーケット",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Trainer",
+
+	effect: {
+		ja: "おたがいの[悪]エネルギーがついている[悪]ポケモンが、相手のポケモンからワザのダメージを受けてきぜつしたとき、とられるサイドは1枚少なくなる。このスタジアムは、場に出ているかぎり、おたがいのプレイヤーが手札からグッズまたはサポートを出して使ったとき、その効果を受けない。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 558626,
+			},
+		},
+	],
+
+	trainerType: "Stadium",
+	rarity: "Rare Holo",
+};
+
+export default card;

--- a/data-asia/SM/SM8a/053.ts
+++ b/data-asia/SM/SM8a/053.ts
@@ -1,0 +1,66 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "デンリュウGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 240,
+	types: ["Lightning"],
+
+	stage: "Stage2",
+
+	attacks: [
+		{
+			name: { ja: "パワーリチャージ" },
+			damage: 30,
+			cost: ["Lightning"],
+			effect: {
+				ja: "自分のトラッシュにある「エレキパワー」をすべて、相手に見せてから、手札に加える。",
+			},
+		},
+		{
+			name: { ja: "インパクトボルト" },
+			damage: 150,
+			cost: ["Lightning", "Lightning"],
+			effect: {
+				ja: "このポケモンについている[雷]エネルギーを、すべてトラッシュする。",
+			},
+		},
+		{
+			name: { ja: "エレクトリカルGX" },
+			cost: ["Lightning"],
+			effect: {
+				ja: "自分の山札にあるポケモンを7枚まで、相手に見せてから、手札に加える。そして山札を切る。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Metal", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 558627,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "モココ",
+	},
+
+	retreat: 3,
+	rarity: "Ultra Rare",
+	dexId: [181],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM8a/054.ts
+++ b/data-asia/SM/SM8a/054.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "フーパGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 190,
+	types: ["Darkness"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ローグリング" },
+			cost: ["Darkness"],
+			effect: {
+				ja: "自分の山札にある好きなカードを2枚まで、手札に加える。そして山札を切る。",
+			},
+		},
+		{
+			name: { ja: "ダークストライク" },
+			damage: 160,
+			cost: ["Darkness", "Darkness", "Darkness"],
+			effect: {
+				ja: "次の自分の番、このポケモンは「ダークストライク」が使えない。",
+			},
+		},
+		{
+			name: { ja: "デビルハンドGX" },
+			cost: ["Darkness", "Darkness", "Darkness"],
+			effect: {
+				ja: "相手の「ポケモンGX・EX」を6回選び、選んだポケモン全員に、弱点・抵抗力を計算せず、選んだ回数x30ダメージ。（1匹を2回以上選べる。）［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 558628,
+			},
+		},
+	],
+
+	retreat: 3,
+	rarity: "Ultra Rare",
+	dexId: [720],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM8a/055.ts
+++ b/data-asia/SM/SM8a/055.ts
@@ -1,0 +1,69 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ガオガエンGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 250,
+	types: ["Darkness"],
+
+	stage: "Stage2",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "スカーチャージ" },
+			effect: {
+				ja: "自分の番に1回使える。このポケモンにダメカンを3個のせる。その後、自分の山札にある[悪]エネルギーを3枚まで、このポケモンにつける。そして山札を切る。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "クラッシュパンチ" },
+			damage: 130,
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンについている特殊エネルギーを、1個トラッシュする。",
+			},
+		},
+		{
+			name: { ja: "DDトルネードGX" },
+			damage: "10+",
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンにのっているダメカンの数x50ダメージ追加。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 558629,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ニャヒート",
+	},
+
+	retreat: 3,
+	rarity: "Ultra Rare",
+	dexId: [727],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM8a/056.ts
+++ b/data-asia/SM/SM8a/056.ts
@@ -1,0 +1,64 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "コバルオンGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 170,
+	types: ["Metal"],
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "メタルシンボル" },
+			effect: {
+				ja: "このポケモンがいるかぎり、[鋼]エネルギーがついている自分のポケモン全員は、特殊状態にならず、受けている特殊状態は、すべて回復する。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "デュエルセーバー" },
+			damage: "50+",
+			cost: ["Metal", "Metal"],
+			effect: {
+				ja: "場にスタジアムが出ているなら、60ダメージ追加。",
+			},
+		},
+		{
+			name: { ja: "てつのおきてGX" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "次の相手の番、相手のポケモン全員はワザが使えない。（新しく出したポケモンも含む。）［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 558630,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Ultra Rare",
+	dexId: [638],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM8a/057.ts
+++ b/data-asia/SM/SM8a/057.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "クチナシ",
+	},
+
+	illustrator: "Hitoshi Ariga",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分のトラッシュにある[悪]タイプのたねポケモン1枚を、自分の場のポケモン1匹と入れ替える（ついているカード・ダメカン・特殊状態・かかっている効果などは、すべて引きつぐ）。入れ替えたポケモンはトラッシュする。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 558631,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	rarity: "Ultra Rare",
+};
+
+export default card;

--- a/data-asia/SM/SM8a/058.ts
+++ b/data-asia/SM/SM8a/058.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ミカン",
+	},
+
+	illustrator: "Hideki Ishikawa",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の山札にある[鋼]ポケモンを1枚、相手に見せてから、手札に加える。そして山札を切る。後攻プレイヤーの最初の番に使ったなら、手札に加えられる[鋼]ポケモンの枚数は5枚までになる。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 558632,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	rarity: "Ultra Rare",
+};
+
+export default card;

--- a/data-asia/SM/SM8a/059.ts
+++ b/data-asia/SM/SM8a/059.ts
@@ -1,0 +1,66 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "デンリュウGX",
+	},
+
+	illustrator: "",
+	category: "Pokemon",
+	hp: 240,
+	types: ["Lightning"],
+
+	stage: "Stage2",
+
+	attacks: [
+		{
+			name: { ja: "パワーリチャージ" },
+			damage: 30,
+			cost: ["Lightning"],
+			effect: {
+				ja: "自分のトラッシュにある「エレキパワー」をすべて、相手に見せてから、手札に加える。",
+			},
+		},
+		{
+			name: { ja: "インパクトボルト" },
+			damage: 150,
+			cost: ["Lightning", "Lightning"],
+			effect: {
+				ja: "このポケモンについている[雷]エネルギーを、すべてトラッシュする。",
+			},
+		},
+		{
+			name: { ja: "エレクトリカルGX" },
+			cost: ["Lightning"],
+			effect: {
+				ja: "自分の山札にあるポケモンを7枚まで、相手に見せてから、手札に加える。そして山札を切る。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Metal", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 558633,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "モココ",
+	},
+
+	retreat: 3,
+	rarity: "Hyper rare",
+	dexId: [181],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM8a/060.ts
+++ b/data-asia/SM/SM8a/060.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "フーパGX",
+	},
+
+	illustrator: "",
+	category: "Pokemon",
+	hp: 190,
+	types: ["Darkness"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ローグリング" },
+			cost: ["Darkness"],
+			effect: {
+				ja: "自分の山札にある好きなカードを2枚まで、手札に加える。そして山札を切る。",
+			},
+		},
+		{
+			name: { ja: "ダークストライク" },
+			damage: 160,
+			cost: ["Darkness", "Darkness", "Darkness"],
+			effect: {
+				ja: "次の自分の番、このポケモンは「ダークストライク」が使えない。",
+			},
+		},
+		{
+			name: { ja: "デビルハンドGX" },
+			cost: ["Darkness", "Darkness", "Darkness"],
+			effect: {
+				ja: "相手の「ポケモンGX・EX」を6回選び、選んだポケモン全員に、弱点・抵抗力を計算せず、選んだ回数x30ダメージ。（1匹を2回以上選べる。）［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 558634,
+			},
+		},
+	],
+
+	retreat: 3,
+	rarity: "Hyper rare",
+	dexId: [720],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM8a/061.ts
+++ b/data-asia/SM/SM8a/061.ts
@@ -1,0 +1,69 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ガオガエンGX",
+	},
+
+	illustrator: "",
+	category: "Pokemon",
+	hp: 250,
+	types: ["Darkness"],
+
+	stage: "Stage2",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "スカーチャージ" },
+			effect: {
+				ja: "自分の番に1回使える。このポケモンにダメカンを3個のせる。その後、自分の山札にある[悪]エネルギーを3枚まで、このポケモンにつける。そして山札を切る。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "クラッシュパンチ" },
+			damage: 130,
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンについている特殊エネルギーを、1個トラッシュする。",
+			},
+		},
+		{
+			name: { ja: "DDトルネードGX" },
+			damage: "10+",
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンにのっているダメカンの数x50ダメージ追加。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 558635,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ニャヒート",
+	},
+
+	retreat: 3,
+	rarity: "Hyper rare",
+	dexId: [727],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM8a/062.ts
+++ b/data-asia/SM/SM8a/062.ts
@@ -1,0 +1,64 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "コバルオンGX",
+	},
+
+	illustrator: "",
+	category: "Pokemon",
+	hp: 170,
+	types: ["Metal"],
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "メタルシンボル" },
+			effect: {
+				ja: "このポケモンがいるかぎり、[鋼]エネルギーがついている自分のポケモン全員は、特殊状態にならず、受けている特殊状態は、すべて回復する。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "デュエルセーバー" },
+			damage: "50+",
+			cost: ["Metal", "Metal"],
+			effect: {
+				ja: "場にスタジアムが出ているなら、60ダメージ追加。",
+			},
+		},
+		{
+			name: { ja: "てつのおきてGX" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "次の相手の番、相手のポケモン全員はワザが使えない。（新しく出したポケモンも含む。）［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 558636,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Hyper rare",
+	dexId: [638],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM8a/063.ts
+++ b/data-asia/SM/SM8a/063.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "エレキチャージャー",
+	},
+
+	illustrator: "",
+	category: "Trainer",
+
+	effect: {
+		ja: "コインを2回投げ、オモテの数ぶん、自分のトラッシュにある「エレキパワー」を、相手に見せてから、山札にもどして切る。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 558637,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	rarity: "Secret Rare",
+};
+
+export default card;

--- a/data-asia/SM/SM8a/064.ts
+++ b/data-asia/SM/SM8a/064.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "デンジャラスドリル",
+	},
+
+	illustrator: "",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードは、自分の手札にある[悪]ポケモンを1枚トラッシュしなければ使えない。相手の場のポケモンについている「ポケモンのどうぐ」「特殊エネルギー」と場に出ている「スタジアム」の中から、1枚トラッシュする。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 558638,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	rarity: "Secret Rare",
+};
+
+export default card;

--- a/data-asia/SM/SM8a/065.ts
+++ b/data-asia/SM/SM8a/065.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "メタルゴーグル",
+	},
+
+	illustrator: "",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードをつけているポケモンは、相手のポケモンから受けるワザのダメージが「-30」され、相手のワザや特性の効果によるダメカンものらない。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 558639,
+			},
+		},
+	],
+
+	trainerType: "Tool",
+	rarity: "Secret Rare",
+};
+
+export default card;


### PR DESCRIPTION
## What

Adds the complete Japanese set **SM8a ダークオーダー (Dark Order)**, released 2018-10-05:

- `data-asia/SM/SM8a/001.ts` … `065.ts` — all 65 cards (52 regular + 13 secret rares: 6 SR, 4 UR, 3 Secret Rare)
- the set definition `data-asia/SM/SM8a.ts` already existed and is untouched

## Data sources

- **pokemon-card.com** (official database): Japanese names, flavor texts, National Dex numbers, official card count
- **limitlesstcg.com**: full Japanese card text, stages, weaknesses/resistances/retreat, rarities, illustrators, attack costs
- **Cardmarket**: product IDs as `thirdParty.cardmarket` on the variant objects (558575–558639; tcgplayer IDs not available to me)

## Notes

- Follows the file format and conventions of the M-era sets (#1728)
- No `regulationMark` (the set predates regulation marks); resistances are `-20` per the era
- All 65 files type-check against `interfaces.d.ts` (`tsc --noEmit`)
