### PR TITLE
(data) Add Japanese SM set SM8b GX Ultra Shiny

### DIFF
--- a/data-asia/SM/SM8b/001.ts
+++ b/data-asia/SM/SM8b/001.ts
@@ -1,0 +1,46 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "フシギダネ",
+	},
+
+	illustrator: "Mizue",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Grass"],
+
+	description: {
+		ja: "生まれたときから 背中に 不思議な タネが 植えてあって 体と ともに 育つという。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "はっぱカッター" },
+			damage: 30,
+			cost: ["Grass", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 550491,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "None",
+	dexId: [1],
+};
+
+export default card;

--- a/data-asia/SM/SM8b/002.ts
+++ b/data-asia/SM/SM8b/002.ts
@@ -1,0 +1,58 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "フシギソウ",
+	},
+
+	illustrator: "Kouki Saitou",
+	category: "Pokemon",
+	hp: 100,
+	types: ["Grass"],
+
+	description: {
+		ja: "つぼみが 背中に ついていて 養分を 吸収していくと 大きな 花が 咲くという。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "はっぱカッター" },
+			damage: 30,
+			cost: ["Grass", "Colorless"],
+		},
+		{
+			name: { ja: "もうどくのムチ" },
+			damage: 50,
+			cost: ["Grass", "Grass", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをどくとこんらんにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 550496,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "フシギダネ",
+	},
+
+	retreat: 4,
+	rarity: "None",
+	dexId: [2],
+};
+
+export default card;

--- a/data-asia/SM/SM8b/003.ts
+++ b/data-asia/SM/SM8b/003.ts
@@ -1,0 +1,60 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "フシギバナ",
+	},
+
+	illustrator: "Eske Yoshinob",
+	category: "Pokemon",
+	hp: 160,
+	types: ["Grass"],
+
+	description: {
+		ja: "大きな 花びらを 広げ 太陽の 光を 浴びていると 体に 元気が みなぎっていく。",
+	},
+
+	stage: "Stage2",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "みつりんのぬし" },
+			effect: {
+				ja: "このポケモンがいるかぎり、自分の場のポケモンについているすべての基本[草]エネルギーは、それぞれ[草]エネルギー2個ぶんとしてはたらく。この効果は、この特性を持つポケモンが何匹いても、重ならない。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ソーラービーム" },
+			damage: 90,
+			cost: ["Grass", "Grass", "Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 550501,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "フシギソウ",
+	},
+
+	retreat: 4,
+	rarity: "None",
+	dexId: [3],
+};
+
+export default card;

--- a/data-asia/SM/SM8b/004.ts
+++ b/data-asia/SM/SM8b/004.ts
@@ -1,0 +1,48 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "タマタマ",
+	},
+
+	illustrator: "Yuka Morii",
+	category: "Pokemon",
+	hp: 40,
+	types: ["Grass"],
+
+	description: {
+		ja: "６匹で １人前の ポケモン。 マケンカニに よく 狙われるが 念力を 使って 撃退する。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ふえる" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札にある「タマタマ」を1枚、ベンチに出す。そして山札を切る。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 550506,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "None",
+	dexId: [102],
+};
+
+export default card;

--- a/data-asia/SM/SM8b/005.ts
+++ b/data-asia/SM/SM8b/005.ts
@@ -1,0 +1,59 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "カットロトム",
+	},
+
+	illustrator: "kawayoo",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Grass"],
+
+	description: {
+		ja: "プラズマで できた 体を 持つ。 電化製品に 潜りこみ 悪さを することで 知られている。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ロトモーター" },
+			effect: {
+				ja: "自分のトラッシュに「ポケモンのどうぐ」が9枚以上あるなら、このポケモンが使うワザに必要なエネルギーは、すべてなくなる。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "スペシャルカット" },
+			damage: 60,
+			cost: ["Grass", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンについている特殊エネルギーを、1個トラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 550511,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "None",
+	dexId: [479],
+};
+
+export default card;

--- a/data-asia/SM/SM8b/006.ts
+++ b/data-asia/SM/SM8b/006.ts
@@ -1,0 +1,45 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "シェイミ",
+	},
+
+	illustrator: "kawayoo",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Grass"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "フラワーストーム" },
+			damage: "30×",
+			cost: ["Grass", "Grass"],
+			effect: {
+				ja: "自分の場のポケモンについている基本エネルギーの数x30ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 550516,
+			},
+		},
+	],
+
+	retreat: 0,
+	rarity: "Rare Holo",
+	dexId: [492],
+};
+
+export default card;

--- a/data-asia/SM/SM8b/007.ts
+++ b/data-asia/SM/SM8b/007.ts
@@ -1,0 +1,56 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "コソクムシ",
+	},
+
+	illustrator: "Kagemaru Himeno",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Grass"],
+
+	description: {
+		ja: "臆病で たくさんの 足を ばたつかせ 必死に 逃げまわる。 逃げたあとは ピカピカ 綺麗。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "にげごし" },
+			effect: {
+				ja: "最初の自分の番、このポケモンのにげるためのエネルギーは、すべてなくなる。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "かじる" },
+			damage: 30,
+			cost: ["Grass", "Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 550521,
+			},
+		},
+	],
+
+	retreat: 3,
+	rarity: "None",
+	dexId: [767],
+};
+
+export default card;

--- a/data-asia/SM/SM8b/008.ts
+++ b/data-asia/SM/SM8b/008.ts
@@ -1,0 +1,67 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "グソクムシャGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 210,
+	types: ["Grass"],
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "であいがしら" },
+			damage: "30+",
+			cost: ["Grass"],
+			effect: {
+				ja: "この番、このポケモンがベンチからバトル場に出ていたなら、90ダメージ追加。",
+			},
+		},
+		{
+			name: { ja: "アーマープレス" },
+			damage: 100,
+			cost: ["Grass", "Colorless", "Colorless"],
+			effect: {
+				ja: "次の相手の番、このポケモンが受けるワザのダメージは「-20」される。",
+			},
+		},
+		{
+			name: { ja: "ザンクロスGX" },
+			damage: 150,
+			cost: ["Grass", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンをベンチポケモンと入れ替える。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 550526,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "コソクムシ",
+	},
+
+	retreat: 3,
+	rarity: "Double rare",
+	dexId: [768],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM8b/009.ts
+++ b/data-asia/SM/SM8b/009.ts
@@ -1,0 +1,54 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "フェローチェ",
+	},
+
+	illustrator: "You Iribi",
+	category: "Pokemon",
+	hp: 110,
+	types: ["Grass"],
+
+	description: {
+		ja: "ＵＢの 一種。 この世界の ものに けがれを 感じるのか 一切 手を 触れようと しない。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "とびひざげり" },
+			damage: 20,
+			cost: ["Colorless"],
+		},
+		{
+			name: { ja: "ホワイトレイ" },
+			damage: "90+",
+			cost: ["Grass", "Grass", "Colorless"],
+			effect: {
+				ja: "自分のサイドの残り枚数が1枚なら、90ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 550531,
+			},
+		},
+	],
+
+	retreat: 0,
+	rarity: "None",
+	dexId: [795],
+};
+
+export default card;

--- a/data-asia/SM/SM8b/010.ts
+++ b/data-asia/SM/SM8b/010.ts
@@ -1,0 +1,54 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "マグマッグ",
+	},
+
+	illustrator: "Midori Harada",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Fire"],
+
+	description: {
+		ja: "溶岩で できた 体を 持つ。 絶えず 動いていないと 体が 冷えて 固まってしまうのだ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "マグマでかこむ" },
+			damage: 10,
+			cost: ["Colorless"],
+			effect: {
+				ja: "次の相手の番、このワザを受けたポケモンは、にげられない。",
+			},
+		},
+		{
+			name: { ja: "ほのお" },
+			damage: 20,
+			cost: ["Fire", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 550536,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "None",
+	dexId: [218],
+};
+
+export default card;

--- a/data-asia/SM/SM8b/011.ts
+++ b/data-asia/SM/SM8b/011.ts
@@ -1,0 +1,60 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "マグカルゴ",
+	},
+
+	illustrator: "Midori Harada",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Fire"],
+
+	description: {
+		ja: "体は いつも 波打っていて 溶岩のように 熱い。 ときどき 殻から 火の粉が漏れる。",
+	},
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "じならし" },
+			effect: {
+				ja: "自分の番に1回使える。自分の山札から好きなカードを1枚選ぶ。残りの山札を切り、選んだカードを山札の上にもどす。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "かえん" },
+			damage: 50,
+			cost: ["Fire", "Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 550541,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "マグマッグ",
+	},
+
+	retreat: 3,
+	rarity: "None",
+	dexId: [219],
+};
+
+export default card;

--- a/data-asia/SM/SM8b/012.ts
+++ b/data-asia/SM/SM8b/012.ts
@@ -1,0 +1,48 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アチャモ",
+	},
+
+	illustrator: "Kouki Saitou",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Fire"],
+
+	description: {
+		ja: "体内で 炎が 燃えているので 抱きしめると とても 温かい。 １０００度の 火の玉を 飛ばす。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "こがす" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "コインを1回投げオモテなら、相手のバトルポケモンをやけどにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 550546,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "None",
+	dexId: [255],
+};
+
+export default card;

--- a/data-asia/SM/SM8b/013.ts
+++ b/data-asia/SM/SM8b/013.ts
@@ -1,0 +1,63 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ワカシャモ",
+	},
+
+	illustrator: "Ken Sugimori",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Fire"],
+
+	description: {
+		ja: "戦いに なると 体内の 炎が 激しく 燃え上がる。 キックは 破壊力 抜群だ。",
+	},
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "しぜんかいふく" },
+			effect: {
+				ja: "手札からこのポケモンにエネルギーをつけるたび、このポケモンの特殊状態をすべて回復する。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "とびかかる" },
+			damage: 60,
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "コインを1回投げウラなら、このワザは失敗。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 550551,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "アチャモ",
+	},
+
+	retreat: 1,
+	rarity: "None",
+	dexId: [256],
+};
+
+export default card;

--- a/data-asia/SM/SM8b/014.ts
+++ b/data-asia/SM/SM8b/014.ts
@@ -1,0 +1,63 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "バシャーモ",
+	},
+
+	illustrator: "Kouki Saitou",
+	category: "Pokemon",
+	hp: 150,
+	types: ["Fire"],
+
+	description: {
+		ja: "強敵に 出会うと 手首から 炎を 噴き出す。 ジャンプで ビルを 跳び越す 脚力。",
+	},
+
+	stage: "Stage2",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "たきつける" },
+			effect: {
+				ja: "自分の番に1回使える。自分のトラッシュにある[炎]エネルギーを1枚、ベンチポケモンにつける。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ファイヤーストリーム" },
+			damage: 90,
+			cost: ["Fire", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンについている[炎]エネルギーを1個トラッシュし、相手のベンチポケモン全員にも、それぞれ20ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 550556,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ワカシャモ",
+	},
+
+	retreat: 2,
+	rarity: "None",
+	dexId: [257],
+};
+
+export default card;

--- a/data-asia/SM/SM8b/015.ts
+++ b/data-asia/SM/SM8b/015.ts
@@ -1,0 +1,56 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヒートロトム",
+	},
+
+	illustrator: "Shin Nagasawa",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Fire"],
+
+	description: {
+		ja: "プラズマで できた 体を 持つ。 電化製品に 潜りこみ 悪さを することで 知られている。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ロトモーター" },
+			effect: {
+				ja: "自分のトラッシュに「ポケモンのどうぐ」が9枚以上あるなら、このポケモンが使うワザに必要なエネルギーは、すべてなくなる。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ヒートブラスト" },
+			damage: 80,
+			cost: ["Fire", "Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 550561,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "None",
+	dexId: [479],
+};
+
+export default card;

--- a/data-asia/SM/SM8b/016.ts
+++ b/data-asia/SM/SM8b/016.ts
@@ -1,0 +1,56 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "クイタラン",
+	},
+
+	illustrator: "Ken Sugimori",
+	category: "Pokemon",
+	hp: 110,
+	types: ["Fire"],
+
+	description: {
+		ja: "尻尾から 取りこんだ 空気を 炎に変えて ベロのように 使い アイアントを 溶かして 食べるぞ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "こがす" },
+			cost: ["Fire"],
+			effect: {
+				ja: "相手のバトルポケモンをやけどにする。",
+			},
+		},
+		{
+			name: { ja: "くろこげブレス" },
+			damage: 120,
+			cost: ["Fire", "Fire"],
+			effect: {
+				ja: "相手のバトルポケモンがやけどでないなら、このワザは失敗。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 550566,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "None",
+	dexId: [631],
+};
+
+export default card;

--- a/data-asia/SM/SM8b/017.ts
+++ b/data-asia/SM/SM8b/017.ts
@@ -1,0 +1,57 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "レシラム",
+	},
+
+	illustrator: "TOKIYA",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Fire"],
+
+	description: {
+		ja: "炎で 世界を 燃やしつくせる 伝説の ポケモン。 真実の 世界を 築く 人を 助ける。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "げきりん" },
+			damage: "20+",
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンにのっているダメカンの数x10ダメージ追加。",
+			},
+		},
+		{
+			name: { ja: "しゃくねつのいぶき" },
+			damage: 130,
+			cost: ["Fire", "Fire", "Colorless"],
+			effect: {
+				ja: "次の自分の番、このポケモンはワザが使えない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 550571,
+			},
+		},
+	],
+
+	retreat: 3,
+	rarity: "None",
+	dexId: [643],
+};
+
+export default card;

--- a/data-asia/SM/SM8b/018.ts
+++ b/data-asia/SM/SM8b/018.ts
@@ -1,0 +1,62 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "レシラムGX",
+	},
+
+	illustrator: "PLANETA Otani",
+	category: "Pokemon",
+	hp: 180,
+	types: ["Fire"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ニトロチャージ" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札にある[炎]エネルギーを2枚まで、このポケモンにつける。そして山札を切る。",
+			},
+		},
+		{
+			name: { ja: "しゃくねつのはしら" },
+			damage: 110,
+			cost: ["Fire", "Fire", "Fire", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをやけどにする。",
+			},
+		},
+		{
+			name: { ja: "ヴァーミリオンGX" },
+			damage: 180,
+			cost: ["Fire", "Fire", "Fire", "Colorless"],
+			effect: {
+				ja: "のぞむなら、自分の手札にある[炎]エネルギーを5枚まで、自分のポケモンに好きなようにつける。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 550576,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Double rare",
+	dexId: [643],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM8b/019.ts
+++ b/data-asia/SM/SM8b/019.ts
@@ -1,0 +1,51 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "フォッコ",
+	},
+
+	illustrator: "Atsuko Nishida",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Fire"],
+
+	description: {
+		ja: "小枝を 持ち歩き おやつがわりに ポリポリ 食べる。 耳から 熱気を 噴き出して 相手を 威嚇する。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ひだね" },
+			damage: 10,
+			cost: ["Fire"],
+		},
+		{
+			name: { ja: "うしろげり" },
+			damage: 20,
+			cost: ["Fire", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 550581,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "None",
+	dexId: [653],
+};
+
+export default card;

--- a/data-asia/SM/SM8b/020.ts
+++ b/data-asia/SM/SM8b/020.ts
@@ -1,0 +1,58 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "テールナー",
+	},
+
+	illustrator: "Kagemaru Himeno",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Fire"],
+
+	description: {
+		ja: "木の枝を 尻尾から 引き抜くとき 摩擦で 着火。 枝の 炎を 振って 仲間に 合図を 送る。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "ほのお" },
+			damage: 20,
+			cost: ["Fire"],
+		},
+		{
+			name: { ja: "かえんほうしゃ" },
+			damage: 80,
+			cost: ["Fire", "Fire", "Colorless"],
+			effect: {
+				ja: "このポケモンについているエネルギーを、1個トラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 550586,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "フォッコ",
+	},
+
+	retreat: 2,
+	rarity: "None",
+	dexId: [654],
+};
+
+export default card;

--- a/data-asia/SM/SM8b/021.ts
+++ b/data-asia/SM/SM8b/021.ts
@@ -1,0 +1,63 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "マフォクシー",
+	},
+
+	illustrator: "kawayoo",
+	category: "Pokemon",
+	hp: 150,
+	types: ["Fire"],
+
+	description: {
+		ja: "摂氏３０００度の 炎の 渦を 超能力で 操る。 敵を 渦で 包み 焼きつくす。",
+	},
+
+	stage: "Stage2",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "マジカルトーチ" },
+			effect: {
+				ja: "自分の番に1回使える。相手のバトルポケモンをやけどにする。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ほのおのうず" },
+			damage: 150,
+			cost: ["Fire", "Fire", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンについているエネルギーを、2個トラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 550591,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "テールナー",
+	},
+
+	retreat: 2,
+	rarity: "None",
+	dexId: [655],
+};
+
+export default card;

--- a/data-asia/SM/SM8b/022.ts
+++ b/data-asia/SM/SM8b/022.ts
@@ -1,0 +1,53 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アローラロコン",
+	},
+
+	illustrator: "You Iribi",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Water"],
+
+	description: {
+		ja: "マイナス５０度の 冷気を 吐く。 アローラの老人は ケオケオという 昔の 名前で 呼ぶことも。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "みちしるべ" },
+			cost: [],
+			effect: {
+				ja: "自分の山札にあるポケモンを2枚まで、相手に見せてから、手札に加える。そして山札を切る。",
+			},
+		},
+		{
+			name: { ja: "スノーアイス" },
+			damage: 20,
+			cost: ["Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 550596,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "None",
+	dexId: [37],
+};
+
+export default card;

--- a/data-asia/SM/SM8b/023.ts
+++ b/data-asia/SM/SM8b/023.ts
@@ -1,0 +1,51 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ウパー",
+	},
+
+	illustrator: "Shibuzoh.",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Water"],
+
+	description: {
+		ja: "夕暮れどき 涼しくなると 水から 上がってきた ウパーたちは エサを 探して 水辺を 歩く。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ぶつかる" },
+			damage: 10,
+			cost: ["Colorless"],
+		},
+		{
+			name: { ja: "みずかけ" },
+			damage: 20,
+			cost: ["Water", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 550601,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "None",
+	dexId: [194],
+};
+
+export default card;

--- a/data-asia/SM/SM8b/024.ts
+++ b/data-asia/SM/SM8b/024.ts
@@ -1,0 +1,63 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヌオー",
+	},
+
+	illustrator: "Ken Sugimori",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Water"],
+
+	description: {
+		ja: "のんびりとした 性格で 気ままに 泳いでは いつも 船底に 頭を ぶつけている。",
+	},
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "おしながす" },
+			effect: {
+				ja: "自分の番に何回でも使える。自分のベンチポケモンについている[水]エネルギーを1個、バトルポケモンにつけ替える。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ハイドロポンプ" },
+			damage: "60+",
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンについている[水]エネルギーの数x20ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 550606,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ウパー",
+	},
+
+	retreat: 2,
+	rarity: "None",
+	dexId: [195],
+};
+
+export default card;

--- a/data-asia/SM/SM8b/025.ts
+++ b/data-asia/SM/SM8b/025.ts
@@ -1,0 +1,49 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ユキカブリ",
+	},
+
+	illustrator: "match",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Water"],
+
+	description: {
+		ja: "春になると アイスキャンディーの ような 食感の 木の実が お腹の まわりに 生る。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "こおりのつぶて" },
+			damage: "20+",
+			cost: ["Water", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンが[闘]ポケモンなら、40ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 550611,
+			},
+		},
+	],
+
+	retreat: 3,
+	rarity: "None",
+	dexId: [459],
+};
+
+export default card;

--- a/data-asia/SM/SM8b/026.ts
+++ b/data-asia/SM/SM8b/026.ts
@@ -1,0 +1,63 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ユキノオー",
+	},
+
+	illustrator: "Masakazu Fukuda",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Water"],
+
+	description: {
+		ja: "万年雪が 積もる 山脈で 静かに 暮らす。 ブリザードを 発生させて 姿を 隠す。",
+	},
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "じゅひょうのめぐみ" },
+			effect: {
+				ja: "自分の番に、このカードを手札から出して進化させたとき、1回使える。自分のトラッシュにある[水]エネルギーを1枚、自分のポケモンにつける。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ヒプノハンマー" },
+			damage: 80,
+			cost: ["Water", "Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをねむりにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 550616,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ユキカブリ",
+	},
+
+	retreat: 3,
+	rarity: "None",
+	dexId: [460],
+};
+
+export default card;

--- a/data-asia/SM/SM8b/027.ts
+++ b/data-asia/SM/SM8b/027.ts
@@ -1,0 +1,69 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "グレイシアGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 200,
+	types: ["Water"],
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "いてつくひとみ" },
+			effect: {
+				ja: "このポケモンがバトル場にいるかぎり、相手の場・手札・トラッシュにある「ポケモンGX・EX」の特性（「いてつくひとみ」をのぞく）は、すべてなくなる。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "フロストバレット" },
+			damage: 90,
+			cost: ["Water", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のベンチポケモン1匹にも、30ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+			},
+		},
+		{
+			name: { ja: "ポーラースピアGX" },
+			damage: "50×",
+			cost: ["Water", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンにのっているダメカンの数x50ダメージ。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 550621,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "イーブイ",
+	},
+
+	retreat: 2,
+	rarity: "Double rare",
+	dexId: [471],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM8b/028.ts
+++ b/data-asia/SM/SM8b/028.ts
@@ -1,0 +1,58 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ウォッシュロトム",
+	},
+
+	illustrator: "Shigenori Negishi",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Water"],
+
+	description: {
+		ja: "プラズマで できた 体を 持つ。 電化製品に 潜りこみ 悪さを することで 知られている。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ロトモーター" },
+			effect: {
+				ja: "自分のトラッシュに「ポケモンのどうぐ」が9枚以上あるなら、このポケモンが使うワザに必要なエネルギーは、すべてなくなる。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ウォッシュアロー" },
+			cost: ["Water", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のベンチポケモン1匹に、50ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 550626,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "None",
+	dexId: [479],
+};
+
+export default card;

--- a/data-asia/SM/SM8b/029.ts
+++ b/data-asia/SM/SM8b/029.ts
@@ -1,0 +1,59 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "フロストロトム",
+	},
+
+	illustrator: "MAHOU",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Water"],
+
+	description: {
+		ja: "プラズマで できた 体を 持つ。 電化製品に 潜りこみ 悪さを することで 知られている。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ロトモーター" },
+			effect: {
+				ja: "自分のトラッシュに「ポケモンのどうぐ」が9枚以上あるなら、このポケモンが使うワザに必要なエネルギーは、すべてなくなる。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "フロストクラッシュ" },
+			damage: "10+",
+			cost: ["Water", "Colorless"],
+			effect: {
+				ja: "相手の場のポケモンについているエネルギーの数x20ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 550631,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "None",
+	dexId: [479],
+};
+
+export default card;

--- a/data-asia/SM/SM8b/030.ts
+++ b/data-asia/SM/SM8b/030.ts
@@ -1,0 +1,56 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "マナフィ",
+	},
+
+	illustrator: "Kagemaru Himeno",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Water"],
+
+	description: {
+		ja: "生まれたときから 備わっている 不思議な 力を 使うと どんな ポケモンとも 心が 通い合う。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "しんかいのめぐみ" },
+			effect: {
+				ja: "自分の番に1回使える。[水]エネルギーがついている自分のポケモン1匹のHPを「20」回復する。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "スプラッシュ" },
+			damage: 30,
+			cost: ["Water", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 550636,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "None",
+	dexId: [490],
+};
+
+export default card;

--- a/data-asia/SM/SM8b/031.ts
+++ b/data-asia/SM/SM8b/031.ts
@@ -1,0 +1,56 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ケロマツ",
+	},
+
+	illustrator: "Ken Sugimori",
+	category: "Pokemon",
+	hp: 50,
+	types: ["Water"],
+
+	description: {
+		ja: "繊細な 泡で 体を 包み 肌を 守る。 のんきに 見せかけて 抜け目なく 周囲を うかがう。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ケロムース" },
+			effect: {
+				ja: "このポケモンに[水]エネルギーがついているなら、このポケモンのにげるためのエネルギーは、すべてなくなる。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "はねまわる" },
+			damage: 20,
+			cost: ["Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 550641,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "None",
+	dexId: [656],
+};
+
+export default card;

--- a/data-asia/SM/SM8b/032.ts
+++ b/data-asia/SM/SM8b/032.ts
@@ -1,0 +1,60 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ゲコガシラ",
+	},
+
+	illustrator: "Akira Komayama",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Water"],
+
+	description: {
+		ja: "身軽さは だれにも 負けない。 ６００メートルを 超える タワーの 天辺まで １分で 登りきる。",
+	},
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "はやてしゅりけん" },
+			effect: {
+				ja: "自分の番に、このカードを手札から出して進化させたとき、1回使える。相手のポケモン1匹に、ダメカンを2個のせる。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "みずきり" },
+			damage: 20,
+			cost: ["Water"],
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 550646,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ケロマツ",
+	},
+
+	retreat: 1,
+	rarity: "None",
+	dexId: [657],
+};
+
+export default card;

--- a/data-asia/SM/SM8b/033.ts
+++ b/data-asia/SM/SM8b/033.ts
@@ -1,0 +1,68 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ゲッコウガGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 230,
+	types: ["Water"],
+
+	stage: "Stage2",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ふうましゅりけん" },
+			effect: {
+				ja: "自分の番に、このカードを手札から出して進化させたとき、1回使える。相手のポケモン1匹に、ダメカンを3個のせる。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "おぼろぎり" },
+			damage: 110,
+			cost: ["Water", "Colorless", "Colorless"],
+			effect: {
+				ja: "のぞむなら、このポケモンと、ついているすべてのカードを、自分の山札にもどして切る。",
+			},
+		},
+		{
+			name: { ja: "シャドーアサシンGX" },
+			cost: ["Water", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のベンチポケモン1匹に、130ダメージ。［ベンチは弱点・抵抗力を計算しない。］［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 550651,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ゲコガシラ",
+	},
+
+	retreat: 2,
+	rarity: "Double rare",
+	dexId: [658],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM8b/034.ts
+++ b/data-asia/SM/SM8b/034.ts
@@ -1,0 +1,54 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ライコウ",
+	},
+
+	illustrator: "Mitsuhiro Arita",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Lightning"],
+
+	description: {
+		ja: "雨雲を 背負っているので どんなときでも 雷を 出せる。 雷とともに 落ちてきたという。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "とどろくらいめい" },
+			damage: 30,
+			cost: ["Lightning"],
+			effect: {
+				ja: "自分のトラッシュにある[雷]エネルギーを1枚、ベンチポケモンにつける。",
+			},
+		},
+		{
+			name: { ja: "ライトニングボール" },
+			damage: 90,
+			cost: ["Lightning", "Lightning", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Metal", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 550656,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "None",
+	dexId: [243],
+};
+
+export default card;

--- a/data-asia/SM/SM8b/035.ts
+++ b/data-asia/SM/SM8b/035.ts
@@ -1,0 +1,55 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "パチリス",
+	},
+
+	illustrator: "OOYAMA",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Lightning"],
+
+	description: {
+		ja: "たまった 電気を 分け与えようと ほほ袋を こすり合わせる パチリスを 見かけることも ある。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "すりすりはつでん" },
+			cost: ["Lightning"],
+			effect: {
+				ja: "自分のベンチにいるワザ「ほっぺすりすり」を持つポケモン全員に、山札にある[雷]エネルギーを1枚ずつつける。そして山札を切る。",
+			},
+		},
+		{
+			name: { ja: "ほっぺすりすり" },
+			cost: ["Lightning"],
+			effect: {
+				ja: "コインを1回投げオモテなら、相手のバトルポケモンをマヒにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Metal", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 550661,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "None",
+	dexId: [417],
+};
+
+export default card;

--- a/data-asia/SM/SM8b/036.ts
+++ b/data-asia/SM/SM8b/036.ts
@@ -1,0 +1,59 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ロトム",
+	},
+
+	illustrator: "Naoyo Kimura",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Lightning"],
+
+	description: {
+		ja: "プラズマで できた 体を 持つ。 電化製品に 潜りこみ 悪さを することで 知られている。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ロトモーター" },
+			effect: {
+				ja: "自分のトラッシュに「ポケモンのどうぐ」が9枚以上あるなら、このポケモンが使うワザに必要なエネルギーは、すべてなくなる。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "プラズマスラッシュ" },
+			damage: 120,
+			cost: ["Lightning", "Lightning", "Lightning"],
+			effect: {
+				ja: "次の自分の番、このポケモンはワザが使えない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Metal", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 550666,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "None",
+	dexId: [479],
+};
+
+export default card;

--- a/data-asia/SM/SM8b/037.ts
+++ b/data-asia/SM/SM8b/037.ts
@@ -1,0 +1,57 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ゼクロム",
+	},
+
+	illustrator: "nagimiso",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Lightning"],
+
+	description: {
+		ja: "稲妻で 世界を 焼きつくせる 伝説の ポケモン。 理想の 世界を つくる 人を 補佐する。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "げきりん" },
+			damage: "20+",
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンにのっているダメカンの数x10ダメージ追加。",
+			},
+		},
+		{
+			name: { ja: "いかずちのやいば" },
+			damage: 130,
+			cost: ["Lightning", "Lightning", "Colorless"],
+			effect: {
+				ja: "このポケモンについているエネルギーを、2個トラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Metal", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 550671,
+			},
+		},
+	],
+
+	retreat: 3,
+	rarity: "None",
+	dexId: [644],
+};
+
+export default card;

--- a/data-asia/SM/SM8b/038.ts
+++ b/data-asia/SM/SM8b/038.ts
@@ -1,0 +1,57 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "デンジュモク",
+	},
+
+	illustrator: "Shin Nagasawa",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Lightning"],
+
+	description: {
+		ja: "ウルトラホールから 出現した。 発電所を 襲撃 したため 電気が エネルギーと おもわれる。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "せんこうだん" },
+			damage: 20,
+			cost: ["Lightning"],
+			effect: {
+				ja: "相手のバトルポケモンをこんらんにする。",
+			},
+		},
+		{
+			name: { ja: "ケーブルグラム" },
+			damage: 100,
+			cost: ["Lightning", "Lightning", "Colorless"],
+			effect: {
+				ja: "自分のサイドの残り枚数が3枚なら、相手のバトルポケモンをマヒにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Metal", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 550676,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "None",
+	dexId: [796],
+};
+
+export default card;

--- a/data-asia/SM/SM8b/039.ts
+++ b/data-asia/SM/SM8b/039.ts
@@ -1,0 +1,64 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "デンジュモクGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 180,
+	types: ["Lightning"],
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "フラッシュヘッド" },
+			effect: {
+				ja: "このポケモンは、特殊エネルギーがついている相手のポケモンから、ワザのダメージを受けない。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ランブルワイヤー" },
+			damage: 100,
+			cost: ["Lightning", "Lightning", "Colorless"],
+			effect: {
+				ja: "相手の山札を上から1枚トラッシュする。",
+			},
+		},
+		{
+			name: { ja: "ライトニングGX" },
+			cost: ["Lightning"],
+			effect: {
+				ja: "相手の手札を見て、その中にあるカードを1枚、ウラにして相手のサイドとして置く。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Metal", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 550681,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Double rare",
+	dexId: [796],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM8b/040.ts
+++ b/data-asia/SM/SM8b/040.ts
@@ -1,0 +1,60 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アローラガラガラ",
+	},
+
+	illustrator: "miki kudo",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Psychic"],
+
+	description: {
+		ja: "仲間を 弔う 習性。 道の すみに 盛り上がった 土が あったら それは ガラガラの 墓。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "リンボーリンボー" },
+			cost: [],
+			effect: {
+				ja: "自分の山札にある基本エネルギーを2枚まで、自分のポケモンに好きなようにつける。そして山札を切る。",
+			},
+		},
+		{
+			name: { ja: "アローラサークル" },
+			damage: "20×",
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "自分の場の、名前に「アローラ」とつくポケモンの数x20ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 550686,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "カラカラ",
+	},
+
+	retreat: 2,
+	rarity: "None",
+	dexId: [105],
+};
+
+export default card;

--- a/data-asia/SM/SM8b/041.ts
+++ b/data-asia/SM/SM8b/041.ts
@@ -1,0 +1,59 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ハブネーク",
+	},
+
+	illustrator: "Eri Yamaki",
+	category: "Pokemon",
+	hp: 100,
+	types: ["Psychic"],
+
+	description: {
+		ja: "猛毒が 染み出している 鋭い 切れ味の 尻尾で 素早い ザングースに 立ち向かう。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ポイズンアップ" },
+			effect: {
+				ja: "このポケモンがいるかぎり、相手のバトルポケモンは、どくでのせるダメカンの数が1個多くなる。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "どくのキバ" },
+			damage: 30,
+			cost: ["Psychic", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをどくにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 550691,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "None",
+	dexId: [336],
+};
+
+export default card;

--- a/data-asia/SM/SM8b/042.ts
+++ b/data-asia/SM/SM8b/042.ts
@@ -1,0 +1,48 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "マーイーカ",
+	},
+
+	illustrator: "sowsow",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Psychic"],
+
+	description: {
+		ja: "光の 点滅で 襲ってきた 敵の 戦意を なくしてしまう。 その すきに 姿を くらますのだ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "さいみんじゅつ" },
+			cost: ["Psychic"],
+			effect: {
+				ja: "相手のバトルポケモンをねむりにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 550696,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "None",
+	dexId: [686],
+};
+
+export default card;

--- a/data-asia/SM/SM8b/043.ts
+++ b/data-asia/SM/SM8b/043.ts
@@ -1,0 +1,60 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "カラマネロ",
+	},
+
+	illustrator: "Shin Nagasawa",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Psychic"],
+
+	description: {
+		ja: "催眠術で おびき寄せて 頭の 触手で 絡め取り 消化液を 浴びせて しとめる。",
+	},
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "サイコリチャージ" },
+			effect: {
+				ja: "自分の番に1回使える。自分のトラッシュにある[超]エネルギーを1枚、ベンチポケモンにつける。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ねんどうだん" },
+			damage: 60,
+			cost: ["Psychic", "Psychic", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 550701,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "マーイーカ",
+	},
+
+	retreat: 2,
+	rarity: "None",
+	dexId: [687],
+};
+
+export default card;

--- a/data-asia/SM/SM8b/044.ts
+++ b/data-asia/SM/SM8b/044.ts
@@ -1,0 +1,64 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "カプ・テテフGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 170,
+	types: ["Psychic"],
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ワンダータッチ" },
+			effect: {
+				ja: "自分の番に、このカードを手札からベンチに出したとき、1回使える。自分の山札にあるサポートを1枚、相手に見せてから、手札に加える。そして山札を切る。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "エナジードライブ" },
+			damage: "20×",
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "おたがいのバトルポケモンについているエネルギーの数x20ダメージ。このワザのダメージは弱点・抵抗力を計算しない。",
+			},
+		},
+		{
+			name: { ja: "カプキュアーGX" },
+			cost: ["Psychic"],
+			effect: {
+				ja: "自分のベンチポケモン2匹のHPを、すべて回復する。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 550706,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Double rare",
+	dexId: [786],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM8b/045.ts
+++ b/data-asia/SM/SM8b/045.ts
@@ -1,0 +1,56 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "コスモッグ",
+	},
+
+	illustrator: "sui",
+	category: "Pokemon",
+	hp: 50,
+	types: ["Psychic"],
+
+	description: {
+		ja: "大昔は 星の子 という 名で 呼ばれた。 別世界の ポケモンと いわれているが 詳しくは 不明。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "コスモガード" },
+			effect: {
+				ja: "このポケモンは、ベンチにいるかぎり、ワザのダメージを受けない。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "つぶやく" },
+			damage: 10,
+			cost: ["Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 550711,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "None",
+	dexId: [789],
+};
+
+export default card;

--- a/data-asia/SM/SM8b/046.ts
+++ b/data-asia/SM/SM8b/046.ts
@@ -1,0 +1,52 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "コスモウム",
+	},
+
+	illustrator: "Kouki Saitou",
+	category: "Pokemon",
+	hp: 100,
+	types: ["Psychic"],
+
+	description: {
+		ja: "硬いカラの 中で 黒いコアに なにかが 集まり 続けている。 別世界の ポケモンと いわれる。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "ひとやすみ" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "このポケモンのHPを「20」回復する。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 550716,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "コスモッグ",
+	},
+
+	retreat: 3,
+	rarity: "None",
+	dexId: [790],
+};
+
+export default card;

--- a/data-asia/SM/SM8b/047.ts
+++ b/data-asia/SM/SM8b/047.ts
@@ -1,0 +1,52 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ルナアーラ",
+	},
+
+	illustrator: "Hitoshi Ariga",
+	category: "Pokemon",
+	hp: 160,
+	types: ["Psychic"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "フルムーンスター" },
+			cost: ["Psychic"],
+			effect: {
+				ja: "自分のトラッシュにある[超]エネルギーを、相手の場のポケモンの数ぶん、自分のポケモンに好きなようにつける。",
+			},
+		},
+		{
+			name: { ja: "サイコストーム" },
+			damage: "20×",
+			cost: ["Psychic", "Psychic", "Psychic", "Psychic"],
+			effect: {
+				ja: "おたがいの場のポケモンについているエネルギーの数x20ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 550721,
+			},
+		},
+	],
+
+	retreat: 3,
+	rarity: "Rare Holo",
+	dexId: [792],
+};
+
+export default card;

--- a/data-asia/SM/SM8b/048.ts
+++ b/data-asia/SM/SM8b/048.ts
@@ -1,0 +1,57 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ネクロズマ あかつきのつばさ",
+	},
+
+	illustrator: "nagimiso",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Psychic"],
+
+	description: {
+		ja: "ルナアーラに 最早 意思は ない。 ネクロズマに 支配され すべての エネルギーを 放出 し続ける。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ガルフストリーム" },
+			damage: "20+",
+			cost: ["Psychic"],
+			effect: {
+				ja: "自分のサイドの残り枚数が6枚なら、このポケモンにのっているダメカンの数x20ダメージ追加。",
+			},
+		},
+		{
+			name: { ja: "あかつきのやいば" },
+			damage: 130,
+			cost: ["Psychic", "Psychic", "Psychic"],
+			effect: {
+				ja: "このポケモンについているエネルギーを、2個トラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 550726,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "None",
+	dexId: [800],
+};
+
+export default card;

--- a/data-asia/SM/SM8b/049.ts
+++ b/data-asia/SM/SM8b/049.ts
@@ -1,0 +1,65 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ネクロズマ あかつきのつばさGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 180,
+	types: ["Psychic"],
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "インベイジョン" },
+			effect: {
+				ja: "このポケモンがベンチにいるなら、自分の番に1回使える。このポケモンを自分のバトルポケモンと入れ替える。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "やみのせんこう" },
+			damage: 120,
+			cost: ["Psychic", "Psychic", "Psychic"],
+			effect: {
+				ja: "このワザのダメージは抵抗力を計算しない。",
+			},
+		},
+		{
+			name: { ja: "イクリプスムーンGX" },
+			damage: 180,
+			cost: ["Psychic", "Psychic", "Psychic"],
+			effect: {
+				ja: "このワザは、自分のサイドの残り枚数が、相手より多いときにしか使えない。次の相手の番、このポケモンはワザのダメージや効果を受けない。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 550731,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Double rare",
+	dexId: [800],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM8b/050.ts
+++ b/data-asia/SM/SM8b/050.ts
@@ -1,0 +1,59 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "マーシャドー",
+	},
+
+	illustrator: "Emi Ando",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Psychic"],
+
+	description: {
+		ja: "影の中に 潜むことが でき 人前に 姿を みせないので その存在は 幻 だった。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "やぶれかぶれ" },
+			effect: {
+				ja: "自分の番に、このカードを手札からベンチに出したとき、1回使える。おたがいのプレイヤーは、それぞれ手札をすべて山札にもどして切る。その後、それぞれ山札を4枚引く。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "シャドーパンチ" },
+			damage: 30,
+			cost: ["Psychic", "Colorless"],
+			effect: {
+				ja: "このワザのダメージは抵抗力を計算しない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 550736,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "None",
+	dexId: [802],
+};
+
+export default card;

--- a/data-asia/SM/SM8b/051.ts
+++ b/data-asia/SM/SM8b/051.ts
@@ -1,0 +1,55 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ベベノム",
+	},
+
+	illustrator: "Megumi Mizutani",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Psychic"],
+
+	description: {
+		ja: "異世界に おいては 旅立ちの パートナーに 選ばれるほど 親しまれている ウルトラビースト。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "どくえき" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをどくにする。",
+			},
+		},
+		{
+			name: { ja: "コープスリバイバー" },
+			cost: ["Psychic", "Colorless"],
+			effect: {
+				ja: "次の相手の番、このポケモンがきぜつしても、相手はサイドをとれない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 550741,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "None",
+	dexId: [803],
+};
+
+export default card;

--- a/data-asia/SM/SM8b/052.ts
+++ b/data-asia/SM/SM8b/052.ts
@@ -1,0 +1,66 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アーゴヨンGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 210,
+	types: ["Psychic"],
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "ビーストレイド" },
+			damage: "20×",
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の場の「ウルトラビースト」の数x20ダメージ。",
+			},
+		},
+		{
+			name: { ja: "ジェットタッカー" },
+			damage: 110,
+			cost: ["Psychic", "Colorless", "Colorless"],
+			effect: {
+				ja: "このワザのダメージは弱点・抵抗力を計算しない。",
+			},
+		},
+		{
+			name: { ja: "スティンガーGX" },
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "おたがいのプレイヤーは、それぞれサイドをすべて山札にもどして切る。その後、それぞれ山札を上から3枚、サイドとして置く。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 550746,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ベベノム",
+	},
+
+	retreat: 1,
+	rarity: "Double rare",
+	dexId: [804],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM8b/053.ts
+++ b/data-asia/SM/SM8b/053.ts
@@ -1,0 +1,49 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "カラカラ",
+	},
+
+	illustrator: "sowsow",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Fighting"],
+
+	description: {
+		ja: "頭に 被った 頭がい骨は 死んだ 母親。 死の 悲しみを 乗り越えたとき 進化する という。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "おもいホネ" },
+			damage: 40,
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "次の自分の番、このポケモンはワザが使えない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 550751,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "None",
+	dexId: [104],
+};
+
+export default card;

--- a/data-asia/SM/SM8b/054.ts
+++ b/data-asia/SM/SM8b/054.ts
@@ -1,0 +1,56 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ウソッキー",
+	},
+
+	illustrator: "Hajime Kusajima",
+	category: "Pokemon",
+	hp: 100,
+	types: ["Fighting"],
+
+	description: {
+		ja: "襲われないため 樹木の 真似を するが 嫌いな 水を かけられて あわてて 逃げだしていく。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "みちをふさぐ" },
+			effect: {
+				ja: "このポケモンがいるかぎり、相手がベンチに出せるポケモンの数は、4匹になる。相手のベンチに5匹以上いる場合は、相手はベンチが4匹になるまでポケモンをトラッシュする。［ベンチの数を変更する効果は、少ない数が優先される。］",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "いわおとし" },
+			damage: 40,
+			cost: ["Fighting", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 550756,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "None",
+	dexId: [185],
+};
+
+export default card;

--- a/data-asia/SM/SM8b/055.ts
+++ b/data-asia/SM/SM8b/055.ts
@@ -1,0 +1,53 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "リオル",
+	},
+
+	illustrator: "Kyoko Umemoto",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Fighting"],
+
+	description: {
+		ja: "一晩中 走っていられる タフさが あり 頑張り屋 だが まだまだ ひよっ子 なのだ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "みきり" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "コインを1回投げオモテなら、次の相手の番、このポケモンはワザのダメージや効果を受けない。",
+			},
+		},
+		{
+			name: { ja: "ジャブ" },
+			damage: 10,
+			cost: ["Fighting"],
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 550761,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "None",
+	dexId: [447],
+};
+
+export default card;

--- a/data-asia/SM/SM8b/056.ts
+++ b/data-asia/SM/SM8b/056.ts
@@ -1,0 +1,63 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ルカリオ",
+	},
+
+	illustrator: "Mitsuhiro Arita",
+	category: "Pokemon",
+	hp: 110,
+	types: ["Fighting"],
+
+	description: {
+		ja: "１キロ先の 生き物の 種類や 気持ちを キャッチする。 波動を 操り 群れで 獲物を 狩る。",
+	},
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "はどうよち" },
+			effect: {
+				ja: "自分の場に「ガブリアス」がいるなら、自分の番に1回使える。自分の山札にある好きなカードを1枚、手札に加える。そして山札を切る。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "スカッドジャブ" },
+			damage: 70,
+			cost: ["Fighting", "Colorless"],
+			effect: {
+				ja: "このワザのダメージは抵抗力を計算しない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 550766,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "リオル",
+	},
+
+	retreat: 1,
+	rarity: "None",
+	dexId: [448],
+};
+
+export default card;

--- a/data-asia/SM/SM8b/057.ts
+++ b/data-asia/SM/SM8b/057.ts
@@ -1,0 +1,57 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ジガルデ",
+	},
+
+	illustrator: "Mitsuhiro Arita",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Fighting"],
+
+	description: {
+		ja: "生態系を 監視 していると 考えられている。 さらなる 力を 秘めているとの ウワサ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "へびにらみ" },
+			damage: 20,
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "コインを1回投げオモテなら、相手のバトルポケモンをマヒにする。",
+			},
+		},
+		{
+			name: { ja: "カームストライク" },
+			damage: "60+",
+			cost: ["Fighting", "Colorless", "Colorless"],
+			effect: {
+				ja: "自分がすでにGXワザを使っていたなら、60ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 550771,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "None",
+	dexId: [718],
+};
+
+export default card;

--- a/data-asia/SM/SM8b/058.ts
+++ b/data-asia/SM/SM8b/058.ts
@@ -1,0 +1,55 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ディアンシー",
+	},
+
+	illustrator: "kawayoo",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Fighting"],
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "プリンセスエール" },
+			effect: {
+				ja: "このポケモンがベンチにいるかぎり、自分の[闘]ポケモンが使うワザの、相手のバトルポケモンへのダメージは「+20」される。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ダイヤレイン" },
+			damage: 90,
+			cost: ["Fighting", "Fighting", "Fighting"],
+			effect: {
+				ja: "自分のベンチポケモン全員のHPを、それぞれ「30」回復する。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 550776,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Rare Holo",
+	dexId: [719],
+};
+
+export default card;

--- a/data-asia/SM/SM8b/059.ts
+++ b/data-asia/SM/SM8b/059.ts
@@ -1,0 +1,49 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "イワンコ",
+	},
+
+	illustrator: "Tomokazu Komiya",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Fighting"],
+
+	description: {
+		ja: "昔から 人と 暮らしてきた。 トレーナーが 悲しんでいると それを 察して 側を 離れない。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ふいをつく" },
+			damage: 50,
+			cost: ["Fighting", "Colorless"],
+			effect: {
+				ja: "コインを1回投げウラなら、このワザは失敗。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 550781,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "None",
+	dexId: [744],
+};
+
+export default card;

--- a/data-asia/SM/SM8b/060.ts
+++ b/data-asia/SM/SM8b/060.ts
@@ -1,0 +1,66 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ルガルガンGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 200,
+	types: ["Fighting"],
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ブラッディアイ" },
+			effect: {
+				ja: "自分の番に、このカードを手札から出して進化させたとき、1回使える。相手のベンチポケモンを1匹選び、バトルポケモンと入れ替える。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ツメできりさく" },
+			damage: 110,
+			cost: ["Fighting", "Colorless", "Colorless"],
+		},
+		{
+			name: { ja: "デスローグGX" },
+			damage: "50×",
+			cost: ["Fighting", "Colorless"],
+			effect: {
+				ja: "相手のベンチポケモンの数x50ダメージ。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 550786,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "イワンコ",
+	},
+
+	retreat: 2,
+	rarity: "Double rare",
+	dexId: [745],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM8b/061.ts
+++ b/data-asia/SM/SM8b/061.ts
@@ -1,0 +1,66 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ルガルガンGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 200,
+	types: ["Fighting"],
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "トワイライトアイ" },
+			effect: {
+				ja: "自分の番に、このカードを手札から出して進化させたとき、1回使える。相手のバトルポケモンについているエネルギーを、1個トラッシュする。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "アクセルロック" },
+			damage: 120,
+			cost: ["Fighting", "Colorless", "Colorless"],
+		},
+		{
+			name: { ja: "ラジアルエッジGX" },
+			damage: "30×",
+			cost: ["Fighting"],
+			effect: {
+				ja: "相手のトラッシュにあるエネルギーの枚数x30ダメージ。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 550791,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "イワンコ",
+	},
+
+	retreat: 2,
+	rarity: "Double rare",
+	dexId: [745],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM8b/062.ts
+++ b/data-asia/SM/SM8b/062.ts
@@ -1,0 +1,57 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "マッシブーン",
+	},
+
+	illustrator: "Masakazu Fukuda",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Fighting"],
+
+	description: {
+		ja: "謎の 生物 ＵＢ。 一発の パンチで ダンプカーを 粉砕する 光景が 目撃 された。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "スレッジハンマー" },
+			damage: "30+",
+			cost: ["Fighting"],
+			effect: {
+				ja: "相手のサイドの残り枚数が4枚なら、90ダメージ追加。",
+			},
+		},
+		{
+			name: { ja: "ふりまわす" },
+			damage: "80+",
+			cost: ["Fighting", "Fighting", "Colorless"],
+			effect: {
+				ja: "コインを2回投げ、オモテの数x20ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 550796,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "None",
+	dexId: [794],
+};
+
+export default card;

--- a/data-asia/SM/SM8b/063.ts
+++ b/data-asia/SM/SM8b/063.ts
@@ -1,0 +1,63 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "マッシブーンGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 190,
+	types: ["Fighting"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ジェットパンチ" },
+			damage: 30,
+			cost: ["Fighting"],
+			effect: {
+				ja: "相手のベンチポケモン1匹にも、30ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+			},
+		},
+		{
+			name: { ja: "ナックルインパクト" },
+			damage: 160,
+			cost: ["Fighting", "Fighting", "Fighting"],
+			effect: {
+				ja: "次の自分の番、このポケモンはワザが使えない。",
+			},
+		},
+		{
+			name: { ja: "イクスパンションGX" },
+			damage: "40×",
+			cost: ["Fighting", "Fighting", "Fighting"],
+			effect: {
+				ja: "自分のサイドの枚数x40ダメージ。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 550801,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Double rare",
+	dexId: [794],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM8b/064.ts
+++ b/data-asia/SM/SM8b/064.ts
@@ -1,0 +1,62 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "マーシャドーGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 150,
+	types: ["Fighting"],
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "シャドーハント" },
+			effect: {
+				ja: "このポケモンは、自分のトラッシュにあるたねポケモンが持っているワザを、すべて使える。［ワザを使うためのエネルギーは必要。］",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "せいけんづき" },
+			damage: 120,
+			cost: ["Fighting", "Fighting", "Colorless"],
+		},
+		{
+			name: { ja: "ひゃくれつむそうGX" },
+			damage: "50×",
+			cost: ["Fighting"],
+			effect: {
+				ja: "このポケモンについている基本エネルギーの数x50ダメージ。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 550806,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Double rare",
+	dexId: [802],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM8b/065.ts
+++ b/data-asia/SM/SM8b/065.ts
@@ -1,0 +1,56 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ニューラ",
+	},
+
+	illustrator: "Masakazu Fukuda",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Darkness"],
+
+	description: {
+		ja: "ツメで タマゴに 穴を 開けて 中味を すする。 ブリーダーに 憎まれ 駆除 されることもある。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "こっそりこわす" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "このワザは、後攻プレイヤーの最初の番にだけ使える。相手の場のポケモンについているエネルギーを、1個トラッシュする。",
+			},
+		},
+		{
+			name: { ja: "おそいかかる" },
+			damage: "10+",
+			cost: ["Darkness"],
+			effect: {
+				ja: "コインを1回投げオモテなら、20ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 550811,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "None",
+	dexId: [215],
+};
+
+export default card;

--- a/data-asia/SM/SM8b/066.ts
+++ b/data-asia/SM/SM8b/066.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "マニューラ",
+	},
+
+	illustrator: "Misa Tsutsui",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Darkness"],
+
+	description: {
+		ja: "寒い 場所に 棲み アローラでは ロコンや サンドが 主な 餌。 獲物は 仲間で きちんと 分ける。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "こごえるかぜ" },
+			damage: 10,
+			cost: ["Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをねむりにする。",
+			},
+		},
+		{
+			name: { ja: "あくのいましめ" },
+			damage: "50×",
+			cost: ["Darkness"],
+			effect: {
+				ja: "相手の場の特性を持つポケモンの数x50ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 550816,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ニューラ",
+	},
+
+	retreat: 1,
+	rarity: "None",
+	dexId: [461],
+};
+
+export default card;

--- a/data-asia/SM/SM8b/067.ts
+++ b/data-asia/SM/SM8b/067.ts
@@ -1,0 +1,59 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヤミラミ",
+	},
+
+	illustrator: "Yukiko Baba",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Darkness"],
+
+	description: {
+		ja: "宝石の 瞳が 怪しく 輝くとき 人の 魂を 奪うと 恐れられる ポケモン。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ほりさげる" },
+			effect: {
+				ja: "自分の番に1回使える。自分の山札を上から1枚見て、もとにもどす。のぞむなら、そのカードをトラッシュする。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "かなしばり" },
+			damage: 10,
+			cost: ["Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンが持っているワザを1つ選ぶ。次の相手の番、このワザを受けたポケモンは、選ばれたワザを使えない。",
+			},
+		},
+	],
+
+	weaknesses: [],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 550821,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "None",
+	dexId: [302],
+};
+
+export default card;

--- a/data-asia/SM/SM8b/068.ts
+++ b/data-asia/SM/SM8b/068.ts
@@ -1,0 +1,57 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ダークライ",
+	},
+
+	illustrator: "Hitoshi Ariga",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Darkness"],
+
+	description: {
+		ja: "深い 眠りに 誘う 力で 人や ポケモンに 悪夢を 見せて 自分の 縄張りから 追い出す。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "さいみんはどう" },
+			damage: 30,
+			cost: ["Darkness", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをねむりにする。",
+			},
+		},
+		{
+			name: { ja: "ダークレイド" },
+			damage: "80+",
+			cost: ["Darkness", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手がすでにGXワザを使っていたなら、80ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 550826,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "None",
+	dexId: [491],
+};
+
+export default card;

--- a/data-asia/SM/SM8b/069.ts
+++ b/data-asia/SM/SM8b/069.ts
@@ -1,0 +1,51 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ゾロア",
+	},
+
+	illustrator: "kodama",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Darkness"],
+
+	description: {
+		ja: "相手そっくりに 化けているように みせかけ だましたり 驚かして そのすきに 逃げ出すことが 多い。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ふむ" },
+			damage: 10,
+			cost: ["Darkness"],
+		},
+		{
+			name: { ja: "ぶつかる" },
+			damage: 20,
+			cost: ["Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 550831,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "None",
+	dexId: [570],
+};
+
+export default card;

--- a/data-asia/SM/SM8b/070.ts
+++ b/data-asia/SM/SM8b/070.ts
@@ -1,0 +1,68 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ゾロアークGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 210,
+	types: ["Darkness"],
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "とりひき" },
+			effect: {
+				ja: "自分の番に1回使える。自分の手札を1枚トラッシュする。その後、山札を2枚引く。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ライオットビート" },
+			damage: "20×",
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "自分の場のポケモンの数x20ダメージ。",
+			},
+		},
+		{
+			name: { ja: "トリックスターGX" },
+			cost: ["Darkness", "Darkness"],
+			effect: {
+				ja: "相手の場のポケモンが持っているワザを1つ選び、このワザとして使う。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 550836,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ゾロア",
+	},
+
+	retreat: 2,
+	rarity: "Double rare",
+	dexId: [571],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM8b/071.ts
+++ b/data-asia/SM/SM8b/071.ts
@@ -1,0 +1,54 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "モノズ",
+	},
+
+	illustrator: "miki kudo",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Darkness"],
+
+	description: {
+		ja: "目が 見えないため 体当たりしたり かみついて まわりを 探る。 体中 生傷が 絶えない。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ずつき" },
+			damage: 20,
+			cost: ["Darkness", "Colorless"],
+		},
+		{
+			name: { ja: "ふいをつく" },
+			damage: 60,
+			cost: ["Darkness", "Darkness", "Colorless"],
+			effect: {
+				ja: "コインを1回投げウラなら、このワザは失敗。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 550841,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "None",
+	dexId: [633],
+};
+
+export default card;

--- a/data-asia/SM/SM8b/072.ts
+++ b/data-asia/SM/SM8b/072.ts
@@ -1,0 +1,58 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ジヘッド",
+	},
+
+	illustrator: "kodama",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Darkness"],
+
+	description: {
+		ja: "２つの 頭は 仲が 悪く 相手より 多く 食べることで 主導権を 握ろうと する。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "ずつき" },
+			damage: 30,
+			cost: ["Darkness", "Colorless"],
+		},
+		{
+			name: { ja: "ダブルアタック" },
+			damage: "60×",
+			cost: ["Darkness", "Darkness", "Colorless"],
+			effect: {
+				ja: "コインを2回投げ、オモテの数x60ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 550846,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "モノズ",
+	},
+
+	retreat: 2,
+	rarity: "None",
+	dexId: [634],
+};
+
+export default card;

--- a/data-asia/SM/SM8b/073.ts
+++ b/data-asia/SM/SM8b/073.ts
@@ -1,0 +1,63 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "サザンドラ",
+	},
+
+	illustrator: "Anesaki Dynamic",
+	category: "Pokemon",
+	hp: 160,
+	types: ["Darkness"],
+
+	description: {
+		ja: "両腕の 頭は 脳みそを 持たない。 ３つの 頭で すべてを 食べつくし 破壊してしまう。",
+	},
+
+	stage: "Stage2",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ふるいおとす" },
+			effect: {
+				ja: "自分の番に1回使える。自分のベンチポケモンを3匹選ぶ。その後、選んでいない自分のベンチポケモン全員と、ついているすべてのカードを、トラッシュする。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ダークデストロイ" },
+			damage: 120,
+			cost: ["Darkness", "Darkness", "Colorless"],
+			effect: {
+				ja: "のぞむなら、このポケモンについているエネルギーを、1個トラッシュする。その場合、相手のバトルポケモンについているエネルギーを、1個トラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 550851,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ジヘッド",
+	},
+
+	retreat: 2,
+	rarity: "None",
+	dexId: [635],
+};
+
+export default card;

--- a/data-asia/SM/SM8b/074.ts
+++ b/data-asia/SM/SM8b/074.ts
@@ -1,0 +1,56 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "フーパ",
+	},
+
+	illustrator: "TOKIYA",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Darkness"],
+
+	description: {
+		ja: "真の姿は 巨大な 力を 持っている。 財宝 欲しさに それが 隠された 城ごと 引き抜き 奪い去った という 伝説が ある。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "バンデットガード" },
+			effect: {
+				ja: "このポケモンは、相手の「ポケモンGX・EX」からワザのダメージや効果を受けない。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ちょうねんりき" },
+			damage: 80,
+			cost: ["Darkness", "Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 550856,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "None",
+	dexId: [720],
+};
+
+export default card;

--- a/data-asia/SM/SM8b/075.ts
+++ b/data-asia/SM/SM8b/075.ts
@@ -1,0 +1,49 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アクジキング",
+	},
+
+	illustrator: "Anesaki Dynamic",
+	category: "Pokemon",
+	hp: 160,
+	types: ["Darkness"],
+
+	description: {
+		ja: "危険生物 ビーストの 一種。 つねに なにかを 喰らっているようだが なぜか フンは 未発見。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "キングスバレイ" },
+			damage: 160,
+			cost: ["Darkness", "Darkness", "Darkness", "Darkness"],
+			effect: {
+				ja: "自分のサイドの残り枚数が6枚・4枚・2枚なら、自分の山札を上から10枚トラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 550861,
+			},
+		},
+	],
+
+	retreat: 4,
+	rarity: "None",
+	dexId: [799],
+};
+
+export default card;

--- a/data-asia/SM/SM8b/076.ts
+++ b/data-asia/SM/SM8b/076.ts
@@ -1,0 +1,49 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アローラディグダ",
+	},
+
+	illustrator: "Naoyo Kimura",
+	category: "Pokemon",
+	hp: 50,
+	types: ["Metal"],
+
+	description: {
+		ja: "金色の 髭は センサー機能を 持っている。 穴から だして 周りの 様子を うかがっている。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "アイアンヘッド" },
+			damage: "10×",
+			cost: [],
+			effect: {
+				ja: "ウラが出るまでコインを投げ、オモテの数x10ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 550866,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "None",
+	dexId: [50],
+};
+
+export default card;

--- a/data-asia/SM/SM8b/077.ts
+++ b/data-asia/SM/SM8b/077.ts
@@ -1,0 +1,53 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アローラダグトリオ",
+	},
+
+	illustrator: "Megumi Mizutani",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Metal"],
+
+	description: {
+		ja: "大地の 女神たちの 化身と 考えられ アローラ地方では とても 大切に されている。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "ゴールドラッシュ" },
+			damage: "30×",
+			cost: [],
+			effect: {
+				ja: "自分の手札にある[鋼]エネルギーを好きなだけトラッシュし、その枚数x30ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 550871,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "アローラディグダ",
+	},
+
+	retreat: 1,
+	rarity: "None",
+	dexId: [51],
+};
+
+export default card;

--- a/data-asia/SM/SM8b/078.ts
+++ b/data-asia/SM/SM8b/078.ts
@@ -1,0 +1,53 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "コイル",
+	},
+
+	illustrator: "MAHOU",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Metal"],
+
+	description: {
+		ja: "電磁波を 放ち 空を 漂う。 電気を 喰っているときに 触ると 全身が ビリッと 痺れるぞ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "マグネサーチ" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札にある[鋼]エネルギーを3枚まで、相手に見せてから、手札に加える。そして山札を切る。",
+			},
+		},
+		{
+			name: { ja: "たいあたり" },
+			damage: 10,
+			cost: ["Metal"],
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 550876,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "None",
+	dexId: [81],
+};
+
+export default card;

--- a/data-asia/SM/SM8b/079.ts
+++ b/data-asia/SM/SM8b/079.ts
@@ -1,0 +1,58 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "レアコイル",
+	},
+
+	illustrator: "kirisAki",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Metal"],
+
+	description: {
+		ja: "ほぼ コイル ３倍の 電力。 太陽の黒点が 多いとき なぜか 大量発生。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "ぶつかる" },
+			damage: 20,
+			cost: ["Metal"],
+		},
+		{
+			name: { ja: "でんじほう" },
+			damage: 80,
+			cost: ["Metal", "Metal", "Colorless"],
+			effect: {
+				ja: "次の自分の番、このポケモンは「でんじほう」が使えない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 550881,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "コイル",
+	},
+
+	retreat: 2,
+	rarity: "None",
+	dexId: [82],
+};
+
+export default card;

--- a/data-asia/SM/SM8b/080.ts
+++ b/data-asia/SM/SM8b/080.ts
@@ -1,0 +1,63 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ジバコイル",
+	},
+
+	illustrator: "Yoshinobu Saito",
+	category: "Pokemon",
+	hp: 150,
+	types: ["Metal"],
+
+	description: {
+		ja: "怪電波を 発信 しながら 空を 飛び回り 未知の 電波を 受信 していると いう。",
+	},
+
+	stage: "Stage2",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "マグネサーキット" },
+			effect: {
+				ja: "自分の番に何回でも使える。自分の手札にある[鋼]エネルギーを1枚、自分のポケモンにつける。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "でんじほう" },
+			damage: 130,
+			cost: ["Metal", "Metal", "Metal", "Colorless"],
+			effect: {
+				ja: "次の自分の番、このポケモンは「でんじほう」が使えない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 550886,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "レアコイル",
+	},
+
+	retreat: 2,
+	rarity: "None",
+	dexId: [462],
+};
+
+export default card;

--- a/data-asia/SM/SM8b/081.ts
+++ b/data-asia/SM/SM8b/081.ts
@@ -1,0 +1,57 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヒードラン",
+	},
+
+	illustrator: "tetsuya koizumi",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Metal"],
+
+	description: {
+		ja: "マグマのように 燃えたぎる 血液が 体を 流れている。 火山の 洞穴に 生息する。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ガードプレス" },
+			damage: 30,
+			cost: ["Metal", "Colorless"],
+			effect: {
+				ja: "次の相手の番、このポケモンが受けるワザのダメージは「-30」される。",
+			},
+		},
+		{
+			name: { ja: "ボイラーインパクト" },
+			damage: 130,
+			cost: ["Metal", "Metal", "Colorless"],
+			effect: {
+				ja: "このポケモンについているエネルギーを、2個トラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 550891,
+			},
+		},
+	],
+
+	retreat: 3,
+	rarity: "None",
+	dexId: [485],
+};
+
+export default card;

--- a/data-asia/SM/SM8b/082.ts
+++ b/data-asia/SM/SM8b/082.ts
@@ -1,0 +1,52 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ソルガレオ",
+	},
+
+	illustrator: "Shin Nagasawa",
+	category: "Pokemon",
+	hp: 160,
+	types: ["Metal"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ライジングスター" },
+			cost: ["Metal"],
+			effect: {
+				ja: "自分のトラッシュにある[鋼]エネルギーを、相手の場のポケモンの数ぶん、自分のポケモンに好きなようにつける。",
+			},
+		},
+		{
+			name: { ja: "コロナインパクト" },
+			damage: 160,
+			cost: ["Metal", "Metal", "Metal", "Metal"],
+			effect: {
+				ja: "次の自分の番、このポケモンはワザが使えない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 550896,
+			},
+		},
+	],
+
+	retreat: 3,
+	rarity: "Rare Holo",
+	dexId: [791],
+};
+
+export default card;

--- a/data-asia/SM/SM8b/083.ts
+++ b/data-asia/SM/SM8b/083.ts
@@ -1,0 +1,49 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "テッカグヤ",
+	},
+
+	illustrator: "kawayoo",
+	category: "Pokemon",
+	hp: 140,
+	types: ["Metal"],
+
+	description: {
+		ja: "ＵＢの 一種。 ２本の 腕から ガスを 噴きだし 森を 焼き払う 姿が 確認 されている。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ムーンレイカー" },
+			damage: 160,
+			cost: ["Metal", "Colorless", "Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "このワザは、おたがいのサイドの残り枚数の合計が6枚なら、[鋼]エネルギー1個で使える。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 550901,
+			},
+		},
+	],
+
+	retreat: 4,
+	rarity: "None",
+	dexId: [797],
+};
+
+export default card;

--- a/data-asia/SM/SM8b/084.ts
+++ b/data-asia/SM/SM8b/084.ts
@@ -1,0 +1,49 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "カミツルギ",
+	},
+
+	illustrator: "Hasuno",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Metal"],
+
+	description: {
+		ja: "巨大な 鉄塔を 一刀の もとに 切り捨てる 姿が 目撃された ビーストの 一種。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "カミカゼ" },
+			damage: "40+",
+			cost: ["Metal", "Metal"],
+			effect: {
+				ja: "相手のサイドの残り枚数が6枚なら、90ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 550906,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "None",
+	dexId: [798],
+};
+
+export default card;

--- a/data-asia/SM/SM8b/085.ts
+++ b/data-asia/SM/SM8b/085.ts
@@ -1,0 +1,56 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ネクロズマ たそがれのたてがみ",
+	},
+
+	illustrator: "nagimiso",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Metal"],
+
+	description: {
+		ja: "ソルガレオの光を 喰らい続ける 姿。 敵に とびかかり 背中と 四肢のツメで 相手を 切り裂く。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "たそがれのだんがん" },
+			cost: ["Metal"],
+			effect: {
+				ja: "相手の「ポケモンGX・EX」1匹に、60ダメージ。このワザのダメージは、弱点・抵抗力を計算しない。",
+			},
+		},
+		{
+			name: { ja: "ラスティネイル" },
+			damage: "100+",
+			cost: ["Metal", "Metal", "Colorless"],
+			effect: {
+				ja: "相手のサイドの残り枚数が1枚なら、100ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 550911,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "None",
+	dexId: [800],
+};
+
+export default card;

--- a/data-asia/SM/SM8b/086.ts
+++ b/data-asia/SM/SM8b/086.ts
@@ -1,0 +1,60 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ネクロズマ たそがれのたてがみGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 190,
+	types: ["Metal"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ツメできりさく" },
+			damage: 60,
+			cost: ["Colorless", "Colorless", "Colorless"],
+		},
+		{
+			name: { ja: "メテオテンペスト" },
+			damage: 220,
+			cost: ["Metal", "Metal", "Metal", "Colorless"],
+			effect: {
+				ja: "このポケモンについているエネルギーを、3個トラッシュする。",
+			},
+		},
+		{
+			name: { ja: "イクリプスサンGX" },
+			damage: 250,
+			cost: ["Metal", "Metal", "Metal"],
+			effect: {
+				ja: "このワザは、自分のサイドの残り枚数が、相手より多いときにしか使えない。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 550916,
+			},
+		},
+	],
+
+	retreat: 3,
+	rarity: "Double rare",
+	dexId: [800],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM8b/087.ts
+++ b/data-asia/SM/SM8b/087.ts
@@ -1,0 +1,56 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "マギアナ",
+	},
+
+	illustrator: "kawayoo",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Metal"],
+
+	description: {
+		ja: "５００年以上前に 造られた 人造ポケモン。 人の 言葉を 理解するが しゃべれない。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "きせかえ" },
+			effect: {
+				ja: "自分の番に1回使える。自分の場のポケモンについている「ポケモンのどうぐ」を1枚、手札にもどす。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ボールアタック" },
+			damage: 60,
+			cost: ["Metal", "Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 550921,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "None",
+	dexId: [801],
+};
+
+export default card;

--- a/data-asia/SM/SM8b/088.ts
+++ b/data-asia/SM/SM8b/088.ts
@@ -1,0 +1,62 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ツンデツンデGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 180,
+	types: ["Metal"],
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ウルトラウォール" },
+			effect: {
+				ja: "このポケモンがいるかぎり、自分の「ウルトラビースト」全員が、相手のポケモンから受けるワザのダメージは「-10」される。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ギガトンスタンプ" },
+			damage: 120,
+			cost: ["Metal", "Metal", "Colorless"],
+		},
+		{
+			name: { ja: "レイGX" },
+			damage: "50+",
+			cost: ["Metal", "Metal", "Colorless"],
+			effect: {
+				ja: "自分がすでにとったサイドの枚数x50ダメージ追加。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 550926,
+			},
+		},
+	],
+
+	retreat: 3,
+	rarity: "Double rare",
+	dexId: [805],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM8b/089.ts
+++ b/data-asia/SM/SM8b/089.ts
@@ -1,0 +1,60 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アローラキュウコン",
+	},
+
+	illustrator: "Misa Tsutsui",
+	category: "Pokemon",
+	hp: 110,
+	types: ["Fairy"],
+
+	description: {
+		ja: "体毛から 氷の粒を 生み 敵に 浴びせかける。 怒らせると 一瞬で 氷漬けに される。",
+	},
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ひかりのけっかい" },
+			effect: {
+				ja: "このポケモンは、相手の「ポケモンGX・EX」からワザのダメージや効果を受けない。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "オーロラビーム" },
+			damage: 80,
+			cost: ["Fairy", "Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 550941,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "アローラロコン",
+	},
+
+	retreat: 1,
+	rarity: "None",
+	dexId: [38],
+};
+
+export default card;

--- a/data-asia/SM/SM8b/090.ts
+++ b/data-asia/SM/SM8b/090.ts
@@ -1,0 +1,49 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ラルトス",
+	},
+
+	illustrator: "Yumi",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Fairy"],
+
+	description: {
+		ja: "赤いツノで 人や ポケモンの 温かな 気持ちを キャッチすると 全身が ほのかに 熱くなる。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ドレインキッス" },
+			damage: 10,
+			cost: ["Fairy"],
+			effect: {
+				ja: "このポケモンのHPを「10」回復する。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [{ type: "Darkness", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 550946,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "None",
+	dexId: [280],
+};
+
+export default card;

--- a/data-asia/SM/SM8b/091.ts
+++ b/data-asia/SM/SM8b/091.ts
@@ -1,0 +1,55 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "キルリア",
+	},
+
+	illustrator: "Anesaki Dynamic",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Fairy"],
+
+	description: {
+		ja: "トレーナーの 明るい 気持ちが サイコパワーの 源。 楽しい 気分に なると クルクル 踊る。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "ひらてうち" },
+			damage: 20,
+			cost: ["Colorless"],
+		},
+		{
+			name: { ja: "マジカルショット" },
+			damage: 30,
+			cost: ["Fairy", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [{ type: "Darkness", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 550951,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ラルトス",
+	},
+
+	retreat: 1,
+	rarity: "None",
+	dexId: [281],
+};
+
+export default card;

--- a/data-asia/SM/SM8b/092.ts
+++ b/data-asia/SM/SM8b/092.ts
@@ -1,0 +1,68 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "サーナイトGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 230,
+	types: ["Fairy"],
+
+	stage: "Stage2",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ひみつのいずみ" },
+			effect: {
+				ja: "自分の番に1回使える。自分の手札にある[妖]エネルギーを1枚、自分のポケモンにつける。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "インフィニットフォース" },
+			damage: "30×",
+			cost: ["Fairy"],
+			effect: {
+				ja: "おたがいのバトルポケモンについているエネルギーの数x30ダメージ。",
+			},
+		},
+		{
+			name: { ja: "トワイライトGX" },
+			cost: ["Fairy"],
+			effect: {
+				ja: "自分のトラッシュにある好きなカードを10枚、相手に見せてから、山札にもどして切る。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [{ type: "Darkness", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 550956,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "キルリア",
+	},
+
+	retreat: 2,
+	rarity: "Double rare",
+	dexId: [282],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM8b/093.ts
+++ b/data-asia/SM/SM8b/093.ts
@@ -1,0 +1,56 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ゼルネアス",
+	},
+
+	illustrator: "sui",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Fairy"],
+
+	description: {
+		ja: "永遠の 命を 分け与えると 言われている。 樹木の 姿で １０００年 眠り 復活する。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "みちびく" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札にあるサポートを1枚、相手に見せてから、手札に加える。そして山札を切る。",
+			},
+		},
+		{
+			name: { ja: "ブライトホーン" },
+			damage: 130,
+			cost: ["Fairy", "Fairy", "Fairy"],
+			effect: {
+				ja: "次の自分の番、このポケモンは「ブライトホーン」が使えない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [{ type: "Darkness", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 550961,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "None",
+	dexId: [716],
+};
+
+export default card;

--- a/data-asia/SM/SM8b/094.ts
+++ b/data-asia/SM/SM8b/094.ts
@@ -1,0 +1,56 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ディアンシー",
+	},
+
+	illustrator: "TOKIYA",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Fairy"],
+
+	description: {
+		ja: "メレシーの 突然変異。 ピンク色に 輝く 体は 世界一 美しいと 言われる。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "きらめくいのり" },
+			cost: ["Fairy"],
+			effect: {
+				ja: "自分の場のポケモン1匹から進化するカードを、自分の山札から1枚選び、そのポケモンにのせて進化させる。そして山札を切る。",
+			},
+		},
+		{
+			name: { ja: "ダイヤストーム" },
+			damage: 30,
+			cost: ["Fairy", "Colorless"],
+			effect: {
+				ja: "自分の[妖]ポケモン全員のHPを、それぞれ「30」回復する。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [{ type: "Darkness", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 550966,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "None",
+	dexId: [719],
+};
+
+export default card;

--- a/data-asia/SM/SM8b/095.ts
+++ b/data-asia/SM/SM8b/095.ts
@@ -1,0 +1,55 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ミミッキュ",
+	},
+
+	illustrator: "Eri Yamaki",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Fairy"],
+
+	description: {
+		ja: "正体不明。 ボロ布の 中身を みた とある 学者は 恐怖の あまり ショック死した。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "くすねる" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札を2枚引く。",
+			},
+		},
+		{
+			name: { ja: "まねっこ" },
+			cost: ["Fairy", "Colorless"],
+			effect: {
+				ja: "前の相手の番に、相手のポケモンがワザ（GXワザをのぞく）を使っていたなら、そのワザをこのワザとして使う。",
+			},
+		},
+	],
+
+	weaknesses: [],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 550971,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "None",
+	dexId: [778],
+};
+
+export default card;

--- a/data-asia/SM/SM8b/096.ts
+++ b/data-asia/SM/SM8b/096.ts
@@ -1,0 +1,53 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アローラナッシー",
+	},
+
+	illustrator: "Anesaki Dynamic",
+	category: "Pokemon",
+	hp: 160,
+	types: ["Dragon"],
+
+	description: {
+		ja: "伸び伸び 育って サイコパワーは いらなくなり 眠れる ドラゴンの 力が 覚醒 したのだ。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "トロピカルシェイク" },
+			damage: "20+",
+			cost: ["Grass"],
+			effect: {
+				ja: "自分のトラッシュにある基本エネルギーのタイプの数x20ダメージ追加。追加できるダメージはタイプ5種類ぶんまで。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fairy", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 550976,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "タマタマ",
+	},
+
+	retreat: 3,
+	rarity: "None",
+	dexId: [103],
+};
+
+export default card;

--- a/data-asia/SM/SM8b/097.ts
+++ b/data-asia/SM/SM8b/097.ts
@@ -1,0 +1,60 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "チルタリス",
+	},
+
+	illustrator: "Kyoko Umemoto",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Dragon"],
+
+	description: {
+		ja: "晴れた日 綿雲に まぎれながら 大空を 自由に 飛び回り 美しい ソプラノで 歌う。",
+	},
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "たたかいのうた" },
+			effect: {
+				ja: "このポケモンがいるかぎり、自分の[竜]ポケモンが使うワザの、相手のバトルポケモンへのダメージは「+20」される。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "つきさす" },
+			damage: 20,
+			cost: ["Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fairy", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 550981,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "チルット",
+	},
+
+	retreat: 1,
+	rarity: "None",
+	dexId: [334],
+};
+
+export default card;

--- a/data-asia/SM/SM8b/098.ts
+++ b/data-asia/SM/SM8b/098.ts
@@ -1,0 +1,64 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "レックウザGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 180,
+	types: ["Dragon"],
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "しっぷうどとう" },
+			effect: {
+				ja: "自分の番に、このカードを手札からベンチに出したとき、1回使える。自分の山札を上から3枚トラッシュする。その後、トラッシュにある基本エネルギーを1枚、このポケモンにつける。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ドラゴンブレイク" },
+			damage: "30×",
+			cost: ["Grass", "Lightning", "Colorless"],
+			effect: {
+				ja: "自分の場のポケモンについている[草]と[雷]タイプの基本エネルギーの数x30ダメージ。",
+			},
+		},
+		{
+			name: { ja: "テンペストGX" },
+			cost: ["Grass"],
+			effect: {
+				ja: "自分の手札をすべてトラッシュし、山札を10枚引く。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fairy", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 550986,
+			},
+		},
+	],
+
+	retreat: 3,
+	rarity: "Double rare",
+	dexId: [384],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM8b/099.ts
+++ b/data-asia/SM/SM8b/099.ts
@@ -1,0 +1,48 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "フカマル",
+	},
+
+	illustrator: "Kyoko Umemoto",
+	category: "Pokemon",
+	hp: 50,
+	types: ["Dragon"],
+
+	description: {
+		ja: "穴倉に 潜み 獲物や 敵が 横切ると 飛びだして 噛みつく。 勢い余り 歯が 欠けることも。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "かくせい" },
+			cost: ["Fighting"],
+			effect: {
+				ja: "このポケモンから進化するカードを、自分の山札から1枚選び、このポケモンにのせて進化させる。そして山札を切る。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fairy", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 550991,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "None",
+	dexId: [443],
+};
+
+export default card;

--- a/data-asia/SM/SM8b/100.ts
+++ b/data-asia/SM/SM8b/100.ts
@@ -1,0 +1,57 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ガバイト",
+	},
+
+	illustrator: "Sumiyoshi Kizuki",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Dragon"],
+
+	description: {
+		ja: "光り 輝くものが 大好き。 宝石や 捕まえた メレシーを 巣穴で じーっと 眺めている。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "かくせい" },
+			cost: ["Fighting"],
+			effect: {
+				ja: "このポケモンから進化するカードを、自分の山札から1枚選び、このポケモンにのせて進化させる。そして山札を切る。",
+			},
+		},
+		{
+			name: { ja: "きりさく" },
+			damage: 40,
+			cost: ["Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fairy", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 550996,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "フカマル",
+	},
+
+	retreat: 1,
+	rarity: "None",
+	dexId: [444],
+};
+
+export default card;

--- a/data-asia/SM/SM8b/101.ts
+++ b/data-asia/SM/SM8b/101.ts
@@ -1,0 +1,60 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ガブリアス",
+	},
+
+	illustrator: "Megumi Mizutani",
+	category: "Pokemon",
+	hp: 150,
+	types: ["Dragon"],
+
+	description: {
+		ja: "頭に ついた ２つの 突起は センサーの 役目。 遥か 先の 獲物の 様子も わかる。",
+	},
+
+	stage: "Stage2",
+
+	attacks: [
+		{
+			name: { ja: "クイックダイブ" },
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "相手のポケモン1匹に、50ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+			},
+		},
+		{
+			name: { ja: "おうじゃのやいば" },
+			damage: "100+",
+			cost: ["Fighting", "Colorless", "Colorless"],
+			effect: {
+				ja: "この番、手札から「シロナ」を出して使っていたなら、100ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fairy", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 551001,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ガバイト",
+	},
+
+	retreat: 0,
+	rarity: "None",
+	dexId: [445],
+};
+
+export default card;

--- a/data-asia/SM/SM8b/102.ts
+++ b/data-asia/SM/SM8b/102.ts
@@ -1,0 +1,54 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ジガルデ",
+	},
+
+	illustrator: "Masakazu Fukuda",
+	category: "Pokemon",
+	hp: 150,
+	types: ["Dragon"],
+
+	description: {
+		ja: "生態系を 脅かす者を 圧倒的な 力を 以て 制圧する ジガルデの 姿。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ランドクラッシュ" },
+			damage: 80,
+			cost: ["Colorless", "Colorless", "Colorless"],
+		},
+		{
+			name: { ja: "コアパニッシャー" },
+			damage: 150,
+			cost: ["Darkness", "Fairy", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンについている[悪]エネルギーと[妖]エネルギーを、1個ずつトラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fairy", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 551006,
+			},
+		},
+	],
+
+	retreat: 4,
+	rarity: "None",
+	dexId: [718],
+};
+
+export default card;

--- a/data-asia/SM/SM8b/103.ts
+++ b/data-asia/SM/SM8b/103.ts
@@ -1,0 +1,49 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "バクガメス",
+	},
+
+	illustrator: "Sumiyoshi Kizuki",
+	category: "Pokemon",
+	hp: 110,
+	types: ["Dragon"],
+
+	description: {
+		ja: "鼻の 孔から 炎や 毒ガスを 吹く。 フンは 爆発物で 色んな 使い道が ある。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ばくふんしゃ" },
+			damage: "50×",
+			cost: ["Fire", "Fire", "Fire"],
+			effect: {
+				ja: "自分の場のポケモンについている[炎]エネルギーを好きなだけトラッシュし、その枚数x50ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fairy", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 551011,
+			},
+		},
+	],
+
+	retreat: 3,
+	rarity: "None",
+	dexId: [776],
+};
+
+export default card;

--- a/data-asia/SM/SM8b/104.ts
+++ b/data-asia/SM/SM8b/104.ts
@@ -1,0 +1,54 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ウルトラネクロズマGX",
+	},
+
+	illustrator: "PLANETA Otani",
+	category: "Pokemon",
+	hp: 190,
+	types: ["Dragon"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "フォトンゲイザー" },
+			damage: "20+",
+			cost: ["Psychic", "Metal"],
+			effect: {
+				ja: "このポケモンについている基本[超]エネルギーをすべてトラッシュし、その枚数x80ダメージ追加。",
+			},
+		},
+		{
+			name: { ja: "めつぼうのひかりGX" },
+			cost: ["Psychic", "Metal"],
+			effect: {
+				ja: "このワザは、おたがいのサイドの残り枚数の合計が、6枚以下のときにしか使えない。相手のポケモン全員に、それぞれダメカンを6個のせる。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fairy", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 551016,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Double rare",
+	dexId: [800],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM8b/105.ts
+++ b/data-asia/SM/SM8b/105.ts
@@ -1,0 +1,58 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "イーブイ",
+	},
+
+	illustrator: "Shibuzoh.",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Colorless"],
+
+	description: {
+		ja: "今 現在の 調査では なんと ８種類もの ポケモンへ 進化する 可能性を 持つ。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "エナジーしんか" },
+			effect: {
+				ja: "自分の番に、自分の手札から基本エネルギーをこのポケモンにつけたとき、1回使える。つけたエネルギーと同じタイプの、このポケモンから進化するカードを、自分の山札から1枚選び、このポケモンにのせて進化させる。そして山札を切る。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "クイックドロー" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "コインを1回投げオモテなら、自分の山札を1枚引く。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 551021,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "None",
+	dexId: [133],
+};
+
+export default card;

--- a/data-asia/SM/SM8b/106.ts
+++ b/data-asia/SM/SM8b/106.ts
@@ -1,0 +1,56 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ノコッチ",
+	},
+
+	illustrator: "Mitsuhiro Arita",
+	category: "Pokemon",
+	hp: 50,
+	types: ["Colorless"],
+
+	description: {
+		ja: "尻尾で 地面を 掘って 迷路のような 巣穴を 作る。 羽で 少しだけ 飛べる。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "よんでにげる" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札にあるたねポケモンを3枚まで、ベンチに出す。そして山札を切る。ベンチに出した場合、のぞむなら、このポケモンをベンチポケモンと入れ替える。",
+			},
+		},
+		{
+			name: { ja: "スネークフラッシュ" },
+			damage: 10,
+			cost: ["Colorless"],
+			effect: {
+				ja: "コインを1回投げオモテなら、相手のバトルポケモンをマヒにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 551026,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "None",
+	dexId: [206],
+};
+
+export default card;

--- a/data-asia/SM/SM8b/107.ts
+++ b/data-asia/SM/SM8b/107.ts
@@ -1,0 +1,53 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "チルット",
+	},
+
+	illustrator: "Yukiko Baba",
+	category: "Pokemon",
+	hp: 50,
+	types: ["Colorless"],
+
+	description: {
+		ja: "真綿の ような 翼の 手入れは 絶対に 欠かさない。 汚れると 水浴びをして きれいに 洗う。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "もってくる" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札を1枚引く。",
+			},
+		},
+		{
+			name: { ja: "つつく" },
+			damage: 20,
+			cost: ["Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 551031,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "None",
+	dexId: [333],
+};
+
+export default card;

--- a/data-asia/SM/SM8b/108.ts
+++ b/data-asia/SM/SM8b/108.ts
@@ -1,0 +1,58 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "スピンロトム",
+	},
+
+	illustrator: "Masakazu Fukuda",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Colorless"],
+
+	description: {
+		ja: "プラズマで できた 体を 持つ。 電化製品に 潜りこみ 悪さを することで 知られている。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ロトモーター" },
+			effect: {
+				ja: "自分のトラッシュに「ポケモンのどうぐ」が9枚以上あるなら、このポケモンが使うワザに必要なエネルギーは、すべてなくなる。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "くるくるスピン" },
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のポケモン全員に、それぞれ20ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 551036,
+			},
+		},
+	],
+
+	retreat: 0,
+	rarity: "None",
+	dexId: [479],
+};
+
+export default card;

--- a/data-asia/SM/SM8b/109.ts
+++ b/data-asia/SM/SM8b/109.ts
@@ -1,0 +1,59 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヤレユータン",
+	},
+
+	illustrator: "Mitsuhiro Arita",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Colorless"],
+
+	description: {
+		ja: "ジャングル奥地の 木の上に 棲む。 まれに 海辺に 現れて ヤドキングと 知恵比べを する。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "さいはい" },
+			effect: {
+				ja: "自分の番に1回使える。自分の手札が3枚になるように、山札を引く。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "サイコキネシス" },
+			damage: "60+",
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンについているエネルギーの数x20ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 551041,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "None",
+	dexId: [765],
+};
+
+export default card;

--- a/data-asia/SM/SM8b/110.ts
+++ b/data-asia/SM/SM8b/110.ts
@@ -1,0 +1,54 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "タイプ：ヌル",
+	},
+
+	illustrator: "Hitoshi Ariga",
+	category: "Pokemon",
+	hp: 110,
+	types: ["Colorless"],
+
+	description: {
+		ja: "重い 制御マスクを つけており 本来の 能力を だせない。 特別な 力を 秘めている。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "アーマープレス" },
+			damage: 30,
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "次の相手の番、このポケモンが受けるワザのダメージは「-30」される。",
+			},
+		},
+		{
+			name: { ja: "スラッシュクロー" },
+			damage: 70,
+			cost: ["Colorless", "Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 551046,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "None",
+	dexId: [772],
+};
+
+export default card;

--- a/data-asia/SM/SM8b/111.ts
+++ b/data-asia/SM/SM8b/111.ts
@@ -1,0 +1,69 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "シルヴァディGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 210,
+	types: ["Colorless"],
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ジャイロユニット" },
+			effect: {
+				ja: "このポケモンがいるかぎり、自分のたねポケモン全員のにげるためのエネルギーは、すべてなくなる。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ターボドライブ" },
+			damage: 120,
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "自分のトラッシュにある基本エネルギーを1枚、ベンチポケモンにつける。",
+			},
+		},
+		{
+			name: { ja: "リベリオンGX" },
+			damage: "50×",
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のベンチポケモンの数x50ダメージ。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 551051,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "タイプ：ヌル",
+	},
+
+	retreat: 2,
+	rarity: "Double rare",
+	dexId: [773],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM8b/112.ts
+++ b/data-asia/SM/SM8b/112.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "エネくじ",
+	},
+
+	illustrator: "Yoshinobu Saito",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の山札を上から7枚見る。その中にあるエネルギーを1枚、相手に見せてから、手札に加えてよい。残りのカードは山札にもどして切る。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 551056,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/SM/SM8b/113.ts
+++ b/data-asia/SM/SM8b/113.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "エネルギーリサイクル",
+	},
+
+	illustrator: "Toyste Beach",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分のトラッシュから基本エネルギーを5枚選び、相手に見せてから、山札にもどす。そして山札を切る。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 551061,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/SM/SM8b/114.ts
+++ b/data-asia/SM/SM8b/114.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "カウンターキャッチャー",
+	},
+
+	illustrator: "Toyste Beach",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードは、自分のサイドの残り枚数が、相手のサイドの残り枚数より多いときにしか使えない。相手のベンチポケモンを1匹選び、バトルポケモンと入れ替える。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 551066,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/SM/SM8b/115.ts
+++ b/data-asia/SM/SM8b/115.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ビーストリング",
+	},
+
+	illustrator: "Toyste Beach",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードは、相手のサイドの残り枚数が、4枚または3枚でなければ使えない。自分の山札にある基本エネルギーを2枚まで、自分の「ウルトラビースト」1匹につける。そして山札を切る。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 551071,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/SM/SM8b/116.ts
+++ b/data-asia/SM/SM8b/116.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "火打石",
+	},
+
+	illustrator: "Eske Yoshinob",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードは、自分の手札を2枚トラッシュしなければ使えない。自分の山札にある[炎]エネルギーを4枚まで、相手に見せてから、手札に加える。そして山札を切る。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 551076,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/SM/SM8b/117.ts
+++ b/data-asia/SM/SM8b/117.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "フィールドブロアー",
+	},
+
+	illustrator: "Toyste Beach",
+	category: "Trainer",
+
+	effect: {
+		ja: "場にある「ポケモンのどうぐ」または「スタジアム」を、2枚までトラッシュする。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 551081,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/SM/SM8b/118.ts
+++ b/data-asia/SM/SM8b/118.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "まんたんのくすり",
+	},
+
+	illustrator: "Toyste Beach",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分のポケモンを1匹選び、HPをすべて回復する。その後、そのポケモンについているエネルギーをすべてトラッシュする。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 551086,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/SM/SM8b/119.ts
+++ b/data-asia/SM/SM8b/119.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ミステリートレジャー",
+	},
+
+	illustrator: "Eske Yoshinob",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードは、自分の手札を1枚トラッシュしなければ使えない。自分の山札にある[超]または[竜]ポケモンを1枚、相手に見せてから、手札に加える。そして山札を切る。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 551091,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/SM/SM8b/120.ts
+++ b/data-asia/SM/SM8b/120.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "レスキュータンカ",
+	},
+
+	illustrator: "Yoshinobu Saito",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分のトラッシュにあるポケモンを1枚、相手に見せてから、手札に加える。または、自分のトラッシュにあるポケモンを3枚、相手に見せてから、山札にもどして切る。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 551096,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/SM/SM8b/121.ts
+++ b/data-asia/SM/SM8b/121.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ウォーターメモリ",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードをつけている「シルヴァディGX」は、ポケモンになる。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 551101,
+			},
+		},
+	],
+
+	trainerType: "Tool",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/SM/SM8b/122.ts
+++ b/data-asia/SM/SM8b/122.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "エスケープボード",
+	},
+
+	illustrator: "Toyste Beach",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードをつけているポケモンは、にげるためのエネルギーが1個ぶん少なくなり、ねむりまたはマヒでも、にげられる。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 551106,
+			},
+		},
+	],
+
+	trainerType: "Tool",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/SM/SM8b/123.ts
+++ b/data-asia/SM/SM8b/123.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "グラスメモリ",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードをつけている「シルヴァディGX」は、ポケモンになる。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 551111,
+			},
+		},
+	],
+
+	trainerType: "Tool",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/SM/SM8b/124.ts
+++ b/data-asia/SM/SM8b/124.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "鋼鉄のフライパン",
+	},
+
+	illustrator: "Toyste Beach",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードをつけているポケモンは、相手のポケモンから受けるワザのダメージが「-30」され、弱点もなくなる。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 551116,
+			},
+		},
+	],
+
+	trainerType: "Tool",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/SM/SM8b/125.ts
+++ b/data-asia/SM/SM8b/125.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ねがいのバトン",
+	},
+
+	illustrator: "Toyste Beach",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードをつけているポケモンが、バトル場で相手のワザのダメージを受けてきぜつしたとき、そのポケモンについている基本エネルギーを3枚まで、自分のベンチポケモン1匹につけ替える。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 551121,
+			},
+		},
+	],
+
+	trainerType: "Tool",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/SM/SM8b/126.ts
+++ b/data-asia/SM/SM8b/126.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "フェアリーチャーム UB",
+	},
+
+	illustrator: "Toyste Beach",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードをつけているポケモンは、相手の「ウルトラビースト」の「ポケモンGX・EX」からワザのダメージを受けない。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 551126,
+			},
+		},
+	],
+
+	trainerType: "Tool",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/SM/SM8b/127.ts
+++ b/data-asia/SM/SM8b/127.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ムキムキダンベル",
+	},
+
+	illustrator: "Eske Yoshinob",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードをつけている1進化ポケモンの最大HPは「40」大きくなる。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 551131,
+			},
+		},
+	],
+
+	trainerType: "Tool",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/SM/SM8b/128.ts
+++ b/data-asia/SM/SM8b/128.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アセロラ",
+	},
+
+	illustrator: "Ken Sugimori",
+	category: "Trainer",
+
+	effect: {
+		ja: "ダメカンがのっている自分のポケモン1匹と、ついているすべてのカードを、手札にもどす。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 551136,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/SM/SM8b/129.ts
+++ b/data-asia/SM/SM8b/129.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "カルネ",
+	},
+
+	illustrator: "Ken Sugimori",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードは、前の相手の番に、自分の[妖]ポケモンがきぜつしていなければ使えない。自分のトラッシュにある好きなカードを2枚、相手に見せてから、手札に加える。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 551141,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/SM/SM8b/130.ts
+++ b/data-asia/SM/SM8b/130.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "グズマ",
+	},
+
+	illustrator: "Ken Sugimori",
+	category: "Trainer",
+
+	effect: {
+		ja: "相手のベンチポケモンを1匹選び、バトルポケモンと入れ替える。その後、自分のバトルポケモンをベンチポケモンと入れ替える。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 551146,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/SM/SM8b/131.ts
+++ b/data-asia/SM/SM8b/131.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "グラジオ",
+	},
+
+	illustrator: "Ken Sugimori",
+	category: "Trainer",
+
+	effect: {
+		ja: "ウラになっている自分のサイドのオモテをすべて見て、その中にあるカードを1枚、この「グラジオ」と入れ替えて、手札に加える。その後、この「グラジオ」と残りのサイドをすべてウラにして切り、サイドとして置く。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 551151,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/SM/SM8b/132.ts
+++ b/data-asia/SM/SM8b/132.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "シロナ",
+	},
+
+	illustrator: "Ken Sugimori",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の手札をすべて山札にもどして切る。その後、山札を6枚引く。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 551156,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/SM/SM8b/133.ts
+++ b/data-asia/SM/SM8b/133.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "デンジ",
+	},
+
+	illustrator: "Ken Sugimori",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の山札にあるグッズと[雷]エネルギーを1枚ずつ、相手に見せてから、手札に加える。そして山札を切る。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 551161,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/SM/SM8b/134.ts
+++ b/data-asia/SM/SM8b/134.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ノボリとクダリ",
+	},
+
+	illustrator: "Yusuke Ohmura",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の山札を上から1枚見て、もとにもどす。その後、2つの効果から1つを選んで使う。◆ 自分の手札をすべてトラッシュし、山札を5枚引く。◆ 自分の手札をすべてトラッシュし、山札を下から5枚引く。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 551166,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/SM/SM8b/135.ts
+++ b/data-asia/SM/SM8b/135.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "モノマネむすめ",
+	},
+
+	illustrator: "Ken Sugimori",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の手札をすべて山札にもどして切る。その後、相手の手札の枚数ぶん、自分の山札を引く。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 551171,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/SM/SM8b/136.ts
+++ b/data-asia/SM/SM8b/136.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ルザミーネ",
+	},
+
+	illustrator: "take",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分のトラッシュにあるサポートとスタジアムを合計2枚、相手に見せてから、手札に加える。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 551176,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/SM/SM8b/137.ts
+++ b/data-asia/SM/SM8b/137.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ルミタン",
+	},
+
+	illustrator: "Megumi Mizutani",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードは、自分の手札にある「ラジュルネ」「ルスワール」「ラニュイ」を1枚ずつトラッシュしなければ使えない。自分の山札を上から12枚見て、その中にあるエネルギーを好きなだけ、自分のポケモンに好きなようにつける。残りのカードは、山札にもどして切る。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 551181,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/SM/SM8b/138.ts
+++ b/data-asia/SM/SM8b/138.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ラジュルネ",
+	},
+
+	illustrator: "Megumi Mizutani",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードは、相手のバトル場に2進化ポケモンがいなければ使えない。自分の山札にある好きなカードを2枚まで、手札に加える。そして山札を切る。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 551186,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/SM/SM8b/139.ts
+++ b/data-asia/SM/SM8b/139.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ルスワール",
+	},
+
+	illustrator: "Megumi Mizutani",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードは、相手のバトル場に1進化ポケモンがいなければ使えない。自分の山札を4枚引く。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 551191,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/SM/SM8b/140.ts
+++ b/data-asia/SM/SM8b/140.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ラニュイ",
+	},
+
+	illustrator: "Megumi Mizutani",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードは、相手のバトル場にたねポケモンがいなければ使えない。相手のバトルポケモンについているエネルギーを1個、相手の山札の上にもどす。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 551196,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/SM/SM8b/141.ts
+++ b/data-asia/SM/SM8b/141.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "戒めの祠",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Trainer",
+
+	effect: {
+		ja: "ポケモンチェックのたび、おたがいの「ポケモンGX・EX」全員に、それぞれダメカンを1個のせる。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 551201,
+			},
+		},
+	],
+
+	trainerType: "Stadium",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/SM/SM8b/142.ts
+++ b/data-asia/SM/SM8b/142.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヴェラ火山公園",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Trainer",
+
+	effect: {
+		ja: "おたがいのやけどのポケモンは、ポケモンチェックのときに投げるコインがオモテでも、やけどは回復しない。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 551206,
+			},
+		},
+	],
+
+	trainerType: "Stadium",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/SM/SM8b/143.ts
+++ b/data-asia/SM/SM8b/143.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ウルトラスペース",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Trainer",
+
+	effect: {
+		ja: "おたがいのプレイヤーは、自分の番ごとに1回、自分の山札にある「ウルトラビースト」を1枚、相手に見せてから、手札に加えてよい。その場合、山札を切る。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 551211,
+			},
+		},
+	],
+
+	trainerType: "Stadium",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/SM/SM8b/144.ts
+++ b/data-asia/SM/SM8b/144.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "テンガン山",
+	},
+
+	illustrator: "Ryo Ueda",
+	category: "Trainer",
+
+	effect: {
+		ja: "おたがいのプレイヤーは、自分の番に1回、自分のトラッシュにある[鋼]エネルギーを2枚、相手に見せてから、手札に加えてよい。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 551216,
+			},
+		},
+	],
+
+	trainerType: "Stadium",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/SM/SM8b/145.ts
+++ b/data-asia/SM/SM8b/145.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ワンダーラビリンス",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Trainer",
+
+	effect: {
+		ja: "おたがいの場のポケモン（[妖]ポケモンをのぞく）が使うワザに必要なエネルギーは、それぞれ[無]エネルギー1個ぶん多くなる。このスタジアムは、場に出ているかぎり、おたがいのプレイヤーが手札からグッズまたはサポートを出して使ったとき、その効果を受けない。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 551221,
+			},
+		},
+	],
+
+	trainerType: "Stadium",
+	rarity: "Rare Holo",
+};
+
+export default card;

--- a/data-asia/SM/SM8b/146.ts
+++ b/data-asia/SM/SM8b/146.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "カウンターエネルギー",
+	},
+
+	illustrator: "",
+	category: "Energy",
+	energyType: "Special",
+
+	effect: {
+		ja: "このカードは[無]エネルギー1個ぶんとしてはたらく。このカードは、自分のポケモン（「ポケモンGX・EX」をのぞく）についているとき、自分のサイドの残り枚数が相手のサイドの残り枚数より多いなら、すべてのタイプのエネルギー2個ぶんとしてはたらく。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 551226,
+			},
+		},
+	],
+
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/SM/SM8b/147.ts
+++ b/data-asia/SM/SM8b/147.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ビーストエネルギー",
+	},
+
+	illustrator: "",
+	category: "Energy",
+	energyType: "Special",
+
+	effect: {
+		ja: "このカードは[無]エネルギー1個ぶんとしてはたらく。このカードは、自分の「ウルトラビースト」についているとき、すべてのタイプのエネルギー1個ぶんとしてはたらき、このカードをつけている「ウルトラビースト」が使うワザの、相手のバトルポケモンへのダメージは「+30」される。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 551231,
+			},
+		},
+	],
+
+	rarity: "Rare Holo",
+};
+
+export default card;

--- a/data-asia/SM/SM8b/148.ts
+++ b/data-asia/SM/SM8b/148.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ユニットエネルギー草炎水",
+	},
+
+	illustrator: "",
+	category: "Energy",
+	energyType: "Special",
+
+	effect: {
+		ja: "このカードは、ポケモンについているかぎり、[草][炎][水]の3つのタイプのエネルギー1個ぶんとしてはたらく。ポケモンについていないなら、[無]エネルギー1個ぶんとしてはたらく。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 551236,
+			},
+		},
+	],
+
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/SM/SM8b/149.ts
+++ b/data-asia/SM/SM8b/149.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ユニットエネルギー雷超鋼",
+	},
+
+	illustrator: "",
+	category: "Energy",
+	energyType: "Special",
+
+	effect: {
+		ja: "このカードは、ポケモンについているかぎり、[雷][超][鋼]の3つのタイプのエネルギー1個ぶんとしてはたらく。ポケモンについていないなら、[無]エネルギー1個ぶんとしてはたらく。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 551241,
+			},
+		},
+	],
+
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/SM/SM8b/150.ts
+++ b/data-asia/SM/SM8b/150.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ユニットエネルギー闘悪妖",
+	},
+
+	illustrator: "",
+	category: "Energy",
+	energyType: "Special",
+
+	effect: {
+		ja: "このカードは、ポケモンについているかぎり、[闘][悪][妖]の3つのタイプのエネルギー1個ぶんとしてはたらく。ポケモンについていないなら、[無]エネルギー1個ぶんとしてはたらく。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 551246,
+			},
+		},
+	],
+
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/SM/SM8b/151.ts
+++ b/data-asia/SM/SM8b/151.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "エーテル財団職員",
+	},
+
+	illustrator: "take",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分のトラッシュにある、名前に「アローラ」とつくポケモンを3枚、相手に見せてから、手札に加える。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 551251,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	rarity: "Ultra Rare",
+};
+
+export default card;

--- a/data-asia/SM/SM8b/152.ts
+++ b/data-asia/SM/SM8b/152.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "グズマ",
+	},
+
+	illustrator: "Hitoshi Ariga",
+	category: "Trainer",
+
+	effect: {
+		ja: "相手のベンチポケモンを1匹選び、バトルポケモンと入れ替える。その後、自分のバトルポケモンをベンチポケモンと入れ替える。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 551256,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	rarity: "Ultra Rare",
+};
+
+export default card;

--- a/data-asia/SM/SM8b/153.ts
+++ b/data-asia/SM/SM8b/153.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "シロナ",
+	},
+
+	illustrator: "Yusuke Ohmura",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の手札をすべて山札にもどして切る。その後、山札を6枚引く。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 551261,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	rarity: "Ultra Rare",
+};
+
+export default card;

--- a/data-asia/SM/SM8b/154.ts
+++ b/data-asia/SM/SM8b/154.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "釣り人",
+	},
+
+	illustrator: "Masakazu Fukuda",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分のトラッシュから基本エネルギーを4枚選び、相手に見せてから、手札に加える。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 551266,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	rarity: "Ultra Rare",
+};
+
+export default card;

--- a/data-asia/SM/SM8b/155.ts
+++ b/data-asia/SM/SM8b/155.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ノボリとクダリ",
+	},
+
+	illustrator: "Megumi Mizutani",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の山札を上から1枚見て、もとにもどす。その後、2つの効果から1つを選んで使う。◆ 自分の手札をすべてトラッシュし、山札を5枚引く。◆ 自分の手札をすべてトラッシュし、山札を下から5枚引く。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 551271,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	rarity: "Ultra Rare",
+};
+
+export default card;

--- a/data-asia/SM/SM8b/156.ts
+++ b/data-asia/SM/SM8b/156.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "やまおとこ",
+	},
+
+	illustrator: "Naoki Saito",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分または相手の山札を上から5枚見て、その中から好きなカードを1枚選ぶ。残りのカードを山札にもどして切り、選んだカードを山札の上にもどす。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 551276,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	rarity: "Ultra Rare",
+};
+
+export default card;

--- a/data-asia/SM/SM8b/157.ts
+++ b/data-asia/SM/SM8b/157.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ルミタン",
+	},
+
+	illustrator: "Kagemaru Himeno",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードは、自分の手札にある「ラジュルネ」「ルスワール」「ラニュイ」を1枚ずつトラッシュしなければ使えない。自分の山札を上から12枚見て、その中にあるエネルギーを好きなだけ、自分のポケモンに好きなようにつける。残りのカードは、山札にもどして切る。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 551281,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	rarity: "Ultra Rare",
+};
+
+export default card;

--- a/data-asia/SM/SM8b/158.ts
+++ b/data-asia/SM/SM8b/158.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ラジュルネ",
+	},
+
+	illustrator: "Kagemaru Himeno",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードは、相手のバトル場に2進化ポケモンがいなければ使えない。自分の山札にある好きなカードを2枚まで、手札に加える。そして山札を切る。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 551286,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	rarity: "Ultra Rare",
+};
+
+export default card;

--- a/data-asia/SM/SM8b/159.ts
+++ b/data-asia/SM/SM8b/159.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ルスワール",
+	},
+
+	illustrator: "Kagemaru Himeno",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードは、相手のバトル場に1進化ポケモンがいなければ使えない。自分の山札を4枚引く。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 551291,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	rarity: "Ultra Rare",
+};
+
+export default card;

--- a/data-asia/SM/SM8b/160.ts
+++ b/data-asia/SM/SM8b/160.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ラニュイ",
+	},
+
+	illustrator: "Kagemaru Himeno",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードは、相手のバトル場にたねポケモンがいなければ使えない。相手のバトルポケモンについているエネルギーを1個、相手の山札の上にもどす。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 551296,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	rarity: "Ultra Rare",
+};
+
+export default card;

--- a/data-asia/SM/SM8b/161.ts
+++ b/data-asia/SM/SM8b/161.ts
@@ -1,0 +1,56 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ストライク",
+	},
+
+	illustrator: "Shigenori Negishi",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Grass"],
+
+	description: {
+		ja: "若いうちは 山奥で 群れて 暮らし 鎌での 戦いかたや 高速移動を 修行する。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ぶんしん" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札にある「ストライク」を2枚まで、ベンチに出す。そして山札を切る。",
+			},
+		},
+		{
+			name: { ja: "こうそくいどう" },
+			damage: 20,
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "コインを1回投げオモテなら、次の相手の番、このポケモンはワザのダメージや効果を受けない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 551301,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Ultra Rare",
+	dexId: [123],
+};
+
+export default card;

--- a/data-asia/SM/SM8b/162.ts
+++ b/data-asia/SM/SM8b/162.ts
@@ -1,0 +1,51 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "モクロー",
+	},
+
+	illustrator: "sui",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Grass"],
+
+	description: {
+		ja: "警戒心が 強い。 昼は 光合成で 力を 溜めて 夜になったら 活動開始。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "たいあたり" },
+			damage: 10,
+			cost: ["Colorless"],
+		},
+		{
+			name: { ja: "このは" },
+			damage: 20,
+			cost: ["Grass", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 551306,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Ultra Rare",
+	dexId: [722],
+};
+
+export default card;

--- a/data-asia/SM/SM8b/163.ts
+++ b/data-asia/SM/SM8b/163.ts
@@ -1,0 +1,60 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "フクスロー",
+	},
+
+	illustrator: "Shigenori Negishi",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Grass"],
+
+	description: {
+		ja: "気取り屋で 暇が あれば 翼の 手入れ。 羽毛の 汚れが 気に なりすぎて 戦えないことも。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "するどいはばね" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "相手のポケモン1匹に、20ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+			},
+		},
+		{
+			name: { ja: "リーフブレード" },
+			damage: "50+",
+			cost: ["Grass", "Colorless", "Colorless"],
+			effect: {
+				ja: "コインを1回投げオモテなら、20ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 551311,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "モクロー",
+	},
+
+	retreat: 1,
+	rarity: "Ultra Rare",
+	dexId: [723],
+};
+
+export default card;

--- a/data-asia/SM/SM8b/164.ts
+++ b/data-asia/SM/SM8b/164.ts
@@ -1,0 +1,56 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "コソクムシ",
+	},
+
+	illustrator: "SATOSHI NAKAI",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Grass"],
+
+	description: {
+		ja: "臆病で たくさんの 足を ばたつかせ 必死に 逃げまわる。 逃げたあとは ピカピカ 綺麗。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "にげごし" },
+			effect: {
+				ja: "最初の自分の番、このポケモンのにげるためのエネルギーは、すべてなくなる。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "かじる" },
+			damage: 30,
+			cost: ["Grass", "Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 551316,
+			},
+		},
+	],
+
+	retreat: 3,
+	rarity: "Ultra Rare",
+	dexId: [767],
+};
+
+export default card;

--- a/data-asia/SM/SM8b/165.ts
+++ b/data-asia/SM/SM8b/165.ts
@@ -1,0 +1,54 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "フェローチェ",
+	},
+
+	illustrator: "Mizue",
+	category: "Pokemon",
+	hp: 110,
+	types: ["Grass"],
+
+	description: {
+		ja: "ＵＢの 一種。 この世界の ものに けがれを 感じるのか 一切 手を 触れようと しない。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "とびひざげり" },
+			damage: 20,
+			cost: ["Colorless"],
+		},
+		{
+			name: { ja: "ホワイトレイ" },
+			damage: "90+",
+			cost: ["Grass", "Grass", "Colorless"],
+			effect: {
+				ja: "自分のサイドの残り枚数が1枚なら、90ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 551321,
+			},
+		},
+	],
+
+	retreat: 0,
+	rarity: "Ultra Rare",
+	dexId: [795],
+};
+
+export default card;

--- a/data-asia/SM/SM8b/166.ts
+++ b/data-asia/SM/SM8b/166.ts
@@ -1,0 +1,49 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヒトカゲ",
+	},
+
+	illustrator: "kirisAki",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Fire"],
+
+	description: {
+		ja: "生まれたときから 尻尾に 炎が 点っている。 炎が 消えたとき その 命は 終わってしまう。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ほのおのキバ" },
+			damage: 20,
+			cost: ["Fire", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをやけどにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 551326,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Ultra Rare",
+	dexId: [4],
+};
+
+export default card;

--- a/data-asia/SM/SM8b/167.ts
+++ b/data-asia/SM/SM8b/167.ts
@@ -1,0 +1,63 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "リザード",
+	},
+
+	illustrator: "nagimiso",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Fire"],
+
+	description: {
+		ja: "燃える 尻尾を 振り回すと まわりの 温度が どんどん 上がって 相手を 苦しめる。",
+	},
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "もえるとうし" },
+			effect: {
+				ja: "自分の番に、このカードを手札から出して進化させたとき、1回使える。自分の山札を上から5枚トラッシュし、その中にある[炎]エネルギーをすべて、このポケモンにつける。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "かえんほうしゃ" },
+			damage: 80,
+			cost: ["Fire", "Fire", "Colorless"],
+			effect: {
+				ja: "このポケモンについているエネルギーを、1個トラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 551331,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ヒトカゲ",
+	},
+
+	retreat: 2,
+	rarity: "Ultra Rare",
+	dexId: [5],
+};
+
+export default card;

--- a/data-asia/SM/SM8b/168.ts
+++ b/data-asia/SM/SM8b/168.ts
@@ -1,0 +1,53 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アローラロコン",
+	},
+
+	illustrator: "Kouki Saitou",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Water"],
+
+	description: {
+		ja: "マイナス５０度の 冷気を 吐く。 アローラの老人は ケオケオという 昔の 名前で 呼ぶことも。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "みちしるべ" },
+			cost: [],
+			effect: {
+				ja: "自分の山札にあるポケモンを2枚まで、相手に見せてから、手札に加える。そして山札を切る。",
+			},
+		},
+		{
+			name: { ja: "スノーアイス" },
+			damage: 20,
+			cost: ["Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 551336,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Ultra Rare",
+	dexId: [37],
+};
+
+export default card;

--- a/data-asia/SM/SM8b/169.ts
+++ b/data-asia/SM/SM8b/169.ts
@@ -1,0 +1,51 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ウパー",
+	},
+
+	illustrator: "Misa Tsutsui",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Water"],
+
+	description: {
+		ja: "夕暮れどき 涼しくなると 水から 上がってきた ウパーたちは エサを 探して 水辺を 歩く。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ぶつかる" },
+			damage: 10,
+			cost: ["Colorless"],
+		},
+		{
+			name: { ja: "みずかけ" },
+			damage: 20,
+			cost: ["Water", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 551341,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Ultra Rare",
+	dexId: [194],
+};
+
+export default card;

--- a/data-asia/SM/SM8b/170.ts
+++ b/data-asia/SM/SM8b/170.ts
@@ -1,0 +1,63 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヌオー",
+	},
+
+	illustrator: "Saya Tsuruta",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Water"],
+
+	description: {
+		ja: "のんびりとした 性格で 気ままに 泳いでは いつも 船底に 頭を ぶつけている。",
+	},
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "おしながす" },
+			effect: {
+				ja: "自分の番に何回でも使える。自分のベンチポケモンについている[水]エネルギーを1個、バトルポケモンにつけ替える。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ハイドロポンプ" },
+			damage: "60+",
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンについている[水]エネルギーの数x20ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 551346,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ウパー",
+	},
+
+	retreat: 2,
+	rarity: "Ultra Rare",
+	dexId: [195],
+};
+
+export default card;

--- a/data-asia/SM/SM8b/171.ts
+++ b/data-asia/SM/SM8b/171.ts
@@ -1,0 +1,56 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ケロマツ",
+	},
+
+	illustrator: "sui",
+	category: "Pokemon",
+	hp: 50,
+	types: ["Water"],
+
+	description: {
+		ja: "繊細な 泡で 体を 包み 肌を 守る。 のんきに 見せかけて 抜け目なく 周囲を うかがう。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ケロムース" },
+			effect: {
+				ja: "このポケモンに[水]エネルギーがついているなら、このポケモンのにげるためのエネルギーは、すべてなくなる。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "はねまわる" },
+			damage: 20,
+			cost: ["Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 551351,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Ultra Rare",
+	dexId: [656],
+};
+
+export default card;

--- a/data-asia/SM/SM8b/172.ts
+++ b/data-asia/SM/SM8b/172.ts
@@ -1,0 +1,60 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ゲコガシラ",
+	},
+
+	illustrator: "Anesaki Dynamic",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Water"],
+
+	description: {
+		ja: "身軽さは だれにも 負けない。 ６００メートルを 超える タワーの 天辺まで １分で 登りきる。",
+	},
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "はやてしゅりけん" },
+			effect: {
+				ja: "自分の番に、このカードを手札から出して進化させたとき、1回使える。相手のポケモン1匹に、ダメカンを2個のせる。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "みずきり" },
+			damage: 20,
+			cost: ["Water"],
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 551356,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ケロマツ",
+	},
+
+	retreat: 1,
+	rarity: "Ultra Rare",
+	dexId: [657],
+};
+
+export default card;

--- a/data-asia/SM/SM8b/173.ts
+++ b/data-asia/SM/SM8b/173.ts
@@ -1,0 +1,59 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ビリリダマ",
+	},
+
+	illustrator: "Shin Nagasawa",
+	category: "Pokemon",
+	hp: 50,
+	types: ["Lightning"],
+
+	description: {
+		ja: "発電所などに 現れる。 モンスターボールと 間違えて 触って しびれる 人が 多い。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "エレキフロート" },
+			effect: {
+				ja: "このポケモンにエネルギーがついているなら、このポケモンのにげるためのエネルギーは、すべてなくなる。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "でんきショック" },
+			damage: 20,
+			cost: ["Lightning", "Colorless"],
+			effect: {
+				ja: "コインを1回投げオモテなら、相手のバトルポケモンをマヒにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Metal", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 551361,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Ultra Rare",
+	dexId: [100],
+};
+
+export default card;

--- a/data-asia/SM/SM8b/174.ts
+++ b/data-asia/SM/SM8b/174.ts
@@ -1,0 +1,57 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "デンジュモク",
+	},
+
+	illustrator: "Naoki Saito",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Lightning"],
+
+	description: {
+		ja: "ウルトラホールから 出現した。 発電所を 襲撃 したため 電気が エネルギーと おもわれる。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "せんこうだん" },
+			damage: 20,
+			cost: ["Lightning"],
+			effect: {
+				ja: "相手のバトルポケモンをこんらんにする。",
+			},
+		},
+		{
+			name: { ja: "ケーブルグラム" },
+			damage: 100,
+			cost: ["Lightning", "Lightning", "Colorless"],
+			effect: {
+				ja: "自分のサイドの残り枚数が3枚なら、相手のバトルポケモンをマヒにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Metal", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 551366,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Ultra Rare",
+	dexId: [796],
+};
+
+export default card;

--- a/data-asia/SM/SM8b/175.ts
+++ b/data-asia/SM/SM8b/175.ts
@@ -1,0 +1,59 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ハブネーク",
+	},
+
+	illustrator: "SATOSHI NAKAI",
+	category: "Pokemon",
+	hp: 100,
+	types: ["Psychic"],
+
+	description: {
+		ja: "猛毒が 染み出している 鋭い 切れ味の 尻尾で 素早い ザングースに 立ち向かう。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ポイズンアップ" },
+			effect: {
+				ja: "このポケモンがいるかぎり、相手のバトルポケモンは、どくでのせるダメカンの数が1個多くなる。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "どくのキバ" },
+			damage: 30,
+			cost: ["Psychic", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをどくにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 551371,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Ultra Rare",
+	dexId: [336],
+};
+
+export default card;

--- a/data-asia/SM/SM8b/176.ts
+++ b/data-asia/SM/SM8b/176.ts
@@ -1,0 +1,51 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "カゲボウズ",
+	},
+
+	illustrator: "sui",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Psychic"],
+
+	description: {
+		ja: "恨みの 感情が 大好き。 恨みを 持つ 人が 住む 家の 軒下に ずらりと ぶらさがる。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ずつき" },
+			damage: 10,
+			cost: ["Colorless"],
+		},
+		{
+			name: { ja: "おにび" },
+			damage: 20,
+			cost: ["Psychic", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 551376,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Ultra Rare",
+	dexId: [353],
+};
+
+export default card;

--- a/data-asia/SM/SM8b/177.ts
+++ b/data-asia/SM/SM8b/177.ts
@@ -1,0 +1,48 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "マーイーカ",
+	},
+
+	illustrator: "Shigenori Negishi",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Psychic"],
+
+	description: {
+		ja: "光の 点滅で 襲ってきた 敵の 戦意を なくしてしまう。 その すきに 姿を くらますのだ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "さいみんじゅつ" },
+			cost: ["Psychic"],
+			effect: {
+				ja: "相手のバトルポケモンをねむりにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 551381,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Ultra Rare",
+	dexId: [686],
+};
+
+export default card;

--- a/data-asia/SM/SM8b/178.ts
+++ b/data-asia/SM/SM8b/178.ts
@@ -1,0 +1,60 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "カラマネロ",
+	},
+
+	illustrator: "Hideki Ishikawa",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Psychic"],
+
+	description: {
+		ja: "催眠術で おびき寄せて 頭の 触手で 絡め取り 消化液を 浴びせて しとめる。",
+	},
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "サイコリチャージ" },
+			effect: {
+				ja: "自分の番に1回使える。自分のトラッシュにある[超]エネルギーを1枚、ベンチポケモンにつける。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ねんどうだん" },
+			damage: 60,
+			cost: ["Psychic", "Psychic", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 551386,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "マーイーカ",
+	},
+
+	retreat: 2,
+	rarity: "Ultra Rare",
+	dexId: [687],
+};
+
+export default card;

--- a/data-asia/SM/SM8b/179.ts
+++ b/data-asia/SM/SM8b/179.ts
@@ -1,0 +1,55 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ベベノム",
+	},
+
+	illustrator: "Akira Komayama",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Psychic"],
+
+	description: {
+		ja: "異世界に おいては 旅立ちの パートナーに 選ばれるほど 親しまれている ウルトラビースト。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "どくえき" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをどくにする。",
+			},
+		},
+		{
+			name: { ja: "コープスリバイバー" },
+			cost: ["Psychic", "Colorless"],
+			effect: {
+				ja: "次の相手の番、このポケモンがきぜつしても、相手はサイドをとれない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 551391,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Ultra Rare",
+	dexId: [803],
+};
+
+export default card;

--- a/data-asia/SM/SM8b/180.ts
+++ b/data-asia/SM/SM8b/180.ts
@@ -1,0 +1,56 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ウソッキー",
+	},
+
+	illustrator: "Kyoko Umemoto",
+	category: "Pokemon",
+	hp: 100,
+	types: ["Fighting"],
+
+	description: {
+		ja: "襲われないため 樹木の 真似を するが 嫌いな 水を かけられて あわてて 逃げだしていく。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "みちをふさぐ" },
+			effect: {
+				ja: "このポケモンがいるかぎり、相手がベンチに出せるポケモンの数は、4匹になる。相手のベンチに5匹以上いる場合は、相手はベンチが4匹になるまでポケモンをトラッシュする。［ベンチの数を変更する効果は、少ない数が優先される。］",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "いわおとし" },
+			damage: 40,
+			cost: ["Fighting", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 551396,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Ultra Rare",
+	dexId: [185],
+};
+
+export default card;

--- a/data-asia/SM/SM8b/181.ts
+++ b/data-asia/SM/SM8b/181.ts
@@ -1,0 +1,53 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "リオル",
+	},
+
+	illustrator: "Misa Tsutsui",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Fighting"],
+
+	description: {
+		ja: "一晩中 走っていられる タフさが あり 頑張り屋 だが まだまだ ひよっ子 なのだ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "みきり" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "コインを1回投げオモテなら、次の相手の番、このポケモンはワザのダメージや効果を受けない。",
+			},
+		},
+		{
+			name: { ja: "ジャブ" },
+			damage: 10,
+			cost: ["Fighting"],
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 551401,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Ultra Rare",
+	dexId: [447],
+};
+
+export default card;

--- a/data-asia/SM/SM8b/182.ts
+++ b/data-asia/SM/SM8b/182.ts
@@ -1,0 +1,63 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ルカリオ",
+	},
+
+	illustrator: "Kouki Saitou",
+	category: "Pokemon",
+	hp: 110,
+	types: ["Fighting"],
+
+	description: {
+		ja: "１キロ先の 生き物の 種類や 気持ちを キャッチする。 波動を 操り 群れで 獲物を 狩る。",
+	},
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "はどうよち" },
+			effect: {
+				ja: "自分の場に「ガブリアス」がいるなら、自分の番に1回使える。自分の山札にある好きなカードを1枚、手札に加える。そして山札を切る。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "スカッドジャブ" },
+			damage: 70,
+			cost: ["Fighting", "Colorless"],
+			effect: {
+				ja: "このワザのダメージは抵抗力を計算しない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 551406,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "リオル",
+	},
+
+	retreat: 1,
+	rarity: "Ultra Rare",
+	dexId: [448],
+};
+
+export default card;

--- a/data-asia/SM/SM8b/183.ts
+++ b/data-asia/SM/SM8b/183.ts
@@ -1,0 +1,49 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "イワンコ",
+	},
+
+	illustrator: "Masakazu Fukuda",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Fighting"],
+
+	description: {
+		ja: "昔から 人と 暮らしてきた。 トレーナーが 悲しんでいると それを 察して 側を 離れない。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ふいをつく" },
+			damage: 50,
+			cost: ["Fighting", "Colorless"],
+			effect: {
+				ja: "コインを1回投げウラなら、このワザは失敗。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 551411,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Ultra Rare",
+	dexId: [744],
+};
+
+export default card;

--- a/data-asia/SM/SM8b/184.ts
+++ b/data-asia/SM/SM8b/184.ts
@@ -1,0 +1,57 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "マッシブーン",
+	},
+
+	illustrator: "Shin Nagasawa",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Fighting"],
+
+	description: {
+		ja: "謎の 生物 ＵＢ。 一発の パンチで ダンプカーを 粉砕する 光景が 目撃 された。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "スレッジハンマー" },
+			damage: "30+",
+			cost: ["Fighting"],
+			effect: {
+				ja: "相手のサイドの残り枚数が4枚なら、90ダメージ追加。",
+			},
+		},
+		{
+			name: { ja: "ふりまわす" },
+			damage: "80+",
+			cost: ["Fighting", "Fighting", "Colorless"],
+			effect: {
+				ja: "コインを2回投げ、オモテの数x20ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 551416,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Ultra Rare",
+	dexId: [794],
+};
+
+export default card;

--- a/data-asia/SM/SM8b/185.ts
+++ b/data-asia/SM/SM8b/185.ts
@@ -1,0 +1,51 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ゾロア",
+	},
+
+	illustrator: "Saya Tsuruta",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Darkness"],
+
+	description: {
+		ja: "相手そっくりに 化けているように みせかけ だましたり 驚かして そのすきに 逃げ出すことが 多い。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ふむ" },
+			damage: 10,
+			cost: ["Darkness"],
+		},
+		{
+			name: { ja: "ぶつかる" },
+			damage: 20,
+			cost: ["Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 551421,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Ultra Rare",
+	dexId: [570],
+};
+
+export default card;

--- a/data-asia/SM/SM8b/186.ts
+++ b/data-asia/SM/SM8b/186.ts
@@ -1,0 +1,49 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アクジキング",
+	},
+
+	illustrator: "Masakazu Fukuda",
+	category: "Pokemon",
+	hp: 160,
+	types: ["Darkness"],
+
+	description: {
+		ja: "危険生物 ビーストの 一種。 つねに なにかを 喰らっているようだが なぜか フンは 未発見。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "キングスバレイ" },
+			damage: 160,
+			cost: ["Darkness", "Darkness", "Darkness", "Darkness"],
+			effect: {
+				ja: "自分のサイドの残り枚数が6枚・4枚・2枚なら、自分の山札を上から10枚トラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 551426,
+			},
+		},
+	],
+
+	retreat: 4,
+	rarity: "Ultra Rare",
+	dexId: [799],
+};
+
+export default card;

--- a/data-asia/SM/SM8b/187.ts
+++ b/data-asia/SM/SM8b/187.ts
@@ -1,0 +1,53 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "コイル",
+	},
+
+	illustrator: "SATOSHI NAKAI",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Metal"],
+
+	description: {
+		ja: "電磁波を 放ち 空を 漂う。 電気を 喰っているときに 触ると 全身が ビリッと 痺れるぞ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "マグネサーチ" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札にある[鋼]エネルギーを3枚まで、相手に見せてから、手札に加える。そして山札を切る。",
+			},
+		},
+		{
+			name: { ja: "たいあたり" },
+			damage: 10,
+			cost: ["Metal"],
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 551431,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Ultra Rare",
+	dexId: [81],
+};
+
+export default card;

--- a/data-asia/SM/SM8b/188.ts
+++ b/data-asia/SM/SM8b/188.ts
@@ -1,0 +1,58 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "レアコイル",
+	},
+
+	illustrator: "Kyoko Umemoto",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Metal"],
+
+	description: {
+		ja: "ほぼ コイル ３倍の 電力。 太陽の黒点が 多いとき なぜか 大量発生。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "ぶつかる" },
+			damage: 20,
+			cost: ["Metal"],
+		},
+		{
+			name: { ja: "でんじほう" },
+			damage: 80,
+			cost: ["Metal", "Metal", "Colorless"],
+			effect: {
+				ja: "次の自分の番、このポケモンは「でんじほう」が使えない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 551436,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "コイル",
+	},
+
+	retreat: 2,
+	rarity: "Ultra Rare",
+	dexId: [82],
+};
+
+export default card;

--- a/data-asia/SM/SM8b/189.ts
+++ b/data-asia/SM/SM8b/189.ts
@@ -1,0 +1,63 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ジバコイル",
+	},
+
+	illustrator: "Misa Tsutsui",
+	category: "Pokemon",
+	hp: 150,
+	types: ["Metal"],
+
+	description: {
+		ja: "怪電波を 発信 しながら 空を 飛び回り 未知の 電波を 受信 していると いう。",
+	},
+
+	stage: "Stage2",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "マグネサーキット" },
+			effect: {
+				ja: "自分の番に何回でも使える。自分の手札にある[鋼]エネルギーを1枚、自分のポケモンにつける。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "でんじほう" },
+			damage: 130,
+			cost: ["Metal", "Metal", "Metal", "Colorless"],
+			effect: {
+				ja: "次の自分の番、このポケモンは「でんじほう」が使えない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 551441,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "レアコイル",
+	},
+
+	retreat: 2,
+	rarity: "Ultra Rare",
+	dexId: [462],
+};
+
+export default card;

--- a/data-asia/SM/SM8b/190.ts
+++ b/data-asia/SM/SM8b/190.ts
@@ -1,0 +1,49 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ダンバル",
+	},
+
+	illustrator: "Mizue",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Metal"],
+
+	description: {
+		ja: "細胞 すべてが 磁石。 磁力を 使って 仲間と コミュニケーションを 取る。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "コアビーム" },
+			damage: 20,
+			cost: ["Metal"],
+			effect: {
+				ja: "このポケモンについている[鋼]エネルギーを、1個トラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 551446,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Ultra Rare",
+	dexId: [374],
+};
+
+export default card;

--- a/data-asia/SM/SM8b/191.ts
+++ b/data-asia/SM/SM8b/191.ts
@@ -1,0 +1,58 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "メタング",
+	},
+
+	illustrator: "Saya Tsuruta",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Metal"],
+
+	description: {
+		ja: "２匹の ダンバルが 連結し サイコパワーは ２倍に。 ただし 賢さ自体は 変わっていない。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "ぶつかる" },
+			damage: 20,
+			cost: ["Colorless"],
+		},
+		{
+			name: { ja: "コアビーム" },
+			damage: 80,
+			cost: ["Metal", "Metal", "Colorless"],
+			effect: {
+				ja: "このポケモンについている[鋼]エネルギーを、1個トラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 551451,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ダンバル",
+	},
+
+	retreat: 3,
+	rarity: "Ultra Rare",
+	dexId: [375],
+};
+
+export default card;

--- a/data-asia/SM/SM8b/192.ts
+++ b/data-asia/SM/SM8b/192.ts
@@ -1,0 +1,49 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "テッカグヤ",
+	},
+
+	illustrator: "Kouki Saitou",
+	category: "Pokemon",
+	hp: 140,
+	types: ["Metal"],
+
+	description: {
+		ja: "ＵＢの 一種。 ２本の 腕から ガスを 噴きだし 森を 焼き払う 姿が 確認 されている。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ムーンレイカー" },
+			damage: 160,
+			cost: ["Metal", "Colorless", "Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "このワザは、おたがいのサイドの残り枚数の合計が6枚なら、[鋼]エネルギー1個で使える。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 551456,
+			},
+		},
+	],
+
+	retreat: 4,
+	rarity: "Ultra Rare",
+	dexId: [797],
+};
+
+export default card;

--- a/data-asia/SM/SM8b/193.ts
+++ b/data-asia/SM/SM8b/193.ts
@@ -1,0 +1,49 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "カミツルギ",
+	},
+
+	illustrator: "Anesaki Dynamic",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Metal"],
+
+	description: {
+		ja: "巨大な 鉄塔を 一刀の もとに 切り捨てる 姿が 目撃された ビーストの 一種。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "カミカゼ" },
+			damage: "40+",
+			cost: ["Metal", "Metal"],
+			effect: {
+				ja: "相手のサイドの残り枚数が6枚なら、90ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 551461,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Ultra Rare",
+	dexId: [798],
+};
+
+export default card;

--- a/data-asia/SM/SM8b/194.ts
+++ b/data-asia/SM/SM8b/194.ts
@@ -1,0 +1,49 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ラルトス",
+	},
+
+	illustrator: "Kyoko Umemoto",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Fairy"],
+
+	description: {
+		ja: "赤いツノで 人や ポケモンの 温かな 気持ちを キャッチすると 全身が ほのかに 熱くなる。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ドレインキッス" },
+			damage: 10,
+			cost: ["Fairy"],
+			effect: {
+				ja: "このポケモンのHPを「10」回復する。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [{ type: "Darkness", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 551466,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Ultra Rare",
+	dexId: [280],
+};
+
+export default card;

--- a/data-asia/SM/SM8b/195.ts
+++ b/data-asia/SM/SM8b/195.ts
@@ -1,0 +1,55 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "キルリア",
+	},
+
+	illustrator: "Sumiyoshi Kizuki",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Fairy"],
+
+	description: {
+		ja: "トレーナーの 明るい 気持ちが サイコパワーの 源。 楽しい 気分に なると クルクル 踊る。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "ひらてうち" },
+			damage: 20,
+			cost: ["Colorless"],
+		},
+		{
+			name: { ja: "マジカルショット" },
+			damage: 30,
+			cost: ["Fairy", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [{ type: "Darkness", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 551471,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ラルトス",
+	},
+
+	retreat: 1,
+	rarity: "Ultra Rare",
+	dexId: [281],
+};
+
+export default card;

--- a/data-asia/SM/SM8b/196.ts
+++ b/data-asia/SM/SM8b/196.ts
@@ -1,0 +1,56 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ディアンシー",
+	},
+
+	illustrator: "Akira Komayama",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Fairy"],
+
+	description: {
+		ja: "メレシーの 突然変異。 ピンク色に 輝く 体は 世界一 美しいと 言われる。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "きらめくいのり" },
+			cost: ["Fairy"],
+			effect: {
+				ja: "自分の場のポケモン1匹から進化するカードを、自分の山札から1枚選び、そのポケモンにのせて進化させる。そして山札を切る。",
+			},
+		},
+		{
+			name: { ja: "ダイヤストーム" },
+			damage: 30,
+			cost: ["Fairy", "Colorless"],
+			effect: {
+				ja: "自分の[妖]ポケモン全員のHPを、それぞれ「30」回復する。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [{ type: "Darkness", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 551476,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Ultra Rare",
+	dexId: [719],
+};
+
+export default card;

--- a/data-asia/SM/SM8b/197.ts
+++ b/data-asia/SM/SM8b/197.ts
@@ -1,0 +1,60 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "チルタリス",
+	},
+
+	illustrator: "kirisAki",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Dragon"],
+
+	description: {
+		ja: "晴れた日 綿雲に まぎれながら 大空を 自由に 飛び回り 美しい ソプラノで 歌う。",
+	},
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "たたかいのうた" },
+			effect: {
+				ja: "このポケモンがいるかぎり、自分の[竜]ポケモンが使うワザの、相手のバトルポケモンへのダメージは「+20」される。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "つきさす" },
+			damage: 20,
+			cost: ["Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fairy", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 551481,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "チルット",
+	},
+
+	retreat: 1,
+	rarity: "Ultra Rare",
+	dexId: [334],
+};
+
+export default card;

--- a/data-asia/SM/SM8b/198.ts
+++ b/data-asia/SM/SM8b/198.ts
@@ -1,0 +1,48 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "フカマル",
+	},
+
+	illustrator: "Saya Tsuruta",
+	category: "Pokemon",
+	hp: 50,
+	types: ["Dragon"],
+
+	description: {
+		ja: "穴倉に 潜み 獲物や 敵が 横切ると 飛びだして 噛みつく。 勢い余り 歯が 欠けることも。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "かくせい" },
+			cost: ["Fighting"],
+			effect: {
+				ja: "このポケモンから進化するカードを、自分の山札から1枚選び、このポケモンにのせて進化させる。そして山札を切る。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fairy", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 551486,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Ultra Rare",
+	dexId: [443],
+};
+
+export default card;

--- a/data-asia/SM/SM8b/199.ts
+++ b/data-asia/SM/SM8b/199.ts
@@ -1,0 +1,57 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ガバイト",
+	},
+
+	illustrator: "Masakazu Fukuda",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Dragon"],
+
+	description: {
+		ja: "光り 輝くものが 大好き。 宝石や 捕まえた メレシーを 巣穴で じーっと 眺めている。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "かくせい" },
+			cost: ["Fighting"],
+			effect: {
+				ja: "このポケモンから進化するカードを、自分の山札から1枚選び、このポケモンにのせて進化させる。そして山札を切る。",
+			},
+		},
+		{
+			name: { ja: "きりさく" },
+			damage: 40,
+			cost: ["Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fairy", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 551491,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "フカマル",
+	},
+
+	retreat: 1,
+	rarity: "Ultra Rare",
+	dexId: [444],
+};
+
+export default card;

--- a/data-asia/SM/SM8b/200.ts
+++ b/data-asia/SM/SM8b/200.ts
@@ -1,0 +1,60 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ガブリアス",
+	},
+
+	illustrator: "Shin Nagasawa",
+	category: "Pokemon",
+	hp: 150,
+	types: ["Dragon"],
+
+	description: {
+		ja: "頭に ついた ２つの 突起は センサーの 役目。 遥か 先の 獲物の 様子も わかる。",
+	},
+
+	stage: "Stage2",
+
+	attacks: [
+		{
+			name: { ja: "クイックダイブ" },
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "相手のポケモン1匹に、50ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+			},
+		},
+		{
+			name: { ja: "おうじゃのやいば" },
+			damage: "100+",
+			cost: ["Fighting", "Colorless", "Colorless"],
+			effect: {
+				ja: "この番、手札から「シロナ」を出して使っていたなら、100ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fairy", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 551496,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ガバイト",
+	},
+
+	retreat: 0,
+	rarity: "Ultra Rare",
+	dexId: [445],
+};
+
+export default card;

--- a/data-asia/SM/SM8b/201.ts
+++ b/data-asia/SM/SM8b/201.ts
@@ -1,0 +1,58 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "イーブイ",
+	},
+
+	illustrator: "kirisAki",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Colorless"],
+
+	description: {
+		ja: "今 現在の 調査では なんと ８種類もの ポケモンへ 進化する 可能性を 持つ。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "エナジーしんか" },
+			effect: {
+				ja: "自分の番に、自分の手札から基本エネルギーをこのポケモンにつけたとき、1回使える。つけたエネルギーと同じタイプの、このポケモンから進化するカードを、自分の山札から1枚選び、このポケモンにのせて進化させる。そして山札を切る。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "クイックドロー" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "コインを1回投げオモテなら、自分の山札を1枚引く。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 551501,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Ultra Rare",
+	dexId: [133],
+};
+
+export default card;

--- a/data-asia/SM/SM8b/202.ts
+++ b/data-asia/SM/SM8b/202.ts
@@ -1,0 +1,53 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "チルット",
+	},
+
+	illustrator: "Shigenori Negishi",
+	category: "Pokemon",
+	hp: 50,
+	types: ["Colorless"],
+
+	description: {
+		ja: "真綿の ような 翼の 手入れは 絶対に 欠かさない。 汚れると 水浴びをして きれいに 洗う。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "もってくる" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札を1枚引く。",
+			},
+		},
+		{
+			name: { ja: "つつく" },
+			damage: 20,
+			cost: ["Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 551506,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Ultra Rare",
+	dexId: [333],
+};
+
+export default card;

--- a/data-asia/SM/SM8b/203.ts
+++ b/data-asia/SM/SM8b/203.ts
@@ -1,0 +1,49 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "オンバット",
+	},
+
+	illustrator: "Mizue",
+	category: "Pokemon",
+	hp: 50,
+	types: ["Colorless"],
+
+	description: {
+		ja: "真っ暗な 洞窟で 暮らす。 ２０万ヘルツの 超音波を 大きな 耳から 発射する。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "こうそくいどう" },
+			damage: 10,
+			cost: ["Colorless"],
+			effect: {
+				ja: "コインを1回投げオモテなら、次の相手の番、このポケモンはワザのダメージや効果を受けない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 551511,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Ultra Rare",
+	dexId: [714],
+};
+
+export default card;

--- a/data-asia/SM/SM8b/204.ts
+++ b/data-asia/SM/SM8b/204.ts
@@ -1,0 +1,59 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヤレユータン",
+	},
+
+	illustrator: "Akira Komayama",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Colorless"],
+
+	description: {
+		ja: "ジャングル奥地の 木の上に 棲む。 まれに 海辺に 現れて ヤドキングと 知恵比べを する。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "さいはい" },
+			effect: {
+				ja: "自分の番に1回使える。自分の手札が3枚になるように、山札を引く。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "サイコキネシス" },
+			damage: "60+",
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンについているエネルギーの数x20ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 551516,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Ultra Rare",
+	dexId: [765],
+};
+
+export default card;

--- a/data-asia/SM/SM8b/205.ts
+++ b/data-asia/SM/SM8b/205.ts
@@ -1,0 +1,54 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "タイプ：ヌル",
+	},
+
+	illustrator: "Shin Nagasawa",
+	category: "Pokemon",
+	hp: 110,
+	types: ["Colorless"],
+
+	description: {
+		ja: "重い 制御マスクを つけており 本来の 能力を だせない。 特別な 力を 秘めている。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "アーマープレス" },
+			damage: 30,
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "次の相手の番、このポケモンが受けるワザのダメージは「-30」される。",
+			},
+		},
+		{
+			name: { ja: "スラッシュクロー" },
+			damage: 70,
+			cost: ["Colorless", "Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 551521,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Ultra Rare",
+	dexId: [772],
+};
+
+export default card;

--- a/data-asia/SM/SM8b/206.ts
+++ b/data-asia/SM/SM8b/206.ts
@@ -1,0 +1,65 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "リーフィアGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 200,
+	types: ["Grass"],
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "あおばのいぶき" },
+			effect: {
+				ja: "このポケモンがバトル場にいるなら、自分の番に1回使える。エネルギーがついている自分のポケモン1匹のHPを「50」回復する。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ソーラービーム" },
+			damage: 110,
+			cost: ["Grass", "Colorless", "Colorless"],
+		},
+		{
+			name: { ja: "グランブルームGX" },
+			cost: ["Grass"],
+			effect: {
+				ja: "自分のベンチのたねポケモン全員からそれぞれ進化するカードを、自分の山札から1枚ずつ選び、それぞれにのせて進化させる。そして山札を切る。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 551526,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "イーブイ",
+	},
+
+	retreat: 2,
+	rarity: "Ultra Rare",
+	dexId: [470],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM8b/207.ts
+++ b/data-asia/SM/SM8b/207.ts
@@ -1,0 +1,65 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ジュナイパーGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 240,
+	types: ["Grass"],
+
+	stage: "Stage2",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "フェザーアロー" },
+			effect: {
+				ja: "自分の番に1回使える。相手のポケモン1匹に、ダメカンを2個のせる。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "はっぱカッター" },
+			damage: 90,
+			cost: ["Grass", "Colorless", "Colorless"],
+		},
+		{
+			name: { ja: "ホロウハントGX" },
+			cost: ["Grass"],
+			effect: {
+				ja: "自分のトラッシュにある好きなカードを3枚、相手に見せてから、手札に加える。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 551531,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "フクスロー",
+	},
+
+	retreat: 2,
+	rarity: "Ultra Rare",
+	dexId: [724],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM8b/208.ts
+++ b/data-asia/SM/SM8b/208.ts
@@ -1,0 +1,67 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "グソクムシャGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 210,
+	types: ["Grass"],
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "であいがしら" },
+			damage: "30+",
+			cost: ["Grass"],
+			effect: {
+				ja: "この番、このポケモンがベンチからバトル場に出ていたなら、90ダメージ追加。",
+			},
+		},
+		{
+			name: { ja: "アーマープレス" },
+			damage: 100,
+			cost: ["Grass", "Colorless", "Colorless"],
+			effect: {
+				ja: "次の相手の番、このポケモンが受けるワザのダメージは「-20」される。",
+			},
+		},
+		{
+			name: { ja: "ザンクロスGX" },
+			damage: 150,
+			cost: ["Grass", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンをベンチポケモンと入れ替える。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 551536,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "コソクムシ",
+	},
+
+	retreat: 3,
+	rarity: "Ultra Rare",
+	dexId: [768],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM8b/209.ts
+++ b/data-asia/SM/SM8b/209.ts
@@ -1,0 +1,63 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "リザードンGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 250,
+	types: ["Fire"],
+
+	stage: "Stage2",
+
+	attacks: [
+		{
+			name: { ja: "つばさでうつ" },
+			damage: 70,
+			cost: ["Colorless", "Colorless", "Colorless"],
+		},
+		{
+			name: { ja: "ぐれんのあらし" },
+			damage: 300,
+			cost: ["Fire", "Fire", "Fire", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンについている[炎]エネルギーを、3個トラッシュする。",
+			},
+		},
+		{
+			name: { ja: "レイジングアウトGX" },
+			cost: ["Fire", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手の山札を上から10枚トラッシュする。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 551541,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "リザード",
+	},
+
+	retreat: 2,
+	rarity: "Ultra Rare",
+	dexId: [6],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM8b/210.ts
+++ b/data-asia/SM/SM8b/210.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ホウオウGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 190,
+	types: ["Fire"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "せいなるほのお" },
+			cost: ["Fire", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のポケモン1匹に、50ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+			},
+		},
+		{
+			name: { ja: "フェニックスバーン" },
+			damage: 180,
+			cost: ["Fire", "Fire", "Fire", "Colorless"],
+			effect: {
+				ja: "次の自分の番、このポケモンは「フェニックスバーン」が使えない。",
+			},
+		},
+		{
+			name: { ja: "エターナルライトGX" },
+			cost: ["Fire", "Colorless", "Colorless"],
+			effect: {
+				ja: "自分のトラッシュにある[炎]タイプの「ポケモンGX・EX」を3枚、ベンチに出す。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 551546,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Ultra Rare",
+	dexId: [250],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM8b/211.ts
+++ b/data-asia/SM/SM8b/211.ts
@@ -1,0 +1,62 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "レシラムGX",
+	},
+
+	illustrator: "PLANETA Igarashi",
+	category: "Pokemon",
+	hp: 180,
+	types: ["Fire"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ニトロチャージ" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札にある[炎]エネルギーを2枚まで、このポケモンにつける。そして山札を切る。",
+			},
+		},
+		{
+			name: { ja: "しゃくねつのはしら" },
+			damage: 110,
+			cost: ["Fire", "Fire", "Fire", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをやけどにする。",
+			},
+		},
+		{
+			name: { ja: "ヴァーミリオンGX" },
+			damage: 180,
+			cost: ["Fire", "Fire", "Fire", "Colorless"],
+			effect: {
+				ja: "のぞむなら、自分の手札にある[炎]エネルギーを5枚まで、自分のポケモンに好きなようにつける。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 551551,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Ultra Rare",
+	dexId: [643],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM8b/212.ts
+++ b/data-asia/SM/SM8b/212.ts
@@ -1,0 +1,62 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "バクガメスGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 190,
+	types: ["Fire"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "トラップシェル" },
+			damage: 20,
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "次の相手の番、このポケモンがワザのダメージを受けたとき、ワザを使ったポケモンにダメカンを8個のせる。",
+			},
+		},
+		{
+			name: { ja: "ぐれんのほのお" },
+			damage: 160,
+			cost: ["Fire", "Fire", "Colorless"],
+			effect: {
+				ja: "このポケモンについている[炎]エネルギーを、2個トラッシュする。",
+			},
+		},
+		{
+			name: { ja: "ニトロタンクGX" },
+			cost: ["Fire"],
+			effect: {
+				ja: "自分のトラッシュにある[炎]エネルギーを5枚、自分のポケモンに好きなようにつける。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 551556,
+			},
+		},
+	],
+
+	retreat: 3,
+	rarity: "Ultra Rare",
+	dexId: [776],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM8b/213.ts
+++ b/data-asia/SM/SM8b/213.ts
@@ -1,0 +1,65 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アローラキュウコンGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 210,
+	types: ["Water"],
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "こおりのやいば" },
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "相手のポケモン1匹に、50ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+			},
+		},
+		{
+			name: { ja: "ブリザードエッジ" },
+			damage: 160,
+			cost: ["Water", "Water", "Colorless"],
+			effect: {
+				ja: "このポケモンについているエネルギーを、2個トラッシュする。",
+			},
+		},
+		{
+			name: { ja: "クリアゲートGX" },
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンにのっているダメカンをすべて、相手のバトルポケモンにのせ替える。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 551561,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "アローラロコン",
+	},
+
+	retreat: 1,
+	rarity: "Ultra Rare",
+	dexId: [38],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM8b/214.ts
+++ b/data-asia/SM/SM8b/214.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "フリーザーGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 170,
+	types: ["Water"],
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "でんせつのひしょう" },
+			effect: {
+				ja: "自分の番に、このカードを手札からベンチに出したとき、1回使える。このポケモンをバトルポケモンと入れ替える。入れ替えた場合、自分の場のポケモンについている[水]エネルギーを好きなだけ、このポケモンにつけ替える。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "アイスウイング" },
+			damage: 130,
+			cost: ["Water", "Water", "Colorless"],
+		},
+		{
+			name: { ja: "コールドクラッシュGX" },
+			cost: ["Water"],
+			effect: {
+				ja: "おたがいのバトルポケモンについているエネルギーを、すべてトラッシュする。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 551566,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Ultra Rare",
+	dexId: [144],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM8b/215.ts
+++ b/data-asia/SM/SM8b/215.ts
@@ -1,0 +1,69 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "グレイシアGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 200,
+	types: ["Water"],
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "いてつくひとみ" },
+			effect: {
+				ja: "このポケモンがバトル場にいるかぎり、相手の場・手札・トラッシュにある「ポケモンGX・EX」の特性（「いてつくひとみ」をのぞく）は、すべてなくなる。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "フロストバレット" },
+			damage: 90,
+			cost: ["Water", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のベンチポケモン1匹にも、30ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+			},
+		},
+		{
+			name: { ja: "ポーラースピアGX" },
+			damage: "50×",
+			cost: ["Water", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンにのっているダメカンの数x50ダメージ。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 551571,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "イーブイ",
+	},
+
+	retreat: 2,
+	rarity: "Ultra Rare",
+	dexId: [471],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM8b/216.ts
+++ b/data-asia/SM/SM8b/216.ts
@@ -1,0 +1,68 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ゲッコウガGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 230,
+	types: ["Water"],
+
+	stage: "Stage2",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ふうましゅりけん" },
+			effect: {
+				ja: "自分の番に、このカードを手札から出して進化させたとき、1回使える。相手のポケモン1匹に、ダメカンを3個のせる。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "おぼろぎり" },
+			damage: 110,
+			cost: ["Water", "Colorless", "Colorless"],
+			effect: {
+				ja: "のぞむなら、このポケモンと、ついているすべてのカードを、自分の山札にもどして切る。",
+			},
+		},
+		{
+			name: { ja: "シャドーアサシンGX" },
+			cost: ["Water", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のベンチポケモン1匹に、130ダメージ。［ベンチは弱点・抵抗力を計算しない。］［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 551576,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ゲコガシラ",
+	},
+
+	retreat: 2,
+	rarity: "Ultra Rare",
+	dexId: [658],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM8b/217.ts
+++ b/data-asia/SM/SM8b/217.ts
@@ -1,0 +1,66 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "マルマインGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 190,
+	types: ["Lightning"],
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "エネエネボンバー" },
+			effect: {
+				ja: "自分の番に1回使えて、使ったなら、このポケモンをきぜつさせる。自分のトラッシュにあるエネルギーを5枚、自分のポケモン（「ポケモンGX・EX」をのぞく）に好きなようにつける。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "エレキボール" },
+			damage: 50,
+			cost: ["Lightning", "Colorless"],
+		},
+		{
+			name: { ja: "クラッシュバーンGX" },
+			damage: "30+",
+			cost: ["Lightning", "Colorless"],
+			effect: {
+				ja: "自分の場のポケモンについているエネルギーを好きなだけトラッシュし、その枚数x50ダメージ追加。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Metal", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 551581,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ビリリダマ",
+	},
+
+	retreat: 1,
+	rarity: "Ultra Rare",
+	dexId: [101],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM8b/218.ts
+++ b/data-asia/SM/SM8b/218.ts
@@ -1,0 +1,64 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "デンジュモクGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 180,
+	types: ["Lightning"],
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "フラッシュヘッド" },
+			effect: {
+				ja: "このポケモンは、特殊エネルギーがついている相手のポケモンから、ワザのダメージを受けない。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ランブルワイヤー" },
+			damage: 100,
+			cost: ["Lightning", "Lightning", "Colorless"],
+			effect: {
+				ja: "相手の山札を上から1枚トラッシュする。",
+			},
+		},
+		{
+			name: { ja: "ライトニングGX" },
+			cost: ["Lightning"],
+			effect: {
+				ja: "相手の手札を見て、その中にあるカードを1枚、ウラにして相手のサイドとして置く。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Metal", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 551586,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Ultra Rare",
+	dexId: [796],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM8b/219.ts
+++ b/data-asia/SM/SM8b/219.ts
@@ -1,0 +1,63 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ミュウツーGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 190,
+	types: ["Psychic"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "フルバースト" },
+			damage: "30×",
+			cost: ["Psychic"],
+			effect: {
+				ja: "このポケモンについているエネルギーの数x30ダメージ。",
+			},
+		},
+		{
+			name: { ja: "ちょうきゅうしゅう" },
+			damage: 60,
+			cost: ["Psychic", "Colorless"],
+			effect: {
+				ja: "このポケモンのHPを「30」回復する。",
+			},
+		},
+		{
+			name: { ja: "サイコブレイクGX" },
+			damage: 200,
+			cost: ["Psychic", "Psychic", "Psychic"],
+			effect: {
+				ja: "このワザのダメージは、相手のバトルポケモンにかかっている効果を計算しない。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 551591,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Ultra Rare",
+	dexId: [150],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM8b/220.ts
+++ b/data-asia/SM/SM8b/220.ts
@@ -1,0 +1,66 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "エーフィGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 200,
+	types: ["Psychic"],
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "サイケこうせん" },
+			damage: 30,
+			cost: ["Psychic"],
+			effect: {
+				ja: "相手のバトルポケモンをこんらんにする。",
+			},
+		},
+		{
+			name: { ja: "サイコキネシス" },
+			damage: "60+",
+			cost: ["Psychic", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンについているエネルギーの数x30ダメージ追加。",
+			},
+		},
+		{
+			name: { ja: "ディビジョンGX" },
+			cost: ["Psychic", "Colorless", "Colorless"],
+			effect: {
+				ja: "ダメカン10個を、相手のポケモンに好きなようにのせる。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 551596,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "イーブイ",
+	},
+
+	retreat: 1,
+	rarity: "Ultra Rare",
+	dexId: [196],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM8b/221.ts
+++ b/data-asia/SM/SM8b/221.ts
@@ -1,0 +1,68 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ジュペッタGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 190,
+	types: ["Psychic"],
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "シャドームーブ" },
+			effect: {
+				ja: "このポケモンがバトル場にいるなら、自分の番に1回使える。おたがいの場のポケモンにのっているダメカンを1個、おたがいの場の別のポケモンにのせ替える。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "かげのじゅもん" },
+			damage: "30+",
+			cost: ["Psychic"],
+			effect: {
+				ja: "自分のトラッシュのサポートの枚数x10ダメージ追加。追加できるダメージはサポート10枚ぶんまで。",
+			},
+		},
+		{
+			name: { ja: "トゥームハントGX" },
+			cost: ["Psychic"],
+			effect: {
+				ja: "自分のトラッシュにある好きなカードを3枚、相手に見せてから、手札に加える。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 551601,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "カゲボウズ",
+	},
+
+	retreat: 1,
+	rarity: "Ultra Rare",
+	dexId: [354],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM8b/222.ts
+++ b/data-asia/SM/SM8b/222.ts
@@ -1,0 +1,64 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ウツロイドGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 180,
+	types: ["Psychic"],
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "うつろなひかり" },
+			effect: {
+				ja: "自分の番に、このカードを手札からベンチに出したとき、1回使える。おたがいのバトルポケモンを、それぞれどくとこんらんにする。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "とじこめる" },
+			damage: 120,
+			cost: ["Psychic", "Psychic", "Psychic"],
+			effect: {
+				ja: "次の相手の番、このワザを受けたポケモンは、にげられない。",
+			},
+		},
+		{
+			name: { ja: "パラサイトGX" },
+			cost: ["Psychic", "Psychic", "Psychic"],
+			effect: {
+				ja: "相手の山札を上から2枚、相手のサイドとして置く。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 551606,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Ultra Rare",
+	dexId: [793],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM8b/223.ts
+++ b/data-asia/SM/SM8b/223.ts
@@ -1,0 +1,66 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アーゴヨンGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 210,
+	types: ["Psychic"],
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "ビーストレイド" },
+			damage: "20×",
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の場の「ウルトラビースト」の数x20ダメージ。",
+			},
+		},
+		{
+			name: { ja: "ジェットタッカー" },
+			damage: 110,
+			cost: ["Psychic", "Colorless", "Colorless"],
+			effect: {
+				ja: "このワザのダメージは弱点・抵抗力を計算しない。",
+			},
+		},
+		{
+			name: { ja: "スティンガーGX" },
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "おたがいのプレイヤーは、それぞれサイドをすべて山札にもどして切る。その後、それぞれ山札を上から3枚、サイドとして置く。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 551611,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ベベノム",
+	},
+
+	retreat: 1,
+	rarity: "Ultra Rare",
+	dexId: [804],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM8b/224.ts
+++ b/data-asia/SM/SM8b/224.ts
@@ -1,0 +1,64 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ルカリオGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 210,
+	types: ["Fighting"],
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "はどうげき" },
+			damage: "30+",
+			cost: ["Fighting"],
+			effect: {
+				ja: "この番、このポケモンが「リオル」から進化していたなら、90ダメージ追加。",
+			},
+		},
+		{
+			name: { ja: "せんぷうきゃく" },
+			damage: 130,
+			cost: ["Fighting", "Fighting", "Colorless"],
+		},
+		{
+			name: { ja: "クロスビートGX" },
+			damage: "30×",
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンにのっているダメカンの数x30ダメージ。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 551616,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "リオル",
+	},
+
+	retreat: 2,
+	rarity: "Ultra Rare",
+	dexId: [448],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM8b/225.ts
+++ b/data-asia/SM/SM8b/225.ts
@@ -1,0 +1,60 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ジガルデGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 200,
+	types: ["Fighting"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "セルコネクター" },
+			damage: 50,
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "自分のトラッシュにある[闘]エネルギーを2枚、このポケモンにつける。",
+			},
+		},
+		{
+			name: { ja: "グランドフォース" },
+			damage: 130,
+			cost: ["Fighting", "Fighting", "Colorless", "Colorless"],
+		},
+		{
+			name: { ja: "ジャッジメントGX" },
+			damage: 150,
+			cost: ["Fighting", "Fighting", "Colorless", "Colorless"],
+			effect: {
+				ja: "次の相手の番、このポケモンは「ポケモンGX・EX」からワザのダメージを受けない。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 551621,
+			},
+		},
+	],
+
+	retreat: 3,
+	rarity: "Ultra Rare",
+	dexId: [718],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM8b/226.ts
+++ b/data-asia/SM/SM8b/226.ts
@@ -1,0 +1,66 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ルガルガンGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 200,
+	types: ["Fighting"],
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ブラッディアイ" },
+			effect: {
+				ja: "自分の番に、このカードを手札から出して進化させたとき、1回使える。相手のベンチポケモンを1匹選び、バトルポケモンと入れ替える。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ツメできりさく" },
+			damage: 110,
+			cost: ["Fighting", "Colorless", "Colorless"],
+		},
+		{
+			name: { ja: "デスローグGX" },
+			damage: "50×",
+			cost: ["Fighting", "Colorless"],
+			effect: {
+				ja: "相手のベンチポケモンの数x50ダメージ。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 551626,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "イワンコ",
+	},
+
+	retreat: 2,
+	rarity: "Ultra Rare",
+	dexId: [745],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM8b/227.ts
+++ b/data-asia/SM/SM8b/227.ts
@@ -1,0 +1,66 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ルガルガンGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 200,
+	types: ["Fighting"],
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "トワイライトアイ" },
+			effect: {
+				ja: "自分の番に、このカードを手札から出して進化させたとき、1回使える。相手のバトルポケモンについているエネルギーを、1個トラッシュする。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "アクセルロック" },
+			damage: 120,
+			cost: ["Fighting", "Colorless", "Colorless"],
+		},
+		{
+			name: { ja: "ラジアルエッジGX" },
+			damage: "30×",
+			cost: ["Fighting"],
+			effect: {
+				ja: "相手のトラッシュにあるエネルギーの枚数x30ダメージ。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 551631,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "イワンコ",
+	},
+
+	retreat: 2,
+	rarity: "Ultra Rare",
+	dexId: [745],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM8b/228.ts
+++ b/data-asia/SM/SM8b/228.ts
@@ -1,0 +1,63 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "マッシブーンGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 190,
+	types: ["Fighting"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ジェットパンチ" },
+			damage: 30,
+			cost: ["Fighting"],
+			effect: {
+				ja: "相手のベンチポケモン1匹にも、30ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+			},
+		},
+		{
+			name: { ja: "ナックルインパクト" },
+			damage: 160,
+			cost: ["Fighting", "Fighting", "Fighting"],
+			effect: {
+				ja: "次の自分の番、このポケモンはワザが使えない。",
+			},
+		},
+		{
+			name: { ja: "イクスパンションGX" },
+			damage: "40×",
+			cost: ["Fighting", "Fighting", "Fighting"],
+			effect: {
+				ja: "自分のサイドの枚数x40ダメージ。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 551636,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Ultra Rare",
+	dexId: [794],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM8b/229.ts
+++ b/data-asia/SM/SM8b/229.ts
@@ -1,0 +1,66 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ブラッキーGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 200,
+	types: ["Darkness"],
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "ひるがえす" },
+			damage: 30,
+			cost: ["Darkness"],
+			effect: {
+				ja: "のぞむなら、このポケモンをベンチポケモンと入れ替える。",
+			},
+		},
+		{
+			name: { ja: "シャドーバレット" },
+			damage: 90,
+			cost: ["Darkness", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のベンチポケモン1匹にも、30ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+			},
+		},
+		{
+			name: { ja: "ナイトクライGX" },
+			cost: ["Darkness", "Colorless"],
+			effect: {
+				ja: "相手の場のポケモンについているエネルギーを、2個トラッシュする。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 551641,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "イーブイ",
+	},
+
+	retreat: 2,
+	rarity: "Ultra Rare",
+	dexId: [197],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM8b/230.ts
+++ b/data-asia/SM/SM8b/230.ts
@@ -1,0 +1,64 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ダークライGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 180,
+	types: ["Darkness"],
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "リザレクション" },
+			effect: {
+				ja: "このカードがトラッシュにあるなら、自分の番に1回使える。このカードをベンチに出す。その後、自分のトラッシュにある[悪]エネルギーを1枚、このカードにつける。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "やみのさけめ" },
+			damage: 130,
+			cost: ["Darkness", "Darkness", "Colorless"],
+			effect: {
+				ja: "このワザのダメージは抵抗力を計算しない。",
+			},
+		},
+		{
+			name: { ja: "デッドエンドGX" },
+			cost: ["Darkness", "Darkness", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンが特殊状態なら、そのポケモンをきぜつさせる。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 551646,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Ultra Rare",
+	dexId: [491],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM8b/231.ts
+++ b/data-asia/SM/SM8b/231.ts
@@ -1,0 +1,68 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ゾロアークGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 210,
+	types: ["Darkness"],
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "とりひき" },
+			effect: {
+				ja: "自分の番に1回使える。自分の手札を1枚トラッシュする。その後、山札を2枚引く。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ライオットビート" },
+			damage: "20×",
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "自分の場のポケモンの数x20ダメージ。",
+			},
+		},
+		{
+			name: { ja: "トリックスターGX" },
+			cost: ["Darkness", "Darkness"],
+			effect: {
+				ja: "相手の場のポケモンが持っているワザを1つ選び、このワザとして使う。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 551651,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ゾロア",
+	},
+
+	retreat: 2,
+	rarity: "Ultra Rare",
+	dexId: [571],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM8b/232.ts
+++ b/data-asia/SM/SM8b/232.ts
@@ -1,0 +1,59 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アクジキングGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 210,
+	types: ["Darkness"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "くいちらかす" },
+			cost: ["Darkness"],
+			effect: {
+				ja: "自分の山札を上から5枚トラッシュし、その中にあるエネルギーをすべて、このポケモンにつける。",
+			},
+		},
+		{
+			name: { ja: "タイラントホール" },
+			damage: 180,
+			cost: ["Darkness", "Darkness", "Darkness", "Colorless", "Colorless"],
+		},
+		{
+			name: { ja: "グラトニーGX" },
+			damage: 100,
+			cost: ["Darkness", "Darkness", "Darkness", "Darkness", "Darkness"],
+			effect: {
+				ja: "このワザのダメージで、相手のポケモンがきぜつしたなら、サイドを2枚多くとる。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 551656,
+			},
+		},
+	],
+
+	retreat: 4,
+	rarity: "Ultra Rare",
+	dexId: [799],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM8b/233.ts
+++ b/data-asia/SM/SM8b/233.ts
@@ -1,0 +1,69 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ハッサムGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 210,
+	types: ["Metal"],
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "きけんしょく" },
+			effect: {
+				ja: "このポケモンの残りHPが「100」以下なら、このポケモンが使うワザの、相手のバトルポケモンへのダメージは「+80」される。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "はがねのつばさ" },
+			damage: 80,
+			cost: ["Metal", "Colorless"],
+			effect: {
+				ja: "次の相手の番、このポケモンが受けるワザのダメージは「-30」される。",
+			},
+		},
+		{
+			name: { ja: "ふりおろすGX" },
+			damage: "100+",
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンが進化ポケモンなら、100ダメージ追加。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 551661,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ストライク",
+	},
+
+	retreat: 1,
+	rarity: "Ultra Rare",
+	dexId: [212],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM8b/234.ts
+++ b/data-asia/SM/SM8b/234.ts
@@ -1,0 +1,68 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "メタグロスGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 250,
+	types: ["Metal"],
+
+	stage: "Stage2",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ジオテックシステム" },
+			effect: {
+				ja: "自分の番に1回使える。自分のトラッシュにある[超]または[鋼]エネルギーを1枚、バトルポケモンにつける。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ギガハンマー" },
+			damage: 150,
+			cost: ["Metal", "Metal", "Colorless"],
+			effect: {
+				ja: "次の自分の番、このポケモンは「ギガハンマー」が使えない。",
+			},
+		},
+		{
+			name: { ja: "アルゴリズムGX" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札にある好きなカードを5枚まで、手札に加える。そして山札を切る。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 551666,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "メタング",
+	},
+
+	retreat: 3,
+	rarity: "Ultra Rare",
+	dexId: [376],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM8b/235.ts
+++ b/data-asia/SM/SM8b/235.ts
@@ -1,0 +1,64 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "カミツルギGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 170,
+	types: ["Metal"],
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "きりすてる" },
+			effect: {
+				ja: "自分の番に、このカードを手札からベンチに出したとき、1回使える。相手の場のポケモンについている特殊エネルギーを、1個トラッシュする。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "はやてのたち" },
+			damage: 70,
+			cost: ["Metal", "Colorless", "Colorless"],
+			effect: {
+				ja: "のぞむなら、このポケモンと、ついているすべてのカードを、自分の山札にもどして切る。",
+			},
+		},
+		{
+			name: { ja: "スラッシュGX" },
+			cost: ["Metal"],
+			effect: {
+				ja: "自分のサイドを1枚とる。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 551671,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Ultra Rare",
+	dexId: [798],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM8b/236.ts
+++ b/data-asia/SM/SM8b/236.ts
@@ -1,0 +1,62 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ツンデツンデGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 180,
+	types: ["Metal"],
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ウルトラウォール" },
+			effect: {
+				ja: "このポケモンがいるかぎり、自分の「ウルトラビースト」全員が、相手のポケモンから受けるワザのダメージは「-10」される。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ギガトンスタンプ" },
+			damage: 120,
+			cost: ["Metal", "Metal", "Colorless"],
+		},
+		{
+			name: { ja: "レイGX" },
+			damage: "50+",
+			cost: ["Metal", "Metal", "Colorless"],
+			effect: {
+				ja: "自分がすでにとったサイドの枚数x50ダメージ追加。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 551676,
+			},
+		},
+	],
+
+	retreat: 3,
+	rarity: "Ultra Rare",
+	dexId: [805],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM8b/237.ts
+++ b/data-asia/SM/SM8b/237.ts
@@ -1,0 +1,68 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "サーナイトGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 230,
+	types: ["Fairy"],
+
+	stage: "Stage2",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ひみつのいずみ" },
+			effect: {
+				ja: "自分の番に1回使える。自分の手札にある[妖]エネルギーを1枚、自分のポケモンにつける。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "インフィニットフォース" },
+			damage: "30×",
+			cost: ["Fairy"],
+			effect: {
+				ja: "おたがいのバトルポケモンについているエネルギーの数x30ダメージ。",
+			},
+		},
+		{
+			name: { ja: "トワイライトGX" },
+			cost: ["Fairy"],
+			effect: {
+				ja: "自分のトラッシュにある好きなカードを10枚、相手に見せてから、山札にもどして切る。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [{ type: "Darkness", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 551681,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "キルリア",
+	},
+
+	retreat: 2,
+	rarity: "Ultra Rare",
+	dexId: [282],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM8b/238.ts
+++ b/data-asia/SM/SM8b/238.ts
@@ -1,0 +1,62 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ニンフィアGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 200,
+	types: ["Fairy"],
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "マジカルリボン" },
+			cost: ["Fairy"],
+			effect: {
+				ja: "自分の山札にある好きなカードを3枚まで、手札に加える。そして山札を切る。",
+			},
+		},
+		{
+			name: { ja: "ようせいのかぜ" },
+			damage: 110,
+			cost: ["Fairy", "Colorless", "Colorless"],
+		},
+		{
+			name: { ja: "プリエールGX" },
+			cost: ["Fairy", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のベンチポケモン2匹と、そのポケモンについているすべてのカードを、相手の手札にもどす。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [{ type: "Darkness", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 551686,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "イーブイ",
+	},
+
+	retreat: 2,
+	rarity: "Ultra Rare",
+	dexId: [700],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM8b/239.ts
+++ b/data-asia/SM/SM8b/239.ts
@@ -1,0 +1,66 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "チルタリスGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 200,
+	types: ["Dragon"],
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "ブライトトーン" },
+			damage: 50,
+			cost: ["Fairy", "Colorless"],
+			effect: {
+				ja: "次の相手の番、このポケモンは「ポケモンGX・EX」からワザのダメージを受けない。",
+			},
+		},
+		{
+			name: { ja: "ソニックエッジ" },
+			damage: 110,
+			cost: ["Water", "Fairy", "Colorless"],
+			effect: {
+				ja: "このワザのダメージは、相手のバトルポケモンにかかっている効果を計算しない。",
+			},
+		},
+		{
+			name: { ja: "ユーフォリアGX" },
+			cost: ["Fairy", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをねむりにする。自分のポケモン全員のHPを、すべて回復する。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fairy", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 551691,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "チルット",
+	},
+
+	retreat: 1,
+	rarity: "Ultra Rare",
+	dexId: [334],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM8b/240.ts
+++ b/data-asia/SM/SM8b/240.ts
@@ -1,0 +1,64 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "レックウザGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 180,
+	types: ["Dragon"],
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "しっぷうどとう" },
+			effect: {
+				ja: "自分の番に、このカードを手札からベンチに出したとき、1回使える。自分の山札を上から3枚トラッシュする。その後、トラッシュにある基本エネルギーを1枚、このポケモンにつける。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ドラゴンブレイク" },
+			damage: "30×",
+			cost: ["Grass", "Lightning", "Colorless"],
+			effect: {
+				ja: "自分の場のポケモンについている[草]と[雷]タイプの基本エネルギーの数x30ダメージ。",
+			},
+		},
+		{
+			name: { ja: "テンペストGX" },
+			cost: ["Grass"],
+			effect: {
+				ja: "自分の手札をすべてトラッシュし、山札を10枚引く。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fairy", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 551696,
+			},
+		},
+	],
+
+	retreat: 3,
+	rarity: "Ultra Rare",
+	dexId: [384],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM8b/241.ts
+++ b/data-asia/SM/SM8b/241.ts
@@ -1,0 +1,66 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "オンバーンGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 200,
+	types: ["Dragon"],
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "ディストーション" },
+			damage: 50,
+			cost: ["Darkness", "Colorless"],
+			effect: {
+				ja: "次の相手の番、相手は手札からグッズを出して使えない。",
+			},
+		},
+		{
+			name: { ja: "ラウドソニック" },
+			damage: 120,
+			cost: ["Psychic", "Darkness", "Colorless"],
+			effect: {
+				ja: "次の相手の番、相手は手札から特殊エネルギーを出してつけられない。",
+			},
+		},
+		{
+			name: { ja: "ばくおんぱGX" },
+			cost: ["Psychic", "Darkness", "Colorless"],
+			effect: {
+				ja: "相手のポケモン全員に、それぞれ50ダメージ。［ベンチは弱点・抵抗力を計算しない。］［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fairy", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 551701,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "オンバット",
+	},
+
+	retreat: 0,
+	rarity: "Ultra Rare",
+	dexId: [715],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM8b/242.ts
+++ b/data-asia/SM/SM8b/242.ts
@@ -1,0 +1,69 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "シルヴァディGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 210,
+	types: ["Colorless"],
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ジャイロユニット" },
+			effect: {
+				ja: "このポケモンがいるかぎり、自分のたねポケモン全員のにげるためのエネルギーは、すべてなくなる。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ターボドライブ" },
+			damage: 120,
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "自分のトラッシュにある基本エネルギーを1枚、ベンチポケモンにつける。",
+			},
+		},
+		{
+			name: { ja: "リベリオンGX" },
+			damage: "50×",
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のベンチポケモンの数x50ダメージ。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 551706,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "タイプ：ヌル",
+	},
+
+	retreat: 2,
+	rarity: "Ultra Rare",
+	dexId: [773],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM8b/243.ts
+++ b/data-asia/SM/SM8b/243.ts
@@ -1,0 +1,62 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ジジーロンGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 180,
+	types: ["Colorless"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ホーリーエッジ" },
+			damage: 20,
+			cost: ["Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンについている特殊エネルギーを、1個トラッシュする。",
+			},
+		},
+		{
+			name: { ja: "ぎゃくじょう" },
+			damage: "80+",
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "自分のベンチポケモンにダメカンがのっているなら、70ダメージ追加。",
+			},
+		},
+		{
+			name: { ja: "だいしゃりんGX" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の手札をすべて山札にもどして切る。その後、山札を10枚引く。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 551711,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Ultra Rare",
+	dexId: [780],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM8b/244.ts
+++ b/data-asia/SM/SM8b/244.ts
@@ -1,0 +1,60 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "カプ・ブルルGX",
+	},
+
+	illustrator: "",
+	category: "Pokemon",
+	hp: 180,
+	types: ["Grass"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "つのでつく" },
+			damage: 30,
+			cost: ["Grass"],
+		},
+		{
+			name: { ja: "しぜんのさばき" },
+			damage: "120+",
+			cost: ["Grass", "Grass", "Colorless"],
+			effect: {
+				ja: "のぞむなら、このポケモンについているエネルギーを、すべてトラッシュする。その場合、60ダメージ追加。",
+			},
+		},
+		{
+			name: { ja: "カプワイルドGX" },
+			damage: 150,
+			cost: ["Grass", "Grass", "Colorless"],
+			effect: {
+				ja: "このポケモンのHPを、すべて回復する。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 551716,
+			},
+		},
+	],
+
+	retreat: 3,
+	rarity: "Secret Rare",
+	dexId: [787],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM8b/245.ts
+++ b/data-asia/SM/SM8b/245.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "カプ・レヒレGX",
+	},
+
+	illustrator: "",
+	category: "Pokemon",
+	hp: 170,
+	types: ["Water"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "アクアリング" },
+			damage: 20,
+			cost: ["Colorless"],
+			effect: {
+				ja: "のぞむなら、このポケモンをベンチポケモンと入れ替える。",
+			},
+		},
+		{
+			name: { ja: "ハイドロシュート" },
+			cost: ["Water", "Water", "Colorless"],
+			effect: {
+				ja: "このポケモンについている[水]エネルギーを2個トラッシュし、相手のポケモン1匹に、120ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+			},
+		},
+		{
+			name: { ja: "カプストームGX" },
+			cost: ["Water"],
+			effect: {
+				ja: "相手のバトルポケモンと、ついているすべてのカードを、相手の山札にもどして切る。相手のベンチポケモンがいないなら、このワザは失敗。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 551721,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Secret Rare",
+	dexId: [788],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM8b/246.ts
+++ b/data-asia/SM/SM8b/246.ts
@@ -1,0 +1,62 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "カプ・コケコGX",
+	},
+
+	illustrator: "",
+	category: "Pokemon",
+	hp: 170,
+	types: ["Lightning"],
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "エアロトレイル" },
+			effect: {
+				ja: "自分の番に、このカードを手札からベンチに出したとき、1回使える。自分の場のポケモンについている[雷]エネルギーを好きなだけ、このポケモンにつけ替える。つけ替えた場合、このポケモンをバトルポケモンと入れ替える。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "てんくうのツメ" },
+			damage: 130,
+			cost: ["Lightning", "Lightning", "Colorless"],
+		},
+		{
+			name: { ja: "カプサンダーGX" },
+			damage: "50×",
+			cost: ["Lightning", "Lightning", "Colorless"],
+			effect: {
+				ja: "相手の場のポケモンについているエネルギーの数x50ダメージ。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 551726,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Secret Rare",
+	dexId: [785],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM8b/247.ts
+++ b/data-asia/SM/SM8b/247.ts
@@ -1,0 +1,64 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "カプ・テテフGX",
+	},
+
+	illustrator: "",
+	category: "Pokemon",
+	hp: 170,
+	types: ["Psychic"],
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ワンダータッチ" },
+			effect: {
+				ja: "自分の番に、このカードを手札からベンチに出したとき、1回使える。自分の山札にあるサポートを1枚、相手に見せてから、手札に加える。そして山札を切る。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "エナジードライブ" },
+			damage: "20×",
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "おたがいのバトルポケモンについているエネルギーの数x20ダメージ。このワザのダメージは弱点・抵抗力を計算しない。",
+			},
+		},
+		{
+			name: { ja: "カプキュアーGX" },
+			cost: ["Psychic"],
+			effect: {
+				ja: "自分のベンチポケモン2匹のHPを、すべて回復する。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 551731,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Secret Rare",
+	dexId: [786],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM8b/248.ts
+++ b/data-asia/SM/SM8b/248.ts
@@ -1,0 +1,68 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ルナアーラGX",
+	},
+
+	illustrator: "",
+	category: "Pokemon",
+	hp: 250,
+	types: ["Psychic"],
+
+	stage: "Stage2",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "サイコトランス" },
+			effect: {
+				ja: "自分の番に何回でも使える。自分の場のポケモンについている[超]エネルギーを1個、自分の別のポケモンにつけ替える。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "シャドーレイ" },
+			damage: 120,
+			cost: ["Psychic", "Psychic", "Psychic", "Psychic"],
+			effect: {
+				ja: "次の相手の番、このワザを受けたポケモンのHPは、回復しない。",
+			},
+		},
+		{
+			name: { ja: "ルナフォールGX" },
+			cost: ["Psychic", "Psychic", "Psychic"],
+			effect: {
+				ja: "相手のたねポケモン（「ポケモンGX」をのぞく）を1匹、きぜつさせる。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 551736,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "コスモウム",
+	},
+
+	retreat: 2,
+	rarity: "Secret Rare",
+	dexId: [792],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM8b/249.ts
+++ b/data-asia/SM/SM8b/249.ts
@@ -1,0 +1,68 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ソルガレオGX",
+	},
+
+	illustrator: "",
+	category: "Pokemon",
+	hp: 250,
+	types: ["Metal"],
+
+	stage: "Stage2",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ウルトラロード" },
+			effect: {
+				ja: "自分の番に1回使える。自分のバトルポケモンをベンチポケモンと入れ替える。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "メテオドライブ" },
+			damage: 230,
+			cost: ["Metal", "Metal", "Colorless"],
+			effect: {
+				ja: "このポケモンについているエネルギーを、すべてトラッシュする。",
+			},
+		},
+		{
+			name: { ja: "ソルバーストGX" },
+			cost: ["Metal"],
+			effect: {
+				ja: "自分の山札にあるエネルギーを5枚まで、自分のポケモンに好きなようにつける。そして山札を切る。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 551741,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "コスモウム",
+	},
+
+	retreat: 3,
+	rarity: "Secret Rare",
+	dexId: [791],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM8b/250.ts
+++ b/data-asia/SM/SM8b/250.ts
@@ -1,0 +1,54 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ウルトラネクロズマGX",
+	},
+
+	illustrator: "",
+	category: "Pokemon",
+	hp: 190,
+	types: ["Dragon"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "フォトンゲイザー" },
+			damage: "20+",
+			cost: ["Psychic", "Metal"],
+			effect: {
+				ja: "このポケモンについている基本[超]エネルギーをすべてトラッシュし、その枚数x80ダメージ追加。",
+			},
+		},
+		{
+			name: { ja: "めつぼうのひかりGX" },
+			cost: ["Psychic", "Metal"],
+			effect: {
+				ja: "このワザは、おたがいのサイドの残り枚数の合計が、6枚以下のときにしか使えない。相手のポケモン全員に、それぞれダメカンを6個のせる。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fairy", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 551746,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Secret Rare",
+	dexId: [800],
+
+	suffix: "GX",
+};
+
+export default card;


### PR DESCRIPTION
## What

Adds the complete Japanese set **SM8b GXウルトラシャイニー (GX Ultra Shiny)**, released 2018-11-02:

- `data-asia/SM/SM8b/001.ts` … `250.ts` — all 250 cards (150 regular + 100 secret rares: 93 SR, 7 Secret Rare)
- the set definition `data-asia/SM/SM8b.ts` already existed and is untouched

## Data sources

- **pokemon-card.com** (official database): Japanese names, flavor texts, National Dex numbers, official card count
- **limitlesstcg.com**: full Japanese card text, stages, weaknesses/resistances/retreat, rarities, illustrators, attack costs
- **Cardmarket**: product IDs as `thirdParty.cardmarket` on the variant objects (550491–551746; tcgplayer IDs not available to me)

## Notes

- Follows the file format and conventions of the M-era sets (#1728)
- No `regulationMark` (the set predates regulation marks); resistances are `-20` per the era
- All 250 files type-check against `interfaces.d.ts` (`tsc --noEmit`)
