### PR TITLE
(data) Add Japanese SM set SM9 Tag Bolt

### DIFF
--- a/data-asia/SM/SM9/001.ts
+++ b/data-asia/SM/SM9/001.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "セレビィ&フシギバナGX",
+	},
+
+	illustrator: "Mitsuhiro Arita",
+	category: "Pokemon",
+	hp: 270,
+	types: ["Grass"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "きけんなかふん" },
+			damage: 50,
+			cost: ["Grass", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをどくとやけどとこんらんにする。",
+			},
+		},
+		{
+			name: { ja: "ソーラービーム" },
+			damage: 150,
+			cost: ["Grass", "Grass", "Colorless", "Colorless"],
+		},
+		{
+			name: { ja: "エバーグリーンGX" },
+			damage: 180,
+			cost: ["Grass", "Grass", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンのHPを、すべて回復する。追加で[草]エネルギーが1個ついているなら、自分のトラッシュにあるカードをすべて山札にもどして切る。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 558279,
+			},
+		},
+	],
+
+	retreat: 4,
+	regulationMark: "C",
+	rarity: "Double rare",
+	dexId: [251, 3],
+
+	suffix: "TAG TEAM-GX",
+};
+
+export default card;

--- a/data-asia/SM/SM9/002.ts
+++ b/data-asia/SM/SM9/002.ts
@@ -1,0 +1,54 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ビードル",
+	},
+
+	illustrator: "Shibuzoh.",
+	category: "Pokemon",
+	hp: 40,
+	types: ["Grass"],
+
+	description: {
+		ja: "森や 草地に 多く 生息。 頭の 先に ５センチぐらいの 小さく 鋭い 毒針を持つ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "からめてひっぱる" },
+			cost: ["Grass"],
+			effect: {
+				ja: "相手のベンチポケモンを1匹選び、バトルポケモンと入れ替える。",
+			},
+		},
+		{
+			name: { ja: "むしくい" },
+			damage: 10,
+			cost: ["Grass"],
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558280,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [13],
+};
+
+export default card;

--- a/data-asia/SM/SM9/003.ts
+++ b/data-asia/SM/SM9/003.ts
@@ -1,0 +1,50 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ビードル",
+	},
+
+	illustrator: "SATOSHI NAKAI",
+	category: "Pokemon",
+	hp: 50,
+	types: ["Grass"],
+
+	description: {
+		ja: "森や 草地に 多く 生息。 頭の 先に ５センチぐらいの 小さく 鋭い 毒針を持つ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "とつげき" },
+			damage: 20,
+			cost: ["Colorless"],
+			effect: {
+				ja: "このポケモンにも10ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558281,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [13],
+};
+
+export default card;

--- a/data-asia/SM/SM9/004.ts
+++ b/data-asia/SM/SM9/004.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "コクーン",
+	},
+
+	illustrator: "Yuka Morii",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Grass"],
+
+	description: {
+		ja: "自分では ほとんど 動けないが 危ないときは 硬くなって 身を守っているようだ。",
+	},
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "くさぶとん" },
+			effect: {
+				ja: "このポケモンに[草]エネルギーがついているなら、このポケモンが受けるワザのダメージは「-30」される。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "むしくい" },
+			damage: 20,
+			cost: ["Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558282,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ビードル",
+	},
+
+	retreat: 3,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [14],
+};
+
+export default card;

--- a/data-asia/SM/SM9/005.ts
+++ b/data-asia/SM/SM9/005.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "スピアー",
+	},
+
+	illustrator: "You Iribi",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Grass"],
+
+	description: {
+		ja: "両手と お尻にある ３本の 毒針で 相手を 刺して 刺して 刺しまくって 攻撃する。",
+	},
+
+	stage: "Stage2",
+
+	attacks: [
+		{
+			name: { ja: "みちづればり" },
+			cost: ["Grass"],
+			effect: {
+				ja: "このワザは、このポケモンにダメカンがのっているときにしか使えない。おたがいのバトルポケモンをきぜつさせる。",
+			},
+		},
+		{
+			name: { ja: "とつげき" },
+			damage: 90,
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンにも10ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558283,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "コクーン",
+	},
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Uncommon",
+	dexId: [15],
+};
+
+export default card;

--- a/data-asia/SM/SM9/006.ts
+++ b/data-asia/SM/SM9/006.ts
@@ -1,0 +1,52 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "パラス",
+	},
+
+	illustrator: "Naoyo Kimura",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Grass"],
+
+	description: {
+		ja: "湿気が 足りないのか 栄養が 足りないのか アローラの パラスの キノコは 育ちが いまいち。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ひっかく" },
+			damage: 10,
+			cost: ["Colorless"],
+		},
+		{
+			name: { ja: "きりさく" },
+			damage: 20,
+			cost: ["Grass", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558284,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [46],
+};
+
+export default card;

--- a/data-asia/SM/SM9/007.ts
+++ b/data-asia/SM/SM9/007.ts
@@ -1,0 +1,64 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "パラセクト",
+	},
+
+	illustrator: "Satoshi Shirai",
+	category: "Pokemon",
+	hp: 100,
+	types: ["Grass"],
+
+	description: {
+		ja: "ムシの 方は ほぼ 死んでいて 本体は 背中の キノコだ。 もげると もう 動かなくなる。",
+	},
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "パニックほうし" },
+			effect: {
+				ja: "このポケモンがいるかぎり、ポケモンチェックのたび、相手のこんらんのポケモンにダメカンを2個のせる。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ふしぎなこな" },
+			damage: 30,
+			cost: ["Grass", "Colorless"],
+			effect: {
+				ja: "コインを1回投げオモテなら、相手のバトルポケモンをこんらんにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558285,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "パラス",
+	},
+
+	retreat: 2,
+	regulationMark: "C",
+	rarity: "Uncommon",
+	dexId: [47],
+};
+
+export default card;

--- a/data-asia/SM/SM9/008.ts
+++ b/data-asia/SM/SM9/008.ts
@@ -1,0 +1,50 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "タマタマ",
+	},
+
+	illustrator: "Ken Sugimori",
+	category: "Pokemon",
+	hp: 50,
+	types: ["Grass"],
+
+	description: {
+		ja: "６匹で １匹。 なにかあって １匹 減っても 翌朝に なると 必ず ６匹に 戻っている。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "タネマシンガン" },
+			damage: "10×",
+			cost: ["Grass"],
+			effect: {
+				ja: "コインを4回投げ、オモテの数x10ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558286,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [102],
+};
+
+export default card;

--- a/data-asia/SM/SM9/009.ts
+++ b/data-asia/SM/SM9/009.ts
@@ -1,0 +1,57 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "カイロス",
+	},
+
+	illustrator: "Eri Yamaki",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Grass"],
+
+	description: {
+		ja: "クワガノンと 縄張りを 争う。 アローラでは なぜか ヘラクロスと 結構 仲が 良いらしい。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "はさんでしめる" },
+			damage: 30,
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "次の相手の番、このワザを受けたポケモンは、にげられない。",
+			},
+		},
+		{
+			name: { ja: "ギロチンハッグ" },
+			cost: ["Grass", "Colorless", "Colorless"],
+			effect: {
+				ja: "コインを2回投げ、すべてオモテなら、相手のバトルポケモンをきぜつさせる。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558287,
+			},
+		},
+	],
+
+	retreat: 3,
+	regulationMark: "C",
+	rarity: "Uncommon",
+	dexId: [127],
+};
+
+export default card;

--- a/data-asia/SM/SM9/010.ts
+++ b/data-asia/SM/SM9/010.ts
@@ -1,0 +1,55 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヒトカゲ",
+	},
+
+	illustrator: "Naoyo Kimura",
+	category: "Pokemon",
+	hp: 50,
+	types: ["Fire"],
+
+	description: {
+		ja: "尻尾の 炎は ヒトカゲの 生命力の 証。 元気だと さかんに 燃えさかる。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ひっかく" },
+			damage: 10,
+			cost: ["Fire"],
+		},
+		{
+			name: { ja: "しかえし" },
+			damage: "20×",
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンにのっているダメカンの数x20ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558288,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [4],
+};
+
+export default card;

--- a/data-asia/SM/SM9/011.ts
+++ b/data-asia/SM/SM9/011.ts
@@ -1,0 +1,50 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヒトカゲ",
+	},
+
+	illustrator: "Atsuko Nishida",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Fire"],
+
+	description: {
+		ja: "尻尾の 炎は ヒトカゲの 生命力の 証。 元気だと さかんに 燃えさかる。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ひのこ" },
+			damage: 30,
+			cost: ["Fire"],
+			effect: {
+				ja: "このポケモンについているエネルギーを、1個トラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558289,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [4],
+};
+
+export default card;

--- a/data-asia/SM/SM9/012.ts
+++ b/data-asia/SM/SM9/012.ts
@@ -1,0 +1,54 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "リザード",
+	},
+
+	illustrator: "Ayaka Yoshida",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Fire"],
+
+	description: {
+		ja: "尻尾を 振り回して 相手を なぎ倒し 鋭い ツメで ズタズタに ひきさいてしまう。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "ほのおのキバ" },
+			damage: 30,
+			cost: ["Fire", "Fire"],
+			effect: {
+				ja: "相手のバトルポケモンをやけどにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558290,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ヒトカゲ",
+	},
+
+	retreat: 2,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [5],
+};
+
+export default card;

--- a/data-asia/SM/SM9/013.ts
+++ b/data-asia/SM/SM9/013.ts
@@ -1,0 +1,64 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "リザードン",
+	},
+
+	illustrator: "Masakazu Fukuda",
+	category: "Pokemon",
+	hp: 150,
+	types: ["Fire"],
+
+	description: {
+		ja: "口から 灼熱の 炎を 吐き出すとき 尻尾の 先は より 赤く 激しく 燃え上がる。",
+	},
+
+	stage: "Stage2",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "たけるとうき" },
+			effect: {
+				ja: "自分の番に1回使える。このポケモンにダメカンを2個のせる。その後、自分の山札にある[炎]エネルギーを2枚まで、このポケモンにつける。そして山札を切る。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "れんぞくブレイズボール" },
+			damage: "30+",
+			cost: ["Fire", "Fire"],
+			effect: {
+				ja: "このポケモンについている[炎]エネルギーをすべてトラッシュし、その枚数x50ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 558291,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "リザード",
+	},
+
+	retreat: 2,
+	regulationMark: "C",
+	rarity: "Rare",
+	dexId: [6],
+};
+
+export default card;

--- a/data-asia/SM/SM9/014.ts
+++ b/data-asia/SM/SM9/014.ts
@@ -1,0 +1,49 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ロコン",
+	},
+
+	illustrator: "Ken Sugimori",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Fire"],
+
+	description: {
+		ja: "美しい シッポで 大人気。 ただし まめに ブラッシングしないと あっという間に 毛玉だらけになる。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "しっぽをふる" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "コインを1回投げオモテなら、次の相手の番、このワザを受けたポケモンは、ワザが使えない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558292,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [37],
+};
+
+export default card;

--- a/data-asia/SM/SM9/015.ts
+++ b/data-asia/SM/SM9/015.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "キュウコン",
+	},
+
+	illustrator: "You Iribi",
+	category: "Pokemon",
+	hp: 100,
+	types: ["Fire"],
+
+	description: {
+		ja: "しつこく 執念深い 性質。 １度 恨むと 子孫を 含め １０００年間 祟り続ける。",
+	},
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "きゅうびのいざない" },
+			effect: {
+				ja: "自分の番に1回使える。自分の手札にある[炎]エネルギーを、2枚トラッシュする。その後、相手のベンチポケモンを1匹選び、バトルポケモンと入れ替える。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ほのおのしっぽ" },
+			damage: 90,
+			cost: ["Fire", "Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558293,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ロコン",
+	},
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Uncommon",
+	dexId: [38],
+};
+
+export default card;

--- a/data-asia/SM/SM9/016.ts
+++ b/data-asia/SM/SM9/016.ts
@@ -1,0 +1,55 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ポニータ",
+	},
+
+	illustrator: "Saya Tsuruta",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Fire"],
+
+	description: {
+		ja: "生まれたばかりでは 立つのがやっと。 だが 走るほどに 足腰は 鍛えられて 速度が 増していく。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ひだね" },
+			damage: 10,
+			cost: ["Fire"],
+		},
+		{
+			name: { ja: "ふみつけ" },
+			damage: "10+",
+			cost: ["Fire", "Fire"],
+			effect: {
+				ja: "コインを1回投げオモテなら、30ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558294,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [77],
+};
+
+export default card;

--- a/data-asia/SM/SM9/017.ts
+++ b/data-asia/SM/SM9/017.ts
@@ -1,0 +1,62 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ギャロップ",
+	},
+
+	illustrator: "Shigenori Negishi",
+	category: "Pokemon",
+	hp: 100,
+	types: ["Fire"],
+
+	description: {
+		ja: "速く 動く 物体を 見ると 競争したくなり 猛烈な スピードで 追いかけはじめる。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "やきこがす" },
+			damage: 20,
+			cost: ["Fire"],
+			effect: {
+				ja: "相手のバトルポケモンをやけどにする。",
+			},
+		},
+		{
+			name: { ja: "こうそくいどう" },
+			damage: 60,
+			cost: ["Fire", "Fire"],
+			effect: {
+				ja: "コインを1回投げオモテなら、次の相手の番、このポケモンはワザのダメージや効果を受けない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558295,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ポニータ",
+	},
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [78],
+};
+
+export default card;

--- a/data-asia/SM/SM9/018.ts
+++ b/data-asia/SM/SM9/018.ts
@@ -1,0 +1,57 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ファイヤー",
+	},
+
+	illustrator: "Shin Nagasawa",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Fire"],
+
+	description: {
+		ja: "昔から 火の鳥伝説として 知られる。 羽ばたくたびに 羽が 明るく 燃え上がり 美しい。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "やまやき" },
+			cost: ["Fire"],
+			effect: {
+				ja: "このポケモンについている[炎]エネルギーをすべてトラッシュし、そのエネルギーの数ぶん、相手の山札をトラッシュする。",
+			},
+		},
+		{
+			name: { ja: "ほのおのうず" },
+			damage: 180,
+			cost: ["Fire", "Fire", "Fire", "Colorless"],
+			effect: {
+				ja: "このポケモンについているエネルギーを、3個トラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 558296,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "C",
+	rarity: "Rare",
+	dexId: [146],
+};
+
+export default card;

--- a/data-asia/SM/SM9/019.ts
+++ b/data-asia/SM/SM9/019.ts
@@ -1,0 +1,53 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "コイキング&ホエルオーGX",
+	},
+
+	illustrator: "Mitsuhiro Arita",
+	category: "Pokemon",
+	hp: 300,
+	types: ["Water"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "スーパースプラッシュ" },
+			damage: 180,
+			cost: ["Water", "Water", "Water", "Water", "Water"],
+		},
+		{
+			name: { ja: "キングザブーンGX" },
+			damage: 10,
+			cost: ["Water"],
+			effect: {
+				ja: "追加で[水]エネルギーが7個ついているなら、相手のベンチポケモン全員にも、それぞれ100ダメージ。［ベンチは弱点・抵抗力を計算しない。］［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 558297,
+			},
+		},
+	],
+
+	retreat: 4,
+	regulationMark: "C",
+	rarity: "Double rare",
+	dexId: [129, 321],
+
+	suffix: "TAG TEAM-GX",
+};
+
+export default card;

--- a/data-asia/SM/SM9/020.ts
+++ b/data-asia/SM/SM9/020.ts
@@ -1,0 +1,57 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ゼニガメ",
+	},
+
+	illustrator: "sui",
+	category: "Pokemon",
+	hp: 50,
+	types: ["Water"],
+
+	description: {
+		ja: "甲羅に 閉じこもり 身を 守る。 相手の すきを 見逃さず 水を 噴き出して 反撃する。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "こうらフロート" },
+			effect: {
+				ja: "場に自分のスタジアムが出ているなら、このポケモンのにげるためのエネルギーは、すべてなくなる。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "みずでっぽう" },
+			damage: 30,
+			cost: ["Water", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558298,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [7],
+};
+
+export default card;

--- a/data-asia/SM/SM9/021.ts
+++ b/data-asia/SM/SM9/021.ts
@@ -1,0 +1,52 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ゼニガメ",
+	},
+
+	illustrator: "HYOGONOSUKE",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Water"],
+
+	description: {
+		ja: "甲羅に 閉じこもり 身を 守る。 相手の すきを 見逃さず 水を 噴き出して 反撃する。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "たいあたり" },
+			damage: 10,
+			cost: ["Colorless"],
+		},
+		{
+			name: { ja: "みずかけ" },
+			damage: 20,
+			cost: ["Water", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558299,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [7],
+};
+
+export default card;

--- a/data-asia/SM/SM9/022.ts
+++ b/data-asia/SM/SM9/022.ts
@@ -1,0 +1,56 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "カメール",
+	},
+
+	illustrator: "Misa Tsutsui",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Water"],
+
+	description: {
+		ja: "ポカンと 頭を たたかれるとき 甲羅に 引っこんで 避ける。 でも ちょっとだけ 尻尾が 出ているよ。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "たいあたり" },
+			damage: 30,
+			cost: ["Colorless", "Colorless"],
+		},
+		{
+			name: { ja: "たきのぼり" },
+			damage: 70,
+			cost: ["Water", "Water", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558300,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ゼニガメ",
+	},
+
+	retreat: 2,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [8],
+};
+
+export default card;

--- a/data-asia/SM/SM9/023.ts
+++ b/data-asia/SM/SM9/023.ts
@@ -1,0 +1,64 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "カメックス",
+	},
+
+	illustrator: "Hitoshi Ariga",
+	category: "Pokemon",
+	hp: 160,
+	types: ["Water"],
+
+	description: {
+		ja: "体が 重たく のしかかって 相手を 気絶させる。 ピンチのときは 殻に 隠れる。",
+	},
+
+	stage: "Stage2",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "パワースコール" },
+			effect: {
+				ja: "自分の番に1回使える。自分の山札を上から6枚見て、その中にある[水]エネルギーを好きなだけ、自分のポケモンに好きなようにつける。残りのカードは山札にもどして切る。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ハイドロタックル" },
+			damage: 150,
+			cost: ["Water", "Water", "Water"],
+			effect: {
+				ja: "このポケモンにも30ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 558301,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "カメール",
+	},
+
+	retreat: 3,
+	regulationMark: "C",
+	rarity: "Rare",
+	dexId: [9],
+};
+
+export default card;

--- a/data-asia/SM/SM9/024.ts
+++ b/data-asia/SM/SM9/024.ts
@@ -1,0 +1,50 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "コダック",
+	},
+
+	illustrator: "Kouki Saitou",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Water"],
+
+	description: {
+		ja: "念力を 使うと 頭痛が するので 普段は なるべく 何も しないで ボーっと 過ごしているよ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ずつう" },
+			damage: 10,
+			cost: ["Colorless"],
+			effect: {
+				ja: "コインを1回投げオモテなら、次の相手の番、相手は手札からトレーナーズを出して使えない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558302,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [54],
+};
+
+export default card;

--- a/data-asia/SM/SM9/025.ts
+++ b/data-asia/SM/SM9/025.ts
@@ -1,0 +1,62 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ゴルダック",
+	},
+
+	illustrator: "Masakazu Fukuda",
+	category: "Pokemon",
+	hp: 110,
+	types: ["Water"],
+
+	description: {
+		ja: "泳ぎが 速い さかなポケモンでも 金縛りで 動きを 止めて 簡単に 捕まえることが できる。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "ドわすれ" },
+			damage: 20,
+			cost: ["Water"],
+			effect: {
+				ja: "相手のバトルポケモンが持っているワザを1つ選ぶ。次の相手の番、このワザを受けたポケモンは、選ばれたワザを使えない。",
+			},
+		},
+		{
+			name: { ja: "およぐ" },
+			damage: 90,
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手の場のポケモンに[水]エネルギーがついている場合、のぞむなら、このワザのダメージを、相手のバトルポケモンではなくベンチポケモン1匹に与える。［ベンチは弱点・抵抗力を計算しない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558303,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "コダック",
+	},
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [55],
+};
+
+export default card;

--- a/data-asia/SM/SM9/026.ts
+++ b/data-asia/SM/SM9/026.ts
@@ -1,0 +1,50 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヒトデマン",
+	},
+
+	illustrator: "Ken Sugimori",
+	category: "Pokemon",
+	hp: 50,
+	types: ["Water"],
+
+	description: {
+		ja: "星屑が 海に 落ちて ヒトデマンに なったのだ という 民話が 各地に 残っている。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "しびれみず" },
+			damage: 10,
+			cost: ["Colorless"],
+			effect: {
+				ja: "コインを1回投げオモテなら、相手のバトルポケモンをマヒにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558304,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [120],
+};
+
+export default card;

--- a/data-asia/SM/SM9/027.ts
+++ b/data-asia/SM/SM9/027.ts
@@ -1,0 +1,49 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "コイキング",
+	},
+
+	illustrator: "sui",
+	category: "Pokemon",
+	hp: 30,
+	types: ["Water"],
+
+	description: {
+		ja: "遥か 大昔は それなりに 強かったが 時が 経つに つれて どんどんどんどん 弱くなっていった。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "とうりゅうもん" },
+			cost: ["Water"],
+			effect: {
+				ja: "コインを1回投げオモテなら、このポケモンから進化するカードを、自分のトラッシュから1枚選び、このポケモンにのせて進化させる。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558305,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [129],
+};
+
+export default card;

--- a/data-asia/SM/SM9/028.ts
+++ b/data-asia/SM/SM9/028.ts
@@ -1,0 +1,62 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ギャラドス",
+	},
+
+	illustrator: "Hasuno",
+	category: "Pokemon",
+	hp: 150,
+	types: ["Water"],
+
+	description: {
+		ja: "破壊光線を はきまくり あたり 一面を 焼き尽くす。 破壊の神と 呼ぶ 地方もある。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "だいぎんじょう" },
+			damage: "30+",
+			cost: ["Water"],
+			effect: {
+				ja: "自分の山札を上から7枚オモテにする。その中にある[水]エネルギーの数x30ダメージ追加し、その[水]エネルギーを山札にもどして切る。残りのカードはトラッシュする。",
+			},
+		},
+		{
+			name: { ja: "はかいこうせん" },
+			damage: 100,
+			cost: ["Water", "Water", "Water"],
+			effect: {
+				ja: "相手のバトルポケモンについているエネルギーを、1個トラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 558306,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "コイキング",
+	},
+
+	retreat: 4,
+	regulationMark: "C",
+	rarity: "Rare",
+	dexId: [130],
+};
+
+export default card;

--- a/data-asia/SM/SM9/029.ts
+++ b/data-asia/SM/SM9/029.ts
@@ -1,0 +1,57 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ラプラス",
+	},
+
+	illustrator: "Ken Sugimori",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Water"],
+
+	description: {
+		ja: "人を 乗せて 泳ぐのが 好き。 アローラ地方 では 大切な 水上の 交通 手段。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "あやしいひかり" },
+			cost: ["Water"],
+			effect: {
+				ja: "相手のバトルポケモンをこんらんにする。",
+			},
+		},
+		{
+			name: { ja: "ハイドロポンプ" },
+			damage: "10+",
+			cost: ["Colorless"],
+			effect: {
+				ja: "このポケモンについている[水]エネルギーの数x30ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558307,
+			},
+		},
+	],
+
+	retreat: 3,
+	regulationMark: "C",
+	rarity: "Uncommon",
+	dexId: [131],
+};
+
+export default card;

--- a/data-asia/SM/SM9/030.ts
+++ b/data-asia/SM/SM9/030.ts
@@ -1,0 +1,60 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "フリーザー",
+	},
+
+	illustrator: "Yusuke Ohmura",
+	category: "Pokemon",
+	hp: 110,
+	types: ["Water"],
+
+	description: {
+		ja: "伝説の とりポケモン。 空気中の 水分を 凍らせ 吹雪を 作り出すことが できる。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ブリザードヴェール" },
+			effect: {
+				ja: "このポケモンがバトル場にいるかぎり、自分のベンチの[水]ポケモン全員は、相手が手札からサポートを出して使ったとき、その効果を受けない。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "コールドサイクロン" },
+			damage: 70,
+			cost: ["Water", "Water"],
+			effect: {
+				ja: "このポケモンについている[水]エネルギーを2個、ベンチポケモン1匹につけ替える。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 558308,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "C",
+	rarity: "Rare",
+	dexId: [144],
+};
+
+export default card;

--- a/data-asia/SM/SM9/031.ts
+++ b/data-asia/SM/SM9/031.ts
@@ -1,0 +1,56 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ピカチュウ&ゼクロムGX",
+	},
+
+	illustrator: "Mitsuhiro Arita",
+	category: "Pokemon",
+	hp: 240,
+	types: ["Lightning"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "フルドライブ" },
+			damage: 150,
+			cost: ["Lightning", "Lightning", "Lightning"],
+			effect: {
+				ja: "自分の山札にある[雷]エネルギーを3枚まで、自分のポケモン1匹につける。そして山札を切る。",
+			},
+		},
+		{
+			name: { ja: "タッグボルトGX" },
+			damage: 200,
+			cost: ["Lightning", "Lightning", "Lightning"],
+			effect: {
+				ja: "追加で[雷]エネルギーが3個ついているなら、相手のベンチポケモン1匹にも、170ダメージ。［ベンチは弱点・抵抗力を計算しない。］［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Metal", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 558309,
+			},
+		},
+	],
+
+	retreat: 3,
+	regulationMark: "C",
+	rarity: "Double rare",
+	dexId: [25, 644],
+
+	suffix: "TAG TEAM-GX",
+};
+
+export default card;

--- a/data-asia/SM/SM9/032.ts
+++ b/data-asia/SM/SM9/032.ts
@@ -1,0 +1,50 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アローライシツブテ",
+	},
+
+	illustrator: "Yukiko Baba",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Lightning"],
+
+	description: {
+		ja: "石ころと 間違え 踏んでしまうと 怒って 頭突きを かましてくる。 痛いだけでなく ビリッと くるぞ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "じばく" },
+			damage: 60,
+			cost: ["Lightning", "Colorless"],
+			effect: {
+				ja: "このポケモンにも60ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Metal", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558310,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [74],
+};
+
+export default card;

--- a/data-asia/SM/SM9/033.ts
+++ b/data-asia/SM/SM9/033.ts
@@ -1,0 +1,57 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アローライシツブテ",
+	},
+
+	illustrator: "Yuka Morii",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Lightning"],
+
+	description: {
+		ja: "石ころと 間違え 踏んでしまうと 怒って 頭突きを かましてくる。 痛いだけでなく ビリッと くるぞ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "じゅうでん" },
+			cost: [],
+			effect: {
+				ja: "自分の山札にある[雷]エネルギーを2枚まで、このポケモンにつける。そして山札を切る。",
+			},
+		},
+		{
+			name: { ja: "スマッシュボンバー" },
+			damage: 50,
+			cost: ["Lightning", "Colorless", "Colorless"],
+			effect: {
+				ja: "コインを1回投げウラなら、このワザは失敗。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Metal", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558311,
+			},
+		},
+	],
+
+	retreat: 3,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [74],
+};
+
+export default card;

--- a/data-asia/SM/SM9/034.ts
+++ b/data-asia/SM/SM9/034.ts
@@ -1,0 +1,56 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アローラゴローン",
+	},
+
+	illustrator: "Misa Tsutsui",
+	category: "Pokemon",
+	hp: 100,
+	types: ["Lightning"],
+
+	description: {
+		ja: "ゴローン同士 争うと あたりに 光と 爆音がする。 地元の 人は 陸花火と 呼んでいる。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "ころがる" },
+			damage: 30,
+			cost: [],
+		},
+		{
+			name: { ja: "エレキスラッグ" },
+			damage: 100,
+			cost: ["Lightning", "Colorless", "Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Metal", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558312,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "アローライシツブテ",
+	},
+
+	retreat: 4,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [75],
+};
+
+export default card;

--- a/data-asia/SM/SM9/035.ts
+++ b/data-asia/SM/SM9/035.ts
@@ -1,0 +1,62 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アローラゴローニャ",
+	},
+
+	illustrator: "kawayoo",
+	category: "Pokemon",
+	hp: 180,
+	types: ["Lightning"],
+
+	description: {
+		ja: "気難しくて 頑固。 機嫌を 損ねると 全身から 放電し 雷鳴の ような 声で ほえる。",
+	},
+
+	stage: "Stage2",
+
+	attacks: [
+		{
+			name: { ja: "マグネボンバー" },
+			damage: "20×",
+			cost: [],
+			effect: {
+				ja: "自分のベンチポケモンについている[雷]エネルギーを好きなだけ、このポケモンにつけ替え、その枚数x20ダメージ。",
+			},
+		},
+		{
+			name: { ja: "ちょうでんじほう" },
+			damage: 190,
+			cost: ["Lightning", "Colorless", "Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンについているエネルギーを、2個トラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Metal", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558313,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "アローラゴローン",
+	},
+
+	retreat: 4,
+	regulationMark: "C",
+	rarity: "Uncommon",
+	dexId: [76],
+};
+
+export default card;

--- a/data-asia/SM/SM9/036.ts
+++ b/data-asia/SM/SM9/036.ts
@@ -1,0 +1,47 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ビリリダマ",
+	},
+
+	illustrator: "Ken Sugimori",
+	category: "Pokemon",
+	hp: 50,
+	types: ["Lightning"],
+
+	description: {
+		ja: "モンスターボールが 売り出されたのと 同じ 時期に 発見された。 なにか 関係があると いわれる。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "たいあたり" },
+			damage: 20,
+			cost: ["Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Metal", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558314,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [100],
+};
+
+export default card;

--- a/data-asia/SM/SM9/037.ts
+++ b/data-asia/SM/SM9/037.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "マルマイン",
+	},
+
+	illustrator: "Asako Ito",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Lightning"],
+
+	description: {
+		ja: "少しの 刺激に 反応して 爆発する。 バクダンボールという あだ名で 怖がられている。",
+	},
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "エレキシェイカー" },
+			effect: {
+				ja: "自分の番に、このカードを手札から出して進化させたとき、1回使える。自分の場のポケモンについている[雷]エネルギーを好きなだけ選び、自分のポケモンに好きなようにつけ替える。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "スピードボール" },
+			damage: 50,
+			cost: ["Lightning", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Metal", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 558315,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ビリリダマ",
+	},
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Rare",
+	dexId: [101],
+};
+
+export default card;

--- a/data-asia/SM/SM9/038.ts
+++ b/data-asia/SM/SM9/038.ts
@@ -1,0 +1,55 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ゲンガー&ミミッキュGX",
+	},
+
+	illustrator: "Mitsuhiro Arita",
+	category: "Pokemon",
+	hp: 240,
+	types: ["Psychic"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ポルターガイスト" },
+			damage: "50×",
+			cost: ["Psychic", "Psychic"],
+			effect: {
+				ja: "相手の手札を見て、その中にあるトレーナーズの枚数x50ダメージ。",
+			},
+		},
+		{
+			name: { ja: "ホラーハウスGX" },
+			cost: ["Psychic"],
+			effect: {
+				ja: "次の相手の番、相手は手札からカードを出して使えない。追加で[超]エネルギーが1個ついているなら、おたがいのプレイヤーは、それぞれの手札が7枚になるように、山札を引く。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 558329,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "C",
+	rarity: "Double rare",
+	dexId: [94, 778],
+
+	suffix: "TAG TEAM-GX",
+};
+
+export default card;

--- a/data-asia/SM/SM9/039.ts
+++ b/data-asia/SM/SM9/039.ts
@@ -1,0 +1,54 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ニドラン♀",
+	},
+
+	illustrator: "miki kudo",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Psychic"],
+
+	description: {
+		ja: "体は 小さくても 毒針を 持つため 注意が 必要だ。 メスのほうが ツノが 小さい。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "なかまをよぶ" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札にあるたねポケモンを1枚、ベンチに出す。そして山札を切る。",
+			},
+		},
+		{
+			name: { ja: "ひっかく" },
+			damage: 20,
+			cost: ["Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558331,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [29],
+};
+
+export default card;

--- a/data-asia/SM/SM9/040.ts
+++ b/data-asia/SM/SM9/040.ts
@@ -1,0 +1,58 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ニドリーナ",
+	},
+
+	illustrator: "Kagemaru Himeno",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Psychic"],
+
+	description: {
+		ja: "メスなので 性格は 温厚。 口から 出す 超音波は 相手を まどわす 力がある。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "ファミリーレスキュー" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分のトラッシュにある[超]ポケモンを5枚、相手に見せてから、山札にもどして切る。",
+			},
+		},
+		{
+			name: { ja: "かみつく" },
+			damage: 30,
+			cost: ["Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558334,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ニドラン♀",
+	},
+
+	retreat: 2,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [30],
+};
+
+export default card;

--- a/data-asia/SM/SM9/041.ts
+++ b/data-asia/SM/SM9/041.ts
@@ -1,0 +1,64 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ニドクイン",
+	},
+
+	illustrator: "nagimiso",
+	category: "Pokemon",
+	hp: 160,
+	types: ["Psychic"],
+
+	description: {
+		ja: "ウロコで 覆われた 頑丈な 体で 巣穴の 入り口を ふさぎ 敵から 子供たちを 守る。",
+	},
+
+	stage: "Stage2",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "マザーコール" },
+			effect: {
+				ja: "自分の番に1回使える。自分の山札にあるポケモン（「ポケモンGX・EX」をのぞく）を1枚、相手に見せてから、手札に加える。そして山札を切る。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "パワーラリアット" },
+			damage: "10+",
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "自分のベンチの進化ポケモンの数x50ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558340,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ニドリーナ",
+	},
+
+	retreat: 3,
+	regulationMark: "C",
+	rarity: "Uncommon",
+	dexId: [31],
+};
+
+export default card;

--- a/data-asia/SM/SM9/042.ts
+++ b/data-asia/SM/SM9/042.ts
@@ -1,0 +1,52 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ニドラン♂",
+	},
+
+	illustrator: "Naoyo Kimura",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Psychic"],
+
+	description: {
+		ja: "草むらの 上に 耳だけ 出して まわりの 気配を 探る。 猛毒の ツノで 身を 守る。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "つつく" },
+			damage: 10,
+			cost: ["Colorless"],
+		},
+		{
+			name: { ja: "つのでつく" },
+			damage: 20,
+			cost: ["Psychic", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558342,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [32],
+};
+
+export default card;

--- a/data-asia/SM/SM9/043.ts
+++ b/data-asia/SM/SM9/043.ts
@@ -1,0 +1,56 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ニドリーノ",
+	},
+
+	illustrator: "Kouki Saitou",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Psychic"],
+
+	description: {
+		ja: "発達した 耳を 立てて まわりの 気配を 探る。 なにかあると すぐに 飛びかかる。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "つつく" },
+			damage: 20,
+			cost: ["Colorless"],
+		},
+		{
+			name: { ja: "つのドリル" },
+			damage: 60,
+			cost: ["Psychic", "Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558345,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ニドラン♂",
+	},
+
+	retreat: 2,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [33],
+};
+
+export default card;

--- a/data-asia/SM/SM9/044.ts
+++ b/data-asia/SM/SM9/044.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ニドキング",
+	},
+
+	illustrator: "kawayoo",
+	category: "Pokemon",
+	hp: 160,
+	types: ["Psychic"],
+
+	description: {
+		ja: "石のように 硬い 皮膚と 長く 伸びた ツノが 特徴。 ツノには 毒も あるので 注意。",
+	},
+
+	stage: "Stage2",
+
+	attacks: [
+		{
+			name: { ja: "ひきずりだす" },
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "相手のベンチポケモンを1匹選び、バトルポケモンと入れ替える。その後、新しく出てきたポケモンに50ダメージ。",
+			},
+		},
+		{
+			name: { ja: "キングドラム" },
+			damage: "100+",
+			cost: ["Psychic", "Colorless", "Colorless"],
+			effect: {
+				ja: "自分のベンチに「ニドクイン」がいるなら、100ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558346,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ニドリーノ",
+	},
+
+	retreat: 3,
+	regulationMark: "C",
+	rarity: "Uncommon",
+	dexId: [34],
+};
+
+export default card;

--- a/data-asia/SM/SM9/045.ts
+++ b/data-asia/SM/SM9/045.ts
@@ -1,0 +1,50 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "メノクラゲ",
+	},
+
+	illustrator: "Ken Sugimori",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Psychic"],
+
+	description: {
+		ja: "海辺を 漂い 獲物を 探す。 毒の 触手は ちぎれることも あるが 時間が 経てば 生えてくる。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "まきつく" },
+			damage: 10,
+			cost: ["Colorless"],
+			effect: {
+				ja: "コインを1回投げオモテなら、相手のバトルポケモンをマヒにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558350,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [72],
+};
+
+export default card;

--- a/data-asia/SM/SM9/046.ts
+++ b/data-asia/SM/SM9/046.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ドククラゲ",
+	},
+
+	illustrator: "kodama",
+	category: "Pokemon",
+	hp: 100,
+	types: ["Psychic"],
+
+	description: {
+		ja: "赤い 玉から 超音波を 発生させ 獲物を 弱らせると ８０本の 触手を 巻きつける。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "うつろなしょくしゅ" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをどくとこんらんにする。",
+			},
+		},
+		{
+			name: { ja: "パラノーマル" },
+			damage: 70,
+			cost: ["Psychic", "Colorless", "Colorless"],
+			effect: {
+				ja: "次の相手の番、このポケモンは「ウルトラビースト」からワザのダメージを受けない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558351,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "メノクラゲ",
+	},
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [73],
+};
+
+export default card;

--- a/data-asia/SM/SM9/047.ts
+++ b/data-asia/SM/SM9/047.ts
@@ -1,0 +1,47 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ベトベター",
+	},
+
+	illustrator: "Ken Sugimori",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Psychic"],
+
+	description: {
+		ja: "海底の ヘドロから 生まれた。 清潔な 場所では 体内の ばい菌が 増やせず 死んでしまう。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "はたく" },
+			damage: 10,
+			cost: ["Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558352,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [88],
+};
+
+export default card;

--- a/data-asia/SM/SM9/048.ts
+++ b/data-asia/SM/SM9/048.ts
@@ -1,0 +1,64 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ベトベトン",
+	},
+
+	illustrator: "Anesaki Dynamic",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Psychic"],
+
+	description: {
+		ja: "エサが 減って 数も 激減。 絶滅を 防ぐため 人工の ヘドロ池が 作られ始めた。",
+	},
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "どくぶくろ" },
+			effect: {
+				ja: "このポケモンがいるかぎり、相手のどくのポケモンは、進化・退化してもどくが回復しない。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "どくどくえき" },
+			damage: 40,
+			cost: ["Psychic"],
+			effect: {
+				ja: "相手のバトルポケモンをどくにする。このどくでのせるダメカンの数は2個になる。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558354,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ベトベター",
+	},
+
+	retreat: 4,
+	regulationMark: "C",
+	rarity: "Uncommon",
+	dexId: [89],
+};
+
+export default card;

--- a/data-asia/SM/SM9/049.ts
+++ b/data-asia/SM/SM9/049.ts
@@ -1,0 +1,54 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "スターミー",
+	},
+
+	illustrator: "Mizue",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Psychic"],
+
+	description: {
+		ja: "輝く コアは 海の 宝石と 呼ばれる。 高価な アクセサリーに 変えられ 隠れて 取引される。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "ストレンジウェーブ" },
+			damage: 40,
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札にある[水]または[超]エネルギーを3枚まで、自分のベンチポケモン1匹につける。そして山札を切る。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558356,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ヒトデマン",
+	},
+
+	retreat: 0,
+	regulationMark: "C",
+	rarity: "Uncommon",
+	dexId: [121],
+};
+
+export default card;

--- a/data-asia/SM/SM9/050.ts
+++ b/data-asia/SM/SM9/050.ts
@@ -1,0 +1,60 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "バリヤード",
+	},
+
+	illustrator: "Atsuko Nishida",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Psychic"],
+
+	description: {
+		ja: "素晴らしい パントマイムの 腕前。 見とれている 間に いつの間にか 本当に 壁が できているのだ。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "かいしゅうふうじ" },
+			effect: {
+				ja: "このポケモンがいるかぎり、ダメカンがのっている相手のポケモンと、そのポケモンについているすべてのカードは、手札にもどせない。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ねんりき" },
+			damage: 20,
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "コインを1回投げオモテなら、相手のバトルポケモンをマヒにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558358,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Uncommon",
+	dexId: [122],
+};
+
+export default card;

--- a/data-asia/SM/SM9/051.ts
+++ b/data-asia/SM/SM9/051.ts
@@ -1,0 +1,56 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ルージュラ",
+	},
+
+	illustrator: "HYOGONOSUKE",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Psychic"],
+
+	description: {
+		ja: "独特の リズムで 腰を 振る。 アローラに 棲む ルージュラは そのキレが 実に 素晴らしい。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "げんわくダンス" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをこんらんにする。",
+			},
+		},
+		{
+			name: { ja: "なぞのダンス" },
+			cost: ["Psychic", "Colorless"],
+			effect: {
+				ja: "相手のベンチポケモンの数ぶんのダメカンを、相手のポケモンに好きなようにのせる。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558360,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [124],
+};
+
+export default card;

--- a/data-asia/SM/SM9/052.ts
+++ b/data-asia/SM/SM9/052.ts
@@ -1,0 +1,54 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "マンキー",
+	},
+
+	illustrator: "Akira Komayama",
+	category: "Pokemon",
+	hp: 50,
+	types: ["Fighting"],
+
+	description: {
+		ja: "ちょっとしたことで すぐ 怒る。 ストレスを ため込まないので かなり 長生きする ポケモンだ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "さぐる" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "相手の手札を見る。",
+			},
+		},
+		{
+			name: { ja: "けたぐり" },
+			damage: 30,
+			cost: ["Fighting", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558378,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [56],
+};
+
+export default card;

--- a/data-asia/SM/SM9/053.ts
+++ b/data-asia/SM/SM9/053.ts
@@ -1,0 +1,59 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "オコリザル",
+	},
+
+	illustrator: "Anesaki Dynamic",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Fighting"],
+
+	description: {
+		ja: "怒らせた 相手を 許さず 追い続ける。 叩きのめして 動かなくなっても まだ 許さない。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "けたぐり" },
+			damage: 30,
+			cost: ["Fighting"],
+		},
+		{
+			name: { ja: "ぶちこわす" },
+			damage: "80+",
+			cost: ["Fighting", "Colorless", "Colorless"],
+			effect: {
+				ja: "場にスタジアムが出ているなら、80ダメージ追加。その後、そのスタジアムをトラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558379,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "マンキー",
+	},
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Uncommon",
+	dexId: [57],
+};
+
+export default card;

--- a/data-asia/SM/SM9/054.ts
+++ b/data-asia/SM/SM9/054.ts
@@ -1,0 +1,54 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "サワムラー",
+	},
+
+	illustrator: "Tomokazu Komiya",
+	category: "Pokemon",
+	hp: 100,
+	types: ["Fighting"],
+
+	description: {
+		ja: "脚が 自由に 伸び縮みして 遠く 離れている 場合でも 相手を 蹴り上げることができる。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "スペシャルコンボ" },
+			cost: ["Fighting"],
+			effect: {
+				ja: "このワザは、前の自分の番に「エビワラー」が「ヒット&アウェー」を使っていなければ使えない。相手のベンチポケモン1匹に、90ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+			},
+		},
+		{
+			name: { ja: "メガトンキック" },
+			damage: 90,
+			cost: ["Fighting", "Fighting", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558380,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [106],
+};
+
+export default card;

--- a/data-asia/SM/SM9/055.ts
+++ b/data-asia/SM/SM9/055.ts
@@ -1,0 +1,55 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "エビワラー",
+	},
+
+	illustrator: "Tomokazu Komiya",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Fighting"],
+
+	description: {
+		ja: "腕を ねじりながら 繰り出す パンチは コンクリートも 粉砕。 ３分 戦うと ひとやすみする。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ヒット&amp;アウェー" },
+			damage: 30,
+			cost: ["Fighting"],
+			effect: {
+				ja: "のぞむなら、このポケモンをベンチポケモンと入れ替える。",
+			},
+		},
+		{
+			name: { ja: "マグナムパンチ" },
+			damage: 70,
+			cost: ["Fighting", "Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558381,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [107],
+};
+
+export default card;

--- a/data-asia/SM/SM9/056.ts
+++ b/data-asia/SM/SM9/056.ts
@@ -1,0 +1,50 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "オムナイト",
+	},
+
+	illustrator: "Midori Harada",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Fighting"],
+
+	description: {
+		ja: "古代の海に 生きていた ポケモン。 アーケオスの エサだったようで 歯型のついた 化石が 見つかる。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "くすぐる" },
+			damage: 30,
+			cost: ["Colorless"],
+			effect: {
+				ja: "コインを1回投げオモテなら、相手のバトルポケモンをマヒにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558382,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Uncommon",
+	dexId: [138],
+};
+
+export default card;

--- a/data-asia/SM/SM9/057.ts
+++ b/data-asia/SM/SM9/057.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "オムスター",
+	},
+
+	illustrator: "kirisAki",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Fighting"],
+
+	description: {
+		ja: "重いカラが 原因で 滅んだと 考えられている 古代ポケモン。 オクタンの 遠い 祖先 らしい。",
+	},
+
+	stage: "Stage2",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "かせきのしがらみ" },
+			effect: {
+				ja: "このポケモンがいるかぎり、自分の場のポケモンの数が、相手より少ないなら、相手は手札からグッズを出して使えない。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "かみつく" },
+			damage: 60,
+			cost: ["Fighting", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 558383,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "オムナイト",
+	},
+
+	retreat: 2,
+	regulationMark: "C",
+	rarity: "Rare",
+	dexId: [139],
+};
+
+export default card;

--- a/data-asia/SM/SM9/058.ts
+++ b/data-asia/SM/SM9/058.ts
@@ -1,0 +1,50 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "カブト",
+	},
+
+	illustrator: "sui",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Fighting"],
+
+	description: {
+		ja: "３億年前に 栄えた ポケモン。 とある 地方では 今でも まれに 生きた 姿が 見られると 言う。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "こうらでぶつかる" },
+			damage: 40,
+			cost: ["Fighting"],
+			effect: {
+				ja: "次の相手の番、このポケモンが受けるワザのダメージは「-20」される。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558384,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Uncommon",
+	dexId: [140],
+};
+
+export default card;

--- a/data-asia/SM/SM9/059.ts
+++ b/data-asia/SM/SM9/059.ts
@@ -1,0 +1,64 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "カブトプス",
+	},
+
+	illustrator: "Shin Nagasawa",
+	category: "Pokemon",
+	hp: 140,
+	types: ["Fighting"],
+
+	description: {
+		ja: "陸でも 活動 できるよう 身体が 変化を 始めていたが 間に合わず 絶滅 してしまった。",
+	},
+
+	stage: "Stage2",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "かせきのきおく" },
+			effect: {
+				ja: "このポケモンがバトル場にいるかぎり、相手は手札からサポートを出して使えない。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "いわなだれ" },
+			damage: 80,
+			cost: ["Fighting", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のベンチポケモン2匹にも、それぞれ20ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558385,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "カブト",
+	},
+
+	retreat: 2,
+	regulationMark: "C",
+	rarity: "Uncommon",
+	dexId: [141],
+};
+
+export default card;

--- a/data-asia/SM/SM9/060.ts
+++ b/data-asia/SM/SM9/060.ts
@@ -1,0 +1,55 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ラティアス&ラティオスGX",
+	},
+
+	illustrator: "Mitsuhiro Arita",
+	category: "Pokemon",
+	hp: 250,
+	types: ["Dragon"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "バスターパージ" },
+			damage: 240,
+			cost: ["Water", "Psychic", "Psychic", "Colorless"],
+			effect: {
+				ja: "このポケモンについているエネルギーを、3個トラッシュする。",
+			},
+		},
+		{
+			name: { ja: "エアロユニットGX" },
+			cost: ["Psychic"],
+			effect: {
+				ja: "自分のトラッシュにある基本エネルギーを5枚、自分のポケモンに好きなようにつける。追加でエネルギーが1個ついているなら、次の相手の番、このポケモンはワザのダメージや効果を受けない。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fairy", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 558386,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Double rare",
+	dexId: [380, 381],
+
+	suffix: "TAG TEAM-GX",
+};
+
+export default card;

--- a/data-asia/SM/SM9/061.ts
+++ b/data-asia/SM/SM9/061.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アローラナッシー",
+	},
+
+	illustrator: "Sanosuke Sakuma",
+	category: "Pokemon",
+	hp: 160,
+	types: ["Dragon"],
+
+	description: {
+		ja: "ナッシーは アローラ人の 誇り。 歴史的な 絵画や 建物に その 姿が 刻まれている。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "パラダイスドロー" },
+			cost: [],
+			effect: {
+				ja: "自分の手札が6枚になるように、山札を引く。のぞむなら、山札を引く前に、自分の手札を好きなだけトラッシュする。",
+			},
+		},
+		{
+			name: { ja: "たまおとし" },
+			damage: "60×",
+			cost: ["Grass", "Colorless"],
+			effect: {
+				ja: "自分の手札にある「タマタマ」を好きなだけトラッシュし、その枚数x60ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fairy", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558387,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "タマタマ",
+	},
+
+	retreat: 4,
+	regulationMark: "C",
+	rarity: "Uncommon",
+	dexId: [103],
+};
+
+export default card;

--- a/data-asia/SM/SM9/062.ts
+++ b/data-asia/SM/SM9/062.ts
@@ -1,0 +1,50 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ミニリュウ",
+	},
+
+	illustrator: "Midori Harada",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Dragon"],
+
+	description: {
+		ja: "まだ 弱いので 水底に 身を 潜め 沈んできた ものを 食らいながら ひそかに 暮らす。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "りゅうのいかり" },
+			damage: 60,
+			cost: ["Lightning"],
+			effect: {
+				ja: "コインを2回投げ、1回でもウラなら、このワザは失敗。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fairy", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558388,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [147],
+};
+
+export default card;

--- a/data-asia/SM/SM9/063.ts
+++ b/data-asia/SM/SM9/063.ts
@@ -1,0 +1,57 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ミニリュウ",
+	},
+
+	illustrator: "Kouki Saitou",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Dragon"],
+
+	description: {
+		ja: "まだ 弱いので 水底に 身を 潜め 沈んできた ものを 食らいながら ひそかに 暮らす。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "まもりのうろこ" },
+			effect: {
+				ja: "このポケモンは、相手のポケモンが使うワザの効果を受けない。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "みずかけ" },
+			damage: 10,
+			cost: ["Water"],
+		},
+	],
+
+	weaknesses: [{ type: "Fairy", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558389,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [147],
+};
+
+export default card;

--- a/data-asia/SM/SM9/064.ts
+++ b/data-asia/SM/SM9/064.ts
@@ -1,0 +1,54 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ハクリュー",
+	},
+
+	illustrator: "kirisAki",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Dragon"],
+
+	description: {
+		ja: "天候を 操ると 信じられ ハクリューの 棲む 湖には お供え物が 絶えない。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "たつまき" },
+			damage: 30,
+			cost: ["Water", "Lightning"],
+			effect: {
+				ja: "コインを2回投げ、オモテの数ぶん、相手のバトルポケモンについているエネルギーをトラッシュする。すべてウラなら、このワザは失敗。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fairy", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558390,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ミニリュウ",
+	},
+
+	retreat: 2,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [148],
+};
+
+export default card;

--- a/data-asia/SM/SM9/065.ts
+++ b/data-asia/SM/SM9/065.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "カイリュー",
+	},
+
+	illustrator: "Megumi Mizutani",
+	category: "Pokemon",
+	hp: 160,
+	types: ["Dragon"],
+
+	description: {
+		ja: "荒れ狂う 海も ものともせずに 飛んでいく。 その姿を 見かけた 船長は 海の化身と 呼んだ。",
+	},
+
+	stage: "Stage2",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ファーストコール" },
+			effect: {
+				ja: "自分の番に1回使える。自分の山札にあるサポートを1枚、相手に見せてから、手札に加える。そして山札を切る。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ドラゴンクロー" },
+			damage: 120,
+			cost: ["Water", "Lightning", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fairy", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 558391,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ハクリュー",
+	},
+
+	retreat: 3,
+	regulationMark: "C",
+	rarity: "Rare",
+	dexId: [149],
+};
+
+export default card;

--- a/data-asia/SM/SM9/066.ts
+++ b/data-asia/SM/SM9/066.ts
@@ -1,0 +1,63 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "イーブイ&カビゴンGX",
+	},
+
+	illustrator: "Mitsuhiro Arita",
+	category: "Pokemon",
+	hp: 270,
+	types: ["Colorless"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "おうえん" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の手札にあるエネルギーを1枚、自分のポケモンにつける。",
+			},
+		},
+		{
+			name: { ja: "ダンププレス" },
+			damage: "120+",
+			cost: ["Colorless", "Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンが進化ポケモンなら、120ダメージ追加。",
+			},
+		},
+		{
+			name: { ja: "メガトンフレンズGX" },
+			damage: 210,
+			cost: ["Colorless", "Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "追加でエネルギーが1個ついているなら、自分の手札が10枚になるように、山札を引く。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 558416,
+			},
+		},
+	],
+
+	retreat: 4,
+	regulationMark: "C",
+	rarity: "Double rare",
+	dexId: [133, 143],
+
+	suffix: "TAG TEAM-GX",
+};
+
+export default card;

--- a/data-asia/SM/SM9/067.ts
+++ b/data-asia/SM/SM9/067.ts
@@ -1,0 +1,54 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ポッポ",
+	},
+
+	illustrator: "Shigenori Negishi",
+	category: "Pokemon",
+	hp: 50,
+	types: ["Colorless"],
+
+	description: {
+		ja: "森や 林に 多く 分布。 地上でも 激しく はばたいて 砂を かけたりする。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "もってくる" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札を1枚引く。",
+			},
+		},
+		{
+			name: { ja: "かぜおこし" },
+			damage: 20,
+			cost: ["Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558418,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [16],
+};
+
+export default card;

--- a/data-asia/SM/SM9/068.ts
+++ b/data-asia/SM/SM9/068.ts
@@ -1,0 +1,50 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ポッポ",
+	},
+
+	illustrator: "Sumiyoshi Kizuki",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Colorless"],
+
+	description: {
+		ja: "森や 林に 多く 分布。 地上でも 激しく はばたいて 砂を かけたりする。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "でんこうせっか" },
+			damage: "10+",
+			cost: ["Colorless"],
+			effect: {
+				ja: "コインを1回投げオモテなら、10ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558419,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [16],
+};
+
+export default card;

--- a/data-asia/SM/SM9/069.ts
+++ b/data-asia/SM/SM9/069.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ピジョン",
+	},
+
+	illustrator: "Mizue",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Colorless"],
+
+	description: {
+		ja: "足の ツメが 発達している。 エサの タマタマを つかんで １００キロ先の 巣まで 運ぶ。",
+	},
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "エアメール" },
+			effect: {
+				ja: "自分の番に1回使える。自分の山札を上から2枚見て、どちらか1枚を手札に加える。残りのカードは、山札の下にもどす。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "かぜおこし" },
+			damage: 30,
+			cost: ["Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558421,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ポッポ",
+	},
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [17],
+};
+
+export default card;

--- a/data-asia/SM/SM9/070.ts
+++ b/data-asia/SM/SM9/070.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ピジョット",
+	},
+
+	illustrator: "Akira Komayama",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Colorless"],
+
+	description: {
+		ja: "エサを 探すとき 水面 すれすれを 滑るように 飛んで コイキングなどを わしづかみにする。",
+	},
+
+	stage: "Stage2",
+
+	attacks: [
+		{
+			name: { ja: "ふきとばし" },
+			damage: 60,
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをベンチポケモンと入れ替える。［バトル場に出すポケモンは相手が選ぶ。］",
+			},
+		},
+		{
+			name: { ja: "せんぷう" },
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンと、ついているすべてのカードを、相手の手札にもどす。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558423,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ピジョン",
+	},
+
+	retreat: 0,
+	regulationMark: "C",
+	rarity: "Uncommon",
+	dexId: [18],
+};
+
+export default card;

--- a/data-asia/SM/SM9/071.ts
+++ b/data-asia/SM/SM9/071.ts
@@ -1,0 +1,52 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ニャース",
+	},
+
+	illustrator: "Ken Sugimori",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Colorless"],
+
+	description: {
+		ja: "ゴミ捨て場に いくと ひかりものを 巡って ヤミカラスと 激しく ケンカする 光景が 見られる。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ひっかく" },
+			damage: 10,
+			cost: ["Colorless"],
+		},
+		{
+			name: { ja: "かみつく" },
+			damage: 20,
+			cost: ["Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558425,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [52],
+};
+
+export default card;

--- a/data-asia/SM/SM9/072.ts
+++ b/data-asia/SM/SM9/072.ts
@@ -1,0 +1,62 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ペルシアン",
+	},
+
+	illustrator: "Yukiko Baba",
+	category: "Pokemon",
+	hp: 100,
+	types: ["Colorless"],
+
+	description: {
+		ja: "アローラの ペルシアンとは 額の 宝石の色が 違って 見えるが 成分は あまり 変わらないのだ。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "おもいしらせる" },
+			damage: 20,
+			cost: ["Colorless"],
+			effect: {
+				ja: "相手の手札が4枚以上なら、相手の手札を見て、その枚数が4枚になるまでトラッシュする。",
+			},
+		},
+		{
+			name: { ja: "するどいツメ" },
+			damage: "30+",
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "コインを1回投げオモテなら、60ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558428,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ニャース",
+	},
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [53],
+};
+
+export default card;

--- a/data-asia/SM/SM9/073.ts
+++ b/data-asia/SM/SM9/073.ts
@@ -1,0 +1,57 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "カモネギ",
+	},
+
+	illustrator: "Shibuzoh.",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Colorless"],
+
+	description: {
+		ja: "持っている 茎は 大切な 武器でもあり 刀を 振るように いろんな ものを 切ることができる。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "もってくる" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札を2枚引く。",
+			},
+		},
+		{
+			name: { ja: "どうぐはじき" },
+			damage: "20+",
+			cost: ["Colorless"],
+			effect: {
+				ja: "ダメージを与える前に、相手のバトルポケモンについている「ポケモンのどうぐ」をトラッシュする。トラッシュした場合、70ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558429,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [83],
+};
+
+export default card;

--- a/data-asia/SM/SM9/074.ts
+++ b/data-asia/SM/SM9/074.ts
@@ -1,0 +1,54 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ガルーラ",
+	},
+
+	illustrator: "Mizue",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Colorless"],
+
+	description: {
+		ja: "お腹の 袋に 我が子を 入れて 守る。 子どもを 傷つけた者は 絶対に 許さず 叩きのめす。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "しんかそくせい" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札にある進化ポケモンを2枚まで、相手に見せてから、手札に加える。そして山札を切る。",
+			},
+		},
+		{
+			name: { ja: "メガトンパンチ" },
+			damage: 80,
+			cost: ["Colorless", "Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558431,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "C",
+	rarity: "Uncommon",
+	dexId: [115],
+};
+
+export default card;

--- a/data-asia/SM/SM9/075.ts
+++ b/data-asia/SM/SM9/075.ts
@@ -1,0 +1,50 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ケンタロス",
+	},
+
+	illustrator: "kodama",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Colorless"],
+
+	description: {
+		ja: "集団で 生活する。 群れの 中で １番 太く 長く キズだらけの ツノを持つのが ボス。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "いかりのむれ" },
+			damage: "10+",
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "自分の場の「ケンタロス（GXをふくむ）」にのっているダメカンの数x10ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558433,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "C",
+	rarity: "Uncommon",
+	dexId: [128],
+};
+
+export default card;

--- a/data-asia/SM/SM9/076.ts
+++ b/data-asia/SM/SM9/076.ts
@@ -1,0 +1,57 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "プテラ",
+	},
+
+	illustrator: "hatachu",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Colorless"],
+
+	description: {
+		ja: "琥珀に 残された 遺伝子から 復元させた。 予想以上に 凶暴で 犠牲者も でた。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "ちょうおんぱ" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをこんらんにする。",
+			},
+		},
+		{
+			name: { ja: "かせきのキバ" },
+			damage: "90+",
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "自分のベンチに「ポケモンGX・EX」がいないなら、90ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558436,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Uncommon",
+	dexId: [142],
+};
+
+export default card;

--- a/data-asia/SM/SM9/077.ts
+++ b/data-asia/SM/SM9/077.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "あなぬけのヒモ",
+	},
+
+	illustrator: "Toyste Beach",
+	category: "Trainer",
+
+	effect: {
+		ja: "おたがいのプレイヤーは、それぞれ、自分のバトルポケモンをベンチポケモンと入れ替える。（入れ替えは相手からおこない、ベンチがいないプレイヤーは、入れ替えをしない。）",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558438,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	regulationMark: "A",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM9/078.ts
+++ b/data-asia/SM/SM9/078.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ジャッジマンホイッスル",
+	},
+
+	illustrator: "Ayaka Yoshida",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードは、2つの効果から1つを選んで使う。◆自分の山札を1枚引く。◆自分のトラッシュにある「ジャッジマン」を1枚、相手に見せてから、手札に加える。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558440,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	regulationMark: "C",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM9/079.ts
+++ b/data-asia/SM/SM9/079.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "なぞの化石",
+	},
+
+	illustrator: "Toyste Beach",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードは、HP60の[無]タイプのたねポケモンとして、場に出すことができる。自分の番の中でなら、場に出ているこのカードをトラッシュしてよい。このカードは、にげられない。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558442,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	regulationMark: "B",
+	rarity: "Common",
+};
+
+export default card;

--- a/data-asia/SM/SM9/080.ts
+++ b/data-asia/SM/SM9/080.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ハイパーボール",
+	},
+
+	illustrator: "Ryo Ueda",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードは、自分の手札を2枚トラッシュしなければ使えない。自分の山札からポケモンを1枚選び、相手に見せてから、手札に加える。そして山札を切る。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558445,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	regulationMark: "A",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM9/081.ts
+++ b/data-asia/SM/SM9/081.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ふしぎなアメ",
+	},
+
+	illustrator: "Toyste Beach",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分のたねポケモン1匹から進化する1進化の上の2進化ポケモンを、手札から1枚選び、そのたねポケモンにのせて進化させる。[最初の自分の番と、この番出したばかりのたねポケモンには使えない。]",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558447,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	regulationMark: "A",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM9/082.ts
+++ b/data-asia/SM/SM9/082.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ポケモン通信",
+	},
+
+	illustrator: "Ayaka Yoshida",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の手札からポケモンを1枚選び、相手に見せてから、山札にもどす。もどした場合、自分の山札からポケモンを1枚選び、相手に見せてから、手札に加える。そして山札を切る。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558448,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	regulationMark: "C",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM9/083.ts
+++ b/data-asia/SM/SM9/083.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ムキムキパッド",
+	},
+
+	illustrator: "Yoshinobu Saito",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードをつけているにげるためのエネルギーが4個のポケモンの最大HPは「50」大きくなる。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558451,
+			},
+		},
+	],
+
+	trainerType: "Tool",
+	regulationMark: "C",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM9/084.ts
+++ b/data-asia/SM/SM9/084.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "エリカのおもてなし",
+	},
+
+	illustrator: "Sanosuke Sakuma",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードは、自分の手札がこのカードをふくめて6枚以上なら使えない。相手の場のポケモンの数ぶん、自分の山札を引く。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 558454,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "C",
+	rarity: "Rare",
+};
+
+export default card;

--- a/data-asia/SM/SM9/085.ts
+++ b/data-asia/SM/SM9/085.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ジャッジマン",
+	},
+
+	illustrator: "Sanosuke Sakuma",
+	category: "Trainer",
+
+	effect: {
+		ja: "おたがいのプレイヤーは、それぞれ、手札をすべて山札にもどし、山札を切る。その後、それぞれの山札を4枚引く。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558456,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "B",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM9/086.ts
+++ b/data-asia/SM/SM9/086.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "シロナ",
+	},
+
+	illustrator: "Ken Sugimori",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の手札をすべて山札にもどして切る。その後、山札を6枚引く。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558458,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "B",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM9/087.ts
+++ b/data-asia/SM/SM9/087.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "タケシのガッツ",
+	},
+
+	illustrator: "Naoki Saito",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分のトラッシュからポケモンと基本エネルギーを合計6枚選び、相手に見せてから、山札にもどす。そして山札を切る。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558460,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "C",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM9/088.ts
+++ b/data-asia/SM/SM9/088.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ナツメの暗示",
+	},
+
+	illustrator: "Hitoshi Ariga",
+	category: "Trainer",
+
+	effect: {
+		ja: "相手の手札を見る。のぞむなら、その中からサポートを1枚選び、そのサポートの効果を、このカードの効果として使う。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558462,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "C",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM9/089.ts
+++ b/data-asia/SM/SM9/089.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "マサキの解析",
+	},
+
+	illustrator: "Naoki Saito",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の山札を上から7枚見る。その中にあるトレーナーズを2枚まで、相手に見せてから、手札に加えてよい。残りのカードは山札にもどして切る。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 558464,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "C",
+	rarity: "Rare",
+};
+
+export default card;

--- a/data-asia/SM/SM9/090.ts
+++ b/data-asia/SM/SM9/090.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "シオンタウン",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Trainer",
+
+	effect: {
+		ja: "おたがいのプレイヤーは、自分の番ごとに1回、相手の手札を見てよい。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558465,
+			},
+		},
+	],
+
+	trainerType: "Stadium",
+	regulationMark: "C",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM9/091.ts
+++ b/data-asia/SM/SM9/091.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "トキワの森",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Trainer",
+
+	effect: {
+		ja: "おたがいのプレイヤーは、自分の番ごとに1回、自分の手札を1枚トラッシュしてよい。その場合、自分の山札にある基本エネルギーを1枚、相手に見せてから、手札に加える。そして山札を切る。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558466,
+			},
+		},
+	],
+
+	trainerType: "Stadium",
+	regulationMark: "C",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM9/092.ts
+++ b/data-asia/SM/SM9/092.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アクアパッチ",
+	},
+
+	illustrator: "Toyste Beach",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分のトラッシュにある[水]エネルギーを1枚、ベンチの[水]ポケモンにつける。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 558467,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	regulationMark: "A",
+	rarity: "Rare Holo",
+};
+
+export default card;

--- a/data-asia/SM/SM9/093.ts
+++ b/data-asia/SM/SM9/093.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "フィールドブロアー",
+	},
+
+	illustrator: "Toyste Beach",
+	category: "Trainer",
+
+	effect: {
+		ja: "場にある「ポケモンのどうぐ」または「スタジアム」を、2枚までトラッシュする。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 558468,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	regulationMark: "A",
+	rarity: "Rare Holo",
+};
+
+export default card;

--- a/data-asia/SM/SM9/094.ts
+++ b/data-asia/SM/SM9/094.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "こだわりハチマキ",
+	},
+
+	illustrator: "Eske Yoshinob",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードをつけているポケモンが使うワザの、相手のバトル場の「ポケモンGX・EX」へのダメージは「+30」される。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 558469,
+			},
+		},
+	],
+
+	trainerType: "Tool",
+	regulationMark: "A",
+	rarity: "Rare Holo",
+};
+
+export default card;

--- a/data-asia/SM/SM9/095.ts
+++ b/data-asia/SM/SM9/095.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "デンジ",
+	},
+
+	illustrator: "Hideki Ishikawa",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の山札にあるグッズと[雷]エネルギーを1枚ずつ、相手に見せてから、手札に加える。そして山札を切る。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 558470,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "B",
+	rarity: "Rare Holo",
+};
+
+export default card;

--- a/data-asia/SM/SM9/096.ts
+++ b/data-asia/SM/SM9/096.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "セレビィ&フシギバナGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 270,
+	types: ["Grass"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "きけんなかふん" },
+			damage: 50,
+			cost: ["Grass", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをどくとやけどとこんらんにする。",
+			},
+		},
+		{
+			name: { ja: "ソーラービーム" },
+			damage: 150,
+			cost: ["Grass", "Grass", "Colorless", "Colorless"],
+		},
+		{
+			name: { ja: "エバーグリーンGX" },
+			damage: 180,
+			cost: ["Grass", "Grass", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンのHPを、すべて回復する。追加で[草]エネルギーが1個ついているなら、自分のトラッシュにあるカードをすべて山札にもどして切る。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 558471,
+			},
+		},
+	],
+
+	retreat: 4,
+	regulationMark: "C",
+	rarity: "Ultra Rare",
+	dexId: [251, 3],
+
+	suffix: "TAG TEAM-GX",
+};
+
+export default card;

--- a/data-asia/SM/SM9/097.ts
+++ b/data-asia/SM/SM9/097.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "セレビィ&フシギバナGX",
+	},
+
+	illustrator: "Shin Nagasawa",
+	category: "Pokemon",
+	hp: 270,
+	types: ["Grass"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "きけんなかふん" },
+			damage: 50,
+			cost: ["Grass", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをどくとやけどとこんらんにする。",
+			},
+		},
+		{
+			name: { ja: "ソーラービーム" },
+			damage: 150,
+			cost: ["Grass", "Grass", "Colorless", "Colorless"],
+		},
+		{
+			name: { ja: "エバーグリーンGX" },
+			damage: 180,
+			cost: ["Grass", "Grass", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンのHPを、すべて回復する。追加で[草]エネルギーが1個ついているなら、自分のトラッシュにあるカードをすべて山札にもどして切る。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 558472,
+			},
+		},
+	],
+
+	retreat: 4,
+	regulationMark: "C",
+	rarity: "Ultra Rare",
+	dexId: [251, 3],
+
+	suffix: "TAG TEAM-GX",
+};
+
+export default card;

--- a/data-asia/SM/SM9/098.ts
+++ b/data-asia/SM/SM9/098.ts
@@ -1,0 +1,53 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "コイキング&ホエルオーGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 300,
+	types: ["Water"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "スーパースプラッシュ" },
+			damage: 180,
+			cost: ["Water", "Water", "Water", "Water", "Water"],
+		},
+		{
+			name: { ja: "キングザブーンGX" },
+			damage: 10,
+			cost: ["Water"],
+			effect: {
+				ja: "追加で[水]エネルギーが7個ついているなら、相手のベンチポケモン全員にも、それぞれ100ダメージ。［ベンチは弱点・抵抗力を計算しない。］［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 558473,
+			},
+		},
+	],
+
+	retreat: 4,
+	regulationMark: "C",
+	rarity: "Ultra Rare",
+	dexId: [129, 321],
+
+	suffix: "TAG TEAM-GX",
+};
+
+export default card;

--- a/data-asia/SM/SM9/099.ts
+++ b/data-asia/SM/SM9/099.ts
@@ -1,0 +1,53 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "コイキング&ホエルオーGX",
+	},
+
+	illustrator: "OOYAMA",
+	category: "Pokemon",
+	hp: 300,
+	types: ["Water"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "スーパースプラッシュ" },
+			damage: 180,
+			cost: ["Water", "Water", "Water", "Water", "Water"],
+		},
+		{
+			name: { ja: "キングザブーンGX" },
+			damage: 10,
+			cost: ["Water"],
+			effect: {
+				ja: "追加で[水]エネルギーが7個ついているなら、相手のベンチポケモン全員にも、それぞれ100ダメージ。［ベンチは弱点・抵抗力を計算しない。］［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 558474,
+			},
+		},
+	],
+
+	retreat: 4,
+	regulationMark: "C",
+	rarity: "Ultra Rare",
+	dexId: [129, 321],
+
+	suffix: "TAG TEAM-GX",
+};
+
+export default card;

--- a/data-asia/SM/SM9/100.ts
+++ b/data-asia/SM/SM9/100.ts
@@ -1,0 +1,56 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ピカチュウ&ゼクロムGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 240,
+	types: ["Lightning"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "フルドライブ" },
+			damage: 150,
+			cost: ["Lightning", "Lightning", "Lightning"],
+			effect: {
+				ja: "自分の山札にある[雷]エネルギーを3枚まで、自分のポケモン1匹につける。そして山札を切る。",
+			},
+		},
+		{
+			name: { ja: "タッグボルトGX" },
+			damage: 200,
+			cost: ["Lightning", "Lightning", "Lightning"],
+			effect: {
+				ja: "追加で[雷]エネルギーが3個ついているなら、相手のベンチポケモン1匹にも、170ダメージ。［ベンチは弱点・抵抗力を計算しない。］［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Metal", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 558475,
+			},
+		},
+	],
+
+	retreat: 3,
+	regulationMark: "C",
+	rarity: "Ultra Rare",
+	dexId: [25, 644],
+
+	suffix: "TAG TEAM-GX",
+};
+
+export default card;

--- a/data-asia/SM/SM9/101.ts
+++ b/data-asia/SM/SM9/101.ts
@@ -1,0 +1,56 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ピカチュウ&ゼクロムGX",
+	},
+
+	illustrator: "kawayoo",
+	category: "Pokemon",
+	hp: 240,
+	types: ["Lightning"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "フルドライブ" },
+			damage: 150,
+			cost: ["Lightning", "Lightning", "Lightning"],
+			effect: {
+				ja: "自分の山札にある[雷]エネルギーを3枚まで、自分のポケモン1匹につける。そして山札を切る。",
+			},
+		},
+		{
+			name: { ja: "タッグボルトGX" },
+			damage: 200,
+			cost: ["Lightning", "Lightning", "Lightning"],
+			effect: {
+				ja: "追加で[雷]エネルギーが3個ついているなら、相手のベンチポケモン1匹にも、170ダメージ。［ベンチは弱点・抵抗力を計算しない。］［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Metal", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 558476,
+			},
+		},
+	],
+
+	retreat: 3,
+	regulationMark: "C",
+	rarity: "Ultra Rare",
+	dexId: [25, 644],
+
+	suffix: "TAG TEAM-GX",
+};
+
+export default card;

--- a/data-asia/SM/SM9/102.ts
+++ b/data-asia/SM/SM9/102.ts
@@ -1,0 +1,55 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ゲンガー&ミミッキュGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 240,
+	types: ["Psychic"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ポルターガイスト" },
+			damage: "50×",
+			cost: ["Psychic", "Psychic"],
+			effect: {
+				ja: "相手の手札を見て、その中にあるトレーナーズの枚数x50ダメージ。",
+			},
+		},
+		{
+			name: { ja: "ホラーハウスGX" },
+			cost: ["Psychic"],
+			effect: {
+				ja: "次の相手の番、相手は手札からカードを出して使えない。追加で[超]エネルギーが1個ついているなら、おたがいのプレイヤーは、それぞれの手札が7枚になるように、山札を引く。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 558477,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "C",
+	rarity: "Ultra Rare",
+	dexId: [94, 778],
+
+	suffix: "TAG TEAM-GX",
+};
+
+export default card;

--- a/data-asia/SM/SM9/103.ts
+++ b/data-asia/SM/SM9/103.ts
@@ -1,0 +1,55 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ゲンガー&ミミッキュGX",
+	},
+
+	illustrator: "Midori Harada",
+	category: "Pokemon",
+	hp: 240,
+	types: ["Psychic"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ポルターガイスト" },
+			damage: "50×",
+			cost: ["Psychic", "Psychic"],
+			effect: {
+				ja: "相手の手札を見て、その中にあるトレーナーズの枚数x50ダメージ。",
+			},
+		},
+		{
+			name: { ja: "ホラーハウスGX" },
+			cost: ["Psychic"],
+			effect: {
+				ja: "次の相手の番、相手は手札からカードを出して使えない。追加で[超]エネルギーが1個ついているなら、おたがいのプレイヤーは、それぞれの手札が7枚になるように、山札を引く。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 558478,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "C",
+	rarity: "Ultra Rare",
+	dexId: [94, 778],
+
+	suffix: "TAG TEAM-GX",
+};
+
+export default card;

--- a/data-asia/SM/SM9/104.ts
+++ b/data-asia/SM/SM9/104.ts
@@ -1,0 +1,55 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ラティアス&ラティオスGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 250,
+	types: ["Dragon"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "バスターパージ" },
+			damage: 240,
+			cost: ["Water", "Psychic", "Psychic", "Colorless"],
+			effect: {
+				ja: "このポケモンについているエネルギーを、3個トラッシュする。",
+			},
+		},
+		{
+			name: { ja: "エアロユニットGX" },
+			cost: ["Psychic"],
+			effect: {
+				ja: "自分のトラッシュにある基本エネルギーを5枚、自分のポケモンに好きなようにつける。追加でエネルギーが1個ついているなら、次の相手の番、このポケモンはワザのダメージや効果を受けない。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fairy", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 558479,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Ultra Rare",
+	dexId: [380, 381],
+
+	suffix: "TAG TEAM-GX",
+};
+
+export default card;

--- a/data-asia/SM/SM9/105.ts
+++ b/data-asia/SM/SM9/105.ts
@@ -1,0 +1,55 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ラティアス&ラティオスGX",
+	},
+
+	illustrator: "Sanosuke Sakuma",
+	category: "Pokemon",
+	hp: 250,
+	types: ["Dragon"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "バスターパージ" },
+			damage: 240,
+			cost: ["Water", "Psychic", "Psychic", "Colorless"],
+			effect: {
+				ja: "このポケモンについているエネルギーを、3個トラッシュする。",
+			},
+		},
+		{
+			name: { ja: "エアロユニットGX" },
+			cost: ["Psychic"],
+			effect: {
+				ja: "自分のトラッシュにある基本エネルギーを5枚、自分のポケモンに好きなようにつける。追加でエネルギーが1個ついているなら、次の相手の番、このポケモンはワザのダメージや効果を受けない。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fairy", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 558480,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Ultra Rare",
+	dexId: [380, 381],
+
+	suffix: "TAG TEAM-GX",
+};
+
+export default card;

--- a/data-asia/SM/SM9/106.ts
+++ b/data-asia/SM/SM9/106.ts
@@ -1,0 +1,63 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "イーブイ&カビゴンGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 270,
+	types: ["Colorless"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "おうえん" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の手札にあるエネルギーを1枚、自分のポケモンにつける。",
+			},
+		},
+		{
+			name: { ja: "ダンププレス" },
+			damage: "120+",
+			cost: ["Colorless", "Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンが進化ポケモンなら、120ダメージ追加。",
+			},
+		},
+		{
+			name: { ja: "メガトンフレンズGX" },
+			damage: 210,
+			cost: ["Colorless", "Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "追加でエネルギーが1個ついているなら、自分の手札が10枚になるように、山札を引く。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 558481,
+			},
+		},
+	],
+
+	retreat: 4,
+	regulationMark: "C",
+	rarity: "Ultra Rare",
+	dexId: [133, 143],
+
+	suffix: "TAG TEAM-GX",
+};
+
+export default card;

--- a/data-asia/SM/SM9/107.ts
+++ b/data-asia/SM/SM9/107.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "エリカのおもてなし",
+	},
+
+	illustrator: "Sanosuke Sakuma",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードは、自分の手札がこのカードをふくめて6枚以上なら使えない。相手の場のポケモンの数ぶん、自分の山札を引く。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 558482,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "C",
+	rarity: "Ultra Rare",
+};
+
+export default card;

--- a/data-asia/SM/SM9/108.ts
+++ b/data-asia/SM/SM9/108.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "タケシのガッツ",
+	},
+
+	illustrator: "Naoki Saito",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分のトラッシュからポケモンと基本エネルギーを合計6枚選び、相手に見せてから、山札にもどす。そして山札を切る。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 558483,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "C",
+	rarity: "Ultra Rare",
+};
+
+export default card;

--- a/data-asia/SM/SM9/109.ts
+++ b/data-asia/SM/SM9/109.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ナツメの暗示",
+	},
+
+	illustrator: "Hitoshi Ariga",
+	category: "Trainer",
+
+	effect: {
+		ja: "相手の手札を見る。のぞむなら、その中からサポートを1枚選び、そのサポートの効果を、このカードの効果として使う。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 558484,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "C",
+	rarity: "Ultra Rare",
+};
+
+export default card;

--- a/data-asia/SM/SM9/110.ts
+++ b/data-asia/SM/SM9/110.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "セレビィ&フシギバナGX",
+	},
+
+	illustrator: "",
+	category: "Pokemon",
+	hp: 270,
+	types: ["Grass"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "きけんなかふん" },
+			damage: 50,
+			cost: ["Grass", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをどくとやけどとこんらんにする。",
+			},
+		},
+		{
+			name: { ja: "ソーラービーム" },
+			damage: 150,
+			cost: ["Grass", "Grass", "Colorless", "Colorless"],
+		},
+		{
+			name: { ja: "エバーグリーンGX" },
+			damage: 180,
+			cost: ["Grass", "Grass", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンのHPを、すべて回復する。追加で[草]エネルギーが1個ついているなら、自分のトラッシュにあるカードをすべて山札にもどして切る。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 558485,
+			},
+		},
+	],
+
+	retreat: 4,
+	regulationMark: "C",
+	rarity: "Hyper rare",
+	dexId: [251, 3],
+
+	suffix: "TAG TEAM-GX",
+};
+
+export default card;

--- a/data-asia/SM/SM9/111.ts
+++ b/data-asia/SM/SM9/111.ts
@@ -1,0 +1,53 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "コイキング&ホエルオーGX",
+	},
+
+	illustrator: "",
+	category: "Pokemon",
+	hp: 300,
+	types: ["Water"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "スーパースプラッシュ" },
+			damage: 180,
+			cost: ["Water", "Water", "Water", "Water", "Water"],
+		},
+		{
+			name: { ja: "キングザブーンGX" },
+			damage: 10,
+			cost: ["Water"],
+			effect: {
+				ja: "追加で[水]エネルギーが7個ついているなら、相手のベンチポケモン全員にも、それぞれ100ダメージ。［ベンチは弱点・抵抗力を計算しない。］［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 558486,
+			},
+		},
+	],
+
+	retreat: 4,
+	regulationMark: "C",
+	rarity: "Hyper rare",
+	dexId: [129, 321],
+
+	suffix: "TAG TEAM-GX",
+};
+
+export default card;

--- a/data-asia/SM/SM9/112.ts
+++ b/data-asia/SM/SM9/112.ts
@@ -1,0 +1,56 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ピカチュウ&ゼクロムGX",
+	},
+
+	illustrator: "",
+	category: "Pokemon",
+	hp: 240,
+	types: ["Lightning"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "フルドライブ" },
+			damage: 150,
+			cost: ["Lightning", "Lightning", "Lightning"],
+			effect: {
+				ja: "自分の山札にある[雷]エネルギーを3枚まで、自分のポケモン1匹につける。そして山札を切る。",
+			},
+		},
+		{
+			name: { ja: "タッグボルトGX" },
+			damage: 200,
+			cost: ["Lightning", "Lightning", "Lightning"],
+			effect: {
+				ja: "追加で[雷]エネルギーが3個ついているなら、相手のベンチポケモン1匹にも、170ダメージ。［ベンチは弱点・抵抗力を計算しない。］［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Metal", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 558487,
+			},
+		},
+	],
+
+	retreat: 3,
+	regulationMark: "C",
+	rarity: "Hyper rare",
+	dexId: [25, 644],
+
+	suffix: "TAG TEAM-GX",
+};
+
+export default card;

--- a/data-asia/SM/SM9/113.ts
+++ b/data-asia/SM/SM9/113.ts
@@ -1,0 +1,55 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ゲンガー&ミミッキュGX",
+	},
+
+	illustrator: "",
+	category: "Pokemon",
+	hp: 240,
+	types: ["Psychic"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ポルターガイスト" },
+			damage: "50×",
+			cost: ["Psychic", "Psychic"],
+			effect: {
+				ja: "相手の手札を見て、その中にあるトレーナーズの枚数x50ダメージ。",
+			},
+		},
+		{
+			name: { ja: "ホラーハウスGX" },
+			cost: ["Psychic"],
+			effect: {
+				ja: "次の相手の番、相手は手札からカードを出して使えない。追加で[超]エネルギーが1個ついているなら、おたがいのプレイヤーは、それぞれの手札が7枚になるように、山札を引く。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 558488,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "C",
+	rarity: "Hyper rare",
+	dexId: [94, 778],
+
+	suffix: "TAG TEAM-GX",
+};
+
+export default card;

--- a/data-asia/SM/SM9/114.ts
+++ b/data-asia/SM/SM9/114.ts
@@ -1,0 +1,55 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ラティアス&ラティオスGX",
+	},
+
+	illustrator: "",
+	category: "Pokemon",
+	hp: 250,
+	types: ["Dragon"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "バスターパージ" },
+			damage: 240,
+			cost: ["Water", "Psychic", "Psychic", "Colorless"],
+			effect: {
+				ja: "このポケモンについているエネルギーを、3個トラッシュする。",
+			},
+		},
+		{
+			name: { ja: "エアロユニットGX" },
+			cost: ["Psychic"],
+			effect: {
+				ja: "自分のトラッシュにある基本エネルギーを5枚、自分のポケモンに好きなようにつける。追加でエネルギーが1個ついているなら、次の相手の番、このポケモンはワザのダメージや効果を受けない。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fairy", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 558489,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Hyper rare",
+	dexId: [380, 381],
+
+	suffix: "TAG TEAM-GX",
+};
+
+export default card;

--- a/data-asia/SM/SM9/115.ts
+++ b/data-asia/SM/SM9/115.ts
@@ -1,0 +1,63 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "イーブイ&カビゴンGX",
+	},
+
+	illustrator: "",
+	category: "Pokemon",
+	hp: 270,
+	types: ["Colorless"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "おうえん" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の手札にあるエネルギーを1枚、自分のポケモンにつける。",
+			},
+		},
+		{
+			name: { ja: "ダンププレス" },
+			damage: "120+",
+			cost: ["Colorless", "Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンが進化ポケモンなら、120ダメージ追加。",
+			},
+		},
+		{
+			name: { ja: "メガトンフレンズGX" },
+			damage: 210,
+			cost: ["Colorless", "Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "追加でエネルギーが1個ついているなら、自分の手札が10枚になるように、山札を引く。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 558490,
+			},
+		},
+	],
+
+	retreat: 4,
+	regulationMark: "C",
+	rarity: "Hyper rare",
+	dexId: [133, 143],
+
+	suffix: "TAG TEAM-GX",
+};
+
+export default card;

--- a/data-asia/SM/SM9/116.ts
+++ b/data-asia/SM/SM9/116.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ポケモン通信",
+	},
+
+	illustrator: "",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の手札からポケモンを1枚選び、相手に見せてから、山札にもどす。もどした場合、自分の山札からポケモンを1枚選び、相手に見せてから、手札に加える。そして山札を切る。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 558491,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	regulationMark: "C",
+	rarity: "Secret Rare",
+};
+
+export default card;

--- a/data-asia/SM/SM9/117.ts
+++ b/data-asia/SM/SM9/117.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ジャッジマンホイッスル",
+	},
+
+	illustrator: "",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードは、2つの効果から1つを選んで使う。◆自分の山札を1枚引く。◆自分のトラッシュにある「ジャッジマン」を1枚、相手に見せてから、手札に加える。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 558492,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	regulationMark: "C",
+	rarity: "Secret Rare",
+};
+
+export default card;

--- a/data-asia/SM/SM9/118.ts
+++ b/data-asia/SM/SM9/118.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "せせらぎの丘",
+	},
+
+	illustrator: "",
+	category: "Trainer",
+
+	effect: {
+		ja: "おたがいのプレイヤーは、自分の番ごとに1回、自分の山札にある[水]または[闘]タイプのたねポケモンを1枚、ベンチに出してよい。その場合、山札を切る。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 558493,
+			},
+		},
+	],
+
+	trainerType: "Stadium",
+	regulationMark: "A",
+	rarity: "Secret Rare",
+};
+
+export default card;


### PR DESCRIPTION
## What

Adds the complete Japanese set **SM9 タッグボルト (Tag Bolt)**, released 2018-12-07:

- `data-asia/SM/SM9/001.ts` … `118.ts` — all 118 cards (95 regular + 23 secret rares: 14 SR, 3 Secret Rare, 6 UR)
- the set definition `data-asia/SM/SM9.ts` already existed and is untouched

## Data sources

- **pokemon-card.com** (official database): Japanese names, flavor texts, National Dex numbers, official card count
- **limitlesstcg.com**: full Japanese card text, stages, weaknesses/resistances/retreat, rarities, illustrators, attack costs
- **Cardmarket**: product IDs as `thirdParty.cardmarket` on the variant objects (558279–558493; tcgplayer IDs not available to me)

## Notes

- Follows the file format and conventions of the M-era sets (#1728)
- All 118 files type-check against `interfaces.d.ts` (`tsc --noEmit`)
