### PR TITLE
(data) Add Japanese SM set SM9a Night Unison

### DIFF
--- a/data-asia/SM/SM9a/001.ts
+++ b/data-asia/SM/SM9a/001.ts
@@ -1,0 +1,54 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "コンパン",
+	},
+
+	illustrator: "kirisAki",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Grass"],
+
+	description: {
+		ja: "小さな 目が たくさん 集まって 大きな 目に なっている。 夜になると 明かりに 集まる。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "レーダーアイ" },
+			cost: ["Grass"],
+			effect: {
+				ja: "自分の山札を上から7枚見て、その中にあるカードを1枚、手札に加える。残りのカードは山札にもどして切る。",
+			},
+		},
+		{
+			name: { ja: "はねまわる" },
+			damage: 20,
+			cost: ["Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558188,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [48],
+};
+
+export default card;

--- a/data-asia/SM/SM9a/002.ts
+++ b/data-asia/SM/SM9a/002.ts
@@ -1,0 +1,60 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "モルフォンGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 200,
+	types: ["Grass"],
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "しのびのごくい" },
+			damage: "110+",
+			cost: ["Grass", "Colorless", "Colorless"],
+			effect: {
+				ja: "この番、手札から「キョウの罠」を出して使っていたなら、90ダメージ追加。「アンズ」を出して使っていたなら、次の相手の番、このポケモンはたねポケモンからワザのダメージを受けない。",
+			},
+		},
+		{
+			name: { ja: "じゅうまいがえしGX" },
+			damage: 60,
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の手札をすべて山札にもどして切る。その後、山札を10枚引く。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 558189,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "コンパン",
+	},
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Double rare",
+	dexId: [49],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM9a/003.ts
+++ b/data-asia/SM/SM9a/003.ts
@@ -1,0 +1,47 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "マダツボミ",
+	},
+
+	illustrator: "Ken Sugimori",
+	category: "Pokemon",
+	hp: 50,
+	types: ["Grass"],
+
+	description: {
+		ja: "ひょろっとした 体つきだが 獲物を 捕らえるときの 動きは 目にも とまらないほど 素早い。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "はっぱカッター" },
+			damage: 20,
+			cost: ["Grass"],
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558190,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [69],
+};
+
+export default card;

--- a/data-asia/SM/SM9a/004.ts
+++ b/data-asia/SM/SM9a/004.ts
@@ -1,0 +1,58 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ウツドン",
+	},
+
+	illustrator: "otumami",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Grass"],
+
+	description: {
+		ja: "葉っぱの 部分は カッターになって 相手を 切り裂く。 口からは なんでも 溶かす 液体を 吐く。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "やけつくどく" },
+			cost: ["Grass"],
+			effect: {
+				ja: "相手のバトルポケモンをどくとやけどにする。",
+			},
+		},
+		{
+			name: { ja: "ぶつかる" },
+			damage: 30,
+			cost: ["Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558191,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "マダツボミ",
+	},
+
+	retreat: 2,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [70],
+};
+
+export default card;

--- a/data-asia/SM/SM9a/005.ts
+++ b/data-asia/SM/SM9a/005.ts
@@ -1,0 +1,62 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ウツボット",
+	},
+
+	illustrator: "Anesaki Dynamic",
+	category: "Pokemon",
+	hp: 140,
+	types: ["Grass"],
+
+	description: {
+		ja: "ジャングルの 奥地に ウツボット ばかり いる 地帯が あって 行ったら ２度と 帰ってこれない。",
+	},
+
+	stage: "Stage2",
+
+	attacks: [
+		{
+			name: { ja: "どくへんげ" },
+			damage: "10+",
+			cost: ["Grass"],
+			effect: {
+				ja: "相手のバトルポケモンが受けている特殊状態の数x60ダメージ追加。",
+			},
+		},
+		{
+			name: { ja: "いえき" },
+			damage: 90,
+			cost: ["Grass", "Colorless", "Colorless"],
+			effect: {
+				ja: "次の自分の番の終わりまで、このワザを受けたポケモンが持つ特性はなくなる。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558192,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ウツドン",
+	},
+
+	retreat: 2,
+	regulationMark: "C",
+	rarity: "Uncommon",
+	dexId: [71],
+};
+
+export default card;

--- a/data-asia/SM/SM9a/006.ts
+++ b/data-asia/SM/SM9a/006.ts
@@ -1,0 +1,54 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アゴジムシ",
+	},
+
+	illustrator: "Yuka Morii",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Grass"],
+
+	description: {
+		ja: "もし 巣穴を 見つけても 手を 突っ込んでは ダメだ。 嫌がる アゴジムシに 噛みつかれるぞ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "エレキシグナル" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札にある[雷]ポケモンを2枚まで、相手に見せてから、手札に加える。そして山札を切る。",
+			},
+		},
+		{
+			name: { ja: "どつく" },
+			damage: 30,
+			cost: ["Colorless", "Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558193,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [736],
+};
+
+export default card;

--- a/data-asia/SM/SM9a/007.ts
+++ b/data-asia/SM/SM9a/007.ts
@@ -1,0 +1,50 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "メノクラゲ",
+	},
+
+	illustrator: "Shin Nagasawa",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Water"],
+
+	description: {
+		ja: "海辺を 漂い 獲物を 探す。 毒の 触手は ちぎれることも あるが 時間が 経てば 生えてくる。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "あわとばしのじゅつ" },
+			damage: "10+",
+			cost: ["Colorless"],
+			effect: {
+				ja: "この番、手札から「アンズ」を出して使っていたなら、50ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558194,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [72],
+};
+
+export default card;

--- a/data-asia/SM/SM9a/008.ts
+++ b/data-asia/SM/SM9a/008.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ドククラゲ",
+	},
+
+	illustrator: "Shigenori Negishi",
+	category: "Pokemon",
+	hp: 100,
+	types: ["Water"],
+
+	description: {
+		ja: "赤い 玉から 超音波を 発生させ 獲物を 弱らせると ８０本の 触手を 巻きつける。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "いけずなしょくしゅ" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "相手の場のポケモンについているエネルギーを1個、相手の別のポケモンにつけ替える。その後、つけ替えたポケモンにダメカンを3個のせる。",
+			},
+		},
+		{
+			name: { ja: "まきつく" },
+			damage: 60,
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "コインを1回投げオモテなら、相手のバトルポケモンをマヒにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558195,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "メノクラゲ",
+	},
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [73],
+};
+
+export default card;

--- a/data-asia/SM/SM9a/009.ts
+++ b/data-asia/SM/SM9a/009.ts
@@ -1,0 +1,50 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "トサキント",
+	},
+
+	illustrator: "Naoyo Kimura",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Water"],
+
+	description: {
+		ja: "美しい 尾びれが 特徴だが トサキント同士は ツノの 太さと 鋭さを 競い合っているらしい。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ゆうがにおよぐ" },
+			damage: 10,
+			cost: ["Water"],
+			effect: {
+				ja: "コインを1回投げオモテなら、次の相手の番、このポケモンはワザのダメージや効果を受けない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558196,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [118],
+};
+
+export default card;

--- a/data-asia/SM/SM9a/010.ts
+++ b/data-asia/SM/SM9a/010.ts
@@ -1,0 +1,54 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アズマオウ",
+	},
+
+	illustrator: "Midori Harada",
+	category: "Pokemon",
+	hp: 100,
+	types: ["Water"],
+
+	description: {
+		ja: "ツノは ドリルのように 回転して 硬い 岩も グングン くり貫く。 オスの方が 鮮やかな 色合い。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "エキサイトホーン" },
+			damage: "30×",
+			cost: ["Water"],
+			effect: {
+				ja: "コインを2回投げ、オモテの数x30ダメージ。このポケモンに「ポケモンのどうぐ」がついているなら、このワザで投げるコインの数は6回になる。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558197,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "トサキント",
+	},
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Uncommon",
+	dexId: [119],
+};
+
+export default card;

--- a/data-asia/SM/SM9a/011.ts
+++ b/data-asia/SM/SM9a/011.ts
@@ -1,0 +1,57 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "キュレム",
+	},
+
+	illustrator: "Anesaki Dynamic",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Water"],
+
+	description: {
+		ja: "失った 体を 真実と 理想で 埋めてくれる 英雄を 待つ 氷の 伝説ポケモン。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "れいきをよぶ" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札にある[水]エネルギーを1枚、このポケモンにつける。そして山札を切る。",
+			},
+		},
+		{
+			name: { ja: "ヘイルプリズン" },
+			damage: 110,
+			cost: ["Water", "Water", "Colorless"],
+			effect: {
+				ja: "このポケモンについている[水]エネルギーを2個トラッシュし、相手のバトルポケモンをマヒにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 558198,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "C",
+	rarity: "Rare",
+	dexId: [646],
+};
+
+export default card;

--- a/data-asia/SM/SM9a/012.ts
+++ b/data-asia/SM/SM9a/012.ts
@@ -1,0 +1,50 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ケロマツ",
+	},
+
+	illustrator: "Kyoko Umemoto",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Water"],
+
+	description: {
+		ja: "胸と 背中から 泡を 出す。 弾力のある 泡で 攻撃を 受け止めて ダメージを 減らす。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "でんこうせっか" },
+			damage: "10+",
+			cost: ["Colorless"],
+			effect: {
+				ja: "コインを1回投げオモテなら、20ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558199,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [656],
+};
+
+export default card;

--- a/data-asia/SM/SM9a/013.ts
+++ b/data-asia/SM/SM9a/013.ts
@@ -1,0 +1,54 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ゲコガシラ",
+	},
+
+	illustrator: "Satoshi Shirai",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Water"],
+
+	description: {
+		ja: "泡で 包んだ 小石を 投げる 技を 使う。 ３０メートル 先の 空き缶に 当てる コントロール。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "ざんぞうぎり" },
+			damage: 20,
+			cost: ["Colorless"],
+			effect: {
+				ja: "次の相手の番、このポケモンがワザのダメージを受けるとき、自分はコインを1回投げる。オモテなら、このポケモンはそのダメージを受けない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558200,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ケロマツ",
+	},
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [657],
+};
+
+export default card;

--- a/data-asia/SM/SM9a/014.ts
+++ b/data-asia/SM/SM9a/014.ts
@@ -1,0 +1,47 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ピカチュウ",
+	},
+
+	illustrator: "nagimiso",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Lightning"],
+
+	description: {
+		ja: "電気を ため込む 性質。 ピカチュウが 群れて 暮らす 森は 落雷が 絶えず 危険だ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ピカボール" },
+			damage: 30,
+			cost: ["Lightning", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Metal", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558201,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [25],
+};
+
+export default card;

--- a/data-asia/SM/SM9a/015.ts
+++ b/data-asia/SM/SM9a/015.ts
@@ -1,0 +1,58 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ライチュウ",
+	},
+
+	illustrator: "Shin Nagasawa",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Lightning"],
+
+	description: {
+		ja: "身体に 電気が たまるに つれ 攻撃的に。 実は 電気が ストレスなのでは という 説もある。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "ネバーギブアップ" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "このワザは、自分のサイドの残り枚数が、相手より3枚以上多いときにしか使えない。自分のトラッシュにある[雷]エネルギーをすべて、自分のポケモンに好きなようにつける。",
+			},
+		},
+		{
+			name: { ja: "ヘッドボルト" },
+			damage: 110,
+			cost: ["Lightning", "Lightning", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Metal", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558202,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ピカチュウ",
+	},
+
+	retreat: 2,
+	regulationMark: "C",
+	rarity: "Uncommon",
+	dexId: [26],
+};
+
+export default card;

--- a/data-asia/SM/SM9a/016.ts
+++ b/data-asia/SM/SM9a/016.ts
@@ -1,0 +1,63 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "デデンネGX",
+	},
+
+	illustrator: "PLANETA Igarashi",
+	category: "Pokemon",
+	hp: 160,
+	types: ["Lightning"],
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "デデチェンジ" },
+			effect: {
+				ja: "自分の番に、このカードを手札からベンチに出したとき、1回使える。自分の手札をすべてトラッシュし、山札を6枚引く。この番、すでに別の「デデチェンジ」を使っていたなら、この特性は使えない。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "バチバチ" },
+			damage: 50,
+			cost: ["Lightning", "Colorless"],
+		},
+		{
+			name: { ja: "ビリリターンGX" },
+			damage: 50,
+			cost: ["Lightning", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをマヒにする。このポケモンと、ついているすべてのカードを、手札にもどす。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Metal", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 558203,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Double rare",
+	dexId: [702],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM9a/017.ts
+++ b/data-asia/SM/SM9a/017.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "デンヂムシ",
+	},
+
+	illustrator: "Sekio",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Lightning"],
+
+	description: {
+		ja: "落ち葉に 埋まり ほとんど 動かず ひたすら 腐葉土を 食っている。 間違って 踏むと ビリビリするぞ。",
+	},
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "バッテリー" },
+			effect: {
+				ja: "このカードが手札にあるなら、自分の番に1回使える。このカードを特殊エネルギーとして自分の「クワガノン（GXをふくむ）」につける。このカードは、ポケモンについているかぎり[雷]エネルギー2個ぶんとしてはたらく。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "つきさす" },
+			damage: 60,
+			cost: ["Colorless", "Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Metal", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558204,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "アゴジムシ",
+	},
+
+	retreat: 3,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [737],
+};
+
+export default card;

--- a/data-asia/SM/SM9a/018.ts
+++ b/data-asia/SM/SM9a/018.ts
@@ -1,0 +1,64 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "クワガノン",
+	},
+
+	illustrator: "Hasuno",
+	category: "Pokemon",
+	hp: 150,
+	types: ["Lightning"],
+
+	description: {
+		ja: "腹部に 発電 器官を 持つ。 大アゴに エネルギーを 集め 凄まじい 電撃を 放つ。",
+	},
+
+	stage: "Stage2",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ステルスボディ" },
+			effect: {
+				ja: "場にスタジアムが出ているなら、このポケモンの弱点は、すべてなくなる。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "エレキほう" },
+			damage: "120+",
+			cost: ["Lightning", "Lightning", "Lightning", "Colorless"],
+			effect: {
+				ja: "のぞむなら、このポケモンについている[雷]エネルギーを、すべてトラッシュする。その場合、100ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Metal", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 558205,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "デンヂムシ",
+	},
+
+	retreat: 2,
+	regulationMark: "C",
+	rarity: "Rare",
+	dexId: [738],
+};
+
+export default card;

--- a/data-asia/SM/SM9a/019.ts
+++ b/data-asia/SM/SM9a/019.ts
@@ -1,0 +1,58 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ゼラオラ",
+	},
+
+	illustrator: "kawayoo",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Lightning"],
+
+	description: {
+		ja: "両手足の ツメを 帯電させ 相手を 八つ裂き。 かわされても 飛び散る 電撃で 感電させる。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "クラッシュクロー" },
+			damage: 20,
+			cost: ["Lightning"],
+			effect: {
+				ja: "相手のバトルポケモンについている特殊エネルギーを、1個トラッシュする。",
+			},
+		},
+		{
+			name: { ja: "ほうでん" },
+			damage: "50×",
+			cost: ["Lightning", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンについている[雷]エネルギーをすべてトラッシュし、その枚数x50ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Metal", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 558206,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Rare",
+	dexId: [807],
+};
+
+export default card;

--- a/data-asia/SM/SM9a/020.ts
+++ b/data-asia/SM/SM9a/020.ts
@@ -1,0 +1,60 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "マーシャドー",
+	},
+
+	illustrator: "chibi",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Psychic"],
+
+	description: {
+		ja: "相手の 影に 潜って 動きや 力を 真似る。 真似ているうちに 本物 よりも 強くなるぞ。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "リセットホール" },
+			effect: {
+				ja: "このポケモンがベンチにいるなら、自分の番に1回使える。場に出ているスタジアムをトラッシュする。その後、このポケモンと、ついているすべてのカードを、トラッシュする。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "レッドナックル" },
+			damage: "10+",
+			cost: ["Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンが「ウルトラビースト」なら、60ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 558207,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Rare",
+	dexId: [802],
+};
+
+export default card;

--- a/data-asia/SM/SM9a/021.ts
+++ b/data-asia/SM/SM9a/021.ts
@@ -1,0 +1,47 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ウパー",
+	},
+
+	illustrator: "tetsuya koizumi",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Fighting"],
+
+	description: {
+		ja: "冷たい 水の中で 生活。 あたりが 涼しくなると エサを 探しに 地上にも 現れる。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "どろばくだん" },
+			damage: 30,
+			cost: ["Water", "Water"],
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558208,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [194],
+};
+
+export default card;

--- a/data-asia/SM/SM9a/022.ts
+++ b/data-asia/SM/SM9a/022.ts
@@ -1,0 +1,56 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヌオー",
+	},
+
+	illustrator: "kirisAki",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Fighting"],
+
+	description: {
+		ja: "のんびりとした 性格。 川底で 口を 開けて エサが 飛びこんでくるのを ひたすら 待つ。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "みずでっぽう" },
+			damage: 20,
+			cost: ["Water"],
+		},
+		{
+			name: { ja: "なみのり" },
+			damage: 120,
+			cost: ["Water", "Water", "Water"],
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558209,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ウパー",
+	},
+
+	retreat: 2,
+	regulationMark: "C",
+	rarity: "Uncommon",
+	dexId: [195],
+};
+
+export default card;

--- a/data-asia/SM/SM9a/023.ts
+++ b/data-asia/SM/SM9a/023.ts
@@ -1,0 +1,60 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "グライガー",
+	},
+
+	illustrator: "Ken Sugimori",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Fighting"],
+
+	description: {
+		ja: "いつもは 崖に 張りついている。 獲物を見つけると 羽を広げ 風に乗り 襲いかかってくる。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "フリーフライト" },
+			effect: {
+				ja: "このポケモンにエネルギーがついていないなら、このポケモンのにげるためのエネルギーは、すべてなくなる。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "しのびのひとつき" },
+			damage: "30+",
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "この番、手札から「アンズ」を出して使っていたなら、90ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558210,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [207],
+};
+
+export default card;

--- a/data-asia/SM/SM9a/024.ts
+++ b/data-asia/SM/SM9a/024.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "グライオン",
+	},
+
+	illustrator: "Mizue",
+	category: "Pokemon",
+	hp: 110,
+	types: ["Fighting"],
+
+	description: {
+		ja: "尻尾で 木の枝に ぶら下がり 獲物を 観察する。 すきを 見て 上空から 襲いかかる。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "もってくる" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札を3枚引く。",
+			},
+		},
+		{
+			name: { ja: "どくづき" },
+			damage: 70,
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをどくにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558211,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "グライガー",
+	},
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [472],
+};
+
+export default card;

--- a/data-asia/SM/SM9a/025.ts
+++ b/data-asia/SM/SM9a/025.ts
@@ -1,0 +1,55 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ゲッコウガ&ゾロアークGX",
+	},
+
+	illustrator: "Mitsuhiro Arita",
+	category: "Pokemon",
+	hp: 250,
+	types: ["Darkness"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "あくのはどう" },
+			damage: "30+",
+			cost: ["Darkness", "Colorless"],
+			effect: {
+				ja: "自分の場のポケモンについている[悪]エネルギーの数x30ダメージ追加。",
+			},
+		},
+		{
+			name: { ja: "ナイトユニゾンGX" },
+			cost: ["Darkness", "Colorless"],
+			effect: {
+				ja: "自分のトラッシュにある[悪]タイプの「ポケモンGX・EX」を2枚、ベンチに出す。 追加でエネルギーが1個ついているなら、新しく出したポケモンに、トラッシュにあるエネルギーを2枚ずつつける。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 558212,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "C",
+	rarity: "Double rare",
+	dexId: [658, 571],
+
+	suffix: "TAG TEAM-GX",
+};
+
+export default card;

--- a/data-asia/SM/SM9a/026.ts
+++ b/data-asia/SM/SM9a/026.ts
@@ -1,0 +1,47 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "キバニア",
+	},
+
+	illustrator: "SATOSHI NAKAI",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Darkness"],
+
+	description: {
+		ja: "臆病で １匹では 狩りも しない。 ５匹 くらい 集まると 急に 凶暴に なるぞ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "かじる" },
+			damage: 10,
+			cost: ["Darkness"],
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558213,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [318],
+};
+
+export default card;

--- a/data-asia/SM/SM9a/027.ts
+++ b/data-asia/SM/SM9a/027.ts
@@ -1,0 +1,64 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "サメハダー",
+	},
+
+	illustrator: "Tomokazu Komiya",
+	category: "Pokemon",
+	hp: 110,
+	types: ["Darkness"],
+
+	description: {
+		ja: "抜けた キバを 持っていると 海で 事故に 遭わないと 信じられており アクセサリーなどに 加工 される。",
+	},
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ごうよくしんか" },
+			effect: {
+				ja: "自分の番に、このカードを手札から出して進化させたとき、1回使える。自分の山札を上から6枚見て、その中にある[悪]エネルギーを好きなだけ、このポケモンにつける。残りのカードは山札にもどして切る。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "バッドファング" },
+			damage: "60+",
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンについている[悪]エネルギーの数x20ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558214,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "キバニア",
+	},
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Uncommon",
+	dexId: [319],
+};
+
+export default card;

--- a/data-asia/SM/SM9a/028.ts
+++ b/data-asia/SM/SM9a/028.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ゲッコウガ",
+	},
+
+	illustrator: "Yusuke Ohmura",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Darkness"],
+
+	description: {
+		ja: "水を 圧縮して 手裏剣を 作り出す。 高速回転させて 飛ばすと 金属も 真っ二つ。",
+	},
+
+	stage: "Stage2",
+
+	attacks: [
+		{
+			name: { ja: "しとめる" },
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモン以外の、おたがいの場のポケモン全員の中から、残りHPが一番少ないポケモンのうち1匹を選び、きぜつさせる。",
+			},
+		},
+		{
+			name: { ja: "かすみぎり" },
+			damage: 70,
+			cost: ["Darkness", "Darkness"],
+			effect: {
+				ja: "このワザのダメージは、弱点・抵抗力と、相手のバトルポケモンにかかっている効果を計算しない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 558215,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ゲコガシラ",
+	},
+
+	retreat: 0,
+	regulationMark: "C",
+	rarity: "Rare",
+	dexId: [658],
+};
+
+export default card;

--- a/data-asia/SM/SM9a/029.ts
+++ b/data-asia/SM/SM9a/029.ts
@@ -1,0 +1,49 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "マーイーカ",
+	},
+
+	illustrator: "Naoyo Kimura",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Darkness"],
+
+	description: {
+		ja: "光を 点滅させて 獲物を おびきよせると 長い 触手で 絡めとり 動きを 封じるぞ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "まどわす" },
+			cost: ["Darkness"],
+			effect: {
+				ja: "相手のバトルポケモンをこんらんにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558216,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [686],
+};
+
+export default card;

--- a/data-asia/SM/SM9a/030.ts
+++ b/data-asia/SM/SM9a/030.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "カラマネロ",
+	},
+
+	illustrator: "Yusuke Ohmura",
+	category: "Pokemon",
+	hp: 100,
+	types: ["Darkness"],
+
+	description: {
+		ja: "強力な さいみんじゅつを 使う。 それを 利用し 悪事を 働く者は 後を 絶たない。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "さいみんしはい" },
+			cost: ["Darkness"],
+			effect: {
+				ja: "相手の手札を見る。のぞむなら、その中にあるポケモンを、1枚トラッシュする。その場合、そのポケモンが持っているワザ（GXワザをのぞく）を1つ選び、このワザとして使う。",
+			},
+		},
+		{
+			name: { ja: "ダークプレッシャー" },
+			damage: 80,
+			cost: ["Darkness", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手の山札を上から1枚トラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 558217,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "マーイーカ",
+	},
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Rare",
+	dexId: [687],
+};
+
+export default card;

--- a/data-asia/SM/SM9a/031.ts
+++ b/data-asia/SM/SM9a/031.ts
@@ -1,0 +1,63 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "サーナイト&ニンフィアGX",
+	},
+
+	illustrator: "Mitsuhiro Arita",
+	category: "Pokemon",
+	hp: 260,
+	types: ["Fairy"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ようせいのうた" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札にある[妖]エネルギーを2枚まで、自分のベンチポケモンに好きなようにつける。そして山札を切る。",
+			},
+		},
+		{
+			name: { ja: "カレイドストーム" },
+			damage: 150,
+			cost: ["Fairy", "Fairy", "Colorless"],
+			effect: {
+				ja: "自分の場のポケモンについているエネルギーを好きなだけ選び、自分のポケモンに好きなようにつけ替える。",
+			},
+		},
+		{
+			name: { ja: "ミラクルマジカルGX" },
+			damage: 200,
+			cost: ["Fairy", "Fairy", "Fairy"],
+			effect: {
+				ja: "追加で[妖]エネルギーが3個ついているなら、相手の手札をすべて山札にもどして切る。[対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [{ type: "Darkness", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 558218,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "C",
+	rarity: "Double rare",
+	dexId: [282, 700],
+
+	suffix: "TAG TEAM-GX",
+};
+
+export default card;

--- a/data-asia/SM/SM9a/032.ts
+++ b/data-asia/SM/SM9a/032.ts
@@ -1,0 +1,50 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ピッピ",
+	},
+
+	illustrator: "0313",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Fairy"],
+
+	description: {
+		ja: "人気だが 数が 少ないので 貴重。 むやみに 見せびらかすと 泥棒に 狙われるぞ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "おうふくビンタ" },
+			damage: "10×",
+			cost: ["Colorless"],
+			effect: {
+				ja: "コインを2回投げ、オモテの数x10ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [{ type: "Darkness", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558219,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [35],
+};
+
+export default card;

--- a/data-asia/SM/SM9a/033.ts
+++ b/data-asia/SM/SM9a/033.ts
@@ -1,0 +1,54 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ピクシー",
+	},
+
+	illustrator: "Suwama Chiaki",
+	category: "Pokemon",
+	hp: 110,
+	types: ["Fairy"],
+
+	description: {
+		ja: "１キロ先で 針が 落ちた 音も 聞こえてしまうので 人やポケモンが 少ない 深い山奥で 暮らす。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "おつきみダンス" },
+			damage: "10+",
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の場の[妖]エネルギーがついているポケモンの数x30ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [{ type: "Darkness", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558220,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ピッピ",
+	},
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Uncommon",
+	dexId: [36],
+};
+
+export default card;

--- a/data-asia/SM/SM9a/034.ts
+++ b/data-asia/SM/SM9a/034.ts
@@ -1,0 +1,50 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "トゲピー",
+	},
+
+	illustrator: "Sekio",
+	category: "Pokemon",
+	hp: 50,
+	types: ["Fairy"],
+
+	description: {
+		ja: "殻の中に 幸せが たくさん つまっているらしく 優しくされると 幸運を 分け与える という。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ひるませる" },
+			damage: 10,
+			cost: ["Colorless"],
+			effect: {
+				ja: "次の相手の番、このワザを受けたポケモンが使うワザのダメージは「-30」される。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [{ type: "Darkness", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558221,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [175],
+};
+
+export default card;

--- a/data-asia/SM/SM9a/035.ts
+++ b/data-asia/SM/SM9a/035.ts
@@ -1,0 +1,58 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "トゲチック",
+	},
+
+	illustrator: "sui",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Fairy"],
+
+	description: {
+		ja: "優しい人の そばに いないと 元気が 出なくなってしまう。 羽を動かさずに 空に浮かべる。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "エネギフト" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の手札にあるエネルギーを1枚、ベンチポケモンにつける。",
+			},
+		},
+		{
+			name: { ja: "マジカルショット" },
+			damage: 30,
+			cost: ["Fairy", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [{ type: "Darkness", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558222,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "トゲピー",
+	},
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [176],
+};
+
+export default card;

--- a/data-asia/SM/SM9a/036.ts
+++ b/data-asia/SM/SM9a/036.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "トゲキッス",
+	},
+
+	illustrator: "Kagemaru Himeno",
+	category: "Pokemon",
+	hp: 140,
+	types: ["Fairy"],
+
+	description: {
+		ja: "争いのない 平和な 土地に トゲキッスは 訪れ さまざまな 恵みを 分け与えると 言われる。",
+	},
+
+	stage: "Stage2",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ようせいのうたげ" },
+			effect: {
+				ja: "自分の番に1回使える。自分の[妖]ポケモン全員のHPを、それぞれ「30」回復する。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "マジカルショット" },
+			damage: 70,
+			cost: ["Fairy", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [{ type: "Darkness", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 558223,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "トゲチック",
+	},
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Rare",
+	dexId: [468],
+};
+
+export default card;

--- a/data-asia/SM/SM9a/037.ts
+++ b/data-asia/SM/SM9a/037.ts
@@ -1,0 +1,54 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "シュシュプ",
+	},
+
+	illustrator: "MAHOU",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Fairy"],
+
+	description: {
+		ja: "かいだ 者を うっとりさせる 香りを 体から 漂わせる。 食べた もので 香りが 変わる。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ひとやすみ" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "このポケモンのHPを「20」回復する。",
+			},
+		},
+		{
+			name: { ja: "ようせいのかぜ" },
+			damage: 10,
+			cost: ["Fairy"],
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [{ type: "Darkness", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558224,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [682],
+};
+
+export default card;

--- a/data-asia/SM/SM9a/038.ts
+++ b/data-asia/SM/SM9a/038.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "フレフワン",
+	},
+
+	illustrator: "Saya Tsuruta",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Fairy"],
+
+	description: {
+		ja: "さまざまな においを 作り出す。 相手の 嫌がる においを 出して 戦いを 有利に 進めるのだ。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "きょうれつなかおり" },
+			cost: ["Fairy"],
+			effect: {
+				ja: "コインを2回投げる。1回でもオモテなら、相手の手札を見て、オモテの数ぶんのカードを、相手の山札にもどして切る。",
+			},
+		},
+		{
+			name: { ja: "ミラクルコロン" },
+			damage: 30,
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "コインを1回投げオモテなら、特殊状態の中から1つを選び、相手のバトルポケモンをその状態にする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [{ type: "Darkness", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558225,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "シュシュプ",
+	},
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Uncommon",
+	dexId: [683],
+};
+
+export default card;

--- a/data-asia/SM/SM9a/039.ts
+++ b/data-asia/SM/SM9a/039.ts
@@ -1,0 +1,47 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "コラッタ",
+	},
+
+	illustrator: "Eri Yamaki",
+	category: "Pokemon",
+	hp: 30,
+	types: ["Colorless"],
+
+	description: {
+		ja: "一生 前歯が 伸び続ける。 あまりに 伸びすぎると エサが 食べられなくなって 餓死 する。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "かじる" },
+			damage: 30,
+			cost: ["Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558226,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [19],
+};
+
+export default card;

--- a/data-asia/SM/SM9a/040.ts
+++ b/data-asia/SM/SM9a/040.ts
@@ -1,0 +1,54 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ラッタ",
+	},
+
+	illustrator: "Shigenori Negishi",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Colorless"],
+
+	description: {
+		ja: "後ろ足の 小さい 水かきで 海を 泳いで 島を 渡り 敵から 逃げていた という。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "とんずらまえば" },
+			damage: 70,
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンが進化ポケモンなら、このポケモンをベンチポケモンと入れ替える。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558227,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "コラッタ",
+	},
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [20],
+};
+
+export default card;

--- a/data-asia/SM/SM9a/041.ts
+++ b/data-asia/SM/SM9a/041.ts
@@ -1,0 +1,50 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ベロリンガ",
+	},
+
+	illustrator: "Yukiko Baba",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Colorless"],
+
+	description: {
+		ja: "長い ベロで なんでも ベロリと 舐めて 確かめている。 舐められた 部分を 放っておくと かぶれるぞ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "したでなめる" },
+			damage: 30,
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "コインを1回投げオモテなら、相手のバトルポケモンをマヒにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558228,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [108],
+};
+
+export default card;

--- a/data-asia/SM/SM9a/042.ts
+++ b/data-asia/SM/SM9a/042.ts
@@ -1,0 +1,62 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ベロベルト",
+	},
+
+	illustrator: "sui",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Colorless"],
+
+	description: {
+		ja: "舌が どこまで 伸びるのかの コンテストが 開催 されている。 現在の 最高記録は２５ｍ。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "つまんでたべる" },
+			damage: 40,
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "ダメージを与える前に、相手のバトルポケモンについている「ポケモンのどうぐ」をトラッシュする。トラッシュした場合、このポケモンのHPを、すべて回復する。",
+			},
+		},
+		{
+			name: { ja: "ベロベロハリケーン" },
+			damage: "60×",
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "コインを4回投げ、オモテの数x60ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558229,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ベロリンガ",
+	},
+
+	retreat: 4,
+	regulationMark: "C",
+	rarity: "Uncommon",
+	dexId: [463],
+};
+
+export default card;

--- a/data-asia/SM/SM9a/043.ts
+++ b/data-asia/SM/SM9a/043.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "電磁レーダー",
+	},
+
+	illustrator: "Yoshinobu Saito",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードは、自分の手札を2枚トラッシュしなければ使えない。自分の山札にある[雷]タイプの「ポケモンGX・EX」を2枚まで、相手に見せてから、手札に加える。そして山札を切る。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558230,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	regulationMark: "C",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM9a/044.ts
+++ b/data-asia/SM/SM9a/044.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "びっくりボックス",
+	},
+
+	illustrator: "Ryo Ueda",
+	category: "Trainer",
+
+	effect: {
+		ja: "相手のトラッシュにある好きなカードを1枚、相手の手札にもどす。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558231,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	regulationMark: "C",
+	rarity: "Common",
+};
+
+export default card;

--- a/data-asia/SM/SM9a/045.ts
+++ b/data-asia/SM/SM9a/045.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ポケギア3.0",
+	},
+
+	illustrator: "Studio Bora Inc.",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の山札を上から7枚見る。その中にあるサポートを1枚、相手に見せてから、手札に加えてよい。残りのカードは山札にもどして切る。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558232,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	regulationMark: "C",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM9a/046.ts
+++ b/data-asia/SM/SM9a/046.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "隠密フード",
+	},
+
+	illustrator: "Ryo Ueda",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードをつけているポケモンは、相手のポケモンから特性の効果を受けない。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558233,
+			},
+		},
+	],
+
+	trainerType: "Tool",
+	regulationMark: "C",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM9a/047.ts
+++ b/data-asia/SM/SM9a/047.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "フェアリーチャーム 雷",
+	},
+
+	illustrator: "Toyste Beach",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードをつけているポケモンは、相手のタイプの「ポケモンGX・EX」からワザのダメージを受けない。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558234,
+			},
+		},
+	],
+
+	trainerType: "Tool",
+	regulationMark: "C",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM9a/048.ts
+++ b/data-asia/SM/SM9a/048.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "フェアリーチャーム 特性",
+	},
+
+	illustrator: "Toyste Beach",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードをつけているポケモンは、相手の特性を持つ「ポケモンGX・EX」からワザのダメージを受けない。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558235,
+			},
+		},
+	],
+
+	trainerType: "Tool",
+	regulationMark: "C",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM9a/049.ts
+++ b/data-asia/SM/SM9a/049.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アンズ",
+	},
+
+	illustrator: "Ken Sugimori",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の山札を上から4枚見て、その中にあるカードを2枚、手札に加える。残りのカードは山札にもどして切る。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558236,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "C",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM9a/050.ts
+++ b/data-asia/SM/SM9a/050.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "キョウの罠",
+	},
+
+	illustrator: "Megumi Mizutani",
+	category: "Trainer",
+
+	effect: {
+		ja: "相手のバトルポケモンをどくとこんらんにする。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558237,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "C",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM9a/051.ts
+++ b/data-asia/SM/SM9a/051.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "マチスの作戦",
+	},
+
+	illustrator: "Megumi Mizutani",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードは、自分のサイドの残り枚数が、相手より多いときにしか使えない。この番、自分が使えるサポートの枚数は3枚になる。（このカードをふくむ。）",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558238,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "C",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM9a/052.ts
+++ b/data-asia/SM/SM9a/052.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "エレキパワー",
+	},
+
+	illustrator: "Ayaka Yoshida",
+	category: "Trainer",
+
+	effect: {
+		ja: "この番、自分の[雷]ポケモンが使うワザの、相手のバトルポケモンへのダメージは「+30」される。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 558239,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	regulationMark: "B",
+	rarity: "Rare Holo",
+};
+
+export default card;

--- a/data-asia/SM/SM9a/053.ts
+++ b/data-asia/SM/SM9a/053.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "改造ハンマー",
+	},
+
+	illustrator: "Yoshinobu Saito",
+	category: "Trainer",
+
+	effect: {
+		ja: "相手のポケモンについている特殊エネルギーを1個選び、トラッシュする。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 558240,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	regulationMark: "A",
+	rarity: "Rare Holo",
+};
+
+export default card;

--- a/data-asia/SM/SM9a/054.ts
+++ b/data-asia/SM/SM9a/054.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "まんたんのくすり",
+	},
+
+	illustrator: "Toyste Beach",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分のポケモンを1匹選び、HPをすべて回復する。その後、そのポケモンについているエネルギーをすべてトラッシュする。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 558241,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	regulationMark: "A",
+	rarity: "Rare Holo",
+};
+
+export default card;

--- a/data-asia/SM/SM9a/055.ts
+++ b/data-asia/SM/SM9a/055.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "グズマ",
+	},
+
+	illustrator: "Masakazu Fukuda",
+	category: "Trainer",
+
+	effect: {
+		ja: "相手のベンチポケモンを1匹選び、バトルポケモンと入れ替える。その後、自分のバトルポケモンをベンチポケモンと入れ替える。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 558242,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "A",
+	rarity: "Rare Holo",
+};
+
+export default card;

--- a/data-asia/SM/SM9a/056.ts
+++ b/data-asia/SM/SM9a/056.ts
@@ -1,0 +1,60 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "モルフォンGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 200,
+	types: ["Grass"],
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "しのびのごくい" },
+			damage: "110+",
+			cost: ["Grass", "Colorless", "Colorless"],
+			effect: {
+				ja: "この番、手札から「キョウの罠」を出して使っていたなら、90ダメージ追加。「アンズ」を出して使っていたなら、次の相手の番、このポケモンはたねポケモンからワザのダメージを受けない。",
+			},
+		},
+		{
+			name: { ja: "じゅうまいがえしGX" },
+			damage: 60,
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の手札をすべて山札にもどして切る。その後、山札を10枚引く。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 558243,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "コンパン",
+	},
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Ultra Rare",
+	dexId: [49],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM9a/057.ts
+++ b/data-asia/SM/SM9a/057.ts
@@ -1,0 +1,63 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "デデンネGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 160,
+	types: ["Lightning"],
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "デデチェンジ" },
+			effect: {
+				ja: "自分の番に、このカードを手札からベンチに出したとき、1回使える。自分の手札をすべてトラッシュし、山札を6枚引く。この番、すでに別の「デデチェンジ」を使っていたなら、この特性は使えない。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "バチバチ" },
+			damage: 50,
+			cost: ["Lightning", "Colorless"],
+		},
+		{
+			name: { ja: "ビリリターンGX" },
+			damage: 50,
+			cost: ["Lightning", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをマヒにする。このポケモンと、ついているすべてのカードを、手札にもどす。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Metal", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 558244,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Ultra Rare",
+	dexId: [702],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM9a/058.ts
+++ b/data-asia/SM/SM9a/058.ts
@@ -1,0 +1,55 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ゲッコウガ&ゾロアークGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 250,
+	types: ["Darkness"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "あくのはどう" },
+			damage: "30+",
+			cost: ["Darkness", "Colorless"],
+			effect: {
+				ja: "自分の場のポケモンについている[悪]エネルギーの数x30ダメージ追加。",
+			},
+		},
+		{
+			name: { ja: "ナイトユニゾンGX" },
+			cost: ["Darkness", "Colorless"],
+			effect: {
+				ja: "自分のトラッシュにある[悪]タイプの「ポケモンGX・EX」を2枚、ベンチに出す。 追加でエネルギーが1個ついているなら、新しく出したポケモンに、トラッシュにあるエネルギーを2枚ずつつける。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 558245,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "C",
+	rarity: "Ultra Rare",
+	dexId: [658, 571],
+
+	suffix: "TAG TEAM-GX",
+};
+
+export default card;

--- a/data-asia/SM/SM9a/059.ts
+++ b/data-asia/SM/SM9a/059.ts
@@ -1,0 +1,55 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ゲッコウガ&ゾロアークGX",
+	},
+
+	illustrator: "kodama",
+	category: "Pokemon",
+	hp: 250,
+	types: ["Darkness"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "あくのはどう" },
+			damage: "30+",
+			cost: ["Darkness", "Colorless"],
+			effect: {
+				ja: "自分の場のポケモンについている[悪]エネルギーの数x30ダメージ追加。",
+			},
+		},
+		{
+			name: { ja: "ナイトユニゾンGX" },
+			cost: ["Darkness", "Colorless"],
+			effect: {
+				ja: "自分のトラッシュにある[悪]タイプの「ポケモンGX・EX」を2枚、ベンチに出す。 追加でエネルギーが1個ついているなら、新しく出したポケモンに、トラッシュにあるエネルギーを2枚ずつつける。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 558246,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "C",
+	rarity: "Ultra Rare",
+	dexId: [658, 571],
+
+	suffix: "TAG TEAM-GX",
+};
+
+export default card;

--- a/data-asia/SM/SM9a/060.ts
+++ b/data-asia/SM/SM9a/060.ts
@@ -1,0 +1,63 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "サーナイト&ニンフィアGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 260,
+	types: ["Fairy"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ようせいのうた" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札にある[妖]エネルギーを2枚まで、自分のベンチポケモンに好きなようにつける。そして山札を切る。",
+			},
+		},
+		{
+			name: { ja: "カレイドストーム" },
+			damage: 150,
+			cost: ["Fairy", "Fairy", "Colorless"],
+			effect: {
+				ja: "自分の場のポケモンについているエネルギーを好きなだけ選び、自分のポケモンに好きなようにつけ替える。",
+			},
+		},
+		{
+			name: { ja: "ミラクルマジカルGX" },
+			damage: 200,
+			cost: ["Fairy", "Fairy", "Fairy"],
+			effect: {
+				ja: "追加で[妖]エネルギーが3個ついているなら、相手の手札をすべて山札にもどして切る。[対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [{ type: "Darkness", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 558247,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "C",
+	rarity: "Ultra Rare",
+	dexId: [282, 700],
+
+	suffix: "TAG TEAM-GX",
+};
+
+export default card;

--- a/data-asia/SM/SM9a/061.ts
+++ b/data-asia/SM/SM9a/061.ts
@@ -1,0 +1,63 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "サーナイト&ニンフィアGX",
+	},
+
+	illustrator: "Atsuko Nishida",
+	category: "Pokemon",
+	hp: 260,
+	types: ["Fairy"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ようせいのうた" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札にある[妖]エネルギーを2枚まで、自分のベンチポケモンに好きなようにつける。そして山札を切る。",
+			},
+		},
+		{
+			name: { ja: "カレイドストーム" },
+			damage: 150,
+			cost: ["Fairy", "Fairy", "Colorless"],
+			effect: {
+				ja: "自分の場のポケモンについているエネルギーを好きなだけ選び、自分のポケモンに好きなようにつけ替える。",
+			},
+		},
+		{
+			name: { ja: "ミラクルマジカルGX" },
+			damage: 200,
+			cost: ["Fairy", "Fairy", "Fairy"],
+			effect: {
+				ja: "追加で[妖]エネルギーが3個ついているなら、相手の手札をすべて山札にもどして切る。[対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [{ type: "Darkness", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 558248,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "C",
+	rarity: "Ultra Rare",
+	dexId: [282, 700],
+
+	suffix: "TAG TEAM-GX",
+};
+
+export default card;

--- a/data-asia/SM/SM9a/062.ts
+++ b/data-asia/SM/SM9a/062.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アンズ",
+	},
+
+	illustrator: "Hideki Ishikawa",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の山札を上から4枚見て、その中にあるカードを2枚、手札に加える。残りのカードは山札にもどして切る。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 558249,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "C",
+	rarity: "Ultra Rare",
+};
+
+export default card;

--- a/data-asia/SM/SM9a/063.ts
+++ b/data-asia/SM/SM9a/063.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "キョウの罠",
+	},
+
+	illustrator: "TOKIYA",
+	category: "Trainer",
+
+	effect: {
+		ja: "相手のバトルポケモンをどくとこんらんにする。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 558250,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "C",
+	rarity: "Ultra Rare",
+};
+
+export default card;

--- a/data-asia/SM/SM9a/064.ts
+++ b/data-asia/SM/SM9a/064.ts
@@ -1,0 +1,60 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "モルフォンGX",
+	},
+
+	illustrator: "",
+	category: "Pokemon",
+	hp: 200,
+	types: ["Grass"],
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "しのびのごくい" },
+			damage: "110+",
+			cost: ["Grass", "Colorless", "Colorless"],
+			effect: {
+				ja: "この番、手札から「キョウの罠」を出して使っていたなら、90ダメージ追加。「アンズ」を出して使っていたなら、次の相手の番、このポケモンはたねポケモンからワザのダメージを受けない。",
+			},
+		},
+		{
+			name: { ja: "じゅうまいがえしGX" },
+			damage: 60,
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の手札をすべて山札にもどして切る。その後、山札を10枚引く。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 558251,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "コンパン",
+	},
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Hyper rare",
+	dexId: [49],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM9a/065.ts
+++ b/data-asia/SM/SM9a/065.ts
@@ -1,0 +1,63 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "デデンネGX",
+	},
+
+	illustrator: "",
+	category: "Pokemon",
+	hp: 160,
+	types: ["Lightning"],
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "デデチェンジ" },
+			effect: {
+				ja: "自分の番に、このカードを手札からベンチに出したとき、1回使える。自分の手札をすべてトラッシュし、山札を6枚引く。この番、すでに別の「デデチェンジ」を使っていたなら、この特性は使えない。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "バチバチ" },
+			damage: 50,
+			cost: ["Lightning", "Colorless"],
+		},
+		{
+			name: { ja: "ビリリターンGX" },
+			damage: 50,
+			cost: ["Lightning", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをマヒにする。このポケモンと、ついているすべてのカードを、手札にもどす。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Metal", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 558252,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Hyper rare",
+	dexId: [702],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM9a/066.ts
+++ b/data-asia/SM/SM9a/066.ts
@@ -1,0 +1,55 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ゲッコウガ&ゾロアークGX",
+	},
+
+	illustrator: "",
+	category: "Pokemon",
+	hp: 250,
+	types: ["Darkness"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "あくのはどう" },
+			damage: "30+",
+			cost: ["Darkness", "Colorless"],
+			effect: {
+				ja: "自分の場のポケモンについている[悪]エネルギーの数x30ダメージ追加。",
+			},
+		},
+		{
+			name: { ja: "ナイトユニゾンGX" },
+			cost: ["Darkness", "Colorless"],
+			effect: {
+				ja: "自分のトラッシュにある[悪]タイプの「ポケモンGX・EX」を2枚、ベンチに出す。 追加でエネルギーが1個ついているなら、新しく出したポケモンに、トラッシュにあるエネルギーを2枚ずつつける。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 558253,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "C",
+	rarity: "Hyper rare",
+	dexId: [658, 571],
+
+	suffix: "TAG TEAM-GX",
+};
+
+export default card;

--- a/data-asia/SM/SM9a/067.ts
+++ b/data-asia/SM/SM9a/067.ts
@@ -1,0 +1,63 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "サーナイト&ニンフィアGX",
+	},
+
+	illustrator: "",
+	category: "Pokemon",
+	hp: 260,
+	types: ["Fairy"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ようせいのうた" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札にある[妖]エネルギーを2枚まで、自分のベンチポケモンに好きなようにつける。そして山札を切る。",
+			},
+		},
+		{
+			name: { ja: "カレイドストーム" },
+			damage: 150,
+			cost: ["Fairy", "Fairy", "Colorless"],
+			effect: {
+				ja: "自分の場のポケモンについているエネルギーを好きなだけ選び、自分のポケモンに好きなようにつけ替える。",
+			},
+		},
+		{
+			name: { ja: "ミラクルマジカルGX" },
+			damage: 200,
+			cost: ["Fairy", "Fairy", "Fairy"],
+			effect: {
+				ja: "追加で[妖]エネルギーが3個ついているなら、相手の手札をすべて山札にもどして切る。[対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [{ type: "Darkness", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 558254,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "C",
+	rarity: "Hyper rare",
+	dexId: [282, 700],
+
+	suffix: "TAG TEAM-GX",
+};
+
+export default card;

--- a/data-asia/SM/SM9a/068.ts
+++ b/data-asia/SM/SM9a/068.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "電磁レーダー",
+	},
+
+	illustrator: "",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードは、自分の手札を2枚トラッシュしなければ使えない。自分の山札にある[雷]タイプの「ポケモンGX・EX」を2枚まで、相手に見せてから、手札に加える。そして山札を切る。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 558255,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	regulationMark: "C",
+	rarity: "Secret Rare",
+};
+
+export default card;

--- a/data-asia/SM/SM9a/069.ts
+++ b/data-asia/SM/SM9a/069.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ポケギア3.0",
+	},
+
+	illustrator: "",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の山札を上から7枚見る。その中にあるサポートを1枚、相手に見せてから、手札に加えてよい。残りのカードは山札にもどして切る。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 558256,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	regulationMark: "C",
+	rarity: "Secret Rare",
+};
+
+export default card;

--- a/data-asia/SM/SM9a/070.ts
+++ b/data-asia/SM/SM9a/070.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "エーテルパラダイス保護区",
+	},
+
+	illustrator: "",
+	category: "Trainer",
+
+	effect: {
+		ja: "おたがいの[草]または[雷]タイプのたねポケモンが、相手のポケモンから受けるワザのダメージは「-30」される。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 558257,
+			},
+		},
+	],
+
+	trainerType: "Stadium",
+	regulationMark: "A",
+	rarity: "Secret Rare",
+};
+
+export default card;


### PR DESCRIPTION
## What

Adds the complete Japanese set **SM9a ナイトユニゾン (Night Unison)**, released 2019-01-11:

- `data-asia/SM/SM9a/001.ts` … `070.ts` — all 70 cards (55 regular + 15 secret rares: 8 SR, 3 Secret Rare, 4 UR)
- the set definition `data-asia/SM/SM9a.ts` already existed and is untouched

## Data sources

- **pokemon-card.com** (official database): Japanese names, flavor texts, National Dex numbers, official card count
- **limitlesstcg.com**: full Japanese card text, stages, weaknesses/resistances/retreat, rarities, illustrators, attack costs
- **Cardmarket**: product IDs as `thirdParty.cardmarket` on the variant objects (558188–558257; tcgplayer IDs not available to me)

## Notes

- Follows the file format and conventions of the M-era sets (#1728)
- All 70 files type-check against `interfaces.d.ts` (`tsc --noEmit`)
