### PR TITLE
(data) Add Japanese SM set SM9b Full Metal Force

### DIFF
--- a/data-asia/SM/SM9b/001.ts
+++ b/data-asia/SM/SM9b/001.ts
@@ -1,0 +1,64 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "フェローチェ&マッシブーンGX",
+	},
+
+	illustrator: "Mitsuhiro Arita",
+	category: "Pokemon",
+	hp: 260,
+	types: ["Grass"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ジェットパンチ" },
+			damage: 30,
+			cost: ["Grass"],
+			effect: {
+				ja: "相手のベンチポケモン1匹にも、30ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+			},
+		},
+		{
+			name: { ja: "エレガントソール" },
+			damage: 190,
+			cost: ["Grass", "Grass", "Colorless"],
+			effect: {
+				ja: "次の自分の番、このポケモンの「エレガントソール」のダメージは「60」になる。",
+			},
+		},
+		{
+			name: { ja: "ビーストゲームGX" },
+			damage: 50,
+			cost: ["Grass"],
+			effect: {
+				ja: "このワザのダメージで、相手のポケモンがきぜつしたなら、サイドを1枚多くとる。追加でエネルギーが7個ついているなら、多くとる枚数は3枚になる。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 558119,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "C",
+	rarity: "Double rare",
+	dexId: [795, 794],
+
+	suffix: "TAG TEAM-GX",
+};
+
+export default card;

--- a/data-asia/SM/SM9b/002.ts
+++ b/data-asia/SM/SM9b/002.ts
@@ -1,0 +1,57 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "キャタピー",
+	},
+
+	illustrator: "Shibuzoh.",
+	category: "Pokemon",
+	hp: 40,
+	types: ["Grass"],
+
+	description: {
+		ja: "早く 成長 したいのか 食欲旺盛で １日に １００枚の 葉っぱを 食らう。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ようか" },
+			effect: {
+				ja: "自分の番に1回使える。コインを1回投げオモテなら、このポケモンから進化するカードを、自分の山札から1枚選び、このポケモンにのせて進化させる。そして山札を切る。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ひっかける" },
+			damage: 10,
+			cost: ["Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558120,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [10],
+};
+
+export default card;

--- a/data-asia/SM/SM9b/003.ts
+++ b/data-asia/SM/SM9b/003.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "トランセル",
+	},
+
+	illustrator: "Shigenori Negishi",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Grass"],
+
+	description: {
+		ja: "カラの中は ドロドロの 液体。 進化に 備えて 体中の 細胞を 作りなおしている。",
+	},
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "うか" },
+			effect: {
+				ja: "自分の番に1回使える。コインを1回投げオモテなら、このポケモンから進化するカードを、自分の山札から1枚選び、このポケモンにのせて進化させる。そして山札を切る。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "むしくい" },
+			damage: 30,
+			cost: ["Grass", "Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558121,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "キャタピー",
+	},
+
+	retreat: 3,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [11],
+};
+
+export default card;

--- a/data-asia/SM/SM9b/004.ts
+++ b/data-asia/SM/SM9b/004.ts
@@ -1,0 +1,58 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "バタフリー",
+	},
+
+	illustrator: "Midori Harada",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Grass"],
+
+	description: {
+		ja: "羽を 包む りん粉は 猛毒。 キャタピーを 狙う とりポケモンを 見つけると ふりかけて 追い払うぞ。",
+	},
+
+	stage: "Stage2",
+
+	attacks: [
+		{
+			name: { ja: "トリプルチャージ" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札にある基本エネルギーを3枚まで、自分のポケモンに好きなようにつける。そして山札を切る。",
+			},
+		},
+		{
+			name: { ja: "ソーラービーム" },
+			damage: 70,
+			cost: ["Grass", "Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558122,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "トランセル",
+	},
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Uncommon",
+	dexId: [12],
+};
+
+export default card;

--- a/data-asia/SM/SM9b/005.ts
+++ b/data-asia/SM/SM9b/005.ts
@@ -1,0 +1,54 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "モンジャラ",
+	},
+
+	illustrator: "Naoyo Kimura",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Grass"],
+
+	description: {
+		ja: "たくさんの うごめく ツルに 覆われて 正体不明。 青いツルは 一生 伸びる。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "からめてひっぱる" },
+			cost: ["Grass"],
+			effect: {
+				ja: "相手のベンチポケモンを1匹選び、バトルポケモンと入れ替える。",
+			},
+		},
+		{
+			name: { ja: "ひっぱたく" },
+			damage: 30,
+			cost: ["Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558123,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [114],
+};
+
+export default card;

--- a/data-asia/SM/SM9b/006.ts
+++ b/data-asia/SM/SM9b/006.ts
@@ -1,0 +1,62 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "モジャンボ",
+	},
+
+	illustrator: "kodama",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Grass"],
+
+	description: {
+		ja: "植物の ツルで できた 腕を 伸ばして 獲物を 絡め取る。 腕を 食べられても へっちゃら。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "しばりつける" },
+			damage: 30,
+			cost: ["Grass"],
+			effect: {
+				ja: "次の相手の番、このワザを受けたポケモンは、にげられない。",
+			},
+		},
+		{
+			name: { ja: "クロロウィップ" },
+			damage: 90,
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンに[草]エネルギーが2個ついているなら、このポケモンのHPを「60」回復する。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558124,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "モンジャラ",
+	},
+
+	retreat: 3,
+	regulationMark: "C",
+	rarity: "Uncommon",
+	dexId: [465],
+};
+
+export default card;

--- a/data-asia/SM/SM9b/007.ts
+++ b/data-asia/SM/SM9b/007.ts
@@ -1,0 +1,57 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "カミツルギ",
+	},
+
+	illustrator: "Shin Nagasawa",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Grass"],
+
+	description: {
+		ja: "紙の ように 薄い 身体から 研がれた 刀に 似た 鋭さを 感じる ウルトラビーストだ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ダイキリ" },
+			damage: "10+",
+			cost: ["Grass"],
+			effect: {
+				ja: "自分のサイドの残り枚数が4枚なら、120ダメージ追加。",
+			},
+		},
+		{
+			name: { ja: "みねうち" },
+			cost: ["Grass", "Colorless", "Colorless"],
+			effect: {
+				ja: "コインを1回投げオモテなら、相手のバトルポケモンの残りHPが「10」になるように、ダメカンをのせる。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 558125,
+			},
+		},
+	],
+
+	retreat: 0,
+	regulationMark: "C",
+	rarity: "Rare",
+	dexId: [798],
+};
+
+export default card;

--- a/data-asia/SM/SM9b/008.ts
+++ b/data-asia/SM/SM9b/008.ts
@@ -1,0 +1,50 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ゼニガメ",
+	},
+
+	illustrator: "tetsuya koizumi",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Water"],
+
+	description: {
+		ja: "甲羅に 閉じこもり 身を 守る。 相手の すきを 見逃さず 水を 噴き出して 反撃する。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "あわ" },
+			damage: 10,
+			cost: ["Water"],
+			effect: {
+				ja: "コインを1回投げオモテなら、相手のバトルポケモンをマヒにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558126,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [7],
+};
+
+export default card;

--- a/data-asia/SM/SM9b/009.ts
+++ b/data-asia/SM/SM9b/009.ts
@@ -1,0 +1,64 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "カメール",
+	},
+
+	illustrator: "Hiroki Asanuma",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Water"],
+
+	description: {
+		ja: "ポカンと 頭を たたかれるとき 甲羅に 引っこんで 避ける。でも ちょっとだけ 尻尾が 出ているよ。",
+	},
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "かたいこうら" },
+			effect: {
+				ja: "このポケモンが受けるワザのダメージは「-20」される。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "アクアスラッシュ" },
+			damage: 60,
+			cost: ["Water", "Water"],
+			effect: {
+				ja: "次の自分の番、このポケモンはワザが使えない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558127,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ゼニガメ",
+	},
+
+	retreat: 2,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [8],
+};
+
+export default card;

--- a/data-asia/SM/SM9b/010.ts
+++ b/data-asia/SM/SM9b/010.ts
@@ -1,0 +1,69 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "カメックスGX",
+	},
+
+	illustrator: "sadaji",
+	category: "Pokemon",
+	hp: 240,
+	types: ["Water"],
+
+	stage: "Stage2",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "かたいこうら" },
+			effect: {
+				ja: "このポケモンが受けるワザのダメージは「-30」される。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ロケットスプラッシュ" },
+			damage: "60×",
+			cost: ["Water", "Water"],
+			effect: {
+				ja: "自分の場のポケモンについている[水]エネルギーを好きなだけ山札にもどし、その枚数x60ダメージ。その場合、山札を切る。",
+			},
+		},
+		{
+			name: { ja: "だいほうすいGX" },
+			cost: ["Water"],
+			effect: {
+				ja: "自分の手札にある[水]エネルギーを好きなだけ、自分のポケモンに好きなようにつける。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 558128,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "カメール",
+	},
+
+	retreat: 3,
+	regulationMark: "C",
+	rarity: "Double rare",
+	dexId: [9],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM9b/011.ts
+++ b/data-asia/SM/SM9b/011.ts
@@ -1,0 +1,54 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヤドン",
+	},
+
+	illustrator: "Kouki Saitou",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Water"],
+
+	description: {
+		ja: "あくびを すると 雨が 降る という 言い伝え から ヤドンを まつっている 地域が あるという。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "なきごえ" },
+			cost: ["Water"],
+			effect: {
+				ja: "次の相手の番、このワザを受けたポケモンが使うワザのダメージは「-20」される。",
+			},
+		},
+		{
+			name: { ja: "しっぽではたく" },
+			damage: 20,
+			cost: ["Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558129,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [79],
+};
+
+export default card;

--- a/data-asia/SM/SM9b/012.ts
+++ b/data-asia/SM/SM9b/012.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヤドラン",
+	},
+
+	illustrator: "Ken Sugimori",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Water"],
+
+	description: {
+		ja: "基本的に ぼんやり している。 シッポが ちぎれて シェルダーが 外れてしまうと ヤドンに 戻る。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "あくび" },
+			cost: ["Water"],
+			effect: {
+				ja: "相手のバトルポケモンをねむりにする。",
+			},
+		},
+		{
+			name: { ja: "かれいなるかけ" },
+			damage: "100×",
+			cost: ["Water", "Colorless", "Colorless"],
+			effect: {
+				ja: "コインを3回投げ、オモテの数x100ダメージ。すべてウラなら、この対戦は自分の負けになる。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 558130,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ヤドン",
+	},
+
+	retreat: 2,
+	regulationMark: "C",
+	rarity: "Rare",
+	dexId: [80],
+};
+
+export default card;

--- a/data-asia/SM/SM9b/013.ts
+++ b/data-asia/SM/SM9b/013.ts
@@ -1,0 +1,57 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ナマコブシ",
+	},
+
+	illustrator: "Asako Ito",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Water"],
+
+	description: {
+		ja: "ナマコブシ投げ という 文化は 打ち上げられた ナマコブシを 海に 投げ返す 習慣が 始まり。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "なかまをよぶ" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札にあるたねポケモンを2枚まで、ベンチに出す。そして山札を切る。",
+			},
+		},
+		{
+			name: { ja: "びっくりけん" },
+			damage: "60+",
+			cost: ["Water", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手プレイヤーとジャンケンをし、自分が勝ったなら60ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558131,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [771],
+};
+
+export default card;

--- a/data-asia/SM/SM9b/014.ts
+++ b/data-asia/SM/SM9b/014.ts
@@ -1,0 +1,54 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アーボ",
+	},
+
+	illustrator: "Yumi",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Psychic"],
+
+	description: {
+		ja: "顎を 外すことで 自分より 大きな 獲物も 丸呑みに する。 食後は 身体を 丸め 休む。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "へびにらみ" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "コインを1回投げオモテなら、相手のバトルポケモンをマヒにする。",
+			},
+		},
+		{
+			name: { ja: "しっぽでたたく" },
+			damage: 20,
+			cost: ["Psychic", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558132,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [23],
+};
+
+export default card;

--- a/data-asia/SM/SM9b/015.ts
+++ b/data-asia/SM/SM9b/015.ts
@@ -1,0 +1,62 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アーボック",
+	},
+
+	illustrator: "Yukiko Baba",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Psychic"],
+
+	description: {
+		ja: "最新の 研究で お腹の 模様は ２０種類 以上の パターンが あることが 判明。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "まきつく" },
+			damage: 30,
+			cost: ["Colorless"],
+			effect: {
+				ja: "コインを1回投げオモテなら、相手のバトルポケモンをマヒにする。",
+			},
+		},
+		{
+			name: { ja: "ヘビーチョーク" },
+			damage: "50+",
+			cost: ["Psychic", "Colorless"],
+			effect: {
+				ja: "前の自分の番、このポケモンが「まきつく」を使っていたなら、120ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558133,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "アーボ",
+	},
+
+	retreat: 2,
+	regulationMark: "C",
+	rarity: "Uncommon",
+	dexId: [24],
+};
+
+export default card;

--- a/data-asia/SM/SM9b/016.ts
+++ b/data-asia/SM/SM9b/016.ts
@@ -1,0 +1,55 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ズバット",
+	},
+
+	illustrator: "Sekio",
+	category: "Pokemon",
+	hp: 50,
+	types: ["Psychic"],
+
+	description: {
+		ja: "目玉が ないので 目は 見えない。 口から 出す 超音波で 周りの 様子を うかがっている。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "かみつく" },
+			damage: 10,
+			cost: ["Psychic"],
+		},
+		{
+			name: { ja: "ベノムショック" },
+			damage: "20+",
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンがどくなら、50ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558134,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [41],
+};
+
+export default card;

--- a/data-asia/SM/SM9b/017.ts
+++ b/data-asia/SM/SM9b/017.ts
@@ -1,0 +1,59 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ゴルバット",
+	},
+
+	illustrator: "Shin Nagasawa",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Psychic"],
+
+	description: {
+		ja: "空腹の あまり はがねポケモンに 噛みついたせいで キバの 欠けた ゴルバットを たまに 見かけるぞ。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "かみつく" },
+			damage: 20,
+			cost: ["Psychic"],
+		},
+		{
+			name: { ja: "きゅうけつ" },
+			damage: 40,
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンに与えたダメージぶん、このポケモンのHPを回復する。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558135,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ズバット",
+	},
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [42],
+};
+
+export default card;

--- a/data-asia/SM/SM9b/018.ts
+++ b/data-asia/SM/SM9b/018.ts
@@ -1,0 +1,64 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "クロバット",
+	},
+
+	illustrator: "Anesaki Dynamic",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Psychic"],
+
+	description: {
+		ja: "キバが 鋭いので 暗闇で 噛まれ 血を 吸われても 痛みが なくて すぐに 気が つかない。",
+	},
+
+	stage: "Stage2",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "おとがくれ" },
+			effect: {
+				ja: "自分の番に、このカードを手札から出して進化させたとき、1回使える。次の相手の番の終わりまで、このポケモンは、相手のポケモンからワザのダメージや効果を受けない。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "バッドポイズン" },
+			damage: 60,
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをどくにする。このどくでのせるダメカンの数は4個になる。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 558136,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ゴルバット",
+	},
+
+	retreat: 0,
+	regulationMark: "C",
+	rarity: "Rare",
+	dexId: [169],
+};
+
+export default card;

--- a/data-asia/SM/SM9b/019.ts
+++ b/data-asia/SM/SM9b/019.ts
@@ -1,0 +1,54 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "スリープ",
+	},
+
+	illustrator: "Miki Tanaka",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Psychic"],
+
+	description: {
+		ja: "レジャー施設の 近くで 姿を 見かける。 その晩 子どもが 見る 楽しいユメを 狙って いるのだ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "さいみんじゅつ" },
+			cost: ["Psychic"],
+			effect: {
+				ja: "相手のバトルポケモンをねむりにする。",
+			},
+		},
+		{
+			name: { ja: "サイコパンチ" },
+			damage: 30,
+			cost: ["Psychic", "Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558137,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [96],
+};
+
+export default card;

--- a/data-asia/SM/SM9b/020.ts
+++ b/data-asia/SM/SM9b/020.ts
@@ -1,0 +1,64 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "スリーパー",
+	},
+
+	illustrator: "sui",
+	category: "Pokemon",
+	hp: 110,
+	types: ["Psychic"],
+
+	description: {
+		ja: "アローラに 暮らす スリーパーの ターゲットは 主に ネッコアラ。 人は あまり 被害に あわない。",
+	},
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "さそうふりこ" },
+			effect: {
+				ja: "このポケモンがいるかぎり、相手のバトルポケモンがきぜつしたとき、自分はコインを1回投げる。オモテなら、次にバトル場に出す相手のベンチポケモンは、このポケモンの持ち主が選ぶ。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "のうをゆさぶる" },
+			damage: "30+",
+			cost: ["Psychic", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手の手札の枚数x10ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558138,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "スリープ",
+	},
+
+	retreat: 2,
+	regulationMark: "C",
+	rarity: "Uncommon",
+	dexId: [97],
+};
+
+export default card;

--- a/data-asia/SM/SM9b/021.ts
+++ b/data-asia/SM/SM9b/021.ts
@@ -1,0 +1,54 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "サンド",
+	},
+
+	illustrator: "Sekio",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Fighting"],
+
+	description: {
+		ja: "雨の 少ない 土地に 棲んでいる。 危険が 迫ると 身体を 丸め 柔らかい お腹を 守るぞ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "もってくる" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札を1枚引く。",
+			},
+		},
+		{
+			name: { ja: "ころがりタックル" },
+			damage: 30,
+			cost: ["Fighting", "Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558139,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [27],
+};
+
+export default card;

--- a/data-asia/SM/SM9b/022.ts
+++ b/data-asia/SM/SM9b/022.ts
@@ -1,0 +1,62 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "サンドパン",
+	},
+
+	illustrator: "Shigenori Negishi",
+	category: "Pokemon",
+	hp: 110,
+	types: ["Fighting"],
+
+	description: {
+		ja: "よく ツメや ツノが 折れてしまう。 折れた ツメや ツノで 土を 耕す 道具が 作られる。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "れんぞくひっかき" },
+			damage: "30×",
+			cost: ["Colorless"],
+			effect: {
+				ja: "コインを4回投げ、オモテの数x30ダメージ。",
+			},
+		},
+		{
+			name: { ja: "すなじごく" },
+			damage: 90,
+			cost: ["Fighting", "Colorless", "Colorless"],
+			effect: {
+				ja: "次の相手の番、このワザを受けたポケモンは、にげられない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558140,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "サンド",
+	},
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Uncommon",
+	dexId: [28],
+};
+
+export default card;

--- a/data-asia/SM/SM9b/023.ts
+++ b/data-asia/SM/SM9b/023.ts
@@ -1,0 +1,54 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "イシツブテ",
+	},
+
+	illustrator: "Sumiyoshi Kizuki",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Fighting"],
+
+	description: {
+		ja: "長く 生きた イシツブテは 角が とれて まんまる。 性格も とても 落ち着いていて 穏やか なのだ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "まるくなる" },
+			cost: ["Fighting"],
+			effect: {
+				ja: "コインを1回投げオモテなら、次の相手の番、このポケモンはワザのダメージを受けない。",
+			},
+		},
+		{
+			name: { ja: "いわおとし" },
+			damage: 40,
+			cost: ["Colorless", "Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558141,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [74],
+};
+
+export default card;

--- a/data-asia/SM/SM9b/024.ts
+++ b/data-asia/SM/SM9b/024.ts
@@ -1,0 +1,59 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ゴローン",
+	},
+
+	illustrator: "Ayaka Yoshida",
+	category: "Pokemon",
+	hp: 110,
+	types: ["Fighting"],
+
+	description: {
+		ja: "崖を 登り 山頂を 目指す。 てっぺんに 着くなり すぐに 来た 山道を 転がり 落ちていく。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "いわころがり" },
+			damage: 50,
+			cost: ["Colorless", "Colorless", "Colorless"],
+		},
+		{
+			name: { ja: "すてみタックル" },
+			damage: 90,
+			cost: ["Fighting", "Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンにも30ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558142,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "イシツブテ",
+	},
+
+	retreat: 4,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [75],
+};
+
+export default card;

--- a/data-asia/SM/SM9b/025.ts
+++ b/data-asia/SM/SM9b/025.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ゴローニャ",
+	},
+
+	illustrator: "Kyoko Umemoto",
+	category: "Pokemon",
+	hp: 180,
+	types: ["Fighting"],
+
+	description: {
+		ja: "年老いると 脱皮 しなくなる。 長く長く 生きた ゴローニャの カラは 苔むしていて 緑だ。",
+	},
+
+	stage: "Stage2",
+
+	attacks: [
+		{
+			name: { ja: "ハードローラー" },
+			damage: 100,
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "このワザのダメージは抵抗力を計算しない。",
+			},
+		},
+		{
+			name: { ja: "ヘビーボンバー 180-" },
+			cost: ["Fighting", "Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンのにげるためのエネルギーの数x20ダメージぶん、このワザのダメージは小さくなる。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 558143,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ゴローン",
+	},
+
+	retreat: 4,
+	regulationMark: "C",
+	rarity: "Rare",
+	dexId: [76],
+};
+
+export default card;

--- a/data-asia/SM/SM9b/026.ts
+++ b/data-asia/SM/SM9b/026.ts
@@ -1,0 +1,54 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "カポエラー",
+	},
+
+	illustrator: "Tomokazu Komiya",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Fighting"],
+
+	description: {
+		ja: "コマのように 回転しながら 戦う。 遠心力の パワーで 破壊力は １０倍だ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "フィニッシュコンボ" },
+			cost: ["Fighting"],
+			effect: {
+				ja: "このワザは、前の自分の番に「サワムラー」が「スペシャルコンボ」を使っていなければ使えない。相手のポケモン全員に、それぞれ60ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+			},
+		},
+		{
+			name: { ja: "かいてんアタック" },
+			damage: 50,
+			cost: ["Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558144,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [237],
+};
+
+export default card;

--- a/data-asia/SM/SM9b/027.ts
+++ b/data-asia/SM/SM9b/027.ts
@@ -1,0 +1,50 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "リオル",
+	},
+
+	illustrator: "Mizue",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Fighting"],
+
+	description: {
+		ja: "波動と 呼ばれる 波を 見て 人や ポケモンの 気持ちを 知る。 危険な 相手には 近付かない。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "フェイント" },
+			damage: 10,
+			cost: ["Colorless"],
+			effect: {
+				ja: "このワザのダメージは抵抗力を計算しない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558145,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [447],
+};
+
+export default card;

--- a/data-asia/SM/SM9b/028.ts
+++ b/data-asia/SM/SM9b/028.ts
@@ -1,0 +1,60 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ツンデツンデ",
+	},
+
+	illustrator: "nagimiso",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Fighting"],
+
+	description: {
+		ja: "ウルトラホールから 出現した。 複数の 生命が 積み上がり １匹を 形成している ようだ。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ストーンフェンス" },
+			effect: {
+				ja: "相手のサイドの残り枚数が3枚以下なら、このポケモンの最大HPは「200」になる。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "やまおとし" },
+			damage: 110,
+			cost: ["Fighting", "Fighting", "Colorless"],
+			effect: {
+				ja: "ウラが出るまでコインを投げ、オモテの数ぶん、相手の山札を上からトラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 558146,
+			},
+		},
+	],
+
+	retreat: 4,
+	regulationMark: "C",
+	rarity: "Rare",
+	dexId: [805],
+};
+
+export default card;

--- a/data-asia/SM/SM9b/029.ts
+++ b/data-asia/SM/SM9b/029.ts
@@ -1,0 +1,60 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ルカリオ&メルメタルGX",
+	},
+
+	illustrator: "Mitsuhiro Arita",
+	category: "Pokemon",
+	hp: 260,
+	types: ["Metal"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "こうてつのこぶし" },
+			damage: 50,
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "自分の山札にある[鋼]エネルギーを1枚、このポケモンにつける。そして山札を切る。",
+			},
+		},
+		{
+			name: { ja: "ヘビーインパクト" },
+			damage: 150,
+			cost: ["Metal", "Metal", "Colorless", "Colorless"],
+		},
+		{
+			name: { ja: "フルメタルウォールGX" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "この対戦が終わるまで、自分の[鋼]ポケモン全員が、相手のポケモンから受けるワザのダメージは、すべて「-30」される。追加でエネルギーが1個ついているなら、相手のバトルポケモンについているエネルギーを、すべてトラッシュする。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 558147,
+			},
+		},
+	],
+
+	retreat: 3,
+	regulationMark: "C",
+	rarity: "Double rare",
+	dexId: [448, 809],
+
+	suffix: "TAG TEAM-GX",
+};
+
+export default card;

--- a/data-asia/SM/SM9b/030.ts
+++ b/data-asia/SM/SM9b/030.ts
@@ -1,0 +1,47 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アローラディグダ",
+	},
+
+	illustrator: "Atsuko Nishida",
+	category: "Pokemon",
+	hp: 50,
+	types: ["Metal"],
+
+	description: {
+		ja: "溶岩質の 地面も グングン 掘り進むほど パワフルだが なかなか 姿を 見せないぞ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ぶつかる" },
+			damage: 10,
+			cost: [],
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558148,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [50],
+};
+
+export default card;

--- a/data-asia/SM/SM9b/031.ts
+++ b/data-asia/SM/SM9b/031.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アローラダグトリオ",
+	},
+
+	illustrator: "SATOSHI NAKAI",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Metal"],
+
+	description: {
+		ja: "金属質の 髭は 重いので 素早さは いまいちだが 硬い 岩盤も 掘りぬくパワーを 持つ。",
+	},
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ヘアーウォール" },
+			effect: {
+				ja: "このポケモンがいるかぎり、自分の[鋼]ポケモン全員が、相手のポケモンから受けるワザのダメージは「-10」される。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ぶちかます" },
+			damage: 40,
+			cost: ["Metal", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558149,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "アローラディグダ",
+	},
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Uncommon",
+	dexId: [51],
+};
+
+export default card;

--- a/data-asia/SM/SM9b/032.ts
+++ b/data-asia/SM/SM9b/032.ts
@@ -1,0 +1,54 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ココドラ",
+	},
+
+	illustrator: "Ken Sugimori",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Metal"],
+
+	description: {
+		ja: "普段は 山奥で 暮らしているが お腹が すくと ふもとに 現われ 線路や 車を 食べてしまう。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "こうちょく" },
+			cost: ["Metal"],
+			effect: {
+				ja: "次の相手の番、このポケモンが受けるワザのダメージは「-30」される。",
+			},
+		},
+		{
+			name: { ja: "メタルクロー" },
+			damage: 20,
+			cost: ["Metal", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558150,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [304],
+};
+
+export default card;

--- a/data-asia/SM/SM9b/033.ts
+++ b/data-asia/SM/SM9b/033.ts
@@ -1,0 +1,58 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "コドラ",
+	},
+
+	illustrator: "Suwama Chiaki",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Metal"],
+
+	description: {
+		ja: "鉄鉱石が 大好物。 鋼の 体を ぶつけ合って 縄張り 争いを する。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "こうちょく" },
+			cost: ["Metal"],
+			effect: {
+				ja: "次の相手の番、このポケモンが受けるワザのダメージは「-30」される。",
+			},
+		},
+		{
+			name: { ja: "ずつき" },
+			damage: 70,
+			cost: ["Metal", "Metal", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558151,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ココドラ",
+	},
+
+	retreat: 3,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [305],
+};
+
+export default card;

--- a/data-asia/SM/SM9b/034.ts
+++ b/data-asia/SM/SM9b/034.ts
@@ -1,0 +1,62 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ボスゴドラ",
+	},
+
+	illustrator: "Satoshi Shirai",
+	category: "Pokemon",
+	hp: 170,
+	types: ["Metal"],
+
+	description: {
+		ja: "山を まるごと 縄張りに する。 傷が 多い ボスゴドラほど 戦っているので 侮れない。",
+	},
+
+	stage: "Stage2",
+
+	attacks: [
+		{
+			name: { ja: "ガチガチプレス" },
+			damage: 80,
+			cost: ["Metal", "Colorless", "Colorless"],
+			effect: {
+				ja: "次の相手の番、このポケモンがワザのダメージを受けたとき、ワザを使ったポケモンにダメカンを8個のせる。",
+			},
+		},
+		{
+			name: { ja: "ギガインパクト" },
+			damage: 160,
+			cost: ["Metal", "Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "次の自分の番、このポケモンはワザが使えない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558152,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "コドラ",
+	},
+
+	retreat: 4,
+	regulationMark: "C",
+	rarity: "Uncommon",
+	dexId: [306],
+};
+
+export default card;

--- a/data-asia/SM/SM9b/035.ts
+++ b/data-asia/SM/SM9b/035.ts
@@ -1,0 +1,59 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ルカリオ",
+	},
+
+	illustrator: "Midori Harada",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Metal"],
+
+	description: {
+		ja: "精神を 集中して 放つ 波動と 呼ばれる 不思議な 波は 大岩をも 粉々に 砕く。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "ローキック" },
+			damage: 40,
+			cost: ["Colorless"],
+		},
+		{
+			name: { ja: "ラッシュアップ" },
+			damage: "60+",
+			cost: ["Metal", "Metal"],
+			effect: {
+				ja: "この番、手札からこのポケモンに「ポケモンのどうぐ」をつけていたなら、70ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 558153,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "リオル",
+	},
+
+	retreat: 2,
+	regulationMark: "C",
+	rarity: "Rare",
+	dexId: [448],
+};
+
+export default card;

--- a/data-asia/SM/SM9b/036.ts
+++ b/data-asia/SM/SM9b/036.ts
@@ -1,0 +1,60 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ゲノセクト",
+	},
+
+	illustrator: "Anesaki Dynamic",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Metal"],
+
+	description: {
+		ja: "プラズマ団によって 改造された 古代の むしポケモン。 背中の 大砲が パワーアップした。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "こうそくひこうけいたい" },
+			effect: {
+				ja: "相手の場に「ポケモンGX・EX」がいるなら、このポケモンのにげるためのエネルギーは、すべてなくなる。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "スプリットビーム" },
+			damage: 30,
+			cost: ["Metal", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のベンチポケモン2匹にも、それぞれ30ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558154,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "C",
+	rarity: "Uncommon",
+	dexId: [649],
+};
+
+export default card;

--- a/data-asia/SM/SM9b/037.ts
+++ b/data-asia/SM/SM9b/037.ts
@@ -1,0 +1,50 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "メルタン",
+	},
+
+	illustrator: "Kouki Saitou",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Metal"],
+
+	description: {
+		ja: "とろりと 溶けた 鋼の 体。 地中の 鉄分や 金属を 溶かして 吸収する。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "はがねとかし" },
+			damage: "10+",
+			cost: ["Metal"],
+			effect: {
+				ja: "相手のバトルポケモンが[鋼]ポケモンなら、40ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558155,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [808],
+};
+
+export default card;

--- a/data-asia/SM/SM9b/038.ts
+++ b/data-asia/SM/SM9b/038.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "メルメタル",
+	},
+
+	illustrator: "Kouki Saitou",
+	category: "Pokemon",
+	hp: 150,
+	types: ["Metal"],
+
+	description: {
+		ja: "鉄を 産み出す 力を 持つと 崇められていた。 ３０００年の 時を 経て なぜか 蘇った。",
+	},
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "メタルイーター" },
+			effect: {
+				ja: "自分の番に1回使える。自分の手札にある[鋼]ポケモンを1枚トラッシュする。その後、このポケモンのHPを「100」回復する。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ヘビーインパクト" },
+			damage: 130,
+			cost: ["Metal", "Colorless", "Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 558156,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "メルタン",
+	},
+
+	retreat: 4,
+	regulationMark: "C",
+	rarity: "Rare",
+	dexId: [809],
+};
+
+export default card;

--- a/data-asia/SM/SM9b/039.ts
+++ b/data-asia/SM/SM9b/039.ts
@@ -1,0 +1,52 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "オニスズメ",
+	},
+
+	illustrator: "tetsuya koizumi",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Colorless"],
+
+	description: {
+		ja: "自分のテリトリーを 守るためなら 大きな ポケモンが 相手でも 向かっていく 向こう見ずな 性質。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "かっくう" },
+			damage: 10,
+			cost: ["Colorless"],
+		},
+		{
+			name: { ja: "スピードひこう" },
+			damage: 20,
+			cost: ["Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558157,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [21],
+};
+
+export default card;

--- a/data-asia/SM/SM9b/040.ts
+++ b/data-asia/SM/SM9b/040.ts
@@ -1,0 +1,54 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "オニドリル",
+	},
+
+	illustrator: "kawayoo",
+	category: "Pokemon",
+	hp: 100,
+	types: ["Colorless"],
+
+	description: {
+		ja: "オニドリルの 縄張りで 食べ物を 持って 歩くのは 危険だ。 あっという 間に かっさらわれるぞ。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "ドリルライナーダブル" },
+			damage: 70,
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "コインを1回投げオモテなら、相手のバトルポケモンについているエネルギーを、2個トラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558158,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "オニスズメ",
+	},
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [22],
+};
+
+export default card;

--- a/data-asia/SM/SM9b/041.ts
+++ b/data-asia/SM/SM9b/041.ts
@@ -1,0 +1,56 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ニャルマー",
+	},
+
+	illustrator: "sowsow",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Colorless"],
+
+	description: {
+		ja: "気に入らないと ツメを 立てるが たまに のどを 鳴らして 甘える 性格が 一部に 大人気だ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ねこびより" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札を1枚引く。その後、このポケモンをねむりにする。",
+			},
+		},
+		{
+			name: { ja: "びょんびょんテール" },
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手の「ポケモンGX・EX」1匹に、60ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558159,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Common",
+	dexId: [431],
+};
+
+export default card;

--- a/data-asia/SM/SM9b/042.ts
+++ b/data-asia/SM/SM9b/042.ts
@@ -1,0 +1,59 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ブニャット",
+	},
+
+	illustrator: "Tomokazu Komiya",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Colorless"],
+
+	description: {
+		ja: "ほかの ポケモンの 住処でも 居心地が 良ければ 居座って 自分の 住処に してしまう。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "ドラネコダッシュ" },
+			damage: 30,
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "相手の手札からオモテを見ないで、1枚トラッシュする。この番、このポケモンが「ニャルマー」から進化していたなら、さらに1枚トラッシュする。",
+			},
+		},
+		{
+			name: { ja: "つきたおし" },
+			damage: 80,
+			cost: ["Colorless", "Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558160,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ニャルマー",
+	},
+
+	retreat: 3,
+	regulationMark: "C",
+	rarity: "Uncommon",
+	dexId: [432],
+};
+
+export default card;

--- a/data-asia/SM/SM9b/043.ts
+++ b/data-asia/SM/SM9b/043.ts
@@ -1,0 +1,65 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "テッカグヤGX",
+	},
+
+	illustrator: "PLANETA Igarashi",
+	category: "Pokemon",
+	hp: 200,
+	types: ["Colorless"],
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "フォースキャンセラー" },
+			effect: {
+				ja: "このポケモンがバトル場にいるかぎり、自分のポケモン全員は、相手のポケモンが使うGXワザのダメージや効果を受けない。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "パワーサイクロン" },
+			damage: 110,
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンについているエネルギーを1個、ベンチポケモンにつけ替える。",
+			},
+		},
+		{
+			name: { ja: "ディスカバリーGX" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分のサイドを数えたあと、すべて手札に加える。その後、山札の上から、加えた枚数ぶんのカードを、サイドとして置く。数えた枚数ぶんのサイドを置けないなら、このワザは失敗。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 558161,
+			},
+		},
+	],
+
+	retreat: 4,
+	regulationMark: "C",
+	rarity: "Double rare",
+	dexId: [797],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM9b/044.ts
+++ b/data-asia/SM/SM9b/044.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "退化スプレーZ",
+	},
+
+	illustrator: "Toyste Beach",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の進化しているポケモンを1匹選び、そのポケモンの上から「進化カード」を好きなだけはがして退化させる。はがしたカードは、山札にもどして切る。［退化したポケモンは、その番に進化できない。］",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558162,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	regulationMark: "C",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM9b/045.ts
+++ b/data-asia/SM/SM9b/045.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ビーストブリンガー",
+	},
+
+	illustrator: "Ayaka Yoshida",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分のサイドの残り枚数が6枚のとき、このカードをつけている「ウルトラビースト」のワザのダメージで、相手のバトル場の「ポケモンGX・EX」がきぜつしたなら、サイドを1枚多くとる。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558163,
+			},
+		},
+	],
+
+	trainerType: "Tool",
+	regulationMark: "C",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM9b/046.ts
+++ b/data-asia/SM/SM9b/046.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "メタルコアバリア",
+	},
+
+	illustrator: "Studio Bora Inc.",
+	category: "Trainer",
+
+	effect: {
+		ja: "ポケモンについているこのカードは、相手の番の終わりにトラッシュする。 このカードをつけているポケモンが、相手のポケモンから受けるワザのダメージは「-70」される。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558164,
+			},
+		},
+	],
+
+	trainerType: "Tool",
+	regulationMark: "C",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM9b/047.ts
+++ b/data-asia/SM/SM9b/047.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ウルトラフォレストのかみつかい",
+	},
+
+	illustrator: "Masakazu Fukuda",
+	category: "Trainer",
+
+	effect: {
+		ja: "この番、自分の「ウルトラビースト」が使うワザのダメージは、相手のバトルポケモンにかかっている効果を計算しない。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558165,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "C",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM9b/048.ts
+++ b/data-asia/SM/SM9b/048.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ブルーの探索",
+	},
+
+	illustrator: "Naoki Saito",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードは、自分の場に特性を持つポケモンがいるなら、使えない。自分の山札にあるトレーナ−ズを2枚まで、相手に見せてから、手札に加える。そして山札を切る。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558166,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "C",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM9b/049.ts
+++ b/data-asia/SM/SM9b/049.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "マーレイン",
+	},
+
+	illustrator: "Ken Sugimori",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードは、自分の手札にある[鋼]エネルギーを2枚トラッシュしなければ使えない。自分のトラッシュにあるトレーナーズを1枚、相手に見せてから、山札にもどして切る。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558167,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "C",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM9b/050.ts
+++ b/data-asia/SM/SM9b/050.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "無人発電所",
+	},
+
+	illustrator: "aky CG Works",
+	category: "Trainer",
+
+	effect: {
+		ja: "おたがいの場の「ポケモンGX・EX」の特性は、すべてなくなる。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 558168,
+			},
+		},
+	],
+
+	trainerType: "Stadium",
+	regulationMark: "C",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SM/SM9b/051.ts
+++ b/data-asia/SM/SM9b/051.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ハイパーボール",
+	},
+
+	illustrator: "Ryo Ueda",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードは、自分の手札を2枚トラッシュしなければ使えない。自分の山札からポケモンを1枚選び、相手に見せてから、手札に加える。そして山札を切る。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 558169,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	regulationMark: "A",
+	rarity: "Rare Holo",
+};
+
+export default card;

--- a/data-asia/SM/SM9b/052.ts
+++ b/data-asia/SM/SM9b/052.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ビーストリング",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードは、相手のサイドの残り枚数が、4枚または3枚でなければ使えない。自分の山札にある基本エネルギーを2枚まで、自分の「ウルトラビースト」1匹につける。そして山札を切る。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 558170,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	regulationMark: "B",
+	rarity: "Rare Holo",
+};
+
+export default card;

--- a/data-asia/SM/SM9b/053.ts
+++ b/data-asia/SM/SM9b/053.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "鋼鉄のフライパン",
+	},
+
+	illustrator: "Ryo Ueda",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードをつけているポケモンは、相手のポケモンから受けるワザのダメージが「-30」され、弱点もなくなる。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 558171,
+			},
+		},
+	],
+
+	trainerType: "Tool",
+	regulationMark: "B",
+	rarity: "Rare Holo",
+};
+
+export default card;

--- a/data-asia/SM/SM9b/054.ts
+++ b/data-asia/SM/SM9b/054.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アセロラ",
+	},
+
+	illustrator: "Hideki Ishikawa",
+	category: "Trainer",
+
+	effect: {
+		ja: "ダメカンがのっている自分のポケモン1匹と、ついているすべてのカードを、手札にもどす。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 558172,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "A",
+	rarity: "Rare Holo",
+};
+
+export default card;

--- a/data-asia/SM/SM9b/055.ts
+++ b/data-asia/SM/SM9b/055.ts
@@ -1,0 +1,64 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "フェローチェ&マッシブーンGX",
+	},
+
+	illustrator: "aky CG Works",
+	category: "Pokemon",
+	hp: 260,
+	types: ["Grass"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ジェットパンチ" },
+			damage: 30,
+			cost: ["Grass"],
+			effect: {
+				ja: "相手のベンチポケモン1匹にも、30ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+			},
+		},
+		{
+			name: { ja: "エレガントソール" },
+			damage: 190,
+			cost: ["Grass", "Grass", "Colorless"],
+			effect: {
+				ja: "次の自分の番、このポケモンの「エレガントソール」のダメージは「60」になる。",
+			},
+		},
+		{
+			name: { ja: "ビーストゲームGX" },
+			damage: 50,
+			cost: ["Grass"],
+			effect: {
+				ja: "このワザのダメージで、相手のポケモンがきぜつしたなら、サイドを1枚多くとる。追加でエネルギーが7個ついているなら、多くとる枚数は3枚になる。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 558173,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "C",
+	rarity: "Ultra Rare",
+	dexId: [795, 794],
+
+	suffix: "TAG TEAM-GX",
+};
+
+export default card;

--- a/data-asia/SM/SM9b/056.ts
+++ b/data-asia/SM/SM9b/056.ts
@@ -1,0 +1,64 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "フェローチェ&マッシブーンGX",
+	},
+
+	illustrator: "kirisAki",
+	category: "Pokemon",
+	hp: 260,
+	types: ["Grass"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ジェットパンチ" },
+			damage: 30,
+			cost: ["Grass"],
+			effect: {
+				ja: "相手のベンチポケモン1匹にも、30ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+			},
+		},
+		{
+			name: { ja: "エレガントソール" },
+			damage: 190,
+			cost: ["Grass", "Grass", "Colorless"],
+			effect: {
+				ja: "次の自分の番、このポケモンの「エレガントソール」のダメージは「60」になる。",
+			},
+		},
+		{
+			name: { ja: "ビーストゲームGX" },
+			damage: 50,
+			cost: ["Grass"],
+			effect: {
+				ja: "このワザのダメージで、相手のポケモンがきぜつしたなら、サイドを1枚多くとる。追加でエネルギーが7個ついているなら、多くとる枚数は3枚になる。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 558174,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "C",
+	rarity: "Ultra Rare",
+	dexId: [795, 794],
+
+	suffix: "TAG TEAM-GX",
+};
+
+export default card;

--- a/data-asia/SM/SM9b/057.ts
+++ b/data-asia/SM/SM9b/057.ts
@@ -1,0 +1,69 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "カメックスGX",
+	},
+
+	illustrator: "sadaji",
+	category: "Pokemon",
+	hp: 240,
+	types: ["Water"],
+
+	stage: "Stage2",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "かたいこうら" },
+			effect: {
+				ja: "このポケモンが受けるワザのダメージは「-30」される。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ロケットスプラッシュ" },
+			damage: "60×",
+			cost: ["Water", "Water"],
+			effect: {
+				ja: "自分の場のポケモンについている[水]エネルギーを好きなだけ山札にもどし、その枚数x60ダメージ。その場合、山札を切る。",
+			},
+		},
+		{
+			name: { ja: "だいほうすいGX" },
+			cost: ["Water"],
+			effect: {
+				ja: "自分の手札にある[水]エネルギーを好きなだけ、自分のポケモンに好きなようにつける。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 558175,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "カメール",
+	},
+
+	retreat: 3,
+	regulationMark: "C",
+	rarity: "Ultra Rare",
+	dexId: [9],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM9b/058.ts
+++ b/data-asia/SM/SM9b/058.ts
@@ -1,0 +1,60 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ルカリオ&メルメタルGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 260,
+	types: ["Metal"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "こうてつのこぶし" },
+			damage: 50,
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "自分の山札にある[鋼]エネルギーを1枚、このポケモンにつける。そして山札を切る。",
+			},
+		},
+		{
+			name: { ja: "ヘビーインパクト" },
+			damage: 150,
+			cost: ["Metal", "Metal", "Colorless", "Colorless"],
+		},
+		{
+			name: { ja: "フルメタルウォールGX" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "この対戦が終わるまで、自分の[鋼]ポケモン全員が、相手のポケモンから受けるワザのダメージは、すべて「-30」される。追加でエネルギーが1個ついているなら、相手のバトルポケモンについているエネルギーを、すべてトラッシュする。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 558176,
+			},
+		},
+	],
+
+	retreat: 3,
+	regulationMark: "C",
+	rarity: "Ultra Rare",
+	dexId: [448, 809],
+
+	suffix: "TAG TEAM-GX",
+};
+
+export default card;

--- a/data-asia/SM/SM9b/059.ts
+++ b/data-asia/SM/SM9b/059.ts
@@ -1,0 +1,60 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ルカリオ&メルメタルGX",
+	},
+
+	illustrator: "nagimiso",
+	category: "Pokemon",
+	hp: 260,
+	types: ["Metal"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "こうてつのこぶし" },
+			damage: 50,
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "自分の山札にある[鋼]エネルギーを1枚、このポケモンにつける。そして山札を切る。",
+			},
+		},
+		{
+			name: { ja: "ヘビーインパクト" },
+			damage: 150,
+			cost: ["Metal", "Metal", "Colorless", "Colorless"],
+		},
+		{
+			name: { ja: "フルメタルウォールGX" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "この対戦が終わるまで、自分の[鋼]ポケモン全員が、相手のポケモンから受けるワザのダメージは、すべて「-30」される。追加でエネルギーが1個ついているなら、相手のバトルポケモンについているエネルギーを、すべてトラッシュする。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 558177,
+			},
+		},
+	],
+
+	retreat: 3,
+	regulationMark: "C",
+	rarity: "Ultra Rare",
+	dexId: [448, 809],
+
+	suffix: "TAG TEAM-GX",
+};
+
+export default card;

--- a/data-asia/SM/SM9b/060.ts
+++ b/data-asia/SM/SM9b/060.ts
@@ -1,0 +1,65 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "テッカグヤGX",
+	},
+
+	illustrator: "aky CG Works",
+	category: "Pokemon",
+	hp: 200,
+	types: ["Colorless"],
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "フォースキャンセラー" },
+			effect: {
+				ja: "このポケモンがバトル場にいるかぎり、自分のポケモン全員は、相手のポケモンが使うGXワザのダメージや効果を受けない。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "パワーサイクロン" },
+			damage: 110,
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンについているエネルギーを1個、ベンチポケモンにつけ替える。",
+			},
+		},
+		{
+			name: { ja: "ディスカバリーGX" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分のサイドを数えたあと、すべて手札に加える。その後、山札の上から、加えた枚数ぶんのカードを、サイドとして置く。数えた枚数ぶんのサイドを置けないなら、このワザは失敗。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 558178,
+			},
+		},
+	],
+
+	retreat: 4,
+	regulationMark: "C",
+	rarity: "Ultra Rare",
+	dexId: [797],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM9b/061.ts
+++ b/data-asia/SM/SM9b/061.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ブルーの探索",
+	},
+
+	illustrator: "Naoki Saito",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードは、自分の場に特性を持つポケモンがいるなら、使えない。自分の山札にあるトレーナ−ズを2枚まで、相手に見せてから、手札に加える。そして山札を切る。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 558179,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "C",
+	rarity: "Ultra Rare",
+};
+
+export default card;

--- a/data-asia/SM/SM9b/062.ts
+++ b/data-asia/SM/SM9b/062.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "マーレイン",
+	},
+
+	illustrator: "Masakazu Fukuda",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードは、自分の手札にある[鋼]エネルギーを2枚トラッシュしなければ使えない。自分のトラッシュにあるトレーナーズを1枚、相手に見せてから、山札にもどして切る。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 558180,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "C",
+	rarity: "Ultra Rare",
+};
+
+export default card;

--- a/data-asia/SM/SM9b/063.ts
+++ b/data-asia/SM/SM9b/063.ts
@@ -1,0 +1,64 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "フェローチェ&マッシブーンGX",
+	},
+
+	illustrator: "",
+	category: "Pokemon",
+	hp: 260,
+	types: ["Grass"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ジェットパンチ" },
+			damage: 30,
+			cost: ["Grass"],
+			effect: {
+				ja: "相手のベンチポケモン1匹にも、30ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+			},
+		},
+		{
+			name: { ja: "エレガントソール" },
+			damage: 190,
+			cost: ["Grass", "Grass", "Colorless"],
+			effect: {
+				ja: "次の自分の番、このポケモンの「エレガントソール」のダメージは「60」になる。",
+			},
+		},
+		{
+			name: { ja: "ビーストゲームGX" },
+			damage: 50,
+			cost: ["Grass"],
+			effect: {
+				ja: "このワザのダメージで、相手のポケモンがきぜつしたなら、サイドを1枚多くとる。追加でエネルギーが7個ついているなら、多くとる枚数は3枚になる。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 558181,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "C",
+	rarity: "Hyper rare",
+	dexId: [795, 794],
+
+	suffix: "TAG TEAM-GX",
+};
+
+export default card;

--- a/data-asia/SM/SM9b/064.ts
+++ b/data-asia/SM/SM9b/064.ts
@@ -1,0 +1,69 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "カメックスGX",
+	},
+
+	illustrator: "",
+	category: "Pokemon",
+	hp: 240,
+	types: ["Water"],
+
+	stage: "Stage2",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "かたいこうら" },
+			effect: {
+				ja: "このポケモンが受けるワザのダメージは「-30」される。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ロケットスプラッシュ" },
+			damage: "60×",
+			cost: ["Water", "Water"],
+			effect: {
+				ja: "自分の場のポケモンについている[水]エネルギーを好きなだけ山札にもどし、その枚数x60ダメージ。その場合、山札を切る。",
+			},
+		},
+		{
+			name: { ja: "だいほうすいGX" },
+			cost: ["Water"],
+			effect: {
+				ja: "自分の手札にある[水]エネルギーを好きなだけ、自分のポケモンに好きなようにつける。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 558182,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "カメール",
+	},
+
+	retreat: 3,
+	regulationMark: "C",
+	rarity: "Hyper rare",
+	dexId: [9],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM9b/065.ts
+++ b/data-asia/SM/SM9b/065.ts
@@ -1,0 +1,60 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ルカリオ&メルメタルGX",
+	},
+
+	illustrator: "",
+	category: "Pokemon",
+	hp: 260,
+	types: ["Metal"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "こうてつのこぶし" },
+			damage: 50,
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "自分の山札にある[鋼]エネルギーを1枚、このポケモンにつける。そして山札を切る。",
+			},
+		},
+		{
+			name: { ja: "ヘビーインパクト" },
+			damage: 150,
+			cost: ["Metal", "Metal", "Colorless", "Colorless"],
+		},
+		{
+			name: { ja: "フルメタルウォールGX" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "この対戦が終わるまで、自分の[鋼]ポケモン全員が、相手のポケモンから受けるワザのダメージは、すべて「-30」される。追加でエネルギーが1個ついているなら、相手のバトルポケモンについているエネルギーを、すべてトラッシュする。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 558183,
+			},
+		},
+	],
+
+	retreat: 3,
+	regulationMark: "C",
+	rarity: "Hyper rare",
+	dexId: [448, 809],
+
+	suffix: "TAG TEAM-GX",
+};
+
+export default card;

--- a/data-asia/SM/SM9b/066.ts
+++ b/data-asia/SM/SM9b/066.ts
@@ -1,0 +1,65 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "テッカグヤGX",
+	},
+
+	illustrator: "",
+	category: "Pokemon",
+	hp: 200,
+	types: ["Colorless"],
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "フォースキャンセラー" },
+			effect: {
+				ja: "このポケモンがバトル場にいるかぎり、自分のポケモン全員は、相手のポケモンが使うGXワザのダメージや効果を受けない。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "パワーサイクロン" },
+			damage: 110,
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンについているエネルギーを1個、ベンチポケモンにつけ替える。",
+			},
+		},
+		{
+			name: { ja: "ディスカバリーGX" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分のサイドを数えたあと、すべて手札に加える。その後、山札の上から、加えた枚数ぶんのカードを、サイドとして置く。数えた枚数ぶんのサイドを置けないなら、このワザは失敗。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 558184,
+			},
+		},
+	],
+
+	retreat: 4,
+	regulationMark: "C",
+	rarity: "Hyper rare",
+	dexId: [797],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SM/SM9b/067.ts
+++ b/data-asia/SM/SM9b/067.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ビーストブリンガー",
+	},
+
+	illustrator: "",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分のサイドの残り枚数が6枚のとき、このカードをつけている「ウルトラビースト」のワザのダメージで、相手のバトル場の「ポケモンGX・EX」がきぜつしたなら、サイドを1枚多くとる。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 558185,
+			},
+		},
+	],
+
+	trainerType: "Tool",
+	regulationMark: "C",
+	rarity: "Secret Rare",
+};
+
+export default card;

--- a/data-asia/SM/SM9b/068.ts
+++ b/data-asia/SM/SM9b/068.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "メタルコアバリア",
+	},
+
+	illustrator: "",
+	category: "Trainer",
+
+	effect: {
+		ja: "ポケモンについているこのカードは、相手の番の終わりにトラッシュする。 このカードをつけているポケモンが、相手のポケモンから受けるワザのダメージは「-70」される。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 558186,
+			},
+		},
+	],
+
+	trainerType: "Tool",
+	regulationMark: "C",
+	rarity: "Secret Rare",
+};
+
+export default card;

--- a/data-asia/SM/SM9b/069.ts
+++ b/data-asia/SM/SM9b/069.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SM9b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "テンガン山",
+	},
+
+	illustrator: "",
+	category: "Trainer",
+
+	effect: {
+		ja: "おたがいのプレイヤーは、自分の番に1回、自分のトラッシュにある[鋼]エネルギーを2枚、相手に見せてから、手札に加えてよい。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 558187,
+			},
+		},
+	],
+
+	trainerType: "Stadium",
+	regulationMark: "B",
+	rarity: "Secret Rare",
+};
+
+export default card;


### PR DESCRIPTION
## What

Adds the complete Japanese set **SM9b フルメタルウォール (Full Metal Force)**, released 2019-02-01:

- `data-asia/SM/SM9b/001.ts` … `069.ts` — all 69 cards (54 regular + 15 secret rares: 8 SR, 3 Secret Rare, 4 UR)
- the set definition `data-asia/SM/SM9b.ts` already existed and is untouched

## Data sources

- **pokemon-card.com** (official database): Japanese names, flavor texts, National Dex numbers, official card count
- **limitlesstcg.com**: full Japanese card text, stages, weaknesses/resistances/retreat, rarities, illustrators, attack costs
- **Cardmarket**: product IDs as `thirdParty.cardmarket` on the variant objects (558119–558187; tcgplayer IDs not available to me)

## Notes

- Follows the file format and conventions of the M-era sets (#1728)
- All 69 files type-check against `interfaces.d.ts` (`tsc --noEmit`)
