### PR TITLE
(data) Update Japanese SV set SV2a Pokémon Card 151

### DIFF
--- a/data-asia/SV/SV2a/001.ts
+++ b/data-asia/SV/SV2a/001.ts
@@ -1,20 +1,17 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV2a"
+import { Card } from "../../../interfaces";
+import Set from "../SV2a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "フシギダネ",
 		'zh-tw': "妙蛙種子",
 		th: "ฟุชิกิดาเนะ",
-		id: "Bulbasaur"
+		id: "Bulbasaur",
 	},
 
 	illustrator: "Yuu Nishida",
-	rarity: "Common",
 	category: "Pokemon",
-	dexId: [1],
 	hp: 70,
 	types: ["Grass"],
 
@@ -22,42 +19,60 @@ const card: Card = {
 		ja: "生まれて しばらくの あいだ 背中の タネに つまった 栄養を とって 育つ。",
 		'zh-tw': "在出生後的一段時間內，牠會吸收背上種子裡 儲存著的營養成長。",
 		th: "ในช่วงเวลาหนึ่งหลังจากเกิดมาแล้ว จะดูดกินสารอาหารที่สะสมไว้ในเมล็ดที่อยู่กลางหลังเพื่อเลี้ยงตัวให้เติบโต",
-		id: "Sesaat setelah dilahirkan, Bulbasaur menggunakan nutrisi yang terkandung dalam biji di punggungnya untuk tumbuh."
+		id: "Sesaat setelah dilahirkan, Bulbasaur menggunakan nutrisi yang terkandung dalam biji di punggungnya untuk tumbuh.",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		cost: ["Grass", "Colorless"],
-
-		name: {
-			ja: "やどりぎのタネ",
-			'zh-tw': "寄生種子",
-			th: "เมล็ดกาฝาก",
-			id: "Bibit Parasit"
+	attacks: [
+		{
+			name: {
+				ja: "やどりぎのタネ",
+				'zh-tw': "寄生種子",
+				th: "เมล็ดกาฝาก",
+				id: "Bibit Parasit",
+			},
+			damage: 20,
+			cost: ["Grass", "Colorless"],
+			effect: {
+				ja: "このポケモンのHPを「20」回復する。",
+				'zh-tw': "將這隻寶可夢恢復「20」HP。",
+				th: "ฟื้นฟู HP ของโปเกมอนนี้ [20]",
+				id: "Pulihkan HP Pokémon ini sejumlah 20.",
+			},
 		},
+	],
 
-		damage: 20,
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
 
-		effect: {
-			ja: "このポケモンのHPを「20」回復する。",
-			'zh-tw': "將這隻寶可夢恢復「20」HP。",
-			th: "ฟื้นฟู HP ของโปเกมอนนี้ [20]",
-			id: "Pulihkan HP Pokémon ini sejumlah 20."
-		}
-	}],
-
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 719442,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				cardmarket: 837230,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				cardmarket: 837231,
+			},
+		},
+	],
 
 	retreat: 2,
 	regulationMark: "G",
+	rarity: "Common",
+	dexId: [1],
+};
 
-	thirdParty: {
-		cardmarket: 719442
-	}
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV2a/002.ts
+++ b/data-asia/SV/SV2a/002.ts
@@ -1,20 +1,17 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV2a"
+import { Card } from "../../../interfaces";
+import Set from "../SV2a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "フシギソウ",
 		'zh-tw': "妙蛙草",
 		th: "ฟุชิกิโซ",
-		id: "Ivysaur"
+		id: "Ivysaur",
 	},
 
 	illustrator: "Yuu Nishida",
-	rarity: "Uncommon",
 	category: "Pokemon",
-	dexId: [2],
 	hp: 100,
 	types: ["Grass"],
 
@@ -22,53 +19,74 @@ const card: Card = {
 		ja: "太陽の 光を 浴びるほど 体に 力が わいて 背中の つぼみが 育っていく。",
 		'zh-tw': "沐浴在陽光下越久，身體內會湧出越多力量， 背上的花苞也會漸漸成長。",
 		th: "ยิ่งอาบแดดมากก็จะยิ่งเกิดพลังมากขึ้นทำให้ดอกตูมบนหลังเติบโต",
-		id: "Mandi cahaya matahari membuat Ivysaur makin kuat dan menumbuhkan kuncup di punggungnya."
+		id: "Mandi cahaya matahari membuat Ivysaur makin kuat dan menumbuhkan kuncup di punggungnya.",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		cost: ["Grass", "Colorless"],
-
-		name: {
-			ja: "やどりぎのタネ",
-			'zh-tw': "寄生種子",
-			th: "เมล็ดกาฝาก",
-			id: "Bibit Parasit"
+	attacks: [
+		{
+			name: {
+				ja: "やどりぎのタネ",
+				'zh-tw': "寄生種子",
+				th: "เมล็ดกาฝาก",
+				id: "Bibit Parasit",
+			},
+			damage: 30,
+			cost: ["Grass", "Colorless"],
+			effect: {
+				ja: "このポケモンのHPを「20」回復する。",
+				'zh-tw': "將這隻寶可夢恢復「20」HP。",
+				th: "ฟื้นฟู HP ของโปเกมอนนี้ [20]",
+				id: "Pulihkan HP Pokémon ini sejumlah 20.",
+			},
 		},
-
-		damage: 30,
-
-		effect: {
-			ja: "このポケモンのHPを「20」回復する。",
-			'zh-tw': "將這隻寶可夢恢復「20」HP。",
-			th: "ฟื้นฟู HP ของโปเกมอนนี้ [20]",
-			id: "Pulihkan HP Pokémon ini sejumlah 20."
-		}
-	}, {
-		cost: ["Grass", "Grass", "Colorless"],
-
-		name: {
-			ja: "つるのムチ",
-			'zh-tw': "藤鞭",
-			th: "แส้เถาวัลย์",
-			id: "Cambuk Jalar"
+		{
+			name: {
+				ja: "つるのムチ",
+				'zh-tw': "藤鞭",
+				th: "แส้เถาวัลย์",
+				id: "Cambuk Jalar",
+			},
+			damage: 80,
+			cost: ["Grass", "Grass", "Colorless"],
 		},
+	],
 
-		damage: 80
-	}],
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 719444,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				cardmarket: 837232,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				cardmarket: 837233,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "フシギダネ",
+	},
 
 	retreat: 3,
 	regulationMark: "G",
+	rarity: "Uncommon",
+	dexId: [2],
+};
 
-	thirdParty: {
-		cardmarket: 719444
-	}
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV2a/003.ts
+++ b/data-asia/SV/SV2a/003.ts
@@ -1,73 +1,81 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV2a"
+import { Card } from "../../../interfaces";
+import Set from "../SV2a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "フシギバナex",
 		'zh-tw': "妙蛙花ex",
 		th: "ฟุชิกิบานะex",
-		id: "Venusaur ex"
+		id: "Venusaur ex",
 	},
 
 	illustrator: "5ban Graphics",
-	rarity: "Double rare",
 	category: "Pokemon",
 	hp: 340,
 	types: ["Grass"],
+
 	stage: "Stage2",
-	suffix: "EX",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			ja: "やすらぎのはな",
-			'zh-tw': "平和之花",
-			th: "ดอกไม้สงบใจ",
-			id: "Bunga Ketenangan"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "やすらぎのはな",
+				'zh-tw': "平和之花",
+				th: "ดอกไม้สงบใจ",
+				id: "Bunga Ketenangan",
+			},
+			effect: {
+				ja: "このポケモンがバトル場にいるなら、自分の番に1回使える。自分のポケモン1匹のHPを「60」回復する。",
+				'zh-tw': "若這隻寶可夢在戰鬥場上，則在自己的回合時可使用1次。將自己的1隻寶可夢恢復「60」HP。",
+				th: "ถ้าโปเกมอนนี้อยู่บนตำแหน่งต่อสู้ ใช้ได้ 1 ครั้งในเทิร์นฝ่ายเรา ฟื้นฟู HP ของโปเกมอนฝ่ายเรา 1 ตัว [60]",
+				id: "Dapat digunakan 1 kali pada giliran sendiri jika Pokémon ini ada di Arena Bertarung. Pulihkan HP 1 Pokémon sendiri sejumlah 60.",
+			},
 		},
+	],
 
-		effect: {
-			ja: "このポケモンがバトル場にいるなら、自分の番に1回使える。自分のポケモン1匹のHPを「60」回復する。",
-			'zh-tw': "若這隻寶可夢在戰鬥場上，則在自己的回合時可使用1次。將自己的1隻寶可夢恢復「60」HP。",
-			th: "ถ้าโปเกมอนนี้อยู่บนตำแหน่งต่อสู้ ใช้ได้ 1 ครั้งในเทิร์นฝ่ายเรา ฟื้นฟู HP ของโปเกมอนฝ่ายเรา 1 ตัว [60]",
-			id: "Dapat digunakan 1 kali pada giliran sendiri jika Pokémon ini ada di Arena Bertarung. Pulihkan HP 1 Pokémon sendiri sejumlah 60."
-		}
-	}],
-
-	attacks: [{
-		cost: ["Grass", "Grass", "Colorless"],
-
-		name: {
-			ja: "もうどくウィップ",
-			'zh-tw': "劇毒鞭打",
-			th: "แส้พิษร้ายแรง",
-			id: "Cambuk Racun Ekstrem"
+	attacks: [
+		{
+			name: {
+				ja: "もうどくウィップ",
+				'zh-tw': "劇毒鞭打",
+				th: "แส้พิษร้ายแรง",
+				id: "Cambuk Racun Ekstrem",
+			},
+			damage: 150,
+			cost: ["Grass", "Grass", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをどくとこんらんにする。",
+				'zh-tw': "將對手的戰鬥寶可夢【中毒】與【混亂】。",
+				th: "ทำให้โปเกมอนบนตำแหน่งต่อสู้ฝ่ายตรงข้ามเป็นสภาวะ[พิษ]และ[สับสน]",
+				id: "Ubah kondisi Pokémon Bertarung lawan menjadi Racun dan Pusing.",
+			},
 		},
+	],
 
-		damage: 150,
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
 
-		effect: {
-			ja: "相手のバトルポケモンをどくとこんらんにする。",
-			'zh-tw': "將對手的戰鬥寶可夢【中毒】與【混亂】。",
-			th: "ทำให้โปเกมอนบนตำแหน่งต่อสู้ฝ่ายตรงข้ามเป็นสภาวะ[พิษ]และ[สับสน]",
-			id: "Ubah kondisi Pokémon Bertarung lawan menjadi Racun dan Pusing."
-		}
-	}],
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 719445,
+			},
+		},
+	],
 
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "フシギソウ",
+	},
 
 	retreat: 4,
 	regulationMark: "G",
+	rarity: "Double rare",
+	dexId: [3],
 
-	thirdParty: {
-		cardmarket: 719445
-	}
-}
+	suffix: "EX",
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV2a/004.ts
+++ b/data-asia/SV/SV2a/004.ts
@@ -1,20 +1,17 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV2a"
+import { Card } from "../../../interfaces";
+import Set from "../SV2a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "ヒトカゲ",
 		'zh-tw': "小火龍",
 		th: "ฮิโตคาเงะ",
-		id: "Charmander"
+		id: "Charmander",
 	},
 
 	illustrator: "GIDORA",
-	rarity: "Common",
 	category: "Pokemon",
-	dexId: [4],
 	hp: 70,
 	types: ["Fire"],
 
@@ -22,51 +19,69 @@ const card: Card = {
 		ja: "生まれたときから しっぽに 炎が ともっている。 炎が 消えたとき その 命は 終わって しまう。",
 		'zh-tw': "從出生時開始尾巴上就有火焰在燃燒。 火焰熄滅時，生命也會結束。",
 		th: "มีหางที่ติดไฟตั้งแต่เกิด หากไฟดับนั่นหมายถึงการจบชีวิต",
-		id: "Sejak lahir, api menyala di ekor Charmander. Hidupnya berakhir saat api tersebut padam."
+		id: "Sejak lahir, api menyala di ekor Charmander. Hidupnya berakhir saat api tersebut padam.",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		cost: ["Fire"],
-
-		name: {
-			ja: "まるやけ",
-			'zh-tw': "全部燒光",
-			th: "เผาเตียน",
-			id: "Bakar Bulat-bulat"
+	attacks: [
+		{
+			name: {
+				ja: "まるやけ",
+				'zh-tw': "全部燒光",
+				th: "เผาเตียน",
+				id: "Bakar Bulat-bulat",
+			},
+			cost: ["Fire"],
+			effect: {
+				ja: "場に出ているスタジアムをトラッシュする。",
+				'zh-tw': "將場上的競技場卡丟棄。",
+				th: "ทิ้งการ์ดสเตเดียมที่วางอยู่บนกระดานที่ตำแหน่งทิ้งการ์ด",
+				id: "Buang Stadium yang ada di Arena ke Trash.",
+			},
 		},
-
-		effect: {
-			ja: "場に出ているスタジアムをトラッシュする。",
-			'zh-tw': "將場上的競技場卡丟棄。",
-			th: "ทิ้งการ์ดสเตเดียมที่วางอยู่บนกระดานที่ตำแหน่งทิ้งการ์ด",
-			id: "Buang Stadium yang ada di Arena ke Trash."
-		}
-	}, {
-		cost: ["Fire", "Fire"],
-
-		name: {
-			ja: "ひをはく",
-			'zh-tw': "吐火",
-			th: "พ่นอัคคี",
-			id: "Memuntahkan Api"
+		{
+			name: {
+				ja: "ひをはく",
+				'zh-tw': "吐火",
+				th: "พ่นอัคคี",
+				id: "Memuntahkan Api",
+			},
+			damage: 30,
+			cost: ["Fire", "Fire"],
 		},
+	],
 
-		damage: 30
-	}],
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Water",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 719446,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				cardmarket: 837234,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				cardmarket: 837235,
+			},
+		},
+	],
 
 	retreat: 1,
 	regulationMark: "G",
+	rarity: "Common",
+	dexId: [4],
+};
 
-	thirdParty: {
-		cardmarket: 719446
-	}
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV2a/005.ts
+++ b/data-asia/SV/SV2a/005.ts
@@ -1,20 +1,17 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV2a"
+import { Card } from "../../../interfaces";
+import Set from "../SV2a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "リザード",
 		'zh-tw': "火恐龍",
 		th: "ลิซาร์โดะ",
-		id: "Charmeleon"
+		id: "Charmeleon",
 	},
 
 	illustrator: "GIDORA",
-	rarity: "Uncommon",
 	category: "Pokemon",
-	dexId: [5],
 	hp: 100,
 	types: ["Fire"],
 
@@ -22,53 +19,74 @@ const card: Card = {
 		ja: "戦いで 気持ちが たかぶると 灼熱の 炎を 吹きながら あたりを 燃やしてまわる。",
 		'zh-tw': "如果牠在戰鬥中亢奮起來，就會噴出灼熱的火焰， 把周圍的東西燒得一乾二淨。",
 		th: "เมื่อตื่นเต้นจากการต่อสู้จะพ่นเปลวเพลิงร้อนแรงแผดเผารอบข้าง",
-		id: "Ketika pertarungan membuat semangat Charmeleon bergejolak, Pokémon ini meniupkan api berpijar dan membakar daerah sekelilingnya."
+		id: "Ketika pertarungan membuat semangat Charmeleon bergejolak, Pokémon ini meniupkan api berpijar dan membakar daerah sekelilingnya.",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		cost: ["Fire"],
-
-		name: {
-			ja: "かえん",
-			'zh-tw': "烈焰",
-			th: "เผาไหม้",
-			id: "Lidah Api"
+	attacks: [
+		{
+			name: {
+				ja: "かえん",
+				'zh-tw': "烈焰",
+				th: "เผาไหม้",
+				id: "Lidah Api",
+			},
+			damage: 20,
+			cost: ["Fire"],
 		},
-
-		damage: 20
-	}, {
-		cost: ["Fire", "Fire", "Fire"],
-
-		name: {
-			ja: "だいもんじ",
-			'zh-tw': "大字爆炎",
-			th: "เพลิงอัคคี",
-			id: "Ledakan Api Besar"
+		{
+			name: {
+				ja: "だいもんじ",
+				'zh-tw': "大字爆炎",
+				th: "เพลิงอัคคี",
+				id: "Ledakan Api Besar",
+			},
+			damage: 90,
+			cost: ["Fire", "Fire", "Fire"],
+			effect: {
+				ja: "このポケモンについているエネルギーを1個選び、トラッシュする。",
+				'zh-tw': "選擇1個這隻寶可夢身上附加的能量，將其丟棄。",
+				th: "เลือกพลังงานที่ติดอยู่กับโปเกมอนนี้ 1 ลูก ทิ้งที่ตำแหน่งทิ้งการ์ด",
+				id: "Pilih 1 Energi yang dikenakan pada Pokémon ini, lalu buang ke Trash.",
+			},
 		},
+	],
 
-		damage: 90,
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
 
-		effect: {
-			ja: "このポケモンについているエネルギーを1個選び、トラッシュする。",
-			'zh-tw': "選擇1個這隻寶可夢身上附加的能量，將其丟棄。",
-			th: "เลือกพลังงานที่ติดอยู่กับโปเกมอนนี้ 1 ลูก ทิ้งที่ตำแหน่งทิ้งการ์ด",
-			id: "Pilih 1 Energi yang dikenakan pada Pokémon ini, lalu buang ke Trash."
-		}
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 719447,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				cardmarket: 837236,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				cardmarket: 837237,
+			},
+		},
+	],
 
-	weaknesses: [{
-		type: "Water",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "ヒトカゲ",
+	},
 
 	retreat: 2,
 	regulationMark: "G",
+	rarity: "Uncommon",
+	dexId: [5],
+};
 
-	thirdParty: {
-		cardmarket: 719447
-	}
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV2a/006.ts
+++ b/data-asia/SV/SV2a/006.ts
@@ -1,73 +1,79 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV2a"
+import { Card } from "../../../interfaces";
+import Set from "../SV2a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "リザードンex",
 		'zh-tw': "噴火龍ex",
 		th: "ลิซาร์ดอนex",
-		id: "Charizard ex"
+		id: "Charizard ex",
 	},
 
 	illustrator: "PLANETA Mochizuki",
-	rarity: "Double rare",
 	category: "Pokemon",
 	hp: 330,
 	types: ["Fire"],
+
 	stage: "Stage2",
-	suffix: "EX",
 
-	attacks: [{
-		cost: ["Fire"],
-
-		name: {
-			ja: "ブレイブウイング",
-			'zh-tw': "無畏之翼",
-			th: "เบรฟวิง",
-			id: "Brave Wing"
+	attacks: [
+		{
+			name: {
+				ja: "ブレイブウイング",
+				'zh-tw': "無畏之翼",
+				th: "เบรฟวิง",
+				id: "Brave Wing",
+			},
+			damage: "60+",
+			cost: ["Fire"],
+			effect: {
+				ja: "このポケモンにダメカンがのっているなら、100ダメージ追加。",
+				'zh-tw': "若這隻寶可夢身上放置有傷害指示物，則增加100點傷害。",
+				th: "ถ้าโปเกมอนนี้มีตัวนับแดเมจวางอยู่ การโจมตีนี้จะเพิ่มแดเมจอีก 100",
+				id: "Jika Pokémon ini memiliki Token Kerusakan, kerusakan yang diberikan bertambah sejumlah 100.",
+			},
 		},
-
-		damage: "60+",
-
-		effect: {
-			ja: "このポケモンにダメカンがのっているなら、100ダメージ追加。",
-			'zh-tw': "若這隻寶可夢身上放置有傷害指示物，則增加100點傷害。",
-			th: "ถ้าโปเกมอนนี้มีตัวนับแดเมจวางอยู่ การโจมตีนี้จะเพิ่มแดเมจอีก 100",
-			id: "Jika Pokémon ini memiliki Token Kerusakan, kerusakan yang diberikan bertambah sejumlah 100."
-		}
-	}, {
-		cost: ["Fire", "Fire", "Fire", "Fire"],
-
-		name: {
-			ja: "ばくえんのうず",
-			'zh-tw': "爆焰旋渦",
-			th: "วงล้อระเบิดไฟ",
-			id: "Pusaran Ledakan Api"
+		{
+			name: {
+				ja: "ばくえんのうず",
+				'zh-tw': "爆焰旋渦",
+				th: "วงล้อระเบิดไฟ",
+				id: "Pusaran Ledakan Api",
+			},
+			damage: 330,
+			cost: ["Fire", "Fire", "Fire", "Fire"],
+			effect: {
+				ja: "このポケモンについているエネルギーを3個選び、トラッシュする。",
+				'zh-tw': "選擇3個這隻寶可夢身上附加的能量，將其丟棄。",
+				th: "เลือกพลังงานที่ติดอยู่กับโปเกมอนนี้ 3 ลูก ทิ้งที่ตำแหน่งทิ้งการ์ด",
+				id: "Pilih 3 Energi yang dikenakan pada Pokémon ini, lalu buang ke Trash.",
+			},
 		},
+	],
 
-		damage: 330,
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
 
-		effect: {
-			ja: "このポケモンについているエネルギーを3個選び、トラッシュする。",
-			'zh-tw': "選擇3個這隻寶可夢身上附加的能量，將其丟棄。",
-			th: "เลือกพลังงานที่ติดอยู่กับโปเกมอนนี้ 3 ลูก ทิ้งที่ตำแหน่งทิ้งการ์ด",
-			id: "Pilih 3 Energi yang dikenakan pada Pokémon ini, lalu buang ke Trash."
-		}
-	}],
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 719448,
+			},
+		},
+	],
 
-	weaknesses: [{
-		type: "Water",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "リザード",
+	},
 
 	retreat: 2,
 	regulationMark: "G",
+	rarity: "Double rare",
+	dexId: [6],
 
-	thirdParty: {
-		cardmarket: 719448
-	}
-}
+	suffix: "EX",
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV2a/007.ts
+++ b/data-asia/SV/SV2a/007.ts
@@ -1,20 +1,17 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV2a"
+import { Card } from "../../../interfaces";
+import Set from "../SV2a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "ゼニガメ",
 		'zh-tw': "傑尼龜",
 		th: "เซนิกาเมะ",
-		id: "Squirtle"
+		id: "Squirtle",
 	},
 
 	illustrator: "kantaro",
-	rarity: "Common",
 	category: "Pokemon",
-	dexId: [7],
 	hp: 60,
 	types: ["Water"],
 
@@ -22,51 +19,69 @@ const card: Card = {
 		ja: "危なくなると 甲羅に 手足を 引っこめて 身を 守りながら 口から 水を 吹き出している。",
 		'zh-tw': "當牠遇到危險的時候，會將四肢收回甲殼裡保護自己， 同時從嘴裡噴出水來。",
 		th: "เมื่อภัยอันตรายเข้าใกล้จะหดแขนขาเข้าในกระดองและฉีดน้ำออกมาจากปากไปพลางปกป้องตัวไปพลาง",
-		id: "Pada kondisi bahaya, Squirtle memasukkan tangan dan kakinya ke dalam tempurung dan menyemprotkan air dari mulutnya sambil melindungi diri."
+		id: "Pada kondisi bahaya, Squirtle memasukkan tangan dan kakinya ke dalam tempurung dan menyemprotkan air dari mulutnya sambil melindungi diri.",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		cost: ["Water"],
-
-		name: {
-			ja: "からにこもる",
-			'zh-tw': "縮入殼中",
-			th: "หดกำบัง",
-			id: "Berperam Dalam Cangkang"
+	attacks: [
+		{
+			name: {
+				ja: "からにこもる",
+				'zh-tw': "縮入殼中",
+				th: "หดกำบัง",
+				id: "Berperam Dalam Cangkang",
+			},
+			cost: ["Water"],
+			effect: {
+				ja: "コインを1回投げオモテなら、次の相手の番、このポケモンはワザのダメージを受けない。",
+				'zh-tw': "擲1次硬幣若為正面，則在下個對手的回合，這隻寶可夢不會受到招式的傷害。",
+				th: "ทอยเหรียญ 1 ครั้งถ้าออกหัว เทิร์นถัดไปของฝ่ายตรงข้าม โปเกมอนนี้จะไม่ได้รับแดเมจของท่าต่อสู้",
+				id: "Lempar koin 1 kali. Jika hasilnya sisi depan, pada giliran lawan berikutnya, Pokémon ini tidak menerima kerusakan akibat serangan.",
+			},
 		},
-
-		effect: {
-			ja: "コインを1回投げオモテなら、次の相手の番、このポケモンはワザのダメージを受けない。",
-			'zh-tw': "擲1次硬幣若為正面，則在下個對手的回合，這隻寶可夢不會受到招式的傷害。",
-			th: "ทอยเหรียญ 1 ครั้งถ้าออกหัว เทิร์นถัดไปของฝ่ายตรงข้าม โปเกมอนนี้จะไม่ได้รับแดเมจของท่าต่อสู้",
-			id: "Lempar koin 1 kali. Jika hasilnya sisi depan, pada giliran lawan berikutnya, Pokémon ini tidak menerima kerusakan akibat serangan."
-		}
-	}, {
-		cost: ["Water", "Water"],
-
-		name: {
-			ja: "ロケットずつき",
-			'zh-tw': "火箭頭錘",
-			th: "พุ่งหัวจรวด",
-			id: "Tandukan Kepala Roket"
+		{
+			name: {
+				ja: "ロケットずつき",
+				'zh-tw': "火箭頭錘",
+				th: "พุ่งหัวจรวด",
+				id: "Tandukan Kepala Roket",
+			},
+			damage: 20,
+			cost: ["Water", "Water"],
 		},
+	],
 
-		damage: 20
-	}],
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Lightning",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 719449,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				cardmarket: 837238,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				cardmarket: 837239,
+			},
+		},
+	],
 
 	retreat: 1,
 	regulationMark: "G",
+	rarity: "Common",
+	dexId: [7],
+};
 
-	thirdParty: {
-		cardmarket: 719449
-	}
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV2a/008.ts
+++ b/data-asia/SV/SV2a/008.ts
@@ -1,20 +1,17 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV2a"
+import { Card } from "../../../interfaces";
+import Set from "../SV2a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "カメール",
 		'zh-tw': "卡咪龜",
 		th: "คาเมล",
-		id: "Wartortle"
+		id: "Wartortle",
 	},
 
 	illustrator: "kantaro",
-	rarity: "Uncommon",
 	category: "Pokemon",
-	dexId: [8],
 	hp: 100,
 	types: ["Water"],
 
@@ -22,51 +19,73 @@ const card: Card = {
 		ja: "ふさふさの 耳と しっぽを たくみに 操って 水中での バランスを たもつ。",
 		'zh-tw': "會靈巧地擺動自己毛茸茸的耳朵和尾巴， 藉此在水中保持平衡。",
 		th: "ใช้หูและหางได้อย่างคล่องแคล่วเพื่อรักษาสมดุลขณะอยู่ในน้ำ",
-		id: "Wartortle mengendalikan telinga dan ekornya yang berbulu lebat untuk menjaga keseimbangan di dalam air."
+		id: "Wartortle mengendalikan telinga dan ekornya yang berbulu lebat untuk menjaga keseimbangan di dalam air.",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		cost: ["Water"],
-
-		name: {
-			ja: "すもぐり",
-			'zh-tw': "自由潛水",
-			th: "มุดเข้ารัง",
-			id: "Berbenam Diri"
+	attacks: [
+		{
+			name: {
+				ja: "すもぐり",
+				'zh-tw': "自由潛水",
+				th: "มุดเข้ารัง",
+				id: "Berbenam Diri",
+			},
+			cost: ["Water"],
+			effect: {
+				ja: "自分のトラッシュから「基本[W]エネルギー」を3枚まで選び、相手に見せて、手札に加える。",
+				'zh-tw': "從自己的棄牌區選擇最多3張「基本【水】能量」卡，在給對手看過後加入手牌。",
+				th: "เลือกการ์ด [พลังงานพื้นฐาน[น้ำ]] ได้สูงสุด 3 ใบจากตำแหน่งทิ้งการ์ดฝ่ายเรา ให้ฝ่ายตรงข้ามดู นำขึ้นมือ",
+				id: "Pilih paling banyak 3 lembar Energi Dasar {Air} dari Trash sendiri, perlihatkan ke lawan, lalu tambahkan ke Kartu Pegangan.",
+			},
 		},
-
-		effect: {
-			ja: "自分のトラッシュから「基本エネルギー」を3枚まで選び、相手に見せて、手札に加える。",
-			'zh-tw': "從自己的棄牌區選擇最多3張「基本【水】能量」卡，在給對手看過後加入手牌。",
-			th: "เลือกการ์ด [พลังงานพื้นฐาน[น้ำ]] ได้สูงสุด 3 ใบจากตำแหน่งทิ้งการ์ดฝ่ายเรา ให้ฝ่ายตรงข้ามดู นำขึ้นมือ",
-			id: "Pilih paling banyak 3 lembar Energi Dasar {Air} dari Trash sendiri, perlihatkan ke lawan, lalu tambahkan ke Kartu Pegangan."
-		}
-	}, {
-		cost: ["Water", "Water"],
-
-		name: {
-			ja: "かいてんアタック",
-			'zh-tw': "迴轉攻擊",
-			th: "โจมตีหมุนวน",
-			id: "Serangan Berputar"
+		{
+			name: {
+				ja: "かいてんアタック",
+				'zh-tw': "迴轉攻擊",
+				th: "โจมตีหมุนวน",
+				id: "Serangan Berputar",
+			},
+			damage: 50,
+			cost: ["Water", "Water"],
 		},
+	],
 
-		damage: 50
-	}],
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Lightning",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 719450,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				cardmarket: 837240,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				cardmarket: 837241,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ゼニガメ",
+	},
 
 	retreat: 2,
 	regulationMark: "G",
+	rarity: "Uncommon",
+	dexId: [8],
+};
 
-	thirdParty: {
-		cardmarket: 719450
-	}
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV2a/009.ts
+++ b/data-asia/SV/SV2a/009.ts
@@ -1,73 +1,81 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV2a"
+import { Card } from "../../../interfaces";
+import Set from "../SV2a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "カメックスex",
 		'zh-tw': "水箭龜ex",
 		th: "คาเม็กซ์ex",
-		id: "Blastoise ex"
+		id: "Blastoise ex",
 	},
 
 	illustrator: "PLANETA Yamashita",
-	rarity: "Double rare",
 	category: "Pokemon",
 	hp: 330,
 	types: ["Water"],
+
 	stage: "Stage2",
-	suffix: "EX",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			ja: "かたいこうら",
-			'zh-tw': "堅硬甲殼",
-			th: "กระดองสุดแข็ง",
-			id: "Tempurung Padat"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "かたいこうら",
+				'zh-tw': "堅硬甲殼",
+				th: "กระดองสุดแข็ง",
+				id: "Tempurung Padat",
+			},
+			effect: {
+				ja: "このポケモンが受けるワザのダメージは「-30」される。",
+				'zh-tw': "這隻寶可夢受到招式的傷害「-30」點。",
+				th: "แดเมจของท่าต่อสู้ที่โปเกมอนนี้จะได้รับจะถูก [-30]",
+				id: "Kerusakan akibat serangan yang diterima Pokémon ini berkurang sejumlah 30.",
+			},
 		},
+	],
 
-		effect: {
-			ja: "このポケモンが受けるワザのダメージは「-30」される。",
-			'zh-tw': "這隻寶可夢受到招式的傷害「-30」點。",
-			th: "แดเมจของท่าต่อสู้ที่โปเกมอนนี้จะได้รับจะถูก [-30]",
-			id: "Kerusakan akibat serangan yang diterima Pokémon ini berkurang sejumlah 30."
-		}
-	}],
-
-	attacks: [{
-		cost: ["Water", "Water"],
-
-		name: {
-			ja: "ツインカノン",
-			'zh-tw': "雙加農炮",
-			th: "ทวินแคนนอน",
-			id: "Twin Cannon"
+	attacks: [
+		{
+			name: {
+				ja: "ツインカノン",
+				'zh-tw': "雙加農炮",
+				th: "ทวินแคนนอน",
+				id: "Twin Cannon",
+			},
+			damage: "140×",
+			cost: ["Water", "Water"],
+			effect: {
+				ja: "自分の手札から「基本[W]エネルギー」を2枚までトラッシュし、その枚数×140ダメージ。",
+				'zh-tw': "從自己的手牌將最多2張「基本【水】能量」卡丟棄，造成其張數×140點傷害。",
+				th: "ทิ้งการ์ด [พลังงานพื้นฐาน[น้ำ]] ได้สูงสุด 2 ใบจากบนมือฝ่ายเราที่ตำแหน่งทิ้งการ์ด แดเมจจะเท่ากับจำนวนการ์ดนั้น x140",
+				id: "Buang paling banyak 2 lembar Energi Dasar {Air} dari Kartu Pegangan sendiri ke Trash, serangan ini memberikan kerusakan sejumlah 140 untuk tiap lembarnya.",
+			},
 		},
+	],
 
-		damage: "140×",
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
 
-		effect: {
-			ja: "自分の手札から「基本エネルギー」を2枚までトラッシュし、その枚数×140ダメージ。",
-			'zh-tw': "從自己的手牌將最多2張「基本【水】能量」卡丟棄，造成其張數×140點傷害。",
-			th: "ทิ้งการ์ด [พลังงานพื้นฐาน[น้ำ]] ได้สูงสุด 2 ใบจากบนมือฝ่ายเราที่ตำแหน่งทิ้งการ์ด แดเมจจะเท่ากับจำนวนการ์ดนั้น x140",
-			id: "Buang paling banyak 2 lembar Energi Dasar {Air} dari Kartu Pegangan sendiri ke Trash, serangan ini memberikan kerusakan sejumlah 140 untuk tiap lembarnya."
-		}
-	}],
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 719451,
+			},
+		},
+	],
 
-	weaknesses: [{
-		type: "Lightning",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "カメール",
+	},
 
 	retreat: 3,
 	regulationMark: "G",
+	rarity: "Double rare",
+	dexId: [9],
 
-	thirdParty: {
-		cardmarket: 719451
-	}
-}
+	suffix: "EX",
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV2a/010.ts
+++ b/data-asia/SV/SV2a/010.ts
@@ -1,20 +1,17 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV2a"
+import { Card } from "../../../interfaces";
+import Set from "../SV2a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "キャタピー",
 		'zh-tw': "綠毛蟲",
 		th: "คาเตอร์ปี",
-		id: "Caterpie"
+		id: "Caterpie",
 	},
 
 	illustrator: "Tika Matsuno",
-	rarity: "Common",
 	category: "Pokemon",
-	dexId: [10],
 	hp: 50,
 	types: ["Grass"],
 
@@ -22,42 +19,60 @@ const card: Card = {
 		ja: "脚は 短いが 吸盤に なっているので 坂でも 壁でも くたびれることなく 進んでいく。",
 		'zh-tw': "別看牠的腳很短，因為是吸盤，所以無論是 斜坡還是牆壁都能輕鬆前進。",
 		th: "ขาสั้นแต่ว่าเป็นปุ่มดูดก็เลยเคลื่อนตัวไปเกาะได้ทั้งทางลาดและกำแพงโดยไม่รู้สึกเหนื่อยเลย",
-		id: "Walau kaki Caterpie pendek, kakinya merupakan pengisap, sehingga Pokémon ini dapat maju terus menaiki tanjakan dan dinding tanpa merasa lelah."
+		id: "Walau kaki Caterpie pendek, kakinya merupakan pengisap, sehingga Pokémon ini dapat maju terus menaiki tanjakan dan dinding tanpa merasa lelah.",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		cost: ["Grass"],
-
-		name: {
-			ja: "はっぱをたべる",
-			'zh-tw': "吃葉子",
-			th: "กินใบไม้",
-			id: "Memakan Daun"
+	attacks: [
+		{
+			name: {
+				ja: "はっぱをたべる",
+				'zh-tw': "吃葉子",
+				th: "กินใบไม้",
+				id: "Memakan Daun",
+			},
+			damage: "10+",
+			cost: ["Grass"],
+			effect: {
+				ja: "相手のバトルポケモンが[G]ポケモンなら、30ダメージ追加。",
+				'zh-tw': "若對手的戰鬥寶可夢為【草】寶可夢，則增加30點傷害。",
+				th: "ถ้าโปเกมอนบนตำแหน่งต่อสู้ฝ่ายตรงข้ามเป็นโปเกมอน[หญ้า] การโจมตีนี้จะเพิ่มแดเมจอีก 30",
+				id: "Jika Pokémon Bertarung lawan adalah Pokémon {Daun}, kerusakan yang diberikan bertambah sejumlah 30.",
+			},
 		},
+	],
 
-		damage: "10+",
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
 
-		effect: {
-			ja: "相手のバトルポケモンがポケモンなら、30ダメージ追加。",
-			'zh-tw': "若對手的戰鬥寶可夢為【草】寶可夢，則增加30點傷害。",
-			th: "ถ้าโปเกมอนบนตำแหน่งต่อสู้ฝ่ายตรงข้ามเป็นโปเกมอน[หญ้า] การโจมตีนี้จะเพิ่มแดเมจอีก 30",
-			id: "Jika Pokémon Bertarung lawan adalah Pokémon {Daun}, kerusakan yang diberikan bertambah sejumlah 30."
-		}
-	}],
-
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 719452,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				cardmarket: 837242,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				cardmarket: 837243,
+			},
+		},
+	],
 
 	retreat: 1,
 	regulationMark: "G",
+	rarity: "Common",
+	dexId: [10],
+};
 
-	thirdParty: {
-		cardmarket: 719452
-	}
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV2a/011.ts
+++ b/data-asia/SV/SV2a/011.ts
@@ -1,20 +1,17 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV2a"
+import { Card } from "../../../interfaces";
+import Set from "../SV2a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "トランセル",
 		'zh-tw': "鐵甲蛹",
 		th: "ทรานเซล",
-		id: "Metapod"
+		id: "Metapod",
 	},
 
 	illustrator: "Tika Matsuno",
-	rarity: "Common",
 	category: "Pokemon",
-	dexId: [11],
 	hp: 90,
 	types: ["Grass"],
 
@@ -22,51 +19,73 @@ const card: Card = {
 		ja: "硬い 殻に 包まれているが 中身は 軟らかいので 強い 攻撃には 耐えられない。",
 		'zh-tw': "雖然有堅硬的外殼，但因為殼裡的身體很軟， 所以無法抵抗強力的攻擊。",
 		th: "ถูกห่อหุ้มอยู่ในเปลือกแข็งแต่ว่าลำตัวนุ่มนิ่มก็เลยไม่สามารถทนต่อการโจมตีรุนแรงได้",
-		id: "Metapod dilindungi oleh cangkang yang keras, tapi bagian dalam tubuhnya lunak sehingga tidak dapat menahan serangan yang kuat."
+		id: "Metapod dilindungi oleh cangkang yang keras, tapi bagian dalam tubuhnya lunak sehingga tidak dapat menahan serangan yang kuat.",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		cost: ["Grass"],
-
-		name: {
-			ja: "たいあたり",
-			'zh-tw': "撞擊",
-			th: "พุ่งเข้าชน",
-			id: "Serudukan"
+	attacks: [
+		{
+			name: {
+				ja: "たいあたり",
+				'zh-tw': "撞擊",
+				th: "พุ่งเข้าชน",
+				id: "Serudukan",
+			},
+			damage: 20,
+			cost: ["Grass"],
 		},
-
-		damage: 20
-	}, {
-		cost: ["Colorless", "Colorless"],
-
-		name: {
-			ja: "ぼうぎょしせい",
-			'zh-tw': "防禦姿勢",
-			th: "ตั้งท่าป้องกัน",
-			id: "Posisi Bertahan"
+		{
+			name: {
+				ja: "ぼうぎょしせい",
+				'zh-tw': "防禦姿勢",
+				th: "ตั้งท่าป้องกัน",
+				id: "Posisi Bertahan",
+			},
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "コインを1回投げオモテなら、次の相手の番、このポケモンはワザのダメージを受けない。",
+				'zh-tw': "擲1次硬幣若為正面，則在下個對手的回合，這隻寶可夢不會受到招式的傷害。",
+				th: "ทอยเหรียญ 1 ครั้งถ้าออกหัว เทิร์นถัดไปของฝ่ายตรงข้าม โปเกมอนนี้จะไม่ได้รับแดเมจของท่าต่อสู้",
+				id: "Lempar koin 1 kali. Jika hasilnya sisi depan, pada giliran lawan berikutnya, Pokémon ini tidak menerima kerusakan akibat serangan.",
+			},
 		},
+	],
 
-		effect: {
-			ja: "コインを1回投げオモテなら、次の相手の番、このポケモンはワザのダメージを受けない。",
-			'zh-tw': "擲1次硬幣若為正面，則在下個對手的回合，這隻寶可夢不會受到招式的傷害。",
-			th: "ทอยเหรียญ 1 ครั้งถ้าออกหัว เทิร์นถัดไปของฝ่ายตรงข้าม โปเกมอนนี้จะไม่ได้รับแดเมจของท่าต่อสู้",
-			id: "Lempar koin 1 kali. Jika hasilnya sisi depan, pada giliran lawan berikutnya, Pokémon ini tidak menerima kerusakan akibat serangan."
-		}
-	}],
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 719453,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				cardmarket: 837244,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				cardmarket: 837245,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "キャタピー",
+	},
 
 	retreat: 3,
 	regulationMark: "G",
+	rarity: "Common",
+	dexId: [11],
+};
 
-	thirdParty: {
-		cardmarket: 719453
-	}
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV2a/012.ts
+++ b/data-asia/SV/SV2a/012.ts
@@ -1,20 +1,17 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV2a"
+import { Card } from "../../../interfaces";
+import Set from "../SV2a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "バタフリー",
 		'zh-tw': "巴大蝶",
 		th: "บัตเตอร์ฟรี",
-		id: "Butterfree"
+		id: "Butterfree",
 	},
 
 	illustrator: "Tika Matsuno",
-	rarity: "Uncommon",
 	category: "Pokemon",
-	dexId: [12],
 	hp: 130,
 	types: ["Grass"],
 
@@ -22,58 +19,79 @@ const card: Card = {
 		ja: "毎日 ミツを 集めまわる。 脚の 産毛に ミツを 塗りこんで 巣に 持ち帰る 習性をもつ。",
 		'zh-tw': "每天都忙著採集花蜜。習慣在腿部的細毛上塗滿花蜜， 然後帶回巢穴裡。",
 		th: "บินเก็บน้ำหวานของดอกไม้ทุกวัน มีนิสัยชอบทาน้ำหวานฝังเข้าไปในขนอ่อน ๆ ที่ขาแล้วนำกลับรัง",
-		id: "Butterfree setiap hari berkeliling mengumpulkan madu. Memiliki kebiasaan mengoleskan madu ke bulu kakinya untuk dibawa pulang ke sarang."
+		id: "Butterfree setiap hari berkeliling mengumpulkan madu. Memiliki kebiasaan mengoleskan madu ke bulu kakinya untuk dibawa pulang ke sarang.",
 	},
 
 	stage: "Stage2",
 
-	attacks: [{
-		cost: ["Grass"],
-
-		name: {
-			ja: "ふきとばし",
-			'zh-tw': "吹飛",
-			th: "เป่ากระเด็น",
-			id: "Angin Penghempas"
+	attacks: [
+		{
+			name: {
+				ja: "ふきとばし",
+				'zh-tw': "吹飛",
+				th: "เป่ากระเด็น",
+				id: "Angin Penghempas",
+			},
+			damage: 60,
+			cost: ["Grass"],
+			effect: {
+				ja: "相手のバトルポケモンをベンチポケモンと入れ替える。［バトル場に出すポケモンは相手が選ぶ。］",
+				'zh-tw': "將對手的戰鬥寶可夢與備戰寶可夢互換。[由對手選擇放置於戰鬥場的寶可夢。]",
+				th: "สลับโปเกมอนบนตำแหน่งต่อสู้ฝ่ายตรงข้ามกับโปเกมอนบนเบนช์ {ฝ่ายตรงข้ามเลือกโปเกมอนที่จะวางบนตำแหน่งต่อสู้}",
+				id: "Tukar Pokémon Bertarung lawan dengan Pokémon Cadangan. [Pokémon yang akan dimasukkan ke Arena Bertarung dipilih oleh lawan.]",
+			},
 		},
-
-		damage: 60,
-
-		effect: {
-			ja: "相手のバトルポケモンをベンチポケモンと入れ替える。［バトル場に出すポケモンは相手が選ぶ。］",
-			'zh-tw': "將對手的戰鬥寶可夢與備戰寶可夢互換。[由對手選擇放置於戰鬥場的寶可夢。]",
-			th: "สลับโปเกมอนบนตำแหน่งต่อสู้ฝ่ายตรงข้ามกับโปเกมอนบนเบนช์ {ฝ่ายตรงข้ามเลือกโปเกมอนที่จะวางบนตำแหน่งต่อสู้}",
-			id: "Tukar Pokémon Bertarung lawan dengan Pokémon Cadangan. [Pokémon yang akan dimasukkan ke Arena Bertarung dipilih oleh lawan.]"
-		}
-	}, {
-		cost: ["Colorless", "Colorless"],
-
-		name: {
-			ja: "バイバイフライト",
-			'zh-tw': "去去飛行",
-			th: "บ๊ายบายไฟลต์",
-			id: "Bye Bye Flight"
+		{
+			name: {
+				ja: "バイバイフライト",
+				'zh-tw': "去去飛行",
+				th: "บ๊ายบายไฟลต์",
+				id: "Bye Bye Flight",
+			},
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンと、相手のベンチポケモンを1匹選び、それぞれのポケモンと、ついているすべてのカードを、山札にもどして切る。相手のベンチポケモンがいないなら、このワザは失敗。",
+				'zh-tw': "選擇1隻對手的備戰寶可夢，將這隻寶可夢與所選的寶可夢，與各自身上附加的卡，全部放回牌庫並重洗。若對手沒有備戰寶可夢，則這個招式失敗。",
+				th: "เลือกโปเกมอนนี้กับ โปเกมอนบนเบนช์ฝ่ายตรงข้าม 1 ตัว นำโปเกมอนของแต่ละฝ่าย และการ์ดทั้งหมดที่ติดอยู่ ใส่กลับไปในสำรับการ์ดแล้วสับ ถ้าฝ่ายตรงข้ามไม่มีโปเกมอนบนเบนช์ ท่าต่อสู้นี้จะล้มเหลว",
+				id: "Pilih Pokémon ini dan 1 Pokémon Cadangan lawan, lalu kocok kembali masing-masing Pokémon dan semua kartu yang dikenakannya ke Deck. Jika lawan tidak memiliki Pokémon Cadangan, serangan ini gagal.",
+			},
 		},
+	],
 
-		effect: {
-			ja: "このポケモンと、相手のベンチポケモンを1匹選び、それぞれのポケモンと、ついているすべてのカードを、山札にもどして切る。相手のベンチポケモンがいないなら、このワザは失敗。",
-			'zh-tw': "選擇1隻對手的備戰寶可夢，將這隻寶可夢與所選的寶可夢，與各自身上附加的卡，全部放回牌庫並重洗。若對手沒有備戰寶可夢，則這個招式失敗。",
-			th: "เลือกโปเกมอนนี้กับ โปเกมอนบนเบนช์ฝ่ายตรงข้าม 1 ตัว นำโปเกมอนของแต่ละฝ่าย และการ์ดทั้งหมดที่ติดอยู่ ใส่กลับไปในสำรับการ์ดแล้วสับ ถ้าฝ่ายตรงข้ามไม่มีโปเกมอนบนเบนช์ ท่าต่อสู้นี้จะล้มเหลว",
-			id: "Pilih Pokémon ini dan 1 Pokémon Cadangan lawan, lalu kocok kembali masing-masing Pokémon dan semua kartu yang dikenakannya ke Deck. Jika lawan tidak memiliki Pokémon Cadangan, serangan ini gagal."
-		}
-	}],
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 719454,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				cardmarket: 837246,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				cardmarket: 837247,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "トランセル",
+	},
 
 	retreat: 1,
 	regulationMark: "G",
+	rarity: "Uncommon",
+	dexId: [12],
+};
 
-	thirdParty: {
-		cardmarket: 719454
-	}
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV2a/013.ts
+++ b/data-asia/SV/SV2a/013.ts
@@ -1,20 +1,17 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV2a"
+import { Card } from "../../../interfaces";
+import Set from "../SV2a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "ビードル",
 		'zh-tw': "獨角蟲",
 		th: "บีเดิล",
-		id: "Weedle"
+		id: "Weedle",
 	},
 
 	illustrator: "nisimono",
-	rarity: "Common",
 	category: "Pokemon",
-	dexId: [13],
 	hp: 50,
 	types: ["Grass"],
 
@@ -22,46 +19,64 @@ const card: Card = {
 		ja: "毒針は とても 強力。 目立つ 体の 色は 相手に 警戒を させるためだ。",
 		'zh-tw': "毒針非常厲害。 鮮豔的體色是用來 警告對手的。",
 		th: "เข็มพิษมันมีพิษรุนแรงมาก สีสันตามตัวที่ดูเด่นสะดุดตาก็เพื่อทำให้ฝ่ายตรงข้ามคอยระวังตัว",
-		id: "Jarum beracun Weedle sangat kuat. Warna tubuhnya yang mencolok membuat lawan menjadi waspada."
+		id: "Jarum beracun Weedle sangat kuat. Warna tubuhnya yang mencolok membuat lawan menjadi waspada.",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		cost: ["Grass"],
-
-		name: {
-			ja: "ぶつかる",
-			'zh-tw': "衝撞",
-			th: "กระแทก",
-			id: "Menyeruduk"
+	attacks: [
+		{
+			name: {
+				ja: "ぶつかる",
+				'zh-tw': "衝撞",
+				th: "กระแทก",
+				id: "Menyeruduk",
+			},
+			damage: 10,
+			cost: ["Grass"],
 		},
-
-		damage: 10
-	}, {
-		cost: ["Colorless", "Colorless"],
-
-		name: {
-			ja: "むしくい",
-			'zh-tw': "蟲咬",
-			th: "แมลงกัด",
-			id: "Gigitan Serangga"
+		{
+			name: {
+				ja: "むしくい",
+				'zh-tw': "蟲咬",
+				th: "แมลงกัด",
+				id: "Gigitan Serangga",
+			},
+			damage: 20,
+			cost: ["Colorless", "Colorless"],
 		},
+	],
 
-		damage: 20
-	}],
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 719455,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				cardmarket: 837248,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				cardmarket: 837249,
+			},
+		},
+	],
 
 	retreat: 1,
 	regulationMark: "G",
+	rarity: "Common",
+	dexId: [13],
+};
 
-	thirdParty: {
-		cardmarket: 719455
-	}
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV2a/014.ts
+++ b/data-asia/SV/SV2a/014.ts
@@ -1,20 +1,17 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV2a"
+import { Card } from "../../../interfaces";
+import Set from "../SV2a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "コクーン",
 		'zh-tw': "鐵殼蛹",
 		th: "โคคูน",
-		id: "Kakuna"
+		id: "Kakuna",
 	},
 
 	illustrator: "nisimono",
-	rarity: "Common",
 	category: "Pokemon",
-	dexId: [14],
 	hp: 80,
 	types: ["Grass"],
 
@@ -22,53 +19,76 @@ const card: Card = {
 		ja: "天敵に 見つからないように 葉っぱの 裏や 枝の すきまに 隠れて 進化の ときを 待つ。",
 		'zh-tw': "為了不被天敵發現， 會躲在葉子背面或樹枝的間隙中， 等待進化的時刻到來。",
 		th: "จะคอยหลบซ่อนตัวตามซอกกิ่งไม้หรือหลังใบไม้เพื่อไม่ให้ศัตรูทางธรรมชาติเห็น และรอเวลาที่จะวิวัฒนาการ",
-		id: "Kakuna bersembunyi di balik daun dan celah di antara batang pohon agar tidak ditemukan oleh musuh alaminya, dan menanti waktu evolusi."
+		id: "Kakuna bersembunyi di balik daun dan celah di antara batang pohon agar tidak ditemukan oleh musuh alaminya, dan menanti waktu evolusi.",
 	},
 
 	stage: "Stage1",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			ja: "さなぎガード",
-			'zh-tw': "蛹之防守",
-			th: "ป้องกันดักแด้",
-			id: "Pupa Pelindung"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "さなぎガード",
+				'zh-tw': "蛹之防守",
+				th: "ป้องกันดักแด้",
+				id: "Pupa Pelindung",
+			},
+			effect: {
+				ja: "このポケモンは、相手のポケモンが使うワザの効果を受けない。",
+				'zh-tw': "這隻寶可夢不會受到對手的寶可夢使用招式的效果的影響。",
+				th: "โปเกมอนนี้ จะไม่ได้รับเอฟเฟกต์ของท่าต่อสู้ที่โปเกมอนฝ่ายตรงข้ามใช้",
+				id: "Pokémon ini tidak menerima efek akibat serangan yang digunakan oleh Pokémon lawan.",
+			},
 		},
+	],
 
-		effect: {
-			ja: "このポケモンは、相手のポケモンが使うワザの効果を受けない。",
-			'zh-tw': "這隻寶可夢不會受到對手的寶可夢使用招式的效果的影響。",
-			th: "โปเกมอนนี้ จะไม่ได้รับเอฟเฟกต์ของท่าต่อสู้ที่โปเกมอนฝ่ายตรงข้ามใช้",
-			id: "Pokémon ini tidak menerima efek akibat serangan yang digunakan oleh Pokémon lawan."
-		}
-	}],
-
-	attacks: [{
-		cost: ["Colorless", "Colorless"],
-
-		name: {
-			ja: "チクッ",
-			'zh-tw': "刺痛",
-			th: "ต่อย",
-			id: "Sengat"
+	attacks: [
+		{
+			name: {
+				ja: "チクッ",
+				'zh-tw': "刺痛",
+				th: "ต่อย",
+				id: "Sengat",
+			},
+			damage: 20,
+			cost: ["Colorless", "Colorless"],
 		},
+	],
 
-		damage: 20
-	}],
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 719456,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				cardmarket: 837250,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				cardmarket: 837251,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ビードル",
+	},
 
 	retreat: 3,
 	regulationMark: "G",
+	rarity: "Common",
+	dexId: [14],
+};
 
-	thirdParty: {
-		cardmarket: 719456
-	}
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV2a/015.ts
+++ b/data-asia/SV/SV2a/015.ts
@@ -1,20 +1,17 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV2a"
+import { Card } from "../../../interfaces";
+import Set from "../SV2a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "スピアー",
 		'zh-tw': "大針蜂",
 		th: "สเปียร์",
-		id: "Beedrill"
+		id: "Beedrill",
 	},
 
 	illustrator: "nisimono",
-	rarity: "Rare",
 	category: "Pokemon",
-	dexId: [15],
 	hp: 130,
 	types: ["Grass"],
 
@@ -22,53 +19,74 @@ const card: Card = {
 		ja: "集団で 現れることもある。 猛スピードで 飛び回り お尻の 毒針で 刺しまくる。",
 		'zh-tw': "有時會成群結隊地出現。 能以極快的速度飛來飛去， 並用尾部的毒針不斷刺擊對手。",
 		th: "บางครั้งจะปรากฏตัวกันเป็นฝูง บินวนไปมาด้วยความเร็วสูงและทิ่มแทงเข็มพิษจากก้นไปทั่ว",
-		id: "Kadang Beedrill muncul secara berkelompok. Pokémon ini terbang berkeliling dengan kecepatan tinggi dan terus-menerus menusuk dengan jarum beracun di bagian bawah tubuhnya."
+		id: "Kadang Beedrill muncul secara berkelompok. Pokémon ini terbang berkeliling dengan kecepatan tinggi dan terus-menerus menusuk dengan jarum beracun di bagian bawah tubuhnya.",
 	},
 
 	stage: "Stage2",
 
-	attacks: [{
-		cost: ["Colorless", "Colorless"],
-
-		name: {
-			ja: "ぎゃっきょうニードル",
-			'zh-tw': "逆境尖刺",
-			th: "เข็มแห่งภัยพิบัติ",
-			id: "Jarum Kemalangan"
+	attacks: [
+		{
+			name: {
+				ja: "ぎゃっきょうニードル",
+				'zh-tw': "逆境尖刺",
+				th: "เข็มแห่งภัยพิบัติ",
+				id: "Jarum Kemalangan",
+			},
+			damage: "30+",
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "自分の手札が1枚もないなら、120ダメージ追加し、相手のバトルポケモンをどくとマヒにする。",
+				'zh-tw': "若自己1張手牌都沒有，則增加120點傷害，並將對手的戰鬥寶可夢【中毒】與【麻痺】。",
+				th: "ถ้าบนมือฝ่ายเราไม่มีการ์ดเลยแม้แต่ 1 ใบ การโจมตีนี้จะเพิ่มแดเมจอีก 120 ทำให้โปเกมอนบนตำแหน่งต่อสู้ฝ่ายตรงข้ามเป็นสภาวะ[พิษ]และ[ชา]",
+				id: "Jika Kartu Pegangan sendiri tidak tersisa 1 lembar pun, kerusakan yang diberikan bertambah sejumlah 120, lalu ubah kondisi Pokémon Bertarung lawan menjadi Racun dan Lumpuh.",
+			},
 		},
-
-		damage: "30+",
-
-		effect: {
-			ja: "自分の手札が1枚もないなら、120ダメージ追加し、相手のバトルポケモンをどくとマヒにする。",
-			'zh-tw': "若自己1張手牌都沒有，則增加120點傷害，並將對手的戰鬥寶可夢【中毒】與【麻痺】。",
-			th: "ถ้าบนมือฝ่ายเราไม่มีการ์ดเลยแม้แต่ 1 ใบ การโจมตีนี้จะเพิ่มแดเมจอีก 120 ทำให้โปเกมอนบนตำแหน่งต่อสู้ฝ่ายตรงข้ามเป็นสภาวะ[พิษ]และ[ชา]",
-			id: "Jika Kartu Pegangan sendiri tidak tersisa 1 lembar pun, kerusakan yang diberikan bertambah sejumlah 120, lalu ubah kondisi Pokémon Bertarung lawan menjadi Racun dan Lumpuh."
-		}
-	}, {
-		cost: ["Grass", "Grass"],
-
-		name: {
-			ja: "つきさす",
-			'zh-tw': "突刺",
-			th: "แทง",
-			id: "Melubangi"
+		{
+			name: {
+				ja: "つきさす",
+				'zh-tw': "突刺",
+				th: "แทง",
+				id: "Melubangi",
+			},
+			damage: 110,
+			cost: ["Grass", "Grass"],
 		},
+	],
 
-		damage: 110
-	}],
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 719457,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				cardmarket: 837252,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				cardmarket: 837253,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "コクーン",
+	},
 
 	retreat: 1,
 	regulationMark: "G",
+	rarity: "Rare",
+	dexId: [15],
+};
 
-	thirdParty: {
-		cardmarket: 719457
-	}
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV2a/016.ts
+++ b/data-asia/SV/SV2a/016.ts
@@ -1,20 +1,17 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV2a"
+import { Card } from "../../../interfaces";
+import Set from "../SV2a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "ポッポ",
 		'zh-tw': "波波",
 		th: "ป็อปโปะ",
-		id: "Pidgey"
+		id: "Pidgey",
 	},
 
 	illustrator: "Oswaldo KATO",
-	rarity: "Common",
 	category: "Pokemon",
-	dexId: [16],
 	hp: 50,
 	types: ["Colorless"],
 
@@ -22,56 +19,69 @@ const card: Card = {
 		ja: "戦いを 好まない おとなしい 性格だが 下手に 手を 出すと 強烈に 反撃されるぞ。",
 		'zh-tw': "雖然性情溫和不愛戰鬥， 但要是隨意對牠出手的話， 就會受到牠強烈的反擊。",
 		th: "มีนิสัยสงบเสงี่ยม ไม่ชอบต่อสู้ แต่ถ้าเผลอไปหาเรื่องมันเข้าล่ะก็ จะถูกโต้กลับอย่างรุนแรงเอานะ",
-		id: "Meski Pidgey berkepribadian tenang dan tidak menyukai pertikaian, ia akan melawan balik dengan ganas jika diganggu."
+		id: "Meski Pidgey berkepribadian tenang dan tidak menyukai pertikaian, ia akan melawan balik dengan ganas jika diganggu.",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		cost: ["Colorless"],
-
-		name: {
-			ja: "なかまをよぶ",
-			'zh-tw': "呼朋引伴",
-			th: "เรียกเพื่อน",
-			id: "Memanggil Teman"
+	attacks: [
+		{
+			name: {
+				ja: "なかまをよぶ",
+				'zh-tw': "呼朋引伴",
+				th: "เรียกเพื่อน",
+				id: "Memanggil Teman",
+			},
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札からたねポケモンを2枚まで選び、ベンチに出す。そして山札を切る。",
+				'zh-tw': "從自己的牌庫選擇最多2張【基礎】寶可夢卡，放置於備戰區。並且重洗牌庫。",
+				th: "เลือกการ์ดโปเกมอน[พื้นฐาน]ได้สูงสุด 2 ใบจากสำรับการ์ดฝ่ายเรา วางบนเบนช์ แล้วสับสำรับการ์ด",
+				id: "Pilih paling banyak 2 lembar Pokémon Basic dari Deck sendiri, lalu masukkan ke Cadangan. Kemudian, kocok Deck.",
+			},
 		},
-
-		effect: {
-			ja: "自分の山札からたねポケモンを2枚まで選び、ベンチに出す。そして山札を切る。",
-			'zh-tw': "從自己的牌庫選擇最多2張【基礎】寶可夢卡，放置於備戰區。並且重洗牌庫。",
-			th: "เลือกการ์ดโปเกมอน[พื้นฐาน]ได้สูงสุด 2 ใบจากสำรับการ์ดฝ่ายเรา วางบนเบนช์ แล้วสับสำรับการ์ด",
-			id: "Pilih paling banyak 2 lembar Pokémon Basic dari Deck sendiri, lalu masukkan ke Cadangan. Kemudian, kocok Deck."
-		}
-	}, {
-		cost: ["Colorless", "Colorless"],
-
-		name: {
-			ja: "たいあたり",
-			'zh-tw': "撞擊",
-			th: "พุ่งเข้าชน",
-			id: "Serudukan"
+		{
+			name: {
+				ja: "たいあたり",
+				'zh-tw': "撞擊",
+				th: "พุ่งเข้าชน",
+				id: "Serudukan",
+			},
+			damage: 20,
+			cost: ["Colorless", "Colorless"],
 		},
+	],
 
-		damage: 20
-	}],
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
 
-	weaknesses: [{
-		type: "Lightning",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Fighting",
-		value: "-30"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 719458,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				cardmarket: 837254,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				cardmarket: 837255,
+			},
+		},
+	],
 
 	retreat: 1,
 	regulationMark: "G",
+	rarity: "Common",
+	dexId: [16],
+};
 
-	thirdParty: {
-		cardmarket: 719458
-	}
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV2a/017.ts
+++ b/data-asia/SV/SV2a/017.ts
@@ -1,20 +1,17 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV2a"
+import { Card } from "../../../interfaces";
+import Set from "../SV2a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "ピジョン",
 		'zh-tw': "比比鳥",
 		th: "พีเจียน",
-		id: "Pidgeotto"
+		id: "Pidgeotto",
 	},
 
 	illustrator: "Oswaldo KATO",
-	rarity: "Common",
 	category: "Pokemon",
-	dexId: [17],
 	hp: 80,
 	types: ["Colorless"],
 
@@ -22,40 +19,58 @@ const card: Card = {
 		ja: "広い 縄張りを 持っており 侵入する 邪魔者は 徹底的に つつかれてしまう。",
 		'zh-tw': "擁有著廣闊的地盤。 要是有哪個討厭鬼膽敢入侵， 就會遭到牠的瘋狂啄擊。",
 		th: "มีอาณาเขตกว้างขวาง ผู้ที่บุกรุกเข้ามาในอาณาเขตจะถูกไล่จิกจนพรุน",
-		id: "Pidgeotto memiliki wilayah teritorial yang luas. Pokémon ini mematuk secara menyeluruh penyusup yang memasuki wilayah teritorialnya."
+		id: "Pidgeotto memiliki wilayah teritorial yang luas. Pokémon ini mematuk secara menyeluruh penyusup yang memasuki wilayah teritorialnya.",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		cost: ["Colorless"],
-
-		name: {
-			ja: "はばたく",
-			'zh-tw': "羽擊",
-			th: "ตีปีก",
-			id: "Mengepak"
+	attacks: [
+		{
+			name: {
+				ja: "はばたく",
+				'zh-tw': "羽擊",
+				th: "ตีปีก",
+				id: "Mengepak",
+			},
+			damage: 20,
+			cost: ["Colorless"],
 		},
+	],
 
-		damage: 20
-	}],
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
 
-	weaknesses: [{
-		type: "Lightning",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 719459,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				cardmarket: 837256,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				cardmarket: 837257,
+			},
+		},
+	],
 
-	resistances: [{
-		type: "Fighting",
-		value: "-30"
-	}],
+	evolveFrom: {
+		ja: "ポッポ",
+	},
 
 	retreat: 0,
 	regulationMark: "G",
+	rarity: "Common",
+	dexId: [17],
+};
 
-	thirdParty: {
-		cardmarket: 719459
-	}
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV2a/018.ts
+++ b/data-asia/SV/SV2a/018.ts
@@ -1,20 +1,17 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV2a"
+import { Card } from "../../../interfaces";
+import Set from "../SV2a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "ピジョット",
 		'zh-tw': "大比鳥",
 		th: "พีเจียต",
-		id: "Pidgeot"
+		id: "Pidgeot",
 	},
 
 	illustrator: "Oswaldo KATO",
-	rarity: "Uncommon",
 	category: "Pokemon",
-	dexId: [18],
 	hp: 130,
 	types: ["Colorless"],
 
@@ -22,58 +19,74 @@ const card: Card = {
 		ja: "美しい 羽を 広げて 相手を 威嚇する。 マッハ２で 空を 飛び回る。",
 		'zh-tw': "會展開美麗的翅膀威嚇對手。 能以２馬赫的速度在空中四處飛行。",
 		th: "กางปีกอันสวยงามออกเพื่อข่มขวัญศัตรู บินไปมาบนท้องฟ้าด้วยความเร็วเสียง 2 มัค",
-		id: "Pidgeot mengintimidasi lawannya dengan melebarkan sayapnya yang indah. Pokémon ini terbang mengelilingi langit dengan kecepatan 2 Mach."
+		id: "Pidgeot mengintimidasi lawannya dengan melebarkan sayapnya yang indah. Pokémon ini terbang mengelilingi langit dengan kecepatan 2 Mach.",
 	},
 
 	stage: "Stage2",
 
-	attacks: [{
-		cost: ["Colorless"],
-
-		name: {
-			ja: "はばたく",
-			'zh-tw': "羽擊",
-			th: "ตีปีก",
-			id: "Mengepak"
+	attacks: [
+		{
+			name: {
+				ja: "はばたく",
+				'zh-tw': "羽擊",
+				th: "ตีปีก",
+				id: "Mengepak",
+			},
+			damage: 40,
+			cost: ["Colorless"],
 		},
-
-		damage: 40
-	}, {
-		cost: ["Colorless", "Colorless", "Colorless"],
-
-		name: {
-			ja: "そらをとぶ",
-			'zh-tw': "飛翔",
-			th: "บินขึ้น",
-			id: "Terbang"
+		{
+			name: {
+				ja: "そらをとぶ",
+				'zh-tw': "飛翔",
+				th: "บินขึ้น",
+				id: "Terbang",
+			},
+			damage: 150,
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "コインを1回投げウラなら、このワザは失敗。オモテなら、次の相手の番、このポケモンはワザのダメージや効果を受けない。",
+				'zh-tw': "擲1次硬幣若為反面，則這個招式失敗。若為正面，則在下個對手的回合，這隻寶可夢不會受到招式的傷害與效果的影響。",
+				th: "ทอยเหรียญ 1 ครั้งถ้าออกก้อย ท่าต่อสู้นี้จะล้มเหลว ถ้าออกหัว เทิร์นถัดไปของฝ่ายตรงข้าม โปเกมอนนี้จะไม่ได้รับแดเมจและเอฟเฟกต์ของท่าต่อสู้",
+				id: "Lempar koin 1 kali. Jika hasilnya sisi belakang, serangan ini gagal. Jika hasilnya sisi depan, pada giliran lawan berikutnya, Pokémon ini tidak menerima kerusakan dan efek akibat serangan.",
+			},
 		},
+	],
 
-		damage: 150,
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
 
-		effect: {
-			ja: "コインを1回投げウラなら、このワザは失敗。オモテなら、次の相手の番、このポケモンはワザのダメージや効果を受けない。",
-			'zh-tw': "擲1次硬幣若為反面，則這個招式失敗。若為正面，則在下個對手的回合，這隻寶可夢不會受到招式的傷害與效果的影響。",
-			th: "ทอยเหรียญ 1 ครั้งถ้าออกก้อย ท่าต่อสู้นี้จะล้มเหลว ถ้าออกหัว เทิร์นถัดไปของฝ่ายตรงข้าม โปเกมอนนี้จะไม่ได้รับแดเมจและเอฟเฟกต์ของท่าต่อสู้",
-			id: "Lempar koin 1 kali. Jika hasilnya sisi belakang, serangan ini gagal. Jika hasilnya sisi depan, pada giliran lawan berikutnya, Pokémon ini tidak menerima kerusakan dan efek akibat serangan."
-		}
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 719460,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				cardmarket: 837258,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				cardmarket: 837259,
+			},
+		},
+	],
 
-	weaknesses: [{
-		type: "Lightning",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Fighting",
-		value: "-30"
-	}],
+	evolveFrom: {
+		ja: "ピジョン",
+	},
 
 	retreat: 0,
 	regulationMark: "G",
+	rarity: "Uncommon",
+	dexId: [18],
+};
 
-	thirdParty: {
-		cardmarket: 719459
-	}
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV2a/019.ts
+++ b/data-asia/SV/SV2a/019.ts
@@ -1,20 +1,17 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV2a"
+import { Card } from "../../../interfaces";
+import Set from "../SV2a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "コラッタ",
 		'zh-tw': "小拉達",
 		th: "โครัตตา",
-		id: "Rattata"
+		id: "Rattata",
 	},
 
 	illustrator: "sowsow",
-	rarity: "Common",
 	category: "Pokemon",
-	dexId: [19],
 	hp: 40,
 	types: ["Colorless"],
 
@@ -22,42 +19,60 @@ const card: Card = {
 		ja: "ありふれた ポケモンだが 注意。 鋭い 前歯は 堅い 材木さえ 簡単に へしおる。",
 		'zh-tw': "雖然是常見的寶可夢，但還是要小心。 銳利的門牙十分堅硬， 就連木材也能輕易咬斷。",
 		th: "เป็นโปเกมอนที่พบเห็นได้ทั่วไปแต่ควรระวังให้ดี ฟันหน้าที่แหลมคมนั้นสามารถงอแม้กระทั่งท่อนไม้แข็ง ๆ จนหักได้อย่างง่ายดาย",
-		id: "Pokémon yang mudah dijumpai, tapi berhati-hatilah. Gigi depan tajam Rattata dapat mematahkan balok kayu keras dengan mudah."
+		id: "Pokémon yang mudah dijumpai, tapi berhati-hatilah. Gigi depan tajam Rattata dapat mematahkan balok kayu keras dengan mudah.",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		cost: ["Colorless", "Colorless"],
-
-		name: {
-			ja: "きずをかじる",
-			'zh-tw': "咬傷口",
-			th: "แทะบาดแผล",
-			id: "Menggerogoti Luka"
+	attacks: [
+		{
+			name: {
+				ja: "きずをかじる",
+				'zh-tw': "咬傷口",
+				th: "แทะบาดแผล",
+				id: "Menggerogoti Luka",
+			},
+			damage: "20+",
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンにのっているダメカンの数×10ダメージ追加。",
+				'zh-tw': "增加對手的戰鬥寶可夢身上放置的傷害指示物的數量×10點傷害。",
+				th: "แดเมจจะเพิ่มตามจำนวนตัวนับแดเมจที่วางอยู่บนโปเกมอนบนตำแหน่งต่อสู้ฝ่ายตรงข้าม x10",
+				id: "Kerusakan yang diberikan bertambah sejumlah 10 untuk tiap Token Kerusakan yang dimiliki Pokémon Bertarung lawan.",
+			},
 		},
+	],
 
-		damage: "20+",
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
 
-		effect: {
-			ja: "相手のバトルポケモンにのっているダメカンの数×10ダメージ追加。",
-			'zh-tw': "增加對手的戰鬥寶可夢身上放置的傷害指示物的數量×10點傷害。",
-			th: "แดเมจจะเพิ่มตามจำนวนตัวนับแดเมจที่วางอยู่บนโปเกมอนบนตำแหน่งต่อสู้ฝ่ายตรงข้าม x10",
-			id: "Kerusakan yang diberikan bertambah sejumlah 10 untuk tiap Token Kerusakan yang dimiliki Pokémon Bertarung lawan."
-		}
-	}],
-
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 719461,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				cardmarket: 837260,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				cardmarket: 837261,
+			},
+		},
+	],
 
 	retreat: 1,
 	regulationMark: "G",
+	rarity: "Common",
+	dexId: [19],
+};
 
-	thirdParty: {
-		cardmarket: 719461
-	}
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV2a/020.ts
+++ b/data-asia/SV/SV2a/020.ts
@@ -1,20 +1,17 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV2a"
+import { Card } from "../../../interfaces";
+import Set from "../SV2a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "ラッタ",
 		'zh-tw': "拉達",
 		th: "รัตตา",
-		id: "Raticate"
+		id: "Raticate",
 	},
 
 	illustrator: "sowsow",
-	rarity: "Uncommon",
 	category: "Pokemon",
-	dexId: [20],
 	hp: 70,
 	types: ["Colorless"],
 
@@ -22,42 +19,64 @@ const card: Card = {
 		ja: "ヒゲは バランスを とる 大切な 器官。 どんなに 仲良くなっても 触られると 怒って 噛みつく。",
 		'zh-tw': "鬍鬚是用來保持平衡的重要器官。 就算感情再好，如果摸了牠的鬍鬚， 牠都會生氣地咬過來。",
 		th: "หนวดเป็นอวัยวะสำคัญสำหรับรักษาสมดุล ไม่ว่าจะสนิทแค่ไหน ถ้าไปแตะถูกหนวดล่ะก็ มันจะโกรธและกัดงับเข้าให้",
-		id: "Kumis Raticate adalah organ penting untuk menjaga keseimbangan. Walau seakrab apa pun dengannya, ia akan marah dan menggigit jika disentuh kumisnya."
+		id: "Kumis Raticate adalah organ penting untuk menjaga keseimbangan. Walau seakrab apa pun dengannya, ia akan marah dan menggigit jika disentuh kumisnya.",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		cost: ["Colorless", "Colorless"],
-
-		name: {
-			ja: "きずにかみつく",
-			'zh-tw': "咬住傷口",
-			th: "กัดติดบาดแผล",
-			id: "Menggigit Luka"
+	attacks: [
+		{
+			name: {
+				ja: "きずにかみつく",
+				'zh-tw': "咬住傷口",
+				th: "กัดติดบาดแผล",
+				id: "Menggigit Luka",
+			},
+			damage: "30+",
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンにのっているダメカンの数×30ダメージ追加。",
+				'zh-tw': "增加對手的戰鬥寶可夢身上放置的傷害指示物的數量×30點傷害。",
+				th: "แดเมจจะเพิ่มตามจำนวนตัวนับแดเมจที่วางอยู่บนโปเกมอนบนตำแหน่งต่อสู้ฝ่ายตรงข้าม x30",
+				id: "Kerusakan yang diberikan bertambah sejumlah 30 untuk tiap Token Kerusakan yang dimiliki Pokémon Bertarung lawan.",
+			},
 		},
+	],
 
-		damage: "30+",
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
 
-		effect: {
-			ja: "相手のバトルポケモンにのっているダメカンの数×30ダメージ追加。",
-			'zh-tw': "增加對手的戰鬥寶可夢身上放置的傷害指示物的數量×30點傷害。",
-			th: "แดเมจจะเพิ่มตามจำนวนตัวนับแดเมจที่วางอยู่บนโปเกมอนบนตำแหน่งต่อสู้ฝ่ายตรงข้าม x30",
-			id: "Kerusakan yang diberikan bertambah sejumlah 30 untuk tiap Token Kerusakan yang dimiliki Pokémon Bertarung lawan."
-		}
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 719462,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				cardmarket: 837262,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				cardmarket: 837263,
+			},
+		},
+	],
 
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "コラッタ",
+	},
 
 	retreat: 0,
 	regulationMark: "G",
+	rarity: "Uncommon",
+	dexId: [20],
+};
 
-	thirdParty: {
-		cardmarket: 719462
-	}
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV2a/021.ts
+++ b/data-asia/SV/SV2a/021.ts
@@ -1,20 +1,17 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV2a"
+import { Card } from "../../../interfaces";
+import Set from "../SV2a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "オニスズメ",
 		'zh-tw': "烈雀",
 		th: "โอนิสึซึเมะ",
-		id: "Spearow"
+		id: "Spearow",
 	},
 
 	illustrator: "Gemi",
-	rarity: "Common",
 	category: "Pokemon",
-	dexId: [21],
 	hp: 50,
 	types: ["Colorless"],
 
@@ -22,58 +19,72 @@ const card: Card = {
 		ja: "羽が 短く 長い 距離を 飛べない。 せわしなく 動き まわって むしポケモンを ついばむ。",
 		'zh-tw': "翅膀很短，無法長距離飛行。 總是不停地四處跳來跳去， 忙著啄食蟲寶可夢。",
 		th: "ด้วยปีกที่สั้นทำให้บินได้ไม่ไกล มักขยับไปมาอย่างลุกลี้ลุกลนจิกกินโปเกมอนแมลง",
-		id: "Spearow tidak dapat terbang jauh karena sayapnya pendek. Pokémon ini bergerak ke sekeliling dengan tergesa-gesa untuk mencari dan mematuk Pokémon serangga."
+		id: "Spearow tidak dapat terbang jauh karena sayapnya pendek. Pokémon ini bergerak ke sekeliling dengan tergesa-gesa untuk mencari dan mematuk Pokémon serangga.",
 	},
 
 	stage: "Basic",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			ja: "ぬけがけしんか",
-			'zh-tw': "搶先進化",
-			th: "ชิงวิวัฒนาการ",
-			id: "Evolusi Mencuri Start"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "ぬけがけしんか",
+				'zh-tw': "搶先進化",
+				th: "ชิงวิวัฒนาการ",
+				id: "Evolusi Mencuri Start",
+			},
+			effect: {
+				ja: "このポケモンは、後攻プレイヤーの最初の番なら、出したばかりでも進化できる。",
+				'zh-tw': "若在後攻玩家的最初回合，則這隻寶可夢就算剛使出也可進化。",
+				th: "โปเกมอนนี้ ถ้าเป็นเทิร์นแรกสุดของผู้เล่นฝ่ายเล่นทีหลัง แม้จะเพิ่งออกมาก็สามารถวิวัฒนาการได้",
+				id: "Jika ini adalah giliran pertama Pemain Kedua, Pokémon ini dapat dievolusikan meskipun baru dimasukkan.",
+			},
 		},
+	],
 
-		effect: {
-			ja: "このポケモンは、後攻プレイヤーの最初の番なら、出したばかりでも進化できる。",
-			'zh-tw': "若在後攻玩家的最初回合，則這隻寶可夢就算剛使出也可進化。",
-			th: "โปเกมอนนี้ ถ้าเป็นเทิร์นแรกสุดของผู้เล่นฝ่ายเล่นทีหลัง แม้จะเพิ่งออกมาก็สามารถวิวัฒนาการได้",
-			id: "Jika ini adalah giliran pertama Pemain Kedua, Pokémon ini dapat dievolusikan meskipun baru dimasukkan."
-		}
-	}],
-
-	attacks: [{
-		cost: ["Colorless"],
-
-		name: {
-			ja: "スピードひこう",
-			'zh-tw': "高速飛行",
-			th: "บินเร็วจี๋",
-			id: "Terbang Cepat"
+	attacks: [
+		{
+			name: {
+				ja: "スピードひこう",
+				'zh-tw': "高速飛行",
+				th: "บินเร็วจี๋",
+				id: "Terbang Cepat",
+			},
+			damage: 10,
+			cost: ["Colorless"],
 		},
+	],
 
-		damage: 10
-	}],
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
 
-	weaknesses: [{
-		type: "Lightning",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Fighting",
-		value: "-30"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 719463,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				cardmarket: 837264,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				cardmarket: 837265,
+			},
+		},
+	],
 
 	retreat: 1,
 	regulationMark: "G",
+	rarity: "Common",
+	dexId: [21],
+};
 
-	thirdParty: {
-		cardmarket: 719463
-	}
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV2a/022.ts
+++ b/data-asia/SV/SV2a/022.ts
@@ -1,20 +1,17 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV2a"
+import { Card } from "../../../interfaces";
+import Set from "../SV2a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "オニドリル",
 		'zh-tw': "大嘴雀",
 		th: "โอนิดริล",
-		id: "Fearow"
+		id: "Fearow",
 	},
 
 	illustrator: "Gemi",
-	rarity: "Uncommon",
 	category: "Pokemon",
-	dexId: [22],
 	hp: 90,
 	types: ["Colorless"],
 
@@ -22,56 +19,73 @@ const card: Card = {
 		ja: "オニドリルの 縄張りで 食べ物を 持って 歩くのは 危険だ。 あっという 間に かっさらわれるぞ。",
 		'zh-tw': "在大嘴雀的地盤上帶著食物走動是件危險的事， 食物轉眼間就會被奪走。",
 		th: "การถือของกินเดินเข้าไปในอาณาเขตของโอนิดริลเป็นเรื่องที่อันตรายอย่างยิ่ง เพราะจะถูกฉกแย่งหายไปโดยที่ไม่ทันได้ตั้งตัว",
-		id: "Berbahaya jika berjalan sambil membawa makanan di daerah kekuasaan Fearow. Pokémon ini akan menyambarnya dalam sekejap."
+		id: "Berbahaya jika berjalan sambil membawa makanan di daerah kekuasaan Fearow. Pokémon ini akan menyambarnya dalam sekejap.",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		cost: ["Colorless"],
-
-		name: {
-			ja: "くちばしキャッチ",
-			'zh-tw': "鳥嘴捕捉",
-			th: "จะงอยจับ",
-			id: "Paruh Penangkap"
+	attacks: [
+		{
+			name: {
+				ja: "くちばしキャッチ",
+				'zh-tw': "鳥嘴捕捉",
+				th: "จะงอยจับ",
+				id: "Paruh Penangkap",
+			},
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札から好きなカードを3枚まで選び、手札に加える。そして山札を切る。",
+				'zh-tw': "從自己的牌庫任意選擇最多3張卡加入手牌。並且重洗牌庫。",
+				th: "เลือกการ์ดที่ชอบได้สูงสุด 3 ใบจากสำรับการ์ดฝ่ายเรา นำขึ้นมือ แล้วสับสำรับการ์ด",
+				id: "Pilih paling banyak 3 kartu sesukanya dari Deck sendiri, lalu tambahkan ke Kartu Pegangan. Kemudian, kocok Deck.",
+			},
 		},
-
-		effect: {
-			ja: "自分の山札から好きなカードを3枚まで選び、手札に加える。そして山札を切る。",
-			'zh-tw': "從自己的牌庫任意選擇最多3張卡加入手牌。並且重洗牌庫。",
-			th: "เลือกการ์ดที่ชอบได้สูงสุด 3 ใบจากสำรับการ์ดฝ่ายเรา นำขึ้นมือ แล้วสับสำรับการ์ด",
-			id: "Pilih paling banyak 3 kartu sesukanya dari Deck sendiri, lalu tambahkan ke Kartu Pegangan. Kemudian, kocok Deck."
-		}
-	}, {
-		cost: ["Colorless"],
-
-		name: {
-			ja: "スピードひこう",
-			'zh-tw': "高速飛行",
-			th: "บินเร็วจี๋",
-			id: "Terbang Cepat"
+		{
+			name: {
+				ja: "スピードひこう",
+				'zh-tw': "高速飛行",
+				th: "บินเร็วจี๋",
+				id: "Terbang Cepat",
+			},
+			damage: 50,
+			cost: ["Colorless"],
 		},
+	],
 
-		damage: 50
-	}],
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
 
-	weaknesses: [{
-		type: "Lightning",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 719464,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				cardmarket: 837267,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				cardmarket: 837268,
+			},
+		},
+	],
 
-	resistances: [{
-		type: "Fighting",
-		value: "-30"
-	}],
+	evolveFrom: {
+		ja: "オニスズメ",
+	},
 
 	retreat: 0,
 	regulationMark: "G",
+	rarity: "Uncommon",
+	dexId: [22],
+};
 
-	thirdParty: {
-		cardmarket: 719464
-	}
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV2a/023.ts
+++ b/data-asia/SV/SV2a/023.ts
@@ -1,20 +1,17 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV2a"
+import { Card } from "../../../interfaces";
+import Set from "../SV2a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "アーボ",
 		'zh-tw': "阿柏蛇",
 		th: "อาร์โบ",
-		id: "Ekans"
+		id: "Ekans",
 	},
 
 	illustrator: "Kedamahadaitai Yawarakai",
-	rarity: "Common",
 	category: "Pokemon",
-	dexId: [23],
 	hp: 70,
 	types: ["Darkness"],
 
@@ -22,42 +19,60 @@ const card: Card = {
 		ja: "とりポケモンの タマゴが 好物。 噛まずに 丸呑みするので 喉が 詰まって 気を 失うことも。",
 		'zh-tw': "最愛吃鳥寶可夢的蛋。 因為總是不咀嚼就整個吞下， 有時會被噎住而昏倒。",
 		th: "ของโปรดคือไข่ของโปเกมอนนก เนื่องจากชอบกลืนเข้าไปทั้งคำโดยไม่เคี้ยว บางครั้งจึงติดคอจนหมดสติไป",
-		id: "Telur Pokémon burung adalah makanan favorit Ekans. Kadang Pokémon ini menelan telur tanpa mengunyahnya, sehingga pingsan karena telur tersangkut di kerongkongannya."
+		id: "Telur Pokémon burung adalah makanan favorit Ekans. Kadang Pokémon ini menelan telur tanpa mengunyahnya, sehingga pingsan karena telur tersangkut di kerongkongannya.",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		cost: ["Darkness", "Darkness"],
-
-		name: {
-			ja: "アシッドボム",
-			'zh-tw': "酸液炸彈",
-			th: "ระเบิดกรด",
-			id: "Semprotan Asam"
+	attacks: [
+		{
+			name: {
+				ja: "アシッドボム",
+				'zh-tw': "酸液炸彈",
+				th: "ระเบิดกรด",
+				id: "Semprotan Asam",
+			},
+			damage: 30,
+			cost: ["Darkness", "Darkness"],
+			effect: {
+				ja: "コインを1回投げオモテなら、相手のバトルポケモンについているエネルギーを1個選び、トラッシュする。",
+				'zh-tw': "擲1次硬幣若為正面，則選擇1個對手的戰鬥寶可夢身上附加的能量，將其丟棄。",
+				th: "ทอยเหรียญ 1 ครั้งถ้าออกหัว เลือกพลังงานที่ติดอยู่กับโปเกมอนบนตำแหน่งต่อสู้ฝ่ายตรงข้าม 1 ลูก ทิ้งที่ตำแหน่งทิ้งการ์ด",
+				id: "Lempar koin 1 kali. Jika hasilnya sisi depan, pilih 1 Energi yang dikenakan pada Pokémon Bertarung lawan, lalu buang ke Trash.",
+			},
 		},
+	],
 
-		damage: 30,
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
 
-		effect: {
-			ja: "コインを1回投げオモテなら、相手のバトルポケモンについているエネルギーを1個選び、トラッシュする。",
-			'zh-tw': "擲1次硬幣若為正面，則選擇1個對手的戰鬥寶可夢身上附加的能量，將其丟棄。",
-			th: "ทอยเหรียญ 1 ครั้งถ้าออกหัว เลือกพลังงานที่ติดอยู่กับโปเกมอนบนตำแหน่งต่อสู้ฝ่ายตรงข้าม 1 ลูก ทิ้งที่ตำแหน่งทิ้งการ์ด",
-			id: "Lempar koin 1 kali. Jika hasilnya sisi depan, pilih 1 Energi yang dikenakan pada Pokémon Bertarung lawan, lalu buang ke Trash."
-		}
-	}],
-
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 719465,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				cardmarket: 837269,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				cardmarket: 837270,
+			},
+		},
+	],
 
 	retreat: 2,
 	regulationMark: "G",
+	rarity: "Common",
+	dexId: [23],
+};
 
-	thirdParty: {
-		cardmarket: 719465
-	}
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV2a/024.ts
+++ b/data-asia/SV/SV2a/024.ts
@@ -1,73 +1,79 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV2a"
+import { Card } from "../../../interfaces";
+import Set from "../SV2a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "アーボックex",
 		'zh-tw': "阿柏怪ex",
 		th: "อาร์บ็อกex",
-		id: "Arbok ex"
+		id: "Arbok ex",
 	},
 
 	illustrator: "Eske Yoshinob",
-	rarity: "Double rare",
 	category: "Pokemon",
 	hp: 270,
 	types: ["Darkness"],
+
 	stage: "Stage1",
-	suffix: "EX",
 
-	attacks: [{
-		cost: ["Darkness", "Darkness"],
-
-		name: {
-			ja: "しばりつける",
-			'zh-tw': "束縛",
-			th: "มัดยึด",
-			id: "Menjerat"
+	attacks: [
+		{
+			name: {
+				ja: "しばりつける",
+				'zh-tw': "束縛",
+				th: "มัดยึด",
+				id: "Menjerat",
+			},
+			damage: 70,
+			cost: ["Darkness", "Darkness"],
+			effect: {
+				ja: "次の相手の番、このワザを受けたポケモンは、にげられない。",
+				'zh-tw': "在下個對手的回合，受到這個招式的寶可夢無法撤退。",
+				th: "เทิร์นถัดไปของฝ่ายตรงข้าม โปเกมอนที่ได้รับท่าต่อสู้นี้ จะหนีไม่ได้",
+				id: "Pada giliran lawan berikutnya, Pokémon yang menerima serangan ini tidak dapat Mundur.",
+			},
 		},
-
-		damage: 70,
-
-		effect: {
-			ja: "次の相手の番、このワザを受けたポケモンは、にげられない。",
-			'zh-tw': "在下個對手的回合，受到這個招式的寶可夢無法撤退。",
-			th: "เทิร์นถัดไปของฝ่ายตรงข้าม โปเกมอนที่ได้รับท่าต่อสู้นี้ จะหนีไม่ได้",
-			id: "Pada giliran lawan berikutnya, Pokémon yang menerima serangan ini tidak dapat Mundur."
-		}
-	}, {
-		cost: ["Darkness", "Darkness", "Darkness"],
-
-		name: {
-			ja: "メナスファング",
-			'zh-tw': "脅迫獠牙",
-			th: "คมเขี้ยวคุกคาม",
-			id: "Menace Fang"
+		{
+			name: {
+				ja: "メナスファング",
+				'zh-tw': "脅迫獠牙",
+				th: "คมเขี้ยวคุกคาม",
+				id: "Menace Fang",
+			},
+			damage: 150,
+			cost: ["Darkness", "Darkness", "Darkness"],
+			effect: {
+				ja: "相手は相手自身の手札を2枚選び、トラッシュする。",
+				'zh-tw': "對手選擇對手自己的2張手牌，將其丟棄。",
+				th: "ฝ่ายตรงข้ามเลือกการ์ดบนมือฝ่ายตรงข้ามเอง 2 ใบ ทิ้งที่ตำแหน่งทิ้งการ์ด",
+				id: "Lawan memilih 2 lembar Kartu Pegangannya, lalu membuangnya ke Trash.",
+			},
 		},
+	],
 
-		damage: 150,
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
 
-		effect: {
-			ja: "相手は相手自身の手札を2枚選び、トラッシュする。",
-			'zh-tw': "對手選擇對手自己的2張手牌，將其丟棄。",
-			th: "ฝ่ายตรงข้ามเลือกการ์ดบนมือฝ่ายตรงข้ามเอง 2 ใบ ทิ้งที่ตำแหน่งทิ้งการ์ด",
-			id: "Lawan memilih 2 lembar Kartu Pegangannya, lalu membuangnya ke Trash."
-		}
-	}],
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 719466,
+			},
+		},
+	],
 
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "アーボ",
+	},
 
 	retreat: 2,
 	regulationMark: "G",
+	rarity: "Double rare",
+	dexId: [24],
 
-	thirdParty: {
-		cardmarket: 719466
-	}
-}
+	suffix: "EX",
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV2a/025.ts
+++ b/data-asia/SV/SV2a/025.ts
@@ -1,20 +1,17 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV2a"
+import { Card } from "../../../interfaces";
+import Set from "../SV2a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "ピカチュウ",
 		'zh-tw': "皮卡丘",
 		th: "พิคาชู",
-		id: "Pikachu"
+		id: "Pikachu",
 	},
 
 	illustrator: "Naoyo Kimura",
-	rarity: "Common",
 	category: "Pokemon",
-	dexId: [25],
 	hp: 60,
 	types: ["Lightning"],
 
@@ -22,51 +19,69 @@ const card: Card = {
 		ja: "両頬には 電気を 溜めこむ 袋がある。 怒ると 溜めこんだ 電気を 一気に 放ってくる。",
 		'zh-tw': "雙頰上有儲存電力的囊袋。一旦生氣就會把儲存的電力 一口氣釋放出來。",
 		th: "ที่แก้มทั้งสองข้างมีถุงสำหรับเก็บไฟฟ้า พอโกรธจะปล่อยไฟฟ้าที่เก็บเอาไว้ออกมาในรวดเดียว",
-		id: "Pikachu memiliki kantong penampung listrik di kedua pipinya. Ketika marah, Pokémon ini mengeluarkan seluruh listrik yang telah terkumpul."
+		id: "Pikachu memiliki kantong penampung listrik di kedua pipinya. Ketika marah, Pokémon ini mengeluarkan seluruh listrik yang telah terkumpul.",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		cost: ["Lightning"],
-
-		name: {
-			ja: "じゅうでん",
-			'zh-tw': "充電",
-			th: "ชาร์จ",
-			id: "Charge"
+	attacks: [
+		{
+			name: {
+				ja: "じゅうでん",
+				'zh-tw': "充電",
+				th: "ชาร์จ",
+				id: "Charge",
+			},
+			cost: ["Lightning"],
+			effect: {
+				ja: "自分の山札から「基本[L]エネルギー」を1枚選び、このポケモンにつける。そして山札を切る。",
+				'zh-tw': "從自己的牌庫選擇1張「基本【雷】能量」卡，附於這隻寶可夢身上。並且重洗牌庫。",
+				th: "เลือกการ์ด [พลังงานพื้นฐาน[สายฟ้า]] 1 ใบจากสำรับการ์ดฝ่ายเรา ติดที่โปเกมอนนี้ แล้วสับสำรับการ์ด",
+				id: "Pilih 1 lembar Energi Dasar {Listrik} dari Deck sendiri, lalu kenakan pada Pokémon ini. Kemudian, kocok Deck.",
+			},
 		},
-
-		effect: {
-			ja: "自分の山札から「基本エネルギー」を1枚選び、このポケモンにつける。そして山札を切る。",
-			'zh-tw': "從自己的牌庫選擇1張「基本【雷】能量」卡，附於這隻寶可夢身上。並且重洗牌庫。",
-			th: "เลือกการ์ด [พลังงานพื้นฐาน[สายฟ้า]] 1 ใบจากสำรับการ์ดฝ่ายเรา ติดที่โปเกมอนนี้ แล้วสับสำรับการ์ด",
-			id: "Pilih 1 lembar Energi Dasar {Listrik} dari Deck sendiri, lalu kenakan pada Pokémon ini. Kemudian, kocok Deck."
-		}
-	}, {
-		cost: ["Lightning", "Lightning", "Colorless"],
-
-		name: {
-			ja: "ピカパンチ",
-			'zh-tw': "皮卡拳",
-			th: "พิคาพันช์",
-			id: "Pika Punch"
+		{
+			name: {
+				ja: "ピカパンチ",
+				'zh-tw': "皮卡拳",
+				th: "พิคาพันช์",
+				id: "Pika Punch",
+			},
+			damage: 50,
+			cost: ["Lightning", "Lightning", "Colorless"],
 		},
+	],
 
-		damage: 50
-	}],
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 719467,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				cardmarket: 837271,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				cardmarket: 837272,
+			},
+		},
+	],
 
 	retreat: 1,
 	regulationMark: "G",
+	rarity: "Common",
+	dexId: [25],
+};
 
-	thirdParty: {
-		cardmarket: 719467
-	}
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV2a/026.ts
+++ b/data-asia/SV/SV2a/026.ts
@@ -1,20 +1,17 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV2a"
+import { Card } from "../../../interfaces";
+import Set from "../SV2a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "ライチュウ",
 		'zh-tw': "雷丘",
 		th: "ไรชู",
-		id: "Raichu"
+		id: "Raichu",
 	},
 
 	illustrator: "Naoyo Kimura",
-	rarity: "Rare",
 	category: "Pokemon",
-	dexId: [26],
 	hp: 120,
 	types: ["Lightning"],
 
@@ -22,60 +19,82 @@ const card: Card = {
 		ja: "尻尾が アースの 役目をはたして 電気を 地面に 逃がすので 自分自身は しびれたりしない。",
 		'zh-tw': "尾巴會發揮接地線的作用把電氣導入地面， 所以自己不會被電得發麻。",
 		th: "หางทำหน้าที่เป็นสายดินปล่อยไฟฟ้าไหลลงสู่พื้นดิน ทำให้ร่างกายของตัวเองไม่ชา",
-		id: "Karena ekornya berperan sebagai grounding yang melepaskan listrik ke tanah, Raichu tidak tersengat oleh listrik tersebut."
+		id: "Karena ekornya berperan sebagai grounding yang melepaskan listrik ke tanah, Raichu tidak tersengat oleh listrik tersebut.",
 	},
 
 	stage: "Stage1",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			ja: "ライアース",
-			'zh-tw': "雷之大地",
-			th: "ไรเอิร์ท",
-			id: "Rai Grounding"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "ライアース",
+				'zh-tw': "雷之大地",
+				th: "ไรเอิร์ท",
+				id: "Rai Grounding",
+			},
+			effect: {
+				ja: "自分のポケモンが、相手のポケモンからワザのダメージを受けてきぜつするたび、1回使える。きぜつしたポケモンについている[L]エネルギーを1枚選び、このポケモンにつけ替える。",
+				'zh-tw': "每次當自己的寶可夢受到對手的寶可夢招式的傷害而【昏厥】時，可使用1次。選擇1張【昏厥】的寶可夢身上附加的【雷】能量卡，改附於這隻寶可夢身上。",
+				th: "ทุกครั้งที่โปเกมอนฝ่ายเรา ได้รับแดเมจของท่าต่อสู้จากโปเกมอนฝ่ายตรงข้ามและ[หมดสภาพ] ใช้ได้ 1 ครั้ง เลือกการ์ดพลังงาน[สายฟ้า]ที่ติดอยู่กับโปเกมอนที่[หมดสภาพ] 1 ใบ ย้ายมาติดกับโปเกมอนนี้",
+				id: "Dapat digunakan 1 kali tiap kali Pokémon sendiri KO karena menerima kerusakan akibat serangan dari Pokémon lawan. Pilih 1 lembar Energi {Listrik} yang dikenakan pada Pokémon yang KO tersebut, lalu pindahkan ke Pokémon ini.",
+			},
 		},
+	],
 
-		effect: {
-			ja: "自分のポケモンが、相手のポケモンからワザのダメージを受けてきぜつするたび、1回使える。きぜつしたポケモンについているエネルギーを1枚選び、このポケモンにつけ替える。",
-			'zh-tw': "每次當自己的寶可夢受到對手的寶可夢招式的傷害而【昏厥】時，可使用1次。選擇1張【昏厥】的寶可夢身上附加的【雷】能量卡，改附於這隻寶可夢身上。",
-			th: "ทุกครั้งที่โปเกมอนฝ่ายเรา ได้รับแดเมจของท่าต่อสู้จากโปเกมอนฝ่ายตรงข้ามและ[หมดสภาพ] ใช้ได้ 1 ครั้ง เลือกการ์ดพลังงาน[สายฟ้า]ที่ติดอยู่กับโปเกมอนที่[หมดสภาพ] 1 ใบ ย้ายมาติดกับโปเกมอนนี้",
-			id: "Dapat digunakan 1 kali tiap kali Pokémon sendiri KO karena menerima kerusakan akibat serangan dari Pokémon lawan. Pilih 1 lembar Energi {Listrik} yang dikenakan pada Pokémon yang KO tersebut, lalu pindahkan ke Pokémon ini."
-		}
-	}],
-
-	attacks: [{
-		cost: ["Lightning", "Lightning", "Colorless"],
-
-		name: {
-			ja: "かみなり",
-			'zh-tw': "打雷",
-			th: "ฟ้าผ่า",
-			id: "Guntur"
+	attacks: [
+		{
+			name: {
+				ja: "かみなり",
+				'zh-tw': "打雷",
+				th: "ฟ้าผ่า",
+				id: "Guntur",
+			},
+			damage: 180,
+			cost: ["Lightning", "Lightning", "Colorless"],
+			effect: {
+				ja: "このポケモンにも50ダメージ。",
+				'zh-tw': "這隻寶可夢也受到50點傷害。",
+				th: "โปเกมอนนี้ก็จะได้รับแดเมจ 50 ด้วย",
+				id: "Pokémon ini juga menerima kerusakan sejumlah 50.",
+			},
 		},
+	],
 
-		damage: 180,
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
 
-		effect: {
-			ja: "このポケモンにも50ダメージ。",
-			'zh-tw': "這隻寶可夢也受到50點傷害。",
-			th: "โปเกมอนนี้ก็จะได้รับแดเมจ 50 ด้วย",
-			id: "Pokémon ini juga menerima kerusakan sejumlah 50."
-		}
-	}],
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 719468,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				cardmarket: 837273,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				cardmarket: 837274,
+			},
+		},
+	],
 
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "ピカチュウ",
+	},
 
 	retreat: 1,
 	regulationMark: "G",
+	rarity: "Rare",
+	dexId: [26],
+};
 
-	thirdParty: {
-		cardmarket: 719468
-	}
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV2a/027.ts
+++ b/data-asia/SV/SV2a/027.ts
@@ -1,20 +1,17 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV2a"
+import { Card } from "../../../interfaces";
+import Set from "../SV2a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "サンド",
 		'zh-tw': "穿山鼠",
 		th: "แซนด์",
-		id: "Sandshrew"
+		id: "Sandshrew",
 	},
 
 	illustrator: "kodama",
-	rarity: "Common",
 	category: "Pokemon",
-	dexId: [27],
 	hp: 60,
 	types: ["Fighting"],
 
@@ -22,53 +19,72 @@ const card: Card = {
 		ja: "地面を 掘って 巣穴を つくる。 地中の 硬い 岩も 鋭い ツメで 砕いて 掘り進むぞ。",
 		'zh-tw': "會在地面挖洞築巢。即使遇到地下堅硬的岩石， 也會用銳利的爪子擊碎並向前挖進。",
 		th: "จะขุดลงไปใต้พื้นดินเพื่อสร้างรัง ถึงจะเป็นหินแข็งที่อยู่ใต้ดิน ก็จะใช้กรงเล็บคมเจาะจนแตกเป็นผุยผงแล้วขุดลงไปต่อ",
-		id: "Sandshrew menggali permukaan tanah untuk membuat sarang. Pokémon ini terus menggali sambil menghancurkan batu keras di dalam tanah menggunakan cakar tajamnya."
+		id: "Sandshrew menggali permukaan tanah untuk membuat sarang. Pokémon ini terus menggali sambil menghancurkan batu keras di dalam tanah menggunakan cakar tajamnya.",
 	},
 
 	stage: "Basic",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			ja: "すなでかくす",
-			'zh-tw': "流沙藏身",
-			th: "ซุกซ่อนด้วยทราย",
-			id: "Sembunyikan di Pasir"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "すなでかくす",
+				'zh-tw': "流沙藏身",
+				th: "ซุกซ่อนด้วยทราย",
+				id: "Sembunyikan di Pasir",
+			},
+			effect: {
+				ja: "このポケモンがいるかぎり、相手のトラッシュにあるトレーナーズは、相手のグッズまたはサポートの効果で、山札にもどせない。",
+				'zh-tw': "只要這隻寶可夢在場上，對手的棄牌區的訓練家卡，無法因對手的物品卡或者支援者卡的效果而放回牌庫。",
+				th: "ตราบใดที่โปเกมอนนี้ยังอยู่ การ์ดเทรนเนอร์ที่อยู่บนตำแหน่งทิ้งการ์ดฝ่ายตรงข้าม จะนำใส่กลับไปในสำรับการ์ด ด้วยเอฟเฟกต์ของการ์ดไอเท็มหรือการ์ดซัพพอร์ตของฝ่ายตรงข้ามไม่ได้",
+				id: "Selama Pokémon ini ada di Arena, Trainer yang ada di Trash lawan tidak dapat dikembalikan ke Deck menggunakan efek Item atau Supporter lawan.",
+			},
 		},
+	],
 
-		effect: {
-			ja: "このポケモンがいるかぎり、相手のトラッシュにあるトレーナーズは、相手のグッズまたはサポートの効果で、山札にもどせない。",
-			'zh-tw': "只要這隻寶可夢在場上，對手的棄牌區的訓練家卡，無法因對手的物品卡或者支援者卡的效果而放回牌庫。",
-			th: "ตราบใดที่โปเกมอนนี้ยังอยู่ การ์ดเทรนเนอร์ที่อยู่บนตำแหน่งทิ้งการ์ดฝ่ายตรงข้าม จะนำใส่กลับไปในสำรับการ์ด ด้วยเอฟเฟกต์ของการ์ดไอเท็มหรือการ์ดซัพพอร์ตของฝ่ายตรงข้ามไม่ได้",
-			id: "Selama Pokémon ini ada di Arena, Trainer yang ada di Trash lawan tidak dapat dikembalikan ke Deck menggunakan efek Item atau Supporter lawan."
-		}
-	}],
-
-	attacks: [{
-		cost: ["Colorless", "Colorless"],
-
-		name: {
-			ja: "ひっかく",
-			'zh-tw': "抓",
-			th: "ข่วน",
-			id: "Menggaruk"
+	attacks: [
+		{
+			name: {
+				ja: "ひっかく",
+				'zh-tw': "抓",
+				th: "ข่วน",
+				id: "Menggaruk",
+			},
+			damage: 30,
+			cost: ["Colorless", "Colorless"],
 		},
+	],
 
-		damage: 30
-	}],
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Grass",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 719469,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				cardmarket: 837275,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				cardmarket: 837276,
+			},
+		},
+	],
 
 	retreat: 1,
 	regulationMark: "G",
+	rarity: "Common",
+	dexId: [27],
+};
 
-	thirdParty: {
-		cardmarket: 719469
-	}
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV2a/028.ts
+++ b/data-asia/SV/SV2a/028.ts
@@ -1,20 +1,17 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV2a"
+import { Card } from "../../../interfaces";
+import Set from "../SV2a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "サンドパン",
 		'zh-tw': "穿山王",
 		th: "แซนด์แพน",
-		id: "Sandslash"
+		id: "Sandslash",
 	},
 
 	illustrator: "kodama",
-	rarity: "Uncommon",
 	category: "Pokemon",
-	dexId: [28],
 	hp: 120,
 	types: ["Fighting"],
 
@@ -22,60 +19,80 @@ const card: Card = {
 		ja: "鋭い ツメを ひっかけて 木を 登る。 下で 待つ サンドたちに 木の実を 落とし 分け与えるのだ。",
 		'zh-tw': "會用銳利的爪子當作鉤子來爬樹。這是為了將樹果擊落， 分給在樹下等待的穿山鼠們。",
 		th: "ใช้กรงเล็บแหลมคมจิกและปีนขึ้นต้นไม้ เพื่อโยนผลไม้ลงมาแบ่งให้กับเหล่าแซนด์ที่รออยู่ด้านล่าง",
-		id: "Sandslash mendaki pohon dengan mengaitkan cakarnya yang tajam. Pokémon ini menjatuhkan beri dan membagikannya pada Sandshrew yang menanti di bawah pohon."
+		id: "Sandslash mendaki pohon dengan mengaitkan cakarnya yang tajam. Pokémon ini menjatuhkan beri dan membagikannya pada Sandshrew yang menanti di bawah pohon.",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		cost: ["Fighting"],
-
-		name: {
-			ja: "じひびき",
-			'zh-tw': "地鳴",
-			th: "พสุธากัมปนาท",
-			id: "Gelegar Tanah"
+	attacks: [
+		{
+			name: {
+				ja: "じひびき",
+				'zh-tw': "地鳴",
+				th: "พสุธากัมปนาท",
+				id: "Gelegar Tanah",
+			},
+			damage: 30,
+			cost: ["Fighting"],
+			effect: {
+				ja: "次の相手の番、このワザを受けたポケモンは、にげられない。",
+				'zh-tw': "在下個對手的回合，受到這個招式的寶可夢無法撤退。",
+				th: "เทิร์นถัดไปของฝ่ายตรงข้าม โปเกมอนที่ได้รับท่าต่อสู้นี้ จะหนีไม่ได้",
+				id: "Pada giliran lawan berikutnya, Pokémon yang menerima serangan ini tidak dapat Mundur.",
+			},
 		},
-
-		damage: 30,
-
-		effect: {
-			ja: "次の相手の番、このワザを受けたポケモンは、にげられない。",
-			'zh-tw': "在下個對手的回合，受到這個招式的寶可夢無法撤退。",
-			th: "เทิร์นถัดไปของฝ่ายตรงข้าม โปเกมอนที่ได้รับท่าต่อสู้นี้ จะหนีไม่ได้",
-			id: "Pada giliran lawan berikutnya, Pokémon yang menerima serangan ini tidak dapat Mundur."
-		}
-	}, {
-		cost: ["Fighting", "Colorless", "Colorless"],
-
-		name: {
-			ja: "トゲでえぐる",
-			'zh-tw': "針裂",
-			th: "คว้านด้วยหนาม",
-			id: "Duri Pengoyak"
+		{
+			name: {
+				ja: "トゲでえぐる",
+				'zh-tw': "針裂",
+				th: "คว้านด้วยหนาม",
+				id: "Duri Pengoyak",
+			},
+			damage: "80+",
+			cost: ["Fighting", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンにダメカンがのっているなら、100ダメージ追加。",
+				'zh-tw': "若對手的戰鬥寶可夢身上放置有傷害指示物，則增加100點傷害。",
+				th: "ถ้าโปเกมอนบนตำแหน่งต่อสู้ฝ่ายตรงข้ามมีตัวนับแดเมจวางอยู่ การโจมตีนี้จะเพิ่มแดเมจอีก 100",
+				id: "Jika Pokémon Bertarung lawan memiliki Token Kerusakan, kerusakan yang diberikan bertambah sejumlah 100.",
+			},
 		},
+	],
 
-		damage: "80+",
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
 
-		effect: {
-			ja: "相手のバトルポケモンにダメカンがのっているなら、100ダメージ追加。",
-			'zh-tw': "若對手的戰鬥寶可夢身上放置有傷害指示物，則增加100點傷害。",
-			th: "ถ้าโปเกมอนบนตำแหน่งต่อสู้ฝ่ายตรงข้ามมีตัวนับแดเมจวางอยู่ การโจมตีนี้จะเพิ่มแดเมจอีก 100",
-			id: "Jika Pokémon Bertarung lawan memiliki Token Kerusakan, kerusakan yang diberikan bertambah sejumlah 100."
-		}
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 719470,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				cardmarket: 837277,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				cardmarket: 837278,
+			},
+		},
+	],
 
-	weaknesses: [{
-		type: "Grass",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "サンド",
+	},
 
 	retreat: 2,
 	regulationMark: "G",
+	rarity: "Uncommon",
+	dexId: [28],
+};
 
-	thirdParty: {
-		cardmarket: 719470
-	}
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV2a/029.ts
+++ b/data-asia/SV/SV2a/029.ts
@@ -1,20 +1,17 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV2a"
+import { Card } from "../../../interfaces";
+import Set from "../SV2a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "ニドラン♀",
 		'zh-tw': "尼多蘭",
 		th: "นิโดรัน♀",
-		id: "Nidoran♀"
+		id: "Nidoran♀",
 	},
 
 	illustrator: "Teeziro",
-	rarity: "Common",
 	category: "Pokemon",
-	dexId: [29],
 	hp: 60,
 	types: ["Darkness"],
 
@@ -22,38 +19,60 @@ const card: Card = {
 		ja: "硬い 前歯で 木の実を 砕いて 食べる。 ツノの 先は オスより 少し 丸みを 帯びている。",
 		'zh-tw': "會用堅硬的門牙咬碎樹果後吃下。角的尖端 會比雄性還要圓一些。",
 		th: "ใช้ฟันหน้าที่สุดแข็งกะเทาะผลไม้และกัดกิน ปลายเขานั้นมีความมนกลมมากกว่าตัวผู้",
-		id: "Nidoran betina menggunakan gigi depannya yang keras untuk mengunyah hancur beri dan memakannya. Ujung tanduknya lebih membulat daripada yang jantan."
+		id: "Nidoran betina menggunakan gigi depannya yang keras untuk mengunyah hancur beri dan memakannya. Ujung tanduknya lebih membulat daripada yang jantan.",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		cost: ["Darkness", "Colorless"],
-
-		name: {
-			ja: "どくのつの",
-			'zh-tw': "毒角",
-			th: "เขาพิษ",
-			id: "Tanduk Beracun"
+	attacks: [
+		{
+			name: {
+				ja: "どくのつの",
+				'zh-tw': "毒角",
+				th: "เขาพิษ",
+				id: "Tanduk Beracun",
+			},
+			damage: 20,
+			cost: ["Darkness", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをどくにする。",
+				'zh-tw': "將對手的戰鬥寶可夢【中毒】。",
+				th: "ทำให้โปเกมอนบนตำแหน่งต่อสู้ฝ่ายตรงข้ามเป็นสภาวะ[พิษ]",
+				id: "Ubah kondisi Pokémon Bertarung lawan menjadi Racun.",
+			},
 		},
+	],
 
-		damage: 20,
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
 
-		effect: {
-			ja: "相手のバトルポケモンをどくにする。",
-			'zh-tw': "將對手的戰鬥寶可夢【中毒】。",
-			th: "ทำให้โปเกมอนบนตำแหน่งต่อสู้ฝ่ายตรงข้ามเป็นสภาวะ[พิษ]",
-			id: "Ubah kondisi Pokémon Bertarung lawan menjadi Racun."
-		}
-	}],
-
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 719471,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				cardmarket: 837279,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				cardmarket: 837280,
+			},
+		},
+	],
 
 	retreat: 1,
-	regulationMark: "G"
-}
+	regulationMark: "G",
+	rarity: "Common",
+	dexId: [29],
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV2a/030.ts
+++ b/data-asia/SV/SV2a/030.ts
@@ -1,20 +1,17 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV2a"
+import { Card } from "../../../interfaces";
+import Set from "../SV2a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "ニドリーナ",
 		'zh-tw': "尼多娜",
 		th: "นิโดรินา",
-		id: "Nidorina"
+		id: "Nidorina",
 	},
 
 	illustrator: "Teeziro",
-	rarity: "Uncommon",
 	category: "Pokemon",
-	dexId: [30],
 	hp: 90,
 	types: ["Darkness"],
 
@@ -22,51 +19,73 @@ const card: Card = {
 		ja: "群れに 危険が せまると 仲間で 結束して 超音波の 大合唱を おみまいするぞ。",
 		'zh-tw': "有危險逼近群體時，會與夥伴們團結一致地 用超音波的大合唱來攻擊。",
 		th: "หากมีภัยอันตรายเข้าใกล้ฝูงจะรวมกลุ่มกับพวกส่งเสียงร้องประสานความถี่สูงเข้าใส่เลยนะ",
-		id: "Ketika bahaya mendekati gerombolannya, Nidorina membuat kesatuan dengan sesamanya untuk menyerang musuh menggunakan paduan suara gelombang ultrasonik."
+		id: "Ketika bahaya mendekati gerombolannya, Nidorina membuat kesatuan dengan sesamanya untuk menyerang musuh menggunakan paduan suara gelombang ultrasonik.",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		cost: ["Darkness"],
-
-		name: {
-			ja: "ファミリーコール",
-			'zh-tw': "家族呼喚",
-			th: "แฟมิลีคอล",
-			id: "Family Call"
+	attacks: [
+		{
+			name: {
+				ja: "ファミリーコール",
+				'zh-tw': "家族呼喚",
+				th: "แฟมิลีคอล",
+				id: "Family Call",
+			},
+			cost: ["Darkness"],
+			effect: {
+				ja: "自分の山札からポケモンを3枚まで選び、相手に見せて、手札に加える。そして山札を切る。",
+				'zh-tw': "從自己的牌庫選擇最多3張寶可夢卡，在給對手看過後加入手牌。並且重洗牌庫。",
+				th: "เลือกการ์ดโปเกมอนได้สูงสุด 3 ใบจากสำรับการ์ดฝ่ายเรา ให้ฝ่ายตรงข้ามดู นำขึ้นมือ แล้วสับสำรับการ์ด",
+				id: "Pilih paling banyak 3 lembar Pokémon dari Deck sendiri, perlihatkan ke lawan, lalu tambahkan ke Kartu Pegangan. Kemudian, kocok Deck.",
+			},
 		},
-
-		effect: {
-			ja: "自分の山札からポケモンを3枚まで選び、相手に見せて、手札に加える。そして山札を切る。",
-			'zh-tw': "從自己的牌庫選擇最多3張寶可夢卡，在給對手看過後加入手牌。並且重洗牌庫。",
-			th: "เลือกการ์ดโปเกมอนได้สูงสุด 3 ใบจากสำรับการ์ดฝ่ายเรา ให้ฝ่ายตรงข้ามดู นำขึ้นมือ แล้วสับสำรับการ์ด",
-			id: "Pilih paling banyak 3 lembar Pokémon dari Deck sendiri, perlihatkan ke lawan, lalu tambahkan ke Kartu Pegangan. Kemudian, kocok Deck."
-		}
-	}, {
-		cost: ["Darkness", "Colorless"],
-
-		name: {
-			ja: "するどいキバ",
-			'zh-tw': "銳利之牙",
-			th: "เขี้ยวคม",
-			id: "Taring Tajam"
+		{
+			name: {
+				ja: "するどいキバ",
+				'zh-tw': "銳利之牙",
+				th: "เขี้ยวคม",
+				id: "Taring Tajam",
+			},
+			damage: 50,
+			cost: ["Darkness", "Colorless"],
 		},
+	],
 
-		damage: 50
-	}],
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 719472,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				cardmarket: 837281,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				cardmarket: 837282,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ニドラン♀",
+	},
 
 	retreat: 2,
 	regulationMark: "G",
+	rarity: "Uncommon",
+	dexId: [30],
+};
 
-	thirdParty: {
-		cardmarket: 719472
-	}
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV2a/031.ts
+++ b/data-asia/SV/SV2a/031.ts
@@ -1,20 +1,17 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV2a"
+import { Card } from "../../../interfaces";
+import Set from "../SV2a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "ニドクイン",
 		'zh-tw': "尼多后",
 		th: "นิโดควีน",
-		id: "Nidoqueen"
+		id: "Nidoqueen",
 	},
 
 	illustrator: "Teeziro",
-	rarity: "Uncommon",
 	category: "Pokemon",
-	dexId: [31],
 	hp: 170,
 	types: ["Darkness"],
 
@@ -22,53 +19,74 @@ const card: Card = {
 		ja: "背中の 棘の 隙間に 子どもを 乗せて あやす。 そのときに 毒が 出ることは けっして ないのだ。",
 		'zh-tw': "會把孩子放在背上的刺與刺之間來哄牠們。 這時候絕對不會釋放毒素。",
 		th: "ปลอบประโลมลูกด้วยการยกขึ้นวางระหว่างหนามบนหลัง ในระหว่างนั้นไม่มีทางที่พิษจะไหลออกมา",
-		id: "Nidoqueen menaikkan anaknya ke celah duri di punggungnya agar tenang. Pada saat itu, racun pasti tidak akan keluar dari duri tersebut."
+		id: "Nidoqueen menaikkan anaknya ke celah duri di punggungnya agar tenang. Pada saat itu, racun pasti tidak akan keluar dari duri tersebut.",
 	},
 
 	stage: "Stage2",
 
-	attacks: [{
-		cost: ["Darkness", "Colorless"],
-
-		name: {
-			ja: "クイーンプレス",
-			'zh-tw': "皇后壓制",
-			th: "ควีนเพรส",
-			id: "Queen Press"
+	attacks: [
+		{
+			name: {
+				ja: "クイーンプレス",
+				'zh-tw': "皇后壓制",
+				th: "ควีนเพรส",
+				id: "Queen Press",
+			},
+			damage: 90,
+			cost: ["Darkness", "Colorless"],
+			effect: {
+				ja: "次の相手の番、このポケモンはたねポケモンからワザのダメージを受けない。",
+				'zh-tw': "在下個對手的回合，這隻寶可夢不會受到【基礎】寶可夢招式的傷害。",
+				th: "เทิร์นถัดไปของฝ่ายตรงข้าม โปเกมอนนี้จะไม่ได้รับแดเมจของท่าต่อสู้จากโปเกมอน[พื้นฐาน]",
+				id: "Pada giliran lawan berikutnya, Pokémon ini tidak menerima kerusakan akibat serangan dari Pokémon Basic.",
+			},
 		},
-
-		damage: 90,
-
-		effect: {
-			ja: "次の相手の番、このポケモンはたねポケモンからワザのダメージを受けない。",
-			'zh-tw': "在下個對手的回合，這隻寶可夢不會受到【基礎】寶可夢招式的傷害。",
-			th: "เทิร์นถัดไปของฝ่ายตรงข้าม โปเกมอนนี้จะไม่ได้รับแดเมจของท่าต่อสู้จากโปเกมอน[พื้นฐาน]",
-			id: "Pada giliran lawan berikutnya, Pokémon ini tidak menerima kerusakan akibat serangan dari Pokémon Basic."
-		}
-	}, {
-		cost: ["Darkness", "Darkness", "Colorless"],
-
-		name: {
-			ja: "つきたおし",
-			'zh-tw': "撞倒",
-			th: "พุ่งชน",
-			id: "Mendorong Jatuh"
+		{
+			name: {
+				ja: "つきたおし",
+				'zh-tw': "撞倒",
+				th: "พุ่งชน",
+				id: "Mendorong Jatuh",
+			},
+			damage: 160,
+			cost: ["Darkness", "Darkness", "Colorless"],
 		},
+	],
 
-		damage: 160
-	}],
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 719473,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				cardmarket: 837283,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				cardmarket: 837284,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ニドリーナ",
+	},
 
 	retreat: 3,
 	regulationMark: "G",
+	rarity: "Uncommon",
+	dexId: [31],
+};
 
-	thirdParty: {
-		cardmarket: 719473
-	}
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV2a/032.ts
+++ b/data-asia/SV/SV2a/032.ts
@@ -1,20 +1,17 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV2a"
+import { Card } from "../../../interfaces";
+import Set from "../SV2a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "ニドラン♂",
 		'zh-tw': "尼多朗",
 		th: "นิโดรัน♂",
-		id: "Nidoran♂"
+		id: "Nidoran♂",
 	},
 
 	illustrator: "Shiburingaru",
-	rarity: "Common",
 	category: "Pokemon",
-	dexId: [32],
 	hp: 60,
 	types: ["Darkness"],
 
@@ -22,31 +19,54 @@ const card: Card = {
 		ja: "小柄だが 勇ましい 性質。 仲良しの メスを 守るため 身を ていして 果敢に 戦う。",
 		'zh-tw': "體型嬌小，但性情勇猛。為了保護感情好的雌性， 會奮不顧身地勇敢戰鬥。",
 		th: "แม้ตัวจะเล็กแต่มีนิสัยกล้าหาญ เพื่อปกป้องตัวเมียที่สนิทสนมด้วยจะเอาตัวเข้าแลกต่อสู้อย่างมุ่งมั่น",
-		id: "Nidoran jantan tubuhnya kecil, tapi memiliki sifat pemberani. Demi melindungi betina yang akrab dengannya, Pokémon ini mempertaruhkan nyawanya dan bertarung dengan gagah berani."
+		id: "Nidoran jantan tubuhnya kecil, tapi memiliki sifat pemberani. Demi melindungi betina yang akrab dengannya, Pokémon ini mempertaruhkan nyawanya dan bertarung dengan gagah berani.",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		cost: ["Darkness"],
-
-		name: {
-			ja: "つのでつく",
-			'zh-tw': "角撞",
-			th: "เขาขวิด",
-			id: "Tusukan Tanduk"
+	attacks: [
+		{
+			name: {
+				ja: "つのでつく",
+				'zh-tw': "角撞",
+				th: "เขาขวิด",
+				id: "Tusukan Tanduk",
+			},
+			damage: 20,
+			cost: ["Darkness"],
 		},
+	],
 
-		damage: 20
-	}],
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 719474,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				cardmarket: 837285,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				cardmarket: 837286,
+			},
+		},
+	],
 
 	retreat: 1,
-	regulationMark: "G"
-}
+	regulationMark: "G",
+	rarity: "Common",
+	dexId: [32],
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV2a/033.ts
+++ b/data-asia/SV/SV2a/033.ts
@@ -1,20 +1,17 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV2a"
+import { Card } from "../../../interfaces";
+import Set from "../SV2a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "ニドリーノ",
 		'zh-tw': "尼多力諾",
 		th: "นิโดริโน",
-		id: "Nidorino"
+		id: "Nidorino",
 	},
 
 	illustrator: "Shiburingaru",
-	rarity: "Uncommon",
 	category: "Pokemon",
-	dexId: [33],
 	hp: 90,
 	types: ["Darkness"],
 
@@ -22,46 +19,68 @@ const card: Card = {
 		ja: "神経質で 喧嘩っ早い。 体内の アドレナリンが 増えると 毒素の 濃度も 高まるぞ。",
 		'zh-tw': "神經質且容易發脾氣打架。當體內的腎上腺素增加時， 毒素的濃度也會提升。",
 		th: "หงุดหงิดขี้กังวล แค่เรื่องนิดหน่อยก็ชวนทะเลาะ หากอะดรีนาลีนในร่างกายเพิ่มสูงขึ้น ความเข้มข้นของพิษก็จะสูงขึ้นไปด้วย",
-		id: "Nidorino mudah tersinggung dan suka berkelahi. Ketika adrenalin di dalam tubuhnya bertambah, kepekatan unsur racunnya pun meningkat."
+		id: "Nidorino mudah tersinggung dan suka berkelahi. Ketika adrenalin di dalam tubuhnya bertambah, kepekatan unsur racunnya pun meningkat.",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		cost: ["Darkness"],
-
-		name: {
-			ja: "するどいキバ",
-			'zh-tw': "銳利之牙",
-			th: "เขี้ยวคม",
-			id: "Taring Tajam"
+	attacks: [
+		{
+			name: {
+				ja: "するどいキバ",
+				'zh-tw': "銳利之牙",
+				th: "เขี้ยวคม",
+				id: "Taring Tajam",
+			},
+			damage: 30,
+			cost: ["Darkness"],
 		},
-
-		damage: 30
-	}, {
-		cost: ["Darkness", "Darkness", "Colorless"],
-
-		name: {
-			ja: "かいりきホーン",
-			'zh-tw': "怪力角擊",
-			th: "เขามหากาฬ",
-			id: "Tanduk Tenaga Super"
+		{
+			name: {
+				ja: "かいりきホーン",
+				'zh-tw': "怪力角擊",
+				th: "เขามหากาฬ",
+				id: "Tanduk Tenaga Super",
+			},
+			damage: 100,
+			cost: ["Darkness", "Darkness", "Colorless"],
 		},
+	],
 
-		damage: 100
-	}],
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 719475,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				cardmarket: 837287,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				cardmarket: 837288,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ニドラン♂",
+	},
 
 	retreat: 2,
 	regulationMark: "G",
+	rarity: "Uncommon",
+	dexId: [33],
+};
 
-	thirdParty: {
-		cardmarket: 719475
-	}
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV2a/034.ts
+++ b/data-asia/SV/SV2a/034.ts
@@ -1,20 +1,17 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV2a"
+import { Card } from "../../../interfaces";
+import Set from "../SV2a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "ニドキング",
 		'zh-tw': "尼多王",
 		th: "นิโดคิง",
-		id: "Nidoking"
+		id: "Nidoking",
 	},
 
 	illustrator: "Shiburingaru",
-	rarity: "Rare",
 	category: "Pokemon",
-	dexId: [34],
 	hp: 170,
 	types: ["Darkness"],
 
@@ -22,60 +19,82 @@ const card: Card = {
 		ja: "力自慢の ポケモン。 太い 尻尾と ダイヤをも 砕く ツノを 駆使して 豪快に 戦う。",
 		'zh-tw': "以力氣為傲的寶可夢。會善用粗壯的尾巴和連鑽石 也能擊碎的角，豪邁地戰鬥。",
 		th: "เป็นโปเกมอนที่ภาคภูมิใจในพละกำลัง ใช้หางอ้วน ๆ กับเขาที่ทุบบดแม้กระทั่งเพชรได้อย่างชำนาญ และต่อสู้อย่างฮึกเหิม",
-		id: "Pokémon yang bangga pada kekuatannya. Nidoking menggunakan ekornya yang tebal dan tanduknya yang mampu menghancurkan intan sekalipun secara maksimal untuk bertarung dengan penuh antusias."
+		id: "Pokémon yang bangga pada kekuatannya. Nidoking menggunakan ekornya yang tebal dan tanduknya yang mampu menghancurkan intan sekalipun secara maksimal untuk bertarung dengan penuh antusias.",
 	},
 
 	stage: "Stage2",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			ja: "はりきりキング",
-			'zh-tw': "活力王者",
-			th: "ราชาฮึกเหิม",
-			id: "Raja Antusias"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "はりきりキング",
+				'zh-tw': "活力王者",
+				th: "ราชาฮึกเหิม",
+				id: "Raja Antusias",
+			},
+			effect: {
+				ja: "自分の場に「ニドクイン」がいるなら、このポケモンがワザを使うためのエネルギーは、すべてなくなる。",
+				'zh-tw': "若自己的場上有「尼多后」，則這隻寶可夢使用招式所需的能量全部消除。",
+				th: "ถ้าบนกระดานฝ่ายเรามี [นิโดควีน] อยู่ พลังงานสำหรับใช้ท่าต่อสู้ของโปเกมอนนี้ ทั้งหมดจะหายไป",
+				id: "Jika ada Nidoqueen di Arena sendiri, Pokémon ini menjadi tidak membutuhkan Energi untuk menggunakan serangan.",
+			},
 		},
+	],
 
-		effect: {
-			ja: "自分の場に「ニドクイン」がいるなら、このポケモンがワザを使うためのエネルギーは、すべてなくなる。",
-			'zh-tw': "若自己的場上有「尼多后」，則這隻寶可夢使用招式所需的能量全部消除。",
-			th: "ถ้าบนกระดานฝ่ายเรามี [นิโดควีน] อยู่ พลังงานสำหรับใช้ท่าต่อสู้ของโปเกมอนนี้ ทั้งหมดจะหายไป",
-			id: "Jika ada Nidoqueen di Arena sendiri, Pokémon ini menjadi tidak membutuhkan Energi untuk menggunakan serangan."
-		}
-	}],
-
-	attacks: [{
-		cost: ["Darkness", "Darkness", "Colorless", "Colorless"],
-
-		name: {
-			ja: "ベノムインパクト",
-			'zh-tw': "毒液衝撞",
-			th: "เวนอมอิมแพกต์",
-			id: "Venom Impact"
+	attacks: [
+		{
+			name: {
+				ja: "ベノムインパクト",
+				'zh-tw': "毒液衝撞",
+				th: "เวนอมอิมแพกต์",
+				id: "Venom Impact",
+			},
+			damage: 190,
+			cost: ["Darkness", "Darkness", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをどくにする。",
+				'zh-tw': "將對手的戰鬥寶可夢【中毒】。",
+				th: "ทำให้โปเกมอนบนตำแหน่งต่อสู้ฝ่ายตรงข้ามเป็นสภาวะ[พิษ]",
+				id: "Ubah kondisi Pokémon Bertarung lawan menjadi Racun.",
+			},
 		},
+	],
 
-		damage: 190,
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
 
-		effect: {
-			ja: "相手のバトルポケモンをどくにする。",
-			'zh-tw': "將對手的戰鬥寶可夢【中毒】。",
-			th: "ทำให้โปเกมอนบนตำแหน่งต่อสู้ฝ่ายตรงข้ามเป็นสภาวะ[พิษ]",
-			id: "Ubah kondisi Pokémon Bertarung lawan menjadi Racun."
-		}
-	}],
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 719476,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				cardmarket: 837289,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				cardmarket: 837290,
+			},
+		},
+	],
 
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "ニドリーノ",
+	},
 
 	retreat: 3,
 	regulationMark: "G",
+	rarity: "Rare",
+	dexId: [34],
+};
 
-	thirdParty: {
-		cardmarket: 719476
-	}
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV2a/035.ts
+++ b/data-asia/SV/SV2a/035.ts
@@ -1,20 +1,17 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV2a"
+import { Card } from "../../../interfaces";
+import Set from "../SV2a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "ピッピ",
 		'zh-tw': "皮皮",
 		th: "ปิปปี",
-		id: "Clefairy"
+		id: "Clefairy",
 	},
 
 	illustrator: "ryoma uratsuka",
-	rarity: "Common",
 	category: "Pokemon",
-	dexId: [35],
 	hp: 60,
 	types: ["Psychic"],
 
@@ -22,51 +19,69 @@ const card: Card = {
 		ja: "愛くるしい しぐさと 鳴き声で かわいいと 大人気の ポケモン。 だが めったに 見つからない。",
 		'zh-tw': "因可愛的舉止和叫聲而廣受歡迎的寶可夢。 不過很少被人發現。",
 		th: "เป็นโปเกมอนน่ารักที่ได้รับความนิยมเป็นอย่างมากเพราะมีลักษณะท่าทางและเสียงร้องที่น่าเอ็นดู แต่แทบจะไม่ค่อยได้พบเห็น",
-		id: "Pokémon dengan tingkah dan suaranya yang imut-imut ini populer karena kemanisannya. Akan tetapi, Clefairy sulit untuk ditemukan."
+		id: "Pokémon dengan tingkah dan suaranya yang imut-imut ini populer karena kemanisannya. Akan tetapi, Clefairy sulit untuk ditemukan.",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		cost: ["Psychic"],
-
-		name: {
-			ja: "つきみにさそう",
-			'zh-tw': "邀請月見",
-			th: "ชวนชมจันทร์",
-			id: "Mengundang Memandang Bulan"
+	attacks: [
+		{
+			name: {
+				ja: "つきみにさそう",
+				'zh-tw': "邀請月見",
+				th: "ชวนชมจันทร์",
+				id: "Mengundang Memandang Bulan",
+			},
+			cost: ["Psychic"],
+			effect: {
+				ja: "自分の山札から「ピッピ」を3枚まで選び、ベンチに出す。そして山札を切る。",
+				'zh-tw': "從自己的牌庫選擇最多3張「皮皮」，放置於備戰區。並且重洗牌庫。",
+				th: "เลือกการ์ด [ปิปปี] ได้สูงสุด 3 ใบจากสำรับการ์ดฝ่ายเรา วางบนเบนช์ แล้วสับสำรับการ์ด",
+				id: "Pilih paling banyak 3 lembar Clefairy dari Deck sendiri, lalu masukkan ke Cadangan. Kemudian, kocok Deck.",
+			},
 		},
-
-		effect: {
-			ja: "自分の山札から「ピッピ」を3枚まで選び、ベンチに出す。そして山札を切る。",
-			'zh-tw': "從自己的牌庫選擇最多3張「皮皮」，放置於備戰區。並且重洗牌庫。",
-			th: "เลือกการ์ด [ปิปปี] ได้สูงสุด 3 ใบจากสำรับการ์ดฝ่ายเรา วางบนเบนช์ แล้วสับสำรับการ์ด",
-			id: "Pilih paling banyak 3 lembar Clefairy dari Deck sendiri, lalu masukkan ke Cadangan. Kemudian, kocok Deck."
-		}
-	}, {
-		cost: ["Psychic", "Colorless"],
-
-		name: {
-			ja: "ひらてうち",
-			'zh-tw': "掌擊",
-			th: "ฝ่ามือตบ",
-			id: "Tampar"
+		{
+			name: {
+				ja: "ひらてうち",
+				'zh-tw': "掌擊",
+				th: "ฝ่ามือตบ",
+				id: "Tampar",
+			},
+			damage: 20,
+			cost: ["Psychic", "Colorless"],
 		},
+	],
 
-		damage: 20
-	}],
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Metal",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 719477,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				cardmarket: 837291,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				cardmarket: 837292,
+			},
+		},
+	],
 
 	retreat: 1,
 	regulationMark: "G",
+	rarity: "Common",
+	dexId: [35],
+};
 
-	thirdParty: {
-		cardmarket: 719477
-	}
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV2a/036.ts
+++ b/data-asia/SV/SV2a/036.ts
@@ -1,20 +1,17 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV2a"
+import { Card } from "../../../interfaces";
+import Set from "../SV2a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "ピクシー",
 		'zh-tw': "皮可西",
 		th: "ปิคซี",
-		id: "Clefable"
+		id: "Clefable",
 	},
 
 	illustrator: "ryoma uratsuka",
-	rarity: "Uncommon",
 	category: "Pokemon",
-	dexId: [36],
 	hp: 100,
 	types: ["Psychic"],
 
@@ -22,58 +19,79 @@ const card: Card = {
 		ja: "１キロ先に 落ちた 針の 音も 聞こえるほど 耳が いいので ふだんは 静かな ところに いる。",
 		'zh-tw': "聽覺靈敏，連１公里以外針落地的聲音都聽得見， 因此平時會待在安靜的地方。",
 		th: "หูดีถึงขนาดได้ยินเสียงเข็มที่ตกอยู่ระยะ 1 กิโลเมตรข้างหน้า โดยปกติจึงอยู่ในสถานที่เงียบ ๆ",
-		id: "Telinga Clefable sangat tajam dan dapat mendengar suara jarum jatuh di tempat berjarak 1 km darinya, sehingga Pokémon ini biasanya berada di tempat yang tenang."
+		id: "Telinga Clefable sangat tajam dan dapat mendengar suara jarum jatuh di tempat berjarak 1 km darinya, sehingga Pokémon ini biasanya berada di tempat yang tenang.",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		cost: ["Psychic"],
-
-		name: {
-			ja: "このゆびとまれ",
-			'zh-tw': "看我嘛",
-			th: "ตามฉันมา",
-			id: "Ikuti Aku"
+	attacks: [
+		{
+			name: {
+				ja: "このゆびとまれ",
+				'zh-tw': "看我嘛",
+				th: "ตามฉันมา",
+				id: "Ikuti Aku",
+			},
+			cost: ["Psychic"],
+			effect: {
+				ja: "相手のベンチポケモンを1匹選び、バトルポケモンと入れ替える。",
+				'zh-tw': "選擇1隻對手的備戰寶可夢，與戰鬥寶可夢互換。",
+				th: "เลือกโปเกมอนบนเบนช์ฝ่ายตรงข้าม 1 ตัว สลับกับโปเกมอนบนตำแหน่งต่อสู้",
+				id: "Pilih 1 Pokémon Cadangan lawan, lalu tukar dengan Pokémon Bertarung.",
+			},
 		},
-
-		effect: {
-			ja: "相手のベンチポケモンを1匹選び、バトルポケモンと入れ替える。",
-			'zh-tw': "選擇1隻對手的備戰寶可夢，與戰鬥寶可夢互換。",
-			th: "เลือกโปเกมอนบนเบนช์ฝ่ายตรงข้าม 1 ตัว สลับกับโปเกมอนบนตำแหน่งต่อสู้",
-			id: "Pilih 1 Pokémon Cadangan lawan, lalu tukar dengan Pokémon Bertarung."
-		}
-	}, {
-		cost: ["Psychic", "Psychic", "Psychic"],
-
-		name: {
-			ja: "アディショナルムーン",
-			'zh-tw': "追加月亮",
-			th: "แอดดิชันนัลมูน",
-			id: "Additional Moon"
+		{
+			name: {
+				ja: "アディショナルムーン",
+				'zh-tw': "追加月亮",
+				th: "แอดดิชันนัลมูน",
+				id: "Additional Moon",
+			},
+			damage: 50,
+			cost: ["Psychic", "Psychic", "Psychic"],
+			effect: {
+				ja: "このワザのダメージで、相手のポケモンがきぜつしたなら、サイドを1枚多くとる。",
+				'zh-tw': "若對手的寶可夢因這個招式的傷害而【昏厥】了，則多獲得1張獎賞卡。",
+				th: "ถ้าโปเกมอนฝ่ายตรงข้าม[หมดสภาพ] ด้วยแดเมจของท่าต่อสู้นี้แล้ว หยิบการ์ดรางวัลเพิ่ม 1 ใบ",
+				id: "Jika Pokémon lawan KO karena kerusakan akibat serangan ini, ambil Kartu Point 1 lembar lebih banyak.",
+			},
 		},
+	],
 
-		damage: 50,
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
 
-		effect: {
-			ja: "このワザのダメージで、相手のポケモンがきぜつしたなら、サイドを1枚多くとる。",
-			'zh-tw': "若對手的寶可夢因這個招式的傷害而【昏厥】了，則多獲得1張獎賞卡。",
-			th: "ถ้าโปเกมอนฝ่ายตรงข้าม[หมดสภาพ] ด้วยแดเมจของท่าต่อสู้นี้แล้ว หยิบการ์ดรางวัลเพิ่ม 1 ใบ",
-			id: "Jika Pokémon lawan KO karena kerusakan akibat serangan ini, ambil Kartu Point 1 lembar lebih banyak."
-		}
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 719478,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				cardmarket: 837293,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				cardmarket: 837294,
+			},
+		},
+	],
 
-	weaknesses: [{
-		type: "Metal",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "ピッピ",
+	},
 
 	retreat: 2,
 	regulationMark: "G",
+	rarity: "Uncommon",
+	dexId: [36],
+};
 
-	thirdParty: {
-		cardmarket: 719478
-	}
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV2a/037.ts
+++ b/data-asia/SV/SV2a/037.ts
@@ -1,20 +1,17 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV2a"
+import { Card } from "../../../interfaces";
+import Set from "../SV2a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "ロコン",
 		'zh-tw': "六尾",
 		th: "โรคอน",
-		id: "Vulpix"
+		id: "Vulpix",
 	},
 
 	illustrator: "kawayoo",
-	rarity: "Common",
 	category: "Pokemon",
-	dexId: [37],
 	hp: 70,
 	types: ["Fire"],
 
@@ -22,42 +19,60 @@ const card: Card = {
 		ja: "６本の しっぽは 育つごとに 毛並みが 良くなり 美しくなる。 抱きしめると ほんのり 温かい。",
 		'zh-tw': "隨著身體的成長，６根尾巴的毛髮也會變得更漂亮。 緊緊抱著牠時能感到微微的溫暖。",
 		th: "ทุกครั้งที่หางทั้ง 6 หางโตขึ้น เส้นขนจะเรียงสวยงาม พอกอดจะรู้สึกอบอุ่นเล็กน้อย",
-		id: "Seiring pertumbuhannya, keenam ekor Vulpix menjadi makin cantik dan bulunya makin lembut. Jika dipeluk, Pokémon ini terasa agak hangat."
+		id: "Seiring pertumbuhannya, keenam ekor Vulpix menjadi makin cantik dan bulunya makin lembut. Jika dipeluk, Pokémon ini terasa agak hangat.",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		cost: ["Fire", "Colorless"],
-
-		name: {
-			ja: "ほのおでこがす",
-			'zh-tw': "火焰灼燒",
-			th: "ลนไฟ",
-			id: "Api Penghangus"
+	attacks: [
+		{
+			name: {
+				ja: "ほのおでこがす",
+				'zh-tw': "火焰灼燒",
+				th: "ลนไฟ",
+				id: "Api Penghangus",
+			},
+			damage: 20,
+			cost: ["Fire", "Colorless"],
+			effect: {
+				ja: "コインを1回投げオモテなら、相手のバトルポケモンをやけどにする。",
+				'zh-tw': "擲1次硬幣若為正面，則將對手的戰鬥寶可夢【灼傷】。",
+				th: "ทอยเหรียญ 1 ครั้งถ้าออกหัว จะทำให้โปเกมอนบนตำแหน่งต่อสู้ฝ่ายตรงข้ามเป็นสภาวะ[ไหม้]",
+				id: "Lempar koin 1 kali. Jika hasilnya sisi depan, ubah kondisi Pokémon Bertarung lawan menjadi Luka Bakar.",
+			},
 		},
+	],
 
-		damage: 20,
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
 
-		effect: {
-			ja: "コインを1回投げオモテなら、相手のバトルポケモンをやけどにする。",
-			'zh-tw': "擲1次硬幣若為正面，則將對手的戰鬥寶可夢【灼傷】。",
-			th: "ทอยเหรียญ 1 ครั้งถ้าออกหัว จะทำให้โปเกมอนบนตำแหน่งต่อสู้ฝ่ายตรงข้ามเป็นสภาวะ[ไหม้]",
-			id: "Lempar koin 1 kali. Jika hasilnya sisi depan, ubah kondisi Pokémon Bertarung lawan menjadi Luka Bakar."
-		}
-	}],
-
-	weaknesses: [{
-		type: "Water",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 719479,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				cardmarket: 837295,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				cardmarket: 837296,
+			},
+		},
+	],
 
 	retreat: 1,
 	regulationMark: "G",
+	rarity: "Common",
+	dexId: [37],
+};
 
-	thirdParty: {
-		cardmarket: 719479
-	}
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV2a/038.ts
+++ b/data-asia/SV/SV2a/038.ts
@@ -1,73 +1,79 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV2a"
+import { Card } from "../../../interfaces";
+import Set from "../SV2a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "キュウコンex",
 		'zh-tw': "九尾ex",
 		th: "คิวคอนex",
-		id: "Ninetales ex"
+		id: "Ninetales ex",
 	},
 
 	illustrator: "kawayoo",
-	rarity: "Double rare",
 	category: "Pokemon",
 	hp: 260,
 	types: ["Fire"],
+
 	stage: "Stage1",
-	suffix: "EX",
 
-	attacks: [{
-		cost: ["Fire"],
-
-		name: {
-			ja: "ねっぷう",
-			'zh-tw': "熱風",
-			th: "คลื่นความร้อน",
-			id: "Angin Panas"
+	attacks: [
+		{
+			name: {
+				ja: "ねっぷう",
+				'zh-tw': "熱風",
+				th: "คลื่นความร้อน",
+				id: "Angin Panas",
+			},
+			damage: 30,
+			cost: ["Fire"],
+			effect: {
+				ja: "相手のバトルポケモンをやけどにする。",
+				'zh-tw': "將對手的戰鬥寶可夢【灼傷】。",
+				th: "ทำให้โปเกมอนบนตำแหน่งต่อสู้ฝ่ายตรงข้ามเป็นสภาวะ[ไหม้]",
+				id: "Ubah kondisi Pokémon Bertarung lawan menjadi Luka Bakar.",
+			},
 		},
-
-		damage: 30,
-
-		effect: {
-			ja: "相手のバトルポケモンをやけどにする。",
-			'zh-tw': "將對手的戰鬥寶可夢【灼傷】。",
-			th: "ทำให้โปเกมอนบนตำแหน่งต่อสู้ฝ่ายตรงข้ามเป็นสภาวะ[ไหม้]",
-			id: "Ubah kondisi Pokémon Bertarung lawan menjadi Luka Bakar."
-		}
-	}, {
-		cost: ["Fire", "Colorless"],
-
-		name: {
-			ja: "うつしほむら",
-			'zh-tw': "現形熾火",
-			th: "เปลวไฟสะท้อน",
-			id: "Kobaran Api Refleksi"
+		{
+			name: {
+				ja: "うつしほむら",
+				'zh-tw': "現形熾火",
+				th: "เปลวไฟสะท้อน",
+				id: "Kobaran Api Refleksi",
+			},
+			damage: "80+",
+			cost: ["Fire", "Colorless"],
+			effect: {
+				ja: "自分の手札と相手の手札が同じ枚数なら、140ダメージ追加。",
+				'zh-tw': "若自己的手牌與對手的手牌張數相同，則增加140點傷害。",
+				th: "ถ้าจำนวนการ์ดบนมือฝ่ายเราเท่ากับจำนวนการ์ดบนมือฝ่ายตรงข้าม การโจมตีนี้จะเพิ่มแดเมจอีก 140",
+				id: "Jika jumlah Kartu Pegangan sendiri dan jumlah Kartu Pegangan lawan sama, kerusakan yang diberikan bertambah sejumlah 140.",
+			},
 		},
+	],
 
-		damage: "80+",
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
 
-		effect: {
-			ja: "自分の手札と相手の手札が同じ枚数なら、140ダメージ追加。",
-			'zh-tw': "若自己的手牌與對手的手牌張數相同，則增加140點傷害。",
-			th: "ถ้าจำนวนการ์ดบนมือฝ่ายเราเท่ากับจำนวนการ์ดบนมือฝ่ายตรงข้าม การโจมตีนี้จะเพิ่มแดเมจอีก 140",
-			id: "Jika jumlah Kartu Pegangan sendiri dan jumlah Kartu Pegangan lawan sama, kerusakan yang diberikan bertambah sejumlah 140."
-		}
-	}],
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 719480,
+			},
+		},
+	],
 
-	weaknesses: [{
-		type: "Water",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "ロコン",
+	},
 
 	retreat: 2,
 	regulationMark: "G",
+	rarity: "Double rare",
+	dexId: [38],
 
-	thirdParty: {
-		cardmarket: 719480
-	}
-}
+	suffix: "EX",
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV2a/039.ts
+++ b/data-asia/SV/SV2a/039.ts
@@ -1,20 +1,17 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV2a"
+import { Card } from "../../../interfaces";
+import Set from "../SV2a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "プリン",
 		'zh-tw': "胖丁",
 		th: "พูริน",
-		id: "Jigglypuff"
+		id: "Jigglypuff",
 	},
 
 	illustrator: "saino misaki",
-	rarity: "Common",
 	category: "Pokemon",
-	dexId: [39],
 	hp: 70,
 	types: ["Colorless"],
 
@@ -22,58 +19,75 @@ const card: Card = {
 		ja: "つぶらな 瞳が 揺れるとき 眠たくなるような 不思議で 気持ちのいい 歌を 歌う。",
 		'zh-tw': "當牠圓圓的大眼睛轉動時，就會唱起奇妙的歌曲， 讓人舒服地昏昏欲睡。",
 		th: "เมื่อตากลมโตสั่นไหว จะร้องเพลงที่ทำให้ง่วงนอนและรู้สึกดีอย่างน่าประหลาด",
-		id: "Jigglypuff menyanyikan lagu ajaib yang menenangkan dan membuat siapa pun jadi mengantuk ketika mata bulatnya bergerak."
+		id: "Jigglypuff menyanyikan lagu ajaib yang menenangkan dan membuat siapa pun jadi mengantuk ketika mata bulatnya bergerak.",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		cost: ["Colorless"],
-
-		name: {
-			ja: "みちびく",
-			'zh-tw': "引路",
-			th: "นำทาง",
-			id: "Menuntun"
+	attacks: [
+		{
+			name: {
+				ja: "みちびく",
+				'zh-tw': "引路",
+				th: "นำทาง",
+				id: "Menuntun",
+			},
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札からサポートを1枚選び、相手に見せて、手札に加える。そして山札を切る。",
+				'zh-tw': "從自己的牌庫選擇1張支援者卡，在給對手看過後加入手牌。並且重洗牌庫。",
+				th: "เลือกการ์ดซัพพอร์ต 1 ใบจากสำรับการ์ดฝ่ายเรา ให้ฝ่ายตรงข้ามดู นำขึ้นมือ แล้วสับสำรับการ์ด",
+				id: "Pilih 1 lembar Supporter dari Deck sendiri, perlihatkan ke lawan, lalu tambahkan ke Kartu Pegangan. Kemudian, kocok Deck.",
+			},
 		},
-
-		effect: {
-			ja: "自分の山札からサポートを1枚選び、相手に見せて、手札に加える。そして山札を切る。",
-			'zh-tw': "從自己的牌庫選擇1張支援者卡，在給對手看過後加入手牌。並且重洗牌庫。",
-			th: "เลือกการ์ดซัพพอร์ต 1 ใบจากสำรับการ์ดฝ่ายเรา ให้ฝ่ายตรงข้ามดู นำขึ้นมือ แล้วสับสำรับการ์ด",
-			id: "Pilih 1 lembar Supporter dari Deck sendiri, perlihatkan ke lawan, lalu tambahkan ke Kartu Pegangan. Kemudian, kocok Deck."
-		}
-	}, {
-		cost: ["Colorless", "Colorless"],
-
-		name: {
-			ja: "ふみふみ",
-			'zh-tw': "踏踏",
-			th: "กระทืบเท้า",
-			id: "Injak-injak"
+		{
+			name: {
+				ja: "ふみふみ",
+				'zh-tw': "踏踏",
+				th: "กระทืบเท้า",
+				id: "Injak-injak",
+			},
+			damage: "20×",
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "コインを2回投げ、オモテの数×20ダメージ。",
+				'zh-tw': "擲2次硬幣，造成正面出現的次數×20點傷害。",
+				th: "ทอยเหรียญ 2 ครั้ง แดเมจจะเท่ากับจำนวนครั้งที่ออกหัว x20",
+				id: "Lempar koin 2 kali. Serangan ini memberikan kerusakan sejumlah 20 untuk tiap lemparan dengan hasil sisi depan.",
+			},
 		},
+	],
 
-		damage: "20×",
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
 
-		effect: {
-			ja: "コインを2回投げ、オモテの数×20ダメージ。",
-			'zh-tw': "擲2次硬幣，造成正面出現的次數×20點傷害。",
-			th: "ทอยเหรียญ 2 ครั้ง แดเมจจะเท่ากับจำนวนครั้งที่ออกหัว x20",
-			id: "Lempar koin 2 kali. Serangan ini memberikan kerusakan sejumlah 20 untuk tiap lemparan dengan hasil sisi depan."
-		}
-	}],
-
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 719481,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				cardmarket: 837297,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				cardmarket: 837298,
+			},
+		},
+	],
 
 	retreat: 1,
 	regulationMark: "G",
+	rarity: "Common",
+	dexId: [39],
+};
 
-	thirdParty: {
-		cardmarket: 719481
-	}
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV2a/040.ts
+++ b/data-asia/SV/SV2a/040.ts
@@ -1,73 +1,81 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV2a"
+import { Card } from "../../../interfaces";
+import Set from "../SV2a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "プクリンex",
 		'zh-tw': "胖可丁ex",
 		th: "พูคูรินex",
-		id: "Wigglytuff ex"
+		id: "Wigglytuff ex",
 	},
 
 	illustrator: "Saki Hayashiro",
-	rarity: "Double rare",
 	category: "Pokemon",
 	hp: 250,
 	types: ["Colorless"],
+
 	stage: "Stage1",
-	suffix: "EX",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			ja: "ふくらむボディ",
-			'zh-tw': "膨脹之軀",
-			th: "ร่างพอง",
-			id: "Tubuh Menggelembung"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "ふくらむボディ",
+				'zh-tw': "膨脹之軀",
+				th: "ร่างพอง",
+				id: "Tubuh Menggelembung",
+			},
+			effect: {
+				ja: "このポケモンに特殊エネルギーがついているなら、このポケモンの最大HPは「+100」される。",
+				'zh-tw': "若這隻寶可夢身上附有特殊能量卡，則這隻寶可夢的最大HP「+100」。",
+				th: "ถ้าโปเกมอนนี้มีพลังงานพิเศษติดอยู่ HP สูงสุดของโปเกมอนนี้จะถูก [+100]",
+				id: "Jika Pokémon ini mengenakan Energi Spesial, HP maksimal Pokémon ini bertambah sejumlah 100.",
+			},
 		},
+	],
 
-		effect: {
-			ja: "このポケモンに特殊エネルギーがついているなら、このポケモンの最大HPは「+100」される。",
-			'zh-tw': "若這隻寶可夢身上附有特殊能量卡，則這隻寶可夢的最大HP「+100」。",
-			th: "ถ้าโปเกมอนนี้มีพลังงานพิเศษติดอยู่ HP สูงสุดของโปเกมอนนี้จะถูก [+100]",
-			id: "Jika Pokémon ini mengenakan Energi Spesial, HP maksimal Pokémon ini bertambah sejumlah 100."
-		}
-	}],
-
-	attacks: [{
-		cost: ["Colorless", "Colorless", "Colorless"],
-
-		name: {
-			ja: "フレンドタックル",
-			'zh-tw': "朋友衝撞",
-			th: "เฟรนด์แท็กเกิล",
-			id: "Friend Tackle"
+	attacks: [
+		{
+			name: {
+				ja: "フレンドタックル",
+				'zh-tw': "朋友衝撞",
+				th: "เฟรนด์แท็กเกิล",
+				id: "Friend Tackle",
+			},
+			damage: "90+",
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "この番、手札からサポートを出して使っていたなら、90ダメージ追加。",
+				'zh-tw': "在這個回合，若從手牌使出了支援者卡，則增加90點傷害。",
+				th: "เทิร์นนี้ ถ้านำการ์ดซัพพอร์ตจากบนมือออกมาใช้แล้ว การโจมตีนี้จะเพิ่มแดเมจอีก 90",
+				id: "Jika pada giliran ini, Supporter telah dimainkan dari Kartu Pegangan, kerusakan yang diberikan bertambah sejumlah 90.",
+			},
 		},
+	],
 
-		damage: "90+",
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
 
-		effect: {
-			ja: "この番、手札からサポートを出して使っていたなら、90ダメージ追加。",
-			'zh-tw': "在這個回合，若從手牌使出了支援者卡，則增加90點傷害。",
-			th: "เทิร์นนี้ ถ้านำการ์ดซัพพอร์ตจากบนมือออกมาใช้แล้ว การโจมตีนี้จะเพิ่มแดเมจอีก 90",
-			id: "Jika pada giliran ini, Supporter telah dimainkan dari Kartu Pegangan, kerusakan yang diberikan bertambah sejumlah 90."
-		}
-	}],
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 719482,
+			},
+		},
+	],
 
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "プリン",
+	},
 
 	retreat: 3,
 	regulationMark: "G",
+	rarity: "Double rare",
+	dexId: [40],
 
-	thirdParty: {
-		cardmarket: 719482
-	}
-}
+	suffix: "EX",
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV2a/041.ts
+++ b/data-asia/SV/SV2a/041.ts
@@ -1,20 +1,17 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV2a"
+import { Card } from "../../../interfaces";
+import Set from "../SV2a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "ズバット",
 		'zh-tw': "超音蝠",
 		th: "ซูแบท",
-		id: "Zubat"
+		id: "Zubat",
 	},
 
 	illustrator: "Scav",
-	rarity: "Common",
 	category: "Pokemon",
-	dexId: [41],
 	hp: 40,
 	types: ["Darkness"],
 
@@ -22,58 +19,72 @@ const card: Card = {
 		ja: "陽の 当たらない 洞窟に 棲む。 朝になると 仲間で 集まり 体を 温めあいながら 寝る。",
 		'zh-tw': "棲息在陽光照射不到的洞窟裡。到了早上就會和夥伴相聚， 一邊互相取暖一邊睡覺。",
 		th: "อาศัยอยู่ในถ้ำที่แสงแดดส่องไม่ถึง เมื่อถึงเวลาเช้าจะรวมกลุ่มกับพวกพ้องเพื่อสร้างความอบอุ่นแก่ร่างกายและนอนหลับ",
-		id: "Zubat tinggal di gua yang tidak terkena sinar matahari. Ketika pagi tiba, Pokémon ini berkumpul dengan sesamanya dan tidur sambil saling menghangatkan tubuh."
+		id: "Zubat tinggal di gua yang tidak terkena sinar matahari. Ketika pagi tiba, Pokémon ini berkumpul dengan sesamanya dan tidur sambil saling menghangatkan tubuh.",
 	},
 
 	stage: "Basic",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			ja: "まるみえエコー",
-			'zh-tw': "全景迴響",
-			th: "คลื่นเสียงสะท้อนหมดเปลือก",
-			id: "Gema Melihat Jelas"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "まるみえエコー",
+				'zh-tw': "全景迴響",
+				th: "คลื่นเสียงสะท้อนหมดเปลือก",
+				id: "Gema Melihat Jelas",
+			},
+			effect: {
+				ja: "このポケモンがバトル場にいるなら、自分の番に1回使える。相手の手札を見る。",
+				'zh-tw': "若這隻寶可夢在戰鬥場上，則在自己的回合時可使用1次。查看對手的手牌。",
+				th: "ถ้าโปเกมอนนี้อยู่บนตำแหน่งต่อสู้ ใช้ได้ 1 ครั้งในเทิร์นฝ่ายเรา ดูการ์ดบนมือฝ่ายตรงข้าม",
+				id: "Dapat digunakan 1 kali pada giliran sendiri jika Pokémon ini ada di Arena Bertarung. Lihat Kartu Pegangan lawan.",
+			},
 		},
+	],
 
-		effect: {
-			ja: "このポケモンがバトル場にいるなら、自分の番に1回使える。相手の手札を見る。",
-			'zh-tw': "若這隻寶可夢在戰鬥場上，則在自己的回合時可使用1次。查看對手的手牌。",
-			th: "ถ้าโปเกมอนนี้อยู่บนตำแหน่งต่อสู้ ใช้ได้ 1 ครั้งในเทิร์นฝ่ายเรา ดูการ์ดบนมือฝ่ายตรงข้าม",
-			id: "Dapat digunakan 1 kali pada giliran sendiri jika Pokémon ini ada di Arena Bertarung. Lihat Kartu Pegangan lawan."
-		}
-	}],
-
-	attacks: [{
-		cost: ["Colorless"],
-
-		name: {
-			ja: "かみつく",
-			'zh-tw': "咬住",
-			th: "กัดติด",
-			id: "Menggigit"
+	attacks: [
+		{
+			name: {
+				ja: "かみつく",
+				'zh-tw': "咬住",
+				th: "กัดติด",
+				id: "Menggigit",
+			},
+			damage: 10,
+			cost: ["Colorless"],
 		},
+	],
 
-		damage: 10
-	}],
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
 
-	weaknesses: [{
-		type: "Lightning",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Fighting",
-		value: "-30"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 719483,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				cardmarket: 837299,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				cardmarket: 837300,
+			},
+		},
+	],
 
 	retreat: 1,
 	regulationMark: "G",
+	rarity: "Common",
+	dexId: [41],
+};
 
-	thirdParty: {
-		cardmarket: 719483
-	}
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV2a/042.ts
+++ b/data-asia/SV/SV2a/042.ts
@@ -1,20 +1,17 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV2a"
+import { Card } from "../../../interfaces";
+import Set from "../SV2a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "ゴルバット",
 		'zh-tw': "大嘴蝠",
 		th: "โกลแบท",
-		id: "Golbat"
+		id: "Golbat",
 	},
 
 	illustrator: "Scav",
-	rarity: "Uncommon",
 	category: "Pokemon",
-	dexId: [42],
 	hp: 80,
 	types: ["Darkness"],
 
@@ -22,45 +19,63 @@ const card: Card = {
 		ja: "小さな 脚で 器用に 歩く。 寝ている 獲物に 忍びより キバを 突きたて 血を すするのだ。",
 		'zh-tw': "能以小小的腳靈巧地步行。會無聲無息地靠近沉睡中的獵物， 用獠牙咬住對方並且吸食血液。",
 		th: "เดินอย่างคล่องตัวด้วยขาขนาดเล็ก แอบฝังเขี้ยวเข้ากับเหยื่อที่กำลังหลับใหลและดูดเลือด",
-		id: "Golbat berjalan dengan cekatan menggunakan kakinya yang kecil. Pokémon ini mengendap mendekati mangsa yang sedang tidur, menusukkan taringnya, dan menyedot darah."
+		id: "Golbat berjalan dengan cekatan menggunakan kakinya yang kecil. Pokémon ini mengendap mendekati mangsa yang sedang tidur, menusukkan taringnya, dan menyedot darah.",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		cost: ["Colorless"],
-
-		name: {
-			ja: "ちょくげきひこう",
-			'zh-tw': "直擊飛行",
-			th: "บินพุ่งชน",
-			id: "Terbang Linear"
+	attacks: [
+		{
+			name: {
+				ja: "ちょくげきひこう",
+				'zh-tw': "直擊飛行",
+				th: "บินพุ่งชน",
+				id: "Terbang Linear",
+			},
+			cost: ["Colorless"],
+			effect: {
+				ja: "相手のポケモン1匹に、40ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+				'zh-tw': "對手的1隻寶可夢受到40點傷害。[在備戰區不計算弱點・抵抗力。]",
+				th: "ทำแดเมจ 40 กับโปเกมอนฝ่ายตรงข้าม 1 ตัว {โปเกมอนบนเบนช์จะไม่นำจุดอ่อนและความต้านทานมาคิด}",
+				id: "Serangan ini memberikan kerusakan sejumlah 40 kepada 1 Pokémon lawan. [Kelemahan dan Resistansi Pokémon Cadangan tidak mempengaruhi jumlah kerusakan.]",
+			},
 		},
+	],
 
-		effect: {
-			ja: "相手のポケモン1匹に、40ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
-			'zh-tw': "對手的1隻寶可夢受到40點傷害。[在備戰區不計算弱點・抵抗力。]",
-			th: "ทำแดเมจ 40 กับโปเกมอนฝ่ายตรงข้าม 1 ตัว {โปเกมอนบนเบนช์จะไม่นำจุดอ่อนและความต้านทานมาคิด}",
-			id: "Serangan ini memberikan kerusakan sejumlah 40 kepada 1 Pokémon lawan. [Kelemahan dan Resistansi Pokémon Cadangan tidak mempengaruhi jumlah kerusakan.]"
-		}
-	}],
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
 
-	weaknesses: [{
-		type: "Lightning",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 719484,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				cardmarket: 837301,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				cardmarket: 837302,
+			},
+		},
+	],
 
-	resistances: [{
-		type: "Fighting",
-		value: "-30"
-	}],
+	evolveFrom: {
+		ja: "ズバット",
+	},
 
 	retreat: 1,
 	regulationMark: "G",
+	rarity: "Uncommon",
+	dexId: [42],
+};
 
-	thirdParty: {
-		cardmarket: 719484
-	}
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV2a/043.ts
+++ b/data-asia/SV/SV2a/043.ts
@@ -1,20 +1,17 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV2a"
+import { Card } from "../../../interfaces";
+import Set from "../SV2a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "ナゾノクサ",
 		'zh-tw': "走路草",
 		th: "นาโซโนะคุสะ",
-		id: "Oddish"
+		id: "Oddish",
 	},
 
 	illustrator: "Sekio",
-	rarity: "Common",
 	category: "Pokemon",
-	dexId: [43],
 	hp: 60,
 	types: ["Grass"],
 
@@ -22,35 +19,54 @@ const card: Card = {
 		ja: "昼間は 太陽を 避けるため 冷たい 地面に もぐっている。 月の光を 浴びて 育つ。",
 		'zh-tw': "白天為了躲避太陽，會鑽進涼爽的地下。 藉由沐浴月光來成長。",
 		th: "ช่วงกลางวันจะมุดอยู่ใต้ดินเย็น ๆ เพื่อหลบดวงอาทิตย์ เติบโตด้วยการอาบแสงจันทร์",
-		id: "Pada siang hari, Oddish membenamkan diri ke dalam tanah yang dingin untuk menghindari matahari. Pokémon ini tumbuh dengan bermandikan cahaya bulan."
+		id: "Pada siang hari, Oddish membenamkan diri ke dalam tanah yang dingin untuk menghindari matahari. Pokémon ini tumbuh dengan bermandikan cahaya bulan.",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		cost: ["Colorless", "Colorless"],
-
-		name: {
-			ja: "はっぱカッター",
-			'zh-tw': "飛葉快刀",
-			th: "คัตเตอร์ใบไม้",
-			id: "Daun Pemotong"
+	attacks: [
+		{
+			name: {
+				ja: "はっぱカッター",
+				'zh-tw': "飛葉快刀",
+				th: "คัตเตอร์ใบไม้",
+				id: "Daun Pemotong",
+			},
+			damage: 20,
+			cost: ["Colorless", "Colorless"],
 		},
+	],
 
-		damage: 20
-	}],
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 719485,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				cardmarket: 837303,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				cardmarket: 837304,
+			},
+		},
+	],
 
 	retreat: 1,
 	regulationMark: "G",
+	rarity: "Common",
+	dexId: [43],
+};
 
-	thirdParty: {
-		cardmarket: 719485
-	}
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV2a/044.ts
+++ b/data-asia/SV/SV2a/044.ts
@@ -1,20 +1,17 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV2a"
+import { Card } from "../../../interfaces";
+import Set from "../SV2a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "クサイハナ",
 		'zh-tw': "臭臭花",
 		th: "คุไซฮานะ",
-		id: "Gloom"
+		id: "Gloom",
 	},
 
 	illustrator: "Sekio",
-	rarity: "Uncommon",
 	category: "Pokemon",
-	dexId: [44],
 	hp: 70,
 	types: ["Grass"],
 
@@ -22,53 +19,76 @@ const card: Card = {
 		ja: "よだれのように 見える 甘い蜜。 とても ねばねば しており 触れると いつまでも まとわりつく。",
 		'zh-tw': "看似口水的東西其實是甜甜的蜜。非常黏稠， 只要碰到就會一直黏住。",
 		th: "น้ำหวาน ๆ ของดอกไม้ที่ดูเหมือนน้ำลายหยดนั้น เหนียวหนืดมาก ถ้าไปโดนเข้าล่ะก็จะติดไปตลอดเลย",
-		id: "Gloom mengeluarkan madu manis yang terlihat seperti air liur. Sangat lengket dan menempel dengan lekat jika disentuh."
+		id: "Gloom mengeluarkan madu manis yang terlihat seperti air liur. Sangat lengket dan menempel dengan lekat jika disentuh.",
 	},
 
 	stage: "Stage1",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			ja: "さんぶざきエナジー",
-			'zh-tw': "三成能量",
-			th: "พลังงานแรกแย้ม",
-			id: "Energi Mekar Sepertiga"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "さんぶざきエナジー",
+				'zh-tw': "三成能量",
+				th: "พลังงานแรกแย้ม",
+				id: "Energi Mekar Sepertiga",
+			},
+			effect: {
+				ja: "自分の番に、このカードを手札から出して進化させたとき、1回使える。自分の山札を上から3枚見て、その中から基本エネルギーを好きなだけ選び、自分のポケモンに好きなようにつける。残りのカードは山札にもどして切る。",
+				'zh-tw': "在自己的回合，從手牌使出這張卡並完成進化時，可使用1次。查看自己的牌庫上方3張卡，從其中選擇任意數量的基本能量卡，以任意方式附於自己的寶可夢身上。將剩餘卡放回牌庫並重洗。",
+				th: "ในเทิร์นฝ่ายเรา เมื่อนำการ์ดนี้จากบนมือออกมาวิวัฒนาการแล้ว ใช้ได้ 1 ครั้ง ดูการ์ด 3 ใบจากด้านบนของสำรับการ์ดฝ่ายเรา เลือกการ์ดพลังงานพื้นฐานจากในนั้นตามจำนวนที่ชอบ ติดที่โปเกมอนฝ่ายเราตามชอบ การ์ดที่เหลือใส่กลับไปในสำรับการ์ดแล้วสับ",
+				id: "Dapat digunakan 1 kali pada giliran sendiri saat memasukkan kartu ini dari Kartu Pegangan untuk melakukan evolusi. Lihat 3 kartu dari atas Deck sendiri, pilih sesukanya Energi Dasar di antaranya, lalu kenakan sesukanya pada Pokémon sendiri. Kocok kembali sisa kartu ke Deck.",
+			},
 		},
+	],
 
-		effect: {
-			ja: "自分の番に、このカードを手札から出して進化させたとき、1回使える。自分の山札を上から3枚見て、その中から基本エネルギーを好きなだけ選び、自分のポケモンに好きなようにつける。残りのカードは山札にもどして切る。",
-			'zh-tw': "在自己的回合，從手牌使出這張卡並完成進化時，可使用1次。查看自己的牌庫上方3張卡，從其中選擇任意數量的基本能量卡，以任意方式附於自己的寶可夢身上。將剩餘卡放回牌庫並重洗。",
-			th: "ในเทิร์นฝ่ายเรา เมื่อนำการ์ดนี้จากบนมือออกมาวิวัฒนาการแล้ว ใช้ได้ 1 ครั้ง ดูการ์ด 3 ใบจากด้านบนของสำรับการ์ดฝ่ายเรา เลือกการ์ดพลังงานพื้นฐานจากในนั้นตามจำนวนที่ชอบ ติดที่โปเกมอนฝ่ายเราตามชอบ การ์ดที่เหลือใส่กลับไปในสำรับการ์ดแล้วสับ",
-			id: "Dapat digunakan 1 kali pada giliran sendiri saat memasukkan kartu ini dari Kartu Pegangan untuk melakukan evolusi. Lihat 3 kartu dari atas Deck sendiri, pilih sesukanya Energi Dasar di antaranya, lalu kenakan sesukanya pada Pokémon sendiri. Kocok kembali sisa kartu ke Deck."
-		}
-	}],
-
-	attacks: [{
-		cost: ["Colorless", "Colorless"],
-
-		name: {
-			ja: "よだれ",
-			'zh-tw': "口水",
-			th: "น้ำลายยืด",
-			id: "Liur"
+	attacks: [
+		{
+			name: {
+				ja: "よだれ",
+				'zh-tw': "口水",
+				th: "น้ำลายยืด",
+				id: "Liur",
+			},
+			damage: 30,
+			cost: ["Colorless", "Colorless"],
 		},
+	],
 
-		damage: 30
-	}],
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 719486,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				cardmarket: 837305,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				cardmarket: 837306,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ナゾノクサ",
+	},
 
 	retreat: 1,
 	regulationMark: "G",
+	rarity: "Uncommon",
+	dexId: [44],
+};
 
-	thirdParty: {
-		cardmarket: 719486
-	}
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV2a/045.ts
+++ b/data-asia/SV/SV2a/045.ts
@@ -1,20 +1,17 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV2a"
+import { Card } from "../../../interfaces";
+import Set from "../SV2a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "ラフレシア",
 		'zh-tw': "霸王花",
 		th: "รัฟเฟรเซีย",
-		id: "Vileplume"
+		id: "Vileplume",
 	},
 
 	illustrator: "Sekio",
-	rarity: "Rare",
 	category: "Pokemon",
-	dexId: [45],
 	hp: 140,
 	types: ["Grass"],
 
@@ -22,53 +19,76 @@ const card: Card = {
 		ja: "花びらが 大きいほど たくさん 花粉を 出すが 頭が 重たくて 疲れてしまうという。",
 		'zh-tw': "雖然花瓣越大就能放出越多的花粉，但頭部也會 隨之變重而容易疲倦。",
 		th: "ว่ากันว่ายิ่งกลีบดอกใหญ่เท่าไรยิ่งปล่อยละอองเกสรได้มากเท่านั้น แต่หัวหนักจนทำให้รู้สึกเหนื่อย",
-		id: "Makin besar kelopak bunga Vileplume, makin banyak pula serbuk sari yang dapat dikeluarkan olehnya. Akan tetapi, dikatakan bahwa kepalanya yang berat membuat Pokémon ini kelelahan."
+		id: "Makin besar kelopak bunga Vileplume, makin banyak pula serbuk sari yang dapat dikeluarkan olehnya. Akan tetapi, dikatakan bahwa kepalanya yang berat membuat Pokémon ini kelelahan.",
 	},
 
 	stage: "Stage2",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			ja: "まんかいエナジー",
-			'zh-tw': "全開能量",
-			th: "พลังงานบานสะพรั่ง",
-			id: "Energi Mekar Penuh"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "まんかいエナジー",
+				'zh-tw': "全開能量",
+				th: "พลังงานบานสะพรั่ง",
+				id: "Energi Mekar Penuh",
+			},
+			effect: {
+				ja: "自分の番に、このカードを手札から出して進化させたとき、1回使える。自分の山札を上から8枚見て、その中から基本エネルギーを好きなだけ選び、自分のポケモンに好きなようにつける。残りのカードは山札にもどして切る。",
+				'zh-tw': "在自己的回合，從手牌使出這張卡並完成進化時，可使用1次。查看自己的牌庫上方8張卡，從其中選擇任意數量的基本能量卡，以任意方式附於自己的寶可夢身上。將剩餘卡放回牌庫並重洗。",
+				th: "ในเทิร์นฝ่ายเรา เมื่อนำการ์ดนี้จากบนมือออกมาวิวัฒนาการแล้ว ใช้ได้ 1 ครั้ง ดูการ์ด 8 ใบจากด้านบนของสำรับการ์ดฝ่ายเรา เลือกการ์ดพลังงานพื้นฐานจากในนั้นตามจำนวนที่ชอบ ติดที่โปเกมอนฝ่ายเราตามชอบ การ์ดที่เหลือใส่กลับไปในสำรับการ์ดแล้วสับ",
+				id: "Dapat digunakan 1 kali pada giliran sendiri saat memasukkan kartu ini dari Kartu Pegangan untuk melakukan evolusi. Lihat 8 kartu dari atas Deck sendiri, pilih sesukanya Energi Dasar di antaranya, lalu kenakan sesukanya pada Pokémon sendiri. Kocok kembali sisa kartu ke Deck.",
+			},
 		},
+	],
 
-		effect: {
-			ja: "自分の番に、このカードを手札から出して進化させたとき、1回使える。自分の山札を上から8枚見て、その中から基本エネルギーを好きなだけ選び、自分のポケモンに好きなようにつける。残りのカードは山札にもどして切る。",
-			'zh-tw': "在自己的回合，從手牌使出這張卡並完成進化時，可使用1次。查看自己的牌庫上方8張卡，從其中選擇任意數量的基本能量卡，以任意方式附於自己的寶可夢身上。將剩餘卡放回牌庫並重洗。",
-			th: "ในเทิร์นฝ่ายเรา เมื่อนำการ์ดนี้จากบนมือออกมาวิวัฒนาการแล้ว ใช้ได้ 1 ครั้ง ดูการ์ด 8 ใบจากด้านบนของสำรับการ์ดฝ่ายเรา เลือกการ์ดพลังงานพื้นฐานจากในนั้นตามจำนวนที่ชอบ ติดที่โปเกมอนฝ่ายเราตามชอบ การ์ดที่เหลือใส่กลับไปในสำรับการ์ดแล้วสับ",
-			id: "Dapat digunakan 1 kali pada giliran sendiri saat memasukkan kartu ini dari Kartu Pegangan untuk melakukan evolusi. Lihat 8 kartu dari atas Deck sendiri, pilih sesukanya Energi Dasar di antaranya, lalu kenakan sesukanya pada Pokémon sendiri. Kocok kembali sisa kartu ke Deck."
-		}
-	}],
-
-	attacks: [{
-		cost: ["Grass", "Colorless", "Colorless"],
-
-		name: {
-			ja: "ソーラービーム",
-			'zh-tw': "日光束",
-			th: "โซล่าร์บีม",
-			id: "Solar Beam"
+	attacks: [
+		{
+			name: {
+				ja: "ソーラービーム",
+				'zh-tw': "日光束",
+				th: "โซล่าร์บีม",
+				id: "Solar Beam",
+			},
+			damage: 90,
+			cost: ["Grass", "Colorless", "Colorless"],
 		},
+	],
 
-		damage: 90
-	}],
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 719487,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				cardmarket: 837307,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				cardmarket: 837308,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "クサイハナ",
+	},
 
 	retreat: 2,
 	regulationMark: "G",
+	rarity: "Rare",
+	dexId: [45],
+};
 
-	thirdParty: {
-		cardmarket: 719487
-	}
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV2a/046.ts
+++ b/data-asia/SV/SV2a/046.ts
@@ -1,20 +1,17 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV2a"
+import { Card } from "../../../interfaces";
+import Set from "../SV2a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "パラス",
 		'zh-tw': "派拉斯",
 		th: "พารัส",
-		id: "Paras"
+		id: "Paras",
 	},
 
 	illustrator: "Yoriyuki Ikegami",
-	rarity: "Common",
 	category: "Pokemon",
-	dexId: [46],
 	hp: 70,
 	types: ["Grass"],
 
@@ -22,53 +19,70 @@ const card: Card = {
 		ja: "冬虫夏草と いう キノコが 虫を 操っているのだ。 虫の 意思は 無視される。",
 		'zh-tw': "控制蟲子的是一種 叫做冬蟲夏草的蕈類。 蟲子的意志會被忽視。",
 		th: "เห็ดที่ชื่อโทจูคะโซจะคอยบงการแมลง โดยไม่สนใจความต้องการของแมลง",
-		id: "Jamur ulat Yarsagumba mengendalikan bagian tubuh serangga dari Paras. Kemauan serangga tidak dipedulikan."
+		id: "Jamur ulat Yarsagumba mengendalikan bagian tubuh serangga dari Paras. Kemauan serangga tidak dipedulikan.",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		cost: ["Grass"],
-
-		name: {
-			ja: "ふむ",
-			'zh-tw': "踩",
-			th: "เหยียบ",
-			id: "Menginjak"
+	attacks: [
+		{
+			name: {
+				ja: "ふむ",
+				'zh-tw': "踩",
+				th: "เหยียบ",
+				id: "Menginjak",
+			},
+			damage: 10,
+			cost: ["Grass"],
 		},
-
-		damage: 10
-	}, {
-		cost: ["Grass", "Colorless"],
-
-		name: {
-			ja: "ほうしだま",
-			'zh-tw': "孢子彈",
-			th: "ลูกสปอร์",
-			id: "Bola Spora"
+		{
+			name: {
+				ja: "ほうしだま",
+				'zh-tw': "孢子彈",
+				th: "ลูกสปอร์",
+				id: "Bola Spora",
+			},
+			damage: 20,
+			cost: ["Grass", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをねむりにする。",
+				'zh-tw': "將對手的戰鬥寶可夢【睡眠】。",
+				th: "ทำให้โปเกมอนบนตำแหน่งต่อสู้ฝ่ายตรงข้ามเป็นสภาวะ[หลับ]",
+				id: "Ubah kondisi Pokémon Bertarung lawan menjadi Tidur.",
+			},
 		},
+	],
 
-		damage: 20,
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
 
-		effect: {
-			ja: "相手のバトルポケモンをねむりにする。",
-			'zh-tw': "將對手的戰鬥寶可夢【睡眠】。",
-			th: "ทำให้โปเกมอนบนตำแหน่งต่อสู้ฝ่ายตรงข้ามเป็นสภาวะ[หลับ]",
-			id: "Ubah kondisi Pokémon Bertarung lawan menjadi Tidur."
-		}
-	}],
-
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 719488,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				cardmarket: 837309,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				cardmarket: 837310,
+			},
+		},
+	],
 
 	retreat: 2,
 	regulationMark: "G",
+	rarity: "Common",
+	dexId: [46],
+};
 
-	thirdParty: {
-		cardmarket: 719488
-	}
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV2a/047.ts
+++ b/data-asia/SV/SV2a/047.ts
@@ -1,20 +1,17 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV2a"
+import { Card } from "../../../interfaces";
+import Set from "../SV2a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "パラセクト",
 		'zh-tw': "派拉斯特",
 		th: "พาราเซ็คท์",
-		id: "Parasect"
+		id: "Parasect",
 	},
 
 	illustrator: "Yoriyuki Ikegami",
-	rarity: "Uncommon",
 	category: "Pokemon",
-	dexId: [47],
 	hp: 120,
 	types: ["Grass"],
 
@@ -22,51 +19,73 @@ const card: Card = {
 		ja: "ムシの 方は ほぼ 死んでいて 本体は 背中の キノコだ。 もげると もう 動かなくなる。",
 		'zh-tw': "本體是背上的蘑菇，底下的蟲子幾乎已經死亡。 一旦蘑菇脫落，牠就再也不會動了。",
 		th: "ส่วนที่เป็นแมลงเกือบจะตายแล้ว ส่วนตัวจริงของมันคือเห็ดที่อยู่บนหลัง ถ้าเด็ดออกจะเคลื่อนไหวไม่ได้อีก",
-		id: "Tubuh serangga sudah hampir mati dan tubuh asli Parasect adalah jamur di punggung serangga tersebut. Begitu jamur tercabut, Pokémon ini tak akan bergerak lagi."
+		id: "Tubuh serangga sudah hampir mati dan tubuh asli Parasect adalah jamur di punggung serangga tersebut. Begitu jamur tercabut, Pokémon ini tak akan bergerak lagi.",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		cost: ["Grass"],
-
-		name: {
-			ja: "きんしをばらまく",
-			'zh-tw': "散佈菌絲",
-			th: "กระจายเส้นใยรา",
-			id: "Menebar Hifa"
+	attacks: [
+		{
+			name: {
+				ja: "きんしをばらまく",
+				'zh-tw': "散佈菌絲",
+				th: "กระจายเส้นใยรา",
+				id: "Menebar Hifa",
+			},
+			cost: ["Grass"],
+			effect: {
+				ja: "コインを2回投げ、オモテの数ぶんまで、自分の山札から[G]ポケモンを選び、ベンチに出す。そして山札を切る。",
+				'zh-tw': "擲2次硬幣，從自己的牌庫選擇最多與正面出現的次數相同數量的【草】寶可夢卡，放置於備戰區。並且重洗牌庫。",
+				th: "ทอยเหรียญ 2 ครั้ง เลือกการ์ดโปเกมอน[หญ้า]จากสำรับการ์ดฝ่ายเรา ได้สูงสุดไม่เกินจำนวนครั้งที่ออกหัว วางบนเบนช์ แล้วสับสำรับการ์ด",
+				id: "Lempar koin 2 kali. Pilih Pokémon {Daun} dari Deck sendiri paling banyak sejumlah lemparan dengan hasil sisi depan, lalu masukkan ke Cadangan. Kemudian, kocok Deck.",
+			},
 		},
-
-		effect: {
-			ja: "コインを2回投げ、オモテの数ぶんまで、自分の山札からポケモンを選び、ベンチに出す。そして山札を切る。",
-			'zh-tw': "擲2次硬幣，從自己的牌庫選擇最多與正面出現的次數相同數量的【草】寶可夢卡，放置於備戰區。並且重洗牌庫。",
-			th: "ทอยเหรียญ 2 ครั้ง เลือกการ์ดโปเกมอน[หญ้า]จากสำรับการ์ดฝ่ายเรา ได้สูงสุดไม่เกินจำนวนครั้งที่ออกหัว วางบนเบนช์ แล้วสับสำรับการ์ด",
-			id: "Lempar koin 2 kali. Pilih Pokémon {Daun} dari Deck sendiri paling banyak sejumlah lemparan dengan hasil sisi depan, lalu masukkan ke Cadangan. Kemudian, kocok Deck."
-		}
-	}, {
-		cost: ["Colorless", "Colorless"],
-
-		name: {
-			ja: "ツメできりさく",
-			'zh-tw': "利爪劈擊",
-			th: "กรงเล็บฉีกร่าง",
-			id: "Cakar Penyayat"
+		{
+			name: {
+				ja: "ツメできりさく",
+				'zh-tw': "利爪劈擊",
+				th: "กรงเล็บฉีกร่าง",
+				id: "Cakar Penyayat",
+			},
+			damage: 50,
+			cost: ["Colorless", "Colorless"],
 		},
+	],
 
-		damage: 50
-	}],
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 719489,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				cardmarket: 837311,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				cardmarket: 837312,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "パラス",
+	},
 
 	retreat: 2,
 	regulationMark: "G",
+	rarity: "Uncommon",
+	dexId: [47],
+};
 
-	thirdParty: {
-		cardmarket: 719489
-	}
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV2a/048.ts
+++ b/data-asia/SV/SV2a/048.ts
@@ -1,20 +1,17 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV2a"
+import { Card } from "../../../interfaces";
+import Set from "../SV2a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "コンパン",
 		'zh-tw': "毛球",
 		th: "คองปัง",
-		id: "Venonat"
+		id: "Venonat",
 	},
 
 	illustrator: "Kagemaru Himeno",
-	rarity: "Common",
 	category: "Pokemon",
-	dexId: [48],
 	hp: 70,
 	types: ["Grass"],
 
@@ -22,46 +19,64 @@ const card: Card = {
 		ja: "全身から 毒が にじみでる。 暗くなると 灯りに 群がった 小さな 虫ポケモンを 捕らえる。",
 		'zh-tw': "全身上下都會滲出毒素。天黑後就會去捕捉聚在 燈光處的小型蟲寶可夢。",
 		th: "มีพิษไหลซึมออกจากทั่วร่างกาย พอตกค่ำจะไปจับโปเกมอนแมลงตัวเล็ก ๆ ที่มารวมตัวกันตามแสงไฟ",
-		id: "Racun bercucuran dari tubuh Venonat. Ketika hari menjadi gelap, Pokémon ini menangkap Pokémon serangga kecil yang berkumpul di sumber cahaya."
+		id: "Racun bercucuran dari tubuh Venonat. Ketika hari menjadi gelap, Pokémon ini menangkap Pokémon serangga kecil yang berkumpul di sumber cahaya.",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		cost: ["Colorless"],
-
-		name: {
-			ja: "かじる",
-			'zh-tw': "咬",
-			th: "แทะ",
-			id: "Menggerogot"
+	attacks: [
+		{
+			name: {
+				ja: "かじる",
+				'zh-tw': "咬",
+				th: "แทะ",
+				id: "Menggerogot",
+			},
+			damage: 10,
+			cost: ["Colorless"],
 		},
-
-		damage: 10
-	}, {
-		cost: ["Grass", "Colorless", "Colorless"],
-
-		name: {
-			ja: "ビーム",
-			'zh-tw': "光束",
-			th: "ลำแสง",
-			id: "Beam"
+		{
+			name: {
+				ja: "ビーム",
+				'zh-tw': "光束",
+				th: "ลำแสง",
+				id: "Beam",
+			},
+			damage: 40,
+			cost: ["Grass", "Colorless", "Colorless"],
 		},
+	],
 
-		damage: 40
-	}],
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 719490,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				cardmarket: 837313,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				cardmarket: 837314,
+			},
+		},
+	],
 
 	retreat: 2,
 	regulationMark: "G",
+	rarity: "Common",
+	dexId: [48],
+};
 
-	thirdParty: {
-		cardmarket: 719490
-	}
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV2a/049.ts
+++ b/data-asia/SV/SV2a/049.ts
@@ -1,20 +1,17 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV2a"
+import { Card } from "../../../interfaces";
+import Set from "../SV2a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "モルフォン",
 		'zh-tw': "摩魯蛾",
 		th: "มอร์ฟอน",
-		id: "Venomoth"
+		id: "Venomoth",
 	},
 
 	illustrator: "Kagemaru Himeno",
-	rarity: "Uncommon",
 	category: "Pokemon",
-	dexId: [49],
 	hp: 90,
 	types: ["Grass"],
 
@@ -22,53 +19,74 @@ const card: Card = {
 		ja: "翅に りんぷんが ついていて ヒラヒラと 羽ばたくたびに 猛毒の粉を ばらまく。",
 		'zh-tw': "翅膀上附著鱗粉，每次翩翩拍動翅膀， 就會散播劇毒的粉末。",
 		th: "มีเกล็ดติดอยู่บนปีก และทุกครั้งที่กระพือปีกจะโปรยผงพิษรุนแรงไปทั่ว",
-		id: "Terdapat sisik pada sayap Venomoth. Pokémon ini menyebarkan bubuk beracun tiap kali ia mengepakkan sayapnya."
+		id: "Terdapat sisik pada sayap Venomoth. Pokémon ini menyebarkan bubuk beracun tiap kali ia mengepakkan sayapnya.",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		cost: ["Grass"],
-
-		name: {
-			ja: "さくらんパウダー",
-			'zh-tw': "錯亂粉",
-			th: "ผงอลเวง",
-			id: "Bubuk Distraksi"
+	attacks: [
+		{
+			name: {
+				ja: "さくらんパウダー",
+				'zh-tw': "錯亂粉",
+				th: "ผงอลเวง",
+				id: "Bubuk Distraksi",
+			},
+			damage: 30,
+			cost: ["Grass"],
+			effect: {
+				ja: "相手のバトルポケモンをこんらんにする。次の相手の番、相手は手札からグッズを出して使えない。",
+				'zh-tw': "將對手的戰鬥寶可夢【混亂】。在下個對手的回合，對手無法從手牌使出物品卡。",
+				th: "ทำให้โปเกมอนบนตำแหน่งต่อสู้ฝ่ายตรงข้ามเป็นสภาวะ[สับสน] เทิร์นถัดไปของฝ่ายตรงข้าม ฝ่ายตรงข้ามไม่สามารถนำการ์ดไอเท็มจากบนมือออกมาใช้ได้",
+				id: "Ubah kondisi Pokémon Bertarung lawan menjadi Pusing. Pada giliran lawan berikutnya, lawan tidak dapat memainkan Item dari Kartu Pegangan.",
+			},
 		},
-
-		damage: 30,
-
-		effect: {
-			ja: "相手のバトルポケモンをこんらんにする。次の相手の番、相手は手札からグッズを出して使えない。",
-			'zh-tw': "將對手的戰鬥寶可夢【混亂】。在下個對手的回合，對手無法從手牌使出物品卡。",
-			th: "ทำให้โปเกมอนบนตำแหน่งต่อสู้ฝ่ายตรงข้ามเป็นสภาวะ[สับสน] เทิร์นถัดไปของฝ่ายตรงข้าม ฝ่ายตรงข้ามไม่สามารถนำการ์ดไอเท็มจากบนมือออกมาใช้ได้",
-			id: "Ubah kondisi Pokémon Bertarung lawan menjadi Pusing. Pada giliran lawan berikutnya, lawan tidak dapat memainkan Item dari Kartu Pegangan."
-		}
-	}, {
-		cost: ["Grass", "Colorless", "Colorless"],
-
-		name: {
-			ja: "スピードウイング",
-			'zh-tw': "高速之翼",
-			th: "สปีดวิง",
-			id: "Speed Wing"
+		{
+			name: {
+				ja: "スピードウイング",
+				'zh-tw': "高速之翼",
+				th: "สปีดวิง",
+				id: "Speed Wing",
+			},
+			damage: 90,
+			cost: ["Grass", "Colorless", "Colorless"],
 		},
+	],
 
-		damage: 90
-	}],
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 719491,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				cardmarket: 837315,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				cardmarket: 837316,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "コンパン",
+	},
 
 	retreat: 1,
 	regulationMark: "G",
+	rarity: "Uncommon",
+	dexId: [49],
+};
 
-	thirdParty: {
-		cardmarket: 719491
-	}
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV2a/050.ts
+++ b/data-asia/SV/SV2a/050.ts
@@ -1,20 +1,17 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV2a"
+import { Card } from "../../../interfaces";
+import Set from "../SV2a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "ディグダ",
 		'zh-tw': "地鼠",
 		th: "ดิกดา",
-		id: "Diglett"
+		id: "Diglett",
 	},
 
 	illustrator: "Miki Tanaka",
-	rarity: "Common",
 	category: "Pokemon",
-	dexId: [50],
 	hp: 50,
 	types: ["Fighting"],
 
@@ -22,46 +19,64 @@ const card: Card = {
 		ja: "地下１メートルくらいを 掘りすすみ 木の根っこなどを かじって 生きる。 たまに 地上に 顔を出す。",
 		'zh-tw': "在大約１公尺深的地底挖洞前進，靠啃食樹根之類的東西生存。 偶爾會到地面上露個臉。",
 		th: "ขุดโพรงในดินลึกประมาณ 1 เมตร ใช้ชีวิตโดยการกัดกินรากไม้ นาน ๆ ทีจะโผล่ขึ้นมาเหนือดิน",
-		id: "Diglett menggali tanah kira-kira sedalam 1 meter dan hidup dengan memakan akar tumbuhan. Terkadang Pokémon ini naik ke permukaan tanah."
+		id: "Diglett menggali tanah kira-kira sedalam 1 meter dan hidup dengan memakan akar tumbuhan. Terkadang Pokémon ini naik ke permukaan tanah.",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		cost: ["Fighting"],
-
-		name: {
-			ja: "とびだしヘッド",
-			'zh-tw': "魯莽頭擊",
-			th: "กระโดดโหม่ง",
-			id: "Sundulan Meloncat"
+	attacks: [
+		{
+			name: {
+				ja: "とびだしヘッド",
+				'zh-tw': "魯莽頭擊",
+				th: "กระโดดโหม่ง",
+				id: "Sundulan Meloncat",
+			},
+			damage: 10,
+			cost: ["Fighting"],
 		},
-
-		damage: 10
-	}, {
-		cost: ["Fighting", "Fighting"],
-
-		name: {
-			ja: "どろかけ",
-			'zh-tw': "擲泥",
-			th: "สาดโคลน",
-			id: "Semprotan Lumpur"
+		{
+			name: {
+				ja: "どろかけ",
+				'zh-tw': "擲泥",
+				th: "สาดโคลน",
+				id: "Semprotan Lumpur",
+			},
+			damage: 30,
+			cost: ["Fighting", "Fighting"],
 		},
+	],
 
-		damage: 30
-	}],
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Grass",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 719492,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				cardmarket: 837317,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				cardmarket: 837318,
+			},
+		},
+	],
 
 	retreat: 1,
 	regulationMark: "G",
+	rarity: "Common",
+	dexId: [50],
+};
 
-	thirdParty: {
-		cardmarket: 719492
-	}
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV2a/051.ts
+++ b/data-asia/SV/SV2a/051.ts
@@ -1,20 +1,17 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV2a"
+import { Card } from "../../../interfaces";
+import Set from "../SV2a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "ダグトリオ",
 		'zh-tw': "三地鼠",
 		th: "ดักทริโอ",
-		id: "Dugtrio"
+		id: "Dugtrio",
 	},
 
 	illustrator: "Miki Tanaka",
-	rarity: "Uncommon",
 	category: "Pokemon",
-	dexId: [51],
 	hp: 90,
 	types: ["Fighting"],
 
@@ -22,46 +19,68 @@ const card: Card = {
 		ja: "３つの 頭が 互い違いに 動くのは まわりの 土を 柔らかくして 掘りやすくするため。",
 		'zh-tw': "三顆頭會輪流活動，是為了讓周圍的土 變得更鬆更好挖。",
 		th: "ทั้ง 3 หัวจะสลับกันเคลื่อนไหวเพื่อให้ดินรอบ ๆ นิ่มลงและขุดง่ายขึ้น",
-		id: "Tiga kepala Dugtrio saling bergerak ke arah yang berbeda-beda untuk melunakkan tanah di sekitarnya agar menjadi lebih mudah untuk digali."
+		id: "Tiga kepala Dugtrio saling bergerak ke arah yang berbeda-beda untuk melunakkan tanah di sekitarnya agar menjadi lebih mudah untuk digali.",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		cost: ["Fighting"],
-
-		name: {
-			ja: "とびだしヘッド",
-			'zh-tw': "魯莽頭擊",
-			th: "กระโดดโหม่ง",
-			id: "Sundulan Meloncat"
+	attacks: [
+		{
+			name: {
+				ja: "とびだしヘッド",
+				'zh-tw': "魯莽頭擊",
+				th: "กระโดดโหม่ง",
+				id: "Sundulan Meloncat",
+			},
+			damage: 40,
+			cost: ["Fighting"],
 		},
-
-		damage: 40
-	}, {
-		cost: ["Fighting", "Fighting"],
-
-		name: {
-			ja: "どろばくだん",
-			'zh-tw': "泥巴炸彈",
-			th: "ระเบิดโคลน",
-			id: "Bom Lumpur"
+		{
+			name: {
+				ja: "どろばくだん",
+				'zh-tw': "泥巴炸彈",
+				th: "ระเบิดโคลน",
+				id: "Bom Lumpur",
+			},
+			damage: 80,
+			cost: ["Fighting", "Fighting"],
 		},
+	],
 
-		damage: 80
-	}],
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Grass",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 719493,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				cardmarket: 837319,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				cardmarket: 837320,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ディグダ",
+	},
 
 	retreat: 1,
 	regulationMark: "G",
+	rarity: "Uncommon",
+	dexId: [51],
+};
 
-	thirdParty: {
-		cardmarket: 719493
-	}
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV2a/052.ts
+++ b/data-asia/SV/SV2a/052.ts
@@ -1,20 +1,17 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV2a"
+import { Card } from "../../../interfaces";
+import Set from "../SV2a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "ニャース",
 		'zh-tw': "喵喵",
 		th: "เนียส",
-		id: "Meowth"
+		id: "Meowth",
 	},
 
 	illustrator: "Naoki Saito",
-	rarity: "Common",
 	category: "Pokemon",
-	dexId: [52],
 	hp: 70,
 	types: ["Colorless"],
 
@@ -22,51 +19,69 @@ const card: Card = {
 		ja: "昼間は 寝てばかりいる。 夜になると 目が 輝き 縄張りを 歩きまわる。",
 		'zh-tw': "白天一直都在睡覺。到了晚上眼睛就會發光， 在自己的地盤徘徊。",
 		th: "ตอนกลางวันจะเอาแต่นอน พอตกกลางคืนจะเดินไปรอบ ๆ อาณาเขตของตนด้วยดวงตาที่เป็นประกาย",
-		id: "Yang dilakukan Meowth pada siang hari hanya tidur. Ketika malam tiba, mata Pokémon ini bercahaya dan ia berjalan mengelilingi wilayah teritorialnya."
+		id: "Yang dilakukan Meowth pada siang hari hanya tidur. Ketika malam tiba, mata Pokémon ini bercahaya dan ia berjalan mengelilingi wilayah teritorialnya.",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		cost: ["Colorless"],
-
-		name: {
-			ja: "まねきねこ",
-			'zh-tw': "招財貓",
-			th: "แมวกวัก",
-			id: "Kucing Pemanggil"
+	attacks: [
+		{
+			name: {
+				ja: "まねきねこ",
+				'zh-tw': "招財貓",
+				th: "แมวกวัก",
+				id: "Kucing Pemanggil",
+			},
+			cost: ["Colorless"],
+			effect: {
+				ja: "コインを1回投げオモテなら、相手のベンチポケモンを1匹選び、バトルポケモンと入れ替える。",
+				'zh-tw': "擲1次硬幣若為正面，則選擇1隻對手的備戰寶可夢，與戰鬥寶可夢互換。",
+				th: "ทอยเหรียญ 1 ครั้งถ้าออกหัว เลือกโปเกมอนบนเบนช์ฝ่ายตรงข้าม 1 ตัว สลับกับโปเกมอนบนตำแหน่งต่อสู้",
+				id: "Lempar koin 1 kali. Jika hasilnya sisi depan, pilih 1 Pokémon Cadangan lawan, lalu tukar dengan Pokémon Bertarung.",
+			},
 		},
-
-		effect: {
-			ja: "コインを1回投げオモテなら、相手のベンチポケモンを1匹選び、バトルポケモンと入れ替える。",
-			'zh-tw': "擲1次硬幣若為正面，則選擇1隻對手的備戰寶可夢，與戰鬥寶可夢互換。",
-			th: "ทอยเหรียญ 1 ครั้งถ้าออกหัว เลือกโปเกมอนบนเบนช์ฝ่ายตรงข้าม 1 ตัว สลับกับโปเกมอนบนตำแหน่งต่อสู้",
-			id: "Lempar koin 1 kali. Jika hasilnya sisi depan, pilih 1 Pokémon Cadangan lawan, lalu tukar dengan Pokémon Bertarung."
-		}
-	}, {
-		cost: ["Colorless", "Colorless"],
-
-		name: {
-			ja: "ツメをたてる",
-			'zh-tw': "豎爪",
-			th: "กางกรงเล็บ",
-			id: "Memasang Cakar"
+		{
+			name: {
+				ja: "ツメをたてる",
+				'zh-tw': "豎爪",
+				th: "กางกรงเล็บ",
+				id: "Memasang Cakar",
+			},
+			damage: 20,
+			cost: ["Colorless", "Colorless"],
 		},
+	],
 
-		damage: 20
-	}],
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 719494,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				cardmarket: 837321,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				cardmarket: 837322,
+			},
+		},
+	],
 
 	retreat: 1,
 	regulationMark: "G",
+	rarity: "Common",
+	dexId: [52],
+};
 
-	thirdParty: {
-		cardmarket: 719494
-	}
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV2a/053.ts
+++ b/data-asia/SV/SV2a/053.ts
@@ -1,20 +1,17 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV2a"
+import { Card } from "../../../interfaces";
+import Set from "../SV2a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "ペルシアン",
 		'zh-tw': "貓老大",
 		th: "เปอร์เซียน",
-		id: "Persian"
+		id: "Persian",
 	},
 
 	illustrator: "Naoki Saito",
-	rarity: "Uncommon",
 	category: "Pokemon",
-	dexId: [53],
 	hp: 110,
 	types: ["Colorless"],
 
@@ -22,53 +19,76 @@ const card: Card = {
 		ja: "毛並みが 美しく ペットにしたがる 人も 多いが すぐ ひっかいたり するので 手強いぞ。",
 		'zh-tw': "有著漂亮的毛色，很多人想養牠當寵物， 但牠很愛亂抓，所以並不好養。",
 		th: "ขนสวยจนคนมากมายอยากได้เป็นสัตว์เลี้ยง แต่รับมือยากเพราะมันชอบข่วน",
-		id: "Meskipun banyak orang yang ingin memelihara Persian karena bulunya yang cantik, Pokémon ini sulit dijinakkan karena ia langsung mencakar siapa pun."
+		id: "Meskipun banyak orang yang ingin memelihara Persian karena bulunya yang cantik, Pokémon ini sulit dijinakkan karena ia langsung mencakar siapa pun.",
 	},
 
 	stage: "Stage1",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			ja: "ロケットコール",
-			'zh-tw': "火箭呼喚",
-			th: "ร็อกเกตคอล",
-			id: "Rocket Call"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "ロケットコール",
+				'zh-tw': "火箭呼喚",
+				th: "ร็อกเกตคอล",
+				id: "Rocket Call",
+			},
+			effect: {
+				ja: "自分の番に1回使える。自分の山札から「サカキのカリスマ」を1枚選び、相手に見せて、手札に加える。そして山札を切る。",
+				'zh-tw': "在自己的回合時可使用1次。從自己的牌庫選擇1張「坂木的領導力」，在給對手看過後加入手牌。並且重洗牌庫。",
+				th: "ใช้ได้ 1 ครั้งในเทิร์นฝ่ายเรา เลือกการ์ด [เสน่ห์ของซากากิ] 1 ใบจากสำรับการ์ดฝ่ายเรา ให้ฝ่ายตรงข้ามดู นำขึ้นมือ แล้วสับสำรับการ์ด",
+				id: "Dapat digunakan 1 kali pada giliran sendiri. Pilih 1 lembar Karisma Giovanni dari Deck sendiri, perlihatkan ke lawan, lalu tambahkan ke Kartu Pegangan. Kemudian, kocok Deck.",
+			},
 		},
+	],
 
-		effect: {
-			ja: "自分の番に1回使える。自分の山札から「サカキのカリスマ」を1枚選び、相手に見せて、手札に加える。そして山札を切る。",
-			'zh-tw': "在自己的回合時可使用1次。從自己的牌庫選擇1張「坂木的領導力」，在給對手看過後加入手牌。並且重洗牌庫。",
-			th: "ใช้ได้ 1 ครั้งในเทิร์นฝ่ายเรา เลือกการ์ด [เสน่ห์ของซากากิ] 1 ใบจากสำรับการ์ดฝ่ายเรา ให้ฝ่ายตรงข้ามดู นำขึ้นมือ แล้วสับสำรับการ์ด",
-			id: "Dapat digunakan 1 kali pada giliran sendiri. Pilih 1 lembar Karisma Giovanni dari Deck sendiri, perlihatkan ke lawan, lalu tambahkan ke Kartu Pegangan. Kemudian, kocok Deck."
-		}
-	}],
-
-	attacks: [{
-		cost: ["Colorless", "Colorless", "Colorless"],
-
-		name: {
-			ja: "きりさく",
-			'zh-tw': "劈開",
-			th: "ฟันแหลก",
-			id: "Menyayat"
+	attacks: [
+		{
+			name: {
+				ja: "きりさく",
+				'zh-tw': "劈開",
+				th: "ฟันแหลก",
+				id: "Menyayat",
+			},
+			damage: 70,
+			cost: ["Colorless", "Colorless", "Colorless"],
 		},
+	],
 
-		damage: 70
-	}],
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 719495,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				cardmarket: 837323,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				cardmarket: 837324,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ニャース",
+	},
 
 	retreat: 1,
 	regulationMark: "G",
+	rarity: "Uncommon",
+	dexId: [53],
+};
 
-	thirdParty: {
-		cardmarket: 719495
-	}
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV2a/054.ts
+++ b/data-asia/SV/SV2a/054.ts
@@ -1,20 +1,17 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV2a"
+import { Card } from "../../../interfaces";
+import Set from "../SV2a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "コダック",
 		'zh-tw': "可達鴨",
 		th: "โคดัก",
-		id: "Psyduck"
+		id: "Psyduck",
 	},
 
 	illustrator: "Taira Akitsu",
-	rarity: "Common",
 	category: "Pokemon",
-	dexId: [54],
 	hp: 70,
 	types: ["Water"],
 
@@ -22,51 +19,69 @@ const card: Card = {
 		ja: "いつも 頭痛に 悩まされている。 この 頭痛が 激しくなると 不思議な 力を 使いはじめる。",
 		'zh-tw': "一直受到頭痛的困擾。當頭痛欲裂時， 就會開始使用神奇的力量。",
 		th: "หงุดหงิดกับอาการปวดหัวอยู่เสมอ พออาการปวดหัวรุนแรงขึ้นจะเริ่มใช้พลังลึกลับ",
-		id: "Psyduck selalu terganggu dengan sakit kepalanya. Pokémon ini mulai menggunakan kekuatan ajaibnya jika kepalanya menjadi makin sakit."
+		id: "Psyduck selalu terganggu dengan sakit kepalanya. Pokémon ini mulai menggunakan kekuatan ajaibnya jika kepalanya menjadi makin sakit.",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		cost: ["Colorless"],
-
-		name: {
-			ja: "かんがえすぎる",
-			'zh-tw': "過慮",
-			th: "คิดมาก",
-			id: "Kebanyakan Berpikir"
+	attacks: [
+		{
+			name: {
+				ja: "かんがえすぎる",
+				'zh-tw': "過慮",
+				th: "คิดมาก",
+				id: "Kebanyakan Berpikir",
+			},
+			cost: ["Colorless"],
+			effect: {
+				ja: "次の相手の番、相手が投げるコインは、すべてウラとしてあつかう。",
+				'zh-tw': "在下個對手的回合，對手擲的硬幣全部視為反面。",
+				th: "เทิร์นถัดไปของฝ่ายตรงข้าม เหรียญที่ฝ่ายตรงข้ามทอย จะถือว่าออกก้อยทั้งหมด",
+				id: "Pada giliran lawan berikutnya, semua lemparan koin yang dilakukan lawan diperlakukan sebagai sisi belakang.",
+			},
 		},
-
-		effect: {
-			ja: "次の相手の番、相手が投げるコインは、すべてウラとしてあつかう。",
-			'zh-tw': "在下個對手的回合，對手擲的硬幣全部視為反面。",
-			th: "เทิร์นถัดไปของฝ่ายตรงข้าม เหรียญที่ฝ่ายตรงข้ามทอย จะถือว่าออกก้อยทั้งหมด",
-			id: "Pada giliran lawan berikutnya, semua lemparan koin yang dilakukan lawan diperlakukan sebagai sisi belakang."
-		}
-	}, {
-		cost: ["Water"],
-
-		name: {
-			ja: "みずでっぽう",
-			'zh-tw': "水槍",
-			th: "ปืนฉีดน้ำ",
-			id: "Pistol Air"
+		{
+			name: {
+				ja: "みずでっぽう",
+				'zh-tw': "水槍",
+				th: "ปืนฉีดน้ำ",
+				id: "Pistol Air",
+			},
+			damage: 10,
+			cost: ["Water"],
 		},
+	],
 
-		damage: 10
-	}],
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Lightning",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 719496,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				cardmarket: 837325,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				cardmarket: 837326,
+			},
+		},
+	],
 
 	retreat: 1,
 	regulationMark: "G",
+	rarity: "Common",
+	dexId: [54],
+};
 
-	thirdParty: {
-		cardmarket: 719496
-	}
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV2a/055.ts
+++ b/data-asia/SV/SV2a/055.ts
@@ -1,20 +1,17 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV2a"
+import { Card } from "../../../interfaces";
+import Set from "../SV2a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "ゴルダック",
 		'zh-tw': "哥達鴨",
 		th: "โกลดัก",
-		id: "Golduck"
+		id: "Golduck",
 	},
 
 	illustrator: "Taira Akitsu",
-	rarity: "Uncommon",
 	category: "Pokemon",
-	dexId: [55],
 	hp: 110,
 	types: ["Water"],
 
@@ -22,51 +19,73 @@ const card: Card = {
 		ja: "水かきのついた 長い 手足を 使い 全力で 泳ぎだすと なぜか 額が 光り輝く。",
 		'zh-tw': "當牠用帶有水蹼的修長手腳全力游泳時， 不知為何額頭會閃閃發光。",
 		th: "ไม่รู้ทำไม พอใช้แขนขายาวที่มีพังผืดว่ายน้ำสุดกำลัง บริเวณหน้าผากจะเรืองแสงขึ้นมา",
-		id: "Entah kenapa kening Golduck bersinar ketika ia berenang sekuat tenaga menggunakan kaki dan tangan panjang berselaputnya."
+		id: "Entah kenapa kening Golduck bersinar ketika ia berenang sekuat tenaga menggunakan kaki dan tangan panjang berselaputnya.",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		cost: ["Colorless"],
-
-		name: {
-			ja: "すいなんきゅうじょ",
-			'zh-tw': "水難救助",
-			th: "กู้ภัยทางน้ำ",
-			id: "Penyelamatan Bencana Air"
+	attacks: [
+		{
+			name: {
+				ja: "すいなんきゅうじょ",
+				'zh-tw': "水難救助",
+				th: "กู้ภัยทางน้ำ",
+				id: "Penyelamatan Bencana Air",
+			},
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分のトラッシュからポケモンを4枚まで選び、相手に見せて、手札に加える。",
+				'zh-tw': "從自己的棄牌區選擇最多4張寶可夢卡，在給對手看過後加入手牌。",
+				th: "เลือกการ์ดโปเกมอนได้สูงสุด 4 ใบจากตำแหน่งทิ้งการ์ดฝ่ายเรา ให้ฝ่ายตรงข้ามดู นำขึ้นมือ",
+				id: "Pilih paling banyak 4 lembar Pokémon dari Trash sendiri, perlihatkan ke lawan, lalu tambahkan ke Kartu Pegangan.",
+			},
 		},
-
-		effect: {
-			ja: "自分のトラッシュからポケモンを4枚まで選び、相手に見せて、手札に加える。",
-			'zh-tw': "從自己的棄牌區選擇最多4張寶可夢卡，在給對手看過後加入手牌。",
-			th: "เลือกการ์ดโปเกมอนได้สูงสุด 4 ใบจากตำแหน่งทิ้งการ์ดฝ่ายเรา ให้ฝ่ายตรงข้ามดู นำขึ้นมือ",
-			id: "Pilih paling banyak 4 lembar Pokémon dari Trash sendiri, perlihatkan ke lawan, lalu tambahkan ke Kartu Pegangan."
-		}
-	}, {
-		cost: ["Water", "Water", "Colorless"],
-
-		name: {
-			ja: "スーパースプラッシュ",
-			'zh-tw': "超級飛濺",
-			th: "ซูเปอร์สแปลช",
-			id: "Super Splash"
+		{
+			name: {
+				ja: "スーパースプラッシュ",
+				'zh-tw': "超級飛濺",
+				th: "ซูเปอร์สแปลช",
+				id: "Super Splash",
+			},
+			damage: 120,
+			cost: ["Water", "Water", "Colorless"],
 		},
+	],
 
-		damage: 120
-	}],
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Lightning",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 719497,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				cardmarket: 837327,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				cardmarket: 837328,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "コダック",
+	},
 
 	retreat: 1,
 	regulationMark: "G",
+	rarity: "Uncommon",
+	dexId: [55],
+};
 
-	thirdParty: {
-		cardmarket: 719497
-	}
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV2a/056.ts
+++ b/data-asia/SV/SV2a/056.ts
@@ -1,20 +1,17 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV2a"
+import { Card } from "../../../interfaces";
+import Set from "../SV2a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "マンキー",
 		'zh-tw': "猴怪",
 		th: "แมนคี",
-		id: "Mankey"
+		id: "Mankey",
 	},
 
 	illustrator: "Mina Nakai",
-	rarity: "Common",
 	category: "Pokemon",
-	dexId: [56],
 	hp: 60,
 	types: ["Fighting"],
 
@@ -22,42 +19,60 @@ const card: Card = {
 		ja: "木の上で 群れをつくって 暮らす。 群れから はぐれた マンキーは 寂しくて すぐに 怒りだす。",
 		'zh-tw': "在樹上群居的寶可夢。和夥伴走散的猴怪會因為 按捺不住寂寞而動不動就生氣。",
 		th: "อาศัยอยู่กันเป็นฝูงบนต้นไม้ แมนคีที่พลัดจากฝูงจะเหงาจนโกรธขึ้นมา",
-		id: "Pokémon ini hidup berkelompok di atas pohon. Mankey yang terpisah dari kawanannya langsung mengamuk karena kesepian."
+		id: "Pokémon ini hidup berkelompok di atas pohon. Mankey yang terpisah dari kawanannya langsung mengamuk karena kesepian.",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		cost: ["Fighting"],
-
-		name: {
-			ja: "あばれる",
-			'zh-tw': "大鬧一番",
-			th: "อาละวาด",
-			id: "Pukulan Membabi Buta"
+	attacks: [
+		{
+			name: {
+				ja: "あばれる",
+				'zh-tw': "大鬧一番",
+				th: "อาละวาด",
+				id: "Pukulan Membabi Buta",
+			},
+			damage: "20+",
+			cost: ["Fighting"],
+			effect: {
+				ja: "コインを1回投げオモテなら、20ダメージ追加。ウラなら、このポケモンにも20ダメージ。",
+				'zh-tw': "擲1次硬幣若為正面，則增加20點傷害。若為反面，則這隻寶可夢也受到20點傷害。",
+				th: "ทอยเหรียญ 1 ครั้งถ้าออกหัว การโจมตีนี้จะเพิ่มแดเมจอีก 20 ถ้าออกก้อย โปเกมอนนี้ก็จะได้รับแดเมจ 20 ด้วย",
+				id: "Lempar koin 1 kali. Jika hasilnya sisi depan, kerusakan yang diberikan bertambah sejumlah 20. Jika hasilnya sisi belakang, Pokémon ini juga menerima kerusakan sejumlah 20.",
+			},
 		},
+	],
 
-		damage: "20+",
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
 
-		effect: {
-			ja: "コインを1回投げオモテなら、20ダメージ追加。ウラなら、このポケモンにも20ダメージ。",
-			'zh-tw': "擲1次硬幣若為正面，則增加20點傷害。若為反面，則這隻寶可夢也受到20點傷害。",
-			th: "ทอยเหรียญ 1 ครั้งถ้าออกหัว การโจมตีนี้จะเพิ่มแดเมจอีก 20 ถ้าออกก้อย โปเกมอนนี้ก็จะได้รับแดเมจ 20 ด้วย",
-			id: "Lempar koin 1 kali. Jika hasilnya sisi depan, kerusakan yang diberikan bertambah sejumlah 20. Jika hasilnya sisi belakang, Pokémon ini juga menerima kerusakan sejumlah 20."
-		}
-	}],
-
-	weaknesses: [{
-		type: "Psychic",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 719498,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				cardmarket: 837329,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				cardmarket: 837330,
+			},
+		},
+	],
 
 	retreat: 1,
 	regulationMark: "G",
+	rarity: "Common",
+	dexId: [56],
+};
 
-	thirdParty: {
-		cardmarket: 719498
-	}
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV2a/057.ts
+++ b/data-asia/SV/SV2a/057.ts
@@ -1,20 +1,17 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV2a"
+import { Card } from "../../../interfaces";
+import Set from "../SV2a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "オコリザル",
 		'zh-tw': "火爆猴",
 		th: "โอโคริซารุ",
-		id: "Primeape"
+		id: "Primeape",
 	},
 
 	illustrator: "Mina Nakai",
-	rarity: "Uncommon",
 	category: "Pokemon",
-	dexId: [57],
 	hp: 120,
 	types: ["Fighting"],
 
@@ -22,60 +19,80 @@ const card: Card = {
 		ja: "だれかの 視線を 感じただけで 猛烈に 怒りだす。 そして 目が合った ものを 追いかけるのだ。",
 		'zh-tw': "光是感覺到他方的視線都會暴怒起來，然後去追 和牠對到眼的傢伙。",
 		th: "แค่รู้สึกว่ามีใครมองก็โกรธเคืองรุนแรง แล้วไล่ล่าสิ่งที่สบตาด้วย",
-		id: "Primeape akan mengamuk besar ketika merasakan ada yang melihatnya. Lalu, ia akan mengejar siapa pun yang bertemu mata dengannya."
+		id: "Primeape akan mengamuk besar ketika merasakan ada yang melihatnya. Lalu, ia akan mengejar siapa pun yang bertemu mata dengannya.",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		cost: ["Fighting"],
-
-		name: {
-			ja: "がなりたてる",
-			'zh-tw': "狂嗥",
-			th: "เอ็ดตะโร",
-			id: "Berteriak-teriak"
+	attacks: [
+		{
+			name: {
+				ja: "がなりたてる",
+				'zh-tw': "狂嗥",
+				th: "เอ็ดตะโร",
+				id: "Berteriak-teriak",
+			},
+			damage: 40,
+			cost: ["Fighting"],
+			effect: {
+				ja: "このポケモンをこんらんにする。",
+				'zh-tw': "將這隻寶可夢【混亂】。",
+				th: "ทำให้โปเกมอนนี้เป็นสภาวะ[สับสน]",
+				id: "Ubah kondisi Pokémon ini menjadi Pusing.",
+			},
 		},
-
-		damage: 40,
-
-		effect: {
-			ja: "このポケモンをこんらんにする。",
-			'zh-tw': "將這隻寶可夢【混亂】。",
-			th: "ทำให้โปเกมอนนี้เป็นสภาวะ[สับสน]",
-			id: "Ubah kondisi Pokémon ini menjadi Pusing."
-		}
-	}, {
-		cost: ["Fighting", "Colorless", "Colorless"],
-
-		name: {
-			ja: "げきこうスマッシュ",
-			'zh-tw': "盛怒粉碎",
-			th: "เดือดจัดซัดแหลก",
-			id: "Smes Geram"
+		{
+			name: {
+				ja: "げきこうスマッシュ",
+				'zh-tw': "盛怒粉碎",
+				th: "เดือดจัดซัดแหลก",
+				id: "Smes Geram",
+			},
+			damage: 150,
+			cost: ["Fighting", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンがこんらんでないなら、このワザは失敗。",
+				'zh-tw': "若這隻寶可夢沒有【混亂】，則這個招式失敗。",
+				th: "ถ้าโปเกมอนนี้ไม่เป็นสภาวะ[สับสน] ท่าต่อสู้นี้จะล้มเหลว",
+				id: "Jika Pokémon ini tidak mengalami kondisi Pusing, serangan ini gagal.",
+			},
 		},
+	],
 
-		damage: 150,
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
 
-		effect: {
-			ja: "このポケモンがこんらんでないなら、このワザは失敗。",
-			'zh-tw': "若這隻寶可夢沒有【混亂】，則這個招式失敗。",
-			th: "ถ้าโปเกมอนนี้ไม่เป็นสภาวะ[สับสน] ท่าต่อสู้นี้จะล้มเหลว",
-			id: "Jika Pokémon ini tidak mengalami kondisi Pusing, serangan ini gagal."
-		}
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 719499,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				cardmarket: 837331,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				cardmarket: 837332,
+			},
+		},
+	],
 
-	weaknesses: [{
-		type: "Psychic",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "マンキー",
+	},
 
 	retreat: 2,
 	regulationMark: "G",
+	rarity: "Uncommon",
+	dexId: [57],
+};
 
-	thirdParty: {
-		cardmarket: 719499
-	}
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV2a/058.ts
+++ b/data-asia/SV/SV2a/058.ts
@@ -1,20 +1,17 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV2a"
+import { Card } from "../../../interfaces";
+import Set from "../SV2a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "ガーディ",
 		'zh-tw': "卡蒂狗",
 		th: "การ์ดี",
-		id: "Growlithe"
+		id: "Growlithe",
 	},
 
 	illustrator: "Atsushi Furusawa",
-	rarity: "Common",
 	category: "Pokemon",
-	dexId: [58],
 	hp: 80,
 	types: ["Fire"],
 
@@ -22,42 +19,60 @@ const card: Card = {
 		ja: "自分より 強くて 大きな 相手にも 恐れずに 立ち向かう 勇敢で 頼もしい 性格。",
 		'zh-tw': "能毫不畏懼地去對抗比自己更強更大的對手。 性格非常勇敢可靠。",
 		th: "มีนิสัยที่พึ่งพาได้ด้วยความกล้ายืนหยัดสู้โดยไม่กลัวคู่ต่อสู้ที่แข็งแกร่งและใหญ่กว่าตัวเอง",
-		id: "Growlithe memiliki kepribadian pemberani dan dapat diandalkan, tidak takut untuk menghadapi lawan yang lebih kuat dan lebih besar dari dirinya."
+		id: "Growlithe memiliki kepribadian pemberani dan dapat diandalkan, tidak takut untuk menghadapi lawan yang lebih kuat dan lebih besar dari dirinya.",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		cost: ["Fire"],
-
-		name: {
-			ja: "じょうはつ",
-			'zh-tw': "蒸發",
-			th: "ระเหย",
-			id: "Menguapkan"
+	attacks: [
+		{
+			name: {
+				ja: "じょうはつ",
+				'zh-tw': "蒸發",
+				th: "ระเหย",
+				id: "Menguapkan",
+			},
+			damage: 10,
+			cost: ["Fire"],
+			effect: {
+				ja: "相手のバトルポケモンについている[W]エネルギーを1個選び、トラッシュする。",
+				'zh-tw': "選擇1個對手的戰鬥寶可夢身上附加的【水】能量，將其丟棄。",
+				th: "เลือกพลังงาน[น้ำ]ที่ติดอยู่กับโปเกมอนบนตำแหน่งต่อสู้ฝ่ายตรงข้าม 1 ลูก ทิ้งที่ตำแหน่งทิ้งการ์ด",
+				id: "Pilih 1 Energi {Air} yang dikenakan pada Pokémon Bertarung lawan, lalu buang ke Trash.",
+			},
 		},
+	],
 
-		damage: 10,
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
 
-		effect: {
-			ja: "相手のバトルポケモンについているエネルギーを1個選び、トラッシュする。",
-			'zh-tw': "選擇1個對手的戰鬥寶可夢身上附加的【水】能量，將其丟棄。",
-			th: "เลือกพลังงาน[น้ำ]ที่ติดอยู่กับโปเกมอนบนตำแหน่งต่อสู้ฝ่ายตรงข้าม 1 ลูก ทิ้งที่ตำแหน่งทิ้งการ์ด",
-			id: "Pilih 1 Energi {Air} yang dikenakan pada Pokémon Bertarung lawan, lalu buang ke Trash."
-		}
-	}],
-
-	weaknesses: [{
-		type: "Water",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 719500,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				cardmarket: 837333,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				cardmarket: 837334,
+			},
+		},
+	],
 
 	retreat: 2,
 	regulationMark: "G",
+	rarity: "Common",
+	dexId: [58],
+};
 
-	thirdParty: {
-		cardmarket: 719500
-	}
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV2a/059.ts
+++ b/data-asia/SV/SV2a/059.ts
@@ -1,20 +1,17 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV2a"
+import { Card } from "../../../interfaces";
+import Set from "../SV2a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "ウインディ",
 		'zh-tw': "風速狗",
 		th: "วินดี",
-		id: "Arcanine"
+		id: "Arcanine",
 	},
 
 	illustrator: "Atsushi Furusawa",
-	rarity: "Uncommon",
 	category: "Pokemon",
-	dexId: [59],
 	hp: 150,
 	types: ["Fire"],
 
@@ -22,60 +19,80 @@ const card: Card = {
 		ja: "草原を 駆け抜ける 様子は 人々の 心を 虜にしたと 昔の 絵巻に 記されていた。",
 		'zh-tw': "根據過去的畫軸記載，牠在草原上奔馳的姿態 擄獲了眾多人心。",
 		th: "ม้วนภาพสมัยก่อนแสดงให้เห็นถึงท่วงท่าวิ่งฝ่าทุ่งหญ้าของมันที่สะกดตาต้องใจผู้พบเห็น",
-		id: "Dalam gulungan gambar kuno tertera bahwa hati orang-orang terpikat saat melihat sosok Arcanine yang berlari di padang rumput."
+		id: "Dalam gulungan gambar kuno tertera bahwa hati orang-orang terpikat saat melihat sosok Arcanine yang berlari di padang rumput.",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		cost: ["Fire"],
-
-		name: {
-			ja: "あつくたぎる",
-			'zh-tw': "熾熱沸騰",
-			th: "เดือดพล่าน",
-			id: "Menggelegak Panas"
+	attacks: [
+		{
+			name: {
+				ja: "あつくたぎる",
+				'zh-tw': "熾熱沸騰",
+				th: "เดือดพล่าน",
+				id: "Menggelegak Panas",
+			},
+			damage: 30,
+			cost: ["Fire"],
+			effect: {
+				ja: "自分のトラッシュから「基本[R]エネルギー」を2枚まで選び、このポケモンにつける。",
+				'zh-tw': "從自己的棄牌區選擇最多2張「基本【火】能量」卡，附於這隻寶可夢身上。",
+				th: "เลือกการ์ด [พลังงานพื้นฐาน[ไฟ]] ได้สูงสุด 2 ใบจากตำแหน่งทิ้งการ์ดฝ่ายเรา ติดที่โปเกมอนนี้",
+				id: "Pilih paling banyak 2 lembar Energi Dasar {Api} dari Trash sendiri, lalu kenakan pada Pokémon ini.",
+			},
 		},
-
-		damage: 30,
-
-		effect: {
-			ja: "自分のトラッシュから「基本エネルギー」を2枚まで選び、このポケモンにつける。",
-			'zh-tw': "從自己的棄牌區選擇最多2張「基本【火】能量」卡，附於這隻寶可夢身上。",
-			th: "เลือกการ์ด [พลังงานพื้นฐาน[ไฟ]] ได้สูงสุด 2 ใบจากตำแหน่งทิ้งการ์ดฝ่ายเรา ติดที่โปเกมอนนี้",
-			id: "Pilih paling banyak 2 lembar Energi Dasar {Api} dari Trash sendiri, lalu kenakan pada Pokémon ini."
-		}
-	}, {
-		cost: ["Fire", "Fire", "Colorless", "Colorless"],
-
-		name: {
-			ja: "ダイナマイトファング",
-			'zh-tw': "炸藥獠牙",
-			th: "ไดนาไมต์แฟงก์",
-			id: "Dynamite Fang"
+		{
+			name: {
+				ja: "ダイナマイトファング",
+				'zh-tw': "炸藥獠牙",
+				th: "ไดนาไมต์แฟงก์",
+				id: "Dynamite Fang",
+			},
+			damage: 240,
+			cost: ["Fire", "Fire", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンについている[R]エネルギーを2個選び、トラッシュする。",
+				'zh-tw': "選擇2個這隻寶可夢身上附加的【火】能量，將其丟棄。",
+				th: "เลือกพลังงาน[ไฟ]ที่ติดอยู่กับโปเกมอนนี้ 2 ลูก ทิ้งที่ตำแหน่งทิ้งการ์ด",
+				id: "Pilih 2 Energi {Api} yang dikenakan pada Pokémon ini, lalu buang ke Trash.",
+			},
 		},
+	],
 
-		damage: 240,
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
 
-		effect: {
-			ja: "このポケモンについているエネルギーを2個選び、トラッシュする。",
-			'zh-tw': "選擇2個這隻寶可夢身上附加的【火】能量，將其丟棄。",
-			th: "เลือกพลังงาน[ไฟ]ที่ติดอยู่กับโปเกมอนนี้ 2 ลูก ทิ้งที่ตำแหน่งทิ้งการ์ด",
-			id: "Pilih 2 Energi {Api} yang dikenakan pada Pokémon ini, lalu buang ke Trash."
-		}
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 719501,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				cardmarket: 837335,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				cardmarket: 837336,
+			},
+		},
+	],
 
-	weaknesses: [{
-		type: "Water",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "ガーディ",
+	},
 
 	retreat: 4,
 	regulationMark: "G",
+	rarity: "Uncommon",
+	dexId: [59],
+};
 
-	thirdParty: {
-		cardmarket: 719501
-	}
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV2a/060.ts
+++ b/data-asia/SV/SV2a/060.ts
@@ -1,20 +1,17 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV2a"
+import { Card } from "../../../interfaces";
+import Set from "../SV2a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "ニョロモ",
 		'zh-tw': "蚊香蝌蚪",
 		th: "เนียวโรโมะ",
-		id: "Poliwag"
+		id: "Poliwag",
 	},
 
 	illustrator: "Kurata So",
-	rarity: "Common",
 	category: "Pokemon",
-	dexId: [60],
 	hp: 60,
 	types: ["Water"],
 
@@ -22,42 +19,60 @@ const card: Card = {
 		ja: "流れが 速い 川では ぶ厚い 唇を 吸盤のように 岩に くっつけて しがみつく。",
 		'zh-tw': "在水流湍急的河川裡，會把厚厚的嘴唇當作吸盤， 吸附在岩石上避免被沖走。",
 		th: "ในแม่น้ำที่ไหลเชี่ยวจะใช้ริมฝีปากหนา ๆ ยึดติดกับหินไว้เหมือนกับปุ่มดูด",
-		id: "Pada sungai yang alirannya deras, Poliwag bertahan agar tidak terbawa arus dengan menempelkan bibir tebalnya ke bebatuan bagaikan pengisap."
+		id: "Pada sungai yang alirannya deras, Poliwag bertahan agar tidak terbawa arus dengan menempelkan bibir tebalnya ke bebatuan bagaikan pengisap.",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		cost: ["Water"],
-
-		name: {
-			ja: "あわ",
-			'zh-tw': "泡沫",
-			th: "ฟอง",
-			id: "Gelembung"
+	attacks: [
+		{
+			name: {
+				ja: "あわ",
+				'zh-tw': "泡沫",
+				th: "ฟอง",
+				id: "Gelembung",
+			},
+			damage: 10,
+			cost: ["Water"],
+			effect: {
+				ja: "コインを1回投げオモテなら、相手のバトルポケモンをマヒにする。",
+				'zh-tw': "擲1次硬幣若為正面，則將對手的戰鬥寶可夢【麻痺】。",
+				th: "ทอยเหรียญ 1 ครั้งถ้าออกหัว จะทำให้โปเกมอนบนตำแหน่งต่อสู้ฝ่ายตรงข้ามเป็นสภาวะ[ชา]",
+				id: "Lempar koin 1 kali. Jika hasilnya sisi depan, ubah kondisi Pokémon Bertarung lawan menjadi Lumpuh.",
+			},
 		},
+	],
 
-		damage: 10,
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
 
-		effect: {
-			ja: "コインを1回投げオモテなら、相手のバトルポケモンをマヒにする。",
-			'zh-tw': "擲1次硬幣若為正面，則將對手的戰鬥寶可夢【麻痺】。",
-			th: "ทอยเหรียญ 1 ครั้งถ้าออกหัว จะทำให้โปเกมอนบนตำแหน่งต่อสู้ฝ่ายตรงข้ามเป็นสภาวะ[ชา]",
-			id: "Lempar koin 1 kali. Jika hasilnya sisi depan, ubah kondisi Pokémon Bertarung lawan menjadi Lumpuh."
-		}
-	}],
-
-	weaknesses: [{
-		type: "Lightning",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 719502,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				cardmarket: 837337,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				cardmarket: 837338,
+			},
+		},
+	],
 
 	retreat: 1,
 	regulationMark: "G",
+	rarity: "Common",
+	dexId: [60],
+};
 
-	thirdParty: {
-		cardmarket: 719502
-	}
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV2a/061.ts
+++ b/data-asia/SV/SV2a/061.ts
@@ -1,20 +1,17 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV2a"
+import { Card } from "../../../interfaces";
+import Set from "../SV2a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "ニョロゾ",
 		'zh-tw': "蚊香君",
 		th: "เนียวโรโซ",
-		id: "Poliwhirl"
+		id: "Poliwhirl",
 	},
 
 	illustrator: "Kurata So",
-	rarity: "Common",
 	category: "Pokemon",
-	dexId: [61],
 	hp: 90,
 	types: ["Water"],
 
@@ -22,53 +19,74 @@ const card: Card = {
 		ja: "ぬめぬめとした 粘液状の 汗を かく。 敵に 捕まっても ぬるりと すり抜け 逃げるのだ。",
 		'zh-tw': "流的汗是又黏又滑的黏液狀。即使被敵人捉住， 也能滑溜溜地輕易逃脫。",
 		th: "ขับเหงื่อที่มีลักษณะเป็นเมือกเหนียวเหนอะออกมา ถึงจะโดนศัตรูจับตัว ก็สามารถลื่นไหลหนีออกมาได้",
-		id: "Poliwhirl mengalirkan keringat berlendir yang licin. Meskipun ditangkap musuh, Pokémon ini dapat meloloskan diri dan kabur berkat kelicinannya."
+		id: "Poliwhirl mengalirkan keringat berlendir yang licin. Meskipun ditangkap musuh, Pokémon ini dapat meloloskan diri dan kabur berkat kelicinannya.",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		cost: ["Water"],
-
-		name: {
-			ja: "スプラッシュ",
-			'zh-tw': "飛濺",
-			th: "สแปลช",
-			id: "Splash"
+	attacks: [
+		{
+			name: {
+				ja: "スプラッシュ",
+				'zh-tw': "飛濺",
+				th: "สแปลช",
+				id: "Splash",
+			},
+			damage: 20,
+			cost: ["Water"],
 		},
-
-		damage: 20
-	}, {
-		cost: ["Water", "Colorless"],
-
-		name: {
-			ja: "かえるとび",
-			'zh-tw': "蛙跳",
-			th: "กระโดดกบ",
-			id: "Lompat Katak"
+		{
+			name: {
+				ja: "かえるとび",
+				'zh-tw': "蛙跳",
+				th: "กระโดดกบ",
+				id: "Lompat Katak",
+			},
+			damage: "30+",
+			cost: ["Water", "Colorless"],
+			effect: {
+				ja: "コインを1回投げオモテなら、60ダメージ追加。",
+				'zh-tw': "擲1次硬幣若為正面，則增加60點傷害。",
+				th: "ทอยเหรียญ 1 ครั้งถ้าออกหัว การโจมตีนี้จะเพิ่มแดเมจอีก 60",
+				id: "Lempar koin 1 kali. Jika hasilnya sisi depan, kerusakan yang diberikan bertambah sejumlah 60.",
+			},
 		},
+	],
 
-		damage: "30+",
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
 
-		effect: {
-			ja: "コインを1回投げオモテなら、60ダメージ追加。",
-			'zh-tw': "擲1次硬幣若為正面，則增加60點傷害。",
-			th: "ทอยเหรียญ 1 ครั้งถ้าออกหัว การโจมตีนี้จะเพิ่มแดเมจอีก 60",
-			id: "Lempar koin 1 kali. Jika hasilnya sisi depan, kerusakan yang diberikan bertambah sejumlah 60."
-		}
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 719503,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				cardmarket: 837339,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				cardmarket: 837340,
+			},
+		},
+	],
 
-	weaknesses: [{
-		type: "Lightning",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "ニョロモ",
+	},
 
 	retreat: 1,
 	regulationMark: "G",
+	rarity: "Common",
+	dexId: [61],
+};
 
-	thirdParty: {
-		cardmarket: 719503
-	}
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV2a/062.ts
+++ b/data-asia/SV/SV2a/062.ts
@@ -1,20 +1,17 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV2a"
+import { Card } from "../../../interfaces";
+import Set from "../SV2a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "ニョロボン",
 		'zh-tw': "蚊香泳士",
 		th: "เนียวโรบอน",
-		id: "Poliwrath"
+		id: "Poliwrath",
 	},
 
 	illustrator: "Kurata So",
-	rarity: "Uncommon",
 	category: "Pokemon",
-	dexId: [62],
 	hp: 160,
 	types: ["Water"],
 
@@ -22,60 +19,80 @@ const card: Card = {
 		ja: "泳ぎ だけでなく 格闘技も 得意。 鍛えあげた 腕から 豪快な パンチを 繰りだす。",
 		'zh-tw': "除了游泳之外，也擅長使用格鬥技。完美鍛鍊的手臂 可以使出豪邁的拳擊。",
 		th: "เก่งทั้งด้านการว่ายน้ำและศิลปะการต่อสู้ ลำแขนที่ฝึกฝนมาเป็นอย่างดีนั้นปล่อยหมัดอันทรงพลังออกมาได้",
-		id: "Poliwrath tidak hanya ahli berenang, tapi juga ahli bela diri. Pokémon ini meluncurkan pukulan dahsyat menggunakan lengannya yang terlatih."
+		id: "Poliwrath tidak hanya ahli berenang, tapi juga ahli bela diri. Pokémon ini meluncurkan pukulan dahsyat menggunakan lengannya yang terlatih.",
 	},
 
 	stage: "Stage2",
 
-	attacks: [{
-		cost: ["Water"],
-
-		name: {
-			ja: "バブルこうせん",
-			'zh-tw': "泡沫光線",
-			th: "บับเบิ้ลบีม",
-			id: "Sinar Gelembung"
+	attacks: [
+		{
+			name: {
+				ja: "バブルこうせん",
+				'zh-tw': "泡沫光線",
+				th: "บับเบิ้ลบีม",
+				id: "Sinar Gelembung",
+			},
+			damage: 50,
+			cost: ["Water"],
+			effect: {
+				ja: "コインを1回投げオモテなら、相手のバトルポケモンをマヒにする。",
+				'zh-tw': "擲1次硬幣若為正面，則將對手的戰鬥寶可夢【麻痺】。",
+				th: "ทอยเหรียญ 1 ครั้งถ้าออกหัว จะทำให้โปเกมอนบนตำแหน่งต่อสู้ฝ่ายตรงข้ามเป็นสภาวะ[ชา]",
+				id: "Lempar koin 1 kali. Jika hasilnya sisi depan, ubah kondisi Pokémon Bertarung lawan menjadi Lumpuh.",
+			},
 		},
-
-		damage: 50,
-
-		effect: {
-			ja: "コインを1回投げオモテなら、相手のバトルポケモンをマヒにする。",
-			'zh-tw': "擲1次硬幣若為正面，則將對手的戰鬥寶可夢【麻痺】。",
-			th: "ทอยเหรียญ 1 ครั้งถ้าออกหัว จะทำให้โปเกมอนบนตำแหน่งต่อสู้ฝ่ายตรงข้ามเป็นสภาวะ[ชา]",
-			id: "Lempar koin 1 kali. Jika hasilnya sisi depan, ubah kondisi Pokémon Bertarung lawan menjadi Lumpuh."
-		}
-	}, {
-		cost: ["Water", "Colorless", "Colorless"],
-
-		name: {
-			ja: "ごうかいパンチ",
-			'zh-tw': "豪邁拳",
-			th: "หมัดแรงถึงใจ",
-			id: "Pukulan Dahsyat"
+		{
+			name: {
+				ja: "ごうかいパンチ",
+				'zh-tw': "豪邁拳",
+				th: "หมัดแรงถึงใจ",
+				id: "Pukulan Dahsyat",
+			},
+			damage: "100+",
+			cost: ["Water", "Colorless", "Colorless"],
+			effect: {
+				ja: "コインを1回投げオモテなら、150ダメージ追加。",
+				'zh-tw': "擲1次硬幣若為正面，則增加150點傷害。",
+				th: "ทอยเหรียญ 1 ครั้งถ้าออกหัว การโจมตีนี้จะเพิ่มแดเมจอีก 150",
+				id: "Lempar koin 1 kali. Jika hasilnya sisi depan, kerusakan yang diberikan bertambah sejumlah 150.",
+			},
 		},
+	],
 
-		damage: "100+",
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
 
-		effect: {
-			ja: "コインを1回投げオモテなら、150ダメージ追加。",
-			'zh-tw': "擲1次硬幣若為正面，則增加150點傷害。",
-			th: "ทอยเหรียญ 1 ครั้งถ้าออกหัว การโจมตีนี้จะเพิ่มแดเมจอีก 150",
-			id: "Lempar koin 1 kali. Jika hasilnya sisi depan, kerusakan yang diberikan bertambah sejumlah 150."
-		}
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 719504,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				cardmarket: 837342,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				cardmarket: 837343,
+			},
+		},
+	],
 
-	weaknesses: [{
-		type: "Lightning",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "ニョロゾ",
+	},
 
 	retreat: 2,
 	regulationMark: "G",
+	rarity: "Uncommon",
+	dexId: [62],
+};
 
-	thirdParty: {
-		cardmarket: 719504
-	}
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV2a/063.ts
+++ b/data-asia/SV/SV2a/063.ts
@@ -1,20 +1,17 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV2a"
+import { Card } from "../../../interfaces";
+import Set from "../SV2a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "ケーシィ",
 		'zh-tw': "凱西",
 		th: "เคซี",
-		id: "Abra"
+		id: "Abra",
 	},
 
 	illustrator: "Mitsuhiro Arita",
-	rarity: "Common",
 	category: "Pokemon",
-	dexId: [63],
 	hp: 50,
 	types: ["Psychic"],
 
@@ -22,40 +19,54 @@ const card: Card = {
 		ja: "眠ったまま テレポート できる。 眠りが 深いほど 離れた 場所に 移動する という。",
 		'zh-tw': "就算在睡夢中也能使用瞬間移動。據說當牠睡得越熟， 瞬間移動的距離就會越遠。",
 		th: "สามารถเทเลพอร์ทได้ระหว่างที่หลับอยู่ ว่ากันว่ายิ่งหลับลึกก็จะยิ่งเคลื่อนตัวไปยังสถานที่ห่างไกลมากขึ้น",
-		id: "Abra dapat melakukan teleportasi sambil tidur. Dikatakan bahwa makin nyenyak tidurnya, makin jauh pula jarak teleportasinya."
+		id: "Abra dapat melakukan teleportasi sambil tidur. Dikatakan bahwa makin nyenyak tidurnya, makin jauh pula jarak teleportasinya.",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		cost: ["Psychic"],
-
-		name: {
-			ja: "サイコショット",
-			'zh-tw': "精神射擊",
-			th: "ไซโคช็อต",
-			id: "Psyshot"
+	attacks: [
+		{
+			name: {
+				ja: "サイコショット",
+				'zh-tw': "精神射擊",
+				th: "ไซโคช็อต",
+				id: "Psyshot",
+			},
+			damage: 20,
+			cost: ["Psychic"],
 		},
+	],
 
-		damage: 20
-	}],
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
 
-	weaknesses: [{
-		type: "Darkness",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Fighting",
-		value: "-30"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 719505,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				cardmarket: 837344,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				cardmarket: 837345,
+			},
+		},
+	],
 
 	retreat: 1,
 	regulationMark: "G",
+	rarity: "Common",
+	dexId: [63],
+};
 
-	thirdParty: {
-		cardmarket: 719505
-	}
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV2a/064.ts
+++ b/data-asia/SV/SV2a/064.ts
@@ -1,20 +1,17 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV2a"
+import { Card } from "../../../interfaces";
+import Set from "../SV2a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "ユンゲラー",
 		'zh-tw': "勇基拉",
 		th: "ยุนเกเรอร์",
-		id: "Kadabra"
+		id: "Kadabra",
 	},
 
 	illustrator: "Mitsuhiro Arita",
-	rarity: "Uncommon",
 	category: "Pokemon",
-	dexId: [64],
 	hp: 80,
 	types: ["Psychic"],
 
@@ -22,47 +19,64 @@ const card: Card = {
 		ja: "念力の 威力は 絶大。 進化に 備えて 額の 星に サイコパワーを 蓄えている。",
 		'zh-tw': "念力的威力大得驚人。會把精神力量儲存在額頭 的星星裡，以備進化所需。",
 		th: "มีพลังจิตตานุภาพอันทรงพลังอยู่ จะเก็บสะสมพลังจิตไว้ที่ดาวบนหัวไว้เพื่อเตรียมวิวัฒนาการ",
-		id: "Kekuatan telekinesis Kadabra sangat kuat. Pokémon ini bersiap untuk berevolusi dengan menghimpun kekuatan psikokinesis pada bintang di dahinya."
+		id: "Kekuatan telekinesis Kadabra sangat kuat. Pokémon ini bersiap untuk berevolusi dengan menghimpun kekuatan psikokinesis pada bintang di dahinya.",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		cost: ["Psychic"],
-
-		name: {
-			ja: "テレポートアタック",
-			'zh-tw': "瞬間移動攻擊",
-			th: "เทเลพอร์ทแอทแทก",
-			id: "Teleport Attack"
+	attacks: [
+		{
+			name: {
+				ja: "テレポートアタック",
+				'zh-tw': "瞬間移動攻擊",
+				th: "เทเลพอร์ทแอทแทก",
+				id: "Teleport Attack",
+			},
+			damage: 30,
+			cost: ["Psychic"],
+			effect: {
+				ja: "このポケモンをベンチポケモンと入れ替える。",
+				'zh-tw': "將這隻寶可夢與備戰寶可夢互換。",
+				th: "สลับโปเกมอนนี้กับโปเกมอนบนเบนช์",
+				id: "Tukar Pokémon ini dengan Pokémon Cadangan.",
+			},
 		},
+	],
 
-		damage: 30,
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
 
-		effect: {
-			ja: "このポケモンをベンチポケモンと入れ替える。",
-			'zh-tw': "將這隻寶可夢與備戰寶可夢互換。",
-			th: "สลับโปเกมอนนี้กับโปเกมอนบนเบนช์",
-			id: "Tukar Pokémon ini dengan Pokémon Cadangan."
-		}
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 719506,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				cardmarket: 837346,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				cardmarket: 837347,
+			},
+		},
+	],
 
-	weaknesses: [{
-		type: "Darkness",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Fighting",
-		value: "-30"
-	}],
+	evolveFrom: {
+		ja: "ケーシィ",
+	},
 
 	retreat: 1,
 	regulationMark: "G",
+	rarity: "Uncommon",
+	dexId: [64],
+};
 
-	thirdParty: {
-		cardmarket: 719506
-	}
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV2a/065.ts
+++ b/data-asia/SV/SV2a/065.ts
@@ -1,78 +1,79 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV2a"
+import { Card } from "../../../interfaces";
+import Set from "../SV2a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "フーディンex",
 		'zh-tw': "胡地ex",
 		th: "ฟูดินex",
-		id: "Alakazam ex"
+		id: "Alakazam ex",
 	},
 
 	illustrator: "Mitsuhiro Arita",
-	rarity: "Double rare",
 	category: "Pokemon",
 	hp: 310,
 	types: ["Psychic"],
+
 	stage: "Stage2",
-	suffix: "EX",
 
-	attacks: [{
-		cost: ["Colorless", "Colorless"],
-
-		name: {
-			ja: "マインドジャック",
-			'zh-tw': "意志劫持",
-			th: "มายด์แจ็ค",
-			id: "Mind Jack"
+	attacks: [
+		{
+			name: {
+				ja: "マインドジャック",
+				'zh-tw': "意志劫持",
+				th: "มายด์แจ็ค",
+				id: "Mind Jack",
+			},
+			damage: "90+",
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "相手のベンチポケモンの数×30ダメージ追加。",
+				'zh-tw': "增加對手的備戰寶可夢的數量×30點傷害。",
+				th: "แดเมจจะเพิ่มตามจำนวนโปเกมอนบนเบนช์ฝ่ายตรงข้าม x30",
+				id: "Kerusakan yang diberikan bertambah sejumlah 30 untuk tiap Pokémon Cadangan lawan.",
+			},
 		},
-
-		damage: "90+",
-
-		effect: {
-			ja: "相手のベンチポケモンの数×30ダメージ追加。",
-			'zh-tw': "增加對手的備戰寶可夢的數量×30點傷害。",
-			th: "แดเมจจะเพิ่มตามจำนวนโปเกมอนบนเบนช์ฝ่ายตรงข้าม x30",
-			id: "Kerusakan yang diberikan bertambah sejumlah 30 untuk tiap Pokémon Cadangan lawan."
-		}
-	}, {
-		cost: ["Psychic", "Psychic"],
-
-		name: {
-			ja: "ディメンションハンド",
-			'zh-tw': "維度之手",
-			th: "ไดเมนชันแฮนด์",
-			id: "Dimension Hand"
+		{
+			name: {
+				ja: "ディメンションハンド",
+				'zh-tw': "維度之手",
+				th: "ไดเมนชันแฮนด์",
+				id: "Dimension Hand",
+			},
+			damage: 120,
+			cost: ["Psychic", "Psychic"],
+			effect: {
+				ja: "このワザは、このポケモンがベンチにいても使える。",
+				'zh-tw': "就算這隻寶可夢在備戰區，這個招式也可使用。",
+				th: "ท่าต่อสู้นี้ แม้โปเกมอนนี้อยู่บนเบนช์ก็ใช้ได้",
+				id: "Serangan ini dapat digunakan meskipun Pokémon ini ada di Cadangan.",
+			},
 		},
+	],
 
-		damage: 120,
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
 
-		effect: {
-			ja: "このワザは、このポケモンがベンチにいても使える。",
-			'zh-tw': "就算這隻寶可夢在備戰區，這個招式也可使用。",
-			th: "ท่าต่อสู้นี้ แม้โปเกมอนนี้อยู่บนเบนช์ก็ใช้ได้",
-			id: "Serangan ini dapat digunakan meskipun Pokémon ini ada di Cadangan."
-		}
-	}],
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 719507,
+			},
+		},
+	],
 
-	weaknesses: [{
-		type: "Darkness",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Fighting",
-		value: "-30"
-	}],
+	evolveFrom: {
+		ja: "ユンゲラー",
+	},
 
 	retreat: 1,
 	regulationMark: "G",
+	rarity: "Double rare",
+	dexId: [65],
 
-	thirdParty: {
-		cardmarket: 719507
-	}
-}
+	suffix: "EX",
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV2a/066.ts
+++ b/data-asia/SV/SV2a/066.ts
@@ -1,20 +1,17 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV2a"
+import { Card } from "../../../interfaces";
+import Set from "../SV2a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "ワンリキー",
 		'zh-tw': "腕力",
 		th: "วันริกี",
-		id: "Machop"
+		id: "Machop",
 	},
 
 	illustrator: "Ryuta Fuse",
-	rarity: "Common",
 	category: "Pokemon",
-	dexId: [66],
 	hp: 70,
 	types: ["Fighting"],
 
@@ -22,51 +19,69 @@ const card: Card = {
 		ja: "いつも パワフル。 体力が 有り余っているので 暇つぶしに 岩を持ち上げ さらに 強くなる。",
 		'zh-tw': "時時刻刻都充滿力量。由於體力過剩而去舉岩石 消磨時間，也因此變得更強。",
 		th: "มีพละกำลังเต็มเปี่ยมอยู่ตลอด มีกำลังเหลือเฟือก็เลยยกหินขึ้นเพื่อฆ่าเวลาและทำให้ตัวเองแข็งแกร่งยิ่งขึ้น",
-		id: "Machop selalu penuh kekuatan. Karena vitalitasnya yang berlebihan, Pokémon ini mengangkat batu besar untuk membuang waktu, sehingga menjadi makin kuat."
+		id: "Machop selalu penuh kekuatan. Karena vitalitasnya yang berlebihan, Pokémon ini mengangkat batu besar untuk membuang waktu, sehingga menjadi makin kuat.",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		cost: ["Fighting"],
-
-		name: {
-			ja: "やまたたき",
-			'zh-tw': "敲山",
-			th: "ทุบภูเขา",
-			id: "Menghantam Gunung"
+	attacks: [
+		{
+			name: {
+				ja: "やまたたき",
+				'zh-tw': "敲山",
+				th: "ทุบภูเขา",
+				id: "Menghantam Gunung",
+			},
+			cost: ["Fighting"],
+			effect: {
+				ja: "相手の山札を上から1枚トラッシュする。",
+				'zh-tw': "將對手的牌庫上方1張卡丟棄。",
+				th: "ทิ้งการ์ด 1 ใบจากด้านบนของสำรับการ์ดฝ่ายตรงข้ามที่ตำแหน่งทิ้งการ์ด",
+				id: "Buang 1 kartu dari atas Deck lawan ke Trash.",
+			},
 		},
-
-		effect: {
-			ja: "相手の山札を上から1枚トラッシュする。",
-			'zh-tw': "將對手的牌庫上方1張卡丟棄。",
-			th: "ทิ้งการ์ด 1 ใบจากด้านบนของสำรับการ์ดฝ่ายตรงข้ามที่ตำแหน่งทิ้งการ์ด",
-			id: "Buang 1 kartu dari atas Deck lawan ke Trash."
-		}
-	}, {
-		cost: ["Fighting", "Fighting"],
-
-		name: {
-			ja: "パンチ",
-			'zh-tw': "出拳",
-			th: "หมัด",
-			id: "Pukulan"
+		{
+			name: {
+				ja: "パンチ",
+				'zh-tw': "出拳",
+				th: "หมัด",
+				id: "Pukulan",
+			},
+			damage: 30,
+			cost: ["Fighting", "Fighting"],
 		},
+	],
 
-		damage: 30
-	}],
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Psychic",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 719508,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				cardmarket: 837348,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				cardmarket: 837349,
+			},
+		},
+	],
 
 	retreat: 2,
 	regulationMark: "G",
+	rarity: "Common",
+	dexId: [66],
+};
 
-	thirdParty: {
-		cardmarket: 719508
-	}
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV2a/067.ts
+++ b/data-asia/SV/SV2a/067.ts
@@ -1,20 +1,17 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV2a"
+import { Card } from "../../../interfaces";
+import Set from "../SV2a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "ゴーリキー",
 		'zh-tw': "豪力",
 		th: "โกริกี",
-		id: "Machoke"
+		id: "Machoke",
 	},
 
 	illustrator: "Ryuta Fuse",
-	rarity: "Uncommon",
 	category: "Pokemon",
-	dexId: [67],
 	hp: 100,
 	types: ["Fighting"],
 
@@ -22,42 +19,64 @@ const card: Card = {
 		ja: "疲れることのない 強靭な 肉体を もつ。 重い 荷物の 運搬などの 仕事を 手伝う。",
 		'zh-tw': "有著不會疲勞的強韌肉體。會去幫助人類完成例如 搬運沉重行李之類的工作。",
 		th: "มีร่างกายแข็งแรงทนทานไม่เคยรู้สึกเหนื่อย ช่วยงานขนยกของหนัก ๆ",
-		id: "Tubuh Machoke tangguh dan tidak mengenal lelah. Pokémon ini membantu melakukan pekerjaan seperti mengangkut barang berat dan lainnya."
+		id: "Tubuh Machoke tangguh dan tidak mengenal lelah. Pokémon ini membantu melakukan pekerjaan seperti mengangkut barang berat dan lainnya.",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		cost: ["Fighting", "Fighting"],
-
-		name: {
-			ja: "やまどつき",
-			'zh-tw': "推山",
-			th: "ต่อยตีภูเขา",
-			id: "Menohok Gunung"
+	attacks: [
+		{
+			name: {
+				ja: "やまどつき",
+				'zh-tw': "推山",
+				th: "ต่อยตีภูเขา",
+				id: "Menohok Gunung",
+			},
+			damage: 50,
+			cost: ["Fighting", "Fighting"],
+			effect: {
+				ja: "相手の山札を上から1枚トラッシュする。",
+				'zh-tw': "將對手的牌庫上方1張卡丟棄。",
+				th: "ทิ้งการ์ด 1 ใบจากด้านบนของสำรับการ์ดฝ่ายตรงข้ามที่ตำแหน่งทิ้งการ์ด",
+				id: "Buang 1 kartu dari atas Deck lawan ke Trash.",
+			},
 		},
+	],
 
-		damage: 50,
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
 
-		effect: {
-			ja: "相手の山札を上から1枚トラッシュする。",
-			'zh-tw': "將對手的牌庫上方1張卡丟棄。",
-			th: "ทิ้งการ์ด 1 ใบจากด้านบนของสำรับการ์ดฝ่ายตรงข้ามที่ตำแหน่งทิ้งการ์ด",
-			id: "Buang 1 kartu dari atas Deck lawan ke Trash."
-		}
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 719509,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				cardmarket: 837350,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				cardmarket: 837351,
+			},
+		},
+	],
 
-	weaknesses: [{
-		type: "Psychic",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "ワンリキー",
+	},
 
 	retreat: 2,
 	regulationMark: "G",
+	rarity: "Uncommon",
+	dexId: [67],
+};
 
-	thirdParty: {
-		cardmarket: 719509
-	}
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV2a/068.ts
+++ b/data-asia/SV/SV2a/068.ts
@@ -1,20 +1,17 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV2a"
+import { Card } from "../../../interfaces";
+import Set from "../SV2a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "カイリキー",
 		'zh-tw': "怪力",
 		th: "ไคริกี",
-		id: "Machamp"
+		id: "Machamp",
 	},
 
 	illustrator: "Ryuta Fuse",
-	rarity: "Rare",
 	category: "Pokemon",
-	dexId: [68],
 	hp: 180,
 	types: ["Fighting"],
 
@@ -22,60 +19,82 @@ const card: Card = {
 		ja: "４本の 腕は 考えるより 早く 反射的に 動き 何発もの パンチを 繰りだせる。",
 		'zh-tw': "４隻手臂在思考之前就會反射性地行動， 使出多發拳擊。",
 		th: "แขนทั้ง 4 แขนตอบสนองได้รวดเร็วยิ่งกว่าความคิด สามารถออกหมัดได้ทีละหลาย ๆ หมัด",
-		id: "Keempat lengan Machamp bergerak cepat secara refleks melebihi kecepatan berpikir, sehingga dapat meluncurkan banyak pukulan secara sekaligus."
+		id: "Keempat lengan Machamp bergerak cepat secara refleks melebihi kecepatan berpikir, sehingga dapat meluncurkan banyak pukulan secara sekaligus.",
 	},
 
 	stage: "Stage2",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			ja: "こんじょう",
-			'zh-tw': "毅力",
-			th: "มุ่งมั่น",
-			id: "Nyali"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "こんじょう",
+				'zh-tw': "毅力",
+				th: "มุ่งมั่น",
+				id: "Nyali",
+			},
+			effect: {
+				ja: "このポケモンが、ワザのダメージを受けてきぜつするとき、自分はコインを1回投げる。オモテなら、このポケモンはきぜつせず、残りHPが「10」の状態で場に残る。",
+				'zh-tw': "這隻寶可夢受到招式的傷害而【昏厥】時，自己擲1次硬幣。若為正面，則這隻寶可夢不會【昏厥】，而是以剩餘HP為「10」的狀態留在場上。",
+				th: "เมื่อโปเกมอนนี้ ได้รับแดเมจของท่าต่อสู้และจะ[หมดสภาพ] ฝ่ายเราทอยเหรียญ 1 ครั้ง ถ้าออกหัว โปเกมอนนี้จะไม่[หมดสภาพ] และจะอยู่บนกระดานด้วย HP ที่เหลือ [10]",
+				id: "Saat Pokémon ini KO karena menerima kerusakan akibat serangan, pemain melempar koin 1 kali. Jika hasilnya sisi depan, Pokémon ini tidak KO dan tetap berada di Arena dengan kondisi sisa HP sejumlah 10.",
+			},
 		},
+	],
 
-		effect: {
-			ja: "このポケモンが、ワザのダメージを受けてきぜつするとき、自分はコインを1回投げる。オモテなら、このポケモンはきぜつせず、残りHPが「10」の状態で場に残る。",
-			'zh-tw': "這隻寶可夢受到招式的傷害而【昏厥】時，自己擲1次硬幣。若為正面，則這隻寶可夢不會【昏厥】，而是以剩餘HP為「10」的狀態留在場上。",
-			th: "เมื่อโปเกมอนนี้ ได้รับแดเมจของท่าต่อสู้และจะ[หมดสภาพ] ฝ่ายเราทอยเหรียญ 1 ครั้ง ถ้าออกหัว โปเกมอนนี้จะไม่[หมดสภาพ] และจะอยู่บนกระดานด้วย HP ที่เหลือ [10]",
-			id: "Saat Pokémon ini KO karena menerima kerusakan akibat serangan, pemain melempar koin 1 kali. Jika hasilnya sisi depan, Pokémon ini tidak KO dan tetap berada di Arena dengan kondisi sisa HP sejumlah 10."
-		}
-	}],
-
-	attacks: [{
-		cost: ["Fighting", "Fighting"],
-
-		name: {
-			ja: "マウンテンチョップ",
-			'zh-tw': "山岳劈打",
-			th: "เมาน์เทนช็อป",
-			id: "Mountain Chop"
+	attacks: [
+		{
+			name: {
+				ja: "マウンテンチョップ",
+				'zh-tw': "山岳劈打",
+				th: "เมาน์เทนช็อป",
+				id: "Mountain Chop",
+			},
+			damage: 100,
+			cost: ["Fighting", "Fighting"],
+			effect: {
+				ja: "相手の山札を上から2枚トラッシュする。",
+				'zh-tw': "將對手的牌庫上方2張卡丟棄。",
+				th: "ทิ้งการ์ด 2 ใบจากด้านบนของสำรับการ์ดฝ่ายตรงข้ามที่ตำแหน่งทิ้งการ์ด",
+				id: "Buang 2 kartu dari atas Deck lawan ke Trash.",
+			},
 		},
+	],
 
-		damage: 100,
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
 
-		effect: {
-			ja: "相手の山札を上から2枚トラッシュする。",
-			'zh-tw': "將對手的牌庫上方2張卡丟棄。",
-			th: "ทิ้งการ์ด 2 ใบจากด้านบนของสำรับการ์ดฝ่ายตรงข้ามที่ตำแหน่งทิ้งการ์ด",
-			id: "Buang 2 kartu dari atas Deck lawan ke Trash."
-		}
-	}],
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 719510,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				cardmarket: 837352,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				cardmarket: 837353,
+			},
+		},
+	],
 
-	weaknesses: [{
-		type: "Psychic",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "ゴーリキー",
+	},
 
 	retreat: 2,
 	regulationMark: "G",
+	rarity: "Rare",
+	dexId: [68],
+};
 
-	thirdParty: {
-		cardmarket: 719510
-	}
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV2a/069.ts
+++ b/data-asia/SV/SV2a/069.ts
@@ -1,20 +1,17 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV2a"
+import { Card } from "../../../interfaces";
+import Set from "../SV2a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "マダツボミ",
 		'zh-tw': "喇叭芽",
 		th: "มาดาซึโบมิ",
-		id: "Bellsprout"
+		id: "Bellsprout",
 	},
 
 	illustrator: "Jerky",
-	rarity: "Common",
 	category: "Pokemon",
-	dexId: [69],
 	hp: 60,
 	types: ["Grass"],
 
@@ -22,53 +19,70 @@ const card: Card = {
 		ja: "人の 顔のような つぼみから 伝説の マンドラゴラの 一種ではないかと ささやかれている。",
 		'zh-tw': "因為花苞長得像人臉， 所以私底下有些人說牠是 傳說生物曼德拉草的一種。",
 		th: "มีเสียงซุบซิบกันว่า จากดอกตูมที่ดูราวกับใบหน้าคนนั้น อาจจะเป็นพันธุ์หนึ่งของแมนเดรกในตำนานหรือไม่",
-		id: "Karena kuncupnya menyerupai wajah manusia, Bellsprout digosipkan sebagai sejenis Mandragora yang legendaris."
+		id: "Karena kuncupnya menyerupai wajah manusia, Bellsprout digosipkan sebagai sejenis Mandragora yang legendaris.",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		cost: ["Grass"],
-
-		name: {
-			ja: "いあいぎり",
-			'zh-tw': "居合斬",
-			th: "ตัด",
-			id: "Potongan Iai"
+	attacks: [
+		{
+			name: {
+				ja: "いあいぎり",
+				'zh-tw': "居合斬",
+				th: "ตัด",
+				id: "Potongan Iai",
+			},
+			damage: 10,
+			cost: ["Grass"],
 		},
-
-		damage: 10
-	}, {
-		cost: ["Grass", "Colorless"],
-
-		name: {
-			ja: "しばりつける",
-			'zh-tw': "束縛",
-			th: "มัดยึด",
-			id: "Menjerat"
+		{
+			name: {
+				ja: "しばりつける",
+				'zh-tw': "束縛",
+				th: "มัดยึด",
+				id: "Menjerat",
+			},
+			damage: 20,
+			cost: ["Grass", "Colorless"],
+			effect: {
+				ja: "次の相手の番、このワザを受けたポケモンは、にげられない。",
+				'zh-tw': "在下個對手的回合，受到這個招式的寶可夢無法撤退。",
+				th: "เทิร์นถัดไปของฝ่ายตรงข้าม โปเกมอนที่ได้รับท่าต่อสู้นี้ จะหนีไม่ได้",
+				id: "Pada giliran lawan berikutnya, Pokémon yang menerima serangan ini tidak dapat Mundur.",
+			},
 		},
+	],
 
-		damage: 20,
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
 
-		effect: {
-			ja: "次の相手の番、このワザを受けたポケモンは、にげられない。",
-			'zh-tw': "在下個對手的回合，受到這個招式的寶可夢無法撤退。",
-			th: "เทิร์นถัดไปของฝ่ายตรงข้าม โปเกมอนที่ได้รับท่าต่อสู้นี้ จะหนีไม่ได้",
-			id: "Pada giliran lawan berikutnya, Pokémon yang menerima serangan ini tidak dapat Mundur."
-		}
-	}],
-
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 719511,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				cardmarket: 837354,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				cardmarket: 837355,
+			},
+		},
+	],
 
 	retreat: 1,
 	regulationMark: "G",
+	rarity: "Common",
+	dexId: [69],
+};
 
-	thirdParty: {
-		cardmarket: 719511
-	}
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV2a/070.ts
+++ b/data-asia/SV/SV2a/070.ts
@@ -1,20 +1,17 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV2a"
+import { Card } from "../../../interfaces";
+import Set from "../SV2a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "ウツドン",
 		'zh-tw': "口呆花",
 		th: "อุซึดง",
-		id: "Weepinbell"
+		id: "Weepinbell",
 	},
 
 	illustrator: "Jerky",
-	rarity: "Common",
 	category: "Pokemon",
-	dexId: [70],
 	hp: 90,
 	types: ["Grass"],
 
@@ -22,46 +19,68 @@ const card: Card = {
 		ja: "まず 毒の粉を 吐き 相手の 動きを 止めてしまってから 溶解液で とどめを 刺す。",
 		'zh-tw': "會先吐出有毒的粉末， 讓對手停止行動後， 再用溶解液解決對手。",
 		th: "ก่อนอื่นจะพ่นผงพิษหยุดการเคลื่อนไหวของฝ่ายตรงข้ามไว้ก่อน แล้วปิดท้ายด้วยของเหลวทำละลาย",
-		id: "Weepinbell terlebih dahulu menyemburkan bubuk beracun untuk menghentikan gerakan lawan, lalu menghabisinya menggunakan cairan pelebur."
+		id: "Weepinbell terlebih dahulu menyemburkan bubuk beracun untuk menghentikan gerakan lawan, lalu menghabisinya menggunakan cairan pelebur.",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		cost: ["Grass"],
-
-		name: {
-			ja: "いあいぎり",
-			'zh-tw': "居合斬",
-			th: "ตัด",
-			id: "Potongan Iai"
+	attacks: [
+		{
+			name: {
+				ja: "いあいぎり",
+				'zh-tw': "居合斬",
+				th: "ตัด",
+				id: "Potongan Iai",
+			},
+			damage: 30,
+			cost: ["Grass"],
 		},
-
-		damage: 30
-	}, {
-		cost: ["Grass", "Colorless"],
-
-		name: {
-			ja: "しるをとばす",
-			'zh-tw': "噴汁",
-			th: "ฉีดพ่นน้ำ",
-			id: "Menyemprotkan Getah"
+		{
+			name: {
+				ja: "しるをとばす",
+				'zh-tw': "噴汁",
+				th: "ฉีดพ่นน้ำ",
+				id: "Menyemprotkan Getah",
+			},
+			damage: 50,
+			cost: ["Grass", "Colorless"],
 		},
+	],
 
-		damage: 50
-	}],
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 719512,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				cardmarket: 837356,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				cardmarket: 837357,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "マダツボミ",
+	},
 
 	retreat: 2,
 	regulationMark: "G",
+	rarity: "Common",
+	dexId: [70],
+};
 
-	thirdParty: {
-		cardmarket: 719512
-	}
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV2a/071.ts
+++ b/data-asia/SV/SV2a/071.ts
@@ -1,20 +1,17 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV2a"
+import { Card } from "../../../interfaces";
+import Set from "../SV2a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "ウツボット",
 		'zh-tw': "大食花",
 		th: "อุซึบ็อท",
-		id: "Victreebel"
+		id: "Victreebel",
 	},
 
 	illustrator: "Jerky",
-	rarity: "Uncommon",
 	category: "Pokemon",
-	dexId: [71],
 	hp: 150,
 	types: ["Grass"],
 
@@ -22,53 +19,74 @@ const card: Card = {
 		ja: "体内に 取りこまれた ものは どんなに 硬くても 溶解液で 跡形なく 溶かされてしまう。",
 		'zh-tw': "被牠吞進體內的東西不管有多硬， 都會被溶解液不留痕跡地融化掉。",
 		th: "สิ่งที่เอาใส่เข้าไปในร่างกายไม่ว่าจะแข็งแค่ไหนก็จะถูกละลายด้วยของเหลวทำละลายจนไม่เหลือซาก",
-		id: "Semua yang ditelan masuk ke dalam tubuh Victreebel akan leleh tak bersisa oleh cairan peleburnya walau sekeras apa pun itu."
+		id: "Semua yang ditelan masuk ke dalam tubuh Victreebel akan leleh tak bersisa oleh cairan peleburnya walau sekeras apa pun itu.",
 	},
 
 	stage: "Stage2",
 
-	attacks: [{
-		cost: ["Grass"],
-
-		name: {
-			ja: "はきだす",
-			'zh-tw': "噴出",
-			th: "บ้วนออกมา",
-			id: "Memuntahkan"
+	attacks: [
+		{
+			name: {
+				ja: "はきだす",
+				'zh-tw': "噴出",
+				th: "บ้วนออกมา",
+				id: "Memuntahkan",
+			},
+			damage: 50,
+			cost: ["Grass"],
 		},
-
-		damage: 50
-	}, {
-		cost: ["Grass", "Colorless"],
-
-		name: {
-			ja: "ディレイドアシッド",
-			'zh-tw': "遲延酸液",
-			th: "ดีเลย์แอซิด",
-			id: "Delayed Acid"
+		{
+			name: {
+				ja: "ディレイドアシッド",
+				'zh-tw': "遲延酸液",
+				th: "ดีเลย์แอซิด",
+				id: "Delayed Acid",
+			},
+			damage: 120,
+			cost: ["Grass", "Colorless"],
+			effect: {
+				ja: "次の相手の番の終わりに、このワザを受けたポケモンにダメカンを12個のせる。",
+				'zh-tw': "在下個對手的回合結束時，在受到這個招式的寶可夢身上放置12個傷害指示物。",
+				th: "เมื่อจบเทิร์นถัดไปของฝ่ายตรงข้าม วางตัวนับแดเมจ 12 ตัวบนโปเกมอนที่ได้รับท่าต่อสู้นี้",
+				id: "Pada akhir giliran lawan berikutnya, letakkan 12 Token Kerusakan pada Pokémon yang menerima serangan ini.",
+			},
 		},
+	],
 
-		damage: 120,
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
 
-		effect: {
-			ja: "次の相手の番の終わりに、このワザを受けたポケモンにダメカンを12個のせる。",
-			'zh-tw': "在下個對手的回合結束時，在受到這個招式的寶可夢身上放置12個傷害指示物。",
-			th: "เมื่อจบเทิร์นถัดไปของฝ่ายตรงข้าม วางตัวนับแดเมจ 12 ตัวบนโปเกมอนที่ได้รับท่าต่อสู้นี้",
-			id: "Pada akhir giliran lawan berikutnya, letakkan 12 Token Kerusakan pada Pokémon yang menerima serangan ini."
-		}
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 719513,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				cardmarket: 837358,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				cardmarket: 837359,
+			},
+		},
+	],
 
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "ウツドン",
+	},
 
 	retreat: 3,
 	regulationMark: "G",
+	rarity: "Uncommon",
+	dexId: [71],
+};
 
-	thirdParty: {
-		cardmarket: 719513
-	}
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV2a/072.ts
+++ b/data-asia/SV/SV2a/072.ts
@@ -1,20 +1,17 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV2a"
+import { Card } from "../../../interfaces";
+import Set from "../SV2a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "メノクラゲ",
 		'zh-tw': "瑪瑙水母",
 		th: "เมโนคุราเกะ",
-		id: "Tentacool"
+		id: "Tentacool",
 	},
 
 	illustrator: "miki kudo",
-	rarity: "Common",
 	category: "Pokemon",
-	dexId: [72],
 	hp: 60,
 	types: ["Water"],
 
@@ -22,46 +19,64 @@ const card: Card = {
 		ja: "ほとんどが 水分で できている。 体は 海の中では 水と 同化して とても 見えづらいのだ。",
 		'zh-tw': "絕大部分都是由水組成的身體在海中會與海水同化， 令其他生物很難看見牠。",
 		th: "ร่างกายส่วนใหญ่เกิดมาจากน้ำ เมื่ออยู่ในทะเลร่างกายจะดูกลมกลืนกับน้ำจนมองแยกไม่ออก",
-		id: "Tubuh Tentacool hampir seluruhnya terbentuk atas air. Di dalam laut, tubuhnya terlihat menyatu dengan air sehingga sulit dilihat."
+		id: "Tubuh Tentacool hampir seluruhnya terbentuk atas air. Di dalam laut, tubuhnya terlihat menyatu dengan air sehingga sulit dilihat.",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		cost: ["Water"],
-
-		name: {
-			ja: "ぴりっ",
-			'zh-tw': "麻",
-			th: "เผ็ด",
-			id: "Pedas Menyengat"
+	attacks: [
+		{
+			name: {
+				ja: "ぴりっ",
+				'zh-tw': "麻",
+				th: "เผ็ด",
+				id: "Pedas Menyengat",
+			},
+			damage: 10,
+			cost: ["Water"],
 		},
-
-		damage: 10
-	}, {
-		cost: ["Colorless", "Colorless"],
-
-		name: {
-			ja: "みずまき",
-			'zh-tw': "灑水",
-			th: "โปรยน้ำ",
-			id: "Menyiramkan Air"
+		{
+			name: {
+				ja: "みずまき",
+				'zh-tw': "灑水",
+				th: "โปรยน้ำ",
+				id: "Menyiramkan Air",
+			},
+			damage: 20,
+			cost: ["Colorless", "Colorless"],
 		},
+	],
 
-		damage: 20
-	}],
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Lightning",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 719514,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				cardmarket: 837370,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				cardmarket: 837372,
+			},
+		},
+	],
 
 	retreat: 1,
 	regulationMark: "G",
+	rarity: "Common",
+	dexId: [72],
+};
 
-	thirdParty: {
-		cardmarket: 719514
-	}
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV2a/073.ts
+++ b/data-asia/SV/SV2a/073.ts
@@ -1,20 +1,17 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV2a"
+import { Card } from "../../../interfaces";
+import Set from "../SV2a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "ドククラゲ",
 		'zh-tw': "毒刺水母",
 		th: "โดคุคุราเกะ",
-		id: "Tentacruel"
+		id: "Tentacruel",
 	},
 
 	illustrator: "miki kudo",
-	rarity: "Uncommon",
 	category: "Pokemon",
-	dexId: [73],
 	hp: 120,
 	types: ["Water"],
 
@@ -22,60 +19,80 @@ const card: Card = {
 		ja: "８０本の 触手は 伸び縮み 自由。 網のように 広げて 獲物を 捕らえ 毒バリを 刺す。",
 		'zh-tw': "能夠自由伸縮身上的８０根觸手。會像撒網般張開觸手捕捉獵物， 並用毒針注入劇毒。",
 		th: "หนวด 80 เส้นนั้นยืดและหดได้อย่างอิสระ จะกางออกเหมือนกับตาข่ายเพื่อจับเหยื่อแล้วแทงเข็มพิษ",
-		id: "Tentacruel dapat memanjangkan dan memendekkan 80 tentakelnya dengan bebas. Pokémon ini melebarkan tentakelnya bagai jaring untuk menangkap mangsa dan menusukkan jarum beracun."
+		id: "Tentacruel dapat memanjangkan dan memendekkan 80 tentakelnya dengan bebas. Pokémon ini melebarkan tentakelnya bagai jaring untuk menangkap mangsa dan menusukkan jarum beracun.",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		cost: ["Colorless", "Colorless"],
-
-		name: {
-			ja: "どくのムチ",
-			'zh-tw': "毒之鞭",
-			th: "แส้พิษ",
-			id: "Cambuk Beracun"
+	attacks: [
+		{
+			name: {
+				ja: "どくのムチ",
+				'zh-tw': "毒之鞭",
+				th: "แส้พิษ",
+				id: "Cambuk Beracun",
+			},
+			damage: 30,
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをどくにする。",
+				'zh-tw': "將對手的戰鬥寶可夢【中毒】。",
+				th: "ทำให้โปเกมอนบนตำแหน่งต่อสู้ฝ่ายตรงข้ามเป็นสภาวะ[พิษ]",
+				id: "Ubah kondisi Pokémon Bertarung lawan menjadi Racun.",
+			},
 		},
-
-		damage: 30,
-
-		effect: {
-			ja: "相手のバトルポケモンをどくにする。",
-			'zh-tw': "將對手的戰鬥寶可夢【中毒】。",
-			th: "ทำให้โปเกมอนบนตำแหน่งต่อสู้ฝ่ายตรงข้ามเป็นสภาวะ[พิษ]",
-			id: "Ubah kondisi Pokémon Bertarung lawan menjadi Racun."
-		}
-	}, {
-		cost: ["Water", "Colorless", "Colorless"],
-
-		name: {
-			ja: "パニックテンタクル",
-			'zh-tw': "恐慌觸手",
-			th: "แพนิกเทนทาเคิล",
-			id: "Panic Tentacle"
+		{
+			name: {
+				ja: "パニックテンタクル",
+				'zh-tw': "恐慌觸手",
+				th: "แพนิกเทนทาเคิล",
+				id: "Panic Tentacle",
+			},
+			damage: "90×",
+			cost: ["Water", "Colorless", "Colorless"],
+			effect: {
+				ja: "ウラが出るまでコインを投げ、オモテの数×90ダメージ。最初のコインがウラなら、相手のバトルポケモンをこんらんにする。",
+				'zh-tw': "擲硬幣直到出現反面，造成正面出現的次數×90點傷害。若最初的硬幣為反面，則將對手的戰鬥寶可夢【混亂】。",
+				th: "ทอยเหรียญจนกว่าจะออกก้อย แดเมจจะเท่ากับจำนวนครั้งที่ออกหัว x90 ถ้าเหรียญออกก้อยในครั้งแรก จะทำให้โปเกมอนบนตำแหน่งต่อสู้ฝ่ายตรงข้ามเป็นสภาวะ[สับสน]",
+				id: "Lempar koin hingga hasilnya sisi belakang. Serangan ini memberikan kerusakan sejumlah 90 untuk tiap lemparan dengan hasil sisi depan. Jika lemparan koin pertama hasilnya sisi belakang, ubah kondisi Pokémon Bertarung lawan menjadi Pusing.",
+			},
 		},
+	],
 
-		damage: "90×",
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
 
-		effect: {
-			ja: "ウラが出るまでコインを投げ、オモテの数×90ダメージ。最初のコインがウラなら、相手のバトルポケモンをこんらんにする。",
-			'zh-tw': "擲硬幣直到出現反面，造成正面出現的次數×90點傷害。若最初的硬幣為反面，則將對手的戰鬥寶可夢【混亂】。",
-			th: "ทอยเหรียญจนกว่าจะออกก้อย แดเมจจะเท่ากับจำนวนครั้งที่ออกหัว x90 ถ้าเหรียญออกก้อยในครั้งแรก จะทำให้โปเกมอนบนตำแหน่งต่อสู้ฝ่ายตรงข้ามเป็นสภาวะ[สับสน]",
-			id: "Lempar koin hingga hasilnya sisi belakang. Serangan ini memberikan kerusakan sejumlah 90 untuk tiap lemparan dengan hasil sisi depan. Jika lemparan koin pertama hasilnya sisi belakang, ubah kondisi Pokémon Bertarung lawan menjadi Pusing."
-		}
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 719515,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				cardmarket: 837373,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				cardmarket: 837374,
+			},
+		},
+	],
 
-	weaknesses: [{
-		type: "Lightning",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "メノクラゲ",
+	},
 
 	retreat: 2,
 	regulationMark: "G",
+	rarity: "Uncommon",
+	dexId: [73],
+};
 
-	thirdParty: {
-		cardmarket: 719515
-	}
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV2a/074.ts
+++ b/data-asia/SV/SV2a/074.ts
@@ -1,20 +1,17 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV2a"
+import { Card } from "../../../interfaces";
+import Set from "../SV2a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "イシツブテ",
 		'zh-tw': "小拳石",
 		th: "อิชิซึบูเตะ",
-		id: "Geodude"
+		id: "Geodude",
 	},
 
 	illustrator: "Uta",
-	rarity: "Common",
 	category: "Pokemon",
-	dexId: [74],
 	hp: 80,
 	types: ["Fighting"],
 
@@ -22,51 +19,69 @@ const card: Card = {
 		ja: "両手を 使い 険しい 崖を 登る。 その姿を 見た 人が ボルダリングを 始めたらしい。",
 		'zh-tw': "會用雙手攀登險峻的山崖。 人們似乎是在目睹牠那姿態之後 才開始了抱石攀岩運動。",
 		th: "ใช้แขนทั้งสองข้างปีนหน้าผาชันได้ จุดเริ่มของกีฬาปีนผา เหมือนจะมาจากคนที่เห็นภาพดังกล่าว",
-		id: "Geodude menggunakan kedua tangannya untuk memanjat tebing yang curam. Orang yang melihatnya kabarnya mulai melakukan panjat tebing."
+		id: "Geodude menggunakan kedua tangannya untuk memanjat tebing yang curam. Orang yang melihatnya kabarnya mulai melakukan panjat tebing.",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		cost: ["Fighting"],
-
-		name: {
-			ja: "かたまる",
-			'zh-tw': "凝固",
-			th: "ทำให้แข็ง",
-			id: "Perkeras"
+	attacks: [
+		{
+			name: {
+				ja: "かたまる",
+				'zh-tw': "凝固",
+				th: "ทำให้แข็ง",
+				id: "Perkeras",
+			},
+			cost: ["Fighting"],
+			effect: {
+				ja: "次の相手の番、このポケモンが受けるワザのダメージは「-30」される。",
+				'zh-tw': "在下個對手的回合，這隻寶可夢受到招式的傷害「-30」點。",
+				th: "เทิร์นถัดไปของฝ่ายตรงข้าม แดเมจของท่าต่อสู้ที่โปเกมอนนี้จะได้รับจะถูก [-30]",
+				id: "Pada giliran lawan berikutnya, kerusakan akibat serangan yang diterima Pokémon ini berkurang sejumlah 30.",
+			},
 		},
-
-		effect: {
-			ja: "次の相手の番、このポケモンが受けるワザのダメージは「-30」される。",
-			'zh-tw': "在下個對手的回合，這隻寶可夢受到招式的傷害「-30」點。",
-			th: "เทิร์นถัดไปของฝ่ายตรงข้าม แดเมจของท่าต่อสู้ที่โปเกมอนนี้จะได้รับจะถูก [-30]",
-			id: "Pada giliran lawan berikutnya, kerusakan akibat serangan yang diterima Pokémon ini berkurang sejumlah 30."
-		}
-	}, {
-		cost: ["Fighting", "Colorless"],
-
-		name: {
-			ja: "げんこつ",
-			'zh-tw': "拳骨",
-			th: "กำปั้น",
-			id: "Kepalan Tinju"
+		{
+			name: {
+				ja: "げんこつ",
+				'zh-tw': "拳骨",
+				th: "กำปั้น",
+				id: "Kepalan Tinju",
+			},
+			damage: 20,
+			cost: ["Fighting", "Colorless"],
 		},
+	],
 
-		damage: 20
-	}],
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Grass",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 719516,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				cardmarket: 837375,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				cardmarket: 837376,
+			},
+		},
+	],
 
 	retreat: 2,
 	regulationMark: "G",
+	rarity: "Common",
+	dexId: [74],
+};
 
-	thirdParty: {
-		cardmarket: 719516
-	}
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV2a/075.ts
+++ b/data-asia/SV/SV2a/075.ts
@@ -1,20 +1,17 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV2a"
+import { Card } from "../../../interfaces";
+import Set from "../SV2a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "ゴローン",
 		'zh-tw': "隆隆石",
 		th: "โกโลน",
-		id: "Graveler"
+		id: "Graveler",
 	},
 
 	illustrator: "Uta",
-	rarity: "Uncommon",
 	category: "Pokemon",
-	dexId: [75],
 	hp: 110,
 	types: ["Fighting"],
 
@@ -22,53 +19,74 @@ const card: Card = {
 		ja: "崖を 転がり 移動する。 間違えて 川に 落ちると 最期の あがきで 大爆発。",
 		'zh-tw': "藉著從山崖上滾落來移動。 如果不小心掉進河裡， 就會在最後掙扎時來個大爆炸。",
 		th: "เคลื่อนที่โดยกลิ้งไปตามผา พอพลาดตกลงแม่น้ำแล้ว ก็จะดิ้นรนจนหยดสุดท้ายแล้วระเบิดตัว",
-		id: "Graveler bergerak dengan cara menggelindingkan diri di tebing. Jika salah gerak dan jatuh ke sungai, Pokémon ini meledak sebagai usaha terakhirnya."
+		id: "Graveler bergerak dengan cara menggelindingkan diri di tebing. Jika salah gerak dan jatuh ke sungai, Pokémon ini meledak sebagai usaha terakhirnya.",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		cost: ["Fighting"],
-
-		name: {
-			ja: "れんぞくいわなげ",
-			'zh-tw': "連續投石",
-			th: "ปาหินต่อเนื่อง",
-			id: "Lempar Batu Beruntun"
+	attacks: [
+		{
+			name: {
+				ja: "れんぞくいわなげ",
+				'zh-tw': "連續投石",
+				th: "ปาหินต่อเนื่อง",
+				id: "Lempar Batu Beruntun",
+			},
+			damage: "40×",
+			cost: ["Fighting"],
+			effect: {
+				ja: "ウラが出るまでコインを投げ、オモテの数×40ダメージ。",
+				'zh-tw': "擲硬幣直到出現反面，造成正面出現的次數×40點傷害。",
+				th: "ทอยเหรียญจนกว่าจะออกก้อย แดเมจจะเท่ากับจำนวนครั้งที่ออกหัว x40",
+				id: "Lempar koin hingga hasilnya sisi belakang. Serangan ini memberikan kerusakan sejumlah 40 untuk tiap lemparan dengan hasil sisi depan.",
+			},
 		},
-
-		damage: "40×",
-
-		effect: {
-			ja: "ウラが出るまでコインを投げ、オモテの数×40ダメージ。",
-			'zh-tw': "擲硬幣直到出現反面，造成正面出現的次數×40點傷害。",
-			th: "ทอยเหรียญจนกว่าจะออกก้อย แดเมจจะเท่ากับจำนวนครั้งที่ออกหัว x40",
-			id: "Lempar koin hingga hasilnya sisi belakang. Serangan ini memberikan kerusakan sejumlah 40 untuk tiap lemparan dengan hasil sisi depan."
-		}
-	}, {
-		cost: ["Fighting", "Colorless", "Colorless"],
-
-		name: {
-			ja: "ヘビーインパクト",
-			'zh-tw': "重磅衝擊",
-			th: "เฮวี่อิมแพ็คท์",
-			id: "Heavy Impact"
+		{
+			name: {
+				ja: "ヘビーインパクト",
+				'zh-tw': "重磅衝擊",
+				th: "เฮวี่อิมแพ็คท์",
+				id: "Heavy Impact",
+			},
+			damage: 60,
+			cost: ["Fighting", "Colorless", "Colorless"],
 		},
+	],
 
-		damage: 60
-	}],
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Grass",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 719517,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				cardmarket: 837377,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				cardmarket: 837378,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "イシツブテ",
+	},
 
 	retreat: 3,
 	regulationMark: "G",
+	rarity: "Uncommon",
+	dexId: [75],
+};
 
-	thirdParty: {
-		cardmarket: 719517
-	}
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV2a/076.ts
+++ b/data-asia/SV/SV2a/076.ts
@@ -1,73 +1,79 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV2a"
+import { Card } from "../../../interfaces";
+import Set from "../SV2a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "ゴローニャex",
 		'zh-tw': "隆隆岩ex",
 		th: "โกโลเนียex",
-		id: "Golem ex"
+		id: "Golem ex",
 	},
 
 	illustrator: "Uta",
-	rarity: "Double rare",
 	category: "Pokemon",
 	hp: 330,
 	types: ["Fighting"],
+
 	stage: "Stage2",
-	suffix: "EX",
 
-	attacks: [{
-		cost: ["Fighting"],
-
-		name: {
-			ja: "ダイナミックロール",
-			'zh-tw': "極限轉動",
-			th: "ไดนามิกโรล",
-			id: "Dynamic Roll"
+	attacks: [
+		{
+			name: {
+				ja: "ダイナミックロール",
+				'zh-tw': "極限轉動",
+				th: "ไดนามิกโรล",
+				id: "Dynamic Roll",
+			},
+			damage: 50,
+			cost: ["Fighting"],
+			effect: {
+				ja: "次の自分の番、このポケモンが使うワザの、相手のバトルポケモンへのダメージは「+120」される。",
+				'zh-tw': "在下個自己的回合，這隻寶可夢使用的招式，對對手的戰鬥寶可夢造成的傷害「+120」點。",
+				th: "เทิร์นถัดไปของฝ่ายเรา แดเมจของท่าต่อสู้ที่โปเกมอนนี้ ใช้ทำกับโปเกมอนบนตำแหน่งต่อสู้ฝ่ายตรงข้ามจะถูก [+120]",
+				id: "Pada giliran sendiri berikutnya, kerusakan akibat serangan yang digunakan oleh Pokémon ini kepada Pokémon Bertarung lawan bertambah sejumlah 120.",
+			},
 		},
-
-		damage: 50,
-
-		effect: {
-			ja: "次の自分の番、このポケモンが使うワザの、相手のバトルポケモンへのダメージは「+120」される。",
-			'zh-tw': "在下個自己的回合，這隻寶可夢使用的招式，對對手的戰鬥寶可夢造成的傷害「+120」點。",
-			th: "เทิร์นถัดไปของฝ่ายเรา แดเมจของท่าต่อสู้ที่โปเกมอนนี้ ใช้ทำกับโปเกมอนบนตำแหน่งต่อสู้ฝ่ายตรงข้ามจะถูก [+120]",
-			id: "Pada giliran sendiri berikutnya, kerusakan akibat serangan yang digunakan oleh Pokémon ini kepada Pokémon Bertarung lawan bertambah sejumlah 120."
-		}
-	}, {
-		cost: ["Fighting", "Colorless", "Colorless"],
-
-		name: {
-			ja: "がんせきボンバー",
-			'zh-tw': "岩石衝撞",
-			th: "ระเบิดหิน",
-			id: "Bom Batu"
+		{
+			name: {
+				ja: "がんせきボンバー",
+				'zh-tw': "岩石衝撞",
+				th: "ระเบิดหิน",
+				id: "Bom Batu",
+			},
+			damage: 180,
+			cost: ["Fighting", "Colorless", "Colorless"],
+			effect: {
+				ja: "このワザのダメージは抵抗力を計算しない。",
+				'zh-tw': "這個招式的傷害不計算抵抗力。",
+				th: "แดเมจของท่าต่อสู้นี้จะไม่นำความต้านทานมาคิด",
+				id: "Kerusakan akibat serangan ini tidak terpengaruh oleh Resistansi.",
+			},
 		},
+	],
 
-		damage: 180,
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
 
-		effect: {
-			ja: "このワザのダメージは抵抗力を計算しない。",
-			'zh-tw': "這個招式的傷害不計算抵抗力。",
-			th: "แดเมจของท่าต่อสู้นี้จะไม่นำความต้านทานมาคิด",
-			id: "Kerusakan akibat serangan ini tidak terpengaruh oleh Resistansi."
-		}
-	}],
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 719518,
+			},
+		},
+	],
 
-	weaknesses: [{
-		type: "Grass",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "ゴローン",
+	},
 
 	retreat: 4,
 	regulationMark: "G",
+	rarity: "Double rare",
+	dexId: [76],
 
-	thirdParty: {
-		cardmarket: 719518
-	}
-}
+	suffix: "EX",
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV2a/077.ts
+++ b/data-asia/SV/SV2a/077.ts
@@ -1,20 +1,17 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV2a"
+import { Card } from "../../../interfaces";
+import Set from "../SV2a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "ポニータ",
 		'zh-tw': "小火馬",
 		th: "โพนีตะ",
-		id: "Ponyta"
+		id: "Ponyta",
 	},
 
 	illustrator: "Nurikabe",
-	rarity: "Common",
 	category: "Pokemon",
-	dexId: [77],
 	hp: 70,
 	types: ["Fire"],
 
@@ -22,51 +19,69 @@ const card: Card = {
 		ja: "ポニータに 認められると 燃える たてがみに 触っても 不思議と 熱くなくなるのだ。",
 		'zh-tw': "得到了小火馬認可的人，在觸摸牠燃燒著的鬃毛時 不會覺得燙手，真是不可思議。",
 		th: "หากได้รับการยอมรับจากโพนีตะแล้ว แม้จะจับแผงขนที่เผาไหม้ก็จะไม่รู้สึกร้อนอย่างน่าประหลาดใจ",
-		id: "Jika diakui oleh Ponyta, maka meskipun menyentuh surai membara Pokémon ini, entah kenapa surainya tidak terasa panas."
+		id: "Jika diakui oleh Ponyta, maka meskipun menyentuh surai membara Pokémon ini, entah kenapa surainya tidak terasa panas.",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		cost: ["Fire"],
-
-		name: {
-			ja: "もってくる",
-			'zh-tw': "呼喚",
-			th: "รวบรวม",
-			id: "Mengumpulkan"
+	attacks: [
+		{
+			name: {
+				ja: "もってくる",
+				'zh-tw': "呼喚",
+				th: "รวบรวม",
+				id: "Mengumpulkan",
+			},
+			cost: ["Fire"],
+			effect: {
+				ja: "自分の山札を1枚引く。",
+				'zh-tw': "從自己的牌庫抽出1張卡。",
+				th: "จั่วการ์ด 1 ใบจากสำรับการ์ดฝ่ายเรา",
+				id: "Ambil 1 kartu dari atas Deck sendiri.",
+			},
 		},
-
-		effect: {
-			ja: "自分の山札を1枚引く。",
-			'zh-tw': "從自己的牌庫抽出1張卡。",
-			th: "จั่วการ์ด 1 ใบจากสำรับการ์ดฝ่ายเรา",
-			id: "Ambil 1 kartu dari atas Deck sendiri."
-		}
-	}, {
-		cost: ["Fire", "Colorless", "Colorless"],
-
-		name: {
-			ja: "はねまわる",
-			'zh-tw': "活蹦亂跳",
-			th: "สะบัดตัว",
-			id: "Melompat Berkeliling"
+		{
+			name: {
+				ja: "はねまわる",
+				'zh-tw': "活蹦亂跳",
+				th: "สะบัดตัว",
+				id: "Melompat Berkeliling",
+			},
+			damage: 30,
+			cost: ["Fire", "Colorless", "Colorless"],
 		},
+	],
 
-		damage: 30
-	}],
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Water",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 719519,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				cardmarket: 837379,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				cardmarket: 837380,
+			},
+		},
+	],
 
 	retreat: 1,
 	regulationMark: "G",
+	rarity: "Common",
+	dexId: [77],
+};
 
-	thirdParty: {
-		cardmarket: 719519
-	}
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV2a/078.ts
+++ b/data-asia/SV/SV2a/078.ts
@@ -1,20 +1,17 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV2a"
+import { Card } from "../../../interfaces";
+import Set from "../SV2a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "ギャロップ",
 		'zh-tw': "烈焰馬",
 		th: "แกลล็อป",
-		id: "Rapidash"
+		id: "Rapidash",
 	},
 
 	illustrator: "Nurikabe",
-	rarity: "Uncommon",
 	category: "Pokemon",
-	dexId: [78],
 	hp: 100,
 	types: ["Fire"],
 
@@ -22,58 +19,79 @@ const card: Card = {
 		ja: "いちばん 脚が 速い ものが リーダー。 群れが 行く 場所や 走る 速度を 決めている。",
 		'zh-tw': "奔跑速度最快的烈焰馬會成為首領，決定族群 前往的地點和奔跑速度。",
 		th: "ตัวที่วิ่งเร็วที่สุดจะเป็นจ่าฝูง จ่าฝูงจะเป็นผู้กำหนดจุดหมายรวมถึงความเร็วในการวิ่งของฝูง",
-		id: "Rapidash yang kakinya paling cepat menjadi pemimpin di kelompoknya. Pemimpin menentukan tempat yang dituju dan kecepatan lari kelompok."
+		id: "Rapidash yang kakinya paling cepat menjadi pemimpin di kelompoknya. Pemimpin menentukan tempat yang dituju dan kecepatan lari kelompok.",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		cost: ["Fire"],
-
-		name: {
-			ja: "こがす",
-			'zh-tw': "灼熱",
-			th: "เผา",
-			id: "Menghanguskan"
+	attacks: [
+		{
+			name: {
+				ja: "こがす",
+				'zh-tw': "灼熱",
+				th: "เผา",
+				id: "Menghanguskan",
+			},
+			cost: ["Fire"],
+			effect: {
+				ja: "相手のバトルポケモンをやけどにする。",
+				'zh-tw': "將對手的戰鬥寶可夢【灼傷】。",
+				th: "ทำให้โปเกมอนบนตำแหน่งต่อสู้ฝ่ายตรงข้ามเป็นสภาวะ[ไหม้]",
+				id: "Ubah kondisi Pokémon Bertarung lawan menjadi Luka Bakar.",
+			},
 		},
-
-		effect: {
-			ja: "相手のバトルポケモンをやけどにする。",
-			'zh-tw': "將對手的戰鬥寶可夢【灼傷】。",
-			th: "ทำให้โปเกมอนบนตำแหน่งต่อสู้ฝ่ายตรงข้ามเป็นสภาวะ[ไหม้]",
-			id: "Ubah kondisi Pokémon Bertarung lawan menjadi Luka Bakar."
-		}
-	}, {
-		cost: ["Fire", "Colorless", "Colorless"],
-
-		name: {
-			ja: "マッハターン",
-			'zh-tw': "音速迴轉",
-			th: "มัคเทิร์น",
-			id: "Mach Turn"
+		{
+			name: {
+				ja: "マッハターン",
+				'zh-tw': "音速迴轉",
+				th: "มัคเทิร์น",
+				id: "Mach Turn",
+			},
+			damage: 90,
+			cost: ["Fire", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンをベンチポケモンと入れ替える。",
+				'zh-tw': "將這隻寶可夢與備戰寶可夢互換。",
+				th: "สลับโปเกมอนนี้กับโปเกมอนบนเบนช์",
+				id: "Tukar Pokémon ini dengan Pokémon Cadangan.",
+			},
 		},
+	],
 
-		damage: 90,
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
 
-		effect: {
-			ja: "このポケモンをベンチポケモンと入れ替える。",
-			'zh-tw': "將這隻寶可夢與備戰寶可夢互換。",
-			th: "สลับโปเกมอนนี้กับโปเกมอนบนเบนช์",
-			id: "Tukar Pokémon ini dengan Pokémon Cadangan."
-		}
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 719520,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				cardmarket: 837382,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				cardmarket: 837383,
+			},
+		},
+	],
 
-	weaknesses: [{
-		type: "Water",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "ポニータ",
+	},
 
 	retreat: 1,
 	regulationMark: "G",
+	rarity: "Uncommon",
+	dexId: [78],
+};
 
-	thirdParty: {
-		cardmarket: 719520
-	}
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV2a/079.ts
+++ b/data-asia/SV/SV2a/079.ts
@@ -1,20 +1,17 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV2a"
+import { Card } from "../../../interfaces";
+import Set from "../SV2a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "ヤドン",
 		'zh-tw': "呆呆獸",
 		th: "ยาดง",
-		id: "Slowpoke"
+		id: "Slowpoke",
 	},
 
 	illustrator: "OKACHEKE",
-	rarity: "Common",
 	category: "Pokemon",
-	dexId: [79],
 	hp: 80,
 	types: ["Psychic"],
 
@@ -22,56 +19,69 @@ const card: Card = {
 		ja: "動きが のろく 間抜け。 叩かれても ５秒 たってから 痛さを 感じるほどだ。",
 		'zh-tw': "動作遲鈍且呆頭呆腦。就算挨打也得花上５秒 才會感受到疼痛。",
 		th: "อืดอาดและซื่อบื้อ ถึงขั้นว่าถูกตีไป 5 วินาทีถึงเพิ่งรู้สึกเจ็บ",
-		id: "Slowpoke lamban dan lemot. Pokémon ini baru merasakan rasa sakit akibat dipukul setelah 5 detik berlalu."
+		id: "Slowpoke lamban dan lemot. Pokémon ini baru merasakan rasa sakit akibat dipukul setelah 5 detik berlalu.",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		cost: ["Psychic"],
-
-		name: {
-			ja: "かいすいよく",
-			'zh-tw': "海水浴",
-			th: "เล่นน้ำทะเล",
-			id: "Mandi Air Laut"
+	attacks: [
+		{
+			name: {
+				ja: "かいすいよく",
+				'zh-tw': "海水浴",
+				th: "เล่นน้ำทะเล",
+				id: "Mandi Air Laut",
+			},
+			cost: ["Psychic"],
+			effect: {
+				ja: "このポケモンのHPを「30」回復し、特殊状態もすべて回復する。",
+				'zh-tw': "將這隻寶可夢恢復「30」HP，特殊狀態也全部恢復。",
+				th: "ฟื้นฟู HP ของโปเกมอนนี้ [30] รักษาสภาวะผิดปกติทั้งหมดด้วย",
+				id: "Pulihkan HP Pokémon ini sejumlah 30, lalu pulihkan juga semua Kondisi Khusus yang dialami Pokémon ini.",
+			},
 		},
-
-		effect: {
-			ja: "このポケモンのHPを「30」回復し、特殊状態もすべて回復する。",
-			'zh-tw': "將這隻寶可夢恢復「30」HP，特殊狀態也全部恢復。",
-			th: "ฟื้นฟู HP ของโปเกมอนนี้ [30] รักษาสภาวะผิดปกติทั้งหมดด้วย",
-			id: "Pulihkan HP Pokémon ini sejumlah 30, lalu pulihkan juga semua Kondisi Khusus yang dialami Pokémon ini."
-		}
-	}, {
-		cost: ["Colorless", "Colorless"],
-
-		name: {
-			ja: "ずつき",
-			'zh-tw': "頭錘",
-			th: "พุ่งหัวชน",
-			id: "Tandukan Kepala"
+		{
+			name: {
+				ja: "ずつき",
+				'zh-tw': "頭錘",
+				th: "พุ่งหัวชน",
+				id: "Tandukan Kepala",
+			},
+			damage: 20,
+			cost: ["Colorless", "Colorless"],
 		},
+	],
 
-		damage: 20
-	}],
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
 
-	weaknesses: [{
-		type: "Darkness",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Fighting",
-		value: "-30"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 719521,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				cardmarket: 837386,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				cardmarket: 837387,
+			},
+		},
+	],
 
 	retreat: 2,
 	regulationMark: "G",
+	rarity: "Common",
+	dexId: [79],
+};
 
-	thirdParty: {
-		cardmarket: 719521
-	}
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV2a/080.ts
+++ b/data-asia/SV/SV2a/080.ts
@@ -1,20 +1,17 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV2a"
+import { Card } from "../../../interfaces";
+import Set from "../SV2a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "ヤドラン",
 		'zh-tw': "呆殼獸",
 		th: "ยาโดรัน",
-		id: "Slowbro"
+		id: "Slowbro",
 	},
 
 	illustrator: "OKACHEKE",
-	rarity: "Uncommon",
 	category: "Pokemon",
-	dexId: [80],
 	hp: 130,
 	types: ["Psychic"],
 
@@ -22,63 +19,79 @@ const card: Card = {
 		ja: "ヤドンが 海へ エサを 取りにいったとき シェルダーに 尻尾を かまれ ヤドランになった。",
 		'zh-tw': "呆呆獸去海裡捕食時，被大舌貝咬住了尾巴， 於是就變成了呆殼獸。",
 		th: "ยาดงโดนเชลเดอร์งับหางตอนออกไปหาอาหารแถวทะเลจนกลายเป็นยาโดรัน",
-		id: "Ketika Slowpoke sedang mencari makan di laut, ekornya digigit oleh Shellder, lalu ia berevolusi menjadi Slowbro."
+		id: "Ketika Slowpoke sedang mencari makan di laut, ekornya digigit oleh Shellder, lalu ia berevolusi menjadi Slowbro.",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		cost: ["Psychic"],
-
-		name: {
-			ja: "おおあくび",
-			'zh-tw': "大哈欠",
-			th: "หาวปากกว้าง",
-			id: "Menguap Lebar"
+	attacks: [
+		{
+			name: {
+				ja: "おおあくび",
+				'zh-tw': "大哈欠",
+				th: "หาวปากกว้าง",
+				id: "Menguap Lebar",
+			},
+			cost: ["Psychic"],
+			effect: {
+				ja: "おたがいのバトルポケモンを、それぞれねむりにする。",
+				'zh-tw': "將雙方的戰鬥寶可夢【睡眠】。",
+				th: "ทำให้โปเกมอนบนตำแหน่งต่อสู้ของทั้งสองฝ่าย แต่ละตัวเป็นสภาวะ[หลับ]",
+				id: "Ubah kondisi Pokémon Bertarung kedua pemain masing-masing menjadi Tidur.",
+			},
 		},
-
-		effect: {
-			ja: "おたがいのバトルポケモンを、それぞれねむりにする。",
-			'zh-tw': "將雙方的戰鬥寶可夢【睡眠】。",
-			th: "ทำให้โปเกมอนบนตำแหน่งต่อสู้ของทั้งสองฝ่าย แต่ละตัวเป็นสภาวะ[หลับ]",
-			id: "Ubah kondisi Pokémon Bertarung kedua pemain masing-masing menjadi Tidur."
-		}
-	}, {
-		cost: ["Psychic", "Colorless", "Colorless"],
-
-		name: {
-			ja: "のんびりタックル",
-			'zh-tw': "悠哉衝撞",
-			th: "กระแทกเรื่อยเฉื่อย",
-			id: "Serudukan Perlahan"
+		{
+			name: {
+				ja: "のんびりタックル",
+				'zh-tw': "悠哉衝撞",
+				th: "กระแทกเรื่อยเฉื่อย",
+				id: "Serudukan Perlahan",
+			},
+			damage: 160,
+			cost: ["Psychic", "Colorless", "Colorless"],
+			effect: {
+				ja: "この番、このポケモンに進化していたなら、このワザは失敗。",
+				'zh-tw': "在這個回合，若進化成這隻寶可夢，則這個招式失敗。",
+				th: "เทิร์นนี้ ถ้าวิวัฒนาการเป็นโปเกมอนนี้แล้ว ท่าต่อสู้นี้จะล้มเหลว",
+				id: "Jika pada giliran ini, Pokémon berevolusi menjadi Pokémon ini, serangan ini gagal.",
+			},
 		},
+	],
 
-		damage: 160,
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
 
-		effect: {
-			ja: "この番、このポケモンに進化していたなら、このワザは失敗。",
-			'zh-tw': "在這個回合，若進化成這隻寶可夢，則這個招式失敗。",
-			th: "เทิร์นนี้ ถ้าวิวัฒนาการเป็นโปเกมอนนี้แล้ว ท่าต่อสู้นี้จะล้มเหลว",
-			id: "Jika pada giliran ini, Pokémon berevolusi menjadi Pokémon ini, serangan ini gagal."
-		}
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 719522,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				cardmarket: 837388,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				cardmarket: 837389,
+			},
+		},
+	],
 
-	weaknesses: [{
-		type: "Darkness",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Fighting",
-		value: "-30"
-	}],
+	evolveFrom: {
+		ja: "ヤドン",
+	},
 
 	retreat: 2,
 	regulationMark: "G",
+	rarity: "Uncommon",
+	dexId: [80],
+};
 
-	thirdParty: {
-		cardmarket: 719522
-	}
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV2a/081.ts
+++ b/data-asia/SV/SV2a/081.ts
@@ -1,20 +1,17 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV2a"
+import { Card } from "../../../interfaces";
+import Set from "../SV2a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "コイル",
 		'zh-tw': "小磁怪",
 		th: "คอยล์",
-		id: "Magnemite"
+		id: "Magnemite",
 	},
 
 	illustrator: "Yuka Morii",
-	rarity: "Common",
 	category: "Pokemon",
-	dexId: [81],
 	hp: 60,
 	types: ["Lightning"],
 
@@ -22,53 +19,70 @@ const card: Card = {
 		ja: "左右にある ユニットから だす 電磁波で 重力を さえぎって 空に 浮かぶのだ。",
 		'zh-tw': "從左右兩邊的組件發出的電磁波能阻礙重力， 使牠浮在空中。",
 		th: "ลอยบนท้องฟ้าโดยไม่สนใจแรงโน้มถ่วงได้ด้วยคลื่นแม่เหล็กไฟฟ้าที่ปล่อยออกมาจากชิ้นส่วนซ้ายขวาของตน",
-		id: "Dengan gelombang elektromagnetik yang dikeluarkan dari unit yang ada di sisi kiri dan kanannya, Magnemite melawan arus gravitasi dan melayang di udara."
+		id: "Dengan gelombang elektromagnetik yang dikeluarkan dari unit yang ada di sisi kiri dan kanannya, Magnemite melawan arus gravitasi dan melayang di udara.",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		cost: ["Lightning"],
-
-		name: {
-			ja: "プチでんき",
-			'zh-tw': "小電氣",
-			th: "กระแสไฟน้อยนิด",
-			id: "Listrik Mini"
+	attacks: [
+		{
+			name: {
+				ja: "プチでんき",
+				'zh-tw': "小電氣",
+				th: "กระแสไฟน้อยนิด",
+				id: "Listrik Mini",
+			},
+			damage: 10,
+			cost: ["Lightning"],
 		},
-
-		damage: 10
-	}, {
-		cost: ["Lightning", "Colorless"],
-
-		name: {
-			ja: "ばくはつ",
-			'zh-tw': "爆炸",
-			th: "ระเบิด",
-			id: "Ledakan"
+		{
+			name: {
+				ja: "ばくはつ",
+				'zh-tw': "爆炸",
+				th: "ระเบิด",
+				id: "Ledakan",
+			},
+			damage: 60,
+			cost: ["Lightning", "Colorless"],
+			effect: {
+				ja: "このポケモンにも60ダメージ。",
+				'zh-tw': "這隻寶可夢也受到60點傷害。",
+				th: "โปเกมอนนี้ก็จะได้รับแดเมจ 60 ด้วย",
+				id: "Pokémon ini juga menerima kerusakan sejumlah 60.",
+			},
 		},
+	],
 
-		damage: 60,
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
 
-		effect: {
-			ja: "このポケモンにも60ダメージ。",
-			'zh-tw': "這隻寶可夢也受到60點傷害。",
-			th: "โปเกมอนนี้ก็จะได้รับแดเมจ 60 ด้วย",
-			id: "Pokémon ini juga menerima kerusakan sejumlah 60."
-		}
-	}],
-
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 719523,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				cardmarket: 837390,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				cardmarket: 837391,
+			},
+		},
+	],
 
 	retreat: 1,
 	regulationMark: "G",
+	rarity: "Common",
+	dexId: [81],
+};
 
-	thirdParty: {
-		cardmarket: 719523
-	}
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV2a/082.ts
+++ b/data-asia/SV/SV2a/082.ts
@@ -1,20 +1,17 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV2a"
+import { Card } from "../../../interfaces";
+import Set from "../SV2a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "レアコイル",
 		'zh-tw': "三合一磁怪",
 		th: "แรคอยล์",
-		id: "Magneton"
+		id: "Magneton",
 	},
 
 	illustrator: "Yuka Morii",
-	rarity: "Uncommon",
 	category: "Pokemon",
-	dexId: [82],
 	hp: 90,
 	types: ["Lightning"],
 
@@ -22,51 +19,73 @@ const card: Card = {
 		ja: "３つのコイルは 強い 磁力で 結びついている。 そばに寄ると 強い 耳鳴りに 襲われる。",
 		'zh-tw': "３隻小磁怪因著強烈的磁力而結合。只要靠近牠 就會發生強烈的耳鳴。",
 		th: "คอยล์ 3 ตัวเชื่อมต่อกันด้วยพลังงานแม่เหล็กแรงสูง หากเข้าไปใกล้จะเกิดอาการหูอื้อขั้นรุนแรง",
-		id: "Tiga Magnemite yang terhubung oleh kekuatan magnet yang kuat. Telingamu akan sakit oleh dengungan kuat jika mendekati Magneton."
+		id: "Tiga Magnemite yang terhubung oleh kekuatan magnet yang kuat. Telingamu akan sakit oleh dengungan kuat jika mendekati Magneton.",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		cost: ["Lightning"],
-
-		name: {
-			ja: "ジャンクマグネット",
-			'zh-tw': "廢品磁鐵",
-			th: "จังก์แมกเน็ท",
-			id: "Junk Magnet"
+	attacks: [
+		{
+			name: {
+				ja: "ジャンクマグネット",
+				'zh-tw': "廢品磁鐵",
+				th: "จังก์แมกเน็ท",
+				id: "Junk Magnet",
+			},
+			cost: ["Lightning"],
+			effect: {
+				ja: "自分のトラッシュからグッズを2枚まで選び、相手に見せて、手札に加える。",
+				'zh-tw': "從自己的棄牌區選擇最多2張物品卡，在給對手看過後加入手牌。",
+				th: "เลือกการ์ดไอเท็มได้สูงสุด 2 ใบจากตำแหน่งทิ้งการ์ดฝ่ายเรา ให้ฝ่ายตรงข้ามดู นำขึ้นมือ",
+				id: "Pilih paling banyak 2 lembar Item dari Trash sendiri, perlihatkan ke lawan, lalu tambahkan ke Kartu Pegangan.",
+			},
 		},
-
-		effect: {
-			ja: "自分のトラッシュからグッズを2枚まで選び、相手に見せて、手札に加える。",
-			'zh-tw': "從自己的棄牌區選擇最多2張物品卡，在給對手看過後加入手牌。",
-			th: "เลือกการ์ดไอเท็มได้สูงสุด 2 ใบจากตำแหน่งทิ้งการ์ดฝ่ายเรา ให้ฝ่ายตรงข้ามดู นำขึ้นมือ",
-			id: "Pilih paling banyak 2 lembar Item dari Trash sendiri, perlihatkan ke lawan, lalu tambahkan ke Kartu Pegangan."
-		}
-	}, {
-		cost: ["Lightning", "Colorless", "Colorless"],
-
-		name: {
-			ja: "ヘッドボルト",
-			'zh-tw': "伏特頭擊",
-			th: "เฮดโบลท์",
-			id: "Head Bolt"
+		{
+			name: {
+				ja: "ヘッドボルト",
+				'zh-tw': "伏特頭擊",
+				th: "เฮดโบลท์",
+				id: "Head Bolt",
+			},
+			damage: 60,
+			cost: ["Lightning", "Colorless", "Colorless"],
 		},
+	],
 
-		damage: 60
-	}],
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 719524,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				cardmarket: 837392,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				cardmarket: 837393,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "コイル",
+	},
 
 	retreat: 2,
 	regulationMark: "G",
+	rarity: "Uncommon",
+	dexId: [82],
+};
 
-	thirdParty: {
-		cardmarket: 719524
-	}
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV2a/083.ts
+++ b/data-asia/SV/SV2a/083.ts
@@ -1,20 +1,17 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV2a"
+import { Card } from "../../../interfaces";
+import Set from "../SV2a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "カモネギ",
 		'zh-tw': "大蔥鴨",
 		th: "คาโมเนกิ",
-		id: "Farfetch'd"
+		id: "Farfetch'd",
 	},
 
 	illustrator: "KG-2000",
-	rarity: "Common",
 	category: "Pokemon",
-	dexId: [83],
 	hp: 90,
 	types: ["Colorless"],
 
@@ -22,56 +19,69 @@ const card: Card = {
 		ja: "植物の 茎で 戦う。 茎の 振り方には いくつかの 流派の ようなものが ある。",
 		'zh-tw': "用植物的莖來戰鬥。莖的揮舞方式存在著 好幾種不同的流派。",
 		th: "ใช้ลำต้นของพืชในการต่อสู้ มีสไตล์การฟาดฟันด้วยลำต้นที่เหมือนกับวิชาต่อสู้หลายรูปแบบ",
-		id: "Farfetch'd bertarung menggunakan batang tumbuhan. Terdapat beberapa aliran terkait cara mengayunkan batang."
+		id: "Farfetch'd bertarung menggunakan batang tumbuhan. Terdapat beberapa aliran terkait cara mengayunkan batang.",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		cost: ["Colorless"],
-
-		name: {
-			ja: "しょってくる",
-			'zh-tw': "背來",
-			th: "แบกขึ้นหลัง",
-			id: "Memanggul"
+	attacks: [
+		{
+			name: {
+				ja: "しょってくる",
+				'zh-tw': "背來",
+				th: "แบกขึ้นหลัง",
+				id: "Memanggul",
+			},
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札を2枚引く。",
+				'zh-tw': "從自己的牌庫抽出2張卡。",
+				th: "จั่วการ์ด 2 ใบจากสำรับการ์ดฝ่ายเรา",
+				id: "Ambil 2 kartu dari atas Deck sendiri.",
+			},
 		},
-
-		effect: {
-			ja: "自分の山札を2枚引く。",
-			'zh-tw': "從自己的牌庫抽出2張卡。",
-			th: "จั่วการ์ด 2 ใบจากสำรับการ์ดฝ่ายเรา",
-			id: "Ambil 2 kartu dari atas Deck sendiri."
-		}
-	}, {
-		cost: ["Colorless"],
-
-		name: {
-			ja: "ネギでぶつ",
-			'zh-tw': "用蔥毆打",
-			th: "หวดด้วยต้นหอม",
-			id: "Daun Bawang Penghajar"
+		{
+			name: {
+				ja: "ネギでぶつ",
+				'zh-tw': "用蔥毆打",
+				th: "หวดด้วยต้นหอม",
+				id: "Daun Bawang Penghajar",
+			},
+			damage: 30,
+			cost: ["Colorless"],
 		},
+	],
 
-		damage: 30
-	}],
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
 
-	weaknesses: [{
-		type: "Lightning",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Fighting",
-		value: "-30"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 719525,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				cardmarket: 837394,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				cardmarket: 837395,
+			},
+		},
+	],
 
 	retreat: 1,
 	regulationMark: "G",
+	rarity: "Common",
+	dexId: [83],
+};
 
-	thirdParty: {
-		cardmarket: 719525
-	}
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV2a/084.ts
+++ b/data-asia/SV/SV2a/084.ts
@@ -1,20 +1,17 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV2a"
+import { Card } from "../../../interfaces";
+import Set from "../SV2a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "ドードー",
 		'zh-tw': "嘟嘟",
 		th: "โดโด",
-		id: "Doduo"
+		id: "Doduo",
 	},
 
 	illustrator: "Anesaki Dynamic",
-	rarity: "Common",
 	category: "Pokemon",
-	dexId: [84],
 	hp: 70,
 	types: ["Colorless"],
 
@@ -22,47 +19,60 @@ const card: Card = {
 		ja: "２つの 頭の 脳みそは テレパシーのような 力で 気持ちを 通じ合わせているらしい。",
 		'zh-tw': "２個腦袋好像會用 類似心靈感應的力量， 來傳遞彼此的想法。",
 		th: "ดูเหมือนว่าสมองในหัวทั้งสองนั้นจะสื่อความรู้สึกถึงกันได้ด้วยพลังคล้ายโทรจิต",
-		id: "Kabarnya otak pada 2 kepala Doduo saling menyalurkan perasaan dengan kekuatan yang seperti telepati."
+		id: "Kabarnya otak pada 2 kepala Doduo saling menyalurkan perasaan dengan kekuatan yang seperti telepati.",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		cost: ["Colorless"],
-
-		name: {
-			ja: "とつげき",
-			'zh-tw': "突擊",
-			th: "ประจัญบาน",
-			id: "Menyerang"
+	attacks: [
+		{
+			name: {
+				ja: "とつげき",
+				'zh-tw': "突擊",
+				th: "ประจัญบาน",
+				id: "Menyerang",
+			},
+			damage: 30,
+			cost: ["Colorless"],
+			effect: {
+				ja: "このポケモンにも10ダメージ。",
+				'zh-tw': "這隻寶可夢也受到10點傷害。",
+				th: "โปเกมอนนี้ก็จะได้รับแดเมจ 10 ด้วย",
+				id: "Pokémon ini juga menerima kerusakan sejumlah 10.",
+			},
 		},
+	],
 
-		damage: 30,
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
 
-		effect: {
-			ja: "このポケモンにも10ダメージ。",
-			'zh-tw': "這隻寶可夢也受到10點傷害。",
-			th: "โปเกมอนนี้ก็จะได้รับแดเมจ 10 ด้วย",
-			id: "Pokémon ini juga menerima kerusakan sejumlah 10."
-		}
-	}],
-
-	weaknesses: [{
-		type: "Lightning",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Fighting",
-		value: "-30"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 719526,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				cardmarket: 837396,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				cardmarket: 837397,
+			},
+		},
+	],
 
 	retreat: 1,
 	regulationMark: "G",
+	rarity: "Common",
+	dexId: [84],
+};
 
-	thirdParty: {
-		cardmarket: 719526
-	}
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV2a/085.ts
+++ b/data-asia/SV/SV2a/085.ts
@@ -1,20 +1,17 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV2a"
+import { Card } from "../../../interfaces";
+import Set from "../SV2a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "ドードリオ",
 		'zh-tw': "嘟嘟利",
 		th: "โดโดริโอ",
-		id: "Dodrio"
+		id: "Dodrio",
 	},
 
 	illustrator: "Anesaki Dynamic",
-	rarity: "Rare",
 	category: "Pokemon",
-	dexId: [85],
 	hp: 100,
 	types: ["Colorless"],
 
@@ -22,65 +19,82 @@ const card: Card = {
 		ja: "めったに 見つからない 珍種。 ３つの 頭は 喜び 悲しみ 怒りの 感情を 表す。",
 		'zh-tw': "極為少見的珍稀物種。 ３顆頭會各自表現出 愉快、悲傷和憤怒的情緒。",
 		th: "เป็นสายพันธุ์หายากที่แทบจะไม่พบเห็น หัวทั้งสามแสดงความรู้สึกยินดี เศร้าโศก และโมโห",
-		id: "Dodrio adalah spesies Pokémon langka yang jarang ditemukan. Tiga kepalanya menunjukkan emosi berupa perasaan senang, sedih, dan marah."
+		id: "Dodrio adalah spesies Pokémon langka yang jarang ditemukan. Tiga kepalanya menunjukkan emosi berupa perasaan senang, sedih, dan marah.",
 	},
 
 	stage: "Stage1",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			ja: "ばくそうドロー",
-			'zh-tw': "爆走抽出",
-			th: "จั่วเต็มเหยียด",
-			id: "Ambil Kebut-kebutan"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "ばくそうドロー",
+				'zh-tw': "爆走抽出",
+				th: "จั่วเต็มเหยียด",
+				id: "Ambil Kebut-kebutan",
+			},
+			effect: {
+				ja: "自分の番に1回使える。このポケモンにダメカンを1個のせる。その後、自分の山札を1枚引く。",
+				'zh-tw': "在自己的回合時可使用1次。在這隻寶可夢身上放置1個傷害指示物。然後，從自己的牌庫抽出1張卡。",
+				th: "ใช้ได้ 1 ครั้งในเทิร์นฝ่ายเรา วางตัวนับแดเมจ 1 ตัวบนโปเกมอนนี้ หลังจากนั้น จั่วการ์ด 1 ใบจากสำรับการ์ดฝ่ายเรา",
+				id: "Dapat digunakan 1 kali pada giliran sendiri. Letakkan 1 Token Kerusakan pada Pokémon ini. Setelah itu, ambil 1 kartu dari atas Deck sendiri.",
+			},
 		},
+	],
 
-		effect: {
-			ja: "自分の番に1回使える。このポケモンにダメカンを1個のせる。その後、自分の山札を1枚引く。",
-			'zh-tw': "在自己的回合時可使用1次。在這隻寶可夢身上放置1個傷害指示物。然後，從自己的牌庫抽出1張卡。",
-			th: "ใช้ได้ 1 ครั้งในเทิร์นฝ่ายเรา วางตัวนับแดเมจ 1 ตัวบนโปเกมอนนี้ หลังจากนั้น จั่วการ์ด 1 ใบจากสำรับการ์ดฝ่ายเรา",
-			id: "Dapat digunakan 1 kali pada giliran sendiri. Letakkan 1 Token Kerusakan pada Pokémon ini. Setelah itu, ambil 1 kartu dari atas Deck sendiri."
-		}
-	}],
-
-	attacks: [{
-		cost: ["Colorless"],
-
-		name: {
-			ja: "いかりのくちばし",
-			'zh-tw': "憤怒鳥嘴",
-			th: "จะงอยปากพิโรธ",
-			id: "Paruh Kemarahan"
+	attacks: [
+		{
+			name: {
+				ja: "いかりのくちばし",
+				'zh-tw': "憤怒鳥嘴",
+				th: "จะงอยปากพิโรธ",
+				id: "Paruh Kemarahan",
+			},
+			damage: "10+",
+			cost: ["Colorless"],
+			effect: {
+				ja: "このポケモンにのっているダメカンの数×30ダメージ追加。",
+				'zh-tw': "增加這隻寶可夢身上放置的傷害指示物的數量×30點傷害。",
+				th: "แดเมจจะเพิ่มตามจำนวนตัวนับแดเมจที่วางอยู่บนโปเกมอนนี้ x30",
+				id: "Kerusakan yang diberikan bertambah sejumlah 30 untuk tiap Token Kerusakan yang dimiliki Pokémon ini.",
+			},
 		},
+	],
 
-		damage: "10+",
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
 
-		effect: {
-			ja: "このポケモンにのっているダメカンの数×30ダメージ追加。",
-			'zh-tw': "增加這隻寶可夢身上放置的傷害指示物的數量×30點傷害。",
-			th: "แดเมจจะเพิ่มตามจำนวนตัวนับแดเมจที่วางอยู่บนโปเกมอนนี้ x30",
-			id: "Kerusakan yang diberikan bertambah sejumlah 30 untuk tiap Token Kerusakan yang dimiliki Pokémon ini."
-		}
-	}],
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 719527,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				cardmarket: 837398,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				cardmarket: 837399,
+			},
+		},
+	],
 
-	weaknesses: [{
-		type: "Lightning",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Fighting",
-		value: "-30"
-	}],
+	evolveFrom: {
+		ja: "ドードー",
+	},
 
 	retreat: 1,
 	regulationMark: "G",
+	rarity: "Rare",
+	dexId: [85],
+};
 
-	thirdParty: {
-		cardmarket: 719527
-	}
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV2a/086.ts
+++ b/data-asia/SV/SV2a/086.ts
@@ -1,20 +1,17 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV2a"
+import { Card } from "../../../interfaces";
+import Set from "../SV2a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "パウワウ",
 		'zh-tw': "小海獅",
 		th: "เพาเวา",
-		id: "Seel"
+		id: "Seel",
 	},
 
 	illustrator: "aoki",
-	rarity: "Common",
 	category: "Pokemon",
-	dexId: [86],
 	hp: 80,
 	types: ["Water"],
 
@@ -22,35 +19,54 @@ const card: Card = {
 		ja: "分厚い 脂肪の おかげで 寒い 海も へっちゃらだけど 暖かい 海では ちょっと バテやすいのだ。",
 		'zh-tw': "因為有著厚厚的脂肪， 所以完全不怕寒冷的海域， 但在溫暖的海裡就有點容易中暑。",
 		th: "ด้วยไขมันที่หนา ทำให้อยู่ในทะเลที่หนาวเย็นได้อย่างสบาย แต่ถ้าเป็นทะเลที่อบอุ่นแล้วก็จะรู้สึกเพลียง่ายหน่อย",
-		id: "Berkat lemaknya yang tebal, laut yang dingin tidak masalah bagi Seel, tapi Pokémon ini mudah lelah di laut hangat."
+		id: "Berkat lemaknya yang tebal, laut yang dingin tidak masalah bagi Seel, tapi Pokémon ini mudah lelah di laut hangat.",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		cost: ["Water"],
-
-		name: {
-			ja: "ひんやり",
-			'zh-tw': "寒意",
-			th: "เย็นยะเยือก",
-			id: "Sejuk"
+	attacks: [
+		{
+			name: {
+				ja: "ひんやり",
+				'zh-tw': "寒意",
+				th: "เย็นยะเยือก",
+				id: "Sejuk",
+			},
+			damage: 20,
+			cost: ["Water"],
 		},
+	],
 
-		damage: 20
-	}],
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Lightning",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 719528,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				cardmarket: 837400,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				cardmarket: 837401,
+			},
+		},
+	],
 
 	retreat: 2,
 	regulationMark: "G",
+	rarity: "Common",
+	dexId: [86],
+};
 
-	thirdParty: {
-		cardmarket: 719528
-	}
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV2a/087.ts
+++ b/data-asia/SV/SV2a/087.ts
@@ -1,20 +1,17 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV2a"
+import { Card } from "../../../interfaces";
+import Set from "../SV2a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "ジュゴン",
 		'zh-tw': "白海獅",
 		th: "จูกอน",
-		id: "Dewgong"
+		id: "Dewgong",
 	},
 
 	illustrator: "aoki",
-	rarity: "Uncommon",
 	category: "Pokemon",
-	dexId: [87],
 	hp: 130,
 	types: ["Water"],
 
@@ -22,51 +19,73 @@ const card: Card = {
 		ja: "食事の 後は 砂浜で 日光浴を している。 体温を あげて 消化を よく するのだ。",
 		'zh-tw': "進食之後會在沙灘上 做日光浴，藉此提高體溫 來幫助消化。",
 		th: "หลังกินอาหาร ก็จะไปนอนอาบแดดที่หาดทราย เพื่อเพิ่มอุณหภูมิร่างกายให้ย่อยอาหารได้ดีขึ้น",
-		id: "Dewgong mandi sinar matahari di pantai setelah selesai makan. Peningkatan suhu tubuhnya membantu proses pencernaan."
+		id: "Dewgong mandi sinar matahari di pantai setelah selesai makan. Peningkatan suhu tubuhnya membantu proses pencernaan.",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		cost: ["Water", "Colorless"],
-
-		name: {
-			ja: "デュアルスプラッシュ",
-			'zh-tw': "二重飛濺",
-			th: "ดูอัลสแปลช",
-			id: "Dual Splash"
+	attacks: [
+		{
+			name: {
+				ja: "デュアルスプラッシュ",
+				'zh-tw': "二重飛濺",
+				th: "ดูอัลสแปลช",
+				id: "Dual Splash",
+			},
+			cost: ["Water", "Colorless"],
+			effect: {
+				ja: "相手のポケモン2匹に、それぞれ50ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+				'zh-tw': "對手的2隻寶可夢各受到50點傷害。[在備戰區不計算弱點・抵抗力。]",
+				th: "โปเกมอนฝ่ายตรงข้าม 2 ตัว จะได้รับแดเมจตัวละ 50 {โปเกมอนบนเบนช์จะไม่นำจุดอ่อนและความต้านทานมาคิด}",
+				id: "Serangan ini memberikan kerusakan masing-masing sejumlah 50 kepada 2 Pokémon lawan. [Kelemahan dan Resistansi Pokémon Cadangan tidak mempengaruhi jumlah kerusakan.]",
+			},
 		},
-
-		effect: {
-			ja: "相手のポケモン2匹に、それぞれ50ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
-			'zh-tw': "對手的2隻寶可夢各受到50點傷害。[在備戰區不計算弱點・抵抗力。]",
-			th: "โปเกมอนฝ่ายตรงข้าม 2 ตัว จะได้รับแดเมจตัวละ 50 {โปเกมอนบนเบนช์จะไม่นำจุดอ่อนและความต้านทานมาคิด}",
-			id: "Serangan ini memberikan kerusakan masing-masing sejumlah 50 kepada 2 Pokémon lawan. [Kelemahan dan Resistansi Pokémon Cadangan tidak mempengaruhi jumlah kerusakan.]"
-		}
-	}, {
-		cost: ["Water", "Colorless", "Colorless"],
-
-		name: {
-			ja: "オーロラビーム",
-			'zh-tw': "極光束",
-			th: "ออโรร่าบีม",
-			id: "Aurora Beam"
+		{
+			name: {
+				ja: "オーロラビーム",
+				'zh-tw': "極光束",
+				th: "ออโรร่าบีม",
+				id: "Aurora Beam",
+			},
+			damage: 100,
+			cost: ["Water", "Colorless", "Colorless"],
 		},
+	],
 
-		damage: 100
-	}],
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Lightning",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 719529,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				cardmarket: 837402,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				cardmarket: 837403,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "パウワウ",
+	},
 
 	retreat: 2,
 	regulationMark: "G",
+	rarity: "Uncommon",
+	dexId: [87],
+};
 
-	thirdParty: {
-		cardmarket: 719529
-	}
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV2a/088.ts
+++ b/data-asia/SV/SV2a/088.ts
@@ -1,20 +1,17 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV2a"
+import { Card } from "../../../interfaces";
+import Set from "../SV2a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "ベトベター",
 		'zh-tw': "臭泥",
 		th: "เบโตเบตา",
-		id: "Grimer"
+		id: "Grimer",
 	},
 
 	illustrator: "Nisota Niso",
-	rarity: "Common",
 	category: "Pokemon",
-	dexId: [88],
 	hp: 80,
 	types: ["Darkness"],
 
@@ -22,42 +19,60 @@ const card: Card = {
 		ja: "ヘドロが ポケモンになった。 汚い 場所に 集まって 体の ばい菌を 増やしていく。",
 		'zh-tw': "污泥變成的寶可夢。會聚集在骯髒的地方 來繁殖身體的細菌。",
 		th: "โคลนสกปรกกลายเป็นโปเกมอน รวมตัวกันในที่สกปรกเพื่อเพิ่มจำนวนเชื้อโรคในร่างกาย",
-		id: "Limbah yang berubah menjadi Pokémon. Grimer berkumpul di tempat-tempat kotor dan menambahkan bakteri ke tubuhnya."
+		id: "Limbah yang berubah menjadi Pokémon. Grimer berkumpul di tempat-tempat kotor dan menambahkan bakteri ke tubuhnya.",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		cost: ["Darkness"],
-
-		name: {
-			ja: "べっとりプレス",
-			'zh-tw': "緊貼壓制",
-			th: "อัดเหนียวหนืด",
-			id: "Tekanan Lengket"
+	attacks: [
+		{
+			name: {
+				ja: "べっとりプレス",
+				'zh-tw': "緊貼壓制",
+				th: "อัดเหนียวหนืด",
+				id: "Tekanan Lengket",
+			},
+			damage: 10,
+			cost: ["Darkness"],
+			effect: {
+				ja: "次の相手の番、このワザを受けたポケモンは、にげるためのエネルギーが、1個ぶん多くなる。",
+				'zh-tw': "在下個對手的回合，受到這個招式的寶可夢【撤退】所需的能量增加1個。",
+				th: "เทิร์นถัดไปของฝ่ายตรงข้าม โปเกมอนที่ได้รับท่าต่อสู้นี้ พลังงานสำหรับ[หนี] จะเพิ่มขึ้น 1 ลูก",
+				id: "Pada giliran lawan berikutnya, Energi yang dibutuhkan oleh Pokémon yang menerima serangan ini untuk Mundur bertambah 1 Energi.",
+			},
 		},
+	],
 
-		damage: 10,
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
 
-		effect: {
-			ja: "次の相手の番、このワザを受けたポケモンは、にげるためのエネルギーが、1個ぶん多くなる。",
-			'zh-tw': "在下個對手的回合，受到這個招式的寶可夢【撤退】所需的能量增加1個。",
-			th: "เทิร์นถัดไปของฝ่ายตรงข้าม โปเกมอนที่ได้รับท่าต่อสู้นี้ พลังงานสำหรับ[หนี] จะเพิ่มขึ้น 1 ลูก",
-			id: "Pada giliran lawan berikutnya, Energi yang dibutuhkan oleh Pokémon yang menerima serangan ini untuk Mundur bertambah 1 Energi."
-		}
-	}],
-
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 719530,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				cardmarket: 837404,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				cardmarket: 837405,
+			},
+		},
+	],
 
 	retreat: 2,
 	regulationMark: "G",
+	rarity: "Common",
+	dexId: [88],
+};
 
-	thirdParty: {
-		cardmarket: 719530
-	}
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV2a/089.ts
+++ b/data-asia/SV/SV2a/089.ts
@@ -1,20 +1,17 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV2a"
+import { Card } from "../../../interfaces";
+import Set from "../SV2a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "ベトベトン",
 		'zh-tw': "臭臭泥",
 		th: "เบโตเบตัน",
-		id: "Muk"
+		id: "Muk",
 	},
 
 	illustrator: "Nisota Niso",
-	rarity: "Uncommon",
 	category: "Pokemon",
-	dexId: [89],
 	hp: 150,
 	types: ["Darkness"],
 
@@ -22,53 +19,74 @@ const card: Card = {
 		ja: "汚い ヘドロが 全身に まとわりつく。 足跡に 触っただけで 毒に 侵される。",
 		'zh-tw': "全身上下沾滿污泥。光是碰到牠的足跡， 都會受到毒素的侵襲。",
 		th: "โคลนสกปรกติดทั่วตัว แค่ไปโดนร่องรอยที่มันขยับตัวผ่านก็ติดพิษแล้ว",
-		id: "Limbah kotor menyelimuti tubuh Muk. Siapa pun akan keracunan walau hanya menyentuh jejak kakinya."
+		id: "Limbah kotor menyelimuti tubuh Muk. Siapa pun akan keracunan walau hanya menyentuh jejak kakinya.",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		cost: ["Darkness"],
-
-		name: {
-			ja: "ベトベトジェイル",
-			'zh-tw': "臭臭獄",
-			th: "จองจำเหนียวเหนอะ",
-			id: "Kerangkeng Lengket Melekat"
+	attacks: [
+		{
+			name: {
+				ja: "ベトベトジェイル",
+				'zh-tw': "臭臭獄",
+				th: "จองจำเหนียวเหนอะ",
+				id: "Kerangkeng Lengket Melekat",
+			},
+			damage: 30,
+			cost: ["Darkness"],
+			effect: {
+				ja: "次の相手の番、このワザを受けたポケモンは、ワザを使うためのエネルギーとにげるためのエネルギーが、それぞれ[C]エネルギー1個ぶん多くなる。",
+				'zh-tw': "在下個對手的回合，受到這個招式的寶可夢使用招式所需的能量與【撤退】所需的能量，各增加1個【無】能量。",
+				th: "เทิร์นถัดไปของฝ่ายตรงข้าม โปเกมอนที่ได้รับท่าต่อสู้นี้ พลังงานสำหรับใช้ท่าต่อสู้กับพลังงานสำหรับ[หนี] แต่ละอย่างจะใช้พลังงาน[ไร้สี]เพิ่มขึ้น 1 ลูก",
+				id: "Pada giliran lawan berikutnya, Energi yang dibutuhkan oleh Pokémon yang menerima serangan ini untuk menggunakan serangan dan Mundur masing-masing bertambah 1 Energi {Bening}.",
+			},
 		},
-
-		damage: 30,
-
-		effect: {
-			ja: "次の相手の番、このワザを受けたポケモンは、ワザを使うためのエネルギーとにげるためのエネルギーが、それぞれエネルギー1個ぶん多くなる。",
-			'zh-tw': "在下個對手的回合，受到這個招式的寶可夢使用招式所需的能量與【撤退】所需的能量，各增加1個【無】能量。",
-			th: "เทิร์นถัดไปของฝ่ายตรงข้าม โปเกมอนที่ได้รับท่าต่อสู้นี้ พลังงานสำหรับใช้ท่าต่อสู้กับพลังงานสำหรับ[หนี] แต่ละอย่างจะใช้พลังงาน[ไร้สี]เพิ่มขึ้น 1 ลูก",
-			id: "Pada giliran lawan berikutnya, Energi yang dibutuhkan oleh Pokémon yang menerima serangan ini untuk menggunakan serangan dan Mundur masing-masing bertambah 1 Energi {Bening}."
-		}
-	}, {
-		cost: ["Darkness", "Darkness", "Darkness", "Colorless"],
-
-		name: {
-			ja: "ヘドロばくだん",
-			'zh-tw': "污泥炸彈",
-			th: "สลัดจ์บอมบ์",
-			id: "Bom Limbah"
+		{
+			name: {
+				ja: "ヘドロばくだん",
+				'zh-tw': "污泥炸彈",
+				th: "สลัดจ์บอมบ์",
+				id: "Bom Limbah",
+			},
+			damage: 180,
+			cost: ["Darkness", "Darkness", "Darkness", "Colorless"],
 		},
+	],
 
-		damage: 180
-	}],
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 719531,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				cardmarket: 837406,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				cardmarket: 837407,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ベトベター",
+	},
 
 	retreat: 4,
 	regulationMark: "G",
+	rarity: "Uncommon",
+	dexId: [89],
+};
 
-	thirdParty: {
-		cardmarket: 719531
-	}
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV2a/090.ts
+++ b/data-asia/SV/SV2a/090.ts
@@ -1,20 +1,17 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV2a"
+import { Card } from "../../../interfaces";
+import Set from "../SV2a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "シェルダー",
 		'zh-tw': "大舌貝",
 		th: "เชลเดอร์",
-		id: "Shellder"
+		id: "Shellder",
 	},
 
 	illustrator: "Nelnal",
-	rarity: "Common",
 	category: "Pokemon",
-	dexId: [90],
 	hp: 70,
 	types: ["Water"],
 
@@ -22,42 +19,60 @@ const card: Card = {
 		ja: "ダイヤモンドよりも 硬い殻に 覆われている。 しかし 中は 意外と 柔らかい。",
 		'zh-tw': "包覆著身體的是比鑽石還硬的殼。不過殼裡面 卻比想像中的還要柔軟。",
 		th: "ปกคลุมด้วยเปลือกที่แข็งยิ่งกว่าเพชร แต่ภายในนิ่มกว่าที่คิด",
-		id: "Meskipun dilapisi oleh cangkang yang lebih keras daripada berlian, tubuh Shellder di dalam cangkangnya ternyata lunak."
+		id: "Meskipun dilapisi oleh cangkang yang lebih keras daripada berlian, tubuh Shellder di dalam cangkangnya ternyata lunak.",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		cost: ["Water", "Water"],
-
-		name: {
-			ja: "シェルプレス",
-			'zh-tw': "硬殼壓制",
-			th: "เชลล์เพรส",
-			id: "Shell Press"
+	attacks: [
+		{
+			name: {
+				ja: "シェルプレス",
+				'zh-tw': "硬殼壓制",
+				th: "เชลล์เพรส",
+				id: "Shell Press",
+			},
+			damage: 30,
+			cost: ["Water", "Water"],
+			effect: {
+				ja: "次の相手の番、このポケモンが受けるワザのダメージは「-30」される。",
+				'zh-tw': "在下個對手的回合，這隻寶可夢受到招式的傷害「-30」點。",
+				th: "เทิร์นถัดไปของฝ่ายตรงข้าม แดเมจของท่าต่อสู้ที่โปเกมอนนี้จะได้รับจะถูก [-30]",
+				id: "Pada giliran lawan berikutnya, kerusakan akibat serangan yang diterima Pokémon ini berkurang sejumlah 30.",
+			},
 		},
+	],
 
-		damage: 30,
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
 
-		effect: {
-			ja: "次の相手の番、このポケモンが受けるワザのダメージは「-30」される。",
-			'zh-tw': "在下個對手的回合，這隻寶可夢受到招式的傷害「-30」點。",
-			th: "เทิร์นถัดไปของฝ่ายตรงข้าม แดเมจของท่าต่อสู้ที่โปเกมอนนี้จะได้รับจะถูก [-30]",
-			id: "Pada giliran lawan berikutnya, kerusakan akibat serangan yang diterima Pokémon ini berkurang sejumlah 30."
-		}
-	}],
-
-	weaknesses: [{
-		type: "Lightning",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 719543,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				cardmarket: 837408,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				cardmarket: 837409,
+			},
+		},
+	],
 
 	retreat: 2,
 	regulationMark: "G",
+	rarity: "Common",
+	dexId: [90],
+};
 
-	thirdParty: {
-		cardmarket: 719543
-	}
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV2a/091.ts
+++ b/data-asia/SV/SV2a/091.ts
@@ -1,20 +1,17 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV2a"
+import { Card } from "../../../interfaces";
+import Set from "../SV2a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "パルシェン",
 		'zh-tw': "刺甲貝",
 		th: "พาร์เชน",
-		id: "Cloyster"
+		id: "Cloyster",
 	},
 
 	illustrator: "Nelnal",
-	rarity: "Uncommon",
 	category: "Pokemon",
-	dexId: [91],
 	hp: 130,
 	types: ["Water"],
 
@@ -22,42 +19,64 @@ const card: Card = {
 		ja: "潮の 流れが 激しい 海に 生息している パルシェンの 殻の トゲは 大きく 鋭い。",
 		'zh-tw': "刺甲貝棲息在潮流湍急的海裡， 殼上的刺又大又尖銳。",
 		th: "เปลือกของพาร์เชนที่อาศัยอยู่ในทะเลที่น้ำไหลเชี่ยวจะมีหนามที่ใหญ่และแหลมคม",
-		id: "Cangkang Cloyster yang hidup di laut bergelombang pasang deras berduri besar dan tajam."
+		id: "Cangkang Cloyster yang hidup di laut bergelombang pasang deras berduri besar dan tajam.",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		cost: ["Water", "Water"],
-
-		name: {
-			ja: "プロテクトチャージ",
-			'zh-tw': "防護充能",
-			th: "โพรเทกชาร์จ",
-			id: "Protect Charge"
+	attacks: [
+		{
+			name: {
+				ja: "プロテクトチャージ",
+				'zh-tw': "防護充能",
+				th: "โพรเทกชาร์จ",
+				id: "Protect Charge",
+			},
+			damage: 80,
+			cost: ["Water", "Water"],
+			effect: {
+				ja: "次の相手の番、このポケモンが受けるワザのダメージは「-80」される。",
+				'zh-tw': "在下個對手的回合，這隻寶可夢受到招式的傷害「-80」點。",
+				th: "เทิร์นถัดไปของฝ่ายตรงข้าม แดเมจของท่าต่อสู้ที่โปเกมอนนี้จะได้รับจะถูก [-80]",
+				id: "Pada giliran lawan berikutnya, kerusakan akibat serangan yang diterima Pokémon ini berkurang sejumlah 80.",
+			},
 		},
+	],
 
-		damage: 80,
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
 
-		effect: {
-			ja: "次の相手の番、このポケモンが受けるワザのダメージは「-80」される。",
-			'zh-tw': "在下個對手的回合，這隻寶可夢受到招式的傷害「-80」點。",
-			th: "เทิร์นถัดไปของฝ่ายตรงข้าม แดเมจของท่าต่อสู้ที่โปเกมอนนี้จะได้รับจะถูก [-80]",
-			id: "Pada giliran lawan berikutnya, kerusakan akibat serangan yang diterima Pokémon ini berkurang sejumlah 80."
-		}
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 719544,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				cardmarket: 837410,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				cardmarket: 837411,
+			},
+		},
+	],
 
-	weaknesses: [{
-		type: "Lightning",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "シェルダー",
+	},
 
 	retreat: 3,
 	regulationMark: "G",
+	rarity: "Uncommon",
+	dexId: [91],
+};
 
-	thirdParty: {
-		cardmarket: 719544
-	}
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV2a/092.ts
+++ b/data-asia/SV/SV2a/092.ts
@@ -1,20 +1,17 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV2a"
+import { Card } from "../../../interfaces";
+import Set from "../SV2a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "ゴース",
 		'zh-tw': "鬼斯",
 		th: "โกส",
-		id: "Gastly"
+		id: "Gastly",
 	},
 
 	illustrator: "Tomokazu Komiya",
-	rarity: "Common",
 	category: "Pokemon",
-	dexId: [92],
 	hp: 50,
 	types: ["Psychic"],
 
@@ -22,40 +19,54 @@ const card: Card = {
 		ja: "ガス状の 体で まとわりつき 獲物の 皮膚から 少しずつ 毒を 送り込んで 弱らせる。",
 		'zh-tw': "會用氣體狀的身體纏住獵物，再從皮膚緩緩地注入毒素， 使對手變得虛弱。",
 		th: "ใช้ร่างกายที่เป็นแก๊สเกาะติดเหยื่อแล้วค่อย ๆ ส่งพิษผ่านเข้าผิวหนังไปทีละนิดจนเหยื่ออ่อนแอลง",
-		id: "Gastly melekat pada mangsanya dengan tubuh gasnya, lalu melemahkan mereka dengan mengirimkan racun sedikit demi sedikit melalui kulit mereka."
+		id: "Gastly melekat pada mangsanya dengan tubuh gasnya, lalu melemahkan mereka dengan mengirimkan racun sedikit demi sedikit melalui kulit mereka.",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		cost: ["Psychic"],
-
-		name: {
-			ja: "ガスでつつむ",
-			'zh-tw': "瓦斯包圍",
-			th: "ห่อหุ้มด้วยแก๊ส",
-			id: "Gas yang Menyelimuti"
+	attacks: [
+		{
+			name: {
+				ja: "ガスでつつむ",
+				'zh-tw': "瓦斯包圍",
+				th: "ห่อหุ้มด้วยแก๊ส",
+				id: "Gas yang Menyelimuti",
+			},
+			damage: 20,
+			cost: ["Psychic"],
 		},
+	],
 
-		damage: 20
-	}],
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
 
-	weaknesses: [{
-		type: "Darkness",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Fighting",
-		value: "-30"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 719545,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				cardmarket: 837412,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				cardmarket: 837413,
+			},
+		},
+	],
 
 	retreat: 1,
 	regulationMark: "G",
+	rarity: "Common",
+	dexId: [92],
+};
 
-	thirdParty: {
-		cardmarket: 719545
-	}
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV2a/093.ts
+++ b/data-asia/SV/SV2a/093.ts
@@ -1,20 +1,17 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV2a"
+import { Card } from "../../../interfaces";
+import Set from "../SV2a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "ゴースト",
 		'zh-tw': "鬼斯通",
 		th: "โกสท์",
-		id: "Haunter"
+		id: "Haunter",
 	},
 
 	illustrator: "Tomokazu Komiya",
-	rarity: "Uncommon",
 	category: "Pokemon",
-	dexId: [93],
 	hp: 80,
 	types: ["Psychic"],
 
@@ -22,58 +19,76 @@ const card: Card = {
 		ja: "暗闇にまぎれ ガスの手を 伸ばし 人の肩を 叩くのが 好き。 触られると 震えが 止まらない。",
 		'zh-tw': "喜歡躲在黑暗中伸出氣體構成的手去拍人的肩膀。 一旦被接觸到，身體便會抖個不停。",
 		th: "ชอบซ่อนตัวในความมืดแล้วยื่นมือที่เป็นแก๊สไปตีไหล่คนเล่น ถ้าโดนเข้าจะตัวสั่นไม่หยุด",
-		id: "Haunter suka bersembunyi di dalam gelap, lalu menepuk pundak manusia dengan tangan gasnya. Sentuhannya membuat tubuh tidak akan berhenti gemetar."
+		id: "Haunter suka bersembunyi di dalam gelap, lalu menepuk pundak manusia dengan tangan gasnya. Sentuhannya membuat tubuh tidak akan berhenti gemetar.",
 	},
 
 	stage: "Stage1",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			ja: "ひとだまがえし",
-			'zh-tw': "孤魂返",
-			th: "คืนลูกไฟวิญญาณ",
-			id: "Putar Balik Roh"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "ひとだまがえし",
+				'zh-tw': "孤魂返",
+				th: "คืนลูกไฟวิญญาณ",
+				id: "Putar Balik Roh",
+			},
+			effect: {
+				ja: "自分の番に、このカードを手札から出して進化させたとき、1回使える。相手のトラッシュからサポートを1枚選び、相手の手札にもどす。",
+				'zh-tw': "在自己的回合，從手牌使出這張卡並完成進化時，可使用1次。從對手的棄牌區選擇1張支援者卡，放回對手的手牌。",
+				th: "ในเทิร์นฝ่ายเรา เมื่อนำการ์ดนี้จากบนมือออกมาวิวัฒนาการแล้ว ใช้ได้ 1 ครั้ง เลือกการ์ดซัพพอร์ต 1 ใบจากตำแหน่งทิ้งการ์ดฝ่ายตรงข้าม นำกลับขึ้นมือฝ่ายตรงข้าม",
+				id: "Dapat digunakan 1 kali pada giliran sendiri saat memasukkan kartu ini dari Kartu Pegangan untuk melakukan evolusi. Pilih 1 lembar Supporter dari Trash lawan, lalu kembalikan ke Kartu Pegangan lawan.",
+			},
 		},
+	],
 
-		effect: {
-			ja: "自分の番に、このカードを手札から出して進化させたとき、1回使える。相手のトラッシュからサポートを1枚選び、相手の手札にもどす。",
-			'zh-tw': "在自己的回合，從手牌使出這張卡並完成進化時，可使用1次。從對手的棄牌區選擇1張支援者卡，放回對手的手牌。",
-			th: "ในเทิร์นฝ่ายเรา เมื่อนำการ์ดนี้จากบนมือออกมาวิวัฒนาการแล้ว ใช้ได้ 1 ครั้ง เลือกการ์ดซัพพอร์ต 1 ใบจากตำแหน่งทิ้งการ์ดฝ่ายตรงข้าม นำกลับขึ้นมือฝ่ายตรงข้าม",
-			id: "Dapat digunakan 1 kali pada giliran sendiri saat memasukkan kartu ini dari Kartu Pegangan untuk melakukan evolusi. Pilih 1 lembar Supporter dari Trash lawan, lalu kembalikan ke Kartu Pegangan lawan."
-		}
-	}],
-
-	attacks: [{
-		cost: ["Psychic", "Colorless"],
-
-		name: {
-			ja: "つぶやく",
-			'zh-tw': "囈語",
-			th: "งึมงำ",
-			id: "Bergumam"
+	attacks: [
+		{
+			name: {
+				ja: "つぶやく",
+				'zh-tw': "囈語",
+				th: "งึมงำ",
+				id: "Bergumam",
+			},
+			damage: 30,
+			cost: ["Psychic", "Colorless"],
 		},
+	],
 
-		damage: 30
-	}],
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
 
-	weaknesses: [{
-		type: "Darkness",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 719546,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				cardmarket: 837414,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				cardmarket: 837415,
+			},
+		},
+	],
 
-	resistances: [{
-		type: "Fighting",
-		value: "-30"
-	}],
+	evolveFrom: {
+		ja: "ゴース",
+	},
 
 	retreat: 1,
 	regulationMark: "G",
+	rarity: "Uncommon",
+	dexId: [93],
+};
 
-	thirdParty: {
-		cardmarket: 719546
-	}
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV2a/094.ts
+++ b/data-asia/SV/SV2a/094.ts
@@ -1,20 +1,17 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV2a"
+import { Card } from "../../../interfaces";
+import Set from "../SV2a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "ゲンガー",
 		'zh-tw': "耿鬼",
 		th: "เก็งกา",
-		id: "Gengar"
+		id: "Gengar",
 	},
 
 	illustrator: "Tomokazu Komiya",
-	rarity: "Rare",
 	category: "Pokemon",
-	dexId: [94],
 	hp: 130,
 	types: ["Psychic"],
 
@@ -22,65 +19,80 @@ const card: Card = {
 		ja: "命を 奪おうと 決めた 獲物の 影に 潜り込み じっと チャンスを 狙ってる。",
 		'zh-tw': "會潛進獵物的影子裡，然後靜靜地等待 奪取性命的機會到來。",
 		th: "เข้าไปในเงาของเหยื่อที่เล็งไว้ แล้วรอโอกาสปลิดชีพ",
-		id: "Untuk merebut nyawa targetnya, Gengar menyelinap ke dalam bayangan targetnya, dan terus terdiam menunggu kesempatan."
+		id: "Untuk merebut nyawa targetnya, Gengar menyelinap ke dalam bayangan targetnya, dan terus terdiam menunggu kesempatan.",
 	},
 
 	stage: "Stage2",
 
-	attacks: [{
-		cost: ["Psychic"],
-
-		name: {
-			ja: "ポルターガイスト",
-			'zh-tw': "靈騷",
-			th: "โพลเตอร์ไกสท์",
-			id: "Poltergeist"
+	attacks: [
+		{
+			name: {
+				ja: "ポルターガイスト",
+				'zh-tw': "靈騷",
+				th: "โพลเตอร์ไกสท์",
+				id: "Poltergeist",
+			},
+			damage: "50×",
+			cost: ["Psychic"],
+			effect: {
+				ja: "相手の手札を見て、その中にあるトレーナーズの枚数×50ダメージ。",
+				'zh-tw': "查看對手的手牌，造成其中訓練家卡的張數×50點傷害。",
+				th: "ดูการ์ดบนมือฝ่ายตรงข้าม แดเมจจะเท่ากับจำนวนการ์ดเทรนเนอร์ที่อยู่ในนั้น x50",
+				id: "Lihat Kartu Pegangan lawan, serangan ini memberikan kerusakan sejumlah 50 untuk tiap lembar Trainer yang ada di antaranya.",
+			},
 		},
-
-		damage: "50×",
-
-		effect: {
-			ja: "相手の手札を見て、その中にあるトレーナーズの枚数×50ダメージ。",
-			'zh-tw': "查看對手的手牌，造成其中訓練家卡的張數×50點傷害。",
-			th: "ดูการ์ดบนมือฝ่ายตรงข้าม แดเมจจะเท่ากับจำนวนการ์ดเทรนเนอร์ที่อยู่ในนั้น x50",
-			id: "Lihat Kartu Pegangan lawan, serangan ini memberikan kerusakan sejumlah 50 untuk tiap lembar Trainer yang ada di antaranya."
-		}
-	}, {
-		cost: ["Psychic", "Colorless"],
-
-		name: {
-			ja: "ホロウダイブ",
-			'zh-tw': "陰森奇襲",
-			th: "ฮอลโลว์ไดฟ์",
-			id: "Hollow Dive"
+		{
+			name: {
+				ja: "ホロウダイブ",
+				'zh-tw': "陰森奇襲",
+				th: "ฮอลโลว์ไดฟ์",
+				id: "Hollow Dive",
+			},
+			damage: 110,
+			cost: ["Psychic", "Colorless"],
+			effect: {
+				ja: "ダメカン3個を、相手のベンチポケモンに好きなようにのせる。",
+				'zh-tw': "將3個傷害指示物以任意方式放置於對手的備戰寶可夢身上。",
+				th: "วางตัวนับแดเมจ 3 ตัว บนโปเกมอนบนเบนช์ฝ่ายตรงข้ามตามชอบ",
+				id: "Letakkan sejumlah 3 Token Kerusakan pada Pokémon Cadangan lawan sesukanya.",
+			},
 		},
+	],
 
-		damage: 110,
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
 
-		effect: {
-			ja: "ダメカン3個を、相手のベンチポケモンに好きなようにのせる。",
-			'zh-tw': "將3個傷害指示物以任意方式放置於對手的備戰寶可夢身上。",
-			th: "วางตัวนับแดเมจ 3 ตัว บนโปเกมอนบนเบนช์ฝ่ายตรงข้ามตามชอบ",
-			id: "Letakkan sejumlah 3 Token Kerusakan pada Pokémon Cadangan lawan sesukanya."
-		}
-	}],
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 719547,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				cardmarket: 837416,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				cardmarket: 837417,
+			},
+		},
+	],
 
-	weaknesses: [{
-		type: "Darkness",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Fighting",
-		value: "-30"
-	}],
+	evolveFrom: {
+		ja: "ゴースト",
+	},
 
 	retreat: 0,
 	regulationMark: "G",
+	rarity: "Rare",
+	dexId: [94],
+};
 
-	thirdParty: {
-		cardmarket: 719547
-	}
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV2a/095.ts
+++ b/data-asia/SV/SV2a/095.ts
@@ -1,20 +1,17 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV2a"
+import { Card } from "../../../interfaces";
+import Set from "../SV2a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "イワーク",
 		'zh-tw': "大岩蛇",
 		th: "อิวาร์ค",
-		id: "Onix"
+		id: "Onix",
 	},
 
 	illustrator: "Shin Nagasawa",
-	rarity: "Uncommon",
 	category: "Pokemon",
-	dexId: [95],
 	hp: 120,
 	types: ["Fighting"],
 
@@ -22,53 +19,70 @@ const card: Card = {
 		ja: "大きく 丈夫な 体を くねらせ よじらせ 時速８０キロで 地面を 勢いよく 掘り進む。",
 		'zh-tw': "彎曲扭動巨大結實的身體，以時速８０公里的 猛烈勢頭挖掘前進。",
 		th: "บิดร่างกายที่ใหญ่และแข็งแรงให้โค้งงอเป็นเกลียวขุดเจาะพื้นดินลงไปอย่างรวดเร็วด้วยความเร็ว 80 กิโลเมตรต่อชั่วโมง",
-		id: "Onix menggali lubang secara bersemangat pada kecepatan 80 km/jam dengan menggoyang dan meliukkan tubuhnya yang besar dan kuat."
+		id: "Onix menggali lubang secara bersemangat pada kecepatan 80 km/jam dengan menggoyang dan meliukkan tubuhnya yang besar dan kuat.",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		cost: ["Colorless", "Colorless"],
-
-		name: {
-			ja: "どっすんなだれ",
-			'zh-tw': "轟隆崩塌",
-			th: "ทลายครืน",
-			id: "Longsoran Dentum"
+	attacks: [
+		{
+			name: {
+				ja: "どっすんなだれ",
+				'zh-tw': "轟隆崩塌",
+				th: "ทลายครืน",
+				id: "Longsoran Dentum",
+			},
+			damage: "80×",
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "自分の山札を上から5枚トラッシュし、その中にあるにげるためのエネルギーが4個のポケモンの枚数×80ダメージ。",
+				'zh-tw': "將自己的牌庫上方5張卡丟棄，造成其中【撤退】所需的能量為4個的寶可夢卡的張數×80點傷害。",
+				th: "ทิ้งการ์ด 5 ใบจากด้านบนของสำรับการ์ดฝ่ายเราที่ตำแหน่งทิ้งการ์ด แดเมจจะเท่ากับจำนวนการ์ดโปเกมอนที่มีพลังงานสำหรับ[หนี] 4 ลูกที่อยู่ในนั้น x80",
+				id: "Buang 5 kartu dari atas Deck sendiri ke Trash, serangan ini memberikan kerusakan sejumlah 80 untuk tiap lembar Pokémon yang membutuhkan 4 Energi untuk Mundur yang ada di antaranya.",
+			},
 		},
-
-		damage: "80×",
-
-		effect: {
-			ja: "自分の山札を上から5枚トラッシュし、その中にあるにげるためのエネルギーが4個のポケモンの枚数×80ダメージ。",
-			'zh-tw': "將自己的牌庫上方5張卡丟棄，造成其中【撤退】所需的能量為4個的寶可夢卡的張數×80點傷害。",
-			th: "ทิ้งการ์ด 5 ใบจากด้านบนของสำรับการ์ดฝ่ายเราที่ตำแหน่งทิ้งการ์ด แดเมจจะเท่ากับจำนวนการ์ดโปเกมอนที่มีพลังงานสำหรับ[หนี] 4 ลูกที่อยู่ในนั้น x80",
-			id: "Buang 5 kartu dari atas Deck sendiri ke Trash, serangan ini memberikan kerusakan sejumlah 80 untuk tiap lembar Pokémon yang membutuhkan 4 Energi untuk Mundur yang ada di antaranya."
-		}
-	}, {
-		cost: ["Fighting", "Fighting", "Colorless", "Colorless"],
-
-		name: {
-			ja: "ヘビーインパクト",
-			'zh-tw': "重磅衝擊",
-			th: "เฮวี่อิมแพ็คท์",
-			id: "Heavy Impact"
+		{
+			name: {
+				ja: "ヘビーインパクト",
+				'zh-tw': "重磅衝擊",
+				th: "เฮวี่อิมแพ็คท์",
+				id: "Heavy Impact",
+			},
+			damage: 100,
+			cost: ["Fighting", "Fighting", "Colorless", "Colorless"],
 		},
+	],
 
-		damage: 100
-	}],
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Grass",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 719548,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				cardmarket: 837418,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				cardmarket: 837419,
+			},
+		},
+	],
 
 	retreat: 4,
 	regulationMark: "G",
+	rarity: "Uncommon",
+	dexId: [95],
+};
 
-	thirdParty: {
-		cardmarket: 719548
-	}
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV2a/096.ts
+++ b/data-asia/SV/SV2a/096.ts
@@ -1,20 +1,17 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV2a"
+import { Card } from "../../../interfaces";
+import Set from "../SV2a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "スリープ",
 		'zh-tw': "催眠貘",
 		th: "สลีป",
-		id: "Drowzee"
+		id: "Drowzee",
 	},
 
 	illustrator: "Mousho",
-	rarity: "Common",
 	category: "Pokemon",
-	dexId: [96],
 	hp: 80,
 	types: ["Psychic"],
 
@@ -22,40 +19,54 @@ const card: Card = {
 		ja: "食べた夢は 全部 覚えている。 子どもの 夢のほうが 美味しいので めったに 大人の 夢は食べない。",
 		'zh-tw': "能記住所有自己吃下的夢。由於小孩的夢更加美味， 因此幾乎不吃大人的夢。",
 		th: "จำฝันที่กินเข้าไปได้หมด ไม่ค่อยกินฝันของผู้ใหญ่เพราะฝันของเด็กอร่อยกว่า",
-		id: "Drowzee mengingat semua mimpi yang dimakannya. Pokémon ini jarang memakan mimpi orang dewasa karena mimpi anak-anak rasanya lebih lezat."
+		id: "Drowzee mengingat semua mimpi yang dimakannya. Pokémon ini jarang memakan mimpi orang dewasa karena mimpi anak-anak rasanya lebih lezat.",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		cost: ["Psychic", "Colorless"],
-
-		name: {
-			ja: "しねんのずつき",
-			'zh-tw': "意念頭錘",
-			th: "ท่าโขกหัวพลังจิต",
-			id: "Sundulan Spiritual"
+	attacks: [
+		{
+			name: {
+				ja: "しねんのずつき",
+				'zh-tw': "意念頭錘",
+				th: "ท่าโขกหัวพลังจิต",
+				id: "Sundulan Spiritual",
+			},
+			damage: 30,
+			cost: ["Psychic", "Colorless"],
 		},
+	],
 
-		damage: 30
-	}],
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
 
-	weaknesses: [{
-		type: "Darkness",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Fighting",
-		value: "-30"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 719549,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				cardmarket: 837420,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				cardmarket: 837421,
+			},
+		},
+	],
 
 	retreat: 2,
 	regulationMark: "G",
+	rarity: "Common",
+	dexId: [96],
+};
 
-	thirdParty: {
-		cardmarket: 719549
-	}
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV2a/097.ts
+++ b/data-asia/SV/SV2a/097.ts
@@ -1,20 +1,17 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV2a"
+import { Card } from "../../../interfaces";
+import Set from "../SV2a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "スリーパー",
 		'zh-tw': "引夢貘人",
 		th: "สลีปเปอร์",
-		id: "Hypno"
+		id: "Hypno",
 	},
 
 	illustrator: "Mousho",
-	rarity: "Uncommon",
 	category: "Pokemon",
-	dexId: [97],
 	hp: 110,
 	types: ["Psychic"],
 
@@ -22,58 +19,76 @@ const card: Card = {
 		ja: "相手と 目が 合ったときに 催眠術など 数々の 超能力を 使うという。",
 		'zh-tw': "據說牠和對手對到眼時，就會使出催眠術等 各式各樣的超能力。",
 		th: "จะใช้พลังเหนือธรรมชาติต่าง ๆ อย่างสะกดจิตให้หลับเมื่อสบตากับอีกฝ่าย",
-		id: "Dikabarkan Hypno menggunakan hipnotis dan berbagai macam kekuatan psikokinesis lainnya saat bertatapan dengan musuhnya."
+		id: "Dikabarkan Hypno menggunakan hipnotis dan berbagai macam kekuatan psikokinesis lainnya saat bertatapan dengan musuhnya.",
 	},
 
 	stage: "Stage1",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			ja: "でたとこさいみん",
-			'zh-tw': "臨場催眠",
-			th: "สะกดจิตฉับพลัน",
-			id: "Hipnosis Masuk Spontan"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "でたとこさいみん",
+				'zh-tw': "臨場催眠",
+				th: "สะกดจิตฉับพลัน",
+				id: "Hipnosis Masuk Spontan",
+			},
+			effect: {
+				ja: "自分の番に、このカードを手札から出して進化させたとき、1回使える。相手のバトルポケモンをねむりにする。",
+				'zh-tw': "在自己的回合，從手牌使出這張卡並完成進化時，可使用1次。將對手的戰鬥寶可夢【睡眠】。",
+				th: "ในเทิร์นฝ่ายเรา เมื่อนำการ์ดนี้จากบนมือออกมาวิวัฒนาการแล้ว ใช้ได้ 1 ครั้ง ทำให้โปเกมอนบนตำแหน่งต่อสู้ฝ่ายตรงข้ามเป็นสภาวะ[หลับ]",
+				id: "Dapat digunakan 1 kali pada giliran sendiri saat memasukkan kartu ini dari Kartu Pegangan untuk melakukan evolusi. Ubah kondisi Pokémon Bertarung lawan menjadi Tidur.",
+			},
 		},
+	],
 
-		effect: {
-			ja: "自分の番に、このカードを手札から出して進化させたとき、1回使える。相手のバトルポケモンをねむりにする。",
-			'zh-tw': "在自己的回合，從手牌使出這張卡並完成進化時，可使用1次。將對手的戰鬥寶可夢【睡眠】。",
-			th: "ในเทิร์นฝ่ายเรา เมื่อนำการ์ดนี้จากบนมือออกมาวิวัฒนาการแล้ว ใช้ได้ 1 ครั้ง ทำให้โปเกมอนบนตำแหน่งต่อสู้ฝ่ายตรงข้ามเป็นสภาวะ[หลับ]",
-			id: "Dapat digunakan 1 kali pada giliran sendiri saat memasukkan kartu ini dari Kartu Pegangan untuk melakukan evolusi. Ubah kondisi Pokémon Bertarung lawan menjadi Tidur."
-		}
-	}],
-
-	attacks: [{
-		cost: ["Psychic", "Psychic", "Colorless"],
-
-		name: {
-			ja: "ちょうねんりき",
-			'zh-tw': "超念力",
-			th: "ซูเปอร์โทรจิต",
-			id: "Psikokinesis Super"
+	attacks: [
+		{
+			name: {
+				ja: "ちょうねんりき",
+				'zh-tw': "超念力",
+				th: "ซูเปอร์โทรจิต",
+				id: "Psikokinesis Super",
+			},
+			damage: 110,
+			cost: ["Psychic", "Psychic", "Colorless"],
 		},
+	],
 
-		damage: 110
-	}],
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
 
-	weaknesses: [{
-		type: "Darkness",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 719550,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				cardmarket: 837422,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				cardmarket: 837423,
+			},
+		},
+	],
 
-	resistances: [{
-		type: "Fighting",
-		value: "-30"
-	}],
+	evolveFrom: {
+		ja: "スリープ",
+	},
 
 	retreat: 2,
 	regulationMark: "G",
+	rarity: "Uncommon",
+	dexId: [97],
+};
 
-	thirdParty: {
-		cardmarket: 719550
-	}
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV2a/098.ts
+++ b/data-asia/SV/SV2a/098.ts
@@ -1,20 +1,17 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV2a"
+import { Card } from "../../../interfaces";
+import Set from "../SV2a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "クラブ",
 		'zh-tw': "大鉗蟹",
 		th: "แครบ",
-		id: "Krabby"
+		id: "Krabby",
 	},
 
 	illustrator: "Yukiko Baba",
-	rarity: "Common",
 	category: "Pokemon",
-	dexId: [98],
 	hp: 70,
 	types: ["Water"],
 
@@ -22,51 +19,69 @@ const card: Card = {
 		ja: "危険がせまると 口から 吐きだす 泡で 全身を 包んで 体を 大きく みせようとする。",
 		'zh-tw': "如果危險逼近，就會從嘴裡吐出泡沫包裹全身， 讓身體看起來更大。",
 		th: "ถ้าอันตรายเข้ามาใกล้ ก็จะพ่นฟองออกมาจากปากห่อหุ้มทั่วร่างเพื่อทำให้ร่างกายดูใหญ่ขึ้น",
-		id: "Ketika bahaya mendekat, Krabby membalut tubuhnya dengan gelembung yang dikeluarkan dari mulutnya agar tubuhnya terlihat lebih besar."
+		id: "Ketika bahaya mendekat, Krabby membalut tubuhnya dengan gelembung yang dikeluarkan dari mulutnya agar tubuhnya terlihat lebih besar.",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		cost: ["Water"],
-
-		name: {
-			ja: "しおまねき",
-			'zh-tw': "招潮",
-			th: "เรียกกระแสน้ำ",
-			id: "Pemanggil Air Laut"
+	attacks: [
+		{
+			name: {
+				ja: "しおまねき",
+				'zh-tw': "招潮",
+				th: "เรียกกระแสน้ำ",
+				id: "Pemanggil Air Laut",
+			},
+			cost: ["Water"],
+			effect: {
+				ja: "コインを1回投げオモテなら、自分の山札から「基本[W]エネルギー」を2枚まで選び、このポケモンにつける。そして山札を切る。",
+				'zh-tw': "擲1次硬幣若為正面，則從自己的牌庫選擇最多2張「基本【水】能量」卡，附於這隻寶可夢身上。並且重洗牌庫。",
+				th: "ทอยเหรียญ 1 ครั้งถ้าออกหัว เลือกการ์ด [พลังงานพื้นฐาน[น้ำ]] ได้สูงสุด 2 ใบจากสำรับการ์ดฝ่ายเรา ติดที่โปเกมอนนี้ แล้วสับสำรับการ์ด",
+				id: "Lempar koin 1 kali. Jika hasilnya sisi depan, pilih paling banyak 2 lembar Energi Dasar {Air} dari Deck sendiri, lalu kenakan pada Pokémon ini. Kemudian, kocok Deck.",
+			},
 		},
-
-		effect: {
-			ja: "コインを1回投げオモテなら、自分の山札から「基本エネルギー」を2枚まで選び、このポケモンにつける。そして山札を切る。",
-			'zh-tw': "擲1次硬幣若為正面，則從自己的牌庫選擇最多2張「基本【水】能量」卡，附於這隻寶可夢身上。並且重洗牌庫。",
-			th: "ทอยเหรียญ 1 ครั้งถ้าออกหัว เลือกการ์ด [พลังงานพื้นฐาน[น้ำ]] ได้สูงสุด 2 ใบจากสำรับการ์ดฝ่ายเรา ติดที่โปเกมอนนี้ แล้วสับสำรับการ์ด",
-			id: "Lempar koin 1 kali. Jika hasilnya sisi depan, pilih paling banyak 2 lembar Energi Dasar {Air} dari Deck sendiri, lalu kenakan pada Pokémon ini. Kemudian, kocok Deck."
-		}
-	}, {
-		cost: ["Water", "Water", "Water"],
-
-		name: {
-			ja: "クラブハンマー",
-			'zh-tw': "蟹鉗錘",
-			th: "ค้อนก้ามปู",
-			id: "Crabhammer"
+		{
+			name: {
+				ja: "クラブハンマー",
+				'zh-tw': "蟹鉗錘",
+				th: "ค้อนก้ามปู",
+				id: "Crabhammer",
+			},
+			damage: 50,
+			cost: ["Water", "Water", "Water"],
 		},
+	],
 
-		damage: 50
-	}],
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Lightning",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 719551,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				cardmarket: 837424,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				cardmarket: 837425,
+			},
+		},
+	],
 
 	retreat: 1,
 	regulationMark: "G",
+	rarity: "Common",
+	dexId: [98],
+};
 
-	thirdParty: {
-		cardmarket: 719551
-	}
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV2a/099.ts
+++ b/data-asia/SV/SV2a/099.ts
@@ -1,20 +1,17 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV2a"
+import { Card } from "../../../interfaces";
+import Set from "../SV2a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "キングラー",
 		'zh-tw': "巨鉗蟹",
 		th: "คิงเกลอร์",
-		id: "Kingler"
+		id: "Kingler",
 	},
 
 	illustrator: "Yukiko Baba",
-	rarity: "Uncommon",
 	category: "Pokemon",
-	dexId: [99],
 	hp: 140,
 	types: ["Water"],
 
@@ -22,53 +19,74 @@ const card: Card = {
 		ja: "破壊力 抜群の 大きな ハサミだが 重すぎるので 戦わないときは じゃまになる。",
 		'zh-tw': "巨大的鉗子破壞力十足，但是因為太過沉重， 不戰鬥的時候就很礙事。",
 		th: "มีก้ามใหญ่ที่มีพลังทำลายล้างยอดเยี่ยม แต่ว่าก้ามนี้หนักเหลือเกินก็เลยเกะกะเวลาที่ไม่ได้ใช้ต่อสู้",
-		id: "Capit besar Kingler memiliki daya penghancur yang luar biasa. Tetapi, saat tidak bertarung capitnya yang berat ini hanya menjadi beban."
+		id: "Capit besar Kingler memiliki daya penghancur yang luar biasa. Tetapi, saat tidak bertarung capitnya yang berat ini hanya menjadi beban.",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		cost: ["Water", "Water", "Water"],
-
-		name: {
-			ja: "アームハンマー",
-			'zh-tw': "臂錘",
-			th: "อาร์มแฮมเมอร์",
-			id: "Arm Hammer"
+	attacks: [
+		{
+			name: {
+				ja: "アームハンマー",
+				'zh-tw': "臂錘",
+				th: "อาร์มแฮมเมอร์",
+				id: "Arm Hammer",
+			},
+			damage: 90,
+			cost: ["Water", "Water", "Water"],
+			effect: {
+				ja: "相手の山札を上から1枚トラッシュする。",
+				'zh-tw': "將對手的牌庫上方1張卡丟棄。",
+				th: "ทิ้งการ์ด 1 ใบจากด้านบนของสำรับการ์ดฝ่ายตรงข้ามที่ตำแหน่งทิ้งการ์ด",
+				id: "Buang 1 kartu dari atas Deck lawan ke Trash.",
+			},
 		},
-
-		damage: 90,
-
-		effect: {
-			ja: "相手の山札を上から1枚トラッシュする。",
-			'zh-tw': "將對手的牌庫上方1張卡丟棄。",
-			th: "ทิ้งการ์ด 1 ใบจากด้านบนของสำรับการ์ดฝ่ายตรงข้ามที่ตำแหน่งทิ้งการ์ด",
-			id: "Buang 1 kartu dari atas Deck lawan ke Trash."
-		}
-	}, {
-		cost: ["Water", "Water", "Water", "Water"],
-
-		name: {
-			ja: "ハサミギロチン",
-			'zh-tw': "斷頭鉗",
-			th: "กรรไกรกิโยติน",
-			id: "Memenggal"
+		{
+			name: {
+				ja: "ハサミギロチン",
+				'zh-tw': "斷頭鉗",
+				th: "กรรไกรกิโยติน",
+				id: "Memenggal",
+			},
+			damage: 220,
+			cost: ["Water", "Water", "Water", "Water"],
 		},
+	],
 
-		damage: 220
-	}],
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Lightning",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 719552,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				cardmarket: 837426,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				cardmarket: 837427,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "クラブ",
+	},
 
 	retreat: 3,
 	regulationMark: "G",
+	rarity: "Uncommon",
+	dexId: [99],
+};
 
-	thirdParty: {
-		cardmarket: 719552
-	}
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV2a/100.ts
+++ b/data-asia/SV/SV2a/100.ts
@@ -1,20 +1,17 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV2a"
+import { Card } from "../../../interfaces";
+import Set from "../SV2a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "ビリリダマ",
 		'zh-tw': "霹靂電球",
 		th: "บิริริดามา",
-		id: "Voltorb"
+		id: "Voltorb",
 	},
 
 	illustrator: "nagimiso",
-	rarity: "Common",
 	category: "Pokemon",
-	dexId: [100],
 	hp: 60,
 	types: ["Lightning"],
 
@@ -22,42 +19,60 @@ const card: Card = {
 		ja: "転がって 移動するので 地面が デコボコだと ショックで 爆発してしまう。",
 		'zh-tw': "靠著翻滾身體來移動，如果地面凹凸不平， 就會受到衝擊而爆炸。",
 		th: "เคลื่อนที่โดยการกลิ้ง ถ้าพื้นไม่สม่ำเสมอจะตกใจจนระเบิด",
-		id: "Karena Voltorb berpindah-pindah dengan bergelinding, Pokémon ini akan meledak karena guncangan ketika melewati tanah yang tidak rata."
+		id: "Karena Voltorb berpindah-pindah dengan bergelinding, Pokémon ini akan meledak karena guncangan ketika melewati tanah yang tidak rata.",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		cost: ["Lightning"],
-
-		name: {
-			ja: "ローリングアタック",
-			'zh-tw': "回轉攻擊",
-			th: "โรลลิ่งแอทแทค",
-			id: "Rolling Attack"
+	attacks: [
+		{
+			name: {
+				ja: "ローリングアタック",
+				'zh-tw': "回轉攻擊",
+				th: "โรลลิ่งแอทแทค",
+				id: "Rolling Attack",
+			},
+			damage: "10+",
+			cost: ["Lightning"],
+			effect: {
+				ja: "コインを1回投げオモテなら、20ダメージ追加。",
+				'zh-tw': "擲1次硬幣若為正面，則增加20點傷害。",
+				th: "ทอยเหรียญ 1 ครั้งถ้าออกหัว การโจมตีนี้จะเพิ่มแดเมจอีก 20",
+				id: "Lempar koin 1 kali. Jika hasilnya sisi depan, kerusakan yang diberikan bertambah sejumlah 20.",
+			},
 		},
+	],
 
-		damage: "10+",
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
 
-		effect: {
-			ja: "コインを1回投げオモテなら、20ダメージ追加。",
-			'zh-tw': "擲1次硬幣若為正面，則增加20點傷害。",
-			th: "ทอยเหรียญ 1 ครั้งถ้าออกหัว การโจมตีนี้จะเพิ่มแดเมจอีก 20",
-			id: "Lempar koin 1 kali. Jika hasilnya sisi depan, kerusakan yang diberikan bertambah sejumlah 20."
-		}
-	}],
-
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 719553,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				cardmarket: 837428,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				cardmarket: 837429,
+			},
+		},
+	],
 
 	retreat: 1,
 	regulationMark: "G",
+	rarity: "Common",
+	dexId: [100],
+};
 
-	thirdParty: {
-		cardmarket: 719553
-	}
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV2a/101.ts
+++ b/data-asia/SV/SV2a/101.ts
@@ -1,20 +1,17 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV2a"
+import { Card } from "../../../interfaces";
+import Set from "../SV2a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "マルマイン",
 		'zh-tw': "頑皮雷彈",
 		th: "มารุมายน์",
-		id: "Electrode"
+		id: "Electrode",
 	},
 
 	illustrator: "nagimiso",
-	rarity: "Rare",
 	category: "Pokemon",
-	dexId: [101],
 	hp: 90,
 	types: ["Lightning"],
 
@@ -22,53 +19,74 @@ const card: Card = {
 		ja: "電気エネルギーを 溜めこむほど 高速で 動けるようになるが そのぶん 爆発 しやすい。",
 		'zh-tw': "雖然儲存的電能越多，移動的速度也會變得越快， 但同時也會變得更容易爆炸。",
 		th: "ยิ่งสะสมพลังงานไฟฟ้ามากเท่าไหร่ยิ่งเคลื่อนไหวได้เร็ว แต่ก็จะระเบิดง่ายขึ้นด้วย",
-		id: "Makin banyak energi listrik yang disimpan, Electrode dapat bergerak dengan kecepatan tinggi. Namun, Pokémon ini juga menjadi lebih mudah untuk meledak."
+		id: "Makin banyak energi listrik yang disimpan, Electrode dapat bergerak dengan kecepatan tinggi. Namun, Pokémon ini juga menjadi lebih mudah untuk meledak.",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		cost: ["Lightning"],
-
-		name: {
-			ja: "ボムボムチェイン",
-			'zh-tw': "轟轟連鎖",
-			th: "บอมบ์บอมบ์เชน",
-			id: "Bomb Bomb Chain"
+	attacks: [
+		{
+			name: {
+				ja: "ボムボムチェイン",
+				'zh-tw': "轟轟連鎖",
+				th: "บอมบ์บอมบ์เชน",
+				id: "Bomb Bomb Chain",
+			},
+			damage: "20+",
+			cost: ["Lightning"],
+			effect: {
+				ja: "ダメージを与える前に、自分の場のポケモンについている「ポケモンのどうぐ」を好きなだけトラッシュし、その枚数×40ダメージ追加。",
+				'zh-tw': "在造成傷害前，將自己的場上寶可夢身上附加的任意數量的「寶可夢道具」卡丟棄，增加其張數×40點傷害。",
+				th: "ก่อนจะทำแดเมจ ทิ้ง [ไอเท็มติดโปเกมอน] ที่ติดอยู่กับโปเกมอนบนกระดานฝ่ายเราที่ตำแหน่งทิ้งการ์ดตามจำนวนที่ชอบ แดเมจจะเพิ่มตามจำนวนการ์ดนั้น x40",
+				id: "Sebelum memberikan kerusakan, buang sesukanya Pokémon Tool yang dikenakan pada Pokémon di Arena sendiri ke Trash, kerusakan yang diberikan bertambah sejumlah 40 untuk tiap lembarnya.",
+			},
 		},
-
-		damage: "20+",
-
-		effect: {
-			ja: "ダメージを与える前に、自分の場のポケモンについている「ポケモンのどうぐ」を好きなだけトラッシュし、その枚数×40ダメージ追加。",
-			'zh-tw': "在造成傷害前，將自己的場上寶可夢身上附加的任意數量的「寶可夢道具」卡丟棄，增加其張數×40點傷害。",
-			th: "ก่อนจะทำแดเมจ ทิ้ง [ไอเท็มติดโปเกมอน] ที่ติดอยู่กับโปเกมอนบนกระดานฝ่ายเราที่ตำแหน่งทิ้งการ์ดตามจำนวนที่ชอบ แดเมจจะเพิ่มตามจำนวนการ์ดนั้น x40",
-			id: "Sebelum memberikan kerusakan, buang sesukanya Pokémon Tool yang dikenakan pada Pokémon di Arena sendiri ke Trash, kerusakan yang diberikan bertambah sejumlah 40 untuk tiap lembarnya."
-		}
-	}, {
-		cost: ["Lightning", "Colorless"],
-
-		name: {
-			ja: "エレキボール",
-			'zh-tw': "電球",
-			th: "อิเล็กทริกบอล",
-			id: "Electro Ball"
+		{
+			name: {
+				ja: "エレキボール",
+				'zh-tw': "電球",
+				th: "อิเล็กทริกบอล",
+				id: "Electro Ball",
+			},
+			damage: 70,
+			cost: ["Lightning", "Colorless"],
 		},
+	],
 
-		damage: 70
-	}],
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 719554,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				cardmarket: 837430,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				cardmarket: 837431,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ビリリダマ",
+	},
 
 	retreat: 1,
 	regulationMark: "G",
+	rarity: "Rare",
+	dexId: [101],
+};
 
-	thirdParty: {
-		cardmarket: 719554
-	}
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV2a/102.ts
+++ b/data-asia/SV/SV2a/102.ts
@@ -1,20 +1,17 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV2a"
+import { Card } from "../../../interfaces";
+import Set from "../SV2a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "タマタマ",
 		'zh-tw': "蛋蛋",
 		th: "ทามะทามะ",
-		id: "Exeggcute"
+		id: "Exeggcute",
 	},
 
 	illustrator: "Shigenori Negishi",
-	rarity: "Common",
 	category: "Pokemon",
-	dexId: [102],
 	hp: 60,
 	types: ["Grass"],
 
@@ -22,42 +19,60 @@ const card: Card = {
 		ja: "６匹で いないと 落ち着かない。 １匹でも いなくなると とたんに 逃げ腰に なるのだ。",
 		'zh-tw': "非得湊齊６隻才會有安全感。那怕只是少了１隻，都會立刻 變得很膽小，隨時想要逃跑。",
 		th: "ถ้าอยู่ไม่ครบทั้ง 6 ตัวจะรู้สึกไม่สงบใจ ถ้าหายไปแม้แต่ 1 ตัวจะเตรียมตัววิ่งหนีทันที",
-		id: "Exeggcute tidak tenang jika tidak berenam. Begitu salah satu menghilang, Pokémon ini segera ingin melarikan diri."
+		id: "Exeggcute tidak tenang jika tidak berenam. Begitu salah satu menghilang, Pokémon ini segera ingin melarikan diri.",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		cost: ["Colorless", "Colorless"],
-
-		name: {
-			ja: "たまころがり",
-			'zh-tw': "滾球",
-			th: "กลิ้งบอล",
-			id: "Menggelindingkan Bola"
+	attacks: [
+		{
+			name: {
+				ja: "たまころがり",
+				'zh-tw': "滾球",
+				th: "กลิ้งบอล",
+				id: "Menggelindingkan Bola",
+			},
+			damage: "30×",
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "ウラが出るまでコインを投げ、オモテの数×30ダメージ。",
+				'zh-tw': "擲硬幣直到出現反面，造成正面出現的次數×30點傷害。",
+				th: "ทอยเหรียญจนกว่าจะออกก้อย แดเมจจะเท่ากับจำนวนครั้งที่ออกหัว x30",
+				id: "Lempar koin hingga hasilnya sisi belakang. Serangan ini memberikan kerusakan sejumlah 30 untuk tiap lemparan dengan hasil sisi depan.",
+			},
 		},
+	],
 
-		damage: "30×",
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
 
-		effect: {
-			ja: "ウラが出るまでコインを投げ、オモテの数×30ダメージ。",
-			'zh-tw': "擲硬幣直到出現反面，造成正面出現的次數×30點傷害。",
-			th: "ทอยเหรียญจนกว่าจะออกก้อย แดเมจจะเท่ากับจำนวนครั้งที่ออกหัว x30",
-			id: "Lempar koin hingga hasilnya sisi belakang. Serangan ini memberikan kerusakan sejumlah 30 untuk tiap lemparan dengan hasil sisi depan."
-		}
-	}],
-
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 719555,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				cardmarket: 837432,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				cardmarket: 837433,
+			},
+		},
+	],
 
 	retreat: 1,
 	regulationMark: "G",
+	rarity: "Common",
+	dexId: [102],
+};
 
-	thirdParty: {
-		cardmarket: 719555
-	}
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV2a/103.ts
+++ b/data-asia/SV/SV2a/103.ts
@@ -1,20 +1,17 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV2a"
+import { Card } from "../../../interfaces";
+import Set from "../SV2a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "ナッシー",
 		'zh-tw': "椰蛋樹",
 		th: "นัชชี",
-		id: "Exeggutor"
+		id: "Exeggutor",
 	},
 
 	illustrator: "Shigenori Negishi",
-	rarity: "Uncommon",
 	category: "Pokemon",
-	dexId: [103],
 	hp: 140,
 	types: ["Grass"],
 
@@ -22,53 +19,74 @@ const card: Card = {
 		ja: "３つの 頭が 一丸となって 撃つ サイコパワーは 強力。 空が 曇ると 動きが 鈍る。",
 		'zh-tw': "３顆頭團結一致發出的精神力量威力強大。天氣 變陰時動作就會變得遲緩。",
 		th: "พลังจิตที่หัวทั้ง 3 หัวรวมใจเป็นหนึ่งเดียวปล่อยออกมานั้นมีพลังแรง วันที่มีเมฆมากจะเคลื่อนไหวช้า",
-		id: "Kekuatan psikokinesis yang ditembakkan saat 3 kepala Exeggutor bekerja sama sangat kuat. Gerakannya menjadi lambat saat langit berawan."
+		id: "Kekuatan psikokinesis yang ditembakkan saat 3 kepala Exeggutor bekerja sama sangat kuat. Gerakannya menjadi lambat saat langit berawan.",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		cost: ["Colorless", "Colorless"],
-
-		name: {
-			ja: "サイコキネシス",
-			'zh-tw': "精神強念",
-			th: "ไซโคคิเนซิส",
-			id: "Psikis"
+	attacks: [
+		{
+			name: {
+				ja: "サイコキネシス",
+				'zh-tw': "精神強念",
+				th: "ไซโคคิเนซิส",
+				id: "Psikis",
+			},
+			damage: "30+",
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンについているエネルギーの数×30ダメージ追加。",
+				'zh-tw': "增加對手的戰鬥寶可夢身上附加的能量的數量×30點傷害。",
+				th: "แดเมจจะเพิ่มตามจำนวนพลังงานที่ติดอยู่กับโปเกมอนบนตำแหน่งต่อสู้ฝ่ายตรงข้าม x30",
+				id: "Kerusakan yang diberikan bertambah sejumlah 30 untuk tiap Energi yang dikenakan pada Pokémon Bertarung lawan.",
+			},
 		},
-
-		damage: "30+",
-
-		effect: {
-			ja: "相手のバトルポケモンについているエネルギーの数×30ダメージ追加。",
-			'zh-tw': "增加對手的戰鬥寶可夢身上附加的能量的數量×30點傷害。",
-			th: "แดเมจจะเพิ่มตามจำนวนพลังงานที่ติดอยู่กับโปเกมอนบนตำแหน่งต่อสู้ฝ่ายตรงข้าม x30",
-			id: "Kerusakan yang diberikan bertambah sejumlah 30 untuk tiap Energi yang dikenakan pada Pokémon Bertarung lawan."
-		}
-	}, {
-		cost: ["Grass", "Grass", "Colorless"],
-
-		name: {
-			ja: "ぶちかます",
-			'zh-tw': "頭突",
-			th: "ตบหนัก",
-			id: "Hantaman Penuh Tenaga"
+		{
+			name: {
+				ja: "ぶちかます",
+				'zh-tw': "頭突",
+				th: "ตบหนัก",
+				id: "Hantaman Penuh Tenaga",
+			},
+			damage: 130,
+			cost: ["Grass", "Grass", "Colorless"],
 		},
+	],
 
-		damage: 130
-	}],
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 719556,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				cardmarket: 837434,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				cardmarket: 837435,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "タマタマ",
+	},
 
 	retreat: 3,
 	regulationMark: "G",
+	rarity: "Uncommon",
+	dexId: [103],
+};
 
-	thirdParty: {
-		cardmarket: 719556
-	}
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV2a/104.ts
+++ b/data-asia/SV/SV2a/104.ts
@@ -1,20 +1,17 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV2a"
+import { Card } from "../../../interfaces";
+import Set from "../SV2a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "カラカラ",
 		'zh-tw': "卡拉卡拉",
 		th: "คาระคาระ",
-		id: "Cubone"
+		id: "Cubone",
 	},
 
 	illustrator: "Shinya Komatsu",
-	rarity: "Common",
 	category: "Pokemon",
-	dexId: [104],
 	hp: 70,
 	types: ["Fighting"],
 
@@ -22,60 +19,78 @@ const card: Card = {
 		ja: "死んだ 母親の 骨を 被る。 夢を 見て 泣くことも あるけど 涙を 流すたびに 強くなる。",
 		'zh-tw': "頭上戴著死去母親的頭骨。雖然有時會因為作夢而哭泣， 但每次流淚後都會變得更強。",
 		th: "สวมใส่กระดูกของแม่ที่เสียชีวิตไปแล้ว บางครั้งก็ร้องไห้เวลาฝัน น้ำตาที่ไหลออกมาแต่ละครั้งนั้นทำให้ตนแข็งแกร่งขึ้น",
-		id: "Cubone mengenakan tengkorak ibunya yang telah mati. Kadang Pokémon ini menangis saat melihat mimpi, tapi tiap tetes air mata yang dialirkan olehnya membuat dirinya menjadi makin kuat."
+		id: "Cubone mengenakan tengkorak ibunya yang telah mati. Kadang Pokémon ini menangis saat melihat mimpi, tapi tiap tetes air mata yang dialirkan olehnya membuat dirinya menjadi makin kuat.",
 	},
 
 	stage: "Basic",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			ja: "おうえんボーン",
-			'zh-tw': "加油骨",
-			th: "กระดูกเชียร์",
-			id: "Tulang Penyemangat"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "おうえんボーン",
+				'zh-tw': "加油骨",
+				th: "กระดูกเชียร์",
+				id: "Tulang Penyemangat",
+			},
+			effect: {
+				ja: "このポケモンがベンチにいるかぎり、自分の「ガラガラ」が使うワザの、相手のバトルポケモンへのダメージは「+30」される。",
+				'zh-tw': "只要這隻寶可夢在備戰區，自己的「嘎啦嘎啦」使用的招式，對對手的戰鬥寶可夢造成的傷害「+30」點。",
+				th: "ตราบใดที่โปเกมอนนี้ยังอยู่บนเบนช์ แดเมจของท่าต่อสู้ที่ [การะการะ] ฝ่ายเรา ใช้ทำกับโปเกมอนบนตำแหน่งต่อสู้ฝ่ายตรงข้ามจะถูก [+30]",
+				id: "Selama Pokémon ini ada di Cadangan, kerusakan akibat serangan yang digunakan oleh Marowak sendiri kepada Pokémon Bertarung lawan bertambah sejumlah 30.",
+			},
 		},
+	],
 
-		effect: {
-			ja: "このポケモンがベンチにいるかぎり、自分の「ガラガラ」が使うワザの、相手のバトルポケモンへのダメージは「+30」される。",
-			'zh-tw': "只要這隻寶可夢在備戰區，自己的「嘎啦嘎啦」使用的招式，對對手的戰鬥寶可夢造成的傷害「+30」點。",
-			th: "ตราบใดที่โปเกมอนนี้ยังอยู่บนเบนช์ แดเมจของท่าต่อสู้ที่ [การะการะ] ฝ่ายเรา ใช้ทำกับโปเกมอนบนตำแหน่งต่อสู้ฝ่ายตรงข้ามจะถูก [+30]",
-			id: "Selama Pokémon ini ada di Cadangan, kerusakan akibat serangan yang digunakan oleh Marowak sendiri kepada Pokémon Bertarung lawan bertambah sejumlah 30."
-		}
-	}],
-
-	attacks: [{
-		cost: ["Fighting"],
-
-		name: {
-			ja: "にどたたき",
-			'zh-tw': "二連敲",
-			th: "ตีสองครั้ง",
-			id: "Hantam Dua Kali"
+	attacks: [
+		{
+			name: {
+				ja: "にどたたき",
+				'zh-tw': "二連敲",
+				th: "ตีสองครั้ง",
+				id: "Hantam Dua Kali",
+			},
+			damage: "10×",
+			cost: ["Fighting"],
+			effect: {
+				ja: "コインを2回投げ、オモテの数×10ダメージ。",
+				'zh-tw': "擲2次硬幣，造成正面出現的次數×10點傷害。",
+				th: "ทอยเหรียญ 2 ครั้ง แดเมจจะเท่ากับจำนวนครั้งที่ออกหัว x10",
+				id: "Lempar koin 2 kali. Serangan ini memberikan kerusakan sejumlah 10 untuk tiap lemparan dengan hasil sisi depan.",
+			},
 		},
+	],
 
-		damage: "10×",
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
 
-		effect: {
-			ja: "コインを2回投げ、オモテの数×10ダメージ。",
-			'zh-tw': "擲2次硬幣，造成正面出現的次數×10點傷害。",
-			th: "ทอยเหรียญ 2 ครั้ง แดเมจจะเท่ากับจำนวนครั้งที่ออกหัว x10",
-			id: "Lempar koin 2 kali. Serangan ini memberikan kerusakan sejumlah 10 untuk tiap lemparan dengan hasil sisi depan."
-		}
-	}],
-
-	weaknesses: [{
-		type: "Grass",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 719557,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				cardmarket: 837436,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				cardmarket: 837437,
+			},
+		},
+	],
 
 	retreat: 1,
 	regulationMark: "G",
+	rarity: "Common",
+	dexId: [104],
+};
 
-	thirdParty: {
-		cardmarket: 719557
-	}
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV2a/105.ts
+++ b/data-asia/SV/SV2a/105.ts
@@ -1,20 +1,17 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV2a"
+import { Card } from "../../../interfaces";
+import Set from "../SV2a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "ガラガラ",
 		'zh-tw': "嘎啦嘎啦",
 		th: "การะการะ",
-		id: "Marowak"
+		id: "Marowak",
 	},
 
 	illustrator: "Shinya Komatsu",
-	rarity: "Rare",
 	category: "Pokemon",
-	dexId: [105],
 	hp: 120,
 	types: ["Fighting"],
 
@@ -22,60 +19,80 @@ const card: Card = {
 		ja: "進化して 被っていた 母親の 骨が 一体化して そのうえ 凶暴な 性格に 変わった。",
 		'zh-tw': "進化時，原本戴在頭上的母親頭骨化為了牠身體的一部份。 不但如此，性格也變得很凶暴。",
 		th: "วิวัฒนาการแล้วทำให้กระดูกของแม่ที่สวมอยู่นั้นกลายเป็นส่วนหนึ่งของตน ยิ่งไปกว่านั้น ยังเปลี่ยนให้มีนิสัยดุดันด้วย",
-		id: "Cubone berevolusi menjadi Marowak dan tengkorak ibunya yang dikenakan di kepalanya menyatu ke tubuhnya. Selain itu, sifatnya juga berubah menjadi brutal."
+		id: "Cubone berevolusi menjadi Marowak dan tengkorak ibunya yang dikenakan di kepalanya menyatu ke tubuhnya. Selain itu, sifatnya juga berubah menjadi brutal.",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		cost: ["Fighting"],
-
-		name: {
-			ja: "ボーンスロー",
-			'zh-tw': "骨棒投擲",
-			th: "โบนโทรว์",
-			id: "Bone Throw"
+	attacks: [
+		{
+			name: {
+				ja: "ボーンスロー",
+				'zh-tw': "骨棒投擲",
+				th: "โบนโทรว์",
+				id: "Bone Throw",
+			},
+			damage: 30,
+			cost: ["Fighting"],
+			effect: {
+				ja: "相手のベンチポケモン1匹にも、30ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+				'zh-tw': "對手的1隻備戰寶可夢也受到30點傷害。[在備戰區不計算弱點・抵抗力。]",
+				th: "โปเกมอนบนเบนช์ฝ่ายตรงข้าม 1 ตัว ก็จะได้รับแดเมจ 30 ด้วย {โปเกมอนบนเบนช์จะไม่นำจุดอ่อนและความต้านทานมาคิด}",
+				id: "Serangan ini juga memberikan kerusakan sejumlah 30 kepada 1 Pokémon Cadangan lawan. [Kelemahan dan Resistansi Pokémon Cadangan tidak mempengaruhi jumlah kerusakan.]",
+			},
 		},
-
-		damage: 30,
-
-		effect: {
-			ja: "相手のベンチポケモン1匹にも、30ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
-			'zh-tw': "對手的1隻備戰寶可夢也受到30點傷害。[在備戰區不計算弱點・抵抗力。]",
-			th: "โปเกมอนบนเบนช์ฝ่ายตรงข้าม 1 ตัว ก็จะได้รับแดเมจ 30 ด้วย {โปเกมอนบนเบนช์จะไม่นำจุดอ่อนและความต้านทานมาคิด}",
-			id: "Serangan ini juga memberikan kerusakan sejumlah 30 kepada 1 Pokémon Cadangan lawan. [Kelemahan dan Resistansi Pokémon Cadangan tidak mempengaruhi jumlah kerusakan.]"
-		}
-	}, {
-		cost: ["Fighting", "Colorless"],
-
-		name: {
-			ja: "そこぢから",
-			'zh-tw': "潛力",
-			th: "พลังแฝง",
-			id: "Kekuatan Laten"
+		{
+			name: {
+				ja: "そこぢから",
+				'zh-tw': "潛力",
+				th: "พลังแฝง",
+				id: "Kekuatan Laten",
+			},
+			damage: 120,
+			cost: ["Fighting", "Colorless"],
+			effect: {
+				ja: "次の自分の番、このポケモンはワザが使えない。",
+				'zh-tw': "在下個自己的回合，這隻寶可夢無法使用招式。",
+				th: "เทิร์นถัดไปของฝ่ายเรา โปเกมอนนี้จะใช้ท่าต่อสู้ไม่ได้",
+				id: "Pada giliran sendiri berikutnya, Pokémon ini tidak dapat menggunakan serangan.",
+			},
 		},
+	],
 
-		damage: 120,
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
 
-		effect: {
-			ja: "次の自分の番、このポケモンはワザが使えない。",
-			'zh-tw': "在下個自己的回合，這隻寶可夢無法使用招式。",
-			th: "เทิร์นถัดไปของฝ่ายเรา โปเกมอนนี้จะใช้ท่าต่อสู้ไม่ได้",
-			id: "Pada giliran sendiri berikutnya, Pokémon ini tidak dapat menggunakan serangan."
-		}
-	}],
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 719558,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				cardmarket: 837438,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				cardmarket: 837439,
+			},
+		},
+	],
 
-	weaknesses: [{
-		type: "Grass",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "カラカラ",
+	},
 
 	retreat: 2,
 	regulationMark: "G",
+	rarity: "Rare",
+	dexId: [105],
+};
 
-	thirdParty: {
-		cardmarket: 719558
-	}
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV2a/106.ts
+++ b/data-asia/SV/SV2a/106.ts
@@ -1,20 +1,17 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV2a"
+import { Card } from "../../../interfaces";
+import Set from "../SV2a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "サワムラー",
 		'zh-tw': "飛腿郎",
 		th: "ซาวามูลาร์",
-		id: "Hitmonlee"
+		id: "Hitmonlee",
 	},
 
 	illustrator: "Hitoshi Ariga",
-	rarity: "Uncommon",
 	category: "Pokemon",
-	dexId: [106],
 	hp: 120,
 	types: ["Fighting"],
 
@@ -22,51 +19,69 @@ const card: Card = {
 		ja: "脚が 自由に 伸び縮みして 遠く 離れている 場合でも 相手を 蹴り上げることが できる。",
 		'zh-tw': "雙腿能夠自由伸縮，即使離得很遠也能 把對手一腳踢飛。",
 		th: "ขายืดหดได้อิสระ ถึงแม้จะอยู่ไกลก็สามารถเตะคู่ต่อสู้ให้ลอยไปได้",
-		id: "Kaki Hitmonlee dapat memanjang dan memendek dengan bebas, sehingga dia dapat menendang lawan meski jaraknya terpisah jauh."
+		id: "Kaki Hitmonlee dapat memanjang dan memendek dengan bebas, sehingga dia dapat menendang lawan meski jaraknya terpisah jauh.",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		cost: ["Fighting"],
-
-		name: {
-			ja: "トルネードキック",
-			'zh-tw': "龍捲風踢腿",
-			th: "ทอร์นาโดคิก",
-			id: "Tornado Kick"
+	attacks: [
+		{
+			name: {
+				ja: "トルネードキック",
+				'zh-tw': "龍捲風踢腿",
+				th: "ทอร์นาโดคิก",
+				id: "Tornado Kick",
+			},
+			cost: ["Fighting"],
+			effect: {
+				ja: "相手のポケモン全員に、それぞれ10ダメージ。このポケモンをベンチポケモンと入れ替える。［ベンチは弱点・抵抗力を計算しない。］",
+				'zh-tw': "對手的所有寶可夢各受到10點傷害。將這隻寶可夢與備戰寶可夢互換。[在備戰區不計算弱點・抵抗力。]",
+				th: "โปเกมอนฝ่ายตรงข้ามทุกตัว จะได้รับแดเมจตัวละ 10 สลับโปเกมอนนี้กับโปเกมอนบนเบนช์ {โปเกมอนบนเบนช์จะไม่นำจุดอ่อนและความต้านทานมาคิด}",
+				id: "Serangan ini memberikan kerusakan masing-masing sejumlah 10 kepada semua Pokémon lawan. Tukar Pokémon ini dengan Pokémon Cadangan. [Kelemahan dan Resistansi Pokémon Cadangan tidak mempengaruhi jumlah kerusakan.]",
+			},
 		},
-
-		effect: {
-			ja: "相手のポケモン全員に、それぞれ10ダメージ。このポケモンをベンチポケモンと入れ替える。［ベンチは弱点・抵抗力を計算しない。］",
-			'zh-tw': "對手的所有寶可夢各受到10點傷害。將這隻寶可夢與備戰寶可夢互換。[在備戰區不計算弱點・抵抗力。]",
-			th: "โปเกมอนฝ่ายตรงข้ามทุกตัว จะได้รับแดเมจตัวละ 10 สลับโปเกมอนนี้กับโปเกมอนบนเบนช์ {โปเกมอนบนเบนช์จะไม่นำจุดอ่อนและความต้านทานมาคิด}",
-			id: "Serangan ini memberikan kerusakan masing-masing sejumlah 10 kepada semua Pokémon lawan. Tukar Pokémon ini dengan Pokémon Cadangan. [Kelemahan dan Resistansi Pokémon Cadangan tidak mempengaruhi jumlah kerusakan.]"
-		}
-	}, {
-		cost: ["Fighting", "Fighting", "Fighting"],
-
-		name: {
-			ja: "けたぐり",
-			'zh-tw': "踢倒",
-			th: "เตะเลียด",
-			id: "Tendangan Rendah"
+		{
+			name: {
+				ja: "けたぐり",
+				'zh-tw': "踢倒",
+				th: "เตะเลียด",
+				id: "Tendangan Rendah",
+			},
+			damage: 100,
+			cost: ["Fighting", "Fighting", "Fighting"],
 		},
+	],
 
-		damage: 100
-	}],
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Psychic",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 719559,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				cardmarket: 837440,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				cardmarket: 837441,
+			},
+		},
+	],
 
 	retreat: 2,
 	regulationMark: "G",
+	rarity: "Uncommon",
+	dexId: [106],
+};
 
-	thirdParty: {
-		cardmarket: 719559
-	}
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV2a/107.ts
+++ b/data-asia/SV/SV2a/107.ts
@@ -1,20 +1,17 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV2a"
+import { Card } from "../../../interfaces";
+import Set from "../SV2a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "エビワラー",
 		'zh-tw': "快拳郎",
 		th: "เอบิวาลาร์",
-		id: "Hitmonchan"
+		id: "Hitmonchan",
 	},
 
 	illustrator: "DOM",
-	rarity: "Uncommon",
 	category: "Pokemon",
-	dexId: [107],
 	hp: 120,
 	types: ["Fighting"],
 
@@ -22,60 +19,78 @@ const card: Card = {
 		ja: "空気をも 切り裂く パンチ。 だが ３分間 攻撃すると ひと休み したくなるらしい。",
 		'zh-tw': "打出的拳擊甚至能劈開空氣。但連續攻擊３分鐘後， 牠似乎就會想休息一下。",
 		th: "หมัดฉีกอากาศ แต่ดูเหมือนว่าพอโจมตีไปได้ 3 นาทีก็ต้องการพัก",
-		id: "Pukulan Hitmonchan dapat membelah udara. Tapi dia butuh istirahat kalau sudah menyerang selama tiga menit."
+		id: "Pukulan Hitmonchan dapat membelah udara. Tapi dia butuh istirahat kalau sudah menyerang selama tiga menit.",
 	},
 
 	stage: "Basic",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			ja: "はんげき",
-			'zh-tw': "反擊",
-			th: "ตีตอบโต้",
-			id: "Serangan Balasan"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "はんげき",
+				'zh-tw': "反擊",
+				th: "ตีตอบโต้",
+				id: "Serangan Balasan",
+			},
+			effect: {
+				ja: "このポケモンが、バトル場で相手のポケモンからワザのダメージを受けたとき、ワザを使ったポケモンにダメカンを3個のせる。",
+				'zh-tw': "這隻寶可夢在戰鬥場受到對手的寶可夢招式的傷害時，在使用招式的寶可夢身上放置3個傷害指示物。",
+				th: "เมื่อโปเกมอนนี้ อยู่บนตำแหน่งต่อสู้และได้รับแดเมจของท่าต่อสู้จากโปเกมอนฝ่ายตรงข้าม วางตัวนับแดเมจ 3 ตัวบนโปเกมอนที่ใช้ท่าต่อสู้",
+				id: "Saat Pokémon ini ada di Arena Bertarung dan menerima kerusakan akibat serangan dari Pokémon lawan, letakkan 3 Token Kerusakan pada Pokémon yang telah menggunakan serangan.",
+			},
 		},
+	],
 
-		effect: {
-			ja: "このポケモンが、バトル場で相手のポケモンからワザのダメージを受けたとき、ワザを使ったポケモンにダメカンを3個のせる。",
-			'zh-tw': "這隻寶可夢在戰鬥場受到對手的寶可夢招式的傷害時，在使用招式的寶可夢身上放置3個傷害指示物。",
-			th: "เมื่อโปเกมอนนี้ อยู่บนตำแหน่งต่อสู้และได้รับแดเมจของท่าต่อสู้จากโปเกมอนฝ่ายตรงข้าม วางตัวนับแดเมจ 3 ตัวบนโปเกมอนที่ใช้ท่าต่อสู้",
-			id: "Saat Pokémon ini ada di Arena Bertarung dan menerima kerusakan akibat serangan dari Pokémon lawan, letakkan 3 Token Kerusakan pada Pokémon yang telah menggunakan serangan."
-		}
-	}],
-
-	attacks: [{
-		cost: ["Fighting", "Fighting"],
-
-		name: {
-			ja: "エキサイトパンチ",
-			'zh-tw': "激動拳",
-			th: "เอ็กซ์ไซต์พันช์",
-			id: "Excite Punch"
+	attacks: [
+		{
+			name: {
+				ja: "エキサイトパンチ",
+				'zh-tw': "激動拳",
+				th: "เอ็กซ์ไซต์พันช์",
+				id: "Excite Punch",
+			},
+			damage: 60,
+			cost: ["Fighting", "Fighting"],
+			effect: {
+				ja: "次の自分の番、このポケモンの「エキサイトパンチ」のダメージは「+60」される。",
+				'zh-tw': "在下個自己的回合，這隻寶可夢「激動拳」的傷害「+60」點。",
+				th: "เทิร์นถัดไปของฝ่ายเรา แดเมจจาก [เอ็กซ์ไซต์พันช์] ของโปเกมอนนี้จะถูก [+60]",
+				id: "Pada giliran sendiri berikutnya, kerusakan akibat Excite Punch Pokémon ini bertambah sejumlah 60.",
+			},
 		},
+	],
 
-		damage: 60,
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
 
-		effect: {
-			ja: "次の自分の番、このポケモンの「エキサイトパンチ」のダメージは「+60」される。",
-			'zh-tw': "在下個自己的回合，這隻寶可夢「激動拳」的傷害「+60」點。",
-			th: "เทิร์นถัดไปของฝ่ายเรา แดเมจจาก [เอ็กซ์ไซต์พันช์] ของโปเกมอนนี้จะถูก [+60]",
-			id: "Pada giliran sendiri berikutnya, kerusakan akibat Excite Punch Pokémon ini bertambah sejumlah 60."
-		}
-	}],
-
-	weaknesses: [{
-		type: "Psychic",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 719560,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				cardmarket: 837442,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				cardmarket: 837443,
+			},
+		},
+	],
 
 	retreat: 1,
 	regulationMark: "G",
+	rarity: "Uncommon",
+	dexId: [107],
+};
 
-	thirdParty: {
-		cardmarket: 719560
-	}
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV2a/108.ts
+++ b/data-asia/SV/SV2a/108.ts
@@ -1,20 +1,17 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV2a"
+import { Card } from "../../../interfaces";
+import Set from "../SV2a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "ベロリンガ",
 		'zh-tw': "大舌頭",
 		th: "เบโรรินกา",
-		id: "Lickitung"
+		id: "Lickitung",
 	},
 
 	illustrator: "Saya Tsuruta",
-	rarity: "Common",
 	category: "Pokemon",
-	dexId: [108],
 	hp: 100,
 	types: ["Colorless"],
 
@@ -22,42 +19,60 @@ const card: Card = {
 		ja: "虫ポケモンが おもな エサ。 長い 舌で 相手を 舐めて 痺れた ところを 丸飲みにする。",
 		'zh-tw': "蟲寶可夢是牠主要的食物。會用長長的舌頭去把對方 舔麻痺，然後趁機一口吞下。",
 		th: "โปเกมอนแมลงเป็นอาหารหลักของมัน มันจะใช้ลิ้นยาวเลียเหยื่อเพื่อทำให้ตัวชาแล้วกลืนกินเข้าไปทั้งตัว",
-		id: "Makanan utama Lickitung adalah Pokémon serangga. Pokémon ini melumpuhkan lawan dengan jilatan lidahnya yang panjang, lalu menelan lawannya bulat-bulat."
+		id: "Makanan utama Lickitung adalah Pokémon serangga. Pokémon ini melumpuhkan lawan dengan jilatan lidahnya yang panjang, lalu menelan lawannya bulat-bulat.",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		cost: ["Colorless", "Colorless", "Colorless"],
-
-		name: {
-			ja: "ベロベロバインド",
-			'zh-tw': "舔舔制約",
-			th: "มัดติดแพล่บแพล่บ",
-			id: "Jilat-jilat Mengikat"
+	attacks: [
+		{
+			name: {
+				ja: "ベロベロバインド",
+				'zh-tw': "舔舔制約",
+				th: "มัดติดแพล่บแพล่บ",
+				id: "Jilat-jilat Mengikat",
+			},
+			damage: 70,
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "次の相手の番、このワザを受けたポケモンは、ワザが使えない。",
+				'zh-tw': "在下個對手的回合，受到這個招式的寶可夢無法使用招式。",
+				th: "เทิร์นถัดไปของฝ่ายตรงข้าม โปเกมอนที่ได้รับท่าต่อสู้นี้ จะใช้ท่าต่อสู้ไม่ได้",
+				id: "Pada giliran lawan berikutnya, Pokémon yang menerima serangan ini tidak dapat menggunakan serangan.",
+			},
 		},
+	],
 
-		damage: 70,
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
 
-		effect: {
-			ja: "次の相手の番、このワザを受けたポケモンは、ワザが使えない。",
-			'zh-tw': "在下個對手的回合，受到這個招式的寶可夢無法使用招式。",
-			th: "เทิร์นถัดไปของฝ่ายตรงข้าม โปเกมอนที่ได้รับท่าต่อสู้นี้ จะใช้ท่าต่อสู้ไม่ได้",
-			id: "Pada giliran lawan berikutnya, Pokémon yang menerima serangan ini tidak dapat menggunakan serangan."
-		}
-	}],
-
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 719561,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				cardmarket: 837444,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				cardmarket: 837445,
+			},
+		},
+	],
 
 	retreat: 4,
 	regulationMark: "G",
+	rarity: "Common",
+	dexId: [108],
+};
 
-	thirdParty: {
-		cardmarket: 719561
-	}
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV2a/109.ts
+++ b/data-asia/SV/SV2a/109.ts
@@ -1,20 +1,17 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV2a"
+import { Card } from "../../../interfaces";
+import Set from "../SV2a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "ドガース",
 		'zh-tw': "瓦斯彈",
 		th: "โดกาซ",
-		id: "Koffing"
+		id: "Koffing",
 	},
 
 	illustrator: "Shibuzoh.",
-	rarity: "Common",
 	category: "Pokemon",
-	dexId: [109],
 	hp: 60,
 	types: ["Darkness"],
 
@@ -22,42 +19,60 @@ const card: Card = {
 		ja: "毒ガスで パンパンの 体。 生ゴミの 腐った においを 求め ゴミ捨て場に やってくる。",
 		'zh-tw': "身體裡充滿了毒氣。會為了尋求廚餘垃圾的 腐敗氣味而來到垃圾場。",
 		th: "ร่างอัดแน่นไปด้วยแก๊สพิษ มาที่ทิ้งขยะเพราะต้องการกลิ่นเหม็นเน่าของขยะสด",
-		id: "Tubuh Koffing padat oleh gas beracun. Dia mendatangi tempat pembuangan sampah untuk mencari bau busuk sampah basah."
+		id: "Tubuh Koffing padat oleh gas beracun. Dia mendatangi tempat pembuangan sampah untuk mencari bau busuk sampah basah.",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		cost: ["Colorless", "Colorless"],
-
-		name: {
-			ja: "あやしいガス",
-			'zh-tw': "奇異瓦斯",
-			th: "ก๊าซประหลาด",
-			id: "Gas Membingungkan"
+	attacks: [
+		{
+			name: {
+				ja: "あやしいガス",
+				'zh-tw': "奇異瓦斯",
+				th: "ก๊าซประหลาด",
+				id: "Gas Membingungkan",
+			},
+			damage: 20,
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをこんらんにする。",
+				'zh-tw': "將對手的戰鬥寶可夢【混亂】。",
+				th: "ทำให้โปเกมอนบนตำแหน่งต่อสู้ฝ่ายตรงข้ามเป็นสภาวะ[สับสน]",
+				id: "Ubah kondisi Pokémon Bertarung lawan menjadi Pusing.",
+			},
 		},
+	],
 
-		damage: 20,
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
 
-		effect: {
-			ja: "相手のバトルポケモンをこんらんにする。",
-			'zh-tw': "將對手的戰鬥寶可夢【混亂】。",
-			th: "ทำให้โปเกมอนบนตำแหน่งต่อสู้ฝ่ายตรงข้ามเป็นสภาวะ[สับสน]",
-			id: "Ubah kondisi Pokémon Bertarung lawan menjadi Pusing."
-		}
-	}],
-
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 719562,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				cardmarket: 837446,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				cardmarket: 837447,
+			},
+		},
+	],
 
 	retreat: 1,
 	regulationMark: "G",
+	rarity: "Common",
+	dexId: [109],
+};
 
-	thirdParty: {
-		cardmarket: 719562
-	}
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV2a/110.ts
+++ b/data-asia/SV/SV2a/110.ts
@@ -1,20 +1,17 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV2a"
+import { Card } from "../../../interfaces";
+import Set from "../SV2a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "マタドガス",
 		'zh-tw': "雙彈瓦斯",
 		th: "มาตาโดกัซ",
-		id: "Weezing"
+		id: "Weezing",
 	},
 
 	illustrator: "Shibuzoh.",
-	rarity: "Rare",
 	category: "Pokemon",
-	dexId: [110],
 	hp: 110,
 	types: ["Darkness"],
 
@@ -22,60 +19,82 @@ const card: Card = {
 		ja: "ごくまれに 突然変異で 双子の 小さい ドガースが 連結したまま 出ることがある。",
 		'zh-tw': "有時會因為非常罕見的突變， 出現２個連在一起的 雙胞胎小瓦斯彈。",
 		th: "มีบ้างที่โดกาซคู่แฝดตัวเล็ก ๆ จะเชื่อมตัวต่อกันออกมาทั้งอย่างนั้น เนื่องจากกระบวนการเปลี่ยนแปลงทางธรรมชาติที่เกิดขึ้นไม่บ่อยนัก",
-		id: "Walau langka, kadang terjadi mutasi sehingga Koffing kecil kembar muncul dalam keadaan tetap menyatu."
+		id: "Walau langka, kadang terjadi mutasi sehingga Koffing kecil kembar muncul dalam keadaan tetap menyatu.",
 	},
 
 	stage: "Stage1",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			ja: "もろともボム",
-			'zh-tw': "齊爆炸彈",
-			th: "บอมบ์พร้อมกันไป",
-			id: "Bom Kena Bersama"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "もろともボム",
+				'zh-tw': "齊爆炸彈",
+				th: "บอมบ์พร้อมกันไป",
+				id: "Bom Kena Bersama",
+			},
+			effect: {
+				ja: "このポケモンが、バトル場で相手のポケモンからワザのダメージを受けてきぜつしたとき、自分はコインを1回投げる。オモテなら、ワザを使ったポケモンをきぜつさせる。",
+				'zh-tw': "這隻寶可夢在戰鬥場上受到對手的寶可夢招式的傷害而【昏厥】時，自己擲1次硬幣。若為正面，則將使用招式的寶可夢【昏厥】。",
+				th: "เมื่อโปเกมอนนี้ อยู่บนตำแหน่งต่อสู้และได้รับแดเมจของท่าต่อสู้จากโปเกมอนฝ่ายตรงข้ามและ[หมดสภาพ]แล้ว ฝ่ายเราทอยเหรียญ 1 ครั้ง ถ้าออกหัว จะทำให้โปเกมอนที่ใช้ท่าต่อสู้[หมดสภาพ]",
+				id: "Saat Pokémon ini ada di Arena Bertarung dan KO karena menerima kerusakan akibat serangan dari Pokémon lawan, pemain melempar koin 1 kali. Jika hasilnya sisi depan, Pokémon yang telah menggunakan serangan KO.",
+			},
 		},
+	],
 
-		effect: {
-			ja: "このポケモンが、バトル場で相手のポケモンからワザのダメージを受けてきぜつしたとき、自分はコインを1回投げる。オモテなら、ワザを使ったポケモンをきぜつさせる。",
-			'zh-tw': "這隻寶可夢在戰鬥場上受到對手的寶可夢招式的傷害而【昏厥】時，自己擲1次硬幣。若為正面，則將使用招式的寶可夢【昏厥】。",
-			th: "เมื่อโปเกมอนนี้ อยู่บนตำแหน่งต่อสู้และได้รับแดเมจของท่าต่อสู้จากโปเกมอนฝ่ายตรงข้ามและ[หมดสภาพ]แล้ว ฝ่ายเราทอยเหรียญ 1 ครั้ง ถ้าออกหัว จะทำให้โปเกมอนที่ใช้ท่าต่อสู้[หมดสภาพ]",
-			id: "Saat Pokémon ini ada di Arena Bertarung dan KO karena menerima kerusakan akibat serangan dari Pokémon lawan, pemain melempar koin 1 kali. Jika hasilnya sisi depan, Pokémon yang telah menggunakan serangan KO."
-		}
-	}],
-
-	attacks: [{
-		cost: ["Colorless", "Colorless"],
-
-		name: {
-			ja: "スピンガス",
-			'zh-tw': "旋轉瓦斯",
-			th: "สปินก๊าซ",
-			id: "Spin Gas"
+	attacks: [
+		{
+			name: {
+				ja: "スピンガス",
+				'zh-tw': "旋轉瓦斯",
+				th: "สปินก๊าซ",
+				id: "Spin Gas",
+			},
+			damage: 50,
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "相手のベンチポケモン全員にも、それぞれ10ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+				'zh-tw': "對手的所有備戰寶可夢也各受到10點傷害。 [在備戰區不計算弱點・抵抗力。]",
+				th: "โปเกมอนบนเบนช์ฝ่ายตรงข้ามทุกตัว ก็จะได้รับแดเมจตัวละ 10 ด้วย {โปเกมอนบนเบนช์จะไม่นำจุดอ่อนและความต้านทานมาคิด}",
+				id: "Serangan ini juga memberikan kerusakan masing-masing sejumlah 10 kepada semua Pokémon Cadangan lawan. [Kelemahan dan Resistansi Pokémon Cadangan tidak mempengaruhi jumlah kerusakan.]",
+			},
 		},
+	],
 
-		damage: 50,
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
 
-		effect: {
-			ja: "相手のベンチポケモン全員にも、それぞれ10ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
-			'zh-tw': "對手的所有備戰寶可夢也各受到10點傷害。 [在備戰區不計算弱點・抵抗力。]",
-			th: "โปเกมอนบนเบนช์ฝ่ายตรงข้ามทุกตัว ก็จะได้รับแดเมจตัวละ 10 ด้วย {โปเกมอนบนเบนช์จะไม่นำจุดอ่อนและความต้านทานมาคิด}",
-			id: "Serangan ini juga memberikan kerusakan masing-masing sejumlah 10 kepada semua Pokémon Cadangan lawan. [Kelemahan dan Resistansi Pokémon Cadangan tidak mempengaruhi jumlah kerusakan.]"
-		}
-	}],
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 719563,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				cardmarket: 837448,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				cardmarket: 837449,
+			},
+		},
+	],
 
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "ドガース",
+	},
 
 	retreat: 2,
 	regulationMark: "G",
+	rarity: "Rare",
+	dexId: [110],
+};
 
-	thirdParty: {
-		cardmarket: 719563
-	}
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV2a/111.ts
+++ b/data-asia/SV/SV2a/111.ts
@@ -1,20 +1,17 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV2a"
+import { Card } from "../../../interfaces";
+import Set from "../SV2a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "サイホーン",
 		'zh-tw': "獨角犀牛",
 		th: "ไซฮอร์น",
-		id: "Rhyhorn"
+		id: "Rhyhorn",
 	},
 
 	illustrator: "GOSSAN",
-	rarity: "Common",
 	category: "Pokemon",
-	dexId: [111],
 	hp: 100,
 	types: ["Fighting"],
 
@@ -22,53 +19,70 @@ const card: Card = {
 		ja: "ひとつの ことしか 覚えられない。 突進を はじめると 理由は どうでもよくなり すぐに 忘れる。",
 		'zh-tw': "腦子裡只能記住一件事。一旦開始猛衝，不管理由是什麼 都會很快感到無所謂而忘掉。",
 		th: "มันจำได้เพียงแค่ครั้งละเรื่อง พอเริ่มพุ่งพรวดพราดเข้าไป มันจะลืมทันทีว่าทำไปทำไม",
-		id: "Rhyhorn hanya dapat mengingat satu hal. Begitu mulai menyeruduk, alasan menyeruduk jadi tidak penting baginya dan segera terlupakan."
+		id: "Rhyhorn hanya dapat mengingat satu hal. Begitu mulai menyeruduk, alasan menyeruduk jadi tidak penting baginya dan segera terlupakan.",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		cost: ["Fighting", "Colorless"],
-
-		name: {
-			ja: "つきとばす",
-			'zh-tw': "推倒",
-			th: "ชนกระเด็น",
-			id: "Mendorong Kuat"
+	attacks: [
+		{
+			name: {
+				ja: "つきとばす",
+				'zh-tw': "推倒",
+				th: "ชนกระเด็น",
+				id: "Mendorong Kuat",
+			},
+			damage: 20,
+			cost: ["Fighting", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをベンチポケモンと入れ替える。［バトル場に出すポケモンは相手が選ぶ。］",
+				'zh-tw': "將對手的戰鬥寶可夢與備戰寶可夢互換。[由對手選擇放置於戰鬥場的寶可夢。]",
+				th: "สลับโปเกมอนบนตำแหน่งต่อสู้ฝ่ายตรงข้ามกับโปเกมอนบนเบนช์ {ฝ่ายตรงข้ามเลือกโปเกมอนที่จะวางบนตำแหน่งต่อสู้}",
+				id: "Tukar Pokémon Bertarung lawan dengan Pokémon Cadangan. [Pokémon yang akan dimasukkan ke Arena Bertarung dipilih oleh lawan.]",
+			},
 		},
-
-		damage: 20,
-
-		effect: {
-			ja: "相手のバトルポケモンをベンチポケモンと入れ替える。［バトル場に出すポケモンは相手が選ぶ。］",
-			'zh-tw': "將對手的戰鬥寶可夢與備戰寶可夢互換。[由對手選擇放置於戰鬥場的寶可夢。]",
-			th: "สลับโปเกมอนบนตำแหน่งต่อสู้ฝ่ายตรงข้ามกับโปเกมอนบนเบนช์ {ฝ่ายตรงข้ามเลือกโปเกมอนที่จะวางบนตำแหน่งต่อสู้}",
-			id: "Tukar Pokémon Bertarung lawan dengan Pokémon Cadangan. [Pokémon yang akan dimasukkan ke Arena Bertarung dipilih oleh lawan.]"
-		}
-	}, {
-		cost: ["Fighting", "Fighting", "Colorless"],
-
-		name: {
-			ja: "ロックスマッシュ",
-			'zh-tw': "岩石粉碎",
-			th: "ร็อคสแมช",
-			id: "Rock Smash"
+		{
+			name: {
+				ja: "ロックスマッシュ",
+				'zh-tw': "岩石粉碎",
+				th: "ร็อคสแมช",
+				id: "Rock Smash",
+			},
+			damage: 70,
+			cost: ["Fighting", "Fighting", "Colorless"],
 		},
+	],
 
-		damage: 70
-	}],
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Grass",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 719564,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				cardmarket: 837450,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				cardmarket: 837451,
+			},
+		},
+	],
 
 	retreat: 3,
 	regulationMark: "G",
+	rarity: "Common",
+	dexId: [111],
+};
 
-	thirdParty: {
-		cardmarket: 719564
-	}
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV2a/112.ts
+++ b/data-asia/SV/SV2a/112.ts
@@ -1,20 +1,17 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV2a"
+import { Card } from "../../../interfaces";
+import Set from "../SV2a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "サイドン",
 		'zh-tw': "鑽角犀獸",
 		th: "ไซดอน",
-		id: "Rhydon"
+		id: "Rhydon",
 	},
 
 	illustrator: "GOSSAN",
-	rarity: "Uncommon",
 	category: "Pokemon",
-	dexId: [112],
 	hp: 120,
 	types: ["Fighting"],
 
@@ -22,53 +19,74 @@ const card: Card = {
 		ja: "全身を よろいのような 皮膚で 守っている。 ２０００度の マグマの 中でも 生きられる。",
 		'zh-tw': "全身被鎧甲般的皮膚保護著。甚至能在 ２０００度的熔岩中生存。",
 		th: "ปกป้องทั้งร่างกายด้วยผิวหนังที่เหมือนเกราะหุ้ม สามารถมีชีวิตอยู่ได้แม้จะอยู่ในแมกมาอุณหภูมิ 2000 องศา",
-		id: "Seluruh tubuh Rhydon dilindungi oleh kulit yang menyerupai zirah. Dia dapat tetap hidup meskipun berada dalam magma bersuhu 2000 °C."
+		id: "Seluruh tubuh Rhydon dilindungi oleh kulit yang menyerupai zirah. Dia dapat tetap hidup meskipun berada dalam magma bersuhu 2000 °C.",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		cost: ["Fighting", "Colorless"],
-
-		name: {
-			ja: "たたきつぶす",
-			'zh-tw': "砸碎",
-			th: "ทุบแหลก",
-			id: "Pukul Hancur"
+	attacks: [
+		{
+			name: {
+				ja: "たたきつぶす",
+				'zh-tw': "砸碎",
+				th: "ทุบแหลก",
+				id: "Pukul Hancur",
+			},
+			damage: 30,
+			cost: ["Fighting", "Colorless"],
 		},
-
-		damage: 30
-	}, {
-		cost: ["Fighting", "Fighting", "Colorless"],
-
-		name: {
-			ja: "カリスマドリル",
-			'zh-tw': "領導力鑽",
-			th: "สว่านทรงเสน่ห์",
-			id: "Charisma Drill"
+		{
+			name: {
+				ja: "カリスマドリル",
+				'zh-tw': "領導力鑽",
+				th: "สว่านทรงเสน่ห์",
+				id: "Charisma Drill",
+			},
+			damage: "40+",
+			cost: ["Fighting", "Fighting", "Colorless"],
+			effect: {
+				ja: "この番、手札から「サカキのカリスマ」を出して使っていたなら、140ダメージ追加。",
+				'zh-tw': "在這個回合，若從手牌使出了「坂木的領導力」，則增加140點傷害。",
+				th: "เทิร์นนี้ ถ้านำการ์ด [เสน่ห์ของซากากิ] จากบนมือออกมาใช้แล้ว การโจมตีนี้จะเพิ่มแดเมจอีก 140",
+				id: "Jika pada giliran ini, Karisma Giovanni telah dimainkan dari Kartu Pegangan, kerusakan yang diberikan bertambah sejumlah 140.",
+			},
 		},
+	],
 
-		damage: "40+",
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
 
-		effect: {
-			ja: "この番、手札から「サカキのカリスマ」を出して使っていたなら、140ダメージ追加。",
-			'zh-tw': "在這個回合，若從手牌使出了「坂木的領導力」，則增加140點傷害。",
-			th: "เทิร์นนี้ ถ้านำการ์ด [เสน่ห์ของซากากิ] จากบนมือออกมาใช้แล้ว การโจมตีนี้จะเพิ่มแดเมจอีก 140",
-			id: "Jika pada giliran ini, Karisma Giovanni telah dimainkan dari Kartu Pegangan, kerusakan yang diberikan bertambah sejumlah 140."
-		}
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 719565,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				cardmarket: 837452,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				cardmarket: 837453,
+			},
+		},
+	],
 
-	weaknesses: [{
-		type: "Grass",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "サイホーン",
+	},
 
 	retreat: 4,
 	regulationMark: "G",
+	rarity: "Uncommon",
+	dexId: [112],
+};
 
-	thirdParty: {
-		cardmarket: 719565
-	}
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV2a/113.ts
+++ b/data-asia/SV/SV2a/113.ts
@@ -1,20 +1,17 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV2a"
+import { Card } from "../../../interfaces";
+import Set from "../SV2a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "ラッキー",
 		'zh-tw': "吉利蛋",
 		th: "ลัคกี",
-		id: "Chansey"
+		id: "Chansey",
 	},
 
 	illustrator: "Taiga Kayama",
-	rarity: "Rare",
 	category: "Pokemon",
-	dexId: [113],
 	hp: 110,
 	types: ["Colorless"],
 
@@ -22,53 +19,72 @@ const card: Card = {
 		ja: "傷ついた ポケモンや 人がいると 栄養満点の タマゴを産み 分け与える 優しい ポケモン。",
 		'zh-tw': "心地很善良的寶可夢，會生出營養滿分的蛋 分給受傷的寶可夢和人類。",
 		th: "เป็นโปเกมอนที่จิตใจอ่อนโยน พอเจอโปเกมอนหรือคนที่บาดเจ็บจะออกไข่ที่มีคุณค่าทางโภชนาการเพียบพร้อมและแบ่งให้ทาน",
-		id: "Chansey adalah Pokémon baik hati yang mengeluarkan telur penuh nutrisi dan membagikannya kepada Pokémon dan manusia yang terluka."
+		id: "Chansey adalah Pokémon baik hati yang mengeluarkan telur penuh nutrisi dan membagikannya kepada Pokémon dan manusia yang terluka.",
 	},
 
 	stage: "Basic",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			ja: "ラッキーボーナス",
-			'zh-tw': "幸運紅利",
-			th: "ลัคกีโบนัส",
-			id: "Lucky Bonus"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "ラッキーボーナス",
+				'zh-tw': "幸運紅利",
+				th: "ลัคกีโบนัส",
+				id: "Lucky Bonus",
+			},
+			effect: {
+				ja: "自分の番に、ウラになっている自分のサイドからこのカードをとったとき、自分のベンチに空きがあるなら、手札に加える前に使える。このポケモンを自分のベンチに出す。その後、コインを1回投げオモテなら、さらにサイドを1枚とる。",
+				'zh-tw': "在自己的回合，從自己的反面朝上的獎賞卡中獲得這張卡時，若自己的備戰區有空位，則可在加入手牌前使用。將這隻寶可夢放置於自己的備戰區。然後，擲1次硬幣若為正面，則再獲得1張獎賞卡。",
+				th: "ในเทิร์นฝ่ายเรา เมื่อหยิบการ์ดนี้จากการ์ดรางวัลฝ่ายเราที่คว่ำอยู่ ถ้าบนเบนช์ฝ่ายเรามีที่ว่าง จะใช้ได้ก่อนนำขึ้นมือ วางโปเกมอนนี้บนเบนช์ฝ่ายเรา หลังจากนั้น ทอยเหรียญ 1 ครั้งถ้าออกหัว จะหยิบการ์ดรางวัลเพิ่มได้ 1 ใบ",
+				id: "Pada giliran sendiri, jika Cadangan sendiri tidak penuh saat mengambil kartu ini dari Kartu Point sendiri yang sisi depannya menghadap ke bawah, sebelum ditambahkan ke Kartu Pegangan, Ability ini dapat digunakan. Masukkan Pokémon ini ke Cadangan sendiri. Setelah itu, lempar koin 1 kali. Jika hasilnya sisi depan, ambil lagi 1 lembar Kartu Point tambahan.",
+			},
 		},
+	],
 
-		effect: {
-			ja: "自分の番に、ウラになっている自分のサイドからこのカードをとったとき、自分のベンチに空きがあるなら、手札に加える前に使える。このポケモンを自分のベンチに出す。その後、コインを1回投げオモテなら、さらにサイドを1枚とる。",
-			'zh-tw': "在自己的回合，從自己的反面朝上的獎賞卡中獲得這張卡時，若自己的備戰區有空位，則可在加入手牌前使用。將這隻寶可夢放置於自己的備戰區。然後，擲1次硬幣若為正面，則再獲得1張獎賞卡。",
-			th: "ในเทิร์นฝ่ายเรา เมื่อหยิบการ์ดนี้จากการ์ดรางวัลฝ่ายเราที่คว่ำอยู่ ถ้าบนเบนช์ฝ่ายเรามีที่ว่าง จะใช้ได้ก่อนนำขึ้นมือ วางโปเกมอนนี้บนเบนช์ฝ่ายเรา หลังจากนั้น ทอยเหรียญ 1 ครั้งถ้าออกหัว จะหยิบการ์ดรางวัลเพิ่มได้ 1 ใบ",
-			id: "Pada giliran sendiri, jika Cadangan sendiri tidak penuh saat mengambil kartu ini dari Kartu Point sendiri yang sisi depannya menghadap ke bawah, sebelum ditambahkan ke Kartu Pegangan, Ability ini dapat digunakan. Masukkan Pokémon ini ke Cadangan sendiri. Setelah itu, lempar koin 1 kali. Jika hasilnya sisi depan, ambil lagi 1 lembar Kartu Point tambahan."
-		}
-	}],
-
-	attacks: [{
-		cost: ["Colorless", "Colorless", "Colorless"],
-
-		name: {
-			ja: "ひっぱたく",
-			'zh-tw': "重摑",
-			th: "ตบแรง",
-			id: "Menepuk"
+	attacks: [
+		{
+			name: {
+				ja: "ひっぱたく",
+				'zh-tw': "重摑",
+				th: "ตบแรง",
+				id: "Menepuk",
+			},
+			damage: 70,
+			cost: ["Colorless", "Colorless", "Colorless"],
 		},
+	],
 
-		damage: 70
-	}],
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 719566,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				cardmarket: 837454,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				cardmarket: 837455,
+			},
+		},
+	],
 
 	retreat: 2,
 	regulationMark: "G",
+	rarity: "Rare",
+	dexId: [113],
+};
 
-	thirdParty: {
-		cardmarket: 719566
-	}
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV2a/114.ts
+++ b/data-asia/SV/SV2a/114.ts
@@ -1,20 +1,17 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV2a"
+import { Card } from "../../../interfaces";
+import Set from "../SV2a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "モンジャラ",
 		'zh-tw': "蔓藤怪",
 		th: "มอนจารา",
-		id: "Tangela"
+		id: "Tangela",
 	},
 
 	illustrator: "Aya Kusube",
-	rarity: "Common",
 	category: "Pokemon",
-	dexId: [114],
 	hp: 80,
 	types: ["Grass"],
 
@@ -22,42 +19,60 @@ const card: Card = {
 		ja: "ちぎれても 無限に 伸びる ツルの 奥の 正体は いまだ 解明されていない。",
 		'zh-tw': "藤蔓即使斷了也會繼續無限地生長。藤蔓下的 真面目至今仍是個謎。",
 		th: "แม้เถาวัลย์จะขาดก็ยืดยาวออกมาได้ไม่มีที่สิ้นสุด ตัวตนลึก ๆ ที่แท้จริงของมัน จนทุกวันนี้ก็ยังพิสูจน์ไม่ได้",
-		id: "Hingga saat ini, wujud asli Tangela di balik jalar yang terus tumbuh tanpa batas walau dicabut ini masih belum terungkap."
+		id: "Hingga saat ini, wujud asli Tangela di balik jalar yang terus tumbuh tanpa batas walau dicabut ini masih belum terungkap.",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		cost: ["Grass"],
-
-		name: {
-			ja: "まきつきさほう",
-			'zh-tw': "緊束作法",
-			th: "วิธีการพันเลื้อย",
-			id: "Etiket Membelit"
+	attacks: [
+		{
+			name: {
+				ja: "まきつきさほう",
+				'zh-tw': "緊束作法",
+				th: "วิธีการพันเลื้อย",
+				id: "Etiket Membelit",
+			},
+			damage: "10+",
+			cost: ["Grass"],
+			effect: {
+				ja: "この番、手札から「エリカの招待」を出して使っていたなら、60ダメージ追加。",
+				'zh-tw': "在這個回合，若從手牌使出了「莉佳的招待」，則增加60點傷害。",
+				th: "เทิร์นนี้ ถ้านำการ์ด [คำเชิญของเอริกะ] จากบนมือออกมาใช้แล้ว การโจมตีนี้จะเพิ่มแดเมจอีก 60",
+				id: "Jika pada giliran ini, Undangan Erika telah dimainkan dari Kartu Pegangan, kerusakan yang diberikan bertambah sejumlah 60.",
+			},
 		},
+	],
 
-		damage: "10+",
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
 
-		effect: {
-			ja: "この番、手札から「エリカの招待」を出して使っていたなら、60ダメージ追加。",
-			'zh-tw': "在這個回合，若從手牌使出了「莉佳的招待」，則增加60點傷害。",
-			th: "เทิร์นนี้ ถ้านำการ์ด [คำเชิญของเอริกะ] จากบนมือออกมาใช้แล้ว การโจมตีนี้จะเพิ่มแดเมจอีก 60",
-			id: "Jika pada giliran ini, Undangan Erika telah dimainkan dari Kartu Pegangan, kerusakan yang diberikan bertambah sejumlah 60."
-		}
-	}],
-
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 719567,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				cardmarket: 837456,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				cardmarket: 837457,
+			},
+		},
+	],
 
 	retreat: 2,
 	regulationMark: "G",
+	rarity: "Common",
+	dexId: [114],
+};
 
-	thirdParty: {
-		cardmarket: 719567
-	}
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV2a/115.ts
+++ b/data-asia/SV/SV2a/115.ts
@@ -1,71 +1,74 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV2a"
+import { Card } from "../../../interfaces";
+import Set from "../SV2a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "ガルーラex",
 		'zh-tw': "袋獸ex",
 		th: "การูราex",
-		id: "Kangaskhan ex"
+		id: "Kangaskhan ex",
 	},
 
 	illustrator: "N-DESIGN Inc.",
-	rarity: "Double rare",
 	category: "Pokemon",
 	hp: 230,
 	types: ["Colorless"],
+
 	stage: "Basic",
-	suffix: "EX",
 
-	attacks: [{
-		cost: ["Colorless"],
-
-		name: {
-			ja: "トリプルドロー",
-			'zh-tw': "三重抽出",
-			th: "ทริปเปิ้ลดรอว์",
-			id: "Triple Draw"
+	attacks: [
+		{
+			name: {
+				ja: "トリプルドロー",
+				'zh-tw': "三重抽出",
+				th: "ทริปเปิ้ลดรอว์",
+				id: "Triple Draw",
+			},
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札を3枚引く。",
+				'zh-tw': "從自己的牌庫抽出3張卡。",
+				th: "จั่วการ์ด 3 ใบจากสำรับการ์ดฝ่ายเรา",
+				id: "Ambil 3 kartu dari atas Deck sendiri.",
+			},
 		},
-
-		effect: {
-			ja: "自分の山札を3枚引く。",
-			'zh-tw': "從自己的牌庫抽出3張卡。",
-			th: "จั่วการ์ด 3 ใบจากสำรับการ์ดฝ่ายเรา",
-			id: "Ambil 3 kartu dari atas Deck sendiri."
-		}
-	}, {
-		cost: ["Colorless", "Colorless", "Colorless"],
-
-		name: {
-			ja: "マシンガンパンチ",
-			'zh-tw': "機關槍拳",
-			th: "แมชชีนกันพันช์",
-			id: "Machinegun Punch"
+		{
+			name: {
+				ja: "マシンガンパンチ",
+				'zh-tw': "機關槍拳",
+				th: "แมชชีนกันพันช์",
+				id: "Machinegun Punch",
+			},
+			damage: "100×",
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "コインを4回投げ、オモテの数×100ダメージ。",
+				'zh-tw': "擲4次硬幣，造成正面出現的次數×100點傷害。",
+				th: "ทอยเหรียญ 4 ครั้ง แดเมจจะเท่ากับจำนวนครั้งที่ออกหัว x100",
+				id: "Lempar koin 4 kali. Serangan ini memberikan kerusakan sejumlah 100 untuk tiap lemparan dengan hasil sisi depan.",
+			},
 		},
+	],
 
-		damage: "100×",
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
 
-		effect: {
-			ja: "コインを4回投げ、オモテの数×100ダメージ。",
-			'zh-tw': "擲4次硬幣，造成正面出現的次數×100點傷害。",
-			th: "ทอยเหรียญ 4 ครั้ง แดเมจจะเท่ากับจำนวนครั้งที่ออกหัว x100",
-			id: "Lempar koin 4 kali. Serangan ini memberikan kerusakan sejumlah 100 untuk tiap lemparan dengan hasil sisi depan."
-		}
-	}],
-
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 719568,
+			},
+		},
+	],
 
 	retreat: 2,
 	regulationMark: "G",
+	rarity: "Double rare",
+	dexId: [115],
 
-	thirdParty: {
-		cardmarket: 719568
-	}
-}
+	suffix: "EX",
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV2a/116.ts
+++ b/data-asia/SV/SV2a/116.ts
@@ -1,20 +1,17 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV2a"
+import { Card } from "../../../interfaces";
+import Set from "../SV2a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "タッツー",
 		'zh-tw': "墨海馬",
 		th: "ทัททู",
-		id: "Horsea"
+		id: "Horsea",
 	},
 
 	illustrator: "aspara",
-	rarity: "Common",
 	category: "Pokemon",
-	dexId: [116],
 	hp: 60,
 	types: ["Water"],
 
@@ -22,46 +19,64 @@ const card: Card = {
 		ja: "水中を 踊るように 泳いで 渦を つくる。 仲間と 渦の 大きさを 競って 遊ぶ。",
 		'zh-tw': "會在水中跳舞似地游動來製造漩渦。玩耍時會和夥伴 比賽誰做出的漩渦比較大。",
 		th: "ว่ายน้ำราวกับเต้นระบำอยู่ในน้ำทำให้เกิดน้ำวน จะแข่งกับพวกพ้องสร้างน้ำวนขนาดใหญ่เล่นกัน",
-		id: "Horsea berenang bagaikan menari di dalam air dan membuat pusaran. Mereka bermain dengan bertanding siapa yang membuat pusaran paling besar."
+		id: "Horsea berenang bagaikan menari di dalam air dan membuat pusaran. Mereka bermain dengan bertanding siapa yang membuat pusaran paling besar.",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		cost: ["Water"],
-
-		name: {
-			ja: "みずかけ",
-			'zh-tw': "潑水",
-			th: "สาดน้ำ",
-			id: "Guyuran Air"
+	attacks: [
+		{
+			name: {
+				ja: "みずかけ",
+				'zh-tw': "潑水",
+				th: "สาดน้ำ",
+				id: "Guyuran Air",
+			},
+			damage: 10,
+			cost: ["Water"],
 		},
-
-		damage: 10
-	}, {
-		cost: ["Water", "Colorless", "Colorless"],
-
-		name: {
-			ja: "するどいひれ",
-			'zh-tw': "銳利鰭",
-			th: "ครีบแหลมคม",
-			id: "Sirip Tajam"
+		{
+			name: {
+				ja: "するどいひれ",
+				'zh-tw': "銳利鰭",
+				th: "ครีบแหลมคม",
+				id: "Sirip Tajam",
+			},
+			damage: 40,
+			cost: ["Water", "Colorless", "Colorless"],
 		},
+	],
 
-		damage: 40
-	}],
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Lightning",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 719569,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				cardmarket: 837458,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				cardmarket: 837459,
+			},
+		},
+	],
 
 	retreat: 1,
 	regulationMark: "G",
+	rarity: "Common",
+	dexId: [116],
+};
 
-	thirdParty: {
-		cardmarket: 719569
-	}
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV2a/117.ts
+++ b/data-asia/SV/SV2a/117.ts
@@ -1,20 +1,17 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV2a"
+import { Card } from "../../../interfaces";
+import Set from "../SV2a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "シードラ",
 		'zh-tw': "海刺龍",
 		th: "ซีดรา",
-		id: "Seadra"
+		id: "Seadra",
 	},
 
 	illustrator: "aspara",
-	rarity: "Uncommon",
 	category: "Pokemon",
-	dexId: [117],
 	hp: 80,
 	types: ["Water"],
 
@@ -22,42 +19,64 @@ const card: Card = {
 		ja: "細い 口だが 吸引力は 強い。 口より 大きな エサも 一瞬で 吸いこみ 食べるぞ。",
 		'zh-tw': "嘴部雖然細，但吸力卻很強。就算是比嘴還要大的食物， 也都能瞬間吸進口裡吃掉。",
 		th: "ถึงแม้ปากจะเรียวเล็กแต่มีพลังดูดสูง ไม่ว่าจะเป็นเหยื่อที่มีขนาดใหญ่กว่าปากของตนก็สามารถดูดเข้าไปกินได้ภายในชั่วพริบตา",
-		id: "Mulut Seadra kecil, tapi kekuatan isapnya besar. Pokémon ini dalam sekejap dapat mengisap dan memakan makanan yang lebih besar dari ukuran mulutnya."
+		id: "Mulut Seadra kecil, tapi kekuatan isapnya besar. Pokémon ini dalam sekejap dapat mengisap dan memakan makanan yang lebih besar dari ukuran mulutnya.",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		cost: ["Water", "Colorless", "Colorless"],
-
-		name: {
-			ja: "ブラインドインク",
-			'zh-tw': "盲目塗墨",
-			th: "ไบลด์อิงค์",
-			id: "Blind Ink"
+	attacks: [
+		{
+			name: {
+				ja: "ブラインドインク",
+				'zh-tw': "盲目塗墨",
+				th: "ไบลด์อิงค์",
+				id: "Blind Ink",
+			},
+			damage: 50,
+			cost: ["Water", "Colorless", "Colorless"],
+			effect: {
+				ja: "次の相手の番、このワザを受けたポケモンがワザを使うとき、相手はコインを2回投げる。1回でもウラなら、そのワザは失敗。",
+				'zh-tw': "在下個對手的回合，受到這個招式的寶可夢使用招式時，對手擲2次硬幣。只要出現1次反面，則那個招式失敗。",
+				th: "เทิร์นถัดไปของฝ่ายตรงข้าม เมื่อโปเกมอนที่ได้รับท่าต่อสู้นี้จะใช้ท่าต่อสู้ ฝ่ายตรงข้ามทอยเหรียญ 2 ครั้ง ถ้าออกก้อยแม้แต่ 1 ครั้ง ท่าต่อสู้นั้นจะล้มเหลว",
+				id: "Pada giliran lawan berikutnya, saat Pokémon yang menerima serangan ini menggunakan serangan, lawan melempar koin 2 kali. Jika salah satu hasilnya sisi belakang, serangan tersebut gagal.",
+			},
 		},
+	],
 
-		damage: 50,
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
 
-		effect: {
-			ja: "次の相手の番、このワザを受けたポケモンがワザを使うとき、相手はコインを2回投げる。1回でもウラなら、そのワザは失敗。",
-			'zh-tw': "在下個對手的回合，受到這個招式的寶可夢使用招式時，對手擲2次硬幣。只要出現1次反面，則那個招式失敗。",
-			th: "เทิร์นถัดไปของฝ่ายตรงข้าม เมื่อโปเกมอนที่ได้รับท่าต่อสู้นี้จะใช้ท่าต่อสู้ ฝ่ายตรงข้ามทอยเหรียญ 2 ครั้ง ถ้าออกก้อยแม้แต่ 1 ครั้ง ท่าต่อสู้นั้นจะล้มเหลว",
-			id: "Pada giliran lawan berikutnya, saat Pokémon yang menerima serangan ini menggunakan serangan, lawan melempar koin 2 kali. Jika salah satu hasilnya sisi belakang, serangan tersebut gagal."
-		}
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 719570,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				cardmarket: 837460,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				cardmarket: 837461,
+			},
+		},
+	],
 
-	weaknesses: [{
-		type: "Lightning",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "タッツー",
+	},
 
 	retreat: 1,
 	regulationMark: "G",
+	rarity: "Uncommon",
+	dexId: [117],
+};
 
-	thirdParty: {
-		cardmarket: 719570
-	}
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV2a/118.ts
+++ b/data-asia/SV/SV2a/118.ts
@@ -1,20 +1,17 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV2a"
+import { Card } from "../../../interfaces";
+import Set from "../SV2a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "トサキント",
 		'zh-tw': "角金魚",
 		th: "โทซาคินโตะ",
-		id: "Goldeen"
+		id: "Goldeen",
 	},
 
 	illustrator: "SIE NANAHARA",
-	rarity: "Common",
 	category: "Pokemon",
-	dexId: [118],
 	hp: 70,
 	types: ["Water"],
 
@@ -22,53 +19,70 @@ const card: Card = {
 		ja: "背びれ 胸びれが 筋肉のように 発達しており 水中を ５ノットの 速さで 泳ぐ。",
 		'zh-tw': "背鰭和尾鰭像肌肉那樣發達。能夠以 ５節的速度在水中游泳。",
 		th: "ครีบหลังและครีบอกเจริญเติบโตราวกับกล้ามเนื้อ ว่ายน้ำด้วยความเร็ว 5 นอต",
-		id: "Sirip punggung dan sirip dada Goldeen tumbuh bak otot, sehingga dia bisa berenang dengan kecepatan 5 knot di dalam air."
+		id: "Sirip punggung dan sirip dada Goldeen tumbuh bak otot, sehingga dia bisa berenang dengan kecepatan 5 knot di dalam air.",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		cost: ["Water"],
-
-		name: {
-			ja: "さんれんづき",
-			'zh-tw': "三連撞",
-			th: "พุ่งชนสามครั้ง",
-			id: "Tusukan Tiga Kali"
+	attacks: [
+		{
+			name: {
+				ja: "さんれんづき",
+				'zh-tw': "三連撞",
+				th: "พุ่งชนสามครั้ง",
+				id: "Tusukan Tiga Kali",
+			},
+			damage: "10×",
+			cost: ["Water"],
+			effect: {
+				ja: "コインを3回投げ、オモテの数×10ダメージ。",
+				'zh-tw': "擲3次硬幣，造成正面出現的次數×10點傷害。",
+				th: "ทอยเหรียญ 3 ครั้ง แดเมจจะเท่ากับจำนวนครั้งที่ออกหัว x10",
+				id: "Lempar koin 3 kali. Serangan ini memberikan kerusakan sejumlah 10 untuk tiap lemparan dengan hasil sisi depan.",
+			},
 		},
-
-		damage: "10×",
-
-		effect: {
-			ja: "コインを3回投げ、オモテの数×10ダメージ。",
-			'zh-tw': "擲3次硬幣，造成正面出現的次數×10點傷害。",
-			th: "ทอยเหรียญ 3 ครั้ง แดเมจจะเท่ากับจำนวนครั้งที่ออกหัว x10",
-			id: "Lempar koin 3 kali. Serangan ini memberikan kerusakan sejumlah 10 untuk tiap lemparan dengan hasil sisi depan."
-		}
-	}, {
-		cost: ["Colorless", "Colorless"],
-
-		name: {
-			ja: "うちみず",
-			'zh-tw': "潑灑清水",
-			th: "ราดน้ำ",
-			id: "Percikan Air"
+		{
+			name: {
+				ja: "うちみず",
+				'zh-tw': "潑灑清水",
+				th: "ราดน้ำ",
+				id: "Percikan Air",
+			},
+			damage: 20,
+			cost: ["Colorless", "Colorless"],
 		},
+	],
 
-		damage: 20
-	}],
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Lightning",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 719571,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				cardmarket: 837462,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				cardmarket: 837463,
+			},
+		},
+	],
 
 	retreat: 1,
 	regulationMark: "G",
+	rarity: "Common",
+	dexId: [118],
+};
 
-	thirdParty: {
-		cardmarket: 719571
-	}
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV2a/119.ts
+++ b/data-asia/SV/SV2a/119.ts
@@ -1,20 +1,17 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV2a"
+import { Card } from "../../../interfaces";
+import Set from "../SV2a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "アズマオウ",
 		'zh-tw': "金魚王",
 		th: "อซึมาโอ",
-		id: "Seaking"
+		id: "Seaking",
 	},
 
 	illustrator: "SIE NANAHARA",
-	rarity: "Uncommon",
 	category: "Pokemon",
-	dexId: [119],
 	hp: 110,
 	types: ["Water"],
 
@@ -22,60 +19,80 @@ const card: Card = {
 		ja: "ツノで 川底の 岩を くりぬき 巣をつくるのは 産みつけた タマゴが 流されないように するためだ。",
 		'zh-tw': "金魚王之所以會用角挖穿河底的岩石來築巢，是為了 防止產下的卵被水流沖走。",
 		th: "ใช้เขาคว้านรูหินที่ก้นแม่น้ำสร้างรังเพื่อเก็บไข่ที่เพิ่งฟักออกมาไม่ให้ถูกน้ำพัด",
-		id: "Seaking membuat sarang dengan melubangi batu karang di dasar sungai menggunakan tanduknya agar setelah bertelur, telur tersebut tidak akan hanyut terbawa arus."
+		id: "Seaking membuat sarang dengan melubangi batu karang di dasar sungai menggunakan tanduknya agar setelah bertelur, telur tersebut tidak akan hanyut terbawa arus.",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		cost: ["Water"],
-
-		name: {
-			ja: "きままにおよぐ",
-			'zh-tw': "隨興游水",
-			th: "ว่ายตามใจชอบ",
-			id: "Berenang Seenaknya"
+	attacks: [
+		{
+			name: {
+				ja: "きままにおよぐ",
+				'zh-tw': "隨興游水",
+				th: "ว่ายตามใจชอบ",
+				id: "Berenang Seenaknya",
+			},
+			damage: 10,
+			cost: ["Water"],
+			effect: {
+				ja: "コインを1回投げオモテなら、次の相手の番、このポケモンはワザのダメージや効果を受けない。",
+				'zh-tw': "擲1次硬幣若為正面，則在下個對手的回合，這隻寶可夢不會受到招式的傷害與效果的影響。",
+				th: "ทอยเหรียญ 1 ครั้งถ้าออกหัว เทิร์นถัดไปของฝ่ายตรงข้าม โปเกมอนนี้จะไม่ได้รับแดเมจและเอฟเฟกต์ของท่าต่อสู้",
+				id: "Lempar koin 1 kali. Jika hasilnya sisi depan, pada giliran lawan berikutnya, Pokémon ini tidak menerima kerusakan dan efek akibat serangan.",
+			},
 		},
-
-		damage: 10,
-
-		effect: {
-			ja: "コインを1回投げオモテなら、次の相手の番、このポケモンはワザのダメージや効果を受けない。",
-			'zh-tw': "擲1次硬幣若為正面，則在下個對手的回合，這隻寶可夢不會受到招式的傷害與效果的影響。",
-			th: "ทอยเหรียญ 1 ครั้งถ้าออกหัว เทิร์นถัดไปของฝ่ายตรงข้าม โปเกมอนนี้จะไม่ได้รับแดเมจและเอฟเฟกต์ของท่าต่อสู้",
-			id: "Lempar koin 1 kali. Jika hasilnya sisi depan, pada giliran lawan berikutnya, Pokémon ini tidak menerima kerusakan dan efek akibat serangan."
-		}
-	}, {
-		cost: ["Colorless", "Colorless", "Colorless"],
-
-		name: {
-			ja: "アクアホーン",
-			'zh-tw': "水之角擊",
-			th: "อควาฮอร์น",
-			id: "Aqua Horn"
+		{
+			name: {
+				ja: "アクアホーン",
+				'zh-tw': "水之角擊",
+				th: "อควาฮอร์น",
+				id: "Aqua Horn",
+			},
+			damage: "60+",
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンについている[W]エネルギーの数×30ダメージ追加。",
+				'zh-tw': "增加這隻寶可夢身上附加的【水】能量的數量×30點傷害。",
+				th: "แดเมจจะเพิ่มตามจำนวนพลังงาน[น้ำ]ที่ติดอยู่กับโปเกมอนนี้ x30",
+				id: "Kerusakan yang diberikan bertambah sejumlah 30 untuk tiap Energi {Air} yang dikenakan pada Pokémon ini.",
+			},
 		},
+	],
 
-		damage: "60+",
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
 
-		effect: {
-			ja: "このポケモンについているエネルギーの数×30ダメージ追加。",
-			'zh-tw': "增加這隻寶可夢身上附加的【水】能量的數量×30點傷害。",
-			th: "แดเมจจะเพิ่มตามจำนวนพลังงาน[น้ำ]ที่ติดอยู่กับโปเกมอนนี้ x30",
-			id: "Kerusakan yang diberikan bertambah sejumlah 30 untuk tiap Energi {Air} yang dikenakan pada Pokémon ini."
-		}
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 719572,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				cardmarket: 837464,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				cardmarket: 837465,
+			},
+		},
+	],
 
-	weaknesses: [{
-		type: "Lightning",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "トサキント",
+	},
 
 	retreat: 2,
 	regulationMark: "G",
+	rarity: "Uncommon",
+	dexId: [119],
+};
 
-	thirdParty: {
-		cardmarket: 719572
-	}
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV2a/120.ts
+++ b/data-asia/SV/SV2a/120.ts
@@ -1,20 +1,17 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV2a"
+import { Card } from "../../../interfaces";
+import Set from "../SV2a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "ヒトデマン",
 		'zh-tw': "海星星",
 		th: "ฮิโตเดมัน",
-		id: "Staryu"
+		id: "Staryu",
 	},
 
 	illustrator: "Arai Kiriko",
-	rarity: "Common",
 	category: "Pokemon",
-	dexId: [120],
 	hp: 60,
 	types: ["Water"],
 
@@ -22,42 +19,60 @@ const card: Card = {
 		ja: "魚ポケモンに ついばまれるが 体が ちぎれても すぐに 再生するので 気にしない。",
 		'zh-tw': "會被魚寶可夢啄食，但是即使身體被咬斷也能很快就 再生，所以一點都不在意。",
 		th: "ถึงแม้ร่างกายจะโดนโปเกมอนปลาตอดกินจนขาดไปก็ไม่สนใจเพราะจะงอกออกมาใหม่ทันที",
-		id: "Meskipun tubuhnya putus tercabik karena digigit oleh Pokémon ikan, Staryu tidak peduli karena tubuhnya akan segera tumbuh kembali."
+		id: "Meskipun tubuhnya putus tercabik karena digigit oleh Pokémon ikan, Staryu tidak peduli karena tubuhnya akan segera tumbuh kembali.",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		cost: ["Water", "Colorless"],
-
-		name: {
-			ja: "スピードスター",
-			'zh-tw': "高速星星",
-			th: "สปีดสตาร์",
-			id: "Speed Star"
+	attacks: [
+		{
+			name: {
+				ja: "スピードスター",
+				'zh-tw': "高速星星",
+				th: "สปีดสตาร์",
+				id: "Speed Star",
+			},
+			damage: 30,
+			cost: ["Water", "Colorless"],
+			effect: {
+				ja: "このワザのダメージは、弱点・抵抗力と、相手のバトルポケモンにかかっている効果を計算しない。",
+				'zh-tw': "這個招式的傷害不計算弱點・抵抗力與對手的戰鬥寶可夢身上的附加效果。",
+				th: "แดเมจของท่าต่อสู้นี้ จะไม่นำจุดอ่อน ความต้านทาน และเอฟเฟกต์ที่มีผลอยู่กับโปเกมอนบนตำแหน่งต่อสู้ฝ่ายตรงข้ามมาคิด",
+				id: "Kerusakan akibat serangan ini tidak terpengaruh oleh Kelemahan, Resistansi, dan efek yang sedang dialami Pokémon Bertarung lawan.",
+			},
 		},
+	],
 
-		damage: 30,
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
 
-		effect: {
-			ja: "このワザのダメージは、弱点・抵抗力と、相手のバトルポケモンにかかっている効果を計算しない。",
-			'zh-tw': "這個招式的傷害不計算弱點・抵抗力與對手的戰鬥寶可夢身上的附加效果。",
-			th: "แดเมจของท่าต่อสู้นี้ จะไม่นำจุดอ่อน ความต้านทาน และเอฟเฟกต์ที่มีผลอยู่กับโปเกมอนบนตำแหน่งต่อสู้ฝ่ายตรงข้ามมาคิด",
-			id: "Kerusakan akibat serangan ini tidak terpengaruh oleh Kelemahan, Resistansi, dan efek yang sedang dialami Pokémon Bertarung lawan."
-		}
-	}],
-
-	weaknesses: [{
-		type: "Lightning",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 719573,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				cardmarket: 837466,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				cardmarket: 837467,
+			},
+		},
+	],
 
 	retreat: 1,
 	regulationMark: "G",
+	rarity: "Common",
+	dexId: [120],
+};
 
-	thirdParty: {
-		cardmarket: 719573
-	}
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV2a/121.ts
+++ b/data-asia/SV/SV2a/121.ts
@@ -1,20 +1,17 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV2a"
+import { Card } from "../../../interfaces";
+import Set from "../SV2a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "スターミー",
 		'zh-tw': "寶石海星",
 		th: "สตาร์มี",
-		id: "Starmie"
+		id: "Starmie",
 	},
 
 	illustrator: "Arai Kiriko",
-	rarity: "Rare",
 	category: "Pokemon",
-	dexId: [121],
 	hp: 90,
 	types: ["Water"],
 
@@ -22,53 +19,76 @@ const card: Card = {
 		ja: "体を 高速で 回転させ 海を 泳ぎながら 小さな プランクトンを 吸収する。",
 		'zh-tw': "會高速旋轉著身體在海裡游泳，並且同時 吸食微小的浮游生物。",
 		th: "หมุนตัวด้วยความเร็วสูงว่ายน้ำในทะเลไปพร้อมกับดูดกินแพลงก์ตอนตัวเล็ก ๆ ไปด้วย",
-		id: "Starmie memutar tubuhnya dengan kecepatan tinggi dan mengisap plankton kecil sambil berenang di laut."
+		id: "Starmie memutar tubuhnya dengan kecepatan tinggi dan mengisap plankton kecil sambil berenang di laut.",
 	},
 
 	stage: "Stage1",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			ja: "なぞのすいせい",
-			'zh-tw': "謎之水性",
-			th: "ดาวหางปริศนา",
-			id: "Komet Misterius"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "なぞのすいせい",
+				'zh-tw': "謎之水性",
+				th: "ดาวหางปริศนา",
+				id: "Komet Misterius",
+			},
+			effect: {
+				ja: "自分の番に1回使える。相手のポケモン1匹に、ダメカンを2個のせる。その後、このポケモンと、ついているすべてのカードを、トラッシュする。",
+				'zh-tw': "在自己的回合時可使用1次。在對手的1隻寶可夢身上放置2個傷害指示物。然後，將這隻寶可夢與附加的卡全部丟棄。",
+				th: "ใช้ได้ 1 ครั้งในเทิร์นฝ่ายเรา วางตัวนับแดเมจ 2 ตัว บนโปเกมอนฝ่ายตรงข้าม 1 ตัว หลังจากนั้น ทิ้งโปเกมอนนี้ และการ์ดทั้งหมดที่ติดอยู่ ที่ตำแหน่งทิ้งการ์ด",
+				id: "Dapat digunakan 1 kali pada giliran sendiri. Letakkan 2 Token Kerusakan pada 1 Pokémon lawan. Setelah itu, buang Pokémon ini dan semua kartu yang dikenakannya ke Trash.",
+			},
 		},
+	],
 
-		effect: {
-			ja: "自分の番に1回使える。相手のポケモン1匹に、ダメカンを2個のせる。その後、このポケモンと、ついているすべてのカードを、トラッシュする。",
-			'zh-tw': "在自己的回合時可使用1次。在對手的1隻寶可夢身上放置2個傷害指示物。然後，將這隻寶可夢與附加的卡全部丟棄。",
-			th: "ใช้ได้ 1 ครั้งในเทิร์นฝ่ายเรา วางตัวนับแดเมจ 2 ตัว บนโปเกมอนฝ่ายตรงข้าม 1 ตัว หลังจากนั้น ทิ้งโปเกมอนนี้ และการ์ดทั้งหมดที่ติดอยู่ ที่ตำแหน่งทิ้งการ์ด",
-			id: "Dapat digunakan 1 kali pada giliran sendiri. Letakkan 2 Token Kerusakan pada 1 Pokémon lawan. Setelah itu, buang Pokémon ini dan semua kartu yang dikenakannya ke Trash."
-		}
-	}],
-
-	attacks: [{
-		cost: ["Water", "Colorless"],
-
-		name: {
-			ja: "スピードアタック",
-			'zh-tw': "高速攻擊",
-			th: "สปีดแอทแทก",
-			id: "Speed Attack"
+	attacks: [
+		{
+			name: {
+				ja: "スピードアタック",
+				'zh-tw': "高速攻擊",
+				th: "สปีดแอทแทก",
+				id: "Speed Attack",
+			},
+			damage: 50,
+			cost: ["Water", "Colorless"],
 		},
+	],
 
-		damage: 50
-	}],
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Lightning",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 719574,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				cardmarket: 837468,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				cardmarket: 837469,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ヒトデマン",
+	},
 
 	retreat: 1,
 	regulationMark: "G",
+	rarity: "Rare",
+	dexId: [121],
+};
 
-	thirdParty: {
-		cardmarket: 719574
-	}
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV2a/122.ts
+++ b/data-asia/SV/SV2a/122.ts
@@ -1,20 +1,17 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV2a"
+import { Card } from "../../../interfaces";
+import Set from "../SV2a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "バリヤード",
 		'zh-tw': "魔牆人偶",
 		th: "บาร์เรียด",
-		id: "Mr. Mime"
+		id: "Mr. Mime",
 	},
 
 	illustrator: "OOYAMA",
-	rarity: "Rare",
 	category: "Pokemon",
-	dexId: [122],
 	hp: 90,
 	types: ["Psychic"],
 
@@ -22,63 +19,77 @@ const card: Card = {
 		ja: "パントマイムが 得意。 指から 出した 波動で 壁を つくり あまたの 攻撃から 身を守る。",
 		'zh-tw': "擅長表演默劇。用手指放出的波動製造牆壁， 保護自己免於大多數的攻擊。",
 		th: "ถนัดเล่นละครใบ้ สร้างกำแพงด้วยคลื่นที่ออกจากนิ้วเพื่อป้องกันตัวจากการโจมตีหลากหลายแบบ",
-		id: "Pintar memainkan pantomim. Mr. Mime membuat dinding menggunakan gelombang yang dikeluarkan dari jarinya untuk melindungi dirinya dari serangan lawan."
+		id: "Pintar memainkan pantomim. Mr. Mime membuat dinding menggunakan gelombang yang dikeluarkan dari jarinya untuk melindungi dirinya dari serangan lawan.",
 	},
 
 	stage: "Basic",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			ja: "ものまねバリア",
-			'zh-tw': "模仿屏障",
-			th: "บาเรียลอกเลียน",
-			id: "Barier Peniru"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "ものまねバリア",
+				'zh-tw': "模仿屏障",
+				th: "บาเรียลอกเลียน",
+				id: "Barier Peniru",
+			},
+			effect: {
+				ja: "このポケモンと相手のバトルポケモンについているエネルギーの数が同じなら、このポケモンは、相手のポケモンからワザのダメージを受けない。",
+				'zh-tw': "若這隻寶可夢與對手的戰鬥寶可夢身上附加的能量數量相同，則這隻寶可夢不會受到對手的寶可夢招式的傷害。",
+				th: "ถ้าจำนวนพลังงานที่ติดอยู่กับโปเกมอนนี้กับโปเกมอนบนตำแหน่งต่อสู้ฝ่ายตรงข้ามเท่ากัน โปเกมอนนี้ จะไม่ได้รับแดเมจของท่าต่อสู้จากโปเกมอนฝ่ายตรงข้าม",
+				id: "Jika Energi yang dikenakan Pokémon ini dan Pokémon Bertarung lawan sama jumlahnya, Pokémon ini tidak menerima kerusakan akibat serangan dari Pokémon lawan.",
+			},
 		},
+	],
 
-		effect: {
-			ja: "このポケモンと相手のバトルポケモンについているエネルギーの数が同じなら、このポケモンは、相手のポケモンからワザのダメージを受けない。",
-			'zh-tw': "若這隻寶可夢與對手的戰鬥寶可夢身上附加的能量數量相同，則這隻寶可夢不會受到對手的寶可夢招式的傷害。",
-			th: "ถ้าจำนวนพลังงานที่ติดอยู่กับโปเกมอนนี้กับโปเกมอนบนตำแหน่งต่อสู้ฝ่ายตรงข้ามเท่ากัน โปเกมอนนี้ จะไม่ได้รับแดเมจของท่าต่อสู้จากโปเกมอนฝ่ายตรงข้าม",
-			id: "Jika Energi yang dikenakan Pokémon ini dan Pokémon Bertarung lawan sama jumlahnya, Pokémon ini tidak menerima kerusakan akibat serangan dari Pokémon lawan."
-		}
-	}],
-
-	attacks: [{
-		cost: ["Colorless"],
-
-		name: {
-			ja: "サイコパワー",
-			'zh-tw': "精神力量",
-			th: "ไซโคพาวเวอร์",
-			id: "Psychopower"
+	attacks: [
+		{
+			name: {
+				ja: "サイコパワー",
+				'zh-tw': "精神力量",
+				th: "ไซโคพาวเวอร์",
+				id: "Psychopower",
+			},
+			cost: ["Colorless"],
+			effect: {
+				ja: "ダメカン3個を、相手のポケモンに好きなようにのせる。",
+				'zh-tw': "將3個傷害指示物以任意方式放置於對手的寶可夢身上。",
+				th: "วางตัวนับแดเมจ 3 ตัว บนโปเกมอนฝ่ายตรงข้ามตามชอบ",
+				id: "Letakkan sejumlah 3 Token Kerusakan pada Pokémon lawan sesukanya.",
+			},
 		},
+	],
 
-		effect: {
-			ja: "ダメカン3個を、相手のポケモンに好きなようにのせる。",
-			'zh-tw': "將3個傷害指示物以任意方式放置於對手的寶可夢身上。",
-			th: "วางตัวนับแดเมจ 3 ตัว บนโปเกมอนฝ่ายตรงข้ามตามชอบ",
-			id: "Letakkan sejumlah 3 Token Kerusakan pada Pokémon lawan sesukanya."
-		}
-	}],
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
 
-	weaknesses: [{
-		type: "Darkness",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Fighting",
-		value: "-30"
-	}],
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 719575,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				cardmarket: 837470,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				cardmarket: 837471,
+			},
+		},
+	],
 
 	retreat: 1,
 	regulationMark: "G",
+	rarity: "Rare",
+	dexId: [122],
+};
 
-	thirdParty: {
-		cardmarket: 719575
-	}
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV2a/123.ts
+++ b/data-asia/SV/SV2a/123.ts
@@ -1,20 +1,17 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV2a"
+import { Card } from "../../../interfaces";
+import Set from "../SV2a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "ストライク",
 		'zh-tw': "飛天螳螂",
 		th: "สไตรค์",
-		id: "Scyther"
+		id: "Scyther",
 	},
 
 	illustrator: "Hideki Ishikawa",
-	rarity: "Uncommon",
 	category: "Pokemon",
-	dexId: [123],
 	hp: 70,
 	types: ["Grass"],
 
@@ -22,53 +19,70 @@ const card: Card = {
 		ja: "切れ味 鋭い カマを 使って 草むらを 切り進む。 あまりに 速い 動きで 目が 追いつかない。",
 		'zh-tw': "會用鋒利的鐮刀割開草叢前進。因為動作實在太快， 甚至無法用肉眼看清。",
 		th: "ใช้เคียวคมกริบถางหญ้าที่ขวางทาง เคลื่อนไหวได้เร็วจนมองตามไม่ทัน",
-		id: "Scyther melaju sambil memotong rerumputan menggunakan sabit tajamnya. Pergerakannya tidak bisa diikuti karena terlalu cepat."
+		id: "Scyther melaju sambil memotong rerumputan menggunakan sabit tajamnya. Pergerakannya tidak bisa diikuti karena terlalu cepat.",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		cost: ["Grass"],
-
-		name: {
-			ja: "アシストスラッシュ",
-			'zh-tw': "輔助斬",
-			th: "แอสซิสต์สแลช",
-			id: "Assist Slash"
+	attacks: [
+		{
+			name: {
+				ja: "アシストスラッシュ",
+				'zh-tw': "輔助斬",
+				th: "แอสซิสต์สแลช",
+				id: "Assist Slash",
+			},
+			damage: 20,
+			cost: ["Grass"],
+			effect: {
+				ja: "自分のトラッシュから「基本[G]エネルギー」を1枚選び、ベンチポケモンにつける。",
+				'zh-tw': "從自己的棄牌區選擇1張「基本【草】能量」卡，附於備戰寶可夢身上。",
+				th: "เลือกการ์ด [พลังงานพื้นฐาน[หญ้า]] 1 ใบจากตำแหน่งทิ้งการ์ดฝ่ายเรา ติดที่โปเกมอนบนเบนช์",
+				id: "Pilih 1 lembar Energi Dasar {Daun} dari Trash sendiri, lalu kenakan pada Pokémon Cadangan.",
+			},
 		},
-
-		damage: 20,
-
-		effect: {
-			ja: "自分のトラッシュから「基本エネルギー」を1枚選び、ベンチポケモンにつける。",
-			'zh-tw': "從自己的棄牌區選擇1張「基本【草】能量」卡，附於備戰寶可夢身上。",
-			th: "เลือกการ์ด [พลังงานพื้นฐาน[หญ้า]] 1 ใบจากตำแหน่งทิ้งการ์ดฝ่ายเรา ติดที่โปเกมอนบนเบนช์",
-			id: "Pilih 1 lembar Energi Dasar {Daun} dari Trash sendiri, lalu kenakan pada Pokémon Cadangan."
-		}
-	}, {
-		cost: ["Grass", "Colorless", "Colorless"],
-
-		name: {
-			ja: "スライスブレード",
-			'zh-tw': "利刃切割",
-			th: "สไลซ์เบลด",
-			id: "Slicing Blade"
+		{
+			name: {
+				ja: "スライスブレード",
+				'zh-tw': "利刃切割",
+				th: "สไลซ์เบลด",
+				id: "Slicing Blade",
+			},
+			damage: 70,
+			cost: ["Grass", "Colorless", "Colorless"],
 		},
+	],
 
-		damage: 70
-	}],
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 719576,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				cardmarket: 837472,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				cardmarket: 837473,
+			},
+		},
+	],
 
 	retreat: 0,
 	regulationMark: "G",
+	rarity: "Uncommon",
+	dexId: [123],
+};
 
-	thirdParty: {
-		cardmarket: 719576
-	}
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV2a/124.ts
+++ b/data-asia/SV/SV2a/124.ts
@@ -1,71 +1,74 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV2a"
+import { Card } from "../../../interfaces";
+import Set from "../SV2a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "ルージュラex",
 		'zh-tw': "迷唇姐ex",
 		th: "รูจูลาex",
-		id: "Jynx ex"
+		id: "Jynx ex",
 	},
 
 	illustrator: "Ayaka Yoshida",
-	rarity: "Double rare",
 	category: "Pokemon",
 	hp: 200,
 	types: ["Water"],
+
 	stage: "Basic",
-	suffix: "EX",
 
-	attacks: [{
-		cost: ["Water", "Colorless", "Colorless"],
-
-		name: {
-			ja: "ズッキュンキッス",
-			'zh-tw': "動心之吻",
-			th: "จุ๊บโดนใจ",
-			id: "Ciuman Meluluhkan"
+	attacks: [
+		{
+			name: {
+				ja: "ズッキュンキッス",
+				'zh-tw': "動心之吻",
+				th: "จุ๊บโดนใจ",
+				id: "Ciuman Meluluhkan",
+			},
+			cost: ["Water", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンがねむりなら、そのポケモンをきぜつさせる。",
+				'zh-tw': "若對手的戰鬥寶可夢【睡眠】，則將那隻寶可夢【昏厥】。",
+				th: "ถ้าโปเกมอนบนตำแหน่งต่อสู้ฝ่ายตรงข้ามเป็นสภาวะ[หลับ] จะทำให้โปเกมอนนั้น[หมดสภาพ]",
+				id: "Jika Pokémon Bertarung lawan mengalami kondisi Tidur, Pokémon tersebut KO.",
+			},
 		},
-
-		effect: {
-			ja: "相手のバトルポケモンがねむりなら、そのポケモンをきぜつさせる。",
-			'zh-tw': "若對手的戰鬥寶可夢【睡眠】，則將那隻寶可夢【昏厥】。",
-			th: "ถ้าโปเกมอนบนตำแหน่งต่อสู้ฝ่ายตรงข้ามเป็นสภาวะ[หลับ] จะทำให้โปเกมอนนั้น[หมดสภาพ]",
-			id: "Jika Pokémon Bertarung lawan mengalami kondisi Tidur, Pokémon tersebut KO."
-		}
-	}, {
-		cost: ["Water", "Water", "Water"],
-
-		name: {
-			ja: "こごえるかぜ",
-			'zh-tw': "冰凍之風",
-			th: "สายลมเยือกแข็ง",
-			id: "Angin Dingin"
+		{
+			name: {
+				ja: "こごえるかぜ",
+				'zh-tw': "冰凍之風",
+				th: "สายลมเยือกแข็ง",
+				id: "Angin Dingin",
+			},
+			damage: 120,
+			cost: ["Water", "Water", "Water"],
+			effect: {
+				ja: "相手のバトルポケモンをねむりにする。",
+				'zh-tw': "將對手的戰鬥寶可夢【睡眠】。",
+				th: "ทำให้โปเกมอนบนตำแหน่งต่อสู้ฝ่ายตรงข้ามเป็นสภาวะ[หลับ]",
+				id: "Ubah kondisi Pokémon Bertarung lawan menjadi Tidur.",
+			},
 		},
+	],
 
-		damage: 120,
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
 
-		effect: {
-			ja: "相手のバトルポケモンをねむりにする。",
-			'zh-tw': "將對手的戰鬥寶可夢【睡眠】。",
-			th: "ทำให้โปเกมอนบนตำแหน่งต่อสู้ฝ่ายตรงข้ามเป็นสภาวะ[หลับ]",
-			id: "Ubah kondisi Pokémon Bertarung lawan menjadi Tidur."
-		}
-	}],
-
-	weaknesses: [{
-		type: "Metal",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 719577,
+			},
+		},
+	],
 
 	retreat: 2,
 	regulationMark: "G",
+	rarity: "Double rare",
+	dexId: [124],
 
-	thirdParty: {
-		cardmarket: 719577
-	}
-}
+	suffix: "EX",
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV2a/125.ts
+++ b/data-asia/SV/SV2a/125.ts
@@ -1,20 +1,17 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV2a"
+import { Card } from "../../../interfaces";
+import Set from "../SV2a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "エレブー",
 		'zh-tw': "電擊獸",
 		th: "เอเลบู",
-		id: "Electabuzz"
+		id: "Electabuzz",
 	},
 
 	illustrator: "NC Empire",
-	rarity: "Common",
 	category: "Pokemon",
-	dexId: [125],
 	hp: 90,
 	types: ["Lightning"],
 
@@ -22,53 +19,70 @@ const card: Card = {
 		ja: "嵐が 来ると 高い 木の まわりに 集まり 雷が 落ちるのを じっと 待ち続ける。",
 		'zh-tw': "暴風雨來臨時，牠們會聚集在高大的樹周圍， 靜靜地一直等待落雷。",
 		th: "เมื่อมีพายุจะพากันไปรวมตัวบริเวณต้นไม้สูงและเฝ้ารอให้ฟ้าผ่าอย่างใจจดใจจ่อ",
-		id: "Ketika badai datang, Electabuzz berkumpul di sekeliling pohon tinggi dan dengan sabar terus menunggu jatuhnya petir."
+		id: "Ketika badai datang, Electabuzz berkumpul di sekeliling pohon tinggi dan dengan sabar terus menunggu jatuhnya petir.",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		cost: ["Lightning"],
-
-		name: {
-			ja: "エレキコンボ",
-			'zh-tw': "電氣合擊",
-			th: "อิเล็กทริกคอมโบ",
-			id: "Electric Combo"
+	attacks: [
+		{
+			name: {
+				ja: "エレキコンボ",
+				'zh-tw': "電氣合擊",
+				th: "อิเล็กทริกคอมโบ",
+				id: "Electric Combo",
+			},
+			damage: "10+",
+			cost: ["Lightning"],
+			effect: {
+				ja: "自分のベンチに「ブーバー」がいるなら、40ダメージ追加。",
+				'zh-tw': "若自己的備戰區有「鴨嘴火獸」，則增加40點傷害。",
+				th: "ถ้าบนเบนช์ฝ่ายเรามี [บูเบอร์] อยู่ การโจมตีนี้จะเพิ่มแดเมจอีก 40",
+				id: "Jika ada Magmar di Cadangan sendiri, kerusakan yang diberikan bertambah sejumlah 40.",
+			},
 		},
-
-		damage: "10+",
-
-		effect: {
-			ja: "自分のベンチに「ブーバー」がいるなら、40ダメージ追加。",
-			'zh-tw': "若自己的備戰區有「鴨嘴火獸」，則增加40點傷害。",
-			th: "ถ้าบนเบนช์ฝ่ายเรามี [บูเบอร์] อยู่ การโจมตีนี้จะเพิ่มแดเมจอีก 40",
-			id: "Jika ada Magmar di Cadangan sendiri, kerusakan yang diberikan bertambah sejumlah 40."
-		}
-	}, {
-		cost: ["Lightning", "Colorless"],
-
-		name: {
-			ja: "なぐる",
-			'zh-tw': "打擊",
-			th: "ทุบตี",
-			id: "Memukul"
+		{
+			name: {
+				ja: "なぐる",
+				'zh-tw': "打擊",
+				th: "ทุบตี",
+				id: "Memukul",
+			},
+			damage: 30,
+			cost: ["Lightning", "Colorless"],
 		},
+	],
 
-		damage: 30
-	}],
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 719578,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				cardmarket: 837474,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				cardmarket: 837475,
+			},
+		},
+	],
 
 	retreat: 2,
 	regulationMark: "G",
+	rarity: "Common",
+	dexId: [125],
+};
 
-	thirdParty: {
-		cardmarket: 719578
-	}
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV2a/126.ts
+++ b/data-asia/SV/SV2a/126.ts
@@ -1,20 +1,17 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV2a"
+import { Card } from "../../../interfaces";
+import Set from "../SV2a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "ブーバー",
 		'zh-tw': "鴨嘴火獸",
 		th: "บูเบอร์",
-		id: "Magmar"
+		id: "Magmar",
 	},
 
 	illustrator: "Toshinao Aoki",
-	rarity: "Common",
 	category: "Pokemon",
-	dexId: [126],
 	hp: 90,
 	types: ["Fire"],
 
@@ -22,53 +19,70 @@ const card: Card = {
 		ja: "全身が つねに 燃えている。 火事を 起こす 原因の ひとつとして 恐れられる。",
 		'zh-tw': "全身時時刻刻都在燃燒。人們認為牠是引起火災的 原因之一，非常畏懼牠。",
 		th: "ทั่วตัวนั้นเผาไหม้อยู่ตลอดเวลา เป็นที่หวาดกลัวเพราะเป็นหนึ่งในสาเหตุของไฟไหม้",
-		id: "Seluruh tubuh Magmar selalu terbakar. Pokémon ini ditakuti sebagai salah satu penyebab terjadinya kebakaran."
+		id: "Seluruh tubuh Magmar selalu terbakar. Pokémon ini ditakuti sebagai salah satu penyebab terjadinya kebakaran.",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		cost: ["Fire"],
-
-		name: {
-			ja: "ひだね",
-			'zh-tw': "火種",
-			th: "เชื้อไฟ",
-			id: "Nyala Api"
+	attacks: [
+		{
+			name: {
+				ja: "ひだね",
+				'zh-tw': "火種",
+				th: "เชื้อไฟ",
+				id: "Nyala Api",
+			},
+			damage: 10,
+			cost: ["Fire"],
 		},
-
-		damage: 10
-	}, {
-		cost: ["Fire", "Fire", "Colorless"],
-
-		name: {
-			ja: "フレアコンボ",
-			'zh-tw': "閃焰合擊",
-			th: "แฟลร์คอมโบ",
-			id: "Flare Combo"
+		{
+			name: {
+				ja: "フレアコンボ",
+				'zh-tw': "閃焰合擊",
+				th: "แฟลร์คอมโบ",
+				id: "Flare Combo",
+			},
+			damage: "80+",
+			cost: ["Fire", "Fire", "Colorless"],
+			effect: {
+				ja: "自分のベンチに「エレブー」がいるなら、80ダメージ追加。",
+				'zh-tw': "若自己的備戰區有「電擊獸」，則增加80點傷害。",
+				th: "ถ้าบนเบนช์ฝ่ายเรามี [เอเลบู] อยู่ การโจมตีนี้จะเพิ่มแดเมจอีก 80",
+				id: "Jika ada Electabuzz di Cadangan sendiri, kerusakan yang diberikan bertambah sejumlah 80.",
+			},
 		},
+	],
 
-		damage: "80+",
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
 
-		effect: {
-			ja: "自分のベンチに「エレブー」がいるなら、80ダメージ追加。",
-			'zh-tw': "若自己的備戰區有「電擊獸」，則增加80點傷害。",
-			th: "ถ้าบนเบนช์ฝ่ายเรามี [เอเลบู] อยู่ การโจมตีนี้จะเพิ่มแดเมจอีก 80",
-			id: "Jika ada Electabuzz di Cadangan sendiri, kerusakan yang diberikan bertambah sejumlah 80."
-		}
-	}],
-
-	weaknesses: [{
-		type: "Water",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 719579,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				cardmarket: 837476,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				cardmarket: 837477,
+			},
+		},
+	],
 
 	retreat: 2,
 	regulationMark: "G",
+	rarity: "Common",
+	dexId: [126],
+};
 
-	thirdParty: {
-		cardmarket: 719579
-	}
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV2a/127.ts
+++ b/data-asia/SV/SV2a/127.ts
@@ -1,20 +1,17 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV2a"
+import { Card } from "../../../interfaces";
+import Set from "../SV2a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "カイロス",
 		'zh-tw': "凱羅斯",
 		th: "ไคลอส",
-		id: "Pinsir"
+		id: "Pinsir",
 	},
 
 	illustrator: "Yuya Oka",
-	rarity: "Uncommon",
 	category: "Pokemon",
-	dexId: [127],
 	hp: 120,
 	types: ["Grass"],
 
@@ -22,53 +19,70 @@ const card: Card = {
 		ja: "ツノで 獲物を 挟みこみ そのまま まっぷたつに するか 強引に 投げ飛ばしてしまう。",
 		'zh-tw': "會用角緊緊夾住獵物，就這樣把對方剪成兩半 或是把牠硬扔到天邊去。",
 		th: "จะใช้เขาหนีบเหยื่อแล้วฉีกเป็นสองส่วนหรือไม่ก็เขวี้ยงออกไปแรง ๆ",
-		id: "Pinsir mencapit mangsa menggunakan tanduknya, lalu mangsa tersebut akan dibelah jadi dua atau dilempar."
+		id: "Pinsir mencapit mangsa menggunakan tanduknya, lalu mangsa tersebut akan dibelah jadi dua atau dilempar.",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		cost: ["Grass", "Colorless"],
-
-		name: {
-			ja: "はさむ",
-			'zh-tw': "夾住",
-			th: "หนีบ",
-			id: "Capitan Keras"
+	attacks: [
+		{
+			name: {
+				ja: "はさむ",
+				'zh-tw': "夾住",
+				th: "หนีบ",
+				id: "Capitan Keras",
+			},
+			damage: 30,
+			cost: ["Grass", "Colorless"],
 		},
-
-		damage: 30
-	}, {
-		cost: ["Grass", "Grass", "Colorless"],
-
-		name: {
-			ja: "がむしゃらなげ",
-			'zh-tw': "蠻幹上投",
-			th: "ทุ่มบ้าระห่ำ",
-			id: "Lempar Mati-matian"
+		{
+			name: {
+				ja: "がむしゃらなげ",
+				'zh-tw': "蠻幹上投",
+				th: "ทุ่มบ้าระห่ำ",
+				id: "Lempar Mati-matian",
+			},
+			damage: "90+",
+			cost: ["Grass", "Grass", "Colorless"],
+			effect: {
+				ja: "自分のサイドの残り枚数が、相手のサイドの残り枚数より多いなら、90ダメージ追加。",
+				'zh-tw': "若自己剩餘獎賞卡的張數，比對手剩餘獎賞卡的張數多，則增加90點傷害。",
+				th: "ถ้าจำนวนการ์ดรางวัลที่เหลือของฝ่ายเรา มากกว่าจำนวนการ์ดรางวัลที่เหลือของฝ่ายตรงข้าม การโจมตีนี้จะเพิ่มแดเมจอีก 90",
+				id: "Jika sisa Kartu Point sendiri lebih banyak dari sisa Kartu Point lawan, kerusakan yang diberikan bertambah sejumlah 90.",
+			},
 		},
+	],
 
-		damage: "90+",
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
 
-		effect: {
-			ja: "自分のサイドの残り枚数が、相手のサイドの残り枚数より多いなら、90ダメージ追加。",
-			'zh-tw': "若自己剩餘獎賞卡的張數，比對手剩餘獎賞卡的張數多，則增加90點傷害。",
-			th: "ถ้าจำนวนการ์ดรางวัลที่เหลือของฝ่ายเรา มากกว่าจำนวนการ์ดรางวัลที่เหลือของฝ่ายตรงข้าม การโจมตีนี้จะเพิ่มแดเมจอีก 90",
-			id: "Jika sisa Kartu Point sendiri lebih banyak dari sisa Kartu Point lawan, kerusakan yang diberikan bertambah sejumlah 90."
-		}
-	}],
-
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 719580,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				cardmarket: 837478,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				cardmarket: 837479,
+			},
+		},
+	],
 
 	retreat: 2,
 	regulationMark: "G",
+	rarity: "Uncommon",
+	dexId: [127],
+};
 
-	thirdParty: {
-		cardmarket: 719580
-	}
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV2a/128.ts
+++ b/data-asia/SV/SV2a/128.ts
@@ -1,20 +1,17 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV2a"
+import { Card } from "../../../interfaces";
+import Set from "../SV2a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "ケンタロス",
 		'zh-tw': "肯泰羅",
 		th: "เคนเทารอส",
-		id: "Tauros"
+		id: "Tauros",
 	},
 
 	illustrator: "Takeshi Nakamura",
-	rarity: "Uncommon",
 	category: "Pokemon",
-	dexId: [128],
 	hp: 120,
 	types: ["Colorless"],
 
@@ -22,58 +19,75 @@ const card: Card = {
 		ja: "獲物に 狙いを つけると 尻尾で 体を 叩きながら まっすぐ 突っ込んでくる。",
 		'zh-tw': "鎖定了獵物之後，就會一邊用尾巴抽打身體， 一邊筆直地衝向目標。",
 		th: "เมื่อเล็งเหยื่อ จะใช้หางตีตัวเองพร้อมกับพุ่งตรงเข้าไป",
-		id: "Begitu menentukan sasarannya, Tauros mencambuk tubuhnya sendiri menggunakan ekornya dan menerjang lurus ke depan."
+		id: "Begitu menentukan sasarannya, Tauros mencambuk tubuhnya sendiri menggunakan ekornya dan menerjang lurus ke depan.",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		cost: ["Colorless"],
-
-		name: {
-			ja: "むれをあつめる",
-			'zh-tw': "群集",
-			th: "รวบรวมฝูง",
-			id: "Mengumpulkan Gerombolan"
+	attacks: [
+		{
+			name: {
+				ja: "むれをあつめる",
+				'zh-tw': "群集",
+				th: "รวบรวมฝูง",
+				id: "Mengumpulkan Gerombolan",
+			},
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札からたねポケモンを1枚選び、ベンチに出す。そして山札を切る。",
+				'zh-tw': "從自己的牌庫選擇1張【基礎】寶可夢卡，放置於備戰區。並且重洗牌庫。",
+				th: "เลือกการ์ดโปเกมอน[พื้นฐาน] 1 ใบจากสำรับการ์ดฝ่ายเรา วางบนเบนช์ แล้วสับสำรับการ์ด",
+				id: "Pilih 1 lembar Pokémon Basic dari Deck sendiri, lalu masukkan ke Cadangan. Kemudian, kocok Deck.",
+			},
 		},
-
-		effect: {
-			ja: "自分の山札からたねポケモンを1枚選び、ベンチに出す。そして山札を切る。",
-			'zh-tw': "從自己的牌庫選擇1張【基礎】寶可夢卡，放置於備戰區。並且重洗牌庫。",
-			th: "เลือกการ์ดโปเกมอน[พื้นฐาน] 1 ใบจากสำรับการ์ดฝ่ายเรา วางบนเบนช์ แล้วสับสำรับการ์ด",
-			id: "Pilih 1 lembar Pokémon Basic dari Deck sendiri, lalu masukkan ke Cadangan. Kemudian, kocok Deck."
-		}
-	}, {
-		cost: ["Colorless", "Colorless"],
-
-		name: {
-			ja: "いかり",
-			'zh-tw': "憤怒",
-			th: "พิโรธ",
-			id: "Amarah"
+		{
+			name: {
+				ja: "いかり",
+				'zh-tw': "憤怒",
+				th: "พิโรธ",
+				id: "Amarah",
+			},
+			damage: "30+",
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンにのっているダメカンの数×10ダメージ追加。",
+				'zh-tw': "增加這隻寶可夢身上放置的傷害指示物的數量×10點傷害。",
+				th: "แดเมจจะเพิ่มตามจำนวนตัวนับแดเมจที่วางอยู่บนโปเกมอนนี้ x10",
+				id: "Kerusakan yang diberikan bertambah sejumlah 10 untuk tiap Token Kerusakan yang dimiliki Pokémon ini.",
+			},
 		},
+	],
 
-		damage: "30+",
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
 
-		effect: {
-			ja: "このポケモンにのっているダメカンの数×10ダメージ追加。",
-			'zh-tw': "增加這隻寶可夢身上放置的傷害指示物的數量×10點傷害。",
-			th: "แดเมจจะเพิ่มตามจำนวนตัวนับแดเมจที่วางอยู่บนโปเกมอนนี้ x10",
-			id: "Kerusakan yang diberikan bertambah sejumlah 10 untuk tiap Token Kerusakan yang dimiliki Pokémon ini."
-		}
-	}],
-
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 719581,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				cardmarket: 837480,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				cardmarket: 837481,
+			},
+		},
+	],
 
 	retreat: 2,
 	regulationMark: "G",
+	rarity: "Uncommon",
+	dexId: [128],
+};
 
-	thirdParty: {
-		cardmarket: 719581
-	}
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV2a/129.ts
+++ b/data-asia/SV/SV2a/129.ts
@@ -1,20 +1,17 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV2a"
+import { Card } from "../../../interfaces";
+import Set from "../SV2a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "コイキング",
 		'zh-tw': "鯉魚王",
 		th: "คอยคิง",
-		id: "Magikarp"
+		id: "Magikarp",
 	},
 
 	illustrator: "Kouki Saitou",
-	rarity: "Common",
 	category: "Pokemon",
-	dexId: [129],
 	hp: 30,
 	types: ["Water"],
 
@@ -22,40 +19,59 @@ const card: Card = {
 		ja: "力のない 情けない ポケモン。 たまに 高く 飛び跳ねても ２メートルを 超すのが やっとだ。",
 		'zh-tw': "沒力量的可憐寶可夢。偶爾跳得比較高時， 也只是勉強高過2公尺而已。",
 		th: "เป็นโปเกมอนที่อ่อนแอและน่าสมเพช นาน ๆ ทีกระโดดสูงเกิน 2 เมตรก็นับว่าดีแล้ว",
-		id: "Pokémon menyedihkan yang tidak memiliki kekuatan. Walau kadang Magikarp melompat tinggi, ketinggiannya hampir tidak dapat melampaui 2 meter."
+		id: "Pokémon menyedihkan yang tidak memiliki kekuatan. Walau kadang Magikarp melompat tinggi, ketinggiannya hampir tidak dapat melampaui 2 meter.",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		cost: ["Water"],
-
-		name: {
-			ja: "はねにはねる",
-			'zh-tw': "跳了又跳",
-			th: "ดิ้นกระแด่วกระแด่ว",
-			id: "Lompatan Demi Lompatan"
+	attacks: [
+		{
+			name: {
+				ja: "はねにはねる",
+				'zh-tw': "跳了又跳",
+				th: "ดิ้นกระแด่วกระแด่ว",
+				id: "Lompatan Demi Lompatan",
+			},
+			cost: ["Water"],
+			effect: {
+				ja: "ウラが出るまでコインを投げ、オモテの数ぶん、自分の山札を引く。",
+				'zh-tw': "擲硬幣直到出現反面，從自己的牌庫抽出與正面出現的次數相同數量的卡。",
+				th: "ทอยเหรียญจนกว่าจะออกก้อย จั่วการ์ดจากสำรับการ์ดฝ่ายเรา ตามจำนวนครั้งที่ออกหัว",
+				id: "Lempar koin hingga hasilnya sisi belakang. Ambil kartu dari atas Deck sendiri untuk tiap lemparan dengan hasil sisi depan.",
+			},
 		},
+	],
 
-		effect: {
-			ja: "ウラが出るまでコインを投げ、オモテの数ぶん、自分の山札を引く。",
-			'zh-tw': "擲硬幣直到出現反面，從自己的牌庫抽出與正面出現的次數相同數量的卡。",
-			th: "ทอยเหรียญจนกว่าจะออกก้อย จั่วการ์ดจากสำรับการ์ดฝ่ายเรา ตามจำนวนครั้งที่ออกหัว",
-			id: "Lempar koin hingga hasilnya sisi belakang. Ambil kartu dari atas Deck sendiri untuk tiap lemparan dengan hasil sisi depan."
-		}
-	}],
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Lightning",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 719582,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				cardmarket: 837482,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				cardmarket: 837483,
+			},
+		},
+	],
 
 	retreat: 1,
 	regulationMark: "G",
+	rarity: "Common",
+	dexId: [129],
+};
 
-	thirdParty: {
-		cardmarket: 719582
-	}
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV2a/130.ts
+++ b/data-asia/SV/SV2a/130.ts
@@ -1,20 +1,17 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV2a"
+import { Card } from "../../../interfaces";
+import Set from "../SV2a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "ギャラドス",
 		'zh-tw': "暴鯉龍",
 		th: "เกียราดอส",
-		id: "Gyarados"
+		id: "Gyarados",
 	},
 
 	illustrator: "Kouki Saitou",
-	rarity: "Rare",
 	category: "Pokemon",
-	dexId: [130],
 	hp: 190,
 	types: ["Water"],
 
@@ -22,60 +19,82 @@ const card: Card = {
 		ja: "一度 姿を 現すと まわりを すべて 焼き尽くさないと 怒りが 鎮まらない という。",
 		'zh-tw': "據說暴鯉龍一旦現身，如果不把周圍的一切都 燃燒殆盡，怒火就不會平息。",
 		th: "ว่ากันว่า เมื่อปรากฏตัวออกมาครั้งหนึ่งแล้ว ถ้าไม่ได้ทำลายทุกอย่างโดยรอบให้ราบเป็นหน้ากลองก็จะไม่หายโกรธ",
-		id: "Gyarados langsung mengamuk begitu muncul. Dikabarkan amukan Pokémon ini tidak akan mereda hingga ia membumihanguskan sekitarnya."
+		id: "Gyarados langsung mengamuk begitu muncul. Dikabarkan amukan Pokémon ini tidak akan mereda hingga ia membumihanguskan sekitarnya.",
 	},
 
 	stage: "Stage1",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			ja: "あらくれもの",
-			'zh-tw': "暴躁者",
-			th: "ผู้ระราน",
-			id: "Perusak"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "あらくれもの",
+				'zh-tw': "暴躁者",
+				th: "ผู้ระราน",
+				id: "Perusak",
+			},
+			effect: {
+				ja: "自分の番に、このカードを手札から出して進化させたとき、必ず1回使う。自分の山札を上から5枚トラッシュする。",
+				'zh-tw': "在自己的回合，從手牌使出這張卡並完成進化時，一定要使用1次。將自己的牌庫上方5張卡丟棄。",
+				th: "ในเทิร์นฝ่ายเรา เมื่อนำการ์ดนี้จากบนมือออกมาวิวัฒนาการแล้ว ต้องใช้ 1 ครั้ง ทิ้งการ์ด 5 ใบจากด้านบนของสำรับการ์ดฝ่ายเราที่ตำแหน่งทิ้งการ์ด",
+				id: "Harus digunakan 1 kali pada giliran sendiri saat memasukkan kartu ini dari Kartu Pegangan untuk melakukan evolusi. Buang 5 kartu dari atas Deck sendiri ke Trash.",
+			},
 		},
+	],
 
-		effect: {
-			ja: "自分の番に、このカードを手札から出して進化させたとき、必ず1回使う。自分の山札を上から5枚トラッシュする。",
-			'zh-tw': "在自己的回合，從手牌使出這張卡並完成進化時，一定要使用1次。將自己的牌庫上方5張卡丟棄。",
-			th: "ในเทิร์นฝ่ายเรา เมื่อนำการ์ดนี้จากบนมือออกมาวิวัฒนาการแล้ว ต้องใช้ 1 ครั้ง ทิ้งการ์ด 5 ใบจากด้านบนของสำรับการ์ดฝ่ายเราที่ตำแหน่งทิ้งการ์ด",
-			id: "Harus digunakan 1 kali pada giliran sendiri saat memasukkan kartu ini dari Kartu Pegangan untuk melakukan evolusi. Buang 5 kartu dari atas Deck sendiri ke Trash."
-		}
-	}],
-
-	attacks: [{
-		cost: ["Water", "Colorless", "Colorless", "Colorless"],
-
-		name: {
-			ja: "はかいこうせん",
-			'zh-tw': "破壞光線",
-			th: "แสงมฤตยู",
-			id: "Sinar Hiper"
+	attacks: [
+		{
+			name: {
+				ja: "はかいこうせん",
+				'zh-tw': "破壞光線",
+				th: "แสงมฤตยู",
+				id: "Sinar Hiper",
+			},
+			damage: 200,
+			cost: ["Water", "Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンについているエネルギーを1個選び、トラッシュする。",
+				'zh-tw': "選擇1個對手的戰鬥寶可夢身上附加的能量，將其丟棄。",
+				th: "เลือกพลังงานที่ติดอยู่กับโปเกมอนบนตำแหน่งต่อสู้ฝ่ายตรงข้าม 1 ลูก ทิ้งที่ตำแหน่งทิ้งการ์ด",
+				id: "Pilih 1 Energi yang dikenakan pada Pokémon Bertarung lawan, lalu buang ke Trash.",
+			},
 		},
+	],
 
-		damage: 200,
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
 
-		effect: {
-			ja: "相手のバトルポケモンについているエネルギーを1個選び、トラッシュする。",
-			'zh-tw': "選擇1個對手的戰鬥寶可夢身上附加的能量，將其丟棄。",
-			th: "เลือกพลังงานที่ติดอยู่กับโปเกมอนบนตำแหน่งต่อสู้ฝ่ายตรงข้าม 1 ลูก ทิ้งที่ตำแหน่งทิ้งการ์ด",
-			id: "Pilih 1 Energi yang dikenakan pada Pokémon Bertarung lawan, lalu buang ke Trash."
-		}
-	}],
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 719583,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				cardmarket: 837484,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				cardmarket: 837485,
+			},
+		},
+	],
 
-	weaknesses: [{
-		type: "Lightning",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "コイキング",
+	},
 
 	retreat: 4,
 	regulationMark: "G",
+	rarity: "Rare",
+	dexId: [130],
+};
 
-	thirdParty: {
-		cardmarket: 719583
-	}
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV2a/131.ts
+++ b/data-asia/SV/SV2a/131.ts
@@ -1,20 +1,17 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV2a"
+import { Card } from "../../../interfaces";
+import Set from "../SV2a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "ラプラス",
 		'zh-tw': "拉普拉斯",
 		th: "ลาพลาซ",
-		id: "Lapras"
+		id: "Lapras",
 	},
 
 	illustrator: "LINNE",
-	rarity: "Uncommon",
 	category: "Pokemon",
-	dexId: [131],
 	hp: 110,
 	types: ["Water"],
 
@@ -22,51 +19,69 @@ const card: Card = {
 		ja: "寒さに 強く 氷の 海も 平気。 皮膚は スベスベで 少しだけ ひんやり しているよ。",
 		'zh-tw': "十分耐寒，不畏冰海。皮膚滑滑的， 摸起來會有點涼。",
 		th: "ทนทานความหนาวเย็นแม้ทะเลน้ำแข็งก็ไม่เป็นไร ผิวหนังเรียบลื่นทำให้รู้สึกเย็นเล็กน้อย",
-		id: "Lapras tahan dingin dan laut es pun tidak menjadi masalah baginya. Kulitnya mulus dan agak dingin."
+		id: "Lapras tahan dingin dan laut es pun tidak menjadi masalah baginya. Kulitnya mulus dan agak dingin.",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		cost: ["Water"],
-
-		name: {
-			ja: "せなかにのせる",
-			'zh-tw': "後背乘載",
-			th: "ให้ขี่หลัง",
-			id: "Letakkan ke Punggung"
+	attacks: [
+		{
+			name: {
+				ja: "せなかにのせる",
+				'zh-tw': "後背乘載",
+				th: "ให้ขี่หลัง",
+				id: "Letakkan ke Punggung",
+			},
+			cost: ["Water"],
+			effect: {
+				ja: "自分の山札からポケモンを2枚まで選び、相手に見せて、手札に加える。そして山札を切る。",
+				'zh-tw': "從自己的牌庫選擇最多2張寶可夢卡，在給對手看過後加入手牌。並且重洗牌庫。",
+				th: "เลือกการ์ดโปเกมอนได้สูงสุด 2 ใบจากสำรับการ์ดฝ่ายเรา ให้ฝ่ายตรงข้ามดู นำขึ้นมือ แล้วสับสำรับการ์ด",
+				id: "Pilih paling banyak 2 lembar Pokémon dari Deck sendiri, perlihatkan ke lawan, lalu tambahkan ke Kartu Pegangan. Kemudian, kocok Deck.",
+			},
 		},
-
-		effect: {
-			ja: "自分の山札からポケモンを2枚まで選び、相手に見せて、手札に加える。そして山札を切る。",
-			'zh-tw': "從自己的牌庫選擇最多2張寶可夢卡，在給對手看過後加入手牌。並且重洗牌庫。",
-			th: "เลือกการ์ดโปเกมอนได้สูงสุด 2 ใบจากสำรับการ์ดฝ่ายเรา ให้ฝ่ายตรงข้ามดู นำขึ้นมือ แล้วสับสำรับการ์ด",
-			id: "Pilih paling banyak 2 lembar Pokémon dari Deck sendiri, perlihatkan ke lawan, lalu tambahkan ke Kartu Pegangan. Kemudian, kocok Deck."
-		}
-	}, {
-		cost: ["Water", "Colorless", "Colorless"],
-
-		name: {
-			ja: "アクアエッジ",
-			'zh-tw': "水之刀鋒",
-			th: "อควาเอดจ์",
-			id: "Aqua Edge"
+		{
+			name: {
+				ja: "アクアエッジ",
+				'zh-tw': "水之刀鋒",
+				th: "อควาเอดจ์",
+				id: "Aqua Edge",
+			},
+			damage: 90,
+			cost: ["Water", "Colorless", "Colorless"],
 		},
+	],
 
-		damage: 90
-	}],
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Lightning",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 719584,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				cardmarket: 837486,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				cardmarket: 837487,
+			},
+		},
+	],
 
 	retreat: 1,
 	regulationMark: "G",
+	rarity: "Uncommon",
+	dexId: [131],
+};
 
-	thirdParty: {
-		cardmarket: 719584
-	}
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV2a/132.ts
+++ b/data-asia/SV/SV2a/132.ts
@@ -1,20 +1,17 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV2a"
+import { Card } from "../../../interfaces";
+import Set from "../SV2a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "メタモン",
 		'zh-tw': "百變怪",
 		th: "เมตามอน",
-		id: "Ditto"
+		id: "Ditto",
 	},
 
 	illustrator: "KIYOTAKA OSHIYAMA",
-	rarity: "Rare",
 	category: "Pokemon",
-	dexId: [132],
 	hp: 60,
 	types: ["Colorless"],
 
@@ -22,53 +19,72 @@ const card: Card = {
 		ja: "変身は 完璧なのだが 笑わされて 力が 抜けると 変身は 解けてしまう。",
 		'zh-tw': "雖然可以變身得很完美，但一旦被逗笑， 就會因鬆懈而解除變身。",
 		th: "สามารถแปลงกายได้อย่างไร้ที่ติ แต่ถ้าขำจนเผลอตัวก็จะกลับร่างเดิม",
-		id: "Meskipun hasil transformasinya sempurna, Ditto akan kembali ke wujud aslinya jika dibuat tertawa dan menjadi rileks."
+		id: "Meskipun hasil transformasinya sempurna, Ditto akan kembali ke wujud aslinya jika dibuat tertawa dan menjadi rileks.",
 	},
 
 	stage: "Basic",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			ja: "へんしんスタート",
-			'zh-tw': "變身啓動",
-			th: "เริ่มแปลงร่าง",
-			id: "Perubahan Wujud Start"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "へんしんスタート",
+				'zh-tw': "變身啓動",
+				th: "เริ่มแปลงร่าง",
+				id: "Perubahan Wujud Start",
+			},
+			effect: {
+				ja: "このポケモンがバトル場にいるなら、最初の自分の番にだけ1回使える。自分の山札からたねポケモン（「メタモン」をのぞく）を1枚選ぶ。その後、このポケモンと、ついているすべてのカードをトラッシュし、このポケモンがいた場所に、選んだポケモンを出す。そして山札を切る。",
+				'zh-tw': "若這隻寶可夢在戰鬥場上，則只有在自己的最初回合可使用1次。從自己的牌庫選擇1張【基礎】寶可夢卡（「百變怪」除外）。然後，將這隻寶可夢與附加的卡全部丟棄，將所選的寶可夢放置於這隻寶可夢原先所在的地方。並且重洗牌庫。",
+				th: "ถ้าโปเกมอนนี้อยู่บนตำแหน่งต่อสู้ ใช้ได้ 1 ครั้งในเทิร์นแรกสุดของฝ่ายเราเท่านั้น เลือกการ์ดโปเกมอน[พื้นฐาน] (ยกเว้น [เมตามอน]) 1 ใบจากสำรับการ์ดฝ่ายเรา หลังจากนั้น ทิ้งโปเกมอนนี้ และการ์ดทั้งหมดที่ติดอยู่ที่ตำแหน่งทิ้งการ์ด วางโปเกมอนที่เลือก บนตำแหน่งที่โปเกมอนนี้เคยอยู่ แล้วสับสำรับการ์ด",
+				id: "Dapat digunakan 1 kali hanya pada giliran pertama sendiri jika Pokémon ini ada di Arena Bertarung. Pilih 1 lembar Pokémon Basic (selain Ditto) dari Deck sendiri. Setelah itu, buang Pokémon ini dan semua kartu yang dikenakannya ke Trash, lalu masukkan Pokémon yang telah dipilih ke tempat Pokémon ini tadinya berada. Kemudian, kocok Deck.",
+			},
 		},
+	],
 
-		effect: {
-			ja: "このポケモンがバトル場にいるなら、最初の自分の番にだけ1回使える。自分の山札からたねポケモン（「メタモン」をのぞく）を1枚選ぶ。その後、このポケモンと、ついているすべてのカードをトラッシュし、このポケモンがいた場所に、選んだポケモンを出す。そして山札を切る。",
-			'zh-tw': "若這隻寶可夢在戰鬥場上，則只有在自己的最初回合可使用1次。從自己的牌庫選擇1張【基礎】寶可夢卡（「百變怪」除外）。然後，將這隻寶可夢與附加的卡全部丟棄，將所選的寶可夢放置於這隻寶可夢原先所在的地方。並且重洗牌庫。",
-			th: "ถ้าโปเกมอนนี้อยู่บนตำแหน่งต่อสู้ ใช้ได้ 1 ครั้งในเทิร์นแรกสุดของฝ่ายเราเท่านั้น เลือกการ์ดโปเกมอน[พื้นฐาน] (ยกเว้น [เมตามอน]) 1 ใบจากสำรับการ์ดฝ่ายเรา หลังจากนั้น ทิ้งโปเกมอนนี้ และการ์ดทั้งหมดที่ติดอยู่ที่ตำแหน่งทิ้งการ์ด วางโปเกมอนที่เลือก บนตำแหน่งที่โปเกมอนนี้เคยอยู่ แล้วสับสำรับการ์ด",
-			id: "Dapat digunakan 1 kali hanya pada giliran pertama sendiri jika Pokémon ini ada di Arena Bertarung. Pilih 1 lembar Pokémon Basic (selain Ditto) dari Deck sendiri. Setelah itu, buang Pokémon ini dan semua kartu yang dikenakannya ke Trash, lalu masukkan Pokémon yang telah dipilih ke tempat Pokémon ini tadinya berada. Kemudian, kocok Deck."
-		}
-	}],
-
-	attacks: [{
-		cost: ["Colorless"],
-
-		name: {
-			ja: "ぺとっ",
-			'zh-tw': "黏",
-			th: "แนบสนิท",
-			id: "Lekat"
+	attacks: [
+		{
+			name: {
+				ja: "ぺとっ",
+				'zh-tw': "黏",
+				th: "แนบสนิท",
+				id: "Lekat",
+			},
+			damage: 10,
+			cost: ["Colorless"],
 		},
+	],
 
-		damage: 10
-	}],
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 719585,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				cardmarket: 837488,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				cardmarket: 837489,
+			},
+		},
+	],
 
 	retreat: 1,
 	regulationMark: "G",
+	rarity: "Rare",
+	dexId: [132],
+};
 
-	thirdParty: {
-		cardmarket: 719585
-	}
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV2a/133.ts
+++ b/data-asia/SV/SV2a/133.ts
@@ -1,20 +1,17 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV2a"
+import { Card } from "../../../interfaces";
+import Set from "../SV2a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "イーブイ",
 		'zh-tw': "伊布",
 		th: "อีวุย",
-		id: "Eevee"
+		id: "Eevee",
 	},
 
 	illustrator: "Narumi Sato",
-	rarity: "Common",
 	category: "Pokemon",
-	dexId: [133],
 	hp: 70,
 	types: ["Colorless"],
 
@@ -22,51 +19,69 @@ const card: Card = {
 		ja: "環境の 変化に すぐさま 合わせられるよう いくつもの 進化の 可能性を 秘めている。",
 		'zh-tw': "為了能瞬即適應環境的變化，這種寶可夢蘊含著 許多種進化的可能性。",
 		th: "มีความสามารถพิเศษในการวิวัฒนาการอย่างหลากหลายเพื่อปรับตัวให้เข้ากับการเปลี่ยนแปลงของสิ่งแวดล้อมได้อย่างทันที",
-		id: "Eevee berpotensi untuk berevolusi ke berbagai macam wujud untuk segera dapat beradaptasi terhadap perubahan lingkungan."
+		id: "Eevee berpotensi untuk berevolusi ke berbagai macam wujud untuk segera dapat beradaptasi terhadap perubahan lingkungan.",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		cost: ["Colorless"],
-
-		name: {
-			ja: "カラフルフレンズ",
-			'zh-tw': "鮮豔友情",
-			th: "คัลเลอร์ฟูลเฟรนส์",
-			id: "Colorful Friends"
+	attacks: [
+		{
+			name: {
+				ja: "カラフルフレンズ",
+				'zh-tw': "鮮豔友情",
+				th: "คัลเลอร์ฟูลเฟรนส์",
+				id: "Colorful Friends",
+			},
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札から、それぞれちがうタイプのポケモンを3枚まで選び、相手に見せて、手札に加える。そして山札を切る。",
+				'zh-tw': "從自己的牌庫選擇最多3張各不同屬性的寶可夢卡，在給對手看過後加入手牌。並且重洗牌庫。",
+				th: "เลือกการ์ดโปเกมอนที่แต่ละใบต่างประเภทกันได้สูงสุด 3 ใบ จากสำรับการ์ดฝ่ายเรา ให้ฝ่ายตรงข้ามดู นำขึ้นมือ แล้วสับสำรับการ์ด",
+				id: "Pilih paling banyak 3 lembar Pokémon yang masing-masing berbeda tipenya dari Deck sendiri, perlihatkan ke lawan, lalu tambahkan ke Kartu Pegangan. Kemudian, kocok Deck.",
+			},
 		},
-
-		effect: {
-			ja: "自分の山札から、それぞれちがうタイプのポケモンを3枚まで選び、相手に見せて、手札に加える。そして山札を切る。",
-			'zh-tw': "從自己的牌庫選擇最多3張各不同屬性的寶可夢卡，在給對手看過後加入手牌。並且重洗牌庫。",
-			th: "เลือกการ์ดโปเกมอนที่แต่ละใบต่างประเภทกันได้สูงสุด 3 ใบ จากสำรับการ์ดฝ่ายเรา ให้ฝ่ายตรงข้ามดู นำขึ้นมือ แล้วสับสำรับการ์ด",
-			id: "Pilih paling banyak 3 lembar Pokémon yang masing-masing berbeda tipenya dari Deck sendiri, perlihatkan ke lawan, lalu tambahkan ke Kartu Pegangan. Kemudian, kocok Deck."
-		}
-	}, {
-		cost: ["Colorless"],
-
-		name: {
-			ja: "スキップ",
-			'zh-tw': "小跳步",
-			th: "กระโดดข้าม",
-			id: "Skip"
+		{
+			name: {
+				ja: "スキップ",
+				'zh-tw': "小跳步",
+				th: "กระโดดข้าม",
+				id: "Skip",
+			},
+			damage: 10,
+			cost: ["Colorless"],
 		},
+	],
 
-		damage: 10
-	}],
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 719586,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				cardmarket: 837490,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				cardmarket: 837491,
+			},
+		},
+	],
 
 	retreat: 1,
 	regulationMark: "G",
+	rarity: "Common",
+	dexId: [133],
+};
 
-	thirdParty: {
-		cardmarket: 719586
-	}
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV2a/134.ts
+++ b/data-asia/SV/SV2a/134.ts
@@ -1,20 +1,17 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV2a"
+import { Card } from "../../../interfaces";
+import Set from "../SV2a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "シャワーズ",
 		'zh-tw': "水伊布",
 		th: "ชาวเวอร์ส",
-		id: "Vaporeon"
+		id: "Vaporeon",
 	},
 
 	illustrator: "kirisAki",
-	rarity: "Rare",
 	category: "Pokemon",
-	dexId: [134],
 	hp: 130,
 	types: ["Water"],
 
@@ -22,60 +19,80 @@ const card: Card = {
 		ja: "水辺に 棲むが 尻尾には 魚のような ひれが 残っていて 人魚と 間違う 人もいる。",
 		'zh-tw': "雖然棲息在水邊，但由於尾巴上有像是魚的鰭， 因此有的人會把牠誤認成人魚。",
 		th: "อาศัยอยู่ริมน้ำ เพราะหางมีครีบเหมือนปลาอยู่เลยมีคนเข้าใจผิดคิดว่าเป็นเงือก",
-		id: "Vaporeon hidup di dekat air. Karena terdapat sirip seperti ikan pada ekornya, ada manusia yang menyangka Pokémon ini adalah putri duyung."
+		id: "Vaporeon hidup di dekat air. Karena terdapat sirip seperti ikan pada ekornya, ada manusia yang menyangka Pokémon ini adalah putri duyung.",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		cost: ["Water"],
-
-		name: {
-			ja: "スパイラルドレイン",
-			'zh-tw': "螺旋吸取",
-			th: "สไปรัลเดรน",
-			id: "Spiral Drain"
+	attacks: [
+		{
+			name: {
+				ja: "スパイラルドレイン",
+				'zh-tw': "螺旋吸取",
+				th: "สไปรัลเดรน",
+				id: "Spiral Drain",
+			},
+			damage: 30,
+			cost: ["Water"],
+			effect: {
+				ja: "このポケモンのHPを「30」回復する。",
+				'zh-tw': "將這隻寶可夢恢復「30」HP。",
+				th: "ฟื้นฟู HP ของโปเกมอนนี้ [30]",
+				id: "Pulihkan HP Pokémon ini sejumlah 30.",
+			},
 		},
-
-		damage: 30,
-
-		effect: {
-			ja: "このポケモンのHPを「30」回復する。",
-			'zh-tw': "將這隻寶可夢恢復「30」HP。",
-			th: "ฟื้นฟู HP ของโปเกมอนนี้ [30]",
-			id: "Pulihkan HP Pokémon ini sejumlah 30."
-		}
-	}, {
-		cost: ["Water", "Colorless", "Colorless"],
-
-		name: {
-			ja: "とうしのうずしお",
-			'zh-tw': "鬥志潮旋",
-			th: "น้ำวนนักสู้",
-			id: "Pusaran Air Semangat Petarung"
+		{
+			name: {
+				ja: "とうしのうずしお",
+				'zh-tw': "鬥志潮旋",
+				th: "น้ำวนนักสู้",
+				id: "Pusaran Air Semangat Petarung",
+			},
+			damage: "90+",
+			cost: ["Water", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンが「ポケモンex・V」なら、90ダメージ追加。",
+				'zh-tw': "若對手的戰鬥寶可夢為「寶可夢【ex】・【V】」，則增加90點傷害。",
+				th: "ถ้าโปเกมอนบนตำแหน่งต่อสู้ฝ่ายตรงข้ามเป็น [โปเกมอน【ex】 /【V】] การโจมตีนี้จะเพิ่มแดเมจอีก 90",
+				id: "Jika Pokémon Bertarung lawan adalah Pokémon {ex}/{V}, kerusakan yang diberikan bertambah sejumlah 90.",
+			},
 		},
+	],
 
-		damage: "90+",
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
 
-		effect: {
-			ja: "相手のバトルポケモンが「ポケモンex・V」なら、90ダメージ追加。",
-			'zh-tw': "若對手的戰鬥寶可夢為「寶可夢【ex】・【V】」，則增加90點傷害。",
-			th: "ถ้าโปเกมอนบนตำแหน่งต่อสู้ฝ่ายตรงข้ามเป็น [โปเกมอน【ex】 /【V】] การโจมตีนี้จะเพิ่มแดเมจอีก 90",
-			id: "Jika Pokémon Bertarung lawan adalah Pokémon {ex}/{V}, kerusakan yang diberikan bertambah sejumlah 90."
-		}
-	}],
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 719587,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				cardmarket: 837492,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				cardmarket: 837493,
+			},
+		},
+	],
 
-	weaknesses: [{
-		type: "Lightning",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "イーブイ",
+	},
 
 	retreat: 2,
 	regulationMark: "G",
+	rarity: "Rare",
+	dexId: [134],
+};
 
-	thirdParty: {
-		cardmarket: 719587
-	}
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV2a/135.ts
+++ b/data-asia/SV/SV2a/135.ts
@@ -1,20 +1,17 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV2a"
+import { Card } from "../../../interfaces";
+import Set from "../SV2a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "サンダース",
 		'zh-tw': "雷伊布",
 		th: "ธันเดอร์ส",
-		id: "Jolteon"
+		id: "Jolteon",
 	},
 
 	illustrator: "sui",
-	rarity: "Rare",
 	category: "Pokemon",
-	dexId: [135],
 	hp: 110,
 	types: ["Lightning"],
 
@@ -22,58 +19,79 @@ const card: Card = {
 		ja: "細胞が 出している 弱い 電気を ひとまとめにして 強力な 電撃を 放つ。",
 		'zh-tw': "會把細胞發出的微弱電流都集中起來 釋放強力的電擊。",
 		th: "รวบรวมพลังไฟฟ้าอ่อน ๆ ที่เซลล์ปล่อยออกมา แล้วยิงกระแสไฟฟ้าอันทรงพลัง",
-		id: "Jolteon mengumpulkan listrik berdaya kecil yang dikeluarkan oleh sel-sel tubuhnya, lalu menembakkan serangan listrik yang kuat."
+		id: "Jolteon mengumpulkan listrik berdaya kecil yang dikeluarkan oleh sel-sel tubuhnya, lalu menembakkan serangan listrik yang kuat.",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		cost: ["Lightning"],
-
-		name: {
-			ja: "ちょくげきだん",
-			'zh-tw': "直擊彈",
-			th: "ยิงตรง",
-			id: "Serangan Linear"
+	attacks: [
+		{
+			name: {
+				ja: "ちょくげきだん",
+				'zh-tw': "直擊彈",
+				th: "ยิงตรง",
+				id: "Serangan Linear",
+			},
+			cost: ["Lightning"],
+			effect: {
+				ja: "相手のポケモン1匹に、30ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+				'zh-tw': "對手的1隻寶可夢受到30點傷害。[在備戰區不計算弱點・抵抗力。]",
+				th: "ทำแดเมจ 30 กับโปเกมอนฝ่ายตรงข้าม 1 ตัว {โปเกมอนบนเบนช์จะไม่นำจุดอ่อนและความต้านทานมาคิด}",
+				id: "Serangan ini memberikan kerusakan sejumlah 30 kepada 1 Pokémon lawan. [Kelemahan dan Resistansi Pokémon Cadangan tidak mempengaruhi jumlah kerusakan.]",
+			},
 		},
-
-		effect: {
-			ja: "相手のポケモン1匹に、30ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
-			'zh-tw': "對手的1隻寶可夢受到30點傷害。[在備戰區不計算弱點・抵抗力。]",
-			th: "ทำแดเมจ 30 กับโปเกมอนฝ่ายตรงข้าม 1 ตัว {โปเกมอนบนเบนช์จะไม่นำจุดอ่อนและความต้านทานมาคิด}",
-			id: "Serangan ini memberikan kerusakan sejumlah 30 kepada 1 Pokémon lawan. [Kelemahan dan Resistansi Pokémon Cadangan tidak mempengaruhi jumlah kerusakan.]"
-		}
-	}, {
-		cost: ["Lightning", "Colorless", "Colorless"],
-
-		name: {
-			ja: "とうしのいかずち",
-			'zh-tw': "鬥志雷霆",
-			th: "สายฟ้านักสู้",
-			id: "Guntur Semangat Petarung"
+		{
+			name: {
+				ja: "とうしのいかずち",
+				'zh-tw': "鬥志雷霆",
+				th: "สายฟ้านักสู้",
+				id: "Guntur Semangat Petarung",
+			},
+			damage: "90+",
+			cost: ["Lightning", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンが「ポケモンex・V」なら、90ダメージ追加。",
+				'zh-tw': "若對手的戰鬥寶可夢為「寶可夢【ex】・【V】」，則增加90點傷害。",
+				th: "ถ้าโปเกมอนบนตำแหน่งต่อสู้ฝ่ายตรงข้ามเป็น [โปเกมอน【ex】 /【V】] การโจมตีนี้จะเพิ่มแดเมจอีก 90",
+				id: "Jika Pokémon Bertarung lawan adalah Pokémon {ex}/{V}, kerusakan yang diberikan bertambah sejumlah 90.",
+			},
 		},
+	],
 
-		damage: "90+",
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
 
-		effect: {
-			ja: "相手のバトルポケモンが「ポケモンex・V」なら、90ダメージ追加。",
-			'zh-tw': "若對手的戰鬥寶可夢為「寶可夢【ex】・【V】」，則增加90點傷害。",
-			th: "ถ้าโปเกมอนบนตำแหน่งต่อสู้ฝ่ายตรงข้ามเป็น [โปเกมอน【ex】 /【V】] การโจมตีนี้จะเพิ่มแดเมจอีก 90",
-			id: "Jika Pokémon Bertarung lawan adalah Pokémon {ex}/{V}, kerusakan yang diberikan bertambah sejumlah 90."
-		}
-	}],
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 719588,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				cardmarket: 837494,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				cardmarket: 837495,
+			},
+		},
+	],
 
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "イーブイ",
+	},
 
 	retreat: 0,
 	regulationMark: "G",
+	rarity: "Rare",
+	dexId: [135],
+};
 
-	thirdParty: {
-		cardmarket: 719588
-	}
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV2a/136.ts
+++ b/data-asia/SV/SV2a/136.ts
@@ -1,20 +1,17 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV2a"
+import { Card } from "../../../interfaces";
+import Set from "../SV2a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "ブースター",
 		'zh-tw': "火伊布",
 		th: "บูสเตอร์",
-		id: "Flareon"
+		id: "Flareon",
 	},
 
 	illustrator: "Ryota Murayama",
-	rarity: "Rare",
 	category: "Pokemon",
-	dexId: [136],
 	hp: 130,
 	types: ["Fire"],
 
@@ -22,60 +19,80 @@ const card: Card = {
 		ja: "吸いこんだ 空気を 体内の 炎袋に 送りこみ １７００度の 炎にして 吹く。",
 		'zh-tw': "會將吸入的空氣送進體內的火囊轉化成 １７００度的火焰後再吐出來。",
 		th: "ส่งอากาศที่สูดเข้ามาไปยังถุงไฟภายในร่างกายเพื่อให้ไฟลุกไหม้ถึง 1700 องศาเซลเซียส แล้วพ่นออกมา",
-		id: "Udara yang diisap Flareon dikirim ke kantong api di dalam tubuhnya, dipanaskan menjadi api bersuhu 1700 ℃, lalu diembuskan."
+		id: "Udara yang diisap Flareon dikirim ke kantong api di dalam tubuhnya, dipanaskan menjadi api bersuhu 1700 ℃, lalu diembuskan.",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		cost: ["Fire"],
-
-		name: {
-			ja: "はかいび",
-			'zh-tw': "破壞火",
-			th: "ไฟทำลายล้าง",
-			id: "Api Penghancur"
+	attacks: [
+		{
+			name: {
+				ja: "はかいび",
+				'zh-tw': "破壞火",
+				th: "ไฟทำลายล้าง",
+				id: "Api Penghancur",
+			},
+			damage: 30,
+			cost: ["Fire"],
+			effect: {
+				ja: "コインを1回投げオモテなら、相手のバトルポケモンについているエネルギーを1個選び、トラッシュする。",
+				'zh-tw': "擲1次硬幣若為正面，則選擇1個對手的戰鬥寶可夢身上附加的能量，將其丟棄。",
+				th: "ทอยเหรียญ 1 ครั้งถ้าออกหัว เลือกพลังงานที่ติดอยู่กับโปเกมอนบนตำแหน่งต่อสู้ฝ่ายตรงข้าม 1 ลูก ทิ้งที่ตำแหน่งทิ้งการ์ด",
+				id: "Lempar koin 1 kali. Jika hasilnya sisi depan, pilih 1 Energi yang dikenakan pada Pokémon Bertarung lawan, lalu buang ke Trash.",
+			},
 		},
-
-		damage: 30,
-
-		effect: {
-			ja: "コインを1回投げオモテなら、相手のバトルポケモンについているエネルギーを1個選び、トラッシュする。",
-			'zh-tw': "擲1次硬幣若為正面，則選擇1個對手的戰鬥寶可夢身上附加的能量，將其丟棄。",
-			th: "ทอยเหรียญ 1 ครั้งถ้าออกหัว เลือกพลังงานที่ติดอยู่กับโปเกมอนบนตำแหน่งต่อสู้ฝ่ายตรงข้าม 1 ลูก ทิ้งที่ตำแหน่งทิ้งการ์ด",
-			id: "Lempar koin 1 kali. Jika hasilnya sisi depan, pilih 1 Energi yang dikenakan pada Pokémon Bertarung lawan, lalu buang ke Trash."
-		}
-	}, {
-		cost: ["Fire", "Colorless", "Colorless"],
-
-		name: {
-			ja: "とうしのもうか",
-			'zh-tw': "鬥志猛火",
-			th: "ไฟลุกนักสู้",
-			id: "Kobar Api Semangat Petarung"
+		{
+			name: {
+				ja: "とうしのもうか",
+				'zh-tw': "鬥志猛火",
+				th: "ไฟลุกนักสู้",
+				id: "Kobar Api Semangat Petarung",
+			},
+			damage: "90+",
+			cost: ["Fire", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンが「ポケモンex・V」なら、90ダメージ追加。",
+				'zh-tw': "若對手的戰鬥寶可夢為「寶可夢【ex】・【V】」，則增加90點傷害。",
+				th: "ถ้าโปเกมอนบนตำแหน่งต่อสู้ฝ่ายตรงข้ามเป็น [โปเกมอน【ex】 /【V】] การโจมตีนี้จะเพิ่มแดเมจอีก 90",
+				id: "Jika Pokémon Bertarung lawan adalah Pokémon {ex}/{V}, kerusakan yang diberikan bertambah sejumlah 90.",
+			},
 		},
+	],
 
-		damage: "90+",
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
 
-		effect: {
-			ja: "相手のバトルポケモンが「ポケモンex・V」なら、90ダメージ追加。",
-			'zh-tw': "若對手的戰鬥寶可夢為「寶可夢【ex】・【V】」，則增加90點傷害。",
-			th: "ถ้าโปเกมอนบนตำแหน่งต่อสู้ฝ่ายตรงข้ามเป็น [โปเกมอน【ex】 /【V】] การโจมตีนี้จะเพิ่มแดเมจอีก 90",
-			id: "Jika Pokémon Bertarung lawan adalah Pokémon {ex}/{V}, kerusakan yang diberikan bertambah sejumlah 90."
-		}
-	}],
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 719589,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				cardmarket: 837496,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				cardmarket: 837497,
+			},
+		},
+	],
 
-	weaknesses: [{
-		type: "Water",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "イーブイ",
+	},
 
 	retreat: 2,
 	regulationMark: "G",
+	rarity: "Rare",
+	dexId: [136],
+};
 
-	thirdParty: {
-		cardmarket: 719589
-	}
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV2a/137.ts
+++ b/data-asia/SV/SV2a/137.ts
@@ -1,20 +1,17 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV2a"
+import { Card } from "../../../interfaces";
+import Set from "../SV2a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "ポリゴン",
 		'zh-tw': "多邊獸",
 		th: "โพรีกอน",
-		id: "Porygon"
+		id: "Porygon",
 	},
 
 	illustrator: "5ban Graphics",
-	rarity: "Common",
 	category: "Pokemon",
-	dexId: [137],
 	hp: 60,
 	types: ["Colorless"],
 
@@ -22,40 +19,59 @@ const card: Card = {
 		ja: "近年は 電脳空間で 大活躍。 怪しい データが ないか チェックして まわっている。",
 		'zh-tw': "近年在電腦空間大展身手。會四處巡邏查看 有沒有可疑的資料。",
 		th: "หลายปีที่ผ่านมา มันมีบทบาทอย่างมากในไซเบอร์สเปซ คอยตระเวนตรวจสอบว่ามีข้อมูลน่าสงสัยหรือไม่",
-		id: "Belakangan Porygon berperan besar di dunia maya. Pokémon ini berkeliling mengecek untuk memastikan tidak ada data yang mencurigakan."
+		id: "Belakangan Porygon berperan besar di dunia maya. Pokémon ini berkeliling mengecek untuk memastikan tidak ada data yang mencurigakan.",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		cost: ["Colorless"],
-
-		name: {
-			ja: "テクスチャー4",
-			'zh-tw': "紋理4",
-			th: "เปลี่ยนสภาพ 4",
-			id: "Texture 4"
+	attacks: [
+		{
+			name: {
+				ja: "テクスチャー4",
+				'zh-tw': "紋理4",
+				th: "เปลี่ยนสภาพ 4",
+				id: "Texture 4",
+			},
+			cost: ["Colorless"],
+			effect: {
+				ja: "[G][R][W][L][P][F][D][M][N]の中からタイプを1つ選ぶ。このワザを受けたポケモンの弱点は、選んだタイプになる。この効果は、このワザを受けたポケモンがバトル場をはなれるまで続く。［弱点は「×2」でダメージ計算をする。］",
+				'zh-tw': "從【草】【火】【水】【雷】【超】【鬥】【惡】【鋼】【龍】中選擇1個屬性。受到這個招式的寶可夢弱點改為所選的屬性。這個效果在受到這個招式的寶可夢離開戰鬥場前一直持續。［弱點以「×2」計算傷害。］",
+				th: "เลือก 1 ประเภทจาก[หญ้า] [ไฟ] [น้ำ] [สายฟ้า] [พลังจิต] [ต่อสู้] [ความมืด] [โลหะ] [มังกร] จุดอ่อนของโปเกมอนที่ได้รับท่าต่อสู้นี้ จะเป็นประเภทที่เลือก เอฟเฟกต์นี้ จะต่อเนื่องไปจนกว่าโปเกมอนที่ได้รับท่าต่อสู้นี้จะออกจากตำแหน่งต่อสู้ {จุดอ่อน คำนวณแดเมจ x2}",
+				id: "Pilih 1 tipe di antara {Daun}, {Api}, {Air}, {Listrik}, {Psychic}, {Petarung}, {Kegelapan}, {Logam}, dan {Naga}. Kelemahan Pokémon yang menerima serangan ini menjadi tipe yang telah dipilih. Efek ini terus berlanjut hingga Pokémon yang menerima serangan ini meninggalkan Arena Bertarung. [Perhitungan kerusakan dari tipe yang menjadi Kelemahan adalah 2 kali lipat.]",
+			},
 		},
+	],
 
-		effect: {
-			ja: "の中からタイプを1つ選ぶ。このワザを受けたポケモンの弱点は、選んだタイプになる。この効果は、このワザを受けたポケモンがバトル場をはなれるまで続く。［弱点は「×2」でダメージ計算をする。］",
-			'zh-tw': "從【草】【火】【水】【雷】【超】【鬥】【惡】【鋼】【龍】中選擇1個屬性。受到這個招式的寶可夢弱點改為所選的屬性。這個效果在受到這個招式的寶可夢離開戰鬥場前一直持續。［弱點以「×2」計算傷害。］",
-			th: "เลือก 1 ประเภทจาก[หญ้า] [ไฟ] [น้ำ] [สายฟ้า] [พลังจิต] [ต่อสู้] [ความมืด] [โลหะ] [มังกร] จุดอ่อนของโปเกมอนที่ได้รับท่าต่อสู้นี้ จะเป็นประเภทที่เลือก เอฟเฟกต์นี้ จะต่อเนื่องไปจนกว่าโปเกมอนที่ได้รับท่าต่อสู้นี้จะออกจากตำแหน่งต่อสู้ {จุดอ่อน คำนวณแดเมจ x2}",
-			id: "Pilih 1 tipe di antara {Daun}, {Api}, {Air}, {Listrik}, {Psychic}, {Petarung}, {Kegelapan}, {Logam}, dan {Naga}. Kelemahan Pokémon yang menerima serangan ini menjadi tipe yang telah dipilih. Efek ini terus berlanjut hingga Pokémon yang menerima serangan ini meninggalkan Arena Bertarung. [Perhitungan kerusakan dari tipe yang menjadi Kelemahan adalah 2 kali lipat.]"
-		}
-	}],
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 719590,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				cardmarket: 837498,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				cardmarket: 837499,
+			},
+		},
+	],
 
 	retreat: 1,
 	regulationMark: "G",
+	rarity: "Common",
+	dexId: [137],
+};
 
-	thirdParty: {
-		cardmarket: 719590
-	}
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV2a/138.ts
+++ b/data-asia/SV/SV2a/138.ts
@@ -1,20 +1,17 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV2a"
+import { Card } from "../../../interfaces";
+import Set from "../SV2a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "オムナイト",
 		'zh-tw': "菊石獸",
 		th: "ออมไนต์",
-		id: "Omanyte"
+		id: "Omanyte",
 	},
 
 	illustrator: "Akira Komayama",
-	rarity: "Uncommon",
 	category: "Pokemon",
-	dexId: [138],
 	hp: 100,
 	types: ["Water"],
 
@@ -22,42 +19,60 @@ const card: Card = {
 		ja: "絶滅した 古代のポケモン。 １０本の脚で 水を かき 漂うように 泳ぐ。",
 		'zh-tw': "一度滅絕的古代寶可夢。會使用１０隻腳划水， 在水中一漂一浮地游動。",
 		th: "เป็นโปเกมอนดึกดำบรรพ์ที่สูญพันธุ์ไปแล้ว ว่ายน้ำโดยการตวัดขาทั้งสิบบนน้ำราวกับลอยตัวอยู่",
-		id: "Pokémon purba yang telah punah. Omanyte mengayuh air menggunakan sepuluh kakinya dan berenang bagai mengambang."
+		id: "Pokémon purba yang telah punah. Omanyte mengayuh air menggunakan sepuluh kakinya dan berenang bagai mengambang.",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		cost: ["Water", "Water"],
-
-		name: {
-			ja: "しょくしゅでもどす",
-			'zh-tw': "觸手復元",
-			th: "ใส่กลับด้วยหนวด",
-			id: "Tentakel Pengembali"
+	attacks: [
+		{
+			name: {
+				ja: "しょくしゅでもどす",
+				'zh-tw': "觸手復元",
+				th: "ใส่กลับด้วยหนวด",
+				id: "Tentakel Pengembali",
+			},
+			damage: 50,
+			cost: ["Water", "Water"],
+			effect: {
+				ja: "相手のバトルポケモンについているエネルギーを1個選び、相手の手札にもどす。",
+				'zh-tw': "選擇1個對手的戰鬥寶可夢身上附加的能量，放回對手的手牌。",
+				th: "เลือกพลังงานที่ติดอยู่กับโปเกมอนบนตำแหน่งต่อสู้ฝ่ายตรงข้าม 1 ลูก นำกลับขึ้นมือฝ่ายตรงข้าม",
+				id: "Pilih 1 Energi yang dikenakan pada Pokémon Bertarung lawan, lalu kembalikan ke Kartu Pegangan lawan.",
+			},
 		},
+	],
 
-		damage: 50,
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
 
-		effect: {
-			ja: "相手のバトルポケモンについているエネルギーを1個選び、相手の手札にもどす。",
-			'zh-tw': "選擇1個對手的戰鬥寶可夢身上附加的能量，放回對手的手牌。",
-			th: "เลือกพลังงานที่ติดอยู่กับโปเกมอนบนตำแหน่งต่อสู้ฝ่ายตรงข้าม 1 ลูก นำกลับขึ้นมือฝ่ายตรงข้าม",
-			id: "Pilih 1 Energi yang dikenakan pada Pokémon Bertarung lawan, lalu kembalikan ke Kartu Pegangan lawan."
-		}
-	}],
-
-	weaknesses: [{
-		type: "Lightning",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 719591,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				cardmarket: 837500,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				cardmarket: 837501,
+			},
+		},
+	],
 
 	retreat: 2,
 	regulationMark: "G",
+	rarity: "Uncommon",
+	dexId: [138],
+};
 
-	thirdParty: {
-		cardmarket: 719591
-	}
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV2a/139.ts
+++ b/data-asia/SV/SV2a/139.ts
@@ -1,20 +1,17 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV2a"
+import { Card } from "../../../interfaces";
+import Set from "../SV2a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "オムスター",
 		'zh-tw': "多刺菊石獸",
 		th: "ออมสตาร์",
-		id: "Omastar"
+		id: "Omastar",
 	},
 
 	illustrator: "Akira Komayama",
-	rarity: "Rare",
 	category: "Pokemon",
-	dexId: [139],
 	hp: 150,
 	types: ["Water"],
 
@@ -22,60 +19,82 @@ const card: Card = {
 		ja: "鋭いキバは 岩も 砕くが 触手の とどく 範囲の 獲物しか 襲えないのだ。",
 		'zh-tw': "尖銳的牙齒足以咬碎岩石，但能夠襲擊的獵物僅限在 牠的觸手可及的範圍之內。",
 		th: "เขี้ยวอันแหลมคมนั้นบดขยี้ได้แม้แต่หินผาทว่ากลับสามารถจู่โจมได้เพียงเหยื่อที่อยู่ในระยะหนวดเอื้อมถึงเท่านั้น",
-		id: "Taring tajam Omastar dapat menghancurkan batu besar sekalipun, tapi Pokémon ini hanya dapat menyerang mangsa dalam lingkup yang dapat dijangkau oleh tentakelnya."
+		id: "Taring tajam Omastar dapat menghancurkan batu besar sekalipun, tapi Pokémon ini hanya dapat menyerang mangsa dalam lingkup yang dapat dijangkau oleh tentakelnya.",
 	},
 
 	stage: "Stage2",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			ja: "みかいのしょくしゅ",
-			'zh-tw': "原始觸手",
-			th: "หนวดไม่เปิดเผย",
-			id: "Tentakel Tak Terjamah"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "みかいのしょくしゅ",
+				'zh-tw': "原始觸手",
+				th: "หนวดไม่เปิดเผย",
+				id: "Tentakel Tak Terjamah",
+			},
+			effect: {
+				ja: "このポケモンがバトル場にいるかぎり、相手のバトルポケモンは、にげられない。",
+				'zh-tw': "只要這隻寶可夢在戰鬥場上，對手的戰鬥寶可夢無法撤退。",
+				th: "ตราบใดที่โปเกมอนนี้ยังอยู่บนตำแหน่งต่อสู้ โปเกมอนบนตำแหน่งต่อสู้ฝ่ายตรงข้าม จะหนีไม่ได้",
+				id: "Selama Pokémon ini ada di Arena Bertarung, Pokémon Bertarung lawan tidak dapat Mundur.",
+			},
 		},
+	],
 
-		effect: {
-			ja: "このポケモンがバトル場にいるかぎり、相手のバトルポケモンは、にげられない。",
-			'zh-tw': "只要這隻寶可夢在戰鬥場上，對手的戰鬥寶可夢無法撤退。",
-			th: "ตราบใดที่โปเกมอนนี้ยังอยู่บนตำแหน่งต่อสู้ โปเกมอนบนตำแหน่งต่อสู้ฝ่ายตรงข้าม จะหนีไม่ได้",
-			id: "Selama Pokémon ini ada di Arena Bertarung, Pokémon Bertarung lawan tidak dapat Mundur."
-		}
-	}],
-
-	attacks: [{
-		cost: ["Water", "Water"],
-
-		name: {
-			ja: "アクアスプリット",
-			'zh-tw': "水分岔",
-			th: "อควาสปลิต",
-			id: "Aqua Split"
+	attacks: [
+		{
+			name: {
+				ja: "アクアスプリット",
+				'zh-tw': "水分岔",
+				th: "อควาสปลิต",
+				id: "Aqua Split",
+			},
+			damage: 90,
+			cost: ["Water", "Water"],
+			effect: {
+				ja: "相手のベンチポケモン2匹にも、それぞれ30ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+				'zh-tw': "對手的2隻備戰寶可夢也各受到30點傷害。[在備戰區不計算弱點・抵抗力。]",
+				th: "โปเกมอนบนเบนช์ฝ่ายตรงข้าม 2 ตัว ก็จะได้รับแดเมจตัวละ 30 ด้วย {โปเกมอนบนเบนช์จะไม่นำจุดอ่อนและความต้านทานมาคิด}",
+				id: "Serangan ini juga memberikan kerusakan masing-masing sejumlah 30 kepada 2 Pokémon Cadangan lawan. [Kelemahan dan Resistansi Pokémon Cadangan tidak mempengaruhi jumlah kerusakan.]",
+			},
 		},
+	],
 
-		damage: 90,
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
 
-		effect: {
-			ja: "相手のベンチポケモン2匹にも、それぞれ30ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
-			'zh-tw': "對手的2隻備戰寶可夢也各受到30點傷害。[在備戰區不計算弱點・抵抗力。]",
-			th: "โปเกมอนบนเบนช์ฝ่ายตรงข้าม 2 ตัว ก็จะได้รับแดเมจตัวละ 30 ด้วย {โปเกมอนบนเบนช์จะไม่นำจุดอ่อนและความต้านทานมาคิด}",
-			id: "Serangan ini juga memberikan kerusakan masing-masing sejumlah 30 kepada 2 Pokémon Cadangan lawan. [Kelemahan dan Resistansi Pokémon Cadangan tidak mempengaruhi jumlah kerusakan.]"
-		}
-	}],
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 719592,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				cardmarket: 837502,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				cardmarket: 837503,
+			},
+		},
+	],
 
-	weaknesses: [{
-		type: "Lightning",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "オムナイト",
+	},
 
 	retreat: 3,
 	regulationMark: "G",
+	rarity: "Rare",
+	dexId: [139],
+};
 
-	thirdParty: {
-		cardmarket: 719592
-	}
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV2a/140.ts
+++ b/data-asia/SV/SV2a/140.ts
@@ -1,20 +1,17 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV2a"
+import { Card } from "../../../interfaces";
+import Set from "../SV2a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "カブト",
 		'zh-tw': "化石盔",
 		th: "คาบูโตะ",
-		id: "Kabuto"
+		id: "Kabuto",
 	},
 
 	illustrator: "Souichirou Gunjima",
-	rarity: "Uncommon",
 	category: "Pokemon",
-	dexId: [140],
 	hp: 90,
 	types: ["Fighting"],
 
@@ -22,42 +19,60 @@ const card: Card = {
 		ja: "絶滅したとも 言われるが 一部の 地域では けっこう 普通に 見かける らしい。",
 		'zh-tw': "雖然有人說這種寶可夢已經滅絕，但牠在一部分 地區似乎是相當常見的。",
 		th: "แม้จะเป็นที่กล่าวกันว่าได้สูญพันธุ์ไปแล้ว แต่ดูเหมือนว่าในบางพื้นที่จะยังสามารถพบเห็นได้โดยทั่วไป",
-		id: "Dikatakan bahwa Kabuto telah punah, tapi kabarnya Pokémon ini lumayan umum ditemukan di sebagian daerah."
+		id: "Dikatakan bahwa Kabuto telah punah, tapi kabarnya Pokémon ini lumayan umum ditemukan di sebagian daerah.",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		cost: ["Fighting", "Colorless"],
-
-		name: {
-			ja: "ダブルひっかき",
-			'zh-tw': "雙重抓",
-			th: "ข่วนทวีคูณ",
-			id: "Cakaran Ganda"
+	attacks: [
+		{
+			name: {
+				ja: "ダブルひっかき",
+				'zh-tw': "雙重抓",
+				th: "ข่วนทวีคูณ",
+				id: "Cakaran Ganda",
+			},
+			damage: "70×",
+			cost: ["Fighting", "Colorless"],
+			effect: {
+				ja: "コインを2回投げ、オモテの数×70ダメージ。",
+				'zh-tw': "擲2次硬幣，造成正面出現的次數×70點傷害。",
+				th: "ทอยเหรียญ 2 ครั้ง แดเมจจะเท่ากับจำนวนครั้งที่ออกหัว x70",
+				id: "Lempar koin 2 kali. Serangan ini memberikan kerusakan sejumlah 70 untuk tiap lemparan dengan hasil sisi depan.",
+			},
 		},
+	],
 
-		damage: "70×",
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
 
-		effect: {
-			ja: "コインを2回投げ、オモテの数×70ダメージ。",
-			'zh-tw': "擲2次硬幣，造成正面出現的次數×70點傷害。",
-			th: "ทอยเหรียญ 2 ครั้ง แดเมจจะเท่ากับจำนวนครั้งที่ออกหัว x70",
-			id: "Lempar koin 2 kali. Serangan ini memberikan kerusakan sejumlah 70 untuk tiap lemparan dengan hasil sisi depan."
-		}
-	}],
-
-	weaknesses: [{
-		type: "Grass",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 719593,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				cardmarket: 837504,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				cardmarket: 837505,
+			},
+		},
+	],
 
 	retreat: 2,
 	regulationMark: "G",
+	rarity: "Uncommon",
+	dexId: [140],
+};
 
-	thirdParty: {
-		cardmarket: 719593
-	}
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV2a/141.ts
+++ b/data-asia/SV/SV2a/141.ts
@@ -1,20 +1,17 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV2a"
+import { Card } from "../../../interfaces";
+import Set from "../SV2a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "カブトプス",
 		'zh-tw': "鐮刀盔",
 		th: "คาบูท็อปส์",
-		id: "Kabutops"
+		id: "Kabutops",
 	},
 
 	illustrator: "Souichirou Gunjima",
-	rarity: "Rare",
 	category: "Pokemon",
-	dexId: [141],
 	hp: 160,
 	types: ["Fighting"],
 
@@ -22,60 +19,82 @@ const card: Card = {
 		ja: "絶滅の 理由は 不明。 暖かい 海に 暮らしていた 凶暴な 古代のポケモン。",
 		'zh-tw': "沒有人知道牠為何會滅絕。過去曾棲息在溫暖的海域， 是性情凶暴的古代寶可夢。",
 		th: "สาเหตุที่สูญพันธุ์ไปนั้นไม่รู้แน่ชัด เป็นโปเกมอนดึกดำบรรพ์จอมโหดที่อาศัยอยู่ใต้ทะเลอุ่น",
-		id: "Alasan Kabutops punah tidak jelas. Pokémon purba brutal yang hidup di laut hangat."
+		id: "Alasan Kabutops punah tidak jelas. Pokémon purba brutal yang hidup di laut hangat.",
 	},
 
 	stage: "Stage2",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			ja: "たいこのことわり",
-			'zh-tw': "遠古真理",
-			th: "หลักการดึกดำบรรพ์",
-			id: "Dogma Purba"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "たいこのことわり",
+				'zh-tw': "遠古真理",
+				th: "หลักการดึกดำบรรพ์",
+				id: "Dogma Purba",
+			},
+			effect: {
+				ja: "このポケモンがいるかぎり、相手のバトルポケモンの弱点は「×4」としてダメージ計算をする。",
+				'zh-tw': "只要這隻寶可夢在場上，對手的戰鬥寶可夢的弱點以「×4」計算傷害。",
+				th: "ตราบใดที่โปเกมอนนี้ยังอยู่ จุดอ่อนของโปเกมอนบนตำแหน่งต่อสู้ฝ่ายตรงข้ามจะคำนวณแดเมจด้วยการ [x4]",
+				id: "Selama Pokémon ini ada di Arena, perhitungan kerusakan dari tipe yang menjadi Kelemahan Pokémon Bertarung lawan adalah 4 kali lipat.",
+			},
 		},
+	],
 
-		effect: {
-			ja: "このポケモンがいるかぎり、相手のバトルポケモンの弱点は「×4」としてダメージ計算をする。",
-			'zh-tw': "只要這隻寶可夢在場上，對手的戰鬥寶可夢的弱點以「×4」計算傷害。",
-			th: "ตราบใดที่โปเกมอนนี้ยังอยู่ จุดอ่อนของโปเกมอนบนตำแหน่งต่อสู้ฝ่ายตรงข้ามจะคำนวณแดเมจด้วยการ [x4]",
-			id: "Selama Pokémon ini ada di Arena, perhitungan kerusakan dari tipe yang menjadi Kelemahan Pokémon Bertarung lawan adalah 4 kali lipat."
-		}
-	}],
-
-	attacks: [{
-		cost: ["Fighting", "Colorless", "Colorless"],
-
-		name: {
-			ja: "ドレインスラッシュ",
-			'zh-tw': "吸取揮砍",
-			th: "เดรนสแลช",
-			id: "Drain Slash"
+	attacks: [
+		{
+			name: {
+				ja: "ドレインスラッシュ",
+				'zh-tw': "吸取揮砍",
+				th: "เดรนสแลช",
+				id: "Drain Slash",
+			},
+			damage: 100,
+			cost: ["Fighting", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンのHPを「30」回復する。",
+				'zh-tw': "將這隻寶可夢恢復「30」HP。",
+				th: "ฟื้นฟู HP ของโปเกมอนนี้ [30]",
+				id: "Pulihkan HP Pokémon ini sejumlah 30.",
+			},
 		},
+	],
 
-		damage: 100,
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
 
-		effect: {
-			ja: "このポケモンのHPを「30」回復する。",
-			'zh-tw': "將這隻寶可夢恢復「30」HP。",
-			th: "ฟื้นฟู HP ของโปเกมอนนี้ [30]",
-			id: "Pulihkan HP Pokémon ini sejumlah 30."
-		}
-	}],
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 719594,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				cardmarket: 837506,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				cardmarket: 837507,
+			},
+		},
+	],
 
-	weaknesses: [{
-		type: "Grass",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "カブト",
+	},
 
 	retreat: 2,
 	regulationMark: "G",
+	rarity: "Rare",
+	dexId: [141],
+};
 
-	thirdParty: {
-		cardmarket: 719594
-	}
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV2a/142.ts
+++ b/data-asia/SV/SV2a/142.ts
@@ -1,20 +1,17 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV2a"
+import { Card } from "../../../interfaces";
+import Set from "../SV2a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "プテラ",
 		'zh-tw': "化石翼龍",
 		th: "พเทอรา",
-		id: "Aerodactyl"
+		id: "Aerodactyl",
 	},
 
 	illustrator: "Shinji Kanda",
-	rarity: "Rare",
 	category: "Pokemon",
-	dexId: [142],
 	hp: 130,
 	types: ["Colorless"],
 
@@ -22,58 +19,70 @@ const card: Card = {
 		ja: "のこぎりの ような キバは はがねポケモンの 皮膚さえ ズタズタに 切り裂いてしまう。",
 		'zh-tw': "擁有像鋸子般的牙齒，就連鋼屬性寶可夢的 皮膚都能撕裂成碎片。",
 		th: "ฟันเขี้ยวดุจใบเลื่อยนั้นแม้จะเป็นผิวของโปเกมอนโลหะก็สามารถกัดฉีกเป็นชิ้น ๆ ได้",
-		id: "Taring Aerodactyl yang bagaikan gergaji dapat mengoyak dan menyayat kulit Pokémon logam sekalipun."
+		id: "Taring Aerodactyl yang bagaikan gergaji dapat mengoyak dan menyayat kulit Pokémon logam sekalipun.",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		cost: ["Colorless"],
-
-		name: {
-			ja: "かっくう",
-			'zh-tw': "滑翔",
-			th: "ถลาลม",
-			id: "Melayang Rendah"
+	attacks: [
+		{
+			name: {
+				ja: "かっくう",
+				'zh-tw': "滑翔",
+				th: "ถลาลม",
+				id: "Melayang Rendah",
+			},
+			damage: 30,
+			cost: ["Colorless"],
 		},
-
-		damage: 30
-	}, {
-		cost: ["Colorless", "Colorless"],
-
-		name: {
-			ja: "たいかこうせん",
-			'zh-tw': "退化光線",
-			th: "ลำแสงย้อนวิวัฒนาการ",
-			id: "Sinar Degradasi"
+		{
+			name: {
+				ja: "たいかこうせん",
+				'zh-tw': "退化光線",
+				th: "ลำแสงย้อนวิวัฒนาการ",
+				id: "Sinar Degradasi",
+			},
+			damage: 100,
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "相手の進化しているバトルポケモンから、「進化カード」を1枚はがして退化させる。はがしたカードは、相手の手札にもどす。",
+				'zh-tw': "從對手的進化的戰鬥寶可夢身上，移除1張「進化卡」使其退化。將移除的卡放回對手的手牌。",
+				th: "ถอด [การ์ดวิวัฒนาการ] 1 ใบออกจากโปเกมอนบนตำแหน่งต่อสู้ฝ่ายตรงข้ามที่วิวัฒนาการแล้ว และทำให้วิวัฒนาการย้อนกลับ การ์ดที่ถอดออกมา นำกลับขึ้นมือฝ่ายตรงข้าม",
+				id: "Turunkan tingkat evolusi Pokémon Bertarung lawan yang telah berevolusi dengan melepas 1 kartu evolusi yang dikenakan. Kartu yang dilepas dikembalikan ke Kartu Pegangan lawan.",
+			},
 		},
+	],
 
-		damage: 100,
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
 
-		effect: {
-			ja: "相手の進化しているバトルポケモンから、「進化カード」を1枚はがして退化させる。はがしたカードは、相手の手札にもどす。",
-			'zh-tw': "從對手的進化的戰鬥寶可夢身上，移除1張「進化卡」使其退化。將移除的卡放回對手的手牌。",
-			th: "ถอด [การ์ดวิวัฒนาการ] 1 ใบออกจากโปเกมอนบนตำแหน่งต่อสู้ฝ่ายตรงข้ามที่วิวัฒนาการแล้ว และทำให้วิวัฒนาการย้อนกลับ การ์ดที่ถอดออกมา นำกลับขึ้นมือฝ่ายตรงข้าม",
-			id: "Turunkan tingkat evolusi Pokémon Bertarung lawan yang telah berevolusi dengan melepas 1 kartu evolusi yang dikenakan. Kartu yang dilepas dikembalikan ke Kartu Pegangan lawan."
-		}
-	}],
-
-	weaknesses: [{
-		type: "Lightning",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Fighting",
-		value: "-30"
-	}],
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 719595,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				cardmarket: 837508,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				cardmarket: 837509,
+			},
+		},
+	],
 
 	retreat: 0,
 	regulationMark: "G",
+	rarity: "Rare",
+	dexId: [142],
+};
 
-	thirdParty: {
-		cardmarket: 719595
-	}
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV2a/143.ts
+++ b/data-asia/SV/SV2a/143.ts
@@ -1,20 +1,17 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV2a"
+import { Card } from "../../../interfaces";
+import Set from "../SV2a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "カビゴン",
 		'zh-tw': "卡比獸",
 		th: "คาบิกอน",
-		id: "Snorlax"
+		id: "Snorlax",
 	},
 
 	illustrator: "HYOGONOSUKE",
-	rarity: "Uncommon",
 	category: "Pokemon",
-	dexId: [143],
 	hp: 150,
 	types: ["Colorless"],
 
@@ -22,60 +19,78 @@ const card: Card = {
 		ja: "頑丈な 胃袋は カビの 生えたものや 腐ったものを 食べても 壊れることはない。",
 		'zh-tw': "擁有一個結實的胃，即使吃了發霉腐爛的東西， 也完全不會吃壞肚子。",
 		th: "มีถุงกระเพาะที่แข็งแรง แม้จะกินของที่มีราขึ้นหรือของเน่าเสียก็ไม่เคยท้องเสีย",
-		id: "Karena perutnya kuat, Snorlax tidak akan sakit perut walau memakan makanan berjamur atau makanan busuk sekalipun."
+		id: "Karena perutnya kuat, Snorlax tidak akan sakit perut walau memakan makanan berjamur atau makanan busuk sekalipun.",
 	},
 
 	stage: "Basic",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			ja: "くいいじ",
-			'zh-tw': "貪嘴",
-			th: "เจริญอาหาร",
-			id: "Kemaruk"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "くいいじ",
+				'zh-tw': "貪嘴",
+				th: "เจริญอาหาร",
+				id: "Kemaruk",
+			},
+			effect: {
+				ja: "自分の番に1回使える。自分のトラッシュから「たべのこし」を2枚まで選び、相手に見せて、手札に加える。",
+				'zh-tw': "在自己的回合時可使用1次。從自己的棄牌區選擇最多2張「吃剩的東西」，在給對手看過後加入手牌。",
+				th: "ใช้ได้ 1 ครั้งในเทิร์นฝ่ายเรา เลือกการ์ด [อาหารเหลือ] ได้สูงสุด 2 ใบจากตำแหน่งทิ้งการ์ดฝ่ายเรา ให้ฝ่ายตรงข้ามดู นำขึ้นมือ",
+				id: "Dapat digunakan 1 kali pada giliran sendiri. Pilih paling banyak 2 lembar Sisa Makanan dari Trash sendiri, perlihatkan ke lawan, lalu tambahkan ke Kartu Pegangan.",
+			},
 		},
+	],
 
-		effect: {
-			ja: "自分の番に1回使える。自分のトラッシュから「たべのこし」を2枚まで選び、相手に見せて、手札に加える。",
-			'zh-tw': "在自己的回合時可使用1次。從自己的棄牌區選擇最多2張「吃剩的東西」，在給對手看過後加入手牌。",
-			th: "ใช้ได้ 1 ครั้งในเทิร์นฝ่ายเรา เลือกการ์ด [อาหารเหลือ] ได้สูงสุด 2 ใบจากตำแหน่งทิ้งการ์ดฝ่ายเรา ให้ฝ่ายตรงข้ามดู นำขึ้นมือ",
-			id: "Dapat digunakan 1 kali pada giliran sendiri. Pilih paling banyak 2 lembar Sisa Makanan dari Trash sendiri, perlihatkan ke lawan, lalu tambahkan ke Kartu Pegangan."
-		}
-	}],
-
-	attacks: [{
-		cost: ["Colorless", "Colorless", "Colorless"],
-
-		name: {
-			ja: "バッタンプレス",
-			'zh-tw': "養肥壓制",
-			th: "อัดตึงตัง",
-			id: "Tekanan Gedebuk"
+	attacks: [
+		{
+			name: {
+				ja: "バッタンプレス",
+				'zh-tw': "養肥壓制",
+				th: "อัดตึงตัง",
+				id: "Tekanan Gedebuk",
+			},
+			damage: 130,
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンにも30ダメージ。",
+				'zh-tw': "這隻寶可夢也受到30點傷害。",
+				th: "โปเกมอนนี้ก็จะได้รับแดเมจ 30 ด้วย",
+				id: "Pokémon ini juga menerima kerusakan sejumlah 30.",
+			},
 		},
+	],
 
-		damage: 130,
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
 
-		effect: {
-			ja: "このポケモンにも30ダメージ。",
-			'zh-tw': "這隻寶可夢也受到30點傷害。",
-			th: "โปเกมอนนี้ก็จะได้รับแดเมจ 30 ด้วย",
-			id: "Pokémon ini juga menerima kerusakan sejumlah 30."
-		}
-	}],
-
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 719596,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				cardmarket: 837510,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				cardmarket: 837511,
+			},
+		},
+	],
 
 	retreat: 4,
 	regulationMark: "G",
+	rarity: "Uncommon",
+	dexId: [143],
+};
 
-	thirdParty: {
-		cardmarket: 719596
-	}
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV2a/144.ts
+++ b/data-asia/SV/SV2a/144.ts
@@ -1,20 +1,17 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV2a"
+import { Card } from "../../../interfaces";
+import Set from "../SV2a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "フリーザー",
 		'zh-tw': "急凍鳥",
 		th: "ฟรีเซอร์",
-		id: "Articuno"
+		id: "Articuno",
 	},
 
 	illustrator: "chibi",
-	rarity: "Rare",
 	category: "Pokemon",
-	dexId: [144],
 	hp: 120,
 	types: ["Water"],
 
@@ -22,65 +19,78 @@ const card: Card = {
 		ja: "氷を 自在に 操る 力を もつ。 永久凍土の 雪山に 棲んでいるという。",
 		'zh-tw': "擁有能自在操縱冰的能力。據說是棲息在 永凍之地的雪山中。",
 		th: "มีพลังในการควบคุมน้ำแข็งได้ดั่งใจนึก ว่ากันว่ามันอาศัยอยู่บนภูเขาหิมะที่เยือกแข็งตลอดปี",
-		id: "Articuno memiliki kekuatan untuk mengendalikan es sesukanya. Dikatakan bahwa Pokémon ini tinggal di gunung bersalju dengan ibun abadi."
+		id: "Articuno memiliki kekuatan untuk mengendalikan es sesukanya. Dikatakan bahwa Pokémon ini tinggal di gunung bersalju dengan ibun abadi.",
 	},
 
 	stage: "Basic",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			ja: "アイスフロート",
-			'zh-tw': "冰之浮游",
-			th: "ไอซ์โฟลต",
-			id: "Ice Float"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "アイスフロート",
+				'zh-tw': "冰之浮游",
+				th: "ไอซ์โฟลต",
+				id: "Ice Float",
+			},
+			effect: {
+				ja: "このポケモンに[W]エネルギーがついているなら、このポケモンのにげるためのエネルギーは、すべてなくなる。",
+				'zh-tw': "若這隻寶可夢身上附有【水】能量卡，則這隻寶可夢【撤退】所需的能量全部消除。",
+				th: "ถ้าโปเกมอนนี้มีพลังงาน[น้ำ]ติดอยู่ พลังงานสำหรับ[หนี]ของโปเกมอนนี้ ทั้งหมดจะหายไป",
+				id: "Jika Pokémon ini mengenakan Energi {Air}, Pokémon ini menjadi tidak membutuhkan Energi untuk Mundur.",
+			},
 		},
+	],
 
-		effect: {
-			ja: "このポケモンにエネルギーがついているなら、このポケモンのにげるためのエネルギーは、すべてなくなる。",
-			'zh-tw': "若這隻寶可夢身上附有【水】能量卡，則這隻寶可夢【撤退】所需的能量全部消除。",
-			th: "ถ้าโปเกมอนนี้มีพลังงาน[น้ำ]ติดอยู่ พลังงานสำหรับ[หนี]ของโปเกมอนนี้ ทั้งหมดจะหายไป",
-			id: "Jika Pokémon ini mengenakan Energi {Air}, Pokémon ini menjadi tidak membutuhkan Energi untuk Mundur."
-		}
-	}],
-
-	attacks: [{
-		cost: ["Water", "Water", "Water"],
-
-		name: {
-			ja: "ふぶき",
-			'zh-tw': "暴風雪",
-			th: "พายุหิมะ",
-			id: "Badai Salju"
+	attacks: [
+		{
+			name: {
+				ja: "ふぶき",
+				'zh-tw': "暴風雪",
+				th: "พายุหิมะ",
+				id: "Badai Salju",
+			},
+			damage: 110,
+			cost: ["Water", "Water", "Water"],
+			effect: {
+				ja: "相手のベンチポケモン全員にも、それぞれ10ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+				'zh-tw': "對手的所有備戰寶可夢也各受到10點傷害。 [在備戰區不計算弱點・抵抗力。]",
+				th: "โปเกมอนบนเบนช์ฝ่ายตรงข้ามทุกตัว ก็จะได้รับแดเมจตัวละ 10 ด้วย {โปเกมอนบนเบนช์จะไม่นำจุดอ่อนและความต้านทานมาคิด}",
+				id: "Serangan ini juga memberikan kerusakan masing-masing sejumlah 10 kepada semua Pokémon Cadangan lawan. [Kelemahan dan Resistansi Pokémon Cadangan tidak mempengaruhi jumlah kerusakan.]",
+			},
 		},
+	],
 
-		damage: 110,
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
 
-		effect: {
-			ja: "相手のベンチポケモン全員にも、それぞれ10ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
-			'zh-tw': "對手的所有備戰寶可夢也各受到10點傷害。 [在備戰區不計算弱點・抵抗力。]",
-			th: "โปเกมอนบนเบนช์ฝ่ายตรงข้ามทุกตัว ก็จะได้รับแดเมจตัวละ 10 ด้วย {โปเกมอนบนเบนช์จะไม่นำจุดอ่อนและความต้านทานมาคิด}",
-			id: "Serangan ini juga memberikan kerusakan masing-masing sejumlah 10 kepada semua Pokémon Cadangan lawan. [Kelemahan dan Resistansi Pokémon Cadangan tidak mempengaruhi jumlah kerusakan.]"
-		}
-	}],
-
-	weaknesses: [{
-		type: "Lightning",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Fighting",
-		value: "-30"
-	}],
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 719597,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				cardmarket: 837512,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				cardmarket: 837513,
+			},
+		},
+	],
 
 	retreat: 2,
 	regulationMark: "G",
+	rarity: "Rare",
+	dexId: [144],
+};
 
-	thirdParty: {
-		cardmarket: 719597
-	}
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV2a/145.ts
+++ b/data-asia/SV/SV2a/145.ts
@@ -1,78 +1,77 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV2a"
+import { Card } from "../../../interfaces";
+import Set from "../SV2a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "サンダーex",
 		'zh-tw': "閃電鳥ex",
 		th: "ธันเดอร์ex",
-		id: "Zapdos ex"
+		id: "Zapdos ex",
 	},
 
 	illustrator: "takuyoa",
-	rarity: "Double rare",
 	category: "Pokemon",
 	hp: 200,
 	types: ["Lightning"],
+
 	stage: "Basic",
-	suffix: "EX",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			ja: "ボルトフロート",
-			'zh-tw': "伏特浮游",
-			th: "โบลต์โฟลต",
-			id: "Bolt Float"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "ボルトフロート",
+				'zh-tw': "伏特浮游",
+				th: "โบลต์โฟลต",
+				id: "Bolt Float",
+			},
+			effect: {
+				ja: "このポケモンに[L]エネルギーがついているなら、このポケモンのにげるためのエネルギーは、すべてなくなる。",
+				'zh-tw': "若這隻寶可夢身上附有【雷】能量卡，則這隻寶可夢【撤退】所需的能量全部消除。",
+				th: "ถ้าโปเกมอนนี้มีพลังงาน[สายฟ้า]ติดอยู่ พลังงานสำหรับ[หนี]ของโปเกมอนนี้ ทั้งหมดจะหายไป",
+				id: "Jika Pokémon ini mengenakan Energi {Listrik}, Pokémon ini menjadi tidak membutuhkan Energi untuk Mundur.",
+			},
 		},
+	],
 
-		effect: {
-			ja: "このポケモンにエネルギーがついているなら、このポケモンのにげるためのエネルギーは、すべてなくなる。",
-			'zh-tw': "若這隻寶可夢身上附有【雷】能量卡，則這隻寶可夢【撤退】所需的能量全部消除。",
-			th: "ถ้าโปเกมอนนี้มีพลังงาน[สายฟ้า]ติดอยู่ พลังงานสำหรับ[หนี]ของโปเกมอนนี้ ทั้งหมดจะหายไป",
-			id: "Jika Pokémon ini mengenakan Energi {Listrik}, Pokémon ini menjadi tidak membutuhkan Energi untuk Mundur."
-		}
-	}],
-
-	attacks: [{
-		cost: ["Lightning", "Lightning", "Lightning"],
-
-		name: {
-			ja: "いなずまれんだん",
-			'zh-tw': "閃電連彈",
-			th: "ฟ้าแลบต่อเนื่อง",
-			id: "Kilat Bertubi-tubi"
+	attacks: [
+		{
+			name: {
+				ja: "いなずまれんだん",
+				'zh-tw': "閃電連彈",
+				th: "ฟ้าแลบต่อเนื่อง",
+				id: "Kilat Bertubi-tubi",
+			},
+			damage: 120,
+			cost: ["Lightning", "Lightning", "Lightning"],
+			effect: {
+				ja: "ダメカンがのっている相手のベンチポケモン1匹にも、90ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+				'zh-tw': "對手的身上放置有傷害指示物的1隻備戰寶可夢也受到90點傷害。[在備戰區不計算弱點・抵抗力。]",
+				th: "โปเกมอนบนเบนช์ฝ่ายตรงข้าม 1 ตัวที่มีตัวนับแดเมจวางอยู่ ก็จะได้รับแดเมจ 90 ด้วย {โปเกมอนบนเบนช์จะไม่นำจุดอ่อนและความต้านทานมาคิด}",
+				id: "Serangan ini juga memberikan kerusakan sejumlah 90 kepada 1 Pokémon Cadangan lawan yang memiliki Token Kerusakan. [Kelemahan dan Resistansi Pokémon Cadangan tidak mempengaruhi jumlah kerusakan.]",
+			},
 		},
+	],
 
-		damage: 120,
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
 
-		effect: {
-			ja: "ダメカンがのっている相手のベンチポケモン1匹にも、90ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
-			'zh-tw': "對手的身上放置有傷害指示物的1隻備戰寶可夢也受到90點傷害。[在備戰區不計算弱點・抵抗力。]",
-			th: "โปเกมอนบนเบนช์ฝ่ายตรงข้าม 1 ตัวที่มีตัวนับแดเมจวางอยู่ ก็จะได้รับแดเมจ 90 ด้วย {โปเกมอนบนเบนช์จะไม่นำจุดอ่อนและความต้านทานมาคิด}",
-			id: "Serangan ini juga memberikan kerusakan sejumlah 90 kepada 1 Pokémon Cadangan lawan yang memiliki Token Kerusakan. [Kelemahan dan Resistansi Pokémon Cadangan tidak mempengaruhi jumlah kerusakan.]"
-		}
-	}],
-
-	weaknesses: [{
-		type: "Lightning",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Fighting",
-		value: "-30"
-	}],
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 719598,
+			},
+		},
+	],
 
 	retreat: 2,
 	regulationMark: "G",
+	rarity: "Double rare",
+	dexId: [145],
 
-	thirdParty: {
-		cardmarket: 719598
-	}
-}
+	suffix: "EX",
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV2a/146.ts
+++ b/data-asia/SV/SV2a/146.ts
@@ -1,20 +1,17 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV2a"
+import { Card } from "../../../interfaces";
+import Set from "../SV2a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "ファイヤー",
 		'zh-tw': "火焰鳥",
 		th: "ไฟเยอร์",
-		id: "Moltres"
+		id: "Moltres",
 	},
 
 	illustrator: "KEIICHIRO ITO",
-	rarity: "Rare",
 	category: "Pokemon",
-	dexId: [146],
 	hp: 120,
 	types: ["Fire"],
 
@@ -22,63 +19,77 @@ const card: Card = {
 		ja: "美しく 燃えあがる 翼で 山道を 照らし 遭難者を 助けたと 言い伝えられている。",
 		'zh-tw': "相傳牠會以美麗燃燒的翅膀照亮山路，救助在 山中遇險的人。",
 		th: "เล่าต่อกันมาว่ามันใช้ปีกที่ลุกโชนอันสวยงามส่องเส้นทางภูเขาให้สว่างและช่วยเหลือผู้ประสบภัยในป่า",
-		id: "Disampaikan bahwa Moltres pernah menolong orang yang tersesat dengan menerangi jalan gunung menggunakan sayapnya yang berkobar dengan cantik."
+		id: "Disampaikan bahwa Moltres pernah menolong orang yang tersesat dengan menerangi jalan gunung menggunakan sayapnya yang berkobar dengan cantik.",
 	},
 
 	stage: "Basic",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			ja: "フレアフロート",
-			'zh-tw': "閃焰浮游",
-			th: "แฟลร์โฟลต",
-			id: "Flare Float"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "フレアフロート",
+				'zh-tw': "閃焰浮游",
+				th: "แฟลร์โฟลต",
+				id: "Flare Float",
+			},
+			effect: {
+				ja: "このポケモンに[R]エネルギーがついているなら、このポケモンのにげるためのエネルギーは、すべてなくなる。",
+				'zh-tw': "若這隻寶可夢身上附有【火】能量卡，則這隻寶可夢【撤退】所需的能量全部消除。",
+				th: "ถ้าโปเกมอนนี้มีพลังงาน[ไฟ]ติดอยู่ พลังงานสำหรับ[หนี]ของโปเกมอนนี้ ทั้งหมดจะหายไป",
+				id: "Jika Pokémon ini mengenakan Energi {Api}, Pokémon ini menjadi tidak membutuhkan Energi untuk Mundur.",
+			},
 		},
+	],
 
-		effect: {
-			ja: "このポケモンにエネルギーがついているなら、このポケモンのにげるためのエネルギーは、すべてなくなる。",
-			'zh-tw': "若這隻寶可夢身上附有【火】能量卡，則這隻寶可夢【撤退】所需的能量全部消除。",
-			th: "ถ้าโปเกมอนนี้มีพลังงาน[ไฟ]ติดอยู่ พลังงานสำหรับ[หนี]ของโปเกมอนนี้ ทั้งหมดจะหายไป",
-			id: "Jika Pokémon ini mengenakan Energi {Api}, Pokémon ini menjadi tidak membutuhkan Energi untuk Mundur."
-		}
-	}],
-
-	attacks: [{
-		cost: ["Fire", "Fire", "Fire"],
-
-		name: {
-			ja: "えんじょうひこう",
-			'zh-tw': "爆燃飛行",
-			th: "ลุกไหม้โบยบิน",
-			id: "Terbang Terbakar"
+	attacks: [
+		{
+			name: {
+				ja: "えんじょうひこう",
+				'zh-tw': "爆燃飛行",
+				th: "ลุกไหม้โบยบิน",
+				id: "Terbang Terbakar",
+			},
+			cost: ["Fire", "Fire", "Fire"],
+			effect: {
+				ja: "このポケモンについている[R]エネルギーを2個トラッシュし、相手のベンチポケモン1匹に、120ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+				'zh-tw': "將2個這隻寶可夢身上附加的【火】能量丟棄，對手的1隻備戰寶可夢受到120點傷害。[在備戰區不計算弱點・抵抗力。]",
+				th: "ทิ้งพลังงาน[ไฟ]ที่ติดอยู่กับโปเกมอนนี้ 2 ลูกที่ตำแหน่งทิ้งการ์ด ทำแดเมจ 120 กับโปเกมอนบนเบนช์ฝ่ายตรงข้าม 1 ตัว {โปเกมอนบนเบนช์จะไม่นำจุดอ่อนและความต้านทานมาคิด}",
+				id: "Buang 2 Energi {Api} yang dikenakan pada Pokémon ini ke Trash, serangan ini memberikan kerusakan sejumlah 120 kepada 1 Pokémon Cadangan lawan. [Kelemahan dan Resistansi Pokémon Cadangan tidak mempengaruhi jumlah kerusakan.]",
+			},
 		},
+	],
 
-		effect: {
-			ja: "このポケモンについているエネルギーを2個トラッシュし、相手のベンチポケモン1匹に、120ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
-			'zh-tw': "將2個這隻寶可夢身上附加的【火】能量丟棄，對手的1隻備戰寶可夢受到120點傷害。[在備戰區不計算弱點・抵抗力。]",
-			th: "ทิ้งพลังงาน[ไฟ]ที่ติดอยู่กับโปเกมอนนี้ 2 ลูกที่ตำแหน่งทิ้งการ์ด ทำแดเมจ 120 กับโปเกมอนบนเบนช์ฝ่ายตรงข้าม 1 ตัว {โปเกมอนบนเบนช์จะไม่นำจุดอ่อนและความต้านทานมาคิด}",
-			id: "Buang 2 Energi {Api} yang dikenakan pada Pokémon ini ke Trash, serangan ini memberikan kerusakan sejumlah 120 kepada 1 Pokémon Cadangan lawan. [Kelemahan dan Resistansi Pokémon Cadangan tidak mempengaruhi jumlah kerusakan.]"
-		}
-	}],
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
 
-	weaknesses: [{
-		type: "Lightning",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Fighting",
-		value: "-30"
-	}],
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 719599,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				cardmarket: 837514,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				cardmarket: 837515,
+			},
+		},
+	],
 
 	retreat: 2,
 	regulationMark: "G",
+	rarity: "Rare",
+	dexId: [146],
+};
 
-	thirdParty: {
-		cardmarket: 719599
-	}
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV2a/147.ts
+++ b/data-asia/SV/SV2a/147.ts
@@ -1,20 +1,17 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV2a"
+import { Card } from "../../../interfaces";
+import Set from "../SV2a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "ミニリュウ",
 		'zh-tw': "迷你龍",
 		th: "มินิริว",
-		id: "Dratini"
+		id: "Dratini",
 	},
 
 	illustrator: "Sanosuke Sakuma",
-	rarity: "Common",
 	category: "Pokemon",
-	dexId: [147],
 	hp: 60,
 	types: ["Dragon"],
 
@@ -22,41 +19,64 @@ const card: Card = {
 		ja: "激しく 流れ落ちる 滝に 守られながら 脱皮を 繰り返し どんどん 大きくなる。",
 		'zh-tw': "會在直瀉而下的瀑布保護下反覆蛻皮， 使身體變得越來越大。",
 		th: "ขณะที่ถูกปกป้องด้วยน้ำตกที่ไหลแรง ก็จะลอกคราบไปเรื่อย ๆ จนค่อย ๆ โตขึ้น",
-		id: "Sambil dilindungi air terjun yang mengalir deras, Dratini terus-menerus berganti kulit dan tumbuh membesar."
+		id: "Sambil dilindungi air terjun yang mengalir deras, Dratini terus-menerus berganti kulit dan tumbuh membesar.",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		cost: ["Water"],
-
-		name: {
-			ja: "たたく",
-			'zh-tw': "敲擊",
-			th: "ตี",
-			id: "Menghantam"
+	attacks: [
+		{
+			name: {
+				ja: "たたく",
+				'zh-tw': "敲擊",
+				th: "ตี",
+				id: "Menghantam",
+			},
+			damage: 10,
+			cost: ["Water"],
 		},
-
-		damage: 10
-	}, {
-		cost: ["Water", "Lightning"],
-
-		name: {
-			ja: "ドラゴンウィップ",
-			'zh-tw': "龍之鞭打",
-			th: "ดรากอนวิป",
-			id: "Dragon Whip"
+		{
+			name: {
+				ja: "ドラゴンウィップ",
+				'zh-tw': "龍之鞭打",
+				th: "ดรากอนวิป",
+				id: "Dragon Whip",
+			},
+			damage: 40,
+			cost: ["Water", "Lightning"],
 		},
+	],
 
-		damage: 40
-	}],
+	weaknesses: [],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 719600,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				cardmarket: 837516,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				cardmarket: 837517,
+			},
+		},
+	],
 
 	retreat: 1,
 	regulationMark: "G",
+	rarity: "Common",
+	dexId: [147],
+};
 
-	thirdParty: {
-		cardmarket: 719600
-	}
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV2a/148.ts
+++ b/data-asia/SV/SV2a/148.ts
@@ -1,20 +1,17 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV2a"
+import { Card } from "../../../interfaces";
+import Set from "../SV2a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "ハクリュー",
 		'zh-tw': "哈克龍",
 		th: "ฮาคุริว",
-		id: "Dragonair"
+		id: "Dragonair",
 	},
 
 	illustrator: "Sanosuke Sakuma",
-	rarity: "Uncommon",
 	category: "Pokemon",
-	dexId: [148],
 	hp: 100,
 	types: ["Dragon"],
 
@@ -22,48 +19,74 @@ const card: Card = {
 		ja: "全身から オーラが 出されると あたりの 天候が みるみるうちに 変わっていく という。",
 		'zh-tw': "據說牠全身上下散發出氣場時，周圍的天氣 就會在轉眼間為之一變。",
 		th: "ว่ากันว่าอากาศโดยรอบจะเปลี่ยนไปทันทีที่มันปล่อยออร่าออกมาจากทั่วทั้งตัว",
-		id: "Dikabarkan jika Dragonair mengeluarkan aura dari seluruh tubuhnya, cuaca di sekitarnya langsung berubah."
+		id: "Dikabarkan jika Dragonair mengeluarkan aura dari seluruh tubuhnya, cuaca di sekitarnya langsung berubah.",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		cost: ["Water"],
-
-		name: {
-			ja: "たたく",
-			'zh-tw': "敲擊",
-			th: "ตี",
-			id: "Menghantam"
+	attacks: [
+		{
+			name: {
+				ja: "たたく",
+				'zh-tw': "敲擊",
+				th: "ตี",
+				id: "Menghantam",
+			},
+			damage: 20,
+			cost: ["Water"],
 		},
-
-		damage: 20
-	}, {
-		cost: ["Water", "Lightning"],
-
-		name: {
-			ja: "アクアスラッシュ",
-			'zh-tw': "水流斬",
-			th: "อควาสแลช",
-			id: "Aqua Slash"
+		{
+			name: {
+				ja: "アクアスラッシュ",
+				'zh-tw': "水流斬",
+				th: "อควาสแลช",
+				id: "Aqua Slash",
+			},
+			damage: 90,
+			cost: ["Water", "Lightning"],
+			effect: {
+				ja: "次の自分の番、このポケモンはワザが使えない。",
+				'zh-tw': "在下個自己的回合，這隻寶可夢無法使用招式。",
+				th: "เทิร์นถัดไปของฝ่ายเรา โปเกมอนนี้จะใช้ท่าต่อสู้ไม่ได้",
+				id: "Pada giliran sendiri berikutnya, Pokémon ini tidak dapat menggunakan serangan.",
+			},
 		},
+	],
 
-		damage: 90,
+	weaknesses: [],
+	resistances: [],
 
-		effect: {
-			ja: "次の自分の番、このポケモンはワザが使えない。",
-			'zh-tw': "在下個自己的回合，這隻寶可夢無法使用招式。",
-			th: "เทิร์นถัดไปของฝ่ายเรา โปเกมอนนี้จะใช้ท่าต่อสู้ไม่ได้",
-			id: "Pada giliran sendiri berikutnya, Pokémon ini tidak dapat menggunakan serangan."
-		}
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 719601,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				cardmarket: 837518,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				cardmarket: 837519,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ミニリュウ",
+	},
 
 	retreat: 2,
 	regulationMark: "G",
+	rarity: "Uncommon",
+	dexId: [148],
+};
 
-	thirdParty: {
-		cardmarket: 719601
-	}
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV2a/149.ts
+++ b/data-asia/SV/SV2a/149.ts
@@ -1,20 +1,17 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV2a"
+import { Card } from "../../../interfaces";
+import Set from "../SV2a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "カイリュー",
 		'zh-tw': "快龍",
 		th: "ไคริว",
-		id: "Dragonite"
+		id: "Dragonite",
 	},
 
 	illustrator: "Sanosuke Sakuma",
-	rarity: "Rare",
 	category: "Pokemon",
-	dexId: [149],
 	hp: 180,
 	types: ["Dragon"],
 
@@ -22,55 +19,82 @@ const card: Card = {
 		ja: "広い 海の どこかには カイリューだけが 集まって 暮らす 島が あるらしい。",
 		'zh-tw': "在廣大海洋的某處，似乎存在著只群居著 快龍的島。",
 		th: "เหมือนจะมีเกาะสักแห่งในทะเลแสนกว้างใหญ่ที่มีแต่เหล่าไคริวอาศัยอยู่",
-		id: "Kabarnya pada suatu tempat di laut yang luas, terdapat pulau yang hanya ditempati oleh kumpulan Dragonite."
+		id: "Kabarnya pada suatu tempat di laut yang luas, terdapat pulau yang hanya ditempati oleh kumpulan Dragonite.",
 	},
 
 	stage: "Stage2",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			ja: "ジェットクルーズ",
-			'zh-tw': "噴射巡航",
-			th: "เจ็ตครูส",
-			id: "Jet Cruise"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "ジェットクルーズ",
+				'zh-tw': "噴射巡航",
+				th: "เจ็ตครูส",
+				id: "Jet Cruise",
+			},
+			effect: {
+				ja: "このポケモンがいるかぎり、自分のポケモン全員のにげるためのエネルギーは、すべてなくなる。",
+				'zh-tw': "只要這隻寶可夢在場上，自己的所有寶可夢【撤退】所需的能量全部消除。",
+				th: "ตราบใดที่โปเกมอนนี้ยังอยู่ พลังงานสำหรับ[หนี]ของโปเกมอนฝ่ายเราทุกตัว ทั้งหมดจะหายไป",
+				id: "Selama Pokémon ini ada di Arena, semua Pokémon sendiri menjadi tidak membutuhkan Energi untuk Mundur.",
+			},
 		},
+	],
 
-		effect: {
-			ja: "このポケモンがいるかぎり、自分のポケモン全員のにげるためのエネルギーは、すべてなくなる。",
-			'zh-tw': "只要這隻寶可夢在場上，自己的所有寶可夢【撤退】所需的能量全部消除。",
-			th: "ตราบใดที่โปเกมอนนี้ยังอยู่ พลังงานสำหรับ[หนี]ของโปเกมอนฝ่ายเราทุกตัว ทั้งหมดจะหายไป",
-			id: "Selama Pokémon ini ada di Arena, semua Pokémon sendiri menjadi tidak membutuhkan Energi untuk Mundur."
-		}
-	}],
-
-	attacks: [{
-		cost: ["Water", "Lightning"],
-
-		name: {
-			ja: "りゅうのはどう",
-			'zh-tw': "龍之波動",
-			th: "คลื่นมังกร",
-			id: "Aura Naga"
+	attacks: [
+		{
+			name: {
+				ja: "りゅうのはどう",
+				'zh-tw': "龍之波動",
+				th: "คลื่นมังกร",
+				id: "Aura Naga",
+			},
+			damage: 180,
+			cost: ["Water", "Lightning"],
+			effect: {
+				ja: "自分の山札を上から2枚トラッシュする。",
+				'zh-tw': "將自己的牌庫上方2張卡丟棄。",
+				th: "ทิ้งการ์ด 2 ใบจากด้านบนของสำรับการ์ดฝ่ายเราที่ตำแหน่งทิ้งการ์ด",
+				id: "Buang 2 kartu dari atas Deck sendiri ke Trash.",
+			},
 		},
+	],
 
-		damage: 180,
+	weaknesses: [],
+	resistances: [],
 
-		effect: {
-			ja: "自分の山札を上から2枚トラッシュする。",
-			'zh-tw': "將自己的牌庫上方2張卡丟棄。",
-			th: "ทิ้งการ์ด 2 ใบจากด้านบนของสำรับการ์ดฝ่ายเราที่ตำแหน่งทิ้งการ์ด",
-			id: "Buang 2 kartu dari atas Deck sendiri ke Trash."
-		}
-	}],
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 719602,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				cardmarket: 837520,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				cardmarket: 837521,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ハクリュー",
+	},
 
 	retreat: 3,
 	regulationMark: "G",
+	rarity: "Rare",
+	dexId: [149],
+};
 
-	thirdParty: {
-		cardmarket: 719602
-	}
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV2a/150.ts
+++ b/data-asia/SV/SV2a/150.ts
@@ -1,20 +1,17 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV2a"
+import { Card } from "../../../interfaces";
+import Set from "../SV2a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "ミュウツー",
 		'zh-tw': "超夢",
 		th: "มิวทู",
-		id: "Mewtwo"
+		id: "Mewtwo",
 	},
 
 	illustrator: "AKIRA EGAWA",
-	rarity: "Rare",
 	category: "Pokemon",
-	dexId: [150],
 	hp: 130,
 	types: ["Psychic"],
 
@@ -22,65 +19,76 @@ const card: Card = {
 		ja: "ミュウの 遺伝子を 組み替えて 生み出された。ポケモンで 一番 凶暴な 心を 持つという。",
 		'zh-tw': "藉著重組夢幻的基因而誕生。 據說有著所有寶可夢中最殘暴的心。",
 		th: "ถูกสร้างขึ้นมาจากการดัดแปลงหน่วยพันธุกรรมของมิว ว่ากันว่ามันมีจิตใจที่โหดร้ายที่สุดในบรรดาโปเกมอน",
-		id: "Mewtwo terlahir dari rekayasa genetik Mew. Dikatakan sebagai Pokémon dengan hati paling brutal."
+		id: "Mewtwo terlahir dari rekayasa genetik Mew. Dikatakan sebagai Pokémon dengan hati paling brutal.",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		cost: ["Colorless", "Colorless"],
-
-		name: {
-			ja: "リフレクトバリア",
-			'zh-tw': "反射屏障",
-			th: "รีเฟล็กต์บาเรีย",
-			id: "Reflect Barrier"
+	attacks: [
+		{
+			name: {
+				ja: "リフレクトバリア",
+				'zh-tw': "反射屏障",
+				th: "รีเฟล็กต์บาเรีย",
+				id: "Reflect Barrier",
+			},
+			damage: 20,
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "次の相手の番、このポケモンがワザのダメージを受けたとき、受けたダメージぶんのダメカンを、ワザを使ったポケモンにのせる。",
+				'zh-tw': "在下個對手的回合，這隻寶可夢受到招式的傷害時，將與受到的傷害相同數值的傷害指示物，放置於使用招式的寶可夢身上。",
+				th: "เทิร์นถัดไปของฝ่ายตรงข้าม เมื่อโปเกมอนนี้ได้รับแดเมจของท่าต่อสู้ วางตัวนับแดเมจบนโปเกมอนที่ใช้ท่าต่อสู้ ตามจำนวนแดเมจที่ได้รับมา",
+				id: "Pada giliran lawan berikutnya, saat Pokémon ini menerima kerusakan akibat serangan, letakkan Token Kerusakan sejumlah kerusakan yang diterima pada Pokémon yang telah menggunakan serangan.",
+			},
 		},
-
-		damage: 20,
-
-		effect: {
-			ja: "次の相手の番、このポケモンがワザのダメージを受けたとき、受けたダメージぶんのダメカンを、ワザを使ったポケモンにのせる。",
-			'zh-tw': "在下個對手的回合，這隻寶可夢受到招式的傷害時，將與受到的傷害相同數值的傷害指示物，放置於使用招式的寶可夢身上。",
-			th: "เทิร์นถัดไปของฝ่ายตรงข้าม เมื่อโปเกมอนนี้ได้รับแดเมจของท่าต่อสู้ วางตัวนับแดเมจบนโปเกมอนที่ใช้ท่าต่อสู้ ตามจำนวนแดเมจที่ได้รับมา",
-			id: "Pada giliran lawan berikutnya, saat Pokémon ini menerima kerusakan akibat serangan, letakkan Token Kerusakan sejumlah kerusakan yang diterima pada Pokémon yang telah menggunakan serangan."
-		}
-	}, {
-		cost: ["Psychic", "Psychic", "Colorless"],
-
-		name: {
-			ja: "サイコストライク",
-			'zh-tw': "精神強襲",
-			th: "ไซโคสไตรค์",
-			id: "Psychostrike"
+		{
+			name: {
+				ja: "サイコストライク",
+				'zh-tw': "精神強襲",
+				th: "ไซโคสไตรค์",
+				id: "Psychostrike",
+			},
+			damage: 130,
+			cost: ["Psychic", "Psychic", "Colorless"],
+			effect: {
+				ja: "このポケモンについているエネルギーを2個選び、トラッシュする。",
+				'zh-tw': "選擇2個這隻寶可夢身上附加的能量，將其丟棄。",
+				th: "เลือกพลังงานที่ติดอยู่กับโปเกมอนนี้ 2 ลูก ทิ้งที่ตำแหน่งทิ้งการ์ด",
+				id: "Pilih 2 Energi yang dikenakan pada Pokémon ini, lalu buang ke Trash.",
+			},
 		},
+	],
 
-		damage: 130,
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
 
-		effect: {
-			ja: "このポケモンについているエネルギーを2個選び、トラッシュする。",
-			'zh-tw': "選擇2個這隻寶可夢身上附加的能量，將其丟棄。",
-			th: "เลือกพลังงานที่ติดอยู่กับโปเกมอนนี้ 2 ลูก ทิ้งที่ตำแหน่งทิ้งการ์ด",
-			id: "Pilih 2 Energi yang dikenakan pada Pokémon ini, lalu buang ke Trash."
-		}
-	}],
-
-	weaknesses: [{
-		type: "Darkness",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Fighting",
-		value: "-30"
-	}],
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 719603,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				cardmarket: 837522,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				cardmarket: 837523,
+			},
+		},
+	],
 
 	retreat: 2,
 	regulationMark: "G",
+	rarity: "Rare",
+	dexId: [150],
+};
 
-	thirdParty: {
-		cardmarket: 719603
-	}
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV2a/151.ts
+++ b/data-asia/SV/SV2a/151.ts
@@ -1,76 +1,76 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV2a"
+import { Card } from "../../../interfaces";
+import Set from "../SV2a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "ミュウex",
 		'zh-tw': "夢幻ex",
 		th: "มิวex",
-		id: "Mew ex"
+		id: "Mew ex",
 	},
 
 	illustrator: "aky CG Works",
-	rarity: "Double rare",
 	category: "Pokemon",
 	hp: 180,
 	types: ["Psychic"],
+
 	stage: "Basic",
-	suffix: "EX",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			ja: "リスタート",
-			'zh-tw': "重啟",
-			th: "รีสตาร์ต",
-			id: "Restart"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "リスタート",
+				'zh-tw': "重啟",
+				th: "รีสตาร์ต",
+				id: "Restart",
+			},
+			effect: {
+				ja: "自分の番に1回使える。自分の手札が3枚になるように、山札を引く。",
+				'zh-tw': "在自己的回合時可使用1次。從牌庫抽卡直到自己的手牌滿3張為止。",
+				th: "ใช้ได้ 1 ครั้งในเทิร์นฝ่ายเรา จั่วการ์ดจากสำรับการ์ด จนได้การ์ดบนมือฝ่ายเราเป็น 3 ใบ",
+				id: "Dapat digunakan 1 kali pada giliran sendiri. Ambil kartu dari atas Deck hingga jumlah Kartu Pegangan sendiri menjadi 3 lembar.",
+			},
 		},
+	],
 
-		effect: {
-			ja: "自分の番に1回使える。自分の手札が3枚になるように、山札を引く。",
-			'zh-tw': "在自己的回合時可使用1次。從牌庫抽卡直到自己的手牌滿3張為止。",
-			th: "ใช้ได้ 1 ครั้งในเทิร์นฝ่ายเรา จั่วการ์ดจากสำรับการ์ด จนได้การ์ดบนมือฝ่ายเราเป็น 3 ใบ",
-			id: "Dapat digunakan 1 kali pada giliran sendiri. Ambil kartu dari atas Deck hingga jumlah Kartu Pegangan sendiri menjadi 3 lembar."
-		}
-	}],
-
-	attacks: [{
-		cost: ["Colorless", "Colorless", "Colorless"],
-
-		name: {
-			ja: "ゲノムハック",
-			'zh-tw': "基因駭入",
-			th: "จีโนมแฮก",
-			id: "Genome Hack"
+	attacks: [
+		{
+			name: {
+				ja: "ゲノムハック",
+				'zh-tw': "基因駭入",
+				th: "จีโนมแฮก",
+				id: "Genome Hack",
+			},
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンが持っているワザを1つ選び、このワザとして使う。",
+				'zh-tw': "選擇1個對手的戰鬥寶可夢持有的招式，作為這個招式使用。",
+				th: "เลือกท่าต่อสู้ที่โปเกมอนบนตำแหน่งต่อสู้ฝ่ายตรงข้ามมี 1 ท่า ใช้เป็นท่าต่อสู้นี้ได้",
+				id: "Pilih 1 serangan yang dimiliki Pokémon Bertarung lawan, lalu gunakan sebagai serangan ini.",
+			},
 		},
+	],
 
-		effect: {
-			ja: "相手のバトルポケモンが持っているワザを1つ選び、このワザとして使う。",
-			'zh-tw': "選擇1個對手的戰鬥寶可夢持有的招式，作為這個招式使用。",
-			th: "เลือกท่าต่อสู้ที่โปเกมอนบนตำแหน่งต่อสู้ฝ่ายตรงข้ามมี 1 ท่า ใช้เป็นท่าต่อสู้นี้ได้",
-			id: "Pilih 1 serangan yang dimiliki Pokémon Bertarung lawan, lalu gunakan sebagai serangan ini."
-		}
-	}],
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
 
-	weaknesses: [{
-		type: "Darkness",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Fighting",
-		value: "-30"
-	}],
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 719604,
+			},
+		},
+	],
 
 	retreat: 0,
 	regulationMark: "G",
+	rarity: "Double rare",
+	dexId: [151],
 
-	thirdParty: {
-		cardmarket: 719604
-	}
-}
+	suffix: "EX",
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV2a/152.ts
+++ b/data-asia/SV/SV2a/152.ts
@@ -1,29 +1,51 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV2a"
+import { Card } from "../../../interfaces";
+import Set from "../SV2a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "エネルギーシール",
 		'zh-tw': "能量貼紙",
 		th: "สติกเกอร์พลังงาน",
-		id: "Stiker Energi"
+		id: "Stiker Energi",
 	},
 
 	illustrator: "Ayaka Yoshida",
-	rarity: "Uncommon",
 	category: "Trainer",
 
 	effect: {
 		ja: "コインを1回投げオモテなら、自分のトラッシュから基本エネルギーを1枚選び、ベンチポケモンにつける。",
 		'zh-tw': "擲1次硬幣若為正面，則從自己的棄牌區選擇1張基本能量卡，附於備戰寶可夢身上。",
 		th: "ทอยเหรียญ 1 ครั้งถ้าออกหัว เลือกการ์ดพลังงานพื้นฐาน 1 ใบจากตำแหน่งทิ้งการ์ดฝ่ายเรา ติดที่โปเกมอนบนเบนช์",
-		id: "Lempar koin 1 kali. Jika hasilnya sisi depan, pilih 1 lembar Energi Dasar dari Trash sendiri, lalu kenakan pada Pokémon Cadangan."
+		id: "Lempar koin 1 kali. Jika hasilnya sisi depan, pilih 1 lembar Energi Dasar dari Trash sendiri, lalu kenakan pada Pokémon Cadangan.",
 	},
 
-	trainerType: "Item",
-	regulationMark: "G"
-}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 719605,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				cardmarket: 837524,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				cardmarket: 837525,
+			},
+		},
+	],
 
-export default card
+	trainerType: "Item",
+	regulationMark: "G",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SV/SV2a/153.ts
+++ b/data-asia/SV/SV2a/153.ts
@@ -1,29 +1,51 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV2a"
+import { Card } from "../../../interfaces";
+import Set from "../SV2a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "スナッチアーム",
 		'zh-tw': "抓換臂",
 		th: "สแนชอาร์ม",
-		id: "Snatch Arm"
+		id: "Snatch Arm",
 	},
 
 	illustrator: "inose yukie",
-	rarity: "Uncommon",
 	category: "Trainer",
 
 	effect: {
 		ja: "相手の手札を見て、その中からポケモンを1枚選び、相手の山札の下にもどす。",
 		'zh-tw': "查看對手的手牌，從其中選擇1張寶可夢卡，放回對手的牌庫下方。",
 		th: "ดูการ์ดบนมือฝ่ายตรงข้าม เลือกการ์ดโปเกมอน 1 ใบจากในนั้น ใส่กลับไปด้านล่างของสำรับการ์ดฝ่ายตรงข้าม",
-		id: "Lihat Kartu Pegangan lawan, pilih 1 lembar Pokémon di antaranya, lalu kembalikan ke bawah Deck lawan."
+		id: "Lihat Kartu Pegangan lawan, pilih 1 lembar Pokémon di antaranya, lalu kembalikan ke bawah Deck lawan.",
 	},
 
-	trainerType: "Item",
-	regulationMark: "G"
-}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 719606,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				cardmarket: 837526,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				cardmarket: 837527,
+			},
+		},
+	],
 
-export default card
+	trainerType: "Item",
+	regulationMark: "G",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SV/SV2a/154.ts
+++ b/data-asia/SV/SV2a/154.ts
@@ -1,30 +1,51 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV2a"
+import { Card } from "../../../interfaces";
+import Set from "../SV2a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "古びたかいの化石",
 		'zh-tw': "陳舊的貝殼化石",
 		th: "ฟอสซิลหอยเก่าแก่",
-		id: "Fosil Kerang Usang"
+		id: "Fosil Kerang Usang",
 	},
 
 	illustrator: "AYUMI ODASHIMA",
-	rarity: "Common",
 	category: "Trainer",
-	hp: 60,
 
 	effect: {
-		ja: "このカードは、HP60のタイプのたねポケモンとして、場に出せる。このカードは、特殊状態にならず、にげられない。\n自分の番の中でなら、場に出ているこのカードをトラッシュできる。",
+		ja: "このカードは、HP60の[C]タイプのたねポケモンとして、場に出せる。このカードは、特殊状態にならず、にげられない。自分の番の中でなら、場に出ているこのカードをトラッシュできる。",
 		'zh-tw': "這張卡可作為HP60的【無】屬性的【基礎】寶可夢放置於場上。這張卡不會陷入特殊狀態，無法撤退。若在自己的回合中，則可將場上的這張卡丟棄。 [特性]貝殼潮漩 只要這隻寶可夢在戰鬥場上，對手無法從手牌使出競技場卡。",
 		th: "การ์ดนี้ สามารถวางบนกระดานได้ เทียบเท่ากับโปเกมอน[พื้นฐาน]ประเภท[ไร้สี]ที่มี HP 60 การ์ดนี้ จะไม่เป็นสภาวะผิดปกติ และจะหนีไม่ได้ ถ้าอยู่ภายในเทิร์นฝ่ายเรา จะทิ้งการ์ดนี้ที่วางอยู่บนกระดานที่ตำแหน่งทิ้งการ์ดได้ [ความสามารถ] เกลียวคลื่นหอย ตราบใดที่โปเกมอนนี้ยังอยู่บนตำแหน่งต่อสู้ ฝ่ายตรงข้ามจะนำการ์ดสเตเดียมจากบนมือออกมาไม่ได้",
-		id: "Kartu ini dapat dimasukkan ke Arena sebagai Pokémon Basic tipe {Bening} dengan HP sejumlah 60. Kartu ini tidak akan menjadi Kondisi Khusus dan tidak dapat Mundur. Pada giliran sendiri, kartu ini yang ada di Arena dapat dibuang ke Trash. [Ability] Ombak Kerang Selama Pokémon ini ada di Arena Bertarung, lawan tidak dapat memasukkan Stadium dari Kartu Pegangan."
+		id: "Kartu ini dapat dimasukkan ke Arena sebagai Pokémon Basic tipe {Bening} dengan HP sejumlah 60. Kartu ini tidak akan menjadi Kondisi Khusus dan tidak dapat Mundur. Pada giliran sendiri, kartu ini yang ada di Arena dapat dibuang ke Trash. [Ability] Ombak Kerang Selama Pokémon ini ada di Arena Bertarung, lawan tidak dapat memasukkan Stadium dari Kartu Pegangan.",
 	},
 
-	trainerType: "Item",
-	regulationMark: "G"
-}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 719607,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				cardmarket: 837528,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				cardmarket: 837529,
+			},
+		},
+	],
 
-export default card
+	trainerType: "Item",
+	regulationMark: "G",
+	rarity: "Common",
+};
+
+export default card;

--- a/data-asia/SV/SV2a/155.ts
+++ b/data-asia/SV/SV2a/155.ts
@@ -1,30 +1,51 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV2a"
+import { Card } from "../../../interfaces";
+import Set from "../SV2a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "古びたこうらの化石",
 		'zh-tw': "陳舊的甲殼化石",
 		th: "ฟอสซิลกระดองเก่าแก่",
-		id: "Fosil Cangkang Usang"
+		id: "Fosil Cangkang Usang",
 	},
 
 	illustrator: "AYUMI ODASHIMA",
-	rarity: "Common",
 	category: "Trainer",
-	hp: 60,
 
 	effect: {
-		ja: "このカードは、HP60のタイプのたねポケモンとして、場に出せる。このカードは、特殊状態にならず、にげられない。\n自分の番の中でなら、場に出ているこのカードをトラッシュできる。",
+		ja: "このカードは、HP60の[C]タイプのたねポケモンとして、場に出せる。このカードは、特殊状態にならず、にげられない。自分の番の中でなら、場に出ているこのカードをトラッシュできる。",
 		'zh-tw': "這張卡可作為HP60的【無】屬性的【基礎】寶可夢放置於場上。這張卡不會陷入特殊狀態，無法撤退。若在自己的回合中，則可將場上的這張卡丟棄。 [特性]甲殼鎧甲 這隻寶可夢受到招式的傷害「-30」點。",
 		th: "การ์ดนี้ สามารถวางบนกระดานได้ เทียบเท่ากับโปเกมอน[พื้นฐาน]ประเภท[ไร้สี]ที่มี HP 60 การ์ดนี้ จะไม่เป็นสภาวะผิดปกติ และจะหนีไม่ได้ ถ้าอยู่ภายในเทิร์นฝ่ายเรา จะทิ้งการ์ดนี้ที่วางอยู่บนกระดานที่ตำแหน่งทิ้งการ์ดได้ [ความสามารถ] เกราะกระดอง แดเมจของท่าต่อสู้ที่โปเกมอนนี้จะได้รับจะถูก [-30]",
-		id: "Kartu ini dapat dimasukkan ke Arena sebagai Pokémon Basic tipe {Bening} dengan HP sejumlah 60. Kartu ini tidak akan menjadi Kondisi Khusus dan tidak dapat Mundur. Pada giliran sendiri, kartu ini yang ada di Arena dapat dibuang ke Trash. [Ability] Lamina Cangkang Kerusakan akibat serangan yang diterima Pokémon ini berkurang sejumlah 30."
+		id: "Kartu ini dapat dimasukkan ke Arena sebagai Pokémon Basic tipe {Bening} dengan HP sejumlah 60. Kartu ini tidak akan menjadi Kondisi Khusus dan tidak dapat Mundur. Pada giliran sendiri, kartu ini yang ada di Arena dapat dibuang ke Trash. [Ability] Lamina Cangkang Kerusakan akibat serangan yang diterima Pokémon ini berkurang sejumlah 30.",
 	},
 
-	trainerType: "Item",
-	regulationMark: "G"
-}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 719608,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				cardmarket: 837530,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				cardmarket: 837531,
+			},
+		},
+	],
 
-export default card
+	trainerType: "Item",
+	regulationMark: "G",
+	rarity: "Common",
+};
+
+export default card;

--- a/data-asia/SV/SV2a/156.ts
+++ b/data-asia/SV/SV2a/156.ts
@@ -1,30 +1,51 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV2a"
+import { Card } from "../../../interfaces";
+import Set from "../SV2a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "古びたひみつのコハク",
 		'zh-tw': "陳舊的秘密琥珀",
 		th: "อำพันลึกลับเก่าแก่",
-		id: "Ambar Rahasia Usang"
+		id: "Ambar Rahasia Usang",
 	},
 
 	illustrator: "AYUMI ODASHIMA",
-	rarity: "Common",
 	category: "Trainer",
-	hp: 60,
 
 	effect: {
-		ja: "このカードは、HP60のタイプのたねポケモンとして、場に出せる。このカードは、特殊状態にならず、にげられない。\n自分の番の中でなら、場に出ているこのカードをトラッシュできる。",
+		ja: "このカードは、HP60の[C]タイプのたねポケモンとして、場に出せる。このカードは、特殊状態にならず、にげられない。自分の番の中でなら、場に出ているこのカードをトラッシュできる。",
 		'zh-tw': "這張卡可作為HP60的【無】屬性的【基礎】寶可夢放置於場上。這張卡不會陷入特殊狀態，無法撤退。若在自己的回合中，則可將場上的這張卡丟棄。 [特性]琥珀守護 這隻寶可夢不會受到對手的寶可夢特性效果的影響。",
 		th: "การ์ดนี้ สามารถวางบนกระดานได้ เทียบเท่ากับโปเกมอน[พื้นฐาน]ประเภท[ไร้สี]ที่มี HP 60 การ์ดนี้ จะไม่เป็นสภาวะผิดปกติ และจะหนีไม่ได้ ถ้าอยู่ภายในเทิร์นฝ่ายเรา จะทิ้งการ์ดนี้ที่วางอยู่บนกระดานที่ตำแหน่งทิ้งการ์ดได้ [ความสามารถ] เครื่องรางอำพัน โปเกมอนนี้ จะไม่ได้รับเอฟเฟกต์ของความสามารถจากโปเกมอนฝ่ายตรงข้าม",
-		id: "Kartu ini dapat dimasukkan ke Arena sebagai Pokémon Basic tipe {Bening} dengan HP sejumlah 60. Kartu ini tidak akan menjadi Kondisi Khusus dan tidak dapat Mundur. Pada giliran sendiri, kartu ini yang ada di Arena dapat dibuang ke Trash. [Ability] Perlindungan Ambar Pokémon ini tidak menerima efek akibat Ability dari Pokémon lawan."
+		id: "Kartu ini dapat dimasukkan ke Arena sebagai Pokémon Basic tipe {Bening} dengan HP sejumlah 60. Kartu ini tidak akan menjadi Kondisi Khusus dan tidak dapat Mundur. Pada giliran sendiri, kartu ini yang ada di Arena dapat dibuang ke Trash. [Ability] Perlindungan Ambar Pokémon ini tidak menerima efek akibat Ability dari Pokémon lawan.",
 	},
 
-	trainerType: "Item",
-	regulationMark: "G"
-}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 719609,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				cardmarket: 837532,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				cardmarket: 837533,
+			},
+		},
+	],
 
-export default card
+	trainerType: "Item",
+	regulationMark: "G",
+	rarity: "Common",
+};
+
+export default card;

--- a/data-asia/SV/SV2a/157.ts
+++ b/data-asia/SV/SV2a/157.ts
@@ -1,29 +1,51 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV2a"
+import { Card } from "../../../interfaces";
+import Set from "../SV2a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "安全ゴーグル",
 		'zh-tw': "安全護目鏡",
 		th: "แว่นนิรภัย",
-		id: "Kacamata Keselamatan"
+		id: "Kacamata Keselamatan",
 	},
 
 	illustrator: "Toyste Beach",
-	rarity: "Uncommon",
 	category: "Trainer",
 
 	effect: {
 		ja: "このカードをつけているたねポケモンの弱点は、すべてなくなる。",
 		'zh-tw': "附有這張卡的【基礎】寶可夢的弱點全部消除。",
 		th: "จุดอ่อนของโปเกมอน[พื้นฐาน]ที่ติดการ์ดนี้อยู่ ทั้งหมดจะหายไป",
-		id: "Pokémon Basic yang mengenakan kartu ini menjadi tidak memiliki Kelemahan."
+		id: "Pokémon Basic yang mengenakan kartu ini menjadi tidak memiliki Kelemahan.",
 	},
 
-	trainerType: "Tool",
-	regulationMark: "G"
-}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 719610,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				cardmarket: 837534,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				cardmarket: 837535,
+			},
+		},
+	],
 
-export default card
+	trainerType: "Tool",
+	regulationMark: "G",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SV/SV2a/158.ts
+++ b/data-asia/SV/SV2a/158.ts
@@ -1,29 +1,51 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV2a"
+import { Card } from "../../../interfaces";
+import Set from "../SV2a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "大きなふうせん",
 		'zh-tw': "大氣球",
 		th: "ลูกโป่งยักษ์",
-		id: "Balon Besar"
+		id: "Balon Besar",
 	},
 
 	illustrator: "Toyste Beach",
-	rarity: "Uncommon",
 	category: "Trainer",
 
 	effect: {
 		ja: "このカードをつけている2進化ポケモンのにげるためのエネルギーは、すべてなくなる。",
 		'zh-tw': "附有這張卡的【2階進化】寶可夢【撤退】所需的能量全部消除。",
 		th: "พลังงานสำหรับ[หนี]ของโปเกมอน[ร่าง2] ที่ติดการ์ดนี้อยู่ ทั้งหมดจะหายไป",
-		id: "Pokémon Stage 2 yang mengenakan kartu ini menjadi tidak membutuhkan Energi untuk Mundur."
+		id: "Pokémon Stage 2 yang mengenakan kartu ini menjadi tidak membutuhkan Energi untuk Mundur.",
 	},
 
-	trainerType: "Tool",
-	regulationMark: "G"
-}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 719611,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				cardmarket: 837536,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				cardmarket: 837537,
+			},
+		},
+	],
 
-export default card
+	trainerType: "Tool",
+	regulationMark: "G",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SV/SV2a/159.ts
+++ b/data-asia/SV/SV2a/159.ts
@@ -1,29 +1,51 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV2a"
+import { Card } from "../../../interfaces";
+import Set from "../SV2a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "ガチガチバンド",
 		'zh-tw': "硬硬束帶",
 		th: "สายรัดแข็งเป๊ก",
-		id: "Gelang Kaku"
+		id: "Gelang Kaku",
 	},
 
 	illustrator: "Toyste Beach",
-	rarity: "Uncommon",
 	category: "Trainer",
 
 	effect: {
 		ja: "このカードをつけている1進化ポケモンが、相手のポケモンから受けるワザのダメージは「-30」される。",
 		'zh-tw': "附有這張卡的【1階進化】寶可夢，受到對手的寶可夢招式的傷害「-30」點。",
 		th: "แดเมจของท่าต่อสู้ที่โปเกมอน[ร่าง1] ที่ติดการ์ดนี้อยู่ จะได้รับจากโปเกมอนฝ่ายตรงข้ามจะถูก [-30]",
-		id: "Kerusakan akibat serangan dari Pokémon lawan yang diterima Pokémon Stage 1 yang mengenakan kartu ini berkurang sejumlah 30."
+		id: "Kerusakan akibat serangan dari Pokémon lawan yang diterima Pokémon Stage 1 yang mengenakan kartu ini berkurang sejumlah 30.",
 	},
 
-	trainerType: "Tool",
-	regulationMark: "G"
-}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 719612,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				cardmarket: 837538,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				cardmarket: 837539,
+			},
+		},
+	],
 
-export default card
+	trainerType: "Tool",
+	regulationMark: "G",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SV/SV2a/160.ts
+++ b/data-asia/SV/SV2a/160.ts
@@ -1,29 +1,51 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV2a"
+import { Card } from "../../../interfaces";
+import Set from "../SV2a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "たべのこし",
 		'zh-tw': "吃剩的東西",
 		th: "อาหารเหลือ",
-		id: "Sisa Makanan"
+		id: "Sisa Makanan",
 	},
 
 	illustrator: "Studio Bora Inc.",
-	rarity: "Uncommon",
 	category: "Trainer",
 
 	effect: {
 		ja: "自分の番の終わりに、このカードをつけているポケモンがバトル場にいるなら、そのポケモンのHPを「20」回復する。",
 		'zh-tw': "在自己的回合結束時，將附有這張卡的戰鬥寶可夢恢復「20」HP。",
 		th: "เมื่อจบเทิร์นฝ่ายเรา ถ้าโปเกมอนที่ติดการ์ดนี้อยู่อยู่บนตำแหน่งต่อสู้ จะฟื้นฟู HP ของโปเกมอนนั้น [20]",
-		id: "Pada akhir giliran sendiri, jika Pokémon yang mengenakan kartu ini ada di Arena Bertarung, pulihkan HP Pokémon tersebut sejumlah 20."
+		id: "Pada akhir giliran sendiri, jika Pokémon yang mengenakan kartu ini ada di Arena Bertarung, pulihkan HP Pokémon tersebut sejumlah 20.",
 	},
 
-	trainerType: "Tool",
-	regulationMark: "G"
-}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 719613,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				cardmarket: 837540,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				cardmarket: 837541,
+			},
+		},
+	],
 
-export default card
+	trainerType: "Tool",
+	regulationMark: "G",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SV/SV2a/161.ts
+++ b/data-asia/SV/SV2a/161.ts
@@ -1,29 +1,51 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV2a"
+import { Card } from "../../../interfaces";
+import Set from "../SV2a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "エリカの招待",
 		'zh-tw': "莉佳的招待",
 		th: "คำเชิญของเอริกะ",
-		id: "Undangan Erika"
+		id: "Undangan Erika",
 	},
 
 	illustrator: "saino misaki",
-	rarity: "Uncommon",
 	category: "Trainer",
 
 	effect: {
 		ja: "相手の手札を見て、その中からたねポケモンを1枚選び、相手のベンチに出す。その後、そのポケモンをバトルポケモンと入れ替える。",
 		'zh-tw': "查看對手的手牌，從其中選擇1張【基礎】寶可夢卡，放置於對手的備戰區。然後，將那隻寶可夢與戰鬥寶可夢互換。",
 		th: "ดูการ์ดบนมือฝ่ายตรงข้าม เลือกการ์ดโปเกมอน[พื้นฐาน] 1 ใบจากในนั้น วางบนเบนช์ฝ่ายตรงข้าม หลังจากนั้น สลับโปเกมอนนั้นกับโปเกมอนบนตำแหน่งต่อสู้",
-		id: "Lihat Kartu Pegangan lawan, pilih 1 lembar Pokémon Basic di antaranya, lalu masukkan ke Cadangan lawan. Setelah itu, tukar Pokémon tersebut dengan Pokémon Bertarung."
+		id: "Lihat Kartu Pegangan lawan, pilih 1 lembar Pokémon Basic di antaranya, lalu masukkan ke Cadangan lawan. Setelah itu, tukar Pokémon tersebut dengan Pokémon Bertarung.",
 	},
 
-	trainerType: "Supporter",
-	regulationMark: "G"
-}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 719614,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				cardmarket: 837542,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				cardmarket: 837543,
+			},
+		},
+	],
 
-export default card
+	trainerType: "Supporter",
+	regulationMark: "G",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SV/SV2a/162.ts
+++ b/data-asia/SV/SV2a/162.ts
@@ -1,29 +1,51 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV2a"
+import { Card } from "../../../interfaces";
+import Set from "../SV2a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "サカキのカリスマ",
 		'zh-tw': "坂木的領導力",
 		th: "เสน่ห์ของซากากิ",
-		id: "Karisma Giovanni"
+		id: "Karisma Giovanni",
 	},
 
 	illustrator: "hncl",
-	rarity: "Uncommon",
 	category: "Trainer",
 
 	effect: {
 		ja: "相手のバトルポケモンについているエネルギーを1個選び、相手の手札にもどす。その後、自分の手札からエネルギーを1枚選び、バトルポケモンにつける。",
 		'zh-tw': "選擇1個對手的戰鬥寶可夢身上附加的能量，放回對手的手牌。然後，從自己的手牌選擇1張能量卡，附於戰鬥寶可夢身上。",
 		th: "เลือกพลังงานที่ติดอยู่กับโปเกมอนบนตำแหน่งต่อสู้ฝ่ายตรงข้าม 1 ลูก นำกลับขึ้นมือฝ่ายตรงข้าม หลังจากนั้น เลือกการ์ดพลังงาน 1 ใบจากบนมือฝ่ายเรา ติดที่โปเกมอนบนตำแหน่งต่อสู้",
-		id: "Pilih 1 Energi yang dikenakan pada Pokémon Bertarung lawan, lalu kembalikan ke Kartu Pegangan lawan. Setelah itu, pilih 1 lembar Energi dari Kartu Pegangan sendiri, lalu kenakan pada Pokémon Bertarung."
+		id: "Pilih 1 Energi yang dikenakan pada Pokémon Bertarung lawan, lalu kembalikan ke Kartu Pegangan lawan. Setelah itu, pilih 1 lembar Energi dari Kartu Pegangan sendiri, lalu kenakan pada Pokémon Bertarung.",
 	},
 
-	trainerType: "Supporter",
-	regulationMark: "G"
-}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 719615,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				cardmarket: 837544,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				cardmarket: 837545,
+			},
+		},
+	],
 
-export default card
+	trainerType: "Supporter",
+	regulationMark: "G",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SV/SV2a/163.ts
+++ b/data-asia/SV/SV2a/163.ts
@@ -1,29 +1,51 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV2a"
+import { Card } from "../../../interfaces";
+import Set from "../SV2a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "ナナミの手助け",
 		'zh-tw': "奈奈美的幫助",
 		th: "การช่วยเหลือของนานามิ",
-		id: "Bantuan Daisy"
+		id: "Bantuan Daisy",
 	},
 
 	illustrator: "Tomomi Kaneko",
-	rarity: "Uncommon",
 	category: "Trainer",
 
 	effect: {
 		ja: "自分の山札を2枚引く。ウラになっている自分のサイドのオモテをすべて見てから、もとにもどす。",
 		'zh-tw': "從自己的牌庫抽出2張卡。在看過所有反面朝上的自己的獎賞卡的正面後，回復原樣。",
 		th: "จั่วการ์ด 2 ใบจากสำรับการ์ดฝ่ายเรา ดูหน้าการ์ดรางวัลที่คว่ำอยู่ทั้งหมดของฝ่ายเรา แล้วคืนที่เดิม",
-		id: "Ambil 2 kartu dari atas Deck sendiri. Lihat sisi depan semua Kartu Point sendiri yang sisi depannya menghadap ke bawah, lalu kembalikan ke posisi semula."
+		id: "Ambil 2 kartu dari atas Deck sendiri. Lihat sisi depan semua Kartu Point sendiri yang sisi depannya menghadap ke bawah, lalu kembalikan ke posisi semula.",
 	},
 
-	trainerType: "Supporter",
-	regulationMark: "G"
-}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 719616,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				cardmarket: 837546,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				cardmarket: 837547,
+			},
+		},
+	],
 
-export default card
+	trainerType: "Supporter",
+	regulationMark: "G",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SV/SV2a/164.ts
+++ b/data-asia/SV/SV2a/164.ts
@@ -1,29 +1,51 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV2a"
+import { Card } from "../../../interfaces";
+import Set from "../SV2a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "マサキの転送",
 		'zh-tw': "正輝的輸送",
 		th: "การส่งต่อของมาซากิ",
-		id: "Transfer Bill"
+		id: "Transfer Bill",
 	},
 
 	illustrator: "GIDORA",
-	rarity: "Uncommon",
 	category: "Trainer",
 
 	effect: {
 		ja: "自分の山札を上から8枚見て、その中からポケモンを好きなだけ選び、相手に見せて、手札に加える。残りのカードは山札にもどして切る。",
 		'zh-tw': "查看自己的牌庫上方8張卡，從其中選擇任意數量的寶可夢卡，在給對手看過後加入手牌。將剩餘卡放回牌庫並重洗。",
 		th: "ดูการ์ด 8 ใบจากด้านบนของสำรับการ์ดฝ่ายเรา เลือกการ์ดโปเกมอนจากในนั้นตามจำนวนที่ชอบ ให้ฝ่ายตรงข้ามดู นำขึ้นมือ การ์ดที่เหลือใส่กลับไปในสำรับการ์ดแล้วสับ",
-		id: "Lihat 8 kartu dari atas Deck sendiri, pilih sesukanya Pokémon di antaranya, perlihatkan ke lawan, lalu tambahkan ke Kartu Pegangan. Kocok kembali sisa kartu ke Deck."
+		id: "Lihat 8 kartu dari atas Deck sendiri, pilih sesukanya Pokémon di antaranya, perlihatkan ke lawan, lalu tambahkan ke Kartu Pegangan. Kocok kembali sisa kartu ke Deck.",
 	},
 
-	trainerType: "Supporter",
-	regulationMark: "G"
-}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 719617,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				cardmarket: 837548,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				cardmarket: 837549,
+			},
+		},
+	],
 
-export default card
+	trainerType: "Supporter",
+	regulationMark: "G",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SV/SV2a/165.ts
+++ b/data-asia/SV/SV2a/165.ts
@@ -1,29 +1,51 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV2a"
+import { Card } from "../../../interfaces";
+import Set from "../SV2a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "サイクリングロード",
 		'zh-tw': "自行車道",
 		th: "ทางจักรยาน",
-		id: "Jalan Sepeda"
+		id: "Jalan Sepeda",
 	},
 
 	illustrator: "Oswaldo KATO",
-	rarity: "Uncommon",
 	category: "Trainer",
 
 	effect: {
 		ja: "おたがいのプレイヤーは、自分の番ごとに1回、自分の手札から基本エネルギーを1枚トラッシュするなら、自分の山札を1枚引いてよい。",
 		'zh-tw': "雙方玩家在每個自己的回合時，可使用1次，若從自己的手牌將1張基本能量卡丟棄，則可從自己的牌庫抽出1張卡。",
 		th: "ผู้เล่นทั้งสองฝ่าย ในแต่ละเทิร์นของตัวเองทำได้ 1 ครั้ง ถ้าทิ้งการ์ดพลังงานพื้นฐาน 1 ใบจากบนมือฝ่ายตัวเองที่ตำแหน่งทิ้งการ์ด จะจั่วการ์ด 1 ใบจากสำรับการ์ดฝ่ายตัวเองก็ได้",
-		id: "Kedua pemain 1 kali pada tiap gilirannya sendiri dapat membuang 1 lembar Energi Dasar dari Kartu Pegangan sendiri ke Trash, lalu mengambil 1 kartu dari atas Deck sendiri."
+		id: "Kedua pemain 1 kali pada tiap gilirannya sendiri dapat membuang 1 lembar Energi Dasar dari Kartu Pegangan sendiri ke Trash, lalu mengambil 1 kartu dari atas Deck sendiri.",
 	},
 
-	trainerType: "Stadium",
-	regulationMark: "G"
-}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 719618,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				cardmarket: 837550,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				cardmarket: 837551,
+			},
+		},
+	],
 
-export default card
+	trainerType: "Stadium",
+	regulationMark: "G",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SV/SV2a/166.ts
+++ b/data-asia/SV/SV2a/166.ts
@@ -1,19 +1,17 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV2a"
+import { Card } from "../../../interfaces";
+import Set from "../SV2a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "フシギダネ",
 		'zh-tw': "妙蛙種子",
 		th: "ฟุชิกิดาเนะ",
-		id: "Bulbasaur"
+		id: "Bulbasaur",
 	},
 
 	illustrator: "Yoriyuki Ikegami",
 	category: "Pokemon",
-	dexId: [1],
 	hp: 70,
 	types: ["Grass"],
 
@@ -21,42 +19,46 @@ const card: Card = {
 		ja: "生まれて しばらくの あいだ 背中の タネに つまった 栄養を とって 育つ。",
 		'zh-tw': "在出生後的一段時間內，牠會吸收背上種子裡儲存著的營養成長。",
 		th: "ในช่วงเวลาหนึ่งหลังจากเกิดมาแล้ว จะดูดกินสารอาหารที่สะสมไว้ในเมล็ดที่อยู่กลางหลังเพื่อเลี้ยงตัวให้เติบโต",
-		id: "Sesaat setelah dilahirkan, Bulbasaur menggunakan nutrisi yang terkandung dalam biji di punggungnya untuk tumbuh."
+		id: "Sesaat setelah dilahirkan, Bulbasaur menggunakan nutrisi yang terkandung dalam biji di punggungnya untuk tumbuh.",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		cost: ["Grass", "Colorless"],
-
-		name: {
-			ja: "やどりぎのタネ",
-			'zh-tw': "寄生種子",
-			th: "เมล็ดกาฝาก",
-			id: "Bibit Parasit"
+	attacks: [
+		{
+			name: {
+				ja: "やどりぎのタネ",
+				'zh-tw': "寄生種子",
+				th: "เมล็ดกาฝาก",
+				id: "Bibit Parasit",
+			},
+			damage: 20,
+			cost: ["Grass", "Colorless"],
+			effect: {
+				ja: "このポケモンのHPを「20」回復する。",
+				'zh-tw': "將這隻寶可夢恢復「20」HP。",
+				th: "ฟื้นฟู HP ของโปเกมอนนี้ [20]",
+				id: "Pulihkan HP Pokémon ini sejumlah 20.",
+			},
 		},
+	],
 
-		damage: 20,
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
 
-		effect: {
-			ja: "このポケモンのHPを「20」回復する。",
-			'zh-tw': "將這隻寶可夢恢復「20」HP。",
-			th: "ฟื้นฟู HP ของโปเกมอนนี้ [20]",
-			id: "Pulihkan HP Pokémon ini sejumlah 20."
-		}
-	}],
-
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 719619,
+			},
+		},
+	],
 
 	retreat: 2,
 	regulationMark: "G",
+	rarity: "Illustration rare",
+	dexId: [1],
+};
 
-	thirdParty: {
-		cardmarket: 719442
-	}
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV2a/167.ts
+++ b/data-asia/SV/SV2a/167.ts
@@ -1,19 +1,17 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV2a"
+import { Card } from "../../../interfaces";
+import Set from "../SV2a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "フシギソウ",
 		'zh-tw': "妙蛙草",
 		th: "ฟุชิกิโซ",
-		id: "Ivysaur"
+		id: "Ivysaur",
 	},
 
 	illustrator: "Yoriyuki Ikegami",
 	category: "Pokemon",
-	dexId: [2],
 	hp: 100,
 	types: ["Grass"],
 
@@ -21,53 +19,60 @@ const card: Card = {
 		ja: "太陽の 光を 浴びるほど 体に 力が わいて 背中の つぼみが 育っていく。",
 		'zh-tw': "沐浴在陽光下越久，身體內會湧出越多力量，背上的花苞也會漸漸成長。",
 		th: "ยิ่งอาบแดดมากก็จะยิ่งเกิดพลังมากขึ้นทำให้ดอกตูมบนหลังเติบโต",
-		id: "Mandi cahaya matahari membuat Ivysaur makin kuat dan menumbuhkan kuncup di punggungnya."
+		id: "Mandi cahaya matahari membuat Ivysaur makin kuat dan menumbuhkan kuncup di punggungnya.",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		cost: ["Grass", "Colorless"],
-
-		name: {
-			ja: "やどりぎのタネ",
-			'zh-tw': "寄生種子",
-			th: "เมล็ดกาฝาก",
-			id: "Bibit Parasit"
+	attacks: [
+		{
+			name: {
+				ja: "やどりぎのタネ",
+				'zh-tw': "寄生種子",
+				th: "เมล็ดกาฝาก",
+				id: "Bibit Parasit",
+			},
+			damage: 30,
+			cost: ["Grass", "Colorless"],
+			effect: {
+				ja: "このポケモンのHPを「20」回復する。",
+				'zh-tw': "將這隻寶可夢恢復「20」HP。",
+				th: "ฟื้นฟู HP ของโปเกมอนนี้ [20]",
+				id: "Pulihkan HP Pokémon ini sejumlah 20.",
+			},
 		},
-
-		damage: 30,
-
-		effect: {
-			ja: "このポケモンのHPを「20」回復する。",
-			'zh-tw': "將這隻寶可夢恢復「20」HP。",
-			th: "ฟื้นฟู HP ของโปเกมอนนี้ [20]",
-			id: "Pulihkan HP Pokémon ini sejumlah 20."
-		}
-	}, {
-		cost: ["Grass", "Grass", "Colorless"],
-
-		name: {
-			ja: "つるのムチ",
-			'zh-tw': "藤鞭",
-			th: "แส้เถาวัลย์",
-			id: "Cambuk Jalar"
+		{
+			name: {
+				ja: "つるのムチ",
+				'zh-tw': "藤鞭",
+				th: "แส้เถาวัลย์",
+				id: "Cambuk Jalar",
+			},
+			damage: 80,
+			cost: ["Grass", "Grass", "Colorless"],
 		},
+	],
 
-		damage: 80
-	}],
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 719620,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "フシギダネ",
+	},
 
 	retreat: 3,
 	regulationMark: "G",
+	rarity: "Illustration rare",
+	dexId: [2],
+};
 
-	thirdParty: {
-		cardmarket: 719444
-	}
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV2a/168.ts
+++ b/data-asia/SV/SV2a/168.ts
@@ -1,19 +1,17 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV2a"
+import { Card } from "../../../interfaces";
+import Set from "../SV2a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "ヒトカゲ",
 		'zh-tw': "小火龍",
 		th: "ฮิโตคาเงะ",
-		id: "Charmander"
+		id: "Charmander",
 	},
 
 	illustrator: "miki kudo",
 	category: "Pokemon",
-	dexId: [4],
 	hp: 70,
 	types: ["Fire"],
 
@@ -21,51 +19,55 @@ const card: Card = {
 		ja: "生まれたときから しっぽに 炎が ともっている。 炎が 消えたとき その 命は 終わって しまう。",
 		'zh-tw': "從出生時開始尾巴上就有火焰在燃燒。火焰熄滅時，生命也會結束。",
 		th: "มีหางที่ติดไฟตั้งแต่เกิด หากไฟดับนั่นหมายถึงการจบชีวิต",
-		id: "Sejak lahir, api menyala di ekor Charmander. Hidupnya berakhir saat api tersebut padam."
+		id: "Sejak lahir, api menyala di ekor Charmander. Hidupnya berakhir saat api tersebut padam.",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		cost: ["Fire"],
-
-		name: {
-			ja: "まるやけ",
-			'zh-tw': "全部燒光",
-			th: "เผาเตียน",
-			id: "Bakar Bulat-bulat"
+	attacks: [
+		{
+			name: {
+				ja: "まるやけ",
+				'zh-tw': "全部燒光",
+				th: "เผาเตียน",
+				id: "Bakar Bulat-bulat",
+			},
+			cost: ["Fire"],
+			effect: {
+				ja: "場に出ているスタジアムをトラッシュする。",
+				'zh-tw': "將場上的競技場卡丟棄。",
+				th: "ทิ้งการ์ดสเตเดียมที่วางอยู่บนกระดานที่ตำแหน่งทิ้งการ์ด",
+				id: "Buang Stadium yang ada di Arena ke Trash.",
+			},
 		},
-
-		effect: {
-			ja: "場に出ているスタジアムをトラッシュする。",
-			'zh-tw': "將場上的競技場卡丟棄。",
-			th: "ทิ้งการ์ดสเตเดียมที่วางอยู่บนกระดานที่ตำแหน่งทิ้งการ์ด",
-			id: "Buang Stadium yang ada di Arena ke Trash."
-		}
-	}, {
-		cost: ["Fire", "Fire"],
-
-		name: {
-			ja: "ひをはく",
-			'zh-tw': "吐火",
-			th: "พ่นอัคคี",
-			id: "Memuntahkan Api"
+		{
+			name: {
+				ja: "ひをはく",
+				'zh-tw': "吐火",
+				th: "พ่นอัคคี",
+				id: "Memuntahkan Api",
+			},
+			damage: 30,
+			cost: ["Fire", "Fire"],
 		},
+	],
 
-		damage: 30
-	}],
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Water",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 719621,
+			},
+		},
+	],
 
 	retreat: 1,
 	regulationMark: "G",
+	rarity: "Illustration rare",
+	dexId: [4],
+};
 
-	thirdParty: {
-		cardmarket: 719446
-	}
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV2a/169.ts
+++ b/data-asia/SV/SV2a/169.ts
@@ -1,19 +1,17 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV2a"
+import { Card } from "../../../interfaces";
+import Set from "../SV2a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "リザード",
 		'zh-tw': "火恐龍",
 		th: "ลิซาร์โดะ",
-		id: "Charmeleon"
+		id: "Charmeleon",
 	},
 
 	illustrator: "miki kudo",
 	category: "Pokemon",
-	dexId: [5],
 	hp: 100,
 	types: ["Fire"],
 
@@ -21,53 +19,60 @@ const card: Card = {
 		ja: "戦いで 気持ちが たかぶると 灼熱の 炎を 吹きながら あたりを 燃やしてまわる。",
 		'zh-tw': "如果牠在戰鬥中亢奮起來，就會噴出灼熱的火焰，把周圍的東西燒得一乾二淨。",
 		th: "เมื่อตื่นเต้นจากการต่อสู้จะพ่นเปลวเพลิงร้อนแรงแผดเผารอบข้าง",
-		id: "Ketika pertarungan membuat semangat Charmeleon bergejolak, Pokémon ini meniupkan api berpijar dan membakar daerah sekelilingnya."
+		id: "Ketika pertarungan membuat semangat Charmeleon bergejolak, Pokémon ini meniupkan api berpijar dan membakar daerah sekelilingnya.",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		cost: ["Fire"],
-
-		name: {
-			ja: "かえん",
-			'zh-tw': "烈焰",
-			th: "เผาไหม้",
-			id: "Lidah Api"
+	attacks: [
+		{
+			name: {
+				ja: "かえん",
+				'zh-tw': "烈焰",
+				th: "เผาไหม้",
+				id: "Lidah Api",
+			},
+			damage: 20,
+			cost: ["Fire"],
 		},
-
-		damage: 20
-	}, {
-		cost: ["Fire", "Fire", "Fire"],
-
-		name: {
-			ja: "だいもんじ",
-			'zh-tw': "大字爆炎",
-			th: "เพลิงอัคคี",
-			id: "Ledakan Api Besar"
+		{
+			name: {
+				ja: "だいもんじ",
+				'zh-tw': "大字爆炎",
+				th: "เพลิงอัคคี",
+				id: "Ledakan Api Besar",
+			},
+			damage: 90,
+			cost: ["Fire", "Fire", "Fire"],
+			effect: {
+				ja: "このポケモンについているエネルギーを1個選び、トラッシュする。",
+				'zh-tw': "選擇1個這隻寶可夢身上附加的能量，將其丟棄。",
+				th: "เลือกพลังงานที่ติดอยู่กับโปเกมอนนี้ 1 ลูก ทิ้งที่ตำแหน่งทิ้งการ์ด",
+				id: "Pilih 1 Energi yang dikenakan pada Pokémon ini, lalu buang ke Trash.",
+			},
 		},
+	],
 
-		damage: 90,
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
 
-		effect: {
-			ja: "このポケモンについているエネルギーを1個選び、トラッシュする。",
-			'zh-tw': "選擇1個這隻寶可夢身上附加的能量，將其丟棄。",
-			th: "เลือกพลังงานที่ติดอยู่กับโปเกมอนนี้ 1 ลูก ทิ้งที่ตำแหน่งทิ้งการ์ด",
-			id: "Pilih 1 Energi yang dikenakan pada Pokémon ini, lalu buang ke Trash."
-		}
-	}],
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 719622,
+			},
+		},
+	],
 
-	weaknesses: [{
-		type: "Water",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "ヒトカゲ",
+	},
 
 	retreat: 2,
 	regulationMark: "G",
+	rarity: "Illustration rare",
+	dexId: [5],
+};
 
-	thirdParty: {
-		cardmarket: 719447
-	}
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV2a/170.ts
+++ b/data-asia/SV/SV2a/170.ts
@@ -1,19 +1,17 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV2a"
+import { Card } from "../../../interfaces";
+import Set from "../SV2a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "ゼニガメ",
 		'zh-tw': "傑尼龜",
 		th: "เซนิกาเมะ",
-		id: "Squirtle"
+		id: "Squirtle",
 	},
 
 	illustrator: "Mitsuhiro Arita",
 	category: "Pokemon",
-	dexId: [7],
 	hp: 60,
 	types: ["Water"],
 
@@ -21,51 +19,55 @@ const card: Card = {
 		ja: "危なくなると 甲羅に 手足を 引っこめて 身を 守りながら 口から 水を 吹き出している。",
 		'zh-tw': "當牠遇到危險的時候，會將四肢收回甲殼裡保護自己，同時從嘴裡噴出水來。",
 		th: "เมื่อภัยอันตรายเข้าใกล้จะหดแขนขาเข้าในกระดองและฉีดน้ำออกมาจากปากไปพลางปกป้องตัวไปพลาง",
-		id: "Pada kondisi bahaya, Squirtle memasukkan tangan dan kakinya ke dalam tempurung dan menyemprotkan air dari mulutnya sambil melindungi diri."
+		id: "Pada kondisi bahaya, Squirtle memasukkan tangan dan kakinya ke dalam tempurung dan menyemprotkan air dari mulutnya sambil melindungi diri.",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		cost: ["Water"],
-
-		name: {
-			ja: "からにこもる",
-			'zh-tw': "縮入殼中",
-			th: "หดกำบัง",
-			id: "Berperam Dalam Cangkang"
+	attacks: [
+		{
+			name: {
+				ja: "からにこもる",
+				'zh-tw': "縮入殼中",
+				th: "หดกำบัง",
+				id: "Berperam Dalam Cangkang",
+			},
+			cost: ["Water"],
+			effect: {
+				ja: "コインを1回投げオモテなら、次の相手の番、このポケモンはワザのダメージを受けない。",
+				'zh-tw': "擲1次硬幣若為正面，則在下個對手的回合，這隻寶可夢不會受到招式的傷害。",
+				th: "ทอยเหรียญ 1 ครั้งถ้าออกหัว เทิร์นถัดไปของฝ่ายตรงข้าม โปเกมอนนี้จะไม่ได้รับแดเมจของท่าต่อสู้",
+				id: "Lempar koin 1 kali. Jika hasilnya sisi depan, pada giliran lawan berikutnya, Pokémon ini tidak menerima kerusakan akibat serangan.",
+			},
 		},
-
-		effect: {
-			ja: "コインを1回投げオモテなら、次の相手の番、このポケモンはワザのダメージを受けない。",
-			'zh-tw': "擲1次硬幣若為正面，則在下個對手的回合，這隻寶可夢不會受到招式的傷害。",
-			th: "ทอยเหรียญ 1 ครั้งถ้าออกหัว เทิร์นถัดไปของฝ่ายตรงข้าม โปเกมอนนี้จะไม่ได้รับแดเมจของท่าต่อสู้",
-			id: "Lempar koin 1 kali. Jika hasilnya sisi depan, pada giliran lawan berikutnya, Pokémon ini tidak menerima kerusakan akibat serangan."
-		}
-	}, {
-		cost: ["Water", "Water"],
-
-		name: {
-			ja: "ロケットずつき",
-			'zh-tw': "火箭頭錘",
-			th: "พุ่งหัวจรวด",
-			id: "Tandukan Kepala Roket"
+		{
+			name: {
+				ja: "ロケットずつき",
+				'zh-tw': "火箭頭錘",
+				th: "พุ่งหัวจรวด",
+				id: "Tandukan Kepala Roket",
+			},
+			damage: 20,
+			cost: ["Water", "Water"],
 		},
+	],
 
-		damage: 20
-	}],
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Lightning",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 719623,
+			},
+		},
+	],
 
 	retreat: 1,
 	regulationMark: "G",
+	rarity: "Illustration rare",
+	dexId: [7],
+};
 
-	thirdParty: {
-		cardmarket: 719449
-	}
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV2a/171.ts
+++ b/data-asia/SV/SV2a/171.ts
@@ -1,19 +1,17 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV2a"
+import { Card } from "../../../interfaces";
+import Set from "../SV2a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "カメール",
 		'zh-tw': "卡咪龜",
 		th: "คาเมล",
-		id: "Wartortle"
+		id: "Wartortle",
 	},
 
 	illustrator: "Mitsuhiro Arita",
 	category: "Pokemon",
-	dexId: [8],
 	hp: 100,
 	types: ["Water"],
 
@@ -21,51 +19,59 @@ const card: Card = {
 		ja: "ふさふさの 耳と しっぽを たくみに 操って 水中での バランスを たもつ。",
 		'zh-tw': "會靈巧地擺動自己毛茸茸的耳朵和尾巴，藉此在水中保持平衡。",
 		th: "ใช้หูและหางได้อย่างคล่องแคล่วเพื่อรักษาสมดุลขณะอยู่ในน้ำ",
-		id: "Wartortle mengendalikan telinga dan ekornya yang berbulu lebat untuk menjaga keseimbangan di dalam air."
+		id: "Wartortle mengendalikan telinga dan ekornya yang berbulu lebat untuk menjaga keseimbangan di dalam air.",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		cost: ["Water"],
-
-		name: {
-			ja: "すもぐり",
-			'zh-tw': "自由潛水",
-			th: "มุดเข้ารัง",
-			id: "Berbenam Diri"
+	attacks: [
+		{
+			name: {
+				ja: "すもぐり",
+				'zh-tw': "自由潛水",
+				th: "มุดเข้ารัง",
+				id: "Berbenam Diri",
+			},
+			cost: ["Water"],
+			effect: {
+				ja: "自分のトラッシュから「基本[W]エネルギー」を3枚まで選び、相手に見せて、手札に加える。",
+				'zh-tw': "從自己的棄牌區選擇最多3張「基本【水】能量」卡，在給對手看過後加入手牌。",
+				th: "เลือกการ์ด [พลังงานพื้นฐาน[น้ำ]] ได้สูงสุด 3 ใบจากตำแหน่งทิ้งการ์ดฝ่ายเรา ให้ฝ่ายตรงข้ามดู นำขึ้นมือ",
+				id: "Pilih paling banyak 3 lembar Energi Dasar {Air} dari Trash sendiri, perlihatkan ke lawan, lalu tambahkan ke Kartu Pegangan.",
+			},
 		},
-
-		effect: {
-			ja: "自分のトラッシュから「基本エネルギー」を3枚まで選び、相手に見せて、手札に加える。",
-			'zh-tw': "從自己的棄牌區選擇最多3張「基本【水】能量」卡，在給對手看過後加入手牌。",
-			th: "เลือกการ์ด [พลังงานพื้นฐาน[น้ำ]] ได้สูงสุด 3 ใบจากตำแหน่งทิ้งการ์ดฝ่ายเรา ให้ฝ่ายตรงข้ามดู นำขึ้นมือ",
-			id: "Pilih paling banyak 3 lembar Energi Dasar {Air} dari Trash sendiri, perlihatkan ke lawan, lalu tambahkan ke Kartu Pegangan."
-		}
-	}, {
-		cost: ["Water", "Water"],
-
-		name: {
-			ja: "かいてんアタック",
-			'zh-tw': "迴轉攻擊",
-			th: "โจมตีหมุนวน",
-			id: "Serangan Berputar"
+		{
+			name: {
+				ja: "かいてんアタック",
+				'zh-tw': "迴轉攻擊",
+				th: "โจมตีหมุนวน",
+				id: "Serangan Berputar",
+			},
+			damage: 50,
+			cost: ["Water", "Water"],
 		},
+	],
 
-		damage: 50
-	}],
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Lightning",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 719624,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ゼニガメ",
+	},
 
 	retreat: 2,
 	regulationMark: "G",
+	rarity: "Illustration rare",
+	dexId: [8],
+};
 
-	thirdParty: {
-		cardmarket: 719450
-	}
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV2a/172.ts
+++ b/data-asia/SV/SV2a/172.ts
@@ -1,19 +1,17 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV2a"
+import { Card } from "../../../interfaces";
+import Set from "../SV2a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "キャタピー",
 		'zh-tw': "綠毛蟲",
 		th: "คาเตอร์ปี",
-		id: "Caterpie"
+		id: "Caterpie",
 	},
 
 	illustrator: "Teeziro",
 	category: "Pokemon",
-	dexId: [10],
 	hp: 50,
 	types: ["Grass"],
 
@@ -21,42 +19,46 @@ const card: Card = {
 		ja: "脚は 短いが 吸盤に なっているので 坂でも 壁でも くたびれることなく 進んでいく。",
 		'zh-tw': "別看牠的腳很短，因為是吸盤，所以無論是斜坡還是牆壁都能輕鬆前進。",
 		th: "ขาสั้นแต่ว่าเป็นปุ่มดูดก็เลยเคลื่อนตัวไปเกาะได้ทั้งทางลาดและกำแพงโดยไม่รู้สึกเหนื่อยเลย",
-		id: "Walau kaki Caterpie pendek, kakinya merupakan pengisap, sehingga Pokémon ini dapat maju terus menaiki tanjakan dan dinding tanpa merasa lelah."
+		id: "Walau kaki Caterpie pendek, kakinya merupakan pengisap, sehingga Pokémon ini dapat maju terus menaiki tanjakan dan dinding tanpa merasa lelah.",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		cost: ["Grass"],
-
-		name: {
-			ja: "はっぱをたべる",
-			'zh-tw': "吃葉子",
-			th: "กินใบไม้",
-			id: "Memakan Daun"
+	attacks: [
+		{
+			name: {
+				ja: "はっぱをたべる",
+				'zh-tw': "吃葉子",
+				th: "กินใบไม้",
+				id: "Memakan Daun",
+			},
+			damage: "10+",
+			cost: ["Grass"],
+			effect: {
+				ja: "相手のバトルポケモンが[G]ポケモンなら、30ダメージ追加。",
+				'zh-tw': "若對手的戰鬥寶可夢為【草】寶可夢，則增加30點傷害。",
+				th: "ถ้าโปเกมอนบนตำแหน่งต่อสู้ฝ่ายตรงข้ามเป็นโปเกมอน[หญ้า] การโจมตีนี้จะเพิ่มแดเมจอีก 30",
+				id: "Jika Pokémon Bertarung lawan adalah Pokémon {Daun}, kerusakan yang diberikan bertambah sejumlah 30.",
+			},
 		},
+	],
 
-		damage: "10+",
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
 
-		effect: {
-			ja: "相手のバトルポケモンがポケモンなら、30ダメージ追加。",
-			'zh-tw': "若對手的戰鬥寶可夢為【草】寶可夢，則增加30點傷害。",
-			th: "ถ้าโปเกมอนบนตำแหน่งต่อสู้ฝ่ายตรงข้ามเป็นโปเกมอน[หญ้า] การโจมตีนี้จะเพิ่มแดเมจอีก 30",
-			id: "Jika Pokémon Bertarung lawan adalah Pokémon {Daun}, kerusakan yang diberikan bertambah sejumlah 30."
-		}
-	}],
-
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 719625,
+			},
+		},
+	],
 
 	retreat: 1,
 	regulationMark: "G",
+	rarity: "Illustration rare",
+	dexId: [10],
+};
 
-	thirdParty: {
-		cardmarket: 719452
-	}
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV2a/173.ts
+++ b/data-asia/SV/SV2a/173.ts
@@ -1,19 +1,17 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV2a"
+import { Card } from "../../../interfaces";
+import Set from "../SV2a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "ピカチュウ",
 		'zh-tw': "皮卡丘",
 		th: "พิคาชู",
-		id: "Pikachu"
+		id: "Pikachu",
 	},
 
 	illustrator: "Hiroyuki Yamamoto",
 	category: "Pokemon",
-	dexId: [25],
 	hp: 60,
 	types: ["Lightning"],
 
@@ -21,51 +19,55 @@ const card: Card = {
 		ja: "両頬には 電気を 溜めこむ 袋がある。 怒ると 溜めこんだ 電気を 一気に 放ってくる。",
 		'zh-tw': "雙頰上有儲存電力的囊袋。一旦生氣就會把儲存的電力一口氣釋放出來。",
 		th: "ที่แก้มทั้งสองข้างมีถุงสำหรับเก็บไฟฟ้า พอโกรธจะปล่อยไฟฟ้าที่เก็บเอาไว้ออกมาในรวดเดียว",
-		id: "Pikachu memiliki kantong penampung listrik di kedua pipinya. Ketika marah, Pokémon ini mengeluarkan seluruh listrik yang telah terkumpul."
+		id: "Pikachu memiliki kantong penampung listrik di kedua pipinya. Ketika marah, Pokémon ini mengeluarkan seluruh listrik yang telah terkumpul.",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		cost: ["Lightning"],
-
-		name: {
-			ja: "じゅうでん",
-			'zh-tw': "充電",
-			th: "ชาร์จ",
-			id: "Charge"
+	attacks: [
+		{
+			name: {
+				ja: "じゅうでん",
+				'zh-tw': "充電",
+				th: "ชาร์จ",
+				id: "Charge",
+			},
+			cost: ["Lightning"],
+			effect: {
+				ja: "自分の山札から「基本[L]エネルギー」を1枚選び、このポケモンにつける。そして山札を切る。",
+				'zh-tw': "從自己的牌庫選擇1張「基本【雷】能量」卡，附於這隻寶可夢身上。並且重洗牌庫。",
+				th: "เลือกการ์ด [พลังงานพื้นฐาน[สายฟ้า]] 1 ใบจากสำรับการ์ดฝ่ายเรา ติดที่โปเกมอนนี้ แล้วสับสำรับการ์ด",
+				id: "Pilih 1 lembar Energi Dasar {Listrik} dari Deck sendiri, lalu kenakan pada Pokémon ini. Kemudian, kocok Deck.",
+			},
 		},
-
-		effect: {
-			ja: "自分の山札から「基本エネルギー」を1枚選び、このポケモンにつける。そして山札を切る。",
-			'zh-tw': "從自己的牌庫選擇1張「基本【雷】能量」卡，附於這隻寶可夢身上。並且重洗牌庫。",
-			th: "เลือกการ์ด [พลังงานพื้นฐาน[สายฟ้า]] 1 ใบจากสำรับการ์ดฝ่ายเรา ติดที่โปเกมอนนี้ แล้วสับสำรับการ์ด",
-			id: "Pilih 1 lembar Energi Dasar {Listrik} dari Deck sendiri, lalu kenakan pada Pokémon ini. Kemudian, kocok Deck."
-		}
-	}, {
-		cost: ["Lightning", "Lightning", "Colorless"],
-
-		name: {
-			ja: "ピカパンチ",
-			'zh-tw': "皮卡拳",
-			th: "พิคาพันช์",
-			id: "Pika Punch"
+		{
+			name: {
+				ja: "ピカパンチ",
+				'zh-tw': "皮卡拳",
+				th: "พิคาพันช์",
+				id: "Pika Punch",
+			},
+			damage: 50,
+			cost: ["Lightning", "Lightning", "Colorless"],
 		},
+	],
 
-		damage: 50
-	}],
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 719626,
+			},
+		},
+	],
 
 	retreat: 1,
 	regulationMark: "G",
+	rarity: "Illustration rare",
+	dexId: [25],
+};
 
-	thirdParty: {
-		cardmarket: 719467
-	}
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV2a/174.ts
+++ b/data-asia/SV/SV2a/174.ts
@@ -1,19 +1,17 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV2a"
+import { Card } from "../../../interfaces";
+import Set from "../SV2a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "ニドキング",
 		'zh-tw': "尼多王",
 		th: "นิโดคิง",
-		id: "Nidoking"
+		id: "Nidoking",
 	},
 
 	illustrator: "Misaki Hashimoto",
 	category: "Pokemon",
-	dexId: [34],
 	hp: 170,
 	types: ["Darkness"],
 
@@ -21,60 +19,68 @@ const card: Card = {
 		ja: "力自慢の ポケモン。 太い 尻尾と ダイヤをも 砕く ツノを 駆使して 豪快に 戦う。",
 		'zh-tw': "以力氣為傲的寶可夢。會善用粗壯的尾巴和連鑽石也能擊碎的角，豪邁地戰鬥。",
 		th: "เป็นโปเกมอนที่ภาคภูมิใจในพละกำลัง ใช้หางอ้วน ๆ กับเขาที่ทุบบดแม้กระทั่งเพชรได้อย่างชำนาญ และต่อสู้อย่างฮึกเหิม",
-		id: "Pokémon yang bangga pada kekuatannya. Nidoking menggunakan ekornya yang tebal dan tanduknya yang mampu menghancurkan intan sekalipun secara maksimal untuk bertarung dengan penuh antusias."
+		id: "Pokémon yang bangga pada kekuatannya. Nidoking menggunakan ekornya yang tebal dan tanduknya yang mampu menghancurkan intan sekalipun secara maksimal untuk bertarung dengan penuh antusias.",
 	},
 
 	stage: "Stage2",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			ja: "はりきりキング",
-			'zh-tw': "活力王者",
-			th: "ราชาฮึกเหิม",
-			id: "Raja Antusias"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "はりきりキング",
+				'zh-tw': "活力王者",
+				th: "ราชาฮึกเหิม",
+				id: "Raja Antusias",
+			},
+			effect: {
+				ja: "自分の場に「ニドクイン」がいるなら、このポケモンがワザを使うためのエネルギーは、すべてなくなる。",
+				'zh-tw': "若自己的場上有「尼多后」，則這隻寶可夢使用招式所需的能量全部消除。",
+				th: "ถ้าบนกระดานฝ่ายเรามี [นิโดควีน] อยู่ พลังงานสำหรับใช้ท่าต่อสู้ของโปเกมอนนี้ ทั้งหมดจะหายไป",
+				id: "Jika ada Nidoqueen di Arena sendiri, Pokémon ini menjadi tidak membutuhkan Energi untuk menggunakan serangan.",
+			},
 		},
+	],
 
-		effect: {
-			ja: "自分の場に「ニドクイン」がいるなら、このポケモンがワザを使うためのエネルギーは、すべてなくなる。",
-			'zh-tw': "若自己的場上有「尼多后」，則這隻寶可夢使用招式所需的能量全部消除。",
-			th: "ถ้าบนกระดานฝ่ายเรามี [นิโดควีน] อยู่ พลังงานสำหรับใช้ท่าต่อสู้ของโปเกมอนนี้ ทั้งหมดจะหายไป",
-			id: "Jika ada Nidoqueen di Arena sendiri, Pokémon ini menjadi tidak membutuhkan Energi untuk menggunakan serangan."
-		}
-	}],
-
-	attacks: [{
-		cost: ["Darkness", "Darkness", "Colorless", "Colorless"],
-
-		name: {
-			ja: "ベノムインパクト",
-			'zh-tw': "毒液衝撞",
-			th: "เวนอมอิมแพกต์",
-			id: "Venom Impact"
+	attacks: [
+		{
+			name: {
+				ja: "ベノムインパクト",
+				'zh-tw': "毒液衝撞",
+				th: "เวนอมอิมแพกต์",
+				id: "Venom Impact",
+			},
+			damage: 190,
+			cost: ["Darkness", "Darkness", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをどくにする。",
+				'zh-tw': "將對手的戰鬥寶可夢【中毒】。",
+				th: "ทำให้โปเกมอนบนตำแหน่งต่อสู้ฝ่ายตรงข้ามเป็นสภาวะ[พิษ]",
+				id: "Ubah kondisi Pokémon Bertarung lawan menjadi Racun.",
+			},
 		},
+	],
 
-		damage: 190,
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
 
-		effect: {
-			ja: "相手のバトルポケモンをどくにする。",
-			'zh-tw': "將對手的戰鬥寶可夢【中毒】。",
-			th: "ทำให้โปเกมอนบนตำแหน่งต่อสู้ฝ่ายตรงข้ามเป็นสภาวะ[พิษ]",
-			id: "Ubah kondisi Pokémon Bertarung lawan menjadi Racun."
-		}
-	}],
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 719627,
+			},
+		},
+	],
 
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "ニドリーノ",
+	},
 
 	retreat: 3,
 	regulationMark: "G",
+	rarity: "Illustration rare",
+	dexId: [34],
+};
 
-	thirdParty: {
-		cardmarket: 719476
-	}
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV2a/175.ts
+++ b/data-asia/SV/SV2a/175.ts
@@ -1,19 +1,17 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV2a"
+import { Card } from "../../../interfaces";
+import Set from "../SV2a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "コダック",
 		'zh-tw': "可達鴨",
 		th: "โคดัก",
-		id: "Psyduck"
+		id: "Psyduck",
 	},
 
 	illustrator: "Whisker",
 	category: "Pokemon",
-	dexId: [54],
 	hp: 70,
 	types: ["Water"],
 
@@ -21,51 +19,55 @@ const card: Card = {
 		ja: "いつも 頭痛に 悩まされている。 この 頭痛が 激しくなると 不思議な 力を 使いはじめる。",
 		'zh-tw': "一直受到頭痛的困擾。當頭痛欲裂時，就會開始使用神奇的力量。",
 		th: "หงุดหงิดกับอาการปวดหัวอยู่เสมอ พออาการปวดหัวรุนแรงขึ้นจะเริ่มใช้พลังลึกลับ",
-		id: "Psyduck selalu terganggu dengan sakit kepalanya. Pokémon ini mulai menggunakan kekuatan ajaibnya jika kepalanya menjadi makin sakit."
+		id: "Psyduck selalu terganggu dengan sakit kepalanya. Pokémon ini mulai menggunakan kekuatan ajaibnya jika kepalanya menjadi makin sakit.",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		cost: ["Colorless"],
-
-		name: {
-			ja: "かんがえすぎる",
-			'zh-tw': "過慮",
-			th: "คิดมาก",
-			id: "Kebanyakan Berpikir"
+	attacks: [
+		{
+			name: {
+				ja: "かんがえすぎる",
+				'zh-tw': "過慮",
+				th: "คิดมาก",
+				id: "Kebanyakan Berpikir",
+			},
+			cost: ["Colorless"],
+			effect: {
+				ja: "次の相手の番、相手が投げるコインは、すべてウラとしてあつかう。",
+				'zh-tw': "在下個對手的回合，對手擲的硬幣全部視為反面。",
+				th: "เทิร์นถัดไปของฝ่ายตรงข้าม เหรียญที่ฝ่ายตรงข้ามทอย จะถือว่าออกก้อยทั้งหมด",
+				id: "Pada giliran lawan berikutnya, semua lemparan koin yang dilakukan lawan diperlakukan sebagai sisi belakang.",
+			},
 		},
-
-		effect: {
-			ja: "次の相手の番、相手が投げるコインは、すべてウラとしてあつかう。",
-			'zh-tw': "在下個對手的回合，對手擲的硬幣全部視為反面。",
-			th: "เทิร์นถัดไปของฝ่ายตรงข้าม เหรียญที่ฝ่ายตรงข้ามทอย จะถือว่าออกก้อยทั้งหมด",
-			id: "Pada giliran lawan berikutnya, semua lemparan koin yang dilakukan lawan diperlakukan sebagai sisi belakang."
-		}
-	}, {
-		cost: ["Water"],
-
-		name: {
-			ja: "みずでっぽう",
-			'zh-tw': "水槍",
-			th: "ปืนฉีดน้ำ",
-			id: "Pistol Air"
+		{
+			name: {
+				ja: "みずでっぽう",
+				'zh-tw': "水槍",
+				th: "ปืนฉีดน้ำ",
+				id: "Pistol Air",
+			},
+			damage: 10,
+			cost: ["Water"],
 		},
+	],
 
-		damage: 10
-	}],
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Lightning",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 719628,
+			},
+		},
+	],
 
 	retreat: 1,
 	regulationMark: "G",
+	rarity: "Illustration rare",
+	dexId: [54],
+};
 
-	thirdParty: {
-		cardmarket: 719496
-	}
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV2a/176.ts
+++ b/data-asia/SV/SV2a/176.ts
@@ -1,19 +1,17 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV2a"
+import { Card } from "../../../interfaces";
+import Set from "../SV2a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "ニョロゾ",
 		'zh-tw': "蚊香君",
 		th: "เนียวโรโซ",
-		id: "Poliwhirl"
+		id: "Poliwhirl",
 	},
 
 	illustrator: "Gemi",
 	category: "Pokemon",
-	dexId: [61],
 	hp: 90,
 	types: ["Water"],
 
@@ -21,53 +19,60 @@ const card: Card = {
 		ja: "ぬめぬめとした 粘液状の 汗を かく。 敵に 捕まっても ぬるりと すり抜け 逃げるのだ。",
 		'zh-tw': "流的汗是又黏又滑的黏液狀。即使被敵人捉住，也能滑溜溜地輕易逃脫。",
 		th: "ขับเหงื่อที่มีลักษณะเป็นเมือกเหนียวเหนอะออกมา ถึงจะโดนศัตรูจับตัว ก็สามารถลื่นไหลหนีออกมาได้",
-		id: "Poliwhirl mengalirkan keringat berlendir yang licin. Meskipun ditangkap musuh, Pokémon ini dapat meloloskan diri dan kabur berkat kelicinannya."
+		id: "Poliwhirl mengalirkan keringat berlendir yang licin. Meskipun ditangkap musuh, Pokémon ini dapat meloloskan diri dan kabur berkat kelicinannya.",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		cost: ["Water"],
-
-		name: {
-			ja: "スプラッシュ",
-			'zh-tw': "飛濺",
-			th: "สแปลช",
-			id: "Splash"
+	attacks: [
+		{
+			name: {
+				ja: "スプラッシュ",
+				'zh-tw': "飛濺",
+				th: "สแปลช",
+				id: "Splash",
+			},
+			damage: 20,
+			cost: ["Water"],
 		},
-
-		damage: 20
-	}, {
-		cost: ["Water", "Colorless"],
-
-		name: {
-			ja: "かえるとび",
-			'zh-tw': "蛙跳",
-			th: "กระโดดกบ",
-			id: "Lompat Katak"
+		{
+			name: {
+				ja: "かえるとび",
+				'zh-tw': "蛙跳",
+				th: "กระโดดกบ",
+				id: "Lompat Katak",
+			},
+			damage: "30+",
+			cost: ["Water", "Colorless"],
+			effect: {
+				ja: "コインを1回投げオモテなら、60ダメージ追加。",
+				'zh-tw': "擲1次硬幣若為正面，則增加60點傷害。",
+				th: "ทอยเหรียญ 1 ครั้งถ้าออกหัว การโจมตีนี้จะเพิ่มแดเมจอีก 60",
+				id: "Lempar koin 1 kali. Jika hasilnya sisi depan, kerusakan yang diberikan bertambah sejumlah 60.",
+			},
 		},
+	],
 
-		damage: "30+",
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
 
-		effect: {
-			ja: "コインを1回投げオモテなら、60ダメージ追加。",
-			'zh-tw': "擲1次硬幣若為正面，則增加60點傷害。",
-			th: "ทอยเหรียญ 1 ครั้งถ้าออกหัว การโจมตีนี้จะเพิ่มแดเมจอีก 60",
-			id: "Lempar koin 1 kali. Jika hasilnya sisi depan, kerusakan yang diberikan bertambah sejumlah 60."
-		}
-	}],
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 719629,
+			},
+		},
+	],
 
-	weaknesses: [{
-		type: "Lightning",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "ニョロモ",
+	},
 
 	retreat: 1,
 	regulationMark: "G",
+	rarity: "Illustration rare",
+	dexId: [61],
+};
 
-	thirdParty: {
-		cardmarket: 719503
-	}
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV2a/177.ts
+++ b/data-asia/SV/SV2a/177.ts
@@ -1,19 +1,17 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV2a"
+import { Card } from "../../../interfaces";
+import Set from "../SV2a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "ゴーリキー",
 		'zh-tw': "豪力",
 		th: "โกริกี",
-		id: "Machoke"
+		id: "Machoke",
 	},
 
 	illustrator: "Tetsu Kayama",
 	category: "Pokemon",
-	dexId: [67],
 	hp: 100,
 	types: ["Fighting"],
 
@@ -21,42 +19,50 @@ const card: Card = {
 		ja: "疲れることのない 強靭な 肉体を もつ。 重い 荷物の 運搬などの 仕事を 手伝う。",
 		'zh-tw': "有著不會疲勞的強韌肉體。會去幫助人類完成例如搬運沉重行李之類的工作。",
 		th: "มีร่างกายแข็งแรงทนทานไม่เคยรู้สึกเหนื่อย ช่วยงานขนยกของหนัก ๆ",
-		id: "Tubuh Machoke tangguh dan tidak mengenal lelah. Pokémon ini membantu melakukan pekerjaan seperti mengangkut barang berat dan lainnya."
+		id: "Tubuh Machoke tangguh dan tidak mengenal lelah. Pokémon ini membantu melakukan pekerjaan seperti mengangkut barang berat dan lainnya.",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		cost: ["Fighting", "Fighting"],
-
-		name: {
-			ja: "やまどつき",
-			'zh-tw': "推山",
-			th: "ต่อยตีภูเขา",
-			id: "Menohok Gunung"
+	attacks: [
+		{
+			name: {
+				ja: "やまどつき",
+				'zh-tw': "推山",
+				th: "ต่อยตีภูเขา",
+				id: "Menohok Gunung",
+			},
+			damage: 50,
+			cost: ["Fighting", "Fighting"],
+			effect: {
+				ja: "相手の山札を上から1枚トラッシュする。",
+				'zh-tw': "將對手的牌庫上方1張卡丟棄。",
+				th: "ทิ้งการ์ด 1 ใบจากด้านบนของสำรับการ์ดฝ่ายตรงข้ามที่ตำแหน่งทิ้งการ์ด",
+				id: "Buang 1 kartu dari atas Deck lawan ke Trash.",
+			},
 		},
+	],
 
-		damage: 50,
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
 
-		effect: {
-			ja: "相手の山札を上から1枚トラッシュする。",
-			'zh-tw': "將對手的牌庫上方1張卡丟棄。",
-			th: "ทิ้งการ์ด 1 ใบจากด้านบนของสำรับการ์ดฝ่ายตรงข้ามที่ตำแหน่งทิ้งการ์ด",
-			id: "Buang 1 kartu dari atas Deck lawan ke Trash."
-		}
-	}],
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 719630,
+			},
+		},
+	],
 
-	weaknesses: [{
-		type: "Psychic",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "ワンリキー",
+	},
 
 	retreat: 2,
 	regulationMark: "G",
+	rarity: "Illustration rare",
+	dexId: [67],
+};
 
-	thirdParty: {
-		cardmarket: 719509
-	}
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV2a/178.ts
+++ b/data-asia/SV/SV2a/178.ts
@@ -1,19 +1,17 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV2a"
+import { Card } from "../../../interfaces";
+import Set from "../SV2a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "モンジャラ",
 		'zh-tw': "蔓藤怪",
 		th: "มอนจารา",
-		id: "Tangela"
+		id: "Tangela",
 	},
 
 	illustrator: "Oswaldo KATO",
 	category: "Pokemon",
-	dexId: [114],
 	hp: 80,
 	types: ["Grass"],
 
@@ -21,42 +19,46 @@ const card: Card = {
 		ja: "ちぎれても 無限に 伸びる ツルの 奥の 正体は いまだ 解明されていない。",
 		'zh-tw': "藤蔓即使斷了也會繼續無限地生長。藤蔓下的真面目至今仍是個謎。",
 		th: "แม้เถาวัลย์จะขาดก็ยืดยาวออกมาได้ไม่มีที่สิ้นสุด ตัวตนลึก ๆ ที่แท้จริงของมัน จนทุกวันนี้ก็ยังพิสูจน์ไม่ได้",
-		id: "Hingga saat ini, wujud asli Tangela di balik jalar yang terus tumbuh tanpa batas walau dicabut ini masih belum terungkap."
+		id: "Hingga saat ini, wujud asli Tangela di balik jalar yang terus tumbuh tanpa batas walau dicabut ini masih belum terungkap.",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		cost: ["Grass"],
-
-		name: {
-			ja: "まきつきさほう",
-			'zh-tw': "緊束作法",
-			th: "วิธีการพันเลื้อย",
-			id: "Etiket Membelit"
+	attacks: [
+		{
+			name: {
+				ja: "まきつきさほう",
+				'zh-tw': "緊束作法",
+				th: "วิธีการพันเลื้อย",
+				id: "Etiket Membelit",
+			},
+			damage: "10+",
+			cost: ["Grass"],
+			effect: {
+				ja: "この番、手札から「エリカの招待」を出して使っていたなら、60ダメージ追加。",
+				'zh-tw': "在這個回合，若從手牌使出了「莉佳的招待」，則增加60點傷害。",
+				th: "เทิร์นนี้ ถ้านำการ์ด [คำเชิญของเอริกะ] จากบนมือออกมาใช้แล้ว การโจมตีนี้จะเพิ่มแดเมจอีก 60",
+				id: "Jika pada giliran ini, Undangan Erika telah dimainkan dari Kartu Pegangan, kerusakan yang diberikan bertambah sejumlah 60.",
+			},
 		},
+	],
 
-		damage: "10+",
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
 
-		effect: {
-			ja: "この番、手札から「エリカの招待」を出して使っていたなら、60ダメージ追加。",
-			'zh-tw': "在這個回合，若從手牌使出了「莉佳的招待」，則增加60點傷害。",
-			th: "เทิร์นนี้ ถ้านำการ์ด [คำเชิญของเอริกะ] จากบนมือออกมาใช้แล้ว การโจมตีนี้จะเพิ่มแดเมจอีก 60",
-			id: "Jika pada giliran ini, Undangan Erika telah dimainkan dari Kartu Pegangan, kerusakan yang diberikan bertambah sejumlah 60."
-		}
-	}],
-
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 719631,
+			},
+		},
+	],
 
 	retreat: 2,
 	regulationMark: "G",
+	rarity: "Illustration rare",
+	dexId: [114],
+};
 
-	thirdParty: {
-		cardmarket: 719567
-	}
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV2a/179.ts
+++ b/data-asia/SV/SV2a/179.ts
@@ -1,19 +1,17 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV2a"
+import { Card } from "../../../interfaces";
+import Set from "../SV2a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "バリヤード",
 		'zh-tw': "魔牆人偶",
 		th: "บาร์เรียด",
-		id: "Mr. Mime"
+		id: "Mr. Mime",
 	},
 
 	illustrator: "OKACHEKE",
 	category: "Pokemon",
-	dexId: [122],
 	hp: 90,
 	types: ["Psychic"],
 
@@ -21,63 +19,63 @@ const card: Card = {
 		ja: "パントマイムが 得意。 指から 出した 波動で 壁を つくり あまたの 攻撃から 身を守る。",
 		'zh-tw': "擅長表演默劇。用手指放出的波動製造牆壁，保護自己免於大多數的攻擊。",
 		th: "ถนัดเล่นละครใบ้ สร้างกำแพงด้วยคลื่นที่ออกจากนิ้วเพื่อป้องกันตัวจากการโจมตีหลากหลายแบบ",
-		id: "Pintar memainkan pantomim. Mr. Mime membuat dinding menggunakan gelombang yang dikeluarkan dari jarinya untuk melindungi dirinya dari serangan lawan."
+		id: "Pintar memainkan pantomim. Mr. Mime membuat dinding menggunakan gelombang yang dikeluarkan dari jarinya untuk melindungi dirinya dari serangan lawan.",
 	},
 
 	stage: "Basic",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			ja: "ものまねバリア",
-			'zh-tw': "模仿屏障",
-			th: "บาเรียลอกเลียน",
-			id: "Barier Peniru"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "ものまねバリア",
+				'zh-tw': "模仿屏障",
+				th: "บาเรียลอกเลียน",
+				id: "Barier Peniru",
+			},
+			effect: {
+				ja: "このポケモンと相手のバトルポケモンについているエネルギーの数が同じなら、このポケモンは、相手のポケモンからワザのダメージを受けない。",
+				'zh-tw': "若這隻寶可夢與對手的戰鬥寶可夢身上附加的能量數量相同，則這隻寶可夢不會受到對手的寶可夢招式的傷害。",
+				th: "ถ้าจำนวนพลังงานที่ติดอยู่กับโปเกมอนนี้กับโปเกมอนบนตำแหน่งต่อสู้ฝ่ายตรงข้ามเท่ากัน โปเกมอนนี้ จะไม่ได้รับแดเมจของท่าต่อสู้จากโปเกมอนฝ่ายตรงข้าม",
+				id: "Jika Energi yang dikenakan Pokémon ini dan Pokémon Bertarung lawan sama jumlahnya, Pokémon ini tidak menerima kerusakan akibat serangan dari Pokémon lawan.",
+			},
 		},
+	],
 
-		effect: {
-			ja: "このポケモンと相手のバトルポケモンについているエネルギーの数が同じなら、このポケモンは、相手のポケモンからワザのダメージを受けない。",
-			'zh-tw': "若這隻寶可夢與對手的戰鬥寶可夢身上附加的能量數量相同，則這隻寶可夢不會受到對手的寶可夢招式的傷害。",
-			th: "ถ้าจำนวนพลังงานที่ติดอยู่กับโปเกมอนนี้กับโปเกมอนบนตำแหน่งต่อสู้ฝ่ายตรงข้ามเท่ากัน โปเกมอนนี้ จะไม่ได้รับแดเมจของท่าต่อสู้จากโปเกมอนฝ่ายตรงข้าม",
-			id: "Jika Energi yang dikenakan Pokémon ini dan Pokémon Bertarung lawan sama jumlahnya, Pokémon ini tidak menerima kerusakan akibat serangan dari Pokémon lawan."
-		}
-	}],
-
-	attacks: [{
-		cost: ["Colorless"],
-
-		name: {
-			ja: "サイコパワー",
-			'zh-tw': "精神力量",
-			th: "ไซโคพาวเวอร์",
-			id: "Psychopower"
+	attacks: [
+		{
+			name: {
+				ja: "サイコパワー",
+				'zh-tw': "精神力量",
+				th: "ไซโคพาวเวอร์",
+				id: "Psychopower",
+			},
+			cost: ["Colorless"],
+			effect: {
+				ja: "ダメカン3個を、相手のポケモンに好きなようにのせる。",
+				'zh-tw': "將3個傷害指示物以任意方式放置於對手的寶可夢身上。",
+				th: "วางตัวนับแดเมจ 3 ตัว บนโปเกมอนฝ่ายตรงข้ามตามชอบ",
+				id: "Letakkan sejumlah 3 Token Kerusakan pada Pokémon lawan sesukanya.",
+			},
 		},
+	],
 
-		effect: {
-			ja: "ダメカン3個を、相手のポケモンに好きなようにのせる。",
-			'zh-tw': "將3個傷害指示物以任意方式放置於對手的寶可夢身上。",
-			th: "วางตัวนับแดเมจ 3 ตัว บนโปเกมอนฝ่ายตรงข้ามตามชอบ",
-			id: "Letakkan sejumlah 3 Token Kerusakan pada Pokémon lawan sesukanya."
-		}
-	}],
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
 
-	weaknesses: [{
-		type: "Darkness",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Fighting",
-		value: "-30"
-	}],
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 719632,
+			},
+		},
+	],
 
 	retreat: 1,
 	regulationMark: "G",
+	rarity: "Illustration rare",
+	dexId: [122],
+};
 
-	thirdParty: {
-		cardmarket: 719575
-	}
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV2a/180.ts
+++ b/data-asia/SV/SV2a/180.ts
@@ -1,19 +1,17 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV2a"
+import { Card } from "../../../interfaces";
+import Set from "../SV2a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "オムナイト",
 		'zh-tw': "菊石獸",
 		th: "ออมไนต์",
-		id: "Omanyte"
+		id: "Omanyte",
 	},
 
 	illustrator: "Yano Keiji",
 	category: "Pokemon",
-	dexId: [138],
 	hp: 100,
 	types: ["Water"],
 
@@ -21,42 +19,46 @@ const card: Card = {
 		ja: "絶滅した 古代のポケモン。 １０本の脚で 水を かき 漂うように 泳ぐ。",
 		'zh-tw': "一度滅絕的古代寶可夢。會使用１０隻腳划水，在水中一漂一浮地游動。",
 		th: "เป็นโปเกมอนดึกดำบรรพ์ที่สูญพันธุ์ไปแล้ว ว่ายน้ำโดยการตวัดขาทั้งสิบบนน้ำราวกับลอยตัวอยู่",
-		id: "Pokémon purba yang telah punah. Omanyte mengayuh air menggunakan sepuluh kakinya dan berenang bagai mengambang."
+		id: "Pokémon purba yang telah punah. Omanyte mengayuh air menggunakan sepuluh kakinya dan berenang bagai mengambang.",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		cost: ["Water", "Water"],
-
-		name: {
-			ja: "しょくしゅでもどす",
-			'zh-tw': "觸手復元",
-			th: "ใส่กลับด้วยหนวด",
-			id: "Tentakel Pengembali"
+	attacks: [
+		{
+			name: {
+				ja: "しょくしゅでもどす",
+				'zh-tw': "觸手復元",
+				th: "ใส่กลับด้วยหนวด",
+				id: "Tentakel Pengembali",
+			},
+			damage: 50,
+			cost: ["Water", "Water"],
+			effect: {
+				ja: "相手のバトルポケモンについているエネルギーを1個選び、相手の手札にもどす。",
+				'zh-tw': "選擇1個對手的戰鬥寶可夢身上附加的能量，放回對手的手牌。",
+				th: "เลือกพลังงานที่ติดอยู่กับโปเกมอนบนตำแหน่งต่อสู้ฝ่ายตรงข้าม 1 ลูก นำกลับขึ้นมือฝ่ายตรงข้าม",
+				id: "Pilih 1 Energi yang dikenakan pada Pokémon Bertarung lawan, lalu kembalikan ke Kartu Pegangan lawan.",
+			},
 		},
+	],
 
-		damage: 50,
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
 
-		effect: {
-			ja: "相手のバトルポケモンについているエネルギーを1個選び、相手の手札にもどす。",
-			'zh-tw': "選擇1個對手的戰鬥寶可夢身上附加的能量，放回對手的手牌。",
-			th: "เลือกพลังงานที่ติดอยู่กับโปเกมอนบนตำแหน่งต่อสู้ฝ่ายตรงข้าม 1 ลูก นำกลับขึ้นมือฝ่ายตรงข้าม",
-			id: "Pilih 1 Energi yang dikenakan pada Pokémon Bertarung lawan, lalu kembalikan ke Kartu Pegangan lawan."
-		}
-	}],
-
-	weaknesses: [{
-		type: "Lightning",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 719633,
+			},
+		},
+	],
 
 	retreat: 2,
 	regulationMark: "G",
+	rarity: "Illustration rare",
+	dexId: [138],
+};
 
-	thirdParty: {
-		cardmarket: 719591
-	}
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV2a/181.ts
+++ b/data-asia/SV/SV2a/181.ts
@@ -1,19 +1,17 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV2a"
+import { Card } from "../../../interfaces";
+import Set from "../SV2a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "カビゴン",
 		'zh-tw': "卡比獸",
 		th: "คาบิกอน",
-		id: "Snorlax"
+		id: "Snorlax",
 	},
 
 	illustrator: "GOSSAN",
 	category: "Pokemon",
-	dexId: [143],
 	hp: 150,
 	types: ["Colorless"],
 
@@ -21,60 +19,64 @@ const card: Card = {
 		ja: "頑丈な 胃袋は カビの 生えたものや 腐ったものを 食べても 壊れることはない。",
 		'zh-tw': "擁有一個結實的胃，即使吃了發霉腐爛的東西，也完全不會吃壞肚子。",
 		th: "มีถุงกระเพาะที่แข็งแรง แม้จะกินของที่มีราขึ้นหรือของเน่าเสียก็ไม่เคยท้องเสีย",
-		id: "Karena perutnya kuat, Snorlax tidak akan sakit perut walau memakan makanan berjamur atau makanan busuk sekalipun."
+		id: "Karena perutnya kuat, Snorlax tidak akan sakit perut walau memakan makanan berjamur atau makanan busuk sekalipun.",
 	},
 
 	stage: "Basic",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			ja: "くいいじ",
-			'zh-tw': "貪嘴",
-			th: "เจริญอาหาร",
-			id: "Kemaruk"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "くいいじ",
+				'zh-tw': "貪嘴",
+				th: "เจริญอาหาร",
+				id: "Kemaruk",
+			},
+			effect: {
+				ja: "自分の番に1回使える。自分のトラッシュから「たべのこし」を2枚まで選び、相手に見せて、手札に加える。",
+				'zh-tw': "在自己的回合時可使用1次。從自己的棄牌區選擇最多2張「吃剩的東西」，在給對手看過後加入手牌。",
+				th: "ใช้ได้ 1 ครั้งในเทิร์นฝ่ายเรา เลือกการ์ด [อาหารเหลือ] ได้สูงสุด 2 ใบจากตำแหน่งทิ้งการ์ดฝ่ายเรา ให้ฝ่ายตรงข้ามดู นำขึ้นมือ",
+				id: "Dapat digunakan 1 kali pada giliran sendiri. Pilih paling banyak 2 lembar Sisa Makanan dari Trash sendiri, perlihatkan ke lawan, lalu tambahkan ke Kartu Pegangan.",
+			},
 		},
+	],
 
-		effect: {
-			ja: "自分の番に1回使える。自分のトラッシュから「たべのこし」を2枚まで選び、相手に見せて、手札に加える。",
-			'zh-tw': "在自己的回合時可使用1次。從自己的棄牌區選擇最多2張「吃剩的東西」，在給對手看過後加入手牌。",
-			th: "ใช้ได้ 1 ครั้งในเทิร์นฝ่ายเรา เลือกการ์ด [อาหารเหลือ] ได้สูงสุด 2 ใบจากตำแหน่งทิ้งการ์ดฝ่ายเรา ให้ฝ่ายตรงข้ามดู นำขึ้นมือ",
-			id: "Dapat digunakan 1 kali pada giliran sendiri. Pilih paling banyak 2 lembar Sisa Makanan dari Trash sendiri, perlihatkan ke lawan, lalu tambahkan ke Kartu Pegangan."
-		}
-	}],
-
-	attacks: [{
-		cost: ["Colorless", "Colorless", "Colorless"],
-
-		name: {
-			ja: "バッタンプレス",
-			'zh-tw': "養肥壓制",
-			th: "อัดตึงตัง",
-			id: "Tekanan Gedebuk"
+	attacks: [
+		{
+			name: {
+				ja: "バッタンプレス",
+				'zh-tw': "養肥壓制",
+				th: "อัดตึงตัง",
+				id: "Tekanan Gedebuk",
+			},
+			damage: 130,
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンにも30ダメージ。",
+				'zh-tw': "這隻寶可夢也受到30點傷害。",
+				th: "โปเกมอนนี้ก็จะได้รับแดเมจ 30 ด้วย",
+				id: "Pokémon ini juga menerima kerusakan sejumlah 30.",
+			},
 		},
+	],
 
-		damage: 130,
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
 
-		effect: {
-			ja: "このポケモンにも30ダメージ。",
-			'zh-tw': "這隻寶可夢也受到30點傷害。",
-			th: "โปเกมอนนี้ก็จะได้รับแดเมจ 30 ด้วย",
-			id: "Pokémon ini juga menerima kerusakan sejumlah 30."
-		}
-	}],
-
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 719634,
+			},
+		},
+	],
 
 	retreat: 4,
 	regulationMark: "G",
+	rarity: "Illustration rare",
+	dexId: [143],
+};
 
-	thirdParty: {
-		cardmarket: 719596
-	}
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV2a/182.ts
+++ b/data-asia/SV/SV2a/182.ts
@@ -1,19 +1,17 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV2a"
+import { Card } from "../../../interfaces";
+import Set from "../SV2a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "ハクリュー",
 		'zh-tw': "哈克龍",
 		th: "ฮาคุริว",
-		id: "Dragonair"
+		id: "Dragonair",
 	},
 
 	illustrator: "rika",
 	category: "Pokemon",
-	dexId: [148],
 	hp: 100,
 	types: ["Dragon"],
 
@@ -21,48 +19,60 @@ const card: Card = {
 		ja: "全身から オーラが 出されると あたりの 天候が みるみるうちに 変わっていく という。",
 		'zh-tw': "據說牠全身上下散發出氣場時，周圍的天氣就會在轉眼間為之一變。",
 		th: "ว่ากันว่าอากาศโดยรอบจะเปลี่ยนไปทันทีที่มันปล่อยออร่าออกมาจากทั่วทั้งตัว",
-		id: "Dikabarkan jika Dragonair mengeluarkan aura dari seluruh tubuhnya, cuaca di sekitarnya langsung berubah."
+		id: "Dikabarkan jika Dragonair mengeluarkan aura dari seluruh tubuhnya, cuaca di sekitarnya langsung berubah.",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		cost: ["Water"],
-
-		name: {
-			ja: "たたく",
-			'zh-tw': "敲擊",
-			th: "ตี",
-			id: "Menghantam"
+	attacks: [
+		{
+			name: {
+				ja: "たたく",
+				'zh-tw': "敲擊",
+				th: "ตี",
+				id: "Menghantam",
+			},
+			damage: 20,
+			cost: ["Water"],
 		},
-
-		damage: 20
-	}, {
-		cost: ["Water", "Lightning"],
-
-		name: {
-			ja: "アクアスラッシュ",
-			'zh-tw': "水流斬",
-			th: "อควาสแลช",
-			id: "Aqua Slash"
+		{
+			name: {
+				ja: "アクアスラッシュ",
+				'zh-tw': "水流斬",
+				th: "อควาสแลช",
+				id: "Aqua Slash",
+			},
+			damage: 90,
+			cost: ["Water", "Lightning"],
+			effect: {
+				ja: "次の自分の番、このポケモンはワザが使えない。",
+				'zh-tw': "在下個自己的回合，這隻寶可夢無法使用招式。",
+				th: "เทิร์นถัดไปของฝ่ายเรา โปเกมอนนี้จะใช้ท่าต่อสู้ไม่ได้",
+				id: "Pada giliran sendiri berikutnya, Pokémon ini tidak dapat menggunakan serangan.",
+			},
 		},
+	],
 
-		damage: 90,
+	weaknesses: [],
+	resistances: [],
 
-		effect: {
-			ja: "次の自分の番、このポケモンはワザが使えない。",
-			'zh-tw': "在下個自己的回合，這隻寶可夢無法使用招式。",
-			th: "เทิร์นถัดไปของฝ่ายเรา โปเกมอนนี้จะใช้ท่าต่อสู้ไม่ได้",
-			id: "Pada giliran sendiri berikutnya, Pokémon ini tidak dapat menggunakan serangan."
-		}
-	}],
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 719635,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ミニリュウ",
+	},
 
 	retreat: 2,
 	regulationMark: "G",
+	rarity: "Illustration rare",
+	dexId: [148],
+};
 
-	thirdParty: {
-		cardmarket: 719601
-	}
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV2a/183.ts
+++ b/data-asia/SV/SV2a/183.ts
@@ -1,19 +1,17 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV2a"
+import { Card } from "../../../interfaces";
+import Set from "../SV2a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "ミュウツー",
 		'zh-tw': "超夢",
 		th: "มิวทู",
-		id: "Mewtwo"
+		id: "Mewtwo",
 	},
 
 	illustrator: "Bun Toujo",
 	category: "Pokemon",
-	dexId: [150],
 	hp: 130,
 	types: ["Psychic"],
 
@@ -21,65 +19,62 @@ const card: Card = {
 		ja: "ミュウの 遺伝子を 組み替えて 生み出された。ポケモンで 一番 凶暴な 心を 持つという。",
 		'zh-tw': "藉著重組夢幻的基因而誕生。 據說有著所有寶可夢中最殘暴的心。",
 		th: "ถูกสร้างขึ้นมาจากการดัดแปลงหน่วยพันธุกรรมของมิว ว่ากันว่ามันมีจิตใจที่โหดร้ายที่สุดในบรรดาโปเกมอน",
-		id: "Mewtwo terlahir dari rekayasa genetik Mew. Dikatakan sebagai Pokémon dengan hati paling brutal."
+		id: "Mewtwo terlahir dari rekayasa genetik Mew. Dikatakan sebagai Pokémon dengan hati paling brutal.",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		cost: ["Colorless", "Colorless"],
-
-		name: {
-			ja: "リフレクトバリア",
-			'zh-tw': "反射屏障",
-			th: "รีเฟล็กต์บาเรีย",
-			id: "Reflect Barrier"
+	attacks: [
+		{
+			name: {
+				ja: "リフレクトバリア",
+				'zh-tw': "反射屏障",
+				th: "รีเฟล็กต์บาเรีย",
+				id: "Reflect Barrier",
+			},
+			damage: 20,
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "次の相手の番、このポケモンがワザのダメージを受けたとき、受けたダメージぶんのダメカンを、ワザを使ったポケモンにのせる。",
+				'zh-tw': "在下個對手的回合，這隻寶可夢受到招式的傷害時，將與受到的傷害相同數值的傷害指示物，放置於使用招式的寶可夢身上。",
+				th: "เทิร์นถัดไปของฝ่ายตรงข้าม เมื่อโปเกมอนนี้ได้รับแดเมจของท่าต่อสู้ วางตัวนับแดเมจบนโปเกมอนที่ใช้ท่าต่อสู้ ตามจำนวนแดเมจที่ได้รับมา",
+				id: "Pada giliran lawan berikutnya, saat Pokémon ini menerima kerusakan akibat serangan, letakkan Token Kerusakan sejumlah kerusakan yang diterima pada Pokémon yang telah menggunakan serangan.",
+			},
 		},
-
-		damage: 20,
-
-		effect: {
-			ja: "次の相手の番、このポケモンがワザのダメージを受けたとき、受けたダメージぶんのダメカンを、ワザを使ったポケモンにのせる。",
-			'zh-tw': "在下個對手的回合，這隻寶可夢受到招式的傷害時，將與受到的傷害相同數值的傷害指示物，放置於使用招式的寶可夢身上。",
-			th: "เทิร์นถัดไปของฝ่ายตรงข้าม เมื่อโปเกมอนนี้ได้รับแดเมจของท่าต่อสู้ วางตัวนับแดเมจบนโปเกมอนที่ใช้ท่าต่อสู้ ตามจำนวนแดเมจที่ได้รับมา",
-			id: "Pada giliran lawan berikutnya, saat Pokémon ini menerima kerusakan akibat serangan, letakkan Token Kerusakan sejumlah kerusakan yang diterima pada Pokémon yang telah menggunakan serangan."
-		}
-	}, {
-		cost: ["Psychic", "Psychic", "Colorless"],
-
-		name: {
-			ja: "サイコストライク",
-			'zh-tw': "精神強襲",
-			th: "ไซโคสไตรค์",
-			id: "Psychostrike"
+		{
+			name: {
+				ja: "サイコストライク",
+				'zh-tw': "精神強襲",
+				th: "ไซโคสไตรค์",
+				id: "Psychostrike",
+			},
+			damage: 130,
+			cost: ["Psychic", "Psychic", "Colorless"],
+			effect: {
+				ja: "このポケモンについているエネルギーを2個選び、トラッシュする。",
+				'zh-tw': "選擇2個這隻寶可夢身上附加的能量，將其丟棄。",
+				th: "เลือกพลังงานที่ติดอยู่กับโปเกมอนนี้ 2 ลูก ทิ้งที่ตำแหน่งทิ้งการ์ด",
+				id: "Pilih 2 Energi yang dikenakan pada Pokémon ini, lalu buang ke Trash.",
+			},
 		},
+	],
 
-		damage: 130,
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
 
-		effect: {
-			ja: "このポケモンについているエネルギーを2個選び、トラッシュする。",
-			'zh-tw': "選擇2個這隻寶可夢身上附加的能量，將其丟棄。",
-			th: "เลือกพลังงานที่ติดอยู่กับโปเกมอนนี้ 2 ลูก ทิ้งที่ตำแหน่งทิ้งการ์ด",
-			id: "Pilih 2 Energi yang dikenakan pada Pokémon ini, lalu buang ke Trash."
-		}
-	}],
-
-	weaknesses: [{
-		type: "Darkness",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Fighting",
-		value: "-30"
-	}],
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 719636,
+			},
+		},
+	],
 
 	retreat: 2,
 	regulationMark: "G",
+	rarity: "Illustration rare",
+	dexId: [150],
+};
 
-	thirdParty: {
-		cardmarket: 719603
-	}
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV2a/184.ts
+++ b/data-asia/SV/SV2a/184.ts
@@ -1,72 +1,81 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV2a"
+import { Card } from "../../../interfaces";
+import Set from "../SV2a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "フシギバナex",
 		'zh-tw': "妙蛙花ex",
 		th: "ฟุชิกิบานะex",
-		id: "Venusaur ex"
+		id: "Venusaur ex",
 	},
 
 	illustrator: "PLANETA Yamashita",
 	category: "Pokemon",
 	hp: 340,
 	types: ["Grass"],
+
 	stage: "Stage2",
-	suffix: "EX",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			ja: "やすらぎのはな",
-			'zh-tw': "平和之花",
-			th: "ดอกไม้สงบใจ",
-			id: "Bunga Ketenangan"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "やすらぎのはな",
+				'zh-tw': "平和之花",
+				th: "ดอกไม้สงบใจ",
+				id: "Bunga Ketenangan",
+			},
+			effect: {
+				ja: "このポケモンがバトル場にいるなら、自分の番に1回使える。自分のポケモン1匹のHPを「60」回復する。",
+				'zh-tw': "若這隻寶可夢在戰鬥場上，則在自己的回合時可使用1次。將自己的1隻寶可夢恢復「60」HP。",
+				th: "ถ้าโปเกมอนนี้อยู่บนตำแหน่งต่อสู้ ใช้ได้ 1 ครั้งในเทิร์นฝ่ายเรา ฟื้นฟู HP ของโปเกมอนฝ่ายเรา 1 ตัว [60]",
+				id: "Dapat digunakan 1 kali pada giliran sendiri jika Pokémon ini ada di Arena Bertarung. Pulihkan HP 1 Pokémon sendiri sejumlah 60.",
+			},
 		},
+	],
 
-		effect: {
-			ja: "このポケモンがバトル場にいるなら、自分の番に1回使える。自分のポケモン1匹のHPを「60」回復する。",
-			'zh-tw': "若這隻寶可夢在戰鬥場上，則在自己的回合時可使用1次。將自己的1隻寶可夢恢復「60」HP。",
-			th: "ถ้าโปเกมอนนี้อยู่บนตำแหน่งต่อสู้ ใช้ได้ 1 ครั้งในเทิร์นฝ่ายเรา ฟื้นฟู HP ของโปเกมอนฝ่ายเรา 1 ตัว [60]",
-			id: "Dapat digunakan 1 kali pada giliran sendiri jika Pokémon ini ada di Arena Bertarung. Pulihkan HP 1 Pokémon sendiri sejumlah 60."
-		}
-	}],
-
-	attacks: [{
-		cost: ["Grass", "Grass", "Colorless"],
-
-		name: {
-			ja: "もうどくウィップ",
-			'zh-tw': "劇毒鞭打",
-			th: "แส้พิษร้ายแรง",
-			id: "Cambuk Racun Ekstrem"
+	attacks: [
+		{
+			name: {
+				ja: "もうどくウィップ",
+				'zh-tw': "劇毒鞭打",
+				th: "แส้พิษร้ายแรง",
+				id: "Cambuk Racun Ekstrem",
+			},
+			damage: 150,
+			cost: ["Grass", "Grass", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをどくとこんらんにする。",
+				'zh-tw': "將對手的戰鬥寶可夢【中毒】與【混亂】。",
+				th: "ทำให้โปเกมอนบนตำแหน่งต่อสู้ฝ่ายตรงข้ามเป็นสภาวะ[พิษ]และ[สับสน]",
+				id: "Ubah kondisi Pokémon Bertarung lawan menjadi Racun dan Pusing.",
+			},
 		},
+	],
 
-		damage: 150,
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
 
-		effect: {
-			ja: "相手のバトルポケモンをどくとこんらんにする。",
-			'zh-tw': "將對手的戰鬥寶可夢【中毒】與【混亂】。",
-			th: "ทำให้โปเกมอนบนตำแหน่งต่อสู้ฝ่ายตรงข้ามเป็นสภาวะ[พิษ]และ[สับสน]",
-			id: "Ubah kondisi Pokémon Bertarung lawan menjadi Racun dan Pusing."
-		}
-	}],
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 719637,
+			},
+		},
+	],
 
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "フシギソウ",
+	},
 
 	retreat: 4,
 	regulationMark: "G",
+	rarity: "Ultra Rare",
+	dexId: [3],
 
-	thirdParty: {
-		cardmarket: 719445
-	}
-}
+	suffix: "EX",
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV2a/185.ts
+++ b/data-asia/SV/SV2a/185.ts
@@ -1,72 +1,79 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV2a"
+import { Card } from "../../../interfaces";
+import Set from "../SV2a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "リザードンex",
 		'zh-tw': "噴火龍ex",
 		th: "ลิซาร์ดอนex",
-		id: "Charizard ex"
+		id: "Charizard ex",
 	},
 
 	illustrator: "PLANETA Mochizuki",
 	category: "Pokemon",
 	hp: 330,
 	types: ["Fire"],
+
 	stage: "Stage2",
-	suffix: "EX",
 
-	attacks: [{
-		cost: ["Fire"],
-
-		name: {
-			ja: "ブレイブウイング",
-			'zh-tw': "無畏之翼",
-			th: "เบรฟวิง",
-			id: "Brave Wing"
+	attacks: [
+		{
+			name: {
+				ja: "ブレイブウイング",
+				'zh-tw': "無畏之翼",
+				th: "เบรฟวิง",
+				id: "Brave Wing",
+			},
+			damage: "60+",
+			cost: ["Fire"],
+			effect: {
+				ja: "このポケモンにダメカンがのっているなら、100ダメージ追加。",
+				'zh-tw': "若這隻寶可夢身上放置有傷害指示物，則增加100點傷害。",
+				th: "ถ้าโปเกมอนนี้มีตัวนับแดเมจวางอยู่ การโจมตีนี้จะเพิ่มแดเมจอีก 100",
+				id: "Jika Pokémon ini memiliki Token Kerusakan, kerusakan yang diberikan bertambah sejumlah 100.",
+			},
 		},
-
-		damage: "60+",
-
-		effect: {
-			ja: "このポケモンにダメカンがのっているなら、100ダメージ追加。",
-			'zh-tw': "若這隻寶可夢身上放置有傷害指示物，則增加100點傷害。",
-			th: "ถ้าโปเกมอนนี้มีตัวนับแดเมจวางอยู่ การโจมตีนี้จะเพิ่มแดเมจอีก 100",
-			id: "Jika Pokémon ini memiliki Token Kerusakan, kerusakan yang diberikan bertambah sejumlah 100."
-		}
-	}, {
-		cost: ["Fire", "Fire", "Fire", "Fire"],
-
-		name: {
-			ja: "ばくえんのうず",
-			'zh-tw': "爆焰旋渦",
-			th: "วงล้อระเบิดไฟ",
-			id: "Pusaran Ledakan Api"
+		{
+			name: {
+				ja: "ばくえんのうず",
+				'zh-tw': "爆焰旋渦",
+				th: "วงล้อระเบิดไฟ",
+				id: "Pusaran Ledakan Api",
+			},
+			damage: 330,
+			cost: ["Fire", "Fire", "Fire", "Fire"],
+			effect: {
+				ja: "このポケモンについているエネルギーを3個選び、トラッシュする。",
+				'zh-tw': "選擇3個這隻寶可夢身上附加的能量，將其丟棄。",
+				th: "เลือกพลังงานที่ติดอยู่กับโปเกมอนนี้ 3 ลูก ทิ้งที่ตำแหน่งทิ้งการ์ด",
+				id: "Pilih 3 Energi yang dikenakan pada Pokémon ini, lalu buang ke Trash.",
+			},
 		},
+	],
 
-		damage: 330,
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
 
-		effect: {
-			ja: "このポケモンについているエネルギーを3個選び、トラッシュする。",
-			'zh-tw': "選擇3個這隻寶可夢身上附加的能量，將其丟棄。",
-			th: "เลือกพลังงานที่ติดอยู่กับโปเกมอนนี้ 3 ลูก ทิ้งที่ตำแหน่งทิ้งการ์ด",
-			id: "Pilih 3 Energi yang dikenakan pada Pokémon ini, lalu buang ke Trash."
-		}
-	}],
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 719638,
+			},
+		},
+	],
 
-	weaknesses: [{
-		type: "Water",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "リザード",
+	},
 
 	retreat: 2,
 	regulationMark: "G",
+	rarity: "Ultra Rare",
+	dexId: [6],
 
-	thirdParty: {
-		cardmarket: 719448
-	}
-}
+	suffix: "EX",
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV2a/186.ts
+++ b/data-asia/SV/SV2a/186.ts
@@ -1,72 +1,81 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV2a"
+import { Card } from "../../../interfaces";
+import Set from "../SV2a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "カメックスex",
 		'zh-tw': "水箭龜ex",
 		th: "คาเม็กซ์ex",
-		id: "Blastoise ex"
+		id: "Blastoise ex",
 	},
 
 	illustrator: "PLANETA Yamashita",
 	category: "Pokemon",
 	hp: 330,
 	types: ["Water"],
+
 	stage: "Stage2",
-	suffix: "EX",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			ja: "かたいこうら",
-			'zh-tw': "堅硬甲殼",
-			th: "กระดองสุดแข็ง",
-			id: "Tempurung Padat"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "かたいこうら",
+				'zh-tw': "堅硬甲殼",
+				th: "กระดองสุดแข็ง",
+				id: "Tempurung Padat",
+			},
+			effect: {
+				ja: "このポケモンが受けるワザのダメージは「-30」される。",
+				'zh-tw': "這隻寶可夢受到招式的傷害「-30」點。",
+				th: "แดเมจของท่าต่อสู้ที่โปเกมอนนี้จะได้รับจะถูก [-30]",
+				id: "Kerusakan akibat serangan yang diterima Pokémon ini berkurang sejumlah 30.",
+			},
 		},
+	],
 
-		effect: {
-			ja: "このポケモンが受けるワザのダメージは「-30」される。",
-			'zh-tw': "這隻寶可夢受到招式的傷害「-30」點。",
-			th: "แดเมจของท่าต่อสู้ที่โปเกมอนนี้จะได้รับจะถูก [-30]",
-			id: "Kerusakan akibat serangan yang diterima Pokémon ini berkurang sejumlah 30."
-		}
-	}],
-
-	attacks: [{
-		cost: ["Water", "Water"],
-
-		name: {
-			ja: "ツインカノン",
-			'zh-tw': "雙加農炮",
-			th: "ทวินแคนนอน",
-			id: "Twin Cannon"
+	attacks: [
+		{
+			name: {
+				ja: "ツインカノン",
+				'zh-tw': "雙加農炮",
+				th: "ทวินแคนนอน",
+				id: "Twin Cannon",
+			},
+			damage: "140×",
+			cost: ["Water", "Water"],
+			effect: {
+				ja: "自分の手札から「基本[W]エネルギー」を2枚までトラッシュし、その枚数×140ダメージ。",
+				'zh-tw': "從自己的手牌將最多2張「基本【水】能量」卡丟棄，造成其張數×140點傷害。",
+				th: "ทิ้งการ์ด [พลังงานพื้นฐาน[น้ำ]] ได้สูงสุด 2 ใบจากบนมือฝ่ายเราที่ตำแหน่งทิ้งการ์ด แดเมจจะเท่ากับจำนวนการ์ดนั้น x140",
+				id: "Buang paling banyak 2 lembar Energi Dasar {Air} dari Kartu Pegangan sendiri ke Trash, serangan ini memberikan kerusakan sejumlah 140 untuk tiap lembarnya.",
+			},
 		},
+	],
 
-		damage: "140×",
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
 
-		effect: {
-			ja: "自分の手札から「基本エネルギー」を2枚までトラッシュし、その枚数×140ダメージ。",
-			'zh-tw': "從自己的手牌將最多2張「基本【水】能量」卡丟棄，造成其張數×140點傷害。",
-			th: "ทิ้งการ์ด [พลังงานพื้นฐาน[น้ำ]] ได้สูงสุด 2 ใบจากบนมือฝ่ายเราที่ตำแหน่งทิ้งการ์ด แดเมจจะเท่ากับจำนวนการ์ดนั้น x140",
-			id: "Buang paling banyak 2 lembar Energi Dasar {Air} dari Kartu Pegangan sendiri ke Trash, serangan ini memberikan kerusakan sejumlah 140 untuk tiap lembarnya."
-		}
-	}],
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 719639,
+			},
+		},
+	],
 
-	weaknesses: [{
-		type: "Lightning",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "カメール",
+	},
 
 	retreat: 3,
 	regulationMark: "G",
+	rarity: "Ultra Rare",
+	dexId: [9],
 
-	thirdParty: {
-		cardmarket: 719451
-	}
-}
+	suffix: "EX",
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV2a/187.ts
+++ b/data-asia/SV/SV2a/187.ts
@@ -1,72 +1,79 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV2a"
+import { Card } from "../../../interfaces";
+import Set from "../SV2a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "アーボックex",
 		'zh-tw': "阿柏怪ex",
 		th: "อาร์บ็อกex",
-		id: "Arbok ex"
+		id: "Arbok ex",
 	},
 
 	illustrator: "Eske Yoshinob",
 	category: "Pokemon",
 	hp: 270,
 	types: ["Darkness"],
+
 	stage: "Stage1",
-	suffix: "EX",
 
-	attacks: [{
-		cost: ["Darkness", "Darkness"],
-
-		name: {
-			ja: "しばりつける",
-			'zh-tw': "束縛",
-			th: "มัดยึด",
-			id: "Menjerat"
+	attacks: [
+		{
+			name: {
+				ja: "しばりつける",
+				'zh-tw': "束縛",
+				th: "มัดยึด",
+				id: "Menjerat",
+			},
+			damage: 70,
+			cost: ["Darkness", "Darkness"],
+			effect: {
+				ja: "次の相手の番、このワザを受けたポケモンは、にげられない。",
+				'zh-tw': "在下個對手的回合，受到這個招式的寶可夢無法撤退。",
+				th: "เทิร์นถัดไปของฝ่ายตรงข้าม โปเกมอนที่ได้รับท่าต่อสู้นี้ จะหนีไม่ได้",
+				id: "Pada giliran lawan berikutnya, Pokémon yang menerima serangan ini tidak dapat Mundur.",
+			},
 		},
-
-		damage: 70,
-
-		effect: {
-			ja: "次の相手の番、このワザを受けたポケモンは、にげられない。",
-			'zh-tw': "在下個對手的回合，受到這個招式的寶可夢無法撤退。",
-			th: "เทิร์นถัดไปของฝ่ายตรงข้าม โปเกมอนที่ได้รับท่าต่อสู้นี้ จะหนีไม่ได้",
-			id: "Pada giliran lawan berikutnya, Pokémon yang menerima serangan ini tidak dapat Mundur."
-		}
-	}, {
-		cost: ["Darkness", "Darkness", "Darkness"],
-
-		name: {
-			ja: "メナスファング",
-			'zh-tw': "脅迫獠牙",
-			th: "คมเขี้ยวคุกคาม",
-			id: "Menace Fang"
+		{
+			name: {
+				ja: "メナスファング",
+				'zh-tw': "脅迫獠牙",
+				th: "คมเขี้ยวคุกคาม",
+				id: "Menace Fang",
+			},
+			damage: 150,
+			cost: ["Darkness", "Darkness", "Darkness"],
+			effect: {
+				ja: "相手は相手自身の手札を2枚選び、トラッシュする。",
+				'zh-tw': "對手選擇對手自己的2張手牌，將其丟棄。",
+				th: "ฝ่ายตรงข้ามเลือกการ์ดบนมือฝ่ายตรงข้ามเอง 2 ใบ ทิ้งที่ตำแหน่งทิ้งการ์ด",
+				id: "Lawan memilih 2 lembar Kartu Pegangannya, lalu membuangnya ke Trash.",
+			},
 		},
+	],
 
-		damage: 150,
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
 
-		effect: {
-			ja: "相手は相手自身の手札を2枚選び、トラッシュする。",
-			'zh-tw': "對手選擇對手自己的2張手牌，將其丟棄。",
-			th: "ฝ่ายตรงข้ามเลือกการ์ดบนมือฝ่ายตรงข้ามเอง 2 ใบ ทิ้งที่ตำแหน่งทิ้งการ์ด",
-			id: "Lawan memilih 2 lembar Kartu Pegangannya, lalu membuangnya ke Trash."
-		}
-	}],
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 719640,
+			},
+		},
+	],
 
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "アーボ",
+	},
 
 	retreat: 2,
 	regulationMark: "G",
+	rarity: "Ultra Rare",
+	dexId: [24],
 
-	thirdParty: {
-		cardmarket: 719466
-	}
-}
+	suffix: "EX",
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV2a/188.ts
+++ b/data-asia/SV/SV2a/188.ts
@@ -1,72 +1,79 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV2a"
+import { Card } from "../../../interfaces";
+import Set from "../SV2a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "キュウコンex",
 		'zh-tw': "九尾ex",
 		th: "คิวคอนex",
-		id: "Ninetales ex"
+		id: "Ninetales ex",
 	},
 
 	illustrator: "PLANETA Tsuji",
 	category: "Pokemon",
 	hp: 260,
 	types: ["Fire"],
+
 	stage: "Stage1",
-	suffix: "EX",
 
-	attacks: [{
-		cost: ["Fire"],
-
-		name: {
-			ja: "ねっぷう",
-			'zh-tw': "熱風",
-			th: "คลื่นความร้อน",
-			id: "Angin Panas"
+	attacks: [
+		{
+			name: {
+				ja: "ねっぷう",
+				'zh-tw': "熱風",
+				th: "คลื่นความร้อน",
+				id: "Angin Panas",
+			},
+			damage: 30,
+			cost: ["Fire"],
+			effect: {
+				ja: "相手のバトルポケモンをやけどにする。",
+				'zh-tw': "將對手的戰鬥寶可夢【灼傷】。",
+				th: "ทำให้โปเกมอนบนตำแหน่งต่อสู้ฝ่ายตรงข้ามเป็นสภาวะ[ไหม้]",
+				id: "Ubah kondisi Pokémon Bertarung lawan menjadi Luka Bakar.",
+			},
 		},
-
-		damage: 30,
-
-		effect: {
-			ja: "相手のバトルポケモンをやけどにする。",
-			'zh-tw': "將對手的戰鬥寶可夢【灼傷】。",
-			th: "ทำให้โปเกมอนบนตำแหน่งต่อสู้ฝ่ายตรงข้ามเป็นสภาวะ[ไหม้]",
-			id: "Ubah kondisi Pokémon Bertarung lawan menjadi Luka Bakar."
-		}
-	}, {
-		cost: ["Fire", "Colorless"],
-
-		name: {
-			ja: "うつしほむら",
-			'zh-tw': "現形熾火",
-			th: "เปลวไฟสะท้อน",
-			id: "Kobaran Api Refleksi"
+		{
+			name: {
+				ja: "うつしほむら",
+				'zh-tw': "現形熾火",
+				th: "เปลวไฟสะท้อน",
+				id: "Kobaran Api Refleksi",
+			},
+			damage: "80+",
+			cost: ["Fire", "Colorless"],
+			effect: {
+				ja: "自分の手札と相手の手札が同じ枚数なら、140ダメージ追加。",
+				'zh-tw': "若自己的手牌與對手的手牌張數相同，則增加140點傷害。",
+				th: "ถ้าจำนวนการ์ดบนมือฝ่ายเราเท่ากับจำนวนการ์ดบนมือฝ่ายตรงข้าม การโจมตีนี้จะเพิ่มแดเมจอีก 140",
+				id: "Jika jumlah Kartu Pegangan sendiri dan jumlah Kartu Pegangan lawan sama, kerusakan yang diberikan bertambah sejumlah 140.",
+			},
 		},
+	],
 
-		damage: "80+",
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
 
-		effect: {
-			ja: "自分の手札と相手の手札が同じ枚数なら、140ダメージ追加。",
-			'zh-tw': "若自己的手牌與對手的手牌張數相同，則增加140點傷害。",
-			th: "ถ้าจำนวนการ์ดบนมือฝ่ายเราเท่ากับจำนวนการ์ดบนมือฝ่ายตรงข้าม การโจมตีนี้จะเพิ่มแดเมจอีก 140",
-			id: "Jika jumlah Kartu Pegangan sendiri dan jumlah Kartu Pegangan lawan sama, kerusakan yang diberikan bertambah sejumlah 140."
-		}
-	}],
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 719641,
+			},
+		},
+	],
 
-	weaknesses: [{
-		type: "Water",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "ロコン",
+	},
 
 	retreat: 2,
 	regulationMark: "G",
+	rarity: "Ultra Rare",
+	dexId: [38],
 
-	thirdParty: {
-		cardmarket: 719480
-	}
-}
+	suffix: "EX",
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV2a/189.ts
+++ b/data-asia/SV/SV2a/189.ts
@@ -1,72 +1,81 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV2a"
+import { Card } from "../../../interfaces";
+import Set from "../SV2a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "プクリンex",
 		'zh-tw': "胖可丁ex",
 		th: "พูคูรินex",
-		id: "Wigglytuff ex"
+		id: "Wigglytuff ex",
 	},
 
 	illustrator: "Saki Hayashiro",
 	category: "Pokemon",
 	hp: 250,
 	types: ["Colorless"],
+
 	stage: "Stage1",
-	suffix: "EX",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			ja: "ふくらむボディ",
-			'zh-tw': "膨脹之軀",
-			th: "ร่างพอง",
-			id: "Tubuh Menggelembung"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "ふくらむボディ",
+				'zh-tw': "膨脹之軀",
+				th: "ร่างพอง",
+				id: "Tubuh Menggelembung",
+			},
+			effect: {
+				ja: "このポケモンに特殊エネルギーがついているなら、このポケモンの最大HPは「+100」される。",
+				'zh-tw': "若這隻寶可夢身上附有特殊能量卡，則這隻寶可夢的最大HP「+100」。",
+				th: "ถ้าโปเกมอนนี้มีพลังงานพิเศษติดอยู่ HP สูงสุดของโปเกมอนนี้จะถูก [+100]",
+				id: "Jika Pokémon ini mengenakan Energi Spesial, HP maksimal Pokémon ini bertambah sejumlah 100.",
+			},
 		},
+	],
 
-		effect: {
-			ja: "このポケモンに特殊エネルギーがついているなら、このポケモンの最大HPは「+100」される。",
-			'zh-tw': "若這隻寶可夢身上附有特殊能量卡，則這隻寶可夢的最大HP「+100」。",
-			th: "ถ้าโปเกมอนนี้มีพลังงานพิเศษติดอยู่ HP สูงสุดของโปเกมอนนี้จะถูก [+100]",
-			id: "Jika Pokémon ini mengenakan Energi Spesial, HP maksimal Pokémon ini bertambah sejumlah 100."
-		}
-	}],
-
-	attacks: [{
-		cost: ["Colorless", "Colorless", "Colorless"],
-
-		name: {
-			ja: "フレンドタックル",
-			'zh-tw': "朋友衝撞",
-			th: "เฟรนด์แท็กเกิล",
-			id: "Friend Tackle"
+	attacks: [
+		{
+			name: {
+				ja: "フレンドタックル",
+				'zh-tw': "朋友衝撞",
+				th: "เฟรนด์แท็กเกิล",
+				id: "Friend Tackle",
+			},
+			damage: "90+",
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "この番、手札からサポートを出して使っていたなら、90ダメージ追加。",
+				'zh-tw': "在這個回合，若從手牌使出了支援者卡，則增加90點傷害。",
+				th: "เทิร์นนี้ ถ้านำการ์ดซัพพอร์ตจากบนมือออกมาใช้แล้ว การโจมตีนี้จะเพิ่มแดเมจอีก 90",
+				id: "Jika pada giliran ini, Supporter telah dimainkan dari Kartu Pegangan, kerusakan yang diberikan bertambah sejumlah 90.",
+			},
 		},
+	],
 
-		damage: "90+",
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
 
-		effect: {
-			ja: "この番、手札からサポートを出して使っていたなら、90ダメージ追加。",
-			'zh-tw': "在這個回合，若從手牌使出了支援者卡，則增加90點傷害。",
-			th: "เทิร์นนี้ ถ้านำการ์ดซัพพอร์ตจากบนมือออกมาใช้แล้ว การโจมตีนี้จะเพิ่มแดเมจอีก 90",
-			id: "Jika pada giliran ini, Supporter telah dimainkan dari Kartu Pegangan, kerusakan yang diberikan bertambah sejumlah 90."
-		}
-	}],
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 719642,
+			},
+		},
+	],
 
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "プリン",
+	},
 
 	retreat: 3,
 	regulationMark: "G",
+	rarity: "Ultra Rare",
+	dexId: [40],
 
-	thirdParty: {
-		cardmarket: 719482
-	}
-}
+	suffix: "EX",
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV2a/190.ts
+++ b/data-asia/SV/SV2a/190.ts
@@ -1,77 +1,79 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV2a"
+import { Card } from "../../../interfaces";
+import Set from "../SV2a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "フーディンex",
 		'zh-tw': "胡地ex",
 		th: "ฟูดินex",
-		id: "Alakazam ex"
+		id: "Alakazam ex",
 	},
 
 	illustrator: "PLANETA Tsuji",
 	category: "Pokemon",
 	hp: 310,
 	types: ["Psychic"],
+
 	stage: "Stage2",
-	suffix: "EX",
 
-	attacks: [{
-		cost: ["Colorless", "Colorless"],
-
-		name: {
-			ja: "マインドジャック",
-			'zh-tw': "意志劫持",
-			th: "มายด์แจ็ค",
-			id: "Mind Jack"
+	attacks: [
+		{
+			name: {
+				ja: "マインドジャック",
+				'zh-tw': "意志劫持",
+				th: "มายด์แจ็ค",
+				id: "Mind Jack",
+			},
+			damage: "90+",
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "相手のベンチポケモンの数×30ダメージ追加。",
+				'zh-tw': "增加對手的備戰寶可夢的數量×30點傷害。",
+				th: "แดเมจจะเพิ่มตามจำนวนโปเกมอนบนเบนช์ฝ่ายตรงข้าม x30",
+				id: "Kerusakan yang diberikan bertambah sejumlah 30 untuk tiap Pokémon Cadangan lawan.",
+			},
 		},
-
-		damage: "90+",
-
-		effect: {
-			ja: "相手のベンチポケモンの数×30ダメージ追加。",
-			'zh-tw': "增加對手的備戰寶可夢的數量×30點傷害。",
-			th: "แดเมจจะเพิ่มตามจำนวนโปเกมอนบนเบนช์ฝ่ายตรงข้าม x30",
-			id: "Kerusakan yang diberikan bertambah sejumlah 30 untuk tiap Pokémon Cadangan lawan."
-		}
-	}, {
-		cost: ["Psychic", "Psychic"],
-
-		name: {
-			ja: "ディメンションハンド",
-			'zh-tw': "維度之手",
-			th: "ไดเมนชันแฮนด์",
-			id: "Dimension Hand"
+		{
+			name: {
+				ja: "ディメンションハンド",
+				'zh-tw': "維度之手",
+				th: "ไดเมนชันแฮนด์",
+				id: "Dimension Hand",
+			},
+			damage: 120,
+			cost: ["Psychic", "Psychic"],
+			effect: {
+				ja: "このワザは、このポケモンがベンチにいても使える。",
+				'zh-tw': "就算這隻寶可夢在備戰區，這個招式也可使用。",
+				th: "ท่าต่อสู้นี้ แม้โปเกมอนนี้อยู่บนเบนช์ก็ใช้ได้",
+				id: "Serangan ini dapat digunakan meskipun Pokémon ini ada di Cadangan.",
+			},
 		},
+	],
 
-		damage: 120,
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
 
-		effect: {
-			ja: "このワザは、このポケモンがベンチにいても使える。",
-			'zh-tw': "就算這隻寶可夢在備戰區，這個招式也可使用。",
-			th: "ท่าต่อสู้นี้ แม้โปเกมอนนี้อยู่บนเบนช์ก็ใช้ได้",
-			id: "Serangan ini dapat digunakan meskipun Pokémon ini ada di Cadangan."
-		}
-	}],
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 719643,
+			},
+		},
+	],
 
-	weaknesses: [{
-		type: "Darkness",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Fighting",
-		value: "-30"
-	}],
+	evolveFrom: {
+		ja: "ユンゲラー",
+	},
 
 	retreat: 1,
 	regulationMark: "G",
+	rarity: "Ultra Rare",
+	dexId: [65],
 
-	thirdParty: {
-		cardmarket: 719507
-	}
-}
+	suffix: "EX",
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV2a/191.ts
+++ b/data-asia/SV/SV2a/191.ts
@@ -1,72 +1,79 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV2a"
+import { Card } from "../../../interfaces";
+import Set from "../SV2a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "ゴローニャex",
 		'zh-tw': "隆隆岩ex",
 		th: "โกโลเนียex",
-		id: "Golem ex"
+		id: "Golem ex",
 	},
 
 	illustrator: "PLANETA Igarashi",
 	category: "Pokemon",
 	hp: 330,
 	types: ["Fighting"],
+
 	stage: "Stage2",
-	suffix: "EX",
 
-	attacks: [{
-		cost: ["Fighting"],
-
-		name: {
-			ja: "ダイナミックロール",
-			'zh-tw': "極限轉動",
-			th: "ไดนามิกโรล",
-			id: "Dynamic Roll"
+	attacks: [
+		{
+			name: {
+				ja: "ダイナミックロール",
+				'zh-tw': "極限轉動",
+				th: "ไดนามิกโรล",
+				id: "Dynamic Roll",
+			},
+			damage: 50,
+			cost: ["Fighting"],
+			effect: {
+				ja: "次の自分の番、このポケモンが使うワザの、相手のバトルポケモンへのダメージは「+120」される。",
+				'zh-tw': "在下個自己的回合，這隻寶可夢使用的招式，對對手的戰鬥寶可夢造成的傷害「+120」點。",
+				th: "เทิร์นถัดไปของฝ่ายเรา แดเมจของท่าต่อสู้ที่โปเกมอนนี้ ใช้ทำกับโปเกมอนบนตำแหน่งต่อสู้ฝ่ายตรงข้ามจะถูก [+120]",
+				id: "Pada giliran sendiri berikutnya, kerusakan akibat serangan yang digunakan oleh Pokémon ini kepada Pokémon Bertarung lawan bertambah sejumlah 120.",
+			},
 		},
-
-		damage: 50,
-
-		effect: {
-			ja: "次の自分の番、このポケモンが使うワザの、相手のバトルポケモンへのダメージは「+120」される。",
-			'zh-tw': "在下個自己的回合，這隻寶可夢使用的招式，對對手的戰鬥寶可夢造成的傷害「+120」點。",
-			th: "เทิร์นถัดไปของฝ่ายเรา แดเมจของท่าต่อสู้ที่โปเกมอนนี้ ใช้ทำกับโปเกมอนบนตำแหน่งต่อสู้ฝ่ายตรงข้ามจะถูก [+120]",
-			id: "Pada giliran sendiri berikutnya, kerusakan akibat serangan yang digunakan oleh Pokémon ini kepada Pokémon Bertarung lawan bertambah sejumlah 120."
-		}
-	}, {
-		cost: ["Fighting", "Colorless", "Colorless"],
-
-		name: {
-			ja: "がんせきボンバー",
-			'zh-tw': "岩石衝撞",
-			th: "ระเบิดหิน",
-			id: "Bom Batu"
+		{
+			name: {
+				ja: "がんせきボンバー",
+				'zh-tw': "岩石衝撞",
+				th: "ระเบิดหิน",
+				id: "Bom Batu",
+			},
+			damage: 180,
+			cost: ["Fighting", "Colorless", "Colorless"],
+			effect: {
+				ja: "このワザのダメージは抵抗力を計算しない。",
+				'zh-tw': "這個招式的傷害不計算抵抗力。",
+				th: "แดเมจของท่าต่อสู้นี้จะไม่นำความต้านทานมาคิด",
+				id: "Kerusakan akibat serangan ini tidak terpengaruh oleh Resistansi.",
+			},
 		},
+	],
 
-		damage: 180,
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
 
-		effect: {
-			ja: "このワザのダメージは抵抗力を計算しない。",
-			'zh-tw': "這個招式的傷害不計算抵抗力。",
-			th: "แดเมจของท่าต่อสู้นี้จะไม่นำความต้านทานมาคิด",
-			id: "Kerusakan akibat serangan ini tidak terpengaruh oleh Resistansi."
-		}
-	}],
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 719644,
+			},
+		},
+	],
 
-	weaknesses: [{
-		type: "Grass",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "ゴローン",
+	},
 
 	retreat: 4,
 	regulationMark: "G",
+	rarity: "Ultra Rare",
+	dexId: [76],
 
-	thirdParty: {
-		cardmarket: 719518
-	}
-}
+	suffix: "EX",
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV2a/192.ts
+++ b/data-asia/SV/SV2a/192.ts
@@ -1,70 +1,74 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV2a"
+import { Card } from "../../../interfaces";
+import Set from "../SV2a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "ガルーラex",
 		'zh-tw': "袋獸ex",
 		th: "การูราex",
-		id: "Kangaskhan ex"
+		id: "Kangaskhan ex",
 	},
 
 	illustrator: "N-DESIGN Inc.",
 	category: "Pokemon",
 	hp: 230,
 	types: ["Colorless"],
+
 	stage: "Basic",
-	suffix: "EX",
 
-	attacks: [{
-		cost: ["Colorless"],
-
-		name: {
-			ja: "トリプルドロー",
-			'zh-tw': "三重抽出",
-			th: "ทริปเปิ้ลดรอว์",
-			id: "Triple Draw"
+	attacks: [
+		{
+			name: {
+				ja: "トリプルドロー",
+				'zh-tw': "三重抽出",
+				th: "ทริปเปิ้ลดรอว์",
+				id: "Triple Draw",
+			},
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札を3枚引く。",
+				'zh-tw': "從自己的牌庫抽出3張卡。",
+				th: "จั่วการ์ด 3 ใบจากสำรับการ์ดฝ่ายเรา",
+				id: "Ambil 3 kartu dari atas Deck sendiri.",
+			},
 		},
-
-		effect: {
-			ja: "自分の山札を3枚引く。",
-			'zh-tw': "從自己的牌庫抽出3張卡。",
-			th: "จั่วการ์ด 3 ใบจากสำรับการ์ดฝ่ายเรา",
-			id: "Ambil 3 kartu dari atas Deck sendiri."
-		}
-	}, {
-		cost: ["Colorless", "Colorless", "Colorless"],
-
-		name: {
-			ja: "マシンガンパンチ",
-			'zh-tw': "機關槍拳",
-			th: "แมชชีนกันพันช์",
-			id: "Machinegun Punch"
+		{
+			name: {
+				ja: "マシンガンパンチ",
+				'zh-tw': "機關槍拳",
+				th: "แมชชีนกันพันช์",
+				id: "Machinegun Punch",
+			},
+			damage: "100×",
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "コインを4回投げ、オモテの数×100ダメージ。",
+				'zh-tw': "擲4次硬幣，造成正面出現的次數×100點傷害。",
+				th: "ทอยเหรียญ 4 ครั้ง แดเมจจะเท่ากับจำนวนครั้งที่ออกหัว x100",
+				id: "Lempar koin 4 kali. Serangan ini memberikan kerusakan sejumlah 100 untuk tiap lemparan dengan hasil sisi depan.",
+			},
 		},
+	],
 
-		damage: "100×",
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
 
-		effect: {
-			ja: "コインを4回投げ、オモテの数×100ダメージ。",
-			'zh-tw': "擲4次硬幣，造成正面出現的次數×100點傷害。",
-			th: "ทอยเหรียญ 4 ครั้ง แดเมจจะเท่ากับจำนวนครั้งที่ออกหัว x100",
-			id: "Lempar koin 4 kali. Serangan ini memberikan kerusakan sejumlah 100 untuk tiap lemparan dengan hasil sisi depan."
-		}
-	}],
-
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 719645,
+			},
+		},
+	],
 
 	retreat: 2,
 	regulationMark: "G",
+	rarity: "Ultra Rare",
+	dexId: [115],
 
-	thirdParty: {
-		cardmarket: 719568
-	}
-}
+	suffix: "EX",
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV2a/193.ts
+++ b/data-asia/SV/SV2a/193.ts
@@ -1,70 +1,74 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV2a"
+import { Card } from "../../../interfaces";
+import Set from "../SV2a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "ルージュラex",
 		'zh-tw': "迷唇姐ex",
 		th: "รูจูลาex",
-		id: "Jynx ex"
+		id: "Jynx ex",
 	},
 
 	illustrator: "Ayaka Yoshida",
 	category: "Pokemon",
 	hp: 200,
 	types: ["Water"],
+
 	stage: "Basic",
-	suffix: "EX",
 
-	attacks: [{
-		cost: ["Water", "Colorless", "Colorless"],
-
-		name: {
-			ja: "ズッキュンキッス",
-			'zh-tw': "動心之吻",
-			th: "จุ๊บโดนใจ",
-			id: "Ciuman Meluluhkan"
+	attacks: [
+		{
+			name: {
+				ja: "ズッキュンキッス",
+				'zh-tw': "動心之吻",
+				th: "จุ๊บโดนใจ",
+				id: "Ciuman Meluluhkan",
+			},
+			cost: ["Water", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンがねむりなら、そのポケモンをきぜつさせる。",
+				'zh-tw': "若對手的戰鬥寶可夢【睡眠】，則將那隻寶可夢【昏厥】。",
+				th: "ถ้าโปเกมอนบนตำแหน่งต่อสู้ฝ่ายตรงข้ามเป็นสภาวะ[หลับ] จะทำให้โปเกมอนนั้น[หมดสภาพ]",
+				id: "Jika Pokémon Bertarung lawan mengalami kondisi Tidur, Pokémon tersebut KO.",
+			},
 		},
-
-		effect: {
-			ja: "相手のバトルポケモンがねむりなら、そのポケモンをきぜつさせる。",
-			'zh-tw': "若對手的戰鬥寶可夢【睡眠】，則將那隻寶可夢【昏厥】。",
-			th: "ถ้าโปเกมอนบนตำแหน่งต่อสู้ฝ่ายตรงข้ามเป็นสภาวะ[หลับ] จะทำให้โปเกมอนนั้น[หมดสภาพ]",
-			id: "Jika Pokémon Bertarung lawan mengalami kondisi Tidur, Pokémon tersebut KO."
-		}
-	}, {
-		cost: ["Water", "Water", "Water"],
-
-		name: {
-			ja: "こごえるかぜ",
-			'zh-tw': "冰凍之風",
-			th: "สายลมเยือกแข็ง",
-			id: "Angin Dingin"
+		{
+			name: {
+				ja: "こごえるかぜ",
+				'zh-tw': "冰凍之風",
+				th: "สายลมเยือกแข็ง",
+				id: "Angin Dingin",
+			},
+			damage: 120,
+			cost: ["Water", "Water", "Water"],
+			effect: {
+				ja: "相手のバトルポケモンをねむりにする。",
+				'zh-tw': "將對手的戰鬥寶可夢【睡眠】。",
+				th: "ทำให้โปเกมอนบนตำแหน่งต่อสู้ฝ่ายตรงข้ามเป็นสภาวะ[หลับ]",
+				id: "Ubah kondisi Pokémon Bertarung lawan menjadi Tidur.",
+			},
 		},
+	],
 
-		damage: 120,
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
 
-		effect: {
-			ja: "相手のバトルポケモンをねむりにする。",
-			'zh-tw': "將對手的戰鬥寶可夢【睡眠】。",
-			th: "ทำให้โปเกมอนบนตำแหน่งต่อสู้ฝ่ายตรงข้ามเป็นสภาวะ[หลับ]",
-			id: "Ubah kondisi Pokémon Bertarung lawan menjadi Tidur."
-		}
-	}],
-
-	weaknesses: [{
-		type: "Metal",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 719646,
+			},
+		},
+	],
 
 	retreat: 2,
 	regulationMark: "G",
+	rarity: "Ultra Rare",
+	dexId: [124],
 
-	thirdParty: {
-		cardmarket: 719577
-	}
-}
+	suffix: "EX",
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV2a/194.ts
+++ b/data-asia/SV/SV2a/194.ts
@@ -1,77 +1,77 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV2a"
+import { Card } from "../../../interfaces";
+import Set from "../SV2a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "サンダーex",
 		'zh-tw': "閃電鳥ex",
 		th: "ธันเดอร์ex",
-		id: "Zapdos ex"
+		id: "Zapdos ex",
 	},
 
 	illustrator: "takuyoa",
 	category: "Pokemon",
 	hp: 200,
 	types: ["Lightning"],
+
 	stage: "Basic",
-	suffix: "EX",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			ja: "ボルトフロート",
-			'zh-tw': "伏特浮游",
-			th: "โบลต์โฟลต",
-			id: "Bolt Float"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "ボルトフロート",
+				'zh-tw': "伏特浮游",
+				th: "โบลต์โฟลต",
+				id: "Bolt Float",
+			},
+			effect: {
+				ja: "このポケモンに[L]エネルギーがついているなら、このポケモンのにげるためのエネルギーは、すべてなくなる。",
+				'zh-tw': "若這隻寶可夢身上附有【雷】能量卡，則這隻寶可夢【撤退】所需的能量全部消除。",
+				th: "ถ้าโปเกมอนนี้มีพลังงาน[สายฟ้า]ติดอยู่ พลังงานสำหรับ[หนี]ของโปเกมอนนี้ ทั้งหมดจะหายไป",
+				id: "Jika Pokémon ini mengenakan Energi {Listrik}, Pokémon ini menjadi tidak membutuhkan Energi untuk Mundur.",
+			},
 		},
+	],
 
-		effect: {
-			ja: "このポケモンにエネルギーがついているなら、このポケモンのにげるためのエネルギーは、すべてなくなる。",
-			'zh-tw': "若這隻寶可夢身上附有【雷】能量卡，則這隻寶可夢【撤退】所需的能量全部消除。",
-			th: "ถ้าโปเกมอนนี้มีพลังงาน[สายฟ้า]ติดอยู่ พลังงานสำหรับ[หนี]ของโปเกมอนนี้ ทั้งหมดจะหายไป",
-			id: "Jika Pokémon ini mengenakan Energi {Listrik}, Pokémon ini menjadi tidak membutuhkan Energi untuk Mundur."
-		}
-	}],
-
-	attacks: [{
-		cost: ["Lightning", "Lightning", "Lightning"],
-
-		name: {
-			ja: "いなずまれんだん",
-			'zh-tw': "閃電連彈",
-			th: "ฟ้าแลบต่อเนื่อง",
-			id: "Kilat Bertubi-tubi"
+	attacks: [
+		{
+			name: {
+				ja: "いなずまれんだん",
+				'zh-tw': "閃電連彈",
+				th: "ฟ้าแลบต่อเนื่อง",
+				id: "Kilat Bertubi-tubi",
+			},
+			damage: 120,
+			cost: ["Lightning", "Lightning", "Lightning"],
+			effect: {
+				ja: "ダメカンがのっている相手のベンチポケモン1匹にも、90ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+				'zh-tw': "對手的身上放置有傷害指示物的1隻備戰寶可夢也受到90點傷害。[在備戰區不計算弱點・抵抗力。]",
+				th: "โปเกมอนบนเบนช์ฝ่ายตรงข้าม 1 ตัวที่มีตัวนับแดเมจวางอยู่ ก็จะได้รับแดเมจ 90 ด้วย {โปเกมอนบนเบนช์จะไม่นำจุดอ่อนและความต้านทานมาคิด}",
+				id: "Serangan ini juga memberikan kerusakan sejumlah 90 kepada 1 Pokémon Cadangan lawan yang memiliki Token Kerusakan. [Kelemahan dan Resistansi Pokémon Cadangan tidak mempengaruhi jumlah kerusakan.]",
+			},
 		},
+	],
 
-		damage: 120,
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
 
-		effect: {
-			ja: "ダメカンがのっている相手のベンチポケモン1匹にも、90ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
-			'zh-tw': "對手的身上放置有傷害指示物的1隻備戰寶可夢也受到90點傷害。[在備戰區不計算弱點・抵抗力。]",
-			th: "โปเกมอนบนเบนช์ฝ่ายตรงข้าม 1 ตัวที่มีตัวนับแดเมจวางอยู่ ก็จะได้รับแดเมจ 90 ด้วย {โปเกมอนบนเบนช์จะไม่นำจุดอ่อนและความต้านทานมาคิด}",
-			id: "Serangan ini juga memberikan kerusakan sejumlah 90 kepada 1 Pokémon Cadangan lawan yang memiliki Token Kerusakan. [Kelemahan dan Resistansi Pokémon Cadangan tidak mempengaruhi jumlah kerusakan.]"
-		}
-	}],
-
-	weaknesses: [{
-		type: "Lightning",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Fighting",
-		value: "-30"
-	}],
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 719647,
+			},
+		},
+	],
 
 	retreat: 2,
 	regulationMark: "G",
+	rarity: "Ultra Rare",
+	dexId: [145],
 
-	thirdParty: {
-		cardmarket: 719598
-	}
-}
+	suffix: "EX",
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV2a/195.ts
+++ b/data-asia/SV/SV2a/195.ts
@@ -1,75 +1,76 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV2a"
+import { Card } from "../../../interfaces";
+import Set from "../SV2a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "ミュウex",
 		'zh-tw': "夢幻ex",
 		th: "มิวex",
-		id: "Mew ex"
+		id: "Mew ex",
 	},
 
 	illustrator: "aky CG Works",
 	category: "Pokemon",
 	hp: 180,
 	types: ["Psychic"],
+
 	stage: "Basic",
-	suffix: "EX",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			ja: "リスタート",
-			'zh-tw': "重啟",
-			th: "รีสตาร์ต",
-			id: "Restart"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "リスタート",
+				'zh-tw': "重啟",
+				th: "รีสตาร์ต",
+				id: "Restart",
+			},
+			effect: {
+				ja: "自分の番に1回使える。自分の手札が3枚になるように、山札を引く。",
+				'zh-tw': "在自己的回合時可使用1次。從牌庫抽卡直到自己的手牌滿3張為止。",
+				th: "ใช้ได้ 1 ครั้งในเทิร์นฝ่ายเรา จั่วการ์ดจากสำรับการ์ด จนได้การ์ดบนมือฝ่ายเราเป็น 3 ใบ",
+				id: "Dapat digunakan 1 kali pada giliran sendiri. Ambil kartu dari atas Deck hingga jumlah Kartu Pegangan sendiri menjadi 3 lembar.",
+			},
 		},
+	],
 
-		effect: {
-			ja: "自分の番に1回使える。自分の手札が3枚になるように、山札を引く。",
-			'zh-tw': "在自己的回合時可使用1次。從牌庫抽卡直到自己的手牌滿3張為止。",
-			th: "ใช้ได้ 1 ครั้งในเทิร์นฝ่ายเรา จั่วการ์ดจากสำรับการ์ด จนได้การ์ดบนมือฝ่ายเราเป็น 3 ใบ",
-			id: "Dapat digunakan 1 kali pada giliran sendiri. Ambil kartu dari atas Deck hingga jumlah Kartu Pegangan sendiri menjadi 3 lembar."
-		}
-	}],
-
-	attacks: [{
-		cost: ["Colorless", "Colorless", "Colorless"],
-
-		name: {
-			ja: "ゲノムハック",
-			'zh-tw': "基因駭入",
-			th: "จีโนมแฮก",
-			id: "Genome Hack"
+	attacks: [
+		{
+			name: {
+				ja: "ゲノムハック",
+				'zh-tw': "基因駭入",
+				th: "จีโนมแฮก",
+				id: "Genome Hack",
+			},
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンが持っているワザを1つ選び、このワザとして使う。",
+				'zh-tw': "選擇1個對手的戰鬥寶可夢持有的招式，作為這個招式使用。",
+				th: "เลือกท่าต่อสู้ที่โปเกมอนบนตำแหน่งต่อสู้ฝ่ายตรงข้ามมี 1 ท่า ใช้เป็นท่าต่อสู้นี้ได้",
+				id: "Pilih 1 serangan yang dimiliki Pokémon Bertarung lawan, lalu gunakan sebagai serangan ini.",
+			},
 		},
+	],
 
-		effect: {
-			ja: "相手のバトルポケモンが持っているワザを1つ選び、このワザとして使う。",
-			'zh-tw': "選擇1個對手的戰鬥寶可夢持有的招式，作為這個招式使用。",
-			th: "เลือกท่าต่อสู้ที่โปเกมอนบนตำแหน่งต่อสู้ฝ่ายตรงข้ามมี 1 ท่า ใช้เป็นท่าต่อสู้นี้ได้",
-			id: "Pilih 1 serangan yang dimiliki Pokémon Bertarung lawan, lalu gunakan sebagai serangan ini."
-		}
-	}],
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
 
-	weaknesses: [{
-		type: "Darkness",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Fighting",
-		value: "-30"
-	}],
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 719648,
+			},
+		},
+	],
 
 	retreat: 0,
 	regulationMark: "G",
+	rarity: "Ultra Rare",
+	dexId: [151],
 
-	thirdParty: {
-		cardmarket: 719604
-	}
-}
+	suffix: "EX",
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV2a/196.ts
+++ b/data-asia/SV/SV2a/196.ts
@@ -1,14 +1,13 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV2a"
+import { Card } from "../../../interfaces";
+import Set from "../SV2a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "エリカの招待",
 		'zh-tw': "莉佳的招待[支援者]",
 		th: "คำเชิญของเอริกะ[ซัพพอร์ต]",
-		id: "Undangan Erika[Supporter]"
+		id: "Undangan Erika[Supporter]",
 	},
 
 	illustrator: "saino misaki",
@@ -18,11 +17,21 @@ const card: Card = {
 		ja: "相手の手札を見て、その中からたねポケモンを1枚選び、相手のベンチに出す。その後、そのポケモンをバトルポケモンと入れ替える。",
 		'zh-tw': "查看對手的手牌，從其中選擇1張【基礎】寶可夢卡，放置於對手的備戰區。然後，將那隻寶可夢與戰鬥寶可夢互換。",
 		th: "ดูการ์ดบนมือฝ่ายตรงข้าม เลือกการ์ดโปเกมอน[พื้นฐาน] 1 ใบจากในนั้น วางบนเบนช์ฝ่ายตรงข้าม หลังจากนั้น สลับโปเกมอนนั้นกับโปเกมอนบนตำแหน่งต่อสู้",
-		id: "Lihat Kartu Pegangan lawan, pilih 1 lembar Pokémon Basic di antaranya, lalu masukkan ke Cadangan lawan. Setelah itu, tukar Pokémon tersebut dengan Pokémon Bertarung."
+		id: "Lihat Kartu Pegangan lawan, pilih 1 lembar Pokémon Basic di antaranya, lalu masukkan ke Cadangan lawan. Setelah itu, tukar Pokémon tersebut dengan Pokémon Bertarung.",
 	},
 
-	trainerType: "Supporter",
-	regulationMark: "G"
-}
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 719649,
+			},
+		},
+	],
 
-export default card
+	trainerType: "Supporter",
+	regulationMark: "G",
+	rarity: "Ultra Rare",
+};
+
+export default card;

--- a/data-asia/SV/SV2a/197.ts
+++ b/data-asia/SV/SV2a/197.ts
@@ -1,14 +1,13 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV2a"
+import { Card } from "../../../interfaces";
+import Set from "../SV2a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "サカキのカリスマ",
 		'zh-tw': "坂木的領導力[支援者]",
 		th: "เสน่ห์ของซากากิ[ซัพพอร์ต]",
-		id: "Karisma Giovanni[Supporter]"
+		id: "Karisma Giovanni[Supporter]",
 	},
 
 	illustrator: "hncl",
@@ -18,11 +17,21 @@ const card: Card = {
 		ja: "相手のバトルポケモンについているエネルギーを1個選び、相手の手札にもどす。その後、自分の手札からエネルギーを1枚選び、バトルポケモンにつける。",
 		'zh-tw': "選擇1個對手的戰鬥寶可夢身上附加的能量，放回對手的手牌。然後，從自己的手牌選擇1張能量卡，附於戰鬥寶可夢身上。",
 		th: "เลือกพลังงานที่ติดอยู่กับโปเกมอนบนตำแหน่งต่อสู้ฝ่ายตรงข้าม 1 ลูก นำกลับขึ้นมือฝ่ายตรงข้าม หลังจากนั้น เลือกการ์ดพลังงาน 1 ใบจากบนมือฝ่ายเรา ติดที่โปเกมอนบนตำแหน่งต่อสู้",
-		id: "Pilih 1 Energi yang dikenakan pada Pokémon Bertarung lawan, lalu kembalikan ke Kartu Pegangan lawan. Setelah itu, pilih 1 lembar Energi dari Kartu Pegangan sendiri, lalu kenakan pada Pokémon Bertarung."
+		id: "Pilih 1 Energi yang dikenakan pada Pokémon Bertarung lawan, lalu kembalikan ke Kartu Pegangan lawan. Setelah itu, pilih 1 lembar Energi dari Kartu Pegangan sendiri, lalu kenakan pada Pokémon Bertarung.",
 	},
 
-	trainerType: "Supporter",
-	regulationMark: "G"
-}
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 719650,
+			},
+		},
+	],
 
-export default card
+	trainerType: "Supporter",
+	regulationMark: "G",
+	rarity: "Ultra Rare",
+};
+
+export default card;

--- a/data-asia/SV/SV2a/198.ts
+++ b/data-asia/SV/SV2a/198.ts
@@ -1,14 +1,13 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV2a"
+import { Card } from "../../../interfaces";
+import Set from "../SV2a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "ナナミの手助け",
 		'zh-tw': "奈奈美的幫助[支援者]",
 		th: "การช่วยเหลือของนานามิ[ซัพพอร์ต]",
-		id: "Bantuan Daisy[Supporter]"
+		id: "Bantuan Daisy[Supporter]",
 	},
 
 	illustrator: "Fumie Kittaka",
@@ -18,11 +17,21 @@ const card: Card = {
 		ja: "自分の山札を2枚引く。ウラになっている自分のサイドのオモテをすべて見てから、もとにもどす。",
 		'zh-tw': "從自己的牌庫抽出2張卡。在看過所有反面朝上的自己的獎賞卡的正面後，回復原樣。",
 		th: "จั่วการ์ด 2 ใบจากสำรับการ์ดฝ่ายเรา ดูหน้าการ์ดรางวัลที่คว่ำอยู่ทั้งหมดของฝ่ายเรา แล้วคืนที่เดิม",
-		id: "Ambil 2 kartu dari atas Deck sendiri. Lihat sisi depan semua Kartu Point sendiri yang sisi depannya menghadap ke bawah, lalu kembalikan ke posisi semula."
+		id: "Ambil 2 kartu dari atas Deck sendiri. Lihat sisi depan semua Kartu Point sendiri yang sisi depannya menghadap ke bawah, lalu kembalikan ke posisi semula.",
 	},
 
-	trainerType: "Supporter",
-	regulationMark: "G"
-}
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 719651,
+			},
+		},
+	],
 
-export default card
+	trainerType: "Supporter",
+	regulationMark: "G",
+	rarity: "Ultra Rare",
+};
+
+export default card;

--- a/data-asia/SV/SV2a/199.ts
+++ b/data-asia/SV/SV2a/199.ts
@@ -1,14 +1,13 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV2a"
+import { Card } from "../../../interfaces";
+import Set from "../SV2a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "マサキの転送",
 		'zh-tw': "正輝的輸送[支援者]",
 		th: "การส่งต่อของมาซากิ[ซัพพอร์ต]",
-		id: "Transfer Bill[Supporter]"
+		id: "Transfer Bill[Supporter]",
 	},
 
 	illustrator: "GIDORA",
@@ -18,11 +17,21 @@ const card: Card = {
 		ja: "自分の山札を上から8枚見て、その中からポケモンを好きなだけ選び、相手に見せて、手札に加える。残りのカードは山札にもどして切る。",
 		'zh-tw': "查看自己的牌庫上方8張卡，從其中選擇任意數量的寶可夢卡，在給對手看過後加入手牌。將剩餘卡放回牌庫並重洗。",
 		th: "ดูการ์ด 8 ใบจากด้านบนของสำรับการ์ดฝ่ายเรา เลือกการ์ดโปเกมอนจากในนั้นตามจำนวนที่ชอบ ให้ฝ่ายตรงข้ามดู นำขึ้นมือ การ์ดที่เหลือใส่กลับไปในสำรับการ์ดแล้วสับ",
-		id: "Lihat 8 kartu dari atas Deck sendiri, pilih sesukanya Pokémon di antaranya, perlihatkan ke lawan, lalu tambahkan ke Kartu Pegangan. Kocok kembali sisa kartu ke Deck."
+		id: "Lihat 8 kartu dari atas Deck sendiri, pilih sesukanya Pokémon di antaranya, perlihatkan ke lawan, lalu tambahkan ke Kartu Pegangan. Kocok kembali sisa kartu ke Deck.",
 	},
 
-	trainerType: "Supporter",
-	regulationMark: "G"
-}
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 719652,
+			},
+		},
+	],
 
-export default card
+	trainerType: "Supporter",
+	regulationMark: "G",
+	rarity: "Ultra Rare",
+};
+
+export default card;

--- a/data-asia/SV/SV2a/200.ts
+++ b/data-asia/SV/SV2a/200.ts
@@ -1,72 +1,81 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV2a"
+import { Card } from "../../../interfaces";
+import Set from "../SV2a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "フシギバナex",
 		'zh-tw': "妙蛙花ex",
 		th: "ฟุชิกิบานะex",
-		id: "Venusaur ex"
+		id: "Venusaur ex",
 	},
 
 	illustrator: "Yoriyuki Ikegami",
 	category: "Pokemon",
 	hp: 340,
 	types: ["Grass"],
+
 	stage: "Stage2",
-	suffix: "EX",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			ja: "やすらぎのはな",
-			'zh-tw': "平和之花",
-			th: "ดอกไม้สงบใจ",
-			id: "Bunga Ketenangan"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "やすらぎのはな",
+				'zh-tw': "平和之花",
+				th: "ดอกไม้สงบใจ",
+				id: "Bunga Ketenangan",
+			},
+			effect: {
+				ja: "このポケモンがバトル場にいるなら、自分の番に1回使える。自分のポケモン1匹のHPを「60」回復する。",
+				'zh-tw': "若這隻寶可夢在戰鬥場上，則在自己的回合時可使用1次。將自己的1隻寶可夢恢復「60」HP。",
+				th: "ถ้าโปเกมอนนี้อยู่บนตำแหน่งต่อสู้ ใช้ได้ 1 ครั้งในเทิร์นฝ่ายเรา ฟื้นฟู HP ของโปเกมอนฝ่ายเรา 1 ตัว [60]",
+				id: "Dapat digunakan 1 kali pada giliran sendiri jika Pokémon ini ada di Arena Bertarung. Pulihkan HP 1 Pokémon sendiri sejumlah 60.",
+			},
 		},
+	],
 
-		effect: {
-			ja: "このポケモンがバトル場にいるなら、自分の番に1回使える。自分のポケモン1匹のHPを「60」回復する。",
-			'zh-tw': "若這隻寶可夢在戰鬥場上，則在自己的回合時可使用1次。將自己的1隻寶可夢恢復「60」HP。",
-			th: "ถ้าโปเกมอนนี้อยู่บนตำแหน่งต่อสู้ ใช้ได้ 1 ครั้งในเทิร์นฝ่ายเรา ฟื้นฟู HP ของโปเกมอนฝ่ายเรา 1 ตัว [60]",
-			id: "Dapat digunakan 1 kali pada giliran sendiri jika Pokémon ini ada di Arena Bertarung. Pulihkan HP 1 Pokémon sendiri sejumlah 60."
-		}
-	}],
-
-	attacks: [{
-		cost: ["Grass", "Grass", "Colorless"],
-
-		name: {
-			ja: "もうどくウィップ",
-			'zh-tw': "劇毒鞭打",
-			th: "แส้พิษร้ายแรง",
-			id: "Cambuk Racun Ekstrem"
+	attacks: [
+		{
+			name: {
+				ja: "もうどくウィップ",
+				'zh-tw': "劇毒鞭打",
+				th: "แส้พิษร้ายแรง",
+				id: "Cambuk Racun Ekstrem",
+			},
+			damage: 150,
+			cost: ["Grass", "Grass", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをどくとこんらんにする。",
+				'zh-tw': "將對手的戰鬥寶可夢【中毒】與【混亂】。",
+				th: "ทำให้โปเกมอนบนตำแหน่งต่อสู้ฝ่ายตรงข้ามเป็นสภาวะ[พิษ]และ[สับสน]",
+				id: "Ubah kondisi Pokémon Bertarung lawan menjadi Racun dan Pusing.",
+			},
 		},
+	],
 
-		damage: 150,
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
 
-		effect: {
-			ja: "相手のバトルポケモンをどくとこんらんにする。",
-			'zh-tw': "將對手的戰鬥寶可夢【中毒】與【混亂】。",
-			th: "ทำให้โปเกมอนบนตำแหน่งต่อสู้ฝ่ายตรงข้ามเป็นสภาวะ[พิษ]และ[สับสน]",
-			id: "Ubah kondisi Pokémon Bertarung lawan menjadi Racun dan Pusing."
-		}
-	}],
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 719653,
+			},
+		},
+	],
 
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "フシギソウ",
+	},
 
 	retreat: 4,
 	regulationMark: "G",
+	rarity: "Special illustration rare",
+	dexId: [3],
 
-	thirdParty: {
-		cardmarket: 719445
-	}
-}
+	suffix: "EX",
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV2a/201.ts
+++ b/data-asia/SV/SV2a/201.ts
@@ -1,72 +1,79 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV2a"
+import { Card } from "../../../interfaces";
+import Set from "../SV2a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "リザードンex",
 		'zh-tw': "噴火龍ex",
 		th: "ลิซาร์ดอนex",
-		id: "Charizard ex"
+		id: "Charizard ex",
 	},
 
 	illustrator: "miki kudo",
 	category: "Pokemon",
 	hp: 330,
 	types: ["Fire"],
+
 	stage: "Stage2",
-	suffix: "EX",
 
-	attacks: [{
-		cost: ["Fire"],
-
-		name: {
-			ja: "ブレイブウイング",
-			'zh-tw': "無畏之翼",
-			th: "เบรฟวิง",
-			id: "Brave Wing"
+	attacks: [
+		{
+			name: {
+				ja: "ブレイブウイング",
+				'zh-tw': "無畏之翼",
+				th: "เบรฟวิง",
+				id: "Brave Wing",
+			},
+			damage: "60+",
+			cost: ["Fire"],
+			effect: {
+				ja: "このポケモンにダメカンがのっているなら、100ダメージ追加。",
+				'zh-tw': "若這隻寶可夢身上放置有傷害指示物，則增加100點傷害。",
+				th: "ถ้าโปเกมอนนี้มีตัวนับแดเมจวางอยู่ การโจมตีนี้จะเพิ่มแดเมจอีก 100",
+				id: "Jika Pokémon ini memiliki Token Kerusakan, kerusakan yang diberikan bertambah sejumlah 100.",
+			},
 		},
-
-		damage: "60+",
-
-		effect: {
-			ja: "このポケモンにダメカンがのっているなら、100ダメージ追加。",
-			'zh-tw': "若這隻寶可夢身上放置有傷害指示物，則增加100點傷害。",
-			th: "ถ้าโปเกมอนนี้มีตัวนับแดเมจวางอยู่ การโจมตีนี้จะเพิ่มแดเมจอีก 100",
-			id: "Jika Pokémon ini memiliki Token Kerusakan, kerusakan yang diberikan bertambah sejumlah 100."
-		}
-	}, {
-		cost: ["Fire", "Fire", "Fire", "Fire"],
-
-		name: {
-			ja: "ばくえんのうず",
-			'zh-tw': "爆焰旋渦",
-			th: "วงล้อระเบิดไฟ",
-			id: "Pusaran Ledakan Api"
+		{
+			name: {
+				ja: "ばくえんのうず",
+				'zh-tw': "爆焰旋渦",
+				th: "วงล้อระเบิดไฟ",
+				id: "Pusaran Ledakan Api",
+			},
+			damage: 330,
+			cost: ["Fire", "Fire", "Fire", "Fire"],
+			effect: {
+				ja: "このポケモンについているエネルギーを3個選び、トラッシュする。",
+				'zh-tw': "選擇3個這隻寶可夢身上附加的能量，將其丟棄。",
+				th: "เลือกพลังงานที่ติดอยู่กับโปเกมอนนี้ 3 ลูก ทิ้งที่ตำแหน่งทิ้งการ์ด",
+				id: "Pilih 3 Energi yang dikenakan pada Pokémon ini, lalu buang ke Trash.",
+			},
 		},
+	],
 
-		damage: 330,
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
 
-		effect: {
-			ja: "このポケモンについているエネルギーを3個選び、トラッシュする。",
-			'zh-tw': "選擇3個這隻寶可夢身上附加的能量，將其丟棄。",
-			th: "เลือกพลังงานที่ติดอยู่กับโปเกมอนนี้ 3 ลูก ทิ้งที่ตำแหน่งทิ้งการ์ด",
-			id: "Pilih 3 Energi yang dikenakan pada Pokémon ini, lalu buang ke Trash."
-		}
-	}],
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 719654,
+			},
+		},
+	],
 
-	weaknesses: [{
-		type: "Water",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "リザード",
+	},
 
 	retreat: 2,
 	regulationMark: "G",
+	rarity: "Special illustration rare",
+	dexId: [6],
 
-	thirdParty: {
-		cardmarket: 719448
-	}
-}
+	suffix: "EX",
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV2a/202.ts
+++ b/data-asia/SV/SV2a/202.ts
@@ -1,72 +1,81 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV2a"
+import { Card } from "../../../interfaces";
+import Set from "../SV2a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "カメックスex",
 		'zh-tw': "水箭龜ex",
 		th: "คาเม็กซ์ex",
-		id: "Blastoise ex"
+		id: "Blastoise ex",
 	},
 
 	illustrator: "Mitsuhiro Arita",
 	category: "Pokemon",
 	hp: 330,
 	types: ["Water"],
+
 	stage: "Stage2",
-	suffix: "EX",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			ja: "かたいこうら",
-			'zh-tw': "堅硬甲殼",
-			th: "กระดองสุดแข็ง",
-			id: "Tempurung Padat"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "かたいこうら",
+				'zh-tw': "堅硬甲殼",
+				th: "กระดองสุดแข็ง",
+				id: "Tempurung Padat",
+			},
+			effect: {
+				ja: "このポケモンが受けるワザのダメージは「-30」される。",
+				'zh-tw': "這隻寶可夢受到招式的傷害「-30」點。",
+				th: "แดเมจของท่าต่อสู้ที่โปเกมอนนี้จะได้รับจะถูก [-30]",
+				id: "Kerusakan akibat serangan yang diterima Pokémon ini berkurang sejumlah 30.",
+			},
 		},
+	],
 
-		effect: {
-			ja: "このポケモンが受けるワザのダメージは「-30」される。",
-			'zh-tw': "這隻寶可夢受到招式的傷害「-30」點。",
-			th: "แดเมจของท่าต่อสู้ที่โปเกมอนนี้จะได้รับจะถูก [-30]",
-			id: "Kerusakan akibat serangan yang diterima Pokémon ini berkurang sejumlah 30."
-		}
-	}],
-
-	attacks: [{
-		cost: ["Water", "Water"],
-
-		name: {
-			ja: "ツインカノン",
-			'zh-tw': "雙加農炮",
-			th: "ทวินแคนนอน",
-			id: "Twin Cannon"
+	attacks: [
+		{
+			name: {
+				ja: "ツインカノン",
+				'zh-tw': "雙加農炮",
+				th: "ทวินแคนนอน",
+				id: "Twin Cannon",
+			},
+			damage: "140×",
+			cost: ["Water", "Water"],
+			effect: {
+				ja: "自分の手札から「基本[W]エネルギー」を2枚までトラッシュし、その枚数×140ダメージ。",
+				'zh-tw': "從自己的手牌將最多2張「基本【水】能量」卡丟棄，造成其張數×140點傷害。",
+				th: "ทิ้งการ์ด [พลังงานพื้นฐาน[น้ำ]] ได้สูงสุด 2 ใบจากบนมือฝ่ายเราที่ตำแหน่งทิ้งการ์ด แดเมจจะเท่ากับจำนวนการ์ดนั้น x140",
+				id: "Buang paling banyak 2 lembar Energi Dasar {Air} dari Kartu Pegangan sendiri ke Trash, serangan ini memberikan kerusakan sejumlah 140 untuk tiap lembarnya.",
+			},
 		},
+	],
 
-		damage: "140×",
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
 
-		effect: {
-			ja: "自分の手札から「基本エネルギー」を2枚までトラッシュし、その枚数×140ダメージ。",
-			'zh-tw': "從自己的手牌將最多2張「基本【水】能量」卡丟棄，造成其張數×140點傷害。",
-			th: "ทิ้งการ์ด [พลังงานพื้นฐาน[น้ำ]] ได้สูงสุด 2 ใบจากบนมือฝ่ายเราที่ตำแหน่งทิ้งการ์ด แดเมจจะเท่ากับจำนวนการ์ดนั้น x140",
-			id: "Buang paling banyak 2 lembar Energi Dasar {Air} dari Kartu Pegangan sendiri ke Trash, serangan ini memberikan kerusakan sejumlah 140 untuk tiap lembarnya."
-		}
-	}],
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 719655,
+			},
+		},
+	],
 
-	weaknesses: [{
-		type: "Lightning",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "カメール",
+	},
 
 	retreat: 3,
 	regulationMark: "G",
+	rarity: "Special illustration rare",
+	dexId: [9],
 
-	thirdParty: {
-		cardmarket: 719451
-	}
-}
+	suffix: "EX",
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV2a/203.ts
+++ b/data-asia/SV/SV2a/203.ts
@@ -1,77 +1,79 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV2a"
+import { Card } from "../../../interfaces";
+import Set from "../SV2a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "フーディンex",
 		'zh-tw': "胡地ex",
 		th: "ฟูดินex",
-		id: "Alakazam ex"
+		id: "Alakazam ex",
 	},
 
 	illustrator: "Shinya Komatsu",
 	category: "Pokemon",
 	hp: 310,
 	types: ["Psychic"],
+
 	stage: "Stage2",
-	suffix: "EX",
 
-	attacks: [{
-		cost: ["Colorless", "Colorless"],
-
-		name: {
-			ja: "マインドジャック",
-			'zh-tw': "意志劫持",
-			th: "มายด์แจ็ค",
-			id: "Mind Jack"
+	attacks: [
+		{
+			name: {
+				ja: "マインドジャック",
+				'zh-tw': "意志劫持",
+				th: "มายด์แจ็ค",
+				id: "Mind Jack",
+			},
+			damage: "90+",
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "相手のベンチポケモンの数×30ダメージ追加。",
+				'zh-tw': "增加對手的備戰寶可夢的數量×30點傷害。",
+				th: "แดเมจจะเพิ่มตามจำนวนโปเกมอนบนเบนช์ฝ่ายตรงข้าม x30",
+				id: "Kerusakan yang diberikan bertambah sejumlah 30 untuk tiap Pokémon Cadangan lawan.",
+			},
 		},
-
-		damage: "90+",
-
-		effect: {
-			ja: "相手のベンチポケモンの数×30ダメージ追加。",
-			'zh-tw': "增加對手的備戰寶可夢的數量×30點傷害。",
-			th: "แดเมจจะเพิ่มตามจำนวนโปเกมอนบนเบนช์ฝ่ายตรงข้าม x30",
-			id: "Kerusakan yang diberikan bertambah sejumlah 30 untuk tiap Pokémon Cadangan lawan."
-		}
-	}, {
-		cost: ["Psychic", "Psychic"],
-
-		name: {
-			ja: "ディメンションハンド",
-			'zh-tw': "維度之手",
-			th: "ไดเมนชันแฮนด์",
-			id: "Dimension Hand"
+		{
+			name: {
+				ja: "ディメンションハンド",
+				'zh-tw': "維度之手",
+				th: "ไดเมนชันแฮนด์",
+				id: "Dimension Hand",
+			},
+			damage: 120,
+			cost: ["Psychic", "Psychic"],
+			effect: {
+				ja: "このワザは、このポケモンがベンチにいても使える。",
+				'zh-tw': "就算這隻寶可夢在備戰區，這個招式也可使用。",
+				th: "ท่าต่อสู้นี้ แม้โปเกมอนนี้อยู่บนเบนช์ก็ใช้ได้",
+				id: "Serangan ini dapat digunakan meskipun Pokémon ini ada di Cadangan.",
+			},
 		},
+	],
 
-		damage: 120,
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
 
-		effect: {
-			ja: "このワザは、このポケモンがベンチにいても使える。",
-			'zh-tw': "就算這隻寶可夢在備戰區，這個招式也可使用。",
-			th: "ท่าต่อสู้นี้ แม้โปเกมอนนี้อยู่บนเบนช์ก็ใช้ได้",
-			id: "Serangan ini dapat digunakan meskipun Pokémon ini ada di Cadangan."
-		}
-	}],
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 719656,
+			},
+		},
+	],
 
-	weaknesses: [{
-		type: "Darkness",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Fighting",
-		value: "-30"
-	}],
+	evolveFrom: {
+		ja: "ユンゲラー",
+	},
 
 	retreat: 1,
 	regulationMark: "G",
+	rarity: "Special illustration rare",
+	dexId: [65],
 
-	thirdParty: {
-		cardmarket: 719507
-	}
-}
+	suffix: "EX",
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV2a/204.ts
+++ b/data-asia/SV/SV2a/204.ts
@@ -1,77 +1,77 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV2a"
+import { Card } from "../../../interfaces";
+import Set from "../SV2a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "サンダーex",
 		'zh-tw': "閃電鳥ex",
 		th: "ธันเดอร์ex",
-		id: "Zapdos ex"
+		id: "Zapdos ex",
 	},
 
 	illustrator: "Shiburingaru",
 	category: "Pokemon",
 	hp: 200,
 	types: ["Lightning"],
+
 	stage: "Basic",
-	suffix: "EX",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			ja: "ボルトフロート",
-			'zh-tw': "伏特浮游",
-			th: "โบลต์โฟลต",
-			id: "Bolt Float"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "ボルトフロート",
+				'zh-tw': "伏特浮游",
+				th: "โบลต์โฟลต",
+				id: "Bolt Float",
+			},
+			effect: {
+				ja: "このポケモンに[L]エネルギーがついているなら、このポケモンのにげるためのエネルギーは、すべてなくなる。",
+				'zh-tw': "若這隻寶可夢身上附有【雷】能量卡，則這隻寶可夢【撤退】所需的能量全部消除。",
+				th: "ถ้าโปเกมอนนี้มีพลังงาน[สายฟ้า]ติดอยู่ พลังงานสำหรับ[หนี]ของโปเกมอนนี้ ทั้งหมดจะหายไป",
+				id: "Jika Pokémon ini mengenakan Energi {Listrik}, Pokémon ini menjadi tidak membutuhkan Energi untuk Mundur.",
+			},
 		},
+	],
 
-		effect: {
-			ja: "このポケモンにエネルギーがついているなら、このポケモンのにげるためのエネルギーは、すべてなくなる。",
-			'zh-tw': "若這隻寶可夢身上附有【雷】能量卡，則這隻寶可夢【撤退】所需的能量全部消除。",
-			th: "ถ้าโปเกมอนนี้มีพลังงาน[สายฟ้า]ติดอยู่ พลังงานสำหรับ[หนี]ของโปเกมอนนี้ ทั้งหมดจะหายไป",
-			id: "Jika Pokémon ini mengenakan Energi {Listrik}, Pokémon ini menjadi tidak membutuhkan Energi untuk Mundur."
-		}
-	}],
-
-	attacks: [{
-		cost: ["Lightning", "Lightning", "Lightning"],
-
-		name: {
-			ja: "いなずまれんだん",
-			'zh-tw': "閃電連彈",
-			th: "ฟ้าแลบต่อเนื่อง",
-			id: "Kilat Bertubi-tubi"
+	attacks: [
+		{
+			name: {
+				ja: "いなずまれんだん",
+				'zh-tw': "閃電連彈",
+				th: "ฟ้าแลบต่อเนื่อง",
+				id: "Kilat Bertubi-tubi",
+			},
+			damage: 120,
+			cost: ["Lightning", "Lightning", "Lightning"],
+			effect: {
+				ja: "ダメカンがのっている相手のベンチポケモン1匹にも、90ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+				'zh-tw': "對手的身上放置有傷害指示物的1隻備戰寶可夢也受到90點傷害。[在備戰區不計算弱點・抵抗力。]",
+				th: "โปเกมอนบนเบนช์ฝ่ายตรงข้าม 1 ตัวที่มีตัวนับแดเมจวางอยู่ ก็จะได้รับแดเมจ 90 ด้วย {โปเกมอนบนเบนช์จะไม่นำจุดอ่อนและความต้านทานมาคิด}",
+				id: "Serangan ini juga memberikan kerusakan sejumlah 90 kepada 1 Pokémon Cadangan lawan yang memiliki Token Kerusakan. [Kelemahan dan Resistansi Pokémon Cadangan tidak mempengaruhi jumlah kerusakan.]",
+			},
 		},
+	],
 
-		damage: 120,
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
 
-		effect: {
-			ja: "ダメカンがのっている相手のベンチポケモン1匹にも、90ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
-			'zh-tw': "對手的身上放置有傷害指示物的1隻備戰寶可夢也受到90點傷害。[在備戰區不計算弱點・抵抗力。]",
-			th: "โปเกมอนบนเบนช์ฝ่ายตรงข้าม 1 ตัวที่มีตัวนับแดเมจวางอยู่ ก็จะได้รับแดเมจ 90 ด้วย {โปเกมอนบนเบนช์จะไม่นำจุดอ่อนและความต้านทานมาคิด}",
-			id: "Serangan ini juga memberikan kerusakan sejumlah 90 kepada 1 Pokémon Cadangan lawan yang memiliki Token Kerusakan. [Kelemahan dan Resistansi Pokémon Cadangan tidak mempengaruhi jumlah kerusakan.]"
-		}
-	}],
-
-	weaknesses: [{
-		type: "Lightning",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Fighting",
-		value: "-30"
-	}],
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 719657,
+			},
+		},
+	],
 
 	retreat: 2,
 	regulationMark: "G",
+	rarity: "Special illustration rare",
+	dexId: [145],
 
-	thirdParty: {
-		cardmarket: 719598
-	}
-}
+	suffix: "EX",
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV2a/205.ts
+++ b/data-asia/SV/SV2a/205.ts
@@ -1,75 +1,76 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV2a"
+import { Card } from "../../../interfaces";
+import Set from "../SV2a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "ミュウex",
 		'zh-tw': "夢幻ex",
 		th: "มิวex",
-		id: "Mew ex"
+		id: "Mew ex",
 	},
 
 	illustrator: "Natsumi Yoshida",
 	category: "Pokemon",
 	hp: 180,
 	types: ["Psychic"],
+
 	stage: "Basic",
-	suffix: "EX",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			ja: "リスタート",
-			'zh-tw': "重啟",
-			th: "รีสตาร์ต",
-			id: "Restart"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "リスタート",
+				'zh-tw': "重啟",
+				th: "รีสตาร์ต",
+				id: "Restart",
+			},
+			effect: {
+				ja: "自分の番に1回使える。自分の手札が3枚になるように、山札を引く。",
+				'zh-tw': "在自己的回合時可使用1次。從牌庫抽卡直到自己的手牌滿3張為止。",
+				th: "ใช้ได้ 1 ครั้งในเทิร์นฝ่ายเรา จั่วการ์ดจากสำรับการ์ด จนได้การ์ดบนมือฝ่ายเราเป็น 3 ใบ",
+				id: "Dapat digunakan 1 kali pada giliran sendiri. Ambil kartu dari atas Deck hingga jumlah Kartu Pegangan sendiri menjadi 3 lembar.",
+			},
 		},
+	],
 
-		effect: {
-			ja: "自分の番に1回使える。自分の手札が3枚になるように、山札を引く。",
-			'zh-tw': "在自己的回合時可使用1次。從牌庫抽卡直到自己的手牌滿3張為止。",
-			th: "ใช้ได้ 1 ครั้งในเทิร์นฝ่ายเรา จั่วการ์ดจากสำรับการ์ด จนได้การ์ดบนมือฝ่ายเราเป็น 3 ใบ",
-			id: "Dapat digunakan 1 kali pada giliran sendiri. Ambil kartu dari atas Deck hingga jumlah Kartu Pegangan sendiri menjadi 3 lembar."
-		}
-	}],
-
-	attacks: [{
-		cost: ["Colorless", "Colorless", "Colorless"],
-
-		name: {
-			ja: "ゲノムハック",
-			'zh-tw': "基因駭入",
-			th: "จีโนมแฮก",
-			id: "Genome Hack"
+	attacks: [
+		{
+			name: {
+				ja: "ゲノムハック",
+				'zh-tw': "基因駭入",
+				th: "จีโนมแฮก",
+				id: "Genome Hack",
+			},
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンが持っているワザを1つ選び、このワザとして使う。",
+				'zh-tw': "選擇1個對手的戰鬥寶可夢持有的招式，作為這個招式使用。",
+				th: "เลือกท่าต่อสู้ที่โปเกมอนบนตำแหน่งต่อสู้ฝ่ายตรงข้ามมี 1 ท่า ใช้เป็นท่าต่อสู้นี้ได้",
+				id: "Pilih 1 serangan yang dimiliki Pokémon Bertarung lawan, lalu gunakan sebagai serangan ini.",
+			},
 		},
+	],
 
-		effect: {
-			ja: "相手のバトルポケモンが持っているワザを1つ選び、このワザとして使う。",
-			'zh-tw': "選擇1個對手的戰鬥寶可夢持有的招式，作為這個招式使用。",
-			th: "เลือกท่าต่อสู้ที่โปเกมอนบนตำแหน่งต่อสู้ฝ่ายตรงข้ามมี 1 ท่า ใช้เป็นท่าต่อสู้นี้ได้",
-			id: "Pilih 1 serangan yang dimiliki Pokémon Bertarung lawan, lalu gunakan sebagai serangan ini."
-		}
-	}],
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
 
-	weaknesses: [{
-		type: "Darkness",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Fighting",
-		value: "-30"
-	}],
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 719658,
+			},
+		},
+	],
 
 	retreat: 0,
 	regulationMark: "G",
+	rarity: "Special illustration rare",
+	dexId: [151],
 
-	thirdParty: {
-		cardmarket: 719604
-	}
-}
+	suffix: "EX",
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV2a/206.ts
+++ b/data-asia/SV/SV2a/206.ts
@@ -1,14 +1,13 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV2a"
+import { Card } from "../../../interfaces";
+import Set from "../SV2a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "エリカの招待",
 		'zh-tw': "莉佳的招待[支援者]",
 		th: "คำเชิญของเอริกะ[ซัพพอร์ต]",
-		id: "Undangan Erika[Supporter]"
+		id: "Undangan Erika[Supporter]",
 	},
 
 	illustrator: "Cona Nitanda",
@@ -18,11 +17,21 @@ const card: Card = {
 		ja: "相手の手札を見て、その中からたねポケモンを1枚選び、相手のベンチに出す。その後、そのポケモンをバトルポケモンと入れ替える。",
 		'zh-tw': "查看對手的手牌，從其中選擇1張【基礎】寶可夢卡，放置於對手的備戰區。然後，將那隻寶可夢與戰鬥寶可夢互換。",
 		th: "ดูการ์ดบนมือฝ่ายตรงข้าม เลือกการ์ดโปเกมอน[พื้นฐาน] 1 ใบจากในนั้น วางบนเบนช์ฝ่ายตรงข้าม หลังจากนั้น สลับโปเกมอนนั้นกับโปเกมอนบนตำแหน่งต่อสู้",
-		id: "Lihat Kartu Pegangan lawan, pilih 1 lembar Pokémon Basic di antaranya, lalu masukkan ke Cadangan lawan. Setelah itu, tukar Pokémon tersebut dengan Pokémon Bertarung."
+		id: "Lihat Kartu Pegangan lawan, pilih 1 lembar Pokémon Basic di antaranya, lalu masukkan ke Cadangan lawan. Setelah itu, tukar Pokémon tersebut dengan Pokémon Bertarung.",
 	},
 
-	trainerType: "Supporter",
-	regulationMark: "G"
-}
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 719659,
+			},
+		},
+	],
 
-export default card
+	trainerType: "Supporter",
+	regulationMark: "G",
+	rarity: "Special illustration rare",
+};
+
+export default card;

--- a/data-asia/SV/SV2a/207.ts
+++ b/data-asia/SV/SV2a/207.ts
@@ -1,14 +1,13 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV2a"
+import { Card } from "../../../interfaces";
+import Set from "../SV2a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "サカキのカリスマ",
 		'zh-tw': "坂木的領導力[支援者]",
 		th: "เสน่ห์ของซากากิ[ซัพพอร์ต]",
-		id: "Karisma Giovanni[Supporter]"
+		id: "Karisma Giovanni[Supporter]",
 	},
 
 	illustrator: "Hideki Ishikawa",
@@ -18,11 +17,21 @@ const card: Card = {
 		ja: "相手のバトルポケモンについているエネルギーを1個選び、相手の手札にもどす。その後、自分の手札からエネルギーを1枚選び、バトルポケモンにつける。",
 		'zh-tw': "選擇1個對手的戰鬥寶可夢身上附加的能量，放回對手的手牌。然後，從自己的手牌選擇1張能量卡，附於戰鬥寶可夢身上。",
 		th: "เลือกพลังงานที่ติดอยู่กับโปเกมอนบนตำแหน่งต่อสู้ฝ่ายตรงข้าม 1 ลูก นำกลับขึ้นมือฝ่ายตรงข้าม หลังจากนั้น เลือกการ์ดพลังงาน 1 ใบจากบนมือฝ่ายเรา ติดที่โปเกมอนบนตำแหน่งต่อสู้",
-		id: "Pilih 1 Energi yang dikenakan pada Pokémon Bertarung lawan, lalu kembalikan ke Kartu Pegangan lawan. Setelah itu, pilih 1 lembar Energi dari Kartu Pegangan sendiri, lalu kenakan pada Pokémon Bertarung."
+		id: "Pilih 1 Energi yang dikenakan pada Pokémon Bertarung lawan, lalu kembalikan ke Kartu Pegangan lawan. Setelah itu, pilih 1 lembar Energi dari Kartu Pegangan sendiri, lalu kenakan pada Pokémon Bertarung.",
 	},
 
-	trainerType: "Supporter",
-	regulationMark: "G"
-}
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 719660,
+			},
+		},
+	],
 
-export default card
+	trainerType: "Supporter",
+	regulationMark: "G",
+	rarity: "Special illustration rare",
+};
+
+export default card;

--- a/data-asia/SV/SV2a/208.ts
+++ b/data-asia/SV/SV2a/208.ts
@@ -1,59 +1,57 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV2a"
+import { Card } from "../../../interfaces";
+import Set from "../SV2a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		ja: "ミュウex"
+		ja: "ミュウex",
 	},
 
 	illustrator: "aky CG Works",
 	category: "Pokemon",
 	hp: 180,
 	types: ["Psychic"],
+
 	stage: "Basic",
-	suffix: "EX",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			ja: "リスタート"
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "リスタート" },
+			effect: {
+				ja: "自分の番に1回使える。自分の手札が3枚になるように、山札を引く。",
+			},
 		},
+	],
 
-		effect: {
-			ja: "自分の番に1回使える。自分の手札が3枚になるように、山札を引く。"
-		}
-	}],
-
-	attacks: [{
-		cost: ["Colorless", "Colorless", "Colorless"],
-
-		name: {
-			ja: "ゲノムハック"
+	attacks: [
+		{
+			name: { ja: "ゲノムハック" },
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンが持っているワザを1つ選び、このワザとして使う。",
+			},
 		},
+	],
 
-		effect: {
-			ja: "相手のバトルポケモンが持っているワザを1つ選び、このワザとして使う。"
-		}
-	}],
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
 
-	weaknesses: [{
-		type: "Darkness",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Fighting",
-		value: "－30"
-	}],
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 719661,
+			},
+		},
+	],
 
 	retreat: 0,
+	regulationMark: "G",
+	rarity: "Mega Hyper Rare",
+	dexId: [151],
 
-	thirdParty: {
-		cardmarket: 719604
-	}
-}
+	suffix: "EX",
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV2a/209.ts
+++ b/data-asia/SV/SV2a/209.ts
@@ -1,21 +1,31 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV2a"
+import { Card } from "../../../interfaces";
+import Set from "../SV2a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		ja: "ポケモンいれかえ"
+		ja: "ポケモンいれかえ",
 	},
 
 	illustrator: "Studio Bora Inc.",
 	category: "Trainer",
 
 	effect: {
-		ja: "自分のバトルポケモンをベンチポケモンと入れ替える。"
+		ja: "自分のバトルポケモンをベンチポケモンと入れ替える。",
 	},
 
-	trainerType: "Item"
-}
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 719662,
+			},
+		},
+	],
 
-export default card
+	trainerType: "Item",
+	regulationMark: "G",
+	rarity: "Mega Hyper Rare",
+};
+
+export default card;

--- a/data-asia/SV/SV2a/210.ts
+++ b/data-asia/SV/SV2a/210.ts
@@ -1,15 +1,31 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV2a"
+import { Card } from "../../../interfaces";
+import Set from "../SV2a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		ja: "基本超エネルギー"
+		ja: "基本超エネルギー",
 	},
 
+	illustrator: "",
 	category: "Energy",
-	energyType: "Normal"
-}
+	energyType: "Normal",
 
-export default card
+	effect: {
+		ja: "&copy;Pokémon/Nintendo/Creatures/GAME FREAK ポケットモンスター・ポケモン・Pokémonは任天堂・クリーチャーズ・ゲームフリークの商標です。 このホームページに掲載された画像その他の内容の無断転載はお断りします。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 719663,
+			},
+		},
+	],
+
+	regulationMark: "G",
+	rarity: "Mega Hyper Rare",
+};
+
+export default card;


### PR DESCRIPTION
## What

Refreshes the existing Japanese set **SV2a ポケモンカード151 (Pokémon Card 151)** from its primary sources. The curated content stays: every card keeps its `zh-tw`/`th`/`id` texts verbatim.

What changes across the 210 card files:

- `thirdParty.cardmarket` moves onto `variants` objects
- per card where missing: `dexId`, `evolveFrom`, `resistances`, the Japanese flavor text and the Japanese effect/attack texts straight from the official database and limitless
- 153 regular cards gain their two mirror prints as `reverse` variants (`foil: "pokeball"` + `foil: "masterball"`) with their own cardmarket ids

## Data sources

- **pokemon-card.com** (official database): Japanese names, flavor texts, National Dex numbers, official card count
- **limitlesstcg.com**: full Japanese card text, stages, weaknesses/resistances/retreat, rarities, illustrators, attack costs
- **Cardmarket**: product IDs as `thirdParty.cardmarket` on the variant objects (719442–719663; tcgplayer IDs not available to me)

## Notes

- Follows the file format and conventions of the M-era sets (#1728)
- 153 regular cards additionally exist as two mirror prints, modeled as `reverse` variants with their own cardmarket ids — `foil: "pokeball"` + `foil: "masterball"`
- All 210 files type-check against `interfaces.d.ts` (`tsc --noEmit`)
