### PR TITLE
fix: Correct Italian name of Phantasmal Flames set

### DIFF
--- a/data/Mega Evolution/Phantasmal Flames.ts
+++ b/data/Mega Evolution/Phantasmal Flames.ts
@@ -10,7 +10,7 @@ const set: Set = {
 		es: "Fuegos Fantasmales",
 		'es-mx': "Llamaradas Fantasmales",
 		fr: "Flammes Fantasmagoriques",
-		it: "Flamme Spettrali",
+		it: "Fiamme Spettrali",
 		pt: "Fogo Fantasmagórico"
 	},
 


### PR DESCRIPTION
The Italian name of the Phantasmal Flames set (`me02`) is misspelled as "Flamme Spettrali". The correct name is **"Fiamme Spettrali"**: "flamme" is not an Italian word, the plural of "fiamma" is "fiamme".

Official source: the Italian Pokémon TCG site titles the expansion "Megaevoluzione - Fiamme Spettrali": https://tcg.pokemon.com/it-it/expansions/phantasmal-flames/