### PR TITLE
(data) Add Mega Evolution set me05 Pitch Black

### DIFF
--- a/data/Mega Evolution/Pitch Black.ts
+++ b/data/Mega Evolution/Pitch Black.ts
@@ -1,0 +1,35 @@
+import { Set } from '../../interfaces'
+import serie from '../Mega Evolution'
+
+const set: Set = {
+	id: "me05",
+
+	name: {
+		de: "Dunkelnacht",
+		en: "Pitch Black",
+		es: "Oscuridad Absoluta",
+		'es-mx': "Tinieblas Umbrías",
+		fr: "Nuit Noire",
+		it: "Buio Pesto",
+		pt: "Escuridão Absoluta"
+	},
+
+	serie: serie,
+
+	cardCount: {
+		official: 84
+	},
+
+	releaseDate: "2026-07-17",
+
+	abbreviations: {
+		official: "PBL"
+	},
+
+	thirdParty: {
+		tcgplayer: 24688,
+		cardmarket: 6569
+	}
+}
+
+export default set

--- a/data/Mega Evolution/Pitch Black/001.ts
+++ b/data/Mega Evolution/Pitch Black/001.ts
@@ -1,0 +1,69 @@
+import { Card } from "../../../interfaces"
+import Set from "../Pitch Black"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Tropius",
+		fr: "Tropius",
+		es: "Tropius",
+		'es-mx': "Tropius",
+		de: "Tropius"
+	},
+
+	illustrator: "Akino Fukuji",
+	rarity: "Common",
+	category: "Pokemon",
+	dexId: [357],
+	hp: 110,
+	types: ["Grass"],
+	stage: "Basic",
+
+	attacks: [{
+		name: {
+			en: "Fruity Aroma"
+		},
+
+		cost: ["Colorless"],
+
+		effect: {
+			en: "Look at the top 6 cards of your deck. Reveal as many Pokémon as you like from there and put them in your hand. Then, shuffle the rest of the cards back into the deck"
+		}
+	}, {
+		name: {
+			en: "Solar Beam"
+		},
+
+		cost: ["Grass", "Colorless"],
+
+		damage: 60
+	}],
+
+	weaknesses: [{
+		type: "Fire",
+		value: "×2"
+	}],
+
+	retreat: 1,
+	regulationMark: "J",
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 895789,
+				tcgplayer: 704758
+			}
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 895789,
+				tcgplayer: 704758
+			}
+		},
+	],
+}
+
+export default card

--- a/data/Mega Evolution/Pitch Black/002.ts
+++ b/data/Mega Evolution/Pitch Black/002.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces"
+import Set from "../Pitch Black"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Grubbin",
+		fr: "Larvibule",
+		es: "Grubbin",
+		'es-mx': "Grubbin",
+		de: "Mabula"
+	},
+
+	illustrator: "Mina Nakai",
+	rarity: "Common",
+	category: "Pokemon",
+	dexId: [736],
+	hp: 70,
+	types: ["Grass"],
+	stage: "Basic",
+
+	attacks: [{
+		name: {
+			en: "String Shot"
+		},
+
+		cost: ["Colorless"],
+
+		effect: {
+			en: "Flip a coin. If heads, your opponent's Active Pokémon is now Paralyzed"
+		}
+	}],
+
+	weaknesses: [{
+		type: "Fire",
+		value: "×2"
+	}],
+
+	retreat: 2,
+	regulationMark: "J",
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 895790,
+				tcgplayer: 704759
+			}
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 895790,
+				tcgplayer: 704759
+			}
+		},
+	],
+}
+
+export default card

--- a/data/Mega Evolution/Pitch Black/003.ts
+++ b/data/Mega Evolution/Pitch Black/003.ts
@@ -1,0 +1,63 @@
+import { Card } from "../../../interfaces"
+import Set from "../Pitch Black"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Fomantis",
+		fr: "Mimantis",
+		es: "Fomantis",
+		'es-mx': "Fomantis",
+		de: "Imantis"
+	},
+
+	illustrator: "nisimono",
+	rarity: "Common",
+	category: "Pokemon",
+	dexId: [753],
+	hp: 70,
+	types: ["Grass"],
+	stage: "Basic",
+
+	attacks: [{
+		name: {
+			en: "Reckless Charge"
+		},
+
+		cost: ["Grass"],
+
+		damage: 30,
+
+		effect: {
+			en: "This Pokémon also does 10 damage to itself"
+		}
+	}],
+
+	weaknesses: [{
+		type: "Fire",
+		value: "×2"
+	}],
+
+	retreat: 1,
+	regulationMark: "J",
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 895791,
+				tcgplayer: 704760
+			}
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 895791,
+				tcgplayer: 704760
+			}
+		},
+	],
+}
+
+export default card

--- a/data/Mega Evolution/Pitch Black/004.ts
+++ b/data/Mega Evolution/Pitch Black/004.ts
@@ -1,0 +1,74 @@
+import { Card } from "../../../interfaces"
+import Set from "../Pitch Black"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Lurantis ex",
+		fr: "Floramantis-ex",
+		es: "Lurantis ex",
+		'es-mx': "Lurantis ex",
+		de: "Mantidea-ex"
+	},
+
+	illustrator: "5ban Graphics",
+	rarity: "Double rare",
+	category: "Pokemon",
+	dexId: [754],
+	hp: 260,
+	types: ["Grass"],
+
+	evolveFrom: {
+		en: "Fomantis"
+	},
+
+	stage: "Stage1",
+	suffix: "EX",
+
+	attacks: [{
+		name: {
+			en: "Lively Cutter"
+		},
+
+		cost: ["Grass"],
+
+		damage: "60+",
+
+		effect: {
+			en: "If this Pokémon recovered any HP this turn, this attack does 200 more damage."
+		}
+	}, {
+		name: {
+			en: "Leaf Guard"
+		},
+
+		cost: ["Grass", "Colorless"],
+
+		damage: 140,
+
+		effect: {
+			en: "During your opponent's next turn, this Pokémon takes 50 less damage from attacks."
+		}
+	}],
+
+	weaknesses: [{
+		type: "Fire",
+		value: "×2"
+	}],
+
+	retreat: 1,
+	regulationMark: "J",
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 895792,
+				tcgplayer: 704761
+			}
+		},
+	],
+}
+
+export default card

--- a/data/Mega Evolution/Pitch Black/005.ts
+++ b/data/Mega Evolution/Pitch Black/005.ts
@@ -1,0 +1,73 @@
+import { Card } from "../../../interfaces"
+import Set from "../Pitch Black"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Poltchageist",
+		fr: "Poltchageist",
+		es: "Poltchageist",
+		'es-mx': "Poltchageist",
+		de: "Mortcha"
+	},
+
+	illustrator: "Mousho",
+	rarity: "Common",
+	category: "Pokemon",
+	dexId: [1012],
+	hp: 30,
+	types: ["Grass"],
+	stage: "Basic",
+
+	abilities: [{
+		type: "Ability",
+
+		name: {
+			en: "Hide 'n' Sneak"
+		},
+
+		effect: {
+			en: "Prevent all effects of opponent's Attacks and Abilities done to this Pokémon."
+		}
+	}],
+
+	attacks: [{
+		name: {
+			en: "Furitive Drop"
+		},
+
+		cost: ["Colorless"],
+
+		effect: {
+			en: "Put 1 damage counter on your opponent's Active Pokémon"
+		}
+	}],
+
+	weaknesses: [{
+		type: "Fire",
+		value: "×2"
+	}],
+
+	retreat: 0,
+	regulationMark: "J",
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 895793,
+				tcgplayer: 704762
+			}
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 895793,
+				tcgplayer: 704762
+			}
+		},
+	],
+}
+
+export default card

--- a/data/Mega Evolution/Pitch Black/006.ts
+++ b/data/Mega Evolution/Pitch Black/006.ts
@@ -1,0 +1,78 @@
+import { Card } from "../../../interfaces"
+import Set from "../Pitch Black"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Sinistcha",
+		fr: "Théffroyable",
+		es: "Sinistcha",
+		'es-mx': "Sinistcha",
+		de: "Fatalitcha"
+	},
+
+	illustrator: "mingo",
+	rarity: "Uncommon",
+	category: "Pokemon",
+	dexId: [1013],
+	hp: 60,
+	types: ["Grass"],
+
+	evolveFrom: {
+		en: "Poltchageist"
+	},
+
+	stage: "Stage1",
+
+	abilities: [{
+		type: "Ability",
+
+		name: {
+			en: "Hide 'n' Sneak"
+		},
+
+		effect: {
+			en: "Prevent all effects of opponent's Attacks and Abilities done to this Pokémon."
+		}
+	}],
+
+	attacks: [{
+		name: {
+			en: "Matcha Spin"
+		},
+
+		cost: ["Colorless"],
+
+		effect: {
+			en: "If you have 6 or more Pokémon with the Hide 'n' Sneak Ability in your discard pile, put 4 damage counters on each of your opponent's Pokémon."
+		}
+	}],
+
+	weaknesses: [{
+		type: "Fire",
+		value: "×2"
+	}],
+
+	retreat: 1,
+	regulationMark: "J",
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 895794,
+				tcgplayer: 704763
+			}
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 895794,
+				tcgplayer: 704763
+			}
+		},
+	],
+}
+
+export default card

--- a/data/Mega Evolution/Pitch Black/007.ts
+++ b/data/Mega Evolution/Pitch Black/007.ts
@@ -1,0 +1,73 @@
+import { Card } from "../../../interfaces"
+import Set from "../Pitch Black"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Heatran",
+		fr: "Heatran",
+		es: "Heatran",
+		'es-mx': "Heatran",
+		de: "Heatran"
+	},
+
+	illustrator: "Takeshi Nakamura",
+	rarity: "Uncommon",
+	category: "Pokemon",
+	dexId: [485],
+	hp: 140,
+	types: ["Fire"],
+	stage: "Basic",
+
+	attacks: [{
+		name: {
+			en: "Singe"
+		},
+
+		cost: ["Fire"],
+
+		effect: {
+			en: "Your opponent's Active Pokémon is now Burned"
+		}
+	}, {
+		name: {
+			en: "Lava Wall"
+		},
+
+		cost: ["Fire", "Fire", "Colorless"],
+
+		damage: 120,
+
+		effect: {
+			en: "During your next turn, this Pokémon will receive no damage from attacks by your opponent's Burned Pokémon"
+		}
+	}],
+
+	weaknesses: [{
+		type: "Water",
+		value: "×2"
+	}],
+
+	retreat: 4,
+	regulationMark: "J",
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 895795,
+				tcgplayer: 704764
+			}
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 895795,
+				tcgplayer: 704764
+			}
+		},
+	],
+}
+
+export default card

--- a/data/Mega Evolution/Pitch Black/008.ts
+++ b/data/Mega Evolution/Pitch Black/008.ts
@@ -1,0 +1,72 @@
+import { Card } from "../../../interfaces"
+import Set from "../Pitch Black"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Mega Delphox ex",
+		fr: "Méga-Goupelin-ex",
+		es: "Mega-Delphox ex",
+		'es-mx': "Mega-Delphox ex",
+		de: "Mega-Fennexis-ex"
+	},
+
+	illustrator: "5ban Graphics",
+	rarity: "Double rare",
+	category: "Pokemon",
+	dexId: [655],
+	hp: 350,
+	types: ["Fire"],
+
+	evolveFrom: {
+		en: "Braixen"
+	},
+
+	stage: "Stage2",
+	suffix: "EX",
+
+	attacks: [{
+		name: {
+			en: "Trick Portal"
+		},
+
+		cost: ["Fire"],
+
+		effect: {
+			en: "Look at the top 9 cards of your deck. You may choose any number of Pokemon you find there and put them onto your Bench. Shuffle the other cards back into your deck."
+		}
+	}, {
+		name: {
+			en: "Eerie Glow"
+		},
+
+		cost: ["Fire", "Colorless", "Colorless"],
+
+		damage: 200,
+
+		effect: {
+			en: "Your opponent's Active Pokémon is now Burned and Confused."
+		}
+	}],
+
+	weaknesses: [{
+		type: "Water",
+		value: "×2"
+	}],
+
+	retreat: 1,
+	regulationMark: "J",
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 895796,
+				tcgplayer: 704765
+			}
+		},
+	],
+}
+
+export default card

--- a/data/Mega Evolution/Pitch Black/009.ts
+++ b/data/Mega Evolution/Pitch Black/009.ts
@@ -1,0 +1,73 @@
+import { Card } from "../../../interfaces"
+import Set from "../Pitch Black"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Sizzlipede",
+		fr: "Grillepattes",
+		es: "Sizzlipede",
+		'es-mx': "Sizzlipede",
+		de: "Thermopod"
+	},
+
+	illustrator: "Yuya Oka",
+	rarity: "Common",
+	category: "Pokemon",
+	dexId: [850],
+	hp: 80,
+	types: ["Fire"],
+	stage: "Basic",
+
+	attacks: [{
+		name: {
+			en: "Controlled Burn"
+		},
+
+		cost: ["Fire"],
+
+		effect: {
+			en: "Discard the top card from your opponent's deck"
+		}
+	}, {
+		name: {
+			en: "Bug Out"
+		},
+
+		cost: ["Colorless", "Colorless", "Colorless"],
+
+		damage: "50x",
+
+		effect: {
+			en: "Reveal the bottom 7 cards of your deck. This attack does 50 damage for each Pokémon with the Bug Panic move. Shuffle the Pokémon cards back into your deck and discard the other cards."
+		}
+	}],
+
+	weaknesses: [{
+		type: "Water",
+		value: "×2"
+	}],
+
+	retreat: 2,
+	regulationMark: "J",
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 895797,
+				tcgplayer: 704766
+			}
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 895797,
+				tcgplayer: 704766
+			}
+		},
+	],
+}
+
+export default card

--- a/data/Mega Evolution/Pitch Black/010.ts
+++ b/data/Mega Evolution/Pitch Black/010.ts
@@ -1,0 +1,78 @@
+import { Card } from "../../../interfaces"
+import Set from "../Pitch Black"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Centiskorch",
+		fr: "Scolocendre",
+		es: "Centiskorch",
+		'es-mx': "Centiskorch",
+		de: "Infernopod"
+	},
+
+	illustrator: "Kouki Saitou",
+	rarity: "Common",
+	category: "Pokemon",
+	dexId: [851],
+	hp: 140,
+	types: ["Fire"],
+
+	evolveFrom: {
+		en: "Sizzlipede"
+	},
+
+	stage: "Stage1",
+
+	attacks: [{
+		name: {
+			en: "Controlled Burn"
+		},
+
+		cost: ["Fire"],
+
+		effect: {
+			en: "Discard the top 2 cards from your opponent's deck"
+		}
+	}, {
+		name: {
+			en: "Heat Tackle"
+		},
+
+		cost: ["Fire", "Colorless", "Colorless", "Colorless"],
+
+		damage: 160,
+
+		effect: {
+			en: "This Pokémon also does 30 damage to itself"
+		}
+	}],
+
+	weaknesses: [{
+		type: "Water",
+		value: "×2"
+	}],
+
+	retreat: 3,
+	regulationMark: "J",
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 895798,
+				tcgplayer: 704767
+			}
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 895798,
+				tcgplayer: 704767
+			}
+		},
+	],
+}
+
+export default card

--- a/data/Mega Evolution/Pitch Black/011.ts
+++ b/data/Mega Evolution/Pitch Black/011.ts
@@ -1,0 +1,63 @@
+import { Card } from "../../../interfaces"
+import Set from "../Pitch Black"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Charcadet",
+		fr: "Charbambin",
+		es: "Charcadet",
+		'es-mx': "Charcadet",
+		de: "Knarbon"
+	},
+
+	illustrator: "Ryuta Fuse",
+	rarity: "Common",
+	category: "Pokemon",
+	dexId: [935],
+	hp: 80,
+	types: ["Fire"],
+	stage: "Basic",
+
+	attacks: [{
+		name: {
+			en: "Best Punch"
+		},
+
+		cost: ["Fire"],
+
+		damage: 40,
+
+		effect: {
+			en: "Flip a coin. If tails, this attack does nothing."
+		}
+	}],
+
+	weaknesses: [{
+		type: "Water",
+		value: "×2"
+	}],
+
+	retreat: 2,
+	regulationMark: "J",
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 895799,
+				tcgplayer: 704768
+			}
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 895799,
+				tcgplayer: 704768
+			}
+		},
+	],
+}
+
+export default card

--- a/data/Mega Evolution/Pitch Black/012.ts
+++ b/data/Mega Evolution/Pitch Black/012.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces"
+import Set from "../Pitch Black"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Armarouge",
+		fr: "Carmadura",
+		es: "Armarouge",
+		'es-mx': "Armarouge",
+		de: "Crimanzo"
+	},
+
+	illustrator: "Jiro Sasumo",
+	rarity: "Rare",
+	category: "Pokemon",
+	dexId: [936],
+	hp: 140,
+	types: ["Fire"],
+
+	evolveFrom: {
+		en: "Charcadet"
+	},
+
+	stage: "Stage1",
+
+	attacks: [{
+		name: {
+			en: "Flame Legion"
+		},
+
+		cost: ["Fire"],
+
+		damage: "40+",
+
+		effect: {
+			en: "This attack does 40 more damage for each of your Benched Pokémon that have Fire Energy attached"
+		}
+	}],
+
+	weaknesses: [{
+		type: "Water",
+		value: "×2"
+	}],
+
+	retreat: 2,
+	regulationMark: "J",
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 895800,
+				tcgplayer: 704769
+			}
+		},
+	],
+}
+
+export default card

--- a/data/Mega Evolution/Pitch Black/013.ts
+++ b/data/Mega Evolution/Pitch Black/013.ts
@@ -1,0 +1,59 @@
+import { Card } from "../../../interfaces"
+import Set from "../Pitch Black"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Goldeen",
+		fr: "Poissirène",
+		es: "Goldeen",
+		'es-mx': "Goldeen",
+		de: "Goldini"
+	},
+
+	illustrator: "Shibuzoh.",
+	rarity: "Common",
+	category: "Pokemon",
+	dexId: [118],
+	hp: 70,
+	types: ["Water"],
+	stage: "Basic",
+
+	attacks: [{
+		name: {
+			en: "Pierce"
+		},
+
+		cost: ["Colorless", "Colorless"],
+
+		damage: 30
+	}],
+
+	weaknesses: [{
+		type: "Lightning",
+		value: "×2"
+	}],
+
+	retreat: 1,
+	regulationMark: "J",
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 895801,
+				tcgplayer: 704770
+			}
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 895801,
+				tcgplayer: 704770
+			}
+		},
+	],
+}
+
+export default card

--- a/data/Mega Evolution/Pitch Black/014.ts
+++ b/data/Mega Evolution/Pitch Black/014.ts
@@ -1,0 +1,66 @@
+import { Card } from "../../../interfaces"
+import Set from "../Pitch Black"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Seaking",
+		fr: "Poissoroy",
+		es: "Seaking",
+		'es-mx': "Seaking",
+		de: "Golking"
+	},
+
+	illustrator: "OKUBO",
+	rarity: "Uncommon",
+	category: "Pokemon",
+	dexId: [119],
+	hp: 110,
+	types: ["Water"],
+
+	evolveFrom: {
+		en: "Goldeen"
+	},
+
+	stage: "Stage1",
+
+	attacks: [{
+		name: {
+			en: "Hydro Jet"
+		},
+
+		cost: ["Colorless", "Colorless", "Colorless"],
+
+		effect: {
+			en: "This attack does 30 damage to 1 of your Benched Pokémon for each Water Energy attached to this Pokémon"
+		}
+	}],
+
+	weaknesses: [{
+		type: "Lightning",
+		value: "×2"
+	}],
+
+	retreat: 1,
+	regulationMark: "J",
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 895802,
+				tcgplayer: 704771
+			}
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 895802,
+				tcgplayer: 704771
+			}
+		},
+	],
+}
+
+export default card

--- a/data/Mega Evolution/Pitch Black/015.ts
+++ b/data/Mega Evolution/Pitch Black/015.ts
@@ -1,0 +1,67 @@
+import { Card } from "../../../interfaces"
+import Set from "../Pitch Black"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Wailmer",
+		fr: "Wailmer",
+		es: "Wailmer",
+		'es-mx': "Wailmer",
+		de: "Wailmer"
+	},
+
+	illustrator: "Asako Ito",
+	rarity: "Common",
+	category: "Pokemon",
+	dexId: [320],
+	hp: 130,
+	types: ["Water"],
+	stage: "Basic",
+
+	attacks: [{
+		name: {
+			en: "Water Gun"
+		},
+
+		cost: ["Water", "Water"],
+
+		damage: 40
+	}, {
+		name: {
+			en: "Wave Splash"
+		},
+
+		cost: ["Water", "Water", "Water"],
+
+		damage: 80
+	}],
+
+	weaknesses: [{
+		type: "Lightning",
+		value: "×2"
+	}],
+
+	retreat: 4,
+	regulationMark: "J",
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 895803,
+				tcgplayer: 704772
+			}
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 895803,
+				tcgplayer: 704772
+			}
+		},
+	],
+}
+
+export default card

--- a/data/Mega Evolution/Pitch Black/016.ts
+++ b/data/Mega Evolution/Pitch Black/016.ts
@@ -1,0 +1,70 @@
+import { Card } from "../../../interfaces"
+import Set from "../Pitch Black"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Wailord ex",
+		fr: "Wailord-ex",
+		es: "Wailord ex",
+		'es-mx': "Wailord ex",
+		de: "Wailord-ex"
+	},
+
+	illustrator: "5ban Graphics",
+	rarity: "Double rare",
+	category: "Pokemon",
+	dexId: [321],
+	hp: 380,
+	types: ["Water"],
+
+	evolveFrom: {
+		en: "Wailmer"
+	},
+
+	stage: "Stage1",
+	suffix: "EX",
+
+	attacks: [{
+		name: {
+			en: "Surf"
+		},
+
+		cost: ["Water", "Water", "Water"],
+
+		damage: 120
+	}, {
+		name: {
+			en: "Falling Down"
+		},
+
+		cost: ["Water", "Water", "Water", "Water", "Water"],
+
+		damage: 270,
+
+		effect: {
+			en: "This Pokémon is now Asleep"
+		}
+	}],
+
+	weaknesses: [{
+		type: "Lightning",
+		value: "×2"
+	}],
+
+	retreat: 4,
+	regulationMark: "J",
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 895804,
+				tcgplayer: 704773
+			}
+		},
+	],
+}
+
+export default card

--- a/data/Mega Evolution/Pitch Black/017.ts
+++ b/data/Mega Evolution/Pitch Black/017.ts
@@ -1,0 +1,63 @@
+import { Card } from "../../../interfaces"
+import Set from "../Pitch Black"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Relicanth",
+		fr: "Relicanth",
+		es: "Relicanth",
+		'es-mx': "Relicanth",
+		de: "Relicanth"
+	},
+
+	illustrator: "Naoyo Kumura",
+	rarity: "Uncommon",
+	category: "Pokemon",
+	dexId: [369],
+	hp: 100,
+	types: ["Water"],
+	stage: "Basic",
+
+	attacks: [{
+		name: {
+			en: "Fossil Beatdown"
+		},
+
+		cost: ["Colorless"],
+
+		damage: "10+",
+
+		effect: {
+			en: "This attack does 30 more damage for each of your Benched Pokémon with \"Antique\" in its name."
+		}
+	}],
+
+	weaknesses: [{
+		type: "Lightning",
+		value: "×2"
+	}],
+
+	retreat: 1,
+	regulationMark: "J",
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 895805,
+				tcgplayer: 704774
+			}
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 895805,
+				tcgplayer: 704774
+			}
+		},
+	],
+}
+
+export default card

--- a/data/Mega Evolution/Pitch Black/018.ts
+++ b/data/Mega Evolution/Pitch Black/018.ts
@@ -1,0 +1,59 @@
+import { Card } from "../../../interfaces"
+import Set from "../Pitch Black"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Popplio",
+		fr: "Otaquin",
+		es: "Popplio",
+		'es-mx': "Popplio",
+		de: "Robball"
+	},
+
+	illustrator: "Oswaldo KATO",
+	rarity: "Common",
+	category: "Pokemon",
+	dexId: [728],
+	hp: 70,
+	types: ["Water"],
+	stage: "Basic",
+
+	attacks: [{
+		name: {
+			en: "Pound"
+		},
+
+		cost: ["Water"],
+
+		damage: 20
+	}],
+
+	weaknesses: [{
+		type: "Lightning",
+		value: "×2"
+	}],
+
+	retreat: 1,
+	regulationMark: "J",
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 895806,
+				tcgplayer: 704775
+			}
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 895806,
+				tcgplayer: 704775
+			}
+		},
+	],
+}
+
+export default card

--- a/data/Mega Evolution/Pitch Black/019.ts
+++ b/data/Mega Evolution/Pitch Black/019.ts
@@ -1,0 +1,64 @@
+import { Card } from "../../../interfaces"
+import Set from "../Pitch Black"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Brionne",
+		fr: "Otarlette",
+		es: "Brionne",
+		'es-mx': "Brionne",
+		de: "Marikeck"
+	},
+
+	illustrator: "MINAMINAMI Take",
+	rarity: "Common",
+	category: "Pokemon",
+	dexId: [729],
+	hp: 90,
+	types: ["Water"],
+
+	evolveFrom: {
+		en: "Popplio"
+	},
+
+	stage: "Stage1",
+
+	attacks: [{
+		name: {
+			en: "Hyper Voice"
+		},
+
+		cost: ["Water"],
+
+		damage: 40
+	}],
+
+	weaknesses: [{
+		type: "Lightning",
+		value: "×2"
+	}],
+
+	retreat: 2,
+	regulationMark: "J",
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 895807,
+				tcgplayer: 704776
+			}
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 895807,
+				tcgplayer: 704776
+			}
+		},
+	],
+}
+
+export default card

--- a/data/Mega Evolution/Pitch Black/020.ts
+++ b/data/Mega Evolution/Pitch Black/020.ts
@@ -1,0 +1,73 @@
+import { Card } from "../../../interfaces"
+import Set from "../Pitch Black"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Primarina",
+		fr: "Oratoria",
+		es: "Primarina",
+		'es-mx': "Primarina",
+		de: "Primarene"
+	},
+
+	illustrator: "Taira Akitsu",
+	rarity: "Rare",
+	category: "Pokemon",
+	dexId: [730],
+	hp: 150,
+	types: ["Water"],
+
+	evolveFrom: {
+		en: "Brionne"
+	},
+
+	stage: "Stage2",
+
+	abilities: [{
+		type: "Ability",
+
+		name: {
+			en: "Enriching Melody"
+		},
+
+		effect: {
+			en: "Once during your turn (before your attack), when you play this card from your hand to evolve 1 of your Pokémon, you may use this Ability. Heal all damage from 1 of your Pokémon"
+		}
+	}],
+
+	attacks: [{
+		name: {
+			en: "Aqua Return"
+		},
+
+		cost: ["Water"],
+
+		damage: 120,
+
+		effect: {
+			en: "Shuffle this Pokémon and all cards attached to it into your deck"
+		}
+	}],
+
+	weaknesses: [{
+		type: "Lightning",
+		value: "×2"
+	}],
+
+	retreat: 2,
+	regulationMark: "J",
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 895808,
+				tcgplayer: 704777
+			}
+		},
+	],
+}
+
+export default card

--- a/data/Mega Evolution/Pitch Black/021.ts
+++ b/data/Mega Evolution/Pitch Black/021.ts
@@ -1,0 +1,63 @@
+import { Card } from "../../../interfaces"
+import Set from "../Pitch Black"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Finizen",
+		fr: "Dofin",
+		es: "Finizen",
+		'es-mx': "Finizen",
+		de: "Normifin"
+	},
+
+	illustrator: "Yukiko baba",
+	rarity: "Common",
+	category: "Pokemon",
+	dexId: [963],
+	hp: 80,
+	types: ["Water"],
+	stage: "Basic",
+
+	attacks: [{
+		name: {
+			en: "Draining Fin"
+		},
+
+		cost: ["Water", "Water"],
+
+		damage: 20,
+
+		effect: {
+			en: "Heal 20 damage from this Pokémon"
+		}
+	}],
+
+	weaknesses: [{
+		type: "Lightning",
+		value: "×2"
+	}],
+
+	retreat: 2,
+	regulationMark: "J",
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 895809,
+				tcgplayer: 704778
+			}
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 895809,
+				tcgplayer: 704778
+			}
+		},
+	],
+}
+
+export default card

--- a/data/Mega Evolution/Pitch Black/022.ts
+++ b/data/Mega Evolution/Pitch Black/022.ts
@@ -1,0 +1,68 @@
+import { Card } from "../../../interfaces"
+import Set from "../Pitch Black"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Palafin",
+		fr: "Superdofin",
+		es: "Palafin",
+		'es-mx': "Palafin",
+		de: "Delfinator"
+	},
+
+	illustrator: "satoma",
+	rarity: "Uncommon",
+	category: "Pokemon",
+	dexId: [964],
+	hp: 150,
+	types: ["Water"],
+
+	evolveFrom: {
+		en: "Finizen"
+	},
+
+	stage: "Stage1",
+
+	attacks: [{
+		name: {
+			en: "Knuckle Justice"
+		},
+
+		cost: ["Water", "Water"],
+
+		damage: "80+",
+
+		effect: {
+			en: "If your opponent has exactly 1 Prize card remaining, this attack does 200 more damage"
+		}
+	}],
+
+	weaknesses: [{
+		type: "Lightning",
+		value: "×2"
+	}],
+
+	retreat: 2,
+	regulationMark: "J",
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 895810,
+				tcgplayer: 704779
+			}
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 895810,
+				tcgplayer: 704779
+			}
+		},
+	],
+}
+
+export default card

--- a/data/Mega Evolution/Pitch Black/023.ts
+++ b/data/Mega Evolution/Pitch Black/023.ts
@@ -1,0 +1,69 @@
+import { Card } from "../../../interfaces"
+import Set from "../Pitch Black"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Electrike",
+		fr: "Dynavolt",
+		es: "Electrike",
+		'es-mx': "Electrike",
+		de: "Frizelbliz"
+	},
+
+	illustrator: "Dsuke",
+	rarity: "Common",
+	category: "Pokemon",
+	dexId: [309],
+	hp: 70,
+	types: ["Lightning"],
+	stage: "Basic",
+
+	attacks: [{
+		name: {
+			en: "Collect"
+		},
+
+		cost: ["Lightning"],
+
+		effect: {
+			en: "Draw a card"
+		}
+	}, {
+		name: {
+			en: "Tackle"
+		},
+
+		cost: ["Lightning", "Lightning"],
+
+		damage: 30
+	}],
+
+	weaknesses: [{
+		type: "Fighting",
+		value: "×2"
+	}],
+
+	retreat: 1,
+	regulationMark: "J",
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 895811,
+				tcgplayer: 704780
+			}
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 895811,
+				tcgplayer: 704780
+			}
+		},
+	],
+}
+
+export default card

--- a/data/Mega Evolution/Pitch Black/024.ts
+++ b/data/Mega Evolution/Pitch Black/024.ts
@@ -1,0 +1,80 @@
+import { Card } from "../../../interfaces"
+import Set from "../Pitch Black"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Manectric",
+		fr: "Élecsprint",
+		es: "Manectric",
+		'es-mx': "Manectric",
+		de: "Voltenso"
+	},
+
+	illustrator: "Uninori",
+	rarity: "Uncommon",
+	category: "Pokemon",
+	dexId: [310],
+	hp: 120,
+	types: ["Lightning"],
+
+	evolveFrom: {
+		en: "Electrike"
+	},
+
+	stage: "Stage1",
+
+	attacks: [{
+		name: {
+			en: "Flashing Barrier"
+		},
+
+		cost: ["Lightning", "Lightning"],
+
+		damage: 50,
+
+		effect: {
+			en: "During your opponent's next turn, this Pokémon won't receive damage from your opponent's Evolution Pokémon's attacks"
+		}
+	}, {
+		name: {
+			en: "Sonic Edge"
+		},
+
+		cost: ["Lightning", "Lightning", "Lightning"],
+
+		damage: 110,
+
+		effect: {
+			en: "This attack's damage isn't affected by any effects on your opponent's Active Pokémon"
+		}
+	}],
+
+	weaknesses: [{
+		type: "Fighting",
+		value: "×2"
+	}],
+
+	retreat: 1,
+	regulationMark: "J",
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 895812,
+				tcgplayer: 704781
+			}
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 895812,
+				tcgplayer: 704781
+			}
+		},
+	],
+}
+
+export default card

--- a/data/Mega Evolution/Pitch Black/025.ts
+++ b/data/Mega Evolution/Pitch Black/025.ts
@@ -1,0 +1,72 @@
+import { Card } from "../../../interfaces"
+import Set from "../Pitch Black"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Charjabug",
+		fr: "Chrysapile",
+		es: "Charjabug",
+		'es-mx': "Charjabug",
+		de: "Akkup"
+	},
+
+	illustrator: "Kazuhisa Uragami",
+	rarity: "Common",
+	category: "Pokemon",
+	dexId: [737],
+	hp: 100,
+	types: ["Lightning"],
+
+	evolveFrom: {
+		en: "Grubbin"
+	},
+
+	stage: "Stage1",
+
+	attacks: [{
+		name: {
+			en: "Vise Grip"
+		},
+
+		cost: ["Lightning"],
+
+		damage: 30
+	}, {
+		name: {
+			en: "Ram"
+		},
+
+		cost: ["Lightning", "Lightning"],
+
+		damage: 50
+	}],
+
+	weaknesses: [{
+		type: "Fighting",
+		value: "×2"
+	}],
+
+	retreat: 2,
+	regulationMark: "J",
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 895813,
+				tcgplayer: 704782
+			}
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 895813,
+				tcgplayer: 704782
+			}
+		},
+	],
+}
+
+export default card

--- a/data/Mega Evolution/Pitch Black/026.ts
+++ b/data/Mega Evolution/Pitch Black/026.ts
@@ -1,0 +1,78 @@
+import { Card } from "../../../interfaces"
+import Set from "../Pitch Black"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Vikavolt",
+		fr: "Lucanon",
+		es: "Vikavolt",
+		'es-mx': "Vikavolt",
+		de: "Donarion"
+	},
+
+	illustrator: "KEIICHIRO ITO",
+	rarity: "Uncommon",
+	category: "Pokemon",
+	dexId: [738],
+	hp: 160,
+	types: ["Lightning"],
+
+	evolveFrom: {
+		en: "Charjabug"
+	},
+
+	stage: "Stage2",
+
+	attacks: [{
+		name: {
+			en: "Quick Dive"
+		},
+
+		cost: ["Lightning"],
+
+		effect: {
+			en: "This attack does 50 damage to 1 of your opponent's Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon)"
+		}
+	}, {
+		name: {
+			en: "Giga Railgun"
+		},
+
+		cost: ["Lightning", "Lightning"],
+
+		damage: 260,
+
+		effect: {
+			en: "If this Pokémon doesn't have Bolt Lightning Energy attached to it, this attack does nothing"
+		}
+	}],
+
+	weaknesses: [{
+		type: "Fighting",
+		value: "×2"
+	}],
+
+	retreat: 2,
+	regulationMark: "J",
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 895814,
+				tcgplayer: 704783
+			}
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 895814,
+				tcgplayer: 704783
+			}
+		},
+	],
+}
+
+export default card

--- a/data/Mega Evolution/Pitch Black/027.ts
+++ b/data/Mega Evolution/Pitch Black/027.ts
@@ -1,0 +1,69 @@
+import { Card } from "../../../interfaces"
+import Set from "../Pitch Black"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Mega Zeraora ex",
+		fr: "Méga-Zeraora-ex",
+		es: "Mega-Zeraora ex",
+		'es-mx': "Mega-Zeraora ex",
+		de: "Mega-Zeraora-ex"
+	},
+
+	illustrator: "5ban Graphics",
+	rarity: "Double rare",
+	category: "Pokemon",
+	dexId: [807],
+	hp: 270,
+	types: ["Lightning"],
+	stage: "Basic",
+	suffix: "EX",
+
+	attacks: [{
+		name: {
+			en: "Thunderous Fist"
+		},
+
+		cost: ["Lightning"],
+
+		damage: "60x",
+
+		effect: {
+			en: "This attack does 60 damage for each Lightning Energy attached to this Pokémon."
+		}
+	}, {
+		name: {
+			en: "Zepto Turn"
+		},
+
+		cost: ["Lightning", "Lightning", "Lightning"],
+
+		damage: 150,
+
+		effect: {
+			en: "Switch this Pokémon with one of your Benched Pokémon."
+		}
+	}],
+
+	weaknesses: [{
+		type: "Fighting",
+		value: "×2"
+	}],
+
+	retreat: 1,
+	regulationMark: "J",
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 895787,
+				tcgplayer: 704784
+			}
+		},
+	],
+}
+
+export default card

--- a/data/Mega Evolution/Pitch Black/028.ts
+++ b/data/Mega Evolution/Pitch Black/028.ts
@@ -1,0 +1,75 @@
+import { Card } from "../../../interfaces"
+import Set from "../Pitch Black"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Miraidon",
+		fr: "Miraidon",
+		es: "Miraidon",
+		'es-mx': "Miraidon",
+		de: "Miraidon"
+	},
+
+	illustrator: "mashu",
+	rarity: "Rare",
+	category: "Pokemon",
+	dexId: [1008],
+	hp: 120,
+	types: ["Lightning"],
+	stage: "Basic",
+
+	abilities: [{
+		type: "Ability",
+
+		name: {
+			en: "Photon Cord"
+		},
+
+		effect: {
+			en: "If this Pokémon is in the Active Spot and is Knocked Out by damage from an opponent's attack, move up to 2 Basic Lightning Energy from this Pokémon to 1 of your Benched Pokémon."
+		}
+	}],
+
+	attacks: [{
+		name: {
+			en: "Thunder"
+		},
+
+		cost: ["Lightning", "Lightning"],
+
+		damage: 90,
+
+		effect: {
+			en: "This Pokémon also does 30 damage to itself"
+		}
+	}],
+
+	weaknesses: [{
+		type: "Fighting",
+		value: "×2"
+	}],
+
+	retreat: 1,
+	regulationMark: "J",
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 895815,
+				tcgplayer: 704785
+			}
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 895815,
+				tcgplayer: 704785
+			}
+		},
+	],
+}
+
+export default card

--- a/data/Mega Evolution/Pitch Black/029.ts
+++ b/data/Mega Evolution/Pitch Black/029.ts
@@ -1,0 +1,71 @@
+import { Card } from "../../../interfaces"
+import Set from "../Pitch Black"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Slowpoke",
+		fr: "Ramoloss",
+		es: "Slowpoke",
+		'es-mx': "Slowpoke",
+		de: "Flegmon"
+	},
+
+	illustrator: "Nelnal",
+	rarity: "Common",
+	category: "Pokemon",
+	dexId: [79],
+	hp: 70,
+	types: ["Psychic"],
+	stage: "Basic",
+
+	attacks: [{
+		name: {
+			en: "All-You-Can-Yeet"
+		},
+
+		cost: ["Psychic"],
+
+		effect: {
+			en: "Discard any number of cards from your hand."
+		}
+	}, {
+		name: {
+			en: "Headbutt"
+		},
+
+		cost: ["Colorless", "Colorless"]
+	}],
+
+	weaknesses: [{
+		type: "Darkness",
+		value: "×2"
+	}],
+	resistances: [{
+		type: "Fighting",
+		value: "-30"
+	}],
+
+	retreat: 2,
+	regulationMark: "J",
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 895816,
+				tcgplayer: 704786
+			}
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 895816,
+				tcgplayer: 704786
+			}
+		},
+	],
+}
+
+export default card

--- a/data/Mega Evolution/Pitch Black/030.ts
+++ b/data/Mega Evolution/Pitch Black/030.ts
@@ -1,0 +1,80 @@
+import { Card } from "../../../interfaces"
+import Set from "../Pitch Black"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Slowbro",
+		fr: "Flagadoss",
+		es: "Slowbro",
+		'es-mx': "Slowbro",
+		de: "Lahmus"
+	},
+
+	illustrator: "CHORISO",
+	rarity: "Uncommon",
+	category: "Pokemon",
+	dexId: [80],
+	hp: 130,
+	types: ["Psychic"],
+
+	evolveFrom: {
+		en: "Slowpoke"
+	},
+
+	stage: "Stage1",
+
+	attacks: [{
+		name: {
+			en: "All Out"
+		},
+
+		cost: ["Psychic"],
+
+		damage: "50+",
+
+		effect: {
+			en: "If you have no cards in your hand, this attack does 160 more damage."
+		}
+	}, {
+		name: {
+			en: "Zen Headbutt"
+		},
+
+		cost: ["Colorless", "Colorless", "Colorless"],
+
+		damage: 110
+	}],
+
+	weaknesses: [{
+		type: "Darkness",
+		value: "×2"
+	}],
+	resistances: [{
+		type: "Fighting",
+		value: "-30"
+	}],
+
+	retreat: 3,
+	regulationMark: "J",
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 895817,
+				tcgplayer: 704787
+			}
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 895817,
+				tcgplayer: 704787
+			}
+		},
+	],
+}
+
+export default card

--- a/data/Mega Evolution/Pitch Black/031.ts
+++ b/data/Mega Evolution/Pitch Black/031.ts
@@ -1,0 +1,66 @@
+import { Card } from "../../../interfaces"
+import Set from "../Pitch Black"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Mega Slowbro ex",
+		fr: "Méga-Flagadoss-ex",
+		es: "Mega-Slowbro ex",
+		'es-mx': "Mega-Slowbro ex",
+		de: "Mega-Lahmus-ex"
+	},
+
+	illustrator: "5ban Graphics",
+	rarity: "Double rare",
+	category: "Pokemon",
+	dexId: [80],
+	hp: 330,
+	types: ["Psychic"],
+
+	evolveFrom: {
+		en: "Slowpoke"
+	},
+
+	stage: "Stage1",
+	suffix: "EX",
+
+	attacks: [{
+		name: {
+			en: "Shellnado Spin"
+		},
+
+		cost: ["Psychic", "Psychic", "Psychic"],
+
+		damage: 180,
+
+		effect: {
+			en: "During your opponent's next turn, if this Pokémon is damaged by an attack (even if this Pokémon is Knocked Out), place 12 damage counters on the attacking Pokémon"
+		}
+	}],
+
+	weaknesses: [{
+		type: "Darkness",
+		value: "×2"
+	}],
+	resistances: [{
+		type: "Fighting",
+		value: "-30"
+	}],
+
+	retreat: 3,
+	regulationMark: "J",
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 895818,
+				tcgplayer: 704788
+			}
+		},
+	],
+}
+
+export default card

--- a/data/Mega Evolution/Pitch Black/032.ts
+++ b/data/Mega Evolution/Pitch Black/032.ts
@@ -1,0 +1,77 @@
+import { Card } from "../../../interfaces"
+import Set from "../Pitch Black"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Jynx",
+		fr: "Lippoutou",
+		es: "Jynx",
+		'es-mx': "Jynx",
+		de: "Rossana"
+	},
+
+	illustrator: "Yoshimoto Yoshimon",
+	rarity: "Common",
+	category: "Pokemon",
+	dexId: [124],
+	hp: 100,
+	types: ["Psychic"],
+	stage: "Basic",
+
+	attacks: [{
+		name: {
+			en: "Intense Kiss"
+		},
+
+		cost: ["Psychic"],
+
+		effect: {
+			en: "At the end of your opponent's next turn, discard the Defending Pokémon and all cards attached to it."
+		}
+	}, {
+		name: {
+			en: "Psy Bolt"
+		},
+
+		cost: ["Psychic", "Colorless"],
+
+		damage: 50,
+
+		effect: {
+			en: "Flip a coin. If heads, your opponent's Active Pokémon is now Paralzed"
+		}
+	}],
+
+	weaknesses: [{
+		type: "Darkness",
+		value: "×2"
+	}],
+	resistances: [{
+		type: "Fighting",
+		value: "-30"
+	}],
+
+	retreat: 1,
+	regulationMark: "J",
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 895819,
+				tcgplayer: 704789
+			}
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 895819,
+				tcgplayer: 704789
+			}
+		},
+	],
+}
+
+export default card

--- a/data/Mega Evolution/Pitch Black/033.ts
+++ b/data/Mega Evolution/Pitch Black/033.ts
@@ -1,0 +1,75 @@
+import { Card } from "../../../interfaces"
+import Set from "../Pitch Black"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Shuppet",
+		fr: "Polichombr",
+		es: "Shuppet",
+		'es-mx': "Shuppet",
+		de: "Shuppet"
+	},
+
+	illustrator: "Bun Toujo",
+	rarity: "Common",
+	category: "Pokemon",
+	dexId: [353],
+	hp: 50,
+	types: ["Psychic"],
+	stage: "Basic",
+
+	abilities: [{
+		type: "Ability",
+
+		name: {
+			en: "Hide 'n' Sneak"
+		},
+
+		effect: {
+			en: "Prevent all effects of opponent's Attacks and Abilities done to this Pokémon."
+		}
+	}],
+
+	attacks: [{
+		name: {
+			en: "Hang Down"
+		},
+
+		cost: ["Psychic", "Psychic"],
+
+		damage: 10
+	}],
+
+	weaknesses: [{
+		type: "Darkness",
+		value: "×2"
+	}],
+	resistances: [{
+		type: "Fighting",
+		value: "-30"
+	}],
+
+	retreat: 1,
+	regulationMark: "J",
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 895820,
+				tcgplayer: 704790
+			}
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 895820,
+				tcgplayer: 704790
+			}
+		},
+	],
+}
+
+export default card

--- a/data/Mega Evolution/Pitch Black/034.ts
+++ b/data/Mega Evolution/Pitch Black/034.ts
@@ -1,0 +1,84 @@
+import { Card } from "../../../interfaces"
+import Set from "../Pitch Black"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Banette",
+		fr: "Branette",
+		es: "Banette",
+		'es-mx': "Banette",
+		de: "Banette"
+	},
+
+	illustrator: "Mugi Hamada",
+	rarity: "Uncommon",
+	category: "Pokemon",
+	dexId: [354],
+	hp: 80,
+	types: ["Psychic"],
+
+	evolveFrom: {
+		en: "Shuppet"
+	},
+
+	stage: "Stage1",
+
+	abilities: [{
+		type: "Ability",
+
+		name: {
+			en: "Hide 'n' Sneak"
+		},
+
+		effect: {
+			en: "Prevent all effects of opponent's Attacks and Abilities done to this Pokémon."
+		}
+	}],
+
+	attacks: [{
+		name: {
+			en: "Puppet Pull"
+		},
+
+		cost: ["Psychic", "Psychic"],
+
+		damage: 80,
+
+		effect: {
+			en: "You may search your deck for a card and put it into your hand. Then shuffle tour deck."
+		}
+	}],
+
+	weaknesses: [{
+		type: "Darkness",
+		value: "×2"
+	}],
+	resistances: [{
+		type: "Fighting",
+		value: "-30"
+	}],
+
+	retreat: 1,
+	regulationMark: "J",
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 895821,
+				tcgplayer: 704791
+			}
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 895821,
+				tcgplayer: 704791
+			}
+		},
+	],
+}
+
+export default card

--- a/data/Mega Evolution/Pitch Black/035.ts
+++ b/data/Mega Evolution/Pitch Black/035.ts
@@ -1,0 +1,65 @@
+import { Card } from "../../../interfaces"
+import Set from "../Pitch Black"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Spiritomb",
+		fr: "Spiritomb",
+		es: "Spiritomb",
+		'es-mx': "Spiritomb",
+		de: "Kryppuk"
+	},
+
+	illustrator: "danciao",
+	rarity: "Rare",
+	category: "Pokemon",
+	dexId: [442],
+	hp: 60,
+	types: ["Psychic"],
+	stage: "Basic",
+
+	attacks: [{
+		name: {
+			en: "Spiritual End"
+		},
+
+		cost: ["Psychic"],
+
+		effect: {
+			en: "If you have 13 or more Pokémon that have the Hide 'n' Sneak Ability in your discard pile, choose 2 of your opponent's Pokémon and quadruple the number of damage counters on each of those Pokémon."
+		}
+	}],
+
+	weaknesses: [{
+		type: "Darkness",
+		value: "×2"
+	}],
+	resistances: [{
+		type: "Fighting",
+		value: "-30"
+	}],
+
+	retreat: 1,
+	regulationMark: "J",
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 895822,
+				tcgplayer: 704792
+			}
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 895822,
+				tcgplayer: 704792
+			}
+		},
+	],
+}
+
+export default card

--- a/data/Mega Evolution/Pitch Black/036.ts
+++ b/data/Mega Evolution/Pitch Black/036.ts
@@ -1,0 +1,63 @@
+import { Card } from "../../../interfaces"
+import Set from "../Pitch Black"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Litwick",
+		fr: "Funécire",
+		es: "Litwick",
+		'es-mx': "Litwick",
+		de: "Lichtel"
+	},
+
+	illustrator: "HYOGONOSUKE",
+	rarity: "Common",
+	category: "Pokemon",
+	dexId: [607],
+	hp: 70,
+	types: ["Psychic"],
+	stage: "Basic",
+
+	attacks: [{
+		name: {
+			en: "Will-O-Wisp"
+		},
+
+		cost: ["Psychic"],
+
+		damage: 20
+	}],
+
+	weaknesses: [{
+		type: "Darkness",
+		value: "×2"
+	}],
+	resistances: [{
+		type: "Fighting",
+		value: "-30"
+	}],
+
+	retreat: 1,
+	regulationMark: "J",
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 895823,
+				tcgplayer: 704793
+			}
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 895823,
+				tcgplayer: 704793
+			}
+		},
+	],
+}
+
+export default card

--- a/data/Mega Evolution/Pitch Black/037.ts
+++ b/data/Mega Evolution/Pitch Black/037.ts
@@ -1,0 +1,70 @@
+import { Card } from "../../../interfaces"
+import Set from "../Pitch Black"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Lampent",
+		fr: "Mélancolux",
+		es: "Lampent",
+		'es-mx': "Lampent",
+		de: "Laternecto"
+	},
+
+	illustrator: "sowsow",
+	rarity: "Uncommon",
+	category: "Pokemon",
+	dexId: [608],
+	hp: 90,
+	types: ["Psychic"],
+
+	evolveFrom: {
+		en: "Litwick"
+	},
+
+	stage: "Stage1",
+
+	attacks: [{
+		name: {
+			en: "Spreading Light"
+		},
+
+		cost: ["Psychic"],
+
+		effect: {
+			en: "Put up to 3 Lampent from your deck onto your Bench, then shuffle your deck."
+		}
+	}],
+
+	weaknesses: [{
+		type: "Darkness",
+		value: "×2"
+	}],
+	resistances: [{
+		type: "Fighting",
+		value: "-30"
+	}],
+
+	retreat: 1,
+	regulationMark: "J",
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 895824,
+				tcgplayer: 704794
+			}
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 895824,
+				tcgplayer: 704794
+			}
+		},
+	],
+}
+
+export default card

--- a/data/Mega Evolution/Pitch Black/038.ts
+++ b/data/Mega Evolution/Pitch Black/038.ts
@@ -1,0 +1,78 @@
+import { Card } from "../../../interfaces"
+import Set from "../Pitch Black"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Mega Chandelure ex",
+		fr: "Méga-Lugulabre-ex",
+		es: "Mega-Chandelure ex",
+		'es-mx': "Mega-Chandelure ex",
+		de: "Mega-Skelabra-ex"
+	},
+
+	illustrator: "5ban Graphics",
+	rarity: "Double rare",
+	category: "Pokemon",
+	dexId: [609],
+	hp: 350,
+	types: ["Psychic"],
+
+	evolveFrom: {
+		en: "Lampent"
+	},
+
+	stage: "Stage2",
+	suffix: "EX",
+
+	abilities: [{
+		type: "Ability",
+
+		name: {
+			en: "Binding Flame"
+		},
+
+		effect: {
+			en: "Your opponent's Pokémon's Retreat Cost is 1 more"
+		}
+	}],
+
+	attacks: [{
+		name: {
+			en: "Phantom Maze"
+		},
+
+		cost: ["Psychic", "Psychic"],
+
+		damage: "130+",
+
+		effect: {
+			en: "This attack does 50 more damage for each Energy in your opponent's Active Pokémon's Retreat Cost."
+		}
+	}],
+
+	weaknesses: [{
+		type: "Darkness",
+		value: "×2"
+	}],
+	resistances: [{
+		type: "Fighting",
+		value: "-30"
+	}],
+
+	retreat: 2,
+	regulationMark: "J",
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 895786,
+				tcgplayer: 704795
+			}
+		},
+	],
+}
+
+export default card

--- a/data/Mega Evolution/Pitch Black/039.ts
+++ b/data/Mega Evolution/Pitch Black/039.ts
@@ -1,0 +1,67 @@
+import { Card } from "../../../interfaces"
+import Set from "../Pitch Black"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Dhelmise",
+		fr: "Sinistrail",
+		es: "Dhelmise",
+		'es-mx': "Dhelmise",
+		de: "Moruda"
+	},
+
+	illustrator: "Oku",
+	rarity: "Uncommon",
+	category: "Pokemon",
+	dexId: [781],
+	hp: 60,
+	types: ["Psychic"],
+	stage: "Basic",
+
+	attacks: [{
+		name: {
+			en: "Vengeful Anchor"
+		},
+
+		cost: ["Psychic"],
+
+		damage: "30+",
+
+		effect: {
+			en: "If you have 4 or more Pokémon that have the Hide 'n' Sneak Ability in your discard pile, this attack does 140 more damage."
+		}
+	}],
+
+	weaknesses: [{
+		type: "Darkness",
+		value: "×2"
+	}],
+	resistances: [{
+		type: "Fighting",
+		value: "-30"
+	}],
+
+	retreat: 1,
+	regulationMark: "J",
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 895825,
+				tcgplayer: 704796
+			}
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 895825,
+				tcgplayer: 704796
+			}
+		},
+	],
+}
+
+export default card

--- a/data/Mega Evolution/Pitch Black/040.ts
+++ b/data/Mega Evolution/Pitch Black/040.ts
@@ -1,0 +1,67 @@
+import { Card } from "../../../interfaces"
+import Set from "../Pitch Black"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Marshadow",
+		fr: "Marshadow",
+		es: "Marshadow",
+		'es-mx': "Marshadow",
+		de: "Marshadow"
+	},
+
+	illustrator: "Nakamura Ippan",
+	rarity: "Uncommon",
+	category: "Pokemon",
+	dexId: [802],
+	hp: 90,
+	types: ["Psychic"],
+	stage: "Basic",
+
+	attacks: [{
+		name: {
+			en: "Shadowy Knot"
+		},
+
+		cost: ["Psychic"],
+
+		damage: "30x",
+
+		effect: {
+			en: "This attack does 30 damage for each Energy in your opponent's Active Pokémon's Retreat Cost."
+		}
+	}],
+
+	weaknesses: [{
+		type: "Darkness",
+		value: "×2"
+	}],
+	resistances: [{
+		type: "Fighting",
+		value: "-30"
+	}],
+
+	retreat: 1,
+	regulationMark: "J",
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 895826,
+				tcgplayer: 704797
+			}
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 895826,
+				tcgplayer: 704797
+			}
+		},
+	],
+}
+
+export default card

--- a/data/Mega Evolution/Pitch Black/041.ts
+++ b/data/Mega Evolution/Pitch Black/041.ts
@@ -1,0 +1,84 @@
+import { Card } from "../../../interfaces"
+import Set from "../Pitch Black"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Annihilape",
+		fr: "Courrousinge",
+		es: "Annihilape",
+		'es-mx': "Annihilape",
+		de: "Epitaff"
+	},
+
+	illustrator: "Haru Akasaka",
+	rarity: "Uncommon",
+	category: "Pokemon",
+	dexId: [979],
+	hp: 150,
+	types: ["Psychic"],
+
+	evolveFrom: {
+		en: "Primeape"
+	},
+
+	stage: "Stage2",
+
+	abilities: [{
+		type: "Ability",
+
+		name: {
+			en: "Durable Body"
+		},
+
+		effect: {
+			en: "If this Pokémon would be Knocked Out by damage from an attack, flip a coin. If heads, this Pokémon is not Knocked Out and its remaining HP becomes 10 instead."
+		}
+	}],
+
+	attacks: [{
+		name: {
+			en: "Ghostly Blow"
+		},
+
+		cost: ["Psychic", "Psychic"],
+
+		damage: 100,
+
+		effect: {
+			en: "Put 5 damage counters on 1 of your opponent's Benched Pokémon."
+		}
+	}],
+
+	weaknesses: [{
+		type: "Darkness",
+		value: "×2"
+	}],
+	resistances: [{
+		type: "Fighting",
+		value: "-30"
+	}],
+
+	retreat: 2,
+	regulationMark: "J",
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 895827,
+				tcgplayer: 704798
+			}
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 895827,
+				tcgplayer: 704798
+			}
+		},
+	],
+}
+
+export default card

--- a/data/Mega Evolution/Pitch Black/042.ts
+++ b/data/Mega Evolution/Pitch Black/042.ts
@@ -1,0 +1,59 @@
+import { Card } from "../../../interfaces"
+import Set from "../Pitch Black"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Mankey",
+		fr: "Férosinge",
+		es: "Mankey",
+		'es-mx': "Mankey",
+		de: "Menki"
+	},
+
+	illustrator: "Yuka Morii",
+	rarity: "Common",
+	category: "Pokemon",
+	dexId: [56],
+	hp: 50,
+	types: ["Fighting"],
+	stage: "Basic",
+
+	attacks: [{
+		name: {
+			en: "Low Sweep"
+		},
+
+		cost: ["Colorless"],
+
+		damage: 20
+	}],
+
+	weaknesses: [{
+		type: "Psychic",
+		value: "×2"
+	}],
+
+	retreat: 1,
+	regulationMark: "J",
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 895828,
+				tcgplayer: 704799
+			}
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 895828,
+				tcgplayer: 704799
+			}
+		},
+	],
+}
+
+export default card

--- a/data/Mega Evolution/Pitch Black/043.ts
+++ b/data/Mega Evolution/Pitch Black/043.ts
@@ -1,0 +1,64 @@
+import { Card } from "../../../interfaces"
+import Set from "../Pitch Black"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Primeape",
+		fr: "Colossinge",
+		es: "Primeape",
+		'es-mx': "Primeape",
+		de: "Rasaff"
+	},
+
+	illustrator: "GOSSAN",
+	rarity: "Common",
+	category: "Pokemon",
+	dexId: [57],
+	hp: 110,
+	types: ["Fighting"],
+
+	evolveFrom: {
+		en: "Mankey"
+	},
+
+	stage: "Stage1",
+
+	attacks: [{
+		name: {
+			en: "Corkscrew Punch"
+		},
+
+		cost: ["Colorless", "Colorless"],
+
+		damage: 50
+	}],
+
+	weaknesses: [{
+		type: "Psychic",
+		value: "×2"
+	}],
+
+	retreat: 2,
+	regulationMark: "J",
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 895829,
+				tcgplayer: 704800
+			}
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 895829,
+				tcgplayer: 704800
+			}
+		},
+	],
+}
+
+export default card

--- a/data/Mega Evolution/Pitch Black/044.ts
+++ b/data/Mega Evolution/Pitch Black/044.ts
@@ -1,0 +1,68 @@
+import { Card } from "../../../interfaces"
+import Set from "../Pitch Black"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Cranidos",
+		fr: "Kranidos",
+		es: "Cranidos",
+		'es-mx': "Cranidos",
+		de: "Koknodon"
+	},
+
+	illustrator: "Hideki Ishikawa",
+	rarity: "Common",
+	category: "Pokemon",
+	dexId: [408],
+	hp: 100,
+	types: ["Fighting"],
+
+	evolveFrom: {
+		en: "Antique Skull Fossil"
+	},
+
+	stage: "Stage1",
+
+	attacks: [{
+		name: {
+			en: "Push Down"
+		},
+
+		cost: ["Fighting", "Fighting"],
+
+		damage: 70,
+
+		effect: {
+			en: "Your opponent switches their Active Pokémon for 1 of their Benched Pokémon"
+		}
+	}],
+
+	weaknesses: [{
+		type: "Grass",
+		value: "×2"
+	}],
+
+	retreat: 2,
+	regulationMark: "J",
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 895830,
+				tcgplayer: 704801
+			}
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 895830,
+				tcgplayer: 704801
+			}
+		},
+	],
+}
+
+export default card

--- a/data/Mega Evolution/Pitch Black/045.ts
+++ b/data/Mega Evolution/Pitch Black/045.ts
@@ -1,0 +1,74 @@
+import { Card } from "../../../interfaces"
+import Set from "../Pitch Black"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Rampardos ex",
+		fr: "Charkos-ex",
+		es: "Rampardos ex",
+		'es-mx': "Rampardos ex",
+		de: "Rameidon-ex"
+	},
+
+	illustrator: "hncl",
+	rarity: "Double rare",
+	category: "Pokemon",
+	dexId: [409],
+	hp: 330,
+	types: ["Fighting"],
+
+	evolveFrom: {
+		en: "Cranidos"
+	},
+
+	stage: "Stage2",
+	suffix: "EX",
+
+	abilities: [{
+		type: "Ability",
+
+		name: {
+			en: "Destructive Headbutting"
+		},
+
+		effect: {
+			en: "Once during your turn, if this Pokémon is in the Active Spot, you may flip a coin. If heads, discard an Energy from your opponent's Active Pokémon."
+		}
+	}],
+
+	attacks: [{
+		name: {
+			en: "Rampaging Hammer"
+		},
+
+		cost: ["Fighting", "Fighting"],
+
+		damage: 150,
+
+		effect: {
+			en: "During your next turn, attacks used by this Pokémon deal 150 more damage to your opponent's Active Pokémon (before applying Weakness and Resistance)"
+		}
+	}],
+
+	weaknesses: [{
+		type: "Grass",
+		value: "×2"
+	}],
+
+	retreat: 2,
+	regulationMark: "J",
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 895831,
+				tcgplayer: 704802
+			}
+		},
+	],
+}
+
+export default card

--- a/data/Mega Evolution/Pitch Black/046.ts
+++ b/data/Mega Evolution/Pitch Black/046.ts
@@ -1,0 +1,69 @@
+import { Card } from "../../../interfaces"
+import Set from "../Pitch Black"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Drilbur",
+		fr: "Rototaupe",
+		es: "Drilbur",
+		'es-mx': "Drilbur",
+		de: "Rotomurf"
+	},
+
+	illustrator: "Atsushi Furusawa",
+	rarity: "Common",
+	category: "Pokemon",
+	dexId: [529],
+	hp: 70,
+	types: ["Fighting"],
+	stage: "Basic",
+
+	attacks: [{
+		name: {
+			en: "Call for Family"
+		},
+
+		cost: ["Colorless"],
+
+		effect: {
+			en: "Search your deck for up to 2 Basic Pokémon and put them on your bench. Then, shuffle your deck."
+		}
+	}, {
+		name: {
+			en: "Claw Slash"
+		},
+
+		cost: ["Colorless", "Colorless"],
+
+		damage: 50
+	}],
+
+	weaknesses: [{
+		type: "Grass",
+		value: "×2"
+	}],
+
+	retreat: 2,
+	regulationMark: "J",
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 895832,
+				tcgplayer: 704803
+			}
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 895832,
+				tcgplayer: 704803
+			}
+		},
+	],
+}
+
+export default card

--- a/data/Mega Evolution/Pitch Black/047.ts
+++ b/data/Mega Evolution/Pitch Black/047.ts
@@ -1,0 +1,75 @@
+import { Card } from "../../../interfaces"
+import Set from "../Pitch Black"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Koraidon",
+		fr: "Koraidon",
+		es: "Koraidon",
+		'es-mx': "Koraidon",
+		de: "Koraidon"
+	},
+
+	illustrator: "kodama",
+	rarity: "Rare",
+	category: "Pokemon",
+	dexId: [1007],
+	hp: 130,
+	types: ["Fighting"],
+	stage: "Basic",
+
+	attacks: [{
+		name: {
+			en: "Battle Claw"
+		},
+
+		cost: ["Fighting"],
+
+		damage: "30+",
+
+		effect: {
+			en: "If your opponent's Active Pokémon is an Evolution Pokémon, this attack does 30 more damage"
+		}
+	}, {
+		name: {
+			en: "Gaia Impact"
+		},
+
+		cost: ["Fighting", "Fighting", "Colorless"],
+
+		damage: 190,
+
+		effect: {
+			en: "Discard all Energy attached to this Pokémon"
+		}
+	}],
+
+	weaknesses: [{
+		type: "Psychic",
+		value: "×2"
+	}],
+
+	retreat: 2,
+	regulationMark: "J",
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 895833,
+				tcgplayer: 704804
+			}
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 895833,
+				tcgplayer: 704804
+			}
+		},
+	],
+}
+
+export default card

--- a/data/Mega Evolution/Pitch Black/048.ts
+++ b/data/Mega Evolution/Pitch Black/048.ts
@@ -1,0 +1,67 @@
+import { Card } from "../../../interfaces"
+import Set from "../Pitch Black"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Mega Darkrai ex",
+		fr: "Méga-Darkrai-ex",
+		es: "Mega-Darkrai ex",
+		'es-mx': "Mega-Darkrai ex",
+		de: "Mega-Darkrai-ex"
+	},
+
+	illustrator: "5ban Graphics",
+	rarity: "Double rare",
+	category: "Pokemon",
+	dexId: [491],
+	hp: 280,
+	types: ["Darkness"],
+	stage: "Basic",
+	suffix: "EX",
+
+	attacks: [{
+		name: {
+			en: "Dusk Raid"
+		},
+
+		cost: ["Darkness", "Darkness"],
+
+		damage: "110+",
+
+		effect: {
+			en: "If any of your Benched Pokémon have any damage counters on them, this attack does 110 more damage."
+		}
+	}, {
+		name: {
+			en: "Abyss Eye"
+		},
+
+		cost: ["Darkness", "Darkness", "Darkness"],
+
+		effect: {
+			en: "If your opponent's Active Pokémon is affected by any Special Condition, it is now Knocked Out."
+		}
+	}],
+
+	weaknesses: [{
+		type: "Grass",
+		value: "×2"
+	}],
+
+	retreat: 2,
+	regulationMark: "J",
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 895788,
+				tcgplayer: 704805
+			}
+		},
+	],
+}
+
+export default card

--- a/data/Mega Evolution/Pitch Black/049.ts
+++ b/data/Mega Evolution/Pitch Black/049.ts
@@ -1,0 +1,71 @@
+import { Card } from "../../../interfaces"
+import Set from "../Pitch Black"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Vullaby",
+		fr: "Vostourno",
+		es: "Vullaby",
+		'es-mx': "Vullaby",
+		de: "Skallyk"
+	},
+
+	illustrator: "Shiburingaru",
+	rarity: "Common",
+	category: "Pokemon",
+	dexId: [629],
+	hp: 70,
+	types: ["Darkness"],
+	stage: "Basic",
+
+	attacks: [{
+		name: {
+			en: "Flap"
+		},
+
+		cost: ["Darkness"],
+
+		damage: 10
+	}, {
+		name: {
+			en: "Gust"
+		},
+
+		cost: ["Darkness", "Colorless"],
+
+		damage: 20
+	}],
+
+	weaknesses: [{
+		type: "Lightning",
+		value: "×2"
+	}],
+	resistances: [{
+		type: "Fighting",
+		value: "-30"
+	}],
+
+	retreat: 1,
+	regulationMark: "J",
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 895834,
+				tcgplayer: 704806
+			}
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 895834,
+				tcgplayer: 704806
+			}
+		},
+	],
+}
+
+export default card

--- a/data/Mega Evolution/Pitch Black/050.ts
+++ b/data/Mega Evolution/Pitch Black/050.ts
@@ -1,0 +1,78 @@
+import { Card } from "../../../interfaces"
+import Set from "../Pitch Black"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Mandibuzz",
+		fr: "Vaututrice",
+		es: "Mandibuzz",
+		'es-mx': "Mandibuzz",
+		de: "Grypheldis"
+	},
+
+	illustrator: "Nisota Niso",
+	rarity: "Common",
+	category: "Pokemon",
+	dexId: [630],
+	hp: 120,
+	types: ["Darkness"],
+
+	evolveFrom: {
+		en: "Vullaby"
+	},
+
+	stage: "Stage1",
+
+	attacks: [{
+		name: {
+			en: "Bone Sniper"
+		},
+
+		cost: ["Darkness"],
+
+		effect: {
+			en: "This attack does 70 damage to 1 of your opponent's Pokémon that has a Special Energy attached to it"
+		}
+	}, {
+		name: {
+			en: "Blasting Wind"
+		},
+
+		cost: ["Darkness", "Darkness", "Colorless"],
+
+		damage: 120
+	}],
+
+	weaknesses: [{
+		type: "Lightning",
+		value: "×2"
+	}],
+	resistances: [{
+		type: "Fighting",
+		value: "-30"
+	}],
+
+	retreat: 2,
+	regulationMark: "J",
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 895835,
+				tcgplayer: 704807
+			}
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 895835,
+				tcgplayer: 704807
+			}
+		},
+	],
+}
+
+export default card

--- a/data/Mega Evolution/Pitch Black/051.ts
+++ b/data/Mega Evolution/Pitch Black/051.ts
@@ -1,0 +1,69 @@
+import { Card } from "../../../interfaces"
+import Set from "../Pitch Black"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Inkay",
+		fr: "Sepiatop",
+		es: "Inkay",
+		'es-mx': "Inkay",
+		de: "Iscalar"
+	},
+
+	illustrator: "Yuriko Akase",
+	rarity: "Common",
+	category: "Pokemon",
+	dexId: [686],
+	hp: 60,
+	types: ["Darkness"],
+	stage: "Basic",
+
+	attacks: [{
+		name: {
+			en: "Procurement"
+		},
+
+		cost: ["Darkness"],
+
+		effect: {
+			en: "Search your deck for an Item card, reveal it, and put it into your hand. Then, shuffle your deck."
+		}
+	}, {
+		name: {
+			en: "Spinning Attack"
+		},
+
+		cost: ["Darkness", "Darkness"],
+
+		damage: 30
+	}],
+
+	weaknesses: [{
+		type: "Grass",
+		value: "×2"
+	}],
+
+	retreat: 1,
+	regulationMark: "J",
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 895836,
+				tcgplayer: 704808
+			}
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 895836,
+				tcgplayer: 704808
+			}
+		},
+	],
+}
+
+export default card

--- a/data/Mega Evolution/Pitch Black/052.ts
+++ b/data/Mega Evolution/Pitch Black/052.ts
@@ -1,0 +1,78 @@
+import { Card } from "../../../interfaces"
+import Set from "../Pitch Black"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Malamar",
+		fr: "Sepiatroce",
+		es: "Malamar",
+		'es-mx': "Malamar",
+		de: "Calamanero"
+	},
+
+	illustrator: "Naoki Saito",
+	rarity: "Uncommon",
+	category: "Pokemon",
+	dexId: [687],
+	hp: 120,
+	types: ["Darkness"],
+
+	evolveFrom: {
+		en: "Inkay"
+	},
+
+	stage: "Stage1",
+
+	attacks: [{
+		name: {
+			en: "Perplex"
+		},
+
+		cost: ["Darkness"],
+
+		effect: {
+			en: "Your opponent's Active Pokémon is now Confused"
+		}
+	}, {
+		name: {
+			en: "Brain Crush"
+		},
+
+		cost: ["Darkness"],
+
+		damage: 130,
+
+		effect: {
+			en: "If your opponent's Active Pokémon is not Confused, this attack does nothing."
+		}
+	}],
+
+	weaknesses: [{
+		type: "Grass",
+		value: "×2"
+	}],
+
+	retreat: 1,
+	regulationMark: "J",
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 895837,
+				tcgplayer: 704809
+			}
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 895837,
+				tcgplayer: 704809
+			}
+		},
+	],
+}
+
+export default card

--- a/data/Mega Evolution/Pitch Black/053.ts
+++ b/data/Mega Evolution/Pitch Black/053.ts
@@ -1,0 +1,67 @@
+import { Card } from "../../../interfaces"
+import Set from "../Pitch Black"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Nickit",
+		fr: "Goupilou",
+		es: "Nickit",
+		'es-mx': "Nickit",
+		de: "Kleptifux"
+	},
+
+	illustrator: "Krgc",
+	rarity: "Common",
+	category: "Pokemon",
+	dexId: [827],
+	hp: 70,
+	types: ["Darkness"],
+	stage: "Basic",
+
+	attacks: [{
+		name: {
+			en: "Gnaw"
+		},
+
+		cost: ["Darkness"],
+
+		damage: 10
+	}, {
+		name: {
+			en: "Rear Kick"
+		},
+
+		cost: ["Darkness", "Colorless"],
+
+		damage: 30
+	}],
+
+	weaknesses: [{
+		type: "Grass",
+		value: "×2"
+	}],
+
+	retreat: 1,
+	regulationMark: "J",
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 895838,
+				tcgplayer: 704810
+			}
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 895838,
+				tcgplayer: 704810
+			}
+		},
+	],
+}
+
+export default card

--- a/data/Mega Evolution/Pitch Black/054.ts
+++ b/data/Mega Evolution/Pitch Black/054.ts
@@ -1,0 +1,74 @@
+import { Card } from "../../../interfaces"
+import Set from "../Pitch Black"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Thievul",
+		fr: "Roublenard",
+		es: "Thievul",
+		'es-mx': "Thievul",
+		de: "Gaunux"
+	},
+
+	illustrator: "GOTO minori",
+	rarity: "Uncommon",
+	category: "Pokemon",
+	dexId: [828],
+	hp: 100,
+	types: ["Darkness"],
+
+	evolveFrom: {
+		en: "Nickit"
+	},
+
+	stage: "Stage1",
+
+	attacks: [{
+		name: {
+			en: "Skill Thief"
+		},
+
+		cost: ["Colorless", "Colorless"],
+
+		effect: {
+			en: "If you have no cards in your hand, choose 1 of your opponent's Pokémon's attacks and use it as this attack."
+		}
+	}, {
+		name: {
+			en: "Sharp Fangs"
+		},
+
+		cost: ["Darkness", "Colorless", "Colorless"],
+
+		damage: 80
+	}],
+
+	weaknesses: [{
+		type: "Grass",
+		value: "×2"
+	}],
+
+	retreat: 1,
+	regulationMark: "J",
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 895839,
+				tcgplayer: 704811
+			}
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 895839,
+				tcgplayer: 704811
+			}
+		},
+	],
+}
+
+export default card

--- a/data/Mega Evolution/Pitch Black/055.ts
+++ b/data/Mega Evolution/Pitch Black/055.ts
@@ -1,0 +1,67 @@
+import { Card } from "../../../interfaces"
+import Set from "../Pitch Black"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Morpeko ex",
+		fr: "Morpeko-ex",
+		es: "Morpeko ex",
+		'es-mx': "Morpeko ex",
+		de: "Morpeko-ex"
+	},
+
+	illustrator: "aky CG Works",
+	rarity: "Double rare",
+	category: "Pokemon",
+	dexId: [877],
+	hp: 180,
+	types: ["Darkness"],
+	stage: "Basic",
+	suffix: "EX",
+
+	attacks: [{
+		name: {
+			en: "Wheely Draw"
+		},
+
+		cost: ["Darkness"],
+
+		effect: {
+			en: "Shuffle your hand into your deck, then draw 6 cards."
+		}
+	}, {
+		name: {
+			en: "Hangry Blast"
+		},
+
+		cost: ["Darkness", "Darkness"],
+
+		damage: "40+",
+
+		effect: {
+			en: "This attack does 40 more damage for each damage counter on this Pokémon"
+		}
+	}],
+
+	weaknesses: [{
+		type: "Grass",
+		value: "×2"
+	}],
+
+	retreat: 1,
+	regulationMark: "J",
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 895840,
+				tcgplayer: 704812
+			}
+		},
+	],
+}
+
+export default card

--- a/data/Mega Evolution/Pitch Black/056.ts
+++ b/data/Mega Evolution/Pitch Black/056.ts
@@ -1,0 +1,75 @@
+import { Card } from "../../../interfaces"
+import Set from "../Pitch Black"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Zarude",
+		fr: "Zarude",
+		es: "Zarude",
+		'es-mx': "Zarude",
+		de: "Zarude"
+	},
+
+	illustrator: "matazo",
+	rarity: "Rare",
+	category: "Pokemon",
+	dexId: [893],
+	hp: 130,
+	types: ["Darkness"],
+	stage: "Basic",
+
+	attacks: [{
+		name: {
+			en: "Overhead Throw"
+		},
+
+		cost: ["Darkness"],
+
+		damage: 30,
+
+		effect: {
+			en: "This attack also does 30 damage to 1 of your Benched Pokémon."
+		}
+	}, {
+		name: {
+			en: "Shadowy Whip"
+		},
+
+		cost: ["Darkness", "Darkness", "Darkness"],
+
+		damage: "100+",
+
+		effect: {
+			en: "If any of your Benched Pokémon has any \"Shadow Darkness Energy\" attached to it, this attack does 70 more damage."
+		}
+	}],
+
+	weaknesses: [{
+		type: "Grass",
+		value: "×2"
+	}],
+
+	retreat: 2,
+	regulationMark: "J",
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 895841,
+				tcgplayer: 704813
+			}
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 895841,
+				tcgplayer: 704813
+			}
+		},
+	],
+}
+
+export default card

--- a/data/Mega Evolution/Pitch Black/057.ts
+++ b/data/Mega Evolution/Pitch Black/057.ts
@@ -1,0 +1,59 @@
+import { Card } from "../../../interfaces"
+import Set from "../Pitch Black"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Maschiff",
+		fr: "Grondogue",
+		es: "Maschiff",
+		'es-mx': "Maschiff",
+		de: "Mobtiff"
+	},
+
+	illustrator: "ryoma uratsuka",
+	rarity: "Common",
+	category: "Pokemon",
+	dexId: [942],
+	hp: 70,
+	types: ["Darkness"],
+	stage: "Basic",
+
+	attacks: [{
+		name: {
+			en: "Bite"
+		},
+
+		cost: ["Darkness", "Darkness"],
+
+		damage: 40
+	}],
+
+	weaknesses: [{
+		type: "Grass",
+		value: "×2"
+	}],
+
+	retreat: 2,
+	regulationMark: "J",
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 895842,
+				tcgplayer: 704814
+			}
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 895842,
+				tcgplayer: 704814
+			}
+		},
+	],
+}
+
+export default card

--- a/data/Mega Evolution/Pitch Black/058.ts
+++ b/data/Mega Evolution/Pitch Black/058.ts
@@ -1,0 +1,76 @@
+import { Card } from "../../../interfaces"
+import Set from "../Pitch Black"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Mabosstiff",
+		fr: "Dogrino",
+		es: "Mabosstiff",
+		'es-mx': "Mabosstiff",
+		de: "Mastifioso"
+	},
+
+	illustrator: "kawayoo",
+	rarity: "Common",
+	category: "Pokemon",
+	dexId: [943],
+	hp: 140,
+	types: ["Darkness"],
+
+	evolveFrom: {
+		en: "Maschiff"
+	},
+
+	stage: "Stage1",
+
+	attacks: [{
+		name: {
+			en: "Bite"
+		},
+
+		cost: ["Darkness", "Darkness"],
+
+		damage: 60
+	}, {
+		name: {
+			en: "Plunging Headbutt"
+		},
+
+		cost: ["Darkness", "Darkness", "Darkness"],
+
+		damage: 210,
+
+		effect: {
+			en: "During your opponent's next turn, this Pokémon receives 100 more damage from your opponent's Pokémon's attacks"
+		}
+	}],
+
+	weaknesses: [{
+		type: "Grass",
+		value: "×2"
+	}],
+
+	retreat: 3,
+	regulationMark: "J",
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 895843,
+				tcgplayer: 704815
+			}
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 895843,
+				tcgplayer: 704815
+			}
+		},
+	],
+}
+
+export default card

--- a/data/Mega Evolution/Pitch Black/059.ts
+++ b/data/Mega Evolution/Pitch Black/059.ts
@@ -1,0 +1,56 @@
+import { Card } from "../../../interfaces"
+import Set from "../Pitch Black"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Chi-Yu",
+		fr: "Yuyu",
+		es: "Chi-Yu",
+		'es-mx': "Chi-Yu",
+		de: "Yuyu"
+	},
+
+	illustrator: "IKEDA Saki",
+	rarity: "Rare",
+	category: "Pokemon",
+	dexId: [1004],
+	hp: 90,
+	types: ["Darkness"],
+	stage: "Basic",
+
+	attacks: [{
+		name: {
+			en: "Whirling Envy"
+		},
+
+		cost: ["Darkness"],
+
+		damage: "20+",
+
+		effect: {
+			en: "If this Pokémon has 2 or more damage counters on it, this attack does 90 more damage. Don't apply Weakness for this attack's damage."
+		}
+	}],
+
+	weaknesses: [{
+		type: "Grass",
+		value: "×2"
+	}],
+
+	retreat: 1,
+	regulationMark: "J",
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 895844,
+				tcgplayer: 704816
+			}
+		},
+	],
+}
+
+export default card

--- a/data/Mega Evolution/Pitch Black/060.ts
+++ b/data/Mega Evolution/Pitch Black/060.ts
@@ -1,0 +1,67 @@
+import { Card } from "../../../interfaces"
+import Set from "../Pitch Black"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Skarmory",
+		fr: "Airmure",
+		es: "Skarmory",
+		'es-mx': "Skarmory",
+		de: "Panzaeron"
+	},
+
+	illustrator: "Anesaki Dynamic",
+	rarity: "Common",
+	category: "Pokemon",
+	dexId: [227],
+	hp: 120,
+	types: ["Metal"],
+	stage: "Basic",
+
+	attacks: [{
+		name: {
+			en: "Steel Cutter"
+		},
+
+		cost: ["Metal"],
+
+		damage: "40x",
+
+		effect: {
+			en: "Discard up to 2 Basic Metal Energy from your hand. This attack does 40 damage for each card discarded this way."
+		}
+	}],
+
+	weaknesses: [{
+		type: "Lightning",
+		value: "×2"
+	}],
+	resistances: [{
+		type: "Fighting",
+		value: "-30"
+	}],
+
+	retreat: 1,
+	regulationMark: "J",
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 895845,
+				tcgplayer: 704817
+			}
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 895845,
+				tcgplayer: 704817
+			}
+		},
+	],
+}
+
+export default card

--- a/data/Mega Evolution/Pitch Black/061.ts
+++ b/data/Mega Evolution/Pitch Black/061.ts
@@ -1,0 +1,72 @@
+import { Card } from "../../../interfaces"
+import Set from "../Pitch Black"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Shieldon",
+		fr: "Dinoclier",
+		es: "Shieldon",
+		'es-mx': "Shieldon",
+		de: "Schilterus"
+	},
+
+	illustrator: "Kurata So",
+	rarity: "Common",
+	category: "Pokemon",
+	dexId: [410],
+	hp: 100,
+	types: ["Metal"],
+
+	evolveFrom: {
+		en: "Antique Armor Fossil"
+	},
+
+	stage: "Stage1",
+
+	attacks: [{
+		name: {
+			en: "Smithereen Smash"
+		},
+
+		cost: ["Metal", "Colorless"],
+
+		damage: 50,
+
+		effect: {
+			en: "Discard 1 Energy from your opponent's Active Pokémon."
+		}
+	}],
+
+	weaknesses: [{
+		type: "Fire",
+		value: "×2"
+	}],
+	resistances: [{
+		type: "Grass",
+		value: "-30"
+	}],
+
+	retreat: 3,
+	regulationMark: "J",
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 895846,
+				tcgplayer: 704818
+			}
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 895846,
+				tcgplayer: 704818
+			}
+		},
+	],
+}
+
+export default card

--- a/data/Mega Evolution/Pitch Black/062.ts
+++ b/data/Mega Evolution/Pitch Black/062.ts
@@ -1,0 +1,73 @@
+import { Card } from "../../../interfaces"
+import Set from "../Pitch Black"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Bastiodon",
+		fr: "Bastiodon",
+		es: "Bastiodon",
+		'es-mx': "Bastiodon",
+		de: "Bollterus"
+	},
+
+	illustrator: "Kinu Nishimura",
+	rarity: "Rare",
+	category: "Pokemon",
+	dexId: [411],
+	hp: 160,
+	types: ["Metal"],
+
+	evolveFrom: {
+		en: "Shieldon"
+	},
+
+	stage: "Stage2",
+
+	abilities: [{
+		type: "Ability",
+
+		name: {
+			en: "Ancient Bulwark"
+		},
+
+		effect: {
+			en: "While this Pokémon is on your Bench, prevent all damage done to your Pokémon by attacks from your opponent's Pokémon that have 2 or fewer Energy attached."
+		}
+	}],
+
+	attacks: [{
+		name: {
+			en: "Hammer In"
+		},
+
+		cost: ["Metal", "Metal", "Colorless"],
+
+		damage: 160
+	}],
+
+	weaknesses: [{
+		type: "Fire",
+		value: "×2"
+	}],
+	resistances: [{
+		type: "Grass",
+		value: "-30"
+	}],
+
+	retreat: 4,
+	regulationMark: "J",
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 895847,
+				tcgplayer: 704819
+			}
+		},
+	],
+}
+
+export default card

--- a/data/Mega Evolution/Pitch Black/063.ts
+++ b/data/Mega Evolution/Pitch Black/063.ts
@@ -1,0 +1,67 @@
+import { Card } from "../../../interfaces"
+import Set from "../Pitch Black"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Bronzor",
+		fr: "Archéomire",
+		es: "Bronzor",
+		'es-mx': "Bronzor",
+		de: "Bronzel"
+	},
+
+	illustrator: "Saboteri",
+	rarity: "Common",
+	category: "Pokemon",
+	dexId: [436],
+	hp: 80,
+	types: ["Metal"],
+	stage: "Basic",
+
+	attacks: [{
+		name: {
+			en: "Mirror Attack"
+		},
+
+		cost: ["Metal"],
+
+		damage: "10+",
+
+		effect: {
+			en: "If your opponent's Active Pokémon is a Metal Pokémon, this attack does 30 more damage"
+		}
+	}],
+
+	weaknesses: [{
+		type: "Fire",
+		value: "×2"
+	}],
+	resistances: [{
+		type: "Grass",
+		value: "-30"
+	}],
+
+	retreat: 3,
+	regulationMark: "J",
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 895848,
+				tcgplayer: 704820
+			}
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 895848,
+				tcgplayer: 704820
+			}
+		},
+	],
+}
+
+export default card

--- a/data/Mega Evolution/Pitch Black/064.ts
+++ b/data/Mega Evolution/Pitch Black/064.ts
@@ -1,0 +1,80 @@
+import { Card } from "../../../interfaces"
+import Set from "../Pitch Black"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Bronzong",
+		fr: "Archéodong",
+		es: "Bronzong",
+		'es-mx': "Bronzong",
+		de: "Bronzong"
+	},
+
+	illustrator: "Uta",
+	rarity: "Uncommon",
+	category: "Pokemon",
+	dexId: [437],
+	hp: 130,
+	types: ["Metal"],
+
+	evolveFrom: {
+		en: "Bronzor"
+	},
+
+	stage: "Stage1",
+
+	attacks: [{
+		name: {
+			en: "Gentle Slap"
+		},
+
+		cost: ["Metal"],
+
+		damage: 40
+	}, {
+		name: {
+			en: "Metal Block"
+		},
+
+		cost: ["Metal", "Metal", "Colorless"],
+
+		damage: 120,
+
+		effect: {
+			en: "During your opponent's next turn, this Pokémon receives 100 less damage from your opponent's Active Pokémon's attacks"
+		}
+	}],
+
+	weaknesses: [{
+		type: "Fire",
+		value: "×2"
+	}],
+	resistances: [{
+		type: "Grass",
+		value: "-30"
+	}],
+
+	retreat: 3,
+	regulationMark: "J",
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 895849,
+				tcgplayer: 704821
+			}
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 895849,
+				tcgplayer: 704821
+			}
+		},
+	],
+}
+
+export default card

--- a/data/Mega Evolution/Pitch Black/065.ts
+++ b/data/Mega Evolution/Pitch Black/065.ts
@@ -1,0 +1,78 @@
+import { Card } from "../../../interfaces"
+import Set from "../Pitch Black"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Mega Excadrill ex",
+		fr: "Méga-Minotaupe-ex",
+		es: "Mega-Excadrill ex",
+		'es-mx': "Mega-Excadrill ex",
+		de: "Mega-Stalobor-ex"
+	},
+
+	illustrator: "Keisuke Azuma",
+	rarity: "Double rare",
+	category: "Pokemon",
+	dexId: [530],
+	hp: 340,
+	types: ["Metal"],
+
+	evolveFrom: {
+		en: "Drilbur"
+	},
+
+	stage: "Stage1",
+	suffix: "EX",
+
+	attacks: [{
+		name: {
+			en: "Undermine"
+		},
+
+		cost: ["Metal", "Metal"],
+
+		damage: 90,
+
+		effect: {
+			en: "Discard the top 2 cards of your opponent's deck"
+		}
+	}, {
+		name: {
+			en: "Maximum Drilling"
+		},
+
+		cost: ["Metal", "Metal"],
+
+		damage: "200+",
+
+		effect: {
+			en: "If you have at least 2 extra Energy attached to this Pokémon, this attack does 130 more damage"
+		}
+	}],
+
+	weaknesses: [{
+		type: "Fire",
+		value: "×2"
+	}],
+	resistances: [{
+		type: "Grass",
+		value: "-30"
+	}],
+
+	retreat: 4,
+	regulationMark: "J",
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 895785,
+				tcgplayer: 704822
+			}
+		},
+	],
+}
+
+export default card

--- a/data/Mega Evolution/Pitch Black/066.ts
+++ b/data/Mega Evolution/Pitch Black/066.ts
@@ -1,0 +1,67 @@
+import { Card } from "../../../interfaces"
+import Set from "../Pitch Black"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Pikipek",
+		fr: "Picassaut",
+		es: "Pikipek",
+		'es-mx': "Pikipek",
+		de: "Peppeck"
+	},
+
+	illustrator: "Koji Nakata",
+	rarity: "Common",
+	category: "Pokemon",
+	dexId: [731],
+	hp: 70,
+	types: ["Colorless"],
+	stage: "Basic",
+
+	attacks: [{
+		name: {
+			en: "Double Stab"
+		},
+
+		cost: ["Colorless"],
+
+		damage: "10x",
+
+		effect: {
+			en: "Flip 2 coins. This attack does 10 damage for each heads"
+		}
+	}],
+
+	weaknesses: [{
+		type: "Lightning",
+		value: "×2"
+	}],
+	resistances: [{
+		type: "Fighting",
+		value: "-30"
+	}],
+
+	retreat: 1,
+	regulationMark: "J",
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 895850,
+				tcgplayer: 704823
+			}
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 895850,
+				tcgplayer: 704823
+			}
+		},
+	],
+}
+
+export default card

--- a/data/Mega Evolution/Pitch Black/067.ts
+++ b/data/Mega Evolution/Pitch Black/067.ts
@@ -1,0 +1,72 @@
+import { Card } from "../../../interfaces"
+import Set from "../Pitch Black"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Trumbeak",
+		fr: "Piclairon",
+		es: "Trumbeak",
+		'es-mx': "Trumbeak",
+		de: "Trompeck"
+	},
+
+	illustrator: "miki kudo",
+	rarity: "Common",
+	category: "Pokemon",
+	dexId: [732],
+	hp: 90,
+	types: ["Colorless"],
+
+	evolveFrom: {
+		en: "Pikipek"
+	},
+
+	stage: "Stage1",
+
+	attacks: [{
+		name: {
+			en: "Fly"
+		},
+
+		cost: ["Colorless"],
+
+		damage: 30,
+
+		effect: {
+			en: "Flip a coin. If tails, this attack does nothing. If heads, prevent all effects of attacks, including damage, done to this Pokémon during your opponent's next turn."
+		}
+	}],
+
+	weaknesses: [{
+		type: "Lightning",
+		value: "×2"
+	}],
+	resistances: [{
+		type: "Fighting",
+		value: "-30"
+	}],
+
+	retreat: 1,
+	regulationMark: "J",
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 895851,
+				tcgplayer: 704824
+			}
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 895851,
+				tcgplayer: 704824
+			}
+		},
+	],
+}
+
+export default card

--- a/data/Mega Evolution/Pitch Black/068.ts
+++ b/data/Mega Evolution/Pitch Black/068.ts
@@ -1,0 +1,84 @@
+import { Card } from "../../../interfaces"
+import Set from "../Pitch Black"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Toucannon",
+		fr: "Bazoucan",
+		es: "Toucannon",
+		'es-mx': "Toucannon",
+		de: "Tukanon"
+	},
+
+	illustrator: "Masako Tomii",
+	rarity: "Uncommon",
+	category: "Pokemon",
+	dexId: [733],
+	hp: 150,
+	types: ["Colorless"],
+
+	evolveFrom: {
+		en: "Trumbeak"
+	},
+
+	stage: "Stage2",
+
+	abilities: [{
+		type: "Ability",
+
+		name: {
+			en: "Aerial Draw"
+		},
+
+		effect: {
+			en: "Once during your turn, you may draw 1 card."
+		}
+	}],
+
+	attacks: [{
+		name: {
+			en: "Feather Rondo"
+		},
+
+		cost: ["Colorless"],
+
+		damage: "60+",
+
+		effect: {
+			en: "This attack does 20 more damage for each Benched Pokémon (both yours and your opponent's)."
+		}
+	}],
+
+	weaknesses: [{
+		type: "Lightning",
+		value: "×2"
+	}],
+	resistances: [{
+		type: "Fighting",
+		value: "-30"
+	}],
+
+	retreat: 2,
+	regulationMark: "J",
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 895852,
+				tcgplayer: 704825
+			}
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 895852,
+				tcgplayer: 704825
+			}
+		},
+	],
+}
+
+export default card

--- a/data/Mega Evolution/Pitch Black/069.ts
+++ b/data/Mega Evolution/Pitch Black/069.ts
@@ -1,0 +1,59 @@
+import { Card } from "../../../interfaces"
+import Set from "../Pitch Black"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Type: Null",
+		fr: "Type:0",
+		es: "Código Cero",
+		'es-mx': "Código Cero",
+		de: "Typ:Null"
+	},
+
+	illustrator: "Ligton",
+	rarity: "Common",
+	category: "Pokemon",
+	dexId: [772],
+	hp: 110,
+	types: ["Colorless"],
+	stage: "Basic",
+
+	attacks: [{
+		name: {
+			en: "Power Edge"
+		},
+
+		cost: ["Colorless", "Colorless"],
+
+		damage: 40
+	}],
+
+	weaknesses: [{
+		type: "Fighting",
+		value: "×2"
+	}],
+
+	retreat: 2,
+	regulationMark: "J",
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 895853,
+				tcgplayer: 704826
+			}
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 895853,
+				tcgplayer: 704826
+			}
+		},
+	],
+}
+
+export default card

--- a/data/Mega Evolution/Pitch Black/070.ts
+++ b/data/Mega Evolution/Pitch Black/070.ts
@@ -1,0 +1,73 @@
+import { Card } from "../../../interfaces"
+import Set from "../Pitch Black"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Silvally",
+		fr: "Silvallié",
+		es: "Silvally",
+		'es-mx': "Silvally",
+		de: "Amigento"
+	},
+
+	illustrator: "Takumi Wada",
+	rarity: "Rare",
+	category: "Pokemon",
+	dexId: [773],
+	hp: 140,
+	types: ["Colorless"],
+
+	evolveFrom: {
+		en: "Type: Null"
+	},
+
+	stage: "Stage1",
+
+	abilities: [{
+		type: "Ability",
+
+		name: {
+			en: "Call a Buddy"
+		},
+
+		effect: {
+			en: "Once during your turn (before your attack), if you have 0 cards in your hand, you may search your deck for a Supporter card, reveal it, and put it into your hand. Then shuffle your deck."
+		}
+	}],
+
+	attacks: [{
+		name: {
+			en: "Air Slash"
+		},
+
+		cost: ["Colorless"],
+
+		damage: 130,
+
+		effect: {
+			en: "Discard 1 Energy from this Pokémon."
+		}
+	}],
+
+	weaknesses: [{
+		type: "Fighting",
+		value: "×2"
+	}],
+
+	retreat: 2,
+	regulationMark: "J",
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 895854,
+				tcgplayer: 704827
+			}
+		},
+	],
+}
+
+export default card

--- a/data/Mega Evolution/Pitch Black/071.ts
+++ b/data/Mega Evolution/Pitch Black/071.ts
@@ -1,0 +1,73 @@
+import { Card } from "../../../interfaces"
+import Set from "../Pitch Black"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Bombirdier",
+		fr: "Lestombaile",
+		es: "Bombirdier",
+		'es-mx': "Bombirdier",
+		de: "Adebom"
+	},
+
+	illustrator: "Wintr Wandr",
+	rarity: "Common",
+	category: "Pokemon",
+	dexId: [962],
+	hp: 100,
+	types: ["Colorless"],
+	stage: "Basic",
+
+	attacks: [{
+		name: {
+			en: "Challenginge Delivery"
+		},
+
+		cost: ["Colorless", "Colorless"],
+
+		effect: {
+			en: "Flip 2 coins. If both of them are heads, search your deck for 1 Pokémon and put it onto your Bench, then shuffle your deck."
+		}
+	}, {
+		name: {
+			en: "Speed Wing"
+		},
+
+		cost: ["Colorless", "Colorless", "Colorless"],
+
+		damage: 100
+	}],
+
+	weaknesses: [{
+		type: "Lightning",
+		value: "×2"
+	}],
+	resistances: [{
+		type: "Fighting",
+		value: "-30"
+	}],
+
+	retreat: 1,
+	regulationMark: "J",
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 895855,
+				tcgplayer: 704828
+			}
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 895855,
+				tcgplayer: 704828
+			}
+		},
+	],
+}
+
+export default card

--- a/data/Mega Evolution/Pitch Black/072.ts
+++ b/data/Mega Evolution/Pitch Black/072.ts
@@ -1,0 +1,43 @@
+import { Card } from "../../../interfaces"
+import Set from "../Pitch Black"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Antique Armor Fossil",
+		fr: "Fossile Armure Ancien",
+		es: "Fósil Coraza Antiguo",
+		'es-mx': "Fósil Coraza Antiguo",
+		de: "Antikes Panzerfossil"
+	},
+
+	illustrator: "AYUMI ODASHIMA",
+	rarity: "Common",
+	category: "Trainer",
+	trainerType: "Item",
+	regulationMark: "J",
+
+	effect: {
+		en: "Play this card as if it were a 60-HP Basic Pokémon. At any time during your turn, you may discard this card from play. This card can't retreat."
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 895856,
+				tcgplayer: 704829
+			}
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 895856,
+				tcgplayer: 704829
+			}
+		},
+	],
+}
+
+export default card

--- a/data/Mega Evolution/Pitch Black/073.ts
+++ b/data/Mega Evolution/Pitch Black/073.ts
@@ -1,0 +1,43 @@
+import { Card } from "../../../interfaces"
+import Set from "../Pitch Black"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Antique Skull Fossil",
+		fr: "Fossile Crâne Ancien",
+		es: "Fósil Cráneo Antiguo",
+		'es-mx': "Fósil Cráneo Antiguo",
+		de: "Antikes Kopffossil"
+	},
+
+	illustrator: "AYUMI ODASHIMA",
+	rarity: "Common",
+	category: "Trainer",
+	trainerType: "Item",
+	regulationMark: "J",
+
+	effect: {
+		en: "Play this card as if it were a 60-HP Basic Pokémon. At any time during your turn, you may discard this card from play. This card can't retreat."
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 895857,
+				tcgplayer: 704830
+			}
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 895857,
+				tcgplayer: 704830
+			}
+		},
+	],
+}
+
+export default card

--- a/data/Mega Evolution/Pitch Black/074.ts
+++ b/data/Mega Evolution/Pitch Black/074.ts
@@ -1,0 +1,43 @@
+import { Card } from "../../../interfaces"
+import Set from "../Pitch Black"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Backtrack Badge",
+		fr: "Badge Rebelote",
+		es: "Insignia Reintento",
+		'es-mx': "Insignia Retroactiva",
+		de: "Retourorden"
+	},
+
+	illustrator: "Toyste Beach",
+	rarity: "Uncommon",
+	category: "Trainer",
+	trainerType: "Tool",
+	regulationMark: "J",
+
+	effect: {
+		en: "Once during your turn, after you flip any coins for an attack of the Colorless Pokémon this card is attached to, you may ignore all results of those coin flips and begin flipping those coins again."
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 895858,
+				tcgplayer: 704831
+			}
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 895858,
+				tcgplayer: 704831
+			}
+		},
+	],
+}
+
+export default card

--- a/data/Mega Evolution/Pitch Black/075.ts
+++ b/data/Mega Evolution/Pitch Black/075.ts
@@ -1,0 +1,43 @@
+import { Card } from "../../../interfaces"
+import Set from "../Pitch Black"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Dark Bell",
+		fr: "Cloche Ténébreuse",
+		es: "Campana Oscura",
+		'es-mx': "Campanilla Oscuridad",
+		de: "Düsterglocke"
+	},
+
+	illustrator: "Toyste Beach",
+	rarity: "Uncommon",
+	category: "Trainer",
+	trainerType: "Item",
+	regulationMark: "J",
+
+	effect: {
+		en: "Both Active Pokémon (except any Darkness type Pokémon) are now Confused."
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 895859,
+				tcgplayer: 704832
+			}
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 895859,
+				tcgplayer: 704832
+			}
+		},
+	],
+}
+
+export default card

--- a/data/Mega Evolution/Pitch Black/076.ts
+++ b/data/Mega Evolution/Pitch Black/076.ts
@@ -1,0 +1,43 @@
+import { Card } from "../../../interfaces"
+import Set from "../Pitch Black"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Fossil Quarry",
+		fr: "Carrière Fossile",
+		es: "Cantera de Fósiles",
+		'es-mx': "Cantera de Fósiles",
+		de: "Fossiliengrube"
+	},
+
+	illustrator: "Oswaldo KATO",
+	rarity: "Uncommon",
+	category: "Trainer",
+	trainerType: "Stadium",
+	regulationMark: "J",
+
+	effect: {
+		en: "Once during each player's turn, that player may search their deck for up to 2 Trainer cards with \"Antique\" in their name and put them onto their Bench. Then, that player shuffles their deck."
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 895860,
+				tcgplayer: 704833
+			}
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 895860,
+				tcgplayer: 704833
+			}
+		},
+	],
+}
+
+export default card

--- a/data/Mega Evolution/Pitch Black/077.ts
+++ b/data/Mega Evolution/Pitch Black/077.ts
@@ -1,0 +1,43 @@
+import { Card } from "../../../interfaces"
+import Set from "../Pitch Black"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Gladion's Final Battle",
+		fr: "Combat Final de Gladio",
+		es: "Combate Final de Gladio",
+		'es-mx': "Combate Final de Gladion",
+		de: "Gladios Finalkampf"
+	},
+
+	illustrator: "akagi",
+	rarity: "Uncommon",
+	category: "Trainer",
+	trainerType: "Supporter",
+	regulationMark: "J",
+
+	effect: {
+		en: "You can play this card only if it is the last card in your hand. During this turn, attacks used by your Pokémon that do not have a Rule Box do 80 more damage to your opponent's Active Pokémon (before applying Weakness and Resistance) (Pokémon ex, Pokémon V etc. have Rule Boxes)"
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 895861,
+				tcgplayer: 704834
+			}
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 895861,
+				tcgplayer: 704834
+			}
+		},
+	],
+}
+
+export default card

--- a/data/Mega Evolution/Pitch Black/078.ts
+++ b/data/Mega Evolution/Pitch Black/078.ts
@@ -1,0 +1,43 @@
+import { Card } from "../../../interfaces"
+import Set from "../Pitch Black"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Gwynn",
+		fr: "Albia",
+		es: "Inma",
+		'es-mx': "Inma",
+		de: "Gwynn"
+	},
+
+	illustrator: "nagimiso",
+	rarity: "Uncommon",
+	category: "Trainer",
+	trainerType: "Supporter",
+	regulationMark: "J",
+
+	effect: {
+		en: "Discard up to 2 Pokémon that don't have a Rule Box from your hand, and draw 3 cards for each card you discarded n this way. (Pokémon ex, Pokémon V, etc. have Rule Boxes)"
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 895862,
+				tcgplayer: 704835
+			}
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 895862,
+				tcgplayer: 704835
+			}
+		},
+	],
+}
+
+export default card

--- a/data/Mega Evolution/Pitch Black/079.ts
+++ b/data/Mega Evolution/Pitch Black/079.ts
@@ -1,0 +1,43 @@
+import { Card } from "../../../interfaces"
+import Set from "../Pitch Black"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Jett",
+		fr: "Bridjet",
+		es: "Viona",
+		'es-mx': "Viona",
+		de: "Jette"
+	},
+
+	illustrator: "GIDORA",
+	rarity: "Uncommon",
+	category: "Trainer",
+	trainerType: "Supporter",
+	regulationMark: "J",
+
+	effect: {
+		en: "Draw a card for each of your opponent's Mega Evolution Pokémon ex in play."
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 895863,
+				tcgplayer: 704836
+			}
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 895863,
+				tcgplayer: 704836
+			}
+		},
+	],
+}
+
+export default card

--- a/data/Mega Evolution/Pitch Black/080.ts
+++ b/data/Mega Evolution/Pitch Black/080.ts
@@ -1,0 +1,43 @@
+import { Card } from "../../../interfaces"
+import Set from "../Pitch Black"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Misty's Vitality",
+		fr: "Vitalité d'Ondine",
+		es: "Vitalidad de Misty",
+		'es-mx': "Vitalidad de Misty",
+		de: "Mistys Vitalität"
+	},
+
+	illustrator: "En Morikura",
+	rarity: "Uncommon",
+	category: "Trainer",
+	trainerType: "Supporter",
+	regulationMark: "J",
+
+	effect: {
+		en: "Search your deck for up to 4 Basic Water Energy and attach them to 1 of your Pokémon. Then, shuffle your deck. Your turn ends."
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 895864,
+				tcgplayer: 704837
+			}
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 895864,
+				tcgplayer: 704837
+			}
+		},
+	],
+}
+
+export default card

--- a/data/Mega Evolution/Pitch Black/081.ts
+++ b/data/Mega Evolution/Pitch Black/081.ts
@@ -1,0 +1,43 @@
+import { Card } from "../../../interfaces"
+import Set from "../Pitch Black"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Rust Syndicate Grunt",
+		fr: "Sbire du Clan Dérouillard",
+		es: "Recluta del Clan Corrosión",
+		'es-mx': "Recluta del Clan Corrosión",
+		de: "Rüpel vom Corrosio-Clan"
+	},
+
+	illustrator: "Teeziro",
+	rarity: "Uncommon",
+	category: "Trainer",
+	trainerType: "Supporter",
+	regulationMark: "J",
+
+	effect: {
+		en: "You can use this card only if any of your Pokémon were Knocked Out during your opponent's last turn. Discard an Energy from 1 of your opponent's Pokémon."
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 895865,
+				tcgplayer: 704838
+			}
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 895865,
+				tcgplayer: 704838
+			}
+		},
+	],
+}
+
+export default card

--- a/data/Mega Evolution/Pitch Black/082.ts
+++ b/data/Mega Evolution/Pitch Black/082.ts
@@ -1,0 +1,43 @@
+import { Card } from "../../../interfaces"
+import Set from "../Pitch Black"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Tremendous Bomb",
+		fr: "Bombe Géniale",
+		es: "Bomba Formidable",
+		'es-mx': "Tremenda Bomba",
+		de: "Ungeheure Bombe"
+	},
+
+	illustrator: "inose yukie",
+	rarity: "Uncommon",
+	category: "Trainer",
+	trainerType: "Tool",
+	regulationMark: "J",
+
+	effect: {
+		en: "If the Active Pokémon this card is attached to isn't a Mega Evolution Pokémon ex, is in the Active Spot, and takes 240 or more damage from your opponent's Mega Evolution Pokémon ex (even if this Pokémon is Knocked Out), place 12 damage counters on the Attacking Pokémon. If you placed any damage counters on in this way, discard this card"
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 895866,
+				tcgplayer: 704839
+			}
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 895866,
+				tcgplayer: 704839
+			}
+		},
+	],
+}
+
+export default card

--- a/data/Mega Evolution/Pitch Black/083.ts
+++ b/data/Mega Evolution/Pitch Black/083.ts
@@ -1,0 +1,35 @@
+import { Card } from "../../../interfaces"
+import Set from "../Pitch Black"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Shadowy Darkness Energy",
+		fr: "Énergie Obscur Sombre",
+		es: "Energía Sombría",
+		'es-mx': "Energía Sombría",
+		de: "Schattige Finsternis-Energie"
+	},
+
+	rarity: "Rare",
+	category: "Energy",
+	energyType: "Special",
+	regulationMark: "J",
+
+	effect: {
+		en: "As long as the Darkness Pokémon this card is attached to is on your Bench, prevent all damage done to it by attacks from your opponent's Pokémon"
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 895867,
+				tcgplayer: 704840
+			}
+		},
+	],
+}
+
+export default card

--- a/data/Mega Evolution/Pitch Black/084.ts
+++ b/data/Mega Evolution/Pitch Black/084.ts
@@ -1,0 +1,35 @@
+import { Card } from "../../../interfaces"
+import Set from "../Pitch Black"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Voltaic Lightning Energy",
+		fr: "Énergie Électrique Voltaïque",
+		es: "Energía Voltaica",
+		'es-mx': "Energía Voltaica",
+		de: "Voltaische Elektro-Energie"
+	},
+
+	rarity: "Rare",
+	category: "Energy",
+	energyType: "Special",
+	regulationMark: "J",
+
+	effect: {
+		en: "While attached to a Pokémon, this card provides 1 Lightning Energy. Attacks used by the Lightning Pokémon this card is attached to deal 20 more damage to your opponent's Active Pokémon."
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 895868,
+				tcgplayer: 704841
+			}
+		},
+	],
+}
+
+export default card

--- a/data/Mega Evolution/Pitch Black/085.ts
+++ b/data/Mega Evolution/Pitch Black/085.ts
@@ -1,0 +1,56 @@
+import { Card } from "../../../interfaces"
+import Set from "../Pitch Black"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Fomantis",
+		fr: "Mimantis",
+		es: "Fomantis",
+		'es-mx': "Fomantis",
+		de: "Imantis"
+	},
+
+	illustrator: "Jiro Sasuno",
+	rarity: "Illustration rare",
+	category: "Pokemon",
+	dexId: [753],
+	hp: 70,
+	types: ["Grass"],
+	stage: "Basic",
+
+	attacks: [{
+		name: {
+			en: "Reckless Charge"
+		},
+
+		cost: ["Grass"],
+
+		damage: 30,
+
+		effect: {
+			en: "This Pokémon also does 10 damage to itself"
+		}
+	}],
+
+	weaknesses: [{
+		type: "Fire",
+		value: "×2"
+	}],
+
+	retreat: 1,
+	regulationMark: "J",
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 895869,
+				tcgplayer: 704842
+			}
+		},
+	],
+}
+
+export default card

--- a/data/Mega Evolution/Pitch Black/086.ts
+++ b/data/Mega Evolution/Pitch Black/086.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces"
+import Set from "../Pitch Black"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Armarouge",
+		fr: "Carmadura",
+		es: "Armarouge",
+		'es-mx': "Armarouge",
+		de: "Crimanzo"
+	},
+
+	illustrator: "Iwamoto05",
+	rarity: "Illustration rare",
+	category: "Pokemon",
+	dexId: [936],
+	hp: 140,
+	types: ["Fire"],
+
+	evolveFrom: {
+		en: "Charcadet"
+	},
+
+	stage: "Stage1",
+
+	attacks: [{
+		name: {
+			en: "Flame Legion"
+		},
+
+		cost: ["Fire"],
+
+		damage: "40+",
+
+		effect: {
+			en: "This attack does 40 more damage for each of your Benched Pokémon that have Fire Energy attached"
+		}
+	}],
+
+	weaknesses: [{
+		type: "Water",
+		value: "×2"
+	}],
+
+	retreat: 2,
+	regulationMark: "J",
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 895870,
+				tcgplayer: 704843
+			}
+		},
+	],
+}
+
+export default card

--- a/data/Mega Evolution/Pitch Black/087.ts
+++ b/data/Mega Evolution/Pitch Black/087.ts
@@ -1,0 +1,52 @@
+import { Card } from "../../../interfaces"
+import Set from "../Pitch Black"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Goldeen",
+		fr: "Poissirène",
+		es: "Goldeen",
+		'es-mx': "Goldeen",
+		de: "Goldini"
+	},
+
+	illustrator: "Gemi",
+	rarity: "Illustration rare",
+	category: "Pokemon",
+	dexId: [118],
+	hp: 70,
+	types: ["Water"],
+	stage: "Basic",
+
+	attacks: [{
+		name: {
+			en: "Pierce"
+		},
+
+		cost: ["Colorless", "Colorless"],
+
+		damage: 30
+	}],
+
+	weaknesses: [{
+		type: "Lightning",
+		value: "×2"
+	}],
+
+	retreat: 1,
+	regulationMark: "J",
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 895871,
+				tcgplayer: 704844
+			}
+		},
+	],
+}
+
+export default card

--- a/data/Mega Evolution/Pitch Black/088.ts
+++ b/data/Mega Evolution/Pitch Black/088.ts
@@ -1,0 +1,73 @@
+import { Card } from "../../../interfaces"
+import Set from "../Pitch Black"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Primarina",
+		fr: "Oratoria",
+		es: "Primarina",
+		'es-mx': "Primarina",
+		de: "Primarene"
+	},
+
+	illustrator: "satoma",
+	rarity: "Illustration rare",
+	category: "Pokemon",
+	dexId: [730],
+	hp: 150,
+	types: ["Water"],
+
+	evolveFrom: {
+		en: "Brionne"
+	},
+
+	stage: "Stage2",
+
+	abilities: [{
+		type: "Ability",
+
+		name: {
+			en: "Enriching Melody"
+		},
+
+		effect: {
+			en: "Once during your turn (before your attack), when you play this card from your hand to evolve 1 of your Pokémon, you may use this Ability. Heal all damage from 1 of your Pokémon"
+		}
+	}],
+
+	attacks: [{
+		name: {
+			en: "Aqua Return"
+		},
+
+		cost: ["Water"],
+
+		damage: 120,
+
+		effect: {
+			en: "Shuffle this Pokémon and all cards attached to it into your deck"
+		}
+	}],
+
+	weaknesses: [{
+		type: "Lightning",
+		value: "×2"
+	}],
+
+	retreat: 2,
+	regulationMark: "J",
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 895872,
+				tcgplayer: 704845
+			}
+		},
+	],
+}
+
+export default card

--- a/data/Mega Evolution/Pitch Black/089.ts
+++ b/data/Mega Evolution/Pitch Black/089.ts
@@ -1,0 +1,73 @@
+import { Card } from "../../../interfaces"
+import Set from "../Pitch Black"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Manectric",
+		fr: "Élecsprint",
+		es: "Manectric",
+		'es-mx': "Manectric",
+		de: "Voltenso"
+	},
+
+	illustrator: "HICO KIM",
+	rarity: "Illustration rare",
+	category: "Pokemon",
+	dexId: [310],
+	hp: 120,
+	types: ["Lightning"],
+
+	evolveFrom: {
+		en: "Electrike"
+	},
+
+	stage: "Stage1",
+
+	attacks: [{
+		name: {
+			en: "Flash Barrier"
+		},
+
+		cost: ["Lightning", "Lightning"],
+
+		damage: 50,
+
+		effect: {
+			en: "During your opponent's next turn, this Pokémon won't receive damage from your opponent's Evolution Pokémon's attacks"
+		}
+	}, {
+		name: {
+			en: "Sonic Edge"
+		},
+
+		cost: ["Lightning", "Lightning", "Lightning"],
+
+		damage: 110,
+
+		effect: {
+			en: "This attack's damage isn't affected by any effects on your opponent's Active Pokémon"
+		}
+	}],
+
+	weaknesses: [{
+		type: "Fighting",
+		value: "×2"
+	}],
+
+	retreat: 1,
+	regulationMark: "J",
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 895873,
+				tcgplayer: 704846
+			}
+		},
+	],
+}
+
+export default card

--- a/data/Mega Evolution/Pitch Black/090.ts
+++ b/data/Mega Evolution/Pitch Black/090.ts
@@ -1,0 +1,73 @@
+import { Card } from "../../../interfaces"
+import Set from "../Pitch Black"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Slowbro",
+		fr: "Flagadoss",
+		es: "Slowbro",
+		'es-mx': "Slowbro",
+		de: "Lahmus"
+	},
+
+	illustrator: "Mekayu",
+	rarity: "Illustration rare",
+	category: "Pokemon",
+	dexId: [80],
+	hp: 130,
+	types: ["Psychic"],
+
+	evolveFrom: {
+		en: "Slowpoke"
+	},
+
+	stage: "Stage1",
+
+	attacks: [{
+		name: {
+			en: "All Out"
+		},
+
+		cost: ["Psychic"],
+
+		damage: "50+",
+
+		effect: {
+			en: "If you have no cards in your hand, this attack does 160 more damage."
+		}
+	}, {
+		name: {
+			en: "Zen Headbutt"
+		},
+
+		cost: ["Colorless", "Colorless", "Colorless"],
+
+		damage: 110
+	}],
+
+	weaknesses: [{
+		type: "Darkness",
+		value: "×2"
+	}],
+	resistances: [{
+		type: "Fighting",
+		value: "-30"
+	}],
+
+	retreat: 3,
+	regulationMark: "J",
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 895874,
+				tcgplayer: 704847
+			}
+		},
+	],
+}
+
+export default card

--- a/data/Mega Evolution/Pitch Black/091.ts
+++ b/data/Mega Evolution/Pitch Black/091.ts
@@ -1,0 +1,60 @@
+import { Card } from "../../../interfaces"
+import Set from "../Pitch Black"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Dhelmise",
+		fr: "Sinistrail",
+		es: "Dhelmise",
+		'es-mx': "Dhelmise",
+		de: "Moruda"
+	},
+
+	illustrator: "Nakamura Ippan",
+	rarity: "Illustration rare",
+	category: "Pokemon",
+	dexId: [781],
+	hp: 60,
+	types: ["Psychic"],
+	stage: "Basic",
+
+	attacks: [{
+		name: {
+			en: "Vengeful Anchor"
+		},
+
+		cost: ["Psychic"],
+
+		damage: "30+",
+
+		effect: {
+			en: "If you have 4 or more Pokémon with the Hide 'n' Sneak Ability in your discard pile, this attack does 140 more damage."
+		}
+	}],
+
+	weaknesses: [{
+		type: "Darkness",
+		value: "×2"
+	}],
+	resistances: [{
+		type: "Fighting",
+		value: "-30"
+	}],
+
+	retreat: 1,
+	regulationMark: "J",
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 895875,
+				tcgplayer: 704848
+			}
+		},
+	],
+}
+
+export default card

--- a/data/Mega Evolution/Pitch Black/092.ts
+++ b/data/Mega Evolution/Pitch Black/092.ts
@@ -1,0 +1,67 @@
+import { Card } from "../../../interfaces"
+import Set from "../Pitch Black"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Thievul",
+		fr: "Roublenard",
+		es: "Thievul",
+		'es-mx': "Thievul",
+		de: "Gaunux"
+	},
+
+	illustrator: "Jerky",
+	rarity: "Illustration rare",
+	category: "Pokemon",
+	dexId: [828],
+	hp: 100,
+	types: ["Darkness"],
+
+	evolveFrom: {
+		en: "Nickit"
+	},
+
+	stage: "Stage1",
+
+	attacks: [{
+		name: {
+			en: "Skill Thief"
+		},
+
+		cost: ["Colorless", "Colorless"],
+
+		effect: {
+			en: "If you have no cards in your hand, choose 1 of your opponent's Pokémon's attacks and use it as this attack."
+		}
+	}, {
+		name: {
+			en: "Sharp Fangs"
+		},
+
+		cost: ["Darkness", "Colorless", "Colorless"],
+
+		damage: 80
+	}],
+
+	weaknesses: [{
+		type: "Grass",
+		value: "×2"
+	}],
+
+	retreat: 1,
+	regulationMark: "J",
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 895876,
+				tcgplayer: 704849
+			}
+		},
+	],
+}
+
+export default card

--- a/data/Mega Evolution/Pitch Black/093.ts
+++ b/data/Mega Evolution/Pitch Black/093.ts
@@ -1,0 +1,73 @@
+import { Card } from "../../../interfaces"
+import Set from "../Pitch Black"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Bastiodon",
+		fr: "Bastiodon",
+		es: "Bastiodon",
+		'es-mx': "Bastiodon",
+		de: "Bollterus"
+	},
+
+	illustrator: "Yoriyuki Ikegami",
+	rarity: "Illustration rare",
+	category: "Pokemon",
+	dexId: [411],
+	hp: 160,
+	types: ["Metal"],
+
+	evolveFrom: {
+		en: "Shieldon"
+	},
+
+	stage: "Stage2",
+
+	abilities: [{
+		type: "Ability",
+
+		name: {
+			en: "Ancient Bulwark"
+		},
+
+		effect: {
+			en: "While this Pokémon is on your Bench, prevent all damage done to your Pokémon by attacks from your opponent's Pokémon that have 2 or fewer Energy attached."
+		}
+	}],
+
+	attacks: [{
+		name: {
+			en: "Hammer In"
+		},
+
+		cost: ["Metal", "Metal", "Colorless"],
+
+		damage: 160
+	}],
+
+	weaknesses: [{
+		type: "Fire",
+		value: "×2"
+	}],
+	resistances: [{
+		type: "Grass",
+		value: "-30"
+	}],
+
+	retreat: 4,
+	regulationMark: "J",
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 895878,
+				tcgplayer: 704850
+			}
+		},
+	],
+}
+
+export default card

--- a/data/Mega Evolution/Pitch Black/094.ts
+++ b/data/Mega Evolution/Pitch Black/094.ts
@@ -1,0 +1,77 @@
+import { Card } from "../../../interfaces"
+import Set from "../Pitch Black"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Toucannon",
+		fr: "Bazoucan",
+		es: "Toucannon",
+		'es-mx': "Toucannon",
+		de: "Tukanon"
+	},
+
+	illustrator: "miki kudo",
+	rarity: "Illustration rare",
+	category: "Pokemon",
+	dexId: [733],
+	hp: 150,
+	types: ["Colorless"],
+
+	evolveFrom: {
+		en: "Trumbeak"
+	},
+
+	stage: "Stage2",
+
+	abilities: [{
+		type: "Ability",
+
+		name: {
+			en: "Sky Draw"
+		},
+
+		effect: {
+			en: "Once during your turn, you may draw 1 card."
+		}
+	}],
+
+	attacks: [{
+		name: {
+			en: "Feather Rondo"
+		},
+
+		cost: ["Colorless"],
+
+		damage: "60+",
+
+		effect: {
+			en: "This attack does 20 more damage for each Benched Pokémon (both yours and your opponent's)."
+		}
+	}],
+
+	weaknesses: [{
+		type: "Lightning",
+		value: "×2"
+	}],
+	resistances: [{
+		type: "Fighting",
+		value: "-30"
+	}],
+
+	retreat: 2,
+	regulationMark: "J",
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 895879,
+				tcgplayer: 704851
+			}
+		},
+	],
+}
+
+export default card

--- a/data/Mega Evolution/Pitch Black/095.ts
+++ b/data/Mega Evolution/Pitch Black/095.ts
@@ -1,0 +1,73 @@
+import { Card } from "../../../interfaces"
+import Set from "../Pitch Black"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Silvally",
+		fr: "Silvallié",
+		es: "Silvally",
+		'es-mx': "Silvally",
+		de: "Amigento"
+	},
+
+	illustrator: "DOM",
+	rarity: "Illustration rare",
+	category: "Pokemon",
+	dexId: [773],
+	hp: 140,
+	types: ["Colorless"],
+
+	evolveFrom: {
+		en: "Type: Null"
+	},
+
+	stage: "Stage1",
+
+	abilities: [{
+		type: "Ability",
+
+		name: {
+			en: "Call a Buddy"
+		},
+
+		effect: {
+			en: "Once during your turn (before your attack), if you have 0 cards in your hand, you may search your deck for a Supporter card, reveal it, and put it into your hand. Then shuffle your deck."
+		}
+	}],
+
+	attacks: [{
+		name: {
+			en: "Air Slash"
+		},
+
+		cost: ["Colorless"],
+
+		damage: 130,
+
+		effect: {
+			en: "Discard 1 Energy from this Pokémon."
+		}
+	}],
+
+	weaknesses: [{
+		type: "Fighting",
+		value: "×2"
+	}],
+
+	retreat: 2,
+	regulationMark: "J",
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 895880,
+				tcgplayer: 704852
+			}
+		},
+	],
+}
+
+export default card

--- a/data/Mega Evolution/Pitch Black/096.ts
+++ b/data/Mega Evolution/Pitch Black/096.ts
@@ -1,0 +1,74 @@
+import { Card } from "../../../interfaces"
+import Set from "../Pitch Black"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Lurantis ex",
+		fr: "Floramantis-ex",
+		es: "Lurantis ex",
+		'es-mx': "Lurantis ex",
+		de: "Mantidea-ex"
+	},
+
+	illustrator: "5ban Graphics",
+	rarity: "Ultra Rare",
+	category: "Pokemon",
+	dexId: [754],
+	hp: 260,
+	types: ["Grass"],
+
+	evolveFrom: {
+		en: "Fomantis"
+	},
+
+	stage: "Stage1",
+	suffix: "EX",
+
+	attacks: [{
+		name: {
+			en: "Vigorous Cutter"
+		},
+
+		cost: ["Grass"],
+
+		damage: "60+",
+
+		effect: {
+			en: "If this Pokémon recovered any HP this turn, this attack does 200 more damage."
+		}
+	}, {
+		name: {
+			en: "Leaf Guard"
+		},
+
+		cost: ["Grass", "Colorless"],
+
+		damage: 140,
+
+		effect: {
+			en: "During your opponent's next turn, this Pokémon takes 50 less damage from attacks."
+		}
+	}],
+
+	weaknesses: [{
+		type: "Fire",
+		value: "×2"
+	}],
+
+	retreat: 1,
+	regulationMark: "J",
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 895881,
+				tcgplayer: 704853
+			}
+		},
+	],
+}
+
+export default card

--- a/data/Mega Evolution/Pitch Black/097.ts
+++ b/data/Mega Evolution/Pitch Black/097.ts
@@ -1,0 +1,70 @@
+import { Card } from "../../../interfaces"
+import Set from "../Pitch Black"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Wailord ex",
+		fr: "Wailord-ex",
+		es: "Wailord ex",
+		'es-mx': "Wailord ex",
+		de: "Wailord-ex"
+	},
+
+	illustrator: "5ban Graphics",
+	rarity: "Ultra Rare",
+	category: "Pokemon",
+	dexId: [321],
+	hp: 380,
+	types: ["Water"],
+
+	evolveFrom: {
+		en: "Wailmer"
+	},
+
+	stage: "Stage1",
+	suffix: "EX",
+
+	attacks: [{
+		name: {
+			en: "Surf"
+		},
+
+		cost: ["Water", "Water", "Water"],
+
+		damage: 120
+	}, {
+		name: {
+			en: "Falling Down"
+		},
+
+		cost: ["Water", "Water", "Water", "Water", "Water"],
+
+		damage: 270,
+
+		effect: {
+			en: "This Pokémon is now Asleep"
+		}
+	}],
+
+	weaknesses: [{
+		type: "Lightning",
+		value: "×2"
+	}],
+
+	retreat: 4,
+	regulationMark: "J",
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 895882,
+				tcgplayer: 704854
+			}
+		},
+	],
+}
+
+export default card

--- a/data/Mega Evolution/Pitch Black/098.ts
+++ b/data/Mega Evolution/Pitch Black/098.ts
@@ -1,0 +1,69 @@
+import { Card } from "../../../interfaces"
+import Set from "../Pitch Black"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Mega Zeraora ex",
+		fr: "Méga-Zeraora-ex",
+		es: "Mega-Zeraora ex",
+		'es-mx': "Mega-Zeraora ex",
+		de: "Mega-Zeraora-ex"
+	},
+
+	illustrator: "5ban Graphics",
+	rarity: "Ultra Rare",
+	category: "Pokemon",
+	dexId: [807],
+	hp: 270,
+	types: ["Lightning"],
+	stage: "Basic",
+	suffix: "EX",
+
+	attacks: [{
+		name: {
+			en: "Thunderous Fist"
+		},
+
+		cost: ["Lightning"],
+
+		damage: "60x",
+
+		effect: {
+			en: "This attack does 60 damage for each Lightning Energy attached to this Pokémon."
+		}
+	}, {
+		name: {
+			en: "Zepto Turn"
+		},
+
+		cost: ["Lightning", "Lightning", "Lightning"],
+
+		damage: 150,
+
+		effect: {
+			en: "Switch this Pokémon with one of your Benched Pokémon."
+		}
+	}],
+
+	weaknesses: [{
+		type: "Fighting",
+		value: "×2"
+	}],
+
+	retreat: 1,
+	regulationMark: "J",
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 895883,
+				tcgplayer: 704855
+			}
+		},
+	],
+}
+
+export default card

--- a/data/Mega Evolution/Pitch Black/099.ts
+++ b/data/Mega Evolution/Pitch Black/099.ts
@@ -1,0 +1,78 @@
+import { Card } from "../../../interfaces"
+import Set from "../Pitch Black"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Mega Chandelure ex",
+		fr: "Méga-Lugulabre-ex",
+		es: "Mega-Chandelure ex",
+		'es-mx': "Mega-Chandelure ex",
+		de: "Mega-Skelabra-ex"
+	},
+
+	illustrator: "5ban Graphics",
+	rarity: "Ultra Rare",
+	category: "Pokemon",
+	dexId: [609],
+	hp: 350,
+	types: ["Psychic"],
+
+	evolveFrom: {
+		en: "Lampent"
+	},
+
+	stage: "Stage2",
+	suffix: "EX",
+
+	abilities: [{
+		type: "Ability",
+
+		name: {
+			en: "Binding Flame"
+		},
+
+		effect: {
+			en: "Your opponent's Pokémon's Retreat Cost is 1 more"
+		}
+	}],
+
+	attacks: [{
+		name: {
+			en: "Phantom Maze"
+		},
+
+		cost: ["Psychic", "Psychic"],
+
+		damage: "130+",
+
+		effect: {
+			en: "This attack does 50 more damage for each Energy in your opponent's Active Pokémon's Retreat Cost."
+		}
+	}],
+
+	weaknesses: [{
+		type: "Darkness",
+		value: "×2"
+	}],
+	resistances: [{
+		type: "Fighting",
+		value: "-30"
+	}],
+
+	retreat: 2,
+	regulationMark: "J",
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 895884,
+				tcgplayer: 704856
+			}
+		},
+	],
+}
+
+export default card

--- a/data/Mega Evolution/Pitch Black/100.ts
+++ b/data/Mega Evolution/Pitch Black/100.ts
@@ -1,0 +1,74 @@
+import { Card } from "../../../interfaces"
+import Set from "../Pitch Black"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Rampardos ex",
+		fr: "Charkos-ex",
+		es: "Rampardos ex",
+		'es-mx': "Rampardos ex",
+		de: "Rameidon-ex"
+	},
+
+	illustrator: "5ban Graphics",
+	rarity: "Ultra Rare",
+	category: "Pokemon",
+	dexId: [409],
+	hp: 330,
+	types: ["Fighting"],
+
+	evolveFrom: {
+		en: "Cranidos"
+	},
+
+	stage: "Stage2",
+	suffix: "EX",
+
+	abilities: [{
+		type: "Ability",
+
+		name: {
+			en: "Destructive Headbutting"
+		},
+
+		effect: {
+			en: "Once during your turn, if this Pokémon is in the Active Spot, you may flip a coin. If heads, discard an Energy from your opponent's Active Pokémon."
+		}
+	}],
+
+	attacks: [{
+		name: {
+			en: "Rowdy Hammer"
+		},
+
+		cost: ["Fighting", "Fighting"],
+
+		damage: 150,
+
+		effect: {
+			en: "During your next turn, attacks used by this Pokémon deal 150 more damage to your opponent's Active Pokémon."
+		}
+	}],
+
+	weaknesses: [{
+		type: "Grass",
+		value: "×2"
+	}],
+
+	retreat: 2,
+	regulationMark: "J",
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 895885,
+				tcgplayer: 704857
+			}
+		},
+	],
+}
+
+export default card

--- a/data/Mega Evolution/Pitch Black/101.ts
+++ b/data/Mega Evolution/Pitch Black/101.ts
@@ -1,0 +1,67 @@
+import { Card } from "../../../interfaces"
+import Set from "../Pitch Black"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Mega Darkrai ex",
+		fr: "Méga-Darkrai-ex",
+		es: "Mega-Darkrai ex",
+		'es-mx': "Mega-Darkrai ex",
+		de: "Mega-Darkrai-ex"
+	},
+
+	illustrator: "5ban Graphics",
+	rarity: "Ultra Rare",
+	category: "Pokemon",
+	dexId: [491],
+	hp: 280,
+	types: ["Darkness"],
+	stage: "Basic",
+	suffix: "EX",
+
+	attacks: [{
+		name: {
+			en: "Dusk Raid"
+		},
+
+		cost: ["Darkness", "Darkness"],
+
+		damage: "110+",
+
+		effect: {
+			en: "If any of your Benched Pokémon have any damage counters on them, this attack does 110 more damage."
+		}
+	}, {
+		name: {
+			en: "Abyss Eye"
+		},
+
+		cost: ["Darkness", "Darkness", "Darkness"],
+
+		effect: {
+			en: "If your opponent's Active Pokémon is affected by any Special Condition, it is now Knocked Out."
+		}
+	}],
+
+	weaknesses: [{
+		type: "Grass",
+		value: "×2"
+	}],
+
+	retreat: 2,
+	regulationMark: "J",
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 895886,
+				tcgplayer: 704858
+			}
+		},
+	],
+}
+
+export default card

--- a/data/Mega Evolution/Pitch Black/102.ts
+++ b/data/Mega Evolution/Pitch Black/102.ts
@@ -1,0 +1,67 @@
+import { Card } from "../../../interfaces"
+import Set from "../Pitch Black"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Morpeko ex",
+		fr: "Morpeko-ex",
+		es: "Morpeko ex",
+		'es-mx': "Morpeko ex",
+		de: "Morpeko-ex"
+	},
+
+	illustrator: "5ban Graphics",
+	rarity: "Ultra Rare",
+	category: "Pokemon",
+	dexId: [877],
+	hp: 180,
+	types: ["Darkness"],
+	stage: "Basic",
+	suffix: "EX",
+
+	attacks: [{
+		name: {
+			en: "Wheel Draw"
+		},
+
+		cost: ["Darkness"],
+
+		effect: {
+			en: "Shuffle your hand into your deck, then draw 6 cards."
+		}
+	}, {
+		name: {
+			en: "Hangry Blaster"
+		},
+
+		cost: ["Darkness", "Darkness"],
+
+		damage: "40+",
+
+		effect: {
+			en: "This attack does 40 more damage for each damage counter on this Pokémon"
+		}
+	}],
+
+	weaknesses: [{
+		type: "Grass",
+		value: "×2"
+	}],
+
+	retreat: 1,
+	regulationMark: "J",
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 895887,
+				tcgplayer: 704859
+			}
+		},
+	],
+}
+
+export default card

--- a/data/Mega Evolution/Pitch Black/103.ts
+++ b/data/Mega Evolution/Pitch Black/103.ts
@@ -1,0 +1,78 @@
+import { Card } from "../../../interfaces"
+import Set from "../Pitch Black"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Mega Excadrill ex",
+		fr: "Méga-Minotaupe-ex",
+		es: "Mega-Excadrill ex",
+		'es-mx': "Mega-Excadrill ex",
+		de: "Mega-Stalobor-ex"
+	},
+
+	illustrator: "Keisuke Azuma",
+	rarity: "Ultra Rare",
+	category: "Pokemon",
+	dexId: [530],
+	hp: 340,
+	types: ["Metal"],
+
+	evolveFrom: {
+		en: "Drilbur"
+	},
+
+	stage: "Stage1",
+	suffix: "EX",
+
+	attacks: [{
+		name: {
+			en: "Undermine"
+		},
+
+		cost: ["Metal", "Metal"],
+
+		damage: 90,
+
+		effect: {
+			en: "Discard the top 2 cards of your opponent's deck"
+		}
+	}, {
+		name: {
+			en: "Maximum Drilling"
+		},
+
+		cost: ["Metal", "Metal"],
+
+		damage: "200+",
+
+		effect: {
+			en: "If you have at least 2 extra Energy attached to this Pokémon, this attack does 130 more damage"
+		}
+	}],
+
+	weaknesses: [{
+		type: "Fire",
+		value: "×2"
+	}],
+	resistances: [{
+		type: "Grass",
+		value: "-30"
+	}],
+
+	retreat: 4,
+	regulationMark: "J",
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 895888,
+				tcgplayer: 704860
+			}
+		},
+	],
+}
+
+export default card

--- a/data/Mega Evolution/Pitch Black/104.ts
+++ b/data/Mega Evolution/Pitch Black/104.ts
@@ -1,0 +1,36 @@
+import { Card } from "../../../interfaces"
+import Set from "../Pitch Black"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Brave Bangle",
+		fr: "Bracelet Vaillant",
+		es: "Pulsera Osada",
+		'es-mx': "Brazalete Valiente",
+		de: "Reif der Tapferkeit"
+	},
+
+	illustrator: "Toyste Beach",
+	rarity: "Ultra Rare",
+	category: "Trainer",
+	trainerType: "Tool",
+	regulationMark: "I",
+
+	effect: {
+		en: "The attacks of the Pokémon this card is attached to (excluding Pokémon with a Rule Box) deal 30 more damage to your opponent's Active Pokémon ex."
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 895889,
+				tcgplayer: 704861
+			}
+		},
+	],
+}
+
+export default card

--- a/data/Mega Evolution/Pitch Black/105.ts
+++ b/data/Mega Evolution/Pitch Black/105.ts
@@ -1,0 +1,36 @@
+import { Card } from "../../../interfaces"
+import Set from "../Pitch Black"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Crushing Hammer",
+		fr: "Maillet Écrasant",
+		es: "Martillo Demoledor",
+		'es-mx': "Martillo Demoledor",
+		de: "Schmetterhammer"
+	},
+
+	illustrator: "Ayako Yoshida",
+	rarity: "Ultra Rare",
+	category: "Trainer",
+	trainerType: "Item",
+	regulationMark: "J",
+
+	effect: {
+		en: "Flip a coin. If heads, discard an Energy attached to 1 of your opponent's Pokémon."
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 895890,
+				tcgplayer: 704862
+			}
+		},
+	],
+}
+
+export default card

--- a/data/Mega Evolution/Pitch Black/106.ts
+++ b/data/Mega Evolution/Pitch Black/106.ts
@@ -1,0 +1,36 @@
+import { Card } from "../../../interfaces"
+import Set from "../Pitch Black"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Dark Bell",
+		fr: "Cloche Ténébreuse",
+		es: "Campana Oscura",
+		'es-mx': "Campanilla Oscuridad",
+		de: "Düsterglocke"
+	},
+
+	illustrator: "Toyste Beach",
+	rarity: "Ultra Rare",
+	category: "Trainer",
+	trainerType: "Item",
+	regulationMark: "J",
+
+	effect: {
+		en: "Both Active Pokémon (except any Darkness type Pokémon) are now Confused."
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 895891,
+				tcgplayer: 704863
+			}
+		},
+	],
+}
+
+export default card

--- a/data/Mega Evolution/Pitch Black/107.ts
+++ b/data/Mega Evolution/Pitch Black/107.ts
@@ -1,0 +1,36 @@
+import { Card } from "../../../interfaces"
+import Set from "../Pitch Black"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Energy Switch",
+		fr: "Échange d'Énergie",
+		es: "Interruptor de Energía",
+		'es-mx': "Cambio de Energía",
+		de: "Energie-Umschalter"
+	},
+
+	illustrator: "Studio Bora Inc.",
+	rarity: "Ultra Rare",
+	category: "Trainer",
+	trainerType: "Item",
+	regulationMark: "I",
+
+	effect: {
+		en: "Move a basic Energy from 1 of your Pokémon to another of your Pokémon."
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 895892,
+				tcgplayer: 704864
+			}
+		},
+	],
+}
+
+export default card

--- a/data/Mega Evolution/Pitch Black/108.ts
+++ b/data/Mega Evolution/Pitch Black/108.ts
@@ -1,0 +1,36 @@
+import { Card } from "../../../interfaces"
+import Set from "../Pitch Black"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Gladion's Final Battle",
+		fr: "Combat Final de Gladio",
+		es: "Combate Final de Gladio",
+		'es-mx': "Combate Final de Gladion",
+		de: "Gladios Finalkampf"
+	},
+
+	illustrator: "akagi",
+	rarity: "Ultra Rare",
+	category: "Trainer",
+	trainerType: "Supporter",
+	regulationMark: "J",
+
+	effect: {
+		en: "You can play this card only if it is the last card in your hand. During this turn, attacks used by your Pokémon that do not have a Rule Box do 80 more damage to your opponent's Active Pokémon (before applying Weakness and Resistance) (Pokémon ex, Pokémon V etc. have Rule Boxes)"
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 895893,
+				tcgplayer: 704865
+			}
+		},
+	],
+}
+
+export default card

--- a/data/Mega Evolution/Pitch Black/109.ts
+++ b/data/Mega Evolution/Pitch Black/109.ts
@@ -1,0 +1,36 @@
+import { Card } from "../../../interfaces"
+import Set from "../Pitch Black"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Gwynn",
+		fr: "Albia",
+		es: "Inma",
+		'es-mx': "Inma",
+		de: "Gwynn"
+	},
+
+	illustrator: "nagimiso",
+	rarity: "Ultra Rare",
+	category: "Trainer",
+	trainerType: "Supporter",
+	regulationMark: "J",
+
+	effect: {
+		en: "Discard up to 2 Pokémon that don't have a Rule Box from your hand, and draw 3 cards for each card you discarded n this way. (Pokémon ex, Pokémon V, etc. have Rule Boxes)"
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 895894,
+				tcgplayer: 704866
+			}
+		},
+	],
+}
+
+export default card

--- a/data/Mega Evolution/Pitch Black/110.ts
+++ b/data/Mega Evolution/Pitch Black/110.ts
@@ -1,0 +1,36 @@
+import { Card } from "../../../interfaces"
+import Set from "../Pitch Black"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Iron Defender",
+		fr: "Défense de Fer",
+		es: "Defensor Férreo",
+		'es-mx': "Defensa Férrea",
+		de: "Eisendefensive"
+	},
+
+	illustrator: "Studio Bora Inc.",
+	rarity: "Ultra Rare",
+	category: "Trainer",
+	trainerType: "Item",
+	regulationMark: "I",
+
+	effect: {
+		en: "During your opponent's next turn, your Metal type Pokémon take 30 less damage from attacks from your opponent's Pokémon (including Pokémon put in play after you play this card)."
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 895895,
+				tcgplayer: 704867
+			}
+		},
+	],
+}
+
+export default card

--- a/data/Mega Evolution/Pitch Black/111.ts
+++ b/data/Mega Evolution/Pitch Black/111.ts
@@ -1,0 +1,36 @@
+import { Card } from "../../../interfaces"
+import Set from "../Pitch Black"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Misty's Vitality",
+		fr: "Vitalité d'Ondine",
+		es: "Vitalidad de Misty",
+		'es-mx': "Vitalidad de Misty",
+		de: "Mistys Vitalität"
+	},
+
+	illustrator: "En Morikura",
+	rarity: "Ultra Rare",
+	category: "Trainer",
+	trainerType: "Supporter",
+	regulationMark: "J",
+
+	effect: {
+		en: "Search your deck for up to 4 Basic Water Energy and attach them to 1 of your Pokémon, then shuffle your deck. Your turn ends."
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 895896,
+				tcgplayer: 704868
+			}
+		},
+	],
+}
+
+export default card

--- a/data/Mega Evolution/Pitch Black/112.ts
+++ b/data/Mega Evolution/Pitch Black/112.ts
@@ -1,0 +1,36 @@
+import { Card } from "../../../interfaces"
+import Set from "../Pitch Black"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Rust Syndicate Grunt",
+		fr: "Sbire du Clan Dérouillard",
+		es: "Recluta del Clan Corrosión",
+		'es-mx': "Recluta del Clan Corrosión",
+		de: "Rüpel vom Corrosio-Clan"
+	},
+
+	illustrator: "Teeziro",
+	rarity: "Ultra Rare",
+	category: "Trainer",
+	trainerType: "Supporter",
+	regulationMark: "J",
+
+	effect: {
+		en: "You can use this card only if any of your Pokémon were Knocked Out during your opponent's last turn. Discard 1 Energy from 1 of your opponent's Pokémon."
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 895897,
+				tcgplayer: 704869
+			}
+		},
+	],
+}
+
+export default card

--- a/data/Mega Evolution/Pitch Black/113.ts
+++ b/data/Mega Evolution/Pitch Black/113.ts
@@ -1,0 +1,36 @@
+import { Card } from "../../../interfaces"
+import Set from "../Pitch Black"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Tremendous Bomb",
+		fr: "Bombe Géniale",
+		es: "Bomba Formidable",
+		'es-mx': "Tremenda Bomba",
+		de: "Ungeheure Bombe"
+	},
+
+	illustrator: "inose yukie",
+	rarity: "Ultra Rare",
+	category: "Trainer",
+	trainerType: "Tool",
+	regulationMark: "J",
+
+	effect: {
+		en: "If the Active Pokémon this card is attached to is not a Mega Pokémon ex and takes 240 damage or more from an attack from your opponent's Mega Pokémon ex, put 12 damage counters on the attacking Pokémon and discard this card."
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 895898,
+				tcgplayer: 704870
+			}
+		},
+	],
+}
+
+export default card

--- a/data/Mega Evolution/Pitch Black/114.ts
+++ b/data/Mega Evolution/Pitch Black/114.ts
@@ -1,0 +1,69 @@
+import { Card } from "../../../interfaces"
+import Set from "../Pitch Black"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Mega Zeraora ex",
+		fr: "Méga-Zeraora-ex",
+		es: "Mega-Zeraora ex",
+		'es-mx': "Mega-Zeraora ex",
+		de: "Mega-Zeraora-ex"
+	},
+
+	illustrator: "GIDORA",
+	rarity: "Special illustration rare",
+	category: "Pokemon",
+	dexId: [807],
+	hp: 270,
+	types: ["Lightning"],
+	stage: "Basic",
+	suffix: "EX",
+
+	attacks: [{
+		name: {
+			en: "Thunderous Fist"
+		},
+
+		cost: ["Lightning"],
+
+		damage: "60x",
+
+		effect: {
+			en: "This attack does 60 damage for each Lightning Energy attached to this Pokémon."
+		}
+	}, {
+		name: {
+			en: "Zepto Turn"
+		},
+
+		cost: ["Lightning", "Lightning", "Lightning"],
+
+		damage: 150,
+
+		effect: {
+			en: "Switch this Pokémon with one of your Benched Pokémon."
+		}
+	}],
+
+	weaknesses: [{
+		type: "Fighting",
+		value: "×2"
+	}],
+
+	retreat: 1,
+	regulationMark: "J",
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 895899,
+				tcgplayer: 704871
+			}
+		},
+	],
+}
+
+export default card

--- a/data/Mega Evolution/Pitch Black/115.ts
+++ b/data/Mega Evolution/Pitch Black/115.ts
@@ -1,0 +1,78 @@
+import { Card } from "../../../interfaces"
+import Set from "../Pitch Black"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Mega Chandelure ex",
+		fr: "Méga-Lugulabre-ex",
+		es: "Mega-Chandelure ex",
+		'es-mx': "Mega-Chandelure ex",
+		de: "Mega-Skelabra-ex"
+	},
+
+	illustrator: "REND",
+	rarity: "Special illustration rare",
+	category: "Pokemon",
+	dexId: [609],
+	hp: 350,
+	types: ["Psychic"],
+
+	evolveFrom: {
+		en: "Lampent"
+	},
+
+	stage: "Stage2",
+	suffix: "EX",
+
+	abilities: [{
+		type: "Ability",
+
+		name: {
+			en: "Binding Flame"
+		},
+
+		effect: {
+			en: "Your opponent's Pokémon's Retreat Cost is 1 more"
+		}
+	}],
+
+	attacks: [{
+		name: {
+			en: "Phantom Maze"
+		},
+
+		cost: ["Psychic", "Psychic"],
+
+		damage: "130+",
+
+		effect: {
+			en: "This attack does 50 more damage for each Energy in your opponent's Active Pokémon's Retreat Cost."
+		}
+	}],
+
+	weaknesses: [{
+		type: "Darkness",
+		value: "×2"
+	}],
+	resistances: [{
+		type: "Fighting",
+		value: "-30"
+	}],
+
+	retreat: 2,
+	regulationMark: "J",
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 895900,
+				tcgplayer: 704872
+			}
+		},
+	],
+}
+
+export default card

--- a/data/Mega Evolution/Pitch Black/116.ts
+++ b/data/Mega Evolution/Pitch Black/116.ts
@@ -1,0 +1,67 @@
+import { Card } from "../../../interfaces"
+import Set from "../Pitch Black"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Mega Darkrai ex",
+		fr: "Méga-Darkrai-ex",
+		es: "Mega-Darkrai ex",
+		'es-mx': "Mega-Darkrai ex",
+		de: "Mega-Darkrai-ex"
+	},
+
+	illustrator: "AKIRA EGAWA",
+	rarity: "Special illustration rare",
+	category: "Pokemon",
+	dexId: [491],
+	hp: 280,
+	types: ["Darkness"],
+	stage: "Basic",
+	suffix: "EX",
+
+	attacks: [{
+		name: {
+			en: "Dusk Raid"
+		},
+
+		cost: ["Darkness", "Darkness"],
+
+		damage: "110+",
+
+		effect: {
+			en: "If any of your Benched Pokémon have any damage counters on them, this attack does 110 more damage."
+		}
+	}, {
+		name: {
+			en: "Abyss Eye"
+		},
+
+		cost: ["Darkness", "Darkness", "Darkness"],
+
+		effect: {
+			en: "If your opponent's Active Pokémon is affected by any Special Condition, it is now Knocked Out."
+		}
+	}],
+
+	weaknesses: [{
+		type: "Grass",
+		value: "×2"
+	}],
+
+	retreat: 2,
+	regulationMark: "J",
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 895901,
+				tcgplayer: 704873
+			}
+		},
+	],
+}
+
+export default card

--- a/data/Mega Evolution/Pitch Black/117.ts
+++ b/data/Mega Evolution/Pitch Black/117.ts
@@ -1,0 +1,67 @@
+import { Card } from "../../../interfaces"
+import Set from "../Pitch Black"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Morpeko ex",
+		fr: "Morpeko-ex",
+		es: "Morpeko ex",
+		'es-mx': "Morpeko ex",
+		de: "Morpeko-ex"
+	},
+
+	illustrator: "NC Empire",
+	rarity: "Special illustration rare",
+	category: "Pokemon",
+	dexId: [877],
+	hp: 180,
+	types: ["Darkness"],
+	stage: "Basic",
+	suffix: "EX",
+
+	attacks: [{
+		name: {
+			en: "Wheel Draw"
+		},
+
+		cost: ["Darkness"],
+
+		effect: {
+			en: "Shuffle your hand into your deck, then draw 6 cards."
+		}
+	}, {
+		name: {
+			en: "Hangry Blaster"
+		},
+
+		cost: ["Darkness", "Darkness"],
+
+		damage: "40+",
+
+		effect: {
+			en: "This attack does 40 more damage for each damage counter on this Pokémon"
+		}
+	}],
+
+	weaknesses: [{
+		type: "Grass",
+		value: "×2"
+	}],
+
+	retreat: 1,
+	regulationMark: "J",
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 895902,
+				tcgplayer: 704874
+			}
+		},
+	],
+}
+
+export default card

--- a/data/Mega Evolution/Pitch Black/118.ts
+++ b/data/Mega Evolution/Pitch Black/118.ts
@@ -1,0 +1,36 @@
+import { Card } from "../../../interfaces"
+import Set from "../Pitch Black"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Gladion's Final Battle",
+		fr: "Combat Final de Gladio",
+		es: "Combate Final de Gladio",
+		'es-mx': "Combate Final de Gladion",
+		de: "Gladios Finalkampf"
+	},
+
+	illustrator: "DOM",
+	rarity: "Special illustration rare",
+	category: "Trainer",
+	trainerType: "Supporter",
+	regulationMark: "J",
+
+	effect: {
+		en: "You can play this card only if it is the last card in your hand. During this turn, attacks used by your Pokémon that do not have a Rule Box do 80 more damage to your opponent's Active Pokémon (before applying Weakness and Resistance) (Pokémon ex, Pokémon V etc. have Rule Boxes)"
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 895903,
+				tcgplayer: 704875
+			}
+		},
+	],
+}
+
+export default card

--- a/data/Mega Evolution/Pitch Black/119.ts
+++ b/data/Mega Evolution/Pitch Black/119.ts
@@ -1,0 +1,36 @@
+import { Card } from "../../../interfaces"
+import Set from "../Pitch Black"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Gwynn",
+		fr: "Albia",
+		es: "Inma",
+		'es-mx': "Inma",
+		de: "Gwynn"
+	},
+
+	illustrator: "Naoki Saito",
+	rarity: "Special illustration rare",
+	category: "Trainer",
+	trainerType: "Supporter",
+	regulationMark: "J",
+
+	effect: {
+		en: "Discard up to 2 Pokémon that don't have a Rule Box from your hand, and draw 3 cards for each card you discarded n this way. (Pokémon ex, Pokémon V, etc. have Rule Boxes)"
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 895904,
+				tcgplayer: 704876
+			}
+		},
+	],
+}
+
+export default card

--- a/data/Mega Evolution/Pitch Black/120.ts
+++ b/data/Mega Evolution/Pitch Black/120.ts
@@ -1,0 +1,67 @@
+import { Card } from "../../../interfaces"
+import Set from "../Pitch Black"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Mega Darkrai ex",
+		fr: "Méga-Darkrai-ex",
+		es: "Mega-Darkrai ex",
+		'es-mx': "Mega-Darkrai ex",
+		de: "Mega-Darkrai-ex"
+	},
+
+	illustrator: "5ban Graphics",
+	rarity: "Mega Hyper Rare",
+	category: "Pokemon",
+	dexId: [491],
+	hp: 280,
+	types: ["Darkness"],
+	stage: "Basic",
+	suffix: "EX",
+
+	attacks: [{
+		name: {
+			en: "Dusk Raid"
+		},
+
+		cost: ["Darkness", "Darkness"],
+
+		damage: "110+",
+
+		effect: {
+			en: "If any of your Benched Pokémon have any damage counters on them, this attack does 110 more damage."
+		}
+	}, {
+		name: {
+			en: "Abyss Eye"
+		},
+
+		cost: ["Darkness", "Darkness", "Darkness"],
+
+		effect: {
+			en: "If your opponent's Active Pokémon is affected by any Special Condition, it is now Knocked Out."
+		}
+	}],
+
+	weaknesses: [{
+		type: "Grass",
+		value: "×2"
+	}],
+
+	retreat: 2,
+	regulationMark: "J",
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 895905,
+				tcgplayer: 704877
+			}
+		},
+	],
+}
+
+export default card


### PR DESCRIPTION
## What

Adds the complete international set **me05 Pitch Black**, released 2026-07-17 — the English adaptation of the Japanese `M5` Abyss Eye (already in the repo as `data-asia/M/M5`):

- `data/Mega Evolution/Pitch Black.ts` — set definition (84 official cards)
- `data/Mega Evolution/Pitch Black/001.ts` … `120.ts` — all 120 cards (84 regular: 71 Pokémon (10 of them ex), 11 Trainers, 2 Energy; 36 secret rares: 11 AR, 18 SR, 6 SAR, 1 Mega Hyper Rare)

## Data sources

- **serebii.net**: English card text (attacks, abilities, Trainer/Energy effects), HP, energy costs, weaknesses/resistances, retreat, illustrators, and the card scans
- **bulbapedia.bulbagarden.net**: English card names, regulation marks, Trainer subtypes, rarities
- **pokecardex.com**: French & German names, `thirdParty.cardmarket` product ids
- **pokewiki.de**: German names (full coverage incl. Trainers/Energy)
- **wikidex.net**: Spanish names — both `es` (Spain) and `es-mx` (Latin America) prints
- **tcgcsv.com**: `thirdParty.tcgplayer` product ids
- **data-asia/M** (this repo): stage and `evolveFrom` from the Japanese twin cards

Cardmarket ids 120/120 (895785–895905); tcgplayer ids 120/120 (704758–704877).

## Notes

- Follows the file format and conventions of the international Mega Evolution sets (Phantasmal Flames / Chaos Rising)
- Localized card **names** are complete in `en`/`fr`/`de`/`es`/`es-mx` (Pokémon, Trainers and Energy)
- Card **text** (attacks, abilities, Trainer/Energy effects) is currently English only. Localized `fr/de/es/it/pt` effect text and the English flavor `description` are not yet available anywhere for this set on release day — they will follow in a second pass once the official Pokémon TCG Live data (malie.io / LimitlessTCG) covers Pitch Black
- `es-mx` carries the Latin-American print names where they differ from Spain's (e.g. `Combate Final de Gladion` vs `Combate Final de Gladio`)
- Reverse-holo variants share the base card's cardmarket/tcgplayer id, like `data/Mega Evolution/Phantasmal Flames`
- Mega Pokémon ex are `stage: "Basic"`; fossil Stage 1 Pokémon (Cranidos, Shieldon) evolve from the Antique Skull/Armor Fossil, like the Scarlet & Violet fossils
- All 120 data files type-check against `interfaces.d.ts` (`tsc --noEmit`), and the set compiles cleanly through `server/` `bun run compile`
- _Card-image links to follow (self-hosted)._
