### PR TITLE
data: PBL localized card text & flavor (de/es/es-mx)

### DIFF
--- a/data/Mega Evolution/Pitch Black/001.ts
+++ b/data/Mega Evolution/Pitch Black/001.ts
@@ -4,6 +4,11 @@ import Set from "../Pitch Black"
 const card: Card = {
 	set: Set,
 
+	description: {
+		en: "Delicious fruits grew out from around its neck because it always ate the same kind of fruit.",
+		de: "Da es immer nur die gleichen Früchte aß, begannen köstliche Früchte an seinem Hals zu wachsen."
+	},
+
 	name: {
 		en: "Tropius",
 		fr: "Tropius",
@@ -22,17 +27,20 @@ const card: Card = {
 
 	attacks: [{
 		name: {
-			en: "Fruity Aroma"
+			en: "Fruity Aroma",
+			de: "Fruchtiges Aroma"
 		},
 
 		cost: ["Colorless"],
 
 		effect: {
-			en: "Look at the top 6 cards of your deck. Reveal as many Pokémon as you like from there and put them in your hand. Then, shuffle the rest of the cards back into the deck"
+			en: "Look at the top 6 cards of your deck. Reveal as many Pokémon as you like from there and put them in your hand. Then, shuffle the rest of the cards back into the deck",
+			de: "Schau dir die obersten 6 Karten deines Decks an. Du kannst beliebig viele Pokémon, die du dort findest, deinem Gegner zeigen und auf deine Hand nehmen. Mische die anderen Karten zurück in dein Deck."
 		}
 	}, {
 		name: {
-			en: "Solar Beam"
+			en: "Solar Beam",
+			de: "Solarstrahl"
 		},
 
 		cost: ["Grass", "Colorless"],

--- a/data/Mega Evolution/Pitch Black/002.ts
+++ b/data/Mega Evolution/Pitch Black/002.ts
@@ -4,6 +4,11 @@ import Set from "../Pitch Black"
 const card: Card = {
 	set: Set,
 
+	description: {
+		en: "It spits sticky thread and winds them around branches, then swings nimbly from tree to tree in a pendulum-like motion.",
+		de: "Es spuckt klebrige Fäden, die es um Äste wickelt, um sich dann mit pendelnden Bewegungen geschickt von Baum zu Baum zu schwingen."
+	},
+
 	name: {
 		en: "Grubbin",
 		fr: "Larvibule",
@@ -22,13 +27,15 @@ const card: Card = {
 
 	attacks: [{
 		name: {
-			en: "String Shot"
+			en: "String Shot",
+			de: "Fadenschuss"
 		},
 
 		cost: ["Colorless"],
 
 		effect: {
-			en: "Flip a coin. If heads, your opponent's Active Pokémon is now Paralyzed"
+			en: "Flip a coin. If heads, your opponent's Active Pokémon is now Paralyzed",
+			de: "Wirf 1 Münze. Bei Kopf ist das Aktive Pokémon deines Gegners jetzt paralysiert."
 		}
 	}],
 

--- a/data/Mega Evolution/Pitch Black/003.ts
+++ b/data/Mega Evolution/Pitch Black/003.ts
@@ -4,6 +4,11 @@ import Set from "../Pitch Black"
 const card: Card = {
 	set: Set,
 
+	description: {
+		en: "Many Trainers give their Fomantis their own flowerpots so they can sunbathe in peace and quiet.",
+		de: "Viele Trainer geben Imantis einen eigenen Blumentopf, damit es ungestört sonnenbaden kann."
+	},
+
 	name: {
 		en: "Fomantis",
 		fr: "Mimantis",
@@ -22,7 +27,8 @@ const card: Card = {
 
 	attacks: [{
 		name: {
-			en: "Reckless Charge"
+			en: "Reckless Charge",
+			de: "Waghalsiger Sturmangriff"
 		},
 
 		cost: ["Grass"],
@@ -30,7 +36,8 @@ const card: Card = {
 		damage: 30,
 
 		effect: {
-			en: "This Pokémon also does 10 damage to itself"
+			en: "This Pokémon also does 10 damage to itself",
+			de: "Dieses Pokémon fügt auch sich selbst 10 Schadenspunkte zu."
 		}
 	}],
 

--- a/data/Mega Evolution/Pitch Black/004.ts
+++ b/data/Mega Evolution/Pitch Black/004.ts
@@ -28,7 +28,8 @@ const card: Card = {
 
 	attacks: [{
 		name: {
-			en: "Lively Cutter"
+			en: "Lively Cutter",
+			de: "Rasante Schneide"
 		},
 
 		cost: ["Grass"],
@@ -36,7 +37,8 @@ const card: Card = {
 		damage: "60+",
 
 		effect: {
-			en: "If this Pokémon recovered any HP this turn, this attack does 200 more damage."
+			en: "If this Pokémon recovered any HP this turn, this attack does 200 more damage.",
+			de: "Wenn dieses Pokémon während dieses Zuges geheilt wurde, fügt diese Attacke 200 Schadenspunkte mehr zu."
 		}
 	}, {
 		name: {
@@ -48,7 +50,8 @@ const card: Card = {
 		damage: 140,
 
 		effect: {
-			en: "During your opponent's next turn, this Pokémon takes 50 less damage from attacks."
+			en: "During your opponent's next turn, this Pokémon takes 50 less damage from attacks.",
+			de: "Während des nächsten Zuges deines Gegners werden diesem Pokémon durch Attacken 50 Schadenspunkte weniger zugefügt (nachdem Schwäche und Resistenz verrechnet wurden)."
 		}
 	}],
 

--- a/data/Mega Evolution/Pitch Black/005.ts
+++ b/data/Mega Evolution/Pitch Black/005.ts
@@ -4,6 +4,11 @@ import Set from "../Pitch Black"
 const card: Card = {
 	set: Set,
 
+	description: {
+		en: "Poltchageist looks like a regional form of Sinistea, but it was recently discovered that the two Pokémon are entirely unrelated.",
+		de: "Es sieht aus wie eine Regionalform von Fatalitee, doch vor Kurzem fand man heraus, dass zwischen den beiden Pokémon keine Verbindung besteht."
+	},
+
 	name: {
 		en: "Poltchageist",
 		fr: "Poltchageist",
@@ -24,23 +29,35 @@ const card: Card = {
 		type: "Ability",
 
 		name: {
-			en: "Hide 'n' Sneak"
+			en: "Hide 'n' Sneak",
+			es: "Escondite a Hurtadillas",
+			'es-mx': "Escondidas Furtivas",
+			de: "Listiges Versteckspiel"
 		},
 
 		effect: {
-			en: "Prevent all effects of opponent's Attacks and Abilities done to this Pokémon."
+			en: "Prevent all effects of opponent's Attacks and Abilities done to this Pokémon.",
+			es: "Se evitan todos los efectos de los ataques y las habilidades de los Pokémon de tu rival infligidos a este Pokémon. (El daño no es un efecto).",
+			'es-mx': "Se evitan todos los efectos de los ataques y las habilidades de los Pokémon de tu rival infligidos a este Pokémon. (El daño no es un efecto).",
+			de: "Verhindere alle Effekte von Attacken und Fähigkeiten der Pokémon deines Gegners, die diesem Pokémon zugefügt werden. (Schaden ist kein Effekt.)"
 		}
 	}],
 
 	attacks: [{
 		name: {
-			en: "Furitive Drop"
+			en: "Furitive Drop",
+			es: "Caída Furtiva",
+			'es-mx': "Caída Furtiva",
+			de: "Hinterhältiger Fall"
 		},
 
 		cost: ["Colorless"],
 
 		effect: {
-			en: "Put 1 damage counter on your opponent's Active Pokémon"
+			en: "Put 1 damage counter on your opponent's Active Pokémon",
+			es: "Pon 1 contador de daño en el Pokémon Activo de tu rival.",
+			'es-mx': "Pon 1 contador de daño en el Pokémon Activo de tu rival.",
+			de: "Lege 1 Schadensmarke auf das Aktive Pokémon deines Gegners."
 		}
 	}],
 

--- a/data/Mega Evolution/Pitch Black/006.ts
+++ b/data/Mega Evolution/Pitch Black/006.ts
@@ -4,6 +4,11 @@ import Set from "../Pitch Black"
 const card: Card = {
 	set: Set,
 
+	description: {
+		en: "It prefers cool, dark places, such as the back of a shelf or the space beneath a home's floorboards. It wanders in search of prey after sunset.",
+		de: "Es hält sich gern an dunklen und kalten Orten auf wie etwa unter Fußböden oder hinter Regalen. Nach Sonnenuntergang geht es auf Beutejagd."
+	},
+
 	name: {
 		en: "Sinistcha",
 		fr: "Théffroyable",
@@ -29,23 +34,35 @@ const card: Card = {
 		type: "Ability",
 
 		name: {
-			en: "Hide 'n' Sneak"
+			en: "Hide 'n' Sneak",
+			es: "Escondite a Hurtadillas",
+			'es-mx': "Escondidas Furtivas",
+			de: "Listiges Versteckspiel"
 		},
 
 		effect: {
-			en: "Prevent all effects of opponent's Attacks and Abilities done to this Pokémon."
+			en: "Prevent all effects of opponent's Attacks and Abilities done to this Pokémon.",
+			es: "Se evitan todos los efectos de los ataques y las habilidades de los Pokémon de tu rival infligidos a este Pokémon. (El daño no es un efecto).",
+			'es-mx': "Se evitan todos los efectos de los ataques y las habilidades de los Pokémon de tu rival infligidos a este Pokémon. (El daño no es un efecto).",
+			de: "Verhindere alle Effekte von Attacken und Fähigkeiten der Pokémon deines Gegners, die diesem Pokémon zugefügt werden. (Schaden ist kein Effekt.)"
 		}
 	}],
 
 	attacks: [{
 		name: {
-			en: "Matcha Spin"
+			en: "Matcha Spin",
+			es: "Giro Matcha",
+			'es-mx': "Giro de Matcha",
+			de: "Matchawirbel"
 		},
 
 		cost: ["Colorless"],
 
 		effect: {
-			en: "If you have 6 or more Pokémon with the Hide 'n' Sneak Ability in your discard pile, put 4 damage counters on each of your opponent's Pokémon."
+			en: "If you have 6 or more Pokémon with the Hide 'n' Sneak Ability in your discard pile, put 4 damage counters on each of your opponent's Pokémon.",
+			es: "Si tienes en tu pila de descartes 6 Pokémon o más que tengan la habilidad Escondite a Hurtadillas, pon 4 contadores de daño en cada uno de los Pokémon de tu rival.",
+			'es-mx': "Si tienes en tu pila de descartes 6 Pokémon o más que tengan la habilidad Escondidas Furtivas, pon 4 contadores de daño en cada uno de los Pokémon de tu rival.",
+			de: "Wenn du 6 oder mehr Pokémon, die die Fähigkeit Listiges Versteckspiel haben, in deinem Ablagestapel hast, lege 4 Schadensmarken auf jedes Pokémon deines Gegners."
 		}
 	}],
 

--- a/data/Mega Evolution/Pitch Black/007.ts
+++ b/data/Mega Evolution/Pitch Black/007.ts
@@ -4,6 +4,11 @@ import Set from "../Pitch Black"
 const card: Card = {
 	set: Set,
 
+	description: {
+		en: "It dwells in volcanic caves. It digs in with its cross-shaped feet to crawl on ceilings and walls.",
+		de: "Es lebt in vulkanischen Höhlen. Mit seinen kreuzförmigen Klauen kann es sogar an der Decke laufen."
+	},
+
 	name: {
 		en: "Heatran",
 		fr: "Heatran",
@@ -22,17 +27,20 @@ const card: Card = {
 
 	attacks: [{
 		name: {
-			en: "Singe"
+			en: "Singe",
+			de: "Versengung"
 		},
 
 		cost: ["Fire"],
 
 		effect: {
-			en: "Your opponent's Active Pokémon is now Burned"
+			en: "Your opponent's Active Pokémon is now Burned",
+			de: "Das Aktive Pokémon deines Gegners ist jetzt verbrannt."
 		}
 	}, {
 		name: {
-			en: "Lava Wall"
+			en: "Lava Wall",
+			de: "Lavawand"
 		},
 
 		cost: ["Fire", "Fire", "Colorless"],
@@ -40,7 +48,8 @@ const card: Card = {
 		damage: 120,
 
 		effect: {
-			en: "During your next turn, this Pokémon will receive no damage from attacks by your opponent's Burned Pokémon"
+			en: "During your next turn, this Pokémon will receive no damage from attacks by your opponent's Burned Pokémon",
+			de: "Verhindere während des nächsten Zuges deines Gegners allen Schaden, der diesem Pokémon durch Attacken von verbrannten Pokémon zugefügt wird."
 		}
 	}],
 

--- a/data/Mega Evolution/Pitch Black/008.ts
+++ b/data/Mega Evolution/Pitch Black/008.ts
@@ -28,17 +28,20 @@ const card: Card = {
 
 	attacks: [{
 		name: {
-			en: "Trick Portal"
+			en: "Trick Portal",
+			de: "Trickportal"
 		},
 
 		cost: ["Fire"],
 
 		effect: {
-			en: "Look at the top 9 cards of your deck. You may choose any number of Pokemon you find there and put them onto your Bench. Shuffle the other cards back into your deck."
+			en: "Look at the top 9 cards of your deck. You may choose any number of Pokemon you find there and put them onto your Bench. Shuffle the other cards back into your deck.",
+			de: "Schau dir die obersten 9 Karten deines Decks an. Du kannst beliebig viele Pokémon, die du dort findest, auf deine Bank legen. Mische die anderen Karten zurück in dein Deck."
 		}
 	}, {
 		name: {
-			en: "Eerie Glow"
+			en: "Eerie Glow",
+			de: "Gruselglühen"
 		},
 
 		cost: ["Fire", "Colorless", "Colorless"],
@@ -46,7 +49,8 @@ const card: Card = {
 		damage: 200,
 
 		effect: {
-			en: "Your opponent's Active Pokémon is now Burned and Confused."
+			en: "Your opponent's Active Pokémon is now Burned and Confused.",
+			de: "Das Aktive Pokémon deines Gegners ist jetzt verbrannt und verwirrt."
 		}
 	}],
 

--- a/data/Mega Evolution/Pitch Black/009.ts
+++ b/data/Mega Evolution/Pitch Black/009.ts
@@ -4,6 +4,11 @@ import Set from "../Pitch Black"
 const card: Card = {
 	set: Set,
 
+	description: {
+		en: "It stores flammable gas in its body and uses it to generate heat. The yellow sections on its belly get particularly hot.",
+		de: "Mit dem entzündlichen Gas in seinem Körper erzeugt es Hitze. Die gelben Stellen an seinem Bauch werden besonders heiß."
+	},
+
 	name: {
 		en: "Sizzlipede",
 		fr: "Grillepattes",
@@ -22,17 +27,20 @@ const card: Card = {
 
 	attacks: [{
 		name: {
-			en: "Controlled Burn"
+			en: "Controlled Burn",
+			de: "Brandrodung"
 		},
 
 		cost: ["Fire"],
 
 		effect: {
-			en: "Discard the top card from your opponent's deck"
+			en: "Discard the top card from your opponent's deck",
+			de: "Lege die oberste Karte des Decks deines Gegners auf seinen Ablagestapel."
 		}
 	}, {
 		name: {
-			en: "Bug Out"
+			en: "Bug Out",
+			de: "Käferkomplott"
 		},
 
 		cost: ["Colorless", "Colorless", "Colorless"],
@@ -40,7 +48,8 @@ const card: Card = {
 		damage: "50x",
 
 		effect: {
-			en: "Reveal the bottom 7 cards of your deck. This attack does 50 damage for each Pokémon with the Bug Panic move. Shuffle the Pokémon cards back into your deck and discard the other cards."
+			en: "Reveal the bottom 7 cards of your deck. This attack does 50 damage for each Pokémon with the Bug Panic move. Shuffle the Pokémon cards back into your deck and discard the other cards.",
+			de: "Zeige deinem Gegner die untersten 7 Karten deines Decks, und diese Attacke fügt für jedes Pokémon, das du dort findest und das die Attacke Käferkomplott hat, 50 Schadenspunkte zu. Mische anschließend alle gezeigten Pokémon zurück in dein Deck. Lege die anderen Karten auf deinen Ablagestapel."
 		}
 	}],
 

--- a/data/Mega Evolution/Pitch Black/010.ts
+++ b/data/Mega Evolution/Pitch Black/010.ts
@@ -4,6 +4,11 @@ import Set from "../Pitch Black"
 const card: Card = {
 	set: Set,
 
+	description: {
+		en: "When it heats up, its body temperature reaches about 1,500 degrees Fahrenheit. It lashes its body like a whip and launches itself at enemies.",
+		de: "Wenn es Hitze erzeugt, beträgt seine Temperatur etwa 800 ºC. Es bewegt seinen Körper wie eine Peitsche, um dann den Gegner anzuspringen."
+	},
+
 	name: {
 		en: "Centiskorch",
 		fr: "Scolocendre",
@@ -27,17 +32,20 @@ const card: Card = {
 
 	attacks: [{
 		name: {
-			en: "Controlled Burn"
+			en: "Controlled Burn",
+			de: "Brandrodung"
 		},
 
 		cost: ["Fire"],
 
 		effect: {
-			en: "Discard the top 2 cards from your opponent's deck"
+			en: "Discard the top 2 cards from your opponent's deck",
+			de: "Lege die obersten 2 Karten des Decks deines Gegners auf seinen Ablagestapel."
 		}
 	}, {
 		name: {
-			en: "Heat Tackle"
+			en: "Heat Tackle",
+			de: "Hitze-Tackle"
 		},
 
 		cost: ["Fire", "Colorless", "Colorless", "Colorless"],
@@ -45,7 +53,8 @@ const card: Card = {
 		damage: 160,
 
 		effect: {
-			en: "This Pokémon also does 30 damage to itself"
+			en: "This Pokémon also does 30 damage to itself",
+			de: "Dieses Pokémon fügt auch sich selbst 30 Schadenspunkte zu."
 		}
 	}],
 

--- a/data/Mega Evolution/Pitch Black/011.ts
+++ b/data/Mega Evolution/Pitch Black/011.ts
@@ -4,6 +4,11 @@ import Set from "../Pitch Black"
 const card: Card = {
 	set: Set,
 
+	description: {
+		en: "Its firepower increases when it fights, reaching over 1,800 degrees Fahrenheit. It likes berries that are rich in fat.",
+		de: "Im Kampf erreichen seine Flammen Temperaturen von bis zu 1000 ℃. Es hat eine Vorliebe für Beeren mit hohem Fettgehalt."
+	},
+
 	name: {
 		en: "Charcadet",
 		fr: "Charbambin",
@@ -22,7 +27,8 @@ const card: Card = {
 
 	attacks: [{
 		name: {
-			en: "Best Punch"
+			en: "Best Punch",
+			de: "Bester Schlag"
 		},
 
 		cost: ["Fire"],
@@ -30,7 +36,8 @@ const card: Card = {
 		damage: 40,
 
 		effect: {
-			en: "Flip a coin. If tails, this attack does nothing."
+			en: "Flip a coin. If tails, this attack does nothing.",
+			de: "Wirf 1 Münze. Bei Zahl hat diese Attacke keine Auswirkungen."
 		}
 	}],
 

--- a/data/Mega Evolution/Pitch Black/012.ts
+++ b/data/Mega Evolution/Pitch Black/012.ts
@@ -4,6 +4,11 @@ import Set from "../Pitch Black"
 const card: Card = {
 	set: Set,
 
+	description: {
+		en: "This Pokémon clads itself in armor that has been fortified by psychic and fire energy, and it shoots blazing fireballs.",
+		de: "Es trägt eine Rüstung, die mit Psycho- sowie Feuer-Energie verstärkt wurde, und verschießt glühend heiße Feuerbälle."
+	},
+
 	name: {
 		en: "Armarouge",
 		fr: "Carmadura",
@@ -27,7 +32,10 @@ const card: Card = {
 
 	attacks: [{
 		name: {
-			en: "Flame Legion"
+			en: "Flame Legion",
+			es: "Legión de Llamas",
+			'es-mx': "Legión de Fuego",
+			de: "Flammenlegion"
 		},
 
 		cost: ["Fire"],
@@ -35,7 +43,10 @@ const card: Card = {
 		damage: "40+",
 
 		effect: {
-			en: "This attack does 40 more damage for each of your Benched Pokémon that have Fire Energy attached"
+			en: "This attack does 40 more damage for each of your Benched Pokémon that have Fire Energy attached",
+			es: "Este ataque hace 40 puntos de daño más por cada uno de tus Pokémon en Banca que tengan alguna Energía {R} unida.",
+			'es-mx': "Este ataque hace 40 puntos de daño más por cada uno de tus Pokémon en Banca que tengan alguna Energía {R} unida.",
+			de: "Diese Attacke fügt für jedes Pokémon auf deiner Bank, an das mindestens 1 {R}-Energie angelegt ist, 40 Schadenspunkte mehr zu."
 		}
 	}],
 

--- a/data/Mega Evolution/Pitch Black/013.ts
+++ b/data/Mega Evolution/Pitch Black/013.ts
@@ -4,6 +4,11 @@ import Set from "../Pitch Black"
 const card: Card = {
 	set: Set,
 
+	description: {
+		en: "Its dorsal, pectoral, and tail fins wave elegantly in water. That is why it is known as the Water Dancer.",
+		de: "Seine Brust-, Rücken- und Schwanzflossen bewegen sich anmutig. Daher nennt man es den „Wassertänzer\"."
+	},
+
 	name: {
 		en: "Goldeen",
 		fr: "Poissirène",
@@ -22,7 +27,8 @@ const card: Card = {
 
 	attacks: [{
 		name: {
-			en: "Pierce"
+			en: "Pierce",
+			de: "Durchbohren"
 		},
 
 		cost: ["Colorless", "Colorless"],

--- a/data/Mega Evolution/Pitch Black/014.ts
+++ b/data/Mega Evolution/Pitch Black/014.ts
@@ -4,6 +4,11 @@ import Set from "../Pitch Black"
 const card: Card = {
 	set: Set,
 
+	description: {
+		en: "In autumn, its body becomes more fatty in preparing to propose to a mate. It takes on beautiful colors.",
+		de: "Im Herbst legt es an Gewicht zu und erscheint in prächtigen Farben, um so einen Partner anzulocken."
+	},
+
 	name: {
 		en: "Seaking",
 		fr: "Poissoroy",
@@ -27,13 +32,15 @@ const card: Card = {
 
 	attacks: [{
 		name: {
-			en: "Hydro Jet"
+			en: "Hydro Jet",
+			de: "Hydrostrahl"
 		},
 
 		cost: ["Colorless", "Colorless", "Colorless"],
 
 		effect: {
-			en: "This attack does 30 damage to 1 of your Benched Pokémon for each Water Energy attached to this Pokémon"
+			en: "This attack does 30 damage to 1 of your Benched Pokémon for each Water Energy attached to this Pokémon",
+			de: "Diese Attacke fügt 1 Pokémon deines Gegners für jede an dieses Pokémon angelegte {W}-Energie 30 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
 		}
 	}],
 

--- a/data/Mega Evolution/Pitch Black/015.ts
+++ b/data/Mega Evolution/Pitch Black/015.ts
@@ -4,6 +4,11 @@ import Set from "../Pitch Black"
 const card: Card = {
 	set: Set,
 
+	description: {
+		en: "It shows off by spraying jets of seawater from the nostrils above its eyes. It eats a solid ton of Wishiwashi every day.",
+		de: "Es prustet Meerwasser aus den Nasenlöchern, die über seinen Augen liegen. Außerdem frisst es täglich eine Tonne Lusardin."
+	},
+
 	name: {
 		en: "Wailmer",
 		fr: "Wailmer",
@@ -22,7 +27,8 @@ const card: Card = {
 
 	attacks: [{
 		name: {
-			en: "Water Gun"
+			en: "Water Gun",
+			de: "Aquaknarre"
 		},
 
 		cost: ["Water", "Water"],
@@ -30,7 +36,8 @@ const card: Card = {
 		damage: 40
 	}, {
 		name: {
-			en: "Wave Splash"
+			en: "Wave Splash",
+			de: "Wellenplatscher"
 		},
 
 		cost: ["Water", "Water", "Water"],

--- a/data/Mega Evolution/Pitch Black/016.ts
+++ b/data/Mega Evolution/Pitch Black/016.ts
@@ -28,7 +28,8 @@ const card: Card = {
 
 	attacks: [{
 		name: {
-			en: "Surf"
+			en: "Surf",
+			de: "Surfer"
 		},
 
 		cost: ["Water", "Water", "Water"],
@@ -36,7 +37,8 @@ const card: Card = {
 		damage: 120
 	}, {
 		name: {
-			en: "Falling Down"
+			en: "Falling Down",
+			de: "Hinfallen"
 		},
 
 		cost: ["Water", "Water", "Water", "Water", "Water"],
@@ -44,7 +46,8 @@ const card: Card = {
 		damage: 270,
 
 		effect: {
-			en: "This Pokémon is now Asleep"
+			en: "This Pokémon is now Asleep",
+			de: "Dieses Pokémon schläft jetzt."
 		}
 	}],
 

--- a/data/Mega Evolution/Pitch Black/017.ts
+++ b/data/Mega Evolution/Pitch Black/017.ts
@@ -4,6 +4,11 @@ import Set from "../Pitch Black"
 const card: Card = {
 	set: Set,
 
+	description: {
+		en: "Rock-hard scales and oil-filled swim bladders allow this Pokémon to survive the intense water pressure of the deep sea.",
+		de: "Dank seiner steinharten Schuppen und mit Fett gefüllten Schwimmblasen kann es dem Wasserdruck der Tiefsee standhalten."
+	},
+
 	name: {
 		en: "Relicanth",
 		fr: "Relicanth",
@@ -22,7 +27,8 @@ const card: Card = {
 
 	attacks: [{
 		name: {
-			en: "Fossil Beatdown"
+			en: "Fossil Beatdown",
+			de: "Fossile Abreibung"
 		},
 
 		cost: ["Colorless"],
@@ -30,7 +36,8 @@ const card: Card = {
 		damage: "10+",
 
 		effect: {
-			en: "This attack does 30 more damage for each of your Benched Pokémon with \"Antique\" in its name."
+			en: "This attack does 30 more damage for each of your Benched Pokémon with \"Antique\" in its name.",
+			de: "Diese Attacke fügt für jedes Pokémon auf deiner Bank, bei dem „Antikes\" oder „Antiker\" zum Namen gehört, 30 Schadenspunkte mehr zu."
 		}
 	}],
 

--- a/data/Mega Evolution/Pitch Black/018.ts
+++ b/data/Mega Evolution/Pitch Black/018.ts
@@ -4,6 +4,11 @@ import Set from "../Pitch Black"
 const card: Card = {
 	set: Set,
 
+	description: {
+		en: "The balloons it inflates with its nose grow larger and larger as it practices day by day.",
+		de: "Dank seines täglichen Trainings gelingt es ihm, mit seiner Nase immer größere Blasen zu erzeugen."
+	},
+
 	name: {
 		en: "Popplio",
 		fr: "Otaquin",
@@ -22,7 +27,8 @@ const card: Card = {
 
 	attacks: [{
 		name: {
-			en: "Pound"
+			en: "Pound",
+			de: "Klaps"
 		},
 
 		cost: ["Water"],

--- a/data/Mega Evolution/Pitch Black/019.ts
+++ b/data/Mega Evolution/Pitch Black/019.ts
@@ -4,6 +4,11 @@ import Set from "../Pitch Black"
 const card: Card = {
 	set: Set,
 
+	description: {
+		en: "It cares deeply for its companions. When its Trainer is feeling down, it performs a cheery dance to try to help.",
+		de: "Das Wohlergehen seiner Freunde ist ihm sehr wichtig. Wenn sein Trainer schlechte Laune hat, versucht es, ihn mit einem Tänzchen aufzuheitern."
+	},
+
 	name: {
 		en: "Brionne",
 		fr: "Otarlette",
@@ -27,7 +32,8 @@ const card: Card = {
 
 	attacks: [{
 		name: {
-			en: "Hyper Voice"
+			en: "Hyper Voice",
+			de: "Schallwelle"
 		},
 
 		cost: ["Water"],

--- a/data/Mega Evolution/Pitch Black/020.ts
+++ b/data/Mega Evolution/Pitch Black/020.ts
@@ -4,6 +4,10 @@ import Set from "../Pitch Black"
 const card: Card = {
 	set: Set,
 
+	description: {
+		en: "Also known as a songstress, it is a sight to behold on moonlit nights when it sings in front of the colony it leads."
+	},
+
 	name: {
 		en: "Primarina",
 		fr: "Oratoria",

--- a/data/Mega Evolution/Pitch Black/021.ts
+++ b/data/Mega Evolution/Pitch Black/021.ts
@@ -4,6 +4,10 @@ import Set from "../Pitch Black"
 const card: Card = {
 	set: Set,
 
+	description: {
+		en: "Its water ring is made from seawater mixed with a sticky fluid that Finizen secretes from its blowhole."
+	},
+
 	name: {
 		en: "Finizen",
 		fr: "Dofin",

--- a/data/Mega Evolution/Pitch Black/022.ts
+++ b/data/Mega Evolution/Pitch Black/022.ts
@@ -4,6 +4,10 @@ import Set from "../Pitch Black"
 const card: Card = {
 	set: Set,
 
+	description: {
+		en: "This hero of the ocean swims at a speed of 50 knots and saves drowning people and Pokémon."
+	},
+
 	name: {
 		en: "Palafin",
 		fr: "Superdofin",

--- a/data/Mega Evolution/Pitch Black/023.ts
+++ b/data/Mega Evolution/Pitch Black/023.ts
@@ -4,6 +4,10 @@ import Set from "../Pitch Black"
 const card: Card = {
 	set: Set,
 
+	description: {
+		en: "It stores static electricity in its fur for discharging. This Pokémon's whole body gives off sparks if a storm approaches."
+	},
+
 	name: {
 		en: "Electrike",
 		fr: "Dynavolt",

--- a/data/Mega Evolution/Pitch Black/024.ts
+++ b/data/Mega Evolution/Pitch Black/024.ts
@@ -4,6 +4,10 @@ import Set from "../Pitch Black"
 const card: Card = {
 	set: Set,
 
+	description: {
+		en: "It discharges electricity from its mane. The Pokémon creates a thundercloud overhead from which to drop lightning bolts."
+	},
+
 	name: {
 		en: "Manectric",
 		fr: "Élecsprint",

--- a/data/Mega Evolution/Pitch Black/025.ts
+++ b/data/Mega Evolution/Pitch Black/025.ts
@@ -4,6 +4,11 @@ import Set from "../Pitch Black"
 const card: Card = {
 	set: Set,
 
+	description: {
+		en: "As it digests fallen leaves, it generates and stores electricity, which it can discharge from the tips of its jaws.",
+		de: "Gefressenes Laub verwandelt Akkup während der Verdauung in Strom, den es speichert. Über die Spitzen an seinem Kiefer entlädt es ihn dann."
+	},
+
 	name: {
 		en: "Charjabug",
 		fr: "Chrysapile",
@@ -27,7 +32,8 @@ const card: Card = {
 
 	attacks: [{
 		name: {
-			en: "Vise Grip"
+			en: "Vise Grip",
+			de: "Klammer"
 		},
 
 		cost: ["Lightning"],
@@ -35,7 +41,8 @@ const card: Card = {
 		damage: 30
 	}, {
 		name: {
-			en: "Ram"
+			en: "Ram",
+			de: "Ramme"
 		},
 
 		cost: ["Lightning", "Lightning"],

--- a/data/Mega Evolution/Pitch Black/026.ts
+++ b/data/Mega Evolution/Pitch Black/026.ts
@@ -4,6 +4,11 @@ import Set from "../Pitch Black"
 const card: Card = {
 	set: Set,
 
+	description: {
+		en: "When carrying a Charjabug, Vikavolt can receive electricity from it and then rapidly fire powerful electromagnetic beams from its large jaws.",
+		de: "Trägt es ein Akkup, wird es von diesem mit Strom versorgt, den es als starke elektromagnetische Strahlen aus seinem großen Kiefer abfeuert."
+	},
+
 	name: {
 		en: "Vikavolt",
 		fr: "Lucanon",
@@ -27,17 +32,20 @@ const card: Card = {
 
 	attacks: [{
 		name: {
-			en: "Quick Dive"
+			en: "Quick Dive",
+			de: "Schnelltaucher"
 		},
 
 		cost: ["Lightning"],
 
 		effect: {
-			en: "This attack does 50 damage to 1 of your opponent's Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon)"
+			en: "This attack does 50 damage to 1 of your opponent's Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon)",
+			de: "Diese Attacke fügt 1 Pokémon deines Gegners 50 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
 		}
 	}, {
 		name: {
-			en: "Giga Railgun"
+			en: "Giga Railgun",
+			de: "Gigaschienenkanone"
 		},
 
 		cost: ["Lightning", "Lightning"],
@@ -45,7 +53,8 @@ const card: Card = {
 		damage: 260,
 
 		effect: {
-			en: "If this Pokémon doesn't have Bolt Lightning Energy attached to it, this attack does nothing"
+			en: "If this Pokémon doesn't have Bolt Lightning Energy attached to it, this attack does nothing",
+			de: "Wenn an dieses Pokémon keine Voltaische-{L}-Energie angelegt ist, hat diese Attacke keine Auswirkungen."
 		}
 	}],
 

--- a/data/Mega Evolution/Pitch Black/027.ts
+++ b/data/Mega Evolution/Pitch Black/027.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	attacks: [{
 		name: {
-			en: "Thunderous Fist"
+			en: "Thunderous Fist",
+			de: "Donnerfäuste"
 		},
 
 		cost: ["Lightning"],
@@ -31,11 +32,13 @@ const card: Card = {
 		damage: "60x",
 
 		effect: {
-			en: "This attack does 60 damage for each Lightning Energy attached to this Pokémon."
+			en: "This attack does 60 damage for each Lightning Energy attached to this Pokémon.",
+			de: "Diese Attacke fügt für jede an dieses Pokémon angelegte {L}-Energie 60 Schadenspunkte zu."
 		}
 	}, {
 		name: {
-			en: "Zepto Turn"
+			en: "Zepto Turn",
+			de: "Zepto-Drehung"
 		},
 
 		cost: ["Lightning", "Lightning", "Lightning"],
@@ -43,7 +46,8 @@ const card: Card = {
 		damage: 150,
 
 		effect: {
-			en: "Switch this Pokémon with one of your Benched Pokémon."
+			en: "Switch this Pokémon with one of your Benched Pokémon.",
+			de: "Tausche dieses Pokémon gegen 1 Pokémon auf deiner Bank aus."
 		}
 	}],
 

--- a/data/Mega Evolution/Pitch Black/028.ts
+++ b/data/Mega Evolution/Pitch Black/028.ts
@@ -4,6 +4,10 @@ import Set from "../Pitch Black"
 const card: Card = {
 	set: Set,
 
+	description: {
+		en: "This seems to be the Iron Serpent mentioned in an old book. The Iron Serpent is said to have turned the land to ash with its lightning."
+	},
+
 	name: {
 		en: "Miraidon",
 		fr: "Miraidon",

--- a/data/Mega Evolution/Pitch Black/029.ts
+++ b/data/Mega Evolution/Pitch Black/029.ts
@@ -4,6 +4,10 @@ import Set from "../Pitch Black"
 const card: Card = {
 	set: Set,
 
+	description: {
+		en: "It lazes vacantly near water. If something bites its tail, it won't even notice for a whole day."
+	},
+
 	name: {
 		en: "Slowpoke",
 		fr: "Ramoloss",

--- a/data/Mega Evolution/Pitch Black/030.ts
+++ b/data/Mega Evolution/Pitch Black/030.ts
@@ -4,6 +4,11 @@ import Set from "../Pitch Black"
 const card: Card = {
 	set: Set,
 
+	description: {
+		en: "An attached Shellder won't let go because of the tasty flavor that oozes out of Slowbro's tail.",
+		de: "Das Muschas an seiner Rute lässt nicht locker, da ein leckerer Geschmack aus dieser strömt."
+	},
+
 	name: {
 		en: "Slowbro",
 		fr: "Flagadoss",
@@ -27,7 +32,10 @@ const card: Card = {
 
 	attacks: [{
 		name: {
-			en: "All Out"
+			en: "All Out",
+			es: "A por Todas",
+			'es-mx': "Sin Más",
+			de: "Aufs Ganze gehen"
 		},
 
 		cost: ["Psychic"],
@@ -35,11 +43,17 @@ const card: Card = {
 		damage: "50+",
 
 		effect: {
-			en: "If you have no cards in your hand, this attack does 160 more damage."
+			en: "If you have no cards in your hand, this attack does 160 more damage.",
+			es: "Si no tienes ninguna carta en tu mano, este ataque hace 160 puntos de daño más.",
+			'es-mx': "Si no tienes ninguna carta en tu mano, este ataque hace 160 puntos de daño más.",
+			de: "Wenn du keine Karten auf deiner Hand hast, fügt diese Attacke 160 Schadenspunkte mehr zu."
 		}
 	}, {
 		name: {
-			en: "Zen Headbutt"
+			en: "Zen Headbutt",
+			es: "Cabezazo Zen",
+			'es-mx': "Cabezazo Zen",
+			de: "Zen-Kopfstoß"
 		},
 
 		cost: ["Colorless", "Colorless", "Colorless"],

--- a/data/Mega Evolution/Pitch Black/031.ts
+++ b/data/Mega Evolution/Pitch Black/031.ts
@@ -28,7 +28,9 @@ const card: Card = {
 
 	attacks: [{
 		name: {
-			en: "Shellnado Spin"
+			en: "Shellnado Spin",
+			es: "Giro Caparazón",
+			'es-mx': "Tornado Acorazado"
 		},
 
 		cost: ["Psychic", "Psychic", "Psychic"],
@@ -36,7 +38,9 @@ const card: Card = {
 		damage: 180,
 
 		effect: {
-			en: "During your opponent's next turn, if this Pokémon is damaged by an attack (even if this Pokémon is Knocked Out), place 12 damage counters on the attacking Pokémon"
+			en: "During your opponent's next turn, if this Pokémon is damaged by an attack (even if this Pokémon is Knocked Out), place 12 damage counters on the attacking Pokémon",
+			es: "Durante el próximo turno de tu rival, si este Pokémon resulta dañado por un ataque (incluso si queda Fuera de Combate), pon 12 contadores de daño en el Pokémon Atacante.",
+			'es-mx': "Durante el próximo turno de tu rival, si este Pokémon recibe daño de un ataque (incluso si queda Fuera de Combate), pon 12 contadores de daño en el Pokémon Atacante."
 		}
 	}],
 

--- a/data/Mega Evolution/Pitch Black/032.ts
+++ b/data/Mega Evolution/Pitch Black/032.ts
@@ -4,6 +4,10 @@ import Set from "../Pitch Black"
 const card: Card = {
 	set: Set,
 
+	description: {
+		en: "Its strange cries sound like human language. There are some musicians who compose songs for Jynx to sing."
+	},
+
 	name: {
 		en: "Jynx",
 		fr: "Lippoutou",

--- a/data/Mega Evolution/Pitch Black/033.ts
+++ b/data/Mega Evolution/Pitch Black/033.ts
@@ -4,6 +4,10 @@ import Set from "../Pitch Black"
 const card: Card = {
 	set: Set,
 
+	description: {
+		en: "It uses its horn to feed on envy and malice—or so it's said. It's very active at night."
+	},
+
 	name: {
 		en: "Shuppet",
 		fr: "Polichombr",
@@ -24,17 +28,23 @@ const card: Card = {
 		type: "Ability",
 
 		name: {
-			en: "Hide 'n' Sneak"
+			en: "Hide 'n' Sneak",
+			es: "Escondite a Hurtadillas",
+			'es-mx': "Escondidas Furtivas"
 		},
 
 		effect: {
-			en: "Prevent all effects of opponent's Attacks and Abilities done to this Pokémon."
+			en: "Prevent all effects of opponent's Attacks and Abilities done to this Pokémon.",
+			es: "Se evitan todos los efectos de los ataques y las habilidades de los Pokémon de tu rival infligidos a este Pokémon. (El daño no es un efecto).",
+			'es-mx': "Se evitan todos los efectos de los ataques y las habilidades de los Pokémon de tu rival infligidos a este Pokémon. (El daño no es un efecto)."
 		}
 	}],
 
 	attacks: [{
 		name: {
-			en: "Hang Down"
+			en: "Hang Down",
+			es: "Prender",
+			'es-mx': "Colgadera"
 		},
 
 		cost: ["Psychic", "Psychic"],

--- a/data/Mega Evolution/Pitch Black/034.ts
+++ b/data/Mega Evolution/Pitch Black/034.ts
@@ -4,6 +4,11 @@ import Set from "../Pitch Black"
 const card: Card = {
 	set: Set,
 
+	description: {
+		en: "A doll bore a grudge over being junked, and it became a Pokémon. It seeks the child that disowned it.",
+		de: "Der Groll darüber, weggeworfen worden zu sein, machte aus einer Plüschpuppe dieses Pokémon. Es sucht das Kind, von dem es verstoßen wurde."
+	},
+
 	name: {
 		en: "Banette",
 		fr: "Branette",
@@ -29,17 +34,26 @@ const card: Card = {
 		type: "Ability",
 
 		name: {
-			en: "Hide 'n' Sneak"
+			en: "Hide 'n' Sneak",
+			es: "Escondite a Hurtadillas",
+			'es-mx': "Escondidas Furtivas",
+			de: "Listiges Versteckspiel"
 		},
 
 		effect: {
-			en: "Prevent all effects of opponent's Attacks and Abilities done to this Pokémon."
+			en: "Prevent all effects of opponent's Attacks and Abilities done to this Pokémon.",
+			es: "Se evitan todos los efectos de los ataques y las habilidades de los Pokémon de tu rival infligidos a este Pokémon. (El daño no es un efecto).",
+			'es-mx': "Se evitan todos los efectos de los ataques y las habilidades de los Pokémon de tu rival infligidos a este Pokémon. (El daño no es un efecto).",
+			de: "Verhindere alle Effekte von Attacken und Fähigkeiten der Pokémon deines Gegners, die diesem Pokémon zugefügt werden. (Schaden ist kein Effekt.)"
 		}
 	}],
 
 	attacks: [{
 		name: {
-			en: "Puppet Pull"
+			en: "Puppet Pull",
+			es: "Tirón del Títere",
+			'es-mx': "Hallazgo del Títere",
+			de: "Marionettenzieher"
 		},
 
 		cost: ["Psychic", "Psychic"],
@@ -47,7 +61,10 @@ const card: Card = {
 		damage: 80,
 
 		effect: {
-			en: "You may search your deck for a card and put it into your hand. Then shuffle tour deck."
+			en: "You may search your deck for a card and put it into your hand. Then shuffle tour deck.",
+			es: "Puedes buscar en tu baraja 1 carta y ponerla en tu mano. Después, baraja las cartas de tu baraja.",
+			'es-mx': "Puedes buscar en tu mazo 1 carta y ponerla en tu mano. Después, baraja tu mazo.",
+			de: "Du kannst dein Deck nach 1 Karte durchsuchen und sie auf deine Hand nehmen. Mische anschließend dein Deck."
 		}
 	}],
 

--- a/data/Mega Evolution/Pitch Black/035.ts
+++ b/data/Mega Evolution/Pitch Black/035.ts
@@ -4,6 +4,10 @@ import Set from "../Pitch Black"
 const card: Card = {
 	set: Set,
 
+	description: {
+		en: "It was formed by uniting 108 spirits. It has been bound to the Odd Keystone to keep it from doing any mischief."
+	},
+
 	name: {
 		en: "Spiritomb",
 		fr: "Spiritomb",

--- a/data/Mega Evolution/Pitch Black/036.ts
+++ b/data/Mega Evolution/Pitch Black/036.ts
@@ -4,6 +4,10 @@ import Set from "../Pitch Black"
 const card: Card = {
 	set: Set,
 
+	description: {
+		en: "Litwick shines a light that absorbs the life energy of people and Pokémon, which becomes the fuel that it burns."
+	},
+
 	name: {
 		en: "Litwick",
 		fr: "Funécire",
@@ -22,7 +26,9 @@ const card: Card = {
 
 	attacks: [{
 		name: {
-			en: "Will-O-Wisp"
+			en: "Will-O-Wisp",
+			es: "Fuego Fatuo",
+			'es-mx': "Fuego Fatuo"
 		},
 
 		cost: ["Psychic"],

--- a/data/Mega Evolution/Pitch Black/037.ts
+++ b/data/Mega Evolution/Pitch Black/037.ts
@@ -4,6 +4,10 @@ import Set from "../Pitch Black"
 const card: Card = {
 	set: Set,
 
+	description: {
+		en: "Lampent appears at the moment of death and promptly absorbs the spirit as it leaves the body."
+	},
+
 	name: {
 		en: "Lampent",
 		fr: "Mélancolux",
@@ -27,13 +31,17 @@ const card: Card = {
 
 	attacks: [{
 		name: {
-			en: "Spreading Light"
+			en: "Spreading Light",
+			es: "Dispersión Lumínica",
+			'es-mx': "Luz Expansiva"
 		},
 
 		cost: ["Psychic"],
 
 		effect: {
-			en: "Put up to 3 Lampent from your deck onto your Bench, then shuffle your deck."
+			en: "Put up to 3 Lampent from your deck onto your Bench, then shuffle your deck.",
+			es: "Busca en tu baraja hasta 3 Lampent y ponlos en tu Banca. Después, baraja las cartas de tu baraja.",
+			'es-mx': "Busca en tu mazo hasta 3 Lampent y ponlos en tu Banca. Después, baraja tu mazo."
 		}
 	}],
 

--- a/data/Mega Evolution/Pitch Black/038.ts
+++ b/data/Mega Evolution/Pitch Black/038.ts
@@ -30,17 +30,26 @@ const card: Card = {
 		type: "Ability",
 
 		name: {
-			en: "Binding Flame"
+			en: "Binding Flame",
+			es: "Atadura Ígnea",
+			'es-mx': "Atadura Llameante",
+			de: "Fesselnde Flamme"
 		},
 
 		effect: {
-			en: "Your opponent's Pokémon's Retreat Cost is 1 more"
+			en: "Your opponent's Pokémon's Retreat Cost is 1 more",
+			es: "El de Retirada del Pokémon Activo de tu rival es de {C} más.",
+			'es-mx': "El de Retirada del Pokémon Activo de tu rival es de {C} más.",
+			de: "Die Rückzugskosten des Aktiven Pokémon deines Gegners erhöhen sich um {C}."
 		}
 	}],
 
 	attacks: [{
 		name: {
-			en: "Phantom Maze"
+			en: "Phantom Maze",
+			es: "Laberinto Fantasmal",
+			'es-mx': "Laberinto Fantasma",
+			de: "Phantomlabyrinth"
 		},
 
 		cost: ["Psychic", "Psychic"],
@@ -48,7 +57,10 @@ const card: Card = {
 		damage: "130+",
 
 		effect: {
-			en: "This attack does 50 more damage for each Energy in your opponent's Active Pokémon's Retreat Cost."
+			en: "This attack does 50 more damage for each Energy in your opponent's Active Pokémon's Retreat Cost.",
+			es: "Este ataque hace 50 puntos de daño más por cada {C} en el Coste de Retirada del Pokémon Activo de tu rival.",
+			'es-mx': "Este ataque hace 50 puntos de daño más por cada {C} en el Coste de Retirada del Pokémon Activo de tu rival.",
+			de: "Diese Attacke fügt für jedes {C} in den Rückzugskosten des Aktiven Pokémon deines Gegners 50 Schadenspunkte mehr zu."
 		}
 	}],
 

--- a/data/Mega Evolution/Pitch Black/039.ts
+++ b/data/Mega Evolution/Pitch Black/039.ts
@@ -4,6 +4,11 @@ import Set from "../Pitch Black"
 const card: Card = {
 	set: Set,
 
+	description: {
+		en: "After a piece of seaweed merged with debris from a sunken ship, it was reborn as this ghost Pokémon.",
+		de: "Dieses Geister-Pokémon entstand, als sich vom Meeresgrund stammendes Seegras auf Bruchstücken eines Schiffswracks ablagerte."
+	},
+
 	name: {
 		en: "Dhelmise",
 		fr: "Sinistrail",
@@ -22,7 +27,10 @@ const card: Card = {
 
 	attacks: [{
 		name: {
-			en: "Vengeful Anchor"
+			en: "Vengeful Anchor",
+			es: "Ancla Vengativa",
+			'es-mx': "Ancla Vengativa",
+			de: "Verankerte Rache"
 		},
 
 		cost: ["Psychic"],
@@ -30,7 +38,10 @@ const card: Card = {
 		damage: "30+",
 
 		effect: {
-			en: "If you have 4 or more Pokémon that have the Hide 'n' Sneak Ability in your discard pile, this attack does 140 more damage."
+			en: "If you have 4 or more Pokémon that have the Hide 'n' Sneak Ability in your discard pile, this attack does 140 more damage.",
+			es: "Si tienes en tu pila de descartes 4 Pokémon o más que tengan la habilidad Escondite a Hurtadillas, este ataque hace 140 puntos de daño más.",
+			'es-mx': "Si tienes 4 Pokémon o más que tengan la Habilidad Escondidas Furtivas en tu pila de descartes, este ataque hace 140 puntos de daño más.",
+			de: "Wenn du 4 oder mehr Pokémon, die die Fähigkeit Listiges Versteckspiel haben, in deinem Ablagestapel hast, fügt diese Attacke 140 Schadenspunkte mehr zu."
 		}
 	}],
 

--- a/data/Mega Evolution/Pitch Black/040.ts
+++ b/data/Mega Evolution/Pitch Black/040.ts
@@ -4,6 +4,11 @@ import Set from "../Pitch Black"
 const card: Card = {
 	set: Set,
 
+	description: {
+		en: "By slipping into the shadow of a martial arts master and copying their movements, this Pokémon learned the ultimate techniques.",
+		de: "Es schlüpfte in den Schatten eines Meisters des Faustkampfes und imitierte dessen Bewegungen. So lernte es ultimative Geheimtechniken."
+	},
+
 	name: {
 		en: "Marshadow",
 		fr: "Marshadow",
@@ -22,7 +27,8 @@ const card: Card = {
 
 	attacks: [{
 		name: {
-			en: "Shadowy Knot"
+			en: "Shadowy Knot",
+			de: "Schattenknoten"
 		},
 
 		cost: ["Psychic"],
@@ -30,7 +36,8 @@ const card: Card = {
 		damage: "30x",
 
 		effect: {
-			en: "This attack does 30 damage for each Energy in your opponent's Active Pokémon's Retreat Cost."
+			en: "This attack does 30 damage for each Energy in your opponent's Active Pokémon's Retreat Cost.",
+			de: "Diese Attacke fügt für jedes {C} in den Rückzugskosten des Aktiven Pokémon deines Gegners 30 Schadenspunkte zu."
 		}
 	}],
 

--- a/data/Mega Evolution/Pitch Black/041.ts
+++ b/data/Mega Evolution/Pitch Black/041.ts
@@ -4,6 +4,10 @@ import Set from "../Pitch Black"
 const card: Card = {
 	set: Set,
 
+	description: {
+		en: "It imbues its fists with the power of the rage that it kept hidden in its heart. Opponents struck by these imbued fists will be shattered to their core."
+	},
+
 	name: {
 		en: "Annihilape",
 		fr: "Courrousinge",

--- a/data/Mega Evolution/Pitch Black/042.ts
+++ b/data/Mega Evolution/Pitch Black/042.ts
@@ -4,6 +4,11 @@ import Set from "../Pitch Black"
 const card: Card = {
 	set: Set,
 
+	description: {
+		en: "It is extremely quick to anger. It could be docile one moment, then thrashing away the next instant.",
+		de: "Auch wenn es guter Stimmung ist, kann es wegen einer Kleinigkeit plötzlich ausrasten und ist daher gefürchtet."
+	},
+
 	name: {
 		en: "Mankey",
 		fr: "Férosinge",
@@ -22,7 +27,8 @@ const card: Card = {
 
 	attacks: [{
 		name: {
-			en: "Low Sweep"
+			en: "Low Sweep",
+			de: "Fußkick"
 		},
 
 		cost: ["Colorless"],

--- a/data/Mega Evolution/Pitch Black/043.ts
+++ b/data/Mega Evolution/Pitch Black/043.ts
@@ -4,6 +4,11 @@ import Set from "../Pitch Black"
 const card: Card = {
 	set: Set,
 
+	description: {
+		en: "Some researchers theorize that Primeape remains angry even when inside a Poké Ball.",
+		de: "Der Theorie eines Forschers zufolge schäumt Rasaff sogar im Inneren von Pokébällen weiter vor Wut."
+	},
+
 	name: {
 		en: "Primeape",
 		fr: "Colossinge",
@@ -27,7 +32,8 @@ const card: Card = {
 
 	attacks: [{
 		name: {
-			en: "Corkscrew Punch"
+			en: "Corkscrew Punch",
+			de: "Korkenzieherhieb"
 		},
 
 		cost: ["Colorless", "Colorless"],

--- a/data/Mega Evolution/Pitch Black/044.ts
+++ b/data/Mega Evolution/Pitch Black/044.ts
@@ -4,6 +4,10 @@ import Set from "../Pitch Black"
 const card: Card = {
 	set: Set,
 
+	description: {
+		en: "Cranidos toughen up their already sturdy heads by headbutting one another."
+	},
+
 	name: {
 		en: "Cranidos",
 		fr: "Kranidos",

--- a/data/Mega Evolution/Pitch Black/046.ts
+++ b/data/Mega Evolution/Pitch Black/046.ts
@@ -4,6 +4,10 @@ import Set from "../Pitch Black"
 const card: Card = {
 	set: Set,
 
+	description: {
+		en: "By spinning its body, it can dig straight through the ground at a speed of 30 mph."
+	},
+
 	name: {
 		en: "Drilbur",
 		fr: "Rototaupe",

--- a/data/Mega Evolution/Pitch Black/047.ts
+++ b/data/Mega Evolution/Pitch Black/047.ts
@@ -4,6 +4,10 @@ import Set from "../Pitch Black"
 const card: Card = {
 	set: Set,
 
+	description: {
+		en: "This seems to be the Winged King mentioned in an old expedition journal. It was said to have split the land with its bare fists."
+	},
+
 	name: {
 		en: "Koraidon",
 		fr: "Koraidon",

--- a/data/Mega Evolution/Pitch Black/048.ts
+++ b/data/Mega Evolution/Pitch Black/048.ts
@@ -23,7 +23,10 @@ const card: Card = {
 
 	attacks: [{
 		name: {
-			en: "Dusk Raid"
+			en: "Dusk Raid",
+			es: "Incursión Crepuscular",
+			'es-mx': "Redada Crepuscular",
+			de: "Finsterer Überfall"
 		},
 
 		cost: ["Darkness", "Darkness"],
@@ -31,17 +34,26 @@ const card: Card = {
 		damage: "110+",
 
 		effect: {
-			en: "If any of your Benched Pokémon have any damage counters on them, this attack does 110 more damage."
+			en: "If any of your Benched Pokémon have any damage counters on them, this attack does 110 more damage.",
+			es: "Si tus Pokémon en Banca tienen algún contador de daño sobre ellos, este ataque hace 110 puntos de daño más.",
+			'es-mx': "Si tus Pokémon en Banca tienen algún contador de daño sobre ellos, este ataque hace 110 puntos de daño más.",
+			de: "Wenn auf den Pokémon auf deiner Bank mindestens 1 Schadensmarke liegt, fügt diese Attacke 110 Schadenspunkte mehr zu."
 		}
 	}, {
 		name: {
-			en: "Abyss Eye"
+			en: "Abyss Eye",
+			es: "Ojo Abismal",
+			'es-mx': "Ojo Abismal",
+			de: "Abgrundauge"
 		},
 
 		cost: ["Darkness", "Darkness", "Darkness"],
 
 		effect: {
-			en: "If your opponent's Active Pokémon is affected by any Special Condition, it is now Knocked Out."
+			en: "If your opponent's Active Pokémon is affected by any Special Condition, it is now Knocked Out.",
+			es: "Si el Pokémon Activo de tu rival se ve afectado por una Condición Especial, queda Fuera de Combate.",
+			'es-mx': "Si el Pokémon Activo de tu rival se ve afectado por una Condición Especial, queda Fuera de Combate.",
+			de: "Wenn das Aktive Pokémon deines Gegners von einem Speziellen Zustand betroffen ist, ist es kampfunfähig."
 		}
 	}],
 

--- a/data/Mega Evolution/Pitch Black/049.ts
+++ b/data/Mega Evolution/Pitch Black/049.ts
@@ -4,6 +4,10 @@ import Set from "../Pitch Black"
 const card: Card = {
 	set: Set,
 
+	description: {
+		en: "Its healthy appetite leads to visible growth spurts. It often has to replace the bones it wears as its size increases."
+	},
+
 	name: {
 		en: "Vullaby",
 		fr: "Vostourno",

--- a/data/Mega Evolution/Pitch Black/050.ts
+++ b/data/Mega Evolution/Pitch Black/050.ts
@@ -4,6 +4,10 @@ import Set from "../Pitch Black"
 const card: Card = {
 	set: Set,
 
+	description: {
+		en: "Watching from the sky, they attack weakened prey on the ground. They have a habit of decorating themselves with bones."
+	},
+
 	name: {
 		en: "Mandibuzz",
 		fr: "Vaututrice",

--- a/data/Mega Evolution/Pitch Black/051.ts
+++ b/data/Mega Evolution/Pitch Black/051.ts
@@ -4,6 +4,10 @@ import Set from "../Pitch Black"
 const card: Card = {
 	set: Set,
 
+	description: {
+		en: "It drains foes' will to fight by flashing light at them. It then takes the opportunity to hide itself away."
+	},
+
 	name: {
 		en: "Inkay",
 		fr: "Sepiatop",

--- a/data/Mega Evolution/Pitch Black/052.ts
+++ b/data/Mega Evolution/Pitch Black/052.ts
@@ -4,6 +4,10 @@ import Set from "../Pitch Black"
 const card: Card = {
 	set: Set,
 
+	description: {
+		en: "It wields the most compelling hypnotic powers of any Pokémon, and it forces others to do whatever it wants."
+	},
+
 	name: {
 		en: "Malamar",
 		fr: "Sepiatroce",

--- a/data/Mega Evolution/Pitch Black/053.ts
+++ b/data/Mega Evolution/Pitch Black/053.ts
@@ -4,6 +4,10 @@ import Set from "../Pitch Black"
 const card: Card = {
 	set: Set,
 
+	description: {
+		en: "Aided by the soft pads on its feet, it silently raids the food stores of other Pokémon. It survives off its ill-gotten gains."
+	},
+
 	name: {
 		en: "Nickit",
 		fr: "Goupilou",

--- a/data/Mega Evolution/Pitch Black/054.ts
+++ b/data/Mega Evolution/Pitch Black/054.ts
@@ -4,6 +4,10 @@ import Set from "../Pitch Black"
 const card: Card = {
 	set: Set,
 
+	description: {
+		en: "It secretly marks potential targets with a scent. By following the scent, it stalks its targets and steals from them when they least expect it."
+	},
+
 	name: {
 		en: "Thievul",
 		fr: "Roublenard",

--- a/data/Mega Evolution/Pitch Black/056.ts
+++ b/data/Mega Evolution/Pitch Black/056.ts
@@ -4,6 +4,10 @@ import Set from "../Pitch Black"
 const card: Card = {
 	set: Set,
 
+	description: {
+		en: "Within dense forests, this Pokémon lives in a pack with others of its kind. It's incredibly aggressive, and the other Pokémon of the forest fear it."
+	},
+
 	name: {
 		en: "Zarude",
 		fr: "Zarude",

--- a/data/Mega Evolution/Pitch Black/057.ts
+++ b/data/Mega Evolution/Pitch Black/057.ts
@@ -4,6 +4,10 @@ import Set from "../Pitch Black"
 const card: Card = {
 	set: Set,
 
+	description: {
+		en: "Its well-developed jaw and fangs are strong enough to crunch through boulders, and its thick fat makes for an excellent defense."
+	},
+
 	name: {
 		en: "Maschiff",
 		fr: "Grondogue",

--- a/data/Mega Evolution/Pitch Black/058.ts
+++ b/data/Mega Evolution/Pitch Black/058.ts
@@ -4,6 +4,10 @@ import Set from "../Pitch Black"
 const card: Card = {
 	set: Set,
 
+	description: {
+		en: "Mabosstiff loves playing with children. Though usually gentle, it takes on an intimidating look when protecting its family."
+	},
+
 	name: {
 		en: "Mabosstiff",
 		fr: "Dogrino",

--- a/data/Mega Evolution/Pitch Black/059.ts
+++ b/data/Mega Evolution/Pitch Black/059.ts
@@ -4,6 +4,11 @@ import Set from "../Pitch Black"
 const card: Card = {
 	set: Set,
 
+	description: {
+		en: "The envy accumulated within curved beads that sparked multiple conflicts has clad itself in fire and become a Pokémon.",
+		de: "Der Neid, der sich in Krummjuwelen sammelte, die viel Streit heraufbeschworen, hüllte sich in Feuer und wurde zu diesem Pokémon."
+	},
+
 	name: {
 		en: "Chi-Yu",
 		fr: "Yuyu",
@@ -22,7 +27,8 @@ const card: Card = {
 
 	attacks: [{
 		name: {
-			en: "Whirling Envy"
+			en: "Whirling Envy",
+			de: "Wirbelnder Neid"
 		},
 
 		cost: ["Darkness"],
@@ -30,7 +36,8 @@ const card: Card = {
 		damage: "20+",
 
 		effect: {
-			en: "If this Pokémon has 2 or more damage counters on it, this attack does 90 more damage. Don't apply Weakness for this attack's damage."
+			en: "If this Pokémon has 2 or more damage counters on it, this attack does 90 more damage. Don't apply Weakness for this attack's damage.",
+			de: "Wenn auf diesem Pokémon 2 oder mehr Schadensmarken liegen, fügt diese Attacke 90 Schadenspunkte mehr zu. Der Schaden dieser Attacke wird durch Schwäche nicht verändert."
 		}
 	}],
 

--- a/data/Mega Evolution/Pitch Black/060.ts
+++ b/data/Mega Evolution/Pitch Black/060.ts
@@ -4,6 +4,11 @@ import Set from "../Pitch Black"
 const card: Card = {
 	set: Set,
 
+	description: {
+		en: "Because it nests in bramble bushes, the feathers of its chicks grow hard from being scratched by thorns.",
+		de: "Da es in dornigem Gestrüpp nistet, wachsen seine Jungen mit häufigen Verletzungen durch Dornen auf, was ihre Federn abhärtet."
+	},
+
 	name: {
 		en: "Skarmory",
 		fr: "Airmure",
@@ -22,7 +27,8 @@ const card: Card = {
 
 	attacks: [{
 		name: {
-			en: "Steel Cutter"
+			en: "Steel Cutter",
+			de: "Stahlschneider"
 		},
 
 		cost: ["Metal"],
@@ -30,7 +36,8 @@ const card: Card = {
 		damage: "40x",
 
 		effect: {
-			en: "Discard up to 2 Basic Metal Energy from your hand. This attack does 40 damage for each card discarded this way."
+			en: "Discard up to 2 Basic Metal Energy from your hand. This attack does 40 damage for each card discarded this way.",
+			de: "Lege bis zu 2 Basis-{M}-Energiekarten aus deiner Hand auf deinen Ablagestapel, und diese Attacke fügt für jede auf diese Weise abgelegte Karte 40 Schadenspunkte zu."
 		}
 	}],
 

--- a/data/Mega Evolution/Pitch Black/061.ts
+++ b/data/Mega Evolution/Pitch Black/061.ts
@@ -4,6 +4,11 @@ import Set from "../Pitch Black"
 const card: Card = {
 	set: Set,
 
+	description: {
+		en: "This Pokémon lived in primeval jungles. It's thought that Shieldon had few enemies thanks to its sturdy face.",
+		de: "Man nimmt an, dass es dank seines gepanzerten Gesichts kaum Feinde hatte. Es lebte vor Urzeiten im Dschungel."
+	},
+
 	name: {
 		en: "Shieldon",
 		fr: "Dinoclier",
@@ -27,7 +32,8 @@ const card: Card = {
 
 	attacks: [{
 		name: {
-			en: "Smithereen Smash"
+			en: "Smithereen Smash",
+			de: "Splitterschlag"
 		},
 
 		cost: ["Metal", "Colorless"],
@@ -35,7 +41,8 @@ const card: Card = {
 		damage: 50,
 
 		effect: {
-			en: "Discard 1 Energy from your opponent's Active Pokémon."
+			en: "Discard 1 Energy from your opponent's Active Pokémon.",
+			de: "Lege 1 Energie vom Aktiven Pokémon deines Gegners auf seinen Ablagestapel."
 		}
 	}],
 

--- a/data/Mega Evolution/Pitch Black/062.ts
+++ b/data/Mega Evolution/Pitch Black/062.ts
@@ -4,6 +4,10 @@ import Set from "../Pitch Black"
 const card: Card = {
 	set: Set,
 
+	description: {
+		en: "Bastiodon live in herds. When assaulted by enemies, they line up side by side and use their hard faces to block attacks."
+	},
+
 	name: {
 		en: "Bastiodon",
 		fr: "Bastiodon",

--- a/data/Mega Evolution/Pitch Black/063.ts
+++ b/data/Mega Evolution/Pitch Black/063.ts
@@ -4,6 +4,10 @@ import Set from "../Pitch Black"
 const card: Card = {
 	set: Set,
 
+	description: {
+		en: "They are found in ancient tombs. The patterns on their backs are said to be imbued with mysterious power."
+	},
+
 	name: {
 		en: "Bronzor",
 		fr: "Archéomire",

--- a/data/Mega Evolution/Pitch Black/064.ts
+++ b/data/Mega Evolution/Pitch Black/064.ts
@@ -4,6 +4,10 @@ import Set from "../Pitch Black"
 const card: Card = {
 	set: Set,
 
+	description: {
+		en: "It brought rains by opening portals to another world. It was revered as a bringer of plentiful harvests."
+	},
+
 	name: {
 		en: "Bronzong",
 		fr: "Archéodong",

--- a/data/Mega Evolution/Pitch Black/065.ts
+++ b/data/Mega Evolution/Pitch Black/065.ts
@@ -28,7 +28,10 @@ const card: Card = {
 
 	attacks: [{
 		name: {
-			en: "Undermine"
+			en: "Undermine",
+			es: "Horadar",
+			'es-mx': "Minería",
+			de: "Untergraben"
 		},
 
 		cost: ["Metal", "Metal"],
@@ -36,11 +39,17 @@ const card: Card = {
 		damage: 90,
 
 		effect: {
-			en: "Discard the top 2 cards of your opponent's deck"
+			en: "Discard the top 2 cards of your opponent's deck",
+			es: "Descarta las 2 primeras cartas de la baraja de tu rival.",
+			'es-mx': "Descarta las primeras 2 cartas del mazo de tu rival.",
+			de: "Lege die obersten 2 Karten des Decks deines Gegners auf seinen Ablagestapel."
 		}
 	}, {
 		name: {
-			en: "Maximum Drilling"
+			en: "Maximum Drilling",
+			es: "Perforación Total",
+			'es-mx': "Taladrado Total",
+			de: "Maximalbohrer"
 		},
 
 		cost: ["Metal", "Metal"],
@@ -48,7 +57,10 @@ const card: Card = {
 		damage: "200+",
 
 		effect: {
-			en: "If you have at least 2 extra Energy attached to this Pokémon, this attack does 130 more damage"
+			en: "If you have at least 2 extra Energy attached to this Pokémon, this attack does 130 more damage",
+			es: "Si este Pokémon tiene por lo menos 2 Energías adicionales unidas (además de las del coste de este ataque), este ataque hace 130 puntos de daño más.",
+			'es-mx': "Si este Pokémon tiene al menos 2 Energías adicionales unidas (además de las del costo de este ataque), este ataque hace 130 puntos de daño más.",
+			de: "Wenn an dieses Pokémon mindestens 2 extra Energien angelegt sind (zusätzlich zu den Kosten dieser Attacke), fügt diese Attacke 130 Schadenspunkte mehr zu."
 		}
 	}],
 

--- a/data/Mega Evolution/Pitch Black/066.ts
+++ b/data/Mega Evolution/Pitch Black/066.ts
@@ -4,6 +4,10 @@ import Set from "../Pitch Black"
 const card: Card = {
 	set: Set,
 
+	description: {
+		en: "Pikipek has strong muscles in its neck, so it won't hurt itself even if it violently shakes its head."
+	},
+
 	name: {
 		en: "Pikipek",
 		fr: "Picassaut",

--- a/data/Mega Evolution/Pitch Black/067.ts
+++ b/data/Mega Evolution/Pitch Black/067.ts
@@ -4,6 +4,11 @@ import Set from "../Pitch Black"
 const card: Card = {
 	set: Set,
 
+	description: {
+		en: "When it encounters foes, it launches the many seeds stored in its beak in a radial burst.",
+		de: "Trifft es auf Feinde, feuert es eine Salve Samen, die es in seinem Schnabel angesammelt hat, auf sie ab."
+	},
+
 	name: {
 		en: "Trumbeak",
 		fr: "Piclairon",
@@ -27,7 +32,8 @@ const card: Card = {
 
 	attacks: [{
 		name: {
-			en: "Fly"
+			en: "Fly",
+			de: "Fliegen"
 		},
 
 		cost: ["Colorless"],
@@ -35,7 +41,8 @@ const card: Card = {
 		damage: 30,
 
 		effect: {
-			en: "Flip a coin. If tails, this attack does nothing. If heads, prevent all effects of attacks, including damage, done to this Pokémon during your opponent's next turn."
+			en: "Flip a coin. If tails, this attack does nothing. If heads, prevent all effects of attacks, including damage, done to this Pokémon during your opponent's next turn.",
+			de: "Wirf 1 Münze. Bei Zahl hat diese Attacke keine Auswirkungen. Verhindere bei Kopf während des nächsten Zuges deines Gegners allen Schaden durch und alle Effekte von Attacken, die diesem Pokémon zugefügt werden."
 		}
 	}],
 

--- a/data/Mega Evolution/Pitch Black/068.ts
+++ b/data/Mega Evolution/Pitch Black/068.ts
@@ -4,6 +4,11 @@ import Set from "../Pitch Black"
 const card: Card = {
 	set: Set,
 
+	description: {
+		en: "Pairs of Toucannon are considered symbols of companionship, as these Pokémon will raise the temperature of their beaks to warm each other.",
+		de: "Tukanon-Pärchen erhöhen die Temperatur ihrer Schnäbel, um sich gegenseitig zu wärmen. Daher gelten sie als Symbol für Harmonie."
+	},
+
 	name: {
 		en: "Toucannon",
 		fr: "Bazoucan",
@@ -29,17 +34,20 @@ const card: Card = {
 		type: "Ability",
 
 		name: {
-			en: "Aerial Draw"
+			en: "Aerial Draw",
+			de: "Höhenzug"
 		},
 
 		effect: {
-			en: "Once during your turn, you may draw 1 card."
+			en: "Once during your turn, you may draw 1 card.",
+			de: "Einmal während deines Zuges kannst du diese Fähigkeit einsetzen. Ziehe 1 Karte."
 		}
 	}],
 
 	attacks: [{
 		name: {
-			en: "Feather Rondo"
+			en: "Feather Rondo",
+			de: "Federrondo"
 		},
 
 		cost: ["Colorless"],
@@ -47,7 +55,8 @@ const card: Card = {
 		damage: "60+",
 
 		effect: {
-			en: "This attack does 20 more damage for each Benched Pokémon (both yours and your opponent's)."
+			en: "This attack does 20 more damage for each Benched Pokémon (both yours and your opponent's).",
+			de: "Diese Attacke fügt für jedes Pokémon auf der Bank (deiner und der deines Gegners) 20 Schadenspunkte mehr zu."
 		}
 	}],
 

--- a/data/Mega Evolution/Pitch Black/069.ts
+++ b/data/Mega Evolution/Pitch Black/069.ts
@@ -4,6 +4,11 @@ import Set from "../Pitch Black"
 const card: Card = {
 	set: Set,
 
+	description: {
+		en: "It was modeled after a mighty Pokémon of myth. The mask placed upon it limits its power in order to keep it under control.",
+		de: "Typ:Null ist eine künstliche Nachbildung eines Pokémon aus einer alten Sage. Die Maske dient dazu, seine Kräfte unter Kontrolle zu halten."
+	},
+
 	name: {
 		en: "Type: Null",
 		fr: "Type:0",
@@ -22,7 +27,8 @@ const card: Card = {
 
 	attacks: [{
 		name: {
-			en: "Power Edge"
+			en: "Power Edge",
+			de: "Kraftklinge"
 		},
 
 		cost: ["Colorless", "Colorless"],

--- a/data/Mega Evolution/Pitch Black/070.ts
+++ b/data/Mega Evolution/Pitch Black/070.ts
@@ -4,6 +4,11 @@ import Set from "../Pitch Black"
 const card: Card = {
 	set: Set,
 
+	description: {
+		en: "The final factor needed to release this Pokémon's true power was a strong bond with a Trainer it trusts.",
+		de: "Der entscheidende Faktor, durch den es seine wahren Kräfte freisetzen kann, ist die enge Bindung zu einem Trainer, dem es vertraut."
+	},
+
 	name: {
 		en: "Silvally",
 		fr: "Silvallié",
@@ -29,17 +34,20 @@ const card: Card = {
 		type: "Ability",
 
 		name: {
-			en: "Call a Buddy"
+			en: "Call a Buddy",
+			de: "Kumpelruf"
 		},
 
 		effect: {
-			en: "Once during your turn (before your attack), if you have 0 cards in your hand, you may search your deck for a Supporter card, reveal it, and put it into your hand. Then shuffle your deck."
+			en: "Once during your turn (before your attack), if you have 0 cards in your hand, you may search your deck for a Supporter card, reveal it, and put it into your hand. Then shuffle your deck.",
+			de: "Einmal während deines Zuges, wenn du keine Karten auf deiner Hand hast, kannst du diese Fähigkeit einsetzen. Durchsuche dein Deck nach 1 Unterstützerkarte, zeige sie deinem Gegner und nimm sie auf deine Hand. Mische anschließend dein Deck."
 		}
 	}],
 
 	attacks: [{
 		name: {
-			en: "Air Slash"
+			en: "Air Slash",
+			de: "Luftschnitt"
 		},
 
 		cost: ["Colorless"],
@@ -47,7 +55,8 @@ const card: Card = {
 		damage: 130,
 
 		effect: {
-			en: "Discard 1 Energy from this Pokémon."
+			en: "Discard 1 Energy from this Pokémon.",
+			de: "Lege 1 Energie von diesem Pokémon auf deinen Ablagestapel."
 		}
 	}],
 

--- a/data/Mega Evolution/Pitch Black/071.ts
+++ b/data/Mega Evolution/Pitch Black/071.ts
@@ -4,6 +4,11 @@ import Set from "../Pitch Black"
 const card: Card = {
 	set: Set,
 
+	description: {
+		en: "Bombirdier uses the apron on its chest to bundle up food, which it carries back to its nest. It enjoys dropping things that make loud noises.",
+		de: "Es wickelt Futter in seine Brustschürze und trägt es so heim ins Nest. Liebend gern lässt es Dinge herabfallen, die beim Aufprall Lärm verursachen."
+	},
+
 	name: {
 		en: "Bombirdier",
 		fr: "Lestombaile",
@@ -22,17 +27,20 @@ const card: Card = {
 
 	attacks: [{
 		name: {
-			en: "Challenginge Delivery"
+			en: "Challenginge Delivery",
+			de: "Schwierige Lieferung"
 		},
 
 		cost: ["Colorless", "Colorless"],
 
 		effect: {
-			en: "Flip 2 coins. If both of them are heads, search your deck for 1 Pokémon and put it onto your Bench, then shuffle your deck."
+			en: "Flip 2 coins. If both of them are heads, search your deck for 1 Pokémon and put it onto your Bench, then shuffle your deck.",
+			de: "Wirf 2 Münzen. Zeigen beide Münzen Kopf, durchsuche dein Deck nach 1 Pokémon und lege es auf deine Bank. Mische anschließend dein Deck."
 		}
 	}, {
 		name: {
-			en: "Speed Wing"
+			en: "Speed Wing",
+			de: "Turboschwinge"
 		},
 
 		cost: ["Colorless", "Colorless", "Colorless"],

--- a/data/Mega Evolution/Pitch Black/074.ts
+++ b/data/Mega Evolution/Pitch Black/074.ts
@@ -19,7 +19,8 @@ const card: Card = {
 	regulationMark: "J",
 
 	effect: {
-		en: "Once during your turn, after you flip any coins for an attack of the Colorless Pokémon this card is attached to, you may ignore all results of those coin flips and begin flipping those coins again."
+		en: "Once during your turn, after you flip any coins for an attack of the Colorless Pokémon this card is attached to, you may ignore all results of those coin flips and begin flipping those coins again.",
+		de: "Einmal während deines Zuges, nachdem du mindestens 1 Münze für eine Attacke des {C}-Pokémon, an das diese Karte angelegt ist, geworfen hast, kannst du alle Ergebnisse jener Münzwürfe ignorieren und jene Münzen erneut werfen.\n\nDu kannst während deines Zuges beliebig viele Pokémon-Ausrüstungen an deine Pokémon anlegen. Du kannst an jedes Pokémon nur 1 Pokémon-Ausrüstung anlegen, und sie bleibt angelegt."
 	},
 
 	variants: [

--- a/data/Mega Evolution/Pitch Black/076.ts
+++ b/data/Mega Evolution/Pitch Black/076.ts
@@ -19,7 +19,8 @@ const card: Card = {
 	regulationMark: "J",
 
 	effect: {
-		en: "Once during each player's turn, that player may search their deck for up to 2 Trainer cards with \"Antique\" in their name and put them onto their Bench. Then, that player shuffles their deck."
+		en: "Once during each player's turn, that player may search their deck for up to 2 Trainer cards with \"Antique\" in their name and put them onto their Bench. Then, that player shuffles their deck.",
+		de: "Einmal während des Zuges jedes Spielers kann jener Spieler sein Deck nach bis zu 2 Itemkarten durchsuchen, bei denen „Antikes\" oder „Antiker\" zum Namen gehört, und sie auf seine Bank legen. Jener Spieler mischt anschließend sein Deck.\n\nDu kannst während deines Zuges nur 1 Stadionkarte spielen. Lege sie neben die Aktive Position, und lege sie auf den Ablagestapel, wenn ein anderes Stadion ins Spiel kommt. Ein Stadion mit demselben Namen kann nicht gespielt werden."
 	},
 
 	variants: [

--- a/data/Mega Evolution/Pitch Black/078.ts
+++ b/data/Mega Evolution/Pitch Black/078.ts
@@ -19,7 +19,8 @@ const card: Card = {
 	regulationMark: "J",
 
 	effect: {
-		en: "Discard up to 2 Pokémon that don't have a Rule Box from your hand, and draw 3 cards for each card you discarded n this way. (Pokémon ex, Pokémon V, etc. have Rule Boxes)"
+		en: "Discard up to 2 Pokémon that don't have a Rule Box from your hand, and draw 3 cards for each card you discarded n this way. (Pokémon ex, Pokémon V, etc. have Rule Boxes)",
+		de: "Lege bis zu 2 Pokémon, die kein Regelfeld haben, aus deiner Hand auf deinen Ablagestapel und ziehe 3 Karten für jede auf diese Weise abgelegte Karte. (Pokémon-ex, Pokémon-V usw. haben Regelfelder.)\n\nDu kannst während deines Zuges nur 1 Unterstützerkarte spielen."
 	},
 
 	variants: [

--- a/data/Mega Evolution/Pitch Black/079.ts
+++ b/data/Mega Evolution/Pitch Black/079.ts
@@ -19,7 +19,8 @@ const card: Card = {
 	regulationMark: "J",
 
 	effect: {
-		en: "Draw a card for each of your opponent's Mega Evolution Pokémon ex in play."
+		en: "Draw a card for each of your opponent's Mega Evolution Pokémon ex in play.",
+		de: "Ziehe 1 Karte für jedes Mega-Entwicklungs-Pokémon-ex deines Gegners im Spiel.\n\nDu kannst während deines Zuges nur 1 Unterstützerkarte spielen."
 	},
 
 	variants: [

--- a/data/Mega Evolution/Pitch Black/080.ts
+++ b/data/Mega Evolution/Pitch Black/080.ts
@@ -19,7 +19,8 @@ const card: Card = {
 	regulationMark: "J",
 
 	effect: {
-		en: "Search your deck for up to 4 Basic Water Energy and attach them to 1 of your Pokémon. Then, shuffle your deck. Your turn ends."
+		en: "Search your deck for up to 4 Basic Water Energy and attach them to 1 of your Pokémon. Then, shuffle your deck. Your turn ends.",
+		de: "Durchsuche dein Deck nach bis zu 4 Basis-{W}-Energiekarten und lege sie an 1 deiner Pokémon an. Mische anschließend dein Deck. Dein Zug endet.\n\nDu kannst während deines Zuges nur 1 Unterstützerkarte spielen."
 	},
 
 	variants: [

--- a/data/Mega Evolution/Pitch Black/081.ts
+++ b/data/Mega Evolution/Pitch Black/081.ts
@@ -19,7 +19,8 @@ const card: Card = {
 	regulationMark: "J",
 
 	effect: {
-		en: "You can use this card only if any of your Pokémon were Knocked Out during your opponent's last turn. Discard an Energy from 1 of your opponent's Pokémon."
+		en: "You can use this card only if any of your Pokémon were Knocked Out during your opponent's last turn. Discard an Energy from 1 of your opponent's Pokémon.",
+		de: "Du kannst diese Karte nur einsetzen, wenn mindestens 1 deiner Pokémon während des letzten Zuges deines Gegners kampfunfähig wurde.\n\nLege 1 Energie von 1 Pokémon deines Gegners auf seinen Ablagestapel.\n\nDu kannst während deines Zuges nur 1 Unterstützerkarte spielen."
 	},
 
 	variants: [

--- a/data/Mega Evolution/Pitch Black/082.ts
+++ b/data/Mega Evolution/Pitch Black/082.ts
@@ -19,7 +19,8 @@ const card: Card = {
 	regulationMark: "J",
 
 	effect: {
-		en: "If the Active Pokémon this card is attached to isn't a Mega Evolution Pokémon ex, is in the Active Spot, and takes 240 or more damage from your opponent's Mega Evolution Pokémon ex (even if this Pokémon is Knocked Out), place 12 damage counters on the Attacking Pokémon. If you placed any damage counters on in this way, discard this card"
+		en: "If the Active Pokémon this card is attached to isn't a Mega Evolution Pokémon ex, is in the Active Spot, and takes 240 or more damage from your opponent's Mega Evolution Pokémon ex (even if this Pokémon is Knocked Out), place 12 damage counters on the Attacking Pokémon. If you placed any damage counters on in this way, discard this card",
+		de: "Wenn das Pokémon, an das diese Karte angelegt istkein Mega-Entwicklungs-Pokémon-ex ist, in der Aktiven Position ist und durch eine Attacke von Mega-Entwicklungs-Pokémon-ex deines Gegners 240 Schadenspunkte oder mehr erhält (auch wenn dieses Pokémon dadurch kampfunfähig wird), lege 12 Schadensmarken auf das Angreifende Pokémon. Wenn du auf diese Weise mindestens 1 Schadensmarke plaziert hast, lege diese Karte auf deinen Ablagestapel.\n\nDu kannst während deines Zuges beliebig viele Itemkarten spielen."
 	},
 
 	variants: [

--- a/data/Mega Evolution/Pitch Black/083.ts
+++ b/data/Mega Evolution/Pitch Black/083.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	regulationMark: "J",
 
 	effect: {
-		en: "As long as the Darkness Pokémon this card is attached to is on your Bench, prevent all damage done to it by attacks from your opponent's Pokémon"
+		en: "As long as the Darkness Pokémon this card is attached to is on your Bench, prevent all damage done to it by attacks from your opponent's Pokémon",
+		de: "Solange diese Karte an ein Pokémon angelegt ist, liefert sie {D}-Energie.\n\nSolange das {D}-Pokémon, an das diese Karte angelegt ist, auf deiner Bank ist, verhindere allen Schaden, der ihm durch Attacken von Pokémon deines Gegners zugefügt wird."
 	},
 
 	variants: [

--- a/data/Mega Evolution/Pitch Black/084.ts
+++ b/data/Mega Evolution/Pitch Black/084.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	regulationMark: "J",
 
 	effect: {
-		en: "While attached to a Pokémon, this card provides 1 Lightning Energy. Attacks used by the Lightning Pokémon this card is attached to deal 20 more damage to your opponent's Active Pokémon."
+		en: "While attached to a Pokémon, this card provides 1 Lightning Energy. Attacks used by the Lightning Pokémon this card is attached to deal 20 more damage to your opponent's Active Pokémon.",
+		de: "Solange diese Karte an ein Pokémon angelegt ist, liefert sie {L}-Energie.\n\nDie eingesetzten Attacken des {L}-Pokémon, an das diese Karte angelegt ist, fügen dem Aktiven Pokémon deines Gegners 20 Schadenspunkte mehr zu (bevor Schwäche und Resistenz verrechnet werden)."
 	},
 
 	variants: [

--- a/data/Mega Evolution/Pitch Black/085.ts
+++ b/data/Mega Evolution/Pitch Black/085.ts
@@ -4,6 +4,11 @@ import Set from "../Pitch Black"
 const card: Card = {
 	set: Set,
 
+	description: {
+		en: "Many Trainers give their Fomantis their own flowerpots so they can sunbathe in peace and quiet.",
+		de: "Viele Trainer geben Imantis einen eigenen Blumentopf, damit es ungestört sonnenbaden kann."
+	},
+
 	name: {
 		en: "Fomantis",
 		fr: "Mimantis",
@@ -22,7 +27,8 @@ const card: Card = {
 
 	attacks: [{
 		name: {
-			en: "Reckless Charge"
+			en: "Reckless Charge",
+			de: "Waghalsiger Sturmangriff"
 		},
 
 		cost: ["Grass"],
@@ -30,7 +36,8 @@ const card: Card = {
 		damage: 30,
 
 		effect: {
-			en: "This Pokémon also does 10 damage to itself"
+			en: "This Pokémon also does 10 damage to itself",
+			de: "Dieses Pokémon fügt auch sich selbst 10 Schadenspunkte zu."
 		}
 	}],
 

--- a/data/Mega Evolution/Pitch Black/086.ts
+++ b/data/Mega Evolution/Pitch Black/086.ts
@@ -4,6 +4,11 @@ import Set from "../Pitch Black"
 const card: Card = {
 	set: Set,
 
+	description: {
+		en: "This Pokémon clads itself in armor that has been fortified by psychic and fire energy, and it shoots blazing fireballs.",
+		de: "Es trägt eine Rüstung, die mit Psycho- sowie Feuer-Energie verstärkt wurde, und verschießt glühend heiße Feuerbälle."
+	},
+
 	name: {
 		en: "Armarouge",
 		fr: "Carmadura",
@@ -27,7 +32,10 @@ const card: Card = {
 
 	attacks: [{
 		name: {
-			en: "Flame Legion"
+			en: "Flame Legion",
+			es: "Legión de Llamas",
+			'es-mx': "Legión de Fuego",
+			de: "Flammenlegion"
 		},
 
 		cost: ["Fire"],
@@ -35,7 +43,10 @@ const card: Card = {
 		damage: "40+",
 
 		effect: {
-			en: "This attack does 40 more damage for each of your Benched Pokémon that have Fire Energy attached"
+			en: "This attack does 40 more damage for each of your Benched Pokémon that have Fire Energy attached",
+			es: "Este ataque hace 40 puntos de daño más por cada uno de tus Pokémon en Banca que tengan alguna Energía {R} unida.",
+			'es-mx': "Este ataque hace 40 puntos de daño más por cada uno de tus Pokémon en Banca que tengan alguna Energía {R} unida.",
+			de: "Diese Attacke fügt für jedes Pokémon auf deiner Bank, an das mindestens 1 {R}-Energie angelegt ist, 40 Schadenspunkte mehr zu."
 		}
 	}],
 

--- a/data/Mega Evolution/Pitch Black/087.ts
+++ b/data/Mega Evolution/Pitch Black/087.ts
@@ -4,6 +4,11 @@ import Set from "../Pitch Black"
 const card: Card = {
 	set: Set,
 
+	description: {
+		en: "Its dorsal, pectoral, and tail fins wave elegantly in water. That is why it is known as the Water Dancer.",
+		de: "Seine Brust-, Rücken- und Schwanzflossen bewegen sich anmutig. Daher nennt man es den „Wassertänzer\"."
+	},
+
 	name: {
 		en: "Goldeen",
 		fr: "Poissirène",
@@ -22,7 +27,8 @@ const card: Card = {
 
 	attacks: [{
 		name: {
-			en: "Pierce"
+			en: "Pierce",
+			de: "Durchbohren"
 		},
 
 		cost: ["Colorless", "Colorless"],

--- a/data/Mega Evolution/Pitch Black/088.ts
+++ b/data/Mega Evolution/Pitch Black/088.ts
@@ -4,6 +4,10 @@ import Set from "../Pitch Black"
 const card: Card = {
 	set: Set,
 
+	description: {
+		en: "Also known as a songstress, it is a sight to behold on moonlit nights when it sings in front of the colony it leads."
+	},
+
 	name: {
 		en: "Primarina",
 		fr: "Oratoria",

--- a/data/Mega Evolution/Pitch Black/089.ts
+++ b/data/Mega Evolution/Pitch Black/089.ts
@@ -4,6 +4,10 @@ import Set from "../Pitch Black"
 const card: Card = {
 	set: Set,
 
+	description: {
+		en: "It discharges electricity from its mane. The Pokémon creates a thundercloud overhead from which to drop lightning bolts."
+	},
+
 	name: {
 		en: "Manectric",
 		fr: "Élecsprint",

--- a/data/Mega Evolution/Pitch Black/090.ts
+++ b/data/Mega Evolution/Pitch Black/090.ts
@@ -4,6 +4,11 @@ import Set from "../Pitch Black"
 const card: Card = {
 	set: Set,
 
+	description: {
+		en: "An attached Shellder won't let go because of the tasty flavor that oozes out of Slowbro's tail.",
+		de: "Das Muschas an seiner Rute lässt nicht locker, da ein leckerer Geschmack aus dieser strömt."
+	},
+
 	name: {
 		en: "Slowbro",
 		fr: "Flagadoss",
@@ -27,7 +32,10 @@ const card: Card = {
 
 	attacks: [{
 		name: {
-			en: "All Out"
+			en: "All Out",
+			es: "A por Todas",
+			'es-mx': "Sin Más",
+			de: "Aufs Ganze gehen"
 		},
 
 		cost: ["Psychic"],
@@ -35,11 +43,17 @@ const card: Card = {
 		damage: "50+",
 
 		effect: {
-			en: "If you have no cards in your hand, this attack does 160 more damage."
+			en: "If you have no cards in your hand, this attack does 160 more damage.",
+			es: "Si no tienes ninguna carta en tu mano, este ataque hace 160 puntos de daño más.",
+			'es-mx': "Si no tienes ninguna carta en tu mano, este ataque hace 160 puntos de daño más.",
+			de: "Wenn du keine Karten auf deiner Hand hast, fügt diese Attacke 160 Schadenspunkte mehr zu."
 		}
 	}, {
 		name: {
-			en: "Zen Headbutt"
+			en: "Zen Headbutt",
+			es: "Cabezazo Zen",
+			'es-mx': "Cabezazo Zen",
+			de: "Zen-Kopfstoß"
 		},
 
 		cost: ["Colorless", "Colorless", "Colorless"],

--- a/data/Mega Evolution/Pitch Black/091.ts
+++ b/data/Mega Evolution/Pitch Black/091.ts
@@ -4,6 +4,11 @@ import Set from "../Pitch Black"
 const card: Card = {
 	set: Set,
 
+	description: {
+		en: "After a piece of seaweed merged with debris from a sunken ship, it was reborn as this ghost Pokémon.",
+		de: "Dieses Geister-Pokémon entstand, als sich vom Meeresgrund stammendes Seegras auf Bruchstücken eines Schiffswracks ablagerte."
+	},
+
 	name: {
 		en: "Dhelmise",
 		fr: "Sinistrail",
@@ -22,7 +27,10 @@ const card: Card = {
 
 	attacks: [{
 		name: {
-			en: "Vengeful Anchor"
+			en: "Vengeful Anchor",
+			es: "Ancla Vengativa",
+			'es-mx': "Ancla Vengativa",
+			de: "Verankerte Rache"
 		},
 
 		cost: ["Psychic"],
@@ -30,7 +38,10 @@ const card: Card = {
 		damage: "30+",
 
 		effect: {
-			en: "If you have 4 or more Pokémon with the Hide 'n' Sneak Ability in your discard pile, this attack does 140 more damage."
+			en: "If you have 4 or more Pokémon with the Hide 'n' Sneak Ability in your discard pile, this attack does 140 more damage.",
+			es: "Si tienes en tu pila de descartes 4 Pokémon o más que tengan la habilidad Escondite a Hurtadillas, este ataque hace 140 puntos de daño más.",
+			'es-mx': "Si tienes 4 Pokémon o más que tengan la Habilidad Escondidas Furtivas en tu pila de descartes, este ataque hace 140 puntos de daño más.",
+			de: "Wenn du 4 oder mehr Pokémon, die die Fähigkeit Listiges Versteckspiel haben, in deinem Ablagestapel hast, fügt diese Attacke 140 Schadenspunkte mehr zu."
 		}
 	}],
 

--- a/data/Mega Evolution/Pitch Black/092.ts
+++ b/data/Mega Evolution/Pitch Black/092.ts
@@ -4,6 +4,10 @@ import Set from "../Pitch Black"
 const card: Card = {
 	set: Set,
 
+	description: {
+		en: "It secretly marks potential targets with a scent. By following the scent, it stalks its targets and steals from them when they least expect it."
+	},
+
 	name: {
 		en: "Thievul",
 		fr: "Roublenard",

--- a/data/Mega Evolution/Pitch Black/093.ts
+++ b/data/Mega Evolution/Pitch Black/093.ts
@@ -4,6 +4,10 @@ import Set from "../Pitch Black"
 const card: Card = {
 	set: Set,
 
+	description: {
+		en: "Bastiodon live in herds. When assaulted by enemies, they line up side by side and use their hard faces to block attacks."
+	},
+
 	name: {
 		en: "Bastiodon",
 		fr: "Bastiodon",

--- a/data/Mega Evolution/Pitch Black/094.ts
+++ b/data/Mega Evolution/Pitch Black/094.ts
@@ -4,6 +4,11 @@ import Set from "../Pitch Black"
 const card: Card = {
 	set: Set,
 
+	description: {
+		en: "Pairs of Toucannon are considered symbols of companionship, as these Pokémon will raise the temperature of their beaks to warm each other.",
+		de: "Tukanon-Pärchen erhöhen die Temperatur ihrer Schnäbel, um sich gegenseitig zu wärmen. Daher gelten sie als Symbol für Harmonie."
+	},
+
 	name: {
 		en: "Toucannon",
 		fr: "Bazoucan",
@@ -29,17 +34,20 @@ const card: Card = {
 		type: "Ability",
 
 		name: {
-			en: "Sky Draw"
+			en: "Sky Draw",
+			de: "Höhenzug"
 		},
 
 		effect: {
-			en: "Once during your turn, you may draw 1 card."
+			en: "Once during your turn, you may draw 1 card.",
+			de: "Einmal während deines Zuges kannst du diese Fähigkeit einsetzen. Ziehe 1 Karte."
 		}
 	}],
 
 	attacks: [{
 		name: {
-			en: "Feather Rondo"
+			en: "Feather Rondo",
+			de: "Federrondo"
 		},
 
 		cost: ["Colorless"],
@@ -47,7 +55,8 @@ const card: Card = {
 		damage: "60+",
 
 		effect: {
-			en: "This attack does 20 more damage for each Benched Pokémon (both yours and your opponent's)."
+			en: "This attack does 20 more damage for each Benched Pokémon (both yours and your opponent's).",
+			de: "Diese Attacke fügt für jedes Pokémon auf der Bank (deiner und der deines Gegners) 20 Schadenspunkte mehr zu."
 		}
 	}],
 

--- a/data/Mega Evolution/Pitch Black/095.ts
+++ b/data/Mega Evolution/Pitch Black/095.ts
@@ -4,6 +4,11 @@ import Set from "../Pitch Black"
 const card: Card = {
 	set: Set,
 
+	description: {
+		en: "The final factor needed to release this Pokémon's true power was a strong bond with a Trainer it trusts.",
+		de: "Der entscheidende Faktor, durch den es seine wahren Kräfte freisetzen kann, ist die enge Bindung zu einem Trainer, dem es vertraut."
+	},
+
 	name: {
 		en: "Silvally",
 		fr: "Silvallié",
@@ -29,17 +34,20 @@ const card: Card = {
 		type: "Ability",
 
 		name: {
-			en: "Call a Buddy"
+			en: "Call a Buddy",
+			de: "Kumpelruf"
 		},
 
 		effect: {
-			en: "Once during your turn (before your attack), if you have 0 cards in your hand, you may search your deck for a Supporter card, reveal it, and put it into your hand. Then shuffle your deck."
+			en: "Once during your turn (before your attack), if you have 0 cards in your hand, you may search your deck for a Supporter card, reveal it, and put it into your hand. Then shuffle your deck.",
+			de: "Einmal während deines Zuges, wenn du keine Karten auf deiner Hand hast, kannst du diese Fähigkeit einsetzen. Durchsuche dein Deck nach 1 Unterstützerkarte, zeige sie deinem Gegner und nimm sie auf deine Hand. Mische anschließend dein Deck."
 		}
 	}],
 
 	attacks: [{
 		name: {
-			en: "Air Slash"
+			en: "Air Slash",
+			de: "Luftschnitt"
 		},
 
 		cost: ["Colorless"],
@@ -47,7 +55,8 @@ const card: Card = {
 		damage: 130,
 
 		effect: {
-			en: "Discard 1 Energy from this Pokémon."
+			en: "Discard 1 Energy from this Pokémon.",
+			de: "Lege 1 Energie von diesem Pokémon auf deinen Ablagestapel."
 		}
 	}],
 

--- a/data/Mega Evolution/Pitch Black/096.ts
+++ b/data/Mega Evolution/Pitch Black/096.ts
@@ -28,7 +28,8 @@ const card: Card = {
 
 	attacks: [{
 		name: {
-			en: "Vigorous Cutter"
+			en: "Vigorous Cutter",
+			de: "Rasante Schneide"
 		},
 
 		cost: ["Grass"],
@@ -36,7 +37,8 @@ const card: Card = {
 		damage: "60+",
 
 		effect: {
-			en: "If this Pokémon recovered any HP this turn, this attack does 200 more damage."
+			en: "If this Pokémon recovered any HP this turn, this attack does 200 more damage.",
+			de: "Wenn dieses Pokémon während dieses Zuges geheilt wurde, fügt diese Attacke 200 Schadenspunkte mehr zu."
 		}
 	}, {
 		name: {
@@ -48,7 +50,8 @@ const card: Card = {
 		damage: 140,
 
 		effect: {
-			en: "During your opponent's next turn, this Pokémon takes 50 less damage from attacks."
+			en: "During your opponent's next turn, this Pokémon takes 50 less damage from attacks.",
+			de: "Während des nächsten Zuges deines Gegners werden diesem Pokémon durch Attacken 50 Schadenspunkte weniger zugefügt (nachdem Schwäche und Resistenz verrechnet wurden)."
 		}
 	}],
 

--- a/data/Mega Evolution/Pitch Black/097.ts
+++ b/data/Mega Evolution/Pitch Black/097.ts
@@ -28,7 +28,8 @@ const card: Card = {
 
 	attacks: [{
 		name: {
-			en: "Surf"
+			en: "Surf",
+			de: "Surfer"
 		},
 
 		cost: ["Water", "Water", "Water"],
@@ -36,7 +37,8 @@ const card: Card = {
 		damage: 120
 	}, {
 		name: {
-			en: "Falling Down"
+			en: "Falling Down",
+			de: "Hinfallen"
 		},
 
 		cost: ["Water", "Water", "Water", "Water", "Water"],
@@ -44,7 +46,8 @@ const card: Card = {
 		damage: 270,
 
 		effect: {
-			en: "This Pokémon is now Asleep"
+			en: "This Pokémon is now Asleep",
+			de: "Dieses Pokémon schläft jetzt."
 		}
 	}],
 

--- a/data/Mega Evolution/Pitch Black/098.ts
+++ b/data/Mega Evolution/Pitch Black/098.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	attacks: [{
 		name: {
-			en: "Thunderous Fist"
+			en: "Thunderous Fist",
+			de: "Donnerfäuste"
 		},
 
 		cost: ["Lightning"],
@@ -31,11 +32,13 @@ const card: Card = {
 		damage: "60x",
 
 		effect: {
-			en: "This attack does 60 damage for each Lightning Energy attached to this Pokémon."
+			en: "This attack does 60 damage for each Lightning Energy attached to this Pokémon.",
+			de: "Diese Attacke fügt für jede an dieses Pokémon angelegte {L}-Energie 60 Schadenspunkte zu."
 		}
 	}, {
 		name: {
-			en: "Zepto Turn"
+			en: "Zepto Turn",
+			de: "Zepto-Drehung"
 		},
 
 		cost: ["Lightning", "Lightning", "Lightning"],
@@ -43,7 +46,8 @@ const card: Card = {
 		damage: 150,
 
 		effect: {
-			en: "Switch this Pokémon with one of your Benched Pokémon."
+			en: "Switch this Pokémon with one of your Benched Pokémon.",
+			de: "Tausche dieses Pokémon gegen 1 Pokémon auf deiner Bank aus."
 		}
 	}],
 

--- a/data/Mega Evolution/Pitch Black/099.ts
+++ b/data/Mega Evolution/Pitch Black/099.ts
@@ -30,17 +30,26 @@ const card: Card = {
 		type: "Ability",
 
 		name: {
-			en: "Binding Flame"
+			en: "Binding Flame",
+			es: "Atadura Ígnea",
+			'es-mx': "Atadura Llameante",
+			de: "Fesselnde Flamme"
 		},
 
 		effect: {
-			en: "Your opponent's Pokémon's Retreat Cost is 1 more"
+			en: "Your opponent's Pokémon's Retreat Cost is 1 more",
+			es: "El de Retirada del Pokémon Activo de tu rival es de {C} más.",
+			'es-mx': "El de Retirada del Pokémon Activo de tu rival es de {C} más.",
+			de: "Die Rückzugskosten des Aktiven Pokémon deines Gegners erhöhen sich um {C}."
 		}
 	}],
 
 	attacks: [{
 		name: {
-			en: "Phantom Maze"
+			en: "Phantom Maze",
+			es: "Laberinto Fantasmal",
+			'es-mx': "Laberinto Fantasma",
+			de: "Phantomlabyrinth"
 		},
 
 		cost: ["Psychic", "Psychic"],
@@ -48,7 +57,10 @@ const card: Card = {
 		damage: "130+",
 
 		effect: {
-			en: "This attack does 50 more damage for each Energy in your opponent's Active Pokémon's Retreat Cost."
+			en: "This attack does 50 more damage for each Energy in your opponent's Active Pokémon's Retreat Cost.",
+			es: "Este ataque hace 50 puntos de daño más por cada {C} en el Coste de Retirada del Pokémon Activo de tu rival.",
+			'es-mx': "Este ataque hace 50 puntos de daño más por cada {C} en el Coste de Retirada del Pokémon Activo de tu rival.",
+			de: "Diese Attacke fügt für jedes {C} in den Rückzugskosten des Aktiven Pokémon deines Gegners 50 Schadenspunkte mehr zu."
 		}
 	}],
 

--- a/data/Mega Evolution/Pitch Black/101.ts
+++ b/data/Mega Evolution/Pitch Black/101.ts
@@ -23,7 +23,10 @@ const card: Card = {
 
 	attacks: [{
 		name: {
-			en: "Dusk Raid"
+			en: "Dusk Raid",
+			es: "Incursión Crepuscular",
+			'es-mx': "Redada Crepuscular",
+			de: "Finsterer Überfall"
 		},
 
 		cost: ["Darkness", "Darkness"],
@@ -31,17 +34,26 @@ const card: Card = {
 		damage: "110+",
 
 		effect: {
-			en: "If any of your Benched Pokémon have any damage counters on them, this attack does 110 more damage."
+			en: "If any of your Benched Pokémon have any damage counters on them, this attack does 110 more damage.",
+			es: "Si tus Pokémon en Banca tienen algún contador de daño sobre ellos, este ataque hace 110 puntos de daño más.",
+			'es-mx': "Si tus Pokémon en Banca tienen algún contador de daño sobre ellos, este ataque hace 110 puntos de daño más.",
+			de: "Wenn auf den Pokémon auf deiner Bank mindestens 1 Schadensmarke liegt, fügt diese Attacke 110 Schadenspunkte mehr zu."
 		}
 	}, {
 		name: {
-			en: "Abyss Eye"
+			en: "Abyss Eye",
+			es: "Ojo Abismal",
+			'es-mx': "Ojo Abismal",
+			de: "Abgrundauge"
 		},
 
 		cost: ["Darkness", "Darkness", "Darkness"],
 
 		effect: {
-			en: "If your opponent's Active Pokémon is affected by any Special Condition, it is now Knocked Out."
+			en: "If your opponent's Active Pokémon is affected by any Special Condition, it is now Knocked Out.",
+			es: "Si el Pokémon Activo de tu rival se ve afectado por una Condición Especial, queda Fuera de Combate.",
+			'es-mx': "Si el Pokémon Activo de tu rival se ve afectado por una Condición Especial, queda Fuera de Combate.",
+			de: "Wenn das Aktive Pokémon deines Gegners von einem Speziellen Zustand betroffen ist, ist es kampfunfähig."
 		}
 	}],
 

--- a/data/Mega Evolution/Pitch Black/103.ts
+++ b/data/Mega Evolution/Pitch Black/103.ts
@@ -28,7 +28,10 @@ const card: Card = {
 
 	attacks: [{
 		name: {
-			en: "Undermine"
+			en: "Undermine",
+			es: "Horadar",
+			'es-mx': "Minería",
+			de: "Untergraben"
 		},
 
 		cost: ["Metal", "Metal"],
@@ -36,11 +39,17 @@ const card: Card = {
 		damage: 90,
 
 		effect: {
-			en: "Discard the top 2 cards of your opponent's deck"
+			en: "Discard the top 2 cards of your opponent's deck",
+			es: "Descarta las 2 primeras cartas de la baraja de tu rival.",
+			'es-mx': "Descarta las primeras 2 cartas del mazo de tu rival.",
+			de: "Lege die obersten 2 Karten des Decks deines Gegners auf seinen Ablagestapel."
 		}
 	}, {
 		name: {
-			en: "Maximum Drilling"
+			en: "Maximum Drilling",
+			es: "Perforación Total",
+			'es-mx': "Taladrado Total",
+			de: "Maximalbohrer"
 		},
 
 		cost: ["Metal", "Metal"],
@@ -48,7 +57,10 @@ const card: Card = {
 		damage: "200+",
 
 		effect: {
-			en: "If you have at least 2 extra Energy attached to this Pokémon, this attack does 130 more damage"
+			en: "If you have at least 2 extra Energy attached to this Pokémon, this attack does 130 more damage",
+			es: "Si este Pokémon tiene por lo menos 2 Energías adicionales unidas (además de las del coste de este ataque), este ataque hace 130 puntos de daño más.",
+			'es-mx': "Si este Pokémon tiene al menos 2 Energías adicionales unidas (además de las del costo de este ataque), este ataque hace 130 puntos de daño más.",
+			de: "Wenn an dieses Pokémon mindestens 2 extra Energien angelegt sind (zusätzlich zu den Kosten dieser Attacke), fügt diese Attacke 130 Schadenspunkte mehr zu."
 		}
 	}],
 

--- a/data/Mega Evolution/Pitch Black/109.ts
+++ b/data/Mega Evolution/Pitch Black/109.ts
@@ -19,7 +19,8 @@ const card: Card = {
 	regulationMark: "J",
 
 	effect: {
-		en: "Discard up to 2 Pokémon that don't have a Rule Box from your hand, and draw 3 cards for each card you discarded n this way. (Pokémon ex, Pokémon V, etc. have Rule Boxes)"
+		en: "Discard up to 2 Pokémon that don't have a Rule Box from your hand, and draw 3 cards for each card you discarded n this way. (Pokémon ex, Pokémon V, etc. have Rule Boxes)",
+		de: "Lege bis zu 2 Pokémon, die kein Regelfeld haben, aus deiner Hand auf deinen Ablagestapel und ziehe 3 Karten für jede auf diese Weise abgelegte Karte. (Pokémon-ex, Pokémon-V usw. haben Regelfelder.)\n\nDu kannst während deines Zuges nur 1 Unterstützerkarte spielen."
 	},
 
 	variants: [

--- a/data/Mega Evolution/Pitch Black/111.ts
+++ b/data/Mega Evolution/Pitch Black/111.ts
@@ -19,7 +19,8 @@ const card: Card = {
 	regulationMark: "J",
 
 	effect: {
-		en: "Search your deck for up to 4 Basic Water Energy and attach them to 1 of your Pokémon, then shuffle your deck. Your turn ends."
+		en: "Search your deck for up to 4 Basic Water Energy and attach them to 1 of your Pokémon, then shuffle your deck. Your turn ends.",
+		de: "Durchsuche dein Deck nach bis zu 4 Basis-{W}-Energiekarten und lege sie an 1 deiner Pokémon an. Mische anschließend dein Deck. Dein Zug endet.\n\nDu kannst während deines Zuges nur 1 Unterstützerkarte spielen."
 	},
 
 	variants: [

--- a/data/Mega Evolution/Pitch Black/112.ts
+++ b/data/Mega Evolution/Pitch Black/112.ts
@@ -19,7 +19,8 @@ const card: Card = {
 	regulationMark: "J",
 
 	effect: {
-		en: "You can use this card only if any of your Pokémon were Knocked Out during your opponent's last turn. Discard 1 Energy from 1 of your opponent's Pokémon."
+		en: "You can use this card only if any of your Pokémon were Knocked Out during your opponent's last turn. Discard 1 Energy from 1 of your opponent's Pokémon.",
+		de: "Du kannst diese Karte nur einsetzen, wenn mindestens 1 deiner Pokémon während des letzten Zuges deines Gegners kampfunfähig wurde.\n\nLege 1 Energie von 1 Pokémon deines Gegners auf seinen Ablagestapel.\n\nDu kannst während deines Zuges nur 1 Unterstützerkarte spielen."
 	},
 
 	variants: [

--- a/data/Mega Evolution/Pitch Black/113.ts
+++ b/data/Mega Evolution/Pitch Black/113.ts
@@ -19,7 +19,8 @@ const card: Card = {
 	regulationMark: "J",
 
 	effect: {
-		en: "If the Active Pokémon this card is attached to is not a Mega Pokémon ex and takes 240 damage or more from an attack from your opponent's Mega Pokémon ex, put 12 damage counters on the attacking Pokémon and discard this card."
+		en: "If the Active Pokémon this card is attached to is not a Mega Pokémon ex and takes 240 damage or more from an attack from your opponent's Mega Pokémon ex, put 12 damage counters on the attacking Pokémon and discard this card.",
+		de: "Wenn das Pokémon, an das diese Karte angelegt istkein Mega-Entwicklungs-Pokémon-ex ist, in der Aktiven Position ist und durch eine Attacke von Mega-Entwicklungs-Pokémon-ex deines Gegners 240 Schadenspunkte oder mehr erhält (auch wenn dieses Pokémon dadurch kampfunfähig wird), lege 12 Schadensmarken auf das Angreifende Pokémon. Wenn du auf diese Weise mindestens 1 Schadensmarke plaziert hast, lege diese Karte auf deinen Ablagestapel.\n\nDu kannst während deines Zuges beliebig viele Itemkarten spielen."
 	},
 
 	variants: [

--- a/data/Mega Evolution/Pitch Black/114.ts
+++ b/data/Mega Evolution/Pitch Black/114.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	attacks: [{
 		name: {
-			en: "Thunderous Fist"
+			en: "Thunderous Fist",
+			de: "Donnerfäuste"
 		},
 
 		cost: ["Lightning"],
@@ -31,11 +32,13 @@ const card: Card = {
 		damage: "60x",
 
 		effect: {
-			en: "This attack does 60 damage for each Lightning Energy attached to this Pokémon."
+			en: "This attack does 60 damage for each Lightning Energy attached to this Pokémon.",
+			de: "Diese Attacke fügt für jede an dieses Pokémon angelegte {L}-Energie 60 Schadenspunkte zu."
 		}
 	}, {
 		name: {
-			en: "Zepto Turn"
+			en: "Zepto Turn",
+			de: "Zepto-Drehung"
 		},
 
 		cost: ["Lightning", "Lightning", "Lightning"],
@@ -43,7 +46,8 @@ const card: Card = {
 		damage: 150,
 
 		effect: {
-			en: "Switch this Pokémon with one of your Benched Pokémon."
+			en: "Switch this Pokémon with one of your Benched Pokémon.",
+			de: "Tausche dieses Pokémon gegen 1 Pokémon auf deiner Bank aus."
 		}
 	}],
 

--- a/data/Mega Evolution/Pitch Black/115.ts
+++ b/data/Mega Evolution/Pitch Black/115.ts
@@ -30,17 +30,26 @@ const card: Card = {
 		type: "Ability",
 
 		name: {
-			en: "Binding Flame"
+			en: "Binding Flame",
+			es: "Atadura Ígnea",
+			'es-mx': "Atadura Llameante",
+			de: "Fesselnde Flamme"
 		},
 
 		effect: {
-			en: "Your opponent's Pokémon's Retreat Cost is 1 more"
+			en: "Your opponent's Pokémon's Retreat Cost is 1 more",
+			es: "El de Retirada del Pokémon Activo de tu rival es de {C} más.",
+			'es-mx': "El de Retirada del Pokémon Activo de tu rival es de {C} más.",
+			de: "Die Rückzugskosten des Aktiven Pokémon deines Gegners erhöhen sich um {C}."
 		}
 	}],
 
 	attacks: [{
 		name: {
-			en: "Phantom Maze"
+			en: "Phantom Maze",
+			es: "Laberinto Fantasmal",
+			'es-mx': "Laberinto Fantasma",
+			de: "Phantomlabyrinth"
 		},
 
 		cost: ["Psychic", "Psychic"],
@@ -48,7 +57,10 @@ const card: Card = {
 		damage: "130+",
 
 		effect: {
-			en: "This attack does 50 more damage for each Energy in your opponent's Active Pokémon's Retreat Cost."
+			en: "This attack does 50 more damage for each Energy in your opponent's Active Pokémon's Retreat Cost.",
+			es: "Este ataque hace 50 puntos de daño más por cada {C} en el Coste de Retirada del Pokémon Activo de tu rival.",
+			'es-mx': "Este ataque hace 50 puntos de daño más por cada {C} en el Coste de Retirada del Pokémon Activo de tu rival.",
+			de: "Diese Attacke fügt für jedes {C} in den Rückzugskosten des Aktiven Pokémon deines Gegners 50 Schadenspunkte mehr zu."
 		}
 	}],
 

--- a/data/Mega Evolution/Pitch Black/116.ts
+++ b/data/Mega Evolution/Pitch Black/116.ts
@@ -23,7 +23,10 @@ const card: Card = {
 
 	attacks: [{
 		name: {
-			en: "Dusk Raid"
+			en: "Dusk Raid",
+			es: "Incursión Crepuscular",
+			'es-mx': "Redada Crepuscular",
+			de: "Finsterer Überfall"
 		},
 
 		cost: ["Darkness", "Darkness"],
@@ -31,17 +34,26 @@ const card: Card = {
 		damage: "110+",
 
 		effect: {
-			en: "If any of your Benched Pokémon have any damage counters on them, this attack does 110 more damage."
+			en: "If any of your Benched Pokémon have any damage counters on them, this attack does 110 more damage.",
+			es: "Si tus Pokémon en Banca tienen algún contador de daño sobre ellos, este ataque hace 110 puntos de daño más.",
+			'es-mx': "Si tus Pokémon en Banca tienen algún contador de daño sobre ellos, este ataque hace 110 puntos de daño más.",
+			de: "Wenn auf den Pokémon auf deiner Bank mindestens 1 Schadensmarke liegt, fügt diese Attacke 110 Schadenspunkte mehr zu."
 		}
 	}, {
 		name: {
-			en: "Abyss Eye"
+			en: "Abyss Eye",
+			es: "Ojo Abismal",
+			'es-mx': "Ojo Abismal",
+			de: "Abgrundauge"
 		},
 
 		cost: ["Darkness", "Darkness", "Darkness"],
 
 		effect: {
-			en: "If your opponent's Active Pokémon is affected by any Special Condition, it is now Knocked Out."
+			en: "If your opponent's Active Pokémon is affected by any Special Condition, it is now Knocked Out.",
+			es: "Si el Pokémon Activo de tu rival se ve afectado por una Condición Especial, queda Fuera de Combate.",
+			'es-mx': "Si el Pokémon Activo de tu rival se ve afectado por una Condición Especial, queda Fuera de Combate.",
+			de: "Wenn das Aktive Pokémon deines Gegners von einem Speziellen Zustand betroffen ist, ist es kampfunfähig."
 		}
 	}],
 

--- a/data/Mega Evolution/Pitch Black/119.ts
+++ b/data/Mega Evolution/Pitch Black/119.ts
@@ -19,7 +19,8 @@ const card: Card = {
 	regulationMark: "J",
 
 	effect: {
-		en: "Discard up to 2 Pokémon that don't have a Rule Box from your hand, and draw 3 cards for each card you discarded n this way. (Pokémon ex, Pokémon V, etc. have Rule Boxes)"
+		en: "Discard up to 2 Pokémon that don't have a Rule Box from your hand, and draw 3 cards for each card you discarded n this way. (Pokémon ex, Pokémon V, etc. have Rule Boxes)",
+		de: "Lege bis zu 2 Pokémon, die kein Regelfeld haben, aus deiner Hand auf deinen Ablagestapel und ziehe 3 Karten für jede auf diese Weise abgelegte Karte. (Pokémon-ex, Pokémon-V usw. haben Regelfelder.)\n\nDu kannst während deines Zuges nur 1 Unterstützerkarte spielen."
 	},
 
 	variants: [

--- a/data/Mega Evolution/Pitch Black/120.ts
+++ b/data/Mega Evolution/Pitch Black/120.ts
@@ -23,7 +23,10 @@ const card: Card = {
 
 	attacks: [{
 		name: {
-			en: "Dusk Raid"
+			en: "Dusk Raid",
+			es: "Incursión Crepuscular",
+			'es-mx': "Redada Crepuscular",
+			de: "Finsterer Überfall"
 		},
 
 		cost: ["Darkness", "Darkness"],
@@ -31,17 +34,26 @@ const card: Card = {
 		damage: "110+",
 
 		effect: {
-			en: "If any of your Benched Pokémon have any damage counters on them, this attack does 110 more damage."
+			en: "If any of your Benched Pokémon have any damage counters on them, this attack does 110 more damage.",
+			es: "Si tus Pokémon en Banca tienen algún contador de daño sobre ellos, este ataque hace 110 puntos de daño más.",
+			'es-mx': "Si tus Pokémon en Banca tienen algún contador de daño sobre ellos, este ataque hace 110 puntos de daño más.",
+			de: "Wenn auf den Pokémon auf deiner Bank mindestens 1 Schadensmarke liegt, fügt diese Attacke 110 Schadenspunkte mehr zu."
 		}
 	}, {
 		name: {
-			en: "Abyss Eye"
+			en: "Abyss Eye",
+			es: "Ojo Abismal",
+			'es-mx': "Ojo Abismal",
+			de: "Abgrundauge"
 		},
 
 		cost: ["Darkness", "Darkness", "Darkness"],
 
 		effect: {
-			en: "If your opponent's Active Pokémon is affected by any Special Condition, it is now Knocked Out."
+			en: "If your opponent's Active Pokémon is affected by any Special Condition, it is now Knocked Out.",
+			es: "Si el Pokémon Activo de tu rival se ve afectado por una Condición Especial, queda Fuera de Combate.",
+			'es-mx': "Si el Pokémon Activo de tu rival se ve afectado por una Condición Especial, queda Fuera de Combate.",
+			de: "Wenn das Aktive Pokémon deines Gegners von einem Speziellen Zustand betroffen ist, ist es kampfunfähig."
 		}
 	}],
 


### PR DESCRIPTION
## What

Enriches the already-merged **me05 Pitch Black** (#1776) with localized card text and flavor text. All 84 official + 36 secret cards are touched where a source exists; the change adds `de`/`es`/`es-mx` effect text and `en`/`de` flavor `description`, and changes nothing else.

## Data sources

- **pokewiki.de**: German attack/ability/Trainer/Energy effect text and German flavor (Pokédex entry)
- **wikidex.net**: Spanish effect text — both `es` (Spain) and `es-mx` (Latin America) wording
- **bulbapedia.bulbagarden.net**: English flavor `description` (Pokédex entry)

Effect-text coverage today: de 61/120, es/es-mx 21/120; flavor: en 72, de 39. (Grows as the wikis fill in — re-run to pick up new pages.)

## Notes

- Follow-up to #1776, which added Pitch Black with English card text and localized card **names** (en/fr/de/es/es-mx). This PR fills in the localized card **text** and flavor.
- **German** attack/ability/Trainer/Energy effects on 61/120 cards and German flavor text on 39 Pokémon, from PokéWiki
- **Spanish** (`es` + `es-mx`) attack/ability effects on 21/120 cards, from WikiDex — including the Latin-American print where its wording differs (e.g. attack `Redada Crepuscular` es-mx vs `Incursión Crepuscular` es)
- **English** flavor `description` on 72 Pokémon (all non-ex; ex cards have no flavor text), from Bulbapedia
- Coverage is partial because the community wikis are still filling pages days after release. `fr/it/pt` effect text is not yet published anywhere and will follow once Pokémon TCG Live data (malie.io / LimitlessTCG) covers the set. Purely additive — no existing en text, name or id is changed.
- All 120 data files type-check against `interfaces.d.ts` (`tsc --noEmit`), and the set compiles cleanly through `server/` `bun run compile`
