### PR TITLE
fix: remove duplicate es-mx name keys in Pitch Black

### DIFF
--- a/data/Mega Evolution/Pitch Black/075.ts
+++ b/data/Mega Evolution/Pitch Black/075.ts
@@ -8,8 +8,8 @@ const card: Card = {
 		en: "Dark Bell",
 		fr: "Cloche Ténébreuse",
 		es: "Campanilla Oscuridad",
-		de: "Düsterglocke",
 		'es-mx': "Campana Oscura",
+		de: "Düsterglocke",
 		it: "Campanella Oscura",
 		pt: "Sino Sombrio"
 	},

--- a/data/Mega Evolution/Pitch Black/075.ts
+++ b/data/Mega Evolution/Pitch Black/075.ts
@@ -8,7 +8,6 @@ const card: Card = {
 		en: "Dark Bell",
 		fr: "Cloche Ténébreuse",
 		es: "Campanilla Oscuridad",
-		'es-mx': "Campanilla Oscuridad",
 		de: "Düsterglocke",
 		'es-mx': "Campana Oscura",
 		it: "Campanella Oscura",

--- a/data/Mega Evolution/Pitch Black/083.ts
+++ b/data/Mega Evolution/Pitch Black/083.ts
@@ -8,7 +8,6 @@ const card: Card = {
 		en: "Shadowy Darkness Energy",
 		fr: "Énergie Darkness Sombre",
 		es: "Energía Darkness Sombría",
-		'es-mx': "Energía Sombría",
 		de: "Schattige Darkness-Energie",
 		'es-mx': "Energía Darkness Sombría",
 		it: "Energia Darkness Ombrosa",

--- a/data/Mega Evolution/Pitch Black/083.ts
+++ b/data/Mega Evolution/Pitch Black/083.ts
@@ -8,8 +8,8 @@ const card: Card = {
 		en: "Shadowy Darkness Energy",
 		fr: "Énergie Darkness Sombre",
 		es: "Energía Darkness Sombría",
-		de: "Schattige Darkness-Energie",
 		'es-mx': "Energía Darkness Sombría",
+		de: "Schattige Darkness-Energie",
 		it: "Energia Darkness Ombrosa",
 		pt: "Energia Darkness Sombria"
 	},

--- a/data/Mega Evolution/Pitch Black/084.ts
+++ b/data/Mega Evolution/Pitch Black/084.ts
@@ -8,7 +8,6 @@ const card: Card = {
 		en: "Voltaic Lightning Energy",
 		fr: "Énergie Lightning Voltaïque",
 		es: "Energía Lightning Voltaica",
-		'es-mx': "Energía Voltaica",
 		de: "Voltaische Lightning-Energie",
 		'es-mx': "Energía Lightning Voltaica",
 		it: "Energia Lightning Voltaica",

--- a/data/Mega Evolution/Pitch Black/084.ts
+++ b/data/Mega Evolution/Pitch Black/084.ts
@@ -8,8 +8,8 @@ const card: Card = {
 		en: "Voltaic Lightning Energy",
 		fr: "Énergie Lightning Voltaïque",
 		es: "Energía Lightning Voltaica",
-		de: "Voltaische Lightning-Energie",
 		'es-mx': "Energía Lightning Voltaica",
+		de: "Voltaische Lightning-Energie",
 		it: "Energia Lightning Voltaica",
 		pt: "Energia Lightning Voltaica"
 	},

--- a/data/Mega Evolution/Pitch Black/106.ts
+++ b/data/Mega Evolution/Pitch Black/106.ts
@@ -8,8 +8,8 @@ const card: Card = {
 		en: "Dark Bell",
 		fr: "Cloche Ténébreuse",
 		es: "Campanilla Oscuridad",
-		de: "Düsterglocke",
 		'es-mx': "Campana Oscura",
+		de: "Düsterglocke",
 		it: "Campanella Oscura",
 		pt: "Sino Sombrio"
 	},

--- a/data/Mega Evolution/Pitch Black/106.ts
+++ b/data/Mega Evolution/Pitch Black/106.ts
@@ -8,7 +8,6 @@ const card: Card = {
 		en: "Dark Bell",
 		fr: "Cloche Ténébreuse",
 		es: "Campanilla Oscuridad",
-		'es-mx': "Campanilla Oscuridad",
 		de: "Düsterglocke",
 		'es-mx': "Campana Oscura",
 		it: "Campanella Oscura",


### PR DESCRIPTION
#1778 updated the `es`/`es-mx` names from #1776 but left the old `es-mx` line in place in four Pitch Black files (075, 083, 084, 106), so each `name` object now has two `es-mx` keys and `npm run validate` fails with TS1117 ("An object literal cannot have multiple properties with the same name").

This removes the stale first `es-mx` line in each file, keeping the value introduced by #1778.