### PR TITLE
fix(data): backfill missing evolveFrom for Standard evolution cards

### DIFF
--- a/data/Mega Evolution/Ascended Heroes/002.ts
+++ b/data/Mega Evolution/Ascended Heroes/002.ts
@@ -14,6 +14,16 @@ const card: Card = {
 		pt: "Gloom da Érica"
 	},
 
+	evolveFrom: {
+		en: "Erika's Oddish",
+		fr: "Mystherbe d'Erika",
+		es: "Oddish de Erika",
+		'es-mx': "Oddish de Erika",
+		de: "Erikas Myrapla",
+		it: "Oddish di Erika",
+		pt: "Oddish da Érica",
+	},
+
 	illustrator: "MARINA Chikazawa",
 	rarity: "Uncommon",
 	category: "Pokemon",

--- a/data/Mega Evolution/Ascended Heroes/003.ts
+++ b/data/Mega Evolution/Ascended Heroes/003.ts
@@ -14,6 +14,16 @@ const card: Card = {
 		pt: "Vileplume ex da Érica"
 	},
 
+	evolveFrom: {
+		en: "Erika's Gloom",
+		fr: "Ortide d'Erika",
+		es: "Gloom de Erika",
+		'es-mx': "Gloom de Erika",
+		de: "Erikas Duflor",
+		it: "Gloom di Erika",
+		pt: "Gloom da Érica",
+	},
+
 	suffix: "ex",
 	illustrator: "5ban Graphics",
 	rarity: "Double rare",

--- a/data/Mega Evolution/Ascended Heroes/005.ts
+++ b/data/Mega Evolution/Ascended Heroes/005.ts
@@ -14,6 +14,16 @@ const card: Card = {
 		pt: "Weepinbell da Érica"
 	},
 
+	evolveFrom: {
+		en: "Erika's Bellsprout",
+		fr: "Chétiflor d'Erika",
+		es: "Bellsprout de Erika",
+		'es-mx': "Bellsprout de Erika",
+		de: "Erikas Knofensa",
+		it: "Bellsprout di Erika",
+		pt: "Bellsprout da Érica",
+	},
+
 	illustrator: "LINNE",
 	rarity: "Uncommon",
 	category: "Pokemon",

--- a/data/Mega Evolution/Ascended Heroes/006.ts
+++ b/data/Mega Evolution/Ascended Heroes/006.ts
@@ -14,6 +14,16 @@ const card: Card = {
 		pt: "Victreebel da Érica"
 	},
 
+	evolveFrom: {
+		en: "Erika's Weepinbell",
+		fr: "Boustiflor d'Erika",
+		es: "Weepinbell de Erika",
+		'es-mx': "Weepinbell de Erika",
+		de: "Erikas Ultrigaria",
+		it: "Weepinbell di Erika",
+		pt: "Weepinbell da Érica",
+	},
+
 	illustrator: "takashi shiraishi",
 	rarity: "Rare",
 	category: "Pokemon",

--- a/data/Mega Evolution/Ascended Heroes/009.ts
+++ b/data/Mega Evolution/Ascended Heroes/009.ts
@@ -14,6 +14,16 @@ const card: Card = {
 		pt: "Bayleef"
 	},
 
+	evolveFrom: {
+		en: "Chikorita",
+		fr: "Germignon",
+		es: "Chikorita",
+		'es-mx': "Chikorita",
+		de: "Endivie",
+		it: "Chikorita",
+		pt: "Chikorita",
+	},
+
 	illustrator: "Tomomi Ozaki",
 	rarity: "Uncommon",
 	category: "Pokemon",

--- a/data/Mega Evolution/Ascended Heroes/012.ts
+++ b/data/Mega Evolution/Ascended Heroes/012.ts
@@ -14,6 +14,16 @@ const card: Card = {
 		pt: "Silcoon"
 	},
 
+	evolveFrom: {
+		en: "Wurmple",
+		fr: "Chenipotte",
+		es: "Wurmple",
+		'es-mx': "Wurmple",
+		de: "Waumpel",
+		it: "Wurmple",
+		pt: "Wurmple",
+	},
+
 	illustrator: "Eri Yamaki",
 	rarity: "Common",
 	category: "Pokemon",

--- a/data/Mega Evolution/Ascended Heroes/013.ts
+++ b/data/Mega Evolution/Ascended Heroes/013.ts
@@ -14,6 +14,16 @@ const card: Card = {
 		pt: "Beautifly"
 	},
 
+	evolveFrom: {
+		en: "Silcoon",
+		fr: "Armulys",
+		es: "Silcoon",
+		'es-mx': "Silcoon",
+		de: "Schaloko",
+		it: "Silcoon",
+		pt: "Silcoon",
+	},
+
 	illustrator: "Narumi Sato",
 	rarity: "Uncommon",
 	category: "Pokemon",

--- a/data/Mega Evolution/Ascended Heroes/014.ts
+++ b/data/Mega Evolution/Ascended Heroes/014.ts
@@ -14,6 +14,16 @@ const card: Card = {
 		pt: "Cascoon"
 	},
 
+	evolveFrom: {
+		en: "Wurmple",
+		fr: "Chenipotte",
+		es: "Wurmple",
+		'es-mx': "Wurmple",
+		de: "Waumpel",
+		it: "Wurmple",
+		pt: "Wurmple",
+	},
+
 	illustrator: "Dsuke",
 	rarity: "Common",
 	category: "Pokemon",

--- a/data/Mega Evolution/Ascended Heroes/015.ts
+++ b/data/Mega Evolution/Ascended Heroes/015.ts
@@ -14,6 +14,16 @@ const card: Card = {
 		pt: "Dustox"
 	},
 
+	evolveFrom: {
+		en: "Cascoon",
+		fr: "Blindalys",
+		es: "Cascoon",
+		'es-mx': "Cascoon",
+		de: "Panekon",
+		it: "Cascoon",
+		pt: "Cascoon",
+	},
+
 	illustrator: "kamonabe",
 	rarity: "Uncommon",
 	category: "Pokemon",

--- a/data/Mega Evolution/Ascended Heroes/019.ts
+++ b/data/Mega Evolution/Ascended Heroes/019.ts
@@ -14,6 +14,16 @@ const card: Card = {
 		pt: "Spidops da Equipe Rocket"
 	},
 
+	evolveFrom: {
+		en: "Team Rocket's Tarountula",
+		fr: "Tissenboule de la Team Rocket",
+		es: "Tarountula del Team Rocket",
+		'es-mx': "Tarountula del Equipo Rocket",
+		de: "Team Rockets Tarundel",
+		it: "Tarountula del Team Rocket",
+		pt: "Tarountula da Equipe Rocket",
+	},
+
 	illustrator: "Taiga Kasai",
 	rarity: "Rare",
 	category: "Pokemon",

--- a/data/Mega Evolution/Ascended Heroes/021.ts
+++ b/data/Mega Evolution/Ascended Heroes/021.ts
@@ -14,6 +14,16 @@ const card: Card = {
 		pt: "Charmeleon"
 	},
 
+	evolveFrom: {
+		en: "Charmander",
+		fr: "Salamèche",
+		es: "Charmander",
+		'es-mx': "Charmander",
+		de: "Glumanda",
+		it: "Charmander",
+		pt: "Charmander",
+	},
+
 	illustrator: "Julie Hang",
 	rarity: "Uncommon",
 	category: "Pokemon",

--- a/data/Mega Evolution/Ascended Heroes/022.ts
+++ b/data/Mega Evolution/Ascended Heroes/022.ts
@@ -14,6 +14,16 @@ const card: Card = {
 		pt: "Mega Charizard Y ex"
 	},
 
+	evolveFrom: {
+		en: "Charmeleon",
+		fr: "Reptincel",
+		es: "Charmeleon",
+		'es-mx': "Charmeleon",
+		de: "Glutexo",
+		it: "Charmeleon",
+		pt: "Charmeleon",
+	},
+
 	suffix: "ex",
 	illustrator: "aky CG Works",
 	rarity: "Double rare",

--- a/data/Mega Evolution/Ascended Heroes/024.ts
+++ b/data/Mega Evolution/Ascended Heroes/024.ts
@@ -14,6 +14,16 @@ const card: Card = {
 		pt: "Magcargo do Ethan"
 	},
 
+	evolveFrom: {
+		en: "Ethan's Slugma",
+		fr: "Limagma de Luth",
+		es: "Slugma de Eco",
+		'es-mx': "Slugma de Ethan",
+		de: "Klarins Schneckmag",
+		it: "Slugma di Armonio",
+		pt: "Slugma do Ethan",
+	},
+
 	illustrator: "kodama",
 	rarity: "Rare",
 	category: "Pokemon",

--- a/data/Mega Evolution/Ascended Heroes/028.ts
+++ b/data/Mega Evolution/Ascended Heroes/028.ts
@@ -14,6 +14,16 @@ const card: Card = {
 		pt: "Camerupt"
 	},
 
+	evolveFrom: {
+		en: "Numel",
+		fr: "Chamallot",
+		es: "Numel",
+		'es-mx': "Numel",
+		de: "Camaub",
+		it: "Numel",
+		pt: "Numel",
+	},
+
 	illustrator: "Minahamu",
 	rarity: "Uncommon",
 	category: "Pokemon",

--- a/data/Mega Evolution/Ascended Heroes/030.ts
+++ b/data/Mega Evolution/Ascended Heroes/030.ts
@@ -14,6 +14,16 @@ const card: Card = {
 		pt: "Pignite"
 	},
 
+	evolveFrom: {
+		en: "Tepig",
+		fr: "Gruikui",
+		es: "Tepig",
+		'es-mx': "Tepig",
+		de: "Floink",
+		it: "Tepig",
+		pt: "Tepig",
+	},
+
 	illustrator: "Aliya Chen",
 	rarity: "Uncommon",
 	category: "Pokemon",

--- a/data/Mega Evolution/Ascended Heroes/033.ts
+++ b/data/Mega Evolution/Ascended Heroes/033.ts
@@ -14,6 +14,16 @@ const card: Card = {
 		pt: "Darmanitan do N"
 	},
 
+	evolveFrom: {
+		en: "N's Darumaka",
+		fr: "Darumarond de N",
+		es: "Darumaka de N",
+		'es-mx': "Darumaka de N",
+		de: "Ns Flampion",
+		it: "Darumaka di N",
+		pt: "Darumaka do N",
+	},
+
 	illustrator: "nagimiso",
 	rarity: "Uncommon",
 	category: "Pokemon",

--- a/data/Mega Evolution/Ascended Heroes/035.ts
+++ b/data/Mega Evolution/Ascended Heroes/035.ts
@@ -14,6 +14,16 @@ const card: Card = {
 		pt: "Salazzle"
 	},
 
+	evolveFrom: {
+		en: "Salandit",
+		fr: "Tritox",
+		es: "Salandit",
+		'es-mx': "Salandit",
+		de: "Molunk",
+		it: "Salandit",
+		pt: "Salandit",
+	},
+
 	illustrator: "Taiga Kasai",
 	rarity: "Uncommon",
 	category: "Pokemon",

--- a/data/Mega Evolution/Ascended Heroes/037.ts
+++ b/data/Mega Evolution/Ascended Heroes/037.ts
@@ -14,6 +14,16 @@ const card: Card = {
 		pt: "Raboot"
 	},
 
+	evolveFrom: {
+		en: "Scorbunny",
+		fr: "Flambino",
+		es: "Scorbunny",
+		'es-mx': "Scorbunny",
+		de: "Hopplo",
+		it: "Scorbunny",
+		pt: "Scorbunny",
+	},
+
 	illustrator: "aspara",
 	rarity: "Common",
 	category: "Pokemon",

--- a/data/Mega Evolution/Ascended Heroes/040.ts
+++ b/data/Mega Evolution/Ascended Heroes/040.ts
@@ -14,6 +14,16 @@ const card: Card = {
 		pt: "Golduck"
 	},
 
+	evolveFrom: {
+		en: "Psyduck",
+		fr: "Psykokwak",
+		es: "Psyduck",
+		'es-mx': "Psyduck",
+		de: "Enton",
+		it: "Psyduck",
+		pt: "Psyduck",
+	},
+
 	illustrator: "Jiro Sasumo",
 	rarity: "Uncommon",
 	category: "Pokemon",

--- a/data/Mega Evolution/Ascended Heroes/042.ts
+++ b/data/Mega Evolution/Ascended Heroes/042.ts
@@ -14,6 +14,16 @@ const card: Card = {
 		pt: "Croconaw"
 	},
 
+	evolveFrom: {
+		en: "Totodile",
+		fr: "Kaiminus",
+		es: "Totodile",
+		'es-mx': "Totodile",
+		de: "Karnimani",
+		it: "Totodile",
+		pt: "Totodile",
+	},
+
 	illustrator: "Felicia Chen",
 	rarity: "Uncommon",
 	category: "Pokemon",

--- a/data/Mega Evolution/Ascended Heroes/045.ts
+++ b/data/Mega Evolution/Ascended Heroes/045.ts
@@ -14,6 +14,16 @@ const card: Card = {
 		pt: "Weavile"
 	},
 
+	evolveFrom: {
+		en: "Sneasel",
+		fr: "Farfuret",
+		es: "Sneasel",
+		'es-mx': "Sneasel",
+		de: "Sniebel",
+		it: "Sneasel",
+		pt: "Sneasel",
+	},
+
 	illustrator: "aspara",
 	rarity: "Uncommon",
 	category: "Pokemon",

--- a/data/Mega Evolution/Ascended Heroes/050.ts
+++ b/data/Mega Evolution/Ascended Heroes/050.ts
@@ -14,6 +14,16 @@ const card: Card = {
 		pt: "Vanillish do N"
 	},
 
+	evolveFrom: {
+		en: "N's Vanillite",
+		fr: "Sorbébé de N",
+		es: "Vanillite de N",
+		'es-mx': "Vanillite de N",
+		de: "Ns Gelatini",
+		it: "Vanillite di N",
+		pt: "Vanillite do N",
+	},
+
 	illustrator: "kirisAki",
 	rarity: "Common",
 	category: "Pokemon",

--- a/data/Mega Evolution/Ascended Heroes/051.ts
+++ b/data/Mega Evolution/Ascended Heroes/051.ts
@@ -14,6 +14,16 @@ const card: Card = {
 		pt: "Vanilluxe do N"
 	},
 
+	evolveFrom: {
+		en: "N's Vanillish",
+		fr: "Sorboul de N",
+		es: "Vanillish de N",
+		'es-mx': "Vanillish de N",
+		de: "Ns Gelatroppo",
+		it: "Vanillish di N",
+		pt: "Vanillish do N",
+	},
+
 	illustrator: "imoniii",
 	rarity: "Uncommon",
 	category: "Pokemon",

--- a/data/Mega Evolution/Ascended Heroes/053.ts
+++ b/data/Mega Evolution/Ascended Heroes/053.ts
@@ -14,6 +14,16 @@ const card: Card = {
 		pt: "Frosmoth"
 	},
 
+	evolveFrom: {
+		en: "Snom",
+		fr: "Frissonille",
+		es: "Snom",
+		'es-mx': "Snom",
+		de: "Snomnom",
+		it: "Snom",
+		pt: "Snom",
+	},
+
 	illustrator: "cochi8i",
 	rarity: "Uncommon",
 	category: "Pokemon",

--- a/data/Mega Evolution/Ascended Heroes/056.ts
+++ b/data/Mega Evolution/Ascended Heroes/056.ts
@@ -14,6 +14,16 @@ const card: Card = {
 		pt: "Raichu"
 	},
 
+	evolveFrom: {
+		en: "Pikachu",
+		fr: "Pikachu",
+		es: "Pikachu",
+		'es-mx': "Pikachu",
+		de: "Pikachu",
+		it: "Pikachu",
+		pt: "Pikachu",
+	},
+
 	illustrator: "Iori Suzuki",
 	rarity: "Uncommon",
 	category: "Pokemon",

--- a/data/Mega Evolution/Ascended Heroes/060.ts
+++ b/data/Mega Evolution/Ascended Heroes/060.ts
@@ -14,6 +14,16 @@ const card: Card = {
 		pt: "Eelektrik"
 	},
 
+	evolveFrom: {
+		en: "Tynamo",
+		fr: "Anchwatt",
+		es: "Tynamo",
+		'es-mx': "Tynamo",
+		de: "Zapplardin",
+		it: "Tynamo",
+		pt: "Tynamo",
+	},
+
 	illustrator: "Jerky",
 	rarity: "Uncommon",
 	category: "Pokemon",

--- a/data/Mega Evolution/Ascended Heroes/064.ts
+++ b/data/Mega Evolution/Ascended Heroes/064.ts
@@ -14,6 +14,16 @@ const card: Card = {
 		pt: "Heliolisk"
 	},
 
+	evolveFrom: {
+		en: "Helioptile",
+		fr: "Galvaran",
+		es: "Helioptile",
+		'es-mx': "Helioptile",
+		de: "Eguana",
+		it: "Helioptile",
+		pt: "Helioptile",
+	},
+
 	illustrator: "svlt",
 	rarity: "Uncommon",
 	category: "Pokemon",

--- a/data/Mega Evolution/Ascended Heroes/065.ts
+++ b/data/Mega Evolution/Ascended Heroes/065.ts
@@ -14,6 +14,16 @@ const card: Card = {
 		pt: "Charjabug"
 	},
 
+	evolveFrom: {
+		en: "Grubbin",
+		fr: "Larvibule",
+		es: "Grubbin",
+		'es-mx': "Grubbin",
+		de: "Mabula",
+		it: "Grubbin",
+		pt: "Grubbin",
+	},
+
 	illustrator: "Misa Tsutsui",
 	rarity: "Common",
 	category: "Pokemon",

--- a/data/Mega Evolution/Ascended Heroes/066.ts
+++ b/data/Mega Evolution/Ascended Heroes/066.ts
@@ -14,6 +14,16 @@ const card: Card = {
 		pt: "Vikavolt"
 	},
 
+	evolveFrom: {
+		en: "Charjabug",
+		fr: "Chrysapile",
+		es: "Charjabug",
+		'es-mx': "Charjabug",
+		de: "Akkup",
+		it: "Charjabug",
+		pt: "Charjabug",
+	},
+
 	illustrator: "Shiburingaru",
 	rarity: "Uncommon",
 	category: "Pokemon",

--- a/data/Mega Evolution/Ascended Heroes/070.ts
+++ b/data/Mega Evolution/Ascended Heroes/070.ts
@@ -14,6 +14,16 @@ const card: Card = {
 		pt: "Bellibolt ex da Kissera"
 	},
 
+	evolveFrom: {
+		en: "Iono's Tadbulb",
+		fr: "Têtampoule de Mashynn",
+		es: "Tadbulb de e-Nigma",
+		'es-mx': "Tadbulb de e-Nigma",
+		de: "Enigmaras Blipp",
+		it: "Tadbulb di Kissara",
+		pt: "Tadbulb da Kissera",
+	},
+
 	suffix: "ex",
 	illustrator: "5ban Graphics",
 	rarity: "Double rare",

--- a/data/Mega Evolution/Ascended Heroes/072.ts
+++ b/data/Mega Evolution/Ascended Heroes/072.ts
@@ -14,6 +14,16 @@ const card: Card = {
 		pt: "Kilowattrel da Kissera"
 	},
 
+	evolveFrom: {
+		en: "Iono's Wattrel",
+		fr: "Zapétrel de Mashynn",
+		es: "Wattrel de e-Nigma",
+		'es-mx': "Wattrel de e-Nigma",
+		de: "Enigmaras Voltrel",
+		it: "Wattrel di Kissara",
+		pt: "Wattrel da Kissera",
+	},
+
 	illustrator: "chibi",
 	rarity: "Rare",
 	category: "Pokemon",

--- a/data/Mega Evolution/Ascended Heroes/075.ts
+++ b/data/Mega Evolution/Ascended Heroes/075.ts
@@ -14,6 +14,16 @@ const card: Card = {
 		pt: "Clefable"
 	},
 
+	evolveFrom: {
+		en: "Clefairy",
+		fr: "Mélofée",
+		es: "Clefairy",
+		'es-mx': "Clefairy",
+		de: "Piepi",
+		it: "Clefairy",
+		pt: "Clefairy",
+	},
+
 	illustrator: "satoma",
 	rarity: "Uncommon",
 	category: "Pokemon",

--- a/data/Mega Evolution/Ascended Heroes/078.ts
+++ b/data/Mega Evolution/Ascended Heroes/078.ts
@@ -14,6 +14,16 @@ const card: Card = {
 		pt: "Exeggutor da Equipe Rocket"
 	},
 
+	evolveFrom: {
+		en: "Team Rocket's Exeggcute",
+		fr: "Noeunoeuf de la Team Rocket",
+		es: "Exeggcute del Team Rocket",
+		'es-mx': "Exeggcute del Equipo Rocket",
+		de: "Team Rockets Owei",
+		it: "Exeggcute del Team Rocket",
+		pt: "Exeggcute da Equipe Rocket",
+	},
+
 	illustrator: "Ryuta Fuse",
 	rarity: "Rare",
 	category: "Pokemon",

--- a/data/Mega Evolution/Ascended Heroes/081.ts
+++ b/data/Mega Evolution/Ascended Heroes/081.ts
@@ -14,6 +14,16 @@ const card: Card = {
 		pt: "Togetic"
 	},
 
+	evolveFrom: {
+		en: "Togepi",
+		fr: "Togepi",
+		es: "Togepi",
+		'es-mx': "Togepi",
+		de: "Togepi",
+		it: "Togepi",
+		pt: "Togepi",
+	},
+
 	illustrator: "Teeziro",
 	rarity: "Common",
 	category: "Pokemon",

--- a/data/Mega Evolution/Ascended Heroes/082.ts
+++ b/data/Mega Evolution/Ascended Heroes/082.ts
@@ -14,6 +14,16 @@ const card: Card = {
 		pt: "Togekiss"
 	},
 
+	evolveFrom: {
+		en: "Togetic",
+		fr: "Togetic",
+		es: "Togetic",
+		'es-mx': "Togetic",
+		de: "Togetic",
+		it: "Togetic",
+		pt: "Togetic",
+	},
+
 	illustrator: "Narano",
 	rarity: "Rare",
 	category: "Pokemon",

--- a/data/Mega Evolution/Ascended Heroes/086.ts
+++ b/data/Mega Evolution/Ascended Heroes/086.ts
@@ -14,6 +14,16 @@ const card: Card = {
 		pt: "Mismagius"
 	},
 
+	evolveFrom: {
+		en: "Misdreavus",
+		fr: "Feuforêve",
+		es: "Misdreavus",
+		'es-mx': "Misdreavus",
+		de: "Traunfugil",
+		it: "Misdreavus",
+		pt: "Misdreavus",
+	},
+
 	illustrator: "nisimono",
 	rarity: "Rare",
 	category: "Pokemon",

--- a/data/Mega Evolution/Ascended Heroes/088.ts
+++ b/data/Mega Evolution/Ascended Heroes/088.ts
@@ -14,6 +14,16 @@ const card: Card = {
 		pt: "Kirlia"
 	},
 
+	evolveFrom: {
+		en: "Ralts",
+		fr: "Tarsal",
+		es: "Ralts",
+		'es-mx': "Ralts",
+		de: "Trasla",
+		it: "Ralts",
+		pt: "Ralts",
+	},
+
 	illustrator: "satoma",
 	rarity: "Common",
 	category: "Pokemon",

--- a/data/Mega Evolution/Ascended Heroes/089.ts
+++ b/data/Mega Evolution/Ascended Heroes/089.ts
@@ -14,6 +14,16 @@ const card: Card = {
 		pt: "Mega Gardevoir ex"
 	},
 
+	evolveFrom: {
+		en: "Kirlia",
+		fr: "Kirlia",
+		es: "Kirlia",
+		'es-mx': "Kirlia",
+		de: "Kirlia",
+		it: "Kirlia",
+		pt: "Kirlia",
+	},
+
 	suffix: "ex",
 	illustrator: "takuyoa",
 	rarity: "Double rare",

--- a/data/Mega Evolution/Ascended Heroes/091.ts
+++ b/data/Mega Evolution/Ascended Heroes/091.ts
@@ -14,6 +14,16 @@ const card: Card = {
 		pt: "Banette"
 	},
 
+	evolveFrom: {
+		en: "Shuppet",
+		fr: "Polichombr",
+		es: "Shuppet",
+		'es-mx': "Shuppet",
+		de: "Shuppet",
+		it: "Shuppet",
+		pt: "Shuppet",
+	},
+
 	illustrator: "Anesaki Dynamic",
 	rarity: "Uncommon",
 	category: "Pokemon",

--- a/data/Mega Evolution/Ascended Heroes/094.ts
+++ b/data/Mega Evolution/Ascended Heroes/094.ts
@@ -14,6 +14,16 @@ const card: Card = {
 		pt: "Slurpuff"
 	},
 
+	evolveFrom: {
+		en: "Swirlix",
+		fr: "Sucroquin",
+		es: "Swirlix",
+		'es-mx': "Swirlix",
+		de: "Flauschling",
+		it: "Swirlix",
+		pt: "Swirlix",
+	},
+
 	illustrator: "Natsumi Yoshida",
 	rarity: "Uncommon",
 	category: "Pokemon",

--- a/data/Mega Evolution/Ascended Heroes/096.ts
+++ b/data/Mega Evolution/Ascended Heroes/096.ts
@@ -14,6 +14,16 @@ const card: Card = {
 		pt: "Trevenant do Lupo"
 	},
 
+	evolveFrom: {
+		en: "Hop's Phantump",
+		fr: "Brocélôme de Nabil",
+		es: "Phantump de Paul",
+		'es-mx': "Phantump de Paul",
+		de: "Hops Paragoni",
+		it: "Phantump di Hop",
+		pt: "Phantump do Lupo",
+	},
+
 	illustrator: "matazo",
 	rarity: "Rare",
 	category: "Pokemon",

--- a/data/Mega Evolution/Ascended Heroes/101.ts
+++ b/data/Mega Evolution/Ascended Heroes/101.ts
@@ -14,6 +14,16 @@ const card: Card = {
 		pt: "Dugtrio da Equipe Rocket"
 	},
 
+	evolveFrom: {
+		en: "Team Rocket's Diglett",
+		fr: "Taupiqueur de la Team Rocket",
+		es: "Diglett del Team Rocket",
+		'es-mx': "Diglett del Equipo Rocket",
+		de: "Team Rockets Digda",
+		it: "Diglett del Team Rocket",
+		pt: "Diglett da Equipe Rocket",
+	},
+
 	illustrator: "KEIICHIRO ITO",
 	rarity: "Uncommon",
 	category: "Pokemon",

--- a/data/Mega Evolution/Ascended Heroes/104.ts
+++ b/data/Mega Evolution/Ascended Heroes/104.ts
@@ -14,6 +14,16 @@ const card: Card = {
 		pt: "Medicham"
 	},
 
+	evolveFrom: {
+		en: "Meditite",
+		fr: "Méditikka",
+		es: "Meditite",
+		'es-mx': "Meditite",
+		de: "Meditie",
+		it: "Meditite",
+		pt: "Meditite",
+	},
+
 	illustrator: "GIDORA",
 	rarity: "Common",
 	category: "Pokemon",

--- a/data/Mega Evolution/Ascended Heroes/110.ts
+++ b/data/Mega Evolution/Ascended Heroes/110.ts
@@ -14,6 +14,16 @@ const card: Card = {
 		pt: "Gabite da Cíntia"
 	},
 
+	evolveFrom: {
+		en: "Cynthia's Gible",
+		fr: "Griknot de Cynthia",
+		es: "Gible de Cintia",
+		'es-mx': "Gible de Cynthia",
+		de: "Cynthias Kaumalat",
+		it: "Gible di Camilla",
+		pt: "Gible da Cíntia",
+	},
+
 	illustrator: "Taira Akitsu",
 	rarity: "Uncommon",
 	category: "Pokemon",

--- a/data/Mega Evolution/Ascended Heroes/111.ts
+++ b/data/Mega Evolution/Ascended Heroes/111.ts
@@ -14,6 +14,16 @@ const card: Card = {
 		pt: "Garchomp ex da Cíntia"
 	},
 
+	evolveFrom: {
+		en: "Cynthia's Gabite",
+		fr: "Carmache de Cynthia",
+		es: "Gabite de Cintia",
+		'es-mx': "Gabite de Cynthia",
+		de: "Cynthias Knarksel",
+		it: "Gabite di Camilla",
+		pt: "Gabite da Cíntia",
+	},
+
 	suffix: "ex",
 	illustrator: "5ban Graphics",
 	rarity: "Double rare",

--- a/data/Mega Evolution/Ascended Heroes/119.ts
+++ b/data/Mega Evolution/Ascended Heroes/119.ts
@@ -14,6 +14,16 @@ const card: Card = {
 		pt: "Carkol"
 	},
 
+	evolveFrom: {
+		en: "Rolycoly",
+		fr: "Charbi",
+		es: "Rolycoly",
+		'es-mx': "Rolycoly",
+		de: "Klonkett",
+		it: "Rolycoly",
+		pt: "Rolycoly",
+	},
+
 	illustrator: "Apios",
 	rarity: "Common",
 	category: "Pokemon",

--- a/data/Mega Evolution/Ascended Heroes/120.ts
+++ b/data/Mega Evolution/Ascended Heroes/120.ts
@@ -14,6 +14,16 @@ const card: Card = {
 		pt: "Coalossal"
 	},
 
+	evolveFrom: {
+		en: "Carkol",
+		fr: "Wagomine",
+		es: "Carkol",
+		'es-mx': "Carkol",
+		de: "Wagong",
+		it: "Carkol",
+		pt: "Carkol",
+	},
+
 	illustrator: "Nisota Niso",
 	rarity: "Rare",
 	category: "Pokemon",

--- a/data/Mega Evolution/Ascended Heroes/124.ts
+++ b/data/Mega Evolution/Ascended Heroes/124.ts
@@ -14,6 +14,16 @@ const card: Card = {
 		pt: "Haunter"
 	},
 
+	evolveFrom: {
+		en: "Gastly",
+		fr: "Fantominus",
+		es: "Gastly",
+		'es-mx': "Gastly",
+		de: "Nebulak",
+		it: "Gastly",
+		pt: "Gastly",
+	},
+
 	illustrator: "Rianti Hidayat",
 	rarity: "Uncommon",
 	category: "Pokemon",

--- a/data/Mega Evolution/Ascended Heroes/127.ts
+++ b/data/Mega Evolution/Ascended Heroes/127.ts
@@ -14,6 +14,16 @@ const card: Card = {
 		pt: "Honchkrow da Equipe Rocket"
 	},
 
+	evolveFrom: {
+		en: "Team Rocket's Murkrow",
+		fr: "Cornèbre de la Team Rocket",
+		es: "Murkrow del Team Rocket",
+		'es-mx': "Murkrow del Equipo Rocket",
+		de: "Team Rockets Kramurx",
+		it: "Murkrow del Team Rocket",
+		pt: "Murkrow da Equipe Rocket",
+	},
+
 	illustrator: "hncl",
 	rarity: "Rare",
 	category: "Pokemon",

--- a/data/Mega Evolution/Ascended Heroes/129.ts
+++ b/data/Mega Evolution/Ascended Heroes/129.ts
@@ -14,6 +14,16 @@ const card: Card = {
 		pt: "Mightyena"
 	},
 
+	evolveFrom: {
+		en: "Poochyena",
+		fr: "Medhyèna",
+		es: "Poochyena",
+		'es-mx': "Poochyena",
+		de: "Fiffyen",
+		it: "Poochyena",
+		pt: "Poochyena",
+	},
+
 	illustrator: "akagi",
 	rarity: "Uncommon",
 	category: "Pokemon",

--- a/data/Mega Evolution/Ascended Heroes/131.ts
+++ b/data/Mega Evolution/Ascended Heroes/131.ts
@@ -14,6 +14,16 @@ const card: Card = {
 		pt: "Linoone de Galar"
 	},
 
+	evolveFrom: {
+		en: "Galarian Zigzagoon",
+		fr: "Zigzaton de Galar",
+		es: "Zigzagoon de Galar",
+		'es-mx': "Zigzagoon de Galar",
+		de: "Galar-Zigzachs",
+		it: "Zigzagoon di Galar",
+		pt: "Zigzagoon de Galar",
+	},
+
 	illustrator: "Tomowaka",
 	rarity: "Common",
 	category: "Pokemon",

--- a/data/Mega Evolution/Ascended Heroes/132.ts
+++ b/data/Mega Evolution/Ascended Heroes/132.ts
@@ -14,6 +14,16 @@ const card: Card = {
 		pt: "Obstagoon de Galar"
 	},
 
+	evolveFrom: {
+		en: "Galarian Linoone",
+		fr: "Linéon de Galar",
+		es: "Linoone de Galar",
+		'es-mx': "Linoone de Galar",
+		de: "Galar-Geradaks",
+		it: "Linoone di Galar",
+		pt: "Linoone de Galar",
+	},
+
 	illustrator: "Dsuke",
 	rarity: "Uncommon",
 	category: "Pokemon",

--- a/data/Mega Evolution/Ascended Heroes/137.ts
+++ b/data/Mega Evolution/Ascended Heroes/137.ts
@@ -14,6 +14,16 @@ const card: Card = {
 		pt: "Zoroark ex do N"
 	},
 
+	evolveFrom: {
+		en: "N's Zorua",
+		fr: "Zorua de N",
+		es: "Zorua de N",
+		'es-mx': "Zorua de N",
+		de: "Ns Zorua",
+		it: "Zorua di N",
+		pt: "Zorua do N",
+	},
+
 	suffix: "ex",
 	illustrator: "takuyoa",
 	rarity: "Double rare",

--- a/data/Mega Evolution/Ascended Heroes/140.ts
+++ b/data/Mega Evolution/Ascended Heroes/140.ts
@@ -14,6 +14,16 @@ const card: Card = {
 		pt: "Pangoro"
 	},
 
+	evolveFrom: {
+		en: "Pancham",
+		fr: "Pandespiègle",
+		es: "Pancham",
+		'es-mx': "Pancham",
+		de: "Pam-Pam",
+		it: "Pancham",
+		pt: "Pancham",
+	},
+
 	illustrator: "takashi shiraishi",
 	rarity: "Uncommon",
 	category: "Pokemon",

--- a/data/Mega Evolution/Ascended Heroes/147.ts
+++ b/data/Mega Evolution/Ascended Heroes/147.ts
@@ -14,6 +14,16 @@ const card: Card = {
 		pt: "Bisharp"
 	},
 
+	evolveFrom: {
+		en: "Pawniard",
+		fr: "Scalpion",
+		es: "Pawniard",
+		'es-mx': "Pawniard",
+		de: "Gladiantri",
+		it: "Pawniard",
+		pt: "Pawniard",
+	},
+
 	illustrator: "Scav",
 	rarity: "Common",
 	category: "Pokemon",

--- a/data/Mega Evolution/Ascended Heroes/148.ts
+++ b/data/Mega Evolution/Ascended Heroes/148.ts
@@ -14,6 +14,16 @@ const card: Card = {
 		pt: "Kingambit"
 	},
 
+	evolveFrom: {
+		en: "Bisharp",
+		fr: "Scalproie",
+		es: "Bisharp",
+		'es-mx': "Bisharp",
+		de: "Caesurio",
+		it: "Bisharp",
+		pt: "Bisharp",
+	},
+
 	illustrator: "Teeziro",
 	rarity: "Rare",
 	category: "Pokemon",

--- a/data/Mega Evolution/Ascended Heroes/151.ts
+++ b/data/Mega Evolution/Ascended Heroes/151.ts
@@ -14,6 +14,16 @@ const card: Card = {
 		pt: "Dragonair"
 	},
 
+	evolveFrom: {
+		en: "Dratini",
+		fr: "Minidraco",
+		es: "Dratini",
+		'es-mx': "Dratini",
+		de: "Dratini",
+		it: "Dratini",
+		pt: "Dratini",
+	},
+
 	illustrator: "Gemi",
 	rarity: "Uncommon",
 	category: "Pokemon",

--- a/data/Mega Evolution/Ascended Heroes/157.ts
+++ b/data/Mega Evolution/Ascended Heroes/157.ts
@@ -14,6 +14,16 @@ const card: Card = {
 		pt: "Noivern"
 	},
 
+	evolveFrom: {
+		en: "Noibat",
+		fr: "Sonistrelle",
+		es: "Noibat",
+		'es-mx': "Noibat",
+		de: "eF-eM",
+		it: "Noibat",
+		pt: "Noibat",
+	},
+
 	illustrator: "Natsumi Miyanose",
 	rarity: "Uncommon",
 	category: "Pokemon",

--- a/data/Mega Evolution/Ascended Heroes/159.ts
+++ b/data/Mega Evolution/Ascended Heroes/159.ts
@@ -14,6 +14,16 @@ const card: Card = {
 		pt: "Drakloak"
 	},
 
+	evolveFrom: {
+		en: "Dreepy",
+		fr: "Fantyrm",
+		es: "Dreepy",
+		'es-mx': "Dreepy",
+		de: "Grolldra",
+		it: "Dreepy",
+		pt: "Dreepy",
+	},
+
 	illustrator: "cochi8i",
 	rarity: "Common",
 	category: "Pokemon",

--- a/data/Mega Evolution/Ascended Heroes/160.ts
+++ b/data/Mega Evolution/Ascended Heroes/160.ts
@@ -14,6 +14,16 @@ const card: Card = {
 		pt: "Dragapult ex"
 	},
 
+	evolveFrom: {
+		en: "Drakloak",
+		fr: "Dispareptil",
+		es: "Drakloak",
+		'es-mx': "Drakloak",
+		de: "Phandra",
+		it: "Drakloak",
+		pt: "Drakloak",
+	},
+
 	suffix: "ex",
 	illustrator: "5ban Graphics",
 	rarity: "Double rare",

--- a/data/Mega Evolution/Ascended Heroes/164.ts
+++ b/data/Mega Evolution/Ascended Heroes/164.ts
@@ -14,6 +14,16 @@ const card: Card = {
 		pt: "Dudunsparce ex do Lauro"
 	},
 
+	evolveFrom: {
+		en: "Larry's Dunsparce",
+		fr: "Insolourdo d'Okuba",
+		es: "Dunsparce de Laureano",
+		'es-mx': "Dunsparce de Laureano",
+		de: "Aokis Dummisel",
+		it: "Dunsparce di Ubaldo",
+		pt: "Dunsparce do Lauro",
+	},
+
 	suffix: "ex",
 	illustrator: "5ban Graphics",
 	rarity: "Double rare",

--- a/data/Mega Evolution/Ascended Heroes/166.ts
+++ b/data/Mega Evolution/Ascended Heroes/166.ts
@@ -14,6 +14,16 @@ const card: Card = {
 		pt: "Delcatty"
 	},
 
+	evolveFrom: {
+		en: "Skitty",
+		fr: "Skitty",
+		es: "Skitty",
+		'es-mx': "Skitty",
+		de: "Eneco",
+		it: "Skitty",
+		pt: "Skitty",
+	},
+
 	illustrator: "buchi",
 	rarity: "Uncommon",
 	category: "Pokemon",

--- a/data/Mega Evolution/Ascended Heroes/169.ts
+++ b/data/Mega Evolution/Ascended Heroes/169.ts
@@ -14,6 +14,16 @@ const card: Card = {
 		pt: "Staravia do Lauro"
 	},
 
+	evolveFrom: {
+		en: "Larry's Starly",
+		fr: "Étourmi d'Okuba",
+		es: "Starly de Laureano",
+		'es-mx': "Starly de Laureano",
+		de: "Aokis Staralili",
+		it: "Starly di Ubaldo",
+		pt: "Starly do Lauro",
+	},
+
 	illustrator: "Fujimoto Gold",
 	rarity: "Uncommon",
 	category: "Pokemon",

--- a/data/Mega Evolution/Ascended Heroes/170.ts
+++ b/data/Mega Evolution/Ascended Heroes/170.ts
@@ -14,6 +14,16 @@ const card: Card = {
 		pt: "Staraptor do Lauro"
 	},
 
+	evolveFrom: {
+		en: "Larry's Staravia",
+		fr: "Étourvol d'Okuba",
+		es: "Staravia de Laureano",
+		'es-mx': "Staravia de Laureano",
+		de: "Aokis Staravia",
+		it: "Staravia di Ubaldo",
+		pt: "Staravia do Lauro",
+	},
+
 	illustrator: "Po-Suzuki",
 	rarity: "Rare",
 	category: "Pokemon",

--- a/data/Mega Evolution/Ascended Heroes/174.ts
+++ b/data/Mega Evolution/Ascended Heroes/174.ts
@@ -14,6 +14,16 @@ const card: Card = {
 		pt: "Braviary do Lauro"
 	},
 
+	evolveFrom: {
+		en: "Larry's Rufflet",
+		fr: "Furaiglon d'Okuba",
+		es: "Rufflet de Laureano",
+		'es-mx': "Rufflet de Laureano",
+		de: "Aokis Geronimatz",
+		it: "Rufflet di Ubaldo",
+		pt: "Rufflet do Lauro",
+	},
+
 	illustrator: "Ryuta Fuse",
 	rarity: "Uncommon",
 	category: "Pokemon",

--- a/data/Mega Evolution/Ascended Heroes/219.ts
+++ b/data/Mega Evolution/Ascended Heroes/219.ts
@@ -14,6 +14,16 @@ const card: Card = {
 		pt: "Beautifly"
 	},
 
+	evolveFrom: {
+		en: "Silcoon",
+		fr: "Armulys",
+		es: "Silcoon",
+		'es-mx': "Silcoon",
+		de: "Schaloko",
+		it: "Silcoon",
+		pt: "Silcoon",
+	},
+
 	illustrator: "Mori Yuu",
 	rarity: "Illustration rare",
 	category: "Pokemon",

--- a/data/Mega Evolution/Ascended Heroes/220.ts
+++ b/data/Mega Evolution/Ascended Heroes/220.ts
@@ -14,6 +14,16 @@ const card: Card = {
 		pt: "Dustox"
 	},
 
+	evolveFrom: {
+		en: "Cascoon",
+		fr: "Blindalys",
+		es: "Cascoon",
+		'es-mx': "Cascoon",
+		de: "Panekon",
+		it: "Cascoon",
+		pt: "Cascoon",
+	},
+
 	illustrator: "IKEDA Saki",
 	rarity: "Illustration rare",
 	category: "Pokemon",

--- a/data/Mega Evolution/Ascended Heroes/222.ts
+++ b/data/Mega Evolution/Ascended Heroes/222.ts
@@ -14,6 +14,16 @@ const card: Card = {
 		pt: "Magcargo do Ethan"
 	},
 
+	evolveFrom: {
+		en: "Ethan's Slugma",
+		fr: "Limagma de Luth",
+		es: "Slugma de Eco",
+		'es-mx': "Slugma de Ethan",
+		de: "Klarins Schneckmag",
+		it: "Slugma di Armonio",
+		pt: "Slugma do Ethan",
+	},
+
 	illustrator: "Hideki Ishikawa",
 	rarity: "Illustration rare",
 	category: "Pokemon",

--- a/data/Mega Evolution/Ascended Heroes/224.ts
+++ b/data/Mega Evolution/Ascended Heroes/224.ts
@@ -14,6 +14,16 @@ const card: Card = {
 		pt: "Salazzle"
 	},
 
+	evolveFrom: {
+		en: "Salandit",
+		fr: "Tritox",
+		es: "Salandit",
+		'es-mx': "Salandit",
+		de: "Molunk",
+		it: "Salandit",
+		pt: "Salandit",
+	},
+
 	illustrator: "Dsuke",
 	rarity: "Illustration rare",
 	category: "Pokemon",

--- a/data/Mega Evolution/Ascended Heroes/228.ts
+++ b/data/Mega Evolution/Ascended Heroes/228.ts
@@ -14,6 +14,16 @@ const card: Card = {
 		pt: "Weavile"
 	},
 
+	evolveFrom: {
+		en: "Sneasel",
+		fr: "Farfuret",
+		es: "Sneasel",
+		'es-mx': "Sneasel",
+		de: "Sniebel",
+		it: "Sneasel",
+		pt: "Sneasel",
+	},
+
 	illustrator: "Uninori",
 	rarity: "Illustration rare",
 	category: "Pokemon",

--- a/data/Mega Evolution/Ascended Heroes/229.ts
+++ b/data/Mega Evolution/Ascended Heroes/229.ts
@@ -14,6 +14,16 @@ const card: Card = {
 		pt: "Heliolisk"
 	},
 
+	evolveFrom: {
+		en: "Helioptile",
+		fr: "Galvaran",
+		es: "Helioptile",
+		'es-mx': "Helioptile",
+		de: "Eguana",
+		it: "Helioptile",
+		pt: "Helioptile",
+	},
+
 	illustrator: "Takeshi Nakamura",
 	rarity: "Illustration rare",
 	category: "Pokemon",

--- a/data/Mega Evolution/Ascended Heroes/230.ts
+++ b/data/Mega Evolution/Ascended Heroes/230.ts
@@ -14,6 +14,16 @@ const card: Card = {
 		pt: "Vikavolt"
 	},
 
+	evolveFrom: {
+		en: "Charjabug",
+		fr: "Chrysapile",
+		es: "Charjabug",
+		'es-mx': "Charjabug",
+		de: "Akkup",
+		it: "Charjabug",
+		pt: "Charjabug",
+	},
+
 	illustrator: "Tonji Matsuno",
 	rarity: "Illustration rare",
 	category: "Pokemon",

--- a/data/Mega Evolution/Ascended Heroes/234.ts
+++ b/data/Mega Evolution/Ascended Heroes/234.ts
@@ -14,6 +14,16 @@ const card: Card = {
 		pt: "Banette"
 	},
 
+	evolveFrom: {
+		en: "Shuppet",
+		fr: "Polichombr",
+		es: "Shuppet",
+		'es-mx': "Shuppet",
+		de: "Shuppet",
+		it: "Shuppet",
+		pt: "Shuppet",
+	},
+
 	illustrator: "YASHIRO Nanaco",
 	rarity: "Illustration rare",
 	category: "Pokemon",

--- a/data/Mega Evolution/Ascended Heroes/235.ts
+++ b/data/Mega Evolution/Ascended Heroes/235.ts
@@ -14,6 +14,16 @@ const card: Card = {
 		pt: "Togekiss"
 	},
 
+	evolveFrom: {
+		en: "Togetic",
+		fr: "Togetic",
+		es: "Togetic",
+		'es-mx': "Togetic",
+		de: "Togetic",
+		it: "Togetic",
+		pt: "Togetic",
+	},
+
 	illustrator: "satoma",
 	rarity: "Illustration rare",
 	category: "Pokemon",

--- a/data/Mega Evolution/Ascended Heroes/236.ts
+++ b/data/Mega Evolution/Ascended Heroes/236.ts
@@ -14,6 +14,16 @@ const card: Card = {
 		pt: "Slurpuff"
 	},
 
+	evolveFrom: {
+		en: "Swirlix",
+		fr: "Sucroquin",
+		es: "Swirlix",
+		'es-mx': "Swirlix",
+		de: "Flauschling",
+		it: "Swirlix",
+		pt: "Swirlix",
+	},
+
 	illustrator: "Yoshimoto Yoshimon",
 	rarity: "Illustration rare",
 	category: "Pokemon",

--- a/data/Mega Evolution/Ascended Heroes/237.ts
+++ b/data/Mega Evolution/Ascended Heroes/237.ts
@@ -14,6 +14,16 @@ const card: Card = {
 		pt: "Trevenant do Lupo"
 	},
 
+	evolveFrom: {
+		en: "Hop's Phantump",
+		fr: "Brocélôme de Nabil",
+		es: "Phantump de Paul",
+		'es-mx': "Phantump de Paul",
+		de: "Hops Paragoni",
+		it: "Phantump di Hop",
+		pt: "Phantump do Lupo",
+	},
+
 	illustrator: "Tomowaka",
 	rarity: "Illustration rare",
 	category: "Pokemon",

--- a/data/Mega Evolution/Ascended Heroes/239.ts
+++ b/data/Mega Evolution/Ascended Heroes/239.ts
@@ -14,6 +14,16 @@ const card: Card = {
 		pt: "Dugtrio da Equipe Rocket"
 	},
 
+	evolveFrom: {
+		en: "Team Rocket's Diglett",
+		fr: "Taupiqueur de la Team Rocket",
+		es: "Diglett del Team Rocket",
+		'es-mx': "Diglett del Equipo Rocket",
+		de: "Team Rockets Digda",
+		it: "Diglett del Team Rocket",
+		pt: "Diglett da Equipe Rocket",
+	},
+
 	illustrator: "Whisker",
 	rarity: "Illustration rare",
 	category: "Pokemon",

--- a/data/Mega Evolution/Ascended Heroes/241.ts
+++ b/data/Mega Evolution/Ascended Heroes/241.ts
@@ -14,6 +14,16 @@ const card: Card = {
 		pt: "Medicham"
 	},
 
+	evolveFrom: {
+		en: "Meditite",
+		fr: "Méditikka",
+		es: "Meditite",
+		'es-mx': "Meditite",
+		de: "Meditie",
+		it: "Meditite",
+		pt: "Meditite",
+	},
+
 	illustrator: "KEIICHIRO ITO",
 	rarity: "Illustration rare",
 	category: "Pokemon",

--- a/data/Mega Evolution/Ascended Heroes/243.ts
+++ b/data/Mega Evolution/Ascended Heroes/243.ts
@@ -14,6 +14,16 @@ const card: Card = {
 		pt: "Mightyena"
 	},
 
+	evolveFrom: {
+		en: "Poochyena",
+		fr: "Medhyèna",
+		es: "Poochyena",
+		'es-mx': "Poochyena",
+		de: "Fiffyen",
+		it: "Poochyena",
+		pt: "Poochyena",
+	},
+
 	illustrator: "Yano Keiji",
 	rarity: "Illustration rare",
 	category: "Pokemon",

--- a/data/Mega Evolution/Ascended Heroes/245.ts
+++ b/data/Mega Evolution/Ascended Heroes/245.ts
@@ -14,6 +14,16 @@ const card: Card = {
 		pt: "Obstagoon de Galar"
 	},
 
+	evolveFrom: {
+		en: "Galarian Linoone",
+		fr: "Linéon de Galar",
+		es: "Linoone de Galar",
+		'es-mx': "Linoone de Galar",
+		de: "Galar-Geradaks",
+		it: "Linoone di Galar",
+		pt: "Linoone de Galar",
+	},
+
 	illustrator: "Krgc",
 	rarity: "Illustration rare",
 	category: "Pokemon",

--- a/data/Mega Evolution/Ascended Heroes/248.ts
+++ b/data/Mega Evolution/Ascended Heroes/248.ts
@@ -14,6 +14,16 @@ const card: Card = {
 		pt: "Drakloak"
 	},
 
+	evolveFrom: {
+		en: "Dreepy",
+		fr: "Fantyrm",
+		es: "Dreepy",
+		'es-mx': "Dreepy",
+		de: "Grolldra",
+		it: "Dreepy",
+		pt: "Dreepy",
+	},
+
 	illustrator: "Jerky",
 	rarity: "Illustration rare",
 	category: "Pokemon",

--- a/data/Mega Evolution/Ascended Heroes/249.ts
+++ b/data/Mega Evolution/Ascended Heroes/249.ts
@@ -14,6 +14,16 @@ const card: Card = {
 		pt: "Staraptor do Lauro"
 	},
 
+	evolveFrom: {
+		en: "Larry's Staravia",
+		fr: "Étourvol d'Okuba",
+		es: "Staravia de Laureano",
+		'es-mx': "Staravia de Laureano",
+		de: "Aokis Staravia",
+		it: "Staravia di Ubaldo",
+		pt: "Staravia do Lauro",
+	},
+
 	illustrator: "kantaro",
 	rarity: "Illustration rare",
 	category: "Pokemon",

--- a/data/Mega Evolution/Ascended Heroes/279.ts
+++ b/data/Mega Evolution/Ascended Heroes/279.ts
@@ -14,6 +14,16 @@ const card: Card = {
 		pt: "Bellibolt ex da Kissera"
 	},
 
+	evolveFrom: {
+		en: "Iono's Tadbulb",
+		fr: "Têtampoule de Mashynn",
+		es: "Tadbulb de e-Nigma",
+		'es-mx': "Tadbulb de e-Nigma",
+		de: "Enigmaras Blipp",
+		it: "Tadbulb di Kissara",
+		pt: "Tadbulb da Kissera",
+	},
+
 	suffix: "ex",
 	illustrator: "Akira Komayama",
 	rarity: "Special illustration rare",

--- a/data/Mega Evolution/Ascended Heroes/286.ts
+++ b/data/Mega Evolution/Ascended Heroes/286.ts
@@ -14,6 +14,16 @@ const card: Card = {
 		pt: "Zoroark ex do N"
 	},
 
+	evolveFrom: {
+		en: "N's Zorua",
+		fr: "Zorua de N",
+		es: "Zorua de N",
+		'es-mx': "Zorua de N",
+		de: "Ns Zorua",
+		it: "Zorua di N",
+		pt: "Zorua do N",
+	},
+
 	suffix: "ex",
 	illustrator: "Raita Kazama",
 	rarity: "Special illustration rare",

--- a/data/Mega Evolution/Ascended Heroes/287.ts
+++ b/data/Mega Evolution/Ascended Heroes/287.ts
@@ -14,6 +14,16 @@ const card: Card = {
 		pt: "Grimmsnarl ex da Marine"
 	},
 
+	evolveFrom: {
+		en: "Marnie's Morgrem",
+		fr: "Fourbelin de Rosemary",
+		es: "Morgrem de Roxy",
+		'es-mx': "Morgrem de Marnie",
+		de: "Marys Pelzebub",
+		it: "Morgrem di Mary",
+		pt: "Morgrem da Marine",
+	},
+
 	suffix: "ex",
 	illustrator: "Ligton",
 	rarity: "Special illustration rare",

--- a/data/Mega Evolution/Ascended Heroes/289.ts
+++ b/data/Mega Evolution/Ascended Heroes/289.ts
@@ -14,6 +14,16 @@ const card: Card = {
 		pt: "Metagross ex do Steven"
 	},
 
+	evolveFrom: {
+		en: "Steven's Metang",
+		fr: "Métang de Pierre",
+		es: "Metang de Máximo",
+		'es-mx': "Metang de Steven",
+		de: "Troys Metang",
+		it: "Metang di Rocco",
+		pt: "Metang do Steven",
+	},
+
 	suffix: "ex",
 	illustrator: "chibi",
 	rarity: "Special illustration rare",

--- a/data/Mega Evolution/Ascended Heroes/294.ts
+++ b/data/Mega Evolution/Ascended Heroes/294.ts
@@ -14,6 +14,16 @@ const card: Card = {
 		pt: "Mega Charizard Y ex"
 	},
 
+	evolveFrom: {
+		en: "Charmeleon",
+		fr: "Reptincel",
+		es: "Charmeleon",
+		'es-mx': "Charmeleon",
+		de: "Glutexo",
+		it: "Charmeleon",
+		pt: "Charmeleon",
+	},
+
 	suffix: "ex",
 	illustrator: "aky CG Works",
 	rarity: "Mega Hyper Rare",

--- a/data/Mega Evolution/MEP Black Star Promos/001.ts
+++ b/data/Mega Evolution/MEP Black Star Promos/001.ts
@@ -14,6 +14,16 @@ const card: Card = {
 		'es-mx': "Meganium"
 	},
 
+	evolveFrom: {
+		en: "Bayleef",
+		fr: "Macronium",
+		de: "Lorblatt",
+		it: "Bayleef",
+		es: "Bayleef",
+		pt: "Bayleef",
+		'es-mx': "Bayleef",
+	},
+
 	illustrator: "Uninori",
 	rarity: "Promo",
 	category: "Pokemon",

--- a/data/Mega Evolution/MEP Black Star Promos/002.ts
+++ b/data/Mega Evolution/MEP Black Star Promos/002.ts
@@ -14,6 +14,16 @@ const card: Card = {
 		'es-mx': "Inteleon"
 	},
 
+	evolveFrom: {
+		en: "Drizzile",
+		fr: "Arrozard",
+		de: "Phlegleon",
+		it: "Drizzile",
+		es: "Drizzile",
+		pt: "Drizzile",
+		'es-mx': "Drizzile",
+	},
+
 	illustrator: "Kazumasa Yasukuni",
 	rarity: "Promo",
 	category: "Pokemon",

--- a/data/Mega Evolution/MEP Black Star Promos/003.ts
+++ b/data/Mega Evolution/MEP Black Star Promos/003.ts
@@ -14,6 +14,16 @@ const card: Card = {
 		'es-mx': "Alakazam"
 	},
 
+	evolveFrom: {
+		en: "Kadabra",
+		fr: "Kadabra",
+		de: "Kadabra",
+		it: "Kadabra",
+		es: "Kadabra",
+		pt: "Kadabra",
+		'es-mx': "Kadabra",
+	},
+
 	illustrator: "cochi8i",
 	rarity: "Promo",
 	category: "Pokemon",

--- a/data/Mega Evolution/MEP Black Star Promos/006.ts
+++ b/data/Mega Evolution/MEP Black Star Promos/006.ts
@@ -13,6 +13,15 @@ const card: Card = {
 		pt: "Drifblim"
 	},
 
+	evolveFrom: {
+		en: "Drifloon",
+		fr: "Baudrive",
+		de: "Driftlon",
+		it: "Drifloon",
+		es: "Drifloon",
+		pt: "Drifloon",
+	},
+
 	illustrator: "Shimaris Yukichi",
 	rarity: "Promo",
 	category: "Pokemon",

--- a/data/Mega Evolution/MEP Black Star Promos/008.ts
+++ b/data/Mega Evolution/MEP Black Star Promos/008.ts
@@ -13,6 +13,15 @@ const card: Card = {
 		pt: "Golduck"
 	},
 
+	evolveFrom: {
+		en: "Psyduck",
+		fr: "Psykokwak",
+		de: "Enton",
+		it: "Psyduck",
+		es: "Psyduck",
+		pt: "Psyduck",
+	},
+
 	illustrator: "Jiro Sasumo",
 	rarity: "Promo",
 	category: "Pokemon",

--- a/data/Mega Evolution/MEP Black Star Promos/009.ts
+++ b/data/Mega Evolution/MEP Black Star Promos/009.ts
@@ -14,6 +14,16 @@ const card: Card = {
 		'es-mx': "Alakazam"
 	},
 
+	evolveFrom: {
+		en: "Kadabra",
+		fr: "Kadabra",
+		de: "Kadabra",
+		it: "Kadabra",
+		es: "Kadabra",
+		pt: "Kadabra",
+		'es-mx': "Kadabra",
+	},
+
 	illustrator: "Aya Kusube",
 	rarity: "Promo",
 	category: "Pokemon",

--- a/data/Mega Evolution/MEP Black Star Promos/014.ts
+++ b/data/Mega Evolution/MEP Black Star Promos/014.ts
@@ -14,6 +14,16 @@ const card: Card = {
 		pt: "Ceruledge"
 	},
 
+	evolveFrom: {
+		en: "Charcadet",
+		fr: "Charbambin",
+		es: "Charcadet",
+		'es-mx': "Charcadet",
+		de: "Knarbon",
+		it: "Charcadet",
+		pt: "Charcadet",
+	},
+
 	rarity: "Promo",
 	category: "Pokemon",
 	dexId: [937],

--- a/data/Mega Evolution/MEP Black Star Promos/016.ts
+++ b/data/Mega Evolution/MEP Black Star Promos/016.ts
@@ -14,6 +14,16 @@ const card: Card = {
 		pt: "Flygon"
 	},
 
+	evolveFrom: {
+		en: "Vibrava",
+		fr: "Vibraninf",
+		es: "Vibrava",
+		'es-mx': "Vibrava",
+		de: "Vibrava",
+		it: "Vibrava",
+		pt: "Vibrava",
+	},
+
 	rarity: "Promo",
 	category: "Pokemon",
 	dexId: [330],

--- a/data/Mega Evolution/MEP Black Star Promos/017.ts
+++ b/data/Mega Evolution/MEP Black Star Promos/017.ts
@@ -14,6 +14,16 @@ const card: Card = {
 		pt: "Toxtricity"
 	},
 
+	evolveFrom: {
+		en: "Toxel",
+		fr: "Toxizap",
+		es: "Toxel",
+		'es-mx': "Toxel",
+		de: "Toxel",
+		it: "Toxel",
+		pt: "Toxel",
+	},
+
 	rarity: "Promo",
 	category: "Pokemon",
 	dexId: [849],

--- a/data/Mega Evolution/Perfect Order/002.ts
+++ b/data/Mega Evolution/Perfect Order/002.ts
@@ -16,6 +16,16 @@ const card: Card = {
 		pt: "Ariados"
 	},
 
+	evolveFrom: {
+		en: "Spinarak",
+		fr: "Mimigal",
+		es: "Spinarak",
+		'es-mx': "Spinarak",
+		de: "Webarak",
+		it: "Spinarak",
+		pt: "Spinarak",
+	},
+
 	illustrator: "svlt",
 	rarity: "Common",
 	category: "Pokemon",

--- a/data/Mega Evolution/Perfect Order/005.ts
+++ b/data/Mega Evolution/Perfect Order/005.ts
@@ -16,6 +16,16 @@ const card: Card = {
 		pt: "Servine"
 	},
 
+	evolveFrom: {
+		en: "Snivy",
+		fr: "Vipélierre",
+		es: "Snivy",
+		'es-mx': "Snivy",
+		de: "Serpifeu",
+		it: "Snivy",
+		pt: "Snivy",
+	},
+
 	illustrator: "Kurata So",
 	rarity: "Common",
 	category: "Pokemon",

--- a/data/Mega Evolution/Perfect Order/006.ts
+++ b/data/Mega Evolution/Perfect Order/006.ts
@@ -16,6 +16,16 @@ const card: Card = {
 		pt: "Serperior"
 	},
 
+	evolveFrom: {
+		en: "Servine",
+		fr: "Lianaja",
+		es: "Servine",
+		'es-mx': "Servine",
+		de: "Efoserp",
+		it: "Servine",
+		pt: "Servine",
+	},
+
 	illustrator: "kodama",
 	rarity: "Rare",
 	category: "Pokemon",

--- a/data/Mega Evolution/Perfect Order/008.ts
+++ b/data/Mega Evolution/Perfect Order/008.ts
@@ -16,6 +16,16 @@ const card: Card = {
 		pt: "Spewpa"
 	},
 
+	evolveFrom: {
+		en: "Scatterbug",
+		fr: "Lépidonille",
+		es: "Scatterbug",
+		'es-mx': "Scatterbug",
+		de: "Purmel",
+		it: "Scatterbug",
+		pt: "Scatterbug",
+	},
+
 	illustrator: "Ounishi",
 	rarity: "Common",
 	category: "Pokemon",

--- a/data/Mega Evolution/Perfect Order/009.ts
+++ b/data/Mega Evolution/Perfect Order/009.ts
@@ -16,6 +16,16 @@ const card: Card = {
 		pt: "Vivillon"
 	},
 
+	evolveFrom: {
+		en: "Spewpa",
+		fr: "Pérégrain",
+		es: "Spewpa",
+		'es-mx': "Spewpa",
+		de: "Puponcho",
+		it: "Spewpa",
+		pt: "Spewpa",
+	},
+
 	illustrator: "mingo",
 	rarity: "Uncommon",
 	category: "Pokemon",

--- a/data/Mega Evolution/Perfect Order/011.ts
+++ b/data/Mega Evolution/Perfect Order/011.ts
@@ -16,6 +16,16 @@ const card: Card = {
 		pt: "Dartrix"
 	},
 
+	evolveFrom: {
+		en: "Rowlet",
+		fr: "Brindibou",
+		es: "Rowlet",
+		'es-mx': "Rowlet",
+		de: "Bauz",
+		it: "Rowlet",
+		pt: "Rowlet",
+	},
+
 	illustrator: "aspara",
 	rarity: "Common",
 	category: "Pokemon",

--- a/data/Mega Evolution/Perfect Order/013.ts
+++ b/data/Mega Evolution/Perfect Order/013.ts
@@ -16,6 +16,16 @@ const card: Card = {
 		pt: "Fletchinder"
 	},
 
+	evolveFrom: {
+		en: "Fletchling",
+		fr: "Passerouge",
+		es: "Fletchling",
+		'es-mx': "Fletchling",
+		de: "Dartiri",
+		it: "Fletchling",
+		pt: "Fletchling",
+	},
+
 	illustrator: "Sumiyoshi Kizuki",
 	rarity: "Common",
 	category: "Pokemon",

--- a/data/Mega Evolution/Perfect Order/014.ts
+++ b/data/Mega Evolution/Perfect Order/014.ts
@@ -16,6 +16,16 @@ const card: Card = {
 		pt: "Talonflame"
 	},
 
+	evolveFrom: {
+		en: "Fletchinder",
+		fr: "Braisillon",
+		es: "Fletchinder",
+		'es-mx': "Fletchinder",
+		de: "Dartignis",
+		it: "Fletchinder",
+		pt: "Fletchinder",
+	},
+
 	illustrator: "Shinji Kanda",
 	rarity: "Uncommon",
 	category: "Pokemon",

--- a/data/Mega Evolution/Perfect Order/019.ts
+++ b/data/Mega Evolution/Perfect Order/019.ts
@@ -16,6 +16,16 @@ const card: Card = {
 		pt: "Dewgong"
 	},
 
+	evolveFrom: {
+		en: "Seel",
+		fr: "Otaria",
+		es: "Seel",
+		'es-mx': "Seel",
+		de: "Jurob",
+		it: "Seel",
+		pt: "Seel",
+	},
+
 	illustrator: "Yoshioka",
 	rarity: "Rare",
 	category: "Pokemon",

--- a/data/Mega Evolution/Perfect Order/023.ts
+++ b/data/Mega Evolution/Perfect Order/023.ts
@@ -16,6 +16,16 @@ const card: Card = {
 		pt: "Amaura"
 	},
 
+	evolveFrom: {
+		en: "Antique Sail Fossil",
+		fr: "Fossile Nageoire Ancien",
+		es: "Fósil Aleta Antiguo",
+		'es-mx': "Fósil Aleta Antiguo",
+		de: "Antikes Flossenfossil",
+		it: "Vecchio Fossilpinna",
+		pt: "Fóssil de Vela Arcaico",
+	},
+
 	illustrator: "Hitoshi Ariga",
 	rarity: "Common",
 	category: "Pokemon",

--- a/data/Mega Evolution/Perfect Order/024.ts
+++ b/data/Mega Evolution/Perfect Order/024.ts
@@ -16,6 +16,16 @@ const card: Card = {
 		pt: "Aurorus"
 	},
 
+	evolveFrom: {
+		en: "Amaura",
+		fr: "Amagara",
+		es: "Amaura",
+		'es-mx': "Amaura",
+		de: "Amarino",
+		it: "Amaura",
+		pt: "Amaura",
+	},
+
 	illustrator: "HACCAN",
 	rarity: "Rare",
 	category: "Pokemon",

--- a/data/Mega Evolution/Perfect Order/027.ts
+++ b/data/Mega Evolution/Perfect Order/027.ts
@@ -16,6 +16,16 @@ const card: Card = {
 		pt: "Luxio"
 	},
 
+	evolveFrom: {
+		en: "Shinx",
+		fr: "Lixy",
+		es: "Shinx",
+		'es-mx': "Shinx",
+		de: "Sheinux",
+		it: "Shinx",
+		pt: "Shinx",
+	},
+
 	illustrator: "Atsuko Nishida",
 	rarity: "Uncommon",
 	category: "Pokemon",

--- a/data/Mega Evolution/Perfect Order/028.ts
+++ b/data/Mega Evolution/Perfect Order/028.ts
@@ -16,6 +16,16 @@ const card: Card = {
 		pt: "Luxray"
 	},
 
+	evolveFrom: {
+		en: "Luxio",
+		fr: "Luxio",
+		es: "Luxio",
+		'es-mx': "Luxio",
+		de: "Luxio",
+		it: "Luxio",
+		pt: "Luxio",
+	},
+
 	illustrator: "Taiga Kasai",
 	rarity: "Rare",
 	category: "Pokemon",

--- a/data/Mega Evolution/Perfect Order/034.ts
+++ b/data/Mega Evolution/Perfect Order/034.ts
@@ -16,6 +16,16 @@ const card: Card = {
 		pt: "Meowstic"
 	},
 
+	evolveFrom: {
+		en: "Espurr",
+		fr: "Psystigri",
+		es: "Espurr",
+		'es-mx': "Espurr",
+		de: "Psiau",
+		it: "Espurr",
+		pt: "Espurr",
+	},
+
 	illustrator: "Kannnu",
 	rarity: "Uncommon",
 	category: "Pokemon",

--- a/data/Mega Evolution/Perfect Order/036.ts
+++ b/data/Mega Evolution/Perfect Order/036.ts
@@ -16,6 +16,16 @@ const card: Card = {
 		pt: "Aromatisse"
 	},
 
+	evolveFrom: {
+		en: "Spritzee",
+		fr: "Fluvetin",
+		es: "Spritzee",
+		'es-mx': "Spritzee",
+		de: "Parfi",
+		it: "Spritzee",
+		pt: "Spritzee",
+	},
+
 	illustrator: "Mori Yuu",
 	rarity: "Uncommon",
 	category: "Pokemon",

--- a/data/Mega Evolution/Perfect Order/038.ts
+++ b/data/Mega Evolution/Perfect Order/038.ts
@@ -16,6 +16,16 @@ const card: Card = {
 		pt: "Probopass"
 	},
 
+	evolveFrom: {
+		en: "Nosepass",
+		fr: "Tarinor",
+		es: "Nosepass",
+		'es-mx': "Nosepass",
+		de: "Nasgnet",
+		it: "Nosepass",
+		pt: "Nosepass",
+	},
+
 	illustrator: "Nurikabe",
 	rarity: "Common",
 	category: "Pokemon",

--- a/data/Mega Evolution/Perfect Order/040.ts
+++ b/data/Mega Evolution/Perfect Order/040.ts
@@ -16,6 +16,16 @@ const card: Card = {
 		pt: "Hippowdon"
 	},
 
+	evolveFrom: {
+		en: "Hippopotas",
+		fr: "Hippopotas",
+		es: "Hippopotas",
+		'es-mx': "Hippopotas",
+		de: "Hippopotas",
+		it: "Hippopotas",
+		pt: "Hippopotas",
+	},
+
 	illustrator: "Souichirou Gunjima",
 	rarity: "Uncommon",
 	category: "Pokemon",

--- a/data/Mega Evolution/Perfect Order/043.ts
+++ b/data/Mega Evolution/Perfect Order/043.ts
@@ -16,6 +16,16 @@ const card: Card = {
 		pt: "Barbaracle"
 	},
 
+	evolveFrom: {
+		en: "Binacle",
+		fr: "Opermine",
+		es: "Binacle",
+		'es-mx': "Binacle",
+		de: "Bithora",
+		it: "Binacle",
+		pt: "Binacle",
+	},
+
 	illustrator: "Kazumasa Yasukuni",
 	rarity: "Uncommon",
 	category: "Pokemon",

--- a/data/Mega Evolution/Perfect Order/044.ts
+++ b/data/Mega Evolution/Perfect Order/044.ts
@@ -16,6 +16,16 @@ const card: Card = {
 		pt: "Tyrunt"
 	},
 
+	evolveFrom: {
+		en: "Antique Jaw Fossil",
+		fr: "Fossile Mâchoire Ancien",
+		es: "Fósil Mandíbula Antiguo",
+		'es-mx': "Fósil Mandíbula Antiguo",
+		de: "Antikes Kieferfossil",
+		it: "Vecchio Fossilmascella",
+		pt: "Fóssil de Mandíbula Arcaico",
+	},
+
 	illustrator: "Tomomi Kaneko",
 	rarity: "Common",
 	category: "Pokemon",

--- a/data/Mega Evolution/Perfect Order/045.ts
+++ b/data/Mega Evolution/Perfect Order/045.ts
@@ -16,6 +16,16 @@ const card: Card = {
 		pt: "Tyrantrum"
 	},
 
+	evolveFrom: {
+		en: "Tyrunt",
+		fr: "Ptyranidur",
+		es: "Tyrunt",
+		'es-mx': "Tyrunt",
+		de: "Balgoras",
+		it: "Tyrunt",
+		pt: "Tyrunt",
+	},
+
 	illustrator: "Dsuke",
 	rarity: "Rare",
 	category: "Pokemon",

--- a/data/Mega Evolution/Perfect Order/049.ts
+++ b/data/Mega Evolution/Perfect Order/049.ts
@@ -16,6 +16,16 @@ const card: Card = {
 		pt: "Haunter"
 	},
 
+	evolveFrom: {
+		en: "Gastly",
+		fr: "Fantominus",
+		es: "Gastly",
+		'es-mx': "Gastly",
+		de: "Nebulak",
+		it: "Gastly",
+		pt: "Gastly",
+	},
+
 	illustrator: "Kedamahadaitai Yawarakai",
 	rarity: "Common",
 	category: "Pokemon",

--- a/data/Mega Evolution/Perfect Order/050.ts
+++ b/data/Mega Evolution/Perfect Order/050.ts
@@ -16,6 +16,16 @@ const card: Card = {
 		pt: "Gengar"
 	},
 
+	evolveFrom: {
+		en: "Haunter",
+		fr: "Spectrum",
+		es: "Haunter",
+		'es-mx': "Haunter",
+		de: "Alpollo",
+		it: "Haunter",
+		pt: "Haunter",
+	},
+
 	illustrator: "Masako Tomii",
 	rarity: "Rare",
 	category: "Pokemon",

--- a/data/Mega Evolution/Perfect Order/052.ts
+++ b/data/Mega Evolution/Perfect Order/052.ts
@@ -16,6 +16,16 @@ const card: Card = {
 		pt: "Drapion"
 	},
 
+	evolveFrom: {
+		en: "Skorupi",
+		fr: "Rapion",
+		es: "Skorupi",
+		'es-mx': "Skorupi",
+		de: "Pionskora",
+		it: "Skorupi",
+		pt: "Skorupi",
+	},
+
 	illustrator: "Nelnal",
 	rarity: "Uncommon",
 	category: "Pokemon",

--- a/data/Mega Evolution/Perfect Order/057.ts
+++ b/data/Mega Evolution/Perfect Order/057.ts
@@ -16,6 +16,16 @@ const card: Card = {
 		pt: "Doublade"
 	},
 
+	evolveFrom: {
+		en: "Honedge",
+		fr: "Monorpale",
+		es: "Honedge",
+		'es-mx': "Honedge",
+		de: "Gramokles",
+		it: "Honedge",
+		pt: "Honedge",
+	},
+
 	illustrator: "Kamome Shirahama",
 	rarity: "Common",
 	category: "Pokemon",

--- a/data/Mega Evolution/Perfect Order/058.ts
+++ b/data/Mega Evolution/Perfect Order/058.ts
@@ -16,6 +16,16 @@ const card: Card = {
 		pt: "Aegislash"
 	},
 
+	evolveFrom: {
+		en: "Doublade",
+		fr: "Dimoclès",
+		es: "Doublade",
+		'es-mx': "Doublade",
+		de: "Duokles",
+		it: "Doublade",
+		pt: "Doublade",
+	},
+
 	illustrator: "Mitsuhiro Arita",
 	rarity: "Uncommon",
 	category: "Pokemon",

--- a/data/Mega Evolution/Perfect Order/061.ts
+++ b/data/Mega Evolution/Perfect Order/061.ts
@@ -16,6 +16,16 @@ const card: Card = {
 		pt: "Raticate"
 	},
 
+	evolveFrom: {
+		en: "Rattata",
+		fr: "Rattata",
+		es: "Rattata",
+		'es-mx': "Rattata",
+		de: "Rattfratz",
+		it: "Rattata",
+		pt: "Rattata",
+	},
+
 	illustrator: "Minahamu",
 	rarity: "Uncommon",
 	category: "Pokemon",

--- a/data/Mega Evolution/Perfect Order/065.ts
+++ b/data/Mega Evolution/Perfect Order/065.ts
@@ -16,6 +16,16 @@ const card: Card = {
 		pt: "Diggersby"
 	},
 
+	evolveFrom: {
+		en: "Bunnelby",
+		fr: "Sapereau",
+		es: "Bunnelby",
+		'es-mx': "Bunnelby",
+		de: "Scoppel",
+		it: "Bunnelby",
+		pt: "Bunnelby",
+	},
+
 	illustrator: "Mousho",
 	rarity: "Uncommon",
 	category: "Pokemon",

--- a/data/Mega Evolution/Perfect Order/089.ts
+++ b/data/Mega Evolution/Perfect Order/089.ts
@@ -16,6 +16,16 @@ const card: Card = {
 		pt: "Spewpa"
 	},
 
+	evolveFrom: {
+		en: "Scatterbug",
+		fr: "Lépidonille",
+		es: "Scatterbug",
+		'es-mx': "Scatterbug",
+		de: "Purmel",
+		it: "Scatterbug",
+		pt: "Scatterbug",
+	},
+
 	illustrator: "kamonabe",
 	rarity: "Illustration rare",
 	category: "Pokemon",

--- a/data/Mega Evolution/Perfect Order/091.ts
+++ b/data/Mega Evolution/Perfect Order/091.ts
@@ -16,6 +16,16 @@ const card: Card = {
 		pt: "Talonflame"
 	},
 
+	evolveFrom: {
+		en: "Fletchinder",
+		fr: "Braisillon",
+		es: "Fletchinder",
+		'es-mx': "Fletchinder",
+		de: "Dartignis",
+		it: "Fletchinder",
+		pt: "Fletchinder",
+	},
+
 	illustrator: "OKACHEKE",
 	rarity: "Illustration rare",
 	category: "Pokemon",

--- a/data/Mega Evolution/Perfect Order/092.ts
+++ b/data/Mega Evolution/Perfect Order/092.ts
@@ -16,6 +16,16 @@ const card: Card = {
 		pt: "Aurorus"
 	},
 
+	evolveFrom: {
+		en: "Amaura",
+		fr: "Amagara",
+		es: "Amaura",
+		'es-mx': "Amaura",
+		de: "Amarino",
+		it: "Amaura",
+		pt: "Amaura",
+	},
+
 	illustrator: "Masa",
 	rarity: "Illustration rare",
 	category: "Pokemon",

--- a/data/Mega Evolution/Perfect Order/096.ts
+++ b/data/Mega Evolution/Perfect Order/096.ts
@@ -16,6 +16,16 @@ const card: Card = {
 		pt: "Probopass"
 	},
 
+	evolveFrom: {
+		en: "Nosepass",
+		fr: "Tarinor",
+		es: "Nosepass",
+		'es-mx': "Nosepass",
+		de: "Nasgnet",
+		it: "Nosepass",
+		pt: "Nosepass",
+	},
+
 	illustrator: "Kinu Nishimura",
 	rarity: "Illustration rare",
 	category: "Pokemon",

--- a/data/Mega Evolution/Perfect Order/097.ts
+++ b/data/Mega Evolution/Perfect Order/097.ts
@@ -16,6 +16,16 @@ const card: Card = {
 		pt: "Drapion"
 	},
 
+	evolveFrom: {
+		en: "Skorupi",
+		fr: "Rapion",
+		es: "Skorupi",
+		'es-mx': "Skorupi",
+		de: "Pionskora",
+		it: "Skorupi",
+		pt: "Skorupi",
+	},
+
 	illustrator: "kawayoo",
 	rarity: "Illustration rare",
 	category: "Pokemon",

--- a/data/Mega Evolution/Perfect Order/098.ts
+++ b/data/Mega Evolution/Perfect Order/098.ts
@@ -16,6 +16,16 @@ const card: Card = {
 		pt: "Doublade"
 	},
 
+	evolveFrom: {
+		en: "Honedge",
+		fr: "Monorpale",
+		es: "Honedge",
+		'es-mx': "Honedge",
+		de: "Gramokles",
+		it: "Honedge",
+		pt: "Honedge",
+	},
+
 	illustrator: "Anesaki Dynamic",
 	rarity: "Illustration rare",
 	category: "Pokemon",

--- a/data/Mega Evolution/Perfect Order/099.ts
+++ b/data/Mega Evolution/Perfect Order/099.ts
@@ -16,6 +16,16 @@ const card: Card = {
 		pt: "Raticate"
 	},
 
+	evolveFrom: {
+		en: "Rattata",
+		fr: "Rattata",
+		es: "Rattata",
+		'es-mx': "Rattata",
+		de: "Rattfratz",
+		it: "Rattata",
+		pt: "Rattata",
+	},
+
 	illustrator: "Mina Nakai",
 	rarity: "Illustration rare",
 	category: "Pokemon",

--- a/data/Mega Evolution/Phantasmal Flames/002.ts
+++ b/data/Mega Evolution/Phantasmal Flames/002.ts
@@ -14,6 +14,16 @@ const card: Card = {
 		pt: "Gloom"
 	},
 
+	evolveFrom: {
+		en: "Oddish",
+		fr: "Mystherbe",
+		es: "Oddish",
+		'es-mx': "Oddish",
+		de: "Myrapla",
+		it: "Oddish",
+		pt: "Oddish",
+	},
+
 	rarity: "Common",
 	category: "Pokemon",
 

--- a/data/Mega Evolution/Phantasmal Flames/003.ts
+++ b/data/Mega Evolution/Phantasmal Flames/003.ts
@@ -14,6 +14,16 @@ const card: Card = {
 		pt: "Vileplume"
 	},
 
+	evolveFrom: {
+		en: "Gloom",
+		fr: "Ortide",
+		es: "Gloom",
+		'es-mx': "Gloom",
+		de: "Duflor",
+		it: "Gloom",
+		pt: "Gloom",
+	},
+
 	rarity: "Rare",
 	category: "Pokemon",
 

--- a/data/Mega Evolution/Phantasmal Flames/006.ts
+++ b/data/Mega Evolution/Phantasmal Flames/006.ts
@@ -14,6 +14,16 @@ const card: Card = {
 		pt: "Lombre"
 	},
 
+	evolveFrom: {
+		en: "Lotad",
+		fr: "Nénupiot",
+		es: "Lotad",
+		'es-mx': "Lotad",
+		de: "Loturzel",
+		it: "Lotad",
+		pt: "Lotad",
+	},
+
 	rarity: "Common",
 	category: "Pokemon",
 

--- a/data/Mega Evolution/Phantasmal Flames/007.ts
+++ b/data/Mega Evolution/Phantasmal Flames/007.ts
@@ -14,6 +14,16 @@ const card: Card = {
 		pt: "Ludicolo"
 	},
 
+	evolveFrom: {
+		en: "Lombre",
+		fr: "Lombre",
+		es: "Lombre",
+		'es-mx': "Lombre",
+		de: "Lombrero",
+		it: "Lombre",
+		pt: "Lombre",
+	},
+
 	rarity: "Uncommon",
 	category: "Pokemon",
 

--- a/data/Mega Evolution/Phantasmal Flames/010.ts
+++ b/data/Mega Evolution/Phantasmal Flames/010.ts
@@ -14,6 +14,16 @@ const card: Card = {
 		pt: "Lokix"
 	},
 
+	evolveFrom: {
+		en: "Nymble",
+		fr: "Lilliterelle",
+		es: "Nymble",
+		'es-mx': "Nymble",
+		de: "Micrick",
+		it: "Nymble",
+		pt: "Nymble",
+	},
+
 	rarity: "Uncommon",
 	category: "Pokemon",
 

--- a/data/Mega Evolution/Phantasmal Flames/012.ts
+++ b/data/Mega Evolution/Phantasmal Flames/012.ts
@@ -14,6 +14,16 @@ const card: Card = {
 		pt: "Charmeleon"
 	},
 
+	evolveFrom: {
+		en: "Charmander",
+		fr: "Salamèche",
+		es: "Charmander",
+		'es-mx': "Charmander",
+		de: "Glumanda",
+		it: "Charmander",
+		pt: "Charmander",
+	},
+
 	rarity: "Common",
 	category: "Pokemon",
 

--- a/data/Mega Evolution/Phantasmal Flames/013.ts
+++ b/data/Mega Evolution/Phantasmal Flames/013.ts
@@ -14,6 +14,16 @@ const card: Card = {
 		pt: "Mega Charizard X ex"
 	},
 
+	evolveFrom: {
+		en: "Charmeleon",
+		fr: "Reptincel",
+		es: "Charmeleon",
+		'es-mx': "Charmeleon",
+		de: "Glutexo",
+		it: "Charmeleon",
+		pt: "Charmeleon",
+	},
+
 	rarity: "Double rare",
 	category: "Pokemon",
 

--- a/data/Mega Evolution/Phantasmal Flames/016.ts
+++ b/data/Mega Evolution/Phantasmal Flames/016.ts
@@ -14,6 +14,16 @@ const card: Card = {
 		pt: "Darmanitan"
 	},
 
+	evolveFrom: {
+		en: "Darumaka",
+		fr: "Darumarond",
+		es: "Darumaka",
+		'es-mx': "Darumaka",
+		de: "Flampion",
+		it: "Darumaka",
+		pt: "Darumaka",
+	},
+
 	rarity: "Uncommon",
 	category: "Pokemon",
 

--- a/data/Mega Evolution/Phantasmal Flames/020.ts
+++ b/data/Mega Evolution/Phantasmal Flames/020.ts
@@ -14,6 +14,16 @@ const card: Card = {
 		pt: "Ceruledge"
 	},
 
+	evolveFrom: {
+		en: "Charcadet",
+		fr: "Charbambin",
+		es: "Charcadet",
+		'es-mx': "Charcadet",
+		de: "Knarbon",
+		it: "Charcadet",
+		pt: "Charcadet",
+	},
+
 	rarity: "Uncommon",
 	category: "Pokemon",
 

--- a/data/Mega Evolution/Phantasmal Flames/022.ts
+++ b/data/Mega Evolution/Phantasmal Flames/022.ts
@@ -14,6 +14,16 @@ const card: Card = {
 		pt: "Dewgong"
 	},
 
+	evolveFrom: {
+		en: "Seel",
+		fr: "Otaria",
+		es: "Seel",
+		'es-mx': "Seel",
+		de: "Jurob",
+		it: "Seel",
+		pt: "Seel",
+	},
+
 	rarity: "Common",
 	category: "Pokemon",
 

--- a/data/Mega Evolution/Phantasmal Flames/024.ts
+++ b/data/Mega Evolution/Phantasmal Flames/024.ts
@@ -14,6 +14,16 @@ const card: Card = {
 		pt: "Piloswine"
 	},
 
+	evolveFrom: {
+		en: "Swinub",
+		fr: "Marcacrin",
+		es: "Swinub",
+		'es-mx': "Swinub",
+		de: "Quiekel",
+		it: "Swinub",
+		pt: "Swinub",
+	},
+
 	rarity: "Common",
 	category: "Pokemon",
 

--- a/data/Mega Evolution/Phantasmal Flames/025.ts
+++ b/data/Mega Evolution/Phantasmal Flames/025.ts
@@ -14,6 +14,16 @@ const card: Card = {
 		pt: "Mamoswine"
 	},
 
+	evolveFrom: {
+		en: "Piloswine",
+		fr: "Cochignon",
+		es: "Piloswine",
+		'es-mx': "Piloswine",
+		de: "Keifel",
+		it: "Piloswine",
+		pt: "Piloswine",
+	},
+
 	rarity: "Uncommon",
 	category: "Pokemon",
 

--- a/data/Mega Evolution/Phantasmal Flames/028.ts
+++ b/data/Mega Evolution/Phantasmal Flames/028.ts
@@ -14,6 +14,16 @@ const card: Card = {
 		pt: "Prinplup"
 	},
 
+	evolveFrom: {
+		en: "Piplup",
+		fr: "Tiplouf",
+		es: "Piplup",
+		'es-mx': "Piplup",
+		de: "Plinfa",
+		it: "Piplup",
+		pt: "Piplup",
+	},
+
 	rarity: "Common",
 	category: "Pokemon",
 

--- a/data/Mega Evolution/Phantasmal Flames/031.ts
+++ b/data/Mega Evolution/Phantasmal Flames/031.ts
@@ -14,6 +14,16 @@ const card: Card = {
 		pt: "Boltund"
 	},
 
+	evolveFrom: {
+		en: "Yamper",
+		fr: "Voltoutou",
+		es: "Yamper",
+		'es-mx': "Yamper",
+		de: "Voldi",
+		it: "Yamper",
+		pt: "Yamper",
+	},
+
 	rarity: "Common",
 	category: "Pokemon",
 

--- a/data/Mega Evolution/Phantasmal Flames/033.ts
+++ b/data/Mega Evolution/Phantasmal Flames/033.ts
@@ -14,6 +14,16 @@ const card: Card = {
 		pt: "Pawmo"
 	},
 
+	evolveFrom: {
+		en: "Pawmi",
+		fr: "Pohm",
+		es: "Pawmi",
+		'es-mx': "Pawmi",
+		de: "Pamo",
+		it: "Pawmi",
+		pt: "Pawmi",
+	},
+
 	rarity: "Common",
 	category: "Pokemon",
 

--- a/data/Mega Evolution/Phantasmal Flames/034.ts
+++ b/data/Mega Evolution/Phantasmal Flames/034.ts
@@ -14,6 +14,16 @@ const card: Card = {
 		pt: "Pawmot"
 	},
 
+	evolveFrom: {
+		en: "Pawmo",
+		fr: "Pohmotte",
+		es: "Pawmo",
+		'es-mx': "Pawmo",
+		de: "Pamamo",
+		it: "Pawmo",
+		pt: "Pawmo",
+	},
+
 	rarity: "Rare",
 	category: "Pokemon",
 

--- a/data/Mega Evolution/Phantasmal Flames/038.ts
+++ b/data/Mega Evolution/Phantasmal Flames/038.ts
@@ -14,6 +14,16 @@ const card: Card = {
 		pt: "Granbull"
 	},
 
+	evolveFrom: {
+		en: "Snubbull",
+		fr: "Snubbull",
+		es: "Snubbull",
+		'es-mx': "Snubbull",
+		de: "Snubbull",
+		it: "Snubbull",
+		pt: "Snubbull",
+	},
+
 	rarity: "Uncommon",
 	category: "Pokemon",
 

--- a/data/Mega Evolution/Phantasmal Flames/044.ts
+++ b/data/Mega Evolution/Phantasmal Flames/044.ts
@@ -14,6 +14,16 @@ const card: Card = {
 		pt: "Alcremie"
 	},
 
+	evolveFrom: {
+		en: "Milcery",
+		fr: "Crèmy",
+		es: "Milcery",
+		'es-mx': "Milcery",
+		de: "Hokumil",
+		it: "Milcery",
+		pt: "Milcery",
+	},
+
 	rarity: "Uncommon",
 	category: "Pokemon",
 

--- a/data/Mega Evolution/Phantasmal Flames/047.ts
+++ b/data/Mega Evolution/Phantasmal Flames/047.ts
@@ -14,6 +14,16 @@ const card: Card = {
 		pt: "Brambleghast"
 	},
 
+	evolveFrom: {
+		en: "Bramblin",
+		fr: "Virovent",
+		es: "Bramblin",
+		'es-mx': "Bramblin",
+		de: "Weherba",
+		it: "Bramblin",
+		pt: "Bramblin",
+	},
+
 	rarity: "Uncommon",
 	category: "Pokemon",
 

--- a/data/Mega Evolution/Phantasmal Flames/050.ts
+++ b/data/Mega Evolution/Phantasmal Flames/050.ts
@@ -14,6 +14,16 @@ const card: Card = {
 		pt: "Gliscor"
 	},
 
+	evolveFrom: {
+		en: "Gligar",
+		fr: "Scorplane",
+		es: "Gligar",
+		'es-mx': "Gligar",
+		de: "Skorgla",
+		it: "Gligar",
+		pt: "Gligar",
+	},
+
 	rarity: "Uncommon",
 	category: "Pokemon",
 

--- a/data/Mega Evolution/Phantasmal Flames/052.ts
+++ b/data/Mega Evolution/Phantasmal Flames/052.ts
@@ -14,6 +14,16 @@ const card: Card = {
 		pt: "Vibrava"
 	},
 
+	evolveFrom: {
+		en: "Trapinch",
+		fr: "Kraknoix",
+		es: "Trapinch",
+		'es-mx': "Trapinch",
+		de: "Knacklion",
+		it: "Trapinch",
+		pt: "Trapinch",
+	},
+
 	rarity: "Common",
 	category: "Pokemon",
 

--- a/data/Mega Evolution/Phantasmal Flames/053.ts
+++ b/data/Mega Evolution/Phantasmal Flames/053.ts
@@ -14,6 +14,16 @@ const card: Card = {
 		pt: "Flygon"
 	},
 
+	evolveFrom: {
+		en: "Vibrava",
+		fr: "Vibraninf",
+		es: "Vibrava",
+		'es-mx': "Vibrava",
+		de: "Vibrava",
+		it: "Vibrava",
+		pt: "Vibrava",
+	},
+
 	rarity: "Rare",
 	category: "Pokemon",
 

--- a/data/Mega Evolution/Phantasmal Flames/055.ts
+++ b/data/Mega Evolution/Phantasmal Flames/055.ts
@@ -14,6 +14,16 @@ const card: Card = {
 		pt: "Haunter"
 	},
 
+	evolveFrom: {
+		en: "Gastly",
+		fr: "Fantominus",
+		es: "Gastly",
+		'es-mx': "Gastly",
+		de: "Nebulak",
+		it: "Gastly",
+		pt: "Gastly",
+	},
+
 	rarity: "Uncommon",
 	category: "Pokemon",
 

--- a/data/Mega Evolution/Phantasmal Flames/058.ts
+++ b/data/Mega Evolution/Phantasmal Flames/058.ts
@@ -14,6 +14,16 @@ const card: Card = {
 		pt: "Honchkrow"
 	},
 
+	evolveFrom: {
+		en: "Murkrow",
+		fr: "Cornèbre",
+		es: "Murkrow",
+		'es-mx': "Murkrow",
+		de: "Kramurx",
+		it: "Murkrow",
+		pt: "Murkrow",
+	},
+
 	rarity: "Uncommon",
 	category: "Pokemon",
 

--- a/data/Mega Evolution/Phantasmal Flames/065.ts
+++ b/data/Mega Evolution/Phantasmal Flames/065.ts
@@ -14,6 +14,16 @@ const card: Card = {
 		pt: "Krokorok"
 	},
 
+	evolveFrom: {
+		en: "Sandile",
+		fr: "Mascaïman",
+		es: "Sandile",
+		'es-mx': "Sandile",
+		de: "Ganovil",
+		it: "Sandile",
+		pt: "Sandile",
+	},
+
 	rarity: "Common",
 	category: "Pokemon",
 

--- a/data/Mega Evolution/Phantasmal Flames/066.ts
+++ b/data/Mega Evolution/Phantasmal Flames/066.ts
@@ -14,6 +14,16 @@ const card: Card = {
 		pt: "Krookodile"
 	},
 
+	evolveFrom: {
+		en: "Krokorok",
+		fr: "Escroco",
+		es: "Krokorok",
+		'es-mx': "Krokorok",
+		de: "Rokkaiman",
+		it: "Krokorok",
+		pt: "Krokorok",
+	},
+
 	rarity: "Uncommon",
 	category: "Pokemon",
 

--- a/data/Mega Evolution/Phantasmal Flames/068.ts
+++ b/data/Mega Evolution/Phantasmal Flames/068.ts
@@ -14,6 +14,16 @@ const card: Card = {
 		pt: "Toxtricity"
 	},
 
+	evolveFrom: {
+		en: "Toxel",
+		fr: "Toxizap",
+		es: "Toxel",
+		'es-mx': "Toxel",
+		de: "Toxel",
+		it: "Toxel",
+		pt: "Toxel",
+	},
+
 	rarity: "Rare",
 	category: "Pokemon",
 

--- a/data/Mega Evolution/Phantasmal Flames/070.ts
+++ b/data/Mega Evolution/Phantasmal Flames/070.ts
@@ -14,6 +14,16 @@ const card: Card = {
 		pt: "Empoleon ex"
 	},
 
+	evolveFrom: {
+		en: "Prinplup",
+		fr: "Prinplouf",
+		es: "Prinplup",
+		'es-mx': "Prinplup",
+		de: "Pliprin",
+		it: "Prinplup",
+		pt: "Prinplup",
+	},
+
 	rarity: "Double rare",
 	category: "Pokemon",
 

--- a/data/Mega Evolution/Phantasmal Flames/072.ts
+++ b/data/Mega Evolution/Phantasmal Flames/072.ts
@@ -14,6 +14,16 @@ const card: Card = {
 		pt: "Bronzong"
 	},
 
+	evolveFrom: {
+		en: "Bronzor",
+		fr: "Archéomire",
+		es: "Bronzor",
+		'es-mx': "Bronzor",
+		de: "Bronzel",
+		it: "Bronzor",
+		pt: "Bronzor",
+	},
+
 	rarity: "Uncommon",
 	category: "Pokemon",
 

--- a/data/Mega Evolution/Phantasmal Flames/075.ts
+++ b/data/Mega Evolution/Phantasmal Flames/075.ts
@@ -14,6 +14,16 @@ const card: Card = {
 		pt: "Archaludon"
 	},
 
+	evolveFrom: {
+		en: "Duraludon",
+		fr: "Duralugon",
+		es: "Duraludon",
+		'es-mx': "Duraludon",
+		de: "Duraludon",
+		it: "Duraludon",
+		pt: "Duraludon",
+	},
+
 	rarity: "Uncommon",
 	category: "Pokemon",
 

--- a/data/Mega Evolution/Phantasmal Flames/077.ts
+++ b/data/Mega Evolution/Phantasmal Flames/077.ts
@@ -14,6 +14,16 @@ const card: Card = {
 		pt: "Wigglytuff"
 	},
 
+	evolveFrom: {
+		en: "Jigglypuff",
+		fr: "Rondoudou",
+		es: "Jigglypuff",
+		'es-mx': "Jigglypuff",
+		de: "Pummeluff",
+		it: "Jigglypuff",
+		pt: "Jigglypuff",
+	},
+
 	rarity: "Uncommon",
 	category: "Pokemon",
 

--- a/data/Mega Evolution/Phantasmal Flames/079.ts
+++ b/data/Mega Evolution/Phantasmal Flames/079.ts
@@ -14,6 +14,16 @@ const card: Card = {
 		pt: "Ambipom"
 	},
 
+	evolveFrom: {
+		en: "Aipom",
+		fr: "Capumain",
+		es: "Aipom",
+		'es-mx': "Aipom",
+		de: "Griffel",
+		it: "Aipom",
+		pt: "Aipom",
+	},
+
 	rarity: "Rare",
 	category: "Pokemon",
 

--- a/data/Mega Evolution/Phantasmal Flames/082.ts
+++ b/data/Mega Evolution/Phantasmal Flames/082.ts
@@ -14,6 +14,16 @@ const card: Card = {
 		pt: "Linoone"
 	},
 
+	evolveFrom: {
+		en: "Zigzagoon",
+		fr: "Zigzaton",
+		es: "Zigzagoon",
+		'es-mx': "Zigzagoon",
+		de: "Zigzachs",
+		it: "Zigzagoon",
+		pt: "Zigzagoon",
+	},
+
 	rarity: "Uncommon",
 	category: "Pokemon",
 

--- a/data/Mega Evolution/Phantasmal Flames/095.ts
+++ b/data/Mega Evolution/Phantasmal Flames/095.ts
@@ -14,6 +14,16 @@ const card: Card = {
 		pt: "Ludicolo"
 	},
 
+	evolveFrom: {
+		en: "Lombre",
+		fr: "Lombre",
+		es: "Lombre",
+		'es-mx': "Lombre",
+		de: "Lombrero",
+		it: "Lombre",
+		pt: "Lombre",
+	},
+
 	rarity: "Illustration rare",
 	category: "Pokemon",
 

--- a/data/Mega Evolution/Phantasmal Flames/097.ts
+++ b/data/Mega Evolution/Phantasmal Flames/097.ts
@@ -14,6 +14,16 @@ const card: Card = {
 		pt: "Dewgong"
 	},
 
+	evolveFrom: {
+		en: "Seel",
+		fr: "Otaria",
+		es: "Seel",
+		'es-mx': "Seel",
+		de: "Jurob",
+		it: "Seel",
+		pt: "Seel",
+	},
+
 	rarity: "Illustration rare",
 	category: "Pokemon",
 

--- a/data/Mega Evolution/Phantasmal Flames/101.ts
+++ b/data/Mega Evolution/Phantasmal Flames/101.ts
@@ -14,6 +14,16 @@ const card: Card = {
 		pt: "Flygon"
 	},
 
+	evolveFrom: {
+		en: "Vibrava",
+		fr: "Vibraninf",
+		es: "Vibrava",
+		'es-mx': "Vibrava",
+		de: "Vibrava",
+		it: "Vibrava",
+		pt: "Vibrava",
+	},
+
 	rarity: "Illustration rare",
 	category: "Pokemon",
 

--- a/data/Mega Evolution/Phantasmal Flames/103.ts
+++ b/data/Mega Evolution/Phantasmal Flames/103.ts
@@ -14,6 +14,16 @@ const card: Card = {
 		pt: "Toxtricity"
 	},
 
+	evolveFrom: {
+		en: "Toxel",
+		fr: "Toxizap",
+		es: "Toxel",
+		'es-mx': "Toxel",
+		de: "Toxel",
+		it: "Toxel",
+		pt: "Toxel",
+	},
+
 	rarity: "Illustration rare",
 	category: "Pokemon",
 

--- a/data/Mega Evolution/Phantasmal Flames/105.ts
+++ b/data/Mega Evolution/Phantasmal Flames/105.ts
@@ -14,6 +14,16 @@ const card: Card = {
 		pt: "Wigglytuff"
 	},
 
+	evolveFrom: {
+		en: "Jigglypuff",
+		fr: "Rondoudou",
+		es: "Jigglypuff",
+		'es-mx': "Jigglypuff",
+		de: "Pummeluff",
+		it: "Jigglypuff",
+		pt: "Jigglypuff",
+	},
+
 	rarity: "Illustration rare",
 	category: "Pokemon",
 

--- a/data/Mega Evolution/Phantasmal Flames/107.ts
+++ b/data/Mega Evolution/Phantasmal Flames/107.ts
@@ -14,6 +14,16 @@ const card: Card = {
 		pt: "Ambipom"
 	},
 
+	evolveFrom: {
+		en: "Aipom",
+		fr: "Capumain",
+		es: "Aipom",
+		'es-mx': "Aipom",
+		de: "Griffel",
+		it: "Aipom",
+		pt: "Aipom",
+	},
+
 	rarity: "Illustration rare",
 	category: "Pokemon",
 

--- a/data/Mega Evolution/Phantasmal Flames/109.ts
+++ b/data/Mega Evolution/Phantasmal Flames/109.ts
@@ -14,6 +14,16 @@ const card: Card = {
 		pt: "Mega Charizard X ex"
 	},
 
+	evolveFrom: {
+		en: "Charmeleon",
+		fr: "Reptincel",
+		es: "Charmeleon",
+		'es-mx': "Charmeleon",
+		de: "Glutexo",
+		it: "Charmeleon",
+		pt: "Charmeleon",
+	},
+
 	rarity: "Ultra Rare",
 	category: "Pokemon",
 

--- a/data/Mega Evolution/Phantasmal Flames/114.ts
+++ b/data/Mega Evolution/Phantasmal Flames/114.ts
@@ -14,6 +14,16 @@ const card: Card = {
 		pt: "Empoleon ex"
 	},
 
+	evolveFrom: {
+		en: "Prinplup",
+		fr: "Prinplouf",
+		es: "Prinplup",
+		'es-mx': "Prinplup",
+		de: "Pliprin",
+		it: "Prinplup",
+		pt: "Prinplup",
+	},
+
 	rarity: "Ultra Rare",
 	category: "Pokemon",
 

--- a/data/Mega Evolution/Phantasmal Flames/125.ts
+++ b/data/Mega Evolution/Phantasmal Flames/125.ts
@@ -14,6 +14,16 @@ const card: Card = {
 		pt: "Mega Charizard X ex"
 	},
 
+	evolveFrom: {
+		en: "Charmeleon",
+		fr: "Reptincel",
+		es: "Charmeleon",
+		'es-mx': "Charmeleon",
+		de: "Glutexo",
+		it: "Charmeleon",
+		pt: "Charmeleon",
+	},
+
 	rarity: "Special illustration rare",
 	category: "Pokemon",
 

--- a/data/Mega Evolution/Phantasmal Flames/130.ts
+++ b/data/Mega Evolution/Phantasmal Flames/130.ts
@@ -14,6 +14,16 @@ const card: Card = {
 		pt: "Mega Charizard X ex"
 	},
 
+	evolveFrom: {
+		en: "Charmeleon",
+		fr: "Reptincel",
+		es: "Charmeleon",
+		'es-mx': "Charmeleon",
+		de: "Glutexo",
+		it: "Charmeleon",
+		pt: "Charmeleon",
+	},
+
 	rarity: "Mega Hyper Rare",
 	category: "Pokemon",
 


### PR DESCRIPTION
## Summary

- add missing localized `evolveFrom` values to 173 Standard-legal Stage 1 and Stage 2 card prints
- cover Phantasmal Flames (43), Ascended Heroes (87), Perfect Order (34), and MEP Black Star Promos (9)
- use the corresponding parent card names already present in the multilingual card database for localized values

## Official verification

Every affected English card image was downloaded from `assets.pokemon.com` and its printed **Evolves from** line was checked against the added English value, including all alternate-art prints and promos.

Representative official records:

- [Toxtricity 68 — Evolves From: Toxel](https://www.pokemon.com/uk/pokemon-tcg/pokemon-cards/series/me02/68/)
- [Erika's Gloom 2 — Evolves From: Erika's Oddish](https://www.pokemon.com/uk/pokemon-tcg/pokemon-cards/series/me2pt5/2/)
- [Amaura 23 — Evolves From: Antique Sail Fossil](https://www.pokemon.com/uk/pokemon-tcg/pokemon-cards/series/me03/23/)
- [Tyrunt 44 — Evolves From: Antique Jaw Fossil](https://www.pokemon.com/uk/pokemon-tcg/pokemon-cards/series/me03/44/)
- [Toxtricity MEP 17 — Evolves From: Toxel](https://www.pokemon.com/uk/pokemon-tcg/pokemon-cards/series/mep/17/)

## Validation

- `npm run validate`
- `git diff --check`
- post-change audit: 1,143 Standard Stage 1/Stage 2 prints checked, 0 missing `evolveFrom`
