### PR TITLE
feat(data): Add missing MEP Black Star Promos and update card infos

### DIFF
--- a/data/Mega Evolution/MEP Black Star Promos/001.ts
+++ b/data/Mega Evolution/MEP Black Star Promos/001.ts
@@ -32,6 +32,16 @@ const card: Card = {
 	stage: "Stage2",
 	dexId: [154],
 
+	evolveFrom: {
+		en: "Bayleef",
+		de: "Lorblatt",
+		es: "Bayleef",
+		'es-mx': "Bayleef",
+		fr: "Macronium",
+		it: "Bayleef",
+		pt: "Bayleef",
+	},
+
 	abilities: [{
 		type: "Ability",
 
@@ -75,19 +85,26 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "I",
 
+	weaknesses: [{
+		type: "Fire",
+		value: "x2"
+	}],
+
 	variants: [
 		{
 			type: "holo",
 			stamp: ["set-logo"],
 			thirdParty: {
-				cardmarket: 851043
+				cardmarket: 851043,
+				tcgplayer: 654594
 			}
 		},
 		{
 			type: "holo",
 			stamp: ["set-logo","staff"],
 			thirdParty: {
-				cardmarket: 851044
+				cardmarket: 851044,
+				tcgplayer: 656800
 			}
 		},
 	],

--- a/data/Mega Evolution/MEP Black Star Promos/001.ts
+++ b/data/Mega Evolution/MEP Black Star Promos/001.ts
@@ -32,16 +32,6 @@ const card: Card = {
 	stage: "Stage2",
 	dexId: [154],
 
-	evolveFrom: {
-		en: "Bayleef",
-		de: "Lorblatt",
-		es: "Bayleef",
-		'es-mx': "Bayleef",
-		fr: "Macronium",
-		it: "Bayleef",
-		pt: "Bayleef",
-	},
-
 	abilities: [{
 		type: "Ability",
 

--- a/data/Mega Evolution/MEP Black Star Promos/002.ts
+++ b/data/Mega Evolution/MEP Black Star Promos/002.ts
@@ -32,6 +32,16 @@ const card: Card = {
 	stage: "Stage2",
 	dexId: [818],
 
+	evolveFrom: {
+		en: "Drizzile",
+		fr: "Arrozard",
+		de: "Phlegleon",
+		it: "Drizzile",
+		es: "Drizzile",
+		pt: "Drizzile",
+		'es-mx': "Drizzile"
+	},
+
 	attacks: [{
 		cost: ["Water"],
 
@@ -83,19 +93,26 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "I",
 
+	weaknesses: [{
+		type: "Lightning",
+		value: "x2"
+	}],
+
 	variants: [
 		{
 			type: "holo",
 			stamp: ["set-logo"],
 			thirdParty: {
-				cardmarket: 851045
+				cardmarket: 851045,
+				tcgplayer: 654596
 			}
 		},
 		{
 			type: "holo",
 			stamp: ["set-logo","staff"],
 			thirdParty: {
-				cardmarket: 851046
+				cardmarket: 851046,
+				tcgplayer: 656802
 			}
 		},
 	],

--- a/data/Mega Evolution/MEP Black Star Promos/002.ts
+++ b/data/Mega Evolution/MEP Black Star Promos/002.ts
@@ -32,16 +32,6 @@ const card: Card = {
 	stage: "Stage2",
 	dexId: [818],
 
-	evolveFrom: {
-		en: "Drizzile",
-		fr: "Arrozard",
-		de: "Phlegleon",
-		it: "Drizzile",
-		es: "Drizzile",
-		pt: "Drizzile",
-		'es-mx': "Drizzile"
-	},
-
 	attacks: [{
 		cost: ["Water"],
 

--- a/data/Mega Evolution/MEP Black Star Promos/003.ts
+++ b/data/Mega Evolution/MEP Black Star Promos/003.ts
@@ -32,6 +32,16 @@ const card: Card = {
 	stage: "Stage2",
 	dexId: [65],
 
+	evolveFrom: {
+		en: "Kadabra",
+		fr: "Kadabra",
+		de: "Kadabra",
+		it: "Kadabra",
+		es: "Kadabra",
+		pt: "Kadabra",
+		'es-mx': "Kadabra"
+	},
+
 	abilities: [{
 		type: "Ability",
 
@@ -83,19 +93,31 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "I",
 
+	weaknesses: [{
+		type: "Darkness",
+		value: "x2"
+	}],
+
+	resistances: [{
+		type: "Fighting",
+		value: "-30"
+	}],
+
 	variants: [
 		{
 			type: "holo",
 			stamp: ["set-logo"],
 			thirdParty: {
-				cardmarket: 851047
+				cardmarket: 851047,
+				tcgplayer: 654597
 			}
 		},
 		{
 			type: "holo",
 			stamp: ["set-logo","staff"],
 			thirdParty: {
-				cardmarket: 851048
+				cardmarket: 851048,
+				tcgplayer: 656385
 			}
 		},
 	],

--- a/data/Mega Evolution/MEP Black Star Promos/003.ts
+++ b/data/Mega Evolution/MEP Black Star Promos/003.ts
@@ -32,16 +32,6 @@ const card: Card = {
 	stage: "Stage2",
 	dexId: [65],
 
-	evolveFrom: {
-		en: "Kadabra",
-		fr: "Kadabra",
-		de: "Kadabra",
-		it: "Kadabra",
-		es: "Kadabra",
-		pt: "Kadabra",
-		'es-mx': "Kadabra"
-	},
-
 	abilities: [{
 		type: "Ability",
 

--- a/data/Mega Evolution/MEP Black Star Promos/004.ts
+++ b/data/Mega Evolution/MEP Black Star Promos/004.ts
@@ -65,19 +65,28 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "I",
 
+	weaknesses: [{
+		type: "Grass",
+		value: "x2"
+	}],
+
 	variants: [
 		{
 			type: "holo",
 			stamp: ["set-logo"],
 			thirdParty: {
-				cardmarket: 851049
+				cardmarket: 851049,
+				tcgplayer: 654598
+
 			}
 		},
 		{
 			type: "holo",
 			stamp: ["set-logo","staff"],
 			thirdParty: {
-				cardmarket: 851050
+				cardmarket: 851050,
+				tcgplayer: 656825
+
 			}
 		},
 	],

--- a/data/Mega Evolution/MEP Black Star Promos/005.ts
+++ b/data/Mega Evolution/MEP Black Star Promos/005.ts
@@ -28,9 +28,10 @@ const card: Card = {
 			en: "Pull",
 			fr: "Tirer",
 			de: "Ziehen",
-			it: "Trascinamento",
-			es: "Jalar",
-			pt: "Puxar"
+			it: "Tira",
+			es: "Tirar",
+			pt: "Puxar",
+			'es-mx': "Jalar"
 		},
 
 		effect: {
@@ -46,9 +47,20 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "I",
 
+	weaknesses: [{
+		type: "Darkness",
+		value: "x2"
+	}],
+
+	resistances: [{
+		type: "Fighting",
+		value: "-30"
+	}],
+
 	variants: [
 		{
 			type: "holo",
+			foil: "cosmos",
 			thirdParty: {
 				cardmarket: 851051,
 				tcgplayer: 656255

--- a/data/Mega Evolution/MEP Black Star Promos/006.ts
+++ b/data/Mega Evolution/MEP Black Star Promos/006.ts
@@ -30,6 +30,15 @@ const card: Card = {
 	stage: "Stage1",
 	dexId: [426],
 
+	evolveFrom: {
+		en: "Drifloon",
+		fr: "Baudrive",
+		es: "Drifloon",
+		it: "Drifloon",
+		pt: "Drifloon",
+		de: "Driftlon"
+	},
+
 	attacks: [{
 		cost: ["Psychic"],
 
@@ -77,9 +86,20 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "I",
 
+	weaknesses: [{
+		type: "Darkness",
+		value: "x2"
+	}],
+
+	resistances: [{
+		type: "Fighting",
+		value: "-30"
+	}],
+
 	variants: [
 		{
 			type: "holo",
+			foil: "cosmos",
 			thirdParty: {
 				cardmarket: 851052,
 				tcgplayer: 656256

--- a/data/Mega Evolution/MEP Black Star Promos/006.ts
+++ b/data/Mega Evolution/MEP Black Star Promos/006.ts
@@ -30,15 +30,6 @@ const card: Card = {
 	stage: "Stage1",
 	dexId: [426],
 
-	evolveFrom: {
-		en: "Drifloon",
-		fr: "Baudrive",
-		es: "Drifloon",
-		it: "Drifloon",
-		pt: "Drifloon",
-		de: "Driftlon"
-	},
-
 	attacks: [{
 		cost: ["Psychic"],
 

--- a/data/Mega Evolution/MEP Black Star Promos/007.ts
+++ b/data/Mega Evolution/MEP Black Star Promos/007.ts
@@ -61,6 +61,11 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "I",
 
+	weaknesses: [{
+		type: "Lightning",
+		value: "x2"
+	}],
+
 	variants: [
 		{
 			type: "holo",

--- a/data/Mega Evolution/MEP Black Star Promos/008.ts
+++ b/data/Mega Evolution/MEP Black Star Promos/008.ts
@@ -30,6 +30,15 @@ const card: Card = {
 	stage: "Stage1",
 	dexId: [55],
 
+	evolveFrom: {
+		en: "Psyduck",
+		fr: "Psykokwak",
+		es: "Psyduck",
+		it: "Psyduck",
+		pt: "Psyduck",
+		de: "Enton"
+	},
+
 	abilities: [{
 		type: "Ability",
 
@@ -78,6 +87,11 @@ const card: Card = {
 
 	retreat: 1,
 	regulationMark: "I",
+
+	weaknesses: [{
+		type: "Lightning",
+		value: "x2"
+	}],
 
 	variants: [
 		{

--- a/data/Mega Evolution/MEP Black Star Promos/008.ts
+++ b/data/Mega Evolution/MEP Black Star Promos/008.ts
@@ -30,15 +30,6 @@ const card: Card = {
 	stage: "Stage1",
 	dexId: [55],
 
-	evolveFrom: {
-		en: "Psyduck",
-		fr: "Psykokwak",
-		es: "Psyduck",
-		it: "Psyduck",
-		pt: "Psyduck",
-		de: "Enton"
-	},
-
 	abilities: [{
 		type: "Ability",
 

--- a/data/Mega Evolution/MEP Black Star Promos/009.ts
+++ b/data/Mega Evolution/MEP Black Star Promos/009.ts
@@ -32,6 +32,16 @@ const card: Card = {
 	stage: "Stage2",
 	dexId: [65],
 
+	evolveFrom: {
+		en: "Kadabra",
+		fr: "Kadabra",
+		de: "Kadabra",
+		it: "Kadabra",
+		es: "Kadabra",
+		pt: "Kadabra",
+		'es-mx': "Kadabra"
+	},
+
 	abilities: [{
 		type: "Ability",
 
@@ -82,6 +92,16 @@ const card: Card = {
 
 	retreat: 1,
 	regulationMark: "I",
+
+	weaknesses: [{
+		type: "Darkness",
+		value: "x2"
+	}],
+
+	resistances: [{
+		type: "Fighting",
+		value: "-30"
+	}],
 
 	variants: [
 		{

--- a/data/Mega Evolution/MEP Black Star Promos/009.ts
+++ b/data/Mega Evolution/MEP Black Star Promos/009.ts
@@ -32,16 +32,6 @@ const card: Card = {
 	stage: "Stage2",
 	dexId: [65],
 
-	evolveFrom: {
-		en: "Kadabra",
-		fr: "Kadabra",
-		de: "Kadabra",
-		it: "Kadabra",
-		es: "Kadabra",
-		pt: "Kadabra",
-		'es-mx': "Kadabra"
-	},
-
 	abilities: [{
 		type: "Ability",
 

--- a/data/Mega Evolution/MEP Black Star Promos/010.ts
+++ b/data/Mega Evolution/MEP Black Star Promos/010.ts
@@ -48,6 +48,11 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "I",
 
+	weaknesses: [{
+		type: "Psychic",
+		value: "x2"
+	}],
+
 	variants: [
 		{
 			type: "holo",

--- a/data/Mega Evolution/MEP Black Star Promos/011.ts
+++ b/data/Mega Evolution/MEP Black Star Promos/011.ts
@@ -85,14 +85,11 @@ const card: Card = {
 			}
 		},
 		{
-			type: "holo",
-			size: "jumbo"
-		},
-		{
 			type: 'lenticular',
 			size: 'jumbo',
 			thirdParty: {
-				cardmarket: 851066
+				cardmarket: 851066,
+				tcgplayer: 657847
 			}
 		},
 	],

--- a/data/Mega Evolution/MEP Black Star Promos/012.ts
+++ b/data/Mega Evolution/MEP Black Star Promos/012.ts
@@ -20,6 +20,9 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 340,
 	types: ["Fighting"],
+	stage: "Stage1",
+	dexId: [448],
+
 	evolveFrom: {
 		en: "Riolu",
 		fr: "Riolu",
@@ -29,8 +32,6 @@ const card: Card = {
 		pt: "Riolu",
 		'es-mx': "Riolu"
 	},
-	stage: "Stage1",
-	dexId: [448],
 
 	attacks: [{
 		cost: ["Fighting"],
@@ -85,6 +86,11 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "I",
 
+	weaknesses: [{
+		type: "Psychic",
+		value: "x2"
+	}],
+
 	variants: [
 		{
 			type: "holo",
@@ -97,7 +103,8 @@ const card: Card = {
 			type: "holo",
 			size: "jumbo",
 			thirdParty: {
-				cardmarket: 858147
+				cardmarket: 858147,
+				tcgplayer: 663178
 			}
 		},
 	],

--- a/data/Mega Evolution/MEP Black Star Promos/013.ts
+++ b/data/Mega Evolution/MEP Black Star Promos/013.ts
@@ -20,6 +20,9 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 380,
 	types: ["Grass"],
+	stage: "Stage2",
+	dexId: [3],
+
 	evolveFrom: {
 		en: "Ivysaur",
 		fr: "Herbizarre",
@@ -29,8 +32,6 @@ const card: Card = {
 		pt: "Ivysaur",
 		'es-mx': "Ivysaur"
 	},
-	stage: "Stage2",
-	dexId: [3],
 
 	abilities: [{
 		type: "Ability",
@@ -85,6 +86,11 @@ const card: Card = {
 	retreat: 4,
 	regulationMark: "I",
 
+	weaknesses: [{
+		type: "Fire",
+		value: "x2"
+	}],
+
 	variants: [
 		{
 			type: "holo",
@@ -94,14 +100,11 @@ const card: Card = {
 			}
 		},
 		{
-			type: "holo",
-			size: "jumbo"
-		},
-		{
 			type: 'lenticular',
 			size: 'jumbo',
 			thirdParty: {
-				cardmarket: 859012
+				cardmarket: 859012,
+				tcgplayer: 668464
 			}
 		},
 	],

--- a/data/Mega Evolution/MEP Black Star Promos/014.ts
+++ b/data/Mega Evolution/MEP Black Star Promos/014.ts
@@ -14,6 +14,7 @@ const card: Card = {
 		pt: "Ceruledge"
 	},
 
+<<<<<<< HEAD
 	evolveFrom: {
 		en: "Charcadet",
 		fr: "Charbambin",
@@ -24,12 +25,26 @@ const card: Card = {
 		pt: "Charcadet",
 	},
 
+=======
+	illustrator: "Anesaki Dynamic",
+>>>>>>> 5c59079c3 (feat(data): Add missing MEP Black Star Promos and update card infos)
 	rarity: "Promo",
 	category: "Pokemon",
 	dexId: [937],
 	hp: 140,
 	types: ["Fire"],
 	stage: "Stage1",
+	dexId: [937],
+
+  evolveFrom: {
+		en: "Charcadet",
+		fr: "Charbambin",
+		es: "Charcadet",
+		'es-mx': "Charcadet",
+		de: "Knarbon",
+		it: "Charcadet",
+		pt: "Charcadet"
+  },
 
 	attacks: [{
 		cost: ["Fire"],
@@ -56,25 +71,30 @@ const card: Card = {
 
 		damage: 220
     }],
-    
-	illustrator: "Anesaki Dynamic",
 
 	retreat: 2,
     regulationMark: "I",
+
+	weaknesses: [{
+		type: "Water",
+		value: "x2"
+	}],
 
     variants: [
     	{
     		type: "holo",
     		stamp: ["set-logo"],
     		thirdParty: {
-    			cardmarket: 857390
+    			cardmarket: 857390,
+    			tcgplayer: 663187
     		}
     	},
     	{
     		type: "holo",
     		stamp: ["set-logo","staff"],
     		thirdParty: {
-    			cardmarket: 859014
+    			cardmarket: 859014,
+    			tcgplayer: 663188
     		}
     	},
     ],

--- a/data/Mega Evolution/MEP Black Star Promos/014.ts
+++ b/data/Mega Evolution/MEP Black Star Promos/014.ts
@@ -14,7 +14,6 @@ const card: Card = {
 		pt: "Ceruledge"
 	},
 
-<<<<<<< HEAD
 	evolveFrom: {
 		en: "Charcadet",
 		fr: "Charbambin",
@@ -25,26 +24,14 @@ const card: Card = {
 		pt: "Charcadet",
 	},
 
-=======
 	illustrator: "Anesaki Dynamic",
->>>>>>> 5c59079c3 (feat(data): Add missing MEP Black Star Promos and update card infos)
 	rarity: "Promo",
 	category: "Pokemon",
 	dexId: [937],
 	hp: 140,
 	types: ["Fire"],
 	stage: "Stage1",
-	dexId: [937],
 
-  evolveFrom: {
-		en: "Charcadet",
-		fr: "Charbambin",
-		es: "Charcadet",
-		'es-mx': "Charcadet",
-		de: "Knarbon",
-		it: "Charcadet",
-		pt: "Charcadet"
-  },
 
 	attacks: [{
 		cost: ["Fire"],

--- a/data/Mega Evolution/MEP Black Star Promos/015.ts
+++ b/data/Mega Evolution/MEP Black Star Promos/015.ts
@@ -14,12 +14,14 @@ const card: Card = {
 		pt: "Zacian"
 	},
 
+	illustrator: "Shiburingaru",
 	rarity: "Promo",
 	category: "Pokemon",
 	dexId: [888],
 	hp: 130,
 	types: ["Psychic"],
 	stage: "Basic",
+	dexId: [888],
 
 	attacks: [{
 		cost: ["Psychic", "Colorless"],
@@ -49,21 +51,27 @@ const card: Card = {
 
 	retreat: 2,
 	regulationMark: "I",
-	illustrator: "Shiburingaru",
+
+	weaknesses: [{
+		type: "Metal",
+		value: "x2"
+	}],
 
     variants: [
     	{
     		type: "holo",
     		stamp: ["set-logo"],
     		thirdParty: {
-    			cardmarket: 857393
+    			cardmarket: 857393,
+    			tcgplayer: 663189
     		}
     	},
     	{
     		type: "holo",
     		stamp: ["set-logo","staff"],
     		thirdParty: {
-    			cardmarket: 859015
+    			cardmarket: 859015,
+    			tcgplayer: 663190
     		}
     	},
     ],

--- a/data/Mega Evolution/MEP Black Star Promos/015.ts
+++ b/data/Mega Evolution/MEP Black Star Promos/015.ts
@@ -21,7 +21,6 @@ const card: Card = {
 	hp: 130,
 	types: ["Psychic"],
 	stage: "Basic",
-	dexId: [888],
 
 	attacks: [{
 		cost: ["Psychic", "Colorless"],

--- a/data/Mega Evolution/MEP Black Star Promos/016.ts
+++ b/data/Mega Evolution/MEP Black Star Promos/016.ts
@@ -14,6 +14,7 @@ const card: Card = {
 		pt: "Flygon"
 	},
 
+<<<<<<< HEAD
 	evolveFrom: {
 		en: "Vibrava",
 		fr: "Vibraninf",
@@ -24,12 +25,26 @@ const card: Card = {
 		pt: "Vibrava",
 	},
 
+=======
+	illustrator: "Oswaldo KATO",
+>>>>>>> 5c59079c3 (feat(data): Add missing MEP Black Star Promos and update card infos)
 	rarity: "Promo",
 	category: "Pokemon",
 	dexId: [330],
 	hp: 150,
 	types: ["Fighting"],
 	stage: "Stage2",
+	dexId: [330],
+
+	evolveFrom: {
+		en: "Vibrava",
+		fr: "Vibraninf",
+		es: "Vibrava",
+		it: "Vibrava",
+		pt: "Vibrava",
+		de: "Vibrava"
+		'es-mx': "Vibrava",
+	},
 
 	abilities: [{
 		type: "Ability",
@@ -74,21 +89,26 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "I",
 
-	illustrator: "Oswaldo KATO",
+	weaknesses: [{
+		type: "Grass",
+		value: "x2"
+	}],
 
     variants: [
     	{
     		type: "holo",
     		stamp: ["set-logo"],
     		thirdParty: {
-    			cardmarket: 857396
+    			cardmarket: 857396,
+    			tcgplayer: 663191
     		}
     	},
     	{
     		type: "holo",
     		stamp: ["set-logo","staff"],
     		thirdParty: {
-    			cardmarket: 859016
+    			cardmarket: 859016,
+    			tcgplayer: 663192
     		}
     	},
     ],

--- a/data/Mega Evolution/MEP Black Star Promos/016.ts
+++ b/data/Mega Evolution/MEP Black Star Promos/016.ts
@@ -14,23 +14,9 @@ const card: Card = {
 		pt: "Flygon"
 	},
 
-<<<<<<< HEAD
-	evolveFrom: {
-		en: "Vibrava",
-		fr: "Vibraninf",
-		es: "Vibrava",
-		'es-mx': "Vibrava",
-		de: "Vibrava",
-		it: "Vibrava",
-		pt: "Vibrava",
-	},
-
-=======
 	illustrator: "Oswaldo KATO",
->>>>>>> 5c59079c3 (feat(data): Add missing MEP Black Star Promos and update card infos)
-	rarity: "Promo",
+  	rarity: "Promo",
 	category: "Pokemon",
-	dexId: [330],
 	hp: 150,
 	types: ["Fighting"],
 	stage: "Stage2",
@@ -42,8 +28,8 @@ const card: Card = {
 		es: "Vibrava",
 		it: "Vibrava",
 		pt: "Vibrava",
-		de: "Vibrava"
-		'es-mx': "Vibrava",
+		de: "Vibrava",
+		'es-mx': "Vibrava"
 	},
 
 	abilities: [{

--- a/data/Mega Evolution/MEP Black Star Promos/017.ts
+++ b/data/Mega Evolution/MEP Black Star Promos/017.ts
@@ -21,23 +21,16 @@ const card: Card = {
 		'es-mx': "Toxel",
 		de: "Toxel",
 		it: "Toxel",
-<<<<<<< HEAD
 		pt: "Toxel",
 	},
 
-=======
-		pt: "Toxel"
-	},
-
 	illustrator: "Krgc",
->>>>>>> 5c59079c3 (feat(data): Add missing MEP Black Star Promos and update card infos)
 	rarity: "Promo",
 	category: "Pokemon",
 	dexId: [849],
 	hp: 140,
 	types: ["Darkness"],
 	stage: "Stage1",
-	dexId: [849],
 
 	abilities: [{
 		type: "Ability",

--- a/data/Mega Evolution/MEP Black Star Promos/017.ts
+++ b/data/Mega Evolution/MEP Black Star Promos/017.ts
@@ -21,15 +21,23 @@ const card: Card = {
 		'es-mx': "Toxel",
 		de: "Toxel",
 		it: "Toxel",
+<<<<<<< HEAD
 		pt: "Toxel",
 	},
 
+=======
+		pt: "Toxel"
+	},
+
+	illustrator: "Krgc",
+>>>>>>> 5c59079c3 (feat(data): Add missing MEP Black Star Promos and update card infos)
 	rarity: "Promo",
 	category: "Pokemon",
 	dexId: [849],
 	hp: 140,
 	types: ["Darkness"],
 	stage: "Stage1",
+	dexId: [849],
 
 	abilities: [{
 		type: "Ability",
@@ -74,21 +82,26 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "I",
 
-	illustrator: "Krgc",
+	weaknesses: [{
+		type: "Fighting",
+		value: "x2"
+	}],
 
     variants: [
     	{
     		type: "holo",
     		stamp: ["set-logo"],
     		thirdParty: {
-    			cardmarket: 857400
+    			cardmarket: 857400,
+    			tcgplayer: 663193
     		}
     	},
     	{
     		type: "holo",
     		stamp: ["set-logo","staff"],
     		thirdParty: {
-    			cardmarket: 859018
+    			cardmarket: 859018,
+    			tcgplayer: 663194
     		}
     	},
     ],

--- a/data/Mega Evolution/MEP Black Star Promos/018.ts
+++ b/data/Mega Evolution/MEP Black Star Promos/018.ts
@@ -46,9 +46,15 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "I",
 
+	weaknesses: [{
+		type: "Metal",
+		value: "x2"
+	}],
+
 	variants: [
 		{
 			type: "holo",
+			foil: "cosmos",
 			thirdParty: {
 				cardmarket: 859021,
 				tcgplayer: 664051

--- a/data/Mega Evolution/MEP Black Star Promos/019.ts
+++ b/data/Mega Evolution/MEP Black Star Promos/019.ts
@@ -77,9 +77,15 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "I",
 
+	weaknesses: [{
+		type: "Metal",
+		value: "x2"
+	}],
+
 	variants: [
 		{
 			type: "holo",
+			foil: "cosmos",
 			thirdParty: {
 				cardmarket: 859022,
 				tcgplayer: 664054

--- a/data/Mega Evolution/MEP Black Star Promos/020.ts
+++ b/data/Mega Evolution/MEP Black Star Promos/020.ts
@@ -52,9 +52,15 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "I",
 
+	weaknesses: [{
+		type: "Grass",
+		value: "x2"
+	}],
+
 	variants: [
 		{
 			type: "holo",
+			foil: "cosmos",
 			thirdParty: {
 				cardmarket: 859024,
 				tcgplayer: 664055

--- a/data/Mega Evolution/MEP Black Star Promos/021.ts
+++ b/data/Mega Evolution/MEP Black Star Promos/021.ts
@@ -70,9 +70,15 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "I",
 
+	weaknesses: [{
+		type: "Grass",
+		value: "x2"
+	}],
+
 	variants: [
 		{
 			type: "holo",
+			foil: "cosmos",
 			thirdParty: {
 				cardmarket: 859026,
 				tcgplayer: 664063

--- a/data/Mega Evolution/MEP Black Star Promos/022.ts
+++ b/data/Mega Evolution/MEP Black Star Promos/022.ts
@@ -59,6 +59,11 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "I",
 
+	weaknesses: [{
+		type: "Water",
+		value: "x2"
+	}],
+
 	variants: [
 		{
 			type: "holo",

--- a/data/Mega Evolution/MEP Black Star Promos/023.ts
+++ b/data/Mega Evolution/MEP Black Star Promos/023.ts
@@ -58,6 +58,11 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "I",
 
+	weaknesses: [{
+		type: "Water",
+		value: "x2"
+	}],
+
 	variants: [
 		{
 			type: "holo",

--- a/data/Mega Evolution/MEP Black Star Promos/024.ts
+++ b/data/Mega Evolution/MEP Black Star Promos/024.ts
@@ -62,6 +62,11 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "I",
 
+	weaknesses: [{
+		type: "Water",
+		value: "x2"
+	}],
+
 	variants: [
 		{
 			type: "holo",

--- a/data/Mega Evolution/MEP Black Star Promos/025.ts
+++ b/data/Mega Evolution/MEP Black Star Promos/025.ts
@@ -71,6 +71,11 @@ const card: Card = {
 	retreat: 3,
 	regulationMark: "I",
 
+	weaknesses: [{
+		type: "Fighting",
+		value: "x2"
+	}],
+
 	variants: [
 		{
 			type: "holo",
@@ -79,13 +84,14 @@ const card: Card = {
 				tcgplayer: 668509
 			}
 		},
-		{
-			type: "holo",
-			size: "jumbo",
-			thirdParty: {
-				cardmarket: 859039
-			}
-		},
+        {
+        	type: 'lenticular',
+        	size: 'jumbo',
+        	thirdParty: {
+        		cardmarket: 859039,
+        		tcgplayer: 668511
+        	}
+        },
 	],
 }
 

--- a/data/Mega Evolution/MEP Black Star Promos/026.ts
+++ b/data/Mega Evolution/MEP Black Star Promos/026.ts
@@ -59,6 +59,16 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "I",
 
+	weaknesses: [{
+		type: "Darkness",
+		value: "x2"
+	}],
+
+	resistances: [{
+		type: "Fighting",
+		value: "-30"
+	}],
+
 	variants: [
 		{
 			type: "holo",

--- a/data/Mega Evolution/MEP Black Star Promos/027.ts
+++ b/data/Mega Evolution/MEP Black Star Promos/027.ts
@@ -48,6 +48,11 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "I",
 
+	weaknesses: [{
+		type: "Fighting",
+		value: "x2"
+	}],
+
 	variants: [
 		{
 			type: "holo",

--- a/data/Mega Evolution/MEP Black Star Promos/028.ts
+++ b/data/Mega Evolution/MEP Black Star Promos/028.ts
@@ -32,6 +32,10 @@ const card: Card = {
 		{
 			type: "holo",
 			stamp: ["ace-trainer"]
+			thirdParty: {
+            	cardmarket: 850977,
+            	tcgplayer: 681244
+            }
 		},
 	],
 }

--- a/data/Mega Evolution/MEP Black Star Promos/028.ts
+++ b/data/Mega Evolution/MEP Black Star Promos/028.ts
@@ -31,7 +31,7 @@ const card: Card = {
 	variants: [
 		{
 			type: "holo",
-			stamp: ["ace-trainer"]
+			stamp: ["ace-trainer"],
 			thirdParty: {
             	cardmarket: 850977,
             	tcgplayer: 681244

--- a/data/Mega Evolution/MEP Black Star Promos/032.ts
+++ b/data/Mega Evolution/MEP Black Star Promos/032.ts
@@ -19,6 +19,9 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 360,
 	types: ["Psychic"],
+	stage: "Stage2",
+	dexId: [282],
+
 	evolveFrom: {
 		en: "Kirlia",
 		fr: "Kirlia",
@@ -27,8 +30,6 @@ const card: Card = {
 		es: "Kirlia",
 		pt: "Kirlia"
 	},
-	stage: "Stage2",
-	dexId: [282],
 
 	attacks: [{
 		cost: ["Psychic"],
@@ -80,6 +81,11 @@ const card: Card = {
 	weaknesses: [{
 		type: "Darkness",
 		value: "x2"
+	}],
+
+	resistances: [{
+		type: "Fighting",
+		value: "-30"
 	}],
 
 	variants: [

--- a/data/Mega Evolution/MEP Black Star Promos/033.ts
+++ b/data/Mega Evolution/MEP Black Star Promos/033.ts
@@ -19,6 +19,9 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 340,
 	types: ["Fighting"],
+	stage: "Stage1",
+	dexId: [448],
+
 	evolveFrom: {
 		en: "Riolu",
 		fr: "Riolu",
@@ -27,8 +30,6 @@ const card: Card = {
 		es: "Riolu",
 		pt: "Riolu"
 	},
-	stage: "Stage1",
-	dexId: [448],
 
 	attacks: [{
 		cost: ["Fighting"],

--- a/data/Mega Evolution/MEP Black Star Promos/034.ts
+++ b/data/Mega Evolution/MEP Black Star Promos/034.ts
@@ -12,14 +12,6 @@ const card: Card = {
 		it: "Mega Meganium-ex",
 		pt: "Mega Meganium ex"
 	},
-	evolveFrom: {
-		en: "Bayleef",
-		de: "Lorblatt",
-		es: "Bayleef",
-		fr: "Macronium",
-		it: "Bayleef",
-		pt: "Bayleef",
-	},
 
 	suffix: "ex",
 	illustrator: "5ban Graphics",
@@ -29,6 +21,15 @@ const card: Card = {
 	types: ["Grass"],
 	stage: "Stage2",
 	dexId: [154],
+
+	evolveFrom: {
+		en: "Bayleef",
+		de: "Lorblatt",
+		es: "Bayleef",
+		fr: "Macronium",
+		it: "Bayleef",
+		pt: "Bayleef",
+	},
 
 	attacks: [{
 		cost: ["Colorless", "Colorless", "Colorless"],
@@ -71,9 +72,13 @@ const card: Card = {
 			}
 		},
 		{
-			type: "holo",
-			size: "jumbo"
-		},
+        	type: 'lenticular',
+        	size: 'jumbo',
+        	thirdParty: {
+        		cardmarket: 873718,
+        		tcgplayer: 692115
+        	}
+        },
 	],
 }
 

--- a/data/Mega Evolution/MEP Black Star Promos/035.ts
+++ b/data/Mega Evolution/MEP Black Star Promos/035.ts
@@ -12,14 +12,6 @@ const card: Card = {
 		it: "Mega Emboar-ex",
 		pt: "Mega Emboar ex"
 	},
-	evolveFrom: {
-		en: "Pignite",
-		de: "Ferkokel",
-		es: "Pignite",
-		fr: "Grotichon",
-		it: "Pignite",
-		pt: "Pignite",
-	},
 
 	suffix: "ex",
 	illustrator: "5ban Graphics",
@@ -29,6 +21,15 @@ const card: Card = {
 	types: ["Fire"],
 	stage: "Stage2",
 	dexId: [500],
+
+	evolveFrom: {
+		en: "Pignite",
+		de: "Ferkokel",
+		es: "Pignite",
+		fr: "Grotichon",
+		it: "Pignite",
+		pt: "Pignite",
+	},
 
 	attacks: [{
 		cost: ["Fire", "Fire", "Colorless"],
@@ -71,9 +72,13 @@ const card: Card = {
 			}
 		},
 		{
-			type: "holo",
-			size: "jumbo"
-		},
+        	type: 'lenticular',
+        	size: 'jumbo',
+        	thirdParty: {
+        		cardmarket: 873720,
+        		tcgplayer: 692116
+        	}
+        },
 	],
 }
 

--- a/data/Mega Evolution/MEP Black Star Promos/036.ts
+++ b/data/Mega Evolution/MEP Black Star Promos/036.ts
@@ -12,14 +12,6 @@ const card: Card = {
 		it: "Mega Feraligatr-ex",
 		pt: "Mega Feraligatr ex"
 	},
-	evolveFrom: {
-		en: "Croconaw",
-		de: "Tyracroc",
-		es: "Croconaw",
-		fr: "Crocrodil",
-		it: "Croconaw",
-		pt: "Croconaw",
-	},
 
 	suffix: "ex",
 	illustrator: "5ban Graphics",
@@ -29,6 +21,15 @@ const card: Card = {
 	types: ["Water"],
 	stage: "Stage2",
 	dexId: [160],
+
+	evolveFrom: {
+		en: "Croconaw",
+		de: "Tyracroc",
+		es: "Croconaw",
+		fr: "Crocrodil",
+		it: "Croconaw",
+		pt: "Croconaw",
+	},
 
 	attacks: [{
 		cost: ["Water", "Water", "Colorless"],
@@ -71,9 +72,13 @@ const card: Card = {
 			}
 		},
 		{
-			type: "holo",
-			size: "jumbo"
-		},
+        	type: 'lenticular',
+        	size: 'jumbo',
+        	thirdParty: {
+        		cardmarket: 873722,
+        		tcgplayer: 692117
+        	}
+        },
 	],
 }
 

--- a/data/Mega Evolution/MEP Black Star Promos/037.ts
+++ b/data/Mega Evolution/MEP Black Star Promos/037.ts
@@ -51,7 +51,10 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "J",
 
-	
+	weaknesses: [{
+		type: "Fire",
+		value: "x2"
+	}],
 
 	variants: [
 		{

--- a/data/Mega Evolution/MEP Black Star Promos/038.ts
+++ b/data/Mega Evolution/MEP Black Star Promos/038.ts
@@ -51,7 +51,10 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "J",
 
-	
+	weaknesses: [{
+		type: "Water",
+		value: "x2"
+	}],
 
 	variants: [
 		{

--- a/data/Mega Evolution/MEP Black Star Promos/039.ts
+++ b/data/Mega Evolution/MEP Black Star Promos/039.ts
@@ -51,7 +51,10 @@ const card: Card = {
 	retreat: 2,
 	regulationMark: "J",
 
-	
+	weaknesses: [{
+		type: "Lightning",
+		value: "x2"
+	}],
 
 	variants: [
 		{

--- a/data/Mega Evolution/MEP Black Star Promos/040.ts
+++ b/data/Mega Evolution/MEP Black Star Promos/040.ts
@@ -41,7 +41,10 @@ const card: Card = {
 	retreat: 3,
 	regulationMark: "J",
 
-	
+	weaknesses: [{
+		type: "Fire",
+		value: "x2"
+	}],
 
 	variants: [
 		{

--- a/data/Mega Evolution/MEP Black Star Promos/041.ts
+++ b/data/Mega Evolution/MEP Black Star Promos/041.ts
@@ -51,7 +51,10 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "J",
 
-	
+	weaknesses: [{
+		type: "Water",
+		value: "x2"
+	}],
 
 	variants: [
 		{

--- a/data/Mega Evolution/MEP Black Star Promos/042.ts
+++ b/data/Mega Evolution/MEP Black Star Promos/042.ts
@@ -41,7 +41,10 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "J",
 
-	
+	weaknesses: [{
+		type: "Lightning",
+		value: "x2"
+	}],
 
 	variants: [
 		{

--- a/data/Mega Evolution/MEP Black Star Promos/043.ts
+++ b/data/Mega Evolution/MEP Black Star Promos/043.ts
@@ -41,7 +41,10 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "J",
 
-	
+	weaknesses: [{
+		type: "Fire",
+		value: "x2"
+	}],
 
 	variants: [
 		{

--- a/data/Mega Evolution/MEP Black Star Promos/044.ts
+++ b/data/Mega Evolution/MEP Black Star Promos/044.ts
@@ -51,7 +51,10 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "J",
 
-	
+	weaknesses: [{
+		type: "Water",
+		value: "x2"
+	}],
 
 	variants: [
 		{

--- a/data/Mega Evolution/MEP Black Star Promos/045.ts
+++ b/data/Mega Evolution/MEP Black Star Promos/045.ts
@@ -51,7 +51,10 @@ const card: Card = {
 	retreat: 1,
 	regulationMark: "J",
 
-	
+	weaknesses: [{
+		type: "Lightning",
+		value: "x2"
+	}],
 
 	variants: [
 		{

--- a/data/Mega Evolution/MEP Black Star Promos/046.ts
+++ b/data/Mega Evolution/MEP Black Star Promos/046.ts
@@ -1,0 +1,60 @@
+import { Card } from "../../../interfaces"
+import Set from "../MEP Black Star Promos"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Chikorita",
+		fr: "Germignon",
+		de: "Endivie",
+		it: "Chikorita",
+		es: "Chikorita",
+		pt: "Chikorita",
+		'es-mx': "Chikorita"
+	},
+
+	illustrator: "Saboteri",
+	rarity: "Promo",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Grass"],
+	stage: "Basic",
+	dexId: [152],
+
+	attacks: [{
+		cost: ["Grass", "Colorless"],
+
+		name: {
+			en: "Razor Leaf",
+			fr: "Tranch’Herbe",
+			de: "Rasierblatt",
+			it: "Foglielama",
+			es: "Hoja Afilada",
+			pt: "Folha Navalha",
+			'es-mx': "Hojas Navaja"
+		},
+
+		damage: 30
+	}],
+
+	retreat: 1,
+	regulationMark: "J",
+
+	weaknesses: [{
+		type: "Fire",
+		value: "x2"
+	}],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 886615,
+				tcgplayer: 699870
+			}
+		},
+	],
+}
+
+export default card

--- a/data/Mega Evolution/MEP Black Star Promos/047.ts
+++ b/data/Mega Evolution/MEP Black Star Promos/047.ts
@@ -1,0 +1,60 @@
+import { Card } from "../../../interfaces"
+import Set from "../MEP Black Star Promos"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Cyndaquil",
+		fr: "Héricendre",
+		de: "Feurigel",
+		it: "Cyndaquil",
+		es: "Cyndaquil",
+		pt: "Cyndaquil",
+		'es-mx': "Cyndaquil"
+	},
+
+	illustrator: "Saboteri",
+	rarity: "Promo",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Fire"],
+	stage: "Basic",
+	dexId: [155],
+
+	attacks: [{
+		cost: ["Fire", "Colorless", "Colorless"],
+
+		name: {
+        	en: "Tackle",
+        	fr: "Charge",
+        	de: "Tackle",
+        	it: "Azione",
+        	es: "Placaje",
+        	pt: "Investida",
+        	'es-mx': "Tacleada"
+        },
+
+		damage: 40
+	}],
+
+	retreat: 1,
+	regulationMark: "J",
+
+	weaknesses: [{
+		type: "Water",
+		value: "x2"
+	}],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 886616,
+				tcgplayer: 699871
+			}
+		},
+	],
+}
+
+export default card

--- a/data/Mega Evolution/MEP Black Star Promos/048.ts
+++ b/data/Mega Evolution/MEP Black Star Promos/048.ts
@@ -1,0 +1,59 @@
+import { Card } from "../../../interfaces"
+import Set from "../MEP Black Star Promos"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Totodile",
+		fr: "Kaiminus",
+		es: "Totodile",
+		'es-mx': "Totodile",
+		de: "Karnimani",
+		it: "Totodile",
+		pt: "Totodile"
+	},
+
+	illustrator: "Saboteri",
+	rarity: "Promo",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Water"],
+	stage: "Basic",
+	dexId: [158],
+
+	attacks: [{
+		cost: ["Water", "Water", "Colorless"],
+
+		name: {
+			en: "Bite",
+			fr: "Morsure",
+			es: "Mordisco",
+			it: "Morso",
+			pt: "Mordida",
+			de: "Biss"
+		},
+
+		damage: 50
+	}],
+
+	retreat: 2,
+	regulationMark: "J",
+
+	weaknesses: [{
+		type: "Lightning",
+		value: "x2"
+	}],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 886617,
+				tcgplayer: 699872
+			}
+		},
+	],
+}
+
+export default card

--- a/data/Mega Evolution/MEP Black Star Promos/049.ts
+++ b/data/Mega Evolution/MEP Black Star Promos/049.ts
@@ -1,0 +1,60 @@
+import { Card } from "../../../interfaces"
+import Set from "../MEP Black Star Promos"
+
+const card: Card = {
+	set: Set,
+
+name: {
+		en: "Snivy",
+		fr: "Vipélierre",
+		es: "Snivy",
+		'es-mx': "Snivy",
+		de: "Serpifeu",
+		it: "Snivy",
+		pt: "Snivy"
+	},
+
+	illustrator: "Saboteri",
+	rarity: "Promo",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Grass"],
+	stage: "Basic",
+	dexId: [495],
+
+	attacks: [{
+		cost: ["Colorless"],
+
+		name: {
+			en: "Vine Whip",
+			fr: "Fouet Lianes",
+			es: "Látigo Cepa",
+			'es-mx': "Látigo Cepa",
+			de: "Rankenhieb",
+			it: "Frustata",
+			pt: "Chicote de Vinha"
+		},
+
+		damage: 20
+	}],
+
+	retreat: 1,
+	regulationMark: "J",
+
+	weaknesses: [{
+		type: "Fire",
+		value: "x2"
+	}],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 886618,
+				tcgplayer: 699873
+			}
+		},
+	],
+}
+
+export default card

--- a/data/Mega Evolution/MEP Black Star Promos/050.ts
+++ b/data/Mega Evolution/MEP Black Star Promos/050.ts
@@ -1,0 +1,60 @@
+import { Card } from "../../../interfaces"
+import Set from "../MEP Black Star Promos"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Tepig",
+		fr: "Gruikui",
+		es: "Tepig",
+		'es-mx': "Tepig",
+		de: "Floink",
+		it: "Tepig",
+		pt: "Tepig"
+	},
+
+	illustrator: "Saboteri",
+	rarity: "Promo",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Fire"],
+	stage: "Basic",
+	dexId: [498],
+
+	attacks: [{
+		cost: ["Fire", "Fire"],
+
+		name: {
+			en: "Ember",
+			fr: "Flammèche",
+			de: "Glut",
+			it: "Braciere",
+			es: "Ascuas",
+			pt: "Brasa",
+			'es-mx': "Ascuas"
+		},
+
+		damage: 40
+	}],
+
+	retreat: 2,
+	regulationMark: "J",
+
+	weaknesses: [{
+		type: "Water",
+		value: "x2"
+	}],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 886619,
+				tcgplayer: 699874
+			}
+		},
+	],
+}
+
+export default card

--- a/data/Mega Evolution/MEP Black Star Promos/051.ts
+++ b/data/Mega Evolution/MEP Black Star Promos/051.ts
@@ -1,0 +1,67 @@
+import { Card } from "../../../interfaces"
+import Set from "../MEP Black Star Promos"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Oshawott",
+		fr: "Moustillon",
+		de: "Ottaro",
+		it: "Oshawott",
+		pt: "Oshawott",
+		es: "Oshawott",
+		'es-mx': "Oshawott"
+	},
+
+	illustrator: "Saboteri",
+	rarity: "Promo",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Water"],
+	stage: "Basic",
+	dexId: [501],
+
+	attacks: [{
+		cost: ["Water", "Colorless"],
+
+			name: {
+				en: "Razor Shell",
+				fr: "Coquilame",
+				es: "Concha Filo",
+				it: "Conchilama",
+				pt: "Concha Navalha",
+				de: "Kalkklinge"
+			},
+			effect: {
+				en: "Flip a coin. If heads, this attack does 30 more damage.",
+				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 30 dégâts supplémentaires.",
+				es: "Lanza 1 moneda. Si sale cara, este ataque hace 30 puntos de daño más.",
+				it: "Lancia una moneta. Se esce testa, questo attacco infligge 30 danni in più.",
+				pt: "Jogue uma moeda. Se sair cara, este ataque causará 30 de danos adicionais.",
+				de: "Wirf 1 Münze. Bei \"Kopf\" fügt dieser Angriff 30 weitere Schadenspunkte zu."
+			},
+
+		damage: "10+"
+	}],
+
+	retreat: 1,
+	regulationMark: "j",
+
+	weaknesses: [{
+		type: "Lightning",
+		value: "x2"
+	}],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 886620,
+				tcgplayer: 699875
+			}
+		},
+	],
+}
+
+export default card

--- a/data/Mega Evolution/MEP Black Star Promos/052.ts
+++ b/data/Mega Evolution/MEP Black Star Promos/052.ts
@@ -1,0 +1,58 @@
+import { Card } from "../../../interfaces"
+import Set from "../MEP Black Star Promos"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Grookey",
+		fr: "Ouistempo",
+		es: "Grookey",
+		it: "Grookey",
+		pt: "Grookey",
+		de: "Chimpep"
+	},
+
+	illustrator: "Saboteri",
+	rarity: "Promo",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Grass"],
+	stage: "Basic",
+	dexId: [810],
+
+	attacks: [{
+		cost: ["Grass", "Grass"],
+
+		name: {
+			fr: "Tapotige",
+			en: "Branch Poke",
+			es: "Punzada Rama",
+			it: "Ramostoccata",
+			pt: "Cutucada com Galho",
+			de: "Zweigstoß"
+		},
+
+		damage: 40
+	}],
+
+	retreat: 1,
+	regulationMark: "J",
+
+	weaknesses: [{
+		type: "Fire",
+		value: "x2"
+	}],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 886621,
+				tcgplayer: 699876
+			}
+		},
+	],
+}
+
+export default card

--- a/data/Mega Evolution/MEP Black Star Promos/053.ts
+++ b/data/Mega Evolution/MEP Black Star Promos/053.ts
@@ -1,0 +1,70 @@
+import { Card } from "../../../interfaces"
+import Set from "../MEP Black Star Promos"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Scorbunny",
+		fr: "Flambino",
+		de: "Hopplo",
+		it: "Scorbunny",
+		es: "Scorbunny",
+		pt: "Scorbunny",
+		'es-mx': "Scorbunny"
+	},
+
+	illustrator: "Saboteri",
+	rarity: "Promo",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Fire"],
+	stage: "Basic",
+	dexId: [813],
+
+	attacks: [{
+		cost: ["Fire", "Colorless"],
+
+		name: {
+			en: "Double Kick",
+			fr: "Double Pied",
+			de: "Doppelkick",
+			it: "Doppiocalcio",
+			es: "Doble Patada",
+			pt: "Chute Duplo",
+			'es-mx': "Doble Patada"
+		},
+
+		effect: {
+			en: "Flip 2 coins. This attack does 20 damage for each heads.",
+			fr: "Lancez 2 pièces. Cette attaque inflige 20 dégâts pour chaque côté face.",
+			de: "Wirf 2 Münzen. Diese Attacke fügt 20 Schadenspunkte pro Kopf zu.",
+			it: "Lancia due volte una moneta. Questo attacco infligge 20 danni ogni volta che esce testa.",
+			es: "Lanza 2 monedas. Este ataque hace 20 puntos de daño por cada cara.",
+			pt: "Jogue 2 moedas. Este ataque causa 20 pontos de dano para cada cara.",
+			'es-mx': "Lanza 2 monedas. Este ataque hace 20 puntos de daño por cada cara."
+		},
+
+		damage: "20×"
+	}],
+
+	retreat: 1,
+	regulationMark: "J",
+
+	weaknesses: [{
+		type: "Water",
+		value: "x2"
+	}],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 886622,
+				tcgplayer: 699877
+			}
+		},
+	],
+}
+
+export default card

--- a/data/Mega Evolution/MEP Black Star Promos/054.ts
+++ b/data/Mega Evolution/MEP Black Star Promos/054.ts
@@ -1,0 +1,59 @@
+import { Card } from "../../../interfaces"
+import Set from "../MEP Black Star Promos"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Sobble",
+		fr: "Larméléon",
+		de: "Memmeon",
+		it: "Sobble",
+		es: "Sobble",
+		pt: "Sobble",
+		'es-mx': "Sobble"
+	},
+
+	illustrator: "Saboteri",
+	rarity: "Promo",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Water"],
+	stage: "Basic",
+	dexId: [816],
+
+	attacks: [{
+		cost: ["Water", "Colorless", "Colorless"],
+
+		name: {
+			en: "Water Gun",
+			fr: "Pistolet à O",
+			es: "Pistola Agua",
+			it: "Pistolacqua",
+			pt: "Revólver d’Água",
+			de: "Aquaknarre"
+		},
+
+		damage: 40
+	}],
+
+	retreat: 1,
+	regulationMark: "J",
+
+	weaknesses: [{
+		type: "Lightning",
+		value: "x2"
+	}],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 886623,
+				tcgplayer: 699878
+			}
+		},
+	],
+}
+
+export default card

--- a/data/Mega Evolution/MEP Black Star Promos/055.ts
+++ b/data/Mega Evolution/MEP Black Star Promos/055.ts
@@ -1,0 +1,57 @@
+import { Card } from "../../../interfaces"
+import Set from "../MEP Black Star Promos"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Treecko",
+		fr: "Arcko",
+		es: "Treecko",
+		it: "Treecko",
+		pt: "Treecko",
+		de: "Geckarbor"
+	},
+
+	illustrator: "Saboteri",
+	rarity: "Promo",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Grass"],
+	stage: "Basic",
+	dexId: [252],
+
+	attacks: [{
+		cost: ["Grass"],
+
+		name: {
+			en: "Pound",
+			fr: "Écras’Face",
+			es: "Destructor",
+			it: "Botta",
+			pt: "Pancada",
+			de: "Pfund"
+		},
+
+		damage: 20
+	}],
+
+	retreat: 1,
+	regulationMark: "J",
+
+	weaknesses: [{
+		type: "Fire",
+		value: "x2"
+	}],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 891870
+			}
+		},
+	],
+}
+
+export default card

--- a/data/Mega Evolution/MEP Black Star Promos/056.ts
+++ b/data/Mega Evolution/MEP Black Star Promos/056.ts
@@ -1,0 +1,59 @@
+import { Card } from "../../../interfaces"
+import Set from "../MEP Black Star Promos"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Torchic",
+		fr: "Poussifeu",
+		de: "Flemmli",
+		it: "Torchic",
+		es: "Torchic",
+		pt: "Torchic",
+		'es-mx': "Torchic"
+	},
+
+	illustrator: "Saboteri",
+	rarity: "Promo",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Fire"],
+	stage: "Basic",
+	dexId: [255],
+
+	attacks: [{
+		cost: ["Colorless"],
+
+		name: {
+			en: "Peck",
+			fr: "Picpic",
+			de: "Pikser",
+			it: "Beccata",
+			es: "Picotazo",
+			pt: "Bicada",
+			'es-mx': "Picotazo"
+		},
+
+		damage: 20
+	}],
+
+	retreat: 1,
+	regulationMark: "J",
+
+	weaknesses: [{
+		type: "Water",
+		value: "x2"
+	}],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 891880
+			}
+		},
+	],
+}
+
+export default card

--- a/data/Mega Evolution/MEP Black Star Promos/057.ts
+++ b/data/Mega Evolution/MEP Black Star Promos/057.ts
@@ -1,0 +1,57 @@
+import { Card } from "../../../interfaces"
+import Set from "../MEP Black Star Promos"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Mudkip",
+		fr: "Gobou",
+		es: "Mudkip",
+		it: "Mudkip",
+		pt: "Mudkip",
+		de: "Hydropi"
+	},
+
+	illustrator: "Saboteri",
+	rarity: "Promo",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Water"],
+	stage: "Basic",
+	dexId: [258],
+
+	attacks: [{
+		cost: ["Water", "Water"],
+
+		name: {
+			en: "Mud-Slap",
+			fr: "Coud'Boue",
+			es: "Bofetón Lodo",
+			it: "Fangosberla",
+			pt: "Tapa de Lama",
+			de: "Lehmschelle"
+		},
+
+		damage: 40
+	}],
+
+	retreat: 1,
+	regulationMark: "J",
+
+	weaknesses: [{
+		type: "Lightning",
+		value: "x2"
+	}],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 891888
+			}
+		},
+	],
+}
+
+export default card

--- a/data/Mega Evolution/MEP Black Star Promos/058.ts
+++ b/data/Mega Evolution/MEP Black Star Promos/058.ts
@@ -1,0 +1,67 @@
+import { Card } from "../../../interfaces"
+import Set from "../MEP Black Star Promos"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Chespin",
+		fr: "Marisson",
+		es: "Chespin",
+		'es-mx': "Chespin",
+		de: "Igamaro",
+		it: "Chespin",
+		pt: "Chespin"
+	},
+
+	illustrator: "Saboteri",
+	rarity: "Promo",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Grass"],
+	stage: "Basic",
+	dexId: [650],
+
+	attacks: [{
+		cost: ["Grass", "Colorless"],
+
+		name: {
+			en: "Pin Missile",
+			fr: "Dard-Nuée",
+			es: "Pin Misil",
+			it: "Missilspillo",
+			pt: "Pin Missile",
+			de: "Nadelrakete"
+		},
+
+		effect: {
+			en: "Flip 4 coins. This attack does 10 damage for each heads.",
+			fr: "Lancez 4 pièces. Cette attaque inflige 10 dégâts pour chaque côté face.",
+			es: "Lanza 4 monedas. Este ataque hace 10 puntos de daño por cada cara.",
+			it: "Lancia quattro volte una moneta. Questo attacco infligge 10 danni ogni volta che esce testa.",
+			pt: "Flip 4 coins. This attack does 10 damage for each heads.",
+			de: "Wirf 4 Münzen. Diese Attacke fügt 10 Schadenspunkte pro Kopf zu."
+		},
+
+		damage: "10×",
+	}],
+
+	retreat: 2,
+	regulationMark: "J",
+
+	weaknesses: [{
+		type: "Fire",
+		value: "x2"
+	}],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 891889
+			}
+		},
+	],
+}
+
+export default card

--- a/data/Mega Evolution/MEP Black Star Promos/059.ts
+++ b/data/Mega Evolution/MEP Black Star Promos/059.ts
@@ -1,0 +1,58 @@
+import { Card } from "../../../interfaces"
+import Set from "../MEP Black Star Promos"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Fennekin",
+		fr: "Feunnec",
+		es: "Fennekin",
+		'es-mx': "Fennekin",
+		de: "Fynx",
+		it: "Fennekin",
+		pt: "Fennekin"
+	},
+
+	illustrator: "Saboteri",
+	rarity: "Promo",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Fire"],
+	stage: "Basic",
+	dexId: [653],
+
+	attacks: [{
+		cost: ["Fire", "Colorless"],
+
+		name: {
+			en: "Scratch",
+			fr: "Griffe",
+			de: "Kratzer",
+			it: "Graffio",
+			es: "Arañazo",
+			pt: "Arranhão"
+		},
+
+		damage: 30
+	}],
+
+	retreat: 1,
+	regulationMark: "J",
+
+	weaknesses: [{
+		type: "Water",
+		value: "x2"
+	}],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 891890
+			}
+		},
+	],
+}
+
+export default card

--- a/data/Mega Evolution/MEP Black Star Promos/060.ts
+++ b/data/Mega Evolution/MEP Black Star Promos/060.ts
@@ -1,0 +1,57 @@
+import { Card } from "../../../interfaces"
+import Set from "../MEP Black Star Promos"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Froakie",
+		fr: "Grenousse",
+		es: "Froakie",
+		it: "Froakie",
+		pt: "Froakie",
+		de: "Froxy"
+	},
+
+	illustrator: "Saboteri",
+	rarity: "Promo",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Water"],
+	stage: "Basic",
+	dexId: [656],
+
+	attacks: [{
+		cost: ["Colorless", "Colorless"],
+
+		name: {
+			en: "Pound",
+			fr: "Écras’Face",
+			es: "Destructor",
+			it: "Botta",
+			pt: "Pancada",
+			de: "Pfund"
+		},
+
+		damage: 20
+	}],
+
+	retreat: 1,
+	regulationMark: "J",
+
+	weaknesses: [{
+		type: "Lightning",
+		value: "x2"
+	}],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 891891
+			}
+		},
+	],
+}
+
+export default card

--- a/data/Mega Evolution/MEP Black Star Promos/061.ts
+++ b/data/Mega Evolution/MEP Black Star Promos/061.ts
@@ -1,0 +1,59 @@
+import { Card } from "../../../interfaces"
+import Set from "../MEP Black Star Promos"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Sprigatito",
+		fr: "Poussacha",
+		es: "Sprigatito",
+		de: "Felori",
+		it: "Sprigatito",
+		pt: "Sprigatito",
+		'es-mx': "Sprigatito"
+	},
+
+	illustrator: "Saboteri",
+	rarity: "Promo",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Grass"],
+	stage: "Basic",
+	dexId: [906],
+
+	attacks: [{
+		cost: ["Grass", "Colorless", "Colorless"],
+
+		name: {
+			en: "Leafage",
+			fr: "Feuillage",
+			es: "Follaje",
+			it: "Fogliame",
+			pt: "Folhagem",
+			de: "Blattwerk"
+		},
+
+
+		damage: 40
+	}],
+
+	retreat: 1,
+	regulationMark: "J",
+
+	weaknesses: [{
+		type: "Fire",
+		value: "x2"
+	}],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 891892
+			}
+		},
+	],
+}
+
+export default card

--- a/data/Mega Evolution/MEP Black Star Promos/062.ts
+++ b/data/Mega Evolution/MEP Black Star Promos/062.ts
@@ -1,0 +1,68 @@
+import { Card } from "../../../interfaces"
+import Set from "../MEP Black Star Promos"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		fr: "Chochodile",
+		en: "Fuecoco",
+		es: "Fuecoco",
+		it: "Fuecoco",
+		pt: "Fuecoco",
+		de: "Krokel"
+	},
+
+	illustrator: "Saboteri",
+	rarity: "Promo",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Fire"],
+	stage: "Basic",
+	dexId: [909],
+
+	attacks: [{
+		cost: ["Fire", "Fire", "Colorless"],
+
+		name: {
+			en: "Flamethrower",
+			fr: "Lance-Flammes",
+			es: "Lanzallamas",
+			'es-mx': "Lanzallamas",
+			de: "Flammenwurf",
+			it: "Lanciafiamme",
+			pt: "Lança-chamas"
+		},
+
+		effect: {
+			en: "Discard an Energy from this Pokémon.",
+			fr: "Défaussez une Énergie de ce Pokémon.",
+			es: "Descarta 1 Energía de este Pokémon.",
+			'es-mx': "Descarta 1 Energía de este Pokémon.",
+			de: "Lege 1 Energie von diesem Pokémon auf deinen Ablagestapel.",
+			it: "Scarta un'Energia da questo Pokémon.",
+			pt: "Descarte uma Energia deste Pokémon."
+		},
+
+		damage: 70
+	}],
+
+	retreat: 3,
+	regulationMark: "J",
+
+	weaknesses: [{
+		type: "Water",
+		value: "x2"
+	}],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 891893
+			}
+		},
+	],
+}
+
+export default card

--- a/data/Mega Evolution/MEP Black Star Promos/063.ts
+++ b/data/Mega Evolution/MEP Black Star Promos/063.ts
@@ -1,0 +1,58 @@
+import { Card } from "../../../interfaces"
+import Set from "../MEP Black Star Promos"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Quaxly",
+		fr: "Coiffeton",
+		es: "Quaxly",
+		it: "Quaxly",
+		pt: "Quaxly",
+		de: "Kwaks"
+	},
+
+	illustrator: "Saboteri",
+	rarity: "Promo",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Water"],
+	stage: "Basic",
+	dexId: [912],
+
+	attacks: [{
+		cost: ["Water", "Colorless"],
+
+		name: {
+			en: "Wing Attack",
+			fr: "Cru-Ailes",
+			de: "Flügelschlag",
+			it: "Attacco d'Ala",
+			es: "Ataque Ala",
+			pt: "Ataque de Asa",
+			'es-mx': "Ataque de Ala"
+		},
+
+		damage: 30
+	}],
+
+	retreat: 1,
+	regulationMark: "J",
+
+	weaknesses: [{
+		type: "Lightning",
+		value: "x2"
+	}],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 891894
+			}
+		},
+	],
+}
+
+export default card

--- a/data/Mega Evolution/MEP Black Star Promos/064.ts
+++ b/data/Mega Evolution/MEP Black Star Promos/064.ts
@@ -98,14 +98,16 @@ const card: Card = {
 			type: 'holo',
 			stamp: ['set-logo'],
 			thirdParty: {
-				cardmarket: 877543
+				cardmarket: 877543,
+				tcgplayer: 685494
 			}
 		},
 		{
 			type: 'holo',
 			stamp: ['set-logo', 'staff'],
 			thirdParty: {
-				cardmarket: 879303
+				cardmarket: 879303,
+				tcgplayer: 685498
 			}
 		},
 	],

--- a/data/Mega Evolution/MEP Black Star Promos/065.ts
+++ b/data/Mega Evolution/MEP Black Star Promos/065.ts
@@ -82,23 +82,19 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "holo",
-			thirdParty: {
-				tcgplayer: 685495
-			}
-		},
-		{
 			type: 'holo',
 			stamp: ['set-logo'],
 			thirdParty: {
-				cardmarket: 877544
+				cardmarket: 877544,
+				tcgplayer: 685495
 			}
 		},
 		{
 			type: 'holo',
 			stamp: ['set-logo', 'staff'],
 			thirdParty: {
-				cardmarket: 879305
+				cardmarket: 879305,
+				tcgplayer: 685499
 			}
 		},
 	],

--- a/data/Mega Evolution/MEP Black Star Promos/066.ts
+++ b/data/Mega Evolution/MEP Black Star Promos/066.ts
@@ -92,23 +92,19 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "holo",
-			thirdParty: {
-				tcgplayer: 685496
-			}
-		},
-		{
 			type: 'holo',
 			stamp: ['set-logo'],
 			thirdParty: {
-				cardmarket: 877545
+				cardmarket: 877545,
+				tcgplayer: 685496
 			}
 		},
 		{
 			type: 'holo',
 			stamp: ['set-logo', 'staff'],
 			thirdParty: {
-				cardmarket: 879315
+				cardmarket: 879315,
+				tcgplayer: 685500
 			}
 		},
 	],

--- a/data/Mega Evolution/MEP Black Star Promos/067.ts
+++ b/data/Mega Evolution/MEP Black Star Promos/067.ts
@@ -73,20 +73,19 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "holo"
-		},
-		{
 			type: 'holo',
 			stamp: ['set-logo'],
 			thirdParty: {
-				cardmarket: 877546
+				cardmarket: 877546,
+				tcgplayer: 685497
 			}
 		},
 		{
 			type: 'holo',
 			stamp: ['set-logo', 'staff'],
 			thirdParty: {
-				cardmarket: 879312
+				cardmarket: 879312,
+				tcgplayer: 685501
 			}
 		},
 	],

--- a/data/Mega Evolution/MEP Black Star Promos/068.ts
+++ b/data/Mega Evolution/MEP Black Star Promos/068.ts
@@ -63,6 +63,7 @@ const card: Card = {
 	variants: [
 		{
 			type: "holo",
+			foil: "cosmos",
 			thirdParty: {
 				cardmarket: 879250,
 				tcgplayer: 686275

--- a/data/Mega Evolution/MEP Black Star Promos/069.ts
+++ b/data/Mega Evolution/MEP Black Star Promos/069.ts
@@ -49,6 +49,7 @@ const card: Card = {
 	variants: [
 		{
 			type: "holo",
+			foil: "cosmos",
 			thirdParty: {
 				cardmarket: 879255,
 				tcgplayer: 686342

--- a/data/Mega Evolution/MEP Black Star Promos/071.ts
+++ b/data/Mega Evolution/MEP Black Star Promos/071.ts
@@ -14,13 +14,13 @@ const card: Card = {
 		pt: "Mega Zygarde ex"
 	},
 
+	suffix: "ex",
 	illustrator: "takuyoa",
 	rarity: "Promo",
 	category: "Pokemon",
 	hp: 310,
 	types: ["Fighting"],
 	stage: "Basic",
-	suffix: "ex",
 	dexId: [718],
 
 	attacks: [{
@@ -81,9 +81,21 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "holo"
-		}
-	]
+			type: "holo",
+			thirdParty: {
+				cardmarket: 873310,
+				tcgplayer: 695311
+			}
+		},
+        {
+        	type: 'lenticular',
+        	size: 'jumbo',
+        	thirdParty: {
+        		cardmarket: 873311,
+        		tcgplayer: 696460
+        	}
+        },
+	],
 }
 
 export default card

--- a/data/Mega Evolution/MEP Black Star Promos/072.ts
+++ b/data/Mega Evolution/MEP Black Star Promos/072.ts
@@ -1,0 +1,103 @@
+import { Card } from "../../../interfaces"
+import Set from "../MEP Black Star Promos"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Mega Clefable ex",
+		fr: "Méga-Mélodelfe-ex",
+		es: "Mega-Clefable ex",
+		'es-mx': "Mega-Clefable ex",
+		de: "Mega-Pixi-ex",
+		it: "Mega Clefable-ex",
+		pt: "Mega Clefable ex"
+	},
+
+	suffix: "ex",
+	illustrator: "aky CG Works",
+	rarity: "Promo",
+	category: "Pokemon",
+	hp: 320,
+	types: ["Psychic"],
+	stage: "Stage1",
+	dexId: [36],
+
+	evolveFrom: {
+		en: "Clefairy",
+		de: "Piepi",
+		es: "Clefairy",
+		fr: "Mélofée",
+		it: "Clefairy",
+		pt: "Clefairy",
+	},
+
+	abilities: [{
+		type: "Ability",
+
+		name: {
+			en: "Luminous Wing",
+			fr: "Aile Luminescente",
+			es: "Ala Luminosa",
+			'es-mx': "Ala Luminosa",
+			de: "Luminöse Flügel",
+			it: "Ala Luminosa",
+			pt: "Asa Luminosa"
+		},
+
+		effect: {
+			en: "Prevent all effects of your opponent's Pokémon's Abilities done to this Pokémon.",
+			fr: "Évitez tous les effets des talents des Pokémon de votre adversaire infligés à ce Pokémon.",
+			es: "Se evitan todos los efectos de las habilidades de los Pokémon de tu rival infligidos a este Pokémon.",
+			'es-mx': "Se evitan todos los efectos de las Habilidades de los Pokémon de tu rival infligidos a este Pokémon.",
+			de: "Verhindere alle Effekte von Fähigkeiten der Pokémon deines Gegners, die diesem Pokémon zugefügt werden.",
+			it: "Previeni tutti gli effetti delle abilità dei Pokémon del tuo avversario inflitti a questo Pokémon.",
+			pt: "Previna todos os efeitos das Habilidades dos Pokémon do seu oponente causados a este Pokémon."
+		}
+
+	attacks: [{
+		cost: ["Psychic", "Psychic"],
+
+		name: {
+			en: "Shooting Moons",
+			fr: "Tirs de Lunes",
+			es: "Disparo Lunar",
+			'es-mx': "Disparo Lunar",
+			de: "Mondschnuppen",
+			it: "Lune Cadenti",
+			pt: "Luas Cadentes"
+		},
+
+		effect: {
+			en: "You may discard up to 4 Energy cards from your hand, and this attack does 40 more damage for each card you discarded in this way.",
+			fr: "Vous pouvez défausser jusqu'à 4 cartes Énergie de votre main. Cette attaque inflige 40 dégâts supplémentaires pour chaque carte défaussée de cette façon.",
+			es: "Puedes descartar hasta 4 cartas de Energía de tu mano, y este ataque hace 40 puntos de daño más por cada carta que hayas descartado de esta manera.",
+			'es-mx': "Puedes descartar hasta 4 cartas de Energía de tu mano, y este ataque hace 40 puntos de daño más por cada carta que descartaste de esta manera.",
+			de: "Du kannst bis zu 4 Energiekarten aus deiner Hand auf deinen Ablagestapel legen, und diese Attacke fügt für jede auf diese Weise abgelegte Karte 40 Schadenspunkte mehr zu.",
+			it: "Puoi scartare fino a quattro carte Energia dalla tua mano e questo attacco infligge 40 danni in più per ogni carta che hai scartato in questo modo.",
+			pt: "Você pode descartar até 4 cartas de Energia da sua mão, e este ataque causa 40 pontos de dano a mais para cada carta descartada desta forma."
+		},
+
+		damage: "120+"
+	}],
+
+	retreat: 1,
+	regulationMark: "J",
+
+	weaknesses: [{
+		type: "Metal",
+		value: "x2"
+	}],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 891720,
+				tcgplayer: 696607
+			}
+		},
+	],
+}
+
+export default card

--- a/data/Mega Evolution/MEP Black Star Promos/072.ts
+++ b/data/Mega Evolution/MEP Black Star Promos/072.ts
@@ -54,6 +54,7 @@ const card: Card = {
 			it: "Previeni tutti gli effetti delle abilità dei Pokémon del tuo avversario inflitti a questo Pokémon.",
 			pt: "Previna todos os efeitos das Habilidades dos Pokémon do seu oponente causados a este Pokémon."
 		}
+	}],
 
 	attacks: [{
 		cost: ["Psychic", "Psychic"],

--- a/data/Mega Evolution/MEP Black Star Promos/073.ts
+++ b/data/Mega Evolution/MEP Black Star Promos/073.ts
@@ -1,0 +1,105 @@
+import { Card } from "../../../interfaces"
+import Set from "../MEP Black Star Promos"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Mega Gengar ex",
+		fr: "Méga-Ectoplasma-ex",
+		es: "Mega-Gengar ex",
+		'es-mx': "Mega-Gengar ex",
+		de: "Mega-Gengar-ex",
+		it: "Mega Gengar-ex",
+		pt: "Mega Gengar ex"
+	},
+
+	suffix: "ex",
+	illustrator: "Ultimateinudog",
+	rarity: "Promo",
+	category: "Pokemon",
+	hp: 350,
+	types: ["Darkness"],
+	stage: "Stage2",
+	dexId: [94],
+
+	evolveFrom: {
+		en: "Haunter",
+		de: "Alpollo",
+		es: "Haunter",
+		'es-mx': "Haunter",
+		fr: "Spectrum",
+		it: "Haunter",
+		pt: "Haunter",
+	},
+
+	abilities: [{
+		type: "Ability",
+
+		name: {
+			en: "Shadowy Concealment",
+			fr: "Dissimulation Obscure",
+			es: "Ocultación Sombría",
+			'es-mx': "Ocultamiento Sombrío",
+			de: "Schattenlist",
+			it: "Occultamento Oscuro",
+			pt: "Ocultação Sombria"
+		},
+
+		effect: {
+			en: "If 1 of your {D} Pokémon is Knocked Out by damage from an attack from your opponent's Pokémon ex, that player takes 1 fewer Prize card. The effect of Shadowy Concealment doesn't stack.",
+			fr: "Si l'un de vos Pokémon {D} est mis K.O. par les dégâts d'une attaque de l'un des Pokémon-ex de votre adversaire, cette personne récupère une carte Récompense de moins. L'effet de Dissimulation Obscure n'est pas cumulable.",
+			es: "Si uno de tus Pokémon {D} queda Fuera de Combate por el daño de un ataque de los Pokémon ex de tu rival, ese jugador coge 1 carta de Premio menos. El efecto de Ocultación Sombría no se acumula.",
+			'es-mx': "Si 1 de tus Pokémon {D} queda Fuera de Combate por el daño de un ataque de los Pokémon ex de tu rival, ese jugador toma 1 carta de Premio menos. El efecto de Ocultamiento Sombrío no se acumula.",
+			de: "Wenn 1 deiner {D}-Pokémon durch Schaden einer Attacke von Pokémon-ex deines Gegners kampfunfähig wird, nimmt jener Spieler 1 Preiskarte weniger. Der Effekt von Schattenlist stapelt sich nicht.",
+			it: "Se uno dei tuoi Pokémon {D} viene messo KO dai danni inflitti da un attacco di un Pokémon-ex del tuo avversario, quel giocatore prende una carta Premio in meno. L'effetto di Occultamento Oscuro non è cumulabile.",
+			pt: "Se 1 dos seus Pokémon {D} for Nocauteado pelo dano de um ataque dos Pokémon ex do seu oponente, aquele jogador pegará 1 carta de Prêmio a menos. O efeito de Ocultação Sombria não acumula."
+		}
+	}],
+
+	attacks: [{
+		cost: ["Darkness", "Darkness"],
+
+		name: {
+			en: "Void Gale",
+			fr: "Bourrasque du Néant",
+			es: "Vendaval Vacuo",
+			'es-mx': "Ráfaga Abismal",
+			de: "Sturm der Leere",
+			it: "Raffica Vacua",
+			pt: "Vendaval Abissal"
+		},
+
+		effect: {
+			en: "Move an Energy from this Pokémon to 1 of your Benched Pokémon.",
+			fr: "Déplacez une Énergie de ce Pokémon vers l'un de vos Pokémon de Banc.",
+			es: "Mueve 1 Energía de este Pokémon a uno de tus Pokémon en Banca.",
+			'es-mx': "Mueve 1 Energía de este Pokémon a 1 de tus Pokémon en Banca.",
+			de: "Verschiebe 1 Energie von diesem Pokémon auf 1 Pokémon auf deiner Bank.",
+			it: "Sposta un'Energia da questo Pokémon a uno di quelli nella tua panchina.",
+			pt: "Mova uma Energia deste Pokémon para 1 dos seus Pokémon no Banco."
+		},
+
+		damage: 230
+	}],
+
+	retreat: 2,
+	regulationMark: "I",
+
+	weaknesses: [{
+		type: "Fighting",
+		value: "x2"
+	}],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 891721,
+				tcgplayer: 696608
+			}
+		},
+	],
+}
+
+export default card

--- a/data/Mega Evolution/MEP Black Star Promos/074.ts
+++ b/data/Mega Evolution/MEP Black Star Promos/074.ts
@@ -92,9 +92,24 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "holo"
-		}
-	]
+			type: "holo",
+			stamp: ["set-logo"],
+			thirdParty: {
+				cardmarket: 884752,
+				tcgplayer: 694679
+
+			}
+		},
+		{
+			type: "holo",
+			stamp: ["set-logo","staff"],
+			thirdParty: {
+				cardmarket: 884753,
+				tcgplayer: 694680
+
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Mega Evolution/MEP Black Star Promos/075.ts
+++ b/data/Mega Evolution/MEP Black Star Promos/075.ts
@@ -92,9 +92,24 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "holo"
-		}
-	]
+			type: "holo",
+			stamp: ["set-logo"],
+			thirdParty: {
+				cardmarket: 884754,
+				tcgplayer: 694681
+
+			}
+		},
+		{
+			type: "holo",
+			stamp: ["set-logo","staff"],
+			thirdParty: {
+				cardmarket: 884755,
+				tcgplayer: 694682
+
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Mega Evolution/MEP Black Star Promos/076.ts
+++ b/data/Mega Evolution/MEP Black Star Promos/076.ts
@@ -97,9 +97,24 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "holo"
-		}
-	]
+			type: "holo",
+			stamp: ["set-logo"],
+			thirdParty: {
+				cardmarket: 884756,
+				tcgplayer: 694686
+
+			}
+		},
+		{
+			type: "holo",
+			stamp: ["set-logo","staff"],
+			thirdParty: {
+				cardmarket: 884757,
+				tcgplayer: 694687
+
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Mega Evolution/MEP Black Star Promos/077.ts
+++ b/data/Mega Evolution/MEP Black Star Promos/077.ts
@@ -87,9 +87,24 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "holo"
-		}
-	]
+			type: "holo",
+			stamp: ["set-logo"],
+			thirdParty: {
+				cardmarket: 884758,
+				tcgplayer: 694688
+
+			}
+		},
+		{
+			type: "holo",
+			stamp: ["set-logo","staff"],
+			thirdParty: {
+				cardmarket: 884759,
+				tcgplayer: 694689
+
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Mega Evolution/MEP Black Star Promos/078.ts
+++ b/data/Mega Evolution/MEP Black Star Promos/078.ts
@@ -70,9 +70,14 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "holo"
-		}
-	]
+			type: "holo",
+			foil: "cosmos",
+			thirdParty: {
+				cardmarket: 888609,
+				tcgplayer: 694692
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Mega Evolution/MEP Black Star Promos/079.ts
+++ b/data/Mega Evolution/MEP Black Star Promos/079.ts
@@ -58,9 +58,14 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "holo"
-		}
-	]
+			type: "holo",
+			foil: "cosmos",
+			thirdParty: {
+				cardmarket: 888607,
+				tcgplayer: 694693
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Mega Evolution/MEP Black Star Promos/080.ts
+++ b/data/Mega Evolution/MEP Black Star Promos/080.ts
@@ -70,9 +70,21 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "holo"
-		}
-	]
+			type: "holo",
+			thirdParty: {
+				cardmarket: 888506,
+				tcgplayer: 694694
+			}
+		},
+		{
+			type: "holo",
+			stamp: ["pokemon-center"],
+			thirdParty: {
+				cardmarket: 889722,
+				tcgplayer: 694695
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Mega Evolution/MEP Black Star Promos/081.ts
+++ b/data/Mega Evolution/MEP Black Star Promos/081.ts
@@ -1,0 +1,113 @@
+import { Card } from "../../../interfaces"
+import Set from "../MEP Black Star Promos"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Mega Greninja ex",
+		fr: "Méga-Amphinobi-ex",
+		es: "Mega-Greninja ex",
+		'es-mx': "Mega-Greninja ex",
+		de: "Mega-Quajutsu-ex",
+		it: "Mega Greninja-ex",
+		pt: "Mega Greninja ex"
+	},
+
+	suffix: "ex",
+	illustrator: "5ban Graphics",
+	rarity: "Promo",
+	category: "Pokemon",
+	hp: 350,
+	types: ["Water"],
+	stage: "Stage2",
+	dexId: [658],
+
+	evolveFrom: {
+		en: "Frogadier",
+		fr: "Croâporal",
+		es: "Frogadier",
+		'es-mx': "Frogadier",
+		de: "Amphizel",
+		it: "Frogadier",
+		pt: "Frogadier"
+	},
+
+	abilities: [{
+		type: "Ability",
+
+		name: {
+			en: "Mortal Shuriken",
+			fr: "Shuriken Mortel",
+			es: "Shuriken Mortal",
+			'es-mx': "Shuriken Mortal",
+			de: "Fatale Shuriken",
+			it: "Lame Letali",
+			pt: "Estrela Ninja Mortal"
+		},
+
+		effect: {
+			en: "Once during your turn, if this Pokémon is in the Active Spot, you may discard a Basic {W} Energy card from your hand in order to use this Ability. Place 6 damage counters on 1 of your opponent's Pokémon.",
+			fr: "Une fois pendant votre tour, si ce Pokémon est sur le Poste Actif, vous pouvez défausser une carte Énergie {W} de base de votre main pour utiliser ce talent. Placez 6 marqueurs de dégâts sur l'un des Pokémon de votre adversaire.",
+			es: "Una vez durante tu turno, si este Pokémon está en el Puesto Activo, puedes descartar 1 carta de Energía {W} Básica de tu mano para poder usar esta habilidad. Pon 6 contadores de daño en uno de los Pokémon de tu rival.",
+			'es-mx': "Una vez durante tu turno, si este Pokémon está en el Puesto Activo, puedes descartar 1 carta de Energía {W} Básica de tu mano para usar esta Habilidad. Pon 6 contadores de daño en 1 de los Pokémon de tu rival.",
+			de: "Einmal während deines Zuges, wenn dieses Pokémon in der Aktiven Position ist, kannst du 1 Basis-{W}-Energiekarte aus deiner Hand auf deinen Ablagestapel legen, um diese Fähigkeit einzusetzen. Lege 6 Schadensmarken auf 1 Pokémon deines Gegners.",
+			it: "Una sola volta durante il tuo turno, se questo Pokémon è in posizione attiva, puoi scartare una carta Energia base {W} che hai in mano per usare questa abilità. Metti sei segnalini danno su uno dei Pokémon del tuo avversario.",
+			pt: "Uma vez durante o seu turno, se este Pokémon estiver no Campo Ativo, você poderá descartar uma carta de Energia {W} Básica da sua mão para usar esta Habilidade. Coloque 6 contadores de dano em 1 dos Pokémon do seu oponente."
+		}
+	}],
+
+	attacks: [{
+		cost: ["Water", "Water"],
+
+		name: {
+			en: "Ninja Spinner",
+			fr: "Hélice Ninja",
+			es: "Pirueta Ninja",
+			'es-mx': "Vórtice Ninja",
+			de: "Ninja-Dreher",
+			it: "Vortice Ninja",
+			pt: "Giro Ninja"
+		},
+
+		effect: {
+			en: "You may put a {W} Energy attached to this Pokémon into your hand and have this attack do 80 more damage.",
+			fr: "Vous pouvez ajouter à votre main une Énergie {W} attachée à ce Pokémon et infliger 80 dégâts supplémentaires avec cette attaque.",
+			es: "Puedes poner 1 Energía {W} unida a este Pokémon en tu mano y hacer que este ataque haga 80 puntos de daño más.",
+			'es-mx': "Puedes poner 1 Energía {W} unida a este Pokémon en tu mano y hacer que este ataque haga 80 puntos de daño más.",
+			de: "Du kannst 1 an dieses Pokémon angelegte {W}-Energie auf deine Hand nehmen und diese Attacke 80 Schadenspunkte mehr zufügen lassen.",
+			it: "Puoi prendere un'Energia {W} assegnata a questo Pokémon, aggiungerla alle carte che hai in mano e infliggere 80 danni in più con questo attacco.",
+			pt: "Você pode colocar uma Energia {W} ligada a este Pokémon na sua mão e fazer este ataque causar 80 pontos de dano a mais."
+		}
+
+		damage: "120+"
+	}],
+
+	retreat: 1,
+	regulationMark: "J",
+
+	weaknesses: [{
+		type: "Lightning",
+		value: "x2"
+	}],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 885516,
+				tcgplayer: 704879
+			}
+		},
+        {
+        	type: 'lenticular',
+        	size: 'jumbo',
+        	thirdParty: {
+        		cardmarket: 885517,
+        		tcgplayer: 704880
+        	}
+        },
+	],
+}
+
+export default card

--- a/data/Mega Evolution/MEP Black Star Promos/081.ts
+++ b/data/Mega Evolution/MEP Black Star Promos/081.ts
@@ -78,7 +78,7 @@ const card: Card = {
 			de: "Du kannst 1 an dieses Pokémon angelegte {W}-Energie auf deine Hand nehmen und diese Attacke 80 Schadenspunkte mehr zufügen lassen.",
 			it: "Puoi prendere un'Energia {W} assegnata a questo Pokémon, aggiungerla alle carte che hai in mano e infliggere 80 danni in più con questo attacco.",
 			pt: "Você pode colocar uma Energia {W} ligada a este Pokémon na sua mão e fazer este ataque causar 80 pontos de dano a mais."
-		}
+		},
 
 		damage: "120+"
 	}],

--- a/data/Mega Evolution/MEP Black Star Promos/082.ts
+++ b/data/Mega Evolution/MEP Black Star Promos/082.ts
@@ -1,0 +1,92 @@
+import { Card } from "../../../interfaces"
+import Set from "../MEP Black Star Promos"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Miraidon",
+		fr: "Miraidon",
+		es: "Miraidon",
+		'es-mx': "Miraidon",
+		de: "Miraidon",
+		it: "Miraidon",
+		pt: "Miraidon"
+	},
+
+	illustrator: "Taira Akitsu",
+	rarity: "Promo",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Lighning"],
+	stage: "Basic",
+	dexId: [1008],
+
+	abilities: [{
+		type: "Ability",
+
+		name: {
+			en: "Photon Cord",
+			fr: "Câble Photonique",
+			es: "Cable Fotónico",
+			de: "Photonenkabel",
+			it: "Prolunga Fotonica",
+			pt: "Corda de Fótons"
+		},
+
+		effect: {
+			en: "If this Pokémon is in the Active Spot and is Knocked Out by damage from an attack from your opponent's Pokémon, move up to 2 Basic {L} Energy cards from this Pokémon to 1 of your Benched Pokémon.",
+			fr: "Si ce Pokémon est sur le Poste Actif et est mis K.O. par les dégâts d'une attaque de l'un des Pokémon de votre adversaire, déplacez jusqu'à 2 cartes Énergie {L} de base de ce Pokémon vers l'un de vos Pokémon de Banc.",
+			es: "Si este Pokémon está en el Puesto Activo y queda Fuera de Combate por el daño de un ataque de los Pokémon de tu rival, mueve hasta 2 cartas de Energía {L} Básica de este Pokémon a uno de tus Pokémon en Banca.",
+			de: "Wenn dieses Pokémon in der Aktiven Position ist und durch Schaden einer Attacke von Pokémon deines Gegners kampfunfähig wird, verschiebe bis zu 2 Basis-{L}-Energiekarten von diesem Pokémon auf 1 Pokémon auf deiner Bank.",
+			it: "Se questo Pokémon è in posizione attiva e viene messo KO dai danni inflitti da un attacco di un Pokémon del tuo avversario, sposta fino a due carte Energia base {L} da questo Pokémon a uno di quelli nella tua panchina.",
+			pt: "Se este Pokémon estiver no Campo Ativo e for Nocauteado pelo dano de um ataque dos Pokémon do seu oponente, mova até 2 cartas de Energia {L} deste Pokémon para 1 dos seus Pokémon no Banco."
+		}
+	}],
+
+	attacks: [{
+		cost: ["Lightning", "Lightning"],
+
+		name: {
+			en: "Thunder",
+			fr: "Fatal-Foudre",
+			es: "Trueno",
+			it: "Tuono",
+			pt: "Trovão",
+			de: "Donner"
+		},
+
+		effect: {
+			en: "This Pokémon does 30 damage to itself.",
+			fr: "Ce Pokémon s'inflige 30 dégâts.",
+			es: "Este Pokémon se hace 30 puntos de daño a sí mismo.",
+			it: "Questo Pokémon infligge 30 danni a se stesso.",
+			pt: "Esse Pokémon causa 30 de danos a ele mesmo.",
+			de: "Dieses Pokémon fügt auch sich selbst 30 Schadenspunkte zu."
+		},
+
+		damage: 90
+	}],
+
+	retreat: 1,
+	regulationMark: "J",
+
+	weaknesses: [{
+		type: "Fighting",
+		value: "x2"
+	}],
+
+	variants: [
+		{
+			type: "holo",
+			stamp: ["set-logo"],
+			thirdParty: {
+				cardmarket: 894261,
+				tcgplayer: 706135
+
+			}
+		},
+	],
+}
+
+export default card

--- a/data/Mega Evolution/MEP Black Star Promos/082.ts
+++ b/data/Mega Evolution/MEP Black Star Promos/082.ts
@@ -18,7 +18,7 @@ const card: Card = {
 	rarity: "Promo",
 	category: "Pokemon",
 	hp: 120,
-	types: ["Lighning"],
+	types: ["Lightning"],
 	stage: "Basic",
 	dexId: [1008],
 

--- a/data/Mega Evolution/MEP Black Star Promos/083.ts
+++ b/data/Mega Evolution/MEP Black Star Promos/083.ts
@@ -1,0 +1,96 @@
+import { Card } from "../../../interfaces"
+import Set from "../MEP Black Star Promos"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Slowbro",
+		fr: "Flagadoss",
+		es: "Slowbro",
+		it: "Slowbro",
+		pt: "Slowbro",
+		de: "Lahmus"
+	},
+
+	illustrator: "Yuriko Akase",
+	rarity: "Promo",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Psychic"],
+	stage: "Stage1",
+	dexId: [80],
+
+	evolveFrom: {
+		en: "Slowpoke",
+		fr: "Ramoloss",
+		es: "Slowpoke",
+		it: "Slowpoke",
+		pt: "Slowpoke",
+		de: "Flegmon"
+	},
+
+	attacks: [{
+		cost: ["Psychic"],
+
+		name: {
+			en: "All Out",
+			fr: "À Fond",
+			es: "A por Todas",
+			it: "A Tutta Forza",
+			pt: "Esgotado",
+			de: "Aufs Ganze gehen"
+		},
+
+		effect: {
+			en: "If you have no cards in your hand, this attack does 160 more damage.",
+			fr: "Si vous n’avez aucune carte dans votre main, cette attaque inflige 160 dégâts supplémentaires.",
+			es: "Si no tienes ninguna carta en tu mano, este ataque hace 160 puntos de daño más.",
+			it: "Se non hai carte in mano, questo attacco infligge 160 danni in più.",
+			pt: "Se você não tiver cartas na sua mão, este ataque causará 160 pontos de dano a mais.",
+			de: "Wenn du keine Karten auf deiner Hand hast, fügt diese Attacke 160 Schadenspunkte mehr zu."
+		},
+
+		damage: "50+"
+	}, {
+      		cost: ["Colorless", "Colorless", "Colorless"],
+
+			name: {
+				en: "Zen Headbutt",
+				fr: "Psykoud'Boul",
+				es: "Cabezazo Zen",
+				it: "Cozzata Zen",
+				pt: "Cabeçada Zen",
+				de: "Zen-Kopfstoß"
+			},
+
+      		damage: "110"
+    }],
+
+	retreat: 3,
+	regulationMark: "J",
+
+	weaknesses: [{
+		type: "Darkness",
+		value: "x2"
+	}],
+
+	resistances: [{
+		type: "Fighting",
+		value: "-30"
+	}],
+
+	variants: [
+		{
+			type: "holo",
+			stamp: ["set-logo"],
+			thirdParty: {
+				cardmarket: 894262,
+				tcgplayer: 706129
+
+			}
+		},
+	],
+}
+
+export default card

--- a/data/Mega Evolution/MEP Black Star Promos/084.ts
+++ b/data/Mega Evolution/MEP Black Star Promos/084.ts
@@ -1,0 +1,77 @@
+import { Card } from "../../../interfaces"
+import Set from "../MEP Black Star Promos"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Dhelmise",
+		fr: "Sinistrail",
+		de: "Moruda",
+		it: "Dhelmise",
+		es: "Dhelmise",
+		pt: "Dhelmise",
+		'es-mx': "Dhelmise"
+	},
+
+	illustrator: "Dsuke",
+	rarity: "Promo",
+	category: "Pokemon",
+	hp: 140,
+	types: ["Psychic"],
+	stage: "Basic",
+	dexId: [781],
+
+	attacks: [{
+		cost: ["Psychic"],
+
+		name: {
+        	en: "Vengeful Anchor",
+        	fr: "Ancre Vengeresse",
+        	de: "Verankerte Rache",
+        	it: "Ancora Vendicativa",
+        	es: "Ancla Vengativa",
+        	pt: "Âncora Vingativa",
+        	'es-mx': "Ancla Vengativa"
+        },
+
+		effect: {
+			en: "If you have 4 or more Pokémon that have the Hide 'n' Sneak Ability in your discard pile, this attack does 140 more damage.",
+			fr: "Si vous avez au moins 4 Pokémon ayant le talent Cachette en Douce dans votre pile de défausse, cette attaque inflige 140 dégâts supplémentaires.",
+			de: "Wenn du 4 oder mehr Pokémon, die die Fähigkeit Listiges Versteckspiel haben, in deinem Ablagestapel hast, fügt diese Attacke 140 Schadenspunkte mehr zu."
+			it: "Se hai quattro o più Pokémon che hanno l'abilità Nascondino Furbino nella tua pila degli scarti, questo attacco infligge 140 danni in più.",
+			es: "Si tienes en tu pila de descartes 4 Pokémon o más que tengan la habilidad Escondite a Hurtadillas, este ataque hace 140 puntos de daño más.",
+			pt: "Se você tiver 4 ou mais Pokémon que têm a Habilidade Esconde-some na sua pilha de descarte, este ataque causará 140 pontos de dano a mais.",
+			'es-mx': "Si tienes 4 Pokémon o más que tengan la Habilidad Escondidas Furtivas en tu pila de descartes, este ataque hace 140 puntos de daño más."
+		},
+
+		damage: "30+"
+	}],
+
+	retreat: 3,
+	regulationMark: "J",
+
+	weaknesses: [{
+		type: "Darkness",
+		value: "x2"
+	}],
+
+	resistances: [{
+		type: "Fighting",
+		value: "-30"
+	}],
+
+	variants: [
+		{
+			type: "holo",
+			stamp: ["set-logo"],
+			thirdParty: {
+				cardmarket: 894263,
+				tcgplayer: 706137
+
+			}
+		},
+	],
+}
+
+export default card

--- a/data/Mega Evolution/MEP Black Star Promos/084.ts
+++ b/data/Mega Evolution/MEP Black Star Promos/084.ts
@@ -38,7 +38,7 @@ const card: Card = {
 		effect: {
 			en: "If you have 4 or more Pokémon that have the Hide 'n' Sneak Ability in your discard pile, this attack does 140 more damage.",
 			fr: "Si vous avez au moins 4 Pokémon ayant le talent Cachette en Douce dans votre pile de défausse, cette attaque inflige 140 dégâts supplémentaires.",
-			de: "Wenn du 4 oder mehr Pokémon, die die Fähigkeit Listiges Versteckspiel haben, in deinem Ablagestapel hast, fügt diese Attacke 140 Schadenspunkte mehr zu."
+			de: "Wenn du 4 oder mehr Pokémon, die die Fähigkeit Listiges Versteckspiel haben, in deinem Ablagestapel hast, fügt diese Attacke 140 Schadenspunkte mehr zu.",
 			it: "Se hai quattro o più Pokémon che hanno l'abilità Nascondino Furbino nella tua pila degli scarti, questo attacco infligge 140 danni in più.",
 			es: "Si tienes en tu pila de descartes 4 Pokémon o más que tengan la habilidad Escondite a Hurtadillas, este ataque hace 140 puntos de daño más.",
 			pt: "Se você tiver 4 ou mais Pokémon que têm a Habilidade Esconde-some na sua pilha de descarte, este ataque causará 140 pontos de dano a mais.",

--- a/data/Mega Evolution/MEP Black Star Promos/085.ts
+++ b/data/Mega Evolution/MEP Black Star Promos/085.ts
@@ -1,0 +1,96 @@
+import { Card } from "../../../interfaces"
+import Set from "../MEP Black Star Promos"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Bastiodon",
+		fr: "Bastiodon",
+		es: "Bastiodon",
+		it: "Bastiodon",
+		pt: "Bastiodon",
+		de: "Bollterus"
+	},
+
+	illustrator: "Minahamu",
+	rarity: "Promo",
+	category: "Pokemon",
+	hp: 160,
+	types: ["Metal"],
+	stage: "Stage2",
+	dexId: [411],
+
+	evolveFrom: {
+		en: "Shieldon",
+		fr: "Dinoclier",
+		es: "Shieldon",
+		it: "Shieldon",
+		pt: "Shieldon",
+		de: "Schilterus"
+	},
+
+	abilities: [{
+		type: "Ability",
+
+		name: {
+			en: "Ancient Bulwark",
+			fr: "Rempart Antique",
+			es: "Bastión Ancestral",
+			de: "Altes Bollwerk",
+			it: "Bastione Antico",
+			pt: "Baluarte Ancestral"
+		},
+
+		effect: {
+			en: "As long as this Pokémon is on your Bench, prevent all damage done to each of your Pokémon by attacks from your opponent's Pokémon that have 2 or less Energy attached.",
+			fr: "Tant que ce Pokémon est sur votre Banc, évitez tous les dégâts infligés à chacun de vos Pokémon par les attaques des Pokémon de votre adversaire auxquels 2 Energies ou moins sont attachées.",
+			es: "Mientras este Pokémon esté en tu Banca, se evita todo el daño infligido a cada uno de tus Pokémon por ataques de los Pokémon de tu rival que tengan 2 Energías o menos unidas.",
+			de: "Solange dieses Pokémon auf deiner Bank ist, verhindere allen Schaden, der jedem deiner Pokémon durch Attacken von Pokémon deines Gegners, an die 2 oder weniger Energien angelegt sind, zugefügt wird.",
+			it: "Fintanto che questo Pokémon è nella tua panchina, previeni tutti i danni inflitti a ciascuno dei tuoi Pokémon dagli attacchi dei Pokémon del tuo avversario che hanno due o meno Energie assegnate.",
+			pt: "Enquanto este Pokémon estiver no seu Banco, previna todo o dano causado a cada um dos seus Pokémon por ataques dos Pokémon do seu oponente que têm 2 ou menos Energias ligadas a eles."
+		}
+	}],
+
+	attacks: [{
+		cost: ["Metal", "Metal", "Colorless"],
+
+		name: {
+			en: "Hammer In",
+			fr: "Enfoncement",
+			es: "Martillear",
+			it: "Martello",
+			pt: "Martelada",
+			de: "Einhämmern"
+		},
+
+		damage: 160
+	}],
+
+	retreat: 4,
+	regulationMark: "J",
+
+	weaknesses: [{
+		type: "Fire",
+		value: "x2"
+	}],
+
+	resistances: [{
+		type: "Grass",
+		value: "-30"
+	}],
+
+	variants: [
+		{
+			type: "holo",
+			stamp: ["set-logo"],
+			thirdParty: {
+				cardmarket: 894264,
+				tcgplayer: 706133
+
+			}
+		},
+	],
+}
+
+export default card

--- a/data/Mega Evolution/MEP Black Star Promos/086.ts
+++ b/data/Mega Evolution/MEP Black Star Promos/086.ts
@@ -1,0 +1,80 @@
+import { Card } from "../../../interfaces"
+import Set from "../MEP Black Star Promos"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Slowpoke",
+		fr: "Ramoloss",
+		es: "Slowpoke",
+		it: "Slowpoke",
+		pt: "Slowpoke",
+		de: "Flegmon"
+	},
+
+	illustrator: "miki kudo",
+	rarity: "Promo",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Psychic"],
+	stage: "Basic",
+	dexId: [79],
+
+	abilities: [{
+		type: "Ability",
+
+		name: {
+			en: "Dopey Face",
+			de: "Dösiger Blick",
+			pt: "Rosto Atordoado"
+		},
+
+		effect: {
+			en: "This Pokémon can't be Confused.",
+			de: "Dieses Pokémon kann nicht verwirrt werden.",
+			pt: "Este Pokémon não pode ficar Confuso."
+		}
+	}],
+
+	attacks: [{
+		cost: ["Psychic", "Psychic", "Colorless"],
+
+		name: {
+			en: "Super Psy Bolt",
+			fr: "Super Psy",
+			es: "Superrayo Psi",
+			it: "Superpsico",
+			pt: "Super-raio Psíquico",
+			de: "Super-Psischlag"
+		},
+
+		damage: 50
+	}],
+
+	retreat: 2,
+	regulationMark: "J",
+
+	weaknesses: [{
+		type: "Darkness",
+		value: "x2"
+	}],
+
+	resistances: [{
+		type: "Fighting",
+		value: "-30"
+	}],
+
+	variants: [
+		{
+			type: "holo",
+			foil: "cosmos",
+			thirdParty: {
+				cardmarket: 898176,
+				tcgplayer: 706130
+			}
+		},
+	],
+}
+
+export default card

--- a/data/Mega Evolution/MEP Black Star Promos/087.ts
+++ b/data/Mega Evolution/MEP Black Star Promos/087.ts
@@ -1,0 +1,78 @@
+import { Card } from "../../../interfaces"
+import Set from "../MEP Black Star Promos"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Binacle",
+		fr: "Opermine",
+		es: "Binacle",
+		'es-mx': "Binacle",
+		de: "Bithora",
+		it: "Binacle",
+		pt: "Binacle"
+	},
+
+	illustrator: "Shimaris Yukichi",
+	rarity: "Promo",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Fighting"],
+	stage: "Basic",
+	dexId: [688],
+
+	attacks: [{
+		cost: ["Fighting"],
+
+		name: {
+			en: "Double Draw",
+			fr: "Double Pioche",
+			es: "Roba Doble",
+			it: "Pescata Doppia",
+			pt: "Compra Dupla",
+			de: "Zweifachzug"
+		},
+
+		effect: {
+			en: "Draw 2 cards.",
+			fr: "Piochez 2 cartes.",
+		},
+
+	}, {
+		cost: ["Fighting", "Fighting"],
+
+		name: {
+			en: "Scratch",
+			fr: "Griffe",
+			es: "Arañazo",
+			it: "Graffio",
+			pt: "Arranhão",
+			de: "Kratzer"
+		},
+
+		damage: 30
+
+	}],
+
+	retreat: 2,
+	regulationMark: "J",
+
+	weaknesses: [{
+		type: "Grass",
+		value: "x2"
+	}],
+
+	variants: [
+		{
+			type: "holo",
+			foil: "cosmos",
+			thirdParty: {
+				cardmarket: 898177,
+				tcgplayer: 706131
+			}
+		},
+	],
+}
+
+export default card

--- a/data/Mega Evolution/MEP Black Star Promos/088.ts
+++ b/data/Mega Evolution/MEP Black Star Promos/088.ts
@@ -1,0 +1,99 @@
+import { Card } from "../../../interfaces"
+import Set from "../MEP Black Star Promos"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Zarude",
+		fr: "Zarude",
+		es: "Zarude",
+		it: "Zarude",
+		pt: "Zarude",
+		de: "Zarude"
+	},
+
+	illustrator: "IKEDA Saki",
+	rarity: "Promo",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Darkness"],
+	stage: "Basic",
+	dexId: [893],
+
+	attacks: [{
+		cost: ["Darkness"],
+
+		name: {
+			en: "Overhead Throw",
+			fr: "Soulève Corne",
+			es: "Lanzamiento Elevado",
+			it: "Lancindietro",
+			pt: "Arremessar por Cima",
+			de: "Überwerfer"
+		},
+
+		effect: {
+			en: "This attack also does 30 damage to 1 of your Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)",
+			fr: "Cette attaque inflige aussi 30 dégâts à l'un de vos Pokémon de Banc. (N'appliquez ni la Faiblesse ni la Résistance aux Pokémon de Banc.)",
+			es: "Este ataque también hace 30 puntos de daño a 1 de tus Pokémon en Banca. (No apliques Debilidad y Resistencia a los Pokémon en Banca).",
+			it: "Questo attacco infligge anche 30 danni a uno dei tuoi Pokémon in panchina. Non applicare debolezza e resistenza ai Pokémon in panchina.",
+			pt: "Este ataque também causa 30 pontos de dano a 1 dos seus Pokémon no Banco (não aplique Fraqueza e Resistência aos Pokémon no Banco).",
+			de: "Diese Attacke fügt auch 1 Pokémon auf deiner Bank 30 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
+		},
+
+		damage: 30
+
+	}, {
+		cost: ["Darkness", "Darkness", "Darkness"],
+
+		name: {
+			en: "Shadowy Whip",
+			fr: "Fouet Sombre",
+			es: "Látigo Sombrío",
+			it: "Frustata Ombrosa",
+			pt: "Chicote Sombrio",
+			de: "Schattige Peitsche"
+		},
+
+		effect: {
+			en: "If your Benched Pokémon have any Shadowy {D} Energy attached, this attack does 70 more damage.",
+			fr: "Si au moins une Énergie {D} Sombre est attachée à vos Pokémon de Banc, cette attaque inflige 70 dégâts supplémentaires.",
+			es: "Si tus Pokémon en Banca tienen alguna Energía {D} Sombría unida, este ataque hace 70 puntos de daño más.",
+			it: "Se i Pokémon nella tua panchina hanno almeno un'Energia {D} Ombrosa assegnata, questo attacco infligge 70 danni in più.",
+			pt: "Se os seus Pokémon no Banco tiverem alguma Energia {D} Sombria ligadas a eles, este ataque causará 70 pontos de dano a mais.",
+			de: "Wenn an den Pokémon auf deiner Bank mindestens 1 Schattige {D}-Energie angelegt ist, fügt diese Attacke 70 Schadenspunkte mehr zu."
+		},
+
+		damage: "100+"
+
+	}],
+
+	retreat: 2,
+	regulationMark: "J",
+
+	weaknesses: [{
+		type: "Grass",
+		value: "x2"
+	}],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 895779,
+				tcgplayer: 706193
+			}
+		},
+		{
+			type: "holo",
+			stamp: ["pokemon-center"],
+			thirdParty: {
+				cardmarket: 895780,
+				tcgplayer: 706199
+			}
+		},
+	],
+}
+
+export default card

--- a/data/Mega Evolution/MEP Black Star Promos/Museum.ts
+++ b/data/Mega Evolution/MEP Black Star Promos/Museum.ts
@@ -1,0 +1,74 @@
+import { Card } from "../../../interfaces"
+import Set from "../MEP Black Star Promos"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Pikachu at the Museum",
+	},
+
+	illustrator: "Naoyo Kimura",
+	rarity: "Promo",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Lightning"],
+	stage: "Basic",
+	dexId: [25],
+
+	attacks: [{
+		cost: ["Lightning", "Lightning", "Lightning"],
+
+		name: {
+			en: "Thunderbolt",
+			fr: "Tonnerre",
+			es: "Rayo",
+			'es-mx': "Atactrueno",
+			de: "Donnerblitz",
+			it: "Fulmine",
+			pt: "Relâmpago"
+		},
+
+		effect: {
+			en: "Discard all Energy from this Pokémon.",
+			fr: "Défaussez toutes les Énergies de ce Pokémon.",
+			es: "Descarta todas las Energías de este Pokémon.",
+			'es-mx': "Descarta todas las Energías de este Pokémon.",
+			de: "Lege alle Energien von diesem Pokémon auf deinen Ablagestapel.",
+			it: "Scarta tutte le Energie da questo Pokémon.",
+			pt: "Descarte todas as Energias deste Pokémon."
+		},
+
+		damage: 100
+	}, {
+       	cost: ["Colorless"],
+
+       	name: {
+       		en: "The Best Collection!",
+       	},
+
+		effect: {
+			en: "Search your Pokémon TCG Collection for a Pokémon, reveal it, and put it into your hand.",
+		}
+   	}],
+
+	retreat: 1,
+
+	weaknesses: [{
+		type: "Fighting",
+		value: "x2"
+	}],
+
+	variants: [
+        {
+        	type: 'normal',
+        	size: 'jumbo',
+        	thirdParty: {
+        		cardmarket: 865392,
+        		tcgplayer: 678659
+        	}
+        },
+	],
+}
+
+export default card

--- a/data/Mega Evolution/MEP Black Star Promos/Museum.ts
+++ b/data/Mega Evolution/MEP Black Star Promos/Museum.ts
@@ -20,23 +20,11 @@ const card: Card = {
 		cost: ["Lightning", "Lightning", "Lightning"],
 
 		name: {
-			en: "Thunderbolt",
-			fr: "Tonnerre",
-			es: "Rayo",
-			'es-mx': "Atactrueno",
-			de: "Donnerblitz",
-			it: "Fulmine",
-			pt: "Relâmpago"
+			en: "Thunderbolt"
 		},
 
 		effect: {
-			en: "Discard all Energy from this Pokémon.",
-			fr: "Défaussez toutes les Énergies de ce Pokémon.",
-			es: "Descarta todas las Energías de este Pokémon.",
-			'es-mx': "Descarta todas las Energías de este Pokémon.",
-			de: "Lege alle Energien von diesem Pokémon auf deinen Ablagestapel.",
-			it: "Scarta tutte le Energie da questo Pokémon.",
-			pt: "Descarte todas as Energias deste Pokémon."
+			en: "Discard all Energy from this Pokémon."
 		},
 
 		damage: 100
@@ -44,11 +32,11 @@ const card: Card = {
        	cost: ["Colorless"],
 
        	name: {
-       		en: "The Best Collection!",
+       		en: "The Best Collection!"
        	},
 
 		effect: {
-			en: "Search your Pokémon TCG Collection for a Pokémon, reveal it, and put it into your hand.",
+			en: "Search your Pokémon TCG Collection for a Pokémon, reveal it, and put it into your hand."
 		}
    	}],
 


### PR DESCRIPTION
<!--
Contribution guide: https://github.com/tcgdex/cards-database/blob/master/CONTRIBUTING.md
please submit changes up to 1 set at most.
-->

closes #1694

## Changes

Add missing MEP Black Star Promos to the database and update existing cards of this set with missing information.

## Details

* Add completely new, previously missing MEP Black Star Promo cards.
* Update existing cards with the following missing fields:
  * `evolveFrom`
  * `dexID`
  * `weaknesses`
  * `resistances`
  * `variants`
  * `thirdparty IDs`