### PR TITLE
(data) Variants for Nintendo Black Star Promos

### DIFF
--- a/data/Neo/Neo Destiny/1.ts
+++ b/data/Neo/Neo Destiny/1.ts
@@ -82,18 +82,22 @@ const card: Card = {
 		fr: "La nuit, la pointe de sa queue est visible à des kilomètres à la ronde, même pour les bateaux qui naviguent au large."
 	},
 
-	thirdParty: {
-		cardmarket: 274653,
-		tcgplayer: 84561
-	},
 
 	variants: [
 		{
-			type: "holo"
+			type: "holo",
+			thirdParty: {
+				cardmarket: 274653,
+				tcgplayer: 84561
+			}
 		},
 		{
 			type: "holo",
-			stamp: ["1st-edition"]
+			stamp: ["1st-edition"],
+			thirdParty: {
+				cardmarket: 274653,
+				tcgplayer: 84561
+			}
 		}
 	]
 }

--- a/data/Neo/Neo Destiny/10.ts
+++ b/data/Neo/Neo Destiny/10.ts
@@ -77,18 +77,22 @@ const card: Card = {
 		fr: "Quand il se bat, l'air autour de lui scintille et semble s'enflammer à cause de l'intense chaleur émanant de lui."
 	},
 
-	thirdParty: {
-		cardmarket: 274662,
-		tcgplayer: 84659
-	},
 
 	variants: [
 		{
-			type: "holo"
+			type: "holo",
+			thirdParty: {
+				cardmarket: 274662,
+				tcgplayer: 84659
+			}
 		},
 		{
 			type: "holo",
-			stamp: ["1st-edition"]
+			stamp: ["1st-edition"],
+			thirdParty: {
+				cardmarket: 274662,
+				tcgplayer: 84659
+			}
 		}
 	]
 }

--- a/data/Neo/Neo Destiny/100.ts
+++ b/data/Neo/Neo Destiny/100.ts
@@ -19,18 +19,22 @@ const card: Card = {
 		de: "Once during each player's turn, that player may flip a coin. If heads, the player draws a card."
 	},
 
-	thirdParty: {
-		cardmarket: 274752,
-		tcgplayer: 86893
-	},
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				cardmarket: 274752,
+				tcgplayer: 86893
+			}
 		},
 		{
 			type: "normal",
-			stamp: ["1st-edition"]
+			stamp: ["1st-edition"],
+			thirdParty: {
+				cardmarket: 274752,
+				tcgplayer: 86893
+			}
 		}
 	]
 }

--- a/data/Neo/Neo Destiny/101.ts
+++ b/data/Neo/Neo Destiny/101.ts
@@ -19,18 +19,22 @@ const card: Card = {
 		de: "Attach Magnifier to 1 of your Pokémon. At he end of your turn, discard Magnifier. If the Pokémon Magnifier is attached to attcks, don't apply Resistance for this attack."
 	},
 
-	thirdParty: {
-		cardmarket: 274753,
-		tcgplayer: 87122
-	},
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				cardmarket: 274753,
+				tcgplayer: 87122
+			}
 		},
 		{
 			type: "normal",
-			stamp: ["1st-edition"]
+			stamp: ["1st-edition"],
+			thirdParty: {
+				cardmarket: 274753,
+				tcgplayer: 87122
+			}
 		}
 	]
 }

--- a/data/Neo/Neo Destiny/102.ts
+++ b/data/Neo/Neo Destiny/102.ts
@@ -19,17 +19,20 @@ const card: Card = {
 		de: "Put an Evoloution card from your hand face down in front of you. Your opponent guesses whether it is a Pokémon card with Light in its name, a Pokémon card with Dark in its name, or neither one. Flip the card over. If your opponent guessed right, he or she draw 3 cards. If your oppnent guessed wrong, you draw 3 cards. Either way, return the card to your hand."
 	},
 
-	thirdParty: {
-		cardmarket: 274754
-	},
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				cardmarket: 274754
+			}
 		},
 		{
 			type: "normal",
-			stamp: ["1st-edition"]
+			stamp: ["1st-edition"],
+			thirdParty: {
+				cardmarket: 274754
+			}
 		}
 	]
 }

--- a/data/Neo/Neo Destiny/103.ts
+++ b/data/Neo/Neo Destiny/103.ts
@@ -19,18 +19,22 @@ const card: Card = {
 		de: "Schaue dir die Karte auf der Hand deines Gegners an und wähle eine Karte davon. Dein Gegner mischt diese Karte in sein Deck. Dann darf er bis zu zwei Karten ziehen."
 	},
 
-	thirdParty: {
-		cardmarket: 274755,
-		tcgplayer: 89850
-	},
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				cardmarket: 274755,
+				tcgplayer: 89850
+			}
 		},
 		{
 			type: "normal",
-			stamp: ["1st-edition"]
+			stamp: ["1st-edition"],
+			thirdParty: {
+				cardmarket: 274755,
+				tcgplayer: 89850
+			}
 		}
 	]
 }

--- a/data/Neo/Neo Destiny/104.ts
+++ b/data/Neo/Neo Destiny/104.ts
@@ -19,18 +19,22 @@ const card: Card = {
 		de: "Wirf eine Münze. Bei 'Kopf' schläft dein Aktives Pokémon nicht mehr und ist nicht länger verwirrt, gelähmt oder vergiftet. Entferne zwei Schadensmarken von deinem aktiven Pokémon. Hat es weniger als zwei Schadensmarken, entferne alle."
 	},
 
-	thirdParty: {
-		cardmarket: 274756,
-		tcgplayer: 86039
-	},
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				cardmarket: 274756,
+				tcgplayer: 86039
+			}
 		},
 		{
 			type: "normal",
-			stamp: ["1st-edition"]
+			stamp: ["1st-edition"],
+			thirdParty: {
+				cardmarket: 274756,
+				tcgplayer: 86039
+			}
 		}
 	]
 }

--- a/data/Neo/Neo Destiny/105.ts
+++ b/data/Neo/Neo Destiny/105.ts
@@ -19,18 +19,22 @@ const card: Card = {
 		de: "You can´t play this card if you have 5 or more cards in your hand (including this one). Draw cards until you have exactly 4 cards in your hand."
 	},
 
-	thirdParty: {
-		cardmarket: 274757,
-		tcgplayer: 87123
-	},
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				cardmarket: 274757,
+				tcgplayer: 87123
+			}
 		},
 		{
 			type: "normal",
-			stamp: ["1st-edition"]
+			stamp: ["1st-edition"],
+			thirdParty: {
+				cardmarket: 274757,
+				tcgplayer: 87123
+			}
 		}
 	]
 }

--- a/data/Neo/Neo Destiny/106.ts
+++ b/data/Neo/Neo Destiny/106.ts
@@ -78,18 +78,22 @@ const card: Card = {
 		fr: "Il est adoré comme un dieu de la forêt. Il n'apparaît que dans des forêts anciennes et paisibles."
 	},
 
-	thirdParty: {
-		cardmarket: 274758,
-		tcgplayer: 89162
-	},
 
 	variants: [
 		{
-			type: "holo"
+			type: "holo",
+			thirdParty: {
+				cardmarket: 274758,
+				tcgplayer: 89162
+			}
 		},
 		{
 			type: "holo",
-			stamp: ["1st-edition"]
+			stamp: ["1st-edition"],
+			thirdParty: {
+				cardmarket: 274758,
+				tcgplayer: 89162
+			}
 		}
 	]
 }

--- a/data/Neo/Neo Destiny/107.ts
+++ b/data/Neo/Neo Destiny/107.ts
@@ -70,18 +70,22 @@ const card: Card = {
 		fr: "Les flammes qu'il souffle sont si chaudes qu'elles peuvent faire fondre n'importe quoi."
 	},
 
-	thirdParty: {
-		cardmarket: 274759,
-		tcgplayer: 89163
-	},
 
 	variants: [
 		{
-			type: "holo"
+			type: "holo",
+			thirdParty: {
+				cardmarket: 274759,
+				tcgplayer: 89163
+			}
 		},
 		{
 			type: "holo",
-			stamp: ["1st-edition"]
+			stamp: ["1st-edition"],
+			thirdParty: {
+				cardmarket: 274759,
+				tcgplayer: 89163
+			}
 		}
 	]
 }

--- a/data/Neo/Neo Destiny/108.ts
+++ b/data/Neo/Neo Destiny/108.ts
@@ -81,18 +81,22 @@ const card: Card = {
 		fr: "Ce Pokémon antique utilise ses griffes acérées pour trancher ses proies et récupérer leur sang."
 	},
 
-	thirdParty: {
-		cardmarket: 274760,
-		tcgplayer: 89165
-	},
 
 	variants: [
 		{
-			type: "holo"
+			type: "holo",
+			thirdParty: {
+				cardmarket: 274760,
+				tcgplayer: 89165
+			}
 		},
 		{
 			type: "holo",
-			stamp: ["1st-edition"]
+			stamp: ["1st-edition"],
+			thirdParty: {
+				cardmarket: 274760,
+				tcgplayer: 89165
+			}
 		}
 	]
 }

--- a/data/Neo/Neo Destiny/109.ts
+++ b/data/Neo/Neo Destiny/109.ts
@@ -78,18 +78,22 @@ const card: Card = {
 		fr: "Il utilise ses pouvoirs psychiques surdéveloppés pour vaincre ses ennemis avant qu'ils n'aient le temps de réfléchir."
 	},
 
-	thirdParty: {
-		cardmarket: 274761,
-		tcgplayer: 89167
-	},
 
 	variants: [
 		{
-			type: "holo"
+			type: "holo",
+			thirdParty: {
+				cardmarket: 274761,
+				tcgplayer: 89167
+			}
 		},
 		{
 			type: "holo",
-			stamp: ["1st-edition"]
+			stamp: ["1st-edition"],
+			thirdParty: {
+				cardmarket: 274761,
+				tcgplayer: 89167
+			}
 		}
 	]
 }

--- a/data/Neo/Neo Destiny/11.ts
+++ b/data/Neo/Neo Destiny/11.ts
@@ -93,18 +93,22 @@ const card: Card = {
 		fr: "Sa puissance est telle que même les montagnes ne lui résistent pas."
 	},
 
-	thirdParty: {
-		cardmarket: 274663,
-		tcgplayer: 84660
-	},
 
 	variants: [
 		{
-			type: "holo"
+			type: "holo",
+			thirdParty: {
+				cardmarket: 274663,
+				tcgplayer: 84660
+			}
 		},
 		{
 			type: "holo",
-			stamp: ["1st-edition"]
+			stamp: ["1st-edition"],
+			thirdParty: {
+				cardmarket: 274663,
+				tcgplayer: 84660
+			}
 		}
 	]
 }

--- a/data/Neo/Neo Destiny/110.ts
+++ b/data/Neo/Neo Destiny/110.ts
@@ -68,18 +68,22 @@ const card: Card = {
 		fr: "Il accélère la vitesse à laquelle il pense en tournant sa tête à 180 degrés."
 	},
 
-	thirdParty: {
-		cardmarket: 274762,
-		tcgplayer: 89168
-	},
 
 	variants: [
 		{
-			type: "holo"
+			type: "holo",
+			thirdParty: {
+				cardmarket: 274762,
+				tcgplayer: 89168
+			}
 		},
 		{
 			type: "holo",
-			stamp: ["1st-edition"]
+			stamp: ["1st-edition"],
+			thirdParty: {
+				cardmarket: 274762,
+				tcgplayer: 89168
+			}
 		}
 	]
 }

--- a/data/Neo/Neo Destiny/111.ts
+++ b/data/Neo/Neo Destiny/111.ts
@@ -64,18 +64,22 @@ const card: Card = {
 		fr: "S'il vient à court d'électricité au niveau de ses joues, il dresse sa queue pour collecter l'énergie dans l'air ambiant."
 	},
 
-	thirdParty: {
-		cardmarket: 274763,
-		tcgplayer: 89169
-	},
 
 	variants: [
 		{
-			type: "holo"
+			type: "holo",
+			thirdParty: {
+				cardmarket: 274763,
+				tcgplayer: 89169
+			}
 		},
 		{
 			type: "holo",
-			stamp: ["1st-edition"]
+			stamp: ["1st-edition"],
+			thirdParty: {
+				cardmarket: 274763,
+				tcgplayer: 89169
+			}
 		}
 	]
 }

--- a/data/Neo/Neo Destiny/112.ts
+++ b/data/Neo/Neo Destiny/112.ts
@@ -71,18 +71,22 @@ const card: Card = {
 		fr: "Si un Onix vit au moins 100 ans, sa peau durcit et devient peu à peu plus dure que le diamant."
 	},
 
-	thirdParty: {
-		cardmarket: 274764,
-		tcgplayer: 89170
-	},
 
 	variants: [
 		{
-			type: "holo"
+			type: "holo",
+			thirdParty: {
+				cardmarket: 274764,
+				tcgplayer: 89170
+			}
 		},
 		{
 			type: "holo",
-			stamp: ["1st-edition"]
+			stamp: ["1st-edition"],
+			thirdParty: {
+				cardmarket: 274764,
+				tcgplayer: 89170
+			}
 		}
 	]
 }

--- a/data/Neo/Neo Destiny/113.ts
+++ b/data/Neo/Neo Destiny/113.ts
@@ -69,18 +69,22 @@ const card: Card = {
 		damage: 50
 	}],
 
-	thirdParty: {
-		cardmarket: 274765,
-		tcgplayer: 89171
-	},
 
 	variants: [
 		{
-			type: "holo"
+			type: "holo",
+			thirdParty: {
+				cardmarket: 274765,
+				tcgplayer: 89171
+			}
 		},
 		{
 			type: "holo",
-			stamp: ["1st-edition"]
+			stamp: ["1st-edition"],
+			thirdParty: {
+				cardmarket: 274765,
+				tcgplayer: 89171
+			}
 		}
 	]
 }

--- a/data/Neo/Neo Destiny/12.ts
+++ b/data/Neo/Neo Destiny/12.ts
@@ -84,18 +84,22 @@ const card: Card = {
 		fr: "Ce légendaire Pokémon chinois est facilement reconnaissable de par sa grande crinière."
 	},
 
-	thirdParty: {
-		cardmarket: 274664,
-		tcgplayer: 86734
-	},
 
 	variants: [
 		{
-			type: "holo"
+			type: "holo",
+			thirdParty: {
+				cardmarket: 274664,
+				tcgplayer: 86734
+			}
 		},
 		{
 			type: "holo",
-			stamp: ["1st-edition"]
+			stamp: ["1st-edition"],
+			thirdParty: {
+				cardmarket: 274664,
+				tcgplayer: 86734
+			}
 		}
 	]
 }

--- a/data/Neo/Neo Destiny/13.ts
+++ b/data/Neo/Neo Destiny/13.ts
@@ -83,18 +83,22 @@ const card: Card = {
 		fr: "Il replie ses longues oreilles quand il nage pour éviter que l'eau y entre."
 	},
 
-	thirdParty: {
-		cardmarket: 274665,
-		tcgplayer: 86735
-	},
 
 	variants: [
 		{
-			type: "holo"
+			type: "holo",
+			thirdParty: {
+				cardmarket: 274665,
+				tcgplayer: 86735
+			}
 		},
 		{
 			type: "holo",
-			stamp: ["1st-edition"]
+			stamp: ["1st-edition"],
+			thirdParty: {
+				cardmarket: 274665,
+				tcgplayer: 86735
+			}
 		}
 	]
 }

--- a/data/Neo/Neo Destiny/14.ts
+++ b/data/Neo/Neo Destiny/14.ts
@@ -82,18 +82,22 @@ const card: Card = {
 		fr: "On raconte qu'il vole constamment au-dessus des mers, à la recherche de personnes ayant besoin d'aide."
 	},
 
-	thirdParty: {
-		cardmarket: 274666,
-		tcgplayer: 86738
-	},
 
 	variants: [
 		{
-			type: "holo"
+			type: "holo",
+			thirdParty: {
+				cardmarket: 274666,
+				tcgplayer: 86738
+			}
 		},
 		{
 			type: "holo",
-			stamp: ["1st-edition"]
+			stamp: ["1st-edition"],
+			thirdParty: {
+				cardmarket: 274666,
+				tcgplayer: 86738
+			}
 		}
 	]
 }

--- a/data/Neo/Neo Destiny/15.ts
+++ b/data/Neo/Neo Destiny/15.ts
@@ -79,18 +79,22 @@ const card: Card = {
 		fr: "Il devient rapidement déprimé s'il n'est pas près de personnes au grand cœur. Il peut flotter dans les airs sans bouger ses ailes."
 	},
 
-	thirdParty: {
-		cardmarket: 274667,
-		tcgplayer: 86750
-	},
 
 	variants: [
 		{
-			type: "holo"
+			type: "holo",
+			thirdParty: {
+				cardmarket: 274667,
+				tcgplayer: 86750
+			}
 		},
 		{
 			type: "holo",
-			stamp: ["1st-edition"]
+			stamp: ["1st-edition"],
+			thirdParty: {
+				cardmarket: 274667,
+				tcgplayer: 86750
+			}
 		}
 	]
 }

--- a/data/Neo/Neo Destiny/16.ts
+++ b/data/Neo/Neo Destiny/16.ts
@@ -19,18 +19,22 @@ const card: Card = {
 		de: "Du kannst maximal 1 Wunder-Energie in deinem Deck haben. Lege Wunder-Energie an eines deiner Schimmernden oder Hellen Pokémon an. Lege am Ende deines Zuges Wunder-Energie auf deinen Ablagestapel. Solange Wunder-Energie im Spiel ist, zählt Wunder-Energie als jeder Energietyp, erzeugt aber 2 Energie gleichzeitig."
 	},
 
-	thirdParty: {
-		cardmarket: 274668,
-		tcgplayer: 87496
-	},
 
 	variants: [
 		{
-			type: "holo"
+			type: "holo",
+			thirdParty: {
+				cardmarket: 274668,
+				tcgplayer: 87496
+			}
 		},
 		{
 			type: "holo",
-			stamp: ["1st-edition"]
+			stamp: ["1st-edition"],
+			thirdParty: {
+				cardmarket: 274668,
+				tcgplayer: 87496
+			}
 		}
 	]
 }

--- a/data/Neo/Neo Destiny/17.ts
+++ b/data/Neo/Neo Destiny/17.ts
@@ -82,18 +82,22 @@ const card: Card = {
 		fr: "Où qu'il aille, il tisse un fil qui le ramène à sa toile."
 	},
 
-	thirdParty: {
-		cardmarket: 274669,
-		tcgplayer: 84566
-	},
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				cardmarket: 274669,
+				tcgplayer: 84566
+			}
 		},
 		{
 			type: "normal",
-			stamp: ["1st-edition"]
+			stamp: ["1st-edition"],
+			thirdParty: {
+				cardmarket: 274669,
+				tcgplayer: 84566
+			}
 		}
 	]
 }

--- a/data/Neo/Neo Destiny/18.ts
+++ b/data/Neo/Neo Destiny/18.ts
@@ -81,18 +81,22 @@ const card: Card = {
 		fr: "La carapace qui couvre son dos s'enlève facilement, exposant à l'air son corps enflammé."
 	},
 
-	thirdParty: {
-		cardmarket: 274670,
-		tcgplayer: 84622
-	},
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				cardmarket: 274670,
+				tcgplayer: 84622
+			}
 		},
 		{
 			type: "normal",
-			stamp: ["1st-edition"]
+			stamp: ["1st-edition"],
+			thirdParty: {
+				cardmarket: 274670,
+				tcgplayer: 84622
+			}
 		}
 	]
 }

--- a/data/Neo/Neo Destiny/19.ts
+++ b/data/Neo/Neo Destiny/19.ts
@@ -81,18 +81,22 @@ const card: Card = {
 		fr: "Rien ne peut lui échapper une fois dans ses tentacules, qu'il utilise pour se défendre, mais aussi pour se nourrir."
 	},
 
-	thirdParty: {
-		cardmarket: 274671,
-		tcgplayer: 84635
-	},
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				cardmarket: 274671,
+				tcgplayer: 84635
+			}
 		},
 		{
 			type: "normal",
-			stamp: ["1st-edition"]
+			stamp: ["1st-edition"],
+			thirdParty: {
+				cardmarket: 274671,
+				tcgplayer: 84635
+			}
 		}
 	]
 }

--- a/data/Neo/Neo Destiny/2.ts
+++ b/data/Neo/Neo Destiny/2.ts
@@ -85,18 +85,22 @@ const card: Card = {
 		fr: "Les ailes supplémentaires qui ornent ses pattes lui permettent de voler très vite, mais elles lui compliquent la vie quand il veut se percher."
 	},
 
-	thirdParty: {
-		cardmarket: 274654,
-		tcgplayer: 84576
-	},
 
 	variants: [
 		{
-			type: "holo"
+			type: "holo",
+			thirdParty: {
+				cardmarket: 274654,
+				tcgplayer: 84576
+			}
 		},
 		{
 			type: "holo",
-			stamp: ["1st-edition"]
+			stamp: ["1st-edition"],
+			thirdParty: {
+				cardmarket: 274654,
+				tcgplayer: 84576
+			}
 		}
 	]
 }

--- a/data/Neo/Neo Destiny/20.ts
+++ b/data/Neo/Neo Destiny/20.ts
@@ -81,18 +81,22 @@ const card: Card = {
 		fr: "À chaque fois qu'il baille, le Kokiyas qu'il porte sur la tête projette une enzyme qui le rend encore plus intelligent."
 	},
 
-	thirdParty: {
-		cardmarket: 274672,
-		tcgplayer: 84656
-	},
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				cardmarket: 274672,
+				tcgplayer: 84656
+			}
 		},
 		{
 			type: "normal",
-			stamp: ["1st-edition"]
+			stamp: ["1st-edition"],
+			thirdParty: {
+				cardmarket: 274672,
+				tcgplayer: 84656
+			}
 		}
 	]
 }

--- a/data/Neo/Neo Destiny/21.ts
+++ b/data/Neo/Neo Destiny/21.ts
@@ -87,18 +87,22 @@ const card: Card = {
 		fr: "Son sens aiguisé de l'odorat détecte la moindre odeur, même celle de la nourriture quand elle est enfouie profondément."
 	},
 
-	thirdParty: {
-		cardmarket: 274673,
-		tcgplayer: 84663
-	},
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				cardmarket: 274673,
+				tcgplayer: 84663
+			}
 		},
 		{
 			type: "normal",
-			stamp: ["1st-edition"]
+			stamp: ["1st-edition"],
+			thirdParty: {
+				cardmarket: 274673,
+				tcgplayer: 84663
+			}
 		}
 	]
 }

--- a/data/Neo/Neo Destiny/22.ts
+++ b/data/Neo/Neo Destiny/22.ts
@@ -85,18 +85,22 @@ const card: Card = {
 		fr: "L'aura qui enveloppe son corps a un effet sur la météo et le climat environnants."
 	},
 
-	thirdParty: {
-		cardmarket: 274674,
-		tcgplayer: 86737
-	},
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				cardmarket: 274674,
+				tcgplayer: 86737
+			}
 		},
 		{
 			type: "normal",
-			stamp: ["1st-edition"]
+			stamp: ["1st-edition"],
+			thirdParty: {
+				cardmarket: 274674,
+				tcgplayer: 86737
+			}
 		}
 	]
 }

--- a/data/Neo/Neo Destiny/23.ts
+++ b/data/Neo/Neo Destiny/23.ts
@@ -81,18 +81,22 @@ const card: Card = {
 		fr: "La nageoire dorsale de ce Pokémon a évolué pour émettre de la lumière, ce qui attire les poissons dont il se nourrit."
 	},
 
-	thirdParty: {
-		cardmarket: 274675,
-		tcgplayer: 86742
-	},
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				cardmarket: 274675,
+				tcgplayer: 86742
+			}
 		},
 		{
 			type: "normal",
-			stamp: ["1st-edition"]
+			stamp: ["1st-edition"],
+			thirdParty: {
+				cardmarket: 274675,
+				tcgplayer: 86742
+			}
 		}
 	]
 }

--- a/data/Neo/Neo Destiny/24.ts
+++ b/data/Neo/Neo Destiny/24.ts
@@ -87,18 +87,22 @@ const card: Card = {
 		fr: "Le nombre de taches sur son dos augmente ou diminue en fonction du nombre d'étoiles visibles dans le ciel nocturne."
 	},
 
-	thirdParty: {
-		cardmarket: 274676,
-		tcgplayer: 86743
-	},
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				cardmarket: 274676,
+				tcgplayer: 86743
+			}
 		},
 		{
 			type: "normal",
-			stamp: ["1st-edition"]
+			stamp: ["1st-edition"],
+			thirdParty: {
+				cardmarket: 274676,
+				tcgplayer: 86743
+			}
 		}
 	]
 }

--- a/data/Neo/Neo Destiny/25.ts
+++ b/data/Neo/Neo Destiny/25.ts
@@ -84,18 +84,22 @@ const card: Card = {
 		type: "Pokemon Power"
 	}],
 
-	thirdParty: {
-		cardmarket: 274677,
-		tcgplayer: 86744
-	},
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				cardmarket: 274677,
+				tcgplayer: 86744
+			}
 		},
 		{
 			type: "normal",
-			stamp: ["1st-edition"]
+			stamp: ["1st-edition"],
+			thirdParty: {
+				cardmarket: 274677,
+				tcgplayer: 86744
+			}
 		}
 	]
 }

--- a/data/Neo/Neo Destiny/26.ts
+++ b/data/Neo/Neo Destiny/26.ts
@@ -87,18 +87,22 @@ const card: Card = {
 		type: "Pokemon Power"
 	}],
 
-	thirdParty: {
-		cardmarket: 274678,
-		tcgplayer: 86747
-	},
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				cardmarket: 274678,
+				tcgplayer: 86747
+			}
 		},
 		{
 			type: "normal",
-			stamp: ["1st-edition"]
+			stamp: ["1st-edition"],
+			thirdParty: {
+				cardmarket: 274678,
+				tcgplayer: 86747
+			}
 		}
 	]
 }

--- a/data/Neo/Neo Destiny/27.ts
+++ b/data/Neo/Neo Destiny/27.ts
@@ -71,18 +71,22 @@ const card: Card = {
 		fr: "On pense que la variété des types de ce Pokémon particulier est le résultat d'une adaptation due à un caprice de l'évolution, chacun possédant une capacité différente."
 	},
 
-	thirdParty: {
-		cardmarket: 274679,
-		tcgplayer: 90209
-	},
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				cardmarket: 274679,
+				tcgplayer: 90209
+			}
 		},
 		{
 			type: "normal",
-			stamp: ["1st-edition"]
+			stamp: ["1st-edition"],
+			thirdParty: {
+				cardmarket: 274679,
+				tcgplayer: 90209
+			}
 		}
 	]
 }

--- a/data/Neo/Neo Destiny/28.ts
+++ b/data/Neo/Neo Destiny/28.ts
@@ -71,18 +71,22 @@ const card: Card = {
 		fr: "On pense que la variété des types de ce Pokémon particulier est le résultat d'une adaptation due à un caprice de l'évolution, chacun possédant une capacité différente."
 	},
 
-	thirdParty: {
-		cardmarket: 274680,
-		tcgplayer: 90211
-	},
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				cardmarket: 274680,
+				tcgplayer: 90211
+			}
 		},
 		{
 			type: "normal",
-			stamp: ["1st-edition"]
+			stamp: ["1st-edition"],
+			thirdParty: {
+				cardmarket: 274680,
+				tcgplayer: 90211
+			}
 		}
 	]
 }

--- a/data/Neo/Neo Destiny/29.ts
+++ b/data/Neo/Neo Destiny/29.ts
@@ -71,18 +71,22 @@ const card: Card = {
 		fr: "On pense que la variété des types de ce Pokémon particulier est le résultat d'une adaptation due à un caprice de l'évolution, chacun possédant une capacité différente."
 	},
 
-	thirdParty: {
-		cardmarket: 274681,
-		tcgplayer: 90240
-	},
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				cardmarket: 274681,
+				tcgplayer: 90240
+			}
 		},
 		{
 			type: "normal",
-			stamp: ["1st-edition"]
+			stamp: ["1st-edition"],
+			thirdParty: {
+				cardmarket: 274681,
+				tcgplayer: 90240
+			}
 		}
 	]
 }

--- a/data/Neo/Neo Destiny/3.ts
+++ b/data/Neo/Neo Destiny/3.ts
@@ -86,18 +86,22 @@ const card: Card = {
 		fr: "Plus ses défenses sont grosses, plus c'est un membre important du troupeau."
 	},
 
-	thirdParty: {
-		cardmarket: 274655,
-		tcgplayer: 84579
-	},
 
 	variants: [
 		{
-			type: "holo"
+			type: "holo",
+			thirdParty: {
+				cardmarket: 274655,
+				tcgplayer: 84579
+			}
 		},
 		{
 			type: "holo",
-			stamp: ["1st-edition"]
+			stamp: ["1st-edition"],
+			thirdParty: {
+				cardmarket: 274655,
+				tcgplayer: 84579
+			}
 		}
 	]
 }

--- a/data/Neo/Neo Destiny/30.ts
+++ b/data/Neo/Neo Destiny/30.ts
@@ -71,18 +71,22 @@ const card: Card = {
 		fr: "On pense que la variété des types de ce Pokémon particulier est le résultat d'une adaptation due à un caprice de l'évolution, chacun possédant une capacité différente."
 	},
 
-	thirdParty: {
-		cardmarket: 274682,
-		tcgplayer: 90242
-	},
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				cardmarket: 274682,
+				tcgplayer: 90242
+			}
 		},
 		{
 			type: "normal",
-			stamp: ["1st-edition"]
+			stamp: ["1st-edition"],
+			thirdParty: {
+				cardmarket: 274682,
+				tcgplayer: 90242
+			}
 		}
 	]
 }

--- a/data/Neo/Neo Destiny/31.ts
+++ b/data/Neo/Neo Destiny/31.ts
@@ -88,18 +88,22 @@ const card: Card = {
 		fr: "Il serre précautionneusement son œuf pour ne pas le casser quand il bouge. Cependant, il reste assez rapide pour disparaître en un clin d'œil."
 	},
 
-	thirdParty: {
-		cardmarket: 274683,
-		tcgplayer: 84170
-	},
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				cardmarket: 274683,
+				tcgplayer: 84170
+			}
 		},
 		{
 			type: "normal",
-			stamp: ["1st-edition"]
+			stamp: ["1st-edition"],
+			thirdParty: {
+				cardmarket: 274683,
+				tcgplayer: 84170
+			}
 		}
 	]
 }

--- a/data/Neo/Neo Destiny/32.ts
+++ b/data/Neo/Neo Destiny/32.ts
@@ -67,18 +67,22 @@ const card: Card = {
 		fr: "Il a 49 dents dans sa gueule qui se régénèrent constamment. Arrachez-en une et une nouvelle pousse à sa place."
 	},
 
-	thirdParty: {
-		cardmarket: 274684,
-		tcgplayer: 84578
-	},
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				cardmarket: 274684,
+				tcgplayer: 84578
+			}
 		},
 		{
 			type: "normal",
-			stamp: ["1st-edition"]
+			stamp: ["1st-edition"],
+			thirdParty: {
+				cardmarket: 274684,
+				tcgplayer: 84578
+			}
 		}
 	]
 }

--- a/data/Neo/Neo Destiny/33.ts
+++ b/data/Neo/Neo Destiny/33.ts
@@ -82,17 +82,20 @@ const card: Card = {
 		fr: "S'il perd une de ses deux têtes, il se transforme en Nœunœuf, qui part aussitôt à la recherche d'un autre Nœunœuf grâce à une forme spéciale de télépathie."
 	},
 
-	thirdParty: {
-		cardmarket: 274685
-	},
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				cardmarket: 274685
+			}
 		},
 		{
 			type: "normal",
-			stamp: ["1st-edition"]
+			stamp: ["1st-edition"],
+			thirdParty: {
+				cardmarket: 274685
+			}
 		}
 	]
 }

--- a/data/Neo/Neo Destiny/34.ts
+++ b/data/Neo/Neo Destiny/34.ts
@@ -82,18 +82,22 @@ const card: Card = {
 		fr: "À cause des énormes quantités d'électricité qu'il stocke, sa laine ne pousse plus à certains endroits de son corps."
 	},
 
-	thirdParty: {
-		cardmarket: 274686,
-		tcgplayer: 84595
-	},
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				cardmarket: 274686,
+				tcgplayer: 84595
+			}
 		},
 		{
 			type: "normal",
-			stamp: ["1st-edition"]
+			stamp: ["1st-edition"],
+			thirdParty: {
+				cardmarket: 274686,
+				tcgplayer: 84595
+			}
 		}
 	]
 }

--- a/data/Neo/Neo Destiny/35.ts
+++ b/data/Neo/Neo Destiny/35.ts
@@ -81,18 +81,22 @@ const card: Card = {
 		fr: "Il reste immobile dans les arbres et chasse les intrus en leur lançant des piquants blindés."
 	},
 
-	thirdParty: {
-		cardmarket: 274687,
-		tcgplayer: 84598
-	},
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				cardmarket: 274687,
+				tcgplayer: 84598
+			}
 		},
 		{
 			type: "normal",
-			stamp: ["1st-edition"]
+			stamp: ["1st-edition"],
+			thirdParty: {
+				cardmarket: 274687,
+				tcgplayer: 84598
+			}
 		}
 	]
 }

--- a/data/Neo/Neo Destiny/36.ts
+++ b/data/Neo/Neo Destiny/36.ts
@@ -79,18 +79,22 @@ const card: Card = {
 		fr: "Il chasse sa proie silencieusement dans les salles obscures."
 	},
 
-	thirdParty: {
-		cardmarket: 274688,
-		tcgplayer: 84609
-	},
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				cardmarket: 274688,
+				tcgplayer: 84609
+			}
 		},
 		{
 			type: "normal",
-			stamp: ["1st-edition"]
+			stamp: ["1st-edition"],
+			thirdParty: {
+				cardmarket: 274688,
+				tcgplayer: 84609
+			}
 		}
 	]
 }

--- a/data/Neo/Neo Destiny/37.ts
+++ b/data/Neo/Neo Destiny/37.ts
@@ -58,18 +58,22 @@ const card: Card = {
 		fr: "Ce Pokémon antique possédait 10 tentacules, qu'il utilisait pour nager dans l'océan."
 	},
 
-	thirdParty: {
-		cardmarket: 274689,
-		tcgplayer: 84634
-	},
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				cardmarket: 274689,
+				tcgplayer: 84634
+			}
 		},
 		{
 			type: "normal",
-			stamp: ["1st-edition"]
+			stamp: ["1st-edition"],
+			thirdParty: {
+				cardmarket: 274689,
+				tcgplayer: 84634
+			}
 		}
 	]
 }

--- a/data/Neo/Neo Destiny/38.ts
+++ b/data/Neo/Neo Destiny/38.ts
@@ -90,18 +90,22 @@ const card: Card = {
 		fr: "Il est protégé par une solide carapace, mais il garde une grande mobilité... Une combinaison dangereuse."
 	},
 
-	thirdParty: {
-		cardmarket: 274690,
-		tcgplayer: 84642
-	},
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				cardmarket: 274690,
+				tcgplayer: 84642
+			}
 		},
 		{
 			type: "normal",
-			stamp: ["1st-edition"]
+			stamp: ["1st-edition"],
+			thirdParty: {
+				cardmarket: 274690,
+				tcgplayer: 84642
+			}
 		}
 	]
 }

--- a/data/Neo/Neo Destiny/39.ts
+++ b/data/Neo/Neo Destiny/39.ts
@@ -83,18 +83,22 @@ const card: Card = {
 		fr: "S'il tourne le dos à son adversaire, c'est signe qu'il se prépare à attaquer."
 	},
 
-	thirdParty: {
-		cardmarket: 274691,
-		tcgplayer: 84645
-	},
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				cardmarket: 274691,
+				tcgplayer: 84645
+			}
 		},
 		{
 			type: "normal",
-			stamp: ["1st-edition"]
+			stamp: ["1st-edition"],
+			thirdParty: {
+				cardmarket: 274691,
+				tcgplayer: 84645
+			}
 		}
 	]
 }

--- a/data/Neo/Neo Destiny/4.ts
+++ b/data/Neo/Neo Destiny/4.ts
@@ -80,18 +80,22 @@ const card: Card = {
 		fr: "La double extrémité de sa queue s'agite quand il utilise ses pouvoirs psychiques pour deviner quelle sera la prochaine action de son adversaire."
 	},
 
-	thirdParty: {
-		cardmarket: 274656,
-		tcgplayer: 84592
-	},
 
 	variants: [
 		{
-			type: "holo"
+			type: "holo",
+			thirdParty: {
+				cardmarket: 274656,
+				tcgplayer: 84592
+			}
 		},
 		{
 			type: "holo",
-			stamp: ["1st-edition"]
+			stamp: ["1st-edition"],
+			thirdParty: {
+				cardmarket: 274656,
+				tcgplayer: 84592
+			}
 		}
 	]
 }

--- a/data/Neo/Neo Destiny/40.ts
+++ b/data/Neo/Neo Destiny/40.ts
@@ -90,18 +90,22 @@ const card: Card = {
 		fr: "Ce Pokémon a des poils fins et soyeux. Quand il se met en colère, il grossit et il n'est pas impossible qu'il charge ceux qu'il considère comme une menace."
 	},
 
-	thirdParty: {
-		cardmarket: 274692,
-		tcgplayer: 84674
-	},
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				cardmarket: 274692,
+				tcgplayer: 84674
+			}
 		},
 		{
 			type: "normal",
-			stamp: ["1st-edition"]
+			stamp: ["1st-edition"],
+			thirdParty: {
+				cardmarket: 274692,
+				tcgplayer: 84674
+			}
 		}
 	]
 }

--- a/data/Neo/Neo Destiny/41.ts
+++ b/data/Neo/Neo Destiny/41.ts
@@ -75,18 +75,22 @@ const card: Card = {
 		fr: "Généralement, il est pacifique, mais il attaquera tous ceux qui s'interposeront entre lui et son miel, sa nourriture préférée."
 	},
 
-	thirdParty: {
-		cardmarket: 274693,
-		tcgplayer: 86060
-	},
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				cardmarket: 274693,
+				tcgplayer: 86060
+			}
 		},
 		{
 			type: "normal",
-			stamp: ["1st-edition"]
+			stamp: ["1st-edition"],
+			thirdParty: {
+				cardmarket: 274693,
+				tcgplayer: 86060
+			}
 		}
 	]
 }

--- a/data/Neo/Neo Destiny/42.ts
+++ b/data/Neo/Neo Destiny/42.ts
@@ -81,18 +81,22 @@ const card: Card = {
 		fr: "Il a un sens parfait de l'équilibre et peut donner des coups puissants dans n'importe quelle position."
 	},
 
-	thirdParty: {
-		cardmarket: 274694,
-		tcgplayer: 86103
-	},
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				cardmarket: 274694,
+				tcgplayer: 86103
+			}
 		},
 		{
 			type: "normal",
-			stamp: ["1st-edition"]
+			stamp: ["1st-edition"],
+			thirdParty: {
+				cardmarket: 274694,
+				tcgplayer: 86103
+			}
 		}
 	]
 }

--- a/data/Neo/Neo Destiny/43.ts
+++ b/data/Neo/Neo Destiny/43.ts
@@ -78,18 +78,22 @@ const card: Card = {
 		fr: "Quand la nuit tombe, les hurlements sinistres de ce Pokémon retentissent dans le silence tandis qu'il chasse sur son territoire."
 	},
 
-	thirdParty: {
-		cardmarket: 274695,
-		tcgplayer: 86219
-	},
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				cardmarket: 274695,
+				tcgplayer: 86219
+			}
 		},
 		{
 			type: "normal",
-			stamp: ["1st-edition"]
+			stamp: ["1st-edition"],
+			thirdParty: {
+				cardmarket: 274695,
+				tcgplayer: 86219
+			}
 		}
 	]
 }

--- a/data/Neo/Neo Destiny/44.ts
+++ b/data/Neo/Neo Destiny/44.ts
@@ -67,18 +67,22 @@ const card: Card = {
 		fr: "Il gonfle son corps comme un ballon et chante une berceuse qui fait sombrer tous ceux qui l'entendent dans un profond sommeil."
 	},
 
-	thirdParty: {
-		cardmarket: 274696,
-		tcgplayer: 86311
-	},
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				cardmarket: 274696,
+				tcgplayer: 86311
+			}
 		},
 		{
 			type: "normal",
-			stamp: ["1st-edition"]
+			stamp: ["1st-edition"],
+			thirdParty: {
+				cardmarket: 274696,
+				tcgplayer: 86311
+			}
 		}
 	]
 }

--- a/data/Neo/Neo Destiny/45.ts
+++ b/data/Neo/Neo Destiny/45.ts
@@ -84,18 +84,22 @@ const card: Card = {
 		fr: "Il a une forme aérodynamique qui lui permet de nager à de grandes vitesses. Plus l'eau est froide, plus il est actif."
 	},
 
-	thirdParty: {
-		cardmarket: 274697,
-		tcgplayer: 86736
-	},
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				cardmarket: 274697,
+				tcgplayer: 86736
+			}
 		},
 		{
 			type: "normal",
-			stamp: ["1st-edition"]
+			stamp: ["1st-edition"],
+			thirdParty: {
+				cardmarket: 274697,
+				tcgplayer: 86736
+			}
 		}
 	]
 }

--- a/data/Neo/Neo Destiny/46.ts
+++ b/data/Neo/Neo Destiny/46.ts
@@ -82,18 +82,22 @@ const card: Card = {
 		fr: "Il crée ses flammes en inspirant l'air dans une poche spéciale de son corps et en le chauffant à plus de 3000 degrés."
 	},
 
-	thirdParty: {
-		cardmarket: 274698,
-		tcgplayer: 86739
-	},
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				cardmarket: 274698,
+				tcgplayer: 86739
+			}
 		},
 		{
 			type: "normal",
-			stamp: ["1st-edition"]
+			stamp: ["1st-edition"],
+			thirdParty: {
+				cardmarket: 274698,
+				tcgplayer: 86739
+			}
 		}
 	]
 }

--- a/data/Neo/Neo Destiny/47.ts
+++ b/data/Neo/Neo Destiny/47.ts
@@ -82,18 +82,22 @@ const card: Card = {
 		fr: "Plus il nage vite, plus l'aura sur son front brille."
 	},
 
-	thirdParty: {
-		cardmarket: 274699,
-		tcgplayer: 86740
-	},
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				cardmarket: 274699,
+				tcgplayer: 86740
+			}
 		},
 		{
 			type: "normal",
-			stamp: ["1st-edition"]
+			stamp: ["1st-edition"],
+			thirdParty: {
+				cardmarket: 274699,
+				tcgplayer: 86740
+			}
 		}
 	]
 }

--- a/data/Neo/Neo Destiny/48.ts
+++ b/data/Neo/Neo Destiny/48.ts
@@ -80,18 +80,22 @@ const card: Card = {
 		fr: "Il peut stocker l'énergie électrique ambiante dans ses cellules et l'expulser sous forme d'explosions massives."
 	},
 
-	thirdParty: {
-		cardmarket: 274700,
-		tcgplayer: 86741
-	},
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				cardmarket: 274700,
+				tcgplayer: 86741
+			}
 		},
 		{
 			type: "normal",
-			stamp: ["1st-edition"]
+			stamp: ["1st-edition"],
+			thirdParty: {
+				cardmarket: 274700,
+				tcgplayer: 86741
+			}
 		}
 	]
 }

--- a/data/Neo/Neo Destiny/49.ts
+++ b/data/Neo/Neo Destiny/49.ts
@@ -83,18 +83,22 @@ const card: Card = {
 		fr: "Ce Pokémon ne se fatigue jamais, quoi qu'il fasse, même s'il s'entraîne dur."
 	},
 
-	thirdParty: {
-		cardmarket: 274701,
-		tcgplayer: 86745
-	},
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				cardmarket: 274701,
+				tcgplayer: 86745
+			}
 		},
 		{
 			type: "normal",
-			stamp: ["1st-edition"]
+			stamp: ["1st-edition"],
+			thirdParty: {
+				cardmarket: 274701,
+				tcgplayer: 86745
+			}
 		}
 	]
 }

--- a/data/Neo/Neo Destiny/5.ts
+++ b/data/Neo/Neo Destiny/5.ts
@@ -82,18 +82,22 @@ const card: Card = {
 		fr: "Ses muscles surpuissants lui permettent de se déplacer très vite et ce, malgré sa forte corpulence."
 	},
 
-	thirdParty: {
-		cardmarket: 274657,
-		tcgplayer: 84594
-	},
 
 	variants: [
 		{
-			type: "holo"
+			type: "holo",
+			thirdParty: {
+				cardmarket: 274657,
+				tcgplayer: 84594
+			}
 		},
 		{
 			type: "holo",
-			stamp: ["1st-edition"]
+			stamp: ["1st-edition"],
+			thirdParty: {
+				cardmarket: 274657,
+				tcgplayer: 84594
+			}
 		}
 	]
 }

--- a/data/Neo/Neo Destiny/50.ts
+++ b/data/Neo/Neo Destiny/50.ts
@@ -83,18 +83,22 @@ const card: Card = {
 		fr: "On dit que chacune de ses neuf queues renferme un pouvoir magique différent."
 	},
 
-	thirdParty: {
-		cardmarket: 274702,
-		tcgplayer: 86746
-	},
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				cardmarket: 274702,
+				tcgplayer: 86746
+			}
 		},
 		{
 			type: "normal",
-			stamp: ["1st-edition"]
+			stamp: ["1st-edition"],
+			thirdParty: {
+				cardmarket: 274702,
+				tcgplayer: 86746
+			}
 		}
 	]
 }

--- a/data/Neo/Neo Destiny/51.ts
+++ b/data/Neo/Neo Destiny/51.ts
@@ -81,18 +81,22 @@ const card: Card = {
 		fr: "Si le Kokyias attaché à sa queue se défait, ce Pokémon redevient un Ramoloss normal."
 	},
 
-	thirdParty: {
-		cardmarket: 274703,
-		tcgplayer: 86748
-	},
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				cardmarket: 274703,
+				tcgplayer: 86748
+			}
 		},
 		{
 			type: "normal",
-			stamp: ["1st-edition"]
+			stamp: ["1st-edition"],
+			thirdParty: {
+				cardmarket: 274703,
+				tcgplayer: 86748
+			}
 		}
 	]
 }

--- a/data/Neo/Neo Destiny/52.ts
+++ b/data/Neo/Neo Destiny/52.ts
@@ -82,18 +82,22 @@ const card: Card = {
 		fr: "Si sa nageoire commence à vibrer, c'est signe qu'il va bientôt pleuvoir."
 	},
 
-	thirdParty: {
-		cardmarket: 274704,
-		tcgplayer: 86751
-	},
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				cardmarket: 274704,
+				tcgplayer: 86751
+			}
 		},
 		{
 			type: "normal",
-			stamp: ["1st-edition"]
+			stamp: ["1st-edition"],
+			thirdParty: {
+				cardmarket: 274704,
+				tcgplayer: 86751
+			}
 		}
 	]
 }

--- a/data/Neo/Neo Destiny/53.ts
+++ b/data/Neo/Neo Destiny/53.ts
@@ -86,18 +86,22 @@ const card: Card = {
 		fr: "Il se défend en battant des ailes à toute vitesse, libérant une poudre empoisonnée dans les airs."
 	},
 
-	thirdParty: {
-		cardmarket: 274705,
-		tcgplayer: 86752
-	},
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				cardmarket: 274705,
+				tcgplayer: 86752
+			}
 		},
 		{
 			type: "normal",
-			stamp: ["1st-edition"]
+			stamp: ["1st-edition"],
+			thirdParty: {
+				cardmarket: 274705,
+				tcgplayer: 86752
+			}
 		}
 	]
 }

--- a/data/Neo/Neo Destiny/54.ts
+++ b/data/Neo/Neo Destiny/54.ts
@@ -89,18 +89,22 @@ const card: Card = {
 		fr: "Si deux d'entre eux se frottent l'un contre l'autre, ils ne peuvent plus se séparer. Ils aiment trop sentir la douceur de la fourrure l'un de l'autre."
 	},
 
-	thirdParty: {
-		cardmarket: 274706,
-		tcgplayer: 86753
-	},
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				cardmarket: 274706,
+				tcgplayer: 86753
+			}
 		},
 		{
 			type: "normal",
-			stamp: ["1st-edition"]
+			stamp: ["1st-edition"],
+			thirdParty: {
+				cardmarket: 274706,
+				tcgplayer: 86753
+			}
 		}
 	]
 }

--- a/data/Neo/Neo Destiny/55.ts
+++ b/data/Neo/Neo Destiny/55.ts
@@ -82,18 +82,22 @@ const card: Card = {
 		fr: "Il se déplace si vite qu'il est invisible à l'oeil nu. Même quand il est immobile, son camouflage lui permet de ne pas être vu."
 	},
 
-	thirdParty: {
-		cardmarket: 274707,
-		tcgplayer: 88995
-	},
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				cardmarket: 274707,
+				tcgplayer: 88995
+			}
 		},
 		{
 			type: "normal",
-			stamp: ["1st-edition"]
+			stamp: ["1st-edition"],
+			thirdParty: {
+				cardmarket: 274707,
+				tcgplayer: 88995
+			}
 		}
 	]
 }

--- a/data/Neo/Neo Destiny/56.ts
+++ b/data/Neo/Neo Destiny/56.ts
@@ -76,18 +76,22 @@ const card: Card = {
 		fr: "On raconte que sa coquille est pleine de bonheur, qu'il partage avec tous ceux qui sont gentils avec lui."
 	},
 
-	thirdParty: {
-		cardmarket: 274708,
-		tcgplayer: 89930
-	},
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				cardmarket: 274708,
+				tcgplayer: 89930
+			}
 		},
 		{
 			type: "normal",
-			stamp: ["1st-edition"]
+			stamp: ["1st-edition"],
+			thirdParty: {
+				cardmarket: 274708,
+				tcgplayer: 89930
+			}
 		}
 	]
 }

--- a/data/Neo/Neo Destiny/57.ts
+++ b/data/Neo/Neo Destiny/57.ts
@@ -71,18 +71,22 @@ const card: Card = {
 		fr: "On pense que la variété des types de ce Pokémon particulier est le résultat d'une adaptation due à un caprice de l'évolution, chacun possédant une capacité différente."
 	},
 
-	thirdParty: {
-		cardmarket: 274709,
-		tcgplayer: 90201
-	},
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				cardmarket: 274709,
+				tcgplayer: 90201
+			}
 		},
 		{
 			type: "normal",
-			stamp: ["1st-edition"]
+			stamp: ["1st-edition"],
+			thirdParty: {
+				cardmarket: 274709,
+				tcgplayer: 90201
+			}
 		}
 	]
 }

--- a/data/Neo/Neo Destiny/58.ts
+++ b/data/Neo/Neo Destiny/58.ts
@@ -69,18 +69,22 @@ const card: Card = {
 		type: "Pokemon Power"
 	}],
 
-	thirdParty: {
-		cardmarket: 274710,
-		tcgplayer: 90227
-	},
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				cardmarket: 274710,
+				tcgplayer: 90227
+			}
 		},
 		{
 			type: "normal",
-			stamp: ["1st-edition"]
+			stamp: ["1st-edition"],
+			thirdParty: {
+				cardmarket: 274710,
+				tcgplayer: 90227
+			}
 		}
 	]
 }

--- a/data/Neo/Neo Destiny/59.ts
+++ b/data/Neo/Neo Destiny/59.ts
@@ -71,18 +71,22 @@ const card: Card = {
 		fr: "On pense que la variété des types de ce Pokémon particulier est le résultat d'une adaptation due à un caprice de l'évolution, chacun possédant une capacité différente."
 	},
 
-	thirdParty: {
-		cardmarket: 274711,
-		tcgplayer: 90229
-	},
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				cardmarket: 274711,
+				tcgplayer: 90229
+			}
 		},
 		{
 			type: "normal",
-			stamp: ["1st-edition"]
+			stamp: ["1st-edition"],
+			thirdParty: {
+				cardmarket: 274711,
+				tcgplayer: 90229
+			}
 		}
 	]
 }

--- a/data/Neo/Neo Destiny/6.ts
+++ b/data/Neo/Neo Destiny/6.ts
@@ -82,18 +82,22 @@ const card: Card = {
 		fr: "Il absorbe la chaleur de l'air autour de lui. Si vous avez soudain très froid, c'est qu'un Ectoplasma vient d'apparaître."
 	},
 
-	thirdParty: {
-		cardmarket: 274658,
-		tcgplayer: 84599
-	},
 
 	variants: [
 		{
-			type: "holo"
+			type: "holo",
+			thirdParty: {
+				cardmarket: 274658,
+				tcgplayer: 84599
+			}
 		},
 		{
 			type: "holo",
-			stamp: ["1st-edition"]
+			stamp: ["1st-edition"],
+			thirdParty: {
+				cardmarket: 274658,
+				tcgplayer: 84599
+			}
 		}
 	]
 }

--- a/data/Neo/Neo Destiny/60.ts
+++ b/data/Neo/Neo Destiny/60.ts
@@ -71,18 +71,22 @@ const card: Card = {
 		fr: "On pense que la variété des types de ce Pokémon particulier est le résultat d'une adaptation due à un caprice de l'évolution, chacun possédant une capacité différente."
 	},
 
-	thirdParty: {
-		cardmarket: 274712,
-		tcgplayer: 90246
-	},
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				cardmarket: 274712,
+				tcgplayer: 90246
+			}
 		},
 		{
 			type: "normal",
-			stamp: ["1st-edition"]
+			stamp: ["1st-edition"],
+			thirdParty: {
+				cardmarket: 274712,
+				tcgplayer: 90246
+			}
 		}
 	]
 }

--- a/data/Neo/Neo Destiny/61.ts
+++ b/data/Neo/Neo Destiny/61.ts
@@ -59,18 +59,22 @@ const card: Card = {
 		fr: "Il est très timide et il est souvent sur la défensive. Quand il se sent menacé, il se protège avec les flammes de son dos."
 	},
 
-	thirdParty: {
-		cardmarket: 274713,
-		tcgplayer: 84546
-	},
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				cardmarket: 274713,
+				tcgplayer: 84546
+			}
 		},
 		{
 			type: "normal",
-			stamp: ["1st-edition"]
+			stamp: ["1st-edition"],
+			thirdParty: {
+				cardmarket: 274713,
+				tcgplayer: 84546
+			}
 		}
 	]
 }

--- a/data/Neo/Neo Destiny/62.ts
+++ b/data/Neo/Neo Destiny/62.ts
@@ -82,18 +82,22 @@ const card: Card = {
 		fr: "Il aime dormir dans les cavernes sous-marines et il lui arrive même de voler le nid d'un autre Octillery."
 	},
 
-	thirdParty: {
-		cardmarket: 274714,
-		tcgplayer: 84632
-	},
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				cardmarket: 274714,
+				tcgplayer: 84632
+			}
 		},
 		{
 			type: "normal",
-			stamp: ["1st-edition"]
+			stamp: ["1st-edition"],
+			thirdParty: {
+				cardmarket: 274714,
+				tcgplayer: 84632
+			}
 		}
 	]
 }

--- a/data/Neo/Neo Destiny/63.ts
+++ b/data/Neo/Neo Destiny/63.ts
@@ -75,18 +75,22 @@ const card: Card = {
 		fr: "Grand dès sa naissance, ce Pokémon augmente de taille durant sa vie en changeant régulièrement de peau."
 	},
 
-	thirdParty: {
-		cardmarket: 274715,
-		tcgplayer: 84929
-	},
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				cardmarket: 274715,
+				tcgplayer: 84929
+			}
 		},
 		{
 			type: "normal",
-			stamp: ["1st-edition"]
+			stamp: ["1st-edition"],
+			thirdParty: {
+				cardmarket: 274715,
+				tcgplayer: 84929
+			}
 		}
 	]
 }

--- a/data/Neo/Neo Destiny/64.ts
+++ b/data/Neo/Neo Destiny/64.ts
@@ -76,18 +76,22 @@ const card: Card = {
 		fr: "Sa coquille est très solide. Elle lui permet de survivre même si elle est fissurée."
 	},
 
-	thirdParty: {
-		cardmarket: 274716,
-		tcgplayer: 85342
-	},
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				cardmarket: 274716,
+				tcgplayer: 85342
+			}
 		},
 		{
 			type: "normal",
-			stamp: ["1st-edition"]
+			stamp: ["1st-edition"],
+			thirdParty: {
+				cardmarket: 274716,
+				tcgplayer: 85342
+			}
 		}
 	]
 }

--- a/data/Neo/Neo Destiny/65.ts
+++ b/data/Neo/Neo Destiny/65.ts
@@ -57,18 +57,22 @@ const card: Card = {
 		fr: "Son corps gazeux lui permet de se faufiler là où il veut, mais il le rend aussi vulnérable aux rafales de vent."
 	},
 
-	thirdParty: {
-		cardmarket: 274717,
-		tcgplayer: 85647
-	},
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				cardmarket: 274717,
+				tcgplayer: 85647
+			}
 		},
 		{
 			type: "normal",
-			stamp: ["1st-edition"]
+			stamp: ["1st-edition"],
+			thirdParty: {
+				cardmarket: 274717,
+				tcgplayer: 85647
+			}
 		}
 	]
 }

--- a/data/Neo/Neo Destiny/66.ts
+++ b/data/Neo/Neo Destiny/66.ts
@@ -71,18 +71,22 @@ const card: Card = {
 		fr: "Sa queue a sa vie propre. Elle réagit à ce qui l'entoure. Bon nombre de personnes ne se méfiant pas se sont fait mordre."
 	},
 
-	thirdParty: {
-		cardmarket: 274718,
-		tcgplayer: 85728
-	},
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				cardmarket: 274718,
+				tcgplayer: 85728
+			}
 		},
 		{
 			type: "normal",
-			stamp: ["1st-edition"]
+			stamp: ["1st-edition"],
+			thirdParty: {
+				cardmarket: 274718,
+				tcgplayer: 85728
+			}
 		}
 	]
 }

--- a/data/Neo/Neo Destiny/67.ts
+++ b/data/Neo/Neo Destiny/67.ts
@@ -67,18 +67,22 @@ const card: Card = {
 		fr: "Il passe ses journées accroché aux falaises, attendant de fondre sur sa proie depuis son poste d'observation."
 	},
 
-	thirdParty: {
-		cardmarket: 274719,
-		tcgplayer: 85762
-	},
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				cardmarket: 274719,
+				tcgplayer: 85762
+			}
 		},
 		{
 			type: "normal",
-			stamp: ["1st-edition"]
+			stamp: ["1st-edition"],
+			thirdParty: {
+				cardmarket: 274719,
+				tcgplayer: 85762
+			}
 		}
 	]
 }

--- a/data/Neo/Neo Destiny/68.ts
+++ b/data/Neo/Neo Destiny/68.ts
@@ -56,18 +56,22 @@ const card: Card = {
 		fr: "Il n'a peur de rien, pas même d'adversaires plus grands que lui."
 	},
 
-	thirdParty: {
-		cardmarket: 274720,
-		tcgplayer: 85952
-	},
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				cardmarket: 274720,
+				tcgplayer: 85952
+			}
 		},
 		{
 			type: "normal",
-			stamp: ["1st-edition"]
+			stamp: ["1st-edition"],
+			thirdParty: {
+				cardmarket: 274720,
+				tcgplayer: 85952
+			}
 		}
 	]
 }

--- a/data/Neo/Neo Destiny/69.ts
+++ b/data/Neo/Neo Destiny/69.ts
@@ -73,18 +73,22 @@ const card: Card = {
 		fr: "Ses coups sont super rapides, mais il ne peut se battre que pendant trois minutes avant qu'il ne soit fatigué et qu'il ne soit obligé de se reposer."
 	},
 
-	thirdParty: {
-		cardmarket: 274721,
-		tcgplayer: 86090
-	},
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				cardmarket: 274721,
+				tcgplayer: 86090
+			}
 		},
 		{
 			type: "normal",
-			stamp: ["1st-edition"]
+			stamp: ["1st-edition"],
+			thirdParty: {
+				cardmarket: 274721,
+				tcgplayer: 86090
+			}
 		}
 	]
 }

--- a/data/Neo/Neo Destiny/7.ts
+++ b/data/Neo/Neo Destiny/7.ts
@@ -81,18 +81,22 @@ const card: Card = {
 		fr: "Les flammes qu'il crache sont en fait un poison qu'il sécrète et qui s'enflamme au contact de l'air."
 	},
 
-	thirdParty: {
-		cardmarket: 274659,
-		tcgplayer: 84610
-	},
 
 	variants: [
 		{
-			type: "holo"
+			type: "holo",
+			thirdParty: {
+				cardmarket: 274659,
+				tcgplayer: 84610
+			}
 		},
 		{
 			type: "holo",
-			stamp: ["1st-edition"]
+			stamp: ["1st-edition"],
+			thirdParty: {
+				cardmarket: 274659,
+				tcgplayer: 84610
+			}
 		}
 	]
 }

--- a/data/Neo/Neo Destiny/70.ts
+++ b/data/Neo/Neo Destiny/70.ts
@@ -79,18 +79,22 @@ const card: Card = {
 		fr: "Il est né dans les profondeurs de la terre et il doit creuser pour sortir à l'air libre."
 	},
 
-	thirdParty: {
-		cardmarket: 274722,
-		tcgplayer: 86633
-	},
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				cardmarket: 274722,
+				tcgplayer: 86633
+			}
 		},
 		{
 			type: "normal",
-			stamp: ["1st-edition"]
+			stamp: ["1st-edition"],
+			thirdParty: {
+				cardmarket: 274722,
+				tcgplayer: 86633
+			}
 		}
 	]
 }

--- a/data/Neo/Neo Destiny/71.ts
+++ b/data/Neo/Neo Destiny/71.ts
@@ -65,18 +65,22 @@ const card: Card = {
 		fr: "Sensibles au froid, les Coxy se rassemblent en groupes pour partager leur chaleur quand la température descend dangereusement."
 	},
 
-	thirdParty: {
-		cardmarket: 274723,
-		tcgplayer: 86700
-	},
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				cardmarket: 274723,
+				tcgplayer: 86700
+			}
 		},
 		{
 			type: "normal",
-			stamp: ["1st-edition"]
+			stamp: ["1st-edition"],
+			thirdParty: {
+				cardmarket: 274723,
+				tcgplayer: 86700
+			}
 		}
 	]
 }

--- a/data/Neo/Neo Destiny/72.ts
+++ b/data/Neo/Neo Destiny/72.ts
@@ -79,18 +79,22 @@ const card: Card = {
 		fr: "Bien qu'extrêmement actif durant la journée, il cesse de bouger dès que le soleil se couche."
 	},
 
-	thirdParty: {
-		cardmarket: 274724,
-		tcgplayer: 86749
-	},
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				cardmarket: 274724,
+				tcgplayer: 86749
+			}
 		},
 		{
 			type: "normal",
-			stamp: ["1st-edition"]
+			stamp: ["1st-edition"],
+			thirdParty: {
+				cardmarket: 274724,
+				tcgplayer: 86749
+			}
 		}
 	]
 }

--- a/data/Neo/Neo Destiny/73.ts
+++ b/data/Neo/Neo Destiny/73.ts
@@ -69,18 +69,22 @@ const card: Card = {
 		fr: "Quand il s'ennuie, ce Pokémon super fort s'entraîne en soulevant des rochers."
 	},
 
-	thirdParty: {
-		cardmarket: 274725,
-		tcgplayer: 86988
-	},
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				cardmarket: 274725,
+				tcgplayer: 86988
+			}
 		},
 		{
 			type: "normal",
-			stamp: ["1st-edition"]
+			stamp: ["1st-edition"],
+			thirdParty: {
+				cardmarket: 274725,
+				tcgplayer: 86988
+			}
 		}
 	]
 }

--- a/data/Neo/Neo Destiny/74.ts
+++ b/data/Neo/Neo Destiny/74.ts
@@ -67,18 +67,22 @@ const card: Card = {
 		fr: "Ce Pokémon est parfaitement adapté au milieu océanique. Il peut accumuler suffisamment de vitesse pour bondir hors de l'eau comme une baleine."
 	},
 
-	thirdParty: {
-		cardmarket: 274726,
-		tcgplayer: 87180
-	},
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				cardmarket: 274726,
+				tcgplayer: 87180
+			}
 		},
 		{
 			type: "normal",
-			stamp: ["1st-edition"]
+			stamp: ["1st-edition"],
+			thirdParty: {
+				cardmarket: 274726,
+				tcgplayer: 87180
+			}
 		}
 	]
 }

--- a/data/Neo/Neo Destiny/75.ts
+++ b/data/Neo/Neo Destiny/75.ts
@@ -55,18 +55,22 @@ const card: Card = {
 		fr: "Sa douce laine capture l'air ambiant, ce qui lui permet de rester frais en été et chaud en hiver."
 	},
 
-	thirdParty: {
-		cardmarket: 274727,
-		tcgplayer: 87194
-	},
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				cardmarket: 274727,
+				tcgplayer: 87194
+			}
 		},
 		{
 			type: "normal",
-			stamp: ["1st-edition"]
+			stamp: ["1st-edition"],
+			thirdParty: {
+				cardmarket: 274727,
+				tcgplayer: 87194
+			}
 		}
 	]
 }

--- a/data/Neo/Neo Destiny/76.ts
+++ b/data/Neo/Neo Destiny/76.ts
@@ -66,18 +66,22 @@ const card: Card = {
 		fr: "Il frappe les gens avec sa trompe en signe d'affection mais il ne connaît pas sa force ; et parfois, il frappe un peu trop fort..."
 	},
 
-	thirdParty: {
-		cardmarket: 274728,
-		tcgplayer: 87997
-	},
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				cardmarket: 274728,
+				tcgplayer: 87997
+			}
 		},
 		{
 			type: "normal",
-			stamp: ["1st-edition"]
+			stamp: ["1st-edition"],
+			thirdParty: {
+				cardmarket: 274728,
+				tcgplayer: 87997
+			}
 		}
 	]
 }

--- a/data/Neo/Neo Destiny/77.ts
+++ b/data/Neo/Neo Destiny/77.ts
@@ -56,18 +56,22 @@ const card: Card = {
 		fr: "Il attend, suspendu à des branches d'arbre que des insectes volent dans sa gueule. Souvent, il reste immobile pendant des heures."
 	},
 
-	thirdParty: {
-		cardmarket: 274729,
-		tcgplayer: 88123
-	},
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				cardmarket: 274729,
+				tcgplayer: 88123
+			}
 		},
 		{
 			type: "normal",
-			stamp: ["1st-edition"]
+			stamp: ["1st-edition"],
+			thirdParty: {
+				cardmarket: 274729,
+				tcgplayer: 88123
+			}
 		}
 	]
 }

--- a/data/Neo/Neo Destiny/78.ts
+++ b/data/Neo/Neo Destiny/78.ts
@@ -63,18 +63,22 @@ const card: Card = {
 		fr: "Ce Pokémon est le résultat de recherches informatiques. Son programme n'est capable que d'actions et de réactions simples."
 	},
 
-	thirdParty: {
-		cardmarket: 274730,
-		tcgplayer: 88305
-	},
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				cardmarket: 274730,
+				tcgplayer: 88305
+			}
 		},
 		{
 			type: "normal",
-			stamp: ["1st-edition"]
+			stamp: ["1st-edition"],
+			thirdParty: {
+				cardmarket: 274730,
+				tcgplayer: 88305
+			}
 		}
 	]
 }

--- a/data/Neo/Neo Destiny/79.ts
+++ b/data/Neo/Neo Destiny/79.ts
@@ -73,18 +73,22 @@ const card: Card = {
 		fr: "Bien que possédant d'immenses pouvoirs mentaux, il ne sait pas les utiliser."
 	},
 
-	thirdParty: {
-		cardmarket: 274731,
-		tcgplayer: 88433
-	},
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				cardmarket: 274731,
+				tcgplayer: 88433
+			}
 		},
 		{
 			type: "normal",
-			stamp: ["1st-edition"]
+			stamp: ["1st-edition"],
+			thirdParty: {
+				cardmarket: 274731,
+				tcgplayer: 88433
+			}
 		}
 	]
 }

--- a/data/Neo/Neo Destiny/8.ts
+++ b/data/Neo/Neo Destiny/8.ts
@@ -89,18 +89,22 @@ const card: Card = {
 		fr: "Les progrès de la technologie lui ont permis d'évoluer. Parfois, il affiche un comportement qui n'a pas été inclus dans sa programmation."
 	},
 
-	thirdParty: {
-		cardmarket: 274660,
-		tcgplayer: 84640
-	},
 
 	variants: [
 		{
-			type: "holo"
+			type: "holo",
+			thirdParty: {
+				cardmarket: 274660,
+				tcgplayer: 84640
+			}
 		},
 		{
 			type: "holo",
-			stamp: ["1st-edition"]
+			stamp: ["1st-edition"],
+			thirdParty: {
+				cardmarket: 274660,
+				tcgplayer: 84640
+			}
 		}
 	]
 }

--- a/data/Neo/Neo Destiny/80.ts
+++ b/data/Neo/Neo Destiny/80.ts
@@ -57,18 +57,22 @@ const card: Card = {
 		fr: "Il peut lancer de l'eau avec sa gueule pour se propulser en arrière à grande vitesse, ce qui lui permet d'échapper à ses ennemis."
 	},
 
-	thirdParty: {
-		cardmarket: 274732,
-		tcgplayer: 88693
-	},
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				cardmarket: 274732,
+				tcgplayer: 88693
+			}
 		},
 		{
 			type: "normal",
-			stamp: ["1st-edition"]
+			stamp: ["1st-edition"],
+			thirdParty: {
+				cardmarket: 274732,
+				tcgplayer: 88693
+			}
 		}
 	]
 }

--- a/data/Neo/Neo Destiny/81.ts
+++ b/data/Neo/Neo Destiny/81.ts
@@ -60,18 +60,22 @@ const card: Card = {
 		fr: "Bien que peu doué pour marcher sur la terre ferme, il se déplace avec aisance dans ses eaux natales de l'Arctique."
 	},
 
-	thirdParty: {
-		cardmarket: 274733,
-		tcgplayer: 89048
-	},
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				cardmarket: 274733,
+				tcgplayer: 89048
+			}
 		},
 		{
 			type: "normal",
-			stamp: ["1st-edition"]
+			stamp: ["1st-edition"],
+			thirdParty: {
+				cardmarket: 274733,
+				tcgplayer: 89048
+			}
 		}
 	]
 }

--- a/data/Neo/Neo Destiny/82.ts
+++ b/data/Neo/Neo Destiny/82.ts
@@ -56,18 +56,22 @@ const card: Card = {
 		fr: "On voit souvent ce Pokémon ramper dans les régions volcaniques."
 	},
 
-	thirdParty: {
-		cardmarket: 274734,
-		tcgplayer: 89337
-	},
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				cardmarket: 274734,
+				tcgplayer: 89337
+			}
 		},
 		{
 			type: "normal",
-			stamp: ["1st-edition"]
+			stamp: ["1st-edition"],
+			thirdParty: {
+				cardmarket: 274734,
+				tcgplayer: 89337
+			}
 		}
 	]
 }

--- a/data/Neo/Neo Destiny/83.ts
+++ b/data/Neo/Neo Destiny/83.ts
@@ -72,18 +72,22 @@ const card: Card = {
 		fr: "Il est tout petit et sans défense. S'il est attaqué, il agite ses feuilles en espérant effrayer ses ennemis."
 	},
 
-	thirdParty: {
-		cardmarket: 274735,
-		tcgplayer: 89618
-	},
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				cardmarket: 274735,
+				tcgplayer: 89618
+			}
 		},
 		{
 			type: "normal",
-			stamp: ["1st-edition"]
+			stamp: ["1st-edition"],
+			thirdParty: {
+				cardmarket: 274735,
+				tcgplayer: 89618
+			}
 		}
 	]
 }

--- a/data/Neo/Neo Destiny/84.ts
+++ b/data/Neo/Neo Destiny/84.ts
@@ -67,18 +67,22 @@ const card: Card = {
 		fr: "Il avance, son nez ultra-sensible contre le sol, toujours à la recherche de nourriture."
 	},
 
-	thirdParty: {
-		cardmarket: 274736,
-		tcgplayer: 89699
-	},
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				cardmarket: 274736,
+				tcgplayer: 89699
+			}
 		},
 		{
 			type: "normal",
-			stamp: ["1st-edition"]
+			stamp: ["1st-edition"],
+			thirdParty: {
+				cardmarket: 274736,
+				tcgplayer: 89699
+			}
 		}
 	]
 }

--- a/data/Neo/Neo Destiny/85.ts
+++ b/data/Neo/Neo Destiny/85.ts
@@ -59,18 +59,22 @@ const card: Card = {
 		fr: "Ses mâchoires surdéveloppées sont assez puissantes pour écraser n'importe quoi. Même les dresseurs adultes les plus expérimentés font très attention."
 	},
 
-	thirdParty: {
-		cardmarket: 274737,
-		tcgplayer: 89993
-	},
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				cardmarket: 274737,
+				tcgplayer: 89993
+			}
 		},
 		{
 			type: "normal",
-			stamp: ["1st-edition"]
+			stamp: ["1st-edition"],
+			thirdParty: {
+				cardmarket: 274737,
+				tcgplayer: 89993
+			}
 		}
 	]
 }

--- a/data/Neo/Neo Destiny/86.ts
+++ b/data/Neo/Neo Destiny/86.ts
@@ -71,18 +71,22 @@ const card: Card = {
 		fr: "On pense que la variété des types de ce Pokémon particulier est le résultat d'une adaptation due à un caprice de l'évolution, chacun possédant une capacité différente."
 	},
 
-	thirdParty: {
-		cardmarket: 274738,
-		tcgplayer: 90219
-	},
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				cardmarket: 274738,
+				tcgplayer: 90219
+			}
 		},
 		{
 			type: "normal",
-			stamp: ["1st-edition"]
+			stamp: ["1st-edition"],
+			thirdParty: {
+				cardmarket: 274738,
+				tcgplayer: 90219
+			}
 		}
 	]
 }

--- a/data/Neo/Neo Destiny/87.ts
+++ b/data/Neo/Neo Destiny/87.ts
@@ -72,18 +72,22 @@ const card: Card = {
 		fr: "On pense que la variété des types de ce Pokémon particulier est le résultat d'une adaptation due à un caprice de l'évolution, chacun possédant une capacité différente."
 	},
 
-	thirdParty: {
-		cardmarket: 274739,
-		tcgplayer: 90232
-	},
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				cardmarket: 274739,
+				tcgplayer: 90232
+			}
 		},
 		{
 			type: "normal",
-			stamp: ["1st-edition"]
+			stamp: ["1st-edition"],
+			thirdParty: {
+				cardmarket: 274739,
+				tcgplayer: 90232
+			}
 		}
 	]
 }

--- a/data/Neo/Neo Destiny/88.ts
+++ b/data/Neo/Neo Destiny/88.ts
@@ -72,18 +72,22 @@ const card: Card = {
 		fr: "On pense que la variété des types de ce Pokémon particulier est le résultat d'une adaptation due à un caprice de l'évolution, chacun possédant une capacité différente."
 	},
 
-	thirdParty: {
-		cardmarket: 274740,
-		tcgplayer: 90234
-	},
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				cardmarket: 274740,
+				tcgplayer: 90234
+			}
 		},
 		{
 			type: "normal",
-			stamp: ["1st-edition"]
+			stamp: ["1st-edition"],
+			thirdParty: {
+				cardmarket: 274740,
+				tcgplayer: 90234
+			}
 		}
 	]
 }

--- a/data/Neo/Neo Destiny/89.ts
+++ b/data/Neo/Neo Destiny/89.ts
@@ -71,18 +71,22 @@ const card: Card = {
 		fr: "On pense que la variété des types de ce Pokémon particulier est le résultat d'une adaptation due à un caprice de l'évolution, chacun possédant une capacité différente."
 	},
 
-	thirdParty: {
-		cardmarket: 274741,
-		tcgplayer: 90238
-	},
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				cardmarket: 274741,
+				tcgplayer: 90238
+			}
 		},
 		{
 			type: "normal",
-			stamp: ["1st-edition"]
+			stamp: ["1st-edition"],
+			thirdParty: {
+				cardmarket: 274741,
+				tcgplayer: 90238
+			}
 		}
 	]
 }

--- a/data/Neo/Neo Destiny/9.ts
+++ b/data/Neo/Neo Destiny/9.ts
@@ -86,18 +86,22 @@ const card: Card = {
 		fr: "Rien ne peut résister à la pression des griffes d'acier de ce Pokémon, aussi puissantes qu'un étau."
 	},
 
-	thirdParty: {
-		cardmarket: 274661,
-		tcgplayer: 84652
-	},
 
 	variants: [
 		{
-			type: "holo"
+			type: "holo",
+			thirdParty: {
+				cardmarket: 274661,
+				tcgplayer: 84652
+			}
 		},
 		{
 			type: "holo",
-			stamp: ["1st-edition"]
+			stamp: ["1st-edition"],
+			thirdParty: {
+				cardmarket: 274661,
+				tcgplayer: 84652
+			}
 		}
 	]
 }

--- a/data/Neo/Neo Destiny/90.ts
+++ b/data/Neo/Neo Destiny/90.ts
@@ -70,18 +70,22 @@ const card: Card = {
 		fr: "Il possède une sorte de radar qu'il utilise pour trouver les insectes qu'il mange, même dans l'obscurité la plus totale."
 	},
 
-	thirdParty: {
-		cardmarket: 274742,
-		tcgplayer: 90305
-	},
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				cardmarket: 274742,
+				tcgplayer: 90305
+			}
 		},
 		{
 			type: "normal",
-			stamp: ["1st-edition"]
+			stamp: ["1st-edition"],
+			thirdParty: {
+				cardmarket: 274742,
+				tcgplayer: 90305
+			}
 		}
 	]
 }

--- a/data/Neo/Neo Destiny/91.ts
+++ b/data/Neo/Neo Destiny/91.ts
@@ -60,18 +60,22 @@ const card: Card = {
 		fr: "Tandis qu'il vieillit, sa queue blanche change de couleur et se sépare en six. Il émane de son corps une faible chaleur."
 	},
 
-	thirdParty: {
-		cardmarket: 274743,
-		tcgplayer: 90433
-	},
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				cardmarket: 274743,
+				tcgplayer: 90433
+			}
 		},
 		{
 			type: "normal",
-			stamp: ["1st-edition"]
+			stamp: ["1st-edition"],
+			thirdParty: {
+				cardmarket: 274743,
+				tcgplayer: 90433
+			}
 		}
 	]
 }

--- a/data/Neo/Neo Destiny/92.ts
+++ b/data/Neo/Neo Destiny/92.ts
@@ -19,18 +19,22 @@ const card: Card = {
 		de: "Each player pays  more to retreat a Baby Pokémon or Basic Pokémon."
 	},
 
-	thirdParty: {
-		cardmarket: 274744,
-		tcgplayer: 83990
-	},
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				cardmarket: 274744,
+				tcgplayer: 83990
+			}
 		},
 		{
 			type: "normal",
-			stamp: ["1st-edition"]
+			stamp: ["1st-edition"],
+			thirdParty: {
+				cardmarket: 274744,
+				tcgplayer: 83990
+			}
 		}
 	]
 }

--- a/data/Neo/Neo Destiny/93.ts
+++ b/data/Neo/Neo Destiny/93.ts
@@ -19,17 +19,20 @@ const card: Card = {
 		de: "During your opponent's turn, if your Active Pokémon would be Knocked Out by your opponent's attack, you may take 1 of the basic Energy cards attached to your Active Pokémon and attach it to the Pokémon with EXP.ALL attached to it. If you do, discard EXP.ALL."
 	},
 
-	thirdParty: {
-		tcgplayer: 85367
-	},
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 85367
+			}
 		},
 		{
 			type: "normal",
-			stamp: ["1st-edition"]
+			stamp: ["1st-edition"],
+			thirdParty: {
+				tcgplayer: 85367
+			}
 		}
 	]
 }

--- a/data/Neo/Neo Destiny/94.ts
+++ b/data/Neo/Neo Destiny/94.ts
@@ -19,18 +19,22 @@ const card: Card = {
 		de: "Look at your opponent´s Prize card. You may have your opponent shuffle them into his or her deck. If you do, your opponent takes that many cards from the top of his or her deck and sets them aside as his or her new Prize cards (without looking at them)."
 	},
 
-	thirdParty: {
-		cardmarket: 274746,
-		tcgplayer: 86272
-	},
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				cardmarket: 274746,
+				tcgplayer: 86272
+			}
 		},
 		{
 			type: "normal",
-			stamp: ["1st-edition"]
+			stamp: ["1st-edition"],
+			thirdParty: {
+				cardmarket: 274746,
+				tcgplayer: 86272
+			}
 		}
 	]
 }

--- a/data/Neo/Neo Destiny/95.ts
+++ b/data/Neo/Neo Destiny/95.ts
@@ -19,18 +19,22 @@ const card: Card = {
 		de: "Once during each player's turn (before attacking), that player may look at the top 2 cards of his or her deck and put them back in the same order."
 	},
 
-	thirdParty: {
-		cardmarket: 274747,
-		tcgplayer: 88497
-	},
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				cardmarket: 274747,
+				tcgplayer: 88497
+			}
 		},
 		{
 			type: "normal",
-			stamp: ["1st-edition"]
+			stamp: ["1st-edition"],
+			thirdParty: {
+				cardmarket: 274747,
+				tcgplayer: 88497
+			}
 		}
 	]
 }

--- a/data/Neo/Neo Destiny/96.ts
+++ b/data/Neo/Neo Destiny/96.ts
@@ -19,18 +19,22 @@ const card: Card = {
 		de: "Flip a coin until you get tails. For each heads, return an Energy card attached to your opponent's Active Pokémon to your opponent's hand. If the Pokémon has fewer attached Energy cards than that, return all of them to your opponent's hand. Your turn is over now (you don't get to attack)."
 	},
 
-	thirdParty: {
-		cardmarket: 274748,
-		tcgplayer: 89898
-	},
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				cardmarket: 274748,
+				tcgplayer: 89898
+			}
 		},
 		{
 			type: "normal",
-			stamp: ["1st-edition"]
+			stamp: ["1st-edition"],
+			thirdParty: {
+				cardmarket: 274748,
+				tcgplayer: 89898
+			}
 		}
 	]
 }

--- a/data/Neo/Neo Destiny/97.ts
+++ b/data/Neo/Neo Destiny/97.ts
@@ -19,18 +19,22 @@ const card: Card = {
 		de: "During your opponent´s turn, if the Pokémon Counterattack Claws is attached to is your Active Pokémon and an opponent´s attack damage it (even if it is Knocked Out), flip a coin. If heads, put 2 damage counters on the Defending Pokémon. Then, discard Counterattack Claws."
 	},
 
-	thirdParty: {
-		cardmarket: 274749,
-		tcgplayer: 84448
-	},
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				cardmarket: 274749,
+				tcgplayer: 84448
+			}
 		},
 		{
 			type: "normal",
-			stamp: ["1st-edition"]
+			stamp: ["1st-edition"],
+			thirdParty: {
+				cardmarket: 274749,
+				tcgplayer: 84448
+			}
 		}
 	]
 }

--- a/data/Neo/Neo Destiny/98.ts
+++ b/data/Neo/Neo Destiny/98.ts
@@ -19,18 +19,22 @@ const card: Card = {
 		de: "Choose an Energy card in your hand, show it to your opponent, and shuffle it into your deck. Then flip a coin. If heads, search your deck for up to 3 basic Energy cards. Show them to your opponent, and put them into your hand. Shuffle your deck afterward."
 	},
 
-	thirdParty: {
-		cardmarket: 274750,
-		tcgplayer: 85208
-	},
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				cardmarket: 274750,
+				tcgplayer: 85208
+			}
 		},
 		{
 			type: "normal",
-			stamp: ["1st-edition"]
+			stamp: ["1st-edition"],
+			thirdParty: {
+				cardmarket: 274750,
+				tcgplayer: 85208
+			}
 		}
 	]
 }

--- a/data/Neo/Neo Destiny/99.ts
+++ b/data/Neo/Neo Destiny/99.ts
@@ -19,18 +19,22 @@ const card: Card = {
 		de: "Once during each player´s turn (before attacking), that player may flip a coin. If heads, that player puts a basic Energy card from his or her discard pile into his or her hand."
 	},
 
-	thirdParty: {
-		cardmarket: 274751,
-		tcgplayer: 85251
-	},
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				cardmarket: 274751,
+				tcgplayer: 85251
+			}
 		},
 		{
 			type: "normal",
-			stamp: ["1st-edition"]
+			stamp: ["1st-edition"],
+			thirdParty: {
+				cardmarket: 274751,
+				tcgplayer: 85251
+			}
 		}
 	]
 }

--- a/data/POP/Nintendo Black Star Promos/1.ts
+++ b/data/POP/Nintendo Black Star Promos/1.ts
@@ -46,10 +46,25 @@ const card: Card = {
 		},
 	],
 
-
-
-
-
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				tcgplayer: 86555
+			}
+		},
+		{
+			type: 'holo',
+			foil: 'cosmos',
+			thirdParty: {
+				tcgplayer: 86555
+			}
+		},
+		{
+			type: 'normal',
+			subtype: 'no-e-reader'
+		}
+	]
 }
 
 export default card

--- a/data/POP/Nintendo Black Star Promos/10.ts
+++ b/data/POP/Nintendo Black Star Promos/10.ts
@@ -59,10 +59,14 @@ const card: Card = {
 		},
 	],
 
-
-
-
-
+	variants: [
+		{
+			type: 'reverse',
+			thirdParty: {
+				tcgplayer: 87604
+			}
+		}
+	]
 }
 
 export default card

--- a/data/POP/Nintendo Black Star Promos/11.ts
+++ b/data/POP/Nintendo Black Star Promos/11.ts
@@ -63,10 +63,23 @@ const card: Card = {
 		},
 	],
 
-
-
-
-
+	variants: [
+		{
+			type: 'normal',
+			stamp: ['winner'],
+			thirdParty: {
+				tcgplayer: 87231
+			}
+		},
+		{
+			type: 'normal',
+			stamp: ['winner'],
+			size: 'jumbo',
+			thirdParty: {
+				tcgplayer: 707229
+			}
+		}
+	]
 }
 
 export default card

--- a/data/POP/Nintendo Black Star Promos/12.ts
+++ b/data/POP/Nintendo Black Star Promos/12.ts
@@ -57,6 +57,22 @@ const card: Card = {
 	],
 	retreat: 1,
 
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				tcgplayer: 88067
+			}
+		},
+		{
+			type: 'holo',
+			stamp: ['10th-anniversary'],
+			thirdParty: {
+				tcgplayer: 187219
+			}
+		}
+	]
+
 }
 
 export default card

--- a/data/POP/Nintendo Black Star Promos/13.ts
+++ b/data/POP/Nintendo Black Star Promos/13.ts
@@ -55,10 +55,14 @@ const card: Card = {
 		},
 	],
 
-
-
-
-
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				tcgplayer: 87310
+			}
+		}
+	]
 }
 
 export default card

--- a/data/POP/Nintendo Black Star Promos/14.ts
+++ b/data/POP/Nintendo Black Star Promos/14.ts
@@ -55,9 +55,14 @@ const card: Card = {
 		},
 	],
 
-
-
-
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				tcgplayer: 86649
+			}
+		}
+	]
 
 }
 

--- a/data/POP/Nintendo Black Star Promos/15.ts
+++ b/data/POP/Nintendo Black Star Promos/15.ts
@@ -56,10 +56,14 @@ const card: Card = {
 		},
 	],
 
-
-
-
-
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				tcgplayer: 86663
+			}
+		}
+	]
 }
 
 export default card

--- a/data/POP/Nintendo Black Star Promos/16.ts
+++ b/data/POP/Nintendo Black Star Promos/16.ts
@@ -20,7 +20,6 @@ const card: Card = {
 
 	stage: "Basic",
 
-
 	attacks: [
 		{
 			cost: [
@@ -59,10 +58,19 @@ const card: Card = {
 			value: "-30"
 		},
 	],
-
-
-
-
+	
+	variants: [
+		{
+			type: 'normal',
+		},
+		{
+			type: 'holo',
+			foil: 'cosmos',
+			thirdParty: {
+				tcgplayer: 153317
+			}
+		}
+	]
 }
 
 export default card

--- a/data/POP/Nintendo Black Star Promos/17.ts
+++ b/data/POP/Nintendo Black Star Promos/17.ts
@@ -44,10 +44,18 @@ const card: Card = {
 		},
 	],
 
-
-
-
-
+	variants: [
+		{
+			type: 'normal',
+		},
+		{
+			type: 'holo',
+			foil: 'cosmos',
+			thirdParty: {
+				tcgplayer: 153317
+			}
+		}
+	]
 }
 
 export default card

--- a/data/POP/Nintendo Black Star Promos/18.ts
+++ b/data/POP/Nintendo Black Star Promos/18.ts
@@ -55,10 +55,21 @@ const card: Card = {
 		},
 	],
 
-
-
-
-
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				tcgplayer: 153319
+			}
+		},
+		{
+			type: 'holo',
+			foil: 'cosmos',
+			thirdParty: {
+				tcgplayer: 87609
+			}
+		}
+	]
 }
 
 export default card

--- a/data/POP/Nintendo Black Star Promos/19.ts
+++ b/data/POP/Nintendo Black Star Promos/19.ts
@@ -53,9 +53,18 @@ const card: Card = {
 		},
 	],
 
-
-
-
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				tcgplayer: 145343
+			}
+		},
+		{
+			type: 'holo',
+			foil: 'cosmos'
+		}
+	]
 
 }
 

--- a/data/POP/Nintendo Black Star Promos/2.ts
+++ b/data/POP/Nintendo Black Star Promos/2.ts
@@ -46,10 +46,25 @@ const card: Card = {
 		},
 	],
 
-
-
-
-
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				tcgplayer: 85928
+			}
+		},
+		{
+			type: 'holo',
+			foil: 'cosmos',
+			thirdParty: {
+				tcgplayer: 85928
+			}
+		},
+		{
+			type: 'normal',
+			subtype: 'no-e-reader'
+		}
+	]
 }
 
 export default card

--- a/data/POP/Nintendo Black Star Promos/20.ts
+++ b/data/POP/Nintendo Black Star Promos/20.ts
@@ -57,9 +57,14 @@ const card: Card = {
 		},
 	],
 
-
-
-
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				tcgplayer: 86896
+			}
+		}
+	]
 
 }
 

--- a/data/POP/Nintendo Black Star Promos/21.ts
+++ b/data/POP/Nintendo Black Star Promos/21.ts
@@ -55,9 +55,14 @@ const card: Card = {
 		},
 	],
 
-
-
-
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				tcgplayer: 86326
+			}
+		}
+	]
 
 }
 

--- a/data/POP/Nintendo Black Star Promos/22.ts
+++ b/data/POP/Nintendo Black Star Promos/22.ts
@@ -61,7 +61,21 @@ const card: Card = {
 	],
 
 
-
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				tcgplayer: 83784
+			}
+		},
+		{
+			type: 'holo',
+			stamp: ['winner'],
+			thirdParty: {
+				tcgplayer: 154789
+			}
+		}
+	]
 
 }
 

--- a/data/POP/Nintendo Black Star Promos/23.ts
+++ b/data/POP/Nintendo Black Star Promos/23.ts
@@ -62,9 +62,15 @@ const card: Card = {
 		},
 	],
 
-
-
-
+	variants: [
+		{
+			type: 'normal',
+			stamp: ['stadium-challenge'],
+			thirdParty: {
+				tcgplayer: 87374
+			}
+		}
+	]
 }
 
 export default card

--- a/data/POP/Nintendo Black Star Promos/24.ts
+++ b/data/POP/Nintendo Black Star Promos/24.ts
@@ -55,10 +55,21 @@ const card: Card = {
 		},
 	],
 
-
-
-
-
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				tcgplayer: 84293
+			}
+		},
+		{
+			type: 'normal',
+			stamp: ['winner'],
+			thirdParty: {
+				tcgplayer: 228153
+			}
+		}
+	]
 }
 
 export default card

--- a/data/POP/Nintendo Black Star Promos/25.ts
+++ b/data/POP/Nintendo Black Star Promos/25.ts
@@ -78,7 +78,21 @@ const card: Card = {
 		},
 	],
 
-
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				tcgplayer: 85523
+			}
+		},
+		{
+			type: 'normal',
+			stamp: ['winner'],
+			thirdParty: {
+				tcgplayer: 228158
+			}
+		},
+	]
 
 
 }

--- a/data/POP/Nintendo Black Star Promos/26.ts
+++ b/data/POP/Nintendo Black Star Promos/26.ts
@@ -12,19 +12,39 @@ const card: Card = {
 
 	set: Set,
 
-
-
-
-
-
-
-
-
-
-
-
-
-
+	variants: [
+		{
+			type: 'normal',
+			stamp: ['worlds-2004'],
+			thirdParty: {
+				tcgplayer: 90053
+			}
+		},
+		{
+			type: 'normal',
+			stamp: ['worlds-2004', 'staff'],
+		},
+		{
+			type: 'normal',
+			stamp: ['worlds-2004', 'finalist'],
+		},
+		{
+			type: 'normal',
+			stamp: ['worlds-2004', 'quarter-finalist'],
+		},
+		{
+			type: 'normal',
+			stamp: ['worlds-2004', 'semi-finalist'],
+		},
+		{
+			type: 'normal',
+			stamp: ['worlds-2004', 'top-sixteen'],
+		},
+		{
+			type: 'normal',
+			stamp: ['worlds-2004', 'top-thirty-two'],
+		}
+	]
 }
 
 export default card

--- a/data/POP/Nintendo Black Star Promos/27.ts
+++ b/data/POP/Nintendo Black Star Promos/27.ts
@@ -12,18 +12,41 @@ const card: Card = {
 
 	set: Set,
 
-
-
-
-
-
-
-
-
-
-
-
 	trainerType: "Item",
+
+	variants: [
+		{
+			type: 'normal',
+			stamp: ['worlds-2005'],
+			thirdParty: {
+				tcgplayer: 90050
+			}
+		},
+		{
+			type: 'normal',
+			stamp: ['worlds-2005', 'staff'],
+		},
+		{
+			type: 'normal',
+			stamp: ['worlds-2005', 'finalist'],
+		},
+		{
+			type: 'normal',
+			stamp: ['worlds-2005', 'quarter-finalist'],
+		},
+		{
+			type: 'normal',
+			stamp: ['worlds-2005', 'semi-finalist'],
+		},
+		{
+			type: 'normal',
+			stamp: ['worlds-2005', 'top-sixteen'],
+		},
+		{
+			type: 'normal',
+			stamp: ['worlds-2005', 'top-thirty-two'],
+		}
+	]
 
 }
 

--- a/data/POP/Nintendo Black Star Promos/28.ts
+++ b/data/POP/Nintendo Black Star Promos/28.ts
@@ -11,18 +11,16 @@ const card: Card = {
 
 	set: Set,
 
-
-
-
-
-
-
-
-
-
-
-
 	trainerType: "Stadium",
+
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				tcgplayer: 84163
+			}
+		}
+	]
 
 }
 

--- a/data/POP/Nintendo Black Star Promos/29.ts
+++ b/data/POP/Nintendo Black Star Promos/29.ts
@@ -47,9 +47,14 @@ const card: Card = {
 		},
 	],
 
-
-
-
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				tcgplayer: 84145
+			}
+		},
+	]
 
 }
 

--- a/data/POP/Nintendo Black Star Promos/3.ts
+++ b/data/POP/Nintendo Black Star Promos/3.ts
@@ -21,7 +21,6 @@ const card: Card = {
 
 	stage: "Basic",
 
-
 	attacks: [
 		{
 			cost: [
@@ -62,9 +61,14 @@ const card: Card = {
 		},
 	],
 
-
-
-
+	variants: [
+		{
+			type: 'reverse',
+			thirdParty: {
+				tcgplayer: 90031
+			}
+		}
+	]
 }
 
 export default card

--- a/data/POP/Nintendo Black Star Promos/30.ts
+++ b/data/POP/Nintendo Black Star Promos/30.ts
@@ -60,10 +60,14 @@ const card: Card = {
 		},
 	],
 
-
-
-
-
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				tcgplayer: 89603
+			}
+		},
+	]
 }
 
 export default card

--- a/data/POP/Nintendo Black Star Promos/31.ts
+++ b/data/POP/Nintendo Black Star Promos/31.ts
@@ -75,9 +75,14 @@ const card: Card = {
 		},
 	],
 
-
-
-
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				tcgplayer: 87567
+			}
+		},
+	]
 
 }
 

--- a/data/POP/Nintendo Black Star Promos/32.ts
+++ b/data/POP/Nintendo Black Star Promos/32.ts
@@ -75,10 +75,14 @@ const card: Card = {
 		},
 	],
 
-
-
-
-
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				tcgplayer: 83655
+			}
+		},
+	]
 }
 
 export default card

--- a/data/POP/Nintendo Black Star Promos/33.ts
+++ b/data/POP/Nintendo Black Star Promos/33.ts
@@ -75,9 +75,14 @@ const card: Card = {
 		},
 	],
 
-
-
-
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				tcgplayer: 90724
+			}
+		}
+	]
 
 }
 

--- a/data/POP/Nintendo Black Star Promos/34.ts
+++ b/data/POP/Nintendo Black Star Promos/34.ts
@@ -70,10 +70,14 @@ const card: Card = {
 		},
 	],
 
-
-
-
-
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				tcgplayer: 90104
+			}
+		}
+	]
 }
 
 export default card

--- a/data/POP/Nintendo Black Star Promos/35.ts
+++ b/data/POP/Nintendo Black Star Promos/35.ts
@@ -56,10 +56,20 @@ const card: Card = {
 		},
 	],
 
-
-
-
-
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				tcgplayer: 88109
+			}
+		},
+		{
+			type: 'holo',
+			thirdParty: {
+				tcgplayer: 88109
+			}
+		}
+	]
 }
 
 export default card

--- a/data/POP/Nintendo Black Star Promos/36.ts
+++ b/data/POP/Nintendo Black Star Promos/36.ts
@@ -12,19 +12,59 @@ const card: Card = {
 
 	set: Set,
 
-
-
-
-
-
-
-
-
-
-
-
 	trainerType: "Item",
 
+	variants: [
+		{
+			type: 'normal',
+			stamp: ['worlds-2010'],
+			thirdParty: {
+				tcgplayer: 90052
+			}
+		},
+		{
+			type: 'normal',
+			stamp: ['worlds-2010', 'staff'],
+			thirdParty: {
+				tcgplayer: 97703
+			}
+		},
+		{
+			type: 'normal',
+			stamp: ['worlds-2010', 'finalist'],
+			thirdParty: {
+				tcgplayer: 97701
+			}
+		},
+		{
+			type: 'normal',
+			stamp: ['worlds-2010', 'quarter-finalist'],
+			thirdParty: {
+				tcgplayer: 97701
+			}
+		},
+		{
+			type: 'normal',
+			stamp: ['worlds-2010', 'semi-finalist'],
+			thirdParty: {
+				tcgplayer: 97702
+			}
+		},
+		{
+			type: 'normal',
+			stamp: ['worlds-2010', 'top-sixteen'],
+			thirdParty: {
+				tcgplayer: 97700
+			}
+		},
+		{
+			type: 'normal',
+			stamp: ['worlds-2010', 'top-thirty-two'],
+			thirdParty: {
+				tcgplayer: 97699
+			}
+		}
+	]
 }
 
 export default card

--- a/data/POP/Nintendo Black Star Promos/37.ts
+++ b/data/POP/Nintendo Black Star Promos/37.ts
@@ -76,10 +76,14 @@ const card: Card = {
 		},
 	],
 
-
-
-
-
+		variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				tcgplayer: 86558
+			}
+		}
+	]
 }
 
 export default card

--- a/data/POP/Nintendo Black Star Promos/38.ts
+++ b/data/POP/Nintendo Black Star Promos/38.ts
@@ -76,10 +76,14 @@ const card: Card = {
 		},
 	],
 
-
-
-
-
+		variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				tcgplayer: 85931
+			}
+		}
+	]
 }
 
 export default card

--- a/data/POP/Nintendo Black Star Promos/39.ts
+++ b/data/POP/Nintendo Black Star Promos/39.ts
@@ -86,8 +86,14 @@ const card: Card = {
 		},
 	],
 
-
-
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				tcgplayer: 88644
+			}
+		}
+	]
 
 }
 

--- a/data/POP/Nintendo Black Star Promos/4.ts
+++ b/data/POP/Nintendo Black Star Promos/4.ts
@@ -72,9 +72,21 @@ const card: Card = {
 		},
 	],
 
-
-
-
+	variants: [
+		{
+			type: 'normal',
+			size: 'standard',
+			stamp: ['winner'],
+			thirdParty: {
+				tcgplayer: 85934
+			}
+		},
+		{
+			type: 'normal',
+			size: 'jumbo',
+			stamp: ['winner']
+		}
+	]
 }
 
 export default card

--- a/data/POP/Nintendo Black Star Promos/40.ts
+++ b/data/POP/Nintendo Black Star Promos/40.ts
@@ -55,10 +55,14 @@ const card: Card = {
 		},
 	],
 
-
-
-
-
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				tcgplayer: 87402
+			}
+		}
+	]
 }
 
 export default card

--- a/data/POP/Nintendo Black Star Promos/5.ts
+++ b/data/POP/Nintendo Black Star Promos/5.ts
@@ -59,9 +59,15 @@ const card: Card = {
 		},
 	],
 
-
-
-
+	variants: [
+		{
+			type: 'holo',
+			stamp: ['pop-tournament'],
+			thirdParty: {
+				tcgplayer: 87608
+			}
+		}
+	]
 
 }
 

--- a/data/POP/Nintendo Black Star Promos/6.ts
+++ b/data/POP/Nintendo Black Star Promos/6.ts
@@ -59,10 +59,15 @@ const card: Card = {
 		},
 	],
 
-
-
-
-
+	variants: [
+		{
+			type: 'holo',
+			stamp: ['pop-tournament'],
+			thirdParty: {
+				tcgplayer: 89952
+			}
+		}
+	]
 }
 
 export default card

--- a/data/POP/Nintendo Black Star Promos/7.ts
+++ b/data/POP/Nintendo Black Star Promos/7.ts
@@ -62,9 +62,15 @@ const card: Card = {
 		},
 	],
 
-
-
-
+	variants: [
+		{
+			type: 'holo',
+			stamp: ['pop-tournament'],
+			thirdParty: {
+				tcgplayer: 90036
+			}
+		}
+	]
 }
 
 export default card

--- a/data/POP/Nintendo Black Star Promos/8.ts
+++ b/data/POP/Nintendo Black Star Promos/8.ts
@@ -58,13 +58,12 @@ const card: Card = {
 			value: "×2"
 		},
 	],
-	
+
 	variants: [
 		{
-			type: 'holo',
-			stamp: ['pop-tournament'],
+			type: 'reverse',
 			thirdParty: {
-				tcgplayer: 90036
+				tcgplayer: 89948
 			}
 		}
 	]

--- a/data/POP/Nintendo Black Star Promos/8.ts
+++ b/data/POP/Nintendo Black Star Promos/8.ts
@@ -58,11 +58,16 @@ const card: Card = {
 			value: "×2"
 		},
 	],
-
-
-
-
-
+	
+	variants: [
+		{
+			type: 'holo',
+			stamp: ['pop-tournament'],
+			thirdParty: {
+				tcgplayer: 90036
+			}
+		}
+	]
 }
 
 export default card

--- a/data/POP/Nintendo Black Star Promos/9.ts
+++ b/data/POP/Nintendo Black Star Promos/9.ts
@@ -33,10 +33,14 @@ const card: Card = {
 		},
 	],
 
-
-
-
-
+	variants: [
+		{
+			type: 'reverse',
+			thirdParty: {
+				tcgplayer: 89948
+			}
+		}
+	]
 }
 
 export default card

--- a/data/POP/Nintendo Black Star Promos/9.ts
+++ b/data/POP/Nintendo Black Star Promos/9.ts
@@ -32,13 +32,18 @@ const card: Card = {
 			value: "×2"
 		},
 	],
-
 	variants: [
 		{
-			type: 'reverse',
+			type: 'normal',
+			stamp: ['winner'],
 			thirdParty: {
-				tcgplayer: 89948
+				tcgplayer: 84399
 			}
+		},
+		{
+			type: 'normal',
+			stamp: ['winner'],
+			size: 'jumbo',
 		}
 	]
 }

--- a/interfaces.d.ts
+++ b/interfaces.d.ts
@@ -26,7 +26,7 @@ export type VariantStamps = '1st-edition' | 'w-promo' | 'pre-release' | 'pokemon
 	| 'pokemon-day' | 'regional-championships' | 'international-championships' | 'stadium-challenge' | '10th-anniversary' | 'wizard-world-philadelphia'
 	| 'wizard-world-chicago' | 'comic-con' | 'nintendo-world' | 'gen-con' | 'akira-miyazaki' | 'tom-roos'
 	| 'pokemon-rocks-america' | 'jun-hasebe' | 'origins' | 'games-expo' | 'kraze-club' | 'dylan-lefavour'
-	| 'tristan-robinson' | 'paul-atanassov' | 'david-cohen' | 'tsubasa-nakamura' | 'worlds-2007' | 'finalist'
+	| 'tristan-robinson' | 'paul-atanassov' | 'david-cohen' | 'tsubasa-nakamura' | 'worlds-2004' | 'worlds-2005' | 'worlds-2007' | 'finalist'
 	| 'quarter-finalist' | 'semi-finalist' | 'top-sixteen' | 'top-thirty-two' | 'worlds-2008' | 'worlds-2009'
 	| 'countdown-calendar' | 'michael-pramawat' | 'distributor-meeting' | 'mychael-bryan' | "stephen-silvestro"
 	| 'yuka-furusawa' | 'jason-martinez' | 'yuta-komatsuda' | 'origins-2008' | 'platinum' | 'worlds-2010'
@@ -35,7 +35,7 @@ export type VariantStamps = '1st-edition' | 'w-promo' | 'pre-release' | 'pokemon
 	| 'illustration-contest-2024' | 'worlds-2025' | 'top-eight' | "champion" | "poke-ball-league" | "master-ball-league" | "ultra-ball-league" | "judge" | "asia-promo"
 	| "international-championship-europe" | "international-championship-latin-america" | "international-championship-north-america" | 'ace-trainer'
 	| 'pikachu' | 'bulbasaur' | 'squirtle' | 'charmander' | 'pokeball' | '30th-pokeday' | 'mcdonalds' | 'pokemon-together' | 'rain-city' | 'tournament-collection'
-	| 'worlds-2024' | 'worlds-2023' | 'asia-2023-24' | 'thank-you' | 'jr-stamp-rally' | 'grey-star'
+	| 'worlds-2024' | 'worlds-2023' | 'asia-2023-24' | 'thank-you' | 'jr-stamp-rally' | 'grey-star' | 'pop-tournament'
 
 export interface variant_detailed {
 	/**


### PR DESCRIPTION
closes # N/A

## Changes

- added all missing variants for np 

## Details

- references data from https://bulbapedia.bulbagarden.net/wiki/Nintendo_Black_Star_Promos_(TCG)
