### PR TITLE
(data) en/np Nintendo Promos - Add Missing Variants

### DIFF
--- a/data/POP/Nintendo Black Star Promos/1.ts
+++ b/data/POP/Nintendo Black Star Promos/1.ts
@@ -46,10 +46,25 @@ const card: Card = {
 		},
 	],
 
-
-
-
-
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				tcgplayer: 86555
+			}
+		},
+		{
+			type: 'holo',
+			foil: 'cosmos',
+			thirdParty: {
+				tcgplayer: 86555
+			}
+		},
+		{
+			type: 'normal',
+			subtype: 'no-e-reader'
+		}
+	]
 }
 
 export default card

--- a/data/POP/Nintendo Black Star Promos/10.ts
+++ b/data/POP/Nintendo Black Star Promos/10.ts
@@ -59,10 +59,14 @@ const card: Card = {
 		},
 	],
 
-
-
-
-
+	variants: [
+		{
+			type: 'reverse',
+			thirdParty: {
+				tcgplayer: 87604
+			}
+		}
+	]
 }
 
 export default card

--- a/data/POP/Nintendo Black Star Promos/11.ts
+++ b/data/POP/Nintendo Black Star Promos/11.ts
@@ -63,10 +63,23 @@ const card: Card = {
 		},
 	],
 
-
-
-
-
+	variants: [
+		{
+			type: 'normal',
+			stamp: ['winner'],
+			thirdParty: {
+				tcgplayer: 87231
+			}
+		},
+		{
+			type: 'normal',
+			stamp: ['winner'],
+			size: 'jumbo',
+			thirdParty: {
+				tcgplayer: 707229
+			}
+		}
+	]
 }
 
 export default card

--- a/data/POP/Nintendo Black Star Promos/12.ts
+++ b/data/POP/Nintendo Black Star Promos/12.ts
@@ -57,6 +57,22 @@ const card: Card = {
 	],
 	retreat: 1,
 
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				tcgplayer: 88067
+			}
+		},
+		{
+			type: 'holo',
+			stamp: ['10th-anniversary'],
+			thirdParty: {
+				tcgplayer: 187219
+			}
+		}
+	]
+
 }
 
 export default card

--- a/data/POP/Nintendo Black Star Promos/13.ts
+++ b/data/POP/Nintendo Black Star Promos/13.ts
@@ -55,10 +55,14 @@ const card: Card = {
 		},
 	],
 
-
-
-
-
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				tcgplayer: 87310
+			}
+		}
+	]
 }
 
 export default card

--- a/data/POP/Nintendo Black Star Promos/14.ts
+++ b/data/POP/Nintendo Black Star Promos/14.ts
@@ -55,9 +55,14 @@ const card: Card = {
 		},
 	],
 
-
-
-
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				tcgplayer: 86649
+			}
+		}
+	]
 
 }
 

--- a/data/POP/Nintendo Black Star Promos/15.ts
+++ b/data/POP/Nintendo Black Star Promos/15.ts
@@ -56,10 +56,14 @@ const card: Card = {
 		},
 	],
 
-
-
-
-
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				tcgplayer: 86663
+			}
+		}
+	]
 }
 
 export default card

--- a/data/POP/Nintendo Black Star Promos/16.ts
+++ b/data/POP/Nintendo Black Star Promos/16.ts
@@ -20,7 +20,6 @@ const card: Card = {
 
 	stage: "Basic",
 
-
 	attacks: [
 		{
 			cost: [
@@ -59,10 +58,19 @@ const card: Card = {
 			value: "-30"
 		},
 	],
-
-
-
-
+	
+	variants: [
+		{
+			type: 'normal',
+		},
+		{
+			type: 'holo',
+			foil: 'cosmos',
+			thirdParty: {
+				tcgplayer: 153317
+			}
+		}
+	]
 }
 
 export default card

--- a/data/POP/Nintendo Black Star Promos/17.ts
+++ b/data/POP/Nintendo Black Star Promos/17.ts
@@ -44,10 +44,18 @@ const card: Card = {
 		},
 	],
 
-
-
-
-
+	variants: [
+		{
+			type: 'normal',
+		},
+		{
+			type: 'holo',
+			foil: 'cosmos',
+			thirdParty: {
+				tcgplayer: 153317
+			}
+		}
+	]
 }
 
 export default card

--- a/data/POP/Nintendo Black Star Promos/18.ts
+++ b/data/POP/Nintendo Black Star Promos/18.ts
@@ -55,10 +55,21 @@ const card: Card = {
 		},
 	],
 
-
-
-
-
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				tcgplayer: 153319
+			}
+		},
+		{
+			type: 'holo',
+			foil: 'cosmos',
+			thirdParty: {
+				tcgplayer: 87609
+			}
+		}
+	]
 }
 
 export default card

--- a/data/POP/Nintendo Black Star Promos/19.ts
+++ b/data/POP/Nintendo Black Star Promos/19.ts
@@ -53,9 +53,18 @@ const card: Card = {
 		},
 	],
 
-
-
-
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				tcgplayer: 145343
+			}
+		},
+		{
+			type: 'holo',
+			foil: 'cosmos'
+		}
+	]
 
 }
 

--- a/data/POP/Nintendo Black Star Promos/2.ts
+++ b/data/POP/Nintendo Black Star Promos/2.ts
@@ -46,10 +46,25 @@ const card: Card = {
 		},
 	],
 
-
-
-
-
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				tcgplayer: 85928
+			}
+		},
+		{
+			type: 'holo',
+			foil: 'cosmos',
+			thirdParty: {
+				tcgplayer: 85928
+			}
+		},
+		{
+			type: 'normal',
+			subtype: 'no-e-reader'
+		}
+	]
 }
 
 export default card

--- a/data/POP/Nintendo Black Star Promos/20.ts
+++ b/data/POP/Nintendo Black Star Promos/20.ts
@@ -57,9 +57,14 @@ const card: Card = {
 		},
 	],
 
-
-
-
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				tcgplayer: 86896
+			}
+		}
+	]
 
 }
 

--- a/data/POP/Nintendo Black Star Promos/21.ts
+++ b/data/POP/Nintendo Black Star Promos/21.ts
@@ -55,9 +55,14 @@ const card: Card = {
 		},
 	],
 
-
-
-
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				tcgplayer: 86326
+			}
+		}
+	]
 
 }
 

--- a/data/POP/Nintendo Black Star Promos/22.ts
+++ b/data/POP/Nintendo Black Star Promos/22.ts
@@ -61,7 +61,21 @@ const card: Card = {
 	],
 
 
-
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				tcgplayer: 83784
+			}
+		},
+		{
+			type: 'holo',
+			stamp: ['winner'],
+			thirdParty: {
+				tcgplayer: 154789
+			}
+		}
+	]
 
 }
 

--- a/data/POP/Nintendo Black Star Promos/23.ts
+++ b/data/POP/Nintendo Black Star Promos/23.ts
@@ -62,9 +62,15 @@ const card: Card = {
 		},
 	],
 
-
-
-
+	variants: [
+		{
+			type: 'normal',
+			stamp: ['stadium-challenge'],
+			thirdParty: {
+				tcgplayer: 87374
+			}
+		}
+	]
 }
 
 export default card

--- a/data/POP/Nintendo Black Star Promos/24.ts
+++ b/data/POP/Nintendo Black Star Promos/24.ts
@@ -55,10 +55,21 @@ const card: Card = {
 		},
 	],
 
-
-
-
-
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				tcgplayer: 84293
+			}
+		},
+		{
+			type: 'normal',
+			stamp: ['winner'],
+			thirdParty: {
+				tcgplayer: 228153
+			}
+		}
+	]
 }
 
 export default card

--- a/data/POP/Nintendo Black Star Promos/25.ts
+++ b/data/POP/Nintendo Black Star Promos/25.ts
@@ -78,7 +78,21 @@ const card: Card = {
 		},
 	],
 
-
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				tcgplayer: 85523
+			}
+		},
+		{
+			type: 'normal',
+			stamp: ['winner'],
+			thirdParty: {
+				tcgplayer: 228158
+			}
+		},
+	]
 
 
 }

--- a/data/POP/Nintendo Black Star Promos/26.ts
+++ b/data/POP/Nintendo Black Star Promos/26.ts
@@ -12,19 +12,39 @@ const card: Card = {
 
 	set: Set,
 
-
-
-
-
-
-
-
-
-
-
-
-
-
+	variants: [
+		{
+			type: 'normal',
+			stamp: ['worlds-2004'],
+			thirdParty: {
+				tcgplayer: 90053
+			}
+		},
+		{
+			type: 'normal',
+			stamp: ['worlds-2004', 'staff'],
+		},
+		{
+			type: 'normal',
+			stamp: ['worlds-2004', 'finalist'],
+		},
+		{
+			type: 'normal',
+			stamp: ['worlds-2004', 'quarter-finalist'],
+		},
+		{
+			type: 'normal',
+			stamp: ['worlds-2004', 'semi-finalist'],
+		},
+		{
+			type: 'normal',
+			stamp: ['worlds-2004', 'top-sixteen'],
+		},
+		{
+			type: 'normal',
+			stamp: ['worlds-2004', 'top-thirty-two'],
+		}
+	]
 }
 
 export default card

--- a/data/POP/Nintendo Black Star Promos/27.ts
+++ b/data/POP/Nintendo Black Star Promos/27.ts
@@ -12,18 +12,41 @@ const card: Card = {
 
 	set: Set,
 
-
-
-
-
-
-
-
-
-
-
-
 	trainerType: "Item",
+
+	variants: [
+		{
+			type: 'normal',
+			stamp: ['worlds-2005'],
+			thirdParty: {
+				tcgplayer: 90050
+			}
+		},
+		{
+			type: 'normal',
+			stamp: ['worlds-2005', 'staff'],
+		},
+		{
+			type: 'normal',
+			stamp: ['worlds-2005', 'finalist'],
+		},
+		{
+			type: 'normal',
+			stamp: ['worlds-2005', 'quarter-finalist'],
+		},
+		{
+			type: 'normal',
+			stamp: ['worlds-2005', 'semi-finalist'],
+		},
+		{
+			type: 'normal',
+			stamp: ['worlds-2005', 'top-sixteen'],
+		},
+		{
+			type: 'normal',
+			stamp: ['worlds-2005', 'top-thirty-two'],
+		}
+	]
 
 }
 

--- a/data/POP/Nintendo Black Star Promos/28.ts
+++ b/data/POP/Nintendo Black Star Promos/28.ts
@@ -11,18 +11,16 @@ const card: Card = {
 
 	set: Set,
 
-
-
-
-
-
-
-
-
-
-
-
 	trainerType: "Stadium",
+
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				tcgplayer: 84163
+			}
+		}
+	]
 
 }
 

--- a/data/POP/Nintendo Black Star Promos/29.ts
+++ b/data/POP/Nintendo Black Star Promos/29.ts
@@ -47,9 +47,14 @@ const card: Card = {
 		},
 	],
 
-
-
-
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				tcgplayer: 84145
+			}
+		},
+	]
 
 }
 

--- a/data/POP/Nintendo Black Star Promos/3.ts
+++ b/data/POP/Nintendo Black Star Promos/3.ts
@@ -21,7 +21,6 @@ const card: Card = {
 
 	stage: "Basic",
 
-
 	attacks: [
 		{
 			cost: [
@@ -62,9 +61,14 @@ const card: Card = {
 		},
 	],
 
-
-
-
+	variants: [
+		{
+			type: 'reverse',
+			thirdParty: {
+				tcgplayer: 90031
+			}
+		}
+	]
 }
 
 export default card

--- a/data/POP/Nintendo Black Star Promos/30.ts
+++ b/data/POP/Nintendo Black Star Promos/30.ts
@@ -60,10 +60,14 @@ const card: Card = {
 		},
 	],
 
-
-
-
-
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				tcgplayer: 89603
+			}
+		},
+	]
 }
 
 export default card

--- a/data/POP/Nintendo Black Star Promos/31.ts
+++ b/data/POP/Nintendo Black Star Promos/31.ts
@@ -75,9 +75,14 @@ const card: Card = {
 		},
 	],
 
-
-
-
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				tcgplayer: 87567
+			}
+		},
+	]
 
 }
 

--- a/data/POP/Nintendo Black Star Promos/32.ts
+++ b/data/POP/Nintendo Black Star Promos/32.ts
@@ -75,10 +75,14 @@ const card: Card = {
 		},
 	],
 
-
-
-
-
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				tcgplayer: 83655
+			}
+		},
+	]
 }
 
 export default card

--- a/data/POP/Nintendo Black Star Promos/33.ts
+++ b/data/POP/Nintendo Black Star Promos/33.ts
@@ -75,9 +75,14 @@ const card: Card = {
 		},
 	],
 
-
-
-
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				tcgplayer: 90724
+			}
+		}
+	]
 
 }
 

--- a/data/POP/Nintendo Black Star Promos/34.ts
+++ b/data/POP/Nintendo Black Star Promos/34.ts
@@ -70,10 +70,14 @@ const card: Card = {
 		},
 	],
 
-
-
-
-
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				tcgplayer: 90104
+			}
+		}
+	]
 }
 
 export default card

--- a/data/POP/Nintendo Black Star Promos/35.ts
+++ b/data/POP/Nintendo Black Star Promos/35.ts
@@ -56,10 +56,20 @@ const card: Card = {
 		},
 	],
 
-
-
-
-
+	variants: [
+		{
+			type: 'normal',
+			thirdParty: {
+				tcgplayer: 88109
+			}
+		},
+		{
+			type: 'holo',
+			thirdParty: {
+				tcgplayer: 88109
+			}
+		}
+	]
 }
 
 export default card

--- a/data/POP/Nintendo Black Star Promos/36.ts
+++ b/data/POP/Nintendo Black Star Promos/36.ts
@@ -12,19 +12,59 @@ const card: Card = {
 
 	set: Set,
 
-
-
-
-
-
-
-
-
-
-
-
 	trainerType: "Item",
 
+	variants: [
+		{
+			type: 'normal',
+			stamp: ['worlds-2010'],
+			thirdParty: {
+				tcgplayer: 90052
+			}
+		},
+		{
+			type: 'normal',
+			stamp: ['worlds-2010', 'staff'],
+			thirdParty: {
+				tcgplayer: 97703
+			}
+		},
+		{
+			type: 'normal',
+			stamp: ['worlds-2010', 'finalist'],
+			thirdParty: {
+				tcgplayer: 97701
+			}
+		},
+		{
+			type: 'normal',
+			stamp: ['worlds-2010', 'quarter-finalist'],
+			thirdParty: {
+				tcgplayer: 97701
+			}
+		},
+		{
+			type: 'normal',
+			stamp: ['worlds-2010', 'semi-finalist'],
+			thirdParty: {
+				tcgplayer: 97702
+			}
+		},
+		{
+			type: 'normal',
+			stamp: ['worlds-2010', 'top-sixteen'],
+			thirdParty: {
+				tcgplayer: 97700
+			}
+		},
+		{
+			type: 'normal',
+			stamp: ['worlds-2010', 'top-thirty-two'],
+			thirdParty: {
+				tcgplayer: 97699
+			}
+		}
+	]
 }
 
 export default card

--- a/data/POP/Nintendo Black Star Promos/37.ts
+++ b/data/POP/Nintendo Black Star Promos/37.ts
@@ -76,10 +76,14 @@ const card: Card = {
 		},
 	],
 
-
-
-
-
+		variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				tcgplayer: 86558
+			}
+		}
+	]
 }
 
 export default card

--- a/data/POP/Nintendo Black Star Promos/38.ts
+++ b/data/POP/Nintendo Black Star Promos/38.ts
@@ -76,10 +76,14 @@ const card: Card = {
 		},
 	],
 
-
-
-
-
+		variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				tcgplayer: 85931
+			}
+		}
+	]
 }
 
 export default card

--- a/data/POP/Nintendo Black Star Promos/39.ts
+++ b/data/POP/Nintendo Black Star Promos/39.ts
@@ -86,8 +86,14 @@ const card: Card = {
 		},
 	],
 
-
-
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				tcgplayer: 88644
+			}
+		}
+	]
 
 }
 

--- a/data/POP/Nintendo Black Star Promos/4.ts
+++ b/data/POP/Nintendo Black Star Promos/4.ts
@@ -72,9 +72,21 @@ const card: Card = {
 		},
 	],
 
-
-
-
+	variants: [
+		{
+			type: 'normal',
+			size: 'standard',
+			stamp: ['winner'],
+			thirdParty: {
+				tcgplayer: 85934
+			}
+		},
+		{
+			type: 'normal',
+			size: 'jumbo',
+			stamp: ['winner']
+		}
+	]
 }
 
 export default card

--- a/data/POP/Nintendo Black Star Promos/40.ts
+++ b/data/POP/Nintendo Black Star Promos/40.ts
@@ -55,10 +55,14 @@ const card: Card = {
 		},
 	],
 
-
-
-
-
+	variants: [
+		{
+			type: 'holo',
+			thirdParty: {
+				tcgplayer: 87402
+			}
+		}
+	]
 }
 
 export default card

--- a/data/POP/Nintendo Black Star Promos/5.ts
+++ b/data/POP/Nintendo Black Star Promos/5.ts
@@ -59,9 +59,15 @@ const card: Card = {
 		},
 	],
 
-
-
-
+	variants: [
+		{
+			type: 'holo',
+			stamp: ['pop-tournament'],
+			thirdParty: {
+				tcgplayer: 87608
+			}
+		}
+	]
 
 }
 

--- a/data/POP/Nintendo Black Star Promos/6.ts
+++ b/data/POP/Nintendo Black Star Promos/6.ts
@@ -59,10 +59,15 @@ const card: Card = {
 		},
 	],
 
-
-
-
-
+	variants: [
+		{
+			type: 'holo',
+			stamp: ['pop-tournament'],
+			thirdParty: {
+				tcgplayer: 89952
+			}
+		}
+	]
 }
 
 export default card

--- a/data/POP/Nintendo Black Star Promos/7.ts
+++ b/data/POP/Nintendo Black Star Promos/7.ts
@@ -62,9 +62,15 @@ const card: Card = {
 		},
 	],
 
-
-
-
+	variants: [
+		{
+			type: 'holo',
+			stamp: ['pop-tournament'],
+			thirdParty: {
+				tcgplayer: 90036
+			}
+		}
+	]
 }
 
 export default card

--- a/data/POP/Nintendo Black Star Promos/8.ts
+++ b/data/POP/Nintendo Black Star Promos/8.ts
@@ -59,10 +59,14 @@ const card: Card = {
 		},
 	],
 
-
-
-
-
+	variants: [
+		{
+			type: 'reverse',
+			thirdParty: {
+				tcgplayer: 89948
+			}
+		}
+	]
 }
 
 export default card

--- a/data/POP/Nintendo Black Star Promos/9.ts
+++ b/data/POP/Nintendo Black Star Promos/9.ts
@@ -32,11 +32,20 @@ const card: Card = {
 			value: "×2"
 		},
 	],
-
-
-
-
-
+	variants: [
+		{
+			type: 'normal',
+			stamp: ['winner'],
+			thirdParty: {
+				tcgplayer: 84399
+			}
+		},
+		{
+			type: 'normal',
+			stamp: ['winner'],
+			size: 'jumbo',
+		}
+	]
 }
 
 export default card

--- a/interfaces.d.ts
+++ b/interfaces.d.ts
@@ -26,7 +26,7 @@ export type VariantStamps = '1st-edition' | 'w-promo' | 'pre-release' | 'pokemon
 	| 'pokemon-day' | 'regional-championships' | 'international-championships' | 'stadium-challenge' | '10th-anniversary' | 'wizard-world-philadelphia'
 	| 'wizard-world-chicago' | 'comic-con' | 'nintendo-world' | 'gen-con' | 'akira-miyazaki' | 'tom-roos'
 	| 'pokemon-rocks-america' | 'jun-hasebe' | 'origins' | 'games-expo' | 'kraze-club' | 'dylan-lefavour'
-	| 'tristan-robinson' | 'paul-atanassov' | 'david-cohen' | 'tsubasa-nakamura' | 'worlds-2007' | 'finalist'
+	| 'tristan-robinson' | 'paul-atanassov' | 'david-cohen' | 'tsubasa-nakamura' | 'worlds-2004' | 'worlds-2005' | 'worlds-2007' | 'finalist'
 	| 'quarter-finalist' | 'semi-finalist' | 'top-sixteen' | 'top-thirty-two' | 'worlds-2008' | 'worlds-2009'
 	| 'countdown-calendar' | 'michael-pramawat' | 'distributor-meeting' | 'mychael-bryan' | "stephen-silvestro"
 	| 'yuka-furusawa' | 'jason-martinez' | 'yuta-komatsuda' | 'origins-2008' | 'platinum' | 'worlds-2010'
@@ -35,7 +35,7 @@ export type VariantStamps = '1st-edition' | 'w-promo' | 'pre-release' | 'pokemon
 	| 'illustration-contest-2024' | 'worlds-2025' | 'top-eight' | "champion" | "poke-ball-league" | "master-ball-league" | "ultra-ball-league" | "judge" | "asia-promo"
 	| "international-championship-europe" | "international-championship-latin-america" | "international-championship-north-america" | 'ace-trainer'
 	| 'pikachu' | 'bulbasaur' | 'squirtle' | 'charmander' | 'pokeball' | '30th-pokeday' | 'mcdonalds' | 'pokemon-together' | 'rain-city' | 'tournament-collection'
-	| 'worlds-2024' | 'worlds-2023' | 'asia-2023-24' | 'thank-you' | 'jr-stamp-rally' | 'grey-star'
+	| 'worlds-2024' | 'worlds-2023' | 'asia-2023-24' | 'thank-you' | 'jr-stamp-rally' | 'grey-star' | 'pop-tournament'
 
 export interface variant_detailed {
 	/**

--- a/meta/translations/de.json
+++ b/meta/translations/de.json
@@ -205,6 +205,8 @@
 		"semi-finalist": "semi-finalist",
 		"top-sixteen": "top-sixteen",
 		"top-thirty-two": "top-thirty-two",
+		"worlds-2004": "worlds-2004",
+		"worlds-2005": "worlds-2005",
 		"worlds-2008": "worlds-2008",
 		"worlds-2009": "worlds-2009",
 		"countdown-calendar": "countdown-calendar",
@@ -258,7 +260,8 @@
 		"asia-2023-24": "asia-2023-24",
 		"thank-you": "thank-you",
 		"jr-stamp-rally": "jr-stamp-rally",
-		"grey-star": "grauer stern"
+		"grey-star": "grauer stern",
+		"pop-tournament": "pop-tournament"
 	},
 	"variantSubtype": {
 		"shadowless": "schattenlos",

--- a/meta/translations/es.json
+++ b/meta/translations/es.json
@@ -205,6 +205,8 @@
 		"semi-finalist": "semi-finalist",
 		"top-sixteen": "top-sixteen",
 		"top-thirty-two": "top-thirty-two",
+		"worlds-2004": "worlds-2004",
+		"worlds-2005": "worlds-2005",
 		"worlds-2008": "worlds-2008",
 		"worlds-2009": "worlds-2009",
 		"countdown-calendar": "countdown-calendar",
@@ -258,7 +260,8 @@
 		"asia-2023-24": "asia-2023-24",
 		"thank-you": "thank-you",
 		"jr-stamp-rally": "jr-stamp-rally",
-		"grey-star": "estrella gris"
+		"grey-star": "estrella gris",
+		"pop-tournament": "pop-tournament"
 	},
 	"variantSubtype": {
 		"shadowless": "sin sombra",

--- a/meta/translations/fr.json
+++ b/meta/translations/fr.json
@@ -204,6 +204,8 @@
 		"semi-finalist": "semi-finalist",
 		"top-sixteen": "top-sixteen",
 		"top-thirty-two": "top-thirty-two",
+		"worlds-2004": "worlds-2004",
+		"worlds-2005": "worlds-2005",
 		"worlds-2008": "worlds-2008",
 		"worlds-2009": "worlds-2009",
 		"countdown-calendar": "countdown-calendar",
@@ -257,7 +259,8 @@
 		"asia-2023-24": "asia-2023-24",
 		"thank-you": "thank-you",
 		"jr-stamp-rally": "jr-stamp-rally",
-		"grey-star": "étoile grise"
+		"grey-star": "étoile grise",
+		"pop-tournament": "pop-tournament"
 	},
 	"variantSubtype": {
 		"shadowless": "sans ombre",

--- a/meta/translations/it.json
+++ b/meta/translations/it.json
@@ -205,6 +205,8 @@
 		"semi-finalist": "semi-finalist",
 		"top-sixteen": "top-sixteen",
 		"top-thirty-two": "top-thirty-two",
+		"worlds-2004": "worlds-2004",
+		"worlds-2005": "worlds-2005",
 		"worlds-2008": "worlds-2008",
 		"worlds-2009": "worlds-2009",
 		"countdown-calendar": "countdown-calendar",
@@ -258,7 +260,8 @@
 		"asia-2023-24": "asia-2023-24",
 		"thank-you": "thank-you",
 		"jr-stamp-rally": "jr-stamp-rally",
-		"grey-star": "grey-star"
+		"grey-star": "grey-star",
+		"pop-tournament": "pop-tournament"
 	},
 	"variantSubtype": {
 		"shadowless": "senza ombra",

--- a/meta/translations/pt.json
+++ b/meta/translations/pt.json
@@ -204,6 +204,8 @@
 		"semi-finalist": "semi-finalist",
 		"top-sixteen": "top-sixteen",
 		"top-thirty-two": "top-thirty-two",
+		"worlds-2004": "worlds-2004",
+		"worlds-2005": "worlds-2005",
 		"worlds-2008": "worlds-2008",
 		"worlds-2009": "worlds-2009",
 		"countdown-calendar": "countdown-calendar",
@@ -257,7 +259,8 @@
 		"asia-2023-24": "asia-2023-24",
 		"thank-you": "thank-you",
 		"jr-stamp-rally": "jr-stamp-rally",
-		"grey-star": "estrela cinza"
+		"grey-star": "estrela cinza",
+		"pop-tournament": "pop-tournament"
 	},
 	"variantSubtype": {
 		"shadowless": "sem sombra",


### PR DESCRIPTION
closes # <!-- Indicate the issue number here -->

## Changes

- adds all missing variant promos for set np

## Details

references variants listed from https://bulbapedia.bulbagarden.net/wiki/Nintendo_Black_Star_Promos_(TCG) 

