### PR TITLE
feat(data): Add MEP promos 046-063 (First Partner starters)

### DIFF
--- a/data/Mega Evolution/MEP Black Star Promos/046.ts
+++ b/data/Mega Evolution/MEP Black Star Promos/046.ts
@@ -1,0 +1,39 @@
+import { Card } from "../../../interfaces"
+import Set from "../MEP Black Star Promos"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Chikorita",
+		fr: "Germignon"
+	},
+
+	illustrator: "Saboteri",
+	rarity: "Promo",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Grass"],
+	stage: "Basic",
+	dexId: [152],
+
+	attacks: [{
+		cost: ["Grass", "Colorless"],
+
+		name: {
+			en: "Razor Leaf",
+			fr: "Tranch'Herbe"
+		},
+
+		damage: 30
+	}],
+
+	weaknesses: [{
+		type: "Fire",
+		value: "×2"
+	}],
+
+	retreat: 1
+}
+
+export default card

--- a/data/Mega Evolution/MEP Black Star Promos/046.ts
+++ b/data/Mega Evolution/MEP Black Star Promos/046.ts
@@ -33,7 +33,13 @@ const card: Card = {
 		value: "×2"
 	}],
 
-	retreat: 1
+	retreat: 1,
+
+	variants: [
+		{
+			type: "holo"
+		}
+	]
 }
 
 export default card

--- a/data/Mega Evolution/MEP Black Star Promos/047.ts
+++ b/data/Mega Evolution/MEP Black Star Promos/047.ts
@@ -1,0 +1,39 @@
+import { Card } from "../../../interfaces"
+import Set from "../MEP Black Star Promos"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Cyndaquil",
+		fr: "Héricendre"
+	},
+
+	illustrator: "Saboteri",
+	rarity: "Promo",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Fire"],
+	stage: "Basic",
+	dexId: [155],
+
+	attacks: [{
+		cost: ["Fire", "Colorless", "Colorless"],
+
+		name: {
+			en: "Tackle",
+			fr: "Charge"
+		},
+
+		damage: 40
+	}],
+
+	weaknesses: [{
+		type: "Water",
+		value: "×2"
+	}],
+
+	retreat: 1
+}
+
+export default card

--- a/data/Mega Evolution/MEP Black Star Promos/047.ts
+++ b/data/Mega Evolution/MEP Black Star Promos/047.ts
@@ -33,7 +33,13 @@ const card: Card = {
 		value: "×2"
 	}],
 
-	retreat: 1
+	retreat: 1,
+
+	variants: [
+		{
+			type: "holo"
+		}
+	]
 }
 
 export default card

--- a/data/Mega Evolution/MEP Black Star Promos/048.ts
+++ b/data/Mega Evolution/MEP Black Star Promos/048.ts
@@ -33,7 +33,13 @@ const card: Card = {
 		value: "×2"
 	}],
 
-	retreat: 2
+	retreat: 2,
+
+	variants: [
+		{
+			type: "holo"
+		}
+	]
 }
 
 export default card

--- a/data/Mega Evolution/MEP Black Star Promos/048.ts
+++ b/data/Mega Evolution/MEP Black Star Promos/048.ts
@@ -1,0 +1,39 @@
+import { Card } from "../../../interfaces"
+import Set from "../MEP Black Star Promos"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Totodile",
+		fr: "Kaiminus"
+	},
+
+	illustrator: "Saboteri",
+	rarity: "Promo",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Water"],
+	stage: "Basic",
+	dexId: [158],
+
+	attacks: [{
+		cost: ["Water", "Water", "Colorless"],
+
+		name: {
+			en: "Bite",
+			fr: "Morsure"
+		},
+
+		damage: 50
+	}],
+
+	weaknesses: [{
+		type: "Lightning",
+		value: "×2"
+	}],
+
+	retreat: 2
+}
+
+export default card

--- a/data/Mega Evolution/MEP Black Star Promos/049.ts
+++ b/data/Mega Evolution/MEP Black Star Promos/049.ts
@@ -1,0 +1,39 @@
+import { Card } from "../../../interfaces"
+import Set from "../MEP Black Star Promos"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Snivy",
+		fr: "Vipélierre"
+	},
+
+	illustrator: "Saboteri",
+	rarity: "Promo",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Grass"],
+	stage: "Basic",
+	dexId: [495],
+
+	attacks: [{
+		cost: ["Colorless"],
+
+		name: {
+			en: "Vine Whip",
+			fr: "Fouet Lianes"
+		},
+
+		damage: 20
+	}],
+
+	weaknesses: [{
+		type: "Fire",
+		value: "×2"
+	}],
+
+	retreat: 1
+}
+
+export default card

--- a/data/Mega Evolution/MEP Black Star Promos/049.ts
+++ b/data/Mega Evolution/MEP Black Star Promos/049.ts
@@ -33,7 +33,13 @@ const card: Card = {
 		value: "×2"
 	}],
 
-	retreat: 1
+	retreat: 1,
+
+	variants: [
+		{
+			type: "holo"
+		}
+	]
 }
 
 export default card

--- a/data/Mega Evolution/MEP Black Star Promos/050.ts
+++ b/data/Mega Evolution/MEP Black Star Promos/050.ts
@@ -38,7 +38,13 @@ const card: Card = {
 		value: "×2"
 	}],
 
-	retreat: 2
+	retreat: 2,
+
+	variants: [
+		{
+			type: "holo"
+		}
+	]
 }
 
 export default card

--- a/data/Mega Evolution/MEP Black Star Promos/050.ts
+++ b/data/Mega Evolution/MEP Black Star Promos/050.ts
@@ -1,0 +1,44 @@
+import { Card } from "../../../interfaces"
+import Set from "../MEP Black Star Promos"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Tepig",
+		fr: "Gruikui"
+	},
+
+	illustrator: "Saboteri",
+	rarity: "Promo",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Fire"],
+	stage: "Basic",
+	dexId: [498],
+
+	attacks: [{
+		cost: ["Fire", "Fire"],
+
+		name: {
+			en: "Ember",
+			fr: "Flammèche"
+		},
+
+		damage: 40,
+
+		effect: {
+			en: "Discard an Energy from this Pokémon.",
+			fr: "Défaussez une Énergie de ce Pokémon."
+		}
+	}],
+
+	weaknesses: [{
+		type: "Water",
+		value: "×2"
+	}],
+
+	retreat: 2
+}
+
+export default card

--- a/data/Mega Evolution/MEP Black Star Promos/051.ts
+++ b/data/Mega Evolution/MEP Black Star Promos/051.ts
@@ -1,0 +1,44 @@
+import { Card } from "../../../interfaces"
+import Set from "../MEP Black Star Promos"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Oshawott",
+		fr: "Moustillon"
+	},
+
+	illustrator: "Saboteri",
+	rarity: "Promo",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Water"],
+	stage: "Basic",
+	dexId: [501],
+
+	attacks: [{
+		cost: ["Water", "Colorless"],
+
+		name: {
+			en: "Razor Shell",
+			fr: "Coquilame"
+		},
+
+		damage: "10+",
+
+		effect: {
+			en: "Flip a coin. If heads, this attack does 30 more damage.",
+			fr: "Lancez une pièce. Si c'est face, cette attaque inflige 30 dégâts supplémentaires."
+		}
+	}],
+
+	weaknesses: [{
+		type: "Lightning",
+		value: "×2"
+	}],
+
+	retreat: 1
+}
+
+export default card

--- a/data/Mega Evolution/MEP Black Star Promos/051.ts
+++ b/data/Mega Evolution/MEP Black Star Promos/051.ts
@@ -38,7 +38,13 @@ const card: Card = {
 		value: "×2"
 	}],
 
-	retreat: 1
+	retreat: 1,
+
+	variants: [
+		{
+			type: "holo"
+		}
+	]
 }
 
 export default card

--- a/data/Mega Evolution/MEP Black Star Promos/052.ts
+++ b/data/Mega Evolution/MEP Black Star Promos/052.ts
@@ -32,7 +32,13 @@ const card: Card = {
 		value: "×2"
 	}],
 
-	retreat: 1
+	retreat: 1,
+
+	variants: [
+		{
+			type: "holo"
+		}
+	]
 }
 
 export default card

--- a/data/Mega Evolution/MEP Black Star Promos/052.ts
+++ b/data/Mega Evolution/MEP Black Star Promos/052.ts
@@ -1,0 +1,38 @@
+import { Card } from "../../../interfaces"
+import Set from "../MEP Black Star Promos"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Grookey",
+		fr: "Ouistempo"
+	},
+
+	illustrator: "Saboteri",
+	rarity: "Promo",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Grass"],
+	stage: "Basic",
+	dexId: [810],
+
+	attacks: [{
+		cost: ["Grass", "Grass"],
+
+		name: {
+			en: "Branch Poke"
+		},
+
+		damage: 40
+	}],
+
+	weaknesses: [{
+		type: "Fire",
+		value: "×2"
+	}],
+
+	retreat: 1
+}
+
+export default card

--- a/data/Mega Evolution/MEP Black Star Promos/053.ts
+++ b/data/Mega Evolution/MEP Black Star Promos/053.ts
@@ -1,0 +1,44 @@
+import { Card } from "../../../interfaces"
+import Set from "../MEP Black Star Promos"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Scorbunny",
+		fr: "Flambino"
+	},
+
+	illustrator: "Saboteri",
+	rarity: "Promo",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Fire"],
+	stage: "Basic",
+	dexId: [813],
+
+	attacks: [{
+		cost: ["Fire", "Colorless"],
+
+		name: {
+			en: "Double Kick",
+			fr: "Double Pied"
+		},
+
+		damage: "20×",
+
+		effect: {
+			en: "Flip 2 coins. This attack does 20 damage for each heads.",
+			fr: "Lancez 2 pièces. Cette attaque inflige 20 dégâts pour chaque côté face."
+		}
+	}],
+
+	weaknesses: [{
+		type: "Water",
+		value: "×2"
+	}],
+
+	retreat: 1
+}
+
+export default card

--- a/data/Mega Evolution/MEP Black Star Promos/053.ts
+++ b/data/Mega Evolution/MEP Black Star Promos/053.ts
@@ -38,7 +38,13 @@ const card: Card = {
 		value: "×2"
 	}],
 
-	retreat: 1
+	retreat: 1,
+
+	variants: [
+		{
+			type: "holo"
+		}
+	]
 }
 
 export default card

--- a/data/Mega Evolution/MEP Black Star Promos/054.ts
+++ b/data/Mega Evolution/MEP Black Star Promos/054.ts
@@ -1,0 +1,39 @@
+import { Card } from "../../../interfaces"
+import Set from "../MEP Black Star Promos"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Sobble",
+		fr: "Larméléon"
+	},
+
+	illustrator: "Saboteri",
+	rarity: "Promo",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Water"],
+	stage: "Basic",
+	dexId: [816],
+
+	attacks: [{
+		cost: ["Water", "Colorless", "Colorless"],
+
+		name: {
+			en: "Water Gun",
+			fr: "Pistolet à O"
+		},
+
+		damage: 40
+	}],
+
+	weaknesses: [{
+		type: "Lightning",
+		value: "×2"
+	}],
+
+	retreat: 1
+}
+
+export default card

--- a/data/Mega Evolution/MEP Black Star Promos/054.ts
+++ b/data/Mega Evolution/MEP Black Star Promos/054.ts
@@ -33,7 +33,13 @@ const card: Card = {
 		value: "×2"
 	}],
 
-	retreat: 1
+	retreat: 1,
+
+	variants: [
+		{
+			type: "holo"
+		}
+	]
 }
 
 export default card

--- a/data/Mega Evolution/MEP Black Star Promos/055.ts
+++ b/data/Mega Evolution/MEP Black Star Promos/055.ts
@@ -1,0 +1,39 @@
+import { Card } from "../../../interfaces"
+import Set from "../MEP Black Star Promos"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Treecko",
+		fr: "Arcko"
+	},
+
+	illustrator: "Saboteri",
+	rarity: "Promo",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Grass"],
+	stage: "Basic",
+	dexId: [252],
+
+	attacks: [{
+		cost: ["Grass"],
+
+		name: {
+			en: "Pound",
+			fr: "Écras'Face"
+		},
+
+		damage: 20
+	}],
+
+	weaknesses: [{
+		type: "Fire",
+		value: "×2"
+	}],
+
+	retreat: 1
+}
+
+export default card

--- a/data/Mega Evolution/MEP Black Star Promos/055.ts
+++ b/data/Mega Evolution/MEP Black Star Promos/055.ts
@@ -33,7 +33,13 @@ const card: Card = {
 		value: "×2"
 	}],
 
-	retreat: 1
+	retreat: 1,
+
+	variants: [
+		{
+			type: "holo"
+		}
+	]
 }
 
 export default card

--- a/data/Mega Evolution/MEP Black Star Promos/056.ts
+++ b/data/Mega Evolution/MEP Black Star Promos/056.ts
@@ -1,0 +1,39 @@
+import { Card } from "../../../interfaces"
+import Set from "../MEP Black Star Promos"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Torchic",
+		fr: "Poussifeu"
+	},
+
+	illustrator: "Saboteri",
+	rarity: "Promo",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Fire"],
+	stage: "Basic",
+	dexId: [255],
+
+	attacks: [{
+		cost: ["Colorless"],
+
+		name: {
+			en: "Peck",
+			fr: "Picpic"
+		},
+
+		damage: 20
+	}],
+
+	weaknesses: [{
+		type: "Water",
+		value: "×2"
+	}],
+
+	retreat: 1
+}
+
+export default card

--- a/data/Mega Evolution/MEP Black Star Promos/056.ts
+++ b/data/Mega Evolution/MEP Black Star Promos/056.ts
@@ -33,7 +33,13 @@ const card: Card = {
 		value: "×2"
 	}],
 
-	retreat: 1
+	retreat: 1,
+
+	variants: [
+		{
+			type: "holo"
+		}
+	]
 }
 
 export default card

--- a/data/Mega Evolution/MEP Black Star Promos/057.ts
+++ b/data/Mega Evolution/MEP Black Star Promos/057.ts
@@ -1,0 +1,39 @@
+import { Card } from "../../../interfaces"
+import Set from "../MEP Black Star Promos"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Mudkip",
+		fr: "Gobou"
+	},
+
+	illustrator: "Saboteri",
+	rarity: "Promo",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Water"],
+	stage: "Basic",
+	dexId: [258],
+
+	attacks: [{
+		cost: ["Water", "Water"],
+
+		name: {
+			en: "Mud-Slap",
+			fr: "Coud'Boue"
+		},
+
+		damage: 40
+	}],
+
+	weaknesses: [{
+		type: "Lightning",
+		value: "×2"
+	}],
+
+	retreat: 1
+}
+
+export default card

--- a/data/Mega Evolution/MEP Black Star Promos/057.ts
+++ b/data/Mega Evolution/MEP Black Star Promos/057.ts
@@ -33,7 +33,13 @@ const card: Card = {
 		value: "×2"
 	}],
 
-	retreat: 1
+	retreat: 1,
+
+	variants: [
+		{
+			type: "holo"
+		}
+	]
 }
 
 export default card

--- a/data/Mega Evolution/MEP Black Star Promos/058.ts
+++ b/data/Mega Evolution/MEP Black Star Promos/058.ts
@@ -1,0 +1,44 @@
+import { Card } from "../../../interfaces"
+import Set from "../MEP Black Star Promos"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Chespin",
+		fr: "Marisson"
+	},
+
+	illustrator: "Saboteri",
+	rarity: "Promo",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Grass"],
+	stage: "Basic",
+	dexId: [650],
+
+	attacks: [{
+		cost: ["Grass", "Colorless"],
+
+		name: {
+			en: "Pin Missile",
+			fr: "Dard-Nuée"
+		},
+
+		damage: "10×",
+
+		effect: {
+			en: "Flip 4 coins. This attack does 10 damage for each heads.",
+			fr: "Lancez 4 pièces. Cette attaque inflige 10 dégâts pour chaque côté face."
+		}
+	}],
+
+	weaknesses: [{
+		type: "Fire",
+		value: "×2"
+	}],
+
+	retreat: 2
+}
+
+export default card

--- a/data/Mega Evolution/MEP Black Star Promos/058.ts
+++ b/data/Mega Evolution/MEP Black Star Promos/058.ts
@@ -38,7 +38,13 @@ const card: Card = {
 		value: "×2"
 	}],
 
-	retreat: 2
+	retreat: 2,
+
+	variants: [
+		{
+			type: "holo"
+		}
+	]
 }
 
 export default card

--- a/data/Mega Evolution/MEP Black Star Promos/059.ts
+++ b/data/Mega Evolution/MEP Black Star Promos/059.ts
@@ -1,0 +1,39 @@
+import { Card } from "../../../interfaces"
+import Set from "../MEP Black Star Promos"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Fennekin",
+		fr: "Feunnec"
+	},
+
+	illustrator: "Saboteri",
+	rarity: "Promo",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Fire"],
+	stage: "Basic",
+	dexId: [653],
+
+	attacks: [{
+		cost: ["Fire", "Colorless"],
+
+		name: {
+			en: "Scratch",
+			fr: "Griffe"
+		},
+
+		damage: 30
+	}],
+
+	weaknesses: [{
+		type: "Water",
+		value: "×2"
+	}],
+
+	retreat: 1
+}
+
+export default card

--- a/data/Mega Evolution/MEP Black Star Promos/059.ts
+++ b/data/Mega Evolution/MEP Black Star Promos/059.ts
@@ -33,7 +33,13 @@ const card: Card = {
 		value: "×2"
 	}],
 
-	retreat: 1
+	retreat: 1,
+
+	variants: [
+		{
+			type: "holo"
+		}
+	]
 }
 
 export default card

--- a/data/Mega Evolution/MEP Black Star Promos/060.ts
+++ b/data/Mega Evolution/MEP Black Star Promos/060.ts
@@ -1,0 +1,39 @@
+import { Card } from "../../../interfaces"
+import Set from "../MEP Black Star Promos"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Froakie",
+		fr: "Grenousse"
+	},
+
+	illustrator: "Saboteri",
+	rarity: "Promo",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Water"],
+	stage: "Basic",
+	dexId: [656],
+
+	attacks: [{
+		cost: ["Colorless", "Colorless"],
+
+		name: {
+			en: "Pound",
+			fr: "Écras'Face"
+		},
+
+		damage: 20
+	}],
+
+	weaknesses: [{
+		type: "Lightning",
+		value: "×2"
+	}],
+
+	retreat: 1
+}
+
+export default card

--- a/data/Mega Evolution/MEP Black Star Promos/060.ts
+++ b/data/Mega Evolution/MEP Black Star Promos/060.ts
@@ -33,7 +33,13 @@ const card: Card = {
 		value: "×2"
 	}],
 
-	retreat: 1
+	retreat: 1,
+
+	variants: [
+		{
+			type: "holo"
+		}
+	]
 }
 
 export default card

--- a/data/Mega Evolution/MEP Black Star Promos/061.ts
+++ b/data/Mega Evolution/MEP Black Star Promos/061.ts
@@ -1,0 +1,39 @@
+import { Card } from "../../../interfaces"
+import Set from "../MEP Black Star Promos"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Sprigatito",
+		fr: "Poussacha"
+	},
+
+	illustrator: "Saboteri",
+	rarity: "Promo",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Grass"],
+	stage: "Basic",
+	dexId: [906],
+
+	attacks: [{
+		cost: ["Grass", "Colorless", "Colorless"],
+
+		name: {
+			en: "Leafage",
+			fr: "Feuillage"
+		},
+
+		damage: 40
+	}],
+
+	weaknesses: [{
+		type: "Fire",
+		value: "×2"
+	}],
+
+	retreat: 1
+}
+
+export default card

--- a/data/Mega Evolution/MEP Black Star Promos/061.ts
+++ b/data/Mega Evolution/MEP Black Star Promos/061.ts
@@ -33,7 +33,13 @@ const card: Card = {
 		value: "×2"
 	}],
 
-	retreat: 1
+	retreat: 1,
+
+	variants: [
+		{
+			type: "holo"
+		}
+	]
 }
 
 export default card

--- a/data/Mega Evolution/MEP Black Star Promos/062.ts
+++ b/data/Mega Evolution/MEP Black Star Promos/062.ts
@@ -38,7 +38,13 @@ const card: Card = {
 		value: "×2"
 	}],
 
-	retreat: 3
+	retreat: 3,
+
+	variants: [
+		{
+			type: "holo"
+		}
+	]
 }
 
 export default card

--- a/data/Mega Evolution/MEP Black Star Promos/062.ts
+++ b/data/Mega Evolution/MEP Black Star Promos/062.ts
@@ -1,0 +1,44 @@
+import { Card } from "../../../interfaces"
+import Set from "../MEP Black Star Promos"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Fuecoco",
+		fr: "Chochodile"
+	},
+
+	illustrator: "Saboteri",
+	rarity: "Promo",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Fire"],
+	stage: "Basic",
+	dexId: [909],
+
+	attacks: [{
+		cost: ["Fire", "Fire", "Colorless"],
+
+		name: {
+			en: "Flamethrower",
+			fr: "Lance-Flammes"
+		},
+
+		damage: 70,
+
+		effect: {
+			en: "Discard an Energy from this Pokémon.",
+			fr: "Défaussez une Énergie de ce Pokémon."
+		}
+	}],
+
+	weaknesses: [{
+		type: "Water",
+		value: "×2"
+	}],
+
+	retreat: 3
+}
+
+export default card

--- a/data/Mega Evolution/MEP Black Star Promos/063.ts
+++ b/data/Mega Evolution/MEP Black Star Promos/063.ts
@@ -1,0 +1,39 @@
+import { Card } from "../../../interfaces"
+import Set from "../MEP Black Star Promos"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		en: "Quaxly",
+		fr: "Coiffeton"
+	},
+
+	illustrator: "Saboteri",
+	rarity: "Promo",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Water"],
+	stage: "Basic",
+	dexId: [912],
+
+	attacks: [{
+		cost: ["Water", "Colorless"],
+
+		name: {
+			en: "Wing Attack",
+			fr: "Cru-Ailes"
+		},
+
+		damage: 30
+	}],
+
+	weaknesses: [{
+		type: "Lightning",
+		value: "×2"
+	}],
+
+	retreat: 1
+}
+
+export default card

--- a/data/Mega Evolution/MEP Black Star Promos/063.ts
+++ b/data/Mega Evolution/MEP Black Star Promos/063.ts
@@ -33,7 +33,13 @@ const card: Card = {
 		value: "×2"
 	}],
 
-	retreat: 1
+	retreat: 1,
+
+	variants: [
+		{
+			type: "holo"
+		}
+	]
 }
 
 export default card


### PR DESCRIPTION
Adds the 18 missing First Partner (starter) promos of the MEP Black Star Promos set, cards 046–063 (Chikorita → Quaxly).

## Changes
- Added `data/Mega Evolution/MEP Black Star Promos/046.ts` … `063.ts`
- Each card: name (en/fr), illustrator (Saboteri), HP, type, dexId, attack (cost / name en+fr / damage / effect), weakness, retreat.

## Details
- Data sourced from the Bulbapedia card pages (`..._(MEP_Promo_46..63)`).
- `regulationMark` omitted (not listed for these Full Art promos); `variants` set to `holo`.
- 052 Grookey "Branch Poke": FR attack name left as en only (to confirm).