### PR TITLE
(data) en Skyridge  Add Thirdparty Variants 

### DIFF
--- a/data/E-Card/Skyridge/1.ts
+++ b/data/E-Card/Skyridge/1.ts
@@ -12,14 +12,12 @@ const card: Card = {
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		142,
-	],
+	dexId: [142],
 
 	hp: 70,
 
 	types: [
-		"Fighting",
+		"Fighting"
 	],
 
 	stage: "Stage1",
@@ -32,7 +30,7 @@ const card: Card = {
 				de: "Ancient Wind"
 			},
 			effect: {
-				en: "Once during your turn (before you attack) if Aerodactyl is your Active Pokémon, you may ignore all Poké-Bodies until the end of your turn. This power can't be used if Aerodactyl is affected by a Special Condition.",
+				en: "Once during your turn (before your attack), if Aerodactyl is your Active Pokémon, you may ignore all Poké-Bodies until the end of your turn. This power can't be used if Aerodactyl is affected by a Special Condition.",
 				de: "Once during your turn (before your attack), if Aerodactyl is your Active Pokémon, you may ignore all Poké-Bodies until the end of your turn. This power can't be used if Aerodactyl is affected by a Special Condition."
 			},
 		},
@@ -60,25 +58,28 @@ const card: Card = {
 	weaknesses: [
 		{
 			type: "Water",
-			value: "×2"
+			value: "x2"
 		},
 	],
 	retreat: 1,
 
 
-	thirdParty: {
-		cardmarket: 275259,
-		tcgplayer: 83465
-	},
-
 	variants: [
 		{
 			type: 'normal',
+			thirdParty: {
+				tcgplayer: 83465,
+				cardmarket: 275259
+			},
 		},
 		{
 			type: 'reverse',
-		}
-	]
+			thirdParty: {
+				tcgplayer: 83465,
+				cardmarket: 275259
+			},
+		},
+	],
 }
 
 export default card

--- a/data/E-Card/Skyridge/10.ts
+++ b/data/E-Card/Skyridge/10.ts
@@ -12,14 +12,12 @@ const card: Card = {
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		94,
-	],
+	dexId: [94],
 
 	hp: 100,
 
 	types: [
-		"Psychic",
+		"Psychic"
 	],
 
 	evolveFrom: {
@@ -36,7 +34,7 @@ const card: Card = {
 				de: "Manipulieren"
 			},
 			effect: {
-				en: "When you play Gengar from your hand to evolve your Active Pokémon, you may put a Basic Pokémon (excluding Baby Pokémon) from your discard pile onto your bench. Then flip 3 coins. For each heads, choose a basic Energy card from your discard pile and attach it to that Pokémon.",
+				en: "When you play Gengar from your hand to evolve your Active Pokémon, you may put a Basic Pokémon (excluding Baby Pokémon) from your discard pile onto your Bench. Then, flip 3 coins. For each heads, choose a basic Energy card from your discard pile and attach it to that Pokémon.",
 				de: "Wenn du Gengar aus deiner Hand spielst, um dein aktives Pokémon zu entwickeln, kannst du ein Basis-Pokémon (aber kein Baby-Pokémon) aus deinem Ablagestapel nehmen und auf deine Bank legen. Wirf dann 3 Münzen. Wähle für jeden geworfenen 'Kopf' eine Basis-Energiekarte aus deinem Ablagestapel und lege sie an dieses Pokémon an."
 			},
 		},
@@ -66,10 +64,9 @@ const card: Card = {
 	weaknesses: [
 		{
 			type: "Darkness",
-			value: "×2"
+			value: "x2"
 		},
 	],
-
 	resistances: [
 		{
 			type: "Fighting",
@@ -79,19 +76,22 @@ const card: Card = {
 	retreat: 2,
 
 
-	thirdParty: {
-		cardmarket: 275250,
-		tcgplayer: 85669
-	},
-
 	variants: [
 		{
 			type: 'normal',
+			thirdParty: {
+				tcgplayer: 85669,
+				cardmarket: 275250
+			},
 		},
 		{
 			type: 'reverse',
-		}
-	]
+			thirdParty: {
+				tcgplayer: 85669,
+				cardmarket: 275250
+			},
+		},
+	],
 }
 
 export default card

--- a/data/E-Card/Skyridge/100.ts
+++ b/data/E-Card/Skyridge/100.ts
@@ -12,14 +12,12 @@ const card: Card = {
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		143,
-	],
+	dexId: [143],
 
 	hp: 80,
 
 	types: [
-		"Colorless",
+		"Colorless"
 	],
 
 	stage: "Basic",
@@ -32,7 +30,7 @@ const card: Card = {
 				de: "Herumlümmeln"
 			},
 			effect: {
-				en: "Once during your turn (before you attack) if Snorlax is your Active Pokémon, you may remove 1 damage counter from Snorlax. Snorlax is now Asleep. This power can't be used if Snorlax is affected by a Special Condition.",
+				en: "Once during your turn (before your attack), if Snorlax is your Active Pokémon, you may remove 1 damage counter from Snorlax. Snorlax is now Asleep. This power can't be used if Snorlax is affected by a Special Condition.",
 				de: "Einmal während deines Zuges (vor deinem Angriff) kannst du, falls Relaxo dein aktives Pokémon ist, 1 Schadensmarke von Relaxo entfernen. Relaxo schläft jetzt. Diese Fähigkeit kann nicht verwendet werden, falls Relaxo von einem speziellen Zustand betroffen ist."
 			},
 		},
@@ -53,7 +51,7 @@ const card: Card = {
 				en: "Flip a coin until you get tails. This attack does 30 damage times the number of heads.",
 				de: "Wirf eine Münze, bis du \"Zahl\" wirfst. Dieser Angriff fügt 30 Schadenspunkte mal der Anzahl \"Kopf\" zu."
 			},
-			damage: "30x",
+			damage: "30×",
 
 		},
 	],
@@ -61,25 +59,28 @@ const card: Card = {
 	weaknesses: [
 		{
 			type: "Fighting",
-			value: "×2"
+			value: "x2"
 		},
 	],
 	retreat: 3,
 
 
-	thirdParty: {
-		cardmarket: 275358,
-		tcgplayer: 89387
-	},
-
 	variants: [
 		{
 			type: 'normal',
+			thirdParty: {
+				tcgplayer: 89387,
+				cardmarket: 275358
+			},
 		},
 		{
 			type: 'reverse',
-		}
-	]
+			thirdParty: {
+				tcgplayer: 89387,
+				cardmarket: 275358
+			},
+		},
+	],
 }
 
 export default card

--- a/data/E-Card/Skyridge/101.ts
+++ b/data/E-Card/Skyridge/101.ts
@@ -12,14 +12,12 @@ const card: Card = {
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		209,
-	],
+	dexId: [209],
 
 	hp: 50,
 
 	types: [
-		"Colorless",
+		"Colorless"
 	],
 
 	stage: "Basic",
@@ -34,7 +32,7 @@ const card: Card = {
 				de: "Grimasse"
 			},
 			effect: {
-				en: "Flip a coin. If heads, until the end of your opponent's next turn the Defending Pokémon can't Retreat.",
+				en: "Flip a coin. If heads, until the end of your opponent's next turn the Defending Pokémon can't attack or retreat.",
 				de: "Wirf eine Münze. Bei 'Kopf' kann das verteidigende Pokémon bis zum Ende des nächsten gegnerischen Zugs weder angreifen noch sich zurückziehen."
 			},
 
@@ -57,25 +55,28 @@ const card: Card = {
 	weaknesses: [
 		{
 			type: "Fighting",
-			value: "×2"
+			value: "x2"
 		},
 	],
 	retreat: 1,
 
 
-	thirdParty: {
-		cardmarket: 275359,
-		tcgplayer: 89413
-	},
-
 	variants: [
 		{
 			type: 'normal',
+			thirdParty: {
+				tcgplayer: 89413,
+				cardmarket: 275359
+			},
 		},
 		{
 			type: 'reverse',
-		}
-	]
+			thirdParty: {
+				tcgplayer: 89413,
+				cardmarket: 275359
+			},
+		},
+	],
 }
 
 export default card

--- a/data/E-Card/Skyridge/102.ts
+++ b/data/E-Card/Skyridge/102.ts
@@ -12,14 +12,12 @@ const card: Card = {
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		234,
-	],
+	dexId: [234],
 
 	hp: 60,
 
 	types: [
-		"Colorless",
+		"Colorless"
 	],
 
 	stage: "Basic",
@@ -34,7 +32,7 @@ const card: Card = {
 				de: "Bedrohen"
 			},
 			effect: {
-				en: "Flip a coin. If heads, look at your opponent's hand. If he or she has any Trainer cards there, choose 1 of them. Your opponent shuffles that card back into his or her deck.",
+				en: "Flip a coin. If heads, look at your opponent's hand. If he or she has any Trainer cards there, choose 1 of them. Your opponent shuffles that card into his or her deck.",
 				de: "Wirf eine Münze. Schau dir bei \"Kopf\" die Karten auf der Hand deines Gegners an. Wenn er darunter mindestens eine Trainerkarte hat, wähle eine davon. Dein Gegner mischt diese Karte in sein Deck."
 			},
 
@@ -49,7 +47,7 @@ const card: Card = {
 				de: "Geweihschlag"
 			},
 			effect: {
-				en: "Flip a coin. If heads, this attack does 20 damage to the Defending Pokémon (Don't apply Weakness and Resistance) If tails, your and opponent has any Benched Pokémon, choose 1 of them and this attack does 20 damage to it. (Don't apply Weakness and Resistance for Benched Pokémon.)",
+				en: "Flip a coin. If heads, this attack does 20 damage to the Defending Pokémon (don't apply Weakness or Resistance). If tails and your opponent has any Benched Pokémon, choose 1 of them and this attack does 20 damage to it. (Don't apply Weakness and Resistance for Benched Pokémon.)",
 				de: "Wirf eine Münze. Bei \"Kopf\" fügt dieser Angriff dem verteidigenden Pokémon 20 Schadenspunkte zu. (Wende keine Schwäche oder Resistenz an.) Bei \"Zahl\", wähle 1 Pokémon von der Bank deines Gegners, wenn dort Pokémon vorhanden sind. Dieser Angriff fügt diesem Pokémon 20 Schadenspunkte zu. (Wende keine Schwäche oder Resistenz bei Pokémon auf der Bank an.)"
 			},
 
@@ -59,25 +57,28 @@ const card: Card = {
 	weaknesses: [
 		{
 			type: "Fighting",
-			value: "×2"
+			value: "x2"
 		},
 	],
 	retreat: 1,
 
 
-	thirdParty: {
-		cardmarket: 275360,
-		tcgplayer: 89502
-	},
-
 	variants: [
 		{
 			type: 'normal',
+			thirdParty: {
+				tcgplayer: 89502,
+				cardmarket: 275360
+			},
 		},
 		{
 			type: 'reverse',
-		}
-	]
+			thirdParty: {
+				tcgplayer: 89502,
+				cardmarket: 275360
+			},
+		},
+	],
 }
 
 export default card

--- a/data/E-Card/Skyridge/103.ts
+++ b/data/E-Card/Skyridge/103.ts
@@ -12,14 +12,12 @@ const card: Card = {
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		120,
-	],
+	dexId: [120],
 
 	hp: 40,
 
 	types: [
-		"Water",
+		"Water"
 	],
 
 	stage: "Basic",
@@ -34,7 +32,7 @@ const card: Card = {
 				de: "Energieauffrischung"
 			},
 			effect: {
-				en: "Remove 2 damage counters from Staryu for each energy attached to it. If it has fewer damage counters than that, remove all of them.",
+				en: "Remove 2 damage counters from Staryu for each Energy attached to it. If it has fewer damage counters than that, remove all of them.",
 				de: "Entferne für jede an Sterndu angelegte Energie 2 Schadensmarken von ihm. Wenn es weniger Schadensmarken hat, entferne alle."
 			},
 
@@ -51,7 +49,7 @@ const card: Card = {
 				en: "Flip 2 coins. This attack does 10 damage times the number of heads.",
 				de: "Wirf 2 Münzen. Dieser Angriff fügt 10 Schadenspunkte mal der Anzahl \"Kopf\" zu."
 			},
-			damage: "10x",
+			damage: "10×",
 
 		},
 	],
@@ -59,25 +57,28 @@ const card: Card = {
 	weaknesses: [
 		{
 			type: "Lightning",
-			value: "×2"
+			value: "x2"
 		},
 	],
 	retreat: 1,
 
 
-	thirdParty: {
-		cardmarket: 275361,
-		tcgplayer: 89544
-	},
-
 	variants: [
 		{
 			type: 'normal',
+			thirdParty: {
+				tcgplayer: 89544,
+				cardmarket: 275361
+			},
 		},
 		{
 			type: 'reverse',
-		}
-	]
+			thirdParty: {
+				tcgplayer: 89544,
+				cardmarket: 275361
+			},
+		},
+	],
 }
 
 export default card

--- a/data/E-Card/Skyridge/104.ts
+++ b/data/E-Card/Skyridge/104.ts
@@ -12,14 +12,12 @@ const card: Card = {
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		120,
-	],
+	dexId: [120],
 
 	hp: 50,
 
 	types: [
-		"Water",
+		"Water"
 	],
 
 	stage: "Basic",
@@ -58,25 +56,28 @@ const card: Card = {
 	weaknesses: [
 		{
 			type: "Lightning",
-			value: "×2"
+			value: "x2"
 		},
 	],
 	retreat: 1,
 
 
-	thirdParty: {
-		cardmarket: 275362,
-		tcgplayer: 89545
-	},
-
 	variants: [
 		{
 			type: 'normal',
+			thirdParty: {
+				tcgplayer: 89545,
+				cardmarket: 275362
+			},
 		},
 		{
 			type: 'reverse',
-		}
-	]
+			thirdParty: {
+				tcgplayer: 89545,
+				cardmarket: 275362
+			},
+		},
+	],
 }
 
 export default card

--- a/data/E-Card/Skyridge/105.ts
+++ b/data/E-Card/Skyridge/105.ts
@@ -12,14 +12,12 @@ const card: Card = {
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		192,
-	],
+	dexId: [192],
 
 	hp: 70,
 
 	types: [
-		"Grass",
+		"Grass"
 	],
 
 	evolveFrom: {
@@ -66,10 +64,9 @@ const card: Card = {
 	weaknesses: [
 		{
 			type: "Fire",
-			value: "×2"
+			value: "x2"
 		},
 	],
-
 	resistances: [
 		{
 			type: "Water",
@@ -79,19 +76,22 @@ const card: Card = {
 	retreat: 1,
 
 
-	thirdParty: {
-		cardmarket: 275363,
-		tcgplayer: 89613
-	},
-
 	variants: [
 		{
 			type: 'normal',
+			thirdParty: {
+				tcgplayer: 89613,
+				cardmarket: 275363
+			},
 		},
 		{
 			type: 'reverse',
-		}
-	]
+			thirdParty: {
+				tcgplayer: 89613,
+				cardmarket: 275363
+			},
+		},
+	],
 }
 
 export default card

--- a/data/E-Card/Skyridge/106.ts
+++ b/data/E-Card/Skyridge/106.ts
@@ -12,14 +12,12 @@ const card: Card = {
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		191,
-	],
+	dexId: [191],
 
 	hp: 40,
 
 	types: [
-		"Grass",
+		"Grass"
 	],
 
 	stage: "Basic",
@@ -57,10 +55,9 @@ const card: Card = {
 	weaknesses: [
 		{
 			type: "Fire",
-			value: "×2"
+			value: "x2"
 		},
 	],
-
 	resistances: [
 		{
 			type: "Water",
@@ -70,19 +67,22 @@ const card: Card = {
 	retreat: 1,
 
 
-	thirdParty: {
-		cardmarket: 275364,
-		tcgplayer: 89619
-	},
-
 	variants: [
 		{
 			type: 'normal',
+			thirdParty: {
+				tcgplayer: 89619,
+				cardmarket: 275364
+			},
 		},
 		{
 			type: 'reverse',
-		}
-	]
+			thirdParty: {
+				tcgplayer: 89619,
+				cardmarket: 275364
+			},
+		},
+	],
 }
 
 export default card

--- a/data/E-Card/Skyridge/107.ts
+++ b/data/E-Card/Skyridge/107.ts
@@ -12,14 +12,12 @@ const card: Card = {
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		220,
-	],
+	dexId: [220],
 
 	hp: 50,
 
 	types: [
-		"Water",
+		"Water"
 	],
 
 	stage: "Basic",
@@ -56,25 +54,28 @@ const card: Card = {
 	weaknesses: [
 		{
 			type: "Metal",
-			value: "×2"
+			value: "x2"
 		},
 	],
 	retreat: 1,
 
 
-	thirdParty: {
-		cardmarket: 275365,
-		tcgplayer: 89700
-	},
-
 	variants: [
 		{
 			type: 'normal',
+			thirdParty: {
+				tcgplayer: 89700,
+				cardmarket: 275365
+			},
 		},
 		{
 			type: 'reverse',
-		}
-	]
+			thirdParty: {
+				tcgplayer: 89700,
+				cardmarket: 275365
+			},
+		},
+	],
 }
 
 export default card

--- a/data/E-Card/Skyridge/108.ts
+++ b/data/E-Card/Skyridge/108.ts
@@ -12,14 +12,12 @@ const card: Card = {
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		220,
-	],
+	dexId: [220],
 
 	hp: 50,
 
 	types: [
-		"Fighting",
+		"Fighting"
 	],
 
 	stage: "Basic",
@@ -47,7 +45,7 @@ const card: Card = {
 				de: "Überrennen"
 			},
 			effect: {
-				en: "If your opponent has nay Benched Pokémon, flip a coin. If heads, choose 1 of them and this attack does 10 damage to it. (Don't apply Weakness and Resistance for Benched Pokémon.)",
+				en: "If your opponent has any Benched Pokémon, flip a coin. If heads, choose 1 of them and this attack does 10 damage to it. (Don't apply Weakness and Resistance for Benched Pokémon.)",
 				de: "Falls dein Gegner mindestens ein Pokémon auf der Bank aht, wirf eine Münze. Wähle bei 'Kopf' eines von diesen. Dieser Angriff fügt ihm dann 10 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
 			},
 			damage: 10,
@@ -58,10 +56,9 @@ const card: Card = {
 	weaknesses: [
 		{
 			type: "Grass",
-			value: "×2"
+			value: "x2"
 		},
 	],
-
 	resistances: [
 		{
 			type: "Lightning",
@@ -71,19 +68,22 @@ const card: Card = {
 	retreat: 1,
 
 
-	thirdParty: {
-		cardmarket: 275366,
-		tcgplayer: 89701
-	},
-
 	variants: [
 		{
 			type: 'normal',
+			thirdParty: {
+				tcgplayer: 89701,
+				cardmarket: 275366
+			},
 		},
 		{
 			type: 'reverse',
-		}
-	]
+			thirdParty: {
+				tcgplayer: 89701,
+				cardmarket: 275366
+			},
+		},
+	],
 }
 
 export default card

--- a/data/E-Card/Skyridge/109.ts
+++ b/data/E-Card/Skyridge/109.ts
@@ -12,14 +12,12 @@ const card: Card = {
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		216,
-	],
+	dexId: [216],
 
 	hp: 40,
 
 	types: [
-		"Colorless",
+		"Colorless"
 	],
 
 	stage: "Basic",
@@ -40,7 +38,7 @@ const card: Card = {
 				de: "Wirf eine Münze. Bei \"Zahl\" hat dieser Angriff keine Auswirkungen."
 			},
 
-			damage: 20
+			damage: 20,
 		},
 		{
 			cost: [
@@ -63,25 +61,28 @@ const card: Card = {
 	weaknesses: [
 		{
 			type: "Fighting",
-			value: "×2"
+			value: "x2"
 		},
 	],
 	retreat: 1,
 
 
-	thirdParty: {
-		cardmarket: 275367,
-		tcgplayer: 89856
-	},
-
 	variants: [
 		{
 			type: 'normal',
+			thirdParty: {
+				tcgplayer: 89856,
+				cardmarket: 275367
+			},
 		},
 		{
 			type: 'reverse',
-		}
-	]
+			thirdParty: {
+				tcgplayer: 89856,
+				cardmarket: 275367
+			},
+		},
+	],
 }
 
 export default card

--- a/data/E-Card/Skyridge/11.ts
+++ b/data/E-Card/Skyridge/11.ts
@@ -12,14 +12,12 @@ const card: Card = {
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		130,
-	],
+	dexId: [130],
 
 	hp: 90,
 
 	types: [
-		"Water",
+		"Water"
 	],
 
 	evolveFrom: {
@@ -61,32 +59,35 @@ const card: Card = {
 				de: "Verfügt Garados über 7 oder mehr Schadensmarken, beträgt der Basisschaden dieses Angriffs 100."
 			},
 
-			damage: 50
+			damage: 50,
 		},
 	],
 
 	weaknesses: [
 		{
 			type: "Lightning",
-			value: "×2"
+			value: "x2"
 		},
 	],
 	retreat: 2,
 
 
-	thirdParty: {
-		cardmarket: 275237,
-		tcgplayer: 85988
-	},
-
 	variants: [
 		{
 			type: 'normal',
+			thirdParty: {
+				tcgplayer: 85988,
+				cardmarket: 275237
+			},
 		},
 		{
 			type: 'reverse',
-		}
-	]
+			thirdParty: {
+				tcgplayer: 85988,
+				cardmarket: 275237
+			},
+		},
+	],
 }
 
 export default card

--- a/data/E-Card/Skyridge/110.ts
+++ b/data/E-Card/Skyridge/110.ts
@@ -12,14 +12,12 @@ const card: Card = {
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		217,
-	],
+	dexId: [217],
 
 	hp: 80,
 
 	types: [
-		"Colorless",
+		"Colorless"
 	],
 
 	evolveFrom: {
@@ -40,7 +38,7 @@ const card: Card = {
 				de: "Umklammerung"
 			},
 			effect: {
-				en: "The Defending Pokémon can't Retreat during your opponent's next turn.",
+				en: "The Defending Pokémon can't retreat during your opponent's next turn.",
 				de: "Das verteidigende Pokémon kann sich im nächsten Zug deines gegners nicht zurückziehen."
 			},
 			damage: 30,
@@ -58,7 +56,7 @@ const card: Card = {
 				de: "Zerreißen"
 			},
 			effect: {
-				en: "If the Defending Pokémon has any damage counters on it, this attack does 40 damage plus 20 more damage. If not, this attack does 40 damage.",
+				en: "If the Defending Pokémon already has any damage counters on it, this attack does 40 damage plus 20 more damage. If not, this attack does 40 damage.",
 				de: "Liegen auf dem verteidigenden Pokémon bereits Schadensmarken, fügt dieser Angriff 40 Schadenspunkte plus 20 weitere Schadenspunkte zu. Sonnst fügt dieser Angriff 40 Schadenspunkte zu."
 			},
 			damage: "40+",
@@ -69,25 +67,28 @@ const card: Card = {
 	weaknesses: [
 		{
 			type: "Fighting",
-			value: "×2"
+			value: "x2"
 		},
 	],
 	retreat: 2,
 
 
-	thirdParty: {
-		cardmarket: 275368,
-		tcgplayer: 90251
-	},
-
 	variants: [
 		{
 			type: 'normal',
+			thirdParty: {
+				tcgplayer: 90251,
+				cardmarket: 275368
+			},
 		},
 		{
 			type: 'reverse',
-		}
-	]
+			thirdParty: {
+				tcgplayer: 90251,
+				cardmarket: 275368
+			},
+		},
+	],
 }
 
 export default card

--- a/data/E-Card/Skyridge/111.ts
+++ b/data/E-Card/Skyridge/111.ts
@@ -12,14 +12,12 @@ const card: Card = {
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		49,
-	],
+	dexId: [49],
 
 	hp: 70,
 
 	types: [
-		"Grass",
+		"Grass"
 	],
 
 	evolveFrom: {
@@ -61,30 +59,33 @@ const card: Card = {
 				de: "Wirf eine Münze. Wähle bei \"Kopf\" einen speziellen Zustand (Schlaf, verbrannt, verwirrt, gelähmt oder vergiftet). Das verteidigende Pokémon ist jetzt von diesem Spezielen Zustand betroffen."
 			},
 
-			damage: 30
+			damage: 30,
 		},
 	],
 
 	weaknesses: [
 		{
 			type: "Fire",
-			value: "×2"
+			value: "x2"
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 275369,
-		tcgplayer: 90300
-	},
-
 	variants: [
 		{
 			type: 'normal',
+			thirdParty: {
+				tcgplayer: 90300,
+				cardmarket: 275369
+			},
 		},
 		{
 			type: 'reverse',
-		}
-	]
+			thirdParty: {
+				tcgplayer: 90300,
+				cardmarket: 275369
+			},
+		},
+	],
+	retreat: 0,
 }
 
 export default card

--- a/data/E-Card/Skyridge/112.ts
+++ b/data/E-Card/Skyridge/112.ts
@@ -12,14 +12,12 @@ const card: Card = {
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		48,
-	],
+	dexId: [48],
 
 	hp: 50,
 
 	types: [
-		"Grass",
+		"Grass"
 	],
 
 	stage: "Basic",
@@ -37,7 +35,7 @@ const card: Card = {
 				en: "Flip 2 coins. This attack does 10 damage times the number of heads.",
 				de: "Wirf 2 Münzen. Dieser Angriff fügt 10 Schadenspunkte mal der Anzahl \"Kopf\" zu."
 			},
-			damage: "10x",
+			damage: "10×",
 
 		},
 		{
@@ -61,25 +59,28 @@ const card: Card = {
 	weaknesses: [
 		{
 			type: "Fire",
-			value: "×2"
+			value: "x2"
 		},
 	],
 	retreat: 1,
 
 
-	thirdParty: {
-		cardmarket: 275370,
-		tcgplayer: 90306
-	},
-
 	variants: [
 		{
 			type: 'normal',
+			thirdParty: {
+				tcgplayer: 90306,
+				cardmarket: 275370
+			},
 		},
 		{
 			type: 'reverse',
-		}
-	]
+			thirdParty: {
+				tcgplayer: 90306,
+				cardmarket: 275370
+			},
+		},
+	],
 }
 
 export default card

--- a/data/E-Card/Skyridge/113.ts
+++ b/data/E-Card/Skyridge/113.ts
@@ -12,14 +12,12 @@ const card: Card = {
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		100,
-	],
+	dexId: [100],
 
 	hp: 50,
 
 	types: [
-		"Lightning",
+		"Lightning"
 	],
 
 	stage: "Basic",
@@ -60,25 +58,28 @@ const card: Card = {
 	weaknesses: [
 		{
 			type: "Fighting",
-			value: "×2"
+			value: "x2"
 		},
 	],
 	retreat: 1,
 
 
-	thirdParty: {
-		cardmarket: 275371,
-		tcgplayer: 90411
-	},
-
 	variants: [
 		{
 			type: 'normal',
+			thirdParty: {
+				tcgplayer: 90411,
+				cardmarket: 275371
+			},
 		},
 		{
 			type: 'reverse',
-		}
-	]
+			thirdParty: {
+				tcgplayer: 90411,
+				cardmarket: 275371
+			},
+		},
+	],
 }
 
 export default card

--- a/data/E-Card/Skyridge/114.ts
+++ b/data/E-Card/Skyridge/114.ts
@@ -12,14 +12,12 @@ const card: Card = {
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		13,
-	],
+	dexId: [13],
 
 	hp: 40,
 
 	types: [
-		"Grass",
+		"Grass"
 	],
 
 	stage: "Basic",
@@ -37,7 +35,7 @@ const card: Card = {
 				en: "Flip 3 coins. This attack does 10 damage times the number of heads.",
 				de: "Wirf 3 Münzen. Dieser Angriff fügt 10 Schadenspunkte mal der Anzahl \"Kopf\" zu."
 			},
-			damage: "10x",
+			damage: "10×",
 
 		},
 	],
@@ -45,25 +43,28 @@ const card: Card = {
 	weaknesses: [
 		{
 			type: "Fire",
-			value: "×2"
+			value: "x2"
 		},
 	],
 	retreat: 1,
 
 
-	thirdParty: {
-		cardmarket: 275372,
-		tcgplayer: 90540
-	},
-
 	variants: [
 		{
 			type: 'normal',
+			thirdParty: {
+				tcgplayer: 90540,
+				cardmarket: 275372
+			},
 		},
 		{
 			type: 'reverse',
-		}
-	]
+			thirdParty: {
+				tcgplayer: 90540,
+				cardmarket: 275372
+			},
+		},
+	],
 }
 
 export default card

--- a/data/E-Card/Skyridge/115.ts
+++ b/data/E-Card/Skyridge/115.ts
@@ -12,14 +12,12 @@ const card: Card = {
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		13,
-	],
+	dexId: [13],
 
 	hp: 50,
 
 	types: [
-		"Grass",
+		"Grass"
 	],
 
 	stage: "Basic",
@@ -58,25 +56,28 @@ const card: Card = {
 	weaknesses: [
 		{
 			type: "Fire",
-			value: "×2"
+			value: "x2"
 		},
 	],
 	retreat: 1,
 
 
-	thirdParty: {
-		cardmarket: 275373,
-		tcgplayer: 90541
-	},
-
 	variants: [
 		{
 			type: 'normal',
+			thirdParty: {
+				tcgplayer: 90541,
+				cardmarket: 275373
+			},
 		},
 		{
 			type: 'reverse',
-		}
-	]
+			thirdParty: {
+				tcgplayer: 90541,
+				cardmarket: 275373
+			},
+		},
+	],
 }
 
 export default card

--- a/data/E-Card/Skyridge/116.ts
+++ b/data/E-Card/Skyridge/116.ts
@@ -12,14 +12,12 @@ const card: Card = {
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		193,
-	],
+	dexId: [193],
 
 	hp: 60,
 
 	types: [
-		"Grass",
+		"Grass"
 	],
 
 	stage: "Basic",
@@ -35,7 +33,7 @@ const card: Card = {
 				de: "Agilität"
 			},
 			effect: {
-				en: "Flip a coin. If heads, during your opponent's next turn prevent all effects of attacks, including damage, done to Yanma.",
+				en: "Flip a coin. If heads, during your opponent's next turn, prevent all effects of attacks, including damage, done to Yanma.",
 				de: "Wird eine Münze. Bei \"Kopf\" verhindere während des nächsten Zuges alle Auswirkungen von Angriffen (einschließlich Schaden), die Yanma zugefügt werden."
 			},
 			damage: 10,
@@ -55,7 +53,7 @@ const card: Card = {
 				en: "Flip 3 coins. This attack does 20 damage plus 10 more damage for each heads.",
 				de: "Wirf 3 Münzen. Dieser Angriff fügt 20 Schadenspunkte plus 10 weitere Schadenspunkte pro geworfenem \"Kopf\" zu."
 			},
-			damage: 20,
+			damage: "20+",
 
 		},
 	],
@@ -63,10 +61,9 @@ const card: Card = {
 	weaknesses: [
 		{
 			type: "Lightning",
-			value: "×2"
+			value: "x2"
 		},
 	],
-
 	resistances: [
 		{
 			type: "Fighting",
@@ -76,19 +73,22 @@ const card: Card = {
 	retreat: 1,
 
 
-	thirdParty: {
-		cardmarket: 275374,
-		tcgplayer: 90682
-	},
-
 	variants: [
 		{
 			type: 'normal',
+			thirdParty: {
+				tcgplayer: 90682,
+				cardmarket: 275374
+			},
 		},
 		{
 			type: 'reverse',
-		}
-	]
+			thirdParty: {
+				tcgplayer: 90682,
+				cardmarket: 275374
+			},
+		},
+	],
 }
 
 export default card

--- a/data/E-Card/Skyridge/117.ts
+++ b/data/E-Card/Skyridge/117.ts
@@ -12,14 +12,12 @@ const card: Card = {
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		41,
-	],
+	dexId: [41],
 
 	hp: 40,
 
 	types: [
-		"Grass",
+		"Grass"
 	],
 
 	stage: "Basic",
@@ -58,10 +56,9 @@ const card: Card = {
 	weaknesses: [
 		{
 			type: "Lightning",
-			value: "×2"
+			value: "x2"
 		},
 	],
-
 	resistances: [
 		{
 			type: "Fighting",
@@ -71,19 +68,22 @@ const card: Card = {
 	retreat: 1,
 
 
-	thirdParty: {
-		cardmarket: 275375,
-		tcgplayer: 90768
-	},
-
 	variants: [
 		{
 			type: 'normal',
+			thirdParty: {
+				tcgplayer: 90768,
+				cardmarket: 275375
+			},
 		},
 		{
 			type: 'reverse',
-		}
-	]
+			thirdParty: {
+				tcgplayer: 90768,
+				cardmarket: 275375
+			},
+		},
+	],
 }
 
 export default card

--- a/data/E-Card/Skyridge/118.ts
+++ b/data/E-Card/Skyridge/118.ts
@@ -12,14 +12,12 @@ const card: Card = {
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		41,
-	],
+	dexId: [41],
 
 	hp: 50,
 
 	types: [
-		"Grass",
+		"Grass"
 	],
 
 	stage: "Basic",
@@ -58,25 +56,28 @@ const card: Card = {
 	weaknesses: [
 		{
 			type: "Psychic",
-			value: "×2"
+			value: "x2"
 		},
 	],
 	retreat: 1,
 
 
-	thirdParty: {
-		cardmarket: 275376,
-		tcgplayer: 90769
-	},
-
 	variants: [
 		{
 			type: 'normal',
+			thirdParty: {
+				tcgplayer: 90769,
+				cardmarket: 275376
+			},
 		},
 		{
 			type: 'reverse',
-		}
-	]
+			thirdParty: {
+				tcgplayer: 90769,
+				cardmarket: 275376
+			},
+		},
+	],
 }
 
 export default card

--- a/data/E-Card/Skyridge/119.ts
+++ b/data/E-Card/Skyridge/119.ts
@@ -10,6 +10,7 @@ const card: Card = {
 	illustrator: "Midori Harada",
 	rarity: "Uncommon",
 	category: "Trainer",
+	trainerType: "Stadium",
 	set: Set,
 
 	effect: {
@@ -17,19 +18,22 @@ const card: Card = {
 		de: "Diese Karte bleibt im Spiel wenn du sie spielst. Lege diese Karte ab, sobald eine weitere Stadion-Karte ins Spiel kommt. Einmal während des Zuges jedes Spielers (vor dem Angriff) kann dieser Spieler, falls er keine Unterstützer-Karte gespielt hat, die Karten auf seiner Hand seinem Gegner zeigen. Wenn dieser Spieler seine Karten zeigt und sich keine Unterstützer-Karte darunter befindet, zieht er eine Karte."
 	},
 
-	thirdParty: {
-		cardmarket: 275377,
-		tcgplayer: 83552
-	},
-
 	variants: [
 		{
 			type: 'normal',
+			thirdParty: {
+				tcgplayer: 83552,
+				cardmarket: 275377
+			},
 		},
 		{
 			type: 'reverse',
-		}
-	]
+			thirdParty: {
+				tcgplayer: 83552,
+				cardmarket: 275377
+			},
+		},
+	],
 }
 
 export default card

--- a/data/E-Card/Skyridge/12.ts
+++ b/data/E-Card/Skyridge/12.ts
@@ -12,14 +12,12 @@ const card: Card = {
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		229,
-	],
+	dexId: [229],
 
 	hp: 70,
 
 	types: [
-		"Darkness",
+		"Darkness"
 	],
 
 	evolveFrom: {
@@ -56,7 +54,7 @@ const card: Card = {
 				de: "Einzelner Reißzahn"
 			},
 			effect: {
-				en: "This attack does 30 damage plus 20 damage times the number of your opponent's Benched Pokémon minus the number of your Benched Pokémon. (For example, if your opponent has 3 Benched Pokémon and you have 1, this attack will do 30 damage plus 40 more damage.",
+				en: "This attack does 30 damage plus 20 damage times the number of your opponent's Benched Pokémon minus the number of your Benched Pokémon. (For example, if your opponent has 3 Benched Pokémon and you have 1, this attack will do 30 damage plus 40 more damage.)",
 				de: "Dieser Angriff fügt 30 Schadenspunkte plus 20 weitere Schadenspunkte für jedes Pokémon auf der Bank deines Gegners minus 20 Schadenspunkte für jedes Pokémon auf deiner Bank zu. (Hat zum Beispiel dein Gegner 3 Pokémon auf seiner Bank und du nur 1 auf deiner, fügt dieser Angriff 30 Schadenspunkte plus 40 weitere Schadenspunkte zu.)"
 			},
 			damage: "30+",
@@ -67,10 +65,9 @@ const card: Card = {
 	weaknesses: [
 		{
 			type: "Fighting",
-			value: "×2"
+			value: "x2"
 		},
 	],
-
 	resistances: [
 		{
 			type: "Psychic",
@@ -80,19 +77,22 @@ const card: Card = {
 	retreat: 1,
 
 
-	thirdParty: {
-		cardmarket: 275236,
-		tcgplayer: 86201
-	},
-
 	variants: [
 		{
 			type: 'normal',
+			thirdParty: {
+				tcgplayer: 86201,
+				cardmarket: 275236
+			},
 		},
 		{
 			type: 'reverse',
-		}
-	]
+			thirdParty: {
+				tcgplayer: 86201,
+				cardmarket: 275236
+			},
+		},
+	],
 }
 
 export default card

--- a/data/E-Card/Skyridge/120.ts
+++ b/data/E-Card/Skyridge/120.ts
@@ -10,6 +10,7 @@ const card: Card = {
 	illustrator: "Kagemaru Himeno",
 	rarity: "Uncommon",
 	category: "Trainer",
+	trainerType: "Supporter",
 	set: Set,
 
 	effect: {
@@ -17,19 +18,22 @@ const card: Card = {
 		de: "Du kannst in jedem Zug nur 1 Unterstützer-Karte spielen. Wenn du diese Karte ausspielst, lege sie neben dein aktives Pokémon. Lege diese Karte am Ende deines Zuges auf deinen Ablagestapel. Durchsuche dein Deck nach bis zu 2 Unterstützer- bzw. Stadion-Karten, zeige sie deinem Gegner und nimm sie auf deine Hand. Mische dein Deck danach."
 	},
 
-	thirdParty: {
-		cardmarket: 275378,
-		tcgplayer: 88683
-	},
-
 	variants: [
 		{
 			type: 'normal',
+			thirdParty: {
+				tcgplayer: 88683,
+				cardmarket: 275378
+			},
 		},
 		{
 			type: 'reverse',
-		}
-	]
+			thirdParty: {
+				tcgplayer: 88683,
+				cardmarket: 275378
+			},
+		},
+	],
 }
 
 export default card

--- a/data/E-Card/Skyridge/121.ts
+++ b/data/E-Card/Skyridge/121.ts
@@ -10,6 +10,7 @@ const card: Card = {
 	illustrator: "Kagemaru Himeno",
 	rarity: "Uncommon",
 	category: "Trainer",
+	trainerType: "Supporter",
 	set: Set,
 
 	effect: {
@@ -17,19 +18,22 @@ const card: Card = {
 		de: "Durchsuche dein Deck nach bis zu 2 Trainer-Karten, die Ball in ihrem Namen haben, zeige sie deinem Gegner und nimm sie auf die Hand. Mische dein Deck danach."
 	},
 
-	thirdParty: {
-		cardmarket: 275379,
-		tcgplayer: 83564
-	},
-
 	variants: [
 		{
 			type: 'normal',
+			thirdParty: {
+				tcgplayer: 83564,
+				cardmarket: 275379
+			},
 		},
 		{
 			type: 'reverse',
-		}
-	]
+			thirdParty: {
+				tcgplayer: 83564,
+				cardmarket: 275379
+			},
+		},
+	],
 }
 
 export default card

--- a/data/E-Card/Skyridge/122.ts
+++ b/data/E-Card/Skyridge/122.ts
@@ -10,6 +10,7 @@ const card: Card = {
 	illustrator: "Jungo Suzuki",
 	rarity: "Uncommon",
 	category: "Trainer",
+	trainerType: "Tool",
 	set: Set,
 
 	effect: {
@@ -17,19 +18,22 @@ const card: Card = {
 		de: "So lange diese Karte an ein Pokémon angelegt ist, ist der Typ (Farbe) dieses Pokémon . Greift das Pokémon an, lege diese Karte am Ende des Zuges auf deinen Ablagestapel."
 	},
 
-	thirdParty: {
-		cardmarket: 275380,
-		tcgplayer: 84519
-	},
-
 	variants: [
 		{
 			type: 'normal',
+			thirdParty: {
+				tcgplayer: 84519,
+				cardmarket: 275380
+			},
 		},
 		{
 			type: 'reverse',
-		}
-	]
+			thirdParty: {
+				tcgplayer: 84519,
+				cardmarket: 275380
+			},
+		},
+	],
 }
 
 export default card

--- a/data/E-Card/Skyridge/123.ts
+++ b/data/E-Card/Skyridge/123.ts
@@ -10,6 +10,7 @@ const card: Card = {
 	illustrator: "Kagemaru Himeno",
 	rarity: "Uncommon",
 	category: "Trainer",
+	trainerType: "Supporter",
 	set: Set,
 
 	effect: {
@@ -17,23 +18,29 @@ const card: Card = {
 		de: "Mische die Karte auf deiner Hand in dein Deck und ziehe bis zu 4 Karten. Dein Gegner geht genau so vor."
 	},
 
-	thirdParty: {
-		cardmarket: 275381,
-		tcgplayer: 84782
-	},
-
 	variants: [
 		{
 			type: 'normal',
+			thirdParty: {
+				tcgplayer: 84782,
+				cardmarket: 275381
+			},
 		},
 		{
 			type: 'reverse',
+			thirdParty: {
+				tcgplayer: 84782,
+				cardmarket: 275381
+			},
 		},
 		{
 			type: 'normal',
-			stamp: ['kevin-nguyen']
+			stamp: ['kevin-nguyen'],
+			thirdParty: {
+				tcgplayer: 477379
+			}
 		}
-	]
+	],
 }
 
 export default card

--- a/data/E-Card/Skyridge/124.ts
+++ b/data/E-Card/Skyridge/124.ts
@@ -17,19 +17,22 @@ const card: Card = {
 		de: "Decke Karten aus deinem deck auf, bis du eine Entwicklungskarte aufdeckst. Zeige diese Karte deinem Gegner und nimm sie auf deine Hand. Mische die anderen aufgedeckten Karten in dein Deck. (Ist unter den aufgedeckten Karten keine Entwicklungskarte, mische alle aufgedeckten karten zurück in dein Deck.)"
 	},
 
-	thirdParty: {
-		cardmarket: 275382,
-		tcgplayer: 85391
-	},
-
 	variants: [
 		{
 			type: 'normal',
+			thirdParty: {
+				tcgplayer: 85391,
+				cardmarket: 275382
+			},
 		},
 		{
 			type: 'reverse',
-		}
-	]
+			thirdParty: {
+				tcgplayer: 85391,
+				cardmarket: 275382
+			},
+		},
+	],
 }
 
 export default card

--- a/data/E-Card/Skyridge/125.ts
+++ b/data/E-Card/Skyridge/125.ts
@@ -10,6 +10,7 @@ const card: Card = {
 	illustrator: "Kagemaru Himeno",
 	rarity: "Uncommon",
 	category: "Trainer",
+	trainerType: "Supporter",
 	set: Set,
 
 	effect: {
@@ -17,19 +18,22 @@ const card: Card = {
 		de: "Wähle 4 Basis Energiekarten aus deinem Ablagestapel (falls dort weniger Basis Energiekarten vorhanden sind, nimm sie alle), zeige sie deinem Gegner und nimm sie auf deine Hand."
 	},
 
-	thirdParty: {
-		cardmarket: 275383,
-		tcgplayer: 85471
-	},
-
 	variants: [
 		{
 			type: 'normal',
+			thirdParty: {
+				tcgplayer: 85471,
+				cardmarket: 275383
+			},
 		},
 		{
 			type: 'reverse',
-		}
-	]
+			thirdParty: {
+				tcgplayer: 85471,
+				cardmarket: 275383
+			},
+		},
+	],
 }
 
 export default card

--- a/data/E-Card/Skyridge/126.ts
+++ b/data/E-Card/Skyridge/126.ts
@@ -17,23 +17,29 @@ const card: Card = {
 		de: "Wähle 1 der Pokémon deines Gegners. Durchsuche dein Deck nach einem Baby-Pokémon, einem Basis-Pokémon oder einer Entwicklungskarte des gleichen Typs (der gleichen Farbe), zeige diese Karte deinem Gegner und nimm sie auf deine Hand. Mische dein Deck danach."
 	},
 
-	thirdParty: {
-		cardmarket: 275384,
-		tcgplayer: 85562
-	},
-
 	variants: [
 		{
 			type: 'normal',
+			thirdParty: {
+				tcgplayer: 85562,
+				cardmarket: 275384
+			},
 		},
 		{
 			type: 'reverse',
+			thirdParty: {
+				tcgplayer: 85562,
+				cardmarket: 275384
+			},
 		},
 		{
 			type: 'normal',
-			stamp: ['chris-fulop']
+			stamp: ['chris-fulop'],
+			thirdParty: {
+				tcgplayer: 477385
+			}
 		}
-	]
+	],
 }
 
 export default card

--- a/data/E-Card/Skyridge/127.ts
+++ b/data/E-Card/Skyridge/127.ts
@@ -17,19 +17,22 @@ const card: Card = {
 		de: "Wähle eines deiner Pokémon. Lege 1 oder 2 an dieses Pokémon angelgte Basis-Energiekarten auf deinen Ablagestapel. Hast du 1 Energiekarte auf deinen Ablagestapel gelegt, entferne bis zu 3 Schadensmarken von diesem Pokémon. Hast du 2 Energiekarten auf deinen Ablagestapel gelegt, entferne bis zu 5 Schadensmarken von deinem Pokémon."
 	},
 
-	thirdParty: {
-		cardmarket: 275385,
-		tcgplayer: 86246
-	},
-
 	variants: [
 		{
 			type: 'normal',
+			thirdParty: {
+				tcgplayer: 86246,
+				cardmarket: 275385
+			},
 		},
 		{
 			type: 'reverse',
-		}
-	]
+			thirdParty: {
+				tcgplayer: 86246,
+				cardmarket: 275385
+			},
+		},
+	],
 }
 
 export default card

--- a/data/E-Card/Skyridge/128.ts
+++ b/data/E-Card/Skyridge/128.ts
@@ -17,19 +17,22 @@ const card: Card = {
 		de: "Wirf 3 Münzen. Bei jedem \"Kopf\" wähle eine Entwicklungskarte aus deinem Ablagestapel, zeige sie deinem Gegner und nimm sie auf deine Hand."
 	},
 
-	thirdParty: {
-		cardmarket: 275386,
-		tcgplayer: 86931
-	},
-
 	variants: [
 		{
 			type: 'normal',
+			thirdParty: {
+				tcgplayer: 86931,
+				cardmarket: 275386
+			},
 		},
 		{
 			type: 'reverse',
-		}
-	]
+			thirdParty: {
+				tcgplayer: 86931,
+				cardmarket: 275386
+			},
+		},
+	],
 }
 
 export default card

--- a/data/E-Card/Skyridge/129.ts
+++ b/data/E-Card/Skyridge/129.ts
@@ -3,8 +3,8 @@ import Set from '../Skyridge'
 
 const card: Card = {
 	name: {
-		en: "Miracle Sphere Alpha",
-		de: "Wunder Sphäre (Alpha)"
+		en: "Miracle Sphere α",
+		de: "Wunder Sphäre α"
 	},
 
 	illustrator: "Hiromichi Sugiyama",
@@ -14,13 +14,14 @@ const card: Card = {
 
 	attacks: [{
 		name: {
+			en: "Fire Force",
 			de: "Feuerkraft"
 		},
 
 		damage: "30+",
 
 		effect: {
-		en: "Attach this card to 1 of your Evolved Fire, Lightning, or Fighting Pokémon in play. That Pokémon may use this card's attack instead of its own. At the end of your turn, discard Miracle Plate α.",
+			en: "If the Pokémon using this attack has Fire and Lightning basic Energy cards attached to it, the Defending Pokémon is now Confused. If the Pokémon using this attack has Fire and Fighting basic Energy cards attached to it, this attack does 30 damage plus 10 more damage and remove 3 damage counters from the Pokémon that Miracle Plate α is attached to.",
 			de: "Sind an das Pokémon, das diesen Angriff verwendet  und  Basis Energiekarten angelegt, ist das verteidigende Pokémon jetzt verwirrt. Sind an das Pokémon das diesen Angriff verwendet  und  Basis-Energiekarten angelegt, fügt dieser Angriff 30 Schadenspunkte plus 10 weitere Schadenspunkte zu und entfernt 3 Schadensmarken von dem Pokémon, an das Wunder Sphäre a angelegt ist."
 		},
 
@@ -32,18 +33,21 @@ const card: Card = {
 		de: "Lege diese Karte an 1 deiner entwickelten  ,  oder  Pokémon im Spiel an. Dieses Pokémon kann den Angriff dieser Karte anstatt seines eigenen verwenden. Lege am Ende deines Zuges die Wunder Sphäre a auf deinen Ablagestapel"
 	},
 
-	thirdParty: {
-		cardmarket: 275387,
-		tcgplayer: 87497
-	},
-
 	variants: [
 		{
 			type: 'normal',
+			thirdParty: {
+				tcgplayer: 87497,
+				cardmarket: 275387
+			},
 		},
 		{
 			type: 'reverse',
-		}
+			thirdParty: {
+				tcgplayer: 87497,
+				cardmarket: 275387
+			},
+		},
 	]
 }
 

--- a/data/E-Card/Skyridge/13.ts
+++ b/data/E-Card/Skyridge/13.ts
@@ -12,14 +12,12 @@ const card: Card = {
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		135,
-	],
+	dexId: [135],
 
 	hp: 70,
 
 	types: [
-		"Lightning",
+		"Lightning"
 	],
 
 	evolveFrom: {
@@ -32,7 +30,7 @@ const card: Card = {
 		{
 			type: "Poke-BODY",
 			name: {
-				en: "Self Healing",
+				en: "Self-healing",
 				de: "Selbstheilung"
 			},
 			effect: {
@@ -80,23 +78,26 @@ const card: Card = {
 	weaknesses: [
 		{
 			type: "Fighting",
-			value: "×2"
+			value: "x2"
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 275239,
-		tcgplayer: 86338
-	},
-
 	variants: [
 		{
 			type: 'normal',
+			thirdParty: {
+				tcgplayer: 86338,
+				cardmarket: 275239
+			},
 		},
 		{
 			type: 'reverse',
-		}
-	]
+			thirdParty: {
+				tcgplayer: 86338,
+				cardmarket: 275239
+			},
+		},
+	],
+	retreat: 0,
 }
 
 export default card

--- a/data/E-Card/Skyridge/130.ts
+++ b/data/E-Card/Skyridge/130.ts
@@ -3,8 +3,8 @@ import Set from '../Skyridge'
 
 const card: Card = {
 	name: {
-		en: "Miracle Sphere Beta",
-		de: "Wunder-Sphäre (Beta)"
+		en: "Miracle Sphere β",
+		de: "Wunder-Sphäre β"
 	},
 
 	illustrator: "Hiromichi Sugiyama",
@@ -14,13 +14,14 @@ const card: Card = {
 
 	attacks: [{
 		name: {
+			en: 'Freezing Force',
 			de: "Frostkraft"
 		},
 
 		damage: "30+",
 
 		effect: {
-		en: "Attach this card to 1 of your Evolved Fire, Water, or Psychic Pokémon in play. That Pokémon may use this card's attack instead of its own. At the end of your turn, discard Miracle Sphere β.",
+			en: "If the Pokémon using this attack has Fire and Water basic Energy cards attached to it, this attack does 30 damage plus 10 more damage and the Defending Pokémon is now Burned. If the Pokémon using this attack has Water and Psychic basic Energy cards attached to it, choose an Energy card attached to the Defending Pokémon, if any, and your opponent shuffles that card into his or her deck.",
 			de: "Frostkraft Sind an das Pokémon, das diesen Angriff verwendet,  und  Basis Energiekarten angelegt, fügt dieser Angriff 30 Schadenspunkte plus 10 weitere Schadenspunkte zu, und das verteidigende Pokémon ist jetzt verbrannt. Sind an das Pokémon, das diesen Angriff verwendet,  und  Basis Energiekarten angelegt, wähle eine an das verteidigende Pokémon angelegte Energiekarte, falls vorhanden. Dein Gegner mischt diese Karte dann in sein Deck."
 		},
 
@@ -32,18 +33,21 @@ const card: Card = {
 		de: "Lege diese Karte an 1 deiner entwickelten -, - oder  Pokémon im Spiel an. Dieses Pokémon kann den Angriff dieser Karte anstatt seines eigenen verwenden. Lege am Ende deines Zuges die Wunder-Sphäre (Beta) auf deinen Ablagestapel."
 	},
 
-	thirdParty: {
-		cardmarket: 275388,
-		tcgplayer: 87498
-	},
-
 	variants: [
 		{
 			type: 'normal',
+			thirdParty: {
+				tcgplayer: 87498,
+				cardmarket: 275388
+			},
 		},
 		{
 			type: 'reverse',
-		}
+			thirdParty: {
+				tcgplayer: 87498,
+				cardmarket: 275388
+			},
+		},
 	]
 }
 

--- a/data/E-Card/Skyridge/130.ts
+++ b/data/E-Card/Skyridge/130.ts
@@ -30,7 +30,7 @@ const card: Card = {
 
 	effect: {
 		en: "Attach this card to 1 of your Evolved Fire, Water, or Psychic Pokémon in play. That Pokémon may use this card's attack instead of its own. At the end of your turn, discard Miracle Sphere β.",
-		de: "Lege diese Karte an 1 deiner entwickelten -, - oder  Pokémon im Spiel an. Dieses Pokémon kann den Angriff dieser Karte anstatt seines eigenen verwenden. Lege am Ende deines Zuges die Wunder-Sphäre (Beta) auf deinen Ablagestapel."
+		de: "Lege diese Karte an 1 deiner entwickelten -, - oder  Pokémon im Spiel an. Dieses Pokémon kann den Angriff dieser Karte anstatt seines eigenen verwenden. Lege am Ende deines Zuges die Wunder-Sphäre β auf deinen Ablagestapel."
 	},
 
 	variants: [

--- a/data/E-Card/Skyridge/131.ts
+++ b/data/E-Card/Skyridge/131.ts
@@ -3,8 +3,8 @@ import Set from '../Skyridge'
 
 const card: Card = {
 	name: {
-		en: "Miracle Sphere Gamma",
-		de: "Wunder-Sphäre (Gamma)"
+		en: "Miracle Sphere γ",
+		de: "Wunder-Sphäre γ"
 	},
 
 	illustrator: "Hiromichi Sugiyama",
@@ -14,13 +14,14 @@ const card: Card = {
 
 	attacks: [{
 		name: {
+			en: "Thunder Force",
 			de: "Donnerkraft"
 		},
 
 		damage: "30+",
 
 		effect: {
-		en: "Attach this card to 1 of your Evolved Grass, Water, or Lightning Pokémon in play. That Pokémon may use this card's attack instead of its own. At the end of your turn, discard Miracle Sphere γ.",
+			en: "If the Pokémon using this attack has Grass and Lightning basic Energy cards attached to it, the Defending Pokémon is now Asleep and Poisoned. If the Pokémon using this attack has Water and Lightning basic Energy cards attached to it, this attack does 30 damage plus 10 more damage and lets you put 1 damage counter on each of your opponent's Benched Pokémon.",
 			de: "Sind an das Pokémon, das diesen Angriff verwendet,  und -Basis-Energiekarten angelegt, ist das Verteidigende Pokémon jetzt vergiftet und schläft. Sind an das Pokémon, das diesen Angriff verwendet, - und -Basis-Energiekarten angelegt, fügt dieser Angriff 30 Schadenspunkte plus 10 weitere Schadenspunkte zu und lässt dich 1 Schadensmarke auf jedes Pokémon auf der Bank deines Gegners legen."
 		},
 
@@ -32,19 +33,22 @@ const card: Card = {
 		de: "Lege diese Karte an 1 deiner entwickelten -, -, oder -Pokémon im Spiel an. Dieses Pokémon kann den Angriff dieser Karte anstatt seines eigenen verwenden. Lege am Ende deines Zuges die Wunder-Sphäre (Gamma) auf deinen Ablagestapel."
 	},
 
-	thirdParty: {
-		cardmarket: 275389,
-		tcgplayer: 87499
-	},
-
 	variants: [
 		{
 			type: 'normal',
+			thirdParty: {
+				tcgplayer: 87499,
+				cardmarket: 275389
+			},
 		},
 		{
 			type: 'reverse',
-		}
-	]
+			thirdParty: {
+				tcgplayer: 87499,
+				cardmarket: 275389
+			},
+		},
+	],
 }
 
 export default card

--- a/data/E-Card/Skyridge/132.ts
+++ b/data/E-Card/Skyridge/132.ts
@@ -10,6 +10,7 @@ const card: Card = {
 	illustrator: "Midori Harada",
 	rarity: "Uncommon",
 	category: "Trainer",
+	trainerType: "Stadium",
 	set: Set,
 
 	effect: {
@@ -17,19 +18,32 @@ const card: Card = {
 		de: "Immer wenn ein Spieler versucht, in seinem Zug ein Pokémon zurückzuziehen, wirft dieser Spieler eine Münze. Bei \"Kopf\" zieht der Spieler das Pokémon zurück (und legt die Energiekarte ganz normal auf den Ablagestapel). Bei \"Zahl\" kann sich dieses Pokémon in diesem nicht zurückziehen (der Spieler legt keine Energiekarte auf den Ablagestapel)."
 	},
 
-	thirdParty: {
-		cardmarket: 275390,
-		tcgplayer: 87500
-	},
+	attacks: [
+		{
+			// name intentionally left blank
+			name: {},
+			effect: {
+				en: 'Whenever a player tries to retreat a Pokémon during his or her turn, that player flips a coin. If heads, that player retreats that Pokémon (and discards Energy normally). If tails, that Pokémon can\'t retreat this turn (the player doesn\'t discard any Energy).'
+			}
+		}
+	],
 
 	variants: [
 		{
 			type: 'normal',
+			thirdParty: {
+				tcgplayer: 87500,
+				cardmarket: 275390
+			},
 		},
 		{
 			type: 'reverse',
-		}
-	]
+			thirdParty: {
+				tcgplayer: 87500,
+				cardmarket: 275390
+			},
+		},
+	],
 }
 
 export default card

--- a/data/E-Card/Skyridge/133.ts
+++ b/data/E-Card/Skyridge/133.ts
@@ -3,7 +3,7 @@ import Set from '../Skyridge'
 
 const card: Card = {
 	name: {
-		en: "Mystery Plate Alpha",
+		en: "Mystery Plate α",
 		de: "Geheimnis-Schild (Alpha)"
 	},
 
@@ -14,10 +14,12 @@ const card: Card = {
 
 	attacks: [{
 		name: {
+			en: "Desert Burn",
 			de: "Wüstenbrand"
 		},
 
 		effect: {
+			en: "If your opponent has 5 or more Prizes, search your deck for a Trainer card, show it to your opponent, and put it into your hand. If your opponent has only 1 Prize, the Defending Pokémon is now Burned, Paralyzed, and Poisoned.",
 			de: "Hat dein Gegner 5 oder mehr Preise, durchsuche dein Deck nach einer Trainerkarte, zeige sie deinem Gegner und nimm sie auf die Hand. Hat dein Gegner nur 1 Preis, ist das Verteidigende Pokémon jetzt verbrannt, gelähmt und vergiftet."
 		},
 
@@ -29,18 +31,21 @@ const card: Card = {
 		de: "Lege diese Karte an 1 deiner Pokémon im Spiel an. Dieses Pokémon kann den Angriff dieser Karte anstatt seines eigenen verwenden. Lege am Ende deines Zuges das Geheimnis-Schild (Alpha) auf deinen Ablagestapel."
 	},
 
-	thirdParty: {
-		cardmarket: 275391,
-		tcgplayer: 87670
-	},
-
 	variants: [
 		{
 			type: 'normal',
+			thirdParty: {
+				tcgplayer: 87670,
+				cardmarket: 275391
+			},
 		},
 		{
 			type: 'reverse',
-		}
+			thirdParty: {
+				tcgplayer: 87670,
+				cardmarket: 275391
+			},
+		},
 	]
 }
 

--- a/data/E-Card/Skyridge/133.ts
+++ b/data/E-Card/Skyridge/133.ts
@@ -4,7 +4,7 @@ import Set from '../Skyridge'
 const card: Card = {
 	name: {
 		en: "Mystery Plate α",
-		de: "Geheimnis-Schild (Alpha)"
+		de: "Geheimnis-Schild α"
 	},
 
 	illustrator: "Hiromichi Sugiyama",
@@ -28,7 +28,7 @@ const card: Card = {
 
 	effect: {
 		en: "Attach this card to 1 of your Pokémon in play. That Pokémon may use this card's attack instead of its own. At the end of your turn, discard Mystery Plate α.",
-		de: "Lege diese Karte an 1 deiner Pokémon im Spiel an. Dieses Pokémon kann den Angriff dieser Karte anstatt seines eigenen verwenden. Lege am Ende deines Zuges das Geheimnis-Schild (Alpha) auf deinen Ablagestapel."
+		de: "Lege diese Karte an 1 deiner Pokémon im Spiel an. Dieses Pokémon kann den Angriff dieser Karte anstatt seines eigenen verwenden. Lege am Ende deines Zuges das Geheimnis-Schild α auf deinen Ablagestapel."
 	},
 
 	variants: [

--- a/data/E-Card/Skyridge/134.ts
+++ b/data/E-Card/Skyridge/134.ts
@@ -3,7 +3,7 @@ import Set from '../Skyridge'
 
 const card: Card = {
 	name: {
-		en: "Mystery Plate Beta",
+		en: "Mystery Plate β",
 		de: "Geheimnis-Schild ß"
 	},
 
@@ -14,10 +14,12 @@ const card: Card = {
 
 	attacks: [{
 		name: {
+			en: "Stone Crush",
 			de: "Steinbrecher"
 		},
 
 		effect: {
+			en: "If your opponent has 5 or more Prizes, draw 3 cards. If your opponent has only 1 Prize, choose 2 Energy cards attached to the Defending Pokémon (1 if there is only 1). Your opponent shuffles those cards into his or her deck.",
 			de: "Hat dein Gegner 5 oder mehr Preise, ziehe 3 Karten. Hat dein Gegner nur 1 Preis, wähle 2 Energiekarten, die an das verteidigende Pokémon angelegt sind (1, falls es nur 1 hat). Dein Gegner mischt diese Karten in sein Deck."
 		},
 
@@ -29,18 +31,21 @@ const card: Card = {
 		de: "Lege diese Karte an 1 deiner Pokémon im Spiel an. Dieses Pokémon kann den Angriff dieser Karte anstatt seines eigenen verwenden. Lege am Ende deines Zuges das Geheimnis-Schild ß auf deinen Ablagestapel."
 	},
 
-	thirdParty: {
-		cardmarket: 275392,
-		tcgplayer: 87671
-	},
-
 	variants: [
 		{
 			type: 'normal',
+			thirdParty: {
+				tcgplayer: 87671,
+				cardmarket: 275392
+			},
 		},
 		{
 			type: 'reverse',
-		}
+			thirdParty: {
+				tcgplayer: 87671,
+				cardmarket: 275392
+			},
+		},
 	]
 }
 

--- a/data/E-Card/Skyridge/135.ts
+++ b/data/E-Card/Skyridge/135.ts
@@ -3,8 +3,8 @@ import Set from '../Skyridge'
 
 const card: Card = {
 	name: {
-		en: "Mystery Plate Gamma",
-		de: "Geheimes Schild (Gamma)"
+		en: "Mystery Plate γ",
+		de: "Geheimes Schild γ"
 	},
 
 	illustrator: "Hiromichi Sugiyama",
@@ -17,18 +17,35 @@ const card: Card = {
 		de: "Hat dein Gegner 5 oder mehr Preise, mische die Karten auf deiner Hand in dein Deck und ziehe anschließend 6 Karten. Hat dein Gegner 2 Preise, wähle 1 der entwickelten Pokémon deines gegners. Dein Gegner legt die oberste Karte dieser entwickelten Pokémon unter sein Deck. (Dies zählt als Rückentwickeln des Pokémon.)"
 	},
 
-	thirdParty: {
-		cardmarket: 275393,
-		tcgplayer: 87673
-	},
+	attacks: [
+		{
+			cost: [
+				"Colorless",
+			],
+			name: {
+				en: "Retro Cave",
+			},
+			effect: {
+				en: "If your opponent has 5 or more Prizes, shuffle your hand into your deck and then draw 6 cards. If your opponent has exactly 2 Prizes, choose 1 of your opponent's Evolved Pokémon. Your opponent puts the top card on that Evolved Pokémon on the bottom of his or her deck. (This counts as devolving that Pokémon.)",
+			},
+		},
+	],
 
 	variants: [
 		{
 			type: 'normal',
+			thirdParty: {
+				tcgplayer: 87673,
+				cardmarket: 275393
+			},
 		},
 		{
 			type: 'reverse',
-		}
+			thirdParty: {
+				tcgplayer: 87673,
+				cardmarket: 275393
+			},
+		},
 	]
 }
 

--- a/data/E-Card/Skyridge/136.ts
+++ b/data/E-Card/Skyridge/136.ts
@@ -3,8 +3,8 @@ import Set from '../Skyridge'
 
 const card: Card = {
 	name: {
-		en: "Mystery Plate Delta",
-		de: "Geheimnis-Schild (Delta)"
+		en: "Mystery Plate δ",
+		de: "Geheimnis-Schild δ"
 	},
 
 	illustrator: "Hiromichi Sugiyama",
@@ -14,10 +14,12 @@ const card: Card = {
 
 	attacks: [{
 		name: {
+			en: "Healing Oasis",
 			de: "Heilungsoase"
 		},
 
 		effect: {
+			en: "If your opponent has 5 or more Prizes, search your deck for up to 3 basic Energy cards, show them to your opponent, and put them into your hand. Shuffle your deck afterward. If your opponent has exactly 2 Prizes, remove all damage counters from 1 of your Pokémon.",
 			de: "Hat dein Gegner 5 oder mehr Preise, durchsuche dein Deck nach bis zu 3 Basis-Energiekarten, zeige sie deinem Gegner und nimm sie auf deine Hand. Mische dein Deck danach. Hat dein Gegner 2 Preise, entferne alle Schadensmarken von 1 deiner Pokémon."
 		},
 
@@ -29,18 +31,21 @@ const card: Card = {
 		de: "Lege diese Karte an 1 deiner Pokémon im Spiel an. Dieses Pokémon kann den Angriff dieser Karte anstatt seines eigenen verwenden. Lege am Ende deines Zuges das Geheimnis Schild S auf deinen Ablagestapel."
 	},
 
-	thirdParty: {
-		cardmarket: 275394,
-		tcgplayer: 87672
-	},
-
 	variants: [
 		{
 			type: 'normal',
+			thirdParty: {
+				tcgplayer: 87672,
+				cardmarket: 275394
+			},
 		},
 		{
 			type: 'reverse',
-		}
+			thirdParty: {
+				tcgplayer: 87672,
+				cardmarket: 275394
+			},
+		},
 	]
 }
 

--- a/data/E-Card/Skyridge/137.ts
+++ b/data/E-Card/Skyridge/137.ts
@@ -10,6 +10,7 @@ const card: Card = {
 	illustrator: "Ken Ikuji",
 	rarity: "Uncommon",
 	category: "Trainer",
+	trainerType: "Stadium",
 	set: Set,
 
 	effect: {
@@ -17,19 +18,32 @@ const card: Card = {
 		de: "Einmal während des Zuges jedes Spielers (vor dem Angriff) kann dieser Spieler, falls er eine Entwicklungskarte auf seiner Hand hat, sein Deck nach einer Basis-Energykarte durchsuchen, sie seinem Gegner zeigen und sie auf die Hand nehmen. Dann wählt dieser Spieler eine Entwicklungskarte von seiner Hand, zeigt sie seinem Gegner und legt sie in sein Deck. Der Spieler mischt sein Deck."
 	},
 
-	thirdParty: {
-		cardmarket: 275395,
-		tcgplayer: 87674
-	},
+	attacks: [
+		{
+			// name intentionally left blank
+			name: {},
+			effect: {
+				en: "Once during each player's turn (before he or she attacks), if that player has an Evolution card in his or her hand, he or she may search his or her deck for a basic Energy card, show it to his or her opponent, and put it into his or her hand. Then that player chooses an Evolution card from his or her hand, shows it to his or her opponent, and puts it into his or her deck. That player shuffles his or her deck afterward."
+			}
+		}
+	],
 
 	variants: [
 		{
 			type: 'normal',
+			thirdParty: {
+				tcgplayer: 87674,
+				cardmarket: 275395
+			},
 		},
 		{
 			type: 'reverse',
-		}
-	]
+			thirdParty: {
+				tcgplayer: 87674,
+				cardmarket: 275395
+			},
+		},
+	],
 }
 
 export default card

--- a/data/E-Card/Skyridge/138.ts
+++ b/data/E-Card/Skyridge/138.ts
@@ -10,6 +10,7 @@ const card: Card = {
 	illustrator: "Kagemaru Himeno",
 	rarity: "Uncommon",
 	category: "Trainer",
+	trainerType: "Supporter",
 	set: Set,
 
 	effect: {
@@ -17,31 +18,53 @@ const card: Card = {
 		de: "Wähle 2 Karten aus deinem Deck und mische den Rest deines Decks. Lege die gewählten Karten in beliebiger Reihenfolge oben auf dein Deck."
 	},
 
-	thirdParty: {
-		cardmarket: 275396,
-		tcgplayer: 87887
-	},
+	attacks: [
+		{
+			// name intentionally left blank
+			name: {},
+			effect: {
+				en: "Choose 2 cards from your deck and shuffle the rest of your deck. Put the chosen cards on top of your deck in any order."
+			}
+		}
+	],
 
 	variants: [
 		{
 			type: 'normal',
+			thirdParty: {
+				tcgplayer: 87887,
+				cardmarket: 275396
+			},
 		},
 		{
 			type: 'reverse',
+			thirdParty: {
+				tcgplayer: 87887,
+				cardmarket: 275396
+			},
 		},
 		{
 			type: 'normal',
-			stamp: ['chris-fulop']
+			stamp: ['chris-fulop'],
+			thirdParty: {
+				tcgplayer: 477410
+			}
 		},
 		{
 			type: 'normal',
-			stamp: ['reed-weichler']
+			stamp: ['reed-weichler'],
+			thirdParty: {
+				tcgplayer: 477411
+			}
 		},
 		{
 			type: 'normal',
-			stamp: ['kevin-nguyen']
+			stamp: ['kevin-nguyen'],
+			thirdParty: {
+				tcgplayer: 477412
+			}
 		}
-	]
+	],
 }
 
 export default card

--- a/data/E-Card/Skyridge/139.ts
+++ b/data/E-Card/Skyridge/139.ts
@@ -10,6 +10,7 @@ const card: Card = {
 	illustrator: "Jungo Suzuki",
 	rarity: "Uncommon",
 	category: "Trainer",
+	trainerType: "Tool",
 	set: Set,
 
 	effect: {
@@ -17,19 +18,32 @@ const card: Card = {
 		de: "Ist zu irgendeinem Zeitpunkt zwischen Zügen das Pokémon an das diese Karte angelegt ist, auf der Bank und hat 2 oder mehr Schadensmarken, durchsuche dein Deck nach einer Entwicklungskarte, in die sich dieses Pokémon entwickelt, und lege sie auf das Pokémon. (Dies zählt als Entwickeln dieses Pokémon.) Mische dein Deck danach. Lege dann das Sternenstück auf deinen Ablagestapel."
 	},
 
-	thirdParty: {
-		cardmarket: 275397,
-		tcgplayer: 89507
-	},
+	attacks: [
+		{
+			// name intentionally left blank
+			name: {},
+			effect: {
+				en: "At any time between turns, if the Pokémon this card is attached to is Benched and has 2 or more damage counters on it, search your deck for an Evolution card that Pokémon evolves into and put it on top of that Pokémon. (This counts as evolving that Pokémon.) Shuffle your deck afterward. Then, discard Star Piece."
+			}
+		}
+	],
 
 	variants: [
 		{
 			type: 'normal',
+			thirdParty: {
+				tcgplayer: 89507,
+				cardmarket: 275397
+			},
 		},
 		{
 			type: 'reverse',
-		}
-	]
+			thirdParty: {
+				tcgplayer: 89507,
+				cardmarket: 275397
+			},
+		},
+	],
 }
 
 export default card

--- a/data/E-Card/Skyridge/14.ts
+++ b/data/E-Card/Skyridge/14.ts
@@ -12,14 +12,12 @@ const card: Card = {
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		141,
-	],
+	dexId: [141],
 
 	hp: 90,
 
 	types: [
-		"Fighting",
+		"Fighting"
 	],
 
 	evolveFrom: {
@@ -57,7 +55,7 @@ const card: Card = {
 				en: "Flip 2 coins. This attack does 50 damage times the number of heads.",
 				de: "Wirf 2 Münzen. Dieser Angriff fügt 50 Schadenspunkte mal der Anzahl \"Kopf\" zu."
 			},
-			damage: "50x",
+			damage: "50×",
 
 		},
 	],
@@ -65,25 +63,28 @@ const card: Card = {
 	weaknesses: [
 		{
 			type: "Grass",
-			value: "×2"
+			value: "x2"
 		},
 	],
 	retreat: 2,
 
 
-	thirdParty: {
-		cardmarket: 275240,
-		tcgplayer: 86392
-	},
-
 	variants: [
 		{
 			type: 'normal',
+			thirdParty: {
+				tcgplayer: 86392,
+				cardmarket: 275240
+			},
 		},
 		{
 			type: 'reverse',
-		}
-	]
+			thirdParty: {
+				tcgplayer: 86392,
+				cardmarket: 275240
+			},
+		},
+	],
 }
 
 export default card

--- a/data/E-Card/Skyridge/140.ts
+++ b/data/E-Card/Skyridge/140.ts
@@ -10,6 +10,7 @@ const card: Card = {
 	illustrator: "Kagemaru Himeno",
 	rarity: "Uncommon",
 	category: "Trainer",
+	trainerType: "Supporter",
 	set: Set,
 
 	effect: {
@@ -17,27 +18,46 @@ const card: Card = {
 		de: "Schaue dir die 4 untersten Karten deines Decks an. Nimm 2 dieser Karten auf deine Hand und lege die übrigen Karten in beliebiger Reihenfolge unter dein Deck zurück."
 	},
 
-	thirdParty: {
-		cardmarket: 275398,
-		tcgplayer: 90155
-	},
+	attacks: [
+		{
+			// name intentionally left blank
+			name: {},
+			effect: {
+				en: "Look at the bottom 4 cards of your deck. Put 2 of those cards into your hand, and then return the remaining cards to the bottom of your deck in any order."
+			}
+		}
+	],
 
 	variants: [
 		{
 			type: 'normal',
+			thirdParty: {
+				tcgplayer: 90155,
+				cardmarket: 275398
+			},
 		},
 		{
 			type: 'reverse',
+			thirdParty: {
+				tcgplayer: 90155,
+				cardmarket: 275398
+			},
 		},
 		{
 			type: 'normal',
-			stamp: ['chris-fulop']
+			stamp: ['chris-fulop'],
+			thirdParty: {
+				tcgplayer: 477458
+			}
 		},
 		{
 			type: 'normal',
-			stamp: ['tsuguyoshi-yamato']
+			stamp: ['tsuguyoshi-yamato'],
+			thirdParty: {
+				tcgplayer: 477457
+			}
 		}
-	]
+	],
 }
 
 export default card

--- a/data/E-Card/Skyridge/141.ts
+++ b/data/E-Card/Skyridge/141.ts
@@ -10,6 +10,7 @@ const card: Card = {
 	illustrator: "Midori Harada",
 	rarity: "Uncommon",
 	category: "Trainer",
+	trainerType: "Stadium",
 	set: Set,
 
 	effect: {
@@ -17,19 +18,32 @@ const card: Card = {
 		de: "Einmal während jedes Zugs eines Spielers kann dieser Spieler eine Amonitas- oder Kabuto-Karte aus seinem Ablagestapel auf seine Bank legen. (Karten, die auf diese Weise auf die Bank gelegt werden, gelten als Basis-Pokémon.)"
 	},
 
-	thirdParty: {
-		cardmarket: 275399,
-		tcgplayer: 90157
-	},
+	attacks: [
+		{
+			// name intentionally left blank
+			name: {},
+			effect: {
+				en: "Once during each player's turn, that player may put an Omanyte or a Kabuto card from his or her discard pile onto his or her Bench. (Cards put on the Bench this way are considered Basic Pokémon.)"
+			}
+		}
+	],
 
 	variants: [
 		{
 			type: 'normal',
+			thirdParty: {
+				tcgplayer: 90157,
+				cardmarket: 275399
+			},
 		},
 		{
 			type: 'reverse',
-		}
-	]
+			thirdParty: {
+				tcgplayer: 90157,
+				cardmarket: 275399
+			},
+		},
+	],
 }
 
 export default card

--- a/data/E-Card/Skyridge/142.ts
+++ b/data/E-Card/Skyridge/142.ts
@@ -18,19 +18,22 @@ const card: Card = {
 		de: "Diese Karte erzeugt -Energie. Du kannst diese Karte an dein Pokémon, an dem mindestens eine Basis-Energiekarte angelegt ist, anlegen. Wenn du diese Karte aus deiner Hand spielst und an 1 deiner Pokémon anlegst, bringe eine Basis-Energiekarte, die an dieses Pokémon angelegt ist, auf deine Hand zurück."
 	},
 
-	thirdParty: {
-		cardmarket: 275400,
-		tcgplayer: 83947
-	},
-
 	variants: [
 		{
 			type: 'normal',
+			thirdParty: {
+				tcgplayer: 83947,
+				cardmarket: 275400
+			},
 		},
 		{
 			type: 'reverse',
-		}
-	]
+			thirdParty: {
+				tcgplayer: 83947,
+				cardmarket: 275400
+			},
+		},
+	],
 }
 
 export default card

--- a/data/E-Card/Skyridge/143.ts
+++ b/data/E-Card/Skyridge/143.ts
@@ -18,19 +18,22 @@ const card: Card = {
 		de: "Dieser Karte erzeugt -Energie. Wenn du diese Karte aus deiner Hand spielst und an dein aktives Pokémon anlegst, tauscht dein Gegner sein aktives Pokémon mit 1 der Pokémon auf seiner Bank aus."
 	},
 
-	thirdParty: {
-		cardmarket: 275401,
-		tcgplayer: 84539
-	},
-
 	variants: [
 		{
 			type: 'normal',
+			thirdParty: {
+				tcgplayer: 84539,
+				cardmarket: 275401
+			},
 		},
 		{
 			type: 'reverse',
-		}
-	]
+			thirdParty: {
+				tcgplayer: 84539,
+				cardmarket: 275401
+			},
+		},
+	],
 }
 
 export default card

--- a/data/E-Card/Skyridge/144.ts
+++ b/data/E-Card/Skyridge/144.ts
@@ -18,19 +18,22 @@ const card: Card = {
 		de: "Diese Karte erzeugt  - Energie. Wenn du diese Karte aus deiner Hand spielst und an 1 deiner entwickelten Pokémon anlegst, kannst du bis zu 2 Schadensmarken von diesem Pokémon entfernen und dann seine oberste Karte auf deinen Ablagestapel legen. (Dies zählt als Rückentwicklung dieses Pokémon)"
 	},
 
-	thirdParty: {
-		cardmarket: 275402,
-		tcgplayer: 88718
-	},
-
 	variants: [
 		{
 			type: 'normal',
+			thirdParty: {
+				tcgplayer: 88718,
+				cardmarket: 275402
+			},
 		},
 		{
 			type: 'reverse',
-		}
-	]
+			thirdParty: {
+				tcgplayer: 88718,
+				cardmarket: 275402
+			},
+		},
+	],
 }
 
 export default card

--- a/data/E-Card/Skyridge/145.ts
+++ b/data/E-Card/Skyridge/145.ts
@@ -12,14 +12,12 @@ const card: Card = {
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		251,
-	],
+	dexId: [251],
 
 	hp: 60,
 
 	types: [
-		"Colorless",
+		"Colorless"
 	],
 
 	stage: "Basic",
@@ -32,7 +30,7 @@ const card: Card = {
 				de: "Kristall-Typ"
 			},
 			effect: {
-				en: "Whenever you attach a Grass, Water, or Psychic basic Energy card from your hand to Celebi, Celebi's type (color) becomes the same as that type of energy until the end of the turn.",
+				en: "Whenever you attach a Grass, Water, or Psychic basic Energy card from your hand to Celebi, Celebi's type (color) becomes the same as that type of Energy until the end of the turn.",
 				de: "Immer wenn du eine -, - oder -Basis-Energiekarte aus deiner Hand an Celebi anlegst, ändert sich Celebis Typ (Farbe) bis zum Ende des Zuges zu dem gleichen Typ wie diese Energie."
 			},
 		},
@@ -45,7 +43,7 @@ const card: Card = {
 				"Water",
 			],
 			name: {
-				en: "Empathetic Healing",
+				en: "Empathic Healing",
 				de: "Empathische Heilung"
 			},
 			effect: {
@@ -76,25 +74,28 @@ const card: Card = {
 	weaknesses: [
 		{
 			type: "Fire",
-			value: "×2"
+			value: "x2"
 		},
 	],
 	retreat: 1,
 
 
-	thirdParty: {
-		cardmarket: 275403,
-		tcgplayer: 84144
-	},
-
 	variants: [
 		{
 			type: 'holo',
+			thirdParty: {
+				tcgplayer: 84144,
+				cardmarket: 275403
+			},
 		},
 		{
 			type: 'reverse',
-		}
-	]
+			thirdParty: {
+				tcgplayer: 84144,
+				cardmarket: 275403
+			},
+		},
+	],
 }
 
 export default card

--- a/data/E-Card/Skyridge/146.ts
+++ b/data/E-Card/Skyridge/146.ts
@@ -12,14 +12,12 @@ const card: Card = {
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		6,
-	],
+	dexId: [6],
 
 	hp: 110,
 
 	types: [
-		"Colorless",
+		"Colorless"
 	],
 
 	evolveFrom: {
@@ -36,7 +34,7 @@ const card: Card = {
 				de: "Kristall-Typ"
 			},
 			effect: {
-				en: "Whenever you attach a Fire, Lightning, or Fighting basic Energy card from your hand to Charizard, Charizard's type (color) becomes the same as that type of energy until the end of the turn.",
+				en: "Whenever you attach a Fire, Lightning, or Fighting basic Energy card from your hand to Charizard, Charizard's type (color) becomes the same as that type of Energy until the end of the turn.",
 				de: "Immer wenn du eine -, - oder -Basis-Energiekarte aus deiner Hand an Glurak anlegst, ändert sich Gluraks Typ (Farbe) bis zum Ende des Zuges zu dem gleichen Typ wie diese Energie."
 			},
 		},
@@ -75,7 +73,7 @@ const card: Card = {
 				en: "Flip 2 coins. This attack does 50 damage times the number of heads.",
 				de: "Wirf 2 Münzen. Dieser Angriff fügt 50 Schadenspunkte mal der Anzahl \"Kopf\" zu."
 			},
-			damage: "50x",
+			damage: "50×",
 
 		},
 	],
@@ -83,25 +81,36 @@ const card: Card = {
 	weaknesses: [
 		{
 			type: "Water",
-			value: "×2"
+			value: "x2"
 		},
 	],
 	retreat: 4,
 
 
-	thirdParty: {
-		cardmarket: 275404,
-		tcgplayer: 84186
-	},
-
 	variants: [
 		{
 			type: 'holo',
+			thirdParty: {
+				tcgplayer: 84186,
+				cardmarket: 275404
+			},
 		},
 		{
 			type: 'reverse',
+			thirdParty: {
+				tcgplayer: 84186,
+				cardmarket: 275404
+			},
+		},
+		{
+			type: 'holo',
+			foil: 'cracked-ice',
+			size: 'jumbo',
+			thirdParty: {
+				tcgplayer: 210851
+			}
 		}
-	]
+	],
 }
 
 export default card

--- a/data/E-Card/Skyridge/147.ts
+++ b/data/E-Card/Skyridge/147.ts
@@ -12,14 +12,12 @@ const card: Card = {
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		169,
-	],
+	dexId: [169],
 
 	hp: 80,
 
 	types: [
-		"Colorless",
+		"Colorless"
 	],
 
 	evolveFrom: {
@@ -36,7 +34,7 @@ const card: Card = {
 				de: "Kristall-Typ"
 			},
 			effect: {
-				en: "Whenever you attach a Grass, Fire, or Psychic basic Energy card from your hand to Crobat, Crobat's type (color) becomes the same as that type of energy until the end of the turn.",
+				en: "Whenever you attach a Grass, Fire, or Psychic basic Energy card from your hand to Crobat, Crobat's type (color) becomes the same as that type of Energy until the end of the turn.",
 				de: "Immer wenn du eine -, - oder -Basis-Energiekarte aus deiner Hand an Iksbat anlegst, ändert sich Iksbats Typ (Farbe) bis zum Ende des Zuges zu dem gleichen Typ wie diese Energie."
 			},
 		},
@@ -60,7 +58,7 @@ const card: Card = {
 				de: "Wirf eine Münze. Bei \"Kopf\" ist das verteidigende Pokémon jetzt verbrannt und vergiftet."
 			},
 
-			damage: 20
+			damage: 20,
 		},
 		{
 			cost: [
@@ -76,7 +74,7 @@ const card: Card = {
 				en: "Flip 4 coins. This attack does 20 damage times the number of heads.",
 				de: "Wirf 4 Münzen. Dieser Angriff fügt 20 Schadenspunkte mal der Anzahl \"Kopf\" zu."
 			},
-			damage: "20x",
+			damage: "20×",
 
 		},
 	],
@@ -84,23 +82,34 @@ const card: Card = {
 	weaknesses: [
 		{
 			type: "Psychic",
-			value: "×2"
+			value: "x2"
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 275264,
-		tcgplayer: 84485
-	},
-
 	variants: [
 		{
 			type: 'holo',
+			thirdParty: {
+				tcgplayer: 84485,
+				cardmarket: 275264
+			},
 		},
 		{
 			type: 'reverse',
+			thirdParty: {
+				tcgplayer: 84485,
+				cardmarket: 275264
+			},
+		},
+		{
+			type: 'holo',
+			foil: 'cracked-ice',
+			size: 'jumbo',
+			thirdParty: {
+				tcgplayer: 210852
+			}
 		}
-	]
+	],
+	retreat: 0,
 }
 
 export default card

--- a/data/E-Card/Skyridge/148.ts
+++ b/data/E-Card/Skyridge/148.ts
@@ -12,14 +12,12 @@ const card: Card = {
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		76,
-	],
+	dexId: [76],
 
 	hp: 100,
 
 	types: [
-		"Colorless",
+		"Colorless"
 	],
 
 	evolveFrom: {
@@ -36,7 +34,7 @@ const card: Card = {
 				de: "Kristall-Typ"
 			},
 			effect: {
-				en: "Whenever you attach a Grass, Fire, or Fighting basic Energy card from your hand to Golem, Golem's type (color) becomes the same as that type of energy until the end of the turn.",
+				en: "Whenever you attach a Grass, Fire, or Fighting basic Energy card from your hand to Golem, Golem's type (color) becomes the same as that type of Energy until the end of the turn.",
 				de: "Immer wenn du eine -, - oder -Basis-Energiekarte aus deiner Hand an Geowaz anlegst, ändert sich Geowaz Typ (Farbe) bis zum Ende des Zuges zu dem gleichen Typ wie diese Energie."
 			},
 		},
@@ -69,7 +67,7 @@ const card: Card = {
 				de: "Erdbombe"
 			},
 			effect: {
-				en: "Golem does 20 damage to itself. This attack also does 10 damage to each Benched Pokémon (yours and your opponents). (Don't apply Weakness and Resistance for Benched Pokémon.)",
+				en: "Golem does 20 damage to itself. This attack also does 10 damage to each Benched Pokémon (yours and your opponent's). (Don't apply Weakness and Resistance for Benched Pokémon.)",
 				de: "Geowaz fügt sich selber 20 Schadenspunkte zu. Deiser Angriff fügt zudem jedem Pokémon auf der Bank 10 Schadnepunkte zu (deinen und den gegnerischen Pokémon). (Wende keine Schwäche oder resistenz bei Pokémon auf der Bank an.)"
 			},
 			damage: 50,
@@ -80,25 +78,28 @@ const card: Card = {
 	weaknesses: [
 		{
 			type: "Water",
-			value: "×2"
+			value: "x2"
 		},
 	],
 	retreat: 4,
 
 
-	thirdParty: {
-		cardmarket: 275406,
-		tcgplayer: 85825
-	},
-
 	variants: [
 		{
 			type: 'holo',
+			thirdParty: {
+				tcgplayer: 85825,
+				cardmarket: 275406
+			},
 		},
 		{
 			type: 'reverse',
-		}
-	]
+			thirdParty: {
+				tcgplayer: 85825,
+				cardmarket: 275406
+			},
+		},
+	],
 }
 
 export default card

--- a/data/E-Card/Skyridge/149.ts
+++ b/data/E-Card/Skyridge/149.ts
@@ -12,14 +12,12 @@ const card: Card = {
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		250,
-	],
+	dexId: [250],
 
 	hp: 80,
 
 	types: [
-		"Colorless",
+		"Colorless"
 	],
 
 	stage: "Basic",
@@ -32,7 +30,7 @@ const card: Card = {
 				de: "Kristall-Typ"
 			},
 			effect: {
-				en: "Whenever you attach a Fire, Water, or Lightning basic Energy card from your hand to Ho-oh, Ho-oh's type (color) becomes the same as that type of energy until the end of the turn.",
+				en: "Whenever you attach a Fire, Water, or Lightning basic Energy card from your hand to Ho-oh, Ho-oh's type (color) becomes the same as that type of Energy until the end of the turn.",
 				de: "Immer wenn du eine -, - oder -Basis-Energiekarte aus deiner Hand an Ho-oh anlegst, ändert sich Ho-ohs Typ (Farbe) bis zum Ende des Zuges zu dem gleichen Typ wie diese Energie."
 			},
 		},
@@ -75,25 +73,36 @@ const card: Card = {
 	weaknesses: [
 		{
 			type: "Water",
-			value: "×2"
+			value: "x2"
 		},
 	],
 	retreat: 3,
 
 
-	thirdParty: {
-		cardmarket: 362907,
-		tcgplayer: 86121
-	},
-
 	variants: [
 		{
 			type: 'holo',
+			thirdParty: {
+				tcgplayer: 86121,
+				cardmarket: 362907
+			},
 		},
 		{
 			type: 'reverse',
+			thirdParty: {
+				tcgplayer: 86121,
+				cardmarket: 362907
+			},
+		},
+		{
+			type: 'holo',
+			foil: 'cracked-ice',
+			size: 'jumbo',
+			thirdParty: {
+				tcgplayer: 210854
+			}
 		}
-	]
+	],
 }
 
 export default card

--- a/data/E-Card/Skyridge/15.ts
+++ b/data/E-Card/Skyridge/15.ts
@@ -12,14 +12,12 @@ const card: Card = {
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		166,
-	],
+	dexId: [166],
 
 	hp: 70,
 
 	types: [
-		"Grass",
+		"Grass"
 	],
 
 	evolveFrom: {
@@ -38,7 +36,7 @@ const card: Card = {
 				de: "Pollenschild"
 			},
 			effect: {
-				en: "During your opponent's next turn, Ledian can't become affected by a Special Condition. (Any other effect of attacks, Poké",
+				en: "During your opponent's next turn, Ledian can't become affected by a Special Condition. (Any other effects of attacks, Poké-Powers, Poké-Bodies, and Trainer cards still happen.)",
 				de: "Während des nächsten gegenerischen Zugs kann Ledian nicht von speziellen Zuständen betroffen werden. (Alle anderen Effekten von Angriffen, Poke-Powers, Poke-Bodies und Trainerkarten finden immer noch statt."
 			},
 			damage: 10,
@@ -66,23 +64,26 @@ const card: Card = {
 	weaknesses: [
 		{
 			type: "Fire",
-			value: "×2"
+			value: "x2"
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 275242,
-		tcgplayer: 86691
-	},
-
 	variants: [
 		{
 			type: 'normal',
+			thirdParty: {
+				tcgplayer: 86691,
+				cardmarket: 275242
+			},
 		},
 		{
 			type: 'reverse',
-		}
-	]
+			thirdParty: {
+				tcgplayer: 86691,
+				cardmarket: 275242
+			},
+		},
+	],
+	retreat: 0,
 }
 
 export default card

--- a/data/E-Card/Skyridge/150.ts
+++ b/data/E-Card/Skyridge/150.ts
@@ -12,14 +12,12 @@ const card: Card = {
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		141,
-	],
+	dexId: [141],
 
 	hp: 90,
 
 	types: [
-		"Colorless",
+		"Colorless"
 	],
 
 	evolveFrom: {
@@ -36,7 +34,7 @@ const card: Card = {
 				de: "Kristall-Typ"
 			},
 			effect: {
-				en: "Whenever you attach a Water, Lightning, or Fighting basic Energy card from your hand to Kabutops, Kabutop's type (color) becomes the same as that type of energy until the end of the turn.",
+				en: "Whenever you attach a Water, Lightning, or Fighting basic Energy card from your hand to Kabutops, Kabutops's type (color) becomes the same as that type of Energy until the end of the turn.",
 				de: "Immer wenn du eine  -,  -oder eine  - Basis Energiekarte aus deiner Hand an Kabutops anlegst, ändert sich Kabutops'Typ (Farbe) bis zum Ende des Zuges zum gleichen Typ wie diese Energie."
 			},
 		},
@@ -75,7 +73,7 @@ const card: Card = {
 				en: "Flip 3 coins. This attack does 30 damage times the number of heads.",
 				de: "Wirf 3 Münzen. Dieser Angriff fügt 30 Schadenspunkte mal der Anzahl \"Kopf\" zu."
 			},
-			damage: "30x",
+			damage: "30×",
 
 		},
 	],
@@ -83,25 +81,36 @@ const card: Card = {
 	weaknesses: [
 		{
 			type: "Grass",
-			value: "×2"
+			value: "x2"
 		},
 	],
 	retreat: 3,
 
 
-	thirdParty: {
-		cardmarket: 275272,
-		tcgplayer: 86396
-	},
-
 	variants: [
 		{
 			type: 'holo',
+			thirdParty: {
+				tcgplayer: 86396,
+				cardmarket: 275272
+			},
 		},
 		{
 			type: 'reverse',
+			thirdParty: {
+				tcgplayer: 86396,
+				cardmarket: 275272
+			},
+		},
+		{
+			type: 'holo',
+			foil: 'cracked-ice',
+			size: 'jumbo',
+			thirdParty: {
+				tcgplayer: 210853
+			}
 		}
-	]
+	],
 }
 
 export default card

--- a/data/E-Card/Skyridge/16.ts
+++ b/data/E-Card/Skyridge/16.ts
@@ -12,14 +12,12 @@ const card: Card = {
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		68,
-	],
+	dexId: [68],
 
 	hp: 120,
 
 	types: [
-		"Fighting",
+		"Fighting"
 	],
 
 	evolveFrom: {
@@ -74,7 +72,7 @@ const card: Card = {
 				en: "Flip 4 coins. This attack does 30 damage times the number of heads.",
 				de: "Wirf 4 Münzen. Dieser Angriff fügt 30 Schadenspunkte mal der Anzahl \"Kopf\" zu."
 			},
-			damage: "30x",
+			damage: "30×",
 
 		},
 	],
@@ -82,25 +80,28 @@ const card: Card = {
 	weaknesses: [
 		{
 			type: "Psychic",
-			value: "×2"
+			value: "x2"
 		},
 	],
 	retreat: 2,
 
 
-	thirdParty: {
-		cardmarket: 275241,
-		tcgplayer: 86959
-	},
-
 	variants: [
 		{
 			type: 'normal',
+			thirdParty: {
+				tcgplayer: 86959,
+				cardmarket: 275241
+			},
 		},
 		{
 			type: 'reverse',
-		}
-	]
+			thirdParty: {
+				tcgplayer: 86959,
+				cardmarket: 275241
+			},
+		},
+	],
 }
 
 export default card

--- a/data/E-Card/Skyridge/17.ts
+++ b/data/E-Card/Skyridge/17.ts
@@ -12,14 +12,12 @@ const card: Card = {
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		219,
-	],
+	dexId: [219],
 
 	hp: 80,
 
 	types: [
-		"Fire",
+		"Fire"
 	],
 
 	evolveFrom: {
@@ -39,7 +37,7 @@ const card: Card = {
 				de: "Ausbruch"
 			},
 			effect: {
-				en: "Each player discards the top card of his or her deck. This attack does 20 damage plus 20 more damage for each Energy card discarded in this way.",
+				en: "Each player discard the top card of his or her deck. This attack does 20 damage plus 20 more damage for each Fire Energy card discarded in this way.",
 				de: "Jeder Spieler legt die oberste Karte seines Decks auf seinen Ablagestapel. Dieser Angriff fügt 20 Schadenspunkte plus 20 weitere Schadenspunkte für jede auf diese Weise abgelegte -Energiekarte zu."
 			},
 			damage: "20+",
@@ -57,7 +55,7 @@ const card: Card = {
 				de: "Feuerstrom"
 			},
 			effect: {
-				en: "Discard a Energy card attached to Magcargo in order to use this attack. If your opponent has any Benched Pokémon, this attack does 10 damage to each of them. (Don't apply Weakness or Resistance for Benched Pokémon.)",
+				en: "Discard a Fire Energy card attached to Magcargo in order to use this attack. If your opponent has any Benched Pokémon, this attack does 10 damage to each of them. (Don't apply Weakness and Resistance for Benched Pokémon.)",
 				de: "Lege eine an Magcargo angelegte -Energiekarte auf deinen Ablagestapel, um diesen Angriff zu verwenden. Wenn dein Gegner über Pokémon auf der Bank verfügt, fügt dieser Angriff jedem von ihnen 10 Schadenspunkte zu. (Wende keine Schwäche oder Resistenz bei Pokémon auf der Bank an.)"
 			},
 			damage: 60,
@@ -68,25 +66,28 @@ const card: Card = {
 	weaknesses: [
 		{
 			type: "Water",
-			value: "×2"
+			value: "x2"
 		},
 	],
 	retreat: 3,
 
 
-	thirdParty: {
-		cardmarket: 275234,
-		tcgplayer: 87009
-	},
-
 	variants: [
 		{
 			type: 'normal',
+			thirdParty: {
+				tcgplayer: 87009,
+				cardmarket: 275234
+			},
 		},
 		{
 			type: 'reverse',
-		}
-	]
+			thirdParty: {
+				tcgplayer: 87009,
+				cardmarket: 275234
+			},
+		},
+	],
 }
 
 export default card

--- a/data/E-Card/Skyridge/18.ts
+++ b/data/E-Card/Skyridge/18.ts
@@ -12,14 +12,12 @@ const card: Card = {
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		219,
-	],
+	dexId: [219],
 
 	hp: 80,
 
 	types: [
-		"Fighting",
+		"Fighting"
 	],
 
 	evolveFrom: {
@@ -36,7 +34,7 @@ const card: Card = {
 				de: "Fließende Umhüllung"
 			},
 			effect: {
-				en: "When you play Magcargo from your hand to evolve your Active Pokémon, you may discard the top 3 cards of your deck and then shuffle 3 basic energy cards from your discard pile into your deck. If you do, your opponent must do the same.",
+				en: "When you play Magcargo from your hand to evolve your Active Pokémon, you may discard the top 3 cards of your deck and and then shuffle 3 basic Energy cards from your discard pile into your deck. If you do, your opponent does the same.",
 				de: "Wenn du Magcargo aus deiner Hand spielst, um dein aktives Pokémon zu entwickeln, kannst du die obersten 3 Karten deines Decks auf deinen Ablagestapel legen und dann 3 Basis-Energiekarten aus deinem Ablagestapel in dein Deck mischen. Falls du dies tust, tut es dein Gegner ebenfalls."
 			},
 		},
@@ -54,7 +52,7 @@ const card: Card = {
 				de: "Erdrückende Lava"
 			},
 			effect: {
-				en: "You may discard a or basic Energy card attached to Magcargo. If you discard a Energy card in this way, the Defending Pokémon is now Burned. If you discard a Energy card in this way, this attack does 40 damage plus 20 more damage.",
+				en: "You may discard a Fire or Fighting basic Energy card attached to Magcargo. If you discard a Fire Energy card in this way, the Defending Pokémon is now Burned. If you discard a Fighting Energy card in this way, this attack does 40 damage plus 20 more damage.",
 				de: "Du kannst eine an Magcargo angelegte - oder -Basis-Energiekarte auf deinen Ablagestapel legen. Legst du auf diese Weise eine -Energiekarte auf deinen Ablagestapel, ist das verteidigende Pokémon jetzt verbrannt. Legst du auf diese Weise eine -Energiekarte auf deinen Ablagestapel, fügt dieser Angriff 40 Schadenspunkte plus 20 weitere Schadenspunkte zu."
 			},
 			damage: "40+",
@@ -65,25 +63,28 @@ const card: Card = {
 	weaknesses: [
 		{
 			type: "Water",
-			value: "×2"
+			value: "x2"
 		},
 	],
 	retreat: 3,
 
 
-	thirdParty: {
-		cardmarket: 275276,
-		tcgplayer: 87011
-	},
-
 	variants: [
 		{
 			type: 'normal',
+			thirdParty: {
+				tcgplayer: 87011,
+				cardmarket: 275276
+			},
 		},
 		{
 			type: 'reverse',
-		}
-	]
+			thirdParty: {
+				tcgplayer: 87011,
+				cardmarket: 275276
+			},
+		},
+	],
 }
 
 export default card

--- a/data/E-Card/Skyridge/19.ts
+++ b/data/E-Card/Skyridge/19.ts
@@ -7,19 +7,17 @@ const card: Card = {
 		de: "Magneton"
 	},
 
-	illustrator: "Kouki Saitou",
+	illustrator: "Hajime Kusajima",
 	rarity: "Rare",
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		82,
-	],
+	dexId: [82],
 
 	hp: 80,
 
 	types: [
-		"Lightning",
+		"Lightning"
 	],
 
 	evolveFrom: {
@@ -54,7 +52,7 @@ const card: Card = {
 				de: "Elektrischer Strahl"
 			},
 			effect: {
-				en: "You may discard all Energy cards attached to Magneton when you use this attack. If you do, put damage counters equal to the amount of Energy cards removed in this way on any number of your opponent's Benched Pokémon in the way you like. (For example, if you discard 3 Energy cards, you can put 1 damage counter on 1 of your opponent's Benched Pokémon and 2 on another.)",
+				en: "You may discard all Lightning Energy cards attached to Magneton when you use this attack. If you do, put damage counters equal to the amount of Energy cards removed in this way on any number of your opponent's Benched Pokémon in the way you like. (For example, if you discard 3 Lightning Energy cards, you can put 1 damage counter on 1 of your opponent's Benched Pokémon and 2 on another.)",
 				de: "Du kannst alle an Magneton angelegten -Energiekarten auf deinen Ablagestapel legen, wenn du diesen Angriff verwendest. Falls du dies tust, verteile so viele Schadensmarken, wie du auf diese Weise Energiekarten abgelegt hast, in beliebiger Weise auf eine beliebige Anzahl an Pokémon auf der Bank deines Gegners. (Legst du zum Beispiel 3 -Energiekarten auf den Ablagestapel, kannst du 1 Schadensmarke auf eins der Pokémon auf der Bank deines Gegners und 2 Marken auf ein anderes legen.)"
 			},
 			damage: 40,
@@ -65,25 +63,28 @@ const card: Card = {
 	weaknesses: [
 		{
 			type: "Fighting",
-			value: "×2"
+			value: "x2"
 		},
 	],
 	retreat: 1,
 
 
-	thirdParty: {
-		cardmarket: 275228,
-		tcgplayer: 87089
-	},
-
 	variants: [
 		{
 			type: 'normal',
+			thirdParty: {
+				tcgplayer: 87089,
+				cardmarket: 275228
+			},
 		},
 		{
 			type: 'reverse',
-		}
-	]
+			thirdParty: {
+				tcgplayer: 87089,
+				cardmarket: 275228
+			},
+		},
+	],
 }
 
 export default card

--- a/data/E-Card/Skyridge/2.ts
+++ b/data/E-Card/Skyridge/2.ts
@@ -12,14 +12,12 @@ const card: Card = {
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		65,
-	],
+	dexId: [65],
 
 	hp: 100,
 
 	types: [
-		"Psychic",
+		"Psychic"
 	],
 
 	evolveFrom: {
@@ -36,7 +34,7 @@ const card: Card = {
 				de: "Energy Jump"
 			},
 			effect: {
-				en: "Once during your turn (before you attack) you may move an energy card from 1 of your Pokémon to another of your Pokémon. This power can't be used if Alakazam is affected by a Special Condition.",
+				en: "Once during your turn (before your attack), you may move an Energy card from 1 of your Pokémon to another of your Pokémon. This power can't be used if Alakazam is affected by a Special Condition.",
 				de: "Once during your turn (before your attack), you may move an Energy card from 1 of your Pokémon to another of your Pokémon. This power can't be used if Alakazam is affected by a Special Condition."
 			},
 		},
@@ -54,7 +52,7 @@ const card: Card = {
 				de: "Psychic"
 			},
 			effect: {
-				en: "This attack does 30 damage plus 10 more damage for each energy card attached to the Defending Pokémon.",
+				en: "This attack does 30 damage plus 10 more damage for each Energy card attached to the Defending Pokémon.",
 				de: "This attack does 30 damage plus 10 more damage for each Energy card attached to the Defending Pokémon."
 			},
 			damage: "30+",
@@ -65,25 +63,28 @@ const card: Card = {
 	weaknesses: [
 		{
 			type: "Psychic",
-			value: "×2"
+			value: "x2"
 		},
 	],
 	retreat: 2,
 
 
-	thirdParty: {
-		cardmarket: 275238,
-		tcgplayer: 83499
-	},
-
 	variants: [
 		{
 			type: 'normal',
+			thirdParty: {
+				tcgplayer: 83499,
+				cardmarket: 275238
+			},
 		},
 		{
 			type: 'reverse',
-		}
-	]
+			thirdParty: {
+				tcgplayer: 83499,
+				cardmarket: 275238
+			},
+		},
+	],
 }
 
 export default card

--- a/data/E-Card/Skyridge/20.ts
+++ b/data/E-Card/Skyridge/20.ts
@@ -12,14 +12,12 @@ const card: Card = {
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		82,
-	],
+	dexId: [82],
 
 	hp: 70,
 
 	types: [
-		"Metal",
+		"Metal"
 	],
 
 	evolveFrom: {
@@ -56,7 +54,7 @@ const card: Card = {
 				de: "Magnetwelle"
 			},
 			effect: {
-				en: "This attack does 30 damage plus 10 more damage times the number of your Benched Pokémon minus the number of your opponent's Benched Pokémon. (For example, if your opponent has 1 Benched Pokémon and you have 3, this attack will do 30 damage plus 20 more damage.)",
+				en: "This attack does 30 damage plus 10 damage times the number of your Benched Pokémon minus the number of your opponent's Benched Pokémon. (For example, if your opponent has 1 Benched Pokémon and you have 3, this attack will do 30 damage plus 20 more damage.)",
 				de: "Dieser Angriff fügt 30 Schadenspunkte plus 10 weitere Schadenspunkte für jedes Pokémon auf deiner Bank minus 10 Schadenspunkte für jedes Pokémon auf der Bank deines Gegners zu. (Hat zum Beispiel dein Gegner 1 Pokémon auf seiner Bank und du 3 auf deiner, fügt dieser Angriff 30 Schadenspunkte plus 20 weitere Schadenspunkte zu.)"
 			},
 			damage: "30+",
@@ -67,10 +65,9 @@ const card: Card = {
 	weaknesses: [
 		{
 			type: "Fire",
-			value: "×2"
+			value: "x2"
 		},
 	],
-
 	resistances: [
 		{
 			type: "Grass",
@@ -80,19 +77,22 @@ const card: Card = {
 	retreat: 2,
 
 
-	thirdParty: {
-		cardmarket: 275277,
-		tcgplayer: 87090
-	},
-
 	variants: [
 		{
 			type: 'normal',
+			thirdParty: {
+				tcgplayer: 87090,
+				cardmarket: 275277
+			},
 		},
 		{
 			type: 'reverse',
-		}
-	]
+			thirdParty: {
+				tcgplayer: 87090,
+				cardmarket: 275277
+			},
+		},
+	],
 }
 
 export default card

--- a/data/E-Card/Skyridge/21.ts
+++ b/data/E-Card/Skyridge/21.ts
@@ -12,14 +12,12 @@ const card: Card = {
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		146,
-	],
+	dexId: [146],
 
 	hp: 80,
 
 	types: [
-		"Fire",
+		"Fire"
 	],
 
 	stage: "Basic",
@@ -48,7 +46,7 @@ const card: Card = {
 				de: "Feuersammeln"
 			},
 			effect: {
-				en: "If there are any Energy cards in your discard pile, flip a coin. If heads, attach 1 of them to Moltres.",
+				en: "If there are any Fire Energy cards in your discard pile, flip a coin. If heads, attach 1 of them to Moltres.",
 				de: "Wenn mindestens eine -Energiekarte in deinem Ablagestapel ist, wirf eine Münze. Lege bei \"Kopf\" eine davon an Lavados an."
 			},
 			damage: 10,
@@ -66,7 +64,7 @@ const card: Card = {
 				de: "Brennender Schweif"
 			},
 			effect: {
-				en: "Flip a coin. If tails, discard a Energy card attached to Moltres.",
+				en: "Flip a coin. If tails, discard a Fire Energy card attached to Moltres.",
 				de: "Wirf eine Münze. Lege bei \"Zahl\" eine an Lavados angelegte -Energiekarte auf deinen Ablagestapel."
 			},
 			damage: 60,
@@ -77,10 +75,9 @@ const card: Card = {
 	weaknesses: [
 		{
 			type: "Water",
-			value: "×2"
+			value: "x2"
 		},
 	],
-
 	resistances: [
 		{
 			type: "Fighting",
@@ -90,19 +87,22 @@ const card: Card = {
 	retreat: 2,
 
 
-	thirdParty: {
-		cardmarket: 275230,
-		tcgplayer: 87558
-	},
-
 	variants: [
 		{
 			type: 'normal',
+			thirdParty: {
+				tcgplayer: 87558,
+				cardmarket: 275230
+			},
 		},
 		{
 			type: 'reverse',
-		}
-	]
+			thirdParty: {
+				tcgplayer: 87558,
+				cardmarket: 275230
+			},
+		},
+	],
 }
 
 export default card

--- a/data/E-Card/Skyridge/22.ts
+++ b/data/E-Card/Skyridge/22.ts
@@ -12,14 +12,12 @@ const card: Card = {
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		31,
-	],
+	dexId: [31],
 
 	hp: 110,
 
 	types: [
-		"Grass",
+		"Grass"
 	],
 
 	evolveFrom: {
@@ -36,7 +34,7 @@ const card: Card = {
 				de: "Evolutions-Helfer"
 			},
 			effect: {
-				en: "Once during your turn (before you attack) if Nidoqueen is on your bench, you may search your deck for a card that evolves from your Active Pokémon and attach it to your Active Pokémon. (this counts as evolving that Pokémon) Shuffle your deck afterward.",
+				en: "Once during your turn (before your attack), if Nidoqueen is on your Bench, you may search your deck for a card that evolves from your Active Pokémon and attach it to your Active Pokémon. (This counts as evolving that Pokémon.) Shuffle your deck afterward.",
 				de: "Einmal während deines Zuges (vor deinem Angriff) kannst du, falls Nidoqueen auf deiner Bank ist, dein Deck nach einer Karte durchsuchen, die sich aus deinem aktiven Pokémon entwickelt, und sie an dein aktives Pokémon anlegen. (Dies zählt als Entwickeln dieses Pokémon.) Mische dein Deck danach."
 			},
 		},
@@ -54,7 +52,7 @@ const card: Card = {
 				de: "Doppelkralle"
 			},
 			effect: {
-				en: "Flip 2 coins. This attack does 30 damage plus 20 more damage for each heads.",
+				en: "Flip 2 coins. This attack does 30 damage plus 20 more damage for each heads",
 				de: "Wirf 2 Münzen. Dieser Angriff fügt 30 Schadenspunkte plus 20 weitere Schadenspunkte pro geworfenem \"Kopf\" zu."
 			},
 			damage: "30+",
@@ -65,25 +63,28 @@ const card: Card = {
 	weaknesses: [
 		{
 			type: "Psychic",
-			value: "×2"
+			value: "x2"
 		},
 	],
 	retreat: 3,
 
 
-	thirdParty: {
-		cardmarket: 275231,
-		tcgplayer: 87704
-	},
-
 	variants: [
 		{
 			type: 'normal',
+			thirdParty: {
+				tcgplayer: 87704,
+				cardmarket: 275231
+			},
 		},
 		{
 			type: 'reverse',
-		}
-	]
+			thirdParty: {
+				tcgplayer: 87704,
+				cardmarket: 275231
+			},
+		},
+	],
 }
 
 export default card

--- a/data/E-Card/Skyridge/23.ts
+++ b/data/E-Card/Skyridge/23.ts
@@ -12,14 +12,12 @@ const card: Card = {
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		139,
-	],
+	dexId: [139],
 
 	hp: 90,
 
 	types: [
-		"Water",
+		"Water"
 	],
 
 	evolveFrom: {
@@ -65,25 +63,28 @@ const card: Card = {
 	weaknesses: [
 		{
 			type: "Lightning",
-			value: "×2"
+			value: "x2"
 		},
 	],
 	retreat: 2,
 
 
-	thirdParty: {
-		cardmarket: 275281,
-		tcgplayer: 87864
-	},
-
 	variants: [
 		{
 			type: 'normal',
+			thirdParty: {
+				tcgplayer: 87864,
+				cardmarket: 275281
+			},
 		},
 		{
 			type: 'reverse',
-		}
-	]
+			thirdParty: {
+				tcgplayer: 87864,
+				cardmarket: 275281
+			},
+		},
+	],
 }
 
 export default card

--- a/data/E-Card/Skyridge/24.ts
+++ b/data/E-Card/Skyridge/24.ts
@@ -12,14 +12,12 @@ const card: Card = {
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		221,
-	],
+	dexId: [221],
 
 	hp: 90,
 
 	types: [
-		"Water",
+		"Water"
 	],
 
 	evolveFrom: {
@@ -69,25 +67,28 @@ const card: Card = {
 	weaknesses: [
 		{
 			type: "Metal",
-			value: "×2"
+			value: "x2"
 		},
 	],
 	retreat: 3,
 
 
-	thirdParty: {
-		cardmarket: 275233,
-		tcgplayer: 88113
-	},
-
 	variants: [
 		{
 			type: 'normal',
+			thirdParty: {
+				tcgplayer: 88113,
+				cardmarket: 275233
+			},
 		},
 		{
 			type: 'reverse',
-		}
-	]
+			thirdParty: {
+				tcgplayer: 88113,
+				cardmarket: 275233
+			},
+		},
+	],
 }
 
 export default card

--- a/data/E-Card/Skyridge/25.ts
+++ b/data/E-Card/Skyridge/25.ts
@@ -12,14 +12,12 @@ const card: Card = {
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		186,
-	],
+	dexId: [186],
 
 	hp: 110,
 
 	types: [
-		"Water",
+		"Water"
 	],
 
 	evolveFrom: {
@@ -73,7 +71,7 @@ const card: Card = {
 				de: "Energieplatscher"
 			},
 			effect: {
-				en: "Move 2 Energy cards attached to Politoed to 1 or 2 of your Benched Pokémon. (You may put both on the same Pokémon, or 1 each on 2 different Pokémon.) If you have no Benched Pokémon, ignore this effect.",
+				en: "Move 2 Water Energy cards attached to Politoed to 1 or 2 of your Benched Pokémon. (You may put both on the same Pokémon or 1 each on 2 different Pokémon.) If you have no Benched Pokémon, ignore this effect.",
 				de: "Lege 2 an Quaxo angelegte -Energiekarten an 1 oder 2 der Pokémon auf deiner Bank an. (Du kannst beide an dasselbe Pokémon anlegen oder je 1 an 2 verschiedene Pokémon.) Hast du keine Pokémon auf deiner Bank, ignoriere diesen Effekt."
 			},
 			damage: 70,
@@ -84,25 +82,28 @@ const card: Card = {
 	weaknesses: [
 		{
 			type: "Lightning",
-			value: "×2"
+			value: "x2"
 		},
 	],
 	retreat: 2,
 
 
-	thirdParty: {
-		cardmarket: 275244,
-		tcgplayer: 88248
-	},
-
 	variants: [
 		{
 			type: 'normal',
+			thirdParty: {
+				tcgplayer: 88248,
+				cardmarket: 275244
+			},
 		},
 		{
 			type: 'reverse',
-		}
-	]
+			thirdParty: {
+				tcgplayer: 88248,
+				cardmarket: 275244
+			},
+		},
+	],
 }
 
 export default card

--- a/data/E-Card/Skyridge/26.ts
+++ b/data/E-Card/Skyridge/26.ts
@@ -12,14 +12,12 @@ const card: Card = {
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		62,
-	],
+	dexId: [62],
 
 	hp: 110,
 
 	types: [
-		"Fighting",
+		"Fighting"
 	],
 
 	evolveFrom: {
@@ -36,7 +34,7 @@ const card: Card = {
 				de: "Seltsame Spirale"
 			},
 			effect: {
-				en: "Once during your turn (before you attack), if Poliwrath if your Active Pokémon, you may discard a basic Energy card attached to Poliwrath. If you do, the Defending Pokémon is now Confused. This power can't be used if Poliwrath is affected by a Special Condition.",
+				en: "Once during your turn (before your attack), if Poliwrath is your Active Pokémon, you may discard a basic Energy card attached to Poliwrath. If you do, the Defending Pokémon is now Confused. This power can't be used if Poliwrath is affected by a Special Condition.",
 				de: "Einmal während deines Zuges (vor deinem Angriff) kannst du, falls Quappo dein aktives Pokémon ist, eine an Quappo angelegte Basis-Energiekarte auf deinen Ablagestapel legen. Falls du dies tust, ist das verteidigende Pokémon jetzt verwirrt. Diese Fähigkeit kann nicht verwendet werden, falls Quappo von einem speziellen Zustand betroffen ist."
 			},
 		},
@@ -65,25 +63,28 @@ const card: Card = {
 	weaknesses: [
 		{
 			type: "Psychic",
-			value: "×2"
+			value: "x2"
 		},
 	],
 	retreat: 2,
 
 
-	thirdParty: {
-		cardmarket: 275232,
-		tcgplayer: 88273
-	},
-
 	variants: [
 		{
 			type: 'normal',
+			thirdParty: {
+				tcgplayer: 88273,
+				cardmarket: 275232
+			},
 		},
 		{
 			type: 'reverse',
-		}
-	]
+			thirdParty: {
+				tcgplayer: 88273,
+				cardmarket: 275232
+			},
+		},
+	],
 }
 
 export default card

--- a/data/E-Card/Skyridge/27.ts
+++ b/data/E-Card/Skyridge/27.ts
@@ -12,14 +12,12 @@ const card: Card = {
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		26,
-	],
+	dexId: [26],
 
 	hp: 80,
 
 	types: [
-		"Lightning",
+		"Lightning"
 	],
 
 	evolveFrom: {
@@ -66,25 +64,28 @@ const card: Card = {
 	weaknesses: [
 		{
 			type: "Fighting",
-			value: "×2"
+			value: "x2"
 		},
 	],
 	retreat: 1,
 
 
-	thirdParty: {
-		cardmarket: 275243,
-		tcgplayer: 88503
-	},
-
 	variants: [
 		{
 			type: 'normal',
+			thirdParty: {
+				tcgplayer: 88503,
+				cardmarket: 275243
+			},
 		},
 		{
 			type: 'reverse',
-		}
-	]
+			thirdParty: {
+				tcgplayer: 88503,
+				cardmarket: 275243
+			},
+		},
+	],
 }
 
 export default card

--- a/data/E-Card/Skyridge/28.ts
+++ b/data/E-Card/Skyridge/28.ts
@@ -12,14 +12,12 @@ const card: Card = {
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		243,
-	],
+	dexId: [243],
 
 	hp: 70,
 
 	types: [
-		"Lightning",
+		"Lightning"
 	],
 
 	stage: "Basic",
@@ -32,7 +30,7 @@ const card: Card = {
 				de: "Reiner Körper"
 			},
 			effect: {
-				en: "To attach a Lightning Energy card from your hand to Raikou, you must discard an Energy card attached to Raikou. (Attach the Lightning energy, and then discard an Energy card from Raikou.)",
+				en: "To attach a Lightning Energy card from your hand to Raikou, you must discard an Energy card attached to Raikou. (Attach the Lightning Energy, and then discard an Energy card from Raikou.)",
 				de: "Um eine-Energiekarte aus deiner Hand an Raikou anzulegen, musst du eine an Raikou angelegte Energiekarte auf deinen Ablagestapel legen. (Lege erst die -Energiekarte an, und lege dann eine an Raikou angelegte Energiekarte auf den Ablagestapel.)"
 			},
 		},
@@ -50,7 +48,7 @@ const card: Card = {
 				de: "Blitz-Spähre"
 			},
 			effect: {
-				en: "You may flip a coin. If heads, discard all Energy cards attached to Raikou. This attack does 40 damage plus 20 more damage for each Energy card discarded in this way.",
+				en: "You may flip a coin. If heads, discard all Lightning Energy cards attached to Raikou. This attack does 40 damage plus 20 more damage for each Energy card discarded in this way.",
 				de: "Du kannst eine Münze werfen. Lege bei 'Kopf' alle an Raikou angelegten -Energiekarten auf deinen Ablagestapel. Dieser Angriff fügt 40 Schadenspunkte plus 20 weitere Schadenspunkte für jede auf diese Weise abgelegte Energiekarten zu."
 			},
 			damage: "40+",
@@ -60,26 +58,29 @@ const card: Card = {
 
 	weaknesses: [
 		{
-			type: "Fire",
-			value: "×2"
+			type: "Fighting",
+			value: "x2"
 		},
 	],
 	retreat: 1,
 
 
-	thirdParty: {
-		cardmarket: 275247,
-		tcgplayer: 88532
-	},
-
 	variants: [
 		{
 			type: 'normal',
+			thirdParty: {
+				tcgplayer: 88532,
+				cardmarket: 275247
+			},
 		},
 		{
 			type: 'reverse',
-		}
-	]
+			thirdParty: {
+				tcgplayer: 88532,
+				cardmarket: 275247
+			},
+		},
+	],
 }
 
 export default card

--- a/data/E-Card/Skyridge/29.ts
+++ b/data/E-Card/Skyridge/29.ts
@@ -12,14 +12,12 @@ const card: Card = {
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		112,
-	],
+	dexId: [112],
 
 	hp: 90,
 
 	types: [
-		"Fighting",
+		"Fighting"
 	],
 
 	evolveFrom: {
@@ -65,17 +63,16 @@ const card: Card = {
 				de: "Wirf eine Münze. Bei 'Zahl' hat dieser Angriff keine Auswirkungen."
 			},
 
-			damage: 100
+			damage: 100,
 		},
 	],
 
 	weaknesses: [
 		{
 			type: "Grass",
-			value: "×2"
+			value: "x2"
 		},
 	],
-
 	resistances: [
 		{
 			type: "Lightning",
@@ -85,19 +82,22 @@ const card: Card = {
 	retreat: 2,
 
 
-	thirdParty: {
-		cardmarket: 275257,
-		tcgplayer: 88729
-	},
-
 	variants: [
 		{
 			type: 'normal',
+			thirdParty: {
+				tcgplayer: 88729,
+				cardmarket: 275257
+			},
 		},
 		{
 			type: 'reverse',
-		}
-	]
+			thirdParty: {
+				tcgplayer: 88729,
+				cardmarket: 275257
+			},
+		},
+	],
 }
 
 export default card

--- a/data/E-Card/Skyridge/3.ts
+++ b/data/E-Card/Skyridge/3.ts
@@ -12,14 +12,12 @@ const card: Card = {
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		59,
-	],
+	dexId: [59],
 
 	hp: 80,
 
 	types: [
-		"Fire",
+		"Fire"
 	],
 
 	evolveFrom: {
@@ -36,7 +34,7 @@ const card: Card = {
 				de: "Energy Recharge"
 			},
 			effect: {
-				en: "When you play Arcanine from your hand to evolve your Active Pokémon, you may flip 3 coins. For each heads, choose a basic energy card from your discard pile and attach it to Arcanine.",
+				en: "When you play Arcanine from your hand to evolve your Active Pokémon, you may flip 3 coins. For each heads, choose a basic Energy card from your discard pile and attach it to Arcanine.",
 				de: "When your play Arcanine from your hand to evolve your Active Pokémon, you may flip 3 coins. For each heads, choose a basic Energy card from your discard pile and attach it to Arcanine."
 			},
 		},
@@ -69,7 +67,7 @@ const card: Card = {
 				de: "White Flames"
 			},
 			effect: {
-				en: "Discard all Energy cards attached to Arcanine.",
+				en: "Discard all Fire Energy cards attached to Arcanine.",
 				de: "Discard all  Energy cards attached to Arcanine."
 			},
 			damage: 70,
@@ -80,25 +78,28 @@ const card: Card = {
 	weaknesses: [
 		{
 			type: "Water",
-			value: "��2"
+			value: "x2"
 		},
 	],
 	retreat: 2,
 
 
-	thirdParty: {
-		cardmarket: 275227,
-		tcgplayer: 83577
-	},
-
 	variants: [
 		{
 			type: 'normal',
+			thirdParty: {
+				tcgplayer: 83577,
+				cardmarket: 275227
+			},
 		},
 		{
 			type: 'reverse',
-		}
-	]
+			thirdParty: {
+				tcgplayer: 83577,
+				cardmarket: 275227
+			},
+		},
+	],
 }
 
 export default card

--- a/data/E-Card/Skyridge/30.ts
+++ b/data/E-Card/Skyridge/30.ts
@@ -7,19 +7,17 @@ const card: Card = {
 		de: "Starmie"
 	},
 
-	illustrator: "CR CG gangs",
+	illustrator: "Hajime Kusajima",
 	rarity: "Rare",
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		121,
-	],
+	dexId: [121],
 
 	hp: 80,
 
 	types: [
-		"Psychic",
+		"Psychic"
 	],
 
 	evolveFrom: {
@@ -38,10 +36,10 @@ const card: Card = {
 				de: "Energieausbruch"
 			},
 			effect: {
-				en: "Flip a coin. If heads, this attack does 10 damage times the number of Energy cards attached to Starmie and the Defending Pokémon.",
+				en: "Flip a coin. If heads, this attack does 10 damage times the number of Energy attached to Starmie and the Defending Pokémon.",
 				de: "Wirf eine Münze. Bei 'Kopf' fügt dieser Angriff 10 Schadenspunkte mal der Anzahl an Energiekarten, die an Starmie und das Verteidigende Pokémon angelegt sind, zu."
 			},
-			damage: "10x",
+			damage: "10×",
 
 		},
 		{
@@ -66,25 +64,28 @@ const card: Card = {
 	weaknesses: [
 		{
 			type: "Psychic",
-			value: "×2"
+			value: "x2"
 		},
 	],
 	retreat: 1,
 
 
-	thirdParty: {
-		cardmarket: 275254,
-		tcgplayer: 89529
-	},
-
 	variants: [
 		{
 			type: 'normal',
+			thirdParty: {
+				tcgplayer: 89529,
+				cardmarket: 275254
+			},
 		},
 		{
 			type: 'reverse',
-		}
-	]
+			thirdParty: {
+				tcgplayer: 89529,
+				cardmarket: 275254
+			},
+		},
+	],
 }
 
 export default card

--- a/data/E-Card/Skyridge/31.ts
+++ b/data/E-Card/Skyridge/31.ts
@@ -12,14 +12,12 @@ const card: Card = {
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		208,
-	],
+	dexId: [208],
 
 	hp: 100,
 
 	types: [
-		"Metal",
+		"Metal"
 	],
 
 	evolveFrom: {
@@ -78,17 +76,16 @@ const card: Card = {
 				de: "Bevor der Schaden zugefügt wird, kannst du eine Münze werfen. Bei 'Kopf' fügt dieser Angriff 80 Schadenspunkte zu. Bei 'Zahl' hat dieser Angriff keine Wirkung."
 			},
 
-			damage: 40
+			damage: 40,
 		},
 	],
 
 	weaknesses: [
 		{
 			type: "Fire",
-			value: "×2"
+			value: "x2"
 		},
 	],
-
 	resistances: [
 		{
 			type: "Grass",
@@ -98,19 +95,22 @@ const card: Card = {
 	retreat: 4,
 
 
-	thirdParty: {
-		cardmarket: 275256,
-		tcgplayer: 89559
-	},
-
 	variants: [
 		{
 			type: 'normal',
+			thirdParty: {
+				tcgplayer: 89559,
+				cardmarket: 275256
+			},
 		},
 		{
 			type: 'reverse',
-		}
-	]
+			thirdParty: {
+				tcgplayer: 89559,
+				cardmarket: 275256
+			},
+		},
+	],
 }
 
 export default card

--- a/data/E-Card/Skyridge/32.ts
+++ b/data/E-Card/Skyridge/32.ts
@@ -12,14 +12,12 @@ const card: Card = {
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		197,
-	],
+	dexId: [197],
 
 	hp: 70,
 
 	types: [
-		"Darkness",
+		"Darkness"
 	],
 
 	evolveFrom: {
@@ -64,10 +62,9 @@ const card: Card = {
 	weaknesses: [
 		{
 			type: "Fighting",
-			value: "×2"
+			value: "x2"
 		},
 	],
-
 	resistances: [
 		{
 			type: "Psychic",
@@ -77,19 +74,22 @@ const card: Card = {
 	retreat: 1,
 
 
-	thirdParty: {
-		cardmarket: 275255,
-		tcgplayer: 90141
-	},
-
 	variants: [
 		{
 			type: 'normal',
+			thirdParty: {
+				tcgplayer: 90141,
+				cardmarket: 275255
+			},
 		},
 		{
 			type: 'reverse',
-		}
-	]
+			thirdParty: {
+				tcgplayer: 90141,
+				cardmarket: 275255
+			},
+		},
+	],
 }
 
 export default card

--- a/data/E-Card/Skyridge/33.ts
+++ b/data/E-Card/Skyridge/33.ts
@@ -12,14 +12,12 @@ const card: Card = {
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		134,
-	],
+	dexId: [134],
 
 	hp: 70,
 
 	types: [
-		"Water",
+		"Water"
 	],
 
 	evolveFrom: {
@@ -32,7 +30,7 @@ const card: Card = {
 		{
 			type: "Poke-BODY",
 			name: {
-				en: "Self Healing",
+				en: "Self-healing",
 				de: "Selbstheilung"
 			},
 			effect: {
@@ -81,25 +79,28 @@ const card: Card = {
 	weaknesses: [
 		{
 			type: "Lightning",
-			value: "×2"
+			value: "x2"
 		},
 	],
 	retreat: 1,
 
 
-	thirdParty: {
-		cardmarket: 275252,
-		tcgplayer: 90281
-	},
-
 	variants: [
 		{
 			type: 'normal',
+			thirdParty: {
+				tcgplayer: 90281,
+				cardmarket: 275252
+			},
 		},
 		{
 			type: 'reverse',
-		}
-	]
+			thirdParty: {
+				tcgplayer: 90281,
+				cardmarket: 275252
+			},
+		},
+	],
 }
 
 export default card

--- a/data/E-Card/Skyridge/34.ts
+++ b/data/E-Card/Skyridge/34.ts
@@ -12,14 +12,12 @@ const card: Card = {
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		40,
-	],
+	dexId: [40],
 
 	hp: 70,
 
 	types: [
-		"Colorless",
+		"Colorless"
 	],
 
 	evolveFrom: {
@@ -36,7 +34,7 @@ const card: Card = {
 				de: "Guter Nachbar"
 			},
 			effect: {
-				en: "Once during your turn (before you attack), if Wigglytuff is on your bench, you may flip a coin. If heads, each player removes up to 2 damage counters from his or her Active Pokémon. This power can't be used if you have already used another Wigglytuff's Good Neighbor Poké-Power this turn.",
+				en: "Once during your turn (before your attack), if Wigglytuff is on your bench, you may flip a coin. If heads, each player removes up to 2 damage counters from his or her Active Pokémon. This power can't be used if you have already used another Wigglytuff's Good Neighbor Poké-Power this turn.",
 				de: "Einmal während deines Zuges (vor deinem Angriff) kannst du, falls Knuddeluff auf deiner Bank ist, eine Münze werfen. Bei \"Kopf\" entfernt jeder Spieler 2 Schadensmarken von seinem aktiven Pokémon. Diese Fähigkeit kann nicht verwendet werden, falls du in diesem Zug bereits die Poké-Power \"Guter Nachbar\" eines anderen Knuddeluffs verwendet hast."
 			},
 		},
@@ -56,7 +54,7 @@ const card: Card = {
 				en: "Flip a coin. If heads, this attack does 10 damage times the number of Pokémon you have in play.",
 				de: "Wirf eine Münze. Bei \"Kopf\" fügt dieser Angriff 10 Schadenspunkte mal der Anzahl an Pokémon, die du im Spiel hast, zu."
 			},
-			damage: "10x",
+			damage: "10×",
 
 		},
 	],
@@ -64,25 +62,28 @@ const card: Card = {
 	weaknesses: [
 		{
 			type: "Fighting",
-			value: "×2"
+			value: "x2"
 		},
 	],
 	retreat: 1,
 
 
-	thirdParty: {
-		cardmarket: 275292,
-		tcgplayer: 90595
-	},
-
 	variants: [
 		{
 			type: 'normal',
+			thirdParty: {
+				tcgplayer: 90595,
+				cardmarket: 275292
+			},
 		},
 		{
 			type: 'reverse',
-		}
-	]
+			thirdParty: {
+				tcgplayer: 90595,
+				cardmarket: 275292
+			},
+		},
+	],
 }
 
 export default card

--- a/data/E-Card/Skyridge/35.ts
+++ b/data/E-Card/Skyridge/35.ts
@@ -12,14 +12,12 @@ const card: Card = {
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		178,
-	],
+	dexId: [178],
 
 	hp: 80,
 
 	types: [
-		"Psychic",
+		"Psychic"
 	],
 
 	evolveFrom: {
@@ -65,25 +63,28 @@ const card: Card = {
 	weaknesses: [
 		{
 			type: "Psychic",
-			value: "×2"
+			value: "x2"
 		},
 	],
 	retreat: 1,
 
 
-	thirdParty: {
-		cardmarket: 275253,
-		tcgplayer: 90659
-	},
-
 	variants: [
 		{
 			type: 'normal',
+			thirdParty: {
+				tcgplayer: 90659,
+				cardmarket: 275253
+			},
 		},
 		{
 			type: 'reverse',
-		}
-	]
+			thirdParty: {
+				tcgplayer: 90659,
+				cardmarket: 275253
+			},
+		},
+	],
 }
 
 export default card

--- a/data/E-Card/Skyridge/36.ts
+++ b/data/E-Card/Skyridge/36.ts
@@ -12,14 +12,12 @@ const card: Card = {
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		101,
-	],
+	dexId: [101],
 
 	hp: 70,
 
 	types: [
-		"Lightning",
+		"Lightning"
 	],
 
 	evolveFrom: {
@@ -39,7 +37,7 @@ const card: Card = {
 				de: "Plasma"
 			},
 			effect: {
-				en: "If there are any Energy cards in your discard pile, flip a coin. If heads, attach 1 of them to Electrode.",
+				en: "If there are any Lightning Energy card in your discard pile, flip a coin. If heads, attach 1 of them to Electrode.",
 				de: "Wenn mindestens eine -Energiekarte in deinem Ablagestapel ist, wirf eine Münze. Lege bei 'Kopf' eine davon an Lektrobal an."
 			},
 			damage: 20,
@@ -53,11 +51,11 @@ const card: Card = {
 				"Colorless",
 			],
 			name: {
-				en: "Self destruct",
+				en: "Selfdestruct",
 				de: "Finale"
 			},
 			effect: {
-				en: "This attack does 20 damage to each Pokémon on each player's bench. (Don't apply Weakness and Resistance for Benched Pokémon) Electrode does 100 damage to itself.",
+				en: "This attack does 20 damage to each Pokémon on each player's Bench. (Don't apply Weakness and Resistance for Benched Pokémon.) Electrode does 100 damage to itself.",
 				de: "Dieser Angriff fügt jedem Pokémon auf der Bank beider Spieler 20 Schadenspunkte zu. (Wende keine Schwäche oder Resistenz bei Pokémon auf der Bank an.) Lektrobal fügt sich selber 100 Schadenspunkte zu."
 			},
 			damage: 100,
@@ -68,25 +66,28 @@ const card: Card = {
 	weaknesses: [
 		{
 			type: "Fighting",
-			value: "×2"
+			value: "x2"
 		},
 	],
 	retreat: 1,
 
 
-	thirdParty: {
-		cardmarket: 275294,
-		tcgplayer: 85152
-	},
-
 	variants: [
 		{
 			type: 'normal',
+			thirdParty: {
+				tcgplayer: 85152,
+				cardmarket: 275294
+			},
 		},
 		{
 			type: 'reverse',
-		}
-	]
+			thirdParty: {
+				tcgplayer: 85152,
+				cardmarket: 275294
+			},
+		},
+	],
 }
 
 export default card

--- a/data/E-Card/Skyridge/37.ts
+++ b/data/E-Card/Skyridge/37.ts
@@ -12,14 +12,12 @@ const card: Card = {
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		140,
-	],
+	dexId: [140],
 
 	hp: 50,
 
 	types: [
-		"Fighting",
+		"Fighting"
 	],
 
 	stage: "Stage1",
@@ -57,25 +55,28 @@ const card: Card = {
 	weaknesses: [
 		{
 			type: "Grass",
-			value: "×2"
+			value: "x2"
 		},
 	],
 	retreat: 1,
 
 
-	thirdParty: {
-		cardmarket: 275295,
-		tcgplayer: 86379
-	},
-
 	variants: [
 		{
 			type: 'normal',
+			thirdParty: {
+				tcgplayer: 86379,
+				cardmarket: 275295
+			},
 		},
 		{
 			type: 'reverse',
-		}
-	]
+			thirdParty: {
+				tcgplayer: 86379,
+				cardmarket: 275295
+			},
+		},
+	],
 }
 
 export default card

--- a/data/E-Card/Skyridge/38.ts
+++ b/data/E-Card/Skyridge/38.ts
@@ -12,14 +12,12 @@ const card: Card = {
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		67,
-	],
+	dexId: [67],
 
 	hp: 80,
 
 	types: [
-		"Fighting",
+		"Fighting"
 	],
 
 	evolveFrom: {
@@ -62,25 +60,28 @@ const card: Card = {
 	weaknesses: [
 		{
 			type: "Psychic",
-			value: "×2"
+			value: "x2"
 		},
 	],
 	retreat: 1,
 
 
-	thirdParty: {
-		cardmarket: 275296,
-		tcgplayer: 86975
-	},
-
 	variants: [
 		{
 			type: 'normal',
+			thirdParty: {
+				tcgplayer: 86975,
+				cardmarket: 275296
+			},
 		},
 		{
 			type: 'reverse',
-		}
-	]
+			thirdParty: {
+				tcgplayer: 86975,
+				cardmarket: 275296
+			},
+		},
+	],
 }
 
 export default card

--- a/data/E-Card/Skyridge/39.ts
+++ b/data/E-Card/Skyridge/39.ts
@@ -12,14 +12,12 @@ const card: Card = {
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		200,
-	],
+	dexId: [200],
 
 	hp: 50,
 
 	types: [
-		"Psychic",
+		"Psychic"
 	],
 
 	stage: "Basic",
@@ -60,10 +58,9 @@ const card: Card = {
 	weaknesses: [
 		{
 			type: "Darkness",
-			value: "×2"
+			value: "x2"
 		},
 	],
-
 	resistances: [
 		{
 			type: "Fighting",
@@ -73,19 +70,22 @@ const card: Card = {
 	retreat: 1,
 
 
-	thirdParty: {
-		cardmarket: 275297,
-		tcgplayer: 87502
-	},
-
 	variants: [
 		{
 			type: 'normal',
+			thirdParty: {
+				tcgplayer: 87502,
+				cardmarket: 275297
+			},
 		},
 		{
 			type: 'reverse',
-		}
-	]
+			thirdParty: {
+				tcgplayer: 87502,
+				cardmarket: 275297
+			},
+		},
+	],
 }
 
 export default card

--- a/data/E-Card/Skyridge/4.ts
+++ b/data/E-Card/Skyridge/4.ts
@@ -12,14 +12,12 @@ const card: Card = {
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		144,
-	],
+	dexId: [144],
 
 	hp: 80,
 
 	types: [
-		"Water",
+		"Water"
 	],
 
 	stage: "Basic",
@@ -48,7 +46,7 @@ const card: Card = {
 				de: "Einfrieren"
 			},
 			effect: {
-				en: "If there are any Energy cards in your discard pile, flip a coin. If heads, attach 1 of them to Articuno.",
+				en: "If there are any Water Energy cards in your discard pile, flip a coin. If heads, attach 1 of them to Articuno.",
 				de: "Wenn mindestens eine  -Energiekarte in deinem Ablegestapel ist, wirf eine Münze. Lege bei \"Kopf\" eine davon an Arktos an."
 			},
 			damage: 10,
@@ -77,10 +75,9 @@ const card: Card = {
 	weaknesses: [
 		{
 			type: "Metal",
-			value: "×2"
+			value: "x2"
 		},
 	],
-
 	resistances: [
 		{
 			type: "Fighting",
@@ -90,19 +87,22 @@ const card: Card = {
 	retreat: 2,
 
 
-	thirdParty: {
-		cardmarket: 275258,
-		tcgplayer: 83645
-	},
-
 	variants: [
 		{
 			type: 'normal',
+			thirdParty: {
+				tcgplayer: 83645,
+				cardmarket: 275258
+			},
 		},
 		{
 			type: 'reverse',
-		}
-	]
+			thirdParty: {
+				tcgplayer: 83645,
+				cardmarket: 275258
+			},
+		},
+	],
 }
 
 export default card

--- a/data/E-Card/Skyridge/40.ts
+++ b/data/E-Card/Skyridge/40.ts
@@ -12,14 +12,12 @@ const card: Card = {
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		164,
-	],
+	dexId: [164],
 
 	hp: 70,
 
 	types: [
-		"Colorless",
+		"Colorless"
 	],
 
 	evolveFrom: {
@@ -36,7 +34,7 @@ const card: Card = {
 				de: "Ermitteln"
 			},
 			effect: {
-				en: "Once during your turn (before you attack) you may look at the top 2 cards of any player's deck or at to up 2 of any player's Prizes. Put any cards you looked at back in the same order. This power can't be used if Noctowl is affected by a Special Condition.",
+				en: "Once during your turn (before your attack), you may look at the top 2 cards of any player's deck or at up to 2 of any player's Prizes. Put any cards you looked at back in the same order. This power can't be used if Noctowl is affected by a Special Condition.",
 				de: "Einmal während deines Zuges (vor deinem Angriff) kannst du dir die obersten 2 Karten des Decks eines der Spieler oder bis zu 2 der Preise eines der Spieler anschauen. Lege alle Karten, die du dir angeschaut hast, in der gleichen Reihenfolge zurück. Diese Fähigkeit kann nicht verwendet werden, falls Noctuh von einem speziellen Zustand betroffen ist."
 			},
 		},
@@ -64,30 +62,32 @@ const card: Card = {
 	weaknesses: [
 		{
 			type: "Lightning",
-			value: "×2"
+			value: "x2"
 		},
 	],
-
+	retreat: 0,
 	resistances: [
 		{
 			type: "Fighting",
 			value: "-30"
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 275298,
-		tcgplayer: 87790
-	},
-
 	variants: [
 		{
 			type: 'normal',
+			thirdParty: {
+				tcgplayer: 87790,
+				cardmarket: 275298
+			},
 		},
 		{
 			type: 'reverse',
-		}
-	]
+			thirdParty: {
+				tcgplayer: 87790,
+				cardmarket: 275298
+			},
+		},
+	],
 }
 
 export default card

--- a/data/E-Card/Skyridge/41.ts
+++ b/data/E-Card/Skyridge/41.ts
@@ -12,14 +12,12 @@ const card: Card = {
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		138,
-	],
+	dexId: [138],
 
 	hp: 60,
 
 	types: [
-		"Water",
+		"Water"
 	],
 
 	stage: "Stage1",
@@ -60,10 +58,9 @@ const card: Card = {
 	weaknesses: [
 		{
 			type: "Lightning",
-			value: "×2"
+			value: "x2"
 		},
 	],
-
 	resistances: [
 		{
 			type: "Water",
@@ -73,19 +70,22 @@ const card: Card = {
 	retreat: 1,
 
 
-	thirdParty: {
-		cardmarket: 275299,
-		tcgplayer: 87853
-	},
-
 	variants: [
 		{
 			type: 'normal',
+			thirdParty: {
+				tcgplayer: 87853,
+				cardmarket: 275299
+			},
 		},
 		{
 			type: 'reverse',
-		}
-	]
+			thirdParty: {
+				tcgplayer: 87853,
+				cardmarket: 275299
+			},
+		},
+	],
 }
 
 export default card

--- a/data/E-Card/Skyridge/42.ts
+++ b/data/E-Card/Skyridge/42.ts
@@ -12,14 +12,12 @@ const card: Card = {
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		53,
-	],
+	dexId: [53],
 
 	hp: 70,
 
 	types: [
-		"Colorless",
+		"Colorless"
 	],
 
 	evolveFrom: {
@@ -39,7 +37,7 @@ const card: Card = {
 				de: "Überraschungsschlitzer"
 			},
 			effect: {
-				en: "Flip a coin. If heads look at your opponent's hand. If he or she has any Trainer cards there, choose 1 of them. Your opponent shuffles that card into his or her deck.",
+				en: "Flip a coin. If heads, look at your opponent's hand. If he or she has any Trainer cards there, choose 1 of them. You opponent shuffles that card into his or her deck.",
 				de: "Wirf eine Münze. Schau dir bei \"Kopf\" die Karte auf der Hand deines Gegners an. Wenn er darunter mindestens eine Trainerkarte hat, wähle eine davon. Dein Gegner mischt diese Karte in sein Deck."
 			},
 			damage: 20,
@@ -61,30 +59,33 @@ const card: Card = {
 				de: "Wirf eine Münze. Bei \"Zahl\" hat dieser Angriff keine Ausiwrkungen."
 			},
 
-			damage: 50
+			damage: 50,
 		},
 	],
 
 	weaknesses: [
 		{
 			type: "Fighting",
-			value: "×2"
+			value: "x2"
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 275300,
-		tcgplayer: 87982
-	},
-
 	variants: [
 		{
 			type: 'normal',
+			thirdParty: {
+				tcgplayer: 87982,
+				cardmarket: 275300
+			},
 		},
 		{
 			type: 'reverse',
-		}
-	]
+			thirdParty: {
+				tcgplayer: 87982,
+				cardmarket: 275300
+			},
+		},
+	],
+	retreat: 0,
 }
 
 export default card

--- a/data/E-Card/Skyridge/43.ts
+++ b/data/E-Card/Skyridge/43.ts
@@ -12,14 +12,12 @@ const card: Card = {
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		221,
-	],
+	dexId: [221],
 
 	hp: 80,
 
 	types: [
-		"Fighting",
+		"Fighting"
 	],
 
 	evolveFrom: {
@@ -55,7 +53,7 @@ const card: Card = {
 				de: "Dauernder Ansturm"
 			},
 			effect: {
-				en: "Flip 4 coins. This attack foes 30 damage plus 20 more damage for each heads. Put a damage counter on Piloswine for each heads.",
+				en: "Flip 4 coins. This attack does 30 damage plus 20 more damage for each heads. Put a damage counter on Piloswine for each heads.",
 				de: "Wirf 4 Münzen. Dieser Angriff fügt 30 Schadenspunkte plus 20 weitere Schadenspunkte pro geworfenem \"Kopf\" zu. Lege für jeden \"Kopf\" eine Schadensmarke auf Keifel."
 			},
 			damage: "30+",
@@ -66,10 +64,9 @@ const card: Card = {
 	weaknesses: [
 		{
 			type: "Grass",
-			value: "×2"
+			value: "x2"
 		},
 	],
-
 	resistances: [
 		{
 			type: "Lightning",
@@ -79,19 +76,22 @@ const card: Card = {
 	retreat: 3,
 
 
-	thirdParty: {
-		cardmarket: 275301,
-		tcgplayer: 88115
-	},
-
 	variants: [
 		{
 			type: 'normal',
+			thirdParty: {
+				tcgplayer: 88115,
+				cardmarket: 275301
+			},
 		},
 		{
 			type: 'reverse',
-		}
-	]
+			thirdParty: {
+				tcgplayer: 88115,
+				cardmarket: 275301
+			},
+		},
+	],
 }
 
 export default card

--- a/data/E-Card/Skyridge/44.ts
+++ b/data/E-Card/Skyridge/44.ts
@@ -12,14 +12,12 @@ const card: Card = {
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		121,
-	],
+	dexId: [121],
 
 	hp: 70,
 
 	types: [
-		"Water",
+		"Water"
 	],
 
 	evolveFrom: {
@@ -38,7 +36,7 @@ const card: Card = {
 				de: "Aquaknarre"
 			},
 			effect: {
-				en: "This attack does 10 damage plus 20 more damage for each Energy attached to Starmie but not used to pay for this attack's energy cost. You can't add more than 40 damage in this way.",
+				en: "This attack does 10 damage plus 20 more damage for each Water Energy attached to Starmie but not used to pay for this attack's Energy cost. You can't add more than 40 damage in this way.",
 				de: "Fügt 10 Schadenspunkte plus 20 weitere Schadenspunkte für jede an Starmie angelegte -Energie, die nicht zum Zahlen der Energiekosten für diesen Angriff verwendet wird, zu. Du kannst auf diese Weise mehr als 40 Schadenspunkte zufügen."
 			},
 			damage: "10+",
@@ -66,25 +64,28 @@ const card: Card = {
 	weaknesses: [
 		{
 			type: "Lightning",
-			value: "×2"
+			value: "x2"
 		},
 	],
 	retreat: 1,
 
 
-	thirdParty: {
-		cardmarket: 275288,
-		tcgplayer: 89530
-	},
-
 	variants: [
 		{
 			type: 'normal',
+			thirdParty: {
+				tcgplayer: 89530,
+				cardmarket: 275288
+			},
 		},
 		{
 			type: 'reverse',
-		}
-	]
+			thirdParty: {
+				tcgplayer: 89530,
+				cardmarket: 275288
+			},
+		},
+	],
 }
 
 export default card

--- a/data/E-Card/Skyridge/45.ts
+++ b/data/E-Card/Skyridge/45.ts
@@ -12,14 +12,12 @@ const card: Card = {
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		202,
-	],
+	dexId: [202],
 
 	hp: 70,
 
 	types: [
-		"Psychic",
+		"Psychic"
 	],
 
 	stage: "Basic",
@@ -52,7 +50,7 @@ const card: Card = {
 				en: "Flip 2 coins. If either is heads, this attack does 10 damage times the number of damage counters on Wobbuffet.",
 				de: "Wirf 2 Münzen. Zeigt mindestens eine der beiden \"Kopf\", fügt dieser Angriff 10 Schadenspunkte mal der Anzahl an Schadensmarken auf Woingenau zu."
 			},
-			damage: "10x",
+			damage: "10×",
 
 		},
 	],
@@ -60,25 +58,28 @@ const card: Card = {
 	weaknesses: [
 		{
 			type: "Psychic",
-			value: "×2"
+			value: "x2"
 		},
 	],
 	retreat: 2,
 
 
-	thirdParty: {
-		cardmarket: 275303,
-		tcgplayer: 90615
-	},
-
 	variants: [
 		{
 			type: 'normal',
+			thirdParty: {
+				tcgplayer: 90615,
+				cardmarket: 275303
+			},
 		},
 		{
 			type: 'reverse',
-		}
-	]
+			thirdParty: {
+				tcgplayer: 90615,
+				cardmarket: 275303
+			},
+		},
+	],
 }
 
 export default card

--- a/data/E-Card/Skyridge/46.ts
+++ b/data/E-Card/Skyridge/46.ts
@@ -12,14 +12,12 @@ const card: Card = {
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		63,
-	],
+	dexId: [63],
 
 	hp: 40,
 
 	types: [
-		"Psychic",
+		"Psychic"
 	],
 
 	stage: "Basic",
@@ -57,25 +55,28 @@ const card: Card = {
 	weaknesses: [
 		{
 			type: "Psychic",
-			value: "×2"
+			value: "x2"
 		},
 	],
 	retreat: 1,
 
 
-	thirdParty: {
-		cardmarket: 275304,
-		tcgplayer: 83444
-	},
-
 	variants: [
 		{
 			type: 'normal',
+			thirdParty: {
+				tcgplayer: 83444,
+				cardmarket: 275304
+			},
 		},
 		{
 			type: 'reverse',
-		}
-	]
+			thirdParty: {
+				tcgplayer: 83444,
+				cardmarket: 275304
+			},
+		},
+	],
 }
 
 export default card

--- a/data/E-Card/Skyridge/47.ts
+++ b/data/E-Card/Skyridge/47.ts
@@ -7,7 +7,7 @@ const card: Card = {
 		de: "Vergrabenes Fossil"
 	},
 
-	illustrator: "Atsuko Nishida",
+	illustrator: "Atsuko Ujiie",
 	rarity: "Common",
 	category: "Pokemon",
 
@@ -16,7 +16,7 @@ const card: Card = {
 	hp: 30,
 
 	types: [
-		"Colorless",
+		"Colorless"
 	],
 
 	stage: "Basic",
@@ -37,19 +37,22 @@ const card: Card = {
 
 	retreat: 1,
 
-	thirdParty: {
-		cardmarket: 275305,
-		tcgplayer: 84048
-	},
-
 	variants: [
 		{
 			type: 'normal',
+			thirdParty: {
+				tcgplayer: 84048,
+				cardmarket: 275305
+			},
 		},
 		{
 			type: 'reverse',
-		}
-	]
+			thirdParty: {
+				tcgplayer: 84048,
+				cardmarket: 275305
+			},
+		},
+	],
 }
 
 export default card

--- a/data/E-Card/Skyridge/48.ts
+++ b/data/E-Card/Skyridge/48.ts
@@ -12,17 +12,15 @@ const card: Card = {
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		173,
-	],
+	dexId: [173],
 
 	hp: 30,
 
 	types: [
-		"Colorless",
+		"Colorless"
 	],
 
-	stage: "Basic",
+	stage: "Baby",
 
 	attacks: [
 		{
@@ -43,19 +41,22 @@ const card: Card = {
 
 	retreat: 1,
 
-	thirdParty: {
-		cardmarket: 275306,
-		tcgplayer: 84364
-	},
-
 	variants: [
 		{
 			type: 'normal',
+			thirdParty: {
+				tcgplayer: 84364,
+				cardmarket: 275306
+			},
 		},
 		{
 			type: 'reverse',
-		}
-	]
+			thirdParty: {
+				tcgplayer: 84364,
+				cardmarket: 275306
+			},
+		},
+	],
 }
 
 export default card

--- a/data/E-Card/Skyridge/49.ts
+++ b/data/E-Card/Skyridge/49.ts
@@ -12,14 +12,12 @@ const card: Card = {
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		225,
-	],
+	dexId: [225],
 
 	hp: 50,
 
 	types: [
-		"Water",
+		"Water"
 	],
 
 	stage: "Basic",
@@ -34,7 +32,7 @@ const card: Card = {
 				de: "Eingeschränkte Lieferung"
 			},
 			effect: {
-				en: "Search your deck for a Technical Machine or Pokémon Tool card show it to your opponent, and put it into your hand. Shuffle your deck afterward.",
+				en: "Search your deck for a Technical Machine or Pokémon Tool card, show it to your opponent, and put it into your hand. Shuffle your deck afterward.",
 				de: "Durchsuche dein Deck nach einer technischen Maschine- oder Pokémon-Ausrüstungskarte, zeige sie deinem Gegner und nimm sie auf deine Hand. Mische dein Deck danach."
 			},
 
@@ -49,7 +47,7 @@ const card: Card = {
 				de: "Wegkicken"
 			},
 			effect: {
-				en: "Your opponent switches the Defending Pokémon with 1 of his or her Benched Pokémon, if any. (Do the damage before switching Pokémon.)",
+				en: "Your opponent switches the Defending Pokémon with 1 of his or her Benched Pokémon, if any. (Do the damage before switching the Pokémon.)",
 				de: "Dein Gegner tauscht das verteidigende Pokémon mit einem der Pokémon auf seiner Bank aus, falls er dort mindestens eins hat. (Füge die Schadenspunkte vor dem Austauschen der Pokémon zu.)"
 			},
 			damage: 20,
@@ -60,25 +58,28 @@ const card: Card = {
 	weaknesses: [
 		{
 			type: "Metal",
-			value: "×2"
+			value: "x2"
 		},
 	],
 	retreat: 1,
 
 
-	thirdParty: {
-		cardmarket: 275307,
-		tcgplayer: 84746
-	},
-
 	variants: [
 		{
 			type: 'normal',
+			thirdParty: {
+				tcgplayer: 84746,
+				cardmarket: 275307
+			},
 		},
 		{
 			type: 'reverse',
-		}
-	]
+			thirdParty: {
+				tcgplayer: 84746,
+				cardmarket: 275307
+			},
+		},
+	],
 }
 
 export default card

--- a/data/E-Card/Skyridge/5.ts
+++ b/data/E-Card/Skyridge/5.ts
@@ -12,14 +12,12 @@ const card: Card = {
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		15,
-	],
+	dexId: [15],
 
 	hp: 80,
 
 	types: [
-		"Grass",
+		"Grass"
 	],
 
 	evolveFrom: {
@@ -64,23 +62,26 @@ const card: Card = {
 	weaknesses: [
 		{
 			type: "Fire",
-			value: "×2"
+			value: "x2"
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 275246,
-		tcgplayer: 83765
-	},
-
 	variants: [
 		{
 			type: 'normal',
+			thirdParty: {
+				tcgplayer: 83765,
+				cardmarket: 275246
+			},
 		},
 		{
 			type: 'reverse',
-		}
-	]
+			thirdParty: {
+				tcgplayer: 83765,
+				cardmarket: 275246
+			},
+		},
+	],
+	retreat: 0,
 }
 
 export default card

--- a/data/E-Card/Skyridge/50.ts
+++ b/data/E-Card/Skyridge/50.ts
@@ -12,14 +12,12 @@ const card: Card = {
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		50,
-	],
+	dexId: [50],
 
 	hp: 40,
 
 	types: [
-		"Fighting",
+		"Fighting"
 	],
 
 	stage: "Basic",
@@ -34,7 +32,7 @@ const card: Card = {
 				de: "Tunnelbau"
 			},
 			effect: {
-				en: "Flip a coin. If heads, prevent all damage done by attacks to Diglett during your opponent's next turn. (Any other effects of attack still happen.)",
+				en: "Flip a coin. If heads, prevent all damage done by attacks to Diglett during your opponent's next turn. (Any other effects of attacks still happen.)",
 				de: "Wirf eine Münze. Verhindere bei \"Kopf\" allen Schaden, der Digda während des nächsten Zugs deines Gegners durch Angriffe zugefügt wird. (Alle anderen Auswirkungen von Angriffen finden immer noch statt.)"
 			},
 			damage: 10,
@@ -45,10 +43,9 @@ const card: Card = {
 	weaknesses: [
 		{
 			type: "Grass",
-			value: "×2"
+			value: "x2"
 		},
 	],
-
 	resistances: [
 		{
 			type: "Lightning",
@@ -58,19 +55,22 @@ const card: Card = {
 	retreat: 1,
 
 
-	thirdParty: {
-		cardmarket: 275308,
-		tcgplayer: 84818
-	},
-
 	variants: [
 		{
 			type: 'normal',
+			thirdParty: {
+				tcgplayer: 84818,
+				cardmarket: 275308
+			},
 		},
 		{
 			type: 'reverse',
-		}
-	]
+			thirdParty: {
+				tcgplayer: 84818,
+				cardmarket: 275308
+			},
+		},
+	],
 }
 
 export default card

--- a/data/E-Card/Skyridge/51.ts
+++ b/data/E-Card/Skyridge/51.ts
@@ -12,14 +12,12 @@ const card: Card = {
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		132,
-	],
+	dexId: [132],
 
 	hp: 50,
 
 	types: [
-		"Colorless",
+		"Colorless"
 	],
 
 	stage: "Basic",
@@ -58,25 +56,28 @@ const card: Card = {
 	weaknesses: [
 		{
 			type: "Fighting",
-			value: "×2"
+			value: "x2"
 		},
 	],
 	retreat: 1,
 
 
-	thirdParty: {
-		cardmarket: 275309,
-		tcgplayer: 84830
-	},
-
 	variants: [
 		{
 			type: 'normal',
+			thirdParty: {
+				tcgplayer: 84830,
+				cardmarket: 275309
+			},
 		},
 		{
 			type: 'reverse',
-		}
-	]
+			thirdParty: {
+				tcgplayer: 84830,
+				cardmarket: 275309
+			},
+		},
+	],
 }
 
 export default card

--- a/data/E-Card/Skyridge/52.ts
+++ b/data/E-Card/Skyridge/52.ts
@@ -12,14 +12,12 @@ const card: Card = {
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		51,
-	],
+	dexId: [51],
 
 	hp: 70,
 
 	types: [
-		"Fighting",
+		"Fighting"
 	],
 
 	evolveFrom: {
@@ -39,7 +37,7 @@ const card: Card = {
 				de: "Tunnelbau"
 			},
 			effect: {
-				en: "Flip a coin. If heads, prevent all damage done by attacks to Dugtrio during your opponent's next turn. (any other effects of attacks still happen.)",
+				en: "Flip a coin. If heads, prevent all damage done by attacks to Dugtrio during your opponent's next turn. (Any other effects of attacks still happen.)",
 				de: "Wirf eine Münze. Verhindere bei \"Kopf\" allen Schaden, der Digdri während des nächsten Zuges deines Gegners durch Angriffe zugefügt wird. (Alle anderen Auswirkungen von Angriffen finden immer noch statt.)"
 			},
 			damage: 20,
@@ -56,7 +54,7 @@ const card: Card = {
 				de: "Vergraben"
 			},
 			effect: {
-				en: "Choose 1 of your opponent's Pokémon. This attack does 30 damage to that Pokémon. Don't apply Weakness or Resistance. (any other effects that would happen after applying Weakness and Resistance still happen.)",
+				en: "Choose 1 of your opponent's Pokémon. This attack does 30 damage to that Pokémon. Don't apply Weakness or Resistance. (Any other effects that would happen after applying Weakness and Resistance still happen.)",
 				de: "Wähle 1 der Pokémon deines Gegners. Dieser Angriff fügt diesem Pokémon 30 Schadenspunkte zu. Wende keine Schwäche oder Resistenz an. (Alle anderen Auswirkungen von Angriffen, die nach der Anwendung von Schwäche und Resistenz stattfinden, finden immer noch statt.)"
 			}
 		},
@@ -65,10 +63,9 @@ const card: Card = {
 	weaknesses: [
 		{
 			type: "Grass",
-			value: "×2"
+			value: "x2"
 		},
 	],
-
 	resistances: [
 		{
 			type: "Lightning",
@@ -78,19 +75,22 @@ const card: Card = {
 	retreat: 1,
 
 
-	thirdParty: {
-		cardmarket: 275310,
-		tcgplayer: 84999
-	},
-
 	variants: [
 		{
 			type: 'normal',
+			thirdParty: {
+				tcgplayer: 84999,
+				cardmarket: 275310
+			},
 		},
 		{
 			type: 'reverse',
-		}
-	]
+			thirdParty: {
+				tcgplayer: 84999,
+				cardmarket: 275310
+			},
+		},
+	],
 }
 
 export default card

--- a/data/E-Card/Skyridge/53.ts
+++ b/data/E-Card/Skyridge/53.ts
@@ -12,14 +12,12 @@ const card: Card = {
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		206,
-	],
+	dexId: [206],
 
 	hp: 40,
 
 	types: [
-		"Colorless",
+		"Colorless"
 	],
 
 	stage: "Basic",
@@ -59,25 +57,28 @@ const card: Card = {
 	weaknesses: [
 		{
 			type: "Fighting",
-			value: "×2"
+			value: "x2"
 		},
 	],
 	retreat: 1,
 
 
-	thirdParty: {
-		cardmarket: 275311,
-		tcgplayer: 85006
-	},
-
 	variants: [
 		{
 			type: 'normal',
+			thirdParty: {
+				tcgplayer: 85006,
+				cardmarket: 275311
+			},
 		},
 		{
 			type: 'reverse',
-		}
-	]
+			thirdParty: {
+				tcgplayer: 85006,
+				cardmarket: 275311
+			},
+		},
+	],
 }
 
 export default card

--- a/data/E-Card/Skyridge/54.ts
+++ b/data/E-Card/Skyridge/54.ts
@@ -12,14 +12,12 @@ const card: Card = {
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		133,
-	],
+	dexId: [133],
 
 	hp: 50,
 
 	types: [
-		"Colorless",
+		"Colorless"
 	],
 
 	stage: "Basic",
@@ -47,7 +45,7 @@ const card: Card = {
 				de: "Bodycheck"
 			},
 			effect: {
-				en: "Eevee does 10 damage to itself",
+				en: "Eevee does 10 damage to itself.",
 				de: "Evoli fügt sich selber 10 Schadenspunkte zu."
 			},
 			damage: 30,
@@ -58,25 +56,28 @@ const card: Card = {
 	weaknesses: [
 		{
 			type: "Fighting",
-			value: "×2"
+			value: "x2"
 		},
 	],
 	retreat: 1,
 
 
-	thirdParty: {
-		cardmarket: 275312,
-		tcgplayer: 85077
-	},
-
 	variants: [
 		{
 			type: 'normal',
+			thirdParty: {
+				tcgplayer: 85077,
+				cardmarket: 275312
+			},
 		},
 		{
 			type: 'reverse',
-		}
-	]
+			thirdParty: {
+				tcgplayer: 85077,
+				cardmarket: 275312
+			},
+		},
+	],
 }
 
 export default card

--- a/data/E-Card/Skyridge/55.ts
+++ b/data/E-Card/Skyridge/55.ts
@@ -12,14 +12,12 @@ const card: Card = {
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		83,
-	],
+	dexId: [83],
 
 	hp: 50,
 
 	types: [
-		"Colorless",
+		"Colorless"
 	],
 
 	stage: "Basic",
@@ -51,7 +49,7 @@ const card: Card = {
 				en: "Flip a coin until you get tails. This attack does 10 damage times the number of heads.",
 				de: "Wirf eine Münze, bis du \"Zahl\" wirfst. Dieser Angriff fügt 10 Schadenspunkte mal der Anzahl \"Kopf\" zu."
 			},
-			damage: "10x",
+			damage: "10×",
 
 		},
 	],
@@ -59,10 +57,9 @@ const card: Card = {
 	weaknesses: [
 		{
 			type: "Lightning",
-			value: "×2"
+			value: "x2"
 		},
 	],
-
 	resistances: [
 		{
 			type: "Fighting",
@@ -72,19 +69,22 @@ const card: Card = {
 	retreat: 1,
 
 
-	thirdParty: {
-		cardmarket: 275313,
-		tcgplayer: 85383
-	},
-
 	variants: [
 		{
 			type: 'normal',
+			thirdParty: {
+				tcgplayer: 85383,
+				cardmarket: 275313
+			},
 		},
 		{
 			type: 'reverse',
-		}
-	]
+			thirdParty: {
+				tcgplayer: 85383,
+				cardmarket: 275313
+			},
+		},
+	],
 }
 
 export default card

--- a/data/E-Card/Skyridge/56.ts
+++ b/data/E-Card/Skyridge/56.ts
@@ -12,14 +12,12 @@ const card: Card = {
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		205,
-	],
+	dexId: [205],
 
 	hp: 70,
 
 	types: [
-		"Grass",
+		"Grass"
 	],
 
 	evolveFrom: {
@@ -72,7 +70,7 @@ const card: Card = {
 				en: "Flip 2 coins. This attack does 40 damage times the number of heads.",
 				de: "Wirf 2 Münzen. Dieser Angriff fügt 40 Schadenspunkte mal der Anzahl \"Kopf\" zu."
 			},
-			damage: "40x",
+			damage: "40×",
 
 		},
 	],
@@ -80,25 +78,28 @@ const card: Card = {
 	weaknesses: [
 		{
 			type: "Fire",
-			value: "×2"
+			value: "x2"
 		},
 	],
 	retreat: 2,
 
 
-	thirdParty: {
-		cardmarket: 275267,
-		tcgplayer: 85546
-	},
-
 	variants: [
 		{
 			type: 'normal',
+			thirdParty: {
+				tcgplayer: 85546,
+				cardmarket: 275267
+			},
 		},
 		{
 			type: 'reverse',
-		}
-	]
+			thirdParty: {
+				tcgplayer: 85546,
+				cardmarket: 275267
+			},
+		},
+	],
 }
 
 export default card

--- a/data/E-Card/Skyridge/57.ts
+++ b/data/E-Card/Skyridge/57.ts
@@ -12,14 +12,12 @@ const card: Card = {
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		92,
-	],
+	dexId: [92],
 
 	hp: 50,
 
 	types: [
-		"Psychic",
+		"Psychic"
 	],
 
 	stage: "Basic",
@@ -44,10 +42,9 @@ const card: Card = {
 	weaknesses: [
 		{
 			type: "Darkness",
-			value: "×2"
+			value: "x2"
 		},
 	],
-
 	resistances: [
 		{
 			type: "Fighting",
@@ -57,19 +54,22 @@ const card: Card = {
 	retreat: 1,
 
 
-	thirdParty: {
-		cardmarket: 275315,
-		tcgplayer: 85646
-	},
-
 	variants: [
 		{
 			type: 'normal',
+			thirdParty: {
+				tcgplayer: 85646,
+				cardmarket: 275315
+			},
 		},
 		{
 			type: 'reverse',
-		}
-	]
+			thirdParty: {
+				tcgplayer: 85646,
+				cardmarket: 275315
+			},
+		},
+	],
 }
 
 export default card

--- a/data/E-Card/Skyridge/58.ts
+++ b/data/E-Card/Skyridge/58.ts
@@ -12,14 +12,12 @@ const card: Card = {
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		203,
-	],
+	dexId: [203],
 
 	hp: 60,
 
 	types: [
-		"Psychic",
+		"Psychic"
 	],
 
 	stage: "Basic",
@@ -55,32 +53,35 @@ const card: Card = {
 				de: "Liegen an Girafarig und am verteidigenden Pokémon nicht die gleiche Anzahl an Energiekarten an, beträgt der Basis-Schaden dieses Angriffs 10 anstatt 40."
 			},
 
-			damage: 40
+			damage: 40,
 		},
 	],
 
 	weaknesses: [
 		{
 			type: "Psychic",
-			value: "×2"
+			value: "x2"
 		},
 	],
 	retreat: 1,
 
 
-	thirdParty: {
-		cardmarket: 275316,
-		tcgplayer: 85727
-	},
-
 	variants: [
 		{
 			type: 'normal',
+			thirdParty: {
+				tcgplayer: 85727,
+				cardmarket: 275316
+			},
 		},
 		{
 			type: 'reverse',
-		}
-	]
+			thirdParty: {
+				tcgplayer: 85727,
+				cardmarket: 275316
+			},
+		},
+	],
 }
 
 export default card

--- a/data/E-Card/Skyridge/59.ts
+++ b/data/E-Card/Skyridge/59.ts
@@ -12,14 +12,12 @@ const card: Card = {
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		207,
-	],
+	dexId: [207],
 
 	hp: 60,
 
 	types: [
-		"Fighting",
+		"Fighting"
 	],
 
 	stage: "Basic",
@@ -53,32 +51,35 @@ const card: Card = {
 				de: "Wirf eine Münze. Bei 'Kopf' ist das verteidigende Pokémon jetzt vergiftet. Bei 'Zahl' ist das verteidigende Pokémon jetzt gelähmt."
 			},
 
-			damage: 10
+			damage: 10,
 		},
 	],
 
 	weaknesses: [
 		{
 			type: "Grass",
-			value: "×2"
+			value: "x2"
 		},
 	],
 	retreat: 1,
 
 
-	thirdParty: {
-		cardmarket: 275317,
-		tcgplayer: 85763
-	},
-
 	variants: [
 		{
 			type: 'normal',
+			thirdParty: {
+				tcgplayer: 85763,
+				cardmarket: 275317
+			},
 		},
 		{
 			type: 'reverse',
-		}
-	]
+			thirdParty: {
+				tcgplayer: 85763,
+				cardmarket: 275317
+			},
+		},
+	],
 }
 
 export default card

--- a/data/E-Card/Skyridge/6.ts
+++ b/data/E-Card/Skyridge/6.ts
@@ -12,14 +12,12 @@ const card: Card = {
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		169,
-	],
+	dexId: [169],
 
 	hp: 90,
 
 	types: [
-		"Grass",
+		"Grass"
 	],
 
 	evolveFrom: {
@@ -36,7 +34,7 @@ const card: Card = {
 				de: "Wegtragen"
 			},
 			effect: {
-				en: "Once during your turn (before you attack) you may flip a coin. If heads, look at your opponent's hand. If your opponent has and Baby Pokémon, Basic Pokémon, of Evolution cards there, choose 1 of them. Your opponent shuffles that card into his or her deck. This power can't be used if Crobat is affected by a Special Condition.",
+				en: "Once during your turn (before your attack), you may flip a coin. If heads, look at your opponent's hand. If your opponent has any Baby Pokémon, Basic Pokémon, or Evolution cards there, choose 1 of them. Your opponent shuffles that card into his or her deck. This power can't be used if Crobat is affected by a Special Condition.",
 				de: "Einmal während deines Zuges (vor deinem Angriff) kannst du eine Münze werfen. Schau dir bei 'Kopf' die Karten auf der Hand deines Gegners an. Falls dein Gegner ein Baby-Pokémon, ein Basis-Pokémon oder eine Entwicklungskarte auf der Hand hat, wähle eine davon. Dein Gegner mischt die Karte in sein Deck. Diese Fähigkeit kann nicht verwendet werden, falls Iksbat von einem speziellen Zustand betroffen ist."
 			},
 		},
@@ -54,10 +52,10 @@ const card: Card = {
 				de: "Doppelspiel"
 			},
 			effect: {
-				en: "Flip 2 coins. This attack does 40 damage times the number of heads. If both of them are tails, the defending Pokémon is now Confused and Poisoned.",
+				en: "Flip 2 coins. This attack does 40 damage times the number of heads. If both of them are tails, the Defending Pokémon is now Confused and Poisoned.",
 				de: "Wirf 2 Münzen. Dieser Angriff fügt 40 Schadenspunkte mal der Anzahl 'Kopf' zu. Wenn beide 'Zahl' zeigen, ist das verteidigende Pokémon jetzt verwirrt und vergiftet."
 			},
-			damage: "40x",
+			damage: "40×",
 
 		},
 	],
@@ -65,23 +63,26 @@ const card: Card = {
 	weaknesses: [
 		{
 			type: "Psychic",
-			value: "×2"
+			value: "x2"
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 275245,
-		tcgplayer: 84484
-	},
-
 	variants: [
 		{
 			type: 'normal',
+			thirdParty: {
+				tcgplayer: 84484,
+				cardmarket: 275245
+			},
 		},
 		{
 			type: 'reverse',
-		}
-	]
+			thirdParty: {
+				tcgplayer: 84484,
+				cardmarket: 275245
+			},
+		},
+	],
+	retreat: 0,
 }
 
 export default card

--- a/data/E-Card/Skyridge/60.ts
+++ b/data/E-Card/Skyridge/60.ts
@@ -12,14 +12,12 @@ const card: Card = {
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		42,
-	],
+	dexId: [42],
 
 	hp: 70,
 
 	types: [
-		"Grass",
+		"Grass"
 	],
 
 	evolveFrom: {
@@ -55,7 +53,7 @@ const card: Card = {
 				de: "Stärke durch Überzahl"
 			},
 			effect: {
-				en: "This attack does 30 damage plus 10 more damage for each Zubat, Golbat, and Crobat on your bench.",
+				en: "This attack does 30 damage plus 10 more damage for each Zubat, Golbat, and Crobat on your Bench.",
 				de: "Dieser Angriff fügt 30 Schadenspunkte plus 10 weitere Schadenspunkte für jedes Zubat, Golbat bzw. Iksbat, das auf deiner Bank ist, zu."
 			},
 			damage: "30+",
@@ -66,25 +64,28 @@ const card: Card = {
 	weaknesses: [
 		{
 			type: "Psychic",
-			value: "×2"
+			value: "x2"
 		},
 	],
 	retreat: 1,
 
 
-	thirdParty: {
-		cardmarket: 275318,
-		tcgplayer: 85792
-	},
-
 	variants: [
 		{
 			type: 'normal',
+			thirdParty: {
+				tcgplayer: 85792,
+				cardmarket: 275318
+			},
 		},
 		{
 			type: 'reverse',
-		}
-	]
+			thirdParty: {
+				tcgplayer: 85792,
+				cardmarket: 275318
+			},
+		},
+	],
 }
 
 export default card

--- a/data/E-Card/Skyridge/61.ts
+++ b/data/E-Card/Skyridge/61.ts
@@ -12,14 +12,12 @@ const card: Card = {
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		210,
-	],
+	dexId: [210],
 
 	hp: 80,
 
 	types: [
-		"Colorless",
+		"Colorless"
 	],
 
 	evolveFrom: {
@@ -39,7 +37,7 @@ const card: Card = {
 				de: "Austoben"
 			},
 			effect: {
-				en: "Your opponent switches the Defending Pokémon with 1 of his or her Benched Pokémon. (Do the damage before switching the Pokémon.)",
+				en: "Your opponent switches the Defending Pokémon with 1 of his or her Benched Pokémon, if any. (Do the damage before switching the Pokémon.)",
 				de: "Dein Gegner tauscht das verteidigende Pokémon mit 1 der Pokémon auf seiner Bank aus. (Fügt die Schadenspunkte vor dem Asutausch der Pokémon zu)"
 			},
 			damage: 20,
@@ -65,25 +63,28 @@ const card: Card = {
 	weaknesses: [
 		{
 			type: "Fighting",
-			value: "×2"
+			value: "x2"
 		},
 	],
 	retreat: 1,
 
 
-	thirdParty: {
-		cardmarket: 275319,
-		tcgplayer: 85862
-	},
-
 	variants: [
 		{
 			type: 'normal',
+			thirdParty: {
+				tcgplayer: 85862,
+				cardmarket: 275319
+			},
 		},
 		{
 			type: 'reverse',
-		}
-	]
+			thirdParty: {
+				tcgplayer: 85862,
+				cardmarket: 275319
+			},
+		},
+	],
 }
 
 export default card

--- a/data/E-Card/Skyridge/62.ts
+++ b/data/E-Card/Skyridge/62.ts
@@ -12,14 +12,12 @@ const card: Card = {
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		58,
-	],
+	dexId: [58],
 
 	hp: 50,
 
 	types: [
-		"Fire",
+		"Fire"
 	],
 
 	stage: "Basic",
@@ -50,7 +48,7 @@ const card: Card = {
 				en: "Flip 2 coins. This attack does 20 damage times the number of heads.",
 				de: "Wirf 2 Münzen. Dieser Angriff fügt 20 Schadenspunkte mal der Anzahl \"Kopf\" zu."
 			},
-			damage: "20x",
+			damage: "20×",
 
 		},
 	],
@@ -58,25 +56,28 @@ const card: Card = {
 	weaknesses: [
 		{
 			type: "Water",
-			value: "×2"
+			value: "x2"
 		},
 	],
 	retreat: 1,
 
 
-	thirdParty: {
-		cardmarket: 275320,
-		tcgplayer: 85950
-	},
-
 	variants: [
 		{
 			type: 'normal',
+			thirdParty: {
+				tcgplayer: 85950,
+				cardmarket: 275320
+			},
 		},
 		{
 			type: 'reverse',
-		}
-	]
+			thirdParty: {
+				tcgplayer: 85950,
+				cardmarket: 275320
+			},
+		},
+	],
 }
 
 export default card

--- a/data/E-Card/Skyridge/63.ts
+++ b/data/E-Card/Skyridge/63.ts
@@ -12,14 +12,12 @@ const card: Card = {
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		93,
-	],
+	dexId: [93],
 
 	hp: 70,
 
 	types: [
-		"Psychic",
+		"Psychic"
 	],
 
 	evolveFrom: {
@@ -67,10 +65,9 @@ const card: Card = {
 	weaknesses: [
 		{
 			type: "Darkness",
-			value: "×2"
+			value: "x2"
 		},
 	],
-
 	resistances: [
 		{
 			type: "Fighting",
@@ -80,19 +77,22 @@ const card: Card = {
 	retreat: 1,
 
 
-	thirdParty: {
-		cardmarket: 275321,
-		tcgplayer: 86023
-	},
-
 	variants: [
 		{
 			type: 'normal',
+			thirdParty: {
+				tcgplayer: 86023,
+				cardmarket: 275321
+			},
 		},
 		{
 			type: 'reverse',
-		}
-	]
+			thirdParty: {
+				tcgplayer: 86023,
+				cardmarket: 275321
+			},
+		},
+	],
 }
 
 export default card

--- a/data/E-Card/Skyridge/64.ts
+++ b/data/E-Card/Skyridge/64.ts
@@ -12,14 +12,12 @@ const card: Card = {
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		214,
-	],
+	dexId: [214],
 
 	hp: 60,
 
 	types: [
-		"Grass",
+		"Grass"
 	],
 
 	stage: "Basic",
@@ -55,32 +53,35 @@ const card: Card = {
 				de: "Liegen auf Skaraborn 4 oder mehr Schadensmarken, beträgt der Basisschaden dieses Angriffs 50 anstatt 30."
 			},
 
-			damage: 30
+			damage: 30,
 		},
 	],
 
 	weaknesses: [
 		{
 			type: "Fire",
-			value: "×2"
+			value: "x2"
 		},
 	],
 	retreat: 1,
 
 
-	thirdParty: {
-		cardmarket: 275322,
-		tcgplayer: 86061
-	},
-
 	variants: [
 		{
 			type: 'normal',
+			thirdParty: {
+				tcgplayer: 86061,
+				cardmarket: 275322
+			},
 		},
 		{
 			type: 'reverse',
-		}
-	]
+			thirdParty: {
+				tcgplayer: 86061,
+				cardmarket: 275322
+			},
+		},
+	],
 }
 
 export default card

--- a/data/E-Card/Skyridge/65.ts
+++ b/data/E-Card/Skyridge/65.ts
@@ -12,14 +12,12 @@ const card: Card = {
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		163,
-	],
+	dexId: [163],
 
 	hp: 40,
 
 	types: [
-		"Colorless",
+		"Colorless"
 	],
 
 	stage: "Basic",
@@ -58,10 +56,9 @@ const card: Card = {
 	weaknesses: [
 		{
 			type: "Lightning",
-			value: "×2"
+			value: "x2"
 		},
 	],
-
 	resistances: [
 		{
 			type: "Fighting",
@@ -71,19 +68,22 @@ const card: Card = {
 	retreat: 1,
 
 
-	thirdParty: {
-		cardmarket: 275323,
-		tcgplayer: 86170
-	},
-
 	variants: [
 		{
 			type: 'normal',
+			thirdParty: {
+				tcgplayer: 86170,
+				cardmarket: 275323
+			},
 		},
 		{
 			type: 'reverse',
-		}
-	]
+			thirdParty: {
+				tcgplayer: 86170,
+				cardmarket: 275323
+			},
+		},
+	],
 }
 
 export default card

--- a/data/E-Card/Skyridge/66.ts
+++ b/data/E-Card/Skyridge/66.ts
@@ -12,14 +12,12 @@ const card: Card = {
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		228,
-	],
+	dexId: [228],
 
 	hp: 50,
 
 	types: [
-		"Fire",
+		"Fire"
 	],
 
 	stage: "Basic",
@@ -37,7 +35,7 @@ const card: Card = {
 				en: "This attack does 10 damage times the number of damage counters on Houndour.",
 				de: "Dieser Angriff fügt 10 Schadenspunkte mal der Anzahl an Schadensmarken auf Hunduster zu."
 			},
-			damage: "10x",
+			damage: "10×",
 
 		},
 		{
@@ -49,7 +47,7 @@ const card: Card = {
 				de: "Feuerwerk"
 			},
 			effect: {
-				en: "Flip a coin. If tails, discard a Energy card attached to Houndour.",
+				en: "Flip a coin. If tails, discard a Fire Energy card attached to Houndour.",
 				de: "Wirf eine Münze. Lege bei \"Zahl\" eine an Hunduster angelegte -Energiekarte auf deinen Ablagestapel."
 			},
 			damage: 20,
@@ -60,25 +58,28 @@ const card: Card = {
 	weaknesses: [
 		{
 			type: "Water",
-			value: "×2"
+			value: "x2"
 		},
 	],
 	retreat: 1,
 
 
-	thirdParty: {
-		cardmarket: 275324,
-		tcgplayer: 86220
-	},
-
 	variants: [
 		{
 			type: 'normal',
+			thirdParty: {
+				tcgplayer: 86220,
+				cardmarket: 275324
+			},
 		},
 		{
 			type: 'reverse',
-		}
-	]
+			thirdParty: {
+				tcgplayer: 86220,
+				cardmarket: 275324
+			},
+		},
+	],
 }
 
 export default card

--- a/data/E-Card/Skyridge/67.ts
+++ b/data/E-Card/Skyridge/67.ts
@@ -12,17 +12,15 @@ const card: Card = {
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		174,
-	],
+	dexId: [174],
 
 	hp: 30,
 
 	types: [
-		"Colorless",
+		"Colorless"
 	],
 
-	stage: "Basic",
+	stage: "Baby",
 
 	attacks: [
 		{
@@ -43,19 +41,22 @@ const card: Card = {
 
 	retreat: 1,
 
-	thirdParty: {
-		cardmarket: 275325,
-		tcgplayer: 86258
-	},
-
 	variants: [
 		{
 			type: 'normal',
+			thirdParty: {
+				tcgplayer: 86258,
+				cardmarket: 275325
+			},
 		},
 		{
 			type: 'reverse',
-		}
-	]
+			thirdParty: {
+				tcgplayer: 86258,
+				cardmarket: 275325
+			},
+		},
+	],
 }
 
 export default card

--- a/data/E-Card/Skyridge/68.ts
+++ b/data/E-Card/Skyridge/68.ts
@@ -12,14 +12,12 @@ const card: Card = {
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		39,
-	],
+	dexId: [39],
 
 	hp: 50,
 
 	types: [
-		"Colorless",
+		"Colorless"
 	],
 
 	stage: "Basic",
@@ -34,7 +32,7 @@ const card: Card = {
 				de: "Nickerchen"
 			},
 			effect: {
-				en: "Remove 1 damage counter from Jigglypuff",
+				en: "Remove 1 damage counter from Jigglypuff.",
 				de: "Entferne eine Schadensmarke von Pummeluff."
 			},
 
@@ -60,25 +58,28 @@ const card: Card = {
 	weaknesses: [
 		{
 			type: "Fighting",
-			value: "×2"
+			value: "x2"
 		},
 	],
 	retreat: 1,
 
 
-	thirdParty: {
-		cardmarket: 275326,
-		tcgplayer: 86313
-	},
-
 	variants: [
 		{
 			type: 'normal',
+			thirdParty: {
+				tcgplayer: 86313,
+				cardmarket: 275326
+			},
 		},
 		{
 			type: 'reverse',
-		}
-	]
+			thirdParty: {
+				tcgplayer: 86313,
+				cardmarket: 275326
+			},
+		},
+	],
 }
 
 export default card

--- a/data/E-Card/Skyridge/69.ts
+++ b/data/E-Card/Skyridge/69.ts
@@ -12,14 +12,12 @@ const card: Card = {
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		64,
-	],
+	dexId: [64],
 
 	hp: 70,
 
 	types: [
-		"Psychic",
+		"Psychic"
 	],
 
 	evolveFrom: {
@@ -66,25 +64,28 @@ const card: Card = {
 	weaknesses: [
 		{
 			type: "Psychic",
-			value: "×2"
+			value: "x2"
 		},
 	],
 	retreat: 1,
 
 
-	thirdParty: {
-		cardmarket: 275327,
-		tcgplayer: 86405
-	},
-
 	variants: [
 		{
 			type: 'normal',
+			thirdParty: {
+				tcgplayer: 86405,
+				cardmarket: 275327
+			},
 		},
 		{
 			type: 'reverse',
-		}
-	]
+			thirdParty: {
+				tcgplayer: 86405,
+				cardmarket: 275327
+			},
+		},
+	],
 }
 
 export default card

--- a/data/E-Card/Skyridge/7.ts
+++ b/data/E-Card/Skyridge/7.ts
@@ -12,14 +12,12 @@ const card: Card = {
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		87,
-	],
+	dexId: [87],
 
 	hp: 80,
 
 	types: [
-		"Water",
+		"Water"
 	],
 
 	evolveFrom: {
@@ -57,7 +55,7 @@ const card: Card = {
 				de: "Erdrückendes Eis"
 			},
 			effect: {
-				en: "This attack does 40 damage plus 10 more damage for each Energy in the Defending Pokémon's Retreat Cost. Damage is calculated using the Defending Pokémon's Retreat Cost after applying effects to the Retreat Cost.",
+				en: "This attack does 40 damage plus 10 more damage for each Colorless Energy in the Defending Pokémon's Retreat Cost. Damage is calculated using the Defending Pokémon's Retreat Cost after applying effects to the Retreat Cost.",
 				de: "Dieser Angriff fügt 40 Schadenspunkte plus 10 weitere Schadenspunkte für jede -Energie in den Rückzugskosten des verteidigenden Pokémon zu. Beim Ermitteln des Schadens werden erst etwaige Effekte auf die Rückzugskosten angewandt und dann die Rückzugskosten des verteidigenden Pokémon verwendet."
 			},
 			damage: "40+",
@@ -68,25 +66,28 @@ const card: Card = {
 	weaknesses: [
 		{
 			type: "Metal",
-			value: "×2"
+			value: "x2"
 		},
 	],
 	retreat: 2,
 
 
-	thirdParty: {
-		cardmarket: 275248,
-		tcgplayer: 84786
-	},
-
 	variants: [
 		{
 			type: 'normal',
+			thirdParty: {
+				tcgplayer: 84786,
+				cardmarket: 275248
+			},
 		},
 		{
 			type: 'reverse',
-		}
-	]
+			thirdParty: {
+				tcgplayer: 84786,
+				cardmarket: 275248
+			},
+		},
+	],
 }
 
 export default card

--- a/data/E-Card/Skyridge/70.ts
+++ b/data/E-Card/Skyridge/70.ts
@@ -12,14 +12,12 @@ const card: Card = {
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		14,
-	],
+	dexId: [14],
 
 	hp: 70,
 
 	types: [
-		"Grass",
+		"Grass"
 	],
 
 	evolveFrom: {
@@ -36,7 +34,7 @@ const card: Card = {
 				de: "Exoskelett"
 			},
 			effect: {
-				en: "All damage done to Kakuna is reduced by 10 (after applying Weakness and Resistance).",
+				en: "All damage by attacks to Kakuna is reduced by 10 (after applying Weakness and Resistance).",
 				de: "Jeder Schaden, der Kokuna durch Angriffe zugefügt wird, wird um 10 reduziert (nachdem Schwäche und Resistenz verrechnet wurden)."
 			},
 		},
@@ -63,25 +61,28 @@ const card: Card = {
 	weaknesses: [
 		{
 			type: "Fire",
-			value: "×2"
+			value: "x2"
 		},
 	],
 	retreat: 2,
 
 
-	thirdParty: {
-		cardmarket: 275328,
-		tcgplayer: 86410
-	},
-
 	variants: [
 		{
 			type: 'normal',
+			thirdParty: {
+				tcgplayer: 86410,
+				cardmarket: 275328
+			},
 		},
 		{
 			type: 'reverse',
-		}
-	]
+			thirdParty: {
+				tcgplayer: 86410,
+				cardmarket: 275328
+			},
+		},
+	],
 }
 
 export default card

--- a/data/E-Card/Skyridge/71.ts
+++ b/data/E-Card/Skyridge/71.ts
@@ -12,14 +12,12 @@ const card: Card = {
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		131,
-	],
+	dexId: [131],
 
 	hp: 60,
 
 	types: [
-		"Water",
+		"Water"
 	],
 
 	stage: "Basic",
@@ -35,7 +33,7 @@ const card: Card = {
 				de: "Assistent"
 			},
 			effect: {
-				en: "Search your deck for a Supporter card, show it to your opponent and put it into your hand. Shuffle your deck afterward.",
+				en: "Search your deck for a Supporter card, show it to your opponent, and put it into your hand. Shuffle your deck afterward.",
 				de: "Durchsuche dein Deck nach einer Unterstützerkarte, zeige sie deinem Gegner und nimm sie auf deine Hand. Mische dein Deck danach."
 			},
 
@@ -62,25 +60,28 @@ const card: Card = {
 	weaknesses: [
 		{
 			type: "Metal",
-			value: "×2"
+			value: "x2"
 		},
 	],
 	retreat: 2,
 
 
-	thirdParty: {
-		cardmarket: 275329,
-		tcgplayer: 86616
-	},
-
 	variants: [
 		{
 			type: 'normal',
+			thirdParty: {
+				tcgplayer: 86616,
+				cardmarket: 275329
+			},
 		},
 		{
 			type: 'reverse',
-		}
-	]
+			thirdParty: {
+				tcgplayer: 86616,
+				cardmarket: 275329
+			},
+		},
+	],
 }
 
 export default card

--- a/data/E-Card/Skyridge/72.ts
+++ b/data/E-Card/Skyridge/72.ts
@@ -12,14 +12,12 @@ const card: Card = {
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		165,
-	],
+	dexId: [165],
 
 	hp: 40,
 
 	types: [
-		"Grass",
+		"Grass"
 	],
 
 	stage: "Basic",
@@ -34,7 +32,7 @@ const card: Card = {
 				de: "Tränende Augen"
 			},
 			effect: {
-				en: "During your opponent's next turn, any damage done to Ledyba is reduced by 20.",
+				en: "During your opponent's next turn, any damage done to Ledyba by attacks is reduced by 20.",
 				de: "Jeder Schaden, der Ledyba im nächsten Zug deines Gegners durch Angriffe zugefügt wird, wird um 20 reduziert."
 			},
 
@@ -51,7 +49,7 @@ const card: Card = {
 				en: "Flip 2 coins. This attack does 10 damage times the number of heads.",
 				de: "Wirf 2 Münzen. Dieser Angriff fügt 10 Schadenspunkte mal der Anzahl \"Kopf\" zu."
 			},
-			damage: "10x",
+			damage: "10×",
 
 		},
 	],
@@ -59,10 +57,9 @@ const card: Card = {
 	weaknesses: [
 		{
 			type: "Lightning",
-			value: "×2"
+			value: "x2"
 		},
 	],
-
 	resistances: [
 		{
 			type: "Fighting",
@@ -72,19 +69,22 @@ const card: Card = {
 	retreat: 1,
 
 
-	thirdParty: {
-		cardmarket: 275330,
-		tcgplayer: 86701
-	},
-
 	variants: [
 		{
 			type: 'normal',
+			thirdParty: {
+				tcgplayer: 86701,
+				cardmarket: 275330
+			},
 		},
 		{
 			type: 'reverse',
-		}
-	]
+			thirdParty: {
+				tcgplayer: 86701,
+				cardmarket: 275330
+			},
+		},
+	],
 }
 
 export default card

--- a/data/E-Card/Skyridge/73.ts
+++ b/data/E-Card/Skyridge/73.ts
@@ -12,14 +12,12 @@ const card: Card = {
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		165,
-	],
+	dexId: [165],
 
 	hp: 50,
 
 	types: [
-		"Grass",
+		"Grass"
 	],
 
 	stage: "Basic",
@@ -50,7 +48,7 @@ const card: Card = {
 				en: "Flip 2 coins. This attack does 20 damage times the number of heads.",
 				de: "Wirf 2 Münzen. Dieser Angriff fügt 20 Schadenspunkte mal der Anzahl \"Kopf\" zu."
 			},
-			damage: "20x",
+			damage: "20×",
 
 		},
 	],
@@ -58,25 +56,28 @@ const card: Card = {
 	weaknesses: [
 		{
 			type: "Fire",
-			value: "×2"
+			value: "x2"
 		},
 	],
 	retreat: 1,
 
 
-	thirdParty: {
-		cardmarket: 275331,
-		tcgplayer: 86702
-	},
-
 	variants: [
 		{
 			type: 'normal',
+			thirdParty: {
+				tcgplayer: 86702,
+				cardmarket: 275331
+			},
 		},
 		{
 			type: 'reverse',
-		}
-	]
+			thirdParty: {
+				tcgplayer: 86702,
+				cardmarket: 275331
+			},
+		},
+	],
 }
 
 export default card

--- a/data/E-Card/Skyridge/74.ts
+++ b/data/E-Card/Skyridge/74.ts
@@ -12,14 +12,12 @@ const card: Card = {
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		66,
-	],
+	dexId: [66],
 
 	hp: 50,
 
 	types: [
-		"Fighting",
+		"Fighting"
 	],
 
 	stage: "Basic",
@@ -40,7 +38,7 @@ const card: Card = {
 				de: "Wirf eine Münze. Bei \"Zahl\" hat dieser Angriff keine Auswirkung."
 			},
 
-			damage: 20
+			damage: 20,
 		},
 		{
 			cost: [
@@ -63,25 +61,28 @@ const card: Card = {
 	weaknesses: [
 		{
 			type: "Psychic",
-			value: "×2"
+			value: "x2"
 		},
 	],
 	retreat: 1,
 
 
-	thirdParty: {
-		cardmarket: 275332,
-		tcgplayer: 86989
-	},
-
 	variants: [
 		{
 			type: 'normal',
+			thirdParty: {
+				tcgplayer: 86989,
+				cardmarket: 275332
+			},
 		},
 		{
 			type: 'reverse',
-		}
-	]
+			thirdParty: {
+				tcgplayer: 86989,
+				cardmarket: 275332
+			},
+		},
+	],
 }
 
 export default card

--- a/data/E-Card/Skyridge/75.ts
+++ b/data/E-Card/Skyridge/75.ts
@@ -12,14 +12,12 @@ const card: Card = {
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		129,
-	],
+	dexId: [129],
 
 	hp: 30,
 
 	types: [
-		"Water",
+		"Water"
 	],
 
 	stage: "Basic",
@@ -56,25 +54,28 @@ const card: Card = {
 	weaknesses: [
 		{
 			type: "Lightning",
-			value: "×2"
+			value: "x2"
 		},
 	],
 	retreat: 1,
 
 
-	thirdParty: {
-		cardmarket: 275333,
-		tcgplayer: 87023
-	},
-
 	variants: [
 		{
 			type: 'normal',
+			thirdParty: {
+				tcgplayer: 87023,
+				cardmarket: 275333
+			},
 		},
 		{
 			type: 'reverse',
-		}
-	]
+			thirdParty: {
+				tcgplayer: 87023,
+				cardmarket: 275333
+			},
+		},
+	],
 }
 
 export default card

--- a/data/E-Card/Skyridge/76.ts
+++ b/data/E-Card/Skyridge/76.ts
@@ -12,14 +12,12 @@ const card: Card = {
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		81,
-	],
+	dexId: [81],
 
 	hp: 40,
 
 	types: [
-		"Lightning",
+		"Lightning"
 	],
 
 	stage: "Basic",
@@ -59,25 +57,28 @@ const card: Card = {
 	weaknesses: [
 		{
 			type: "Fighting",
-			value: "×2"
+			value: "x2"
 		},
 	],
 	retreat: 1,
 
 
-	thirdParty: {
-		cardmarket: 275334,
-		tcgplayer: 87069
-	},
-
 	variants: [
 		{
 			type: 'normal',
+			thirdParty: {
+				tcgplayer: 87069,
+				cardmarket: 275334
+			},
 		},
 		{
 			type: 'reverse',
-		}
-	]
+			thirdParty: {
+				tcgplayer: 87069,
+				cardmarket: 275334
+			},
+		},
+	],
 }
 
 export default card

--- a/data/E-Card/Skyridge/77.ts
+++ b/data/E-Card/Skyridge/77.ts
@@ -12,14 +12,12 @@ const card: Card = {
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		226,
-	],
+	dexId: [226],
 
 	hp: 60,
 
 	types: [
-		"Water",
+		"Water"
 	],
 
 	stage: "Basic",
@@ -34,10 +32,10 @@ const card: Card = {
 				de: "Flossenknaller"
 			},
 			effect: {
-				en: "Flip 2 coins. This attack does 10 damage times the number of heads.",
+				en: "Flip 2 coins. This attack does 10 damage times the number of heads",
 				de: "Wirf 2 Münzen. Dieser Angriff fügt 10 Schadenspunkte mal der Anzahl 'Kopf' zu."
 			},
-			damage: "10x",
+			damage: "10×",
 
 		},
 		{
@@ -51,7 +49,7 @@ const card: Card = {
 				de: "Wassersonar"
 			},
 			effect: {
-				en: "Don't apply Weakness and Resistance.",
+				en: "Don't apply Resistance.",
 				de: "Wende keine Resistenz an."
 			},
 			damage: 30,
@@ -62,10 +60,9 @@ const card: Card = {
 	weaknesses: [
 		{
 			type: "Lightning",
-			value: "×2"
+			value: "x2"
 		},
 	],
-
 	resistances: [
 		{
 			type: "Fighting",
@@ -75,19 +72,22 @@ const card: Card = {
 	retreat: 2,
 
 
-	thirdParty: {
-		cardmarket: 275335,
-		tcgplayer: 87181
-	},
-
 	variants: [
 		{
 			type: 'normal',
+			thirdParty: {
+				tcgplayer: 87181,
+				cardmarket: 275335
+			},
 		},
 		{
 			type: 'reverse',
-		}
-	]
+			thirdParty: {
+				tcgplayer: 87181,
+				cardmarket: 275335
+			},
+		},
+	],
 }
 
 export default card

--- a/data/E-Card/Skyridge/78.ts
+++ b/data/E-Card/Skyridge/78.ts
@@ -12,14 +12,12 @@ const card: Card = {
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		52,
-	],
+	dexId: [52],
 
 	hp: 40,
 
 	types: [
-		"Colorless",
+		"Colorless"
 	],
 
 	stage: "Basic",
@@ -45,25 +43,28 @@ const card: Card = {
 	weaknesses: [
 		{
 			type: "Fighting",
-			value: "×2"
+			value: "x2"
 		},
 	],
 	retreat: 1,
 
 
-	thirdParty: {
-		cardmarket: 275336,
-		tcgplayer: 87314
-	},
-
 	variants: [
 		{
 			type: 'normal',
+			thirdParty: {
+				tcgplayer: 87314,
+				cardmarket: 275336
+			},
 		},
 		{
 			type: 'reverse',
-		}
-	]
+			thirdParty: {
+				tcgplayer: 87314,
+				cardmarket: 275336
+			},
+		},
+	],
 }
 
 export default card

--- a/data/E-Card/Skyridge/79.ts
+++ b/data/E-Card/Skyridge/79.ts
@@ -12,14 +12,12 @@ const card: Card = {
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		198,
-	],
+	dexId: [198],
 
 	hp: 50,
 
 	types: [
-		"Darkness",
+		"Darkness"
 	],
 
 	stage: "Basic",
@@ -59,10 +57,9 @@ const card: Card = {
 	weaknesses: [
 		{
 			type: "Fighting",
-			value: "×2"
+			value: "x2"
 		},
 	],
-
 	resistances: [
 		{
 			type: "Psychic",
@@ -72,19 +69,22 @@ const card: Card = {
 	retreat: 1,
 
 
-	thirdParty: {
-		cardmarket: 275337,
-		tcgplayer: 87649
-	},
-
 	variants: [
 		{
 			type: 'normal',
+			thirdParty: {
+				tcgplayer: 87649,
+				cardmarket: 275337
+			},
 		},
 		{
 			type: 'reverse',
-		}
-	]
+			thirdParty: {
+				tcgplayer: 87649,
+				cardmarket: 275337
+			},
+		},
+	],
 }
 
 export default card

--- a/data/E-Card/Skyridge/8.ts
+++ b/data/E-Card/Skyridge/8.ts
@@ -12,14 +12,12 @@ const card: Card = {
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		136,
-	],
+	dexId: [136],
 
 	hp: 70,
 
 	types: [
-		"Fire",
+		"Fire"
 	],
 
 	evolveFrom: {
@@ -32,7 +30,7 @@ const card: Card = {
 		{
 			type: "Poke-BODY",
 			name: {
-				en: "Self Healing",
+				en: "Self-healing",
 				de: "Selbstheilung"
 			},
 			effect: {
@@ -68,7 +66,7 @@ const card: Card = {
 				de: "Brennverstärker"
 			},
 			effect: {
-				en: "Discard an Energy card attached to Flareon in order to use this attack. If the discarded card is a Energy card, this attack does 40 damage plus 10 more damage.",
+				en: "Discard an Energy card attached to Flareon in order to use this attack. If the discarded card is a Fire Energy card, this attack does 40 damage plus 10 more damage.",
 				de: "Lege eine an Flamara angelegte Energiekarte auf deinen Ablagestapel, um diesen Angriff zu verwenden. Ist die abgelegte Karte eine -Energiekarte, fügt dieser Angriff 40 Schadenspunkte plus 10 weiter Schadenspunkte zu."
 			},
 			damage: "40+",
@@ -79,25 +77,28 @@ const card: Card = {
 	weaknesses: [
 		{
 			type: "Water",
-			value: "×2"
+			value: "x2"
 		},
 	],
 	retreat: 1,
 
 
-	thirdParty: {
-		cardmarket: 275249,
-		tcgplayer: 85491
-	},
-
 	variants: [
 		{
 			type: 'normal',
+			thirdParty: {
+				tcgplayer: 85491,
+				cardmarket: 275249
+			},
 		},
 		{
 			type: 'reverse',
-		}
-	]
+			thirdParty: {
+				tcgplayer: 85491,
+				cardmarket: 275249
+			},
+		},
+	],
 }
 
 export default card

--- a/data/E-Card/Skyridge/80.ts
+++ b/data/E-Card/Skyridge/80.ts
@@ -12,14 +12,12 @@ const card: Card = {
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		177,
-	],
+	dexId: [177],
 
 	hp: 50,
 
 	types: [
-		"Psychic",
+		"Psychic"
 	],
 
 	stage: "Basic",
@@ -49,7 +47,7 @@ const card: Card = {
 				de: "Entfernungsstrahl"
 			},
 			effect: {
-				en: "If the Defending Pokémon has any Energy cards attached to it, flip a coin. If heads, choose one of those Energy cards and discard it.",
+				en: "If the Defending Pokémon has any Energy cards attached to it, flip a coin. If heads, choose 1 of those Energy cards and discard it.",
 				de: "Wirf eine Münze, falls an das verteidigende Pokémon mindestens eine Energiekarte angelegt ist. Wähle bei \"Kopf\" 1 dieser Energiekarten und lege sie auf den Ablagestapel deines Gegners."
 			},
 			damage: 10,
@@ -60,25 +58,28 @@ const card: Card = {
 	weaknesses: [
 		{
 			type: "Psychic",
-			value: "×2"
+			value: "x2"
 		},
 	],
 	retreat: 1,
 
 
-	thirdParty: {
-		cardmarket: 275338,
-		tcgplayer: 87683
-	},
-
 	variants: [
 		{
 			type: 'normal',
+			thirdParty: {
+				tcgplayer: 87683,
+				cardmarket: 275338
+			},
 		},
 		{
 			type: 'reverse',
-		}
-	]
+			thirdParty: {
+				tcgplayer: 87683,
+				cardmarket: 275338
+			},
+		},
+	],
 }
 
 export default card

--- a/data/E-Card/Skyridge/81.ts
+++ b/data/E-Card/Skyridge/81.ts
@@ -3,20 +3,18 @@ import Set from '../Skyridge'
 
 const card: Card = {
 	name: {
-		en: "Nidoran♀",
+		en: "Nidoran ♀",
 		de: "Nidoran W"
 	},
-	illustrator: "Masako Yamashita",
+	illustrator: "Midori Harada",
 	rarity: "Common",
 	category: "Pokemon",
 
 	set: Set,
-	dexId: [
-		29,
-	],
+	dexId: [29],
 	hp: 50,
 	types: [
-		"Grass",
+		"Grass"
 	],
 
 	stage: "Basic",
@@ -32,7 +30,7 @@ const card: Card = {
 				de: "Familie holen"
 			},
 			effect: {
-				en: "Search your deck for a Basic Pokémon card named Nidoran M or Nidoran F and put it onto your Bench. Shuffle your deck afterward. (You can't use this attack if your bench is full.)",
+				en: "Search your deck for a Basic Pokémon card named Nidoran ♀ or Nidoran ♂ and put it onto your Bench. Shuffle your deck afterward. (You can't use this attack if your Bench is full.)",
 				de: "Durchsuche dein Deck nach einer Basis-Pokémonkarte mit dem Namen Nidoran W oder Nidoran M und lege sie auf deine Bank. Mische dein Deck danach. (Du kannst diesen Angriff nicht verwenden, wenn deine Bank voll ist.)"
 			},
 
@@ -53,7 +51,7 @@ const card: Card = {
 	weaknesses: [
 		{
 			type: "Psychic",
-			value: "×2"
+			value: "x2"
 		},
 	],
 	retreat: 1,
@@ -62,11 +60,17 @@ const card: Card = {
 	variants: [
 		{
 			type: 'normal',
+			thirdParty: {
+				tcgplayer: 87714,
+			},
 		},
 		{
 			type: 'reverse',
-		}
-	]
+			thirdParty: {
+				tcgplayer: 87714,
+			},
+		},
+	],
 }
 
 export default card

--- a/data/E-Card/Skyridge/82.ts
+++ b/data/E-Card/Skyridge/82.ts
@@ -3,7 +3,7 @@ import Set from '../Skyridge'
 
 const card: Card = {
 	name: {
-		en: "Nidoran♀",
+		en: "Nidoran ♀",
 		de: "Nidoran W"
 	},
 	illustrator: "Masako Yamashita",
@@ -11,12 +11,10 @@ const card: Card = {
 	category: "Pokemon",
 
 	set: Set,
-	dexId: [
-		29,
-	],
+	dexId: [29],
 	hp: 50,
 	types: [
-		"Grass",
+		"Grass"
 	],
 
 	stage: "Basic",
@@ -43,7 +41,7 @@ const card: Card = {
 	weaknesses: [
 		{
 			type: "Psychic",
-			value: "×2"
+			value: "x2"
 		},
 	],
 	retreat: 1,
@@ -52,11 +50,17 @@ const card: Card = {
 	variants: [
 		{
 			type: 'normal',
+			thirdParty: {
+				tcgplayer: 87716,
+			},
 		},
 		{
 			type: 'reverse',
-		}
-	]
+			thirdParty: {
+				tcgplayer: 87716,
+			},
+		},
+	],
 }
 
 export default card

--- a/data/E-Card/Skyridge/83.ts
+++ b/data/E-Card/Skyridge/83.ts
@@ -12,14 +12,12 @@ const card: Card = {
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		30,
-	],
+	dexId: [30],
 
 	hp: 80,
 
 	types: [
-		"Grass",
+		"Grass"
 	],
 
 	evolveFrom: {
@@ -59,32 +57,35 @@ const card: Card = {
 				de: "Wirf eine Münze. Bei \"Kopf\" ist das verteidigende Pokémon jetzt vergiftet."
 			},
 
-			damage: 30
+			damage: 30,
 		},
 	],
 
 	weaknesses: [
 		{
 			type: "Psychic",
-			value: "×2"
+			value: "x2"
 		},
 	],
 	retreat: 2,
 
 
-	thirdParty: {
-		cardmarket: 275341,
-		tcgplayer: 87734
-	},
-
 	variants: [
 		{
 			type: 'normal',
+			thirdParty: {
+				tcgplayer: 87734,
+				cardmarket: 275341
+			},
 		},
 		{
 			type: 'reverse',
-		}
-	]
+			thirdParty: {
+				tcgplayer: 87734,
+				cardmarket: 275341
+			},
+		},
+	],
 }
 
 export default card

--- a/data/E-Card/Skyridge/84.ts
+++ b/data/E-Card/Skyridge/84.ts
@@ -12,14 +12,12 @@ const card: Card = {
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		25,
-	],
+	dexId: [25],
 
 	hp: 50,
 
 	types: [
-		"Lightning",
+		"Lightning"
 	],
 
 	stage: "Basic",
@@ -35,7 +33,7 @@ const card: Card = {
 				de: "Höchstspannung"
 			},
 			effect: {
-				en: "Discard all Energy cards attached to Pikachu. This attack does 20 damage plus 10 more damage for each Energy card discarded in this way.",
+				en: "Discard all Lightning Energy cards attached to Pikachu. This attack does 20 damage plus 10 more damage for each Energy card discarded in this way.",
 				de: "Lege alle an Pikachu angelegten -Energiekarten auf deinen Ablagestapel. Dieser Angriff fügt 20 Schadenspunkte plus 10 weitere Schadenspunkte für jede auf diese Weise abgelegte Energiekarte zu."
 			},
 			damage: "20+",
@@ -46,25 +44,28 @@ const card: Card = {
 	weaknesses: [
 		{
 			type: "Fighting",
-			value: "×2"
+			value: "x2"
 		},
 	],
 	retreat: 1,
 
 
-	thirdParty: {
-		cardmarket: 275342,
-		tcgplayer: 88074
-	},
-
 	variants: [
 		{
 			type: 'normal',
+			thirdParty: {
+				tcgplayer: 88074,
+				cardmarket: 275342
+			},
 		},
 		{
 			type: 'reverse',
-		}
-	]
+			thirdParty: {
+				tcgplayer: 88074,
+				cardmarket: 275342
+			},
+		},
+	],
 }
 
 export default card

--- a/data/E-Card/Skyridge/85.ts
+++ b/data/E-Card/Skyridge/85.ts
@@ -12,14 +12,12 @@ const card: Card = {
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		204,
-	],
+	dexId: [204],
 
 	hp: 40,
 
 	types: [
-		"Grass",
+		"Grass"
 	],
 
 	stage: "Basic",
@@ -40,32 +38,35 @@ const card: Card = {
 				de: "Wirf eine Münze. Bei \"Zahl\" hat dieser Angriff keine Auswirkungen."
 			},
 
-			damage: 20
+			damage: 20,
 		},
 	],
 
 	weaknesses: [
 		{
 			type: "Fire",
-			value: "×2"
+			value: "x2"
 		},
 	],
 	retreat: 1,
 
 
-	thirdParty: {
-		cardmarket: 275343,
-		tcgplayer: 88124
-	},
-
 	variants: [
 		{
 			type: 'normal',
+			thirdParty: {
+				tcgplayer: 88124,
+				cardmarket: 275343
+			},
 		},
 		{
 			type: 'reverse',
-		}
-	]
+			thirdParty: {
+				tcgplayer: 88124,
+				cardmarket: 275343
+			},
+		},
+	],
 }
 
 export default card

--- a/data/E-Card/Skyridge/86.ts
+++ b/data/E-Card/Skyridge/86.ts
@@ -12,14 +12,12 @@ const card: Card = {
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		204,
-	],
+	dexId: [204],
 
 	hp: 50,
 
 	types: [
-		"Grass",
+		"Grass"
 	],
 
 	stage: "Basic",
@@ -46,25 +44,28 @@ const card: Card = {
 	weaknesses: [
 		{
 			type: "Fire",
-			value: "×2"
+			value: "x2"
 		},
 	],
 	retreat: 1,
 
 
-	thirdParty: {
-		cardmarket: 275344,
-		tcgplayer: 88125
-	},
-
 	variants: [
 		{
 			type: 'normal',
+			thirdParty: {
+				tcgplayer: 88125,
+				cardmarket: 275344
+			},
 		},
 		{
 			type: 'reverse',
-		}
-	]
+			thirdParty: {
+				tcgplayer: 88125,
+				cardmarket: 275344
+			},
+		},
+	],
 }
 
 export default card

--- a/data/E-Card/Skyridge/87.ts
+++ b/data/E-Card/Skyridge/87.ts
@@ -12,14 +12,12 @@ const card: Card = {
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		60,
-	],
+	dexId: [60],
 
 	hp: 40,
 
 	types: [
-		"Water",
+		"Water"
 	],
 
 	stage: "Basic",
@@ -53,7 +51,7 @@ const card: Card = {
 				en: "Flip 2 coins. This attack does 20 damage times the number of heads.",
 				de: "Wirf 2 Münzen. Dieser Angriff frügt 20 Schadenspunkte mal der Anzahl \"Kopf\" zu."
 			},
-			damage: "20x",
+			damage: "20×",
 
 		},
 	],
@@ -61,25 +59,28 @@ const card: Card = {
 	weaknesses: [
 		{
 			type: "Lightning",
-			value: "×2"
+			value: "x2"
 		},
 	],
 	retreat: 1,
 
 
-	thirdParty: {
-		cardmarket: 275345,
-		tcgplayer: 88255
-	},
-
 	variants: [
 		{
 			type: 'normal',
+			thirdParty: {
+				tcgplayer: 88255,
+				cardmarket: 275345
+			},
 		},
 		{
 			type: 'reverse',
-		}
-	]
+			thirdParty: {
+				tcgplayer: 88255,
+				cardmarket: 275345
+			},
+		},
+	],
 }
 
 export default card

--- a/data/E-Card/Skyridge/88.ts
+++ b/data/E-Card/Skyridge/88.ts
@@ -12,14 +12,12 @@ const card: Card = {
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		61,
-	],
+	dexId: [61],
 
 	hp: 70,
 
 	types: [
-		"Water",
+		"Water"
 	],
 
 	evolveFrom: {
@@ -57,7 +55,7 @@ const card: Card = {
 				en: "Flip 2 coins. This attack does 30 damage times the number of heads.",
 				de: "Wirf 2 Münzen. Dieser Angriff fügt 30 Schadenspunkte mal der Anzahl 'Kopf' zu."
 			},
-			damage: "30x",
+			damage: "30×",
 
 		},
 	],
@@ -65,25 +63,28 @@ const card: Card = {
 	weaknesses: [
 		{
 			type: "Lightning",
-			value: "×2"
+			value: "x2"
 		},
 	],
 	retreat: 1,
 
 
-	thirdParty: {
-		cardmarket: 275346,
-		tcgplayer: 88263
-	},
-
 	variants: [
 		{
 			type: 'normal',
+			thirdParty: {
+				tcgplayer: 88263,
+				cardmarket: 275346
+			},
 		},
 		{
 			type: 'reverse',
-		}
-	]
+			thirdParty: {
+				tcgplayer: 88263,
+				cardmarket: 275346
+			},
+		},
+	],
 }
 
 export default card

--- a/data/E-Card/Skyridge/89.ts
+++ b/data/E-Card/Skyridge/89.ts
@@ -12,14 +12,12 @@ const card: Card = {
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		20,
-	],
+	dexId: [20],
 
 	hp: 70,
 
 	types: [
-		"Colorless",
+		"Colorless"
 	],
 
 	evolveFrom: {
@@ -62,25 +60,28 @@ const card: Card = {
 	weaknesses: [
 		{
 			type: "Fighting",
-			value: "×2"
+			value: "x2"
 		},
 	],
 	retreat: 1,
 
 
-	thirdParty: {
-		cardmarket: 275347,
-		tcgplayer: 88602
-	},
-
 	variants: [
 		{
 			type: 'normal',
+			thirdParty: {
+				tcgplayer: 88602,
+				cardmarket: 275347
+			},
 		},
 		{
 			type: 'reverse',
-		}
-	]
+			thirdParty: {
+				tcgplayer: 88602,
+				cardmarket: 275347
+			},
+		},
+	],
 }
 
 export default card

--- a/data/E-Card/Skyridge/9.ts
+++ b/data/E-Card/Skyridge/9.ts
@@ -12,14 +12,12 @@ const card: Card = {
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		205,
-	],
+	dexId: [205],
 
 	hp: 70,
 
 	types: [
-		"Metal",
+		"Metal"
 	],
 
 	evolveFrom: {
@@ -42,7 +40,7 @@ const card: Card = {
 				en: "Flip 2 coins. This attack does 20 damage times the number of heads. If both coins are heads, switch Forretress with 1 of your Benched Pokémon.",
 				de: "Wirf zwei Münzen. Dieser Angriff fügt 20 Schadenspunkte mal der Anzahl \"Kopf\" zu. Zeigen beide Münzen \"Kopf\", tausche Forstellka mit 1 der Pokémon auf deiner Bank aus."
 			},
-			damage: "20x",
+			damage: "20×",
 
 		},
 		{
@@ -56,7 +54,7 @@ const card: Card = {
 				de: "Streubombe"
 			},
 			effect: {
-				en: "Flip 2 coins. For each heads, do 10 damage to each of your opponent's Benched Pokémon. For each tails, do 10 damage to each of your own Benched Pokémon. (Don't apply Weakness or Resistance for Benched Pokémon.)",
+				en: "Flip 2 coins. For each heads, do 10 damage to each of your opponent's Benched Pokémon. For each tails, do 10 damage to each of your own Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)",
 				de: "Wirf 2 Münzen. Füge für jeden geworfenen \"Kopf\" jedem Pokémon auf der generischen Bank 10 Schadenspunkte zu. Füge für jede geworfene \"Zahl\" jedem Pokémon auf deiner eigenen Bank 10 Schadenspunkte zu. (Wende keine Schwäche oder Resistenz bei Pokémon auf der Bank an.)"
 			},
 			damage: 40,
@@ -67,10 +65,9 @@ const card: Card = {
 	weaknesses: [
 		{
 			type: "Fire",
-			value: "×2"
+			value: "x2"
 		},
 	],
-
 	resistances: [
 		{
 			type: "Grass",
@@ -80,19 +77,22 @@ const card: Card = {
 	retreat: 2,
 
 
-	thirdParty: {
-		cardmarket: 275251,
-		tcgplayer: 85544
-	},
-
 	variants: [
 		{
 			type: 'normal',
+			thirdParty: {
+				tcgplayer: 85544,
+				cardmarket: 275251
+			},
 		},
 		{
 			type: 'reverse',
-		}
-	]
+			thirdParty: {
+				tcgplayer: 85544,
+				cardmarket: 275251
+			},
+		},
+	],
 }
 
 export default card

--- a/data/E-Card/Skyridge/90.ts
+++ b/data/E-Card/Skyridge/90.ts
@@ -12,14 +12,12 @@ const card: Card = {
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		19,
-	],
+	dexId: [19],
 
 	hp: 30,
 
 	types: [
-		"Colorless",
+		"Colorless"
 	],
 
 	stage: "Basic",
@@ -34,7 +32,7 @@ const card: Card = {
 				de: "Freunds holen"
 			},
 			effect: {
-				en: "Search your deck for a Baby Pokémon or Basic Pokémon and put it onto your bench. Shuffle your deck afterward. (You can't use this attack it your bench is full.)",
+				en: "Search your deck for a Baby Pokémon or Basic Pokémon card and put it onto your Bench. Shuffle your deck afterward. (You can't use this attack if your Bench is full.)",
 				de: "Durchsuche dein Deck nach einem Baby-Pokémon oder einem basis-Pokémon und lege sie auf deine Bank. Mische dein Deck danach. (Du kannst diesen Angriff nicht verwenden, wenn deine Bank voll ist.)"
 			},
 
@@ -59,25 +57,28 @@ const card: Card = {
 	weaknesses: [
 		{
 			type: "Fighting",
-			value: "×2"
+			value: "x2"
 		},
 	],
 	retreat: 1,
 
 
-	thirdParty: {
-		cardmarket: 275348,
-		tcgplayer: 88613
-	},
-
 	variants: [
 		{
 			type: 'normal',
+			thirdParty: {
+				tcgplayer: 88613,
+				cardmarket: 275348
+			},
 		},
 		{
 			type: 'reverse',
-		}
-	]
+			thirdParty: {
+				tcgplayer: 88613,
+				cardmarket: 275348
+			},
+		},
+	],
 }
 
 export default card

--- a/data/E-Card/Skyridge/91.ts
+++ b/data/E-Card/Skyridge/91.ts
@@ -12,14 +12,12 @@ const card: Card = {
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		111,
-	],
+	dexId: [111],
 
 	hp: 60,
 
 	types: [
-		"Fighting",
+		"Fighting"
 	],
 
 	stage: "Basic",
@@ -50,7 +48,7 @@ const card: Card = {
 				en: "This attack does 10 damage times the number of damage counters on Rhyhorn.",
 				de: "Dieser Angriff fügt 10 Schadenspunkte mal der Anzahl an Schadensmarken auf Rihorn zu."
 			},
-			damage: "10x",
+			damage: "10×",
 
 		},
 	],
@@ -58,10 +56,9 @@ const card: Card = {
 	weaknesses: [
 		{
 			type: "Grass",
-			value: "×2"
+			value: "x2"
 		},
 	],
-
 	resistances: [
 		{
 			type: "Lightning",
@@ -71,19 +68,22 @@ const card: Card = {
 	retreat: 2,
 
 
-	thirdParty: {
-		cardmarket: 275349,
-		tcgplayer: 88739
-	},
-
 	variants: [
 		{
 			type: 'normal',
+			thirdParty: {
+				tcgplayer: 88739,
+				cardmarket: 275349
+			},
 		},
 		{
 			type: 'reverse',
-		}
-	]
+			thirdParty: {
+				tcgplayer: 88739,
+				cardmarket: 275349
+			},
+		},
+	],
 }
 
 export default card

--- a/data/E-Card/Skyridge/92.ts
+++ b/data/E-Card/Skyridge/92.ts
@@ -12,14 +12,12 @@ const card: Card = {
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		27,
-	],
+	dexId: [27],
 
 	hp: 40,
 
 	types: [
-		"Fighting",
+		"Fighting"
 	],
 
 	stage: "Basic",
@@ -37,7 +35,7 @@ const card: Card = {
 				en: "Flip 2 coins. This attack does 10 damage times the number of heads.",
 				de: "Wirf 2 Münzen. Dieser Angriff fügt 10 Schadenspunkte mal der Anzahl \"Kopf\" zu."
 			},
-			damage: "10x",
+			damage: "10×",
 
 		},
 		{
@@ -59,10 +57,9 @@ const card: Card = {
 	weaknesses: [
 		{
 			type: "Grass",
-			value: "×2"
+			value: "x2"
 		},
 	],
-
 	resistances: [
 		{
 			type: "Lightning",
@@ -72,19 +69,22 @@ const card: Card = {
 	retreat: 1,
 
 
-	thirdParty: {
-		cardmarket: 275350,
-		tcgplayer: 88921
-	},
-
 	variants: [
 		{
 			type: 'normal',
+			thirdParty: {
+				tcgplayer: 88921,
+				cardmarket: 275350
+			},
 		},
 		{
 			type: 'reverse',
-		}
-	]
+			thirdParty: {
+				tcgplayer: 88921,
+				cardmarket: 275350
+			},
+		},
+	],
 }
 
 export default card

--- a/data/E-Card/Skyridge/93.ts
+++ b/data/E-Card/Skyridge/93.ts
@@ -12,14 +12,12 @@ const card: Card = {
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		28,
-	],
+	dexId: [28],
 
 	hp: 70,
 
 	types: [
-		"Fighting",
+		"Fighting"
 	],
 
 	evolveFrom: {
@@ -59,7 +57,7 @@ const card: Card = {
 				en: "Flip 3 coins. This attack does 20 damage times the number of heads. If you get at least 1 heads, the Defending Pokémon is now Poisoned.",
 				de: "Wirf 3 Münzen. Dieser Angriff fügt 20 Schadenspunkte mal der Anzahl \"Kopf\" zu. Wenn du dabei mindestens 1 \"Kopf\" erzielst, ist das verteidigende Pokémon jetzt vergiftet."
 			},
-			damage: "20x",
+			damage: "20×",
 
 		},
 	],
@@ -67,10 +65,9 @@ const card: Card = {
 	weaknesses: [
 		{
 			type: "Grass",
-			value: "×2"
+			value: "x2"
 		},
 	],
-
 	resistances: [
 		{
 			type: "Lightning",
@@ -80,19 +77,22 @@ const card: Card = {
 	retreat: 1,
 
 
-	thirdParty: {
-		cardmarket: 275351,
-		tcgplayer: 88931
-	},
-
 	variants: [
 		{
 			type: 'normal',
+			thirdParty: {
+				tcgplayer: 88931,
+				cardmarket: 275351
+			},
 		},
 		{
 			type: 'reverse',
-		}
-	]
+			thirdParty: {
+				tcgplayer: 88931,
+				cardmarket: 275351
+			},
+		},
+	],
 }
 
 export default card

--- a/data/E-Card/Skyridge/94.ts
+++ b/data/E-Card/Skyridge/94.ts
@@ -12,14 +12,12 @@ const card: Card = {
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		86,
-	],
+	dexId: [86],
 
 	hp: 50,
 
 	types: [
-		"Water",
+		"Water"
 	],
 
 	stage: "Basic",
@@ -45,25 +43,28 @@ const card: Card = {
 	weaknesses: [
 		{
 			type: "Lightning",
-			value: "×2"
+			value: "x2"
 		},
 	],
 	retreat: 1,
 
 
-	thirdParty: {
-		cardmarket: 275352,
-		tcgplayer: 89050
-	},
-
 	variants: [
 		{
 			type: 'normal',
+			thirdParty: {
+				tcgplayer: 89050,
+				cardmarket: 275352
+			},
 		},
 		{
 			type: 'reverse',
-		}
-	]
+			thirdParty: {
+				tcgplayer: 89050,
+				cardmarket: 275352
+			},
+		},
+	],
 }
 
 export default card

--- a/data/E-Card/Skyridge/95.ts
+++ b/data/E-Card/Skyridge/95.ts
@@ -12,14 +12,12 @@ const card: Card = {
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		86,
-	],
+	dexId: [86],
 
 	hp: 50,
 
 	types: [
-		"Water",
+		"Water"
 	],
 
 	stage: "Basic",
@@ -37,7 +35,7 @@ const card: Card = {
 				en: "Flip 2 coins. This attack does 10 damage times the number of heads.",
 				de: "Wirf 2 Münzen. Dieser Angriff fügt 10 Schadenspunkte mal der Anzahl 'Kopf' zu."
 			},
-			damage: "10x",
+			damage: "10×",
 
 		},
 		{
@@ -61,25 +59,28 @@ const card: Card = {
 	weaknesses: [
 		{
 			type: "Lightning",
-			value: "×2"
+			value: "x2"
 		},
 	],
 	retreat: 1,
 
 
-	thirdParty: {
-		cardmarket: 275353,
-		tcgplayer: 89051
-	},
-
 	variants: [
 		{
 			type: 'normal',
+			thirdParty: {
+				tcgplayer: 89051,
+				cardmarket: 275353
+			},
 		},
 		{
 			type: 'reverse',
-		}
-	]
+			thirdParty: {
+				tcgplayer: 89051,
+				cardmarket: 275353
+			},
+		},
+	],
 }
 
 export default card

--- a/data/E-Card/Skyridge/96.ts
+++ b/data/E-Card/Skyridge/96.ts
@@ -12,14 +12,12 @@ const card: Card = {
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		213,
-	],
+	dexId: [213],
 
 	hp: 30,
 
 	types: [
-		"Grass",
+		"Grass"
 	],
 
 	stage: "Basic",
@@ -32,7 +30,7 @@ const card: Card = {
 				de: "Vasenkörper"
 			},
 			effect: {
-				en: "All damage done to Shuckle is reduced by 20 (after applying Weakness and Resistance).",
+				en: "All damage done by attacks to Shuckle is reduced by 20 (after applying Weakness and Resistance).",
 				de: "Jeder Schaden, der Pottrott durch Angriffe zugefügt wird, wird um 20 reduziert (nachdem Schwäche und Resistenz verrechnet wurden)."
 			},
 		},
@@ -60,25 +58,28 @@ const card: Card = {
 	weaknesses: [
 		{
 			type: "Fire",
-			value: "×2"
+			value: "x2"
 		},
 	],
 	retreat: 2,
 
 
-	thirdParty: {
-		cardmarket: 275354,
-		tcgplayer: 89189
-	},
-
 	variants: [
 		{
 			type: 'normal',
+			thirdParty: {
+				tcgplayer: 89189,
+				cardmarket: 275354
+			},
 		},
 		{
 			type: 'reverse',
-		}
-	]
+			thirdParty: {
+				tcgplayer: 89189,
+				cardmarket: 275354
+			},
+		},
+	],
 }
 
 export default card

--- a/data/E-Card/Skyridge/97.ts
+++ b/data/E-Card/Skyridge/97.ts
@@ -12,14 +12,12 @@ const card: Card = {
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		227,
-	],
+	dexId: [227],
 
 	hp: 60,
 
 	types: [
-		"Metal",
+		"Metal"
 	],
 
 	stage: "Basic",
@@ -37,7 +35,7 @@ const card: Card = {
 				en: "Flip 2 coins. This attack does 10 damage times the number of heads.",
 				de: "Wirf 2 Münzen. Dieser Angriff fügt 10 Schadenspunkte mal der Anzahl \"Kopf\" zu."
 			},
-			damage: "10x",
+			damage: "10×",
 
 		},
 		{
@@ -62,10 +60,9 @@ const card: Card = {
 	weaknesses: [
 		{
 			type: "Fire",
-			value: "×2"
+			value: "x2"
 		},
 	],
-
 	resistances: [
 		{
 			type: "Grass",
@@ -75,19 +72,22 @@ const card: Card = {
 	retreat: 2,
 
 
-	thirdParty: {
-		cardmarket: 275355,
-		tcgplayer: 89236
-	},
-
 	variants: [
 		{
 			type: 'normal',
+			thirdParty: {
+				tcgplayer: 89236,
+				cardmarket: 275355
+			},
 		},
 		{
 			type: 'reverse',
-		}
-	]
+			thirdParty: {
+				tcgplayer: 89236,
+				cardmarket: 275355
+			},
+		},
+	],
 }
 
 export default card

--- a/data/E-Card/Skyridge/98.ts
+++ b/data/E-Card/Skyridge/98.ts
@@ -12,14 +12,12 @@ const card: Card = {
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		218,
-	],
+	dexId: [218],
 
 	hp: 50,
 
 	types: [
-		"Fire",
+		"Fire"
 	],
 
 	stage: "Basic",
@@ -46,7 +44,7 @@ const card: Card = {
 				de: "Glühendheiße Lava"
 			},
 			effect: {
-				en: "Discard a Energy card attached to Slugma in order to use this attack. The Defending Pokémon is now Burned.",
+				en: "Discard a Fire Energy card attached to Slugma in order to use this attack. The Defending Pokémon is now Burned.",
 				de: "Lege eine an Schneckmag angelegte -Energiekarte auf deinen Ablagestapel, um diesen Angriff zu verwenden. Das verteidigende Pokémon ist jetzt verbrannt."
 			},
 
@@ -56,25 +54,28 @@ const card: Card = {
 	weaknesses: [
 		{
 			type: "Water",
-			value: "×2"
+			value: "x2"
 		},
 	],
 	retreat: 2,
 
 
-	thirdParty: {
-		cardmarket: 275356,
-		tcgplayer: 89338
-	},
-
 	variants: [
 		{
 			type: 'normal',
+			thirdParty: {
+				tcgplayer: 89338,
+				cardmarket: 275356
+			},
 		},
 		{
 			type: 'reverse',
-		}
-	]
+			thirdParty: {
+				tcgplayer: 89338,
+				cardmarket: 275356
+			},
+		},
+	],
 }
 
 export default card

--- a/data/E-Card/Skyridge/99.ts
+++ b/data/E-Card/Skyridge/99.ts
@@ -12,14 +12,12 @@ const card: Card = {
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		218,
-	],
+	dexId: [218],
 
 	hp: 50,
 
 	types: [
-		"Fire",
+		"Fire"
 	],
 
 	stage: "Basic",
@@ -46,25 +44,28 @@ const card: Card = {
 	weaknesses: [
 		{
 			type: "Water",
-			value: "×2"
+			value: "x2"
 		},
 	],
 	retreat: 2,
 
 
-	thirdParty: {
-		cardmarket: 275357,
-		tcgplayer: 89339
-	},
-
 	variants: [
 		{
 			type: 'normal',
+			thirdParty: {
+				tcgplayer: 89339,
+				cardmarket: 275357
+			},
 		},
 		{
 			type: 'reverse',
-		}
-	]
+			thirdParty: {
+				tcgplayer: 89339,
+				cardmarket: 275357
+			},
+		},
+	],
 }
 
 export default card

--- a/data/E-Card/Skyridge/H01.ts
+++ b/data/E-Card/Skyridge/H01.ts
@@ -8,18 +8,16 @@ const card: Card = {
 	},
 
 	illustrator: "Kimiya Masago",
-	rarity: "Rare",
+	rarity: "Holo Rare",
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		65,
-	],
+	dexId: [65],
 
 	hp: 100,
 
 	types: [
-		"Psychic",
+		"Psychic"
 	],
 
 	evolveFrom: {
@@ -36,7 +34,7 @@ const card: Card = {
 				de: "Energy Jump"
 			},
 			effect: {
-				en: "Once during your turn (before you attack) you may move an energy card from 1 of your Pokémon to another of your Pokémon. This power can't be used if Alakazam is affected by a Special Condition.",
+				en: "Once during your turn (before your attack), you may move an Energy card from 1 of your Pokémon to another of your Pokémon. This power can't be used if Alakazam is affected by a Special Condition.",
 				de: "Once during your turn (before your attack), you may move an Energy card from 1 of your Pokémon to another of your Pokémon. This power can't be used if Alakazam is affected by a Special Condition."
 			},
 		},
@@ -54,10 +52,10 @@ const card: Card = {
 				de: "Psychic"
 			},
 			effect: {
-				en: "This attack does 30 damage plus 10 more damage for each energy card attached to the Defending Pokémon.",
+				en: "This attack does 30 damage plus 10 more damage for each Energy card attached to the Defending Pokémon.",
 				de: "This attack does 30 damage plus 10 more damage for each Energy card attached to the Defending Pokémon."
 			},
-			damage: 30,
+			damage: "30+",
 
 		},
 	],
@@ -65,22 +63,21 @@ const card: Card = {
 	weaknesses: [
 		{
 			type: "Psychic",
-			value: "×2"
+			value: "x2"
 		},
 	],
 	retreat: 2,
 
 
-	thirdParty: {
-		cardmarket: 275260,
-		tcgplayer: 83498
-	},
-
 	variants: [
 		{
 			type: 'holo',
-		}
-	]
+			thirdParty: {
+				tcgplayer: 83498,
+				cardmarket: 275260
+			},
+		},
+	],
 }
 
 export default card

--- a/data/E-Card/Skyridge/H02.ts
+++ b/data/E-Card/Skyridge/H02.ts
@@ -8,18 +8,16 @@ const card: Card = {
 	},
 
 	illustrator: "Aya Kusube",
-	rarity: "Rare",
+	rarity: "Holo Rare",
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		59,
-	],
+	dexId: [59],
 
 	hp: 80,
 
 	types: [
-		"Fire",
+		"Fire"
 	],
 
 	evolveFrom: {
@@ -36,7 +34,7 @@ const card: Card = {
 				de: "Energy Recharge"
 			},
 			effect: {
-				en: "When you play Arcanine from your hand to evolve your Active Pokémon, you may flip 3 coins. For each heads, choose a basic energy card from your discard pile and attach it to Arcanine.",
+				en: "When you play Arcanine from your hand to evolve your Active Pokémon, you may flip 3 coins. For each heads, choose a basic Energy card from your discard pile and attach it to Arcanine.",
 				de: "When your play Arcanine from your hand to evolve your Active Pokémon, you may flip 3 coins. For each heads, choose a basic Energy card from your discard pile and attach it to Arcanine."
 			},
 		},
@@ -69,7 +67,7 @@ const card: Card = {
 				de: "White Flames"
 			},
 			effect: {
-				en: "Discard all Energy cards attached to Arcanine.",
+				en: "Discard all Fire Energy cards attached to Arcanine.",
 				de: "Discard all  Energy cards attached to Arcanine."
 			},
 			damage: 70,
@@ -80,22 +78,21 @@ const card: Card = {
 	weaknesses: [
 		{
 			type: "Water",
-			value: "×2"
+			value: "x2"
 		},
 	],
 	retreat: 2,
 
 
-	thirdParty: {
-		cardmarket: 275261,
-		tcgplayer: 83574
-	},
-
 	variants: [
 		{
 			type: 'holo',
-		}
-	]
+			thirdParty: {
+				tcgplayer: 83574,
+				cardmarket: 275261
+			},
+		},
+	],
 }
 
 export default card

--- a/data/E-Card/Skyridge/H03.ts
+++ b/data/E-Card/Skyridge/H03.ts
@@ -8,18 +8,16 @@ const card: Card = {
 	},
 
 	illustrator: "Hajime Kusajima",
-	rarity: "Rare",
+	rarity: "Holo Rare",
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		144,
-	],
+	dexId: [144],
 
 	hp: 80,
 
 	types: [
-		"Water",
+		"Water"
 	],
 
 	stage: "Basic",
@@ -48,7 +46,7 @@ const card: Card = {
 				de: "Einfrieren"
 			},
 			effect: {
-				en: "If there are any Energy cards in your discard pile, flip a coin. If heads, attach 1 of them to Articuno.",
+				en: "If there are any Water Energy cards in your discard pile, flip a coin. If heads, attach 1 of them to Articuno.",
 				de: "Wenn mindestens eine  -Energiekarte in deinem Ablegestapel ist, wirf eine Münze. Lege bei \"Kopf\" eine davon an Arktos an."
 			},
 			damage: 10,
@@ -77,10 +75,9 @@ const card: Card = {
 	weaknesses: [
 		{
 			type: "Metal",
-			value: "×2"
+			value: "x2"
 		},
 	],
-
 	resistances: [
 		{
 			type: "Fighting",
@@ -90,16 +87,15 @@ const card: Card = {
 	retreat: 2,
 
 
-	thirdParty: {
-		cardmarket: 275262,
-		tcgplayer: 83644
-	},
-
 	variants: [
 		{
 			type: 'holo',
-		}
-	]
+			thirdParty: {
+				tcgplayer: 83644,
+				cardmarket: 275262
+			},
+		},
+	],
 }
 
 export default card

--- a/data/E-Card/Skyridge/H04.ts
+++ b/data/E-Card/Skyridge/H04.ts
@@ -8,18 +8,16 @@ const card: Card = {
 	},
 
 	illustrator: "Hikaru Koike",
-	rarity: "Rare",
+	rarity: "Holo Rare",
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		15,
-	],
+	dexId: [15],
 
 	hp: 80,
 
 	types: [
-		"Grass",
+		"Grass"
 	],
 
 	evolveFrom: {
@@ -56,7 +54,7 @@ const card: Card = {
 				en: "Flip 4 coins. If you get 1 heads, this attack does 10 damage plus 10 more damage. If you get 2 heads, this attack does 10 damage plus 20 more damage. If you get 3 heads, this attack does 10 damage plus 50 more damage. If you get 4 heads, this attack does 10 damage plus 90 more damage.",
 				de: "Wirf 4 Münzen. Zeigt 1 Münze 'Kopf', fügt dieser Angriff 10 Schadenspunkte plus 10 weitere Schadenspunkte zu. Zeigen 2 Münzen 'Kopf', fügt dieser Angriff 10 Schadenspunkte plus 20 weitere Schadenspunkte zu. Zeigen 3 Münzen 'Kopf', fügt dieser Angriff 10 Schadenspunkte plus 50 weitere Schadenspunkte zu. Zeigen 4 Münzen 'Kopf', fügt dieser Angriff 10 Schadenspunkte plus 90 weitere Schadenspunkte zu."
 			},
-			damage: 10,
+			damage: "10+",
 
 		},
 	],
@@ -64,20 +62,19 @@ const card: Card = {
 	weaknesses: [
 		{
 			type: "Fire",
-			value: "×2"
+			value: "x2"
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 275263,
-		tcgplayer: 83764
-	},
-
 	variants: [
 		{
 			type: 'holo',
-		}
-	]
+			thirdParty: {
+				tcgplayer: 83764,
+				cardmarket: 275263
+			},
+		},
+	],
+	retreat: 0,
 }
 
 export default card

--- a/data/E-Card/Skyridge/H05.ts
+++ b/data/E-Card/Skyridge/H05.ts
@@ -8,18 +8,16 @@ const card: Card = {
 	},
 
 	illustrator: "Kimiya Masago",
-	rarity: "Rare",
+	rarity: "Holo Rare",
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		169,
-	],
+	dexId: [169],
 
 	hp: 90,
 
 	types: [
-		"Grass",
+		"Grass"
 	],
 
 	evolveFrom: {
@@ -36,7 +34,7 @@ const card: Card = {
 				de: "Wegtragen"
 			},
 			effect: {
-				en: "Once during your turn (before you attack) you may flip a coin. If heads, look at your opponent's hand. If your opponent has and Baby Pokémon, Basic Pokémon, of Evolution cards there, choose 1 of them. Your opponent shuffles that card into his or her deck. This power can't be used if Crobat is affected by a Special Condition.",
+				en: "Once during your turn (before your attack), you may flip a coin. If heads, look at your opponent's hand. If your opponent has any Baby Pokémon, Basic Pokémon, or Evolution cards there, choose 1 of them. Your opponent shuffles that card into his or her deck. This power can't be used if Crobat is affected by a Special Condition.",
 				de: "Einmal während deines Zuges (vor deinem Angriff) kannst du eine Münze werfen. Schau dir bei 'Kopf' die Karten auf der Hand deines Gegners an. Falls dein Gegner ein Baby-Pokémon, ein Basis-Pokémon oder eine Entwicklungskarte auf der Hand hat, wähle eine davon. Dein Gegner mischt die Karte in sein Deck. Diese Fähigkeit kann nicht verwendet werden, falls Iksbat von einem speziellen ustand betroffen ist."
 			},
 		},
@@ -54,10 +52,10 @@ const card: Card = {
 				de: "Doppelspiel"
 			},
 			effect: {
-				en: "Flip 2 coins. This attack does 40 damage times the number of heads. If both of them are tails, the defending Pokémon is now Confused and Poisoned.",
+				en: "Flip 2 coins. This attack does 40 damage times the number of heads. If both of them are tails, the Defending Pokémon is now Confused and Poisoned.",
 				de: "Wirf 2 Münzen. Dieser Angriff fügt 40 Schadenspunkte mal der Anzahl 'Kopf' zu. Wenn beide 'Zahl' zeigen, ist das verteidigende Pokémon jetzt verwirrt und vergiftet."
 			},
-			damage: 40,
+			damage: "40×",
 
 		},
 	],
@@ -65,20 +63,19 @@ const card: Card = {
 	weaknesses: [
 		{
 			type: "Psychic",
-			value: "×2"
+			value: "x2"
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 275264,
-		tcgplayer: 84483
-	},
-
 	variants: [
 		{
 			type: 'holo',
-		}
-	]
+			thirdParty: {
+				tcgplayer: 84483,
+				cardmarket: 275264
+			},
+		},
+	],
+	retreat: 0,
 }
 
 export default card

--- a/data/E-Card/Skyridge/H06.ts
+++ b/data/E-Card/Skyridge/H06.ts
@@ -8,18 +8,16 @@ const card: Card = {
 	},
 
 	illustrator: "Kouki Saitou",
-	rarity: "Rare",
+	rarity: "Holo Rare",
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		87,
-	],
+	dexId: [87],
 
 	hp: 80,
 
 	types: [
-		"Water",
+		"Water"
 	],
 
 	evolveFrom: {
@@ -57,10 +55,10 @@ const card: Card = {
 				de: "Erdrückendes Eis"
 			},
 			effect: {
-				en: "This attack does 40 damage plus 10 more damage for each Energy in the Defending Pokémon's Retreat Cost. Damage is calculated using the Defending Pokémon's Retreat Cost after applying effects to the Retreat Cost.",
+				en: "This attack does 40 damage plus 10 more damage for each Colorless Energy in the Defending Pokémon's Retreat Cost. Damage is calculated using the Defending Pokémon's Retreat Cost after applying effects to the Retreat Cost.",
 				de: "Dieser Angriff fügt 40 Schadenspunkte plus 10 weitere Schadenspunkte für jede -Energie in den Rückzugskosten des verteidigenden Pokémon zu. Beim Ermitteln des Schadens werden erst etwaige Effekte auf die Rückzugskosten angewandt und dann die Rückzugskosten des verteidigenden Pokémon verwendet."
 			},
-			damage: 40,
+			damage: "40+",
 
 		},
 	],
@@ -68,22 +66,21 @@ const card: Card = {
 	weaknesses: [
 		{
 			type: "Metal",
-			value: "×2"
+			value: "x2"
 		},
 	],
 	retreat: 2,
 
 
-	thirdParty: {
-		cardmarket: 275265,
-		tcgplayer: 84785
-	},
-
 	variants: [
 		{
 			type: 'holo',
-		}
-	]
+			thirdParty: {
+				tcgplayer: 84785,
+				cardmarket: 275265
+			},
+		},
+	],
 }
 
 export default card

--- a/data/E-Card/Skyridge/H07.ts
+++ b/data/E-Card/Skyridge/H07.ts
@@ -8,18 +8,16 @@ const card: Card = {
 	},
 
 	illustrator: "Kyoko Umemoto",
-	rarity: "Rare",
+	rarity: "Holo Rare",
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		136,
-	],
+	dexId: [136],
 
 	hp: 70,
 
 	types: [
-		"Fire",
+		"Fire"
 	],
 
 	evolveFrom: {
@@ -32,7 +30,7 @@ const card: Card = {
 		{
 			type: "Poke-BODY",
 			name: {
-				en: "Self Healing",
+				en: "Self-healing",
 				de: "Selbstheilung"
 			},
 			effect: {
@@ -68,10 +66,10 @@ const card: Card = {
 				de: "Brennverstärker"
 			},
 			effect: {
-				en: "Discard an Energy card attached to Flareon in order to use this attack. If the discarded card is a Energy card, this attack does 40 damage plus 10 more damage.",
+				en: "Discard an Energy card attached to Flareon in order to use this attack. If the discarded card is a Fire Energy card, this attack does 40 damage plus 10 more damage.",
 				de: "Lege eine an Flamara angelegte Energiekarte auf deinen Ablagestapel, um diesen Angriff zu verwenden. Ist die abgelegte Karte eine -Energiekarte, fügt dieser Angriff 40 Schadenspunkte plus 10 weiter Schadenspunkte zu."
 			},
-			damage: 40,
+			damage: "40+",
 
 		},
 	],
@@ -79,22 +77,21 @@ const card: Card = {
 	weaknesses: [
 		{
 			type: "Water",
-			value: "×2"
+			value: "x2"
 		},
 	],
 	retreat: 1,
 
 
-	thirdParty: {
-		cardmarket: 275266,
-		tcgplayer: 85490
-	},
-
 	variants: [
 		{
 			type: 'holo',
-		}
-	]
+			thirdParty: {
+				tcgplayer: 85490,
+				cardmarket: 275266
+			},
+		},
+	],
 }
 
 export default card

--- a/data/E-Card/Skyridge/H08.ts
+++ b/data/E-Card/Skyridge/H08.ts
@@ -8,18 +8,16 @@ const card: Card = {
 	},
 
 	illustrator: "Midori Harada",
-	rarity: "Rare",
+	rarity: "Holo Rare",
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		205,
-	],
+	dexId: [205],
 
 	hp: 70,
 
 	types: [
-		"Metal",
+		"Metal"
 	],
 
 	evolveFrom: {
@@ -42,7 +40,7 @@ const card: Card = {
 				en: "Flip 2 coins. This attack does 20 damage times the number of heads. If both coins are heads, switch Forretress with 1 of your Benched Pokémon.",
 				de: "Wirf zwei Münzen. Dieser Angriff fügt 20 Schadenspunkte mal der Anzahl \"Kopf\" zu. Zeigen beide Münzen \"Kopf\", tausche Forstellka mit 1 der Pokémon auf deiner Bank aus."
 			},
-			damage: 20,
+			damage: "20×",
 
 		},
 		{
@@ -56,7 +54,7 @@ const card: Card = {
 				de: "Streubombe"
 			},
 			effect: {
-				en: "Flip 2 coins. For each heads, do 10 damage to each of your opponent's Benched Pokémon. For each tails, do 10 damage to each of your own Benched Pokémon. (Don't apply Weakness or Resistance for Benched Pokémon.)",
+				en: "Flip 2 coins. For each heads, do 10 damage to each of your opponent's Benched Pokémon. For each tails, do 10 damage to each of your own Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)",
 				de: "Wirf 2 Münzen. Füge für jeden geworfenen \"Kopf\" jedem Pokémon auf der generischen Bank 10 Schadenspunkte zu. Füge für jede geworfene \"Zahl\" jedem Pokémon auf deiner eigenen Bank 10 Schadenspunkte zu. (Wende keine Schwäche oder Resistenz bei Pokémon auf der Bank an.)"
 			},
 			damage: 40,
@@ -67,10 +65,9 @@ const card: Card = {
 	weaknesses: [
 		{
 			type: "Fire",
-			value: "×2"
+			value: "x2"
 		},
 	],
-
 	resistances: [
 		{
 			type: "Grass",
@@ -80,16 +77,15 @@ const card: Card = {
 	retreat: 2,
 
 
-	thirdParty: {
-		cardmarket: 275267,
-		tcgplayer: 85543
-	},
-
 	variants: [
 		{
 			type: 'holo',
-		}
-	]
+			thirdParty: {
+				tcgplayer: 85543,
+				cardmarket: 275267
+			},
+		},
+	],
 }
 
 export default card

--- a/data/E-Card/Skyridge/H09.ts
+++ b/data/E-Card/Skyridge/H09.ts
@@ -8,18 +8,16 @@ const card: Card = {
 	},
 
 	illustrator: "Kyoko Umemoto",
-	rarity: "Rare",
+	rarity: "Holo Rare",
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		94,
-	],
+	dexId: [94],
 
 	hp: 100,
 
 	types: [
-		"Psychic",
+		"Psychic"
 	],
 
 	evolveFrom: {
@@ -36,7 +34,7 @@ const card: Card = {
 				de: "Manipulieren"
 			},
 			effect: {
-				en: "When you play Gengar from your hand to evolve your Active Pokémon, you may put a Basic Pokémon (excluding Baby Pokémon) from your discard pile onto your bench. Then flip 3 coins. For each heads, choose a basic Energy card from your discard pile and attach it to that Pokémon.",
+				en: "When you play Gengar from your hand to evolve your Active Pokémon, you may put a Basic Pokémon (excluding Baby Pokémon) from your discard pile onto your Bench. Then, flip 3 coins. For each heads, choose a basic Energy card from your discard pile and attach it to that Pokémon.",
 				de: "Wenn du Gengar aus deiner Hand spielst, um dein aktives Pokémon zu entwickeln, kannst du ein Basis-Pokémon (aber kein Baby-Pokémon) aus deinem Ablagestapel nehmen und auf deine Bank legen. Wirf dann 3 Münzen. Wähle für jeden geworfenen 'Kopf' eine Basis-Energiekarte aus deinem Ablagestapel und lege sie an dieses Pokémon an."
 			},
 		},
@@ -66,10 +64,9 @@ const card: Card = {
 	weaknesses: [
 		{
 			type: "Darkness",
-			value: "×2"
+			value: "x2"
 		},
 	],
-
 	resistances: [
 		{
 			type: "Fighting",
@@ -79,16 +76,15 @@ const card: Card = {
 	retreat: 2,
 
 
-	thirdParty: {
-		cardmarket: 275268,
-		tcgplayer: 85668
-	},
-
 	variants: [
 		{
 			type: 'holo',
-		}
-	]
+			thirdParty: {
+				tcgplayer: 85668,
+				cardmarket: 275268
+			},
+		},
+	],
 }
 
 export default card

--- a/data/E-Card/Skyridge/H10.ts
+++ b/data/E-Card/Skyridge/H10.ts
@@ -8,18 +8,16 @@ const card: Card = {
 	},
 
 	illustrator: "Kimiya Masago",
-	rarity: "Rare",
+	rarity: "Holo Rare",
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		130,
-	],
+	dexId: [130],
 
 	hp: 90,
 
 	types: [
-		"Water",
+		"Water"
 	],
 
 	evolveFrom: {
@@ -61,29 +59,28 @@ const card: Card = {
 				de: "Verfügt Garados über 7 oder mehr Schadensmarken, beträgt der Basisschaden dieses Angriffs 100."
 			},
 
-			damage: 50
+			damage: 50,
 		},
 	],
 
 	weaknesses: [
 		{
 			type: "Lightning",
-			value: "×2"
+			value: "x2"
 		},
 	],
 	retreat: 2,
 
 
-	thirdParty: {
-		cardmarket: 275269,
-		tcgplayer: 85987
-	},
-
 	variants: [
 		{
 			type: 'holo',
-		}
-	]
+			thirdParty: {
+				tcgplayer: 85987,
+				cardmarket: 275269
+			},
+		},
+	],
 }
 
 export default card

--- a/data/E-Card/Skyridge/H11.ts
+++ b/data/E-Card/Skyridge/H11.ts
@@ -8,18 +8,16 @@ const card: Card = {
 	},
 
 	illustrator: "Kimiya Masago",
-	rarity: "Rare",
+	rarity: "Holo Rare",
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		229,
-	],
+	dexId: [229],
 
 	hp: 70,
 
 	types: [
-		"Darkness",
+		"Darkness"
 	],
 
 	evolveFrom: {
@@ -56,7 +54,7 @@ const card: Card = {
 				de: "Einzelner Reißzahn"
 			},
 			effect: {
-				en: "This attack does 30 damage plus 20 damage times the number of your opponent's Benched Pokémon minus the number of your Benched Pokémon. (For example, if your opponent has 3 Benched Pokémon and you have 1, this attack will do 30 damage plus 40 more damage.",
+				en: "This attack does 30 damage plus 20 damage times the number of your opponent's Benched Pokémon minus the number of your Benched Pokémon. (For example, if your opponent has 3 Benched Pokémon and you have 1, this attack will do 30 damage plus 40 more damage.)",
 				de: "Dieser Angriff fügt 30 Schadenspunkte plus 20 weitere Schadenspunkte für jedes Pokémon auf der Bank deines Gegners minus 20 Schadenspunkte für jedes Pokémon auf deiner Bank zu. (Hat zum Beispiel dein Gegner 3 Pokémon auf seiner Bank und du nur 1 auf deiner, fügt dieser Angriff 30 Schadenspunkte plus 40 weitere Schadenspunkte zu.)"
 			},
 			damage: "30+",
@@ -67,10 +65,9 @@ const card: Card = {
 	weaknesses: [
 		{
 			type: "Fighting",
-			value: "×2"
+			value: "x2"
 		},
 	],
-
 	resistances: [
 		{
 			type: "Psychic",
@@ -80,16 +77,15 @@ const card: Card = {
 	retreat: 1,
 
 
-	thirdParty: {
-		cardmarket: 275270,
-		tcgplayer: 86200
-	},
-
 	variants: [
 		{
 			type: 'holo',
-		}
-	]
+			thirdParty: {
+				tcgplayer: 86200,
+				cardmarket: 275270
+			},
+		},
+	],
 }
 
 export default card

--- a/data/E-Card/Skyridge/H12.ts
+++ b/data/E-Card/Skyridge/H12.ts
@@ -8,18 +8,16 @@ const card: Card = {
 	},
 
 	illustrator: "Hikaru Koike",
-	rarity: "Rare",
+	rarity: "Holo Rare",
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		135,
-	],
+	dexId: [135],
 
 	hp: 70,
 
 	types: [
-		"Lightning",
+		"Lightning"
 	],
 
 	evolveFrom: {
@@ -32,7 +30,7 @@ const card: Card = {
 		{
 			type: "Poke-BODY",
 			name: {
-				en: "Self Healing",
+				en: "Self-healing",
 				de: "Selbstheilung"
 			},
 			effect: {
@@ -80,20 +78,19 @@ const card: Card = {
 	weaknesses: [
 		{
 			type: "Fighting",
-			value: "×2"
+			value: "x2"
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 275271,
-		tcgplayer: 86337
-	},
-
 	variants: [
 		{
 			type: 'holo',
-		}
-	]
+			thirdParty: {
+				tcgplayer: 86337,
+				cardmarket: 275271
+			},
+		},
+	],
+	retreat: 0,
 }
 
 export default card

--- a/data/E-Card/Skyridge/H13.ts
+++ b/data/E-Card/Skyridge/H13.ts
@@ -8,18 +8,16 @@ const card: Card = {
 	},
 
 	illustrator: "Kouki Saitou",
-	rarity: "Rare",
+	rarity: "Holo Rare",
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		141,
-	],
+	dexId: [141],
 
 	hp: 90,
 
 	types: [
-		"Fighting",
+		"Fighting"
 	],
 
 	evolveFrom: {
@@ -57,7 +55,7 @@ const card: Card = {
 				en: "Flip 2 coins. This attack does 50 damage times the number of heads.",
 				de: "Wirf 2 Münzen. Dieser Angriff fügt 50 Schadenspunkte mal der Anzahl \"Kopf\" zu."
 			},
-			damage: "50x",
+			damage: "50×",
 
 		},
 	],
@@ -65,22 +63,21 @@ const card: Card = {
 	weaknesses: [
 		{
 			type: "Grass",
-			value: "×2"
+			value: "x2"
 		},
 	],
 	retreat: 2,
 
 
-	thirdParty: {
-		cardmarket: 275272,
-		tcgplayer: 86391
-	},
-
 	variants: [
 		{
 			type: 'holo',
-		}
-	]
+			thirdParty: {
+				tcgplayer: 86391,
+				cardmarket: 275272
+			},
+		},
+	],
 }
 
 export default card

--- a/data/E-Card/Skyridge/H14.ts
+++ b/data/E-Card/Skyridge/H14.ts
@@ -8,18 +8,16 @@ const card: Card = {
 	},
 
 	illustrator: "Hikaru Koike",
-	rarity: "Rare",
+	rarity: "Holo Rare",
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		166,
-	],
+	dexId: [166],
 
 	hp: 70,
 
 	types: [
-		"Grass",
+		"Grass"
 	],
 
 	evolveFrom: {
@@ -38,7 +36,7 @@ const card: Card = {
 				de: "Pollenschild"
 			},
 			effect: {
-				en: "During your opponent's next turn, Ledian can't become affected by a Special Condition. (Any other effect of attacks, Poké",
+				en: "During your opponent's next turn, Ledian can't become affected by a Special Condition. (Any other effects of attacks, Poké-Powers, Poké-Bodies, and Trainer cards still happen.)",
 				de: "Während des nächsten gegnerischen Zugs kann Ledian nicht von speziellen Zuständen betroffen werden. (Alle anderen Effekte von Angriffen, Poke-Powers, Poke-Bodies und Trainerkarten finden immer noch statt.)"
 			},
 			damage: 10,
@@ -66,20 +64,19 @@ const card: Card = {
 	weaknesses: [
 		{
 			type: "Fire",
-			value: "×2"
+			value: "x2"
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 275273,
-		tcgplayer: 86690
-	},
-
 	variants: [
 		{
 			type: 'holo',
-		}
-	]
+			thirdParty: {
+				tcgplayer: 86690,
+				cardmarket: 275273
+			},
+		},
+	],
+	retreat: 0,
 }
 
 export default card

--- a/data/E-Card/Skyridge/H15.ts
+++ b/data/E-Card/Skyridge/H15.ts
@@ -8,18 +8,16 @@ const card: Card = {
 	},
 
 	illustrator: "Naoyo Kimura",
-	rarity: "Rare",
+	rarity: "Holo Rare",
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		68,
-	],
+	dexId: [68],
 
 	hp: 120,
 
 	types: [
-		"Fighting",
+		"Fighting"
 	],
 
 	evolveFrom: {
@@ -74,7 +72,7 @@ const card: Card = {
 				en: "Flip 4 coins. This attack does 30 damage times the number of heads.",
 				de: "Wirf 4 Münzen. Dieser Angriff fügt 30 Schadenspunkte mal der Anzahl \"Kopf\" zu."
 			},
-			damage: "30x",
+			damage: "30×",
 
 		},
 	],
@@ -82,22 +80,21 @@ const card: Card = {
 	weaknesses: [
 		{
 			type: "Psychic",
-			value: "×2"
+			value: "x2"
 		},
 	],
 	retreat: 2,
 
 
-	thirdParty: {
-		cardmarket: 275274,
-		tcgplayer: 86958
-	},
-
 	variants: [
 		{
 			type: 'holo',
-		}
-	]
+			thirdParty: {
+				tcgplayer: 86958,
+				cardmarket: 275274
+			},
+		},
+	],
 }
 
 export default card

--- a/data/E-Card/Skyridge/H16.ts
+++ b/data/E-Card/Skyridge/H16.ts
@@ -8,18 +8,16 @@ const card: Card = {
 	},
 
 	illustrator: "Hajime Kusajima",
-	rarity: "Rare",
+	rarity: "Holo Rare",
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		219,
-	],
+	dexId: [219],
 
 	hp: 80,
 
 	types: [
-		"Fire",
+		"Fire"
 	],
 
 	evolveFrom: {
@@ -39,7 +37,7 @@ const card: Card = {
 				de: "Ausbruch"
 			},
 			effect: {
-				en: "Each player discards the top card of his or her deck. This attack does 20 damage plus 20 more damage for each Energy card discarded in this way.",
+				en: "Each player discard the top card of his or her deck. This attack does 20 damage plus 20 more damage for each Fire Energy card discarded in this way.",
 				de: "Jeder Spieler legt die oberste Karte seines Decks auf seinen Ablagestapel. Dieser Angriff fügt 20 Schadenspunkte plus 20 weitere Schadenspunkte für jede auf diese Weise abgelegte -Energiekarte zu."
 			},
 			damage: "20+",
@@ -57,7 +55,7 @@ const card: Card = {
 				de: "Feuerstrom"
 			},
 			effect: {
-				en: "Discard a Energy card attached to Magcargo in order to use this attack. If your opponent has any Benched Pokémon, this attack does 10 damage to each of them. (Don't apply Weakness or Resistance for Benched Pokémon.)",
+				en: "Discard a Fire Energy card attached to Magcargo in order to use this attack. If your opponent has any Benched Pokémon, this attack does 10 damage to each of them. (Don't apply Weakness and Resistance for Benched Pokémon.)",
 				de: "Lege eine an Magcargo angelegte -Energiekarte auf deinen Ablagestapel, um diesen Angriff zu verwenden. Wenn dein Gegner über Pokémon auf der Bank verfügt, fügt dieser Angriff jedem von ihnen 10 Schadenspunkte zu. (Wende keine Schwäche oder Resistenz bei Pokémon auf der Bank an.)"
 			},
 			damage: 60,
@@ -68,22 +66,21 @@ const card: Card = {
 	weaknesses: [
 		{
 			type: "Water",
-			value: "×2"
+			value: "x2"
 		},
 	],
 	retreat: 3,
 
 
-	thirdParty: {
-		cardmarket: 275276,
-		tcgplayer: 87008
-	},
-
 	variants: [
 		{
 			type: 'holo',
-		}
-	]
+			thirdParty: {
+				tcgplayer: 87008,
+				cardmarket: 275276
+			},
+		},
+	],
 }
 
 export default card

--- a/data/E-Card/Skyridge/H17.ts
+++ b/data/E-Card/Skyridge/H17.ts
@@ -8,18 +8,16 @@ const card: Card = {
 	},
 
 	illustrator: "Mitsuhiro Arita",
-	rarity: "Rare",
+	rarity: "Holo Rare",
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		219,
-	],
+	dexId: [219],
 
 	hp: 80,
 
 	types: [
-		"Fighting",
+		"Fighting"
 	],
 
 	evolveFrom: {
@@ -36,7 +34,7 @@ const card: Card = {
 				de: "Fließende Umhüllung"
 			},
 			effect: {
-				en: "When you play Magcargo from your hand to evolve your Active Pokémon, you may discard the top 3 cards of your deck and then shuffle 3 basic energy cards from your discard pile into your deck. If you do, your opponent must do the same.",
+				en: "When you play Magcargo from your hand to evolve your Active Pokémon, you may discard the top 3 cards of your deck and and then shuffle 3 basic Energy cards from your discard pile into your deck. If you do, your opponent does the same.",
 				de: "Wenn du Magcargo aus deiner Hand spielst, um dein aktives Pokémon zu entwickeln, kannst du die obersten 3 Karten deines Decks auf deinen Ablagestapel legen und dann 3 Basis-Energiekarten aus deinem Ablagestapel in dein Deck mischen. Falls du dies tust, tut es dein Gegner ebenfalls."
 			},
 		},
@@ -54,7 +52,7 @@ const card: Card = {
 				de: "Erdrückende Lava"
 			},
 			effect: {
-				en: "You may discard a or basic Energy card attached to Magcargo. If you discard a Energy card in this way, the Defending Pokémon is now Burned. If you discard a Energy card in this way, this attack does 40 damage plus 20 more damage.",
+				en: "You may discard a Fire or Fighting basic Energy card attached to Magcargo. If you discard a Fire Energy card in this way, the Defending Pokémon is now Burned. If you discard a Fighting Energy card in this way, this attack does 40 damage plus 20 more damage.",
 				de: "Du kannst eine an Magcargo angelegte - oder -Basis-Energiekarte auf deinen Ablagestapel legen. Legst du auf diese Weise eine -Energiekarte auf deinen Ablagestapel, ist das verteidigende Pokémon jetzt verbrannt. Legst du auf diese Weise eine -Energiekarte auf deinen Ablagestapel, fügt dieser Angriff 40 Schadenspunkte plus 20 weitere Schadenspunkte zu."
 			},
 			damage: "40+",
@@ -65,22 +63,21 @@ const card: Card = {
 	weaknesses: [
 		{
 			type: "Water",
-			value: "×2"
+			value: "x2"
 		},
 	],
 	retreat: 3,
 
 
-	thirdParty: {
-		cardmarket: 275276,
-		tcgplayer: 87010
-	},
-
 	variants: [
 		{
 			type: 'holo',
-		}
-	]
+			thirdParty: {
+				tcgplayer: 87010,
+				cardmarket: 275276
+			},
+		},
+	],
 }
 
 export default card

--- a/data/E-Card/Skyridge/H18.ts
+++ b/data/E-Card/Skyridge/H18.ts
@@ -8,18 +8,16 @@ const card: Card = {
 	},
 
 	illustrator: "Hajime Kusajima",
-	rarity: "Rare",
+	rarity: "Holo Rare",
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		82,
-	],
+	dexId: [82],
 
 	hp: 80,
 
 	types: [
-		"Lightning",
+		"Lightning"
 	],
 
 	evolveFrom: {
@@ -54,7 +52,7 @@ const card: Card = {
 				de: "Elektrischer Strahl"
 			},
 			effect: {
-				en: "You may discard all Energy cards attached to Magneton when you use this attack. If you do, put damage counters equal to the amount of Energy cards removed in this way on any number of your opponent's Benched Pokémon in the way you like. (For example, if you discard 3 Energy cards, you can put 1 damage counter on 1 of your opponent's Benched Pokémon and 2 on another.)",
+				en: "You may discard all Lightning Energy cards attached to Magneton when you use this attack. If you do, put damage counters equal to the amount of Energy cards removed in this way on any number of your opponent's Benched Pokémon in the way you like. (For example, if you discard 3 Lightning Energy cards, you can put 1 damage counter on 1 of your opponent's Benched Pokémon and 2 on another.)",
 				de: "Du kannst alle an Magneton angelegten -Energiekarten auf deinen Ablagestapel legen, wenn du diesen Angriff verwendest. Falls du dies tust, verteile so viele Schadensmarken, wie du auf diese Weise Energiekarten abgelegt hast, in beliebiger Weise auf eine beliebige Anzahl an Pokémon auf der Bank deines Gegners. (Legst du zum Beispiel 3 -Energiekarten auf den Ablagestapel, kannst du 1 Schadensmarke auf eins der Pokémon auf der Bank deines Gegners und 2 Marken auf ein anderes legen.)"
 			},
 			damage: 40,
@@ -65,22 +63,21 @@ const card: Card = {
 	weaknesses: [
 		{
 			type: "Fighting",
-			value: "×2"
+			value: "x2"
 		},
 	],
 	retreat: 1,
 
 
-	thirdParty: {
-		cardmarket: 275277,
-		tcgplayer: 87095
-	},
-
 	variants: [
 		{
 			type: 'holo',
-		}
-	]
+			thirdParty: {
+				tcgplayer: 87095,
+				cardmarket: 275277
+			},
+		},
+	],
 }
 
 export default card

--- a/data/E-Card/Skyridge/H19.ts
+++ b/data/E-Card/Skyridge/H19.ts
@@ -7,19 +7,17 @@ const card: Card = {
 		de: "Magneton"
 	},
 
-	illustrator: "Hajime Kusajima",
-	rarity: "Rare",
+	illustrator: "Kouki Saitou",
+	rarity: "Holo Rare",
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		82,
-	],
+	dexId: [82],
 
-	hp: 80,
+	hp: 70,
 
 	types: [
-		"Lightning",
+		"Metal"
 	],
 
 	evolveFrom: {
@@ -56,7 +54,7 @@ const card: Card = {
 				de: "Magnetwelle"
 			},
 			effect: {
-				en: "This attack does 30 damage plus 10 more damage times the number of your Benched Pokémon minus the number of your opponent's Benched Pokémon. (For example, if your opponent has 1 Benched Pokémon and you have 3, this attack will do 30 damage plus 20 more damage.)",
+				en: "This attack does 30 damage plus 10 damage times the number of your Benched Pokémon minus the number of your opponent's Benched Pokémon. (For example, if your opponent has 1 Benched Pokémon and you have 3, this attack will do 30 damage plus 20 more damage.)",
 				de: "Dieser Angriff fügt 30 Schadenspunkte plus 10 weitere Schadenspunkte für jedes Pokémon auf deiner Bank minus 10 Schadenspunkte für jedes Pokémon auf der Bank deines Gegners zu. (Hat zum Beispiel dein Gegner 1 Pokémon auf seiner Bank und du 3 auf deiner, fügt dieser Angriff 30 Schadenspunkte plus 20 weitere Schadenspunkte zu.)"
 			},
 			damage: "30+",
@@ -66,11 +64,10 @@ const card: Card = {
 
 	weaknesses: [
 		{
-			type: "Fighting",
-			value: "×2"
+			type: "Fire",
+			value: "x2"
 		},
 	],
-
 	resistances: [
 		{
 			type: "Grass",
@@ -80,16 +77,15 @@ const card: Card = {
 	retreat: 2,
 
 
-	thirdParty: {
-		cardmarket: 275277,
-		tcgplayer: 87096
-	},
-
 	variants: [
 		{
 			type: 'holo',
-		}
-	]
+			thirdParty: {
+				tcgplayer: 87096,
+				cardmarket: 275277
+			},
+		},
+	],
 }
 
 export default card

--- a/data/E-Card/Skyridge/H20.ts
+++ b/data/E-Card/Skyridge/H20.ts
@@ -8,18 +8,16 @@ const card: Card = {
 	},
 
 	illustrator: "Kouki Saitou",
-	rarity: "Rare",
+	rarity: "Holo Rare",
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		146,
-	],
+	dexId: [146],
 
 	hp: 80,
 
 	types: [
-		"Fire",
+		"Fire"
 	],
 
 	stage: "Basic",
@@ -48,7 +46,7 @@ const card: Card = {
 				de: "Feuersammeln"
 			},
 			effect: {
-				en: "If there are any Energy cards in your discard pile, flip a coin. If heads, attach 1 of them to Moltres.",
+				en: "If there are any Fire Energy cards in your discard pile, flip a coin. If heads, attach 1 of them to Moltres.",
 				de: "Wenn mindestens eine -Energiekarte in deinem Ablagestapel ist, wirf eine Münze. Lege bei \"Kopf\" eine davon an Lavados an."
 			},
 			damage: 10,
@@ -66,7 +64,7 @@ const card: Card = {
 				de: "Brennender Schweif"
 			},
 			effect: {
-				en: "Flip a coin. If tails, discard a Energy card attached to Moltres.",
+				en: "Flip a coin. If tails, discard a Fire Energy card attached to Moltres.",
 				de: "Wirf eine Münze. Lege bei \"Zahl\" eine an Lavados angelegte -Energiekarte auf deinen Ablagestapel."
 			},
 			damage: 60,
@@ -77,10 +75,9 @@ const card: Card = {
 	weaknesses: [
 		{
 			type: "Water",
-			value: "×2"
+			value: "x2"
 		},
 	],
-
 	resistances: [
 		{
 			type: "Fighting",
@@ -90,16 +87,15 @@ const card: Card = {
 	retreat: 2,
 
 
-	thirdParty: {
-		cardmarket: 275279,
-		tcgplayer: 87556
-	},
-
 	variants: [
 		{
 			type: 'holo',
-		}
-	]
+			thirdParty: {
+				tcgplayer: 87556,
+				cardmarket: 275279
+			},
+		},
+	],
 }
 
 export default card

--- a/data/E-Card/Skyridge/H21.ts
+++ b/data/E-Card/Skyridge/H21.ts
@@ -8,18 +8,16 @@ const card: Card = {
 	},
 
 	illustrator: "Mitsuhiro Arita",
-	rarity: "Rare",
+	rarity: "Holo Rare",
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		31,
-	],
+	dexId: [31],
 
 	hp: 110,
 
 	types: [
-		"Grass",
+		"Grass"
 	],
 
 	evolveFrom: {
@@ -36,7 +34,7 @@ const card: Card = {
 				de: "Evolutions-Helfer"
 			},
 			effect: {
-				en: "Once during your turn (before you attack) if Nidoqueen is on your bench, you may search your deck for a card that evolves from your Active Pokémon and attach it to your Active Pokémon. (this counts as evolving that Pokémon) Shuffle your deck afterward.",
+				en: "Once during your turn (before your attack), if Nidoqueen is on your Bench, you may search your deck for a card that evolves from your Active Pokémon and attach it to your Active Pokémon. (This counts as evolving that Pokémon.) Shuffle your deck afterward.",
 				de: "Einmal während deines Zuges (vor deinem Angriff) kannst du, falls Nidoqueen auf deiner Bank ist, dein Deck nach einer Karte durchsuchen, die sich aus deinem aktiven Pokémon entwickelt, und sie an dein aktives Pokémon anlegen. (Dies zählt als Entwickeln dieses Pokémon.) Mische dein Deck danach."
 			},
 		},
@@ -54,7 +52,7 @@ const card: Card = {
 				de: "Doppelkralle"
 			},
 			effect: {
-				en: "Flip 2 coins. This attack does 30 damage plus 20 more damage for each heads.",
+				en: "Flip 2 coins. This attack does 30 damage plus 20 more damage for each heads",
 				de: "Wirf 2 Münzen. Dieser Angriff fügt 30 Schadenspunkte plus 20 weitere Schadenspunkte pro geworfenem \"Kopf\" zu."
 			},
 			damage: "30+",
@@ -65,22 +63,21 @@ const card: Card = {
 	weaknesses: [
 		{
 			type: "Psychic",
-			value: "×2"
+			value: "x2"
 		},
 	],
 	retreat: 3,
 
 
-	thirdParty: {
-		cardmarket: 275280,
-		tcgplayer: 87703
-	},
-
 	variants: [
 		{
 			type: 'holo',
-		}
-	]
+			thirdParty: {
+				tcgplayer: 87703,
+				cardmarket: 275280
+			},
+		},
+	],
 }
 
 export default card

--- a/data/E-Card/Skyridge/H22.ts
+++ b/data/E-Card/Skyridge/H22.ts
@@ -8,18 +8,16 @@ const card: Card = {
 	},
 
 	illustrator: "Yuka Morii",
-	rarity: "Rare",
+	rarity: "Holo Rare",
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		221,
-	],
+	dexId: [221],
 
 	hp: 90,
 
 	types: [
-		"Water",
+		"Water"
 	],
 
 	evolveFrom: {
@@ -69,22 +67,21 @@ const card: Card = {
 	weaknesses: [
 		{
 			type: "Metal",
-			value: "×2"
+			value: "x2"
 		},
 	],
 	retreat: 3,
 
 
-	thirdParty: {
-		cardmarket: 275301,
-		tcgplayer: 88112
-	},
-
 	variants: [
 		{
 			type: 'holo',
-		}
-	]
+			thirdParty: {
+				tcgplayer: 88112,
+				cardmarket: 275301
+			},
+		},
+	],
 }
 
 export default card

--- a/data/E-Card/Skyridge/H23.ts
+++ b/data/E-Card/Skyridge/H23.ts
@@ -8,18 +8,16 @@ const card: Card = {
 	},
 
 	illustrator: "Atsuko Nishida",
-	rarity: "Rare",
+	rarity: "Holo Rare",
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		186,
-	],
+	dexId: [186],
 
 	hp: 110,
 
 	types: [
-		"Water",
+		"Water"
 	],
 
 	evolveFrom: {
@@ -73,7 +71,7 @@ const card: Card = {
 				de: "Energieplatscher"
 			},
 			effect: {
-				en: "Move 2 Energy cards attached to Politoed to 1 or 2 of your Benched Pokémon. (You may put both on the same Pokémon, or 1 each on 2 different Pokémon.) If you have no Benched Pokémon, ignore this effect.",
+				en: "Move 2 Water Energy cards attached to Politoed to 1 or 2 of your Benched Pokémon. (You may put both on the same Pokémon or 1 each on 2 different Pokémon.) If you have no Benched Pokémon, ignore this effect.",
 				de: "Lege 2 an Quaxo angelegte -Energiekarten an 1 oder 2 der Pokémon auf deiner Bank an. (Du kannst beide an dasselbe Pokémon anlegen oder je 1 an 2 verschiedene Pokémon.) Hast du keine Pokémon auf deiner Bank, ignoriere diesen Effekt."
 			},
 			damage: 70,
@@ -84,22 +82,21 @@ const card: Card = {
 	weaknesses: [
 		{
 			type: "Lightning",
-			value: "×2"
+			value: "x2"
 		},
 	],
 	retreat: 2,
 
 
-	thirdParty: {
-		cardmarket: 275283,
-		tcgplayer: 88247
-	},
-
 	variants: [
 		{
 			type: 'holo',
-		}
-	]
+			thirdParty: {
+				tcgplayer: 88247,
+				cardmarket: 275283
+			},
+		},
+	],
 }
 
 export default card

--- a/data/E-Card/Skyridge/H24.ts
+++ b/data/E-Card/Skyridge/H24.ts
@@ -8,18 +8,16 @@ const card: Card = {
 	},
 
 	illustrator: "Naoyo Kimura",
-	rarity: "Rare",
+	rarity: "Holo Rare",
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		62,
-	],
+	dexId: [62],
 
 	hp: 110,
 
 	types: [
-		"Fighting",
+		"Fighting"
 	],
 
 	evolveFrom: {
@@ -36,7 +34,7 @@ const card: Card = {
 				de: "Seltsame Spirale"
 			},
 			effect: {
-				en: "Once during your turn (before you attack), if Poliwrath if your Active Pokémon, you may discard a basic Energy card attached to Poliwrath. If you do, the Defending Pokémon is now Confused. This power can't be used if Poliwrath is affected by a Special Condition.",
+				en: "Once during your turn (before your attack), if Poliwrath is your Active Pokémon, you may discard a basic Energy card attached to Poliwrath. If you do, the Defending Pokémon is now Confused. This power can't be used if Poliwrath is affected by a Special Condition.",
 				de: "Einmal während deines Zuges (vor deinem Angriff) kannst du, falls Quappo dein aktives Pokémon ist, eine an Quappo angelegte Basis-Energiekarte auf deinen Ablagestapel legen. Falls du dies tust, ist das verteidigende Pokémon jetzt verwirrt. Fähigkeit kann nicht verwendet werden, falls Quappo von einem speziellen Zustand betroffen ist."
 			},
 		},
@@ -65,22 +63,21 @@ const card: Card = {
 	weaknesses: [
 		{
 			type: "Psychic",
-			value: "×2"
+			value: "x2"
 		},
 	],
 	retreat: 2,
 
 
-	thirdParty: {
-		cardmarket: 275284,
-		tcgplayer: 88272
-	},
-
 	variants: [
 		{
 			type: 'holo',
-		}
-	]
+			thirdParty: {
+				tcgplayer: 88272,
+				cardmarket: 275284
+			},
+		},
+	],
 }
 
 export default card

--- a/data/E-Card/Skyridge/H25.ts
+++ b/data/E-Card/Skyridge/H25.ts
@@ -8,18 +8,16 @@ const card: Card = {
 	},
 
 	illustrator: "Yuka Morii",
-	rarity: "Rare",
+	rarity: "Holo Rare",
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		26,
-	],
+	dexId: [26],
 
 	hp: 80,
 
 	types: [
-		"Lightning",
+		"Lightning"
 	],
 
 	evolveFrom: {
@@ -39,7 +37,7 @@ const card: Card = {
 				de: "Zzzapp!"
 			},
 			effect: {
-				en: "This attack does 20 damage to each Pokémon with a Poké",
+				en: "This attack does 20 damage to each Pokémon with a Poké-Body or Poké-Power (yours and your opponent's). (Don't apply Weakness or Resistance.)",
 				de: "Dieser Angriff fügt jedem Pokémon mit einem Poké-Body oder einer Poké-Power 20 Schadenspunkte zu (deinen und den gegnerischen Pokémon). (Wende keine Schwäche oder Resistenz an.)"
 			},
 
@@ -66,22 +64,21 @@ const card: Card = {
 	weaknesses: [
 		{
 			type: "Fighting",
-			value: "×2"
+			value: "x2"
 		},
 	],
 	retreat: 1,
 
 
-	thirdParty: {
-		cardmarket: 275285,
-		tcgplayer: 88502
-	},
-
 	variants: [
 		{
 			type: 'holo',
-		}
-	]
+			thirdParty: {
+				tcgplayer: 88502,
+				cardmarket: 275285
+			},
+		},
+	],
 }
 
 export default card

--- a/data/E-Card/Skyridge/H26.ts
+++ b/data/E-Card/Skyridge/H26.ts
@@ -8,18 +8,16 @@ const card: Card = {
 	},
 
 	illustrator: "Mitsuhiro Arita",
-	rarity: "Rare",
+	rarity: "Holo Rare",
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		243,
-	],
+	dexId: [243],
 
 	hp: 70,
 
 	types: [
-		"Lightning",
+		"Lightning"
 	],
 
 	stage: "Basic",
@@ -32,7 +30,7 @@ const card: Card = {
 				de: "Reiner Körper"
 			},
 			effect: {
-				en: "To attach a Lightning Energy card from your hand to Raikou, you must discard an Energy card attached to Raikou. (Attach the Lightning energy, and then discard an Energy card from Raikou.)",
+				en: "To attach a Lightning Energy card from your hand to Raikou, you must discard an Energy card attached to Raikou. (Attach the Lightning Energy, and then discard an Energy card from Raikou.)",
 				de: "Um eine -Energiekarte aus deiner Hand an Raikou anzulegen, musst du eine an Raikou angelegte Energiekarte auf deinen Ablagestapel legen. (Lege erst die -Energiekarten an, dann eine an Raikou angelegte Energiekarte auf den Ablagestapel.)"
 			},
 		},
@@ -50,7 +48,7 @@ const card: Card = {
 				de: "Blitz-Spähre"
 			},
 			effect: {
-				en: "You may flip a coin. If heads, discard all Energy cards attached to Raikou. This attack does 40 damage plus 20 more damage for each Energy card discarded in this way.",
+				en: "You may flip a coin. If heads, discard all Lightning Energy cards attached to Raikou. This attack does 40 damage plus 20 more damage for each Energy card discarded in this way.",
 				de: "Du kannst eine Münze werfen. Lege bei 'Kopf' alle an Raikou angelegten -Energiekarten auf deinen Ablagestapel. Dieser Angriff fügt 40 Schadenspunkte plus 20 weitere Schadenspunkte für jede auf diese Weise abgelegte Energiekarten zu."
 			},
 			damage: "40+",
@@ -60,23 +58,22 @@ const card: Card = {
 
 	weaknesses: [
 		{
-			type: "Fire",
-			value: "×2"
+			type: "Fighting",
+			value: "x2"
 		},
 	],
 	retreat: 1,
 
 
-	thirdParty: {
-		cardmarket: 275286,
-		tcgplayer: 88531
-	},
-
 	variants: [
 		{
 			type: 'holo',
-		}
-	]
+			thirdParty: {
+				tcgplayer: 88531,
+				cardmarket: 275286
+			},
+		},
+	],
 }
 
 export default card

--- a/data/E-Card/Skyridge/H27.ts
+++ b/data/E-Card/Skyridge/H27.ts
@@ -8,18 +8,16 @@ const card: Card = {
 	},
 
 	illustrator: "Mitsuhiro Arita",
-	rarity: "Rare",
+	rarity: "Holo Rare",
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		112,
-	],
+	dexId: [112],
 
 	hp: 90,
 
 	types: [
-		"Fighting",
+		"Fighting"
 	],
 
 	evolveFrom: {
@@ -65,17 +63,16 @@ const card: Card = {
 				de: "Wirf eine Münze. Bei 'Zahl' hat dieser Angriff keine Auswirkungen."
 			},
 
-			damage: 100
+			damage: 100,
 		},
 	],
 
 	weaknesses: [
 		{
 			type: "Grass",
-			value: "×2"
+			value: "x2"
 		},
 	],
-
 	resistances: [
 		{
 			type: "Lightning",
@@ -85,16 +82,15 @@ const card: Card = {
 	retreat: 2,
 
 
-	thirdParty: {
-		cardmarket: 275287,
-		tcgplayer: 88728
-	},
-
 	variants: [
 		{
 			type: 'holo',
-		}
-	]
+			thirdParty: {
+				tcgplayer: 88728,
+				cardmarket: 275287
+			},
+		},
+	],
 }
 
 export default card

--- a/data/E-Card/Skyridge/H28.ts
+++ b/data/E-Card/Skyridge/H28.ts
@@ -8,18 +8,16 @@ const card: Card = {
 	},
 
 	illustrator: "Hajime Kusajima",
-	rarity: "Rare",
+	rarity: "Holo Rare",
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		121,
-	],
+	dexId: [121],
 
 	hp: 80,
 
 	types: [
-		"Psychic",
+		"Psychic"
 	],
 
 	evolveFrom: {
@@ -38,10 +36,10 @@ const card: Card = {
 				de: "Energieausbruch"
 			},
 			effect: {
-				en: "Flip a coin. If heads, this attack does 10 damage times the number of Energy cards attached to Starmie and the Defending Pokémon.",
+				en: "Flip a coin. If heads, this attack does 10 damage times the number of Energy attached to Starmie and the Defending Pokémon.",
 				de: "Wirf eine Münze. Bei 'Kopf' fügt dieser Angriff 10 Schadenspunkte mal der Anzahl an Energiekarten, die an Starmie und das Verteidigende Pokémon angelegt sind, zu."
 			},
-			damage: "10x",
+			damage: "10×",
 
 		},
 		{
@@ -66,22 +64,21 @@ const card: Card = {
 	weaknesses: [
 		{
 			type: "Psychic",
-			value: "×2"
+			value: "x2"
 		},
 	],
 	retreat: 1,
 
 
-	thirdParty: {
-		cardmarket: 275288,
-		tcgplayer: 89528
-	},
-
 	variants: [
 		{
 			type: 'holo',
-		}
-	]
+			thirdParty: {
+				tcgplayer: 89528,
+				cardmarket: 275288
+			},
+		},
+	],
 }
 
 export default card

--- a/data/E-Card/Skyridge/H29.ts
+++ b/data/E-Card/Skyridge/H29.ts
@@ -8,18 +8,16 @@ const card: Card = {
 	},
 
 	illustrator: "Hikaru Koike",
-	rarity: "Rare",
+	rarity: "Holo Rare",
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		208,
-	],
+	dexId: [208],
 
 	hp: 100,
 
 	types: [
-		"Metal",
+		"Metal"
 	],
 
 	evolveFrom: {
@@ -78,17 +76,16 @@ const card: Card = {
 				de: "Bevor der Schaden zugefügt wird, kannst du eine Münze werfen. Bei 'Kopf' fügt dieser Angriff 80 Schadenspunkte zu. Bei 'Zahl' hat dieser Angriff keine Wirkung."
 			},
 
-			damage: 40
+			damage: 40,
 		},
 	],
 
 	weaknesses: [
 		{
 			type: "Fire",
-			value: "×2"
+			value: "x2"
 		},
 	],
-
 	resistances: [
 		{
 			type: "Grass",
@@ -98,16 +95,15 @@ const card: Card = {
 	retreat: 4,
 
 
-	thirdParty: {
-		cardmarket: 275289,
-		tcgplayer: 89558
-	},
-
 	variants: [
 		{
 			type: 'holo',
-		}
-	]
+			thirdParty: {
+				tcgplayer: 89558,
+				cardmarket: 275289
+			},
+		},
+	],
 }
 
 export default card

--- a/data/E-Card/Skyridge/H30.ts
+++ b/data/E-Card/Skyridge/H30.ts
@@ -8,18 +8,16 @@ const card: Card = {
 	},
 
 	illustrator: "Atsuko Nishida",
-	rarity: "Rare",
+	rarity: "Holo Rare",
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		197,
-	],
+	dexId: [197],
 
 	hp: 70,
 
 	types: [
-		"Darkness",
+		"Darkness"
 	],
 
 	evolveFrom: {
@@ -64,10 +62,9 @@ const card: Card = {
 	weaknesses: [
 		{
 			type: "Fighting",
-			value: "×2"
+			value: "x2"
 		},
 	],
-
 	resistances: [
 		{
 			type: "Psychic",
@@ -77,16 +74,15 @@ const card: Card = {
 	retreat: 1,
 
 
-	thirdParty: {
-		cardmarket: 275290,
-		tcgplayer: 90140
-	},
-
 	variants: [
 		{
 			type: 'holo',
-		}
-	]
+			thirdParty: {
+				tcgplayer: 90140,
+				cardmarket: 275290
+			},
+		},
+	],
 }
 
 export default card

--- a/data/E-Card/Skyridge/H31.ts
+++ b/data/E-Card/Skyridge/H31.ts
@@ -8,18 +8,16 @@ const card: Card = {
 	},
 
 	illustrator: "Naoyo Kimura",
-	rarity: "Rare",
+	rarity: "Holo Rare",
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		134,
-	],
+	dexId: [134],
 
 	hp: 70,
 
 	types: [
-		"Water",
+		"Water"
 	],
 
 	evolveFrom: {
@@ -32,7 +30,7 @@ const card: Card = {
 		{
 			type: "Poke-BODY",
 			name: {
-				en: "Self Healing",
+				en: "Self-healing",
 				de: "Selbstheilung"
 			},
 			effect: {
@@ -81,22 +79,21 @@ const card: Card = {
 	weaknesses: [
 		{
 			type: "Lightning",
-			value: "×2"
+			value: "x2"
 		},
 	],
 	retreat: 1,
 
 
-	thirdParty: {
-		cardmarket: 275252,
-		tcgplayer: 90280
-	},
-
 	variants: [
 		{
 			type: 'holo',
-		}
-	]
+			thirdParty: {
+				tcgplayer: 90280,
+				cardmarket: 275252
+			},
+		},
+	],
 }
 
 export default card

--- a/data/E-Card/Skyridge/H32.ts
+++ b/data/E-Card/Skyridge/H32.ts
@@ -8,18 +8,16 @@ const card: Card = {
 	},
 
 	illustrator: "Atsuko Nishida",
-	rarity: "Rare",
+	rarity: "Holo Rare",
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		178,
-	],
+	dexId: [178],
 
 	hp: 80,
 
 	types: [
-		"Psychic",
+		"Psychic"
 	],
 
 	evolveFrom: {
@@ -65,22 +63,21 @@ const card: Card = {
 	weaknesses: [
 		{
 			type: "Psychic",
-			value: "×2"
+			value: "x2"
 		},
 	],
 	retreat: 1,
 
 
-	thirdParty: {
-		cardmarket: 275293,
-		tcgplayer: 90658
-	},
-
 	variants: [
 		{
 			type: 'holo',
-		}
-	]
+			thirdParty: {
+				tcgplayer: 90658,
+				cardmarket: 275293
+			},
+		},
+	],
 }
 
 export default card


### PR DESCRIPTION
closes #n/a

## Changes

- add variants using new third party format
- moved old thirdparty variants into per variant format

## Details

- some german cards had (alpha), (gamma) and (beta). changed card names these to match what is shown on card (α, γ, β)
- added jumbo cracked ice box toppers 

