### PR TITLE
(data) en ex-tk-latia EX Trainer Kit Latias - added card variants 

### DIFF
--- a/data/Trainer kits/EX trainer Kit (Latias).ts
+++ b/data/Trainer kits/EX trainer Kit (Latias).ts
@@ -26,6 +26,7 @@ const set: Set = {
 	},
 
 	thirdParty: {
+		cardmarket: 275771,
 		tcgplayer: 1543
 	}
 }

--- a/data/Trainer kits/EX trainer Kit (Latias)/1.ts
+++ b/data/Trainer kits/EX trainer Kit (Latias)/1.ts
@@ -11,7 +11,7 @@ const card: Card = {
 	},
 
 	illustrator: "Ken Sugimori",
-	rarity: "Common",
+	rarity: "None",
 	category: "Pokemon",
 	stage: "Basic",
 	hp: 40,

--- a/data/Trainer kits/EX trainer Kit (Latias)/1.ts
+++ b/data/Trainer kits/EX trainer Kit (Latias)/1.ts
@@ -48,6 +48,7 @@ const card: Card = {
 		{
 			type: "normal",
 			thirdParty: {
+				cardmarket: 275777,
 				tcgplayer: 83694
 			}
 		},

--- a/data/Trainer kits/EX trainer Kit (Latias)/1.ts
+++ b/data/Trainer kits/EX trainer Kit (Latias)/1.ts
@@ -11,41 +11,48 @@ const card: Card = {
 	},
 
 	illustrator: "Ken Sugimori",
-	rarity: "None",
+	rarity: "Common",
 	category: "Pokemon",
 	stage: "Basic",
 	hp: 40,
 
 	types: [
-		"Colorless",
+		"Colorless"
 	],
 
-	attacks: [{
-		cost: [
-			"Colorless",
-		],
-		name: {
-			en: "Headbutt",
-			fr: "Coup d'boule"
-		},
-		damage: 10
-	}, {
-		cost: [
-			"Fire",
-			"Colorless"
-		],
-		name: {
-			en: "Flare",
-			fr: "Enflammer"
-		},
-		damage: 20
-	}],
+	attacks: [
+		{
+			cost: [
+				"Colorless",
+			],
+			name: {
+				en: "Headbutt",
+				fr: "Coup d'boule"
+			},
+			damage: 10
+		}, {
+			cost: [
+				"Fire",
+				"Colorless"
+			],
+			name: {
+				en: "Flare",
+				fr: "Enflammer"
+			},
+			damage: 20
+		}],
 
 	retreat: 1,
 
-	thirdParty: {
-		tcgplayer: 83694
-	}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 83694
+			}
+		},
+	],
+
 }
 
 export default card

--- a/data/Trainer kits/EX trainer Kit (Latias)/10.ts
+++ b/data/Trainer kits/EX trainer Kit (Latias)/10.ts
@@ -21,6 +21,7 @@ const card: Card = {
 		{
 			type: "normal",
 			thirdParty: {
+				cardmarket: 275771,
 				tcgplayer: 85457
 			}
 		},

--- a/data/Trainer kits/EX trainer Kit (Latias)/10.ts
+++ b/data/Trainer kits/EX trainer Kit (Latias)/10.ts
@@ -7,8 +7,7 @@ const card: Card = {
 		fr: "Énergie Feu"
 	},
 
-	illustrator: "",
-	rarity: "Common",
+	rarity: "None",
 	category: "Energy",
 	set: Set,
 	stage: "Basic",

--- a/data/Trainer kits/EX trainer Kit (Latias)/10.ts
+++ b/data/Trainer kits/EX trainer Kit (Latias)/10.ts
@@ -8,15 +8,25 @@ const card: Card = {
 	},
 
 	illustrator: "",
-	rarity: "None",
+	rarity: "Common",
 	category: "Energy",
 	set: Set,
 	stage: "Basic",
 	energyType: "Normal",
 
-	thirdParty: {
-		tcgplayer: 85457
-	}
+	types: [
+		"Fire"
+	],
+	retreat: 0,
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 85457
+			}
+		},
+	],
+
 }
 
 export default card

--- a/data/Trainer kits/EX trainer Kit (Latias)/2.ts
+++ b/data/Trainer kits/EX trainer Kit (Latias)/2.ts
@@ -11,13 +11,13 @@ const card: Card = {
 	},
 
 	illustrator: "Kouki Saitou",
-	rarity: "None",
+	rarity: "Common",
 	category: "Pokemon",
 	stage: "Stage1",
 	hp: 70,
 
 	types: [
-		"Fire",
+		"Fire"
 	],
 
 	evolveFrom: {
@@ -54,15 +54,20 @@ const card: Card = {
 	weaknesses: [
 		{
 			type: "Water",
-			value: "2x"
 		},
 	],
 
 	retreat: 1,
 
-	thirdParty: {
-		tcgplayer: 84403
-	}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 84403
+			}
+		},
+	],
+
 }
 
 export default card

--- a/data/Trainer kits/EX trainer Kit (Latias)/2.ts
+++ b/data/Trainer kits/EX trainer Kit (Latias)/2.ts
@@ -63,6 +63,7 @@ const card: Card = {
 		{
 			type: "normal",
 			thirdParty: {
+				cardmarket: 275770,
 				tcgplayer: 84403
 			}
 		},

--- a/data/Trainer kits/EX trainer Kit (Latias)/2.ts
+++ b/data/Trainer kits/EX trainer Kit (Latias)/2.ts
@@ -11,7 +11,7 @@ const card: Card = {
 	},
 
 	illustrator: "Kouki Saitou",
-	rarity: "Common",
+	rarity: "None",
 	category: "Pokemon",
 	stage: "Stage1",
 	hp: 70,

--- a/data/Trainer kits/EX trainer Kit (Latias)/3.ts
+++ b/data/Trainer kits/EX trainer Kit (Latias)/3.ts
@@ -11,7 +11,7 @@ const card: Card = {
 	},
 
 	illustrator: "Midori Harada",
-	rarity: "Common",
+	rarity: "None",
 	category: "Pokemon",
 	stage: "Stage1",
 	hp: 80,

--- a/data/Trainer kits/EX trainer Kit (Latias)/3.ts
+++ b/data/Trainer kits/EX trainer Kit (Latias)/3.ts
@@ -11,13 +11,13 @@ const card: Card = {
 	},
 
 	illustrator: "Midori Harada",
-	rarity: "None",
+	rarity: "Common",
 	category: "Pokemon",
 	stage: "Stage1",
 	hp: 80,
 
 	types: [
-		"Colorless",
+		"Colorless"
 	],
 
 	evolveFrom: {
@@ -55,15 +55,20 @@ const card: Card = {
 	weaknesses: [
 		{
 			type: "Fighting",
-			value: "2x"
 		},
 	],
 
 	retreat: 1,
 
-	thirdParty: {
-		tcgplayer: 84737
-	}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 84737
+			}
+		},
+	],
+
 }
 
 export default card

--- a/data/Trainer kits/EX trainer Kit (Latias)/3.ts
+++ b/data/Trainer kits/EX trainer Kit (Latias)/3.ts
@@ -64,6 +64,7 @@ const card: Card = {
 		{
 			type: "normal",
 			thirdParty: {
+				cardmarket: 275769,
 				tcgplayer: 84737
 			}
 		},

--- a/data/Trainer kits/EX trainer Kit (Latias)/4.ts
+++ b/data/Trainer kits/EX trainer Kit (Latias)/4.ts
@@ -58,6 +58,7 @@ const card: Card = {
 		{
 			type: "holo",
 			thirdParty: {
+				cardmarket: 275772,
 				tcgplayer: 86650
 			}
 		},

--- a/data/Trainer kits/EX trainer Kit (Latias)/4.ts
+++ b/data/Trainer kits/EX trainer Kit (Latias)/4.ts
@@ -11,13 +11,13 @@ const card: Card = {
 	},
 
 	illustrator: "Nakaoka",
-	rarity: "None",
+	rarity: "Rare",
 	category: "Pokemon",
 	stage: "Basic",
 	hp: 70,
 
 	types: [
-		"Colorless",
+		"Colorless"
 	],
 
 	attacks: [{
@@ -49,15 +49,20 @@ const card: Card = {
 	weaknesses: [
 		{
 			type: "Psychic",
-			value: "2x"
 		},
 	],
 
 	retreat: 1,
 
-	thirdParty: {
-		tcgplayer: 86650
-	}
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				tcgplayer: 86650
+			}
+		},
+	],
+
 }
 
 export default card

--- a/data/Trainer kits/EX trainer Kit (Latias)/4.ts
+++ b/data/Trainer kits/EX trainer Kit (Latias)/4.ts
@@ -11,7 +11,7 @@ const card: Card = {
 	},
 
 	illustrator: "Nakaoka",
-	rarity: "Rare",
+	rarity: "None",
 	category: "Pokemon",
 	stage: "Basic",
 	hp: 70,

--- a/data/Trainer kits/EX trainer Kit (Latias)/5.ts
+++ b/data/Trainer kits/EX trainer Kit (Latias)/5.ts
@@ -11,7 +11,7 @@ const card: Card = {
 	},
 
 	illustrator: "Yuka Morii",
-	rarity: "Common",
+	rarity: "None",
 	category: "Pokemon",
 	stage: "Basic",
 	hp: 40,

--- a/data/Trainer kits/EX trainer Kit (Latias)/5.ts
+++ b/data/Trainer kits/EX trainer Kit (Latias)/5.ts
@@ -57,6 +57,7 @@ const card: Card = {
 		{
 			type: "normal",
 			thirdParty: {
+				cardmarket: 275773,
 				tcgplayer: 87808
 			}
 		},

--- a/data/Trainer kits/EX trainer Kit (Latias)/5.ts
+++ b/data/Trainer kits/EX trainer Kit (Latias)/5.ts
@@ -11,13 +11,13 @@ const card: Card = {
 	},
 
 	illustrator: "Yuka Morii",
-	rarity: "None",
+	rarity: "Common",
 	category: "Pokemon",
 	stage: "Basic",
 	hp: 40,
 
 	types: [
-		"Fire",
+		"Fire"
 	],
 
 	attacks: [{
@@ -48,15 +48,20 @@ const card: Card = {
 	weaknesses: [
 		{
 			type: "Water",
-			value: "2x"
 		},
 	],
 
 	retreat: 1,
 
-	thirdParty: {
-		tcgplayer: 87808
-	}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 87808
+			}
+		},
+	],
+
 }
 
 export default card

--- a/data/Trainer kits/EX trainer Kit (Latias)/6.ts
+++ b/data/Trainer kits/EX trainer Kit (Latias)/6.ts
@@ -11,13 +11,13 @@ const card: Card = {
 	},
 
 	illustrator: "Atsuko Nishida",
-	rarity: "None",
+	rarity: "Common",
 	category: "Pokemon",
 	stage: "Basic",
 	hp: 50,
 
 	types: [
-		"Colorless",
+		"Colorless"
 	],
 
 	attacks: [{
@@ -48,15 +48,20 @@ const card: Card = {
 	weaknesses: [
 		{
 			type: "Fighting",
-			value: "2x"
 		},
 	],
 
 	retreat: 1,
 
-	thirdParty: {
-		tcgplayer: 89263
-	}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 89263
+			}
+		},
+	],
+
 }
 
 export default card

--- a/data/Trainer kits/EX trainer Kit (Latias)/6.ts
+++ b/data/Trainer kits/EX trainer Kit (Latias)/6.ts
@@ -11,7 +11,7 @@ const card: Card = {
 	},
 
 	illustrator: "Atsuko Nishida",
-	rarity: "Common",
+	rarity: "None",
 	category: "Pokemon",
 	stage: "Basic",
 	hp: 50,

--- a/data/Trainer kits/EX trainer Kit (Latias)/6.ts
+++ b/data/Trainer kits/EX trainer Kit (Latias)/6.ts
@@ -57,6 +57,7 @@ const card: Card = {
 		{
 			type: "normal",
 			thirdParty: {
+				cardmarket: 275776,
 				tcgplayer: 89263
 			}
 		},

--- a/data/Trainer kits/EX trainer Kit (Latias)/7.ts
+++ b/data/Trainer kits/EX trainer Kit (Latias)/7.ts
@@ -11,7 +11,7 @@ const card: Card = {
 	},
 
 	illustrator: "Hironobu Yoshida",
-	rarity: "Common",
+	rarity: "None",
 	category: "Pokemon",
 	stage: "Basic",
 	hp: 50,

--- a/data/Trainer kits/EX trainer Kit (Latias)/7.ts
+++ b/data/Trainer kits/EX trainer Kit (Latias)/7.ts
@@ -48,6 +48,7 @@ const card: Card = {
 		{
 			type: "normal",
 			thirdParty: {
+				cardmarket: 275775,
 				tcgplayer: 89954
 			}
 		},

--- a/data/Trainer kits/EX trainer Kit (Latias)/7.ts
+++ b/data/Trainer kits/EX trainer Kit (Latias)/7.ts
@@ -11,13 +11,13 @@ const card: Card = {
 	},
 
 	illustrator: "Hironobu Yoshida",
-	rarity: "None",
+	rarity: "Common",
 	category: "Pokemon",
 	stage: "Basic",
 	hp: 50,
 
 	types: [
-		"Fire",
+		"Fire"
 	],
 
 	attacks: [{
@@ -39,15 +39,20 @@ const card: Card = {
 	weaknesses: [
 		{
 			type: "Water",
-			value: "2x"
 		},
 	],
 
 	retreat: 1,
 
-	thirdParty: {
-		tcgplayer: 89954
-	}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 89954
+			}
+		},
+	],
+
 }
 
 export default card

--- a/data/Trainer kits/EX trainer Kit (Latias)/8.ts
+++ b/data/Trainer kits/EX trainer Kit (Latias)/8.ts
@@ -23,6 +23,7 @@ const card: Card = {
 		{
 			type: "normal",
 			thirdParty: {
+				cardmarket: 275774,
 				tcgplayer: 88335
 			}
 		},

--- a/data/Trainer kits/EX trainer Kit (Latias)/8.ts
+++ b/data/Trainer kits/EX trainer Kit (Latias)/8.ts
@@ -8,7 +8,7 @@ const card: Card = {
 	},
 
 	illustrator: "Keiji Kinebuchi",
-	rarity: "None",
+	rarity: "Common",
 	category: "Trainer",
 	set: Set,
 
@@ -17,9 +17,17 @@ const card: Card = {
 		fr: "Soignez 30 dégâts à 1 de vos Pokémon."
 	},
 
-	thirdParty: {
-		tcgplayer: 88335
-	}
+	trainerType: "Item",
+	retreat: 0,
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 88335
+			}
+		},
+	],
+
 }
 
 export default card

--- a/data/Trainer kits/EX trainer Kit (Latias)/8.ts
+++ b/data/Trainer kits/EX trainer Kit (Latias)/8.ts
@@ -8,7 +8,7 @@ const card: Card = {
 	},
 
 	illustrator: "Keiji Kinebuchi",
-	rarity: "Common",
+	rarity: "None",
 	category: "Trainer",
 	set: Set,
 

--- a/data/Trainer kits/EX trainer Kit (Latias)/9.ts
+++ b/data/Trainer kits/EX trainer Kit (Latias)/9.ts
@@ -23,6 +23,7 @@ const card: Card = {
 		{
 			type: "normal",
 			thirdParty: {
+				cardmarket: 275768,
 				tcgplayer: 85239
 			}
 		},

--- a/data/Trainer kits/EX trainer Kit (Latias)/9.ts
+++ b/data/Trainer kits/EX trainer Kit (Latias)/9.ts
@@ -8,18 +8,26 @@ const card: Card = {
 	},
 
 	illustrator: "Kai Ishikawa",
-	rarity: "None",
+	rarity: "Common",
 	category: "Trainer",
 	set: Set,
 
 	effect: {
-		en: "Search your deck for a basic Energy card, show it to your opponent, and put it into your hand. Shuffle your deck afterward.",
+		en: "Search your deck for a basic Energy card, show it to your opponent, and put it into your hand. Shuffle your deck afterward",
 		fr: "Cherchez dans votre deck une carte Énergie de base, montrez-la à votre adversaire et placez-la dans votre main. Mélangez ensuite votre deck."
 	},
 
-	thirdParty: {
-		tcgplayer: 85239
-	}
+	trainerType: "Item",
+	retreat: 0,
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 85239
+			}
+		},
+	],
+
 }
 
 export default card

--- a/data/Trainer kits/EX trainer Kit (Latias)/9.ts
+++ b/data/Trainer kits/EX trainer Kit (Latias)/9.ts
@@ -8,7 +8,7 @@ const card: Card = {
 	},
 
 	illustrator: "Kai Ishikawa",
-	rarity: "Common",
+	rarity: "None",
 	category: "Trainer",
 	set: Set,
 


### PR DESCRIPTION
closes #N/A

## Changes

- moved thirdparty to variants
- moved tcgplayer ids
- added card market ids

## Details

- fixed incorrect weakness from x2 to just x1

