### PR TITLE
(data) en ex-tk-latio EX Trainer Kit Latios - added card variants 

### DIFF
--- a/data/Trainer kits/EX trainer Kit (Latios)/1.ts
+++ b/data/Trainer kits/EX trainer Kit (Latios)/1.ts
@@ -11,7 +11,7 @@ const card: Card = {
 	},
 
 	illustrator: "Ken Sugimori",
-	rarity: "Common",
+	rarity: "None",
 	category: "Pokemon",
 	stage: "Basic",
 	hp: 50,

--- a/data/Trainer kits/EX trainer Kit (Latios)/1.ts
+++ b/data/Trainer kits/EX trainer Kit (Latios)/1.ts
@@ -11,13 +11,13 @@ const card: Card = {
 	},
 
 	illustrator: "Ken Sugimori",
-	rarity: "None",
+	rarity: "Common",
 	category: "Pokemon",
 	stage: "Basic",
 	hp: 50,
 
 	types: [
-		"Lightning",
+		"Lightning"
 	],
 
 	attacks: [{
@@ -34,7 +34,6 @@ const card: Card = {
 	weaknesses: [
 		{
 			type: "Fighting",
-			value: "2x"
 		},
 	],
 
@@ -47,9 +46,16 @@ const card: Card = {
 
 	retreat: 1,
 
-	thirdParty: {
-		tcgplayer: 85131
-	}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 275767,
+				tcgplayer: 85131
+			}
+		},
+	],
+
 }
 
 export default card

--- a/data/Trainer kits/EX trainer Kit (Latios)/10.ts
+++ b/data/Trainer kits/EX trainer Kit (Latios)/10.ts
@@ -7,16 +7,23 @@ const card: Card = {
 		fr: "Énergie Électrique"
 	},
 
-	illustrator: "",
-	rarity: "None",
+	rarity: "Common",
 	category: "Energy",
 	set: Set,
 	stage: "Basic",
 	energyType: "Normal",
 
-	thirdParty: {
-		tcgplayer: 86760
-	}
+	retreat: 0,
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 275761,
+				tcgplayer: 86760
+			}
+		},
+	],
+
 }
 
 export default card

--- a/data/Trainer kits/EX trainer Kit (Latios)/10.ts
+++ b/data/Trainer kits/EX trainer Kit (Latios)/10.ts
@@ -7,7 +7,7 @@ const card: Card = {
 		fr: "Énergie Électrique"
 	},
 
-	rarity: "Common",
+	rarity: "None",
 	category: "Energy",
 	set: Set,
 	stage: "Basic",

--- a/data/Trainer kits/EX trainer Kit (Latios)/2.ts
+++ b/data/Trainer kits/EX trainer Kit (Latios)/2.ts
@@ -11,13 +11,13 @@ const card: Card = {
 	},
 
 	illustrator: "Kyoko Koizumi",
-	rarity: "None",
+	rarity: "Rare",
 	category: "Pokemon",
 	stage: "Basic",
 	hp: 80,
 
 	types: [
-		"Colorless",
+		"Colorless"
 	],
 
 	attacks: [{
@@ -50,15 +50,21 @@ const card: Card = {
 	weaknesses: [
 		{
 			type: "Psychic",
-			value: "2x"
 		},
 	],
 
 	retreat: 1,
 
-	thirdParty: {
-		tcgplayer: 86664
-	}
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 275760,
+				tcgplayer: 86664
+			}
+		},
+	],
+
 }
 
 export default card

--- a/data/Trainer kits/EX trainer Kit (Latios)/2.ts
+++ b/data/Trainer kits/EX trainer Kit (Latios)/2.ts
@@ -11,7 +11,7 @@ const card: Card = {
 	},
 
 	illustrator: "Kyoko Koizumi",
-	rarity: "Rare",
+	rarity: "None",
 	category: "Pokemon",
 	stage: "Basic",
 	hp: 80,

--- a/data/Trainer kits/EX trainer Kit (Latios)/3.ts
+++ b/data/Trainer kits/EX trainer Kit (Latios)/3.ts
@@ -11,13 +11,13 @@ const card: Card = {
 	},
 
 	illustrator: "Ken Sugimori",
-	rarity: "None",
+	rarity: "Common",
 	category: "Pokemon",
 	stage: "Stage1",
 	hp: 70,
 
 	types: [
-		"Colorless",
+		"Colorless"
 	],
 
 	evolveFrom: {
@@ -56,15 +56,21 @@ const card: Card = {
 	weaknesses: [
 		{
 			type: "Fighting",
-			value: "2x"
 		},
 	],
 
 	retreat: 1,
 
-	thirdParty: {
-		tcgplayer: 86805
-	}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 275759,
+				tcgplayer: 86805
+			}
+		},
+	],
+
 }
 
 export default card

--- a/data/Trainer kits/EX trainer Kit (Latios)/3.ts
+++ b/data/Trainer kits/EX trainer Kit (Latios)/3.ts
@@ -11,7 +11,7 @@ const card: Card = {
 	},
 
 	illustrator: "Ken Sugimori",
-	rarity: "Common",
+	rarity: "None",
 	category: "Pokemon",
 	stage: "Stage1",
 	hp: 70,

--- a/data/Trainer kits/EX trainer Kit (Latios)/4.ts
+++ b/data/Trainer kits/EX trainer Kit (Latios)/4.ts
@@ -11,13 +11,13 @@ const card: Card = {
 	},
 
 	illustrator: "Tomokazu Komiya",
-	rarity: "None",
+	rarity: "Common",
 	category: "Pokemon",
 	stage: "Basic",
 	hp: 40,
 
 	types: [
-		"Lightning",
+		"Lightning"
 	],
 
 	attacks: [{
@@ -44,7 +44,6 @@ const card: Card = {
 	weaknesses: [
 		{
 			type: "Fighting",
-			value: "2x"
 		},
 	],
 
@@ -57,9 +56,16 @@ const card: Card = {
 
 	retreat: 1,
 
-	thirdParty: {
-		tcgplayer: 87076
-	}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 275758,
+				tcgplayer: 87076
+			}
+		},
+	],
+
 }
 
 export default card

--- a/data/Trainer kits/EX trainer Kit (Latios)/4.ts
+++ b/data/Trainer kits/EX trainer Kit (Latios)/4.ts
@@ -11,7 +11,7 @@ const card: Card = {
 	},
 
 	illustrator: "Tomokazu Komiya",
-	rarity: "Common",
+	rarity: "None",
 	category: "Pokemon",
 	stage: "Basic",
 	hp: 40,

--- a/data/Trainer kits/EX trainer Kit (Latios)/5.ts
+++ b/data/Trainer kits/EX trainer Kit (Latios)/5.ts
@@ -11,7 +11,7 @@ const card: Card = {
 	},
 
 	illustrator: "Kyoko Umemoto",
-	rarity: "Common",
+	rarity: "None",
 	category: "Pokemon",
 	stage: "Stage1",
 	hp: 80,

--- a/data/Trainer kits/EX trainer Kit (Latios)/5.ts
+++ b/data/Trainer kits/EX trainer Kit (Latios)/5.ts
@@ -11,13 +11,13 @@ const card: Card = {
 	},
 
 	illustrator: "Kyoko Umemoto",
-	rarity: "None",
+	rarity: "Common",
 	category: "Pokemon",
 	stage: "Stage1",
 	hp: 80,
 
 	types: [
-		"Lightning",
+		"Lightning"
 	],
 
 	evolveFrom: {
@@ -55,15 +55,21 @@ const card: Card = {
 	weaknesses: [
 		{
 			type: "Fighting",
-			value: "2x"
 		},
 	],
 
 	retreat: 1,
 
-	thirdParty: {
-		tcgplayer: 87103
-	}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 275762,
+				tcgplayer: 87103
+			}
+		},
+	],
+
 }
 
 export default card

--- a/data/Trainer kits/EX trainer Kit (Latios)/6.ts
+++ b/data/Trainer kits/EX trainer Kit (Latios)/6.ts
@@ -11,13 +11,13 @@ const card: Card = {
 	},
 
 	illustrator: "Mitsuhiro Arita",
-	rarity: "None",
+	rarity: "Common",
 	category: "Pokemon",
 	stage: "Basic",
 	hp: 50,
 
 	types: [
-		"Lightning",
+		"Lightning"
 	],
 
 	attacks: [{
@@ -45,15 +45,21 @@ const card: Card = {
 	weaknesses: [
 		{
 			type: "Fighting",
-			value: "2x"
 		},
 	],
 
 	retreat: 1,
 
-	thirdParty: {
-		tcgplayer: 88079
-	}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 275763,
+				tcgplayer: 88079
+			}
+		},
+	],
+
 }
 
 export default card

--- a/data/Trainer kits/EX trainer Kit (Latios)/6.ts
+++ b/data/Trainer kits/EX trainer Kit (Latios)/6.ts
@@ -11,7 +11,7 @@ const card: Card = {
 	},
 
 	illustrator: "Mitsuhiro Arita",
-	rarity: "Common",
+	rarity: "None",
 	category: "Pokemon",
 	stage: "Basic",
 	hp: 50,

--- a/data/Trainer kits/EX trainer Kit (Latios)/7.ts
+++ b/data/Trainer kits/EX trainer Kit (Latios)/7.ts
@@ -11,7 +11,7 @@ const card: Card = {
 	},
 
 	illustrator: "Atsuko Nishida",
-	rarity: "Common",
+	rarity: "None",
 	category: "Pokemon",
 	stage: "Basic",
 	hp: 40,

--- a/data/Trainer kits/EX trainer Kit (Latios)/7.ts
+++ b/data/Trainer kits/EX trainer Kit (Latios)/7.ts
@@ -11,13 +11,13 @@ const card: Card = {
 	},
 
 	illustrator: "Atsuko Nishida",
-	rarity: "None",
+	rarity: "Common",
 	category: "Pokemon",
 	stage: "Basic",
 	hp: 40,
 
 	types: [
-		"Colorless",
+		"Colorless"
 	],
 
 	attacks: [{
@@ -38,15 +38,21 @@ const card: Card = {
 	weaknesses: [
 		{
 			type: "Fighting",
-			value: "2x"
 		},
 	],
 
 	retreat: 1,
 
-	thirdParty: {
-		tcgplayer: 90746
-	}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 275766,
+				tcgplayer: 90746
+			}
+		},
+	],
+
 }
 
 export default card

--- a/data/Trainer kits/EX trainer Kit (Latios)/8.ts
+++ b/data/Trainer kits/EX trainer Kit (Latios)/8.ts
@@ -8,7 +8,7 @@ const card: Card = {
 	},
 
 	illustrator: "Keiji Kinebuchi",
-	rarity: "None",
+	rarity: "Common",
 	category: "Trainer",
 	set: Set,
 
@@ -17,9 +17,18 @@ const card: Card = {
 		fr: "Soignez 30 dégâts à 1 de vos Pokémon."
 	},
 
-	thirdParty: {
-		tcgplayer: 88335
-	}
+	trainerType: "Item",
+	retreat: 0,
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 275765,
+				tcgplayer: 88336
+			}
+		},
+	],
+
 }
 
 export default card

--- a/data/Trainer kits/EX trainer Kit (Latios)/8.ts
+++ b/data/Trainer kits/EX trainer Kit (Latios)/8.ts
@@ -8,7 +8,7 @@ const card: Card = {
 	},
 
 	illustrator: "Keiji Kinebuchi",
-	rarity: "Common",
+	rarity: "None",
 	category: "Trainer",
 	set: Set,
 

--- a/data/Trainer kits/EX trainer Kit (Latios)/9.ts
+++ b/data/Trainer kits/EX trainer Kit (Latios)/9.ts
@@ -8,18 +8,27 @@ const card: Card = {
 	},
 
 	illustrator: "Kai Ishikawa",
-	rarity: "None",
+	rarity: "Common",
 	category: "Trainer",
 	set: Set,
 
 	effect: {
-		en: "Search your deck for a basic Energy card, show it to your opponent, and put it into your hand. Shuffle your deck afterward.",
+		en: "Search your deck for a basic Energy card, show it to your opponent, and put it into your hand. Shuffle your deck afterward",
 		fr: "Cherchez dans votre deck une carte Énergie de base, montrez-la à votre adversaire et placez-la dans votre main. Mélangez ensuite votre deck."
 	},
 
-	thirdParty: {
-		tcgplayer: 85239
-	}
+	trainerType: "Item",
+	retreat: 0,
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 275764,
+				tcgplayer: 85240
+			}
+		},
+	],
+
 }
 
 export default card

--- a/data/Trainer kits/EX trainer Kit (Latios)/9.ts
+++ b/data/Trainer kits/EX trainer Kit (Latios)/9.ts
@@ -8,7 +8,7 @@ const card: Card = {
 	},
 
 	illustrator: "Kai Ishikawa",
-	rarity: "Common",
+	rarity: "None",
 	category: "Trainer",
 	set: Set,
 


### PR DESCRIPTION
closes #N/A

## Changes

- moved thirdparty to variants
- moved tcgplayer ids
- added card market ids

## Details

- fixed incorrect weakness from x2 to just x1

