### PR TITLE
(data) en tk-hs-r Trainer Kit Raichu - added card variants 

### DIFF
--- a/data/Trainer kits/HS trainer Kit (Raichu)/1.ts
+++ b/data/Trainer kits/HS trainer Kit (Raichu)/1.ts
@@ -1,0 +1,29 @@
+import { Card } from '../../../interfaces'
+import Set from '../HS trainer Kit (Raichu)'
+
+const card: Card = {
+	name: {
+		en: "Moomoo Milk",
+	},
+
+	illustrator: "Noriko Hotta",
+	rarity: "None",
+	category: "Trainer",
+	set: Set,
+	trainerType: "Item",
+	retreat: 0,
+
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 279125,
+				tcgplayer: 87577,
+			},
+		},
+	],
+
+}
+
+export default card

--- a/data/Trainer kits/HS trainer Kit (Raichu)/10.ts
+++ b/data/Trainer kits/HS trainer Kit (Raichu)/10.ts
@@ -1,0 +1,27 @@
+import { Card } from '../../../interfaces'
+import Set from '../HS trainer Kit (Raichu)'
+
+const card: Card = {
+	name: {
+		en: "Lightning Energy",
+	},
+
+	rarity: "None",
+	category: "Energy",
+	set: Set,
+	retreat: 0,
+
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 279105,
+				tcgplayer: 86774,
+			},
+		},
+	],
+
+}
+
+export default card

--- a/data/Trainer kits/HS trainer Kit (Raichu)/11.ts
+++ b/data/Trainer kits/HS trainer Kit (Raichu)/11.ts
@@ -1,0 +1,27 @@
+import { Card } from '../../../interfaces'
+import Set from '../HS trainer Kit (Raichu)'
+
+const card: Card = {
+	name: {
+		en: "Lightning Energy",
+	},
+
+	rarity: "None",
+	category: "Energy",
+	set: Set,
+	retreat: 0,
+
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 279104,
+				tcgplayer: 86775,
+			},
+		},
+	],
+
+}
+
+export default card

--- a/data/Trainer kits/HS trainer Kit (Raichu)/12.ts
+++ b/data/Trainer kits/HS trainer Kit (Raichu)/12.ts
@@ -1,0 +1,64 @@
+import { Card } from '../../../interfaces'
+import Set from '../HS trainer Kit (Raichu)'
+
+const card: Card = {
+	name: {
+		en: "Meowth",
+	},
+
+	illustrator: "Kagemaru Himeno",
+	rarity: "None",
+	category: "Pokemon",
+	set: Set,
+	dexId: [52],
+	hp: 60,
+	types: [
+		"Colorless",
+	],
+	stage: "Basic",
+	attacks: [
+		{
+			cost: [
+				"Colorless",
+			],
+			name: {
+				en: "Pay Day",
+			},
+			effect: {
+				en: "Draw a card.",
+			},
+			damage: 10,
+		},
+		{
+			cost: [
+				"Colorless",
+				"Colorless",
+			],
+			name: {
+				en: "Dig Claws",
+			},
+			damage: 20,
+		},
+	],
+	weaknesses: [
+		{
+			type: "Fighting",
+			value: "×2"
+		},
+	],
+	retreat: 1,
+
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 279106,
+				tcgplayer: 87324,
+			},
+		},
+	],
+
+}
+
+export default card

--- a/data/Trainer kits/HS trainer Kit (Raichu)/13.ts
+++ b/data/Trainer kits/HS trainer Kit (Raichu)/13.ts
@@ -1,0 +1,69 @@
+import { Card } from '../../../interfaces'
+import Set from '../HS trainer Kit (Raichu)'
+
+const card: Card = {
+	name: {
+		en: "Mareep",
+	},
+
+	illustrator: "Masakazu Fukuda",
+	rarity: "None",
+	category: "Pokemon",
+	set: Set,
+	dexId: [179],
+	hp: 40,
+	types: [
+		"Lightning",
+	],
+	stage: "Basic",
+	attacks: [
+		{
+			cost: [
+				"Colorless",
+			],
+			name: {
+				en: "Static Electricity",
+			},
+			effect: {
+				en: "Search your deck for a number of Lightning Energy cards up to the number of Mareep in play (both yours and your opponent's) and attach them to Mareep. Shuffle your deck afterward.",
+			},
+		},
+		{
+			cost: [
+				"Colorless",
+				"Colorless",
+			],
+			name: {
+				en: "Ram",
+			},
+			damage: 20,
+		},
+	],
+	weaknesses: [
+		{
+			type: "Fighting",
+			value: "×2"
+		},
+	],
+	resistances: [
+		{
+			type: "Metal",
+			value: "-20"
+		},
+	],
+	retreat: 1,
+
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 279107,
+				tcgplayer: 87205,
+			},
+		},
+	],
+
+}
+
+export default card

--- a/data/Trainer kits/HS trainer Kit (Raichu)/14.ts
+++ b/data/Trainer kits/HS trainer Kit (Raichu)/14.ts
@@ -1,0 +1,27 @@
+import { Card } from '../../../interfaces'
+import Set from '../HS trainer Kit (Raichu)'
+
+const card: Card = {
+	name: {
+		en: "Lightning Energy",
+	},
+
+	rarity: "None",
+	category: "Energy",
+	set: Set,
+	retreat: 0,
+
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 279109,
+				tcgplayer: 86776,
+			},
+		},
+	],
+
+}
+
+export default card

--- a/data/Trainer kits/HS trainer Kit (Raichu)/15.ts
+++ b/data/Trainer kits/HS trainer Kit (Raichu)/15.ts
@@ -1,0 +1,27 @@
+import { Card } from '../../../interfaces'
+import Set from '../HS trainer Kit (Raichu)'
+
+const card: Card = {
+	name: {
+		en: "Lightning Energy",
+	},
+
+	rarity: "None",
+	category: "Energy",
+	set: Set,
+	retreat: 0,
+
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 279108,
+				tcgplayer: 86777,
+			},
+		},
+	],
+
+}
+
+export default card

--- a/data/Trainer kits/HS trainer Kit (Raichu)/16.ts
+++ b/data/Trainer kits/HS trainer Kit (Raichu)/16.ts
@@ -1,0 +1,70 @@
+import { Card } from '../../../interfaces'
+import Set from '../HS trainer Kit (Raichu)'
+
+const card: Card = {
+	name: {
+		en: "Pikachu",
+	},
+
+	illustrator: "match",
+	rarity: "None",
+	category: "Pokemon",
+	set: Set,
+	dexId: [25],
+	hp: 60,
+	types: [
+		"Lightning",
+	],
+	stage: "Basic",
+	attacks: [
+		{
+			cost: [
+				"Colorless",
+			],
+			name: {
+				en: "Tail Slap",
+			},
+			damage: 10,
+		},
+		{
+			cost: [
+				"Lightning",
+				"Colorless",
+			],
+			name: {
+				en: "Quick Attack",
+			},
+			effect: {
+				en: "Flip a coin. If heads, this attack does 20 damage plus 10 more damage.",
+			},
+			damage: "20+",
+		},
+	],
+	weaknesses: [
+		{
+			type: "Fighting",
+			value: "×2"
+		},
+	],
+	resistances: [
+		{
+			type: "Metal",
+			value: "-20"
+		},
+	],
+	retreat: 1,
+
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 279103,
+				tcgplayer: 88100,
+			},
+		},
+	],
+
+}
+
+export default card

--- a/data/Trainer kits/HS trainer Kit (Raichu)/17.ts
+++ b/data/Trainer kits/HS trainer Kit (Raichu)/17.ts
@@ -1,0 +1,76 @@
+import { Card } from '../../../interfaces'
+import Set from '../HS trainer Kit (Raichu)'
+
+const card: Card = {
+	name: {
+		en: "Flaaffy",
+	},
+
+	illustrator: "Masakazu Fukuda",
+	rarity: "None",
+	category: "Pokemon",
+	set: Set,
+	dexId: [180],
+	hp: 80,
+	types: [
+		"Lightning",
+	],
+	evolveFrom: {
+		en: "Mareep",
+	},
+	stage: "Stage1",
+	attacks: [
+		{
+			cost: [
+				"Lightning",
+			],
+			name: {
+				en: "Thunder Spear",
+			},
+			effect: {
+				en: "Choose 1 of your opponent's Pokémon. This attack does 20 damage to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)",
+			},
+		},
+		{
+			cost: [
+				"Lightning",
+				"Colorless",
+				"Colorless",
+			],
+			name: {
+				en: "Thundershock",
+			},
+			effect: {
+				en: "Flip a coin. If heads, the Defending Pokémon is now Paralyzed.",
+			},
+			damage: 40,
+		},
+	],
+	weaknesses: [
+		{
+			type: "Fighting",
+			value: "×2"
+		},
+	],
+	resistances: [
+		{
+			type: "Metal",
+			value: "-20"
+		},
+	],
+	retreat: 1,
+
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 279102,
+				tcgplayer: 85484,
+			},
+		},
+	],
+
+}
+
+export default card

--- a/data/Trainer kits/HS trainer Kit (Raichu)/18.ts
+++ b/data/Trainer kits/HS trainer Kit (Raichu)/18.ts
@@ -1,0 +1,27 @@
+import { Card } from '../../../interfaces'
+import Set from '../HS trainer Kit (Raichu)'
+
+const card: Card = {
+	name: {
+		en: "Lightning Energy",
+	},
+
+	rarity: "None",
+	category: "Energy",
+	set: Set,
+	retreat: 0,
+
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 279097,
+				tcgplayer: 86778,
+			},
+		},
+	],
+
+}
+
+export default card

--- a/data/Trainer kits/HS trainer Kit (Raichu)/19.ts
+++ b/data/Trainer kits/HS trainer Kit (Raichu)/19.ts
@@ -4,6 +4,7 @@ import Set from '../HS trainer Kit (Raichu)'
 const card: Card = {
 	name: {
 		en: "Raichu",
+		fr: "Raichu"
 	},
 
 	illustrator: "match",
@@ -26,6 +27,7 @@ const card: Card = {
 			],
 			name: {
 				en: "Iron Tail",
+				fr: "Queue de fer"
 			},
 			effect: {
 				en: "Flip a coin until you get tails. This attack does 30 damage times the number of heads.",
@@ -39,9 +41,11 @@ const card: Card = {
 			],
 			name: {
 				en: "Thunderbolt",
+				fr: "Tonnerre",
 			},
 			effect: {
 				en: "Discard all Energy attached to Raichu.",
+				fr: "Défaussez toutes les cartes Énergie attachées à Raichu."
 			},
 			damage: 100,
 		},

--- a/data/Trainer kits/HS trainer Kit (Raichu)/19.ts
+++ b/data/Trainer kits/HS trainer Kit (Raichu)/19.ts
@@ -2,53 +2,73 @@ import { Card } from '../../../interfaces'
 import Set from '../HS trainer Kit (Raichu)'
 
 const card: Card = {
-	dexId: [26],
-	set: Set,
-
 	name: {
 		en: "Raichu",
-		fr: "Raichu"
 	},
 
 	illustrator: "match",
 	rarity: "None",
 	category: "Pokemon",
-
-	description: {
-		en: "If the electric pouches in its cheeks become fully charged, both ears will stand straight up."
-	},
-	
+	set: Set,
+	dexId: [26],
 	hp: 90,
-	types: ["Lightning"],
-
+	types: [
+		"Lightning",
+	],
+	evolveFrom: {
+		en: "Pikachu",
+	},
 	stage: "Stage1",
-
-	attacks: [{
-		name: {
-			en: "Iron Tail",
-			fr: "Queue de fer"
+	attacks: [
+		{
+			cost: [
+				"Colorless",
+			],
+			name: {
+				en: "Iron Tail",
+			},
+			effect: {
+				en: "Flip a coin until you get tails. This attack does 30 damage times the number of heads.",
+			},
+			damage: "30×",
 		},
-
-		damage: "30×",
-
-		effect: {
-			en: "Flip a coin until you get tails. This attack does 30 damage times the number of heads.",
-			fr: "Lancez une pièce jusqu'à ce qu'elle tombe sur pile. Cette carte inflige 30 dégâts multipliés par le nombre de faces."
-		}
-	}, {
-		name: {
-			en: "Thunderbolt",
-			fr: "Tonnerre"
+		{
+			cost: [
+				"Lightning",
+				"Lightning",
+			],
+			name: {
+				en: "Thunderbolt",
+			},
+			effect: {
+				en: "Discard all Energy attached to Raichu.",
+			},
+			damage: 100,
 		},
+	],
+	weaknesses: [
+		{
+			type: "Fighting",
+			value: "×2"
+		},
+	],
+	resistances: [
+		{
+			type: "Metal",
+			value: "-20"
+		},
+	],
+	retreat: 0,
 
-		damage: 100,
-
-		effect: {
-			en: "Discard all Energy attached to Raichu.",
-			fr: "Défaussez toutes les cartes Énergie attachées à Raichu."
-		}
-	}],
-
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 279096,
+				tcgplayer: 88520,
+			},
+		},
+	],
 }
 
 export default card

--- a/data/Trainer kits/HS trainer Kit (Raichu)/19.ts
+++ b/data/Trainer kits/HS trainer Kit (Raichu)/19.ts
@@ -49,9 +49,6 @@ const card: Card = {
 		}
 	}],
 
-	thirdParty: {
-		tcgplayer: 88520
-	}
 }
 
 export default card

--- a/data/Trainer kits/HS trainer Kit (Raichu)/2.ts
+++ b/data/Trainer kits/HS trainer Kit (Raichu)/2.ts
@@ -1,0 +1,70 @@
+import { Card } from '../../../interfaces'
+import Set from '../HS trainer Kit (Raichu)'
+
+const card: Card = {
+	name: {
+		en: "Pikachu",
+	},
+
+	illustrator: "match",
+	rarity: "None",
+	category: "Pokemon",
+	set: Set,
+	dexId: [25],
+	hp: 60,
+	types: [
+		"Lightning",
+	],
+	stage: "Basic",
+	attacks: [
+		{
+			cost: [
+				"Colorless",
+			],
+			name: {
+				en: "Tail Slap",
+			},
+			damage: 10,
+		},
+		{
+			cost: [
+				"Lightning",
+				"Colorless",
+			],
+			name: {
+				en: "Quick Attack",
+			},
+			effect: {
+				en: "Flip a coin. If heads, this attack does 20 damage plus 10 more damage.",
+			},
+			damage: "20+",
+		},
+	],
+	weaknesses: [
+		{
+			type: "Fighting",
+			value: "×2"
+		},
+	],
+	resistances: [
+		{
+			type: "Metal",
+			value: "-20"
+		},
+	],
+	retreat: 1,
+
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 279098,
+				tcgplayer: 88099,
+			},
+		},
+	],
+
+}
+
+export default card

--- a/data/Trainer kits/HS trainer Kit (Raichu)/20.ts
+++ b/data/Trainer kits/HS trainer Kit (Raichu)/20.ts
@@ -1,0 +1,69 @@
+import { Card } from '../../../interfaces'
+import Set from '../HS trainer Kit (Raichu)'
+
+const card: Card = {
+	name: {
+		en: "Mareep",
+	},
+
+	illustrator: "Masakazu Fukuda",
+	rarity: "None",
+	category: "Pokemon",
+	set: Set,
+	dexId: [179],
+	hp: 40,
+	types: [
+		"Lightning",
+	],
+	stage: "Basic",
+	attacks: [
+		{
+			cost: [
+				"Colorless",
+			],
+			name: {
+				en: "Static Electricity",
+			},
+			effect: {
+				en: "Search your deck for a number of Lightning Energy cards up to the number of Mareep in play (both yours and your opponent's) and attach them to Mareep. Shuffle your deck afterward.",
+			},
+		},
+		{
+			cost: [
+				"Colorless",
+				"Colorless",
+			],
+			name: {
+				en: "Ram",
+			},
+			damage: 20,
+		},
+	],
+	weaknesses: [
+		{
+			type: "Fighting",
+			value: "×2"
+		},
+	],
+	resistances: [
+		{
+			type: "Metal",
+			value: "-20"
+		},
+	],
+	retreat: 1,
+
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 279099,
+				tcgplayer: 87206,
+			},
+		},
+	],
+
+}
+
+export default card

--- a/data/Trainer kits/HS trainer Kit (Raichu)/21.ts
+++ b/data/Trainer kits/HS trainer Kit (Raichu)/21.ts
@@ -1,0 +1,29 @@
+import { Card } from '../../../interfaces'
+import Set from '../HS trainer Kit (Raichu)'
+
+const card: Card = {
+	name: {
+		en: "Copycat",
+	},
+
+	illustrator: "Kanako Eo",
+	rarity: "None",
+	category: "Trainer",
+	set: Set,
+	trainerType: "Supporter",
+	retreat: 0,
+
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 279101,
+				tcgplayer: 84427,
+			},
+		},
+	],
+
+}
+
+export default card

--- a/data/Trainer kits/HS trainer Kit (Raichu)/22.ts
+++ b/data/Trainer kits/HS trainer Kit (Raichu)/22.ts
@@ -1,0 +1,29 @@
+import { Card } from '../../../interfaces'
+import Set from '../HS trainer Kit (Raichu)'
+
+const card: Card = {
+	name: {
+		en: "Pokémon Collector",
+	},
+
+	illustrator: "Masakazu Fukuda",
+	rarity: "None",
+	category: "Trainer",
+	set: Set,
+	trainerType: "Supporter",
+	retreat: 0,
+
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 279100,
+				tcgplayer: 88218,
+			},
+		},
+	],
+
+}
+
+export default card

--- a/data/Trainer kits/HS trainer Kit (Raichu)/23.ts
+++ b/data/Trainer kits/HS trainer Kit (Raichu)/23.ts
@@ -1,0 +1,27 @@
+import { Card } from '../../../interfaces'
+import Set from '../HS trainer Kit (Raichu)'
+
+const card: Card = {
+	name: {
+		en: "Lightning Energy",
+	},
+
+	rarity: "None",
+	category: "Energy",
+	set: Set,
+	retreat: 0,
+
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 279110,
+				tcgplayer: 86779,
+			},
+		},
+	],
+
+}
+
+export default card

--- a/data/Trainer kits/HS trainer Kit (Raichu)/24.ts
+++ b/data/Trainer kits/HS trainer Kit (Raichu)/24.ts
@@ -1,0 +1,29 @@
+import { Card } from '../../../interfaces'
+import Set from '../HS trainer Kit (Raichu)'
+
+const card: Card = {
+	name: {
+		en: "Switch",
+	},
+
+	illustrator: "Hideaki Hakozaki",
+	rarity: "None",
+	category: "Trainer",
+	set: Set,
+	trainerType: "Item",
+	retreat: 0,
+
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 279111,
+				tcgplayer: 89720,
+			},
+		},
+	],
+
+}
+
+export default card

--- a/data/Trainer kits/HS trainer Kit (Raichu)/25.ts
+++ b/data/Trainer kits/HS trainer Kit (Raichu)/25.ts
@@ -1,0 +1,29 @@
+import { Card } from '../../../interfaces'
+import Set from '../HS trainer Kit (Raichu)'
+
+const card: Card = {
+	name: {
+		en: "Poké Ball",
+	},
+
+	illustrator: "Hideaki Hakozaki",
+	rarity: "None",
+	category: "Trainer",
+	set: Set,
+	trainerType: "Item",
+	retreat: 0,
+
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 279121,
+				tcgplayer: 88191,
+			},
+		},
+	],
+
+}
+
+export default card

--- a/data/Trainer kits/HS trainer Kit (Raichu)/26.ts
+++ b/data/Trainer kits/HS trainer Kit (Raichu)/26.ts
@@ -1,0 +1,29 @@
+import { Card } from '../../../interfaces'
+import Set from '../HS trainer Kit (Raichu)'
+
+const card: Card = {
+	name: {
+		en: "Moomoo Milk",
+	},
+
+	illustrator: "Noriko Hotta",
+	rarity: "None",
+	category: "Trainer",
+	set: Set,
+	trainerType: "Item",
+	retreat: 0,
+
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 279120,
+				tcgplayer: 87578,
+			},
+		},
+	],
+
+}
+
+export default card

--- a/data/Trainer kits/HS trainer Kit (Raichu)/27.ts
+++ b/data/Trainer kits/HS trainer Kit (Raichu)/27.ts
@@ -1,0 +1,29 @@
+import { Card } from '../../../interfaces'
+import Set from '../HS trainer Kit (Raichu)'
+
+const card: Card = {
+	name: {
+		en: "Pokémon Collector",
+	},
+
+	illustrator: "Masakazu Fukuda",
+	rarity: "None",
+	category: "Trainer",
+	set: Set,
+	trainerType: "Supporter",
+	retreat: 0,
+
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 279122,
+				tcgplayer: 88219,
+			},
+		},
+	],
+
+}
+
+export default card

--- a/data/Trainer kits/HS trainer Kit (Raichu)/28.ts
+++ b/data/Trainer kits/HS trainer Kit (Raichu)/28.ts
@@ -1,0 +1,27 @@
+import { Card } from '../../../interfaces'
+import Set from '../HS trainer Kit (Raichu)'
+
+const card: Card = {
+	name: {
+		en: "Lightning Energy",
+	},
+
+	rarity: "None",
+	category: "Energy",
+	set: Set,
+	retreat: 0,
+
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 279123,
+				tcgplayer: 86780,
+			},
+		},
+	],
+
+}
+
+export default card

--- a/data/Trainer kits/HS trainer Kit (Raichu)/29.ts
+++ b/data/Trainer kits/HS trainer Kit (Raichu)/29.ts
@@ -1,0 +1,28 @@
+import { Card } from '../../../interfaces'
+import Set from '../HS trainer Kit (Raichu)'
+
+const card: Card = {
+	name: {
+		en: "Energy Switch",
+	},
+
+	illustrator: "Wataru Kawahara",
+	rarity: "None",
+	category: "Trainer",
+	set: Set,
+	retreat: 0,
+
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 279124,
+				tcgplayer: 85261,
+			},
+		},
+	],
+
+}
+
+export default card

--- a/data/Trainer kits/HS trainer Kit (Raichu)/3.ts
+++ b/data/Trainer kits/HS trainer Kit (Raichu)/3.ts
@@ -1,0 +1,76 @@
+import { Card } from '../../../interfaces'
+import Set from '../HS trainer Kit (Raichu)'
+
+const card: Card = {
+	name: {
+		en: "Flaaffy",
+	},
+
+	illustrator: "Masakazu Fukuda",
+	rarity: "None",
+	category: "Pokemon",
+	set: Set,
+	dexId: [180],
+	hp: 80,
+	types: [
+		"Lightning",
+	],
+	evolveFrom: {
+		en: "Mareep",
+	},
+	stage: "Stage1",
+	attacks: [
+		{
+			cost: [
+				"Lightning",
+			],
+			name: {
+				en: "Thunder Spear",
+			},
+			effect: {
+				en: "Choose 1 of your opponent's Pokémon. This attack does 20 damage to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)",
+			},
+		},
+		{
+			cost: [
+				"Lightning",
+				"Colorless",
+				"Colorless",
+			],
+			name: {
+				en: "Thundershock",
+			},
+			effect: {
+				en: "Flip a coin. If heads, the Defending Pokémon is now Paralyzed.",
+			},
+			damage: 40,
+		},
+	],
+	weaknesses: [
+		{
+			type: "Fighting",
+			value: "×2"
+		},
+	],
+	resistances: [
+		{
+			type: "Metal",
+			value: "-20"
+		},
+	],
+	retreat: 1,
+
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 279119,
+				tcgplayer: 85483,
+			},
+		},
+	],
+
+}
+
+export default card

--- a/data/Trainer kits/HS trainer Kit (Raichu)/30.ts
+++ b/data/Trainer kits/HS trainer Kit (Raichu)/30.ts
@@ -1,0 +1,76 @@
+import { Card } from '../../../interfaces'
+import Set from '../HS trainer Kit (Raichu)'
+
+const card: Card = {
+	name: {
+		en: "Raichu",
+	},
+
+	illustrator: "match",
+	rarity: "None",
+	category: "Pokemon",
+	set: Set,
+	dexId: [26],
+	hp: 90,
+	types: [
+		"Lightning",
+	],
+	evolveFrom: {
+		en: "Pikachu",
+	},
+	stage: "Stage1",
+	attacks: [
+		{
+			cost: [
+				"Colorless",
+			],
+			name: {
+				en: "Iron Tail",
+			},
+			effect: {
+				en: "Flip a coin until you get tails. This attack does 30 damage times the number of heads.",
+			},
+			damage: "30×",
+		},
+		{
+			cost: [
+				"Lightning",
+				"Lightning",
+			],
+			name: {
+				en: "Thunderbolt",
+			},
+			effect: {
+				en: "Discard all Energy attached to Raichu.",
+			},
+			damage: 100,
+		},
+	],
+	weaknesses: [
+		{
+			type: "Fighting",
+			value: "×2"
+		},
+	],
+	resistances: [
+		{
+			type: "Metal",
+			value: "-20"
+		},
+	],
+	retreat: 0,
+
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 279118,
+				tcgplayer: 88521,
+			},
+		},
+	],
+
+}
+
+export default card

--- a/data/Trainer kits/HS trainer Kit (Raichu)/4.ts
+++ b/data/Trainer kits/HS trainer Kit (Raichu)/4.ts
@@ -1,0 +1,64 @@
+import { Card } from '../../../interfaces'
+import Set from '../HS trainer Kit (Raichu)'
+
+const card: Card = {
+	name: {
+		en: "Meowth",
+	},
+
+	illustrator: "Kagemaru Himeno",
+	rarity: "None",
+	category: "Pokemon",
+	set: Set,
+	dexId: [52],
+	hp: 60,
+	types: [
+		"Colorless",
+	],
+	stage: "Basic",
+	attacks: [
+		{
+			cost: [
+				"Colorless",
+			],
+			name: {
+				en: "Pay Day",
+			},
+			effect: {
+				en: "Draw a card.",
+			},
+			damage: 10,
+		},
+		{
+			cost: [
+				"Colorless",
+				"Colorless",
+			],
+			name: {
+				en: "Dig Claws",
+			},
+			damage: 20,
+		},
+	],
+	weaknesses: [
+		{
+			type: "Fighting",
+			value: "×2"
+		},
+	],
+	retreat: 1,
+
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 279113,
+				tcgplayer: 87323,
+			},
+		},
+	],
+
+}
+
+export default card

--- a/data/Trainer kits/HS trainer Kit (Raichu)/5.ts
+++ b/data/Trainer kits/HS trainer Kit (Raichu)/5.ts
@@ -1,0 +1,27 @@
+import { Card } from '../../../interfaces'
+import Set from '../HS trainer Kit (Raichu)'
+
+const card: Card = {
+	name: {
+		en: "Lightning Energy",
+	},
+
+	rarity: "None",
+	category: "Energy",
+	set: Set,
+	retreat: 0,
+
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 279112,
+				tcgplayer: 86769,
+			},
+		},
+	],
+
+}
+
+export default card

--- a/data/Trainer kits/HS trainer Kit (Raichu)/6.ts
+++ b/data/Trainer kits/HS trainer Kit (Raichu)/6.ts
@@ -1,0 +1,27 @@
+import { Card } from '../../../interfaces'
+import Set from '../HS trainer Kit (Raichu)'
+
+const card: Card = {
+	name: {
+		en: "Lightning Energy",
+	},
+
+	rarity: "None",
+	category: "Energy",
+	set: Set,
+	retreat: 0,
+
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 279114,
+				tcgplayer: 86770,
+			},
+		},
+	],
+
+}
+
+export default card

--- a/data/Trainer kits/HS trainer Kit (Raichu)/7.ts
+++ b/data/Trainer kits/HS trainer Kit (Raichu)/7.ts
@@ -1,0 +1,27 @@
+import { Card } from '../../../interfaces'
+import Set from '../HS trainer Kit (Raichu)'
+
+const card: Card = {
+	name: {
+		en: "Lightning Energy",
+	},
+
+	rarity: "None",
+	category: "Energy",
+	set: Set,
+	retreat: 0,
+
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 279115,
+				tcgplayer: 86771,
+			},
+		},
+	],
+
+}
+
+export default card

--- a/data/Trainer kits/HS trainer Kit (Raichu)/8.ts
+++ b/data/Trainer kits/HS trainer Kit (Raichu)/8.ts
@@ -1,0 +1,27 @@
+import { Card } from '../../../interfaces'
+import Set from '../HS trainer Kit (Raichu)'
+
+const card: Card = {
+	name: {
+		en: "Lightning Energy",
+	},
+
+	rarity: "None",
+	category: "Energy",
+	set: Set,
+	retreat: 0,
+
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 279117,
+				tcgplayer: 86772,
+			},
+		},
+	],
+
+}
+
+export default card

--- a/data/Trainer kits/HS trainer Kit (Raichu)/9.ts
+++ b/data/Trainer kits/HS trainer Kit (Raichu)/9.ts
@@ -1,0 +1,27 @@
+import { Card } from '../../../interfaces'
+import Set from '../HS trainer Kit (Raichu)'
+
+const card: Card = {
+	name: {
+		en: "Lightning Energy",
+	},
+
+	rarity: "None",
+	category: "Energy",
+	set: Set,
+	retreat: 0,
+
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 279116,
+				tcgplayer: 86773,
+			},
+		},
+	],
+
+}
+
+export default card


### PR DESCRIPTION
closes #N/A

## Changes

- added missing data from cards 1-30
- add tcgplayer ids
- add cardmarket ids
- moved thirdparty
- 
## Details


