### PR TITLE
(data) ja SV1V Violet ex - cardmarket + tcgplayer product ids

### DIFF
--- a/data-asia/SV/SV1V/001.ts
+++ b/data-asia/SV/SV1V/001.ts
@@ -52,12 +52,18 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 693075,
+				tcgplayer: 568227,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "G",
-
-	thirdParty: {
-		cardmarket: 693075
-	}
 }
 
 export default card

--- a/data-asia/SV/SV1V/002.ts
+++ b/data-asia/SV/SV1V/002.ts
@@ -63,12 +63,18 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 693076,
+				tcgplayer: 568228,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "G",
-
-	thirdParty: {
-		cardmarket: 693076
-	}
 }
 
 export default card

--- a/data-asia/SV/SV1V/003.ts
+++ b/data-asia/SV/SV1V/003.ts
@@ -63,12 +63,18 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 693077,
+				tcgplayer: 568229,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "G",
-
-	thirdParty: {
-		cardmarket: 693077
-	}
 }
 
 export default card

--- a/data-asia/SV/SV1V/004.ts
+++ b/data-asia/SV/SV1V/004.ts
@@ -63,12 +63,18 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 693078,
+				tcgplayer: 568230,
+			},
+		},
+	],
+
 	retreat: 3,
 	regulationMark: "G",
-
-	thirdParty: {
-		cardmarket: 693078
-	}
 }
 
 export default card

--- a/data-asia/SV/SV1V/005.ts
+++ b/data-asia/SV/SV1V/005.ts
@@ -62,12 +62,18 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 693079,
+				tcgplayer: 568231,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "G",
-
-	thirdParty: {
-		cardmarket: 693079
-	}
 }
 
 export default card

--- a/data-asia/SV/SV1V/006.ts
+++ b/data-asia/SV/SV1V/006.ts
@@ -52,6 +52,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 693080,
+				tcgplayer: 568232,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV1V/007.ts
+++ b/data-asia/SV/SV1V/007.ts
@@ -52,6 +52,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 693081,
+				tcgplayer: 568233,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV1V/008.ts
+++ b/data-asia/SV/SV1V/008.ts
@@ -62,6 +62,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 693082,
+				tcgplayer: 568234,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV1V/009.ts
+++ b/data-asia/SV/SV1V/009.ts
@@ -52,6 +52,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 693083,
+				tcgplayer: 568235,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV1V/010.ts
+++ b/data-asia/SV/SV1V/010.ts
@@ -61,6 +61,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 693084,
+				tcgplayer: 568236,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV1V/011.ts
+++ b/data-asia/SV/SV1V/011.ts
@@ -70,6 +70,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 693085,
+				tcgplayer: 568237,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV1V/012.ts
+++ b/data-asia/SV/SV1V/012.ts
@@ -52,6 +52,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 693086,
+				tcgplayer: 568238,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV1V/013.ts
+++ b/data-asia/SV/SV1V/013.ts
@@ -61,6 +61,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 693087,
+				tcgplayer: 568239,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV1V/014.ts
+++ b/data-asia/SV/SV1V/014.ts
@@ -70,6 +70,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 693088,
+				tcgplayer: 568240,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV1V/015.ts
+++ b/data-asia/SV/SV1V/015.ts
@@ -61,12 +61,18 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 693089,
+				tcgplayer: 568241,
+			},
+		},
+	],
+
 	retreat: 3,
 	regulationMark: "G",
-
-	thirdParty: {
-		cardmarket: 693089
-	}
 }
 
 export default card

--- a/data-asia/SV/SV1V/016.ts
+++ b/data-asia/SV/SV1V/016.ts
@@ -62,12 +62,18 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 693090,
+				tcgplayer: 568242,
+			},
+		},
+	],
+
 	retreat: 3,
 	regulationMark: "G",
-
-	thirdParty: {
-		cardmarket: 693090
-	}
 }
 
 export default card

--- a/data-asia/SV/SV1V/017.ts
+++ b/data-asia/SV/SV1V/017.ts
@@ -56,12 +56,18 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 693091,
+				tcgplayer: 568243,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "G",
-
-	thirdParty: {
-		cardmarket: 693091
-	}
 }
 
 export default card

--- a/data-asia/SV/SV1V/018.ts
+++ b/data-asia/SV/SV1V/018.ts
@@ -63,12 +63,18 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 693092,
+				tcgplayer: 568244,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "G",
-
-	thirdParty: {
-		cardmarket: 693092
-	}
 }
 
 export default card

--- a/data-asia/SV/SV1V/019.ts
+++ b/data-asia/SV/SV1V/019.ts
@@ -61,12 +61,18 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 693093,
+				tcgplayer: 568245,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "G",
-
-	thirdParty: {
-		cardmarket: 693093
-	}
 }
 
 export default card

--- a/data-asia/SV/SV1V/020.ts
+++ b/data-asia/SV/SV1V/020.ts
@@ -70,12 +70,18 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 693094,
+				tcgplayer: 568246,
+			},
+		},
+	],
+
 	retreat: 3,
 	regulationMark: "G",
-
-	thirdParty: {
-		cardmarket: 693094
-	}
 }
 
 export default card

--- a/data-asia/SV/SV1V/021.ts
+++ b/data-asia/SV/SV1V/021.ts
@@ -45,12 +45,18 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 693095,
+				tcgplayer: 568247,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "G",
-
-	thirdParty: {
-		cardmarket: 693095
-	}
 }
 
 export default card

--- a/data-asia/SV/SV1V/022.ts
+++ b/data-asia/SV/SV1V/022.ts
@@ -63,12 +63,18 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 693097,
+				tcgplayer: 568248,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "G",
-
-	thirdParty: {
-		cardmarket: 693097
-	}
 }
 
 export default card

--- a/data-asia/SV/SV1V/023.ts
+++ b/data-asia/SV/SV1V/023.ts
@@ -45,6 +45,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 693098,
+				tcgplayer: 568249,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV1V/024.ts
+++ b/data-asia/SV/SV1V/024.ts
@@ -56,6 +56,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 693099,
+				tcgplayer: 568250,
+			},
+		},
+	],
+
 	retreat: 3,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV1V/025.ts
+++ b/data-asia/SV/SV1V/025.ts
@@ -63,6 +63,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 693100,
+				tcgplayer: 568251,
+			},
+		},
+	],
+
 	retreat: 3,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV1V/026.ts
+++ b/data-asia/SV/SV1V/026.ts
@@ -61,12 +61,18 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 693101,
+				tcgplayer: 568252,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "G",
-
-	thirdParty: {
-		cardmarket: 693101
-	}
 }
 
 export default card

--- a/data-asia/SV/SV1V/027.ts
+++ b/data-asia/SV/SV1V/027.ts
@@ -63,12 +63,18 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 693102,
+				tcgplayer: 568253,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "G",
-
-	thirdParty: {
-		cardmarket: 693102
-	}
 }
 
 export default card

--- a/data-asia/SV/SV1V/028.ts
+++ b/data-asia/SV/SV1V/028.ts
@@ -62,12 +62,18 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 693103,
+				tcgplayer: 568254,
+			},
+		},
+	],
+
 	retreat: 3,
 	regulationMark: "G",
-
-	thirdParty: {
-		cardmarket: 693103
-	}
 }
 
 export default card

--- a/data-asia/SV/SV1V/029.ts
+++ b/data-asia/SV/SV1V/029.ts
@@ -70,12 +70,18 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 693104,
+				tcgplayer: 568255,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "G",
-
-	thirdParty: {
-		cardmarket: 693104
-	}
 }
 
 export default card

--- a/data-asia/SV/SV1V/030.ts
+++ b/data-asia/SV/SV1V/030.ts
@@ -68,12 +68,18 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 693105,
+				tcgplayer: 568256,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "G",
-
-	thirdParty: {
-		cardmarket: 693105
-	}
 }
 
 export default card

--- a/data-asia/SV/SV1V/031.ts
+++ b/data-asia/SV/SV1V/031.ts
@@ -45,6 +45,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 693106,
+				tcgplayer: 568257,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV1V/032.ts
+++ b/data-asia/SV/SV1V/032.ts
@@ -68,6 +68,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 693107,
+				tcgplayer: 568258,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV1V/033.ts
+++ b/data-asia/SV/SV1V/033.ts
@@ -50,6 +50,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 693108,
+				tcgplayer: 568259,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV1V/034.ts
+++ b/data-asia/SV/SV1V/034.ts
@@ -56,6 +56,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 693109,
+				tcgplayer: 568260,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV1V/035.ts
+++ b/data-asia/SV/SV1V/035.ts
@@ -63,6 +63,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 693110,
+				tcgplayer: 568261,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV1V/036.ts
+++ b/data-asia/SV/SV1V/036.ts
@@ -70,6 +70,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 693111,
+				tcgplayer: 568262,
+			},
+		},
+	],
+
 	retreat: 0,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV1V/037.ts
+++ b/data-asia/SV/SV1V/037.ts
@@ -62,6 +62,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 693112,
+				tcgplayer: 568263,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV1V/038.ts
+++ b/data-asia/SV/SV1V/038.ts
@@ -66,12 +66,18 @@ const card: Card = {
 		value: "-30"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 693113,
+				tcgplayer: 568264,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "G",
-
-	thirdParty: {
-		cardmarket: 693113
-	}
 }
 
 export default card

--- a/data-asia/SV/SV1V/039.ts
+++ b/data-asia/SV/SV1V/039.ts
@@ -66,12 +66,18 @@ const card: Card = {
 		value: "-30"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 693114,
+				tcgplayer: 568265,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "G",
-
-	thirdParty: {
-		cardmarket: 693114
-	}
 }
 
 export default card

--- a/data-asia/SV/SV1V/040.ts
+++ b/data-asia/SV/SV1V/040.ts
@@ -57,12 +57,18 @@ const card: Card = {
 		value: "-30"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 693115,
+				tcgplayer: 568266,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "G",
-
-	thirdParty: {
-		cardmarket: 693115
-	}
 }
 
 export default card

--- a/data-asia/SV/SV1V/041.ts
+++ b/data-asia/SV/SV1V/041.ts
@@ -67,12 +67,18 @@ const card: Card = {
 		value: "-30"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 693116,
+				tcgplayer: 568267,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "G",
-
-	thirdParty: {
-		cardmarket: 693116
-	}
 }
 
 export default card

--- a/data-asia/SV/SV1V/042.ts
+++ b/data-asia/SV/SV1V/042.ts
@@ -45,12 +45,18 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 693117,
+				tcgplayer: 568268,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "G",
-
-	thirdParty: {
-		cardmarket: 693117
-	}
 }
 
 export default card

--- a/data-asia/SV/SV1V/043.ts
+++ b/data-asia/SV/SV1V/043.ts
@@ -52,12 +52,18 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 693118,
+				tcgplayer: 568269,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "G",
-
-	thirdParty: {
-		cardmarket: 693118
-	}
 }
 
 export default card

--- a/data-asia/SV/SV1V/044.ts
+++ b/data-asia/SV/SV1V/044.ts
@@ -70,12 +70,18 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 693119,
+				tcgplayer: 568270,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "G",
-
-	thirdParty: {
-		cardmarket: 693119
-	}
 }
 
 export default card

--- a/data-asia/SV/SV1V/045.ts
+++ b/data-asia/SV/SV1V/045.ts
@@ -70,12 +70,18 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 693120,
+				tcgplayer: 568271,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "G",
-
-	thirdParty: {
-		cardmarket: 693120
-	}
 }
 
 export default card

--- a/data-asia/SV/SV1V/046.ts
+++ b/data-asia/SV/SV1V/046.ts
@@ -57,6 +57,16 @@ const card: Card = {
 		value: "-30"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 693121,
+				tcgplayer: 568272,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV1V/047.ts
+++ b/data-asia/SV/SV1V/047.ts
@@ -66,6 +66,16 @@ const card: Card = {
 		value: "-30"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 693122,
+				tcgplayer: 568273,
+			},
+		},
+	],
+
 	retreat: 3,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV1V/048.ts
+++ b/data-asia/SV/SV1V/048.ts
@@ -57,6 +57,16 @@ const card: Card = {
 		value: "-30"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 693123,
+				tcgplayer: 568274,
+			},
+		},
+	],
+
 	retreat: 3,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV1V/049.ts
+++ b/data-asia/SV/SV1V/049.ts
@@ -52,12 +52,18 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 693124,
+				tcgplayer: 568275,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "G",
-
-	thirdParty: {
-		cardmarket: 693124
-	}
 }
 
 export default card

--- a/data-asia/SV/SV1V/050.ts
+++ b/data-asia/SV/SV1V/050.ts
@@ -52,12 +52,18 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 693125,
+				tcgplayer: 568276,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "G",
-
-	thirdParty: {
-		cardmarket: 693125
-	}
 }
 
 export default card

--- a/data-asia/SV/SV1V/051.ts
+++ b/data-asia/SV/SV1V/051.ts
@@ -70,6 +70,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 693126,
+				tcgplayer: 568277,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV1V/052.ts
+++ b/data-asia/SV/SV1V/052.ts
@@ -66,12 +66,18 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 693127,
+				tcgplayer: 568278,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "G",
-
-	thirdParty: {
-		cardmarket: 693127
-	}
 }
 
 export default card

--- a/data-asia/SV/SV1V/053.ts
+++ b/data-asia/SV/SV1V/053.ts
@@ -56,6 +56,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 693128,
+				tcgplayer: 568279,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV1V/054.ts
+++ b/data-asia/SV/SV1V/054.ts
@@ -52,6 +52,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 693129,
+				tcgplayer: 568280,
+			},
+		},
+	],
+
 	retreat: 3,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV1V/055.ts
+++ b/data-asia/SV/SV1V/055.ts
@@ -70,6 +70,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 693130,
+				tcgplayer: 568281,
+			},
+		},
+	],
+
 	retreat: 3,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV1V/056.ts
+++ b/data-asia/SV/SV1V/056.ts
@@ -73,6 +73,16 @@ const card: Card = {
 		value: "-30"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 693131,
+				tcgplayer: 568282,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV1V/057.ts
+++ b/data-asia/SV/SV1V/057.ts
@@ -75,12 +75,18 @@ const card: Card = {
 		value: "-30"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 693132,
+				tcgplayer: 568283,
+			},
+		},
+	],
+
 	retreat: 3,
 	regulationMark: "G",
-
-	thirdParty: {
-		cardmarket: 693132
-	}
 }
 
 export default card

--- a/data-asia/SV/SV1V/058.ts
+++ b/data-asia/SV/SV1V/058.ts
@@ -65,6 +65,16 @@ const card: Card = {
 		value: "-30"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 693133,
+				tcgplayer: 568284,
+			},
+		},
+	],
+
 	retreat: 3,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV1V/059.ts
+++ b/data-asia/SV/SV1V/059.ts
@@ -63,12 +63,18 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 693134,
+				tcgplayer: 568285,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "G",
-
-	thirdParty: {
-		cardmarket: 693134
-	}
 }
 
 export default card

--- a/data-asia/SV/SV1V/060.ts
+++ b/data-asia/SV/SV1V/060.ts
@@ -70,12 +70,18 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 693135,
+				tcgplayer: 568286,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "G",
-
-	thirdParty: {
-		cardmarket: 693135
-	}
 }
 
 export default card

--- a/data-asia/SV/SV1V/061.ts
+++ b/data-asia/SV/SV1V/061.ts
@@ -63,6 +63,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 693136,
+				tcgplayer: 568287,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV1V/062.ts
+++ b/data-asia/SV/SV1V/062.ts
@@ -63,6 +63,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 693137,
+				tcgplayer: 568288,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV1V/063.ts
+++ b/data-asia/SV/SV1V/063.ts
@@ -68,6 +68,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 693138,
+				tcgplayer: 568289,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV1V/064.ts
+++ b/data-asia/SV/SV1V/064.ts
@@ -45,6 +45,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 693139,
+				tcgplayer: 568290,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV1V/065.ts
+++ b/data-asia/SV/SV1V/065.ts
@@ -52,6 +52,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 693140,
+				tcgplayer: 568291,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV1V/066.ts
+++ b/data-asia/SV/SV1V/066.ts
@@ -63,6 +63,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 693141,
+				tcgplayer: 568292,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV1V/067.ts
+++ b/data-asia/SV/SV1V/067.ts
@@ -73,6 +73,16 @@ const card: Card = {
 		value: "-30"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 693142,
+				tcgplayer: 568293,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV1V/068.ts
+++ b/data-asia/SV/SV1V/068.ts
@@ -61,12 +61,18 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 693143,
+				tcgplayer: 568294,
+			},
+		},
+	],
+
 	retreat: 0,
 	regulationMark: "G",
-
-	thirdParty: {
-		cardmarket: 693143
-	}
 }
 
 export default card

--- a/data-asia/SV/SV1V/069.ts
+++ b/data-asia/SV/SV1V/069.ts
@@ -22,6 +22,16 @@ const card: Card = {
 		id: "Lihat 5 kartu dari atas Deck sendiri, pilih paling banyak 2 lembar Energi Dasar {Listrik} di antaranya, lalu kenakan sesukanya pada Pokémon {Listrik} di Cadangan. Kocok kembali sisa kartu ke Deck."
 	},
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 693144,
+				tcgplayer: 568295,
+			},
+		},
+	],
+
 	trainerType: "Item",
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV1V/070.ts
+++ b/data-asia/SV/SV1V/070.ts
@@ -22,6 +22,16 @@ const card: Card = {
 		id: "Kartu ini dapat digunakan jika pemain membuang 2 lembar Kartu Pegangan sendiri ke Trash. Pilih 1 lembar Pokémon dari Deck sendiri, perlihatkan ke lawan, lalu tambahkan ke Kartu Pegangan. Kemudian, kocok Deck."
 	},
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 693145,
+				tcgplayer: 568296,
+			},
+		},
+	],
+
 	trainerType: "Item",
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV1V/071.ts
+++ b/data-asia/SV/SV1V/071.ts
@@ -22,6 +22,16 @@ const card: Card = {
 		id: "Pulihkan HP semua Pokémon kedua pemain masing-masing sejumlah 30."
 	},
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 693146,
+				tcgplayer: 568297,
+			},
+		},
+	],
+
 	trainerType: "Item",
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV1V/072.ts
+++ b/data-asia/SV/SV1V/072.ts
@@ -22,6 +22,16 @@ const card: Card = {
 		id: "Pilih 1 lembar Pokémon Stage 2 dari Kartu Pegangan sendiri, lalu letakkan ke Pokémon Basic di Arena sendiri yang berevolusi menjadi Pokémon tersebut, lakukan evolusi tanpa perlu melakukan evolusi Stage 1. (Tidak dapat digunakan pada giliran pertama pemain dan pada Pokémon yang baru dimasukkan.)"
 	},
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 693147,
+				tcgplayer: 568298,
+			},
+		},
+	],
+
 	trainerType: "Item",
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV1V/073.ts
+++ b/data-asia/SV/SV1V/073.ts
@@ -22,6 +22,16 @@ const card: Card = {
 		id: "Saat Pokémon yang mengenakan kartu ini ada di Arena Bertarung dan menerima kerusakan akibat serangan dari Pokémon lawan, letakkan 2 Token Kerusakan pada Pokémon yang telah menggunakan serangan."
 	},
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 693148,
+				tcgplayer: 568299,
+			},
+		},
+	],
+
 	trainerType: "Tool",
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV1V/074.ts
+++ b/data-asia/SV/SV1V/074.ts
@@ -22,6 +22,16 @@ const card: Card = {
 		id: "Giliran pemain akan selesai jika menggunakan kartu ini. Kocok kembali semua Kartu Pegangan sendiri ke Deck. Setelah itu, ambil 8 kartu dari atas Deck."
 	},
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 693149,
+				tcgplayer: 568300,
+			},
+		},
+	],
+
 	trainerType: "Supporter",
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV1V/075.ts
+++ b/data-asia/SV/SV1V/075.ts
@@ -22,6 +22,16 @@ const card: Card = {
 		id: "Buang semua Kartu Pegangan sendiri ke Trash, lalu ambil 7 kartu dari atas Deck."
 	},
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 693150,
+				tcgplayer: 568301,
+			},
+		},
+	],
+
 	trainerType: "Supporter",
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV1V/076.ts
+++ b/data-asia/SV/SV1V/076.ts
@@ -22,6 +22,16 @@ const card: Card = {
 		id: "Pilih Item dan Pokémon Tool masing-masing 1 lembar dari Deck sendiri, perlihatkan ke lawan, lalu tambahkan ke Kartu Pegangan. Kemudian, kocok Deck."
 	},
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 693151,
+				tcgplayer: 568302,
+			},
+		},
+	],
+
 	trainerType: "Supporter",
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV1V/077.ts
+++ b/data-asia/SV/SV1V/077.ts
@@ -22,6 +22,16 @@ const card: Card = {
 		id: "Pilih paling banyak 5 lembar Pokémon dari Trash sendiri, perlihatkan ke lawan, lalu kocok kembali ke Deck. Setelah itu, ambil 3 kartu dari atas Deck."
 	},
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 693152,
+				tcgplayer: 568303,
+			},
+		},
+	],
+
 	trainerType: "Supporter",
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV1V/078.ts
+++ b/data-asia/SV/SV1V/078.ts
@@ -22,6 +22,16 @@ const card: Card = {
 		id: "Kedua pemain 1 kali pada tiap gilirannya sendiri dapat melempar koin 1 kali. Jika hasilnya sisi depan, pilih 1 lembar Pokémon dari Deck sendiri, perlihatkan ke lawan, lalu tambahkan ke Kartu Pegangan. Kemudian, kocok Deck."
 	},
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 693153,
+				tcgplayer: 568304,
+			},
+		},
+	],
+
 	trainerType: "Stadium",
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV1V/079.ts
+++ b/data-asia/SV/SV1V/079.ts
@@ -39,6 +39,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 693154,
+				tcgplayer: 568305,
+			},
+		},
+	],
+
 	retreat: 1
 }
 

--- a/data-asia/SV/SV1V/080.ts
+++ b/data-asia/SV/SV1V/080.ts
@@ -39,6 +39,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 693155,
+				tcgplayer: 568306,
+			},
+		},
+	],
+
 	retreat: 1
 }
 

--- a/data-asia/SV/SV1V/081.ts
+++ b/data-asia/SV/SV1V/081.ts
@@ -51,6 +51,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 693156,
+				tcgplayer: 568307,
+			},
+		},
+	],
+
 	retreat: 1
 }
 

--- a/data-asia/SV/SV1V/082.ts
+++ b/data-asia/SV/SV1V/082.ts
@@ -45,11 +45,17 @@ const card: Card = {
 		value: "×2"
 	}],
 
-	retreat: 2,
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 693157,
+				tcgplayer: 568308,
+			},
+		},
+	],
 
-	thirdParty: {
-		cardmarket: 693093
-	}
+	retreat: 2,
 }
 
 export default card

--- a/data-asia/SV/SV1V/083.ts
+++ b/data-asia/SV/SV1V/083.ts
@@ -35,11 +35,17 @@ const card: Card = {
 		value: "×2"
 	}],
 
-	retreat: 1,
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 693158,
+				tcgplayer: 568309,
+			},
+		},
+	],
 
-	thirdParty: {
-		cardmarket: 693095
-	}
+	retreat: 1,
 }
 
 export default card

--- a/data-asia/SV/SV1V/084.ts
+++ b/data-asia/SV/SV1V/084.ts
@@ -51,11 +51,17 @@ const card: Card = {
 		value: "×2"
 	}],
 
-	retreat: 1,
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 693159,
+				tcgplayer: 568310,
+			},
+		},
+	],
 
-	thirdParty: {
-		cardmarket: 693104
-	}
+	retreat: 1,
 }
 
 export default card

--- a/data-asia/SV/SV1V/085.ts
+++ b/data-asia/SV/SV1V/085.ts
@@ -51,6 +51,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 693160,
+				tcgplayer: 568311,
+			},
+		},
+	],
+
 	retreat: 0
 }
 

--- a/data-asia/SV/SV1V/086.ts
+++ b/data-asia/SV/SV1V/086.ts
@@ -50,11 +50,17 @@ const card: Card = {
 		value: "－30"
 	}],
 
-	retreat: 1,
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 693161,
+				tcgplayer: 568312,
+			},
+		},
+	],
 
-	thirdParty: {
-		cardmarket: 693113
-	}
+	retreat: 1,
 }
 
 export default card

--- a/data-asia/SV/SV1V/087.ts
+++ b/data-asia/SV/SV1V/087.ts
@@ -44,6 +44,16 @@ const card: Card = {
 		value: "－30"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 693162,
+				tcgplayer: 568313,
+			},
+		},
+	],
+
 	retreat: 2
 }
 

--- a/data-asia/SV/SV1V/088.ts
+++ b/data-asia/SV/SV1V/088.ts
@@ -51,6 +51,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 693163,
+				tcgplayer: 568314,
+			},
+		},
+	],
+
 	retreat: 3
 }
 

--- a/data-asia/SV/SV1V/089.ts
+++ b/data-asia/SV/SV1V/089.ts
@@ -54,6 +54,16 @@ const card: Card = {
 		value: "－30"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 693164,
+				tcgplayer: 568315,
+			},
+		},
+	],
+
 	retreat: 1
 }
 

--- a/data-asia/SV/SV1V/090.ts
+++ b/data-asia/SV/SV1V/090.ts
@@ -47,6 +47,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 693165,
+				tcgplayer: 568316,
+			},
+		},
+	],
+
 	retreat: 1
 }
 

--- a/data-asia/SV/SV1V/091.ts
+++ b/data-asia/SV/SV1V/091.ts
@@ -46,6 +46,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 693166,
+				tcgplayer: 568317,
+			},
+		},
+	],
+
 	retreat: 2
 }
 

--- a/data-asia/SV/SV1V/092.ts
+++ b/data-asia/SV/SV1V/092.ts
@@ -46,11 +46,17 @@ const card: Card = {
 		value: "×2"
 	}],
 
-	retreat: 3,
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 693167,
+				tcgplayer: 568318,
+			},
+		},
+	],
 
-	thirdParty: {
-		cardmarket: 693090
-	}
+	retreat: 3,
 }
 
 export default card

--- a/data-asia/SV/SV1V/093.ts
+++ b/data-asia/SV/SV1V/093.ts
@@ -46,11 +46,17 @@ const card: Card = {
 		value: "×2"
 	}],
 
-	retreat: 3,
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 693168,
+				tcgplayer: 568319,
+			},
+		},
+	],
 
-	thirdParty: {
-		cardmarket: 693103
-	}
+	retreat: 3,
 }
 
 export default card

--- a/data-asia/SV/SV1V/094.ts
+++ b/data-asia/SV/SV1V/094.ts
@@ -46,6 +46,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 693169,
+				tcgplayer: 568320,
+			},
+		},
+	],
+
 	retreat: 1
 }
 

--- a/data-asia/SV/SV1V/095.ts
+++ b/data-asia/SV/SV1V/095.ts
@@ -51,11 +51,17 @@ const card: Card = {
 		value: "－30"
 	}],
 
-	retreat: 2,
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 693170,
+				tcgplayer: 568321,
+			},
+		},
+	],
 
-	thirdParty: {
-		cardmarket: 693116
-	}
+	retreat: 2,
 }
 
 export default card

--- a/data-asia/SV/SV1V/096.ts
+++ b/data-asia/SV/SV1V/096.ts
@@ -49,6 +49,16 @@ const card: Card = {
 		value: "－30"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 693171,
+				tcgplayer: 568322,
+			},
+		},
+	],
+
 	retreat: 3
 }
 

--- a/data-asia/SV/SV1V/097.ts
+++ b/data-asia/SV/SV1V/097.ts
@@ -15,6 +15,16 @@ const card: Card = {
 		ja: "このカードを使ったら、自分の番は終わる。\n\n自分の手札をすべて山札にもどして切る。その後、山札を8枚引く。"
 	},
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 693172,
+				tcgplayer: 568323,
+			},
+		},
+	],
+
 	trainerType: "Supporter"
 }
 

--- a/data-asia/SV/SV1V/098.ts
+++ b/data-asia/SV/SV1V/098.ts
@@ -15,6 +15,16 @@ const card: Card = {
 		ja: "自分の手札をすべてトラッシュし、山札を7枚引く。"
 	},
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 693173,
+				tcgplayer: 568324,
+			},
+		},
+	],
+
 	trainerType: "Supporter"
 }
 

--- a/data-asia/SV/SV1V/099.ts
+++ b/data-asia/SV/SV1V/099.ts
@@ -15,6 +15,16 @@ const card: Card = {
 		ja: "自分の山札から「グッズ」と「ポケモンのどうぐ」を1枚ずつ選び、相手に見せて、手札に加える。そして山札を切る。"
 	},
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 693174,
+				tcgplayer: 568325,
+			},
+		},
+	],
+
 	trainerType: "Supporter"
 }
 

--- a/data-asia/SV/SV1V/100.ts
+++ b/data-asia/SV/SV1V/100.ts
@@ -15,6 +15,16 @@ const card: Card = {
 		ja: "自分のトラッシュからポケモンを5枚まで選び、相手に見せて、山札にもどして切る。その後、山札を3枚引く。"
 	},
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 693175,
+				tcgplayer: 568326,
+			},
+		},
+	],
+
 	trainerType: "Supporter"
 }
 

--- a/data-asia/SV/SV1V/101.ts
+++ b/data-asia/SV/SV1V/101.ts
@@ -46,6 +46,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 693176,
+				tcgplayer: 568327,
+			},
+		},
+	],
+
 	retreat: 2
 }
 

--- a/data-asia/SV/SV1V/102.ts
+++ b/data-asia/SV/SV1V/102.ts
@@ -46,6 +46,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 693177,
+				tcgplayer: 568328,
+			},
+		},
+	],
+
 	retreat: 1
 }
 

--- a/data-asia/SV/SV1V/103.ts
+++ b/data-asia/SV/SV1V/103.ts
@@ -49,6 +49,16 @@ const card: Card = {
 		value: "－30"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 693178,
+				tcgplayer: 568329,
+			},
+		},
+	],
+
 	retreat: 3
 }
 

--- a/data-asia/SV/SV1V/104.ts
+++ b/data-asia/SV/SV1V/104.ts
@@ -15,6 +15,16 @@ const card: Card = {
 		ja: "自分の山札から「グッズ」と「ポケモンのどうぐ」を1枚ずつ選び、相手に見せて、手札に加える。そして山札を切る。"
 	},
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 693179,
+				tcgplayer: 568330,
+			},
+		},
+	],
+
 	trainerType: "Supporter"
 }
 

--- a/data-asia/SV/SV1V/105.ts
+++ b/data-asia/SV/SV1V/105.ts
@@ -15,6 +15,16 @@ const card: Card = {
 		ja: "自分のトラッシュからポケモンを5枚まで選び、相手に見せて、山札にもどして切る。その後、山札を3枚引く。"
 	},
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 693180,
+				tcgplayer: 568331,
+			},
+		},
+	],
+
 	trainerType: "Supporter"
 }
 

--- a/data-asia/SV/SV1V/106.ts
+++ b/data-asia/SV/SV1V/106.ts
@@ -46,6 +46,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 693181,
+				tcgplayer: 568332,
+			},
+		},
+	],
+
 	retreat: 1
 }
 

--- a/data-asia/SV/SV1V/107.ts
+++ b/data-asia/SV/SV1V/107.ts
@@ -15,6 +15,16 @@ const card: Card = {
 		ja: "自分の手札から2進化ポケモンを1枚選び、そのポケモンへと進化する自分の場のたねポケモンにのせ、1進化をとばして進化させる。（最初の自分の番や、出したばかりのポケモンには使えない。）"
 	},
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 693182,
+				tcgplayer: 568333,
+			},
+		},
+	],
+
 	trainerType: "Item"
 }
 

--- a/data-asia/SV/SV1V/108.ts
+++ b/data-asia/SV/SV1V/108.ts
@@ -9,7 +9,17 @@ const card: Card = {
 	},
 
 	category: "Energy",
-	energyType: "Normal"
+	energyType: "Normal",
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 693183,
+				tcgplayer: 568334,
+			},
+		},
+	],
 }
 
 export default card


### PR DESCRIPTION
## What

Links the cards of the existing Japanese set **SV1V バイオレットex (Violet ex)** to their Cardmarket **and TCGplayer** products, so the API can serve their prices.

- **68** cards carried no product id at all and get both
- **40** carried a card-level `thirdParty.cardmarket`, which is moved onto the card's `variants` entry and joined by its tcgplayer id
- **7** carried the cardmarket id of a different print and are corrected

Afterwards every card of the set carries its id on a `variants` entry and none on the card itself, which is where tcgdex is heading. Nothing else changes: the `zh-tw`/`th`/`id` texts and the Japanese card data are not rewritten.

7 cards carried the product of **another print** of the same card, so the API served that print's price for them:

| card | was | is | the old id belongs to |
|---|---|---|---|
| 082 | 693093 | 693157 | points at card 019 of this set |
| 083 | 693095 | 693158 | points at card 021 of this set |
| 084 | 693104 | 693159 | points at card 029 of this set |
| 086 | 693113 | 693161 | points at card 038 of this set |
| 092 | 693090 | 693167 | points at card 016 of this set |
| 093 | 693103 | 693168 | points at card 028 of this set |
| 095 | 693116 | 693170 | points at card 041 of this set |

The ids are assigned **by collection number**, not by name: within a Cardmarket expansion the products sorted by `idProduct` follow the collection order, and the assignment is verified against the sample rows pokepricelab renders. That matters because Cardmarket names every print of a card identically inside an expansion, so a name lookup cannot tell a base print from its AR/full-art reprint — which is where the corrected ids above come from. That the 33 ids this set already carried correctly agree with the same assignment is an independent cross-check.

## Data sources

- **Cardmarket** public product catalog (`downloads.s3.cardmarket.com`): the product ids (693075–693183), assigned by collection number
- **pokepricelab.com**: the sample rows that verify that assignment
- **TCGplayer** via [tcgcsv.com](https://tcgcsv.com) (category 85, "Pokemon Japan"): product IDs as `thirdParty.tcgplayer` (568227–568334), keyed by the collection number each product carries in `extendedData`
- **limitlesstcg.com**: the set's card list — used here for nothing but the rarity per number, which decides whether a variant is `holo` or `normal`

## Notes

- `tsc --noEmit` reports the same 30 pre-existing errors as upstream/master — this change adds none. They are `rarity` being required by `interfaces.d.ts` while these older hand-written files omit it, which is out of scope here.
