### PR TITLE
(data) ja M1S Mega Symphonia - cardmarket + tcgplayer product ids

### DIFF
--- a/data-asia/M/M1S/001.ts
+++ b/data-asia/M/M1S/001.ts
@@ -33,6 +33,16 @@ const card: Card = {
 		type: "Fire",
 		value: "×2"
 	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 840539,
+				tcgplayer: 647258,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "I",
 	rarity: "Common",

--- a/data-asia/M/M1S/002.ts
+++ b/data-asia/M/M1S/002.ts
@@ -14,6 +14,16 @@ const card: Card = {
 		ja: "暖かい土地で暮らすものほど、ツルの伸びが早い。伸びると自ら切って短くする。"
 	},
 	stage: "Stage1",
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 840540,
+				tcgplayer: 647259,
+			},
+		},
+	],
+
 	evolveFrom: {
 		ja: "モンジャラ"
 	},

--- a/data-asia/M/M1S/003.ts
+++ b/data-asia/M/M1S/003.ts
@@ -25,6 +25,16 @@ const card: Card = {
 		type: "Fire",
 		value: "×2"
 	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 840542,
+				tcgplayer: 647242,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "I",
 	rarity: "Common",

--- a/data-asia/M/M1S/004.ts
+++ b/data-asia/M/M1S/004.ts
@@ -14,6 +14,16 @@ const card: Card = {
 		ja: "首の周りから出されるスパイシーな香りを嗅いでいるとなぜだか戦いたくなる。"
 	},
 	stage: "Stage1",
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 840543,
+				tcgplayer: 647243,
+			},
+		},
+	],
+
 	evolveFrom: {
 		ja: "チコリータ"
 	},

--- a/data-asia/M/M1S/005.ts
+++ b/data-asia/M/M1S/005.ts
@@ -14,6 +14,16 @@ const card: Card = {
 		ja: "メガニウムのそばにいると森林浴をしたようなすがすがしい気分になれる。"
 	},
 	stage: "Stage2",
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 840545,
+				tcgplayer: 647244,
+			},
+		},
+	],
+
 	evolveFrom: {
 		ja: "ベイリーフ"
 	},

--- a/data-asia/M/M1S/006.ts
+++ b/data-asia/M/M1S/006.ts
@@ -34,6 +34,16 @@ const card: Card = {
 		type: "Fire",
 		value: "×2"
 	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 840547,
+				tcgplayer: 647260,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "I",
 	rarity: "Uncommon",

--- a/data-asia/M/M1S/007.ts
+++ b/data-asia/M/M1S/007.ts
@@ -25,6 +25,16 @@ const card: Card = {
 		type: "Fire",
 		value: "×2"
 	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 840549,
+				tcgplayer: 647226,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "I",
 	rarity: "Common",

--- a/data-asia/M/M1S/008.ts
+++ b/data-asia/M/M1S/008.ts
@@ -14,6 +14,16 @@ const card: Card = {
 		ja: "どんな攻撃でも避けてしまうと いわれるほど素早い ポケモン。甘い樹液が大好物。"
 	},
 	stage: "Stage1",
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 840553,
+				tcgplayer: 647227,
+			},
+		},
+	],
+
 	evolveFrom: {
 		ja: "ツチニン"
 	},

--- a/data-asia/M/M1S/009.ts
+++ b/data-asia/M/M1S/009.ts
@@ -28,6 +28,16 @@ const card: Card = {
 		type: "Fire",
 		value: "×2"
 	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 840554,
+				tcgplayer: 647262,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "I",
 	rarity: "Common",

--- a/data-asia/M/M1S/010.ts
+++ b/data-asia/M/M1S/010.ts
@@ -25,6 +25,16 @@ const card: Card = {
 		type: "Water",
 		value: "×2"
 	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 840556,
+				tcgplayer: 647263,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "I",
 	rarity: "Common",

--- a/data-asia/M/M1S/011.ts
+++ b/data-asia/M/M1S/011.ts
@@ -14,6 +14,16 @@ const card: Card = {
 		ja: "オスの たてがみは 戦いになると 摂氏２０００度の 高温になる。 近寄るだけで 大火傷だ。"
 	},
 	stage: "Stage1",
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 840557,
+				tcgplayer: 647265,
+			},
+		},
+	],
+
 	evolveFrom: {
 		ja: "シシコ"
 	},

--- a/data-asia/M/M1S/012.ts
+++ b/data-asia/M/M1S/012.ts
@@ -31,6 +31,16 @@ const card: Card = {
 		type: "Water",
 		value: "×2"
 	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 840558,
+				tcgplayer: 647266,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "I",
 	rarity: "Common",

--- a/data-asia/M/M1S/013.ts
+++ b/data-asia/M/M1S/013.ts
@@ -14,6 +14,16 @@ const card: Card = {
 		ja: "攻撃的な性質。焼けた体も危険だが大きなキバも鋭いぞ。"
 	},
 	stage: "Stage1",
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 840559,
+				tcgplayer: 647267,
+			},
+		},
+	],
+
 	evolveFrom: {
 		ja: "ヤクデ"
 	},

--- a/data-asia/M/M1S/014.ts
+++ b/data-asia/M/M1S/014.ts
@@ -28,6 +28,16 @@ const card: Card = {
 		type: "Water",
 		value: "×2"
 	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 840562,
+				tcgplayer: 647268,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "I",
 	rarity: "Uncommon",

--- a/data-asia/M/M1S/015.ts
+++ b/data-asia/M/M1S/015.ts
@@ -33,6 +33,16 @@ const card: Card = {
 		type: "Lightning",
 		value: "×2"
 	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 840564,
+				tcgplayer: 647269,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "I",
 	rarity: "Common",

--- a/data-asia/M/M1S/016.ts
+++ b/data-asia/M/M1S/016.ts
@@ -37,6 +37,16 @@ const card: Card = {
 		type: "Lightning",
 		value: "×2"
 	}],
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 840566,
+				tcgplayer: 647241,
+			},
+		},
+	],
+
 	retreat: 3,
 	regulationMark: "I",
 	rarity: "Rare",

--- a/data-asia/M/M1S/017.ts
+++ b/data-asia/M/M1S/017.ts
@@ -31,6 +31,16 @@ const card: Card = {
 		type: "Metal",
 		value: "×2"
 	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 840567,
+				tcgplayer: 647245,
+			},
+		},
+	],
+
 	retreat: 3,
 	regulationMark: "I",
 	rarity: "Common",

--- a/data-asia/M/M1S/018.ts
+++ b/data-asia/M/M1S/018.ts
@@ -11,6 +11,16 @@ const card: Card = {
 	hp: 350,
 	types: ["Water"],
 	stage: "MEGA",
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 840568,
+				tcgplayer: 647247,
+			},
+		},
+	],
+
 	evolveFrom: {
 		ja: "ユキカブリ"
 	},

--- a/data-asia/M/M1S/019.ts
+++ b/data-asia/M/M1S/019.ts
@@ -25,6 +25,16 @@ const card: Card = {
 		type: "Lightning",
 		value: "×2"
 	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 840569,
+				tcgplayer: 647272,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "I",
 	rarity: "Common",

--- a/data-asia/M/M1S/020.ts
+++ b/data-asia/M/M1S/020.ts
@@ -14,6 +14,16 @@ const card: Card = {
 		ja: "体内ガスの力でハサミのお尻から水を噴射して６０ノットのスピードで泳ぐ。"
 	},
 	stage: "Stage1",
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 840571,
+				tcgplayer: 647273,
+			},
+		},
+	],
+
 	evolveFrom: {
 		ja: "ウデッポウ"
 	},

--- a/data-asia/M/M1S/021.ts
+++ b/data-asia/M/M1S/021.ts
@@ -28,6 +28,16 @@ const card: Card = {
 		type: "Lightning",
 		value: "×2"
 	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 840572,
+				tcgplayer: 647208,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "I",
 	rarity: "Common",

--- a/data-asia/M/M1S/022.ts
+++ b/data-asia/M/M1S/022.ts
@@ -14,6 +14,16 @@ const card: Card = {
 		ja: "粘液まみれの長い舌を目にも留まらない速さで伸ばし獲物を見事に仕留めてみせる。"
 	},
 	stage: "Stage1",
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 840573,
+				tcgplayer: 647209,
+			},
+		},
+	],
+
 	evolveFrom: {
 		ja: "メッソン"
 	},

--- a/data-asia/M/M1S/023.ts
+++ b/data-asia/M/M1S/023.ts
@@ -14,6 +14,16 @@ const card: Card = {
 		ja: "目の特殊なレンズを使って相手の体温などを感知して急所を見抜き攻撃する。"
 	},
 	stage: "Stage2",
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 840574,
+				tcgplayer: 647210,
+			},
+		},
+	],
+
 	evolveFrom: {
 		ja: "ジメレオン"
 	},

--- a/data-asia/M/M1S/024.ts
+++ b/data-asia/M/M1S/024.ts
@@ -27,6 +27,16 @@ const card: Card = {
 		type: "Metal",
 		value: "×2"
 	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 840576,
+				tcgplayer: 647275,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "I",
 	rarity: "Common",

--- a/data-asia/M/M1S/025.ts
+++ b/data-asia/M/M1S/025.ts
@@ -14,6 +14,16 @@ const card: Card = {
 		ja: "触角で大気の流れを察知する。りんぷんに冷気を織り交ぜ雪のように降らせる。"
 	},
 	stage: "Stage1",
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 840579,
+				tcgplayer: 647276,
+			},
+		},
+	],
+
 	evolveFrom: {
 		ja: "ユキハミ"
 	},

--- a/data-asia/M/M1S/026.ts
+++ b/data-asia/M/M1S/026.ts
@@ -34,6 +34,16 @@ const card: Card = {
 		type: "Metal",
 		value: "×2"
 	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 840580,
+				tcgplayer: 647277,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "I",
 	rarity: "Common",

--- a/data-asia/M/M1S/027.ts
+++ b/data-asia/M/M1S/027.ts
@@ -25,6 +25,16 @@ const card: Card = {
 		type: "Fighting",
 		value: "×2"
 	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 840582,
+				tcgplayer: 647278,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "I",
 	rarity: "Common",

--- a/data-asia/M/M1S/028.ts
+++ b/data-asia/M/M1S/028.ts
@@ -14,6 +14,16 @@ const card: Card = {
 		ja: "3つのコイルは強い磁力で結びついている。そばに寄ると強い耳鳴りに襲われる。"
 	},
 	stage: "Stage1",
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 840583,
+				tcgplayer: 647279,
+			},
+		},
+	],
+
 	evolveFrom: {
 		ja: "コイル"
 	},

--- a/data-asia/M/M1S/029.ts
+++ b/data-asia/M/M1S/029.ts
@@ -14,6 +14,16 @@ const card: Card = {
 		ja: "怪電波を発信しながら空を飛びまわり未知の電波を受信しているという。"
 	},
 	stage: "Stage2",
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 840584,
+				tcgplayer: 647280,
+			},
+		},
+	],
+
 	evolveFrom: {
 		ja: "レアコイル"
 	},

--- a/data-asia/M/M1S/030.ts
+++ b/data-asia/M/M1S/030.ts
@@ -28,6 +28,16 @@ const card: Card = {
 		type: "Fighting",
 		value: "×2"
 	}],
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 840585,
+				tcgplayer: 647270,
+			},
+		},
+	],
+
 	retreat: 0,
 	regulationMark: "I",
 	rarity: "Rare",

--- a/data-asia/M/M1S/031.ts
+++ b/data-asia/M/M1S/031.ts
@@ -28,6 +28,16 @@ const card: Card = {
 		type: "Fighting",
 		value: "×2"
 	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 840586,
+				tcgplayer: 647249,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "I",
 	rarity: "Common",

--- a/data-asia/M/M1S/032.ts
+++ b/data-asia/M/M1S/032.ts
@@ -11,6 +11,16 @@ const card: Card = {
 	hp: 330,
 	types: ["Lightning"],
 	stage: "Stage1",
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 840588,
+				tcgplayer: 647250,
+			},
+		},
+	],
+
 	evolveFrom: {
 		ja: "ラクライ"
 	},

--- a/data-asia/M/M1S/033.ts
+++ b/data-asia/M/M1S/033.ts
@@ -28,6 +28,16 @@ const card: Card = {
 		type: "Fighting",
 		value: "×2"
 	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 840589,
+				tcgplayer: 647212,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "I",
 	rarity: "Common",

--- a/data-asia/M/M1S/034.ts
+++ b/data-asia/M/M1S/034.ts
@@ -28,6 +28,16 @@ const card: Card = {
 		type: "Fighting",
 		value: "×2"
 	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 840590,
+				tcgplayer: 647281,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "I",
 	rarity: "Common",

--- a/data-asia/M/M1S/035.ts
+++ b/data-asia/M/M1S/035.ts
@@ -14,6 +14,16 @@ const card: Card = {
 		ja: "襟巻を広げて太陽光を浴びると大都会で使われる電気を1匹で発電する。"
 	},
 	stage: "Stage1",
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 840591,
+				tcgplayer: 647283,
+			},
+		},
+	],
+
 	evolveFrom: {
 		ja: "エリキテル"
 	},

--- a/data-asia/M/M1S/036.ts
+++ b/data-asia/M/M1S/036.ts
@@ -32,6 +32,16 @@ const card: Card = {
 		type: "Fighting",
 		value: "-30"
 	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 840595,
+				tcgplayer: 647231,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "I",
 	rarity: "Common",

--- a/data-asia/M/M1S/037.ts
+++ b/data-asia/M/M1S/037.ts
@@ -14,6 +14,16 @@ const card: Card = {
 		ja: "念力の威力は絶大。進化に備えて額の星にサイコパワーを蓄えている。"
 	},
 	stage: "Stage1",
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 840596,
+				tcgplayer: 647232,
+			},
+		},
+	],
+
 	evolveFrom: {
 		ja: "ケーシィ"
 	},

--- a/data-asia/M/M1S/038.ts
+++ b/data-asia/M/M1S/038.ts
@@ -14,6 +14,16 @@ const card: Card = {
 		ja: "強力な超能力を操る。両手のスプーンはその力で作りだしたという。"
 	},
 	stage: "Stage2",
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 840597,
+				tcgplayer: 647233,
+			},
+		},
+	],
+
 	evolveFrom: {
 		ja: "ユンゲラー"
 	},

--- a/data-asia/M/M1S/039.ts
+++ b/data-asia/M/M1S/039.ts
@@ -32,6 +32,16 @@ const card: Card = {
 		type: "Fighting",
 		value: "-30"
 	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 840598,
+				tcgplayer: 647257,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "I",
 	rarity: "Common",

--- a/data-asia/M/M1S/040.ts
+++ b/data-asia/M/M1S/040.ts
@@ -37,6 +37,16 @@ const card: Card = {
 		type: "Fighting",
 		value: "-30"
 	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 840599,
+				tcgplayer: 647213,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "I",
 	rarity: "Common",

--- a/data-asia/M/M1S/041.ts
+++ b/data-asia/M/M1S/041.ts
@@ -14,6 +14,16 @@ const card: Card = {
 		ja: "サイコパワーを操りまわりの空間をねじ曲げることで未来を見通すことができる。"
 	},
 	stage: "Stage1",
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 840600,
+				tcgplayer: 647214,
+			},
+		},
+	],
+
 	evolveFrom: {
 		ja: "ラルトス"
 	},

--- a/data-asia/M/M1S/042.ts
+++ b/data-asia/M/M1S/042.ts
@@ -11,6 +11,16 @@ const card: Card = {
 	hp: 360,
 	types: ["Psychic"],
 	stage: "Stage2",
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 840601,
+				tcgplayer: 647204,
+			},
+		},
+	],
+
 	evolveFrom: {
 		ja: "キルリア"
 	},

--- a/data-asia/M/M1S/043.ts
+++ b/data-asia/M/M1S/043.ts
@@ -41,6 +41,16 @@ const card: Card = {
 		type: "Fighting",
 		value: "-30"
 	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 840602,
+				tcgplayer: 647229,
+			},
+		},
+	],
+
 	retreat: 0,
 	regulationMark: "I",
 	rarity: "Uncommon",

--- a/data-asia/M/M1S/044.ts
+++ b/data-asia/M/M1S/044.ts
@@ -32,6 +32,16 @@ const card: Card = {
 		type: "Fighting",
 		value: "-30"
 	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 840603,
+				tcgplayer: 647284,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "I",
 	rarity: "Common",

--- a/data-asia/M/M1S/045.ts
+++ b/data-asia/M/M1S/045.ts
@@ -14,6 +14,16 @@ const card: Card = {
 		ja: "相手を操るときの不思議なステップは昔外国で大流行したことがある。"
 	},
 	stage: "Stage1",
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 840604,
+				tcgplayer: 647285,
+			},
+		},
+	],
+
 	evolveFrom: {
 		ja: "バネブー"
 	},

--- a/data-asia/M/M1S/046.ts
+++ b/data-asia/M/M1S/046.ts
@@ -36,6 +36,16 @@ const card: Card = {
 		type: "Metal",
 		value: "×2"
 	}],
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 840605,
+				tcgplayer: 647271,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "I",
 	rarity: "Rare",

--- a/data-asia/M/M1S/047.ts
+++ b/data-asia/M/M1S/047.ts
@@ -38,6 +38,16 @@ const card: Card = {
 		type: "Fighting",
 		value: "-30"
 	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 840606,
+				tcgplayer: 647286,
+			},
+		},
+	],
+
 	retreat: 3,
 	regulationMark: "I",
 	rarity: "Common",

--- a/data-asia/M/M1S/048.ts
+++ b/data-asia/M/M1S/048.ts
@@ -14,6 +14,16 @@ const card: Card = {
 		ja: "普段は墓場で眠っている。数いる犬ポケモンの中でもっとも主に忠実だ。"
 	},
 	stage: "Stage1",
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 840607,
+				tcgplayer: 647287,
+			},
+		},
+	],
+
 	evolveFrom: {
 		ja: "ボチ"
 	},

--- a/data-asia/M/M1S/049.ts
+++ b/data-asia/M/M1S/049.ts
@@ -30,6 +30,16 @@ const card: Card = {
 		},
 		cost: ["Fire", "Psychic", "Colorless"]
 	}],
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 840608,
+				tcgplayer: 647215,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "I",
 	rarity: "Double rare",

--- a/data-asia/M/M1S/050.ts
+++ b/data-asia/M/M1S/050.ts
@@ -30,6 +30,16 @@ const card: Card = {
 		damage: 130,
 		cost: ["Water", "Psychic", "Colorless"]
 	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 840609,
+				tcgplayer: 647218,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "I",
 	rarity: "Uncommon",

--- a/data-asia/M/M1S/051.ts
+++ b/data-asia/M/M1S/051.ts
@@ -34,6 +34,16 @@ const card: Card = {
 		type: "Fighting",
 		value: "×2"
 	}],
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 840610,
+				tcgplayer: 647238,
+			},
+		},
+	],
+
 	retreat: 3,
 	regulationMark: "I",
 	rarity: "Double rare",

--- a/data-asia/M/M1S/052.ts
+++ b/data-asia/M/M1S/052.ts
@@ -37,6 +37,16 @@ const card: Card = {
 		type: "Fighting",
 		value: "-30"
 	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 840611,
+				tcgplayer: 647255,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "I",
 	rarity: "Common",

--- a/data-asia/M/M1S/053.ts
+++ b/data-asia/M/M1S/053.ts
@@ -33,6 +33,16 @@ const card: Card = {
 		type: "Fighting",
 		value: "×2"
 	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 840612,
+				tcgplayer: 647289,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "I",
 	rarity: "Common",

--- a/data-asia/M/M1S/054.ts
+++ b/data-asia/M/M1S/054.ts
@@ -14,6 +14,16 @@ const card: Card = {
 		ja: "暑い季節が終わると空気をたくさん含んだ体毛に生え変わり寒さに備える。"
 	},
 	stage: "Stage1",
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 840613,
+				tcgplayer: 647290,
+			},
+		},
+	],
+
 	evolveFrom: {
 		ja: "ミミロル"
 	},

--- a/data-asia/M/M1S/055.ts
+++ b/data-asia/M/M1S/055.ts
@@ -31,6 +31,16 @@ const card: Card = {
 		type: "Fighting",
 		value: "×2"
 	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 840614,
+				tcgplayer: 647291,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "I",
 	rarity: "Common",

--- a/data-asia/M/M1S/056.ts
+++ b/data-asia/M/M1S/056.ts
@@ -14,6 +14,16 @@ const card: Card = {
 		ja: "格闘家顔負けの技で仕留めた獲物を両脇に抱えてすみかへ持ち帰る。"
 	},
 	stage: "Stage1",
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 840615,
+				tcgplayer: 647293,
+			},
+		},
+	],
+
 	evolveFrom: {
 		ja: "ヌイコグマ"
 	},

--- a/data-asia/M/M1S/057.ts
+++ b/data-asia/M/M1S/057.ts
@@ -8,6 +8,16 @@ const card: Card = {
 	},
 	illustrator: "Toyste Beach",
 	category: "Trainer",
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 840616,
+				tcgplayer: 647252,
+			},
+		},
+	],
+
 	trainerType: "Item",
 	effect: {
 		ja: "自分の進化している超ポケモンを1匹選び、「進化カード」を好きなだけはがして退化させる。はがしたカードは、手札に戻す。[退化したポケモンは、その番に進化できない。]"

--- a/data-asia/M/M1S/058.ts
+++ b/data-asia/M/M1S/058.ts
@@ -8,6 +8,16 @@ const card: Card = {
 	},
 	illustrator: "Inose yukie",
 	category: "Trainer",
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 840617,
+				tcgplayer: 647219,
+			},
+		},
+	],
+
 	trainerType: "Item",
 	effect: {
 		ja: "自分の山札から「メガシンカex」を1枚選び、相手に見せて手札に加える。そして山札を切る。"

--- a/data-asia/M/M1S/059.ts
+++ b/data-asia/M/M1S/059.ts
@@ -8,6 +8,16 @@ const card: Card = {
 	},
 	illustrator: "Yuu Nishida",
 	category: "Trainer",
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 840618,
+				tcgplayer: 647235,
+			},
+		},
+	],
+
 	trainerType: "Supporter",
 	effect: {
 		ja: "このカードは、相手のサイドの残り枚数が2枚以下のカードの時にしか使えない。自分の場のポケモンを1匹を選ぶ。次の相手の番、そのポケモンは相手の「ポケモンex」からワザのダメージや効果を受けない。"

--- a/data-asia/M/M1S/060.ts
+++ b/data-asia/M/M1S/060.ts
@@ -8,6 +8,16 @@ const card: Card = {
 	},
 	illustrator: "Iori Suzuki",
 	category: "Trainer",
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 840619,
+				tcgplayer: 647221,
+			},
+		},
+	],
+
 	trainerType: "Supporter",
 	effect: {
 		ja: "自分の「メガシンカex」1匹のHPを、すべて回復する。その後、回復したポケモンについているエネルギーを、すべて手札にもどす。"

--- a/data-asia/M/M1S/061.ts
+++ b/data-asia/M/M1S/061.ts
@@ -8,6 +8,16 @@ const card: Card = {
 	},
 	illustrator: "AYUMI ODASHIMA",
 	category: "Trainer",
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 840620,
+				tcgplayer: 647253,
+			},
+		},
+	],
+
 	trainerType: "Item",
 	effect: {
 		ja: "おたがいの草ポケモン全員は、出したばかりの番（最初の自分の番をのぞく）でも草ポケモンに進化できる。"

--- a/data-asia/M/M1S/062.ts
+++ b/data-asia/M/M1S/062.ts
@@ -8,6 +8,16 @@ const card: Card = {
 	},
 	illustrator: "AYUMI ODASHIMA",
 	category: "Trainer",
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 840621,
+				tcgplayer: 647254,
+			},
+		},
+	],
+
 	trainerType: "Item",
 	effect: {
 		ja: "おたがいのプレイヤーは、自分の番ごとに1回、自分のバトル場の水ポケモンを、ベンチの水ポケモンと入れ替えてよい。",

--- a/data-asia/M/M1S/063.ts
+++ b/data-asia/M/M1S/063.ts
@@ -8,6 +8,16 @@ const card: Card = {
 	},
 	illustrator: "AYUMI ODASHIMA",
 	category: "Trainer",
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 840622,
+				tcgplayer: 647224,
+			},
+		},
+	],
+
 	trainerType: "Stadium",
 	effect: {
 		ja: "おたがいのプレイヤーは、自分の番ごとに1回、手札からエネルギーカードを1枚トラッシュするなら、自分の手札の枚数が、自分の場の超エネルギーポケモンの数と同じ枚数になるように山札を引いてもよい。"

--- a/data-asia/M/M1S/064.ts
+++ b/data-asia/M/M1S/064.ts
@@ -25,6 +25,16 @@ const card: Card = {
 		type: "Fire",
 		value: "×2"
 	}],
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 840623,
+				tcgplayer: 647261,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "I",
 	rarity: "Illustration rare",

--- a/data-asia/M/M1S/065.ts
+++ b/data-asia/M/M1S/065.ts
@@ -14,6 +14,16 @@ const card: Card = {
 		ja: "動きが速すぎて目で追えないため姿を見た瞬間から消えているように思えてしまう。"
 	},
 	stage: "Stage1",
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 840624,
+				tcgplayer: 647228,
+			},
+		},
+	],
+
 	evolveFrom: {
 		ja: "ツチニン"
 	},

--- a/data-asia/M/M1S/066.ts
+++ b/data-asia/M/M1S/066.ts
@@ -25,6 +25,16 @@ const card: Card = {
 		type: "Water",
 		value: "×2"
 	}],
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 840625,
+				tcgplayer: 647264,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "I",
 	rarity: "Illustration rare",

--- a/data-asia/M/M1S/067.ts
+++ b/data-asia/M/M1S/067.ts
@@ -31,6 +31,16 @@ const card: Card = {
 		type: "Metal",
 		value: "×2"
 	}],
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 840626,
+				tcgplayer: 647246,
+			},
+		},
+	],
+
 	retreat: 3,
 	regulationMark: "I",
 	rarity: "Illustration rare",

--- a/data-asia/M/M1S/068.ts
+++ b/data-asia/M/M1S/068.ts
@@ -14,6 +14,16 @@ const card: Card = {
 		ja: "体内ガスの力でハサミのお尻から水を噴射して６０ノットのスピードで泳ぐ。"
 	},
 	stage: "Stage1",
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 840627,
+				tcgplayer: 647274,
+			},
+		},
+	],
+
 	evolveFrom: {
 		ja: "ウデッポウ"
 	},

--- a/data-asia/M/M1S/069.ts
+++ b/data-asia/M/M1S/069.ts
@@ -14,6 +14,16 @@ const card: Card = {
 		ja: "目の特殊なレンズを使って相手の体温などを感知して急所を見抜き攻撃する。"
 	},
 	stage: "Stage2",
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 840628,
+				tcgplayer: 647211,
+			},
+		},
+	],
+
 	evolveFrom: {
 		ja: "ジメレオン"
 	},

--- a/data-asia/M/M1S/070.ts
+++ b/data-asia/M/M1S/070.ts
@@ -28,6 +28,16 @@ const card: Card = {
 		type: "Fighting",
 		value: "×2"
 	}],
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 840629,
+				tcgplayer: 647282,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "I",
 	rarity: "Illustration rare",

--- a/data-asia/M/M1S/071.ts
+++ b/data-asia/M/M1S/071.ts
@@ -14,6 +14,16 @@ const card: Card = {
 		ja: "強力な超能力を操る。両手のスプーンはその力で作りだしたという。"
 	},
 	stage: "Stage2",
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 840630,
+				tcgplayer: 647234,
+			},
+		},
+	],
+
 	evolveFrom: {
 		ja: "ユンゲラー"
 	},

--- a/data-asia/M/M1S/072.ts
+++ b/data-asia/M/M1S/072.ts
@@ -41,6 +41,16 @@ const card: Card = {
 		type: "Fighting",
 		value: "-30"
 	}],
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 840631,
+				tcgplayer: 647230,
+			},
+		},
+	],
+
 	retreat: 0,
 	regulationMark: "I",
 	rarity: "Illustration rare",

--- a/data-asia/M/M1S/073.ts
+++ b/data-asia/M/M1S/073.ts
@@ -14,6 +14,16 @@ const card: Card = {
 		ja: "普段は墓場で眠っている。数いる犬ポケモンの中でもっとも主に忠実だ。"
 	},
 	stage: "Stage1",
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 840632,
+				tcgplayer: 647288,
+			},
+		},
+	],
+
 	evolveFrom: {
 		ja: "ボチ"
 	},

--- a/data-asia/M/M1S/074.ts
+++ b/data-asia/M/M1S/074.ts
@@ -37,6 +37,16 @@ const card: Card = {
 		type: "Fighting",
 		value: "-30"
 	}],
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 840633,
+				tcgplayer: 647256,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "I",
 	rarity: "Illustration rare",

--- a/data-asia/M/M1S/075.ts
+++ b/data-asia/M/M1S/075.ts
@@ -31,6 +31,16 @@ const card: Card = {
 		type: "Fighting",
 		value: "×2"
 	}],
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 840634,
+				tcgplayer: 647292,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "I",
 	rarity: "Illustration rare",

--- a/data-asia/M/M1S/076.ts
+++ b/data-asia/M/M1S/076.ts
@@ -11,6 +11,16 @@ const card: Card = {
 	hp: 350,
 	types: ["Water"],
 	stage: "MEGA",
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 840635,
+				tcgplayer: 647248,
+			},
+		},
+	],
+
 	evolveFrom: {
 		ja: "ユキカブリ"
 	},

--- a/data-asia/M/M1S/077.ts
+++ b/data-asia/M/M1S/077.ts
@@ -11,6 +11,16 @@ const card: Card = {
 	hp: 330,
 	types: ["Lightning"],
 	stage: "Stage1",
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 840636,
+				tcgplayer: 647251,
+			},
+		},
+	],
+
 	evolveFrom: {
 		ja: "ラクライ"
 	},

--- a/data-asia/M/M1S/078.ts
+++ b/data-asia/M/M1S/078.ts
@@ -11,6 +11,16 @@ const card: Card = {
 	hp: 360,
 	types: ["Psychic"],
 	stage: "Stage2",
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 840637,
+				tcgplayer: 647205,
+			},
+		},
+	],
+
 	evolveFrom: {
 		ja: "キルリア"
 	},

--- a/data-asia/M/M1S/079.ts
+++ b/data-asia/M/M1S/079.ts
@@ -30,6 +30,16 @@ const card: Card = {
 		},
 		cost: ["Fire", "Psychic", "Colorless"]
 	}],
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 840638,
+				tcgplayer: 647216,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "I",
 	rarity: "Secret Rare",

--- a/data-asia/M/M1S/080.ts
+++ b/data-asia/M/M1S/080.ts
@@ -34,6 +34,16 @@ const card: Card = {
 		type: "Fighting",
 		value: "×2"
 	}],
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 840639,
+				tcgplayer: 647239,
+			},
+		},
+	],
+
 	retreat: 3,
 	regulationMark: "I",
 	rarity: "Secret Rare",

--- a/data-asia/M/M1S/081.ts
+++ b/data-asia/M/M1S/081.ts
@@ -8,6 +8,16 @@ const card: Card = {
 	},
 	illustrator: "AYUMI ODASHIMA",
 	category: "Trainer",
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 840640,
+				tcgplayer: 647203,
+			},
+		},
+	],
+
 	trainerType: "Item",
 	effect: {
 		ja: "自分の山札から、HPが「70」以下のたねポケモンを2枚まで選び、ベンチに出す。そして山札を切る。"

--- a/data-asia/M/M1S/082.ts
+++ b/data-asia/M/M1S/082.ts
@@ -8,6 +8,16 @@ const card: Card = {
 	},
 	illustrator: "Studio Bora Inc.",
 	category: "Trainer",
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 840641,
+				tcgplayer: 647202,
+			},
+		},
+	],
+
 	trainerType: "Item",
 	effect: {
 		ja: "自分の手札から2進化ポケモンを1枚選び、そのポケモンへと進化する自分の場のたねポケモンにのせ、1進化をとばして進化させる。（最初の自分の番や、出したばかりのポケモンには使えない。）"

--- a/data-asia/M/M1S/083.ts
+++ b/data-asia/M/M1S/083.ts
@@ -8,6 +8,16 @@ const card: Card = {
 	},
 	illustrator: "Inose yukie",
 	category: "Trainer",
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 840642,
+				tcgplayer: 647220,
+			},
+		},
+	],
+
 	trainerType: "Item",
 	effect: {
 		ja: "自分の山札から「メガシンカex」を1枚選び、相手に見せて手札に加える。そして山札を切る。"

--- a/data-asia/M/M1S/084.ts
+++ b/data-asia/M/M1S/084.ts
@@ -8,6 +8,16 @@ const card: Card = {
 	},
 	illustrator: "Yuu Nishida",
 	category: "Trainer",
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 840643,
+				tcgplayer: 647236,
+			},
+		},
+	],
+
 	trainerType: "Supporter",
 	effect: {
 		ja: "このカードは、相手のサイドの残り枚数が2枚以下のカードの時にしか使えない。自分の場のポケモンを1匹を選ぶ。次の相手の番、そのポケモンは相手の「ポケモンex」からワザのダメージや効果を受けない。"

--- a/data-asia/M/M1S/085.ts
+++ b/data-asia/M/M1S/085.ts
@@ -8,6 +8,16 @@ const card: Card = {
 	},
 	illustrator: "Iori Suzuki",
 	category: "Trainer",
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 840644,
+				tcgplayer: 647222,
+			},
+		},
+	],
+
 	trainerType: "Supporter",
 	effect: {
 		ja: "自分の「メガシンカex」1匹のHPを、すべて回復する。その後、回復したポケモンについているエネルギーを、すべて手札にもどす。"

--- a/data-asia/M/M1S/086.ts
+++ b/data-asia/M/M1S/086.ts
@@ -8,6 +8,16 @@ const card: Card = {
 	},
 	illustrator: "AYUMI ODASHIMA",
 	category: "Trainer",
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 840645,
+				tcgplayer: 647225,
+			},
+		},
+	],
+
 	trainerType: "Stadium",
 	effect: {
 		ja: "おたがいのプレイヤーは、自分の番ごとに1回、手札からエネルギーカードを1枚トラッシュするなら、自分の手札の枚数が、自分の場の超エネルギーポケモンの数と同じ枚数になるように山札を引いてもよい。"

--- a/data-asia/M/M1S/087.ts
+++ b/data-asia/M/M1S/087.ts
@@ -11,6 +11,16 @@ const card: Card = {
 	hp: 360,
 	types: ["Psychic"],
 	stage: "Stage2",
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 840646,
+				tcgplayer: 647206,
+			},
+		},
+	],
+
 	evolveFrom: {
 		ja: "キルリア"
 	},

--- a/data-asia/M/M1S/088.ts
+++ b/data-asia/M/M1S/088.ts
@@ -30,6 +30,16 @@ const card: Card = {
 		},
 		cost: ["Fire", "Psychic", "Colorless"]
 	}],
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 840647,
+				tcgplayer: 647217,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "I",
 	rarity: "Special illustration rare",

--- a/data-asia/M/M1S/089.ts
+++ b/data-asia/M/M1S/089.ts
@@ -34,6 +34,16 @@ const card: Card = {
 		type: "Fighting",
 		value: "×2"
 	}],
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 840648,
+				tcgplayer: 647240,
+			},
+		},
+	],
+
 	retreat: 3,
 	regulationMark: "I",
 	rarity: "Special illustration rare",

--- a/data-asia/M/M1S/090.ts
+++ b/data-asia/M/M1S/090.ts
@@ -8,6 +8,16 @@ const card: Card = {
 	},
 	illustrator: "sui",
 	category: "Trainer",
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 840649,
+				tcgplayer: 647237,
+			},
+		},
+	],
+
 	trainerType: "Supporter",
 	effect: {
 		ja: "このカードは、相手のサイドの残り枚数が2枚以下のカードの時にしか使えない。自分の場のポケモンを1匹を選ぶ。次の相手の番、そのポケモンは相手の「ポケモンex」からワザのダメージや効果を受けない。"

--- a/data-asia/M/M1S/091.ts
+++ b/data-asia/M/M1S/091.ts
@@ -8,6 +8,16 @@ const card: Card = {
 	},
 	illustrator: "Jiro Sasumo",
 	category: "Trainer",
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 840650,
+				tcgplayer: 647223,
+			},
+		},
+	],
+
 	trainerType: "Supporter",
 	effect: {
 		ja: "自分の「メガシンカex」1匹のHPを、すべて回復する。その後、回復したポケモンについているエネルギーを、すべて手札にもどす。"

--- a/data-asia/M/M1S/092.ts
+++ b/data-asia/M/M1S/092.ts
@@ -11,6 +11,16 @@ const card: Card = {
 	hp: 360,
 	types: ["Psychic"],
 	stage: "Stage2",
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 840651,
+				tcgplayer: 647207,
+			},
+		},
+	],
+
 	evolveFrom: {
 		ja: "キルリア"
 	},


### PR DESCRIPTION
## What

Links the cards of the existing Japanese set **M1S メガシンフォニア (Mega Symphonia)** to their Cardmarket **and TCGplayer** products, so the API can serve their prices.

- **92** cards carried no product id at all and get both

Afterwards every card of the set carries its id on a `variants` entry and none on the card itself, which is where tcgdex is heading. Nothing else changes.

The ids are assigned **by collection number**, not by name: within a Cardmarket expansion the products sorted by `idProduct` follow the collection order, and the assignment is verified against the sample rows pokepricelab renders. That matters because Cardmarket names every print of a card identically inside an expansion, so a name lookup cannot tell a base print from its AR/full-art reprint. This set carried no id yet, so there is nothing in the repository to cross-check the assignment against — it rests on the verified ordering alone.

## Data sources

- **Cardmarket** public product catalog (`downloads.s3.cardmarket.com`): the product ids (840539–840651), assigned by collection number
- **pokepricelab.com**: the sample rows that verify that assignment
- **TCGplayer** via [tcgcsv.com](https://tcgcsv.com) (category 85, "Pokemon Japan"): product IDs as `thirdParty.tcgplayer` (647202–647293), keyed by the collection number each product carries in `extendedData`
- **limitlesstcg.com**: the set's card list — used here for nothing but the rarity per number, which decides whether a variant is `holo` or `normal`

## Notes

- All 92 files type-check against `interfaces.d.ts` (`tsc --noEmit`)
